### PR TITLE
List View: Remove fade in/out animation for block settings menu icon button

### DIFF
--- a/packages/block-editor/src/components/list-view/style.scss
+++ b/packages/block-editor/src/components/list-view/style.scss
@@ -123,7 +123,6 @@
 		border-radius: 0;
 	}
 
-
 	// List View renders a fixed number of items and relies on each item having a fixed height of 36px.
 	// If this value changes, we should also change the itemHeight value set in useFixedWindowList.
 	// See: https://github.com/WordPress/gutenberg/pull/35230 for additional context.
@@ -214,10 +213,8 @@
 		line-height: 0;
 		width: $button-size;
 		vertical-align: middle;
-		@include reduce-motion("transition");
 
 		> * {
-			will-change: opacity;
 			opacity: 0;
 		}
 
@@ -227,7 +224,6 @@
 		&.is-visible {
 			> * {
 				opacity: 1;
-				@include edit-post__fade-in-animation;
 			}
 		}
 


### PR DESCRIPTION
## What?
Fixes #50750

Removes the fade in/out animation when hovering over the block settings menu icon button.

## Why?
It's a small aesthetic improvement. See the issue for more details.

## How?
Remove the css transition.

## Testing Instructions
1. Add a few blocks to a post
2. Open List View
3. Hover over some of the blocks in List View, observe the fade in/out animation is no longer present

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/677833/b87e0118-8ee3-401a-ae2a-4658a604aa47
