### PR TITLE
[Post Featured Image]: Try fix max-width sizing issues

### DIFF
--- a/packages/block-library/src/post-featured-image/edit.js
+++ b/packages/block-library/src/post-featured-image/edit.js
@@ -59,6 +59,7 @@ export default function PostFeaturedImageEdit( {
 		sizeSlug,
 		rel,
 		linkTarget,
+		align,
 	} = attributes;
 	const [ featuredImage, setFeaturedImage ] = useEntityProp(
 		'postType',
@@ -96,9 +97,19 @@ export default function PostFeaturedImageEdit( {
 			label: name,
 		} ) );
 
-	const blockProps = useBlockProps( {
-		style: { width, height, aspectRatio, maxWidth: '100%' },
-	} );
+	const style = {
+		width,
+		height,
+		aspectRatio,
+	};
+	// Depending on the `align` value we need to set a different max-width
+	// to restrict properly the image size.
+	if ( ! align ) {
+		style.maxWidth = 'min(100%, var(--wp--style--global--content-size))';
+	} else if ( align === 'wide' ) {
+		style.maxWidth = 'min(100%, var(--wp--style--global--wide-size))';
+	}
+	const blockProps = useBlockProps( { style } );
 	const borderProps = useBorderProps( attributes );
 
 	const placeholder = ( content ) => {

--- a/packages/block-library/src/post-featured-image/index.php
+++ b/packages/block-library/src/post-featured-image/index.php
@@ -92,7 +92,13 @@ function render_block_core_post_featured_image( $attributes, $content, $block ) 
 	if ( ! $height && ! $width && ! $aspect_ratio ) {
 		$wrapper_attributes = get_block_wrapper_attributes();
 	} else {
-		$wrapper_attributes = get_block_wrapper_attributes( array( 'style' => $aspect_ratio . $width . $height . 'max-width:100%;' ) );
+		$max_width = '';
+		if ( empty( $attributes['align'] ) ) {
+			$max_width = 'max-width:min(100%, var(--wp--style--global--content-size));';
+		} elseif ( 'wide' === $attributes['align'] ) {
+			$max_width = 'max-width:min(100%, var(--wp--style--global--wide-size));';
+		}
+		$wrapper_attributes = get_block_wrapper_attributes( array( 'style' => $aspect_ratio . $width . $height . $max_width ) );
 	}
 	return "<figure {$wrapper_attributes}>{$featured_image}</figure>";
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Follow up of: https://github.com/WordPress/gutenberg/pull/49641#issuecomment-1534916923

The above PR tried to fix some sizing issues with Post Featured Image, but introduced a regression.
> I just noticed that after this change, the Feature Image block in post content takes up full width, even when alignment says "None."
>![CleanShot 2023-05-04 at 17 25 36](https://user-images.githubusercontent.com/240569/236218462-12e85f37-4d9e-4170-b98c-cba9e1523c66.png)

This PR tries to constraint the max-width based on the alignment, but I'm not sure of all the nuances here and we might end up reverting the original PR.

This PR while it seems to handle properly the `wide, none` alignments, doesn't prevent the overflowing of images when we have set a `full align` and a big `width` in the block settings. Noting though that this will still be the case by reverting the original PR. Any ideas or insights maybe from @tellthemachines would be much appreciated!

## Testing Instructions
1. Insert Post Feature Image block
2. Set a big width like 1500px
3. Observe there is no overflow of images, except when we have `full` align.


