### PR TITLE
Cover: Unlock private APIs outside of the component

### DIFF
--- a/packages/block-library/src/cover/edit/resizable-cover-popover.js
+++ b/packages/block-library/src/cover/edit/resizable-cover-popover.js
@@ -25,6 +25,8 @@ const RESIZABLE_BOX_ENABLE_OPTION = {
 	topLeft: false,
 };
 
+const { ResizableBoxPopover } = unlock( blockEditorPrivateApis );
+
 export default function ResizableCoverPopover( {
 	className,
 	height,
@@ -37,7 +39,6 @@ export default function ResizableCoverPopover( {
 	width,
 	...props
 } ) {
-	const { ResizableBoxPopover } = unlock( blockEditorPrivateApis );
 	const [ isResizing, setIsResizing ] = useState( false );
 	const dimensions = useMemo(
 		() => ( { height, minHeight, width } ),


### PR DESCRIPTION
## What?
Related: https://github.com/WordPress/gutenberg/pull/50509.

PR moves unlocking of the private components outside the function.

## Why?
The private components can be unlocked at the file level. There's no need to perform the action on each component re-render.

## Testing Instructions
Confirm that the Cover block resizing works as before. See #41153. 
