### PR TITLE
Lodash: Remove `_.isEmpty()` from site editor

### DIFF
--- a/packages/edit-site/src/components/global-styles/screen-revisions/use-global-styles-revisions.js
+++ b/packages/edit-site/src/components/global-styles/screen-revisions/use-global-styles-revisions.js
@@ -5,10 +5,7 @@ import { useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 import { useContext, useMemo } from '@wordpress/element';
 import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
-/**
- * External dependencies
- */
-import { isEmpty } from 'lodash';
+
 /**
  * Internal dependencies
  */
@@ -75,7 +72,12 @@ export default function useGlobalStylesRevisions() {
 		}
 
 		// Adds an item for unsaved changes.
-		if ( isDirty && ! isEmpty( userConfig ) && currentUser ) {
+		if (
+			isDirty &&
+			userConfig &&
+			Object.keys( userConfig ).length > 0 &&
+			currentUser
+		) {
 			const unsavedRevision = {
 				id: 'unsaved',
 				styles: userConfig?.styles,

--- a/packages/edit-site/src/components/header-edit-mode/tools-more-menu-group/index.js
+++ b/packages/edit-site/src/components/header-edit-mode/tools-more-menu-group/index.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { isEmpty } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { createSlotFill } from '@wordpress/components';
@@ -14,7 +9,7 @@ const { Fill: ToolsMoreMenuGroup, Slot } = createSlotFill(
 
 ToolsMoreMenuGroup.Slot = ( { fillProps } ) => (
 	<Slot fillProps={ fillProps }>
-		{ ( fills ) => ! isEmpty( fills ) && fills }
+		{ ( fills ) => fills && fills.length > 0 }
 	</Slot>
 );
 

--- a/packages/edit-site/src/components/revisions/index.js
+++ b/packages/edit-site/src/components/revisions/index.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { isEmpty } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { Disabled } from '@wordpress/components';
@@ -30,6 +25,10 @@ import EditorCanvasContainer from '../editor-canvas-container';
 const { ExperimentalBlockEditorProvider, useGlobalStylesOutputWithConfig } =
 	unlock( blockEditorPrivateApis );
 
+function isObjectEmpty( object ) {
+	return ! object || Object.keys( object ).length === 0;
+}
+
 function Revisions( { onClose, userConfig, blocks } ) {
 	const { baseConfig } = useSelect(
 		( select ) => ( {
@@ -42,7 +41,7 @@ function Revisions( { onClose, userConfig, blocks } ) {
 	);
 
 	const mergedConfig = useMemo( () => {
-		if ( ! isEmpty( userConfig ) && ! isEmpty( baseConfig ) ) {
+		if ( ! isObjectEmpty( userConfig ) && ! isObjectEmpty( baseConfig ) ) {
 			return mergeBaseAndUserConfigs( baseConfig, userConfig );
 		}
 		return {};
@@ -65,7 +64,7 @@ function Revisions( { onClose, userConfig, blocks } ) {
 	const [ globalStyles ] = useGlobalStylesOutputWithConfig( mergedConfig );
 
 	const editorStyles =
-		! isEmpty( globalStyles ) && ! isEmpty( userConfig )
+		! isObjectEmpty( globalStyles ) && ! isObjectEmpty( userConfig )
 			? globalStyles
 			: settings.styles;
 


### PR DESCRIPTION
## What?
This PR removes Lodash's `_.isEmpty()` from the site editor.

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?

An object is empty if it's not an object or if it has zero properties. We're using truthiness checks and `Object.keys().length` to verify that.

## Testing Instructions
* Verify global styles revisions still work well (saving new, restoring previous existing ones).
* Verify the Tools sub menu in the global editor settings still appears and works well.
* Verify all checks are green and all tests still pass.