### PR TITLE
Site Editor Sidebar: display preview in the frame when hovering mouse over a page

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen-pages/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-pages/index.js
@@ -8,6 +8,7 @@ import {
 import { __ } from '@wordpress/i18n';
 import { useEntityRecords } from '@wordpress/core-data';
 import { decodeEntities } from '@wordpress/html-entities';
+import { privateApis as routerPrivateApis } from '@wordpress/router';
 
 /**
  * Internal dependencies
@@ -16,13 +17,31 @@ import SidebarNavigationScreen from '../sidebar-navigation-screen';
 import { useLink } from '../routes/link';
 import SidebarNavigationItem from '../sidebar-navigation-item';
 import SidebarNavigationSubtitle from '../sidebar-navigation-subtitle';
+import { unlock } from '../../private-apis';
 
 const PageItem = ( { postId, ...props } ) => {
+	const { useHistory } = unlock( routerPrivateApis );
+	const history = useHistory();
 	const linkInfo = useLink( {
 		postType: 'page',
 		postId,
 	} );
-	return <SidebarNavigationItem { ...linkInfo } { ...props } />;
+	const handleNavigationItemHover = ( event ) => {
+		event.stopPropagation();
+		history.push( {
+			path: '/' + 'page',
+			postId,
+			postType: 'page',
+		} );
+	};
+
+	return (
+		<SidebarNavigationItem
+			onMouseEnter={ handleNavigationItemHover }
+			{ ...linkInfo }
+			{ ...props }
+		/>
+	);
 };
 
 export default function SidebarNavigationScreenPages() {

--- a/packages/edit-site/src/components/sidebar-navigation-screen-pages/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-pages/index.js
@@ -28,7 +28,7 @@ const PageItem = ( { postId, ...props } ) => {
 	} );
 	const handleNavigationItemHover = ( event ) => {
 		event.stopPropagation();
-		history.push( {
+		history.replace( {
 			path: '/' + 'page',
 			postId,
 			postType: 'page',
@@ -38,6 +38,7 @@ const PageItem = ( { postId, ...props } ) => {
 	return (
 		<SidebarNavigationItem
 			onMouseEnter={ handleNavigationItemHover }
+			onFocus={ handleNavigationItemHover }
 			{ ...linkInfo }
 			{ ...props }
 		/>

--- a/packages/edit-site/src/components/sync-state-with-url/use-sync-path-with-url.js
+++ b/packages/edit-site/src/components/sync-state-with-url/use-sync-path-with-url.js
@@ -21,6 +21,15 @@ export function getPathFromURL( urlParams ) {
 			case 'wp_template':
 			case 'wp_template_part':
 			case 'page':
+				/*
+				 * We are on the pages list path (/path),
+				 * and have triggered a history event
+				 * using a single page's type and id.
+				 * Do not navigate to the single page path.
+				 */
+				if ( path === '/page' ) {
+					return path;
+				}
 				path = `/${ encodeURIComponent(
 					urlParams.postType
 				) }/${ encodeURIComponent( urlParams.postId ) }`;


### PR DESCRIPTION
## What?
This is an experiment to test the UX of hovering/focus over page items to preview the page in the editor (view mode).

See:
- https://github.com/WordPress/gutenberg/issues/44461

## Why?
To play around with it.

## How?

By fiddling with the history stack.

## Thoughts

1. This has a major downside in that the event adds to the stack and I don't believe there's a documented way to remove items. I've tested using history.push and history.replace (the latter of which replaces the current entry on the history stack).
2. How does this affect accessibility/keyboard navigation? Is it predictable? 
3. Performance - throttling the network, pages do load slowly on the first interaction and are then cached. It might be mitigated by some loading UI. I'm not sure many folks are going to wait around while hovering (?). Clicking a page element seems more predictable and consistent.

## Testing Instructions
First make sure you have a few pages on your site.

Run this a few times if you're like me:

`wp post create --post_type=page --post_title="A new post" --post_status='publish'`

Head over to the site editor and navigate to the Site Editor (Appearance > Editor)

In the sidebar, click on "Pages", and then hover over the items.

See what happens.

The page should load in the editor.

Clicking on the page item should take you to the single page route in the sidebar.

Play with the browser's back button.

### Testing Instructions for Keyboard
When navigating the page list using a keyboard, the pages should load in the browser `onFocus` as well.

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/6458278/201d003e-33e2-4e1a-95e4-98914239fa94



