### PR TITLE
Fix flaky template revert e2e tests

### DIFF
--- a/test/e2e/specs/site-editor/template-revert.spec.js
+++ b/test/e2e/specs/site-editor/template-revert.spec.js
@@ -4,8 +4,8 @@
 const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 
 test.use( {
-	templateRevertUtils: async ( { page }, use ) => {
-		await use( new TemplateRevertUtils( { page } ) );
+	templateRevertUtils: async ( { editor, page }, use ) => {
+		await use( new TemplateRevertUtils( { editor, page } ) );
 	},
 } );
 
@@ -39,7 +39,6 @@ test.describe( 'Template Revert', () => {
 		await templateRevertUtils.revertTemplate();
 		await editor.saveSiteEditorEntities();
 
-		await page.click( 'role=button[name="Settings"i]' );
 		const isTemplateTabVisible = await page
 			.locator(
 				'role=region[name="Editor settings"i] >> role=button[name="Template"i]'
@@ -286,12 +285,13 @@ test.describe( 'Template Revert', () => {
 } );
 
 class TemplateRevertUtils {
-	constructor( { page } ) {
+	constructor( { editor, page } ) {
+		this.editor = editor;
 		this.page = page;
 	}
 
 	async revertTemplate() {
-		await this.page.click( 'role=button[name="Settings"i]' );
+		await this.editor.openDocumentSettingsSidebar();
 		const isTemplateTabVisible = await this.page
 			.locator(
 				'role=region[name="Editor settings"i] >> role=button[name="Template"i]'
@@ -309,7 +309,6 @@ class TemplateRevertUtils {
 		await this.page.waitForSelector(
 			'role=button[name="Dismiss this notice"i] >> text="Template reverted."'
 		);
-		await this.page.click( 'role=button[name="Settings"i]' );
 	}
 
 	async getCurrentSiteEditorContent() {


### PR DESCRIPTION
## What?
Resolves #50783.
Resolves #47897.

PR fixes "Template revert" e2e test regressions after #50369.

## Why?
The user preferences are persisted in DB and shared across the tests. If previous tests opened the document settings sidebar, the template revert tests accidentally closed it, causing a locator failure that depended on the sidebar's open state.

## How?
Updates the `revertTemplate` helper to use the `editor.openDocumentSettingsSidebar()` utility method instead of a direct locator. The former has extra checks to avoid accidentally closing the document settings sidebar.

## Testing Instructions
To quickly reproduce the issue on the `trunk`:

1. Place `editor.openDocumentSettingsSidebar()` at the end of the `test.beforeEach` block.
2. Run the tests - `npm run test:e2e:playwright -- /test/e2e/specs/site-editor/template-revert.spec.js`.
3. Confirm failure.