### PR TITLE
Remove the experimental flag of the command tool

### DIFF
--- a/lib/experimental/editor-settings.php
+++ b/lib/experimental/editor-settings.php
@@ -83,12 +83,6 @@ function gutenberg_enable_experiments() {
 	if ( $gutenberg_experiments && array_key_exists( 'gutenberg-color-randomizer', $gutenberg_experiments ) ) {
 		wp_add_inline_script( 'wp-block-editor', 'window.__experimentalEnableColorRandomizer = true', 'before' );
 	}
-	if ( $gutenberg_experiments && array_key_exists( 'gutenberg-command-center', $gutenberg_experiments ) ) {
-		wp_add_inline_script( 'wp-edit-site', 'window.__experimentalEnableCommandCenter = true', 'before' );
-	}
-	if ( $gutenberg_experiments && array_key_exists( 'gutenberg-command-center', $gutenberg_experiments ) ) {
-		wp_add_inline_script( 'wp-edit-post', 'window.__experimentalEnableCommandCenter = true', 'before' );
-	}
 	if ( $gutenberg_experiments && array_key_exists( 'gutenberg-group-grid-variation', $gutenberg_experiments ) ) {
 		wp_add_inline_script( 'wp-block-editor', 'window.__experimentalEnableGroupGridVariation = true', 'before' );
 	}

--- a/lib/experiments-page.php
+++ b/lib/experiments-page.php
@@ -66,18 +66,6 @@ function gutenberg_initialize_experiments_settings() {
 	);
 
 	add_settings_field(
-		'gutenberg-command-center',
-		__( 'Command center ', 'gutenberg' ),
-		'gutenberg_display_experiment_field',
-		'gutenberg-experiments',
-		'gutenberg_experiments_section',
-		array(
-			'label' => __( 'Test the command center; Open it using cmd + k in the site or post editors.', 'gutenberg' ),
-			'id'    => 'gutenberg-command-center',
-		)
-	);
-
-	add_settings_field(
 		'gutenberg-group-grid-variation',
 		__( 'Grid variation for Group block ', 'gutenberg' ),
 		'gutenberg_display_experiment_field',

--- a/packages/edit-post/src/editor.js
+++ b/packages/edit-post/src/editor.js
@@ -189,9 +189,7 @@ function Editor( { postId, postType, settings, initialEdits, ...props } ) {
 					{ ...props }
 				>
 					<ErrorBoundary>
-						{ window?.__experimentalEnableCommandCenter && (
-							<CommandMenu />
-						) }
+						<CommandMenu />
 						<EditorInitialization postId={ postId } />
 						<Layout styles={ styles } />
 					</ErrorBoundary>

--- a/packages/edit-site/src/components/layout/index.js
+++ b/packages/edit-site/src/components/layout/index.js
@@ -143,7 +143,7 @@ export default function Layout() {
 
 	return (
 		<>
-			{ window?.__experimentalEnableCommandCenter && <CommandMenu /> }
+			<CommandMenu />
 			<KeyboardShortcutsRegister />
 			<KeyboardShortcutsGlobal />
 			{ fullResizer }

--- a/packages/edit-site/src/components/site-hub/index.js
+++ b/packages/edit-site/src/components/site-hub/index.js
@@ -150,15 +150,14 @@ const SiteHub = forwardRef( ( props, ref ) => {
 						</motion.div>
 					</AnimatePresence>
 				</HStack>
-				{ window?.__experimentalEnableCommandCenter &&
-					canvasMode === 'view' && (
-						<Button
-							className="edit-site-site-hub_toggle-command-center"
-							icon={ search }
-							onClick={ () => openCommandCenter() }
-							label={ __( 'Open command center' ) }
-						/>
-					) }
+				{ canvasMode === 'view' && (
+					<Button
+						className="edit-site-site-hub_toggle-command-center"
+						icon={ search }
+						onClick={ () => openCommandCenter() }
+						label={ __( 'Open command center' ) }
+					/>
+				) }
 			</HStack>
 		</motion.div>
 	);


### PR DESCRIPTION
Related #48457 

## What?

Remove the experimental flag of the command center. It's not finished yet, we're missing a lot of commands but it's ready to get more widespread testing in the Gutenberg Plugin.

## Testing Instructions

1- Open the site or post editor
2- The command center should be available (cmd+k) regardless of the experimental flag.
