### PR TITLE
Template revisions: require 2 revisions before showing the revisions UI

### DIFF
--- a/packages/edit-site/src/components/sidebar-edit-mode/template-revisions/index.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/template-revisions/index.js
@@ -19,8 +19,7 @@ const useRevisionData = () => {
 		currentTemplate?._links?.[ 'predecessor-version' ]?.[ 0 ]?.id ?? null;
 
 	const revisionsCount =
-		( currentTemplate?._links?.[ 'version-history' ]?.[ 0 ]?.count ?? 0 ) +
-		1;
+		currentTemplate?._links?.[ 'version-history' ]?.[ 0 ]?.count ?? 0;
 
 	return {
 		currentTemplate,


### PR DESCRIPTION
Resolves https://github.com/WordPress/gutenberg/issues/50675 (at least partially)

## What?
We want to have at least 2 revisions before showing the revisions UI for templates and template parts.

| Before | After|
| ------------- | ------------- |
| <img width="300" alt="Screenshot 2023-05-19 at 11 48 10 am" src="https://github.com/WordPress/gutenberg/assets/6458278/40fb8fa0-8a37-446a-88cf-a6d288928c48">  | <img width="300" alt="Screenshot 2023-05-19 at 11 47 19 am" src="https://github.com/WordPress/gutenberg/assets/6458278/481f6fb2-fab7-4e15-b16f-cfd0ff8b21ab"> |


## Why?
> When a user makes a first modification of a template part, a template part post is created and effectively takes over responsibility from the file. 

Quoting @talldan from https://github.com/WordPress/gutenberg/issues/50675#issuecomment-1550821851

Because of this, it takes another 2 edits to create 2 "revisions". Without that crucial second edit the revisions UI will not display an empty pane as it has nothing with which to compare the first.

## How?
Removing the `+ 1` on the revisions count.


## Testing Instructions

In the site editor, make three changes to a template.

The revisions button should display. 

Now check out the revisions UI and ensure that there is no blank revision on the right hand side.

Repeat for a template part.

cc @georgeh for review as well



## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/6458278/e6d37061-af1b-48e4-b1b8-d911d0a25de4

