### PR TITLE
Add @ObliviousHarmony to wp-env codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -125,7 +125,7 @@
 /packages/report-flaky-tests                    @kevin940726
 
 # wp-env
-/packages/env                                   @noahtallen
+/packages/env                                   @noahtallen @ObliviousHarmony
 
 # PHP
 /lib                                            @spacedmonkey


### PR DESCRIPTION
@ObliviousHarmony has made a lot of great wp-env contributions recently, so this puts him on the docket for PR reviews as well ;)