### PR TITLE
Enable  iframe-inline-styles e2e test

### DIFF
--- a/packages/e2e-tests/specs/editor/plugins/iframed-inline-styles.test.js
+++ b/packages/e2e-tests/specs/editor/plugins/iframed-inline-styles.test.js
@@ -32,7 +32,7 @@ describe( 'iframed inline styles', () => {
 	} );
 
 	// Skip flaky test. See https://github.com/WordPress/gutenberg/issues/35172
-	it.skip( 'should load inline styles in iframe', async () => {
+	it( 'should load inline styles in iframe', async () => {
 		await insertBlock( 'Iframed Inline Styles' );
 
 		expect( await getEditedPostContent() ).toMatchSnapshot();


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This was disabled in https://github.com/WordPress/gutenberg/pull/50320. Re-enabling it to see if it passes this time.

