### PR TITLE
Update format used by font resolver

### DIFF
--- a/lib/experimental/fonts-api/class-wp-fonts-resolver.php
+++ b/lib/experimental/fonts-api/class-wp-fonts-resolver.php
@@ -92,11 +92,14 @@ class WP_Fonts_Resolver {
 			return '';
 		}
 
-		$starting_pattern = "var:preset|{$preset_type}|";
+		$starting_pattern = "var(--wp--preset--{$preset_type}--";
+		$ending_pattern   = ')';
 		if ( ! str_starts_with( $style, $starting_pattern ) ) {
 			return '';
 		}
 
-		return substr( $style, strlen( $starting_pattern ) );
+		$offset = strlen( $starting_pattern );
+		$length = strpos( $style, $ending_pattern ) - $offset;
+		return substr( $style, $offset, $length );
 	}
 }

--- a/lib/experimental/fonts-api/class-wp-fonts-resolver.php
+++ b/lib/experimental/fonts-api/class-wp-fonts-resolver.php
@@ -45,8 +45,12 @@ class WP_Fonts_Resolver {
 	 * @return array User selected font-families when exists, else empty array.
 	 */
 	public static function enqueue_user_selected_fonts() {
-		$global_styles       = gutenberg_get_global_styles();
-		$user_selected_fonts = static::get_user_selected_fonts( $global_styles );
+		$user_selected_fonts = array();
+		$user_global_styles  = WP_Theme_JSON_Resolver_Gutenberg::get_user_data()->get_raw_data();
+		if ( isset( $user_global_styles['styles'] ) ) {
+			$user_selected_fonts = static::get_user_selected_fonts( $user_global_styles['styles'] );
+		}
+
 		if ( empty( $user_selected_fonts ) ) {
 			return array();
 		}

--- a/lib/experimental/fonts-api/class-wp-fonts-resolver.php
+++ b/lib/experimental/fonts-api/class-wp-fonts-resolver.php
@@ -45,7 +45,7 @@ class WP_Fonts_Resolver {
 	 * @return array User selected font-families when exists, else empty array.
 	 */
 	public static function enqueue_user_selected_fonts() {
-		$global_styles       = wp_get_global_styles();
+		$global_styles       = gutenberg_get_global_styles();
 		$user_selected_fonts = static::get_user_selected_fonts( $global_styles );
 		if ( empty( $user_selected_fonts ) ) {
 			return array();


### PR DESCRIPTION
Follow-up to https://github.com/WordPress/gutenberg/pull/50297 and https://github.com/WordPress/gutenberg/pull/50366

## What?

Fixes two issues:

- one issue by which the font resolver is unable to locate the proper fonts due to a later change introduced at https://github.com/WordPress/gutenberg/pull/50366
- updates how the fonts API determine what's a user-provided font, as it was incorrectly using the internal format. See https://github.com/WordPress/gutenberg/pull/50297#discussion_r1189573512

## Why?

https://github.com/WordPress/gutenberg/pull/50366 updated `gutenberg_get_global_styles` so that the custom format `var:preset|...` is never returned to consumers. Just before it was merged, a PR for the font resolver landed at https://github.com/WordPress/gutenberg/pull/50297/ that makes use of that format. Hence, when 50366 landed, it broke the font resolver.

Investigating this issue uncovered a bug in how the user-provided fonts are detected. See https://github.com/WordPress/gutenberg/pull/50297#discussion_r1189573512 

## How?

- Update the font resolver to use the regular format.
- Update the font resolver to query for user data explicitly, instead of trying to infer it based on whether the font is using `var:preset|...` format that any origin can use.

## Testing Instructions

Make sure automated test pass.

See manual test instructions at https://github.com/WordPress/gutenberg/pull/50297
