### PR TITLE
Global styles revisions: remove unused private var

### DIFF
--- a/lib/compat/wordpress-6.3/class-gutenberg-rest-global-styles-controller-6-3.php
+++ b/lib/compat/wordpress-6.3/class-gutenberg-rest-global-styles-controller-6-3.php
@@ -11,14 +11,6 @@
  */
 class Gutenberg_REST_Global_Styles_Controller_6_3 extends Gutenberg_REST_Global_Styles_Controller_6_2 {
 	/**
-	 * Revision controller.
-	 *
-	 * @since 6.3.0
-	 * @var WP_REST_Revisions_Controller
-	 */
-	private $revisions_controller;
-
-	/**
 	 * Prepares links for the request.
 	 *
 	 * @since 5.9.0


### PR DESCRIPTION
## What?
`$this->revisions_controller` is not used. Let's delete it.

## Why?
It's not used.

## How?

<img width="615" alt="Screenshot 2023-05-19 at 12 07 48 pm" src="https://github.com/WordPress/gutenberg/assets/6458278/732ea4ed-b480-4fbd-a697-bdfc63fffe1d">

## Testing Instructions
Nothing should change. Tests should pass.
If you want, check that global styles revisions work in the site editor. Check the test instructions over at https://github.com/WordPress/gutenberg/pull/50089
