### PR TITLE
Pattern block: Try adding Pattern Part block

### DIFF
--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -32,6 +32,7 @@ function gutenberg_reregister_core_block_types() {
 				'more',
 				'nextpage',
 				'paragraph',
+				'pattern-part',
 				'preformatted',
 				'pullquote',
 				'quote',

--- a/packages/block-library/src/index.js
+++ b/packages/block-library/src/index.js
@@ -67,6 +67,7 @@ import * as navigationLink from './navigation-link';
 import * as navigationSubmenu from './navigation-submenu';
 import * as nextpage from './nextpage';
 import * as pattern from './pattern';
+import * as patternPart from './pattern-part';
 import * as pageList from './page-list';
 import * as pageListItem from './page-list-item';
 import * as paragraph from './paragraph';
@@ -160,6 +161,7 @@ const getAllBlocks = () => {
 		pageList,
 		pageListItem,
 		pattern,
+		patternPart,
 		preformatted,
 		pullquote,
 		reusableBlock,

--- a/packages/block-library/src/pattern-part/block.json
+++ b/packages/block-library/src/pattern-part/block.json
@@ -1,0 +1,19 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 2,
+	"name": "core/pattern-part",
+	"title": "Pattern part",
+	"category": "text",
+	"description": "A wrapper for a pattern's inner blocks",
+	"keywords": [ "bob" ],
+	"textdomain": "default",
+	"attributes": {
+		"slug": {
+			"type": "string"
+		}
+	},
+	"supports": {
+		"html": false,
+		"inserter": false
+	}
+}

--- a/packages/block-library/src/pattern-part/edit.js
+++ b/packages/block-library/src/pattern-part/edit.js
@@ -1,0 +1,9 @@
+/**
+ * WordPress dependencies
+ */
+import { useInnerBlocksProps, useBlockProps } from '@wordpress/block-editor';
+export default function Edit() {
+	const blockProps = useBlockProps();
+	const innerBlocksProps = useInnerBlocksProps( blockProps );
+	return <>{ innerBlocksProps.children }</>;
+}

--- a/packages/block-library/src/pattern-part/edit.js
+++ b/packages/block-library/src/pattern-part/edit.js
@@ -5,5 +5,6 @@ import { useInnerBlocksProps, useBlockProps } from '@wordpress/block-editor';
 export default function Edit() {
 	const blockProps = useBlockProps();
 	const innerBlocksProps = useInnerBlocksProps( blockProps );
-	return <>{ innerBlocksProps.children }</>;
+	console.log( 'innerBlocksProps', innerBlocksProps.children );
+	return <div { ...innerBlocksProps }></div>;
 }

--- a/packages/block-library/src/pattern-part/index.js
+++ b/packages/block-library/src/pattern-part/index.js
@@ -2,16 +2,18 @@
  * Internal dependencies
  */
 import initBlock from '../utils/init-block';
+import edit from './edit';
 import metadata from './block.json';
-import PatternEditV1 from './v1/edit';
-import PatternEditV2 from './edit';
 import save from './save';
 
 const { name } = metadata;
+
 export { metadata, name };
 
-export const settings = window?.__experimentalEnablePatternEnhancements
-	? { edit: PatternEditV2, save }
-	: { edit: PatternEditV1 };
+const settings = {
+	edit,
+	save,
+};
 
+export { settings };
 export const init = () => initBlock( { name, metadata, settings } );

--- a/packages/block-library/src/pattern-part/init.js
+++ b/packages/block-library/src/pattern-part/init.js
@@ -1,0 +1,6 @@
+/**
+ * Internal dependencies
+ */
+import { init } from './';
+
+export default init();

--- a/packages/block-library/src/pattern-part/save.js
+++ b/packages/block-library/src/pattern-part/save.js
@@ -1,0 +1,8 @@
+/**
+ * WordPress dependencies
+ */
+import { InnerBlocks } from '@wordpress/block-editor';
+
+export default function save() {
+	return <InnerBlocks.Content />;
+}

--- a/packages/block-library/src/pattern-part/save.js
+++ b/packages/block-library/src/pattern-part/save.js
@@ -1,8 +1,10 @@
 /**
  * WordPress dependencies
  */
-import { InnerBlocks } from '@wordpress/block-editor';
+import { useInnerBlocksProps, useBlockProps } from '@wordpress/block-editor';
 
 export default function save() {
-	return <InnerBlocks.Content />;
+	const blockProps = useBlockProps.save();
+	const innerBlocksProps = useInnerBlocksProps.save( blockProps );
+	return <div { ...innerBlocksProps }>{ innerBlocksProps.children }</div>;
 }

--- a/packages/block-library/src/pattern-part/style.scss
+++ b/packages/block-library/src/pattern-part/style.scss
@@ -1,0 +1,3 @@
+.wp-block-pattern-part {
+	display: contents;
+}

--- a/packages/block-library/src/pattern/edit.js
+++ b/packages/block-library/src/pattern/edit.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { cloneBlock } from '@wordpress/blocks';
+import { cloneBlock, createBlock } from '@wordpress/blocks';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useEffect } from '@wordpress/element';
 import {
@@ -44,9 +44,21 @@ const PatternEdit = ( { attributes, clientId } ) => {
 			window.queueMicrotask( () => {
 				// Clone blocks from the pattern before insertion to ensure they receive
 				// distinct client ids. See https://github.com/WordPress/gutenberg/issues/50628.
-				const clonedBlocks = selectedPattern.blocks.map( ( block ) =>
-					cloneBlock( block )
-				);
+				const clonedBlocks = selectedPattern.blocks.map( ( block ) => {
+					let newInnerBlocks = [];
+					if ( block.innerBlocks.length > 0 ) {
+						newInnerBlocks = block.innerBlocks.map(
+							( innerBlock ) => {
+								return createBlock( 'core/pattern-part', {}, [
+									cloneBlock( innerBlock ),
+								] );
+							}
+						);
+					}
+					return createBlock( 'core/pattern-part', {}, [
+						cloneBlock( block, {}, newInnerBlocks ),
+					] );
+				} );
 				__unstableMarkNextChangeAsNotPersistent();
 				if ( syncStatus === 'partial' ) {
 					replaceInnerBlocks( clientId, clonedBlocks );

--- a/packages/block-library/src/pattern/save.js
+++ b/packages/block-library/src/pattern/save.js
@@ -1,0 +1,19 @@
+/**
+ * WordPress dependencies
+ */
+import { useBlockProps, useInnerBlocksProps } from '@wordpress/block-editor';
+
+export default function save( {
+	attributes: { syncStatus, slug },
+	innerBlocks,
+} ) {
+	if ( innerBlocks?.length === 0 || syncStatus !== 'partial' ) {
+		return;
+	}
+	//test
+	const blockProps = useBlockProps.save( {
+		className: slug?.replace( '/', '-' ),
+	} );
+	const innerBlocksProps = useInnerBlocksProps.save( blockProps );
+	return <div { ...innerBlocksProps }>{ innerBlocksProps.children }</div>;
+}

--- a/packages/block-library/src/style.scss
+++ b/packages/block-library/src/style.scss
@@ -27,6 +27,7 @@
 @import "./navigation-link/style.scss";
 @import "./page-list/style.scss";
 @import "./paragraph/style.scss";
+@import "./pattern-part/style.scss";
 @import "./post-author/style.scss";
 @import "./post-comments-form/style.scss";
 @import "./post-date/style.scss";


### PR DESCRIPTION
## What?
Adds a Pattern Part block that is wrapped around every block within a Pattern

## Why?
Just as an experiment to see if it was a potential way to add fine-grained control over each part of a [partially synced pattern](https://github.com/WordPress/gutenberg/discussions/50456)

The vague theory was that each Pattern Part block could be responsible for saving any local changes to the block as apposed to pushing all the content changes up to the parent Pattern block attributes as [proposed here](https://github.com/WordPress/gutenberg/pull/50649). This could potentially remove the need for complex ids/refs/addressing to track which blocks with the pattern the content relates to.

**But** Although it is relatively easy to add these wrapper blocks, it causes a lot of layout issues in the editor due to extra divs. There may be a way to make them useful without adding divs for them in the editor, but there is also the issue of how to get the child block to push its attributes up to the Pattern Part block without being aware that it is in fact wrapped. It would be possible to [monkey patch the setting of attributes as here](https://github.com/WordPress/gutenberg/pull/50649), but that won't work if a block uses  `updateBlockAttributes` from `useDispatch` for some reason.

Going to shelve for now, but adding as a PR as a record of what was explored. 

## How?
When loading a Pattern block in the editor all of the innerBlocks are recursed and the Pattern Part block wrapper is added.

## Testing Instructions
- In Editor code view paste with TT3 theme `<!-- wp:pattern {"slug":"twentytwentythree/cta","syncStatus":"partial"} /-->`
- Switch to Editor view and check that each pattern in the block is wrapped in a Pattern Part block

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
<img width="1033" alt="Screenshot 2023-05-24 at 4 00 56 PM" src="https://github.com/WordPress/gutenberg/assets/3629020/fe68f785-1c48-4070-b77a-6bc338da36e6">


