### PR TITLE
Site editor: remove canvas box shadow

### DIFF
--- a/packages/edit-site/src/components/block-editor/style.scss
+++ b/packages/edit-site/src/components/block-editor/style.scss
@@ -54,14 +54,16 @@
 		overflow: auto;
 	}
 
-	/*
-		Temporary to hide the contextual toolbar in view mode.
-		See: https://github.com/WordPress/gutenberg/pull/46298
-		This rule can possibly be removed once the
-		contextual toolbar has been redesigned.
-		See: https://github.com/WordPress/gutenberg/issues/40450
-	*/
 	&.is-view-mode {
+		box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.8), 0 8px 10px -6px rgba(0, 0, 0, 0.8);
+
+		/*
+			Temporary to hide the contextual toolbar in view mode.
+			See: https://github.com/WordPress/gutenberg/pull/46298
+			This rule can possibly be removed once the
+			contextual toolbar has been redesigned.
+			See: https://github.com/WordPress/gutenberg/issues/40450
+		*/
 		.block-editor-block-contextual-toolbar {
 			display: none;
 		}

--- a/packages/edit-site/src/components/layout/style.scss
+++ b/packages/edit-site/src/components/layout/style.scss
@@ -108,7 +108,6 @@
 
 	& > div {
 		color: $gray-900;
-		box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.8), 0 8px 10px -6px rgba(0, 0, 0, 0.8);
 	}
 
 	@include break-medium {
@@ -134,7 +133,6 @@
 
 		& > div {
 			border-radius: 0;
-			box-shadow: none;
 		}
 	}
 }

--- a/packages/edit-site/src/components/list/style.scss
+++ b/packages/edit-site/src/components/list/style.scss
@@ -33,6 +33,10 @@
 
 .edit-site {
 	.edit-site-list {
+		background: $white;
+		border-radius: $radius-block-ui * 4;
+		box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.8), 0 8px 10px -6px rgba(0, 0, 0, 0.8);
+
 		.interface-interface-skeleton__editor {
 			min-width: 100%;
 


### PR DESCRIPTION
## What?

Fixes a regression introduce in #48970 because the list pages still require white backgrounds. Also removes the box shadow from the higher level div and moves it down into each "frame" separately. That way when loading, the box shadow is not visible.

## Testing Instructions

1- Check the loading state of the site editor
2- Check the "browse all templates" page in the site editor
