### PR TITLE
Fix custom duotone filters in frontend

### DIFF
--- a/lib/experimental/kses.php
+++ b/lib/experimental/kses.php
@@ -78,7 +78,7 @@ add_action( 'set_current_user', 'gutenberg_override_core_kses_init_filters' );
  */
 function allow_filter_in_styles( $allow_css, $css_test_string ) {
 	if ( preg_match(
-		"/^filter:\s*url\('#wp-duotone-[-a-zA-Z0-9]+'\) !important$/",
+		"/^filter:\s*url\((['\"]?)#wp-duotone-[-a-zA-Z0-9]+\\1\)(\s+!important)?$/",
 		$css_test_string
 	) ) {
 		return true;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes an issue where custom duotone filters weren't rendering to the page due to kses.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Bug fix

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Makes the kses filter more forgiving by:
1. Allowing CSS urls with single, double, or no quotes around the path.
2. Making `!important` optional at the end.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Create a post with a block using custom duotone filters
2. Save and view the post. Duotone filters should show correctly.

<details>
<summary>Example Post Content</summary>

This example makes 2 assumptions about your theme.
1. A `contrast` duotone filter is defined.
2. A filter is applied via theme.json styles to the image and cover blocks.

```html
<!-- wp:heading -->
<h2 class="wp-block-heading">Duotone core preset</h2>
<!-- /wp:heading -->

<!-- wp:cover {"url":"http://placekitten.com/800/400","dimRatio":0,"isDark":false,"style":{"color":{"duotone":"var:preset|duotone|midnight"}}} -->
<div class="wp-block-cover is-light"><span aria-hidden="true" class="wp-block-cover__background has-background-dim-0 has-background-dim"></span><img class="wp-block-cover__image-background" alt="" src="http://placekitten.com/800/400" data-object-fit="cover"/><div class="wp-block-cover__inner-container"><!-- wp:paragraph {"align":"center","placeholder":"Write title…","fontSize":"large"} -->
<p class="has-text-align-center has-large-font-size">Preset slug: midnight</p>
<!-- /wp:paragraph --></div></div>
<!-- /wp:cover -->

<!-- wp:heading -->
<h2 class="wp-block-heading">Duotone theme preset</h2>
<!-- /wp:heading -->

<!-- wp:cover {"url":"http://placekitten.com/800/400","dimRatio":0,"isDark":false,"style":{"color":{"duotone":"var:preset|duotone|contrast"}}} -->
<div class="wp-block-cover is-light"><span aria-hidden="true" class="wp-block-cover__background has-background-dim-0 has-background-dim"></span><img class="wp-block-cover__image-background" alt="" src="http://placekitten.com/800/400" data-object-fit="cover"/><div class="wp-block-cover__inner-container"><!-- wp:paragraph {"align":"center","placeholder":"Write title…","fontSize":"large"} -->
<p class="has-text-align-center has-large-font-size">Preset slug: contrast</p>
<!-- /wp:paragraph --></div></div>
<!-- /wp:cover -->

<!-- wp:heading -->
<h2 class="wp-block-heading">Duotone custom filter</h2>
<!-- /wp:heading -->

<!-- wp:cover {"url":"http://placekitten.com/800/400","dimRatio":0,"isDark":false,"style":{"color":{"duotone":["rgb(92, 51, 10)","#fcf2e8"]}}} -->
<div class="wp-block-cover is-light"><span aria-hidden="true" class="wp-block-cover__background has-background-dim-0 has-background-dim"></span><img class="wp-block-cover__image-background" alt="" src="http://placekitten.com/800/400" data-object-fit="cover"/><div class="wp-block-cover__inner-container"><!-- wp:paragraph {"align":"center","placeholder":"Write title…","fontSize":"large"} -->
<p class="has-text-align-center has-large-font-size">Custom sepia filter</p>
<!-- /wp:paragraph --></div></div>
<!-- /wp:cover -->

<!-- wp:heading -->
<h2 class="wp-block-heading">Duotone unset</h2>
<!-- /wp:heading -->

<!-- wp:cover {"url":"http://placekitten.com/800/400","dimRatio":0,"isDark":false,"style":{"color":{"duotone":"unset"}}} -->
<div class="wp-block-cover is-light"><span aria-hidden="true" class="wp-block-cover__background has-background-dim-0 has-background-dim"></span><img class="wp-block-cover__image-background" alt="" src="http://placekitten.com/800/400" data-object-fit="cover"/><div class="wp-block-cover__inner-container"><!-- wp:paragraph {"align":"center","placeholder":"Write title…","fontSize":"large"} -->
<p class="has-text-align-center has-large-font-size">This should never have a filter applied.</p>
<!-- /wp:paragraph --></div></div>
<!-- /wp:cover -->

<!-- wp:heading -->
<h2 class="wp-block-heading">Duotone theme.json styles (plain block)</h2>
<!-- /wp:heading -->

<!-- wp:cover {"url":"http://placekitten.com/800/400","dimRatio":0,"isDark":false} -->
<div class="wp-block-cover is-light"><span aria-hidden="true" class="wp-block-cover__background has-background-dim-0 has-background-dim"></span><img class="wp-block-cover__image-background" alt="" src="http://placekitten.com/800/400" data-object-fit="cover"/><div class="wp-block-cover__inner-container"><!-- wp:paragraph {"align":"center","placeholder":"Write title…"} -->
<p class="has-text-align-center">This depends on <code>styles.blocks['core/cover'].filter.duotone being set</code> to the CSS custom property for a preset.</p>
<!-- /wp:paragraph --></div></div>
<!-- /wp:cover -->

<!-- wp:heading -->
<h2 class="wp-block-heading">Image core preset</h2>
<!-- /wp:heading -->

<!-- wp:image {"style":{"color":{"duotone":"var:preset|duotone|midnight"}}} -->
<figure class="wp-block-image"><img src="http://placekitten.com/800/400" alt=""/><figcaption class="wp-element-caption">Preset slug: midnight</figcaption></figure>
<!-- /wp:image -->

<!-- wp:heading -->
<h2 class="wp-block-heading">Image theme preset</h2>
<!-- /wp:heading -->

<!-- wp:image {"style":{"color":{"duotone":"var:preset|duotone|contrast"}}} -->
<figure class="wp-block-image"><img src="http://placekitten.com/800/400" alt=""/><figcaption class="wp-element-caption">Preset slug: contrast</figcaption></figure>
<!-- /wp:image -->

<!-- wp:heading -->
<h2 class="wp-block-heading">Image custom filter</h2>
<!-- /wp:heading -->

<!-- wp:image {"style":{"color":{"duotone":["rgb(92, 51, 10)","#fcf2e8"]}}} -->
<figure class="wp-block-image"><img src="http://placekitten.com/800/400" alt=""/><figcaption class="wp-element-caption">Custom sepia filter</figcaption></figure>
<!-- /wp:image -->

<!-- wp:heading -->
<h2 class="wp-block-heading">Image unset</h2>
<!-- /wp:heading -->

<!-- wp:image {"style":{"color":{"duotone":"unset"}}} -->
<figure class="wp-block-image"><img src="http://placekitten.com/800/400" alt=""/><figcaption class="wp-element-caption">This should never have a filter applied</figcaption></figure>
<!-- /wp:image -->

<!-- wp:heading -->
<h2 class="wp-block-heading">Image theme.json styles (plain block)</h2>
<!-- /wp:heading -->

<!-- wp:image {"style":{"color":{}}} -->
<figure class="wp-block-image"><img src="http://placekitten.com/800/400" alt=""/><figcaption class="wp-element-caption"><code>styles.blocks['core/image'].filter.duotone</code></figcaption></figure>
<!-- /wp:image -->
```

</details>

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
