### PR TITLE
Iframe: avoid asset parsing, avoid body replacement, fix script localisation

### DIFF
--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -194,9 +194,14 @@ function Iframe( {
 	// content.
 	const html =
 		'<!doctype html>' +
+		'<head>' +
+		'<meta charset="utf-8">' +
 		'<style>html{height:auto!important;}body{margin:0}</style>' +
 		styles +
-		scripts;
+		'</head>' +
+		'<body>' +
+		scripts +
+		'</body>';
 
 	const [ src, cleanup ] = useMemo( () => {
 		const _src = URL.createObjectURL(

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -190,14 +190,9 @@ function Iframe( {
 	// content.
 	const html =
 		'<!doctype html>' +
-		'<head>' +
-		'<meta charset="utf-8">' +
 		'<style>html{height:auto!important;}body{margin:0}</style>' +
 		styles +
-		'</head>' +
-		'<body>' +
-		scripts +
-		'</body>';
+		scripts;
 
 	const [ src, cleanup ] = useMemo( () => {
 		const _src = URL.createObjectURL(

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -189,15 +189,15 @@ function Iframe( {
 		};
 	}, [] );
 
+	// Correct doctype is required to enable rendering in standards
+	// mode. Also preload the styles to avoid a flash of unstyled
+	// content.
 	const html =
 		'<!doctype html>' +
 		'<style>html{height:auto!important;}body{margin:0}</style>' +
 		styles +
 		scripts;
 
-	// Correct doctype is required to enable rendering in standards
-	// mode. Also preload the styles to avoid a flash of unstyled
-	// content.
 	const [ src, cleanup ] = useMemo( () => {
 		const _src = URL.createObjectURL(
 			new window.Blob( [ html ], { type: 'text/html' } )
@@ -236,9 +236,6 @@ function Iframe( {
 				} }
 				ref={ useMergeRefs( [ ref, setRef ] ) }
 				tabIndex={ tabIndex }
-				// Correct doctype is required to enable rendering in standards
-				// mode. Also preload the styles to avoid a flash of unstyled
-				// content.
 				src={ src }
 				title={ __( 'Editor canvas' ) }
 			>

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -116,9 +116,16 @@ function Iframe( {
 			bubbleEvents( contentDocument );
 			setIframeDocument( contentDocument );
 			clearerRef( documentElement );
+			bodyRef( contentDocument.body );
 
 			contentDocument.body.classList.add( 'wp-block-editor__iframe' );
 			contentDocument.body.classList.add( 'editor-styles-wrapper' );
+
+			contentDocument.body.addEventListener( 'click', ( event ) => {
+				if ( event.target === contentDocument.body ) {
+					node.click();
+				}
+			} );
 
 			// Ideally ALL classes that are added through get_body_class should
 			// be added in the editor too, which we'll somehow have to get from
@@ -235,12 +242,12 @@ function Iframe( {
 			>
 				{ iframeDocument &&
 					createPortal(
-						<div ref={ bodyRef }>
+						<>
 							{ contentResizeListener }
 							<StyleProvider document={ iframeDocument }>
 								{ children }
 							</StyleProvider>
-						</div>,
+						</>,
 						iframeDocument.body
 					) }
 			</iframe>

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -133,16 +133,6 @@ function Iframe( {
 				}
 			}
 
-			for ( const compatStyle of compatStyles ) {
-				if ( contentDocument.getElementById( compatStyle.id ) ) {
-					continue;
-				}
-
-				contentDocument.head.appendChild(
-					compatStyle.cloneNode( true )
-				);
-			}
-
 			contentDocument.dir = ownerDocument.dir;
 
 			for ( const compatStyle of compatStyles ) {

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -121,6 +121,12 @@ function Iframe( {
 			contentDocument.body.classList.add( 'wp-block-editor__iframe' );
 			contentDocument.body.classList.add( 'editor-styles-wrapper' );
 
+			contentDocument.body.addEventListener( 'click', ( event ) => {
+				if ( event.target === contentDocument.body ) {
+					node.click();
+				}
+			} );
+
 			// Ideally ALL classes that are added through get_body_class should
 			// be added in the editor too, which we'll somehow have to get from
 			// the server in the future (which will run the PHP filters).

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -116,16 +116,9 @@ function Iframe( {
 			bubbleEvents( contentDocument );
 			setIframeDocument( contentDocument );
 			clearerRef( documentElement );
-			bodyRef( contentDocument.body );
 
 			contentDocument.body.classList.add( 'wp-block-editor__iframe' );
 			contentDocument.body.classList.add( 'editor-styles-wrapper' );
-
-			contentDocument.body.addEventListener( 'click', ( event ) => {
-				if ( event.target === contentDocument.body ) {
-					node.click();
-				}
-			} );
 
 			// Ideally ALL classes that are added through get_body_class should
 			// be added in the editor too, which we'll somehow have to get from
@@ -252,12 +245,12 @@ function Iframe( {
 			>
 				{ iframeDocument &&
 					createPortal(
-						<>
+						<div ref={ bodyRef }>
 							{ contentResizeListener }
 							<StyleProvider document={ iframeDocument }>
 								{ children }
 							</StyleProvider>
-						</>,
+						</div>,
 						iframeDocument.body
 					) }
 			</iframe>

--- a/packages/e2e-tests/plugins/iframed-enqueue-block-assets.php
+++ b/packages/e2e-tests/plugins/iframed-enqueue-block-assets.php
@@ -17,5 +17,18 @@ add_action(
 			filemtime( plugin_dir_path( __FILE__ ) . 'iframed-enqueue-block-assets/style.css' )
 		);
 		wp_add_inline_style( 'iframed-enqueue-block-assets', 'body{padding:20px!important}' );
+		wp_enqueue_script(
+			'iframed-enqueue-block-assets-script',
+			plugin_dir_url( __FILE__ ) . 'iframed-enqueue-block-assets/script.js',
+			array(),
+			filemtime( plugin_dir_path( __FILE__ ) . 'iframed-enqueue-block-assets/script.js' )
+		);
+		wp_localize_script(
+			'iframed-enqueue-block-assets-script',
+			'iframedEnqueueBlockAssetsL10n',
+			array(
+				'test' => __( 'Iframed Enqueue Block Assets!' ),
+			)
+		);
 	}
 );

--- a/packages/e2e-tests/plugins/iframed-enqueue-block-assets.php
+++ b/packages/e2e-tests/plugins/iframed-enqueue-block-assets.php
@@ -27,7 +27,7 @@ add_action(
 			'iframed-enqueue-block-assets-script',
 			'iframedEnqueueBlockAssetsL10n',
 			array(
-				'test' => __( 'Iframed Enqueue Block Assets!' ),
+				'test' => 'Iframed Enqueue Block Assets!',
 			)
 		);
 	}

--- a/packages/e2e-tests/plugins/iframed-enqueue-block-assets/script.js
+++ b/packages/e2e-tests/plugins/iframed-enqueue-block-assets/script.js
@@ -1,0 +1,3 @@
+window.addEventListener( 'DOMContentLoaded', () => {
+    document.body.dataset.iframedEnqueueBlockAssetsL10n = window.iframedEnqueueBlockAssetsL10n.test;
+} );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes https://github.com/WordPress/gutenberg/pull/49655#issuecomment-1549834238.

Since we started using `srcDoc` and now a src with a blob, we can simply pass the style and script dependencies we get as HTML. We don't need to parse the HTML separately and then add it through as React elements.

Additionally, we should avoid replacing the body element. Scripts should be loaded on page load as they normally would so they can make use of `load` and `DOMContentLoaded` events, with the root elements being available and not replaced later.

This should also fix script localisation since the browser now handles script loading.

## Why?

Simplify, performance.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
