### PR TITLE
Lodash: Remove from Latest Posts block

### DIFF
--- a/packages/block-library/src/latest-posts/edit.native.js
+++ b/packages/block-library/src/latest-posts/edit.native.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { TouchableWithoutFeedback, View, Text } from 'react-native';
-import { isEmpty } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -63,9 +62,7 @@ class LatestPostsEdit extends Component {
 			.then( ( categoriesList ) => {
 				if ( this.isStillMounted ) {
 					this.setState( {
-						categoriesList: isEmpty( categoriesList )
-							? []
-							: categoriesList,
+						categoriesList,
 					} );
 				}
 			} )


### PR DESCRIPTION
## What?
This PR removes Lodash from the Latest Posts block.

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?

We're always returning the API response since it will always be an array, and even in the case of no categories, it will be an empty array, making the extra check there unnecessary.

## Testing Instructions
* Verify categories are still loading properly for the Latest Posts block in the mobile block editor.