### PR TITLE
Allow renaming, duplication and deleting of Navigation menus from Browse Mode Sidebar

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/delete-modal.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/delete-modal.js
@@ -1,0 +1,46 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+	Button,
+	Modal,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+export default function RenameModal( { onClose, onConfirm } ) {
+	return (
+		<Modal title={ __( 'Delete' ) } onRequestClose={ onClose }>
+			<form>
+				<VStack spacing="3">
+					<p>
+						{ __(
+							'Are you sure you wish to delete this Navigation menu?'
+						) }
+					</p>
+					<HStack justify="right">
+						<Button variant="tertiary" onClick={ onClose }>
+							{ __( 'Cancel' ) }
+						</Button>
+
+						<Button
+							isDestructive
+							variant="primary"
+							type="submit"
+							onClick={ ( e ) => {
+								e.preventDefault();
+								onConfirm();
+
+								// Immediate close avoids ability to hit delete multiple times.
+								onClose();
+							} }
+						>
+							{ __( 'Confirm' ) }
+						</Button>
+					</HStack>
+				</VStack>
+			</form>
+		</Modal>
+	);
+}

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/delete-modal.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/delete-modal.js
@@ -16,7 +16,7 @@ export default function RenameModal( { onClose, onConfirm } ) {
 				<VStack spacing="3">
 					<p>
 						{ __(
-							'Are you sure you wish to delete this Navigation menu?'
+							'Are you sure you want to delete this Navigation menu?'
 						) }
 					</p>
 					<HStack justify="right">

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/index.js
@@ -51,6 +51,7 @@ export default function SidebarNavigationScreenNavigationMenu() {
 
 	const postType = `wp_navigation`;
 	const {
+		goTo,
 		params: { postId },
 	} = useNavigator();
 
@@ -76,11 +77,11 @@ export default function SidebarNavigationScreenNavigationMenu() {
 		createSuccessNotice( 'Deleted Navigation menu', {
 			type: 'snackbar',
 		} );
-		//TODO: navigate to previous menu
+		goTo( '/navigation' );
 	};
 	const handleDuplicate = async () => {
 		const savedRecord = await saveEntityRecord( 'postType', postType, {
-			title: menuTitle,
+			title: menuTitle + __( ' (Copy)' ),
 			content: navigationMenu?.content?.raw,
 			status: 'publish',
 		} );
@@ -88,7 +89,7 @@ export default function SidebarNavigationScreenNavigationMenu() {
 			createSuccessNotice( 'Duplicated Navigation menu', {
 				type: 'snackbar',
 			} );
-			//TODO: navigate to the duplicated menu
+			goTo( `/navigation/${ postType }/${ savedRecord.id }` );
 		}
 	};
 

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/index.js
@@ -39,10 +39,12 @@ const { useHistory } = unlock( routerPrivateApis );
 const noop = () => {};
 
 export default function SidebarNavigationScreenNavigationMenu() {
-	const { deleteEntityRecord } = useDispatch( coreStore );
-	const { editEntityRecord } = useDispatch( coreStore );
-	const { saveEditedEntityRecord } = useDispatch( coreStore );
-
+	const {
+		deleteEntityRecord,
+		editEntityRecord,
+		saveEntityRecord,
+		saveEditedEntityRecord,
+	} = useDispatch( coreStore );
 	const [ isOpen, setOpen ] = useState( false );
 
 	const postType = `wp_navigation`;
@@ -56,6 +58,8 @@ export default function SidebarNavigationScreenNavigationMenu() {
 		postId
 	);
 
+	const menuTitle = navigationMenu?.title?.rendered || navigationMenu?.slug;
+
 	const handleSave = async () => {
 		saveEditedEntityRecord( 'postType', postType, postId );
 		setOpen( false );
@@ -64,8 +68,16 @@ export default function SidebarNavigationScreenNavigationMenu() {
 		editEntityRecord( 'postType', postType, postId, { title } );
 	const handleDelete = () =>
 		deleteEntityRecord( 'postType', postType, postId, { force: true } );
-
-	const menuTitle = navigationMenu?.title?.rendered || navigationMenu?.slug;
+	const handleDuplicate = async () => {
+		const savedRecord = await saveEntityRecord( 'postType', postType, {
+			title: menuTitle,
+			content: navigationMenu?.content?.raw,
+			status: 'publish',
+		} );
+		if ( savedRecord ) {
+			//TODO: add toast message and navigate back?
+		}
+	};
 
 	const element = useSelect(
 		( select ) =>
@@ -83,6 +95,7 @@ export default function SidebarNavigationScreenNavigationMenu() {
 		handleDelete,
 		handleSave,
 		handleChange,
+		handleDuplicate,
 		editedMenuTitle: element.title,
 	};
 
@@ -212,6 +225,7 @@ function ScreenNavigationMoreMenu( props ) {
 		handleDelete,
 		handleSave,
 		handleChange,
+		handleDuplicate,
 		editedMenuTitle,
 	} = props;
 	const closeModal = () => setOpen( false );
@@ -235,7 +249,14 @@ function ScreenNavigationMoreMenu( props ) {
 							>
 								{ __( 'Rename' ) }
 							</MenuItem>
-							<MenuItem>{ __( 'Duplicate' ) }</MenuItem>
+							<MenuItem
+								onClick={ () => {
+									handleDuplicate();
+									onClose();
+								} }
+							>
+								{ __( 'Duplicate' ) }
+							</MenuItem>
 							<MenuItem
 								isDestructive
 								isTertiary

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/index.js
@@ -1,18 +1,22 @@
 /**
  * WordPress dependencies
  */
-import { useEntityRecord } from '@wordpress/core-data';
+import { useEntityRecord, store as coreStore } from '@wordpress/core-data';
 import {
 	__experimentalUseNavigator as useNavigator,
 	Spinner,
+	DropdownMenu,
+	MenuItem,
+	MenuGroup,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useCallback, useMemo } from '@wordpress/element';
-import { useSelect } from '@wordpress/data';
+import { useSelect, useDispatch } from '@wordpress/data';
 import { privateApis as routerPrivateApis } from '@wordpress/router';
 import { BlockEditorProvider } from '@wordpress/block-editor';
 import { createBlock } from '@wordpress/blocks';
 import { decodeEntities } from '@wordpress/html-entities';
+import { moreVertical } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -74,6 +78,7 @@ export default function SidebarNavigationScreenNavigationMenu() {
 
 	return (
 		<SidebarNavigationScreenWrapper
+			actions={ ScreenNavigationMoreMenu( postId ) }
 			title={ decodeEntities( menuTitle ) }
 			description={ __(
 				'Navigation menus are a curated collection of blocks that allow visitors to get around your site.'
@@ -153,5 +158,45 @@ function NavigationMenuEditor( { navigationMenu } ) {
 				/>
 			</div>
 		</BlockEditorProvider>
+	);
+}
+
+const POPOVER_PROPS = {
+	position: 'bottom right',
+	variant: 'toolbar',
+};
+
+function ScreenNavigationMoreMenu( navigationMenuID ) {
+	const { deleteEntityRecord } = useDispatch( coreStore );
+	return (
+		<DropdownMenu
+			className="sidebar-navigation__more-menu"
+			icon={ moreVertical }
+			popoverProps={ POPOVER_PROPS }
+		>
+			{ ( { onClose } ) => (
+				<div>
+					<MenuGroup>
+						<MenuItem>{ __( 'Rename' ) }</MenuItem>
+						<MenuItem>{ __( 'Duplicate' ) }</MenuItem>
+						<MenuItem
+							isDestructive
+							isTertiary
+							onClick={ () => {
+								deleteEntityRecord(
+									'postType',
+									'wp_navigation',
+									navigationMenuID,
+									{ force: true }
+								);
+								onClose();
+							} }
+						>
+							{ __( 'Delete' ) }
+						</MenuItem>
+					</MenuGroup>
+				</div>
+			) }
+		</DropdownMenu>
 	);
 }

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/index.js
@@ -22,6 +22,7 @@ import { BlockEditorProvider } from '@wordpress/block-editor';
 import { createBlock } from '@wordpress/blocks';
 import { decodeEntities } from '@wordpress/html-entities';
 import { moreVertical } from '@wordpress/icons';
+import { store as noticesStore } from '@wordpress/notices';
 
 /**
  * Internal dependencies
@@ -46,6 +47,7 @@ export default function SidebarNavigationScreenNavigationMenu() {
 		saveEditedEntityRecord,
 	} = useDispatch( coreStore );
 	const [ isOpen, setOpen ] = useState( false );
+	const { createSuccessNotice } = useDispatch( noticesStore );
 
 	const postType = `wp_navigation`;
 	const {
@@ -63,11 +65,19 @@ export default function SidebarNavigationScreenNavigationMenu() {
 	const handleSave = async () => {
 		saveEditedEntityRecord( 'postType', postType, postId );
 		setOpen( false );
+		createSuccessNotice( 'Renamed Navigation menu', {
+			type: 'snackbar',
+		} );
 	};
 	const handleChange = ( title ) =>
 		editEntityRecord( 'postType', postType, postId, { title } );
-	const handleDelete = () =>
+	const handleDelete = () => {
 		deleteEntityRecord( 'postType', postType, postId, { force: true } );
+		createSuccessNotice( 'Deleted Navigation menu', {
+			type: 'snackbar',
+		} );
+		//TODO: navigate to previous menu
+	};
 	const handleDuplicate = async () => {
 		const savedRecord = await saveEntityRecord( 'postType', postType, {
 			title: menuTitle,
@@ -75,7 +85,10 @@ export default function SidebarNavigationScreenNavigationMenu() {
 			status: 'publish',
 		} );
 		if ( savedRecord ) {
-			//TODO: add toast message and navigate back?
+			createSuccessNotice( 'Duplicated Navigation menu', {
+				type: 'snackbar',
+			} );
+			//TODO: navigate to the duplicated menu
 		}
 	};
 

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/index.js
@@ -39,6 +39,8 @@ const { useHistory } = unlock( routerPrivateApis );
 const noop = () => {};
 
 export default function SidebarNavigationScreenNavigationMenu() {
+	const { deleteEntityRecord } = useDispatch( coreStore );
+	const [ isOpen, setOpen ] = useState( false );
 	const postType = `wp_navigation`;
 	const {
 		params: { postId },
@@ -52,7 +54,13 @@ export default function SidebarNavigationScreenNavigationMenu() {
 
 	const menuTitle = navigationMenu?.title?.rendered || navigationMenu?.slug;
 
-	const [ isOpen, setOpen ] = useState( false );
+	const modalProps = {
+		postId,
+		isOpen,
+		setOpen,
+		deleteEntityRecord,
+		menuTitle,
+	};
 
 	if ( isLoading ) {
 		return (
@@ -85,7 +93,7 @@ export default function SidebarNavigationScreenNavigationMenu() {
 
 	return (
 		<SidebarNavigationScreenWrapper
-			actions={ ScreenNavigationMoreMenu( postId, isOpen, setOpen ) }
+			actions={ ScreenNavigationMoreMenu( modalProps ) }
 			title={ decodeEntities( menuTitle ) }
 			description={ __(
 				'Navigation menus are a curated collection of blocks that allow visitors to get around your site.'
@@ -173,10 +181,11 @@ const POPOVER_PROPS = {
 	variant: 'toolbar',
 };
 
-function ScreenNavigationMoreMenu( navigationMenuID, isOpen, setOpen ) {
-	const { deleteEntityRecord } = useDispatch( coreStore );
+function ScreenNavigationMoreMenu( props ) {
+	const { postId, isOpen, setOpen, deleteEntityRecord, menuTitle } = props;
 	const closeModal = () => setOpen( false );
 	const openModal = () => setOpen( true );
+
 	return (
 		<>
 			<DropdownMenu
@@ -187,7 +196,12 @@ function ScreenNavigationMoreMenu( navigationMenuID, isOpen, setOpen ) {
 				{ ( { onClose } ) => (
 					<div>
 						<MenuGroup>
-							<MenuItem onClick={ openModal }>
+							<MenuItem
+								onClick={ () => {
+									openModal();
+									onClose();
+								} }
+							>
 								{ __( 'Rename' ) }
 							</MenuItem>
 							<MenuItem>{ __( 'Duplicate' ) }</MenuItem>
@@ -198,7 +212,7 @@ function ScreenNavigationMoreMenu( navigationMenuID, isOpen, setOpen ) {
 									deleteEntityRecord(
 										'postType',
 										'wp_navigation',
-										navigationMenuID,
+										postId,
 										{ force: true }
 									);
 									onClose();
@@ -217,7 +231,7 @@ function ScreenNavigationMoreMenu( navigationMenuID, isOpen, setOpen ) {
 						<VStack spacing="3">
 							<TextControl
 								__nextHasNoMarginBottom
-								value="NAME!"
+								value={ decodeEntities( menuTitle ) }
 								placeholder={ __( 'Navigation title' ) }
 							/>
 							<HStack justify="right">

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/index.js
@@ -154,7 +154,11 @@ export default function SidebarNavigationScreenNavigationMenu() {
 				'postType',
 				postType,
 				{
-					title: menuTitle + __( ' (Copy)' ),
+					title: sprintf(
+						/* translators: %s: Navigation menu title */
+						__( '%s (Copy)' ),
+						menuTitle
+					),
 					content: navigationMenu?.content?.raw,
 					status: 'publish',
 				},

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/index.js
@@ -309,7 +309,7 @@ function ScreenNavigationMoreMenu( props ) {
 									type="submit"
 									onClick={ handleSave }
 								>
-									{ __( 'Ok' ) }
+									{ __( 'OK' ) }
 								</Button>
 							</HStack>
 						</VStack>

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/index.js
@@ -63,8 +63,9 @@ export default function SidebarNavigationScreenNavigationMenu() {
 			type: 'snackbar',
 		} );
 	};
-	const handleChange = ( title ) =>
+	const editRecordTitle = ( title = '' ) =>
 		editEntityRecord( 'postType', postType, postId, { title } );
+
 	const handleDelete = () => {
 		deleteEntityRecord( 'postType', postType, postId, { force: true } );
 		createSuccessNotice( __( 'Deleted Navigation menu' ), {
@@ -101,7 +102,7 @@ export default function SidebarNavigationScreenNavigationMenu() {
 		setOpen,
 		handleDelete,
 		handleSave,
-		handleChange,
+		onChange: editRecordTitle,
 		handleDuplicate,
 		editedMenuTitle: entity?.title || '',
 	};

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/index.js
@@ -66,7 +66,7 @@ export default function SidebarNavigationScreenNavigationMenu() {
 	const handleSave = async () => {
 		saveEditedEntityRecord( 'postType', postType, postId );
 		setOpen( false );
-		createSuccessNotice( 'Renamed Navigation menu', {
+		createSuccessNotice( __( 'Renamed Navigation menu' ), {
 			type: 'snackbar',
 		} );
 	};
@@ -74,7 +74,7 @@ export default function SidebarNavigationScreenNavigationMenu() {
 		editEntityRecord( 'postType', postType, postId, { title } );
 	const handleDelete = () => {
 		deleteEntityRecord( 'postType', postType, postId, { force: true } );
-		createSuccessNotice( 'Deleted Navigation menu', {
+		createSuccessNotice( __( 'Deleted Navigation menu' ), {
 			type: 'snackbar',
 		} );
 		goTo( '/navigation' );

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/index.js
@@ -4,15 +4,7 @@
 import { useEntityRecord, store as coreStore } from '@wordpress/core-data';
 import {
 	__experimentalUseNavigator as useNavigator,
-	__experimentalHStack as HStack,
-	__experimentalVStack as VStack,
-	Button,
-	DropdownMenu,
 	Spinner,
-	TextControl,
-	MenuItem,
-	MenuGroup,
-	Modal,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useCallback, useMemo, useState } from '@wordpress/element';
@@ -21,7 +13,7 @@ import { privateApis as routerPrivateApis } from '@wordpress/router';
 import { BlockEditorProvider } from '@wordpress/block-editor';
 import { createBlock } from '@wordpress/blocks';
 import { decodeEntities } from '@wordpress/html-entities';
-import { moreVertical } from '@wordpress/icons';
+
 import { store as noticesStore } from '@wordpress/notices';
 
 /**
@@ -35,6 +27,7 @@ import {
 } from '../../utils/is-previewing-theme';
 import { SidebarNavigationScreenWrapper } from '../sidebar-navigation-screen-navigation-menus';
 import NavigationMenuContent from '../sidebar-navigation-screen-navigation-menus/navigation-menu-content';
+import ScreenNavigationMoreMenu from './more-menu';
 
 const { useHistory } = unlock( routerPrivateApis );
 const noop = () => {};
@@ -224,98 +217,5 @@ function NavigationMenuEditor( { navigationMenu } ) {
 				/>
 			</div>
 		</BlockEditorProvider>
-	);
-}
-
-const POPOVER_PROPS = {
-	position: 'bottom right',
-	variant: 'toolbar',
-};
-
-function ScreenNavigationMoreMenu( props ) {
-	const {
-		isOpen,
-		setOpen,
-		handleDelete,
-		handleSave,
-		handleChange,
-		handleDuplicate,
-		editedMenuTitle,
-	} = props;
-	const closeModal = () => setOpen( false );
-	const openModal = () => setOpen( true );
-
-	return (
-		<>
-			<DropdownMenu
-				className="sidebar-navigation__more-menu"
-				icon={ moreVertical }
-				popoverProps={ POPOVER_PROPS }
-			>
-				{ ( { onClose } ) => (
-					<div>
-						<MenuGroup>
-							<MenuItem
-								onClick={ () => {
-									openModal();
-									onClose();
-								} }
-							>
-								{ __( 'Rename' ) }
-							</MenuItem>
-							<MenuItem
-								onClick={ () => {
-									handleDuplicate();
-									onClose();
-								} }
-							>
-								{ __( 'Duplicate' ) }
-							</MenuItem>
-							<MenuItem
-								isDestructive
-								isTertiary
-								onClick={ () => {
-									handleDelete();
-									onClose();
-								} }
-							>
-								{ __( 'Delete' ) }
-							</MenuItem>
-						</MenuGroup>
-					</div>
-				) }
-			</DropdownMenu>
-
-			{ isOpen && (
-				<Modal title="Rename" onRequestClose={ closeModal }>
-					<form>
-						<VStack spacing="3">
-							<TextControl
-								__nextHasNoMarginBottom
-								value={ editedMenuTitle }
-								placeholder={ __( 'Navigation title' ) }
-								onChange={ handleChange }
-							/>
-							<HStack justify="right">
-								<Button
-									variant="tertiary"
-									onClick={ closeModal }
-								>
-									{ __( 'Cancel' ) }
-								</Button>
-
-								<Button
-									variant="primary"
-									type="submit"
-									onClick={ handleSave }
-								>
-									{ __( 'Save' ) }
-								</Button>
-							</HStack>
-						</VStack>
-					</form>
-				</Modal>
-			) }
-		</>
 	);
 }

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/index.js
@@ -35,8 +35,8 @@ const noop = () => {};
 export default function SidebarNavigationScreenNavigationMenu() {
 	const {
 		deleteEntityRecord,
-		editEntityRecord,
 		saveEntityRecord,
+		editEntityRecord,
 		saveEditedEntityRecord,
 	} = useDispatch( coreStore );
 	const [ isOpen, setOpen ] = useState( false );
@@ -56,15 +56,14 @@ export default function SidebarNavigationScreenNavigationMenu() {
 
 	const menuTitle = navigationMenu?.title?.rendered || navigationMenu?.slug;
 
-	const handleSave = async () => {
-		saveEditedEntityRecord( 'postType', postType, postId );
+	const handleSave = async ( edits = {} ) => {
+		editEntityRecord( 'postType', postType, postId, edits );
 		setOpen( false );
+		await saveEditedEntityRecord( 'postType', postType, postId );
 		createSuccessNotice( __( 'Renamed Navigation menu' ), {
 			type: 'snackbar',
 		} );
 	};
-	const editRecordTitle = ( title = '' ) =>
-		editEntityRecord( 'postType', postType, postId, { title } );
 
 	const handleDelete = () => {
 		deleteEntityRecord( 'postType', postType, postId, { force: true } );
@@ -87,24 +86,13 @@ export default function SidebarNavigationScreenNavigationMenu() {
 		}
 	};
 
-	const entity = useSelect(
-		( select ) =>
-			select( coreStore ).getEditedEntityRecord(
-				'postType',
-				postType,
-				postId
-			),
-		[ postType, postId ]
-	);
-
 	const modalProps = {
 		isOpen,
 		setOpen,
 		handleDelete,
 		handleSave,
-		onChange: editRecordTitle,
 		handleDuplicate,
-		editedMenuTitle: entity?.title || '',
+		menuTitle: decodeEntities( menuTitle ),
 	};
 
 	if ( isLoading ) {

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/index.js
@@ -93,7 +93,7 @@ export default function SidebarNavigationScreenNavigationMenu() {
 		}
 	};
 
-	const element = useSelect(
+	const entity = useSelect(
 		( select ) =>
 			select( coreStore ).getEditedEntityRecord(
 				'postType',
@@ -110,7 +110,7 @@ export default function SidebarNavigationScreenNavigationMenu() {
 		handleSave,
 		handleChange,
 		handleDuplicate,
-		editedMenuTitle: element.title,
+		editedMenuTitle: entity?.title || '',
 	};
 
 	if ( isLoading ) {

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/index.js
@@ -218,9 +218,9 @@ export default function SidebarNavigationScreenNavigationMenu() {
 			actions={
 				<ScreenNavigationMoreMenu
 					menuTitle={ decodeEntities( menuTitle ) }
-					handleDelete={ handleDelete }
-					handleSave={ handleSave }
-					handleDuplicate={ handleDuplicate }
+					onDelete={ handleDelete }
+					onSave={ handleSave }
+					onDuplicate={ handleDuplicate }
 				/>
 			}
 			title={ decodeEntities( menuTitle ) }

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/index.js
@@ -43,19 +43,40 @@ export default function SidebarNavigationScreenNavigationMenu() {
 	const { createSuccessNotice, createErrorNotice } =
 		useDispatch( noticesStore );
 
-	const { getEditedEntityRecord } = useSelect( coreStore );
-
 	const postType = `wp_navigation`;
 	const {
 		goTo,
 		params: { postId },
 	} = useNavigator();
 
-	const { record: navigationMenu, isResolving: isLoading } = useEntityRecord(
+	const { record: navigationMenu, isResolving } = useEntityRecord(
 		'postType',
 		postType,
 		postId
 	);
+
+	const { getEditedEntityRecord, isSaving, isDeleting } = useSelect(
+		( select ) => {
+			const {
+				isSavingEntityRecord,
+				isDeletingEntityRecord,
+				getEditedEntityRecord: getEditedEntityRecordSelector,
+			} = select( coreStore );
+
+			return {
+				isSaving: isSavingEntityRecord( 'postType', postType, postId ),
+				isDeleting: isDeletingEntityRecord(
+					'postType',
+					postType,
+					postId
+				),
+				getEditedEntityRecord: getEditedEntityRecordSelector,
+			};
+		},
+		[ postId, postType ]
+	);
+
+	const isLoading = isResolving || isSaving || isDeleting;
 
 	const menuTitle = navigationMenu?.title?.rendered || navigationMenu?.slug;
 

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/index.js
@@ -86,7 +86,7 @@ export default function SidebarNavigationScreenNavigationMenu() {
 			status: 'publish',
 		} );
 		if ( savedRecord ) {
-			createSuccessNotice( 'Duplicated Navigation menu', {
+			createSuccessNotice( __( 'Duplicated Navigation menu' ), {
 				type: 'snackbar',
 			} );
 			goTo( `/navigation/${ postType }/${ savedRecord.id }` );

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/index.js
@@ -86,7 +86,7 @@ export default function SidebarNavigationScreenNavigationMenu() {
 				sprintf(
 					/* translators: %s: error message describing why the navigation menu could not be renamed. */
 					__( `Unable to rename Navigation menu (%s).` ),
-					error
+					error?.message
 				),
 
 				{
@@ -118,7 +118,7 @@ export default function SidebarNavigationScreenNavigationMenu() {
 				sprintf(
 					/* translators: %s: error message describing why the navigation menu could not be deleted. */
 					__( `Unable to delete Navigation menu (%s).` ),
-					error
+					error?.message
 				),
 
 				{
@@ -128,23 +128,38 @@ export default function SidebarNavigationScreenNavigationMenu() {
 		}
 	};
 	const handleDuplicate = async () => {
-		const savedRecord = await saveEntityRecord(
-			'postType',
-			postType,
-			{
-				title: menuTitle + __( ' (Copy)' ),
-				content: navigationMenu?.content?.raw,
-				status: 'publish',
-			},
-			{
-				throwOnError: true,
+		try {
+			const savedRecord = await saveEntityRecord(
+				'postType',
+				postType,
+				{
+					title: menuTitle + __( ' (Copy)' ),
+					content: navigationMenu?.content?.raw,
+					status: 'publish',
+				},
+				{
+					throwOnError: true,
+				}
+			);
+
+			if ( savedRecord ) {
+				createSuccessNotice( __( 'Duplicated Navigation menu' ), {
+					type: 'snackbar',
+				} );
+				goTo( `/navigation/${ postType }/${ savedRecord.id }` );
 			}
-		);
-		if ( savedRecord ) {
-			createSuccessNotice( __( 'Duplicated Navigation menu' ), {
-				type: 'snackbar',
-			} );
-			goTo( `/navigation/${ postType }/${ savedRecord.id }` );
+		} catch ( error ) {
+			createErrorNotice(
+				sprintf(
+					/* translators: %s: error message describing why the navigation menu could not be deleted. */
+					__( `Unable to duplicate Navigation menu (%s).` ),
+					error?.message
+				),
+
+				{
+					type: 'snackbar',
+				}
+			);
 		}
 	};
 

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/index.js
@@ -309,7 +309,7 @@ function ScreenNavigationMoreMenu( props ) {
 									type="submit"
 									onClick={ handleSave }
 								>
-									{ __( 'OK' ) }
+									{ __( 'Save' ) }
 								</Button>
 							</HStack>
 						</VStack>

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/index.js
@@ -7,7 +7,7 @@ import {
 	Spinner,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { useCallback, useMemo, useState } from '@wordpress/element';
+import { useCallback, useMemo } from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { privateApis as routerPrivateApis } from '@wordpress/router';
 import { BlockEditorProvider } from '@wordpress/block-editor';
@@ -39,7 +39,7 @@ export default function SidebarNavigationScreenNavigationMenu() {
 		editEntityRecord,
 		saveEditedEntityRecord,
 	} = useDispatch( coreStore );
-	const [ isOpen, setOpen ] = useState( false );
+
 	const { createSuccessNotice } = useDispatch( noticesStore );
 
 	const postType = `wp_navigation`;
@@ -58,7 +58,6 @@ export default function SidebarNavigationScreenNavigationMenu() {
 
 	const handleSave = async ( edits = {} ) => {
 		editEntityRecord( 'postType', postType, postId, edits );
-		setOpen( false );
 		await saveEditedEntityRecord( 'postType', postType, postId );
 		createSuccessNotice( __( 'Renamed Navigation menu' ), {
 			type: 'snackbar',
@@ -84,15 +83,6 @@ export default function SidebarNavigationScreenNavigationMenu() {
 			} );
 			goTo( `/navigation/${ postType }/${ savedRecord.id }` );
 		}
-	};
-
-	const modalProps = {
-		isOpen,
-		setOpen,
-		handleDelete,
-		handleSave,
-		handleDuplicate,
-		menuTitle: decodeEntities( menuTitle ),
 	};
 
 	if ( isLoading ) {
@@ -126,7 +116,14 @@ export default function SidebarNavigationScreenNavigationMenu() {
 
 	return (
 		<SidebarNavigationScreenWrapper
-			actions={ ScreenNavigationMoreMenu( modalProps ) }
+			actions={
+				<ScreenNavigationMoreMenu
+					menuTitle={ decodeEntities( menuTitle ) }
+					handleDelete={ handleDelete }
+					handleSave={ handleSave }
+					handleDuplicate={ handleDuplicate }
+				/>
+			}
 			title={ decodeEntities( menuTitle ) }
 			description={ __(
 				'Navigation menus are a curated collection of blocks that allow visitors to get around your site.'

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/index.js
@@ -6,7 +6,7 @@ import {
 	__experimentalUseNavigator as useNavigator,
 	Spinner,
 } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { useCallback, useMemo } from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { privateApis as routerPrivateApis } from '@wordpress/router';
@@ -79,18 +79,43 @@ export default function SidebarNavigationScreenNavigationMenu() {
 		} catch ( error ) {
 			// Revert to original in case of error.
 			editEntityRecord( 'postType', postType, postId, originalRecord );
-			createErrorNotice( __( 'Unable to rename Navigation menu' ), {
-				type: 'snackbar',
-			} );
+
+			createErrorNotice(
+				sprintf(
+					/* translators: %s: error message describing why the navigation menu could not be renamed. */
+					__( `Unable to rename Navigation menu (%s).` ),
+					error
+				),
+
+				{
+					type: 'snackbar',
+				}
+			);
 		}
 	};
 
-	const handleDelete = () => {
-		deleteEntityRecord( 'postType', postType, postId, { force: true } );
-		createSuccessNotice( __( 'Deleted Navigation menu' ), {
-			type: 'snackbar',
-		} );
-		goTo( '/navigation' );
+	const handleDelete = async () => {
+		try {
+			await deleteEntityRecord( 'postType', postType, postId, {
+				force: true,
+			} );
+			createSuccessNotice( __( 'Deleted Navigation menu' ), {
+				type: 'snackbar',
+			} );
+			goTo( '/navigation' );
+		} catch ( error ) {
+			createErrorNotice(
+				sprintf(
+					/* translators: %s: error message describing why the navigation menu could not be deleted. */
+					__( `Unable to delete Navigation menu (%s).` ),
+					error
+				),
+
+				{
+					type: 'snackbar',
+				}
+			);
+		}
 	};
 	const handleDuplicate = async () => {
 		const savedRecord = await saveEntityRecord( 'postType', postType, {

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/index.js
@@ -72,7 +72,9 @@ export default function SidebarNavigationScreenNavigationMenu() {
 
 		// Attempt to persist.
 		try {
-			await saveEditedEntityRecord( 'postType', postType, postId );
+			await saveEditedEntityRecord( 'postType', postType, postId, {
+				throwOnError: true,
+			} );
 			createSuccessNotice( __( 'Renamed Navigation menu' ), {
 				type: 'snackbar',
 			} );
@@ -96,9 +98,17 @@ export default function SidebarNavigationScreenNavigationMenu() {
 
 	const handleDelete = async () => {
 		try {
-			await deleteEntityRecord( 'postType', postType, postId, {
-				force: true,
-			} );
+			await deleteEntityRecord(
+				'postType',
+				postType,
+				postId,
+				{
+					force: true,
+				},
+				{
+					throwOnError: true,
+				}
+			);
 			createSuccessNotice( __( 'Deleted Navigation menu' ), {
 				type: 'snackbar',
 			} );
@@ -118,11 +128,18 @@ export default function SidebarNavigationScreenNavigationMenu() {
 		}
 	};
 	const handleDuplicate = async () => {
-		const savedRecord = await saveEntityRecord( 'postType', postType, {
-			title: menuTitle + __( ' (Copy)' ),
-			content: navigationMenu?.content?.raw,
-			status: 'publish',
-		} );
+		const savedRecord = await saveEntityRecord(
+			'postType',
+			postType,
+			{
+				title: menuTitle + __( ' (Copy)' ),
+				content: navigationMenu?.content?.raw,
+				status: 'publish',
+			},
+			{
+				throwOnError: true,
+			}
+		);
 		if ( savedRecord ) {
 			createSuccessNotice( __( 'Duplicated Navigation menu' ), {
 				type: 'snackbar',

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/more-menu.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/more-menu.js
@@ -1,0 +1,108 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+	Button,
+	DropdownMenu,
+	TextControl,
+	MenuItem,
+	MenuGroup,
+	Modal,
+} from '@wordpress/components';
+import { moreVertical } from '@wordpress/icons';
+import { __ } from '@wordpress/i18n';
+
+const POPOVER_PROPS = {
+	position: 'bottom right',
+	variant: 'toolbar',
+};
+
+export default function ScreenNavigationMoreMenu( props ) {
+	const {
+		isOpen,
+		setOpen,
+		handleDelete,
+		handleSave,
+		handleChange,
+		handleDuplicate,
+		editedMenuTitle,
+	} = props;
+	const closeModal = () => setOpen( false );
+	const openModal = () => setOpen( true );
+
+	return (
+		<>
+			<DropdownMenu
+				className="sidebar-navigation__more-menu"
+				icon={ moreVertical }
+				popoverProps={ POPOVER_PROPS }
+			>
+				{ ( { onClose } ) => (
+					<div>
+						<MenuGroup>
+							<MenuItem
+								onClick={ () => {
+									openModal();
+									onClose();
+								} }
+							>
+								{ __( 'Rename' ) }
+							</MenuItem>
+							<MenuItem
+								onClick={ () => {
+									handleDuplicate();
+									onClose();
+								} }
+							>
+								{ __( 'Duplicate' ) }
+							</MenuItem>
+							<MenuItem
+								isDestructive
+								isTertiary
+								onClick={ () => {
+									handleDelete();
+									onClose();
+								} }
+							>
+								{ __( 'Delete' ) }
+							</MenuItem>
+						</MenuGroup>
+					</div>
+				) }
+			</DropdownMenu>
+
+			{ isOpen && (
+				<Modal title="Rename" onRequestClose={ closeModal }>
+					<form>
+						<VStack spacing="3">
+							<TextControl
+								__nextHasNoMarginBottom
+								value={ editedMenuTitle }
+								placeholder={ __( 'Navigation title' ) }
+								onChange={ handleChange }
+							/>
+							<HStack justify="right">
+								<Button
+									variant="tertiary"
+									onClick={ closeModal }
+								>
+									{ __( 'Cancel' ) }
+								</Button>
+
+								<Button
+									variant="primary"
+									type="submit"
+									onClick={ handleSave }
+								>
+									{ __( 'Save' ) }
+								</Button>
+							</HStack>
+						</VStack>
+					</form>
+				</Modal>
+			) }
+		</>
+	);
+}

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/more-menu.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/more-menu.js
@@ -70,7 +70,7 @@ export default function ScreenNavigationMoreMenu( props ) {
 				<RenameModal
 					onClose={ closeRenameModal }
 					menuTitle={ menuTitle }
-					handleSave={ handleSave }
+					onSave={ handleSave }
 				/>
 			) }
 		</>

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/more-menu.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/more-menu.js
@@ -4,6 +4,7 @@
 import { DropdownMenu, MenuItem, MenuGroup } from '@wordpress/components';
 import { moreVertical } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
+import { useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -16,16 +17,12 @@ const POPOVER_PROPS = {
 };
 
 export default function ScreenNavigationMoreMenu( props ) {
-	const {
-		isOpen,
-		setOpen,
-		handleDelete,
-		handleSave,
-		handleDuplicate,
-		menuTitle,
-	} = props;
-	const closeModal = () => setOpen( false );
-	const openModal = () => setOpen( true );
+	const { handleDelete, handleSave, handleDuplicate, menuTitle } = props;
+
+	const [ renameModalOpen, setRenameModalOpen ] = useState( false );
+
+	const closeRenameModal = () => setRenameModalOpen( false );
+	const openRenameModal = () => setRenameModalOpen( true );
 
 	return (
 		<>
@@ -39,7 +36,8 @@ export default function ScreenNavigationMoreMenu( props ) {
 						<MenuGroup>
 							<MenuItem
 								onClick={ () => {
-									openModal();
+									openRenameModal();
+									// Close the dropdown after opening the modal.
 									onClose();
 								} }
 							>
@@ -68,9 +66,9 @@ export default function ScreenNavigationMoreMenu( props ) {
 				) }
 			</DropdownMenu>
 
-			{ isOpen && (
+			{ renameModalOpen && (
 				<RenameModal
-					onClose={ closeModal }
+					onClose={ closeRenameModal }
 					menuTitle={ menuTitle }
 					handleSave={ handleSave }
 				/>

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/more-menu.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/more-menu.js
@@ -21,7 +21,7 @@ export default function ScreenNavigationMoreMenu( props ) {
 		setOpen,
 		handleDelete,
 		handleSave,
-		handleChange,
+		onChange,
 		handleDuplicate,
 		editedMenuTitle,
 	} = props;
@@ -72,7 +72,7 @@ export default function ScreenNavigationMoreMenu( props ) {
 			{ isOpen && (
 				<RenameModal
 					onClose={ closeModal }
-					handleChange={ handleChange }
+					onChange={ onChange }
 					handleSave={ handleSave }
 					editedMenuTitle={ editedMenuTitle }
 				/>

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/more-menu.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/more-menu.js
@@ -14,7 +14,6 @@ import DeleteModal from './delete-modal';
 
 const POPOVER_PROPS = {
 	position: 'bottom right',
-	variant: 'toolbar',
 };
 
 export default function ScreenNavigationMoreMenu( props ) {

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/more-menu.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/more-menu.js
@@ -21,9 +21,8 @@ export default function ScreenNavigationMoreMenu( props ) {
 		setOpen,
 		handleDelete,
 		handleSave,
-		onChange,
 		handleDuplicate,
-		editedMenuTitle,
+		menuTitle,
 	} = props;
 	const closeModal = () => setOpen( false );
 	const openModal = () => setOpen( true );
@@ -72,9 +71,8 @@ export default function ScreenNavigationMoreMenu( props ) {
 			{ isOpen && (
 				<RenameModal
 					onClose={ closeModal }
-					onChange={ onChange }
+					menuTitle={ menuTitle }
 					handleSave={ handleSave }
-					editedMenuTitle={ editedMenuTitle }
 				/>
 			) }
 		</>

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/more-menu.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/more-menu.js
@@ -1,18 +1,14 @@
 /**
  * WordPress dependencies
  */
-import {
-	__experimentalHStack as HStack,
-	__experimentalVStack as VStack,
-	Button,
-	DropdownMenu,
-	TextControl,
-	MenuItem,
-	MenuGroup,
-	Modal,
-} from '@wordpress/components';
+import { DropdownMenu, MenuItem, MenuGroup } from '@wordpress/components';
 import { moreVertical } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import RenameModal from './rename-modal';
 
 const POPOVER_PROPS = {
 	position: 'bottom right',
@@ -74,34 +70,12 @@ export default function ScreenNavigationMoreMenu( props ) {
 			</DropdownMenu>
 
 			{ isOpen && (
-				<Modal title="Rename" onRequestClose={ closeModal }>
-					<form>
-						<VStack spacing="3">
-							<TextControl
-								__nextHasNoMarginBottom
-								value={ editedMenuTitle }
-								placeholder={ __( 'Navigation title' ) }
-								onChange={ handleChange }
-							/>
-							<HStack justify="right">
-								<Button
-									variant="tertiary"
-									onClick={ closeModal }
-								>
-									{ __( 'Cancel' ) }
-								</Button>
-
-								<Button
-									variant="primary"
-									type="submit"
-									onClick={ handleSave }
-								>
-									{ __( 'Save' ) }
-								</Button>
-							</HStack>
-						</VStack>
-					</form>
-				</Modal>
+				<RenameModal
+					onClose={ closeModal }
+					handleChange={ handleChange }
+					handleSave={ handleSave }
+					editedMenuTitle={ editedMenuTitle }
+				/>
 			) }
 		</>
 	);

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/more-menu.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/more-menu.js
@@ -17,7 +17,7 @@ const POPOVER_PROPS = {
 };
 
 export default function ScreenNavigationMoreMenu( props ) {
-	const { handleDelete, handleSave, handleDuplicate, menuTitle } = props;
+	const { onDelete, onSave, onDuplicate, menuTitle } = props;
 
 	const [ renameModalOpen, setRenameModalOpen ] = useState( false );
 
@@ -45,7 +45,7 @@ export default function ScreenNavigationMoreMenu( props ) {
 							</MenuItem>
 							<MenuItem
 								onClick={ () => {
-									handleDuplicate();
+									onDuplicate();
 									onClose();
 								} }
 							>
@@ -55,7 +55,7 @@ export default function ScreenNavigationMoreMenu( props ) {
 								isDestructive
 								isTertiary
 								onClick={ () => {
-									handleDelete();
+									onDelete();
 									onClose();
 								} }
 							>
@@ -70,7 +70,7 @@ export default function ScreenNavigationMoreMenu( props ) {
 				<RenameModal
 					onClose={ closeRenameModal }
 					menuTitle={ menuTitle }
-					onSave={ handleSave }
+					onSave={ onSave }
 				/>
 			) }
 		</>

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/more-menu.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/more-menu.js
@@ -10,6 +10,7 @@ import { useState } from '@wordpress/element';
  * Internal dependencies
  */
 import RenameModal from './rename-modal';
+import DeleteModal from './delete-modal';
 
 const POPOVER_PROPS = {
 	position: 'bottom right',
@@ -20,9 +21,14 @@ export default function ScreenNavigationMoreMenu( props ) {
 	const { onDelete, onSave, onDuplicate, menuTitle } = props;
 
 	const [ renameModalOpen, setRenameModalOpen ] = useState( false );
+	const [ deleteModalOpen, setDeleteModalOpen ] = useState( false );
 
-	const closeRenameModal = () => setRenameModalOpen( false );
+	const closeModals = () => {
+		setRenameModalOpen( false );
+		setDeleteModalOpen( false );
+	};
 	const openRenameModal = () => setRenameModalOpen( true );
+	const openDeleteModal = () => setDeleteModalOpen( true );
 
 	return (
 		<>
@@ -55,7 +61,9 @@ export default function ScreenNavigationMoreMenu( props ) {
 								isDestructive
 								isTertiary
 								onClick={ () => {
-									onDelete();
+									openDeleteModal();
+
+									// Close the dropdown after opening the modal.
 									onClose();
 								} }
 							>
@@ -66,9 +74,13 @@ export default function ScreenNavigationMoreMenu( props ) {
 				) }
 			</DropdownMenu>
 
+			{ deleteModalOpen && (
+				<DeleteModal onClose={ closeModals } onConfirm={ onDelete } />
+			) }
+
 			{ renameModalOpen && (
 				<RenameModal
-					onClose={ closeRenameModal }
+					onClose={ closeModals }
 					menuTitle={ menuTitle }
 					onSave={ onSave }
 				/>

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/rename-modal.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/rename-modal.js
@@ -11,7 +11,7 @@ import {
 import { __ } from '@wordpress/i18n';
 import { useState } from '@wordpress/element';
 
-export default function RenameModal( { onClose, menuTitle, handleSave } ) {
+export default function RenameModal( { menuTitle, onClose, onSave } ) {
 	const [ editedMenuTitle, setEditedMenuTitle ] = useState( menuTitle );
 
 	return (
@@ -30,11 +30,14 @@ export default function RenameModal( { onClose, menuTitle, handleSave } ) {
 						</Button>
 
 						<Button
+							disabled={ editedMenuTitle === menuTitle }
 							variant="primary"
 							type="submit"
 							onClick={ ( e ) => {
 								e.preventDefault();
-								handleSave( { title: editedMenuTitle } );
+								onSave( { title: editedMenuTitle } );
+
+								// Immediate close avoids ability to hit save multiple times.
 								onClose();
 							} }
 						>

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/rename-modal.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/rename-modal.js
@@ -13,7 +13,7 @@ import { __ } from '@wordpress/i18n';
 export default function RenameModal( {
 	onClose,
 	editedMenuTitle,
-	handleChange,
+	onChange,
 	handleSave,
 } ) {
 	return (
@@ -24,7 +24,7 @@ export default function RenameModal( {
 						__nextHasNoMarginBottom
 						value={ editedMenuTitle }
 						placeholder={ __( 'Navigation title' ) }
-						onChange={ handleChange }
+						onChange={ onChange }
 					/>
 					<HStack justify="right">
 						<Button variant="tertiary" onClick={ onClose }>

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/rename-modal.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/rename-modal.js
@@ -1,0 +1,46 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+	Button,
+	TextControl,
+	Modal,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+export default function RenameModal( {
+	onClose,
+	editedMenuTitle,
+	handleChange,
+	handleSave,
+} ) {
+	return (
+		<Modal title="Rename" onRequestClose={ onClose }>
+			<form>
+				<VStack spacing="3">
+					<TextControl
+						__nextHasNoMarginBottom
+						value={ editedMenuTitle }
+						placeholder={ __( 'Navigation title' ) }
+						onChange={ handleChange }
+					/>
+					<HStack justify="right">
+						<Button variant="tertiary" onClick={ onClose }>
+							{ __( 'Cancel' ) }
+						</Button>
+
+						<Button
+							variant="primary"
+							type="submit"
+							onClick={ handleSave }
+						>
+							{ __( 'Save' ) }
+						</Button>
+					</HStack>
+				</VStack>
+			</form>
+		</Modal>
+	);
+}

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/rename-modal.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/rename-modal.js
@@ -12,7 +12,6 @@ import { __ } from '@wordpress/i18n';
 import { useState } from '@wordpress/element';
 
 export default function RenameModal( { onClose, menuTitle, handleSave } ) {
-	// create local state to store the editedMenuTitle
 	const [ editedMenuTitle, setEditedMenuTitle ] = useState( menuTitle );
 
 	return (
@@ -36,6 +35,7 @@ export default function RenameModal( { onClose, menuTitle, handleSave } ) {
 							onClick={ ( e ) => {
 								e.preventDefault();
 								handleSave( { title: editedMenuTitle } );
+								onClose();
 							} }
 						>
 							{ __( 'Save' ) }

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/rename-modal.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/rename-modal.js
@@ -15,7 +15,7 @@ export default function RenameModal( { menuTitle, onClose, onSave } ) {
 	const [ editedMenuTitle, setEditedMenuTitle ] = useState( menuTitle );
 
 	return (
-		<Modal title="Rename" onRequestClose={ onClose }>
+		<Modal title={ __( 'Rename' ) } onRequestClose={ onClose }>
 			<form>
 				<VStack spacing="3">
 					<TextControl

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/rename-modal.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/rename-modal.js
@@ -9,13 +9,12 @@ import {
 	Modal,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { useState } from '@wordpress/element';
 
-export default function RenameModal( {
-	onClose,
-	editedMenuTitle,
-	onChange,
-	handleSave,
-} ) {
+export default function RenameModal( { onClose, menuTitle, handleSave } ) {
+	// create local state to store the editedMenuTitle
+	const [ editedMenuTitle, setEditedMenuTitle ] = useState( menuTitle );
+
 	return (
 		<Modal title="Rename" onRequestClose={ onClose }>
 			<form>
@@ -24,7 +23,7 @@ export default function RenameModal( {
 						__nextHasNoMarginBottom
 						value={ editedMenuTitle }
 						placeholder={ __( 'Navigation title' ) }
-						onChange={ onChange }
+						onChange={ setEditedMenuTitle }
 					/>
 					<HStack justify="right">
 						<Button variant="tertiary" onClick={ onClose }>
@@ -34,7 +33,10 @@ export default function RenameModal( {
 						<Button
 							variant="primary"
 							type="submit"
-							onClick={ handleSave }
+							onClick={ ( e ) => {
+								e.preventDefault();
+								handleSave( { title: editedMenuTitle } );
+							} }
 						>
 							{ __( 'Save' ) }
 						</Button>

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/rename-modal.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/rename-modal.js
@@ -16,7 +16,7 @@ export default function RenameModal( { menuTitle, onClose, onSave } ) {
 
 	return (
 		<Modal title={ __( 'Rename' ) } onRequestClose={ onClose }>
-			<form>
+			<form className="sidebar-navigation__rename-modal-form">
 				<VStack spacing="3">
 					<TextControl
 						__nextHasNoMarginBottom

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/style.scss
@@ -1,0 +1,10 @@
+.sidebar-navigation__more-menu {
+	.components-button {
+		color: $gray-600;
+		&:hover,
+		&:focus,
+		&[aria-current] {
+			color: $white;
+		}
+	}
+}

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/style.scss
@@ -8,3 +8,8 @@
 		}
 	}
 }
+
+.sidebar-navigation__rename-modal-form {
+	// Fix for input focus style being cut off by the modal.
+	padding-top: 1px;
+}

--- a/packages/edit-site/src/style.scss
+++ b/packages/edit-site/src/style.scss
@@ -28,7 +28,9 @@
 @import "./components/sidebar-navigation-item/style.scss";
 @import "./components/sidebar-navigation-screen/style.scss";
 @import "./components/sidebar-navigation-screen-global-styles/style.scss";
+@import "./components/sidebar-navigation-screen-navigation-menu/style.scss";
 @import "./components/sidebar-navigation-screen-page/style.scss";
+@import "./components/sidebar-navigation-screen-pages/style.scss";
 @import "./components/sidebar-navigation-screen-template/style.scss";
 @import "./components/sidebar-navigation-screen-templates/style.scss";
 @import "./components/sidebar-navigation-subtitle/style.scss";

--- a/packages/edit-site/src/style.scss
+++ b/packages/edit-site/src/style.scss
@@ -30,7 +30,6 @@
 @import "./components/sidebar-navigation-screen-global-styles/style.scss";
 @import "./components/sidebar-navigation-screen-navigation-menu/style.scss";
 @import "./components/sidebar-navigation-screen-page/style.scss";
-@import "./components/sidebar-navigation-screen-pages/style.scss";
 @import "./components/sidebar-navigation-screen-template/style.scss";
 @import "./components/sidebar-navigation-screen-templates/style.scss";
 @import "./components/sidebar-navigation-subtitle/style.scss";


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Following the UX suggested in https://github.com/WordPress/gutenberg/issues/50583 this PR implements a new ellipsis menu in browse mode that allows us to rename, duplicate and delete menus

Closes https://github.com/WordPress/gutenberg/issues/50583

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Some of these actions were not available to the user yet.

~This is part of the effort to improve [Navigation on browse mode](https://github.com/WordPress/gutenberg/issues/50396).~

This PR has subsequently undergone several revisions and so it should be in a good state.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

- Add more menu
- Add actions for rename, duplicate and delete.
- Rename has a modal with local state so that edits can be cancelled on modal dismiss.
- Delete has a confirmatory modal state to avoid accidentally destructive actions.

## Follow Ups

The following items would be good for a followup.

- I think we could improve the loading states for when actions are triggered. For example:
    - not defaulting to displaying `Navigation` at the top of the panel when something is changing
    - show instant feedback when duplicating a menu (currently there is a short delay)
    - possibly optimistically navigating to `/navigation` and then reverting on error.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

- Using the new three dot menu, test that you can rename a Navigation menu, duplicate it and delete it.
- Check you can achieve all this with a keyboard only.
- Check that all cancel states work.
- Now repeat the steps above but this time observe the Network tab and block the relevant requests and then retry the action to see the error handling. Note that you can edit the blocked url in dev tools block list in order to substitude IDs .etc.


## Screenshots or screencast <!-- if applicable -->


https://github.com/WordPress/gutenberg/assets/444434/fff062d0-4f67-49a9-9995-8cc31509add4



Co-authored-by: Dave Smith <444434+getdave@users.noreply.github.com>