### PR TITLE
Tweak edit site resizable frame handle

### DIFF
--- a/packages/edit-site/src/components/resizable-frame/index.js
+++ b/packages/edit-site/src/components/resizable-frame/index.js
@@ -171,6 +171,18 @@ function ResizableFrame( {
 		},
 	};
 
+	const resizeHandleVariants = {
+		default: {
+			opacity: 1,
+			left: -16,
+		},
+		resizing: {
+			opacity: 1,
+			left: -16,
+			scaleY: 1.3,
+		},
+	};
+
 	return (
 		<ResizableBox
 			as={ motion.div }
@@ -212,20 +224,18 @@ function ResizableFrame( {
 						<motion.div
 							key="handle"
 							className="edit-site-resizable-frame__handle"
+							variants={ resizeHandleVariants }
+							animate={ isResizing ? 'resizing' : 'default' }
 							title="Drag to resize"
 							initial={ {
 								opacity: 0,
 								left: 0,
 							} }
-							animate={ {
-								opacity: 1,
-								left: -15,
-							} }
 							exit={ {
 								opacity: 0,
 								left: 0,
 							} }
-							whileHover={ { scale: 1.1 } }
+							whileHover={ { scaleY: 1.3 } }
 						/>
 					) : null,
 			} }

--- a/packages/edit-site/src/components/resizable-frame/style.scss
+++ b/packages/edit-site/src/components/resizable-frame/style.scss
@@ -28,42 +28,44 @@
 }
 
 .edit-site-resizable-frame__handle {
-	position: absolute;
-	width: 5px;
-	height: 50px;
-	background-color: rgba(255, 255, 255, 0.3);
-	z-index: 100;
-	border-radius: 5px;
+	align-items: center;
+	background-color: rgba($gray-700, 0.4);
+	border-radius: $grid-unit-05;
 	cursor: col-resize;
 	display: flex;
-	align-items: center;
+	height: $grid-unit-80;
 	justify-content: flex-end;
-	top: 50%;
+	position: absolute;
+	top: calc(50% - #{$grid-unit-40});
+	width: $grid-unit-05;
+	z-index: 100;
+
 	&::before {
-		position: absolute;
-		left: 100%;
-		height: 100%;
-		width: $grid-unit-30;
 		content: "";
+		height: 100%;
+		left: 100%;
+		position: absolute;
+		width: $grid-unit-40;
 	}
 
 	&::after {
+		content: "";
+		height: 100%;
 		position: absolute;
 		right: 100%;
-		height: 100%;
-		width: $grid-unit-30;
-		content: "";
+		width: $grid-unit-40;
 	}
 
-	&:hover {
+	&:hover,
+	.is-resizing & {
 		background-color: var(--wp-admin-theme-color);
 	}
 
 	.edit-site-resizable-frame__handle-label {
-		border-radius: 2px;
 		background: var(--wp-admin-theme-color);
-		padding: 4px 8px;
+		border-radius: 2px;
 		color: #fff;
 		margin-right: $grid-unit-10;
+		padding: 4px 8px;
 	}
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Vertically centers the new resize handle (https://github.com/WordPress/gutenberg/pull/49910), applies standard metrics to the handle, adjusts the hover scaling animations, and ensures the handle stays in its focused state as you're dragging it. 

## Why?
Makes it feel nicer to interact with. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open the Site Editor.
2. Hover over the canvas on the right. 
3. See the updated edit site resizable frame handle.

## Screenshots or screencast <!-- if applicable -->

### Before
https://github.com/WordPress/gutenberg/assets/1813435/6dbc9e05-1d5d-4184-b721-eec2eb9e05f4

### After 
https://github.com/WordPress/gutenberg/assets/1813435/370811a8-9671-45ef-9d9c-ef19d4b2c0ef


