### PR TITLE
Integrate `prioritizedInserterBlocks` API to slash inserter

### DIFF
--- a/packages/block-editor/src/autocompleters/block.js
+++ b/packages/block-editor/src/autocompleters/block.js
@@ -16,6 +16,7 @@ import useBlockTypesState from '../components/inserter/hooks/use-block-types-sta
 import BlockIcon from '../components/block-icon';
 import { store as blockEditorStore } from '../store';
 import { orderBy } from '../utils/sorting';
+import { orderInserterBlockItems } from '../utils/order-inserter-block-items';
 
 const noop = () => {};
 const SHOWN_BLOCK_TYPES = 9;
@@ -34,23 +35,26 @@ function createBlockCompleter() {
 		triggerPrefix: '/',
 
 		useItems( filterValue ) {
-			const { rootClientId, selectedBlockName } = useSelect(
-				( select ) => {
+			const { rootClientId, selectedBlockName, prioritizedBlocks } =
+				useSelect( ( select ) => {
 					const {
 						getSelectedBlockClientId,
 						getBlockName,
 						getBlockInsertionPoint,
+						getBlockListSettings,
 					} = select( blockEditorStore );
 					const selectedBlockClientId = getSelectedBlockClientId();
+					const _rootClientId = getBlockInsertionPoint().rootClientId;
 					return {
 						selectedBlockName: selectedBlockClientId
 							? getBlockName( selectedBlockClientId )
 							: null,
-						rootClientId: getBlockInsertionPoint().rootClientId,
+						rootClientId: _rootClientId,
+						prioritizedBlocks:
+							getBlockListSettings( _rootClientId )
+								?.prioritizedInserterBlocks,
 					};
-				},
-				[]
-			);
+				}, [] );
 			const [ items, categories, collections ] = useBlockTypesState(
 				rootClientId,
 				noop
@@ -64,7 +68,10 @@ function createBlockCompleter() {
 							collections,
 							filterValue
 					  )
-					: orderBy( items, 'frecency', 'desc' );
+					: orderInserterBlockItems(
+							orderBy( items, 'frecency', 'desc' ),
+							prioritizedBlocks
+					  );
 
 				return initialFilteredItems
 					.filter( ( item ) => item.name !== selectedBlockName )
@@ -75,6 +82,7 @@ function createBlockCompleter() {
 				items,
 				categories,
 				collections,
+				prioritizedBlocks,
 			] );
 
 			const options = useMemo(

--- a/packages/block-editor/src/components/inserter/search-results.js
+++ b/packages/block-editor/src/components/inserter/search-results.js
@@ -22,6 +22,7 @@ import useBlockTypesState from './hooks/use-block-types-state';
 import { searchBlockItems, searchItems } from './search-items';
 import InserterListbox from '../inserter-listbox';
 import { orderBy } from '../../utils/sorting';
+import { orderInserterBlockItems } from '../../utils/order-inserter-block-items';
 import { store as blockEditorStore } from '../../store';
 
 const INITIAL_INSERTER_RESULTS = 9;
@@ -32,24 +33,6 @@ const INITIAL_INSERTER_RESULTS = 9;
  * @type {Array}
  */
 const EMPTY_ARRAY = [];
-
-const orderInitialBlockItems = ( items, priority ) => {
-	if ( ! priority ) {
-		return items;
-	}
-
-	items.sort( ( { id: aName }, { id: bName } ) => {
-		// Sort block items according to `priority`.
-		let aIndex = priority.indexOf( aName );
-		let bIndex = priority.indexOf( bName );
-		// All other block items should come after that.
-		if ( aIndex < 0 ) aIndex = priority.length;
-		if ( bIndex < 0 ) bIndex = priority.length;
-		return aIndex - bIndex;
-	} );
-
-	return items;
-};
 
 function InserterSearchResults( {
 	filterValue,
@@ -125,7 +108,7 @@ function InserterSearchResults( {
 		let orderedItems = orderBy( blockTypes, 'frecency', 'desc' );
 
 		if ( ! filterValue && prioritizedBlocks.length ) {
-			orderedItems = orderInitialBlockItems(
+			orderedItems = orderInserterBlockItems(
 				orderedItems,
 				prioritizedBlocks
 			);

--- a/packages/block-editor/src/utils/order-inserter-block-items.js
+++ b/packages/block-editor/src/utils/order-inserter-block-items.js
@@ -1,0 +1,26 @@
+/** @typedef {import('../store/selectors').WPEditorInserterItem} WPEditorInserterItem */
+
+/**
+ * Helper function to order inserter block items according to a provided array of prioritized blocks.
+ *
+ * @param {WPEditorInserterItem[]} items    The array of editor inserter block items to be sorted.
+ * @param {string[]}               priority The array of block names to be prioritized.
+ * @return {WPEditorInserterItem[]} The sorted array of editor inserter block items.
+ */
+export const orderInserterBlockItems = ( items, priority ) => {
+	if ( ! priority ) {
+		return items;
+	}
+
+	items.sort( ( { id: aName }, { id: bName } ) => {
+		// Sort block items according to `priority`.
+		let aIndex = priority.indexOf( aName );
+		let bIndex = priority.indexOf( bName );
+		// All other block items should come after that.
+		if ( aIndex < 0 ) aIndex = priority.length;
+		if ( bIndex < 0 ) bIndex = priority.length;
+		return aIndex - bIndex;
+	} );
+
+	return items;
+};

--- a/packages/e2e-tests/specs/editor/plugins/inner-blocks-prioritized-inserter-blocks.test.js
+++ b/packages/e2e-tests/specs/editor/plugins/inner-blocks-prioritized-inserter-blocks.test.js
@@ -105,4 +105,27 @@ describe( 'Prioritized Inserter Blocks Setting on InnerBlocks', () => {
 			);
 		} );
 	} );
+	describe( 'Slash inserter', () => {
+		it( 'uses the priority ordering if prioritzed blocks setting is set', async () => {
+			await insertBlock( 'Prioritized Inserter Blocks Set' );
+			await page.click( '[data-type="core/image"]' );
+			await page.keyboard.press( 'Enter' );
+			await page.keyboard.type( '/' );
+			// Wait for the results to display.
+			await page.waitForSelector( '.components-autocomplete__result' );
+			const inserterItemTitles = await page.evaluate( () => {
+				return Array.from(
+					document.querySelectorAll(
+						'.components-autocomplete__result'
+					)
+				).map( ( { innerText } ) => innerText );
+			} );
+			expect( inserterItemTitles ).toHaveLength( 9 ); // Default suggested blocks number.
+			expect( inserterItemTitles.slice( 0, 3 ) ).toEqual( [
+				'Audio',
+				'Spacer',
+				'Code',
+			] );
+		} );
+	} );
 } );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Resolves: https://github.com/WordPress/gutenberg/issues/50635
Follow up of: https://github.com/WordPress/gutenberg/pull/50510

This PR integrates the `prioritizedInserterBlocks` API to the slash inserter.

## Testing Instructions
1. In a block with inner blocks add the `prioritizedInserterBlocks` API. For example you can add this: `prioritizedInserterBlocks: [ 'core/site-logo' ]` to the Group block [here](https://github.com/WordPress/gutenberg/blob/trunk/packages/block-library/src/group/edit.js#L140).
2. Insert a Group and inside add a Paragraph and type `/` to trigger the slash inserter.
3. Observe that the provided blocks are prioritized
4. Ensure the blocks are prioritized in the appender too (original PR)

