### PR TITLE
[Fonts API] Automatically enqueue user-selected global fonts

### DIFF
--- a/lib/experimental/fonts-api/class-wp-fonts-resolver.php
+++ b/lib/experimental/fonts-api/class-wp-fonts-resolver.php
@@ -1,0 +1,102 @@
+<?php
+/**
+ * WP_Fonts_Resolver class.
+ *
+ * @package    WordPress
+ * @subpackage Fonts API
+ * @since      X.X.X
+ */
+
+if ( class_exists( 'WP_Fonts_Resolver' ) ) {
+	return;
+}
+
+/**
+ * The Fonts API Resolver abstracts the processing of different data sources
+ * (such as theme.json and global styles) for font interactions with the API.
+ *
+ * This class is for internal core usage and is not supposed to be used by
+ * extenders (plugins and/or themes).
+ *
+ * @access private
+ */
+class WP_Fonts_Resolver {
+	/**
+	 * Defines the key structure in global styles to the fontFamily
+	 * user-selected font.
+	 *
+	 * @since X.X.X
+	 *
+	 * @var string[][]
+	 */
+	protected static $global_styles_font_family_structure = array(
+		array( 'elements', 'link', 'typography', 'fontFamily' ),
+		array( 'elements', 'heading', 'typography', 'fontFamily' ),
+		array( 'elements', 'caption', 'typography', 'fontFamily' ),
+		array( 'elements', 'button', 'typography', 'fontFamily' ),
+		array( 'typography', 'fontFamily' ),
+	);
+
+	/**
+	 * Enqueues user-selected fonts via global styles.
+	 *
+	 * @since X.X.X
+	 *
+	 * @return array User selected font-families when exists, else empty array.
+	 */
+	public static function enqueue_user_selected_fonts() {
+		$global_styles       = wp_get_global_styles();
+		$user_selected_fonts = static::get_user_selected_fonts( $global_styles );
+		if ( empty( $user_selected_fonts ) ) {
+			return array();
+		}
+
+		wp_enqueue_fonts( $user_selected_fonts );
+		return $user_selected_fonts;
+	}
+
+	/**
+	 * Gets the user-selected font-family handles.
+	 *
+	 * @since X.X.X
+	 *
+	 * @param  array $global_styles Global styles potentially containing user-selected fonts.
+	 * @return array User-selected font-families.
+	 */
+	private static function get_user_selected_fonts( array $global_styles ) {
+		$font_families = array();
+
+		foreach ( static::$global_styles_font_family_structure as $path ) {
+			$style_value = _wp_array_get( $global_styles, $path, '' );
+
+			$font_family = static::get_value_from_style( $style_value );
+			if ( '' !== $font_family ) {
+				$font_families[] = $font_family;
+			}
+		}
+
+		return array_unique( $font_families );
+	}
+
+	/**
+	 * Get the value (i.e. preset slug) from the given style value.
+	 *
+	 * @since X.X.X
+	 *
+	 * @param string $style       The style to parse.
+	 * @param string $preset_type Optional. The type to parse. Default 'font-family'.
+	 * @return string Preset slug.
+	 */
+	private static function get_value_from_style( $style, $preset_type = 'font-family' ) {
+		if ( '' === $style ) {
+			return '';
+		}
+
+		$starting_pattern = "var:preset|{$preset_type}|";
+		if ( ! str_starts_with( $style, $starting_pattern ) ) {
+			return '';
+		}
+
+		return substr( $style, strlen( $starting_pattern ) );
+	}
+}

--- a/lib/experimental/fonts-api/class-wp-fonts-resolver.php
+++ b/lib/experimental/fonts-api/class-wp-fonts-resolver.php
@@ -45,8 +45,12 @@ class WP_Fonts_Resolver {
 	 * @return array User selected font-families when exists, else empty array.
 	 */
 	public static function enqueue_user_selected_fonts() {
-		$global_styles       = wp_get_global_styles();
-		$user_selected_fonts = static::get_user_selected_fonts( $global_styles );
+		$user_selected_fonts = array();
+		$user_global_styles  = WP_Theme_JSON_Resolver_Gutenberg::get_user_data()->get_raw_data();
+		if ( isset( $user_global_styles['styles'] ) ) {
+			$user_selected_fonts = static::get_user_selected_fonts( $user_global_styles['styles'] );
+		}
+
 		if ( empty( $user_selected_fonts ) ) {
 			return array();
 		}
@@ -92,11 +96,14 @@ class WP_Fonts_Resolver {
 			return '';
 		}
 
-		$starting_pattern = "var:preset|{$preset_type}|";
+		$starting_pattern = "var(--wp--preset--{$preset_type}--";
+		$ending_pattern   = ')';
 		if ( ! str_starts_with( $style, $starting_pattern ) ) {
 			return '';
 		}
 
-		return substr( $style, strlen( $starting_pattern ) );
+		$offset = strlen( $starting_pattern );
+		$length = strpos( $style, $ending_pattern ) - $offset;
+		return substr( $style, $offset, $length );
 	}
 }

--- a/lib/experimental/fonts-api/fonts-api.php
+++ b/lib/experimental/fonts-api/fonts-api.php
@@ -198,8 +198,10 @@ if ( ! function_exists( 'wp_print_fonts' ) ) {
 			return array();
 		}
 
