### PR TITLE
Revert "Enqueue the registered assets (#50185)"

### DIFF
--- a/lib/compat/wordpress-6.2/default-filters.php
+++ b/lib/compat/wordpress-6.2/default-filters.php
@@ -16,18 +16,3 @@
  *
  * @package gutenberg
  */
-
-/**
- * This is a temporary fix to ensure that the block editor styles are enqueued
- * in the order the iframe expects.
- *
- * The wp_enqueue_registered_block_scripts_and_styles callback has been removed in core
- * as of https://github.com/WordPress/wordpress-develop/pull/4356.
- *
- * However, Gutenberg supports WordPress 6.1 and 6.2, which still have this callback.
- * Hence, why we remove it first and then re-add it.
- *
- * This way we make sure it still works the same in WordPress trunk, 6.1 and 6.2.
- */
-remove_action( 'enqueue_block_editor_assets', 'wp_enqueue_registered_block_scripts_and_styles' );
-add_action( 'enqueue_block_editor_assets', 'wp_enqueue_registered_block_scripts_and_styles', 1 );

--- a/packages/e2e-tests/specs/editor/plugins/iframed-inline-styles.test.js
+++ b/packages/e2e-tests/specs/editor/plugins/iframed-inline-styles.test.js
@@ -31,7 +31,6 @@ describe( 'iframed inline styles', () => {
 		await deactivatePlugin( 'gutenberg-test-iframed-inline-styles' );
 	} );
 
-	// Skip flaky test. See https://github.com/WordPress/gutenberg/issues/35172
 	it( 'should load inline styles in iframe', async () => {
 		await insertBlock( 'Iframed Inline Styles' );
 


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/50246

## What?

This PR reverts https://github.com/WordPress/gutenberg/pull/50185

## Why?

That was a temporary fix to get the `iframed-inline-styles` e2e test passing.

The root issue was caused by a core change that is being reverted at https://github.com/WordPress/wordpress-develop/pull/4498. As soon as it is, we can revert this as well.

## How?

Revert the temporary fix.

## Testing Instructions

The `iframed-inline-styles` e2e test should pass.