### PR TITLE
babel-preset-default: enable the bugfixes option for preset-env

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10466,6 +10466,25 @@
 						}
 					}
 				},
+				"terser": {
+					"version": "4.8.1",
+					"resolved": "https://registry.npmjs.org/terser/-/terser-4.8.1.tgz",
+					"integrity": "sha512-4GnLC0x667eJG0ewJTa6z/yXrbLGv80D9Ru6HIpCQmO+Q4PfEtBFi0ObSckqwL6VyQv/7ENJieXHo2ANmdQwgw==",
+					"dev": true,
+					"requires": {
+						"commander": "^2.20.0",
+						"source-map": "~0.6.1",
+						"source-map-support": "~0.5.12"
+					},
+					"dependencies": {
+						"commander": {
+							"version": "2.20.3",
+							"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+							"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+							"dev": true
+						}
+					}
+				},
 				"terser-webpack-plugin": {
 					"version": "4.2.3",
 					"resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-4.2.3.tgz",
@@ -10510,9 +10529,9 @@
 							}
 						},
 						"terser": {
-							"version": "5.15.0",
-							"resolved": "https://registry.npmjs.org/terser/-/terser-5.15.0.tgz",
-							"integrity": "sha512-L1BJiXVmheAQQy+as0oF3Pwtlo4s3Wi1X2zNZ2NxOB4wx9bdS9Vk67XQENLFdLYGCK/Z2di53mTj/hBafR+dTA==",
+							"version": "5.17.6",
+							"resolved": "https://registry.npmjs.org/terser/-/terser-5.17.6.tgz",
+							"integrity": "sha512-V8QHcs8YuyLkLHsJO5ucyff1ykrLVsR4dNnS//L5Y3NiSXpbK1J+WMVUs67eI0KTxs9JtHhgEQpXQVHlHI92DQ==",
 							"dev": true,
 							"requires": {
 								"@jridgewell/source-map": "^0.3.2",
@@ -11522,6 +11541,12 @@
 						"get-intrinsic": "^1.0.2"
 					}
 				},
+				"commander": {
+					"version": "2.20.3",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+					"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+					"dev": true
+				},
 				"debug": {
 					"version": "4.3.4",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
@@ -11818,6 +11843,17 @@
 						"isobject": "^4.0.0",
 						"lodash": "^4.17.21",
 						"memoizerific": "^1.11.3"
+					}
+				},
+				"terser": {
+					"version": "4.8.1",
+					"resolved": "https://registry.npmjs.org/terser/-/terser-4.8.1.tgz",
+					"integrity": "sha512-4GnLC0x667eJG0ewJTa6z/yXrbLGv80D9Ru6HIpCQmO+Q4PfEtBFi0ObSckqwL6VyQv/7ENJieXHo2ANmdQwgw==",
+					"dev": true,
+					"requires": {
+						"commander": "^2.20.0",
+						"source-map": "~0.6.1",
+						"source-map-support": "~0.5.12"
 					}
 				},
 				"terser-webpack-plugin": {
@@ -12348,6 +12384,25 @@
 						"isobject": "^4.0.0",
 						"lodash": "^4.17.21",
 						"memoizerific": "^1.11.3"
+					}
+				},
+				"terser": {
+					"version": "4.8.1",
+					"resolved": "https://registry.npmjs.org/terser/-/terser-4.8.1.tgz",
+					"integrity": "sha512-4GnLC0x667eJG0ewJTa6z/yXrbLGv80D9Ru6HIpCQmO+Q4PfEtBFi0ObSckqwL6VyQv/7ENJieXHo2ANmdQwgw==",
+					"dev": true,
+					"requires": {
+						"commander": "^2.20.0",
+						"source-map": "~0.6.1",
+						"source-map-support": "~0.5.12"
+					},
+					"dependencies": {
+						"commander": {
+							"version": "2.20.3",
+							"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+							"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+							"dev": true
+						}
 					}
 				},
 				"terser-webpack-plugin": {
@@ -13572,6 +13627,25 @@
 						"memoizerific": "^1.11.3"
 					}
 				},
