### PR TITLE
Refactor code that adds resolver fulfillment to selector calls

### DIFF
--- a/packages/data/src/redux-store/index.js
+++ b/packages/data/src/redux-store/index.js
@@ -559,7 +559,10 @@ function mapResolvers( resolvers, selectors, store, resolversCache ) {
 				metadataActions.startResolution( selectorName, args )
 			);
 			try {
-				await fulfillResolver( store, resolver, ...args );
+				const action = resolver.fulfill( ...args );
+				if ( action ) {
+					await store.dispatch( action );
+				}
 				store.dispatch(
 					metadataActions.finishResolution( selectorName, args )
 				);
@@ -590,18 +593,4 @@ function mapResolvers( resolvers, selectors, store, resolversCache ) {
 		resolvers: mappedResolvers,
 		selectors: mapValues( selectors, mapSelector ),
 	};
-}
-
-/**
- * Calls a resolver given arguments
- *
- * @param {Object} store    Store reference, for fulfilling via resolvers
- * @param {Object} resolver Store Resolvers
- * @param {Array}  args     Selector Arguments.
- */
-async function fulfillResolver( store, resolver, ...args ) {
-	const action = resolver.fulfill( ...args );
-	if ( action ) {
-		await store.dispatch( action );
-	}
 }

--- a/packages/data/src/redux-store/index.js
+++ b/packages/data/src/redux-store/index.js
@@ -571,7 +571,7 @@ function mapResolvers( resolvers, selectors, store, resolversCache ) {
 					metadataActions.failResolution( selectorName, args, error )
 				);
 			}
-		} );
+		}, 0 );
 	}
 
 	const mapSelector = ( selector, selectorName ) => {

--- a/packages/data/src/redux-store/index.js
+++ b/packages/data/src/redux-store/index.js
@@ -529,7 +529,7 @@ function mapResolvers( resolvers, selectors, store, resolversCache ) {
 	} );
 
 	const mapSelector = ( selector, selectorName ) => {
-		const resolver = resolvers[ selectorName ];
+		const resolver = mappedResolvers[ selectorName ];
 		if ( ! resolver ) {
 			selector.hasResolver = false;
 			return selector;

--- a/packages/data/src/redux-store/index.js
+++ b/packages/data/src/redux-store/index.js
@@ -567,12 +567,7 @@ function mapResolvers( resolvers, selectors, store, resolversCache ) {
 						metadataActions.startResolution( selectorName, args )
 					);
 					try {
-						await fulfillResolver(
-							store,
-							mappedResolvers,
-							selectorName,
-							...args
-						);
+						await fulfillResolver( store, resolver, ...args );
 						store.dispatch(
 							metadataActions.finishResolution(
 								selectorName,
@@ -607,17 +602,11 @@ function mapResolvers( resolvers, selectors, store, resolversCache ) {
 /**
  * Calls a resolver given arguments
  *
- * @param {Object} store        Store reference, for fulfilling via resolvers
- * @param {Object} resolvers    Store Resolvers
- * @param {string} selectorName Selector name to fulfill.
- * @param {Array}  args         Selector Arguments.
+ * @param {Object} store    Store reference, for fulfilling via resolvers
+ * @param {Object} resolver Store Resolvers
+ * @param {Array}  args     Selector Arguments.
  */
-async function fulfillResolver( store, resolvers, selectorName, ...args ) {
-	const resolver = resolvers[ selectorName ];
-	if ( ! resolver ) {
-		return;
-	}
-
+async function fulfillResolver( store, resolver, ...args ) {
 	const action = resolver.fulfill( ...args );
 	if ( action ) {
 		await store.dispatch( action );

--- a/packages/data/src/redux-store/index.js
+++ b/packages/data/src/redux-store/index.js
@@ -536,7 +536,7 @@ function mapResolvers( resolvers, selectors, store, resolversCache ) {
 		}
 
 		const selectorResolver = ( ...args ) => {
-			async function fulfillSelector() {
+			function fulfillSelector() {
 				const state = store.getState();
 
 				if (


### PR DESCRIPTION
This PR cleans up a little bit the code that adds resolution code to selectors. There are several commits that each do one thing, described in the commit message.

This is a good first step towards further refactorings and bugfixes, like adding resolver support to private selectors, exposing private selectors to thunks etc.

**How to test:**
Everything should be the same as before.