### PR TITLE
[RNMobile] Disable regular blocks conversion if the reusable block is empty

### DIFF
--- a/packages/block-editor/src/components/block-mobile-toolbar/block-actions-menu.native.js
+++ b/packages/block-editor/src/components/block-mobile-toolbar/block-actions-menu.native.js
@@ -229,7 +229,9 @@ const BlockActionsMenu = ( {
 		canDuplicate && allOptions.cutButton,
 		canDuplicate && isPasteEnabled && allOptions.pasteButton,
 		canDuplicate && allOptions.duplicateButton,
-		isReusableBlockType && allOptions.convertToRegularBlocks,
+		isReusableBlockType &&
+			innerBlockCount > 0 &&
+			allOptions.convertToRegularBlocks,
 		! isLocked && allOptions.delete,
 	].filter( Boolean );
 

--- a/packages/react-native-editor/CHANGELOG.md
+++ b/packages/react-native-editor/CHANGELOG.md
@@ -10,6 +10,7 @@ For each user feature we should also add a importance categorization label  to i
 -->
 
 ## Unreleased
+-   [*] Fix crash when trying to convert to regular blocks an undefined/deleted reusable block [#50475]
 
 ## 1.94.0
 -   [*] Split pasted content between title and body. [#37169]


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/5723.

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Disables the option for converting to regular blocks a deleted reusable block in order to prevent an exception.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
This PR addresses a crash we have in the app: https://github.com/wordpress-mobile/gutenberg-mobile/issues/5723.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
We check the inner blocks count to determine if the conversion option should be displayed.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

### Conversion option is not displayed on deleted reusable blocks

1. Add an undefined reusable block. This can be done by adding the following HTML code to a post:
```
<!-- wp:block {"ref":-1} /-->
```
2. Observe that the block displays a message stating that is deleted or unavailable. 
3. Select the block.
4. Tap on the three dots button to open the block options.
5. Observe that the "Convert to regular blocks" option is not displayed.

**NOTE:** The above steps are the same as outlined in the issue being solved: https://github.com/wordpress-mobile/gutenberg-mobile/issues/5723.

### Conversion option is displayed for regular reusable blocks
1. Create a reusable block in the web version.
2. In the app, insert the reusable block.
3. Select the block.
4. Tap on the three dots button to open the block options.
5. Observe that the "Convert to regular blocks" option is displayed.
6. Tap on the option and observe that the reusable block is converted into regular blocks.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
N/A

## Screenshots or screencast <!-- if applicable -->
<img src=https://github.com/WordPress/gutenberg/assets/14905380/334553e0-a3a7-40b3-8f9c-39b381c4c9bc width=300>
