### PR TITLE
Add extensibility to PreviewOptions

### DIFF
--- a/packages/block-editor/package.json
+++ b/packages/block-editor/package.json
@@ -51,6 +51,7 @@
 		"@wordpress/html-entities": "file:../html-entities",
 		"@wordpress/i18n": "file:../i18n",
 		"@wordpress/icons": "file:../icons",
+		"@wordpress/interface": "file:../interface",
 		"@wordpress/is-shallow-equal": "file:../is-shallow-equal",
 		"@wordpress/keyboard-shortcuts": "file:../keyboard-shortcuts",
 		"@wordpress/keycodes": "file:../keycodes",

--- a/packages/block-editor/src/components/preview-options/index.js
+++ b/packages/block-editor/src/components/preview-options/index.js
@@ -10,6 +10,7 @@ import { useViewportMatch } from '@wordpress/compose';
 import { DropdownMenu, MenuGroup, MenuItem } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { check, desktop, mobile, tablet } from '@wordpress/icons';
+import { PluginPreviewMenu } from '@wordpress/interface';
 
 export default function PreviewOptions( {
 	children,
@@ -79,6 +80,9 @@ export default function PreviewOptions( {
 							{ __( 'Mobile' ) }
 						</MenuItem>
 					</MenuGroup>
+					<PluginPreviewMenu.Slot>
+						{ ( fills ) => <MenuGroup>{ fills }</MenuGroup> }
+					</PluginPreviewMenu.Slot>
 					{ children( renderProps ) }
 				</>
 			) }

--- a/packages/interface/src/components/index.js
+++ b/packages/interface/src/components/index.js
@@ -11,3 +11,4 @@ export { default as PreferencesModalTabs } from './preferences-modal-tabs';
 export { default as PreferencesModalSection } from './preferences-modal-section';
 export { default as ___unstablePreferencesModalBaseOption } from './preferences-modal-base-option';
 export { default as NavigableRegion } from './navigable-region';
+export { default as PluginPreviewMenu } from './plugin-preview-menu';

--- a/packages/interface/src/components/plugin-preview-menu/index.js
+++ b/packages/interface/src/components/plugin-preview-menu/index.js
@@ -1,0 +1,58 @@
+/**
+ * WordPress dependencies
+ */
+import { createSlotFill, MenuItem } from '@wordpress/components';
+
+export const { Fill, Slot } = createSlotFill( 'PluginPreviewMenu' );
+
+/**
+ * Defines an extensibility slot for the device preview dropdown.
+ *
+ * The `title` and `icon` are used to populate the Preview menu item.
+ *
+ * @param {Object}   props         Component properties.
+ * @param {string}   props.name    A unique name of the custom preview. Prefix with plugin name.
+ * @param {Function} props.onClick Menu item click handler
+ * @param {string}   props.title   Menu item title.
+ */
+const PluginPreviewMenu = ( { name, onClick, title, ...props } ) => (
+	<Fill>
+		<MenuItem
+			className="block-editor-post-preview__button-resize"
+			onClick={ ( ...args ) => {
+				if ( onClick ) {
+					onClick( ...args );
+				}
+			} }
+			{ ...props }
+		>
+			{ title }
+		</MenuItem>
+	</Fill>
+);
+
+PluginPreviewMenu.Slot = Slot;
+
+/**
+ * Renders items in the devide preview dropdown within the editor header.
+ *
+ * @example
+ * ```jsx
+ * // Using ESNext syntax
+ * import { PluginPreviewMenu } from '@wordpress/interface';
+ * import { registerPlugin } from '@wordpress/plugins';
+ *
+ * const MyPreviewMenu = () => (
+ *		<PluginPreviewMenu
+ *			name="MyPreview"
+ *			onClick={ () => {} }
+ *			title="My preview"
+ *		/>
+ *	);
+ *
+ *  registerPlugin( 'my-preview-menu', { render: MyPreviewMenu } );
+ * ```
+ *
+ * @return {WPComponent} The component to be rendered.
+ */
+export default PluginPreviewMenu;


### PR DESCRIPTION
Resolves https://github.com/WordPress/gutenberg/issues/25309

Builds from https://github.com/WordPress/gutenberg/pull/36119, which includes work from https://github.com/WordPress/gutenberg/pull/31984.

## What?

Most basic version of extending plugin preview menu; and only that. 

Does not allow replacing editor canvas with custom previews yet.

The extension point also does not allow just any custom HTML within the dropdown. Instead the extension is declarative by nature, restricting to specific props only ([background](https://github.com/WordPress/gutenberg/pull/31984#issuecomment-845712238)). This gives us freedom to change the UI later, and plugin developer wouldn't need to care about menu's internal structure.

#### Example usage:

```jsx
<>
	<PluginPreviewMenu
		name="MyPreview1"
		onClick={ () => {} }
		title="My preview 1"
	/>
	<PluginPreviewMenu
		name="MyPreview2"
		onClick={ () => {} }
		title="My preview 2"
	/>
</>
```

#### Example result:

<img width="264" alt="Screenshot 2023-07-26 at 11 29 52" src="https://github.com/WordPress/gutenberg/assets/87168/960ece98-51bb-4312-b166-27cee63646b7">


#### Single item example

<img width="262" alt="Screenshot 2023-07-26 at 11 12 53" src="https://github.com/WordPress/gutenberg/assets/87168/a37bd8e6-43c2-4f5e-a587-2f5dda9e7faf">


### API allows:

- Adding new menu items in the dropdown of post/page editor, within a new menu group, with custom title.
- Using `onClick` handler to open a modal for example.

### API does not allow:

- Adding content to other editors, such as site-editor or widgets.
- Adding custom components/HTML within the dropdown
- Adding multiple menu groups.
- Setting the new item as "selected"; this will make sense once we allow either:
   - replacing the canvas with entirely custom preview,
   - custom canvas preview sizes, or
   - groupings independent from Desktop/Tablet/Mobile selections that can be selected within that group (screenshot below)
- Attaching icon to the menu item; since items cannot be selected, no point providing icon just yet.
- "New tab" functionality which handles saving the draft automatically.
- Plugin branding. I considered always showing icon when defined, but this could cause trouble with showing the selection icon later on.

## Future iterations

### Allow new tabs

Example API could just require adding `href="#"` and we would handle it as new tab automatically:

```jsx
<PluginPreviewMenu
	name="MyPluginPreview"
	href="/my-plugin-preview"
	title="My plugin preview in new tab"
/>
```

Resulting:

<img width="271" alt="Screenshot 2023-07-26 at 11 05 22" src="https://github.com/WordPress/gutenberg/assets/87168/2ce7b80d-9734-4064-9f68-c4250949fa9f">

### Allow selecting items

Allowing selecting (or "setting device") would work well with conjuction in allowing custom canvas preview, or custom canvas preview sizes. https://github.com/WordPress/gutenberg/pull/36119 has one technical implementation idea.

Example API could look like:

```jsx
<PluginPreviewMenu
	icon={ globe }
	name="MyPluginDevice"
	title="My plugin preview"
	setDeviceOnClick
/>
```

Resulting:

<img width="262" alt="Screenshot 2023-07-26 at 11 04 44" src="https://github.com/WordPress/gutenberg/assets/87168/a3a906c7-cd14-49a2-af91-897b924565a9">

Meanwhile current API format would continue supporting e.g. popups:

```jsx
<PluginPreviewMenu
	name="MyPluginPreviewPopup"
	onClick={ () => {} }
	title="My preview popup"
/>
```

### Allow new groupings

Example API could look like:

```jsx
<>
	<PluginPreviewMenu
		icon={ globe }
		group="MyPluginMembersPreview"
		name="MyPluginPaidMembers"
		onClick={ () => {} }
		title="Paid members"
	/>
	<PluginPreviewMenu
		icon={ globe }
		group="MyPluginMembersPreview"
		name="MyPluginFreeMembers"
		onClick={ () => {} }
		title="Free members"
	/>
</>
```

Resulting:

<img width="267" alt="Screenshot 2023-07-26 at 11 07 49" src="https://github.com/WordPress/gutenberg/assets/87168/a68d4119-d171-4bb3-8894-70fdeb673559">

Multiple groupings combined with selection could allow something more sophisticated such as:

<img width="256" alt="Screenshot 2023-07-26 at 11 08 25" src="https://github.com/WordPress/gutenberg/assets/87168/57da36ab-9fc7-41a5-9f0f-f5b2f079752d">



<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

<!-- In a few words, what is the PR actually doing? -->

## Why?
See issue https://github.com/WordPress/gutenberg/issues/25309

Extending the preview menu allows variety of publishing flows and tools, some examples:

- AMP format previews
- Social media share previews
- Previewing same content in different formats such as website, email, RSS, printed
- Displaying with different membership or paid access restrictions/without
- Dark mode for websites that implement it (while editor stays light mode by default)
- Additional display sizes for more exotic targets such as televisions, watches

An example of more complex preview capabilities from Substack:

https://github.com/WordPress/gutenberg/assets/87168/f5004855-fb42-4fe9-8fd0-e143a07e0191

## How?
Extension point utilizing slot/fill.

I didn't add tests yet; I will add those once we are certain this API is acceptable first step.

## Testing Instructions
Test with:

```jsx
 import { PluginPreviewMenu } from '@wordpress/interface';
 import { registerPlugin } from '@wordpress/plugins';

 const MyPreviewMenu = () => (
	<PluginPreviewMenu
		name="MyPreview1"
		onClick={ () => {} }
		title="My preview 1"
	/>
);

registerPlugin( 'my-preview-menu', { render: MyPreviewMenu } );
```

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
