### PR TITLE
Improve (and relax) search vs direct URL entry detection in Link Control

### DIFF
--- a/packages/block-editor/src/components/link-control/is-url-like.js
+++ b/packages/block-editor/src/components/link-control/is-url-like.js
@@ -1,4 +1,9 @@
 /**
+ * WordPress dependencies
+ */
+import { getProtocol, isValidProtocol, isValidFragment } from '@wordpress/url';
+
+/**
  * Determines whether a given value could be a URL. Note this does not
  * guarantee the value is a URL only that it looks like it might be one. For
  * example, just because a string has `www.` in it doesn't make it a URL,
@@ -10,9 +15,20 @@
  * @return {boolean} whether or not the value is potentially a URL.
  */
 export default function isURLLike( val ) {
-	const isInternal = val?.startsWith( '#' );
-	const isWWW = val?.startsWith( 'www.' );
-	const isHTTPProtocol = /^(http|https)/.test( val );
+	const hasSpaces = val.includes( ' ' );
 
-	return isHTTPProtocol || isWWW || isInternal;
+	if ( hasSpaces ) {
+		return false;
+	}
+
+	const protocol = getProtocol( val );
+	const protocolIsValid = isValidProtocol( protocol );
+
+	const isWWW = val?.startsWith( 'www.' );
+	const isHTTPProtocol = /^(http|https)/.test( val ) && protocolIsValid;
+	const isMailTo = val?.startsWith( 'mailto:' ) && protocolIsValid;
+	const isTel = val?.startsWith( 'tel:' ) && protocolIsValid;
+	const isInternal = val?.startsWith( '#' ) && isValidFragment( val );
+
+	return isHTTPProtocol || isWWW || isMailTo || isTel || isInternal;
 }

--- a/packages/block-editor/src/components/link-control/is-url-like.js
+++ b/packages/block-editor/src/components/link-control/is-url-like.js
@@ -1,9 +1,4 @@
 /**
- * WordPress dependencies
- */
-import { isURL } from '@wordpress/url';
-
-/**
  * Determines whether a given value could be a URL. Note this does not
  * guarantee the value is a URL only that it looks like it might be one. For
  * example, just because a string has `www.` in it doesn't make it a URL,
@@ -16,5 +11,8 @@ import { isURL } from '@wordpress/url';
  */
 export default function isURLLike( val ) {
 	const isInternal = val?.startsWith( '#' );
-	return isURL( val ) || ( val && val.includes( 'www.' ) ) || isInternal;
+	const isWWW = val?.startsWith( 'www.' );
+	const isHTTPProtocol = /^(http|https)/.test( val );
+
+	return isHTTPProtocol || isWWW || isInternal;
 }

