### PR TITLE
Comment Template Block: Add test coverage for context setting

### DIFF
--- a/phpunit/blocks/render-comment-template-test.php
+++ b/phpunit/blocks/render-comment-template-test.php
@@ -86,6 +86,10 @@ class Tests_Blocks_RenderCommentTemplateBlock extends WP_UnitTestCase {
 			)
 		);
 		$comment_author_name_block_markup = $comment_author_name_block->render();
+		$this->assertNotEmpty(
+			$comment_author_name_block_markup,
+			'Comment Author Name block rendered markup is empty.'
+		);
 
 		$render_block_callback = static function( $block_content, $block ) use ( $parsed_comment_author_name_block ) {
 			// Insert a Comment Author Name block (which requires `commentId`
@@ -111,6 +115,10 @@ class Tests_Blocks_RenderCommentTemplateBlock extends WP_UnitTestCase {
 		$markup        = $block->render();
 		remove_filter( 'render_block', $render_block_callback );
 
-		$this->assertStringContainsString( $comment_author_name_block_markup, $markup );
+		$this->assertStringContainsString(
+			$comment_author_name_block_markup,
+			$markup,
+			"Rendered markup doesn't contain Comment Author Name block."
+		);
 	}
 }

--- a/phpunit/blocks/render-comment-template-test.php
+++ b/phpunit/blocks/render-comment-template-test.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ * Tests for the Comment Template block rendering.
+ *
+ * @package WordPress
+ * @subpackage Blocks
+ * @since 6.0.0
+ *
+ * @group blocks
+ */
+class Tests_Blocks_RenderCommentTemplateBlock extends WP_UnitTestCase {
+
+	private static $custom_post;
+	private static $comment_ids;
+	private static $per_page = 5;
+
+	/**
+	 * Array of the comments options and their original values.
+	 * Used to reset the options after each test.
+	 *
+	 * @var array
+	 */
+	private static $original_options;
+
+	public static function set_up_before_class() {
+		parent::set_up_before_class();
+
+		// Store the original option values.
+		$options = array(
+			'comment_order',
+			'comments_per_page',
+			'default_comments_page',
+			'page_comments',
+			'previous_default_page',
+			'thread_comments_depth',
+		);
+		foreach ( $options as $option ) {
+			static::$original_options[ $option ] = get_option( $option );
+		}
+	}
+
+	public function tear_down() {
+		// Reset the comment options to their original values.
+		foreach ( static::$original_options as $option => $original_value ) {
+			update_option( $option, $original_value );
+		}
+
+		parent::tear_down();
+	}
+
+	public function set_up() {
+		parent::set_up();
+
+		update_option( 'page_comments', true );
+		update_option( 'comments_per_page', self::$per_page );
+
+		self::$custom_post = self::factory()->post->create_and_get(
+			array(
+				'post_type'    => 'dogs',
+				'post_status'  => 'publish',
+				'post_name'    => 'metaldog',
+				'post_title'   => 'Metal Dog',
+				'post_content' => 'Metal Dog content',
+				'post_excerpt' => 'Metal Dog',
+			)
+		);
+
+		self::$comment_ids = self::factory()->comment->create_post_comments(
+			self::$custom_post->ID,
+			1,
+			array(
+				'comment_author'       => 'Test',
+				'comment_author_email' => 'test@example.org',
+				'comment_author_url'   => 'http://example.com/author-url/',
+				'comment_content'      => 'Hello world',
+			)
+		);
+	}
+
+	public function test_rendering_comment_template_sets_comment_id_context() {
+		$render_block_callback    = new MockAction();
+		add_filter( 'render_block', array( $render_block_callback, 'filter' ), 10, 3 );
+
+		$parsed_blocks = parse_blocks(
+			'<!-- wp:comment-template --><!-- wp:comment-author-name /--><!-- /wp:comment-template -->'
+		);
+		$block = new WP_Block(
+			$parsed_blocks[0],
+			array(
+				'postId' => self::$custom_post->ID,
+			)
+		);
+		$block->render();
+
+		$this->assertSame( 3, $render_block_callback->get_call_count() );
+
+		$args = $render_block_callback->get_args();
+
+		$this->assertSame( 'core/comment-author-name', $args[0][2]->name );
+		$this->assertArrayHasKey( 'commentId', $args[0][2]->context );
+		$this->assertSame( strval( self::$comment_ids[0] ), $args[0][2]->context['commentId'] );
+
+		$this->assertSame( 'core/comment-template', $args[1][2]->name );
+		$this->assertSame( 'core/comment-template', $args[2][2]->name );
+	}
+}

