### PR TITLE
Fix flaky Behaviors UI e2e tests

### DIFF
--- a/test/e2e/specs/editor/various/behaviors.spec.js
+++ b/test/e2e/specs/editor/various/behaviors.spec.js
@@ -8,16 +8,15 @@ const path = require( 'path' );
  */
 const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 
+test.use( {
+	behaviorUtils: async ( { page, requestUtils }, use ) => {
+		await use( new BehaviorUtils( { page, requestUtils } ) );
+	},
+} );
+
+const filename = '1024x768_e2e_test_image_size.jpeg';
+
 test.describe( 'Testing behaviors functionality', () => {
-	const filename = '1024x768_e2e_test_image_size.jpeg';
-	const filepath = path.join( './test/e2e/assets', filename );
-
-	const createMedia = async ( { admin, requestUtils } ) => {
-		await admin.createNewPost();
-		const media = await requestUtils.uploadMedia( filepath );
-		return media;
-	};
-
 	test.afterAll( async ( { requestUtils } ) => {
 		await requestUtils.activateTheme( 'twentytwentyone' );
 		await requestUtils.deleteAllPosts();
@@ -32,9 +31,11 @@ test.describe( 'Testing behaviors functionality', () => {
 		editor,
 		requestUtils,
 		page,
+		behaviorUtils,
 	} ) => {
 		await requestUtils.activateTheme( 'twentytwentyone' );
-		const media = await createMedia( { admin, requestUtils } );
+		await admin.createNewPost();
+		const media = await behaviorUtils.createMedia();
 		await editor.insertBlock( {
 			name: 'core/image',
 			attributes: {
@@ -44,16 +45,22 @@ test.describe( 'Testing behaviors functionality', () => {
 			},
 		} );
 
-		await page.getByRole( 'button', { name: 'Advanced' } ).click();
-		const select = page.getByLabel( 'Behavior' );
+		await editor.openDocumentSettingsSidebar();
+		const editorSettings = page.getByRole( 'region', {
+			name: 'Editor settings',
+		} );
+		await editorSettings
+			.getByRole( 'button', { name: 'Advanced' } )
+			.click();
+		const select = editorSettings.getByRole( 'combobox', {
+			name: 'Behavior',
+		} );
 
 		// By default, no behaviors should be selected.
-		await expect( select ).toHaveCount( 1 );
 		await expect( select ).toHaveValue( '' );
 
 		// By default, you should be able to select the Lightbox behavior.
-		const options = select.locator( 'option' );
-		await expect( options ).toHaveCount( 2 );
+		await expect( select.getByRole( 'option' ) ).toHaveCount( 2 );
 	} );
 
 	test( 'Behaviors UI can be disabled in the `theme.json`', async ( {
@@ -61,12 +68,14 @@ test.describe( 'Testing behaviors functionality', () => {
 		editor,
 		requestUtils,
 		page,
+		behaviorUtils,
 	} ) => {
 		// { "lightbox": true } is the default behavior setting, so we activate the
 		// `behaviors-ui-disabled` theme where it is disabled by default. Change if we change
 		// the default value in the core theme.json file.
 		await requestUtils.activateTheme( 'behaviors-ui-disabled' );
-		const media = await createMedia( { admin, requestUtils } );
+		await admin.createNewPost();
+		const media = await behaviorUtils.createMedia();
 
 		await editor.insertBlock( {
 			name: 'core/image',
@@ -77,10 +86,20 @@ test.describe( 'Testing behaviors functionality', () => {
 			},
 		} );
 
-		await page.getByRole( 'button', { name: 'Advanced' } ).click();
+		await editor.openDocumentSettingsSidebar();
+		const editorSettings = page.getByRole( 'region', {
+			name: 'Editor settings',
+		} );
+		await editorSettings
+			.getByRole( 'button', { name: 'Advanced' } )
+			.click();
 
 		// No behaviors dropdown should be present.
-		await expect( page.getByLabel( 'Behavior' ) ).toHaveCount( 0 );
+		await expect(
+			editorSettings.getByRole( 'combobox', {
+				name: 'Behavior',
+			} )
+		).toBeHidden();
 	} );
 
 	test( "Block's value for behaviors takes precedence over the theme's value", async ( {
@@ -88,9 +107,11 @@ test.describe( 'Testing behaviors functionality', () => {
 		editor,
 		requestUtils,
 		page,
+		behaviorUtils,
 	} ) => {
 		await requestUtils.activateTheme( 'twentytwentyone' );
-		const media = await createMedia( { admin, requestUtils } );
+		await admin.createNewPost();
+		const media = await behaviorUtils.createMedia();
 
 		await editor.insertBlock( {
 			name: 'core/image',
@@ -103,17 +124,23 @@ test.describe( 'Testing behaviors functionality', () => {
 			},
 		} );
 
-		await page.getByRole( 'button', { name: 'Advanced' } ).click();
-		const select = page.getByLabel( 'Behavior' );
+		await editor.openDocumentSettingsSidebar();
+		const editorSettings = page.getByRole( 'region', {
+			name: 'Editor settings',
+		} );
+		await editorSettings
+			.getByRole( 'button', { name: 'Advanced' } )
+			.click();
+		const select = editorSettings.getByRole( 'combobox', {
+			name: 'Behavior',
+		} );
 
 		// The lightbox should be selected because the value from the block's
 		// attributes takes precedence over the theme's value.
-		await expect( select ).toHaveCount( 1 );
 		await expect( select ).toHaveValue( 'lightbox' );
 
 		// There should be 2 options available: `No behaviors` and `Lightbox`.
-		const options = select.locator( 'option' );
-		await expect( options ).toHaveCount( 2 );
+		await expect( select.getByRole( 'option' ) ).toHaveCount( 2 );
 
 		// We can change the value of the behaviors dropdown to `No behaviors`.
 		await select.selectOption( { label: 'No behaviors' } );
@@ -128,10 +155,12 @@ test.describe( 'Testing behaviors functionality', () => {
 		editor,
 		requestUtils,
 		page,
+		behaviorUtils,
 	} ) => {
 		// In this theme, the default value for settings.behaviors.blocks.core/image.lightbox is `true`.
 		await requestUtils.activateTheme( 'behaviors-enabled' );
-		const media = await createMedia( { admin, requestUtils } );
+		await admin.createNewPost();
+		const media = await behaviorUtils.createMedia();
 
 		await editor.insertBlock( {
 			name: 'core/image',
@@ -142,20 +171,49 @@ test.describe( 'Testing behaviors functionality', () => {
 			},
 		} );
 
-		await page.getByRole( 'button', { name: 'Advanced' } ).click();
-		const select = page.getByLabel( 'Behavior' );
+		await editor.openDocumentSettingsSidebar();
+		const editorSettings = page.getByRole( 'region', {
+			name: 'Editor settings',
+		} );
+		await editorSettings
+			.getByRole( 'button', { name: 'Advanced' } )
+			.click();
+		const select = editorSettings.getByRole( 'combobox', {
+			name: 'Behavior',
+		} );
 
 		// The behaviors dropdown should be present and the value should be set to
 		// `lightbox`.
-		await expect( select ).toHaveCount( 1 );
 		await expect( select ).toHaveValue( 'lightbox' );
 
 		// There should be 2 options available: `No behaviors` and `Lightbox`.
-		const options = select.locator( 'option' );
-		await expect( options ).toHaveCount( 2 );
+		await expect( select.getByRole( 'option' ) ).toHaveCount( 2 );
 
 		// We can change the value of the behaviors dropdown to `No behaviors`.
 		await select.selectOption( { label: 'No behaviors' } );
 		await expect( select ).toHaveValue( '' );
 	} );
 } );
+
+class BehaviorUtils {
+	constructor( { page, requestUtils } ) {
+		this.page = page;
+		this.requestUtils = requestUtils;
+
+		this.TEST_IMAGE_FILE_PATH = path.join(
+			__dirname,
+			'..',
+			'..',
+			'..',
+			'assets',
+			filename
+		);
+	}
+
+	async createMedia() {
+		const media = await this.requestUtils.uploadMedia(
+			this.TEST_IMAGE_FILE_PATH
+		);
+		return media;
+	}
+}


### PR DESCRIPTION
## What?
Closes #50923.

PR fixes flaky Behavior UI tests and addressed feedback from @kevin940726 - https://github.com/WordPress/gutenberg/pull/49972#pullrequestreview-1442369331.

## Why?
The document settings sidebar might be closed when the tests run.

## How?
Make the document settings sidebar is open before selecting elements.

## Testing Instructions
```
npm run test:e2e:playwright -- test/e2e/specs/editor/various/behaviors.spec.js
```
