### PR TITLE
Add transparent outline to input control BackdropUI focus style.

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -11,6 +11,9 @@
 -   `Modal`: Remove children container's unused class name ([#50655](https://github.com/WordPress/gutenberg/pull/50655)).
 -   `DropdownMenu`: Convert to TypeScript ([#50187](https://github.com/WordPress/gutenberg/pull/50187)).
 
+### Bug Fix
+
+-   `InputControl`: Fix focus style to support Windows High Contrast mode ([#50772](https://github.com/WordPress/gutenberg/pull/50772)).
 
 ## 24.0.0 (2023-05-10)
 
@@ -21,7 +24,7 @@
 ### Bug Fix
 
 -   `NavigableContainer`: do not trap focus in `TabbableContainer` ([#49846](https://github.com/WordPress/gutenberg/pull/49846)).
--   Update `<Button>` component to have a transparent background for its tertiary disabled state, to match its enabled state.  ([#50496](https://github.com/WordPress/gutenberg/pull/50496)).
+-   Update `<Button>` component to have a transparent background for its tertiary disabled state, to match its enabled state. ([#50496](https://github.com/WordPress/gutenberg/pull/50496)).
 
 ### Internal
 

--- a/packages/components/src/input-control/styles/input-control-styles.tsx
+++ b/packages/components/src/input-control/styles/input-control-styles.tsx
@@ -270,9 +270,14 @@ const backdropFocusedStyles = ( {
 	let borderColor = isFocused ? COLORS.ui.borderFocus : COLORS.ui.border;
 
 	let boxShadow;
+	let outline;
+	let outlineOffset;
 
 	if ( isFocused ) {
 		boxShadow = `0 0 0 1px ${ COLORS.ui.borderFocus } inset`;
+		// Windows High Contrast mode will show this outline, but not the box-shadow.
+		outline = `2px solid transparent`;
+		outlineOffset = `-2px`;
 	}
 
 	if ( disabled ) {
@@ -284,6 +289,8 @@ const backdropFocusedStyles = ( {
 		borderColor,
 		borderStyle: 'solid',
 		borderWidth: 1,
+		outline,
+		outlineOffset,
 	} );
 };
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Fixes https://github.com/WordPress/gutenberg/issues/50738

## What?
<!-- In a few words, what is the PR actually doing? -->
Adds a transparent outline to the input control `BackdropUI` focus style to support Windows High Contrast mode.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
In Windows High Contrast mode, box-shadows aren't visible. Only borders and outlines are visible. The focus style of the input control component is provided by `BackdropUI` which only uses a box-shadow. 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
This PR adds a transparent outline so that the focus style is visible in Windows High Contrast mode. The negative offset makes the outline overlay the box-shadow.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
- This should be tested on Windows with High Contrast mode enabled.
- Alternatively, alter the code and use a solid color e.g. `red` instead of `transparent.
- Check a few components that use the input control e.g.:
  - Go to the Site editor.
  - Select a Group block.
  - Tab to the 'Content', 'Wide', and 'Position' controls (see screenshot).
  - Check these controls focus style does use the transparent outline.

<img width="281" alt="Screenshot 2023-05-19 at 09 21 41" src="https://github.com/WordPress/gutenberg/assets/1682452/2f0022f8-ed4e-43dd-8d7b-fcdf951ff84c">


### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
