### PR TITLE
Add grab cursor style for Block mover drag handle button

### DIFF
--- a/packages/block-editor/src/components/block-mover/style.scss
+++ b/packages/block-editor/src/components/block-mover/style.scss
@@ -55,6 +55,7 @@
 }
 
 .block-editor-block-mover__drag-handle {
+	cursor: grab;
 	@include break-small() {
 		width: $block-toolbar-height * 0.5;
 		min-width: 0 !important; // overrides default button width.


### PR DESCRIPTION
## What?
Add grab cursor style for Block mover drag handle button

## Why?
As part #50789

## How?
The cursor style specification in edit mode was missing, so a new grab style specification has been added.

## Testing Instructions
- Make sure you are in edit mode.
- Add two arbitrary blocks.
- Select one block and place the cursor on "drag handle".
- Make sure the cursor is set to grab.

### Testing Instructions for Keyboard
Not supported as it is not within the scope of Keyborad operation

## Screenshots or screencast <!-- if applicable -->
![screenshot_20230520_02](https://github.com/WordPress/gutenberg/assets/15826102/37ef8596-67d9-4c5e-8291-b00836496c2c)
