### PR TITLE
[Post Featured Image]: Revert maxWidth addition

### DIFF
--- a/packages/block-library/src/post-featured-image/edit.js
+++ b/packages/block-library/src/post-featured-image/edit.js
@@ -97,7 +97,7 @@ export default function PostFeaturedImageEdit( {
 		} ) );
 
 	const blockProps = useBlockProps( {
-		style: { width, height, aspectRatio, maxWidth: '100%' },
+		style: { width, height, aspectRatio },
 	} );
 	const borderProps = useBorderProps( attributes );
 

--- a/packages/block-library/src/post-featured-image/index.php
+++ b/packages/block-library/src/post-featured-image/index.php
@@ -92,7 +92,7 @@ function render_block_core_post_featured_image( $attributes, $content, $block ) 
 	if ( ! $height && ! $width && ! $aspect_ratio ) {
 		$wrapper_attributes = get_block_wrapper_attributes();
 	} else {
-		$wrapper_attributes = get_block_wrapper_attributes( array( 'style' => $aspect_ratio . $width . $height . 'max-width:100%;' ) );
+		$wrapper_attributes = get_block_wrapper_attributes( array( 'style' => $aspect_ratio . $width . $height ) );
 	}
 	return "<figure {$wrapper_attributes}>{$featured_image}</figure>";
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Partially reverts: https://github.com/WordPress/gutenberg/pull/49641 (see https://github.com/WordPress/gutenberg/pull/49641#issuecomment-1534780874).

I've kept the `percentage` width fix from the original PR. I've also tried to a fix [here](https://github.com/WordPress/gutenberg/pull/50370), before reverting, but there are a lot of nuances, so let's roll back for now as it's less impactful than the current behavior.
