### PR TITLE
Site: editor: Add view site link to site editor nav

### DIFF
--- a/packages/edit-site/src/components/site-hub/index.js
+++ b/packages/edit-site/src/components/site-hub/index.js
@@ -162,6 +162,7 @@ const SiteHub = forwardRef( ( props, ref ) => {
 						href={ homeUrl }
 						target="_blank"
 						label={ __( 'View site' ) }
+						aria-label={ __( 'View site (opens in a new tab)' ) }
 						icon={ external }
 						className="edit-site-site-hub__site-view-link"
 					/>

--- a/packages/edit-site/src/components/site-hub/index.js
+++ b/packages/edit-site/src/components/site-hub/index.js
@@ -12,8 +12,6 @@ import {
 	__unstableMotion as motion,
 	__unstableAnimatePresence as AnimatePresence,
 	__experimentalHStack as HStack,
-	ExternalLink,
-	Tooltip,
 } from '@wordpress/components';
 import { useReducedMotion } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
@@ -21,7 +19,7 @@ import { store as blockEditorStore } from '@wordpress/block-editor';
 import { store as coreStore } from '@wordpress/core-data';
 import { decodeEntities } from '@wordpress/html-entities';
 import { forwardRef } from '@wordpress/element';
-import { search } from '@wordpress/icons';
+import { search, external } from '@wordpress/icons';
 import { privateApis as commandsPrivateApis } from '@wordpress/commands';
 
 /**
@@ -156,9 +154,13 @@ const SiteHub = forwardRef( ( props, ref ) => {
 							{ decodeEntities( siteTitle ) }
 						</motion.div>
 					</AnimatePresence>
-					<Tooltip text={ __( 'View site' ) }>
-						<ExternalLink href={ homeUrl } />
-					</Tooltip>
+					<Button
+						href={ homeUrl }
+						target="_blank"
+						label={ __( 'View site' ) }
+						icon={ external }
+						className="edit-site-site-hub__site-view-link"
+					/>
 				</HStack>
 				{ window?.__experimentalEnableCommandCenter &&
 					canvasMode === 'view' && (

--- a/packages/edit-site/src/components/site-hub/index.js
+++ b/packages/edit-site/src/components/site-hub/index.js
@@ -153,13 +153,12 @@ const SiteHub = forwardRef( ( props, ref ) => {
 								delay: canvasMode === 'view' ? 0.1 : 0,
 							} }
 						>
-							<Tooltip text={ __( 'View site' ) }>
-								<ExternalLink href={ homeUrl }>
-									{ decodeEntities( siteTitle ) }
-								</ExternalLink>
-							</Tooltip>
+							{ decodeEntities( siteTitle ) }
 						</motion.div>
 					</AnimatePresence>
+					<Tooltip text={ __( 'View site' ) }>
+						<ExternalLink href={ homeUrl } />
+					</Tooltip>
 				</HStack>
 				{ window?.__experimentalEnableCommandCenter &&
 					canvasMode === 'view' && (

--- a/packages/edit-site/src/components/site-hub/index.js
+++ b/packages/edit-site/src/components/site-hub/index.js
@@ -12,6 +12,8 @@ import {
 	__unstableMotion as motion,
 	__unstableAnimatePresence as AnimatePresence,
 	__experimentalHStack as HStack,
+	ExternalLink,
+	Tooltip,
 } from '@wordpress/components';
 import { useReducedMotion } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
@@ -34,15 +36,20 @@ const { store: commandsStore } = unlock( commandsPrivateApis );
 const HUB_ANIMATION_DURATION = 0.3;
 
 const SiteHub = forwardRef( ( props, ref ) => {
-	const { canvasMode, dashboardLink } = useSelect( ( select ) => {
+	const { canvasMode, dashboardLink, homeUrl } = useSelect( ( select ) => {
 		const { getCanvasMode, getSettings } = unlock(
 			select( editSiteStore )
 		);
+
+		const {
+			getUnstableBase, // Site index.
+		} = select( coreStore );
 
 		return {
 			canvasMode: getCanvasMode(),
 			dashboardLink:
 				getSettings().__experimentalDashboardLink || 'index.php',
+			homeUrl: getUnstableBase()?.home,
 		};
 	}, [] );
 	const { open: openCommandCenter } = useDispatch( commandsStore );

--- a/packages/edit-site/src/components/site-hub/index.js
+++ b/packages/edit-site/src/components/site-hub/index.js
@@ -92,7 +92,11 @@ const SiteHub = forwardRef( ( props, ref ) => {
 				ease: 'easeOut',
 			} }
 		>
-			<HStack justify="space-between" alignment="center">
+			<HStack
+				justify="space-between"
+				alignment="center"
+				className="edit-site-site-hub__container"
+			>
 				<HStack
 					justify="flex-start"
 					className="edit-site-site-hub__text-content"

--- a/packages/edit-site/src/components/site-hub/index.js
+++ b/packages/edit-site/src/components/site-hub/index.js
@@ -153,7 +153,11 @@ const SiteHub = forwardRef( ( props, ref ) => {
 								delay: canvasMode === 'view' ? 0.1 : 0,
 							} }
 						>
-							{ decodeEntities( siteTitle ) }
+							<Tooltip text={ __( 'View site' ) }>
+								<ExternalLink href={ homeUrl }>
+									{ decodeEntities( siteTitle ) }
+								</ExternalLink>
+							</Tooltip>
 						</motion.div>
 					</AnimatePresence>
 				</HStack>

--- a/packages/edit-site/src/components/site-hub/style.scss
+++ b/packages/edit-site/src/components/site-hub/style.scss
@@ -30,8 +30,8 @@
 		}
 		.components-external-link__icon {
 			fill: $white;
-			height: 18px;
-			width: 18px;
+			height: initial;
+			width: initial;
 		}
 	}
 	&:hover {

--- a/packages/edit-site/src/components/site-hub/style.scss
+++ b/packages/edit-site/src/components/site-hub/style.scss
@@ -32,7 +32,10 @@
 	flex-grow: 1;
 	.components-external-link {
 		color: $white;
-		text-decoration: underline;
+		text-decoration: none;
+		&:hover {
+			text-decoration: underline;
+		}
 		&:focus {
 			outline: none;
 			box-shadow: none;

--- a/packages/edit-site/src/components/site-hub/style.scss
+++ b/packages/edit-site/src/components/site-hub/style.scss
@@ -39,6 +39,12 @@
 			opacity: 1;
 		}
 	}
+	&:focus {
+		.edit-site-site-hub__site-view-link {
+			display: inline-block;
+			opacity: 1;
+		}
+	}
 }
 
 .edit-site-site-hub__title {

--- a/packages/edit-site/src/components/site-hub/style.scss
+++ b/packages/edit-site/src/components/site-hub/style.scss
@@ -35,13 +35,11 @@
 	}
 	&:hover {
 		.edit-site-site-hub__site-view-link {
-			display: inline-block;
 			opacity: 1;
 		}
 	}
 	&:focus {
 		.edit-site-site-hub__site-view-link {
-			display: inline-block;
 			opacity: 1;
 		}
 	}

--- a/packages/edit-site/src/components/site-hub/style.scss
+++ b/packages/edit-site/src/components/site-hub/style.scss
@@ -21,7 +21,9 @@
 	overflow: hidden;
 	.components-external-link {
 		flex-grow: 0;
-		display: none;
+		@media (min-width: 600px) {
+			display: none;
+		}
 		&:focus {
 			outline: none;
 			box-shadow: none;

--- a/packages/edit-site/src/components/site-hub/style.scss
+++ b/packages/edit-site/src/components/site-hub/style.scss
@@ -3,6 +3,31 @@
 	align-items: center;
 	justify-content: space-between;
 	gap: $grid-unit-10;
+
+	.edit-site-site-hub__container {
+		gap: 0;
+	}
+
+	.edit-site-site-hub__site-view-link {
+		flex-grow: 0;
+		@include break-mobile() {
+			opacity: 0;
+			transition: opacity 0.2s ease-in-out;
+		}
+		&:focus {
+			outline: none;
+			box-shadow: none;
+			opacity: 1;
+		}
+		svg {
+			fill: $white;
+		}
+	}
+	&:hover {
+		.edit-site-site-hub__site-view-link {
+			opacity: 1;
+		}
+	}
 }
 
 .edit-site-site-hub__post-type {
@@ -19,30 +44,6 @@
 .edit-site-site-hub__text-content {
 	// Necessary for the ellipsis to work.
 	overflow: hidden;
-	.edit-site-site-hub__site-view-link {
-		flex-grow: 0;
-		@include break-mobile() {
-			opacity: 0;
-			transition: opacity 0.2s ease-in-out;
-		}
-		&:focus {
-			outline: none;
-			box-shadow: none;
-		}
-		svg {
-			fill: $white;
-		}
-	}
-	&:hover {
-		.edit-site-site-hub__site-view-link {
-			opacity: 1;
-		}
-	}
-	&:focus {
-		.edit-site-site-hub__site-view-link {
-			opacity: 1;
-		}
-	}
 }
 
 .edit-site-site-hub__title {

--- a/packages/edit-site/src/components/site-hub/style.scss
+++ b/packages/edit-site/src/components/site-hub/style.scss
@@ -19,6 +19,24 @@
 .edit-site-site-hub__text-content {
 	// Necessary for the ellipsis to work.
 	overflow: hidden;
+	.components-external-link {
+		flex-grow: 0;
+		display: none;
+		&:focus {
+			outline: none;
+			box-shadow: none;
+		}
+		.components-external-link__icon {
+			fill: $white;
+			height: 18px;
+			width: 18px;
+		}
+	}
+	&:hover {
+		.components-external-link {
+			display: inline-block;
+		}
+	}
 }
 
 .edit-site-site-hub__title {
@@ -30,20 +48,6 @@
 .edit-site-site-hub__site-title {
 	margin-left: $grid-unit-05;
 	flex-grow: 1;
-	.components-external-link {
-		color: $white;
-		text-decoration: none;
-		&:hover {
-			text-decoration: underline;
-		}
-		&:focus {
-			outline: none;
-			box-shadow: none;
-		}
-	}
-	.components-external-link__icon {
-		display: none;
-	}
 }
 
 .edit-site-site-hub_toggle-command-center {

--- a/packages/edit-site/src/components/site-hub/style.scss
+++ b/packages/edit-site/src/components/site-hub/style.scss
@@ -22,7 +22,8 @@
 	.components-external-link {
 		flex-grow: 0;
 		@include break-mobile() {
-			display: none;
+			opacity: 0;
+			transition: opacity 0.2s ease-in-out;
 		}
 		&:focus {
 			outline: none;
@@ -37,6 +38,7 @@
 	&:hover {
 		.components-external-link {
 			display: inline-block;
+			opacity: 1;
 		}
 	}
 }

--- a/packages/edit-site/src/components/site-hub/style.scss
+++ b/packages/edit-site/src/components/site-hub/style.scss
@@ -29,6 +29,21 @@
 
 .edit-site-site-hub__site-title {
 	margin-left: $grid-unit-05;
+	flex-grow: 1;
+}
+
+.edit-site-site-hub__site-view {
+	outline: none;
+	.components-external-link:focus {
+		outline: 0;
+		box-shadow: none;
+	}
+	.components-external-link__icon {
+		height: $grid-unit-30;
+		width: $grid-unit-30;
+		color: $white;
+		outline: none;
+	}
 }
 
 .edit-site-site-hub_toggle-command-center {

--- a/packages/edit-site/src/components/site-hub/style.scss
+++ b/packages/edit-site/src/components/site-hub/style.scss
@@ -21,7 +21,7 @@
 	overflow: hidden;
 	.components-external-link {
 		flex-grow: 0;
-		@media (min-width: 600px) {
+		@include break-mobile() {
 			display: none;
 		}
 		&:focus {

--- a/packages/edit-site/src/components/site-hub/style.scss
+++ b/packages/edit-site/src/components/site-hub/style.scss
@@ -19,7 +19,7 @@
 .edit-site-site-hub__text-content {
 	// Necessary for the ellipsis to work.
 	overflow: hidden;
-	.components-external-link {
+	.edit-site-site-hub__site-view-link {
 		flex-grow: 0;
 		@include break-mobile() {
 			opacity: 0;
@@ -29,14 +29,12 @@
 			outline: none;
 			box-shadow: none;
 		}
-		.components-external-link__icon {
+		svg {
 			fill: $white;
-			height: initial;
-			width: initial;
 		}
 	}
 	&:hover {
-		.components-external-link {
+		.edit-site-site-hub__site-view-link {
 			display: inline-block;
 			opacity: 1;
 		}

--- a/packages/edit-site/src/components/site-hub/style.scss
+++ b/packages/edit-site/src/components/site-hub/style.scss
@@ -30,19 +30,16 @@
 .edit-site-site-hub__site-title {
 	margin-left: $grid-unit-05;
 	flex-grow: 1;
-}
-
-.edit-site-site-hub__site-view {
-	outline: none;
-	.components-external-link:focus {
-		outline: 0;
-		box-shadow: none;
+	.components-external-link {
+		color: $white;
+		text-decoration: underline;
+		&:focus {
+			outline: none;
+			box-shadow: none;
+		}
 	}
 	.components-external-link__icon {
-		height: $grid-unit-30;
-		width: $grid-unit-30;
-		color: $white;
-		outline: none;
+		display: none;
 	}
 }
 


### PR DESCRIPTION
## What?
Adds a `View site` link to the site title at top of site editor left nav

## Why?
Fixes: #50405

## How?
Adds an `ExternalLink` component with `getUnstableBase().home` as the url.

## Testing Instructions

- Open site editor and check that no external link icon is visible at top right of left panel
- Hover over  top of left panel and make sure external link icon appears and the `View site` tooltip appears if icon is moused over
- Click site name and check site home opens in new tab

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/3629020/99691876-c373-464d-ac0f-3748f4f6beca