### PR TITLE
Plugin: Fix building plugin zip to include interactive blocks

### DIFF
--- a/bin/build-plugin-zip.sh
+++ b/bin/build-plugin-zip.sh
@@ -83,6 +83,7 @@ build_files=$(
 	build/block-library/blocks/*.php \
 	build/block-library/blocks/*/block.json \
 	build/block-library/blocks/*/*.{js,js.map,css,asset.php} \
+	build/block-library/interactive-blocks/*.js \
 	build/edit-widgets/blocks/*/block.json \
 	build/widgets/blocks/*.php \
 	build/widgets/blocks/*/block.json \


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes the issue reported in the https://github.com/WordPress/gutenberg/pull/50041#issuecomment-1544003629:

> Version 15.9.20230511 returns 404 for the following files:
> ```
> vendors.min.js
> interactivity.min.js
> navigation.min.js
> ```

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Files were missing in the `gutenberg.zip` file.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions

Run `npm run build:plugin-zip locally` (_warning: it removes all artifacts from the branch_) or check one of the CI job in this branch that should have the zip file attached.

I uploaded the `gutenberg.zip` file to a WordPress instance and ensured that the Navigation block works correctly with the feature flag enabled:

Basically, we have to ensure that the Navigation block, the navigation submenu, and the page list behave exactly the same when the option is activated/deactivated. I used the testing instructions from #50041:

> Toggle the Experimental option in Gutenberg -> Experiments:
> - Check that the mentioned experiences (and anything not mentioned) work as expected.
> - Check that it is only sending the Interactivity API scripts.
> - Change the settings of the navigation block to ensure it works fine in all cases.
> - If the Overlay menu is set to off and the "Show arrow" is set to false, the scripts shouldn't be loaded.
