### PR TITLE
Search Block: add button only with expandable input

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -726,7 +726,7 @@ Help visitors find your content. ([Source](https://github.com/WordPress/gutenber
 -	**Name:** core/search
 -	**Category:** widgets
 -	**Supports:** align (center, left, right), anchor, color (background, gradients, text), typography (fontSize, lineHeight), ~~html~~
--	**Attributes:** buttonPosition, buttonText, buttonUseIcon, label, placeholder, query, showLabel, width, widthUnit
+-	**Attributes:** buttonBehavior, buttonPosition, buttonText, buttonUseIcon, isSearchFieldHidden, label, placeholder, query, showLabel, width, widthUnit
 
 ## Separator
 

--- a/packages/block-library/src/search/block.json
+++ b/packages/block-library/src/search/block.json
@@ -42,6 +42,14 @@
 		"query": {
 			"type": "object",
 			"default": {}
+		},
+		"buttonBehavior": {
+			"type": "string",
+			"default": "expand-searchfield"
+		},
+		"isSearchFieldHidden": {
+			"type": "boolean",
+			"default": false
 		}
 	},
 	"supports": {
@@ -83,6 +91,7 @@
 		},
 		"html": false
 	},
+	"viewScript": "file:./view.js",
 	"editorStyle": "wp-block-search-editor",
 	"style": "wp-block-search"
 }

--- a/packages/block-library/src/search/block.json
+++ b/packages/block-library/src/search/block.json
@@ -91,7 +91,6 @@
 		},
 		"html": false
 	},
-	"viewScript": "file:./view.js",
 	"editorStyle": "wp-block-search-editor",
 	"style": "wp-block-search"
 }

--- a/packages/block-library/src/search/edit.js
+++ b/packages/block-library/src/search/edit.js
@@ -150,8 +150,9 @@ export default function SearchEdit( {
 		}
 	}, [ hasOnlyButton, isSelected, setAttributes ] );
 
