### PR TITLE
Query Pagination: allow hiding the label text

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -654,7 +654,7 @@ Displays a paginated navigation to next/previous set of posts, when applicable. 
 -	**Name:** core/query-pagination
 -	**Category:** theme
 -	**Supports:** align, anchor, color (background, gradients, link, text), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
--	**Attributes:** paginationArrow
+-	**Attributes:** paginationArrow, showLabel
 
 ## Next Page
 

--- a/packages/block-library/src/query-pagination-next/block.json
+++ b/packages/block-library/src/query-pagination-next/block.json
@@ -12,7 +12,7 @@
 			"type": "string"
 		}
 	},
-	"usesContext": [ "queryId", "query", "paginationArrow" ],
+	"usesContext": [ "queryId", "query", "paginationArrow", "showLabel" ],
 	"supports": {
 		"anchor": true,
 		"reusable": false,

--- a/packages/block-library/src/query-pagination-next/edit.js
+++ b/packages/block-library/src/query-pagination-next/edit.js
@@ -13,7 +13,7 @@ const arrowMap = {
 export default function QueryPaginationNextEdit( {
 	attributes: { label },
 	setAttributes,
-	context: { paginationArrow },
+	context: { paginationArrow, showLabel },
 } ) {
 	const displayArrow = arrowMap[ paginationArrow ];
 	return (
@@ -26,8 +26,8 @@ export default function QueryPaginationNextEdit( {
 				__experimentalVersion={ 2 }
 				tagName="span"
 				aria-label={ __( 'Next page link' ) }
-				placeholder={ __( 'Next Page' ) }
-				value={ label }
+				placeholder={ showLabel ? __( 'Next Page' ) : '' }
+				value={ showLabel ? label : '' }
 				onChange={ ( newLabel ) =>
 					setAttributes( { label: newLabel } )
 				}

--- a/packages/block-library/src/query-pagination-next/index.php
+++ b/packages/block-library/src/query-pagination-next/index.php
@@ -20,10 +20,15 @@ function render_block_core_query_pagination_next( $attributes, $content, $block 
 	$max_page = isset( $block->context['query']['pages'] ) ? (int) $block->context['query']['pages'] : 0;
 
 	$wrapper_attributes = get_block_wrapper_attributes();
+	$show_label         = isset( $block->context['showLabel'] ) ? (bool) $block->context['showLabel'] : true;
 	$default_label      = __( 'Next Page' );
-	$label              = isset( $attributes['label'] ) && ! empty( $attributes['label'] ) ? esc_html( $attributes['label'] ) : $default_label;
+	$label_text         = isset( $attributes['label'] ) && ! empty( $attributes['label'] ) ? esc_html( $attributes['label'] ) : $default_label;
+	$label              = $show_label ? $label_text : '';
 	$pagination_arrow   = get_query_pagination_arrow( $block, true );
 
+	if ( ! $label ) {
+		$wrapper_attributes .= ' aria-label="' . $label_text . '"';
+	}
 	if ( $pagination_arrow ) {
 		$label .= $pagination_arrow;
 	}

--- a/packages/block-library/src/query-pagination-previous/block.json
+++ b/packages/block-library/src/query-pagination-previous/block.json
@@ -12,7 +12,7 @@
 			"type": "string"
 		}
 	},
-	"usesContext": [ "queryId", "query", "paginationArrow" ],
+	"usesContext": [ "queryId", "query", "paginationArrow", "showLabel" ],
 	"supports": {
 		"anchor": true,
 		"reusable": false,

--- a/packages/block-library/src/query-pagination-previous/edit.js
+++ b/packages/block-library/src/query-pagination-previous/edit.js
@@ -13,7 +13,7 @@ const arrowMap = {
 export default function QueryPaginationPreviousEdit( {
 	attributes: { label },
 	setAttributes,
-	context: { paginationArrow },
+	context: { paginationArrow, showLabel },
 } ) {
 	const displayArrow = arrowMap[ paginationArrow ];
 	return (
@@ -34,8 +34,8 @@ export default function QueryPaginationPreviousEdit( {
 				__experimentalVersion={ 2 }
 				tagName="span"
 				aria-label={ __( 'Previous page link' ) }
-				placeholder={ __( 'Previous Page' ) }
-				value={ label }
+				placeholder={ showLabel ? __( 'Previous Page' ) : '' }
+				value={ showLabel ? label : '' }
 				onChange={ ( newLabel ) =>
 					setAttributes( { label: newLabel } )
 				}

--- a/packages/block-library/src/query-pagination-previous/index.php
+++ b/packages/block-library/src/query-pagination-previous/index.php
@@ -19,9 +19,14 @@ function render_block_core_query_pagination_previous( $attributes, $content, $bl
 	$page     = empty( $_GET[ $page_key ] ) ? 1 : (int) $_GET[ $page_key ];
 
 	$wrapper_attributes = get_block_wrapper_attributes();
+	$show_label         = isset( $block->context['showLabel'] ) ? (bool) $block->context['showLabel'] : true;
 	$default_label      = __( 'Previous Page' );
-	$label              = isset( $attributes['label'] ) && ! empty( $attributes['label'] ) ? esc_html( $attributes['label'] ) : $default_label;
+	$label_text         = isset( $attributes['label'] ) && ! empty( $attributes['label'] ) ? esc_html( $attributes['label'] ) : $default_label;
+	$label              = $show_label ? $label_text : '';
 	$pagination_arrow   = get_query_pagination_arrow( $block, false );
+	if ( ! $label ) {
+		$wrapper_attributes .= ' aria-label="' . $label_text . '"';
+	}
 	if ( $pagination_arrow ) {
 		$label = $pagination_arrow . $label;
 	}

--- a/packages/block-library/src/query-pagination/block.json
+++ b/packages/block-library/src/query-pagination/block.json
@@ -11,11 +11,16 @@
 		"paginationArrow": {
 			"type": "string",
 			"default": "none"
+		},
+		"showLabel": {
+			"type": "boolean",
+			"default": true
 		}
 	},
 	"usesContext": [ "queryId", "query" ],
 	"providesContext": {
-		"paginationArrow": "paginationArrow"
+		"paginationArrow": "paginationArrow",
+		"showLabel": "showLabel"
 	},
 	"supports": {
 		"anchor": true,

--- a/packages/block-library/src/query-pagination/edit.js
+++ b/packages/block-library/src/query-pagination/edit.js
@@ -37,7 +37,7 @@ export default function QueryPaginationEdit( {
 		const { getBlocks } = select( blockEditorStore );
 		const innerBlocks = getBlocks( clientId );
 		/**
-		 * Show the `paginationArrow` and 'showLabel' controls only if a
+		 * Show the `paginationArrow` and `showLabel` controls only if a
 		 * `QueryPaginationNext/Previous` block exists.
 		 */
 		return innerBlocks?.find( ( innerBlock ) => {

--- a/packages/block-library/src/query-pagination/edit.js
+++ b/packages/block-library/src/query-pagination/edit.js
@@ -52,6 +52,10 @@ export default function QueryPaginationEdit( {
 		template: TEMPLATE,
 		allowedBlocks: ALLOWED_BLOCKS,
 	} );
+	// Always show label text if paginationArrow is set to 'none'.
+	if ( paginationArrow === 'none' ) {
+		setAttributes( { showLabel: true } );
+	}
 	return (
 		<>
 			{ hasNextPreviousBlocks && (

--- a/packages/block-library/src/query-pagination/edit.js
+++ b/packages/block-library/src/query-pagination/edit.js
@@ -15,6 +15,7 @@ import { PanelBody } from '@wordpress/components';
  * Internal dependencies
  */
 import { QueryPaginationArrowControls } from './query-pagination-arrow-controls';
+import { QueryPaginationLabelControl } from './query-pagination-label-control';
 
 const TEMPLATE = [
 	[ 'core/query-pagination-previous' ],
@@ -28,7 +29,7 @@ const ALLOWED_BLOCKS = [
 ];
 
 export default function QueryPaginationEdit( {
-	attributes: { paginationArrow },
+	attributes: { paginationArrow, showLabel },
 	setAttributes,
 	clientId,
 } ) {
@@ -36,7 +37,7 @@ export default function QueryPaginationEdit( {
 		const { getBlocks } = select( blockEditorStore );
 		const innerBlocks = getBlocks( clientId );
 		/**
-		 * Show the `paginationArrow` control only if a
+		 * Show the `paginationArrow` and 'showLabel' controls only if a
 		 * `QueryPaginationNext/Previous` block exists.
 		 */
 		return innerBlocks?.find( ( innerBlock ) => {
@@ -62,6 +63,14 @@ export default function QueryPaginationEdit( {
 								setAttributes( { paginationArrow: value } );
 							} }
 						/>
+						{ paginationArrow !== 'none' && (
+							<QueryPaginationLabelControl
+								value={ showLabel }
+								onChange={ ( value ) => {
+									setAttributes( { showLabel: value } );
+								} }
+							/>
+						) }
 					</PanelBody>
 				</InspectorControls>
 			) }

--- a/packages/block-library/src/query-pagination/query-pagination-label-control.js
+++ b/packages/block-library/src/query-pagination/query-pagination-label-control.js
@@ -1,0 +1,19 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { ToggleControl } from '@wordpress/components';
+
+export function QueryPaginationLabelControl( { value, onChange } ) {
+	return (
+		<ToggleControl
+			__nextHasNoMarginBottom
+			label={ __( 'Show pagination text' ) }
+			help={ __(
+				'Toggle off to hide the pagination label text, e.g. "Next Page".'
+			) }
+			onChange={ onChange }
+			checked={ value === true }
+		/>
+	);
+}

--- a/packages/block-library/src/query-pagination/query-pagination-label-control.js
+++ b/packages/block-library/src/query-pagination/query-pagination-label-control.js
@@ -8,9 +8,9 @@ export function QueryPaginationLabelControl( { value, onChange } ) {
 	return (
 		<ToggleControl
 			__nextHasNoMarginBottom
-			label={ __( 'Show pagination text' ) }
+			label={ __( 'Show label text' ) }
 			help={ __(
-				'Toggle off to hide the pagination label text, e.g. "Next Page".'
+				'Toggle off to hide the label text, e.g. "Next Page".'
 			) }
 			onChange={ onChange }
 			checked={ value === true }

--- a/test/integration/fixtures/blocks/core__query-pagination.json
+++ b/test/integration/fixtures/blocks/core__query-pagination.json
@@ -3,7 +3,8 @@
 		"name": "core/query-pagination",
 		"isValid": true,
 		"attributes": {
-			"paginationArrow": "none"
+			"paginationArrow": "none",
+			"showLabel": true
 		},
 		"innerBlocks": []
 	}

--- a/test/integration/fixtures/blocks/core__query__deprecated-3.json
+++ b/test/integration/fixtures/blocks/core__query__deprecated-3.json
@@ -87,7 +87,8 @@
 						"name": "core/query-pagination",
 						"isValid": true,
 						"attributes": {
-							"paginationArrow": "none"
+							"paginationArrow": "none",
+							"showLabel": true
 						},
 						"innerBlocks": [
 							{


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
This adds an extra display option to the Query Pagination block which allows users to hide the text for the pagination links. This then unlocks several display options for the pagination links:

- Text only
- Icon only
- Text + Icon

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Closes https://github.com/WordPress/gutenberg/issues/49266.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
This adds a new boolean attribute, `showLabel`, to the Query Pagination block. The default value is `true`, and when set to `false`, it will hide the text labels. 

`showLabel` is controlled by a toggle control which is only displayed when an arrow icon type is selected. The attribute cannot be set to `false` if there is no `paginationArrow` set, to prevent the pagination link from being empty when no arrow or label is set.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
1. In the editor, insert a Query Pagination block
2. Go to the block settings and toggle through the different arrow options
3. The "Show pagination text" toggle should show when the arrow is set to "Arrow" or "Chevron"
4. The "Show pagination text" toggle should be hidden when the arrow is set to "None", and the labels should be visible in the block
5. The "Show pagination text" toggle should toggle the visibility of the pagination text labels in the editor and on the front end

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
**Editor testing instructions:**
1. In the editor, insert a Query Pagination block
2. Tab to the Query Pagination block settings panel
3. Select the "Arrow" or "Chevron" arrow settings
4. Ensure that the next option you tab to is the "Show label text" checkbox
5. Tab back to the arrow options and select "None" from the list of options
6. Ensure that the "Show label text" checkbox cannot be accessed

**Front end testing instructions:**
1. In the editor, set the Query Pagination arrow to "Arrow" or "Chevron"
2. Uncheck the "Show label text" checkbox to hide the label text
3. Save your changes, go to the front end and tab to the query pagination
4. When the "Previous page" icon is tabbed to, it should have an aria-label using the label text. The default is "Previous Page".
5. When the "Next page" icon is tabbed to, it should have an aria-label using the label text. The default is "Next Page".

## Screenshots or screencast <!-- if applicable -->
Settings panel:
![image](https://github.com/WordPress/gutenberg/assets/1645628/7d276999-3f18-49d1-9511-6adb3b554239)

https://github.com/WordPress/gutenberg/assets/1645628/8d386a46-a7c7-4b62-8e87-294eac5fd006


