### PR TITLE
Improve the image block lightbox translations, labelling, and escaping

### DIFF
--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -49,13 +49,13 @@ function render_block_core_image( $attributes, $content ) {
 
 	if ( ! empty( $experiments['gutenberg-interactivity-api-core-blocks'] ) && 'none' === $link_destination && $lightbox ) {
 
-		$aria_label = __( 'Open image lightbox' );
+		$aria_label = __( 'Enlarge image' );
 
 		$alt_attribute = trim( $processor->get_attribute( 'alt' ) );
 
 		if ( $alt_attribute ) {
 			/* translators: %s: Image alt text. */
-			$aria_label = sprintf( __( 'Open image lightbox: %s' ), $alt_attribute );
+			$aria_label = sprintf( __( 'Enlarge image: %s' ), $alt_attribute );
 		}
 		$content = $processor->get_updated_html();
 
@@ -78,7 +78,7 @@ function render_block_core_image( $attributes, $content ) {
 		$background_color  = wp_get_global_styles( array( 'color', 'background' ) );
 		$close_button_icon = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="30" height="30" aria-hidden="true" focusable="false"><path d="M13 11.8l6.1-6.3-1-1-6.1 6.2-6.1-6.2-1 1 6.1 6.3-6.5 6.7 1 1 6.5-6.6 6.5 6.6 1-1z"></path></svg>';
 
-		$close_label = __( 'Close lightbox' );
+		$close_label = __( 'Close' );
 
 		return
 			<<<HTML

--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -68,17 +68,12 @@ function render_block_core_image( $attributes, $content ) {
 								'</div>';
 		$body_content = preg_replace( '/<img[^>]+>/', $button, $content );
 
-		// For the modal, set an ID on the image to be used for an aria-labelledby attribute.
-		$modal_content = new WP_HTML_Tag_Processor( $content );
-		$modal_content->next_tag( 'img' );
-		$image_lightbox_id = $modal_content->get_attribute( 'class' ) . '-lightbox';
-		$modal_content->set_attribute( 'id', $image_lightbox_id );
-		$modal_content = $modal_content->get_updated_html();
-
 		$background_color  = wp_get_global_styles( array( 'color', 'background' ) );
 		$close_button_icon = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="30" height="30" aria-hidden="true" focusable="false"><path d="M13 11.8l6.1-6.3-1-1-6.1 6.2-6.1-6.2-1 1 6.1 6.3-6.5 6.7 1 1 6.5-6.6 6.5 6.6 1-1z"></path></svg>';
 
-		$close_label = __( 'Close' );
+		$dialog_label = $alt_attribute ? $alt_attribute : _( 'Image' );
+
+		$close_button_label = __( 'Close' );
 
 		return
 			<<<HTML
@@ -88,7 +83,7 @@ function render_block_core_image( $attributes, $content ) {
 						$body_content
 						<div data-wp-body="" class="wp-lightbox-overlay"
 							data-wp-bind.role="selectors.core.image.roleAttribute"
-							aria-labelledby="$image_lightbox_id"
+							aria-label="$dialog_label"
 							data-wp-class.initialized="context.core.image.initialized"
 							data-wp-class.active="context.core.image.lightboxEnabled"
 							data-wp-bind.aria-hidden="!context.core.image.lightboxEnabled"
@@ -98,10 +93,10 @@ function render_block_core_image( $attributes, $content ) {
 							data-wp-on.mousewheel="actions.core.image.hideLightbox"
 							data-wp-on.click="actions.core.image.hideLightbox"
 							>
-								<button aria-label="$close_label" class="close-button" data-wp-on.click="actions.core.image.hideLightbox">
+								<button aria-label="$close_button_label" class="close-button" data-wp-on.click="actions.core.image.hideLightbox">
 									$close_button_icon
 								</button>
-								$modal_content
+								$content
 								<div class="scrim" style="background-color: $background_color"></div>
 						</div>
 				</div>

--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -63,7 +63,7 @@ function render_block_core_image( $attributes, $content ) {
 		$img = null;
 		preg_match( '/<img[^>]+>/', $content, $img );
 		$button       = '<div class="img-container">
-			 					<button aria-haspopup="dialog" aria-label="' . esc_attr( $aria_label ) . '" data-wp-on.click="actions.core.image.showLightbox"></button>'
+			 					<button type="button" aria-haspopup="dialog" aria-label="' . esc_attr( $aria_label ) . '" data-wp-on.click="actions.core.image.showLightbox"></button>'
 									. $img[0] .
 								'</div>';
 		$body_content = preg_replace( '/<img[^>]+>/', $button, $content );
@@ -93,7 +93,7 @@ function render_block_core_image( $attributes, $content ) {
 							data-wp-on.mousewheel="actions.core.image.hideLightbox"
 							data-wp-on.click="actions.core.image.hideLightbox"
 							>
-								<button aria-label="$close_button_label" class="close-button" data-wp-on.click="actions.core.image.hideLightbox">
+								<button type="button" aria-label="$close_button_label" class="close-button" data-wp-on.click="actions.core.image.hideLightbox">
 									$close_button_icon
 								</button>
 								$content

--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -49,9 +49,13 @@ function render_block_core_image( $attributes, $content ) {
 
 	if ( ! empty( $experiments['gutenberg-interactivity-api-core-blocks'] ) && 'none' === $link_destination && $lightbox ) {
 
-		$aria_label = 'Open image lightbox';
-		if ( $processor->get_attribute( 'alt' ) ) {
-			$aria_label .= ' : ' . $processor->get_attribute( 'alt' );
+		$aria_label = __( 'Open image lightbox' );
+
+		$alt_attribute = trim( $processor->get_attribute( 'alt' ) );
+
+		if ( $alt_attribute ) {
+			/* translators: %s: Image alt text. */
+			$aria_label = sprintf( __( 'Open image lightbox: %s' ), $alt_attribute );
 		}
 		$content = $processor->get_updated_html();
 
@@ -59,7 +63,7 @@ function render_block_core_image( $attributes, $content ) {
 		$img = null;
 		preg_match( '/<img[^>]+>/', $content, $img );
 		$button       = '<div class="img-container">
-			 					<button aria-haspopup="dialog" aria-label="' . $aria_label . '" data-wp-on.click="actions.core.image.showLightbox"></button>'
+			 					<button aria-haspopup="dialog" aria-label="' . esc_attr( $aria_label ) . '" data-wp-on.click="actions.core.image.showLightbox"></button>'
 									. $img[0] .
 								'</div>';
 		$body_content = preg_replace( '/<img[^>]+>/', $button, $content );
@@ -73,6 +77,8 @@ function render_block_core_image( $attributes, $content ) {
 
 		$background_color  = wp_get_global_styles( array( 'color', 'background' ) );
 		$close_button_icon = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="30" height="30" aria-hidden="true" focusable="false"><path d="M13 11.8l6.1-6.3-1-1-6.1 6.2-6.1-6.2-1 1 6.1 6.3-6.5 6.7 1 1 6.5-6.6 6.5 6.6 1-1z"></path></svg>';
+
+		$close_label = __( 'Close lightbox' );
 
 		return
 			<<<HTML
@@ -92,7 +98,7 @@ function render_block_core_image( $attributes, $content ) {
 							data-wp-on.mousewheel="actions.core.image.hideLightbox"
 							data-wp-on.click="actions.core.image.hideLightbox"
 							>
-								<button aria-label="Close lightbox" class="close-button" data-wp-on.click="actions.core.image.hideLightbox">
+								<button aria-label="$close_label" class="close-button" data-wp-on.click="actions.core.image.hideLightbox">
 									$close_button_icon
 								</button>
 								$modal_content

--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -71,7 +71,7 @@ function render_block_core_image( $attributes, $content ) {
 		$background_color  = wp_get_global_styles( array( 'color', 'background' ) );
 		$close_button_icon = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="30" height="30" aria-hidden="true" focusable="false"><path d="M13 11.8l6.1-6.3-1-1-6.1 6.2-6.1-6.2-1 1 6.1 6.3-6.5 6.7 1 1 6.5-6.6 6.5 6.6 1-1z"></path></svg>';
 
-		$dialog_label = $alt_attribute ? $alt_attribute : _( 'Image' );
+		$dialog_label = $alt_attribute ? $alt_attribute : __( 'Image' );
 
 		$close_button_label = __( 'Close' );
 

--- a/test/e2e/specs/editor/blocks/image.spec.js
+++ b/test/e2e/specs/editor/blocks/image.spec.js
@@ -831,14 +831,12 @@ test.describe( 'Image - interactivity', () => {
 		const image = lightbox.locator( 'img' );
 		await expect( image ).toHaveAttribute( 'src', new RegExp( filename ) );
 
-		await page
-			.getByRole( 'button', { name: 'Open image lightbox' } )
-			.click();
+		await page.getByRole( 'button', { name: 'Enlarge image' } ).click();
 
 		await expect( lightbox ).toBeVisible();
 
-		const closeButton = page.getByRole( 'button', {
-			name: 'Close lightbox',
+		const closeButton = lightbox.getByRole( 'button', {
+			name: 'Close',
 		} );
 		await closeButton.click();
 
@@ -860,11 +858,11 @@ test.describe( 'Image - interactivity', () => {
 			await page.goto( `/?p=${ postId }` );
 
 			openLightboxButton = page.getByRole( 'button', {
-				name: 'Open image lightbox',
+				name: 'Enlarge image',
 			} );
 			lightbox = page.getByRole( 'dialog' );
 			closeButton = lightbox.getByRole( 'button', {
-				name: 'Close lightbox',
+				name: 'Close',
 			} );
 		} );
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Fixes https://github.com/WordPress/gutenberg/issues/50959

Note: this PR is a the result of a team coding session with @aristath, @carolinan, @SergeyBiryukov, and @afercia.

## What?
<!-- In a few words, what is the PR actually doing? -->
- Some of the image block lightbox labels are not translatable.
- The terms used for labelling could be improved and simplified: as a used, I'm not expected to know what a `lightbox` is. That term is way too technical. As a user, I'm only interested in understanding what an UI control does.
- The modal dialog must always be  properly labelled, even when the image has an empty alt text.
- Escaping is required for values entered by users (e.g.. the alt text).
- Buttons miss the `type="button"` attribute: potentially, the may submit a form when the block is rendered within a form.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
- Strings must always be translatable.
- The modal dialog and the buttons must always be properly labeled. Teh simpleer, teh better. Avoid technical terms.
- We must make sure clicking the buttons does not submit a form rendered by other means on the page.
- Etc.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Makes strings translatable. Avoids concatenation.
- Removes the term `lightbox` and simplifies the labels. New labels:
  - Enlarge image
  - Enlarge image: {alt text}
  - Close
- Adds missing escaping for user-provided strings.
- Changes the modal dialog `aria-labellednby` to `aria-label`: this allows to provide a default label. Also, prevents potentially duplicated IDs and allows to simplify the code.
- Adds missing `type="button"` attributes.

Nnte:
The Close button misses a tooltip. Icon-buttons should always visually expose their accessible name. In the admin, we're using the Tooltip component for this. Not sure how to solve this for the front end so I'm keeping this point out of this PR for now.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
- Make sure to enable `Core blocks` in the Gutenberg Experiments settings page.
- Edit a post, add an image with an alt text and an image without an alt text.
- Set both images to open in a lightbox (from the Advanced settings in the block settings sidebar).
- Publish the post and go to the front end.
- For the image that does have an alt text:
  - Check the button to open the lightbox has an aria-label `Enlarge image: {alt text here}`.
  - Open the lightbox.
  - Check the modal dialog aria-label is the image alt text.
- For the image that does not have an alt text:
  - Check the button to open the lightbox has an aria-label `Enlarge image`.
  - Open the lightbox.
  - Check the modal dialog aria-label is `Image`.
- Note: For the button and the dialog there's no need to provide information that is already automatically announceed by screen readers:
  - The button `aria-haspopup="dialog"` attribute makes screen reader announce something along the lines of `dialog pop-up`.
  - The dialog is already announced as `dialog` or `web dialog`.


### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

Screenshots with Safari + VoiceOver announcing the Lightbox button and dialog:

Button: 

<img width="1241" alt="Screenshot 2023-05-25 at 15 08 04" src="https://github.com/WordPress/gutenberg/assets/1682452/8eb43028-3900-465f-9f0f-89588866db0f">

Dialog:

<img width="1792" alt="Screenshot 2023-05-25 at 15 08 56" src="https://github.com/WordPress/gutenberg/assets/1682452/5dde87ff-b900-4fd8-93a4-c6c77fedf972">

