### PR TITLE
Fix gutenberg_get_block_editor_settings overriding other hooks

### DIFF
--- a/lib/block-editor-settings.php
+++ b/lib/block-editor-settings.php
@@ -79,4 +79,4 @@ function gutenberg_get_block_editor_settings( $settings ) {
 
 	return $settings;
 }
-add_filter( 'block_editor_settings_all', 'gutenberg_get_block_editor_settings', PHP_INT_MAX );
+add_filter( 'block_editor_settings_all', 'gutenberg_get_block_editor_settings', 0 );

--- a/lib/block-editor-settings.php
+++ b/lib/block-editor-settings.php
@@ -76,6 +76,72 @@ function gutenberg_get_block_editor_settings( $settings ) {
 
 	// Copied from get_block_editor_settings() at wordpress-develop/block-editor.php.
 	$settings['__experimentalFeatures'] = gutenberg_get_global_settings();
+	// These settings may need to be updated based on data coming from theme.json sources.
+	if ( isset( $settings['__experimentalFeatures']['color']['palette'] ) ) {
+		$colors_by_origin          = $settings['__experimentalFeatures']['color']['palette'];
+		$settings['colors'] = isset( $colors_by_origin['custom'] ) ?
+			$colors_by_origin['custom'] : (
+				isset( $colors_by_origin['theme'] ) ?
+					$colors_by_origin['theme'] :
+					$colors_by_origin['default']
+			);
+	}
+	if ( isset( $settings['__experimentalFeatures']['color']['gradients'] ) ) {
+		$gradients_by_origin          = $settings['__experimentalFeatures']['color']['gradients'];
+		$settings['gradients'] = isset( $gradients_by_origin['custom'] ) ?
+			$gradients_by_origin['custom'] : (
+				isset( $gradients_by_origin['theme'] ) ?
+					$gradients_by_origin['theme'] :
+					$gradients_by_origin['default']
+			);
+	}
+	if ( isset( $settings['__experimentalFeatures']['typography']['fontSizes'] ) ) {
+		$font_sizes_by_origin         = $settings['__experimentalFeatures']['typography']['fontSizes'];
+		$settings['fontSizes'] = isset( $font_sizes_by_origin['custom'] ) ?
+			$font_sizes_by_origin['custom'] : (
+				isset( $font_sizes_by_origin['theme'] ) ?
+					$font_sizes_by_origin['theme'] :
+					$font_sizes_by_origin['default']
+			);
+	}
+	if ( isset( $settings['__experimentalFeatures']['color']['custom'] ) ) {
+		$settings['disableCustomColors'] = ! $settings['__experimentalFeatures']['color']['custom'];
+		unset( $settings['__experimentalFeatures']['color']['custom'] );
+	}
+	if ( isset( $settings['__experimentalFeatures']['color']['customGradient'] ) ) {
+		$settings['disableCustomGradients'] = ! $settings['__experimentalFeatures']['color']['customGradient'];
+		unset( $settings['__experimentalFeatures']['color']['customGradient'] );
+	}
+	if ( isset( $settings['__experimentalFeatures']['typography']['customFontSize'] ) ) {
+		$settings['disableCustomFontSizes'] = ! $settings['__experimentalFeatures']['typography']['customFontSize'];
+		unset( $settings['__experimentalFeatures']['typography']['customFontSize'] );
+	}
+	if ( isset( $settings['__experimentalFeatures']['typography']['lineHeight'] ) ) {
+		$settings['enableCustomLineHeight'] = $settings['__experimentalFeatures']['typography']['lineHeight'];
+		unset( $settings['__experimentalFeatures']['typography']['lineHeight'] );
+	}
+	if ( isset( $settings['__experimentalFeatures']['spacing']['units'] ) ) {
+		$settings['enableCustomUnits'] = $settings['__experimentalFeatures']['spacing']['units'];
+		unset( $settings['__experimentalFeatures']['spacing']['units'] );
+	}
+	if ( isset( $settings['__experimentalFeatures']['spacing']['padding'] ) ) {
+		$settings['enableCustomSpacing'] = $settings['__experimentalFeatures']['spacing']['padding'];
+		unset( $settings['__experimentalFeatures']['spacing']['padding'] );
+	}
+	if ( isset( $settings['__experimentalFeatures']['spacing']['customSpacingSize'] ) ) {
+		$settings['disableCustomSpacingSizes'] = ! $settings['__experimentalFeatures']['spacing']['customSpacingSize'];
+		unset( $settings['__experimentalFeatures']['spacing']['customSpacingSize'] );
+	}
+
+	if ( isset( $settings['__experimentalFeatures']['spacing']['spacingSizes'] ) ) {
+		$spacing_sizes_by_origin         = $settings['__experimentalFeatures']['spacing']['spacingSizes'];
+		$settings['spacingSizes'] = isset( $spacing_sizes_by_origin['custom'] ) ?
+			$spacing_sizes_by_origin['custom'] : (
+				isset( $spacing_sizes_by_origin['theme'] ) ?
+					$spacing_sizes_by_origin['theme'] :
+					$spacing_sizes_by_origin['default']
+			);
+	}
 
 	return $settings;
 }

