### PR TITLE
Fix multi-entity multi-property undo redo

### DIFF
--- a/docs/reference-guides/data/data-core.md
+++ b/docs/reference-guides/data/data-core.md
@@ -358,6 +358,8 @@ _Returns_
 
 ### getRedoEdit
 
+> **Deprecated** since 6.3
+
 Returns the next edit from the current undo offset for the entity records edits history, if any.
 
 _Parameters_
@@ -400,6 +402,8 @@ _Returns_
 -   `any`: Index data.
 
 ### getUndoEdit
+
+> **Deprecated** since 6.3
 
 Returns the previous edit from the current undo offset for the entity records edits history, if any.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -29227,7 +29227,7 @@
 		"co": {
 			"version": "4.6.0",
 			"resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-			"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+			"integrity": "sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==",
 			"dev": true
 		},
 		"code-point-at": {
@@ -30804,7 +30804,7 @@
 		"css.escape": {
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
-			"integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+			"integrity": "sha1-QuJ9T6BK4y+TGktNQZH6nN3ul8s=",
 			"dev": true
 		},
 		"cssesc": {
@@ -41365,7 +41365,7 @@
 		"lz-string": {
 			"version": "1.4.4",
 			"resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.4.4.tgz",
-			"integrity": "sha512-0ckx7ZHRPqb0oUm8zNr+90mtf9DQB60H1wMCjBtfi62Kl3a7JbHob6gA2bC+xRvZoOL+1hzUK8jeuEIQE8svEQ==",
+			"integrity": "sha1-wNjq82BZ9wV5bh40SBHPTEmNOiY=",
 			"dev": true
 		},
 		"macos-release": {

--- a/packages/core-data/README.md
+++ b/packages/core-data/README.md
@@ -535,6 +535,8 @@ _Returns_
 
 ### getRedoEdit
 
+> **Deprecated** since 6.3
+
 Returns the next edit from the current undo offset for the entity records edits history, if any.
 
 _Parameters_
@@ -577,6 +579,8 @@ _Returns_
 -   `any`: Index data.
 
 ### getUndoEdit
+
+> **Deprecated** since 6.3
 
 Returns the previous edit from the current undo offset for the entity records edits history, if any.
 

--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -411,9 +411,8 @@ export const undo =
 			return;
 		}
 		dispatch( {
-			type: 'EDIT_ENTITY_RECORD',
-			...undoEdit,
-			meta: { isUndo: true },
+			type: 'UNDO',
+			stackedEdits: undoEdit,
 		} );
 	};
 
@@ -429,9 +428,8 @@ export const redo =
 			return;
 		}
 		dispatch( {
-			type: 'EDIT_ENTITY_RECORD',
-			...redoEdit,
-			meta: { isRedo: true },
+			type: 'REDO',
+			stackedEdits: redoEdit,
 		} );
 	};
 

--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -18,6 +18,7 @@ import { receiveItems, removeItems, receiveQueriedItems } from './queried-data';
 import { getOrLoadEntitiesConfig, DEFAULT_ENTITY_KEY } from './entities';
 import { createBatch } from './batch';
 import { STORE_NAME } from './name';
+import { getUndoEdits, getRedoEdits } from './private-selectors';
 
 /**
  * Returns an action object used in signalling that authors have been received.
@@ -406,7 +407,8 @@ export const editEntityRecord =
 export const undo =
 	() =>
 	( { select, dispatch } ) => {
-		const undoEdit = select.getUndoEdit();
+		// Todo: we shouldn't have to pass "root" here.
+		const undoEdit = select( ( state ) => getUndoEdits( state.root ) );
 		if ( ! undoEdit ) {
 			return;
 		}
@@ -423,7 +425,8 @@ export const undo =
 export const redo =
 	() =>
 	( { select, dispatch } ) => {
-		const redoEdit = select.getRedoEdit();
+		// Todo: we shouldn't have to pass "root" here.
+		const redoEdit = select( ( state ) => getRedoEdits( state.root ) );
 		if ( ! redoEdit ) {
 			return;
 		}

--- a/packages/core-data/src/index.js
+++ b/packages/core-data/src/index.js
@@ -62,7 +62,6 @@ const storeConfig = () => ( {
  * @see https://github.com/WordPress/gutenberg/blob/HEAD/packages/data/README.md#createReduxStore
  */
 export const store = createReduxStore( STORE_NAME, storeConfig() );
