### PR TITLE
Added applyfilters around getSaveCommentAttributes in serializer.js

### DIFF
--- a/packages/blocks/src/api/serializer.js
+++ b/packages/blocks/src/api/serializer.js
@@ -361,7 +361,18 @@ export function serializeBlock( block, { isInnerBlocks = false } = {} ) {
 		return saveContent;
 	}
 
-	const saveAttributes = getCommentAttributes( blockType, block.attributes );
+	/**
+	 * Filters the comment attributes before serialization.
+	 *
+	 * @param {Object}  attributes Block attributes.
+	 * @param {WPBlock} blockType  Block type definition.
+	 */
+	const saveAttributes = applyFilters(
+		'blocks.getSaveCommentAttributes',
+		getCommentAttributes( blockType, block.attributes ),
+		blockType
+	);
+
 	return getCommentDelimitedContent( blockName, saveAttributes, saveContent );
 }
 


### PR DESCRIPTION
## What?
This PR delivers an additional applyFilters hook around the result of getCommentAttributes in /packages/blocks/src/api/serializer.js.

## Why?
It provides a better control about the saved block attributes for 3rd Party solutions. I described my usecase on:
https://gist.github.com/0verscore/393982c179eeb061f5945bc95cc6d9a0

## How?
The most important to this hook, is that you need to build up new object references to return, if you don't want to change the stored attributes in datastore "core/block-editor"

## Testing Instructions
This i how you would add a filter to change attributes, that affect datastore attributes.

```
addFilter( 'blocks.getSaveCommentAttributes', 'my/hook/saveBlockAttributes', ( attributes, blockType ) => {
	attributes.style = {};

	return attributes;
});
```

This i how you would add a filter to change attributes, that doesn't affect datastore attributes.

```
addFilter( 'blocks.getSaveCommentAttributes', 'my/hook/saveBlockAttributes', ( attributes, blockType ) => {
	attributes.style = {};

	return { ...attributes };
});
```