### PR TITLE
Edit Site: Move loading logic to a separate hook

### DIFF
--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -62,8 +62,6 @@ function useIsSiteEditorLoading() {
 
 	useEffect( () => {
 		if ( ! hasResolvingSelectors && ! loaded ) {
-			clearTimeout( timeoutRef.current );
-
 			/*
 			 * We're using an arbitrary 1s timeout here to catch brief moments
 			 * without any resolving selectors that would result in displaying

--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -59,9 +59,10 @@ function useIsSiteEditorLoading() {
 	} );
 	const [ loaded, setLoaded ] = useState( false );
 	const timeoutRef = useRef( null );
+	const inLoadingPause = ! loaded && ! hasResolvingSelectors;
 
 	useEffect( () => {
-		if ( ! hasResolvingSelectors && ! loaded ) {
+		if ( inLoadingPause ) {
 			/*
 			 * We're using an arbitrary 1s timeout here to catch brief moments
 			 * without any resolving selectors that would result in displaying
@@ -78,7 +79,7 @@ function useIsSiteEditorLoading() {
 				clearTimeout( timeoutRef.current );
 			};
 		}
-	}, [ loaded, hasResolvingSelectors ] );
+	}, [ inLoadingPause ] );
 
 	return ! loaded || ! hasLoadedPost;
 }

--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useEffect, useMemo, useRef, useState } from '@wordpress/element';
+import { useEffect, useMemo, useState } from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { Notice } from '@wordpress/components';
 import { EntityProvider, store as coreStore } from '@wordpress/core-data';
@@ -58,7 +58,6 @@ function useIsSiteEditorLoading() {
 		};
 	} );
 	const [ loaded, setLoaded ] = useState( false );
-	const timeoutRef = useRef( null );
 	const inLoadingPause = ! loaded && ! hasResolvingSelectors;
 
 	useEffect( () => {
@@ -71,12 +70,12 @@ function useIsSiteEditorLoading() {
 			 * It's worth experimenting with different values, since this also
 			 * adds 1s of artificial delay after loading has finished.
 			 */
-			timeoutRef.current = setTimeout( () => {
+			const timeout = setTimeout( () => {
 				setLoaded( true );
 			}, 1000 );
 
 			return () => {
-				clearTimeout( timeoutRef.current );
+				clearTimeout( timeout );
 			};
 		}
 	}, [ inLoadingPause ] );


### PR DESCRIPTION
## What?
This PR is a follow-up to https://github.com/WordPress/gutenberg/pull/50222#discussion_r1188538281 and moves the site editor loading logic to a separate hook. 

## Why?
Helps abstract the loading logic from the `Editor` component and improve readability.

## How?
We're moving the logic to a hook and keeping the logic unchanged.

## Testing Instructions
Same as testing instructions of #50222.

### Testing Instructions for Keyboard
None

## Screenshots or screencast <!-- if applicable -->
None
