### PR TITLE
Browse Mode: Add snackbar notices

### DIFF
--- a/packages/components/src/snackbar/list.tsx
+++ b/packages/components/src/snackbar/list.tsx
@@ -73,7 +73,6 @@ export function SnackbarList( {
 
 					return (
 						<motion.div
-							layout={ ! isReducedMotion } // See https://www.framer.com/docs/animation/#layout-animations
 							initial={ 'init' }
 							animate={ 'open' }
 							exit={ 'exit' }

--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -180,12 +180,7 @@ export default function Editor( { isLoading } ) {
 									'is-loading': isLoading,
 								}
 							) }
-							notices={
-								( isEditMode ||
-									window?.__experimentalEnableThemePreviews ) && (
-									<EditorSnackbars />
-								)
-							}
+							notices={ <EditorSnackbars /> }
 							content={
 								<>
 									<GlobalStylesRenderer />

--- a/packages/edit-site/src/components/editor/style.scss
+++ b/packages/edit-site/src/components/editor/style.scss
@@ -19,10 +19,16 @@
 }
 
 // Adjust the position of the notices
-.edit-site .components-editor-notices__snackbar {
-	position: fixed;
-	right: 0;
-	bottom: 0;
-	padding: 16px;
+.edit-site {
+	.components-editor-notices__snackbar {
+		position: fixed;
+		right: 0;
+		bottom: 0;
+		padding: 16px;
+	}
+	.is-edit-mode .components-editor-notices__snackbar {
+		bottom: 24px;
+	}
 }
+
 @include editor-left(".edit-site .components-editor-notices__snackbar")

--- a/packages/edit-site/src/components/editor/style.scss
+++ b/packages/edit-site/src/components/editor/style.scss
@@ -22,8 +22,7 @@
 .edit-site .components-editor-notices__snackbar {
 	position: fixed;
 	right: 0;
-	bottom: 40px;
-	padding-left: 16px;
-	padding-right: 16px;
+	bottom: 0;
+	padding: 16px;
 }
 @include editor-left(".edit-site .components-editor-notices__snackbar")

--- a/packages/edit-site/src/components/layout/index.js
+++ b/packages/edit-site/src/components/layout/index.js
@@ -227,7 +227,7 @@ export default function Layout() {
 											  }
 											: {}
 									}
-									// Setting a transform property (in this case scale) on an element makes it act as a containing block for its descendents.
+									// Setting a transform property (in this case scale) on an element makes it act as a containing block for its descendants.
 									// This means that the snackbar notices inside this component are repositioned to be relative to this element.
 									// To avoid the snackbars jumping about we need to ensure that a transform property is always set.
 									// Setting a scale of 1 is interpred by framer as no change, so once the animation completes

--- a/packages/edit-site/src/components/layout/index.js
+++ b/packages/edit-site/src/components/layout/index.js
@@ -232,8 +232,9 @@ export default function Layout() {
 									// To avoid the snackbars jumping about we need to ensure that a transform property is always set.
 									// Setting a scale of 1 is interpred by framer as no change, so once the animation completes
 									// the transform property of this element is set to none, thus removing its role as a container block.
-									// Instead we set the initial scale of this element to 1.000000000000001 so that there is always a transform property set.
-									initial={ { scale: 1.000000000000001 } }
+									// Instead we set the initial scale of this element to 1.0001 so that there is always a transform property set.
+									// If we set the initial scale to less than 1.001 then JavaScript rounds it to 1 and the problem reoccurs.
+									initial={ { scale: 1.001 } }
 									layout="position"
 									className="edit-site-layout__canvas"
 									transition={ {

--- a/packages/edit-site/src/components/layout/index.js
+++ b/packages/edit-site/src/components/layout/index.js
@@ -227,7 +227,13 @@ export default function Layout() {
 											  }
 											: {}
 									}
-									initial={ false }
+									// Setting a transform property (in this case scale) on an element makes it act as a containing block for its descendents.
+									// This means that the snackbar notices inside this component are repositioned to be relative to this element.
+									// To avoid the snackbars jumping about we need to ensure that a transform property is always set.
+									// Setting a scale of 1 is interpred by framer as no change, so once the animation completes
+									// the transform property of this element is set to none, thus removing its role as a container block.
+									// Instead we set the initial scale of this element to 1.000000000000001 so that there is always a transform property set.
+									initial={ { scale: 1.000000000000001 } }
 									layout="position"
 									className="edit-site-layout__canvas"
 									transition={ {

--- a/packages/edit-site/src/components/layout/index.js
+++ b/packages/edit-site/src/components/layout/index.js
@@ -215,7 +215,7 @@ export default function Layout() {
 									whileHover={
 										isEditorPage && canvasMode === 'view'
 											? {
-													scale: 1.005,
+													scale: 1.006,
 													transition: {
 														duration:
 															disableMotion ||

--- a/packages/edit-site/src/components/layout/index.js
+++ b/packages/edit-site/src/components/layout/index.js
@@ -235,7 +235,6 @@ export default function Layout() {
 									// Instead we set the initial scale of this element to 1.0001 so that there is always a transform property set.
 									// If we set the initial scale to less than 1.001 then JavaScript rounds it to 1 and the problem reoccurs.
 									initial={ { scale: 1.001 } }
-									layout="position"
 									className="edit-site-layout__canvas"
 									transition={ {
 										type: 'tween',


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Adds Snackbar notices to browse mode.

## Why?
Setting a transform property (in this case scale) on an element makes it act as a containing block for its descendants. This means that the snackbar notices inside this component are repositioned to be relative to this element. To avoid the snackbars jumping about we need to ensure that a transform property is always set. Setting a scale of 1 is interpred by framer as no change, so once the animation completes the transform property of this element is set to none, thus removing its role as a container block.

## How?
We set the initial scale of this element to 1.0001 so that there is always a transform property set. If we set the initial scale to less than 1.001 then JavaScript rounds it to 1 and the problem reoccurs.

Other solutions are to set a perspective or filter property on the same element in CSS, which would potentially be simpler but also much less clear.

The issue this is solving (https://github.com/WordPress/gutenberg/issues/50175) suggested moving this to the centre, but it's not clear whether we mean the centre of the window or of the site frame. This solution is fairly simple and gets the snackbars working. We can follow up with a design iteration to improve things.

## Testing Instructions
1. Open the site editor
2. Make some changes to your navigation
3. Save the changes
4. Confirm that you see the snackbar notice over the site, and that it doesn't jump around.

### Testing Instructions for Keyboard
Follow the steps as above and confirm that you are given notices.

## Screenshots or screencast <!-- if applicable -->
<img width="1512" alt="Screenshot 2023-05-23 at 12 58 40" src="https://github.com/WordPress/gutenberg/assets/275961/e6f513ae-05e7-4d9d-89b6-7573f0e39699">
<img width="1512" alt="Screenshot 2023-05-23 at 12 58 34" src="https://github.com/WordPress/gutenberg/assets/275961/b032e8e1-d66c-4621-abd9-3deaa999baa6">
