### PR TITLE
Gallery: Fix inner block selection

### DIFF
--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -127,7 +127,6 @@ function GalleryEdit( props ) {
 		replaceInnerBlocks,
 		updateBlockAttributes,
 		selectBlock,
-		clearSelectedBlock,
 	} = useDispatch( blockEditorStore );
 	const { createSuccessNotice, createErrorNotice } =
 		useDispatch( noticesStore );
@@ -186,9 +185,6 @@ function GalleryEdit( props ) {
 				align: undefined,
 			} );
 		} );
-		if ( newImages?.length > 0 ) {
-			clearSelectedBlock();
-		}
 	}, [ newImages ] );
 
 	const imageSizeOptions = useImageSizes(
@@ -343,10 +339,6 @@ function GalleryEdit( props ) {
 			} );
 		} );
 
-		if ( newBlocks?.length > 0 ) {
-			selectBlock( newBlocks[ 0 ].clientId );
-		}
-
 		replaceInnerBlocks(
 			clientId,
 			existingImageBlocks
@@ -357,6 +349,11 @@ function GalleryEdit( props ) {
 						newOrderMap[ b.attributes.id ]
 				)
 		);
+
+		// Select the first block to scroll into view when new blocks are added.
+		if ( newBlocks?.length > 0 ) {
+			selectBlock( newBlocks[ 0 ].clientId );
+		}
 	}
 
 	function onUploadError( message ) {

--- a/test/e2e/specs/editor/blocks/classic.spec.js
+++ b/test/e2e/specs/editor/blocks/classic.spec.js
@@ -84,10 +84,6 @@ test.describe( 'Classic', () => {
 		);
 		await expect( galleryBlock ).toBeVisible();
 
-		// Focus on the editor so that keyboard shortcuts work.
-		// See: https://github.com/WordPress/gutenberg/issues/46844
-		await galleryBlock.focus();
-
 		// Check that you can undo back to a Classic block gallery in one step.
 		await pageUtils.pressKeys( 'primary+z' );
 		await expect(


### PR DESCRIPTION
## What?
Fixes #46844.
Fixes #50308.

Fixes a bug when Gallery wasn't selected after transformation from an Image block.

I also noticed that the fix from #39269 got regressed. So this update also fixes the new image upload selection for Galleries.

## Why?
In the Edit component, the `clearSelectedBlock` action was being called from an effect that runs whenever a new image array is updated. This caused the selected block to be deselected whenever an image was transformed or added to the gallery.

## How?
* Removes the `clearSelectedBlock` call from the effect.
* Moves the `selectBlock` call after the `replaceInnerBlocks` action call. This order allows correct block selection.

## Testing Instructions

**The block transformation fix:**
1. Open a Post or Page.
2. Insert an Image block.
3. Transform the image block into a Gallery.
4. Confirm the gallery block is selected after transformation.

**Selecting the first block after upload.**
1. Open a Post or Page.
2. Insert a Gallery block and add one image.
3. Add more images to the block.
4. Confirm that the first of the images is selected after the upload.

I also smoked tested the issue from #39847 and couldn't confirm any regressions.

## Screenshots or screencast <!-- if applicable -->

**Before**

https://user-images.githubusercontent.com/240569/236398468-1f87a227-6aba-46f6-888c-f2e2ca0c9bf8.mp4

**After**

https://user-images.githubusercontent.com/240569/236398721-dbcc60c0-2900-488e-a047-3ed6b3d71fa0.mp4

