### PR TITLE
Navigation: Unlock private APIs outside of the component

### DIFF
--- a/packages/block-library/src/navigation/edit/menu-inspector-controls.js
+++ b/packages/block-library/src/navigation/edit/menu-inspector-controls.js
@@ -25,6 +25,7 @@ import useNavigationMenu from '../use-navigation-menu';
 
 /* translators: %s: The name of a menu. */
 const actionLabel = __( "Switch to '%s'" );
+const { OffCanvasEditor, LeafMoreMenu } = unlock( blockEditorPrivateApis );
 
 const MainContent = ( {
 	clientId,
@@ -33,7 +34,6 @@ const MainContent = ( {
 	isNavigationMenuMissing,
 	onCreateNew,
 } ) => {
-	const { OffCanvasEditor, LeafMoreMenu } = unlock( blockEditorPrivateApis );
 	// Provide a hierarchy of clientIds for the given Navigation block (clientId).
 	// This is required else the list view will display the entire block tree.
 	const clientIdsTree = useSelect(


### PR DESCRIPTION
## What?
PR unlocks the `OffCanvasEditor` and `LeafMoreMenu` private components outside the function.

## Why?
The private components can be unlocked at the file level. There's no need to perform the action on each component re-render.

## Testing Instructions
1. Open a Post or Page.
2. Insert the Navigation block.
3. Confirm that the off-canvas editor works as before.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2023-05-10 at 14 13 02](https://github.com/WordPress/gutenberg/assets/240569/fbe08558-85b9-41cd-ac97-47a61896971b)
