### PR TITLE
[RNMobile] Mock `Date.now` when using Jest's fake timers to allow `debounce` to be executed

### DIFF
--- a/test/native/integration-test-helpers/with-fake-timers.js
+++ b/test/native/integration-test-helpers/with-fake-timers.js
@@ -23,6 +23,10 @@ export async function withFakeTimers( fn ) {
 	// for its calculations, which can lead to wrong behaviors when executing timers.
 	// To avoid this, we mock this function and return the time provided Jest fake timers.
 	// Reference: https://jestjs.io/docs/jest-object#jestnow
+	//
+	// Eventually, we could explore using the "modern" fake timers, which would replace
+	// this workaround. However, this won't be possible until upgrading RN to version `0.71`
+	// or above. Once we apply the upgrade, we should consider removing this mock.
 	let dateNowSpy;
 	if ( ! jest.isMockFunction( Date.now ) ) {
 		dateNowSpy = jest


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Mock `Date.now` when using Jest's fake timers to allow `debounce` to be executed.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

In integration tests, if a component uses the `debounce` function, the debounced function never gets triggered. This PR solves this issue.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

`debounce` relies on the time returned by `Date.now` to calculate the expiration of the timer:
https://github.com/WordPress/gutenberg/blob/ce29b86a56a18696af4b76208e3c668c194e0781/packages/compose/src/utils/debounce/index.ts#L192-L200

However, `Date.now` is returning the real-time even when using fake timers. To avoid this, `Date.now` is mocked when using the `withFakeTimers` test helper that enables/disables the fake timers.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
1. Run the command `npm run native test`.
2. Observe that all tests pass.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
N/A

## Screenshots or screencast <!-- if applicable -->
N/A