### PR TITLE
Move `"No Behaviors"` to be the first option in the list of behaviors.

### DIFF
--- a/packages/block-editor/src/hooks/behaviors.js
+++ b/packages/block-editor/src/hooks/behaviors.js
@@ -71,7 +71,7 @@ export const withBehaviors = createHigherOrderComponent( ( BlockEdit ) => {
 					behaviorName.slice( 1 ).toLowerCase(),
 			} ) );
 
-		const options = [ noBehaviorsOption, behaviorsOptions ];
+		const options = [ noBehaviorsOption, ...behaviorsOptions ];
 
 		return (
 			<>

--- a/packages/block-editor/src/hooks/behaviors.js
+++ b/packages/block-editor/src/hooks/behaviors.js
@@ -56,6 +56,23 @@ export const withBehaviors = createHigherOrderComponent( ( BlockEdit ) => {
 		// Block behaviors take precedence over theme behaviors.
 		const behaviors = merge( themeBehaviors, blockBehaviors || {} );
 
+		const noBehaviorsOption = {
+			value: '',
+			label: __( 'No behaviors' ),
+		};
+
+		const behaviorsOptions = Object.entries( settings )
+			.filter( ( [ , behaviorValue ] ) => behaviorValue ) // Filter out behaviors that are disabled.
+			.map( ( [ behaviorName ] ) => ( {
+				value: behaviorName,
+				label:
+					// Capitalize the first letter of the behavior name.
+					behaviorName[ 0 ].toUpperCase() +
+					behaviorName.slice( 1 ).toLowerCase(),
+			} ) );
+
+		const options = [ noBehaviorsOption, behaviorsOptions ];
+
 		return (
 			<>
 				<BlockEdit { ...props } />
@@ -65,19 +82,7 @@ export const withBehaviors = createHigherOrderComponent( ( BlockEdit ) => {
 						label={ __( 'Behaviors' ) }
 						// At the moment we are only supporting one behavior (Lightbox)
 						value={ behaviors?.lightbox ? 'lightbox' : '' }
-						options={ Object.entries( settings )
-							.filter( ( [ , behaviorValue ] ) => behaviorValue ) // Filter out behaviors that are disabled.
-							.map( ( [ behaviorName ] ) => ( {
-								value: behaviorName,
-								label:
-									// Capitalize the first letter of the behavior name.
-									behaviorName[ 0 ].toUpperCase() +
-									behaviorName.slice( 1 ).toLowerCase(),
-							} ) )
-							.concat( {
-								value: '',
-								label: __( 'No behaviors' ),
-							} ) }
+						options={ options }
 						onChange={ ( nextValue ) => {
 							// If the user selects something, it means that they want to
 							// change the default value (true) so we save it in the attributes.


### PR DESCRIPTION
## Why?
UX bug: It's typical for the "empty" or "none" option to be the first item in the `<select>` list.

### Before
<img width="278" alt="Screenshot 2023-05-25 at 14 26 42" src="https://github.com/WordPress/gutenberg/assets/5417266/eebad53d-0996-4bdb-a728-78ef9612b568">


### After

<img width="278" alt="Screenshot 2023-05-25 at 14 28 29" src="https://github.com/WordPress/gutenberg/assets/5417266/53137a9e-c563-4990-b3bf-672f1716e819">

