### PR TITLE
[RNMobile] Add disabled prop to SwitchCell component

### DIFF
--- a/packages/components/src/mobile/bottom-sheet/switch-cell.native.js
+++ b/packages/components/src/mobile/bottom-sheet/switch-cell.native.js
@@ -13,7 +13,7 @@ import { __, _x, sprintf } from '@wordpress/i18n';
 import Cell from './cell';
 
 export default function BottomSheetSwitchCell( props ) {
-	const { value, onValueChange, ...cellProps } = props;
+	const { value, onValueChange, disabled, ...cellProps } = props;
 
 	const onPress = () => {
 		onValueChange( ! value );
@@ -60,8 +60,13 @@ export default function BottomSheetSwitchCell( props ) {
 			onPress={ onPress }
 			editable={ false }
 			value={ '' }
+			disabled={ disabled }
 		>
-			<Switch value={ value } onValueChange={ onValueChange } />
+			<Switch
+				value={ value }
+				onValueChange={ onValueChange }
+				disabled={ disabled }
+			/>
 		</Cell>
 	);
 }


### PR DESCRIPTION
## What?

This PR introduces a new disabled prop to the `SwitchCell` component.

## Why?

There are scenarios where we may need to prevent user interaction with the `SwitchCell` component. Introducing the disabled prop allows for this.

## How?

The disabled prop has been passed down to both the `Cell` and `Switch` components:

* The `Cell` component [uses the disabled prop](https://github.com/WordPress/gutenberg/blob/f4da24145ec853cbb94f8f5800f37c13f725bd0e/packages/components/src/mobile/bottom-sheet/cell.native.js#L342) to prevent user interaction.
* The `Switch` component [uses the disabled prop](https://reactnative.dev/docs/switch#disabled) to prevent toggling, and also to change the default appearance of the switch.  

This change is backwards-compatible, as the disabled prop is optional and won't affect existing usage of `SwitchCell`.

## Testing Instructions

[The `ToggleControl` component](https://github.com/WordPress/gutenberg/tree/f4da24145ec853cbb94f8f5800f37c13f725bd0e/packages/components/src/toggle-control) makes use of `SwitchCell`, so we can update a usage of it to test the new prop. 

* Apply the following patch to add the prop to a toggle in the search block:

```patch
diff --git a/packages/block-library/src/search/edit.native.js b/packages/block-library/src/search/edit.native.js
index c5f5fb4cf2..7dfa33d0ff 100644
--- a/packages/block-library/src/search/edit.native.js
+++ b/packages/block-library/src/search/edit.native.js
@@ -182,6 +182,7 @@ export default function SearchEdit( {
 							showLabel: ! showLabel,
 						} );
 					} }
+					disabled={ true }
 				/>
 				<SelectControl
 					label={ __( 'Button position' ) }
```

* Add the search block and open its settings up.
* Verify that the "Hide search heading" setting is now disabled. It shouldn't be possible to interact with it and its appearance should differ to enabled toggles.

## Screenshots or screencast 

| Before  | After |
| ------------- | ------------- |
| <img src="https://github.com/WordPress/gutenberg/assets/2998162/63aaa365-4720-4693-9706-512824c107ee" width="100%"> | <img src="https://github.com/WordPress/gutenberg/assets/2998162/4910e7b4-ccd6-407d-92b4-99319cae065b" width="100%"> |