### PR TITLE
Navigation: Apply color classes to the navigation container element

### DIFF
--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -517,6 +517,33 @@ function render_block_core_navigation( $attributes, $content, $block ) {
 		'core/site-logo',
 	);
 
+	$block_styles = isset( $attributes['styles'] ) ? $attributes['styles'] : '';
+	$style = $block_styles . $colors['inline_styles'] . $font_sizes['inline_styles'];
+	$class = implode( ' ', $classes );
+
+	// If the menu name has been used previously then append an ID
+	// to the name to ensure uniqueness across a given post.
+	if ( isset( $seen_menu_names[ $nav_menu_name ] ) && $seen_menu_names[ $nav_menu_name ] > 1 ) {
+		$count         = $seen_menu_names[ $nav_menu_name ];
+		$nav_menu_name = $nav_menu_name . ' ' . ( $count );
+	}
+
+	$wrapper_attributes = get_block_wrapper_attributes(
+		array(
+			'class'      => $class,
+			'style'      => $style,
+			'aria-label' => $nav_menu_name,
+		)
+	);
+
+	$container_attributes = get_block_wrapper_attributes(
+		array(
+			'class'      => 'wp-block-navigation__container ' . $class,
+			'style'      => $style,
+		)
+	);
+
+
 	$inner_blocks_html = '';
 	$is_list_open      = false;
 	foreach ( $inner_blocks as $inner_block ) {
@@ -524,7 +551,10 @@ function render_block_core_navigation( $attributes, $content, $block ) {
 
 		if ( $is_list_item && ! $is_list_open ) {
 			$is_list_open       = true;
-			$inner_blocks_html .= '<ul class="wp-block-navigation__container '.implode( ' ', $classes ).'">';
+			$inner_blocks_html .= sprintf(
+				'<ul %1$s>',
+				$container_attributes,
+			);
 		}
 
 		if ( ! $is_list_item && $is_list_open ) {
@@ -545,23 +575,6 @@ function render_block_core_navigation( $attributes, $content, $block ) {
 	if ( $is_list_open ) {
 		$inner_blocks_html .= '</ul>';
 	}
-
-	$block_styles = isset( $attributes['styles'] ) ? $attributes['styles'] : '';
-
-	// If the menu name has been used previously then append an ID
-	// to the name to ensure uniqueness across a given post.
-	if ( isset( $seen_menu_names[ $nav_menu_name ] ) && $seen_menu_names[ $nav_menu_name ] > 1 ) {
-		$count         = $seen_menu_names[ $nav_menu_name ];
-		$nav_menu_name = $nav_menu_name . ' ' . ( $count );
-	}
-
-	$wrapper_attributes = get_block_wrapper_attributes(
-		array(
-			'class'      => implode( ' ', $classes ),
-			'style'      => $block_styles . $colors['inline_styles'] . $font_sizes['inline_styles'],
-			'aria-label' => $nav_menu_name,
-		)
-	);
 
 	$modal_unique_id = wp_unique_id( 'modal-' );
 

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -552,7 +552,7 @@ function render_block_core_navigation( $attributes, $content, $block ) {
 			$is_list_open       = true;
 			$inner_blocks_html .= sprintf(
 				'<ul %1$s>',
-				$container_attributes,
+				$container_attributes
 			);
 		}
 

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -518,8 +518,8 @@ function render_block_core_navigation( $attributes, $content, $block ) {
 	);
 
 	$block_styles = isset( $attributes['styles'] ) ? $attributes['styles'] : '';
-	$style = $block_styles . $colors['inline_styles'] . $font_sizes['inline_styles'];
-	$class = implode( ' ', $classes );
+	$style        = $block_styles . $colors['inline_styles'] . $font_sizes['inline_styles'];
+	$class        = implode( ' ', $classes );
 
 	// If the menu name has been used previously then append an ID
 	// to the name to ensure uniqueness across a given post.
@@ -538,11 +538,10 @@ function render_block_core_navigation( $attributes, $content, $block ) {
 
 	$container_attributes = get_block_wrapper_attributes(
 		array(
-			'class'      => 'wp-block-navigation__container ' . $class,
-			'style'      => $style,
+			'class' => 'wp-block-navigation__container ' . $class,
+			'style' => $style,
 		)
 	);
-
 
 	$inner_blocks_html = '';
 	$is_list_open      = false;

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -524,7 +524,7 @@ function render_block_core_navigation( $attributes, $content, $block ) {
 
 		if ( $is_list_item && ! $is_list_open ) {
 			$is_list_open       = true;
-			$inner_blocks_html .= '<ul class="wp-block-navigation__container">';
+			$inner_blocks_html .= '<ul class="wp-block-navigation__container '.implode( ' ', $classes ).'">';
 		}
 
 		if ( ! $is_list_item && $is_list_open ) {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Makes the navigation submenu blocks inherit their color from the navigation block. Fixes #50235

## Why?
On trunk when a navigation block sets a background color the submenus lose their color which cases issues like https://github.com/WordPress/gutenberg/issues/50235.

## How?
We just needed to add the right classes to the container block.

## Testing Instructions
1. Add a navigation block
1. Set a background color for the block but not for the submenus/overlay
1. Open the site in the front end
1. Check that the submenus still have a background color set.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
<img width="343" alt="Screenshot 2023-05-25 at 15 20 35" src="https://github.com/WordPress/gutenberg/assets/275961/f42da923-200a-401c-ad61-310b2f9dbb25">

Props to @MaggieCabrera who found the issue.