### PR TITLE
 Navigation: browse mode list all Navigation Menus.

### DIFF
--- a/lib/compat/wordpress-6.3/navigation-block-preloading.php
+++ b/lib/compat/wordpress-6.3/navigation-block-preloading.php
@@ -43,15 +43,15 @@ function gutenberg_preload_navigation_posts( $preload_paths, $context ) {
 		'GET',
 	);
 
-	// Preload request for Browse Mode sidebar "Navigation" section.
+	// Preload request for all menus in Browse Mode sidebar "Navigation" section.
 	$preload_paths[] = array(
 		add_query_arg(
 			array(
 				'context'  => 'edit',
-				'per_page' => 1,
-				'status'   => 'publish',
+				'per_page' => 100,
 				'order'    => 'desc',
 				'orderby'  => 'date',
+				'status'   => 'publish',
 			),
 			$navigation_rest_route
 		),

--- a/packages/edit-site/src/components/sidebar-navigation-screen-main/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-main/index.js
@@ -8,7 +8,7 @@ import {
 import { __ } from '@wordpress/i18n';
 import { layout, symbol, navigation, styles, page } from '@wordpress/icons';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { store as coreStore } from '@wordpress/core-data';
+
 import { useEffect } from '@wordpress/element';
 
 /**
@@ -19,27 +19,9 @@ import SidebarNavigationItem from '../sidebar-navigation-item';
 import { SidebarNavigationItemGlobalStyles } from '../sidebar-navigation-screen-global-styles';
 import { unlock } from '../../private-apis';
 import { store as editSiteStore } from '../../store';
+import SidebarNavigationScreenNavigationMenuButton from '../sidebar-navigation-screen-navigation-menus/navigator-button';
 
 export default function SidebarNavigationScreenMain() {
-	const hasNavigationMenus = useSelect( ( select ) => {
-		// The query needs to be the same as in the "SidebarNavigationScreenNavigationMenus" component,
-		// to avoid double network calls.
-		const navigationMenus = select( coreStore ).getEntityRecords(
-			'postType',
-			'wp_navigation',
-			{
-				per_page: 1,
-				status: 'publish',
-				order: 'desc',
-				orderby: 'date',
-			}
-		);
-		return !! navigationMenus?.length;
-	}, [] );
-	const showNavigationScreen = process.env.IS_GUTENBERG_PLUGIN
-		? hasNavigationMenus
-		: false;
-
 	const editorCanvasContainerView = useSelect( ( select ) => {
 		return unlock( select( editSiteStore ) ).getEditorCanvasContainerView();
 	}, [] );
@@ -64,16 +46,14 @@ export default function SidebarNavigationScreenMain() {
 			) }
 			content={
 				<ItemGroup>
-					{ showNavigationScreen && (
-						<NavigatorButton
-							as={ SidebarNavigationItem }
-							path="/navigation"
-							withChevron
-							icon={ navigation }
-						>
-							{ __( 'Navigation' ) }
-						</NavigatorButton>
-					) }
+					<SidebarNavigationScreenNavigationMenuButton
+						withChevron
+						icon={ navigation }
+						as={ SidebarNavigationItem }
+					>
+						{ __( 'Navigation' ) }
+					</SidebarNavigationScreenNavigationMenuButton>
+
 					<SidebarNavigationItemGlobalStyles
 						withChevron
 						icon={ styles }

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/index.js
@@ -38,7 +38,7 @@ export default function SidebarNavigationScreenNavigationMenu() {
 		postId
 	);
 
-	const menuTitle = navigationMenu?.title?.rendered || navigationMenu.slug;
+	const menuTitle = navigationMenu?.title?.rendered || navigationMenu?.slug;
 
 	if ( isLoading ) {
 		return (
@@ -59,7 +59,9 @@ export default function SidebarNavigationScreenNavigationMenu() {
 	return (
 		<SidebarNavigationScreenWrapper
 			title={ decodeEntities( menuTitle ) }
-			description={ '...' }
+			description={ __(
+				'Navigation menus are a curated collection of blocks that allow visitors to get around your site.'
+			) }
 		>
 			<NavigationMenuEditor navigationMenu={ navigationMenu } />
 		</SidebarNavigationScreenWrapper>

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/index.js
@@ -9,6 +9,7 @@ import { useSelect } from '@wordpress/data';
 import { privateApis as routerPrivateApis } from '@wordpress/router';
 import { BlockEditorProvider } from '@wordpress/block-editor';
 import { createBlock } from '@wordpress/blocks';
+import { decodeEntities } from '@wordpress/html-entities';
 
 /**
  * Internal dependencies
@@ -37,6 +38,8 @@ export default function SidebarNavigationScreenNavigationMenu() {
 		postId
 	);
 
+	const menuTitle = navigationMenu?.title?.rendered || navigationMenu.slug;
+
 	if ( isLoading ) {
 		return (
 			<SidebarNavigationScreenWrapper>
@@ -54,13 +57,16 @@ export default function SidebarNavigationScreenNavigationMenu() {
 	}
 
 	return (
-		<SidebarNavigationScreenWrapper>
-			<SidebarNavigationMenu navigationMenu={ navigationMenu } />
+		<SidebarNavigationScreenWrapper
+			title={ decodeEntities( menuTitle ) }
+			description={ '...' }
+		>
+			<NavigationMenuEditor navigationMenu={ navigationMenu } />
 		</SidebarNavigationScreenWrapper>
 	);
 }
 
-export function SidebarNavigationMenu( { navigationMenu } ) {
+function NavigationMenuEditor( { navigationMenu } ) {
 	const history = useHistory();
 
 	const onSelect = useCallback(
@@ -102,7 +108,7 @@ export function SidebarNavigationMenu( { navigationMenu } ) {
 	}, [] );
 
 	const blocks = useMemo( () => {
-		if ( ! SidebarNavigationMenu ) {
+		if ( ! NavigationMenuEditor ) {
 			return [];
 		}
 

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/index.js
@@ -1,0 +1,46 @@
+/**
+ * WordPress dependencies
+ */
+import { useEntityRecord } from '@wordpress/core-data';
+import { __experimentalUseNavigator as useNavigator } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { SidebarNavigationScreenWrapper } from '../sidebar-navigation-screen-navigation-menus';
+
+export default function SidebarNavigationScreenNavigationMenu() {
+	const postType = `wp_navigation`;
+	const {
+		params: { postId },
+	} = useNavigator();
+
+	const { record: navigationMenu, isResolving: isLoading } = useEntityRecord(
+		'postType',
+		postType,
+		postId
+	);
+
+	if ( isLoading ) {
+		return (
+			<SidebarNavigationScreenWrapper>
+				{ __( 'Loading Navigation Menu.' ) }
+			</SidebarNavigationScreenWrapper>
+		);
+	}
+
+	if ( ! isLoading && ! navigationMenu ) {
+		return (
+			<SidebarNavigationScreenWrapper>
+				{ __( 'Navigation Menu Missing.' ) }
+			</SidebarNavigationScreenWrapper>
+		);
+	}
+
+	return (
+		<SidebarNavigationScreenWrapper>
+			{ navigationMenu?.title.rendered }
+		</SidebarNavigationScreenWrapper>
+	);
+}

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/index.js
@@ -4,11 +4,26 @@
 import { useEntityRecord } from '@wordpress/core-data';
 import { __experimentalUseNavigator as useNavigator } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { useCallback, useMemo } from '@wordpress/element';
+import { useSelect } from '@wordpress/data';
+import { privateApis as routerPrivateApis } from '@wordpress/router';
+import { BlockEditorProvider } from '@wordpress/block-editor';
+import { createBlock } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
  */
+import { unlock } from '../../private-apis';
+import { store as editSiteStore } from '../../store';
+import {
+	isPreviewingTheme,
+	currentlyPreviewingTheme,
+} from '../../utils/is-previewing-theme';
 import { SidebarNavigationScreenWrapper } from '../sidebar-navigation-screen-navigation-menus';
+import NavigationMenuContent from '../sidebar-navigation-screen-navigation-menus/navigation-menu-content';
+
+const { useHistory } = unlock( routerPrivateApis );
+const noop = () => {};
 
 export default function SidebarNavigationScreenNavigationMenu() {
 	const postType = `wp_navigation`;
@@ -40,7 +55,79 @@ export default function SidebarNavigationScreenNavigationMenu() {
 
 	return (
 		<SidebarNavigationScreenWrapper>
-			{ navigationMenu?.title.rendered }
+			<SidebarNavigationMenu navigationMenu={ navigationMenu } />
 		</SidebarNavigationScreenWrapper>
+	);
+}
+
+export function SidebarNavigationMenu( { navigationMenu } ) {
+	const history = useHistory();
+
+	const onSelect = useCallback(
+		( selectedBlock ) => {
+			const { attributes, name } = selectedBlock;
+			if (
+				attributes.kind === 'post-type' &&
+				attributes.id &&
+				attributes.type &&
+				history
+			) {
+				history.push( {
+					postType: attributes.type,
+					postId: attributes.id,
+					...( isPreviewingTheme() && {
+						theme_preview: currentlyPreviewingTheme(),
+					} ),
+				} );
+			}
+			if ( name === 'core/page-list-item' && attributes.id && history ) {
+				history.push( {
+					postType: 'page',
+					postId: attributes.id,
+					...( isPreviewingTheme() && {
+						theme_preview: currentlyPreviewingTheme(),
+					} ),
+				} );
+			}
+		},
+		[ history ]
+	);
+
+	const { storedSettings } = useSelect( ( select ) => {
+		const { getSettings } = unlock( select( editSiteStore ) );
+
+		return {
+			storedSettings: getSettings( false ),
+		};
+	}, [] );
+
+	const blocks = useMemo( () => {
+		if ( ! SidebarNavigationMenu ) {
+			return [];
+		}
+
+		return [
+			createBlock( 'core/navigation', { ref: navigationMenu?.id } ),
+		];
+	}, [ navigationMenu ] );
+
+	if ( ! navigationMenu || ! blocks?.length ) {
+		return null;
+	}
+
+	return (
+		<BlockEditorProvider
+			settings={ storedSettings }
+			value={ blocks }
+			onChange={ noop }
+			onInput={ noop }
+		>
+			<div className="edit-site-sidebar-navigation-screen-navigation-menus__content">
+				<NavigationMenuContent
+					rootClientId={ blocks[ 0 ].clientId }
+					onSelect={ onSelect }
+				/>
+			</div>
+		</BlockEditorProvider>
 	);
 }

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/index.js
@@ -42,17 +42,17 @@ export default function SidebarNavigationScreenNavigationMenu() {
 
 	if ( isLoading ) {
 		return (
-			<SidebarNavigationScreenWrapper>
-				{ __( 'Loading Navigation Menu.' ) }
-			</SidebarNavigationScreenWrapper>
+			<SidebarNavigationScreenWrapper
+				description={ __( 'Loading Navigation Menu.' ) }
+			/>
 		);
 	}
 
 	if ( ! isLoading && ! navigationMenu ) {
 		return (
-			<SidebarNavigationScreenWrapper>
-				{ __( 'Navigation Menu Missing.' ) }
-			</SidebarNavigationScreenWrapper>
+			<SidebarNavigationScreenWrapper
+				description={ __( 'Navigation Menu missing.' ) }
+			/>
 		);
 	}
 

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/index.js
@@ -2,7 +2,10 @@
  * WordPress dependencies
  */
 import { useEntityRecord } from '@wordpress/core-data';
-import { __experimentalUseNavigator as useNavigator } from '@wordpress/components';
+import {
+	__experimentalUseNavigator as useNavigator,
+	Spinner,
+} from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useCallback, useMemo } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
@@ -43,8 +46,12 @@ export default function SidebarNavigationScreenNavigationMenu() {
 	if ( isLoading ) {
 		return (
 			<SidebarNavigationScreenWrapper
-				description={ __( 'Loading Navigation Menu.' ) }
-			/>
+				description={ __(
+					'Navigation menus are a curated collection of blocks that allow visitors to get around your site.'
+				) }
+			>
+				<Spinner className="edit-site-sidebar-navigation-screen-navigation-menus__loading" />
+			</SidebarNavigationScreenWrapper>
 		);
 	}
 

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/constants.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/constants.js
@@ -1,0 +1,9 @@
+// This requested is preloaded in `gutenberg_preload_navigation_posts`.
+// As unbounded queries are limited to 100 by `fetchAllMiddleware`
+// on apiFetch this query is limited to 100.
+export const PRELOADED_NAVIGATION_MENUS_QUERY = {
+	per_page: 100,
+	status: 'publish',
+	order: 'desc',
+	orderby: 'date',
+};

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/index.js
@@ -19,8 +19,11 @@ import SidebarNavigationItem from '../sidebar-navigation-item';
 
 import { useLink } from '../routes/link';
 
-const NAVIGATION_MENUS_QUERY = {
-	per_page: -1,
+// This requested is preloaded in `gutenberg_preload_navigation_posts`.
+// As unbounded queries are limited to 100 by `fetchAllMiddleware`
+// on apiFetch this query is limited to 100.
+const PRELOADED_NAVIGATION_MENUS_QUERY = {
+	per_page: 100,
 	status: 'publish',
 	order: 'desc',
 	orderby: 'date',
@@ -28,7 +31,11 @@ const NAVIGATION_MENUS_QUERY = {
 
 export default function SidebarNavigationScreenNavigationMenus() {
 	const { records: navigationMenus, isResolving: isLoading } =
-		useEntityRecords( 'postType', `wp_navigation`, NAVIGATION_MENUS_QUERY );
+		useEntityRecords(
+			'postType',
+			`wp_navigation`,
+			PRELOADED_NAVIGATION_MENUS_QUERY
+		);
 
 	const hasNavigationMenus = !! navigationMenus?.length;
 

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/index.js
@@ -30,17 +30,17 @@ export default function SidebarNavigationScreenNavigationMenus() {
 
 	if ( isLoading ) {
 		return (
-			<SidebarNavigationScreenWrapper>
-				{ __( 'Loading Navigation Menus.' ) }
-			</SidebarNavigationScreenWrapper>
+			<SidebarNavigationScreenWrapper
+				description={ __( 'Loading Navigation Menus.' ) }
+			/>
 		);
 	}
 
 	if ( ! isLoading && ! hasNavigationMenus ) {
 		return (
-			<SidebarNavigationScreenWrapper>
-				{ __( 'There are no Navigation Menus.' ) }
-			</SidebarNavigationScreenWrapper>
+			<SidebarNavigationScreenWrapper
+				description={ __( 'No Navigation Menus found.' ) }
+			/>
 		);
 	}
 

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/index.js
@@ -4,15 +4,18 @@
 import { __ } from '@wordpress/i18n';
 import { useCallback, useMemo } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
-import { store as coreStore } from '@wordpress/core-data';
+import { useEntityRecords } from '@wordpress/core-data';
 import { BlockEditorProvider } from '@wordpress/block-editor';
 import { createBlock } from '@wordpress/blocks';
 import { privateApis as routerPrivateApis } from '@wordpress/router';
+import { decodeEntities } from '@wordpress/html-entities';
+import { __experimentalItemGroup as ItemGroup } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
 import SidebarNavigationScreen from '../sidebar-navigation-screen';
+import SidebarNavigationItem from '../sidebar-navigation-item';
 import NavigationMenuContent from './navigation-menu-content';
 import { unlock } from '../../private-apis';
 import { store as editSiteStore } from '../../store';
@@ -20,61 +23,41 @@ import {
 	isPreviewingTheme,
 	currentlyPreviewingTheme,
 } from '../../utils/is-previewing-theme';
+import { useLink } from '../routes/link';
 
 const { useHistory } = unlock( routerPrivateApis );
 
 const noop = () => {};
 const NAVIGATION_MENUS_QUERY = {
-	per_page: 1,
+	per_page: -1,
 	status: 'publish',
 	order: 'desc',
 	orderby: 'date',
 };
 
-function SidebarNavigationScreenWrapper( { children, actions } ) {
+export function SidebarNavigationScreenWrapper( { children, actions } ) {
 	return (
 		<SidebarNavigationScreen
 			title={ __( 'Navigation' ) }
 			actions={ actions }
-			description={ __(
-				'Browse your site, edit pages, and manage your primary navigation menu.'
-			) }
+			description={ __( 'Manage your Navigation menus.' ) }
 			content={ children }
 		/>
 	);
 }
 
-export default function SidebarNavigationScreenNavigationMenus() {
+const NavMenuItem = ( { postType, postId, ...props } ) => {
+	const linkInfo = useLink( {
+		postType,
+		postId,
+	} );
+	return <SidebarNavigationItem { ...linkInfo } { ...props } />;
+};
+
+const SideBarNavigationScreenNavigationMenu = ( {
+	menu: firstNavigationMenu,
+} ) => {
 	const history = useHistory();
-	const { navigationMenus, hasResolvedNavigationMenus, storedSettings } =
-		useSelect( ( select ) => {
-			const { getSettings } = unlock( select( editSiteStore ) );
-			const { getEntityRecords, hasFinishedResolution } =
-				select( coreStore );
-
-			const navigationMenusQuery = [
-				'postType',
-				'wp_navigation',
-				NAVIGATION_MENUS_QUERY,
-			];
-			return {
-				storedSettings: getSettings( false ),
-				navigationMenus: getEntityRecords( ...navigationMenusQuery ),
-				hasResolvedNavigationMenus: hasFinishedResolution(
-					'getEntityRecords',
-					navigationMenusQuery
-				),
-			};
-		}, [] );
-
-	const firstNavigationMenu = navigationMenus?.[ 0 ]?.id;
-	const blocks = useMemo( () => {
-		return [
-			createBlock( 'core/navigation', { ref: firstNavigationMenu } ),
-		];
-	}, [ firstNavigationMenu ] );
-
-	const hasNavigationMenus = !! navigationMenus?.length;
 
 	const onSelect = useCallback(
 		( selectedBlock ) => {
@@ -106,13 +89,19 @@ export default function SidebarNavigationScreenNavigationMenus() {
 		[ history ]
 	);
 
-	if ( hasResolvedNavigationMenus && ! hasNavigationMenus ) {
-		return (
-			<SidebarNavigationScreenWrapper>
-				{ __( 'There are no Navigation Menus.' ) }
-			</SidebarNavigationScreenWrapper>
-		);
-	}
+	const { storedSettings } = useSelect( ( select ) => {
+		const { getSettings } = unlock( select( editSiteStore ) );
+
+		return {
+			storedSettings: getSettings( false ),
+		};
+	}, [] );
+
+	const blocks = useMemo( () => {
+		return [
+			createBlock( 'core/navigation', { ref: firstNavigationMenu } ),
+		];
+	}, [ firstNavigationMenu ] );
 
 	return (
 		<BlockEditorProvider
@@ -121,14 +110,68 @@ export default function SidebarNavigationScreenNavigationMenus() {
 			onChange={ noop }
 			onInput={ noop }
 		>
-			<SidebarNavigationScreenWrapper>
-				<div className="edit-site-sidebar-navigation-screen-navigation-menus__content">
-					<NavigationMenuContent
-						rootClientId={ blocks[ 0 ].clientId }
-						onSelect={ onSelect }
-					/>
-				</div>
-			</SidebarNavigationScreenWrapper>
+			<div className="edit-site-sidebar-navigation-screen-navigation-menus__content">
+				<NavigationMenuContent
+					rootClientId={ blocks[ 0 ].clientId }
+					onSelect={ onSelect }
+				/>
+			</div>
 		</BlockEditorProvider>
+	);
+};
+
+export default function SidebarNavigationScreenNavigationMenus() {
+	const postType = 'wp_navigation';
+
+	const { records: navigationMenus, isResolving: isLoading } =
+		useEntityRecords( 'postType', `wp_navigation`, NAVIGATION_MENUS_QUERY );
+
+	const hasNavigationMenus = !! navigationMenus?.length;
+	const hasSingleNavigationMenu = navigationMenus?.length === 1;
+	const firstNavigationMenu = navigationMenus?.[ 0 ]?.id;
+
+	if ( isLoading ) {
+		return (
+			<SidebarNavigationScreenWrapper>
+				{ __( 'Loading Navigation Menus.' ) }
+			</SidebarNavigationScreenWrapper>
+		);
+	}
+
+	if ( ! isLoading && ! hasNavigationMenus ) {
+		return (
+			<SidebarNavigationScreenWrapper>
+				{ __( 'There are no Navigation Menus.' ) }
+			</SidebarNavigationScreenWrapper>
+		);
+	}
+
+	if ( hasSingleNavigationMenu ) {
+		return (
+			<SidebarNavigationScreenWrapper>
+				<SideBarNavigationScreenNavigationMenu
+					menu={ firstNavigationMenu }
+				/>
+			</SidebarNavigationScreenWrapper>
+		);
+	}
+
+	return (
+		<SidebarNavigationScreenWrapper>
+			<ItemGroup>
+				{ navigationMenus?.map( ( navMenu ) => (
+					<NavMenuItem
+						postType={ postType }
+						postId={ navMenu.id }
+						key={ navMenu.id }
+						withChevron
+					>
+						{ decodeEntities(
+							navMenu.title?.rendered || navMenu.slug
+						) }
+					</NavMenuItem>
+				) ) }
+			</ItemGroup>
+		</SidebarNavigationScreenWrapper>
 	);
 }

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/index.js
@@ -16,18 +16,8 @@ import { navigation } from '@wordpress/icons';
  */
 import SidebarNavigationScreen from '../sidebar-navigation-screen';
 import SidebarNavigationItem from '../sidebar-navigation-item';
-
+import { PRELOADED_NAVIGATION_MENUS_QUERY } from './constants';
 import { useLink } from '../routes/link';
-
-// This requested is preloaded in `gutenberg_preload_navigation_posts`.
-// As unbounded queries are limited to 100 by `fetchAllMiddleware`
-// on apiFetch this query is limited to 100.
-const PRELOADED_NAVIGATION_MENUS_QUERY = {
-	per_page: 100,
-	status: 'publish',
-	order: 'desc',
-	orderby: 'date',
-};
 
 export default function SidebarNavigationScreenNavigationMenus() {
 	const { records: navigationMenus, isResolving: isLoading } =

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/index.js
@@ -14,7 +14,6 @@ import SidebarNavigationScreen from '../sidebar-navigation-screen';
 import SidebarNavigationItem from '../sidebar-navigation-item';
 
 import { useLink } from '../routes/link';
-import { SidebarNavigationMenu } from '../sidebar-navigation-screen-navigation-menu';
 
 const NAVIGATION_MENUS_QUERY = {
 	per_page: -1,
@@ -30,8 +29,6 @@ export default function SidebarNavigationScreenNavigationMenus() {
 		useEntityRecords( 'postType', `wp_navigation`, NAVIGATION_MENUS_QUERY );
 
 	const hasNavigationMenus = !! navigationMenus?.length;
-	const hasSingleNavigationMenu = navigationMenus?.length === 1;
-	const firstNavigationMenu = navigationMenus?.[ 0 ];
 
 	if ( isLoading ) {
 		return (
@@ -45,16 +42,6 @@ export default function SidebarNavigationScreenNavigationMenus() {
 		return (
 			<SidebarNavigationScreenWrapper>
 				{ __( 'There are no Navigation Menus.' ) }
-			</SidebarNavigationScreenWrapper>
-		);
-	}
-
-	if ( hasSingleNavigationMenu ) {
-		return (
-			<SidebarNavigationScreenWrapper
-				title={ firstNavigationMenu?.title?.rendered }
-			>
-				<SidebarNavigationMenu navigationMenu={ firstNavigationMenu } />
 			</SidebarNavigationScreenWrapper>
 		);
 	}
@@ -79,12 +66,17 @@ export default function SidebarNavigationScreenNavigationMenus() {
 	);
 }
 
-export function SidebarNavigationScreenWrapper( { children, actions, title } ) {
+export function SidebarNavigationScreenWrapper( {
+	children,
+	actions,
+	title,
+	description,
+} ) {
 	return (
 		<SidebarNavigationScreen
 			title={ title || __( 'Navigation' ) }
 			actions={ actions }
-			description={ __( 'Manage your Navigation menus.' ) }
+			description={ description || __( 'Manage your Navigation menus.' ) }
 			content={ children }
 		/>
 	);

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/index.js
@@ -2,12 +2,8 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useCallback, useMemo } from '@wordpress/element';
-import { useSelect } from '@wordpress/data';
 import { useEntityRecords } from '@wordpress/core-data';
-import { BlockEditorProvider } from '@wordpress/block-editor';
-import { createBlock } from '@wordpress/blocks';
-import { privateApis as routerPrivateApis } from '@wordpress/router';
+
 import { decodeEntities } from '@wordpress/html-entities';
 import { __experimentalItemGroup as ItemGroup } from '@wordpress/components';
 
@@ -16,108 +12,15 @@ import { __experimentalItemGroup as ItemGroup } from '@wordpress/components';
  */
 import SidebarNavigationScreen from '../sidebar-navigation-screen';
 import SidebarNavigationItem from '../sidebar-navigation-item';
-import NavigationMenuContent from './navigation-menu-content';
-import { unlock } from '../../private-apis';
-import { store as editSiteStore } from '../../store';
-import {
-	isPreviewingTheme,
-	currentlyPreviewingTheme,
-} from '../../utils/is-previewing-theme';
+
 import { useLink } from '../routes/link';
+import { SidebarNavigationMenu } from '../sidebar-navigation-screen-navigation-menu';
 
-const { useHistory } = unlock( routerPrivateApis );
-
-const noop = () => {};
 const NAVIGATION_MENUS_QUERY = {
 	per_page: -1,
 	status: 'publish',
 	order: 'desc',
 	orderby: 'date',
-};
-
-export function SidebarNavigationScreenWrapper( { children, actions } ) {
-	return (
-		<SidebarNavigationScreen
-			title={ __( 'Navigation' ) }
-			actions={ actions }
-			description={ __( 'Manage your Navigation menus.' ) }
-			content={ children }
-		/>
-	);
-}
-
-const NavMenuItem = ( { postType, postId, ...props } ) => {
-	const linkInfo = useLink( {
-		postType,
-		postId,
-	} );
-	return <SidebarNavigationItem { ...linkInfo } { ...props } />;
-};
-
-const SideBarNavigationScreenNavigationMenu = ( {
-	menu: firstNavigationMenu,
-} ) => {
-	const history = useHistory();
-
-	const onSelect = useCallback(
-		( selectedBlock ) => {
-			const { attributes, name } = selectedBlock;
-			if (
-				attributes.kind === 'post-type' &&
-				attributes.id &&
-				attributes.type &&
-				history
-			) {
-				history.push( {
-					postType: attributes.type,
-					postId: attributes.id,
-					...( isPreviewingTheme() && {
-						theme_preview: currentlyPreviewingTheme(),
-					} ),
-				} );
-			}
-			if ( name === 'core/page-list-item' && attributes.id && history ) {
-				history.push( {
-					postType: 'page',
-					postId: attributes.id,
-					...( isPreviewingTheme() && {
-						theme_preview: currentlyPreviewingTheme(),
-					} ),
-				} );
-			}
-		},
-		[ history ]
-	);
-
-	const { storedSettings } = useSelect( ( select ) => {
-		const { getSettings } = unlock( select( editSiteStore ) );
-
-		return {
-			storedSettings: getSettings( false ),
-		};
-	}, [] );
-
-	const blocks = useMemo( () => {
-		return [
-			createBlock( 'core/navigation', { ref: firstNavigationMenu } ),
-		];
-	}, [ firstNavigationMenu ] );
-
-	return (
-		<BlockEditorProvider
-			settings={ storedSettings }
-			value={ blocks }
-			onChange={ noop }
-			onInput={ noop }
-		>
-			<div className="edit-site-sidebar-navigation-screen-navigation-menus__content">
-				<NavigationMenuContent
-					rootClientId={ blocks[ 0 ].clientId }
-					onSelect={ onSelect }
-				/>
-			</div>
-		</BlockEditorProvider>
-	);
 };
 
 export default function SidebarNavigationScreenNavigationMenus() {
@@ -128,7 +31,7 @@ export default function SidebarNavigationScreenNavigationMenus() {
 
 	const hasNavigationMenus = !! navigationMenus?.length;
 	const hasSingleNavigationMenu = navigationMenus?.length === 1;
-	const firstNavigationMenu = navigationMenus?.[ 0 ]?.id;
+	const firstNavigationMenu = navigationMenus?.[ 0 ];
 
 	if ( isLoading ) {
 		return (
@@ -148,10 +51,10 @@ export default function SidebarNavigationScreenNavigationMenus() {
 
 	if ( hasSingleNavigationMenu ) {
 		return (
-			<SidebarNavigationScreenWrapper>
-				<SideBarNavigationScreenNavigationMenu
-					menu={ firstNavigationMenu }
-				/>
+			<SidebarNavigationScreenWrapper
+				title={ firstNavigationMenu?.title?.rendered }
+			>
+				<SidebarNavigationMenu navigationMenu={ firstNavigationMenu } />
 			</SidebarNavigationScreenWrapper>
 		);
 	}
@@ -175,3 +78,22 @@ export default function SidebarNavigationScreenNavigationMenus() {
 		</SidebarNavigationScreenWrapper>
 	);
 }
+
+export function SidebarNavigationScreenWrapper( { children, actions, title } ) {
+	return (
+		<SidebarNavigationScreen
+			title={ title || __( 'Navigation' ) }
+			actions={ actions }
+			description={ __( 'Manage your Navigation menus.' ) }
+			content={ children }
+		/>
+	);
+}
+
+const NavMenuItem = ( { postType, postId, ...props } ) => {
+	const linkInfo = useLink( {
+		postType,
+		postId,
+	} );
+	return <SidebarNavigationItem { ...linkInfo } { ...props } />;
+};

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/index.js
@@ -6,6 +6,7 @@ import { useEntityRecords } from '@wordpress/core-data';
 
 import { decodeEntities } from '@wordpress/html-entities';
 import { __experimentalItemGroup as ItemGroup } from '@wordpress/components';
+import { navigation } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -52,6 +53,7 @@ export default function SidebarNavigationScreenNavigationMenus() {
 						postId={ navMenu.id }
 						key={ navMenu.id }
 						withChevron
+						icon={ navigation }
 					>
 						{ decodeEntities(
 							navMenu.title?.rendered || navMenu.slug

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/index.js
@@ -5,7 +5,10 @@ import { __ } from '@wordpress/i18n';
 import { useEntityRecords } from '@wordpress/core-data';
 
 import { decodeEntities } from '@wordpress/html-entities';
-import { __experimentalItemGroup as ItemGroup } from '@wordpress/components';
+import {
+	__experimentalItemGroup as ItemGroup,
+	Spinner,
+} from '@wordpress/components';
 import { navigation } from '@wordpress/icons';
 
 /**
@@ -31,9 +34,9 @@ export default function SidebarNavigationScreenNavigationMenus() {
 
 	if ( isLoading ) {
 		return (
-			<SidebarNavigationScreenWrapper
-				description={ __( 'Loading Navigation Menus.' ) }
-			/>
+			<SidebarNavigationScreenWrapper>
+				<Spinner className="edit-site-sidebar-navigation-screen-navigation-menus__loading" />
+			</SidebarNavigationScreenWrapper>
 		);
 	}
 

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/index.js
@@ -23,8 +23,6 @@ const NAVIGATION_MENUS_QUERY = {
 };
 
 export default function SidebarNavigationScreenNavigationMenus() {
-	const postType = 'wp_navigation';
-
 	const { records: navigationMenus, isResolving: isLoading } =
 		useEntityRecords( 'postType', `wp_navigation`, NAVIGATION_MENUS_QUERY );
 
@@ -51,7 +49,6 @@ export default function SidebarNavigationScreenNavigationMenus() {
 			<ItemGroup>
 				{ navigationMenus?.map( ( navMenu ) => (
 					<NavMenuItem
-						postType={ postType }
 						postId={ navMenu.id }
 						key={ navMenu.id }
 						withChevron
@@ -82,10 +79,10 @@ export function SidebarNavigationScreenWrapper( {
 	);
 }
 
-const NavMenuItem = ( { postType, postId, ...props } ) => {
+const NavMenuItem = ( { postId, ...props } ) => {
 	const linkInfo = useLink( {
-		postType,
 		postId,
+		postType: 'wp_navigation',
 	} );
 	return <SidebarNavigationItem { ...linkInfo } { ...props } />;
 };

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/navigator-button.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/navigator-button.js
@@ -1,0 +1,45 @@
+/**
+ * WordPress dependencies
+ */
+
+import { __experimentalNavigatorButton as NavigatorButton } from '@wordpress/components';
+import { useEntityRecords } from '@wordpress/core-data';
+
+const NAVIGATION_MENUS_QUERY = {
+	per_page: -1,
+	status: 'publish',
+	order: 'desc',
+	orderby: 'date',
+};
+
+export default function SidebarNavigationScreenNavigationMenuButton( {
+	children,
+	...props
+} ) {
+	const { records: navigationMenus, isResolving: isLoading } =
+		useEntityRecords( 'postType', `wp_navigation`, NAVIGATION_MENUS_QUERY );
+
+	const hasNavigationMenus = !! navigationMenus?.length;
+	const hasSingleNavigationMenu = navigationMenus?.length === 1;
+	const firstNavigationMenu = navigationMenus?.[ 0 ];
+
+	const showNavigationScreen = process.env.IS_GUTENBERG_PLUGIN
+		? hasNavigationMenus
+		: false;
+
+	// If there is a single menu then we can go directly to that menu.
+	// Otherwise we go to the navigation listing screen.
+	const path = hasSingleNavigationMenu
+		? `/navigation/${ firstNavigationMenu?.id }`
+		: '/navigation';
+
+	if ( ! showNavigationScreen ) {
+		return null;
+	}
+
+	return (
+		<NavigatorButton { ...props } disabled={ isLoading } path={ path }>
+			{ children }
+		</NavigatorButton>
+	);
+}

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/navigator-button.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/navigator-button.js
@@ -30,7 +30,7 @@ export default function SidebarNavigationScreenNavigationMenuButton( {
 	// If there is a single menu then we can go directly to that menu.
 	// Otherwise we go to the navigation listing screen.
 	const path = hasSingleNavigationMenu
-		? `/navigation/${ firstNavigationMenu?.id }`
+		? `/navigation/wp_navigation/${ firstNavigationMenu?.id }`
 		: '/navigation';
 
 	if ( ! showNavigationScreen ) {

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/navigator-button.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/navigator-button.js
@@ -5,19 +5,21 @@
 import { __experimentalNavigatorButton as NavigatorButton } from '@wordpress/components';
 import { useEntityRecords } from '@wordpress/core-data';
 
-const NAVIGATION_MENUS_QUERY = {
-	per_page: -1,
-	status: 'publish',
-	order: 'desc',
-	orderby: 'date',
-};
+/**
+ * Internal dependencies
+ */
+import { PRELOADED_NAVIGATION_MENUS_QUERY } from './constants';
 
 export default function SidebarNavigationScreenNavigationMenuButton( {
 	children,
 	...props
 } ) {
 	const { records: navigationMenus, isResolving: isLoading } =
-		useEntityRecords( 'postType', `wp_navigation`, NAVIGATION_MENUS_QUERY );
+		useEntityRecords(
+			'postType',
+			`wp_navigation`,
+			PRELOADED_NAVIGATION_MENUS_QUERY
+		);
 
 	const hasNavigationMenus = !! navigationMenus?.length;
 	const hasSingleNavigationMenu = navigationMenus?.length === 1;

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/style.scss
@@ -93,3 +93,9 @@
 .edit-site-sidebar-navigation-screen-navigation-menus__content .popover-slot .wp-block-navigation-submenu {
 	display: none;
 }
+
+.edit-site-sidebar-navigation-screen-navigation-menus__loading.components-spinner {
+	margin-left: auto;
+	margin-right: auto;
+	display: block;
+}

--- a/packages/edit-site/src/components/sidebar/index.js
+++ b/packages/edit-site/src/components/sidebar/index.js
@@ -39,11 +39,11 @@ function SidebarScreens() {
 			<NavigatorScreen path="/navigation">
 				<SidebarNavigationScreenNavigationMenus />
 			</NavigatorScreen>
+			<NavigatorScreen path="/navigation/:postType/:postId">
+				<SidebarNavigationScreenNavigationMenu />
+			</NavigatorScreen>
 			<NavigatorScreen path="/wp_global_styles">
 				<SidebarNavigationScreenGlobalStyles />
-			</NavigatorScreen>
-			<NavigatorScreen path="/navigation/:postId">
-				<SidebarNavigationScreenNavigationMenu />
 			</NavigatorScreen>
 			<NavigatorScreen path="/page">
 				<SidebarNavigationScreenPages />

--- a/packages/edit-site/src/components/sidebar/index.js
+++ b/packages/edit-site/src/components/sidebar/index.js
@@ -42,7 +42,7 @@ function SidebarScreens() {
 			<NavigatorScreen path="/wp_global_styles">
 				<SidebarNavigationScreenGlobalStyles />
 			</NavigatorScreen>
-			<NavigatorScreen path="/navigation/:postType/:postId">
+			<NavigatorScreen path="/navigation/:postId">
 				<SidebarNavigationScreenNavigationMenu />
 			</NavigatorScreen>
 			<NavigatorScreen path="/page">

--- a/packages/edit-site/src/components/sidebar/index.js
+++ b/packages/edit-site/src/components/sidebar/index.js
@@ -18,10 +18,10 @@ import useSyncPathWithURL, {
 	getPathFromURL,
 } from '../sync-state-with-url/use-sync-path-with-url';
 import SidebarNavigationScreenNavigationMenus from '../sidebar-navigation-screen-navigation-menus';
+import SidebarNavigationScreenNavigationMenu from '../sidebar-navigation-screen-navigation-menu';
 import SidebarNavigationScreenGlobalStyles from '../sidebar-navigation-screen-global-styles';
 import SidebarNavigationScreenTemplatesBrowse from '../sidebar-navigation-screen-templates-browse';
 import SaveHub from '../save-hub';
-import SidebarNavigationScreenNavigationItem from '../sidebar-navigation-screen-navigation-item';
 import { unlock } from '../../private-apis';
 import SidebarNavigationScreenPages from '../sidebar-navigation-screen-pages';
 import SidebarNavigationScreenPage from '../sidebar-navigation-screen-page';
@@ -43,7 +43,7 @@ function SidebarScreens() {
 				<SidebarNavigationScreenGlobalStyles />
 			</NavigatorScreen>
 			<NavigatorScreen path="/navigation/:postType/:postId">
-				<SidebarNavigationScreenNavigationItem />
+				<SidebarNavigationScreenNavigationMenu />
 			</NavigatorScreen>
 			<NavigatorScreen path="/page">
 				<SidebarNavigationScreenPages />


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Adds a list of all Navigation menus to the Browse Mode section of the Site Editor.

Obeys rule:

- Only one menu - clicking through immediately shows that menu in list view mode.
- Multiple menus - clicking through shows a list of menus. You can click on any menu to enter list view mode.

All menus are accessible directly via URL as is the listing screen.

Closes https://github.com/WordPress/gutenberg/issues/50578

Also addresses part of https://github.com/WordPress/gutenberg/issues/50579.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Address the part of the UX and Design shown in https://github.com/WordPress/gutenberg/issues/50578. This part of the wider effort to add Navigation to the Browse mode.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Creates dedicated components for listing all menus and showing a single menu.

Updates the main Browse Mode sidebar to use a special component for the `Navigation` button which will route according to the number of Navigation menus it finds (obeying the rules set out above).


## Known Issues

- Clicking through to individual menu seems to trigger a new API request which is unexpected as it should be in state already. We will fix this in a followup.
- An individual menu takes a long time to load into the list view. This is because of the additional Nav block under the hood. We can replace this in a follow up as I don't believe it's required.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

Throughout the testing below keep clicking back button and checking it routes you as expected.

- Add 2 (or more) menus using a Nav block.
- Open Site Editor.
- See `Navigation` in Browse Mode and click it.
- See you are routed to a listing of all menus. Check and copy the URL for reference.
- Click on individual menu. Check you are navigated to a list view of that menu. Copy the URL for reference.
- Click back. 
- Delete menus at http://localhost:8888/wp-admin/edit.php?post_type=wp_navigation&paged=1 such that you have a _single_ menu remaining.
- Load Site Editor.
- Click on `Navigation` in Browse Mode.
- See that you are routed _directly_ to the list view for that menu without any intermediate "listing" view.
- Delete all menus at http://localhost:8888/wp-admin/edit.php?post_type=wp_navigation&paged=1. 
   - Check that loading the site editor gives you no `Navigation` option.
   - Check that going directly to menus listing by URL show appropriate message.
   - Check that going direct to single menu by URL shows appropriate message.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->


https://github.com/WordPress/gutenberg/assets/444434/ae029ccc-6363-411c-b2ef-0ab4aa79b2a0





