### PR TITLE
Post Featured Image: Hide overlay controls when color support is disabled

### DIFF
--- a/packages/block-library/src/post-featured-image/overlay.js
+++ b/packages/block-library/src/post-featured-image/overlay.js
@@ -45,6 +45,10 @@ const Overlay = ( {
 		...borderProps.style,
 	};
 
+	if ( ! colorGradientSettings.hasColorsOrGradients ) {
+		return null;
+	}
+
 	return (
 		<>
 			{ !! dimRatio && (


### PR DESCRIPTION
## What?
Previous work - #50115, #50275

Hides the Post Featured Image's overlay controls when a theme disables color support.

## Why?
Matches behavior when colors are enabled for a block using `block.support`.

## How?
Return early in the `Overlay` component when `hasColorsOrGradients` is false.

## Testing Instructions
1. Disabled Color support for a block theme (snippet below).
2. Open a post or page.
3. Insert the Post Featured Image block.
4. Open the "Styles" inspector tab.
5. The O panel shouldn't be displayed.

## Snippet
```
"color": {
      "custom": false,
      "customDuotone": false,
      "customGradient": false,
      "defaultGradients": false,
      "defaultPalette": false,
      "background": false,
      "defaultDuotone": false,
      "text": false
},
```

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2023-05-04 at 17 34 34](https://user-images.githubusercontent.com/240569/236221960-2842fc81-c7a8-45bd-b546-78d14bd8174e.png)

