### PR TITLE
Navigation: Fix warning when stretch justification is used

### DIFF
--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -470,7 +470,10 @@ function render_block_core_navigation( $attributes, $content, $block ) {
 
 	// Restore legacy classnames for submenu positioning.
 	$layout_class = '';
-	if ( isset( $attributes['layout']['justifyContent'] ) ) {
+	if (
+		isset( $attributes['layout']['justifyContent'] ) &&
+		isset( $layout_justification[ $attributes['layout']['justifyContent'] ] )
+	) {
 		$layout_class .= $layout_justification[ $attributes['layout']['justifyContent'] ];
 	}
 	if ( isset( $attributes['layout']['orientation'] ) && 'vertical' === $attributes['layout']['orientation'] ) {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes the warning issue reported in https://github.com/WordPress/gutenberg/issues/50550

In the Navigation block's PHP, check that the provided justification value is present in the mapping array before attempting to access it.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Since `stretch` was introduced as a valid value, when `stretch` is set on the Navigation block, it throws a warning when rendered on the site frontend.

This PR doesn't implement proper support for `stretch` in this block — it's just looking at resolving this PHP warning.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* Check the value exists before attempting to access it

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Add a Navigation block
2. Set it to vertical orientation
3. Select `stretch` content justification (the right-most option)
4. Save the block
5. Load the post / page / site on the site's frontend
6. In PHP logs, note that with this PR applied there should be no warning logged.
7. `stretch` doesn't really do anything for this block yet (I don't think), but double-check that `left`, `centre`, `right` justifications still work as expected

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

This is the warning that should not be logged with this PR applied:

<img width="1233" alt="image" src="https://github.com/WordPress/gutenberg/assets/14988353/63c86f60-716d-4a29-9d93-9b6d94cd16e2">

