### PR TITLE
Add reset button to color control

### DIFF
--- a/packages/block-editor/src/components/colors-gradients/style.scss
+++ b/packages/block-editor/src/components/colors-gradients/style.scss
@@ -69,6 +69,7 @@ $swatch-gap: 12px;
 * with the `:last-child` styles.
 */
 .block-editor-tools-panel-color-gradient-settings__item {
+	position: relative;
 	padding: 0;
 	max-width: 100%;
 
@@ -99,7 +100,7 @@ $swatch-gap: 12px;
 	display: block;
 	padding: 0;
 
-	> button {
+	> .block-editor-panel-color-gradient-settings__dropdown {
 		height: auto;
 		padding-top: $grid-unit * 1.25;
 		padding-bottom: $grid-unit * 1.25;
@@ -123,5 +124,34 @@ $swatch-gap: 12px;
 
 	.component-color-indicator {
 		flex-shrink: 0;
+	}
+}
+
+.block-editor-panel-color-gradient-settings__reset {
+	position: absolute;
+	display: inline-flex;
+	right: 0;
+	top: 0;
+	bottom: 0;
+	margin: auto $grid-unit auto;
+	height: 24px;
+	width: 24px;
+	opacity: 0;
+	transition: opacity 0.1s ease-in-out;
+
+	// Override the button style.
+	&.components-button.has-icon {
+		padding: 0;
+		min-width: 0;
+		border-radius: 0;
+	}
+
+	.block-editor-panel-color-gradient-settings__dropdown:hover + & {
+		opacity: 1;
+	}
+
+	&:focus,
+	&:hover {
+		opacity: 1;
 	}
 }

--- a/packages/block-editor/src/components/global-styles/color-panel.js
+++ b/packages/block-editor/src/components/global-styles/color-panel.js
@@ -21,6 +21,7 @@ import {
 } from '@wordpress/components';
 import { useCallback } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
+import { reset } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -238,12 +239,25 @@ function ColorPanelDropdown( {
 					};
 
 					return (
-						<Button { ...toggleProps }>
-							<LabeledColorIndicators
-								indicators={ indicators }
-								label={ label }
+						<>
+							<Button { ...toggleProps }>
+								<LabeledColorIndicators
+									indicators={ indicators }
+									label={ label }
+								/>
+							</Button>
+							<Button
+								label={ __( 'Reset' ) }
+								aria-label={
+									/* translators: %s is the type of color property, e.g., "background" */
+									__( 'Reset %s color' )
+								}
+								className="block-editor-panel-color-gradient-settings__reset"
+								icon={ reset }
+								onClick={ resetValue }
+								showTooltip
 							/>
-						</Button>
+						</>
 					);
 				} }
 				renderContent={ () => (

--- a/packages/components/src/circular-option-picker/README.md
+++ b/packages/components/src/circular-option-picker/README.md
@@ -42,7 +42,7 @@ const Example = () => {
 					<CircularOptionPicker.ButtonAction
 						onClick={ () => setCurrentColor( undefined ) }
 					>
-						{ 'Clear' }
+						{ 'Reset' }
 					</CircularOptionPicker.ButtonAction>
 				}
 			/>
@@ -136,6 +136,6 @@ Inherits all of the [`Dropdown` props](/packages/components/src/dropdown/README.
 
 Props for the underlying `Button` component.
 
-Inherits all of the [`Button` props](/packages/components/src/button/README.md#props), except for `href`, `target`, and `children`. 
+Inherits all of the [`Button` props](/packages/components/src/button/README.md#props), except for `href`, `target`, and `children`.
 
 - Required: No

--- a/packages/components/src/circular-option-picker/index.tsx
+++ b/packages/components/src/circular-option-picker/index.tsx
@@ -142,7 +142,7 @@ export function ButtonAction( {
  * 					<CircularOptionPicker.ButtonAction
  * 						onClick={ () => setCurrentColor( undefined ) }
  * 					>
- * 						{ 'Clear' }
+ * 						{ 'Reset' }
  * 					</CircularOptionPicker.ButtonAction>
  * 				}
  * 			/>

--- a/packages/components/src/circular-option-picker/stories/index.tsx
+++ b/packages/components/src/circular-option-picker/stories/index.tsx
@@ -97,7 +97,7 @@ const DefaultActions = () => {
 		<CircularOptionPicker.ButtonAction
 			onClick={ () => setCurrentColor?.( undefined ) }
 		>
-			{ 'Clear' }
+			{ 'Reset' }
 		</CircularOptionPicker.ButtonAction>
 	);
 };

--- a/packages/components/src/color-palette/index.tsx
+++ b/packages/components/src/color-palette/index.tsx
@@ -244,7 +244,7 @@ function UnforwardedColorPalette(
 		value,
 		actions: !! clearable && (
 			<CircularOptionPicker.ButtonAction onClick={ clearColor }>
-				{ __( 'Clear' ) }
+				{ __( 'Reset' ) }
 			</CircularOptionPicker.ButtonAction>
 		),
 		headingLevel,

--- a/packages/components/src/color-palette/test/index.tsx
+++ b/packages/components/src/color-palette/test/index.tsx
@@ -109,7 +109,7 @@ describe( 'ColorPalette', () => {
 			/>
 		);
 
-		await user.click( screen.getByRole( 'button', { name: 'Clear' } ) );
+		await user.click( screen.getByRole( 'button', { name: 'Reset' } ) );
 
 		expect( onChange ).toHaveBeenCalledTimes( 1 );
 		expect( onChange ).toHaveBeenCalledWith( undefined );
@@ -188,7 +188,7 @@ describe( 'ColorPalette', () => {
 		);
 
 		expect(
-			screen.getByRole( 'button', { name: 'Clear' } )
+			screen.getByRole( 'button', { name: 'Reset' } )
 		).toBeInTheDocument();
 	} );
 
@@ -198,7 +198,7 @@ describe( 'ColorPalette', () => {
 		render( <ColorPalette colors={ [] } onChange={ onChange } /> );
 
 		expect(
-			screen.getByRole( 'button', { name: 'Clear' } )
+			screen.getByRole( 'button', { name: 'Reset' } )
 		).toBeInTheDocument();
 	} );
 } );

--- a/packages/components/src/duotone-picker/duotone-picker.tsx
+++ b/packages/components/src/duotone-picker/duotone-picker.tsx
@@ -128,7 +128,7 @@ function DuotonePicker( {
 					<CircularOptionPicker.ButtonAction
 						onClick={ () => onChange( undefined ) }
 					>
-						{ __( 'Clear' ) }
+						{ __( 'Reset' ) }
 					</CircularOptionPicker.ButtonAction>
 				)
 			}

--- a/packages/components/src/gradient-picker/index.tsx
+++ b/packages/components/src/gradient-picker/index.tsx
@@ -222,7 +222,7 @@ export function GradientPicker( {
 								<CircularOptionPicker.ButtonAction
 									onClick={ clearGradient }
 								>
-									{ __( 'Clear' ) }
+									{ __( 'Reset' ) }
 								</CircularOptionPicker.ButtonAction>
 							)
 						}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Add inline reset button only shown on hover/focus to color control. Also unify the name from "clear" to "reset".

Note that gradient color doesn't have a reset button to match the original implementation in the dropdown. I don't know if it's a deliberate choice or an oversight?

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Close https://github.com/WordPress/gutenberg/issues/41866

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Add a button and tweak CSS.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
1. Add a paragraph
2. Open the editor settings
3. Hover over the color control, a "-" button should show
4. Clicking on it should reset the value

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
1. Add a paragraph
2. Open the editor settings
3. Tab through the color controls.
4. Second tab should focus on a reset button read "Reset [type] color", `[type]` is the property of the color, e.g. "Text" or "Background".
5. Hit enter should reset the value.

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/7753001/d0599a5c-20a8-4617-aa08-bc6d3abedf9e

