### PR TITLE
Modals: Update the Cancel action's button design

### DIFF
--- a/packages/block-library/src/navigation/edit/navigation-menu-delete-control.js
+++ b/packages/block-library/src/navigation/edit/navigation-menu-delete-control.js
@@ -1,7 +1,11 @@
 /**
  * WordPress dependencies
  */
-import { Button, Flex, FlexItem, Modal } from '@wordpress/components';
+import {
+	Button,
+	Modal,
+	__experimentalHStack as HStack,
+} from '@wordpress/components';
 import {
 	store as coreStore,
 	useEntityId,
@@ -44,34 +48,30 @@ export default function NavigationMenuDeleteControl( { onDelete } ) {
 							'Are you sure you want to delete this navigation menu?'
 						) }
 					</p>
-					<Flex justify="flex-end">
-						<FlexItem>
-							<Button
-								variant="secondary"
-								onClick={ () => {
-									setIsConfirmModalVisible( false );
-								} }
-							>
-								{ __( 'Cancel' ) }
-							</Button>
-						</FlexItem>
-						<FlexItem>
-							<Button
-								variant="primary"
-								onClick={ () => {
-									deleteEntityRecord(
-										'postType',
-										'wp_navigation',
-										id,
-										{ force: true }
-									);
-									onDelete( title );
-								} }
-							>
-								{ __( 'Confirm' ) }
-							</Button>
-						</FlexItem>
-					</Flex>
+					<HStack justify="right">
+						<Button
+							variant="tertiary"
+							onClick={ () => {
+								setIsConfirmModalVisible( false );
+							} }
+						>
+							{ __( 'Cancel' ) }
+						</Button>
+						<Button
+							variant="primary"
+							onClick={ () => {
+								deleteEntityRecord(
+									'postType',
+									'wp_navigation',
+									id,
+									{ force: true }
+								);
+								onDelete( title );
+							} }
+						>
+							{ __( 'Confirm' ) }
+						</Button>
+					</HStack>
 				</Modal>
 			) }
 		</>

--- a/packages/edit-site/src/components/create-template-part-modal/index.js
+++ b/packages/edit-site/src/components/create-template-part-modal/index.js
@@ -13,6 +13,7 @@ import {
 	Modal,
 	__experimentalRadioGroup as RadioGroup,
 	__experimentalRadio as Radio,
+	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
@@ -106,31 +107,24 @@ export default function CreateTemplatePartModal( { closeModal, onCreate } ) {
 							) }
 						</RadioGroup>
 					</BaseControl>
-					<Flex
-						className="edit-site-create-template-part-modal__modal-actions"
-						justify="flex-end"
-					>
-						<FlexItem>
-							<Button
-								variant="secondary"
-								onClick={ () => {
-									closeModal();
-								} }
-							>
-								{ __( 'Cancel' ) }
-							</Button>
-						</FlexItem>
-						<FlexItem>
-							<Button
-								variant="primary"
-								type="submit"
-								disabled={ ! title }
-								isBusy={ isSubmitting }
-							>
-								{ __( 'Create' ) }
-							</Button>
-						</FlexItem>
-					</Flex>
+					<HStack justify="right">
+						<Button
+							variant="tertiary"
+							onClick={ () => {
+								closeModal();
+							} }
+						>
+							{ __( 'Cancel' ) }
+						</Button>
+						<Button
+							variant="primary"
+							type="submit"
+							disabled={ ! title }
+							isBusy={ isSubmitting }
+						>
+							{ __( 'Create' ) }
+						</Button>
+					</HStack>
 				</VStack>
 			</form>
 		</Modal>


### PR DESCRIPTION
## What?
Part of #50518.

PR changes the "Cancel" action button variation from `secondary` to `tertiary` for the `CreateTemplatePartModal` and `NavigationMenuDeleteControl` modals.

I've also simplified the markup around the buttons to match other models.

## Why?
See #50518.

## Testing Instructions
**Navigation**
1. Open a Post or Page.
2. Insert the Navigation block and select the menu.
3. Try deleting the menu from block Settings > Advanced.
4. Confirm the updated button design.

**Template Parts**
1. Open Site Editor.
2. Create a new template from the "Manage all template parts" page.
3. Confirm the updated button design.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

**Create a new template part modal**
![CleanShot 2023-05-11 at 15 56 24](https://github.com/WordPress/gutenberg/assets/240569/dd60762d-e913-456a-9683-32092ca017fd)

**Delete navigation confirmation modal**
![CleanShot 2023-05-11 at 15 56 10](https://github.com/WordPress/gutenberg/assets/240569/f4b86ab7-16a2-41ec-b164-401ced828e67)
