### PR TITLE
Multi-select: capitalise B in blocks

### DIFF
--- a/packages/block-editor/src/components/multi-selection-inspector/index.js
+++ b/packages/block-editor/src/components/multi-selection-inspector/index.js
@@ -30,7 +30,7 @@ function MultiSelectionInspector( { blocks } ) {
 				<div className="block-editor-multi-selection-inspector__card-description">
 					{ sprintf(
 						/* translators: %d: number of words */
-						_n( '%d word', '%d words', words ),
+						_n( '%d word selected.', '%d words selected.', words ),
 						words
 					) }
 				</div>

--- a/packages/block-editor/src/components/multi-selection-inspector/index.js
+++ b/packages/block-editor/src/components/multi-selection-inspector/index.js
@@ -23,7 +23,7 @@ function MultiSelectionInspector( { blocks } ) {
 				<div className="block-editor-multi-selection-inspector__card-title">
 					{ sprintf(
 						/* translators: %d: number of blocks */
-						_n( '%d block', '%d blocks', blocks.length ),
+						_n( '%d Block', '%d Blocks', blocks.length ),
 						blocks.length
 					) }
 				</div>


### PR DESCRIPTION
## What?
Capitalise the B in blocks in the mulitselect heading

## Why?
Rich said so 😄 
Fixes: #50347

## How?
Held down the shift key while typing the B

## Testing Instructions

- Select multiple blocks and make sure it says `Blocks` and not `blocks` in the right panel, and that `words`  is changes to `words selected.`

## Screenshots or screencast <!-- if applicable -->

Before:
<img width="277" alt="CleanShot 2023-05-03 at 18 06 48" src="https://user-images.githubusercontent.com/1813435/236291780-169045b8-7080-4e9a-8565-5fd3e9068938.png">

After:
<img width="205" alt="Screenshot 2023-05-08 at 1 15 45 PM" src="https://user-images.githubusercontent.com/3629020/236713723-ac50c83b-3626-44c1-8acb-92ddc770bde2.png">



