### PR TITLE
Preload request for fallback Navigation menu in Site Editor

### DIFF
--- a/lib/compat/wordpress-6.3/navigation-block-preloading.php
+++ b/lib/compat/wordpress-6.3/navigation-block-preloading.php
@@ -58,6 +58,17 @@ function gutenberg_preload_navigation_posts( $preload_paths, $context ) {
 		'GET',
 	);
 
+	// Preload the request for a fallback navigation menu.
+	$preload_paths[] = array(
+		add_query_arg(
+			array(
+				'_embed' => 1,
+			),
+			'wp-block-editor/v1/navigation-fallback'
+		),
+		'GET',
+	);
+
 	return $preload_paths;
 }
 add_filter( 'block_editor_rest_api_preload_paths', 'gutenberg_preload_navigation_posts', 10, 2 );

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -576,7 +576,10 @@ export const getNavigationFallbackId =
 	async ( { dispatch } ) => {
 		const fallback = await apiFetch( {
 			path: addQueryArgs( '/wp-block-editor/v1/navigation-fallback', {
-				_embed: true,
+				// _embed is intentionally set as `1` (as opposed to `true`)
+				// to ensure preloading of this request works correctly.
+				// see https://github.com/WordPress/gutenberg/pull/48683/#issuecomment-1543726404.
+				_embed: 1,
 			} ),
 		} );
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Extends https://github.com/WordPress/gutenberg/pull/48683 by also preloading the request for the fallback Navigation menu.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Calls to the fallback endpoint slow the rendering of the Nav block (or anything that uses the fallback endpoint). By preloading we avoid a network fetch on the client side.

This is more controversial than https://github.com/WordPress/gutenberg/pull/48683 because the fallbacks endpoint isn't always triggered. It's a great optimisation for the scenarios outlined below but otherwise is a waste of resources for a request that doesn't need to be made.

Not sure how we weigh that tradeoff.

The fallback request will be triggered when the block is "empty" (i.e. has no `ref` attribute). This means 

- any new site 
- when the user switches theme.
- when patterns are shown which use the Nav block
- when a new Navigation block is inserted

In the future this fallback request may also be [triggered by the `Navigation` section of the Browse Mode sidebar](https://github.com/WordPress/gutenberg/pull/50321).

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Preloads the matching request.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

#### On TRUNK
- Reset your Theme so you have any empty Navigation block in your Theme's header.
- Load the Site Editor
- See a request to the `navigation-fallback` endpoint.
- See the fallback resolved correctly.

#### On this PR
- Reset your Theme so you have any empty Navigation block in your Theme's header.
- Load the Site Editor
- See _**no**_ requests to the `navigation-fallback` endpoint.
- See the fallback resolved correctly.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
