### PR TITLE
Preferentially Execute Local `wp-env`

### DIFF
--- a/packages/env/CHANGELOG.md
+++ b/packages/env/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### New feature
+
+-   Execute the local package's `wp-env` instead of the globally installed version if one is available.
+
 ## 8.0.0 (2023-05-24)
 
 ### Breaking Change

--- a/packages/env/README.md
+++ b/packages/env/README.md
@@ -44,7 +44,7 @@ If your project already has a package.json, it's also possible to use `wp-env` a
 $ npm i @wordpress/env --save-dev
 ```
 
-If you have also installed `wp-env` globally, running it will automatically execute the local, project-level package. You can also execute it via [`npx`](https://www.npmjs.com/package/npx), a utility automatically installed with `npm`.`npx` finds binaries like `wp-env` installed through node modules. As an example: `npx wp-env start --update`.
+If you have also installed `wp-env` globally, running it will automatically execute the local, project-level package. Alternatively, you can execute `wp-env` via [`npx`](https://www.npmjs.com/package/npx), a utility automatically installed with `npm`.`npx` finds binaries like `wp-env` installed through node modules. As an example: `npx wp-env start --update`.
 
 If you don't wish to use the global installation or `npx`, modify your `package.json` and add an extra command to npm `scripts` (https://docs.npmjs.com/misc/scripts):
 

--- a/packages/env/README.md
+++ b/packages/env/README.md
@@ -44,9 +44,9 @@ If your project already has a package.json, it's also possible to use `wp-env` a
 $ npm i @wordpress/env --save-dev
 ```
 
