### PR TITLE
Revert docker-compose exec to docker-compose run

### DIFF
--- a/packages/env/CHANGELOG.md
+++ b/packages/env/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Breaking Change
 
 -   Docker containers now run as the host user. This should resolve problems with permissions arising from different owners
-between the host, web container, and cli container. If you still encounter permissions issues, try running `npx wp-env destroy` so that the environment can be recreated with the correct permissions.
+    between the host, web container, and cli container. If you still encounter permissions issues, try running `npx wp-env destroy` so that the environment can be recreated with the correct permissions.
 
 ### New feature
 
@@ -17,10 +17,6 @@ between the host, web container, and cli container. If you still encounter permi
 ### Bug fix
 
 -   Ensure `wordpress`, `tests-wordpress`, `cli`, and `tests-cli` always build the correct Docker image.
-
-### Enhancement
-
--   `wp-env run ...` now uses docker-compose exec instead of docker-compose run. As a result, it is much faster, since commands are executed against existing services, rather than creating them from scratch each time.
 
 ## 6.0.0 (2023-04-26)
 

--- a/packages/env/lib/commands/run.js
+++ b/packages/env/lib/commands/run.js
@@ -63,12 +63,10 @@ function spawnCommandDirectly( config, container, command, envCwd, spinner ) {
 	// We need to pass absolute paths to the container.
 	envCwd = path.resolve( '/var/www/html', envCwd );
 
-	const isTTY = process.stdout.isTTY;
 	const composeCommand = [
 		'-f',
 		config.dockerComposeConfigPath,
-		'exec',
-		! isTTY ? '--no-TTY' : '',
+		'run',
 		'-w',
 		envCwd,
 		'--user',

--- a/phpunit/class-override-script-test.php
+++ b/phpunit/class-override-script-test.php
@@ -40,7 +40,7 @@ class Override_Script_Test extends WP_UnitTestCase {
 		);
 
 		$script = $wp_scripts->query( 'gutenberg-dummy-script', 'registered' );
-		$this->assertEquals( array( 'dependency', 'wp-i18n' ), $script->deps );
+		$this->assertEquals( array( 'dependency' ), $script->deps );
 	}
 
 	/**
@@ -60,7 +60,7 @@ class Override_Script_Test extends WP_UnitTestCase {
 
 		$script = $wp_scripts->query( 'gutenberg-dummy-script', 'registered' );
 		$this->assertEquals( 'https://example.com/updated', $script->src );
-		$this->assertEquals( array( 'updated-dependency', 'wp-i18n' ), $script->deps );
+		$this->assertEquals( array( 'updated-dependency' ), $script->deps );
 		$this->assertEquals( 'updated-version', $script->ver );
 		$this->assertSame( 1, $script->args );
 	}
@@ -82,7 +82,7 @@ class Override_Script_Test extends WP_UnitTestCase {
 
 		$script = $wp_scripts->query( 'gutenberg-second-dummy-script', 'registered' );
 		$this->assertEquals( 'https://example.com/', $script->src );
-		$this->assertEquals( array( 'dependency', 'wp-i18n' ), $script->deps );
+		$this->assertEquals( array( 'dependency' ), $script->deps );
 		$this->assertEquals( 'version', $script->ver );
 		$this->assertSame( 1, $script->args );
 	}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Effectively reverts #50007, because phpunit tests are not running on trunk.

https://github.com/WordPress/gutenberg/pull/50411 adds debug around exec calls to see if we can figure out the issue.

## Why?
Because phpunit tests are not running on trunk.

## How?
Change docker-compose exec back to run

## Testing Instructions
Phpunit tests should pass (**_CHECK OUTPUT TO MAKE SURE TESTS RUN_**)

## Follow-up
- [ ] See why exec doesn't work (or just leave it if the effort is too high)
- [ ] Add something which fails the unit tests workflow if no test runs are detected

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
