### PR TITLE
[RNMobile] Add Picker test helper

### DIFF
--- a/packages/block-library/src/gallery/test/index.native.js
+++ b/packages/block-library/src/gallery/test/index.native.js
@@ -16,6 +16,7 @@ import {
 	within,
 	setupPicker,
 } from 'test/helpers';
+import { ActionSheetIOS } from 'react-native';
 
 /**
  * WordPress dependencies
@@ -103,9 +104,44 @@ describe( 'Gallery block', () => {
 		expect( getByText( 'WordPress Media Library' ) ).toBeVisible();
 	} );
 
+	it( 'displays correct media options picker', async () => {
+		// Initialize with an empty gallery
+		const screen = await initializeEditor( {
+			initialHtml: generateGalleryBlock( 0 ),
+		} );
+		const { getByText } = screen;
+
+		// Tap on Gallery block
+		const block = await getBlock( screen, 'Gallery' );
+		fireEvent.press( block );
+		fireEvent.press( within( block ).getByText( 'ADD MEDIA' ) );
+
+		// Observe that media options picker is displayed
+		/* eslint-disable jest/no-conditional-expect */
+		if ( Platform.isIOS ) {
+			// On iOS the picker is rendered natively, so we have
+			// to check the arguments passed to `ActionSheetIOS`.
+			expect(
+				ActionSheetIOS.showActionSheetWithOptions
+			).toHaveBeenCalledWith(
+				expect.objectContaining( {
+					title: 'Choose images',
+					options: [ 'Cancel', ...MEDIA_OPTIONS ],
+				} ),
+				expect.any( Function )
+			);
+		} else {
+			expect( getByText( 'Choose images' ) ).toBeVisible();
+			MEDIA_OPTIONS.forEach( ( option ) =>
+				expect( getByText( option ) ).toBeVisible()
+			);
+		}
+		/* eslint-enable jest/no-conditional-expect */
+	} );
+
 	// This case is disabled until the issue (https://github.com/WordPress/gutenberg/issues/38444)
 	// is addressed.
