### PR TITLE
List View: Allow dragging outside the immediate area by passing down a dropZoneElement

### DIFF
--- a/packages/block-editor/src/components/list-view/index.js
+++ b/packages/block-editor/src/components/list-view/index.js
@@ -52,23 +52,24 @@ export const BLOCK_LIST_ITEM_HEIGHT = 36;
 
 /** @typedef {import('react').ComponentType} ComponentType */
 /** @typedef {import('react').Ref<HTMLElement>} Ref */
+/** @typedef {import('react').RefObject} RefObject */
 
 /**
  * Show a hierarchical list of blocks.
  *
- * @param {Object}         props                         Components props.
- * @param {string}         props.id                      An HTML element id for the root element of ListView.
- * @param {Array}          props.blocks                  _deprecated_ Custom subset of block client IDs to be used instead of the default hierarchy.
- * @param {Ref}            props.dropZoneRef             Optional ref to be used as the drop zone.
- * @param {?boolean}       props.showBlockMovers         Flag to enable block movers. Defaults to `false`.
- * @param {?boolean}       props.isExpanded              Flag to determine whether nested levels are expanded by default. Defaults to `false`.
- * @param {?boolean}       props.showAppender            Flag to show or hide the block appender. Defaults to `false`.
- * @param {?ComponentType} props.blockSettingsMenu       Optional more menu substitution. Defaults to the standard `BlockSettingsDropdown` component.
- * @param {string}         props.rootClientId            The client id of the root block from which we determine the blocks to show in the list.
- * @param {string}         props.description             Optional accessible description for the tree grid component.
- * @param {?Function}      props.onSelect                Optional callback to be invoked when a block is selected. Receives the block object that was selected.
- * @param {Function}       props.renderAdditionalBlockUI Function that renders additional block content UI.
- * @param {Ref}            ref                           Forwarded ref
+ * @param {Object}                  props                         Components props.
+ * @param {string}                  props.id                      An HTML element id for the root element of ListView.
+ * @param {Array}                   props.blocks                  _deprecated_ Custom subset of block client IDs to be used instead of the default hierarchy.
+ * @param {?RefObject<HTMLElement>} props.dropZoneRef             Optional ref to be used as the drop zone.
+ * @param {?boolean}                props.showBlockMovers         Flag to enable block movers. Defaults to `false`.
+ * @param {?boolean}                props.isExpanded              Flag to determine whether nested levels are expanded by default. Defaults to `false`.
+ * @param {?boolean}                props.showAppender            Flag to show or hide the block appender. Defaults to `false`.
+ * @param {?ComponentType}          props.blockSettingsMenu       Optional more menu substitution. Defaults to the standard `BlockSettingsDropdown` component.
+ * @param {string}                  props.rootClientId            The client id of the root block from which we determine the blocks to show in the list.
+ * @param {string}                  props.description             Optional accessible description for the tree grid component.
+ * @param {?Function}               props.onSelect                Optional callback to be invoked when a block is selected. Receives the block object that was selected.
+ * @param {Function}                props.renderAdditionalBlockUI Function that renders additional block content UI.
+ * @param {Ref}                     ref                           Forwarded ref
  */
 function ListViewComponent(
 	{

--- a/packages/block-editor/src/components/list-view/index.js
+++ b/packages/block-editor/src/components/list-view/index.js
@@ -52,30 +52,29 @@ export const BLOCK_LIST_ITEM_HEIGHT = 36;
 
 /** @typedef {import('react').ComponentType} ComponentType */
 /** @typedef {import('react').Ref<HTMLElement>} Ref */
-/** @typedef {import('react').RefObject} RefObject */
 
 /**
  * Show a hierarchical list of blocks.
  *
- * @param {Object}                  props                         Components props.
- * @param {string}                  props.id                      An HTML element id for the root element of ListView.
- * @param {Array}                   props.blocks                  _deprecated_ Custom subset of block client IDs to be used instead of the default hierarchy.
- * @param {?RefObject<HTMLElement>} props.dropZoneRef             Optional ref to be used as the drop zone.
- * @param {?boolean}                props.showBlockMovers         Flag to enable block movers. Defaults to `false`.
- * @param {?boolean}                props.isExpanded              Flag to determine whether nested levels are expanded by default. Defaults to `false`.
- * @param {?boolean}                props.showAppender            Flag to show or hide the block appender. Defaults to `false`.
- * @param {?ComponentType}          props.blockSettingsMenu       Optional more menu substitution. Defaults to the standard `BlockSettingsDropdown` component.
- * @param {string}                  props.rootClientId            The client id of the root block from which we determine the blocks to show in the list.
- * @param {string}                  props.description             Optional accessible description for the tree grid component.
- * @param {?Function}               props.onSelect                Optional callback to be invoked when a block is selected. Receives the block object that was selected.
- * @param {Function}                props.renderAdditionalBlockUI Function that renders additional block content UI.
- * @param {Ref}                     ref                           Forwarded ref
+ * @param {Object}         props                         Coprops.
+ * @param {string}         props.id                      An HTML element id for the root element of ListView.
+ * @param {Array}          props.blocks                  _deprecated_ Custom subset of block client IDs to be used instead of the default hierarchy.
+ * @param {?HTMLElement}   props.dropZoneElement         Optional element to be used as the drop zone.
+ * @param {?boolean}       props.showBlockMovers         Flag to enable block movers. Defaults to `false`.
+ * @param {?boolean}       props.isExpanded              Flag to determine whether nested levels are expanded by default. Defaults to `false`.
+ * @param {?boolean}       props.showAppender            Flag to show or hide the block appender. Defaults to `false`.
+ * @param {?ComponentType} props.blockSettingsMenu       Optional more menu substitution. Defaults to the standard `BlockSettingsDropdown` component.
+ * @param {string}         props.rootClientId            The client id of the root block from which we determine the blocks to show in the list.
+ * @param {string}         props.description             Optional accessible description for the tree grid component.
+ * @param {?Function}      props.onSelect                Optional callback to be invoked when a block is selected. Receives the block object that was selected.
+ * @param {Function}       props.renderAdditionalBlockUI Function that renders additional block content UI.
+ * @param {Ref}            ref                           Forwarded ref
  */
 function ListViewComponent(
 	{
 		id,
 		blocks,
-		dropZoneRef: customDropZoneRef,
+		dropZoneElement,
 		showBlockMovers = false,
 		isExpanded = false,
 		showAppender = false,
@@ -127,7 +126,7 @@ function ListViewComponent(
 	const [ expandedState, setExpandedState ] = useReducer( expanded, {} );
 
 	const { ref: dropZoneRef, target: blockDropTarget } = useListViewDropZone( {
-		dropZoneRef: customDropZoneRef,
+		dropZoneElement,
 	} );
 	const elementRef = useRef();
 	const treeGridRef = useMergeRefs( [ elementRef, dropZoneRef, ref ] );

--- a/packages/block-editor/src/components/list-view/index.js
+++ b/packages/block-editor/src/components/list-view/index.js
@@ -59,6 +59,7 @@ export const BLOCK_LIST_ITEM_HEIGHT = 36;
  * @param {Object}         props                         Components props.
  * @param {string}         props.id                      An HTML element id for the root element of ListView.
  * @param {Array}          props.blocks                  _deprecated_ Custom subset of block client IDs to be used instead of the default hierarchy.
+ * @param {Ref}            props.dropZoneRef             Optional ref to be used as the drop zone.
  * @param {?boolean}       props.showBlockMovers         Flag to enable block movers. Defaults to `false`.
  * @param {?boolean}       props.isExpanded              Flag to determine whether nested levels are expanded by default. Defaults to `false`.
  * @param {?boolean}       props.showAppender            Flag to show or hide the block appender. Defaults to `false`.
@@ -73,6 +74,7 @@ function ListViewComponent(
 	{
 		id,
 		blocks,
+		dropZoneRef: customDropZoneRef,
 		showBlockMovers = false,
 		isExpanded = false,
 		showAppender = false,
@@ -123,7 +125,9 @@ function ListViewComponent(
 
 	const [ expandedState, setExpandedState ] = useReducer( expanded, {} );
 
-	const { ref: dropZoneRef, target: blockDropTarget } = useListViewDropZone();
+	const { ref: dropZoneRef, target: blockDropTarget } = useListViewDropZone( {
+		dropZoneRef: customDropZoneRef,
+	} );
 	const elementRef = useRef();
 	const treeGridRef = useMergeRefs( [ elementRef, dropZoneRef, ref ] );
 

--- a/packages/block-editor/src/components/list-view/index.js
+++ b/packages/block-editor/src/components/list-view/index.js
@@ -56,7 +56,7 @@ export const BLOCK_LIST_ITEM_HEIGHT = 36;
 /**
  * Show a hierarchical list of blocks.
  *
- * @param {Object}         props                         Coprops.
+ * @param {Object}         props                         Components props.
  * @param {string}         props.id                      An HTML element id for the root element of ListView.
  * @param {Array}          props.blocks                  _deprecated_ Custom subset of block client IDs to be used instead of the default hierarchy.
  * @param {?HTMLElement}   props.dropZoneElement         Optional element to be used as the drop zone.

--- a/packages/block-editor/src/components/list-view/test/use-list-view-drop-zone.js
+++ b/packages/block-editor/src/components/list-view/test/use-list-view-drop-zone.js
@@ -261,4 +261,21 @@ describe( 'getListViewDropTarget', () => {
 
 		expect( target ).toBeUndefined();
 	} );
+
+	it( 'should move below, and not nest when dragging lower than the bottom-most block', () => {
+		const singleBlock = [ { ...blocksData[ 0 ], innerBlockCount: 0 } ];
+
+		// This position is to the right of the block, but below the bottom of the block.
+		// This should result in the block being moved below the bottom-most block, and
+		// not being treated as a nesting gesture.
+		const position = { x: 160, y: 250 };
+		const target = getListViewDropTarget( singleBlock, position );
+
+		expect( target ).toEqual( {
+			blockIndex: 1,
+			clientId: 'block-1',
+			dropPosition: 'bottom',
+			rootClientId: '',
+		} );
+	} );
 } );

--- a/packages/block-editor/src/components/list-view/use-list-view-drop-zone.js
+++ b/packages/block-editor/src/components/list-view/use-list-view-drop-zone.js
@@ -387,12 +387,7 @@ export default function useListViewDropZone( { dropZoneRef } ) {
 	const draggedBlockClientIds = getDraggedBlockClientIds();
 	const throttled = useThrottle(
 		useCallback(
-			( event, currentTarget, action ) => {
-				if ( action === 'clear' ) {
-					setTarget( null );
-					return;
-				}
-
+			( event, currentTarget ) => {
 				const position = { x: event.clientX, y: event.clientY };
 				const isBlockDrag = !! draggedBlockClientIds?.length;
 
@@ -448,8 +443,9 @@ export default function useListViewDropZone( { dropZoneRef } ) {
 	const ref = useDropZone( {
 		dropZoneRef,
 		onDrop: onBlockDrop,
-		onDragLeave( event ) {
-			throttled( event, event.currentTarget, 'clear' );
+		onDragLeave() {
+			throttled.cancel();
+			setTarget( null );
 		},
 		onDragOver( event ) {
 			// `currentTarget` is only available while the event is being

--- a/packages/block-editor/src/components/list-view/use-list-view-drop-zone.js
+++ b/packages/block-editor/src/components/list-view/use-list-view-drop-zone.js
@@ -360,17 +360,15 @@ export function getListViewDropTarget( blocksData, position ) {
 	};
 }
 
-/** @typedef {import('react').RefObject} RefObject */
-
 /**
  * A react hook for implementing a drop zone in list view.
  *
- * @param {Object}                  props               Named parameters.
- * @param {?RefObject<HTMLElement>} [props.dropZoneRef] Optional ref to be used as the drop zone.
+ * @param {Object}       props                   Named parameters.
+ * @param {?HTMLElement} [props.dropZoneElement] Optional element to be used as the drop zone.
  *
  * @return {WPListViewDropZoneTarget} The drop target.
  */
-export default function useListViewDropZone( { dropZoneRef } ) {
+export default function useListViewDropZone( { dropZoneElement } ) {
 	const {
 		getBlockRootClientId,
 		getBlockIndex,
@@ -441,7 +439,7 @@ export default function useListViewDropZone( { dropZoneRef } ) {
 	);
 
 	const ref = useDropZone( {
-		dropZoneRef,
+		dropZoneElement,
 		onDrop: onBlockDrop,
 		onDragLeave() {
 			throttled.cancel();

--- a/packages/block-editor/src/components/list-view/use-list-view-drop-zone.js
+++ b/packages/block-editor/src/components/list-view/use-list-view-drop-zone.js
@@ -364,7 +364,7 @@ export function getListViewDropTarget( blocksData, position ) {
  * A react hook for implementing a drop zone in list view.
  *
  * @param {Object}                                 props               Named parameters.
- * @param {import('react').RefObject<HTMLElement>} [props.dropZoneRef] Used to find the closest scroll container that contains element.
+ * @param {import('react').RefObject<HTMLElement>} [props.dropZoneRef] Optional ref to be used as the drop zone.
  *
  * @return {WPListViewDropZoneTarget} The drop target.
  */

--- a/packages/block-editor/src/components/list-view/use-list-view-drop-zone.js
+++ b/packages/block-editor/src/components/list-view/use-list-view-drop-zone.js
@@ -152,7 +152,8 @@ function getNextNonDraggedBlock( blocksData, index ) {
  * inner block.
  *
  * Determined based on nesting level indentation of the current block, plus
- * the indentation of the next level of nesting.
+ * the indentation of the next level of nesting. The vertical position of the
+ * cursor must also be within the block.
  *
  * @param {WPPoint} point        The point representing the cursor position when dragging.
  * @param {DOMRect} rect         The rectangle.
@@ -161,7 +162,10 @@ function getNextNonDraggedBlock( blocksData, index ) {
 function isNestingGesture( point, rect, nestingLevel = 1 ) {
 	const blockIndentPosition =
 		rect.left + nestingLevel * NESTING_LEVEL_INDENTATION;
-	return point.x > blockIndentPosition + NESTING_LEVEL_INDENTATION;
+	return (
+		point.x > blockIndentPosition + NESTING_LEVEL_INDENTATION &&
+		point.y < rect.bottom
+	);
 }
 
 // Block navigation is always a vertical list, so only allow dropping

--- a/packages/block-editor/src/components/list-view/use-list-view-drop-zone.js
+++ b/packages/block-editor/src/components/list-view/use-list-view-drop-zone.js
@@ -359,9 +359,12 @@ export function getListViewDropTarget( blocksData, position ) {
 /**
  * A react hook for implementing a drop zone in list view.
  *
+ * @param {Object}                                 props               Named parameters.
+ * @param {import('react').RefObject<HTMLElement>} [props.dropZoneRef] Used to find the closest scroll container that contains element.
+ *
  * @return {WPListViewDropZoneTarget} The drop target.
  */
-export default function useListViewDropZone() {
+export default function useListViewDropZone( { dropZoneRef } ) {
 	const {
 		getBlockRootClientId,
 		getBlockIndex,
@@ -378,7 +381,12 @@ export default function useListViewDropZone() {
 	const draggedBlockClientIds = getDraggedBlockClientIds();
 	const throttled = useThrottle(
 		useCallback(
-			( event, currentTarget ) => {
+			( event, currentTarget, action ) => {
+				if ( action === 'clear' ) {
+					setTarget( null );
+					return;
+				}
+
 				const position = { x: event.clientX, y: event.clientY };
 				const isBlockDrag = !! draggedBlockClientIds?.length;
 
@@ -432,7 +440,11 @@ export default function useListViewDropZone() {
 	);
 
 	const ref = useDropZone( {
+		dropZoneRef,
 		onDrop: onBlockDrop,
+		onDragLeave( event ) {
+			throttled( event, event.currentTarget, 'clear' );
+		},
 		onDragOver( event ) {
 			// `currentTarget` is only available while the event is being
 			// handled, so get it now and pass it to the thottled function.

--- a/packages/block-editor/src/components/list-view/use-list-view-drop-zone.js
+++ b/packages/block-editor/src/components/list-view/use-list-view-drop-zone.js
@@ -360,11 +360,13 @@ export function getListViewDropTarget( blocksData, position ) {
 	};
 }
 
+/** @typedef {import('react').RefObject} RefObject */
+
 /**
  * A react hook for implementing a drop zone in list view.
  *
- * @param {Object}                                 props               Named parameters.
- * @param {import('react').RefObject<HTMLElement>} [props.dropZoneRef] Optional ref to be used as the drop zone.
+ * @param {Object}                  props               Named parameters.
+ * @param {?RefObject<HTMLElement>} [props.dropZoneRef] Optional ref to be used as the drop zone.
  *
  * @return {WPListViewDropZoneTarget} The drop target.
  */

--- a/packages/compose/src/hooks/use-drop-zone/README.md
+++ b/packages/compose/src/hooks/use-drop-zone/README.md
@@ -1,4 +1,4 @@
-# useDropZone
+# useDropZone (experimental)
 
 A hook to facilitate drag and drop handling within a designated drop zone area. An optional `dropZoneElement` can be provided, however by default the drop zone is bound by the area where the returned `ref` is assigned.
 

--- a/packages/compose/src/hooks/use-drop-zone/README.md
+++ b/packages/compose/src/hooks/use-drop-zone/README.md
@@ -1,0 +1,71 @@
+# useDropZone
+
+A hook to facilitate drag and drop handling within a designated drop zone area. An optional `dropZoneElement` can be provided, however by default the drop zone is bound by the area where the returned `ref` is assigned.
+
+When using a `dropZoneElement`, it is expected that the `ref` will be attached to a node that is a descendent of the `dropZoneElement`. Additionally, the element passed to `dropZoneElement` should be stored in state rather than a plain ref to ensure reactive updating when it changes.
+
+## Usage
+
+```js
+import { useDropZone } from '@wordpress/compose';
+import { useState } from '@wordpress/element';
+
+const WithWrapperDropZoneElement = () => {
+	const [ dropZoneElement, setDropZoneElement ] = useState( null );
+
+	const dropZoneRef = useDropZone(
+		{
+			dropZoneElement,
+			onDrop() => {
+				console.log( 'Dropped within the drop zone.' );
+			},
+			onDragEnter() => {
+				console.log( 'Dragging within the drop zone' );
+			}
+		}
+	)
+
+	return (
+		<div className="outer-wrapper" ref={ setDropZoneElement }>
+			<div ref={ dropZoneRef }>
+				<p>Drop Zone</p>
+			</div>
+		</div>
+	);
+};
+
+const WithoutWrapperDropZoneElement = () => {
+	const dropZoneRef = useDropZone(
+		{
+			onDrop() => {
+				console.log( 'Dropped within the drop zone.' );
+			},
+			onDragEnter() => {
+				console.log( 'Dragging within the drop zone' );
+			}
+		}
+	)
+
+	return (
+		<div ref={ dropZoneRef }>
+			<p>Drop Zone</p>
+		</div>
+	);
+};
+```
+
+## Parameters
+
+-   _props_ `Object`: Named parameters.
+-   _props.dropZoneElement_ `HTMLElement`: Optional element to be used as the drop zone.
+-   _props.isDisabled_ `boolean`: Whether or not to disable the drop zone.
+-   _props.onDragStart_ `( e: DragEvent ) => void`: Called when dragging has started.
+-   _props.onDragEnter_ `( e: DragEvent ) => void`: Called when the zone is entered.
+-   _props.onDragOver_ `( e: DragEvent ) => void`: Called when the zone is moved within.
+-   _props.onDragLeave_ `( e: DragEvent ) => void`: Called when the zone is left.
+-   _props.onDragEnd_ `( e: MouseEvent ) => void`: Called when dragging has ended.
+-   _props.onDrop_ `( e: DragEvent ) => void`: Called when dropping in the zone.
+
+_Returns_
+
+-   `RefCallback< HTMLElement >`: Ref callback to be passed to the drop zone element.

--- a/packages/compose/src/hooks/use-drop-zone/index.js
+++ b/packages/compose/src/hooks/use-drop-zone/index.js
@@ -34,7 +34,7 @@ function useFreshRef( value ) {
  * A hook to facilitate drag and drop handling.
  *
  * @param {Object}                                 props               Named parameters.
- * @param {import('react').RefObject<HTMLElement>} [props.dropZoneRef] Used to find the closest scroll container that contains element.
+ * @param {import('react').RefObject<HTMLElement>} [props.dropZoneRef] Optional ref to be used as the drop zone.
  * @param {boolean}                                [props.isDisabled]  Whether or not to disable the drop zone.
  * @param {(e: DragEvent) => void}                 [props.onDragStart] Called when dragging has started.
  * @param {(e: DragEvent) => void}                 [props.onDragEnter] Called when the zone is entered.

--- a/packages/compose/src/hooks/use-drop-zone/index.js
+++ b/packages/compose/src/hooks/use-drop-zone/index.js
@@ -235,6 +235,6 @@ export default function useDropZone( {
 				);
 			};
 		},
-		[ isDisabled, dropZoneRef, dropZoneRef?.current ] // Refresh when the passed in dropZoneRef changes.
+		[ isDisabled, dropZoneRef?.current ] // Refresh when the passed in dropZoneRef changes.
 	);
 }

--- a/packages/compose/src/hooks/use-drop-zone/index.js
+++ b/packages/compose/src/hooks/use-drop-zone/index.js
@@ -33,15 +33,15 @@ function useFreshRef( value ) {
 /**
  * A hook to facilitate drag and drop handling.
  *
- * @param {Object}                                 props               Named parameters.
- * @param {import('react').RefObject<HTMLElement>} [props.dropZoneRef] Optional ref to be used as the drop zone.
- * @param {boolean}                                [props.isDisabled]  Whether or not to disable the drop zone.
- * @param {(e: DragEvent) => void}                 [props.onDragStart] Called when dragging has started.
- * @param {(e: DragEvent) => void}                 [props.onDragEnter] Called when the zone is entered.
- * @param {(e: DragEvent) => void}                 [props.onDragOver]  Called when the zone is moved within.
- * @param {(e: DragEvent) => void}                 [props.onDragLeave] Called when the zone is left.
- * @param {(e: MouseEvent) => void}                [props.onDragEnd]   Called when dragging has ended.
- * @param {(e: DragEvent) => void}                 [props.onDrop]      Called when dropping in the zone.
+ * @param {Object}                                  props               Named parameters.
+ * @param {?import('react').RefObject<HTMLElement>} [props.dropZoneRef] Optional ref to be used as the drop zone.
+ * @param {boolean}                                 [props.isDisabled]  Whether or not to disable the drop zone.
+ * @param {(e: DragEvent) => void}                  [props.onDragStart] Called when dragging has started.
+ * @param {(e: DragEvent) => void}                  [props.onDragEnter] Called when the zone is entered.
+ * @param {(e: DragEvent) => void}                  [props.onDragOver]  Called when the zone is moved within.
+ * @param {(e: DragEvent) => void}                  [props.onDragLeave] Called when the zone is left.
+ * @param {(e: MouseEvent) => void}                 [props.onDragEnd]   Called when dragging has ended.
+ * @param {(e: DragEvent) => void}                  [props.onDrop]      Called when dropping in the zone.
  *
  * @return {import('react').RefCallback<HTMLElement>} Ref callback to be passed to the drop zone element.
  */

--- a/packages/compose/src/hooks/use-drop-zone/index.js
+++ b/packages/compose/src/hooks/use-drop-zone/index.js
@@ -33,20 +33,20 @@ function useFreshRef( value ) {
 /**
  * A hook to facilitate drag and drop handling.
  *
- * @param {Object}                                  props               Named parameters.
- * @param {?import('react').RefObject<HTMLElement>} [props.dropZoneRef] Optional ref to be used as the drop zone.
- * @param {boolean}                                 [props.isDisabled]  Whether or not to disable the drop zone.
- * @param {(e: DragEvent) => void}                  [props.onDragStart] Called when dragging has started.
- * @param {(e: DragEvent) => void}                  [props.onDragEnter] Called when the zone is entered.
- * @param {(e: DragEvent) => void}                  [props.onDragOver]  Called when the zone is moved within.
- * @param {(e: DragEvent) => void}                  [props.onDragLeave] Called when the zone is left.
- * @param {(e: MouseEvent) => void}                 [props.onDragEnd]   Called when dragging has ended.
- * @param {(e: DragEvent) => void}                  [props.onDrop]      Called when dropping in the zone.
+ * @param {Object}                  props                   Named parameters.
+ * @param {HTMLElement}             [props.dropZoneElement] Optional element to be used as the drop zone.
+ * @param {boolean}                 [props.isDisabled]      Whether or not to disable the drop zone.
+ * @param {(e: DragEvent) => void}  [props.onDragStart]     Called when dragging has started.
+ * @param {(e: DragEvent) => void}  [props.onDragEnter]     Called when the zone is entered.
+ * @param {(e: DragEvent) => void}  [props.onDragOver]      Called when the zone is moved within.
+ * @param {(e: DragEvent) => void}  [props.onDragLeave]     Called when the zone is left.
+ * @param {(e: MouseEvent) => void} [props.onDragEnd]       Called when dragging has ended.
+ * @param {(e: DragEvent) => void}  [props.onDrop]          Called when dropping in the zone.
  *
  * @return {import('react').RefCallback<HTMLElement>} Ref callback to be passed to the drop zone element.
  */
 export default function useDropZone( {
-	dropZoneRef,
+	dropZoneElement,
 	isDisabled,
 	onDrop: _onDrop,
 	onDragStart: _onDragStart,
@@ -71,7 +71,7 @@ export default function useDropZone( {
 			// If a custom dropZoneRef is passed, use that instead of the element.
 			// This allows the dropzone to cover an expanded area, rather than
 			// be restricted to the area of the ref returned by this hook.
-			const element = dropZoneRef?.current ?? elem;
+			const element = dropZoneElement ?? elem;
 
 			let isDragging = false;
 
@@ -235,6 +235,6 @@ export default function useDropZone( {
 				);
 			};
 		},
-		[ isDisabled, dropZoneRef?.current ] // Refresh when the passed in dropZoneRef changes.
+		[ isDisabled, dropZoneElement ] // Refresh when the passed in dropZoneElement changes.
 	);
 }

--- a/packages/compose/src/hooks/use-drop-zone/index.js
+++ b/packages/compose/src/hooks/use-drop-zone/index.js
@@ -68,6 +68,9 @@ export default function useDropZone( {
 				return;
 			}
 
+			// If a custom dropZoneRef is passed, use that instead of the element.
+			// This allows the dropzone to cover an expanded area, rather than
+			// be restricted to the area of the ref returned by this hook.
 			const element = dropZoneRef?.current ?? elem;
 
 			let isDragging = false;
@@ -232,6 +235,6 @@ export default function useDropZone( {
 				);
 			};
 		},
-		[ isDisabled ]
+		[ isDisabled, dropZoneRef, dropZoneRef?.current ] // Refresh when the passed in dropZoneRef changes.
 	);
 }

--- a/packages/compose/src/hooks/use-drop-zone/index.js
+++ b/packages/compose/src/hooks/use-drop-zone/index.js
@@ -34,7 +34,7 @@ function useFreshRef( value ) {
  * A hook to facilitate drag and drop handling.
  *
  * @param {Object}                  props                   Named parameters.
- * @param {HTMLElement}             [props.dropZoneElement] Optional element to be used as the drop zone.
+ * @param {?HTMLElement}            [props.dropZoneElement] Optional element to be used as the drop zone.
  * @param {boolean}                 [props.isDisabled]      Whether or not to disable the drop zone.
  * @param {(e: DragEvent) => void}  [props.onDragStart]     Called when dragging has started.
  * @param {(e: DragEvent) => void}  [props.onDragEnter]     Called when the zone is entered.

--- a/packages/compose/src/hooks/use-drop-zone/index.js
+++ b/packages/compose/src/hooks/use-drop-zone/index.js
@@ -33,18 +33,20 @@ function useFreshRef( value ) {
 /**
  * A hook to facilitate drag and drop handling.
  *
- * @param {Object}                  props               Named parameters.
- * @param {boolean}                 [props.isDisabled]  Whether or not to disable the drop zone.
- * @param {(e: DragEvent) => void}  [props.onDragStart] Called when dragging has started.
- * @param {(e: DragEvent) => void}  [props.onDragEnter] Called when the zone is entered.
- * @param {(e: DragEvent) => void}  [props.onDragOver]  Called when the zone is moved within.
- * @param {(e: DragEvent) => void}  [props.onDragLeave] Called when the zone is left.
- * @param {(e: MouseEvent) => void} [props.onDragEnd]   Called when dragging has ended.
- * @param {(e: DragEvent) => void}  [props.onDrop]      Called when dropping in the zone.
+ * @param {Object}                                 props               Named parameters.
+ * @param {import('react').RefObject<HTMLElement>} [props.dropZoneRef] Used to find the closest scroll container that contains element.
+ * @param {boolean}                                [props.isDisabled]  Whether or not to disable the drop zone.
+ * @param {(e: DragEvent) => void}                 [props.onDragStart] Called when dragging has started.
+ * @param {(e: DragEvent) => void}                 [props.onDragEnter] Called when the zone is entered.
+ * @param {(e: DragEvent) => void}                 [props.onDragOver]  Called when the zone is moved within.
+ * @param {(e: DragEvent) => void}                 [props.onDragLeave] Called when the zone is left.
+ * @param {(e: MouseEvent) => void}                [props.onDragEnd]   Called when dragging has ended.
+ * @param {(e: DragEvent) => void}                 [props.onDrop]      Called when dropping in the zone.
  *
  * @return {import('react').RefCallback<HTMLElement>} Ref callback to be passed to the drop zone element.
  */
 export default function useDropZone( {
+	dropZoneRef,
 	isDisabled,
 	onDrop: _onDrop,
 	onDragStart: _onDragStart,
@@ -61,10 +63,12 @@ export default function useDropZone( {
 	const onDragOverRef = useFreshRef( _onDragOver );
 
 	return useRefEffect(
-		( element ) => {
+		( elem ) => {
 			if ( isDisabled ) {
 				return;
 			}
+
+			const element = dropZoneRef?.current ?? elem;
 
 			let isDragging = false;
 

--- a/packages/compose/src/hooks/use-drop-zone/test/index.js
+++ b/packages/compose/src/hooks/use-drop-zone/test/index.js
@@ -1,0 +1,63 @@
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+
+/**
+ * WordPress dependencies
+ */
+import { useRef } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import useDropZone from '../';
+
+describe( 'useDropZone', () => {
+	const ComponentWithWrapperDropZone = () => {
+		const outerRef = useRef();
+		const dropZoneRef = useDropZone( {
+			dropZoneRef: outerRef,
+		} );
+
+		return (
+			<div role="main" ref={ outerRef }>
+				<div role="region" ref={ dropZoneRef }>
+					<div>Drop Zone</div>
+				</div>
+			</div>
+		);
+	};
+
+	const ComponentWithoutWrapperDropZone = () => {
+		const dropZoneRef = useDropZone( {} );
+
+		return (
+			<div role="main">
+				<div role="region" ref={ dropZoneRef }>
+					<div>Drop Zone</div>
+				</div>
+			</div>
+		);
+	};
+
+	it( 'will attach dropzone to outer wrapper', () => {
+		const { rerender } = render( <ComponentWithWrapperDropZone /> );
+		// Ensure `useEffect` has run.
+		rerender( <ComponentWithWrapperDropZone /> );
+
+		expect( screen.getByRole( 'main' ) ).toHaveAttribute(
+			'data-is-drop-zone'
+		);
+	} );
+
+	it( 'will attach dropzone to element with dropZoneRef attached', () => {
+		const { rerender } = render( <ComponentWithoutWrapperDropZone /> );
+		// Ensure `useEffect` has run.
+		rerender( <ComponentWithoutWrapperDropZone /> );
+
+		expect( screen.getByRole( 'region' ) ).toHaveAttribute(
+			'data-is-drop-zone'
+		);
+	} );
+} );

--- a/packages/compose/src/hooks/use-drop-zone/test/index.js
+++ b/packages/compose/src/hooks/use-drop-zone/test/index.js
@@ -6,7 +6,7 @@ import { render, screen } from '@testing-library/react';
 /**
  * WordPress dependencies
  */
-import { useRef } from '@wordpress/element';
+import { useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -15,13 +15,13 @@ import useDropZone from '../';
 
 describe( 'useDropZone', () => {
 	const ComponentWithWrapperDropZone = () => {
-		const outerRef = useRef();
+		const [ dropZoneElement, setDropZoneElement ] = useState( null );
 		const dropZoneRef = useDropZone( {
-			dropZoneRef: outerRef,
+			dropZoneElement,
 		} );
 
 		return (
-			<div role="main" ref={ outerRef }>
+			<div role="main" ref={ setDropZoneElement }>
 				<div role="region" ref={ dropZoneRef }>
 					<div>Drop Zone</div>
 				</div>

--- a/packages/edit-post/src/components/secondary-sidebar/list-view-sidebar.js
+++ b/packages/edit-post/src/components/secondary-sidebar/list-view-sidebar.js
@@ -152,7 +152,7 @@ export default function ListViewSidebar() {
 			>
 				{ tab === 'list-view' && (
 					<div className="edit-post-editor__list-view-panel-content">
-						<ListView />
+						<ListView dropZoneRef={ listViewRef } />
 					</div>
 				) }
 				{ tab === 'outline' && <ListViewOutline /> }

--- a/packages/edit-post/src/components/secondary-sidebar/list-view-sidebar.js
+++ b/packages/edit-post/src/components/secondary-sidebar/list-view-sidebar.js
@@ -41,6 +41,10 @@ export default function ListViewSidebar() {
 		}
 	}
 
+	// Use internal state instead of a ref to make sure that the component
+	// re-renders when the dropZoneElement updates.
+	const [ dropZoneElement, setDropZoneElement ] = useState( null );
+
 	const [ tab, setTab ] = useState( 'list-view' );
 
 	// This ref refers to the sidebar as a whole.
@@ -147,12 +151,13 @@ export default function ListViewSidebar() {
 					contentFocusReturnRef,
 					focusOnMountRef,
 					listViewRef,
+					setDropZoneElement,
 				] ) }
 				className="edit-post-editor__list-view-container"
 			>
 				{ tab === 'list-view' && (
 					<div className="edit-post-editor__list-view-panel-content">
-						<ListView dropZoneRef={ listViewRef } />
+						<ListView dropZoneElement={ dropZoneElement } />
 					</div>
 				) }
 				{ tab === 'outline' && <ListViewOutline /> }

--- a/packages/edit-site/src/components/secondary-sidebar/list-view-sidebar.js
+++ b/packages/edit-site/src/components/secondary-sidebar/list-view-sidebar.js
@@ -9,7 +9,7 @@ import {
 	useMergeRefs,
 } from '@wordpress/compose';
 import { useDispatch } from '@wordpress/data';
-import { useRef } from '@wordpress/element';
+import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { closeSmall } from '@wordpress/icons';
 import { ESCAPE } from '@wordpress/keycodes';
@@ -25,10 +25,14 @@ const { PrivateListView } = unlock( blockEditorPrivateApis );
 export default function ListViewSidebar() {
 	const { setIsListViewOpened } = useDispatch( editSiteStore );
 
+	// Use internal state instead of a ref to make sure that the component
+	// re-renders when the dropZoneElement updates.
+	const [ dropZoneElement, setDropZoneElement ] = useState( null );
+
 	const focusOnMountRef = useFocusOnMount( 'firstElement' );
 	const headerFocusReturnRef = useFocusReturn();
 	const contentFocusReturnRef = useFocusReturn();
-	const dropZoneRef = useRef();
+
 	function closeOnEscape( event ) {
 		if ( event.keyCode === ESCAPE && ! event.defaultPrevented ) {
 			setIsListViewOpened( false );
@@ -56,11 +60,11 @@ export default function ListViewSidebar() {
 				className="edit-site-editor__list-view-panel-content"
 				ref={ useMergeRefs( [
 					contentFocusReturnRef,
-					dropZoneRef,
 					focusOnMountRef,
+					setDropZoneElement,
 				] ) }
 			>
-				<PrivateListView dropZoneRef={ dropZoneRef } />
+				<PrivateListView dropZoneElement={ dropZoneElement } />
 			</div>
 		</div>
 	);

--- a/packages/edit-site/src/components/secondary-sidebar/list-view-sidebar.js
+++ b/packages/edit-site/src/components/secondary-sidebar/list-view-sidebar.js
@@ -8,6 +8,7 @@ import {
 	useFocusReturn,
 	useMergeRefs,
 } from '@wordpress/compose';
+import { useRef } from '@wordpress/element';
 import { useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { closeSmall } from '@wordpress/icons';
@@ -27,6 +28,7 @@ export default function ListViewSidebar() {
 	const focusOnMountRef = useFocusOnMount( 'firstElement' );
 	const headerFocusReturnRef = useFocusReturn();
 	const contentFocusReturnRef = useFocusReturn();
+	const dropZoneRef = useRef();
 	function closeOnEscape( event ) {
 		if ( event.keyCode === ESCAPE && ! event.defaultPrevented ) {
 			setIsListViewOpened( false );
@@ -54,10 +56,11 @@ export default function ListViewSidebar() {
 				className="edit-site-editor__list-view-panel-content"
 				ref={ useMergeRefs( [
 					contentFocusReturnRef,
+					dropZoneRef,
 					focusOnMountRef,
 				] ) }
 			>
-				<PrivateListView />
+				<PrivateListView dropZoneRef={ dropZoneRef } />
 			</div>
 		</div>
 	);

--- a/packages/edit-site/src/components/secondary-sidebar/list-view-sidebar.js
+++ b/packages/edit-site/src/components/secondary-sidebar/list-view-sidebar.js
@@ -8,8 +8,8 @@ import {
 	useFocusReturn,
 	useMergeRefs,
 } from '@wordpress/compose';
-import { useRef } from '@wordpress/element';
 import { useDispatch } from '@wordpress/data';
+import { useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { closeSmall } from '@wordpress/icons';
 import { ESCAPE } from '@wordpress/keycodes';

--- a/packages/edit-widgets/src/components/secondary-sidebar/list-view-sidebar.js
+++ b/packages/edit-widgets/src/components/secondary-sidebar/list-view-sidebar.js
@@ -9,7 +9,7 @@ import {
 	useMergeRefs,
 } from '@wordpress/compose';
 import { useDispatch } from '@wordpress/data';
-import { useRef } from '@wordpress/element';
+import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { closeSmall } from '@wordpress/icons';
 import { ESCAPE } from '@wordpress/keycodes';
@@ -22,10 +22,14 @@ import { store as editWidgetsStore } from '../../store';
 export default function ListViewSidebar() {
 	const { setIsListViewOpened } = useDispatch( editWidgetsStore );
 
+	// Use internal state instead of a ref to make sure that the component
+	// re-renders when the dropZoneElement updates.
+	const [ dropZoneElement, setDropZoneElement ] = useState( null );
+
 	const focusOnMountRef = useFocusOnMount( 'firstElement' );
 	const headerFocusReturnRef = useFocusReturn();
 	const contentFocusReturnRef = useFocusReturn();
-	const dropZoneRef = useRef();
+
 	function closeOnEscape( event ) {
 		if ( event.keyCode === ESCAPE && ! event.defaultPrevented ) {
 			event.preventDefault();
@@ -54,11 +58,11 @@ export default function ListViewSidebar() {
 				className="edit-widgets-editor__list-view-panel-content"
 				ref={ useMergeRefs( [
 					contentFocusReturnRef,
-					dropZoneRef,
 					focusOnMountRef,
+					setDropZoneElement,
 				] ) }
 			>
-				<ListView dropZoneRef={ dropZoneRef } />
+				<ListView dropZoneElement={ dropZoneElement } />
 			</div>
 		</div>
 	);

--- a/packages/edit-widgets/src/components/secondary-sidebar/list-view-sidebar.js
+++ b/packages/edit-widgets/src/components/secondary-sidebar/list-view-sidebar.js
@@ -9,6 +9,7 @@ import {
 	useMergeRefs,
 } from '@wordpress/compose';
 import { useDispatch } from '@wordpress/data';
+import { useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { closeSmall } from '@wordpress/icons';
 import { ESCAPE } from '@wordpress/keycodes';
@@ -24,6 +25,7 @@ export default function ListViewSidebar() {
 	const focusOnMountRef = useFocusOnMount( 'firstElement' );
 	const headerFocusReturnRef = useFocusReturn();
 	const contentFocusReturnRef = useFocusReturn();
+	const dropZoneRef = useRef();
 	function closeOnEscape( event ) {
 		if ( event.keyCode === ESCAPE && ! event.defaultPrevented ) {
 			event.preventDefault();
@@ -52,10 +54,11 @@ export default function ListViewSidebar() {
 				className="edit-widgets-editor__list-view-panel-content"
 				ref={ useMergeRefs( [
 					contentFocusReturnRef,
+					dropZoneRef,
 					focusOnMountRef,
 				] ) }
 			>
-				<ListView />
+				<ListView dropZoneRef={ dropZoneRef } />
 			</div>
 		</div>
 	);


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Part of addressing #43881 and #32438, alternative to #49420 and #50689. Overall, this PR makes dragging to the top and bottom positions of the list view easier.

Allow dragging and dropping within the list view, beyond the bounds of the list view itself, when passed a `dropZoneElement` (an element to be used as the drop zone, typically a parent of the final drop zone ref). Within the list view sidebar, pass the list view container area as a `dropZoneElement` to the `ListView` component.

Then, when the mouse leaves that drop zone area, clear the drop target so that the blue line no longer appears. The result should be that the blue drop indicator line within the list view is now accurate — it will only display when a drop will occur, and it displays across the whole list view area, making it easier to drag to the top and bottom-most positions.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

One of the frustrations with drag and drop in the list view is that it's very difficult to drag to the top and bottom-most positions. This PR hopefully makes that experience feel more flexible and accurate.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* Pass an optional `dropZoneElement` element to `useDropZone` and use its element if available, falling back to the one passed down by `useDropZone`.
* Allow this prop at the `ListView` and `useListViewDropZone` levels.
* In the post and site editors (and widget editor), pass a ref of the list view container to the `ListView`.
* Within the list view drop zone logic, when the user leaves the drop zone area, set the target to `null` so that the drop indicator disappears.
* Update nesting logic so that if a user drags below the final item in the list, it won't be treated as a nesting gesture. This helps when a collapsed block is the last item in the list view, as a user dragging all the way to the bottom-most position likely wishes to move the block below rather than nest.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. In the post editor and site editors, experiment with dragging blocks to the top-most and bottom-most positions. Compared with `trunk`, it should be a lot easier to drop to these positions.
2. Test with short list views and really long post content.
3. If the last block in the list is a collapsed container block (e.g. group), then the nesting gesture should only apply when dragging over the bottom half of that block — if you drag further down, the drop indicator should change to be beneath that block rather than inside it.
4. If the last block in the list is an expanded container block with some level of nesting, then dragging to parents should still work when dragging well below the bottom block position.
5. Smoke test that dragging regular blocks in the editor canvas works as on trunk.
6. Smoke test other list view instances (e.g. navigation in editor browse mode) that nothing breaks elsewhere.

## Screenshots or screencast <!-- if applicable -->

Note how in the before version, the Heading looks like it can be dropped to the very bottom of the area by dragging well below, but it cannot. In the after version, the drop is respected correctly.

| Before | After |
| --- | --- |
| ![2023-05-18 17 17 20](https://github.com/WordPress/gutenberg/assets/14988353/766f276b-2cd7-4e66-9b16-2d6ac9ff769d) | ![2023-05-18 17 13 38](https://github.com/WordPress/gutenberg/assets/14988353/6e1d58e4-af37-414a-ad7d-f762cda2fb54) |

Some more details of the behaviour in this PR:

| Dragging up the block hierarchy should still work when cursor is lower than the last block | Nesting a collapsed block only happens if the cursor is over the block (makes it easier to drop below) |
| --- | --- |
| ![2023-05-19 12 00 02](https://github.com/WordPress/gutenberg/assets/14988353/abd06731-3cbb-4321-9809-f37a591022ab) | ![2023-05-19 11 59 31](https://github.com/WordPress/gutenberg/assets/14988353/c390335e-504c-431d-b9a7-a7db0b93e166) |