### PR TITLE
Fix: jsdoc dependency rules changed #50452

### DIFF
--- a/packages/eslint-plugin/CHANGELOG.md
+++ b/packages/eslint-plugin/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+- The bundled eslint-plugin-jsdoc dependency has been updated from requiring ^39.6.9 to requiring ^44.2.3 ([#50586](https://github.com/WordPress/gutenberg/pull/50586)) :
+    - Removes `jsdoc/newline-after-description` rule in favor of `jsdoc/tag-lines` with option `startLines: 0` for "never" and `startLines: 1` for "always". Defaults now to `startLines: 0`
+    - Removes `dropEndLines: true` from `jsdoc/tag-lines` in favor of option `endLines: 0`
+    - Drops `jsdoc/tag-lines` rule's `noEndLines: true` in favor of `applyToEndTag: false`
+
 ## 14.6.0 (2023-05-10)
 
 ### Enhancement

--- a/packages/eslint-plugin/CHANGELOG.md
+++ b/packages/eslint-plugin/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Breaking Changes
 
-- The bundled eslint-plugin-jsdoc dependency has been updated from requiring ^39.6.9 to requiring ^44.2.3 ([#50586](https://github.com/WordPress/gutenberg/pull/50586)) :
+- The bundled eslint-plugin-jsdoc dependency has been updated from requiring ^39.6.9 to requiring ^44.2.3 ([#50590](https://github.com/WordPress/gutenberg/pull/50590)) :
     - Removes `jsdoc/newline-after-description` rule in favor of `jsdoc/tag-lines` with option `startLines: 0` for "never" and `startLines: 1` for "always". Defaults now to `startLines: 0`
     - Removes `dropEndLines: true` from `jsdoc/tag-lines` in favor of option `endLines: 0`
     - Drops `jsdoc/tag-lines` rule's `noEndLines: true` in favor of `applyToEndTag: false`

--- a/packages/eslint-plugin/configs/jsdoc.js
+++ b/packages/eslint-plugin/configs/jsdoc.js
@@ -105,7 +105,15 @@ module.exports = {
 		'jsdoc/require-param-description': 'off',
 		'jsdoc/require-returns': 'off',
 		'jsdoc/require-yields': 'off',
-		'jsdoc/tag-lines': 'off',
+		'jsdoc/tag-lines': [
+			1,
+			'any',
+			{
+				startLines: 0,
+				endLines: 0,
+				applyToEndTag: false,
+			},
+		],
 		'jsdoc/no-multi-asterisks': [
 			'error',
 			{ preventAtMiddleLines: false },
@@ -127,7 +135,6 @@ module.exports = {
 		'jsdoc/check-values': 'off',
 		'jsdoc/empty-tags': 'error',
 		'jsdoc/implements-on-classes': 'error',
-		'jsdoc/newline-after-description': 'error',
 		'jsdoc/require-param': 'error',
 		'jsdoc/require-param-name': 'error',
 		'jsdoc/require-param-type': 'error',

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -40,7 +40,7 @@
 		"eslint-config-prettier": "^8.3.0",
 		"eslint-plugin-import": "^2.25.2",
 		"eslint-plugin-jest": "^27.2.1",
-		"eslint-plugin-jsdoc": "^39.6.9",
+		"eslint-plugin-jsdoc": "^44.2.3",
 		"eslint-plugin-jsx-a11y": "^6.5.1",
 		"eslint-plugin-prettier": "^3.3.0",
 		"eslint-plugin-react": "^7.27.0",


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Resolved #50452 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
It's solving jsdoc dependency rules changed.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Updated jsdoc to the latest version and Also added Breaking Changes in changelogs.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

Provided in Issue -> #50452 