-	it.skip( 'displays media options picker when selecting the block', async () => {
+	it.skip( 'block remains selected after dimissing the media options picker', async () => {
 		// Initialize with an empty gallery
 		const { getByLabelText, getByText, getByTestId } =
 			await initializeEditor( {

--- a/packages/block-library/src/gallery/test/index.native.js
+++ b/packages/block-library/src/gallery/test/index.native.js
@@ -14,6 +14,7 @@ import {
 	setupMediaUpload,
 	triggerBlockListLayout,
 	within,
+	setupPicker,
 } from 'test/helpers';
 
 /**
@@ -35,6 +36,12 @@ import {
 	getGalleryItem,
 	generateGalleryBlock,
 } from './helpers';
+
+const MEDIA_OPTIONS = [
+	'Choose from device',
+	'Take a Photo',
+	'WordPress Media Library',
+];
 
 const media = [
 	{
@@ -213,11 +220,13 @@ describe( 'Gallery block', () => {
 			setupMediaPicker();
 
 		// Initialize with an empty gallery
-		const { galleryBlock, getByText } = await initializeWithGalleryBlock();
+		const screen = await initializeWithGalleryBlock();
+		const { galleryBlock, getByText } = screen;
+		const { selectOption } = setupPicker( screen, MEDIA_OPTIONS );
 
 		// Upload images from device
 		fireEvent.press( getByText( 'ADD MEDIA' ) );
-		fireEvent.press( getByText( 'Choose from device' ) );
+		selectOption( 'Choose from device' );
 		expectMediaPickerCall( 'DEVICE_MEDIA_LIBRARY', [ 'image' ], true );
 
 		// Return media items picked

--- a/test/native/__mocks__/styleMock.js
+++ b/test/native/__mocks__/styleMock.js
@@ -181,4 +181,7 @@ module.exports = {
 	defaultAppender: {
 		marginLeft: 16,
 	},
+	'components-picker__button-title': {
+		color: 'white',
+	},
 };

--- a/test/native/integration-test-helpers/README.md
+++ b/test/native/integration-test-helpers/README.md
@@ -66,6 +66,10 @@ Sets up Media Picker mock functions.
 
 Sets up the media upload mock functions for testing.
 
+### [`setupPicker`](https://github.com/WordPress/gutenberg/blob/HEAD/test/native/integration-test-helpers/setup-picker.js)
+
+Sets up the Picker component for testing.
+
 ### [`changeTextOfTextInput`](https://github.com/WordPress/gutenberg/blob/HEAD/test/native/integration-test-helpers/text-input-change-text.js)
 
 Changes the text of a TextInput component.

--- a/test/native/integration-test-helpers/index.js
+++ b/test/native/integration-test-helpers/index.js
@@ -17,6 +17,7 @@ export { pasteIntoRichText } from './rich-text-paste';
 export { setupCoreBlocks } from './setup-core-blocks';
 export { setupMediaPicker } from './setup-media-picker';
 export { setupMediaUpload } from './setup-media-upload';
+export { setupPicker } from './setup-picker';
 export { changeTextOfTextInput } from './text-input-change-text';
 export { transformBlock } from './transform-block';
 export { triggerBlockListLayout } from './trigger-block-list-layout';

--- a/test/native/integration-test-helpers/setup-picker.js
+++ b/test/native/integration-test-helpers/setup-picker.js
@@ -1,0 +1,40 @@
+/**
+ * WordPress dependencies
+ */
+import { Platform } from '@wordpress/element';
+
+/**
+ * External dependencies
+ */
+import { fireEvent } from '@testing-library/react-native';
+import { ActionSheetIOS } from 'react-native';
+
+/**
+ * Sets up the Picker component for testing.
+ *
+ * @typedef {Object} PickerMockFunctions
+ * @property {Function}                                          selectOption Selects one of the options of the picker.
+ *
+ * @param    {import('@testing-library/react-native').RenderAPI} screen       A Testing Library screen.
+ * @param    {string[]}                                          options      Array with the options of the picker.
+ *
+ * @return {PickerMockFunctions} Picker functions.
+ */
+export function setupPicker( screen, options ) {
+	let selectOption = ( option ) => {
+		fireEvent.press( screen.getByText( option ) );
+	};
+	if ( Platform.isIOS ) {
+		let onOptionSelected;
+		ActionSheetIOS.showActionSheetWithOptions.mockImplementation(
+			( _, callback ) => {
+				onOptionSelected = callback;
+			}
+		);
+		// The index passed is incremented by one as the first
+		// option of the picker is `Cancel`.
+		selectOption = ( option ) =>
+			onOptionSelected( options.indexOf( option ) + 1 );
+	}
+	return { selectOption };
+}

--- a/test/native/setup.js
+++ b/test/native/setup.js
@@ -228,6 +228,9 @@ jest.mock(
 		},
 	} )
 );
+jest.mock( 'react-native/Libraries/ActionSheetIOS/ActionSheetIOS', () => ( {
+	showActionSheetWithOptions: jest.fn(),
+} ) );
 
 // The mock provided by the package itself does not appear to work correctly.
 // Specifically, the mock provides a named export, where the module itself uses


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Adds a test helper to manipulate the Picker component on Android and iOS.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Currently, the Picker component works on Android tests but not on iOS.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

The helper mocks the `ActionSheetIOS` library which renders the Picker component natively on iOS.

Additionally, the Gallery block tests have been updated to use this helper as a demonstration.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
### Android
1. Run the command: `TEST_RN_PLATFORM=android npm run native test -- gallery/test/index`
2. Observe that all tests pass.

**NOTE:** The Gallery block tests are displaying the warning `An update to UncontrolledInnerBlocks inside a test was not wrapped in act(...)`. I confirmed that this warning is also displayed in `trunk`, so we can omit it.

### iOS
1. Apply the following patch to limit the run on specific tests:
```patch
diff --git forkSrcPrefix/packages/block-library/src/gallery/test/index.native.js forkDstPrefix/packages/block-library/src/gallery/test/index.native.js
index dabc6d6b1b30c64cdd3ab0361839d968782a7ed1..60be04026ca52647bc6910022d860a0c9c6674ec 100644
--- forkSrcPrefix/packages/block-library/src/gallery/test/index.native.js
+++ forkDstPrefix/packages/block-library/src/gallery/test/index.native.js
@@ -104,7 +104,7 @@ describe( 'Gallery block', () => {
 		expect( getByText( 'WordPress Media Library' ) ).toBeVisible();
 	} );
 
-	it( 'displays correct media options picker', async () => {
+	it.only( 'displays correct media options picker', async () => {
 		// Initialize with an empty gallery
 		const screen = await initializeEditor( {
 			initialHtml: generateGalleryBlock( 0 ),
@@ -250,7 +250,7 @@ describe( 'Gallery block', () => {
 
 	// Test case related to TC005 - Choose from device (stay in editor) - Successful upload
 	// Reference: https://github.com/wordpress-mobile/test-cases/blob/trunk/test-cases/gutenberg/gallery.md#tc005
-	it( 'successfully uploads items', async () => {
+	it.only( 'successfully uploads items', async () => {
 		const { notifyUploadingState, notifySucceedState } = setupMediaUpload();
 		const { expectMediaPickerCall, mediaPickerCallback } =
 			setupMediaPicker();
```
2. Run the command: `TEST_RN_PLATFORM=ios npm run native test -- gallery/test/index`
3. Observe that all tests pass.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
N/A

## Screenshots or screencast <!-- if applicable -->
N/A