-At this point, you can use the local, project-level version of wp-env via [`npx`](https://www.npmjs.com/package/npx), a utility automatically installed with `npm`.`npx` finds binaries like wp-env installed through node modules. As an example: `npx wp-env start --update`.
+If you have also installed `wp-env` globally, running it will automatically execute the local, project-level package. You can also execute it via [`npx`](https://www.npmjs.com/package/npx), a utility automatically installed with `npm`.`npx` finds binaries like `wp-env` installed through node modules. As an example: `npx wp-env start --update`.
 
-If you don't wish to use `npx`, modify your package.json and add an extra command to npm `scripts` (https://docs.npmjs.com/misc/scripts):
+If you don't wish to use the global installation or `npx`, modify your `package.json` and add an extra command to npm `scripts` (https://docs.npmjs.com/misc/scripts):
 
 ```json
 "scripts": {

--- a/packages/env/bin/wp-env
+++ b/packages/env/bin/wp-env
@@ -17,8 +17,8 @@ if ( ! command.length ) {
 // Rather than just executing the current CLI we will attempt to find a local version
 // and execute that one instead. This prevents users from accidentally using the
 // global CLI when a potentially different local version is expected.
-const localPath = path.resolve( './node_modules/@wordpress/env/lib/cli' );
-const cliPath = fs.existsSync( localPath ) ? localPath : '../lib/cli';
+const localPath = path.resolve( './node_modules/@wordpress/env/lib/cli.js' );
+const cliPath = fs.existsSync( localPath ) ? localPath : '../lib/cli.js';
 const cli = require( cliPath )();
 
 // Now we can execute the CLI with the given command.

--- a/packages/env/bin/wp-env
+++ b/packages/env/bin/wp-env
@@ -1,25 +1,20 @@
 #!/usr/bin/env node
 'use strict';
 
-/**
- * External dependencies.
- */
-const path = require( 'path' );
-const fs = require( 'fs' );
-
 // Remove 'node' and the name of the script from the arguments.
 let command = process.argv.slice( 2 );
 // Default to help text when they aren't running any commands.
 if ( ! command.length ) {
-    command = [ '--help' ];
+	command = [ '--help' ];
 }
 
 // Rather than just executing the current CLI we will attempt to find a local version
 // and execute that one instead. This prevents users from accidentally using the
 // global CLI when a potentially different local version is expected.
-const localPath = path.resolve( './node_modules/@wordpress/env/lib/cli.js' );
-const cliPath = fs.existsSync( localPath ) ? localPath : '../lib/cli.js';
-const cli = require( cliPath )();
+const localPath = require.resolve( '@wordpress/env/lib/cli.js', {
+	paths: [ process.cwd(), __dirname ],
+} );
+const cli = require( localPath )();
 
 // Now we can execute the CLI with the given command.
 cli.parse( command );

--- a/packages/env/bin/wp-env
+++ b/packages/env/bin/wp-env
@@ -1,4 +1,25 @@
 #!/usr/bin/env node
 'use strict';
-const command = process.argv.slice( 2 );
-require( '../lib/cli' )().parse( command.length ? command : [ '--help' ] );
+
+/**
+ * External dependencies.
+ */
+const path = require( 'path' );
+const fs = require( 'fs' );
+
+// Remove 'node' and the name of the script from the arguments.
+let command = process.argv.slice( 2 );
+// Default to help text when they aren't running any commands.
+if ( ! command.length ) {
+    command = [ '--help' ];
+}
+
+// Rather than just executing the current CLI we will attempt to find a local version
+// and execute that one instead. This prevents users from accidentally using the
+// global CLI when a potentially different local version is expected.
+const localPath = path.resolve( './node_modules/@wordpress/env/lib/cli' );
+const cliPath = fs.existsSync( localPath ) ? localPath : '../lib/cli';
+const cli = require( cliPath )();
+
+// Now we can execute the CLI with the given command.
+cli.parse( command );

--- a/packages/env/lib/cli.js
+++ b/packages/env/lib/cli.js
@@ -7,12 +7,11 @@ const ora = require( 'ora' );
 const yargs = require( 'yargs' );
 const terminalLink = require( 'terminal-link' );
 const { execSync } = require( 'child_process' );
-const path = require( 'path' );
 
 /**
  * Internal dependencies
  */
-const pkg = require( path.resolve( __dirname, '../package.json' ) );
+const pkg = require( '../package.json' );
 const env = require( './env' );
 const parseXdebugMode = require( './parse-xdebug-mode' );
 const {

--- a/packages/env/lib/cli.js
+++ b/packages/env/lib/cli.js
@@ -7,10 +7,12 @@ const ora = require( 'ora' );
 const yargs = require( 'yargs' );
 const terminalLink = require( 'terminal-link' );
 const { execSync } = require( 'child_process' );
+const path = require( 'path' );
 
 /**
  * Internal dependencies
  */
+const pkg = require( path.resolve( __dirname, '../package.json' ) );
 const env = require( './env' );
 const parseXdebugMode = require( './parse-xdebug-mode' );
 const {
@@ -109,6 +111,10 @@ module.exports = function cli() {
 		// Populates '--' in the command options with arguments after the double dash.
 		'populate--': true,
 	} );
+
+	// Since we might be running a different CLI version than the one that was called
+	// we need to set the version manually from the correct package.json.
+	yargs.version( pkg.version );
 
 	yargs.command(
 		'start',


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This pull request causes `wp-env` commands to be executed by the local package's version if one is available.

## Why?
When someone has a global `wp-env` that is a different version than the one installed in the package, running `wp-env` commands can be problematic. There may be compatibility problems for instance.

## How?
Rather than relying on something like `execSync`, this PR loads the `lib/cli.js` file from the local package if it is available. This makes the entire execution seamless.

## Testing Instructions

1. Set the `version` in `packages/env/package.json` to `20.0.0`.
2. Run `npm pack` in `packages/env`.
3. Run `npm -g I ./wordpress-env-20.0.0.tgz` and install this package globally.
4. Change the `version` back to what it was before.
5. Run `wp-env --version` in `packages/env/lib` and confirm it is `20.0.0.0`.
6. Run `wp-env --version` in `packages/env` and confirm it is the local version, probably `8.0.0`.