### PR TITLE
alternative to 50235

### DIFF
--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -524,7 +524,7 @@ function render_block_core_navigation( $attributes, $content, $block ) {
 
 		if ( $is_list_item && ! $is_list_open ) {
 			$is_list_open       = true;
-			$inner_blocks_html .= '<ul class="wp-block-navigation__container">';
+			$inner_blocks_html .= '<ul class="wp-block-navigation__container '.implode( ' ', $classes ).'">';
 		}
 
 		if ( ! $is_list_item && $is_list_open ) {

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -176,12 +176,12 @@ $navigation-icon-size: 24px;
 		height: 0;
 		overflow: hidden; // Overflow is necessary to set, otherwise submenu items will take up space.
 
-		// Set a default background color for submenus so that they're not transparent.
+		// Inherit the background color for submenus so that they're not transparent.
 		// NOTE TO DEVS - if refactoring this code, please double-check that
 		// submenus have a default background color, this feature has regressed
 		// several times, so care needs to be taken.
-		background-color: #fff;
-		color: #000;
+		background-color: inherit;
+		color: inherit;
 
 		// Submenu items.
 		> .wp-block-navigation-item {
@@ -405,6 +405,8 @@ button.wp-block-navigation-item__content {
 // Default border color.
 .wp-block-navigation:not(.has-background) {
 	.wp-block-navigation__submenu-container {
+		background-color: #fff;
+		color: #000;
 		// Sets a border for submenus for backwards compatibility.
 		// This is under a :not selector so that if a user sets
 		// a background color the borders are removed.


### PR DESCRIPTION
- Navigation: Keep the default submenu colors unless the block sets others
- Match the behaviour of the editor to the front end
- Update packages/block-library/src/navigation/style.scss
- inherit background color

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
