### PR TITLE
Remove `unwrap` from transforms and add `ungroup` to more blocks

### DIFF
--- a/docs/reference-guides/block-api/block-transforms.md
+++ b/docs/reference-guides/block-api/block-transforms.md
@@ -341,7 +341,7 @@ transforms: {
 
 Via the optional `transforms` key of the block configuration, blocks can use the `ungroup` subkey to define the blocks that will replace the block being processed. These new blocks will usually be a subset of the existing inner blocks, but could also include new blocks.
 
-If a block has an `ungroup` transform, it is considered ungroupable, without the requirement of being the default grouping block. The UI used to ungroup a block with this API is the same as the one used for the default grouping block. In order for the Ungroup button to be displayed, we must have a single grouping block selected, which also contains some inner blocks.
+If a block has an `ungroup` transform, it is eligible for ungrouping, without the requirement of being the default grouping block. The UI used to ungroup a block with this API is the same as the one used for the default grouping block. In order for the Ungroup button to be displayed, we must have a single grouping block selected, which also contains some inner blocks.
 
 **ungroup** is a callback function that receives the attributes and inner blocks of the block being processed. It should return an array of block objects.
 

--- a/docs/reference-guides/block-api/block-transforms.md
+++ b/docs/reference-guides/block-api/block-transforms.md
@@ -339,7 +339,7 @@ transforms: {
 
 ## `ungroup` blocks
 
-Via the optional `transforms` key of the block configuration, blocks can use the `ungroup` subkey to define which inner blocks of a grouping block can be extracted, replacing the block.
+Via the optional `transforms` key of the block configuration, blocks can use the `ungroup` subkey to define the blocks that will replace the block being processed. These new blocks will usually be a subset of the existing inner blocks, but could also include new blocks.
 
 If a block has an `ungroup` transform, it is considered ungroupable, without the requirement of being the default grouping block. The UI used to ungroup a block with this API is the same as the one used for the default grouping block. In order for the Ungroup button to be displayed, we must have a single grouping block selected, which also contains some inner blocks.
 

--- a/docs/reference-guides/block-api/block-transforms.md
+++ b/docs/reference-guides/block-api/block-transforms.md
@@ -270,7 +270,7 @@ A transformation of type `shortcode` is an object that takes the following param
 
 -   **type** _(string)_: the value `shortcode`.
 -   **tag** _(string|array)_: the shortcode tag or list of shortcode aliases this transform can work with.
--   **transform** \_(function, optional): a callback that receives the shortcode attributes as the first argument and the [WPShortcodeMatch](/packages/shortcode/README.md#next) as the second. It should return a block object or an array of block objects. When this parameter is defined, it will take precedence over the `attributes` parameter.
+-   **transform** _(function, optional)_: a callback that receives the shortcode attributes as the first argument and the [WPShortcodeMatch](/packages/shortcode/README.md#next) as the second. It should return a block object or an array of block objects. When this parameter is defined, it will take precedence over the `attributes` parameter.
 -   **attributes** _(object, optional)_: object representing where the block attributes should be sourced from, according to the attributes shape defined by the [block configuration object](./block-registration.md). If a particular attribute contains a `shortcode` key, it should be a function that receives the shortcode attributes as the first arguments and the [WPShortcodeMatch](/packages/shortcode/README.md#next) as second, and returns a value for the attribute that will be sourced in the block's comment.
 -   **isMatch** _(function, optional)_: a callback that receives the shortcode attributes per the [Shortcode API](https://codex.wordpress.org/Shortcode_API) and should return a boolean. Returning `false` from this function will prevent the shortcode to be transformed into this block.
 -   **priority** _(number, optional)_: controls the priority with which a transform is applied, where a lower value will take precedence over higher values. This behaves much like a [WordPress hook](https://codex.wordpress.org/Plugin_API#Hook_to_WordPress). Like hooks, the default priority is `10` when not otherwise set.
@@ -341,7 +341,7 @@ transforms: {
 
 Via the optional `transforms` key of the block configuration, blocks can use the `ungroup` subkey to define which inner blocks of a grouping block can be extracted, replacing the block.
 
-If a block has an `ungroup` transform, it is considered ungroupable, without the requirement of being the default grouping block. The UI used to ungroup a block with this API, is the same with the one used for the default grouping block. In order for the ugroup UI to render, we must have a single grouping block selected, which also contains some inner blocks.
+If a block has an `ungroup` transform, it is considered ungroupable, without the requirement of being the default grouping block. The UI used to ungroup a block with this API is the same as the one used for the default grouping block. In order for the Ungroup button to be displayed, we must have a single grouping block selected, which also contains some inner blocks.
 
 **ungroup** is a callback function that receives the attributes and inner blocks of the block being processed. It should return an array of block objects.
 

--- a/docs/reference-guides/block-api/block-transforms.md
+++ b/docs/reference-guides/block-api/block-transforms.md
@@ -228,7 +228,7 @@ When pasting content it's possible to define a [content model](https://html.spec
 When writing `raw` transforms you can control this by supplying a `schema` which describes allowable content and which will be applied to clean up the pasted content before attempting to match with your block. The schemas are passed into [`cleanNodeList` from `@wordpress/dom`](https://github.com/wordpress/gutenberg/blob/trunk/packages/dom/src/dom/clean-node-list.js); check there for a [complete description of the schema](https://github.com/wordpress/gutenberg/blob/trunk/packages/dom/src/phrasing-content.js).
 
 ```js
-schema = { span: { children: { '#text': {} } } }
+schema = { span: { children: { '#text': {} } } };
 ```
 
 **Example: a custom content model**
@@ -237,8 +237,8 @@ Suppose we want to match the following HTML snippet and turn it into some kind o
 
 ```html
 <div data-post-id="13">
-    <h2>The Post Title</h2>
-    <p>Some <em>great</em> content.</p>
+	<h2>The Post Title</h2>
+	<p>Some <em>great</em> content.</p>
 </div>
 ```
 
@@ -270,7 +270,7 @@ A transformation of type `shortcode` is an object that takes the following param
 
 -   **type** _(string)_: the value `shortcode`.
 -   **tag** _(string|array)_: the shortcode tag or list of shortcode aliases this transform can work with.
--   **transform** _(function, optional): a callback that receives the shortcode attributes as the first argument and the [WPShortcodeMatch](/packages/shortcode/README.md#next) as the second. It should return a block object or an array of block objects. When this parameter is defined, it will take precedence over the `attributes` parameter.
+-   **transform** \_(function, optional): a callback that receives the shortcode attributes as the first argument and the [WPShortcodeMatch](/packages/shortcode/README.md#next) as the second. It should return a block object or an array of block objects. When this parameter is defined, it will take precedence over the `attributes` parameter.
 -   **attributes** _(object, optional)_: object representing where the block attributes should be sourced from, according to the attributes shape defined by the [block configuration object](./block-registration.md). If a particular attribute contains a `shortcode` key, it should be a function that receives the shortcode attributes as the first arguments and the [WPShortcodeMatch](/packages/shortcode/README.md#next) as second, and returns a value for the attribute that will be sourced in the block's comment.
 -   **isMatch** _(function, optional)_: a callback that receives the shortcode attributes per the [Shortcode API](https://codex.wordpress.org/Shortcode_API) and should return a boolean. Returning `false` from this function will prevent the shortcode to be transformed into this block.
 -   **priority** _(number, optional)_: controls the priority with which a transform is applied, where a lower value will take precedence over higher values. This behaves much like a [WordPress hook](https://codex.wordpress.org/Plugin_API#Hook_to_WordPress). Like hooks, the default priority is `10` when not otherwise set.
@@ -335,4 +335,26 @@ transforms: {
         },
     ]
 },
+```
+
+## `ungroup` blocks
+
+Via the optional `transforms` key of the block configuration, blocks can use the `ungroup` subkey to define which inner blocks of a grouping block can be extracted, replacing the block.
+
+If a block has an `ungroup` transform, it is considered ungroupable, without the requirement of being the default grouping block. The UI used to ungroup a block with this API, is the same with the one used for the default grouping block. In order for the ugroup UI to render, we must have a single grouping block selected, which also contains some inner blocks.
+
+**ungroup** is a callback function that receives the attributes and inner blocks of the block being processed. It should return an array of block objects.
+
+Example:
+
+```js
+export const settings = {
+	title: 'My grouping Block Title',
+	description: 'My grouping block description',
+	/* ... */
+	transforms: {
+		ungroup: ( attributes, innerBlocks ) =>
+			innerBlocks.flatMap( ( innerBlock ) => innerBlock.innerBlocks ),
+	},
+};
 ```

--- a/packages/block-editor/src/components/block-mobile-toolbar/block-actions-menu.native.js
+++ b/packages/block-editor/src/components/block-mobile-toolbar/block-actions-menu.native.js
@@ -39,6 +39,10 @@ import { store as coreStore } from '@wordpress/core-data';
 import { getMoversSetup } from '../block-mover/mover-description';
 import { store as blockEditorStore } from '../../store';
 import BlockTransformationsMenu from '../block-switcher/block-transformations-menu';
+import {
+	useConvertToGroupButtons,
+	useConvertToGroupButtonProps,
+} from '../convert-to-group-buttons';
 
 const BlockActionsMenu = ( {
 	// Select.
@@ -55,6 +59,7 @@ const BlockActionsMenu = ( {
 	rootClientId,
 	selectedBlockClientId,
 	selectedBlockPossibleTransformations,
+	canRemove,
 	// Dispatch.
 	createSuccessNotice,
 	convertToRegularBlocks,
@@ -92,6 +97,17 @@ const BlockActionsMenu = ( {
 			forward: forwardButtonTitle,
 		},
 	} = getMoversSetup( isStackedHorizontally, moversOptions );
+
+	// Check if selected block is Groupable and/or Ungroupable.
+	const convertToGroupButtonProps = useConvertToGroupButtonProps( [
+		selectedBlockClientId,
+	] );
+	const { isGroupable, isUngroupable } = convertToGroupButtonProps;
+	const showConvertToGroupButton =
+		( isGroupable || isUngroupable ) && canRemove;
+	const convertToGroupButtons = useConvertToGroupButtons( {
+		...convertToGroupButtonProps,
+	} );
 
 	const allOptions = {
 		settings: {
@@ -229,6 +245,10 @@ const BlockActionsMenu = ( {
 		canDuplicate && allOptions.cutButton,
 		canDuplicate && isPasteEnabled && allOptions.pasteButton,
 		canDuplicate && allOptions.duplicateButton,
+		showConvertToGroupButton && isGroupable && convertToGroupButtons.group,
+		showConvertToGroupButton &&
+			isUngroupable &&
+			convertToGroupButtons.ungroup,
 		isReusableBlockType &&
 			innerBlockCount > 0 &&
 			allOptions.convertToRegularBlocks,
@@ -327,6 +347,7 @@ export default compose(
 			getSelectedBlockClientIds,
 			canInsertBlockType,
 			getTemplateLock,
+			canRemoveBlock,
 		} = select( blockEditorStore );
 		const block = getBlock( clientId );
 		const blockName = getBlockName( clientId );
@@ -363,6 +384,7 @@ export default compose(
 		const selectedBlockPossibleTransformations = selectedBlock
 			? getBlockTransformItems( selectedBlock, rootClientId )
 			: EMPTY_BLOCK_LIST;
+		const canRemove = canRemoveBlock( selectedBlockClientId );
 
 		const isReusableBlockType = block ? isReusableBlock( block ) : false;
 		const reusableBlock = isReusableBlockType
@@ -388,6 +410,7 @@ export default compose(
 			rootClientId,
 			selectedBlockClientId,
 			selectedBlockPossibleTransformations,
+			canRemove,
 		};
 	} ),
 	withDispatch(

--- a/packages/block-editor/src/components/convert-to-group-buttons/index.js
+++ b/packages/block-editor/src/components/convert-to-group-buttons/index.js
@@ -17,6 +17,7 @@ function ConvertToGroupButton( {
 	clientIds,
 	isGroupable,
 	isUngroupable,
+	onUngroup,
 	blocksSelection,
 	groupingBlockName,
 	onClose = () => {},
@@ -34,9 +35,15 @@ function ConvertToGroupButton( {
 	};
 
 	const onConvertFromGroup = () => {
-		const innerBlocks = blocksSelection[ 0 ].innerBlocks;
+		let innerBlocks = blocksSelection[ 0 ].innerBlocks;
 		if ( ! innerBlocks.length ) {
 			return;
+		}
+		if ( onUngroup ) {
+			innerBlocks = onUngroup(
+				blocksSelection[ 0 ].attributes,
+				blocksSelection[ 0 ].innerBlocks
+			);
 		}
 		replaceBlocks( clientIds, innerBlocks );
 	};
@@ -66,7 +73,7 @@ function ConvertToGroupButton( {
 				>
 					{ _x(
 						'Ungroup',
-						'Ungrouping blocks from within a Group block back into individual blocks within the Editor '
+						'Ungrouping blocks from within a grouping block back into individual blocks within the Editor '
 					) }
 				</MenuItem>
 			) }

--- a/packages/block-editor/src/components/convert-to-group-buttons/index.native.js
+++ b/packages/block-editor/src/components/convert-to-group-buttons/index.native.js
@@ -1,1 +1,79 @@
-export default () => null;
+/**
+ * WordPress dependencies
+ */
+import { __, _x } from '@wordpress/i18n';
+import { switchToBlockType } from '@wordpress/blocks';
+import { useDispatch } from '@wordpress/data';
+import { store as noticesStore } from '@wordpress/notices';
+
+/**
+ * Internal dependencies
+ */
+import { store as blockEditorStore } from '../../store';
+import useConvertToGroupButtonProps from './use-convert-to-group-button-props';
+
+function useConvertToGroupButtons( {
+	clientIds,
+	onUngroup,
+	blocksSelection,
+	groupingBlockName,
+} ) {
+	const { replaceBlocks } = useDispatch( blockEditorStore );
+	const { createSuccessNotice } = useDispatch( noticesStore );
+	const onConvertToGroup = () => {
+		// Activate the `transform` on the Grouping Block which does the conversion.
+		const newBlocks = switchToBlockType(
+			blocksSelection,
+			groupingBlockName
+		);
+		if ( newBlocks ) {
+			replaceBlocks( clientIds, newBlocks );
+		}
+	};
+
+	const onConvertFromGroup = () => {
+		let innerBlocks = blocksSelection[ 0 ].innerBlocks;
+		if ( ! innerBlocks.length ) {
+			return;
+		}
+		if ( onUngroup ) {
+			innerBlocks = onUngroup(
+				blocksSelection[ 0 ].attributes,
+				blocksSelection[ 0 ].innerBlocks
+			);
+		}
+		replaceBlocks( clientIds, innerBlocks );
+	};
+
+	return {
+		group: {
+			id: 'groupButtonOption',
+			label: _x( 'Group', 'verb' ),
+			value: 'groupButtonOption',
+			onSelect: () => {
+				onConvertToGroup();
+				createSuccessNotice(
+					// translators: displayed right after the block is grouped
+					__( 'Block grouped' )
+				);
+			},
+		},
+		ungroup: {
+			id: 'ungroupButtonOption',
+			label: _x(
+				'Ungroup',
+				'Ungrouping blocks from within a grouping block back into individual blocks within the Editor'
+			),
+			value: 'ungroupButtonOption',
+			onSelect: () => {
+				onConvertFromGroup();
+				createSuccessNotice(
+					// translators: displayed right after the block is ungrouped.
+					__( 'Block ungrouped' )
+				);
+			},
+		},
+	};
+}
+
+export { useConvertToGroupButtons, useConvertToGroupButtonProps };

--- a/packages/block-editor/src/components/convert-to-group-buttons/use-convert-to-group-button-props.js
+++ b/packages/block-editor/src/components/convert-to-group-buttons/use-convert-to-group-button-props.js
@@ -31,14 +31,7 @@ import { store as blockEditorStore } from '../../store';
  * @return {ConvertToGroupButtonProps} Returns the properties needed by `ConvertToGroupButton`.
  */
 export default function useConvertToGroupButtonProps( selectedClientIds ) {
-	const {
-		clientIds,
-		isGroupable,
-		isUngroupable,
-		blocksSelection,
-		groupingBlockName,
-		onUngroup,
-	} = useSelect(
+	return useSelect(
 		( select ) => {
 			const {
 				getBlockRootClientId,
@@ -48,30 +41,30 @@ export default function useConvertToGroupButtonProps( selectedClientIds ) {
 			} = select( blockEditorStore );
 			const { getGroupingBlockName, getBlockType } =
 				select( blocksStore );
-			const _clientIds = selectedClientIds?.length
+			const clientIds = selectedClientIds?.length
 				? selectedClientIds
 				: getSelectedBlockClientIds();
-			const _groupingBlockName = getGroupingBlockName();
+			const groupingBlockName = getGroupingBlockName();
 
-			const rootClientId = !! _clientIds?.length
-				? getBlockRootClientId( _clientIds[ 0 ] )
+			const rootClientId = clientIds?.length
+				? getBlockRootClientId( clientIds[ 0 ] )
 				: undefined;
 
 			const groupingBlockAvailable = canInsertBlockType(
-				_groupingBlockName,
+				groupingBlockName,
 				rootClientId
 			);
 
-			const _blocksSelection = getBlocksByClientId( _clientIds );
-			const _isSingleBlockSelected = _blocksSelection.length === 1;
-			const [ firstSelectedBlock ] = _blocksSelection;
+			const blocksSelection = getBlocksByClientId( clientIds );
+			const isSingleBlockSelected = blocksSelection.length === 1;
+			const [ firstSelectedBlock ] = blocksSelection;
 			// A block is ungroupable if it is a single grouping block with inner blocks.
 			// If a block has an `ungroup` transform, it is also ungroupable, without the
 			// requirement of being the default grouping block.
 			// Do we have a single grouping Block selected and does that group have inner blocks?
-			const _isUngroupable =
-				_isSingleBlockSelected &&
-				( firstSelectedBlock.name === _groupingBlockName ||
+			const isUngroupable =
+				isSingleBlockSelected &&
+				( firstSelectedBlock.name === groupingBlockName ||
 					getBlockType( firstSelectedBlock.name )?.transforms
 						?.ungroup ) &&
 				!! firstSelectedBlock.innerBlocks.length;
@@ -79,30 +72,21 @@ export default function useConvertToGroupButtonProps( selectedClientIds ) {
 			// Do we have
 			// 1. Grouping block available to be inserted?
 			// 2. One or more blocks selected
-			const _isGroupable =
-				groupingBlockAvailable && _blocksSelection.length;
+			const isGroupable =
+				groupingBlockAvailable && blocksSelection.length;
 
 			return {
-				clientIds: _clientIds,
-				isGroupable: _isGroupable,
-				isUngroupable: _isUngroupable,
-				blocksSelection: _blocksSelection,
-				groupingBlockName: _groupingBlockName,
+				clientIds,
+				isGroupable,
+				isUngroupable,
+				blocksSelection,
+				groupingBlockName,
 				onUngroup:
-					_isUngroupable &&
+					isUngroupable &&
 					getBlockType( firstSelectedBlock.name )?.transforms
 						?.ungroup,
 			};
 		},
 		[ selectedClientIds ]
 	);
-
-	return {
-		clientIds,
-		isGroupable,
-		isUngroupable,
-		onUngroup,
-		blocksSelection,
-		groupingBlockName,
-	};
 }

--- a/packages/block-editor/src/components/convert-to-group-buttons/use-convert-to-group-button-props.js
+++ b/packages/block-editor/src/components/convert-to-group-buttons/use-convert-to-group-button-props.js
@@ -37,6 +37,7 @@ export default function useConvertToGroupButtonProps( selectedClientIds ) {
 		isUngroupable,
 		blocksSelection,
 		groupingBlockName,
+		onUngroup,
 	} = useSelect(
 		( select ) => {
 			const {
@@ -45,8 +46,8 @@ export default function useConvertToGroupButtonProps( selectedClientIds ) {
 				canInsertBlockType,
 				getSelectedBlockClientIds,
 			} = select( blockEditorStore );
-			const { getGroupingBlockName } = select( blocksStore );
-
+			const { getGroupingBlockName, getBlockType } =
+				select( blocksStore );
 			const _clientIds = selectedClientIds?.length
 				? selectedClientIds
 				: getSelectedBlockClientIds();
@@ -62,10 +63,18 @@ export default function useConvertToGroupButtonProps( selectedClientIds ) {
 			);
 
 			const _blocksSelection = getBlocksByClientId( _clientIds );
-
-			const isSingleGroupingBlock =
-				_blocksSelection.length === 1 &&
-				_blocksSelection[ 0 ]?.name === _groupingBlockName;
+			const _isSingleBlockSelected = _blocksSelection.length === 1;
+			const [ firstSelectedBlock ] = _blocksSelection;
+			// A block is ungroupable if it is a single grouping block with inner blocks.
+			// If a block has an `ungroup` transform, it is also ungroupable, without the
+			// requirement of being the default grouping block.
+			// Do we have a single grouping Block selected and does that group have inner blocks?
+			const _isUngroupable =
+				_isSingleBlockSelected &&
+				( firstSelectedBlock.name === _groupingBlockName ||
+					getBlockType( firstSelectedBlock.name )?.transforms
+						?.ungroup ) &&
+				!! firstSelectedBlock.innerBlocks.length;
 
 			// Do we have
 			// 1. Grouping block available to be inserted?
@@ -73,16 +82,16 @@ export default function useConvertToGroupButtonProps( selectedClientIds ) {
 			const _isGroupable =
 				groupingBlockAvailable && _blocksSelection.length;
 
-			// Do we have a single Group Block selected and does that group have inner blocks?
-			const _isUngroupable =
-				isSingleGroupingBlock &&
-				!! _blocksSelection[ 0 ].innerBlocks.length;
 			return {
 				clientIds: _clientIds,
 				isGroupable: _isGroupable,
 				isUngroupable: _isUngroupable,
 				blocksSelection: _blocksSelection,
 				groupingBlockName: _groupingBlockName,
+				onUngroup:
+					_isUngroupable &&
+					getBlockType( firstSelectedBlock.name )?.transforms
+						?.ungroup,
 			};
 		},
 		[ selectedClientIds ]
@@ -92,6 +101,7 @@ export default function useConvertToGroupButtonProps( selectedClientIds ) {
 		clientIds,
 		isGroupable,
 		isUngroupable,
+		onUngroup,
 		blocksSelection,
 		groupingBlockName,
 	};

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -18,7 +18,6 @@ import {
 import { Platform } from '@wordpress/element';
 import { applyFilters } from '@wordpress/hooks';
 import { symbol } from '@wordpress/icons';
-import { __ } from '@wordpress/i18n';
 import { create, remove, toHTMLString } from '@wordpress/rich-text';
 import deprecated from '@wordpress/deprecated';
 
@@ -2101,7 +2100,6 @@ export const getInserterItems = createSelector(
 export const getBlockTransformItems = createSelector(
 	( state, blocks, rootClientId = null ) => {
 		const normalizedBlocks = Array.isArray( blocks ) ? blocks : [ blocks ];
-		const [ sourceBlock ] = normalizedBlocks;
 		const buildBlockTypeTransformItem = buildBlockTypeItem( state, {
 			buildScope: 'transform',
 		} );
@@ -2118,22 +2116,10 @@ export const getBlockTransformItems = createSelector(
 			] )
 		);
 
-		// Consider unwraping the highest priority.
-		itemsByName[ '*' ] = {
-			frecency: +Infinity,
-			id: '*',
-			isDisabled: false,
-			name: '*',
-			title: __( 'Unwrap' ),
-			icon: itemsByName[ sourceBlock?.name ]?.icon,
-		};
-
 		const possibleTransforms = getPossibleBlockTransformations(
 			normalizedBlocks
 		).reduce( ( accumulator, block ) => {
-			if ( block === '*' ) {
-				accumulator.push( itemsByName[ '*' ] );
-			} else if ( itemsByName[ block?.name ] ) {
+			if ( itemsByName[ block?.name ] ) {
 				accumulator.push( itemsByName[ block.name ] );
 			}
 			return accumulator;

--- a/packages/block-library/src/columns/test/__snapshots__/transforms.native.js.snap
+++ b/packages/block-library/src/columns/test/__snapshots__/transforms.native.js.snap
@@ -34,7 +34,7 @@ exports[`Columns block transforms to Group block 1`] = `
 <!-- /wp:group -->"
 `;
 
-exports[`Columns block transforms unwraps content 1`] = `
+exports[`Columns block transforms ungroups block 1`] = `
 "<!-- wp:paragraph {"align":"left"} -->
 <p class="has-text-align-left"><strong>Built with modern technology.</strong></p>
 <!-- /wp:paragraph -->

--- a/packages/block-library/src/columns/test/transforms.native.js
+++ b/packages/block-library/src/columns/test/transforms.native.js
@@ -60,14 +60,13 @@ describe( `${ block } block transforms`, () => {
 		expect( getEditorHtml() ).toMatchSnapshot();
 	} );
 
-	it( 'unwraps content', async () => {
+	it( 'ungroups block', async () => {
 		const screen = await initializeEditor( { initialHtml } );
 		const { getByText } = screen;
 		fireEvent.press( getBlock( screen, block ) );
 
 		await openBlockActionsMenu( screen );
-		fireEvent.press( getByText( 'Transform block…' ) );
-		fireEvent.press( getByText( 'Unwrap' ) );
+		fireEvent.press( getByText( 'Ungroup' ) );
 
 		// The first block created is the content of the Paragraph block.
 		const paragraph = getBlock( screen, 'Paragraph', 0 );
@@ -83,8 +82,7 @@ describe( `${ block } block transforms`, () => {
 		const screen = await initializeEditor( { initialHtml } );
 		const transformOptions = await getBlockTransformOptions(
 			screen,
-			block,
-			{ canUnwrap: true }
+			block
 		);
 		expect( transformOptions ).toHaveLength( blockTransforms.length );
 	} );

--- a/packages/block-library/src/columns/transforms.js
+++ b/packages/block-library/src/columns/transforms.js
@@ -105,14 +105,8 @@ const transforms = {
 			},
 		},
 	],
-	to: [
-		{
-			type: 'block',
-			blocks: [ '*' ],
-			transform: ( attributes, innerBlocks ) =>
-				innerBlocks.flatMap( ( innerBlock ) => innerBlock.innerBlocks ),
-		},
-	],
+	ungroup: ( attributes, innerBlocks ) =>
+		innerBlocks.flatMap( ( innerBlock ) => innerBlock.innerBlocks ),
 };
 
 export default transforms;

--- a/packages/block-library/src/group/test/__snapshots__/transforms.native.js.snap
+++ b/packages/block-library/src/group/test/__snapshots__/transforms.native.js.snap
@@ -20,7 +20,7 @@ exports[`Group block transforms to Columns block 1`] = `
 <!-- /wp:columns -->"
 `;
 
-exports[`Group block transforms unwraps content 1`] = `
+exports[`Group block transforms ungroups block 1`] = `
 "<!-- wp:paragraph -->
 <p>One.</p>
 <!-- /wp:paragraph -->

--- a/packages/block-library/src/group/test/transforms.native.js
+++ b/packages/block-library/src/group/test/transforms.native.js
@@ -44,14 +44,13 @@ describe( `${ block } block transforms`, () => {
 		expect( getEditorHtml() ).toMatchSnapshot();
 	} );
 
-	it( 'unwraps content', async () => {
+	it( 'ungroups block', async () => {
 		const screen = await initializeEditor( { initialHtml } );
 		const { getByText } = screen;
 		fireEvent.press( getBlock( screen, block ) );
 
 		await openBlockActionsMenu( screen );
-		fireEvent.press( getByText( 'Transform block…' ) );
-		fireEvent.press( getByText( 'Unwrap' ) );
+		fireEvent.press( getByText( 'Ungroup' ) );
 
 		// The first block created is the content of the Paragraph block.
 		const paragraph = getBlock( screen, 'Paragraph', 0 );
@@ -67,8 +66,7 @@ describe( `${ block } block transforms`, () => {
 		const screen = await initializeEditor( { initialHtml } );
 		const transformOptions = await getBlockTransformOptions(
 			screen,
-			block,
-			{ canUnwrap: true }
+			block
 		);
 		expect( transformOptions ).toHaveLength( blockTransforms.length );
 	} );

--- a/packages/block-library/src/group/transforms.js
+++ b/packages/block-library/src/group/transforms.js
@@ -48,13 +48,6 @@ const transforms = {
 			},
 		},
 	],
-	to: [
-		{
-			type: 'block',
-			blocks: [ '*' ],
-			transform: ( attributes, innerBlocks ) => innerBlocks,
-		},
-	],
 };
 
 export default transforms;

--- a/packages/block-library/src/quote/test/__snapshots__/transforms.native.js.snap
+++ b/packages/block-library/src/quote/test/__snapshots__/transforms.native.js.snap
@@ -28,7 +28,7 @@ exports[`Quote block transforms to Pullquote block 1`] = `
 <!-- /wp:pullquote -->"
 `;
 
-exports[`Quote block transforms unwraps content 1`] = `
+exports[`Quote block transforms ungroups block 1`] = `
 "<!-- wp:paragraph -->
 <p>"This will make running your own blog a viable alternative again."</p>
 <!-- /wp:paragraph -->

--- a/packages/block-library/src/quote/test/transforms.native.js
+++ b/packages/block-library/src/quote/test/transforms.native.js
@@ -36,14 +36,13 @@ describe( `${ block } block transforms`, () => {
 		expect( getEditorHtml() ).toMatchSnapshot();
 	} );
 
-	it( 'unwraps content', async () => {
+	it( 'ungroups block', async () => {
 		const screen = await initializeEditor( { initialHtml } );
 		const { getByText } = screen;
 		fireEvent.press( getBlock( screen, block ) );
 
 		await openBlockActionsMenu( screen );
-		fireEvent.press( getByText( 'Transform block…' ) );
-		fireEvent.press( getByText( 'Unwrap' ) );
+		fireEvent.press( getByText( 'Ungroup' ) );
 
 		// The first block created is the content of the Paragraph block.
 		const paragraph = getBlock( screen, 'Paragraph', 0 );
@@ -59,8 +58,7 @@ describe( `${ block } block transforms`, () => {
 		const screen = await initializeEditor( { initialHtml } );
 		const transformOptions = await getBlockTransformOptions(
 			screen,
-			block,
-			{ canUnwrap: true }
+			block
 		);
 		expect( transformOptions ).toHaveLength( blockTransforms.length );
 	} );

--- a/packages/block-library/src/quote/transforms.js
+++ b/packages/block-library/src/quote/transforms.js
@@ -126,20 +126,16 @@ const transforms = {
 						: innerBlocks
 				),
 		},
-		{
-			type: 'block',
-			blocks: [ '*' ],
-			transform: ( { citation }, innerBlocks ) =>
-				citation
-					? [
-							...innerBlocks,
-							createBlock( 'core/paragraph', {
-								content: citation,
-							} ),
-					  ]
-					: innerBlocks,
-		},
 	],
+	ungroup: ( { citation }, innerBlocks ) =>
+		citation
+			? [
+					...innerBlocks,
+					createBlock( 'core/paragraph', {
+						content: citation,
+					} ),
+			  ]
+			: innerBlocks,
 };
 
 export default transforms;

--- a/packages/blocks/src/api/factory.js
+++ b/packages/blocks/src/api/factory.js
@@ -278,9 +278,7 @@ const getBlockTypesForPossibleToTransforms = ( blocks ) => {
 		.flat();
 
 	// Map block names to block types.
-	return blockNames.map( ( name ) =>
-		name === '*' ? name : getBlockType( name )
-	);
+	return blockNames.map( getBlockType );
 };
 
 /**
@@ -473,7 +471,8 @@ export function switchToBlockType( blocks, name ) {
 			transformationsTo,
 			( t ) =>
 				t.type === 'block' &&
-				t.blocks.indexOf( name ) !== -1 &&
+				( isWildcardBlockTransform( t ) ||
+					t.blocks.indexOf( name ) !== -1 ) &&
 				( ! isMultiBlock || t.isMultiBlock ) &&
 				maybeCheckTransformIsMatch( t, blocksArray )
 		) ||
@@ -537,12 +536,6 @@ export function switchToBlockType( blocks, name ) {
 		)
 	) {
 		return null;
-	}
-
-	// When unwrapping blocks (`switchToBlockType( wrapperblocks, '*' )`), do
-	// not run filters on the unwrapped blocks. They shoud remain as they are.
-	if ( name === '*' ) {
-		return transformationResults;
 	}
 
 	const hasSwitchedBlock = transformationResults.some(

--- a/test/e2e/specs/editor/blocks/columns.spec.js
+++ b/test/e2e/specs/editor/blocks/columns.spec.js
@@ -82,4 +82,54 @@ test.describe( 'Columns', () => {
 		await pageUtils.pressKeys( 'Tab' );
 		await expect( columnsChangeInput ).toHaveValue( '3' );
 	} );
+	test( 'Ungroup properly', async ( { editor } ) => {
+		await editor.insertBlock( {
+			name: 'core/columns',
+			innerBlocks: [
+				{
+					name: 'core/column',
+					innerBlocks: [
+						{
+							name: 'core/paragraph',
+							attributes: { content: '1' },
+						},
+					],
+				},
+				{
+					name: 'core/column',
+					innerBlocks: [
+						{
+							name: 'core/paragraph',
+							attributes: { content: '2' },
+						},
+					],
+				},
+			],
+		} );
+		expect( await editor.getEditedPostContent() ).toBe(
+			`<!-- wp:columns -->
+<div class="wp-block-columns"><!-- wp:column -->
+<div class="wp-block-column"><!-- wp:paragraph -->
+<p>1</p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:column -->
+
+<!-- wp:column -->
+<div class="wp-block-column"><!-- wp:paragraph -->
+<p>2</p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns -->`
+		);
+		await editor.clickBlockOptionsMenuItem( 'Ungroup' );
+		expect( await editor.getEditedPostContent() ).toBe(
+			`<!-- wp:paragraph -->
+<p>1</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>2</p>
+<!-- /wp:paragraph -->`
+		);
+	} );
 } );

--- a/test/e2e/specs/editor/blocks/columns.spec.js
+++ b/test/e2e/specs/editor/blocks/columns.spec.js
@@ -106,30 +106,16 @@ test.describe( 'Columns', () => {
 				},
 			],
 		} );
-		expect( await editor.getEditedPostContent() ).toBe(
-			`<!-- wp:columns -->
-<div class="wp-block-columns"><!-- wp:column -->
-<div class="wp-block-column"><!-- wp:paragraph -->
-<p>1</p>
-<!-- /wp:paragraph --></div>
-<!-- /wp:column -->
-
-<!-- wp:column -->
-<div class="wp-block-column"><!-- wp:paragraph -->
-<p>2</p>
-<!-- /wp:paragraph --></div>
-<!-- /wp:column --></div>
-<!-- /wp:columns -->`
-		);
 		await editor.clickBlockOptionsMenuItem( 'Ungroup' );
-		expect( await editor.getEditedPostContent() ).toBe(
-			`<!-- wp:paragraph -->
-<p>1</p>
-<!-- /wp:paragraph -->
-
-<!-- wp:paragraph -->
-<p>2</p>
-<!-- /wp:paragraph -->`
-		);
+		await expect.poll( editor.getBlocks ).toMatchObject( [
+			{
+				name: 'core/paragraph',
+				attributes: { content: '1' },
+			},
+			{
+				name: 'core/paragraph',
+				attributes: { content: '2' },
+			},
+		] );
 	} );
 } );

--- a/test/e2e/specs/editor/blocks/quote.spec.js
+++ b/test/e2e/specs/editor/blocks/quote.spec.js
@@ -138,8 +138,7 @@ test.describe( 'Quote', () => {
 			await page.keyboard.type( 'two' );
 			// Navigate to the citation to select the block.
 			await page.keyboard.press( 'ArrowRight' );
-			// Unwrap the block.
-			await editor.transformBlockTo( '*' );
+			await editor.clickBlockOptionsMenuItem( 'Ungroup' );
 			expect( await editor.getEditedPostContent() ).toBe(
 				`<!-- wp:paragraph -->
 <p>one</p>
@@ -161,8 +160,7 @@ test.describe( 'Quote', () => {
 			await page.keyboard.type( 'two' );
 			await page.keyboard.press( 'ArrowRight' );
 			await page.keyboard.type( 'cite' );
-			// Unwrap the block.
-			await editor.transformBlockTo( '*' );
+			await editor.clickBlockOptionsMenuItem( 'Ungroup' );
 			expect( await editor.getEditedPostContent() ).toBe(
 				`<!-- wp:paragraph -->
 <p>one</p>
@@ -185,8 +183,7 @@ test.describe( 'Quote', () => {
 			await editor.insertBlock( { name: 'core/quote' } );
 			await page.keyboard.press( 'ArrowRight' );
 			await page.keyboard.type( 'cite' );
-			// Unwrap the block.
-			await editor.transformBlockTo( '*' );
+			await editor.clickBlockOptionsMenuItem( 'Ungroup' );
 			expect( await editor.getEditedPostContent() ).toBe(
 				`<!-- wp:paragraph -->
 <p></p>
@@ -205,8 +202,7 @@ test.describe( 'Quote', () => {
 			await editor.insertBlock( { name: 'core/quote' } );
 			// Select the quote
 			await page.keyboard.press( 'ArrowRight' );
-			// Unwrap the block.
-			await editor.transformBlockTo( '*' );
+			await editor.clickBlockOptionsMenuItem( 'Ungroup' );
 			expect( await editor.getEditedPostContent() ).toBe( '' );
 		} );
 	} );

--- a/test/native/integration-test-helpers/get-block-transform-options.js
+++ b/test/native/integration-test-helpers/get-block-transform-options.js
@@ -12,36 +12,18 @@ import { openBlockActionsMenu } from './open-block-actions-menu';
 /**
  * Transforms the selected block to a specified block.
  *
- * @param {import('@testing-library/react-native').RenderAPI} screen              A Testing Library screen.
- * @param {string}                                            blockName           Name of the block.
- * @param {Object}                                            [options]           Configuration options.
- * @param {number}                                            [options.canUnwrap] True if the block can be unwrapped.
+ * @param {import('@testing-library/react-native').RenderAPI} screen    A Testing Library screen.
+ * @param {string}                                            blockName Name of the block.
  * @return {[import('react-test-renderer').ReactTestInstance]} Block transform options.
  */
-export const getBlockTransformOptions = async (
-	screen,
-	blockName,
-	{ canUnwrap = false } = {}
-) => {
+export const getBlockTransformOptions = async ( screen, blockName ) => {
 	const { getByTestId, getByText } = screen;
 
 	fireEvent.press( getBlock( screen, blockName ) );
 	await openBlockActionsMenu( screen );
 	fireEvent.press( getByText( 'Transform block…' ) );
 
-	let blockTransformButtons = within(
-		getByTestId( 'block-transformations-menu' )
-	).getAllByRole( 'button' );
-
-	// Remove Unwrap option as it's not a direct block transformation.
-	if ( canUnwrap ) {
-		const unwrapButton = within(
-			getByTestId( 'block-transformations-menu' )
-		).getByLabelText( 'Unwrap' );
-		blockTransformButtons = blockTransformButtons.filter(
-			( button ) => button !== unwrapButton
-		);
-	}
-
-	return blockTransformButtons;
+	return within( getByTestId( 'block-transformations-menu' ) ).getAllByRole(
+		'button'
+	);
 };


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Part of: https://github.com/WordPress/gutenberg/issues/45841

Regarding the above issue, this PR will not add any shortcuts to reduce its scope. Additionally this PR could (and maybe will) be split in two separate ones. This is because it does two things:
1. Remove the `unwrap` from the block switcher for `Group, Columns, Quote` blocks and essentially partially or fully reverting [1](https://github.com/WordPress/gutenberg/pull/45666/), [2](https://github.com/WordPress/gutenberg/pull/42685), [3](https://github.com/WordPress/gutenberg/pull/39718). 
2. Adds a new API for blocks to be able to `ungroup`


## How and Why?
This PR suggests a new `transforms` API for the `ungroup` functionality in block settings menu controls(ellipsis menu in block toolbar). If a block, besides the set grouping block(see [here](https://github.com/WordPress/gutenberg/blob/trunk/packages/blocks/README.md#setgroupingblockname)), want to render the `Ungroup` button, should add an `ungroup` function in their `transforms` of the block type.

This new function accepts the block's attributes and innerBlocks(although we might consider passing the whole block) and is responsible for returning the new blocks to replace the selected block. This is because blocks can have a different unwrapping handling - ex. Columns need to also remove the `core/column` blocks etc..

**Why in `transforms` API?**
No strong opinions here, but I felt it's less impactful than adding a new `Block` API and it can make sense semantically. We could do it there too though.

**Why we even need a new API?**
My first try was just adding the `Ungroup` button inside the blocks' edit function with `BlockSettingsMenuControls`. That would be the best option, if we could handle the wanted position of the menu item. Right now the `fills` are rendered above the `Group` menu item and creates a disconnect with the rest of the menu items. 

## Testing Instructions
1. Insert `Group, Quote, Columns` blocks
2. Observe the `unwrap` option in block switcher is gone
3. Observe that the `Ungroup` menu item in the ellipsis menu in block toolbar works as the `unwrap` button was working. I'm saying this because there is already a flow there in the logic about when to show this button. Checking innerBlocks existence is not enough because for example in an seemingly empty Columns block we have empty `core/column` blocks.
4. Observe that transform options in block switcher are not affected besides the removal of `unwrap` option.

### Tasks
- [x] Agreement on API/approach
- [x] Add docs
- [x] Add/update tests
- [x] Check with mobile as I saw some tests with `unwrap` 

