### PR TITLE
Update end to end test sharding on CI, make Playwright tests faster, Puppeteer tests slower

### DIFF
--- a/.github/workflows/end2end-test.yml
+++ b/.github/workflows/end2end-test.yml
@@ -23,8 +23,8 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                part: [1, 2, 3, 4]
-                totalParts: [4]
+                part: [1, 2, 3]
+                totalParts: [3]
 
         steps:
             - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
@@ -67,8 +67,8 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                part: [1, 2]
-                totalParts: [2]
+                part: [1, 2, 3, 4]
+                totalParts: [4]
 
         steps:
             - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0

--- a/test/e2e/playwright.config.ts
+++ b/test/e2e/playwright.config.ts
@@ -11,9 +11,7 @@ const STORAGE_STATE_PATH =
 	path.join( process.cwd(), 'artifacts/storage-states/admin.json' );
 
 const config = defineConfig( {
-	reporter: process.env.CI
-		? [ [ 'github' ], [ './config/flaky-tests-reporter.ts' ] ]
-		: 'list',
+	reporter: 'list',
 	forbidOnly: !! process.env.CI,
 	workers: 1,
 	retries: process.env.CI ? 2 : 0,

--- a/test/e2e/playwright.config.ts
+++ b/test/e2e/playwright.config.ts
@@ -11,7 +11,9 @@ const STORAGE_STATE_PATH =
 	path.join( process.cwd(), 'artifacts/storage-states/admin.json' );
 
 const config = defineConfig( {
-	reporter: 'list',
+	reporter: process.env.CI
+		? [ [ 'github' ], [ './config/flaky-tests-reporter.ts' ] ]
+		: 'list',
 	forbidOnly: !! process.env.CI,
 	workers: 1,
 	retries: process.env.CI ? 2 : 0,


### PR DESCRIPTION
## What?
As more end to end tests are migrated to Playwright (and new tests are added), those jobs are naturally taking longer. (around 30-35 minutes)

Similarly as there are fewer tests running using Puppeteer those are becoming quicker. (around 10-15 minutes)

This adjusts the jobs so that there's more sharding for Playwright, now tests are split into 4 sets. Puppeteer tests are now reduced to 3 sets.

By my calculations, it should make both Puppeteer and Playwright tests complete in around 20 minutes, so they'll both be quicker than Performance tests again.
