### PR TITLE
Fixes focus managemnt on block selection change for fixed block toolbar

### DIFF
--- a/packages/block-editor/src/components/block-tools/block-contextual-toolbar.js
+++ b/packages/block-editor/src/components/block-tools/block-contextual-toolbar.js
@@ -55,7 +55,7 @@ const ExpandFixedToolbarButton = forwardRef( ( { onClick, icon }, ref ) => {
 function BlockContextualToolbar( { focusOnMount, isFixed, ...props } ) {
 	// When the toolbar is fixed it can be collapsed
 	const [ isCollapsed, setIsCollapsed ] = useState( false );
-	const [ isNewBlockSelected, setIsNewBlockSelected ] = useState( true );
+	const [ isNewBlockSelected, setIsNewBlockSelected ] = useState( false );
 	const expandFixedToolbarButtonRef = useRef();
 	const collapseFixedToolbarButtonRef = useRef();
 
@@ -107,7 +107,6 @@ function BlockContextualToolbar( { focusOnMount, isFixed, ...props } ) {
 			setIsNewBlockSelected( true );
 			return;
 		}
-		setIsNewBlockSelected( false );
 		if ( initialRender.current ) {
 			initialRender.current = false;
 			return;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Closes #50337


## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Because clicking on a block should keep focus on the clicked block.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Adds a new state to the block toolbar that tracks block selection change. We need a new state because we need to konw that the selection changed between renders of the block toolbar inside the block contextual toolbar which is only mounted once.

## Testing Instructions
1. Set top toolbar to on
2. Select a block
3. Collapse toolbar
4. Select another block
5. Notice the expanded toolbar shows but the focus remains on the selected block

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/107534/236291460-82322bcc-5e5d-4b87-a539-526e76af95ad.mp4