+				"terser": {
+					"version": "4.8.1",
+					"resolved": "https://registry.npmjs.org/terser/-/terser-4.8.1.tgz",
+					"integrity": "sha512-4GnLC0x667eJG0ewJTa6z/yXrbLGv80D9Ru6HIpCQmO+Q4PfEtBFi0ObSckqwL6VyQv/7ENJieXHo2ANmdQwgw==",
+					"dev": true,
+					"requires": {
+						"commander": "^2.20.0",
+						"source-map": "~0.6.1",
+						"source-map-support": "~0.5.12"
+					},
+					"dependencies": {
+						"commander": {
+							"version": "2.20.3",
+							"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+							"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+							"dev": true
+						}
+					}
+				},
 				"terser-webpack-plugin": {
 					"version": "4.2.3",
 					"resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-4.2.3.tgz",
@@ -13607,9 +13681,9 @@
 							}
 						},
 						"terser": {
-							"version": "5.15.0",
-							"resolved": "https://registry.npmjs.org/terser/-/terser-5.15.0.tgz",
-							"integrity": "sha512-L1BJiXVmheAQQy+as0oF3Pwtlo4s3Wi1X2zNZ2NxOB4wx9bdS9Vk67XQENLFdLYGCK/Z2di53mTj/hBafR+dTA==",
+							"version": "5.17.6",
+							"resolved": "https://registry.npmjs.org/terser/-/terser-5.17.6.tgz",
+							"integrity": "sha512-V8QHcs8YuyLkLHsJO5ucyff1ykrLVsR4dNnS//L5Y3NiSXpbK1J+WMVUs67eI0KTxs9JtHhgEQpXQVHlHI92DQ==",
 							"dev": true,
 							"requires": {
 								"@jridgewell/source-map": "^0.3.2",
@@ -18618,7 +18692,7 @@
 				"sass-loader": "^12.1.0",
 				"source-map-loader": "^3.0.0",
 				"stylelint": "^14.2.0",
-				"terser-webpack-plugin": "^5.1.4",
+				"terser-webpack-plugin": "^5.3.9",
 				"url-loader": "^4.1.1",
 				"webpack": "^5.47.1",
 				"webpack-bundle-analyzer": "^4.4.2",
@@ -30259,6 +30333,12 @@
 						}
 					}
 				},
+				"commander": {
+					"version": "2.20.3",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+					"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+					"dev": true
+				},
 				"fill-range": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
@@ -30343,6 +30423,17 @@
 					"resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.3.tgz",
 					"integrity": "sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==",
 					"dev": true
+				},
+				"terser": {
+					"version": "4.8.1",
+					"resolved": "https://registry.npmjs.org/terser/-/terser-4.8.1.tgz",
+					"integrity": "sha512-4GnLC0x667eJG0ewJTa6z/yXrbLGv80D9Ru6HIpCQmO+Q4PfEtBFi0ObSckqwL6VyQv/7ENJieXHo2ANmdQwgw==",
+					"dev": true,
+					"requires": {
+						"commander": "^2.20.0",
+						"source-map": "~0.6.1",
+						"source-map-support": "~0.5.12"
+					}
 				},
 				"terser-webpack-plugin": {
 					"version": "1.4.5",
@@ -36878,37 +36969,11 @@
 				"terser": "^5.10.0"
 			},
 			"dependencies": {
-				"acorn": {
-					"version": "8.7.1",
-					"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.1.tgz",
-					"integrity": "sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A==",
-					"dev": true
-				},
 				"commander": {
 					"version": "8.3.0",
 					"resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
 					"integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
 					"dev": true
-				},
-				"terser": {
-					"version": "5.15.0",
-					"resolved": "https://registry.npmjs.org/terser/-/terser-5.15.0.tgz",
-					"integrity": "sha512-L1BJiXVmheAQQy+as0oF3Pwtlo4s3Wi1X2zNZ2NxOB4wx9bdS9Vk67XQENLFdLYGCK/Z2di53mTj/hBafR+dTA==",
-					"dev": true,
-					"requires": {
-						"@jridgewell/source-map": "^0.3.2",
-						"acorn": "^8.5.0",
-						"commander": "^2.20.0",
-						"source-map-support": "~0.5.20"
-					},
-					"dependencies": {
-						"commander": {
-							"version": "2.20.3",
-							"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-							"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-							"dev": true
-						}
-					}
 				}
 			}
 		},
