### PR TITLE
Add fall-through conditional for editor syncing of Navigation post types

### DIFF
--- a/packages/edit-site/src/components/sync-state-with-url/use-init-edited-entity-from-url.js
+++ b/packages/edit-site/src/components/sync-state-with-url/use-init-edited-entity-from-url.js
@@ -43,6 +43,8 @@ export default function useInitEditedEntityFromURL() {
 				case 'wp_template_part':
 					setTemplatePart( postId );
 					break;
+				case 'wp_navigation':
+					break;
 				default:
 					setPage( {
 						context: { postType, postId },


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Avoids unwanted network request to `find_template` triggered by syncing editor with state.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

We want to avoid unnecessary network calls.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Add a conditional to the code that inits an entity in the editor from the URL. As we're not _yet_ ready to handle Navigation entities but we're showing them in browse mode we need to catch this condition and allow it to do nothing.

In the future we will utilise this to implement focus mode for Navigation.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

- Have at least one menu.
- Open Site Editor
- Open Browse Mode
- Click Navigation
- Browse to a single Navigation
- See no network request to `/navigation/?_wp-find-template=true&_locale=user`

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
