### PR TITLE
Try: Sentence case template parts.

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen-main/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-main/index.js
@@ -102,7 +102,7 @@ export default function SidebarNavigationScreenMain() {
 						withChevron
 						icon={ symbol }
 					>
-						{ __( 'Template Parts' ) }
+						{ __( 'Template parts' ) }
 					</NavigatorButton>
 				</ItemGroup>
 			}

--- a/test/e2e/specs/site-editor/site-editor-url-navigation.spec.js
+++ b/test/e2e/specs/site-editor/site-editor-url-navigation.spec.js
@@ -62,7 +62,7 @@ test.describe( 'Site editor url navigation', () => {
 			page,
 		} ) => {
 			await admin.visitSiteEditor();
-			await page.click( 'role=button[name="Template Parts"i]' );
+			await page.click( 'role=button[name="Template parts"i]' );
 			await page.click( 'role=button[name="Add New"i]' );
 			// Fill in a name in the dialog that pops up.
 			await page.type(


### PR DESCRIPTION
## What?

The template parts detail page uses sentence case for the term "Template parts":

<img width="358" alt="Screenshot 2023-05-19 at 09 49 59" src="https://github.com/WordPress/gutenberg/assets/1204802/b941b658-1808-4472-bba2-9121e482316b">

But the menu item does not:

<img width="356" alt="Screenshot 2023-05-19 at 09 50 51" src="https://github.com/WordPress/gutenberg/assets/1204802/a08f03c8-2741-4d58-b73e-e0ee2546ab8d">

This PR makes the menu item title match:

<img width="355" alt="Screenshot 2023-05-19 at 09 49 52" src="https://github.com/WordPress/gutenberg/assets/1204802/a8b9bcd2-dbca-43da-ab64-19008ce3d280">

## Testing Instructions

* Test the site editor and note that the Template parts item is in sentence case.