### PR TITLE
Remove "preview" mode/step from Link Control component

### DIFF
--- a/packages/block-editor/src/components/link-control/constants.js
+++ b/packages/block-editor/src/components/link-control/constants.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { page, tag, postList, category, file } from '@wordpress/icons';
 
 // Used as a unique identifier for the "Create" option within search results.
 // Used to help distinguish the "Create" suggestion within the search results in
@@ -18,6 +19,14 @@ export const LINK_ENTRY_TYPES = [
 	TEL_TYPE,
 	INTERNAL_TYPE,
 ];
+
+export const ICONS_MAP = {
+	post: postList,
+	page,
+	post_tag: tag,
+	category,
+	attachment: file,
+};
 
 export const DEFAULT_LINK_SETTINGS = [
 	{

--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -314,6 +314,10 @@ function LinkControl( {
 
 	const showActions = hasLinkValue;
 
+	// Show the input if there is not a link value or if the link value
+	// does not represent a Post object.
+	const showSearchInput = ! hasLinkValue || ! value?.id;
+
 	// Only show text control once a URL value has been committed
 	// and it isn't just empty whitespace.
 	// See https://github.com/WordPress/gutenberg/pull/33849/#issuecomment-932194927.
@@ -351,23 +355,27 @@ function LinkControl( {
 					'has-actions': showActions,
 				} ) }
 			>
-				<LinkControlSearchInput
-					currentLink={ value }
-					className="block-editor-link-control__field block-editor-link-control__search-input"
-					placeholder={ searchInputPlaceholder }
-					value={ currentUrlInputValue }
-					withCreateSuggestion={ withCreateSuggestion }
-					onCreateSuggestion={ createPage }
-					onChange={ setInternalURLInputValue }
-					onSelect={ handleSelectSuggestion }
-					showInitialSuggestions={ showInitialSuggestions }
-					allowDirectEntry={ ! noDirectEntry }
-					showSuggestions={ showSuggestions }
-					suggestionsQuery={ suggestionsQuery }
-					withURLSuggestion={ ! noURLSuggestion }
-					createSuggestionButtonText={ createSuggestionButtonText }
-					hideLabelFromVision={ ! showTextControl }
-				/>
+				{ showSearchInput && (
+					<LinkControlSearchInput
+						currentLink={ value }
+						className="block-editor-link-control__field block-editor-link-control__search-input"
+						placeholder={ searchInputPlaceholder }
+						value={ currentUrlInputValue }
+						withCreateSuggestion={ withCreateSuggestion }
+						onCreateSuggestion={ createPage }
+						onChange={ setInternalURLInputValue }
+						onSelect={ handleSelectSuggestion }
+						showInitialSuggestions={ showInitialSuggestions }
+						allowDirectEntry={ ! noDirectEntry }
+						showSuggestions={ showSuggestions }
+						suggestionsQuery={ suggestionsQuery }
+						withURLSuggestion={ ! noURLSuggestion }
+						createSuggestionButtonText={
+							createSuggestionButtonText
+						}
+						hideLabelFromVision={ ! showTextControl }
+					/>
+				) }
 
 				{ showTextControl && (
 					<TextControl

--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -91,9 +91,6 @@ import { DEFAULT_LINK_SETTINGS } from './constants';
  *
  * @property {(WPLinkControlSetting[])=}  settings                   An array of settings objects. Each object will used to
  *                                                                   render a `ToggleControl` for that setting.
- * @property {boolean=}                   forceIsEditingLink         If passed as either `true` or `false`, controls the
- *                                                                   internal editing state of the component to respective
- *                                                                   show or not show the URL input field.
  * @property {WPLinkControlValue=}        value                      Current link value.
  * @property {WPLinkControlOnChangeProp=} onChange                   Value change handler, called with the updated value if
  *                                                                   the user selects a new link or updates settings.
@@ -130,7 +127,6 @@ function LinkControl( {
 	noDirectEntry = false,
 	showSuggestions = true,
 	showInitialSuggestions,
-	forceIsEditingLink,
 	createSuggestion,
 	withCreateSuggestion,
 	inputValue: propInputValue = '',
@@ -198,22 +194,8 @@ function LinkControl( {
 	const valueHasChanges =
 		value && ! isShallowEqualObjects( internalControlValue, value );
 
-	const [ isEditingLink, setIsEditingLink ] = useState(
-		forceIsEditingLink !== undefined
-			? forceIsEditingLink
-			: ! value || ! value.url
-	);
-
 	const { createPage, isCreatingPage, errorMessage } =
 		useCreatePage( createSuggestion );
-
-	useEffect( () => {
-		if ( forceIsEditingLink === undefined ) {
-			return;
-		}
-
-		setIsEditingLink( forceIsEditingLink );
-	}, [ forceIsEditingLink ] );
 
 	useEffect( () => {
 		// We don't auto focus into the Link UI on mount
@@ -236,7 +218,7 @@ function LinkControl( {
 		nextFocusTarget.focus();
 
 		isEndingEditWithFocus.current = false;
-	}, [ isEditingLink, isCreatingPage ] );
+	}, [ isCreatingPage ] );
 
 	const hasLinkValue = value?.url?.trim()?.length > 0;
 
@@ -248,8 +230,6 @@ function LinkControl( {
 		isEndingEditWithFocus.current = !! wrapperNode.current?.contains(
 			wrapperNode.current.ownerDocument.activeElement
 		);
-
-		setIsEditingLink( false );
 	};
 
 	const handleSelectSuggestion = ( updatedValue ) => {
@@ -330,8 +310,7 @@ function LinkControl( {
 
 	const currentInputIsEmpty = ! currentUrlInputValue?.trim()?.length;
 
-	const shownUnlinkControl =
-		onRemove && value && ! isEditingLink && ! isCreatingPage;
+	const shownUnlinkControl = onRemove && value && ! isCreatingPage;
 
 	const showActions = hasLinkValue;
 
@@ -359,13 +338,9 @@ function LinkControl( {
 				<LinkPreview
 					key={ value?.url } // force remount when URL changes to avoid race conditions for rich previews
 					value={ value }
-					onEditClick={ () => setIsEditingLink( true ) }
 					hasRichPreviews={ hasRichPreviews }
 					hasUnlinkControl={ shownUnlinkControl }
-					onRemove={ () => {
-						onRemove();
-						setIsEditingLink( true );
-					} }
+					onRemove={ onRemove }
 				/>
 			) }
 

--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -333,16 +333,15 @@ function LinkControl( {
 	const shownUnlinkControl =
 		onRemove && value && ! isEditingLink && ! isCreatingPage;
 
-	const showActions = isEditingLink && hasLinkValue;
+	const showActions = hasLinkValue;
 
 	// Only show text control once a URL value has been committed
 	// and it isn't just empty whitespace.
 	// See https://github.com/WordPress/gutenberg/pull/33849/#issuecomment-932194927.
 	const showTextControl = hasLinkValue && hasTextControl;
 
-	const isEditing = ( isEditingLink || ! value ) && ! isCreatingPage;
 	const isDisabled = ! valueHasChanges || currentInputIsEmpty;
-	const showSettings = !! settings?.length && isEditingLink && hasLinkValue;
+	const showSettings = !! settings?.length && hasLinkValue;
 
 	return (
 		<div
@@ -356,101 +355,78 @@ function LinkControl( {
 				</div>
 			) }
 
-			{ isEditing && (
-				<>
-					<div
-						className={ classnames( {
-							'block-editor-link-control__search-input-wrapper': true,
-							'has-text-control': showTextControl,
-							'has-actions': showActions,
-						} ) }
-					>
-						{ showTextControl && (
-							<TextControl
-								__nextHasNoMarginBottom
-								ref={ textInputRef }
-								className="block-editor-link-control__field block-editor-link-control__text-content"
-								label={ __( 'Text' ) }
-								value={ internalControlValue?.title }
-								onChange={ setInternalTextInputValue }
-								onKeyDown={ handleSubmitWithEnter }
-								size="__unstable-large"
-							/>
-						) }
-						<LinkControlSearchInput
-							currentLink={ value }
-							className="block-editor-link-control__field block-editor-link-control__search-input"
-							placeholder={ searchInputPlaceholder }
-							value={ currentUrlInputValue }
-							withCreateSuggestion={ withCreateSuggestion }
-							onCreateSuggestion={ createPage }
-							onChange={ setInternalURLInputValue }
-							onSelect={ handleSelectSuggestion }
-							showInitialSuggestions={ showInitialSuggestions }
-							allowDirectEntry={ ! noDirectEntry }
-							showSuggestions={ showSuggestions }
-							suggestionsQuery={ suggestionsQuery }
-							withURLSuggestion={ ! noURLSuggestion }
-							createSuggestionButtonText={
-								createSuggestionButtonText
-							}
-							hideLabelFromVision={ ! showTextControl }
-						/>
-						{ ! showActions && (
-							<div className="block-editor-link-control__search-enter">
-								<Button
-									onClick={ isDisabled ? noop : handleSubmit }
-									label={ __( 'Submit' ) }
-									icon={ keyboardReturn }
-									className="block-editor-link-control__search-submit"
-									aria-disabled={ isDisabled }
-								/>
-							</div>
-						) }
-					</div>
-					{ errorMessage && (
-						<Notice
-							className="block-editor-link-control__search-error"
-							status="error"
-							isDismissible={ false }
-						>
-							{ errorMessage }
-						</Notice>
-					) }
-				</>
-			) }
-
-			{ value && ! isEditingLink && ! isCreatingPage && (
+			{ hasLinkValue && ! isCreatingPage && (
 				<LinkPreview
 					key={ value?.url } // force remount when URL changes to avoid race conditions for rich previews
 					value={ value }
 					onEditClick={ () => setIsEditingLink( true ) }
 					hasRichPreviews={ hasRichPreviews }
 					hasUnlinkControl={ shownUnlinkControl }
-					additionalControls={ () => {
-						// Expose the "Opens in new tab" settings in the preview
-						// as it is the most common setting to change.
-						if (
-							settings?.find(
-								( setting ) => setting.id === 'opensInNewTab'
-							)
-						) {
-							return (
-								<LinkSettings
-									value={ internalControlValue }
-									settings={ settings?.filter(
-										( { id } ) => id === 'opensInNewTab'
-									) }
-									onChange={ onChange }
-								/>
-							);
-						}
-					} }
 					onRemove={ () => {
 						onRemove();
 						setIsEditingLink( true );
 					} }
 				/>
+			) }
+
+			<div
+				className={ classnames( {
+					'block-editor-link-control__search-input-wrapper': true,
+					'has-text-control': showTextControl,
+					'has-actions': showActions,
+				} ) }
+			>
+				<LinkControlSearchInput
+					currentLink={ value }
+					className="block-editor-link-control__field block-editor-link-control__search-input"
+					placeholder={ searchInputPlaceholder }
+					value={ currentUrlInputValue }
+					withCreateSuggestion={ withCreateSuggestion }
+					onCreateSuggestion={ createPage }
+					onChange={ setInternalURLInputValue }
+					onSelect={ handleSelectSuggestion }
+					showInitialSuggestions={ showInitialSuggestions }
+					allowDirectEntry={ ! noDirectEntry }
+					showSuggestions={ showSuggestions }
+					suggestionsQuery={ suggestionsQuery }
+					withURLSuggestion={ ! noURLSuggestion }
+					createSuggestionButtonText={ createSuggestionButtonText }
+					hideLabelFromVision={ ! showTextControl }
+				/>
+
+				{ showTextControl && (
+					<TextControl
+						__nextHasNoMarginBottom
+						ref={ textInputRef }
+						className="block-editor-link-control__field block-editor-link-control__text-content"
+						label={ __( 'Text' ) }
+						value={ internalControlValue?.title }
+						onChange={ setInternalTextInputValue }
+						onKeyDown={ handleSubmitWithEnter }
+						size="__unstable-large"
+					/>
+				) }
+
+				{ ! showActions && (
+					<div className="block-editor-link-control__search-enter">
+						<Button
+							onClick={ isDisabled ? noop : handleSubmit }
+							label={ __( 'Submit' ) }
+							icon={ keyboardReturn }
+							className="block-editor-link-control__search-submit"
+							aria-disabled={ isDisabled }
+						/>
+					</div>
+				) }
+			</div>
+			{ errorMessage && (
+				<Notice
+					className="block-editor-link-control__search-error"
+					status="error"
+					isDismissible={ false }
+				>
+					{ errorMessage }
+				</Notice>
 			) }
 
 			{ showSettings && (

--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -314,9 +314,12 @@ function LinkControl( {
 
 	const showActions = hasLinkValue;
 
-	// Show the input if there is not a link value or if the link value
-	// does not represent a Post object.
-	const showSearchInput = ! hasLinkValue || ! value?.id;
+	// Show the searchable input if there is not a link value.
+	const showSearchInput = ! hasLinkValue;
+
+	// Show the plain URL input if there is a link value and
+	// it does not represent a Post object.
+	const showURLInput = hasLinkValue && ! value?.id;
 
 	// Only show text control once a URL value has been committed
 	// and it isn't just empty whitespace.
@@ -374,6 +377,18 @@ function LinkControl( {
 							createSuggestionButtonText
 						}
 						hideLabelFromVision={ ! showTextControl }
+					/>
+				) }
+
+				{ showURLInput && (
+					<TextControl
+						__nextHasNoMarginBottom
+						className="block-editor-link-control__field block-editor-link-control__search-input"
+						label={ __( 'Link' ) }
+						value={ currentUrlInputValue }
+						onChange={ setInternalURLInputValue }
+						onKeyDown={ handleSubmitWithEnter }
+						size="__unstable-large"
 					/>
 				) }
 

--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -286,7 +286,23 @@ function LinkControl( {
 			onRemove?.();
 		}
 
-		onCancel?.();
+		// In previous iterations of this component, clicking "Cancel" would toggle
+		// the component's UI into "preview" mode.
+		//
+		// However, this UI state was removed in:
+		// https://github.com/WordPress/gutenberg/pull/50998
+		//
+		// This poses a backwards compatibility problem as current consumers will
+		// assume that the previous UI behaviour is maintained.
+		//
+		// To avoid this, if a dedicated onCancel hanlder is not provided then the
+		// component will simply call onChange with the **original** (unchanged) value.
+		// This should effectively save the current value and close the UI.
+		if ( onCancel ) {
+			onCancel();
+		} else {
+			onChange( value );
+		}
 	};
 
 	const currentUrlInputValue =
@@ -305,16 +321,6 @@ function LinkControl( {
 
 	const isDisabled = ! valueHasChanges || currentInputIsEmpty;
 	const showSettings = !! settings?.length && hasLinkValue;
-
-	// In previous iterations of this component, clicking "Cancel" would toggle
-	// the UI to "preview" mode.
-	//
-	// However, this UI state was removed in:
-	// https://github.com/WordPress/gutenberg/pull/50998
-	//
-	// Therefore as the state no longer exists, unless a dedicated handler is
-	// provided, the cancel button will not be shown.
-	const showOnCancel = onCancel;
 
 	return (
 		<div
@@ -422,11 +428,10 @@ function LinkControl( {
 					justify="right"
 					className="block-editor-link-control__search-actions"
 				>
-					{ showOnCancel && (
-						<Button variant="tertiary" onClick={ handleCancel }>
-							{ __( 'Cancel' ) }
-						</Button>
-					) }
+					<Button variant="tertiary" onClick={ handleCancel }>
+						{ __( 'Cancel' ) }
+					</Button>
+
 					<Button
 						variant="primary"
 						onClick={ isDisabled ? noop : handleSubmit }

--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -222,16 +222,6 @@ function LinkControl( {
 
 	const hasLinkValue = value?.url?.trim()?.length > 0;
 
-	/**
-	 * Cancels editing state and marks that focus may need to be restored after
-	 * the next render, if focus was within the wrapper when editing finished.
-	 */
-	const stopEditing = () => {
-		isEndingEditWithFocus.current = !! wrapperNode.current?.contains(
-			wrapperNode.current.ownerDocument.activeElement
-		);
-	};
-
 	const handleSelectSuggestion = ( updatedValue ) => {
 		// Suggestions may contains "settings" values (e.g. `opensInNewTab`)
 		// which should not overide any existing settings values set by the
@@ -254,8 +244,6 @@ function LinkControl( {
 			// any "title" value provided by the "suggestion".
 			title: internalControlValue?.title || updatedValue?.title,
 		} );
-
-		stopEditing();
 	};
 
 	const handleSubmit = () => {
@@ -268,7 +256,6 @@ function LinkControl( {
 				url: currentUrlInputValue,
 			} );
 		}
-		stopEditing();
 	};
 
 	const handleSubmitWithEnter = ( event ) => {
@@ -294,10 +281,7 @@ function LinkControl( {
 		// Ensure that any unsubmitted input changes are reset.
 		resetInternalValues();
 
-		if ( hasLinkValue ) {
-			// If there is a link then exist editing mode and show preview.
-			stopEditing();
-		} else {
+		if ( ! hasLinkValue ) {
 			// If there is no link value, then remove the link entirely.
 			onRemove?.();
 		}

--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -322,6 +322,16 @@ function LinkControl( {
 	const isDisabled = ! valueHasChanges || currentInputIsEmpty;
 	const showSettings = !! settings?.length && hasLinkValue;
 
+	// In previous iterations of this component, clicking "Cancel" would toggle
+	// the UI to "preview" mode.
+	//
+	// However, this UI state was removed in:
+	// https://github.com/WordPress/gutenberg/pull/50998
+	//
+	// Therefore as the state no longer exists, unless a dedicated handler is
+	// provided, the cancel button will not be shown.
+	const showOnCancel = onCancel;
+
 	return (
 		<div
 			tabIndex={ -1 }
@@ -428,9 +438,11 @@ function LinkControl( {
 					justify="right"
 					className="block-editor-link-control__search-actions"
 				>
-					<Button variant="tertiary" onClick={ handleCancel }>
-						{ __( 'Cancel' ) }
-					</Button>
+					{ showOnCancel && (
+						<Button variant="tertiary" onClick={ handleCancel }>
+							{ __( 'Cancel' ) }
+						</Button>
+					) }
 					<Button
 						variant="primary"
 						onClick={ isDisabled ? noop : handleSubmit }

--- a/packages/block-editor/src/components/link-control/link-preview.js
+++ b/packages/block-editor/src/components/link-control/link-preview.js
@@ -38,12 +38,10 @@ export default function LinkPreview( {
 		( value && filterURLForDisplay( safeDecodeURI( value.url ), 16 ) ) ||
 		'';
 
+	const displayTitle = stripHTML( richData?.title || displayURL );
+
 	// url can be undefined if the href attribute is unset
 	const isEmptyURL = ! value?.url?.length;
-
-	const displayTitle =
-		! isEmptyURL &&
-		stripHTML( richData?.title || value?.title || displayURL );
 
 	let icon;
 

--- a/packages/block-editor/src/components/link-control/link-preview.js
+++ b/packages/block-editor/src/components/link-control/link-preview.js
@@ -14,7 +14,7 @@ import {
 	Tooltip,
 } from '@wordpress/components';
 import { filterURLForDisplay, safeDecodeURI } from '@wordpress/url';
-import { Icon, globe, info, linkOff, edit } from '@wordpress/icons';
+import { Icon, globe, info, linkOff } from '@wordpress/icons';
 import { __unstableStripHTML as stripHTML } from '@wordpress/dom';
 
 /**
@@ -26,7 +26,6 @@ import useRichUrlData from './use-rich-url-data';
 
 export default function LinkPreview( {
 	value,
-	onEditClick,
 	hasRichPreviews = false,
 	hasUnlinkControl = false,
 	onRemove,
@@ -114,13 +113,6 @@ export default function LinkPreview( {
 					</span>
 				</span>
 
-				<Button
-					icon={ edit }
-					label={ __( 'Edit' ) }
-					className="block-editor-link-control__search-item-action"
-					onClick={ onEditClick }
-					iconSize={ 24 }
-				/>
 				{ hasUnlinkControl && (
 					<Button
 						icon={ linkOff }

--- a/packages/block-editor/src/components/link-control/link-preview.js
+++ b/packages/block-editor/src/components/link-control/link-preview.js
@@ -7,12 +7,7 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import {
-	Button,
-	ExternalLink,
-	__experimentalText as Text,
-	Tooltip,
-} from '@wordpress/components';
+import { Button, ExternalLink, Tooltip } from '@wordpress/components';
 import { filterURLForDisplay, safeDecodeURI } from '@wordpress/url';
 import { Icon, globe, info, linkOff } from '@wordpress/icons';
 import { __unstableStripHTML as stripHTML } from '@wordpress/dom';
@@ -124,48 +119,6 @@ export default function LinkPreview( {
 				) }
 				<ViewerSlot fillProps={ value } />
 			</div>
-
-			{ !! (
-				( hasRichData &&
-					( richData?.image || richData?.description ) ) ||
-				isFetching
-			) && (
-				<div className="block-editor-link-control__search-item-bottom">
-					{ ( richData?.image || isFetching ) && (
-						<div
-							aria-hidden={ ! richData?.image }
-							className={ classnames(
-								'block-editor-link-control__search-item-image',
-								{
-									'is-placeholder': ! richData?.image,
-								}
-							) }
-						>
-							{ richData?.image && (
-								<img src={ richData?.image } alt="" />
-							) }
-						</div>
-					) }
-
-					{ ( richData?.description || isFetching ) && (
-						<div
-							aria-hidden={ ! richData?.description }
-							className={ classnames(
-								'block-editor-link-control__search-item-description',
-								{
-									'is-placeholder': ! richData?.description,
-								}
-							) }
-						>
-							{ richData?.description && (
-								<Text truncate numberOfLines="2">
-									{ richData.description }
-								</Text>
-							) }
-						</div>
-					) }
-				</div>
-			) }
 
 			{ additionalControls && additionalControls() }
 		</div>

--- a/packages/block-editor/src/components/link-control/link-preview.js
+++ b/packages/block-editor/src/components/link-control/link-preview.js
@@ -26,6 +26,9 @@ export default function LinkPreview( {
 	onRemove,
 	additionalControls,
 } ) {
+	// Only use the image if the type is a media attachment.
+	const showRichDataImage = value?.type === 'attachment';
+
 	// Avoid fetching if rich previews are not desired.
 	const showRichPreviews = hasRichPreviews ? value?.url : null;
 
@@ -117,6 +120,30 @@ export default function LinkPreview( {
 				) }
 				<ViewerSlot fillProps={ value } />
 			</div>
+
+			{ !! (
+				hasRichData &&
+				showRichDataImage &&
+				( richData?.image || isFetching )
+			) && (
+				<div className="block-editor-link-control__search-item-bottom">
+					{ ( richData?.image || isFetching ) && (
+						<div
+							aria-hidden={ ! richData?.image }
+							className={ classnames(
+								'block-editor-link-control__search-item-image',
+								{
+									'is-placeholder': ! richData?.image,
+								}
+							) }
+						>
+							{ richData?.image && (
+								<img src={ richData?.image } alt="" />
+							) }
+						</div>
+					) }
+				</div>
+			) }
 
 			{ additionalControls && additionalControls() }
 		</div>

--- a/packages/block-editor/src/components/link-control/search-item.js
+++ b/packages/block-editor/src/components/link-control/search-item.js
@@ -3,28 +3,15 @@
  */
 import { __ } from '@wordpress/i18n';
 import { MenuItem, TextHighlight } from '@wordpress/components';
-import {
-	Icon,
-	globe,
-	page,
-	tag,
-	postList,
-	category,
-	file,
-	home,
-	verse,
-} from '@wordpress/icons';
+import { Icon, globe, home, verse } from '@wordpress/icons';
 import { __unstableStripHTML as stripHTML } from '@wordpress/dom';
 import { safeDecodeURI, filterURLForDisplay, getPath } from '@wordpress/url';
 import { pipe } from '@wordpress/compose';
 
-const ICONS_MAP = {
-	post: postList,
-	page,
-	post_tag: tag,
-	category,
-	attachment: file,
-};
+/**
+ * Internal dependencies
+ */
+import { ICONS_MAP } from './constants';
 
 function SearchItemIcon( { isURL, suggestion } ) {
 	let icon = null;

--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -195,6 +195,10 @@ $preview-image-height: 140px;
 		}
 	}
 
+	&.is-preview {
+		border-bottom: 1px solid $gray-400;
+	}
+
 	&.is-preview .block-editor-link-control__search-item-header {
 		display: flex;
 		flex: 1; // Fill available space.

--- a/packages/block-editor/src/components/link-control/use-entity-data.js
+++ b/packages/block-editor/src/components/link-control/use-entity-data.js
@@ -1,0 +1,89 @@
+/**
+ * Internal dependencies
+ */
+import { store as blockEditorStore } from '../../store';
+
+/**
+ * WordPress dependencies
+ */
+import { useSelect } from '@wordpress/data';
+import { useEffect, useReducer } from '@wordpress/element';
+
+function reducer( state, action ) {
+	switch ( action.type ) {
+		case 'RESOLVED':
+			return {
+				...state,
+				isFetching: false,
+				entityData: action.entityData,
+			};
+		case 'ERROR':
+			return {
+				...state,
+				isFetching: false,
+				entityData: null,
+			};
+		case 'LOADING':
+			return {
+				...state,
+				isFetching: true,
+			};
+		default:
+			throw new Error( `Unexpected action type ${ action.type }` );
+	}
+}
+
+function useEntityData( postType, id ) {
+	const [ state, dispatch ] = useReducer( reducer, {
+		entityData: null,
+		isFetching: false,
+	} );
+
+	const { fetchEntityData } = useSelect( ( select ) => {
+		const { getSettings } = select( blockEditorStore );
+		return {
+			fetchEntityData: getSettings().__experimentalSyncGetEntityRecord,
+		};
+	}, [] );
+
+	useEffect( () => {
+		// Only make the request if we have an actual URL
+		// and the fetching util is available. In some editors
+		// there may not be such a util.
+		if ( id && fetchEntityData && typeof AbortController !== 'undefined' ) {
+			dispatch( {
+				type: 'LOADING',
+			} );
+
+			const controller = new window.AbortController();
+
+			const signal = controller.signal;
+
+			fetchEntityData( 'postType', postType, Number( id ), {
+				signal,
+			} )
+				.then( ( data ) => {
+					dispatch( {
+						type: 'RESOLVED',
+						entityData: data,
+					} );
+				} )
+				.catch( () => {
+					// Avoid setting state on unmounted component
+					if ( ! signal.aborted ) {
+						dispatch( {
+							type: 'ERROR',
+						} );
+					}
+				} );
+			// Cleanup: when the URL changes the abort the current request.
+			return () => {
+				controller.abort();
+			};
+		}
+	}, [ fetchEntityData, postType, id ] );
+
+	return state;
+}
+
+export default useEntityData;

--- a/packages/block-editor/src/components/link-control/use-search-handler.js
+++ b/packages/block-editor/src/components/link-control/use-search-handler.js
@@ -39,7 +39,6 @@ export const handleDirectEntry = ( val ) => {
 
 	return Promise.resolve( [
 		{
-			id: val,
 			title: val,
 			url: type === 'URL' ? prependHTTP( val ) : val,
 			type,

--- a/packages/block-library/src/button/edit.js
+++ b/packages/block-library/src/button/edit.js
@@ -311,7 +311,7 @@ function ButtonEdit( props ) {
 						richTextRef.current?.focus();
 					} }
 					anchor={ popoverAnchor }
-					focusOnMount={ isEditingURL ? 'firstElement' : false }
+					focusOnMount={ 'firstElement' }
 					__unstableSlotName={ '__unstable-block-tools-after' }
 					shift
 				>

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -581,6 +581,8 @@ export default function NavigationLinkEdit( {
 									setAttributes,
 									attributes
 								);
+
+								setIsLinkOpen( false );
 							} }
 						/>
 					) }

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -574,6 +574,7 @@ export default function NavigationLinkEdit( {
 							onClose={ () => setIsLinkOpen( false ) }
 							anchor={ popoverAnchor }
 							onRemove={ removeLink }
+							onCancel={ () => setIsLinkOpen( false ) }
 							onChange={ ( updatedValue ) => {
 								updateAttributes(
 									updatedValue,

--- a/packages/editor/src/components/provider/use-block-editor-settings.js
+++ b/packages/editor/src/components/provider/use-block-editor-settings.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { Platform, useMemo, useCallback } from '@wordpress/element';
-import { useDispatch, useSelect } from '@wordpress/data';
+import { resolveSelect, useDispatch, useSelect } from '@wordpress/data';
 import {
 	store as coreStore,
 	__experimentalFetchLinkSuggestions as fetchLinkSuggestions,
@@ -216,6 +216,9 @@ function useBlockEditorSettings( settings, postType, postId ) {
 	);
 
 	const forceDisableFocusMode = settings.focusMode === false;
+	const syncGetEntityRecord = useCallback( async ( ...args ) => {
+		return await resolveSelect( coreStore ).getEntityRecord( ...args );
+	}, [] );
 
 	return useMemo(
 		() => ( {
@@ -259,6 +262,7 @@ function useBlockEditorSettings( settings, postType, postId ) {
 					? [ [ 'core/navigation', {}, [] ] ]
 					: settings.template,
 			__experimentalSetIsInserterOpened: setIsInserterOpened,
+			__experimentalSyncGetEntityRecord: syncGetEntityRecord,
 		} ),
 		[
 			allowRightClickOverrides,
@@ -281,6 +285,7 @@ function useBlockEditorSettings( settings, postType, postId ) {
 			pageForPosts,
 			postType,
 			setIsInserterOpened,
+			syncGetEntityRecord,
 		]
 	);
 }

--- a/packages/format-library/src/link/index.js
+++ b/packages/format-library/src/link/index.js
@@ -11,6 +11,7 @@ import {
 	isCollapsed,
 	insert,
 	create,
+	concat,
 } from '@wordpress/rich-text';
 import { isURL, isEmail } from '@wordpress/url';
 import {
@@ -64,6 +65,18 @@ function Edit( {
 
 	function stopAddingLink( returnFocus = true ) {
 		setAddingLink( false );
+
+		// Remove any active formats.
+		// Cloning the existing value has the effect of removing
+		// any active formats and is roughly equivalent to the
+		// following mutation:
+		// value.activeFormats = [];
+		const newValue = concat( value );
+
+		// Update to force format to no longer be active.
+		onChange( newValue );
+
+		// Handle focus
 		if ( returnFocus ) {
 			onFocus();
 		}

--- a/packages/format-library/src/link/index.js
+++ b/packages/format-library/src/link/index.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useState } from '@wordpress/element';
+import { useState, useEffect } from '@wordpress/element';
 import {
 	getTextContent,
 	applyFormat,
@@ -39,6 +39,18 @@ function Edit( {
 	contentRef,
 } ) {
 	const [ addingLink, setAddingLink ] = useState( false );
+
+	// When the format is active toggle the state keeping track
+	// of whether to show the Link UI. This is needed to ensure
+	// that the addingLink state alone controls the visibility
+	// of the Link UI. This allows the Link UI to be forced to
+	// close (even if the format is active) if the user closes
+	// the Popover.
+	useEffect( () => {
+		if ( isActive ) {
+			setAddingLink( true );
+		}
+	}, [ isActive ] );
 
 	function addLink() {
 		const text = getTextContent( slice( value ) );
@@ -108,7 +120,7 @@ function Edit( {
 					aria-expanded={ addingLink || isActive }
 				/>
 			) }
-			{ ( addingLink || isActive ) && (
+			{ addingLink && (
 				<InlineLinkUI
 					addingLink={ addingLink }
 					stopAddingLink={ stopAddingLink }

--- a/packages/format-library/src/link/index.js
+++ b/packages/format-library/src/link/index.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useState, useEffect } from '@wordpress/element';
+import { useState } from '@wordpress/element';
 import {
 	getTextContent,
 	applyFormat,
@@ -39,18 +39,6 @@ function Edit( {
 	contentRef,
 } ) {
 	const [ addingLink, setAddingLink ] = useState( false );
-
-	// When the format is active toggle the state keeping track
-	// of whether to show the Link UI. This is needed to ensure
-	// that the addingLink state alone controls the visibility
-	// of the Link UI. This allows the Link UI to be forced to
-	// close (even if the format is active) if the user closes
-	// the Popover.
-	useEffect( () => {
-		if ( isActive ) {
-			setAddingLink( true );
-		}
-	}, [ isActive ] );
 
 	function addLink() {
 		const text = getTextContent( slice( value ) );
@@ -120,7 +108,7 @@ function Edit( {
 					aria-expanded={ addingLink || isActive }
 				/>
 			) }
-			{ addingLink && (
+			{ ( addingLink || isActive ) && (
 				<InlineLinkUI
 					addingLink={ addingLink }
 					stopAddingLink={ stopAddingLink }

--- a/packages/format-library/src/link/inline.js
+++ b/packages/format-library/src/link/inline.js
@@ -89,12 +89,6 @@ function InlineLinkUI( {
 	}
 
 	function onChangeLink( nextValue ) {
-		// LinkControl calls `onChange` immediately upon the toggling a setting.
-		// Before merging the next value with the current link value, check if
-		// the setting was toggled.
-		const didToggleSetting =
-			linkValue.opensInNewTab !== nextValue.opensInNewTab &&
-			nextValue.url === undefined;
 		// Merge the next value with the current link value.
 		nextValue = {
 			...linkValue,
@@ -180,14 +174,7 @@ function InlineLinkUI( {
 			newValue.start = newValue.end;
 
 			// Hides the Link UI.
-			newValue.activeFormats = [];
 			onChange( newValue );
-		}
-
-		// Focus should only be shifted back to the formatted segment when the
-		// URL is submitted.
-		if ( ! didToggleSetting ) {
-			stopAddingLink();
 		}
 
 		if ( ! isValidHref( newUrl ) ) {

--- a/packages/format-library/src/link/inline.js
+++ b/packages/format-library/src/link/inline.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useMemo, createInterpolateElement } from '@wordpress/element';
+import { useMemo, useRef, createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { speak } from '@wordpress/a11y';
 import { Popover } from '@wordpress/components';
@@ -241,11 +241,22 @@ function InlineLinkUI( {
 		);
 	}
 
+	const hasLink = linkValue?.url;
+
+	// Focus should only be moved into the Popover when the Link is being **created**.
+	// When the link has already been created it is in a pseudo "preview" mode and thus
+	// focus should remain on the rich text because at this point the Link dialog is
+	// partially informational and thus the user should be able to continue editing the
+	// rich text.
+	// Ref used because the focusOnMount prop shouldn't evolve during render of a Popover
+	// otherwise it causes a render of the content.
+	const focusOnMount = useRef( hasLink ? false : 'firstElement' );
+
 	return (
 		<Popover
 			role="dialog"
 			anchor={ popoverAnchor }
-			focusOnMount={ 'firstElement' }
+			focusOnMount={ focusOnMount.current }
 			onClose={ stopAddingLink }
 			onFocusOutside={ () => stopAddingLink( false ) }
 			placement="bottom"

--- a/packages/format-library/src/link/inline.js
+++ b/packages/format-library/src/link/inline.js
@@ -243,6 +243,7 @@ function InlineLinkUI( {
 
 	return (
 		<Popover
+			role="dialog"
 			anchor={ popoverAnchor }
 			focusOnMount={ 'firstElement' }
 			onClose={ stopAddingLink }

--- a/packages/format-library/src/link/inline.js
+++ b/packages/format-library/src/link/inline.js
@@ -264,7 +264,7 @@ function InlineLinkUI( {
 				value={ linkValue }
 				onChange={ onChangeLink }
 				onRemove={ removeLink }
-				forceIsEditingLink={ addingLink }
+				onCancel={ stopAddingLink }
 				hasRichPreviews
 				createSuggestion={ createPageEntity && handleCreate }
 				withCreateSuggestion={ userCanCreatePages }

--- a/packages/format-library/src/link/inline.js
+++ b/packages/format-library/src/link/inline.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useMemo, useRef, createInterpolateElement } from '@wordpress/element';
+import { useMemo, createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { speak } from '@wordpress/a11y';
 import { Popover } from '@wordpress/components';
@@ -42,7 +42,6 @@ const LINK_SETTINGS = [
 function InlineLinkUI( {
 	isActive,
 	activeAttributes,
-	addingLink,
 	value,
 	onChange,
 	stopAddingLink,
@@ -216,14 +215,6 @@ function InlineLinkUI( {
 	// See https://github.com/WordPress/gutenberg/pull/34742.
 	const forceRemountKey = useLinkInstanceKey( popoverAnchor );
 
-	// Focus should only be moved into the Popover when the Link is being created or edited.
-	// When the Link is in "preview" mode focus should remain on the rich text because at
-	// this point the Link dialog is informational only and thus the user should be able to
-	// continue editing the rich text.
-	// Ref used because the focusOnMount prop shouldn't evolve during render of a Popover
-	// otherwise it causes a render of the content.
-	const focusOnMount = useRef( addingLink ? 'firstElement' : false );
-
 	async function handleCreate( pageTitle ) {
 		const page = await createPageEntity( {
 			title: pageTitle,
@@ -253,7 +244,7 @@ function InlineLinkUI( {
 	return (
 		<Popover
 			anchor={ popoverAnchor }
-			focusOnMount={ focusOnMount.current }
+			focusOnMount={ 'firstElement' }
 			onClose={ stopAddingLink }
 			onFocusOutside={ () => stopAddingLink( false ) }
 			placement="bottom"

--- a/packages/format-library/src/link/inline.js
+++ b/packages/format-library/src/link/inline.js
@@ -89,6 +89,9 @@ function InlineLinkUI( {
 	}
 
 	function onChangeLink( nextValue ) {
+		const hasLink = linkValue?.url;
+		const isNewLink = ! hasLink;
+
 		// Merge the next value with the current link value.
 		nextValue = {
 			...linkValue,
@@ -173,7 +176,11 @@ function InlineLinkUI( {
 
 			newValue.start = newValue.end;
 
-			// Hides the Link UI.
+			// Hides the Link UI on change except upon the initial creation of the link.
+			if ( ! isNewLink ) {
+				newValue.activeFormats = [];
+			}
+
 			onChange( newValue );
 		}
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Removes the "Preview" UI state from the Link Control. This means it's always possible to directly edit a link without an extra "edit" click.

⚠️ There is a potential regression in this PR. See `Backwards compatbility` below.

Closes https://github.com/WordPress/gutenberg/issues/50892

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

As the control has evolved the preview step has become less and less useful. The main concerns are:

- requires an extra step to reach the editing of the link
- [causes a11y problems relating to perception, focus management and constrained tabbing](https://github.com/WordPress/gutenberg/pull/54063#issuecomment-1708852218)
- the two modes (edit and preview) are internal to the `LinkControl` and thus require hacks to force editing when required (e.g. `forceIsEditing`).

By removing the dedicated preview step we solve all these issues whilst improving the usability. The "preview" is still there but it is now alongside the edit state (albeit in a slimed down form).

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

- Removes all references to editing/preview mode.
- Places the preview above the editing fields in the UI.
- Updates internal implementations to handle new UI including
    - RichText
    - Navigation block
    - Button
- Attempts backwards compatibility risk mitigation due to removal of "preview" state (see below).

## Backwards compatibility

Previous the `LinkControl` had internal states for edit and preview "modes".

Whilst state was internal, this feature was partially exposed in the component API by the addition of the `forceIsEditing` prop which was original required to allow richtext formats to trigger the Link UI in "edit" mode when first creating a link in rich text. It's usage has since spread to other parts of Core (and likely is also used by 3rd party consumers).

Therefore we need to consider backwards compatibility. 

The primary problem is that consumers are used assuming that clicking the `Cancel` button in the UI will trigger an internal state change in the UI (toggle to "preview" mode) that they have not previously needed to handle. The change in this PR will mean that clicking `Cancel` would do nothing as there is no longer an preview mode.

To mitigate this I have thought of two options:

#### Call onChange with current `value` object

⚠️ This is the current solution I have implemented in this PR. It's up for debate.

When the `Cancel` button is clicked, the component will call `onChange` with the current `value`. As this represents the original value of the control _without_ any modifications, the consuming code should treat this like any other change to the component value. Most consumers treat `onChange` as a cue to close the UI and thus using it as a proxy for "cancel" seems logical. 

If a dedicated `onCancel` prop is provided however, we do not call `onChange` and assume that the consumer will handle the rendered state (likely visibility within a `Popover`) of the control.

However we are making a number of assumptions.

#### Hide  the Cancel button entirely

In this route, we simply hide the `Cancel` button unless the consumer supplies a dedicated `onCancel` handler prop. Whilst non-optimal for a UI/UX point of view, this is relatively safe as it makes fewer assumptions. 

It does however, leave consumers who haven't passed `onCancel` without a dedicated `Cancel` button.




## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

- New Post
- Switch to `Code view`
- Copy the following and paste into the code view text box
```
<!-- wp:heading {"level":4} -->
<h4 class="wp-block-heading">Standard Rich Text Links</h4>
<!-- /wp:heading -->

<!-- wp:paragraph -->
<p>Hello changes will be <a href="http://www.wordpress.org">link</a></p>
<!-- /wp:paragraph -->

<!-- wp:heading {"level":4} -->
<h4 class="wp-block-heading">Link to Attachment</h4>
<!-- /wp:heading -->

<!-- wp:paragraph -->
<p>Link to <a href="http://localhost:8888/wp-content/uploads/2023/09/ice-snowy-rocks-mountains-hd-background-wallpapers-widescreen-high-resolutions-025.jpg" data-type="attachment" data-id="599">media</a></p>
<!-- /wp:paragraph -->

<!-- wp:heading {"level":4} -->
<h4 class="wp-block-heading">Navigation Block</h4>
<!-- /wp:heading -->

<!-- wp:navigation {"ref":552} /-->

<!-- wp:heading {"level":4} -->
<h4 class="wp-block-heading">Button Block</h4>
<!-- /wp:heading -->

<!-- wp:buttons -->
<div class="wp-block-buttons"><!-- wp:button -->
<div class="wp-block-button"><a class="wp-block-button__link wp-element-button" href="http://www.wordpress.org">Hello world</a></div>
<!-- /wp:button --></div>
<!-- /wp:buttons -->

<!-- wp:paragraph -->
<p></p>
<!-- /wp:paragraph -->
```
- Interact with the links in each block and see if it feels natural
- Test with 3rd party Plugins such as Yoast SEO who are known to consume `LinkControl`.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/444434/9187000e-dc7f-426e-a7d9-af83a2cefefe

