### PR TITLE
Fix width of Template Parts view

### DIFF
--- a/packages/edit-site/src/components/list/style.scss
+++ b/packages/edit-site/src/components/list/style.scss
@@ -33,6 +33,7 @@
 
 .edit-site {
 	.edit-site-list {
+		flex-grow: 1;
 		background: $white;
 		border-radius: $radius-block-ui * 4;
 		box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.8), 0 8px 10px -6px rgba(0, 0, 0, 0.8);


### PR DESCRIPTION
Fixes #50815

## What?

Fixes a style regression in #49910 where the "All template parts" screen was not taking up the full width available.

## How?

As far as I can tell, this style only affects the "All templates" and "All template parts" screen in the Site Editor.

The reason the bug only reproduces in the "All template parts" screen (at least for the Twenty Twenty-Three theme) is that the template parts don't have these descriptions that push out the content width:

<img src="https://github.com/WordPress/gutenberg/assets/555336/c3c43cdb-82dc-4300-a236-1bfc07a2d772" alt="Templates have some text descriptions in the table" width="400">

## Testing Instructions

1. Go to `/wp-admin/site-editor.php?path=%2Fwp_template_part%2Fall`. The white content card should take up the width available.
2. Goto `/wp-admin/site-editor.php?path=%2Fwp_template%2Fall`. It should be the same as before.
