### PR TITLE
wp-env: Add better default PHPunit settings, fix Xdebug, and update docs

### DIFF
--- a/packages/env/CHANGELOG.md
+++ b/packages/env/CHANGELOG.md
@@ -4,8 +4,7 @@
 
 ### Breaking Change
 
--   Docker containers now run as the host user. This should resolve problems with permissions arising from different owners
-between the host, web container, and cli container. If you still encounter permissions issues, try running `npx wp-env destroy` so that the environment can be recreated with the correct permissions.
+-   Docker containers now run as the host user. This should resolve problems with permissions arising from different owners between the host, web container, and cli container. If you still encounter permissions issues, try running `npx wp-env destroy` so that the environment can be recreated with the correct permissions.
 -   Remove the `composer` and `phpunit` Docker containers. If you are currently using the `run composer` or `run phpunit` command you can migrate to `run cli composer` or `run tests-cli phpunit` respectively. Note that with `composer`, you will need to use the `--env-cwd` option to navigate to your plugin's directory as it is no longer the default working directory.
 
 ### New feature
@@ -23,6 +22,7 @@ between the host, web container, and cli container. If you still encounter permi
 ### Enhancement
 
 -   `wp-env run ...` now uses docker-compose exec instead of docker-compose run. As a result, it is much faster, since commands are executed against existing services, rather than creating them from scratch each time.
+-   Increase the maximum upload size to 1GB.
 
 ## 6.0.0 (2023-04-26)
 

--- a/packages/env/CHANGELOG.md
+++ b/packages/env/CHANGELOG.md
@@ -18,6 +18,7 @@
 ### Bug fix
 
 -   Ensure `wordpress`, `tests-wordpress`, `cli`, and `tests-cli` always build the correct Docker image.
+-   Fix Xdebug while using PHP 7.2x.
 
 ### Enhancement
 

--- a/packages/env/README.md
+++ b/packages/env/README.md
@@ -713,12 +713,12 @@ This is useful for performing some actions after setting up the environment, suc
 
 ### Advanced PHP settings
 
-You can set PHP settings by mapping an `.htaccess` file:
+You can set PHP settings by mapping an `.htaccess` file. This maps an `.htaccess` file to the WordPress root (`/var/www/html`) from the directory in which you run `wp-env`.
 
 ```json
 {
 	"mappings": {
-		"wp-content/.htaccess": "./.htaccess"
+		".htaccess": ".htaccess"
 	}
 }
 ```
@@ -727,13 +727,12 @@ Then, your .htaccess file can contain various settings like this:
 
 ```
 # Note: the default upload value is 1G.
-
 php_value post_max_size 2G
 php_value upload_max_filesize 2G
 php_value memory_limit 2G
 ```
 
-This is useful if there are options you'd normally add to `php.ini`, which is difficult to access in this environment.
+This is useful if there are options you'd like to add to `php.ini`, which is difficult to access in this environment.
 
 ## Contributing to this package
 

