### PR TITLE
Navigation: Respect showAppender when there are no items in list view.

### DIFF
--- a/packages/block-editor/src/components/list-view/index.js
+++ b/packages/block-editor/src/components/list-view/index.js
@@ -224,8 +224,8 @@ function ListViewComponent(
 		]
 	);
 
-	// If there are no blocks to show, do not render the list view.
-	if ( ! clientIdsTree.length ) {
+	// If there are no blocks to show and we're not showing the appender, do not render the list view.
+	if ( ! clientIdsTree.length && ! showAppender ) {
 		return null;
 	}
 

--- a/packages/block-library/src/navigation/edit/menu-inspector-controls.js
+++ b/packages/block-library/src/navigation/edit/menu-inspector-controls.js
@@ -133,6 +133,11 @@ const MainContent = ( {
 
 	return (
 		<div className="wp-block-navigation__menu-inspector-controls">
+			{ clientIdsTree.length === 0 && (
+				<p className="wp-block-navigation__menu-inspector-controls__empty-message">
+					{ __( 'This navigation menu is empty.' ) }
+				</p>
+			) }
 			<PrivateListView
 				blocks={ clientIdsTree }
 				rootClientId={ clientId }

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -663,3 +663,7 @@ body.editor-styles-wrapper .wp-block-navigation__responsive-container.is-menu-op
 
 	@include custom-scrollbars-on-hover(transparent, $gray-600);
 }
+
+.wp-block-navigation__menu-inspector-controls__empty-message {
+	margin-left: 24px;
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
On an empty menu, the appender is missing in the right navigation editor sidebar.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
If the `showAppender` attribute is `true` and there are no items, still show the ListView so the appender can show.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Go to the site editor
2. Add a navigation block
3. Add a new menu 
4. See the empty navigation menu message and appender
5. Use the appender to add a link

## Screenshots or screencast <!-- if applicable -->
<img width="410" alt="Navigation sidebar in site editor showing the empty nav message and appender" src="https://github.com/WordPress/gutenberg/assets/967608/3fbce184-893b-4d8c-81d6-c023cfd8ab72">
