### PR TITLE
[Fonts API] Print registered fonts for only the Site Editor

### DIFF
--- a/lib/experimental/fonts-api/fonts-api.php
+++ b/lib/experimental/fonts-api/fonts-api.php
@@ -202,9 +202,14 @@ if ( ! function_exists( 'wp_print_fonts' ) ) {
 		$in_iframed_editor = true === $handles;
 		$in_site_editor    = $in_iframed_editor && 'site-editor.php' === $pagenow;
 
-		if ( $in_iframed_editor ) {
+		// Automatically enqueue all user-selected fonts.
+		if ( empty( $handles ) || $in_iframed_editor ) {
+			WP_Fonts_Resolver::enqueue_user_selected_fonts();
 			$handles = false;
+		}
 
+		// Set up for the iframed editor.
+		if ( $in_iframed_editor ) {
 			// When in an iframed editor, reset "done".
 			$done           = $wp_fonts->done;
 			$wp_fonts->done = array();
@@ -214,12 +219,6 @@ if ( ! function_exists( 'wp_print_fonts' ) ) {
 				$queue           = $wp_fonts->queue;
 				$wp_fonts->queue = $registered;
 			}
-		}
-
-		// Automatically enqueue all user-selected fonts.
-		if ( empty( $handles ) || ( $in_iframed_editor && ! $in_site_editor ) ) {
-			WP_Fonts_Resolver::enqueue_user_selected_fonts();
-			$handles = false;
 		}
 
 		_wp_scripts_maybe_doing_it_wrong( __FUNCTION__ );


### PR DESCRIPTION
Fixes #49645

Requires PR https://github.com/WordPress/gutenberg/pull/50529, which has been merged ✅ 

Related PR https://github.com/WordPress/gutenberg/pull/50558, which was reverted by PR https://github.com/WordPress/gutenberg/pull/49863.

## STATUS BLOCKED

This PR is currently blocked for merging by https://github.com/WordPress/gutenberg/issues/40362. [See my explanation here](https://github.com/WordPress/gutenberg/pull/50558#issuecomment-1561734474). Once the issue is resolved, then this PR can be merged.

## What?

Fixes which fonts get their `@font-face` styles generated the specific iframe:

* Site Editor: uses all registered fonts.
* Block Editor: uses all enqueued fonts.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Outside of the Site Editor, only the enqueued fonts are to be used. Why? To avoid a potential performance impact when a site has one or more plugins or scripts that are registering fonts with the Fonts API.

In the Site Editor, all registered are to be used. Why? To allow users to preview typography choices before selecting and updating the global styles.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Uses `$pagenow` to identify if the web page is the Site Editor. If yes, then modifies the `queue` to use the registered fonts and restores the `queue` after the `@font-face` styles are generated.

## TODO
- [X] Add conditional to know if the iframed editor request (i.e. when `$handles` is `true`) is coming from the Site Editor.
- [x] Rebase after PR https://github.com/WordPress/gutenberg/pull/50529 merged (for the updated print tests).
- [x] Update tests.
- [x] Add tests for non-Site Editor iframed requests.

## Testing Instructions
### Set up
1. On your test site, activate the TT3 theme and Gutenberg plugin.
2. Install and activate [this test plugin](https://github.com/ironprogrammer/webfonts-jetpack-test).

### Scenario 1: No Google Fonts selected (no user fonts selected)
For this scenario, use the default setup and do not select any typography options in the Site Editor > Styles > Typography UI.

1. Open a post by going to Posts > and selecting or adding a post.
2. In your browser, open Dev Tools to the `Inspector` tab.
3. Search for `wp-fonts-jetpack-google-fonts`. 
    The expected behavior: 
    * `<style id="wp-fonts-jetpack-google-fonts">` **should _not_** exist.
    * `<style id="wp-fonts-local">` should exist (these are the theme's defined fonts).
4. Then go to the Site Editor, i.e. Appearance > Editor.
5. Search for `wp-fonts-jetpack-google-fonts`. 
    The expected behavior: 
    * `<style id="wp-fonts-jetpack-google-fonts">` **_should_** exist.
    * `<style id="wp-fonts-local">` should exist (these are the theme's defined fonts).

### Scenario 2: A Google Font is selected.

Follow the same instructions above to set up the test environment.

Then do the following:
1. Go to the Site Editor.
2. Change the typography for all Headings by:
   * Open the Styles > Typography > Headings UI.
   * For Font, select Playfair Display.
   * For Appearance, select Bold Italic.
3. Select the "Save" button twice, which saves your user selections.
4. Go to an existing post (or create a new one).
5. In your browser's dev tools in the Inspector (HTML) tab, search for `wp-fonts-jetpack-google-fonts`.

## Screenshots, screen recording, code snippet
![pr50558-before](https://github.com/WordPress/gutenberg/assets/7284611/d99304b7-eba7-4ff6-8ca7-5f46c143f0c2)

[Test Report 1 shows Scenario 1](https://github.com/WordPress/gutenberg/pull/50558#issuecomment-1559771886) works as expected ✅ 
![pr50558-after](https://github.com/WordPress/gutenberg/assets/7284611/2a856624-6947-4747-8b61-7bb0db4f2c37)

[Test Report 2 shows Scenario 2](https://github.com/WordPress/gutenberg/pull/50558#issuecomment-1559818173) works as expected ✅ 

<img width="1124" alt="Screen Shot 2023-05-23 at 11 29 02 AM" src="https://github.com/WordPress/gutenberg/assets/7284611/79787657-11ee-4f29-9303-3d58d6d2024d">
