### PR TITLE
Command tool: Enable e2e tests

### DIFF
--- a/test/e2e/specs/site-editor/command-center.spec.js
+++ b/test/e2e/specs/site-editor/command-center.spec.js
@@ -20,28 +20,27 @@ test.describe( 'Site editor command center', () => {
 	test( 'Open the command center and navigate to the page create page', async ( {
 		page,
 	} ) => {
-		await page.focus( 'role=button[name="Open command center"i]' );
+		await page
+			.getByRole( 'button', { name: 'Open command center' } )
+			.focus();
 		await page.keyboard.press( 'Meta+k' );
 		await page.keyboard.type( 'new page' );
-		const newPageButton = page.locator(
-			'role=option[name="Add new page"i]'
-		);
-		await expect( newPageButton ).toBeVisible();
-		await newPageButton.click();
-
+		await page.getByRole( 'option', { name: 'Add new page' } ).click();
 		await page.waitForSelector( 'iframe[name="editor-canvas"]' );
 		const frame = page.frame( 'editor-canvas' );
 		await expect(
-			frame.locator( 'role=textbox[name=/Add title/i]' )
+			frame.getByRole( 'textbox', { name: 'Add title' } )
 		).toBeVisible();
 	} );
 
 	test( 'Open the command center and navigate to a template', async ( {
 		page,
 	} ) => {
-		await page.click( 'role=button[name="Open command center"i]' );
+		await page
+			.getByRole( 'button', { name: 'Open command center' } )
+			.click();
 		await page.keyboard.type( 'index' );
-		await page.click( 'role=option[name="index"i]' );
+		await page.getByRole( 'option', { name: 'index' } ).click();
 		await expect( page.locator( 'h2' ) ).toHaveText( 'Index' );
 	} );
 } );

--- a/test/e2e/specs/site-editor/command-center.spec.js
+++ b/test/e2e/specs/site-editor/command-center.spec.js
@@ -17,34 +17,29 @@ test.describe( 'Site editor command center', () => {
 		await admin.visitSiteEditor();
 	} );
 
-	test.skip( 'Open the command center and navigate to the page create page', async ( {
+	test( 'Open the command center and navigate to the page create page', async ( {
 		page,
 	} ) => {
+		await page.focus( 'role=button[name="Open command center"i]' );
 		await page.keyboard.press( 'Meta+k' );
+		await page.keyboard.type( 'new page' );
 		const newPageButton = page.locator(
-			'role=option[name="Create a new page"i]'
+			'role=option[name="Add new page"i]'
 		);
 		await expect( newPageButton ).toBeVisible();
-
-		// Type a random post title
-		await page.keyboard.type( 'E2E Test Post' );
-		await page.click(
-			'role=option[name="Create a new post \\"E2E Test Post\\""i]'
-		);
+		await newPageButton.click();
 
 		await page.waitForSelector( 'iframe[name="editor-canvas"]' );
 		const frame = page.frame( 'editor-canvas' );
-		const postTitleInput = frame.locator(
-			'role=textbox[name=/Add title/i]'
-		);
-		await expect( postTitleInput ).toHaveText( 'E2E Test Post' );
+		await expect(
+			frame.locator( 'role=textbox[name=/Add title/i]' )
+		).toBeVisible();
 	} );
 
-	test.skip( 'Open the command center and navigate to a template', async ( {
+	test( 'Open the command center and navigate to a template', async ( {
 		page,
 	} ) => {
-		await page.keyboard.press( 'Meta+k' );
-
+		await page.click( 'role=button[name="Open command center"i]' );
 		await page.keyboard.type( 'index' );
 		await page.click( 'role=option[name="index"i]' );
 		await expect( page.locator( 'h2' ) ).toHaveText( 'Index' );

--- a/test/e2e/specs/site-editor/command-center.spec.js
+++ b/test/e2e/specs/site-editor/command-center.spec.js
@@ -41,6 +41,8 @@ test.describe( 'Site editor command center', () => {
 			.click();
 		await page.keyboard.type( 'index' );
 		await page.getByRole( 'option', { name: 'index' } ).click();
-		await expect( page.locator( 'h2' ) ).toHaveText( 'Index' );
+		await expect( page.getByRole( 'heading', { level: 2 } ) ).toHaveText(
+			'Index'
+		);
 	} );
 } );


### PR DESCRIPTION
Related #48457 

## What?

Enable e2e tests for the command center now that it's not experimental anymore.
