### PR TITLE
Lodash: Remove from blocks store reducer

### DIFF
--- a/packages/blocks/src/store/reducer.js
+++ b/packages/blocks/src/store/reducer.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { get, isEmpty } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { combineReducers } from '@wordpress/data';
@@ -123,13 +118,11 @@ export function blockStyles( state = {}, action ) {
 					).map( ( [ name, blockType ] ) => [
 						name,
 						getUniqueItemsByName( [
-							...get( blockType, [ 'styles' ], [] ).map(
-								( style ) => ( {
-									...style,
-									source: 'block',
-								} )
-							),
-							...get( state, [ blockType.name ], [] ).filter(
+							...( blockType.styles ?? [] ).map( ( style ) => ( {
+								...style,
+								source: 'block',
+							} ) ),
+							...( state[ blockType.name ] ?? [] ).filter(
 								( { source } ) => 'block' !== source
 							),
 						] ),
@@ -140,17 +133,15 @@ export function blockStyles( state = {}, action ) {
 			return {
 				...state,
 				[ action.blockName ]: getUniqueItemsByName( [
-					...get( state, [ action.blockName ], [] ),
+					...( state[ action.blockName ] ?? [] ),
 					...action.styles,
 				] ),
 			};
 		case 'REMOVE_BLOCK_STYLES':
 			return {
 				...state,
-				[ action.blockName ]: get(
-					state,
-					[ action.blockName ],
-					[]
+				[ action.blockName ]: (
+					state[ action.blockName ] ?? []
 				).filter(
 					( style ) => action.styleNames.indexOf( style.name ) === -1
 				),
@@ -180,13 +171,13 @@ export function blockVariations( state = {}, action ) {
 						return [
 							name,
 							getUniqueItemsByName( [
-								...get( blockType, [ 'variations' ], [] ).map(
+								...( blockType.variations ?? [] ).map(
 									( variation ) => ( {
 										...variation,
 										source: 'block',
 									} )
 								),
-								...get( state, [ blockType.name ], [] ).filter(
+								...( state[ blockType.name ] ?? [] ).filter(
 									( { source } ) => 'block' !== source
 								),
 							] ),
@@ -198,17 +189,15 @@ export function blockVariations( state = {}, action ) {
 			return {
 				...state,
 				[ action.blockName ]: getUniqueItemsByName( [
-					...get( state, [ action.blockName ], [] ),
+					...( state[ action.blockName ] ?? [] ),
 					...action.variations,
 				] ),
 			};
 		case 'REMOVE_BLOCK_VARIATIONS':
 			return {
 				...state,
-				[ action.blockName ]: get(
-					state,
-					[ action.blockName ],
-					[]
+				[ action.blockName ]: (
+					state[ action.blockName ] ?? []
 				).filter(
 					( variation ) =>
 						action.variationNames.indexOf( variation.name ) === -1
@@ -269,7 +258,10 @@ export function categories( state = DEFAULT_CATEGORIES, action ) {
 		case 'SET_CATEGORIES':
 			return action.categories || [];
 		case 'UPDATE_CATEGORY': {
-			if ( ! action.category || isEmpty( action.category ) ) {
+			if (
+				! action.category ||
+				! Object.keys( action.category ).length
+			) {
 				return state;
 			}
 			const categoryToChange = state.find(


### PR DESCRIPTION
## What?
This PR removes Lodash's `_.get()` and `_.isEmpty()` from the `@wordpress/blocks` store reducer. 

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?

We're using direct access with nullish coalescing with default values. We're using an `Object.keys().length` instead of `isEmpty()` before verifying that it's not nullish.

## Testing Instructions

* Smoke test all editors and perform various actions with blocks, block categories, block styles, and block variations.
* Verify all checks are green. The changes are covered by existing unit and e2e tests.