### PR TITLE
[RNMobile] Update setup media picker helper

### DIFF
--- a/packages/components/src/sandbox/index.native.js
+++ b/packages/components/src/sandbox/index.native.js
@@ -187,6 +187,7 @@ const Sandbox = forwardRef( function Sandbox(
 		onWindowEvents = {},
 		viewportProps = '',
 		onLoadEnd = () => {},
+		testID,
 	},
 	ref
 ) {
@@ -374,6 +375,7 @@ const Sandbox = forwardRef( function Sandbox(
 			showsVerticalScrollIndicator={ false }
 			mediaPlaybackRequiresUserAction={ false }
 			onLoadEnd={ onLoadEnd }
+			testID={ testID }
 		/>
 	);
 } );

--- a/test/native/integration-test-helpers/setup-media-picker.js
+++ b/test/native/integration-test-helpers/setup-media-picker.js
@@ -20,9 +20,11 @@ import { requestMediaPicker } from '@wordpress/react-native-bridge';
  */
 export const setupMediaPicker = () => {
 	let mediaPickerCallback;
+	let multipleItems;
 	requestMediaPicker.mockImplementation(
 		( source, filter, multiple, callback ) => {
 			mediaPickerCallback = callback;
+			multipleItems = multiple;
 		}
 	);
 	return {
@@ -34,16 +36,25 @@ export const setupMediaPicker = () => {
 				mediaPickerCallback
 			),
 		mediaPickerCallback: async ( ...mediaItems ) =>
-			act( async () =>
+			act( async () => {
+				const items = mediaItems.map(
+					( {
+						localId,
+						localUrl,
+						type = 'image',
+						url,
+						id,
+						metadata,
+					} ) => ( {
+						type,
+						url: url ?? localUrl,
+						id: id ?? localId,
+						metadata,
+					} )
+				);
 				mediaPickerCallback(
-					mediaItems.map(
-						( { localId, localUrl, type = 'image' } ) => ( {
-							type,
-							url: localUrl,
-							id: localId,
-						} )
-					)
-				)
-			),
+					items.length === 1 && ! multipleItems ? items[ 0 ] : items
+				);
+			} ),
 	};
 };

--- a/test/native/integration-test-helpers/setup-media-upload.js
+++ b/test/native/integration-test-helpers/setup-media-upload.js
@@ -50,6 +50,7 @@ export const setupMediaUpload = () => {
 					mediaId: mediaItem.localId,
 					mediaUrl: mediaItem.serverUrl,
 					mediaServerId: mediaItem.serverId,
+					metadata: mediaItem.metadata,
 				} );
 			} ),
 		notifyFailedState: async ( mediaItem ) =>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Update the media picker helper to support more functionality.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
This is needed for tests being worked on Gutenberg Mobile: https://github.com/wordpress-mobile/gutenberg-mobile/issues/5734.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
The following updates have been made:
1. If the media picker was invoked with `multiple` option as `false`, when calling back `mediaPickerCallback` it will return the media item instead of an array. This is needed for components that expect only an item to be returned.
2. Passing the `metadata` property when notifying a succeeded upload.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
These changes can be tested via https://github.com/wordpress-mobile/gutenberg-mobile/pull/5735. Specifically, this change is used [here](https://github.com/wordpress-mobile/gutenberg-mobile/pull/5735/files#diff-b7c32751c022a44134457a37167be9ad1cfbe9e036bb7678a8082e40140f9dfbR208).

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
N/A

## Screenshots or screencast <!-- if applicable -->
N/A