### PR TITLE
Edit Site: Unlock private APIs outside of the component

### DIFF
--- a/packages/edit-site/src/components/secondary-sidebar/list-view-sidebar.js
+++ b/packages/edit-site/src/components/secondary-sidebar/list-view-sidebar.js
@@ -19,6 +19,8 @@ import { ESCAPE } from '@wordpress/keycodes';
 import { store as editSiteStore } from '../../store';
 import { unlock } from '../../private-apis';
 
+const { PrivateListView } = unlock( blockEditorPrivateApis );
+
 export default function ListViewSidebar() {
 	const { setIsListViewOpened } = useDispatch( editSiteStore );
 
@@ -31,7 +33,6 @@ export default function ListViewSidebar() {
 		}
 	}
 
-	const { PrivateListView } = unlock( blockEditorPrivateApis );
 	return (
 		// eslint-disable-next-line jsx-a11y/no-static-element-interactions
 		<div

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/navigation-menu-content.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/navigation-menu-content.js
@@ -21,6 +21,8 @@ import { store as coreStore } from '@wordpress/core-data';
 import { unlock } from '../../private-apis';
 import { NavigationMenuLoader } from './loader';
 
+const { PrivateListView, LeafMoreMenu } = unlock( blockEditorPrivateApis );
+
 function CustomLinkAdditionalBlockUI( { block, onClose } ) {
 	const { updateBlockAttributes } = useDispatch( blockEditorStore );
 	const { label, url, opensInNewTab } = block.attributes;
@@ -143,8 +145,6 @@ export default function NavigationMenuContent( { rootClientId, onSelect } ) {
 			}
 		};
 	}, [ shouldKeepLoading, clientIdsTree, isLoading ] );
-
-	const { PrivateListView, LeafMoreMenu } = unlock( blockEditorPrivateApis );
 
 	const offCanvasOnselect = useCallback(
 		( block ) => {


### PR DESCRIPTION
## What?
Related: #50509.

PR moves unlocking of the private components outside the function.

## Why?
The private components can be unlocked at the file level. There's no need to perform the action on each component re-render.

## Testing Instructions
1. Open the Site Editor
2. Confirm list view renders as before.
3. Confirm the Navigation block's list view works as before.
