### PR TITLE
Ignore framer-motion warning when running E2E tests locally

### DIFF
--- a/packages/e2e-tests/config/setup-test-framework.js
+++ b/packages/e2e-tests/config/setup-test-framework.js
@@ -158,6 +158,15 @@ function observeConsoleLogging() {
 			return;
 		}
 
+		// Ignore framer-motion warnings about reduced motion.
+		if (
+			text.includes(
+				'You have Reduced Motion enabled on your device. Animations may not appear as expected.'
+			)
+		) {
+			return;
+		}
+
 		const logFunction = OBSERVED_CONSOLE_MESSAGE_TYPES[ type ];
 
 		// As of Puppeteer 1.6.1, `message.text()` wrongly returns an object of


### PR DESCRIPTION
You get this error when running Puppeteer tests locally with a development build (`rpm run dev`).

```
Expected mock function not to be called but it was called with:
    ["You have Reduced Motion enabled on your device. Animations may not appear as expected."]
```

It's expected that reduced motion is enabled in our E2E test suite as it helps the tests run quicker. 

So the solution is to just ignore this warning.