### PR TITLE
[Mobile] - Update Header component to use the `useEditorWrapperStyles` hook

### DIFF
--- a/packages/block-editor/src/hooks/index.native.js
+++ b/packages/block-editor/src/hooks/index.native.js
@@ -15,3 +15,4 @@ export { getBorderClassesAndStyles, useBorderProps } from './use-border-props';
 export { getColorClassesAndStyles, useColorProps } from './use-color-props';
 export { getSpacingClassesAndStyles } from './use-spacing-props';
 export { useCachedTruthy } from './use-cached-truthy';
+export { useEditorWrapperStyles } from './use-editor-wrapper-styles';

--- a/packages/block-editor/src/index.native.js
+++ b/packages/block-editor/src/index.native.js
@@ -1,0 +1,6 @@
+/**
+ * Internal dependencies
+ */
+export * from './index.js';
+
+export { useEditorWrapperStyles } from './hooks';

--- a/packages/edit-post/src/components/visual-editor/header.native.js
+++ b/packages/edit-post/src/components/visual-editor/header.native.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { View } from 'react-native';
+
+/**
  * WordPress dependencies
  */
 import { memo } from '@wordpress/element';
@@ -6,8 +11,10 @@ import { __ } from '@wordpress/i18n';
 import { withDispatch, withSelect } from '@wordpress/data';
 import { compose, withPreferredColorScheme } from '@wordpress/compose';
 import { PostTitle } from '@wordpress/editor';
-import { ReadableContentView } from '@wordpress/components';
-import { store as blockEditorStore } from '@wordpress/block-editor';
+import {
+	store as blockEditorStore,
+	useEditorWrapperStyles,
+} from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
@@ -21,12 +28,13 @@ const Header = memo(
 		title,
 		getStylesFromColorScheme,
 	} ) {
+		const [ wrapperStyles ] = useEditorWrapperStyles();
 		const blockHolderFocusedStyle = getStylesFromColorScheme(
 			styles.blockHolderFocused,
 			styles.blockHolderFocusedDark
 		);
 		return (
-			<ReadableContentView>
+			<View style={ wrapperStyles }>
 				<PostTitle
 					innerRef={ setTitleRef }
 					title={ title }
@@ -36,7 +44,7 @@ const Header = memo(
 					focusedBorderColor={ blockHolderFocusedStyle.borderColor }
 					accessibilityLabel="post-title"
 				/>
-			</ReadableContentView>
+			</View>
 		);
 	},
 	( prevProps, nextProps ) => prevProps.title === nextProps.title


### PR DESCRIPTION
Closes https://github.com/wordpress-mobile/gutenberg-mobile/issues/5685

## What?
This PR updates the `Header` component to use the `useEditorWrapperStyles` hook instead of the `ReadableContentView` component.

## Why?
To use the recently added `useEditorWrapperStyles` hook so we can deprecate the usage of `ReadableContentView`.

## How?
First, it creates the native `index` entry point for the `block-editor` package, which will export all from the web's entry point plus native-only exports like the `useEditorWrapperStyles` hook.

It updates the `Header` component by removing the usage of the `ReadableContentView` component in favor of the `useEditorWrapperStyles` hook. For this case, no options are needed to be set for the hook since the header's width is limited to the maximum width of the canvas. Although if in the future we want to allow a full-size option we can just pass the `align` option and it will automatically adapt.

## Testing Instructions

Test the title shows with the expected size and margins, check the same in landscape.

### Testing Instructions for Keyboard
N/A

## Screenshots or screencast <!-- if applicable -->

iPhone portrait | iPad portrait
-|-
<kbd><img src="https://user-images.githubusercontent.com/4885740/236829834-3988bbb3-4af7-426a-903d-2fdf56b945d5.png" width=200 /></kbd> | <kbd><img src="https://user-images.githubusercontent.com/4885740/236830096-05fb8799-3c0e-47e5-ba66-2b9b464cbf00.png" width=300 /></kbd>

iPhone landscape | iPad landscape
-|-
<kbd><img src="https://user-images.githubusercontent.com/4885740/236829848-9246e198-a53e-4d02-8635-1c8745959082.png" width=200 /></kbd> | <kbd><img src="https://user-images.githubusercontent.com/4885740/236830197-ba86b2cc-7244-47e0-9e08-92837b9e0534.png" width=200 /></kbd>