### PR TITLE
Add tests coverage for the navigation block frontend interactivity

### DIFF
--- a/packages/e2e-test-utils-playwright/src/editor/site-editor.ts
+++ b/packages/e2e-test-utils-playwright/src/editor/site-editor.ts
@@ -16,7 +16,8 @@ export async function saveSiteEditorEntities( this: Editor ) {
 	await this.page.click(
 		'role=region[name="Save panel"i] >> role=button[name="Save"i]'
 	);
-	await this.page.waitForSelector(
-		'role=region[name="Editor top bar"i] >> role=button[name="Saved"i][disabled]'
-	);
+	// A role selector cannot be used here because it needs to check that the `is-busy` class is not present.
+	await this.page.waitForSelector( '[aria-label="Saved"].is-busy', {
+		state: 'hidden',
+	} );
 }

--- a/test/e2e/specs/editor/blocks/navigation.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation.spec.js
@@ -886,7 +886,8 @@ test.describe( 'Navigation block - Frontend interactivity', () => {
 				name: 'Open menu',
 			} );
 			await expect( overlayMenuFirstElement ).toBeHidden();
-			await openMenuButton.click();
+			await openMenuButton.focus();
+			await page.keyboard.press( 'Enter' );
 			await expect( overlayMenuFirstElement ).toBeVisible();
 			await page.keyboard.press( 'Escape' );
 			await expect( overlayMenuFirstElement ).toBeHidden();
@@ -904,7 +905,8 @@ test.describe( 'Navigation block - Frontend interactivity', () => {
 				name: 'Open menu',
 			} );
 			await expect( overlayMenuFirstElement ).toBeHidden();
-			await openMenuButton.click();
+			await openMenuButton.focus();
+			await page.keyboard.press( 'Enter' );
 			await expect( overlayMenuFirstElement ).toBeVisible();
 			await expect( overlayMenuFirstElement ).toBeFocused();
 		} );
@@ -921,7 +923,8 @@ test.describe( 'Navigation block - Frontend interactivity', () => {
 				name: 'Close menu',
 			} );
 			await expect( overlayMenuFirstElement ).toBeHidden();
-			await openMenuButton.click();
+			await openMenuButton.focus();
+			await page.keyboard.press( 'Enter' );
 			await expect( overlayMenuFirstElement ).toBeVisible();
 			await expect( overlayMenuFirstElement ).toBeFocused();
 			await page.keyboard.press( 'Tab' );
@@ -1024,7 +1027,8 @@ test.describe( 'Navigation block - Frontend interactivity', () => {
 				name: 'Simple Submenu Link 1',
 			} );
 			await expect( innerElement ).toBeHidden();
-			await simpleSubmenuButton.click();
+			await simpleSubmenuButton.focus();
+			await page.keyboard.press( 'Enter' );
 			await expect( innerElement ).toBeVisible();
 			await page.keyboard.press( 'Escape' );
 			await expect( innerElement ).toBeHidden();
@@ -1043,7 +1047,8 @@ test.describe( 'Navigation block - Frontend interactivity', () => {
 				name: 'Simple Submenu Link 1',
 			} );
 			await expect( innerElement ).toBeHidden();
-			await simpleSubmenuButton.click();
+			await simpleSubmenuButton.focus();
+			await page.keyboard.press( 'Enter' );
 			await expect( innerElement ).toBeVisible();
 			// Tab to first element.
 			await page.keyboard.press( 'Tab' );
