### PR TITLE
Add quick links header to the templates and pages site editor sidebars

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen-pages/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-pages/index.js
@@ -62,6 +62,12 @@ export default function SidebarNavigationScreenPages() {
 										) ?? __( '(no title)' ) }
 									</PageItem>
 								) ) }
+							</ItemGroup>
+
+							<SidebarNavigationSubtitle>
+								{ __( 'Quick links' ) }
+							</SidebarNavigationSubtitle>
+							<ItemGroup>
 								<SidebarNavigationItem
 									className="edit-site-sidebar-navigation-screen-pages__see-all"
 									href="edit.php?post_type=page"

--- a/packages/edit-site/src/components/sidebar-navigation-screen-templates/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-templates/index.js
@@ -21,6 +21,7 @@ import SidebarNavigationItem from '../sidebar-navigation-item';
 import AddNewTemplate from '../add-new-template';
 import { store as editSiteStore } from '../../store';
 import SidebarButton from '../sidebar-button';
+import SidebarNavigationSubtitle from '../sidebar-navigation-subtitle';
 
 const config = {
 	wp_template: {
@@ -122,7 +123,16 @@ export default function SidebarNavigationScreenTemplates() {
 									) }
 								</TemplateItem>
 							) ) }
-							{ ! isMobileViewport && (
+						</ItemGroup>
+					) }
+
+					{ ! isLoading && ! isMobileViewport && (
+						<>
+							<SidebarNavigationSubtitle>
+								{ __( 'Quick links' ) }
+							</SidebarNavigationSubtitle>
+
+							<ItemGroup>
 								<SidebarNavigationItem
 									className="edit-site-sidebar-navigation-screen-templates__see-all"
 									{ ...browseAllLink }
@@ -131,8 +141,8 @@ export default function SidebarNavigationScreenTemplates() {
 									}
 									withChevron
 								/>
-							) }
-						</ItemGroup>
+							</ItemGroup>
+						</>
 					) }
 				</>
 			}


### PR DESCRIPTION
First small follow-up to #50463 
Related to #44461 

## What?

This is just a small PR that adds "Quick links" header to the sidebar of both "templates" and "pages" in the site editor to clearly differentiate between the list of pages and templates and the "manage all" links. This is based on some of the mockups on the related issue.

<img width="358" alt="Screenshot 2023-05-10 at 9 46 09 AM" src="https://github.com/WordPress/gutenberg/assets/272444/df720b4c-439c-417e-8644-56304af40431">
<img width="358" alt="Screenshot 2023-05-10 at 9 46 17 AM" src="https://github.com/WordPress/gutenberg/assets/272444/82fe280c-e4fd-49be-a384-331355d188c1">

**Notes**

I've noticed that in the mockups, there are three main differences with the current design:

 - The colors are inverted: the menu items are "white" while the headers are more "gray": I didn't do this here because I kept the existing colors, I'm ok with changing the colors but we'd have to change them for all menus (let me know if I should go this route)
 - There are icons for each menu item: The icons might become handy in "pages" specially when we mix templates and pages, for now, it's all the same, so I didn't add them but I can do it if you think we should go this route now.
 - The "quick links" is kind of forced into the bottom of the sidebar in the mockups: I felt that it's not necessary personally, both because most of the time the list of pages/templates will be long enough and because having two different panels in the bottom (quick links and save panel) seemed not great for me.
