### PR TITLE
Accept transforms in gutenberg_get_global_styles context params

### DIFF
--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -3699,7 +3699,7 @@ class WP_Theme_JSON_Gutenberg {
 	 * @since 6.3.0
 	 * @param WP_Theme_JSON_Gutenberg $theme_json The theme json resolver.
 	 *
-	 * @return array The styles with the variables replaced with their values.
+	 * @return WP_Theme_JSON_Gutenberg The $theme_json with resolved variables.
 	 */
 	public static function resolve_variables( $theme_json ) {
 		$settings    = $theme_json->get_settings();
@@ -3716,7 +3716,8 @@ class WP_Theme_JSON_Gutenberg {
 			array()
 		);
 
-		return self::convert_variables_to_value( $styles, $vars );
+		$theme_json->theme_json['styles'] = self::convert_variables_to_value( $styles, $vars );
+		return $theme_json;
 	}
 
 }

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -3669,14 +3669,18 @@ class WP_Theme_JSON_Gutenberg {
 	}
 
 	/**
-	 * Get styles defined in theme.json with values for the css variables.
+	 * Resolves the values of CSS variables in the given styles.
 	 *
 	 * @since 6.3.0
-	 * @return array
+	 * @param WP_Theme_JSON_Gutenberg $theme_json The theme json resolver.
+	 *
+	 * @return array The styles with the variables replaced with their values.
 	 */
