### PR TITLE
Ensure multiple pattern blocks with the same slug each create unique blocks

### DIFF
--- a/packages/block-library/src/pattern/edit.js
+++ b/packages/block-library/src/pattern/edit.js
@@ -42,17 +42,17 @@ const PatternEdit = ( { attributes, clientId } ) => {
 			// because nested pattern blocks cannot be inserted if the parent block supports
 			// inner blocks but doesn't have blockSettings in the state.
 			window.queueMicrotask( () => {
+				// Clone blocks from the pattern before insertion to ensure they receive
+				// distinct client ids. See https://github.com/WordPress/gutenberg/issues/50628.
+				const clonedBlocks = selectedPattern.blocks.map( ( block ) =>
+					cloneBlock( block )
+				);
 				__unstableMarkNextChangeAsNotPersistent();
 				if ( syncStatus === 'partial' ) {
-					replaceInnerBlocks(
-						clientId,
-						selectedPattern.blocks.map( ( block ) =>
-							cloneBlock( block )
-						)
-					);
+					replaceInnerBlocks( clientId, clonedBlocks );
 					return;
 				}
-				replaceBlocks( clientId, selectedPattern.blocks );
+				replaceBlocks( clientId, clonedBlocks );
 			} );
 		}
 	}, [

--- a/packages/block-library/src/pattern/v1/edit.js
+++ b/packages/block-library/src/pattern/v1/edit.js
@@ -1,6 +1,7 @@
 /**
  * WordPress dependencies
  */
+import { cloneBlock } from '@wordpress/blocks';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useEffect } from '@wordpress/element';
 import {
@@ -32,8 +33,13 @@ const PatternEdit = ( { attributes, clientId } ) => {
 			// because nested pattern blocks cannot be inserted if the parent block supports
 			// inner blocks but doesn't have blockSettings in the state.
 			window.queueMicrotask( () => {
+				// Clone blocks from the pattern before insertion to ensure they receive
+				// distinct client ids. See https://github.com/WordPress/gutenberg/issues/50628.
+				const clonedBlocks = selectedPattern.blocks.map( ( block ) =>
+					cloneBlock( block )
+				);
 				__unstableMarkNextChangeAsNotPersistent();
-				replaceBlocks( clientId, selectedPattern.blocks );
+				replaceBlocks( clientId, clonedBlocks );
 			} );
 		}
 	}, [


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

Fixes #50629

## What?
If multiple pattern blocks are inserted that reference the same slug, they can cause weird issue with blocks selections and updates. The blocks seem 'linked'.

This is because when the pattern is inserted, it gets the block data from the __experimentalGetParsedPattern selector each time, and that selector provides the same client ids for the inner blocks of each pattern.

This PR fixes the issue.

Kudos to @aaronrobertshaw for suggesting the fix, and @glendaviesnz for partially implementing it in #50533

## How?
Clone the blocks prior to insertion.

## Testing Instructions
1. Use twenty twenty three
2. Open an editor and switch to code editor mode
3. Paste `<!-- wp:pattern {"slug":"twentytwentythree/cta"} /-->` in multiple times
4. Switch back to visual mode and try editing the text of the 'Get in touch' button

Expected: The pattern content should be separate individual content. The block toolbar has normal icon buttons
In trunk: Each instance of that button is selected and updated at the same time. The block toolbar has duplicate icon buttons.

## Screenshots or screencast <!-- if applicable -->
#### Before

https://github.com/WordPress/gutenberg/assets/677833/38f1515f-ade6-495f-a45f-3b65ad0cc4e3

#### After

https://github.com/WordPress/gutenberg/assets/677833/5549352c-7d7e-46ab-a34b-169ff2906a13


