### PR TITLE
update site editor sidebar alignment

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-screen/style.scss
@@ -6,7 +6,7 @@
 }
 
 .edit-site-sidebar-navigation-screen__content {
-	margin: 0 $grid-unit-20 $grid-unit-20 $button-size;
+	margin: 0 0 $grid-unit-20 0;
 	color: $gray-600;
 	//z-index: z-index(".edit-site-sidebar-navigation-screen__content");
 }
@@ -34,7 +34,6 @@
 	box-shadow: 0 $grid-unit-10 $grid-unit-20 $gray-900;
 	margin-bottom: $grid-unit-10;
 	padding-bottom: $grid-unit-10;
-	padding-right: $grid-unit-20;
 	z-index: z-index(".edit-site-sidebar-navigation-screen__title-icon");
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Updates the site editor sidebar padding/margin to be closer to newer designs. e.g. https://github.com/WordPress/gutenberg/issues/50390 or https://github.com/WordPress/gutenberg/issues/44461

https://github.com/WordPress/gutenberg/assets/1072756/a3ec0cd6-8635-401e-a448-5959f87bb14a
