### PR TITLE
FontSizePicker: Fix control header spacing

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -22,6 +22,7 @@
 ### Enhancements
 
 -   `Tooltip`: Update background color so tooltip boundaries are more visible in the site editor ([#50792](https://github.com/WordPress/gutenberg/pull/50792)).
+-   `FontSizePicker`: Tweak the header spacing to be more consistent with other design tools ([#50855](https://github.com/WordPress/gutenberg/pull/50855)).
 
 ## 24.0.0 (2023-05-10)
 

--- a/packages/components/src/font-size-picker/index.tsx
+++ b/packages/components/src/font-size-picker/index.tsx
@@ -14,7 +14,6 @@ import { useState, useMemo, forwardRef } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import Button from '../button';
 import RangeControl from '../range-control';
 import { Flex, FlexItem } from '../flex';
 import {
@@ -24,12 +23,13 @@ import {
 } from '../unit-control';
 import { VisuallyHidden } from '../visually-hidden';
 import { getCommonSizeUnit } from './utils';
-import { HStack } from '../h-stack';
 import type { FontSizePickerProps } from './types';
 import {
 	Container,
+	Header,
 	HeaderHint,
 	HeaderLabel,
+	HeaderToggle,
 	Controls,
 	ResetButton,
 } from './styles';
@@ -127,7 +127,7 @@ const UnforwardedFontSizePicker = (
 		<Container ref={ ref } className="components-font-size-picker">
 			<VisuallyHidden as="legend">{ __( 'Font size' ) }</VisuallyHidden>
 			<Spacer>
-				<HStack className="components-font-size-picker__header">
+				<Header className="components-font-size-picker__header">
 					<HeaderLabel
 						aria-label={ `${ __( 'Size' ) } ${ headerHint || '' }` }
 					>
@@ -139,7 +139,7 @@ const UnforwardedFontSizePicker = (
 						) }
 					</HeaderLabel>
 					{ ! disableCustomFontSizes && (
-						<Button
+						<HeaderToggle
 							label={
 								showCustomValueControl
 									? __( 'Use size preset' )
@@ -155,7 +155,7 @@ const UnforwardedFontSizePicker = (
 							isSmall
 						/>
 					) }
-				</HStack>
+				</Header>
 			</Spacer>
 			<Controls
 				className="components-font-size-picker__controls"

--- a/packages/components/src/font-size-picker/styles.ts
+++ b/packages/components/src/font-size-picker/styles.ts
@@ -8,6 +8,7 @@ import styled from '@emotion/styled';
  */
 import BaseControl from '../base-control';
 import Button from '../button';
+import { HStack } from '../h-stack';
 import { space } from '../ui/utils/space';
 import { COLORS } from '../utils';
 import type { FontSizePickerProps } from './types';
@@ -16,6 +17,14 @@ export const Container = styled.fieldset`
 	border: 0;
 	margin: 0;
 	padding: 0;
+`;
+
+export const Header = styled( HStack )`
+	height: ${ space( 4 ) };
+`;
+
+export const HeaderToggle = styled( Button )`
+	margin-top: ${ space( -1 ) };
 `;
 
 export const HeaderLabel = styled( BaseControl.VisualLabel )`


### PR DESCRIPTION
## What?

Updates the FontSizePicker control's header (label + toggle) so that it is consistent with our design tools spacing.
- 16px height
- Toggle button is 24px and "breaks out" of the 16px container height via negative margin


## Why?

Makes the font size picker spacing consistent with other design tools.

See https://github.com/WordPress/gutenberg/pull/50660#issuecomment-1556809865 for more context.

## How?

Replaces the direct use of the `HStack` and `Button` in the font size picker's header with new styled components based off them. The styled components then have the necessary styles to bring the component in line with other design tools.

## Testing Instructions

1. Edit a post, and select a paragraph block
2. Switch to the styles tab and inspect the label of the font size control
3. Check that the label's parent has a height of `16px`
4. Confirm the control's toggle button is still `24px` tall but is not offset via a `-4px` top margin.


## Screenshots or screencast <!-- if applicable -->

| Before | After |
|---|---|
| <img width="304" alt="Screenshot 2023-05-23 at 3 06 39 pm" src="https://github.com/WordPress/gutenberg/assets/60436221/3855fd0a-24f8-4b28-8991-538066635543"> | <img width="300" alt="Screenshot 2023-05-23 at 2 57 06 pm" src="https://github.com/WordPress/gutenberg/assets/60436221/a794f3f5-e71a-42f3-9c61-ab3a1e56152d"> |




