### PR TITLE
Use `bdo` element when defining the language of some text

### DIFF
--- a/packages/format-library/src/language/index.js
+++ b/packages/format-library/src/language/index.js
@@ -23,8 +23,8 @@ const title = __( 'Language' );
 
 export const language = {
 	name,
-	tagName: 'span',
-	className: 'has-language',
+	tagName: 'bdo',
+	className: null,
 	edit: Edit,
 	title,
 };


### PR DESCRIPTION
## What?
This is a followup to https://github.com/WordPress/gutenberg/pull/49985
In https://github.com/WordPress/gutenberg/pull/49985#issuecomment-1545681999, @ellatrix suggested using the [`bdo`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/bdo) element, so this PR does just that.

## Why?
Because it's the proper HTML element to use in this scenario.

## How?
* Changed `span` to `bdo`
* Removed the CSS class since it's no longer necessary. It was needed in the `span` element to differentiate it from other formatting that was also using `span`, but `bdo` is a unique case.

The implementation in #49985 was only released a few days ago and it's not used in the wild yet, so it's safe to do this NOW without the need for a deprecation.