### PR TITLE
[RNMobile] Wait for delayed block insertion in the add block test helper

### DIFF
--- a/test/native/integration-test-helpers/add-block.js
+++ b/test/native/integration-test-helpers/add-block.js
@@ -1,12 +1,19 @@
 /**
+ * WordPress dependencies
+ */
+import { Platform } from '@wordpress/element';
+
+/**
  * External dependencies
  */
-import { fireEvent } from '@testing-library/react-native';
+import { act, fireEvent } from '@testing-library/react-native';
+import { AccessibilityInfo } from 'react-native';
 
 /**
  * Internal dependencies
  */
 import { waitFor } from './wait-for';
+import { withFakeTimers } from './with-fake-timers';
 
 /**
  * Adds a block via the block picker.
@@ -38,4 +45,13 @@ export const addBlock = async (
 	} );
 
 	fireEvent.press( await waitFor( () => getByText( blockName ) ) );
+
+	// On iOS the action for inserting a block is delayed (https://bit.ly/3AVALqH).
+	// Hence, we need to wait for the different steps until the the block is inserted.
+	if ( Platform.isIOS ) {
+		await withFakeTimers( async () => {
+			await AccessibilityInfo.isScreenReaderEnabled();
+			act( () => jest.runOnlyPendingTimers() );
+		} );
+	}
 };


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

When using the [`addBlock` test helper](https://github.com/WordPress/gutenberg/blob/trunk/test/native/integration-test-helpers/add-block.js) on tests that use the iOS platform, we noticed that querying the inserted block fails after insertion. This PR fixes this issue.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

We'll be introducing integration tests on Gutenberg Mobile that will be run on the iOS platform, hence we need to fix any issues we might have with test helpers.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

The helper is now waiting for the insertion based on the logic of the inserter menu:
1. Wait for `AccessibilityInfo.isScreenReaderEnabled` promise.
2. Run timers to complete `setTimeout`.
https://github.com/WordPress/gutenberg/blob/e1c720c4ffefa0812be6b2963527722eb80f0469/packages/block-editor/src/components/inserter/menu.native.js#L140-L152

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
1. Apply the following patch:
```patch
diff --git forkSrcPrefix/packages/block-library/src/paragraph/test/edit.native.js forkDstPrefix/packages/block-library/src/paragraph/test/edit.native.js
index d3ff59c0e42c29e6c5baa6da3482952cca0c9d66..02c2bee66b9e5e2f5518199c3009cec3699841f7 100644
--- forkSrcPrefix/packages/block-library/src/paragraph/test/edit.native.js
+++ forkDstPrefix/packages/block-library/src/paragraph/test/edit.native.js
@@ -45,6 +45,13 @@ describe( 'Paragraph block', () => {
 		expect( screen.container ).toBeTruthy();
 	} );
 
+	it.only( 'inserts block', async () => {
+		const screen = await initializeEditor();
+		await addBlock( screen, 'Paragraph' );
+		const block = getBlock( screen, 'Paragraph' );
+		expect( block ).toBeVisible();
+	} );
+
 	it( 'should bold text', async () => {
 		// Arrange
 		const screen = await initializeEditor();

```
2. Run the command: `TEST_RN_PLATFORM=ios npm run native test -- paragraph/test/edit`
3. Observe that tests pass.
4. Observe that `Unit Tests / Mobile` CI job success.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
N/A

## Screenshots or screencast <!-- if applicable -->
N/A