### PR TITLE
support searching pages

### DIFF
--- a/packages/core-commands/src/site-editor-navigation-commands.js
+++ b/packages/core-commands/src/site-editor-navigation-commands.js
@@ -28,9 +28,11 @@ const icons = {
 const getNavigationCommandLoaderPerPostType = ( postType ) =>
 	function useNavigationCommandLoader( { search } ) {
 		const history = useHistory();
-		const supportsSearch = ! [ 'wp_template', 'wp_template_part' ].includes(
-			postType
-		);
+		const supportsSearch = ! [
+			'wp_template',
+			'wp_template_part',
+			'page',
+		].includes( postType );
 		const deps = supportsSearch ? [ search ] : [];
 		const { records, isLoading } = useSelect( ( select ) => {
 			const { getEntityRecords } = select( coreStore );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Adds ability to search and edit pages in the site editor via the command menu.
## Why?
We are [re-introducing content editing in the site editor](https://github.com/WordPress/gutenberg/issues/44461) which means it may also be a good time to allow searching for pages via command center.
