### PR TITLE
Update Template Parts icon to use the symbol

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen-main/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-main/index.js
@@ -6,7 +6,7 @@ import {
 	__experimentalNavigatorButton as NavigatorButton,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { layout, symbolFilled, navigation, styles } from '@wordpress/icons';
+import { layout, symbol, navigation, styles } from '@wordpress/icons';
 import { useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 
@@ -88,7 +88,7 @@ export default function SidebarNavigationScreenMain() {
 						as={ SidebarNavigationItem }
 						path="/wp_template_part"
 						withChevron
-						icon={ symbolFilled }
+						icon={ symbol }
 					>
 						{ __( 'Template Parts' ) }
 					</NavigatorButton>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Minor icon change from the `symbolFilled` to `symbol` icon for Template Parts menu item in the Site Editor nav.

## Why?
In support of https://github.com/WordPress/gutenberg/issues/50397. 

## Testing Instructions
1. Open the Site Editor.
2. See the new icon for "Template Parts"

## Screenshots or screencast <!-- if applicable -->

| Before  | After |
| ------------- | ------------- |
|<img width="354" alt="CleanShot 2023-05-05 at 18 17 43" src="https://user-images.githubusercontent.com/1813435/236577690-3cb43db7-4de6-41f2-b69d-0fdaa74d13a0.png">|<img width="357" alt="CleanShot 2023-05-05 at 18 14 27" src="https://user-images.githubusercontent.com/1813435/236577574-fc2e0837-d7f0-4e23-84c8-ff960b4902c1.png">|
