### PR TITLE
Synchronise inner block attribute updates to a partially synced parent pattern block

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -465,7 +465,7 @@ Show a block pattern. ([Source](https://github.com/WordPress/gutenberg/tree/trun
 -	**Name:** core/pattern
 -	**Category:** theme
 -	**Supports:** ~~html~~, ~~inserter~~
--	**Attributes:** slug, syncStatus
+-	**Attributes:** content, slug, syncStatus
 
 ## Post Author
 

--- a/packages/block-library/src/pattern/block.json
+++ b/packages/block-library/src/pattern/block.json
@@ -17,6 +17,9 @@
 		"syncStatus": {
 			"type": [ "string", "boolean" ],
 			"enum": [ "full", "partial" ]
+		},
+		"content": {
+			"type": "object"
 		}
 	}
 }


### PR DESCRIPTION
## What?
Related: #50456, #48458, #50159

This is an experimental proof of concept PR for the pattern block. When the pattern block is partially synced, a goal is to store any child block attributes that have `content: role` in an attribute of the pattern block itself.

There are a few different way this could be achieved. This PR tries monkey patching the `setAttributes` function for blocks that are a child of a partially synced pattern, so that attribute changes are stored both on the parent pattern block and the child block.

## Why?
The idea is that eventually these attributes will be used to dynamically render the pattern block

## How?
- Uses the `BlockEdit` filter to create a higher order component around blocks
- Checks if those blocks are child of a partially synced pattern
- If they're not, it returns the `BlockEdit` component as normal
- If they are it monkey patches the `setAttributes` function to additionally store attribute changes on the pattern block.

## Testing Instructions
Prerequisite: enable the Enhanced Patterns experiment toggle in the Gutenberg plugins experiment screen.

1. Switch to code view and add `<!-- wp:pattern {"slug":"twentytwentythree/cta", "syncStatus":"partial"} /-->`
2. Modify the pattern paragraph text, button text, button url
3. Switch back to code view, observe the pattern block should have a content attribute that stores the attributes of the inner blocks

## Problems to solve
- This stores all attribute changes, not just those with `__experimentalRole: 'content'`
- This block name is used as a key in the content object. If there are two blocks of the same type, they'll overwrite eachother. Ideally this would use the `data-attribute` keys as described in #50456, but they still need to be implemented.

## Screenshots or screencast <!-- if applicable -->