-
 register( store );
 
 export { default as EntityProvider } from './entity-provider';

--- a/packages/core-data/src/private-selectors.ts
+++ b/packages/core-data/src/private-selectors.ts
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import type { State } from './selectors';
+import type { State, UndoEdit } from './selectors';
 
 type Optional< T > = T | undefined;
 
@@ -13,7 +13,7 @@ type Optional< T > = T | undefined;
  *
  * @return The edit.
  */
-export function getUndoEdits( state: State ): Optional< any > {
+export function getUndoEdits( state: State ): Optional< UndoEdit[] > {
 	return state.undo.list[ state.undo.list.length - 1 + state.undo.offset ];
 }
 
@@ -25,6 +25,6 @@ export function getUndoEdits( state: State ): Optional< any > {
  *
  * @return The edit.
  */
-export function getRedoEdits( state: State ): Optional< any > {
+export function getRedoEdits( state: State ): Optional< UndoEdit[] > {
 	return state.undo.list[ state.undo.list.length + state.undo.offset ];
 }

--- a/packages/core-data/src/private-selectors.ts
+++ b/packages/core-data/src/private-selectors.ts
@@ -14,7 +14,7 @@ type Optional< T > = T | undefined;
  * @return The edit.
  */
 export function getUndoEdits( state: State ): Optional< any > {
-	return state.undo.list[ state.undo.list.length - 2 + state.undo.offset ];
+	return state.undo.list[ state.undo.list.length - 1 + state.undo.offset ];
 }
 
 /**

--- a/packages/core-data/src/private-selectors.ts
+++ b/packages/core-data/src/private-selectors.ts
@@ -1,0 +1,30 @@
+/**
+ * Internal dependencies
+ */
+import type { State } from './selectors';
+
+type Optional< T > = T | undefined;
+
+/**
+ * Returns the previous edit from the current undo offset
+ * for the entity records edits history, if any.
+ *
+ * @param state State tree.
+ *
+ * @return The edit.
+ */
+export function getUndoEdits( state: State ): Optional< any > {
+	return state.undo.list[ state.undo.list.length - 2 + state.undo.offset ];
+}
+
+/**
+ * Returns the next edit from the current undo offset
+ * for the entity records edits history, if any.
+ *
+ * @param state State tree.
+ *
+ * @return The edit.
+ */
+export function getRedoEdits( state: State ): Optional< any > {
+	return state.undo.list[ state.undo.list.length + state.undo.offset ];
+}

--- a/packages/core-data/src/reducer.js
+++ b/packages/core-data/src/reducer.js
@@ -507,7 +507,10 @@ export function undo( state = UNDO_INITIAL_STATE, action ) {
 		const nextStack = [ ...stack ];
 		if ( existingEditIndex !== -1 ) {
 			// If the edit is already in the stack leave the initial "from" value.
-			nextStack[ existingEditIndex ].to = to;
+			nextStack[ existingEditIndex ] = {
+				...nextStack[ existingEditIndex ],
+				to,
+			};
 		} else {
 			nextStack.push( {
 				kind,
@@ -555,14 +558,9 @@ export function undo( state = UNDO_INITIAL_STATE, action ) {
 			} );
 
 			if ( isCachedChange ) {
-				let newCache = state.cache;
-				edits.forEach(
-					( edit ) =>
-						( newCache = appendEditToStack( newCache, edit ) )
-				);
 				return {
 					...state,
-					cache: newCache,
+					cache: edits.reduce( appendEditToStack, state.cache ),
 				};
 			}
 

--- a/packages/core-data/src/reducer.js
+++ b/packages/core-data/src/reducer.js
@@ -481,11 +481,12 @@ export function undo( state = UNDO_INITIAL_STATE, action ) {
 			list: [ ...currentState.list ],
 		};
 		nextState = omitPendingRedos( nextState );
-		let previousUndoState = nextState.list.pop();
-		currentState.cache.forEach( ( edit ) => {
-			previousUndoState = appendEditToStack( previousUndoState, edit );
-		} );
-		nextState.list.push( previousUndoState );
+		const previousUndoState = nextState.list.pop();
+		const updatedUndoState = currentState.cache.reduce(
+			appendEditToStack,
+			previousUndoState
+		);
+		nextState.list.push( updatedUndoState );
 
 		return {
 			...nextState,

--- a/packages/core-data/src/reducer.js
+++ b/packages/core-data/src/reducer.js
@@ -530,6 +530,13 @@ export function undo( state = UNDO_INITIAL_STATE, action ) {
 		}
 
 		case 'EDIT_ENTITY_RECORD':
+			// When undo is not specified,
+			// It's unclear whether we should ignore the undo entirely
+			// or consider it a transient (cached) edit.
+			if ( ! action?.meta?.undo ) {
+				return state;
+			}
+
 			const isCachedChange = Object.keys( action.edits ).every(
 				( key ) => action.transientEdits[ key ]
 			);

--- a/packages/core-data/src/reducer.js
+++ b/packages/core-data/src/reducer.js
@@ -183,6 +183,26 @@ export function themeGlobalStyleVariations( state = {}, action ) {
 	return state;
 }
 
+const withMultiEntityRecordEdits = ( reducer ) => ( state, action ) => {
+	if ( action.type === 'UNDO' || action.type === 'REDO' ) {
+		const { stackedEdits } = action;
+
+		let newState = state;
+		stackedEdits.forEach( ( { kind, name, recordId, edits } ) => {
+			newState = reducer( newState, {
+				type: 'EDIT_ENTITY_RECORD',
+				kind,
+				name,
+				recordId,
+				edits,
+			} );
+		} );
+		return newState;
+	}
+
+	return reducer( state, action );
+};
+
 /**
  * Higher Order Reducer for a given entity config. It supports:
  *
@@ -196,6 +216,8 @@ export function themeGlobalStyleVariations( state = {}, action ) {
  */
 function entity( entityConfig ) {
 	return compose( [
+		withMultiEntityRecordEdits,
+
 		// Limit to matching action type so we don't attempt to replace action on
 		// an unhandled action.
 		ifMatchingAction(
@@ -411,8 +433,9 @@ export const entities = ( state = {}, action ) => {
 /**
  * @typedef {Object} UndoStateMeta
  *
- * @property {number} offset          Where in the undo stack we are.
- * @property {Object} [flattenedUndo] Flattened form of undo stack.
+ * @property {number} list   The undo stack.
+ * @property {number} offset Where in the undo stack we are.
+ * @property {Object} cache  Cache of unpersisted transient edits.
  */
 
 /** @typedef {Array<Object> & UndoStateMeta} UndoState */
@@ -422,10 +445,7 @@ export const entities = ( state = {}, action ) => {
  *
  * @todo Given how we use this we might want to make a custom class for it.
  */
-const UNDO_INITIAL_STATE = Object.assign( [], { offset: 0 } );
-
-/** @type {Object} */
-let lastEditAction;
+const UNDO_INITIAL_STATE = { list: [], offset: 0 };
 
 /**
  * Reducer keeping track of entity edit undo history.
@@ -436,107 +456,103 @@ let lastEditAction;
  * @return {UndoState} Updated state.
  */
 export function undo( state = UNDO_INITIAL_STATE, action ) {
+	const omitPendingRedos = ( currentState ) => {
+		return {
+			...currentState,
+			list: currentState.list.slice(
+				0,
+				currentState.offset || undefined
+			),
+			offset: 0,
+		};
+	};
+
+	const appendCachedEditsToLastUndo = ( currentState ) => {
+		if ( ! currentState.cache ) {
+			return currentState;
+		}
+
+		let nextState = {
+			...currentState,
+			list: [ ...currentState.list ],
+		};
+		nextState = omitPendingRedos( nextState );
+		let previousUndoState = nextState.list.pop();
+		currentState.cache.forEach( ( edit ) => {
+			previousUndoState = appendEditsToStack( previousUndoState, edit );
+		} );
+		nextState.list.push( previousUndoState );
+
+		return {
+			...nextState,
+			cache: undefined,
+		};
+	};
+
+	const appendEditsToStack = (
+		stack = [],
+		{ kind, name, recordId, edits }
+	) => {
+		const existingEditIndex = stack?.findIndex(
+			( { kind: k, name: n, recordId: r } ) => {
+				return k === kind && n === name && r === recordId;
+			}
+		);
+
+		const nextStack = stack.filter(
+			( _, index ) => index !== existingEditIndex
+		);
+		nextStack.push( {
+			kind,
+			name,
+			recordId,
+			edits: {
+				...( existingEditIndex !== -1
+					? stack[ existingEditIndex ].edits
+					: {} ),
+				...edits,
+			},
+		} );
+		return nextStack;
+	};
+
 	switch ( action.type ) {
-		case 'EDIT_ENTITY_RECORD':
 		case 'CREATE_UNDO_LEVEL':
-			let isCreateUndoLevel = action.type === 'CREATE_UNDO_LEVEL';
-			const isUndoOrRedo =
-				! isCreateUndoLevel &&
-				( action.meta.isUndo || action.meta.isRedo );
-			if ( isCreateUndoLevel ) {
-				action = lastEditAction;
-			} else if ( ! isUndoOrRedo ) {
-				// Don't lose the last edit cache if the new one only has transient edits.
-				// Transient edits don't create new levels so updating the cache would make
-				// us skip an edit later when creating levels explicitly.
-				if (
-					Object.keys( action.edits ).some(
-						( key ) => ! action.transientEdits[ key ]
-					)
-				) {
-					lastEditAction = action;
-				} else {
-					lastEditAction = {
-						...action,
-						edits: {
-							...( lastEditAction && lastEditAction.edits ),
-							...action.edits,
-						},
-					};
-				}
-			}
+			return appendCachedEditsToLastUndo( state );
 
-			/** @type {UndoState} */
-			let nextState;
+		case 'UNDO':
+		case 'REDO': {
+			const nextState = appendCachedEditsToLastUndo( state );
+			return {
+				...nextState,
+				offset: state.offset + ( action.type === 'UNDO' ? -1 : 1 ),
+			};
+		}
 
-			if ( isUndoOrRedo ) {
-				// @ts-ignore we might consider using Object.assign({}, state)
-				nextState = [ ...state ];
-				nextState.offset =
-					state.offset + ( action.meta.isUndo ? -1 : 1 );
+		case 'EDIT_ENTITY_RECORD':
+			const isCachedChange = Object.keys( action.edits ).every(
+				( key ) => action.transientEdits[ key ]
+			);
 
-				if ( state.flattenedUndo ) {
-					// The first undo in a sequence of undos might happen while we have
-					// flattened undos in state. If this is the case, we want execution
-					// to continue as if we were creating an explicit undo level. This
-					// will result in an extra undo level being appended with the flattened
-					// undo values.
-					// We also have to take into account if the `lastEditAction` had opted out
-					// of being tracked in undo history, like the action that persists the latest
-					// content right before saving. In that case we have to update the `lastEditAction`
-					// to avoid returning early before applying the existing flattened undos.
-					isCreateUndoLevel = true;
-					if ( ! lastEditAction.meta.undo ) {
-						lastEditAction.meta.undo = {
-							edits: {},
-						};
-					}
-					action = lastEditAction;
-				} else {
-					return nextState;
-				}
-			}
-
-			if ( ! action.meta.undo ) {
-				return state;
-			}
-
-			// Transient edits don't create an undo level, but are
-			// reachable in the next meaningful edit to which they
-			// are merged. They are defined in the entity's config.
-			if (
-				! isCreateUndoLevel &&
-				! Object.keys( action.edits ).some(
-					( key ) => ! action.transientEdits[ key ]
-				)
-			) {
-				// @ts-ignore we might consider using Object.assign({}, state)
-				nextState = [ ...state ];
-				nextState.flattenedUndo = {
-					...state.flattenedUndo,
-					...action.edits,
+			if ( isCachedChange ) {
+				return {
+					...state,
+					cache: appendEditsToStack( state.cache, action ),
 				};
-				nextState.offset = state.offset;
-				return nextState;
 			}
 
-			// Clear potential redos, because this only supports linear history.
-			nextState =
-				// @ts-ignore this needs additional cleanup, probably involving code-level changes
-				nextState || state.slice( 0, state.offset || undefined );
-			nextState.offset = nextState.offset || 0;
-			nextState.pop();
-			if ( ! isCreateUndoLevel ) {
-				nextState.push( {
-					kind: action.meta.undo.kind,
-					name: action.meta.undo.name,
-					recordId: action.meta.undo.recordId,
-					edits: {
-						...state.flattenedUndo,
-						...action.meta.undo.edits,
-					},
-				} );
-			}
+			let nextState = omitPendingRedos( state );
+			nextState = appendCachedEditsToLastUndo( nextState );
+			nextState = { ...nextState, list: [ ...nextState.list ] };
+			const previousUndoState = nextState.list.pop();
+			nextState.list.push(
+				appendEditsToStack( previousUndoState, {
+					kind: action.kind,
+					name: action.name,
+					recordId: action.recordId,
+					edits: action.meta.undo.edits,
+				} )
+			);
 			// When an edit is a function it's an optimization to avoid running some expensive operation.
 			// We can't rely on the function references being the same so we opt out of comparing them here.
 			const comparisonUndoEdits = Object.values(
@@ -546,15 +562,16 @@ export function undo( state = UNDO_INITIAL_STATE, action ) {
 				( edit ) => typeof edit !== 'function'
 			);
 			if ( ! isShallowEqual( comparisonUndoEdits, comparisonEdits ) ) {
-				nextState.push( {
-					kind: action.kind,
-					name: action.name,
-					recordId: action.recordId,
-					edits: isCreateUndoLevel
-						? { ...state.flattenedUndo, ...action.edits }
-						: action.edits,
-				} );
+				nextState.list.push( [
+					{
+						kind: action.kind,
+						name: action.name,
+						recordId: action.recordId,
+						edits: action.edits,
+					},
+				] );
 			}
+
 			return nextState;
 	}
 

--- a/packages/core-data/src/selectors.ts
+++ b/packages/core-data/src/selectors.ts
@@ -74,9 +74,18 @@ interface EntityConfig {
 	kind: string;
 }
 
+export interface UndoEdit {
+	name: string;
+	kind: string;
+	recordId: string;
+	from: any;
+	to: any;
+}
+
 interface UndoState {
-	list: Array< Object >;
+	list: Array< UndoEdit[] >;
 	offset: number;
+	cache: UndoEdit[];
 }
 
 interface UserState {

--- a/packages/core-data/src/selectors.ts
+++ b/packages/core-data/src/selectors.ts
@@ -73,8 +73,8 @@ interface EntityConfig {
 	kind: string;
 }
 
-interface UndoState extends Array< Object > {
-	flattenedUndo: unknown;
+interface UndoState {
+	list: Array< Object >;
 	offset: number;
 }
 
@@ -889,7 +889,9 @@ function getCurrentUndoOffset( state: State ): number {
  * @return The edit.
  */
 export function getUndoEdit( state: State ): Optional< any > {
-	return state.undo[ state.undo.length - 2 + getCurrentUndoOffset( state ) ];
+	return state.undo.list[
+		state.undo.list.length - 2 + getCurrentUndoOffset( state )
+	];
 }
 
 /**
@@ -901,7 +903,9 @@ export function getUndoEdit( state: State ): Optional< any > {
  * @return The edit.
  */
 export function getRedoEdit( state: State ): Optional< any > {
-	return state.undo[ state.undo.length + getCurrentUndoOffset( state ) ];
+	return state.undo.list[
+		state.undo.list.length + getCurrentUndoOffset( state )
+	];
 }
 
 /**
@@ -1142,11 +1146,7 @@ export const hasFetchedAutosaves = createRegistrySelector(
 export const getReferenceByDistinctEdits = createSelector(
 	// This unused state argument is listed here for the documentation generating tool (docgen).
 	( state: State ) => [],
-	( state: State ) => [
-		state.undo.length,
-		state.undo.offset,
-		state.undo.flattenedUndo,
-	]
+	( state: State ) => [ state.undo.list.length, state.undo.offset ]
 );
 
 /**

--- a/packages/core-data/src/selectors.ts
+++ b/packages/core-data/src/selectors.ts
@@ -22,6 +22,7 @@ import {
 	setNestedValue,
 } from './utils';
 import type * as ET from './entity-types';
+import { getUndoEdits, getRedoEdits } from './private-selectors';
 
 // This is an incomplete, high-level approximation of the State type.
 // It makes the selectors slightly more safe, but is intended to evolve
@@ -884,28 +885,38 @@ function getCurrentUndoOffset( state: State ): number {
  * Returns the previous edit from the current undo offset
  * for the entity records edits history, if any.
  *
- * @param state State tree.
+ * @deprecated since 6.3
+ *
+ * @param      state State tree.
  *
  * @return The edit.
  */
 export function getUndoEdit( state: State ): Optional< any > {
+	deprecated( "select( 'core' ).getUndoEdit()", {
+		since: '6.3',
+	} );
 	return state.undo.list[
 		state.undo.list.length - 2 + getCurrentUndoOffset( state )
-	];
+	]?.[ 0 ];
 }
 
 /**
  * Returns the next edit from the current undo offset
  * for the entity records edits history, if any.
  *
- * @param state State tree.
+ * @deprecated since 6.3
+ *
+ * @param      state State tree.
  *
  * @return The edit.
  */
 export function getRedoEdit( state: State ): Optional< any > {
+	deprecated( "select( 'core' ).getRedoEdit()", {
+		since: '6.3',
+	} );
 	return state.undo.list[
 		state.undo.list.length + getCurrentUndoOffset( state )
-	];
+	]?.[ 0 ];
 }
 
 /**
@@ -917,7 +928,7 @@ export function getRedoEdit( state: State ): Optional< any > {
  * @return Whether there is a previous edit or not.
  */
 export function hasUndo( state: State ): boolean {
-	return Boolean( getUndoEdit( state ) );
+	return Boolean( getUndoEdits( state ) );
 }
 
 /**
@@ -929,7 +940,7 @@ export function hasUndo( state: State ): boolean {
  * @return Whether there is a next edit or not.
  */
 export function hasRedo( state: State ): boolean {
-	return Boolean( getRedoEdit( state ) );
+	return Boolean( getRedoEdits( state ) );
 }
 
 /**

--- a/packages/core-data/src/test/reducer.js
+++ b/packages/core-data/src/test/reducer.js
@@ -220,6 +220,28 @@ describe( 'undo', () => {
 		expect( undoState ).toEqual( expectedUndoState );
 	} );
 
+	it( 'stacks and merges multi-property undo levels', () => {
+		undoState = createNextUndoState();
+
+		undoState = createNextUndoState( { value: 1 } );
+		undoState = createNextUndoState( { value2: 2 } );
+		expectedUndoState.list.push(
+			[ createEditActionPart( {} ) ],
+			[ createEditActionPart( { value: 1, value2: undefined } ) ],
+			[ createEditActionPart( { value2: 2 } ) ]
+		);
+		expect( undoState ).toEqual( expectedUndoState );
+
+		// Check that that creating another undo level merges the "edits"
+		undoState = createNextUndoState( { value: 2 } );
+		expectedUndoState.list.pop(); // Edits the last list item and pushes a new one
+		expectedUndoState.list.push(
+			[ createEditActionPart( { value2: 2, value: 1 } ) ],
+			[ createEditActionPart( { value: 2 } ) ]
+		);
+		expect( undoState ).toEqual( expectedUndoState );
+	} );
+
 	it( 'handles undos/redos', () => {
 		undoState = createNextUndoState();
 		undoState = createNextUndoState( { value: 1 } );

--- a/packages/core-data/src/test/selectors.js
+++ b/packages/core-data/src/test/selectors.js
@@ -838,20 +838,20 @@ describe( 'getCurrentUser', () => {
 
 describe( 'getReferenceByDistinctEdits', () => {
 	it( 'should return referentially equal values across empty states', () => {
-		const state = { undo: [] };
+		const state = { undo: { list: [] } };
 		expect( getReferenceByDistinctEdits( state ) ).toBe(
 			getReferenceByDistinctEdits( state )
 		);
 
-		const beforeState = { undo: [] };
-		const afterState = { undo: [] };
+		const beforeState = { undo: { list: [] } };
+		const afterState = { undo: { list: [] } };
 		expect( getReferenceByDistinctEdits( beforeState ) ).toBe(
 			getReferenceByDistinctEdits( afterState )
 		);
 	} );
 
 	it( 'should return referentially equal values across unchanging non-empty state', () => {
-		const undoStates = [ {} ];
+		const undoStates = { list: [ {} ] };
 		const state = { undo: undoStates };
 		expect( getReferenceByDistinctEdits( state ) ).toBe(
 			getReferenceByDistinctEdits( state )
@@ -866,9 +866,9 @@ describe( 'getReferenceByDistinctEdits', () => {
 
 	describe( 'when adding edits', () => {
 		it( 'should return referentially different values across changing states', () => {
-			const beforeState = { undo: [ {} ] };
+			const beforeState = { undo: { list: [ {} ] } };
 			beforeState.undo.offset = 0;
-			const afterState = { undo: [ {}, {} ] };
+			const afterState = { undo: { list: [ {}, {} ] } };
 			afterState.undo.offset = 1;
 			expect( getReferenceByDistinctEdits( beforeState ) ).not.toBe(
 				getReferenceByDistinctEdits( afterState )
@@ -878,9 +878,9 @@ describe( 'getReferenceByDistinctEdits', () => {
 
 	describe( 'when using undo', () => {
 		it( 'should return referentially different values across changing states', () => {
-			const beforeState = { undo: [ {}, {} ] };
+			const beforeState = { undo: { list: [ {}, {} ] } };
 			beforeState.undo.offset = 1;
-			const afterState = { undo: [ {}, {} ] };
+			const afterState = { undo: { list: [ {}, {} ] } };
 			afterState.undo.offset = 0;
 			expect( getReferenceByDistinctEdits( beforeState ) ).not.toBe(
 				getReferenceByDistinctEdits( afterState )

--- a/test/e2e/specs/editor/various/undo.spec.js
+++ b/test/e2e/specs/editor/various/undo.spec.js
@@ -455,6 +455,35 @@ test.describe( 'undo', () => {
 			},
 		] );
 	} );
+
+	// @see https://github.com/WordPress/gutenberg/issues/12075
+	test( 'should be able to undo and redo property cross property changes', async ( {
+		page,
+		pageUtils,
+	} ) => {
+		await page.getByRole( 'textbox', { name: 'Add title' } ).type( 'a' ); // First step.
+		await page.keyboard.press( 'Backspace' ); // Second step.
+		await page.getByRole( 'button', { name: 'Add default block' } ).click(); // third step.
+
+		// Title should be empty
+		await expect(
+			page.getByRole( 'textbox', { name: 'Add title' } )
+		).toHaveText( '' );
+
+		// First undo removes the block.
+		// Second undo restores the title.
+		await pageUtils.pressKeys( 'primary+z' );
+		await pageUtils.pressKeys( 'primary+z' );
+		await expect(
+			page.getByRole( 'textbox', { name: 'Add title' } )
+		).toHaveText( 'a' );
+
+		// Redoing the "backspace" should clear the title again.
+		await pageUtils.pressKeys( 'primaryShift+z' );
+		await expect(
+			page.getByRole( 'textbox', { name: 'Add title' } )
+		).toHaveText( '' );
+	} );
 } );
 
 class UndoUtils {


### PR DESCRIPTION
closes #12075

It's been sometime I didn't dig into the undo/redo reducer and while taking a deep look into it, I noticed a fundamental issue in how the stack is recorded and applied when undoing/redoing.

### How Undo works ?

To understand the issue and the need for this PR to solve it, we first need to understand how the undo/redo works in Gutenberg. 

In trunk, for any change done in the editor, a "set of edits" is added to a list of undos. Each edit, contain the following information: The identifier of the modified entity/record + the set of edits to apply when going (either back or forth) to that state. So the list resembles something like this:

 - entity1, { property1: value1, property2: value2 }
 - entityX { propertyX: valueX, propertyY: valueY }
 - ...

We also keep track of a "pointer" to a particular "step" in this list. By default the pointer is always pointing at the last step (current step) and when calling "undo" it goes back by 1 step (and opposite for redo). 

Each time this step is modified (undo or redo called), we retrieve the set of "edits" corresponding to that step and apply it.

### How do these steps gets recorded

This is a bit complex (as there are edge cases) but for the regular case, the behavior is the following: Let's stay initially the "undo list" contained the following content:

- entity1, { property1: value1 }

The user in the UI edits property1 with value12, the list becomes:

- entity1, { property1: value1 }
- entity1, { property1: value12 }

The user in the UI edits property2 with value22 (let's also assume that the previous value of value2 was value21 but this was not in the undo list, it's just the saved value), the list becomes

- entity1, { property1: value1 }
- entity1, { property2: value21 }
- entity1, { property2: value22 }

Notice that for the second item (penultimate item) of the list, we actually updated the edits to store the previous value of  property2. The reason we do this is because when "undoing" to that step, we need to restore the previous value, so we need to "edit" value2 to set the previous value.

And here's the bug, now let's say with used undo twice, we went to the initial step (property 1 is value1), and now we "redo" to move to the pointer to step2. What will happen now is that the edits of step2 will be applied, so `property2 set to value21` but if you remember properly, in step2, property1 need to be set to value12 and it didn't happen. (This is the bug recorded in #12075)

So what this tells us is that for each "step" in the undo list, we need to record both:

 - The edits to apply when we go up the list (redo)
 - The edits to apply when we go down the list (undo)

### Multi-entity bug

Worth nothing that in trunk, the undo/redo suffer also from the "multi-entity" diff problem. Each diff can contain multiple properties (especially when using transient edits) but in theory "multi-entity" diffs are possible. So each "diff" should be a list of diffs instead.

### Solution

One solution to this is to update the "diff" format to use a (from, to) tupples instead, so for the example above, we should have the following undo stack:

- [ { entity1,  property1, from: value1, to: value12 } ]
- [ { entity2,  property2, from: value21, to: value22 } ]

And when undoing, we use the pointer to retrieve the current diff and edit the entities using the "from" values. (Restore the from values), while for redos, we'd use the "to" values.

Now, this solves navigating up and down the list and we'll get the expected result (and works both for multi property and multi entities).

**This is the main change in this PR** 

 - It changes the format of the undo list in the reducer
 - It allows "multiple edits from multiple entities" to be applied at the same time (using UNDO, REDO actions for now)
 - It also contains secondary changes to simplify the reducer: more specifically "flattenedUndo" is replaced with "cache" which represents a list of multi entity edits that have been performed but no "undo" step has been created for them, they are just waiting for the "next" undo step to be created. This is needed to support "transient entity changes" and "stacked undo steps in RichText".
 - Unfortunately, since the format of the list change and the format is currently exposed in `getUndoEdit`/`getRedoEdit`, this PR contains a breaking change right now. Ideally these selectors should have been private, I'll find a way to solve this by using new private selectors and trying to return something similar in format for these two selectors and probably deprecate them.

There are some extra simplifications that are possible to our undo/redo APIs but are not included in this PR.

**Todo**

 - [x] Ensure all existing unit/e2e tests pass.
 - [x] Add a unit test and/or e2e test for the specific issue being fixed.
 - [x] Backward compatibility for getUndoEdit / getRedoEdit

**Testing instructions**

 - Create a new post
 - Type a character in the post title
 - Remove that character from the post title
 - Type something in the post content
 - Undo until the post title is filled back with the initial character
 - Redo ==> the character should get removed again.