### PR TITLE
Pattern block: update frontend render code to match the new version of syncStatus attrib

### DIFF
--- a/packages/block-library/src/pattern/index.php
+++ b/packages/block-library/src/pattern/index.php
@@ -22,7 +22,7 @@ function register_block_core_pattern() {
 /**
  * Renders the `core/pattern` block on the server.
  *
- * @param array  $attributes Block attributes.
+ * @param array $attributes Block attributes.
  *
  * @return string Returns the output of the pattern.
  */

--- a/packages/block-library/src/pattern/index.php
+++ b/packages/block-library/src/pattern/index.php
@@ -23,7 +23,6 @@ function register_block_core_pattern() {
  * Renders the `core/pattern` block on the server.
  *
  * @param array  $attributes Block attributes.
- * @param string $content    The block rendered content.
  *
  * @return string Returns the output of the pattern.
  */
@@ -34,7 +33,7 @@ function render_block_core_pattern( $attributes ) {
 
 	$slug     = $attributes['slug'];
 	$registry = WP_Block_Patterns_Registry::get_instance();
-	
+
 	if ( ! $registry->is_registered( $slug ) ) {
 		return '';
 	}

--- a/packages/block-library/src/pattern/index.php
+++ b/packages/block-library/src/pattern/index.php
@@ -27,25 +27,28 @@ function register_block_core_pattern() {
  *
  * @return string Returns the output of the pattern.
  */
-function render_block_core_pattern( $attributes, $content ) {
+function render_block_core_pattern( $attributes ) {
 	if ( empty( $attributes['slug'] ) ) {
 		return '';
-	}
-	$slug_classname = str_replace( '/', '-', $attributes['slug'] );
-	$classnames     = isset( $attributes['className'] ) ? $attributes['className'] . ' ' . $slug_classname : $slug_classname;
-	$wrapper        = '<div class="' . esc_attr( $classnames ) . '">%s</div>';
-
-	if ( isset( $attributes['syncStatus'] ) && 'unsynced' === $attributes['syncStatus'] ) {
-		return sprintf( $wrapper, $content );
 	}
 
 	$slug     = $attributes['slug'];
 	$registry = WP_Block_Patterns_Registry::get_instance();
+	
 	if ( ! $registry->is_registered( $slug ) ) {
 		return '';
 	}
 
 	$pattern = $registry->get_registered( $slug );
+
+	if ( ! isset( $attributes['syncStatus'] ) ) {
+		return do_blocks( $pattern['content'] );
+	}
+
+	$block_classnames = 'wp-block-pattern ' . str_replace( '/', '-', $attributes['slug'] );
+	$classnames       = isset( $attributes['className'] ) ? $attributes['className'] . ' ' . $block_classnames : $block_classnames;
+	$wrapper          = '<div class="' . esc_attr( $classnames ) . '">%s</div>';
+
 	return sprintf( $wrapper, do_blocks( $pattern['content'] ) );
 }
 

--- a/packages/block-library/src/pattern/index.php
+++ b/packages/block-library/src/pattern/index.php
@@ -40,6 +40,9 @@ function render_block_core_pattern( $attributes ) {
 
 	$pattern = $registry->get_registered( $slug );
 
+	// Currently all existing blocks should be returned here without a wp-block-pattern wrapper
+	// as the syncStatus attribute is only used if the gutenberg-pattern-enhancements experiment
+	// is enabled.
 	if ( ! isset( $attributes['syncStatus'] ) ) {
 		return do_blocks( $pattern['content'] );
 	}


### PR DESCRIPTION
## What?
Updates frontend render code so that blocks with no `syncStatus` attrib do not get wrapped in a block wrapper.

## Why?
This matches the latest iteration of the synced block setup implemented in #50533, but the frontend code was overlooked in this change. This fix makes sure the change is backwards compat with existing Pattern blocks that do not have a wrapper.

## How?
Modified `index.php` code to return early with previous version of render if no `syncStatus` attrib set.

## Testing Instructions

- Add the following block markup in the code editor view of post editor and save:
```html
 <!-- wp:pattern {"slug":"twentytwentythree/cta"} /-->
 <!-- wp:pattern {"slug":"twentytwentythree/cta","syncStatus":"partial","className":"my-custom-classname"} /-->
```
- Load the front end view of the post and check that the first CTA block has not `wp-block-pattern` wrapper and the second one does. Also check that the custom classname displays on the second one

## Screenshots or screencast <!-- if applicable -->
<img width="820" alt="Screenshot 2023-05-16 at 3 05 05 PM" src="https://github.com/WordPress/gutenberg/assets/3629020/a729a6da-6e02-4d0d-afeb-d89e9722bcfa">

