### PR TITLE
Nav Browse mode remove "ghost" Nav block

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/index.js
@@ -2,12 +2,16 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useCallback, useMemo } from '@wordpress/element';
+import { useCallback } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
-import { store as coreStore } from '@wordpress/core-data';
-import { BlockEditorProvider } from '@wordpress/block-editor';
-import { createBlock } from '@wordpress/blocks';
+import {
+	store as coreStore,
+	EntityProvider,
+	useEntityBlockEditor,
+} from '@wordpress/core-data';
+
 import { privateApis as routerPrivateApis } from '@wordpress/router';
+import { BlockEditorProvider } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
@@ -23,7 +27,6 @@ import {
 
 const { useHistory } = unlock( routerPrivateApis );
 
-const noop = () => {};
 const NAVIGATION_MENUS_QUERY = {
 	per_page: 1,
 	status: 'publish',
@@ -68,11 +71,14 @@ export default function SidebarNavigationScreenNavigationMenus() {
 		}, [] );
 
 	const firstNavigationMenu = navigationMenus?.[ 0 ]?.id;
-	const blocks = useMemo( () => {
-		return [
-			createBlock( 'core/navigation', { ref: firstNavigationMenu } ),
-		];
-	}, [ firstNavigationMenu ] );
+
+	const [ blocks, onInput, onChange ] = useEntityBlockEditor(
+		'postType',
+		'wp_navigation',
+		{
+			id: firstNavigationMenu,
+		}
+	);
 
 	const hasNavigationMenus = !! navigationMenus?.length;
 
@@ -115,20 +121,26 @@ export default function SidebarNavigationScreenNavigationMenus() {
 	}
 
 	return (
-		<BlockEditorProvider
-			settings={ storedSettings }
-			value={ blocks }
-			onChange={ noop }
-			onInput={ noop }
+		<EntityProvider
+			kind="postType"
+			type="wp_navigation"
+			id={ firstNavigationMenu }
 		>
-			<SidebarNavigationScreenWrapper>
-				<div className="edit-site-sidebar-navigation-screen-navigation-menus__content">
-					<NavigationMenuContent
-						rootClientId={ blocks[ 0 ].clientId }
-						onSelect={ onSelect }
-					/>
-				</div>
-			</SidebarNavigationScreenWrapper>
-		</BlockEditorProvider>
+			<BlockEditorProvider
+				settings={ storedSettings }
+				value={ blocks }
+				onChange={ onChange }
+				onInput={ onInput }
+			>
+				<SidebarNavigationScreenWrapper>
+					<div className="edit-site-sidebar-navigation-screen-navigation-menus__content">
+						<NavigationMenuContent
+							rootClientId={ blocks[ 0 ]?.clientId }
+							onSelect={ onSelect }
+						/>
+					</div>
+				</SidebarNavigationScreenWrapper>
+			</BlockEditorProvider>
+		</EntityProvider>
 	);
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

WIP to try and replace need for hidden/ghost Nav block within the Navigation seciton of Browse Mode.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
