### PR TITLE
In CI, verify that PHPunit is actually running

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -182,13 +182,13 @@ jobs:
               if: ${{ ! matrix.multisite }}
               run: |
                   set -o pipefail
-                  npm run test:unit:php | tee phpunit.log
+                  echo "nothing happened" | tee phpunit.log
 
             - name: Running multisite unit tests
               if: ${{ matrix.multisite }}
               run: |
                   set -o pipefail
-                  npm run test:unit:php:multisite | tee phpunit.log
+                  echo "nothing happened" | tee phpunit.log
 
             # Verifies that PHPUnit actually runs in the first place. We want visibility
             # into issues which can cause it to fail silently, so we check the output

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -180,11 +180,15 @@ jobs:
 
             - name: Running single site unit tests
               if: ${{ ! matrix.multisite }}
-              run: npm run test:unit:php | tee phpunit.log
+              run: |
+                  set -o pipefail
+                  npm run test:unit:php | tee phpunit.log
 
             - name: Running multisite unit tests
               if: ${{ matrix.multisite }}
-              run: npm run test:unit:php:multisite | tee phpunit.log
+              run: |
+                  set -o pipefail
+                  npm run test:unit:php:multisite | tee phpunit.log
 
             # Verifies that PHPUnit actually runs in the first place. We want visibility
             # into issues which can cause it to fail silently, so we check the output

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -180,11 +180,31 @@ jobs:
 
             - name: Running single site unit tests
               if: ${{ ! matrix.multisite }}
-              run: npm run test:unit:php
+              run: npm run test:unit:php | tee phpunit.log
 
             - name: Running multisite unit tests
               if: ${{ matrix.multisite }}
-              run: npm run test:unit:php:multisite
+              run: npm run test:unit:php:multisite | tee phpunit.log
+
+            # Verifies that PHPUnit actually runs in the first place. We want visibility
+            # into issues which can cause it to fail silently, so we check the output
+            # to verify that at least 500 tests have passed. This is an arbitrary
+            # number, but makes sure a drastic change doesn't happen without us noticing.
+            - name: Check number of passed tests
+              run: |
+                  # Note: relies on PHPUnit execution to fail on test failure.
+                  # Extract the number of executed tests from the log file.
+                  if ! num_tests=$(grep -Eo 'OK \([0-9]+ tests' phpunit.log) ; then
+                    if ! num_tests=$(grep -Eo 'Tests: [0-9]+, Assertions:' phpunit.log) ; then
+                      echo "PHPUnit failed or did not run." && exit 1
+                    fi
+                  fi
+                  # Extract just the number of tests from the string.
+                  num_tests=$(echo "$num_tests" | grep -Eo '[0-9]+')
+                  if [ $num_tests -lt 500 ] ; then
+                    echo "Only $num_tests tests passed, which is much fewer than expected." && exit 1
+                  fi
+                  echo "$num_tests tests passed."
 
     phpcs:
         name: PHP coding standards

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -200,7 +200,7 @@ jobs:
                   # Extract the number of executed tests from the log file.
                   if ! num_tests=$(grep -Eo 'OK \([0-9]+ tests' phpunit.log) ; then
                     if ! num_tests=$(grep -Eo 'Tests: [0-9]+, Assertions:' phpunit.log) ; then
-                      echo "PHPUnit failed or did not run." && exit 1
+                      echo "PHPUnit failed or did not run. Check the PHPUnit output in the previous step to debug." && exit 1
                     fi
                   fi
                   # Extract just the number of tests from the string.

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -182,13 +182,13 @@ jobs:
               if: ${{ ! matrix.multisite }}
               run: |
                   set -o pipefail
-                  echo "nothing happened" | tee phpunit.log
+                  npm run test:unit:php | tee phpunit.log
 
             - name: Running multisite unit tests
               if: ${{ matrix.multisite }}
               run: |
                   set -o pipefail
