### PR TITLE
Command tool: Add searchLabel property to commands

### DIFF
--- a/packages/commands/src/components/command-menu.js
+++ b/packages/commands/src/components/command-menu.js
@@ -41,7 +41,7 @@ function CommandMenuLoader( { name, search, hook, setLoader, close } ) {
 				{ commands.map( ( command ) => (
 					<Command.Item
 						key={ command.name }
-						value={ command.name }
+						value={ command.searchLabel ?? command.label }
 						onSelect={ () => command.callback( { close } ) }
 					>
 						<HStack
@@ -110,7 +110,7 @@ export function CommandMenuGroup( { isContextual, search, setLoader, close } ) {
 			{ commands.map( ( command ) => (
 				<Command.Item
 					key={ command.name }
-					value={ command.name }
+					value={ command.searchLabel ?? command.label }
 					onSelect={ () => command.callback( { close } ) }
 				>
 					<HStack

--- a/packages/commands/src/hooks/use-command.js
+++ b/packages/commands/src/hooks/use-command.js
@@ -26,6 +26,7 @@ export default function useCommand( command ) {
 			name: command.name,
 			context: command.context,
 			label: command.label,
+			searchLabel: command.searchLabel,
 			icon: command.icon,
 			callback: currentCallback.current,
 		} );
@@ -35,6 +36,7 @@ export default function useCommand( command ) {
 	}, [
 		command.name,
 		command.label,
+		command.searchLabel,
 		command.icon,
 		command.context,
 		registerCommand,

--- a/packages/commands/src/store/actions.js
+++ b/packages/commands/src/store/actions.js
@@ -5,11 +5,12 @@
  *
  * @typedef {Object} WPCommandConfig
  *
- * @property {string}      name     Command name.
- * @property {string}      label    Command label.
- * @property {string=}     context  Command context.
- * @property {JSX.Element} icon     Command icon.
- * @property {Function}    callback Command callback.
+ * @property {string}      name        Command name.
+ * @property {string}      label       Command label.
+ * @property {string=}     searchLabel Command label.
+ * @property {string=}     context     Command context.
+ * @property {JSX.Element} icon        Command icon.
+ * @property {Function}    callback    Command callback.
  */
 
 /**

--- a/packages/commands/src/store/actions.js
+++ b/packages/commands/src/store/actions.js
@@ -7,7 +7,7 @@
  *
  * @property {string}      name        Command name.
  * @property {string}      label       Command label.
- * @property {string=}     searchLabel Command label.
+ * @property {string=}     searchLabel Command search label.
  * @property {string=}     context     Command context.
  * @property {JSX.Element} icon        Command icon.
  * @property {Function}    callback    Command callback.

--- a/packages/commands/src/store/reducer.js
+++ b/packages/commands/src/store/reducer.js
@@ -19,6 +19,7 @@ function commands( state = {}, action ) {
 				[ action.name ]: {
 					name: action.name,
 					label: action.label,
+					searchLabel: action.searchLabel,
 					context: action.context,
 					callback: action.callback,
 					icon: action.icon,

--- a/packages/core-commands/src/add-post-type-commands.js
+++ b/packages/core-commands/src/add-post-type-commands.js
@@ -14,7 +14,7 @@ const { useCommand } = unlock( privateApis );
 
 export function useAddPostTypeCommands() {
 	useCommand( {
-		name: 'add new post',
+		name: 'core/add-new-post',
 		label: __( 'Add new post' ),
 		icon: plus,
 		callback: () => {
@@ -22,7 +22,7 @@ export function useAddPostTypeCommands() {
 		},
 	} );
 	useCommand( {
-		name: 'add new page',
+		name: 'core/add-new-page',
 		label: __( 'Add new page' ),
 		icon: plus,
 		callback: () => {

--- a/packages/core-commands/src/site-editor-navigation-commands.js
+++ b/packages/core-commands/src/site-editor-navigation-commands.js
@@ -66,7 +66,8 @@ const getNavigationCommandLoaderPerPostType = ( postType ) =>
 					? { canvas: getQueryArg( window.location.href, 'canvas' ) }
 					: {};
 				return {
-					name: record.title?.rendered + ' ' + record.id,
+					name: postType + '-' + record.id,
+					searchLabel: record.title?.rendered + ' ' + record.id,
 					label: record.title?.rendered
 						? record.title?.rendered
 						: __( '(no title)' ),

--- a/packages/edit-site/src/hooks/commands/use-edit-mode-commands.js
+++ b/packages/edit-site/src/hooks/commands/use-edit-mode-commands.js
@@ -35,7 +35,7 @@ function useEditModeCommandLoader() {
 				? __( 'Delete template' )
 				: __( 'Delete template part' );
 		commands.push( {
-			name: label,
+			name: 'core/remove-template',
 			label,
 			icon: trash,
 			context: 'site-editor-edit',
@@ -55,7 +55,7 @@ function useEditModeCommandLoader() {
 				? __( 'Reset template' )
 				: __( 'Reset template part' );
 		commands.push( {
-			name: label,
+			name: 'core/reset-template',
 			label,
 			icon: backup,
 			callback: ( { close } ) => {


### PR DESCRIPTION
Related to https://github.com/WordPress/gutenberg/issues/50407

## What?

We're using the [following library](https://github.com/pacocoursey/cmdk) for the command center. The library requires that each command has a unique "value" prop. Also, the library relies on that prop for its "search" algorithm. This has two implications:

 - That prop need to be "translatable" (since we use it for search), so it shouldn't be a technical id.
 - The prop may some time differ from the "label" of the command because we might have duplication there (a "test" template and a "test" page for instance).

To address this I'm using the command "label" by default for that prop and in the cases where the label is not sufficient for the unique constraint, one can provide a "searchLabel" property in addition to the default "label" one.

## Testing Instructions

1- Create a page and a template with the same name
2- Ensure the command center still works properly when searching for these.
