### PR TITLE
Dimensions Panel: Fix resetting of axial spacing controls

### DIFF
--- a/packages/block-editor/src/components/global-styles/dimensions-panel.js
+++ b/packages/block-editor/src/components/global-styles/dimensions-panel.js
@@ -103,8 +103,9 @@ function useHasSpacingPresets( settings ) {
 }
 
 function filterValuesBySides( values, sides ) {
-	if ( ! sides ) {
-		// If no custom side configuration all sides are opted into by default.
+	// If no custom side configuration, all sides are opted into by default.
+	// Without any values, we have nothing to filter either.
+	if ( ! sides || ! values ) {
 		return values;
 	}
 


### PR DESCRIPTION
Related: 
- https://github.com/WordPress/gutenberg/pull/48070

## What?

Fixes regression introduced in https://github.com/WordPress/gutenberg/pull/48070 which prevents resetting spacing controls for blocks with axial sides support only e.g. Button block padding.

## Why?

Without this fix, any block specifying horizontal or vertical side support will crash when choosing to reset the relevant individual control in the Dimension panel.

## How?

Skips filtering the values per side if there are no values.

## Testing Instructions

1. Before checking out this PR, create a post, add a Buttons block and select an individual button.
2. Navigate to the Block Inspector's Styles tab, set a padding value, then try to reset "Padding" via the dimension panel's menu. The block will crash and a console error logged.
3. Checkout this PR, repeat the process and confirm no error is thrown and control is correctly reset.


## Screenshots or screencast <!-- if applicable -->

| Before | After |
|---|---|
| <video src="https://github.com/WordPress/gutenberg/assets/60436221/56c8f992-2882-494f-96f3-c0a984db29cc" /> | <video src="https://github.com/WordPress/gutenberg/assets/60436221/341df544-f913-4677-8d3c-7f1dbb5afd35" /> |









