### PR TITLE
List view: update to remember lastest state rather than needing a preference

### DIFF
--- a/packages/edit-post/src/components/header/header-toolbar/index.js
+++ b/packages/edit-post/src/components/header/header-toolbar/index.js
@@ -32,7 +32,7 @@ const preventDefault = ( event ) => {
 
 function HeaderToolbar() {
 	const inserterButton = useRef();
-	const { setIsInserterOpened, setIsListViewOpened } =
+	const { setIsInserterOpened, setIsListViewOpened, toggleFeature } =
 		useDispatch( editPostStore );
 	const {
 		isInserterEnabled,
@@ -85,10 +85,10 @@ function HeaderToolbar() {
 	/* translators: accessibility text for the editor toolbar */
 	const toolbarAriaLabel = __( 'Document tools' );
 
-	const toggleListView = useCallback(
-		() => setIsListViewOpened( ! isListViewOpen ),
-		[ setIsListViewOpened, isListViewOpen ]
-	);
+	const toggleListView = useCallback( () => {
+		toggleFeature( 'showListViewByDefault' );
+		setIsListViewOpened( ! isListViewOpen );
+	}, [ toggleFeature, setIsListViewOpened, isListViewOpen ] );
 	const overflowItems = (
 		<>
 			<ToolbarItem

--- a/packages/edit-post/src/components/preferences-modal/index.js
+++ b/packages/edit-post/src/components/preferences-modal/index.js
@@ -128,13 +128,6 @@ export default function EditPostPreferencesModal() {
 								) }
 							/>
 							<EnableFeature
-								featureName="showListViewByDefault"
-								help={ __(
-									'Opens the block list view sidebar by default.'
-								) }
-								label={ __( 'Always open list view' ) }
-							/>
-							<EnableFeature
 								featureName="themeStyles"
 								help={ __(
 									'Make the editor look like your theme.'

--- a/packages/edit-site/src/components/header-edit-mode/index.js
+++ b/packages/edit-site/src/components/header-edit-mode/index.js
@@ -106,6 +106,7 @@ export default function HeaderEditMode() {
 		setIsListViewOpened,
 	} = useDispatch( editSiteStore );
 	const { __unstableSetEditorMode } = useDispatch( blockEditorStore );
+	const { toggle } = useDispatch( preferencesStore );
 
 	const isLargeViewport = useViewportMatch( 'medium' );
 
@@ -121,10 +122,10 @@ export default function HeaderEditMode() {
 		}
 	}, [ isInserterOpen, setIsInserterOpened ] );
 
-	const toggleListView = useCallback(
-		() => setIsListViewOpened( ! isListViewOpen ),
-		[ setIsListViewOpened, isListViewOpen ]
-	);
+	const toggleListView = useCallback( () => {
+		toggle( 'core/edit-site', 'showListViewByDefault' );
+		setIsListViewOpened( ! isListViewOpen );
+	}, [ toggle, setIsListViewOpened, isListViewOpen ] );
 
 	const { useShouldContextualToolbarShow } = unlock( blockEditorPrivateApis );
 	const {

--- a/packages/edit-site/src/components/preferences-modal/index.js
+++ b/packages/edit-site/src/components/preferences-modal/index.js
@@ -42,13 +42,6 @@ export default function EditSitePreferencesModal( {
 						help={ __( 'Show text instead of icons on buttons.' ) }
 					/>
 					<EnableFeature
-						featureName="showListViewByDefault"
-						help={ __(
-							'Opens the block list view sidebar by default.'
-						) }
-						label={ __( 'Always open list view' ) }
-					/>
-					<EnableFeature
 						featureName="showBlockBreadcrumbs"
 						help={ __(
 							'Shows block breadcrumbs at the bottom of the editor.'


### PR DESCRIPTION
## What?
Removes the List view toggle preference and instead remembers the last open state of the panel

## Why?
Fixes: #50017

## How?
Dispatches `toggleFeature( 'showListViewByDefault' )` when panel opened or closed

## Testing Instructions

- Toggle the list view off and on a few times and reload between each and make sure the editor remembers the last open state when loading

## Screenshots or screencast <!-- if applicable -->

Before:

https://github.com/WordPress/gutenberg/assets/3629020/6825f20d-0251-4d92-9635-abc9ca2fed53

After:

https://github.com/WordPress/gutenberg/assets/3629020/fef37c7d-94f6-4f4a-af66-9b3cc8705cc0
