### PR TITLE
Add `t-hamano` as codeowner for `env` package

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -125,7 +125,7 @@
 /packages/report-flaky-tests                    @kevin940726
 
 # wp-env
-/packages/env                                   @noahtallen @ObliviousHarmony
+/packages/env                                   @noahtallen @ObliviousHarmony @t-hamano
 
 # PHP
 /lib                                            @spacedmonkey


### PR DESCRIPTION
## What?
Added myself (`t-hamano`) as a codeowner for `env` package.

## Why?
I do not fully understand the `env` package and may not be able to give a detailed review. However, it appears that many Windows OS-specific problems have occurred so far, especially in this package:

- #50814
- #45592
- #31192
- #30638
- #23121

Therefore, I would like to receive a notification when a pull request is submitted for this package and see if the changes work properly on the Windows OS.