### PR TITLE
Post Comments From: Prevent hidden input fields from being focusable in Safari.

### DIFF
--- a/packages/block-library/src/post-comments-form/style.scss
+++ b/packages/block-library/src/post-comments-form/style.scss
@@ -45,7 +45,9 @@
 
 	.comment-form {
 		textarea,
-		input:not([type="submit"]):not([type="checkbox"]) {
+		// Make sure to not set display block on hidden input fields, to prevent
+		// the Safari bug experienced in https://github.com/WordPress/gutenberg/issues/50830
+		input:not([type="submit"]):not([type="checkbox"]):not([type="hidden"]) {
 			display: block;
 			box-sizing: border-box;
 			width: 100%;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Fixes https://github.com/WordPress/gutenberg/issues/50830

## What?
<!-- In a few words, what is the PR actually doing? -->
It appears hidden input fields with a `display: biock` CSS property stay invisible in Safari but become focusable. 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
As the hidden input fields become focusable, there are invisible tab stops when navigating the page with the Tab key. Invisible tab stops are extremely confusing for keyboard users, including screen reader users.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Make sure to exclude hidden input fields from getting `display: biock` in the post comment form block.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
- Repeat the steps described in the related issue https://github.com/WordPress/gutenberg/issues/50830
- Observe there are no invisible tab stops.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
See above.

## Screenshots or screencast <!-- if applicable -->
