### PR TITLE
Library: Rename template parts to library

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-item/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-item/style.scss
@@ -19,6 +19,15 @@
 	.edit-site-sidebar-navigation-item__drilldown-indicator {
 		fill: $gray-700;
 	}
+
+	&:is(a) {
+		text-decoration: none;
+
+		&:focus {
+			box-shadow: none;
+			outline: none;
+		}
+	}
 }
 
 .edit-site-sidebar-navigation-screen__content .block-editor-list-view-block-select-button {

--- a/packages/edit-site/src/components/sidebar-navigation-screen-main/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-main/index.js
@@ -102,7 +102,7 @@ export default function SidebarNavigationScreenMain() {
 						withChevron
 						icon={ symbol }
 					>
-						{ __( 'Template Parts' ) }
+						{ __( 'Library' ) }
 					</NavigatorButton>
 				</ItemGroup>
 			}

--- a/packages/edit-site/src/components/sidebar-navigation-screen-templates/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-templates/index.js
@@ -39,7 +39,7 @@ const config = {
 			title: __( 'Library' ),
 			loading: __( 'Loading library' ),
 			notFound: __( 'No patterns found' ),
-			manage: __( 'Manage all patterns' ),
+			manage: __( 'Manage all template parts' ),
 			reusableBlocks: __( 'Manage reusable blocks' ),
 			description: __(
 				'Manage what patterns are available when editing your site.'

--- a/packages/edit-site/src/components/sidebar-navigation-screen-templates/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-templates/index.js
@@ -36,12 +36,13 @@ const config = {
 	},
 	wp_template_part: {
 		labels: {
-			title: __( 'Template parts' ),
-			loading: __( 'Loading template parts' ),
-			notFound: __( 'No template parts found' ),
-			manage: __( 'Manage all template parts' ),
+			title: __( 'Library' ),
+			loading: __( 'Loading library' ),
+			notFound: __( 'No patterns found' ),
+			manage: __( 'Manage all patterns' ),
+			reusableBlocks: __( 'Manage reusable blocks' ),
 			description: __(
-				'Template Parts are small pieces of a layout that can be reused across multiple templates and always appear the same way. Common template parts include the site header, footer, or sidebar.'
+				'Manage what patterns are available when editing your site.'
 			),
 		},
 	},
@@ -123,14 +124,31 @@ export default function SidebarNavigationScreenTemplates() {
 								</TemplateItem>
 							) ) }
 							{ ! isMobileViewport && (
-								<SidebarNavigationItem
-									className="edit-site-sidebar-navigation-screen-templates__see-all"
-									{ ...browseAllLink }
-									children={
-										config[ postType ].labels.manage
-									}
-									withChevron
-								/>
+								<>
+									<SidebarNavigationItem
+										className="edit-site-sidebar-navigation-screen-templates__see-all"
+										{ ...browseAllLink }
+										children={
+											config[ postType ].labels.manage
+										}
+										withChevron
+									/>
+									{ !! config[ postType ].labels
+										.reusableBlocks && (
+										<SidebarNavigationItem
+											href="edit.php?post_type=wp_block"
+											onClick={ () => {
+												document.location =
+													'edit.php?post_type=wp_block';
+											} }
+											children={
+												config[ postType ].labels
+													.reusableBlocks
+											}
+											withChevron
+										/>
+									) }
+								</>
 							) }
 						</ItemGroup>
 					) }

--- a/packages/edit-site/src/components/sidebar-navigation-screen-templates/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-templates/index.js
@@ -127,26 +127,23 @@ export default function SidebarNavigationScreenTemplates() {
 								<>
 									<SidebarNavigationItem
 										className="edit-site-sidebar-navigation-screen-templates__see-all"
-										{ ...browseAllLink }
-										children={
-											config[ postType ].labels.manage
-										}
 										withChevron
-									/>
+										{ ...browseAllLink }
+									>
+										{ config[ postType ].labels.manage }
+									</SidebarNavigationItem>
 									{ !! config[ postType ].labels
 										.reusableBlocks && (
 										<SidebarNavigationItem
+											as="a"
 											href="edit.php?post_type=wp_block"
-											onClick={ () => {
-												document.location =
-													'edit.php?post_type=wp_block';
-											} }
-											children={
+											withChevron
+										>
+											{
 												config[ postType ].labels
 													.reusableBlocks
 											}
-											withChevron
-										/>
+										</SidebarNavigationItem>
 									) }
 								</>
 							) }

--- a/test/e2e/specs/site-editor/site-editor-url-navigation.spec.js
+++ b/test/e2e/specs/site-editor/site-editor-url-navigation.spec.js
@@ -62,7 +62,7 @@ test.describe( 'Site editor url navigation', () => {
 			page,
 		} ) => {
 			await admin.visitSiteEditor();
-			await page.click( 'role=button[name="Template Parts"i]' );
+			await page.click( 'role=button[name="Library"i]' );
 			await page.click( 'role=button[name="Add New"i]' );
 			// Fill in a name in the dialog that pops up.
 			await page.type(


### PR DESCRIPTION
Related: 
- https://github.com/WordPress/gutenberg/issues/50028


## What?

Renames the primary template part navigation items in the site editor and adds a link off to the reusable blocks admin.

## Why?

This is a small step towards the new "Library" to manage all things patterns, reusable blocks, template parts etc.

## How?

- Renames the template parts navigation labels to "Library"
- Updates the template parts navigation screen's description
- Adds a link to existing reusable blocks admin in the "library" navigation screen

## Testing Instructions

1. Open the site editor
2. Confirm the Template Parts navigation item has been renamed Library and click it
3. Confirm the following screen now references Library instead of Template Parts
4. Double check the new screen description still makes sense for this small incremental step to a unified library
5. Confirm the new "Manage reusable blocks" item navigates you to the wp-admin reusable blocks page


## Screenshots or screencast <!-- if applicable -->

| Before | After |
|---|---|
| <img width="358" alt="Screenshot 2023-05-19 at 5 19 26 pm" src="https://github.com/WordPress/gutenberg/assets/60436221/8698daf4-e0fa-403c-a62c-66363d782367"><img width="358" alt="Screenshot 2023-05-19 at 5 19 39 pm" src="https://github.com/WordPress/gutenberg/assets/60436221/76629a1c-f799-403a-9a5a-3e7203a9f654"> | <img width="357" alt="Screenshot 2023-05-19 at 5 18 40 pm" src="https://github.com/WordPress/gutenberg/assets/60436221/d5eb5dfb-6b60-42ca-ba86-52806ed436bc"><img width="353" alt="Screenshot 2023-05-22 at 11 51 56 am" src="https://github.com/WordPress/gutenberg/assets/60436221/d459e7cb-7429-4983-8b4d-3e794538cba3"> |





