### PR TITLE
Spacing: Fix reset of spacing sizes control

### DIFF
--- a/packages/block-editor/src/components/spacing-sizes-control/spacing-input-control.js
+++ b/packages/block-editor/src/components/spacing-sizes-control/spacing-input-control.js
@@ -74,6 +74,7 @@ export default function SpacingInputControl( {
 
 	const previousValue = usePrevious( value );
 	if (
+		!! value &&
 		previousValue !== value &&
 		! isValueSpacingPreset( value ) &&
 		showCustomValueControl !== true


### PR DESCRIPTION
## What?

Fixes regression in reset of spacing sizes control which resulted in incorrect switch to custom input view for the control.

## Why?

Restores original behaviour, resetting the behaviour should leave the control in its default state.

## How?

Add a check for a defined value when determining if a change in value should result in display of the custom input.


## Testing Instructions

1. Add a group block to a post, select it and apply a padding value
2. Reset the padding control and it should display its default range control view
3. Add a spacer block, confirm you can still configure custom or preset values via the padding control
4. Confirm that when a preset padding has been applied to the spacer block and you adjust the resizable box in the editor via the drag handle, that it switches the padding control to the custom input view.

## Screenshots or screencast <!-- if applicable -->

| Before | After |
|---|---|
| <video src="https://user-images.githubusercontent.com/60436221/236993713-2171c6e3-c169-416a-9732-6e1221c3f644.mp4" /> |  <video src="https://user-images.githubusercontent.com/60436221/236993721-4c7772db-4849-437b-bfc1-0956649ec488.mp4" /> | 


