### PR TITLE
Remove outdated Babel spread optimization from selectors

### DIFF
--- a/packages/data/src/redux-store/index.js
+++ b/packages/data/src/redux-store/index.js
@@ -371,23 +371,8 @@ function instantiateReduxStore( key, options, registry, thunkArgs ) {
  */
 function mapSelectors( selectors, store ) {
 	const createStateSelector = ( registrySelector ) => {
-		const selector = function runSelector() {
-			// This function is an optimized implementation of:
-			//
-			//   selector( store.getState(), ...arguments )
-			//
-			// Where the above would incur an `Array#concat` in its application,
-			// the logic here instead efficiently constructs an arguments array via
-			// direct assignment.
-			const argsLength = arguments.length;
-			const args = new Array( argsLength + 1 );
-			args[ 0 ] = store.__unstableOriginalGetState();
-			for ( let i = 0; i < argsLength; i++ ) {
-				args[ i + 1 ] = arguments[ i ];
-			}
-
-			return registrySelector( ...args );
-		};
+		const selector = ( ...args ) =>
+			registrySelector( store.__unstableOriginalGetState(), ...args );
 		selector.hasResolver = false;
 		return selector;
 	};


### PR DESCRIPTION
In the `mapSelector` function there is an optimization that constructs arguments array (state + args) to be passed to an inner selector. That's because manually constructing them can be faster than what Babel transpilation would otherwise do.

But nowadays, with the current browserslist config, the transpilation of spread function arguments is no longer done. Code like this:
```js
function mapped(...args) {
  return selector(1,...args);
}
```
used to be transpiled as:
```js
function mapped() {
  for (var _len = arguments.length, args = new Array(_len), _key = 0; _key < _len; _key++) {
    args[_key] = arguments[_key];
  }
  return selector.apply(void 0, [1].concat(args));
}
```
with the `transform-parameters` and `transform-spread` plugins, but today it's just:
```js
function mapped() {
  for (var _len = arguments.length, args = new Array(_len), _key = 0; _key < _len; _key++) {
    args[_key] = arguments[_key];
  }
  return selector(1, ...args);
}
```
Only the `transform-parameters` plugin is used, to transform _incoming_ spreads, but in call arguments, where there used to be the offending `.concat`, we no longer transpile.

One day even the `transform-parameters` will go away, it's currently there only because of one obscure Safari bug in destructuring: https://github.com/babel/babel/issues/13916

My PR is removing the custom arguments-transforming code. It's always been a mild annoyance when debugging and having to step through it.