--- a/packages/env/README.md
+++ b/packages/env/README.md
@@ -183,6 +183,26 @@ Out of the box `wp-env` includes the [WordPress' PHPUnit test files](https://dev
 
 While we do provide a default `wp-tests-config.php` file within the environment, there may be cases where you want to use your own. WordPress provides a `WP_TESTS_CONFIG_FILE_PATH` constant that you can use to change the `wp-config.php` file used for testing. Set this to a desired path in your `bootstrap.php` file and the file you've chosen will be used instead of the one included in the environment.
 
+## Using `composer`, `phpunit`, and `wp-cli` tools.
+
+For ease of use, Composer, PHPUnit, and wp-cli are available for in the environment. To run these executables, use `wp-env run <env> <tool> <command>`. For example, `wp-env run cli composer install`, or `wp-env run tests-cli phpunit`. You can also access various shells like `wp-env run cli bash` or `wp-env run cli wp shell`.
+
+For the `env` part, `cli` and `wordpress` share a database and mapped volumes, but more tools are available in the cli environment. You should use the `tests-cli` / `tests-wordpress` environments for a separate testing database.
+
+By default, the cwd of the run command is the root of the WordPress install. If you're working on a plugin, you likely need to pass `--env-cwd` to make sure composer/phpunit commands are executed relative to the plugin you're working on. For example, `wp-env run cli --env-cwd=wp-content/plugins/gutenberg composer install`.
+
+To make this easier, it's often helpful to add scripts in your `package.json` file:
+
+```json
+{
+	"scripts": {
+		"composer": "wp-env run cli --env-cwd=wp-content/plugins/gutenberg composer"
+	}
+}
+```
+
+Then, `npm run composer install` would run composer install in the environment. You could also do this for phpunit, wp-cli, etc.
+
 ## Using Xdebug
 
 Xdebug is installed in the wp-env environment, but it is turned off by default. To enable Xdebug, you can use the `--xdebug` flag with the `wp-env start` command. Here is a reference to how the flag works:
@@ -310,9 +330,10 @@ back to using quotation marks; <code>wp-env</code> considers everything inside t
 quotation marks to be command argument.
 
 For example, to ask <code>WP-CLI</code> for its help text:
+
 <pre>sh
 <code class="language-sh">wp-env run cli "wp --help"</code></pre>
-	
+
 Without the quotation marks, <code>wp-env</code> will print its own help text instead of
 passing it to the container. If you experience any problems where the command
 is not being passed correctly, fall back to using quotation marks.
@@ -396,6 +417,7 @@ Success: Installed 1 of 1 plugins.
 ```
 
 #### Changing the permalink structure
+
 You might want to do this to enable access to the REST API (`wp-env/wp/v2/`) endpoint in your wp-env environment. The endpoint is not available with plain permalinks.
 
 **Examples**
@@ -540,14 +562,14 @@ Additionally, the values referencing a URL include the specified port for the gi
 ## Lifecycle Hooks
 
 These hooks are executed at certain points during the lifecycle of a command's execution. Keep in mind that these will be executed on both fresh and existing
-environments, so, ensure any commands you build won't break on subsequent executions. 
+environments, so, ensure any commands you build won't break on subsequent executions.
 
 ### After Setup
 
 Using the `afterSetup` option in `.wp-env.json` files will allow you to configure an arbitrary command to execute after the environment's setup is complete:
 
-- `wp-env start`: Runs when the config changes, WordPress updates, or you pass the `--update` flag.
-- `wp-env clean`: Runs after the selected environments have been cleaned.
+-   `wp-env start`: Runs when the config changes, WordPress updates, or you pass the `--update` flag.
+-   `wp-env clean`: Runs after the selected environments have been cleaned.
 
 You can override the `afterSetup` option using the `WP_ENV_AFTER_SETUP` environment variable.
 
@@ -688,6 +710,30 @@ This is useful for performing some actions after setting up the environment, suc
 	"afterSetup": "node tests/e2e/bin/setup-env.js"
 }
 ```
+
+### Advanced PHP settings
+
+You can set PHP settings by mapping an `.htaccess` file:
+
+```json
+{
+	"mappings": {
+		"wp-content/.htaccess": "./.htaccess"
+	}
+}
+```
+
+Then, your .htaccess file can contain various settings like this:
+
+```
+# Note: the default upload value is 1G.
+
+php_value post_max_size 2G
+php_value upload_max_filesize 2G
+php_value memory_limit 2G
+```
+
+This is useful if there are options you'd normally add to `php.ini`, which is difficult to access in this environment.
 
 ## Contributing to this package
 

--- a/packages/env/lib/build-docker-compose-config.js
+++ b/packages/env/lib/build-docker-compose-config.js
@@ -209,6 +209,7 @@ module.exports = function buildDockerComposeConfig( config ) {
 					WP_TESTS_DIR: '/wordpress-phpunit',
 				},
 				volumes: developmentMounts,
+				extra_hosts: [ 'host.docker.internal:host-gateway' ],
 			},
 			'tests-wordpress': {
 				depends_on: [ 'tests-mysql' ],
@@ -226,6 +227,7 @@ module.exports = function buildDockerComposeConfig( config ) {
 					WP_TESTS_DIR: '/wordpress-phpunit',
 				},
 				volumes: testsMounts,
+				extra_hosts: [ 'host.docker.internal:host-gateway' ],
 			},
 			cli: {
 				depends_on: [ 'wordpress' ],
@@ -241,6 +243,7 @@ module.exports = function buildDockerComposeConfig( config ) {
 					...dbEnv.development,
 					WP_TESTS_DIR: '/wordpress-phpunit',
 				},
+				extra_hosts: [ 'host.docker.internal:host-gateway' ],
 			},
 			'tests-cli': {
 				depends_on: [ 'tests-wordpress' ],
@@ -256,6 +259,7 @@ module.exports = function buildDockerComposeConfig( config ) {
 					...dbEnv.tests,
 					WP_TESTS_DIR: '/wordpress-phpunit',
 				},
+				extra_hosts: [ 'host.docker.internal:host-gateway' ],
 			},
 		},
 		volumes: {

--- a/packages/env/lib/build-docker-compose-config.js
+++ b/packages/env/lib/build-docker-compose-config.js
@@ -209,7 +209,6 @@ module.exports = function buildDockerComposeConfig( config ) {
 					WP_TESTS_DIR: '/wordpress-phpunit',
 				},
 				volumes: developmentMounts,
-				extra_hosts: [ 'host.docker.internal:host-gateway' ],
 			},
 			'tests-wordpress': {
 				depends_on: [ 'tests-mysql' ],
@@ -227,7 +226,6 @@ module.exports = function buildDockerComposeConfig( config ) {
 					WP_TESTS_DIR: '/wordpress-phpunit',
 				},
 				volumes: testsMounts,
-				extra_hosts: [ 'host.docker.internal:host-gateway' ],
 			},
 			cli: {
 				depends_on: [ 'wordpress' ],
@@ -243,7 +241,6 @@ module.exports = function buildDockerComposeConfig( config ) {
 					...dbEnv.development,
 					WP_TESTS_DIR: '/wordpress-phpunit',
 				},
-				extra_hosts: [ 'host.docker.internal:host-gateway' ],
 			},
 			'tests-cli': {
 				depends_on: [ 'tests-wordpress' ],
@@ -259,7 +256,6 @@ module.exports = function buildDockerComposeConfig( config ) {
 					...dbEnv.tests,
 					WP_TESTS_DIR: '/wordpress-phpunit',
 				},
-				extra_hosts: [ 'host.docker.internal:host-gateway' ],
 			},
 		},
 		volumes: {

--- a/packages/env/lib/init-config.js
+++ b/packages/env/lib/init-config.js
@@ -10,9 +10,9 @@ const yaml = require( 'js-yaml' );
 /**
  * Internal dependencies
  */
-const { loadConfig } = require( './config' );
+const { loadConfig, ValidationError } = require( './config' );
 const buildDockerComposeConfig = require( './build-docker-compose-config' );
-const { ValidationError } = require( './config' );
+
 /**
  * @typedef {import('./config').WPConfig} WPConfig
  */

--- a/packages/env/lib/init-config.js
+++ b/packages/env/lib/init-config.js
@@ -80,38 +80,23 @@ module.exports = async function initConfig( {
 			yaml.dump( dockerComposeConfig )
 		);
 
-		await writeFile(
-			path.resolve( config.workDirectoryPath, 'WordPress.Dockerfile' ),
-			wordpressDockerFileContents(
-				getBaseDockerImage( config.env.development.phpVersion, false ),
-				config
-			)
-		);
-		await writeFile(
-			path.resolve(
-				config.workDirectoryPath,
-				'Tests-WordPress.Dockerfile'
-			),
-			wordpressDockerFileContents(
-				getBaseDockerImage( config.env.tests.phpVersion, false ),
-				config
-			)
-		);
-
-		await writeFile(
-			path.resolve( config.workDirectoryPath, 'CLI.Dockerfile' ),
-			cliDockerFileContents(
-				getBaseDockerImage( config.env.development.phpVersion, true ),
-				config
-			)
-		);
-		await writeFile(
-			path.resolve( config.workDirectoryPath, 'Tests-CLI.Dockerfile' ),
-			cliDockerFileContents(
-				getBaseDockerImage( config.env.tests.phpVersion, true ),
-				config
-			)
-		);
+		// Write four Dockerfiles for each service we provided.
+		// (WordPress and CLI services, then a development and test environment for each.)
+		for ( const imageType of [ 'WordPress', 'CLI' ] ) {
+			for ( const envType of [ 'development', 'tests' ] ) {
+				await writeFile(
+					path.resolve(
+						config.workDirectoryPath,
+						`${
+							envType === 'tests' ? 'Tests-' : ''
+						}${ imageType }.Dockerfile`
+					),
+					imageType === 'WordPress'
+						? wordpressDockerFileContents( envType, config )
+						: cliDockerFileContents( envType, config )
+				);
+			}
+		}
 	} else if ( ! existsSync( config.workDirectoryPath ) ) {
 		spinner.fail(
 			'wp-env has not yet been initialized. Please run `wp-env start` to install the WordPress instance before using any other commands. This is only necessary to set up the environment for the first time; it is typically not necessary for the instance to be running after that in order to use other commands.'
@@ -125,13 +110,16 @@ module.exports = async function initConfig( {
 /**
  * Generates the Dockerfile used by wp-env's `wordpress` and `tests-wordpress` instances.
  *
- * @param {string}   image  The base docker image to use.
+ * @param {string}   env    The environment we're installing -- development or tests.
  * @param {WPConfig} config The configuration object.
- *
  * @return {string} The dockerfile contents.
  */
-function wordpressDockerFileContents( image, config ) {
-	return `FROM ${ image }
+function wordpressDockerFileContents( env, config ) {
+	const phpVersion = config.env[ env ].phpVersion
+		? ':php' + config.env[ env ].phpVersion
+		: '';
+
+	return `FROM wordpress${ phpVersion }
 
 # Update apt sources for archived versions of Debian.
 
@@ -149,19 +137,22 @@ RUN groupadd -g $HOST_GID $HOST_USERNAME || true
 RUN useradd -m -u $HOST_UID -g $HOST_GID $HOST_USERNAME || true
 
 # Install any dependencies we need in the container.
-${ installDependencies( 'wordpress', config ) }`;
+${ installDependencies( 'wordpress', env, config ) }`;
 }
 
 /**
  * Generates the Dockerfile used by wp-env's `cli` and `tests-cli` instances.
  *
- * @param {string}   image  The base docker image to use.
+ * @param {string}   env    The environment we're installing -- development or tests.
  * @param {WPConfig} config The configuration object.
- *
  * @return {string} The dockerfile contents.
  */
-function cliDockerFileContents( image, config ) {
-	return `FROM ${ image }
+function cliDockerFileContents( env, config ) {
+	const phpVersion = config.env[ env ].phpVersion
+		? '-php' + config.env[ env ].phpVersion
+		: '';
+
+	return `FROM wordpress:cli${ phpVersion }
 
 # Switch to root so we can create users.
 USER root
@@ -175,7 +166,7 @@ RUN addgroup -g $HOST_GID $HOST_USERNAME || true
 RUN adduser -h /home/$HOST_USERNAME -G $( getent group $HOST_GID | cut -d: -f1 ) -u $HOST_UID $HOST_USERNAME || true
 
 # Install any dependencies we need in the container.
-${ installDependencies( 'cli', config ) }
+${ installDependencies( 'cli', env, config ) }
 	
 # Switch back to the original user now that we're done.
 USER www-data
@@ -186,44 +177,21 @@ CMD [ "/bin/sh", "-c", "while true; do sleep 2073600; done" ]
 }
 
 /**
- * Gets the base docker image to use based on our input.
- *
- * @param {string}  phpVersion The version of PHP to get an image for.
- * @param {boolean} isCLI      Indicates whether or not the image is for a CLI.
- * @return {string} The Docker image to use.
- */
-function getBaseDockerImage( phpVersion, isCLI ) {
-	// We can rely on a consistent format for PHP versions.
-	if ( phpVersion ) {
-		phpVersion = ( isCLI ? '-' : ':' ) + 'php' + phpVersion;
-	} else {
-		phpVersion = '';
-	}
-
-	let wordpressImage = 'wordpress';
-	if ( isCLI ) {
-		wordpressImage += ':cli';
-	}
-
-	return wordpressImage + phpVersion;
-}
-
-/**
  * Generates content for the Dockerfile to install dependencies.
  *
- * @param {string}   environment The kind of environment that we're installing dependencies on ('wordpress' or 'cli').
- * @param {WPConfig} config      The configuration object.
- *
+ * @param {string}   service The kind of service that we're installing dependencies on ('wordpress' or 'cli').
+ * @param {string}   env     The environment we're installing dependencies for ('development' or 'tests').
+ * @param {WPConfig} config  The configuration object.
  * @return {string} The Dockerfile content for installing dependencies.
  */
-function installDependencies( environment, config ) {
+function installDependencies( service, env, config ) {
 	let dockerFileContent = '';
 
 	// At times we may need to evaluate the environment. This is because the
 	// WordPress image uses Ubuntu while the CLI image uses Alpine.
 
 	// Start with some environment-specific dependency installations.
-	switch ( environment ) {
+	switch ( service ) {
 		case 'wordpress': {
 			dockerFileContent += `
 # Make sure we're working with the latest packages.
@@ -246,18 +214,21 @@ RUN echo "$HOST_USERNAME ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers`;
 			break;
 		}
 		default: {
-			throw new Error( `Invalid environment "${ environment }" given` );
+			throw new Error( `Invalid service "${ service }" given` );
 		}
 	}
 
-	dockerFileContent += getXdebugConfig( config );
+	dockerFileContent += getXdebugConfig(
+		config.xdebug,
+		config.env[ env ].phpVersion
+	);
 
 	// Add better PHP settings.
 	dockerFileContent += `
 RUN echo 'upload_max_filesize = 1G' >> /usr/local/etc/php/php.ini
 RUN echo 'post_max_size = 1G' >> /usr/local/etc/php/php.ini`;
 
-	// Make sure Composer is available for use in all environments.
+	// Make sure Composer is available for use in all services.
 	dockerFileContent += `
 RUN curl -sS https://getcomposer.org/installer -o /tmp/composer-setup.php
 RUN export COMPOSER_HASH=\`curl -sS https://composer.github.io/installer.sig\` && php -r "if (hash_file('SHA384', '/tmp/composer-setup.php') === '$COMPOSER_HASH') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('/tmp/composer-setup.php'); } echo PHP_EOL;"
@@ -278,21 +249,18 @@ USER root`;
 /**
  * Gets the Xdebug config based on the options in the config object.
  *
- * @param {WPConfig} config
+ * @param {string} xdebugMode The Xdebug mode set in the config.
+ * @param {string} phpVersion The php version set in the environment.
  * @return {string} The Xdebug config -- can be an empty string when it's not used.
  */
-function getXdebugConfig( config ) {
-	if ( config.xdebug === 'off' ) {
+function getXdebugConfig( xdebugMode = 'off', phpVersion ) {
+	if ( xdebugMode === 'off' ) {
 		return '';
 	}
 
-	// Throw an error if someone tries to use Xdebug with an unsupported PHP version.
-	const phpVersions = [
-		config.env.development.phpVersion,
-		config.env.tests.phpVersion,
-	].filter( Boolean );
+	let xdebugVersion = 'xdebug';
 
-	for ( const phpVersion of phpVersions ) {
+	if ( phpVersion ) {
 		const versionTokens = phpVersion.split( '.' );
 		const majorVer = parseInt( versionTokens[ 0 ] );
 		const minorVer = parseInt( versionTokens[ 1 ] );
@@ -303,19 +271,26 @@ function getXdebugConfig( config ) {
 			);
 		}
 
-		// Xdebug 3 supports 7.2 and higher
-		// Ensure user has specified a compatible PHP version.
+		// Throw an error if someone tries to use Xdebug with an unsupported PHP version.
+		// Xdebug 3 only supports 7.2 and higher.
 		if ( majorVer < 7 || ( majorVer === 7 && minorVer < 2 ) ) {
 			throw new Error(
 				`Cannot use XDebug 3 with PHP < 7.2. Your PHP version is ${ phpVersion }.`
 			);
 		}
+
+		// For now, we support PHP 7 by installing the final version of Xdebug to
+		// support PHP 7 when the environment uses that version. By default, use the
+		// latest version.
+		if ( majorVer === 7 ) {
+			xdebugVersion = 'xdebug-3.1.6';
+		}
 	}
 
 	return `
-RUN if [ -z "$(pecl list | grep xdebug)" ] ; then pecl install xdebug ; fi
+RUN if [ -z "$(pecl list | grep ${ xdebugVersion })" ] ; then pecl install ${ xdebugVersion } ; fi
 RUN docker-php-ext-enable xdebug
 RUN echo 'xdebug.start_with_request=yes' >> /usr/local/etc/php/php.ini
-RUN echo 'xdebug.mode=${ config.xdebug }' >> /usr/local/etc/php/php.ini
+RUN echo 'xdebug.mode=${ xdebugMode }' >> /usr/local/etc/php/php.ini
 RUN echo 'xdebug.client_host="host.docker.internal"' >> /usr/local/etc/php/php.ini`;
 }

--- a/packages/env/lib/init-config.js
+++ b/packages/env/lib/init-config.js
@@ -287,8 +287,13 @@ function getXdebugConfig( config ) {
 	}
 
 	// Throw an error if someone tries to use Xdebug with an unsupported PHP version.
-	if ( config.env.development.phpVersion ) {
-		const versionTokens = config.env.development.phpVersion.split( '.' );
+	const phpVersions = [
+		config.env.development.phpVersion,
+		config.env.tests.phpVersion,
+	].filter( Boolean );
+
+	for ( const phpVersion of phpVersions ) {
+		const versionTokens = phpVersion.split( '.' );
 		const majorVer = parseInt( versionTokens[ 0 ] );
 		const minorVer = parseInt( versionTokens[ 1 ] );
 
@@ -301,7 +306,9 @@ function getXdebugConfig( config ) {
 		// Xdebug 3 supports 7.2 and higher
 		// Ensure user has specified a compatible PHP version.
 		if ( majorVer < 7 || ( majorVer === 7 && minorVer < 2 ) ) {
-			throw new Error( 'Cannot use XDebug 3 on PHP < 7.2.' );
+			throw new Error(
+				`Cannot use XDebug 3 with PHP < 7.2. Your PHP version is ${ phpVersion }.`
+			);
 		}
 	}
 

--- a/packages/env/lib/init-config.js
+++ b/packages/env/lib/init-config.js
@@ -287,13 +287,8 @@ function getXdebugConfig( config ) {
 	}
 
 	// Throw an error if someone tries to use Xdebug with an unsupported PHP version.
-	const phpVersions = [
-		config.env.development.phpVersion,
-		config.env.tests.phpVersion,
-	].filter( Boolean );
-
-	for ( const phpVersion of phpVersions ) {
-		const versionTokens = phpVersion.split( '.' );
+	if ( config.env.development.phpVersion ) {
+		const versionTokens = config.env.development.phpVersion.split( '.' );
 		const majorVer = parseInt( versionTokens[ 0 ] );
 		const minorVer = parseInt( versionTokens[ 1 ] );
 
@@ -306,9 +301,7 @@ function getXdebugConfig( config ) {
 		// Xdebug 3 supports 7.2 and higher
 		// Ensure user has specified a compatible PHP version.
 		if ( majorVer < 7 || ( majorVer === 7 && minorVer < 2 ) ) {
-			throw new Error(
-				`Cannot use XDebug 3 with PHP < 7.2. Your PHP version is ${ phpVersion }.`
-			);
+			throw new Error( 'Cannot use XDebug 3 on PHP < 7.2.' );
 		}
 	}
 

--- a/packages/env/lib/init-config.js
+++ b/packages/env/lib/init-config.js
@@ -6,7 +6,6 @@ const path = require( 'path' );
 const { writeFile, mkdir } = require( 'fs' ).promises;
 const { existsSync } = require( 'fs' );
 const yaml = require( 'js-yaml' );
-const os = require( 'os' );
 
 /**
  * Internal dependencies
@@ -306,16 +305,10 @@ function getXdebugConfig( config ) {
 		}
 	}
 
-	// Discover client host does not appear to work on macOS with Docker.
-	const clientDetectSettings =
-		os.type() === 'Linux'
-			? 'xdebug.discover_client_host=true'
-			: 'xdebug.client_host="host.docker.internal"';
-
 	return `
 RUN if [ -z "$(pecl list | grep xdebug)" ] ; then pecl install xdebug ; fi
 RUN docker-php-ext-enable xdebug
 RUN echo 'xdebug.start_with_request=yes' >> /usr/local/etc/php/php.ini
 RUN echo 'xdebug.mode=${ config.xdebug }' >> /usr/local/etc/php/php.ini
-RUN echo '${ clientDetectSettings }' >> /usr/local/etc/php/php.ini`;
+RUN echo 'xdebug.client_host="host.docker.internal"' >> /usr/local/etc/php/php.ini`;
 }

--- a/packages/env/lib/init-config.js
+++ b/packages/env/lib/init-config.js
@@ -12,7 +12,7 @@ const yaml = require( 'js-yaml' );
  */
 const { loadConfig } = require( './config' );
 const buildDockerComposeConfig = require( './build-docker-compose-config' );
-
+const { ValidationError } = require( './config' );
 /**
  * @typedef {import('./config').WPConfig} WPConfig
  */
@@ -266,7 +266,7 @@ function getXdebugConfig( xdebugMode = 'off', phpVersion ) {
 		const minorVer = parseInt( versionTokens[ 1 ] );
 
 		if ( isNaN( majorVer ) || isNaN( minorVer ) ) {
-			throw new Error(
+			throw new ValidationError(
 				'Something went wrong when parsing the PHP version.'
 			);
 		}
@@ -274,7 +274,7 @@ function getXdebugConfig( xdebugMode = 'off', phpVersion ) {
 		// Throw an error if someone tries to use Xdebug with an unsupported PHP version.
 		// Xdebug 3 only supports 7.2 and higher.
 		if ( majorVer < 7 || ( majorVer === 7 && minorVer < 2 ) ) {
-			throw new Error(
+			throw new ValidationError(
 				`Cannot use XDebug 3 with PHP < 7.2. Your PHP version is ${ phpVersion }.`
 			);
 		}

--- a/packages/env/lib/init-config.js
+++ b/packages/env/lib/init-config.js
@@ -236,24 +236,23 @@ RUN apt-get -qy install $PHPIZE_DEPS && touch /usr/local/etc/php/php.ini
 # Set up sudo so they can have root access.
 RUN apt-get -qy install sudo
 RUN echo "$HOST_USERNAME ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers`;
-			if ( shouldEnableXdebug( config ) ) {
-				// Xdebug is only needed for WordPress environments.
-				dockerFileContent += getXdebugSetup( config.xdebug );
-			}
 			break;
 		}
 		case 'cli': {
 			dockerFileContent += `
 RUN apk update
 RUN apk --no-cache add $PHPIZE_DEPS && touch /usr/local/etc/php/php.ini
-RUN apk --no-cache add linux-headers
-RUN apk --no-cache add sudo
+RUN apk --no-cache add sudo linux-headers
 RUN echo "$HOST_USERNAME ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers`;
 			break;
 		}
 		default: {
 			throw new Error( `Invalid environment "${ environment }" given` );
 		}
+	}
+
+	if ( shouldEnableXdebug( config ) ) {
+		dockerFileContent += getXdebugSetup( config.xdebug );
 	}
 
 	// Add better PHP settings.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
1. Resolves #28703 by documenting `.htaccess` mapping and increasing default upload size to 1GB. 
2. Resolves #46635 by using the previous Xdebug version when using PHP 7.x
3. Fixes Xdebug, which I found was broken while testing this
4. Adds more documentation about stuff in this PR, and for #50408 

### Before:
![SCR-20230509-ilv](https://github.com/WordPress/gutenberg/assets/6265975/325045e1-ce7a-4abd-b88a-166203da9735)

### After:
![SCR-20230509-iu0](https://github.com/WordPress/gutenberg/assets/6265975/8d24d9e3-f076-4e92-81dd-38e372129b2d)


## How?
Adjusts the dockerfiles we generate! This also changes Xdebug such that it's not installed in the CLI environments.

## Testing Instructions
### PHP settings
1. Verify that larger files can be uploaded
2. Check the media upload settings here: http://localhost:8888/wp-admin/site-health.php?tab=debug
3. Map a `.htaccess` file (following the documentation), and verify those upload sizes override the default values

### Xdebug
1. Setup Xdebug in VS Code following the instructions in the readme
2. Run `npx wp-env start --xdebug`
3. Add a breakpoint to `gutenberg.php`
5. Access the site via URL, and verify a breakpoint is triggered.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
