### PR TITLE
Navigation block: Set correct aria-expanded on hover

### DIFF
--- a/lib/experimental/interactivity-api/blocks.php
+++ b/lib/experimental/interactivity-api/blocks.php
@@ -200,7 +200,7 @@ function gutenberg_block_core_navigation_add_directives_to_submenu( $w, $block_a
 		$w->set_attribute( 'data-wp-effect', 'effects.core.navigation.initMenu' );
 		$w->set_attribute( 'data-wp-on.focusout', 'actions.core.navigation.handleMenuFocusout' );
 		$w->set_attribute( 'data-wp-on.keydown', 'actions.core.navigation.handleMenuKeydown' );
-		if ( ! isset( $block_attributes['openSubmenusOnClick'] ) ) {
+		if ( ! isset( $block_attributes['openSubmenusOnClick'] ) || false === $block_attributes['openSubmenusOnClick'] ) {
 			$w->set_attribute( 'data-wp-on.mouseenter', 'actions.core.navigation.openMenuOnHover' );
 			$w->set_attribute( 'data-wp-on.mouseleave', 'actions.core.navigation.closeMenuOnHover' );
 		}

--- a/lib/experimental/interactivity-api/blocks.php
+++ b/lib/experimental/interactivity-api/blocks.php
@@ -39,7 +39,7 @@ add_filter( 'render_block_core/file', 'gutenberg_block_core_file_add_directives_
  * >
  *   <button
  *     class="wp-block-navigation__responsive-container-open"
- *     data-wp-on.click="actions.core.navigation.openMenu"
+ *     data-wp-on.click="actions.core.navigation.openMenuOnClick"
  *     data-wp-on.keydown="actions.core.navigation.handleMenuKeydown"
  *   >
  *   <div
@@ -167,10 +167,12 @@ function gutenberg_block_core_navigation_add_directives_to_markup( $block_conten
  *   data-wp-effect="effects.core.navigation.initMenu"
  *   data-wp-on.keydown="actions.core.navigation.handleMenuKeydown"
  *   data-wp-on.focusout="actions.core.navigation.handleMenuFocusout"
+ * 	 data-wp-on.mouseenter="actions.core.navigation.openMenuOnHover"
+ * 	 data-wp-on.mouseleave="actions.core.navigation.closeMenuOnHover"
  * >
  *   <button
  *     class="wp-block-navigation-submenu__toggle"
- *     data-wp-on.click="actions.core.navigation.openMenuOnClick"
+ *     data-wp-on.click="actions.core.navigation.toggleMenuOnClick"
  *     data-wp-bind.aria-expanded="selectors.core.navigation.isMenuOpen"
  *   >
  *   </button>

--- a/lib/experimental/interactivity-api/blocks.php
+++ b/lib/experimental/interactivity-api/blocks.php
@@ -61,7 +61,7 @@ add_filter( 'render_block_core/file', 'gutenberg_block_core_file_add_directives_
  *       >
  *         <button
  *           class="wp-block-navigation__responsive-container-close"
- *           data-wp-on.click="actions.core.navigation.closeMenu"
+ *           data-wp-on.click="actions.core.navigation.closeMenuOnclick"
  *         >
  *           <svg>
  *         <button>
@@ -147,7 +147,7 @@ function gutenberg_block_core_navigation_add_directives_to_markup( $block_conten
 			'class_name' => 'wp-block-navigation__responsive-container-close',
 		)
 	) ) {
-		$w->set_attribute( 'data-wp-on.click', 'actions.core.navigation.closeMenu' );
+		$w->set_attribute( 'data-wp-on.click', 'actions.core.navigation.closeMenuOnClick' );
 		$w->remove_attribute( 'data-micromodal-close' );
 	};
 
@@ -170,7 +170,7 @@ function gutenberg_block_core_navigation_add_directives_to_markup( $block_conten
  * >
  *   <button
  *     class="wp-block-navigation-submenu__toggle"
- *     data-wp-on.click="actions.core.navigation.openMenu"
+ *     data-wp-on.click="actions.core.navigation.openMenuOnClick"
  *     data-wp-bind.aria-expanded="selectors.core.navigation.isMenuOpen"
  *   >
  *   </button>

--- a/lib/experimental/interactivity-api/blocks.php
+++ b/lib/experimental/interactivity-api/blocks.php
@@ -35,7 +35,7 @@ add_filter( 'render_block_core/file', 'gutenberg_block_core_file_add_directives_
  *
  * <nav
  *   data-wp-island
- *   data-wp-context='{ "core": { "navigation": { "isMenuOpen": false, "overlay": true, "roleAttribute": "" } } }'
+ *   data-wp-context='{ "core": { "navigation": { "isMenuOpen": { "click": false, "hover": false }, "overlay": true, "roleAttribute": "" } } }'
  * >
  *   <button
  *     class="wp-block-navigation__responsive-container-open"
@@ -44,9 +44,9 @@ add_filter( 'render_block_core/file', 'gutenberg_block_core_file_add_directives_
  *   >
  *   <div
  *     class="wp-block-navigation__responsive-container"
- *     data-wp-class.has-modal-open="context.core.navigation.isMenuOpen"
- *     data-wp-class.is-menu-open="context.core.navigation.isMenuOpen"
- *     data-wp-bind.aria-hidden="!context.core.navigation.isMenuOpen"
+ *     data-wp-class.has-modal-open="selectors.core.navigation.isMenuOpen"
+ *     data-wp-class.is-menu-open="selectors.core.navigation.isMenuOpen"
+ *     data-wp-bind.aria-hidden="!selectors.core.navigation.isMenuOpen"
  *     data-wp-effect="effects.core.navigation.initMenu"
  *     data-wp-on.keydown="actions.core.navigation.handleMenuKeydown"
  *     data-wp-on.focusout="actions.core.navigation.handleMenuFocusout"
@@ -55,7 +55,7 @@ add_filter( 'render_block_core/file', 'gutenberg_block_core_file_add_directives_
  *     <div class="wp-block-navigation__responsive-close">
  *       <div
  *         class="wp-block-navigation__responsive-dialog"
- *         data-wp-bind.aria-modal="context.core.navigation.isMenuOpen"
+ *         data-wp-bind.aria-modal="selectors.core.navigation.isMenuOpen"
  *         data-wp-bind.role="selectors.core.navigation.roleAttribute"
  *         data-wp-effect="effects.core.navigation.focusFirstElement"
  *       >
@@ -75,12 +75,12 @@ add_filter( 'render_block_core/file', 'gutenberg_block_core_file_add_directives_
  *
  * @return string Navigation block markup with the proper directives
  */
-function gutenberg_block_core_navigation_add_directives_to_markup( $block_content ) {
+function gutenberg_block_core_navigation_add_directives_to_markup( $block_content, $block, $instance ) {
 	$w = new WP_HTML_Tag_Processor( $block_content );
 	// Add directives to the `<nav>` element.
 	if ( $w->next_tag( 'nav' ) ) {
 		$w->set_attribute( 'data-wp-island', '' );
-		$w->set_attribute( 'data-wp-context', '{ "core": { "navigation": { "isMenuOpen": false, "overlay": true, "roleAttribute": "" } } }' );
+		$w->set_attribute( 'data-wp-context', '{ "core": { "navigation": { "isMenuOpen": { "click": false, "hover": false }, "overlay": true, "roleAttribute": "" } } }' );
 	};
 
 	// Add directives to the open menu button.
@@ -90,14 +90,14 @@ function gutenberg_block_core_navigation_add_directives_to_markup( $block_conten
 			'class_name' => 'wp-block-navigation__responsive-container-open',
 		)
 	) ) {
-		$w->set_attribute( 'data-wp-on.click', 'actions.core.navigation.openMenu' );
+		$w->set_attribute( 'data-wp-on.click', 'actions.core.navigation.openMenuOnClick' );
 		$w->set_attribute( 'data-wp-on.keydown', 'actions.core.navigation.handleMenuKeydown' );
 		$w->remove_attribute( 'data-micromodal-trigger' );
 	} else {
 		// If the open modal button not found, we handle submenus immediately.
 		$w = new WP_HTML_Tag_Processor( $w->get_updated_html() );
 
-		gutenberg_block_core_navigation_add_directives_to_submenu( $w );
+		gutenberg_block_core_navigation_add_directives_to_submenu( $w, $block[ 'attrs' ] );
 
 		return $w->get_updated_html();
 	}
@@ -109,9 +109,9 @@ function gutenberg_block_core_navigation_add_directives_to_markup( $block_conten
 			'class_name' => 'wp-block-navigation__responsive-container',
 		)
 	) ) {
-		$w->set_attribute( 'data-wp-class.has-modal-open', 'context.core.navigation.isMenuOpen' );
-		$w->set_attribute( 'data-wp-class.is-menu-open', 'context.core.navigation.isMenuOpen' );
-		$w->set_attribute( 'data-wp-bind.aria-hidden', '!context.core.navigation.isMenuOpen' );
+		$w->set_attribute( 'data-wp-class.has-modal-open', 'selectors.core.navigation.isMenuOpen' );
+		$w->set_attribute( 'data-wp-class.is-menu-open', 'selectors.core.navigation.isMenuOpen' );
+		$w->set_attribute( 'data-wp-bind.aria-hidden', '!selectors.core.navigation.isMenuOpen' );
 		$w->set_attribute( 'data-wp-effect', 'effects.core.navigation.initMenu' );
 		$w->set_attribute( 'data-wp-on.keydown', 'actions.core.navigation.handleMenuKeydown' );
 		$w->set_attribute( 'data-wp-on.focusout', 'actions.core.navigation.handleMenuFocusout' );
@@ -135,7 +135,7 @@ function gutenberg_block_core_navigation_add_directives_to_markup( $block_conten
 			'class_name' => 'wp-block-navigation__responsive-dialog',
 		)
 	) ) {
-		$w->set_attribute( 'data-wp-bind.aria-modal', 'context.core.navigation.isMenuOpen' );
+		$w->set_attribute( 'data-wp-bind.aria-modal', 'selectors.core.navigation.isMenuOpen' );
 		$w->set_attribute( 'data-wp-bind.role', 'selectors.core.navigation.roleAttribute' );
 		$w->set_attribute( 'data-wp-effect', 'effects.core.navigation.focusFirstElement' );
 	};
@@ -152,7 +152,7 @@ function gutenberg_block_core_navigation_add_directives_to_markup( $block_conten
 	};
 
 	// Submenus.
-	gutenberg_block_core_navigation_add_directives_to_submenu( $w );
+	gutenberg_block_core_navigation_add_directives_to_submenu( $w, $block[ 'attrs' ] );
 
 	return $w->get_updated_html();
 };
@@ -163,7 +163,7 @@ function gutenberg_block_core_navigation_add_directives_to_markup( $block_conten
  *
  * <li
  *   class="has-child"
- *   data-wp-context='{ "core": { "navigation": { "isMenuOpen": false, "overlay": false } } }'
+ *   data-wp-context='{ "core": { "navigation": { "isMenuOpen": { "click": false, "hover": false, "overlay": false } } }'
  *   data-wp-effect="effects.core.navigation.initMenu"
  *   data-wp-on.keydown="actions.core.navigation.handleMenuKeydown"
  *   data-wp-on.focusout="actions.core.navigation.handleMenuFocusout"
@@ -171,7 +171,7 @@ function gutenberg_block_core_navigation_add_directives_to_markup( $block_conten
  *   <button
  *     class="wp-block-navigation-submenu__toggle"
  *     data-wp-on.click="actions.core.navigation.openMenu"
- *     data-wp-bind.aria-expanded="context.core.navigation.isMenuOpen"
+ *     data-wp-bind.aria-expanded="selectors.core.navigation.isMenuOpen"
  *   >
  *   </button>
  *   <span>Title</span>
@@ -184,7 +184,7 @@ function gutenberg_block_core_navigation_add_directives_to_markup( $block_conten
  *
  * @return void
  */
-function gutenberg_block_core_navigation_add_directives_to_submenu( $w ) {
+function gutenberg_block_core_navigation_add_directives_to_submenu( $w, $block_attributes ) {
 	while ( $w->next_tag(
 		array(
 			'tag_name'   => 'LI',
@@ -192,12 +192,14 @@ function gutenberg_block_core_navigation_add_directives_to_submenu( $w ) {
 		)
 	) ) {
 		// Add directives to the parent `<li>`.
-		$w->set_attribute( 'data-wp-context', '{ "core": { "navigation": { "isMenuOpen": false, "overlay": false, "isHovering": false } } }' );
+		$w->set_attribute( 'data-wp-context', '{ "core": { "navigation": { "isMenuOpen": { "click": false, "hover": false }, "overlay": false } } }' );
 		$w->set_attribute( 'data-wp-effect', 'effects.core.navigation.initMenu' );
 		$w->set_attribute( 'data-wp-on.focusout', 'actions.core.navigation.handleMenuFocusout' );
 		$w->set_attribute( 'data-wp-on.keydown', 'actions.core.navigation.handleMenuKeydown' );
-		$w->set_attribute( 'data-wp-on.mouseover', 'actions.core.navigation.openMenuOnHover' );
-		$w->set_attribute( 'data-wp-on.mouseout', 'actions.core.navigation.closeMenuOnHover' );
+		if ( ! isset( $block_attributes[ 'openSubmenusOnClick' ] ) ) {
+			$w->set_attribute( 'data-wp-on.mouseenter', 'actions.core.navigation.openMenuOnHover' );
+			$w->set_attribute( 'data-wp-on.mouseleave', 'actions.core.navigation.closeMenuOnHover' );
+		}
 
 		// Add directives to the toggle submenu button.
 		if ( $w->next_tag(
@@ -206,16 +208,17 @@ function gutenberg_block_core_navigation_add_directives_to_submenu( $w ) {
 				'class_name' => 'wp-block-navigation-submenu__toggle',
 			)
 		) ) {
-			$w->set_attribute( 'data-wp-on.click', 'actions.core.navigation.toggleMenu' );
-			$w->set_attribute( 'data-wp-bind.aria-expanded', 'context.core.navigation.isMenuOpen' );
+			$w->set_attribute( 'data-wp-on.click', 'actions.core.navigation.toggleMenuOnClick' );
+			$w->set_attribute( 'data-wp-bind.aria-expanded', 'selectors.core.navigation.isMenuOpen' );
+			$w->set_attribute( 'data-wp-bind.data-menu-opened-on', 'selectors.core.navigation.menuOpenedOn' );
 		};
 
 		// Iterate through subitems if exist.
-		gutenberg_block_core_navigation_add_directives_to_submenu( $w );
+		gutenberg_block_core_navigation_add_directives_to_submenu( $w, $block_attributes );
 	}
 };
 
-add_filter( 'render_block_core/navigation', 'gutenberg_block_core_navigation_add_directives_to_markup', 10, 1 );
+add_filter( 'render_block_core/navigation', 'gutenberg_block_core_navigation_add_directives_to_markup', 10, 3 );
 
 /**
  * Replaces view script for the File, Navigation, and Image blocks with version using Interactivity API.

--- a/lib/experimental/interactivity-api/blocks.php
+++ b/lib/experimental/interactivity-api/blocks.php
@@ -72,10 +72,11 @@ add_filter( 'render_block_core/file', 'gutenberg_block_core_file_add_directives_
  * </nav>
  *
  * @param string $block_content Markup of the navigation block.
+ * @param array  $block         Block object.
  *
  * @return string Navigation block markup with the proper directives
  */
-function gutenberg_block_core_navigation_add_directives_to_markup( $block_content, $block, $instance ) {
+function gutenberg_block_core_navigation_add_directives_to_markup( $block_content, $block ) {
 	$w = new WP_HTML_Tag_Processor( $block_content );
 	// Add directives to the `<nav>` element.
 	if ( $w->next_tag( 'nav' ) ) {
@@ -97,7 +98,7 @@ function gutenberg_block_core_navigation_add_directives_to_markup( $block_conten
 		// If the open modal button not found, we handle submenus immediately.
 		$w = new WP_HTML_Tag_Processor( $w->get_updated_html() );
 
-		gutenberg_block_core_navigation_add_directives_to_submenu( $w, $block[ 'attrs' ] );
+		gutenberg_block_core_navigation_add_directives_to_submenu( $w, $block['attrs'] );
 
 		return $w->get_updated_html();
 	}
@@ -152,7 +153,7 @@ function gutenberg_block_core_navigation_add_directives_to_markup( $block_conten
 	};
 
 	// Submenus.
-	gutenberg_block_core_navigation_add_directives_to_submenu( $w, $block[ 'attrs' ] );
+	gutenberg_block_core_navigation_add_directives_to_submenu( $w, $block['attrs'] );
 
 	return $w->get_updated_html();
 };
@@ -167,8 +168,8 @@ function gutenberg_block_core_navigation_add_directives_to_markup( $block_conten
  *   data-wp-effect="effects.core.navigation.initMenu"
  *   data-wp-on.keydown="actions.core.navigation.handleMenuKeydown"
  *   data-wp-on.focusout="actions.core.navigation.handleMenuFocusout"
- * 	 data-wp-on.mouseenter="actions.core.navigation.openMenuOnHover"
- * 	 data-wp-on.mouseleave="actions.core.navigation.closeMenuOnHover"
+ *   data-wp-on.mouseenter="actions.core.navigation.openMenuOnHover"
+ *   data-wp-on.mouseleave="actions.core.navigation.closeMenuOnHover"
  * >
  *   <button
  *     class="wp-block-navigation-submenu__toggle"
@@ -182,7 +183,8 @@ function gutenberg_block_core_navigation_add_directives_to_markup( $block_conten
  *   </ul>
  * </li>
  *
- * @param string $w Markup of the navigation block.
+ * @param string $w                Markup of the navigation block.
+ * @param array  $block_attributes Block attributes.
  *
  * @return void
  */
@@ -198,7 +200,7 @@ function gutenberg_block_core_navigation_add_directives_to_submenu( $w, $block_a
 		$w->set_attribute( 'data-wp-effect', 'effects.core.navigation.initMenu' );
 		$w->set_attribute( 'data-wp-on.focusout', 'actions.core.navigation.handleMenuFocusout' );
 		$w->set_attribute( 'data-wp-on.keydown', 'actions.core.navigation.handleMenuKeydown' );
-		if ( ! isset( $block_attributes[ 'openSubmenusOnClick' ] ) ) {
+		if ( ! isset( $block_attributes['openSubmenusOnClick'] ) ) {
 			$w->set_attribute( 'data-wp-on.mouseenter', 'actions.core.navigation.openMenuOnHover' );
 			$w->set_attribute( 'data-wp-on.mouseleave', 'actions.core.navigation.closeMenuOnHover' );
 		}
@@ -219,7 +221,7 @@ function gutenberg_block_core_navigation_add_directives_to_submenu( $w, $block_a
 	}
 };
 
-add_filter( 'render_block_core/navigation', 'gutenberg_block_core_navigation_add_directives_to_markup', 10, 3 );
+add_filter( 'render_block_core/navigation', 'gutenberg_block_core_navigation_add_directives_to_markup', 10, 2 );
 
 /**
  * Replaces view script for the File, Navigation, and Image blocks with version using Interactivity API.

--- a/lib/experimental/interactivity-api/blocks.php
+++ b/lib/experimental/interactivity-api/blocks.php
@@ -210,7 +210,6 @@ function gutenberg_block_core_navigation_add_directives_to_submenu( $w, $block_a
 		) ) {
 			$w->set_attribute( 'data-wp-on.click', 'actions.core.navigation.toggleMenuOnClick' );
 			$w->set_attribute( 'data-wp-bind.aria-expanded', 'selectors.core.navigation.isMenuOpen' );
-			$w->set_attribute( 'data-wp-bind.data-menu-opened-on', 'selectors.core.navigation.menuOpenedOn' );
 		};
 
 		// Iterate through subitems if exist.

--- a/lib/experimental/interactivity-api/blocks.php
+++ b/lib/experimental/interactivity-api/blocks.php
@@ -192,10 +192,12 @@ function gutenberg_block_core_navigation_add_directives_to_submenu( $w ) {
 		)
 	) ) {
 		// Add directives to the parent `<li>`.
-		$w->set_attribute( 'data-wp-context', '{ "core": { "navigation": { "isMenuOpen": false, "overlay": false } } }' );
+		$w->set_attribute( 'data-wp-context', '{ "core": { "navigation": { "isMenuOpen": false, "overlay": false, "isHovering": false } } }' );
 		$w->set_attribute( 'data-wp-effect', 'effects.core.navigation.initMenu' );
 		$w->set_attribute( 'data-wp-on.focusout', 'actions.core.navigation.handleMenuFocusout' );
 		$w->set_attribute( 'data-wp-on.keydown', 'actions.core.navigation.handleMenuKeydown' );
+		$w->set_attribute( 'data-wp-on.mouseover', 'actions.core.navigation.openMenuOnHover' );
+		$w->set_attribute( 'data-wp-on.mouseout', 'actions.core.navigation.closeMenuOnHover' );
 
 		// Add directives to the toggle submenu button.
 		if ( $w->next_tag(

--- a/packages/block-library/src/navigation/interactivity.js
+++ b/packages/block-library/src/navigation/interactivity.js
@@ -81,11 +81,6 @@ store( {
 					Object.values( context.core.navigation.isMenuOpen ).filter(
 						Boolean
 					).length > 0,
-				menuOpenedOn: ( { context } ) =>
-					Object.entries( context.core.navigation.isMenuOpen )
-						.filter( ( [ , value ] ) => value )
-						.map( ( [ key ] ) => key )
-						.join( ', ' ) || 'none',
 			},
 		},
 	},

--- a/packages/block-library/src/navigation/interactivity.js
+++ b/packages/block-library/src/navigation/interactivity.js
@@ -98,6 +98,12 @@ store( {
 				closeMenuOnHover( args ) {
 					closeMenu( args, 'hover' );
 				},
+				openMenuOnClick( args ) {
+					openMenu( args, 'click' );
+				},
+				closeMenuOnClick( args ) {
+					closeMenu( args, 'click' );
+				},
 				toggleMenuOnClick: ( args ) => {
 					const { context } = args;
 					if ( context.core.navigation.isMenuOpen.click ) {

--- a/packages/block-library/src/navigation/interactivity.js
+++ b/packages/block-library/src/navigation/interactivity.js
@@ -21,13 +21,14 @@ const openMenu = ( { context, ref }, menuOpenedOn ) => {
 	context.core.navigation.isMenuOpen[ menuOpenedOn ] = true;
 	context.core.navigation.previousFocus = ref;
 	if ( context.core.navigation.overlay ) {
-		// It adds a `has-modal-open` class to the <html> root
+		// Add a `has-modal-open` class to the <html> root.
 		document.documentElement.classList.add( 'has-modal-open' );
 	}
 };
 
 const closeMenu = ( { context, selectors }, menuClosedOn ) => {
 	context.core.navigation.isMenuOpen[ menuClosedOn ] = false;
+	// Check if the menu is still open or not.
 	if ( ! selectors.core.navigation.isMenuOpen( { context } ) ) {
 		if (
 			context.core.navigation.modal.contains(
@@ -78,6 +79,7 @@ store( {
 						? 'dialog'
 						: '',
 				isMenuOpen: ( { context } ) =>
+					// The menu is opened if either `click` or `hover` is true.
 					Object.values( context.core.navigation.isMenuOpen ).filter(
 						Boolean
 					).length > 0,
@@ -149,7 +151,8 @@ store( {
 					// If focus is outside modal, and in the document, close menu
 					// event.target === The element losing focus
 					// event.relatedTarget === The element receiving focus (if any)
-					// When focusout is outsite the document, `window.document.activeElement` doesn't change
+					// When focusout is outsite the document,
+					// `window.document.activeElement` doesn't change
 					if (
 						context.core.navigation.isMenuOpen.click &&
 						! context.core.navigation.modal.contains(

--- a/packages/block-library/src/navigation/interactivity.js
+++ b/packages/block-library/src/navigation/interactivity.js
@@ -73,9 +73,9 @@ store( {
 	selectors: {
 		core: {
 			navigation: {
-				roleAttribute: ( { context } ) =>
+				roleAttribute: ( { context, selectors } ) =>
 					context.core.navigation.overlay &&
-					context.core.navigation.isMenuOpen
+					selectors.core.navigation.isMenuOpen( { context } )
 						? 'dialog'
 						: '',
 				isMenuOpen: ( { context } ) =>

--- a/packages/block-library/src/navigation/interactivity.js
+++ b/packages/block-library/src/navigation/interactivity.js
@@ -17,12 +17,39 @@ const focusableSelectors = [
 	'[tabindex]:not([tabindex^="-"])',
 ];
 
+const openMenu = ( { context, ref }, menuOpenedOn ) => {
+	context.core.navigation.isMenuOpen[ menuOpenedOn ] = true;
+	context.core.navigation.previousFocus = ref;
+	if ( context.core.navigation.overlay ) {
+		// It adds a `has-modal-open` class to the <html> root
+		document.documentElement.classList.add( 'has-modal-open' );
+	}
+};
+
+const closeMenu = ( { context, selectors }, menuClosedOn ) => {
+	context.core.navigation.isMenuOpen[ menuClosedOn ] = false;
+	if ( ! selectors.core.navigation.isMenuOpen( { context } ) ) {
+		if (
+			context.core.navigation.modal.contains(
+				window.document.activeElement
+			)
+		) {
+			context.core.navigation.previousFocus.focus();
+		}
+		context.core.navigation.modal = null;
+		context.core.navigation.previousFocus = null;
+		if ( context.core.navigation.overlay ) {
+			document.documentElement.classList.remove( 'has-modal-open' );
+		}
+	}
+};
+
 store( {
 	effects: {
 		core: {
 			navigation: {
-				initMenu: ( { context, ref } ) => {
-					if ( context.core.navigation.isMenuOpen ) {
+				initMenu: ( { context, selectors, ref } ) => {
+					if ( selectors.core.navigation.isMenuOpen( { context } ) ) {
 						const focusableElements =
 							ref.querySelectorAll( focusableSelectors );
 						context.core.navigation.modal = ref;
@@ -32,8 +59,8 @@ store( {
 							focusableElements[ focusableElements.length - 1 ];
 					}
 				},
-				focusFirstElement: ( { context, ref } ) => {
-					if ( context.core.navigation.isMenuOpen ) {
+				focusFirstElement: ( { context, selectors, ref } ) => {
+					if ( selectors.core.navigation.isMenuOpen( { context } ) ) {
 						ref.querySelector(
 							'.wp-block-navigation-item > *:first-child'
 						).focus();
@@ -45,73 +72,49 @@ store( {
 	selectors: {
 		core: {
 			navigation: {
-				roleAttribute: ( { context } ) => {
-					return context.core.navigation.overlay &&
-						context.core.navigation.isMenuOpen
+				roleAttribute: ( { context } ) =>
+					context.core.navigation.overlay &&
+					context.core.navigation.isMenuOpen
 						? 'dialog'
-						: '';
-				},
+						: '',
+				isMenuOpen: ( { context } ) =>
+					Object.values( context.core.navigation.isMenuOpen ).filter(
+						Boolean
+					).length > 0,
+				menuOpenedOn: ( { context } ) =>
+					Object.entries( context.core.navigation.isMenuOpen )
+						.filter( ( [ , value ] ) => value )
+						.map( ( [ key ] ) => key )
+						.join( ', ' ) || 'none',
 			},
 		},
 	},
 	actions: {
 		core: {
 			navigation: {
-				openMenu: ( { context, ref } ) => {
-					context.core.navigation.isMenuOpen = true;
-					context.core.navigation.previousFocus = ref;
-					if ( context.core.navigation.overlay ) {
-						// It adds a `has-modal-open` class to the <html> root
-						document.documentElement.classList.add(
-							'has-modal-open'
-						);
-					}
+				openMenuOnHover( args ) {
+					openMenu( args, 'hover' );
 				},
-				closeMenu: ( { context } ) => {
-					if (
-						context.core.navigation.isMenuOpen &&
-						! context.core.navigation.isHovering
-					) {
-						context.core.navigation.isMenuOpen = false;
-						if (
-							context.core.navigation.modal.contains(
-								window.document.activeElement
-							)
-						) {
-							context.core.navigation.previousFocus.focus();
-						}
-						context.core.navigation.modal = null;
-						context.core.navigation.previousFocus = null;
-						if ( context.core.navigation.overlay ) {
-							document.documentElement.classList.remove(
-								'has-modal-open'
-							);
-						}
-					}
+				closeMenuOnHover( args ) {
+					closeMenu( args, 'hover' );
 				},
-				openMenuOnHover( { actions, context, ref } ) {
-					context.core.navigation.isHovering = true;
-					actions.core.navigation.openMenu( { context, ref } );
-				},
-				closeMenuOnHover( { actions, context } ) {
-					context.core.navigation.isHovering = false;
-					actions.core.navigation.closeMenu( { context } );
-				},
-				toggleMenu: ( { context, actions, ref } ) => {
-					if ( context.core.navigation.isMenuOpen ) {
-						actions.core.navigation.closeMenu( { context } );
+				toggleMenuOnClick: ( args ) => {
+					const { context } = args;
+					if ( context.core.navigation.isMenuOpen.click ) {
+						closeMenu( args, 'click' );
 					} else {
-						actions.core.navigation.openMenu( { context, ref } );
+						openMenu( args, 'click' );
 					}
 				},
-				handleMenuKeydown: ( { actions, context, event } ) => {
+				handleMenuKeydown: ( args ) => {
+					const { context, event } = args;
 					if ( context.core.navigation.isMenuOpen ) {
 						// If Escape close the menu
 						if (
 							event?.key === 'Escape' ||
 							event?.keyCode === 27
 						) {
-							actions.core.navigation.closeMenu( { context } );
+							closeMenu( args, 'click' );
 							return;
 						}
 
@@ -140,20 +143,20 @@ store( {
 						}
 					}
 				},
-				handleMenuFocusout: ( { actions, context, event } ) => {
-					if ( context.core.navigation.isMenuOpen ) {
-						// If focus is outside modal, and in the document, close menu
-						// event.target === The element losing focus
-						// event.relatedTarget === The element receiving focus (if any)
-						// When focusout is outsite the document, `window.document.activeElement` doesn't change
-						if (
-							! context.core.navigation.modal.contains(
-								event.relatedTarget
-							) &&
-							event.target !== window.document.activeElement
-						) {
-							actions.core.navigation.closeMenu( { context } );
-						}
+				handleMenuFocusout: ( args ) => {
+					const { context, event } = args;
+					// If focus is outside modal, and in the document, close menu
+					// event.target === The element losing focus
+					// event.relatedTarget === The element receiving focus (if any)
+					// When focusout is outsite the document, `window.document.activeElement` doesn't change
+					if (
+						context.core.navigation.isMenuOpen.click &&
+						! context.core.navigation.modal.contains(
+							event.relatedTarget
+						) &&
+						event.target !== window.document.activeElement
+					) {
+						closeMenu( args, 'click' );
 					}
 				},
 			},

--- a/packages/block-library/src/navigation/interactivity.js
+++ b/packages/block-library/src/navigation/interactivity.js
@@ -68,7 +68,10 @@ store( {
 					}
 				},
 				closeMenu: ( { context } ) => {
-					if ( context.core.navigation.isMenuOpen ) {
+					if (
+						context.core.navigation.isMenuOpen &&
+						! context.core.navigation.isHovering
+					) {
 						context.core.navigation.isMenuOpen = false;
 						if (
 							context.core.navigation.modal.contains(
@@ -85,6 +88,14 @@ store( {
 							);
 						}
 					}
+				},
+				openMenuOnHover( { actions, context, ref } ) {
+					context.core.navigation.isHovering = true;
+					actions.core.navigation.openMenu( { context, ref } );
+				},
+				closeMenuOnHover( { actions, context } ) {
+					context.core.navigation.isHovering = false;
+					actions.core.navigation.closeMenu( { context } );
 				},
 				toggleMenu: ( { context, actions, ref } ) => {
 					if ( context.core.navigation.isMenuOpen ) {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

<!-- In a few words, what is the PR actually doing? -->

It sets the correct `aria-expanded` for the button of the submenus when the mouse is over it.

## Why?

<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Because previously it was only working for the keyboard, but as stated by @jeryj [in Slack](https://wordpress.slack.com/archives/C02RP4X03/p1684940296840589?thread_ts=1684403764.422519&cid=C02RP4X03), some users may use both a screen reader and a mouse.

## How?

<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

I added `mouseover` and `mouseout` directives to the `<li>` element.

I also created a new `context` property called `isHovering` to indicate that the mouse is over the submenu (`li` element), because in that case, the `isMenuOpen` property should not turn `false` if the user clicks the button, uses the keyboard, or moves the focus away.

## Testing Instructions

<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

You can use WordPress Playground to test this out: https://playground.wordpress.net/?gutenberg-pr=50953

1. Turn on your screen reader of choice
2. Enable the "Core blocks" experiment
3. Have a navigation with a submenu
4. Go to the frontend of the site
5. Use the mouse to hover over the submenu
6. The state of expanded should be announced
7. Move the mouse away from the submenu
8. The state of collapsed should be announced
9. Move again the focus to the submenu button
10. Use the mouse to hover over the submenu
11. The state of expanded should be announced
12. Hit `enter` to "toggle the menu", the state of expanded should remain (because the mouse is hovering and prevents it from closing)
13. Move the tab away from the submenu, the state of expanded should remain (because the mouse is hovering and prevents it from closing)
14. Move the mouse away
15. The state of collapsed should be announced

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/3305402/e5c905d5-834b-47bd-abc7-7afb30fcaf7f
