### PR TITLE
Try fixing flaky CPT e2e test

### DIFF
--- a/test/e2e/specs/editor/plugins/custom-post-types.spec.js
+++ b/test/e2e/specs/editor/plugins/custom-post-types.spec.js
@@ -35,7 +35,15 @@ test.describe( 'Test Custom Post Types', () => {
 			.click();
 
 		// Open the Document -> Page Attributes panel.
-		await page.getByRole( 'button', { name: 'Page Attributes' } ).click();
+		const pageAttributes = page.getByRole( 'button', {
+			name: 'Page Attributes',
+		} );
+		const isClosed =
+			( await pageAttributes.getAttribute( 'aria-expanded' ) ) ===
+			'false';
+		if ( isClosed ) {
+			await pageAttributes.click();
+		}
 
 		const parentPageLocator = page.getByRole( 'combobox', {
 			name: 'Parent Page',


### PR DESCRIPTION
## What?
Closes #36939.

Updates CPT e2e test to avoid closing the Page Attributes panel if it's already open.

## Why?
The tests started failing after #50462; based on the artifact traces the panel stays open between tests.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions

```
npm run test:e2e:playwright -- e2e/specs/editor/blocks/navigation.spec.js e2e/specs/editor/plugins/custom-post-types.spec.js
```
