### PR TITLE
Fix release performance tests

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -54,7 +54,7 @@ jobs:
                   WP_VERSION=$(awk -F ': ' '/^Tested up to/{print $2}' readme.txt)
                   IFS=. read -ra WP_VERSION_ARRAY <<< "$WP_VERSION"
                   WP_MAJOR="${WP_VERSION_ARRAY[0]}.${WP_VERSION_ARRAY[1]}"
-                  ./bin/plugin/cli.js perf "wp/$WP_MAJOR" "$PREVIOUS_RELEASE_BRANCH" "$CURRENT_RELEASE_BRANCH" --wp-version "$WP_MAJOR"
+                  ./bin/plugin/cli.js perf "wp/$WP_MAJOR" "$PREVIOUS_RELEASE_BRANCH" "$CURRENT_RELEASE_BRANCH" --tests-branch $GITHUB_SHA --wp-version "$WP_MAJOR"
 
             - name: Compare performance with base branch
               if: github.event_name == 'push'


### PR DESCRIPTION
## What?

The disparity between the `performance.js` runner source and the tests' source is causing the release perf tests to fail. The error is that the tests are saving result artifacts under a different name than the perf script is expecting them to be, so it cannot find them. For example, we can look at the [most recent release perf job](https://github.com/WordPress/gutenberg/actions/runs/4940023826/jobs/8831319111). The command is:

```shell
./bin/plugin/cli.js perf "wp/$WP_MAJOR" "$PREVIOUS_RELEASE_BRANCH" "$CURRENT_RELEASE_BRANCH" --wp-version "$WP_MAJOR"
```

...which values for that run are:

```
./bin/plugin/cli.js perf wp/6.2 release/15.7 release/15.8 --wp-version 6.2
```

- The source of the workflow and the `performance.js` script is the branch that the job is dispatched from, which is actually a tag ref `tags/v15.8.0-rc.1`.
- The **source of the tests** is the first branch to be compared, which is `wp/6.2`, hence the disparity.


## How?

The fix is to make the tests source the same as the runner source (`GITHUB_SHA`).

## Testing Instructions

The next release perf tests should pass.
