### PR TITLE
Fix accessibility of the Classic block modal dialog

### DIFF
--- a/packages/block-library/src/freeform/modal.js
+++ b/packages/block-library/src/freeform/modal.js
@@ -11,6 +11,7 @@ import {
 import { useEffect, useState, RawHTML } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
+import { useInstanceId } from '@wordpress/compose';
 
 function ClassicEdit( props ) {
 	const styles = useSelect(
@@ -59,6 +60,7 @@ export default function ModalEdit( props ) {
 	const [ isOpen, setOpen ] = useState( false );
 	const id = `editor-${ clientId }`;
 	const label = __( 'Classic Edit' );
+	const instanceId = useInstanceId( ModalEdit, 'components-modal-header' );
 
 	return (
 		<>
@@ -71,12 +73,16 @@ export default function ModalEdit( props ) {
 			</BlockControls>
 			{ content && <RawHTML>{ content }</RawHTML> }
 			{ ( isOpen || ! content ) && (
-				<Modal title={ label } __experimentalHideHeader={ true }>
+				<Modal
+					__experimentalHideHeader={ true }
+					aria={ { labelledby: instanceId } }
+				>
 					<h2
 						style={ {
 							display: 'flex',
 							justifyContent: 'space-between',
 						} }
+						id={ instanceId }
 					>
 						<div>{ label }</div>
 						<div>

--- a/packages/block-library/src/freeform/modal.js
+++ b/packages/block-library/src/freeform/modal.js
@@ -12,7 +12,7 @@ import {
 	__experimentalHeading as Heading,
 } from '@wordpress/components';
 import { useEffect, useState, RawHTML } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
 import { useInstanceId } from '@wordpress/compose';
 
@@ -62,7 +62,7 @@ export default function ModalEdit( props ) {
 	} = props;
 	const [ isOpen, setOpen ] = useState( false );
 	const id = `editor-${ clientId }`;
-	const label = __( 'Classic Edit' );
+	const label = _x( 'Classic Edit', 'Classic block' );
 	const instanceId = useInstanceId(
 		ModalEdit,
 		'wp-block-freeform-modal-header'

--- a/packages/block-library/src/freeform/modal.js
+++ b/packages/block-library/src/freeform/modal.js
@@ -7,6 +7,9 @@ import {
 	ToolbarButton,
 	Modal,
 	Button,
+	Flex,
+	FlexItem,
+	__experimentalHeading as Heading,
 } from '@wordpress/components';
 import { useEffect, useState, RawHTML } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -60,7 +63,10 @@ export default function ModalEdit( props ) {
 	const [ isOpen, setOpen ] = useState( false );
 	const id = `editor-${ clientId }`;
 	const label = __( 'Classic Edit' );
-	const instanceId = useInstanceId( ModalEdit, 'components-modal-header' );
+	const instanceId = useInstanceId(
+		ModalEdit,
+		'wp-block-freeform-modal-header'
+	);
 
 	return (
 		<>
@@ -77,38 +83,46 @@ export default function ModalEdit( props ) {
 					__experimentalHideHeader={ true }
 					aria={ { labelledby: instanceId } }
 				>
-					<h2
-						style={ {
-							display: 'flex',
-							justifyContent: 'space-between',
-						} }
-						id={ instanceId }
+					<Flex
+						justify="space-between"
+						expanded={ true }
+						style={ { marginBottom: 8 } }
 					>
-						<div>{ label }</div>
-						<div>
-							<Button
-								onClick={ () =>
-									content ? setOpen( false ) : onReplace( [] )
-								}
-							>
-								{ __( 'Cancel' ) }
-							</Button>
-							<Button
-								variant="primary"
-								onClick={ () => {
-									setAttributes( {
-										content:
-											window.wp.oldEditor.getContent(
-												id
-											),
-									} );
-									setOpen( false );
-								} }
-							>
-								{ __( 'Save' ) }
-							</Button>
-						</div>
-					</h2>
+						<FlexItem>
+							<Heading level={ 1 } size="16" id={ instanceId }>
+								{ label }
+							</Heading>
+						</FlexItem>
+						<Flex justify="flex-end" expanded={ false }>
+							<FlexItem>
+								<Button
+									onClick={ () =>
+										content
+											? setOpen( false )
+											: onReplace( [] )
+									}
+								>
+									{ __( 'Cancel' ) }
+								</Button>
+							</FlexItem>
+							<FlexItem>
+								<Button
+									variant="primary"
+									onClick={ () => {
+										setAttributes( {
+											content:
+												window.wp.oldEditor.getContent(
+													id
+												),
+										} );
+										setOpen( false );
+									} }
+								>
+									{ __( 'Save' ) }
+								</Button>
+							</FlexItem>
+						</Flex>
+					</Flex>
 					<ClassicEdit id={ id } defaultValue={ content } />
 				</Modal>
 			) }

--- a/packages/block-library/src/freeform/modal.js
+++ b/packages/block-library/src/freeform/modal.js
@@ -9,12 +9,10 @@ import {
 	Button,
 	Flex,
 	FlexItem,
-	__experimentalHeading as Heading,
 } from '@wordpress/components';
 import { useEffect, useState, RawHTML } from '@wordpress/element';
 import { __, _x } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
-import { useInstanceId } from '@wordpress/compose';
 
 function ClassicEdit( props ) {
 	const styles = useSelect(
@@ -31,7 +29,6 @@ function ClassicEdit( props ) {
 		window.wp.oldEditor.initialize( props.id, {
 			tinymce: {
 				...settings,
-				height: 500,
 				setup( editor ) {
 					editor.on( 'init', () => {
 						const doc = editor.getDoc();
@@ -63,10 +60,8 @@ export default function ModalEdit( props ) {
 	const [ isOpen, setOpen ] = useState( false );
 	const id = `editor-${ clientId }`;
 	const label = _x( 'Classic Edit', 'Classic block' );
-	const instanceId = useInstanceId(
-		ModalEdit,
-		'wp-block-freeform-modal-header'
-	);
+
+	const onClose = () => ( content ? setOpen( false ) : onReplace( [] ) );
 
 	return (
 		<>
@@ -80,50 +75,42 @@ export default function ModalEdit( props ) {
 			{ content && <RawHTML>{ content }</RawHTML> }
 			{ ( isOpen || ! content ) && (
 				<Modal
-					__experimentalHideHeader={ true }
-					aria={ { labelledby: instanceId } }
+					title={ label }
+					onRequestClose={ onClose }
+					shouldCloseOnClickOutside={ false }
 				>
+					<ClassicEdit
+						id={ id }
+						defaultValue={ content }
+						className="block-editor-freeform-modal__textarea"
+					/>
 					<Flex
-						justify="space-between"
-						expanded={ true }
-						style={ { marginBottom: 8 } }
+						className="block-editor-freeform-modal__actions"
+						justify="flex-end"
+						expanded={ false }
 					>
 						<FlexItem>
-							<Heading level={ 1 } size="16" id={ instanceId }>
-								{ label }
-							</Heading>
+							<Button variant="tertiary" onClick={ onClose }>
+								{ __( 'Cancel' ) }
+							</Button>
 						</FlexItem>
-						<Flex justify="flex-end" expanded={ false }>
-							<FlexItem>
-								<Button
-									onClick={ () =>
-										content
-											? setOpen( false )
-											: onReplace( [] )
-									}
-								>
-									{ __( 'Cancel' ) }
-								</Button>
-							</FlexItem>
-							<FlexItem>
-								<Button
-									variant="primary"
-									onClick={ () => {
-										setAttributes( {
-											content:
-												window.wp.oldEditor.getContent(
-													id
-												),
-										} );
-										setOpen( false );
-									} }
-								>
-									{ __( 'Save' ) }
-								</Button>
-							</FlexItem>
-						</Flex>
+						<FlexItem>
+							<Button
+								variant="primary"
+								onClick={ () => {
+									setAttributes( {
+										content:
+											window.wp.oldEditor.getContent(
+												id
+											),
+									} );
+									setOpen( false );
+								} }
+							>
+								{ __( 'Save' ) }
+							</Button>
+						</FlexItem>
 					</Flex>
-					<ClassicEdit id={ id } defaultValue={ content } />
 				</Modal>
 			) }
 		</>

--- a/packages/block-library/src/freeform/modal.js
+++ b/packages/block-library/src/freeform/modal.js
@@ -78,6 +78,7 @@ export default function ModalEdit( props ) {
 					title={ label }
 					onRequestClose={ onClose }
 					shouldCloseOnClickOutside={ false }
+					overlayClassName="block-editor-freeform-modal"
 				>
 					<ClassicEdit
 						id={ id }

--- a/packages/block-library/src/freeform/modal.js
+++ b/packages/block-library/src/freeform/modal.js
@@ -79,11 +79,7 @@ export default function ModalEdit( props ) {
 					shouldCloseOnClickOutside={ false }
 					overlayClassName="block-editor-freeform-modal"
 				>
-					<ClassicEdit
-						id={ id }
-						defaultValue={ content }
-						className="block-editor-freeform-modal__textarea"
-					/>
+					<ClassicEdit id={ id } defaultValue={ content } />
 					<Flex
 						className="block-editor-freeform-modal__actions"
 						justify="flex-end"

--- a/packages/block-library/src/freeform/modal.js
+++ b/packages/block-library/src/freeform/modal.js
@@ -11,7 +11,7 @@ import {
 	FlexItem,
 } from '@wordpress/components';
 import { useEffect, useState, RawHTML } from '@wordpress/element';
-import { __, _x } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
 
 function ClassicEdit( props ) {
@@ -59,7 +59,6 @@ export default function ModalEdit( props ) {
 	} = props;
 	const [ isOpen, setOpen ] = useState( false );
 	const id = `editor-${ clientId }`;
-	const label = _x( 'Classic Edit', 'Classic block' );
 
 	const onClose = () => ( content ? setOpen( false ) : onReplace( [] ) );
 
@@ -68,14 +67,14 @@ export default function ModalEdit( props ) {
 			<BlockControls>
 				<ToolbarGroup>
 					<ToolbarButton onClick={ () => setOpen( true ) }>
-						{ label }
+						{ __( 'Edit' ) }
 					</ToolbarButton>
 				</ToolbarGroup>
 			</BlockControls>
 			{ content && <RawHTML>{ content }</RawHTML> }
 			{ ( isOpen || ! content ) && (
 				<Modal
-					title={ label }
+					title={ __( 'Classic Editor' ) }
 					onRequestClose={ onClose }
 					shouldCloseOnClickOutside={ false }
 					overlayClassName="block-editor-freeform-modal"

--- a/packages/block-library/src/freeform/style.scss
+++ b/packages/block-library/src/freeform/style.scss
@@ -1,0 +1,9 @@
+// The default value of TinyMCE height is set to the height of the HTML element
+// TinyMCE replaces. For example, the pixel height of a textarea.
+.block-editor-freeform-modal__textarea {
+	height: 500px;
+}
+
+.block-editor-freeform-modal__actions {
+	margin-top: $grid-unit-30;
+}

--- a/packages/block-library/src/freeform/style.scss
+++ b/packages/block-library/src/freeform/style.scss
@@ -1,9 +1,44 @@
-// The default value of TinyMCE height is set to the height of the HTML element
-// TinyMCE replaces. For example, the pixel height of a textarea.
-.block-editor-freeform-modal__textarea {
-	height: 500px;
-}
+.block-editor-freeform-modal {
+	.components-modal__frame {
+		// On large screens, make the TinyMCE edit area grow to take all the
+		// available height so that the Cancel/Save buttons are always into the
+		// view. On smaller screens, the modal content is scrollable.
+		@include break-large() {
+			// On medium and large screens, the modal component sets a max-height.
+			// We want the modal to be as tall as possible also when the content is short.
+			height: 9999rem;
 
-.block-editor-freeform-modal__actions {
-	margin-top: $grid-unit-30;
+			.components-modal__header + div {
+				height: 100%;
+			}
+
+			.mce-tinymce {
+				height: calc(100% - #{$button-size} - #{$grid-unit-20});
+			}
+
+			.mce-container-body {
+				height: 100%;
+				display: flex;
+				flex-direction: column;
+			}
+
+			.mce-edit-area {
+				flex-grow: 1;
+				display: flex;
+				flex-direction: column;
+
+				iframe {
+					flex-grow: 1;
+					// Override the height TinyMCE sets via JavaScript so that it
+					// can shrink to a smaller height. The actual height is
+					// determined by Flexbox.
+					height: 10px !important;
+				}
+			}
+		}
+	}
+
+	&__actions {
+		margin-top: $grid-unit-20;
+	}
 }

--- a/packages/block-library/src/style.scss
+++ b/packages/block-library/src/style.scss
@@ -15,6 +15,7 @@
 @import "./details-summary/style.scss";
 @import "./embed/style.scss";
 @import "./file/style.scss";
+@import "./freeform/style.scss";
 @import "./gallery/style.scss";
 @import "./group/style.scss";
 @import "./heading/style.scss";


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Fixes https://github.com/WordPress/gutenberg/issues/50161

## What?
<!-- In a few words, what is the PR actually doing? -->
FIxes the accessibility of the Classic block modal dialog. Also improves labeling and design consistency.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The modal dialog misses some important accessibility features. Keyboard interaction is broken, labeling is incorrect, etc.
Also improves design consistency with other modal dialogs.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Makes sure the modal dialog is labeled.
- Restores the following default features of the modal dialog component as there's no reason to not use them. Also improves consistency with other dialogs.
  - The default modal dialog header.
  - The default modal dialog title so that it's now a H1. This also restores the default title font size.
  - The default X close button.
- Restores the 'close on Escape' behavior. Note: this can't work when focus is in the edit area, as that belongs to the iframe document.
- Keeps the 'close on click outside' behavior disabled, as clicking in the edit area would close the dialog. Actually, the edit area belongs to the iframe document: clicking there is equivalent to 'click outside'. This should be probably addressed separately in the `useFocusOutside` hook.
- Improves the labels:
  - The toolbar button label 'Classic Edit' didn't make much sense. It's also confusing for translators. This is the 'Classic' block, no need to further specify the 'Edit' action. The new 'Edit' label is also consistent with other toolbars used in the (Site) Editor. See screenshot.
  - The modal dialog title is now 'Classic Editor'.
- Uses Flex and FlexItem components for the Cancel/Save buttons to improve spacing and consistency.
- Changes the Cancel button to `tertiary` for consistency.
- Moves the Cancel/Save buttons at the bottom so that constrained tabbing now works as expected. This also improves consistency with other modal dialogs e.g. the Block Lock one.
- Makes sure that on large screens the Cancel/Save buttons are always into view.
- On smaller screens, the modal dialog content is scrollable so that the Cancel/Save buttons will be visible whe scrolling.


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
- Add a Classic block.
- A modal dialog opens. 
- Enter some text and save.
- Open the Chrome dev tools inspector > select the element with role=dialog > switch the inspector to the accessibility tab
- Observe the dialog Name is 'Classic Editor'. Screenshot:

<img width="1667" alt="Screenshot 2023-05-05 at 15 50 48" src="https://user-images.githubusercontent.com/1682452/236476931-30102e98-37d4-4bd3-b75e-da57fb4a8435.png">

- Observe the name is determined by the `aria-labelledby` attribute that points to the dialog heading.
- Observe the heading is now a H1.
- Use the Tab key to navigate the modal dialog.
- Observe tabbing is now constrained within the dialog.
- Test also with Shift+Tab.
- When focus is on an element within the dialog (except the TinyMCE edit area), press the Escape key and observe the dialog closes without saving.
- Reopen the dialog and click outside of it: observe the dialog stays open.
- Click the X button and observe the dialog closes without saving.
- Reopen the dialog, make some edit, and click Save. Observe the dialog closes and does save content within the block (actually, this does _not_ save the post content).
- Test with various viewport widths and heights:
  - With short and long content in the block.
  - Expanding and collapsing the TinyMCE toolbar second row (press the TinyMCE 'Toggle toolbar' button).
  - Observe the Cancel/Save buttons are always usable:
  - Either because they're into view on large screens
  - Or because it is possible to scroll the dialog content on small screens.
  - **Important**: test with different browsers.
- Close the dialog
- Select the Classic block: the block toolbar appears.
- Observe the text of the button to open the dialog is now 'Edit'. This is simpler and consistent with other toolbars e.g. some toolbars in the Site Editor. Screenshot: 

<img width="369" alt="Screenshot 2023-05-05 at 16 06 54" src="https://user-images.githubusercontent.com/1682452/236480850-e3544f23-7143-491d-849c-590d85e44a0e.png">

Screenshot of a template toolbar:

<img width="613" alt="site editor toolbar with edit button" src="https://user-images.githubusercontent.com/1682452/236480487-412d2b37-1e77-47d5-ac3a-590ab1f83085.png">

- Reopen the dialog,
- Observe the Cancel button is now a `tertiary` button, with blue text, like in other dialogs e,g, the Block Lock one.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
See above.

## Screenshots or screencast <!-- if applicable -->