-                  echo "nothing happened" | tee phpunit.log
+                  npm run test:unit:php:multisite | tee phpunit.log
 
             # Verifies that PHPUnit actually runs in the first place. We want visibility
             # into issues which can cause it to fail silently, so we check the output

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -66,7 +66,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 		// Results also include root site blocks styles.
 		$this->assertEquals(
 			'body { margin: 0;}.wp-site-blocks > .alignleft { float: left; margin-right: 2em; }.wp-site-blocks > .alignright { float: right; margin-left: 2em; }.wp-site-blocks > .aligncenter { justify-content: center; margin-left: auto; margin-right: auto; }:where(.wp-site-blocks) > * { margin-block-start: 1em; margin-block-end: 0; }:where(.wp-site-blocks) > :first-child:first-child { margin-block-start: 0; }:where(.wp-site-blocks) > :last-child:last-child { margin-block-end: 0; }body { --wp--style--block-gap: 1em; }:where(body .is-layout-flow)  > *{margin-block-start: 0;margin-block-end: 0;}:where(body .is-layout-flow)  > * + *{margin-block-start: 1em;margin-block-end: 0;}:where(body .is-layout-flex) {gap: 1em;}body .is-layout-flow > .alignleft{float: left;margin-inline-start: 0;margin-inline-end: 2em;}body .is-layout-flow > .alignright{float: right;margin-inline-start: 2em;margin-inline-end: 0;}body .is-layout-flow > .aligncenter{margin-left: auto !important;margin-right: auto !important;}body .is-layout-flex{display: flex;}body .is-layout-flex{flex-wrap: wrap;align-items: center;}',
-			''
+			$theme_json->get_stylesheet( array( 'styles' ) )
 		);
 	}
 

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -66,7 +66,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 		// Results also include root site blocks styles.
 		$this->assertEquals(
 			'body { margin: 0;}.wp-site-blocks > .alignleft { float: left; margin-right: 2em; }.wp-site-blocks > .alignright { float: right; margin-left: 2em; }.wp-site-blocks > .aligncenter { justify-content: center; margin-left: auto; margin-right: auto; }:where(.wp-site-blocks) > * { margin-block-start: 1em; margin-block-end: 0; }:where(.wp-site-blocks) > :first-child:first-child { margin-block-start: 0; }:where(.wp-site-blocks) > :last-child:last-child { margin-block-end: 0; }body { --wp--style--block-gap: 1em; }:where(body .is-layout-flow)  > *{margin-block-start: 0;margin-block-end: 0;}:where(body .is-layout-flow)  > * + *{margin-block-start: 1em;margin-block-end: 0;}:where(body .is-layout-flex) {gap: 1em;}body .is-layout-flow > .alignleft{float: left;margin-inline-start: 0;margin-inline-end: 2em;}body .is-layout-flow > .alignright{float: right;margin-inline-start: 2em;margin-inline-end: 0;}body .is-layout-flow > .aligncenter{margin-left: auto !important;margin-right: auto !important;}body .is-layout-flex{display: flex;}body .is-layout-flex{flex-wrap: wrap;align-items: center;}',
-			$theme_json->get_stylesheet( array( 'styles' ) )
+			''
 		);
 	}
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This PR adds a check to the unit test workflow which makes sure that PHPunit is executing correctly.

## Why?
In #50411, we found that all PHPUnit suites on trunk were not running at all. However, this did not fail the test suite, which meant the issue was undetected for more than a week.

## How?
In the PHPUnit github workflow, add a grep call which extracts the number of completed tests from a phpunit log file, and makes sure that at least 500 tests are passing. (This is about half of the current test suite, which seems reasonable when we mostly want to make sure we're 

There are a few different scenarios for test output:

1. Tests do not run. The output looks like this:
```sh
ℹ Starting '/var/www/html/wp-content/plugins/gutenberg/vendor/bin/phpunit -c /var/www/html/wp-content/plugins/gutenberg/phpunit.xml.dist --verbose' on the tests-wordpress container. 

✔ Ran `/var/www/html/wp-content/plugins/gutenberg/vendor/bin/phpunit -c /var/www/html/wp-content/plugins/gutenberg/phpunit.xml.dist --verbose` in 'tests-wordpress'. (in 0s 701ms)
```

2. Tests fail.
```sh
ℹ Starting '/var/www/html/wp-content/plugins/gutenberg/vendor/bin/phpunit -c /var/www/html/wp-content/plugins/gutenberg/phpunit.xml.dist --verbose' on the tests-wordpress container. 

(...a lot of output we don't care about...)

FAILURES!
Tests: 1181, Assertions: 2152, Failures: 3, Warnings: 34.
```

3. Tests pass with warnings
```sh
(...a lot of output we don't care about...)
WARNINGS!
Tests: 1181, Assertions: 2156, Warnings: 34.
```

4. Tests pass with no issues:
```sh
ℹ Starting '/var/www/html/wp-content/plugins/gutenberg/vendor/bin/phpunit -c /var/www/html/wp-content/plugins/gutenberg/phpunit.xml.dist --verbose' on the tests-wordpress container. 

(...a lot of output we don't care about...)

Time: 5.16 seconds, Memory: 58.00 MB

OK (1120 tests, 2156 assertions)
✔ Ran `/var/www/html/wp-content/plugins/gutenberg/vendor/bin/phpunit -c /var/www/html/wp-content/plugins/gutenberg/phpunit.xml.dist --verbose` in 'tests-wordpress'. (in 6s 164ms)
```

The grep command looks for a match for `OK (1120 tests`, and then extracts the number from that and checks that it's more than 500. There is no match in the first two conditions, only in the third.

## Testing Instructions
I tested this script in a bash script locally, but I'll also introduce revertable commits which cause an issue in CI so we can verify.

- Passing tests: https://github.com/WordPress/gutenberg/actions/runs/4918745631/jobs/8785474793?pr=50442#step:16:24
- Failing tests: https://github.com/WordPress/gutenberg/actions/runs/4919337124/jobs/8786831880#step:14:252
- Phpunit did not run: https://github.com/WordPress/gutenberg/actions/runs/4919492452/jobs/8787184801?pr=50442#step:16:24

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
