### PR TITLE
Update PHP docblock for `WP_Theme_JSON_Gutenberg::get_property_value`

### DIFF
--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -1928,10 +1928,6 @@ class WP_Theme_JSON_Gutenberg {
 	/**
 	 * Returns the style property for the given path.
 	 *
-	 * It also converts CSS Custom Property stored as
-	 * "var:preset|color|secondary" to the form
-	 * "--wp--preset--color--secondary".
-	 *
 	 * It also converts references to a path to the value
 	 * stored at that location, e.g.
 	 * { "ref": "style.color.background" } => "#fff".


### PR DESCRIPTION
## What?

Per this [PR](https://github.com/WordPress/gutenberg/pull/50366) the conversation of `var:preset|color|secondary` to `--wp--preset--color--secondary` is now happening in the constructor, there is no need to do it in `get_property_value` so that's updated in [50366](https://github.com/WordPress/gutenberg/pull/50366), but the docblock had stayed the same.

