### PR TITLE
Site editor: update custom post types with _edit_link

### DIFF
--- a/lib/compat/wordpress-6.3/link-template.php
+++ b/lib/compat/wordpress-6.3/link-template.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Overrides Core's wp-includes/link-template.php for WP 6.3.
+ *
+ * @package gutenberg
+ */
+
+/**
+ * Updates the post edit link using the `_edit_link` property in wp_global_styles`, `wp_template`,
+ * and `wp_template_part` custom post types.
+ *
+ * `_edit_link` for these custom post types is added by `gutenberg_update_templates_template_parts_rest_controller()`
+ * in lib/compat/wordpress-6.3/rest-api.php.
+ *
+ * This functionality has already been ported to Core. See https://github.com/WordPress/gutenberg/issues/48065
+ * The following hook is a modified version that passes only 2 arguments to `sprintf()` to be compatible with WP <= 6.2.
+ *
+ * @param string $link    The edit link.
+ * @param int    $post_id Post ID.
+ * @return string|null The edit post link for the given post. Null if the post type does not exist
+ *                     or does not allow an editing UI.
+ */
+function gutenberg_update_get_edit_post_link( $link, $post_id ) {
+	$post = get_post( $post_id );
+
+	if ( 'wp_template' === $post->post_type || 'wp_template_part' === $post->post_type ) {
+		$post_type_object = get_post_type_object( $post->post_type );
+		$slug             = urlencode( get_stylesheet() . '//' . $post->post_name );
+		$link             = admin_url( sprintf( $post_type_object->_edit_link, $slug ) );
+	}
+	return $link;
+}
+
+add_filter( 'get_edit_post_link', 'gutenberg_update_get_edit_post_link', 10, 2 );

--- a/lib/compat/wordpress-6.3/rest-api.php
+++ b/lib/compat/wordpress-6.3/rest-api.php
@@ -15,20 +15,34 @@ function gutenberg_register_rest_pattern_directory() {
 add_action( 'rest_api_init', 'gutenberg_register_rest_pattern_directory' );
 
 /**
- * Update `wp_template` and `wp_template-part` post types to use
- * Gutenberg's REST controller.
+ * Updates `wp_template` and `wp_template_part` post types to use
+ * Gutenberg's REST controllers
+ *
+ * Adds `_edit_link` to the `wp_global_styles`, `wp_template`,
+ * and `wp_template_part` post type schemata. See https://github.com/WordPress/gutenberg/issues/48065
  *
  * @param array  $args Array of arguments for registering a post type.
  * @param string $post_type Post type key.
  */
 function gutenberg_update_templates_template_parts_rest_controller( $args, $post_type ) {
 	if ( in_array( $post_type, array( 'wp_template', 'wp_template_part' ), true ) ) {
+		$template_edit_link            = 'site-editor.php?' . build_query(
+			array(
+				'postType' => $post_type,
+				'postId'   => '%s',
+				'canvas'   => 'edit',
+			)
+		);
+		$args['_edit_link']            = $template_edit_link;
 		$args['rest_controller_class'] = 'Gutenberg_REST_Templates_Controller_6_3';
+	}
+
+	if ( in_array( $post_type, array( 'wp_global_styles' ), true ) ) {
+		$args['_edit_link'] = '/site-editor.php?canvas=edit';
 	}
 	return $args;
 }
 add_filter( 'register_post_type_args', 'gutenberg_update_templates_template_parts_rest_controller', 10, 2 );
-
 
 /**
  * Registers the Global Styles Revisions REST API routes.

--- a/lib/load.php
+++ b/lib/load.php
@@ -50,6 +50,7 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 	require_once __DIR__ . '/compat/wordpress-6.3/rest-api.php';
 	require_once __DIR__ . '/compat/wordpress-6.3/theme-previews.php';
 	require_once __DIR__ . '/compat/wordpress-6.3/navigation-block-preloading.php';
+	require_once __DIR__ . '/compat/wordpress-6.3/link-template.php';
 
 	// Experimental.
 	if ( ! class_exists( 'WP_Rest_Customizer_Nonces' ) ) {


### PR DESCRIPTION
## What?

Resolves: #48065

Hello!

This PR backports the following functionality from Core:

- adds an `_edit_link` property to `wp_global_styles`, `wp_template`, and `wp_template-part` custom post type schemata via filter
- uses the `_edit_link` value to create an edit link via the `get_edit_post_link` hook

## Why?
A revisions link was added to view revisions for [templates and template parts](https://github.com/WordPress/gutenberg/pull/45215). 

<img width="273" alt="Screenshot 2023-05-12 at 12 59 36 pm" src="https://github.com/WordPress/gutenberg/assets/6458278/abc811c3-85e5-4c51-b100-cbb97e296576">

This link takes the user to the WordPress `revision.php` screen. Here there are two links that should link back to the editor.

<img width="512" alt="Screenshot 2023-05-12 at 12 55 48 pm" src="https://github.com/WordPress/gutenberg/assets/6458278/89260fd7-994b-47ed-a373-dc544d212ac8">

But since the custom post types schemata did not contain an `_edit_link` property, the links were broken.

`wp_global_styles` was covered for the sake of completion.

This was recently fixed in Core and already has test coverage:

- https://github.com/WordPress/gutenberg/issues/48065
- https://core.trac.wordpress.org/ticket/57709

But 6.3 won't be out until later in the year. August?

## How?
`register_post_type_args` and `get_edit_post_link filters`

## Testing Instructions
1. Spin up this branch and head over to the site editor.
2. Make a few (more than 1) changes to a template and also to a template part
3. In the right-hand-side inspector, select the "Template" menu item and click on the "Revisions" button
4. You should be taken to `revision.php`. Now make sure that the two links, e.g., **Compare Revisions of “header”** and **← Go to editor** take you back to the site editor with the right template in edit mode.
