### PR TITLE
Fix refactor flat term selector to use data api for creating new terms

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17863,7 +17863,6 @@
 				"@wordpress/wordcount": "file:packages/wordcount",
 				"classnames": "^2.3.1",
 				"date-fns": "^2.28.0",
-				"escape-html": "^1.0.3",
 				"memize": "^2.1.0",
 				"react-autosize-textarea": "^7.1.0",
 				"rememo": "^4.0.2",

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -61,7 +61,6 @@
 		"@wordpress/wordcount": "file:../wordcount",
 		"classnames": "^2.3.1",
 		"date-fns": "^2.28.0",
-		"escape-html": "^1.0.3",
 		"memize": "^2.1.0",
 		"react-autosize-textarea": "^7.1.0",
 		"rememo": "^4.0.2",

--- a/packages/editor/src/components/post-taxonomies/flat-term-selector.js
+++ b/packages/editor/src/components/post-taxonomies/flat-term-selector.js
@@ -143,7 +143,7 @@ export function FlatTermSelector( { slug } ) {
 		return null;
 	}
 
-	async function createTerm( term ) {
+	async function findOrCreateTerm( term ) {
 		try {
 			const newTerm = await saveEntityRecord( 'taxonomy', slug, term, {
 				throwOnError: true,
@@ -201,7 +201,9 @@ export function FlatTermSelector( { slug } ) {
 		}
 
 		Promise.all(
-			newTermNames.map( ( termName ) => createTerm( { name: termName } ) )
+			newTermNames.map( ( termName ) =>
+				findOrCreateTerm( { name: termName } )
+			)
 		).then( ( newTerms ) => {
 			const newAvailableTerms = availableTerms.concat( newTerms );
 			return onUpdateTerms(


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Refactors the `FlatTermSelector` component to use the Data API instead of direct fetch calls for creating new terms.


## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
When using straight-up fetch calls to create new terms that doesn't trigger an invalidation of the relevant data store. Therefore any listeners subscribed to the terms won't trigger an update.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
By using the `saveEntityRecord` dispatcher instead of a raw `apiFetch` call

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a Post in the editor.
2. Open the document sidebar
3. Add some existing and some new terms.
4. Ensure that they are saved/created correctly

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
