### PR TITLE
Removes the Post Content block from the inserter in the post editor 

### DIFF
--- a/packages/edit-post/src/index.js
+++ b/packages/edit-post/src/index.js
@@ -79,7 +79,7 @@ export function initializeEditor(
 	}
 
 	/*
-	 * Prevent adding template part in the post editor.
+	 * Prevent adding template part and post content block in the post editor.
 	 * Only add the filter when the post editor is initialized, not imported.
 	 * Also only add the filter(s) after registerCoreBlocks()
 	 * so that common filters in the block library are not overwritten.
@@ -90,7 +90,8 @@ export function initializeEditor(
 		( canInsert, blockType ) => {
 			if (
 				! select( editPostStore ).isEditingTemplate() &&
-				blockType.name === 'core/template-part'
+				( blockType.name === 'core/template-part' ||
+					blockType.name === 'core/post-content' )
 			) {
 				return false;
 			}


### PR DESCRIPTION
## What?
Removes the Post content block from the inserter in the Post Editor

## Why?
Fixes: #36870 This block just gives an error message about not being usable in a post, so no point in having it in the inserter there.

## How?
Uses the same filter that is being used to stop the template part block being used in the Post editor

## Testing Instructions

- In the Post editor check the block inserter list and make sure the Post Content block does not appear
- In the Site editor make sure the Post Content block does appear

## Screenshots or screencast <!-- if applicable -->

Before:
<img width="783" alt="Screenshot 2023-05-15 at 12 43 15 PM" src="https://github.com/WordPress/gutenberg/assets/3629020/1ed4787b-11f8-47d1-991f-2e70af7a45b7">

After:
<img width="778" alt="Screenshot 2023-05-15 at 12 41 55 PM" src="https://github.com/WordPress/gutenberg/assets/3629020/6049230e-91eb-4172-b307-5b48bc324af4">

