### PR TITLE
update the site editor title bar

### DIFF
--- a/packages/edit-site/src/components/header-edit-mode/document-actions/index.js
+++ b/packages/edit-site/src/components/header-edit-mode/document-actions/index.js
@@ -11,27 +11,30 @@ import {
 	__experimentalGetBlockLabel as getBlockLabel,
 	getBlockType,
 } from '@wordpress/blocks';
-import { useSelect } from '@wordpress/data';
+import { useSelect, useDispatch } from '@wordpress/data';
 import {
-	Dropdown,
 	Button,
 	VisuallyHidden,
+	Icon,
+	__experimentalHStack as HStack,
 	__experimentalText as Text,
+	Path,
+	SVG,
 } from '@wordpress/components';
-import { chevronDown } from '@wordpress/icons';
-import { useState, useMemo } from '@wordpress/element';
+import { layout, page, symbol, chevronLeftSmall } from '@wordpress/icons';
 import {
 	store as blockEditorStore,
 	useBlockDisplayInformation,
-	BlockIcon,
 } from '@wordpress/block-editor';
-import { store as preferencesStore } from '@wordpress/preferences';
+import { privateApis as commandsPrivateApis } from '@wordpress/commands';
 
 /**
  * Internal dependencies
  */
-import TemplateDetails from '../../template-details';
 import useEditedEntityRecord from '../../use-edited-entity-record';
