### PR TITLE
Fix BlockPatternSetup toolbar #50683 

### DIFF
--- a/packages/block-editor/src/components/block-pattern-setup/style.scss
+++ b/packages/block-editor/src/components/block-pattern-setup/style.scss
@@ -78,6 +78,7 @@
 		color: $gray-900;
 		position: absolute;
 		bottom: 0;
+		left: 0;
 		// Block UI appearance.
 		background-color: $white;
 		display: flex;


### PR DESCRIPTION
## What?
Fix #50683 

## Why?
The block pattern are wrongly positioned inside a modal, due to position absolute conflicting with modal padding.

## How?
Adding `left: 0` will solve the problem.

## Testing Instructions
1. Use a BlockPatternSetup inside a modal or simply download [Formello](https://it.wordpress.org/plugins/formello/)
2. Try to navigate between patter, the arrow are incorrectly positioned
3. See screenshot


## Screenshots or screencast
![image](https://github.com/WordPress/gutenberg/assets/1663035/21ab2e35-3b12-4f1e-82fc-3271d71ce2a5)

