### PR TITLE
Move `gutenberg_get_remote_theme_patterns`

### DIFF
--- a/lib/compat/wordpress-6.3/get-global-styles-and-settings.php
+++ b/lib/compat/wordpress-6.3/get-global-styles-and-settings.php
@@ -112,15 +112,3 @@ if ( ! function_exists( 'wp_get_block_css_selector' ) ) {
 		return null;
 	}
 }
-
-/**
- * Returns the current theme's wanted patterns(slugs) to be
- * registered from Pattern Directory.
- *
- * @since 6.3.0
- *
- * @return string[]
- */
-function gutenberg_get_remote_theme_patterns() {
-	return WP_Theme_JSON_Resolver_Gutenberg::get_theme_data( array(), array( 'with_supports' => false ) )->get_patterns();
-}

--- a/lib/global-styles-and-settings.php
+++ b/lib/global-styles-and-settings.php
@@ -267,7 +267,7 @@ function gutenberg_get_global_styles( $path = array(), $context = array() ) {
 }
 
 /**
-* Returns the current theme's wanted patterns (slugs) to be
+ * Returns the current theme's wanted patterns (slugs) to be
  * registered from Pattern Directory.
  *
  * @since 6.3.0

--- a/lib/global-styles-and-settings.php
+++ b/lib/global-styles-and-settings.php
@@ -265,3 +265,15 @@ function gutenberg_get_global_styles( $path = array(), $context = array() ) {
 
 	return _wp_array_get( $styles, $path, $styles );
 }
+
+/**
+* Returns the current theme's wanted patterns (slugs) to be
+ * registered from Pattern Directory.
+ *
+ * @since 6.3.0
+ *
+ * @return string[]
+ */
+function gutenberg_get_remote_theme_patterns() {
+	return WP_Theme_JSON_Resolver_Gutenberg::get_theme_data( array(), array( 'with_supports' => false ) )->get_patterns();
+}


### PR DESCRIPTION
Follow-up to https://github.com/WordPress/gutenberg/pull/50310
Related https://github.com/WordPress/gutenberg/pull/50596

## What

This PR moves `gutenberg_get_remote_theme_patterns` from: `lib/compat/wordpress-6.3/get-global-styles-and-settings.php` to  `lib/global-styles-and-settings.php`

## Why?

The reason is that while the global styles APIs continue to be developed, we need the public API to use the gutenberg classes.

## How?

Move the function from one file to another verbatim.

## Testing Instructions

Verify automated test pass.