### PR TITLE
Add new API to allow inserter items to be prioritised

### DIFF
--- a/packages/block-editor/src/components/inner-blocks/README.md
+++ b/packages/block-editor/src/components/inner-blocks/README.md
@@ -180,3 +180,8 @@ For example, a button block, deeply nested in several levels of block `X` that u
 
 -   **Type:** `Function`
 -   **Default:** - `undefined`. The placeholder is an optional function that can be passed in to be a rendered component placed in front of the appender. This can be used to represent an example state prior to any blocks being placed. See the Social Links for an implementation example.
+
+### `prioritizedInserterBlocks`
+
+-   **Type:** `Array`
+-   **Default:** - `undefined`. Determines which inner blocks should be returned first from the block inserter. For example, when inserting a block within the Navigation Block, `core/navigation-link/page` and `core/navigation-link` are the most common inner blocks. We can use `prioritizedInserterBlocks` to pass these `navigation-link` blocks as an array so they can be returned first by default from the Navigation Block inserter.

--- a/packages/block-editor/src/components/inner-blocks/README.md
+++ b/packages/block-editor/src/components/inner-blocks/README.md
@@ -184,4 +184,4 @@ For example, a button block, deeply nested in several levels of block `X` that u
 ### `prioritizedInserterBlocks`
 
 -   **Type:** `Array`
--   **Default:** - `undefined`. Determines which inner blocks should be returned first from the block inserter. For example, when inserting a block within the Navigation Block, `core/navigation-link` and `core/navigation-link/page` are the most common inner blocks. We can use `prioritizedInserterBlocks` to pass these `navigation-link` blocks as an array so they can be returned first by default from the Navigation Block inserter.
+-   **Default:** - `undefined`. Determines which inner blocks should be returned first from the block inserter. For example, when inserting a block within the Navigation Block, `core/navigation-link` and `core/navigation-link/page` are the most commonly used inner blocks. We can use `prioritizedInserterBlocks` to pass these `navigation-link` blocks as an array so they can be returned first by default from the Navigation Block inserter.

--- a/packages/block-editor/src/components/inner-blocks/README.md
+++ b/packages/block-editor/src/components/inner-blocks/README.md
@@ -184,4 +184,4 @@ For example, a button block, deeply nested in several levels of block `X` that u
 ### `prioritizedInserterBlocks`
 
 -   **Type:** `Array`
--   **Default:** - `undefined`. Determines which inner blocks should be returned first from the block inserter. For example, when inserting a block within the Navigation Block, `core/navigation-link/page` and `core/navigation-link` are the most common inner blocks. We can use `prioritizedInserterBlocks` to pass these `navigation-link` blocks as an array so they can be returned first by default from the Navigation Block inserter.
+-   **Default:** - `undefined`. Determines which inner blocks should be returned first from the block inserter. For example, when inserting a block within the Navigation Block, `core/navigation-link` and `core/navigation-link/page` are the most common inner blocks. We can use `prioritizedInserterBlocks` to pass these `navigation-link` blocks as an array so they can be returned first by default from the Navigation Block inserter.

--- a/packages/block-editor/src/components/inner-blocks/README.md
+++ b/packages/block-editor/src/components/inner-blocks/README.md
@@ -184,4 +184,4 @@ For example, a button block, deeply nested in several levels of block `X` that u
 ### `prioritizedInserterBlocks`
 
 -   **Type:** `Array`
--   **Default:** - `undefined`. Determines which inner blocks should be returned first from the block inserter. For example, when inserting a block within the Navigation Block, `core/navigation-link` and `core/navigation-link/page` are the most commonly used inner blocks. We can use `prioritizedInserterBlocks` to pass these `navigation-link` blocks as an array so they can be returned first by default from the Navigation Block inserter.
+-   **Default:** - `undefined`. Determines which block types should be shown in the block inserter. For example, when inserting a block within the Navigation block we specify `core/navigation-link` and `core/navigation-link/page` as these are the most commonly used inner blocks. `prioritizedInserterBlocks` takes an array of the form {blockName}/{variationName}, where {variationName} is optional.

