### PR TITLE
Fix custom template creation regression

### DIFF
--- a/packages/edit-site/src/components/add-new-template/add-custom-generic-template-modal-content.js
+++ b/packages/edit-site/src/components/add-new-template/add-custom-generic-template-modal-content.js
@@ -50,7 +50,7 @@ function AddCustomGenericTemplateModalContent( { onClose, createTemplate } ) {
 					placeholder={ defaultTitle }
 					disabled={ isBusy }
 					help={ __(
-						'Describe the template, e.g. "Post with sidebar".'
+						'Describe the template, e.g. "Post with sidebar". A custom template can be manually applied to any post or page.'
 					) }
 				/>
 				<HStack

--- a/packages/edit-site/src/components/add-new-template/new-template.js
+++ b/packages/edit-site/src/components/add-new-template/new-template.js
@@ -96,10 +96,6 @@ export default function NewTemplate( {
 	const [ modalContent, setModalContent ] = useState(
 		modalContentMap.templatesList
 	);
-	const [
-		showCustomGenericTemplateModal,
-		setShowCustomGenericTemplateModal,
-	] = useState( false );
 	const [ entityForSuggestions, setEntityForSuggestions ] = useState( {} );
 	const [ isCreatingTemplate, setIsCreatingTemplate ] = useState( false );
 
@@ -183,7 +179,7 @@ export default function NewTemplate( {
 			__( 'Add template: %s' ),
 			entityForSuggestions.labels.singular_name
 		);
-	} else if ( showCustomGenericTemplateModal ) {
+	} else if ( modalContent === modalContentMap.customGenericTemplate ) {
 		modalTitle = __( 'Create custom template' );
 	}
 	return (
@@ -246,7 +242,9 @@ export default function NewTemplate( {
 									'A custom template can be manually applied to any post or page.'
 								) }
 								onClick={ () =>
-									setShowCustomGenericTemplateModal( true )
+									setModalContent(
+										modalContentMap.customGenericTemplate
+									)
 								}
 							/>
 						</Grid>

--- a/packages/edit-site/src/components/add-new-template/style.scss
+++ b/packages/edit-site/src/components/add-new-template/style.scss
@@ -98,12 +98,6 @@
 }
 
 .edit-site-custom-generic-template__modal {
-	.components-base-control {
-		@include break-medium() {
-			width: $grid-unit * 40;
-		}
-	}
-
 	.components-modal__header {
 		border-bottom: none;
 	}

--- a/test/e2e/specs/site-editor/templates.spec.js
+++ b/test/e2e/specs/site-editor/templates.spec.js
@@ -1,0 +1,43 @@
+/**
+ * WordPress dependencies
+ */
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+
+test.describe( 'Templates', () => {
+	test.beforeAll( async ( { requestUtils } ) => {
+		await requestUtils.activateTheme( 'emptytheme' );
+	} );
+	test.afterEach( async ( { requestUtils } ) => {
+		await requestUtils.deleteAllTemplates( 'wp_template' );
+	} );
+	test( 'Create a custom template', async ( { admin, page } ) => {
+		const templateName = 'demo';
+		await admin.visitSiteEditor();
+		await page.click( 'role=button[name="Templates"]' );
+		await page.click( 'role=button[name="Add New Template"i]' );
+		await page
+			.getByRole( 'button', {
+				name: 'A custom template can be manually applied to any post or page.',
+			} )
+			.click();
+		// Fill the template title and submit.
+		const newTemplateDialog = page.locator(
+			'role=dialog[name="Create custom template"i]'
+		);
+		const templateNameInput = newTemplateDialog.locator(
+			'role=textbox[name="Name"i]'
+		);
+		await templateNameInput.fill( templateName );
+		await page.keyboard.press( 'Enter' );
+		// Close the pattern suggestions dialog.
+		await page
+			.getByRole( 'dialog', { name: 'Choose a pattern' } )
+			.getByRole( 'button', { name: 'Close' } )
+			.click();
+		await expect(
+			page.locator(
+				`role=button[name="Dismiss this notice"i] >> text="${ templateName }" successfully created.`
+			)
+		).toBeVisible();
+	} );
+} );

--- a/test/e2e/specs/site-editor/templates.spec.js
+++ b/test/e2e/specs/site-editor/templates.spec.js
@@ -13,8 +13,8 @@ test.describe( 'Templates', () => {
 	test( 'Create a custom template', async ( { admin, page } ) => {
 		const templateName = 'demo';
 		await admin.visitSiteEditor();
-		await page.click( 'role=button[name="Templates"]' );
-		await page.click( 'role=button[name="Add New Template"i]' );
+		await page.getByRole( 'button', { name: 'Templates' } ).click();
+		await page.getByRole( 'button', { name: 'Add New Template' } ).click();
 		await page
 			.getByRole( 'button', {
 				name: 'A custom template can be manually applied to any post or page.',


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Resolves: https://github.com/WordPress/gutenberg/issues/50793

I introduce a regression in https://github.com/WordPress/gutenberg/pull/50595 where the creation of a custom template is not possible right now. This PR fixes that.

Since it seems we focuses on the other flows mostly, this might need some css tweaks or design feedback

<img width="884" alt="Screenshot 2023-05-22 at 11 48 27 AM" src="https://github.com/WordPress/gutenberg/assets/16275880/f39cad3a-71e8-481f-b704-3687a95b797d">


