### PR TITLE
Fix screen readers not announcing updated `aria-describedby` in Firefox

### DIFF
--- a/packages/block-editor/src/components/list-view/appender.js
+++ b/packages/block-editor/src/components/list-view/appender.js
@@ -1,12 +1,10 @@
 /**
  * WordPress dependencies
  */
-import { useInstanceId } from '@wordpress/compose';
 import { speak } from '@wordpress/a11y';
 import { useSelect } from '@wordpress/data';
 import { forwardRef, useEffect } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
-import { VisuallyHidden } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -20,7 +18,6 @@ export const Appender = forwardRef(
 	( { nestingLevel, blockCount, clientId, ...props }, ref ) => {
 		const { insertedBlock, setInsertedBlock } = useListViewContext();
 
-		const instanceId = useInstanceId( Appender );
 		const { hideInserter } = useSelect(
 			( select ) => {
 				const { getTemplateLock, __unstableGetEditorMode } =
@@ -64,7 +61,6 @@ export const Appender = forwardRef(
 			return null;
 		}
 
-		const descriptionId = `list-view-appender__${ instanceId }`;
 		const description = sprintf(
 			/* translators: 1: The name of the block. 2: The numerical position of the block. 3: The level of nesting for the block. */
 			__( 'Append to %1$s block at position %2$d, Level %3$d' ),
@@ -84,16 +80,13 @@ export const Appender = forwardRef(
 					shouldDirectInsert={ false }
 					__experimentalIsQuick
 					{ ...props }
-					toggleProps={ { 'aria-describedby': descriptionId } }
+					toggleProps={ { 'aria-description': description } }
 					onSelectOrClose={ ( maybeInsertedBlock ) => {
 						if ( maybeInsertedBlock?.clientId ) {
 							setInsertedBlock( maybeInsertedBlock );
 						}
 					} }
 				/>
-				<VisuallyHidden id={ descriptionId }>
-					{ description }
-				</VisuallyHidden>
 			</div>
 		);
 	}

--- a/packages/block-editor/src/components/list-view/appender.js
+++ b/packages/block-editor/src/components/list-view/appender.js
@@ -6,6 +6,7 @@ import { speak } from '@wordpress/a11y';
 import { useSelect } from '@wordpress/data';
 import { forwardRef, useEffect } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
+import { VisuallyHidden } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -90,12 +91,9 @@ export const Appender = forwardRef(
 						}
 					} }
 				/>
-				<div
-					className="list-view-appender__description"
-					id={ descriptionId }
-				>
+				<VisuallyHidden id={ descriptionId }>
 					{ description }
-				</div>
+				</VisuallyHidden>
 			</div>
 		);
 	}

--- a/packages/block-editor/src/components/list-view/appender.js
+++ b/packages/block-editor/src/components/list-view/appender.js
@@ -1,6 +1,7 @@
 /**
  * WordPress dependencies
  */
+import { useInstanceId } from '@wordpress/compose';
 import { speak } from '@wordpress/a11y';
 import { useSelect } from '@wordpress/data';
 import { forwardRef, useEffect } from '@wordpress/element';
@@ -13,11 +14,13 @@ import { store as blockEditorStore } from '../../store';
 import useBlockDisplayTitle from '../block-title/use-block-display-title';
 import { useListViewContext } from './context';
 import Inserter from '../inserter';
