### PR TITLE
Fix coding-standards issues

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -28,6 +28,7 @@
 	<rule ref="WordPress.WP.I18n.MissingArgDomainDefault">
 		<exclude-pattern>lib/compat/*</exclude-pattern>
 		<exclude-pattern>packages/block-library/src/*</exclude-pattern>
+		<exclude-pattern>build/block-library/*</exclude-pattern>
 	</rule>
 
 	<arg value="ps"/>
@@ -45,6 +46,10 @@
 
 	<!-- Exclude generated files -->
 	<exclude-pattern>./packages/block-serialization-spec-parser/parser.php</exclude-pattern>
+	<exclude-pattern>node_modules/*</exclude-pattern>
+
+	<!-- Exclude third party libraries -->
+	<exclude-pattern>./vendor/*</exclude-pattern>
 
 	<!-- These special comments are markers for the build process -->
 	<rule ref="Squiz.Commenting.InlineComment.WrongStyle">
@@ -57,6 +62,7 @@
 	</rule>
 	<rule ref="Squiz.Commenting.FileComment.Missing">
 		<exclude-pattern>phpunit/*</exclude-pattern>
+		<exclude-pattern>**/*.min.asset.php</exclude-pattern>
 	</rule>
 	<rule ref="Squiz.Commenting.ClassComment.Missing">
 		<exclude-pattern>phpunit/*</exclude-pattern>

--- a/test/emptytheme/functions.php
+++ b/test/emptytheme/functions.php
@@ -1,7 +1,15 @@
 <?php
+/**
+ * Empty theme functions and definitions.
+ *
+ * @package Gutenberg
+ */
 
 if ( ! function_exists( 'emptytheme_support' ) ) :
-	function emptytheme_support()  {
+	/**
+	 * Add theme support for various features.
+	 */
+	function emptytheme_support() {
 
 		// Adding support for core block visual styles.
 		add_theme_support( 'wp-block-styles' );

--- a/test/emptytheme/index.php
+++ b/test/emptytheme/index.php
@@ -1,0 +1,9 @@
+<?php
+/**
+ * Empty theme index.php file.
+ *
+ * @package Gutenberg
+ */
+
+// Silence is golden.
+return;

--- a/test/gutenberg-test-themes/emptyhybrid/functions.php
+++ b/test/gutenberg-test-themes/emptyhybrid/functions.php
@@ -1,6 +1,14 @@
 <?php
+/**
+ * Empty theme functions and definitions.
+ *
+ * @package Gutenberg
+ */
 
 if ( ! function_exists( 'emptyhybrid_support' ) ) :
+	/**
+	 * Add theme support for various features.
+	 */
 	function emptyhybrid_support() {
 
 		// Adding support for core block visual styles.

--- a/test/gutenberg-test-themes/emptyhybrid/index.php
+++ b/test/gutenberg-test-themes/emptyhybrid/index.php
@@ -1,3 +1,11 @@
+<?php
+/**
+ * Empty-Hybrid theme index.php file.
+ *
+ * @package Gutenberg
+ */
+
+?>
 <!doctype html>
 <html <?php language_attributes(); ?>>
 <head>

--- a/test/gutenberg-test-themes/style-variations/index.php
+++ b/test/gutenberg-test-themes/style-variations/index.php
@@ -1,0 +1,9 @@
+<?php
+/**
+ * Theme index.php file.
+ *
+ * @package Gutenberg
+ */
+
+// Silence is golden.
+return;


### PR DESCRIPTION
## What?
Just fixing some coding-standards issues that come up when I run `vendor/bin/phpcs .` locally.
The errors are in the test themes we use and we _could_ just ignore these files, but there's no reason why we can't just fix them 🤷 

## Why?
Because these errors & warnings are annoying
