### PR TITLE
[RNMobile] Test Helpers: Provide `onPickerButtonPressed` arg to `setupPicker` helper

### DIFF
--- a/packages/block-library/src/gallery/test/index.native.js
+++ b/packages/block-library/src/gallery/test/index.native.js
@@ -262,7 +262,7 @@ describe( 'Gallery block', () => {
 
 		// Upload images from device
 		fireEvent.press( getByText( 'ADD MEDIA' ) );
-		selectOption( 'Choose from device' );
+		await selectOption( 'Choose from device' );
 		expectMediaPickerCall( 'DEVICE_MEDIA_LIBRARY', [ 'image' ], true );
 
 		// Return media items picked

--- a/packages/block-library/src/gallery/test/index.native.js
+++ b/packages/block-library/src/gallery/test/index.native.js
@@ -258,11 +258,11 @@ describe( 'Gallery block', () => {
 		// Initialize with an empty gallery
 		const screen = await initializeWithGalleryBlock();
 		const { galleryBlock, getByText } = screen;
-		const { selectOption } = setupPicker( screen, MEDIA_OPTIONS );
+		const { selectOption } = await setupPicker( screen, MEDIA_OPTIONS );
 
 		// Upload images from device
 		fireEvent.press( getByText( 'ADD MEDIA' ) );
-		await selectOption( 'Choose from device' );
+		selectOption( 'Choose from device' );
 		expectMediaPickerCall( 'DEVICE_MEDIA_LIBRARY', [ 'image' ], true );
 
 		// Return media items picked

--- a/packages/block-library/src/gallery/test/index.native.js
+++ b/packages/block-library/src/gallery/test/index.native.js
@@ -258,11 +258,11 @@ describe( 'Gallery block', () => {
 		// Initialize with an empty gallery
 		const screen = await initializeWithGalleryBlock();
 		const { galleryBlock, getByText } = screen;
-		const { selectOption } = await setupPicker( screen, MEDIA_OPTIONS );
+		const { selectOption } = setupPicker( screen, MEDIA_OPTIONS );
 
 		// Upload images from device
 		fireEvent.press( getByText( 'ADD MEDIA' ) );
-		selectOption( 'Choose from device' );
+		await selectOption( 'Choose from device' );
 		expectMediaPickerCall( 'DEVICE_MEDIA_LIBRARY', [ 'image' ], true );
 
 		// Return media items picked

--- a/test/native/integration-test-helpers/setup-picker.js
+++ b/test/native/integration-test-helpers/setup-picker.js
@@ -21,7 +21,7 @@ import { ActionSheetIOS } from 'react-native';
  *
  * @return {PickerMockFunctions} Picker functions.
  */
-export async function setupPicker(
+export function setupPicker(
 	screen,
 	options,
 	onPickerButtonPressed = () => {}
@@ -39,8 +39,10 @@ export async function setupPicker(
 		);
 		// The index passed is incremented by one as the first
 		// option of the picker is `Cancel`.
-		selectOption = ( option ) =>
+		selectOption = async ( option ) => {
+			await onPickerButtonPressed();
 			onOptionSelected( options.indexOf( option ) + 1 );
+		};
 	}
 	return { selectOption };
 }

--- a/test/native/integration-test-helpers/setup-picker.js
+++ b/test/native/integration-test-helpers/setup-picker.js
@@ -13,14 +13,15 @@ import { ActionSheetIOS } from 'react-native';
  * Sets up the Picker component for testing.
  *
  * @typedef {Object} PickerMockFunctions
- * @property {Function}                                          selectOption Selects one of the options of the picker.
+ * @property {Function}                                          selectOption    Selects one of the options of the picker.
  *
- * @param    {import('@testing-library/react-native').RenderAPI} screen       A Testing Library screen.
- * @param    {string[]}                                          options      Array with the options of the picker.
+ * @param    {import('@testing-library/react-native').RenderAPI} screen          A Testing Library screen.
+ * @param    {string[]}                                          options         Array with the options of the picker.
+ * @param    {Function}                                          onManualTrigger Optional function when a picker is manually triggered.
  *
  * @return {PickerMockFunctions} Picker functions.
  */
-export function setupPicker( screen, options ) {
+export function setupPicker( screen, options, onManualTrigger = () => {} ) {
 	let selectOption = ( option ) => {
 		fireEvent.press( screen.getByText( option ) );
 	};
@@ -33,8 +34,10 @@ export function setupPicker( screen, options ) {
 		);
 		// The index passed is incremented by one as the first
 		// option of the picker is `Cancel`.
-		selectOption = ( option ) =>
+		selectOption = async ( option ) => {
+			await onManualTrigger();
 			onOptionSelected( options.indexOf( option ) + 1 );
+		};
 	}
 	return { selectOption };
 }

--- a/test/native/integration-test-helpers/setup-picker.js
+++ b/test/native/integration-test-helpers/setup-picker.js
@@ -39,9 +39,8 @@ export async function setupPicker(
 		);
 		// The index passed is incremented by one as the first
 		// option of the picker is `Cancel`.
-		selectOption = async ( option ) => {
+		selectOption = ( option ) =>
 			onOptionSelected( options.indexOf( option ) + 1 );
-		};
 	}
 	return { selectOption };
 }

--- a/test/native/integration-test-helpers/setup-picker.js
+++ b/test/native/integration-test-helpers/setup-picker.js
@@ -13,21 +13,21 @@ import { ActionSheetIOS } from 'react-native';
  * Sets up the Picker component for testing.
  *
  * @typedef {Object} PickerMockFunctions
- * @property {Function}                                          selectOption      Selects one of the options of the picker.
+ * @property {Function}                                          selectOption          Selects one of the options of the picker.
  *
- * @param    {import('@testing-library/react-native').RenderAPI} screen            A Testing Library screen.
- * @param    {string[]}                                          options           Array with the options of the picker.
- * @param    {Function}                                          onPickerTriggered Optional function when a picker is manually triggered.
+ * @param    {import('@testing-library/react-native').RenderAPI} screen                A Testing Library screen.
+ * @param    {string[]}                                          options               Array with the options of the picker.
+ * @param    {Function}                                          onPickerButtonPressed Optional function when a picker is manually triggered via a button.
  *
  * @return {PickerMockFunctions} Picker functions.
  */
 export async function setupPicker(
 	screen,
 	options,
-	onPickerTriggered = () => {}
+	onPickerButtonPressed = () => {}
 ) {
-	await onPickerTriggered();
 	let selectOption = async ( option ) => {
+		await onPickerButtonPressed();
 		fireEvent.press( screen.getByText( option ) );
 	};
 	if ( Platform.isIOS ) {

--- a/test/native/integration-test-helpers/setup-picker.js
+++ b/test/native/integration-test-helpers/setup-picker.js
@@ -13,16 +13,21 @@ import { ActionSheetIOS } from 'react-native';
  * Sets up the Picker component for testing.
  *
  * @typedef {Object} PickerMockFunctions
- * @property {Function}                                          selectOption    Selects one of the options of the picker.
+ * @property {Function}                                          selectOption      Selects one of the options of the picker.
  *
- * @param    {import('@testing-library/react-native').RenderAPI} screen          A Testing Library screen.
- * @param    {string[]}                                          options         Array with the options of the picker.
- * @param    {Function}                                          onManualTrigger Optional function when a picker is manually triggered.
+ * @param    {import('@testing-library/react-native').RenderAPI} screen            A Testing Library screen.
+ * @param    {string[]}                                          options           Array with the options of the picker.
+ * @param    {Function}                                          onPickerTriggered Optional function when a picker is manually triggered.
  *
  * @return {PickerMockFunctions} Picker functions.
  */
-export function setupPicker( screen, options, onManualTrigger = () => {} ) {
-	let selectOption = ( option ) => {
+export async function setupPicker(
+	screen,
+	options,
+	onPickerTriggered = () => {}
+) {
+	await onPickerTriggered();
+	let selectOption = async ( option ) => {
 		fireEvent.press( screen.getByText( option ) );
 	};
 	if ( Platform.isIOS ) {
@@ -35,7 +40,6 @@ export function setupPicker( screen, options, onManualTrigger = () => {} ) {
 		// The index passed is incremented by one as the first
 		// option of the picker is `Cancel`.
 		selectOption = async ( option ) => {
-			await onManualTrigger();
 			onOptionSelected( options.indexOf( option ) + 1 );
 		};
 	}


### PR DESCRIPTION
## What?

This PR adds an optional `onPickerButtonPressed ` callback to the `setupPicker` helper function, allowing easier testing on iOS for components like [`SelectControl`](https://github.com/WordPress/gutenberg/blob/ccd529d7a6af0e233c2bef03dde214ca48165c75/packages/components/src/select-control/index.native.js), which display a native iOS action sheet only when pressed.

## Why?

In certain test cases for iOS, the picker is only displayed after manually pressing a button, for example in [`SelectControl`](https://github.com/WordPress/gutenberg/blob/ccd529d7a6af0e233c2bef03dde214ca48165c75/packages/components/src/select-control/index.native.js). Attempting to use `setupPicker` in these cases doesn't work as expected out-of-the-box due to timeout issues.

By providing an `onPickerButtonPressed` callback, we can avoid timeout issues and more accurately simulate user interaction. 

## How?

The `setupPicker` function now accepts an optional third argument, `onPickerButtonPressed `, which defaults to an empty function. By awaiting the `onPickerButtonPressed ` function, we ensure that any required setup or interaction occurs before the picker is displayed.

## Testing Instructions

* Verify that there are no regressions to existing tests that make use of the `setupPicker` helper on iOS. 
* At the moment, the helper is only used in the `successfully uploads items` Gallery test. Apply the following patch to isolate that test: 

```patch
+diff --git a/packages/block-library/src/gallery/test/index.native.js b/packages/block-library/src/gallery/test/index.native.js
index 137a0949f9..9420fbebbf 100644
--- a/packages/block-library/src/gallery/test/index.native.js
+++ b/packages/block-library/src/gallery/test/index.native.js
@@ -250,7 +250,7 @@ describe( 'Gallery block', () => {
 
 	// Test case related to TC005 - Choose from device (stay in editor) - Successful upload
 	// Reference: https://github.com/wordpress-mobile/test-cases/blob/trunk/test-cases/gutenberg/gallery.md#tc005
-	it( 'successfully uploads items', async () => {
+	it.only( 'successfully uploads items', async () => {
 		const { notifyUploadingState, notifySucceedState } = setupMediaUpload();
 		const { expectMediaPickerCall, mediaPickerCallback } =
 			setupMediaPicker();
```

* After applying the above patch, run the `TEST_RN_PLATFORM=ios npm run native test -- gallery/test/index` command in the terminal to verify it still passes following the changes in this PR.

* Verify that it's possible to successfully pass the new argument to the helper. An example of this being used be found in https://github.com/wordpress-mobile/gutenberg-mobile/pull/5754.