+import AriaReferencedText from './aria-referenced-text';
 
 export const Appender = forwardRef(
 	( { nestingLevel, blockCount, clientId, ...props }, ref ) => {
 		const { insertedBlock, setInsertedBlock } = useListViewContext();
 
+		const instanceId = useInstanceId( Appender );
 		const { hideInserter } = useSelect(
 			( select ) => {
 				const { getTemplateLock, __unstableGetEditorMode } =
@@ -61,6 +64,7 @@ export const Appender = forwardRef(
 			return null;
 		}
 
+		const descriptionId = `list-view-appender__${ instanceId }`;
 		const description = sprintf(
 			/* translators: 1: The name of the block. 2: The numerical position of the block. 3: The level of nesting for the block. */
 			__( 'Append to %1$s block at position %2$d, Level %3$d' ),
@@ -87,6 +91,9 @@ export const Appender = forwardRef(
 						}
 					} }
 				/>
+				<AriaReferencedText id={ descriptionId }>
+					{ description }
+				</AriaReferencedText>
 			</div>
 		);
 	}

--- a/packages/block-editor/src/components/list-view/appender.js
+++ b/packages/block-editor/src/components/list-view/appender.js
@@ -84,7 +84,7 @@ export const Appender = forwardRef(
 					shouldDirectInsert={ false }
 					__experimentalIsQuick
 					{ ...props }
-					toggleProps={ { 'aria-description': description } }
+					toggleProps={ { 'aria-describedby': descriptionId } }
 					onSelectOrClose={ ( maybeInsertedBlock ) => {
 						if ( maybeInsertedBlock?.clientId ) {
 							setInsertedBlock( maybeInsertedBlock );

--- a/packages/block-editor/src/components/list-view/aria-referenced-text.js
+++ b/packages/block-editor/src/components/list-view/aria-referenced-text.js
@@ -1,0 +1,30 @@
+/**
+ * WordPress dependencies
+ */
+import { useRef, useEffect } from '@wordpress/element';
+
+/**
+ * A component specifically designed to be used as an element referenced
+ * by ARIA attributes such as `aria-labelledby` or `aria-describedby`.
+ *
+ * @param {Object}                    props          Props.
+ * @param {import('react').ReactNode} props.children
+ */
+export default function AriaReferencedText( { children, ...props } ) {
+	const ref = useRef();
+
+	useEffect( () => {
+		if ( ref.current ) {
+			// This seems like a no-op, but it fixes a bug in Firefox where
+			// it fails to recompute the text when only the text node changes.
+			// @see https://github.com/WordPress/gutenberg/pull/51035
+			ref.current.textContent = ref.current.textContent;
+		}
+	}, [ children ] );
+
+	return (
+		<div hidden { ...props } ref={ ref }>
+			{ children }
+		</div>
+	);
+}

--- a/packages/block-editor/src/components/list-view/block-select-button.js
+++ b/packages/block-editor/src/components/list-view/block-select-button.js
@@ -40,7 +40,7 @@ function ListViewBlockSelectButton(
 		draggable,
 		isExpanded,
 		ariaLabel,
-		ariaDescription,
+		ariaDescribedBy,
 		updateFocusAndSelection,
 	},
 	ref
@@ -138,8 +138,7 @@ function ListViewBlockSelectButton(
 				draggable={ draggable }
 				href={ `#block-${ clientId }` }
 				aria-label={ ariaLabel }
-				// eslint-disable-next-line jsx-a11y/aria-props
-				aria-description={ ariaDescription }
+				aria-describedby={ ariaDescribedBy }
 				aria-expanded={ isExpanded }
 			>
 				<ListViewExpander onClick={ onToggleExpanded } />

--- a/packages/block-editor/src/components/list-view/block-select-button.js
+++ b/packages/block-editor/src/components/list-view/block-select-button.js
@@ -40,7 +40,7 @@ function ListViewBlockSelectButton(
 		draggable,
 		isExpanded,
 		ariaLabel,
-		ariaDescribedBy,
+		ariaDescription,
 		updateFocusAndSelection,
 	},
 	ref
@@ -138,7 +138,8 @@ function ListViewBlockSelectButton(
 				draggable={ draggable }
 				href={ `#block-${ clientId }` }
 				aria-label={ ariaLabel }
-				aria-describedby={ ariaDescribedBy }
+				// eslint-disable-next-line jsx-a11y/aria-props
+				aria-description={ ariaDescription }
 				aria-expanded={ isExpanded }
 			>
 				<ListViewExpander onClick={ onToggleExpanded } />

--- a/packages/block-editor/src/components/list-view/block.js
+++ b/packages/block-editor/src/components/list-view/block.js
@@ -11,6 +11,7 @@ import {
 	__experimentalTreeGridCell as TreeGridCell,
 	__experimentalTreeGridItem as TreeGridItem,
 } from '@wordpress/components';
+import { useInstanceId } from '@wordpress/compose';
 import { moreVertical } from '@wordpress/icons';
 import {
 	useState,
@@ -39,6 +40,7 @@ import { store as blockEditorStore } from '../../store';
 import useBlockDisplayInformation from '../use-block-display-information';
 import { useBlockLock } from '../block-lock';
 import { unlock } from '../../lock-unlock';
+import AriaReferencedText from './aria-referenced-text';
 
 function ListViewBlock( {
 	block: { clientId },
@@ -95,6 +97,8 @@ function ListViewBlock( {
 		hasBlockSupport( blockName, '__experimentalToolbar', true ) &&
 		// Don't show the settings menu if block is disabled or content only.
 		blockEditingMode === 'default';
+	const instanceId = useInstanceId( ListViewBlock );
+	const descriptionId = `list-view-block-select-button__${ instanceId }`;
 	const blockPositionDescription = getBlockPositionDescription(
 		position,
 		siblingBlockCount,
@@ -291,9 +295,12 @@ function ListViewBlock( {
 							isExpanded={ canEdit ? isExpanded : undefined }
 							selectedClientIds={ selectedClientIds }
 							ariaLabel={ blockAriaLabel }
-							ariaDescription={ blockPositionDescription }
+							ariaDescribedBy={ descriptionId }
 							updateFocusAndSelection={ updateFocusAndSelection }
 						/>
+						<AriaReferencedText id={ descriptionId }>
+							{ blockPositionDescription }
+						</AriaReferencedText>
 					</div>
 				) }
 			</TreeGridCell>

--- a/packages/block-editor/src/components/list-view/block.js
+++ b/packages/block-editor/src/components/list-view/block.js
@@ -10,9 +10,7 @@ import { hasBlockSupport } from '@wordpress/blocks';
 import {
 	__experimentalTreeGridCell as TreeGridCell,
 	__experimentalTreeGridItem as TreeGridItem,
-	VisuallyHidden,
 } from '@wordpress/components';
-import { useInstanceId } from '@wordpress/compose';
 import { moreVertical } from '@wordpress/icons';
 import {
 	useState,
@@ -97,8 +95,6 @@ function ListViewBlock( {
 		hasBlockSupport( blockName, '__experimentalToolbar', true ) &&
 		// Don't show the settings menu if block is disabled or content only.
 		blockEditingMode === 'default';
-	const instanceId = useInstanceId( ListViewBlock );
-	const descriptionId = `list-view-block-select-button__${ instanceId }`;
 	const blockPositionDescription = getBlockPositionDescription(
 		position,
 		siblingBlockCount,
@@ -295,12 +291,9 @@ function ListViewBlock( {
 							isExpanded={ canEdit ? isExpanded : undefined }
 							selectedClientIds={ selectedClientIds }
 							ariaLabel={ blockAriaLabel }
-							ariaDescribedBy={ descriptionId }
+							ariaDescription={ blockPositionDescription }
 							updateFocusAndSelection={ updateFocusAndSelection }
 						/>
-						<VisuallyHidden id={ descriptionId }>
-							{ blockPositionDescription }
-						</VisuallyHidden>
 					</div>
 				) }
 			</TreeGridCell>

--- a/packages/block-editor/src/components/list-view/block.js
+++ b/packages/block-editor/src/components/list-view/block.js
@@ -10,6 +10,7 @@ import { hasBlockSupport } from '@wordpress/blocks';
 import {
 	__experimentalTreeGridCell as TreeGridCell,
 	__experimentalTreeGridItem as TreeGridItem,
+	VisuallyHidden,
 } from '@wordpress/components';
 import { useInstanceId } from '@wordpress/compose';
 import { moreVertical } from '@wordpress/icons';
@@ -297,12 +298,9 @@ function ListViewBlock( {
 							ariaDescribedBy={ descriptionId }
 							updateFocusAndSelection={ updateFocusAndSelection }
 						/>
-						<div
-							className="block-editor-list-view-block-select-button__description"
-							id={ descriptionId }
-						>
+						<VisuallyHidden id={ descriptionId }>
 							{ blockPositionDescription }
-						</div>
+						</VisuallyHidden>
 					</div>
 				) }
 			</TreeGridCell>

--- a/packages/block-editor/src/components/list-view/style.scss
+++ b/packages/block-editor/src/components/list-view/style.scss
@@ -340,11 +340,6 @@
 	}
 }
 
-.block-editor-list-view-block-select-button__description,
-.block-editor-list-view-appender__description {
-	display: none;
-}
-
 .block-editor-list-view-block__contents-cell,
 .block-editor-list-view-appender__cell {
 	.block-editor-list-view-block__contents-container,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Originally discovered and reported by @alexstine in https://github.com/WordPress/gutenberg/pull/50422#pullrequestreview-1433625084. This PR fixes the issue where screen readers in Firefox fail to announce updated changes when the content of an element referenced by the `aria-describedby` attribute is updated.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
It's important to make sure screen readers get the correct and expected experience.

It is crucial to ensure that screen readers provide the correct and expected experience for users.

I investigated this issue further and found that it appears to be a bug specific to Firefox, as it is only reproducible in Firefox. The following conditions must all be met for the issue to occur:

1. The issue only occurs in Firefox, regardless of the screen reader or operating system used. I tested it with macOS's VoiceOver and Windows 11's NVDA.
2. The issue affects any `aria-*` attribute that references an element's ID, such as `aria-describedby` or `aria-labelledby`.
3. The element referenced by the `aria-*` attribute must be hidden from assistive technology, for example, through `display: none`, `aria-hidden="true"`, or `hidden`.
4. The code that updates the text content must operate on the text node. For example, `span.textContent = 'Updated changes'` works fine, but `span.childNodes[0].nodeValue = 'Updated changes'` does not. This issue is particularly noticeable in modern frontend frameworks like React, which always updates the smallest possible node for simplicity and performance.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

To fix this issue, we only need to modify one of the conditions mentioned above. Since we need to support Firefox and screen readers, we cannot change conditions (1) and (2). Modifying (3) is also tricky because it sometimes double-announces the description if it's accessible to screen readers.

I created a `<AriaReferencedText>` component in this PR to leverage (4) to force a recomputation of `textContent` when the text changes. It triggers Firefox to acknowledge the changes and announce the correct value.

This might not be the best solution, so I also want to seek insights from the Firefox accessibility team to understand the root cause of this issue. If we all agree that it is a bug, we may be able to address it in a future Firefox release.

### Testing Instructions for the minimal reproducible jsfiddle
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
I created a [jsfiddle](https://jsfiddle.net/kevin940726/k9qz0cyh/) to demonstrate the issue. Be sure to open it in Firefox and follow these steps.

1. Enable your screen readers if you haven't already.
2. Hit <kbd>Command</kbd>/<kbd>Control</kbd>+<kbd>Enter</kbd> to run the fiddle.
3. Navigate to the result/preview frame and click the "Start tabbing" button. This will update the text content of the description for the following buttons.
4. Press <kbd>Tab</kbd> once to reach a button with the description updated by setting `textContent` directly. The screen reader should announce "Updated! Everything works correctly".
5. Press <kbd>Tab</kbd> again to reach a button with the description updated by altering the underlying `textNode`. The screen reader should announce "Not updated, something is wrong".

### Testing Instructions for the List View in gutenberg

1. Use Firefox.
1. Create a post and add some blocks (5 paragraphs for instance).
2. Enable List view.
3. Try to navigate and delete a block inside the list view. (Using the options menu for deletion is recommended to ignore a known issue of screen readers sometimes skip announcing the focused element after deleting with keyboard shortcut for now.)
4. Expect the screen readers to announce the correct description for the focused element.

## Screenshots or screencast <!-- if applicable -->

List view screencasts:

| Before | After |
|--------|--------|
| <video src="https://github.com/WordPress/gutenberg/assets/7753001/909890e6-3659-496b-bc35-4f756ea7488c"> | <video src="https://github.com/WordPress/gutenberg/assets/7753001/2d97ddd6-9fa0-4775-a113-69b81807f34b"> |

jsfiddle screencast:

https://github.com/WordPress/gutenberg/assets/7753001/1ee0bf74-d10c-425a-8cea-1534a3caed13

