### PR TITLE
[Group]: Remove Quote transform

### DIFF
--- a/packages/block-library/src/quote/transforms.js
+++ b/packages/block-library/src/quote/transforms.js
@@ -22,12 +22,6 @@ const transforms = {
 			},
 		},
 		{
-			type: 'block',
-			blocks: [ 'core/group' ],
-			transform: ( { anchor }, innerBlocks ) =>
-				createBlock( 'core/quote', { anchor }, innerBlocks ),
-		},
-		{
 			type: 'prefix',
 			prefix: '>',
 			transform: ( content ) =>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes: https://github.com/WordPress/gutenberg/issues/49879
This PR just removes an extra existing transform from Group to Quote.
In general the transform from Quote, if a single block is selected, is [limited](https://github.com/WordPress/gutenberg/pull/44072) to `paragraph, heading, list, pullquote` blocks.

## Testing Instructions
1. Select a Group block 
2. Observe that the Quote transform is unavailable.