### PR TITLE
Templates: Sort  by the rendered title instead of the slug

### DIFF
--- a/packages/edit-site/src/components/list/table.js
+++ b/packages/edit-site/src/components/list/table.js
@@ -61,7 +61,9 @@ export default function Table( { templateType } ) {
 	}
 
 	const sortedTemplates = [ ...templates ];
-	sortedTemplates.sort( ( a, b ) => a.slug.localeCompare( b.slug ) );
+	sortedTemplates.sort( ( a, b ) =>
+		a.title.rendered.localeCompare( b.title.rendered )
+	);
 
 	return (
 		// These explicit aria roles are needed for Safari.

--- a/packages/edit-site/src/components/sidebar-navigation-screen-templates/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-templates/index.js
@@ -74,7 +74,9 @@ export default function SidebarNavigationScreenTemplates() {
 		}
 	);
 	const sortedTemplates = templates ? [ ...templates ] : [];
-	sortedTemplates.sort( ( a, b ) => a.slug.localeCompare( b.slug ) );
+	sortedTemplates.sort( ( a, b ) =>
+		a.title.rendered.localeCompare( b.title.rendered )
+	);
 
 	const browseAllLink = useLink( {
 		path: '/' + postType + '/all',


### PR DESCRIPTION
## What?
Switches the template sort order in the site editor left navigation and the manage all templates list to use the rendered title instead of the slug

## Why?
It is possible for the template to have a title that is very different to the slug, and so the sort order can end up appearing random to the user

## How?
Uses `title.rendered` instead of `slug` to sort

## Testing Instructions

- Go to the Site Editor and check that the Templates and Template parts are sorted alphabetically by the visible Title name in both the left nav and on the Manage all templates pages

## Screenshots or screencast <!-- if applicable -->

| Before| After |
|--------|-------|
| <img width="347" alt="Screenshot 2023-05-05 at 10 02 59 AM" src="https://user-images.githubusercontent.com/3629020/236339533-7a8bcb31-8d8e-41bb-9cc4-65b49842e2dc.png">  | <img width="339" alt="Screenshot 2023-05-05 at 10 01 35 AM" src="https://user-images.githubusercontent.com/3629020/236339486-ecb9630b-affc-4790-ab79-d2ce00da4149.png"> |
