### PR TITLE
[Site Editor]: Sort template parts by type in navigation screen

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen-templates/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-templates/index.js
@@ -46,6 +46,22 @@ const config = {
 				'Manage what patterns are available when editing your site.'
 			),
 		},
+		sortCallback: ( items ) => {
+			const groupedByArea = items.reduce(
+				( accumulator, item ) => {
+					const key = accumulator[ item.area ] ? item.area : 'rest';
+					accumulator[ key ].push( item );
+					return accumulator;
+				},
+				{ header: [], footer: [], sidebar: [], rest: [] }
+			);
+			return [
+				...groupedByArea.header,
+				...groupedByArea.footer,
+				...groupedByArea.sidebar,
+				...groupedByArea.rest,
+			];
+		},
 	},
 };
 
@@ -75,10 +91,13 @@ export default function SidebarNavigationScreenTemplates() {
 			per_page: -1,
 		}
 	);
-	const sortedTemplates = templates ? [ ...templates ] : [];
+	let sortedTemplates = templates ? [ ...templates ] : [];
 	sortedTemplates.sort( ( a, b ) =>
 		a.title.rendered.localeCompare( b.title.rendered )
 	);
+	if ( config[ postType ].sortCallback ) {
+		sortedTemplates = config[ postType ].sortCallback( sortedTemplates );
+	}
 
 	const browseAllLink = useLink( {
 		path: '/' + postType + '/all',


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Follow up of: https://github.com/WordPress/gutenberg/pull/50791 and specifically this [comment](https://github.com/WordPress/gutenberg/pull/50791#issuecomment-1554608052).
>Looking at the screenshot above, I wonder if it would aid scan-ability if the list was ordered by area. Headers at the top, then Footers, then General.

This PR sorts the templates parts by type:
1. Headers
2. Footers
3. Sidebar
4. All the others

## Screenshots or screencast <!-- if applicable -->
<img width="335" alt="Screenshot 2023-05-22 at 2 29 45 PM" src="https://github.com/WordPress/gutenberg/assets/16275880/790b6f3f-007c-4c5b-ad9a-b8dffd60c499">

