### PR TITLE
Update `runtime` test field in WebPack config to support Windows

### DIFF
--- a/tools/webpack/blocks.js
+++ b/tools/webpack/blocks.js
@@ -251,7 +251,7 @@ module.exports = [
 					},
 					runtime: {
 						name: 'runtime',
-						test: /[\\/]utils\/interactivity[\\/]/,
+						test: /[\\/]utils[\\/]interactivity[\\/]/,
 						filename: './interactivity/[name].min.js',
 						chunks: 'all',
 						minSize: 0,


### PR DESCRIPTION
## What?
Update the `test` field in the WebPack config that is building the runtime file for the Interactivity API to support Windows.

## Why?
As explained in [this warning in WebPack docs](https://webpack.js.org/plugins/split-chunks-plugin/#optimizationsplitchunks): "When files paths are processed by webpack, they always contain / on Unix systems and \ on Windows. That's why using [\\/] in {cacheGroup}.test fields is necessary to represent a path separator. / or \ in {cacheGroup}.test will cause issues when used cross-platform."

## How?
Using `[\\/]` for all the separators seems to fix the problem for Windows and it still works in other OS.

## Testing Instructions

### Before this change

In a Windows machine, run `npm run build` command and check that inside `build/block-library/interactivity` the `runtime.js` file (and minified ones) **ARE NOT** there.

### After this change

In a Windows machine, run `npm run build` command and check that inside `build/block-library/interactivity` the `runtime.js` file (and minified ones) **ARE** there.

We can also check that in other OS it keeps working as expected.
