### PR TITLE
Block Toolbar: Keep collapsed state when switching between the blocks

### DIFF
--- a/packages/block-editor/src/components/block-tools/block-contextual-toolbar.js
+++ b/packages/block-editor/src/components/block-tools/block-contextual-toolbar.js
@@ -117,10 +117,11 @@ function BlockContextualToolbar( { focusOnMount, isFixed, ...props } ) {
 
 	const isLargeViewport = useViewportMatch( 'medium' );
 
-	if ( blockType ) {
-		if ( ! hasBlockSupport( blockType, '__experimentalToolbar', true ) ) {
-			return null;
-		}
+	if (
+		blockType &&
+		! hasBlockSupport( blockType, '__experimentalToolbar', true )
+	) {
+		return null;
 	}
 
 	// Shifts the toolbar to make room for the parent block selector.

--- a/packages/block-editor/src/components/block-tools/block-contextual-toolbar.js
+++ b/packages/block-editor/src/components/block-tools/block-contextual-toolbar.js
@@ -110,7 +110,9 @@ function BlockContextualToolbar( { focusOnMount, isFixed, ...props } ) {
 		}, [] );
 
 	useEffect( () => {
-		setIsCollapsed( false );
+		if ( ! selectedBlockClientId ) {
+			setIsCollapsed( false );
+		}
 	}, [ selectedBlockClientId ] );
 
 	const isLargeViewport = useViewportMatch( 'medium' );


### PR DESCRIPTION
## What?
Fixes #50337.
Alternative to #50346

PR updates the `BlockContextualToolbar` component logic to keep collapsed state when switching between blocks.

## Why?
I think it makes sense to keep the user's "preference" while switching between the blocks. Also, resetting the state causes incorrect button focus.

## Testing Instructions
1. Open a Post or Page.
2. Enabled the "Top Toolbar."
3. Selected the block.
4. Collapse the block tools. Confirm that the "Show block tools" button gets the focus.
5. Switch to another block.
6. Confirm that the "block tools" stays collapsed.

## Screenshots or screencast <!-- if applicable -->

**Before**

https://github.com/WordPress/gutenberg/assets/240569/7b4ffd20-270d-4102-8a81-6ebe513eb4fa

**After**

https://github.com/WordPress/gutenberg/assets/240569/2794e754-fce9-4984-801d-b4b313a38cca