@@ -55575,54 +55640,48 @@
 			}
 		},
 		"terser": {
-			"version": "4.8.1",
-			"resolved": "https://registry.npmjs.org/terser/-/terser-4.8.1.tgz",
-			"integrity": "sha512-4GnLC0x667eJG0ewJTa6z/yXrbLGv80D9Ru6HIpCQmO+Q4PfEtBFi0ObSckqwL6VyQv/7ENJieXHo2ANmdQwgw==",
+			"version": "5.17.6",
+			"resolved": "https://registry.npmjs.org/terser/-/terser-5.17.6.tgz",
+			"integrity": "sha512-V8QHcs8YuyLkLHsJO5ucyff1ykrLVsR4dNnS//L5Y3NiSXpbK1J+WMVUs67eI0KTxs9JtHhgEQpXQVHlHI92DQ==",
 			"dev": true,
 			"requires": {
+				"@jridgewell/source-map": "^0.3.2",
+				"acorn": "^8.5.0",
 				"commander": "^2.20.0",
-				"source-map": "~0.6.1",
-				"source-map-support": "~0.5.12"
+				"source-map-support": "~0.5.20"
 			},
 			"dependencies": {
+				"acorn": {
+					"version": "8.8.2",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz",
+					"integrity": "sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==",
+					"dev": true
+				},
 				"commander": {
 					"version": "2.20.3",
 					"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
 					"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
 					"dev": true
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
 				}
 			}
 		},
 		"terser-webpack-plugin": {
-			"version": "5.1.4",
-			"resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.1.4.tgz",
-			"integrity": "sha512-C2WkFwstHDhVEmsmlCxrXUtVklS+Ir1A7twrYzrDrQQOIMOaVAYykaoo/Aq1K0QRkMoY2hhvDQY1cm4jnIMFwA==",
+			"version": "5.3.9",
+			"resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.9.tgz",
+			"integrity": "sha512-ZuXsqE07EcggTWQjXUj+Aot/OMcD0bMKGgF63f7UxYcu5/AJF53aIpK1YoP5xR9l6s/Hy2b+t1AM0bLNPRuhwA==",
 			"dev": true,
 			"requires": {
-				"jest-worker": "^27.0.2",
-				"p-limit": "^3.1.0",
-				"schema-utils": "^3.0.0",
-				"serialize-javascript": "^6.0.0",
-				"source-map": "^0.6.1",
-				"terser": "^5.7.0"
+				"@jridgewell/trace-mapping": "^0.3.17",
+				"jest-worker": "^27.4.5",
+				"schema-utils": "^3.1.1",
+				"serialize-javascript": "^6.0.1",
+				"terser": "^5.16.8"
 			},
 			"dependencies": {
 				"@types/json-schema": {
-					"version": "7.0.8",
-					"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.8.tgz",
-					"integrity": "sha512-YSBPTLTVm2e2OoQIDYx8HaeWJ5tTToLH67kXR7zYNGupXMEHa2++G8k+DczX2cFVgalypqtyZIcU19AFcmOpmg==",
-					"dev": true
-				},
-				"acorn": {
-					"version": "8.8.0",
-					"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
-					"integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
+					"version": "7.0.12",
+					"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.12.tgz",
+					"integrity": "sha512-Hr5Jfhc9eYOQNPYO5WLDq/n4jqijdHNlDXjuAQkkt+mWdQR+XJToOHrsD4cPaMXpn6KO7y2+wM8AZEs8VpBLVA==",
 					"dev": true
 				},
 				"ajv": {
@@ -55643,18 +55702,6 @@
 					"integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
 					"dev": true
 				},
-				"commander": {
-					"version": "2.20.3",
-					"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-					"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-					"dev": true
-				},
-				"fast-deep-equal": {
-					"version": "3.1.3",
-					"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-					"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-					"dev": true
-				},
 				"has-flag": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -55662,9 +55709,9 @@
 					"dev": true
 				},
 				"jest-worker": {
-					"version": "27.0.6",
-					"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.0.6.tgz",
-					"integrity": "sha512-qupxcj/dRuA3xHPMUd40gr2EaAurFbkwzOh7wfPaeE9id7hyjURRQoqNfHifHK3XjJU6YJJUQKILGUnwGPEOCA==",
+					"version": "27.5.1",
+					"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
+					"integrity": "sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==",
 					"dev": true,
 					"requires": {
 						"@types/node": "*",
@@ -55672,19 +55719,10 @@
 						"supports-color": "^8.0.0"
 					}
 				},
-				"p-limit": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
-					"integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-					"dev": true,
-					"requires": {
-						"yocto-queue": "^0.1.0"
-					}
-				},
 				"schema-utils": {
-					"version": "3.1.1",
-					"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.1.tgz",
-					"integrity": "sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==",
+					"version": "3.1.2",
+					"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.2.tgz",
+					"integrity": "sha512-pvjEHOgWc9OWA/f/DE3ohBWTD6EleVLf7iFUkoSwAxttdBhB9QUebQgxER2kWueOvRJXPHNnyrvvh9eZINB8Eg==",
 					"dev": true,
 					"requires": {
 						"@types/json-schema": "^7.0.8",
@@ -55693,9 +55731,9 @@
 					}
 				},
 				"serialize-javascript": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
-					"integrity": "sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==",
+					"version": "6.0.1",
+					"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.1.tgz",
+					"integrity": "sha512-owoXEFjWRllis8/M1Q+Cw5k8ZH40e3zhp/ovX+Xr/vi1qj6QesbyXXViFbpNvWvPNAD62SutwEXavefrLJWj7w==",
 					"dev": true,
 					"requires": {
 						"randombytes": "^2.1.0"
@@ -55708,18 +55746,6 @@
 					"dev": true,
 					"requires": {
 						"has-flag": "^4.0.0"
-					}
-				},
-				"terser": {
-					"version": "5.15.0",
-					"resolved": "https://registry.npmjs.org/terser/-/terser-5.15.0.tgz",
-					"integrity": "sha512-L1BJiXVmheAQQy+as0oF3Pwtlo4s3Wi1X2zNZ2NxOB4wx9bdS9Vk67XQENLFdLYGCK/Z2di53mTj/hBafR+dTA==",
-					"dev": true,
-					"requires": {
-						"@jridgewell/source-map": "^0.3.2",
-						"acorn": "^8.5.0",
-						"commander": "^2.20.0",
-						"source-map-support": "~0.5.20"
 					}
 				}
 			}

