### PR TITLE
Removed `gutenberg` Directory Name Expectation

### DIFF
--- a/packages/env/lib/config/test/config-integration.js
+++ b/packages/env/lib/config/test/config-integration.js
@@ -3,7 +3,6 @@
 /**
  * External dependencies
  */
-const path = require( 'path' );
 const { readFile } = require( 'fs' ).promises;
 
 /**
@@ -80,7 +79,7 @@ describe( 'Config Integration', () => {
 			throw { code: 'ENOENT' };
 		} );
 
-		const config = await loadConfig( path.resolve( '/test/gutenberg' ) );
+		const config = await loadConfig( '/test/gutenberg' );
 
 		expect( config.env.development.port ).toEqual( 123 );
 		expect( config.env.tests.port ).toEqual( 8889 );
@@ -116,7 +115,7 @@ describe( 'Config Integration', () => {
 			throw { code: 'ENOENT' };
 		} );
 
-		const config = await loadConfig( path.resolve( '/test/gutenberg' ) );
+		const config = await loadConfig( '/test/gutenberg' );
 
 		expect( config.env.development.port ).toEqual( 999 );
 		expect( config.env.tests.port ).toEqual( 456 );
@@ -151,7 +150,7 @@ describe( 'Config Integration', () => {
 			throw { code: 'ENOENT' };
 		} );
 
-		const config = await loadConfig( path.resolve( '/test/gutenberg' ) );
+		const config = await loadConfig( '/test/gutenberg' );
 
 		expect( config.env.development.port ).toEqual( 12345 );
 		expect( config.env.tests.port ).toEqual( 61234 );

--- a/packages/env/lib/config/test/parse-source-string.js
+++ b/packages/env/lib/config/test/parse-source-string.js
@@ -45,7 +45,7 @@ describe( 'parseSourceString', () => {
 	describe( 'local sources', () => {
 		it( 'should parse relative directories', () => {
 			expect( parseSourceString( '.', options ) ).toEqual( {
-				basename: 'gutenberg',
+				basename: path.basename( path.resolve( '.' ) ),
 				path: path.resolve( '.' ),
 				type: 'local',
 			} );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Some of the `wp-env` unit tests fail when the developer has Gutenberg checked out into another directory.

Closes #50800.

## Why?

The tests were using `path.resolve()` in many places but expecting `parseSourceString()` to set the `basename` to `gutenberg`. Since the `basename` comes from the directory name, this doesn't work when the directory is renamed.

## How?

Removes the relative paths and updates tests to work without `gutenberg` being the base name. I initially took a look at mocking `parseSourceString()` but it is used in so many places that it was unwieldy.

## Testing Instructions
1. Run `npm run test:unit packages/env` with the directory being `gutenberg`.
2. Rename your Gutenberg directory temporarily
3. Run `npm run test:unit packages/env` again, confirm that tests still pass.