### PR TITLE
Block Toolbar: Fix text only label for locked blocks

### DIFF
--- a/packages/block-editor/src/components/block-lock/style.scss
+++ b/packages/block-editor/src/components/block-lock/style.scss
@@ -52,10 +52,17 @@
 .block-editor-block-lock-toolbar {
 	.components-button.has-icon {
 		min-width: $button-size-small + $grid-unit-15 !important;
-		padding-left: 0 !important;
+	}
+}
 
-		&:focus::before {
-			right: $grid-unit-10 !important;
-		}
+.block-editor-block-toolbar__block-controls .block-editor-block-lock-toolbar {
+	margin-left: -$grid-unit-15 * 0.5 !important;
+}
+
+.show-icon-labels {
+	.block-editor-block-toolbar__block-controls .block-editor-block-lock-toolbar {
+		border-left: 1px solid $gray-900;
+		margin-left: $grid-unit-15 * 0.5 !important;
+		margin-right: -$grid-unit-15 * 0.5;
 	}
 }

--- a/packages/block-editor/src/components/block-toolbar/style.scss
+++ b/packages/block-editor/src/components/block-toolbar/style.scss
@@ -110,10 +110,6 @@
 		}
 	}
 
-	.block-editor-block-lock-toolbar {
-		margin-left: -$grid-unit-15 * 0.5 !important;
-	}
-
 	// @todo: override toolbar group inherited paddings from components/block-tools/style.scss.
 	// This is best fixed by making the mover control area a proper single toolbar group.
 	.components-toolbar-group {


### PR DESCRIPTION
## What?
Fixes #49865.

PR adjusts the styling of the text-only label for locked blocks.

## Testing Instructions
1. Open a Post or Page.
2. Insert any block and lock it.
3. Confirm the lock icon is displayed as before.
4. Enable "Show button text labels" from Preferences.
5. Confirm label is correctly spaced and has a left border.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2023-05-31 at 08 55 15](https://github.com/WordPress/gutenberg/assets/240569/3f3c69c1-330c-4f5f-afa7-496a0dec85df)
![CleanShot 2023-05-25 at 12 51 57](https://github.com/WordPress/gutenberg/assets/240569/b81ec752-0cf9-444a-88f1-69f093efc834)