-		// Skip this reassignment decision-making when using the default of `false`.
-		if ( false !== $handles ) {
+		if ( false === $handles ) {
+			// Automatically enqueue all user-selected fonts.
+			WP_Fonts_Resolver::enqueue_user_selected_fonts();
+		} else {
 			// When `true`, print all registered fonts for the iframed editor.
 			if ( $in_iframed_editor ) {
 				$queue           = $wp_fonts->queue;

--- a/lib/experimental/fonts-api/fonts-api.php
+++ b/lib/experimental/fonts-api/fonts-api.php
@@ -198,21 +198,17 @@ if ( ! function_exists( 'wp_print_fonts' ) ) {
 			return array();
 		}
 
-		if ( false === $handles ) {
+		if ( empty( $handles ) ) {
 			// Automatically enqueue all user-selected fonts.
 			WP_Fonts_Resolver::enqueue_user_selected_fonts();
-		} else {
-			// When `true`, print all registered fonts for the iframed editor.
-			if ( $in_iframed_editor ) {
-				$queue           = $wp_fonts->queue;
-				$done            = $wp_fonts->done;
-				$wp_fonts->done  = array();
-				$wp_fonts->queue = $registered;
-				$handles         = false;
-			} elseif ( empty( $handles ) ) {
-				// When falsey, assign `false` to print enqueued fonts.
-				$handles = false;
-			}
+			$handles = false;
+		} elseif ( $in_iframed_editor ) {
+			// Print all registered fonts for the iframed editor.
+			$queue           = $wp_fonts->queue;
+			$done            = $wp_fonts->done;
+			$wp_fonts->done  = array();
+			$wp_fonts->queue = $registered;
+			$handles         = false;
 		}
 
 		_wp_scripts_maybe_doing_it_wrong( __FUNCTION__ );

--- a/lib/load.php
+++ b/lib/load.php
@@ -115,7 +115,9 @@ if ( ! class_exists( 'WP_Fonts' ) ) {
 	require __DIR__ . '/experimental/fonts-api/register-fonts-from-theme-json.php';
 	require __DIR__ . '/experimental/fonts-api/class-wp-fonts.php';
 	require __DIR__ . '/experimental/fonts-api/class-wp-fonts-provider-local.php';
+	require __DIR__ . '/experimental/fonts-api/class-wp-fonts-resolver.php';
 	require __DIR__ . '/experimental/fonts-api/fonts-api.php';
+
 	// BC Layer files, which will not be backported to WP Core.
 	require __DIR__ . '/experimental/fonts-api/bc-layer/class-gutenberg-fonts-api-bc-layer.php';
 	require __DIR__ . '/experimental/fonts-api/bc-layer/webfonts-deprecations.php';

--- a/phpunit/fonts-api/wp-fonts-tests-dataset.php
+++ b/phpunit/fonts-api/wp-fonts-tests-dataset.php
@@ -1161,4 +1161,236 @@ CSS
 			),
 		);
 	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array
+	 */
+	public function data_print_user_selected_fonts() {
+		$global_styles = $this->get_mock_user_selected_fonts_global_styles();
+		$font_faces    = $this->get_registered_fonts_css();
+
+		return array(
+			'print font1'           => array(
+				'global_styles'   => $global_styles['font1'],
+				'expected_done'   => array(
+					'font1-300-normal',
+					'font1-300-italic',
+					'font1-900-normal',
+					'font1',
+				),
+				'expected_output' => sprintf(
+					'<mock id="wp-fonts-mock" attr="some-attr">%s; %s; %s</mock>\n',
+					$font_faces['font1-300-normal'],
+					$font_faces['font1-300-italic'],
+					$font_faces['font1-900-normal']
+				),
+			),
+			'print font2'           => array(
+				'global_styles'   => $global_styles['font2'],
+				'expected_done'   => array( 'font2-200-900-normal', 'font2-200-900-italic', 'font2' ),
+				'expected_output' => sprintf(
+					'<mock id="wp-fonts-mock" attr="some-attr">%s; %s</mock>\n',
+					$font_faces['font2-200-900-normal'],
+					$font_faces['font2-200-900-italic']
+				),
+			),
+			'print font3'           => array(
+				'global_styles'   => $global_styles['font3'],
+				'expected_done'   => array( 'font3', 'font3-bold-normal' ),
+				'expected_output' => sprintf(
+					'<mock id="wp-fonts-mock" attr="some-attr">%s</mock>\n',
+					$font_faces['font3-bold-normal']
+				),
+			),
+			'print all fonts'       => array(
+				'global_styles'   => $global_styles['all'],
+				'expected_done'   => array(
+					'font1-300-normal',
+					'font1-300-italic',
+					'font1-900-normal',
+					'font1',
+					'font2-200-900-normal',
+					'font2-200-900-italic',
+					'font2',
+					'font3-bold-normal',
+					'font3',
+				),
+				'expected_output' => sprintf(
+					'<mock id="wp-fonts-mock" attr="some-attr">%s; %s; %s; %s; %s; %s</mock>\n',
+					$font_faces['font1-300-normal'],
+					$font_faces['font1-300-italic'],
+					$font_faces['font1-900-normal'],
+					$font_faces['font2-200-900-normal'],
+					$font_faces['font2-200-900-italic'],
+					$font_faces['font3-bold-normal']
+				),
+			),
+			'print all valid fonts' => array(
+				'global_styles'   => $global_styles['all with invalid element'],
+				'expected_done'   => array(
+					'font1-300-normal',
+					'font1-300-italic',
+					'font1-900-normal',
+					'font1',
+					'font2-200-900-normal',
+					'font2-200-900-italic',
+					'font2',
+					'font3-bold-normal',
+					'font3',
+				),
+				'expected_output' => sprintf(
+					'<mock id="wp-fonts-mock" attr="some-attr">%s; %s; %s; %s; %s; %s</mock>\n',
+					$font_faces['font1-300-normal'],
+					$font_faces['font1-300-italic'],
+					$font_faces['font1-900-normal'],
+					$font_faces['font2-200-900-normal'],
+					$font_faces['font2-200-900-italic'],
+					$font_faces['font3-bold-normal']
+				),
+			),
+		);
+	}
+
+	/**
+	 * Gets user-selected fonts for global styles for the mock provider.
+	 *
+	 * @since X.X.X
+	 *
+	 * @return array
+	 */
+	protected function get_mock_user_selected_fonts_global_styles() {
+		return array(
+			'font1'                    => array(
+				'elements'   => array(
+					'heading' => array(
+						'typography' => array(
+							'fontFamily' => 'var:preset|font-family|font1',
+							'fontStyle'  => 'normal',
+							'fontWeight' => '300',
+						),
+					),
+					'caption' => array(
+						'typography' => array(
+							'fontFamily' => 'var:preset|font-family|font1',
+							'fontStyle'  => 'italic',
+							'fontWeight' => '300',
+						),
+					),
+				),
+				'typography' => array(
+					'fontFamily' => 'var:preset|font-family|font1',
+					'fontStyle'  => 'normal',
+					'fontWeight' => '900',
+				),
+			),
+			'font2'                    => array(
+				'elements' => array(
+					'heading' => array(
+						'typography' => array(
+							'fontFamily' => 'var:preset|font-family|font2',
+							'fontStyle'  => 'normal',
+							'fontWeight' => '200-900',
+						),
+					),
+					'button'  => array(
+						'typography' => array(
+							'fontFamily' => 'var:preset|font-family|font2',
+							'fontStyle'  => 'italic',
+							'fontWeight' => '200-900',
+						),
+					),
+				),
+			),
+			'font3'                    => array(
+				'typography' => array(
+					'fontFamily' => 'var:preset|font-family|font3',
+					'fontStyle'  => 'normal',
+					'fontWeight' => 'bold',
+				),
+			),
+			'all'                      => array(
+				'elements'   => array(
+					'link'    => array(
+						'typography' => array(
+							'fontFamily' => 'var:preset|font-family|font1',
+							'fontStyle'  => 'italic',
+							'fontWeight' => '300',
+						),
+					),
+					'heading' => array(
+						'typography' => array(
+							'fontFamily' => 'var:preset|font-family|font1',
+							'fontStyle'  => 'normal',
+							'fontWeight' => '900',
+						),
+					),
+					'caption' => array(
+						'typography' => array(
+							'fontFamily' => 'var:preset|font-family|font1',
+							'fontStyle'  => 'italic',
+							'fontWeight' => '300',
+						),
+					),
+					'button'  => array(
+						'typography' => array(
+							'fontFamily' => 'var:preset|font-family|font2',
+							'fontStyle'  => 'normal',
+							'fontWeight' => '200-900',
+						),
+					),
+				),
+				'typography' => array(
+					'fontFamily' => 'var:preset|font-family|font3',
+					'fontStyle'  => 'normal',
+					'fontWeight' => 'bold',
+				),
+			),
+			'all with invalid element' => array(
+				'elements'   => array(
+					'link'    => array(
+						'typography' => array(
+							'fontFamily' => 'var:preset|font-family|font1',
+							'fontStyle'  => 'italic',
+							'fontWeight' => '300',
+						),
+					),
+					'heading' => array(
+						'typography' => array(
+							'fontFamily' => 'var:preset|font-family|font1',
+							'fontStyle'  => 'normal',
+							'fontWeight' => '900',
+						),
+					),
+					'caption' => array(
+						'typography' => array(
+							'fontFamily' => 'var:preset|font-family|font1',
+							'fontStyle'  => 'italic',
+							'fontWeight' => '300',
+						),
+					),
+					'button'  => array(
+						'typography' => array(
+							'fontFamily' => 'var:preset|font-family|font2',
+							'fontStyle'  => 'normal',
+							'fontWeight' => '200-900',
+						),
+					),
+					'invalid' => array(
+						'typography' => array(
+							'fontFamily' => 'var:preset|font-family|font2',
+							'fontStyle'  => 'italic',
+							'fontWeight' => '200-900',
+						),
+					),
+				),
+				'typography' => array(
+					'fontFamily' => 'var:preset|font-family|font3',
+					'fontStyle'  => 'normal',
+					'fontWeight' => 'bold',
+				),
+			),
+		);
+	}
 }

--- a/phpunit/fonts-api/wpFontsResolver/enqueueUserSelectedFonts-test.php
+++ b/phpunit/fonts-api/wpFontsResolver/enqueueUserSelectedFonts-test.php
@@ -1,0 +1,256 @@
+<?php
+/**
+ * WP_Fonts_Resolver::enqueue_user_selected_fonts() tests.
+ *
+ * @package    WordPress
+ * @subpackage Fonts API
+ */
+
+require_once __DIR__ . '/../wp-fonts-testcase.php';
+
+/**
+ * @group  fontsapi
+ * @covers WP_Fonts_Resolver::enqueue_user_selected_fonts
+ */
+class Tests_Fonts_WpFontsResolver_EnqueueUserSelectedFonts extends WP_Fonts_TestCase {
+	const FONTS_THEME = 'fonts-block-theme';
+	/**
+	 * Administrator ID.
+	 *
+	 * @var int
+	 */
+	private static $administrator_id = 0;
+
+	public static function set_up_before_class() {
+		self::$requires_switch_theme_fixtures = true;
+
+		parent::set_up_before_class();
+
+		self::$administrator_id = self::factory()->user->create(
+			array(
+				'role'       => 'administrator',
+				'user_email' => 'administrator@example.com',
+			)
+		);
+	}
+
+	/**
+	 * @dataProvider data_should_not_enqueue_when_no_user_selected_fonts
+	 *
+	 * @param array $styles Optional. Test styles. Default empty array.
+	 */
+	public function test_should_not_enqueue_when_no_user_selected_fonts( $styles = array() ) {
+		$this->set_up_global_styles( $styles );
+
+		$mock = $this->set_up_mock( 'enqueue' );
+		$mock->expects( $this->never() )
+			->method( 'enqueue' );
+
+		$expected = array();
+		$this->assertSame( $expected, WP_Fonts_Resolver::enqueue_user_selected_fonts() );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array
+	 */
+	public function data_should_not_enqueue_when_no_user_selected_fonts() {
+		return array(
+			'no user-selected styles' => array(),
+			'invalid element'         => array(
+				array(
+					'elements' => array(
+						'invalid' => array(
+							'typography' => array(
+								'fontFamily' => 'var:preset|font-family|font1',
+								'fontStyle'  => 'normal',
+								'fontWeight' => '400',
+							),
+						),
+					),
+				),
+			),
+		);
+	}
+
+	/**
+	 * @dataProvider data_should_enqueue_when_user_selected_fonts
+	 *
+	 * @param array $styles   Test styles.
+	 * @param array $expected Expected results.
+	 */
+	public function test_should_enqueue_when_user_selected_fonts( $styles, $expected ) {
+		$mock = $this->set_up_mock( 'enqueue' );
+		$mock->expects( $this->once() )
+			->method( 'enqueue' )
+			->with(
+				$this->identicalTo( $expected )
+			);
+
+		$this->set_up_global_styles( $styles );
+
+		$this->assertSameSets( $expected, WP_Fonts_Resolver::enqueue_user_selected_fonts() );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array
+	 */
+	public function data_should_enqueue_when_user_selected_fonts() {
+		$fonts = array(
+			'font1-400-normal' => array(
+				'fontFamily' => 'var:preset|font-family|font1',
+				'fontStyle'  => 'normal',
+				'fontWeight' => '400',
+			),
+			'font1-400-italic' => array(
+				'fontFamily' => 'var:preset|font-family|font1',
+				'fontStyle'  => 'italic',
+				'fontWeight' => '400',
+			),
+			'font2-600-normal' => array(
+				'fontFamily' => 'var:preset|font-family|font2',
+				'fontStyle'  => 'normal',
+				'fontWeight' => '600',
+			),
+			'font2-600-italic' => array(
+				'fontFamily' => 'var:preset|font-family|font2',
+				'fontStyle'  => 'italic',
+				'fontWeight' => '600',
+			),
+			'font3-900-normal' => array(
+				'fontFamily' => 'var:preset|font-family|font3',
+				'fontStyle'  => 'normal',
+				'fontWeight' => '900',
+			),
+		);
+
+		return array(
+			'link'                  => array(
+				'styles'   => array(
+					'elements' => array(
+						'link' => array(
+							'typography' => $fonts['font1-400-italic'],
+						),
+					),
+				),
+				'expected' => array( 'font1' ),
+			),
+			'heading'               => array(
+				'styles'   => array(
+					'elements' => array(
+						'heading' => array(
+							'typography' => $fonts['font2-600-italic'],
+						),
+					),
+				),
+				'expected' => array( 'font2' ),
+			),
+			'caption'               => array(
+				'styles'   => array(
+					'elements' => array(
+						'caption' => array(
+							'typography' => $fonts['font2-600-normal'],
+						),
+					),
+				),
+				'expected' => array( 'font2' ),
+			),
+			'button'                => array(
+				'styles'   => array(
+					'elements' => array(
+						'button' => array(
+							'typography' => $fonts['font1-400-normal'],
+						),
+					),
+				),
+				'expected' => array( 'font1' ),
+			),
+			'text'                  => array(
+				'styles'   => array(
+					'typography' => $fonts['font1-400-normal'],
+				),
+				'expected' => array( 'font1' ),
+			),
+			'all elements'          => array(
+				'styles'   => array(
+					'elements' => array(
+						'link'    => array(
+							'typography' => $fonts['font1-400-italic'],
+						),
+						'heading' => array(
+							'typography' => $fonts['font2-600-italic'],
+						),
+						'caption' => array(
+							'typography' => $fonts['font2-600-normal'],
+						),
+						'button'  => array(
+							'typography' => $fonts['font1-400-normal'],
+						),
+					),
+				),
+				'expected' => array( 'font1', 'font2' ),
+			),
+			'all elements and text' => array(
+				'styles'   => array(
+					'elements'   => array(
+						'link'    => array(
+							'typography' => $fonts['font1-400-italic'],
+						),
+						'heading' => array(
+							'typography' => $fonts['font2-600-italic'],
+						),
+						'caption' => array(
+							'typography' => $fonts['font3-900-normal'],
+						),
+						'button'  => array(
+							'typography' => $fonts['font1-400-normal'],
+						),
+					),
+					'typography' => $fonts['font1-400-normal'],
+				),
+				'expected' => array( 'font1', 'font2', 'font3' ),
+			),
+			'with invalid element'  => array(
+				'styles'   => array(
+					'elements' => array(
+						'button'  => array(
+							'typography' => $fonts['font1-400-normal'],
+						),
+						'invalid' => array(
+							'typography' => $fonts['font3-900-normal'],
+						),
+					),
+				),
+				'expected' => array( 'font1' ),
+			),
+		);
+	}
+
+	/**
+	 * Sets up the global styles.
+	 *
+	 * @param array $styles User-selected styles structure.
+	 */
+	private function set_up_global_styles( array $styles ) {
+		switch_theme( static::FONTS_THEME );
+
+		if ( empty( $styles ) ) {
+			return;
+		}
+
+		// Make sure there is data from the user origin.
+		wp_set_current_user( self::$administrator_id );
+		$user_cpt = WP_Theme_JSON_Resolver::get_user_data_from_wp_global_styles( wp_get_theme(), true );
+		$config   = json_decode( $user_cpt['post_content'], true );
+
+		// Add the test styles.
+		$config['styles'] = $styles;
+
+		// Update the global styles and settings post.
+		$user_cpt['post_content'] = wp_json_encode( $config );
+		wp_update_post( $user_cpt, true, false );
+	}
+}

--- a/phpunit/fonts-api/wpFontsResolver/enqueueUserSelectedFonts-test.php
+++ b/phpunit/fonts-api/wpFontsResolver/enqueueUserSelectedFonts-test.php
@@ -13,13 +13,6 @@ require_once __DIR__ . '/../wp-fonts-testcase.php';
  * @covers WP_Fonts_Resolver::enqueue_user_selected_fonts
  */
 class Tests_Fonts_WpFontsResolver_EnqueueUserSelectedFonts extends WP_Fonts_TestCase {
-	const FONTS_THEME = 'fonts-block-theme';
-	/**
-	 * Administrator ID.
-	 *
-	 * @var int
-	 */
-	private static $administrator_id = 0;
 
 	public static function set_up_before_class() {
 		self::$requires_switch_theme_fixtures = true;
@@ -99,158 +92,40 @@ class Tests_Fonts_WpFontsResolver_EnqueueUserSelectedFonts extends WP_Fonts_Test
 	 * @return array
 	 */
 	public function data_should_enqueue_when_user_selected_fonts() {
-		$fonts = array(
-			'font1-400-normal' => array(
-				'fontFamily' => 'var:preset|font-family|font1',
-				'fontStyle'  => 'normal',
-				'fontWeight' => '400',
-			),
-			'font1-400-italic' => array(
-				'fontFamily' => 'var:preset|font-family|font1',
-				'fontStyle'  => 'italic',
-				'fontWeight' => '400',
-			),
-			'font2-600-normal' => array(
-				'fontFamily' => 'var:preset|font-family|font2',
-				'fontStyle'  => 'normal',
-				'fontWeight' => '600',
-			),
-			'font2-600-italic' => array(
-				'fontFamily' => 'var:preset|font-family|font2',
-				'fontStyle'  => 'italic',
-				'fontWeight' => '600',
-			),
-			'font3-900-normal' => array(
-				'fontFamily' => 'var:preset|font-family|font3',
-				'fontStyle'  => 'normal',
-				'fontWeight' => '900',
-			),
-		);
+		$global_styles = $this->get_mock_user_selected_fonts_global_styles();
 
 		return array(
-			'link'                  => array(
-				'styles'   => array(
-					'elements' => array(
-						'link' => array(
-							'typography' => $fonts['font1-400-italic'],
-						),
-					),
-				),
+			'heading, caption, text'   => array(
+				'styles'   => $global_styles['font1'],
 				'expected' => array( 'font1' ),
 			),
-			'heading'               => array(
-				'styles'   => array(
-					'elements' => array(
-						'heading' => array(
-							'typography' => $fonts['font2-600-italic'],
-						),
-					),
-				),
+			'heading, button'          => array(
+				'styles'   => $global_styles['font2'],
 				'expected' => array( 'font2' ),
 			),
-			'caption'               => array(
-				'styles'   => array(
-					'elements' => array(
-						'caption' => array(
-							'typography' => $fonts['font2-600-normal'],
-						),
-					),
-				),
-				'expected' => array( 'font2' ),
+			'text'                     => array(
+				'styles'   => $global_styles['font3'],
+				'expected' => array( 'font3' ),
 			),
-			'button'                => array(
-				'styles'   => array(
-					'elements' => array(
-						'button' => array(
-							'typography' => $fonts['font1-400-normal'],
-						),
-					),
+			'all'                      => array(
+				'styles'   => $global_styles['all'],
+				'expected' => array(
+					0 => 'font1',
+					// font1 occurs 2 more times and gets removed as duplicates.
+					3 => 'font2',
+					4 => 'font3',
 				),
-				'expected' => array( 'font1' ),
 			),
-			'text'                  => array(
-				'styles'   => array(
-					'typography' => $fonts['font1-400-normal'],
+			'all with invalid element' => array(
+				'styles'   => $global_styles['all with invalid element'],
+				'expected' => array(
+					0 => 'font1',
+					// font1 occurs 2 more times and gets removed as duplicates.
+					3 => 'font2',
+					// Skips font2 for the "invalid" element.
+					4 => 'font3',
 				),
-				'expected' => array( 'font1' ),
-			),
-			'all elements'          => array(
-				'styles'   => array(
-					'elements' => array(
-						'link'    => array(
-							'typography' => $fonts['font1-400-italic'],
-						),
-						'heading' => array(
-							'typography' => $fonts['font2-600-italic'],
-						),
-						'caption' => array(
-							'typography' => $fonts['font2-600-normal'],
-						),
-						'button'  => array(
-							'typography' => $fonts['font1-400-normal'],
-						),
-					),
-				),
-				'expected' => array( 'font1', 'font2' ),
-			),
-			'all elements and text' => array(
-				'styles'   => array(
-					'elements'   => array(
-						'link'    => array(
-							'typography' => $fonts['font1-400-italic'],
-						),
-						'heading' => array(
-							'typography' => $fonts['font2-600-italic'],
-						),
-						'caption' => array(
-							'typography' => $fonts['font3-900-normal'],
-						),
-						'button'  => array(
-							'typography' => $fonts['font1-400-normal'],
-						),
-					),
-					'typography' => $fonts['font1-400-normal'],
-				),
-				'expected' => array( 'font1', 'font2', 'font3' ),
-			),
-			'with invalid element'  => array(
-				'styles'   => array(
-					'elements' => array(
-						'button'  => array(
-							'typography' => $fonts['font1-400-normal'],
-						),
-						'invalid' => array(
-							'typography' => $fonts['font3-900-normal'],
-						),
-					),
-				),
-				'expected' => array( 'font1' ),
 			),
 		);
-	}
-
-	/**
-	 * Sets up the global styles.
-	 *
-	 * @param array $styles User-selected styles structure.
-	 */
-	private function set_up_global_styles( array $styles ) {
-		switch_theme( static::FONTS_THEME );
-
-		if ( empty( $styles ) ) {
-			return;
-		}
-
-		// Make sure there is data from the user origin.
-		wp_set_current_user( self::$administrator_id );
-		$user_cpt = WP_Theme_JSON_Resolver::get_user_data_from_wp_global_styles( wp_get_theme(), true );
-		$config   = json_decode( $user_cpt['post_content'], true );
-
-		// Add the test styles.
-		$config['styles'] = $styles;
-
-		// Update the global styles and settings post.
-		$user_cpt['post_content'] = wp_json_encode( $config );
-		wp_update_post( $user_cpt, true, false );
 	}
 }

--- a/phpunit/fonts-api/wpPrintFonts-test.php
+++ b/phpunit/fonts-api/wpPrintFonts-test.php
@@ -15,6 +15,14 @@ require_once __DIR__ . '/../fixtures/mock-provider.php';
  */
 class Tests_Fonts_WpPrintFonts extends WP_Fonts_TestCase {
 
+	public static function set_up_before_class() {
+		self::$requires_switch_theme_fixtures = true;
+
+		parent::set_up_before_class();
+
+		static::set_up_admin_user();
+	}
+
 	public function test_should_return_empty_array_when_no_fonts_registered() {
 		$this->assertSame( array(), wp_print_fonts() );
 	}
@@ -105,26 +113,6 @@ class Tests_Fonts_WpPrintFonts extends WP_Fonts_TestCase {
 	}
 
 	/**
-	 * Sets up the dependencies for integration test.
-	 *
-	 * @param array    $setup    Dependencies to set up.
-	 * @param WP_Fonts $wp_fonts Instance of WP_Fonts.
-	 * @param bool     $enqueue  Whether to enqueue. Default true.
-	 */
-	private function setup_integrated_deps( array $setup, $wp_fonts, $enqueue = true ) {
-		foreach ( $setup['provider'] as $provider ) {
-			$wp_fonts->register_provider( $provider['id'], $provider['class'] );
-		}
-		foreach ( $setup['registered'] as $handle => $variations ) {
-			$this->setup_register( $handle, $variations, $wp_fonts );
-		}
-
-		if ( $enqueue ) {
-			$wp_fonts->enqueue( $setup['enqueued'] );
-		}
-	}
-
-	/**
 	 * @dataProvider data_should_print_all_registered_fonts_for_iframed_editor
 	 *
 	 * @param string $fonts    Fonts to register.
@@ -188,5 +176,55 @@ class Tests_Fonts_WpPrintFonts extends WP_Fonts_TestCase {
 				),
 			),
 		);
+	}
+
+	/**
+	 * Integration test for printing user-selected global fonts.
+	 * This test registers providers and fonts and then enqueues before testing the printing functionality.
+	 *
+	 * @dataProvider data_print_user_selected_fonts
+	 *
+	 * @param array  $global_styles   Test set up information for provider, fonts, and enqueued.
+	 * @param array  $expected_done   Expected array of printed handles.
+	 * @param string $expected_output Expected printed output.
+	 */
+	public function test_should_print_user_selected_fonts( $global_styles, $expected_done, $expected_output ) {
+		$wp_fonts = wp_fonts();
+
+		$setup = array(
+			'provider'      => array( 'mock' => $this->get_provider_definitions( 'mock' ) ),
+			'registered'    => $this->get_registered_mock_fonts(),
+			'global_styles' => $global_styles,
+		);
+		$this->setup_integrated_deps( $setup, $wp_fonts, false );
+
+		$this->expectOutputString( $expected_output );
+		$actual_printed_fonts = wp_print_fonts();
+		$this->assertSameSets( $expected_done, $actual_printed_fonts, 'Should print font-faces for given user-selected fonts' );
+	}
+
+
+	/**
+	 * Sets up the dependencies for integration test.
+	 *
+	 * @param array    $setup    Dependencies to set up.
+	 * @param WP_Fonts $wp_fonts Instance of WP_Fonts.
+	 * @param bool     $enqueue  Whether to enqueue. Default true.
+	 */
+	private function setup_integrated_deps( array $setup, $wp_fonts, $enqueue = true ) {
+		foreach ( $setup['provider'] as $provider ) {
+			$wp_fonts->register_provider( $provider['id'], $provider['class'] );
+		}
+		foreach ( $setup['registered'] as $handle => $variations ) {
+			$this->setup_register( $handle, $variations, $wp_fonts );
+		}
+
+		if ( $enqueue ) {
+			$wp_fonts->enqueue( $setup['enqueued'] );
+		}
+
+		if ( ! empty( $setup['global_styles'] ) ) {
+			$this->set_up_global_styles( $setup['global_styles'] );
+		}
 	}
 }


### PR DESCRIPTION
Closes #40363 

Follow-up to #50297, #50499, and #50512.

## What?

Adds a new enhancement to the Fonts API: automatic enqueue all user-selected fonts.

### What's different in this PR vs the reverted PR?

PR #50297 introduced this enhancement using `wp_get_global_styles()`. But after #50366 modified the style value structure, the tests failed. This revealed a problem. `wp_get_global_styles()` fetched the combined/merged core, theme, and user data, whereas the global styles this enhancement needs is only the user data. Whoopsie. This PR uses `WP_Theme_JSON_Resolver_Gutenberg::get_merged_data()` instead of `wp_get_global_styles()` and the new style value structure from #50297. Props to @oandregal.

## Why?

Prior to this PR, the API automatically registers and enqueues all fonts defined in a theme's `theme.json` file, but not fonts from plugins. Instead, plugins were required to handle the enqueuing.

With this PR, the API now handles enqueuing those fonts that users select in the Site Editor > Styles > Typography.

Why the change?
1. To ensure all user-selected fonts are enqueued before printing.
2. To make it easier for plugin developers to interact with the API, i.e. by removing the need for their plugins to carry (and maintain) enqueuing.

## How?

tl;dr
A Resolver parses the user data global styles to collect the font-families. Then enqueues those found before printing happens.

This PR is a combination of #50297 and #50499. Thus it is co-authored by @oandregal.

Longer explanation:

User selections are made in the Site Editor > Styles > Typography UI. That data is available within the global styles custom post type (CPT), which is fetchable using `WP_Theme_JSON_Resolver_Gutenberg::get_merged_data()`.

![Screen Shot 2023-05-03 at 11 09 44 AM](https://user-images.githubusercontent.com/7284611/235976226-8620d0b8-fc44-4176-a8ce-9229f55cc7cb.png)

If user selected, each of the following "Elements" are in the `wp_get_global_styles()` returned array:
* Text: `$global_styles['typography']['fontFamily']`
* Links: `$global_styles['elements']['link']['typography']['fontFamily']`
* Headings: `$global_styles['elements']['heading']['typography']['fontFamily']`
* Captions: `$global_styles['elements']['caption']['typography']['fontFamily']`
* Buttons: `$global_styles['elements']['button']['typography']['fontFamily']`

Since the global styles have a specific and known structure, the Resolver knowns how to iterate through the styles to find any that are defined.

This PR adds a resolver called `WP_Fonts_Resolver` for processing different data sources and interactions. Currently, it's processing the user-selected fonts that are available within the global styles. Later, other functionality can be added to it, such as (a) reconciling any missing fonts in the theme.json and registering and (b) enqueuing the theme's theme.json defined fonts.

A  property (`WP_Fonts_Resolver::$global_styles_font_family_structure`) exists to define the nested key structure within the global styles data array. Iterating through that structure, `_wp_array_get()` searches to find each font-family if it exists.

If the parser finds a user-selected font, then the font-family is parsed from the style, which has a format of `var(--wp-preset--font-family--<font-family-handle>)`. `WP_Fonts_Resolver::get_value_from_style()` handles this process.

Code Design notes:
- Why is `WP_Fonts_Resolver::$global_styles_font_family_structure` a protected static property instead of a `const`?

A `const` is public. Once introduced into Core, it must be maintained for BC. By making it as a property, the BC concern is removed providing more flexibility for future changes.

By having it as `$protected` rather than `$private`, it gives the Gutenberg plugin the means to modify that structure if needed for future changes (i.e. once the API is in Core).

- Why is `WP_Fonts_Resolver::get_value_from_style()` generic for any preset type?

Currently only the `font-family` preset type is needed. But in the future, other preset types might be needed, such as extracting the variation details, e.g. `font-weight`, `font-style`. So I designed this method to be generic for parsing any preset type from the given style.

- Why invoke in `wp_print_fonts()`? Why so late?

My thinking is: 
1. enqueue as late as possible to ensure all customizations have processed (i.e. in plugins). Why? To avoid having to dequeue a font if something changes before printing. 
2. Avoid potential race conditions where a plugin may be processing later for registration.

## TODO
- [X] Cherry-pick PR #50297.
- [X] Cherry-pick PR #50499.
- [x] Add more test datasets, if applicable, for the new style value structure.

## Testing Instructions

### Automated Tests

```
npm run test:unit:php -- --filter Tests_Fonts_WpFontsResolver_EnqueueUserSelectedFonts
```

### Manually Testing

The key to testing is to select and save one or more fonts and then check that only those fonts are in the `<style id="wp-fonts-jetpack-google-fonts">` element on the front-end.

Set up:
On your test site:
1. Install and activate the Fonts API Tester using [Jetpack's Google Fonts composer package](https://github.com/ironprogrammer/webfonts-jetpack-test) - installation instructions are found in the [plugins' README.md page](https://github.com/ironprogrammer/webfonts-jetpack-test/blob/master/README.md).
2. Disable enqueuing in the Fonts API Tester's plugin: Open its root PHP file in your fav code editor. Comment out these lines of code:
```php
add_filter( 'pre_render_block', '\Automattic\Jetpack\Fonts\Introspectors\Blocks::enqueue_block_fonts', 10, 2 );
add_action( 'init', '\Automattic\Jetpack\Fonts\Introspectors\Global_Styles::enqueue_global_styles_fonts', 22 );
```
4. Activate the Gutenberg plugin from this branch.
5. Activate the TT3 theme.

Testing Instructions:
1. Go to the Site Editor > Styles > Typography.
2. For headings, select `Playfair Display` font and set Appearance to `Bold Italic`. 
3. For text, select `Poppins` font and set the Appearance to `Regular`. 
4. Save the styles.
6. Go to the front-end.
7. Open your browser's dev tools to inspect the HTML.
8. Search for `wp-fonts-jetpack-google-fonts`. Expected: It should exist in the `<head>`.
9. Open the `<style>` element and inspect the styles. Expected: It should only contain Poppins and Playfair Display, i.e. no other font-families should be in that element. (Note: there will be a lot of variations for each of these font families.)
     Tip: Copy the element's styles and then search for `font-family`. Check each one.

<details>
<summary>Google Fonts: font-face styles</summary>

```html
<style id="wp-fonts-jetpack-google-fonts">
/* cyrillic */
@font-face {
  font-family: 'Playfair Display';
  font-style: italic;
  font-weight: 400;
  font-display: fallback;
  src: url(https://fonts.gstatic.com/s/playfairdisplay/v30/nuFkD-vYSZviVYUb_rj3ij__anPXDTnohkk72xU.woff2) format('woff2');
  unicode-range: U+0301, U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
}
/* vietnamese */
@font-face {
  font-family: 'Playfair Display';
  font-style: italic;
  font-weight: 400;
  font-display: fallback;
  src: url(https://fonts.gstatic.com/s/playfairdisplay/v30/nuFkD-vYSZviVYUb_rj3ij__anPXDTnojUk72xU.woff2) format('woff2');
  unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+0300-0301, U+0303-0304, U+0308-0309, U+0323, U+0329, U+1EA0-1EF9, U+20AB;
}
/* latin-ext */
@font-face {
  font-family: 'Playfair Display';
  font-style: italic;
  font-weight: 400;
  font-display: fallback;
  src: url(https://fonts.gstatic.com/s/playfairdisplay/v30/nuFkD-vYSZviVYUb_rj3ij__anPXDTnojEk72xU.woff2) format('woff2');
  unicode-range: U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
}
/* latin */
@font-face {
  font-family: 'Playfair Display';
  font-style: italic;
  font-weight: 400;
  font-display: fallback;
  src: url(https://fonts.gstatic.com/s/playfairdisplay/v30/nuFkD-vYSZviVYUb_rj3ij__anPXDTnogkk7.woff2) format('woff2');
  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
}
/* cyrillic */
@font-face {
  font-family: 'Playfair Display';
  font-style: italic;
  font-weight: 500;
  font-display: fallback;
  src: url(https://fonts.gstatic.com/s/playfairdisplay/v30/nuFkD-vYSZviVYUb_rj3ij__anPXDTnohkk72xU.woff2) format('woff2');
  unicode-range: U+0301, U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
}
/* vietnamese */
@font-face {
  font-family: 'Playfair Display';
  font-style: italic;
  font-weight: 500;
  font-display: fallback;
  src: url(https://fonts.gstatic.com/s/playfairdisplay/v30/nuFkD-vYSZviVYUb_rj3ij__anPXDTnojUk72xU.woff2) format('woff2');
  unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+0300-0301, U+0303-0304, U+0308-0309, U+0323, U+0329, U+1EA0-1EF9, U+20AB;
}
/* latin-ext */
@font-face {
  font-family: 'Playfair Display';
  font-style: italic;
  font-weight: 500;
  font-display: fallback;
  src: url(https://fonts.gstatic.com/s/playfairdisplay/v30/nuFkD-vYSZviVYUb_rj3ij__anPXDTnojEk72xU.woff2) format('woff2');
  unicode-range: U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
}
/* latin */
@font-face {
  font-family: 'Playfair Display';
  font-style: italic;
  font-weight: 500;
  font-display: fallback;
  src: url(https://fonts.gstatic.com/s/playfairdisplay/v30/nuFkD-vYSZviVYUb_rj3ij__anPXDTnogkk7.woff2) format('woff2');
  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
}
/* cyrillic */
@font-face {
  font-family: 'Playfair Display';
  font-style: italic;
  font-weight: 600;
  font-display: fallback;
  src: url(https://fonts.gstatic.com/s/playfairdisplay/v30/nuFkD-vYSZviVYUb_rj3ij__anPXDTnohkk72xU.woff2) format('woff2');
  unicode-range: U+0301, U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
}
/* vietnamese */
@font-face {
  font-family: 'Playfair Display';
  font-style: italic;
  font-weight: 600;
  font-display: fallback;
  src: url(https://fonts.gstatic.com/s/playfairdisplay/v30/nuFkD-vYSZviVYUb_rj3ij__anPXDTnojUk72xU.woff2) format('woff2');
  unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+0300-0301, U+0303-0304, U+0308-0309, U+0323, U+0329, U+1EA0-1EF9, U+20AB;
}
/* latin-ext */
@font-face {
  font-family: 'Playfair Display';
  font-style: italic;
  font-weight: 600;
  font-display: fallback;
  src: url(https://fonts.gstatic.com/s/playfairdisplay/v30/nuFkD-vYSZviVYUb_rj3ij__anPXDTnojEk72xU.woff2) format('woff2');
  unicode-range: U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
}
/* latin */
@font-face {
  font-family: 'Playfair Display';
  font-style: italic;
  font-weight: 600;
  font-display: fallback;
  src: url(https://fonts.gstatic.com/s/playfairdisplay/v30/nuFkD-vYSZviVYUb_rj3ij__anPXDTnogkk7.woff2) format('woff2');
  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
}
/* cyrillic */
@font-face {
  font-family: 'Playfair Display';
  font-style: italic;
  font-weight: 700;
  font-display: fallback;
  src: url(https://fonts.gstatic.com/s/playfairdisplay/v30/nuFkD-vYSZviVYUb_rj3ij__anPXDTnohkk72xU.woff2) format('woff2');
  unicode-range: U+0301, U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
}
/* vietnamese */
@font-face {
  font-family: 'Playfair Display';
  font-style: italic;
  font-weight: 700;
  font-display: fallback;
  src: url(https://fonts.gstatic.com/s/playfairdisplay/v30/nuFkD-vYSZviVYUb_rj3ij__anPXDTnojUk72xU.woff2) format('woff2');
  unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+0300-0301, U+0303-0304, U+0308-0309, U+0323, U+0329, U+1EA0-1EF9, U+20AB;
}
/* latin-ext */
@font-face {
  font-family: 'Playfair Display';
  font-style: italic;
  font-weight: 700;
  font-display: fallback;
  src: url(https://fonts.gstatic.com/s/playfairdisplay/v30/nuFkD-vYSZviVYUb_rj3ij__anPXDTnojEk72xU.woff2) format('woff2');
  unicode-range: U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
}
/* latin */
@font-face {
  font-family: 'Playfair Display';
  font-style: italic;
  font-weight: 700;
  font-display: fallback;
  src: url(https://fonts.gstatic.com/s/playfairdisplay/v30/nuFkD-vYSZviVYUb_rj3ij__anPXDTnogkk7.woff2) format('woff2');
  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
}
/* cyrillic */
@font-face {
  font-family: 'Playfair Display';
  font-style: italic;
  font-weight: 800;
  font-display: fallback;
  src: url(https://fonts.gstatic.com/s/playfairdisplay/v30/nuFkD-vYSZviVYUb_rj3ij__anPXDTnohkk72xU.woff2) format('woff2');
  unicode-range: U+0301, U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
}
/* vietnamese */
@font-face {
  font-family: 'Playfair Display';
  font-style: italic;
  font-weight: 800;
  font-display: fallback;
  src: url(https://fonts.gstatic.com/s/playfairdisplay/v30/nuFkD-vYSZviVYUb_rj3ij__anPXDTnojUk72xU.woff2) format('woff2');
  unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+0300-0301, U+0303-0304, U+0308-0309, U+0323, U+0329, U+1EA0-1EF9, U+20AB;
}
/* latin-ext */
@font-face {
  font-family: 'Playfair Display';
  font-style: italic;
  font-weight: 800;
  font-display: fallback;
  src: url(https://fonts.gstatic.com/s/playfairdisplay/v30/nuFkD-vYSZviVYUb_rj3ij__anPXDTnojEk72xU.woff2) format('woff2');
  unicode-range: U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
}
/* latin */
@font-face {
  font-family: 'Playfair Display';
  font-style: italic;
  font-weight: 800;
  font-display: fallback;
  src: url(https://fonts.gstatic.com/s/playfairdisplay/v30/nuFkD-vYSZviVYUb_rj3ij__anPXDTnogkk7.woff2) format('woff2');
  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
}
/* cyrillic */
@font-face {
  font-family: 'Playfair Display';
  font-style: italic;
  font-weight: 900;
  font-display: fallback;
  src: url(https://fonts.gstatic.com/s/playfairdisplay/v30/nuFkD-vYSZviVYUb_rj3ij__anPXDTnohkk72xU.woff2) format('woff2');
  unicode-range: U+0301, U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
}
/* vietnamese */
@font-face {
  font-family: 'Playfair Display';
  font-style: italic;
  font-weight: 900;
  font-display: fallback;
  src: url(https://fonts.gstatic.com/s/playfairdisplay/v30/nuFkD-vYSZviVYUb_rj3ij__anPXDTnojUk72xU.woff2) format('woff2');
  unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+0300-0301, U+0303-0304, U+0308-0309, U+0323, U+0329, U+1EA0-1EF9, U+20AB;
}
/* latin-ext */
@font-face {
  font-family: 'Playfair Display';
  font-style: italic;
  font-weight: 900;
  font-display: fallback;
  src: url(https://fonts.gstatic.com/s/playfairdisplay/v30/nuFkD-vYSZviVYUb_rj3ij__anPXDTnojEk72xU.woff2) format('woff2');
  unicode-range: U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
}
/* latin */
@font-face {
  font-family: 'Playfair Display';
  font-style: italic;
  font-weight: 900;
  font-display: fallback;
  src: url(https://fonts.gstatic.com/s/playfairdisplay/v30/nuFkD-vYSZviVYUb_rj3ij__anPXDTnogkk7.woff2) format('woff2');
  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
}
/* cyrillic */
@font-face {
  font-family: 'Playfair Display';
  font-style: normal;
  font-weight: 400;
  font-display: fallback;
  src: url(https://fonts.gstatic.com/s/playfairdisplay/v30/nuFiD-vYSZviVYUb_rj3ij__anPXDTjYgFE_.woff2) format('woff2');
  unicode-range: U+0301, U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
}
/* vietnamese */
@font-face {
  font-family: 'Playfair Display';
  font-style: normal;
  font-weight: 400;
  font-display: fallback;
  src: url(https://fonts.gstatic.com/s/playfairdisplay/v30/nuFiD-vYSZviVYUb_rj3ij__anPXDTPYgFE_.woff2) format('woff2');
  unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+0300-0301, U+0303-0304, U+0308-0309, U+0323, U+0329, U+1EA0-1EF9, U+20AB;
}
/* latin-ext */
@font-face {
  font-family: 'Playfair Display';
  font-style: normal;
  font-weight: 400;
  font-display: fallback;
  src: url(https://fonts.gstatic.com/s/playfairdisplay/v30/nuFiD-vYSZviVYUb_rj3ij__anPXDTLYgFE_.woff2) format('woff2');
  unicode-range: U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
}
/* latin */
@font-face {
  font-family: 'Playfair Display';
  font-style: normal;
  font-weight: 400;
  font-display: fallback;
  src: url(https://fonts.gstatic.com/s/playfairdisplay/v30/nuFiD-vYSZviVYUb_rj3ij__anPXDTzYgA.woff2) format('woff2');
  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
}
/* cyrillic */
@font-face {
  font-family: 'Playfair Display';
  font-style: normal;
  font-weight: 500;
  font-display: fallback;
  src: url(https://fonts.gstatic.com/s/playfairdisplay/v30/nuFiD-vYSZviVYUb_rj3ij__anPXDTjYgFE_.woff2) format('woff2');
  unicode-range: U+0301, U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
}
/* vietnamese */
@font-face {
  font-family: 'Playfair Display';
  font-style: normal;
  font-weight: 500;
  font-display: fallback;
  src: url(https://fonts.gstatic.com/s/playfairdisplay/v30/nuFiD-vYSZviVYUb_rj3ij__anPXDTPYgFE_.woff2) format('woff2');
  unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+0300-0301, U+0303-0304, U+0308-0309, U+0323, U+0329, U+1EA0-1EF9, U+20AB;
}
/* latin-ext */
@font-face {
  font-family: 'Playfair Display';
  font-style: normal;
  font-weight: 500;
  font-display: fallback;
  src: url(https://fonts.gstatic.com/s/playfairdisplay/v30/nuFiD-vYSZviVYUb_rj3ij__anPXDTLYgFE_.woff2) format('woff2');
  unicode-range: U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
}
/* latin */
@font-face {
  font-family: 'Playfair Display';
  font-style: normal;
  font-weight: 500;
  font-display: fallback;
  src: url(https://fonts.gstatic.com/s/playfairdisplay/v30/nuFiD-vYSZviVYUb_rj3ij__anPXDTzYgA.woff2) format('woff2');
  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
}
/* cyrillic */
@font-face {
  font-family: 'Playfair Display';
  font-style: normal;
  font-weight: 600;
  font-display: fallback;
  src: url(https://fonts.gstatic.com/s/playfairdisplay/v30/nuFiD-vYSZviVYUb_rj3ij__anPXDTjYgFE_.woff2) format('woff2');
  unicode-range: U+0301, U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
}
/* vietnamese */
@font-face {
  font-family: 'Playfair Display';
  font-style: normal;
  font-weight: 600;
  font-display: fallback;
  src: url(https://fonts.gstatic.com/s/playfairdisplay/v30/nuFiD-vYSZviVYUb_rj3ij__anPXDTPYgFE_.woff2) format('woff2');
  unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+0300-0301, U+0303-0304, U+0308-0309, U+0323, U+0329, U+1EA0-1EF9, U+20AB;
}
/* latin-ext */
@font-face {
  font-family: 'Playfair Display';
  font-style: normal;
  font-weight: 600;
  font-display: fallback;
  src: url(https://fonts.gstatic.com/s/playfairdisplay/v30/nuFiD-vYSZviVYUb_rj3ij__anPXDTLYgFE_.woff2) format('woff2');
  unicode-range: U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
}
/* latin */
@font-face {
  font-family: 'Playfair Display';
  font-style: normal;
  font-weight: 600;
  font-display: fallback;
  src: url(https://fonts.gstatic.com/s/playfairdisplay/v30/nuFiD-vYSZviVYUb_rj3ij__anPXDTzYgA.woff2) format('woff2');
  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
}
/* cyrillic */
@font-face {
  font-family: 'Playfair Display';
  font-style: normal;
  font-weight: 700;
  font-display: fallback;
  src: url(https://fonts.gstatic.com/s/playfairdisplay/v30/nuFiD-vYSZviVYUb_rj3ij__anPXDTjYgFE_.woff2) format('woff2');
  unicode-range: U+0301, U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
}
/* vietnamese */
@font-face {
  font-family: 'Playfair Display';
  font-style: normal;
  font-weight: 700;
  font-display: fallback;
  src: url(https://fonts.gstatic.com/s/playfairdisplay/v30/nuFiD-vYSZviVYUb_rj3ij__anPXDTPYgFE_.woff2) format('woff2');
  unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+0300-0301, U+0303-0304, U+0308-0309, U+0323, U+0329, U+1EA0-1EF9, U+20AB;
}
/* latin-ext */
@font-face {
  font-family: 'Playfair Display';
  font-style: normal;
  font-weight: 700;
  font-display: fallback;
  src: url(https://fonts.gstatic.com/s/playfairdisplay/v30/nuFiD-vYSZviVYUb_rj3ij__anPXDTLYgFE_.woff2) format('woff2');
  unicode-range: U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
}
/* latin */
@font-face {
  font-family: 'Playfair Display';
  font-style: normal;
  font-weight: 700;
  font-display: fallback;
  src: url(https://fonts.gstatic.com/s/playfairdisplay/v30/nuFiD-vYSZviVYUb_rj3ij__anPXDTzYgA.woff2) format('woff2');
  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
}
/* cyrillic */
@font-face {
  font-family: 'Playfair Display';
  font-style: normal;
  font-weight: 800;
  font-display: fallback;
  src: url(https://fonts.gstatic.com/s/playfairdisplay/v30/nuFiD-vYSZviVYUb_rj3ij__anPXDTjYgFE_.woff2) format('woff2');
  unicode-range: U+0301, U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
}
/* vietnamese */
@font-face {
  font-family: 'Playfair Display';
  font-style: normal;
  font-weight: 800;
  font-display: fallback;
  src: url(https://fonts.gstatic.com/s/playfairdisplay/v30/nuFiD-vYSZviVYUb_rj3ij__anPXDTPYgFE_.woff2) format('woff2');
  unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+0300-0301, U+0303-0304, U+0308-0309, U+0323, U+0329, U+1EA0-1EF9, U+20AB;
}
/* latin-ext */
@font-face {
  font-family: 'Playfair Display';
  font-style: normal;
  font-weight: 800;
  font-display: fallback;
  src: url(https://fonts.gstatic.com/s/playfairdisplay/v30/nuFiD-vYSZviVYUb_rj3ij__anPXDTLYgFE_.woff2) format('woff2');
  unicode-range: U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
}
/* latin */
@font-face {
  font-family: 'Playfair Display';
  font-style: normal;
  font-weight: 800;
  font-display: fallback;
  src: url(https://fonts.gstatic.com/s/playfairdisplay/v30/nuFiD-vYSZviVYUb_rj3ij__anPXDTzYgA.woff2) format('woff2');
  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
}
/* cyrillic */
@font-face {
  font-family: 'Playfair Display';
  font-style: normal;
  font-weight: 900;
  font-display: fallback;
  src: url(https://fonts.gstatic.com/s/playfairdisplay/v30/nuFiD-vYSZviVYUb_rj3ij__anPXDTjYgFE_.woff2) format('woff2');
  unicode-range: U+0301, U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
}
/* vietnamese */
@font-face {
  font-family: 'Playfair Display';
  font-style: normal;
  font-weight: 900;
  font-display: fallback;
  src: url(https://fonts.gstatic.com/s/playfairdisplay/v30/nuFiD-vYSZviVYUb_rj3ij__anPXDTPYgFE_.woff2) format('woff2');
  unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+0300-0301, U+0303-0304, U+0308-0309, U+0323, U+0329, U+1EA0-1EF9, U+20AB;
}
/* latin-ext */
@font-face {
  font-family: 'Playfair Display';
  font-style: normal;
  font-weight: 900;
  font-display: fallback;
  src: url(https://fonts.gstatic.com/s/playfairdisplay/v30/nuFiD-vYSZviVYUb_rj3ij__anPXDTLYgFE_.woff2) format('woff2');
  unicode-range: U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
}
/* latin */
@font-face {
  font-family: 'Playfair Display';
  font-style: normal;
  font-weight: 900;
  font-display: fallback;
  src: url(https://fonts.gstatic.com/s/playfairdisplay/v30/nuFiD-vYSZviVYUb_rj3ij__anPXDTzYgA.woff2) format('woff2');
  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
}
/* devanagari */
@font-face {
  font-family: 'Poppins';
  font-style: italic;
  font-weight: 100;
  font-display: fallback;
  src: url(https://fonts.gstatic.com/s/poppins/v20/pxiAyp8kv8JHgFVrJJLmE0tDMPKzSQ.woff2) format('woff2');
  unicode-range: U+0900-097F, U+1CD0-1CF9, U+200C-200D, U+20A8, U+20B9, U+25CC, U+A830-A839, U+A8E0-A8FF;
}
/* latin-ext */
@font-face {
  font-family: 'Poppins';
  font-style: italic;
  font-weight: 100;
  font-display: fallback;
  src: url(https://fonts.gstatic.com/s/poppins/v20/pxiAyp8kv8JHgFVrJJLmE0tMMPKzSQ.woff2) format('woff2');
  unicode-range: U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
}
/* latin */
@font-face {
  font-family: 'Poppins';
  font-style: italic;
  font-weight: 100;
  font-display: fallback;
  src: url(https://fonts.gstatic.com/s/poppins/v20/pxiAyp8kv8JHgFVrJJLmE0tCMPI.woff2) format('woff2');
  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
}
/* devanagari */
@font-face {
  font-family: 'Poppins';
  font-style: italic;
  font-weight: 200;
  font-display: fallback;
  src: url(https://fonts.gstatic.com/s/poppins/v20/pxiDyp8kv8JHgFVrJJLmv1pVFteOcEg.woff2) format('woff2');
  unicode-range: U+0900-097F, U+1CD0-1CF9, U+200C-200D, U+20A8, U+20B9, U+25CC, U+A830-A839, U+A8E0-A8FF;
}
/* latin-ext */
@font-face {
  font-family: 'Poppins';
  font-style: italic;
  font-weight: 200;
  font-display: fallback;
  src: url(https://fonts.gstatic.com/s/poppins/v20/pxiDyp8kv8JHgFVrJJLmv1pVGdeOcEg.woff2) format('woff2');
  unicode-range: U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
}
/* latin */
@font-face {
  font-family: 'Poppins';
  font-style: italic;
  font-weight: 200;
  font-display: fallback;
  src: url(https://fonts.gstatic.com/s/poppins/v20/pxiDyp8kv8JHgFVrJJLmv1pVF9eO.woff2) format('woff2');
  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
}
/* devanagari */
@font-face {
  font-family: 'Poppins';
  font-style: italic;
  font-weight: 300;
  font-display: fallback;
  src: url(https://fonts.gstatic.com/s/poppins/v20/pxiDyp8kv8JHgFVrJJLm21lVFteOcEg.woff2) format('woff2');
  unicode-range: U+0900-097F, U+1CD0-1CF9, U+200C-200D, U+20A8, U+20B9, U+25CC, U+A830-A839, U+A8E0-A8FF;
}
/* latin-ext */
@font-face {
  font-family: 'Poppins';
  font-style: italic;
  font-weight: 300;
  font-display: fallback;
  src: url(https://fonts.gstatic.com/s/poppins/v20/pxiDyp8kv8JHgFVrJJLm21lVGdeOcEg.woff2) format('woff2');
  unicode-range: U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
}
/* latin */
@font-face {
  font-family: 'Poppins';
  font-style: italic;
  font-weight: 300;
  font-display: fallback;
  src: url(https://fonts.gstatic.com/s/poppins/v20/pxiDyp8kv8JHgFVrJJLm21lVF9eO.woff2) format('woff2');
  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
}
/* devanagari */
@font-face {
  font-family: 'Poppins';
  font-style: italic;
  font-weight: 400;
  font-display: fallback;
  src: url(https://fonts.gstatic.com/s/poppins/v20/pxiGyp8kv8JHgFVrJJLucXtAKPY.woff2) format('woff2');
  unicode-range: U+0900-097F, U+1CD0-1CF9, U+200C-200D, U+20A8, U+20B9, U+25CC, U+A830-A839, U+A8E0-A8FF;
}
/* latin-ext */
@font-face {
  font-family: 'Poppins';
  font-style: italic;
  font-weight: 400;
  font-display: fallback;
  src: url(https://fonts.gstatic.com/s/poppins/v20/pxiGyp8kv8JHgFVrJJLufntAKPY.woff2) format('woff2');
  unicode-range: U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
}
/* latin */
@font-face {
  font-family: 'Poppins';
  font-style: italic;
  font-weight: 400;
  font-display: fallback;
  src: url(https://fonts.gstatic.com/s/poppins/v20/pxiGyp8kv8JHgFVrJJLucHtA.woff2) format('woff2');
  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
}
/* devanagari */
@font-face {
  font-family: 'Poppins';
  font-style: italic;
  font-weight: 500;
  font-display: fallback;
  src: url(https://fonts.gstatic.com/s/poppins/v20/pxiDyp8kv8JHgFVrJJLmg1hVFteOcEg.woff2) format('woff2');
  unicode-range: U+0900-097F, U+1CD0-1CF9, U+200C-200D, U+20A8, U+20B9, U+25CC, U+A830-A839, U+A8E0-A8FF;
}
/* latin-ext */
@font-face {
  font-family: 'Poppins';
  font-style: italic;
  font-weight: 500;
  font-display: fallback;
  src: url(https://fonts.gstatic.com/s/poppins/v20/pxiDyp8kv8JHgFVrJJLmg1hVGdeOcEg.woff2) format('woff2');
  unicode-range: U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
}
/* latin */
@font-face {
  font-family: 'Poppins';
  font-style: italic;
  font-weight: 500;
  font-display: fallback;
  src: url(https://fonts.gstatic.com/s/poppins/v20/pxiDyp8kv8JHgFVrJJLmg1hVF9eO.woff2) format('woff2');
  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
}
/* devanagari */
@font-face {
  font-family: 'Poppins';
  font-style: italic;
  font-weight: 600;
  font-display: fallback;
  src: url(https://fonts.gstatic.com/s/poppins/v20/pxiDyp8kv8JHgFVrJJLmr19VFteOcEg.woff2) format('woff2');
  unicode-range: U+0900-097F, U+1CD0-1CF9, U+200C-200D, U+20A8, U+20B9, U+25CC, U+A830-A839, U+A8E0-A8FF;
}
/* latin-ext */
@font-face {
  font-family: 'Poppins';
  font-style: italic;
  font-weight: 600;
  font-display: fallback;
  src: url(https://fonts.gstatic.com/s/poppins/v20/pxiDyp8kv8JHgFVrJJLmr19VGdeOcEg.woff2) format('woff2');
  unicode-range: U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
}
/* latin */
@font-face {
  font-family: 'Poppins';
  font-style: italic;
  font-weight: 600;
  font-display: fallback;
  src: url(https://fonts.gstatic.com/s/poppins/v20/pxiDyp8kv8JHgFVrJJLmr19VF9eO.woff2) format('woff2');
  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
}
/* devanagari */
@font-face {
  font-family: 'Poppins';
  font-style: italic;
  font-weight: 700;
  font-display: fallback;
  src: url(https://fonts.gstatic.com/s/poppins/v20/pxiDyp8kv8JHgFVrJJLmy15VFteOcEg.woff2) format('woff2');
  unicode-range: U+0900-097F, U+1CD0-1CF9, U+200C-200D, U+20A8, U+20B9, U+25CC, U+A830-A839, U+A8E0-A8FF;
}
/* latin-ext */
@font-face {
  font-family: 'Poppins';
  font-style: italic;
  font-weight: 700;
  font-display: fallback;
  src: url(https://fonts.gstatic.com/s/poppins/v20/pxiDyp8kv8JHgFVrJJLmy15VGdeOcEg.woff2) format('woff2');
  unicode-range: U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
}
/* latin */
@font-face {
  font-family: 'Poppins';
  font-style: italic;
  font-weight: 700;
  font-display: fallback;
  src: url(https://fonts.gstatic.com/s/poppins/v20/pxiDyp8kv8JHgFVrJJLmy15VF9eO.woff2) format('woff2');
  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
}
/* devanagari */
@font-face {
  font-family: 'Poppins';
  font-style: italic;
  font-weight: 800;
  font-display: fallback;
  src: url(https://fonts.gstatic.com/s/poppins/v20/pxiDyp8kv8JHgFVrJJLm111VFteOcEg.woff2) format('woff2');
  unicode-range: U+0900-097F, U+1CD0-1CF9, U+200C-200D, U+20A8, U+20B9, U+25CC, U+A830-A839, U+A8E0-A8FF;
}
/* latin-ext */
@font-face {
  font-family: 'Poppins';
  font-style: italic;
  font-weight: 800;
  font-display: fallback;
  src: url(https://fonts.gstatic.com/s/poppins/v20/pxiDyp8kv8JHgFVrJJLm111VGdeOcEg.woff2) format('woff2');
  unicode-range: U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
}
/* latin */
@font-face {
  font-family: 'Poppins';
  font-style: italic;
  font-weight: 800;
  font-display: fallback;
  src: url(https://fonts.gstatic.com/s/poppins/v20/pxiDyp8kv8JHgFVrJJLm111VF9eO.woff2) format('woff2');
  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
}
/* devanagari */
@font-face {
  font-family: 'Poppins';
  font-style: italic;
  font-weight: 900;
  font-display: fallback;
  src: url(https://fonts.gstatic.com/s/poppins/v20/pxiDyp8kv8JHgFVrJJLm81xVFteOcEg.woff2) format('woff2');
  unicode-range: U+0900-097F, U+1CD0-1CF9, U+200C-200D, U+20A8, U+20B9, U+25CC, U+A830-A839, U+A8E0-A8FF;
}
/* latin-ext */
@font-face {
  font-family: 'Poppins';
  font-style: italic;
  font-weight: 900;
  font-display: fallback;
  src: url(https://fonts.gstatic.com/s/poppins/v20/pxiDyp8kv8JHgFVrJJLm81xVGdeOcEg.woff2) format('woff2');
  unicode-range: U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
}
/* latin */
@font-face {
  font-family: 'Poppins';
  font-style: italic;
  font-weight: 900;
  font-display: fallback;
  src: url(https://fonts.gstatic.com/s/poppins/v20/pxiDyp8kv8JHgFVrJJLm81xVF9eO.woff2) format('woff2');
  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
}
/* devanagari */
@font-face {
  font-family: 'Poppins';
  font-style: normal;
  font-weight: 100;
  font-display: fallback;
  src: url(https://fonts.gstatic.com/s/poppins/v20/pxiGyp8kv8JHgFVrLPTucXtAKPY.woff2) format('woff2');
  unicode-range: U+0900-097F, U+1CD0-1CF9, U+200C-200D, U+20A8, U+20B9, U+25CC, U+A830-A839, U+A8E0-A8FF;
}
/* latin-ext */
@font-face {
  font-family: 'Poppins';
  font-style: normal;
  font-weight: 100;
  font-display: fallback;
  src: url(https://fonts.gstatic.com/s/poppins/v20/pxiGyp8kv8JHgFVrLPTufntAKPY.woff2) format('woff2');
  unicode-range: U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
}
/* latin */
@font-face {
  font-family: 'Poppins';
  font-style: normal;
  font-weight: 100;
  font-display: fallback;
  src: url(https://fonts.gstatic.com/s/poppins/v20/pxiGyp8kv8JHgFVrLPTucHtA.woff2) format('woff2');
  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
}
/* devanagari */
@font-face {
  font-family: 'Poppins';
  font-style: normal;
  font-weight: 200;
  font-display: fallback;
  src: url(https://fonts.gstatic.com/s/poppins/v20/pxiByp8kv8JHgFVrLFj_Z11lFc-K.woff2) format('woff2');
  unicode-range: U+0900-097F, U+1CD0-1CF9, U+200C-200D, U+20A8, U+20B9, U+25CC, U+A830-A839, U+A8E0-A8FF;
}
/* latin-ext */
@font-face {
  font-family: 'Poppins';
  font-style: normal;
  font-weight: 200;
  font-display: fallback;
  src: url(https://fonts.gstatic.com/s/poppins/v20/pxiByp8kv8JHgFVrLFj_Z1JlFc-K.woff2) format('woff2');
  unicode-range: U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
}
/* latin */
@font-face {
  font-family: 'Poppins';
  font-style: normal;
  font-weight: 200;
  font-display: fallback;
  src: url(https://fonts.gstatic.com/s/poppins/v20/pxiByp8kv8JHgFVrLFj_Z1xlFQ.woff2) format('woff2');
  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
}
/* devanagari */
@font-face {
  font-family: 'Poppins';
  font-style: normal;
  font-weight: 300;
  font-display: fallback;
  src: url(https://fonts.gstatic.com/s/poppins/v20/pxiByp8kv8JHgFVrLDz8Z11lFc-K.woff2) format('woff2');
  unicode-range: U+0900-097F, U+1CD0-1CF9, U+200C-200D, U+20A8, U+20B9, U+25CC, U+A830-A839, U+A8E0-A8FF;
}
/* latin-ext */
@font-face {
  font-family: 'Poppins';
  font-style: normal;
  font-weight: 300;
  font-display: fallback;
  src: url(https://fonts.gstatic.com/s/poppins/v20/pxiByp8kv8JHgFVrLDz8Z1JlFc-K.woff2) format('woff2');
  unicode-range: U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
}
/* latin */
@font-face {
  font-family: 'Poppins';
  font-style: normal;
  font-weight: 300;
  font-display: fallback;
  src: url(https://fonts.gstatic.com/s/poppins/v20/pxiByp8kv8JHgFVrLDz8Z1xlFQ.woff2) format('woff2');
  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
}
/* devanagari */
@font-face {
  font-family: 'Poppins';
  font-style: normal;
  font-weight: 400;
  font-display: fallback;
  src: url(https://fonts.gstatic.com/s/poppins/v20/pxiEyp8kv8JHgFVrJJbecmNE.woff2) format('woff2');
  unicode-range: U+0900-097F, U+1CD0-1CF9, U+200C-200D, U+20A8, U+20B9, U+25CC, U+A830-A839, U+A8E0-A8FF;
}
/* latin-ext */
@font-face {
  font-family: 'Poppins';
  font-style: normal;
  font-weight: 400;
  font-display: fallback;
  src: url(https://fonts.gstatic.com/s/poppins/v20/pxiEyp8kv8JHgFVrJJnecmNE.woff2) format('woff2');
  unicode-range: U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
}
/* latin */
@font-face {
  font-family: 'Poppins';
  font-style: normal;
  font-weight: 400;
  font-display: fallback;
  src: url(https://fonts.gstatic.com/s/poppins/v20/pxiEyp8kv8JHgFVrJJfecg.woff2) format('woff2');
  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
}
/* devanagari */
@font-face {
  font-family: 'Poppins';
  font-style: normal;
  font-weight: 500;
  font-display: fallback;
  src: url(https://fonts.gstatic.com/s/poppins/v20/pxiByp8kv8JHgFVrLGT9Z11lFc-K.woff2) format('woff2');
  unicode-range: U+0900-097F, U+1CD0-1CF9, U+200C-200D, U+20A8, U+20B9, U+25CC, U+A830-A839, U+A8E0-A8FF;
}
/* latin-ext */
@font-face {
  font-family: 'Poppins';
  font-style: normal;
  font-weight: 500;
  font-display: fallback;
  src: url(https://fonts.gstatic.com/s/poppins/v20/pxiByp8kv8JHgFVrLGT9Z1JlFc-K.woff2) format('woff2');
  unicode-range: U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
}
/* latin */
@font-face {
  font-family: 'Poppins';
  font-style: normal;
  font-weight: 500;
  font-display: fallback;
  src: url(https://fonts.gstatic.com/s/poppins/v20/pxiByp8kv8JHgFVrLGT9Z1xlFQ.woff2) format('woff2');
  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
}
/* devanagari */
@font-face {
  font-family: 'Poppins';
  font-style: normal;
  font-weight: 600;
  font-display: fallback;
  src: url(https://fonts.gstatic.com/s/poppins/v20/pxiByp8kv8JHgFVrLEj6Z11lFc-K.woff2) format('woff2');
  unicode-range: U+0900-097F, U+1CD0-1CF9, U+200C-200D, U+20A8, U+20B9, U+25CC, U+A830-A839, U+A8E0-A8FF;
}
/* latin-ext */
@font-face {
  font-family: 'Poppins';
  font-style: normal;
  font-weight: 600;
  font-display: fallback;
  src: url(https://fonts.gstatic.com/s/poppins/v20/pxiByp8kv8JHgFVrLEj6Z1JlFc-K.woff2) format('woff2');
  unicode-range: U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
}
/* latin */
@font-face {
  font-family: 'Poppins';
  font-style: normal;
  font-weight: 600;
  font-display: fallback;
  src: url(https://fonts.gstatic.com/s/poppins/v20/pxiByp8kv8JHgFVrLEj6Z1xlFQ.woff2) format('woff2');
  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
}
/* devanagari */
@font-face {
  font-family: 'Poppins';
  font-style: normal;
  font-weight: 700;
  font-display: fallback;
  src: url(https://fonts.gstatic.com/s/poppins/v20/pxiByp8kv8JHgFVrLCz7Z11lFc-K.woff2) format('woff2');
  unicode-range: U+0900-097F, U+1CD0-1CF9, U+200C-200D, U+20A8, U+20B9, U+25CC, U+A830-A839, U+A8E0-A8FF;
}
/* latin-ext */
@font-face {
  font-family: 'Poppins';
  font-style: normal;
  font-weight: 700;
  font-display: fallback;
  src: url(https://fonts.gstatic.com/s/poppins/v20/pxiByp8kv8JHgFVrLCz7Z1JlFc-K.woff2) format('woff2');
  unicode-range: U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
}
/* latin */
@font-face {
  font-family: 'Poppins';
  font-style: normal;
  font-weight: 700;
  font-display: fallback;
  src: url(https://fonts.gstatic.com/s/poppins/v20/pxiByp8kv8JHgFVrLCz7Z1xlFQ.woff2) format('woff2');
  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
}
/* devanagari */
@font-face {
  font-family: 'Poppins';
  font-style: normal;
  font-weight: 800;
  font-display: fallback;
  src: url(https://fonts.gstatic.com/s/poppins/v20/pxiByp8kv8JHgFVrLDD4Z11lFc-K.woff2) format('woff2');
  unicode-range: U+0900-097F, U+1CD0-1CF9, U+200C-200D, U+20A8, U+20B9, U+25CC, U+A830-A839, U+A8E0-A8FF;
}
/* latin-ext */
@font-face {
  font-family: 'Poppins';
  font-style: normal;
  font-weight: 800;
  font-display: fallback;
  src: url(https://fonts.gstatic.com/s/poppins/v20/pxiByp8kv8JHgFVrLDD4Z1JlFc-K.woff2) format('woff2');
  unicode-range: U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
}
/* latin */
@font-face {
  font-family: 'Poppins';
  font-style: normal;
  font-weight: 800;
  font-display: fallback;
  src: url(https://fonts.gstatic.com/s/poppins/v20/pxiByp8kv8JHgFVrLDD4Z1xlFQ.woff2) format('woff2');
  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
}
/* devanagari */
@font-face {
  font-family: 'Poppins';
  font-style: normal;
  font-weight: 900;
  font-display: fallback;
  src: url(https://fonts.gstatic.com/s/poppins/v20/pxiByp8kv8JHgFVrLBT5Z11lFc-K.woff2) format('woff2');
  unicode-range: U+0900-097F, U+1CD0-1CF9, U+200C-200D, U+20A8, U+20B9, U+25CC, U+A830-A839, U+A8E0-A8FF;
}
/* latin-ext */
@font-face {
  font-family: 'Poppins';
  font-style: normal;
  font-weight: 900;
  font-display: fallback;
  src: url(https://fonts.gstatic.com/s/poppins/v20/pxiByp8kv8JHgFVrLBT5Z1JlFc-K.woff2) format('woff2');
  unicode-range: U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
}
/* latin */
@font-face {
  font-family: 'Poppins';
  font-style: normal;
  font-weight: 900;
  font-display: fallback;
  src: url(https://fonts.gstatic.com/s/poppins/v20/pxiByp8kv8JHgFVrLBT5Z1xlFQ.woff2) format('woff2');
  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
}

</style>

```

</details>

## Screenshots or screencast <!-- if applicable -->