### PR TITLE
Hide the hidden navigation block

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/navigation-menu-content.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/navigation-menu-content.js
@@ -9,7 +9,6 @@ import {
 } from '@wordpress/block-editor';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { createBlock } from '@wordpress/blocks';
-import { VisuallyHidden } from '@wordpress/components';
 import { useCallback } from '@wordpress/element';
 import { store as coreStore } from '@wordpress/core-data';
 
@@ -106,11 +105,11 @@ export default function NavigationMenuContent( { rootClientId } ) {
 					showAppender={ false }
 				/>
 			) }
-			<VisuallyHidden aria-hidden="true">
+			<div className="edit-site-sidebar-navigation-screen-navigation-menus__helper-block-editor">
 				<BlockTools>
 					<BlockList />
 				</BlockTools>
-			</VisuallyHidden>
+			</div>
 		</>
 	);
 }

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/style.scss
@@ -99,3 +99,7 @@
 	margin-right: auto;
 	display: block;
 }
+
+.edit-site-sidebar-navigation-screen-navigation-menus__helper-block-editor {
+	display: none;
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes #50639

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

We use a hidden navigation block to allow the edits to the navigation entity to be caught by the entity system and also to allow the effects of the block to run. This block was hidden using `VisuallyHidden` which is the wrong component for this case.

Here we want to really hide the block, not hide it visually.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Instead of using `VisuallyHidden` I just use a `div` that is set to `display:none`.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Go to the side editor
2. Open the navigation sidebar screen
3. Tab around
4. You should not be able to tab into a navigation block

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

N/A
