### PR TITLE
Fix flaky media inserter drag-and-dropping e2e test

### DIFF
--- a/test/e2e/specs/editor/blocks/image.spec.js
+++ b/test/e2e/specs/editor/blocks/image.spec.js
@@ -552,9 +552,16 @@ test.describe( 'Image', () => {
 		} );
 
 		async function openMediaTab() {
-			await page
-				.getByRole( 'button', { name: 'Toggle block inserter' } )
-				.click();
+			const blockInserter = page.getByRole( 'button', {
+				name: 'Toggle block inserter',
+			} );
+			const isClosed =
+				( await blockInserter.getAttribute( 'aria-pressed' ) ) ===
+				'false';
+
+			if ( isClosed ) {
+				await blockInserter.click();
+			}
 
 			await blockLibrary.getByRole( 'tab', { name: 'Media' } ).click();
 


### PR DESCRIPTION
## What?
Fixes #50325.

PR fixes flaky "can be replaced by dragging-and-dropping images from the inserter" e2e test.

## Why?
A consecutive call to `openMediaTab` will close the block inserter if it's open, and block library locators will fail. The [first test assertion](https://github.com/WordPress/gutenberg/blob/37a691faacdb98cefa201c558bbd7fe18f171ebd/test/e2e/specs/editor/blocks/image.spec.js#L576-L592) closes the inserter sometimes and allows the test to pass.

The test trace from this run can be used to confirm my theory - https://github.com/WordPress/gutenberg/actions/runs/5013447893.

## How?
I adjust the logic in `openMediaTab` to avoid accidentally closing the inserter.

## Testing Instructions
1. Update the test and add the `openMediaTab` call below the first one.
2. Run the test and confirm it still passes.

```
npm run test:e2e:playwright -- test/e2e/specs/editor/blocks/image.spec.js
```