### PR TITLE
FlatTermSelector: Fix the 'useSelect' missing dependency

### DIFF
--- a/packages/editor/src/components/post-taxonomies/flat-term-selector.js
+++ b/packages/editor/src/components/post-taxonomies/flat-term-selector.js
@@ -142,7 +142,7 @@ export function FlatTermSelector( { slug } ) {
 					: EMPTY_ARRAY,
 			};
 		},
-		[ search ]
+		[ search, slug ]
 	);
 
 	// Update terms state only after the selectors are resolved.


### PR DESCRIPTION
## What?
PR fixes `React Hook useSelect has a missing dependency: 'slug'.` ESLint notice.

## Why?
I was looking into a different issue and saw the notice. The `slug` is a string and won't change during the editor lifecycle.

## Testing Instructions
1. Open a Post or Page
2. Confirm "Tags" selector works as before.