### PR TITLE
Custom CSS: Force display of in custom css input boxes to LTR

### DIFF
--- a/packages/block-editor/src/components/global-styles/style.scss
+++ b/packages/block-editor/src/components/global-styles/style.scss
@@ -44,6 +44,9 @@
 
 .block-editor-global-styles-advanced-panel__custom-css-input textarea {
 	font-family: $editor_html_font;
+	// CSS input is always LTR regardless of language.
+	/*rtl:ignore*/
+	direction: ltr;
 }
 
 .block-editor-global-styles-advanced-panel__custom-css-validation-wrapper {

--- a/packages/edit-site/src/components/global-styles/style.scss
+++ b/packages/edit-site/src/components/global-styles/style.scss
@@ -143,6 +143,9 @@
 
 				.components-textarea-control__input {
 					flex: 1 1 auto;
+					// CSS input is always LTR regardless of language.
+					/*rtl:ignore*/
+					direction: ltr;
 				}
 			}
 		}


### PR DESCRIPTION
## What?
Forces the text in the custom CSS input boxes to display left to right.

## Why?
Currently in RTL languages the CSS input is displayed RTL, which makes input of CSS very difficult. 
See: #50721

## How?
Adds:
```css
/*rtl:ignore*/
direction: ltr;
```

To input boxes for global and block CSS.

The ignore comment is needed aas by default WP rewrites all `direction` properties to `rtl` when an RTL language is set for the site.

## Testing Instructions

- Change your site to an RTL language
- Go to global styles custom CSS and block custom CSS input boxes and make sure text displays LTR

## Screenshots or screencast <!-- if applicable -->

Before:
<img width="265" alt="Screenshot 2023-05-19 at 5 18 35 PM" src="https://github.com/WordPress/gutenberg/assets/3629020/5d8b5730-9148-4c11-a0c5-4bd496a7b5e6">

After:
<img width="273" alt="Screenshot 2023-05-19 at 5 16 27 PM" src="https://github.com/WordPress/gutenberg/assets/3629020/20901490-fab6-4e70-8f96-fc35d6d7af29">

