### PR TITLE
Theme Preview: Restrict to admin users

### DIFF
--- a/lib/compat/wordpress-6.3/theme-previews.php
+++ b/lib/compat/wordpress-6.3/theme-previews.php
@@ -14,7 +14,7 @@
 function gutenberg_theme_preview_stylesheet( $current_stylesheet = null ) {
 	$preview_stylesheet = ! empty( $_GET['theme_preview'] ) ? $_GET['theme_preview'] : null;
 	$wp_theme           = wp_get_theme( $preview_stylesheet );
-	if ( ! is_wp_error( $wp_theme->errors() ) ) {
+	if ( ! is_wp_error( $wp_theme->errors() ) && current_user_can( 'switch_themes' ) ) {
 		return sanitize_text_field( $preview_stylesheet );
 	}
 
@@ -30,7 +30,7 @@ function gutenberg_theme_preview_stylesheet( $current_stylesheet = null ) {
 function gutenberg_theme_preview_template( $current_stylesheet = null ) {
 	$preview_stylesheet = ! empty( $_GET['theme_preview'] ) ? $_GET['theme_preview'] : null;
 	$wp_theme           = wp_get_theme( $preview_stylesheet );
-	if ( ! is_wp_error( $wp_theme->errors() ) ) {
+	if ( ! is_wp_error( $wp_theme->errors() ) && current_user_can( 'switch_themes' ) ) {
 		return sanitize_text_field( $wp_theme->get_template() );
 	}
 
@@ -41,6 +41,11 @@ function gutenberg_theme_preview_template( $current_stylesheet = null ) {
  * Adds a middleware to the REST API to set the theme for the preview.
  */
 function gutenberg_attach_theme_preview_middleware() {
+	// Don't allow non-admins to preview themes.
+	if ( ! current_user_can( 'switch_themes' ) ) {
+		return;
+	}
+
 	wp_add_inline_script(
 		'wp-api-fetch',
 		sprintf(

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -545,5 +545,12 @@ export const getNavigationFallbackId =
 				'wp_navigation',
 				record
 			);
+
+			// Resolve to avoid further network requests.
+			dispatch.finishResolution( 'getEntityRecord', [
+				'postType',
+				'wp_navigation',
+				fallback?.id,
+			] );
 		}
 	};


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Add a check for as users capabilities to determine whether they can preview themes. Fixes #50188
 
## Why?
Only users who have `switch_themes` capabilities should be able to preview themes.

## How?
Call `current_user_can` before enabling theme previews.

## Testing Instructions
1. Visit your site with ?theme_preview=[theme_directory] when you are logged in as an admin and confirm you see the theme previewed in the front end.
1. Visit your site with ?theme_preview=[theme_directory] when you are not logged in and confirm you do not see the theme previewed in the front end.
