### PR TITLE
List View: Try a slightly more accurate and flexible approach for drag to top and bottom

### DIFF
--- a/packages/block-editor/src/components/list-view/index.js
+++ b/packages/block-editor/src/components/list-view/index.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import classNames from 'classnames';
+
+/**
  * WordPress dependencies
  */
 import {
@@ -59,6 +64,7 @@ export const BLOCK_LIST_ITEM_HEIGHT = 36;
  * @param {Object}         props                         Components props.
  * @param {string}         props.id                      An HTML element id for the root element of ListView.
  * @param {Array}          props.blocks                  _deprecated_ Custom subset of block client IDs to be used instead of the default hierarchy.
+ * @param {?string}        props.className               Optional class name to add to the TreeGrid element.
  * @param {?boolean}       props.showBlockMovers         Flag to enable block movers. Defaults to `false`.
  * @param {?boolean}       props.isExpanded              Flag to determine whether nested levels are expanded by default. Defaults to `false`.
  * @param {?boolean}       props.showAppender            Flag to show or hide the block appender. Defaults to `false`.
@@ -73,6 +79,7 @@ function ListViewComponent(
 	{
 		id,
 		blocks,
+		className,
 		showBlockMovers = false,
 		isExpanded = false,
 		showAppender = false,
@@ -237,7 +244,10 @@ function ListViewComponent(
 			/>
 			<TreeGrid
 				id={ id }
-				className="block-editor-list-view-tree"
+				className={ classNames(
+					'block-editor-list-view-tree',
+					className
+				) }
 				aria-label={ __( 'Block navigation structure' ) }
 				ref={ treeGridRef }
 				onCollapseRow={ collapseRow }

--- a/packages/block-editor/src/components/list-view/use-list-view-drop-zone.js
+++ b/packages/block-editor/src/components/list-view/use-list-view-drop-zone.js
@@ -378,7 +378,12 @@ export default function useListViewDropZone() {
 	const draggedBlockClientIds = getDraggedBlockClientIds();
 	const throttled = useThrottle(
 		useCallback(
-			( event, currentTarget ) => {
+			( event, currentTarget, action ) => {
+				if ( action === 'clear' ) {
+					setTarget( null );
+					return;
+				}
+
 				const position = { x: event.clientX, y: event.clientY };
 				const isBlockDrag = !! draggedBlockClientIds?.length;
 
@@ -433,6 +438,9 @@ export default function useListViewDropZone() {
 
 	const ref = useDropZone( {
 		onDrop: onBlockDrop,
+		onDragLeave( event ) {
+			throttled( event, event.currentTarget, 'clear' );
+		},
 		onDragOver( event ) {
 			// `currentTarget` is only available while the event is being
 			// handled, so get it now and pass it to the thottled function.

--- a/packages/edit-post/src/components/secondary-sidebar/list-view-sidebar.js
+++ b/packages/edit-post/src/components/secondary-sidebar/list-view-sidebar.js
@@ -152,7 +152,7 @@ export default function ListViewSidebar() {
 			>
 				{ tab === 'list-view' && (
 					<div className="edit-post-editor__list-view-panel-content">
-						<ListView />
+						<ListView className="edit-post-editor__list-view-panel-content__list-view" />
 					</div>
 				) }
 				{ tab === 'outline' && <ListViewOutline /> }

--- a/packages/edit-post/src/components/secondary-sidebar/style.scss
+++ b/packages/edit-post/src/components/secondary-sidebar/style.scss
@@ -83,6 +83,18 @@
 	padding: $grid-unit-10 ($grid-unit-10 - $border-width - $border-width);
 }
 
+.edit-post-editor__list-view-panel-content {
+	padding: 0;
+}
+
+.edit-post-editor__list-view-panel-content__list-view {
+	padding: $grid-unit-10 ($grid-unit-10 - $border-width - $border-width);
+	// Override the border collapse set by the TreeGrid table.
+	// This is so that the panel's height and padding can take effect.
+	border-collapse: separate;
+	border-spacing: 0;
+}
+
 .edit-post-editor__list-view-empty-headings {
 	& > svg {
 		margin-top: $grid-unit-30 + $grid-unit-05;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

TBC, this is an exploration into an alternative to https://github.com/WordPress/gutenberg/pull/49420.

The goal is to slightly expand the area of the drop zone for the list view in the sidebar, and to hide the drop indicator when a valid drop will not occur (so that the presence of the drop indicator more accurately reflects what's going to happen when a user releases the mouse button)

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

TBC

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

TBC

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

TBC

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
