### PR TITLE
Migrate Navigable toolbar test to Playwright

### DIFF
--- a/test/e2e/specs/editor/various/navigable-toolbar.spec.js
+++ b/test/e2e/specs/editor/various/navigable-toolbar.spec.js
@@ -3,27 +3,16 @@
  */
 const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 
-test.use( {
-	navigableToolbar: async ( { page }, use ) => {
-		await use( new navigableToolbar( { page } ) );
-	},
-} );
-
 test.describe( 'Block Toolbar', () => {
 	test.beforeEach( async ( { admin } ) => {
 		await admin.createNewPost();
 	} );
 
 	test.describe( 'Contextual Toolbar', () => {
-		test( 'should not scroll page', async ( {
-			page,
-			pageUtils,
-			navigableToolbar,
-		} ) => {
-			const wp = '';
+		test( 'should not scroll page', async ( { page, pageUtils } ) => {
 			while (
 				await page.evaluate( () => {
-					const scrollable = wp.dom.getScrollContainer(
+					const scrollable = window.wp.dom.getScrollContainer(
 						document.activeElement
 					);
 					return ! scrollable || scrollable.scrollTop === 0;
@@ -36,15 +25,19 @@ test.describe( 'Block Toolbar', () => {
 
 			const scrollTopBefore = await page.evaluate(
 				() =>
-					wp.dom.getScrollContainer( document.activeElement )
+					window.wp.dom.getScrollContainer( document.activeElement )
 						.scrollTop
 			);
 			await pageUtils.pressKeys( 'alt+F10' );
-			expect( await navigableToolbar.isInBlockToolbar() ).toBe( true );
+			await expect(
+				page
+					.getByRole( 'toolbar', { name: 'Block Tools' } )
+					.getByRole( 'button', { name: 'Paragraph' } )
+			).toBeFocused();
 
 			const scrollTopAfter = await page.evaluate(
 				() =>
-					wp.dom.getScrollContainer( document.activeElement )
+					window.wp.dom.getScrollContainer( document.activeElement )
 						.scrollTop
 			);
 
@@ -54,42 +47,7 @@ test.describe( 'Block Toolbar', () => {
 		test( 'navigates into the toolbar by keyboard (Alt+F10)', async ( {
 			page,
 			pageUtils,
-			navigableToolbar,
 		} ) => {
-			// Assumes new post focus starts in title. Create first new
-			// block by Enter.
-			await page.keyboard.press( 'Enter' );
-
-			// [TEMPORARY]: A new paragraph is not technically a block yet
-			// until starting to type within it.
-			await page.keyboard.type( 'Example' );
-
-			// Upward.
-			await pageUtils.pressKeys( 'alt+F10' );
-
-			expect( await navigableToolbar.isInBlockToolbar() ).toBe( true );
-		} );
-	} );
-
-	test.describe( 'Unified Toolbar', () => {
-		test( 'navigates into the toolbar by keyboard (Alt+F10)', async ( {
-			page,
-			pageUtils,
-		} ) => {
-			const wp = '';
-			await page.evaluate( () => {
-				const { select, dispatch } = wp.data;
-				const isCurrentlyUnified =
-					select( 'core/edit-post' ).isFeatureActive(
-						'fixedToolbar'
-					);
-				if ( ! isCurrentlyUnified ) {
-					dispatch( 'core/edit-post' ).toggleFeature(
-						'fixedToolbar'
-					);
-				}
-			} );
-
 			// Assumes new post focus starts in title. Create first new
 			// block by Enter.
 			await page.keyboard.press( 'Enter' );
@@ -102,22 +60,10 @@ test.describe( 'Block Toolbar', () => {
 			await pageUtils.pressKeys( 'alt+F10' );
 
 			await expect(
-				page.locator( 'role=toolbar[name="Document tools"i]' )
-			).toBeVisible();
+				page
+					.getByRole( 'toolbar', { name: 'Block Tools' } )
+					.getByRole( 'button', { name: 'Paragraph' } )
+			).toBeFocused();
 		} );
 	} );
 } );
-
-class navigableToolbar {
-	constructor( { page } ) {
-		this.page = page;
-	}
-
-	async isInBlockToolbar() {
-		return await this.page.evaluate( () => {
-			return !! document.activeElement.closest(
-				'.block-editor-block-toolbar'
-			);
-		} );
-	}
-}

--- a/test/e2e/specs/editor/various/navigable-toolbar.spec.js
+++ b/test/e2e/specs/editor/various/navigable-toolbar.spec.js
@@ -4,8 +4,8 @@
 const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 
 test.use( {
-	navigable_Toolbar: async ( { page }, use ) => {
-		await use( new navigable_Toolbar( { page } ) );
+	navigableToolbar: async ( { page }, use ) => {
+		await use( new navigableToolbar( { page } ) );
 	},
 } );
 
@@ -18,7 +18,7 @@ test.describe( 'Block Toolbar', () => {
 		test( 'should not scroll page', async ( {
 			page,
 			pageUtils,
-			navigable_Toolbar,
+			navigableToolbar,
 		} ) => {
 			const wp = '';
 			while (
@@ -40,7 +40,7 @@ test.describe( 'Block Toolbar', () => {
 						.scrollTop
 			);
 			await pageUtils.pressKeys( 'alt+F10' );
-			expect( await navigable_Toolbar.isInBlockToolbar() ).toBe( true );
+			expect( await navigableToolbar.isInBlockToolbar() ).toBe( true );
 
 			const scrollTopAfter = await page.evaluate(
 				() =>
@@ -54,7 +54,7 @@ test.describe( 'Block Toolbar', () => {
 		test( 'navigates into the toolbar by keyboard (Alt+F10)', async ( {
 			page,
 			pageUtils,
-			navigable_Toolbar,
+			navigableToolbar,
 		} ) => {
 			// Assumes new post focus starts in title. Create first new
 			// block by Enter.
@@ -67,7 +67,7 @@ test.describe( 'Block Toolbar', () => {
 			// Upward.
 			await pageUtils.pressKeys( 'alt+F10' );
 
-			expect( await navigable_Toolbar.isInBlockToolbar() ).toBe( true );
+			expect( await navigableToolbar.isInBlockToolbar() ).toBe( true );
 		} );
 	} );
 
@@ -101,14 +101,14 @@ test.describe( 'Block Toolbar', () => {
 			// Upward.
 			await pageUtils.pressKeys( 'alt+F10' );
 
-			expect(
-				await page.locator( 'role=toolbar[name="Document tools"i]' )
+			await expect(
+				page.locator( 'role=toolbar[name="Document tools"i]' )
 			).toBeVisible();
 		} );
 	} );
 } );
 
-class navigable_Toolbar {
+class navigableToolbar {
 	constructor( { page } ) {
 		this.page = page;
 	}

--- a/test/e2e/specs/editor/various/navigable-toolbar.spec.js
+++ b/test/e2e/specs/editor/various/navigable-toolbar.spec.js
@@ -4,8 +4,8 @@
 const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 
 test.use( {
-	navigable_toolbar: async ( { page }, use ) => {
-		await use( new navigable_toolbar( { page } ) );
+	navigable_Toolbar: async ( { page }, use ) => {
+		await use( new navigable_Toolbar( { page } ) );
 	},
 } );
 
@@ -18,8 +18,9 @@ test.describe( 'Block Toolbar', () => {
 		test( 'should not scroll page', async ( {
 			page,
 			pageUtils,
-			navigable_toolbar,
+			navigable_Toolbar,
 		} ) => {
+			const wp = '';
 			while (
 				await page.evaluate( () => {
 					const scrollable = wp.dom.getScrollContainer(
@@ -39,7 +40,7 @@ test.describe( 'Block Toolbar', () => {
 						.scrollTop
 			);
 			await pageUtils.pressKeys( 'alt+F10' );
-			expect( await navigable_toolbar.isInBlockToolbar() ).toBe( true );
+			expect( await navigable_Toolbar.isInBlockToolbar() ).toBe( true );
 
 			const scrollTopAfter = await page.evaluate(
 				() =>
@@ -53,7 +54,7 @@ test.describe( 'Block Toolbar', () => {
 		test( 'navigates into the toolbar by keyboard (Alt+F10)', async ( {
 			page,
 			pageUtils,
-			navigable_toolbar,
+			navigable_Toolbar,
 		} ) => {
 			// Assumes new post focus starts in title. Create first new
 			// block by Enter.
@@ -66,7 +67,7 @@ test.describe( 'Block Toolbar', () => {
 			// Upward.
 			await pageUtils.pressKeys( 'alt+F10' );
 
-			expect( await navigable_toolbar.isInBlockToolbar() ).toBe( true );
+			expect( await navigable_Toolbar.isInBlockToolbar() ).toBe( true );
 		} );
 	} );
 
@@ -75,6 +76,7 @@ test.describe( 'Block Toolbar', () => {
 			page,
 			pageUtils,
 		} ) => {
+			const wp = '';
 			await page.evaluate( () => {
 				const { select, dispatch } = wp.data;
 				const isCurrentlyUnified =
@@ -100,13 +102,13 @@ test.describe( 'Block Toolbar', () => {
 			await pageUtils.pressKeys( 'alt+F10' );
 
 			expect(
-				page.locator( 'role=toolbar[name="Document tools"i]' )
+				await page.locator( 'role=toolbar[name="Document tools"i]' )
 			).toBeVisible();
 		} );
 	} );
 } );
 
-class navigable_toolbar {
+class navigable_Toolbar {
 	constructor( { page } ) {
 		this.page = page;
 	}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
## What?
<!-- In a few words, what is the PR actually doing? -->
Part of https://github.com/WordPress/gutenberg/issues/38851.
Migrate[ navigable-toolbar.test.js ](https://github.com/WordPress/gutenberg/blob/trunk/packages/e2e-tests/specs/editor/various/navigable-toolbar.test.js) to its Playwright version.
## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Part of https://github.com/WordPress/gutenberg/issues/38851.
## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
See[ MIGRATION.md](https://github.com/WordPress/gutenberg/blob/trunk/test/e2e/MIGRATION.md) for migration steps.
## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
Run` npm run test:e2e:playwright test/e2e/specs/editor/various/navigable-toolbar.spec.js`