### PR TITLE
Fix Link UI showing on mount for first and last nav menu items

### DIFF
--- a/packages/block-library/src/navigation/edit/menu-inspector-controls.js
+++ b/packages/block-library/src/navigation/edit/menu-inspector-controls.js
@@ -80,7 +80,7 @@ const MainContent = ( {
 		// We need to check isMounted because we never want to show the Link UI on initial render,
 		// as there's no way that a user interaction would have caused the Link UI to be shown from that state.
 		if (
-			isMounted &&
+			isMounted.current &&
 			lastInsertedBlockClientId &&
 			BLOCKS_WITH_LINK_UI_SUPPORT?.includes( insertedBlockName ) &&
 			! hasExistingLinkValue // don't re-show the Link UI if the block already has a link value.


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/50601
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Prevents the Link Control UI from showing for empty custom links when the sidebar List View is mounted.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
If you have a custom link without a URL in the first or last spot on your navigation menu, every time the sidebar list view is mounted, the Link Control will show unexpectedly.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
There wasn't a way I could find to identify if a block had just been inserted, as on mount the `lastInsertedBlockId` was set to the first item in the existing navigation menu. We know the Link UI should never show when it's first mounted, so I added a `isMounted` ref that gets set to `true` after the first `useEffect` hook is run. This ensures the Link UI won't display on mount.

## Testing Instructions

#### Test Setup
1. Go to the Site Editor
2. Click your header navigation block to reveal the right sidebar list view navigation editor
3. Have a navigation where the Last item is a custom link with NO URL set
4. Save the navigation
5. Reload the page 

#### Link UI Should not show on mount when the LAST item doesn't have a link
1. Go to the Site Editor
2. Click your header navigation block to reveal the right sidebar list view navigation editor
3. The link control should not show for the last item on mount
4. Click on a navigation item to edit it
6. Go back to the list view navigation editor
7. The link control should not show

#### Link UI Should not show on mount when the FIRST item doesn't have a link
1. Move the last link item without a url to the first position (top of the navigation)
2. Save
3. Reload the page
2. Click your header navigation block to reveal the right sidebar list view navigation editor
3. The link control should not show for the first item on mount
4. Click on a navigation item to edit it
6. Go back to the list view navigation editor
7. The link control should not show

### Link UI Should Show When Adding a Link
1. Add a link to the navigation sidebar
2. The Link UI should show and work as expected (basically, make sure it shows in the contexts we want it to)

## Screenshots or screencast <!-- if applicable -->
![Fixed no link ui on mount](https://github.com/WordPress/gutenberg/assets/967608/cbd981af-736c-4af3-b443-1525d13e7593)
