### PR TITLE
Lodash: Remove unnecessary mock from Buttons tests.

### DIFF
--- a/packages/block-library/src/buttons/test/edit.native.js
+++ b/packages/block-library/src/buttons/test/edit.native.js
@@ -19,15 +19,6 @@ import {
 import { getBlockTypes, unregisterBlockType } from '@wordpress/blocks';
 import { registerCoreBlocks } from '@wordpress/block-library';
 
-// Mock debounce to prevent potentially belated state updates.
-jest.mock( 'lodash', () => ( {
-	...jest.requireActual( 'lodash' ),
-	debounce: ( fn ) => {
-		fn.cancel = jest.fn();
-		return fn;
-	},
-} ) );
-
 const BUTTONS_HTML = `<!-- wp:buttons -->
 <div class="wp-block-buttons"><!-- wp:button /--></div>
 <!-- /wp:buttons -->`;


### PR DESCRIPTION
## What?
This PR removes an unnecessary lodash debounce mock from Buttons block tests.

## Why?
The mock is no longer necessary - we're using an in-house debounce function.

## How?
We're just deleting the unnecessary mock.

## Testing Instructions
Verify all tests still pass.