--- a/lib/block-editor-settings.php
+++ b/lib/block-editor-settings.php
@@ -6,7 +6,12 @@
  */
 
 /**
- * Adds styles and __experimentalFeatures to the block editor settings.
+ * Replaces core 'styles' and '__experimentalFeatures' block editor settings from
+ * wordpress-develop/block-editor.php with the Gutenberg versions. Much of the
+ * code is copied from get_block_editor_settings() in that file.
+ *
+ * This hook should run first as it completely replaces the core settings that
+ * other hooks may need to update.
  *
  * Note: The settings that are WP version specific should be handled inside the `compat` directory.
  *
@@ -15,7 +20,6 @@
  * @return array New block editor settings.
  */
 function gutenberg_get_block_editor_settings( $settings ) {
-	// Recreate global styles.
 	$global_styles = array();
 	$presets       = array(
 		array(
@@ -74,7 +78,6 @@ function gutenberg_get_block_editor_settings( $settings ) {
 
 	$settings['styles'] = array_merge( $global_styles, get_block_editor_theme_styles() );
 
-	// Copied from get_block_editor_settings() at wordpress-develop/block-editor.php.
 	$settings['__experimentalFeatures'] = gutenberg_get_global_settings();
 	// These settings may need to be updated based on data coming from theme.json sources.
 	if ( isset( $settings['__experimentalFeatures']['color']['palette'] ) ) {

--- a/lib/block-editor-settings.php
+++ b/lib/block-editor-settings.php
@@ -81,7 +81,7 @@ function gutenberg_get_block_editor_settings( $settings ) {
 	$settings['__experimentalFeatures'] = gutenberg_get_global_settings();
 	// These settings may need to be updated based on data coming from theme.json sources.
 	if ( isset( $settings['__experimentalFeatures']['color']['palette'] ) ) {
-		$colors_by_origin          = $settings['__experimentalFeatures']['color']['palette'];
+		$colors_by_origin   = $settings['__experimentalFeatures']['color']['palette'];
 		$settings['colors'] = isset( $colors_by_origin['custom'] ) ?
 			$colors_by_origin['custom'] : (
 				isset( $colors_by_origin['theme'] ) ?
@@ -90,7 +90,7 @@ function gutenberg_get_block_editor_settings( $settings ) {
 			);
 	}
 	if ( isset( $settings['__experimentalFeatures']['color']['gradients'] ) ) {
-		$gradients_by_origin          = $settings['__experimentalFeatures']['color']['gradients'];
+		$gradients_by_origin   = $settings['__experimentalFeatures']['color']['gradients'];
 		$settings['gradients'] = isset( $gradients_by_origin['custom'] ) ?
 			$gradients_by_origin['custom'] : (
 				isset( $gradients_by_origin['theme'] ) ?
@@ -99,7 +99,7 @@ function gutenberg_get_block_editor_settings( $settings ) {
 			);
 	}
 	if ( isset( $settings['__experimentalFeatures']['typography']['fontSizes'] ) ) {
-		$font_sizes_by_origin         = $settings['__experimentalFeatures']['typography']['fontSizes'];
+		$font_sizes_by_origin  = $settings['__experimentalFeatures']['typography']['fontSizes'];
 		$settings['fontSizes'] = isset( $font_sizes_by_origin['custom'] ) ?
 			$font_sizes_by_origin['custom'] : (
 				isset( $font_sizes_by_origin['theme'] ) ?
@@ -137,7 +137,7 @@ function gutenberg_get_block_editor_settings( $settings ) {
 	}
 
 	if ( isset( $settings['__experimentalFeatures']['spacing']['spacingSizes'] ) ) {
-		$spacing_sizes_by_origin         = $settings['__experimentalFeatures']['spacing']['spacingSizes'];
+		$spacing_sizes_by_origin  = $settings['__experimentalFeatures']['spacing']['spacingSizes'];
 		$settings['spacingSizes'] = isset( $spacing_sizes_by_origin['custom'] ) ?
 			$spacing_sizes_by_origin['custom'] : (
 				isset( $spacing_sizes_by_origin['theme'] ) ?


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Other files that used the `block_editor_settings_all` hook and updated settings were getting overridden.

In gutenberg `WP_Duotone_Gutenberg::add_editor_settings` updated `$settings['styles']`.

In core `wp_add_editor_classic_theme_styles` also updated `$settings['styles']`.

I also expected that there may have been bugs with some of the `__experimentalFeature` settings since those were also completely being overridden and the renames weren't removed.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Bug fix.

1. Duotone filters weren't showing in the post editor.
   See https://github.com/WordPress/gutenberg/blob/trunk/lib/block-supports/duotone.php#L54.
2. `/css/classic-themes.css` wasn't being added for classic themes.
   See https://github.com/WordPress/wordpress-develop/blob/23b007b126fa73211b7db56a38e78e601e4abbc6/src/wp-includes/default-filters.php#L582.
3. `__experimentalFeatures` renames weren't being handled.
   See https://github.com/WordPress/wordpress-develop/blob/23b007b126fa73211b7db56a38e78e601e4abbc6/src/wp-includes/block-editor.php#L443

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

- Update the hook priority to run first.
- Copy the remaining `__experimentalFeatures` code from core.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## 1. Duotone filters weren't showing in the post editor.

1. Set `styles.blocks['core/cover'].filter.duotone` to an existing filter either via the site editor or in theme.json.
2. See that the filter you selected is correct in the post editor when adding a new cover block.

@jeryj, you reported this one to me, so would you be able to test it here?

## 2. `/css/classic-themes.css` wasn't being added for classic themes.

@scruffian fixed something similar in https://github.com/WordPress/gutenberg/pull/44334, but I would expect this issue to show in the post editor. Would you be able to confirm this one?

## 3. `__experimentalFeatures` renames weren't being handled.

@oandregal did something similar back in https://github.com/WordPress/gutenberg/pull/32059. Would you be able to confirm this one?

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
