### PR TITLE
Update background color of post editor when viewing mobile or tablet viewports, or in template mode

### DIFF
--- a/packages/edit-post/src/components/visual-editor/style.scss
+++ b/packages/edit-post/src/components/visual-editor/style.scss
@@ -7,7 +7,7 @@
 	// Gray preview overlay (desktop/tablet/mobile) is intentionally not set on an element with scrolling content like
 	// interface-interface-skeleton__content. This causes graphical glitches (flashes of the background color)
 	// when scrolling in Safari due to incorrect ordering of large compositing layers (GPU acceleration).
-	background-color: $gray-800;
+	background-color: $gray-900;
 
 	// The button element easily inherits styles that are meant for the editor style.
 	// These rules enhance the specificity to reduce that inheritance.

--- a/packages/edit-site/src/style.scss
+++ b/packages/edit-site/src/style.scss
@@ -85,7 +85,7 @@ body.site-editor-php {
 	}
 
 	.interface-interface-skeleton__content {
-		background-color: $gray-800;
+		background-color: $gray-900;
 	}
 }
 


### PR DESCRIPTION
## What?
Fixes #50341

Updates background color of post editor when viewing mobile or tablet viewports, or in template mode.

Also updates a similar style in the site editor, though it's not clear to me if that's ever visible.

## Testing Instructions
1. Open the post editor
2. Switch to mobile or tablet view, or template editing mode
3. Check the dark gray background color, it should be #1e1e1e

## Screenshots or screencast <!-- if applicable -->
![Screen Shot 2023-05-05 at 2 27 09 pm](https://user-images.githubusercontent.com/677833/236390108-9aee2d19-9377-4ee0-8db2-be546211af9f.png)

![Screen Shot 2023-05-05 at 2 27 01 pm](https://user-images.githubusercontent.com/677833/236390160-d3f44da6-fc1a-4d96-9587-58af6f97a247.png)

