### PR TITLE
List View: Ensure settings menu is visible when focused

### DIFF
--- a/packages/block-editor/src/components/list-view/style.scss
+++ b/packages/block-editor/src/components/list-view/style.scss
@@ -221,7 +221,7 @@
 			opacity: 0;
 		}
 
-		// Show on hover, visible, and show above to keep the hit area size.
+		// Show on hover, visible, when focused, and show above to keep the hit area size.
 		&:hover,
 		&:focus-within,
 		&.is-visible {

--- a/packages/block-editor/src/components/list-view/style.scss
+++ b/packages/block-editor/src/components/list-view/style.scss
@@ -223,6 +223,7 @@
 
 		// Show on hover, visible, and show above to keep the hit area size.
 		&:hover,
+		&:focus-within,
 		&.is-visible {
 			> * {
 				opacity: 1;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes #50357 

Ensure that when hovering over a focused settings menu button in the List View, that the focused state remains even when moving the mouse cursor away.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

As reported in #50357, without adding a `:focus-within` rule to ensure visibility, it looks like focus is lost when mousing over the settings button.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* Add `:focus-within` to the visibility rule for the settings menu buttons

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Add some blocks to a post
2. Open List View
3. Tab into it and use the arrow keys to focus a non-selected block
4. Press the right-arrow key to focus the options button of that block
5. Hover over the button with a mouse and then move the cursor away

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

As above

## Screenshots or screencast <!-- if applicable -->

Note that in Before the focused settings menu is unexpectedly hidden. In After, the focused settings menu state is preserved.

| Before | After |
| --- | --- |
| ![2023-05-12 16 54 05](https://github.com/WordPress/gutenberg/assets/14988353/d0a193a4-7951-460e-9bca-bd221613b992) | ![2023-05-12 16 53 19](https://github.com/WordPress/gutenberg/assets/14988353/0b264842-0309-446a-8730-4d290b2e8193) |