### PR TITLE
Display conditionally the `styles` in sidebar main navigation screen

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen-main/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-main/index.js
@@ -17,23 +17,33 @@ import SidebarNavigationScreen from '../sidebar-navigation-screen';
 import SidebarNavigationItem from '../sidebar-navigation-item';
 
 export default function SidebarNavigationScreenMain() {
-	const hasNavigationMenus = useSelect( ( select ) => {
-		// The query needs to be the same as in the "SidebarNavigationScreenNavigationMenus" component,
-		// to avoid double network calls.
-		const navigationMenus = select( coreStore ).getEntityRecords(
-			'postType',
-			'wp_navigation',
-			{
-				per_page: 1,
-				status: 'publish',
-				order: 'desc',
-				orderby: 'date',
-			}
-		);
-
-		return navigationMenus?.length > 0;
-	} );
-
+	const { hasNavigationMenus, hasGlobalStyleVariations } = useSelect(
+		( select ) => {
+			const {
+				getEntityRecords,
+				__experimentalGetCurrentThemeGlobalStylesVariations,
+			} = select( coreStore );
+			// The query needs to be the same as in the "SidebarNavigationScreenNavigationMenus" component,
+			// to avoid double network calls.
+			const navigationMenus = getEntityRecords(
+				'postType',
+				'wp_navigation',
+				{
+					per_page: 1,
+					status: 'publish',
+					order: 'desc',
+					orderby: 'date',
+				}
+			);
+			return {
+				hasNavigationMenus: !! navigationMenus?.length,
+				hasGlobalStyleVariations:
+					!! __experimentalGetCurrentThemeGlobalStylesVariations()
+						?.length,
+			};
+		},
+		[]
+	);
 	const showNavigationScreen = process.env.IS_GUTENBERG_PLUGIN
 		? hasNavigationMenus
 		: false;
@@ -56,14 +66,16 @@ export default function SidebarNavigationScreenMain() {
 							{ __( 'Navigation' ) }
 						</NavigatorButton>
 					) }
-					<NavigatorButton
-						as={ SidebarNavigationItem }
-						path="/wp_global_styles"
-						withChevron
-						icon={ styles }
-					>
-						{ __( 'Styles' ) }
-					</NavigatorButton>
+					{ hasGlobalStyleVariations && (
+						<NavigatorButton
+							as={ SidebarNavigationItem }
+							path="/wp_global_styles"
+							withChevron
+							icon={ styles }
+						>
+							{ __( 'Styles' ) }
+						</NavigatorButton>
+					) }
 					<NavigatorButton
 						as={ SidebarNavigationItem }
 						path="/wp_template"


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
While working on something different I noticed that the `styles` navigation item is rendered even if a theme has no Global Styles variations. This PR fixes that.


## Testing Instructions
1. Use a block theme without GS variations (alternatively use the empty theme and rename the `styles` folder there).
2. The main sidebar on the left should not render the `styles` navigation item

## Screenshots or screencast <!-- if applicable -->
