### PR TITLE
Update the undo/redo format to store diffs

### DIFF
--- a/packages/core-data/src/private-selectors.ts
+++ b/packages/core-data/src/private-selectors.ts
@@ -14,7 +14,7 @@ type Optional< T > = T | undefined;
  * @return The edit.
  */
 export function getUndoEdits( state: State ): Optional< any > {
-	return state.undo.list[ state.undo.list.length - 2 + state.undo.offset ];
+	return state.undo.list[ state.undo.list.length - 1 + state.undo.offset ];
 }
 
 /**


### PR DESCRIPTION
Explores implementing this comment https://github.com/WordPress/gutenberg/pull/50911#issuecomment-1562707868
