### PR TITLE
Fix labelling, description, and focus style of the block transform to pattern previews

### DIFF
--- a/packages/block-editor/src/components/block-switcher/pattern-transformations-menu.js
+++ b/packages/block-editor/src/components/block-switcher/pattern-transformations-menu.js
@@ -105,15 +105,15 @@ function BlockPattern( { pattern, onSelect, composite } ) {
 		`${ baseClassName }-list__item-description`
 	);
 	return (
-		<div
-			className={ `${ baseClassName }-list__list-item` }
-			aria-label={ pattern.title }
-			aria-describedby={ pattern.description ? descriptionId : undefined }
-		>
+		<div className={ `${ baseClassName }-list__list-item` }>
 			<CompositeItem
 				role="option"
 				as="div"
 				{ ...composite }
+				aria-label={ pattern.title }
+				aria-describedby={
+					pattern.description ? descriptionId : undefined
+				}
 				className={ `${ baseClassName }-list__item` }
 				onClick={ () => onSelect( pattern.transformedBlocks ) }
 			>

--- a/packages/block-editor/src/components/block-switcher/style.scss
+++ b/packages/block-editor/src/components/block-switcher/style.scss
@@ -109,19 +109,20 @@
 	}
 
 	.components-popover__content {
-		box-shadow: none;
+		width: 300px;
 		border: $border-width solid $gray-900;
 		background: $white;
 		border-radius: $radius-block-ui;
 		outline: none;
+		box-shadow: none;
 	}
 
 	.block-editor-block-switcher__preview {
-		width: 300px;
-		height: auto;
-		// Subtract margin from max-height.
+		// Subtract vertical margin from max-height.
 		max-height: calc(500px - #{$grid-unit-40});
-		margin: $grid-unit-20;
+		margin: $grid-unit-20 0;
+		// Use padding to prevent the pattern previews focus style from being cut-off.
+		padding: 0 $grid-unit-20;
 		overflow: hidden;
 	}
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Fixes https://github.com/WordPress/gutenberg/issues/50549

## What?
<!-- In a few words, what is the PR actually doing? -->
- The ARIA attributes `aria-label` and `aria-describedbby` on the 'transform block to pattern' previews are set on the wrong element. Thus the element with role=option has no accessible name and no accessible description.
- The focus style is cut-off.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
- The ARIA attributes must be set on the element with role=option, to provide the accessible name and description.
- Indication of focus must always be clear.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Moves the ARIA attributes on the correct element.
- Adjusts the CSS to prevent the focus style fro being cut-off.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
- Use Twenty Twenty-Three.
- Edit a post, add a Heading block.
- Click the Block switcher button in the block toolbar.
- A dropdown menu opens. Hit the first item in the dropdown: 'Patterns'. 
- A popover opens on the right to show the preview of the available pattern(s).
- You should see a 'Heading' pattern that comes from the Patterns directory.
- Inspect the source and check the aria-label attributes are set on the element with role=option.

Before:

<img width="1152" alt="before attr" src="https://github.com/WordPress/gutenberg/assets/1682452/d5fbcb1f-1392-4494-955d-949928b66539">

After:

<img width="1068" alt="ater attr" src="https://github.com/WordPress/gutenberg/assets/1682452/e3361fa2-9972-44c3-8fff-583f3fb9220a">

## Focus style

- Observe the focus style on the Heading pattern preview is fully visible.

Before:

<img width="724" alt="before" src="https://github.com/WordPress/gutenberg/assets/1682452/bf4890e7-3166-4967-9562-9bc5705dec35">

After:

<img width="724" alt="after" src="https://github.com/WordPress/gutenberg/assets/1682452/2501777c-9e1b-4c6d-abfd-d40a72320a94">

- Check the width of the popover with the pattern(s) is 300 pixels.
- Check the preview fly-outs of the other items in the dropdown menu (Paragraph, List, Quote, etc.) work as expected.
- Activate Twenty Twenty-One.
- Repeat the steps above.
- On the Heading block you should now get _two_ Patterns peviews:
  - Heading (from the Patterns directory)
  - Large text (provided by the theme)
- Check the ARIA attributes, focus style, and width as detailed above.
- Add a Cover block. No need to set the image/text, just keep the placeholder.
- Click the Block Switcher > Patterns button.
- You should see a 'Links area' pattern (provided by the theme).
- Check the ARIA attributes, focus style, and width as detailed above.


Note: turns out the Patterns list is not scrollable. This originates from the change in https://github.com/WordPress/gutenberg/pull/44079. However, the list _must_ be scrollable: when the block content is long and there's more than one pattern shown in the list, it's impossible to scroll past the first pattern. Thus, it's impossible to transform the block to the second, third, etc. pattern shown in the list hen using the mouse. This problem is out of the scope of this PR. I will report it in a new issue.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
