### PR TITLE
Comment Template Block: Retain inner blocks inserted via render_block_data filter

### DIFF
--- a/packages/block-library/src/comment-template/index.php
+++ b/packages/block-library/src/comment-template/index.php
@@ -30,8 +30,20 @@ function block_core_comment_template_render_comments( $comments, $block ) {
 			$context['commentId'] = $comment_id;
 			return $context;
 		};
+
+		/*
+		 * We set commentId context through the `render_block_context` filter so
+		 * that dynamically inserted blocks (at `render_block` filter stage)
+		 * will also receive that context.
+		 */
 		add_filter( 'render_block_context', $filter_block_context );
-		$block_content = $block->render( array( 'dynamic' => false ) );
+
+		/*
+		 * We construct a new WP_Block instance from the parsed block so that
+		 * it'll receive any changes made by the `render_block_data` filter.
+		 */
+		$block_content = ( new WP_Block( $block->parsed_block ) )->render( array( 'dynamic' => false ) );
+
 		remove_filter( 'render_block_context', $filter_block_context );
 
 		$children = $comment->get_children();

--- a/phpunit/blocks/render-comment-template-test.php
+++ b/phpunit/blocks/render-comment-template-test.php
@@ -121,4 +121,45 @@ class Tests_Blocks_RenderCommentTemplateBlock extends WP_UnitTestCase {
 			"Rendered markup doesn't contain Comment Author Name block."
 		);
 	}
+
+	public function test_inner_block_inserted_by_render_block_data_is_retained() {
+		$render_block_callback = new MockAction();
+		add_filter( 'render_block', array( $render_block_callback, 'filter' ), 10, 3 );
+
+		$render_block_data_callback = static function( $parsed_block ) {
+			// Add a Social Links block to a Comment Template block's inner blocks.
+			if ( 'core/comment-template' === $parsed_block['blockName'] ) {
+				$inserted_block_markup = <<<END
+<!-- wp:social-links -->
+<ul class="wp-block-social-links"><!-- wp:social-link {"url":"https://wordpress.org","service":"wordpress"} /--></ul>
+<!-- /wp:social-links -->'
+END;
+
+				$inserted_blocks = parse_blocks( $inserted_block_markup );
+
+				$parsed_block['innerBlocks'][] = $inserted_blocks[0];
+			}
+			return $parsed_block;
+		};
+
+		add_filter( 'render_block_data', $render_block_data_callback, 10, 1 );
+		$parsed_blocks = parse_blocks(
+			'<!-- wp:comments --><!-- wp:comment-template --><!-- wp:comment-content /--><!-- /wp:comment-template --><!-- /wp:comments -->'
+		);
+		$block         = new WP_Block(
+			$parsed_blocks[0],
+			array(
+				'postId' => self::$custom_post->ID,
+			)
+		);
+		$block->render();
+		remove_filter( 'render_block_data', $render_block_data_callback );
+
+		$this->assertSame( 5, $render_block_callback->get_call_count() );
+
+		$args = $render_block_callback->get_args();
+		$this->assertSame( 'core/comment-content', $args[0][2]->name );
+		$this->assertSame( 'core/comment-template', $args[1][2]->name );
+		$this->assertCount( 2, $args[1][2]->inner_blocks, "Inner block inserted by render_block_data filter wasn't retained." );
+	}
 }

--- a/phpunit/blocks/render-comment-template-test.php
+++ b/phpunit/blocks/render-comment-template-test.php
@@ -161,5 +161,15 @@ END;
 		$this->assertSame( 'core/comment-content', $args[0][2]->name );
 		$this->assertSame( 'core/comment-template', $args[1][2]->name );
 		$this->assertCount( 2, $args[1][2]->inner_blocks, "Inner block inserted by render_block_data filter wasn't retained." );
+		$this->assertInstanceOf(
+			'WP_Block',
+			$args[1][2]->inner_blocks[1],
+			"Inner block inserted by render_block_data isn't a WP_Block class instance."
+		);
+		$this->assertSame(
+			'core/social-links',
+			$args[1][2]->inner_blocks[1]->name,
+			"Inner block inserted by render_block_data isn't named as expected."
+		);
 	}
 }


### PR DESCRIPTION
## What?
Add a unit test to verify that an inner block added to a given Comment Template block via the `render_block_data` filter is retained at `render_block` time.  Then, change the block's code to actually retain those modifications from `render_block_data`.

Follow up to https://github.com/WordPress/gutenberg/pull/50279.

## Why?
See https://github.com/WordPress/gutenberg/pull/50279/files#r1184916607.

## How?
The unit test: By adding a `render_block_data` filter to insert a Social Icons block, and a filter mock to the `render_block` hook to check the length of the Comment Template block's inner blocks.

The fix: By creating a new `WP_Block` instance from the parsed block (similar to how we did things before #50279; however, we continue to set block context via the `render_block_context` filter).

## Testing Instructions

See CI. Locally, this can be tested via `npm run test:unit:php -- --group=blocks`.
