### PR TITLE
Better error message when theme.json styles use a duotone preset not in settings

### DIFF
--- a/lib/class-wp-duotone-gutenberg.php
+++ b/lib/class-wp-duotone-gutenberg.php
@@ -715,7 +715,7 @@ class WP_Duotone_Gutenberg {
 		if ( ! array_key_exists( $filter_id, self::$global_styles_presets ) ) {
 			$error_message = sprintf(
 				/* translators: %s: duotone filter ID */
-				__( 'The duotone id "%s" is not registered in theme.json settings' ),
+				__( 'The duotone id "%s" is not registered in theme.json settings', 'gutenberg' ),
 				$filter_id
 			);
 			trigger_error( $error_message );

--- a/lib/class-wp-duotone-gutenberg.php
+++ b/lib/class-wp-duotone-gutenberg.php
@@ -712,6 +712,15 @@ class WP_Duotone_Gutenberg {
 	 * @param string $filter_value     The filter CSS value. e.g. 'url(#wp-duotone-blue-orange)' or 'unset'.
 	 */
 	private static function enqueue_global_styles_preset( $filter_id, $duotone_selector, $filter_value ) {
+		if ( ! array_key_exists( $filter_id, self::$global_styles_presets ) ) {
+			$error_message = sprintf(
+				/* translators: %s: duotone filter ID */
+				__( 'The duotone id "%s" is not registered in theme.json settings.' ),
+				$filter_id
+			);
+			trigger_error( $error_message );
+			return;
+		}
 		self::$used_global_styles_presets[ $filter_id ] = self::$global_styles_presets[ $filter_id ];
 		self::enqueue_custom_filter( $filter_id, $duotone_selector, $filter_value, self::$global_styles_presets[ $filter_id ] );
 	}

--- a/lib/class-wp-duotone-gutenberg.php
+++ b/lib/class-wp-duotone-gutenberg.php
@@ -718,7 +718,7 @@ class WP_Duotone_Gutenberg {
 				__( 'The duotone id "%s" is not registered in theme.json settings', 'gutenberg' ),
 				$filter_id
 			);
-			trigger_error( $error_message );
+			_doing_it_wrong( __METHOD__, $error_message, '6.3.0' );
 			return;
 		}
 		self::$used_global_styles_presets[ $filter_id ] = self::$global_styles_presets[ $filter_id ];

--- a/lib/class-wp-duotone-gutenberg.php
+++ b/lib/class-wp-duotone-gutenberg.php
@@ -715,7 +715,7 @@ class WP_Duotone_Gutenberg {
 		if ( ! array_key_exists( $filter_id, self::$global_styles_presets ) ) {
 			$error_message = sprintf(
 				/* translators: %s: duotone filter ID */
-				__( 'The duotone id "%s" is not registered in theme.json settings.' ),
+				__( 'The duotone id "%s" is not registered in theme.json settings' ),
 				$filter_id
 			);
 			trigger_error( $error_message );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Provides a more helpful error message when you've misspelled a duotone variable name or tried to use a variable that we don't have the duotone information to generate an SVG.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

More clear error messages are more helpful for theme developers. And it's better to show a clear error than silently not render the filter since this problem exists within a hand-coded theme.json that a developer would be creating. Using the global styles UI shouldn't create this error because only presets are able to be selected from in the interface.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Triggers a custom error message when the CSS `var` being used in `styles` isn't part of the presets defined in `settings`.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Update theme.json `styles.blocks['core/image'].filter.duotone = var(--wp--preset--duotone--does-not-exist)`.
2. Add image block in the post editor.
3. See the new error message.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

### Before

```
Notice: Undefined index: wp-duotone-does-not-exist in /Users/ajlende/Documents/gutenberg/lib/class-wp-duotone-gutenberg.php on line 715
```

### After

```
Notice: Function WP_Duotone_Gutenberg::enqueue_global_styles_preset was called <strong>incorrectly</strong>. The duotone id "wp-duotone-prmary" is not registered in theme.json settings Please see <a href="https://wordpress.org/documentation/article/debugging-in-wordpress/">Debugging in WordPress</a> for more information. (This message was added in version 6.3.0.) in /Users/ajlende/Documents/wordpress-develop/src/wp-includes/functions.php on line 5865
```

Previously, in this PR using `trigger_error`.

```
Notice: The duotone id "wp-duotone-does-not-exist" is not registered in theme.json settings in /Users/ajlende/Documents/gutenberg/lib/class-wp-duotone-gutenberg.php on line 718
```
