### PR TITLE
Link Control require user to manually submit any changes

### DIFF
--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -231,6 +231,8 @@ function LinkControl( {
 
 	const hasLinkValue = value?.url?.trim()?.length > 0;
 
+	const settingsKeys = settings.map( ( { id } ) => id );
+
 	/**
 	 * Cancels editing state and marks that focus may need to be restored after
 	 * the next render, if focus was within the wrapper when editing finished.
@@ -245,8 +247,6 @@ function LinkControl( {
 	};
 
 	const handleSelectSuggestion = ( updatedValue ) => {
-		const settingsKeys = settings.map( ( { id } ) => id );
-
 		// Suggestions may contains "settings" values (e.g. `opensInNewTab`)
 		// which should not overide any existing settings values set by the
 		// user. This filters out any settings values from the suggestion.

--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -192,8 +192,8 @@ function LinkControl( {
 		) {
 			setIsEditingLink( forceIsEditingLink );
 		}
-		// eslint-disable-next-line react-hooks/exhaustive-deps
 		// Todo: bug if the missing dep is introduced. Will need a fix.
+		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [ forceIsEditingLink ] );
 
 	useEffect( () => {
@@ -242,19 +242,41 @@ function LinkControl( {
 	};
 
 	const handleSelectSuggestion = ( updatedValue ) => {
+		const settingsKeys = settings.map( ( { id } ) => id );
+
+		// Suggestions may contains "settings" values (e.g. `opensInNewTab`)
+		// which should not overide any existing settings values set by the
+		// user. This filters out any settings values from the suggestion.
+		const nonSettingsChanges = Object.keys( updatedValue ).reduce(
+			( acc, key ) => {
+				if ( ! settingsKeys.includes( key ) ) {
+					acc[ key ] = updatedValue[ key ];
+				}
+				return acc;
+			},
+			{}
+		);
+
 		onChange( {
-			...updatedValue,
+			...internalControlValue,
+			...nonSettingsChanges,
+			// As title is not a setting, it must be manually applied
+			// in such a way as to preserve the users changes over
+			// any "title" value provided by the "suggestion".
 			title: internalControlValue?.title || updatedValue?.title,
 		} );
+
 		stopEditing();
 	};
 
 	const handleSubmit = () => {
 		if ( valueHasChanges ) {
+			// Submit the original value with new stored values applied
+			// on top. URL is a special case as it may also be a prop.
 			onChange( {
 				...value,
+				...internalControlValue,
 				url: currentUrlInputValue,
-				title: internalControlValue?.title,
 			} );
 		}
 		stopEditing();

--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -146,7 +146,7 @@ function LinkControl( {
 		setInternalControlValue,
 		setInternalURLInputValue,
 		setInternalTextInputValue,
-		setInternalSettingValue,
+		createSetInternalSettingValueHandler,
 	] = useInternalValue( value );
 
 	const valueHasChanges =
@@ -388,7 +388,9 @@ function LinkControl( {
 							handleSubmitWithEnter={ handleSubmitWithEnter }
 							value={ internalControlValue }
 							settings={ settings }
-							onChange={ setInternalSettingValue( settingsKeys ) }
+							onChange={ createSetInternalSettingValueHandler(
+								settingsKeys
+							) }
 						/>
 					) }
 

--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -160,16 +160,19 @@ function LinkControl( {
 	};
 
 	const setInternalSettingValue = ( nextValue ) => {
-		const nonSettingsKeys = [ 'url', 'title' ];
+		const settingsKeys = settings.map( ( { id } ) => id );
+
+		// Only apply settings values which are defined in the settings prop.
 		const settingsUpdates = Object.keys( nextValue ).reduce(
 			( acc, key ) => {
-				if ( ! nonSettingsKeys?.includes( key ) ) {
+				if ( settingsKeys.includes( key ) ) {
 					acc[ key ] = nextValue[ key ];
 				}
 				return acc;
 			},
 			{}
 		);
+
 		setInternalControlValue( {
 			...internalControlValue,
 			...settingsUpdates,

--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -145,10 +145,8 @@ function LinkControl( {
 	// const [ internalTextInputValue?.title, setInternalTextInputValue ] =
 	// 	useInternalInputValue( value?.title || '' );
 
-	const valueHasChanges = ! isShallowEqualObjects(
-		internalControlValue,
-		value
-	);
+	const valueHasChanges =
+		value && ! isShallowEqualObjects( internalControlValue, value );
 
 	const setInternalURLInputValue = ( nextValue ) => {
 		setInternalControlValue( {
@@ -281,7 +279,8 @@ function LinkControl( {
 		onCancel?.();
 	};
 
-	const currentUrlInputValue = propInputValue || internalControlValue?.url;
+	const currentUrlInputValue =
+		propInputValue || internalControlValue?.url || '';
 
 	const currentInputIsEmpty = ! currentUrlInputValue?.trim()?.length;
 

--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -162,6 +162,22 @@ function LinkControl( {
 		} );
 	};
 
+	const setInternalSettingValue = ( nextValue ) => {
+		const settingUpdates = Object.keys( nextValue ).reduce(
+			( acc, key ) => {
+				if ( key !== 'url' && key !== 'title' ) {
+					acc[ key ] = nextValue[ key ];
+				}
+				return acc;
+			},
+			{}
+		);
+		setInternalControlValue( {
+			...internalControlValue,
+			...settingUpdates,
+		} );
+	};
+
 	const [ isEditingLink, setIsEditingLink ] = useState(
 		forceIsEditingLink !== undefined
 			? forceIsEditingLink
@@ -376,9 +392,9 @@ function LinkControl( {
 								setInternalTextInputValue
 							}
 							handleSubmitWithEnter={ handleSubmitWithEnter }
-							value={ value }
+							value={ internalControlValue }
 							settings={ settings }
-							onChange={ onChange }
+							onChange={ setInternalSettingValue }
 						/>
 					) }
 

--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -137,47 +137,20 @@ function LinkControl( {
 	const textInputRef = useRef();
 	const isEndingEditWithFocus = useRef( false );
 
+	const settingsKeys = settings.map( ( { id } ) => id );
+
 	const [ settingsOpen, setSettingsOpen ] = useState( false );
 
-	const [ internalControlValue, setInternalControlValue ] =
-		useInternalValue( value );
+	const [
+		internalControlValue,
+		setInternalControlValue,
+		setInternalURLInputValue,
+		setInternalTextInputValue,
+		setInternalSettingValue,
+	] = useInternalValue( value );
 
 	const valueHasChanges =
 		value && ! isShallowEqualObjects( internalControlValue, value );
-
-	const setInternalURLInputValue = ( nextValue ) => {
-		setInternalControlValue( {
-			...internalControlValue,
-			url: nextValue,
-		} );
-	};
-
-	const setInternalTextInputValue = ( nextValue ) => {
-		setInternalControlValue( {
-			...internalControlValue,
-			title: nextValue,
-		} );
-	};
-
-	const setInternalSettingValue = ( nextValue ) => {
-		const settingsKeys = settings.map( ( { id } ) => id );
-
-		// Only apply settings values which are defined in the settings prop.
-		const settingsUpdates = Object.keys( nextValue ).reduce(
-			( acc, key ) => {
-				if ( settingsKeys.includes( key ) ) {
-					acc[ key ] = nextValue[ key ];
-				}
-				return acc;
-			},
-			{}
-		);
-
-		setInternalControlValue( {
-			...internalControlValue,
-			...settingsUpdates,
-		} );
-	};
 
 	const [ isEditingLink, setIsEditingLink ] = useState(
 		forceIsEditingLink !== undefined
@@ -230,8 +203,6 @@ function LinkControl( {
 	}, [ isEditingLink, isCreatingPage ] );
 
 	const hasLinkValue = value?.url?.trim()?.length > 0;
-
-	const settingsKeys = settings.map( ( { id } ) => id );
 
 	/**
 	 * Cancels editing state and marks that focus may need to be restored after
@@ -417,7 +388,7 @@ function LinkControl( {
 							handleSubmitWithEnter={ handleSubmitWithEnter }
 							value={ internalControlValue }
 							settings={ settings }
-							onChange={ setInternalSettingValue }
+							onChange={ setInternalSettingValue( settingsKeys ) }
 						/>
 					) }
 

--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -142,9 +142,6 @@ function LinkControl( {
 	const [ internalControlValue, setInternalControlValue ] =
 		useInternalInputValue( value );
 
-	// const [ internalTextInputValue?.title, setInternalTextInputValue ] =
-	// 	useInternalInputValue( value?.title || '' );
-
 	const valueHasChanges =
 		value && ! isShallowEqualObjects( internalControlValue, value );
 
@@ -163,9 +160,10 @@ function LinkControl( {
 	};
 
 	const setInternalSettingValue = ( nextValue ) => {
-		const settingUpdates = Object.keys( nextValue ).reduce(
+		const nonSettingsKeys = [ 'url', 'title' ];
+		const settingsUpdates = Object.keys( nextValue ).reduce(
 			( acc, key ) => {
-				if ( key !== 'url' && key !== 'title' ) {
+				if ( ! nonSettingsKeys?.includes( key ) ) {
 					acc[ key ] = nextValue[ key ];
 				}
 				return acc;
@@ -174,7 +172,7 @@ function LinkControl( {
 		);
 		setInternalControlValue( {
 			...internalControlValue,
-			...settingUpdates,
+			...settingsUpdates,
 		} );
 	};
 

--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -20,7 +20,7 @@ import LinkControlSettingsDrawer from './settings-drawer';
 import LinkControlSearchInput from './search-input';
 import LinkPreview from './link-preview';
 import useCreatePage from './use-create-page';
-import useInternalInputValue from './use-internal-input-value';
+import useInternalValue from './use-internal-value';
 import { ViewerFill } from './viewer-slot';
 import { DEFAULT_LINK_SETTINGS } from './constants';
 
@@ -140,7 +140,7 @@ function LinkControl( {
 	const [ settingsOpen, setSettingsOpen ] = useState( false );
 
 	const [ internalControlValue, setInternalControlValue ] =
-		useInternalInputValue( value );
+		useInternalValue( value );
 
 	const valueHasChanges =
 		value && ! isShallowEqualObjects( internalControlValue, value );

--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -248,9 +248,10 @@ function LinkControl( {
 
 	const handleSubmitWithEnter = ( event ) => {
 		const { keyCode } = event;
+
 		if (
 			keyCode === ENTER &&
-			currentInputIsEmpty // Disallow submitting empty values.
+			! currentInputIsEmpty // Disallow submitting empty values.
 		) {
 			event.preventDefault();
 			handleSubmit();

--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -140,7 +140,7 @@ function LinkControl( {
 	const [ settingsOpen, setSettingsOpen ] = useState( false );
 
 	const [ internalControlValue, setInternalControlValue ] =
-		useInternalInputValue( value || {} );
+		useInternalInputValue( value );
 
 	// const [ internalTextInputValue?.title, setInternalTextInputValue ] =
 	// 	useInternalInputValue( value?.title || '' );

--- a/packages/block-editor/src/components/link-control/test/index.js
+++ b/packages/block-editor/src/components/link-control/test/index.js
@@ -1784,6 +1784,57 @@ describe( 'Addition Settings UI', () => {
 			} )
 		).toBeChecked();
 	} );
+
+	it( 'should require settings changes to be submitted/applied', async () => {
+		const user = userEvent.setup();
+
+		const mockOnChange = jest.fn();
+
+		const selectedLink = fauxEntitySuggestions[ 0 ];
+
+		render(
+			<LinkControl
+				value={ selectedLink }
+				forceIsEditingLink
+				hasTextControl
+				onChange={ mockOnChange }
+			/>
+		);
+
+		// check that the "Apply" button is disabled by default.
+		const submitButton = screen.queryByRole( 'button', {
+			name: 'Apply',
+		} );
+
+		expect( submitButton ).toBeDisabled();
+
+		await toggleSettingsDrawer( user );
+
+		const opensInNewTabToggle = screen.queryByRole( 'checkbox', {
+			name: 'Open in new tab',
+		} );
+
+		// toggle the checkbox
+		await user.click( opensInNewTabToggle );
+
+		// Check settings are **not** directly submitted
+		// which would trigger the onChange handler.
+		expect( mockOnChange ).not.toHaveBeenCalled();
+
+		// Check Apply button is now enabled because changes
+		// have been detected.
+		expect( submitButton ).toBeEnabled();
+
+		// Submit the changed setting value using the Apply button
+		await user.click( submitButton );
+
+		// Assert the value is updated.
+		expect( mockOnChange ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				opensInNewTab: true,
+			} )
+		);
+	} );
 } );
 
 describe( 'Post types', () => {

--- a/packages/block-editor/src/components/link-control/test/index.js
+++ b/packages/block-editor/src/components/link-control/test/index.js
@@ -2236,7 +2236,7 @@ describe( 'Controlling link title text', () => {
 		).not.toBeInTheDocument();
 	} );
 
-	it( 'should reset state on value change', async () => {
+	it( 'should reset state upon controlled value change', async () => {
 		const user = userEvent.setup();
 		const textValue = 'My new text value';
 		const mockOnChange = jest.fn();

--- a/packages/block-editor/src/components/link-control/test/index.js
+++ b/packages/block-editor/src/components/link-control/test/index.js
@@ -2199,7 +2199,7 @@ describe( 'Controlling link title text', () => {
 
 	it( 'should allow `ENTER` keypress within the text field to trigger submission of value', async () => {
 		const user = userEvent.setup();
-		const textValue = 'My new text value';
+		const newTextValue = 'My new text value';
 		const mockOnChange = jest.fn();
 
 		render(
@@ -2218,14 +2218,14 @@ describe( 'Controlling link title text', () => {
 		expect( textInput ).toBeVisible();
 
 		await user.clear( textInput );
-		await user.keyboard( textValue );
+		await user.keyboard( newTextValue );
 
 		// Attempt to submit the empty search value in the input.
 		triggerEnter( textInput );
 
 		expect( mockOnChange ).toHaveBeenCalledWith(
 			expect.objectContaining( {
-				title: textValue,
+				title: newTextValue,
 				url: selectedLink.url,
 			} )
 		);

--- a/packages/block-editor/src/components/link-control/test/index.js
+++ b/packages/block-editor/src/components/link-control/test/index.js
@@ -1790,7 +1790,13 @@ describe( 'Addition Settings UI', () => {
 
 		const mockOnChange = jest.fn();
 
-		const selectedLink = fauxEntitySuggestions[ 0 ];
+		const selectedLink = {
+			...fauxEntitySuggestions[ 0 ],
+			// Including a setting here helps to assert on a potential bug
+			// whereby settings on the suggestion override the current (internal)
+			// settings values set by the user in the UI.
+			opensInNewTab: false,
+		};
 
 		render(
 			<LinkControl

--- a/packages/block-editor/src/components/link-control/use-internal-input-value.js
+++ b/packages/block-editor/src/components/link-control/use-internal-input-value.js
@@ -5,7 +5,7 @@ import { useState, useEffect } from '@wordpress/element';
 
 export default function useInternalInputValue( value ) {
 	const [ internalInputValue, setInternalInputValue ] = useState(
-		value || ''
+		value || {}
 	);
 
 	// If the value prop changes, update the internal state.

--- a/packages/block-editor/src/components/link-control/use-internal-value.js
+++ b/packages/block-editor/src/components/link-control/use-internal-value.js
@@ -3,14 +3,12 @@
  */
 import { useState, useEffect } from '@wordpress/element';
 
-export default function useInternalInputValue( value ) {
-	const [ internalInputValue, setInternalInputValue ] = useState(
-		value || {}
-	);
+export default function useInternalValue( value ) {
+	const [ internalValue, setInternalValue ] = useState( value || {} );
 
 	// If the value prop changes, update the internal state.
 	useEffect( () => {
-		setInternalInputValue( ( prevValue ) => {
+		setInternalValue( ( prevValue ) => {
 			if ( value && value !== prevValue ) {
 				return value;
 			}
@@ -19,5 +17,5 @@ export default function useInternalInputValue( value ) {
 		} );
 	}, [ value ] );
 
-	return [ internalInputValue, setInternalInputValue ];
+	return [ internalValue, setInternalValue ];
 }

--- a/packages/block-editor/src/components/link-control/use-internal-value.js
+++ b/packages/block-editor/src/components/link-control/use-internal-value.js
@@ -31,29 +31,30 @@ export default function useInternalValue( value ) {
 		} );
 	};
 
-	const setInternalSettingValue = ( settingsKeys ) => ( nextValue ) => {
-		// Only apply settings values which are defined in the settings prop.
-		const settingsUpdates = Object.keys( nextValue ).reduce(
-			( acc, key ) => {
-				if ( settingsKeys.includes( key ) ) {
-					acc[ key ] = nextValue[ key ];
-				}
-				return acc;
-			},
-			{}
-		);
+	const createSetInternalSettingValueHandler =
+		( settingsKeys ) => ( nextValue ) => {
+			// Only apply settings values which are defined in the settings prop.
+			const settingsUpdates = Object.keys( nextValue ).reduce(
+				( acc, key ) => {
+					if ( settingsKeys.includes( key ) ) {
+						acc[ key ] = nextValue[ key ];
+					}
+					return acc;
+				},
+				{}
+			);
 
-		setInternalValue( {
-			...internalValue,
-			...settingsUpdates,
-		} );
-	};
+			setInternalValue( {
+				...internalValue,
+				...settingsUpdates,
+			} );
+		};
 
 	return [
 		internalValue,
 		setInternalValue,
 		setInternalURLInputValue,
 		setInternalTextInputValue,
-		setInternalSettingValue,
+		createSetInternalSettingValueHandler,
 	];
 }

--- a/packages/block-editor/src/components/link-control/use-internal-value.js
+++ b/packages/block-editor/src/components/link-control/use-internal-value.js
@@ -17,5 +17,43 @@ export default function useInternalValue( value ) {
 		} );
 	}, [ value ] );
 
