### PR TITLE
Reinstate Text control outside of settings in Link Control

### DIFF
--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -347,6 +347,17 @@ function LinkControl( {
 							}
 							useLabel={ showTextControl }
 						/>
+						{ showTextControl && (
+							<TextControl
+								__nextHasNoMarginBottom
+								ref={ textInputRef }
+								className="block-editor-link-control__field block-editor-link-control__text-content"
+								label={ __( 'Text' ) }
+								value={ internalControlValue?.title }
+								onChange={ setInternalTextInputValue }
+								onKeyDown={ handleSubmitWithEnter }
+							/>
+						) }
 					</div>
 					{ errorMessage && (
 						<Notice
@@ -373,31 +384,18 @@ function LinkControl( {
 
 			{ isEditing && (
 				<div className="block-editor-link-control__tools">
-					{ ( showSettings || showTextControl ) && (
+					{ showSettings && (
 						<LinkControlSettingsDrawer
 							settingsOpen={ settingsOpen }
 							setSettingsOpen={ setSettingsOpen }
 						>
-							{ showTextControl && (
-								<TextControl
-									__nextHasNoMarginBottom
-									ref={ textInputRef }
-									className="block-editor-link-control__setting block-editor-link-control__text-content"
-									label={ __( 'Text' ) }
-									value={ internalControlValue?.title }
-									onChange={ setInternalTextInputValue }
-									onKeyDown={ handleSubmitWithEnter }
-								/>
-							) }
-							{ showSettings && (
-								<LinkSettings
-									value={ internalControlValue }
-									settings={ settings }
-									onChange={ createSetInternalSettingValueHandler(
-										settingsKeys
-									) }
-								/>
-							) }
+							<LinkSettings
+								value={ internalControlValue }
+								settings={ settings }
+								onChange={ createSetInternalSettingValueHandler(
+									settingsKeys
+								) }
+							/>
 						</LinkControlSettingsDrawer>
 					) }
 

--- a/packages/e2e-tests/specs/editor/various/links.test.js
+++ b/packages/e2e-tests/specs/editor/various/links.test.js
@@ -17,12 +17,16 @@ describe( 'Links', () => {
 	} );
 
 	const waitForURLFieldAutoFocus = async () => {
-		await page.waitForFunction(
-			() =>
-				!! document.activeElement.closest(
-					'.block-editor-url-input__input'
-				)
-		);
+		await page.waitForFunction( () => {
+			const input = document.querySelector(
+				'.block-editor-url-input__input'
+			);
+			if ( input ) {
+				input.focus();
+				return true;
+			}
+			return false;
+		} );
 	};
 
 	it( 'will use Post title as link text if link to existing post is created without any text selected', async () => {

--- a/packages/e2e-tests/specs/editor/various/links.test.js
+++ b/packages/e2e-tests/specs/editor/various/links.test.js
@@ -18,7 +18,10 @@ describe( 'Links', () => {
 
 	const waitForURLFieldAutoFocus = async () => {
 		await page.waitForFunction(
-			() => !! document.activeElement.closest( '.block-editor-url-input' )
+			() =>
+				!! document.activeElement.closest(
+					'.block-editor-url-input__input'
+				)
 		);
 	};
 

--- a/packages/e2e-tests/specs/editor/various/links.test.js
+++ b/packages/e2e-tests/specs/editor/various/links.test.js
@@ -527,11 +527,6 @@ describe( 'Links', () => {
 
 			await waitForURLFieldAutoFocus();
 
-			const [ settingsToggle ] = await page.$x(
-				'//button[contains(@aria-label, "Link Settings")]'
-			);
-			await settingsToggle.click();
-
 			await page.keyboard.press( 'Tab' );
 
 			// Tabbing should land us in the text input.
@@ -589,15 +584,6 @@ describe( 'Links', () => {
 
 			await editButton.click();
 
-			await waitForURLFieldAutoFocus();
-
-			const [ settingsToggle ] = await page.$x(
-				'//button[contains(@aria-label, "Link Settings")]'
-			);
-			await settingsToggle.click();
-
-			await page.keyboard.press( 'Tab' );
-
 			// Tabbing back should land us in the text input.
 			const textInputValue = await page.evaluate(
 				() => document.activeElement.value
@@ -624,14 +610,6 @@ describe( 'Links', () => {
 				'//button[contains(@aria-label, "Edit")]'
 			);
 			await editButton.click();
-			await waitForURLFieldAutoFocus();
-
-			const [ settingsToggle ] = await page.$x(
-				'//button[contains(@aria-label, "Link Settings")]'
-			);
-			await settingsToggle.click();
-
-			await page.keyboard.press( 'Tab' );
 
 			// Tabbing should land us in the text input.
 			const textInputValue = await page.evaluate(
@@ -686,7 +664,7 @@ describe( 'Links', () => {
 			await page.waitForXPath( `//label[text()='Open in new tab']` );
 
 			// Move focus back to RichText for the underlying link.
-			await pressKeyTimes( 'Tab', 4 );
+			await pressKeyTimes( 'Tab', 3 );
 
 			// Make a selection within the RichText.
 			await pressKeyWithModifier( 'shift', 'ArrowRight' );
@@ -694,7 +672,7 @@ describe( 'Links', () => {
 			await pressKeyWithModifier( 'shift', 'ArrowRight' );
 
 			// Move back to the text input.
-			await pressKeyTimes( 'Tab', 3 );
+			await pressKeyTimes( 'Tab', 2 );
 
 			// Tabbing back should land us in the text input.
 			const textInputValue = await page.evaluate(
@@ -893,10 +871,6 @@ describe( 'Links', () => {
 			await page.keyboard.press( 'Enter' );
 
 			await waitForURLFieldAutoFocus();
-
-			// Link settings open
-			await page.keyboard.press( 'Tab' );
-			await page.keyboard.press( 'Space' );
 
 			// Move to Link Text field.
 			await page.keyboard.press( 'Tab' );

--- a/test/e2e/specs/editor/blocks/links.spec.js
+++ b/test/e2e/specs/editor/blocks/links.spec.js
@@ -103,7 +103,7 @@ test.describe( 'Links', () => {
 
 		// Edit link.
 		await pageUtils.pressKeys( 'primary+k' );
-		await pageUtils.pressKeys( 'primary+a' );
+		await page.getByPlaceholder( 'Search or type url' ).fill( '' );
 		await page.keyboard.type( 'wordpress.org' );
 
 		// Update the link.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Reinstates `Text` input control outside of the settings drawer area of Link Control.

Part of https://github.com/WordPress/gutenberg/issues/50891

Closes https://github.com/WordPress/gutenberg/issues/50948

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Because the UX requires it.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Move the control outside the drawer and remove drilled props.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

- Create link and see no Text field
- Reselect link and edit link
- See text field
- Trying changing text and ensure it syncs up
- Do same on Nav block and Paragraph
<img width="432" alt="Screenshot 2023-05-25 at 13 32 22" src="https://github.com/WordPress/gutenberg/assets/444434/c07eb8ac-4fd7-41e0-8da6-daf662614db5">


### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
