### PR TITLE
Edit Site: Fix `useEditedEntityRecord()` loading state

### DIFF
--- a/packages/edit-site/src/components/use-edited-entity-record/index.js
+++ b/packages/edit-site/src/components/use-edited-entity-record/index.js
@@ -27,11 +27,13 @@ export default function useEditedEntityRecord( postType, postId ) {
 				usedPostType,
 				usedPostId
 			);
-			const _isLoaded = hasFinishedResolution( 'getEditedEntityRecord', [
-				'postType',
-				usedPostType,
-				usedPostId,
-			] );
+			const _isLoaded =
+				usedPostId &&
+				hasFinishedResolution( 'getEditedEntityRecord', [
+					'postType',
+					usedPostType,
+					usedPostId,
+				] );
 			const templateInfo = getTemplateInfo( _record );
 
 			return {

--- a/packages/edit-site/src/components/use-edited-entity-record/index.js
+++ b/packages/edit-site/src/components/use-edited-entity-record/index.js
@@ -16,7 +16,8 @@ export default function useEditedEntityRecord( postType, postId ) {
 		( select ) => {
 			const { getEditedPostType, getEditedPostId } =
 				select( editSiteStore );
-			const { getEditedEntityRecord } = select( coreStore );
+			const { getEditedEntityRecord, hasFinishedResolution } =
+				select( coreStore );
 			const { __experimentalGetTemplateInfo: getTemplateInfo } =
 				select( editorStore );
 			const usedPostType = postType ?? getEditedPostType();
@@ -26,8 +27,11 @@ export default function useEditedEntityRecord( postType, postId ) {
 				usedPostType,
 				usedPostId
 			);
-			const _isLoaded =
-				!! usedPostId && _record && Object.keys( _record ).length > 0;
+			const _isLoaded = hasFinishedResolution( 'getEditedEntityRecord', [
+				'postType',
+				usedPostType,
+				usedPostId,
+			] );
 			const templateInfo = getTemplateInfo( _record );
 
 			return {

--- a/packages/edit-site/src/components/use-edited-entity-record/index.js
+++ b/packages/edit-site/src/components/use-edited-entity-record/index.js
@@ -26,7 +26,8 @@ export default function useEditedEntityRecord( postType, postId ) {
 				usedPostType,
 				usedPostId
 			);
-			const _isLoaded = !! usedPostId;
+			const _isLoaded =
+				!! usedPostId && _record && Object.keys( _record ).length > 0;
 			const templateInfo = getTemplateInfo( _record );
 
 			return {


### PR DESCRIPTION
## What?
This PR fixes the `null` title that appears when fresh loading a template part.

## Why?
While working on testing site editor loading experience in various areas, I discovered that on a fresh load of a template part, the title of the document shortly appears as "null > Template Part > {SITE NAME}". 

## How?
It seems that the loaded state (`isLoaded`) of the `useEditedEntityRecord()` hook doesn't work correctly for template parts. The reason is that we're currently relying on a `!! postID` check to verify entity record has loaded, and the post ID for a template part is always a string (like `twentytwentytwo//header` for example). That way, it's always considered `true`, and when passing the `null` title to the `useTitle()` hook, it is converted to a `null` string.

Since this is leading to a bigger issue, where the loading experience could be broken in other places due to it always being considered loaded, we're fixing the loaded state by having it check if the entity record is not empty. 

## Testing Instructions
* Open a template part.
* Refresh the page to get a fresh page load.
* Verify that the document title never is "null > Template Part > ...." and it correctly is set to the title of the template part once it's loaded.

### Testing Instructions for Keyboard
None

## Screenshots or screencast <!-- if applicable -->
Demo of the issue (watch the last 5-6 seconds):

https://github.com/WordPress/gutenberg/assets/8436925/48a066ea-525c-4f08-a245-15e1b69ef094
