### PR TITLE
Data: Improve `hasResolvingSelectors` redux metadata selector

### DIFF
--- a/packages/data/src/redux-store/metadata/selectors.js
+++ b/packages/data/src/redux-store/metadata/selectors.js
@@ -144,11 +144,11 @@ export function hasResolvingSelectors( state ) {
 		/**
 		 * This uses the internal `_map` property of `EquivalentKeyMap` for
 		 * optimization purposes, since the `EquivalentKeyMap` implementation
-		 * does not support a `.some()` implementation.
+		 * does not support a `.values()` implementation.
 		 *
 		 * @see https://github.com/aduth/equivalent-key-map
 		 */
-		Array.from( selectorState._map ).some(
+		Array.from( selectorState._map.values() ).some(
 			( resolution ) => resolution[ 1 ]?.status === 'resolving'
 		)
 	);

--- a/packages/data/src/redux-store/metadata/selectors.js
+++ b/packages/data/src/redux-store/metadata/selectors.js
@@ -148,7 +148,7 @@ export function hasResolvingSelectors( state ) {
 		 *
 		 * @see https://github.com/aduth/equivalent-key-map
 		 */
-		[ ...selectorState._map.values() ].some(
+		Array.from( selectorState._map ).some(
 			( resolution ) => resolution[ 1 ]?.status === 'resolving'
 		)
 	);

--- a/packages/data/src/redux-store/metadata/selectors.js
+++ b/packages/data/src/redux-store/metadata/selectors.js
@@ -141,6 +141,13 @@ export function getCachedResolvers( state ) {
  */
 export function hasResolvingSelectors( state ) {
 	return Object.values( state ).some( ( selectorState ) =>
+		/**
+		 * This uses the internal `_map` property of `EquivalentKeyMap` for
+		 * optimization purposes, since the `EquivalentKeyMap` implementation
+		 * does not support a `.some()` implementation.
+		 *
+		 * @see https://github.com/aduth/equivalent-key-map
+		 */
 		[ ...selectorState._map.values() ].some(
 			( resolution ) => resolution[ 1 ]?.status === 'resolving'
 		)

--- a/packages/data/src/redux-store/metadata/selectors.js
+++ b/packages/data/src/redux-store/metadata/selectors.js
@@ -140,7 +140,7 @@ export function getCachedResolvers( state ) {
  * @return {boolean} True if one or more selectors are resolving, false otherwise.
  */
 export function hasResolvingSelectors( state ) {
-	return [ ...Object.values( state ) ].some( ( selectorState ) =>
+	return Object.values( state ).some( ( selectorState ) =>
 		[ ...selectorState._map.values() ].some(
 			( resolution ) => resolution[ 1 ]?.status === 'resolving'
 		)


### PR DESCRIPTION
## What?
This PR adds a couple of improvements to the `hasResolvingSelectors` selector to address the feedback provided in https://github.com/WordPress/gutenberg/pull/50222#discussion_r1200516933.

## Why?
To address some feedback and use the opportunity to improve and better document the selector.

## How?
We're essentially doing a couple of improvements:
* Removing an unnecessary array cloning, since `Object.values()` already returns an array and cloning is unnecessary since there's no way to mutate it.
* Documenting the internal `EquivalentKeyMap` property usage.

## Testing Instructions
* Verify site editor still loads correctly.
* Verify all checks are green.

### Testing Instructions for Keyboard
None

## Screenshots or screencast <!-- if applicable -->
None