### PR TITLE
[RNMobile] Fix embed webview endcoding

### DIFF
--- a/packages/react-native-bridge/android/react-native-bridge/src/main/java/org/wordpress/mobile/ReactNativeGutenbergBridge/GutenbergEmbedWebViewActivity.java
+++ b/packages/react-native-bridge/android/react-native-bridge/src/main/java/org/wordpress/mobile/ReactNativeGutenbergBridge/GutenbergEmbedWebViewActivity.java
@@ -4,12 +4,8 @@ import android.annotation.SuppressLint;
 import android.graphics.Bitmap;
 import android.os.Bundle;
 import android.os.Handler;
-import android.util.Log;
-import android.view.Menu;
-import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
-import android.webkit.CookieManager;
 import android.webkit.WebChromeClient;
 import android.webkit.WebSettings;
 import android.webkit.WebView;
@@ -22,8 +18,6 @@ import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.Toolbar;
 
 import java.util.concurrent.atomic.AtomicBoolean;
-
-import static java.lang.String.format;
 
 public class GutenbergEmbedWebViewActivity extends AppCompatActivity {
     public static final String ARG_CONTENT = "content";
@@ -129,7 +123,7 @@ public class GutenbergEmbedWebViewActivity extends AppCompatActivity {
             public void onPageStarted(WebView view, String url, Bitmap favicon) {
                 // Center the embed with a black background;
                 String css = "body{margin:0;background:#000;display:flex;align-items:center;}";
-                String js = format("(()=>{const c='%s';const s=document.createElement('style');s.textContent=c;document.head.append(s);})()", css);
+                String js = String.format("(()=>{const c='%s';const s=document.createElement('style');s.textContent=c;document.head.append(s);})()", css);
                 view.evaluateJavascript(js, null);
                 super.onPageStarted(view, url, favicon);
             }

--- a/packages/react-native-bridge/android/react-native-bridge/src/main/java/org/wordpress/mobile/ReactNativeGutenbergBridge/GutenbergEmbedWebViewActivity.java
+++ b/packages/react-native-bridge/android/react-native-bridge/src/main/java/org/wordpress/mobile/ReactNativeGutenbergBridge/GutenbergEmbedWebViewActivity.java
@@ -4,6 +4,7 @@ import android.annotation.SuppressLint;
 import android.graphics.Bitmap;
 import android.os.Bundle;
 import android.os.Handler;
+import android.util.Log;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
@@ -21,6 +22,8 @@ import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.Toolbar;
 
 import java.util.concurrent.atomic.AtomicBoolean;
+
+import static java.lang.String.format;
 
 public class GutenbergEmbedWebViewActivity extends AppCompatActivity {
     public static final String ARG_CONTENT = "content";
@@ -80,7 +83,7 @@ public class GutenbergEmbedWebViewActivity extends AppCompatActivity {
 
     protected void load() {
         String content = getIntent().getExtras().getString(ARG_CONTENT);
-        mWebView.loadData(content, "text/html", "UTF-8");
+        mWebView.loadDataWithBaseURL(null, content, "text/html", "UTF-8", null);
     }
 
     private void setupToolbar() {
@@ -126,7 +129,7 @@ public class GutenbergEmbedWebViewActivity extends AppCompatActivity {
             public void onPageStarted(WebView view, String url, Bitmap favicon) {
                 // Center the embed with a black background;
                 String css = "body{margin:0;background:#000;display:flex;align-items:center;}";
-                String js = String.format("(()=>{const c='%s';const s=document.createElement('style');s.textContent=c;document.head.append(s);})()", css);
+                String js = format("(()=>{const c='%s';const s=document.createElement('style');s.textContent=c;document.head.append(s);})()", css);
                 view.evaluateJavascript(js, null);
                 super.onPageStarted(view, url, favicon);
             }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Fixes issues with encoded characters with the native Android WebView 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Decoding encoded characters can lead to unexpected behavior

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Switching from `WebView.loadData` to `WebView.loadDataWithBaseUrl` fixes the encoding

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
The core embed is not currently being used on any core embed blocks so to test:
- Verify that the Android package builds
- That the code changes look ok 

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
