### PR TITLE
Create pages before navigation tests requiring link control to find page results

### DIFF
--- a/test/e2e/specs/editor/blocks/navigation.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation.spec.js
@@ -396,6 +396,26 @@ test.describe( 'Navigation block', () => {
 			<!-- /wp:navigation-submenu -->`,
 		};
 
+		test.beforeAll( async ( { requestUtils } ) => {
+			// We need pages to be published so the Link Control can return pages
+			await requestUtils.createPage( {
+				title: 'Test Page 1',
+				status: 'publish',
+			} );
+			await requestUtils.createPage( {
+				title: 'Test Page 2',
+				status: 'publish',
+			} );
+			await requestUtils.createPage( {
+				title: 'Test Page 3',
+				status: 'publish',
+			} );
+		} );
+
+		test.afterAll( async ( { requestUtils } ) => {
+			await requestUtils.deleteAllPages();
+		} );
+
 		test.use( {
 			linkControl: async ( { page }, use ) => {
 				await use( new LinkControl( { page } ) );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Tests were failing due to [the Link Control not containing any pages](https://github.com/WordPress/gutenberg/blob/trunk/test/e2e/specs/editor/blocks/navigation.spec.js#L557) in its search results.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
There were no pages on the site running for tests, so no pages were returned in the search API query.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Before all the tests in this section, create three pages so the Link Control has pages. It's unclear to me how these were passing before.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
`npm run test:e2e:playwright -- editor/blocks/navigation.spec.js -g "List view editing"` will run all the tests that this impacts.
