### PR TITLE
Show visual cue when dragging over empty group block

### DIFF
--- a/packages/block-editor/src/components/block-list-appender/index.js
+++ b/packages/block-editor/src/components/block-list-appender/index.js
@@ -85,6 +85,22 @@ function BlockListAppender( {
 	tagName: TagName = 'div',
 } ) {
 	const appender = useAppender( rootClientId, renderAppender );
+	const isDragOver = useSelect(
+		( select ) => {
+			const {
+				getBlockInsertionPoint,
+				isBlockInsertionPointVisible,
+				getBlockCount,
+			} = select( blockEditorStore );
+			const insertionPoint = getBlockInsertionPoint();
+			return (
+				isBlockInsertionPointVisible() &&
+				rootClientId === insertionPoint?.rootClientId &&
+				getBlockCount( rootClientId ) === 0
+			);
+		},
+		[ rootClientId ]
+	);
 
 	if ( ! appender ) {
 		return null;
@@ -103,7 +119,8 @@ function BlockListAppender( {
 			tabIndex={ -1 }
 			className={ classnames(
 				'block-list-appender wp-block',
-				className
+				className,
+				isDragOver && 'is-drag-over'
 			) }
 			// Needed in case the whole editor is content editable (for multi
 			// selection). It fixes an edge case where ArrowDown and ArrowRight

--- a/packages/block-editor/src/components/block-list-appender/index.js
+++ b/packages/block-editor/src/components/block-list-appender/index.js
@@ -93,6 +93,9 @@ function BlockListAppender( {
 				getBlockCount,
 			} = select( blockEditorStore );
 			const insertionPoint = getBlockInsertionPoint();
+			// Ideally we should also check for `isDragging` but currently it
+			// requires a lot more setup. We can revisit this once we refactor
+			// the DnD utility hooks.
 			return (
 				isBlockInsertionPointVisible() &&
 				rootClientId === insertionPoint?.rootClientId &&
@@ -117,11 +120,9 @@ function BlockListAppender( {
 			//
 			// See: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#Clicking_and_focus
 			tabIndex={ -1 }
-			className={ classnames(
-				'block-list-appender wp-block',
-				className,
-				isDragOver && 'is-drag-over'
-			) }
+			className={ classnames( 'block-list-appender wp-block', className, {
+				'is-drag-over': isDragOver,
+			} ) }
 			// Needed in case the whole editor is content editable (for multi
 			// selection). It fixes an edge case where ArrowDown and ArrowRight
 			// should collapse the selection to the end of that selection and

--- a/packages/block-editor/src/components/block-tools/insertion-point.js
+++ b/packages/block-editor/src/components/block-tools/insertion-point.js
@@ -198,16 +198,30 @@ function InbetweenInsertionPointPopover( {
 }
 
 export default function InsertionPoint( props ) {
-	const { insertionPoint, isVisible } = useSelect( ( select ) => {
-		const { getBlockInsertionPoint, isBlockInsertionPointVisible } =
-			select( blockEditorStore );
-		return {
-			insertionPoint: getBlockInsertionPoint(),
-			isVisible: isBlockInsertionPointVisible(),
-		};
-	}, [] );
+	const { insertionPoint, isVisible, isBlockListEmpty } = useSelect(
+		( select ) => {
+			const {
+				getBlockInsertionPoint,
+				isBlockInsertionPointVisible,
+				getBlockCount,
+			} = select( blockEditorStore );
+			const blockInsertionPoint = getBlockInsertionPoint();
+			return {
+				insertionPoint: blockInsertionPoint,
+				isVisible: isBlockInsertionPointVisible(),
+				isBlockListEmpty:
+					getBlockCount( blockInsertionPoint?.rootClientId ) === 0,
+			};
+		},
+		[]
+	);
 
-	if ( ! isVisible ) {
+	if (
+		! isVisible ||
+		// Don't render the insertion point if the block list is empty.
+		// The insertion point will be represented by the appender instead.
+		isBlockListEmpty
+	) {
 		return null;
 	}
 

--- a/packages/block-editor/src/components/button-block-appender/content.scss
+++ b/packages/block-editor/src/components/button-block-appender/content.scss
@@ -32,6 +32,7 @@
 	}
 }
 
+
 // When the appender shows up in empty container blocks, such as Group and Columns, add an extra click state.
 .block-list-appender:only-child {
 	.is-layout-constrained.block-editor-block-list__block:not(.is-selected) > &,
@@ -55,6 +56,27 @@
 
 		.block-editor-inserter {
 			visibility: hidden;
+		}
+
+		&.is-drag-over {
+			&::after {
+				border: none;
+			}
+
+			.block-editor-inserter {
+				visibility: visible;
+			}
+		}
+	}
+
+	&.is-drag-over .block-editor-button-block-appender {
+		background-color: var(--wp-admin-theme-color);
+		box-shadow: inset 0 0 0 $border-width $light-gray-placeholder;
+		color: $light-gray-placeholder;
+		transition: background-color 0.2s ease-in-out;
+
+		@media ( prefers-reduced-motion: reduce ) {
+			transition: none;
 		}
 	}
 }

--- a/packages/block-editor/src/components/use-block-drop-zone/index.js
+++ b/packages/block-editor/src/components/use-block-drop-zone/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useDispatch, useSelect } from '@wordpress/data';
+import { useDispatch, useSelect, useRegistry } from '@wordpress/data';
 import { useCallback, useState } from '@wordpress/element';
 import {
 	useThrottle,
@@ -142,6 +142,7 @@ export default function useBlockDropZone( {
 	// an empty string to represent top-level blocks.
 	rootClientId: targetRootClientId = '',
 } = {} ) {
+	const registry = useRegistry();
 	const [ dropTarget, setDropTarget ] = useState( {
 		index: null,
 		operation: 'insert',
@@ -181,9 +182,14 @@ export default function useBlockDropZone( {
 
 				// The block list is empty, don't show the insertion point but still allow dropping.
 				if ( blocks.length === 0 ) {
-					setDropTarget( {
-						index: 0,
-						operation: 'insert',
+					registry.batch( () => {
+						setDropTarget( {
+							index: 0,
+							operation: 'insert',
+						} );
+						showInsertionPoint( targetRootClientId, 0, {
+							operation: 'insert',
+						} );
 					} );
 					return;
 				}
@@ -208,15 +214,24 @@ export default function useBlockDropZone( {
 					getBlockListSettings( targetRootClientId )?.orientation
 				);
 
-				setDropTarget( {
-					index: targetIndex,
-					operation,
-				} );
-				showInsertionPoint( targetRootClientId, targetIndex, {
-					operation,
+				registry.batch( () => {
+					setDropTarget( {
+						index: targetIndex,
+						operation,
+					} );
+					showInsertionPoint( targetRootClientId, targetIndex, {
+						operation,
+					} );
 				} );
 			},
-			[ targetRootClientId ]
+			[
+				getBlocks,
+				targetRootClientId,
+				getBlockListSettings,
+				registry,
+				showInsertionPoint,
+				getBlockIndex,
+			]
 		),
 		200
 	);

--- a/test/e2e/specs/editor/various/draggable-blocks.spec.js
+++ b/test/e2e/specs/editor/various/draggable-blocks.spec.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+const path = require( 'path' );
+
+/**
  * WordPress dependencies
  */
 const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
@@ -322,5 +327,135 @@ test.describe( 'Draggable block', () => {
 <p>1</p>
 <!-- /wp:paragraph --></div>
 <!-- /wp:group -->` );
+	} );
+
+	test( 'can drag and drop to an empty parent block like Group or Columns', async ( {
+		page,
+		editor,
+		pageUtils,
+	} ) => {
+		// Insert a row.
+		await editor.insertBlock( {
+			name: 'core/group',
+			attributes: {
+				layout: { type: 'flex', flexWrap: 'nowrap' },
+			},
+		} );
+		await editor.insertBlock( {
+			name: 'core/columns',
+			innerBlocks: [
+				{
+					name: 'core/column',
+					innerBlocks: [
+						{
+							name: 'core/paragraph',
+							attributes: { content: '1' },
+						},
+					],
+				},
+				{ name: 'core/column' },
+				{
+					name: 'core/column',
+					innerBlocks: [
+						{
+							name: 'core/paragraph',
+							attributes: { content: '3' },
+						},
+					],
+				},
+			],
+		} );
+
+		// Deselect the block to hide th block toolbar.
+		await page.evaluate( () =>
+			window.wp.data.dispatch( 'core/block-editor' ).clearSelectedBlock()
+		);
+
+		const testImageName = '10x10_e2e_test_image_z9T8jK.png';
+		const testImagePath = path.join(
+			__dirname,
+			'../../../assets',
+			testImageName
+		);
+
+		{
+			const { dragOver, drop } = await pageUtils.dragFiles(
+				testImagePath
+			);
+
+			const rowBlock = editor.canvas.getByRole( 'document', {
+				name: 'Block: Row',
+			} );
+			const rowAppender = rowBlock.getByRole( 'button', {
+				name: 'Add block',
+			} );
+
+			await dragOver( rowAppender );
+			// Expect to show the drop indicator blue background.
+			// This is technically an implementation detail but easier to test in this case.
+			await expect(
+				rowAppender,
+				'Dragging over the button block appender should show the blue background'
+			).toHaveCSS( 'background-color', 'rgb(0, 124, 186)' );
+
+			const { width: rowWidth } = await rowBlock.boundingBox();
+			await dragOver( rowBlock, { position: { x: rowWidth - 10 } } );
+			// Expect to show the drop indicator blue background.
+			// This is technically an implementation detail but easier to test in this case.
+			await expect(
+				rowAppender,
+				'Dragging over the empty group block but outside the appender should still show the blue background'
+			).toHaveCSS( 'background-color', 'rgb(0, 124, 186)' );
+
+			await drop();
+			await expect( rowAppender ).toBeHidden();
+			await expect.poll( editor.getBlocks ).toMatchObject( [
+				{
+					name: 'core/group',
+					innerBlocks: [ { name: 'core/image' } ],
+				},
+				{ name: 'core/columns' },
+			] );
+		}
+
+		{
+			const { dragOver, drop } = await pageUtils.dragFiles(
+				testImagePath
+			);
+
+			const columnAppender = editor.canvas
+				.getByRole( 'document', {
+					name: 'Block: Column',
+				} )
+				.getByRole( 'button', {
+					name: 'Add block',
+					includeHidden: true,
+				} );
+
+			await dragOver( columnAppender );
+			// Expect to show the drop indicator blue background.
+			// This is technically an implementation detail but easier to test in this case.
+			await expect( columnAppender ).toHaveCSS(
+				'background-color',
+				'rgb(0, 124, 186)'
+			);
+
+			await drop();
+			await expect( columnAppender ).toBeHidden();
+			await expect.poll( editor.getBlocks ).toMatchObject( [
+				{ name: 'core/group' },
+				{
+					name: 'core/columns',
+					innerBlocks: [
+						{ name: 'core/column' },
+						{
+							name: 'core/column',
+							innerBlocks: [ { name: 'core/image' } ],
+						},
+						{ name: 'core/column' },
+					],
+				},
+			] );
+		}
 	} );
 } );

--- a/test/e2e/specs/editor/various/draggable-blocks.spec.js
+++ b/test/e2e/specs/editor/various/draggable-blocks.spec.js
@@ -366,7 +366,7 @@ test.describe( 'Draggable block', () => {
 			],
 		} );
 
-		// Deselect the block to hide th block toolbar.
+		// Deselect the block to hide the block toolbar.
 		await page.evaluate( () =>
 			window.wp.data.dispatch( 'core/block-editor' ).clearSelectedBlock()
 		);


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Fix https://github.com/WordPress/gutenberg/issues/39064. Add a visual animation when dragging a block over an empty group block.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
See https://github.com/WordPress/gutenberg/issues/39064.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Call `showInsertionPoint` even when the list is empty but update the insertion point to not show the in-between blue line indicator. Instead, use it to change the background of the appender.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
1. Add an empty parent block with the ButtonBlockAppender, some examples are Group and Columns.
2. Try dragging stuff over the button appender.
3. Expect the button appender to show blue background.
4. Try dragging stuff over the dashed appender too.
5. Expect the button block appender to animate in.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
It's a drag-and-drop (DnD) feature, and currently DnD doesn't work with keyboard in gutenberg.

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/7753001/f44de646-8283-4a5e-950d-add540f798a1

