### PR TITLE
Command Tool: Fix contextual commands selectors

### DIFF
--- a/packages/commands/src/store/selectors.js
+++ b/packages/commands/src/store/selectors.js
@@ -10,7 +10,7 @@ export const getCommands = createSelector(
 				command.context && command.context === state.context;
 			return contextual ? isContextual : ! isContextual;
 		} ),
-	( state ) => [ state.commands ]
+	( state ) => [ state.commands, state.context ]
 );
 
 export const getCommandLoaders = createSelector(
@@ -20,7 +20,7 @@ export const getCommandLoaders = createSelector(
 				loader.context && loader.context === state.context;
 			return contextual ? isContextual : ! isContextual;
 		} ),
-	( state ) => [ state.commandLoaders ]
+	( state ) => [ state.commandLoaders, state.context ]
 );
 
 export function isOpen( state ) {


### PR DESCRIPTION
related #48457 

## What?

This PR fixes a small bug where the initial "context" persists. In other words, if you load the site editor in "edit" mode, the "revert template" command is always shown even if you leave the mode (go to view mode). The opposite is true, it's never shown if you open the editor in "view mode".

## Testing Instructions

1- Have a modified saved template
2- Open the editor and check that the "revert template" command is visible when open the command center in "edit" mode but not "view" mode without refreshing the page between the mode switch.
