### PR TITLE
[Fonts API] Show enqueued font-families in font pickers outside of Site Editor

### DIFF
--- a/lib/experimental/fonts-api/class-wp-fonts-resolver.php
+++ b/lib/experimental/fonts-api/class-wp-fonts-resolver.php
@@ -135,7 +135,9 @@ class WP_Fonts_Resolver {
 	 * @return WP_Theme_JSON_Gutenberg|WP_Theme_JSON The global styles with missing fonts.
 	 */
 	public static function add_missing_fonts_to_theme_json( $data ) {
-		$font_families_registered = wp_fonts()->get_registered_font_families();
+		$font_families = WP_Fonts_Utils::is_in_site_editor()
+			? wp_fonts()->get_registered_font_families()
+			: wp_fonts()->get_enqueued();
 
 		$raw_data = $data->get_raw_data();
 
@@ -145,8 +147,8 @@ class WP_Fonts_Resolver {
 
 		// Find missing fonts that are not in the theme's theme.json.
 		$to_add = array();
-		if ( ! empty( $font_families_registered ) ) {
-			$to_add = array_diff( $font_families_registered, static::get_font_families( $font_families_from_theme ) );
+		if ( ! empty( $font_families ) ) {
+			$to_add = array_diff( $font_families, static::get_font_families( $font_families_from_theme ) );
 		}
 
 		// Bail out early if there are no missing fonts.

--- a/lib/experimental/fonts-api/class-wp-fonts-utils.php
+++ b/lib/experimental/fonts-api/class-wp-fonts-utils.php
@@ -119,4 +119,17 @@ class WP_Fonts_Utils {
 		trigger_error( 'Font family not defined in the variation.' );
 		return null;
 	}
+
+	/**
+	 * Checks if the Site Editor is the current page being displayed.
+	 *
+	 * @since X.X.X
+	 *
+	 * @return bool True when the Site Editor is the current page, else false.
+	 */
+	public static function is_in_site_editor() {
+		global $pagenow;
+
+		return is_admin() && ( 'site-editor.php' === $pagenow );
+	}
 }

--- a/phpunit/fonts-api/wpFontsResolver/addMissingFontsToThemeJson-test.php
+++ b/phpunit/fonts-api/wpFontsResolver/addMissingFontsToThemeJson-test.php
@@ -13,7 +13,8 @@ require_once __DIR__ . '/../wp-fonts-testcase.php';
  * @covers WP_Fonts_Resolver::add_missing_fonts_to_theme_json
  */
 class Tests_Fonts_WPFontsResolver_AddMissingFontsToThemeJson extends WP_Fonts_TestCase {
-	const FONTS_THEME = 'fonts-block-theme';
+	const FONTS_THEME       = 'fonts-block-theme';
+	private static $pagenow = '';
 
 	/**
 	 * Cache of test themes' `theme.json` contents.
@@ -35,6 +36,13 @@ class Tests_Fonts_WPFontsResolver_AddMissingFontsToThemeJson extends WP_Fonts_Te
 			$file                            = self::$theme_root . "/{$theme}/theme.json";
 			self::$theme_json_data[ $theme ] = json_decode( file_get_contents( $file ), true );
 		}
+
+		self::$pagenow = $GLOBALS['pagenow'];
+	}
+
+	public function tear_down() {
+		$GLOBALS['pagenow'] = self::$pagenow;
+		parent::tear_down();
 	}
 
 	/**
@@ -79,14 +87,19 @@ class Tests_Fonts_WPFontsResolver_AddMissingFontsToThemeJson extends WP_Fonts_Te
 	}
 
 	/**
-	 * @dataProvider data_should_add_non_theme_json_fonts
+	 * @dataProvider data_should_add_non_theme_json_fonts_when_in_site_editor
 	 *
 	 * @param string $theme    Theme to use.
 	 * @param array  $fonts    Fonts to register.
 	 * @param array  $expected Expected fonts to be added.
 	 */
-	public function test_should_add_non_theme_json_fonts( $theme, $fonts, $expected ) {
+	public function test_should_add_non_theme_json_fonts_when_in_site_editor( $theme, $fonts, $expected ) {
 		switch_theme( static::FONTS_THEME );
+
+		// Set up the Site Editor.
+		global $pagenow;
+		$pagenow = 'site-editor.php';
+		set_current_screen( 'site-editor' );
 
 		// Register the fonts.
 		wp_register_fonts( $fonts );
@@ -113,7 +126,7 @@ class Tests_Fonts_WPFontsResolver_AddMissingFontsToThemeJson extends WP_Fonts_Te
 	 *
 	 * @return array
 	 */
-	public function data_should_add_non_theme_json_fonts() {
+	public function data_should_add_non_theme_json_fonts_when_in_site_editor() {
 		$lato = array(
 			'Lato' => array(
 				array(


### PR DESCRIPTION
Fixes #40362.

## What?

When not in the Site Editor, font-family pickers should only show enqueued font-families. Prior to this PR, all registered fonts were available for user selection.

## Why?

Global fonts (i.e. enqueued fonts) consist of (a) the theme's defined fonts in its `theme.json` file and (b) user selected fonts from the Site Editor. These fonts are then used for the entire website. At the block level within a UI other than the Site Editor, users can select from those globally defined fonts (i.e. enqueued fonts). 

## How?

In `WP_Fonts_Resolver::add_missing_fonts_to_theme_json()`, it detects when not in the Site Editor and uses the enqueued fonts for determining missing user-selected fonts to add.

## Testing Instructions

### Manual Testing

Setting up your local test site:
1. Make sure Gutenberg is activated: Plugins > Gutenberg.
2. Install and activate [this test plugin](https://github.com/ironprogrammer/webfonts-jetpack-test).
3. Activate the TT3, if it is not already.

#### Scenario 1: Site Editor font pickers
1. Open the Site Editor > Styles > Typography UI.
2. Select Heading.
3. In the Fonts selector, verify the theme and all Google Fonts are available for selection. **Expectation**: All of the registered fonts should be listed in the font picker.

<img width="429" alt="Screen Shot 2023-05-25 at 4 48 05 PM" src="https://github.com/WordPress/gutenberg/assets/7284611/f23815e5-8dfb-4908-83c7-1f1b5e5c33f9">

#### Scenario 2: Block Editor font pickers in a Post or Page
1. Open a post in the Post editor.
2. Select a block.
3. In the block inspector, select the Typography options (the 3 vertical dots next to the Typography) and then select "Font family" to display that tool.
5. In the Fonts selector, verify that only the themes fonts are available for selection. **Expectation**: All of the enqueued fonts should be listed in the font picker.

<img width="531" alt="Screen Shot 2023-05-25 at 4 40 44 PM" src="https://github.com/WordPress/gutenberg/assets/7284611/291aa13d-1d2d-4404-9026-434ab37f3c8f">

#### Scenario 3: User selected font
1. Open the Site Editor > Styles > Typography UI.
2. Select Headings.
3. Select Playfair Display.
4. Save the custom styles.
6. Go back to the post from scenario 2.
7. Verify Playfair Display is available for selection in a block's Font tool.

<img width="464" alt="Screen Shot 2023-05-25 at 4 46 40 PM" src="https://github.com/WordPress/gutenberg/assets/7284611/24bb76c1-ea65-4ef1-9045-bf203cceff8d">

### Automated Testing

Run the following:
```
npm run test:unit:php -- --group fontsapi
```

All tests should pass.