+import { unlock } from '../../../private-apis';
+
+const { store: commandsStore } = unlock( commandsPrivateApis );
 
 function getBlockDisplayText( block ) {
 	if ( block ) {
@@ -66,38 +69,31 @@ function useSecondaryText() {
 	return {};
 }
 
-export default function DocumentActions() {
-	const showIconLabels = useSelect(
-		( select ) =>
-			select( preferencesStore ).get(
-				'core/edit-site',
-				'showIconLabels'
-			),
-		[]
-	);
+const titleIcon = {
+	page,
+	wp_template: layout,
+	wp_template_part: symbol,
+};
+
+export default function DocumentActions( {
+	showBack = false,
+	onBack,
+	backLabel = __( 'Back' ),
+} ) {
 	const { isLoaded, record, getTitle } = useEditedEntityRecord();
-	const { label, icon } = useSecondaryText();
-
-	// Use internal state instead of a ref to make sure that the component
-	// re-renders when the popover's anchor updates.
-	const [ popoverAnchor, setPopoverAnchor ] = useState( null );
-
-	// Memoize popoverProps to avoid returning a new object every time.
-	const popoverProps = useMemo(
-		() => ( {
-			// Use the title wrapper as the popover anchor so that the dropdown is
-			// centered over the whole title area rather than just one part of it.
-			anchor: popoverAnchor,
-			placement: 'bottom',
-		} ),
-		[ popoverAnchor ]
-	);
+	const { label } = useSecondaryText();
+	const { open: openCommand } = useDispatch( commandsStore );
 
 	// Return a simple loading indicator until we have information to show.
 	if ( ! isLoaded ) {
 		return (
 			<div className="edit-site-document-actions">
-				{ __( 'Loading…' ) }
+				<Text
+					size="body"
+					className="edit-site-document-actions__title-wrapper"
+				>
+					{ __( 'Loading…' ) }
+				</Text>
 			</div>
 		);
 	}
@@ -116,16 +112,41 @@ export default function DocumentActions() {
 			? __( 'template part' )
 			: __( 'template' );
 
+	const handleBack = ( e ) => {
+		e.stopPropagation();
+		onBack();
+	};
 	return (
 		<div
 			className={ classnames( 'edit-site-document-actions', {
 				'has-secondary-label': !! label,
 			} ) }
+			role="button"
+			tabIndex={ 0 }
+			onClick={ openCommand }
+			onKeyDown={ openCommand }
 		>
-			<div
-				ref={ setPopoverAnchor }
-				className="edit-site-document-actions__title-wrapper"
+			{ showBack && (
+				<HStack alignment="left">
+					<Button
+						className="edit-site-document-actions__back"
+						onClick={ handleBack }
+						icon={ chevronLeftSmall }
+					>
+						{ backLabel }
+					</Button>
+				</HStack>
+			) }
+			<HStack
+				spacing={ 2 }
+				className={ classnames(
+					'edit-site-document-actions__title-wrapper',
+					{
+						'is-global': !! record.type !== 'page',
+					}
+				) }
 			>
+				<Icon icon={ titleIcon[ record.type ] } />
 				<Text
 					size="body"
 					className="edit-site-document-actions__title"
@@ -140,39 +161,36 @@ export default function DocumentActions() {
 					</VisuallyHidden>
 					{ getTitle() }
 				</Text>
-				<div className="edit-site-document-actions__secondary-item">
-					<BlockIcon icon={ icon } showColors />
-					<Text size="body">{ label ?? '' }</Text>
-				</div>
-
-				<Dropdown
-					popoverProps={ popoverProps }
-					renderToggle={ ( { isOpen, onToggle } ) => (
-						<Button
-							className="edit-site-document-actions__get-info"
-							icon={ chevronDown }
-							aria-expanded={ isOpen }
-							aria-haspopup="true"
-							onClick={ onToggle }
-							variant={ showIconLabels ? 'tertiary' : undefined }
-							label={ sprintf(
-								/* translators: %s: the entity to see details about, like "template"*/
-								__( 'Show %s details' ),
-								entityLabel
-							) }
+			</HStack>
+			<HStack
+				spacing={ 1 }
+				alignment="right"
+				className="edit-site-document-actions__shortcut"
+			>
+				<Icon
+					icon={
+						<SVG
+							width="24px"
+							height="24px"
+							viewBox="0 0 24 24"
+							strokeWidth="1.5"
+							fill="none"
+							xmlns="http://www.w3.org/2000/SVG"
+							color="currentColor"
 						>
-							{ showIconLabels && __( 'Details' ) }
-						</Button>
-					) }
-					contentClassName="edit-site-document-actions__info-dropdown"
-					renderContent={ ( { onClose } ) => (
-						<TemplateDetails
-							template={ record }
-							onClose={ onClose }
-						/>
-					) }
+							<Path
+								d="M9 6v12M15 6v12M9 6a3 3 0 10-3 3h12a3 3 0 10-3-3M9 18a3 3 0 11-3-3h12a3 3 0 11-3 3"
+								stroke="currentColor"
+								strokeWidth="1.5"
+								strokeLinecap="round"
+								strokeLinejoin="round"
+							></Path>
+						</SVG>
+					}
+					size={ 16 }
 				/>
-			</div>
+				<Text>K</Text>
+			</HStack>
 		</div>
 	);
 }

--- a/packages/edit-site/src/components/header-edit-mode/document-actions/style.scss
+++ b/packages/edit-site/src/components/header-edit-mode/document-actions/style.scss
@@ -1,23 +1,42 @@
 .edit-site-document-actions {
-	display: flex;
+	display: grid;
+	grid-template-columns: 1fr 1fr 1fr;
 	flex-direction: column;
 	justify-content: center;
-	padding: 0 $grid-unit;
-	height: 100%;
+	width: 100%;
+	height: 36px;
+	max-width: 400px;
+	border-radius: 2px;
+	background: $gray-100;
+	color: $gray-700;
+	padding: 0 $grid-unit-10;
 	// Flex items will, by default, refuse to shrink below a minimum
 	// intrinsic width. In order to shrink this flexbox item, and
 	// subsequently truncate child text, we set an explicit min-width.
 	// See https://dev.w3.org/csswg/css-flexbox/#min-size-auto
 	min-width: 0;
+	cursor: pointer;
+
+	&:hover {
+		background: $gray-200;
+	}
 
 	.edit-site-document-actions__title-wrapper {
 		display: flex;
 		flex-direction: row;
 		justify-content: center;
 		align-items: center;
-
+		grid-column: 2 / 3;
 		// See comment above about min-width
 		min-width: 0;
+		color: $gray-900;
+		svg {
+			fill: currentColor;
+		}
+
+		&.is-global {
+			color: var(--wp-block-synced-color);
+		}
 
 		.components-dropdown {
 			display: inline-flex;
@@ -27,6 +46,18 @@
 				min-width: 0;
 				padding: 0;
 			}
+		}
+	}
+
+	.edit-site-document-actions__back {
+		color: $gray-700;
+	}
+
+	.edit-site-document-actions__shortcut {
+		color: $gray-700;
+		padding: 0 $grid-unit-10;
+		.components-text {
+			color: $gray-700;
 		}
 	}
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Updates the site editor title bar to trigger command center and prepares for when https://github.com/WordPress/gutenberg/pull/49980 lands.

## Why?
Addresses https://github.com/WordPress/gutenberg/issues/50378

## How?
Optional `back` prop.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/1072756/c45803a5-0be3-47ae-9391-ffe80ce88c55



