### PR TITLE
Fixed Docker Image Size Ballooning

### DIFF
--- a/packages/env/CHANGELOG.md
+++ b/packages/env/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 -   Execute the local package's `wp-env` instead of the globally installed version if one is available.
 
+### Bug fix
+
+-   Run `useradd` with `-l` option to prevent excessive Docker image sizes.
+
 ## 8.0.0 (2023-05-24)
 
 ### Breaking Change

--- a/packages/env/lib/init-config.js
+++ b/packages/env/lib/init-config.js
@@ -133,8 +133,8 @@ ARG HOST_USERNAME
 ARG HOST_UID
 ARG HOST_GID
 # When the IDs are already in use we can still safely move on.
-RUN groupadd -g $HOST_GID $HOST_USERNAME || true
-RUN useradd -m -u $HOST_UID -g $HOST_GID $HOST_USERNAME || true
+RUN groupadd -o -g $HOST_GID $HOST_USERNAME
+RUN useradd -mlo -u $HOST_UID -g $HOST_GID $HOST_USERNAME
 
 # Install any dependencies we need in the container.
 ${ installDependencies( 'wordpress', env, config ) }`;

--- a/packages/env/lib/init-config.js
+++ b/packages/env/lib/init-config.js
@@ -133,8 +133,8 @@ ARG HOST_USERNAME
 ARG HOST_UID
 ARG HOST_GID
 # When the IDs are already in use we can still safely move on.
-RUN groupadd -o -g $HOST_GID $HOST_USERNAME
-RUN useradd -mlo -u $HOST_UID -g $HOST_GID $HOST_USERNAME
+RUN groupadd -o -g $HOST_GID $HOST_USERNAME || true
+RUN useradd -mlo -u $HOST_UID -g $HOST_GID $HOST_USERNAME || true
 
 # Install any dependencies we need in the container.
 ${ installDependencies( 'wordpress', env, config ) }`;


### PR DESCRIPTION
## What?
This pull request stops the `wordpress` Docker image generated by `wp-env start` from reaching absurd file sizes.

## Why?

When ran without the `-l` option, `useradd` can cause certain log files the balloon in size. This seems to have something to do with how high the `uid` is, but, the option should eliminate the problem.

Closes #50934.

## How?

We add the `-l` option to `useradd` in the `wordpress` Dockerfile.

## Testing Instructions

1. Run `npx wp-env destroy`.
2. Run `npx wp-env start`.
3. Confirm that the environment is created successfully.