### PR TITLE
Revise LinkControl suggestions UI to use MenuItem

### DIFF
--- a/packages/block-editor/src/components/link-control/constants.js
+++ b/packages/block-editor/src/components/link-control/constants.js
@@ -8,7 +8,7 @@ import { __ } from '@wordpress/i18n';
 // order to handle it as a unique case.
 export const CREATE_TYPE = '__CREATE__';
 export const TEL_TYPE = 'tel';
-export const URL_TYPE = 'URL';
+export const URL_TYPE = 'link';
 export const MAILTO_TYPE = 'mailto';
 export const INTERNAL_TYPE = 'internal';
 

--- a/packages/block-editor/src/components/link-control/search-create-button.js
+++ b/packages/block-editor/src/components/link-control/search-create-button.js
@@ -1,21 +1,15 @@
 /**
- * External dependencies
- */
-import classnames from 'classnames';
-
-/**
  * WordPress dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
-import { Button } from '@wordpress/components';
+import { MenuItem } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
-import { Icon, plus } from '@wordpress/icons';
+import { plus } from '@wordpress/icons';
 
 export const LinkControlSearchCreate = ( {
 	searchTerm,
 	onClick,
 	itemProps,
-	isSelected,
 	buttonText,
 } ) => {
 	if ( ! searchTerm ) {
@@ -40,27 +34,15 @@ export const LinkControlSearchCreate = ( {
 	}
 
 	return (
-		<Button
+		<MenuItem
 			{ ...itemProps }
-			className={ classnames(
-				'block-editor-link-control__search-create block-editor-link-control__search-item',
-				{
-					'is-selected': isSelected,
-				}
-			) }
+			iconPosition="left"
+			icon={ plus }
+			className="block-editor-link-control__search-item"
 			onClick={ onClick }
 		>
-			<Icon
-				className="block-editor-link-control__search-item-icon"
-				icon={ plus }
-			/>
-
-			<span className="block-editor-link-control__search-item-header">
-				<span className="block-editor-link-control__search-item-title">
-					{ text }
-				</span>
-			</span>
-		</Button>
+			{ text }
+		</MenuItem>
 	);
 };
 

--- a/packages/block-editor/src/components/link-control/search-item.js
+++ b/packages/block-editor/src/components/link-control/search-item.js
@@ -1,14 +1,8 @@
 /**
- * External dependencies
- */
-import classnames from 'classnames';
-
-/**
  * WordPress dependencies
  */
-import { safeDecodeURI, filterURLForDisplay } from '@wordpress/url';
 import { __ } from '@wordpress/i18n';