@@ -1094,7 +1099,8 @@ test.describe( 'Navigation block - Frontend interactivity', () => {
 			const secondLevelElement = page.getByRole( 'link', {
 				name: 'Nested Submenu Link 1',
 			} );
-			await complexSubmenuButton.click();
+			await complexSubmenuButton.focus();
+			await page.keyboard.press( 'Enter' );
 			await expect( firstLevelElement ).toBeVisible();
 			await expect( secondLevelElement ).toBeHidden();
 
@@ -1124,7 +1130,8 @@ test.describe( 'Navigation block - Frontend interactivity', () => {
 			const secondLevelElement = page.getByRole( 'link', {
 				name: 'Nested Submenu Link 1',
 			} );
-			await complexSubmenuButton.click();
+			await complexSubmenuButton.focus();
+			await page.keyboard.press( 'Enter' );
 			await expect( firstLevelElement ).toBeVisible();
 			await expect( secondLevelElement ).toBeHidden();
 
@@ -1287,7 +1294,8 @@ test.describe( 'Navigation block - Frontend interactivity', () => {
 				name: 'Subpage',
 			} );
 			await expect( innerElement ).toBeHidden();
-			await submenuButton.click();
+			await submenuButton.focus();
+			await page.keyboard.press( 'Enter' );
 			await expect( innerElement ).toBeVisible();
 			await page.keyboard.press( 'Escape' );
 			await expect( innerElement ).toBeHidden();
@@ -1305,7 +1313,8 @@ test.describe( 'Navigation block - Frontend interactivity', () => {
 				name: 'Subpage',
 			} );
 			await expect( innerElement ).toBeHidden();
-			await submenuButton.click();
+			await submenuButton.focus();
+			await page.keyboard.press( 'Enter' );
 			await expect( innerElement ).toBeVisible();
 			// Tab to first element.
 			await page.keyboard.press( 'Tab' );

--- a/test/e2e/specs/editor/blocks/navigation.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation.spec.js
@@ -845,42 +845,51 @@ test.describe( 'Navigation block - Frontend interactivity', () => {
 			page,
 		} ) => {
 			await page.goto( '/' );
-			const overlayMenu = page.locator(
-				'nav.wp-block-navigation div.has-modal-open'
-			);
-			const openMenuButton = page.locator( '[aria-label="Open menu"]' );
-			await expect( overlayMenu ).toBeHidden();
+			const overlayMenuFirstElement = page.getByRole( 'link', {
+				name: 'Item 1',
+			} );
+			const openMenuButton = page.getByRole( 'button', {
+				name: 'Open menu',
+			} );
+
+			await expect( overlayMenuFirstElement ).toBeHidden();
 			await openMenuButton.click();
-			await expect( overlayMenu ).toBeVisible();
+			await expect( overlayMenuFirstElement ).toBeVisible();
 		} );
 
 		test( 'overlay menu closes on click on close menu button', async ( {
 			page,
 		} ) => {
 			await page.goto( '/' );
-			const overlayMenu = page.locator(
-				'nav.wp-block-navigation div.has-modal-open'
-			);
-			const openMenuButton = page.locator( '[aria-label="Open menu"]' );
-			const closeMenuButton = page.locator( '[aria-label="Close menu"]' );
-			await expect( overlayMenu ).toBeHidden();
+			const overlayMenuFirstElement = page.getByRole( 'link', {
+				name: 'Item 1',
+			} );
+			const openMenuButton = page.getByRole( 'button', {
+				name: 'Open menu',
+			} );
+			const closeMenuButton = page.getByRole( 'button', {
+				name: 'Close menu',
+			} );
+			await expect( overlayMenuFirstElement ).toBeHidden();
 			await openMenuButton.click();
-			await expect( overlayMenu ).toBeVisible();
+			await expect( overlayMenuFirstElement ).toBeVisible();
 			await closeMenuButton.click();
-			await expect( overlayMenu ).toBeHidden();
+			await expect( overlayMenuFirstElement ).toBeHidden();
 		} );
 
 		test( 'overlay menu closes on ESC key', async ( { page } ) => {
 			await page.goto( '/' );
-			const overlayMenu = page.locator(
-				'nav.wp-block-navigation div.has-modal-open'
-			);
-			const openMenuButton = page.locator( '[aria-label="Open menu"]' );
-			await expect( overlayMenu ).toBeHidden();
+			const overlayMenuFirstElement = page.getByRole( 'link', {
+				name: 'Item 1',
+			} );
+			const openMenuButton = page.getByRole( 'button', {
+				name: 'Open menu',
+			} );
+			await expect( overlayMenuFirstElement ).toBeHidden();
 			await openMenuButton.click();
-			await expect( overlayMenu ).toBeVisible();
+			await expect( overlayMenuFirstElement ).toBeVisible();
 			await page.keyboard.press( 'Escape' );
-			await expect( overlayMenu ).toBeHidden();
+			await expect( overlayMenuFirstElement ).toBeHidden();
 			await expect( openMenuButton ).toBeFocused();
 		} );
 
@@ -888,39 +897,39 @@ test.describe( 'Navigation block - Frontend interactivity', () => {
 			page,
 		} ) => {
 			await page.goto( '/' );
-			const overlayMenu = page.locator(
-				'nav.wp-block-navigation div.has-modal-open'
-			);
-			const openMenuButton = page.locator( '[aria-label="Open menu"]' );
-			const firstItem = page.locator(
-				'ul li.wp-block-navigation-item:first-child > *:first-child'
-			);
-			await expect( overlayMenu ).toBeHidden();
+			const overlayMenuFirstElement = page.getByRole( 'link', {
+				name: 'Item 1',
+			} );
+			const openMenuButton = page.getByRole( 'button', {
+				name: 'Open menu',
+			} );
+			await expect( overlayMenuFirstElement ).toBeHidden();
 			await openMenuButton.click();
-			await expect( overlayMenu ).toBeVisible();
-			await expect( firstItem ).toBeFocused();
+			await expect( overlayMenuFirstElement ).toBeVisible();
+			await expect( overlayMenuFirstElement ).toBeFocused();
 		} );
 
 		test( 'overlay menu traps focus', async ( { page } ) => {
 			await page.goto( '/' );
-			const overlayMenu = page.locator(
-				'nav.wp-block-navigation div.has-modal-open'
-			);
-			const openMenuButton = page.locator( '[aria-label="Open menu"]' );
-			const firstItem = page.locator(
-				'ul li.wp-block-navigation-item:first-child > *:first-child'
-			);
-			const closeMenuButton = page.locator( '[aria-label="Close menu"]' );
-			await expect( overlayMenu ).toBeHidden();
+			const overlayMenuFirstElement = page.getByRole( 'link', {
+				name: 'Item 1',
+			} );
+			const openMenuButton = page.getByRole( 'button', {
+				name: 'Open menu',
+			} );
+			const closeMenuButton = page.getByRole( 'button', {
+				name: 'Close menu',
+			} );
+			await expect( overlayMenuFirstElement ).toBeHidden();
 			await openMenuButton.click();
-			await expect( overlayMenu ).toBeVisible();
-			await expect( firstItem ).toBeFocused();
+			await expect( overlayMenuFirstElement ).toBeVisible();
+			await expect( overlayMenuFirstElement ).toBeFocused();
 			await page.keyboard.press( 'Tab' );
 			await page.keyboard.press( 'Tab' );
 			await expect( closeMenuButton ).toBeFocused();
 			await page.keyboard.press( 'Shift+Tab' );
 			await page.keyboard.press( 'Shift+Tab' );
-			await expect( firstItem ).toBeFocused();
+			await expect( overlayMenuFirstElement ).toBeFocused();
 		} );
 	} );
 
