### PR TITLE
Lodash: Replace `_.mergeWith()` with `deepmerge` in blocks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17371,6 +17371,7 @@
 				"@wordpress/shortcode": "file:packages/shortcode",
 				"change-case": "^4.1.2",
 				"colord": "^2.7.0",
+				"deepmerge": "^4.3.0",
 				"fast-deep-equal": "^3.1.3",
 				"hpq": "^1.3.0",
 				"is-plain-object": "^5.0.0",

--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -45,6 +45,7 @@
 		"@wordpress/shortcode": "file:../shortcode",
 		"change-case": "^4.1.2",
 		"colord": "^2.7.0",
+		"deepmerge": "^4.3.0",
 		"fast-deep-equal": "^3.1.3",
 		"hpq": "^1.3.0",
 		"is-plain-object": "^5.0.0",

--- a/packages/blocks/src/api/raw-handling/utils.js
+++ b/packages/blocks/src/api/raw-handling/utils.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { mergeWith } from 'lodash';
+import deepmerge from 'deepmerge';
 
 /**
  * WordPress dependencies
@@ -13,6 +13,41 @@ import { isPhrasingContent, getPhrasingContentSchema } from '@wordpress/dom';
  */
 import { hasBlockSupport } from '..';
 import { getRawTransforms } from './get-raw-transforms';
+
+const customMerge = ( key ) => {
+	return ( srcValue, objValue ) => {
+		switch ( key ) {
+			case 'children': {
+				if ( objValue === '*' || srcValue === '*' ) {
+					return '*';
+				}
+
+				return { ...objValue, ...srcValue };
+			}
+			case 'attributes':
+			case 'require': {
+				return [ ...( objValue || [] ), ...( srcValue || [] ) ];
+			}
+			case 'isMatch': {
+				// If one of the values being merge is undefined (matches everything),
+				// the result of the merge will be undefined.
+				if ( ! objValue || ! srcValue ) {
+					return undefined;
+				}
+				// When merging two isMatch functions, the result is a new function
+				// that returns if one of the source functions returns true.
+				return ( ...args ) => {
+					return objValue( ...args ) || srcValue( ...args );
+				};
+			}
+		}
+
+		return deepmerge( objValue, srcValue, {
+			customMerge,
+			clone: false,
+		} );
+	};
+};
 
 export function getBlockContentSchemaFromTransforms( transforms, context ) {
 	const phrasingContentSchema = getPhrasingContentSchema( context );
@@ -51,32 +86,9 @@ export function getBlockContentSchemaFromTransforms( transforms, context ) {
 		);
 	} );
 
-	return mergeWith( {}, ...schemas, ( objValue, srcValue, key ) => {
-		switch ( key ) {
-			case 'children': {
-				if ( objValue === '*' || srcValue === '*' ) {
-					return '*';
-				}
-
-				return { ...objValue, ...srcValue };
-			}
-			case 'attributes':
-			case 'require': {
-				return [ ...( objValue || [] ), ...( srcValue || [] ) ];
-			}
-			case 'isMatch': {
-				// If one of the values being merge is undefined (matches everything),
-				// the result of the merge will be undefined.
-				if ( ! objValue || ! srcValue ) {
-					return undefined;
-				}
-				// When merging two isMatch functions, the result is a new function
-				// that returns if one of the source functions returns true.
-				return ( ...args ) => {
-					return objValue( ...args ) || srcValue( ...args );
-				};
-			}
-		}
+	return deepmerge.all( schemas, {
+		customMerge,
+		clone: false,
 	} );
 }
 


### PR DESCRIPTION
## What?
This PR removes Lodash's `_.mergeWith()` from `getBlockContentSchemaFromTransforms()`.

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?

We're using `deepmerge` as a replacement as we've done in other places already. 

## Testing Instructions

* Verify pasting HTML into the editor is still handled properly.
* Verify that inputting custom HTML in the code editor is still properly converted to blocks when switching to visual.
* Verify all checks are green and all tests still pass. The changes are covered by a bunch of unit tests.