### PR TITLE
Fix toggle new tab does not persist changes to text input in Link Control

### DIFF
--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -99,10 +99,7 @@ import { DEFAULT_LINK_SETTINGS } from './constants';
  */
 
 const noop = () => {};
-const __newOnChangeForLinkControl = ( callback1, callback2, value ) => {
-	callback1( value );
-	callback2( value );
-};
+
 /**
  * Renders a link control. A link control is a controlled input which maintains
  * a value associated with a link (HTML anchor element) and relevant settings
@@ -165,6 +162,11 @@ function LinkControl( {
 		}
 	}, [ forceIsEditingLink ] );
 
+	const newOnChangeForLinkControl = ( data ) => {
+		setNewValue( data );
+		onChange( data );
+	};
+
 	useEffect( () => {
 		// We don't auto focus into the Link UI on mount
 		// because otherwise using the keyboard to select text
@@ -208,7 +210,7 @@ function LinkControl( {
 	};
 
 	const handleSelectSuggestion = ( updatedValue ) => {
-		__newOnChangeForLinkControl( onChange, setNewValue, {
+		newOnChangeForLinkControl( {
 			...updatedValue,
 			title: internalTextInputValue || updatedValue?.title,
 		} );
@@ -216,7 +218,7 @@ function LinkControl( {
 	};
 
 	const handleSubmit = () => {
-		__newOnChangeForLinkControl( onChange, setNewValue, {
+		newOnChangeForLinkControl( {
 			...newValue,
 			url: currentUrlInputValue,
 			title: internalTextInputValue,

--- a/packages/block-editor/src/components/link-control/settings-drawer.js
+++ b/packages/block-editor/src/components/link-control/settings-drawer.js
@@ -1,97 +1,45 @@
 /**
  * WordPress dependencies
  */
-import {
-	Button,
-	TextControl,
-	__unstableMotion as motion,
-	__unstableAnimatePresence as AnimatePresence,
-} from '@wordpress/components';
-import { settings as settingsIcon } from '@wordpress/icons';
-import { useReducedMotion, useInstanceId } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
-import { Fragment } from '@wordpress/element';
+import { ToggleControl, VisuallyHidden } from '@wordpress/components';
 
-/**
- * Internal dependencies
- */
-import Settings from './settings';
+const noop = () => {};
 
-function LinkSettingsDrawer( {
-	settingsOpen,
-	setSettingsOpen,
-	showTextControl,
-	showSettings,
-	textInputRef,
-	internalTextInputValue,
-	setInternalTextInputValue,
-	handleSubmitWithEnter,
+const LinkControlSettingsDrawer = ( {
 	value,
 	settings,
-	onChange,
-} ) {
-	const prefersReducedMotion = useReducedMotion();
-	const MaybeAnimatePresence = prefersReducedMotion
-		? Fragment
-		: AnimatePresence;
-	const MaybeMotionDiv = prefersReducedMotion ? 'div' : motion.div;
+	setNewValue = noop,
+} ) => {
+	if ( ! settings || ! settings.length ) {
+		return null;
+	}
 
-	const id = useInstanceId( LinkSettingsDrawer );
+	const handleSettingChange = ( setting ) => ( newValue ) => {
+		setNewValue( {
+			...value,
+			[ setting.id ]: newValue,
+		} );
+	};
 
-	const settingsDrawerId = `link-control-settings-drawer-${ id }`;
+	const theSettings = settings.map( ( setting ) => (
+		<ToggleControl
+			className="block-editor-link-control__setting"
+			key={ setting.id }
+			label={ setting.title }
+			onChange={ handleSettingChange( setting ) }
+			checked={ value ? !! value[ setting.id ] : false }
+		/>
+	) );
 
 	return (
-		<>
-			<Button
-				className="block-editor-link-control__drawer-toggle"
-				aria-expanded={ settingsOpen }
-				onClick={ () => setSettingsOpen( ! settingsOpen ) }
-				icon={ settingsIcon }
-				label={ __( 'Link Settings' ) }
-				aria-controls={ settingsDrawerId }
-			/>
-			<MaybeAnimatePresence>
-				{ settingsOpen && (
-					<MaybeMotionDiv
-						className="block-editor-link-control__drawer"
-						hidden={ ! settingsOpen }
-						id={ settingsDrawerId }
-						initial="collapsed"
-						animate="open"
-						exit="collapsed"
-						variants={ {
-							open: { opacity: 1, height: 'auto' },
-							collapsed: { opacity: 0, height: 0 },
-						} }
-						transition={ {
-							duration: 0.1,
-						} }
-					>
-						<div className="block-editor-link-control__drawer-inner">
-							{ showTextControl && (
-								<TextControl
-									__nextHasNoMarginBottom
-									ref={ textInputRef }
-									className="block-editor-link-control__setting block-editor-link-control__text-content"
-									label="Text"
-									value={ internalTextInputValue }
-									onChange={ setInternalTextInputValue }
-									onKeyDown={ handleSubmitWithEnter }
-								/>
-							) }
-							{ showSettings && (
-								<Settings
-									value={ value }
-									settings={ settings }
-									onChange={ onChange }
-								/>
-							) }
-						</div>
-					</MaybeMotionDiv>
-				) }
-			</MaybeAnimatePresence>
-		</>
+		<fieldset className="block-editor-link-control__settings">
+			<VisuallyHidden as="legend">
+				{ __( 'Currently selected link settings' ) }
+			</VisuallyHidden>
+			{ theSettings }
+		</fieldset>
 	);
-}
+};
 
-export default LinkSettingsDrawer;
+export default LinkControlSettingsDrawer;


### PR DESCRIPTION
### Updated version of the PR is this 👉 https://github.com/WordPress/gutenberg/pull/50602. Probaly gonna close this PR soon, but keeping it open for now to get some feedback as to if this one is a a better candidate just for a cherry pick to `wp/6.2 minor release`. 
### The mentioned updated PR is created as this one doesn't maintain the current state/UI/UX of the `link-control` component. See the conversations & the videos shown there for more clarity

This PR fixes issues: #45741 & #43144

Here's what I did in my code to fix this issue👇:

** step 1: took a new state 'newValue' and used the 'recieved 'value' prop' as default.
** step 2: replaced the 'value' with 'newValue' state everywhere. It's help us to change the 'value' without causing any mutation using 'setNewValue' when we need it
** step 3: passed 'setNewValue' function to 'LinkControlSettingsDrawer' component to be able to change the value from inside that component
** step 4: in 'settings-drawer.js' file used the passed 'setNewValue' function to update 'just the settings' and keeping the other values to make sure no mutation happen to the original 'value' prop
** step 5: removed 'onChange' entirely from 'LinkControlSettingsDrawer' as 'this onchange call is the culprit' that causes the link modal to close. also removed passing the 'onChange' as a prop to 'LinkControlSettingsDrawer' component in the 'index.js' file as it's no longer used
