### PR TITLE
Mobile - E2E test - Update code to use the new navigateUp helper

### DIFF
--- a/packages/react-native-editor/__device-tests__/gutenberg-editor-media-blocks-@canary.test.js
+++ b/packages/react-native-editor/__device-tests__/gutenberg-editor-media-blocks-@canary.test.js
@@ -133,7 +133,7 @@ onlyOniOS( 'Gutenberg Editor Cover Block test', () => {
 		expect( coverBlock ).toBeTruthy();
 
 		// Navigate upwards to select parent block
-		await editorPage.navigateUp();
+		await editorPage.moveBlockSelectionUp();
 		await editorPage.removeBlockAtPosition( blockNames.cover );
 	} );
 
@@ -148,7 +148,7 @@ onlyOniOS( 'Gutenberg Editor Cover Block test', () => {
 		);
 		await coverBlock.click();
 		// Navigate upwards to select parent block
-		await editorPage.navigateUp();
+		await editorPage.moveBlockSelectionUp();
 
 		await editorPage.openBlockSettings();
 		await editorPage.clickAddMediaFromCoverBlock();

--- a/packages/react-native-editor/__device-tests__/gutenberg-editor-media-blocks-@canary.test.js
+++ b/packages/react-native-editor/__device-tests__/gutenberg-editor-media-blocks-@canary.test.js
@@ -133,9 +133,7 @@ onlyOniOS( 'Gutenberg Editor Cover Block test', () => {
 		expect( coverBlock ).toBeTruthy();
 
 		// Navigate upwards to select parent block
-		const navigateUpElement =
-			await editorPage.waitForElementToBeDisplayedById( 'Navigate Up' );
-		await navigateUpElement.click();
+		await editorPage.navigateUp();
 		await editorPage.removeBlockAtPosition( blockNames.cover );
 	} );
 
@@ -150,9 +148,7 @@ onlyOniOS( 'Gutenberg Editor Cover Block test', () => {
 		);
 		await coverBlock.click();
 		// Navigate upwards to select parent block
-		const navigateUpElement =
-			await editorPage.waitForElementToBeDisplayedById( 'Navigate Up' );
-		await navigateUpElement.click();
+		await editorPage.navigateUp();
 
 		await editorPage.openBlockSettings();
 		await editorPage.clickAddMediaFromCoverBlock();

--- a/packages/react-native-editor/__device-tests__/pages/editor-page.js
+++ b/packages/react-native-editor/__device-tests__/pages/editor-page.js
@@ -499,7 +499,7 @@ class EditorPage {
 		await toolBarButton.click();
 	}
 
-	async navigateUp( options = { recursive: false } ) {
+	async moveBlockSelectionUp( options = { toRoot: false } ) {
 		let navigateUpElements = [];
 		do {
 			await this.driver.sleep( 2000 );
@@ -509,7 +509,7 @@ class EditorPage {
 			if ( navigateUpElements.length > 0 ) {
 				await navigateUpElements[ 0 ].click();
 			}
-			if ( ! options.recursive ) {
+			if ( ! options.toRoot ) {
 				break;
 			}
 		} while ( navigateUpElements.length > 0 );

--- a/packages/react-native-editor/__device-tests__/pages/editor-page.js
+++ b/packages/react-native-editor/__device-tests__/pages/editor-page.js
@@ -499,7 +499,7 @@ class EditorPage {
 		await toolBarButton.click();
 	}
 
-	async navigateUp() {
+	async navigateUp( options = { recursive: false } ) {
 		let navigateUpElements = [];
 		do {
 			await this.driver.sleep( 2000 );
@@ -508,6 +508,9 @@ class EditorPage {
 			);
 			if ( navigateUpElements.length > 0 ) {
 				await navigateUpElements[ 0 ].click();
+			}
+			if ( ! options.recursive ) {
+				break;
 			}
 		} while ( navigateUpElements.length > 0 );
 	}


### PR DESCRIPTION
**Related PRs:**
- https://github.com/WordPress/gutenberg/pull/50672
- https://github.com/wordpress-mobile/gutenberg-mobile/pull/5781

## What?
This PR is a follow-up of https://github.com/WordPress/gutenberg/pull/50672 where the `navigateUp` helper was introduced.

## Why?
To update current tests to use the new helper.

## How?
It updates one E2E test to use the `navigateUp` helper.

The `navigateUp` helper gets an update where it'll accept an object with options, currently only one option is supported. The `recursive` option will be `false` as its default value, it it's `true` it will loop until there are no more up levels to go to.

## Testing Instructions
CI checks should pass on this PR and on Gutenberg Mobile.

### Testing Instructions for Keyboard
N/A

## Screenshots or screencast <!-- if applicable -->
N/A