### PR TITLE
Check `.wp-env.json` For Unknown Options

### DIFF
--- a/packages/env/CHANGELOG.md
+++ b/packages/env/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancement
+
+-   Validate whether or not config options exist to prevent accidentally including ones that don't.
+
 ## 7.0.0 (2023-05-10)
 
 ### Breaking Change

--- a/packages/env/lib/config/parse-config.js
+++ b/packages/env/lib/config/parse-config.js
@@ -34,9 +34,10 @@ const mergeConfigs = require( './merge-configs' );
  * The root configuration options.
  *
  * @typedef WPRootConfigOptions
- * @property {number}      port       The port to use in the development environment.
- * @property {number}      testsPort  The port to use in the tests environment.
- * @property {string|null} afterSetup The command(s) to run after configuring WordPress on start and clean.
+ * @property {number}                               port       The port to use in the development environment.
+ * @property {number}                               testsPort  The port to use in the tests environment.
+ * @property {string|null}                          afterSetup The command(s) to run after configuring WordPress on start and clean.
+ * @property {Object.<string, WPEnvironmentConfig>} env        The environment-specific configuration options.
  */
 
 /**
@@ -68,6 +69,33 @@ const mergeConfigs = require( './merge-configs' );
  * @property {?string}             ref      The git ref for the source if the source type is 'git'.
  * @property {string}              basename Name that identifies the WordPress installation, plugin or theme.
  */
+
+/**
+ * An object containing all of the default configuration options for environment-specific configurations.
+ * Unless otherwise set at the root-level or the environment-level, these are the values that will be
+ * parsed into the environment. This is useful for tracking known configuration options since these
+ * are the only configuration options that can be set in each environment.
+ */
+const DEFAULT_ENVIRONMENT_CONFIG = {
+	core: null,
+	phpVersion: null,
+	plugins: [],
+	themes: [],
+	port: 8888,
+	testsPort: 8889,
+	mappings: {},
+	config: {
+		WP_DEBUG: true,
+		SCRIPT_DEBUG: true,
+		WP_ENVIRONMENT_TYPE: 'local',
+		WP_PHP_BINARY: 'php',
+		WP_TESTS_EMAIL: 'admin@example.org',
+		WP_TESTS_TITLE: 'Test Blog',
+		WP_TESTS_DOMAIN: 'localhost',
+		WP_SITEURL: 'http://localhost',
+		WP_HOME: 'http://localhost',
+	},
+};
 
 /**
  * Given a directory, this parses any relevant config files and
@@ -164,9 +192,7 @@ async function getDefaultConfig(
 	configDirectoryPath,
 	{ shouldInferType, cacheDirectoryPath }
 ) {
-	// Our default config should try to infer what type of project
-	// this is in order to automatically map the current directory.
-	const detectedType = shouldInferType
+	const detectedDirectoryType = shouldInferType
 		? await detectDirectoryType( configDirectoryPath )
 		: null;
 
@@ -175,24 +201,28 @@ async function getDefaultConfig(
 	// config objects easier because once merged we don't need to
 	// verify that a given option exists before using it.
 	const rawConfig = {
-		core: detectedType === 'core' ? '.' : null,
-		phpVersion: null,
-		plugins: detectedType === 'plugin' ? [ '.' ] : [],
-		themes: detectedType === 'theme' ? [ '.' ] : [],
-		port: 8888,
-		testsPort: 8889,
-		mappings: {},
-		config: {
-			WP_DEBUG: true,
-			SCRIPT_DEBUG: true,
-			WP_ENVIRONMENT_TYPE: 'local',
-			WP_PHP_BINARY: 'php',
-			WP_TESTS_EMAIL: 'admin@example.org',
-			WP_TESTS_TITLE: 'Test Blog',
-			WP_TESTS_DOMAIN: 'localhost',
-			WP_SITEURL: 'http://localhost',
-			WP_HOME: 'http://localhost',
-		},
+		// Since the root config is the base "environment" config for
+		// all environments, we will start with those defaults.
+		...DEFAULT_ENVIRONMENT_CONFIG,
+
+		// When the current directory has no configuration file we support a zero-config mode of operation.
+		// This works by using the default options and inferring how to map the current directory based
+		// on the contents of the directory.
+		core:
+			detectedDirectoryType === 'core'
+				? '.'
+				: DEFAULT_ENVIRONMENT_CONFIG.core,
+		plugins:
+			detectedDirectoryType === 'plugin'
+				? [ '.' ]
+				: DEFAULT_ENVIRONMENT_CONFIG.plugins,
+		themes:
+			detectedDirectoryType === 'theme'
+				? [ '.' ]
+				: DEFAULT_ENVIRONMENT_CONFIG.themes,
+
+		// These configuration options are root-only and should not be present
+		// on environment-specific configuration objects.
 		afterSetup: null,
 		env: {
 			development: {},
@@ -292,7 +322,10 @@ async function parseRootConfig( configFile, rawConfig, options ) {
 		configFile,
 		null,
 		rawConfig,
-		options
+		{
+			...options,
+			rootConfig: true,
+		}
 	);
 
 	// Parse any root-only options.
@@ -333,6 +366,7 @@ async function parseRootConfig( configFile, rawConfig, options ) {
  * @param {Object}      config                     A config object to parse.
  * @param {Object}      options
  * @param {string}      options.cacheDirectoryPath Path to the work directory located in ~/.wp-env.
+ * @param {boolean}     options.rootConfig         Indicates whether or not this is the root config object.
  *
  * @return {Promise<WPEnvironmentConfig>} The environment config object.
  */
@@ -348,6 +382,36 @@ async function parseEnvironmentConfig(
 
 	const environmentPrefix = environment ? environment + '.' : '';
 
+	// Before we move forward with parsing we should make sure that there aren't any
+	// configuration options that do not exist. This helps prevent silent failures
+	// when a user sets up their configuration incorrectly.
+	for ( const key in config ) {
+		if ( DEFAULT_ENVIRONMENT_CONFIG[ key ] !== undefined ) {
+			continue;
+		}
+
+		// We should also check root-only options for the root config
+		// because these aren't part of the above defaults but are
+		// configuration options that we will parse.
+		switch ( key ) {
+			case 'testsPort':
+			case 'afterSetup':
+			case 'env': {
+				if ( options.rootConfig ) {
+					continue;
+				}
+
+				break;
+			}
+		}
+
+		throw new ValidationError(
+			`Invalid ${ configFile }: "${ environmentPrefix }${ key }" is not a configuration option.`
+		);
+	}
+
+	// Parse each option individually so that we can handle the validation
+	// and any conversion that is required to use the option.
 	const parsedConfig = {};
 
 	if ( config.port !== undefined ) {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This pull request checks that all given configuration options exist.

## Why?
If a user misspells a configuration option or we remove one there is no communication to the user that the given option is doing nothing. If we provide clear error messaging that the option does not exist they can make adjustments accordingly.

## How?
We separate the default environment configuration and use that to check whether or not a configuration option exists. There is also some handling for root-only options.

## Testing Instructions

1. Create a `.wp-env.json` file with an invalid option and confirm it errors.
2. Create a `.wp-env.override.json` file with an invalid option and confirm it errors.
3. Add a root-only option (such as `env`) to either of the above files and confirm it errors.
