### PR TITLE
Edit Post: Unlock useShouldContextualToolbarShow outside of the component

### DIFF
--- a/packages/edit-post/src/components/header/header-toolbar/index.js
+++ b/packages/edit-post/src/components/header/header-toolbar/index.js
@@ -26,6 +26,8 @@ import { store as keyboardShortcutsStore } from '@wordpress/keyboard-shortcuts';
 import { store as editPostStore } from '../../../store';
 import { unlock } from '../../../private-apis';
 
+const { useShouldContextualToolbarShow } = unlock( blockEditorPrivateApis );
+
 const preventDefault = ( event ) => {
 	event.preventDefault();
 };
@@ -66,8 +68,6 @@ function HeaderToolbar() {
 			),
 		};
 	}, [] );
-
-	const { useShouldContextualToolbarShow } = unlock( blockEditorPrivateApis );
 
 	const isLargeViewport = useViewportMatch( 'medium' );
 	const isWideViewport = useViewportMatch( 'wide' );

--- a/packages/edit-site/src/components/header-edit-mode/index.js
+++ b/packages/edit-site/src/components/header-edit-mode/index.js
@@ -45,6 +45,8 @@ import {
 } from '../editor-canvas-container';
 import { unlock } from '../../private-apis';
 
+const { useShouldContextualToolbarShow } = unlock( blockEditorPrivateApis );
+
 const preventDefault = ( event ) => {
 	event.preventDefault();
 };
@@ -126,7 +128,6 @@ export default function HeaderEditMode() {
 		[ setIsListViewOpened, isListViewOpen ]
 	);
 
-	const { useShouldContextualToolbarShow } = unlock( blockEditorPrivateApis );
 	const {
 		shouldShowContextualToolbar,
 		canFocusHiddenToolbar,

--- a/packages/edit-widgets/src/components/header/index.js
+++ b/packages/edit-widgets/src/components/header/index.js
@@ -25,6 +25,8 @@ import useLastSelectedWidgetArea from '../../hooks/use-last-selected-widget-area
 import { store as editWidgetsStore } from '../../store';
 import { unlock } from '../../private-apis';
 
+const { useShouldContextualToolbarShow } = unlock( blockEditorPrivateApis );
+
 function Header() {
 	const isMediumViewport = useViewportMatch( 'medium' );
 	const inserterButton = useRef();
@@ -72,7 +74,6 @@ function Header() {
 		[ setIsListViewOpened, isListViewOpen ]
 	);
 
-	const { useShouldContextualToolbarShow } = unlock( blockEditorPrivateApis );
 	const {
 		shouldShowContextualToolbar,
 		canFocusHiddenToolbar,


### PR DESCRIPTION
## What?
This is similar to #50506 and #50509.

PR moves the private `useShouldContextualToolbarShow` hook unlocking outside of the component.

## Why?
The private hooks can be unlocked at the file level. There's no need to perform the action on each component re-render.

## Testing Instructions
Confirm post editor loads without errors.