-	return [ internalValue, setInternalValue ];
+	const setInternalURLInputValue = ( nextValue ) => {
+		setInternalValue( {
+			...internalValue,
+			url: nextValue,
+		} );
+	};
+
+	const setInternalTextInputValue = ( nextValue ) => {
+		setInternalValue( {
+			...internalValue,
+			title: nextValue,
+		} );
+	};
+
+	const setInternalSettingValue = ( settingsKeys ) => ( nextValue ) => {
+		// Only apply settings values which are defined in the settings prop.
+		const settingsUpdates = Object.keys( nextValue ).reduce(
+			( acc, key ) => {
+				if ( settingsKeys.includes( key ) ) {
+					acc[ key ] = nextValue[ key ];
+				}
+				return acc;
+			},
+			{}
+		);
+
+		setInternalValue( {
+			...internalValue,
+			...settingsUpdates,
+		} );
+	};
+
+	return [
+		internalValue,
+		setInternalValue,
+		setInternalURLInputValue,
+		setInternalTextInputValue,
+		setInternalSettingValue,
+	];
 }

--- a/packages/e2e-tests/specs/editor/various/links.test.js
+++ b/packages/e2e-tests/specs/editor/various/links.test.js
@@ -793,7 +793,7 @@ describe( 'Links', () => {
 			await settingsToggle.click();
 
 			// Move focus back to RichText for the underlying link.
-			await pressKeyTimes( 'Tab', 5 );
+			await pressKeyTimes( 'Tab', 4 );
 
 			// Make a selection within the RichText.
 			await pressKeyWithModifier( 'shift', 'ArrowRight' );

--- a/packages/e2e-tests/specs/editor/various/links.test.js
+++ b/packages/e2e-tests/specs/editor/various/links.test.js
@@ -792,6 +792,9 @@ describe( 'Links', () => {
 			);
 			await settingsToggle.click();
 
+			// Wait for settings to open.
+			await page.waitForXPath( `//label[text()='Open in new tab']` );
+
 			// Move focus back to RichText for the underlying link.
 			await pressKeyTimes( 'Tab', 4 );
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Requires users to _manually_ **submit** any changes to link "settings" (e.g. `Open in new tab` .etc) in the Link UI.

⚠️ This means that simply toggling the `Opens in new tab` will _not_ automatically submit the value.

Closes https://github.com/WordPress/gutenberg/issues/50945


## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Since the inception of `<LinkControl>` toggling a setting (e.g. `Open in new tab`) meant that the Link UI automatically submitted itself. This was intended functionality but the implementation had bugs. 

For example when users made a change to the link _URL_ or _Text_, and then subsequently toggled the `Open in new tab`, the value would get submitted _with_ the change to the `opensInNewTab` setting, but _without_ the changes to the URL or Text.

This is not the correct behaviour and often resulted in confusion when changes to the URL of Text were not persisted.

We could have changed this so that toggling the toggle submits the _entire_ value including changes to URL and Text, but that seems strange when we have an `Apply` button that implies _all_ changes must be manually submitted. Let's lean on that.

This PR changes things so that all changes to settings must be submitted using `Apply`. Clicking `Cancel` or otherwise opting out will cause the change to the toggle to be discarded.

This UX expectation is reinforced by only enabling the `Apply` button when any part of the value has changed.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Rework the tracking of the internal (unsubmitted) values to track the _entire_ `value` object and not just the `url` or `title` fields.

The purpose of the internal state is to track any as yet unsubmitted changes to the link. This is in order to allow users to discard their changes at any point.

Therefore we must check whether the internal state now differs from the original `value` passed in. We can safely (and quickly thanks to referential equality) do this with the shallow equality utility as the properties of the `value` are always shallow.

With this in place we can selectively track changes to the intenral link value and only submit when the user is ready. Moreover we can improve the UI to only enable `Apply` when changes have been made thereby providing an improved UX.



## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

Repeat the steps below in the places Link Control is used:

- Rich Text (e.g. paragraph)
- Nav block

Steps:

- Create a link.
- Check that the `Apply` button is not enabled unless you make changes to that link value in some way
- Check particularly that toggling "Open in new tab" doesn't cause the UI to submit/close.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/444434/a00321d8-c2c6-4894-8aae-d9e93102efc0

