### PR TITLE
Fix/wp get global styles for custom props returns internal variable

### DIFF
--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -795,7 +795,7 @@ class WP_Theme_JSON_Gutenberg {
 			if ( empty( $result ) ) {
 				unset( $output[ $subtree ] );
 			} else {
-				$output[ $subtree ] = static::sanitize_variables( $result );
+				$output[ $subtree ] = static::resolve_custom_css_format( $result );
 			}
 		}
 
@@ -3598,14 +3598,14 @@ class WP_Theme_JSON_Gutenberg {
 	 * @param array $tree   Input to process.
 	 * @return array The modified $tree.
 	 */
-	private static function sanitize_variables( $tree ) {
+	private static function resolve_custom_css_format( $tree ) {
 		$prefix = 'var:';
 
 		foreach ( $tree as $key => $data ) {
 			if ( is_string( $data ) && 0 === strpos( $data, $prefix ) ) {
 				$tree[ $key ] = self::convert_custom_properties( $data );
 			} elseif ( is_array( $data ) ) {
-				$tree[ $key ] = self::sanitize_variables( $data );
+				$tree[ $key ] = self::resolve_custom_css_format( $data );
 			}
 		}
 

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -1989,21 +1989,7 @@ class WP_Theme_JSON_Gutenberg {
 			return $value;
 		}
 
-		// Convert custom CSS properties.
-		$prefix     = 'var:';
-		$prefix_len = strlen( $prefix );
-		$token_in   = '|';
-		$token_out  = '--';
-		if ( 0 === strncmp( $value, $prefix, $prefix_len ) ) {
-			$unwrapped_name = str_replace(
-				$token_in,
-				$token_out,
-				substr( $value, $prefix_len )
-			);
-			$value          = "var(--wp--$unwrapped_name)";
-		}
-
-		return $value;
+    return self::convert_custom_properties( $value );
 	}
 
 	/**
@@ -3578,4 +3564,29 @@ class WP_Theme_JSON_Gutenberg {
 
 		return $declarations;
 	}
+
+  /**
+   * This is used to convert the internal representation of variables to the CSS representation.
+   * For example, `var:preset|color|vivid-green-cyan` becomes `var(--wp--preset--color--vivid-green-cyan)`.
+	 * 
+   * @since 6.3.0
+   * @param string $value The variable such as var:preset|color|vivid-green-cyan to convert.
+   * @return string The converted variable.
+   */
+  private static function convert_custom_properties($value) {
+    $prefix     = 'var:';
+    $prefix_len = strlen( $prefix );
+    $token_in   = '|';
+    $token_out  = '--';
+    if ( 0 === strncmp( $value, $prefix, $prefix_len ) ) {
+      $unwrapped_name = str_replace(
+        $token_in,
+        $token_out,
+        substr( $value, $prefix_len )
+      );
+      $value          = "var(--wp--$unwrapped_name)";
+    }
+
+    return $value;
+  }
 }

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -3612,6 +3612,10 @@ class WP_Theme_JSON_Gutenberg {
 				foreach ( $values as $name => $value ) {
 					// if value is an array, do recursion.
 					if ( is_array( $value ) ) {
+						// make sure variations are included in the schema for recursion.
+						if ( isset( $value['variations'] ) ) {
+							$schema = $schema + array( 'variations' => null );
+						}
 						$values[ $name ] = array_merge( $value, self::sanitize_variables( $value, $schema ) );
 						continue;
 					}

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -3578,7 +3578,7 @@ class WP_Theme_JSON_Gutenberg {
 		$prefix_len = strlen( $prefix );
 		$token_in   = '|';
 		$token_out  = '--';
-		if ( 0 === strncmp( $value, $prefix, $prefix_len ) ) {
+		if ( 0 === strpos( $value, $prefix ) ) {
 			$unwrapped_name = str_replace(
 				$token_in,
 				$token_out,
@@ -3602,7 +3602,6 @@ class WP_Theme_JSON_Gutenberg {
 	private static function sanitize_variables( $tree, $schema ) {
 		$tree   = array_intersect_key( $tree, $schema );
 		$prefix = 'var:';
-
 		foreach ( $schema as $key => $data ) {
 			if ( ! isset( $tree[ $key ] ) ) {
 				continue;
@@ -3625,11 +3624,9 @@ class WP_Theme_JSON_Gutenberg {
 
 					$values[ $name ] = self::convert_custom_properties( $value );
 				}
+			} elseif ( ! is_string( $values ) || 0 !== strpos( $values, $prefix ) ) {
+				continue;
 			} else {
-				if ( ! is_string( $values ) || 0 !== strpos( $values, $prefix ) ) {
-					continue;
-				}
-
 				$values = self::convert_custom_properties( $values );
 			}
 

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -1989,7 +1989,7 @@ class WP_Theme_JSON_Gutenberg {
 			return $value;
 		}
 
-		return self::convert_custom_properties( $value );
+		return $value;
 	}
 
 	/**

--- a/lib/compat/wordpress-6.3/get-global-styles-and-settings.php
+++ b/lib/compat/wordpress-6.3/get-global-styles-and-settings.php
@@ -124,3 +124,35 @@ if ( ! function_exists( 'wp_get_block_css_selector' ) ) {
 function gutenberg_get_remote_theme_patterns() {
 	return WP_Theme_JSON_Resolver_Gutenberg::get_theme_data( array(), array( 'with_supports' => false ) )->get_patterns();
 }
+
+/**
+ * Gets the styles resulting of merging core, theme, and user data.
+ *
+ * @since 6.3.0
+ *
+ * @param array $path    Path to the specific style to retrieve. Optional.
+ *                       If empty, will return all styles.
+ * @param array $context {
+ *     Metadata to know where to retrieve the $path from. Optional.
+ *
+ *     @type string $block_name Which block to retrieve the styles from.
+ *                              If empty, it'll return the styles for the global context.
+ *     @type string $origin     Which origin to take data from.
+ *                              Valid values are 'all' (core, theme, and user) or 'base' (core and theme).
+ *                              If empty or unknown, 'all' is used.
+ * }
+ * @return array The styles to retrieve.
+ */
+function gutenberg_get_global_styles( $path = array(), $context = array() ) {
+	if ( ! empty( $context['block_name'] ) ) {
+		$path = array_merge( array( 'blocks', $context['block_name'] ), $path );
+	}
+
+	$origin = 'custom';
+	if ( isset( $context['origin'] ) && 'base' === $context['origin'] ) {
+		$origin = 'theme';
+	}
+	$styles = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data( $origin )->get_raw_data()['styles'];
+
+	return _wp_array_get( $styles, $path, $styles );
+}

--- a/lib/compat/wordpress-6.3/get-global-styles-and-settings.php
+++ b/lib/compat/wordpress-6.3/get-global-styles-and-settings.php
@@ -128,7 +128,7 @@ function gutenberg_get_remote_theme_patterns() {
 /**
  * Gets the styles resulting of merging core, theme, and user data.
  *
- * @since 6.3.0
+ * @since 5.9.0
  *
  * @param array $path    Path to the specific style to retrieve. Optional.
  *                       If empty, will return all styles.

--- a/lib/compat/wordpress-6.3/get-global-styles-and-settings.php
+++ b/lib/compat/wordpress-6.3/get-global-styles-and-settings.php
@@ -129,6 +129,8 @@ function gutenberg_get_remote_theme_patterns() {
  * Gets the styles resulting of merging core, theme, and user data.
  *
  * @since 5.9.0
+ * @since 6.3.0 the internal link format "var:preset|color|secondary" is resolved
+ * to "var(--wp--preset--font-size--small)" so consumers don't have to.
  *
  * @param array $path    Path to the specific style to retrieve. Optional.
  *                       If empty, will return all styles.

--- a/lib/experimental/block-editor-settings-mobile.php
+++ b/lib/experimental/block-editor-settings-mobile.php
@@ -23,7 +23,7 @@ function gutenberg_get_block_editor_settings_mobile( $settings ) {
 		'mobile' === $_GET['context']
 	) {
 		if ( wp_theme_has_theme_json() ) {
-			$settings['__experimentalStyles'] = wp_get_global_styles();
+			$settings['__experimentalStyles'] = gutenberg_get_global_styles();
 		}
 
 		// To tell mobile that the site uses quote v2 (inner blocks).

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -2071,4 +2071,69 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 			),
 		);
 	}
+
+	public function test_internal_syntax_is_converted_to_css_variables() {
+		$result = new WP_Theme_JSON_Gutenberg(
+			array(
+				'version' => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+				'styles'  => array(
+					'color'    => array(
+						'background' => 'var:preset|color|primary',
+						'text'       => 'var(--wp--preset--color--secondary)',
+					),
+					'elements' => array(
+						'link' => array(
+							'color' => array(
+								'background' => 'var:preset|color|pri',
+								'text'       => 'var(--wp--preset--color--sec)',
+							),
+						),
+					),
+					'blocks'   => array(
+						'core/post-terms' => array(
+							'typography' => array( 'fontSize' => 'var(--wp--preset--font-size--small)' ),
+							'color'      => array( 'background' => 'var:preset|color|secondary' ),
+						),
+						'core/navigation' => array(
+							'elements' => array(
+								'link' => array(
+									'color' => array(
+										'background' => 'var:preset|color|p',
+										'text'       => 'var(--wp--preset--color--s)',
+									),
+								),
+							),
+						),
+						'core/quote'      => array(
+							'typography' => array( 'fontSize' => 'var(--wp--preset--font-size--d)' ),
+							'color'      => array( 'background' => 'var:preset|color|d' ),
+							'variations' => array(
+								'plain' => array(
+									'typography' => array( 'fontSize' => 'var(--wp--preset--font-size--s)' ),
+									'color'      => array( 'background' => 'var:preset|color|s' ),
+								),
+							),
+						),
+					),
+				),
+			)
+		);
+		$styles = $result->get_raw_data()['styles'];
+
+		$this->assertEquals( 'var(--wp--preset--color--primary)', $styles['color']['background'], 'Top level: Assert the originally correct values are still correct.' );
+		$this->assertEquals( 'var(--wp--preset--color--secondary)', $styles['color']['text'], 'Top level: Assert the originally correct values are still correct.' );
+
+		$this->assertEquals( 'var(--wp--preset--color--pri)', $styles['elements']['link']['color']['background'], 'Element top level: Assert the originally correct values are still correct.' );
+		$this->assertEquals( 'var(--wp--preset--color--sec)', $styles['elements']['link']['color']['text'], 'Element top level: Assert the originally correct values are still correct.' );
+
+		$this->assertEquals( 'var(--wp--preset--font-size--small)', $styles['blocks']['core/post-terms']['typography']['fontSize'], 'Top block level: Assert the originally correct values are still correct.' );
+		$this->assertEquals( 'var(--wp--preset--color--secondary)', $styles['blocks']['core/post-terms']['color']['background'], 'Top block level: Assert the internal variables are convert to CSS custom variables.' );
+
+		$this->assertEquals( 'var(--wp--preset--color--p)', $styles['blocks']['core/navigation']['elements']['link']['color']['background'], 'Elements block level: Assert the originally correct values are still correct.' );
+		$this->assertEquals( 'var(--wp--preset--color--s)', $styles['blocks']['core/navigation']['elements']['link']['color']['text'], 'Elements block level: Assert the originally correct values are still correct.' );
+
+		$this->assertEquals( 'var(--wp--preset--font-size--s)', $styles['blocks']['core/quote']['variations']['plain']['typography']['fontSize'], 'Style variations: Assert the originally correct values are still correct.' );
+		$this->assertEquals( 'var(--wp--preset--color--s)', $styles['blocks']['core/quote']['variations']['plain']['color']['background'], 'Style variations: Assert the internal variables are convert to CSS custom variables.' );
+
+	}
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This PR fixes https://github.com/WordPress/gutenberg/issues/49693 so that `wp_get_global_styles` for the following in theme.json 
```
"core/post-terms": {
    "typography": { "fontSize": "var(--wp--preset--font-size--small)" },
    "color":{ "background": "var:preset|color|secondary" }
}
```
returns:

```
(
    [typography] => Array( [fontSize] => var(--wp--preset--font-size--small) )
    [color] => Array( [background] => var(--wp--preset--color--secondary) )
)
```

## Why?
https://github.com/WordPress/gutenberg/issues/49693
The internal syntax shouldn't leak out.

## How?
This PR extract the already existing logic that converts `var:preset|color|secondary` to `var(--wp--preset--font-size--small)` to a separate method, then uses the same method to sanitize the output of `wp_get_global_styles` to only include custom CSS variables and not internal variable syntax.

## Testing Instructions
Please refer to the issues for testing instructions, but please note the following:

1) Make sure the Gutenberg plugin is installed and active
2) In body of `wp_get_global_styles` exchange `WP_Theme_JSON_Resolver`  with `WP_Theme_JSON_Resolver_Gutenberg`
3) Confirm the output of `wp_get_global_styles` doesn't include internal variable syntax.


