### PR TITLE
Fix docker-compose options for the phpunit and composer environments

### DIFF
--- a/packages/env/lib/commands/run.js
+++ b/packages/env/lib/commands/run.js
@@ -81,7 +81,7 @@ function spawnCommandDirectly( config, container, command, envCwd, spinner ) {
 		hostUser.fullUser,
 		container,
 		...command.split( ' ' ), // The command will fail if passed as a complete string.
-	].filter( Boolean );
+	];
 
 	return new Promise( ( resolve, reject ) => {
 		// Note: since the npm docker-compose package uses the -T option, we

--- a/packages/env/lib/commands/run.js
+++ b/packages/env/lib/commands/run.js
@@ -61,21 +61,27 @@ function spawnCommandDirectly( config, container, command, envCwd, spinner ) {
 	const hostUser = getHostUser();
 
 	// We need to pass absolute paths to the container.
-	envCwd = path.resolve( '/var/www/html', envCwd );
+	envCwd = path.resolve(
+		container === 'composer' ? '/app' : '/var/www/html',
+		envCwd
+	);
 
+	const useRun = container === 'phpunit' || container === 'composer';
 	const isTTY = process.stdout.isTTY;
+
 	const composeCommand = [
 		'-f',
 		config.dockerComposeConfigPath,
-		'exec',
+		useRun ? 'run' : 'exec',
 		! isTTY ? '--no-TTY' : '',
 		'-w',
 		envCwd,
+		useRun ? '--rm' : '',
 		'--user',
 		hostUser.fullUser,
 		container,
 		...command.split( ' ' ), // The command will fail if passed as a complete string.
-	];
+	].filter( Boolean );
 
 	return new Promise( ( resolve, reject ) => {
 		// Note: since the npm docker-compose package uses the -T option, we


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This is kind of a partial revert of #50007 -- it restores the previous "docker-compose run" behavior for the phpunit and composer environments, which are not long-running envs.

This also fixes the root path of the composer environment -- the root cwd was changed in #49908 to the WordPress root which is different from what composer uses.

## Why?
It's not possible to use these environments correctly on trunk.

## How?
See above

## Testing Instructions
local testing / tbd

