### PR TITLE
List View: Append when dragging into collapsed blocks

### DIFF
--- a/packages/block-editor/src/components/list-view/test/use-list-view-drop-zone.js
+++ b/packages/block-editor/src/components/list-view/test/use-list-view-drop-zone.js
@@ -172,7 +172,7 @@ describe( 'getListViewDropTarget', () => {
 		} );
 	} );
 
-	it( 'should nest when dragging a block over the right side and bottom half of a collapsed block with children', () => {
+	it( 'should nest and append to end when dragging a block over the right side and bottom half of a collapsed block with children', () => {
 		const position = { x: 160, y: 90 };
 
 		const collapsedBlockData = [ ...blocksData ];
@@ -185,6 +185,26 @@ describe( 'getListViewDropTarget', () => {
 
 		// Hide the first block's children.
 		collapsedBlockData.splice( 1, 1 );
+
+		const target = getListViewDropTarget( collapsedBlockData, position );
+
+		expect( target ).toEqual( {
+			blockIndex: 1,
+			dropPosition: 'inside',
+			rootClientId: 'block-1',
+		} );
+	} );
+
+	it( 'should nest and prepend when dragging a block over the right side and bottom half of an expanded block with children', () => {
+		const position = { x: 160, y: 90 };
+
+		const collapsedBlockData = [ ...blocksData ];
+
+		// Set the first block to be collapsed.
+		collapsedBlockData[ 0 ] = {
+			...collapsedBlockData[ 0 ],
+			isExpanded: true,
+		};
 
 		const target = getListViewDropTarget( collapsedBlockData, position );
 

--- a/packages/block-editor/src/components/list-view/use-list-view-drop-zone.js
+++ b/packages/block-editor/src/components/list-view/use-list-view-drop-zone.js
@@ -338,9 +338,15 @@ export function getListViewDropTarget( blocksData, position ) {
 				candidateBlockParents.length
 			) )
 	) {
+		// If the block is expanded, insert the block as the first child.
+		// Otherwise, for collapsed blocks, insert the block as the last child.
+		const newBlockIndex = candidateBlockData.isExpanded
+			? 0
+			: candidateBlockData.innerBlockCount || 0;
+
 		return {
 			rootClientId: candidateBlockData.clientId,
-			blockIndex: 0,
+			blockIndex: newBlockIndex,
 			dropPosition: 'inside',
 		};
 	}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Part of https://github.com/WordPress/gutenberg/issues/49563, fixes https://github.com/WordPress/gutenberg/issues/50716

When dragging a block within the list view over a collapsed block, append the dropped block to the end of the container block's inner blocks, instead of prepending to the beginning of the block.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

As raised in #50716, when a group block is collapsed and a user drags a block onto it, it's likely that the expected result is for the block to be appended to the end of that block's children instead of being prepended.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* In the nesting logic for the list view drag and drop, check if the block is expanded. If it is expanded, then set the `blockIndex` to `0` explicitly as the block's children are expanded, so the user will be visually attempting to place the block at the beginning of that part of the list.
* If the block is not expanded, then use the number of inner blocks for the block as the `blockIndex` if it is available. This places the dragged block at the end of the inner blocks of the container block.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Add a Group block with a few children to a post, page, or template.
2. Open the list view and with the Group block collapsed, go to drag another block within the Group block.
3. Expand the Group block, and observe that the dragged block should now be at the bottom of the list of inner blocks.
4. With the Group block expanded, go to drag a block to the first position with the Group block — this should still be possible just as on `trunk`
5. Smoke test that dragging blocks onto empty Group blocks works as on trunk with no issues.

## Screenshots or screencast <!-- if applicable -->

| Before | After |
| --- | --- |
| ![2023-05-25 10 38 49](https://github.com/WordPress/gutenberg/assets/14988353/1541b1c1-78d1-4cf3-b626-f42383a15083) | ![2023-05-25 12 00 06](https://github.com/WordPress/gutenberg/assets/14988353/231b6e58-08da-4bfb-b297-fb81db9b3183) |