### PR TITLE
Block Theme Switching

### DIFF
--- a/docs/reference-guides/data/data-core.md
+++ b/docs/reference-guides/data/data-core.md
@@ -44,6 +44,18 @@ _Returns_
 
 -   `boolean | undefined`: Whether or not the user can edit, or `undefined` if the OPTIONS request is still being made.
 
+### getAllThemes
+
+Return all themes.
+
+_Parameters_
+
+-   _state_ `State`: Data state.
+
+_Returns_
+
+-   `any`: All themes.
+
 ### getAuthors
 
 > **Deprecated** since 11.3. Callers should use `select( 'core' ).getUsers({ who: 'authors' })` instead.

--- a/lib/compat/wordpress-6.3/theme-previews.php
+++ b/lib/compat/wordpress-6.3/theme-previews.php
@@ -112,6 +112,11 @@ function block_theme_activate_nonce() {
 	<?php
 }
 
+function gutenberg_theme_preview_add_block_theme_flag( $response, $theme, $request ) {
+	$response->data['block_theme'] = $theme->is_block_theme();
+	return $response;
+}
+
 // Hide this feature behind an experiment.
 $gutenberg_experiments = get_option( 'gutenberg-experiments' );
 if ( $gutenberg_experiments && array_key_exists( 'gutenberg-theme-previews', $gutenberg_experiments ) ) {
@@ -126,4 +131,5 @@ if ( $gutenberg_experiments && array_key_exists( 'gutenberg-theme-previews', $gu
 
 	add_action( 'admin_head', 'block_theme_activate_nonce' );
 	add_action( 'admin_print_footer_scripts', 'add_live_preview_button', 11 );
+	add_filter( 'rest_prepare_theme', 'gutenberg_theme_preview_add_block_theme_flag', 10, 3 );
 }

--- a/packages/core-data/README.md
+++ b/packages/core-data/README.md
@@ -221,6 +221,18 @@ _Returns_
 
 -   `boolean | undefined`: Whether or not the user can edit, or `undefined` if the OPTIONS request is still being made.
 
+### getAllThemes
+
+Return all themes.
+
+_Parameters_
+
+-   _state_ `State`: Data state.
+
+_Returns_
+
+-   `any`: All themes.
+
 ### getAuthors
 
 > **Deprecated** since 11.3. Callers should use `select( 'core' ).getUsers({ who: 'authors' })` instead.

--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -131,6 +131,23 @@ export function receiveCurrentTheme( currentTheme ) {
 }
 
 /**
+ * Returns an action object used in signalling that all themes have been received.
+ * Ignored from documentation as it's internal to the data store.
+ *
+ * @ignore
+ *
+ * @param {Object} allThemes The list of all instaled theme.
+ *
+ * @return {Object} Action object.
+ */
+export function receiveAllThemes( allThemes ) {
+	return {
+		type: 'RECEIVE_All_THEMES',
+		allThemes,
+	};
+}
+
+/**
  * Returns an action object used in signalling that the current global styles id has been received.
  * Ignored from documentation as it's internal to the data store.
  *

--- a/packages/core-data/src/reducer.js
+++ b/packages/core-data/src/reducer.js
@@ -127,6 +127,23 @@ export function currentTheme( state = undefined, action ) {
 }
 
 /**
+ * Reducer managing all themes.
+ *
+ * @param {string|undefined} state  Current state.
+ * @param {Object}           action Dispatched action.
+ *
+ * @return {string|undefined} Updated state.
+ */
+export function allThemes( state = undefined, action ) {
+	switch ( action.type ) {
+		case 'RECEIVE_ALL_THEMES':
+			return action.allThemes;
+	}
+
+	return state;
+}
+
+/**
  * Reducer managing the current global styles id.
  *
  * @param {string|undefined} state  Current state.

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -246,6 +246,21 @@ export const getCurrentTheme =
 	};
 
 /**
+ * Requests all themes.
+ */
+export const getAllThemes =
+	() =>
+	async ( { dispatch, resolveSelect } ) => {
+		const allThemes = await resolveSelect.getEntityRecords(
+			'root',
+			'theme',
+			{ per_page: -1 }
+		);
+
+		dispatch.receiveAllThemes( allThemes );
+	};
+
+/**
  * Requests theme supports data from the index.
  */
 export const getThemeSupports = forwardResolver( 'getCurrentTheme' );

--- a/packages/core-data/src/selectors.ts
+++ b/packages/core-data/src/selectors.ts
@@ -939,6 +939,17 @@ export function getCurrentTheme( state: State ): any {
 }
 
 /**
+ * Return all themes.
+ *
+ * @param state Data state.
+ *
+ * @return All themes.
+ */
+export function getAllThemes( state: State ): any {
+	return getEntityRecords( state, 'root', 'theme', { per_page: -1 } );
+}
+
+/**
  * Return the ID of the current global styles object.
  *
  * @param state Data state.

--- a/packages/edit-site/src/components/sidebar-navigation-screen-main/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-main/index.js
@@ -6,7 +6,13 @@ import {
 	__experimentalNavigatorButton as NavigatorButton,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { layout, symbolFilled, navigation, styles } from '@wordpress/icons';
+import {
+	layout,
+	symbolFilled,
+	navigation,
+	styles,
+	brush,
+} from '@wordpress/icons';
 import { useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 
@@ -91,6 +97,14 @@ export default function SidebarNavigationScreenMain() {
 						icon={ symbolFilled }
 					>
 						{ __( 'Template Parts' ) }
+					</NavigatorButton>
+					<NavigatorButton
+						as={ SidebarNavigationItem }
+						path="/themes"
+						withChevron
+						icon={ brush }
+					>
+						{ __( 'Themes' ) }
 					</NavigatorButton>
 				</ItemGroup>
 			}

--- a/packages/edit-site/src/components/sidebar-navigation-screen-themes/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-themes/index.js
@@ -1,0 +1,20 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import SidebarNavigationScreen from '../sidebar-navigation-screen';
+import Themes from '../themes';
+
+export default function SidebarNavigationScreenThemes() {
+	return (
+		<SidebarNavigationScreen
+			title={ __( 'Themes' ) }
+			description={ __( 'Choose a theme to preview.' ) }
+			content={ <Themes /> }
+		/>
+	);
+}

--- a/packages/edit-site/src/components/sidebar/index.js
+++ b/packages/edit-site/src/components/sidebar/index.js
@@ -19,6 +19,7 @@ import useSyncPathWithURL, {
 } from '../sync-state-with-url/use-sync-path-with-url';
 import SidebarNavigationScreenNavigationMenus from '../sidebar-navigation-screen-navigation-menus';
 import SidebarNavigationScreenGlobalStyles from '../sidebar-navigation-screen-global-styles';
+import SidebarNavigationScreenThemes from '../sidebar-navigation-screen-themes';
 import SidebarNavigationScreenTemplatesBrowse from '../sidebar-navigation-screen-templates-browse';
 import SaveHub from '../save-hub';
 import SidebarNavigationScreenNavigationItem from '../sidebar-navigation-screen-navigation-item';
@@ -51,6 +52,9 @@ function SidebarScreens() {
 			</NavigatorScreen>
 			<NavigatorScreen path="/:postType(wp_template|wp_template_part)/:postId">
 				<SidebarNavigationScreenTemplate />
+			</NavigatorScreen>
+			<NavigatorScreen path="/themes">
+				<SidebarNavigationScreenThemes />
 			</NavigatorScreen>
 		</>
 	);

--- a/packages/edit-site/src/components/themes/index.js
+++ b/packages/edit-site/src/components/themes/index.js
@@ -1,0 +1,50 @@
+/**
+ * WordPress dependencies
+ */
+import { store as coreStore } from '@wordpress/core-data';
+import { useSelect } from '@wordpress/data';
+import { privateApis as routerPrivateApis } from '@wordpress/router';
+
+/**
+ * Internal dependencies
+ */
+import { unlock } from '../../private-apis';
+import { currentlyPreviewingTheme } from '../../utils/is-previewing-theme';
+
+const { useHistory, useLocation } = unlock( routerPrivateApis );
+
+export default function Themes() {
+	const history = useHistory();
+	const location = useLocation();
+	const { allThemes } = useSelect( ( select ) => {
+		return {
+			allThemes: select( coreStore ).getAllThemes() || [],
+		};
+	}, [] );
+
+	return (
+		<select
+			onChange={ ( event ) => {
+				history.push( {
+					...location.params,
+					theme_preview: event.target.value,
+				} );
+				window.location.reload();
+			} }
+			value={ currentlyPreviewingTheme() }
+		>
+			{ allThemes
+				.filter( ( theme ) => theme.block_theme )
+				.map( ( theme ) => {
+					return (
+						<option
+							value={ theme.stylesheet }
+							key={ theme.stylesheet }
+						>
+							{ theme.name.rendered }
+						</option>
+					);
+				} ) }
+		</select>
+	);
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
WIP. This makes it possible to switch block themes within the Site Editor. It's just a prototype for now.

## Why?
It's easier than going back to the dashboard each time.

## How?
Lots of hacks just to get a demo working. I'm not sure how to trigger the iframe to reload with the correct middleware.

## Testing Instructions
1. Open the Site Editor
2. Open the "Themes" panel
3. Change the theme in the select
4. You should see the new theme loaded in the preview

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/275961/236504777-ee2a45ee-51d0-426f-9b70-4604b5c47644.mov

