### PR TITLE
Add Paragraph prompt to Post Content when empty

### DIFF
--- a/packages/block-library/src/post-content/edit.js
+++ b/packages/block-library/src/post-content/edit.js
@@ -67,7 +67,7 @@ function EditableContent( { context = {} } ) {
 	const props = useInnerBlocksProps(
 		useBlockProps( { className: 'entry-content' } ),
 		{
-			value: blocks,
+			value: hasInnerBlocks ? blocks : undefined,
 			onInput,
 			onChange,
 			template: ! hasInnerBlocks ? initialInnerBlocks : undefined,

--- a/packages/block-library/src/post-content/edit.js
+++ b/packages/block-library/src/post-content/edit.js
@@ -48,19 +48,12 @@ function EditableContent( { context = {}, clientId } ) {
 
 	const hasInnerBlocks = useSelect(
 		( select ) =>
-			select( blockEditorStore ).getBlock( clientId ).innerBlocks.length >
-			0,
+			select( blockEditorStore ).getBlock( clientId )?.innerBlocks
+				.length > 0,
 		[ clientId ]
 	);
 
-	const initialInnerBlocks = [
-		[
-			'core/paragraph',
-			{
-				placeholder: __( 'Type / to add blocks to your page' ),
-			},
-		],
-	];
+	const initialInnerBlocks = [ [ 'core/paragraph' ] ];
 
 	const props = useInnerBlocksProps(
 		useBlockProps( { className: 'entry-content' } ),

--- a/packages/block-library/src/post-content/edit.js
+++ b/packages/block-library/src/post-content/edit.js
@@ -60,14 +60,14 @@ function EditableContent( { context = {} } ) {
 		[ postType, postId ]
 	);
 
-	const hasInnerBlocks = !! entityRecord?.content?.raw;
+	const hasInnerBlocks = !! entityRecord?.content?.raw || blocks?.length;
 
 	const initialInnerBlocks = [ [ 'core/paragraph' ] ];
 
 	const props = useInnerBlocksProps(
 		useBlockProps( { className: 'entry-content' } ),
 		{
-			value: hasInnerBlocks ? blocks : undefined,
+			value: blocks,
 			onInput,
 			onChange,
 			template: ! hasInnerBlocks ? initialInnerBlocks : undefined,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes #49086.

Adds an empty paragraph as template to inner blocks if the Post Content block doesn't already have content in it.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Create and publish a new page, but leave its content empty.
2. In the site editor, navigate to Pages -> the page you just created.
3. Check that an empty Paragraph block with a placeholder prompt now displays inside the Post Content block.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<img width="1136" alt="Screenshot 2023-05-15 at 1 21 31 pm" src="https://github.com/WordPress/gutenberg/assets/8096000/0ecd78a0-56ba-4070-8a0d-24395ad013ed">

<img width="761" alt="Screenshot 2023-05-15 at 1 21 55 pm" src="https://github.com/WordPress/gutenberg/assets/8096000/062248ba-c743-4653-a2bd-d65e6c66d218">
