### PR TITLE
Revert "Browse Mode: Add snackbar notices (#50794)"

### DIFF
--- a/packages/components/src/snackbar/list.tsx
+++ b/packages/components/src/snackbar/list.tsx
@@ -73,6 +73,7 @@ export function SnackbarList( {
 
 					return (
 						<motion.div
+							layout={ ! isReducedMotion } // See https://www.framer.com/docs/animation/#layout-animations
 							initial={ 'init' }
 							animate={ 'open' }
 							exit={ 'exit' }

--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -180,7 +180,12 @@ export default function Editor( { isLoading } ) {
 									'is-loading': isLoading,
 								}
 							) }
-							notices={ <EditorSnackbars /> }
+							notices={
+								( isEditMode ||
+									window?.__experimentalEnableThemePreviews ) && (
+									<EditorSnackbars />
+								)
+							}
 							content={
 								<>
 									<GlobalStylesRenderer />

--- a/packages/edit-site/src/components/editor/style.scss
+++ b/packages/edit-site/src/components/editor/style.scss
@@ -19,16 +19,11 @@
 }
 
 // Adjust the position of the notices
-.edit-site {
-	.components-editor-notices__snackbar {
-		position: fixed;
-		right: 0;
-		bottom: 0;
-		padding: 16px;
-	}
-	.is-edit-mode .components-editor-notices__snackbar {
-		bottom: 24px;
-	}
+.edit-site .components-editor-notices__snackbar {
+	position: fixed;
+	right: 0;
+	bottom: 40px;
+	padding-left: 16px;
+	padding-right: 16px;
 }
-
 @include editor-left(".edit-site .components-editor-notices__snackbar")

--- a/packages/edit-site/src/components/layout/index.js
+++ b/packages/edit-site/src/components/layout/index.js
@@ -215,7 +215,7 @@ export default function Layout() {
 									whileHover={
 										isEditorPage && canvasMode === 'view'
 											? {
-													scale: 1.006,
+													scale: 1.005,
 													transition: {
 														duration:
 															disableMotion ||
@@ -227,14 +227,8 @@ export default function Layout() {
 											  }
 											: {}
 									}
-									// Setting a transform property (in this case scale) on an element makes it act as a containing block for its descendants.
-									// This means that the snackbar notices inside this component are repositioned to be relative to this element.
-									// To avoid the snackbars jumping about we need to ensure that a transform property is always set.
-									// Setting a scale of 1 is interpred by framer as no change, so once the animation completes
-									// the transform property of this element is set to none, thus removing its role as a container block.
-									// Instead we set the initial scale of this element to 1.0001 so that there is always a transform property set.
-									// If we set the initial scale to less than 1.001 then JavaScript rounds it to 1 and the problem reoccurs.
-									initial={ { scale: 1.001 } }
+									initial={ false }
+									layout="position"
 									className="edit-site-layout__canvas"
 									transition={ {
 										type: 'tween',


### PR DESCRIPTION
## What?
As mentioned in https://github.com/WordPress/gutenberg/pull/50794#issuecomment-1562247497, this causes quite a bad bug with block toolbars, so I think a revert is best for now.

## Why?
I'm not sure why the bug happens.

The change to `scale` might explain the blur, but I'm not sure on the rest of it.

## How?
`git revert`

## Testing Instructions
1. Open the site editor to a template with enough content to show a toolbar
2. Select a block
3. The toolbar shouldn't be blurred.
4. Scroll
5. The toolbar should follow the block position

## Screenshots or screencast <!-- if applicable -->
#### Before
![2023-05-25 14 11 25](https://github.com/WordPress/gutenberg/assets/677833/78e0738f-3fc7-4bc6-9732-ccf1a2c24015)

#### After
https://github.com/WordPress/gutenberg/assets/677833/8e301fe9-bc69-4625-b80b-b5c935b8de58

