### PR TITLE
Don't use global 'select' in the Behaviors controls component

### DIFF
--- a/packages/block-editor/src/hooks/behaviors.js
+++ b/packages/block-editor/src/hooks/behaviors.js
@@ -5,7 +5,7 @@ import { addFilter } from '@wordpress/hooks';
 import { SelectControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { createHigherOrderComponent } from '@wordpress/compose';
-import { select } from '@wordpress/data';
+import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -17,6 +17,66 @@ import { store as blockEditorStore } from '../store';
  * External dependencies
  */
 import merge from 'deepmerge';
+
+function BehaviorsControl( { blockName, blockBehaviors, onChange } ) {
+	const { settings, themeBehaviors } = useSelect(
+		( select ) => {
+			const { getBehaviors, getSettings } = select( blockEditorStore );
+
+			return {
+				settings:
+					getSettings()?.__experimentalFeatures?.blocks?.[ blockName ]
+						?.behaviors,
+				themeBehaviors: getBehaviors()?.blocks?.[ blockName ],
+			};
+		},
+		[ blockName ]
+	);
+
+	if (
+		! settings ||
+		// If every behavior is disabled, do not show the behaviors inspector control.
+		Object.entries( settings ).every( ( [ , value ] ) => ! value )
+	) {
+		return null;
+	}
+
+	// Block behaviors take precedence over theme behaviors.
+	const behaviors = merge( themeBehaviors, blockBehaviors || {} );
+
+	const noBehaviorsOption = {
+		value: '',
+		label: __( 'No behaviors' ),
+	};
+
+	const behaviorsOptions = Object.entries( settings )
+		.filter( ( [ , behaviorValue ] ) => behaviorValue ) // Filter out behaviors that are disabled.
+		.map( ( [ behaviorName ] ) => ( {
+			value: behaviorName,
+			label:
+				// Capitalize the first letter of the behavior name.
+				behaviorName[ 0 ].toUpperCase() +
+				behaviorName.slice( 1 ).toLowerCase(),
+		} ) );
+
+	const options = [ noBehaviorsOption, ...behaviorsOptions ];
+
+	return (
+		<InspectorControls group="advanced">
+			<SelectControl
+				__nextHasNoMarginBottom
+				label={ __( 'Behaviors' ) }
+				// At the moment we are only supporting one behavior (Lightbox)
+				value={ behaviors?.lightbox ? 'lightbox' : '' }
+				options={ options }
+				onChange={ onChange }
+				hideCancelButton={ true }
+				help={ __( 'Add behaviors.' ) }
+				size="__unstable-large"
+			/>
+		</InspectorControls>
+	);
+}
 
 /**
  * Override the default edit UI to include a new block inspector control for
@@ -30,72 +90,28 @@ import merge from 'deepmerge';
  */
 export const withBehaviors = createHigherOrderComponent( ( BlockEdit ) => {
 	return ( props ) => {
+		const blockEdit = <BlockEdit key="edit" { ...props } />;
 		// Only add behaviors to the core/image block.
 		if ( props.name !== 'core/image' ) {
-			return <BlockEdit { ...props } />;
+			return blockEdit;
 		}
-
-		const settings =
-			select( blockEditorStore ).getSettings()?.__experimentalFeatures
-				?.blocks?.[ props.name ]?.behaviors;
-		if (
-			! settings ||
-			// If every behavior is disabled, do not show the behaviors inspector control.
-			Object.entries( settings ).every( ( [ , value ] ) => ! value )
-		) {
-			return <BlockEdit { ...props } />;
-		}
-
-		const { behaviors: blockBehaviors } = props.attributes;
-
-		// Get the theme behaviors for the block from the theme.json.
-		const themeBehaviors =
-			select( blockEditorStore ).getBehaviors()?.blocks?.[ props.name ];
-
-		// Block behaviors take precedence over theme behaviors.
-		const behaviors = merge( themeBehaviors, blockBehaviors || {} );
-
-		const noBehaviorsOption = {
-			value: '',
-			label: __( 'No behaviors' ),
-		};
-
-		const behaviorsOptions = Object.entries( settings )
-			.filter( ( [ , behaviorValue ] ) => behaviorValue ) // Filter out behaviors that are disabled.
-			.map( ( [ behaviorName ] ) => ( {
-				value: behaviorName,
-				label:
-					// Capitalize the first letter of the behavior name.
-					behaviorName[ 0 ].toUpperCase() +
-					behaviorName.slice( 1 ).toLowerCase(),
-			} ) );
-
-		const options = [ noBehaviorsOption, ...behaviorsOptions ];
 
 		return (
 			<>
-				<BlockEdit { ...props } />
-				<InspectorControls group="advanced">
-					<SelectControl
-						__nextHasNoMarginBottom
-						label={ __( 'Behaviors' ) }
-						// At the moment we are only supporting one behavior (Lightbox)
-						value={ behaviors?.lightbox ? 'lightbox' : '' }
-						options={ options }
-						onChange={ ( nextValue ) => {
-							// If the user selects something, it means that they want to
-							// change the default value (true) so we save it in the attributes.
-							props.setAttributes( {
-								behaviors: {
-									lightbox: nextValue === 'lightbox',
-								},
-							} );
-						} }
-						hideCancelButton={ true }
-						help={ __( 'Add behaviors.' ) }
-						size="__unstable-large"
-					/>
-				</InspectorControls>
+				{ blockEdit }
+				<BehaviorsControl
+					blockName={ props.name }
+					blockBehaviors={ props.attributes.behaviors }
+					onChange={ ( nextValue ) => {
+						// If the user selects something, it means that they want to
+						// change the default value (true) so we save it in the attributes.
+						props.setAttributes( {
+							behaviors: {
+								lightbox: nextValue === 'lightbox',
+							},
+						} );
+					} }
+				/>
 			</>
 		);
 	};


### PR DESCRIPTION
## What?
This is a follow-up to #49972.

PR refactors the Behaviors controls integration to avoid using the global `select` calls.

## Why?
Using global `select` is considered a bad pattern as it only works with the default registry, not custom registry providers.

## How?
PR extracts control into a separate component so that we can use the `useSelect` hook.

## Testing Instructions
1. Open a Post or Page.
2. Insert an Image Block.
3. Confirm that the Behavior controls work as before.
4. Corresponding E2E tests are passing.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2023-05-27 at 10 08 27](https://github.com/WordPress/gutenberg/assets/240569/ad8c4f54-12a9-46e7-a048-e457d994a548)

