### PR TITLE
Fix Multiple Tooltips from Focus Toolbar Shortcut on Site Editor

### DIFF
--- a/packages/edit-site/src/components/header-edit-mode/index.js
+++ b/packages/edit-site/src/components/header-edit-mode/index.js
@@ -14,6 +14,7 @@ import {
 	__experimentalPreviewOptions as PreviewOptions,
 	NavigableToolbar,
 	store as blockEditorStore,
+	privateApis as blockEditorPrivateApis,
 } from '@wordpress/block-editor';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { PinnedItems } from '@wordpress/interface';
@@ -125,6 +126,19 @@ export default function HeaderEditMode() {
 		[ setIsListViewOpened, isListViewOpen ]
 	);
 
+	const { useShouldContextualToolbarShow } = unlock( blockEditorPrivateApis );
+	const {
+		shouldShowContextualToolbar,
+		canFocusHiddenToolbar,
+		fixedToolbarCanBeFocused,
+	} = useShouldContextualToolbarShow();
+	// If there's a block toolbar to be focused, disable the focus shortcut for the document toolbar.
+	// There's a fixed block toolbar when the fixed toolbar option is enabled or when the browser width is less than the large viewport.
+	const blockToolbarCanBeFocused =
+		shouldShowContextualToolbar ||
+		canFocusHiddenToolbar ||
+		fixedToolbarCanBeFocused;
+
 	const hasDefaultEditorCanvasView = ! useHasEditorCanvasContainer();
 
 	const isFocusMode = templateType === 'wp_template_part';
@@ -150,6 +164,9 @@ export default function HeaderEditMode() {
 				<NavigableToolbar
 					className="edit-site-header-edit-mode__start"
 					aria-label={ __( 'Document tools' ) }
+					shouldUseKeyboardFocusShortcut={
+						! blockToolbarCanBeFocused
+					}
 				>
 					<div className="edit-site-header-edit-mode__toolbar">
 						<ToolbarItem


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/49925

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?/Why?
Fixes multiple tooltips being visible when using the focus toolbar shortcut (alt + F10) on the Site Editor

## How?
Implements the refactored `useShouldContextualToolbarShow()` from https://github.com/WordPress/gutenberg/pull/50344 on the Site Editor `<NavigableToolbar />`.

### Testing Instructions for Keyboard
Switch to a theme that can use the Site Editor, such as TT3, and go to the Site Editor: `/wp-admin/site-editor.php?canvas=edit`

#### Block toolbar open
- Move focus into a block to display the block toolbar. 
- Press `alt + F10` (or `fn + option + F10` on mac keyboards)
- Focus should be applied to the block toolbar

#### No selected blocks
- Hide the block toolbar by moving to somewhere on the page without a block selected (this can even be outside the editor canvas)
- Press `alt + F10` (or `fn + option + F10` on mac keyboards)
- Focus should be in the document toolbar 

#### In Select Mode
- In the top document toolbar, change to Select mode
- Place focus on a block
- Press `alt + F10` (or `fn + option + F10` on mac keyboards)
- Focus should be in the document toolbar 

Basically, try to break it using all of the different view modes (Top Toolbar on/off, Spotlight mode, etc) and with an empty default blocks selected, a block selected, multiple blocks selected, etc. When pressing the shortcut, focus should get moved to one and only one toolbar.

## Screenshots or screencast <!-- if applicable -->
Broken State: Only one tooltip should show
<img width="1484" alt="Site editor with block toolbar open with focus on the first item in the block toolbar and the Toggle block inserter tooltip is showing in the top-level document toolbar" src="https://user-images.githubusercontent.com/967608/233149188-3754fba5-1cd3-45fc-b806-2c4e2410436e.png">
