### PR TITLE
Update OffCanvas component's more menu to get clientId from block rather than passed in as prop

### DIFF
--- a/packages/block-editor/src/components/off-canvas-editor/leaf-more-menu.js
+++ b/packages/block-editor/src/components/off-canvas-editor/leaf-more-menu.js
@@ -88,7 +88,8 @@ function AddSubmenuItem( { block, onClose } ) {
 }
 
 export default function LeafMoreMenu( props ) {
-	const { clientId, block } = props;
+	const { block } = props;
+	const { clientId } = block;
 
 	const { moveBlocksDown, moveBlocksUp, removeBlocks } =
 		useDispatch( blockEditorStore );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
In the OffCanvas component this PR uodates the more menu of the block leaf to extract the `clientId` from the current `block` leaf, instead of having to pass the `clientId` as a prop to the more menu.

## Why?
We are removing `<OffCanvasEditor />`, and this change is necessary for several of the PRs that are part of this work. This shouldn't change the functionality of anything, but is a necessary change to move several PRs forwards so it made sense to merge it to trunk and rebase the other PRs, like:

- https://github.com/WordPress/gutenberg/pull/49417
- https://github.com/WordPress/gutenberg/pull/50287

## Testing Instructions
There should be no functional changes to anything. Purely a refactor.