### PR TITLE
Fixed `wp-env start` On Windows

### DIFF
--- a/packages/env/CHANGELOG.md
+++ b/packages/env/CHANGELOG.md
@@ -17,6 +17,10 @@
 -   Support using double dashes in `wp-env run ...` to pass arguments that would otherwise be consumed by `wp-env`. For example, while normally `--help` would provide the `wp-env` help text, if you use `npx wp-env run cli php -- --help` you will see the PHP help text.
 -   Validate whether or not config options exist to prevent accidentally including ones that don't.
 
+### Bug fix
+
+-   Support Windows without requiring the use of WSL.
+
 ## 7.0.0 (2023-05-10)
 
 ### Breaking Change

--- a/packages/env/lib/commands/run.js
+++ b/packages/env/lib/commands/run.js
@@ -67,8 +67,9 @@ function spawnCommandDirectly( config, container, command, envCwd, spinner ) {
 	// to interact with the files mounted from the host.
 	const hostUser = getHostUser();
 
-	// We need to pass absolute paths to the container.
-	envCwd = path.resolve(
+	// Since Docker requires absolute paths, we should resolve the input to a POSIX path.
+	// This is needed because Windows resolves relative paths from the C: drive.
+	envCwd = path.posix.resolve(
 		// Not all containers have the same starting working directory.
 		container === 'mysql' || container === 'tests-mysql'
 			? '/'

--- a/packages/env/lib/config/parse-config.js
+++ b/packages/env/lib/config/parse-config.js
@@ -87,6 +87,7 @@ const DEFAULT_ENVIRONMENT_CONFIG = {
 	testsPort: 8889,
 	mappings: {},
 	config: {
+		FS_METHOD: 'direct',
 		WP_DEBUG: true,
 		SCRIPT_DEBUG: true,
 		WP_ENVIRONMENT_TYPE: 'local',
@@ -233,7 +234,10 @@ async function getDefaultConfig(
 		env: {
 			development: {},
 			tests: {
-				config: { WP_DEBUG: false, SCRIPT_DEBUG: false },
+				config: {
+					WP_DEBUG: false,
+					SCRIPT_DEBUG: false,
+				},
 			},
 		},
 	};

--- a/packages/env/lib/config/test/__snapshots__/config-integration.js.snap
+++ b/packages/env/lib/config/test/__snapshots__/config-integration.js.snap
@@ -8,6 +8,7 @@ exports[`Config Integration should load local and override configuration files 1
   "env": {
     "development": {
       "config": {
+        "FS_METHOD": "direct",
         "SCRIPT_DEBUG": true,
         "WP_DEBUG": true,
         "WP_ENVIRONMENT_TYPE": "local",
@@ -35,6 +36,7 @@ exports[`Config Integration should load local and override configuration files 1
     },
     "tests": {
       "config": {
+        "FS_METHOD": "direct",
         "SCRIPT_DEBUG": false,
         "WP_DEBUG": false,
         "WP_ENVIRONMENT_TYPE": "local",
@@ -79,6 +81,7 @@ exports[`Config Integration should load local configuration file 1`] = `
   "env": {
     "development": {
       "config": {
+        "FS_METHOD": "direct",
         "SCRIPT_DEBUG": true,
         "WP_DEBUG": true,
         "WP_ENVIRONMENT_TYPE": "local",
@@ -106,6 +109,7 @@ exports[`Config Integration should load local configuration file 1`] = `
     },
     "tests": {
       "config": {
+        "FS_METHOD": "direct",
         "SCRIPT_DEBUG": false,
         "WP_DEBUG": false,
         "WP_ENVIRONMENT_TYPE": "local",
@@ -150,6 +154,7 @@ exports[`Config Integration should use default configuration 1`] = `
   "env": {
     "development": {
       "config": {
+        "FS_METHOD": "direct",
         "SCRIPT_DEBUG": true,
         "WP_DEBUG": true,
         "WP_ENVIRONMENT_TYPE": "local",
@@ -177,6 +182,7 @@ exports[`Config Integration should use default configuration 1`] = `
     },
     "tests": {
       "config": {
+        "FS_METHOD": "direct",
         "SCRIPT_DEBUG": false,
         "WP_DEBUG": false,
         "WP_ENVIRONMENT_TYPE": "local",
@@ -221,6 +227,7 @@ exports[`Config Integration should use environment variables over local and over
   "env": {
     "development": {
       "config": {
+        "FS_METHOD": "direct",
         "SCRIPT_DEBUG": true,
         "WP_DEBUG": true,
         "WP_ENVIRONMENT_TYPE": "local",
@@ -249,6 +256,7 @@ exports[`Config Integration should use environment variables over local and over
     },
     "tests": {
       "config": {
+        "FS_METHOD": "direct",
         "SCRIPT_DEBUG": false,
         "WP_DEBUG": false,
         "WP_ENVIRONMENT_TYPE": "local",

--- a/packages/env/lib/config/test/parse-config.js
+++ b/packages/env/lib/config/test/parse-config.js
@@ -40,6 +40,7 @@ const DEFAULT_CONFIG = {
 	pluginSources: [],
 	themeSources: [],
 	config: {
+		FS_METHOD: 'direct',
 		WP_DEBUG: true,
 		SCRIPT_DEBUG: true,
 		WP_ENVIRONMENT_TYPE: 'local',

--- a/packages/env/lib/get-host-user.js
+++ b/packages/env/lib/get-host-user.js
@@ -13,14 +13,10 @@ module.exports = function getHostUser() {
 	const hostUser = os.userInfo();
 
 	// On Windows the uid and gid will be -1. Since there isn't a great way to handle this,
-	// we're just going to say that the host user is root. On Windows you'll likely be
-	// using WSL to run commands inside the container, which has a uid and gid. If
-	// you aren't, you'll be mounting directories from Windows, to a Linux
-	// VM (Docker Desktop uses one), to the guest OS. I assume that
-	// when dealing with this configuration that file ownership
-	// has the same kind of magic handling that macOS uses.
-	const uid = ( hostUser.uid === -1 ? 0 : hostUser.uid ).toString();
-	const gid = ( hostUser.gid === -1 ? 0 : hostUser.gid ).toString();
+	// we're just going to assign them to 1000. Docker Desktop already takes care of
+	// permission-related issues using magic, so this should be fine.
+	const uid = ( hostUser.uid === -1 ? 1000 : hostUser.uid ).toString();
+	const gid = ( hostUser.gid === -1 ? 1000 : hostUser.gid ).toString();
 
 	return {
 		name: hostUser.username,

--- a/packages/env/lib/init-config.js
+++ b/packages/env/lib/init-config.js
@@ -207,8 +207,13 @@ RUN echo "$HOST_USERNAME ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers`;
 		}
 		case 'cli': {
 			dockerFileContent += `
+# Make sure we're working with the latest packages.
 RUN apk update
+
+# Install some basic PHP dependencies.
 RUN apk --no-cache add $PHPIZE_DEPS && touch /usr/local/etc/php/php.ini
+
+# Set up sudo so they can have root access.
 RUN apk --no-cache add sudo linux-headers
 RUN echo "$HOST_USERNAME ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers`;
 			break;
@@ -238,7 +243,7 @@ RUN rm /tmp/composer-setup.php`;
 	// Install any Composer packages we might need globally.
 	// Make sure to do this as the user and ensure the binaries are available in the $PATH.
 	dockerFileContent += `
-USER $HOST_USERNAME
+USER $HOST_UID:$HOST_GID
 ENV PATH="\${PATH}:/home/$HOST_USERNAME/.composer/vendor/bin"
 RUN composer global require --dev yoast/phpunit-polyfills:"^1.0"
 USER root`;

--- a/packages/env/lib/init-config.js
+++ b/packages/env/lib/init-config.js
@@ -244,7 +244,7 @@ RUN rm /tmp/composer-setup.php`;
 	// Make sure to do this as the user and ensure the binaries are available in the $PATH.
 	dockerFileContent += `
 USER $HOST_UID:$HOST_GID
-ENV PATH="\${PATH}:/home/$HOST_USERNAME/.composer/vendor/bin"
+ENV PATH="\${PATH}:~/.composer/vendor/bin"
 RUN composer global require --dev yoast/phpunit-polyfills:"^1.0"
 USER root`;
 

--- a/packages/env/lib/init-config.js
+++ b/packages/env/lib/init-config.js
@@ -202,7 +202,7 @@ RUN apt-get -qy install $PHPIZE_DEPS && touch /usr/local/etc/php/php.ini
 
 # Set up sudo so they can have root access.
 RUN apt-get -qy install sudo
-RUN echo "$HOST_USERNAME ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers`;
+RUN echo "$( whoami ) ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers`;
 			break;
 		}
 		case 'cli': {
@@ -215,7 +215,7 @@ RUN apk --no-cache add $PHPIZE_DEPS && touch /usr/local/etc/php/php.ini
 
 # Set up sudo so they can have root access.
 RUN apk --no-cache add sudo linux-headers
-RUN echo "$HOST_USERNAME ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers`;
+RUN echo "$( whoami ) ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers`;
 			break;
 		}
 		default: {

--- a/packages/env/lib/init-config.js
+++ b/packages/env/lib/init-config.js
@@ -202,7 +202,7 @@ RUN apt-get -qy install $PHPIZE_DEPS && touch /usr/local/etc/php/php.ini
 
 # Set up sudo so they can have root access.
 RUN apt-get -qy install sudo
-RUN echo "$( whoami ) ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers`;
+RUN echo "#$HOST_UID ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers`;
 			break;
 		}
 		case 'cli': {
@@ -215,7 +215,7 @@ RUN apk --no-cache add $PHPIZE_DEPS && touch /usr/local/etc/php/php.ini
 
 # Set up sudo so they can have root access.
 RUN apk --no-cache add sudo linux-headers
-RUN echo "$( whoami ) ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers`;
+RUN echo "#$HOST_UID ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers`;
 			break;
 		}
 		default: {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

This pull request assigns an arbitrary `uid` and `gid` of `1000` when running `wp-env` from Windows natively (without using WSL).

Closes #50814.

## Why?

When we fixed the permission-related problems we introduced an incompatibility when running `wp-env` using Windows natively. While it _does_ work with WSL, when used natively, the `uid` and `gid` are `-1`. We handled this case by assigning it a `uid` and `gid` of `0`, but, this introduced other problems with trying to run everything as `root`.

## How?

We just assign an arbitrary `uid` and `gid`. This _should_ work fine because Windows is already performing magic for us with filesystem permissions to get everything in working order in the first place. It doesn't really matter to Windows what the user is because the Docker container has full permissions.

## Testing Instructions

1. Install `node` on Windows without using WSL. Meaning you should be able to run it from PowerShell or CMD.
2. Run `npx wp-env start` from Windows without using WSL. It should boot correctly without any problems.
3. Try to install a plugin. We expect this to work without problem.