### PR TITLE
Site Editor navigation: Add corresponding area icon to template part menu items

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen-templates/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-templates/index.js
@@ -11,6 +11,7 @@ import { useEntityRecords } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
 import { decodeEntities } from '@wordpress/html-entities';
 import { useViewportMatch } from '@wordpress/compose';
+import { getTemplatePartIcon } from '@wordpress/editor';
 
 /**
  * Internal dependencies
@@ -83,7 +84,7 @@ export default function SidebarNavigationScreenTemplates() {
 	} );
 
 	const canCreate = ! isMobileViewport && ! isTemplatePartsMode;
-
+	const isTemplateList = postType === 'wp_template';
 	return (
 		<SidebarNavigationScreen
 			isRoot={ isTemplatePartsMode }
@@ -115,6 +116,10 @@ export default function SidebarNavigationScreenTemplates() {
 									postId={ template.id }
 									key={ template.id }
 									withChevron
+									icon={
+										! isTemplateList &&
+										getTemplatePartIcon( template.area )
+									}
 								>
 									{ decodeEntities(
 										template.title?.rendered ||


### PR DESCRIPTION

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Resolves: https://github.com/WordPress/gutenberg/issues/50776


## Screenshots or screencast <!-- if applicable -->
<img width="346" alt="Screenshot 2023-05-19 at 4 31 08 PM" src="https://github.com/WordPress/gutenberg/assets/16275880/99b33a98-bc58-4f26-bcfc-57c5dda71732">
