### PR TITLE
File block: Fix editing of empty file name 

### DIFF
--- a/packages/block-library/src/file/edit.js
+++ b/packages/block-library/src/file/edit.js
@@ -271,18 +271,16 @@ function FileEdit( { attributes, isSelected, setAttributes, clientId } ) {
 					</ResizableBox>
 				) }
 				<div className={ 'wp-block-file__content-wrapper' }>
-					<div className="wp-block-file__button-richtext-wrapper">
-						<RichText
-							tagName="a"
-							value={ fileName }
-							placeholder={ __( 'Write file name…' ) }
-							withoutInteractiveFormatting
-							onChange={ ( text ) =>
-								setAttributes( { fileName: text } )
-							}
-							href={ textLinkHref }
-						/>
-					</div>
+					<RichText
+						tagName="a"
+						value={ fileName }
+						placeholder={ __( 'Write file name…' ) }
+						withoutInteractiveFormatting
+						onChange={ ( text ) =>
+							setAttributes( { fileName: text } )
+						}
+						href={ textLinkHref }
+					/>
 					{ showDownloadButton && (
 						<div
 							className={

--- a/packages/block-library/src/file/edit.js
+++ b/packages/block-library/src/file/edit.js
@@ -271,16 +271,18 @@ function FileEdit( { attributes, isSelected, setAttributes, clientId } ) {
 					</ResizableBox>
 				) }
 				<div className={ 'wp-block-file__content-wrapper' }>
-					<RichText
-						tagName="a"
-						value={ fileName }
-						placeholder={ __( 'Write file name…' ) }
-						withoutInteractiveFormatting
-						onChange={ ( text ) =>
-							setAttributes( { fileName: text } )
-						}
-						href={ textLinkHref }
-					/>
+					<div className="wp-block-file__button-richtext-wrapper">
+						<RichText
+							tagName="a"
+							value={ fileName }
+							placeholder={ __( 'Write file name…' ) }
+							withoutInteractiveFormatting
+							onChange={ ( text ) =>
+								setAttributes( { fileName: text } )
+							}
+							href={ textLinkHref }
+						/>
+					</div>
 					{ showDownloadButton && (
 						<div
 							className={

--- a/packages/block-library/src/file/editor.scss
+++ b/packages/block-library/src/file/editor.scss
@@ -35,6 +35,10 @@
 
 	a {
 		min-width: 1em;
+
+		&:not(.wp-block-file__button) {
+			display: inline-block;
+		}
 	}
 
 	.wp-block-file__button-richtext-wrapper {


### PR DESCRIPTION
## What?
Fixes: https://github.com/WordPress/gutenberg/issues/50421

Added wrapper element "wp-block-file__button-richtext-wrapper" for the RichText component.

## Why?
Issue was pointed out by #50421 

## How?
If File block was added and then file name was erased from RichText user was unable to re-edit the RichText content.

## Testing Instructions
1. Open post or page and File block
2. Once added name of the file is added as the name of file in the editor
3. Erase that to see placeholder
4. Click on some other block
5. Re-edit the name of file in the File block.
   - If checkout trunk and do same steps you are unable to re-edit the name of the file

