### PR TITLE
Migrate Adding Inline Token test to Playwright

### DIFF
--- a/test/e2e/specs/editor/various/adding-inline-tokens.spec.js
+++ b/test/e2e/specs/editor/various/adding-inline-tokens.spec.js
@@ -23,6 +23,7 @@ test.describe( 'adding inline tokens', () => {
 	} ) => {
 		// Create a paragraph.
 		await page.click( 'role=button[name="Add default block"i]' );
+
 		await page.keyboard.type( 'a ' );
 
 		await editor.showBlockToolbar();
@@ -48,10 +49,15 @@ test.describe( 'adding inline tokens', () => {
 		await page.click( 'role=button[name="Select"i]' );
 
 		// Check the content.
-		const regex = new RegExp(
-			`<!-- wp:paragraph -->\\s*<p>a <img class="wp-image-\\d+" style="width:\\s*10px;?" src="[^"]+\\/${ filename }\\.png" alt=""\\/?><\\/p>\\s*<!-- \\/wp:paragraph -->`
+		const contentRegex = new RegExp(
+			`a <img class="wp-image-\\d+" style="width:\\s*10px;?" src="[^"]+\\/${ filename }\\.png" alt=""\\/?>`
 		);
-		expect( await editor.getEditedPostContent() ).toMatch( regex );
+		await expect.poll( editor.getBlocks ).toMatchObject( [
+			{
+				name: 'core/paragraph',
+				attributes: { content: expect.stringMatching( contentRegex ) },
+			},
+		] );
 
 		await pageUtils.pressKeys( 'shift+ArrowLeft' );
 
@@ -61,9 +67,14 @@ test.describe( 'adding inline tokens', () => {
 		await page.keyboard.press( 'Enter' );
 
 		// Check the content.
-		const regex2 = new RegExp(
-			`<!-- wp:paragraph -->\\s*<p>a <img class="wp-image-\\d+" style="width:\\s*20px;?" src="[^"]+\\/${ filename }\\.png" alt=""\\/?><\\/p>\\s*<!-- \\/wp:paragraph -->`
+		const contentRegex2 = new RegExp(
+			`a <img class="wp-image-\\d+" style="width:\\s*20px;?" src="[^"]+\\/${ filename }\\.png" alt=""\\/?>`
 		);
-		expect( await editor.getEditedPostContent() ).toMatch( regex2 );
+		await expect.poll( editor.getBlocks ).toMatchObject( [
+			{
+				name: 'core/paragraph',
+				attributes: { content: expect.stringMatching( contentRegex2 ) },
+			},
+		] );
 	} );
 } );

--- a/test/e2e/specs/editor/various/adding-inline-tokens.spec.js
+++ b/test/e2e/specs/editor/various/adding-inline-tokens.spec.js
@@ -40,7 +40,9 @@ test.describe( 'adding inline tokens', () => {
 		const filename = uuid();
 		const tmpFileName = path.join( os.tmpdir(), filename + '.png' );
 		fs.copyFileSync( testImagePath, tmpFileName );
-		await page.locator('.media-modal .moxie-shim input[type=file]').setInputFiles( tmpFileName );
+		await page
+			.locator( '.media-modal .moxie-shim input[type=file]' )
+			.setInputFiles( tmpFileName );
 
 		// Insert the uploaded image.
 		await page.click( 'role=button[name="Select"i]' );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
## What?
<!-- In a few words, what is the PR actually doing? -->
Part of https://github.com/WordPress/gutenberg/issues/38851.
Migrate[ adding-inline-tokens.test.js ](https://github.com/WordPress/gutenberg/blob/trunk/packages/e2e-tests/specs/editor/various/adding-inline-tokens.test.js) to its Playwright version.
## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Part of https://github.com/WordPress/gutenberg/issues/38851.
## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
See[ MIGRATION.md](https://github.com/WordPress/gutenberg/blob/trunk/test/e2e/MIGRATION.md) for migration steps.
## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
Run` npm run test:e2e:playwright test/e2e/specs/editor/various/adding-inline-tokens.spec.js`