--- a/packages/block-editor/src/components/link-control/is-url-like.js
+++ b/packages/block-editor/src/components/link-control/is-url-like.js
@@ -27,14 +27,10 @@ export default function isURLLike( val ) {
 	const mayBeTLD = hasPossibleTLD( val );
 
 	const isWWW = val?.startsWith( 'www.' );
-	const isHTTPProtocol = /^(http|https)/.test( val ) && protocolIsValid;
-	const isMailTo = val?.startsWith( 'mailto:' ) && protocolIsValid;
-	const isTel = val?.startsWith( 'tel:' ) && protocolIsValid;
+
 	const isInternal = val?.startsWith( '#' ) && isValidFragment( val );
 
-	return (
-		isHTTPProtocol || isWWW || isMailTo || isTel || isInternal || mayBeTLD
-	);
+	return protocolIsValid || isWWW || isInternal || mayBeTLD;
 }
 
 /**

--- a/packages/block-editor/src/components/link-control/is-url-like.js
+++ b/packages/block-editor/src/components/link-control/is-url-like.js
@@ -24,11 +24,38 @@ export default function isURLLike( val ) {
 	const protocol = getProtocol( val );
 	const protocolIsValid = isValidProtocol( protocol );
 
+	const mayBeTLD = hasPossibleTLD( val );
+
 	const isWWW = val?.startsWith( 'www.' );
 	const isHTTPProtocol = /^(http|https)/.test( val ) && protocolIsValid;
 	const isMailTo = val?.startsWith( 'mailto:' ) && protocolIsValid;
 	const isTel = val?.startsWith( 'tel:' ) && protocolIsValid;
 	const isInternal = val?.startsWith( '#' ) && isValidFragment( val );
 
-	return isHTTPProtocol || isWWW || isMailTo || isTel || isInternal;
+	return (
+		isHTTPProtocol || isWWW || isMailTo || isTel || isInternal || mayBeTLD
+	);
+}
+
+/**
+ * Checks if a given URL has a valid Top-Level Domain (TLD).
+ *
+ * @param {string} url       - The URL to check.
+ * @param {number} maxLength - The maximum length of the TLD.
+ * @return {boolean} Returns true if the URL has a valid TLD, false otherwise.
+ */
+function hasPossibleTLD( url, maxLength = 6 ) {
+	// Clean the URL by removing anything after the first occurrence of "?" or "#".
+	const cleanedURL = url.split( /[?#]/ )[ 0 ];
+
+	// Regular expression explanation:
+	// - (?<=\S)                  : Positive lookbehind assertion to ensure there is at least one non-whitespace character before the TLD
+	// - \.                       : Matches a literal dot (.)
+	// - [a-zA-Z_]{2,maxLength}   : Matches 2 to maxLength letters or underscores, representing the TLD
+	// - (?:\/|$)                 : Non-capturing group that matches either a forward slash (/) or the end of the string
+	const regex = new RegExp(
+		`(?<=\\S)\\.(?:[a-zA-Z_]{2,${ maxLength }})(?:\\/|$)`
+	);
+
+	return regex.test( cleanedURL );
 }

--- a/packages/block-editor/src/components/link-control/test/index.js
+++ b/packages/block-editor/src/components/link-control/test/index.js
@@ -478,35 +478,46 @@ describe( 'Searching for a link', () => {
 		).not.toHaveTextContent( 'URL' );
 	} );
 
-	it( 'should display only URL result when current input value is URL-like', async () => {
-		const user = userEvent.setup();
-		const searchTerm = 'www.wordpress.org';
+	it.each( [
+		[ 'https://wordpress.org', 'URL' ],
+		[ 'http://wordpress.org', 'URL' ],
+		[ 'www.wordpress.org', 'URL' ],
+		[ 'wordpress.org', 'URL' ],
+		[ 'ftp://wordpress.org', 'URL' ],
+		[ 'mailto:hello@wordpress.org', 'mailto' ],
+		[ 'tel:123456789', 'tel' ],
+		[ '#internal', 'internal' ],
+	] )(
+		'should display only URL result when current input value is URL-like (e.g. %s)',
+		async ( searchTerm, type ) => {
+			const user = userEvent.setup();
 
-		render( <LinkControl /> );
+			render( <LinkControl /> );
 
-		// Search Input UI.
-		const searchInput = screen.getByRole( 'combobox', { name: 'URL' } );
+			// Search Input UI.
+			const searchInput = screen.getByRole( 'combobox', { name: 'URL' } );
 
-		// Simulate searching for a term.
-		await user.type( searchInput, searchTerm );
+			// Simulate searching for a term.
+			await user.type( searchInput, searchTerm );
 
-		const searchResultElement = within(
-			await screen.findByRole( 'listbox', {
-				name: /Search results for.*/,
-			} )
-		).getByRole( 'option' );
+			const searchResultElement = within(
+				await screen.findByRole( 'listbox', {
+					name: /Search results for.*/,
+				} )
+			).getByRole( 'option' );
 
-		expect( searchResultElement ).toBeInTheDocument();
+			expect( searchResultElement ).toBeInTheDocument();
 
-		// Should only be the `URL` suggestion.
-		expect( searchInput ).toHaveAttribute( 'aria-expanded', 'true' );
+			// Should only be the `URL` suggestion.
+			expect( searchInput ).toHaveAttribute( 'aria-expanded', 'true' );
 
-		expect( searchResultElement ).toHaveTextContent( searchTerm );
-		expect( searchResultElement ).toHaveTextContent( 'URL' );
-		expect( searchResultElement ).toHaveTextContent(
-			'Press ENTER to add this link'
-		);
-	} );
+			expect( searchResultElement ).toHaveTextContent( searchTerm );
+			expect( searchResultElement ).toHaveTextContent( type );
+			expect( searchResultElement ).toHaveTextContent(
+				'Press ENTER to add this link'
+			);
+		}
+	);
 
 	it( 'should trim search term', async () => {
 		const user = userEvent.setup();

--- a/packages/block-editor/src/components/link-control/test/index.js
+++ b/packages/block-editor/src/components/link-control/test/index.js
@@ -439,44 +439,46 @@ describe( 'Searching for a link', () => {
 		expect( screen.queryByRole( 'presentation' ) ).not.toBeInTheDocument();
 	} );
 
-	it( 'should display only search suggestions (and not URL result type) when current input value is not URL-like', async () => {
-		const user = userEvent.setup();
-		const searchTerm = 'Hello world';
-		const firstSuggestion = fauxEntitySuggestions[ 0 ];
+	it.each( [ 'With spaces', 'Uppercase', 'lowercase' ] )(
+		'should display only search suggestions (and not URL result type) when current input value (e.g. %s) is not URL-like',
+		async ( searchTerm ) => {
+			const user = userEvent.setup();
+			const firstSuggestion = fauxEntitySuggestions[ 0 ];
 
-		render( <LinkControl /> );
+			render( <LinkControl /> );
 
-		// Search Input UI.
-		const searchInput = screen.getByRole( 'combobox', { name: 'URL' } );
+			// Search Input UI.
+			const searchInput = screen.getByRole( 'combobox', { name: 'URL' } );
 
-		// Simulate searching for a term.
-		await user.type( searchInput, searchTerm );
+			// Simulate searching for a term.
+			await user.type( searchInput, searchTerm );
 
-		const searchResultElements = within(
-			await screen.findByRole( 'listbox', {
-				name: /Search results for.*/,
-			} )
-		).getAllByRole( 'option' );
+			const searchResultElements = within(
+				await screen.findByRole( 'listbox', {
+					name: /Search results for.*/,
+				} )
+			).getAllByRole( 'option' );
 
-		expect( searchResultElements ).toHaveLength(
-			fauxEntitySuggestions.length
-		);
+			expect( searchResultElements ).toHaveLength(
+				fauxEntitySuggestions.length
+			);
 
-		expect( searchInput ).toHaveAttribute( 'aria-expanded', 'true' );
+			expect( searchInput ).toHaveAttribute( 'aria-expanded', 'true' );
 
-		// Check that a search suggestion shows up corresponding to the data.
-		expect( searchResultElements[ 0 ] ).toHaveTextContent(
-			firstSuggestion.title
-		);
-		expect( searchResultElements[ 0 ] ).toHaveTextContent(
-			firstSuggestion.type
-		);
+			// Check that a search suggestion shows up corresponding to the data.
+			expect( searchResultElements[ 0 ] ).toHaveTextContent(
+				firstSuggestion.title
+			);
+			expect( searchResultElements[ 0 ] ).toHaveTextContent(
+				firstSuggestion.type
+			);
 
-		// The fallback URL suggestion should not be shown when input is not URL-like.
-		expect(
-			searchResultElements[ searchResultElements.length - 1 ]
-		).not.toHaveTextContent( 'URL' );
-	} );
+			// The fallback URL suggestion should not be shown when input is not URL-like.
+			expect(
+				searchResultElements[ searchResultElements.length - 1 ]
+			).not.toHaveTextContent( 'URL' );
+		}
+	);
 
 	it.each( [
 		[ 'https://wordpress.org', 'URL' ],

--- a/packages/block-editor/src/components/link-control/test/index.js
+++ b/packages/block-editor/src/components/link-control/test/index.js
@@ -439,7 +439,7 @@ describe( 'Searching for a link', () => {
 		expect( screen.queryByRole( 'presentation' ) ).not.toBeInTheDocument();
 	} );
 
-	it( 'should display only search suggestions when current input value is not URL-like', async () => {
+	it( 'should display only search suggestions (and not URL result type) when current input value is not URL-like', async () => {
 		const user = userEvent.setup();
 		const searchTerm = 'Hello world';
 		const firstSuggestion = fauxEntitySuggestions[ 0 ];
@@ -476,6 +476,36 @@ describe( 'Searching for a link', () => {
 		expect(
 			searchResultElements[ searchResultElements.length - 1 ]
 		).not.toHaveTextContent( 'URL' );
+	} );
+
+	it( 'should display only URL result when current input value is URL-like', async () => {
+		const user = userEvent.setup();
+		const searchTerm = 'www.wordpress.org';
+
+		render( <LinkControl /> );
+
+		// Search Input UI.
+		const searchInput = screen.getByRole( 'combobox', { name: 'URL' } );
+
+		// Simulate searching for a term.
+		await user.type( searchInput, searchTerm );
+
+		const searchResultElement = within(
+			await screen.findByRole( 'listbox', {
+				name: /Search results for.*/,
+			} )
+		).getByRole( 'option' );
+
+		expect( searchResultElement ).toBeInTheDocument();
+
+		// Should only be the `URL` suggestion.
+		expect( searchInput ).toHaveAttribute( 'aria-expanded', 'true' );
+
+		expect( searchResultElement ).toHaveTextContent( searchTerm );
+		expect( searchResultElement ).toHaveTextContent( 'URL' );
+		expect( searchResultElement ).toHaveTextContent(
+			'Press ENTER to add this link'
+		);
 	} );
 
 	it( 'should trim search term', async () => {

--- a/packages/block-editor/src/components/link-control/test/index.js
+++ b/packages/block-editor/src/components/link-control/test/index.js
@@ -196,8 +196,7 @@ describe( 'Basic rendering', () => {
 			within( resultsList ).getAllByRole( 'option' );
 
 		expect( searchResultElements ).toHaveLength(
-			// The fauxEntitySuggestions length plus the 'Press ENTER to add this link' button.
-			fauxEntitySuggestions.length + 1
+			fauxEntitySuggestions.length
 		);
 
 		// Step down into the search results, highlighting the first result item.
@@ -504,8 +503,7 @@ describe( 'Searching for a link', () => {
 			.flat()
 			.filter( Boolean );
 
-		// Given we're mocking out the results we should always have 4 mark elements.
-		expect( searchResultTextHighlightElements ).toHaveLength( 4 );
+		expect( searchResultTextHighlightElements ).toHaveLength( 3 );
 
 		// Make sure there are no `mark` elements which contain anything other
 		// than the trimmed search term (ie: no whitespace).
@@ -565,16 +563,15 @@ describe( 'Searching for a link', () => {
 			const lastSearchResultItem =
 				searchResultElements[ searchResultElements.length - 1 ];
 
-			// We should see a search result for each of the expect search suggestions
-			// plus 1 additional one for the fallback URL suggestion.
+			// We should see a search result for each of the expect search suggestions.
 			expect( searchResultElements ).toHaveLength(
-				fauxEntitySuggestions.length + 1
+				fauxEntitySuggestions.length
 			);
 
-			// The last item should be a URL search suggestion.
-			expect( lastSearchResultItem ).toHaveTextContent( searchTerm );
-			expect( lastSearchResultItem ).toHaveTextContent( 'URL' );
-			expect( lastSearchResultItem ).toHaveTextContent(
+			// The URL search suggestion should not exist.
+			expect( lastSearchResultItem ).not.toHaveTextContent( searchTerm );
+			expect( lastSearchResultItem ).not.toHaveTextContent( 'URL' );
+			expect( lastSearchResultItem ).not.toHaveTextContent(
 				'Press ENTER to add this link'
 			);
 		}
@@ -952,8 +949,7 @@ describe( 'Default search suggestions', () => {
 			} )
 		).getAllByRole( 'option' );
 
-		// It should match any url that's like ?p= and also include a URL option.
-		expect( searchResultElements ).toHaveLength( 5 );
+		expect( searchResultElements ).toHaveLength( 4 );
 
 		expect( searchInput ).toHaveAttribute( 'aria-expanded', 'true' );
 

--- a/packages/block-editor/src/components/link-control/test/is-url-like.js
+++ b/packages/block-editor/src/components/link-control/test/is-url-like.js
@@ -40,4 +40,27 @@ describe( 'isURLLike', () => {
 	it( 'returns true for internal anchor ("hash") links.', () => {
 		expect( isURLLike( '#someinternallink' ) ).toBe( true );
 	} );
+
+	// use .each to test multiple cases
+	it.each( [
+		[ true, 'http://example.com' ],
+		[ true, 'https://test.co.uk?query=param' ],
+		[ true, 'ftp://openai.ai?param=value#section' ],
+		[ true, 'example.com' ],
+		[ true, 'http://example.com?query=param#section' ],
+		[ true, 'https://test.co.uk/some/path' ],
+		[ true, 'ftp://openai.ai/some/path' ],
+		[ true, 'example.org/some/path' ],
+		[ true, 'example_test.tld' ],
+		[ true, 'example_test.com' ],
+		[ false, 'example' ],
+		[ false, '.com' ],
+		[ true, '_test.com' ],
+		[ true, 'http://example_test.com' ],
+	] )(
+		'returns %s when testing against string "%s" for a valid TLD',
+		( expected, testString ) => {
+			expect( isURLLike( testString ) ).toBe( expected );
+		}
+	);
 } );

--- a/packages/block-editor/src/components/link-control/test/is-url-like.js
+++ b/packages/block-editor/src/components/link-control/test/is-url-like.js
@@ -1,0 +1,43 @@
+/**
+ * Internal dependencies
+ */
+import isURLLike from '../is-url-like';
+
+describe( 'isURLLike', () => {
+	it.each( [ 'https://wordpress.org', 'http://wordpress.org' ] )(
+		'returns true for a string that starts with an http(s) protocol',
+		( testString ) => {
+			expect( isURLLike( testString ) ).toBe( true );
+		}
+	);
+
+	it.each( [
+		'hello world',
+		'https://   has spaces even though starts with protocol',
+		'www. wordpress . org',
+	] )(
+		'returns false for any string with spaces (e.g. "%s")',
+		( testString ) => {
+			expect( isURLLike( testString ) ).toBe( false );
+		}
+	);
+
+	it( 'returns false for a string without a protocol or a TLD', () => {
+		expect( isURLLike( 'somedirectentryhere' ) ).toBe( false );
+	} );
+
+	it( 'returns true for a string beginning with www.', () => {
+		expect( isURLLike( 'www.wordpress.org' ) ).toBe( true );
+	} );
+
+	it.each( [ 'mailto:test@wordpress.org', 'tel:123456' ] )(
+		'returns true for common protocols',
+		( testString ) => {
+			expect( isURLLike( testString ) ).toBe( true );
+		}
+	);
+
+	it( 'returns true for internal anchor ("hash") links.', () => {
+		expect( isURLLike( '#someinternallink' ) ).toBe( true );
+	} );
+} );

--- a/packages/block-editor/src/components/link-control/use-search-handler.js
+++ b/packages/block-editor/src/components/link-control/use-search-handler.js
@@ -51,45 +51,22 @@ const handleEntitySearch = async (
 	val,
 	suggestionsQuery,
 	fetchSearchSuggestions,
-	directEntryHandler,
 	withCreateSuggestion,
-	withURLSuggestion,
 	pageOnFront
 ) => {
 	const { isInitialSuggestions } = suggestionsQuery;
-	let resultsIncludeFrontPage = false;
 
-	let results = await Promise.all( [
-		fetchSearchSuggestions( val, suggestionsQuery ),
-		directEntryHandler( val ),
-	] );
+	const results = await fetchSearchSuggestions( val, suggestionsQuery );
 
 	// Identify front page and update type to match.
-	results[ 0 ] = results[ 0 ].map( ( result ) => {
+	results.map( ( result ) => {
 		if ( Number( result.id ) === pageOnFront ) {
-			resultsIncludeFrontPage = true;
 			result.isFrontPage = true;
 			return result;
 		}
 
 		return result;
 	} );
-
-	const couldBeURL = ! val.includes( ' ' );
-
-	// If it's potentially a URL search then concat on a URL search suggestion
-	// just for good measure. That way once the actual results run out we always
-	// have a URL option to fallback on.
-	if (
-		! resultsIncludeFrontPage &&
-		couldBeURL &&
-		withURLSuggestion &&
-		! isInitialSuggestions
-	) {
-		results = results[ 0 ].concat( results[ 1 ] );
-	} else {
-		results = results[ 0 ];
-	}
 
 	// If displaying initial suggestions just return plain results.
 	if ( isInitialSuggestions ) {
@@ -150,12 +127,18 @@ export default function useSearchHandler(
 						val,
 						{ ...suggestionsQuery, isInitialSuggestions },
 						fetchSearchSuggestions,
-						directEntryHandler,
 						withCreateSuggestion,
 						withURLSuggestion,
 						pageOnFront
 				  );
 		},
-		[ directEntryHandler, fetchSearchSuggestions, withCreateSuggestion ]
+		[
+			directEntryHandler,
+			fetchSearchSuggestions,
+			pageOnFront,
+			suggestionsQuery,
+			withCreateSuggestion,
+			withURLSuggestion,
+		]
 	);
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Improves the matching for URLs vs Entity Searches when typing in the Link Control search box.

Also removes the direct entry "suggestion" when an entity is returned.

Part of https://github.com/WordPress/gutenberg/issues/50178

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

It's required by https://github.com/WordPress/gutenberg/issues/50178 to simplify the process of:

- selecting a search result
- adding a direct entry URL
- creating a page (note: this option will become less of a concern as we will move this as part of https://github.com/WordPress/gutenberg/issues/50891).

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Updates the `isURLLike` method by removing the very "open" `isURL` check which allowed pretty much anything to be technically valid. That's correct but in our case we want to limit the "URL" suggestion prompt to be only when it's prettry obviously a domain. So this result should now only show if:

- it's a valid protocol (http(s), ftp, mailto...etc)
- it's an internal link `#something`
- it starts with `www.`
- it has something that looks like a TLD (`wordpress.org`).

That's likely to exclude some edge cases that are technically valid URLs. However the approach previously which tried to account for any possible URL made the UX poorer by saying "this is a URL" even when it probably wasn't (e.g. `heelloiamnotaurl`).

This trades accuracy for an improved UX.


Note that I used ChatGPT to help me scaffold out the regex for the TLD helper. 


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

- Add a paragraph
- Add a link.
- Try searching for a page.
- See that search results display but without any result for "direct entry"
- Try another link, this time entering things that would seem like "URLs" to you. 
- Check the system accurately recognises these and does not show entity search results but rather displays the "URL" suggestion for you to click on.
- You should never see both entity results and direct entry URL result at the same time.
- Check that it's still possible to manually enter any input even if it's not recognised as a URL. In the future we need to follow up with _validation_ which will _strictly_ check the type of input is a valid URL using `isURL`.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
