### PR TITLE
Fix media uploads for Docker in rootless mode

### DIFF
--- a/packages/env/lib/build-docker-compose-config.js
+++ b/packages/env/lib/build-docker-compose-config.js
@@ -54,6 +54,11 @@ function getMounts(
 			? `user-home:/home/${ hostUsername }`
 			: `tests-user-home:/home/${ hostUsername }`;
 
+	const userUploadsMount =
+		wordpressDefault === 'wordpress'
+			? `user-uploads:/var/www/html/wp-content/uploads/`
+			: `tests-user-uploads:/var/www/html/wp-content/uploads/`;
+
 	const corePHPUnitMount = `${ path.join(
 		workDirectoryPath,
 		wordpressDefault === 'wordpress'
@@ -72,6 +77,7 @@ function getMounts(
 			coreMount, // Must be first because of some operations later that expect it to be!
 			corePHPUnitMount,
 			userHomeMount,
+			userUploadsMount,
 			...directoryMounts,
 			...pluginMounts,
 			...themeMounts,
@@ -269,6 +275,8 @@ module.exports = function buildDockerComposeConfig( config ) {
 			'mysql-test': {},
 			'user-home': {},
 			'tests-user-home': {},
+			'user-uploads': {},
+			'tests-user-uploads': {},
 		},
 	};
 };

--- a/packages/env/lib/build-docker-compose-config.js
+++ b/packages/env/lib/build-docker-compose-config.js
@@ -54,10 +54,10 @@ function getMounts(
 			? `user-home:/home/${ hostUsername }`
 			: `tests-user-home:/home/${ hostUsername }`;
 
-	const userUploadsMount =
+	const wordpressUploadsMount =
 		wordpressDefault === 'wordpress'
-			? `user-uploads:/var/www/html/wp-content/uploads`
-			: `tests-user-uploads:/var/www/html/wp-content/uploads`;
+			? `wordpress-uploads:/var/www/html/wp-content/uploads`
+			: `tests-wordpress-uploads:/var/www/html/wp-content/uploads`;
 
 	const corePHPUnitMount = `${ path.join(
 		workDirectoryPath,
@@ -77,7 +77,7 @@ function getMounts(
 			coreMount, // Must be first because of some operations later that expect it to be!
 			corePHPUnitMount,
 			userHomeMount,
-			userUploadsMount,
+			wordpressUploadsMount,
 			...directoryMounts,
 			...pluginMounts,
 			...themeMounts,
@@ -275,8 +275,8 @@ module.exports = function buildDockerComposeConfig( config ) {
 			'mysql-test': {},
 			'user-home': {},
 			'tests-user-home': {},
-			'user-uploads': {},
-			'tests-user-uploads': {},
+			'wordpress-uploads': {},
+			'tests-wordpress-uploads': {},
 		},
 	};
 };

--- a/packages/env/lib/build-docker-compose-config.js
+++ b/packages/env/lib/build-docker-compose-config.js
@@ -56,8 +56,8 @@ function getMounts(
 
 	const userUploadsMount =
 		wordpressDefault === 'wordpress'
-			? `user-uploads:/var/www/html/wp-content/uploads/`
-			: `tests-user-uploads:/var/www/html/wp-content/uploads/`;
+			? `user-uploads:/var/www/html/wp-content/uploads`
+			: `tests-user-uploads:/var/www/html/wp-content/uploads`;
 
 	const corePHPUnitMount = `${ path.join(
 		workDirectoryPath,

--- a/packages/env/lib/init-config.js
+++ b/packages/env/lib/init-config.js
@@ -136,6 +136,10 @@ ARG HOST_GID
 RUN groupadd -g $HOST_GID $HOST_USERNAME || true
 RUN useradd -m -u $HOST_UID -g $HOST_GID $HOST_USERNAME || true
 
+# Make media uploads writeable by the host user.
+RUN mkdir /var/www/html/wp-content/uploads/
+RUN chown -R $HOST_UID:$HOST_GID /var/www/html/wp-content/uploads/
+
 # Install any dependencies we need in the container.
 ${ installDependencies( 'wordpress', env, config ) }`;
 }

--- a/packages/env/lib/init-config.js
+++ b/packages/env/lib/init-config.js
@@ -137,7 +137,7 @@ RUN groupadd -g $HOST_GID $HOST_USERNAME || true
 RUN useradd -m -u $HOST_UID -g $HOST_GID $HOST_USERNAME || true
 
 # Make media uploads writeable by the host user.
-RUN mkdir /var/www/html/wp-content/uploads/
+RUN mkdir -p /var/www/html/wp-content/uploads/
 RUN chown -R $HOST_UID:$HOST_GID /var/www/html/wp-content/uploads/
 
 # Install any dependencies we need in the container.

--- a/packages/env/lib/init-config.js
+++ b/packages/env/lib/init-config.js
@@ -137,8 +137,7 @@ RUN groupadd -g $HOST_GID $HOST_USERNAME || true
 RUN useradd -m -u $HOST_UID -g $HOST_GID $HOST_USERNAME || true
 
 # Make media uploads writeable by the host user.
-RUN mkdir -p /var/www/html/wp-content/uploads/
-RUN chown -R $HOST_UID:$HOST_GID /var/www/html/wp-content/uploads/
+RUN install -d -o $HOST_UID -g $HOST_GID /var/www/html/wp-content/uploads
 
 # Install any dependencies we need in the container.
 ${ installDependencies( 'wordpress', env, config ) }`;

--- a/packages/env/lib/test/build-docker-compose-config.js
+++ b/packages/env/lib/test/build-docker-compose-config.js
@@ -46,6 +46,7 @@ describe( 'buildDockerComposeConfig', () => {
 			'wordpress:/var/www/html', // WordPress root.
 			'/path/WordPress-PHPUnit/tests/phpunit:/wordpress-phpunit', // WordPress test library,
 			'user-home:/home/test',
+			'user-uploads:/var/www/html/wp-content/uploads',
 			'/path/to/wp-plugins:/var/www/html/wp-content/plugins', // Mapped plugins root.
 			'/path/to/local/plugin:/var/www/html/wp-content/plugins/test-name', // Mapped plugin.
 		] );

--- a/packages/env/lib/test/build-docker-compose-config.js
+++ b/packages/env/lib/test/build-docker-compose-config.js
@@ -46,7 +46,7 @@ describe( 'buildDockerComposeConfig', () => {
 			'wordpress:/var/www/html', // WordPress root.
 			'/path/WordPress-PHPUnit/tests/phpunit:/wordpress-phpunit', // WordPress test library,
 			'user-home:/home/test',
-			'user-uploads:/var/www/html/wp-content/uploads',
+			'wordpress-uploads:/var/www/html/wp-content/uploads',
 			'/path/to/wp-plugins:/var/www/html/wp-content/plugins', // Mapped plugins root.
 			'/path/to/local/plugin:/var/www/html/wp-content/plugins/test-name', // Mapped plugin.
 		] );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes media uploads for Docker running in rootless mode.

```
$ npx playwright test --config test/e2e/playwright.config.ts -g inserted Image      

Running 1 test using 1 worker

  ✘  1 [chromium] › editor/blocks/image.spec.js:35:2 › Image › can be inserted (7.3s)
Failed to load resource: the server responded with a status of 500 (Internal Server Error)


  1) [chromium] › editor/blocks/image.spec.js:35:2 › Image › can be inserted ───────────────────────

    Error: Timed out 5000ms waiting for expect(received).toHaveAttribute(expected)

    Expected pattern: /acb14c9d-3b63-4942-be10-4da20cf1a647/
    Received string:  ""
    Call log:
      - expect.toHaveAttribute with timeout 5000ms
      - waiting for locator('role=document[name="Block: Image"i]').locator('role=img')
      - waiting for locator('role=document[name="Block: Image"i]').locator('role=img')


      47 |              const image = imageBlock.locator( 'role=img' );
      48 |              await expect( image ).toBeVisible();
    > 49 |              await expect( image ).toHaveAttribute( 'src', new RegExp( filename ) );
         |                                    ^
      50 |
      51 |              const regex = new RegExp(
      52 |                      `<!-- wp:image {"id":(\\d+),"sizeSlug":"full","linkDestination":"none"} -->

        at /home/ajlende/Documents/gutenberg/test/e2e/specs/editor/blocks/image.spec.js:49:25

    attachment #1: trace (application/zip) ─────────────────────────────────────────────────────────
    artifacts/test-results/editor-blocks-image-Image-can-be-inserted-chromium/trace.zip
    Usage:

        npx playwright show-trace artifacts/test-results/editor-blocks-image-Image-can-be-inserted-chromium/trace.zip

    ────────────────────────────────────────────────────────────────────────────────────────────────

    attachment #2: screenshot (image/png) ──────────────────────────────────────────────────────────
    artifacts/test-results/editor-blocks-image-Image-can-be-inserted-chromium/test-failed-1.png
    ────────────────────────────────────────────────────────────────────────────────────────────────

  1 failed
    [chromium] › editor/blocks/image.spec.js:35:2 › Image › can be inserted ────────────────────────
```

```
$ npx playwright show-trace artifacts/test-results/editor-blocks-image-Image-can-be-inserted-chromium/trace.zip
```

![image upload error screenshot](https://github.com/WordPress/gutenberg/assets/5129775/b5f519b2-f7dd-40c3-923d-26dd414c4dfb)

> Unable to create directory wp-content/uploads/2023/05. Is its parent directory writable by the server?


## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Running Docker in rootless mode provides an extra layer of security by not running the daemon with the root user.

May also solve #32519 because it's using a volume for the uploads now.


## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

- Creates a volume for the uploads directory.
- Changes uploads directory to be owned by the host user.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Install Docker in [rootless mode](https://docs.docker.com/engine/security/rootless/)
2. Run `wp-env start`
3. Upload image

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
