### PR TITLE
Navigation: Keep the default submenu colors unless the block sets others

### DIFF
--- a/packages/block-library/src/navigation/edit/utils.js
+++ b/packages/block-library/src/navigation/edit/utils.js
@@ -62,28 +62,38 @@ export function getColors( context, isSubMenu ) {
 
 	const colors = {};
 
-	if ( isSubMenu && !! customOverlayTextColor ) {
-		colors.customTextColor = customOverlayTextColor;
-	} else if ( isSubMenu && !! overlayTextColor ) {
-		colors.textColor = overlayTextColor;
-	} else if ( !! customTextColor ) {
-		colors.customTextColor = customTextColor;
-	} else if ( !! textColor ) {
-		colors.textColor = textColor;
-	} else if ( !! style?.color?.text ) {
-		colors.customTextColor = style.color.text;
-	}
+	if ( isSubMenu ) {
+		// Text colors
+		if ( !! customOverlayTextColor ) {
+			colors.customTextColor = customOverlayTextColor;
+		} else if ( !! overlayTextColor ) {
+			colors.textColor = overlayTextColor;
+		}
 
-	if ( isSubMenu && !! customOverlayBackgroundColor ) {
-		colors.customBackgroundColor = customOverlayBackgroundColor;
-	} else if ( isSubMenu && !! overlayBackgroundColor ) {
-		colors.backgroundColor = overlayBackgroundColor;
-	} else if ( !! customBackgroundColor ) {
-		colors.customBackgroundColor = customBackgroundColor;
-	} else if ( !! backgroundColor ) {
-		colors.backgroundColor = backgroundColor;
-	} else if ( !! style?.color?.background ) {
-		colors.customTextColor = style.color.background;
+		// Background colors
+		if ( !! customOverlayBackgroundColor ) {
+			colors.customBackgroundColor = customOverlayBackgroundColor;
+		} else if ( !! overlayBackgroundColor ) {
+			colors.backgroundColor = overlayBackgroundColor;
+		}
+	} else {
+		// Text colors
+		if ( !! customTextColor ) {
+			colors.customTextColor = customTextColor;
+		} else if ( !! textColor ) {
+			colors.textColor = textColor;
+		} else if ( !! style?.color?.text ) {
+			colors.customTextColor = style.color.text;
+		}
+
+		// Background colors
+		if ( !! customBackgroundColor ) {
+			colors.customBackgroundColor = customBackgroundColor;
+		} else if ( !! backgroundColor ) {
+			colors.backgroundColor = backgroundColor;
+		} else if ( !! style?.color?.background ) {
+			colors.customTextColor = style.color.background;
+		}
 	}
 
 	return colors;

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -160,8 +160,6 @@ $navigation-icon-size: 24px;
 // These are separated out with reduced specificity to allow better inheritance from Global Styles.
 .wp-block-navigation .has-child {
 	.wp-block-navigation__submenu-container {
-		background-color: inherit;
-		color: inherit;
 		position: absolute;
 		z-index: 2;
 		display: flex;
@@ -177,6 +175,13 @@ $navigation-icon-size: 24px;
 		width: 0;
 		height: 0;
 		overflow: hidden; // Overflow is necessary to set, otherwise submenu items will take up space.
+
+		// Set a default background color for submenus so that they're not transparent.
+		// NOTE TO DEVS - if refactoring this code, please double-check that
+		// submenus have a default background color, this feature has regressed
+		// several times, so care needs to be taken.
+		background-color: #fff;
+		color: #000;
 
 		// Submenu items.
 		> .wp-block-navigation-item {
@@ -397,15 +402,13 @@ button.wp-block-navigation-item__content {
 	}
 }
 
-// Default background and font color.
+// Default border color.
 .wp-block-navigation:not(.has-background) {
 	.wp-block-navigation__submenu-container {
-		// Set a background color for submenus so that they're not transparent.
-		// NOTE TO DEVS - if refactoring this code, please double-check that
-		// submenus have a default background color, this feature has regressed
-		// several times, so care needs to be taken.
-		background-color: #fff;
-		color: #000;
+		// Sets a border for submenus for backwards compatibility.
+		// This is under a :not selector so that if a user sets
+		// a background color the borders are removed.
+		// One day is should be possible to control this via Global Styles.
 		border: 1px solid rgba(0, 0, 0, 0.15);
 	}
 }

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -180,6 +180,7 @@ $navigation-icon-size: 24px;
 		// NOTE TO DEVS - if refactoring this code, please double-check that
 		// submenus have a default background color, this feature has regressed
 		// several times, so care needs to be taken.
+		// see also: https://github.com/WordPress/gutenberg/pull/50470
 		background-color: #fff;
 		color: #000;
 

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -408,7 +408,7 @@ button.wp-block-navigation-item__content {
 		// Sets a border for submenus for backwards compatibility.
 		// This is under a :not selector so that if a user sets
 		// a background color the borders are removed.
-		// One day is should be possible to control this via Global Styles.
+		// One day it should be possible to control this via Global Styles.
 		border: 1px solid rgba(0, 0, 0, 0.15);
 	}
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This sets default background and text colors for submenus in the navigation block, even if the navigation block has background colors set already.

## Why?
As outlined in https://github.com/WordPress/gutenberg/issues/50235, the submenus need to have a background color, even if the navigation block itself sets a color.

## How?
Remove the `:not(.has-background)` selector so that the background and text colors are always set, unless they get overridden by the block settings.

It would be nice to use `background: inherit` so that the the submenus use the same background color as the navigation. However to achieve this, every element in the cascade would need to have `background: inherit` set, which would be a lot of CSS!

## Testing Instructions
1. Add a navigation block
2. Set a background color for the block but not for the submenus/overlay
3. Open the site in the front end
4. Check that the submenus still have a background color set.

## Screenshots or screencast <!-- if applicable -->
<img width="262" alt="Screenshot 2023-05-09 at 14 44 16" src="https://github.com/WordPress/gutenberg/assets/275961/fc5f0f88-453d-4a18-a2db-4fc1225fd7ff">
