### PR TITLE
[RNMobile] Display lock icon in disabled state of `Cell` component 

### DIFF
--- a/packages/components/src/mobile/bottom-sheet-select-control/index.native.js
+++ b/packages/components/src/mobile/bottom-sheet-select-control/index.native.js
@@ -71,7 +71,7 @@ const BottomSheetSelectControl = ( {
 					) }
 					disabled={ disabled }
 				>
-					<Icon icon={ chevronRight }></Icon>
+					{ disabled ? null : <Icon icon={ chevronRight } /> }
 				</BottomSheet.Cell>
 			}
 			showSheet={ showSubSheet }

--- a/packages/components/src/mobile/bottom-sheet-text-control/index.native.js
+++ b/packages/components/src/mobile/bottom-sheet-text-control/index.native.js
@@ -65,7 +65,7 @@ const BottomSheetTextControl = ( {
 					placeholder={ cellPlaceholder || placeholder || '' }
 					disabled={ disabled }
 				>
-					<Icon icon={ chevronRight }></Icon>
+					{ disabled ? null : <Icon icon={ chevronRight } /> }
 				</BottomSheet.Cell>
 			}
 			showSheet={ showSubSheet }

--- a/packages/components/src/mobile/bottom-sheet/cell.native.js
+++ b/packages/components/src/mobile/bottom-sheet/cell.native.js
@@ -26,6 +26,7 @@ import { withPreferredColorScheme } from '@wordpress/compose';
 import styles from './styles.scss';
 import platformStyles from './cellStyles.scss';
 import TouchableRipple from './ripple';
+import LockIcon from './lock-icon';
 
 const isIOS = Platform.OS === 'ios';
 class BottomSheetCell extends Component {
@@ -93,6 +94,7 @@ class BottomSheetCell extends Component {
 			accessibilityRole,
 			disabled = false,
 			disabledStyle = styles.cellDisabled,
+			showLockIcon = true,
 			activeOpacity,
 			onPress,
 			onLongPress,
@@ -374,6 +376,7 @@ class BottomSheetCell extends Component {
 									] }
 								>
 									<Icon
+										lock
 										icon={ icon }
 										size={ 24 }
 										fill={
@@ -440,6 +443,11 @@ class BottomSheetCell extends Component {
 					>
 						{ children }
 					</View>
+					{ disabled && showLockIcon && (
+						<View style={ styles.cellDisabled }>
+							<LockIcon />
+						</View>
+					) }
 				</View>
 				{ help && (
 					<Text style={ [ cellHelpStyle, styles.placeholderColor ] }>

--- a/packages/components/src/mobile/bottom-sheet/color-cell.native.js
+++ b/packages/components/src/mobile/bottom-sheet/color-cell.native.js
@@ -11,7 +11,7 @@ import Cell from './cell';
 import styles from './styles.scss';
 
 export default function BottomSheetColorCell( props ) {
-	const { color, withColorIndicator = true, ...cellProps } = props;
+	const { color, withColorIndicator = true, disabled, ...cellProps } = props;
 
 	return (
 		<Cell
@@ -22,12 +22,13 @@ export default function BottomSheetColorCell( props ) {
 				__( 'Double tap to go to color settings' )
 			}
 			editable={ false }
+			disabled={ disabled }
 			value={ withColorIndicator && ! color && __( 'Default' ) }
 		>
 			{ withColorIndicator && color && (
 				<ColorIndicator color={ color } style={ styles.colorCircle } />
 			) }
-			<Icon icon={ chevronRight }></Icon>
+			{ disabled ? null : <Icon icon={ chevronRight }></Icon> }
 		</Cell>
 	);
 }

--- a/packages/components/src/mobile/bottom-sheet/lock-icon/index.native.js
+++ b/packages/components/src/mobile/bottom-sheet/lock-icon/index.native.js
@@ -1,0 +1,19 @@
+/**
+ * WordPress dependencies
+ */
+import { Icon, lock } from '@wordpress/icons';
+import { usePreferredColorSchemeStyle } from '@wordpress/compose';
+
+/**
+ * Internal dependencies
+ */
+import styles from './styles.scss';
+
+export default function LockIcon() {
+	const iconStyle = usePreferredColorSchemeStyle(
+		styles.icon,
+		styles[ 'icon--dark' ]
+	);
+
+	return <Icon icon={ lock } color={ iconStyle.color } style={ iconStyle } />;
+}

--- a/packages/components/src/mobile/bottom-sheet/lock-icon/styles.native.scss
+++ b/packages/components/src/mobile/bottom-sheet/lock-icon/styles.native.scss
@@ -1,0 +1,8 @@
+.icon {
+	color: $gray-dark;
+	margin-left: 6px;
+}
+
+.icon--dark {
+	color: $gray-light;
+}

--- a/packages/components/src/mobile/bottom-sheet/radio-cell.native.js
+++ b/packages/components/src/mobile/bottom-sheet/radio-cell.native.js
@@ -10,7 +10,7 @@ import { usePreferredColorSchemeStyle } from '@wordpress/compose';
 import Cell from './cell';
 import styles from './styles.scss';
 
-export default function BottomSheetColorCell( props ) {
+export default function BottomSheetRadioCell( props ) {
 	const { selected, ...cellProps } = props;
 
 	const selectedIconStyle = usePreferredColorSchemeStyle(

--- a/packages/components/src/mobile/bottom-sheet/radio-cell.native.js
+++ b/packages/components/src/mobile/bottom-sheet/radio-cell.native.js
@@ -29,6 +29,7 @@ export default function BottomSheetColorCell( props ) {
 			}
 			editable={ false }
 			value={ '' }
+			showLockIcon={ selected }
 		>
 			{ selected && (
 				<Icon icon={ check } style={ selectedIconStyle }></Icon>

--- a/packages/components/src/mobile/bottom-sheet/range-cell.native.js
+++ b/packages/components/src/mobile/bottom-sheet/range-cell.native.js
@@ -15,6 +15,7 @@ import { withPreferredColorScheme } from '@wordpress/compose';
  * Internal dependencies
  */
 import Cell from './cell';
+import LockIcon from './lock-icon';
 import styles from './range-cell.scss';
 import RangeTextInput from './range-text-input';
 import { toFixed } from '../utils';
@@ -219,6 +220,7 @@ class BottomSheetRangeCell extends Component {
 						accessible={ false }
 						valueStyle={ styles.valueStyle }
 						disabled={ disabled }
+						showLockIcon={ false }
 					>
 						<View style={ containerStyle }>
 							{ preview }
@@ -260,6 +262,7 @@ class BottomSheetRangeCell extends Component {
 									{ children }
 								</RangeTextInput>
 							) }
+							{ disabled && <LockIcon /> }
 						</View>
 					</Cell>
 				</View>

--- a/packages/components/src/mobile/bottom-sheet/styles.native.scss
+++ b/packages/components/src/mobile/bottom-sheet/styles.native.scss
@@ -1,5 +1,7 @@
 //Bottom Sheet
 
+$cell-disable-opacity: 0.38;
+
 .bottomModal {
 	justify-content: flex-end;
 	margin: 0;
@@ -288,11 +290,11 @@
 }
 
 .placeholderColorDisabled {
-	color: lighten($gray, 20%);
+	color: rgba($gray-dark, $cell-disable-opacity);
 }
 
 .placeholderColorDisabledDark {
-	color: lighten($gray-dark, 10%);
+	color: rgba($white, $cell-disable-opacity);
 }
 
 .applyButton {
@@ -327,5 +329,5 @@
 }
 
 .cellDisabled {
-	opacity: 0.3;
+	opacity: $cell-disable-opacity;
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? --> 

Adds a UX improvement for the disabled state of the `Cell` component by adding a lock icon.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Follows up https://github.com/WordPress/gutenberg/pull/50665 and [this comment](https://github.com/WordPress/gutenberg/pull/50665#issuecomment-1556997697). 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

The following design updates have been applied to the disabled style of cell components:
* Lock icon added on the right.
* Replace the chevron icon on the right with the lock icon.
* Values dimmed to 38%.

And the accordingly updates to the code:
* Adds lock icon component.
* Renders the lock icon in the `Cell` component.
* Updates the following components to use the lock icon properly in the disabled state:
    * `BottomSheetSelectControl`: Don't render the chevron icon in favor of the lock icon.
    * `BottomSheetTextControl`: Don't render the chevron icon in favor of the lock icon.
    * `BottomSheetColorCell`: Don't render the chevron icon in favor of the lock icon.
    * `BottomSheetRadioCell`: Only render lock icon for the selected item.
    * `BottomSheetRangeCell`: Render the lock icon along with the slider.
* Update the placeholder color used in the disabled state.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
In order to test the different control components, I created a test component for this purpose.

1. Apply the following patch to incorporate the test component:

<details><summary>Click here to display patch</summary>

```patch
diff --git forkSrcPrefix/packages/edit-post/src/components/layout/index.native.js forkDstPrefix/packages/edit-post/src/components/layout/index.native.js
index a9c38ee1ccb8d5ea579a46bde8070edc372e8567..e0d2ea1c969805500405bbeb8c75255ebc08793b 100644
--- forkSrcPrefix/packages/edit-post/src/components/layout/index.native.js
+++ forkDstPrefix/packages/edit-post/src/components/layout/index.native.js
@@ -33,6 +33,7 @@ import headerToolbarStyles from '../header/header-toolbar/style.scss';
 import Header from '../header';
 import VisualEditor from '../visual-editor';
 import { store as editPostStore } from '../../store';
+import TestControls from './test-controls';
 
 class Layout extends Component {
 	constructor() {
@@ -149,6 +150,7 @@ class Layout extends Component {
 				>
 					<AutosaveMonitor disableIntervalChecks />
 					<View style={ editorStyles }>
+						<TestControls />
 						{ isHtmlView ? this.renderHTML() : this.renderVisual() }
 						{ ! isHtmlView && Platform.OS === 'android' && (
 							<FloatingToolbar />
diff --git forkSrcPrefix/packages/edit-post/src/components/layout/test-controls.js forkDstPrefix/packages/edit-post/src/components/layout/test-controls.js
new file mode 100644
index 0000000000000000000000000000000000000000..7dacdb799c72f42449bcd0d004f4352a5f6a0187
--- /dev/null
+++ forkDstPrefix/packages/edit-post/src/components/layout/test-controls.js
@@ -0,0 +1,221 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	PanelBody,
+	BottomSheet,
+	BottomSheetTextControl,
+	BottomSheetSelectControl,
+	FooterMessageControl,
+	RangeControl,
+	TextControl,
+	ColorControl,
+	ToggleControl,
+	CycleSelectControl,
+	SelectControl,
+	RadioControl,
+	UnitControl,
+	ColorSettings,
+} from '@wordpress/components';
+import { useState } from '@wordpress/element';
+import { useMultipleOriginColorsAndGradients } from '@wordpress/block-editor';
+
+/**
+ * External dependencies
+ */
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { useNavigation } from '@react-navigation/native';
+
+const TestControlsContainer = () => {
+	const colorSettings = useMultipleOriginColorsAndGradients();
+
+	return (
+		<BottomSheet
+			isVisible={ true }
+			onClose={ () => {} }
+			hideHeader
+			hasNavigation
+		>
+			<BottomSheet.NavigationContainer animate main>
+				<BottomSheet.NavigationScreen name={ 'main' }>
+					<TestControls />
+				</BottomSheet.NavigationScreen>
+				<BottomSheet.NavigationScreen
+					name={ BottomSheet.SubSheet.screenName }
+				>
+					<BottomSheet.SubSheet.Slot />
+				</BottomSheet.NavigationScreen>
+				<BottomSheet.NavigationScreen name="Color">
+					<ColorSettings defaultSettings={ colorSettings } />
+				</BottomSheet.NavigationScreen>
+			</BottomSheet.NavigationContainer>
+		</BottomSheet>
+	);
+};
+
+const TestControls = () => {
+	const [ controlsDisabled, setControlsDisabled ] = useState( true );
+
+	const [ selectValue, setSelectValue ] = useState( 1 );
+	const [ rangeValue, setRangeValue ] = useState( 0 );
+	const [ unitValue, setUnitValue ] = useState( 'px' );
+	const [ textValue, setTextValue ] = useState( 'example' );
+	const [ colorValue, setColorValue ] = useState( '#000000' );
+	const [ toggleValue, setToggleValue ] = useState( false );
+
+	const navigation = useNavigation();
+
+	return (
+		<>
+			<PanelBody title="Panel only for Testing">
+				<ToggleControl
+					label="Disable the below controls"
+					onChange={ setControlsDisabled }
+					checked={ controlsDisabled }
+				/>
+			</PanelBody>
+			<PanelBody title="Select Controls">
+				<BottomSheetSelectControl
+					label="BottomSheetSelectControl"
+					options={ [
+						{ value: 1, label: 'Value 1' },
+						{ value: 2, label: 'Value 2' },
+						{ value: 3, label: 'Value 3' },
+					] }
+					onChange={ setSelectValue }
+					value={ selectValue }
+					disabled={ controlsDisabled }
+				/>
+				<CycleSelectControl
+					label="CycleSelectControl"
+					onChange={ setSelectValue }
+					options={ [
+						{ value: 1, name: 'Value 1' },
+						{ value: 2, name: 'Value 2' },
+						{ value: 3, name: 'Value 3' },
+					] }
+					value={ selectValue }
+					disabled={ controlsDisabled }
+				/>
+				<SelectControl
+					label="SelectControl"
+					value={ selectValue }
+					onChange={ setSelectValue }
+					options={ [
+						{ value: 1, label: 'Value 1' },
+						{ value: 2, label: 'Value 2' },
+						{ value: 3, label: 'Value 3' },
+					] }
+					hideCancelButton
+					disabled={ controlsDisabled }
+				/>
+			</PanelBody>
+			<PanelBody title="Radio Control">
+				<RadioControl
+					selected={ selectValue }
+					options={ [
+						{ value: 1, label: 'Value 1' },
+						{ value: 2, label: 'Value 2' },
+						{ value: 3, label: 'Value 3' },
+					] }
+					onChange={ setSelectValue }
+					disabled={ controlsDisabled }
+				/>
+			</PanelBody>
+			<PanelBody title="Range Controls">
+				<RangeControl
+					label="RangeControl - Stepper"
+					value={ rangeValue }
+					onChange={ setRangeValue }
+					min={ 0 }
+					max={ 10 }
+					type="stepper"
+					disabled={ controlsDisabled }
+				/>
+				<RangeControl
+					label="RangeControl - Slider"
+					value={ rangeValue }
+					onChange={ setRangeValue }
+					min={ 0 }
+					max={ 10 }
+					disabled={ controlsDisabled }
+				/>
+				<UnitControl
+					label="UnitControl"
+					min={ 0 }
+					max={ 10 }
+					value={ rangeValue }
+					onChange={ setRangeValue }
+					onUnitChange={ setUnitValue }
+					unit={ unitValue }
+					units={ [
+						{
+							value: 'px',
+							label: 'px',
+							step: 1,
+						},
+						{
+							value: 'em',
+							label: 'em',
+							step: 0.1,
+						},
+					] }
+					disabled={ controlsDisabled }
+				/>
+			</PanelBody>
+			<PanelBody title="Text Controls">
+				<TextControl
+					value={ textValue }
+					onChange={ setTextValue }
+					placeholder="placeholder"
+					label="TextControl"
+					disabled={ controlsDisabled }
+				/>
+				<TextControl
+					value=""
+					onChange={ setTextValue }
+					placeholder="placeholder"
+					label="TextControl"
+					disabled={ controlsDisabled }
+				/>
+				<BottomSheetTextControl
+					initialValue={ textValue }
+					onChange={ setTextValue }
+					label="BottomSheetTextControl"
+					disabled={ controlsDisabled }
+				/>
+				<BottomSheetTextControl
+					onChange={ setTextValue }
+					placeholder="placeholder"
+					label="BottomSheetTextControl"
+					disabled={ controlsDisabled }
+				/>
+			</PanelBody>
+			<PanelBody title="Other controls">
+				<ColorControl
+					label="ColorControl"
+					color={ colorValue }
+					onPress={ () => {
+						navigation.navigate( 'Color', {
+							onColorChange: setColorValue,
+							colorValue,
+							onColorCleared: () => setColorValue( undefined ),
+							label: 'ColorControl',
+						} );
+					} }
+					withColorIndicator
+					disabled={ controlsDisabled }
+				/>
+				<ToggleControl
+					label="ToggleControl"
+					onChange={ setToggleValue }
+					checked={ toggleValue }
+					disabled={ controlsDisabled }
+				/>
+				<FooterMessageControl label="FooterMessageControl" />
+			</PanelBody>
+		</>
+	);
+};
+
+export default TestControlsContainer;

```

</details> 

2. Open a post/page in the app.
3. Observe that a bottom sheet is automatically open.
4. Observe that all displayed controls are disabled and show a lock icon.
5. Enable the controls using the toggle located at the top of the sheet.
6. Observe that all displayed controls are enabled and do not show a lock icon.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
N/A

## Screenshots or screencast <!-- if applicable -->

<details><summary><strong>Click here to show Android screenshots</strong></summary>

## Light mode
| Cell active | Cell disabled |
|--------|--------|
|  <img src=https://github.com/WordPress/gutenberg/assets/14905380/96190516-f443-4ffe-b883-0566f7b1ca1a width=300> | <img src=https://github.com/WordPress/gutenberg/assets/14905380/4312817f-ee8d-4a9e-8b92-5143c0519e3d width=300> | 
| <img src=https://github.com/WordPress/gutenberg/assets/14905380/4ce49fd3-3aee-4896-b98a-26b6f0738e1a width=300> | <img src=https://github.com/WordPress/gutenberg/assets/14905380/82883f48-235a-4ee4-be6d-706a6606358b width=300> |
| <img src=https://github.com/WordPress/gutenberg/assets/14905380/fb1176a0-bd30-434f-9d8c-5e7c29f0c524 width=300> | <img src=https://github.com/WordPress/gutenberg/assets/14905380/d19fa7d9-b13f-4db0-9730-b5bef3e4521f width=300> | 

## Dark mode
| Cell active | Cell disabled |
|--------|--------|
|  <img src=https://github.com/WordPress/gutenberg/assets/14905380/400a05f1-4d12-40aa-a78a-97c175a1cdb3 width=300> | <img src=https://github.com/WordPress/gutenberg/assets/14905380/78d13371-d87c-4f8b-ba0c-751528828eaf width=300> | 
| <img src=https://github.com/WordPress/gutenberg/assets/14905380/a1cde795-86fa-4749-a734-6e8092c9f67d width=300> | <img src=https://github.com/WordPress/gutenberg/assets/14905380/2aefda2b-eb2e-412b-ba46-23e7a33327e8 width=300> | 
| <img src=https://github.com/WordPress/gutenberg/assets/14905380/1f5c0eb3-4b97-46eb-8056-540eb34e06c8 width=300> | <img src=https://github.com/WordPress/gutenberg/assets/14905380/ab6db25a-e677-44da-bb96-91988668ef97 width=300> |

</details>

<details><summary><strong>Click here to show iOS screenshots</strong></summary>

## Light mode
| Cell active | Cell disabled |
|--------|--------|
|  <img src=https://github.com/WordPress/gutenberg/assets/14905380/ef8c9b53-fd47-4402-8cd1-ff245ead7029 width=300> | <img src=https://github.com/WordPress/gutenberg/assets/14905380/ab9b3ec3-7790-42ee-b77a-72ecd0a20077 width=300> | 
| <img src=https://github.com/WordPress/gutenberg/assets/14905380/ee1da86c-4d18-4fc9-a544-6494a8d59412 width=300> | <img src=https://github.com/WordPress/gutenberg/assets/14905380/07b97287-3f99-443c-b026-478d504b6f74 width=300> | 
| <img src=https://github.com/WordPress/gutenberg/assets/14905380/bebe31b6-dea1-4e69-8372-a7062fabf367 width=300> | <img src=https://github.com/WordPress/gutenberg/assets/14905380/993508f2-bdb6-49be-82c2-503543410611 width=300> |

## Dark mode
| Cell active | Cell disabled |
|--------|--------|
|  <img src=https://github.com/WordPress/gutenberg/assets/14905380/eddb9cae-b580-48ac-9458-f43cc37f911b width=300> | <img src=https://github.com/WordPress/gutenberg/assets/14905380/a9a80422-2c84-46e6-b88a-555f8bc4b505 width=300> | 
| <img src=https://github.com/WordPress/gutenberg/assets/14905380/58f35c57-60d8-4272-b9a6-b06f2088a311 width=300> | <img src=https://github.com/WordPress/gutenberg/assets/14905380/38ce19af-254d-4ea7-bb4a-ed39994aa963 width=300> | 
| <img src=https://github.com/WordPress/gutenberg/assets/14905380/82f2fbc6-c536-415c-b1a0-0f20fbb23711 width=300> | <img src=https://github.com/WordPress/gutenberg/assets/14905380/5b9142e4-1716-4b88-aaab-b87b9f2563de width=300> |

</details>