### PR TITLE
Fix: Can't type space if `RichText` component is inside button/summary in Firefox

### DIFF
--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -402,7 +402,7 @@ function RichTextWrapper(
 						disableLineBreaks,
 						onSplitAtEnd,
 					} ),
-					useFirefoxCompat(),
+					useFirefoxCompat( { value, onChange } ),
 					anchorRef,
 				] ) }
 				contentEditable={ true }

--- a/packages/block-editor/src/components/rich-text/use-firefox-compat.js
+++ b/packages/block-editor/src/components/rich-text/use-firefox-compat.js
@@ -1,15 +1,21 @@
 /**
  * WordPress dependencies
  */
+import { useRef } from '@wordpress/element';
 import { useRefEffect } from '@wordpress/compose';
 import { useSelect } from '@wordpress/data';
+import { SPACE } from '@wordpress/keycodes';
+import { insert } from '@wordpress/rich-text';
 
 /**
  * Internal dependencies
  */
 import { store as blockEditorStore } from '../../store';
 
-export function useFirefoxCompat() {
+export function useFirefoxCompat( props ) {
+	const propsRef = useRef( props );
+	propsRef.current = props;
+
 	const { isMultiSelecting } = useSelect( blockEditorStore );
 	return useRefEffect( ( element ) => {
 		function onFocus() {
@@ -31,9 +37,25 @@ export function useFirefoxCompat() {
 			}
 		}
 
+		// If a contenteditable element is inside a button/summary element,
+		// it is not possible to type a space in Firefox. Therefore, cancel
+		// the default event and insert a space explicitly.
+		// See: https://bugzilla.mozilla.org/show_bug.cgi?id=1822860
+		function onKeyDown( event ) {
+			if ( event.keyCode !== SPACE ) {
+				return;
+			}
+
+			const { value, onChange } = propsRef.current;
+			onChange( insert( value, ' ' ) );
+			event.preventDefault();
+		}
+
 		element.addEventListener( 'focus', onFocus );
+		element.addEventListener( 'keydown', onKeyDown );
 		return () => {
 			element.removeEventListener( 'focus', onFocus );
+			element.removeEventListener( 'keydown', onKeyDown );
 		};
 	}, [] );
 }

--- a/packages/block-editor/src/components/rich-text/use-firefox-compat.js
+++ b/packages/block-editor/src/components/rich-text/use-firefox-compat.js
@@ -46,6 +46,10 @@ export function useFirefoxCompat( props ) {
 				return;
 			}
 
+			if ( element.closest( 'button, summary' ) === null ) {
+				return;
+			}
+
 			const { value, onChange } = propsRef.current;
 			onChange( insert( value, ' ' ) );
 			event.preventDefault();


### PR DESCRIPTION
Fixes: #49679

## What?
This PR fixes a problem where a space could not be entered if there is a `RichText` component in the `button`/`summary` element. In the core block, this can be reproduced with the summary element in the Details block.

## Why?
This is a Firefox-specific issue and has been reported in bug reports, as reported in [this comment](https://github.com/WordPress/gutenberg/issues/49679#issuecomment-1543262993). In the future, this may be fixed in Firefox itself, but it should not be a problem to fix it in Gutenberg first.

## How?
I have added an event to the RichText component hook that monitors keydowns. In this event, if the space key is pressed and in a button/summary element (which is the case that causes the problem), the default event is canceled and an explicit space is added.

## Testing Instructions

Insert a Details block in the Firefox browser.
In the summary element, make sure you can type the space key.

### Before

https://github.com/WordPress/gutenberg/assets/54422211/19e26084-acb5-4e4e-9763-06c0f45e7d15

### After

https://github.com/WordPress/gutenberg/assets/54422211/2d20fe47-fb6b-4344-9dd0-178a2a89e575