### PR TITLE
Fix Multiple Tooltips from Focus Toolbar Shortcut on Widget Editor

### DIFF
--- a/packages/block-editor/src/components/block-tools/selected-block-popover.js
+++ b/packages/block-editor/src/components/block-tools/selected-block-popover.js
@@ -75,7 +75,7 @@ function SelectedBlockPopover( {
 	);
 	const isToolbarForced = useRef( false );
 	const { shouldShowContextualToolbar, canFocusHiddenToolbar } =
-		useShouldContextualToolbarShow( clientId );
+		useShouldContextualToolbarShow();
 
 	const { stopTyping } = useDispatch( blockEditorStore );
 

--- a/packages/edit-post/src/components/header/header-toolbar/index.js
+++ b/packages/edit-post/src/components/header/header-toolbar/index.js
@@ -41,27 +41,15 @@ function HeaderToolbar() {
 		showIconLabels,
 		isListViewOpen,
 		listViewShortcut,
-		selectedBlockId,
-		hasFixedToolbar,
 	} = useSelect( ( select ) => {
-		const {
-			hasInserterItems,
-			getBlockRootClientId,
-			getBlockSelectionEnd,
-			getSelectedBlockClientId,
-			getFirstMultiSelectedBlockClientId,
-			getSettings,
-		} = select( blockEditorStore );
+		const { hasInserterItems, getBlockRootClientId, getBlockSelectionEnd } =
+			select( blockEditorStore );
 		const { getEditorSettings } = select( editorStore );
 		const { getEditorMode, isFeatureActive, isListViewOpened } =
 			select( editPostStore );
 		const { getShortcutRepresentation } = select( keyboardShortcutsStore );
 
 		return {
-			hasFixedToolbar: getSettings().hasFixedToolbar,
-			selectedBlockId:
-				getSelectedBlockClientId() ||
-				getFirstMultiSelectedBlockClientId(),
 			// This setting (richEditingEnabled) should not live in the block editor's setting.
 			isInserterEnabled:
 				getEditorMode() === 'visual' &&
@@ -83,14 +71,17 @@ function HeaderToolbar() {
 
 	const isLargeViewport = useViewportMatch( 'medium' );
 	const isWideViewport = useViewportMatch( 'wide' );
-	const { shouldShowContextualToolbar, canFocusHiddenToolbar } =
-		useShouldContextualToolbarShow( selectedBlockId );
+	const {
+		shouldShowContextualToolbar,
+		canFocusHiddenToolbar,
+		fixedToolbarCanBeFocused,
+	} = useShouldContextualToolbarShow();
 	// If there's a block toolbar to be focused, disable the focus shortcut for the document toolbar.
 	// There's a fixed block toolbar when the fixed toolbar option is enabled or when the browser width is less than the large viewport.
 	const blockToolbarCanBeFocused =
 		shouldShowContextualToolbar ||
 		canFocusHiddenToolbar ||
-		( ( hasFixedToolbar || ! isLargeViewport ) && selectedBlockId );
+		fixedToolbarCanBeFocused;
 	/* translators: accessibility text for the editor toolbar */
 	const toolbarAriaLabel = __( 'Document tools' );
 

--- a/packages/edit-widgets/src/components/header/index.js
+++ b/packages/edit-widgets/src/components/header/index.js
@@ -7,6 +7,7 @@ import { Button, ToolbarItem, VisuallyHidden } from '@wordpress/components';
 import {
 	NavigableToolbar,
 	store as blockEditorStore,
+	privateApis as blockEditorPrivateApis,
 } from '@wordpress/block-editor';
 import { PinnedItems } from '@wordpress/interface';
 import { listView, plus } from '@wordpress/icons';
@@ -22,6 +23,7 @@ import RedoButton from './undo-redo/redo';
 import MoreMenu from '../more-menu';
 import useLastSelectedWidgetArea from '../../hooks/use-last-selected-widget-area';
 import { store as editWidgetsStore } from '../../store';
+import { unlock } from '../../private-apis';
 
 function Header() {
 	const isMediumViewport = useViewportMatch( 'medium' );
@@ -70,6 +72,19 @@ function Header() {
 		[ setIsListViewOpened, isListViewOpen ]
 	);
 
+	const { useShouldContextualToolbarShow } = unlock( blockEditorPrivateApis );
+	const {
+		shouldShowContextualToolbar,
+		canFocusHiddenToolbar,
+		fixedToolbarCanBeFocused,
+	} = useShouldContextualToolbarShow();
+	// If there's a block toolbar to be focused, disable the focus shortcut for the document toolbar.
+	// There's a fixed block toolbar when the fixed toolbar option is enabled or when the browser width is less than the large viewport.
+	const blockToolbarCanBeFocused =
+		shouldShowContextualToolbar ||
+		canFocusHiddenToolbar ||
+		fixedToolbarCanBeFocused;
+
 	return (
 		<>
 			<div className="edit-widgets-header">
@@ -90,6 +105,9 @@ function Header() {
 					<NavigableToolbar
 						className="edit-widgets-header-toolbar"
 						aria-label={ __( 'Document tools' ) }
+						shouldUseKeyboardFocusShortcut={
+							! blockToolbarCanBeFocused
+						}
 					>
 						<ToolbarItem
 							ref={ inserterButton }


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/49926
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?/Why?
Fixes multiple tooltips being visible when using the focus toolbar shortcut (alt + F10) on the Widgets Editor.

## How?
- Implements `useShouldContextualToolbarShow()` from https://github.com/WordPress/gutenberg/pull/49644.
- Refactors `useShouldContextualToolbarShow()` to make it require less code to connect to the Widgets Header (and also the Site Editor in a separate PR).

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
Switch to a theme with widgets, such as Twenty Nineteen, and go to the widgets editor page: `/wp-admin/widgets.php`

#### Block toolbar open
- Move focus into a block to display the block toolbar. 
- Press `alt + F10` (or `fn + option + F10` on mac keyboards)
- Focus should be applied to the block toolbar

#### No selected blocks
- Hide the block toolbar by moving focus to the editor page title (or anywhere else)
- Press `alt + F10` (or `fn + option + F10` on mac keyboards)
- Focus should be in the document toolbar 

#### In Select Mode
- In the top document toolbar, change to Select mode
- Place focus on a block
- Press `alt + F10` (or `fn + option + F10` on mac keyboards)
- Focus should be in the document toolbar 

#### From the + Button
- In Edit mode in Default view
- Add a paragraph with content
- Move focus to the large + Button at the bottom of the widget area
- Press `alt + F10` (or `fn + option + F10` on mac keyboards)
- Focus should be in the Document Toolbar

Basically, try to break it using all of the different view modes (Top Toolbar on/off, Spotlight mode, etc) and with an empty default blocks selected, a block selected, multiple blocks selected, etc. Anytime a block toolbar is showing, it should receive focus with the `alt + F10`  shortcut, and anytime it's _not_ showing, focus should be in the top toolbar.

## Screenshots or screencast <!-- if applicable -->
Broken State: Only one tooltip should show
<img width="1373" alt="Widget editor with block toolbar open with focus on the first item in the block toolbar and the Toggle block inserter tooltip is showing in the top-level document toolbar" src="https://user-images.githubusercontent.com/967608/233150263-063d11c8-1858-4ec1-95f7-5694592546c6.png">
