### PR TITLE
Block card: Add `min-height` to prevent layout shift.

### DIFF
--- a/packages/block-editor/src/components/block-card/style.scss
+++ b/packages/block-editor/src/components/block-card/style.scss
@@ -1,6 +1,7 @@
 .block-editor-block-card {
 	display: flex;
 	align-items: flex-start;
+	min-height: 102px;
 }
 
 .block-editor-block-card__content {

--- a/packages/block-editor/src/components/block-card/style.scss
+++ b/packages/block-editor/src/components/block-card/style.scss
@@ -1,7 +1,7 @@
 .block-editor-block-card {
 	display: flex;
 	align-items: flex-start;
-	min-height: 102px;
+	min-height: 100px;
 }
 
 .block-editor-block-card__content {


### PR DESCRIPTION
## What?
<!-- In a few words, what is the PR actually doing? -->

Adding `min-height` to the block card. Setting the value to `102px`, as the two-line descriptions computed height is slightly more than 100 (and probably my OCD is aligned with even numbers).

Fixes: https://github.com/WordPress/gutenberg/issues/49734

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

To prevent a layout shift when selecting different blocks, in favor of a more consistent user experience.

## Testing Instructions
1. Create a page.
2. Add two blocks having different length for their descriptions (i.e.: Tag cloud and Archives).
3. Confirm that the block card for both has the same height.

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/252415/be7e87e3-39cb-467f-a1c4-4eb436fd108f

