### PR TITLE
Lightbox UI appearing with interactivity experiment disabled

### DIFF
--- a/lib/experimental/editor-settings.php
+++ b/lib/experimental/editor-settings.php
@@ -92,6 +92,9 @@ function gutenberg_enable_experiments() {
 	if ( $gutenberg_experiments && array_key_exists( 'gutenberg-pattern-enhancements', $gutenberg_experiments ) ) {
 		wp_add_inline_script( 'wp-block-editor', 'window.__experimentalEnablePatternEnhancements = true', 'before' );
 	}
+	if ( $gutenberg_experiments && array_key_exists( 'gutenberg-interactivity-api-core-blocks', $gutenberg_experiments ) ) {
+		wp_add_inline_script( 'wp-block-editor', 'window.__experimentalInteractivityAPI = true', 'before' );
+	}
 
 }
 

--- a/packages/block-editor/src/hooks/behaviors.js
+++ b/packages/block-editor/src/hooks/behaviors.js
@@ -38,7 +38,6 @@ export const withBehaviors = createHigherOrderComponent( ( BlockEdit ) => {
 		const settings =
 			select( blockEditorStore ).getSettings()?.__experimentalFeatures
 				?.blocks?.[ props.name ]?.behaviors;
-
 		if (
 			! settings ||
 			// If every behavior is disabled, do not show the behaviors inspector control.
@@ -102,8 +101,10 @@ export const withBehaviors = createHigherOrderComponent( ( BlockEdit ) => {
 	};
 }, 'withBehaviors' );
 
-addFilter(
-	'editor.BlockEdit',
-	'core/behaviors/with-inspector-control',
-	withBehaviors
-);
+if ( window?.__experimentalInteractivityAPI ) {
+	addFilter(
+		'editor.BlockEdit',
+		'core/behaviors/with-inspector-control',
+		withBehaviors
+	);
+}

--- a/test/e2e/specs/editor/various/behaviors.spec.js
+++ b/test/e2e/specs/editor/various/behaviors.spec.js
@@ -21,9 +21,32 @@ test.describe( 'Testing behaviors functionality', () => {
 		await requestUtils.activateTheme( 'twentytwentyone' );
 		await requestUtils.deleteAllPosts();
 	} );
-
-	test.afterEach( async ( { requestUtils } ) => {
+	test.beforeEach( async ( { admin, page, requestUtils } ) => {
 		await requestUtils.deleteAllMedia();
+		await admin.visitAdminPage(
+			'/admin.php',
+			'page=gutenberg-experiments'
+		);
+
+		await page
+			.locator( `#gutenberg-interactivity-api-core-blocks` )
+			.setChecked( true );
+		await page.locator( `input[name="submit"]` ).click();
+		await page.waitForLoadState();
+	} );
+
+	test.afterEach( async ( { admin, page, requestUtils } ) => {
+		await requestUtils.deleteAllMedia();
+		await admin.visitAdminPage(
+			'/admin.php',
+			'page=gutenberg-experiments'
+		);
+
+		await page
+			.locator( `#gutenberg-interactivity-api-core-blocks` )
+			.setChecked( false );
+		await page.locator( `input[name="submit"]` ).click();
+		await page.waitForLoadState();
 	} );
 
 	test( '`No Behaviors` should be the default as defined in the core theme.json', async ( {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
A Lightbox feature for images has been recently merged into Gutenberg for the 15.9. This feature can be enabled with a dropdown on advanced settings of the Image block. As it requires the Interactivity API, it only works if you have the experiment enabled.


Lightbox option:
![Screenshot 2023-05-27 at 00 09 27](https://github.com/WordPress/gutenberg/assets/37012961/568a6d58-5c4d-4ce0-afff-2d4b025f254d)


Experiments required to be enabled:
![Screenshot 2023-05-27 at 00 08 28](https://github.com/WordPress/gutenberg/assets/37012961/414d4109-0957-4d7b-837d-db18c17c495b)

Right now, the Behavior UI interface appears even when the experiment is disabled. As we have only one behavior, and requires the Interactivity API to be enabled, it shouldn't be like that. This PR fixes.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Hiding the behaviors UI if the Interactivity API is disabled.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
1. Open a post or page. Add an image. Go to Advanced Settings of the block. Behaviors UI should not appear.
2. Go to Gutenberg -> Experiments. Enable Core blocks.
3. Return to the image. Now you should be able to select if the image contains the lightbox behavior or not.
4. Feel free to enable/disable and check that the image on the front has the effect.

