### PR TITLE
Button: Update disabled state to be without background.

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 ## Unreleased
 
-### Bug Fix
-
--   Update `<Button>` component to have a transparent background for its tertiary disabled state, to match its enabled state.  ([#50496](https://github.com/WordPress/gutenberg/pull/50496)).
-
 ### Breaking Changes
 
 -   `onDragStart` in `<Draggable>` is now a synchronous function to allow setting additional data for `event.dataTransfer` ([#49673](https://github.com/WordPress/gutenberg/pull/49673)).
@@ -13,6 +9,7 @@
 ### Bug Fix
 
 -   `NavigableContainer`: do not trap focus in `TabbableContainer` ([#49846](https://github.com/WordPress/gutenberg/pull/49846)).
+-   Update `<Button>` component to have a transparent background for its tertiary disabled state, to match its enabled state.  ([#50496](https://github.com/WordPress/gutenberg/pull/50496)).
 
 ### Internal
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fix
+
+-   Update `<Button>` component to have a transparent background for its tertiary disabled state, to match its enabled state.  ([#50496](https://github.com/WordPress/gutenberg/pull/50496)).
+
 ### Breaking Changes
 
 -   `onDragStart` in `<Draggable>` is now a synchronous function to allow setting additional data for `event.dataTransfer` ([#49673](https://github.com/WordPress/gutenberg/pull/49673)).

--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -124,7 +124,6 @@
 		&:disabled,
 		&[aria-disabled="true"],
 		&[aria-disabled="true"]:hover {
-			// TODO: Prepare for theming (https://github.com/WordPress/gutenberg/pull/45466/files#r1030872724)
 			color: $gray-600;
 			background: transparent;
 			transform: none;

--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -118,21 +118,15 @@
 		outline: 1px solid transparent;
 
 		&:active:not(:disabled) {
-			background: $components-color-gray-300;
-			color: $components-color-accent-darker-10;
 			box-shadow: none;
-		}
-
-		&:hover:not(:disabled) {
-			color: $components-color-accent-darker-10;
 		}
 
 		&:disabled,
 		&[aria-disabled="true"],
 		&[aria-disabled="true"]:hover {
 			// TODO: Prepare for theming (https://github.com/WordPress/gutenberg/pull/45466/files#r1030872724)
-			color: lighten($gray-700, 5%);
-			background: lighten($gray-300, 5%);
+			color: $gray-600;
+			background: transparent;
 			transform: none;
 			opacity: 1;
 			box-shadow: none;
@@ -165,12 +159,12 @@
 		color: $components-color-accent;
 		background: transparent;
 
-		&:hover:not(:disabled) {
+		&:hover:not(:disabled, [aria-disabled="true"]) {
 			// TODO: Prepare for theming (https://github.com/WordPress/gutenberg/pull/45466/files#r1030872724)
 			background: rgba(var(--wp-admin-theme-color--rgb), 0.04);
 		}
 
-		&:active:not(:disabled) {
+		&:active:not(:disabled, [aria-disabled="true"]) {
 			// TODO: Prepare for theming (https://github.com/WordPress/gutenberg/pull/45466/files#r1030872724)
 			background: rgba(var(--wp-admin-theme-color--rgb), 0.08);
 		}
@@ -239,7 +233,7 @@
 		}
 	}
 
-	&:not([aria-disabled="true"]):active {
+	&:not(:disabled, [aria-disabled="true"]):active {
 		color: $components-color-foreground;
 	}
 


### PR DESCRIPTION
## What?

The disabled state of notably the tertiary variant of the button component adds a background:

<img width="448" alt="Screenshot 2023-05-10 at 08 36 31" src="https://github.com/WordPress/gutenberg/assets/1204802/b15e3023-1e9b-4c10-906b-11678ed96b25">

This is incorrect for that particular variant, this PR removes it:

<img width="421" alt="Screenshot 2023-05-10 at 08 52 43" src="https://github.com/WordPress/gutenberg/assets/1204802/a4b457ea-fc8d-4cd7-be74-bb7c81769fd8">

Incidentally that unifies its style with this "Saved" disabled button as well.

<img width="388" alt="Screenshot 2023-05-10 at 08 39 22" src="https://github.com/WordPress/gutenberg/assets/1204802/259e0376-8da3-475a-a19b-f44767b5264f">

The PR also updates some incorrect hover and active states.

## Why?

The primary button is filled, the secondary button is outlined, the tertiary button is without background. This makes that consistent for the disabled state.

## Testing Instructions

Create a new post, and before adding any content, observe the save draft and preview buttons.
