### PR TITLE
Site editor: make sure only one template deleted snackbar displays at once

### DIFF
--- a/packages/edit-site/src/store/actions.js
+++ b/packages/edit-site/src/store/actions.js
@@ -146,7 +146,7 @@ export const removeTemplate =
 					__( '"%s" deleted.' ),
 					template.title.rendered
 				),
-				{ type: 'snackbar' }
+				{ type: 'snackbar', id: 'site-editor-template-deleted-success' }
 			);
 		} catch ( error ) {
 			const errorMessage =


### PR DESCRIPTION
## What?
Make sure only one template deleted snackbar notice displays at a time.

## Why?
Stacking multiple notices obscures the interface.
Fixes: #46901

## How?
Gives the notice a unique id.

## Testing Instructions
Add several custom template parts
In the manage all template parts screen use the overflow menu to delete each new template
Check that only one snackbar displays

## Screenshots or screencast <!-- if applicable -->

Before:

https://github.com/WordPress/gutenberg/assets/3629020/5e5c644c-f837-4a06-9d06-77e3edc8be47

After:

https://github.com/WordPress/gutenberg/assets/3629020/55cc5060-4bc6-401d-bed2-581ec5f39182


