### PR TITLE
Block styles: remove unused prop from inserter preview component

### DIFF
--- a/packages/block-editor/src/components/block-styles/preview-panel.js
+++ b/packages/block-editor/src/components/block-styles/preview-panel.js
@@ -33,7 +33,5 @@ export default function BlockStylesPreviewPanel( {
 		};
 	}, [ genericPreviewBlock, styleClassName ] );
 
-	return (
-		<InserterPreviewPanel item={ previewBlocks } isStylePreview={ true } />
-	);
+	return <InserterPreviewPanel item={ previewBlocks } />;
 }


### PR DESCRIPTION


## What?
Removing `isStylePreview` prop from usage of `<InserterPreviewPanel />`. 

## Why?
 The prop is not [used anywhere](https://github.com/WordPress/gutenberg/blob/01657af5611af0b8772c4d2b151ae52a89a32d83/packages/block-editor/src/components/inserter/preview-panel.js#L17-L17)

## How?
<img width="400" alt="Screenshot 2023-05-15 at 1 21 27 pm" src="https://github.com/WordPress/gutenberg/assets/6458278/db9a2b0b-a443-4fd7-b1cb-f861005862a8">


## Testing Instructions
In a post insert a Table, Button or Image block (any block with style previews). In the block settings panel, ensure the block previews still work as they do on trunk.

<img width="627" alt="Screenshot 2023-05-15 at 1 12 03 pm" src="https://github.com/WordPress/gutenberg/assets/6458278/0e05b4e9-aa29-4559-be81-1eb45412c940">


