### PR TITLE
Block Editor: Directly import useShouldContextualToolbarShow hook

### DIFF
--- a/packages/block-editor/src/components/block-tools/selected-block-popover.js
+++ b/packages/block-editor/src/components/block-tools/selected-block-popover.js
@@ -20,8 +20,7 @@ import { store as blockEditorStore } from '../../store';
 import BlockPopover from '../block-popover';
 import useBlockToolbarPopoverProps from './use-block-toolbar-popover-props';
 import Inserter from '../inserter';
-import { unlock } from '../../lock-unlock';
-import { privateApis } from '../../private-apis';
+import { useShouldContextualToolbarShow } from '../../utils/use-should-contextual-toolbar-show';
 
 function selector( select ) {
 	const {
@@ -29,7 +28,7 @@ function selector( select ) {
 		hasMultiSelection,
 		isTyping,
 		getLastMultiSelectedBlockClientId,
-	} = unlock( select( blockEditorStore ) );
+	} = select( blockEditorStore );
 
 	return {
 		editorMode: __unstableGetEditorMode(),
@@ -54,7 +53,6 @@ function SelectedBlockPopover( {
 		[]
 	);
 
-	const { useShouldContextualToolbarShow } = unlock( privateApis );
 	const isInsertionPointVisible = useSelect(
 		( select ) => {
 			const {


### PR DESCRIPTION
## What?
This is a follow-up to #49644.

PR removes unnecessary unlocking of private APIs from the `SelectedBlockPopover` component.

## Why?
The file is in the same package as a hook. So there's no need for it to use unlocking API.

## Testing Instructions
1. Open a Post or Page.
2. Insert a block.
3. Confirm block toolbar is displayed as before.