### PR TITLE
Lodash: Remove from template part block

### DIFF
--- a/packages/block-library/src/template-part/edit/index.js
+++ b/packages/block-library/src/template-part/edit/index.js
@@ -72,8 +72,8 @@ export default function TemplatePartEdit( {
 				isResolved: hasResolvedEntity,
 				isMissing:
 					hasResolvedEntity &&
-					entityRecord &&
-					Object.keys( entityRecord ).length > 0,
+					( ! entityRecord ||
+						Object.keys( entityRecord ).length === 0 ),
 				area: _area,
 			};
 		},

--- a/packages/block-library/src/template-part/edit/index.js
+++ b/packages/block-library/src/template-part/edit/index.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { isEmpty } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { useSelect } from '@wordpress/data';
@@ -75,7 +70,10 @@ export default function TemplatePartEdit( {
 			return {
 				innerBlocks: getBlocks( clientId ),
 				isResolved: hasResolvedEntity,
-				isMissing: hasResolvedEntity && isEmpty( entityRecord ),
+				isMissing:
+					hasResolvedEntity &&
+					entityRecord &&
+					Object.keys( entityRecord ).length > 0,
 				area: _area,
 			};
 		},

--- a/packages/block-library/src/template-part/edit/utils/hooks.js
+++ b/packages/block-library/src/template-part/edit/utils/hooks.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { kebabCase } from 'lodash';
+import { paramCase as kebabCase } from 'change-case';
 
 /**
  * WordPress dependencies


### PR DESCRIPTION
## What?
This PR removes Lodash from the template part block.

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?

We're using straightforward native JS functionality instead for checking if the value is an empty object. We're using the `change-case` package for `kebabCase`, which we've been utilizing in a few other places already.

## Testing Instructions

* Verify testing instructions of #37370 still work well.
* Verify testing instructions of #38861 still work well.
* Verify all checks are green. 