### PR TITLE
Use checkbox for `Open in new tab` within Link Control 

### DIFF
--- a/packages/block-editor/src/components/link-control/settings.js
+++ b/packages/block-editor/src/components/link-control/settings.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { ToggleControl, VisuallyHidden } from '@wordpress/components';
+import { CheckboxControl, VisuallyHidden } from '@wordpress/components';
 
 const noop = () => {};
 
@@ -19,7 +19,7 @@ const LinkControlSettings = ( { value, onChange = noop, settings } ) => {
 	};
 
 	const theSettings = settings.map( ( setting ) => (
-		<ToggleControl
+		<CheckboxControl
 			__nextHasNoMarginBottom
 			className="block-editor-link-control__setting"
 			key={ setting.id }

--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -495,6 +495,11 @@ $preview-image-height: 140px;
 .block-editor-link-control__setting {
 	margin-bottom: $grid-unit-20;
 
+	// Cancel left margin inherited from WP Admin Forms CSS.
+	input {
+		margin-left: 0;
+	}
+
 	&.block-editor-link-control__setting:last-child {
 		margin-bottom: 0;
 	}

--- a/packages/e2e-tests/specs/editor/various/links.test.js
+++ b/packages/e2e-tests/specs/editor/various/links.test.js
@@ -130,7 +130,7 @@ describe( 'Links', () => {
 
 		// Toggle should still have focus and be checked.
 		await page.waitForSelector(
-			':focus:checked.components-form-toggle__input'
+			':focus:checked.components-checkbox-control__input'
 		);
 
 		// Ensure that the contents of the post have not been changed, since at
@@ -539,7 +539,9 @@ describe( 'Links', () => {
 
 		// Confirm that focus was not prematurely returned to the paragraph on
 		// a changing value of the setting.
-		await page.waitForSelector( ':focus.components-form-toggle__input' );
+		await page.waitForSelector(
+			':focus.components-checkbox-control__input'
+		);
 
 		// Submit link. Expect that "Open in new tab" would have been applied
 		// immediately.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Changes Link Control to use a checkbox rather than a toggle switch for the `Open in new tab` setting.

Part of https://github.com/WordPress/gutenberg/issues/50890

Closes https://github.com/WordPress/gutenberg/issues/50947

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Specifically required as a result of https://github.com/WordPress/gutenberg/issues/50945.

Also because the [new UX](https://github.com/WordPress/gutenberg/issues/50891) requires it.



## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Changes the component to checkbox. Corrects visual alignment.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

- Create link
- Opens settings drawer
- See `Open in new tab` setting
- See it's a Checkbox
- Try using it to set the value.
- Does it work?

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
<img width="475" alt="Screenshot 2023-05-25 at 14 00 25" src="https://github.com/WordPress/gutenberg/assets/444434/59dd02a6-baab-48d9-b5e5-2cb373100b13">
