### PR TITLE
Handle isDraft or isInvalid Enter keypress via onKeyDown instead of a Keyboard Shortcut

### DIFF
--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -15,7 +15,6 @@ import {
 	ToolbarButton,
 	Tooltip,
 	ToolbarGroup,
-	KeyboardShortcuts,
 } from '@wordpress/components';
 import { displayShortcut, isKeyboardEvent, ENTER } from '@wordpress/keycodes';
 import { __ } from '@wordpress/i18n';
@@ -340,7 +339,7 @@ export default function NavigationLinkEdit( {
 	function onKeyDown( event ) {
 		if (
 			isKeyboardEvent.primary( event, 'k' ) ||
-			( ! url && event.keyCode === ENTER )
+			( ( ! url || isDraft || isInvalid ) && event.keyCode === ENTER )
 		) {
 			setIsLinkOpen( true );
 		}
@@ -553,13 +552,6 @@ export default function NavigationLinkEdit( {
 							) }
 							{ ( isInvalid || isDraft ) && (
 								<div className="wp-block-navigation-link__placeholder-text wp-block-navigation-link__label">
-									<KeyboardShortcuts
-										shortcuts={ {
-											enter: () =>
-												isSelected &&
-												setIsLinkOpen( true ),
-										} }
-									/>
 									<Tooltip
 										position="top center"
 										text={ tooltipText }


### PR DESCRIPTION

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Removes the Keyboard Shortcut for `enter` and relies on the `onKeyDown` event.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Having a Keyboard Shortcut for `enter`, meant that it captured all `enter` keypresses when a draft or invalid link was on the editor, breaking `enter` keypresses for anything else on the editor, even outside of the iframed editor pane in the site editor.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Remove the Keyboard Shortcut and add conditions to the existing `onKeyDown` event. I would have used the `onClick` event, but it wasn't working. I feel like it should work with `onClick`, but this implementation is clearly better for now since it doesn't break `enter` keypresses across the app when there's a draft post in a navigation block.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
- Add a draft post to a navigation
- Check that you can open the link ui via click or enter keypress
- Check that enter keypresses work on the editor when the draft post is present