### PR TITLE
Remove parent block selector from Block Settings Menu

### DIFF
--- a/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
@@ -1,21 +1,12 @@
 /**
  * WordPress dependencies
  */
-import {
-	getBlockType,
-	serialize,
-	store as blocksStore,
-} from '@wordpress/blocks';
+import { serialize } from '@wordpress/blocks';
 import { DropdownMenu, MenuGroup, MenuItem } from '@wordpress/components';
-import { useDispatch, useSelect } from '@wordpress/data';
+import { useSelect } from '@wordpress/data';
 import { moreVertical } from '@wordpress/icons';
-import {
-	Children,
-	cloneElement,
-	useCallback,
-	useRef,
-} from '@wordpress/element';
-import { __, sprintf } from '@wordpress/i18n';
+import { Children, cloneElement, useCallback } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
 import { store as keyboardShortcutsStore } from '@wordpress/keyboard-shortcuts';
 import { pipe, useCopyToClipboard } from '@wordpress/compose';
 
@@ -23,13 +14,11 @@ import { pipe, useCopyToClipboard } from '@wordpress/compose';
  * Internal dependencies
  */
 import BlockActions from '../block-actions';
-import BlockIcon from '../block-icon';
 import BlockModeToggle from './block-mode-toggle';
 import BlockHTMLConvertButton from './block-html-convert-button';
 import __unstableBlockSettingsMenuFirstItem from './block-settings-menu-first-item';
 import BlockSettingsMenuControls from '../block-settings-menu-controls';
 import { store as blockEditorStore } from '../../store';
-import { useShowMoversGestures } from '../block-toolbar/utils';
 
 const noop = () => {};
 const POPOVER_PROPS = {
@@ -60,9 +49,7 @@ export function BlockSettingsDropdown( {
 	const firstBlockClientId = blockClientIds[ 0 ];
 	const {
 		firstParentClientId,
-		isDistractionFree,
 		onlyBlock,
-		parentBlockType,
 		previousBlockClientId,
 		nextBlockClientId,
 		selectedBlockClientIds,
@@ -70,33 +57,18 @@ export function BlockSettingsDropdown( {
 		( select ) => {
 			const {
 				getBlockCount,
-				getBlockName,
 				getBlockRootClientId,
 				getPreviousBlockClientId,
 				getNextBlockClientId,
 				getSelectedBlockClientIds,
-				getSettings,
-				getBlockAttributes,
 			} = select( blockEditorStore );
-
-			const { getActiveBlockVariation } = select( blocksStore );
 
 			const _firstParentClientId =
 				getBlockRootClientId( firstBlockClientId );
-			const parentBlockName =
-				_firstParentClientId && getBlockName( _firstParentClientId );
 
 			return {
 				firstParentClientId: _firstParentClientId,
-				isDistractionFree: getSettings().isDistractionFree,
 				onlyBlock: 1 === getBlockCount( _firstParentClientId ),
-				parentBlockType:
-					_firstParentClientId &&
-					( getActiveBlockVariation(
-						parentBlockName,
-						getBlockAttributes( _firstParentClientId )
-					) ||
-						getBlockType( parentBlockName ) ),
 				previousBlockClientId:
 					getPreviousBlockClientId( firstBlockClientId ),
 				nextBlockClientId: getNextBlockClientId( firstBlockClientId ),
@@ -121,9 +93,6 @@ export function BlockSettingsDropdown( {
 			),
 		};
 	}, [] );
-
-	const { selectBlock, toggleBlockHighlight } =
-		useDispatch( blockEditorStore );
 
 	const updateSelectionAfterDuplicate = useCallback(
 		__experimentalSelectBlock
@@ -170,24 +139,6 @@ export function BlockSettingsDropdown( {
 	const removeBlockLabel =
 		count === 1 ? __( 'Delete' ) : __( 'Delete blocks' );
 
-	// Allows highlighting the parent block outline when focusing or hovering
-	// the parent block selector within the child.
-	const selectParentButtonRef = useRef();
-	const { gestures: showParentOutlineGestures } = useShowMoversGestures( {
-		ref: selectParentButtonRef,
-		onChange( isFocused ) {
-			if ( isFocused && isDistractionFree ) {
-				return;
-			}
-			toggleBlockHighlight( firstParentClientId, isFocused );
-		},
-	} );
-
-	// This can occur when the selected block (the parent)
-	// displays child blocks within a List View.
-	const parentBlockIsSelected =
-		selectedBlockClientIds?.includes( firstParentClientId );
-
 	return (
 		<BlockActions
 			clientIds={ clientIds }
@@ -221,33 +172,6 @@ export function BlockSettingsDropdown( {
 								<__unstableBlockSettingsMenuFirstItem.Slot
 									fillProps={ { onClose } }
 								/>
-								{ ! parentBlockIsSelected &&
-									!! firstParentClientId && (
-										<MenuItem
-											{ ...showParentOutlineGestures }
-											ref={ selectParentButtonRef }
-											icon={
-												<BlockIcon
-													icon={
-														parentBlockType.icon
-													}
-												/>
-											}
-											onClick={ () =>
-												selectBlock(
-													firstParentClientId
-												)
-											}
-										>
-											{ sprintf(
-												/* translators: %s: Name of the block's parent. */
-												__(
-													'Select parent block (%s)'
-												),
-												parentBlockType.title
-											) }
-										</MenuItem>
-									) }
 								{ count === 1 && (
 									<BlockHTMLConvertButton
 										clientId={ firstBlockClientId }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Removes the extraneous "Select parent block (blockName)" menu item from the Block Settings Dropdown. The parent selector is already available as part of the block toolbar. 

## Why?
Cleaning up and simplifying the menu in support of https://github.com/WordPress/gutenberg/issues/49271. 

## How?
Removes the relevant code for the menu item. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a Post or Page
2. Insert a Group block.
3. Insert a Heading into the Group block.
4. Select the Heading block.
5. See the "Select parent block" menu item no longer there.

## Screenshots or screencast <!-- if applicable -->

| Before  | After |
| ------------- | ------------- |
|<img width="859" alt="CleanShot 2023-05-08 at 15 45 54" src="https://user-images.githubusercontent.com/1813435/236919775-d90a1c13-d21c-4b5d-8b9e-45870f184c88.png">|<img width="855" alt="CleanShot 2023-05-08 at 15 41 09" src="https://user-images.githubusercontent.com/1813435/236919807-4ca10d5f-de96-438c-bac1-41ee38e2ad1a.png">|
