### PR TITLE
Simplify cover block description

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -226,7 +226,7 @@ Displays a title with the number of comments ([Source](https://github.com/WordPr
 
 ## Cover
 
-Add an image or video with a text overlay — great for headers. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/cover))
+Add an image or video with a text overlay. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/cover))
 
 -	**Name:** core/cover
 -	**Category:** media

--- a/packages/block-library/src/cover/block.json
+++ b/packages/block-library/src/cover/block.json
@@ -4,7 +4,7 @@
 	"name": "core/cover",
 	"title": "Cover",
 	"category": "media",
-	"description": "Add an image or video with a text overlay — great for headers.",
+	"description": "Add an image or video with a text overlay.",
 	"textdomain": "default",
 	"attributes": {
 		"url": {

--- a/packages/block-library/src/cover/variations.js
+++ b/packages/block-library/src/cover/variations.js
@@ -8,9 +8,7 @@ const variations = [
 	{
 		name: 'cover',
 		title: __( 'Cover' ),
-		description: __(
-			'Add an image or video with a text overlay — great for headers.'
-		),
+		description: __( 'Add an image or video with a text overlay.' ),
 		attributes: { layout: { type: 'constrained' } },
 		isDefault: true,
 		icon: cover,


### PR DESCRIPTION
## What?
Removes the `great for headers` text from Cover block description.

## Why?
Not really needed and simplifies UI.

Fixes: #50348

## How?
Highlighted text and hit delete 😄 

## Testing Instructions

- Insert a Cover block and make sure text in the inspector panel is just `Add an image or video with a text overlay.`
- Also mouse over the Cover block in the left inserter panel and make sure text is correct in popover there

## Screenshots or screencast <!-- if applicable -->

Before:
<img width="280" alt="CleanShot 2023-05-03 at 18 16 48" src="https://user-images.githubusercontent.com/1813435/236292361-ac0fc1a3-0c28-4c9d-a725-12069706e060.png">

After:
<img width="272" alt="Screenshot 2023-05-05 at 12 00 33 PM" src="https://user-images.githubusercontent.com/3629020/236354904-bb4870f1-418f-4ec6-ab8c-f730868ab634.png">


