### PR TITLE
Library: Revert description change until new grid view lands

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen-templates/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-templates/index.js
@@ -43,7 +43,7 @@ const config = {
 			manage: __( 'Manage all template parts' ),
 			reusableBlocks: __( 'Manage reusable blocks' ),
 			description: __(
-				'Manage what patterns are available when editing your site.'
+				'Template Parts are small pieces of a layout that can be reused across multiple templates and always appear the same way. Common template parts include the site header, footer, or sidebar.'
 			),
 		},
 		sortCallback: ( items ) => {


### PR DESCRIPTION
Related:
- https://github.com/WordPress/gutenberg/pull/50769
- https://github.com/WordPress/gutenberg/issues/50028

## What?

Reverts the Library navigation screen's description back to what it was prior to https://github.com/WordPress/gutenberg/pull/50769.

## Why?

Until we land the changes that [display patterns, template parts, and reusable blocks on the Library page](https://github.com/WordPress/gutenberg/issues/50028) it could be misleading to reference patterns in this description.

## How?

Revert the text back.

## Testing Instructions

1. Visit `/wp-admin/site-editor.php?path=%2Fwp_template_part` 
2. Confirm the reverted description displays

## Screenshots or screencast <!-- if applicable -->


| Before | After |
|---|---|
| <img width="359" alt="Screenshot 2023-05-29 at 3 39 30 pm" src="https://github.com/WordPress/gutenberg/assets/60436221/cf64cc77-7f91-41b2-b76d-3962b075b9d7"> | <img width="358" alt="Screenshot 2023-05-29 at 3 39 56 pm" src="https://github.com/WordPress/gutenberg/assets/60436221/9ef16d1b-6f42-404e-a296-5e065ca39197"> |




