### PR TITLE
Refactor theme previews

### DIFF
--- a/lib/compat/wordpress-6.3/theme-previews.php
+++ b/lib/compat/wordpress-6.3/theme-previews.php
@@ -5,12 +5,12 @@
  * @package gutenberg
  */
 
- /**
-  * Filters the blog option to return the path for the previewed theme.
-  *
-  * @param string $current_stylesheet The current theme's stylesheet or template path.
-  * @return string The previewed theme's stylesheet or template path.
-  */
+/**
+ * Filters the blog option to return the path for the previewed theme.
+ *
+ * @param string $current_stylesheet The current theme's stylesheet or template path.
+ * @return string The previewed theme's stylesheet or template path.
+ */
 function gutenberg_get_theme_preview_path( $current_stylesheet = null ) {
 	// Don't allow non-admins to preview themes.
 	if ( ! current_user_can( 'switch_themes' ) ) {

--- a/lib/compat/wordpress-6.3/theme-previews.php
+++ b/lib/compat/wordpress-6.3/theme-previews.php
@@ -5,33 +5,28 @@
  * @package gutenberg
  */
 
-/**
- * Filters the blog option to return the directory for the previewed theme.
+ /**
+ * Filters the blog option to return the path for the previewed theme.
  *
- * @param string $current_stylesheet The current theme directory.
- * @return string The previewed theme directory.
+ * @param string $current_stylesheet The current theme's stylesheet or template path.
+ * @return string The previewed theme's stylesheet or template path.
  */
-function gutenberg_theme_preview_stylesheet( $current_stylesheet = null ) {
-	$preview_stylesheet = ! empty( $_GET['theme_preview'] ) ? $_GET['theme_preview'] : null;
-	$wp_theme           = wp_get_theme( $preview_stylesheet );
-	if ( ! is_wp_error( $wp_theme->errors() ) && current_user_can( 'switch_themes' ) ) {
-		return sanitize_text_field( $preview_stylesheet );
+function gutenberg_get_theme_preview_path( $current_stylesheet = null ) {
+	// Don't allow non-admins to preview themes.
+	if ( ! current_user_can( 'switch_themes' ) ) {
+		return;
 	}
 
-	return $current_stylesheet;
-}
-
-/**
- * Filters the blog option to return the parent theme directory for the previewed theme.
- *
- * @param string $current_stylesheet The current theme directory.
- * @return string The previewed theme directory.
- */
-function gutenberg_theme_preview_template( $current_stylesheet = null ) {
 	$preview_stylesheet = ! empty( $_GET['theme_preview'] ) ? $_GET['theme_preview'] : null;
 	$wp_theme           = wp_get_theme( $preview_stylesheet );
-	if ( ! is_wp_error( $wp_theme->errors() ) && current_user_can( 'switch_themes' ) ) {
-		return sanitize_text_field( $wp_theme->get_template() );
+	if ( ! is_wp_error( $wp_theme->errors() ) ) {
+		if ( current_filter() === 'stylesheet' ) {
+			$theme_path = $wp_theme->get_stylesheet();
+		} else if ( current_filter() === 'template' ) {
+			$theme_path = $wp_theme->get_template();
+		}
+
+		return sanitize_text_field( $theme_path );
 	}
 
 	return $current_stylesheet;
@@ -124,8 +119,8 @@ if ( $gutenberg_experiments && array_key_exists( 'gutenberg-theme-previews', $gu
 	 * Attaches filters to enable theme previews in the Site Editor.
 	 */
 	if ( ! empty( $_GET['theme_preview'] ) ) {
-		add_filter( 'stylesheet', 'gutenberg_theme_preview_stylesheet' );
-		add_filter( 'template', 'gutenberg_theme_preview_template' );
+		add_filter( 'stylesheet', 'gutenberg_get_theme_preview_path' );
+		add_filter( 'template', 'gutenberg_get_theme_preview_path' );
 		add_filter( 'init', 'gutenberg_attach_theme_preview_middleware' );
 	}
 

--- a/lib/compat/wordpress-6.3/theme-previews.php
+++ b/lib/compat/wordpress-6.3/theme-previews.php
@@ -6,11 +6,11 @@
  */
 
  /**
- * Filters the blog option to return the path for the previewed theme.
- *
- * @param string $current_stylesheet The current theme's stylesheet or template path.
- * @return string The previewed theme's stylesheet or template path.
- */
+  * Filters the blog option to return the path for the previewed theme.
+  *
+  * @param string $current_stylesheet The current theme's stylesheet or template path.
+  * @return string The previewed theme's stylesheet or template path.
+  */
 function gutenberg_get_theme_preview_path( $current_stylesheet = null ) {
 	// Don't allow non-admins to preview themes.
 	if ( ! current_user_can( 'switch_themes' ) ) {
@@ -22,7 +22,7 @@ function gutenberg_get_theme_preview_path( $current_stylesheet = null ) {
 	if ( ! is_wp_error( $wp_theme->errors() ) ) {
 		if ( current_filter() === 'stylesheet' ) {
 			$theme_path = $wp_theme->get_stylesheet();
-		} else if ( current_filter() === 'template' ) {
+		} elseif ( current_filter() === 'template' ) {
 			$theme_path = $wp_theme->get_template();
 		}
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Refactors the way we filter `stylesheet` and `template` to reduce code duplication.

## Why?
Makes the code easier to maintain.

## How?
Uses `current_filter` to get the name of the current filter.

## Testing Instructions
Check that when you apply ?theme_preview=[theme_path] to your URL, you still see the correct theme being previewed.
