### PR TITLE
Use same styles for block highlight and hover

### DIFF
--- a/packages/block-editor/src/components/block-list/content.scss
+++ b/packages/block-editor/src/components/block-list/content.scss
@@ -273,13 +273,20 @@
 		&::after {
 			content: "";
 			position: absolute;
+			z-index: 1;
 			pointer-events: none;
 			top: $border-width;
-			left: $border-width;
 			right: $border-width;
 			bottom: $border-width;
-			box-shadow: 0 0 0 $border-width var(--wp-admin-theme-color);
-			border-radius: $radius-block-ui - $border-width;
+			left: $border-width;
+			box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
+			border-radius: $radius-block-ui - $border-width; // Border is outset, so subtract the width to achieve correct radius.
+			outline: 2px solid transparent; // This shows up in Windows High Contrast Mode.
+
+			// Show a light color for dark themes.
+			.is-dark-theme & {
+				box-shadow: 0 0 0 var(--wp-admin-border-width-focus) $dark-theme-focus;
+			}
 		}
 	}
 


### PR DESCRIPTION
## What?
Closes #50747

Uses the same styles for highlighted and hovered blocks (in the site editor).

## Why?
See #50747 for reasoning.

## How?
Copy/paste the styles.

## Testing Instructions
1. Open the site editor
2. Hover over blocks in List View
3. Hover over blocks in the editor canvas

The styles should be the same.

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/677833/36d8830b-1c73-4c92-80b5-1365a64ba250

