### PR TITLE
wp-env fix exec command in CI

### DIFF
--- a/packages/env/lib/commands/run.js
+++ b/packages/env/lib/commands/run.js
@@ -62,7 +62,7 @@ function spawnCommandDirectly( config, container, command, envCwd, spinner ) {
 
 	// We need to pass absolute paths to the container.
 	envCwd = path.resolve(
-		// Note: mysql doesn't have the /var/www/html construct.
+		// Not all containers have the same starting working directory.
 		container === 'mysql' || container === 'tests-mysql'
 			? '/'
 			: '/var/www/html',

--- a/packages/env/lib/commands/run.js
+++ b/packages/env/lib/commands/run.js
@@ -61,14 +61,20 @@ function spawnCommandDirectly( config, container, command, envCwd, spinner ) {
 	const hostUser = getHostUser();
 
 	// We need to pass absolute paths to the container.
-	envCwd = path.resolve( '/var/www/html', envCwd );
+	envCwd = path.resolve(
+		// Note: mysql doesn't have the /var/www/html construct.
+		container === 'mysql' || container === 'tests-mysql'
+			? '/'
+			: '/var/www/html',
+		envCwd
+	);
 
 	const isTTY = process.stdout.isTTY;
 	const composeCommand = [
 		'-f',
 		config.dockerComposeConfigPath,
 		'exec',
-		! isTTY ? '--no-TTY' : '',
+		! isTTY ? '-T' : '',
 		'-w',
 		envCwd,
 		'--user',

--- a/phpunit/class-override-script-test.php
+++ b/phpunit/class-override-script-test.php
@@ -40,7 +40,7 @@ class Override_Script_Test extends WP_UnitTestCase {
 		);
 
 		$script = $wp_scripts->query( 'gutenberg-dummy-script', 'registered' );
-		$this->assertEquals( array( 'dependency', 'wp-i18n' ), $script->deps );
+		$this->assertEquals( array( 'dependency' ), $script->deps );
 	}
 
 	/**
@@ -60,7 +60,7 @@ class Override_Script_Test extends WP_UnitTestCase {
 
 		$script = $wp_scripts->query( 'gutenberg-dummy-script', 'registered' );
 		$this->assertEquals( 'https://example.com/updated', $script->src );
-		$this->assertEquals( array( 'updated-dependency', 'wp-i18n' ), $script->deps );
+		$this->assertEquals( array( 'updated-dependency' ), $script->deps );
 		$this->assertEquals( 'updated-version', $script->ver );
 		$this->assertSame( 1, $script->args );
 	}
@@ -82,7 +82,7 @@ class Override_Script_Test extends WP_UnitTestCase {
 
 		$script = $wp_scripts->query( 'gutenberg-second-dummy-script', 'registered' );
 		$this->assertEquals( 'https://example.com/', $script->src );
-		$this->assertEquals( array( 'dependency', 'wp-i18n' ), $script->deps );
+		$this->assertEquals( array( 'dependency' ), $script->deps );
 		$this->assertEquals( 'version', $script->ver );
 		$this->assertSame( 1, $script->args );
 	}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Phpunit tests are not running anything in Github actions currently. This makes them work again. This was ultimately caused by #50007, so PHPunit hasn't been running on trunk or in branches for about a week. Thankfully, not many failures were introduced!

The issue was that wp-env would say phpunit was executing, but nothing would happen, and nothing would be printed to the terminal. Ultimately, Docker has very poor documentation around this issue (--no-TTY is supposed to work, but doesn't, and docker-compose run prints a help message, but docker-compose exec doesn't.) Plus, we don't have anything making sure that phpunit tests are being executed!

Essentially, `--no-TTY` isn't actually a flag that docker-compose accepts. When using `run` instead of `exec`, you get a help message which says that only `-T` is accepted. I _guessed_ this was also the case for exec, but for some reason no help message was printed to indicate this. Changing that to `-T` when we aren't running with a TTY (like in CI), it started running phpunit again.

I also fixed the failing trunk test.

## Follow-up
- [ ] add something to github actions which detects if no tests completed. (including when there is no phpunit output) (see https://github.com/WordPress/gutenberg/pull/50442)

## Testing Instructions
PHPunit should pass

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
