### PR TITLE
Site editor sidebar: extract get page details function.

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen-page/get-page-details.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-page/get-page-details.js
@@ -1,0 +1,80 @@
+/**
+ * WordPress dependencies
+ */
+import { __, _x, sprintf } from '@wordpress/i18n';
+import { __experimentalTruncate as Truncate } from '@wordpress/components';
+import { count as wordCount } from '@wordpress/wordcount';
+
+/**
+ * Internal dependencies
+ */
+import StatusLabel from './status-label';
+
+// Taken from packages/editor/src/components/time-to-read/index.js.
+const AVERAGE_READING_RATE = 189;
+
+export default function getPageDetails( page ) {
+	if ( ! page ) {
+		return [];
+	}
+
+	const details = [
+		{
+			label: __( 'Status' ),
+			value: (
+				<StatusLabel
+					status={ page?.password ? 'protected' : page.status }
+					date={ page?.date }
+				/>
+			),
+		},
+		{
+			label: __( 'Slug' ),
+			value: <Truncate numberOfLines={ 1 }>{ page.slug }</Truncate>,
+		},
+	];
+
+	if ( page?.templateTitle ) {
+		details.push( {
+			label: __( 'Template' ),
+			value: page.templateTitle,
+		} );
+	}
+
+	details.push( {
+		label: __( 'Parent' ),
+		value: page?.parentTitle,
+	} );
+
+	/*
+	 * translators: If your word count is based on single characters (e.g. East Asian characters),
+	 * enter 'characters_excluding_spaces' or 'characters_including_spaces'. Otherwise, enter 'words'.
+	 * Do not translate into your own language.
+	 */
+	const wordCountType = _x( 'words', 'Word count type. Do not translate!' );
+	const wordsCounted = page?.content?.rendered
+		? wordCount( page.content.rendered, wordCountType )
+		: 0;
+	const readingTime = Math.round( wordsCounted / AVERAGE_READING_RATE );
+
+	if ( wordsCounted ) {
+		details.push(
+			{
+				label: __( 'Words' ),
+				value: wordsCounted.toLocaleString() || __( 'Unknown' ),
+			},
+			{
+				label: __( 'Time to read' ),
+				value:
+					readingTime > 1
+						? sprintf(
+								/* translators: %s: is the number of minutes. */
+								__( '%s mins' ),
+								readingTime.toLocaleString()
+						  )
+						: __( '< 1 min' ),
+			}
+		);
+	}
+	return details;
+}

--- a/packages/edit-site/src/components/sidebar-navigation-screen-page/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-page/index.js
@@ -6,7 +6,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { __, _x, sprintf } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { useDispatch, useSelect } from '@wordpress/data';
 import {
 	__experimentalUseNavigator as useNavigator,
@@ -22,7 +22,6 @@ import {
 import { decodeEntities } from '@wordpress/html-entities';
 import { pencil } from '@wordpress/icons';
 import { humanTimeDiff } from '@wordpress/date';
-import { count as wordCount } from '@wordpress/wordcount';
 import { createInterpolateElement } from '@wordpress/element';
 import { privateApis as privateEditorApis } from '@wordpress/editor';
 import { __unstableStripHTML as stripHTML } from '@wordpress/dom';
@@ -38,76 +37,7 @@ import SidebarButton from '../sidebar-button';
 import SidebarNavigationSubtitle from '../sidebar-navigation-subtitle';
 import SidebarDetails from '../sidebar-navigation-data-list';
 import DataListItem from '../sidebar-navigation-data-list/data-list-item';
-import StatusLabel from './status-label';
-
-// Taken from packages/editor/src/components/time-to-read/index.js.
-const AVERAGE_READING_RATE = 189;
-
-function getPageDetails( page ) {
-	if ( ! page ) {
-		return [];
-	}
-
-	const details = [
-		{
-			label: __( 'Status' ),
-			value: (
-				<StatusLabel
-					status={ page?.password ? 'protected' : page.status }
-					date={ page?.date }
-				/>
-			),
-		},
-		{
-			label: __( 'Slug' ),
-			value: <Truncate numberOfLines={ 1 }>{ page.slug }</Truncate>,
-		},
-	];
-
-	if ( page?.templateTitle ) {
-		details.push( {
-			label: __( 'Template' ),
-			value: page.templateTitle,
-		} );
-	}
-
-	details.push( {
-		label: __( 'Parent' ),
-		value: page?.parentTitle,
-	} );
-
-	/*
-	 * translators: If your word count is based on single characters (e.g. East Asian characters),
-	 * enter 'characters_excluding_spaces' or 'characters_including_spaces'. Otherwise, enter 'words'.
-	 * Do not translate into your own language.
-	 */
-	const wordCountType = _x( 'words', 'Word count type. Do not translate!' );
-	const wordsCounted = page?.content?.rendered
-		? wordCount( page.content.rendered, wordCountType )
-		: 0;
-	const readingTime = Math.round( wordsCounted / AVERAGE_READING_RATE );
-
-	if ( wordsCounted ) {
-		details.push(
-			{
-				label: __( 'Words' ),
-				value: wordsCounted.toLocaleString() || __( 'Unknown' ),
-			},
-			{
-				label: __( 'Time to read' ),
-				value:
-					readingTime > 1
-						? sprintf(
-								/* translators: %s: is the number of minutes. */
-								__( '%s mins' ),
-								readingTime.toLocaleString()
-						  )
-						: __( '< 1 min' ),
-			}
-		);
-	}
-	return details;
-}
+import getPageDetails from './get-page-details';
 
 export default function SidebarNavigationScreenPage() {
 	const { setCanvasMode } = unlock( useDispatch( editSiteStore ) );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Extracting `getPageDetails` function into a separate file.

Context: https://github.com/WordPress/gutenberg/pull/50767#discussion_r1206323684

## Why?
Organizational bliss.

## Testing Instructions

- Activate a block theme
- Make sure you have some pages ready to role. Add featured images, leave some scheduled too.
- Now head over to the site editor
- In the side bar, navigate to Design > Pages and click on the pages.
- Check that you can see each page's details (no regressions from https://github.com/WordPress/gutenberg/pull/50767)
