### PR TITLE
Fix private registry selectors

### DIFF
--- a/packages/data/src/test/privateAPIs.js
+++ b/packages/data/src/test/privateAPIs.js
@@ -183,24 +183,23 @@ describe( 'Private data APIs', () => {
 
 		it( 'should support calling a private registry selector from a public selector', () => {
 			const groceryStore = createStore();
-			const storeA = createReduxStore( 'a', {
-				reducer: ( state = {} ) => state,
-			} );
-			registry.register( storeA );
-			const getPrice = createRegistrySelector(
-				( select ) => () => select( groceryStore ).getPublicPrice()
-			);
-			unlock( storeA ).registerPrivateSelectors( {
-				getPrice,
-			} );
-			const storeB = createReduxStore( 'b', {
+			const store = createReduxStore( 'a', {
 				reducer: ( state = {} ) => state,
 				selectors: {
-					getPrice: ( state ) => getPrice( state ),
+					getPriceWithShippingAndTax: ( state ) =>
+						getPriceWithShipping( state ) * 1.1,
 				},
 			} );
-			registry.register( storeB );
-			expect( registry.select( storeB ).getPrice() ).toEqual( 1000 );
+			registry.register( store );
+			const getPriceWithShipping = createRegistrySelector(
+				( select ) => () => select( groceryStore ).getPublicPrice() + 5
+			);
+			unlock( store ).registerPrivateSelectors( {
+				getPriceWithShipping,
+			} );
+			expect(
+				registry.select( store ).getPriceWithShippingAndTax()
+			).toEqual( 1105.5 );
 		} );
 	} );
 


### PR DESCRIPTION
## What, why, how
Currently one gets an error if you call a private registry selector (created using `createRegistrySelector`) from a regular public selector.

This is happens because the `mapValues` that sets `selector.registry` happens lazily for private selectors.

https://github.com/WordPress/gutenberg/blob/382eda62d90c7a41abb209613792b27e6e90d968/packages/data/src/redux-store/index.js#L218-L237

It needs to be eager (the same as public selectors) so that selectors can be composed.

I can't figure out a good way to fix this, so this PR just adds a failing test. @jsnajdr @adamziel: could you please help me? 😀

## Testing Instructions
```
npm run test
```