--- a/packages/block-editor/src/components/inner-blocks/index.js
+++ b/packages/block-editor/src/components/inner-blocks/index.js
@@ -45,7 +45,7 @@ function UncontrolledInnerBlocks( props ) {
 	const {
 		clientId,
 		allowedBlocks,
-		inserterPriority,
+		prioritizedInserterBlocks,
 		__experimentalDefaultBlock,
 		__experimentalDirectInsert,
 		template,
@@ -63,7 +63,7 @@ function UncontrolledInnerBlocks( props ) {
 	useNestedSettingsUpdate(
 		clientId,
 		allowedBlocks,
-		inserterPriority,
+		prioritizedInserterBlocks,
 		__experimentalDefaultBlock,
 		__experimentalDirectInsert,
 		templateLock,

--- a/packages/block-editor/src/components/inner-blocks/index.js
+++ b/packages/block-editor/src/components/inner-blocks/index.js
@@ -45,6 +45,7 @@ function UncontrolledInnerBlocks( props ) {
 	const {
 		clientId,
 		allowedBlocks,
+		inserterPriority,
 		__experimentalDefaultBlock,
 		__experimentalDirectInsert,
 		template,
@@ -62,6 +63,7 @@ function UncontrolledInnerBlocks( props ) {
 	useNestedSettingsUpdate(
 		clientId,
 		allowedBlocks,
+		inserterPriority,
 		__experimentalDefaultBlock,
 		__experimentalDirectInsert,
 		templateLock,

--- a/packages/block-editor/src/components/inner-blocks/index.native.js
+++ b/packages/block-editor/src/components/inner-blocks/index.native.js
@@ -73,9 +73,13 @@ function UncontrolledInnerBlocks( props ) {
 	const {
 		clientId,
 		allowedBlocks,
+		prioritizedInserterBlocks,
+		__experimentalDefaultBlock,
+		__experimentalDirectInsert,
 		template,
 		templateLock,
 		templateInsertUpdatesSelection,
+		__experimentalCaptureToolbars: captureToolbars,
 		orientation,
 		renderAppender,
 		renderFooterAppender,
@@ -97,7 +101,17 @@ function UncontrolledInnerBlocks( props ) {
 
 	const context = useBlockContext( clientId );
 
-	useNestedSettingsUpdate( clientId, allowedBlocks, templateLock );
+	useNestedSettingsUpdate(
+		clientId,
+		allowedBlocks,
+		prioritizedInserterBlocks,
+		__experimentalDefaultBlock,
+		__experimentalDirectInsert,
+		templateLock,
+		captureToolbars,
+		orientation,
+		layout
+	);
 
 	useInnerBlockTemplateSync(
 		clientId,

--- a/packages/block-editor/src/components/inner-blocks/use-nested-settings-update.js
+++ b/packages/block-editor/src/components/inner-blocks/use-nested-settings-update.js
@@ -25,7 +25,7 @@ const pendingSettingsUpdates = new WeakMap();
  * @param {string}               clientId                   The client ID of the block to update.
  * @param {string[]}             allowedBlocks              An array of block names which are permitted
  *                                                          in inner blocks.
- * @param {string[]}             inserterPriority           Block names and/or block variations to be prioritised in the inserter.
+ * @param {string[]}             prioritizedInserterBlocks  Block names and/or block variations to be prioritised in the inserter.
  * @param {?WPDirectInsertBlock} __experimentalDefaultBlock The default block to insert: [ blockName, { blockAttributes } ].
  * @param {?Function|boolean}    __experimentalDirectInsert If a default block should be inserted directly by the
  *                                                          appender.
@@ -41,7 +41,7 @@ const pendingSettingsUpdates = new WeakMap();
 export default function useNestedSettingsUpdate(
 	clientId,
 	allowedBlocks,
-	inserterPriority,
+	prioritizedInserterBlocks,
 	__experimentalDefaultBlock,
 	__experimentalDirectInsert,
 	templateLock,
@@ -68,17 +68,22 @@ export default function useNestedSettingsUpdate(
 
 	// Memoize as inner blocks implementors often pass a new array on every
 	// render.
-	const _allowedBlocks = useMemo( () => allowedBlocks, allowedBlocks );
+	const _allowedBlocks = useMemo(
+		() => allowedBlocks,
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+		allowedBlocks
+	);
 
-	const _inserterPriority = useMemo(
-		() => inserterPriority,
-		inserterPriority
+	const _prioritizedInserterBlocks = useMemo(
+		() => prioritizedInserterBlocks,
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+		prioritizedInserterBlocks
 	);
 
 	useLayoutEffect( () => {
 		const newSettings = {
 			allowedBlocks: _allowedBlocks,
-			inserterPriority: _inserterPriority,
+			prioritizedInserterBlocks: _prioritizedInserterBlocks,
 			templateLock:
 				templateLock === undefined || parentLock === 'contentOnly'
 					? parentLock
@@ -138,7 +143,7 @@ export default function useNestedSettingsUpdate(
 		clientId,
 		blockListSettings,
 		_allowedBlocks,
-		_inserterPriority,
+		_prioritizedInserterBlocks,
 		__experimentalDefaultBlock,
 		__experimentalDirectInsert,
 		templateLock,

--- a/packages/block-editor/src/components/inner-blocks/use-nested-settings-update.js
+++ b/packages/block-editor/src/components/inner-blocks/use-nested-settings-update.js
@@ -66,8 +66,11 @@ export default function useNestedSettingsUpdate(
 		[ clientId ]
 	);
 
-	// Memoize as inner blocks implementors often pass a new array on every
-	// render.
+	// Memoize allowedBlocks and prioritisedInnerBlocks based on the contents
+	// of the arrays. Implementors often pass a new array on every render,
+	// and the contents of the arrays are just strings, so the entire array
+	// can be passed as dependencies.
+	
 	const _allowedBlocks = useMemo(
 		() => allowedBlocks,
 		// eslint-disable-next-line react-hooks/exhaustive-deps

--- a/packages/block-editor/src/components/inner-blocks/use-nested-settings-update.js
+++ b/packages/block-editor/src/components/inner-blocks/use-nested-settings-update.js
@@ -25,6 +25,7 @@ const pendingSettingsUpdates = new WeakMap();
  * @param {string}               clientId                   The client ID of the block to update.
  * @param {string[]}             allowedBlocks              An array of block names which are permitted
  *                                                          in inner blocks.
+ * @param {string[]}             inserterPriority           Block names and/or block variations to be prioritised in the inserter.
  * @param {?WPDirectInsertBlock} __experimentalDefaultBlock The default block to insert: [ blockName, { blockAttributes } ].
  * @param {?Function|boolean}    __experimentalDirectInsert If a default block should be inserted directly by the
  *                                                          appender.
@@ -40,6 +41,7 @@ const pendingSettingsUpdates = new WeakMap();
 export default function useNestedSettingsUpdate(
 	clientId,
 	allowedBlocks,
+	inserterPriority,
 	__experimentalDefaultBlock,
 	__experimentalDirectInsert,
 	templateLock,
@@ -68,9 +70,15 @@ export default function useNestedSettingsUpdate(
 	// render.
 	const _allowedBlocks = useMemo( () => allowedBlocks, allowedBlocks );
 
+	const _inserterPriority = useMemo(
+		() => inserterPriority,
+		inserterPriority
+	);
+
 	useLayoutEffect( () => {
 		const newSettings = {
 			allowedBlocks: _allowedBlocks,
+			inserterPriority: _inserterPriority,
 			templateLock:
 				templateLock === undefined || parentLock === 'contentOnly'
 					? parentLock
@@ -130,6 +138,7 @@ export default function useNestedSettingsUpdate(
 		clientId,
 		blockListSettings,
 		_allowedBlocks,
+		_inserterPriority,
 		__experimentalDefaultBlock,
 		__experimentalDirectInsert,
 		templateLock,

--- a/packages/block-editor/src/components/inner-blocks/use-nested-settings-update.js
+++ b/packages/block-editor/src/components/inner-blocks/use-nested-settings-update.js
@@ -25,7 +25,7 @@ const pendingSettingsUpdates = new WeakMap();
  * @param {string}               clientId                   The client ID of the block to update.
  * @param {string[]}             allowedBlocks              An array of block names which are permitted
  *                                                          in inner blocks.
- * @param {string[]}             prioritizedInserterBlocks  Block names and/or block variations to be prioritized in the inserter.
+ * @param {string[]}             prioritizedInserterBlocks  Block names and/or block variations to be prioritized in the inserter, in the format {blockName}/{variationName}.
  * @param {?WPDirectInsertBlock} __experimentalDefaultBlock The default block to insert: [ blockName, { blockAttributes } ].
  * @param {?Function|boolean}    __experimentalDirectInsert If a default block should be inserted directly by the
  *                                                          appender.

--- a/packages/block-editor/src/components/inner-blocks/use-nested-settings-update.js
+++ b/packages/block-editor/src/components/inner-blocks/use-nested-settings-update.js
@@ -25,7 +25,7 @@ const pendingSettingsUpdates = new WeakMap();
  * @param {string}               clientId                   The client ID of the block to update.
  * @param {string[]}             allowedBlocks              An array of block names which are permitted
  *                                                          in inner blocks.
- * @param {string[]}             prioritizedInserterBlocks  Block names and/or block variations to be prioritised in the inserter.
+ * @param {string[]}             prioritizedInserterBlocks  Block names and/or block variations to be prioritized in the inserter.
  * @param {?WPDirectInsertBlock} __experimentalDefaultBlock The default block to insert: [ blockName, { blockAttributes } ].
  * @param {?Function|boolean}    __experimentalDirectInsert If a default block should be inserted directly by the
  *                                                          appender.

--- a/packages/block-editor/src/components/inner-blocks/use-nested-settings-update.js
+++ b/packages/block-editor/src/components/inner-blocks/use-nested-settings-update.js
@@ -70,7 +70,7 @@ export default function useNestedSettingsUpdate(
 	// of the arrays. Implementors often pass a new array on every render,
 	// and the contents of the arrays are just strings, so the entire array
 	// can be passed as dependencies.
-	
+
 	const _allowedBlocks = useMemo(
 		() => allowedBlocks,
 		// eslint-disable-next-line react-hooks/exhaustive-deps

--- a/packages/block-editor/src/components/inserter/index.js
+++ b/packages/block-editor/src/components/inserter/index.js
@@ -150,7 +150,6 @@ class PrivateInserter extends Component {
 			prioritizePatterns,
 			onSelectOrClose,
 			selectBlockOnInsert,
-			orderInitialBlockItems,
 		} = this.props;
 
 		if ( isQuick ) {
@@ -174,7 +173,6 @@ class PrivateInserter extends Component {
 					isAppender={ isAppender }
 					prioritizePatterns={ prioritizePatterns }
 					selectBlockOnInsert={ selectBlockOnInsert }
-					orderInitialBlockItems={ orderInitialBlockItems }
 				/>
 			);
 		}
@@ -426,13 +424,7 @@ export const ComposedPrivateInserter = compose( [
 ] )( PrivateInserter );
 
 const Inserter = forwardRef( ( props, ref ) => {
-	return (
-		<ComposedPrivateInserter
-			ref={ ref }
-			{ ...props }
-			orderInitialBlockItems={ undefined }
-		/>
-	);
+	return <ComposedPrivateInserter ref={ ref } { ...props } />;
 } );
 
 export default Inserter;

--- a/packages/block-editor/src/components/inserter/quick-inserter.js
+++ b/packages/block-editor/src/components/inserter/quick-inserter.js
@@ -32,7 +32,6 @@ export default function QuickInserter( {
 	isAppender,
 	prioritizePatterns,
 	selectBlockOnInsert,
-	orderInitialBlockItems,
 } ) {
 	const [ filterValue, setFilterValue ] = useState( '' );
 	const [ destinationRootClientId, onInsertBlocks ] = useInsertionPoint( {
@@ -125,7 +124,6 @@ export default function QuickInserter( {
 					isDraggable={ false }
 					prioritizePatterns={ prioritizePatterns }
 					selectBlockOnInsert={ selectBlockOnInsert }
-					orderInitialBlockItems={ orderInitialBlockItems }
 				/>
 			</div>
 

--- a/packages/block-editor/src/components/inserter/search-results.js
+++ b/packages/block-editor/src/components/inserter/search-results.js
@@ -50,7 +50,19 @@ function InserterSearchResults( {
 	selectBlockOnInsert,
 } ) {
 	const debouncedSpeak = useDebounce( speak, 500 );
-	const { getBlockListSettings } = useSelect( blockEditorStore );
+
+	const { parentInserterPriority } = useSelect(
+		( select ) => {
+			const { inserterPriority } =
+				select( blockEditorStore ).getBlockListSettings( rootClientId );
+
+			return {
+				parentInserterPriority: inserterPriority,
+			};
+		},
+		[ rootClientId ]
+	);
+
 	const [ destinationRootClientId, onInsertBlocks ] = useInsertionPoint( {
 		onSelect,
 		rootClientId,
@@ -70,9 +82,6 @@ function InserterSearchResults( {
 		onInsertBlocks,
 		destinationRootClientId
 	);
-
-	const parentBlockListSettings = getBlockListSettings( rootClientId );
-	const parentInserterPriority = parentBlockListSettings?.inserterPriority;
 
 	const filteredBlockPatterns = useMemo( () => {
 		if ( maxBlockPatterns === 0 ) {

--- a/packages/block-editor/src/components/inserter/search-results.js
+++ b/packages/block-editor/src/components/inserter/search-results.js
@@ -92,7 +92,7 @@ function InserterSearchResults( {
 	const orderInitialBlockItems = useCallback(
 		( items ) => {
 			items.sort( ( { id: aName }, { id: bName } ) => {
-				// Sort block items according to `prioritizedInserterBlocks`.
+				// Sort block items according to `parentInserterPriority`.
 				let aIndex = parentInserterPriority.indexOf( aName );
 				let bIndex = parentInserterPriority.indexOf( bName );
 				// All other block items should come after that.

--- a/packages/block-editor/src/components/inserter/search-results.js
+++ b/packages/block-editor/src/components/inserter/search-results.js
@@ -38,7 +38,6 @@ const orderInitialBlockItems = ( items, priority ) => {
 		return items;
 	}
 
-	// Sort is "in place".
 	items.sort( ( { id: aName }, { id: bName } ) => {
 		// Sort block items according to `priority`.
 		let aIndex = priority.indexOf( aName );

--- a/packages/block-editor/src/components/inserter/search-results.js
+++ b/packages/block-editor/src/components/inserter/search-results.js
@@ -70,13 +70,13 @@ function InserterSearchResults( {
 } ) {
 	const debouncedSpeak = useDebounce( speak, 500 );
 
-	const { parentInserterPriority } = useSelect(
+	const { prioritisedBlocks } = useSelect(
 		( select ) => {
-			const { inserterPriority } =
+			const { prioritizedInserterBlocks } =
 				select( blockEditorStore ).getBlockListSettings( rootClientId );
 
 			return {
-				parentInserterPriority: inserterPriority,
+				prioritisedBlocks: prioritizedInserterBlocks,
 			};
 		},
 		[ rootClientId ]
@@ -124,10 +124,10 @@ function InserterSearchResults( {
 
 		let orderedItems = orderBy( blockTypes, 'frecency', 'desc' );
 
-		if ( ! filterValue && parentInserterPriority ) {
+		if ( ! filterValue && prioritisedBlocks ) {
 			orderedItems = orderInitialBlockItems(
 				orderedItems,
-				parentInserterPriority
+				prioritisedBlocks
 			);
 		}
 
@@ -147,7 +147,7 @@ function InserterSearchResults( {
 		blockTypeCategories,
 		blockTypeCollections,
 		maxBlockTypesToShow,
-		parentInserterPriority,
+		prioritisedBlocks,
 	] );
 
 	// Announce search results on change.

--- a/packages/block-editor/src/components/inserter/search-results.js
+++ b/packages/block-editor/src/components/inserter/search-results.js
@@ -69,13 +69,13 @@ function InserterSearchResults( {
 } ) {
 	const debouncedSpeak = useDebounce( speak, 500 );
 
-	const { prioritisedBlocks } = useSelect(
+	const { prioritizedBlocks } = useSelect(
 		( select ) => {
 			const blockListSettings =
 				select( blockEditorStore ).getBlockListSettings( rootClientId );
 
 			return {
-				prioritisedBlocks:
+				prioritizedBlocks:
 					blockListSettings?.prioritizedInserterBlocks || [],
 			};
 		},
@@ -124,10 +124,10 @@ function InserterSearchResults( {
 
 		let orderedItems = orderBy( blockTypes, 'frecency', 'desc' );
 
-		if ( ! filterValue && prioritisedBlocks.length ) {
+		if ( ! filterValue && prioritizedBlocks.length ) {
 			orderedItems = orderInitialBlockItems(
 				orderedItems,
-				prioritisedBlocks
+				prioritizedBlocks
 			);
 		}
 
@@ -147,7 +147,7 @@ function InserterSearchResults( {
 		blockTypeCategories,
 		blockTypeCollections,
 		maxBlockTypesToShow,
-		prioritisedBlocks,
+		prioritizedBlocks,
 	] );
 
 	// Announce search results on change.

--- a/packages/block-editor/src/components/inserter/search-results.js
+++ b/packages/block-editor/src/components/inserter/search-results.js
@@ -76,7 +76,7 @@ function InserterSearchResults( {
 
 			return {
 				prioritizedBlocks:
-					blockListSettings?.prioritizedInserterBlocks || [],
+					blockListSettings?.prioritizedInserterBlocks || EMPTY_ARRAY,
 			};
 		},
 		[ rootClientId ]

--- a/packages/block-editor/src/components/inserter/search-results.js
+++ b/packages/block-editor/src/components/inserter/search-results.js
@@ -71,11 +71,12 @@ function InserterSearchResults( {
 
 	const { prioritisedBlocks } = useSelect(
 		( select ) => {
-			const { prioritizedInserterBlocks } =
+			const blockListSettings =
 				select( blockEditorStore ).getBlockListSettings( rootClientId );
 
 			return {
-				prioritisedBlocks: prioritizedInserterBlocks,
+				prioritisedBlocks:
+					blockListSettings?.prioritizedInserterBlocks || [],
 			};
 		},
 		[ rootClientId ]
@@ -123,7 +124,7 @@ function InserterSearchResults( {
 
 		let orderedItems = orderBy( blockTypes, 'frecency', 'desc' );
 
-		if ( ! filterValue && prioritisedBlocks ) {
+		if ( ! filterValue && prioritisedBlocks.length ) {
 			orderedItems = orderInitialBlockItems(
 				orderedItems,
 				prioritisedBlocks

--- a/packages/block-editor/src/components/inserter/search-results.js
+++ b/packages/block-editor/src/components/inserter/search-results.js
@@ -6,6 +6,7 @@ import { __, _n, sprintf } from '@wordpress/i18n';
 import { VisuallyHidden } from '@wordpress/components';
 import { useDebounce, useAsyncList } from '@wordpress/compose';
 import { speak } from '@wordpress/a11y';
+import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -21,6 +22,7 @@ import useBlockTypesState from './hooks/use-block-types-state';
 import { searchBlockItems, searchItems } from './search-items';
 import InserterListbox from '../inserter-listbox';
 import { orderBy } from '../../utils/sorting';
+import { store as blockEditorStore } from '../../store';
 
 const INITIAL_INSERTER_RESULTS = 9;
 /**
@@ -49,7 +51,7 @@ function InserterSearchResults( {
 	orderInitialBlockItems,
 } ) {
 	const debouncedSpeak = useDebounce( speak, 500 );
-
+	const { getBlockListSettings } = useSelect( blockEditorStore );
 	const [ destinationRootClientId, onInsertBlocks ] = useInsertionPoint( {
 		onSelect,
 		rootClientId,
@@ -89,12 +91,25 @@ function InserterSearchResults( {
 		if ( maxBlockTypesToShow === 0 ) {
 			return [];
 		}
+
 		let orderedItems = orderBy( blockTypes, 'frecency', 'desc' );
 		if ( ! filterValue && orderInitialBlockItems ) {
 			orderedItems = orderInitialBlockItems( orderedItems );
 		}
+
+		// Get the allowed blocks for the parent block.
+		const parentBlockListSettings = getBlockListSettings(
+			state,
+			rootClientId
+		);
+		const parentAllowedBlocks = parentBlockListSettings?.allowedBlocks;
+		if ( parentAllowedBlocks ) {
+			console.log( 'parentAllowedBlocks', parentAllowedBlocks );
+			// Use the parent allowed blocks to sort the results.
+		}
+
 		const results = searchBlockItems(
-			orderedItems,
+			blockTypes,
 			blockTypeCategories,
 			blockTypeCollections,
 			filterValue

--- a/packages/block-editor/src/components/off-canvas-editor/appender.js
+++ b/packages/block-editor/src/components/off-canvas-editor/appender.js
@@ -4,12 +4,7 @@
 import { useInstanceId } from '@wordpress/compose';
 import { speak } from '@wordpress/a11y';
 import { useSelect } from '@wordpress/data';
-import {
-	forwardRef,
-	useState,
-	useEffect,
-	useCallback,
-} from '@wordpress/element';
+import { forwardRef, useState, useEffect } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 
 /**
@@ -18,11 +13,6 @@ import { __, sprintf } from '@wordpress/i18n';
 import { store as blockEditorStore } from '../../store';
 import useBlockDisplayTitle from '../block-title/use-block-display-title';
 import { ComposedPrivateInserter as PrivateInserter } from '../inserter';
-
-const prioritizedInserterBlocks = [
-	'core/navigation-link/page',
-	'core/navigation-link',
-];
 
 export const Appender = forwardRef(
 	( { nestingLevel, blockCount, clientId, ...props }, ref ) => {
@@ -68,19 +58,6 @@ export const Appender = forwardRef(
 			);
 		}, [ insertedBlockTitle ] );
 
-		const orderInitialBlockItems = useCallback( ( items ) => {
-			items.sort( ( { id: aName }, { id: bName } ) => {
-				// Sort block items according to `prioritizedInserterBlocks`.
-				let aIndex = prioritizedInserterBlocks.indexOf( aName );
-				let bIndex = prioritizedInserterBlocks.indexOf( bName );
-				// All other block items should come after that.
-				if ( aIndex < 0 ) aIndex = prioritizedInserterBlocks.length;
-				if ( bIndex < 0 ) bIndex = prioritizedInserterBlocks.length;
-				return aIndex - bIndex;
-			} );
-			return items;
-		}, [] );
-
 		if ( hideInserter ) {
 			return null;
 		}
@@ -110,7 +87,6 @@ export const Appender = forwardRef(
 							setInsertedBlock( maybeInsertedBlock );
 						}
 					} }
-					orderInitialBlockItems={ orderInitialBlockItems }
 				/>
 				<div
 					className="offcanvas-editor-appender__description"

--- a/packages/block-library/src/navigation/constants.js
+++ b/packages/block-library/src/navigation/constants.js
@@ -16,6 +16,7 @@ export const ALLOWED_BLOCKS = [
 ];
 
 export const INSERTER_PRIORITY = [
+	'core/spacer',
 	'core/navigation-link/page',
 	'core/navigation-link',
 ];

--- a/packages/block-library/src/navigation/constants.js
+++ b/packages/block-library/src/navigation/constants.js
@@ -14,3 +14,8 @@ export const ALLOWED_BLOCKS = [
 	'core/navigation-submenu',
 	'core/loginout',
 ];
+
+export const INSERTER_PRIORITY = [
+	'core/navigation-link/page',
+	'core/navigation-link',
+];

--- a/packages/block-library/src/navigation/constants.js
+++ b/packages/block-library/src/navigation/constants.js
@@ -15,7 +15,7 @@ export const ALLOWED_BLOCKS = [
 	'core/loginout',
 ];
 
-export const INSERTER_PRIORITY = [
+export const PRIORITIZED_INSERTER_BLOCKS = [
 	'core/navigation-link/page',
 	'core/navigation-link',
 ];

--- a/packages/block-library/src/navigation/constants.js
+++ b/packages/block-library/src/navigation/constants.js
@@ -16,7 +16,6 @@ export const ALLOWED_BLOCKS = [
 ];
 
 export const INSERTER_PRIORITY = [
-	'core/spacer',
 	'core/navigation-link/page',
 	'core/navigation-link',
 ];

--- a/packages/block-library/src/navigation/edit/inner-blocks.js
+++ b/packages/block-library/src/navigation/edit/inner-blocks.js
@@ -14,7 +14,7 @@ import { useMemo } from '@wordpress/element';
  * Internal dependencies
  */
 import PlaceholderPreview from './placeholder/placeholder-preview';
-import { DEFAULT_BLOCK, ALLOWED_BLOCKS } from '../constants';
+import { DEFAULT_BLOCK, ALLOWED_BLOCKS, INSERTER_PRIORITY } from '../constants';
 
 export default function NavigationInnerBlocks( {
 	clientId,
@@ -93,6 +93,7 @@ export default function NavigationInnerBlocks( {
 			onInput,
 			onChange,
 			allowedBlocks: ALLOWED_BLOCKS,
+			inserterPriority: INSERTER_PRIORITY,
 			__experimentalDefaultBlock: DEFAULT_BLOCK,
 			__experimentalDirectInsert: shouldDirectInsert,
 			orientation,

--- a/packages/block-library/src/navigation/edit/inner-blocks.js
+++ b/packages/block-library/src/navigation/edit/inner-blocks.js
@@ -14,7 +14,11 @@ import { useMemo } from '@wordpress/element';
  * Internal dependencies
  */
 import PlaceholderPreview from './placeholder/placeholder-preview';
-import { DEFAULT_BLOCK, ALLOWED_BLOCKS, INSERTER_PRIORITY } from '../constants';
+import {
+	DEFAULT_BLOCK,
+	ALLOWED_BLOCKS,
+	PRIORITIZED_INSERTER_BLOCKS,
+} from '../constants';
 
 export default function NavigationInnerBlocks( {
 	clientId,
@@ -93,7 +97,7 @@ export default function NavigationInnerBlocks( {
 			onInput,
 			onChange,
 			allowedBlocks: ALLOWED_BLOCKS,
-			prioritizedInserterBlocks: INSERTER_PRIORITY,
+			prioritizedInserterBlocks: PRIORITIZED_INSERTER_BLOCKS,
 			__experimentalDefaultBlock: DEFAULT_BLOCK,
 			__experimentalDirectInsert: shouldDirectInsert,
 			orientation,

--- a/packages/block-library/src/navigation/edit/inner-blocks.js
+++ b/packages/block-library/src/navigation/edit/inner-blocks.js
@@ -93,7 +93,7 @@ export default function NavigationInnerBlocks( {
 			onInput,
 			onChange,
 			allowedBlocks: ALLOWED_BLOCKS,
-			inserterPriority: INSERTER_PRIORITY,
+			prioritizedInserterBlocks: INSERTER_PRIORITY,
 			__experimentalDefaultBlock: DEFAULT_BLOCK,
 			__experimentalDirectInsert: shouldDirectInsert,
 			orientation,

--- a/packages/e2e-test-utils/src/get-all-block-inserter-item-titles.js
+++ b/packages/e2e-test-utils/src/get-all-block-inserter-item-titles.js
@@ -20,5 +20,5 @@ export async function getAllBlockInserterItemTitles() {
 			return inserterItem.innerText;
 		} );
 	} );
-	return [ ...new Set( inserterItemTitles ) ].sort();
+	return [ ...new Set( inserterItemTitles ) ];
 }

--- a/packages/e2e-tests/plugins/inner-blocks-prioritized-inserter-blocks.php
+++ b/packages/e2e-tests/plugins/inner-blocks-prioritized-inserter-blocks.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Plugin Name: Gutenberg Test InnerBlocks Prioritized Inserter Blocks
+ * Plugin URI: https://github.com/WordPress/gutenberg
+ * Author: Gutenberg Team
+ *
+ * @package gutenberg-test-inner-blocks-prioritized-inserter-blocks
+ */
+
+/**
+ * Registers a custom script for the plugin.
+ */
+function enqueue_inner_blocks_prioritized_inserter_blocks_script() {
+	wp_enqueue_script(
+		'gutenberg-test-inner-blocks-prioritized-inserter-blocks',
+		plugins_url( 'inner-blocks-prioritized-inserter-blocks/index.js', __FILE__ ),
+		array(
+			'wp-blocks',
+			'wp-block-editor',
+			'wp-element',
+			'wp-i18n',
+		),
+		filemtime( plugin_dir_path( __FILE__ ) . 'inner-blocks-prioritized-inserter-blocks/index.js' ),
+		true
+	);
+}
+
+add_action( 'init', 'enqueue_inner_blocks_prioritized_inserter_blocks_script' );

--- a/packages/e2e-tests/plugins/inner-blocks-prioritized-inserter-blocks/index.js
+++ b/packages/e2e-tests/plugins/inner-blocks-prioritized-inserter-blocks/index.js
@@ -2,7 +2,6 @@
 	const { registerBlockType } = wp.blocks;
 	const { createElement: el } = wp.element;
 	const { InnerBlocks } = wp.blockEditor;
-	const __ = wp.i18n.__;
 
     const divProps = {
 		className: 'product',
@@ -51,32 +50,32 @@
 		save,
 	} );
 
-	// registerBlockType( 'test/prioritized-inserter-blocks-dynamic', {
-	// 	title: 'Allowed Blocks Dynamic',
-	// 	icon: 'carrot',
-	// 	category: 'text',
+    registerBlockType( 'test/prioritized-inserter-blocks-set-with-conflicting-allowed-blocks', {
+		title: 'Prioritized Inserter Blocks Set With Conflicting Allowed Blocks',
+		icon: 'carrot',
+		category: 'text',
+		edit() {
+			return el(
+				'div',
+				divProps,
+				el( InnerBlocks, {
+                    template,
+                    allowedBlocks: [
+                        'core/spacer',
+                        'core/code',
+                        'core/paragraph',
+                        'core/heading'
+                    ],
+					prioritizedInserterBlocks: [
+                        'core/audio', // this is **not** in the allowedBlocks list
+						'core/spacer',
+                        'core/code',
+					],
+				} )
+			);
+		},
 
-	// 	edit: withSelect( function ( select, ownProps ) {
-	// 		const getBlockOrder = select( 'core/block-editor' ).getBlockOrder;
-	// 		return {
-	// 			numberOfChildren: getBlockOrder( ownProps.clientId ).length,
-	// 		};
-	// 	} )( function ( props ) {
-	// 		return el(
-	// 			'div',
-	// 			{
-	// 				...divProps,
-	// 				'data-number-of-children': props.numberOfChildren,
-	// 			},
-	// 			el( InnerBlocks, {
-	// 				allowedBlocks:
-	// 					props.numberOfChildren < 2
-	// 						? allowedBlocksWhenSingleEmptyChild
-	// 						: allowedBlocksWhenMultipleChildren,
-	// 			} )
-	// 		);
-	// 	} ),
+		save,
+	} );
 
-	// 	save,
-	// } );
 } )();

--- a/packages/e2e-tests/plugins/inner-blocks-prioritized-inserter-blocks/index.js
+++ b/packages/e2e-tests/plugins/inner-blocks-prioritized-inserter-blocks/index.js
@@ -8,7 +8,8 @@
 		style: { outline: '1px solid gray', padding: 5 },
 	};
 
-    // Make it easier to select the block.
+    // without a placeholder within the inner blocks it can be difficult to select the block using e2e tests
+    // especially using Puppeteer, so we use an image block which has a placeholder.
 	const template = [
 		[ 'core/image' ],
     ];

--- a/packages/e2e-tests/plugins/inner-blocks-prioritized-inserter-blocks/index.js
+++ b/packages/e2e-tests/plugins/inner-blocks-prioritized-inserter-blocks/index.js
@@ -3,15 +3,16 @@
 	const { createElement: el } = wp.element;
 	const { InnerBlocks } = wp.blockEditor;
 	const __ = wp.i18n.__;
-	const divProps = {
+
+    const divProps = {
 		className: 'product',
 		style: { outline: '1px solid gray', padding: 5 },
 	};
+
+    // Make it easier to select the block.
 	const template = [
 		[ 'core/image' ],
-		[ 'core/paragraph', { placeholder: __( 'Add a description' ) } ],
-		[ 'core/quote' ],
-	];
+    ];
 
 	const save = function () {
 		return el( 'div', divProps, el( InnerBlocks.Content ) );
@@ -37,10 +38,11 @@
 				'div',
 				divProps,
 				el( InnerBlocks, {
-					template,
+                    template,
 					prioritizedInserterBlocks: [
+                        'core/audio',
 						'core/spacer',
-						'core/button',
+                        'core/code',
 					],
 				} )
 			);

--- a/packages/e2e-tests/plugins/inner-blocks-prioritized-inserter-blocks/index.js
+++ b/packages/e2e-tests/plugins/inner-blocks-prioritized-inserter-blocks/index.js
@@ -1,0 +1,87 @@
+( function () {
+	const { withSelect } = wp.data;
+	const { registerBlockType } = wp.blocks;
+	const { createElement: el } = wp.element;
+	const { InnerBlocks } = wp.blockEditor;
+	const __ = wp.i18n.__;
+	const divProps = {
+		className: 'product',
+		style: { outline: '1px solid gray', padding: 5 },
+	};
+	const template = [
+		[ 'core/image' ],
+		[ 'core/paragraph', { placeholder: __( 'Add a description' ) } ],
+		[ 'core/quote' ],
+	];
+	const allowedBlocksWhenSingleEmptyChild = [ 'core/image', 'core/list' ];
+	const allowedBlocksWhenMultipleChildren = [ 'core/gallery', 'core/video' ];
+
+	const save = function () {
+		return el( 'div', divProps, el( InnerBlocks.Content ) );
+	};
+	registerBlockType( 'test/prioritized-inserter-blocks-unset', {
+		title: 'Prioritized Inserter Blocks Unset',
+		icon: 'carrot',
+		category: 'text',
+
+		edit() {
+			return el( 'div', divProps, el( InnerBlocks, { template } ) );
+		},
+
+		save,
+	} );
+
+	// registerBlockType( 'test/allowed-blocks-set', {
+	// 	title: 'Allowed Blocks Set',
+	// 	icon: 'carrot',
+	// 	category: 'text',
+
+	// 	edit() {
+	// 		return el(
+	// 			'div',
+	// 			divProps,
+	// 			el( InnerBlocks, {
+	// 				template,
+	// 				allowedBlocks: [
+	// 					'core/button',
+	// 					'core/gallery',
+	// 					'core/list',
+	// 					'core/media-text',
+	// 					'core/quote',
+	// 				],
+	// 			} )
+	// 		);
+	// 	},
+
+	// 	save,
+	// } );
+
+	// registerBlockType( 'test/allowed-blocks-dynamic', {
+	// 	title: 'Allowed Blocks Dynamic',
+	// 	icon: 'carrot',
+	// 	category: 'text',
+
+	// 	edit: withSelect( function ( select, ownProps ) {
+	// 		const getBlockOrder = select( 'core/block-editor' ).getBlockOrder;
+	// 		return {
+	// 			numberOfChildren: getBlockOrder( ownProps.clientId ).length,
+	// 		};
+	// 	} )( function ( props ) {
+	// 		return el(
+	// 			'div',
+	// 			{
+	// 				...divProps,
+	// 				'data-number-of-children': props.numberOfChildren,
+	// 			},
+	// 			el( InnerBlocks, {
+	// 				allowedBlocks:
+	// 					props.numberOfChildren < 2
+	// 						? allowedBlocksWhenSingleEmptyChild
+	// 						: allowedBlocksWhenMultipleChildren,
+	// 			} )
+	// 		);
+	// 	} ),
+
+	// 	save,
+	// } );
+} )();

--- a/packages/e2e-tests/plugins/inner-blocks-prioritized-inserter-blocks/index.js
+++ b/packages/e2e-tests/plugins/inner-blocks-prioritized-inserter-blocks/index.js
@@ -1,5 +1,4 @@
 ( function () {
-	const { withSelect } = wp.data;
 	const { registerBlockType } = wp.blocks;
 	const { createElement: el } = wp.element;
 	const { InnerBlocks } = wp.blockEditor;
@@ -13,8 +12,6 @@
 		[ 'core/paragraph', { placeholder: __( 'Add a description' ) } ],
 		[ 'core/quote' ],
 	];
-	const allowedBlocksWhenSingleEmptyChild = [ 'core/image', 'core/list' ];
-	const allowedBlocksWhenMultipleChildren = [ 'core/gallery', 'core/video' ];
 
 	const save = function () {
 		return el( 'div', divProps, el( InnerBlocks.Content ) );
@@ -31,32 +28,28 @@
 		save,
 	} );
 
-	// registerBlockType( 'test/allowed-blocks-set', {
-	// 	title: 'Allowed Blocks Set',
-	// 	icon: 'carrot',
-	// 	category: 'text',
+	registerBlockType( 'test/prioritized-inserter-blocks-set', {
+		title: 'Prioritized Inserter Blocks Set',
+		icon: 'carrot',
+		category: 'text',
+		edit() {
+			return el(
+				'div',
+				divProps,
+				el( InnerBlocks, {
+					template,
+					prioritizedInserterBlocks: [
+						'core/spacer',
+						'core/button',
+					],
+				} )
+			);
+		},
 
-	// 	edit() {
-	// 		return el(
-	// 			'div',
-	// 			divProps,
-	// 			el( InnerBlocks, {
-	// 				template,
-	// 				allowedBlocks: [
-	// 					'core/button',
-	// 					'core/gallery',
-	// 					'core/list',
-	// 					'core/media-text',
-	// 					'core/quote',
-	// 				],
-	// 			} )
-	// 		);
-	// 	},
+		save,
+	} );
 
-	// 	save,
-	// } );
-
-	// registerBlockType( 'test/allowed-blocks-dynamic', {
+	// registerBlockType( 'test/prioritized-inserter-blocks-dynamic', {
 	// 	title: 'Allowed Blocks Dynamic',
 	// 	icon: 'carrot',
 	// 	category: 'text',

--- a/packages/e2e-tests/specs/editor/plugins/child-blocks.test.js
+++ b/packages/e2e-tests/specs/editor/plugins/child-blocks.test.js
@@ -56,7 +56,8 @@ describe( 'Child Blocks', () => {
 			'[data-type="test/child-blocks-restricted-parent"] .block-editor-default-block-appender'
 		);
 		await openGlobalBlockInserter();
-		expect( await getAllBlockInserterItemTitles() ).toEqual( [
+		const allowedBlocks = await getAllBlockInserterItemTitles();
+		expect( allowedBlocks.sort() ).toEqual( [
 			'Child Blocks Child',
 			'Image',
 			'Paragraph',

--- a/packages/e2e-tests/specs/editor/plugins/inner-blocks-allowed-blocks.test.js
+++ b/packages/e2e-tests/specs/editor/plugins/inner-blocks-allowed-blocks.test.js
@@ -50,7 +50,8 @@ describe( 'Allowed Blocks Setting on InnerBlocks', () => {
 		await page.waitForSelector( childParagraphSelector );
 		await page.click( childParagraphSelector );
 		await openGlobalBlockInserter();
-		expect( await getAllBlockInserterItemTitles() ).toEqual( [
+		const allowedBlocks = await getAllBlockInserterItemTitles();
+		expect( allowedBlocks.sort() ).toEqual( [
 			'Button',
 			'Gallery',
 			'List',
@@ -75,7 +76,7 @@ describe( 'Allowed Blocks Setting on InnerBlocks', () => {
 			await page.$x( `//button//span[contains(text(), 'List')]` )
 		 )[ 0 ];
 		await insertButton.click();
-		// Select the list wrapper so the image is inserable.
+		// Select the list wrapper so the image is insertable.
 		await page.keyboard.press( 'ArrowUp' );
 		await insertBlock( 'Image' );
 		await closeGlobalBlockInserter();

--- a/packages/e2e-tests/specs/editor/plugins/inner-blocks-prioritized-inserter-blocks.test.js
+++ b/packages/e2e-tests/specs/editor/plugins/inner-blocks-prioritized-inserter-blocks.test.js
@@ -7,14 +7,13 @@ import {
 	deactivatePlugin,
 	getAllBlockInserterItemTitles,
 	insertBlock,
-	openGlobalBlockInserter,
 	closeGlobalBlockInserter,
-	clickBlockToolbarButton,
 } from '@wordpress/e2e-test-utils';
 
+const QUICK_INSERTER_RESULTS_SELECTOR =
+	'.block-editor-inserter__quick-inserter-results';
+
 describe( 'Prioritized Inserter Blocks Setting on InnerBlocks', () => {
-	const imageBlockSelector =
-		'.block-editor-rich-text__editable[data-type="core/paragraph"]';
 	beforeAll( async () => {
 		await activatePlugin(
 			'gutenberg-test-innerblocks-prioritized-inserter-blocks'
@@ -31,7 +30,7 @@ describe( 'Prioritized Inserter Blocks Setting on InnerBlocks', () => {
 		);
 	} );
 
-	it( 'allows all blocks if the allowed blocks setting was not set', async () => {
+	it( 'uses defaulting ordering if prioritzed blocks setting was not set', async () => {
 		const parentBlockSelector =
 			'[data-type="test/prioritized-inserter-blocks-unset"]';
 		await insertBlock( 'Prioritized Inserter Blocks Unset' );
@@ -40,12 +39,10 @@ describe( 'Prioritized Inserter Blocks Setting on InnerBlocks', () => {
 		await page.waitForSelector( parentBlockSelector );
 
 		await page.click(
-			`[data-type="test/prioritized-inserter-blocks-unset"] .block-list-appender .block-editor-inserter__toggle`
+			`${ parentBlockSelector } .block-list-appender .block-editor-inserter__toggle`
 		);
 
-		await page.waitForSelector(
-			'.block-editor-inserter__quick-inserter-results'
-		);
+		await page.waitForSelector( QUICK_INSERTER_RESULTS_SELECTOR );
 
 		await expect( await getAllBlockInserterItemTitles() ).toHaveLength( 6 );
 	} );

--- a/packages/e2e-tests/specs/editor/plugins/inner-blocks-prioritized-inserter-blocks.test.js
+++ b/packages/e2e-tests/specs/editor/plugins/inner-blocks-prioritized-inserter-blocks.test.js
@@ -64,6 +64,9 @@ describe( 'Prioritized Inserter Blocks Setting on InnerBlocks', () => {
 		// Should still be only 6 results regardless of the priority ordering.
 		const inserterItems = await getAllBlockInserterItemTitles();
 
+		// Should still be only 6 results regardless of the priority ordering.
+		expect( inserterItems ).toHaveLength( 6 );
+
 		expect( inserterItems.slice( 0, 3 ) ).toEqual( [
 			'Audio',
 			'Spacer',

--- a/packages/e2e-tests/specs/editor/plugins/inner-blocks-prioritized-inserter-blocks.test.js
+++ b/packages/e2e-tests/specs/editor/plugins/inner-blocks-prioritized-inserter-blocks.test.js
@@ -64,7 +64,7 @@ describe( 'Prioritized Inserter Blocks Setting on InnerBlocks', () => {
 		// Should still be only 6 results regardless of the priority ordering.
 		const inserterItems = await getAllBlockInserterItemTitles();
 
-		expect( inserterItems.slice( 0, 2 ) ).toEqual( [
+		expect( inserterItems.slice( 0, 3 ) ).toEqual( [
 			'Audio',
 			'Spacer',
 			'Code',

--- a/packages/e2e-tests/specs/editor/plugins/inner-blocks-prioritized-inserter-blocks.test.js
+++ b/packages/e2e-tests/specs/editor/plugins/inner-blocks-prioritized-inserter-blocks.test.js
@@ -70,4 +70,32 @@ describe( 'Prioritized Inserter Blocks Setting on InnerBlocks', () => {
 			'Code',
 		] );
 	} );
+
+	it( 'obeys allowed blocks over prioritzed blocks setting if conflicted', async () => {
+		const parentBlockSelector =
+			'[data-type="test/prioritized-inserter-blocks-set-with-conflicting-allowed-blocks"]';
+		await insertBlock(
+			'Prioritized Inserter Blocks Set With Conflicting Allowed Blocks'
+		);
+		await closeGlobalBlockInserter();
+
+		await page.waitForSelector( parentBlockSelector );
+
+		await page.click(
+			`${ parentBlockSelector } .block-list-appender .block-editor-inserter__toggle`
+		);
+
+		await page.waitForSelector( QUICK_INSERTER_RESULTS_SELECTOR );
+
+		const inserterItems = await getAllBlockInserterItemTitles();
+
+		expect( inserterItems.slice( 0, 3 ) ).toEqual( [
+			'Spacer',
+			'Code',
+			'Paragraph',
+		] );
+		expect( inserterItems ).toEqual(
+			expect.not.arrayContaining( [ 'Audio' ] )
+		);
+	} );
 } );

--- a/packages/e2e-tests/specs/editor/plugins/inner-blocks-prioritized-inserter-blocks.test.js
+++ b/packages/e2e-tests/specs/editor/plugins/inner-blocks-prioritized-inserter-blocks.test.js
@@ -47,56 +47,27 @@ describe( 'Prioritized Inserter Blocks Setting on InnerBlocks', () => {
 		await expect( await getAllBlockInserterItemTitles() ).toHaveLength( 6 );
 	} );
 
-	// it( 'allows the blocks if the allowed blocks setting was set', async () => {
-	// 	const parentBlockSelector = '[data-type="test/prioritized-inner-block-set"]';
-	// 	const childParagraphSelector = `${ parentBlockSelector } ${ imageBlockSelector }`;
-	// 	await insertBlock( 'Prioritized Inserter Blocks Set' );
-	// 	await closeGlobalBlockInserter();
-	// 	await page.waitForSelector( childParagraphSelector );
-	// 	await page.click( childParagraphSelector );
-	// 	await openGlobalBlockInserter();
-	// 	expect( await getAllBlockInserterItemTitles() ).toEqual( [
-	// 		'Button',
-	// 		'Gallery',
-	// 		'List',
-	// 		'Media & Text',
-	// 		'Quote',
-	// 	] );
-	// } );
+	it( 'uses the priority ordering if prioritzed blocks setting is set', async () => {
+		const parentBlockSelector =
+			'[data-type="test/prioritized-inserter-blocks-set"]';
+		await insertBlock( 'Prioritized Inserter Blocks Set' );
+		await closeGlobalBlockInserter();
 
-	// it( 'correctly applies dynamic allowed blocks restrictions', async () => {
-	// 	await insertBlock( 'Prioritized Inserter Blocks Dynamic' );
-	// 	await closeGlobalBlockInserter();
-	// 	const parentBlockSelector = '[data-type="test/prioritized-inner-block-dynamic"]';
-	// 	const blockAppender = '.block-list-appender button';
-	// 	const appenderSelector = `${ parentBlockSelector } ${ blockAppender }`;
-	// 	await page.waitForSelector( appenderSelector );
-	// 	await page.click( appenderSelector );
-	// 	expect( await getAllBlockInserterItemTitles() ).toEqual( [
-	// 		'Image',
-	// 		'List',
-	// 	] );
-	// 	const insertButton = (
-	// 		await page.$x( `//button//span[contains(text(), 'List')]` )
-	// 	 )[ 0 ];
-	// 	await insertButton.click();
-	// 	// Select the list wrapper so the image is inserable.
-	// 	await page.keyboard.press( 'ArrowUp' );
-	// 	await insertBlock( 'Image' );
-	// 	await closeGlobalBlockInserter();
-	// 	await page.waitForSelector( '.product[data-number-of-children="2"]' );
-	// 	await clickBlockToolbarButton(
-	// 		'Select Prioritized Inserter Blocks Dynamic'
-	// 	);
-	// 	// This focus shouldn't be neessary but there's a bug in trunk right now
-	// 	// Where if you open the inserter, don't do anything and click the "appender" on the canvas
-	// 	// the appender is not opened right away.
-	// 	// It needs to be investigated on its own.
-	// 	await page.focus( appenderSelector );
-	// 	await page.click( appenderSelector );
-	// 	expect( await getAllBlockInserterItemTitles() ).toEqual( [
-	// 		'Gallery',
-	// 		'Video',
-	// 	] );
-	// } );
+		await page.waitForSelector( parentBlockSelector );
+
+		await page.click(
+			`${ parentBlockSelector } .block-list-appender .block-editor-inserter__toggle`
+		);
+
+		await page.waitForSelector( QUICK_INSERTER_RESULTS_SELECTOR );
+
+		// Should still be only 6 results regardless of the priority ordering.
+		const inserterItems = await getAllBlockInserterItemTitles();
+
+		expect( inserterItems.slice( 0, 2 ) ).toEqual( [
+			'Audio',
+			'Spacer',
+			'Code',
+		] );
+	} );
 } );

--- a/packages/e2e-tests/specs/editor/plugins/inner-blocks-prioritized-inserter-blocks.test.js
+++ b/packages/e2e-tests/specs/editor/plugins/inner-blocks-prioritized-inserter-blocks.test.js
@@ -1,0 +1,105 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	activatePlugin,
+	createNewPost,
+	deactivatePlugin,
+	getAllBlockInserterItemTitles,
+	insertBlock,
+	openGlobalBlockInserter,
+	closeGlobalBlockInserter,
+	clickBlockToolbarButton,
+} from '@wordpress/e2e-test-utils';
+
+describe( 'Prioritized Inserter Blocks Setting on InnerBlocks', () => {
+	const imageBlockSelector =
+		'.block-editor-rich-text__editable[data-type="core/paragraph"]';
+	beforeAll( async () => {
+		await activatePlugin(
+			'gutenberg-test-innerblocks-prioritized-inserter-blocks'
+		);
+	} );
+
+	beforeEach( async () => {
+		await createNewPost();
+	} );
+
+	afterAll( async () => {
+		await deactivatePlugin(
+			'gutenberg-test-innerblocks-prioritized-inserter-blocks'
+		);
+	} );
+
+	it( 'allows all blocks if the allowed blocks setting was not set', async () => {
+		const parentBlockSelector =
+			'[data-type="test/prioritized-inserter-blocks-unset"]';
+		await insertBlock( 'Prioritized Inserter Blocks Unset' );
+		await closeGlobalBlockInserter();
+
+		await page.waitForSelector( parentBlockSelector );
+
+		await page.click(
+			`[data-type="test/prioritized-inserter-blocks-unset"] .block-list-appender .block-editor-inserter__toggle`
+		);
+
+		await page.waitForSelector(
+			'.block-editor-inserter__quick-inserter-results'
+		);
+
+		await expect( await getAllBlockInserterItemTitles() ).toHaveLength( 6 );
+	} );
+
+	// it( 'allows the blocks if the allowed blocks setting was set', async () => {
+	// 	const parentBlockSelector = '[data-type="test/prioritized-inner-block-set"]';
+	// 	const childParagraphSelector = `${ parentBlockSelector } ${ imageBlockSelector }`;
+	// 	await insertBlock( 'Prioritized Inserter Blocks Set' );
+	// 	await closeGlobalBlockInserter();
+	// 	await page.waitForSelector( childParagraphSelector );
+	// 	await page.click( childParagraphSelector );
+	// 	await openGlobalBlockInserter();
+	// 	expect( await getAllBlockInserterItemTitles() ).toEqual( [
+	// 		'Button',
+	// 		'Gallery',
+	// 		'List',
+	// 		'Media & Text',
+	// 		'Quote',
+	// 	] );
+	// } );
+
+	// it( 'correctly applies dynamic allowed blocks restrictions', async () => {
+	// 	await insertBlock( 'Prioritized Inserter Blocks Dynamic' );
+	// 	await closeGlobalBlockInserter();
+	// 	const parentBlockSelector = '[data-type="test/prioritized-inner-block-dynamic"]';
+	// 	const blockAppender = '.block-list-appender button';
+	// 	const appenderSelector = `${ parentBlockSelector } ${ blockAppender }`;
+	// 	await page.waitForSelector( appenderSelector );
+	// 	await page.click( appenderSelector );
+	// 	expect( await getAllBlockInserterItemTitles() ).toEqual( [
+	// 		'Image',
+	// 		'List',
+	// 	] );
+	// 	const insertButton = (
+	// 		await page.$x( `//button//span[contains(text(), 'List')]` )
+	// 	 )[ 0 ];
+	// 	await insertButton.click();
+	// 	// Select the list wrapper so the image is inserable.
+	// 	await page.keyboard.press( 'ArrowUp' );
+	// 	await insertBlock( 'Image' );
+	// 	await closeGlobalBlockInserter();
+	// 	await page.waitForSelector( '.product[data-number-of-children="2"]' );
+	// 	await clickBlockToolbarButton(
+	// 		'Select Prioritized Inserter Blocks Dynamic'
+	// 	);
+	// 	// This focus shouldn't be neessary but there's a bug in trunk right now
+	// 	// Where if you open the inserter, don't do anything and click the "appender" on the canvas
+	// 	// the appender is not opened right away.
+	// 	// It needs to be investigated on its own.
+	// 	await page.focus( appenderSelector );
+	// 	await page.click( appenderSelector );
+	// 	expect( await getAllBlockInserterItemTitles() ).toEqual( [
+	// 		'Gallery',
+	// 		'Video',
+	// 	] );
+	// } );
+} );

--- a/packages/e2e-tests/specs/editor/plugins/inner-blocks-prioritized-inserter-blocks.test.js
+++ b/packages/e2e-tests/specs/editor/plugins/inner-blocks-prioritized-inserter-blocks.test.js
@@ -30,75 +30,79 @@ describe( 'Prioritized Inserter Blocks Setting on InnerBlocks', () => {
 		);
 	} );
 
-	it( 'uses defaulting ordering if prioritzed blocks setting was not set', async () => {
-		const parentBlockSelector =
-			'[data-type="test/prioritized-inserter-blocks-unset"]';
-		await insertBlock( 'Prioritized Inserter Blocks Unset' );
-		await closeGlobalBlockInserter();
+	describe( 'Quick inserter', () => {
+		it( 'uses defaulting ordering if prioritzed blocks setting was not set', async () => {
+			const parentBlockSelector =
+				'[data-type="test/prioritized-inserter-blocks-unset"]';
+			await insertBlock( 'Prioritized Inserter Blocks Unset' );
+			await closeGlobalBlockInserter();
 
-		await page.waitForSelector( parentBlockSelector );
+			await page.waitForSelector( parentBlockSelector );
 
-		await page.click(
-			`${ parentBlockSelector } .block-list-appender .block-editor-inserter__toggle`
-		);
+			await page.click(
+				`${ parentBlockSelector } .block-list-appender .block-editor-inserter__toggle`
+			);
 
-		await page.waitForSelector( QUICK_INSERTER_RESULTS_SELECTOR );
+			await page.waitForSelector( QUICK_INSERTER_RESULTS_SELECTOR );
 
-		await expect( await getAllBlockInserterItemTitles() ).toHaveLength( 6 );
-	} );
+			await expect( await getAllBlockInserterItemTitles() ).toHaveLength(
+				6
+			);
+		} );
 
-	it( 'uses the priority ordering if prioritzed blocks setting is set', async () => {
-		const parentBlockSelector =
-			'[data-type="test/prioritized-inserter-blocks-set"]';
-		await insertBlock( 'Prioritized Inserter Blocks Set' );
-		await closeGlobalBlockInserter();
+		it( 'uses the priority ordering if prioritzed blocks setting is set', async () => {
+			const parentBlockSelector =
+				'[data-type="test/prioritized-inserter-blocks-set"]';
+			await insertBlock( 'Prioritized Inserter Blocks Set' );
+			await closeGlobalBlockInserter();
 
-		await page.waitForSelector( parentBlockSelector );
+			await page.waitForSelector( parentBlockSelector );
 
-		await page.click(
-			`${ parentBlockSelector } .block-list-appender .block-editor-inserter__toggle`
-		);
+			await page.click(
+				`${ parentBlockSelector } .block-list-appender .block-editor-inserter__toggle`
+			);
 
-		await page.waitForSelector( QUICK_INSERTER_RESULTS_SELECTOR );
+			await page.waitForSelector( QUICK_INSERTER_RESULTS_SELECTOR );
 
-		// Should still be only 6 results regardless of the priority ordering.
-		const inserterItems = await getAllBlockInserterItemTitles();
+			// Should still be only 6 results regardless of the priority ordering.
+			const inserterItems = await getAllBlockInserterItemTitles();
 
-		// Should still be only 6 results regardless of the priority ordering.
-		expect( inserterItems ).toHaveLength( 6 );
+			// Should still be only 6 results regardless of the priority ordering.
+			expect( inserterItems ).toHaveLength( 6 );
 
-		expect( inserterItems.slice( 0, 3 ) ).toEqual( [
-			'Audio',
-			'Spacer',
-			'Code',
-		] );
-	} );
+			expect( inserterItems.slice( 0, 3 ) ).toEqual( [
+				'Audio',
+				'Spacer',
+				'Code',
+			] );
+		} );
 
-	it( 'obeys allowed blocks over prioritzed blocks setting if conflicted', async () => {
-		const parentBlockSelector =
-			'[data-type="test/prioritized-inserter-blocks-set-with-conflicting-allowed-blocks"]';
-		await insertBlock(
-			'Prioritized Inserter Blocks Set With Conflicting Allowed Blocks'
-		);
-		await closeGlobalBlockInserter();
+		it( 'obeys allowed blocks over prioritzed blocks setting if conflicted', async () => {
+			const parentBlockSelector =
+				'[data-type="test/prioritized-inserter-blocks-set-with-conflicting-allowed-blocks"]';
+			await insertBlock(
+				'Prioritized Inserter Blocks Set With Conflicting Allowed Blocks'
+			);
+			await closeGlobalBlockInserter();
 
-		await page.waitForSelector( parentBlockSelector );
+			await page.waitForSelector( parentBlockSelector );
 
-		await page.click(
-			`${ parentBlockSelector } .block-list-appender .block-editor-inserter__toggle`
-		);
+			await page.click(
+				`${ parentBlockSelector } .block-list-appender .block-editor-inserter__toggle`
+			);
 
-		await page.waitForSelector( QUICK_INSERTER_RESULTS_SELECTOR );
+			await page.waitForSelector( QUICK_INSERTER_RESULTS_SELECTOR );
 
-		const inserterItems = await getAllBlockInserterItemTitles();
+			const inserterItems = await getAllBlockInserterItemTitles();
 
-		expect( inserterItems.slice( 0, 3 ) ).toEqual( [
-			'Spacer',
-			'Code',
-			'Paragraph',
-		] );
-		expect( inserterItems ).toEqual(
-			expect.not.arrayContaining( [ 'Audio' ] )
-		);
+			expect( inserterItems.slice( 0, 3 ) ).toEqual( [
+				'Spacer',
+				'Code',
+				'Paragraph',
+			] );
+			expect( inserterItems ).toEqual(
+				expect.not.arrayContaining( [ 'Audio' ] )
+			);
+		} );
 	} );
 } );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Adds a new API to the block list settings to allow parent blocks to define a priority for blocks in the inserter for a given inner blocks.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

In https://github.com/WordPress/gutenberg/pull/48752 we added a private API to allow blocks to be prioritised. This was so we could force `Page Link` and `Custom Link` to show up as the first two results in the inserter options for the Navigation block's list view editing mode.

However, this was always envisaged as a short term way to allow the wider feature to land in WP 6.2. This PR circles back (and is an alternative to https://github.com/WordPress/gutenberg/pull/49959) with an alternative approach which looks at this problem more holistically by assuming the requirement to prioritise blocks will likely be useful to other block's in future.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Adds a new `inserterPriority` property to inner blocks which allows the consumer to pass an array of blocks and/or variations which should be prioritised in the Inserter.

It also adds a concrete example, by way of alternating the Nav block to utilise this new property to cause the `Page Link` and `Custom Link` blocks to show up first in the Inserter.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

#### Automated Testing

Run

```
npm run test:e2e packages/e2e-tests/specs/editor/plugins/inner-blocks-prioritized-inserter-blocks.test.js
```

#### Manual Testing

- Alter the `INSERTER_PRIORITY` constant in `constants.js` (see changeset) to be:

```js
export const INSERTER_PRIORITY = [
	'core/spacer',
	'core/navigation-link/page',
	'core/navigation-link',
];
```
- Rebuild with `npm run dev`
- New Post
- Add Nav block
- Open inspector controls
- Open List View tab in inspector controls
- Click inserter
- See `core/spacer` block as first item followed by the other two block variations.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

Co-authored-by: Dave Smith <444434+getdave@users.noreply.github.com> 
