### PR TITLE
Add the pages menu to the site editor

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen-main/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-main/index.js
@@ -6,7 +6,7 @@ import {
 	__experimentalNavigatorButton as NavigatorButton,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { layout, symbol, navigation, styles } from '@wordpress/icons';
+import { layout, symbol, navigation, styles, page } from '@wordpress/icons';
 import { useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 
@@ -76,6 +76,15 @@ export default function SidebarNavigationScreenMain() {
 							{ __( 'Styles' ) }
 						</NavigatorButton>
 					) }
+
+					<NavigatorButton
+						as={ SidebarNavigationItem }
+						path="/page"
+						withChevron
+						icon={ page }
+					>
+						{ __( 'Pages' ) }
+					</NavigatorButton>
 					<NavigatorButton
 						as={ SidebarNavigationItem }
 						path="/wp_template"

--- a/packages/edit-site/src/components/sidebar-navigation-screen-page/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-page/index.js
@@ -19,12 +19,12 @@ import { unlock } from '../../private-apis';
 import { store as editSiteStore } from '../../store';
 import SidebarButton from '../sidebar-button';
 
-export default function SidebarNavigationScreenNavigationItem() {
+export default function SidebarNavigationScreenPage() {
 	const { setCanvasMode } = unlock( useDispatch( editSiteStore ) );
 	const {
-		params: { postType, postId },
+		params: { postId },
 	} = useNavigator();
-	const { record } = useEntityRecord( 'postType', postType, postId );
+	const { record } = useEntityRecord( 'postType', 'page', postId );
 
 	return (
 		<SidebarNavigationScreen
@@ -37,7 +37,7 @@ export default function SidebarNavigationScreenNavigationItem() {
 				/>
 			}
 			description={ __(
-				'Posts are entries listed in reverse chronological order on the site homepage or on the posts page.'
+				'Pages are static and are not listed by date. Pages do not use tags or categories.'
 			) }
 			content={
 				<>

--- a/packages/edit-site/src/components/sidebar-navigation-screen-pages/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-pages/index.js
@@ -28,16 +28,13 @@ const PageItem = ( { postId, ...props } ) => {
 export default function SidebarNavigationScreenPages() {
 	const { records: pages, isResolving: isLoading } = useEntityRecords(
 		'postType',
-		'page',
-		{
-			orderby: 'date',
-		}
+		'page'
 	);
 
 	return (
 		<SidebarNavigationScreen
 			title={ __( 'Pages' ) }
-			description={ __( 'Browse and edit pages on your site' ) }
+			description={ __( 'Browse and edit pages on your site.' ) }
 			content={
 				<>
 					{ isLoading && (
@@ -66,7 +63,7 @@ export default function SidebarNavigationScreenPages() {
 									</PageItem>
 								) ) }
 								<SidebarNavigationItem
-									className="edit-site-sidebar-navigation-screen-templates__see-all"
+									className="edit-site-sidebar-navigation-screen-pages__see-all"
 									href="edit.php?post_type=page"
 									onClick={ () => {
 										document.location =

--- a/packages/edit-site/src/components/sidebar-navigation-screen-pages/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-pages/index.js
@@ -1,0 +1,85 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	__experimentalItemGroup as ItemGroup,
+	__experimentalItem as Item,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { useEntityRecords } from '@wordpress/core-data';
+import { decodeEntities } from '@wordpress/html-entities';
+
+/**
+ * Internal dependencies
+ */
+import SidebarNavigationScreen from '../sidebar-navigation-screen';
+import { useLink } from '../routes/link';
+import SidebarNavigationItem from '../sidebar-navigation-item';
+import SidebarNavigationSubtitle from '../sidebar-navigation-subtitle';
+
+const PageItem = ( { postId, ...props } ) => {
+	const linkInfo = useLink( {
+		postType: 'page',
+		postId,
+	} );
+	return <SidebarNavigationItem { ...linkInfo } { ...props } />;
+};
+
+export default function SidebarNavigationScreenPages() {
+	const { records: pages, isResolving: isLoading } = useEntityRecords(
+		'postType',
+		'page',
+		{
+			orderby: 'date',
+		}
+	);
+
+	return (
+		<SidebarNavigationScreen
+			title={ __( 'Pages' ) }
+			description={ __( 'Browse and edit pages on your site' ) }
+			content={
+				<>
+					{ isLoading && (
+						<ItemGroup>
+							<Item>{ __( 'Loading pages' ) }</Item>
+						</ItemGroup>
+					) }
+					{ ! isLoading && (
+						<>
+							<SidebarNavigationSubtitle>
+								{ __( 'Recent' ) }
+							</SidebarNavigationSubtitle>
+							<ItemGroup>
+								{ ! pages?.length && (
+									<Item>{ __( 'No page found' ) }</Item>
+								) }
+								{ pages?.map( ( page ) => (
+									<PageItem
+										postId={ page.id }
+										key={ page.id }
+										withChevron
+									>
+										{ decodeEntities(
+											page.title?.rendered
+										) ?? __( '(no title)' ) }
+									</PageItem>
+								) ) }
+								<SidebarNavigationItem
+									className="edit-site-sidebar-navigation-screen-templates__see-all"
+									href="edit.php?post_type=page"
+									onClick={ () => {
+										document.location =
+											'edit.php?post_type=page';
+									} }
+								>
+									{ __( 'Manage all pages' ) }
+								</SidebarNavigationItem>
+							</ItemGroup>
+						</>
+					) }
+				</>
+			}
+		/>
+	);
+}

--- a/packages/edit-site/src/components/sidebar-navigation-screen-pages/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-pages/style.scss
@@ -1,0 +1,4 @@
+.edit-site-sidebar-navigation-screen-pages__see-all {
+	/* Overrides the margin that comes from the Item component */
+	margin-top: $grid-unit-20 !important;
+}

--- a/packages/edit-site/src/components/sidebar-navigation-subtitle/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-subtitle/index.js
@@ -1,0 +1,5 @@
+export default function SidebarNavigationSubtitle( { children } ) {
+	return (
+		<h3 className="edit-site-sidebar-navigation-subtitle">{ children }</h3>
+	);
+}

--- a/packages/edit-site/src/components/sidebar-navigation-subtitle/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-subtitle/style.scss
@@ -1,0 +1,7 @@
+.edit-site-sidebar-navigation-subtitle {
+	color: $gray-100;
+	text-transform: uppercase;
+	font-weight: 500;
+	font-size: 11px;
+	padding: $grid-unit-20 0 0 $grid-unit-20;
+}

--- a/packages/edit-site/src/components/sidebar/index.js
+++ b/packages/edit-site/src/components/sidebar/index.js
@@ -23,6 +23,8 @@ import SidebarNavigationScreenTemplatesBrowse from '../sidebar-navigation-screen
 import SaveHub from '../save-hub';
 import SidebarNavigationScreenNavigationItem from '../sidebar-navigation-screen-navigation-item';
 import { unlock } from '../../private-apis';
+import SidebarNavigationScreenPages from '../sidebar-navigation-screen-pages';
+import SidebarNavigationScreenPage from '../sidebar-navigation-screen-page';
 
 const { useLocation } = unlock( routerPrivateApis );
 
@@ -42,6 +44,12 @@ function SidebarScreens() {
 			</NavigatorScreen>
 			<NavigatorScreen path="/navigation/:postType/:postId">
 				<SidebarNavigationScreenNavigationItem />
+			</NavigatorScreen>
+			<NavigatorScreen path="/page">
+				<SidebarNavigationScreenPages />
+			</NavigatorScreen>
+			<NavigatorScreen path="/page/:postId">
+				<SidebarNavigationScreenPage />
 			</NavigatorScreen>
 			<NavigatorScreen path="/:postType(wp_template|wp_template_part)">
 				<SidebarNavigationScreenTemplates />

--- a/packages/edit-site/src/components/sync-state-with-url/use-sync-path-with-url.js
+++ b/packages/edit-site/src/components/sync-state-with-url/use-sync-path-with-url.js
@@ -20,6 +20,7 @@ export function getPathFromURL( urlParams ) {
 		switch ( urlParams.postType ) {
 			case 'wp_template':
 			case 'wp_template_part':
+			case 'page':
 				path = `/${ encodeURIComponent(
 					urlParams.postType
 				) }/${ encodeURIComponent( urlParams.postId ) }`;

--- a/packages/edit-site/src/components/sync-state-with-url/use-sync-path-with-url.js
+++ b/packages/edit-site/src/components/sync-state-with-url/use-sync-path-with-url.js
@@ -77,6 +77,15 @@ export default function useSyncPathWithURL() {
 				postId: navigatorParams?.postId,
 				path: undefined,
 			} );
+		} else if (
+			navigatorLocation.path.startsWith( '/page/' ) &&
+			navigatorParams?.postId
+		) {
+			updateUrlParams( {
+				postType: 'page',
+				postId: navigatorParams?.postId,
+				path: undefined,
+			} );
 		} else {
 			updateUrlParams( {
 				postType: undefined,

--- a/packages/edit-site/src/style.scss
+++ b/packages/edit-site/src/style.scss
@@ -28,6 +28,7 @@
 @import "./components/sidebar-navigation-screen/style.scss";
 @import "./components/sidebar-navigation-screen-template/style.scss";
 @import "./components/sidebar-navigation-screen-templates/style.scss";
+@import "./components/sidebar-navigation-subtitle/style.scss";
 @import "./components/site-hub/style.scss";
 @import "./components/sidebar-navigation-screen-navigation-menus/style.scss";
 @import "./components/site-icon/style.scss";

--- a/packages/edit-site/src/style.scss
+++ b/packages/edit-site/src/style.scss
@@ -26,6 +26,7 @@
 @import "./components/sidebar-button/style.scss";
 @import "./components/sidebar-navigation-item/style.scss";
 @import "./components/sidebar-navigation-screen/style.scss";
+@import "./components/sidebar-navigation-screen-pages/style.scss";
 @import "./components/sidebar-navigation-screen-template/style.scss";
 @import "./components/sidebar-navigation-screen-templates/style.scss";
 @import "./components/sidebar-navigation-subtitle/style.scss";


### PR DESCRIPTION
Partially implements the "pages" menu of the site editor from https://github.com/WordPress/gutenberg/issues/44461#issuecomment-1536430171
 
## What?

To add content editing to the site editor, we need a way to access pages from the site editor, this PR bootstraps the "pages" menu item of the site editor. The current PR focuses essentially on the navigation behavior and less on the design:

 - Adds the "pages" menu item (`/page` in the sidebar navigator)
 - Moves the "single page" menu item under "pages" in the hierarchy (`/page/id` in the sidebar navigator): Side effect of this change is that when you load a page in the site editor, either from the "pages" menu or from the "navigation" menu, clicking "back" always returns to the "pages" menu item.

The pages render the latest 10 pages with a link to the wp admin page list at the bottom.

Things I chose to not include in this initial PR:

 - Hovering a page will show that page as a preview in the Frame: If we do this we should probably do it across the board (templates, template parts and pages)
 - As the Site Editor makes them editable we can include 'dynamic page' templates like Home, Search, 404, in addition to static pages. 
- Front page and Posts page are marked according to site home page settings. 
- Add page flow (https://github.com/WordPress/gutenberg/issues/48456).
- "Quick links" section pinned to the bottom of the panel includes: I added a quick link to the "manage all pages", similar to the ones we have for "templates" but decided to stick with the design of the "templates" one for now, the update to the new design should be done in its own PR.

Each one of these items should be implemented and discussed in its own PR.

## Testing Instructions

1- Open the site editor
2- Click "pages"
3- See the sidebar and use it.