--- a/package.json
+++ b/package.json
@@ -241,7 +241,7 @@
 		"storybook-source-link": "2.0.4",
 		"strip-json-comments": "5.0.0",
 		"style-loader": "3.2.1",
-		"terser-webpack-plugin": "5.1.4",
+		"terser-webpack-plugin": "5.3.9",
 		"typescript": "4.9.5",
 		"uglify-js": "3.13.7",
 		"uuid": "8.3.0",

--- a/packages/babel-preset-default/CHANGELOG.md
+++ b/packages/babel-preset-default/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancement
+
+-   Enable the `bugfixes` option in `@babel/preset-env` to remove unneeded transpilation ([#50994](https://github.com/WordPress/gutenberg/pull/50994)).
+
 ## 7.18.0 (2023-05-24)
 
 ## 7.17.0 (2023-05-10)

--- a/packages/babel-preset-default/index.js
+++ b/packages/babel-preset-default/index.js
@@ -22,6 +22,7 @@ module.exports = ( api ) => {
 
 	const getPresetEnv = () => {
 		const opts = {
+			bugfixes: true,
 			include: [
 				'proposal-nullish-coalescing-operator',
 				'proposal-logical-assignment-operators',

--- a/packages/babel-preset-default/test/__snapshots__/index.js.snap
+++ b/packages/babel-preset-default/test/__snapshots__/index.js.snap
@@ -15,15 +15,13 @@ exports[`Babel preset default transpilation works properly 1`] = `
     });
   });
   test('support for optional chaining', () => {
-    var _obj$foo, _obj$foo2;
-
     const obj = {
       foo: {
         bar: 42
       }
     };
-    expect(obj === null || obj === void 0 ? void 0 : (_obj$foo = obj.foo) === null || _obj$foo === void 0 ? void 0 : _obj$foo.bar).toEqual(42);
-    expect(obj === null || obj === void 0 ? void 0 : (_obj$foo2 = obj.foo) === null || _obj$foo2 === void 0 ? void 0 : _obj$foo2.baz).toEqual(undefined);
+    expect(obj?.foo?.bar).toEqual(42);
+    expect(obj?.foo?.baz).toEqual(undefined);
   });
 });"
 `;

--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancements
+
+-   The bundled `terser-webpack-plugin` dependency has been updated from requiring `^5.1.4` to requiring `^5.3.9` ([#50994](https://github.com/WordPress/gutenberg/pull/50994)).
+
 ## 26.5.0 (2023-05-24)
 
 ## 26.4.0 (2023-05-10)

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -82,7 +82,7 @@
 		"sass-loader": "^12.1.0",
 		"source-map-loader": "^3.0.0",
 		"stylelint": "^14.2.0",
-		"terser-webpack-plugin": "^5.1.4",
+		"terser-webpack-plugin": "^5.3.9",
 		"url-loader": "^4.1.1",
 		"webpack": "^5.47.1",
 		"webpack-bundle-analyzer": "^4.4.2",


### PR DESCRIPTION
Babel has a `transform-parameters` transform plugin that transpiles all kinds of function parameters: destructuring, spread operators, ...

Today all supported browsers have full ES6 support, so this transform shouldn't be active. But it is. Because Safari has an obscure bug in one destructuring edge case (https://bugs.webkit.org/show_bug.cgi?id=220517), it's not 100% safe to leave destructuring code untranspiled. That's why `transform-parameters` is active by default and we get _all_ ES6 function parameters syntax transpiled.

See this screenshot where an innocent `[ key, attribute ]` destructuring gets transpiled:

<img width="521" alt="Screenshot 2023-05-26 at 10 08 33" src="https://github.com/WordPress/gutenberg/assets/664258/a00fd718-b478-4f49-bbd8-90767c9a52ec">

That's why Babel has a `bugfixes` option. It replaces the `transform-parameters` plugin with a more targeted one that transpiles just that one Safari edge case.

Enabling this option removed all that unnecessary transpilation:

<img width="613" alt="Screenshot 2023-05-26 at 10 14 52" src="https://github.com/WordPress/gutenberg/assets/664258/923dfb01-0d3a-452b-8ca7-e5b036d0a1f8">

It is planned to be enabled by default in Babel 8, so it should be safe for Gutenberg, too.

Related to #50987.