### PR TITLE
Theme Previews: Fix refactor

### DIFF
--- a/lib/compat/wordpress-6.3/theme-previews.php
+++ b/lib/compat/wordpress-6.3/theme-previews.php
@@ -20,10 +20,10 @@ function gutenberg_get_theme_preview_path( $current_stylesheet = null ) {
 	$preview_stylesheet = ! empty( $_GET['theme_preview'] ) ? $_GET['theme_preview'] : null;
 	$wp_theme           = wp_get_theme( $preview_stylesheet );
 	if ( ! is_wp_error( $wp_theme->errors() ) ) {
-		if ( current_filter() === 'stylesheet' ) {
-			$theme_path = $wp_theme->get_stylesheet();
-		} elseif ( current_filter() === 'template' ) {
+		if ( current_filter() === 'template' ) {
 			$theme_path = $wp_theme->get_template();
+		} else {
+			$theme_path = $wp_theme->get_stylesheet();
 		}
 
 		return sanitize_text_field( $theme_path );
@@ -104,7 +104,7 @@ function add_live_preview_button() {
  * Adds a nonce for the theme activation link.
  */
 function block_theme_activate_nonce() {
-	$nonce_handle = 'switch-theme_' . gutenberg_theme_preview_stylesheet();
+	$nonce_handle = 'switch-theme_' . gutenberg_get_theme_preview_path();
 	?>
 <script type="text/javascript">
 	window.BLOCK_THEME_ACTIVATE_NONCE = '<?php echo wp_create_nonce( $nonce_handle ); ?>';


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
I refactored this code in https://github.com/WordPress/gutenberg/pull/50338 but missed a function name change. This finishes the refactor properly

## Why?
`wp-admin/themes.php` is throwing a fatal on trunk.

## How?
Rename the function and then reorganise the code so it behaves the same as before.

## Testing Instructions
1. Go to `wp-admin/themes.php` and confirm you don't see a fatal error
2. Preview a block theme
3. Activate it from the site editor
4. Confirm that the activation works correctly
