### PR TITLE
Pattern block: Add slug as classname to pattern block wrapper

### DIFF
--- a/packages/block-library/src/pattern/edit.js
+++ b/packages/block-library/src/pattern/edit.js
@@ -65,7 +65,9 @@ const PatternEdit = ( { attributes, clientId } ) => {
 		replaceBlocks,
 	] );
 
-	const blockProps = useBlockProps();
+	const blockProps = useBlockProps( {
+		className: slug?.replace( '/', '-' ),
+	} );
 
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {
 		templateLock: syncStatus === 'partial' ? 'contentOnly' : false,


### PR DESCRIPTION
## What?
Adds the pattern slug as a classname to block wrapper in the editor.

## Why?
The slug is added to the wrapper in the frontend currently in order to allow targeting of theme.json styles to a pattern, but it is not added in the editor.

## How?
Added via blockprops

## Testing Instructions

- Add `<!-- wp:pattern {"slug":"twentytwentythree/cta","syncStatus":"partial"} /-->` to code editor and switch to visual editor
- Check that the `twentytwentythree-cta` classname is added to the block wrapper

## Screenshots or screencast <!-- if applicable -->

<img width="566" alt="Screenshot 2023-05-16 at 11 43 51 AM" src="https://github.com/WordPress/gutenberg/assets/3629020/111c54c6-9502-4b71-ad5c-7585571c1d5f">