@@ -957,12 +966,12 @@ test.describe( 'Navigation block - Frontend interactivity', () => {
 
 		test( 'submenu opens on click', async ( { page } ) => {
 			await page.goto( '/' );
-			const simpleSubmenuButton = page.locator(
-				'button:has-text("Simple Submenu")'
-			);
-			const innerElement = page.locator(
-				'a:has-text("Simple Submenu Link 1")'
-			);
+			const simpleSubmenuButton = page.getByRole( 'button', {
+				name: 'Simple Submenu',
+			} );
+			const innerElement = page.getByRole( 'link', {
+				name: 'Simple Submenu Link 1',
+			} );
 			await expect( innerElement ).toBeHidden();
 			await simpleSubmenuButton.click();
 			await expect( innerElement ).toBeVisible();
@@ -970,18 +979,18 @@ test.describe( 'Navigation block - Frontend interactivity', () => {
 
 		test( 'nested submenu opens on click', async ( { page } ) => {
 			await page.goto( '/' );
-			const complexSubmenuButton = page.locator(
-				'button:has-text("Complex Submenu")'
-			);
-			const nestedSubmenuButton = page.locator(
-				'button:has-text("Nested Submenu")'
-			);
-			const firstLevelElement = page.locator(
-				'a:has-text("Complex Submenu Link 1")'
-			);
-			const secondLevelElement = page.locator(
-				'a:has-text("Nested Submenu Link 1")'
-			);
+			const complexSubmenuButton = page.getByRole( 'button', {
+				name: 'Complex Submenu',
+			} );
+			const nestedSubmenuButton = page.getByRole( 'button', {
+				name: 'Nested Submenu',
+			} );
+			const firstLevelElement = page.getByRole( 'link', {
+				name: 'Complex Submenu Link 1',
+			} );
+			const secondLevelElement = page.getByRole( 'link', {
+				name: 'Nested Submenu Link 1',
+			} );
 			await complexSubmenuButton.click();
 			await expect( firstLevelElement ).toBeVisible();
 			await expect( secondLevelElement ).toBeHidden();
@@ -993,12 +1002,12 @@ test.describe( 'Navigation block - Frontend interactivity', () => {
 
 		test( 'submenu closes on click outside', async ( { page } ) => {
 			await page.goto( '/' );
-			const simpleSubmenuButton = page.locator(
-				'button:has-text("Simple Submenu")'
-			);
-			const innerElement = page.locator(
-				'a:has-text("Simple Submenu Link 1")'
-			);
+			const simpleSubmenuButton = page.getByRole( 'button', {
+				name: 'Simple Submenu',
+			} );
+			const innerElement = page.getByRole( 'link', {
+				name: 'Simple Submenu Link 1',
+			} );
 			await expect( innerElement ).toBeHidden();
 			await simpleSubmenuButton.click();
 			await expect( innerElement ).toBeVisible();
@@ -1008,12 +1017,12 @@ test.describe( 'Navigation block - Frontend interactivity', () => {
 
 		test( 'submenu closes on ESC key', async ( { page } ) => {
 			await page.goto( '/' );
-			const simpleSubmenuButton = page.locator(
-				'button:has-text("Simple Submenu")'
-			);
-			const innerElement = page.locator(
-				'a:has-text("Simple Submenu Link 1")'
-			);
+			const simpleSubmenuButton = page.getByRole( 'button', {
+				name: 'Simple Submenu',
+			} );
+			const innerElement = page.getByRole( 'link', {
+				name: 'Simple Submenu Link 1',
+			} );
 			await expect( innerElement ).toBeHidden();
 			await simpleSubmenuButton.click();
 			await expect( innerElement ).toBeVisible();
@@ -1024,15 +1033,15 @@ test.describe( 'Navigation block - Frontend interactivity', () => {
 
 		test( 'submenu closes on tab outside submenu', async ( { page } ) => {
 			await page.goto( '/' );
-			const simpleSubmenuButton = page.locator(
-				'button:has-text("Simple Submenu")'
-			);
-			const complexSubmenuButton = page.locator(
-				'button:has-text("Complex Submenu")'
-			);
-			const innerElement = page.locator(
-				'a:has-text("Simple Submenu Link 1")'
-			);
+			const simpleSubmenuButton = page.getByRole( 'button', {
+				name: 'Simple Submenu',
+			} );
+			const complexSubmenuButton = page.getByRole( 'button', {
+				name: 'Complex Submenu',
+			} );
+			const innerElement = page.getByRole( 'link', {
+				name: 'Simple Submenu Link 1',
+			} );
 			await expect( innerElement ).toBeHidden();
 			await simpleSubmenuButton.click();
 			await expect( innerElement ).toBeVisible();
@@ -1046,18 +1055,18 @@ test.describe( 'Navigation block - Frontend interactivity', () => {
 
 		test( 'nested submenu closes on click outside', async ( { page } ) => {
 			await page.goto( '/' );
-			const complexSubmenuButton = page.locator(
-				'button:has-text("Complex Submenu")'
-			);
-			const nestedSubmenuButton = page.locator(
-				'button:has-text("Nested Submenu")'
-			);
-			const firstLevelElement = page.locator(
-				'a:has-text("Complex Submenu Link 1")'
-			);
-			const secondLevelElement = page.locator(
-				'a:has-text("Nested Submenu Link 1")'
-			);
+			const complexSubmenuButton = page.getByRole( 'button', {
+				name: 'Complex Submenu',
+			} );
+			const nestedSubmenuButton = page.getByRole( 'button', {
+				name: 'Nested Submenu',
+			} );
+			const firstLevelElement = page.getByRole( 'link', {
+				name: 'Complex Submenu Link 1',
+			} );
+			const secondLevelElement = page.getByRole( 'link', {
+				name: 'Nested Submenu Link 1',
+			} );
 			await complexSubmenuButton.click();
 			await expect( firstLevelElement ).toBeVisible();
 			await expect( secondLevelElement ).toBeHidden();
@@ -1073,18 +1082,18 @@ test.describe( 'Navigation block - Frontend interactivity', () => {
 
 		test( 'nested submenu closes on ESC key', async ( { page } ) => {
 			await page.goto( '/' );
-			const complexSubmenuButton = page.locator(
-				'button:has-text("Complex Submenu")'
-			);
-			const nestedSubmenuButton = page.locator(
-				'button:has-text("Nested Submenu")'
-			);
-			const firstLevelElement = page.locator(
-				'a:has-text("Complex Submenu Link 1")'
-			);
-			const secondLevelElement = page.locator(
-				'a:has-text("Nested Submenu Link 1")'
-			);
+			const complexSubmenuButton = page.getByRole( 'button', {
+				name: 'Complex Submenu',
+			} );
+			const nestedSubmenuButton = page.getByRole( 'button', {
+				name: 'Nested Submenu',
+			} );
+			const firstLevelElement = page.getByRole( 'link', {
+				name: 'Complex Submenu Link 1',
+			} );
+			const secondLevelElement = page.getByRole( 'link', {
+				name: 'Nested Submenu Link 1',
+			} );
 			await complexSubmenuButton.click();
 			await expect( firstLevelElement ).toBeVisible();
 			await expect( secondLevelElement ).toBeHidden();
@@ -1103,18 +1112,18 @@ test.describe( 'Navigation block - Frontend interactivity', () => {
 			page,
 		} ) => {
 			await page.goto( '/' );
-			const complexSubmenuButton = page.locator(
-				'button:has-text("Complex Submenu")'
-			);
-			const nestedSubmenuButton = page.locator(
-				'button:has-text("Nested Submenu")'
-			);
-			const firstLevelElement = page.locator(
-				'a:has-text("Complex Submenu Link 1")'
-			);
-			const secondLevelElement = page.locator(
-				'a:has-text("Nested Submenu Link 1")'
-			);
+			const complexSubmenuButton = page.getByRole( 'button', {
+				name: 'Complex Submenu',
+			} );
+			const nestedSubmenuButton = page.getByRole( 'button', {
+				name: 'Nested Submenu',
+			} );
+			const firstLevelElement = page.getByRole( 'link', {
+				name: 'Complex Submenu Link 1',
+			} );
+			const secondLevelElement = page.getByRole( 'link', {
+				name: 'Nested Submenu Link 1',
+			} );
 			await complexSubmenuButton.click();
 			await expect( firstLevelElement ).toBeVisible();
 			await expect( secondLevelElement ).toBeHidden();
@@ -1162,20 +1171,18 @@ test.describe( 'Navigation block - Frontend interactivity', () => {
 
 		test( 'submenu opens on click in the arrow', async ( { page } ) => {
 			await page.goto( '/' );
-			const arrowButton = page.locator(
-				'a:has-text("Submenu") + button.wp-block-navigation__submenu-icon'
-			);
-
-			const nestedSubmenuArrowButton = page.locator(
-				'a:has-text("Nested Menu") + button.wp-block-navigation__submenu-icon'
-			);
-
-			const firstLevelElement = page.locator(
-				'a:has-text("Submenu Link")'
-			);
-			const secondLevelElement = page.locator(
-				'a:has-text("Nested Menu Link")'
-			);
+			const arrowButton = page.getByRole( 'button', {
+				name: 'Submenu submenu',
+			} );
+			const nestedSubmenuArrowButton = page.getByRole( 'button', {
+				name: 'Nested Menu submenu',
+			} );
+			const firstLevelElement = page.getByRole( 'link', {
+				name: 'Submenu Link',
+			} );
+			const secondLevelElement = page.getByRole( 'link', {
+				name: 'Nested Menu Link',
+			} );
 
 			await expect( firstLevelElement ).toBeHidden();
 			await expect( secondLevelElement ).toBeHidden();
@@ -1206,15 +1213,20 @@ test.describe( 'Navigation block - Frontend interactivity', () => {
 				title: 'Subpage',
 			} );
 			await editor.openDocumentSettingsSidebar();
-			const parentPage = page.locator( 'label:has-text("Parent page")' );
-
-			if ( await parentPage.isHidden() ) {
+			const parentPageList = page.getByLabel( 'Parent page:' );
+			if ( await parentPageList.isHidden() ) {
 				await page
-					.locator( 'button:has-text("Page Attributes")' )
+					.getByRole( 'button', {
+						name: 'Page Attributes',
+					} )
 					.click();
 			}
-			await page.locator( 'label:has-text("Parent page")' ).click();
-			await page.locator( 'li:has-text("Parent Page")' ).click();
+			await parentPageList.click();
+			await page
+				.getByRole( 'option', {
+					name: 'Parent Page',
+				} )
+				.click();
 			await editor.publishPost();
 
 			await admin.visitSiteEditor( {
@@ -1238,10 +1250,12 @@ test.describe( 'Navigation block - Frontend interactivity', () => {
 
 		test( 'page-list submenu opens on click', async ( { page } ) => {
 			await page.goto( '/' );
-			const submenuButton = page.locator(
-				'button:has-text("Parent Page")'
-			);
-			const innerElement = page.locator( 'a:has-text("Subpage")' );
+			const submenuButton = page.getByRole( 'button', {
+				name: 'Parent Page',
+			} );
+			const innerElement = page.getByRole( 'link', {
+				name: 'Subpage',
+			} );
 			await expect( innerElement ).toBeHidden();
 			await submenuButton.click();
 			await expect( innerElement ).toBeVisible();
@@ -1251,10 +1265,12 @@ test.describe( 'Navigation block - Frontend interactivity', () => {
 			page,
 		} ) => {
 			await page.goto( '/' );
-			const submenuButton = page.locator(
-				'button:has-text("Parent Page")'
-			);
-			const innerElement = page.locator( 'a:has-text("Subpage")' );
+			const submenuButton = page.getByRole( 'button', {
+				name: 'Parent Page',
+			} );
+			const innerElement = page.getByRole( 'link', {
+				name: 'Subpage',
+			} );
 			await expect( innerElement ).toBeHidden();
 			await submenuButton.click();
 			await expect( innerElement ).toBeVisible();
@@ -1264,10 +1280,12 @@ test.describe( 'Navigation block - Frontend interactivity', () => {
 
 		test( 'page-list submenu closes on ESC key', async ( { page } ) => {
 			await page.goto( '/' );
-			const submenuButton = page.locator(
-				'button:has-text("Parent Page")'
-			);
-			const innerElement = page.locator( 'a:has-text("Subpage")' );
+			const submenuButton = page.getByRole( 'button', {
+				name: 'Parent Page',
+			} );
+			const innerElement = page.getByRole( 'link', {
+				name: 'Subpage',
+			} );
 			await expect( innerElement ).toBeHidden();
 			await submenuButton.click();
 			await expect( innerElement ).toBeVisible();
@@ -1280,10 +1298,12 @@ test.describe( 'Navigation block - Frontend interactivity', () => {
 			page,
 		} ) => {
 			await page.goto( '/' );
-			const submenuButton = page.locator(
-				'button:has-text("Parent Page")'
-			);
-			const innerElement = page.locator( 'a:has-text("Subpage")' );
+			const submenuButton = page.getByRole( 'button', {
+				name: 'Parent Page',
+			} );
+			const innerElement = page.getByRole( 'link', {
+				name: 'Subpage',
+			} );
 			await expect( innerElement ).toBeHidden();
 			await submenuButton.click();
 			await expect( innerElement ).toBeVisible();

--- a/test/e2e/specs/editor/blocks/navigation.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation.spec.js
@@ -806,28 +806,22 @@ test.describe( 'Navigation block - Frontend interactivity', () => {
 	test.beforeAll( async ( { requestUtils } ) => {
 		await requestUtils.activateTheme( 'emptytheme' );
 		await requestUtils.deleteAllTemplates( 'wp_template_part' );
-	} );
-
-	test.beforeEach( async ( { requestUtils } ) => {
-		await Promise.all( [ requestUtils.deleteAllMenus() ] );
+		await requestUtils.deleteAllPages();
+		await requestUtils.deleteAllMenus();
 	} );
 
 	test.afterAll( async ( { requestUtils } ) => {
-		await Promise.all( [
-			requestUtils.deleteAllMenus(),
-			requestUtils.activateTheme( 'twentytwentyone' ),
-		] );
+		await requestUtils.activateTheme( 'twentytwentyone' );
 	} );
 
 	test.afterEach( async ( { requestUtils } ) => {
-		await requestUtils.deleteAllPosts();
-		await requestUtils.deleteAllMenus();
 		await requestUtils.deleteAllTemplates( 'wp_template_part' );
+		await requestUtils.deleteAllPages();
+		await requestUtils.deleteAllMenus();
 	} );
 
 	test.describe( 'Overlay menu', () => {
-		test.beforeEach( async ( { admin, editor, page, requestUtils } ) => {
-			await requestUtils.activateTheme( 'emptytheme' );
+		test.beforeEach( async ( { admin, editor, requestUtils } ) => {
 			await admin.visitSiteEditor( {
 				postId: 'emptytheme//header',
 				postType: 'wp_template_part',
@@ -845,12 +839,12 @@ test.describe( 'Navigation block - Frontend interactivity', () => {
 				attributes: { overlayMenu: 'always' },
 			} );
 			await editor.saveSiteEditorEntities();
-			await page.goto( '/' );
 		} );
 
 		test( 'overlay menu opens on click on open menu button', async ( {
 			page,
 		} ) => {
+			await page.goto( '/' );
 			const overlayMenu = page.locator(
 				'nav.wp-block-navigation div.has-modal-open'
 			);
@@ -863,6 +857,7 @@ test.describe( 'Navigation block - Frontend interactivity', () => {
 		test( 'overlay menu closes on click on close menu button', async ( {
 			page,
 		} ) => {
+			await page.goto( '/' );
 			const overlayMenu = page.locator(
 				'nav.wp-block-navigation div.has-modal-open'
 			);
@@ -876,6 +871,7 @@ test.describe( 'Navigation block - Frontend interactivity', () => {
 		} );
 
 		test( 'overlay menu closes on ESC key', async ( { page } ) => {
+			await page.goto( '/' );
 			const overlayMenu = page.locator(
 				'nav.wp-block-navigation div.has-modal-open'
 			);
@@ -891,6 +887,7 @@ test.describe( 'Navigation block - Frontend interactivity', () => {
 		test( 'overlay menu focuses on first element after opening', async ( {
 			page,
 		} ) => {
+			await page.goto( '/' );
 			const overlayMenu = page.locator(
 				'nav.wp-block-navigation div.has-modal-open'
 			);
@@ -905,6 +902,7 @@ test.describe( 'Navigation block - Frontend interactivity', () => {
 		} );
 
 		test( 'overlay menu traps focus', async ( { page } ) => {
+			await page.goto( '/' );
 			const overlayMenu = page.locator(
 				'nav.wp-block-navigation div.has-modal-open'
 			);
@@ -927,8 +925,7 @@ test.describe( 'Navigation block - Frontend interactivity', () => {
 	} );
 
 	test.describe( 'Submenus (Open on click)', () => {
-		test.beforeEach( async ( { admin, editor, page, requestUtils } ) => {
-			await requestUtils.activateTheme( 'emptytheme' );
+		test.beforeEach( async ( { admin, editor, requestUtils } ) => {
 			await admin.visitSiteEditor( {
 				postId: 'emptytheme//header',
 				postType: 'wp_template_part',
@@ -956,10 +953,10 @@ test.describe( 'Navigation block - Frontend interactivity', () => {
 				attributes: { overlayMenu: 'off', openSubmenusOnClick: true },
 			} );
 			await editor.saveSiteEditorEntities();
-			await page.goto( '/' );
 		} );
 
 		test( 'submenu opens on click', async ( { page } ) => {
+			await page.goto( '/' );
 			const simpleSubmenuButton = page.locator(
 				'button:has-text("Simple Submenu")'
 			);
@@ -972,6 +969,7 @@ test.describe( 'Navigation block - Frontend interactivity', () => {
 		} );
 
 		test( 'nested submenu opens on click', async ( { page } ) => {
+			await page.goto( '/' );
 			const complexSubmenuButton = page.locator(
 				'button:has-text("Complex Submenu")'
 			);
@@ -994,6 +992,7 @@ test.describe( 'Navigation block - Frontend interactivity', () => {
 		} );
 
 		test( 'submenu closes on click outside', async ( { page } ) => {
+			await page.goto( '/' );
 			const simpleSubmenuButton = page.locator(
 				'button:has-text("Simple Submenu")'
 			);
@@ -1008,6 +1007,7 @@ test.describe( 'Navigation block - Frontend interactivity', () => {
 		} );
 
 		test( 'submenu closes on ESC key', async ( { page } ) => {
+			await page.goto( '/' );
 			const simpleSubmenuButton = page.locator(
 				'button:has-text("Simple Submenu")'
 			);
@@ -1023,6 +1023,7 @@ test.describe( 'Navigation block - Frontend interactivity', () => {
 		} );
 
 		test( 'submenu closes on tab outside submenu', async ( { page } ) => {
+			await page.goto( '/' );
 			const simpleSubmenuButton = page.locator(
 				'button:has-text("Simple Submenu")'
 			);
@@ -1044,6 +1045,7 @@ test.describe( 'Navigation block - Frontend interactivity', () => {
 		} );
 
 		test( 'nested submenu closes on click outside', async ( { page } ) => {
+			await page.goto( '/' );
 			const complexSubmenuButton = page.locator(
 				'button:has-text("Complex Submenu")'
 			);
@@ -1070,6 +1072,7 @@ test.describe( 'Navigation block - Frontend interactivity', () => {
 		} );
 
 		test( 'nested submenu closes on ESC key', async ( { page } ) => {
+			await page.goto( '/' );
 			const complexSubmenuButton = page.locator(
 				'button:has-text("Complex Submenu")'
 			);
@@ -1099,6 +1102,7 @@ test.describe( 'Navigation block - Frontend interactivity', () => {
 		test( 'only nested submenu closes on tab outside', async ( {
 			page,
 		} ) => {
+			await page.goto( '/' );
 			const complexSubmenuButton = page.locator(
 				'button:has-text("Complex Submenu")'
 			);
@@ -1132,8 +1136,7 @@ test.describe( 'Navigation block - Frontend interactivity', () => {
 	} );
 
 	test.describe( 'Submenus (Arrow setting)', () => {
-		test.beforeEach( async ( { admin, editor, page, requestUtils } ) => {
-			await requestUtils.activateTheme( 'emptytheme' );
+		test.beforeEach( async ( { admin, editor, requestUtils } ) => {
 			await admin.visitSiteEditor( {
 				postId: 'emptytheme//header',
 				postType: 'wp_template_part',
@@ -1155,10 +1158,10 @@ test.describe( 'Navigation block - Frontend interactivity', () => {
 				attributes: { overlayMenu: 'off' },
 			} );
 			await editor.saveSiteEditorEntities();
-			await page.goto( '/' );
 		} );
 
 		test( 'submenu opens on click in the arrow', async ( { page } ) => {
+			await page.goto( '/' );
 			const arrowButton = page.locator(
 				'a:has-text("Submenu") + button.wp-block-navigation__submenu-icon'
 			);
@@ -1190,8 +1193,6 @@ test.describe( 'Navigation block - Frontend interactivity', () => {
 
 	test.describe( 'Page list block', () => {
 		test.beforeEach( async ( { admin, editor, page, requestUtils } ) => {
-			await requestUtils.activateTheme( 'emptytheme' );
-
 			// Create parent page.
 			await admin.createNewPost( {
 				postType: 'page',
@@ -1233,14 +1234,10 @@ test.describe( 'Navigation block - Frontend interactivity', () => {
 				attributes: { overlayMenu: 'off', openSubmenusOnClick: true },
 			} );
 			await editor.saveSiteEditorEntities();
-			await page.goto( '/' );
-		} );
-
-		test.afterEach( async ( { requestUtils } ) => {
-			await requestUtils.deleteAllPages();
 		} );
 
 		test( 'page-list submenu opens on click', async ( { page } ) => {
+			await page.goto( '/' );
 			const submenuButton = page.locator(
 				'button:has-text("Parent Page")'
 			);
@@ -1253,6 +1250,7 @@ test.describe( 'Navigation block - Frontend interactivity', () => {
 		test( 'page-list submenu closes on click outside', async ( {
 			page,
 		} ) => {
+			await page.goto( '/' );
 			const submenuButton = page.locator(
 				'button:has-text("Parent Page")'
 			);
@@ -1265,6 +1263,7 @@ test.describe( 'Navigation block - Frontend interactivity', () => {
 		} );
 
 		test( 'page-list submenu closes on ESC key', async ( { page } ) => {
+			await page.goto( '/' );
 			const submenuButton = page.locator(
 				'button:has-text("Parent Page")'
 			);
@@ -1280,6 +1279,7 @@ test.describe( 'Navigation block - Frontend interactivity', () => {
 		test( 'page-list submenu closes on tab outside submenu', async ( {
 			page,
 		} ) => {
+			await page.goto( '/' );
 			const submenuButton = page.locator(
 				'button:has-text("Parent Page")'
 			);


### PR DESCRIPTION
## What?
Adding e2e tests for testing the frontend interactivity of the navigation block and the submenus.

## Why?
Right now, most of the tests cover the editor experience of the navigation block, but there are no checks to ensure it is working properly in the frontend.

## How?
The main aspects of the implementation are:
* It is adding a new navigation menu for each test using `requestUtils.createNavigationMenu` and `editor.insertBlock`. Depending on the test, it is passing different attributes to the block.
* It modifies the `saveSiteEditorEntities` function to ensure it waits until the template parts have been saved before navigating to the frontend.

Tests are divided into mainly three parts:

1. **Overlay menu**: It tests the hamburger button that opens the overlay menu when it is enabled.
![Screenshot 2023-05-09 at 10 03 24](https://user-images.githubusercontent.com/34552881/237033562-4430e89d-f4b5-4592-95c1-72defcea8823.png)

It is testing:
* Overlay menu opens on click on "open menu" button.
* Overlay menu closes on click on "close menu" button.
* Overlay menu closes when ESC key is pressed.
* Overlay menu focuses on first element after opening.
* Overlay menu traps focus.

2. **Submenus (open on click)**: It tests the submenus when "Open on click" option is activated:
![Screenshot 2023-05-09 at 10 06 32](https://user-images.githubusercontent.com/34552881/237034241-914d35b2-117f-4134-89f4-2401c18c6cca.png)

It is testing:
* Submenu opens on click.
* Nested submenu opens on click.
* Submenu closes on click outside.
* Nested submenu closes on click outside.
* Submenu closes on ESC key.
* Nested submenu closes on ESC key
* Submenu closes on tab outside submenu.
* Only nested submenu closes on tab outside.

3. **Submenus (Arrow setting)**: It tests the submenus when "Open on click" is deactivated and "Show arrow" is activated.
![Screenshot 2023-05-09 at 10 11 22](https://user-images.githubusercontent.com/34552881/237035480-f42ed39e-c663-4d8b-b71c-0ed77587b1ad.png)

It is testing:
* Submenu opens on click in the arrow.
The rest should be covered by the previous tests.

4. **Page list block**: It is testing the Page list block, which should behave as the submenus.

For that, it is creating two pages: A Parent page and a Subpage.

It is testing:
* Page list submenu opens on click.
* Page list submenu closes on click outside.
* Page list submenu closes on ESC key.
* Page list submenu closes on tab outside submenu.

---

I tried to cover as many use cases as possible, but let me know if you are missing anything. And I am not familiar with Playwright, so feel totally free to suggest any improvements to the code.