### PR TITLE
Widget Editor: Update settings icon

### DIFF
--- a/packages/edit-widgets/src/components/sidebar/index.js
+++ b/packages/edit-widgets/src/components/sidebar/index.js
@@ -7,7 +7,7 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { useEffect, Platform } from '@wordpress/element';
-import { __, sprintf } from '@wordpress/i18n';
+import { isRTL, __, sprintf } from '@wordpress/i18n';
 import {
 	ComplementaryArea,
 	store as interfaceStore,
@@ -17,7 +17,7 @@ import {
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
 
-import { cog } from '@wordpress/icons';
+import { drawerLeft, drawerRight } from '@wordpress/icons';
 import { Button } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 
@@ -168,7 +168,7 @@ export default function Sidebar() {
 			closeLabel={ __( 'Close Settings' ) }
 			scope="core/edit-widgets"
 			identifier={ currentArea }
-			icon={ cog }
+			icon={ isRTL() ? drawerLeft : drawerRight }
 			isActiveByDefault={ SIDEBAR_ACTIVE_BY_DEFAULT }
 		>
 			{ currentArea === WIDGET_AREAS_IDENTIFIER && (


### PR DESCRIPTION
## What?
This PR updates the settings icon in the Widget Block Editor.

![widget_trunk](https://github.com/WordPress/gutenberg/assets/54422211/0d3b016c-0542-4e25-a5b6-a1d4c8016656)

## Why?

As [part of #45005](https://github.com/WordPress/gutenberg/pull/45005/files#diff-b20e58387aaaf1809d52371285cc4ac37a5d860ab462647f038cbdaf54e9b876L81), the settings icons in the post editor and site editor have been updated. (from `cog` to `drawerLeft` | `drawerRight`). I believe that the widget editor icon should also be updated to maintain consistency in the UI.

Meanwhile, we need to continue to discuss #46851, which proposes reverting this icon back to the previous gear icon.

## Testing Instructions

- Activate the TwentyTwenty One theme and access the widget menu.
- Confirm that the icon has changed.

![widget](https://github.com/WordPress/gutenberg/assets/54422211/be5eb766-5886-47d4-82f3-c6dd33a148d5)

If the language of the site is RTL language, make sure that the icons are also reversed left to right.

![widget_rtl](https://github.com/WordPress/gutenberg/assets/54422211/37421d5d-34ba-47ea-adeb-ed1a311145ca)
