### PR TITLE
Fix query-no-results block from showing when their is one search result #47793

### DIFF
--- a/packages/block-library/src/post-content/index.php
+++ b/packages/block-library/src/post-content/index.php
@@ -22,6 +22,9 @@ function render_block_core_post_content( $attributes, $content, $block ) {
 
 	$post_id = $block->context['postId'];
 
+	// Get the current query the block is rendered with.
+	$query = isset( $GLOBALS['post_template_query'] ) ? $GLOBALS['post_template_query'] : $GLOBALS['wp_query'];
+
 	if ( isset( $seen_ids[ $post_id ] ) ) {
 		// WP_DEBUG_DISPLAY must only be honored when WP_DEBUG. This precedent
 		// is set in `wp_debug_mode()`.
@@ -37,8 +40,8 @@ function render_block_core_post_content( $attributes, $content, $block ) {
 
 	// Check is needed for backward compatibility with third-party plugins
 	// that might rely on the `in_the_loop` check; calling `the_post` sets it to true.
-	if ( ! in_the_loop() && have_posts() ) {
-		the_post();
+	if ( ! $query->in_the_loop && $query->have_posts() ) {
+		$query->the_post();
 	}
 
 	// When inside the main loop, we want to use queried object

--- a/packages/block-library/src/post-featured-image/index.php
+++ b/packages/block-library/src/post-featured-image/index.php
@@ -19,10 +19,13 @@ function render_block_core_post_featured_image( $attributes, $content, $block ) 
 	}
 	$post_ID = $block->context['postId'];
 
+	// Get the current query the block is rendered with.
+	$query = isset( $GLOBALS['post_template_query'] ) ? $GLOBALS['post_template_query'] : $GLOBALS['wp_query'];
+
 	// Check is needed for backward compatibility with third-party plugins
 	// that might rely on the `in_the_loop` check; calling `the_post` sets it to true.
-	if ( ! in_the_loop() && have_posts() ) {
-		the_post();
+	if ( ! $query->in_the_loop && $query->have_posts() ) {
+		$query->the_post();
 	}
 
 	$is_link        = isset( $attributes['isLink'] ) && $attributes['isLink'];

--- a/packages/block-library/src/post-template/index.php
+++ b/packages/block-library/src/post-template/index.php
@@ -74,6 +74,10 @@ function render_block_core_post_template( $attributes, $content, $block ) {
 
 	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => trim( $classnames ) ) );
 
+	// Store the query used by the post-template.
+	// This allows inner blocks of the post-template to access it.
+	$GLOBALS['post_template_query'] = $query;
+
 	$content = '';
 	while ( $query->have_posts() ) {
 		$query->the_post();
@@ -101,6 +105,9 @@ function render_block_core_post_template( $attributes, $content, $block ) {
 		$post_classes = implode( ' ', get_post_class( 'wp-block-post' ) );
 		$content     .= '<li class="' . esc_attr( $post_classes ) . '">' . $block_content . '</li>';
 	}
+
+	// Reset the global after the post-template loop.
+	unset( $GLOBALS['post_template_query'] );
 
 	/*
 	 * Use this function to restore the context of the template tags


### PR DESCRIPTION
This allows inner blocks to operate on the correct query when checking for the state of the loop.

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md --> 

## What?
This is an attempt at addressing #47793
Store the `post-template` block's query in globals. In `post-content` and `post-featured-image` blocks, use the query if available instead of the global one.

**⚠️ Warning :** The current behavior was meant to fix an issue where some plugins would work properly because the check to `in_the_loop` would fail. This PR should be tested to see if it reintroduces the bug or not.

## Why?
This change is to avoid manipulating the global `wp_query` in the `post-content` and `post-featured-image` blocks.

These blocks are typically used as inner blocks of the `post-template` block. When the `post-template` block is configured to use the global `wp_query` it'll create a clone of it instead of using it directly, so the two aforementioned blocks shouldn't operate on the global one.

## How?
In `post-template`, the query is stored in a global. In the blocks `post-content` and `post-featured-image` this query is retrieved and used instead of using the functions for the global query.

## Testing Instructions
1. Activate Twenty Twenty-Three, or insert the No Results block in a search template
2. Search for a keyword that should have 1 search result (e.g. "hello world")
3. The No Results block should not be show
