### PR TITLE
Doc: Don't use markdown in the callout section

### DIFF
--- a/docs/how-to-guides/themes/theme-json.md
+++ b/docs/how-to-guides/themes/theme-json.md
@@ -1174,7 +1174,7 @@ Currently block variations exist for "header" and "footer" values of the area te
 
 ### patterns
 
-<div class="callout callout-alert">Supported in WordPress from version 6.0 using [version 2](https://developer.wordpress.org/block-editor/reference-guides/theme-json-reference/theme-json-living/) of `theme.json`.</div>
+<div class="callout callout-alert">Supported in WordPress from version 6.0 using <a href="https://developer.wordpress.org/block-editor/reference-guides/theme-json-reference/theme-json-living/">version 2</a> of <code>theme.json</code>.</div>
 
 Within this field themes can list patterns to register from [Pattern Directory](https://wordpress.org/patterns/). The `patterns` field is an array of pattern `slugs` from the Pattern Directory. Pattern slugs can be extracted by the `url` in single pattern view at the Pattern Directory. For example in this url `https://wordpress.org/patterns/pattern/partner-logos` the slug is `partner-logos`.
 

--- a/packages/blocks/README.md
+++ b/packages/blocks/README.md
@@ -5,7 +5,7 @@
 For more context, refer to [_What Are Little Blocks Made Of?_](https://make.wordpress.org/design/2017/01/25/what-are-little-blocks-made-of/) from the [Make WordPress Design](https://make.wordpress.org/design/) blog.
 
 <div class="callout callout-alert">
-[Learn how to create your first block](https://developer.wordpress.org/block-editor/getting-started/create-block/) for the WordPress block editor. From setting up your development environment, tools, and getting comfortable with the new development model, this tutorial covers all you need to know to get started with creating blocks.
+<a href="https://developer.wordpress.org/block-editor/getting-started/create-block/">Learn how to create your first block</a> for the WordPress block editor. From setting up your development environment, tools, and getting comfortable with the new development model, this tutorial covers all you need to know to get started with creating blocks.
 </div>
 
 ## Installation

--- a/packages/e2e-test-utils-playwright/README.md
+++ b/packages/e2e-test-utils-playwright/README.md
@@ -5,7 +5,7 @@ End-To-End (E2E) Playwright test utils for WordPress.
 _It works properly with the minimum version of Gutenberg `9.2.0` or the minimum version of WordPress `5.6.0`._
 
 <div class="callout callout-alert">
-This package is still under active development. Documentation might not be up-to-date, and the `v0.x` version can introduce breaking changes without a detailed migration guide. Early adopters are encouraged to use a [lock file](https://docs.npmjs.com/cli/v9/configuring-npm/package-lock-json) to prevent unexpected breakages.
+This package is still under active development. Documentation might not be up-to-date, and the `v0.x` version can introduce breaking changes without a detailed migration guide. Early adopters are encouraged to use a <a href="https://docs.npmjs.com/cli/v9/configuring-npm/package-lock-json">lock file</a> to prevent unexpected breakages.
 </div>
 
 ## Installation

--- a/packages/e2e-test-utils-playwright/README.md
+++ b/packages/e2e-test-utils-playwright/README.md
@@ -5,7 +5,7 @@ End-To-End (E2E) Playwright test utils for WordPress.
 _It works properly with the minimum version of Gutenberg `9.2.0` or the minimum version of WordPress `5.6.0`._
 
 <div class="callout callout-alert">
-This package is still under active development. Documentation might not be up-to-date, and the `v0.x` version can introduce breaking changes without a detailed migration guide. Early adopters are encouraged to use a <a href="https://docs.npmjs.com/cli/v9/configuring-npm/package-lock-json">lock file</a> to prevent unexpected breakages.
+This package is still under active development. Documentation might not be up-to-date, and the <code>v0.x</code> version can introduce breaking changes without a detailed migration guide. Early adopters are encouraged to use a <a href="https://docs.npmjs.com/cli/v9/configuring-npm/package-lock-json">lock file</a> to prevent unexpected breakages.
 </div>
 
 ## Installation


### PR DESCRIPTION
Related to: #50110, #50090

## What?
This PR rewrites the markdown to an anchor element to ensure that the link in the callout section of the document displays correctly.

This PR rewrites the markdown to an anchor element to ensure that the link in the callout section of the document displays correctly.

---

https://developer.wordpress.org/block-editor/how-to-guides/themes/theme-json/#patterns

![theme-json](https://user-images.githubusercontent.com/54422211/236859646-9595093b-7268-4b79-bed6-3921cf2b95b3.png)

---

https://developer.wordpress.org/block-editor/reference-guides/packages/packages-blocks/

![blocks](https://user-images.githubusercontent.com/54422211/236859690-1ab056dd-4d16-4a53-8c7f-4b4ad895125a.png)

---

https://developer.wordpress.org/block-editor/reference-guides/packages/packages-e2e-test-utils-playwright/

![ese-test-utils-playwright](https://user-images.githubusercontent.com/54422211/236859708-884e3a64-d700-4f3e-902f-95a15af67500.png)

## Why?

As noted in [this comment](https://github.com/WordPress/gutenberg/pull/50110#issuecomment-1525423477), if HTML is used within the callout section, it appears to display correctly. This PR uses the `a` and `code` elements, which also appear to be rendered correctly in [the README on GitHub](https://github.com/WordPress/gutenberg/blob/docs/use-atag-in-callout/docs/how-to-guides/themes/theme-json.md#patterns).


