### PR TITLE
Fix height mismatch between viewing and editing template parts

### DIFF
--- a/packages/edit-site/src/components/block-editor/index.js
+++ b/packages/edit-site/src/components/block-editor/index.js
@@ -140,7 +140,7 @@ export default function BlockEditor() {
 	] );
 	const isMobileViewport = useViewportMatch( 'small', '<' );
 	const { clearSelectedBlock } = useDispatch( blockEditorStore );
-	const [ resizeObserver, sizes ] = useResizeObserver();
+	const [ resizeObserver ] = useResizeObserver();
 
 	const isTemplatePart = templateType === 'wp_template_part';
 
@@ -189,10 +189,7 @@ export default function BlockEditor() {
 						>
 							<BlockEditorKeyboardShortcuts.Register />
 							<BackButton />
-							<ResizableEditor
-								enableResizing={ enableResizing }
-								height={ sizes.height ?? '100%' }
-							>
+							<ResizableEditor enableResizing={ enableResizing }>
 								<EditorCanvas
 									enableResizing={ enableResizing }
 									settings={ settings }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Resolves: https://github.com/WordPress/gutenberg/issues/48476

This PR just removes the specific height when editing a Template Part, so it defaults to `100%`, like the rest of the frames' height.  @youknowriad [mentioned](https://github.com/WordPress/gutenberg/issues/48476#issuecomment-1446611554) that there might be some nuances, but in my testing I didn't spot and side effect..
<!-- In a few words, what is the PR actually doing? -->

## Testing Instructions
1. Go to a Template Part in `edit` mode
2. Observe that the height is 100%


