### PR TITLE
Button: Add basic visual regression tests

### DIFF
--- a/packages/components/src/button/stories/e2e/index.tsx
+++ b/packages/components/src/button/stories/e2e/index.tsx
@@ -1,0 +1,58 @@
+/**
+ * External dependencies
+ */
+import type { ComponentStory, ComponentMeta } from '@storybook/react';
+
+/**
+ * WordPress dependencies
+ */
+import { wordpress } from '@wordpress/icons';
+
+/**
+ * Internal dependencies
+ */
+import { Button } from '../..';
+import type { ButtonAsButtonProps } from '../../types';
+
+const meta: ComponentMeta< typeof Button > = {
+	component: Button,
+	title: 'Components/Button',
+};
+export default meta;
+
+export const VariantStates: ComponentStory< typeof Button > = (
+	props: ButtonAsButtonProps
+) => {
+	const variants: ( typeof props.variant )[] = [
+		undefined,
+		'primary',
+		'secondary',
+		'tertiary',
+		'link',
+	];
+
+	return (
+		<div style={ { display: 'flex', flexDirection: 'column', gap: 24 } }>
+			{ variants.map( ( variant ) => (
+				<div
+					style={ { display: 'flex', gap: 8 } }
+					key={ variant ?? 'undefined' }
+				>
+					<Button { ...props } variant={ variant } />
+					<Button { ...props } variant={ variant } disabled />
+					<Button { ...props } variant={ variant } isBusy />
+					<Button { ...props } variant={ variant } isDestructive />
+					<Button { ...props } variant={ variant } isPressed />
+				</div>
+			) ) }
+		</div>
+	);
+};
+VariantStates.args = {
+	children: 'Code is poetry',
+};
+
+export const Icon = VariantStates.bind( {} );
+Icon.args = {
+	icon: wordpress,
+};

--- a/test/storybook-playwright/specs/button.spec.ts
+++ b/test/storybook-playwright/specs/button.spec.ts
@@ -1,0 +1,57 @@
+/**
+ * External dependencies
+ */
+import { expect, test } from '@playwright/test';
+
+/**
+ * Internal dependencies
+ */
+import {
+	gotoStoryId,
+	getAllPropsPermutations,
+	testSnapshotForPropsConfig,
+} from '../utils';
+
+test.describe( 'Button', () => {
+	test.describe( 'variant states', () => {
+		test.beforeEach( async ( { page } ) => {
+			gotoStoryId( page, 'components-button--variant-states', {
+				decorators: { customE2EControls: 'show' },
+			} );
+		} );
+
+		getAllPropsPermutations( [
+			{
+				propName: '__next40pxDefaultSize',
+				valuesToTest: [ true, false ],
+			},
+		] ).forEach( ( propsConfig ) => {
+			test( `should render with ${ JSON.stringify(
+				propsConfig
+			) }`, async ( { page } ) => {
+				await testSnapshotForPropsConfig( page, propsConfig );
+			} );
+		} );
+	} );
+
+	test.describe( 'icon', () => {
+		test.beforeEach( async ( { page } ) => {
+			gotoStoryId( page, 'components-button--icon', {
+				decorators: { customE2EControls: 'show' },
+			} );
+		} );
+
+		getAllPropsPermutations( [
+			{
+				propName: '__next40pxDefaultSize',
+				valuesToTest: [ true, false ],
+			},
+		] ).forEach( ( propsConfig ) => {
+			test( `should render with ${ JSON.stringify(
+				propsConfig
+			) }`, async ( { page } ) => {
+				await testSnapshotForPropsConfig( page, propsConfig );
+			} );
+		} );
+	} );
+} );

--- a/test/storybook-playwright/utils.ts
+++ b/test/storybook-playwright/utils.ts
@@ -62,9 +62,10 @@ export const getAllPropsPermutations = (
 
 		// Test all values for the given prop.
 		for ( const value of propObject.valuesToTest ) {
+			const valueAsString = value === undefined ? 'undefined' : value;
 			const newAccProps = {
 				...accProps,
-				[ propObject.propName ]: value,
+				[ propObject.propName ]: valueAsString,
 			};
 
 			if ( restProps.length === 0 ) {

--- a/test/storybook-playwright/utils.ts
+++ b/test/storybook-playwright/utils.ts
@@ -100,5 +100,7 @@ export const testSnapshotForPropsConfig = async (
 
 	await submitButton.click();
 
-	expect( await page.screenshot() ).toMatchSnapshot();
+	expect(
+		await page.screenshot( { animations: 'disabled' } )
+	).toMatchSnapshot();
 };


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Adds some basic visual regression tests for the Button component.

## Why?

The Button component is particularly complicated, so we want more confidence when making style changes.

## How?

Given the number of variants and modifiers this component has, brute force checking all permutations is not cost effective. Plus, some combinations of variants/modifiers are non-sensical or broken to begin with. Instead, I suggest we be strategic about what and how we test, taking into account which combinations are likely to occur, or which combinations are likely to break.

To start out, I want to test the basic variant/modifier combinations and their sizes. A matrix is rendered in a single story for efficiency.

<img width="640" alt="A matrix of Button variants and state modifiers, with text content" src="https://github.com/WordPress/gutenberg/assets/555336/c9a79e15-e1b3-44ab-b942-c7c46b4ac853">
<img width="237" alt="A matrix of Button variants and state modifiers, with icon content" src="https://github.com/WordPress/gutenberg/assets/555336/7aa03346-bab1-48e5-8f47-f94bf2083185">

We'll continue to add more stories as needed.

## Testing Instructions

1. Check out `trunk`.
1. `npm run storybook:e2e:dev` to build and serve the E2E Storybook. Keep this running while you're testing.
1. Run `npm run test:e2e:storybook -- --update-snapshots`.
1. Check out this PR branch.
1. Run `npm run test:e2e:storybook` a couple times to verify that everything is still passing and there is no flakiness.