### PR TITLE
Playwright Utils: Use 'set' to disable the Styles welcome guide

### DIFF
--- a/packages/e2e-test-utils-playwright/src/admin/visit-site-editor.ts
+++ b/packages/e2e-test-utils-playwright/src/admin/visit-site-editor.ts
@@ -43,7 +43,7 @@ export async function visitSiteEditor(
 
 			window.wp.data
 				.dispatch( 'core/preferences' )
-				.toggle( 'core/edit-site', 'welcomeGuideStyles', false );
+				.set( 'core/edit-site', 'welcomeGuideStyles', false );
 		} );
 	}
 


### PR DESCRIPTION
## What?
Resolves #49942

PR updates the `visitSiteEditor` utility method to use the `set` action to disable the Styles welcome guide.

## Why?
The `toggle` action doesn't accept `value` as an argument and can sometimes enable the welcome guide modal.

## Testing Instructions
1. Add a new test to the "Push to Global Styles button". See the code below.
2. Running the test on the trunk will fail, but will pass on this branch.

```
npm run test:e2e:playwright -- test/e2e/specs/site-editor/push-to-global-styles.spec.js
```


```js
test( 'should apply condition', async ( { page } ) => {
        // Turn off the welcome guide.
        await page.evaluate( () => {
            window.wp.data
                .dispatch( 'core/preferences' )
                .set( 'core/edit-site', 'welcomeGuideStyles', false );
        } );
} );
```