### PR TITLE
Site editor sidebar: add page details

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17778,6 +17778,7 @@
 				"@wordpress/url": "file:packages/url",
 				"@wordpress/viewport": "file:packages/viewport",
 				"@wordpress/widgets": "file:packages/widgets",
+				"@wordpress/wordcount": "file:packages/wordcount",
 				"classnames": "^2.3.1",
 				"colord": "^2.9.2",
 				"downloadjs": "^1.4.7",
@@ -25879,7 +25880,7 @@
 		"array-ify": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/array-ify/-/array-ify-1.0.0.tgz",
-			"integrity": "sha1-nlKHYrSpBmrRY6aWKjZEGOlibs4=",
+			"integrity": "sha512-c5AMf34bKdvPhQ7tBGhqkgKNUzMr4WUs+WDtC2ZUGOUncbxKMTvqxYctiseW3+L4bA8ec+GcZ6/A/FW4m8ukng==",
 			"dev": true
 		},
 		"array-includes": {
@@ -31048,7 +31049,7 @@
 		"debuglog": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/debuglog/-/debuglog-1.0.1.tgz",
-			"integrity": "sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=",
+			"integrity": "sha512-syBZ+rnAK3EgMsH2aYEOLUW7mZSY9Gb+0wUMCFsZvcmiz+HigA0LOcq/HoQqVuGG+EKykunc7QG2bzrponfaSw==",
 			"dev": true
 		},
 		"decache": {
@@ -35890,7 +35891,7 @@
 		"git-remote-origin-url": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/git-remote-origin-url/-/git-remote-origin-url-2.0.0.tgz",
-			"integrity": "sha1-UoJlna4hBxRaERJhEq0yFuxfpl8=",
+			"integrity": "sha512-eU+GGrZgccNJcsDH5LkXR3PB9M958hxc7sbA8DFJjrv9j4L2P/eZfKhM+QD6wyzpiv+b1BpK0XrYCxkovtjSLw==",
 			"dev": true,
 			"requires": {
 				"gitconfiglocal": "^1.0.0",
@@ -35937,7 +35938,7 @@
 		"gitconfiglocal": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/gitconfiglocal/-/gitconfiglocal-1.0.0.tgz",
-			"integrity": "sha1-QdBF84UaXqiPA/JMocYXgRRGS5s=",
+			"integrity": "sha512-spLUXeTAVHxDtKsJc8FkFVgFtMdEN9qPGpL23VfSHx4fP4+Ds097IXLvymbnDH8FnmxX5Nr9bPw3A+AQ6mWEaQ==",
 			"dev": true,
 			"requires": {
 				"ini": "^1.3.2"
@@ -37211,7 +37212,7 @@
 		"humanize-ms": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
-			"integrity": "sha1-xG4xWaKT9riW2ikxbYtv6Lt5u+0=",
+			"integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
 			"dev": true,
 			"requires": {
 				"ms": "^2.0.0"
@@ -38227,7 +38228,7 @@
 		"is-text-path": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-text-path/-/is-text-path-1.0.1.tgz",
-			"integrity": "sha1-Thqg+1G/vLPpJogAE5cgLBd1tm4=",
+			"integrity": "sha512-xFuJpne9oFz5qDaodwmmG08e3CawH/2ZV8Qqza1Ko7Sk8POWbkRdwIoAWVhqvq0XeUzANEhKo2n0IXUGBm7A/w==",
 			"dev": true,
 			"requires": {
 				"text-extensions": "^1.0.0"
@@ -40000,7 +40001,7 @@
 		"jsonparse": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
-			"integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
+			"integrity": "sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==",
 			"dev": true
 		},
 		"jsprim": {
@@ -41100,7 +41101,7 @@
 		"lodash.ismatch": {
 			"version": "4.4.0",
 			"resolved": "https://registry.npmjs.org/lodash.ismatch/-/lodash.ismatch-4.4.0.tgz",
-			"integrity": "sha1-dWy1FQyjum8RCFp4hJZF8Yj4Xzc=",
+			"integrity": "sha512-fPMfXjGQEV9Xsq/8MTSgUf255gawYRbjwMyDbcvDhXgV7enSZA0hynz6vMPnpAb5iONEzBHBPsT+0zes5Z301g==",
 			"dev": true
 		},
 		"lodash.isplainobject": {
@@ -48603,7 +48604,7 @@
 		"promzard": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/promzard/-/promzard-0.3.0.tgz",
-			"integrity": "sha1-JqXW7ox97kyxIggwWs+5O6OCqe4=",
+			"integrity": "sha512-JZeYqd7UAcHCwI+sTOeUDYkvEU+1bQ7iE0UT1MgB/tERkAPkesW46MrpIySzODi+owTjZtiF8Ay5j9m60KmMBw==",
 			"dev": true,
 			"requires": {
 				"read": "1"
@@ -48637,7 +48638,7 @@
 		"proto-list": {
 			"version": "1.2.4",
 			"resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
-			"integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=",
+			"integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==",
 			"dev": true
 		},
 		"protocols": {
@@ -50194,7 +50195,7 @@
 		"read": {
 			"version": "1.0.7",
 			"resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
-			"integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
+			"integrity": "sha512-rSOKNYUmaxy0om1BNjMN4ezNT6VKK+2xF4GBhc81mkH7L60i6dp8qPYrkndNLT3QPphoII3maL9PVC9XmhHwVQ==",
 			"dev": true,
 			"requires": {
 				"mute-stream": "~0.0.4"
@@ -55551,7 +55552,7 @@
 		"temp-dir": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-1.0.0.tgz",
-			"integrity": "sha1-CnwOom06Oa+n4OvqnB/AvE2qAR0=",
+			"integrity": "sha512-xZFXEGbG7SNC3itwBzI3RYjq/cEhBkx2hJuKGIUOcEULmkQExXiHat2z/qkISYsuR+IKumhEfKKbV5qXmhICFQ==",
 			"dev": true
 		},
 		"terminal-link": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -17760,6 +17760,7 @@
 				"@wordpress/dom": "file:packages/dom",
 				"@wordpress/editor": "file:packages/editor",
 				"@wordpress/element": "file:packages/element",
+				"@wordpress/escape-html": "file:packages/escape-html",
 				"@wordpress/hooks": "file:packages/hooks",
 				"@wordpress/html-entities": "file:packages/html-entities",
 				"@wordpress/i18n": "file:packages/i18n",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17771,6 +17771,7 @@
 				"@wordpress/notices": "file:packages/notices",
 				"@wordpress/plugins": "file:packages/plugins",
 				"@wordpress/preferences": "file:packages/preferences",
+				"@wordpress/primitives": "file:packages/primitives",
 				"@wordpress/private-apis": "file:packages/private-apis",
 				"@wordpress/reusable-blocks": "file:packages/reusable-blocks",
 				"@wordpress/router": "file:packages/router",

--- a/packages/date/src/test/index.js
+++ b/packages/date/src/test/index.js
@@ -623,7 +623,7 @@ describe( 'Moment.js Localization', () => {
 	} );
 
 	describe( 'humanTimeDiff', () => {
-		it( 'should return human readable time differences', () => {
+		it( 'should return human readable time differences in the past', () => {
 			expect(
 				humanTimeDiff(
 					'2023-04-28T11:00:00.000Z',
@@ -642,6 +642,35 @@ describe( 'Moment.js Localization', () => {
 					'2023-04-30T13:00:00.000Z'
 				)
 			).toBe( '2 days ago' );
+
+			expect(
+				humanTimeDiff(
+					'2023-04-28T11:00:00.000Z',
+					'2023-04-28T13:00:00.000Z'
+				)
+			).toBe( '2 hours ago' );
+
+			expect(
+				humanTimeDiff(
+					'2023-04-26T13:00:00.000Z',
+					'2023-04-28T13:00:00.000Z'
+				)
+			).toBe( '2 days ago' );
+		} );
+
+		it( 'should return human readable time differences in the future', () => {
+			// Future.
+			const now = new Date();
+			const twoHoursLater = new Date(
+				now.getTime() + 2 * 60 * 60 * 1000
+			);
+			expect( humanTimeDiff( twoHoursLater ) ).toBe( 'in 2 hours' );
+
+			const twoDaysLater = new Date(
+				now.getTime() + 2 * 24 * 60 * 60 * 1000
+			); // Adding 2 days in milliseconds
+
+			expect( humanTimeDiff( twoDaysLater ) ).toBe( 'in 2 days' );
 		} );
 	} );
 } );

--- a/packages/date/src/test/index.js
+++ b/packages/date/src/test/index.js
@@ -642,20 +642,6 @@ describe( 'Moment.js Localization', () => {
 					'2023-04-30T13:00:00.000Z'
 				)
 			).toBe( '2 days ago' );
-
-			expect(
-				humanTimeDiff(
-					'2023-04-28T11:00:00.000Z',
-					'2023-04-28T13:00:00.000Z'
-				)
-			).toBe( '2 hours ago' );
-
-			expect(
-				humanTimeDiff(
-					'2023-04-26T13:00:00.000Z',
-					'2023-04-28T13:00:00.000Z'
-				)
-			).toBe( '2 days ago' );
 		} );
 
 		it( 'should return human readable time differences in the future', () => {

--- a/packages/edit-site/package.json
+++ b/packages/edit-site/package.json
@@ -61,6 +61,7 @@
 		"@wordpress/url": "file:../url",
 		"@wordpress/viewport": "file:../viewport",
 		"@wordpress/widgets": "file:../widgets",
+		"@wordpress/wordcount": "file:../wordcount",
 		"classnames": "^2.3.1",
 		"colord": "^2.9.2",
 		"downloadjs": "^1.4.7",

--- a/packages/edit-site/package.json
+++ b/packages/edit-site/package.json
@@ -43,6 +43,7 @@
 		"@wordpress/dom": "file:../dom",
 		"@wordpress/editor": "file:../editor",
 		"@wordpress/element": "file:../element",
+		"@wordpress/escape-html": "file:../escape-html",
 		"@wordpress/hooks": "file:../hooks",
 		"@wordpress/html-entities": "file:../html-entities",
 		"@wordpress/i18n": "file:../i18n",

--- a/packages/edit-site/package.json
+++ b/packages/edit-site/package.json
@@ -54,6 +54,7 @@
 		"@wordpress/notices": "file:../notices",
 		"@wordpress/plugins": "file:../plugins",
 		"@wordpress/preferences": "file:../preferences",
+		"@wordpress/primitives": "file:../primitives",
 		"@wordpress/private-apis": "file:../private-apis",
 		"@wordpress/reusable-blocks": "file:../reusable-blocks",
 		"@wordpress/router": "file:../router",

--- a/packages/edit-site/src/components/sidebar-navigation-data-list/data-list-item.js
+++ b/packages/edit-site/src/components/sidebar-navigation-data-list/data-list-item.js
@@ -1,0 +1,25 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	__experimentalHStack as HStack,
+	__experimentalText as Text,
+} from '@wordpress/components';
+
+export default function DataListItem( { label, value } ) {
+	return (
+		<HStack
+			className="edit-site-sidebar-navigation_data-list__item"
+			key={ label }
+			spacing={ 5 }
+			alignment="left"
+		>
+			<Text className="edit-site-sidebar-navigation_data-list__label">
+				{ label }
+			</Text>
+			<Text className="edit-site-sidebar-navigation_data-list__value">
+				{ value }
+			</Text>
+		</HStack>
+	);
+}

--- a/packages/edit-site/src/components/sidebar-navigation-data-list/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-data-list/index.js
@@ -1,0 +1,33 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+	__experimentalText as Text,
+} from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+
+export default function SidebarDetails( { details } ) {
+	return (
+		<VStack className="edit-site-sidebar-data-list" spacing={ 4 }>
+			{ details.map( ( detail ) => (
+				<HStack
+					className="edit-site-sidebar-navigation-screen_data-list-item"
+					key={ detail.label }
+					spacing={ 2 }
+				>
+					<Text className="edit-site-sidebar-data-list__label">
+						{ detail.label }
+					</Text>
+					<Text className="edit-site-sidebar-data-list__value">
+						{ detail.value }
+					</Text>
+				</HStack>
+			) ) }
+		</VStack>
+	);
+}

--- a/packages/edit-site/src/components/sidebar-navigation-data-list/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-data-list/index.js
@@ -7,10 +7,6 @@ import {
 	__experimentalText as Text,
 } from '@wordpress/components';
 
-/**
- * Internal dependencies
- */
-
 export default function SidebarDetails( { details } ) {
 	return (
 		<VStack

--- a/packages/edit-site/src/components/sidebar-navigation-data-list/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-data-list/index.js
@@ -1,31 +1,24 @@
 /**
  * WordPress dependencies
  */
-import {
-	__experimentalHStack as HStack,
-	__experimentalVStack as VStack,
-	__experimentalText as Text,
-} from '@wordpress/components';
+import { __experimentalVStack as VStack } from '@wordpress/components';
+/**
+ * Internal dependencies
+ */
+import DataListItem from './data-list-item';
 
 export default function SidebarDetails( { details } ) {
 	return (
 		<VStack
 			className="edit-site-sidebar-navigation_data-list"
-			spacing={ 10 }
+			spacing={ 5 }
 		>
 			{ details.map( ( detail ) => (
-				<HStack
-					className="edit-site-sidebar-navigation_data-list__item"
+				<DataListItem
 					key={ detail.label }
-					spacing={ 10 }
-				>
-					<Text className="edit-site-sidebar-navigation_data-list__label">
-						{ detail.label }
-					</Text>
-					<Text className="edit-site-sidebar-navigation_data-list__value">
-						{ detail.value }
-					</Text>
-				</HStack>
+					label={ detail.label }
+					value={ detail.value }
+				/>
 			) ) }
 		</VStack>
 	);

--- a/packages/edit-site/src/components/sidebar-navigation-data-list/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-data-list/index.js
@@ -13,17 +13,20 @@ import {
 
 export default function SidebarDetails( { details } ) {
 	return (
-		<VStack className="edit-site-sidebar-data-list" spacing={ 4 }>
+		<VStack
+			className="edit-site-sidebar-navigation_data-list"
+			spacing={ 10 }
+		>
 			{ details.map( ( detail ) => (
 				<HStack
-					className="edit-site-sidebar-navigation-screen_data-list-item"
+					className="edit-site-sidebar-navigation_data-list__item"
 					key={ detail.label }
-					spacing={ 2 }
+					spacing={ 10 }
 				>
-					<Text className="edit-site-sidebar-data-list__label">
+					<Text className="edit-site-sidebar-navigation_data-list__label">
 						{ detail.label }
 					</Text>
-					<Text className="edit-site-sidebar-data-list__value">
+					<Text className="edit-site-sidebar-navigation_data-list__value">
 						{ detail.value }
 					</Text>
 				</HStack>

--- a/packages/edit-site/src/components/sidebar-navigation-data-list/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-data-list/style.scss
@@ -1,0 +1,5 @@
+.edit-site-sidebar-data-list {
+	.edit-site-sidebar-data-list__label {
+		color: $gray-600;
+	}
+}

--- a/packages/edit-site/src/components/sidebar-navigation-data-list/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-data-list/style.scss
@@ -2,11 +2,11 @@
 
 .edit-site-sidebar-navigation_data-list__item {
 	.edit-site-sidebar-navigation_data-list__label {
-		color: $gray-400;
+		color: $gray-600;
 		width: 100px;
 	}
 
 	.edit-site-sidebar-navigation_data-list__value.edit-site-sidebar-navigation_data-list__value {
-		color: $white;
+		color: $gray-200;
 	}
 }

--- a/packages/edit-site/src/components/sidebar-navigation-data-list/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-data-list/style.scss
@@ -1,5 +1,7 @@
-.edit-site-sidebar-data-list {
-	.edit-site-sidebar-data-list__label {
-		color: $gray-600;
-	}
+.edit-site-sidebar-navigation_data-list__label {
+	color: $gray-600;
+}
+
+.edit-site-sidebar-navigation_data-list__item .edit-site-sidebar-navigation_data-list__value {
+	color: $white;
 }

--- a/packages/edit-site/src/components/sidebar-navigation-data-list/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-data-list/style.scss
@@ -1,7 +1,12 @@
-.edit-site-sidebar-navigation_data-list__label {
-	color: $gray-600;
-}
 
-.edit-site-sidebar-navigation_data-list__value.edit-site-sidebar-navigation_data-list__value {
-	color: $white;
+
+.edit-site-sidebar-navigation_data-list__item {
+	.edit-site-sidebar-navigation_data-list__label {
+		color: $gray-400;
+		width: 100px;
+	}
+
+	.edit-site-sidebar-navigation_data-list__value.edit-site-sidebar-navigation_data-list__value {
+		color: $white;
+	}
 }

--- a/packages/edit-site/src/components/sidebar-navigation-data-list/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-data-list/style.scss
@@ -2,6 +2,6 @@
 	color: $gray-600;
 }
 
-.edit-site-sidebar-navigation_data-list__item .edit-site-sidebar-navigation_data-list__value {
+.edit-site-sidebar-navigation_data-list__value.edit-site-sidebar-navigation_data-list__value {
 	color: $white;
 }

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/style.scss
@@ -1,5 +1,5 @@
 .edit-site-sidebar-navigation-screen__description {
-	margin: 0 0 $grid-unit-40 $grid-unit-20;
+	margin: 0 0 $grid-unit-40 0;
 }
 
 .edit-site-sidebar-navigation-screen-navigation-menus__content {

--- a/packages/edit-site/src/components/sidebar-navigation-screen-page/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-page/index.js
@@ -5,6 +5,9 @@ import { __ } from '@wordpress/i18n';
 import { useDispatch } from '@wordpress/data';
 import {
 	__experimentalUseNavigator as useNavigator,
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+	__experimentalText as Text,
 	ExternalLink,
 } from '@wordpress/components';
 import { useEntityRecord } from '@wordpress/core-data';
@@ -18,6 +21,8 @@ import SidebarNavigationScreen from '../sidebar-navigation-screen';
 import { unlock } from '../../private-apis';
 import { store as editSiteStore } from '../../store';
 import SidebarButton from '../sidebar-button';
+import SidebarNavigationSubtitle from '../sidebar-navigation-subtitle';
+import SidebarDetails from '../sidebar-navigation-data-list';
 
 export default function SidebarNavigationScreenPage() {
 	const { setCanvasMode } = unlock( useDispatch( editSiteStore ) );
@@ -36,24 +41,231 @@ export default function SidebarNavigationScreenPage() {
 					icon={ pencil }
 				/>
 			}
-			description={ __(
-				'Pages are static and are not listed by date. Pages do not use tags or categories.'
-			) }
+			meta={
+				record ? (
+					<VStack spacing={ 3 }>
+						{ record?.link && (
+							<ExternalLink
+								className="edit-site-sidebar-navigation-screen__page-link"
+								href={ record.link }
+							>
+								{ record.link }
+							</ExternalLink>
+						) }
+						<PostStatus
+							status={ record.status }
+							date={ record.date }
+						/>
+					</VStack>
+				) : null
+			}
+			footer={
+				record && (
+					<PostModified
+						date={ record.modified }
+						user={ record.modifiedBy }
+					/>
+				)
+			}
 			content={
 				<>
-					{ record?.link ? (
-						<ExternalLink
-							className="edit-site-sidebar-navigation-screen__page-link"
-							href={ record.link }
-						>
-							{ record.link }
-						</ExternalLink>
-					) : null }
-					{ record
-						? decodeEntities( record?.description?.rendered )
-						: null }
+					<img
+						alt={ record?.title || 'no description' }
+						className="edit-site-sidebar-navigation-screen__page-image"
+						src="https://images.unsplash.com/photo-1579546929518-9e396f3cc809?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=2070&q=80"
+					/>
+					{ record?.excerpt?.raw && (
+						<Text>{ decodeEntities( record?.excerpt?.raw ) }</Text>
+					) }
+					<SidebarNavigationSubtitle>
+						Details
+					</SidebarNavigationSubtitle>
+					<SidebarDetails
+						details={ [
+							{ label: 'Template', value: 'Page' },
+							{ label: 'Parent', value: 'Top level' },
+							{ label: 'Words', value: '1402' },
+							{ label: 'Time to read', value: '7 minutes' },
+						] }
+					/>
 				</>
 			}
 		/>
 	);
 }
+
+const statusLabels = {
+	publish: 'Published',
+	future: 'Scheduled',
+	draft: 'Draft',
+	pending: 'Pending',
+};
+
+function relativeTime( date1, date2 ) {
+	const diffInSeconds = Math.abs( date1.getTime() - date2.getTime() ) / 1000;
+
+	const units = [
+		{ name: 'second', limit: 60, in_seconds: 1 },
+		{ name: 'minute', limit: 3600, in_seconds: 60 },
+		{ name: 'hour', limit: 86400, in_seconds: 3600 },
+		{ name: 'day', limit: 604800, in_seconds: 86400 },
+		{ name: 'week', limit: 2629743, in_seconds: 604800 },
+		{ name: 'month', limit: 31556926, in_seconds: 2629743 },
+		{ name: 'year', limit: Infinity, in_seconds: 31556926 },
+	];
+
+	let i = 0,
+		unit;
+	while ( ( unit = units[ i++ ] ) ) {
+		if ( diffInSeconds < unit.limit || ! unit.limit ) {
+			const diff = Math.floor( diffInSeconds / unit.in_seconds );
+			return (
+				diff +
+				' ' +
+				unit.name +
+				( diff > 1 ? 's' : '' ) +
+				' ' +
+				( date1 > date2 ? 'ago' : 'from now' )
+			);
+		}
+	}
+}
+
+export const PostStatus = ( { status, date } ) => {
+	const statusLabel = statusLabels[ status ] ?? 'Unknown';
+	const formattedDate = date
+		? relativeTime( new Date(), new Date( date ) )
+		: null;
+
+	return (
+		<HStack alignment="left" spacing={ 3 }>
+			{ /* <StatusIcon status={ status } /> */ }
+			<Text>{ statusLabel }</Text>
+			{ formattedDate && <Text>{ formattedDate }</Text> }
+		</HStack>
+	);
+};
+
+// const StatusIcon = ( { status } ) => {
+// 	switch ( status ) {
+// 		case 'draft':
+// 			return <DraftIcon />;
+// 		case 'pending':
+// 			return <PendingIcon />;
+// 		case 'future':
+// 			return <ScheduledIcon />;
+// 		case 'publish':
+// 			return <PublishIcon />;
+// 	}
+// 	return null;
+// };
+
+const PostModified = ( { date } ) => {
+	return (
+		<HStack
+			className="edit-site-sidebar-modified"
+			alignment="left"
+			spacing={ 3 }
+		>
+			<div className="edit-site-sidebar-modified__avatar" />
+			<Text>
+				Last modified { relativeTime( new Date(), new Date( date ) ) }{ ' ' }
+				by Dan
+			</Text>
+		</HStack>
+	);
+};
+
+// const DraftIcon = () => (
+// 	<SVG
+// 		width="16"
+// 		height="16"
+// 		viewBox="0 0 16 16"
+// 		fill="none"
+// 		xmlns="http://www.w3.org/2000/svg"
+// 	>
+// 		<Path
+// 			d="M12 8C12 10.2091 10.2091 12 8 12C8 10.5 8 10.2091 8 8C8 5.79086 8 6 8 4C10.2091 4 12 5.79086 12 8Z"
+// 			fill="#F0B849"
+// 		/>
+// 	</SVG>
+// );
+
+// const PendingIcon = () => (
+// 	<SVG
+// 		width="16"
+// 		height="16"
+// 		viewBox="0 0 16 16"
+// 		fill="none"
+// 		xmlns="http://www.w3.org/2000/svg"
+// 	>
+// 		<G clipPath="url(#clip0_790_59125)">
+// 			<Rect x="4" y="4" width="8" height="8" rx="4" fill="#F0B849" />
+// 		</G>
+// 		<Rect
+// 			x="0.75"
+// 			y="0.75"
+// 			width="14.5"
+// 			height="14.5"
+// 			rx="7.25"
+// 			stroke="#F0B849"
+// 			strokeWidth="1.5"
+// 		/>
+// 		<defs>
+// 			<clipPath id="clip0_790_59125">
+// 				<Rect width="16" height="16" rx="8" fill="white" />
+// 			</clipPath>
+// 		</defs>
+// 	</SVG>
+// );
+
+// const ScheduledIcon = () => (
+// 	<SVG
+// 		width="16"
+// 		height="16"
+// 		viewBox="0 0 16 16"
+// 		fill="none"
+// 		xmlns="http://www.w3.org/2000/svg"
+// 	>
+// 		<G clipPath="url(#clip0_763_59172)">
+// 			<Circle cx="8" cy="8" r="4" fill="#4AB866" />
+// 		</G>
+// 		<Rect
+// 			x="0.75"
+// 			y="0.75"
+// 			width="14.5"
+// 			height="14.5"
+// 			rx="7.25"
+// 			stroke="#4AB866"
+// 			strokeWidth="1.5"
+// 		/>
+// 		<defs>
+// 			<clipPath id="clip0_763_59172">
+// 				<Rect width="16" height="16" rx="8" fill="white" />
+// 			</clipPath>
+// 		</defs>
+// 	</SVG>
+// );
+
+// const PublishIcon = () => (
+// 	<SVG
+// 		width="16"
+// 		height="16"
+// 		viewBox="0 0 16 16"
+// 		fill="none"
+// 		xmlns="http://www.w3.org/2000/svg"
+// 	>
+// 		<G clipPath="url(#clip0_823_59447)">
+// 			<Rect width="16" height="16" rx="8" fill="#4AB866" />
+// 			<Path
+// 				d="M11.1328 4.7334L6.93281 10.4001L4.73281 8.7334L4.13281 9.5334L7.13281 11.8001L11.9328 5.3334L11.1328 4.7334Z"
+// 				fill="#003008"
+// 			/>
+// 		</G>
+// 		<defs>
+// 			<clipPath id="clip0_823_59447">
+// 				<Rect width="16" height="16" rx="8" fill="white" />
+// 			</clipPath>
+// 		</defs>
+// 	</SVG>
+// );

--- a/packages/edit-site/src/components/sidebar-navigation-screen-page/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-page/index.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useDispatch } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 import {
 	__experimentalUseNavigator as useNavigator,
 	__experimentalHStack as HStack,
@@ -10,7 +10,11 @@ import {
 	__experimentalText as Text,
 	ExternalLink,
 } from '@wordpress/components';
-import { useEntityRecord } from '@wordpress/core-data';
+import {
+	store as coreStore,
+	useEntityRecord,
+	useEntityRecords,
+} from '@wordpress/core-data';
 import { decodeEntities } from '@wordpress/html-entities';
 import { pencil } from '@wordpress/icons';
 
@@ -24,12 +28,102 @@ import SidebarButton from '../sidebar-button';
 import SidebarNavigationSubtitle from '../sidebar-navigation-subtitle';
 import SidebarDetails from '../sidebar-navigation-data-list';
 
+function countWordsInHTML( htmlString ) {
+	const parser = new window.DOMParser();
+	const doc = parser.parseFromString( htmlString, 'text/html' );
+
+	let wordCount = 0;
+
+	function countWords( node ) {
+		if ( node.nodeType === 3 ) {
+			const text = node.textContent.trim();
+
+			if ( text !== '' ) {
+				const words = text.split( /\s+/ );
+				wordCount += words.length;
+			}
+		} else if ( node.nodeType === 1 ) {
+			const children = node.childNodes;
+			for ( let i = 0; i < children.length; i++ ) {
+				countWords( children[ i ] );
+			}
+		}
+	}
+
+	countWords( doc.body );
+	return wordCount;
+}
+const estimateReadingTime = ( wordCount, wordsPerMinute = 200 ) =>
+	Math.ceil( wordCount / wordsPerMinute );
+
+function getPageDetails( page ) {
+	if ( ! page ) {
+		return [];
+	}
+
+	const wordCount = countWordsInHTML( page?.content?.rendered ) || 0;
+	const readingTime = estimateReadingTime( wordCount );
+
+	return [
+		{
+			label: 'Template',
+			value: page?.templateTitle,
+		},
+		{
+			label: 'Parent',
+			value: page?.parentTitle,
+		},
+		{
+			label: 'Words',
+			value: wordCount.toLocaleString() || 'Unknown',
+		},
+		{
+			label: 'Time to read',
+			value:
+				readingTime > 1
+					? `${ readingTime.toLocaleString() } mins`
+					: '1 min',
+		},
+	];
+}
+
 export default function SidebarNavigationScreenPage() {
 	const { setCanvasMode } = unlock( useDispatch( editSiteStore ) );
 	const {
 		params: { postId },
 	} = useNavigator();
+
 	const { record } = useEntityRecord( 'postType', 'page', postId );
+	const { records: templates, isResolving: areTemplatesLoading } =
+		useEntityRecords( 'postType', 'wp_template', {
+			per_page: -1,
+		} );
+
+	const templateTitle = areTemplatesLoading
+		? ''
+		: templates?.find( ( template ) => template?.slug === record?.template )
+				?.title?.rendered || 'Default';
+
+	const parentTitle = useSelect(
+		( select ) => {
+			const parent = record?.parent
+				? select( coreStore ).getEntityRecord(
+						'postType',
+						'page',
+						record.parent
+				  )
+				: null;
+
+			if ( parent ) {
+				return parent?.title?.rendered
+					? decodeEntities( parent.title.rendered )
+					: 'No title';
+			}
+
+			return 'Top level';
+		},
+		[ record ]
+	);
 
 	return (
 		<SidebarNavigationScreen
@@ -81,12 +175,11 @@ export default function SidebarNavigationScreenPage() {
 						Details
 					</SidebarNavigationSubtitle>
 					<SidebarDetails
-						details={ [
-							{ label: 'Template', value: 'Page' },
-							{ label: 'Parent', value: 'Top level' },
-							{ label: 'Words', value: '1402' },
-							{ label: 'Time to read', value: '7 minutes' },
-						] }
+						details={ getPageDetails( {
+							parentTitle,
+							templateTitle,
+							...record,
+						} ) }
 					/>
 				</>
 			}

--- a/packages/edit-site/src/components/sidebar-navigation-screen-page/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-page/index.js
@@ -11,7 +11,6 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import {
 	__experimentalUseNavigator as useNavigator,
 	__experimentalVStack as VStack,
-	__experimentalText as Text,
 	ExternalLink,
 	__experimentalTruncate as Truncate,
 } from '@wordpress/components';
@@ -36,6 +35,7 @@ import { store as editSiteStore } from '../../store';
 import SidebarButton from '../sidebar-button';
 import SidebarNavigationSubtitle from '../sidebar-navigation-subtitle';
 import SidebarDetails from '../sidebar-navigation-data-list';
+import DataListItem from '../sidebar-navigation-data-list/data-list-item';
 import StatusLabel from './status-label';
 
 // Taken from packages/editor/src/components/time-to-read/index.js.
@@ -210,26 +210,23 @@ export default function SidebarNavigationScreenPage() {
 									'has-image': !! mediaSourceUrl,
 								}
 							) }
-							style={
-								!! mediaSourceUrl
-									? {
-											backgroundImage: `url(${ mediaSourceUrl })`,
-									  }
-									: {}
-							}
 						>
+							{ !! mediaSourceUrl && (
+								<img
+									alt={
+										mediaDescription
+											? decodeEntities( mediaDescription )
+											: decodeEntities(
+													record?.title?.rendered
+											  ) || __( 'Featured image' )
+									}
+									src={ mediaSourceUrl }
+								/>
+							) }
 							{ record && ! record?.featured_media && (
 								<p>{ __( 'No featured image' ) }</p>
 							) }
 						</div>
-						{ mediaSourceUrl && mediaDescription && (
-							<Truncate
-								className="edit-site-sidebar-navigation-screen-page__featured-image-description"
-								numberOfLines={ 1 }
-							>
-								{ decodeEntities( mediaDescription ) }
-							</Truncate>
-						) }
 					</VStack>
 					{ !! record?.excerpt?.raw && (
 						<Truncate
@@ -249,27 +246,24 @@ export default function SidebarNavigationScreenPage() {
 							...record,
 						} ) }
 					/>
-					{ !! record && (
-						<VStack className="edit-site-sidebar-navigation-screen__sticky-section">
-							<Text>
-								{ createInterpolateElement(
-									sprintf(
-										/* translators: %s: is the relative time when the post was last modified. */
-										__( 'Last modified <time>%s</time>' ),
-										humanTimeDiff( record.modified )
-									),
-									{
-										time: (
-											<time
-												dateTime={ record.modified }
-											/>
-										),
-									}
-								) }
-							</Text>
-						</VStack>
-					) }
 				</>
+			}
+			footer={
+				!! record ? (
+					<DataListItem
+						label={ __( 'Last modified' ) }
+						value={ createInterpolateElement(
+							sprintf(
+								/* translators: %s: is the relative time when the post was last modified. */
+								__( '<time>%s</time>' ),
+								humanTimeDiff( record.modified )
+							),
+							{
+								time: <time dateTime={ record.modified } />,
+							}
+						) }
+					/>
+				) : null
 			}
 		/>
 	);

--- a/packages/edit-site/src/components/sidebar-navigation-screen-page/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-page/index.js
@@ -112,24 +112,15 @@ export default function SidebarNavigationScreenPage() {
 		params: { postId },
 	} = useNavigator();
 	const { record } = useEntityRecord( 'postType', 'page', postId );
-	/*
-	 * Only custom template slugs are available in the post entity record
-	 * Pages using theme templates will not have a template slug.
-	 */
-	const { records: templates, isResolving: areTemplatesLoading } =
-		useEntityRecords( 'postType', 'wp_template', {
-			per_page: -1,
-		} );
-	const templateTitle = areTemplatesLoading
-		? ''
-		: templates?.find( ( template ) => template?.slug === record?.template )
-				?.title?.rendered || '';
 
 	const {
 		parentTitle,
 		featuredMediaDetails: { mediaSourceUrl, mediaDescription },
+		templateSlug,
 	} = useSelect(
 		( select ) => {
+			const { getEditedPostContext } = unlock( select( editSiteStore ) );
+
 			// Featured image.
 			const attachedMedia = record?.featured_media
 				? select( coreStore ).getEntityRecord(
@@ -156,6 +147,7 @@ export default function SidebarNavigationScreenPage() {
 
 			return {
 				parentTitle: _parentTitle,
+				templateSlug: getEditedPostContext()?.templateSlug,
 				featuredMediaDetails: {
 					...getMediaDetails( attachedMedia, postId ),
 					mediaDescription: attachedMedia?.description?.raw,
@@ -164,6 +156,18 @@ export default function SidebarNavigationScreenPage() {
 		},
 		[ record ]
 	);
+
+	// Match template slug to template title.
+	const { records: templates, isResolving: areTemplatesLoading } =
+		useEntityRecords( 'postType', 'wp_template', {
+			per_page: -1,
+		} );
+	const templateTitle =
+		! areTemplatesLoading && templateSlug
+			? templates?.find( ( template ) => template?.slug === templateSlug )
+					?.title?.rendered || templateSlug
+			: '';
+
 	const displayLink = record?.link
 		? record.link.replace( /^(https?:\/\/)?/, '' )
 		: null;

--- a/packages/edit-site/src/components/sidebar-navigation-screen-page/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-page/index.js
@@ -10,7 +10,6 @@ import { __, _x, sprintf } from '@wordpress/i18n';
 import { useDispatch, useSelect } from '@wordpress/data';
 import {
 	__experimentalUseNavigator as useNavigator,
-	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
 	__experimentalText as Text,
 	ExternalLink,
@@ -23,7 +22,7 @@ import {
 } from '@wordpress/core-data';
 import { decodeEntities } from '@wordpress/html-entities';
 import { pencil } from '@wordpress/icons';
-import { dateI18n, getDate, getSettings, humanTimeDiff } from '@wordpress/date';
+import { humanTimeDiff } from '@wordpress/date';
 import { count as wordCount } from '@wordpress/wordcount';
 import { getMediaDetails } from '@wordpress/editor';
 import { createInterpolateElement } from '@wordpress/element';
@@ -37,68 +36,10 @@ import { store as editSiteStore } from '../../store';
 import SidebarButton from '../sidebar-button';
 import SidebarNavigationSubtitle from '../sidebar-navigation-subtitle';
 import SidebarDetails from '../sidebar-navigation-data-list';
+import StatusLabel from './status-label';
 
 // Taken from packages/editor/src/components/time-to-read/index.js.
 const AVERAGE_READING_RATE = 189;
-
-function StatusLabel( { status, date } ) {
-	const relateToNow = humanTimeDiff( date );
-	let statusLabel = '';
-	switch ( status ) {
-		case 'publish':
-			statusLabel = createInterpolateElement(
-				sprintf(
-					/* translators: %s: is the relative time when the post was published. */
-					__( 'Published <time>%s</time>' ),
-					relateToNow
-				),
-				{ time: <time dateTime={ date } /> }
-			);
-			break;
-		case 'future':
-			const formattedDate = dateI18n(
-				getSettings().formats.date,
-				getDate( date )
-			);
-			statusLabel = createInterpolateElement(
-				sprintf(
-					/* translators: %s: is the formatted date and time on which the post is scheduled to be published. */
-					__( 'Scheduled for <time>%s</time>' ),
-					formattedDate
-				),
-				{ time: <time dateTime={ date } /> }
-			);
-			break;
-		case 'draft':
-			statusLabel = __( 'Draft' );
-			break;
-		case 'pending':
-			statusLabel = __( 'Pending' );
-			break;
-		default:
-			statusLabel = __( 'Unknown' );
-			break;
-	}
-
-	return (
-		<HStack
-			alignment="left"
-			spacing={ 2 }
-			className="edit-site-sidebar-navigation-screen-page__status"
-		>
-			<div
-				className={ classnames(
-					'edit-site-sidebar-navigation-screen-page__status-indicator',
-					{
-						[ `has-status has-${ status }-status` ]: !! status,
-					}
-				) }
-				aria-hidden="true"
-			/>
-			<Text>{ statusLabel }</Text>
-		</HStack>
-	);
-}
 
 function getPageDetails( page ) {
 	if ( ! page ) {
@@ -108,27 +49,27 @@ function getPageDetails( page ) {
 
 	if ( page?.status ) {
 		details.push( {
-			label: 'Status',
+			label: __( 'Status' ),
 			value: <StatusLabel status={ page.status } date={ page?.date } />,
 		} );
 	}
 
 	if ( page?.slug ) {
 		details.push( {
-			label: 'Slug',
+			label: __( 'Slug' ),
 			value: <Truncate numberOfLines={ 1 }>{ page.slug }</Truncate>,
 		} );
 	}
 
 	if ( page?.templateTitle ) {
 		details.push( {
-			label: 'Template',
+			label: __( 'Template' ),
 			value: page.templateTitle,
 		} );
 	}
 
 	details.push( {
-		label: 'Parent',
+		label: __( 'Parent' ),
 		value: page?.parentTitle,
 	} );
 

--- a/packages/edit-site/src/components/sidebar-navigation-screen-page/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-page/index.js
@@ -47,10 +47,16 @@ function getPageDetails( page ) {
 	if ( ! page ) {
 		return [];
 	}
+
 	const details = [
 		{
 			label: __( 'Status' ),
-			value: <StatusLabel status={ page.status } date={ page?.date } />,
+			value: (
+				<StatusLabel
+					status={ page?.password ? 'protected' : page.status }
+					date={ page?.date }
+				/>
+			),
 		},
 		{
 			label: __( 'Slug' ),

--- a/packages/edit-site/src/components/sidebar-navigation-screen-page/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-page/index.js
@@ -1,7 +1,12 @@
 /**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, _x, sprintf } from '@wordpress/i18n';
 import { useDispatch, useSelect } from '@wordpress/data';
 import {
 	__experimentalUseNavigator as useNavigator,
@@ -9,6 +14,7 @@ import {
 	__experimentalVStack as VStack,
 	__experimentalText as Text,
 	ExternalLink,
+	__experimentalTruncate as Truncate,
 } from '@wordpress/components';
 import {
 	store as coreStore,
@@ -17,6 +23,10 @@ import {
 } from '@wordpress/core-data';
 import { decodeEntities } from '@wordpress/html-entities';
 import { pencil } from '@wordpress/icons';
+import { dateI18n, getDate, getSettings, humanTimeDiff } from '@wordpress/date';
+import { count as wordCount } from '@wordpress/wordcount';
+import { getMediaDetails } from '@wordpress/editor';
+import { createInterpolateElement } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -28,63 +38,131 @@ import SidebarButton from '../sidebar-button';
 import SidebarNavigationSubtitle from '../sidebar-navigation-subtitle';
 import SidebarDetails from '../sidebar-navigation-data-list';
 
-function countWordsInHTML( htmlString ) {
-	const parser = new window.DOMParser();
-	const doc = parser.parseFromString( htmlString, 'text/html' );
+// Taken from packages/editor/src/components/time-to-read/index.js.
+const AVERAGE_READING_RATE = 189;
 
-	let wordCount = 0;
-
-	function countWords( node ) {
-		if ( node.nodeType === 3 ) {
-			const text = node.textContent.trim();
-
-			if ( text !== '' ) {
-				const words = text.split( /\s+/ );
-				wordCount += words.length;
-			}
-		} else if ( node.nodeType === 1 ) {
-			const children = node.childNodes;
-			for ( let i = 0; i < children.length; i++ ) {
-				countWords( children[ i ] );
-			}
-		}
+function StatusLabel( { status, date } ) {
+	const relateToNow = humanTimeDiff( date );
+	let statusLabel = '';
+	switch ( status ) {
+		case 'publish':
+			statusLabel = createInterpolateElement(
+				sprintf(
+					/* translators: %s: is the relative time when the post was published. */
+					__( 'Published <time>%s</time>' ),
+					relateToNow
+				),
+				{ time: <time dateTime={ date } /> }
+			);
+			break;
+		case 'future':
+			const formattedDate = dateI18n(
+				getSettings().formats.date,
+				getDate( date )
+			);
+			statusLabel = createInterpolateElement(
+				sprintf(
+					/* translators: %s: is the formatted date and time on which the post is scheduled to be published. */
+					__( 'Scheduled for <time>%s</time>' ),
+					formattedDate
+				),
+				{ time: <time dateTime={ date } /> }
+			);
+			break;
+		case 'draft':
+			statusLabel = __( 'Draft' );
+			break;
+		case 'pending':
+			statusLabel = __( 'Pending' );
+			break;
+		default:
+			statusLabel = __( 'Unknown' );
+			break;
 	}
 
-	countWords( doc.body );
-	return wordCount;
+	return (
+		<HStack
+			alignment="left"
+			spacing={ 2 }
+			className="edit-site-sidebar-navigation-screen-page__status"
+		>
+			<div
+				className={ classnames(
+					'edit-site-sidebar-navigation-screen-page__status-indicator',
+					{
+						[ `has-status has-${ status }-status` ]: !! status,
+					}
+				) }
+				aria-hidden="true"
+			/>
+			<Text>{ statusLabel }</Text>
+		</HStack>
+	);
 }
-const estimateReadingTime = ( wordCount, wordsPerMinute = 200 ) =>
-	Math.ceil( wordCount / wordsPerMinute );
 
 function getPageDetails( page ) {
 	if ( ! page ) {
 		return [];
 	}
+	const details = [];
 
-	const wordCount = countWordsInHTML( page?.content?.rendered ) || 0;
-	const readingTime = estimateReadingTime( wordCount );
+	if ( page?.status ) {
+		details.push( {
+			label: 'Status',
+			value: <StatusLabel status={ page.status } date={ page?.date } />,
+		} );
+	}
 
-	return [
-		{
+	if ( page?.slug ) {
+		details.push( {
+			label: 'Slug',
+			value: <Truncate numberOfLines={ 1 }>{ page.slug }</Truncate>,
+		} );
+	}
+
+	if ( page?.templateTitle ) {
+		details.push( {
 			label: 'Template',
-			value: page?.templateTitle,
-		},
-		{
-			label: 'Parent',
-			value: page?.parentTitle,
-		},
-		{
-			label: 'Words',
-			value: wordCount.toLocaleString() || 'Unknown',
-		},
-		{
-			label: 'Time to read',
-			value:
-				readingTime > 1
-					? `${ readingTime.toLocaleString() } mins`
-					: '1 min',
-		},
-	];
+			value: page.templateTitle,
+		} );
+	}
+
+	details.push( {
+		label: 'Parent',
+		value: page?.parentTitle,
+	} );
+
+	/*
+	 * translators: If your word count is based on single characters (e.g. East Asian characters),
+	 * enter 'characters_excluding_spaces' or 'characters_including_spaces'. Otherwise, enter 'words'.
+	 * Do not translate into your own language.
+	 */
+	const wordCountType = _x( 'words', 'Word count type. Do not translate!' );
+	const wordsCounted = page?.content?.raw
+		? wordCount( page.content.raw, wordCountType )
+		: 0;
+	const readingTime = Math.round( wordsCounted / AVERAGE_READING_RATE );
+
+	if ( wordsCounted ) {
+		details.push(
+			{
+				label: 'Words',
+				value: wordsCounted.toLocaleString() || __( 'Unknown' ),
+			},
+			{
+				label: 'Time to read',
+				value:
+					readingTime > 1
+						? sprintf(
+								/* translators: %s: is the number of minutes. */
+								__( '%s mins' ),
+								readingTime.toLocaleString()
+						  )
+						: __( '< 1 min' ),
+			}
+		);
+	}
+	return details;
 }
 
 export default function SidebarNavigationScreenPage() {
@@ -92,20 +170,35 @@ export default function SidebarNavigationScreenPage() {
 	const {
 		params: { postId },
 	} = useNavigator();
-
 	const { record } = useEntityRecord( 'postType', 'page', postId );
+	/*
+	 * Only custom template slugs are available in the post entity record
+	 * Pages using theme templates will not have a template slug.
+	 */
 	const { records: templates, isResolving: areTemplatesLoading } =
 		useEntityRecords( 'postType', 'wp_template', {
 			per_page: -1,
 		} );
-
 	const templateTitle = areTemplatesLoading
 		? ''
 		: templates?.find( ( template ) => template?.slug === record?.template )
-				?.title?.rendered || 'Default';
+				?.title?.rendered || '';
 
-	const parentTitle = useSelect(
+	const {
+		parentTitle,
+		featuredMediaDetails: { mediaSourceUrl, mediaDescription },
+	} = useSelect(
 		( select ) => {
+			// Featured image.
+			const attachedMedia = record?.featured_media
+				? select( coreStore ).getEntityRecord(
+						'postType',
+						'attachment',
+						record?.featured_media
+				  )
+				: null;
+
+			// Parent page title.
 			const parent = record?.parent
 				? select( coreStore ).getEntityRecord(
 						'postType',
@@ -113,21 +206,35 @@ export default function SidebarNavigationScreenPage() {
 						record.parent
 				  )
 				: null;
-
+			let _parentTitle = __( 'Top level' );
 			if ( parent ) {
-				return parent?.title?.rendered
+				_parentTitle = parent?.title?.rendered
 					? decodeEntities( parent.title.rendered )
-					: 'No title';
+					: __( 'Untitled' );
 			}
 
-			return 'Top level';
+			return {
+				parentTitle: _parentTitle,
+				featuredMediaDetails: {
+					...getMediaDetails( attachedMedia, postId ),
+					mediaDescription: attachedMedia?.description?.raw,
+				},
+			};
 		},
 		[ record ]
 	);
+	const displayLink = record?.link
+		? record.link.replace( /^(https?:\/\/)?/, '' )
+		: null;
 
 	return (
 		<SidebarNavigationScreen
-			title={ record ? decodeEntities( record?.title?.rendered ) : null }
+			className="edit-site-sidebar-navigation-screen-page"
+			title={
+				record
+					? decodeEntities( record?.title?.rendered )
+					: __( 'Untitled' )
+			}
 			actions={
 				<SidebarButton
 					onClick={ () => setCanvasMode( 'edit' ) }
@@ -136,40 +243,57 @@ export default function SidebarNavigationScreenPage() {
 				/>
 			}
 			meta={
-				record ? (
-					<VStack spacing={ 3 }>
-						{ record?.link && (
-							<ExternalLink
-								className="edit-site-sidebar-navigation-screen__page-link"
-								href={ record.link }
-							>
-								{ record.link }
-							</ExternalLink>
-						) }
-						<PostStatus
-							status={ record.status }
-							date={ record.date }
-						/>
-					</VStack>
-				) : null
-			}
-			footer={
-				record && (
-					<PostModified
-						date={ record.modified }
-						user={ record.modifiedBy }
-					/>
+				!! record?.link && (
+					<ExternalLink
+						className="edit-site-sidebar-navigation-screen__page-link"
+						href={ record.link }
+					>
+						{ displayLink }
+					</ExternalLink>
 				)
 			}
 			content={
 				<>
-					<img
-						alt={ record?.title || 'no description' }
-						className="edit-site-sidebar-navigation-screen__page-image"
-						src="https://images.unsplash.com/photo-1579546929518-9e396f3cc809?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=2070&q=80"
-					/>
-					{ record?.excerpt?.raw && (
-						<Text>{ decodeEntities( record?.excerpt?.raw ) }</Text>
+					<VStack
+						className="edit-site-sidebar-navigation-screen-page__featured-image-wrapper"
+						alignment="left"
+						spacing={ 2 }
+					>
+						<div
+							className={ classnames(
+								'edit-site-sidebar-navigation-screen-page__featured-image',
+								{
+									'has-image': !! mediaSourceUrl,
+								}
+							) }
+							style={
+								!! mediaSourceUrl
+									? {
+											backgroundImage: `url(${ mediaSourceUrl })`,
+									  }
+									: {}
+							}
+						>
+							{ record && ! record?.featured_media && (
+								<p>{ __( 'No featured image' ) }</p>
+							) }
+						</div>
+						{ mediaSourceUrl && mediaDescription && (
+							<Truncate
+								className="edit-site-sidebar-navigation-screen-page__featured-image-description"
+								numberOfLines={ 1 }
+							>
+								{ decodeEntities( mediaDescription ) }
+							</Truncate>
+						) }
+					</VStack>
+					{ !! record?.excerpt?.raw && (
+						<Truncate
+							className="edit-site-sidebar-navigation-screen-page__excerpt"
+							numberOfLines={ 3 }
+						>
+							{ decodeEntities( record?.excerpt?.raw ) }
+						</Truncate>
 					) }
 					<SidebarNavigationSubtitle>
 						Details
@@ -181,184 +305,28 @@ export default function SidebarNavigationScreenPage() {
 							...record,
 						} ) }
 					/>
+					{ !! record && (
+						<VStack className="edit-site-sidebar-navigation-screen__sticky-section">
+							<Text>
+								{ createInterpolateElement(
+									sprintf(
+										/* translators: %s: is the relative time when the post was last modified. */
+										__( 'Last modified <time>%s</time>' ),
+										humanTimeDiff( record.modified )
+									),
+									{
+										time: (
+											<time
+												dateTime={ record.modified }
+											/>
+										),
+									}
+								) }
+							</Text>
+						</VStack>
+					) }
 				</>
 			}
 		/>
 	);
 }
-
-const statusLabels = {
-	publish: 'Published',
-	future: 'Scheduled',
-	draft: 'Draft',
-	pending: 'Pending',
-};
-
-function relativeTime( date1, date2 ) {
-	const diffInSeconds = Math.abs( date1.getTime() - date2.getTime() ) / 1000;
-
-	const units = [
-		{ name: 'second', limit: 60, in_seconds: 1 },
-		{ name: 'minute', limit: 3600, in_seconds: 60 },
-		{ name: 'hour', limit: 86400, in_seconds: 3600 },
-		{ name: 'day', limit: 604800, in_seconds: 86400 },
-		{ name: 'week', limit: 2629743, in_seconds: 604800 },
-		{ name: 'month', limit: 31556926, in_seconds: 2629743 },
-		{ name: 'year', limit: Infinity, in_seconds: 31556926 },
-	];
-
-	let i = 0,
-		unit;
-	while ( ( unit = units[ i++ ] ) ) {
-		if ( diffInSeconds < unit.limit || ! unit.limit ) {
-			const diff = Math.floor( diffInSeconds / unit.in_seconds );
-			return (
-				diff +
-				' ' +
-				unit.name +
-				( diff > 1 ? 's' : '' ) +
-				' ' +
-				( date1 > date2 ? 'ago' : 'from now' )
-			);
-		}
-	}
-}
-
-export const PostStatus = ( { status, date } ) => {
-	const statusLabel = statusLabels[ status ] ?? 'Unknown';
-	const formattedDate = date
-		? relativeTime( new Date(), new Date( date ) )
-		: null;
-
-	return (
-		<HStack alignment="left" spacing={ 3 }>
-			{ /* <StatusIcon status={ status } /> */ }
-			<Text>{ statusLabel }</Text>
-			{ formattedDate && <Text>{ formattedDate }</Text> }
-		</HStack>
-	);
-};
-
-// const StatusIcon = ( { status } ) => {
-// 	switch ( status ) {
-// 		case 'draft':
-// 			return <DraftIcon />;
-// 		case 'pending':
-// 			return <PendingIcon />;
-// 		case 'future':
-// 			return <ScheduledIcon />;
-// 		case 'publish':
-// 			return <PublishIcon />;
-// 	}
-// 	return null;
-// };
-
-const PostModified = ( { date } ) => {
-	return (
-		<HStack
-			className="edit-site-sidebar-modified"
-			alignment="left"
-			spacing={ 3 }
-		>
-			<div className="edit-site-sidebar-modified__avatar" />
-			<Text>
-				Last modified { relativeTime( new Date(), new Date( date ) ) }{ ' ' }
-				by Dan
-			</Text>
-		</HStack>
-	);
-};
-
-// const DraftIcon = () => (
-// 	<SVG
-// 		width="16"
-// 		height="16"
-// 		viewBox="0 0 16 16"
-// 		fill="none"
-// 		xmlns="http://www.w3.org/2000/svg"
-// 	>
-// 		<Path
-// 			d="M12 8C12 10.2091 10.2091 12 8 12C8 10.5 8 10.2091 8 8C8 5.79086 8 6 8 4C10.2091 4 12 5.79086 12 8Z"
-// 			fill="#F0B849"
-// 		/>
-// 	</SVG>
-// );
-
-// const PendingIcon = () => (
-// 	<SVG
-// 		width="16"
-// 		height="16"
-// 		viewBox="0 0 16 16"
-// 		fill="none"
-// 		xmlns="http://www.w3.org/2000/svg"
-// 	>
-// 		<G clipPath="url(#clip0_790_59125)">
-// 			<Rect x="4" y="4" width="8" height="8" rx="4" fill="#F0B849" />
-// 		</G>
-// 		<Rect
-// 			x="0.75"
-// 			y="0.75"
-// 			width="14.5"
-// 			height="14.5"
-// 			rx="7.25"
-// 			stroke="#F0B849"
-// 			strokeWidth="1.5"
-// 		/>
-// 		<defs>
-// 			<clipPath id="clip0_790_59125">
-// 				<Rect width="16" height="16" rx="8" fill="white" />
-// 			</clipPath>
-// 		</defs>
-// 	</SVG>
-// );
-
-// const ScheduledIcon = () => (
-// 	<SVG
-// 		width="16"
-// 		height="16"
-// 		viewBox="0 0 16 16"
-// 		fill="none"
-// 		xmlns="http://www.w3.org/2000/svg"
-// 	>
-// 		<G clipPath="url(#clip0_763_59172)">
-// 			<Circle cx="8" cy="8" r="4" fill="#4AB866" />
-// 		</G>
-// 		<Rect
-// 			x="0.75"
-// 			y="0.75"
-// 			width="14.5"
-// 			height="14.5"
-// 			rx="7.25"
-// 			stroke="#4AB866"
-// 			strokeWidth="1.5"
-// 		/>
-// 		<defs>
-// 			<clipPath id="clip0_763_59172">
-// 				<Rect width="16" height="16" rx="8" fill="white" />
-// 			</clipPath>
-// 		</defs>
-// 	</SVG>
-// );
-
-// const PublishIcon = () => (
-// 	<SVG
-// 		width="16"
-// 		height="16"
-// 		viewBox="0 0 16 16"
-// 		fill="none"
-// 		xmlns="http://www.w3.org/2000/svg"
-// 	>
-// 		<G clipPath="url(#clip0_823_59447)">
-// 			<Rect width="16" height="16" rx="8" fill="#4AB866" />
-// 			<Path
-// 				d="M11.1328 4.7334L6.93281 10.4001L4.73281 8.7334L4.13281 9.5334L7.13281 11.8001L11.9328 5.3334L11.1328 4.7334Z"
-// 				fill="#003008"
-// 			/>
-// 		</G>
-// 		<defs>
-// 			<clipPath id="clip0_823_59447">
-// 				<Rect width="16" height="16" rx="8" fill="white" />
-// 			</clipPath>
-// 		</defs>
-// 	</SVG>
-// );

--- a/packages/edit-site/src/components/sidebar-navigation-screen-page/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-page/index.js
@@ -174,7 +174,6 @@ export default function SidebarNavigationScreenPage() {
 
 	return (
 		<SidebarNavigationScreen
-			className="edit-site-sidebar-navigation-screen-page"
 			title={
 				record
 					? decodeEntities( record?.title?.rendered )

--- a/packages/edit-site/src/components/sidebar-navigation-screen-page/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-page/index.js
@@ -87,11 +87,11 @@ function getPageDetails( page ) {
 	if ( wordsCounted ) {
 		details.push(
 			{
-				label: 'Words',
+				label: __( 'Words' ),
 				value: wordsCounted.toLocaleString() || __( 'Unknown' ),
 			},
 			{
-				label: 'Time to read',
+				label: __( 'Time to read' ),
 				value:
 					readingTime > 1
 						? sprintf(

--- a/packages/edit-site/src/components/sidebar-navigation-screen-page/status-label.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-page/status-label.js
@@ -1,0 +1,98 @@
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
+ * WordPress dependencies
+ */
+import { __, sprintf } from '@wordpress/i18n';
+import { dateI18n, getDate, getSettings, humanTimeDiff } from '@wordpress/date';
+import { createInterpolateElement } from '@wordpress/element';
+import { Path, SVG } from '@wordpress/primitives';
+
+const publishedIcon = (
+	<SVG fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+		<Path
+			fillRule="evenodd"
+			clipRule="evenodd"
+			d="M8 16A8 8 0 1 0 8 0a8 8 0 0 0 0 16Zm-1.067-5.6 4.2-5.667.8.6-4.8 6.467-3-2.267.6-.8 2.2 1.667Z"
+		/>
+	</SVG>
+);
+
+const draftIcon = (
+	<SVG fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+		<Path
+			fillRule="evenodd"
+			clipRule="evenodd"
+			d="M14.5 8a6.5 6.5 0 1 1-13 0 6.5 6.5 0 0 1 13 0ZM16 8A8 8 0 1 1 0 8a8 8 0 0 1 16 0Zm-8 4a4 4 0 0 0 0-8v8Z"
+		/>
+	</SVG>
+);
+
+const pendingIcon = (
+	<SVG fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+		<Path
+			fillRule="evenodd"
+			clipRule="evenodd"
+			d="M14.5 8a6.5 6.5 0 1 1-13 0 6.5 6.5 0 0 1 13 0ZM16 8A8 8 0 1 1 0 8a8 8 0 0 1 16 0ZM8 4a4 4 0 1 0 0 8 4 4 0 0 0 0-8Z"
+		/>
+	</SVG>
+);
+
+export default function StatusLabel( { status, date } ) {
+	const relateToNow = humanTimeDiff( date );
+	let statusLabel = '';
+	let statusIcon = pendingIcon;
+	switch ( status ) {
+		case 'publish':
+			statusLabel = createInterpolateElement(
+				sprintf(
+					/* translators: %s: is the relative time when the post was published. */
+					__( 'Published <time>%s</time>' ),
+					relateToNow
+				),
+				{ time: <time dateTime={ date } /> }
+			);
+			statusIcon = publishedIcon;
+			break;
+		case 'future':
+			const formattedDate = dateI18n(
+				getSettings().formats.date,
+				getDate( date )
+			);
+			statusLabel = createInterpolateElement(
+				sprintf(
+					/* translators: %s: is the formatted date and time on which the post is scheduled to be published. */
+					__( 'Scheduled for <time>%s</time>' ),
+					formattedDate
+				),
+				{ time: <time dateTime={ date } /> }
+			);
+			break;
+		case 'draft':
+			statusLabel = __( 'Draft' );
+			statusIcon = draftIcon;
+			break;
+		case 'pending':
+			statusLabel = __( 'Pending' );
+			break;
+		default:
+			statusLabel = __( 'Unknown' );
+			break;
+	}
+
+	return (
+		<div
+			className={ classnames(
+				'edit-site-sidebar-navigation-screen-page__status',
+				{
+					[ `has-status has-${ status }-status` ]: !! status,
+				}
+			) }
+		>
+			{ statusIcon } { statusLabel }
+		</div>
+	);
+}

--- a/packages/edit-site/src/components/sidebar-navigation-screen-page/status-label.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-page/status-label.js
@@ -78,6 +78,12 @@ export default function StatusLabel( { status, date } ) {
 		case 'pending':
 			statusLabel = __( 'Pending' );
 			break;
+		case 'private':
+			statusLabel = __( 'Private' );
+			break;
+		case 'protected':
+			statusLabel = __( 'Password protected' );
+			break;
 	}
 
 	return (

--- a/packages/edit-site/src/components/sidebar-navigation-screen-page/status-label.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-page/status-label.js
@@ -78,9 +78,6 @@ export default function StatusLabel( { status, date } ) {
 		case 'pending':
 			statusLabel = __( 'Pending' );
 			break;
-		default:
-			statusLabel = __( 'Unknown' );
-			break;
 	}
 
 	return (

--- a/packages/edit-site/src/components/sidebar-navigation-screen-page/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-page/style.scss
@@ -7,6 +7,7 @@
 	background-color: $gray-800;
 	margin-bottom: $grid-unit-20;
 	min-height: 128px;
+	border-radius: $grid-unit-05;
 }
 
 .edit-site-sidebar-navigation-screen-page__featured-image {

--- a/packages/edit-site/src/components/sidebar-navigation-screen-page/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-page/style.scss
@@ -1,10 +1,9 @@
 .edit-site-sidebar-navigation-screen__sticky-section {
 	padding: $grid-unit-40 0;
-	margin: $grid-unit-40 0;
+	margin: $grid-unit-40 $grid-unit-20;
 }
 
 .edit-site-sidebar-navigation-screen-page__featured-image-wrapper {
-	padding: $grid-unit-10;
 	background-color: $gray-800;
 	margin-bottom: $grid-unit-20;
 	min-height: 128px;
@@ -21,6 +20,12 @@
 	align-items: center;
 	justify-content: center;
 	color: $gray-600;
+	img {
+		object-fit: cover;
+		height: 100%;
+		width: 100%;
+		object-position: 50% 50%;
+	}
 }
 
 .edit-site-sidebar-navigation-screen-page__featured-image-description {

--- a/packages/edit-site/src/components/sidebar-navigation-screen-page/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-page/style.scss
@@ -1,0 +1,110 @@
+.edit-site-sidebar-navigation-screen-page {
+	.edit-site-sidebar-navigation-screen__sticky-section {
+		padding: $grid-unit-40 0;
+		margin: $grid-unit-40 0;
+	}
+}
+
+.edit-site-sidebar-navigation-screen-page__featured-image-wrapper {
+	padding: $grid-unit-10;
+	background-color: $gray-800;
+	margin-bottom: $grid-unit-20;
+	min-height: 128px;
+	.edit-site-sidebar-navigation-screen-page__featured-image {
+		border-radius: 2px;
+		height: 128px;
+		overflow: hidden;
+		width: 100%;
+		background-size: cover;
+		background-position: 50% 50%;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		color: $gray-600;
+	}
+
+	.edit-site-sidebar-navigation-screen-page__featured-image-description {
+		font-size: $helptext-font-size;
+	}
+}
+
+.edit-site-sidebar-navigation-screen-page__excerpt {
+	font-size: $helptext-font-size;
+}
+
+.edit-site-sidebar-navigation-screen-page__modified {
+	margin: 0 0 $grid-unit-20 0;
+	color: $gray-600;
+	margin-left: $grid-unit-20;
+	.components-text {
+		color: $gray-600;
+	}
+}
+
+.edit-site-sidebar-navigation-screen-page__status .components-text {
+	color: $white;
+}
+
+.edit-site-sidebar-navigation-screen-page__status-indicator {
+	display: none;
+	&.has-status {
+		border-radius: 999px;
+		height: 16px;
+		width: 16px;
+		display: flex;
+		align-items: center;
+		position: relative;
+		justify-content: center;
+
+		&::before {
+			height: 12px;
+			width: 12px;
+			border-radius: 60%;
+			border: 2px solid $gray-900;
+			display: block;
+			content: "";
+			position: absolute;
+		}
+	}
+
+	&.has-publish-status {
+		background-color: $alert-green;
+		&::before {
+			background-color: $alert-green;
+			border: none;
+			width: inherit;
+			height: inherit;
+			content: "\2713";
+			text-align: center;
+			color: $gray-900;
+			font-weight: 700;
+		}
+	}
+
+	&.has-future-status {
+		background-color: $alert-green;
+		&::before {
+			background-color: $alert-green;
+		}
+	}
+
+	&.has-pending-status {
+		background-color: $alert-yellow;
+		&::before {
+			background-color: $alert-yellow;
+		}
+	}
+
+	&.has-draft-status {
+		background-color: $alert-yellow;
+		&::before {
+			background-color: $gray-900;
+			border: 0;
+			border-radius: 0 0 8px 8px;
+			height: 8px;
+			left: -1px;
+			transform: rotate(90deg);
+			width: 13px;
+		}
+	}
+}

--- a/packages/edit-site/src/components/sidebar-navigation-screen-page/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-page/style.scss
@@ -1,8 +1,6 @@
-.edit-site-sidebar-navigation-screen-page {
-	.edit-site-sidebar-navigation-screen__sticky-section {
-		padding: $grid-unit-40 0;
-		margin: $grid-unit-40 0;
-	}
+.edit-site-sidebar-navigation-screen__sticky-section {
+	padding: $grid-unit-40 0;
+	margin: $grid-unit-40 0;
 }
 
 .edit-site-sidebar-navigation-screen-page__featured-image-wrapper {
@@ -10,22 +8,23 @@
 	background-color: $gray-800;
 	margin-bottom: $grid-unit-20;
 	min-height: 128px;
-	.edit-site-sidebar-navigation-screen-page__featured-image {
-		border-radius: 2px;
-		height: 128px;
-		overflow: hidden;
-		width: 100%;
-		background-size: cover;
-		background-position: 50% 50%;
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		color: $gray-600;
-	}
+}
 
-	.edit-site-sidebar-navigation-screen-page__featured-image-description {
-		font-size: $helptext-font-size;
-	}
+.edit-site-sidebar-navigation-screen-page__featured-image {
+	border-radius: 2px;
+	height: 128px;
+	overflow: hidden;
+	width: 100%;
+	background-size: cover;
+	background-position: 50% 50%;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	color: $gray-600;
+}
+
+.edit-site-sidebar-navigation-screen-page__featured-image-description {
+	font-size: $helptext-font-size;
 }
 
 .edit-site-sidebar-navigation-screen-page__excerpt {
@@ -41,70 +40,26 @@
 	}
 }
 
-.edit-site-sidebar-navigation-screen-page__status .components-text {
-	color: $white;
-}
+.edit-site-sidebar-navigation-screen-page__status {
+	display: inline-flex;
 
-.edit-site-sidebar-navigation-screen-page__status-indicator {
-	display: none;
-	&.has-status {
-		border-radius: 999px;
+	time {
+		display: contents;
+	}
+
+	svg {
 		height: 16px;
 		width: 16px;
-		display: flex;
-		align-items: center;
-		position: relative;
-		justify-content: center;
-
-		&::before {
-			height: 12px;
-			width: 12px;
-			border-radius: 60%;
-			border: 2px solid $gray-900;
-			display: block;
-			content: "";
-			position: absolute;
-		}
+		margin-right: $grid-unit-10;
 	}
 
-	&.has-publish-status {
-		background-color: $alert-green;
-		&::before {
-			background-color: $alert-green;
-			border: none;
-			width: inherit;
-			height: inherit;
-			content: "\2713";
-			text-align: center;
-			color: $gray-900;
-			font-weight: 700;
-		}
+	&.has-publish-status svg,
+	&.has-future-status svg {
+		fill: $alert-green;
 	}
 
-	&.has-future-status {
-		background-color: $alert-green;
-		&::before {
-			background-color: $alert-green;
-		}
-	}
-
-	&.has-pending-status {
-		background-color: $alert-yellow;
-		&::before {
-			background-color: $alert-yellow;
-		}
-	}
-
-	&.has-draft-status {
-		background-color: $alert-yellow;
-		&::before {
-			background-color: $gray-900;
-			border: 0;
-			border-radius: 0 0 8px 8px;
-			height: 8px;
-			left: -1px;
-			transform: rotate(90deg);
-			width: 13px;
-		}
+	&.has-pending-status svg,
+	&.has-draft-status svg {
+		fill: $alert-yellow;
 	}
 }

--- a/packages/edit-site/src/components/sidebar-navigation-screen-page/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-page/style.scss
@@ -57,15 +57,11 @@
 		height: 16px;
 		width: 16px;
 		margin-right: $grid-unit-10;
+		fill: $alert-yellow;
 	}
 
 	&.has-publish-status svg,
 	&.has-future-status svg {
 		fill: $alert-green;
-	}
-
-	&.has-pending-status svg,
-	&.has-draft-status svg {
-		fill: $alert-yellow;
 	}
 }

--- a/packages/edit-site/src/components/sidebar-navigation-screen-pages/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-pages/index.js
@@ -4,6 +4,7 @@
 import {
 	__experimentalItemGroup as ItemGroup,
 	__experimentalItem as Item,
+	__experimentalTruncate as Truncate,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useEntityRecords } from '@wordpress/core-data';
@@ -28,7 +29,8 @@ const PageItem = ( { postId, ...props } ) => {
 export default function SidebarNavigationScreenPages() {
 	const { records: pages, isResolving: isLoading } = useEntityRecords(
 		'postType',
-		'page'
+		'page',
+		{ status: 'any' }
 	);
 
 	return (
@@ -57,9 +59,11 @@ export default function SidebarNavigationScreenPages() {
 										key={ page.id }
 										withChevron
 									>
-										{ decodeEntities(
-											page.title?.rendered
-										) ?? __( '(no title)' ) }
+										<Truncate numberOfLines={ 1 }>
+											{ decodeEntities(
+												page.title?.rendered
+											) ?? __( 'Untitled' ) }
+										</Truncate>
 									</PageItem>
 								) ) }
 								<SidebarNavigationItem

--- a/packages/edit-site/src/components/sidebar-navigation-screen/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen/index.js
@@ -27,7 +27,9 @@ export default function SidebarNavigationScreen( {
 	isRoot,
 	title,
 	actions,
+	meta,
 	content,
+	footer,
 	description,
 } ) {
 	const { dashboardLink } = useSelect( ( select ) => {
@@ -40,7 +42,7 @@ export default function SidebarNavigationScreen( {
 	const theme = getTheme( currentlyPreviewingTheme() );
 
 	return (
-		<VStack spacing={ 2 }>
+		<VStack spacing={ 0 }>
 			<HStack
 				spacing={ 4 }
 				alignment="flex-start"
@@ -83,6 +85,13 @@ export default function SidebarNavigationScreen( {
 				</Heading>
 				{ actions }
 			</HStack>
+			{ meta && (
+				<>
+					<div className="edit-site-sidebar-navigation-screen__meta">
+						{ meta }
+					</div>
+				</>
+			) }
 
 			<nav className="edit-site-sidebar-navigation-screen__content">
 				{ description && (
@@ -92,6 +101,11 @@ export default function SidebarNavigationScreen( {
 				) }
 				{ content }
 			</nav>
+			{ footer && (
+				<footer className="edit-site-sidebar-navigation-screen__footer">
+					{ footer }
+				</footer>
+			) }
 		</VStack>
 	);
 }

--- a/packages/edit-site/src/components/sidebar-navigation-screen/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen/index.js
@@ -31,7 +31,6 @@ export default function SidebarNavigationScreen( {
 	content,
 	footer,
 	description,
-	...otherProps
 } ) {
 	const { dashboardLink } = useSelect( ( select ) => {
 		const { getSettings } = unlock( select( editSiteStore ) );
@@ -43,7 +42,7 @@ export default function SidebarNavigationScreen( {
 	const theme = getTheme( currentlyPreviewingTheme() );
 
 	return (
-		<VStack spacing={ 0 } { ...otherProps }>
+		<VStack spacing={ 0 }>
 			<HStack
 				spacing={ 4 }
 				alignment="flex-start"

--- a/packages/edit-site/src/components/sidebar-navigation-screen/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen/index.js
@@ -31,6 +31,7 @@ export default function SidebarNavigationScreen( {
 	content,
 	footer,
 	description,
+	...otherProps
 } ) {
 	const { dashboardLink } = useSelect( ( select ) => {
 		const { getSettings } = unlock( select( editSiteStore ) );
@@ -42,7 +43,7 @@ export default function SidebarNavigationScreen( {
 	const theme = getTheme( currentlyPreviewingTheme() );
 
 	return (
-		<VStack spacing={ 0 }>
+		<VStack spacing={ 0 } { ...otherProps }>
 			<HStack
 				spacing={ 4 }
 				alignment="flex-start"

--- a/packages/edit-site/src/components/sidebar-navigation-screen/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen/index.js
@@ -102,7 +102,7 @@ export default function SidebarNavigationScreen( {
 				{ content }
 			</nav>
 			{ footer && (
-				<footer className="edit-site-sidebar-navigation-screen__footer">
+				<footer className="edit-site-sidebar-navigation-screen__sticky-section">
 					{ footer }
 				</footer>
 			) }

--- a/packages/edit-site/src/components/sidebar-navigation-screen/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-screen/style.scss
@@ -8,7 +8,11 @@
 .edit-site-sidebar-navigation-screen__content {
 	margin: 0 0 $grid-unit-20 0;
 	color: $gray-400;
-	padding: $grid-unit-20;
+	padding: 0 $grid-unit-20;
+	.components-item-group {
+		margin-left: -$grid-unit-20;
+		margin-right: -$grid-unit-20;
+	}
 	.components-text {
 		color: $gray-400;
 	}
@@ -80,7 +84,6 @@
 }
 
 .edit-site-sidebar-navigation-screen__content .edit-site-global-styles-style-variations-container {
-	margin-left: $grid-unit-20;
 	.edit-site-global-styles-variations_item-preview {
 		border: $gray-900 $border-width solid;
 	}

--- a/packages/edit-site/src/components/sidebar-navigation-screen/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-screen/style.scss
@@ -7,7 +7,37 @@
 
 .edit-site-sidebar-navigation-screen__content {
 	margin: 0 0 $grid-unit-20 0;
+	color: $gray-400;
+	padding: $grid-unit-20;
+	.components-text {
+		color: $gray-400;
+	}
+	//z-index: z-index(".edit-site-sidebar-navigation-screen__content");
+}
+
+.edit-site-sidebar-navigation-screen__meta {
+	margin: 0 0 $grid-unit-20 0;
+	color: $gray-400;
+	margin-left: $grid-unit-20;
+	.components-text {
+		color: $gray-400;
+	}
+	//z-index: z-index(".edit-site-sidebar-navigation-screen__content");
+}
+
+.edit-site-sidebar-modified {
+	margin: 0 0 $grid-unit-20 0;
 	color: $gray-600;
+	margin-left: $grid-unit-20;
+	.components-text {
+		color: $gray-600;
+	}
+	.edit-site-sidebar-modified__avatar {
+		width: 16px;
+		height: 16px;
+		border-radius: 999px;
+		background: $gray-700;
+	}
 	//z-index: z-index(".edit-site-sidebar-navigation-screen__content");
 }
 
@@ -22,8 +52,15 @@
 	.components-external-link__icon {
 		margin-left: $grid-unit-05;
 	}
-	margin-left: $grid-unit-20;
 	display: inline-block;
+}
+
+.edit-site-sidebar-navigation-screen__page-image {
+	width: 100%;
+	border-radius: 2px;
+	margin-bottom: $grid-unit-20;
+	display: block;
+	max-height: 128px;
 }
 
 .edit-site-sidebar-navigation-screen__title-icon {

--- a/packages/edit-site/src/components/sidebar-navigation-screen/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-screen/style.scss
@@ -16,7 +16,6 @@
 	.components-text {
 		color: $gray-400;
 	}
-	//z-index: z-index(".edit-site-sidebar-navigation-screen__content");
 }
 
 .edit-site-sidebar-navigation-screen__meta {
@@ -26,23 +25,6 @@
 	.components-text {
 		color: $gray-400;
 	}
-	//z-index: z-index(".edit-site-sidebar-navigation-screen__content");
-}
-
-.edit-site-sidebar-modified {
-	margin: 0 0 $grid-unit-20 0;
-	color: $gray-600;
-	margin-left: $grid-unit-20;
-	.components-text {
-		color: $gray-600;
-	}
-	.edit-site-sidebar-modified__avatar {
-		width: 16px;
-		height: 16px;
-		border-radius: 999px;
-		background: $gray-700;
-	}
-	//z-index: z-index(".edit-site-sidebar-navigation-screen__content");
 }
 
 .edit-site-sidebar-navigation-screen__page-link {
@@ -57,14 +39,6 @@
 		margin-left: $grid-unit-05;
 	}
 	display: inline-block;
-}
-
-.edit-site-sidebar-navigation-screen__page-image {
-	width: 100%;
-	border-radius: 2px;
-	margin-bottom: $grid-unit-20;
-	display: block;
-	max-height: 128px;
 }
 
 .edit-site-sidebar-navigation-screen__title-icon {
@@ -97,4 +71,14 @@
 	.edit-site-global-styles-variations_item:focus .edit-site-global-styles-variations_item-preview {
 		border: var(--wp-admin-theme-color) var(--wp-admin-border-width-focus) solid;
 	}
+}
+
+.edit-site-sidebar-navigation-screen__sticky-section {
+	position: sticky;
+	bottom: 0;
+	background-color: $gray-900;
+	gap: 0;
+	padding: $grid-unit-20 0;
+	margin: $grid-unit-20 0 #{- $grid-unit-20} 0;
+	border-top: 1px solid $gray-800;
 }

--- a/packages/edit-site/src/components/sidebar-navigation-subtitle/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-subtitle/style.scss
@@ -3,5 +3,5 @@
 	text-transform: uppercase;
 	font-weight: 500;
 	font-size: 11px;
-	padding: $grid-unit-20 0 $grid-unit-10;
+	padding: $grid-unit-10 0;
 }

--- a/packages/edit-site/src/components/sidebar-navigation-subtitle/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-subtitle/style.scss
@@ -3,5 +3,5 @@
 	text-transform: uppercase;
 	font-weight: 500;
 	font-size: 11px;
-	padding: $grid-unit-20 0 0 $grid-unit-20;
+	padding: $grid-unit-20 0 $grid-unit-10;
 }

--- a/packages/edit-site/src/components/sidebar-navigation-subtitle/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-subtitle/style.scss
@@ -1,5 +1,5 @@
 .edit-site-sidebar-navigation-subtitle {
-	color: $gray-100;
+	color: $gray-400;
 	text-transform: uppercase;
 	font-weight: 500;
 	font-size: 11px;

--- a/packages/edit-site/src/style.scss
+++ b/packages/edit-site/src/style.scss
@@ -29,6 +29,7 @@
 @import "./components/sidebar-navigation-screen-template/style.scss";
 @import "./components/sidebar-navigation-screen-templates/style.scss";
 @import "./components/sidebar-navigation-subtitle/style.scss";
+@import "./components/sidebar-navigation-data-list/style.scss";
 @import "./components/site-hub/style.scss";
 @import "./components/sidebar-navigation-screen-navigation-menus/style.scss";
 @import "./components/site-icon/style.scss";

--- a/packages/edit-site/src/style.scss
+++ b/packages/edit-site/src/style.scss
@@ -26,6 +26,7 @@
 @import "./components/sidebar-navigation-item/style.scss";
 @import "./components/sidebar-navigation-screen/style.scss";
 @import "./components/sidebar-navigation-screen-pages/style.scss";
+@import "./components/sidebar-navigation-screen-page/style.scss";
 @import "./components/sidebar-navigation-screen-template/style.scss";
 @import "./components/sidebar-navigation-screen-templates/style.scss";
 @import "./components/sidebar-navigation-subtitle/style.scss";

--- a/packages/editor/src/components/index.js
+++ b/packages/editor/src/components/index.js
@@ -25,10 +25,7 @@ export { default as PostAuthorCheck } from './post-author/check';
 export { default as PostComments } from './post-comments';
 export { default as PostExcerpt } from './post-excerpt';
 export { default as PostExcerptCheck } from './post-excerpt/check';
-export {
-	default as PostFeaturedImage,
-	getMediaDetails,
-} from './post-featured-image';
+export { default as PostFeaturedImage } from './post-featured-image';
 export { default as PostFeaturedImageCheck } from './post-featured-image/check';
 export { default as PostFormat } from './post-format';
 export { default as PostFormatCheck } from './post-format/check';

--- a/packages/editor/src/components/index.js
+++ b/packages/editor/src/components/index.js
@@ -25,7 +25,10 @@ export { default as PostAuthorCheck } from './post-author/check';
 export { default as PostComments } from './post-comments';
 export { default as PostExcerpt } from './post-excerpt';
 export { default as PostExcerptCheck } from './post-excerpt/check';
-export { default as PostFeaturedImage } from './post-featured-image';
+export {
+	default as PostFeaturedImage,
+	getMediaDetails,
+} from './post-featured-image';
 export { default as PostFeaturedImageCheck } from './post-featured-image/check';
 export { default as PostFormat } from './post-format';
 export { default as PostFormatCheck } from './post-format/check';

--- a/packages/editor/src/components/post-featured-image/get-featured-media-details.js
+++ b/packages/editor/src/components/post-featured-image/get-featured-media-details.js
@@ -1,0 +1,64 @@
+/**
+ * WordPress dependencies
+ */
+import { applyFilters } from '@wordpress/hooks';
+
+/**
+ * The media details object.
+ *
+ * @typedef {Object} MediaDetails
+ *
+ * @property {string} mediaWidth     Width value of the media.
+ * @property {string} mediaHeight    Height value of the media.
+ * @property {string} mediaSourceUrl URL of the media.
+ */
+
+/**
+ * Returns the featured media dimensions and source URL.
+ *
+ * @param {Object} media  The media object.
+ * @param {number} postId The post ID of the media
+ * @return {MediaDetails} The featured media details.
+ */
+export default function getFeaturedMediaDetails( media, postId ) {
+	if ( ! media ) {
+		return {};
+	}
+
+	const defaultSize = applyFilters(
+		'editor.PostFeaturedImage.imageSize',
+		'large',
+		media.id,
+		postId
+	);
+	if ( defaultSize in ( media?.media_details?.sizes ?? {} ) ) {
+		return {
+			mediaWidth: media.media_details.sizes[ defaultSize ].width,
+			mediaHeight: media.media_details.sizes[ defaultSize ].height,
+			mediaSourceUrl: media.media_details.sizes[ defaultSize ].source_url,
+		};
+	}
+
+	// Use fallbackSize when defaultSize is not available.
+	const fallbackSize = applyFilters(
+		'editor.PostFeaturedImage.imageSize',
+		'thumbnail',
+		media.id,
+		postId
+	);
+	if ( fallbackSize in ( media?.media_details?.sizes ?? {} ) ) {
+		return {
+			mediaWidth: media.media_details.sizes[ fallbackSize ].width,
+			mediaHeight: media.media_details.sizes[ fallbackSize ].height,
+			mediaSourceUrl:
+				media.media_details.sizes[ fallbackSize ].source_url,
+		};
+	}
+
+	// Use full image size when fallbackSize and defaultSize are not available.
+	return {
+		mediaWidth: media.media_details.width,
+		mediaHeight: media.media_details.height,
+		mediaSourceUrl: media.source_url,
+	};
+}

--- a/packages/editor/src/components/post-featured-image/index.js
+++ b/packages/editor/src/components/post-featured-image/index.js
@@ -43,7 +43,7 @@ const instructions = (
 	</p>
 );
 
-function getMediaDetails( media, postId ) {
+export function getMediaDetails( media, postId ) {
 	if ( ! media ) {
 		return {};
 	}

--- a/packages/editor/src/components/post-featured-image/index.js
+++ b/packages/editor/src/components/post-featured-image/index.js
@@ -2,7 +2,6 @@
  * WordPress dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
-import { applyFilters } from '@wordpress/hooks';
 import {
 	DropZone,
 	Button,
@@ -28,6 +27,7 @@ import { store as coreStore } from '@wordpress/core-data';
  */
 import PostFeaturedImageCheck from './check';
 import { store as editorStore } from '../../store';
+import getFeaturedMediaDetails from './get-featured-media-details';
 
 const ALLOWED_MEDIA_TYPES = [ 'image' ];
 
@@ -42,49 +42,6 @@ const instructions = (
 		) }
 	</p>
 );
-
-export function getMediaDetails( media, postId ) {
-	if ( ! media ) {
-		return {};
-	}
-
-	const defaultSize = applyFilters(
-		'editor.PostFeaturedImage.imageSize',
-		'large',
-		media.id,
-		postId
-	);
-	if ( defaultSize in ( media?.media_details?.sizes ?? {} ) ) {
-		return {
-			mediaWidth: media.media_details.sizes[ defaultSize ].width,
-			mediaHeight: media.media_details.sizes[ defaultSize ].height,
-			mediaSourceUrl: media.media_details.sizes[ defaultSize ].source_url,
-		};
-	}
-
-	// Use fallbackSize when defaultSize is not available.
-	const fallbackSize = applyFilters(
-		'editor.PostFeaturedImage.imageSize',
-		'thumbnail',
-		media.id,
-		postId
-	);
-	if ( fallbackSize in ( media?.media_details?.sizes ?? {} ) ) {
-		return {
-			mediaWidth: media.media_details.sizes[ fallbackSize ].width,
-			mediaHeight: media.media_details.sizes[ fallbackSize ].height,
-			mediaSourceUrl:
-				media.media_details.sizes[ fallbackSize ].source_url,
-		};
-	}
-
-	// Use full image size when fallbackSize and defaultSize are not available.
-	return {
-		mediaWidth: media.media_details.width,
-		mediaHeight: media.media_details.height,
-		mediaSourceUrl: media.source_url,
-	};
-}
 
 function PostFeaturedImage( {
 	currentPostId,
@@ -101,7 +58,7 @@ function PostFeaturedImage( {
 	const mediaUpload = useSelect( ( select ) => {
 		return select( blockEditorStore ).getSettings().mediaUpload;
 	}, [] );
-	const { mediaWidth, mediaHeight, mediaSourceUrl } = getMediaDetails(
+	const { mediaWidth, mediaHeight, mediaSourceUrl } = getFeaturedMediaDetails(
 		media,
 		currentPostId
 	);

--- a/packages/editor/src/private-apis.js
+++ b/packages/editor/src/private-apis.js
@@ -4,9 +4,11 @@
 import { ExperimentalEditorProvider } from './components/provider';
 import { lock } from './lockUnlock';
 import { EntitiesSavedStatesExtensible } from './components/entities-saved-states';
+import getFeaturedMediaDetails from './components/post-featured-image/get-featured-media-details';
 
 export const privateApis = {};
 lock( privateApis, {
 	ExperimentalEditorProvider,
 	EntitiesSavedStatesExtensible,
+	getFeaturedMediaDetails,
 } );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Updates the existing page detail view in the site editor to include more useful information.

## Why?
https://github.com/WordPress/gutenberg/issues/50390

## Constraints

- If we want to get the author and avatar of the user who last modified the page we'll need to fetch and consult the revisions. This is possible, but needs extra work to set up the store in a follow up PR.


## Testing Instructions
1. Activate a block theme
2. Make sure you have some pages ready to role. Add featured images, leave some scheduled too.
3. Now head over to the site editor 
4. In the side bar, navigate to Design > Pages and click on the pages.
5. Check each page's details in the sidebar.
6. Overcome your bedazzlement and provide some constructive feedback. 




<img width="349" alt="Screenshot 2023-05-25 at 3 27 12 pm" src="https://github.com/WordPress/gutenberg/assets/6458278/50d593e8-b11e-4d83-b922-67a58d292506">
<img width="346" alt="Screenshot 2023-05-25 at 3 27 00 pm" src="https://github.com/WordPress/gutenberg/assets/6458278/573a1a31-4813-4a41-9249-afa15b4d9bd6">
<img width="348" alt="Screenshot 2023-05-25 at 3 26 32 pm" src="https://github.com/WordPress/gutenberg/assets/6458278/371f6e29-eb29-463e-b8b1-82d468214d77">


