### PR TITLE
Hide the "View" button when previewing a theme

### DIFF
--- a/packages/edit-site/src/components/header-edit-mode/index.js
+++ b/packages/edit-site/src/components/header-edit-mode/index.js
@@ -260,6 +260,14 @@ export default function HeaderEditMode() {
 			<div className="edit-site-header-edit-mode__end">
 				<div className="edit-site-header-edit-mode__actions">
 					{ ! isFocusMode &&
+						/**
+						 * This isPreviewingTheme() condition can be removed
+						 * once the issues below are fixed
+						 * and previewing the front of the site works well.
+						 *
+						 * https://github.com/WordPress/gutenberg/issues/50713
+						 * https://github.com/WordPress/gutenberg/issues/50712
+						 */
 						! isPreviewingTheme() &&
 						hasDefaultEditorCanvasView && (
 							<div

--- a/packages/edit-site/src/components/header-edit-mode/index.js
+++ b/packages/edit-site/src/components/header-edit-mode/index.js
@@ -44,6 +44,7 @@ import {
 	useHasEditorCanvasContainer,
 } from '../editor-canvas-container';
 import { unlock } from '../../private-apis';
+import { isPreviewingTheme } from '../../utils/is-previewing-theme';
 
 const { useShouldContextualToolbarShow } = unlock( blockEditorPrivateApis );
 
@@ -258,37 +259,39 @@ export default function HeaderEditMode() {
 
 			<div className="edit-site-header-edit-mode__end">
 				<div className="edit-site-header-edit-mode__actions">
-					{ ! isFocusMode && hasDefaultEditorCanvasView && (
-						<div
-							className={ classnames(
-								'edit-site-header-edit-mode__preview-options',
-								{ 'is-zoomed-out': isZoomedOutView }
-							) }
-						>
-							<PreviewOptions
-								deviceType={ deviceType }
-								setDeviceType={ setPreviewDeviceType }
-								/* translators: button label text should, if possible, be under 16 characters. */
-								viewLabel={ __( 'View' ) }
+					{ ! isFocusMode &&
+						! isPreviewingTheme() &&
+						hasDefaultEditorCanvasView && (
+							<div
+								className={ classnames(
+									'edit-site-header-edit-mode__preview-options',
+									{ 'is-zoomed-out': isZoomedOutView }
+								) }
 							>
-								<MenuGroup>
-									<MenuItem
-										href={ homeUrl }
-										target="_blank"
-										icon={ external }
-									>
-										{ __( 'View site' ) }
-										<VisuallyHidden as="span">
-											{
-												/* translators: accessibility text */
-												__( '(opens in a new tab)' )
-											}
-										</VisuallyHidden>
-									</MenuItem>
-								</MenuGroup>
-							</PreviewOptions>
-						</div>
-					) }
+								<PreviewOptions
+									deviceType={ deviceType }
+									setDeviceType={ setPreviewDeviceType }
+									/* translators: button label text should, if possible, be under 16 characters. */
+									viewLabel={ __( 'View' ) }
+								>
+									<MenuGroup>
+										<MenuItem
+											href={ homeUrl }
+											target="_blank"
+											icon={ external }
+										>
+											{ __( 'View site' ) }
+											<VisuallyHidden as="span">
+												{
+													/* translators: accessibility text */
+													__( '(opens in a new tab)' )
+												}
+											</VisuallyHidden>
+										</MenuItem>
+									</MenuGroup>
+								</PreviewOptions>
+							</div>
+						) }
 					<SaveButton />
 					<PinnedItems.Slot scope="core/edit-site" />
 					<MoreMenu showIconLabels={ showIconLabels } />


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Hide "View" when [previewing](https://github.com/WordPress/gutenberg/pull/50030) a block theme.

Close: https://github.com/WordPress/gutenberg/issues/50919

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

While we can show a preview on the front of the site with `?theme_preview` URL query, I thought we better fix these issues (https://github.com/WordPress/gutenberg/issues/50713, https://github.com/WordPress/gutenberg/issues/50712) before adding the URL query to the link. 
So, I'm proposing to hide it until previewing the front of the site works well.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

- Look at the result of `isPreviewing()` and show/hide "View"

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

- Open the Site Editor and add the following to your URL: ?theme_preview=[themePath] where themePath is the relative path to the theme you want to preview (e.g. twentytwentythree).
- Try to edit it 
- No longer see the "View" button on the header

## Screenshots or screencast <!-- if applicable -->

When previewing;
![590abb864c05501320ba3b5f2249f3b6](https://github.com/WordPress/gutenberg/assets/5287479/cf8aa1b6-e451-4337-a305-2094d641c513)

When not previewing;
<img width="1438" alt="Screen Shot 2023-05-26 at 15 03 17" src="https://github.com/WordPress/gutenberg/assets/5287479/f0315a09-f126-4def-86ed-adf96377d982">
