### PR TITLE
Lodash: Remove from Media & Text block

### DIFF
--- a/packages/block-library/src/media-text/deprecated.js
+++ b/packages/block-library/src/media-text/deprecated.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { isEmpty } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -258,7 +257,7 @@ const v6 = {
 		} = attributes;
 		const mediaSizeSlug =
 			attributes.mediaSizeSlug || DEFAULT_MEDIA_SIZE_SLUG;
-		const newRel = isEmpty( rel ) ? undefined : rel;
+		const newRel = ! rel ? undefined : rel;
 
 		const imageClasses = classnames( {
 			[ `wp-image-${ mediaId }` ]: mediaId && mediaType === 'image',
@@ -387,7 +386,7 @@ const v5 = {
 		} = attributes;
 		const mediaSizeSlug =
 			attributes.mediaSizeSlug || DEFAULT_MEDIA_SIZE_SLUG;
-		const newRel = isEmpty( rel ) ? undefined : rel;
+		const newRel = ! rel ? undefined : rel;
 
 		const imageClasses = classnames( {
 			[ `wp-image-${ mediaId }` ]: mediaId && mediaType === 'image',
@@ -501,7 +500,7 @@ const v4 = {
 		} = attributes;
 		const mediaSizeSlug =
 			attributes.mediaSizeSlug || DEFAULT_MEDIA_SIZE_SLUG;
-		const newRel = isEmpty( rel ) ? undefined : rel;
+		const newRel = ! rel ? undefined : rel;
 
 		const imageClasses = classnames( {
 			[ `wp-image-${ mediaId }` ]: mediaId && mediaType === 'image',
@@ -646,7 +645,7 @@ const v3 = {
 			linkTarget,
 			rel,
 		} = attributes;
-		const newRel = isEmpty( rel ) ? undefined : rel;
+		const newRel = ! rel ? undefined : rel;
 
 		let image = (
 			<img

--- a/packages/block-library/src/media-text/save.js
+++ b/packages/block-library/src/media-text/save.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { isEmpty } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -36,7 +35,7 @@ export default function save( { attributes } ) {
 		rel,
 	} = attributes;
 	const mediaSizeSlug = attributes.mediaSizeSlug || DEFAULT_MEDIA_SIZE_SLUG;
-	const newRel = isEmpty( rel ) ? undefined : rel;
+	const newRel = ! rel ? undefined : rel;
 
 	const imageClasses = classnames( {
 		[ `wp-image-${ mediaId }` ]: mediaId && mediaType === 'image',


### PR DESCRIPTION
## What?
This PR removes Lodash from the Media & Text block.

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?

We're using a straightforward falsy check instead of `_.isEmpty()`. 

## Testing Instructions

* Try saving, and loading a Media & Text block with and without rel. Verify it still properly saves and that there are no errors in the console.
* Verify all checks are green. 

## Screenshots

Link `rel` attributes are set from the link settings:

![Screenshot 2023-05-12 at 16 06 29](https://github.com/WordPress/gutenberg/assets/8436925/f344f889-b910-4b10-895e-ed5da3777983)


