### PR TITLE
Navigation: Handle empty menus in Navigation Browse Mode.

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/index.js
@@ -63,6 +63,15 @@ export default function SidebarNavigationScreenNavigationMenu() {
 		);
 	}
 
+	if ( ! navigationMenu?.content?.raw ) {
+		return (
+			<SidebarNavigationScreenWrapper
+				title={ decodeEntities( menuTitle ) }
+				description={ __( 'This Navigation Menu is empty.' ) }
+			/>
+		);
+	}
+
 	return (
 		<SidebarNavigationScreenWrapper
 			title={ decodeEntities( menuTitle ) }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Shows an appropriate message if a menu has no items. Note we cannot add items here because we agreed that this mode would have no edit functionality.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Just showing blank panel to users is bad.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Check if the entity has any `content`. If not then there are no blocks and thus the menu is empty. Show an appropriate message.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Site Editor
2. Use Nav block to create empty Menu with no items. Save.
3. Open Nav Browse mode and go to the empty menu.
4. See message that the menu is empty.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
<img width="761" alt="Screen Shot 2023-05-23 at 11 34 53" src="https://github.com/WordPress/gutenberg/assets/444434/95c7cddb-3b32-4f88-b722-1d5e0fc506be">