--- a/phpunit/blocks/render-comment-template-test.php
+++ b/phpunit/blocks/render-comment-template-test.php
@@ -4,7 +4,7 @@
  *
  * @package WordPress
  * @subpackage Blocks
- * @since 6.0.0
+ * @since 6.3.0
  *
  * @group blocks
  */

--- a/phpunit/blocks/render-comment-template-test.php
+++ b/phpunit/blocks/render-comment-template-test.php
@@ -77,8 +77,10 @@ class Tests_Blocks_RenderCommentTemplateBlock extends WP_UnitTestCase {
 		);
 	}
 
-	public function test_rendering_comment_template_sets_comment_id_context() {
+	public function test_rendering_comment_template_sets_comment_id_context() {.
 		$render_block_callback = static function( $block_content, $block ) {
+			// Insert a Comment Author Name block (which requires `commentId`
+			// block context to work) after the Comment Content block.
 			if ( 'core/comment-content' !== $block['blockName'] ) {
 				return $block_content;
 			}
@@ -92,13 +94,13 @@ class Tests_Blocks_RenderCommentTemplateBlock extends WP_UnitTestCase {
 		$parsed_blocks = parse_blocks(
 			'<!-- wp:comment-template --><!-- wp:comment-content /--><!-- /wp:comment-template -->'
 		);
-		$block = new WP_Block(
+		$block         = new WP_Block(
 			$parsed_blocks[0],
 			array(
 				'postId' => self::$custom_post->ID,
 			)
 		);
-		$markup = $block->render();
+		$markup        = $block->render();
 		remove_filter( 'render_block', $render_block_callback );
 
 		$this->assertSame(

--- a/phpunit/blocks/render-comment-template-test.php
+++ b/phpunit/blocks/render-comment-template-test.php
@@ -77,7 +77,7 @@ class Tests_Blocks_RenderCommentTemplateBlock extends WP_UnitTestCase {
 		);
 	}
 
-	public function test_rendering_comment_template_sets_comment_id_context() {.
+	public function test_rendering_comment_template_sets_comment_id_context() {
 		$render_block_callback = static function( $block_content, $block ) {
 			// Insert a Comment Author Name block (which requires `commentId`
 			// block context to work) after the Comment Content block.


### PR DESCRIPTION
## What?
Add a unit test to verify that the Comment Template block sets `commentId` context as expected. Follow up to https://github.com/WordPress/gutenberg/pull/50279; see https://github.com/WordPress/gutenberg/pull/50279#issuecomment-1557733489 for context.

## Why?
Conversation on https://github.com/WordPress/gutenberg/pull/50279 indicates that it's fairly easy to make a change to the relevant code which would break this behavior. Consequently, it makes sense to guard against such breakage.

## How?
By inserting a block which requires `commentId` context to work via the `render_block` hook.

## Testing Instructions

1. Verify that test pass. Locally, this can be done via `npm run test:unit:php -- --group=blocks`.
2. Now revert https://github.com/WordPress/gutenberg/commit/4409ba473ae73fd7288888eb9182b4e9a42ca7ef and rebuild blocks (`npm run build`). Re-run the test, and verify that it fails now.

## Note

In the long run, this test should be merged into `wordpress-develop`'s [`renderCommentTemplate.php` test file](https://github.com/WordPress/wordpress-develop/blob/00f5110d9f71cb1b992d9d29af3d8d76ffc161f2/tests/phpunit/tests/blocks/renderCommentTemplate.php).