### PR TITLE
Add SelectControl to change post-template markup.

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -62,7 +62,7 @@ Prompt visitors to take action with a group of button-style links. ([Source](htt
 -	**Name:** core/buttons
 -	**Category:** design
 -	**Supports:** align (full, wide), anchor, layout (default, ~~allowInheriting~~, ~~allowSwitching~~), spacing (blockGap, margin), typography (fontSize, lineHeight), ~~html~~
--	**Attributes:**
+-	**Attributes:** 
 
 ## Calendar
 
@@ -173,7 +173,7 @@ Contains the block elements used to display a comment, like the title, date, aut
 -	**Category:** design
 -	**Parent:** core/comments
 -	**Supports:** align, spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
--	**Attributes:**
+-	**Attributes:** 
 
 ## Comments
 
@@ -212,7 +212,7 @@ Displays a list of page numbers for comments pagination. ([Source](https://githu
 -	**Category:** theme
 -	**Parent:** core/comments-pagination
 -	**Supports:** color (background, gradients, ~~text~~), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
--	**Attributes:**
+-	**Attributes:** 
 
 ## Comments Previous Page
 
@@ -276,7 +276,7 @@ Add a link to a downloadable file. ([Source](https://github.com/WordPress/gutenb
 -	**Name:** core/footnotes
 -	**Category:** text
 -	**Supports:** color (background, link, text), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~, ~~multiple~~, ~~reusable~~
--	**Attributes:**
+-	**Attributes:** 
 
 ## Classic
 
@@ -452,7 +452,7 @@ Separate your content into a multi-page experience. ([Source](https://github.com
 -	**Category:** design
 -	**Parent:** core/post-content
 -	**Supports:** ~~className~~, ~~customClassName~~, ~~html~~
--	**Attributes:**
+-	**Attributes:** 
 
 ## Page List
 
@@ -564,7 +564,7 @@ Displays the contents of a post or page. ([Source](https://github.com/WordPress/
 -	**Name:** core/post-content
 -	**Category:** theme
 -	**Supports:** align (full, wide), color (background, gradients, link, text), dimensions (minHeight), layout, typography (fontSize, lineHeight), ~~html~~
--	**Attributes:**
+-	**Attributes:** 
 
 ## Date
 
@@ -675,7 +675,7 @@ Contains the block elements used to render content when no query results are fou
 -	**Category:** theme
 -	**Parent:** core/query
 -	**Supports:** align, color (background, gradients, link, text), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
--	**Attributes:**
+-	**Attributes:** 
 
 ## Pagination
 
@@ -705,7 +705,7 @@ Displays a list of page numbers for pagination ([Source](https://github.com/Word
 -	**Category:** theme
 -	**Parent:** core/query-pagination
 -	**Supports:** color (background, gradients, ~~text~~), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
--	**Attributes:**
+-	**Attributes:** 
 
 ## Previous Page
 

--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -62,7 +62,7 @@ Prompt visitors to take action with a group of button-style links. ([Source](htt
 -	**Name:** core/buttons
 -	**Category:** design
 -	**Supports:** align (full, wide), anchor, layout (default, ~~allowInheriting~~, ~~allowSwitching~~), spacing (blockGap, margin), typography (fontSize, lineHeight), ~~html~~
--	**Attributes:** 
+-	**Attributes:**
 
 ## Calendar
 
@@ -173,7 +173,7 @@ Contains the block elements used to display a comment, like the title, date, aut
 -	**Category:** design
 -	**Parent:** core/comments
 -	**Supports:** align, spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
--	**Attributes:** 
+-	**Attributes:**
 
 ## Comments
 
@@ -212,7 +212,7 @@ Displays a list of page numbers for comments pagination. ([Source](https://githu
 -	**Category:** theme
 -	**Parent:** core/comments-pagination
 -	**Supports:** color (background, gradients, ~~text~~), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
--	**Attributes:** 
+-	**Attributes:**
 
 ## Comments Previous Page
 
@@ -276,7 +276,7 @@ Add a link to a downloadable file. ([Source](https://github.com/WordPress/gutenb
 -	**Name:** core/footnotes
 -	**Category:** text
 -	**Supports:** color (background, link, text), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~, ~~multiple~~, ~~reusable~~
--	**Attributes:** 
+-	**Attributes:**
 
 ## Classic
 
@@ -452,7 +452,7 @@ Separate your content into a multi-page experience. ([Source](https://github.com
 -	**Category:** design
 -	**Parent:** core/post-content
 -	**Supports:** ~~className~~, ~~customClassName~~, ~~html~~
--	**Attributes:** 
+-	**Attributes:**
 
 ## Page List
 
@@ -564,7 +564,7 @@ Displays the contents of a post or page. ([Source](https://github.com/WordPress/
 -	**Name:** core/post-content
 -	**Category:** theme
 -	**Supports:** align (full, wide), color (background, gradients, link, text), dimensions (minHeight), layout, typography (fontSize, lineHeight), ~~html~~
--	**Attributes:** 
+-	**Attributes:**
 
 ## Date
 
@@ -610,7 +610,7 @@ Contains the block elements used to render a post, like the title, date, feature
 -	**Category:** theme
 -	**Parent:** core/query
 -	**Supports:** align (full, wide), color (background, gradients, link, text), layout, spacing (blockGap), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
--	**Attributes:** 
+-	**Attributes:** tagName
 
 ## Post Terms
 
@@ -675,7 +675,7 @@ Contains the block elements used to render content when no query results are fou
 -	**Category:** theme
 -	**Parent:** core/query
 -	**Supports:** align, color (background, gradients, link, text), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
--	**Attributes:** 
+-	**Attributes:**
 
 ## Pagination
 
@@ -705,7 +705,7 @@ Displays a list of page numbers for pagination ([Source](https://github.com/Word
 -	**Category:** theme
 -	**Parent:** core/query-pagination
 -	**Supports:** color (background, gradients, ~~text~~), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
--	**Attributes:** 
+-	**Attributes:**
 
 ## Previous Page
 

--- a/packages/block-library/src/post-template/block.json
+++ b/packages/block-library/src/post-template/block.json
@@ -15,6 +15,12 @@
 		"templateSlug",
 		"previewPostType"
 	],
+	"attributes": {
+		"tagName": {
+			"type": "string",
+			"default": "ul"
+		}
+	},
 	"supports": {
 		"reusable": false,
 		"html": false,

--- a/packages/block-library/src/post-template/edit.js
+++ b/packages/block-library/src/post-template/edit.js
@@ -12,12 +12,13 @@ import { __ } from '@wordpress/i18n';
 import {
 	BlockControls,
 	BlockContextProvider,
+	InspectorControls,
 	__experimentalUseBlockPreview as useBlockPreview,
 	useBlockProps,
 	useInnerBlocksProps,
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
-import { Spinner, ToolbarGroup } from '@wordpress/components';
+import { SelectControl, Spinner, ToolbarGroup } from '@wordpress/components';
 import { store as coreStore } from '@wordpress/core-data';
 import { list, grid } from '@wordpress/icons';
 
@@ -27,12 +28,12 @@ const TEMPLATE = [
 	[ 'core/post-excerpt' ],
 ];
 
-function PostTemplateInnerBlocks() {
+function PostTemplateInnerBlocks( { tagName: TagName = 'li' } ) {
 	const innerBlocksProps = useInnerBlocksProps(
 		{ className: 'wp-block-post' },
 		{ template: TEMPLATE, __unstableDisableLayoutClassNames: true }
 	);
-	return <li { ...innerBlocksProps } />;
+	return <TagName { ...innerBlocksProps } />;
 }
 
 function PostTemplateBlockPreview( {
@@ -40,6 +41,7 @@ function PostTemplateBlockPreview( {
 	blockContextId,
 	isHidden,
 	setActiveBlockContextId,
+	tagName: TagName = 'li',
 } ) {
 	const blockPreviewProps = useBlockPreview( {
 		blocks,
@@ -57,7 +59,7 @@ function PostTemplateBlockPreview( {
 	};
 
 	return (
-		<li
+		<TagName
 			{ ...blockPreviewProps }
 			tabIndex={ 0 }
 			// eslint-disable-next-line jsx-a11y/no-noninteractive-element-to-interactive-role
@@ -100,7 +102,7 @@ export default function PostTemplateEdit( {
 		templateSlug,
 		previewPostType,
 	},
-	attributes: { layout },
+	attributes: { layout, tagName: TagName = 'ul' },
 	__unstableLayoutClassNames,
 } ) {
 	const { type: layoutType, columnCount = 3 } = layout || {};
@@ -273,8 +275,22 @@ export default function PostTemplateEdit( {
 			<BlockControls>
 				<ToolbarGroup controls={ displayLayoutControls } />
 			</BlockControls>
+			<InspectorControls group="advanced">
+				<SelectControl
+					__nextHasNoMarginBottom
+					label={ __( 'Posts HTML element' ) }
+					options={ [
+						{ label: __( 'Default (<ul>)' ), value: 'ul' },
+						{ label: '<div>', value: 'div' },
+					] }
+					value={ TagName }
+					onChange={ ( value ) =>
+						setAttributes( { tagName: value } )
+					}
+				/>
+			</InspectorControls>
 
-			<ul { ...blockProps }>
+			<TagName { ...blockProps }>
 				{ blockContexts &&
 					blockContexts.map( ( blockContext ) => (
 						<BlockContextProvider
@@ -284,7 +300,9 @@ export default function PostTemplateEdit( {
 							{ blockContext.postId ===
 							( activeBlockContextId ||
 								blockContexts[ 0 ]?.postId ) ? (
-								<PostTemplateInnerBlocks />
+								<PostTemplateInnerBlocks
+									tagName={ TagName === 'ul' ? 'li' : 'div' }
+								/>
 							) : null }
 							<MemoizedPostTemplateBlockPreview
 								blocks={ blocks }
@@ -297,10 +315,11 @@ export default function PostTemplateEdit( {
 									( activeBlockContextId ||
 										blockContexts[ 0 ]?.postId )
 								}
+								tagName={ TagName === 'ul' ? 'li' : 'div' }
 							/>
 						</BlockContextProvider>
 					) ) }
-			</ul>
+			</TagName>
 		</>
 	);
 }

--- a/packages/block-library/src/post-template/editor.scss
+++ b/packages/block-library/src/post-template/editor.scss
@@ -1,5 +1,5 @@
 .editor-styles-wrapper {
-	ul.wp-block-post-template {
+	.wp-block-post-template {
 		padding-left: 0;
 		margin-left: 0;
 		list-style: none;

--- a/packages/block-library/src/post-template/index.php
+++ b/packages/block-library/src/post-template/index.php
@@ -79,6 +79,8 @@ function render_block_core_post_template( $attributes, $content, $block ) {
 		$classnames .= ' ' . sanitize_title( 'columns-' . $attributes['layout']['columnCount'] );
 	}
 
+	$wrapper_tag_name   = isset( $attributes['tagName'] ) ? $attributes['tagName'] : 'ul';
+	$item_tag_name      = 'ul' === $wrapper_tag_name ? 'li' : 'div';
 	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => trim( $classnames ) ) );
 
 	$content = '';
@@ -107,9 +109,9 @@ function render_block_core_post_template( $attributes, $content, $block ) {
 		$block_content = ( new WP_Block( $block_instance ) )->render( array( 'dynamic' => false ) );
 		remove_filter( 'render_block_context', $filter_block_context, 1 );
 
-		// Wrap the render inner blocks in a `li` element with the appropriate post classes.
+		// Wrap the render inner blocks in a `li`or `div` element with the appropriate post classes.
 		$post_classes = implode( ' ', get_post_class( 'wp-block-post' ) );
-		$content     .= '<li class="' . esc_attr( $post_classes ) . '">' . $block_content . '</li>';
+		$content     .= '<' . $item_tag_name . ' class="' . esc_attr( $post_classes ) . '">' . $block_content . '</' . $item_tag_name . '>';
 	}
 
 	/*
@@ -120,7 +122,8 @@ function render_block_core_post_template( $attributes, $content, $block ) {
 	wp_reset_postdata();
 
 	return sprintf(
-		'<ul %1$s>%2$s</ul>',
+		'<%1$s %2$s>%3$s</%1$s>',
+		tag_escape( $wrapper_tag_name ),
 		$wrapper_attributes,
 		$content
 	);

--- a/packages/block-library/src/post-template/style.scss
+++ b/packages/block-library/src/post-template/style.scss
@@ -16,14 +16,14 @@
 		flex-wrap: wrap;
 		gap: 1.25em;
 
-		> li {
+		> * {
 			margin: 0;
 			width: 100%;
 		}
 
 		@include break-small {
 			@for $i from 2 through 6 {
-				&.is-flex-container.columns-#{ $i } > li {
+				&.is-flex-container.columns-#{ $i } > * {
 					width: calc((100% / #{ $i }) - 1.25em + (1.25em / #{ $i }));
 				}
 			}

--- a/test/integration/fixtures/blocks/core__post-template.json
+++ b/test/integration/fixtures/blocks/core__post-template.json
@@ -2,7 +2,9 @@
 	{
 		"name": "core/post-template",
 		"isValid": true,
-		"attributes": {},
+		"attributes": {
+			"tagName": "ul"
+		},
 		"innerBlocks": []
 	}
 ]

--- a/test/integration/fixtures/blocks/core__query__deprecated-2-with-colors.json
+++ b/test/integration/fixtures/blocks/core__query__deprecated-2-with-colors.json
@@ -48,6 +48,7 @@
 						"name": "core/post-template",
 						"isValid": true,
 						"attributes": {
+							"tagName": "ul",
 							"layout": {
 								"type": "default"
 							}

--- a/test/integration/fixtures/blocks/core__query__deprecated-2.json
+++ b/test/integration/fixtures/blocks/core__query__deprecated-2.json
@@ -28,6 +28,7 @@
 				"name": "core/post-template",
 				"isValid": true,
 				"attributes": {
+					"tagName": "ul",
 					"layout": {
 						"type": "default"
 					}

--- a/test/integration/fixtures/blocks/core__query__deprecated-3.json
+++ b/test/integration/fixtures/blocks/core__query__deprecated-3.json
@@ -45,6 +45,7 @@
 						"name": "core/post-template",
 						"isValid": true,
 						"attributes": {
+							"tagName": "ul",
 							"fontSize": "large",
 							"layout": {
 								"type": "grid",

--- a/test/integration/fixtures/blocks/core__query__deprecated-4.json
+++ b/test/integration/fixtures/blocks/core__query__deprecated-4.json
@@ -28,6 +28,7 @@
 				"name": "core/post-template",
 				"isValid": true,
 				"attributes": {
+					"tagName": "ul",
 					"layout": {
 						"type": "default"
 					}

--- a/test/integration/fixtures/blocks/core__query__deprecated-5.json
+++ b/test/integration/fixtures/blocks/core__query__deprecated-5.json
@@ -27,6 +27,7 @@
 				"name": "core/post-template",
 				"isValid": true,
 				"attributes": {
+					"tagName": "ul",
 					"layout": {
 						"type": "default"
 					}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Add a SelectControl to change Post Template markup to `ul` or `div`.

## Why?
fix #50627. #37659 will also be fixed IMO.

## How?

Add `SelectControl` for change markup to Post Template block. The default value is ul > li for markup. This can now be changed to div > div.

Also changed so that styles like `.column-3 > li` are applied to elements that are not `li`.

## Testing Instructions
1. Open site editor.
2. Select Post Template block
3. Open advanced panel.
4. Chenge SelectControl value.
5. Check markup in editor and website view.

## Screenshots or screencast <!-- if applicable -->

![](https://github.com/WordPress/gutenberg/assets/1908815/59349b78-1113-4040-b060-e4affa1bb9e2)

https://github.com/WordPress/gutenberg/assets/1908815/500b9b24-7352-4c6f-9ed3-140b20866688


