### PR TITLE
Remove the loader from sidebar navigation screen.

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/index.js
@@ -14,7 +14,6 @@ import { privateApis as routerPrivateApis } from '@wordpress/router';
  */
 import SidebarNavigationScreen from '../sidebar-navigation-screen';
 import NavigationMenuContent from './navigation-menu-content';
-import { NavigationMenuLoader } from './loader';
 import { unlock } from '../../private-apis';
 import { store as editSiteStore } from '../../store';
 import {
@@ -75,7 +74,6 @@ export default function SidebarNavigationScreenNavigationMenus() {
 		];
 	}, [ firstNavigationMenu ] );
 
-	const isLoading = ! hasResolvedNavigationMenus;
 	const hasNavigationMenus = !! navigationMenus?.length;
 
 	const onSelect = useCallback(
@@ -112,14 +110,6 @@ export default function SidebarNavigationScreenNavigationMenus() {
 		return (
 			<SidebarNavigationScreenWrapper>
 				{ __( 'There are no Navigation Menus.' ) }
-			</SidebarNavigationScreenWrapper>
-		);
-	}
-
-	if ( ! hasResolvedNavigationMenus || isLoading ) {
-		return (
-			<SidebarNavigationScreenWrapper>
-				<NavigationMenuLoader />
 			</SidebarNavigationScreenWrapper>
 		);
 	}

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/loader.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/loader.js
@@ -1,9 +1,0 @@
-export function NavigationMenuLoader() {
-	return (
-		<>
-			<div className="edit-site-sidebar-navigation-screen-navigation-menus__placeholder" />
-			<div className="edit-site-sidebar-navigation-screen-navigation-menus__placeholder" />
-			<div className="edit-site-sidebar-navigation-screen-navigation-menus__placeholder" />
-		</>
-	);
-}

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/navigation-menu-content.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/navigation-menu-content.js
@@ -19,7 +19,6 @@ import { store as coreStore } from '@wordpress/core-data';
  * Internal dependencies
  */
 import { unlock } from '../../private-apis';
-import { NavigationMenuLoader } from './loader';
 
 function CustomLinkAdditionalBlockUI( { block, onClose } ) {
 	const { updateBlockAttributes } = useDispatch( blockEditorStore );
@@ -179,7 +178,6 @@ export default function NavigationMenuContent( { rootClientId, onSelect } ) {
 	// For example a navigation page list load its items has an effect on edit to load its items.
 	return (
 		<>
-			{ isLoading && <NavigationMenuLoader /> }
 			{ ! isLoading && (
 				<OffCanvasEditor
 					blocks={

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/style.scss
@@ -2,26 +2,6 @@
 	margin: 0 0 $grid-unit-40 $grid-unit-20;
 }
 
-.edit-site-sidebar-navigation-screen-navigation-menus__placeholder {
-	padding: $grid-unit-10;
-	margin: $grid-unit-10;
-	background-color: $gray-100;
-	animation: loadingpulse 1s linear infinite;
-	animation-delay: 0.5s; // avoid animating for fast network responses
-}
-
-@keyframes loadingpulse {
-	0% {
-		opacity: 1;
-	}
-	50% {
-		opacity: 0.5;
-	}
-	100% {
-		opacity: 1;
-	}
-}
-
 .edit-site-sidebar-navigation-screen-navigation-menus__content {
 	.offcanvas-editor-list-view-leaf {
 		max-width: calc(100% - #{ $grid-unit-05 });


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Resolves #50224.

Removing the navigation loader as per https://github.com/WordPress/gutenberg/issues/50224

## Why?

It was reported that the navigation loader was flashing in, and it wasn't following the design patterns of other loaders. I'm removing the code, as it was also reported to be triggered when navigating back and forth, and it wasn't ideal. I could adjust the PR to re-introduce the loader component but empty if that's a better approach for future development (Although, I think having an empty placeholder wouldn't be ideal at this stage).

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open the site editor.
2. Navigate to Navigation, or templates.
3. Confirm that there's no loading state anymore.

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/252415/236194011-a649b2b0-618a-4ad4-9ca9-5c48250ff240.mov
