### PR TITLE
[RNMobile] Add disabled style to `Cell` component

### DIFF
--- a/packages/components/src/mobile/bottom-sheet-select-control/index.native.js
+++ b/packages/components/src/mobile/bottom-sheet-select-control/index.native.js
@@ -22,6 +22,7 @@ const BottomSheetSelectControl = ( {
 	options: items,
 	onChange,
 	value: selectedValue,
+	disabled,
 } ) => {
 	const [ showSubSheet, setShowSubSheet ] = useState( false );
 	const navigation = useNavigation();
@@ -68,6 +69,7 @@ const BottomSheetSelectControl = ( {
 						__( 'Navigates to select %s' ),
 						label
 					) }
+					disabled={ disabled }
 				>
 					<Icon icon={ chevronRight }></Icon>
 				</BottomSheet.Cell>

--- a/packages/components/src/mobile/bottom-sheet-text-control/index.native.js
+++ b/packages/components/src/mobile/bottom-sheet-text-control/index.native.js
@@ -29,7 +29,7 @@ const BottomSheetTextControl = ( {
 	icon,
 	footerNote,
 	cellPlaceholder,
-	disabled = false,
+	disabled,
 } ) => {
 	const [ showSubSheet, setShowSubSheet ] = useState( false );
 	const navigation = useNavigation();

--- a/packages/components/src/mobile/bottom-sheet-text-control/index.native.js
+++ b/packages/components/src/mobile/bottom-sheet-text-control/index.native.js
@@ -29,6 +29,7 @@ const BottomSheetTextControl = ( {
 	icon,
 	footerNote,
 	cellPlaceholder,
+	disabled = false,
 } ) => {
 	const [ showSubSheet, setShowSubSheet ] = useState( false );
 	const navigation = useNavigation();
@@ -62,6 +63,7 @@ const BottomSheetTextControl = ( {
 					onPress={ openSubSheet }
 					value={ initialValue || '' }
 					placeholder={ cellPlaceholder || placeholder || '' }
+					disabled={ disabled }
 				>
 					<Icon icon={ chevronRight }></Icon>
 				</BottomSheet.Cell>

--- a/packages/components/src/mobile/bottom-sheet/cell.native.js
+++ b/packages/components/src/mobile/bottom-sheet/cell.native.js
@@ -424,7 +424,16 @@ class BottomSheetCell extends Component {
 						/>
 					) }
 					{ showValue && getValueComponent() }
-					{ children }
+					<View
+						style={ [
+							disabled && styles.cellDisabled,
+							styles.cellRowContainer,
+						] }
+						pointerEvents={ disabled ? 'none' : 'auto' }
+						aria-disabled={ disabled }
+					>
+						{ children }
+					</View>
 				</View>
 				{ help && (
 					<Text style={ [ cellHelpStyle, styles.placeholderColor ] }>

--- a/packages/components/src/mobile/bottom-sheet/cell.native.js
+++ b/packages/components/src/mobile/bottom-sheet/cell.native.js
@@ -256,6 +256,7 @@ class BottomSheetCell extends Component {
 					onBlur={ finishEditing }
 					onSubmitEditing={ onSubmit }
 					keyboardType={ this.typeToKeyboardType( type, step ) }
+					disabled={ disabled }
 					{ ...valueProps }
 				/>
 			) : (

--- a/packages/components/src/mobile/bottom-sheet/cell.native.js
+++ b/packages/components/src/mobile/bottom-sheet/cell.native.js
@@ -431,7 +431,6 @@ class BottomSheetCell extends Component {
 							styles.cellRowContainer,
 						] }
 						pointerEvents={ disabled ? 'none' : 'auto' }
-						aria-disabled={ disabled }
 					>
 						{ children }
 					</View>

--- a/packages/components/src/mobile/bottom-sheet/cell.native.js
+++ b/packages/components/src/mobile/bottom-sheet/cell.native.js
@@ -229,6 +229,12 @@ class BottomSheetCell extends Component {
 				...valueStyle,
 				...styleRTL,
 			};
+			const placeholderTextColor = disabled
+				? this.props.getStylesFromColorScheme(
+						styles.placeholderColorDisabled,
+						styles.placeholderColorDisabledDark
+				  ).color
+				: styles.placeholderColor.color;
 			const textStyle = {
 				...( disabled && styles.cellDisabled ),
 				...cellValueStyle,
@@ -247,7 +253,7 @@ class BottomSheetCell extends Component {
 					style={ textInputStyle }
 					value={ value }
 					placeholder={ valuePlaceholder }
-					placeholderTextColor={ '#87a6bc' }
+					placeholderTextColor={ placeholderTextColor }
 					onChangeText={ onChangeValue }
 					editable={ isValueEditable }
 					pointerEvents={

--- a/packages/components/src/mobile/bottom-sheet/cell.native.js
+++ b/packages/components/src/mobile/bottom-sheet/cell.native.js
@@ -92,6 +92,7 @@ class BottomSheetCell extends Component {
 			accessibilityHint,
 			accessibilityRole,
 			disabled = false,
+			disabledStyle = styles.cellDisabled,
 			activeOpacity,
 			onPress,
 			onLongPress,
@@ -426,7 +427,7 @@ class BottomSheetCell extends Component {
 					{ showValue && getValueComponent() }
 					<View
 						style={ [
-							disabled && styles.cellDisabled,
+							disabled && disabledStyle,
 							styles.cellRowContainer,
 						] }
 						pointerEvents={ disabled ? 'none' : 'auto' }

--- a/packages/components/src/mobile/bottom-sheet/cell.native.js
+++ b/packages/components/src/mobile/bottom-sheet/cell.native.js
@@ -223,10 +223,15 @@ class BottomSheetCell extends Component {
 				styles.cellValue,
 				styles.cellTextDark
 			);
-			const finalStyle = {
+			const textInputStyle = {
 				...cellValueStyle,
 				...valueStyle,
 				...styleRTL,
+			};
+			const textStyle = {
+				...( disabled && styles.cellDisabled ),
+				...cellValueStyle,
+				...valueStyle,
 			};
 
 			// To be able to show the `middle` ellipsizeMode on editable cells
@@ -238,7 +243,7 @@ class BottomSheetCell extends Component {
 				<TextInput
 					ref={ ( c ) => ( this._valueTextInput = c ) }
 					numberOfLines={ 1 }
-					style={ finalStyle }
+					style={ textInputStyle }
 					value={ value }
 					placeholder={ valuePlaceholder }
 					placeholderTextColor={ '#87a6bc' }
@@ -255,7 +260,7 @@ class BottomSheetCell extends Component {
 				/>
 			) : (
 				<Text
-					style={ { ...cellValueStyle, ...valueStyle } }
+					style={ textStyle }
 					numberOfLines={ 1 }
 					ellipsizeMode={ 'middle' }
 				>

--- a/packages/components/src/mobile/bottom-sheet/range-cell.native.js
+++ b/packages/components/src/mobile/bottom-sheet/range-cell.native.js
@@ -226,7 +226,7 @@ class BottomSheetRangeCell extends Component {
 								testID={ `Slider ${ cellProps.label }` }
 								value={ sliderValue }
 								defaultValue={ defaultValue }
-								disabled={ disabled }
+								disabled={ disabled && ! isIOS }
 								step={ step }
 								minimumValue={ minimumValue }
 								maximumValue={ maximumValue }

--- a/packages/components/src/mobile/bottom-sheet/range-cell.native.js
+++ b/packages/components/src/mobile/bottom-sheet/range-cell.native.js
@@ -137,6 +137,7 @@ class BottomSheetRangeCell extends Component {
 			defaultValue,
 			minimumValue = 0,
 			maximumValue = 10,
+			disabled,
 			step = 1,
 			preferredColorScheme,
 			minimumTrackTintColor = preferredColorScheme === 'light'
@@ -217,6 +218,7 @@ class BottomSheetRangeCell extends Component {
 						activeOpacity={ 1 }
 						accessible={ false }
 						valueStyle={ styles.valueStyle }
+						disabled={ disabled }
 					>
 						<View style={ containerStyle }>
 							{ preview }
@@ -224,6 +226,7 @@ class BottomSheetRangeCell extends Component {
 								testID={ `Slider ${ cellProps.label }` }
 								value={ sliderValue }
 								defaultValue={ defaultValue }
+								disabled={ disabled }
 								step={ step }
 								minimumValue={ minimumValue }
 								maximumValue={ maximumValue }

--- a/packages/components/src/mobile/bottom-sheet/range-cell.native.js
+++ b/packages/components/src/mobile/bottom-sheet/range-cell.native.js
@@ -137,7 +137,6 @@ class BottomSheetRangeCell extends Component {
 			defaultValue,
 			minimumValue = 0,
 			maximumValue = 10,
-			disabled,
 			step = 1,
 			preferredColorScheme,
 			minimumTrackTintColor = preferredColorScheme === 'light'
@@ -225,7 +224,6 @@ class BottomSheetRangeCell extends Component {
 								testID={ `Slider ${ cellProps.label }` }
 								value={ sliderValue }
 								defaultValue={ defaultValue }
-								disabled={ disabled }
 								step={ step }
 								minimumValue={ minimumValue }
 								maximumValue={ maximumValue }

--- a/packages/components/src/mobile/bottom-sheet/stepper-cell/index.native.js
+++ b/packages/components/src/mobile/bottom-sheet/stepper-cell/index.native.js
@@ -144,6 +144,7 @@ class BottomSheetStepperCell extends Component {
 			openUnitPicker,
 			decimalNum,
 			cellContainerStyle,
+			disabled,
 		} = this.props;
 		const { inputValue } = this.state;
 		const isMinValue = value === min;
@@ -215,6 +216,7 @@ class BottomSheetStepperCell extends Component {
 						labelStyle={ labelStyle }
 						leftAlign={ true }
 						separatorType={ separatorType }
+						disabled={ disabled }
 					>
 						<View style={ preview && containerStyle }>
 							{ preview }

--- a/packages/components/src/mobile/bottom-sheet/styles.native.scss
+++ b/packages/components/src/mobile/bottom-sheet/styles.native.scss
@@ -319,5 +319,5 @@
 }
 
 .cellDisabled {
-	opacity: 0.25;
+	opacity: 0.3;
 }

--- a/packages/components/src/mobile/bottom-sheet/styles.native.scss
+++ b/packages/components/src/mobile/bottom-sheet/styles.native.scss
@@ -284,7 +284,15 @@
 
 // used in both light and dark modes
 .placeholderColor {
-	color: #87a6bc;
+	color: $gray;
+}
+
+.placeholderColorDisabled {
+	color: lighten($gray, 20%);
+}
+
+.placeholderColorDisabledDark {
+	color: lighten($gray-dark, 10%);
 }
 
 .applyButton {

--- a/packages/components/src/mobile/bottom-sheet/styles.native.scss
+++ b/packages/components/src/mobile/bottom-sheet/styles.native.scss
@@ -317,3 +317,7 @@
 .cellSubLabelTextDark {
 	color: $sub-heading-dark;
 }
+
+.cellDisabled {
+	opacity: 0.25;
+}

--- a/packages/components/src/mobile/bottom-sheet/switch-cell.native.js
+++ b/packages/components/src/mobile/bottom-sheet/switch-cell.native.js
@@ -13,7 +13,7 @@ import { __, _x, sprintf } from '@wordpress/i18n';
 import Cell from './cell';
 
 export default function BottomSheetSwitchCell( props ) {
-	const { value, onValueChange, disabled, ...cellProps } = props;
+	const { value, onValueChange, ...cellProps } = props;
 
 	const onPress = () => {
 		onValueChange( ! value );
@@ -60,13 +60,8 @@ export default function BottomSheetSwitchCell( props ) {
 			onPress={ onPress }
 			editable={ false }
 			value={ '' }
-			disabled={ disabled }
 		>
-			<Switch
-				value={ value }
-				onValueChange={ onValueChange }
-				disabled={ disabled }
-			/>
+			<Switch value={ value } onValueChange={ onValueChange } />
 		</Cell>
 	);
 }

--- a/packages/components/src/mobile/bottom-sheet/switch-cell.native.js
+++ b/packages/components/src/mobile/bottom-sheet/switch-cell.native.js
@@ -12,8 +12,10 @@ import { __, _x, sprintf } from '@wordpress/i18n';
  */
 import Cell from './cell';
 
+const EMPTY_STYLE = {};
+
 export default function BottomSheetSwitchCell( props ) {
-	const { value, onValueChange, ...cellProps } = props;
+	const { value, onValueChange, disabled, ...cellProps } = props;
 
 	const onPress = () => {
 		onValueChange( ! value );
@@ -60,8 +62,14 @@ export default function BottomSheetSwitchCell( props ) {
 			onPress={ onPress }
 			editable={ false }
 			value={ '' }
+			disabled={ disabled }
+			disabledStyle={ EMPTY_STYLE }
 		>
-			<Switch value={ value } onValueChange={ onValueChange } />
+			<Switch
+				value={ value }
+				onValueChange={ onValueChange }
+				disabled={ disabled }
+			/>
 		</Cell>
 	);
 }

--- a/packages/components/src/range-control/index.native.js
+++ b/packages/components/src/range-control/index.native.js
@@ -25,6 +25,7 @@ const RangeControl = memo(
 		max,
 		type,
 		separatorType,
+		disabled,
 		...props
 	} ) => {
 		if ( type === 'stepper' ) {
@@ -36,6 +37,7 @@ const RangeControl = memo(
 					onChange={ onChange }
 					separatorType={ separatorType }
 					value={ value }
+					disabled={ disabled }
 				/>
 			);
 		}
@@ -61,6 +63,7 @@ const RangeControl = memo(
 				allowReset={ allowReset }
 				defaultValue={ initialSliderValue }
 				separatorType={ separatorType }
+				disabled={ disabled }
 				{ ...props }
 			/>
 		);

--- a/packages/react-native-editor/CHANGELOG.md
+++ b/packages/react-native-editor/CHANGELOG.md
@@ -11,6 +11,7 @@ For each user feature we should also add a importance categorization label  to i
 
 ## Unreleased
 -   [**] Tapping on all nested blocks gets focus directly instead of having to tap multiple times depending on the nesting levels. [#50672]
+-   [*] Add disabled style to `Cell` component [#50665]
 
 ## 1.95.0
 -   [*] Fix crash when trying to convert to regular blocks an undefined/deleted reusable block [#50475]

--- a/test/native/__mocks__/styleMock.js
+++ b/test/native/__mocks__/styleMock.js
@@ -184,4 +184,7 @@ module.exports = {
 	'components-picker__button-title': {
 		color: 'white',
 	},
+	placeholderColor: {
+		color: 'gray',
+	},
 };


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Add disabled style to `Cell` component to reflect when a cell is disabled.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Disabling the `Cell` component didn't reflect any change in the UI, which is confusing to users.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Change the opacity of the value component (`Text` / `TextInput` components) when the `Cell` component is disabled.

Since this change might affect the different control components we use in the app, I checked the different components exported in the `@wordpress/components` package. The ones with ✅ are controls affected that have been verified:
- `TextControl` ✅
- `ColorControl` ✅
- `RangeControl - Slider` ✅
- `RangeControl - Stepper` ✅
- `ToggleControl` ✅ (This PR reverts https://github.com/WordPress/gutenberg/pull/50560 as now the disabled state is managed in the `Cell` component)
- `BottomSheetTextControl` ✅
- `BottomSheetSelectControl` ✅
- `CycleSelectControl` ✅
- `BaseControl` (cell not used)
- `TextareaControl` (cell not used)
- `SearchControl` (cell not used)
- `SelectControl` ✅
- `FooterMessageControl` (`disabled` not needed)
- `QueryControls` (composition of control components - `SelectControl` + `SelectControl` (`TreeSelect`) + `RangeControl`)
- `RadioControl` ✅
- `UnitControl` ✅
- `SegmentedControls` (cell not used)
- `SegmentedControl` (cell not used)

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

In order to test the different control components, I created a test component for this purpose.

1. Apply the following patch to incorporate the test component:

<details><summary>Click here to display patch</summary>

```patch
diff --git forkSrcPrefix/packages/edit-post/src/components/layout/index.native.js forkDstPrefix/packages/edit-post/src/components/layout/index.native.js
index a9c38ee1ccb8d5ea579a46bde8070edc372e8567..e0d2ea1c969805500405bbeb8c75255ebc08793b 100644
--- forkSrcPrefix/packages/edit-post/src/components/layout/index.native.js
+++ forkDstPrefix/packages/edit-post/src/components/layout/index.native.js
@@ -33,6 +33,7 @@ import headerToolbarStyles from '../header/header-toolbar/style.scss';
 import Header from '../header';
 import VisualEditor from '../visual-editor';
 import { store as editPostStore } from '../../store';
+import TestControls from './test-controls';
 
 class Layout extends Component {
 	constructor() {
@@ -149,6 +150,7 @@ class Layout extends Component {
 				>
 					<AutosaveMonitor disableIntervalChecks />
 					<View style={ editorStyles }>
+						<TestControls />
 						{ isHtmlView ? this.renderHTML() : this.renderVisual() }
 						{ ! isHtmlView && Platform.OS === 'android' && (
 							<FloatingToolbar />
diff --git forkSrcPrefix/packages/edit-post/src/components/layout/test-controls.js forkDstPrefix/packages/edit-post/src/components/layout/test-controls.js
new file mode 100644
index 0000000000000000000000000000000000000000..7dacdb799c72f42449bcd0d004f4352a5f6a0187
--- /dev/null
+++ forkDstPrefix/packages/edit-post/src/components/layout/test-controls.js
@@ -0,0 +1,221 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	PanelBody,
+	BottomSheet,
+	BottomSheetTextControl,
+	BottomSheetSelectControl,
+	FooterMessageControl,
+	RangeControl,
+	TextControl,
+	ColorControl,
+	ToggleControl,
+	CycleSelectControl,
+	SelectControl,
+	RadioControl,
+	UnitControl,
+	ColorSettings,
+} from '@wordpress/components';
+import { useState } from '@wordpress/element';
+import { useMultipleOriginColorsAndGradients } from '@wordpress/block-editor';
+
+/**
+ * External dependencies
+ */
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { useNavigation } from '@react-navigation/native';
+
+const TestControlsContainer = () => {
+	const colorSettings = useMultipleOriginColorsAndGradients();
+
+	return (
+		<BottomSheet
+			isVisible={ true }
+			onClose={ () => {} }
+			hideHeader
+			hasNavigation
+		>
+			<BottomSheet.NavigationContainer animate main>
+				<BottomSheet.NavigationScreen name={ 'main' }>
+					<TestControls />
+				</BottomSheet.NavigationScreen>
+				<BottomSheet.NavigationScreen
+					name={ BottomSheet.SubSheet.screenName }
+				>
+					<BottomSheet.SubSheet.Slot />
+				</BottomSheet.NavigationScreen>
+				<BottomSheet.NavigationScreen name="Color">
+					<ColorSettings defaultSettings={ colorSettings } />
+				</BottomSheet.NavigationScreen>
+			</BottomSheet.NavigationContainer>
+		</BottomSheet>
+	);
+};
+
+const TestControls = () => {
+	const [ controlsDisabled, setControlsDisabled ] = useState( true );
+
+	const [ selectValue, setSelectValue ] = useState( 1 );
+	const [ rangeValue, setRangeValue ] = useState( 0 );
+	const [ unitValue, setUnitValue ] = useState( 'px' );
+	const [ textValue, setTextValue ] = useState( 'example' );
+	const [ colorValue, setColorValue ] = useState( '#000000' );
+	const [ toggleValue, setToggleValue ] = useState( false );
+
+	const navigation = useNavigation();
+
+	return (
+		<>
+			<PanelBody title="Panel only for Testing">
+				<ToggleControl
+					label="Disable the below controls"
+					onChange={ setControlsDisabled }
+					checked={ controlsDisabled }
+				/>
+			</PanelBody>
+			<PanelBody title="Select Controls">
+				<BottomSheetSelectControl
+					label="BottomSheetSelectControl"
+					options={ [
+						{ value: 1, label: 'Value 1' },
+						{ value: 2, label: 'Value 2' },
+						{ value: 3, label: 'Value 3' },
+					] }
+					onChange={ setSelectValue }
+					value={ selectValue }
+					disabled={ controlsDisabled }
+				/>
+				<CycleSelectControl
+					label="CycleSelectControl"
+					onChange={ setSelectValue }
+					options={ [
+						{ value: 1, name: 'Value 1' },
+						{ value: 2, name: 'Value 2' },
+						{ value: 3, name: 'Value 3' },
+					] }
+					value={ selectValue }
+					disabled={ controlsDisabled }
+				/>
+				<SelectControl
+					label="SelectControl"
+					value={ selectValue }
+					onChange={ setSelectValue }
+					options={ [
+						{ value: 1, label: 'Value 1' },
+						{ value: 2, label: 'Value 2' },
+						{ value: 3, label: 'Value 3' },
+					] }
+					hideCancelButton
+					disabled={ controlsDisabled }
+				/>
+			</PanelBody>
+			<PanelBody title="Radio Control">
+				<RadioControl
+					selected={ selectValue }
+					options={ [
+						{ value: 1, label: 'Value 1' },
+						{ value: 2, label: 'Value 2' },
+						{ value: 3, label: 'Value 3' },
+					] }
+					onChange={ setSelectValue }
+					disabled={ controlsDisabled }
+				/>
+			</PanelBody>
+			<PanelBody title="Range Controls">
+				<RangeControl
+					label="RangeControl - Stepper"
+					value={ rangeValue }
+					onChange={ setRangeValue }
+					min={ 0 }
+					max={ 10 }
+					type="stepper"
+					disabled={ controlsDisabled }
+				/>
+				<RangeControl
+					label="RangeControl - Slider"
+					value={ rangeValue }
+					onChange={ setRangeValue }
+					min={ 0 }
+					max={ 10 }
+					disabled={ controlsDisabled }
+				/>
+				<UnitControl
+					label="UnitControl"
+					min={ 0 }
+					max={ 10 }
+					value={ rangeValue }
+					onChange={ setRangeValue }
+					onUnitChange={ setUnitValue }
+					unit={ unitValue }
+					units={ [
+						{
+							value: 'px',
+							label: 'px',
+							step: 1,
+						},
+						{
+							value: 'em',
+							label: 'em',
+							step: 0.1,
+						},
+					] }
+					disabled={ controlsDisabled }
+				/>
+			</PanelBody>
+			<PanelBody title="Text Controls">
+				<TextControl
+					value={ textValue }
+					onChange={ setTextValue }
+					placeholder="placeholder"
+					label="TextControl"
+					disabled={ controlsDisabled }
+				/>
+				<TextControl
+					value=""
+					onChange={ setTextValue }
+					placeholder="placeholder"
+					label="TextControl"
+					disabled={ controlsDisabled }
+				/>
+				<BottomSheetTextControl
+					initialValue={ textValue }
+					onChange={ setTextValue }
+					label="BottomSheetTextControl"
+					disabled={ controlsDisabled }
+				/>
+				<BottomSheetTextControl
+					onChange={ setTextValue }
+					placeholder="placeholder"
+					label="BottomSheetTextControl"
+					disabled={ controlsDisabled }
+				/>
+			</PanelBody>
+			<PanelBody title="Other controls">
+				<ColorControl
+					label="ColorControl"
+					color={ colorValue }
+					onPress={ () => {
+						navigation.navigate( 'Color', {
+							onColorChange: setColorValue,
+							colorValue,
+							onColorCleared: () => setColorValue( undefined ),
+							label: 'ColorControl',
+						} );
+					} }
+					withColorIndicator
+					disabled={ controlsDisabled }
+				/>
+				<ToggleControl
+					label="ToggleControl"
+					onChange={ setToggleValue }
+					checked={ toggleValue }
+					disabled={ controlsDisabled }
+				/>
+				<FooterMessageControl label="FooterMessageControl" />
+			</PanelBody>
+		</>
+	);
+};
+
+export default TestControlsContainer;

```

</details> 

2. Open a post/page in the app.
3. Observe that a bottom sheet is automatically open.
4. Observe that all displayed controls are disabled.
5. Enable the controls using the toggle located at the top of the sheet.
6. Observe that all displayed controls are enabled.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
N/A

## Screenshots or screencast <!-- if applicable -->

<details><summary><strong>Click here to show Android screenshots</strong></summary>

## Light mode
| Cell active | Cell disabled |
|--------|--------|
|  <img src=https://github.com/WordPress/gutenberg/assets/14905380/16908d8f-a0ab-47e9-9e3e-17e4362694c6 width=300> | <img src=https://github.com/WordPress/gutenberg/assets/14905380/14f2fdc7-9c76-4ed0-8bde-91a6a1e81367 width=300> | 
| <img src=https://github.com/WordPress/gutenberg/assets/14905380/a5e54d8a-17d4-4a1b-8513-176cc9e8a5ae width=300> | <img src=https://github.com/WordPress/gutenberg/assets/14905380/e42e3e56-09c9-49e6-8d92-6fd7769bfb4f width=300> | 
| <img src=https://github.com/WordPress/gutenberg/assets/14905380/231d5949-323b-4885-9c11-e46bef70599a width=300> | <img src=https://github.com/WordPress/gutenberg/assets/14905380/92b3210d-f1ef-4634-99e2-7023309ecdca width=300> |

## Dark mode
| Cell active | Cell disabled |
|--------|--------|
|  <img src=https://github.com/WordPress/gutenberg/assets/14905380/1ce74adf-a5c3-4c57-a36d-03b2d70c2a92 width=300> | <img src=https://github.com/WordPress/gutenberg/assets/14905380/fa8e3fb6-6f4a-4374-993e-25e00b0a289c width=300> | 
| <img src=https://github.com/WordPress/gutenberg/assets/14905380/777d5f6a-8ed8-417a-8355-000b68fbed4e width=300> | <img src=https://github.com/WordPress/gutenberg/assets/14905380/7ad69b28-4007-4708-ad7f-553c38952971 width=300> | 
| <img src=https://github.com/WordPress/gutenberg/assets/14905380/3cc416b3-2f28-409d-ba59-a2a62844c9f5 width=300> | <img src=https://github.com/WordPress/gutenberg/assets/14905380/be8f24ce-8001-4491-982b-a4c170f9204a width=300> |

</details> 

<details><summary><strong>Click here to show iOS screenshots</strong></summary>

## Light mode
| Cell active | Cell disabled |
|--------|--------|
|  <img src=https://github.com/WordPress/gutenberg/assets/14905380/bbc07700-967d-4aa5-acc1-441934704b39 width=300> | <img src=https://github.com/WordPress/gutenberg/assets/14905380/09225fd7-93ff-46a4-8fd1-bc96a58bee4e width=300> | 
| <img src=https://github.com/WordPress/gutenberg/assets/14905380/8eb7a6d4-96db-4c43-87fd-c7f210c18987 width=300> | <img src=https://github.com/WordPress/gutenberg/assets/14905380/14dd6b1e-6fef-4935-be97-91517dd01a3b width=300> | 
| <img src=https://github.com/WordPress/gutenberg/assets/14905380/dd2985bd-e255-4e46-80a3-724b7e2720a8 width=300> | <img src=https://github.com/WordPress/gutenberg/assets/14905380/b799ab4d-eaaf-4484-a9ba-8ce4c8fea8e2 width=300> |


## Dark mode
| Cell active | Cell disabled |
|--------|--------|
|  <img src=https://github.com/WordPress/gutenberg/assets/14905380/2eda2347-ebeb-48ed-ab83-fbea5c5471e5 width=300> | <img src=https://github.com/WordPress/gutenberg/assets/14905380/96044dbb-f549-4bc7-92bd-98cef8526f28 width=300> | 
| <img src=https://github.com/WordPress/gutenberg/assets/14905380/77b3d714-3f28-4777-ae68-914822cd9f07 width=300> | <img src=https://github.com/WordPress/gutenberg/assets/14905380/7959fd7e-7371-46b1-9874-c89f6d15bc13 width=300> | 
| <img src=https://github.com/WordPress/gutenberg/assets/14905380/6caa8fe6-8ae9-4a3a-807c-d1966fd4c959 width=300> | <img src=https://github.com/WordPress/gutenberg/assets/14905380/25ce3eb2-8a3f-403f-a6f6-8a8434efabd3 width=300> |

</details> 