### PR TITLE
List View: Update the expanded text color so that it works in both a dark and light context

### DIFF
--- a/packages/block-editor/src/components/list-view/style.scss
+++ b/packages/block-editor/src/components/list-view/style.scss
@@ -18,7 +18,7 @@
 	.block-editor-list-view-block-select-button {
 		// When a row is expanded, retain the dark color.
 		&[aria-expanded="true"] {
-			color: $gray-900;
+			color: inherit;
 		}
 
 		// Ensure that on hover, the admin color is still used.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Updates the CSS for list view so that the overrides for button colors works in both a light and dark context.

## Why?
This is needed that the list view can work in the browse mode sidebar as well as the regular canvas.

## How?
This line of CSS makes these buttons blue by default:

```
.components-button:hover, .components-button[aria-expanded="true"] {
color: var(--wp-components-color-accent, var(--wp-admin-theme-color, #3858e9))
}
```

List view already has an override for this to make it grey, but we can change that to just inherit from the wider context, which means that it will use whatever color the rest of the text is.


## Testing Instructions
1. Open List View on the canvas and open some nodes with children.
2. Check that the expanded nodes still have a grey text color.
3. Check out this PR: https://github.com/WordPress/gutenberg/pull/50287
4. Open the navigation part of the browse mode in the site editor: site-editor.php?path=%2Fnavigation
5. Open some nodes with children.
6. Check that the expanded node still have a white text color.

### Testing Instructions for Keyboard
As above

## Screenshots or screencast <!-- if applicable -->
<img width="350" alt="Screenshot 2023-05-08 at 14 53 47" src="https://user-images.githubusercontent.com/275961/236846380-8af09829-bcff-4b64-905e-6b2285f73041.png">
<img width="357" alt="Screenshot 2023-05-08 at 14 53 23" src="https://user-images.githubusercontent.com/275961/236846386-e284aae1-067c-4b2c-aa17-796018ba5e31.png">