-	public function get_styles_with_values() {
-		$preset_vars = static::compute_preset_vars( self::get_settings(), static::VALID_ORIGINS );
-		$theme_vars  = static::compute_theme_vars( self::get_settings() );
+	public static function resolve_variables( $theme_json ) {
+		$settings    = $theme_json->get_settings();
+		$styles      = $theme_json->get_raw_data()['styles'];
+		$preset_vars = static::compute_preset_vars( $settings, static::VALID_ORIGINS );
+		$theme_vars  = static::compute_theme_vars( $settings );
 		$vars        = array_reduce(
 			array_merge( $preset_vars, $theme_vars ),
 			function( $carry, $item ) {
@@ -3687,7 +3691,6 @@ class WP_Theme_JSON_Gutenberg {
 			array()
 		);
 
-		$styles = self::get_raw_data()['styles'];
 		return self::convert_variables_to_value( $styles, $vars );
 	}
 

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -3659,9 +3659,20 @@ class WP_Theme_JSON_Gutenberg {
 		foreach ( $styles as $key => $style ) {
 			if ( is_array( $style ) ) {
 				$styles[ $key ] = self::convert_variables_to_value( $style, $values );
+				continue;
 			}
-			if ( is_string( $style ) && 0 === strpos( $style, 'var(' ) ) {
+
+			if ( 0 === strpos( $style, 'var(' ) ) {
 				$styles[ $key ] = isset( $values[ $style ] ) ? $values[ $style ] : $style;
+			} elseif ( 0 < strpos( $style, 'var(' ) ) { // if the variable is not the first value in the string.
+				$has_matches = preg_match_all( '/var\(([^)]+)\)/', $style, $var_parts );
+				if ( $has_matches ) {
+					$resolved_style = $styles[ $key ];
+					foreach ( $var_parts[0] as $var_part ) {
+						$resolved_style = str_replace( $var_part, isset( $values[ $var_part ] ) ? $values[ $var_part ] : $var_part, $resolved_style );
+					}
+					$styles[ $key ] = $resolved_style;
+				}
 			}
 		}
 

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -3663,14 +3663,27 @@ class WP_Theme_JSON_Gutenberg {
 			}
 
 			if ( 0 <= strpos( $style, 'var(' ) ) {
-				// find all the variables in the string in the form of var(--variable-name, fallback)
-				$has_matches = preg_match_all( '/var\(([^),]+)?(,?\s\S+)?\)/', $style, $var_parts );
+				// find all the variables in the string in the form of var(--variable-name, fallback), with fallback in the second capture group.
+
+				$has_matches = preg_match_all( '/var\(([^),]+)?,?\s?(\S+)?\)/', $style, $var_parts );
+
 				if ( $has_matches ) {
 					$resolved_style = $styles[ $key ];
 					foreach ( $var_parts[1] as $index => $var_part ) {
 						$key_in_values   = 'var(' . $var_part . ')';
-						$rule_to_replace = $var_parts[0][ $index ]; // the css rule to replace e.g. var(--wp--preset--color--vivid-green-cyan)
-						$resolved_style  = str_replace( $rule_to_replace, isset( $values[ $key_in_values ] ) ? $values[ $key_in_values ] : $rule_to_replace, $resolved_style );
+						$rule_to_replace = $var_parts[0][ $index ]; // the css rule to replace e.g. var(--wp--preset--color--vivid-green-cyan).
+						$fallback        = $var_parts[2][ $index ]; // the fallback value.
+						$resolved_style  = str_replace(
+							array(
+								$rule_to_replace,
+								$fallback,
+							),
+							array(
+								isset( $values[ $key_in_values ] ) ? $values[ $key_in_values ] : $rule_to_replace,
+								isset( $values[ $fallback ] ) ? $values[ $fallback ] : $fallback,
+							),
+							$resolved_style
+						);
 					}
 					$styles[ $key ] = $resolved_style;
 				}

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -3662,14 +3662,15 @@ class WP_Theme_JSON_Gutenberg {
 				continue;
 			}
 
-			if ( 0 === strpos( $style, 'var(' ) ) {
-				$styles[ $key ] = isset( $values[ $style ] ) ? $values[ $style ] : $style;
-			} elseif ( 0 < strpos( $style, 'var(' ) ) { // if the variable is not the first value in the string.
-				$has_matches = preg_match_all( '/var\(([^)]+)\)/', $style, $var_parts );
+			if ( 0 <= strpos( $style, 'var(' ) ) {
+				// find all the variables in the string in the form of var(--variable-name, fallback)
+				$has_matches = preg_match_all( '/var\(([^),]+)?(,?\s\S+)?\)/', $style, $var_parts );
 				if ( $has_matches ) {
 					$resolved_style = $styles[ $key ];
-					foreach ( $var_parts[0] as $var_part ) {
-						$resolved_style = str_replace( $var_part, isset( $values[ $var_part ] ) ? $values[ $var_part ] : $var_part, $resolved_style );
+					foreach ( $var_parts[1] as $index => $var_part ) {
+						$key_in_values   = 'var(' . $var_part . ')';
+						$rule_to_replace = $var_parts[0][ $index ]; // the css rule to replace e.g. var(--wp--preset--color--vivid-green-cyan)
+						$resolved_style  = str_replace( $rule_to_replace, isset( $values[ $key_in_values ] ) ? $values[ $key_in_values ] : $rule_to_replace, $resolved_style );
 					}
 					$styles[ $key ] = $resolved_style;
 				}

--- a/lib/global-styles-and-settings.php
+++ b/lib/global-styles-and-settings.php
@@ -271,11 +271,11 @@ function gutenberg_get_global_styles( $path = array(), $context = array() ) {
 	&& is_array( $context['transforms'] )
 	&& in_array( 'resolve-variables', $context['transforms'], true );
 
+	$merged_data = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data( $origin );
 	if ( $resolve_variables ) {
-		$styles = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data( $origin )->get_styles_with_values();
-	} else {
-		$styles = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data( $origin )->get_raw_data()['styles'];
+		$merged_data = WP_Theme_JSON_Gutenberg::resolve_variables( $merged_data );
 	}
+	$styles = $merged_data->get_raw_data()['styles'];
 	return _wp_array_get( $styles, $path, $styles );
 }
 

--- a/lib/global-styles-and-settings.php
+++ b/lib/global-styles-and-settings.php
@@ -238,6 +238,8 @@ add_action( 'switch_theme', '_gutenberg_clean_theme_json_caches' );
  * @since 5.9.0
  * @since 6.3.0 the internal link format "var:preset|color|secondary" is resolved
  * to "var(--wp--preset--font-size--small)" so consumers don't have to.
+ * @since 6.3.0 `transforms` is now usable in the `context` parameter. In case [`transforms`]['resolve_variables']
+ * is defined, variables are resolved to their value in the styles.
  *
  * @param array $path    Path to the specific style to retrieve. Optional.
  *                       If empty, will return all styles.
@@ -249,6 +251,9 @@ add_action( 'switch_theme', '_gutenberg_clean_theme_json_caches' );
  *     @type string $origin     Which origin to take data from.
  *                              Valid values are 'all' (core, theme, and user) or 'base' (core and theme).
  *                              If empty or unknown, 'all' is used.
+ *     @type array $transforms Which transformation(s) to apply.
+ *                              Valid value is array( 'resolve-variables' ).
+ *                              If defined, variables are resolved to their value in the styles.
  * }
  * @return array The styles to retrieve.
  */
@@ -261,8 +266,16 @@ function gutenberg_get_global_styles( $path = array(), $context = array() ) {
 	if ( isset( $context['origin'] ) && 'base' === $context['origin'] ) {
 		$origin = 'theme';
 	}
-	$styles = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data( $origin )->get_raw_data()['styles'];
 
+	$resolve_variables = isset( $context['transforms'] )
+	&& is_array( $context['transforms'] )
+	&& in_array( 'resolve-variables', $context['transforms'], true );
+
+	if ( $resolve_variables ) {
+		$styles = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data( $origin )->get_styles_with_values();
+	} else {
+		$styles = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data( $origin )->get_raw_data()['styles'];
+	}
 	return _wp_array_get( $styles, $path, $styles );
 }
 

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -2021,4 +2021,111 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 		$this->assertEquals( 'var(--wp--preset--color--s)', $styles['blocks']['core/quote']['variations']['plain']['color']['background'], 'Style variations: Assert the internal variables are convert to CSS custom variables.' );
 
 	}
+
+	public function test_resolve_variables() {
+		$primary_color   = '#9DFF20';
+		$secondary_color = '#9DFF21';
+		$contrast_color  = '#000';
+		$large_font      = '18px';
+		$small_font      = '12px';
+		$theme_json      = new WP_Theme_JSON_Gutenberg(
+			array(
+				'version'  => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+				'settings' => array(
+					'color'      => array(
+						'palette' => array(
+							'theme' => array(
+								array(
+									'color' => $primary_color,
+									'name'  => 'Primary',
+									'slug'  => 'primary',
+								),
+								array(
+									'color' => $secondary_color,
+									'name'  => 'Secondary',
+									'slug'  => 'secondary',
+								),
+								array(
+									'color' => $contrast_color,
+									'name'  => 'Contrast',
+									'slug'  => 'contrast',
+								),
+							),
+						),
+					),
+					'typography' => array(
+						'fontSizes' => array(
+							array(
+								'size' => $small_font,
+								'name' => 'Font size small',
+								'slug' => 'small',
+							),
+							array(
+								'size' => $large_font,
+								'name' => 'Font size large',
+								'slug' => 'large',
+							),
+						),
+					),
+				),
+				'styles'   => array(
+					'elements' => array(
+						'button' => array(
+							'color'      => array(
+								'text' => 'var(--wp--preset--color--contrast)',
+							),
+							'typography' => array(
+								'fontSize' => 'var(--wp--preset--font-size--small)',
+							),
+						),
+					),
+					'blocks'   => array(
+						'core/post-terms' => array(
+							'typography' => array( 'fontSize' => 'var(--wp--preset--font-size--small)' ),
+							'color'      => array( 'background' => 'var(--wp--preset--color--secondary)' ),
+						),
+						'core/navigation' => array(
+							'elements' => array(
+								'link' => array(
+									'color'      => array(
+										'background' => 'var(--wp--preset--color--primary)',
+										'text'       => 'var(--wp--preset--color--secondary)',
+									),
+									'typography' => array(
+										'fontSize' => 'var(--wp--preset--font-size--large)',
+									),
+								),
+							),
+						),
+						'core/quote'      => array(
+							'typography' => array( 'fontSize' => 'var(--wp--preset--font-size--large)' ),
+							'color'      => array( 'background' => 'var(--wp--preset--color--primary)' ),
+							'variations' => array(
+								'plain' => array(
+									'typography' => array( 'fontSize' => 'var(--wp--preset--font-size--small)' ),
+									'color'      => array( 'background' => 'var(--wp--preset--color--secondary)' ),
+								),
+							),
+						),
+					),
+				),
+			)
+		);
+
+		$styles = $theme_json->get_styles_with_values();
+
+		$this->assertEquals( $contrast_color, $styles['elements']['button']['color']['text'], 'Elements: color' );
+		$this->assertEquals( $small_font, $styles['elements']['button']['typography']['fontSize'], 'Elements: font-size' );
+
+		$this->assertEquals( $large_font, $styles['blocks']['core/quote']['typography']['fontSize'], 'Blocks: font-size' );
+		$this->assertEquals( $primary_color, $styles['blocks']['core/quote']['color']['background'], 'Blocks: color' );
+
+		$this->assertEquals( $primary_color, $styles['blocks']['core/navigation']['elements']['link']['color']['background'], 'Block element: background color' );
+		$this->assertEquals( $secondary_color, $styles['blocks']['core/navigation']['elements']['link']['color']['text'], 'Block element: text color' );
+		$this->assertEquals( $large_font, $styles['blocks']['core/navigation']['elements']['link']['typography']['fontSize'], 'Block element: font-size' );
+
+		$this->assertEquals( $small_font, $styles['blocks']['core/quote']['variations']['plain']['typography']['fontSize'], 'Block variations: font-size' );
+		$this->assertEquals( $secondary_color, $styles['blocks']['core/quote']['variations']['plain']['color']['background'], 'Block variations: color' );
+	}
+
 }

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -2094,7 +2094,17 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 							'color'      => array( 'background' => 'linear-gradient(90deg, var(--wp--preset--color--primary) 0%, var(--wp--preset--color--secondary) 35%, var(--wp--undefined--color--secondary) 100%)' ),
 						),
 						'core/comment-content' => array(
-							'typography' => array( 'fontSize' => 'calc(var(--wp--preset--font-size--small) + 20px)' ),
+							'typography' => array( 'fontSize' => 'calc(var(--wp--preset--font-size--small, 12px) + 20px)' ),
+							'color'      => array(
+								'text'       => 'var(--wp--preset--color--primary, red)',
+								'background' => 'var(--wp--preset--color--primary, var(--wp--preset--font-size--secondary))',
+								'link'       => 'var(--undefined--color--primary, var(--wp--preset--font-size--secondary))',
+							),
+						),
+						'core/comments'        => array(
+							'color' => array(
+								'text' => 'var(--undefined--color--primary, var(--wp--preset--font-size--secondary))',
+							),
 						),
 						'core/navigation'      => array(
 							'elements' => array(
@@ -2143,10 +2153,17 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 		);
 		$this->assertEquals( 'var(--undefined--font-size--small)', $styles['blocks']['core/more']['typography']['fontSize'], 'Blocks: undefined font-size ' );
 		$this->assertEquals( "calc($small_font + 20px)", $styles['blocks']['core/comment-content']['typography']['fontSize'], 'Blocks: font-size in random place' );
-
+		$this->assertEquals( $primary_color, $styles['blocks']['core/comment-content']['color']['text'], 'Blocks: text color with fallback' );
+		$this->assertEquals( $primary_color, $styles['blocks']['core/comment-content']['color']['background'], 'Blocks: background color with var as fallback' );
 		$this->assertEquals( $primary_color, $styles['blocks']['core/navigation']['elements']['link']['color']['background'], 'Block element: background color' );
 		$this->assertEquals( $secondary_color, $styles['blocks']['core/navigation']['elements']['link']['color']['text'], 'Block element: text color' );
 		$this->assertEquals( $large_font, $styles['blocks']['core/navigation']['elements']['link']['typography']['fontSize'], 'Block element: font-size' );
+
+		$this->assertEquals(
+			'var(--undefined--color--primary, var(--wp--preset--font-size--secondary))',
+			$styles['blocks']['core/comments']['color']['text'],
+			'Blocks: text color with undefined var and fallback'
+		);
 
 		$this->assertEquals( $small_font, $styles['blocks']['core/quote']['variations']['plain']['typography']['fontSize'], 'Block variations: font-size' );
 		$this->assertEquals( $secondary_color, $styles['blocks']['core/quote']['variations']['plain']['color']['background'], 'Block variations: color' );

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -2135,7 +2135,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 			)
 		);
 
-		$styles = $theme_json::resolve_variables( $theme_json );
+		$styles = $theme_json::resolve_variables( $theme_json )->get_raw_data()['styles'];
 
 		$this->assertEquals( $primary_color, $styles['color']['background'], 'Top level: Assert values are converted' );
 		$this->assertEquals( $raw_color_value, $styles['color']['text'], 'Top level: Assert raw values stay intact' );

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -2026,6 +2026,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 		$primary_color   = '#9DFF20';
 		$secondary_color = '#9DFF21';
 		$contrast_color  = '#000';
+		$raw_color_value = '#efefef';
 		$large_font      = '18px';
 		$small_font      = '12px';
 		$theme_json      = new WP_Theme_JSON_Gutenberg(
@@ -2069,6 +2070,10 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 					),
 				),
 				'styles'   => array(
+					'color'    => array(
+						'background' => 'var(--wp--preset--color--primary)',
+						'text'       => $raw_color_value,
+					),
 					'elements' => array(
 						'button' => array(
 							'color'      => array(
@@ -2082,7 +2087,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 					'blocks'   => array(
 						'core/post-terms' => array(
 							'typography' => array( 'fontSize' => 'var(--wp--preset--font-size--small)' ),
-							'color'      => array( 'background' => 'var(--wp--preset--color--secondary)' ),
+							'color'      => array( 'background' => $raw_color_value ),
 						),
 						'core/navigation' => array(
 							'elements' => array(
@@ -2114,11 +2119,16 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 
 		$styles = $theme_json->get_styles_with_values();
 
+		$this->assertEquals( $primary_color, $styles['color']['background'], 'Top level: Assert values are converted' );
+		$this->assertEquals( $raw_color_value, $styles['color']['text'], 'Top level: Assert raw values stay intact' );
+
 		$this->assertEquals( $contrast_color, $styles['elements']['button']['color']['text'], 'Elements: color' );
 		$this->assertEquals( $small_font, $styles['elements']['button']['typography']['fontSize'], 'Elements: font-size' );
 
 		$this->assertEquals( $large_font, $styles['blocks']['core/quote']['typography']['fontSize'], 'Blocks: font-size' );
 		$this->assertEquals( $primary_color, $styles['blocks']['core/quote']['color']['background'], 'Blocks: color' );
+		$this->assertEquals( $raw_color_value, $styles['blocks']['core/post-terms']['color']['background'], 'Blocks: Raw color value stays intact' );
+		$this->assertEquals( $small_font, $styles['blocks']['core/post-terms']['typography']['fontSize'], 'Block core/post-terms: font-size' );
 
 		$this->assertEquals( $primary_color, $styles['blocks']['core/navigation']['elements']['link']['color']['background'], 'Block element: background color' );
 		$this->assertEquals( $secondary_color, $styles['blocks']['core/navigation']['elements']['link']['color']['text'], 'Block element: text color' );

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -2085,11 +2085,18 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 						),
 					),
 					'blocks'   => array(
-						'core/post-terms' => array(
+						'core/post-terms'      => array(
 							'typography' => array( 'fontSize' => 'var(--wp--preset--font-size--small)' ),
 							'color'      => array( 'background' => $raw_color_value ),
 						),
-						'core/navigation' => array(
+						'core/more'            => array(
+							'typography' => array( 'fontSize' => 'var(--undefined--font-size--small)' ),
+							'color'      => array( 'background' => 'linear-gradient(90deg, var(--wp--preset--color--primary) 0%, var(--wp--preset--color--secondary) 35%, var(--wp--undefined--color--secondary) 100%)' ),
+						),
+						'core/comment-content' => array(
+							'typography' => array( 'fontSize' => 'calc(var(--wp--preset--font-size--small) + 20px)' ),
+						),
+						'core/navigation'      => array(
 							'elements' => array(
 								'link' => array(
 									'color'      => array(
@@ -2102,7 +2109,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 								),
 							),
 						),
-						'core/quote'      => array(
+						'core/quote'           => array(
 							'typography' => array( 'fontSize' => 'var(--wp--preset--font-size--large)' ),
 							'color'      => array( 'background' => 'var(--wp--preset--color--primary)' ),
 							'variations' => array(
@@ -2129,6 +2136,13 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 		$this->assertEquals( $primary_color, $styles['blocks']['core/quote']['color']['background'], 'Blocks: color' );
 		$this->assertEquals( $raw_color_value, $styles['blocks']['core/post-terms']['color']['background'], 'Blocks: Raw color value stays intact' );
 		$this->assertEquals( $small_font, $styles['blocks']['core/post-terms']['typography']['fontSize'], 'Block core/post-terms: font-size' );
+		$this->assertEquals(
+			"linear-gradient(90deg, $primary_color 0%, $secondary_color 35%, var(--wp--undefined--color--secondary) 100%)",
+			$styles['blocks']['core/more']['color']['background'],
+			'Blocks: multiple colors and undefined color'
+		);
+		$this->assertEquals( 'var(--undefined--font-size--small)', $styles['blocks']['core/more']['typography']['fontSize'], 'Blocks: undefined font-size ' );
+		$this->assertEquals( "calc($small_font + 20px)", $styles['blocks']['core/comment-content']['typography']['fontSize'], 'Blocks: font-size in random place' );
 
 		$this->assertEquals( $primary_color, $styles['blocks']['core/navigation']['elements']['link']['color']['background'], 'Block element: background color' );
 		$this->assertEquals( $secondary_color, $styles['blocks']['core/navigation']['elements']['link']['color']['text'], 'Block element: text color' );

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -2117,7 +2117,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 			)
 		);
 
-		$styles = $theme_json->get_styles_with_values();
+		$styles = $theme_json::resolve_variables( $theme_json );
 
 		$this->assertEquals( $primary_color, $styles['color']['background'], 'Top level: Assert values are converted' );
 		$this->assertEquals( $raw_color_value, $styles['color']['text'], 'Top level: Assert raw values stay intact' );

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -2103,7 +2103,8 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 						),
 						'core/comments'        => array(
 							'color' => array(
-								'text' => 'var(--undefined--color--primary, var(--wp--preset--font-size--secondary))',
+								'text'       => 'var(--undefined--color--primary, var(--wp--preset--font-size--small))',
+								'background' => 'var(--wp--preset--color--primary, var(--undefined--color--primary))',
 							),
 						),
 						'core/navigation'      => array(
@@ -2160,9 +2161,14 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 		$this->assertEquals( $large_font, $styles['blocks']['core/navigation']['elements']['link']['typography']['fontSize'], 'Block element: font-size' );
 
 		$this->assertEquals(
-			'var(--undefined--color--primary, var(--wp--preset--font-size--secondary))',
+			"var(--undefined--color--primary, $small_font)",
 			$styles['blocks']['core/comments']['color']['text'],
 			'Blocks: text color with undefined var and fallback'
+		);
+		$this->assertEquals(
+			$primary_color,
+			$styles['blocks']['core/comments']['color']['background'],
+			'Blocks: background color with variable and undefined fallback'
 		);
 
 		$this->assertEquals( $small_font, $styles['blocks']['core/quote']['variations']['plain']['typography']['fontSize'], 'Block variations: font-size' );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This PR addresses the changes explained in https://github.com/WordPress/gutenberg/issues/49712 by introducing the `transforms` to the `$context` param as form of an array, so that 
``` 
gutenberg_get_global_styles( array(), array( 
    'block_name' => 'core/post-terms',
    'transforms' => array( 'resolve-variables' ) 
    )
 );
```
returns:

```
"core/post-terms": {
    "typography": { "fontSize": "12px" }
}

```
and not the following:
```
"core/post-terms": {
    "typography": { "fontSize": "var(--wp--preset--font-size--small)" }
}
```

for a `theme.json` with the following content:

```
"core/post-terms": {
    "typography": { "fontSize": "var(--wp--preset--font-size--small)" }
}
```

## Why?
There are some usages of the `gutenberg_get_global_styles`  where the user is interested in the values of the css rules and not the variables.

## How?

Currently the acceptable value is only `resolve-variables` as in 
```
$context = array( 'transforms' => array( 'resolve-variables' ) ) 
```
and in future PRs other transforms can be added such as 
```
$context =  array( 'transforms' => array( 'resolve-references' ) )
```

## Testing Instructions
Paste the following in `functions.php` of the theme:

```
add_action( 'init', function(){
        error_log( print_r( wp_get_global_styles( array(), array('block_name'=>'core/post-terms') ), true ) );
} );
```
