### PR TITLE
Performance tests: Create wpCLI() utility

### DIFF
--- a/bin/plugin/commands/performance.js
+++ b/bin/plugin/commands/performance.js
@@ -337,8 +337,6 @@ async function runPerformanceTests( branches, options ) {
 							performanceTestDirectory,
 							'test/emptytheme'
 						),
-						'https://downloads.wordpress.org/theme/twentytwentyone.1.7.zip',
-						'https://downloads.wordpress.org/theme/twentytwentythree.1.0.zip',
 					],
 					env: {
 						tests: {
@@ -420,6 +418,9 @@ async function runPerformanceTests( branches, options ) {
 		performanceTestDirectory,
 		'node_modules/.bin/wp-env'
 	);
+
+	// Expose the path so we can e.g. use the WP CLI in the tests.
+	process.env.WP_ENV_PATH = wpEnvPath;
 
 	for ( const testSuite of testSuites ) {
 		results[ testSuite ] = {};

--- a/packages/e2e-tests/specs/performance/front-end-block-theme.test.js
+++ b/packages/e2e-tests/specs/performance/front-end-block-theme.test.js
@@ -1,12 +1,12 @@
 /**
  * WordPress dependencies
  */
-import { activateTheme, createURL, logout } from '@wordpress/e2e-test-utils';
+import { createURL, logout } from '@wordpress/e2e-test-utils';
 
 /**
  * Internal dependencies
  */
-import { saveResultsFile } from './utils';
+import { wpCLI, saveResultsFile } from './utils';
 
 describe( 'Front End Performance', () => {
 	const results = {
@@ -16,13 +16,16 @@ describe( 'Front End Performance', () => {
 	};
 
 	beforeAll( async () => {
-		await activateTheme( 'twentytwentythree' );
+		wpCLI(
+			// See https://github.com/WordPress/gutenberg/pull/47037/files#r1087561588
+			'theme install twentytwentythree --version=1.0 --force --activate'
+		);
 		await logout();
 	} );
 
 	afterAll( async () => {
 		saveResultsFile( __filename, results );
-		await activateTheme( 'twentytwentyone' );
+		wpCLI( 'theme update twentytwentythree' );
 	} );
 
 	it( 'Report TTFB, LCP, and LCP-TTFB', async () => {

--- a/packages/e2e-tests/specs/performance/front-end-classic-theme.test.js
+++ b/packages/e2e-tests/specs/performance/front-end-classic-theme.test.js
@@ -1,12 +1,12 @@
 /**
  * WordPress dependencies
  */
-import { activateTheme, createURL, logout } from '@wordpress/e2e-test-utils';
+import { createURL, logout } from '@wordpress/e2e-test-utils';
 
 /**
  * Internal dependencies
  */
-import { saveResultsFile } from './utils';
+import { wpCLI, saveResultsFile } from './utils';
 
 describe( 'Front End Performance', () => {
 	const results = {
@@ -16,12 +16,16 @@ describe( 'Front End Performance', () => {
 	};
 
 	beforeAll( async () => {
-		await activateTheme( 'twentytwentyone' );
+		wpCLI(
+			// See https://github.com/WordPress/gutenberg/pull/47037/files#r1087561588
+			'theme install twentytwentyone --version=1.7 --force --activate'
+		);
 		await logout();
 	} );
 
 	afterAll( async () => {
 		saveResultsFile( __filename, results );
+		wpCLI( 'theme update twentytwentyone' );
 	} );
 
 	it( 'Report TTFB, LCP, and LCP-TTFB', async () => {

--- a/packages/e2e-tests/specs/performance/utils.js
+++ b/packages/e2e-tests/specs/performance/utils.js
@@ -2,7 +2,20 @@
  * External dependencies
  */
 import path from 'path';
+import { execSync } from 'child_process';
 import { existsSync, readFileSync, unlinkSync, writeFileSync } from 'fs';
+
+export function wpCLI( command ) {
+	const wpEnvPath = process.env.WP_ENV_PATH || './node_modules/.bin/wp-env';
+
+	if ( ! existsSync( wpEnvPath ) ) {
+		throw new Error( "Couldn't find wp-env instance." );
+	}
+
+	execSync( `${ wpEnvPath } run cli 'wp ${ command }'`, {
+		stdio: 'inherit',
+	} );
+}
 
 export function readFile( filePath ) {
 	return existsSync( filePath )


### PR DESCRIPTION
## What?

- Create wpCLI() utility to run the dockerized wp-cli commands from within the tests,
- Use that utility to selectively install and activate themes required by the specific suites instead of doing that via the env setup. This addresses the discrepancy between running the performance tests via the `performance.js` runner and directly via `npm run test:performance <suite-name>`.

## Why?

For more consistent testing via a controlled environment.

## Testing Instructions

The following should install the necessary themes in the before hook and revert by updating them in the after hook:

1. `npm run test:performance specs/performance/front-end-classic-theme.test.js`
2. `npm run test:performance specs/performance/front-end-block-theme.test.js`

Example run:

<img width="894" alt="Screenshot 2023-05-23 at 11 52 58" src="https://github.com/WordPress/gutenberg/assets/1451471/2bc3c944-91d0-4919-8c21-32ffbfa5beba">
