### PR TITLE
Remove redundant calls to disable the Styles welcome guide

### DIFF
--- a/test/e2e/specs/site-editor/style-book.spec.js
+++ b/test/e2e/specs/site-editor/style-book.spec.js
@@ -162,17 +162,7 @@ class StyleBook {
 		this.page = page;
 	}
 
-	async disableWelcomeGuide() {
-		// Turn off the welcome guide.
-		await this.page.evaluate( () => {
-			window.wp.data
-				.dispatch( 'core/preferences' )
-				.set( 'core/edit-site', 'welcomeGuideStyles', false );
-		} );
-	}
-
 	async open() {
-		await this.disableWelcomeGuide();
 		await this.page
 			.getByRole( 'region', { name: 'Editor top bar' } )
 			.getByRole( 'button', { name: 'Styles' } )

--- a/test/e2e/specs/site-editor/style-variations.spec.js
+++ b/test/e2e/specs/site-editor/style-variations.spec.js
@@ -217,17 +217,7 @@ class SiteEditorStyleVariations {
 		this.page = page;
 	}
 
-	async disableWelcomeGuide() {
-		// Turn off the welcome guide.
-		await this.page.evaluate( () => {
-			window.wp.data
-				.dispatch( 'core/preferences' )
-				.set( 'core/edit-site', 'welcomeGuideStyles', false );
-		} );
-	}
-
 	async browseStyles() {
-		await this.disableWelcomeGuide();
 		await this.page.click( 'role=button[name="Styles"i]' );
 		await this.page.click( 'role=button[name="Browse styles"i]' );
 	}

--- a/test/e2e/specs/site-editor/user-global-styles-revisions.spec.js
+++ b/test/e2e/specs/site-editor/user-global-styles-revisions.spec.js
@@ -1,16 +1,9 @@
 /**
  * WordPress dependencies
  */
-const {
-	test,
-	expect,
-	Editor,
-} = require( '@wordpress/e2e-test-utils-playwright' );
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 
 test.use( {
-	editor: async ( { page }, use ) => {
-		await use( new Editor( { page } ) );
-	},
 	userGlobalStylesRevisions: async ( { page, requestUtils }, use ) => {
 		await use( new UserGlobalStylesRevisions( { page, requestUtils } ) );
 	},
@@ -29,10 +22,9 @@ test.describe( 'Global styles revisions', () => {
 		await requestUtils.activateTheme( 'twentytwentyone' );
 	} );
 
-	test.beforeEach( async ( { admin } ) => {
-		await admin.visitSiteEditor( {
-			canvas: 'edit',
-		} );
+	test.beforeEach( async ( { admin, editor } ) => {
+		await admin.visitSiteEditor();
+		await editor.canvas.click( 'body' );
 	} );
 
 	test( 'should display revisions UI when there is more than 1 revision', async ( {

--- a/test/e2e/specs/site-editor/user-global-styles-revisions.spec.js
+++ b/test/e2e/specs/site-editor/user-global-styles-revisions.spec.js
@@ -131,15 +131,6 @@ class UserGlobalStylesRevisions {
 		this.requestUtils = requestUtils;
 	}
 
-	async disableWelcomeGuide() {
-		// Turn off the welcome guide.
-		await this.page.evaluate( () => {
-			window.wp.data
-				.dispatch( 'core/preferences' )
-				.set( 'core/edit-site', 'welcomeGuideStyles', false );
-		} );
-	}
-
 	async getGlobalStylesRevisions() {
 		const stylesPostId =
 			await this.requestUtils.getCurrentThemeGlobalStylesPostId();
@@ -159,7 +150,6 @@ class UserGlobalStylesRevisions {
 	}
 
 	async openStylesPanel() {
-		await this.disableWelcomeGuide();
 		await this.page
 			.getByRole( 'region', { name: 'Editor top bar' } )
 			.getByRole( 'button', { name: 'Styles' } )


### PR DESCRIPTION
## What?
A minor cleanup after #50852.

## Why?
The Styles panel welcome guide is now correctly disabled when visiting the Site Editor, so there's no need for separate helper methods.

## Testing Instructions
CI should be green.
