### PR TITLE
Comments: Replace get_comments() with get_comments_number(). 

### DIFF
--- a/packages/block-library/src/comments/index.php
+++ b/packages/block-library/src/comments/index.php
@@ -29,13 +29,8 @@ function render_block_core_comments( $attributes, $content, $block ) {
 		return '';
 	}
 
-	$comment_args = array(
-		'post_id' => $post_id,
-		'count'   => true,
-		'status'  => 'approve',
-	);
 	// Return early if there are no comments and comments are closed.
-	if ( ! comments_open( $post_id ) && get_comments( $comment_args ) === 0 ) {
+	if ( ! comments_open( $post_id ) && (int) get_comments_number( $post_id ) === 0 ) {
 		return '';
 	}
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
This PR replaces a `get_comments()` call and database query with `get_comments_number()`.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
This approach has three advantages:

1. It's faster. `get_comments_number()` uses a post property vs a separate database query.
2. `get_comments_number()` is filtered, and it's much easier for plugins/themes to manipulate, vs having to use `pre_get_comments` and jump through several hoops.
3. This is consistent with the way core themes used to determine whether or not to render the comments template, from [twentyten](https://core.trac.wordpress.org/browser/trunk/src/wp-content/themes/twentyten/comments.php#L86) up to [twentytwentyone](https://github.com/WordPress/twentytwentyone/blob/ba9f20cad89163761185c0467b346ba42541ae22/single.php#L30-L33). Maybe even older, I didn't check Kubrick 😄.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
Using the comments block under normal circumstances, no behavior changes should be observable.

To disabled comments and commenting on all content, one should now be able to:
```php
add_filter( 'comments_open', '__return_false' );
add_filter( 'get_comments_number', '__return_zero' );
```

Observe that prior to this PR, comments will still render using the comments block.

Closes #48975