### PR TITLE
[RNMobile] Add Group and Ungroup block actions

### DIFF
--- a/packages/block-editor/src/components/block-mobile-toolbar/block-actions-menu.native.js
+++ b/packages/block-editor/src/components/block-mobile-toolbar/block-actions-menu.native.js
@@ -39,6 +39,10 @@ import { store as coreStore } from '@wordpress/core-data';
 import { getMoversSetup } from '../block-mover/mover-description';
 import { store as blockEditorStore } from '../../store';
 import BlockTransformationsMenu from '../block-switcher/block-transformations-menu';
+import {
+	useConvertToGroupButtons,
+	useConvertToGroupButtonProps,
+} from '../convert-to-group-buttons';
 
 const BlockActionsMenu = ( {
 	// Select.
@@ -55,6 +59,7 @@ const BlockActionsMenu = ( {
 	rootClientId,
 	selectedBlockClientId,
 	selectedBlockPossibleTransformations,
+	canRemove,
 	// Dispatch.
 	createSuccessNotice,
 	convertToRegularBlocks,
@@ -92,6 +97,17 @@ const BlockActionsMenu = ( {
 			forward: forwardButtonTitle,
 		},
 	} = getMoversSetup( isStackedHorizontally, moversOptions );
+
+	// Check if selected block is Groupable and/or Ungroupable.
+	const convertToGroupButtonProps = useConvertToGroupButtonProps( [
+		selectedBlockClientId,
+	] );
+	const { isGroupable, isUngroupable } = convertToGroupButtonProps;
+	const showConvertToGroupButton =
+		( isGroupable || isUngroupable ) && canRemove;
+	const convertToGroupButtons = useConvertToGroupButtons( {
+		...convertToGroupButtonProps,
+	} );
 
 	const allOptions = {
 		settings: {
@@ -229,6 +245,10 @@ const BlockActionsMenu = ( {
 		canDuplicate && allOptions.cutButton,
 		canDuplicate && isPasteEnabled && allOptions.pasteButton,
 		canDuplicate && allOptions.duplicateButton,
+		showConvertToGroupButton && isGroupable && convertToGroupButtons.group,
+		showConvertToGroupButton &&
+			isUngroupable &&
+			convertToGroupButtons.ungroup,
 		isReusableBlockType &&
 			innerBlockCount > 0 &&
 			allOptions.convertToRegularBlocks,
@@ -327,6 +347,7 @@ export default compose(
 			getSelectedBlockClientIds,
 			canInsertBlockType,
 			getTemplateLock,
+			canRemoveBlock,
 		} = select( blockEditorStore );
 		const block = getBlock( clientId );
 		const blockName = getBlockName( clientId );
@@ -363,6 +384,7 @@ export default compose(
 		const selectedBlockPossibleTransformations = selectedBlock
 			? getBlockTransformItems( selectedBlock, rootClientId )
 			: EMPTY_BLOCK_LIST;
+		const canRemove = canRemoveBlock( selectedBlockClientId );
 
 		const isReusableBlockType = block ? isReusableBlock( block ) : false;
 		const reusableBlock = isReusableBlockType
@@ -388,6 +410,7 @@ export default compose(
 			rootClientId,
 			selectedBlockClientId,
 			selectedBlockPossibleTransformations,
+			canRemove,
 		};
 	} ),
 	withDispatch(

--- a/packages/block-editor/src/components/convert-to-group-buttons/index.native.js
+++ b/packages/block-editor/src/components/convert-to-group-buttons/index.native.js
@@ -1,1 +1,79 @@
-export default () => null;
+/**
+ * WordPress dependencies
+ */
+import { __, _x } from '@wordpress/i18n';
+import { switchToBlockType } from '@wordpress/blocks';
+import { useDispatch } from '@wordpress/data';
+import { store as noticesStore } from '@wordpress/notices';
+
+/**
+ * Internal dependencies
+ */
+import { store as blockEditorStore } from '../../store';
+import useConvertToGroupButtonProps from './use-convert-to-group-button-props';
+
+function useConvertToGroupButtons( {
+	clientIds,
+	onUngroup,
+	blocksSelection,
+	groupingBlockName,
+} ) {
+	const { replaceBlocks } = useDispatch( blockEditorStore );
+	const { createSuccessNotice } = useDispatch( noticesStore );
+	const onConvertToGroup = () => {
+		// Activate the `transform` on the Grouping Block which does the conversion.
+		const newBlocks = switchToBlockType(
+			blocksSelection,
+			groupingBlockName
+		);
+		if ( newBlocks ) {
+			replaceBlocks( clientIds, newBlocks );
+		}
+	};
+
+	const onConvertFromGroup = () => {
+		let innerBlocks = blocksSelection[ 0 ].innerBlocks;
+		if ( ! innerBlocks.length ) {
+			return;
+		}
+		if ( onUngroup ) {
+			innerBlocks = onUngroup(
+				blocksSelection[ 0 ].attributes,
+				blocksSelection[ 0 ].innerBlocks
+			);
+		}
+		replaceBlocks( clientIds, innerBlocks );
+	};
+
+	return {
+		group: {
+			id: 'groupButtonOption',
+			label: _x( 'Group', 'verb' ),
+			value: 'groupButtonOption',
+			onSelect: () => {
+				onConvertToGroup();
+				createSuccessNotice(
+					// translators: displayed right after the block is grouped
+					__( 'Block grouped' )
+				);
+			},
+		},
+		ungroup: {
+			id: 'ungroupButtonOption',
+			label: _x(
+				'Ungroup',
+				'Ungrouping blocks from within a grouping block back into individual blocks within the Editor'
+			),
+			value: 'ungroupButtonOption',
+			onSelect: () => {
+				onConvertFromGroup();
+				createSuccessNotice(
+					// translators: displayed right after the block is ungrouped.
+					__( 'Block ungrouped' )
+				);
+			},
+		},
+	};
+}
+
+export { useConvertToGroupButtons, useConvertToGroupButtonProps };

--- a/packages/block-library/src/columns/test/__snapshots__/transforms.native.js.snap
+++ b/packages/block-library/src/columns/test/__snapshots__/transforms.native.js.snap
@@ -34,7 +34,7 @@ exports[`Columns block transforms to Group block 1`] = `
 <!-- /wp:group -->"
 `;
 
-exports[`Columns block transforms unwraps content 1`] = `
+exports[`Columns block transforms ungroups block 1`] = `
 "<!-- wp:paragraph {"align":"left"} -->
 <p class="has-text-align-left"><strong>Built with modern technology.</strong></p>
 <!-- /wp:paragraph -->

--- a/packages/block-library/src/columns/test/transforms.native.js
+++ b/packages/block-library/src/columns/test/transforms.native.js
@@ -60,14 +60,13 @@ describe( `${ block } block transforms`, () => {
 		expect( getEditorHtml() ).toMatchSnapshot();
 	} );
 
-	it( 'unwraps content', async () => {
+	it( 'ungroups block', async () => {
 		const screen = await initializeEditor( { initialHtml } );
 		const { getByText } = screen;
 		fireEvent.press( getBlock( screen, block ) );
 
 		await openBlockActionsMenu( screen );
-		fireEvent.press( getByText( 'Transform block…' ) );
-		fireEvent.press( getByText( 'Unwrap' ) );
+		fireEvent.press( getByText( 'Ungroup' ) );
 
 		// The first block created is the content of the Paragraph block.
 		const paragraph = getBlock( screen, 'Paragraph', 0 );
@@ -83,8 +82,7 @@ describe( `${ block } block transforms`, () => {
 		const screen = await initializeEditor( { initialHtml } );
 		const transformOptions = await getBlockTransformOptions(
 			screen,
-			block,
-			{ canUnwrap: true }
+			block
 		);
 		expect( transformOptions ).toHaveLength( blockTransforms.length );
 	} );

--- a/packages/block-library/src/group/test/__snapshots__/transforms.native.js.snap
+++ b/packages/block-library/src/group/test/__snapshots__/transforms.native.js.snap
@@ -20,7 +20,7 @@ exports[`Group block transforms to Columns block 1`] = `
 <!-- /wp:columns -->"
 `;
 
-exports[`Group block transforms unwraps content 1`] = `
+exports[`Group block transforms ungroups block 1`] = `
 "<!-- wp:paragraph -->
 <p>One.</p>
 <!-- /wp:paragraph -->

--- a/packages/block-library/src/group/test/transforms.native.js
+++ b/packages/block-library/src/group/test/transforms.native.js
@@ -44,14 +44,13 @@ describe( `${ block } block transforms`, () => {
 		expect( getEditorHtml() ).toMatchSnapshot();
 	} );
 
-	it( 'unwraps content', async () => {
+	it( 'ungroups block', async () => {
 		const screen = await initializeEditor( { initialHtml } );
 		const { getByText } = screen;
 		fireEvent.press( getBlock( screen, block ) );
 
 		await openBlockActionsMenu( screen );
-		fireEvent.press( getByText( 'Transform block…' ) );
-		fireEvent.press( getByText( 'Unwrap' ) );
+		fireEvent.press( getByText( 'Ungroup' ) );
 
 		// The first block created is the content of the Paragraph block.
 		const paragraph = getBlock( screen, 'Paragraph', 0 );
@@ -67,8 +66,7 @@ describe( `${ block } block transforms`, () => {
 		const screen = await initializeEditor( { initialHtml } );
 		const transformOptions = await getBlockTransformOptions(
 			screen,
-			block,
-			{ canUnwrap: true }
+			block
 		);
 		expect( transformOptions ).toHaveLength( blockTransforms.length );
 	} );

--- a/packages/block-library/src/quote/test/__snapshots__/transforms.native.js.snap
+++ b/packages/block-library/src/quote/test/__snapshots__/transforms.native.js.snap
@@ -28,7 +28,7 @@ exports[`Quote block transforms to Pullquote block 1`] = `
 <!-- /wp:pullquote -->"
 `;
 
-exports[`Quote block transforms unwraps content 1`] = `
+exports[`Quote block transforms ungroups block 1`] = `
 "<!-- wp:paragraph -->
 <p>"This will make running your own blog a viable alternative again."</p>
 <!-- /wp:paragraph -->

--- a/packages/block-library/src/quote/test/transforms.native.js
+++ b/packages/block-library/src/quote/test/transforms.native.js
@@ -36,14 +36,13 @@ describe( `${ block } block transforms`, () => {
 		expect( getEditorHtml() ).toMatchSnapshot();
 	} );
 
-	it( 'unwraps content', async () => {
+	it( 'ungroups block', async () => {
 		const screen = await initializeEditor( { initialHtml } );
 		const { getByText } = screen;
 		fireEvent.press( getBlock( screen, block ) );
 
 		await openBlockActionsMenu( screen );
-		fireEvent.press( getByText( 'Transform block…' ) );
-		fireEvent.press( getByText( 'Unwrap' ) );
+		fireEvent.press( getByText( 'Ungroup' ) );
 
 		// The first block created is the content of the Paragraph block.
 		const paragraph = getBlock( screen, 'Paragraph', 0 );
@@ -59,8 +58,7 @@ describe( `${ block } block transforms`, () => {
 		const screen = await initializeEditor( { initialHtml } );
 		const transformOptions = await getBlockTransformOptions(
 			screen,
-			block,
-			{ canUnwrap: true }
+			block
 		);
 		expect( transformOptions ).toHaveLength( blockTransforms.length );
 	} );

--- a/test/native/integration-test-helpers/get-block-transform-options.js
+++ b/test/native/integration-test-helpers/get-block-transform-options.js
@@ -12,36 +12,18 @@ import { openBlockActionsMenu } from './open-block-actions-menu';
 /**
  * Transforms the selected block to a specified block.
  *
- * @param {import('@testing-library/react-native').RenderAPI} screen              A Testing Library screen.
- * @param {string}                                            blockName           Name of the block.
- * @param {Object}                                            [options]           Configuration options.
- * @param {number}                                            [options.canUnwrap] True if the block can be unwrapped.
+ * @param {import('@testing-library/react-native').RenderAPI} screen    A Testing Library screen.
+ * @param {string}                                            blockName Name of the block.
  * @return {[import('react-test-renderer').ReactTestInstance]} Block transform options.
  */
-export const getBlockTransformOptions = async (
-	screen,
-	blockName,
-	{ canUnwrap = false } = {}
-) => {
+export const getBlockTransformOptions = async ( screen, blockName ) => {
 	const { getByTestId, getByText } = screen;
 
 	fireEvent.press( getBlock( screen, blockName ) );
 	await openBlockActionsMenu( screen );
 	fireEvent.press( getByText( 'Transform block…' ) );
 
-	let blockTransformButtons = within(
-		getByTestId( 'block-transformations-menu' )
-	).getAllByRole( 'button' );
-
-	// Remove Unwrap option as it's not a direct block transformation.
-	if ( canUnwrap ) {
-		const unwrapButton = within(
-			getByTestId( 'block-transformations-menu' )
-		).getByLabelText( 'Unwrap' );
-		blockTransformButtons = blockTransformButtons.filter(
-			( button ) => button !== unwrapButton
-		);
-	}
-
-	return blockTransformButtons;
+	return within( getByTestId( 'block-transformations-menu' ) ).getAllByRole(
+		'button'
+	);
 };


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This PR incorporates the Group and Ungroup block actions to match the web version.

<img src=https://github.com/WordPress/gutenberg/assets/14905380/0c45ef68-27c8-4420-81fc-b71b152fce9f width=600>

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Currently, grouped blocks can be unwrapped via the `unwrap` transform option. This option will be removed in https://github.com/WordPress/gutenberg/pull/50385 in favor of Ungroup block action. Hence, we need to incorporate it in the native version.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* Create the hook `useConvertToGroupButtons` that returns the Group and Ungroup options to use in the block actions menu. The logic for this hook is very similar to [the `ConvertToGroupButton` component](https://github.com/WordPress/gutenberg/blob/2452a92dce0e2db2b8b58be3089e7c31e4f74b45/packages/block-editor/src/components/convert-to-group-buttons/index.js#L16-L75), the main difference is that the latter returns a component.
* Group and Ungroup options have been added to the block actions menu. The logic to determine if they should be displayed has been based on the web version ([reference](https://github.com/WordPress/gutenberg/blob/2452a92dce0e2db2b8b58be3089e7c31e4f74b45/packages/block-editor/src/components/block-settings-menu-controls/index.js#L81-L86)).

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

### Group/Ungroup
1. Open a post/page in the app.
2. Add any block and select it.
3. Tap on the ⚙️ button to open the block actions menu.
4. Observe that the "Group" option is displayed.
5. Tap on the "Group" option.
6. Observe a Group block is created and the selected block is inserted into it.
7. Observe that a notice is displayed with the message: "Block grouped".
8. Tap on the ⚙️ button to open the block actions menu.
9. Observe that the "Ungroup" option is displayed.
10. Tap on the "Ungroup" option.
11. Observe that the Group block is removed and the inner block is now at the root level.
12. Observe that a notice is displayed with the message: "Block ungrouped".

### Ungroup is not displayed on empty groups
1. Open a post/page in the app.
2. Add a Group block.
3. Do not add content to the blocks.
4. Tap on the ⚙️ button to open the block actions menu.
5. Observe that the "Ungroup" option is not displayed.
6. Add Quote and Columns blocks.
7. Observe that blocks are empty.
8. Tap on the ⚙️ button to open the block actions menu.
9. Observe that the "Ungroup" option is displayed.
10. Tap on the "Ungroup" option.
11. Observe the block is transformed depending on the block type:
    1. **Quote block:** Results in an empty Paragraph block.
    2. **Columns block:** Removes the block.

### Unwrap transform is not displayed
1. Open a post/page in the app.
3. Insert `Group`, `Quote`, `Columns` blocks.
4. Add content to the block.
5. Tap on the ⚙️ button to open the block actions menu.
6. Observe that the "Ungroup" option is displayed.
13. Tap on the "Transform block..." option.
14. Observe that the `unwrap` option is not displayed.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
N/A

## Screenshots or screencast <!-- if applicable -->
<img src=https://github.com/WordPress/gutenberg/assets/14905380/5ed53f55-2f01-46d4-a462-2fb00f30311e width=250>


