### PR TITLE
Added a check for null as well

### DIFF
--- a/packages/block-editor/src/components/use-setting/index.js
+++ b/packages/block-editor/src/components/use-setting/index.js
@@ -132,7 +132,7 @@ export default function useSetting( path ) {
 				blockName
 			);
 
-			if ( undefined !== result || null !== result ) {
+			if ( result ) {
 				return result;
 			}
 
@@ -170,7 +170,7 @@ export default function useSetting( path ) {
 							`settings.blocks.${ blockName }.${ normalizedPath }`
 						) ??
 						get( candidateAtts, `settings.${ normalizedPath }` );
-					if ( result !== undefined ) {
+					if ( result ) {
 						// Stop the search for more distant ancestors and move on.
 						break;
 					}
@@ -179,7 +179,7 @@ export default function useSetting( path ) {
 
 			// 2. Fall back to the settings from the block editor store (__experimentalFeatures).
 			const settings = select( blockEditorStore ).getSettings();
-			if ( result === undefined || result === null ) {
+			if ( ! result ) {
 				const defaultsPath = `__experimentalFeatures.${ normalizedPath }`;
 				const blockPath = `__experimentalFeatures.blocks.${ blockName }.${ normalizedPath }`;
 				result =
@@ -187,7 +187,7 @@ export default function useSetting( path ) {
 			}
 
 			// Return if the setting was found in either the block instance or the store.
-			if ( result !== undefined ) {
+			if ( result ) {
 				if ( PATHS_WITH_MERGE[ normalizedPath ] ) {
 					return result.custom ?? result.theme ?? result.default;
 				}

--- a/packages/block-editor/src/components/use-setting/index.js
+++ b/packages/block-editor/src/components/use-setting/index.js
@@ -132,7 +132,7 @@ export default function useSetting( path ) {
 				blockName
 			);
 
-			if ( undefined !== result ) {
+			if ( undefined !== result || null !== result ) {
 				return result;
 			}
 
@@ -179,7 +179,7 @@ export default function useSetting( path ) {
 
 			// 2. Fall back to the settings from the block editor store (__experimentalFeatures).
 			const settings = select( blockEditorStore ).getSettings();
-			if ( result === undefined ) {
+			if ( result === undefined || result === null ) {
 				const defaultsPath = `__experimentalFeatures.${ normalizedPath }`;
 				const blockPath = `__experimentalFeatures.blocks.${ blockName }.${ normalizedPath }`;
 				result =


### PR DESCRIPTION
## What?
This PR adds a null check to the `use-setting` component.

## Why?
Because we had the case, that a combination of a faulty `theme.json` and ACF blocks crashed the Gutenberg editor on one of customers websites - on production! -.- Tn this case the components constructor got `null` instead of `undefined` or a valid component data model. 
## How?
I added a null check as well.

## Testing Instructions
Unfortunately I have no clue how exactly we got there. However the more stable this code gets, the better - right? 

### Testing Instructions for Keyboard
n/a