-import { Button, TextHighlight } from '@wordpress/components';
+import { MenuItem, TextHighlight } from '@wordpress/components';
 import {
 	Icon,
 	globe,
@@ -52,50 +46,29 @@ function SearchItemIcon( { isURL, suggestion } ) {
 export const LinkControlSearchItem = ( {
 	itemProps,
 	suggestion,
-	isSelected = false,
+	searchTerm,
 	onClick,
 	isURL = false,
-	searchTerm = '',
 	shouldShowType = false,
 } ) => {
 	return (
-		<Button
+		<MenuItem
 			{ ...itemProps }
+			info={ isURL && __( 'Press ENTER to add this link' ) } // perhaps add info for all items.
+			iconPosition="left"
+			icon={
+				<SearchItemIcon suggestion={ suggestion } isURL={ isURL } />
+			}
 			onClick={ onClick }
-			className={ classnames( 'block-editor-link-control__search-item', {
-				'is-selected': isSelected,
-				'is-url': isURL,
-				'is-entity': ! isURL,
-			} ) }
+			shortcut={ shouldShowType && getVisualTypeName( suggestion ) }
+			className="block-editor-link-control__search-item"
 		>
-			<SearchItemIcon suggestion={ suggestion } isURL={ isURL } />
-
-			<span className="block-editor-link-control__search-item-header">
-				<span className="block-editor-link-control__search-item-title">
-					<TextHighlight
-						// The component expects a plain text string.
-						text={ stripHTML( suggestion.title ) }
-						highlight={ searchTerm }
-					/>
-				</span>
-				<span
-					aria-hidden={ ! isURL }
-					className="block-editor-link-control__search-item-info"
-				>
-					{ ! isURL &&
-						( filterURLForDisplay(
-							safeDecodeURI( suggestion.url )
-						) ||
-							'' ) }
-					{ isURL && __( 'Press ENTER to add this link' ) }
-				</span>
-			</span>
-			{ shouldShowType && suggestion.type && (
-				<span className="block-editor-link-control__search-item-type">
-					{ getVisualTypeName( suggestion ) }
-				</span>
-			) }
-		</Button>
+			<TextHighlight
+				// The component expects a plain text string.
+				text={ stripHTML( suggestion.title ) }
+				highlight={ searchTerm }
+			/>
+		</MenuItem>
 	);
 };
 

--- a/packages/block-editor/src/components/link-control/search-item.js
+++ b/packages/block-editor/src/components/link-control/search-item.js
@@ -13,6 +13,7 @@ import {
 	file,
 } from '@wordpress/icons';
 import { __unstableStripHTML as stripHTML } from '@wordpress/dom';
+import { safeDecodeURI, filterURLForDisplay } from '@wordpress/url';
 
 const ICONS_MAP = {
 	post: postList,
@@ -51,10 +52,14 @@ export const LinkControlSearchItem = ( {
 	isURL = false,
 	shouldShowType = false,
 } ) => {
+	const info = isURL
+		? __( 'Press ENTER to add this link' )
+		: filterURLForDisplay( safeDecodeURI( suggestion?.url ) );
+
 	return (
 		<MenuItem
 			{ ...itemProps }
-			info={ isURL && __( 'Press ENTER to add this link' ) } // perhaps add info for all items.
+			info={ info }
 			iconPosition="left"
 			icon={
 				<SearchItemIcon suggestion={ suggestion } isURL={ isURL } />

--- a/packages/block-editor/src/components/link-control/search-results.js
+++ b/packages/block-editor/src/components/link-control/search-results.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
-import { VisuallyHidden } from '@wordpress/components';
+import { VisuallyHidden, MenuGroup } from '@wordpress/components';
 
 /**
  * External dependencies
@@ -72,59 +72,61 @@ export default function LinkControlSearchResults( {
 				className={ resultsListClasses }
 				aria-labelledby={ searchResultsLabelId }
 			>
-				{ suggestions.map( ( suggestion, index ) => {
-					if (
-						shouldShowCreateSuggestion &&
-						CREATE_TYPE === suggestion.type
-					) {
+				<MenuGroup>
+					{ suggestions.map( ( suggestion, index ) => {
+						if (
+							shouldShowCreateSuggestion &&
+							CREATE_TYPE === suggestion.type
+						) {
+							return (
+								<LinkControlSearchCreate
+									searchTerm={ currentInputValue }
+									buttonText={ createSuggestionButtonText }
+									onClick={ () =>
+										handleSuggestionClick( suggestion )
+									}
+									// Intentionally only using `type` here as
+									// the constant is enough to uniquely
+									// identify the single "CREATE" suggestion.
+									key={ suggestion.type }
+									itemProps={ buildSuggestionItemProps(
+										suggestion,
+										index
+									) }
+									isSelected={ index === selectedSuggestion }
+								/>
+							);
+						}
+
+						// If we're not handling "Create" suggestions above then
+						// we don't want them in the main results so exit early.
+						if ( CREATE_TYPE === suggestion.type ) {
+							return null;
+						}
+
 						return (
-							<LinkControlSearchCreate
-								searchTerm={ currentInputValue }
-								buttonText={ createSuggestionButtonText }
-								onClick={ () =>
-									handleSuggestionClick( suggestion )
-								}
-								// Intentionally only using `type` here as
-								// the constant is enough to uniquely
-								// identify the single "CREATE" suggestion.
-								key={ suggestion.type }
+							<LinkControlSearchItem
+								key={ `${ suggestion.id }-${ suggestion.type }` }
 								itemProps={ buildSuggestionItemProps(
 									suggestion,
 									index
 								) }
+								suggestion={ suggestion }
+								index={ index }
+								onClick={ () => {
+									handleSuggestionClick( suggestion );
+								} }
 								isSelected={ index === selectedSuggestion }
+								isURL={ LINK_ENTRY_TYPES.includes(
+									suggestion.type
+								) }
+								searchTerm={ currentInputValue }
+								shouldShowType={ shouldShowSuggestionsTypes }
+								isFrontPage={ suggestion?.isFrontPage }
 							/>
 						);
-					}
-
-					// If we're not handling "Create" suggestions above then
-					// we don't want them in the main results so exit early.
-					if ( CREATE_TYPE === suggestion.type ) {
-						return null;
-					}
-
-					return (
-						<LinkControlSearchItem
-							key={ `${ suggestion.id }-${ suggestion.type }` }
-							itemProps={ buildSuggestionItemProps(
-								suggestion,
-								index
-							) }
-							suggestion={ suggestion }
-							index={ index }
-							onClick={ () => {
-								handleSuggestionClick( suggestion );
-							} }
-							isSelected={ index === selectedSuggestion }
-							isURL={ LINK_ENTRY_TYPES.includes(
-								suggestion.type
-							) }
-							searchTerm={ currentInputValue }
-							shouldShowType={ shouldShowSuggestionsTypes }
-							isFrontPage={ suggestion?.isFrontPage }
-						/>
-					);
-				} ) }
+					} ) }
+				</MenuGroup>
 			</div>
 		</div>
 	);

--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -13,6 +13,12 @@ $preview-image-height: 140px;
 	}
 }
 
+.link-control-transform,
+.block-editor-link-control__tools,
+.block-editor-link-control__search-results-label {
+	display: none !important; // temp hacky hide — should def be removed.
+}
+
 .block-editor-link-control {
 	position: relative;
 	min-width: $modal-min-width;
@@ -41,6 +47,7 @@ $preview-image-height: 140px;
 // Provides positioning context for reset button. Without this then when an
 // error notice is displayed the input's reset button is incorrectly positioned.
 .block-editor-link-control__search-input-wrapper {
+	margin-bottom: $grid-unit-10;
 	position: relative;
 }
 
@@ -77,10 +84,11 @@ $preview-image-height: 140px;
 		@include input-control;
 		width: calc(100% - #{$grid-unit-20 * 2});
 		display: block;
-		padding: 11px $grid-unit-20;
+		padding: $grid-unit-10 $grid-unit-20;
 		margin: 0;
 		position: relative;
-		border: 1px solid $gray-300;
+		border: 1px solid $gray-600;
+		height: 40px;
 		border-radius: $radius-block-ui;
 	}
 }
@@ -97,37 +105,37 @@ $preview-image-height: 140px;
 	order: 20;
 }
 
-.block-editor-link-control__search-results-wrapper {
-	position: relative;
-	margin-top: -$grid-unit-20 + 1px;
+// .block-editor-link-control__search-results-wrapper {
+// 	position: relative;
+// 	margin-top: -$grid-unit-20 + 1px;
 
-	&::before,
-	&::after {
-		content: "";
-		position: absolute;
-		left: -1px;
-		right: $grid-unit-20; // avoid overlaying scrollbars
-		display: block;
-		pointer-events: none;
-		z-index: 100;
-	}
+// 	&::before,
+// 	&::after {
+// 		content: "";
+// 		position: absolute;
+// 		left: -1px;
+// 		right: $grid-unit-20; // avoid overlaying scrollbars
+// 		display: block;
+// 		pointer-events: none;
+// 		z-index: 100;
+// 	}
 
-	&::before {
-		height: $grid-unit-20 * 0.5;
-		top: 0;
-		bottom: auto;
-	}
+// 	&::before {
+// 		height: $grid-unit-20 * 0.5;
+// 		top: 0;
+// 		bottom: auto;
+// 	}
 
-	&::after {
-		height: $grid-unit-20;
-		bottom: 0;
-		top: auto;
-	}
-}
+// 	&::after {
+// 		height: $grid-unit-20;
+// 		bottom: 0;
+// 		top: auto;
+// 	}
+// }
 
 .block-editor-link-control__search-results {
-	margin: 0;
-	padding: $grid-unit-20 * 0.5 $grid-unit-20 $grid-unit-20 * 0.5;
+	margin-top: -$grid-unit-20;
+	padding: $grid-unit-10;
 	max-height: 200px;
 	overflow-y: auto; // allow results list to scroll
 
@@ -136,40 +144,28 @@ $preview-image-height: 140px;
 	}
 }
 
+// .block-editor-link-control__search-results-wrapper {
+// 	border-bottom: 1px solid $gray-400; // its odd currently because there are no persistent controls in the foot.
+// }
+
 .block-editor-link-control__search-item {
-	position: relative;
-	display: flex;
-	align-items: flex-start; // when link text is very long it is important this indicator remains visible and thus should be aligned top.
-	font-size: $default-font-size;
-	cursor: pointer;
-	background: $white;
-	width: 100%;
-	border: none;
-	text-align: left;
-	padding: $grid-unit-15 $grid-unit-20;
-	border-radius: 2px;
-	height: auto;
 
-	&:hover,
-	&:focus {
-		background-color: $gray-100;
-
-		.block-editor-link-control__search-item-type {
-			background: $white;
-		}
+	&.components-button.components-menu-item__button {
+		padding-left: $grid-unit-05;
+		padding-right: $grid-unit-10;
+		height: auto;
+		text-align: left;
 	}
 
-	// The added specificity is needed to override.
-	&:focus:not(:disabled) {
-		box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color) inset;
+	.components-menu-item__item {
+		overflow: hidden;
+		text-overflow: ellipsis;
 	}
 
-	&.is-selected {
-		background: $gray-100;
-
-		.block-editor-link-control__search-item-type {
-			background: $white;
-		}
+	.components-menu-item__shortcut {
+		color: $gray-700;
+		text-transform: capitalize;
+		white-space: nowrap; // tags shouldn't go over two lines.
 	}
 
 	&.is-current {
@@ -207,20 +203,20 @@ $preview-image-height: 140px;
 		align-items: center;
 	}
 
-	.block-editor-link-control__search-item-icon {
-		position: relative;
-		top: 0.2em;
-		margin-right: $grid-unit-10;
-		max-height: 24px;
-		flex-shrink: 0;
-		width: 24px;
-		display: flex;
-		justify-content: center;
+	// .block-editor-link-control__search-item-icon {
+	// 	position: relative;
+	// 	top: 0.2em;
+	// 	margin-right: $grid-unit-10;
+	// 	max-height: 24px;
+	// 	flex-shrink: 0;
+	// 	width: 24px;
+	// 	display: flex;
+	// 	justify-content: center;
 
-		img {
-			width: 16px; // favicons often have a source of 32px
-		}
-	}
+	// 	img {
+	// 		width: 16px; // favicons often have a source of 32px
+	// 	}
+	// }
 
 	&.is-error .block-editor-link-control__search-item-icon {
 		top: 0;
@@ -228,17 +224,6 @@ $preview-image-height: 140px;
 		max-height: 32px;
 	}
 
-	.block-editor-link-control__search-item-info,
-	.block-editor-link-control__search-item-title {
-		overflow: hidden;
-		text-overflow: ellipsis;
-
-		.components-external-link__icon {
-			position: absolute;
-			right: 0;
-			margin-top: 0;
-		}
-	}
 
 	.block-editor-link-control__search-item-title {
 		display: block;
@@ -261,27 +246,11 @@ $preview-image-height: 140px;
 		}
 	}
 
-	.block-editor-link-control__search-item-info {
-		display: block;
-		color: $gray-700;
-		font-size: 0.9em;
-		line-height: 1.3;
-	}
-
-	.block-editor-link-control__search-item-error-notice {
-		font-style: italic;
-		font-size: 1.1em;
-	}
-
-	.block-editor-link-control__search-item-type {
-		display: block;
-		padding: 3px 6px;
-		margin-left: auto;
-		font-size: 0.9em;
-		background-color: $gray-100;
-		border-radius: 2px;
-		white-space: nowrap; // tags shouldn't go over two lines.
-	}
+	// .block-editor-link-control__search-item-info {
+	// 	display: block;
+	// 	color: $gray-700;
+	// 	line-height: 1.3;
+	// }
 
 	.block-editor-link-control__search-item-description {
 		padding-top: 12px;
@@ -423,9 +392,9 @@ $preview-image-height: 140px;
 }
 
 // Specificity override
-.block-editor-link-control__search-results div[role="menu"] > .block-editor-link-control__search-item.block-editor-link-control__search-item {
-	padding: 10px;
-}
+// .block-editor-link-control__search-results div[role="menu"] > .block-editor-link-control__search-item.block-editor-link-control__search-item {
+// 	padding: 10px;
+// }
 
 .block-editor-link-control__drawer {
 	display: flex; // allow for ordering.

--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -142,6 +142,7 @@ $preview-image-height: 140px;
 // 	border-bottom: 1px solid $gray-400; // its odd currently because there are no persistent controls in the foot.
 // }
 
+
 .block-editor-link-control__search-item {
 
 	&.components-button.components-menu-item__button {
@@ -149,6 +150,10 @@ $preview-image-height: 140px;
 		padding-right: $grid-unit-10;
 		height: auto;
 		text-align: left;
+
+		&[aria-selected] {
+			background: $gray-100;
+		}
 	}
 
 	.components-menu-item__item {

--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -243,12 +243,6 @@ $preview-image-height: 140px;
 		}
 	}
 
-	// .block-editor-link-control__search-item-info {
-	// 	display: block;
-	// 	color: $gray-700;
-	// 	line-height: 1.3;
-	// }
-
 	.block-editor-link-control__search-item-description {
 		padding-top: 12px;
 		margin: 0;
@@ -387,11 +381,6 @@ $preview-image-height: 140px;
 		top: 0; // cancel compensatory spacing added to default suggestions.
 	}
 }
-
-// Specificity override
-// .block-editor-link-control__search-results div[role="menu"] > .block-editor-link-control__search-item.block-editor-link-control__search-item {
-// 	padding: 10px;
-// }
 
 .block-editor-link-control__drawer {
 	display: flex; // allow for ordering.

--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -160,6 +160,9 @@ $preview-image-height: 140px;
 	.components-menu-item__item {
 		overflow: hidden;
 		text-overflow: ellipsis;
+		// Inline block required to preserve white space
+		// between `<mark>` elements and text nodes.
+		display: inline-block;
 	}
 
 	.components-menu-item__shortcut {

--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -200,20 +200,20 @@ $preview-image-height: 140px;
 		align-items: center;
 	}
 
-	// .block-editor-link-control__search-item-icon {
-	// 	position: relative;
-	// 	top: 0.2em;
-	// 	margin-right: $grid-unit-10;
-	// 	max-height: 24px;
-	// 	flex-shrink: 0;
-	// 	width: 24px;
-	// 	display: flex;
-	// 	justify-content: center;
+	.block-editor-link-control__search-item-icon {
+		position: relative;
+		top: 0.2em;
+		margin-right: $grid-unit-10;
+		max-height: 24px;
+		flex-shrink: 0;
+		width: 24px;
+		display: flex;
+		justify-content: center;
 
-	// 	img {
-	// 		width: 16px; // favicons often have a source of 32px
-	// 	}
-	// }
+		img {
+			width: 16px; // favicons often have a source of 32px
+		}
+	}
 
 	&.is-error .block-editor-link-control__search-item-icon {
 		top: 0;

--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -179,7 +179,6 @@ $preview-image-height: 140px;
 
 	.block-editor-link-control__search-item-icon {
 		position: relative;
-		top: 0.2em;
 		margin-right: $grid-unit-10;
 		max-height: 24px;
 		flex-shrink: 0;

--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -13,12 +13,6 @@ $preview-image-height: 140px;
 	}
 }
 
-.link-control-transform,
-.block-editor-link-control__tools,
-.block-editor-link-control__search-results-label {
-	display: none !important; // temp hacky hide — should def be removed.
-}
-
 .block-editor-link-control {
 	position: relative;
 	min-width: $modal-min-width;

--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -121,6 +121,11 @@ $preview-image-height: 140px;
 		&[aria-selected] {
 			background: $gray-100;
 		}
+
+		&:hover,
+		&:focus {
+			background-color: $gray-200;
+		}
 	}
 
 	.components-menu-item__item {

--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -99,34 +99,6 @@ $preview-image-height: 140px;
 	order: 20;
 }
 
-// .block-editor-link-control__search-results-wrapper {
-// 	position: relative;
-// 	margin-top: -$grid-unit-20 + 1px;
-
-// 	&::before,
-// 	&::after {
-// 		content: "";
-// 		position: absolute;
-// 		left: -1px;
-// 		right: $grid-unit-20; // avoid overlaying scrollbars
-// 		display: block;
-// 		pointer-events: none;
-// 		z-index: 100;
-// 	}
-
-// 	&::before {
-// 		height: $grid-unit-20 * 0.5;
-// 		top: 0;
-// 		bottom: auto;
-// 	}
-
-// 	&::after {
-// 		height: $grid-unit-20;
-// 		bottom: 0;
-// 		top: auto;
-// 	}
-// }
-
 .block-editor-link-control__search-results {
 	margin-top: -$grid-unit-20;
 	padding: $grid-unit-10;
@@ -137,11 +109,6 @@ $preview-image-height: 140px;
 		opacity: 0.2;
 	}
 }
-
-// .block-editor-link-control__search-results-wrapper {
-// 	border-bottom: 1px solid $gray-400; // its odd currently because there are no persistent controls in the foot.
-// }
-
 
 .block-editor-link-control__search-item {
 

--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -131,6 +131,10 @@ $preview-image-height: 140px;
 		white-space: nowrap; // tags shouldn't go over two lines.
 	}
 
+	&[aria-selected] {
+		background: $gray-100;
+	}
+
 	&.is-current {
 		flex-direction: column; // allow for stacking.
 		background: transparent;

--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -113,19 +113,8 @@ $preview-image-height: 140px;
 .block-editor-link-control__search-item {
 
 	&.components-button.components-menu-item__button {
-		padding-left: $grid-unit-05;
-		padding-right: $grid-unit-10;
 		height: auto;
 		text-align: left;
-
-		&[aria-selected] {
-			background: $gray-100;
-		}
-
-		&:hover,
-		&:focus {
-			background-color: $gray-200;
-		}
 	}
 
 	.components-menu-item__item {
@@ -196,7 +185,6 @@ $preview-image-height: 140px;
 		width: 32px;
 		max-height: 32px;
 	}
-
 
 	.block-editor-link-control__search-item-title {
 		display: block;

--- a/packages/block-editor/src/components/link-control/test/index.js
+++ b/packages/block-editor/src/components/link-control/test/index.js
@@ -582,42 +582,36 @@ describe( 'Searching for a link', () => {
 		expect( mockFetchSearchSuggestions ).not.toHaveBeenCalled();
 	} );
 
-	it.each( [
-		[ 'couldbeurlorentitysearchterm' ],
-		[ 'ThisCouldAlsoBeAValidURL' ],
-	] )(
-		'should display a URL suggestion as a default fallback for the search term "%s" which could potentially be a valid url.',
-		async ( searchTerm ) => {
-			const user = userEvent.setup();
-			render( <LinkControl /> );
+	it( 'should not display a URL suggestion when input is not likely to be a URL.', async () => {
+		const searchTerm = 'unlikelytobeaURL';
+		const user = userEvent.setup();
+		render( <LinkControl /> );
 
-			// Search Input UI.
-			const searchInput = screen.getByRole( 'combobox', { name: 'URL' } );
+		// Search Input UI.
+		const searchInput = screen.getByRole( 'combobox', { name: 'URL' } );
 
-			// Simulate searching for a term.
-			await user.type( searchInput, searchTerm );
+		// Simulate searching for a term.
+		await user.type( searchInput, searchTerm );
 
-			const searchResultElements = within(
-				await screen.findByRole( 'listbox', {
-					name: /Search results for.*/,
-				} )
-			).getAllByRole( 'option' );
+		const searchResultElements = within(
+			await screen.findByRole( 'listbox', {
+				name: /Search results for.*/,
+			} )
+		).getAllByRole( 'option' );
 
-			const lastSearchResultItem =
-				searchResultElements[ searchResultElements.length - 1 ];
+		const lastSearchResultItem =
+			searchResultElements[ searchResultElements.length - 1 ];
 
-			// We should see a search result for each of the expect search suggestions.
-			expect( searchResultElements ).toHaveLength(
-				fauxEntitySuggestions.length
-			);
+		// We should see a search result for each of the expect search suggestions.
+		expect( searchResultElements ).toHaveLength(
+			fauxEntitySuggestions.length
+		);
 
-			// The URL search suggestion should not exist.
-			expect( lastSearchResultItem ).not.toHaveTextContent( searchTerm );
-			expect( lastSearchResultItem ).not.toHaveTextContent(
-				'Press ENTER to add this link'
-			);
-		}
-	);
+		// The URL search suggestion should not exist.
+		expect( lastSearchResultItem ).not.toHaveTextContent(
+			'Press ENTER to add this link'
+		);
+	} );
 
 	it( 'should not display a URL suggestion as a default fallback when noURLSuggestion is passed.', async () => {
 		const user = userEvent.setup();

--- a/packages/block-editor/src/components/link-control/test/index.js
+++ b/packages/block-editor/src/components/link-control/test/index.js
@@ -476,16 +476,16 @@ describe( 'Searching for a link', () => {
 			// The fallback URL suggestion should not be shown when input is not URL-like.
 			expect(
 				searchResultElements[ searchResultElements.length - 1 ]
-			).not.toHaveTextContent( 'URL' );
+			).not.toHaveTextContent( 'Press ENTER to add this link' );
 		}
 	);
 
 	it.each( [
-		[ 'https://wordpress.org', 'URL' ],
-		[ 'http://wordpress.org', 'URL' ],
-		[ 'www.wordpress.org', 'URL' ],
-		[ 'wordpress.org', 'URL' ],
-		[ 'ftp://wordpress.org', 'URL' ],
+		[ 'https://wordpress.org', 'link' ],
+		[ 'http://wordpress.org', 'link' ],
+		[ 'www.wordpress.org', 'link' ],
+		[ 'wordpress.org', 'link' ],
+		[ 'ftp://wordpress.org', 'link' ],
 		[ 'mailto:hello@wordpress.org', 'mailto' ],
 		[ 'tel:123456789', 'tel' ],
 		[ '#internal', 'internal' ],
@@ -582,6 +582,43 @@ describe( 'Searching for a link', () => {
 		expect( mockFetchSearchSuggestions ).not.toHaveBeenCalled();
 	} );
 
+	it.each( [
+		[ 'couldbeurlorentitysearchterm' ],
+		[ 'ThisCouldAlsoBeAValidURL' ],
+	] )(
+		'should display a URL suggestion as a default fallback for the search term "%s" which could potentially be a valid url.',
+		async ( searchTerm ) => {
+			const user = userEvent.setup();
+			render( <LinkControl /> );
+
+			// Search Input UI.
+			const searchInput = screen.getByRole( 'combobox', { name: 'URL' } );
+
+			// Simulate searching for a term.
+			await user.type( searchInput, searchTerm );
+
+			const searchResultElements = within(
+				await screen.findByRole( 'listbox', {
+					name: /Search results for.*/,
+				} )
+			).getAllByRole( 'option' );
+
+			const lastSearchResultItem =
+				searchResultElements[ searchResultElements.length - 1 ];
+
+			// We should see a search result for each of the expect search suggestions.
+			expect( searchResultElements ).toHaveLength(
+				fauxEntitySuggestions.length
+			);
+
+			// The URL search suggestion should not exist.
+			expect( lastSearchResultItem ).not.toHaveTextContent( searchTerm );
+			expect( lastSearchResultItem ).not.toHaveTextContent(
+				'Press ENTER to add this link'
+			);
+		}
+	);
+
 	it( 'should not display a URL suggestion as a default fallback when noURLSuggestion is passed.', async () => {
 		const user = userEvent.setup();
 		render( <LinkControl noURLSuggestion /> );
@@ -630,7 +667,6 @@ describe( 'Manual link entry', () => {
 
 			expect( searchResultElements ).toBeVisible();
 			expect( searchResultElements ).toHaveTextContent( searchTerm );
-			expect( searchResultElements ).toHaveTextContent( 'URL' );
 			expect( searchResultElements ).toHaveTextContent(
 				'Press ENTER to add this link'
 			);

--- a/packages/format-library/src/link/inline.js
+++ b/packages/format-library/src/link/inline.js
@@ -243,7 +243,7 @@ function InlineLinkUI( {
 		return createInterpolateElement(
 			sprintf(
 				/* translators: %s: search term. */
-				__( 'Create Page: <mark>%s</mark>' ),
+				__( 'Create page: <mark>%s</mark>' ),
 				searchTerm
 			),
 			{ mark: <mark /> }

--- a/test/e2e/specs/editor/blocks/navigation.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation.spec.js
@@ -1304,7 +1304,9 @@ class LinkControl {
 		await expect( result ).toBeVisible();
 
 		return result
-			.locator( '.block-editor-link-control__search-item-title' ) // this is the only way to get the label text without the URL.
+			.locator(
+				'.components-menu-item__info-wrapper .components-menu-item__item'
+			) // this is the only way to get the label text without the URL.
 			.innerText();
 	}
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Part of https://github.com/WordPress/gutenberg/issues/50885, as part of a greater [LinkControl refresh](https://github.com/WordPress/gutenberg/issues/50891) effort. Note that this should follow https://github.com/WordPress/gutenberg/pull/50977. 

- [x]  Try using `<MenuItem>` for items instead of custom buttons + styles. 
- [x]  Clean up search results metrics to match the mockups proposed in https://github.com/WordPress/gutenberg/issues/50891
- [x]  Refactor unused CSS
- [x]  Try adding back permalink info per [this discussion](https://github.com/WordPress/gutenberg/issues/50891#issuecomment-1561440083) 
- [x]  Tests

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a Post or Page.
2. Insert a Navigation Block.
3. Add a link item. 
4. See changes. 
5. Insert a Paragraph block.
6. Create an inline link. 
7. See changes. 

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/1813435/3ceb1600-3c64-4342-ab2f-054e641c9257

Co-authored-by: Dave Smith <444434+getdave@users.noreply.github.com>
