### PR TITLE
Styles Navigation Screen: Add Style Book

### DIFF
--- a/packages/edit-site/src/components/editor-canvas-container/style.scss
+++ b/packages/edit-site/src/components/editor-canvas-container/style.scss
@@ -1,4 +1,5 @@
 .edit-site-editor-canvas-container {
+	background: $white; // Fallback color, overridden by JavaScript.
 	border-radius: $radius-block-ui;
 	bottom: 0;
 	left: 0;

--- a/packages/edit-site/src/components/editor-canvas-container/style.scss
+++ b/packages/edit-site/src/components/editor-canvas-container/style.scss
@@ -1,5 +1,4 @@
 .edit-site-editor-canvas-container {
-	background: $white; // Fallback color, overridden by JavaScript.
 	border-radius: $radius-block-ui;
 	bottom: 0;
 	left: 0;

--- a/packages/edit-site/src/components/sidebar-navigation-screen-global-styles/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-global-styles/index.js
@@ -1,8 +1,9 @@
 /**
  * WordPress dependencies
  */
+import { useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { edit } from '@wordpress/icons';
+import { edit, seen } from '@wordpress/icons';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 import { __experimentalNavigatorButton as NavigatorButton } from '@wordpress/components';
@@ -51,7 +52,20 @@ export function SidebarNavigationItemGlobalStyles( props ) {
 
 export default function SidebarNavigationScreenGlobalStyles() {
 	const { openGeneralSidebar } = useDispatch( editSiteStore );
-	const { setCanvasMode } = unlock( useDispatch( editSiteStore ) );
+	const { setCanvasMode, setEditorCanvasContainerView } = unlock(
+		useDispatch( editSiteStore )
+	);
+	const [ isStyleBookOpened, setIsStyleBookOpened ] = useState( false );
+
+	// When the style book is opened, switch to the style book view.
+	// This is done in a useEffect to ensure that the canvas mode is changed,
+	// and the global styles sidebar is opened before attempting to open the style book.
+	useEffect( () => {
+		if ( isStyleBookOpened ) {
+			setEditorCanvasContainerView( 'style-book' );
+		}
+	}, [ setEditorCanvasContainerView, isStyleBookOpened ] );
+
 	return (
 		<SidebarNavigationScreen
 			title={ __( 'Styles' ) }
@@ -60,16 +74,32 @@ export default function SidebarNavigationScreenGlobalStyles() {
 			) }
 			content={ <StyleVariationsContainer /> }
 			actions={
-				<SidebarButton
-					icon={ edit }
-					label={ __( 'Edit styles' ) }
-					onClick={ () => {
-						// switch to edit mode.
-						setCanvasMode( 'edit' );
-						// open global styles sidebar.
-						openGeneralSidebar( 'edit-site/global-styles' );
-					} }
-				/>
+				<div>
+					<SidebarButton
+						icon={ seen }
+						label={ __( 'Style Book' ) }
+						onClick={ () => {
+							// Switch to edit mode.
+							setCanvasMode( 'edit' );
+							// Open global styles sidebar.
+							openGeneralSidebar( 'edit-site/global-styles' );
+							// Open style book, via the useEffect above.
+							// This is done via a local state change to ensure that the canvas mode is changed,
+							// and the global styles sidebar is opened before attempting to open the style book.
+							setIsStyleBookOpened( true );
+						} }
+					/>
+					<SidebarButton
+						icon={ edit }
+						label={ __( 'Edit styles' ) }
+						onClick={ () => {
+							// Switch to edit mode.
+							setCanvasMode( 'edit' );
+							// Open global styles sidebar.
+							openGeneralSidebar( 'edit-site/global-styles' );
+						} }
+					/>
+				</div>
 			}
 		/>
 	);

--- a/packages/edit-site/src/components/sidebar-navigation-screen-global-styles/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-global-styles/index.js
@@ -16,6 +16,7 @@ import { unlock } from '../../private-apis';
 import { store as editSiteStore } from '../../store';
 import SidebarButton from '../sidebar-button';
 import SidebarNavigationItem from '../sidebar-navigation-item';
+import StyleBook from '../style-book';
 
 export function SidebarNavigationItemGlobalStyles( props ) {
 	const { openGeneralSidebar } = useDispatch( editSiteStore );
@@ -49,11 +50,31 @@ export function SidebarNavigationItemGlobalStyles( props ) {
 	);
 }
 
+function GlobalStylesStyleBook( { onSelect } ) {
+	return (
+		<StyleBook
+			isSelected={ () => false }
+			onSelect={ async ( blockName ) => {
+				await onSelect( blockName );
+			} }
+		/>
+	);
+}
+
 export default function SidebarNavigationScreenGlobalStyles() {
 	const { openGeneralSidebar } = useDispatch( editSiteStore );
 	const { setCanvasMode, setEditorCanvasContainerView } = unlock(
 		useDispatch( editSiteStore )
 	);
+
+	const { isStyleBookOpened } = useSelect( ( select ) => {
+		const { getEditorCanvasContainerView } = unlock(
+			select( editSiteStore )
+		);
+		return {
+			isStyleBookOpened: 'style-book' === getEditorCanvasContainerView(),
+		};
+	}, [] );
 
 	const openGlobalStyles = async () =>
 		Promise.all( [
@@ -62,32 +83,48 @@ export default function SidebarNavigationScreenGlobalStyles() {
 		] );
 
 	return (
-		<SidebarNavigationScreen
-			title={ __( 'Styles' ) }
-			description={ __(
-				'Choose a different style combination for the theme styles.'
+		<>
+			<SidebarNavigationScreen
+				title={ __( 'Styles' ) }
+				description={ __(
+					'Choose a different style combination for the theme styles.'
+				) }
+				content={ <StyleVariationsContainer /> }
+				actions={
+					<div>
+						<SidebarButton
+							icon={ seen }
+							label={ __( 'Style Book' ) }
+							onClick={ async () => {
+								if ( ! isStyleBookOpened ) {
+									setEditorCanvasContainerView(
+										'style-book'
+									);
+								} else {
+									setEditorCanvasContainerView( undefined );
+								}
+							} }
+							isPressed={ isStyleBookOpened }
+						/>
+						<SidebarButton
+							icon={ edit }
+							label={ __( 'Edit styles' ) }
+							onClick={ async () => await openGlobalStyles() }
+						/>
+					</div>
+				}
+			/>
+			{ isStyleBookOpened && (
+				<GlobalStylesStyleBook
+					onSelect={ async () => {
+						await openGlobalStyles();
+						// Open the Style Book once the canvas mode is set to edit,
+						// and the global styles sidebar is open. This ensures that
+						// the Style Book is not prematurely closed.
+						setEditorCanvasContainerView( 'style-book' );
+					} }
+				/>
 			) }
-			content={ <StyleVariationsContainer /> }
-			actions={
-				<div>
-					<SidebarButton
-						icon={ seen }
-						label={ __( 'Style Book' ) }
-						onClick={ async () => {
-							await openGlobalStyles();
-							// Open the Style Book once the canvas mode is set to edit,
-							// and the global styles sidebar is open. This ensures that
-							// the Style Book is not prematurely closed.
-							setEditorCanvasContainerView( 'style-book' );
-						} }
-					/>
-					<SidebarButton
-						icon={ edit }
-						label={ __( 'Edit styles' ) }
-						onClick={ async () => await openGlobalStyles() }
-					/>
-				</div>
-			}
-		/>
+		</>
 	);
 }

--- a/packages/edit-site/src/components/sidebar-navigation-screen-global-styles/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-global-styles/index.js
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { edit, seen } from '@wordpress/icons';
 import { useSelect, useDispatch } from '@wordpress/data';
@@ -55,16 +54,12 @@ export default function SidebarNavigationScreenGlobalStyles() {
 	const { setCanvasMode, setEditorCanvasContainerView } = unlock(
 		useDispatch( editSiteStore )
 	);
-	const [ isStyleBookOpened, setIsStyleBookOpened ] = useState( false );
 
-	// When the style book is opened, switch to the style book view.
-	// This is done in a useEffect to ensure that the canvas mode is changed,
-	// and the global styles sidebar is opened before attempting to open the style book.
-	useEffect( () => {
-		if ( isStyleBookOpened ) {
-			setEditorCanvasContainerView( 'style-book' );
-		}
-	}, [ setEditorCanvasContainerView, isStyleBookOpened ] );
+	const openGlobalStyles = async () =>
+		Promise.all( [
+			setCanvasMode( 'edit' ),
+			openGeneralSidebar( 'edit-site/global-styles' ),
+		] );
 
 	return (
 		<SidebarNavigationScreen
@@ -78,26 +73,18 @@ export default function SidebarNavigationScreenGlobalStyles() {
 					<SidebarButton
 						icon={ seen }
 						label={ __( 'Style Book' ) }
-						onClick={ () => {
-							// Switch to edit mode.
-							setCanvasMode( 'edit' );
-							// Open global styles sidebar.
-							openGeneralSidebar( 'edit-site/global-styles' );
-							// Open style book, via the useEffect above.
-							// This is done via a local state change to ensure that the canvas mode is changed,
-							// and the global styles sidebar is opened before attempting to open the style book.
-							setIsStyleBookOpened( true );
+						onClick={ async () => {
+							await openGlobalStyles();
+							// Open the Style Book once the canvas mode is set to edit,
+							// and the global styles sidebar is open. This ensures that
+							// the Style Book is not prematurely closed.
+							setEditorCanvasContainerView( 'style-book' );
 						} }
 					/>
 					<SidebarButton
 						icon={ edit }
 						label={ __( 'Edit styles' ) }
-						onClick={ () => {
-							// Switch to edit mode.
-							setCanvasMode( 'edit' );
-							// Open global styles sidebar.
-							openGeneralSidebar( 'edit-site/global-styles' );
-						} }
+						onClick={ async () => await openGlobalStyles() }
 					/>
 				</div>
 			}

--- a/packages/edit-site/src/components/sidebar-navigation-screen-global-styles/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-global-styles/index.js
@@ -58,14 +58,12 @@ export default function SidebarNavigationScreenGlobalStyles() {
 		useDispatch( editSiteStore )
 	);
 
-	const { isStyleBookOpened } = useSelect( ( select ) => {
-		const { getEditorCanvasContainerView } = unlock(
-			select( editSiteStore )
-		);
-		return {
-			isStyleBookOpened: 'style-book' === getEditorCanvasContainerView(),
-		};
-	}, [] );
+	const isStyleBookOpened = useSelect(
+		( select ) =>
+			'style-book' ===
+			unlock( select( editSiteStore ) ).getEditorCanvasContainerView(),
+		[]
+	);
 
 	const openGlobalStyles = async () =>
 		Promise.all( [
@@ -95,17 +93,13 @@ export default function SidebarNavigationScreenGlobalStyles() {
 							<SidebarButton
 								icon={ seen }
 								label={ __( 'Style Book' ) }
-								onClick={ async () => {
-									if ( ! isStyleBookOpened ) {
-										setEditorCanvasContainerView(
-											'style-book'
-										);
-									} else {
-										setEditorCanvasContainerView(
-											undefined
-										);
-									}
-								} }
+								onClick={ () =>
+									setEditorCanvasContainerView(
+										! isStyleBookOpened
+											? 'style-book'
+											: undefined
+									)
+								}
 								isPressed={ isStyleBookOpened }
 							/>
 						) }

--- a/packages/edit-site/src/components/sidebar-navigation-screen-global-styles/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-global-styles/index.js
@@ -51,20 +51,6 @@ export function SidebarNavigationItemGlobalStyles( props ) {
 	);
 }
 
-function GlobalStylesStyleBook( { onClick, onSelect } ) {
-	return (
-		<StyleBook
-			isSelected={ () => false }
-			onClick={ onClick }
-			onSelect={ async ( blockName ) => {
-				await onSelect( blockName );
-			} }
-			showCloseButton={ false }
-			showTabs={ false }
-		/>
-	);
-}
-
 export default function SidebarNavigationScreenGlobalStyles() {
 	const { openGeneralSidebar } = useDispatch( editSiteStore );
 	const isMobileViewport = useViewportMatch( 'medium', '<' );
@@ -87,11 +73,7 @@ export default function SidebarNavigationScreenGlobalStyles() {
 			openGeneralSidebar( 'edit-site/global-styles' ),
 		] );
 
-	const openStyleBook = async ( event ) => {
-		if ( event.defaultPrevented ) {
-			return;
-		}
-		event.preventDefault();
+	const openStyleBook = async () => {
 		await openGlobalStyles();
 		// Open the Style Book once the canvas mode is set to edit,
 		// and the global styles sidebar is open. This ensures that
@@ -136,9 +118,13 @@ export default function SidebarNavigationScreenGlobalStyles() {
 				}
 			/>
 			{ isStyleBookOpened && ! isMobileViewport && (
-				<GlobalStylesStyleBook
+				<StyleBook
+					enableResizing={ false }
+					isSelected={ () => false }
 					onClick={ openStyleBook }
 					onSelect={ openStyleBook }
+					showCloseButton={ false }
+					showTabs={ false }
 				/>
 			) }
 		</>

--- a/packages/edit-site/src/components/sidebar-navigation-screen-main/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-main/index.js
@@ -7,8 +7,9 @@ import {
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { layout, symbol, navigation, styles, page } from '@wordpress/icons';
-import { useSelect } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
+import { useEffect } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -16,6 +17,8 @@ import { store as coreStore } from '@wordpress/core-data';
 import SidebarNavigationScreen from '../sidebar-navigation-screen';
 import SidebarNavigationItem from '../sidebar-navigation-item';
 import { SidebarNavigationItemGlobalStyles } from '../sidebar-navigation-screen-global-styles';
+import { unlock } from '../../private-apis';
+import { store as editSiteStore } from '../../store';
 
 export default function SidebarNavigationScreenMain() {
 	const hasNavigationMenus = useSelect( ( select ) => {
@@ -36,6 +39,22 @@ export default function SidebarNavigationScreenMain() {
 	const showNavigationScreen = process.env.IS_GUTENBERG_PLUGIN
 		? hasNavigationMenus
 		: false;
+
+	const editorCanvasContainerView = useSelect( ( select ) => {
+		return unlock( select( editSiteStore ) ).getEditorCanvasContainerView();
+	}, [] );
+
+	const { setEditorCanvasContainerView } = unlock(
+		useDispatch( editSiteStore )
+	);
+
+	// Clear the editor canvas container view when accessing the main navigation screen.
+	useEffect( () => {
+		if ( editorCanvasContainerView ) {
+			setEditorCanvasContainerView( undefined );
+		}
+	}, [ editorCanvasContainerView, setEditorCanvasContainerView ] );
+
 	return (
 		<SidebarNavigationScreen
 			isRoot

--- a/packages/edit-site/src/components/style-book/index.js
+++ b/packages/edit-site/src/components/style-book/index.js
@@ -13,6 +13,7 @@ import {
 	Disabled,
 	TabPanel,
 } from '@wordpress/components';
+
 import { __, sprintf } from '@wordpress/i18n';
 import {
 	getCategories,
@@ -29,7 +30,8 @@ import {
 } from '@wordpress/block-editor';
 import { useSelect } from '@wordpress/data';
 import { useResizeObserver } from '@wordpress/compose';
-import { useMemo, memo } from '@wordpress/element';
+import { useMemo, useState, memo } from '@wordpress/element';
+import { ENTER, SPACE } from '@wordpress/keycodes';
 
 /**
  * Internal dependencies
@@ -161,7 +163,13 @@ function getExamples() {
 	return [ headingsExample, ...otherExamples ];
 }
 
-function StyleBook( { isSelected, onSelect } ) {
+function StyleBook( {
+	isSelected,
+	onClick,
+	onSelect,
+	showCloseButton = true,
+	showTabs = true,
+} ) {
 	const [ resizeObserver, sizes ] = useResizeObserver();
 	const [ textColor ] = useGlobalStyle( 'color.text' );
 	const [ backgroundColor ] = useGlobalStyle( 'color.background' );
@@ -194,11 +202,14 @@ function StyleBook( { isSelected, onSelect } ) {
 	return (
 		<EditorCanvasContainer
 			enableResizing={ true }
-			closeButtonLabel={ __( 'Close Style Book' ) }
+			closeButtonLabel={
+				showCloseButton ? __( 'Close Style Book' ) : null
+			}
 		>
 			<div
 				className={ classnames( 'edit-site-style-book', {
 					'is-wide': sizes.width > 600,
+					'is-button': !! onClick,
 				} ) }
 				style={ {
 					color: textColor,
@@ -206,52 +217,117 @@ function StyleBook( { isSelected, onSelect } ) {
 				} }
 			>
 				{ resizeObserver }
-				<TabPanel
-					className="edit-site-style-book__tab-panel"
-					tabs={ tabs }
-				>
-					{ ( tab ) => (
-						<Iframe
-							className="edit-site-style-book__iframe"
-							name="style-book-canvas"
-							tabIndex={ 0 }
-						>
-							<EditorStyles styles={ settings.styles } />
-							<style>
-								{
-									// Forming a "block formatting context" to prevent margin collapsing.
-									// @see https://developer.mozilla.org/en-US/docs/Web/Guide/CSS/Block_formatting_context
-									`.is-root-container { display: flow-root; }
-											body { position: relative; padding: 32px !important; }` +
-										STYLE_BOOK_IFRAME_STYLES
-								}
-							</style>
-							<Examples
-								className={ classnames(
-									'edit-site-style-book__examples',
-									{
-										'is-wide': sizes.width > 600,
-									}
-								) }
-								examples={ examples }
+				{ showTabs ? (
+					<TabPanel
+						className="edit-site-style-book__tab-panel"
+						tabs={ tabs }
+					>
+						{ ( tab ) => (
+							<StyleBookBody
 								category={ tab.name }
-								label={ sprintf(
-									// translators: %s: Category of blocks, e.g. Text.
-									__(
-										'Examples of blocks in the %s category'
-									),
-									tab.title
-								) }
+								examples={ examples }
 								isSelected={ isSelected }
 								onSelect={ onSelect }
+								settings={ settings }
+								sizes={ sizes }
+								title={ tab.title }
 							/>
-						</Iframe>
-					) }
-				</TabPanel>
+						) }
+					</TabPanel>
+				) : (
+					<StyleBookBody
+						examples={ examples }
+						isSelected={ isSelected }
+						onClick={ onClick }
+						onSelect={ onSelect }
+						settings={ settings }
+						sizes={ sizes }
+					/>
+				) }
 			</div>
 		</EditorCanvasContainer>
 	);
 }
+
+const StyleBookBody = ( {
+	category,
+	examples,
+	isSelected,
+	onClick,
+	onSelect,
+	settings,
+	sizes,
+	title,
+} ) => {
+	const [ isFocused, setIsFocused ] = useState( false );
+
+	// The presence of an `onClick` prop indicates that the Style Book is being used
+	// as a button. In this case, we need to add additional props to the iframe to
+	// make it behave like a button.
+	const buttonModeProps = {
+		role: 'button',
+		onFocus: () => setIsFocused( true ),
+		onBlur: () => setIsFocused( false ),
+		onKeyDown: ( event ) => {
+			const { keyCode } = event;
+			if ( onClick && ( keyCode === ENTER || keyCode === SPACE ) ) {
+				onClick( event );
+			}
+		},
+		onClick: ( event ) => {
+			if ( onClick ) {
+				onClick( event );
+			}
+		},
+		readonly: true,
+	};
+
+	const buttonModeStyles = onClick
+		? 'body { cursor: pointer; } body * { pointer-events: none; }'
+		: '';
+
+	return (
+		<Iframe
+			className={ classnames( 'edit-site-style-book__iframe', {
+				'is-focused': isFocused && !! onClick,
+				'is-button': !! onClick,
+			} ) }
+			name="style-book-canvas"
+			tabIndex={ 0 }
+			{ ...( onClick ? buttonModeProps : {} ) }
+		>
+			<EditorStyles styles={ settings.styles } />
+			<style>
+				{
+					// Forming a "block formatting context" to prevent margin collapsing.
+					// @see https://developer.mozilla.org/en-US/docs/Web/Guide/CSS/Block_formatting_context
+					`.is-root-container { display: flow-root; }
+						body { position: relative; padding: 32px !important; }` +
+						STYLE_BOOK_IFRAME_STYLES +
+						buttonModeStyles
+				}
+			</style>
+			<Examples
+				className={ classnames( 'edit-site-style-book__examples', {
+					'is-wide': sizes.width > 600,
+				} ) }
+				examples={ examples }
+				category={ category }
+				label={
+					title
+						? sprintf(
+								// translators: %s: Category of blocks, e.g. Text.
+								__( 'Examples of blocks in the %s category' ),
+								title
+						  )
+						: __( 'Examples of blocks' )
+				}
+				isSelected={ isSelected }
+				onSelect={ onSelect }
+			/>
+		</Iframe>
+	);
+};
 
 const Examples = memo(
 	( { className, examples, category, label, isSelected, onSelect } ) => {
@@ -263,7 +339,9 @@ const Examples = memo(
 				aria-label={ label }
 			>
 				{ examples
-					.filter( ( example ) => example.category === category )
+					.filter( ( example ) =>
+						category ? example.category === category : true
+					)
 					.map( ( example ) => (
 						<Example
 							key={ example.name }
@@ -273,7 +351,7 @@ const Examples = memo(
 							blocks={ example.blocks }
 							isSelected={ isSelected( example.name ) }
 							onClick={ () => {
-								onSelect( example.name );
+								onSelect?.( example.name );
 							} }
 						/>
 					) ) }

--- a/packages/edit-site/src/components/style-book/index.js
+++ b/packages/edit-site/src/components/style-book/index.js
@@ -164,6 +164,7 @@ function getExamples() {
 }
 
 function StyleBook( {
+	enableResizing = true,
 	isSelected,
 	onClick,
 	onSelect,
@@ -201,7 +202,7 @@ function StyleBook( {
 
 	return (
 		<EditorCanvasContainer
-			enableResizing={ true }
+			enableResizing={ enableResizing }
 			closeButtonLabel={
 				showCloseButton ? __( 'Close Style Book' ) : null
 			}
@@ -261,21 +262,28 @@ const StyleBookBody = ( {
 } ) => {
 	const [ isFocused, setIsFocused ] = useState( false );
 
-	// The presence of an `onClick` prop indicates that the Style Book is being used
-	// as a button. In this case, we need to add additional props to the iframe to
-	// make it behave like a button.
+	// The presence of an `onClick` prop indicates that the Style Book is being used as a button.
+	// In this case, add additional props to the iframe to make it behave like a button.
 	const buttonModeProps = {
 		role: 'button',
 		onFocus: () => setIsFocused( true ),
 		onBlur: () => setIsFocused( false ),
 		onKeyDown: ( event ) => {
+			if ( event.defaultPrevented ) {
+				return;
+			}
 			const { keyCode } = event;
 			if ( onClick && ( keyCode === ENTER || keyCode === SPACE ) ) {
+				event.preventDefault();
 				onClick( event );
 			}
 		},
 		onClick: ( event ) => {
+			if ( event.defaultPrevented ) {
+				return;
+			}
 			if ( onClick ) {
+				event.preventDefault();
 				onClick( event );
 			}
 		},

--- a/packages/edit-site/src/components/style-book/style.scss
+++ b/packages/edit-site/src/components/style-book/style.scss
@@ -1,3 +1,22 @@
+.edit-site-style-book {
+	// Ensure the style book fills the available vertical space.
+	// This is useful when the style book is used to fill a frame.
+	height: 100%;
+	&.is-button {
+		border-radius: $radius-block-ui * 4;
+	}
+}
+
+.edit-site-style-book__iframe {
+	&.is-button {
+		border-radius: $radius-block-ui * 4;
+	}
+	&.is-focused {
+		outline: calc(2 * var(--wp-admin-border-width-focus)) solid var(--wp-admin-theme-color);
+		outline-offset: calc(-2 * var(--wp-admin-border-width-focus));
+	}
+}
+
 .edit-site-style-book__tab-panel {
 	.components-tab-panel__tabs {
 		background: $white;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes: https://github.com/WordPress/gutenberg/issues/50393

Add a button to the Styles left-hand navigation screen in the site editor Browse mode. Clicking the button opens the Style Book within the frame, displayed without tabs. Clicking anywhere within the Style Book frame opens up the edit mode with the Style Book open.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

As raised in #50393, the goal is to make it easier for folks to open up the Style Book and see how styles look across blocks at a glance.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* Add an extra button to the Styles navigation screen within the browse mode of the site editor
* Use the same icon as the Style Book icon in the global styles sidebar
* Allow the Style Book to be rendered within the frame in browse mode
* Hide the tabs, and treat the Style Book as one big button when displayed in this screen

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Open up the site editor, and go to the Styles screen on the left hand side
2. Click the eye icon expose the Style Book
3. You should be able to scroll up and down the Style Book. Clicking within it will open up the edit mode / navigate to the full site editor.
4. Navigating from the Styles screen back to the main navigation screen and back to Styles screen should reset the display state for the Style Book.
5. Double-check that otherwise opening/closing the site editor works just as before, and that the Style Book within the site editor is otherwise unaffected.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

Similar to above, but tab over to the eye icon from the Styles screen. Also, try tabbing all the way to the Style Book frame. You should be able to press Enter / Space to open up the edit mode.

## Screenshots or screencast <!-- if applicable -->

<img width="347" alt="image" src="https://github.com/WordPress/gutenberg/assets/14988353/59e55223-6325-4cdf-a8ce-1e1baf88cccd">

https://github.com/WordPress/gutenberg/assets/14988353/e32f86bd-a7f2-4598-844c-4aeea9bc399b