### PR TITLE
Update mobile block editor settings to use Gallery block v2 for WordPress 5.9+

### DIFF
--- a/lib/experimental/block-editor-settings-mobile.php
+++ b/lib/experimental/block-editor-settings-mobile.php
@@ -31,6 +31,8 @@ function gutenberg_get_block_editor_settings_mobile( $settings ) {
 		$settings['__experimentalEnableQuoteBlockV2'] = true;
 		// To tell mobile that the site uses list v2 (inner blocks).
 		$settings['__experimentalEnableListBlockV2'] = true;
+		// To tell mobile that the site uses gallery v2 (inner blocks) for sites using WP 5.9+
+		$settings['__unstableGalleryWithImageBlocks'] = is_wp_version_compatible( '5.9' );
 	}
 
 	return $settings;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Attempts to fix an issue where users on WordPress 5.9+ receive the wrong version of the Gallery block. 

Related issues:
* https://github.com/WordPress/gutenberg/issues/47782
* https://github.com/wordpress-mobile/WordPress-Android/issues/17712

## Why?
When a self-hosted site is using WordPress 5.9+ and the Gutenberg plugin is not installed, the Gallery block defaults to v1. This is due to the prop `galleryWithImageBlocks` being unknown. 

## How?
In the [mobile block editor settings](https://github.com/WordPress/gutenberg/blob/ab6c6f2d08b39a622e616ea832ee7f97a21defa0/lib/experimental/block-editor-settings-mobile.php#L29-L33), the list and quote blocks are instructed to use v2 versions. This PR introduces a similar instruction for the Gallery block for sites using WP 5.9+. (This technique was also used when the Gallery block v1 was temporarily deprecated, which has since been reverted.)
*Caveat:* I noted that as this code is in `lib/experiments`, it may not be available to users without the Gutenberg plugin installed, which is the group that would benefit the most from this change. However, perhaps this PR could be a starting point for how we leverage a similar technique to provide either the WP version number or the `galleryWithImageBlocks` flag itself to users without the plugin installed. 

## Testing Instructions
1. Create a self-hosted site with WordPress version 5.9 or above.
2. Check that the Gutenberg plugin is not installed. If not, uninstall it.
3. Create a post.
4. Insert a Gallery block.
5. Observe that the Gallery block is v2 (content is rendered using inner blocks).
6. Repeat the above steps for a self-hosted site using WordPress 5.8 or below.
7. Observe that the Gallery block is using v1 (content is rendered using inner blocks).

