### PR TITLE
Add wide align support to code block

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -86,7 +86,7 @@ Display code snippets that respect your spacing and tabs. ([Source](https://gith
 
 -	**Name:** core/code
 -	**Category:** text
--	**Supports:** anchor, color (background, gradients, text), spacing (margin, padding), typography (fontSize, lineHeight)
+-	**Supports:** align (wide), anchor, color (background, gradients, text), spacing (margin, padding), typography (fontSize, lineHeight)
 -	**Attributes:** content
 
 ## Column

--- a/packages/block-library/src/code/block.json
+++ b/packages/block-library/src/code/block.json
@@ -14,6 +14,7 @@
 		}
 	},
 	"supports": {
+		"align": [ "wide" ],
 		"anchor": true,
 		"typography": {
 			"fontSize": true,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
I noticed today that there's not support for alignwide on the code block. Especially for blogs that leverage wide imagery and other content, I'd expect to also make the code block a wide width. 

If so, you could achieve more expressive, and cohesive, designs like this, where everything other than text is wide width.  

<img width="1236" alt="CleanShot 2023-05-17 at 12 11 39" src="https://github.com/WordPress/gutenberg/assets/1813435/4c5a0edd-79a9-4f92-9b05-18c80ed22d66">

## Why?
Design tooling.

## How?
Block.json supports.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a Post or Page.
2. Insert a Code block.
3. Set it to "Wide width" via the block toolbar.

## Screenshots or screencast <!-- if applicable -->

| Before  | After |
| ------------- | ------------- |
|<img width="663" alt="CleanShot 2023-05-17 at 12 01 06" src="https://github.com/WordPress/gutenberg/assets/1813435/1c1b570b-f083-4d00-8e22-abb4b9686cfd">|<img width="838" alt="CleanShot 2023-05-17 at 12 09 23" src="https://github.com/WordPress/gutenberg/assets/1813435/803046c3-5a76-418f-8331-586e3067585c">|