+	// Show the search field when width changes.
 	useEffect( () => {
-		if ( hasOnlyButton || ! isSelected ) {
+		if ( ! hasOnlyButton || ! isSelected ) {
 			return;
 		}
 

--- a/packages/block-library/src/search/edit.js
+++ b/packages/block-library/src/search/edit.js
@@ -148,7 +148,7 @@ export default function SearchEdit( {
 				isSearchFieldHidden: true,
 			} );
 		}
-	}, [ isSelected ] );
+	}, [ hasOnlyButton, isSelected, setAttributes ] );
 
 	useEffect( () => {
 		if ( hasOnlyButton || ! isSelected ) {
@@ -158,7 +158,7 @@ export default function SearchEdit( {
 		setAttributes( {
 			isSearchFieldHidden: false,
 		} );
-	}, [ width ] );
+	}, [ hasOnlyButton, isSelected, setAttributes, width ] );
 
 	const getBlockClassNames = () => {
 		return classnames(

--- a/packages/block-library/src/search/edit.js
+++ b/packages/block-library/src/search/edit.js
@@ -19,7 +19,7 @@ import {
 	useSetting,
 } from '@wordpress/block-editor';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { useEffect } from '@wordpress/element';
+import { useEffect, useRef } from '@wordpress/element';
 import {
 	ToolbarDropdownMenu,
 	ToolbarGroup,
@@ -59,6 +59,8 @@ import {
 // button is placed inside wrapper.
 const DEFAULT_INNER_PADDING = '4px';
 
+const BUTTON_BEHAVIOR_EXPAND = 'expand-searchfield';
+
 export default function SearchEdit( {
 	className,
 	attributes,
@@ -77,6 +79,8 @@ export default function SearchEdit( {
 		buttonText,
 		buttonPosition,
 		buttonUseIcon,
+		buttonBehavior,
+		isSearchFieldHidden,
 		style,
 	} = attributes;
 
@@ -130,11 +134,31 @@ export default function SearchEdit( {
 	const isButtonPositionOutside = 'button-outside' === buttonPosition;
 	const hasNoButton = 'no-button' === buttonPosition;
 	const hasOnlyButton = 'button-only' === buttonPosition;
+	const searchFieldRef = useRef();
+	const buttonRef = useRef();
 
 	const units = useCustomUnits( {
 		availableUnits: [ '%', 'px' ],
 		defaultValues: { '%': PC_WIDTH_DEFAULT, px: PX_WIDTH_DEFAULT },
 	} );
+
+	useEffect( () => {
+		if ( hasOnlyButton && ! isSelected ) {
+			setAttributes( {
+				isSearchFieldHidden: true,
+			} );
+		}
+	}, [ isSelected ] );
+
+	useEffect( () => {
+		if ( hasOnlyButton || ! isSelected ) {
+			return;
+		}
+
+		setAttributes( {
+			isSearchFieldHidden: false,
+		} );
+	}, [ width ] );
 
 	const getBlockClassNames = () => {
 		return classnames(
@@ -152,6 +176,12 @@ export default function SearchEdit( {
 				: undefined,
 			buttonUseIcon && ! hasNoButton
 				? 'wp-block-search__icon-button'
+				: undefined,
+			hasOnlyButton && BUTTON_BEHAVIOR_EXPAND === buttonBehavior
+				? 'wp-block-search__button-behavior-expand'
+				: undefined,
+			hasOnlyButton && isSearchFieldHidden
+				? 'wp-block-search__searchfield-hidden'
 				: undefined
 		);
 	};
@@ -165,6 +195,7 @@ export default function SearchEdit( {
 			onClick: () => {
 				setAttributes( {
 					buttonPosition: 'button-outside',
+					isSearchFieldHidden: false,
 				} );
 			},
 		},
@@ -176,6 +207,7 @@ export default function SearchEdit( {
 			onClick: () => {
 				setAttributes( {
 					buttonPosition: 'button-inside',
+					isSearchFieldHidden: false,
 				} );
 			},
 		},
@@ -187,6 +219,19 @@ export default function SearchEdit( {
 			onClick: () => {
 				setAttributes( {
 					buttonPosition: 'no-button',
+					isSearchFieldHidden: false,
+				} );
+			},
+		},
+		{
+			role: 'menuitemradio',
+			title: __( 'Button Only' ),
+			isActive: buttonPosition === 'button-only',
+			icon: buttonOnly,
+			onClick: () => {
+				setAttributes( {
+					buttonPosition: 'button-only',
+					isSearchFieldHidden: true,
 				} );
 			},
 		},
@@ -247,6 +292,7 @@ export default function SearchEdit( {
 				onChange={ ( event ) =>
 					setAttributes( { placeholder: event.target.value } )
 				}
+				ref={ searchFieldRef }
 			/>
 		);
 	};
@@ -268,6 +314,13 @@ export default function SearchEdit( {
 				? { borderRadius }
 				: borderProps.style ),
 		};
+		const handleButtonClick = () => {
+			if ( hasOnlyButton && BUTTON_BEHAVIOR_EXPAND === buttonBehavior ) {
+				setAttributes( {
+					isSearchFieldHidden: ! isSearchFieldHidden,
+				} );
+			}
+		};
 
 		return (
 			<>
@@ -281,6 +334,8 @@ export default function SearchEdit( {
 								? stripHTML( buttonText )
 								: __( 'Search' )
 						}
+						onClick={ handleButtonClick }
+						ref={ buttonRef }
 					>
 						<Icon icon={ search } />
 					</button>
@@ -297,6 +352,7 @@ export default function SearchEdit( {
 						onChange={ ( html ) =>
 							setAttributes( { buttonText: html } )
 						}
+						onClick={ handleButtonClick }
 					/>
 				) }
 			</>
@@ -516,14 +572,15 @@ export default function SearchEdit( {
 				} }
 				showHandle={ isSelected }
 			>
-				{ ( isButtonPositionInside || isButtonPositionOutside ) && (
+				{ ( isButtonPositionInside ||
+					isButtonPositionOutside ||
+					hasOnlyButton ) && (
 					<>
 						{ renderTextField() }
 						{ renderButton() }
 					</>
 				) }
 
-				{ hasOnlyButton && renderButton() }
 				{ hasNoButton && renderTextField() }
 			</ResizableBox>
 		</div>

--- a/packages/block-library/src/search/editor.scss
+++ b/packages/block-library/src/search/editor.scss
@@ -18,10 +18,4 @@
 	&__components-button-group {
 		margin-top: 10px;
 	}
-
-	&.wp-block-search__button-behavior-expand {
-		.wp-block-search__input {
-			transition-duration: 300ms;
-		}
-	}
 }

--- a/packages/block-library/src/search/editor.scss
+++ b/packages/block-library/src/search/editor.scss
@@ -18,4 +18,10 @@
 	&__components-button-group {
 		margin-top: 10px;
 	}
+
+	&.wp-block-search__button-behavior-expand {
+		.wp-block-search__input {
+			transition-duration: 300ms;
+		}
+	}
 }

--- a/packages/block-library/src/search/index.php
+++ b/packages/block-library/src/search/index.php
@@ -125,8 +125,8 @@ function render_block_core_search( $attributes ) {
 					<path d="M13 5c-3.3 0-6 2.7-6 6 0 1.4.5 2.7 1.3 3.7l-3.8 3.8 1.1 1.1 3.8-3.8c1 .8 2.3 1.3 3.7 1.3 3.3 0 6-2.7 6-6S16.3 5 13 5zm0 10.5c-2.5 0-4.5-2-4.5-4.5s2-4.5 4.5-4.5 4.5 2 4.5 4.5-2 4.5-4.5 4.5z"></path>
 				</svg>';
 		}
-		if ( 'expand-searchfield' !== $attributes['buttonBehavior'] ) {
-			$button_aria = sprintf( 'aria-label="%s" aria-expanded="false" aria-controls="wp-block-search__input-%s"', __( 'Expand search form' ), esc_attr( $input_id ) );
+		if ( 'expand-searchfield' === $attributes['buttonBehavior'] ) {
+			$button_aria = sprintf( 'aria-label="%s" aria-expanded="false" aria-controls="wp-block-search__input-%s"', __( 'Expand search field' ), esc_attr( $input_id ) );
 		}
 
 		// Include the button element class.

--- a/packages/block-library/src/search/index.php
+++ b/packages/block-library/src/search/index.php
@@ -63,10 +63,12 @@ function render_block_core_search( $attributes ) {
 		);
 	}
 
-	$aria_hidden = '';
+	$aria_label    = '';
+	$aria_hidden   = '';
 	$aria_expanded = '';
 	if ( ! empty( $attributes['buttonPosition'] ) && ! empty( $attributes['buttonBehavior'] ) ) {
 		if ( 'button-only' === $attributes['buttonPosition'] && 'expand-searchfield' === $attributes['buttonBehavior'] ) {
+			$aria_label    = sprintf( 'aria-label="%s"', __( 'Expand search form' ) );
 			$aria_hidden   = 'aria-hidden="true"';
 			$aria_expanded = sprintf( ' aria-expanded="false" aria-controls="wp-block-search__input-%s"', esc_attr( $input_id ) );
 			wp_enqueue_script( 'wp-block--search-view', plugins_url( 'search/view.min.js', __FILE__ ) );
@@ -109,7 +111,6 @@ function render_block_core_search( $attributes ) {
 		if ( ! empty( $typography_classes ) ) {
 			$button_classes[] = $typography_classes;
 		}
-		$aria_label = '';
 
 		if ( ! $is_button_inside && ! empty( $border_color_classes ) ) {
 			$button_classes[] = $border_color_classes;
@@ -119,7 +120,9 @@ function render_block_core_search( $attributes ) {
 				$button_internal_markup = wp_kses_post( $attributes['buttonText'] );
 			}
 		} else {
-			$aria_label       = sprintf( 'aria-label="%s"', esc_attr( wp_strip_all_tags( $attributes['buttonText'] ) ) );
+			if ( 'expand-searchfield' != $attributes['buttonBehavior'] ) {
+				$aria_label = sprintf( 'aria-label="%s"', esc_attr( wp_strip_all_tags( $attributes['buttonText'] ) ) );
+			}
 			$button_classes[] = 'has-icon';
 
 			$button_internal_markup =

--- a/packages/block-library/src/search/index.php
+++ b/packages/block-library/src/search/index.php
@@ -63,6 +63,8 @@ function render_block_core_search( $attributes ) {
 		);
 	}
 
+	$aria_hidden = '';
+	$aria_expanded = '';
 	if ( ! empty( $attributes['buttonPosition'] ) && ! empty( $attributes['buttonBehavior'] ) ) {
 		if ( 'button-only' === $attributes['buttonPosition'] && 'expand-searchfield' === $attributes['buttonBehavior'] ) {
 			$aria_hidden   = 'aria-hidden="true"';

--- a/packages/block-library/src/search/index.php
+++ b/packages/block-library/src/search/index.php
@@ -139,7 +139,6 @@ function render_block_core_search( $attributes ) {
 		array( 'class' => $classnames )
 	);
 
-
 	if ( ! empty( $attributes['buttonPosition'] ) && ! empty( $attributes['buttonBehavior'] ) ) {
 		if ( 'button-only' === $attributes['buttonPosition'] && 'expand-searchfield' === $attributes['buttonBehavior'] ) {
 			wp_enqueue_script( 'wp-block--search-view', plugins_url( 'search/view.min.js', __FILE__ ) );
@@ -304,7 +303,6 @@ function styles_for_block_core_search( $attributes ) {
 
 	// Add width styles.
 	$has_width   = ! empty( $attributes['width'] ) && ! empty( $attributes['widthUnit'] );
-	$button_only = ! empty( $attributes['buttonPosition'] ) && 'button-only' === $attributes['buttonPosition'];
 
 	if ( $has_width ) {
 		$wrapper_styles[] = sprintf(

--- a/packages/block-library/src/search/index.php
+++ b/packages/block-library/src/search/index.php
@@ -120,7 +120,7 @@ function render_block_core_search( $attributes ) {
 				$button_internal_markup = wp_kses_post( $attributes['buttonText'] );
 			}
 		} else {
-			if ( 'expand-searchfield' != $attributes['buttonBehavior'] ) {
+			if ( 'expand-searchfield' !== $attributes['buttonBehavior'] ) {
 				$aria_label = sprintf( 'aria-label="%s"', esc_attr( wp_strip_all_tags( $attributes['buttonText'] ) ) );
 			}
 			$button_classes[] = 'has-icon';

--- a/packages/block-library/src/search/index.php
+++ b/packages/block-library/src/search/index.php
@@ -29,7 +29,6 @@ function render_block_core_search( $attributes ) {
 	$classnames          = classnames_for_block_core_search( $attributes );
 	$show_label          = ( ! empty( $attributes['showLabel'] ) ) ? true : false;
 	$use_icon_button     = ( ! empty( $attributes['buttonUseIcon'] ) ) ? true : false;
-	$show_input          = ( ! empty( $attributes['buttonPosition'] ) && 'button-only' === $attributes['buttonPosition'] ) ? false : true;
 	$show_button         = ( ! empty( $attributes['buttonPosition'] ) && 'no-button' === $attributes['buttonPosition'] ) ? false : true;
 	$query_params        = ( ! empty( $attributes['query'] ) ) ? $attributes['query'] : array();
 	$input_markup        = '';
@@ -64,23 +63,21 @@ function render_block_core_search( $attributes ) {
 		);
 	}
 
-	if ( $show_input ) {
-		$input_classes = array( 'wp-block-search__input' );
-		if ( ! $is_button_inside && ! empty( $border_color_classes ) ) {
-			$input_classes[] = $border_color_classes;
-		}
-		if ( ! empty( $typography_classes ) ) {
-			$input_classes[] = $typography_classes;
-		}
-		$input_markup = sprintf(
-			'<input type="search" id="%s" class="%s" name="s" value="%s" placeholder="%s" %s required />',
-			$input_id,
-			esc_attr( implode( ' ', $input_classes ) ),
-			get_search_query(),
-			esc_attr( $attributes['placeholder'] ),
-			$inline_styles['input']
-		);
+	$input_classes = array( 'wp-block-search__input' );
+	if ( ! $is_button_inside && ! empty( $border_color_classes ) ) {
+		$input_classes[] = $border_color_classes;
 	}
+	if ( ! empty( $typography_classes ) ) {
+		$input_classes[] = $typography_classes;
+	}
+	$input_markup = sprintf(
+		'<input type="search" id="%s" class="%s" name="s" value="%s" placeholder="%s" %s required />',
+		$input_id,
+		esc_attr( implode( ' ', $input_classes ) ),
+		get_search_query(),
+		esc_attr( $attributes['placeholder'] ),
+		$inline_styles['input']
+	);
 
 	if ( count( $query_params ) > 0 ) {
 		foreach ( $query_params as $param => $value ) {
@@ -142,6 +139,13 @@ function render_block_core_search( $attributes ) {
 		array( 'class' => $classnames )
 	);
 
+
+	if ( ! empty( $attributes['buttonPosition'] ) && ! empty( $attributes['buttonBehavior'] ) ) {
+		if ( 'button-only' === $attributes['buttonPosition'] && 'expand-searchfield' === $attributes['buttonBehavior'] ) {
+			wp_enqueue_script( 'wp-block--search-view', plugins_url( 'search/view.min.js', __FILE__ ) );
+		}
+	}
+
 	return sprintf(
 		'<form role="search" method="get" action="%s" %s>%s</form>',
 		esc_url( home_url( '/' ) ),
@@ -188,6 +192,11 @@ function classnames_for_block_core_search( $attributes ) {
 
 		if ( 'button-only' === $attributes['buttonPosition'] ) {
 			$classnames[] = 'wp-block-search__button-only';
+			if ( ! empty( $attributes['buttonBehavior'] ) ) {
+				if ( 'expand-searchfield' === $attributes['buttonBehavior'] ) {
+					$classnames[] = 'wp-block-search__button-behavior-expand';
+				}
+			}
 		}
 	}
 
@@ -297,7 +306,7 @@ function styles_for_block_core_search( $attributes ) {
 	$has_width   = ! empty( $attributes['width'] ) && ! empty( $attributes['widthUnit'] );
 	$button_only = ! empty( $attributes['buttonPosition'] ) && 'button-only' === $attributes['buttonPosition'];
 
-	if ( $has_width && ! $button_only ) {
+	if ( $has_width ) {
 		$wrapper_styles[] = sprintf(
 			'width: %d%s;',
 			esc_attr( $attributes['width'] ),

--- a/packages/block-library/src/search/index.php
+++ b/packages/block-library/src/search/index.php
@@ -191,10 +191,8 @@ function classnames_for_block_core_search( $attributes ) {
 
 		if ( 'button-only' === $attributes['buttonPosition'] ) {
 			$classnames[] = 'wp-block-search__button-only';
-			if ( ! empty( $attributes['buttonBehavior'] ) ) {
-				if ( 'expand-searchfield' === $attributes['buttonBehavior'] ) {
-					$classnames[] = 'wp-block-search__button-behavior-expand';
-				}
+			if ( ! empty( $attributes['buttonBehavior'] ) && 'expand-searchfield' === $attributes['buttonBehavior'] ) {
+				$classnames[] = 'wp-block-search__button-behavior-expand wp-block-search__searchfield-hidden';
 			}
 		}
 	}

--- a/packages/block-library/src/search/index.php
+++ b/packages/block-library/src/search/index.php
@@ -30,9 +30,13 @@ function render_block_core_search( $attributes ) {
 	$show_label          = ( ! empty( $attributes['showLabel'] ) ) ? true : false;
 	$use_icon_button     = ( ! empty( $attributes['buttonUseIcon'] ) ) ? true : false;
 	$show_button         = ( ! empty( $attributes['buttonPosition'] ) && 'no-button' === $attributes['buttonPosition'] ) ? false : true;
+	$button_position     = $show_button ? $attributes['buttonPosition'] : null;
 	$query_params        = ( ! empty( $attributes['query'] ) ) ? $attributes['query'] : array();
+	$button_behavior     = ( ! empty( $attributes['buttonBehavior'] ) ) ? $attributes['buttonBehavior'] : 'default';
 	$input_markup        = '';
 	$button_markup       = '';
+	$input_aria          = '';
+	$button_aria         = '';
 	$query_params_markup = '';
 	$inline_styles       = styles_for_block_core_search( $attributes );
 	$color_classes       = get_color_classes_for_block_core_search( $attributes );
@@ -63,16 +67,9 @@ function render_block_core_search( $attributes ) {
 		);
 	}
 
-	$aria_label    = '';
-	$aria_hidden   = '';
-	$aria_expanded = '';
-	if ( ! empty( $attributes['buttonPosition'] ) && ! empty( $attributes['buttonBehavior'] ) ) {
-		if ( 'button-only' === $attributes['buttonPosition'] && 'expand-searchfield' === $attributes['buttonBehavior'] ) {
-			$aria_label    = sprintf( 'aria-label="%s"', __( 'Expand search form' ) );
-			$aria_hidden   = 'aria-hidden="true"';
-			$aria_expanded = sprintf( ' aria-expanded="false" aria-controls="wp-block-search__input-%s"', esc_attr( $input_id ) );
-			wp_enqueue_script( 'wp-block--search-view', plugins_url( 'search/view.min.js', __FILE__ ) );
-		}
+	if ( 'button-only' === $button_position && 'expand-searchfield' === $button_behavior ) {
+		$input_aria = 'aria-hidden="true" tabindex="-1"';
+		wp_enqueue_script( 'wp-block--search-view', plugins_url( 'search/view.min.js', __FILE__ ) );
 	}
 
 	$input_classes = array( 'wp-block-search__input' );
@@ -89,7 +86,7 @@ function render_block_core_search( $attributes ) {
 		get_search_query(),
 		esc_attr( $attributes['placeholder'] ),
 		$inline_styles['input'],
-		$aria_hidden
+		$input_aria
 	);
 
 	if ( count( $query_params ) > 0 ) {
@@ -120,9 +117,7 @@ function render_block_core_search( $attributes ) {
 				$button_internal_markup = wp_kses_post( $attributes['buttonText'] );
 			}
 		} else {
-			if ( 'expand-searchfield' !== $attributes['buttonBehavior'] ) {
-				$aria_label = sprintf( 'aria-label="%s"', esc_attr( wp_strip_all_tags( $attributes['buttonText'] ) ) );
-			}
+			$button_aria      = sprintf( 'aria-label="%s"', esc_attr( wp_strip_all_tags( $attributes['buttonText'] ) ) );
 			$button_classes[] = 'has-icon';
 
 			$button_internal_markup =
@@ -130,15 +125,17 @@ function render_block_core_search( $attributes ) {
 					<path d="M13 5c-3.3 0-6 2.7-6 6 0 1.4.5 2.7 1.3 3.7l-3.8 3.8 1.1 1.1 3.8-3.8c1 .8 2.3 1.3 3.7 1.3 3.3 0 6-2.7 6-6S16.3 5 13 5zm0 10.5c-2.5 0-4.5-2-4.5-4.5s2-4.5 4.5-4.5 4.5 2 4.5 4.5-2 4.5-4.5 4.5z"></path>
 				</svg>';
 		}
+		if ( 'expand-searchfield' !== $attributes['buttonBehavior'] ) {
+			$button_aria = sprintf( 'aria-label="%s" aria-expanded="false" aria-controls="wp-block-search__input-%s"', __( 'Expand search form' ), esc_attr( $input_id ) );
+		}
 
 		// Include the button element class.
 		$button_classes[] = wp_theme_get_element_class_name( 'button' );
-		$aria_attributes  = $aria_label .= $aria_expanded;
 		$button_markup    = sprintf(
 			'<button type="submit" class="%s" %s %s>%s</button>',
 			esc_attr( implode( ' ', $button_classes ) ),
 			$inline_styles['button'],
-			$aria_attributes,
+			$button_aria,
 			$button_internal_markup
 		);
 	}

--- a/packages/block-library/src/search/index.php
+++ b/packages/block-library/src/search/index.php
@@ -133,7 +133,7 @@ function render_block_core_search( $attributes ) {
 			'<button type="submit" class="%s" %s %s>%s</button>',
 			esc_attr( implode( ' ', $button_classes ) ),
 			$inline_styles['button'],
-			$aria_label .= $aria_expanded,
+			$aria_attributes,
 			$button_internal_markup
 		);
 	}

--- a/packages/block-library/src/search/index.php
+++ b/packages/block-library/src/search/index.php
@@ -302,7 +302,7 @@ function styles_for_block_core_search( $attributes ) {
 	$show_label       = ( isset( $attributes['showLabel'] ) ) && false !== $attributes['showLabel'];
 
 	// Add width styles.
-	$has_width   = ! empty( $attributes['width'] ) && ! empty( $attributes['widthUnit'] );
+	$has_width = ! empty( $attributes['width'] ) && ! empty( $attributes['widthUnit'] );
 
 	if ( $has_width ) {
 		$wrapper_styles[] = sprintf(

--- a/packages/block-library/src/search/index.php
+++ b/packages/block-library/src/search/index.php
@@ -63,6 +63,14 @@ function render_block_core_search( $attributes ) {
 		);
 	}
 
+	if ( ! empty( $attributes['buttonPosition'] ) && ! empty( $attributes['buttonBehavior'] ) ) {
+		if ( 'button-only' === $attributes['buttonPosition'] && 'expand-searchfield' === $attributes['buttonBehavior'] ) {
+			$aria_hidden   = 'aria-hidden="true"';
+			$aria_expanded = sprintf( ' aria-expanded="false" aria-controls="wp-block-search__input-%s"', esc_attr( $input_id ) );
+			wp_enqueue_script( 'wp-block--search-view', plugins_url( 'search/view.min.js', __FILE__ ) );
+		}
+	}
+
 	$input_classes = array( 'wp-block-search__input' );
 	if ( ! $is_button_inside && ! empty( $border_color_classes ) ) {
 		$input_classes[] = $border_color_classes;
@@ -71,12 +79,13 @@ function render_block_core_search( $attributes ) {
 		$input_classes[] = $typography_classes;
 	}
 	$input_markup = sprintf(
-		'<input type="search" id="%s" class="%s" name="s" value="%s" placeholder="%s" %s required />',
+		'<input type="search" id="%s" class="%s" name="s" value="%s" placeholder="%s" %s required %s/>',
 		$input_id,
 		esc_attr( implode( ' ', $input_classes ) ),
 		get_search_query(),
 		esc_attr( $attributes['placeholder'] ),
-		$inline_styles['input']
+		$inline_styles['input'],
+		$aria_hidden
 	);
 
 	if ( count( $query_params ) > 0 ) {
@@ -119,11 +128,12 @@ function render_block_core_search( $attributes ) {
 
 		// Include the button element class.
 		$button_classes[] = wp_theme_get_element_class_name( 'button' );
+		$aria_attributes  = $aria_label .= $aria_expanded;
 		$button_markup    = sprintf(
 			'<button type="submit" class="%s" %s %s>%s</button>',
 			esc_attr( implode( ' ', $button_classes ) ),
 			$inline_styles['button'],
-			$aria_label,
+			$aria_label .= $aria_expanded,
 			$button_internal_markup
 		);
 	}
@@ -138,12 +148,6 @@ function render_block_core_search( $attributes ) {
 	$wrapper_attributes   = get_block_wrapper_attributes(
 		array( 'class' => $classnames )
 	);
-
-	if ( ! empty( $attributes['buttonPosition'] ) && ! empty( $attributes['buttonBehavior'] ) ) {
-		if ( 'button-only' === $attributes['buttonPosition'] && 'expand-searchfield' === $attributes['buttonBehavior'] ) {
-			wp_enqueue_script( 'wp-block--search-view', plugins_url( 'search/view.min.js', __FILE__ ) );
-		}
-	}
 
 	return sprintf(
 		'<form role="search" method="get" action="%s" %s>%s</form>',

--- a/packages/block-library/src/search/style.scss
+++ b/packages/block-library/src/search/style.scss
@@ -89,8 +89,7 @@ $button-spacing-y: math.div($grid-unit-15, 2); // 6px
 	}
 
 	.wp-block-search__input {
-		transition-property: all;
-		transition-duration: 0;
+		transition-duration: 300ms;
 		flex-basis: 100%;
 	}
 

--- a/packages/block-library/src/search/style.scss
+++ b/packages/block-library/src/search/style.scss
@@ -81,3 +81,43 @@ $button-spacing-y: math.div($grid-unit-15, 2); // 6px
 .wp-block-search.aligncenter .wp-block-search__inside-wrapper {
 	margin: auto;
 }
+
+.wp-block-search__button-behavior-expand {
+	.wp-block-search__inside-wrapper {
+		transition-property: width;
+		min-width: 0 !important;
+	}
+
+	.wp-block-search__input {
+		transition-property: all;
+		transition-duration: 0;
+		flex-basis: 100%;
+	}
+
+	// !important here to override inline styles on button only deselected view.
+	&.wp-block-search__searchfield-hidden {
+		overflow: hidden;
+
+		.wp-block-search__inside-wrapper {
+			overflow: hidden;
+		}
+
+		.wp-block-search__input {
+			width: 0 !important;
+			min-width: 0 !important;
+			padding-left: 0 !important;
+			padding-right: 0 !important;
+			border-left-width: 0 !important;
+			border-right-width: 0 !important;
+			flex-grow: 0;
+			margin: 0;
+			flex-basis: 0;
+		}
+	}
+}
+
+.wp-block[data-align="right"] .wp-block-search__button-behavior-expand {
+	.wp-block-search__inside-wrapper {
+		float: right;
+	}
+}

--- a/packages/block-library/src/search/view.js
+++ b/packages/block-library/src/search/view.js
@@ -18,11 +18,13 @@ window.addEventListener( 'DOMContentLoaded', () => {
 				searchField.removeAttribute( 'tabindex' );
 				searchButton.removeAttribute( 'aria-expanded' );
 				searchButton.removeAttribute( 'aria-controls' );
-				searchButton.removeAttribute( 'aria-label' );
+				searchButton.setAttribute( 'type', 'submit' );
+				searchButton.setAttribute( 'aria-label', 'Submit Search' );
 
 				return block.classList.remove( hiddenClass );
 			}
 
+			searchButton.removeAttribute( 'type' );
 			searchField.setAttribute( 'aria-hidden', 'true' );
 			searchField.setAttribute( 'tabindex', '-1' );
 			searchButton.setAttribute( 'aria-expanded', 'false' );
@@ -50,10 +52,14 @@ window.addEventListener( 'DOMContentLoaded', () => {
 			}
 		};
 
+		searchButton.removeAttribute( 'type' );
 		searchField.addEventListener( 'keydown', ( e ) => {
 			hideSearchField( e );
 		} );
 		searchButton.addEventListener( 'click', handleButtonClick );
+		searchButton.addEventListener( 'keydown', ( e ) => {
+			hideSearchField( e );
+		} );
 		searchLabel.addEventListener( 'click', handleButtonClick );
 		document.body.addEventListener( 'click', hideSearchField );
 	} );

--- a/packages/block-library/src/search/view.js
+++ b/packages/block-library/src/search/view.js
@@ -12,9 +12,14 @@ window.addEventListener( 'DOMContentLoaded', () => {
 
 		const toggleSearchField = ( showSearchField ) => {
 			if ( showSearchField ) {
+				searchField.setAttribute( 'aria-hidden', 'false' );
+				searchButton.setAttribute( 'aria-expanded', 'true' );
+
 				return block.classList.remove( hiddenClass );
 			}
 
+			searchField.setAttribute( 'aria-hidden', 'true' );
+			searchButton.setAttribute( 'aria-expanded', 'false' );
 			return block.classList.add( hiddenClass );
 		};
 

--- a/packages/block-library/src/search/view.js
+++ b/packages/block-library/src/search/view.js
@@ -20,17 +20,15 @@ window.addEventListener( 'DOMContentLoaded', () => {
 
 		const hideSearchField = ( e ) => {
 			if (
-				e.type === 'blur' &&
-				( e.relatedTarget !== searchButton ||
-					e.target === searchButton )
-			) {
-				return toggleSearchField( false );
-			}
-			if (
 				! e.target.closest( '.wp-block-search__inside-wrapper' ) &&
 				activeElement !== searchButton &&
 				activeElement !== searchField
 			) {
+				return toggleSearchField( false );
+			}
+
+			if ( e.key === 'Escape' ) {
+				searchButton.focus();
 				return toggleSearchField( false );
 			}
 		};
@@ -39,15 +37,15 @@ window.addEventListener( 'DOMContentLoaded', () => {
 			if ( block.classList.contains( hiddenClass ) ) {
 				e.preventDefault();
 				searchField.focus();
+				toggleSearchField( true );
 			}
 		};
 
-		searchField.addEventListener( 'focus', () =>
-			toggleSearchField( true )
-		);
 		searchField.addEventListener( 'blur', hideSearchField );
+		searchField.addEventListener( 'keydown', ( e ) => {
+			hideSearchField( e );
+		} );
 		searchButton.addEventListener( 'click', handleButtonClick );
-		searchButton.addEventListener( 'blur', hideSearchField );
 		document.body.addEventListener( 'click', hideSearchField );
 	} );
 } );

--- a/packages/block-library/src/search/view.js
+++ b/packages/block-library/src/search/view.js
@@ -10,16 +10,23 @@ window.addEventListener( 'DOMContentLoaded', () => {
 		const searchButton = block.querySelector( '.wp-block-search__button' );
 		const activeElement = block.ownerDocument.activeElement;
 
+		const ariaLabel = searchButton.getAttribute( 'aria-label' );
+		const id = searchField.getAttribute( 'id' );
+
 		const toggleSearchField = ( showSearchField ) => {
 			if ( showSearchField ) {
 				searchField.setAttribute( 'aria-hidden', 'false' );
-				searchButton.setAttribute( 'aria-expanded', 'true' );
+				searchButton.removeAttribute( 'aria-expanded' );
+				searchButton.removeAttribute( 'aria-controls' );
+				searchButton.removeAttribute( 'aria-label' );
 
 				return block.classList.remove( hiddenClass );
 			}
 
 			searchField.setAttribute( 'aria-hidden', 'true' );
 			searchButton.setAttribute( 'aria-expanded', 'false' );
+			searchButton.setAttribute( 'aria-controls', id );
+			searchButton.setAttribute( 'aria-label', ariaLabel );
 			return block.classList.add( hiddenClass );
 		};
 

--- a/packages/block-library/src/search/view.js
+++ b/packages/block-library/src/search/view.js
@@ -1,0 +1,61 @@
+window.addEventListener( 'DOMContentLoaded', () => {
+	const transitionDuration = 300;
+	const hiddenClass = 'wp-block-search__searchfield-hidden';
+	const wrapperClass = '.wp-block-search__inside-wrapper';
+	const buttonClass = '.wp-block-search__button';
+
+	Array.from(
+		document.getElementsByClassName(
+			'wp-block-search__button-behavior-expand'
+		)
+	).forEach( ( block ) => {
+		const wrapper = block.querySelector( wrapperClass );
+		const searchField = block.querySelector( '.wp-block-search__input' );
+		const button = block.querySelector( buttonClass );
+
+		// Hide search on init.
+		block.classList.add( hiddenClass );
+		setTimeout(
+			() =>
+				( searchField.style.transitionDuration = `${ transitionDuration }ms` ),
+			transitionDuration
+		);
+
+		const toggleSearchField = ( e ) => {
+			if ( e.target !== button && ! e.target.closest( buttonClass ) ) {
+				return false;
+			}
+
+			e.preventDefault();
+
+			return block.classList.contains( hiddenClass )
+				? doShowSearchField()
+				: doHideSearchField();
+		};
+
+		const doShowSearchField = () => {
+			block.classList.remove( hiddenClass );
+			searchField.focus();
+
+			wrapper.removeEventListener( 'click', toggleSearchField );
+			document.body.addEventListener( 'click', doSearch );
+		};
+
+		const doHideSearchField = () => {
+			block.classList.add( hiddenClass );
+		};
+
+		const doSearch = ( e ) => {
+			if ( e.target.closest( wrapperClass ) ) {
+				return false;
+			}
+
+			doHideSearchField();
+
+			document.body.removeEventListener( 'click', doSearch );
+			wrapper.addEventListener( 'click', toggleSearchField );
+		};
+
+		wrapper.addEventListener( 'click', toggleSearchField );
+	} );
+} );

--- a/packages/block-library/src/search/view.js
+++ b/packages/block-library/src/search/view.js
@@ -1,42 +1,53 @@
 window.addEventListener( 'DOMContentLoaded', () => {
 	const hiddenClass = 'wp-block-search__searchfield-hidden';
-	const wrapperClass = '.wp-block-search__inside-wrapper';
-	const buttonClass = '.wp-block-search__button';
 
 	Array.from(
 		document.getElementsByClassName(
 			'wp-block-search__button-behavior-expand'
 		)
 	).forEach( ( block ) => {
-		const wrapper = block.querySelector( wrapperClass );
 		const searchField = block.querySelector( '.wp-block-search__input' );
-		const button = block.querySelector( buttonClass );
+		const searchButton = block.querySelector( '.wp-block-search__button' );
+		const activeElement = block.ownerDocument.activeElement;
 
-		const toggleSearchField = ( e ) => {
-			if ( e.target !== button && ! e.target.closest( buttonClass ) ) {
-				return false;
+		const toggleSearchField = ( showSearchField ) => {
+			if ( showSearchField ) {
+				return block.classList.remove( hiddenClass );
 			}
 
-			e.preventDefault();
-
-			return block.classList.contains( hiddenClass )
-				? doShowSearchField()
-				: doHideSearchField();
+			return block.classList.add( hiddenClass );
 		};
 
-		const doShowSearchField = () => {
-			block.classList.remove( hiddenClass );
-			searchField.focus();
-
-			wrapper.removeEventListener( 'click', toggleSearchField );
-			button.addEventListener( 'blur', toggleSearchField );
-			document.body.addEventListener( 'click', doHideSearchField );
+		const hideSearchField = ( e ) => {
+			if (
+				e.type === 'blur' &&
+				( e.relatedTarget !== searchButton ||
+					e.target === searchButton )
+			) {
+				return toggleSearchField( false );
+			}
+			if (
+				! e.target.closest( '.wp-block-search__inside-wrapper' ) &&
+				activeElement !== searchButton &&
+				activeElement !== searchField
+			) {
+				return toggleSearchField( false );
+			}
 		};
 
-		const doHideSearchField = () => {
-			block.classList.add( hiddenClass );
+		const handleButtonClick = ( e ) => {
+			if ( block.classList.contains( hiddenClass ) ) {
+				e.preventDefault();
+				searchField.focus();
+			}
 		};
 
-		searchField.addEventListener( 'focus', doShowSearchField );
+		searchField.addEventListener( 'focus', () =>
+			toggleSearchField( true )
+		);
+		searchField.addEventListener( 'blur', hideSearchField );
+		searchButton.addEventListener( 'click', handleButtonClick );
+		searchButton.addEventListener( 'blur', hideSearchField );
+		document.body.addEventListener( 'click', hideSearchField );
 	} );
 } );

--- a/packages/block-library/src/search/view.js
+++ b/packages/block-library/src/search/view.js
@@ -12,9 +12,6 @@ window.addEventListener( 'DOMContentLoaded', () => {
 		const searchField = block.querySelector( '.wp-block-search__input' );
 		const button = block.querySelector( buttonClass );
 
-		// Hide search on init.
-		block.classList.add( hiddenClass );
-
 		const toggleSearchField = ( e ) => {
 			if ( e.target !== button && ! e.target.closest( buttonClass ) ) {
 				return false;
@@ -32,27 +29,14 @@ window.addEventListener( 'DOMContentLoaded', () => {
 			searchField.focus();
 
 			wrapper.removeEventListener( 'click', toggleSearchField );
-			button.removeEventListener( 'focus', toggleSearchField );
-			document.body.addEventListener( 'click', doSearch );
+			button.addEventListener( 'blur', toggleSearchField );
+			document.body.addEventListener( 'click', doHideSearchField );
 		};
 
 		const doHideSearchField = () => {
 			block.classList.add( hiddenClass );
 		};
 
-		const doSearch = ( e ) => {
-			if ( e.target.closest( wrapperClass ) ) {
-				return false;
-			}
-
-			doHideSearchField();
-
-			document.body.removeEventListener( 'click', doSearch );
-			wrapper.addEventListener( 'click', toggleSearchField );
-			button.addEventListener( 'focus', toggleSearchField );
-		};
-
-		wrapper.addEventListener( 'click', toggleSearchField );
-		button.addEventListener( 'focus', toggleSearchField );
+		searchField.addEventListener( 'focus', doShowSearchField );
 	} );
 } );

--- a/packages/block-library/src/search/view.js
+++ b/packages/block-library/src/search/view.js
@@ -15,7 +15,8 @@ window.addEventListener( 'DOMContentLoaded', () => {
 
 		const toggleSearchField = ( showSearchField ) => {
 			if ( showSearchField ) {
-				searchField.setAttribute( 'aria-hidden', 'false' );
+				searchField.removeAttribute( 'aria-hidden' );
+				searchField.removeAttribute( 'tabindex' );
 				searchButton.removeAttribute( 'aria-expanded' );
 				searchButton.removeAttribute( 'aria-controls' );
 				searchButton.removeAttribute( 'aria-label' );
@@ -24,6 +25,7 @@ window.addEventListener( 'DOMContentLoaded', () => {
 			}
 
 			searchField.setAttribute( 'aria-hidden', 'true' );
+			searchField.setAttribute( 'tabindex', '-1' );
 			searchButton.setAttribute( 'aria-expanded', 'false' );
 			searchButton.setAttribute( 'aria-controls', id );
 			searchButton.setAttribute( 'aria-label', ariaLabel );

--- a/packages/block-library/src/search/view.js
+++ b/packages/block-library/src/search/view.js
@@ -1,5 +1,4 @@
 window.addEventListener( 'DOMContentLoaded', () => {
-	const transitionDuration = 300;
 	const hiddenClass = 'wp-block-search__searchfield-hidden';
 	const wrapperClass = '.wp-block-search__inside-wrapper';
 	const buttonClass = '.wp-block-search__button';
@@ -15,11 +14,6 @@ window.addEventListener( 'DOMContentLoaded', () => {
 
 		// Hide search on init.
 		block.classList.add( hiddenClass );
-		setTimeout(
-			() =>
-				( searchField.style.transitionDuration = `${ transitionDuration }ms` ),
-			transitionDuration
-		);
 
 		const toggleSearchField = ( e ) => {
 			if ( e.target !== button && ! e.target.closest( buttonClass ) ) {
@@ -38,6 +32,7 @@ window.addEventListener( 'DOMContentLoaded', () => {
 			searchField.focus();
 
 			wrapper.removeEventListener( 'click', toggleSearchField );
+			button.removeEventListener( 'focus', toggleSearchField );
 			document.body.addEventListener( 'click', doSearch );
 		};
 
@@ -54,8 +49,10 @@ window.addEventListener( 'DOMContentLoaded', () => {
 
 			document.body.removeEventListener( 'click', doSearch );
 			wrapper.addEventListener( 'click', toggleSearchField );
+			button.addEventListener( 'focus', toggleSearchField );
 		};
 
 		wrapper.addEventListener( 'click', toggleSearchField );
+		button.addEventListener( 'focus', toggleSearchField );
 	} );
 } );

--- a/packages/block-library/src/search/view.js
+++ b/packages/block-library/src/search/view.js
@@ -8,8 +8,7 @@ window.addEventListener( 'DOMContentLoaded', () => {
 	).forEach( ( block ) => {
 		const searchField = block.querySelector( '.wp-block-search__input' );
 		const searchButton = block.querySelector( '.wp-block-search__button' );
-		const activeElement = block.ownerDocument.activeElement;
-
+		const searchLabel = block.querySelector( '.wp-block-search__label' );
 		const ariaLabel = searchButton.getAttribute( 'aria-label' );
 		const id = searchField.getAttribute( 'id' );
 
@@ -33,11 +32,7 @@ window.addEventListener( 'DOMContentLoaded', () => {
 		};
 
 		const hideSearchField = ( e ) => {
-			if (
-				! e.target.closest( '.wp-block-search__inside-wrapper' ) &&
-				activeElement !== searchButton &&
-				activeElement !== searchField
-			) {
+			if ( ! e.target.closest( '.wp-block-search' ) ) {
 				return toggleSearchField( false );
 			}
 
@@ -55,11 +50,11 @@ window.addEventListener( 'DOMContentLoaded', () => {
 			}
 		};
 
-		searchField.addEventListener( 'blur', hideSearchField );
 		searchField.addEventListener( 'keydown', ( e ) => {
 			hideSearchField( e );
 		} );
 		searchButton.addEventListener( 'click', handleButtonClick );
+		searchLabel.addEventListener( 'click', handleButtonClick );
 		document.body.addEventListener( 'click', hideSearchField );
 	} );
 } );

--- a/test/integration/fixtures/blocks/core__search.json
+++ b/test/integration/fixtures/blocks/core__search.json
@@ -7,7 +7,9 @@
 			"placeholder": "",
 			"buttonPosition": "button-outside",
 			"buttonUseIcon": false,
-			"query": {}
+			"query": {},
+			"buttonBehavior": "expand-searchfield",
+			"isSearchFieldHidden": false
 		},
 		"innerBlocks": []
 	}

--- a/test/integration/fixtures/blocks/core__search__custom-text.json
+++ b/test/integration/fixtures/blocks/core__search__custom-text.json
@@ -9,7 +9,9 @@
 			"buttonText": "Custom button text",
 			"buttonPosition": "button-outside",
 			"buttonUseIcon": false,
-			"query": {}
+			"query": {},
+			"buttonBehavior": "expand-searchfield",
+			"isSearchFieldHidden": false
 		},
 		"innerBlocks": []
 	}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Adds the Button (Icon) Only option to the search block. With this option selected, the behavior of the button changes so that when it's clicked, the search input field expands to the defined width.

## Why?
Solves #31128

## How?
If the revelant block attributes are present, a small client side script is enqueued to handle showing / hiding the search field. h/t @apeatling @aristath in #31719 for the starting point.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Insert a search block to a post/page or in the site editor
2. Select the Button Only option from the toolbar
3. Select the button in the editor, verify the search field expands 
5. View the front end, click on it and verify focus is moved to the input. Type in a search term, click on the search button again and verify it performs the search.

### Testing Instructions for Keyboard
- Add a search block to a post or in the site editor, select the button only option
- Navigate to it using the keyboard / via tab. When the search block is focused, press enter / return. Verify the input field expands.
- Visit the front-end. Navigate to the search button. When it is focused, press enter / return. Verify the input expands and focus is moved to the input. Type in a search, press return, and verify.

## Screenshots or screencast <!-- if applicable -->

**Editor**

https://github.com/WordPress/gutenberg/assets/5375500/4dca833f-2333-4bd9-b2fe-19b414c6b810 

**Front-end**

https://github.com/WordPress/gutenberg/assets/5375500/005c457a-b209-4778-b328-6eab5753a1a6


