### PR TITLE
SpacingSizesControl: Fix problem with the slider position being reset when saving global styles

### DIFF
--- a/packages/block-editor/src/components/global-styles/dimensions-panel.js
+++ b/packages/block-editor/src/components/global-styles/dimensions-panel.js
@@ -207,8 +207,19 @@ export default function DimensionsPanel( {
 	// in global styles but not in block inspector.
 	includeLayoutControls = false,
 } ) {
-	const decodeValue = ( rawValue ) =>
-		getValueFromVariable( { settings }, '', rawValue );
+	const decodeValue = ( rawValue ) => {
+		if ( typeof rawValue === 'object' ) {
+			return Object.keys( rawValue ).reduce( ( acc, key ) => {
+				acc[ key ] = getValueFromVariable(
+					{ settings },
+					'',
+					rawValue[ key ]
+				);
+				return acc;
+			}, {} );
+		}
+		return getValueFromVariable( { settings }, '', rawValue );
+	};
 
 	const showSpacingPresetsControl = useHasSpacingPresets( settings );
 	const units = useCustomUnits( {


### PR DESCRIPTION
Fixes: #50940

## What?
This PR fixes a problem with the `SpacingSizesControl` slider position being reset when the global style is saved.

https://github.com/WordPress/gutenberg/assets/54422211/1875ec50-7b57-4ebd-8d04-e5c17678087a

## Why?

I will try to explain the cause of this in turn.

When you move a slider in the `SpacingSizesControl` component, it holds an object with a CSS variable containing a `pipe` and a `colon` as values, like this:

```
{
  "top": "var:preset|spacing|50",
  "right": "var:preset|spacing|50",
  "bottom": "var:preset|spacing|50",
  "left": "var:preset|spacing|50"
}
```

If you save the global style after moving the slider, an object with the usual CSS variables will be passed to the `DimensionsPanel` component as a value, like this:

```
{
  "top": "var(--wp--preset--spacing--50)",
  "right": "var(--wp--preset--spacing--50)",
  "bottom": "var(--wp--preset--spacing--50)",
  "left": "var(--wp--preset--spacing--50)"
}
```

Upon receiving the value, the `DimensionsPanel` component attempts to decode the normal CSS variable into a CSS variable containing the `pipe` and `colon` by means of the `decodeValue()` function.

For Padding, here it is.

https://github.com/WordPress/gutenberg/blob/f10f85f5779eab8a9daeb00ef6721543dce91201/packages/block-editor/src/components/global-styles/dimensions-panel.js#L258

However, the `getValueFromVariable()` function that the `decodeValue()` function calls internally expects the passed value to be of type `string` and returns the received value as is if the condition is not met:

https://github.com/WordPress/gutenberg/blob/f10f85f5779eab8a9daeb00ef6721543dce91201/packages/block-editor/src/components/global-styles/utils.js#L307

Since this value is not a CSS variable containing `pipe` and `colon`, the `SpacingSizesControl` component that receives the value will assume it is not a preset value:

https://github.com/WordPress/gutenberg/blob/f10f85f5779eab8a9daeb00ef6721543dce91201/packages/block-editor/src/components/spacing-sizes-control/utils.js#L17

As a result, the slider position will be lost.

## How?

We need to decode the value of each of the objects with `top` / `right` / `bottom` / `left` properties in some way.

I found #48070 where this component was affected, but I expect that perhaps before this PR, the object type was also taken into account when decoding.

I have added a condition and processing to check if the value is an object in the `decodeValue()` function, but there might be a better way.

## Testing Instructions

- Open the global styles to access blocks with Dimensions controls, such as the paragraph block.
- Manipulate the slider.
- Make sure the slider position is not lost after saving.

