### PR TITLE
Edit Site: Optimize loading `useSelect` call

### DIFF
--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -52,13 +52,15 @@ const interfaceLabels = {
 
 function useIsSiteEditorLoading() {
 	const { isLoaded: hasLoadedPost } = useEditedEntityRecord();
-	const { hasResolvingSelectors } = useSelect( ( select ) => {
-		return {
-			hasResolvingSelectors: select( coreStore ).hasResolvingSelectors(),
-		};
-	} );
 	const [ loaded, setLoaded ] = useState( false );
-	const inLoadingPause = ! loaded && ! hasResolvingSelectors;
+	const inLoadingPause = useSelect(
+		( select ) => {
+			const hasResolvingSelectors =
+				select( coreStore ).hasResolvingSelectors();
+			return ! loaded && ! hasResolvingSelectors;
+		},
+		[ loaded ]
+	);
 
 	useEffect( () => {
 		if ( inLoadingPause ) {


### PR DESCRIPTION
## What?
This PR is a follow-up to https://github.com/WordPress/gutenberg/pull/50511#discussion_r1190048420 which optimizes the `useSelect` call of the site editor loading experience.

## Why?
Reduces the number of re-renders, as explained in the comment.

## How?
We're only calling's `useSelect` when `loaded` is `false`, once the site editor is marked as loaded, `useSelect` will no longer trigger rerenders.

## Testing Instructions
Same as testing instructions of #50222.

### Testing Instructions for Keyboard
None

## Screenshots or screencast <!-- if applicable -->
None
