### PR TITLE
Try partially synced patterns via a template block

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -482,6 +482,36 @@ Show a block pattern. ([Source](https://github.com/WordPress/gutenberg/tree/trun
 -	**Supports:** ~~html~~, ~~inserter~~
 -	**Attributes:** slug, syncStatus
 
+## Pattern Template
+
+Create arrangements of blocks where the design is fixed, but content can be altered. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/pattern-template))
+
+-	**Name:** core/pattern-template
+-	**Experimental:** true
+-	**Category:** design
+-	**Supports:** ~~html~~, ~~inserter~~, ~~reusable~~
+-	**Attributes:** 
+
+## Pattern Template Content
+
+The content of a pattern template. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/pattern-template-content))
+
+-	**Name:** core/pattern-template-content
+-	**Experimental:** true
+-	**Category:** design
+-	**Supports:** ~~html~~, ~~inserter~~, ~~reusable~~
+-	**Attributes:** 
+
+## Pattern Template Token
+
+A token that can be inserted into a pattern template. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/pattern-template-token))
+
+-	**Name:** core/pattern-template-token
+-	**Experimental:** true
+-	**Category:** design
+-	**Supports:** ~~html~~, ~~inserter~~, ~~reusable~~
+-	**Attributes:** 
+
 ## Post Author
 
 Display post author details such as name, avatar, and bio. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/post-author))

--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -489,7 +489,7 @@ Create arrangements of blocks where the design is fixed, but content can be alte
 -	**Name:** core/pattern-template
 -	**Experimental:** true
 -	**Category:** design
--	**Supports:** ~~html~~, ~~inserter~~, ~~reusable~~
+-	**Supports:** ~~html~~, ~~reusable~~
 -	**Attributes:** 
 
 ## Pattern Template Content

--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -79,6 +79,7 @@ function gutenberg_reregister_core_block_types() {
 				'page-list.php'                    => 'core/page-list',
 				'page-list-item.php'               => 'core/page-list-item',
 				'pattern.php'                      => 'core/pattern',
+				'pattern-template.php'             => 'core/pattern-template',
 				'post-author.php'                  => 'core/post-author',
 				'post-author-name.php'             => 'core/post-author-name',
 				'post-author-biography.php'        => 'core/post-author-biography',

--- a/packages/block-library/src/index.js
+++ b/packages/block-library/src/index.js
@@ -67,6 +67,9 @@ import * as navigationLink from './navigation-link';
 import * as navigationSubmenu from './navigation-submenu';
 import * as nextpage from './nextpage';
 import * as pattern from './pattern';
+import * as patternTemplate from './pattern-template';
+import * as patternTemplateContent from './pattern-template-content';
+import * as patternTemplateToken from './pattern-template-token';
 import * as pageList from './page-list';
 import * as pageListItem from './page-list-item';
 import * as paragraph from './paragraph';
@@ -227,6 +230,11 @@ const getAllBlocks = () => {
 		queryTitle,
 		postAuthorBiography,
 	];
+	if ( window?.__experimentalEnablePatternEnhancements ) {
+		blocks.push( patternTemplate );
+		blocks.push( patternTemplateContent );
+		blocks.push( patternTemplateToken );
+	}
 	return blocks.filter( Boolean );
 };
 

--- a/packages/block-library/src/pattern-template-content/block.json
+++ b/packages/block-library/src/pattern-template-content/block.json
@@ -1,0 +1,17 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 2,
+	"__experimental": true,
+	"name": "core/pattern-template-content",
+	"title": "Pattern Template Content",
+	"category": "design",
+	"description": "The content of a pattern template.",
+	"textdomain": "default",
+	"attributes": {},
+	"supports": {
+		"__experimentalExposeControlsToChildren": true,
+		"inserter": false,
+		"html": false,
+		"reusable": false
+	}
+}

--- a/packages/block-library/src/pattern-template-content/edit.js
+++ b/packages/block-library/src/pattern-template-content/edit.js
@@ -1,0 +1,158 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	BlockControls,
+	useBlockProps,
+	useInnerBlocksProps,
+	privateApis as blockEditorPrivateApis,
+	store as blockEditorStore,
+} from '@wordpress/block-editor';
+import { createBlock } from '@wordpress/blocks';
+import { ToolbarButton } from '@wordpress/components';
+import { createHigherOrderComponent } from '@wordpress/compose';
+import { useDispatch, useRegistry, useSelect } from '@wordpress/data';
+import { addFilter } from '@wordpress/hooks';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { unlock } from '../private-apis';
+
+const { useBlockEditingMode } = unlock( blockEditorPrivateApis );
+
+const NON_CONVERTABLE_BLOCKS = [
+	'core/pattern-template-content',
+	'core/pattern-template-token',
+];
+
+export default function PatternTemplateContentEdit( { clientId } ) {
+	useBlockEditingMode( 'disabled' );
+	const registry = useRegistry();
+
+	const {
+		parentClientId,
+		selectedBlockIndex,
+		selectedBlockName,
+		selectedClientId,
+		selectedParentClientId,
+		tokenIndex,
+	} = useSelect(
+		( select ) => {
+			const {
+				getBlocksByClientId,
+				getBlockIndex,
+				getBlockName,
+				getClientIdsOfDescendants,
+				getBlockRootClientId,
+				getSelectedBlockClientId,
+			} = select( blockEditorStore );
+
+			const selectedBlockClientId = getSelectedBlockClientId();
+
+			// Find the index of this block compared to other token blocks.
+			const flattenedClientIds = getClientIdsOfDescendants( [
+				clientId,
+			] );
+			const tokenBlocks = getBlocksByClientId(
+				flattenedClientIds
+			).filter(
+				( { name, clientId: childClientId } ) =>
+					name === 'core/pattern-template-token' ||
+					childClientId === selectedBlockClientId
+			);
+			const tokenPosition = tokenBlocks.findIndex(
+				( { clientId: tokenClientId } ) =>
+					tokenClientId === selectedBlockClientId
+			);
+
+			return {
+				parentClientId: getBlockRootClientId( clientId ),
+				selectedBlockIndex: getBlockIndex( selectedBlockClientId ),
+				selectedClientId: selectedBlockClientId,
+				selectedBlockName: getBlockName( selectedBlockClientId ),
+				selectedParentClientId: getBlockRootClientId(
+					selectedBlockClientId
+				),
+				tokenIndex: Math.max( 0, tokenPosition ),
+			};
+		},
+		[ clientId ]
+	);
+
+	const { insertBlock, moveBlockToPosition } =
+		useDispatch( blockEditorStore );
+
+	const canConvertToToken =
+		! NON_CONVERTABLE_BLOCKS.includes( selectedBlockName );
+
+	// Show a 'convert' button on children, but not on this block.
+	const controls = canConvertToToken && (
+		<BlockControls group="block" __experimentalShareWithChildBlocks>
+			<ToolbarButton
+				onClick={ () => {
+					const token = createBlock( 'core/pattern-template-token' );
+					const updateSelection = false;
+					registry.batch( () => {
+						moveBlockToPosition(
+							selectedClientId,
+							selectedParentClientId,
+							parentClientId,
+							tokenIndex + 1
+						);
+						// TODO - determine if the move was successful before inserting the token.
+						insertBlock(
+							token,
+							selectedBlockIndex,
+							selectedParentClientId,
+							updateSelection
+						);
+					} );
+				} }
+			>
+				{ __( 'Convert to placeholder' ) }
+			</ToolbarButton>
+		</BlockControls>
+	);
+
+	const blockProps = useBlockProps();
+	const innerBlocksProps = useInnerBlocksProps( blockProps );
+
+	// TODO - render the compiled template.
+	return (
+		<>
+			{ controls }
+			<div { ...innerBlocksProps } />
+		</>
+	);
+}
+
+const withEnableTemplateContent = createHigherOrderComponent(
+	( BlockEdit ) => ( props ) => {
+		const mode = useSelect(
+			( select ) => {
+				// While the pattern template content block itself has blockEditingMode=disabled,
+				// the children should still be enabled. Set 'default' for any children.
+				if (
+					select( blockEditorStore ).getBlockParentsByBlockName(
+						props.clientId,
+						'core/pattern-template-content'
+					).length
+				) {
+					return 'default';
+				}
+			},
+			[ props.clientId ]
+		);
+		useBlockEditingMode( mode );
+		return <BlockEdit { ...props } />;
+	},
+	'withBlockEditingMode'
+);
+
+addFilter(
+	'editor.BlockEdit',
+	'core/block-library/pattern-template-content/enable-content-blocks',
+	withEnableTemplateContent
+);

--- a/packages/block-library/src/pattern-template-content/edit.js
+++ b/packages/block-library/src/pattern-template-content/edit.js
@@ -28,7 +28,7 @@ const NON_CONVERTABLE_BLOCKS = [
 ];
 
 export default function PatternTemplateContentEdit( { clientId } ) {
-	useBlockEditingMode( 'disabled' );
+	// useBlockEditingMode( 'disabled' );
 	const registry = useRegistry();
 
 	const {

--- a/packages/block-library/src/pattern-template-content/index.js
+++ b/packages/block-library/src/pattern-template-content/index.js
@@ -1,0 +1,15 @@
+/**
+ * Internal dependencies
+ */
+import initBlock from '../utils/init-block';
+import metadata from './block.json';
+import edit from './edit';
+
+const { name } = metadata;
+export { metadata, name };
+
+export const settings = {
+	edit,
+};
+
+export const init = () => initBlock( { name, metadata, settings } );

--- a/packages/block-library/src/pattern-template-content/index.js
+++ b/packages/block-library/src/pattern-template-content/index.js
@@ -4,12 +4,14 @@
 import initBlock from '../utils/init-block';
 import metadata from './block.json';
 import edit from './edit';
+import save from './save';
 
 const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
 	edit,
+	save,
 };
 
 export const init = () => initBlock( { name, metadata, settings } );

--- a/packages/block-library/src/pattern-template-content/save.js
+++ b/packages/block-library/src/pattern-template-content/save.js
@@ -1,0 +1,8 @@
+/**
+ * WordPress dependencies
+ */
+import { useInnerBlocksProps, useBlockProps } from '@wordpress/block-editor';
+
+export default function save() {
+	return <div { ...useInnerBlocksProps.save( useBlockProps.save() ) } />;
+}

--- a/packages/block-library/src/pattern-template-token/block.json
+++ b/packages/block-library/src/pattern-template-token/block.json
@@ -1,0 +1,16 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 2,
+	"__experimental": true,
+	"name": "core/pattern-template-token",
+	"title": "Pattern Template Token",
+	"category": "design",
+	"description": "A token that can be inserted into a pattern template.",
+	"textdomain": "default",
+	"attributes": {},
+	"supports": {
+		"inserter": false,
+		"html": false,
+		"reusable": false
+	}
+}

--- a/packages/block-library/src/pattern-template-token/edit.js
+++ b/packages/block-library/src/pattern-template-token/edit.js
@@ -1,0 +1,69 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	useBlockProps,
+	privateApis as blockEditorPrivateApis,
+	store as blockEditorStore,
+} from '@wordpress/block-editor';
+import { useSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { unlock } from '../private-apis';
+
+const { useBlockEditingMode } = unlock( blockEditorPrivateApis );
+
+export default function PatternTemplateTokenEdit( { clientId } ) {
+	useBlockEditingMode( 'disabled' );
+
+	const placeholderBlock = useSelect(
+		( select ) => {
+			const {
+				getBlocksByClientId,
+				getBlockParentsByBlockName,
+				getClientIdsOfDescendants,
+				getBlockOrder,
+				getBlock,
+			} = select( blockEditorStore );
+			const [ contentClientId ] = getBlockParentsByBlockName(
+				clientId,
+				'core/pattern-template-content',
+				true
+			);
+
+			// Find the index of this block compared to other token blocks.
+			const flattenedClientIds = getClientIdsOfDescendants( [
+				contentClientId,
+			] );
+			const tokenBlocks = getBlocksByClientId(
+				flattenedClientIds
+			).filter( ( { name } ) => name === 'core/pattern-template-token' );
+			const myPosition = tokenBlocks.findIndex(
+				( { clientId: tokenClientId } ) => tokenClientId === clientId
+			);
+
+			// Use the index of the token to get the placeholder block.
+			const [ templateClientId ] = getBlockParentsByBlockName(
+				clientId,
+				'core/pattern-template',
+				true
+			);
+			const [ , ...placeholderClientIds ] =
+				getBlockOrder( templateClientId );
+			const placeholderClientId = placeholderClientIds[ myPosition ];
+
+			return getBlock( placeholderClientId );
+		},
+		[ clientId ]
+	);
+
+	const blockProps = useBlockProps();
+
+	return (
+		<div { ...blockProps }>
+			{ `Token for ${ placeholderBlock?.name } (clientId: ${ placeholderBlock?.clientId })` }
+		</div>
+	);
+}

--- a/packages/block-library/src/pattern-template-token/index.js
+++ b/packages/block-library/src/pattern-template-token/index.js
@@ -1,0 +1,15 @@
+/**
+ * Internal dependencies
+ */
+import initBlock from '../utils/init-block';
+import metadata from './block.json';
+import edit from './edit';
+
+const { name } = metadata;
+export { metadata, name };
+
+export const settings = {
+	edit,
+};
+
+export const init = () => initBlock( { name, metadata, settings } );

--- a/packages/block-library/src/pattern-template/block.json
+++ b/packages/block-library/src/pattern-template/block.json
@@ -1,0 +1,16 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 2,
+	"__experimental": true,
+	"name": "core/pattern-template",
+	"title": "Pattern Template",
+	"category": "design",
+	"description": "Create arrangements of blocks where the design is fixed, but content can be altered.",
+	"textdomain": "default",
+	"attributes": {},
+	"supports": {
+		"inserter": false,
+		"html": false,
+		"reusable": false
+	}
+}

--- a/packages/block-library/src/pattern-template/block.json
+++ b/packages/block-library/src/pattern-template/block.json
@@ -9,7 +9,6 @@
 	"textdomain": "default",
 	"attributes": {},
 	"supports": {
-		"inserter": false,
 		"html": false,
 		"reusable": false
 	}

--- a/packages/block-library/src/pattern-template/edit.js
+++ b/packages/block-library/src/pattern-template/edit.js
@@ -14,7 +14,7 @@ const TEMPLATE = [
 			[
 				'core/buttons',
 				{},
-				[ [ 'core/button', { label: 'Click here!' } ] ],
+				[ [ 'core/button', { text: 'Click here!' } ] ],
 			],
 		],
 	],

--- a/packages/block-library/src/pattern-template/edit.js
+++ b/packages/block-library/src/pattern-template/edit.js
@@ -1,0 +1,31 @@
+/**
+ * WordPress dependencies
+ */
+import { useBlockProps, useInnerBlocksProps } from '@wordpress/block-editor';
+
+// This template is temporary, to make the block easier to test.
+const TEMPLATE = [
+	[
+		'core/pattern-template-content',
+		{},
+		[
+			[ 'core/heading', { content: 'Call to action.' } ],
+			[ 'core/paragraph', { content: 'Test paragraph.' } ],
+			[
+				'core/buttons',
+				{},
+				[ [ 'core/button', { label: 'Click here!' } ] ],
+			],
+		],
+	],
+];
+
+export default function PatternTemplateEdit() {
+	const blockProps = useBlockProps();
+	const innerBlocksProps = useInnerBlocksProps( blockProps, {
+		renderAppender: false,
+		template: TEMPLATE,
+	} );
+
+	return <div { ...innerBlocksProps } />;
+}

--- a/packages/block-library/src/pattern-template/index.js
+++ b/packages/block-library/src/pattern-template/index.js
@@ -1,0 +1,15 @@
+/**
+ * Internal dependencies
+ */
+import initBlock from '../utils/init-block';
+import metadata from './block.json';
+import edit from './edit';
+
+const { name } = metadata;
+export { metadata, name };
+
+export const settings = {
+	edit,
+};
+
+export const init = () => initBlock( { name, metadata, settings } );

--- a/packages/block-library/src/pattern-template/index.js
+++ b/packages/block-library/src/pattern-template/index.js
@@ -4,12 +4,14 @@
 import initBlock from '../utils/init-block';
 import metadata from './block.json';
 import edit from './edit';
+import save from './save';
 
 const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
 	edit,
+	save,
 };
 
 export const init = () => initBlock( { name, metadata, settings } );

--- a/packages/block-library/src/pattern-template/index.php
+++ b/packages/block-library/src/pattern-template/index.php
@@ -20,16 +20,16 @@ function register_block_core_pattern_template() {
 }
 
 /**
- * Replaces token blocks with the matching placeholder block.
+ * Inserts the corresponding 'value' block into the template when a token is encountered.
  *
- * @param WP_Block_List $content_block      The content inner blocks.
- * @param array         $placeholder_blocks The block's content.
+ * @param WP_Block_List $content_block The content inner blocks.
+ * @param array         $value_blocks  The value blocks to insert into the template.
  *
  * @return WP_Block_List The compiled block list.
  */
-function block_core_pattern_template_replace_content_tokens_with_placeholder_blocks( $content_block, $placeholder_blocks ) {
-	$content_blocks              = $content_block->inner_blocks;
-	static $placeholder_position = 0;
+function block_core_pattern_template_insert_value_blocks_into_content( $content_block, $value_blocks ) {
+	$content_blocks        = $content_block->inner_blocks;
+	static $token_position = 0;
 
 	// If there are no blocks, there's nothing to do.
 	if ( 0 === count( $content_blocks ) ) {
@@ -39,18 +39,71 @@ function block_core_pattern_template_replace_content_tokens_with_placeholder_blo
 	foreach ( $content_blocks as $index => $inner_block ) {
 		// Recurse and update any inner blocks of this block first.
 		if ( count( $inner_block->inner_blocks ) ) {
-			block_core_pattern_template_replace_content_tokens_with_placeholder_blocks( $inner_block, $placeholder_blocks );
+			block_core_pattern_template_insert_value_blocks_into_content( $inner_block, $value_blocks );
 		}
 
 		// If this is a token, replace it with the placeholder that's in this position.
 		if ( 'core/pattern-template-token' === $inner_block->name ) {
-			if ( isset( $placeholder_blocks[ $placeholder_position ] ) ) {
+			if ( isset( $value_blocks[ $token_position ] ) ) {
 				// TODO - it might be better to create a new inner blocks list instead of overwriting the existing one.
-				$content_blocks[ $index ] = $placeholder_blocks[ $placeholder_position ];
-				$placeholder_position     = $placeholder_position + 1;
+				$content_blocks[ $index ] = $value_blocks[ $token_position ];
+				$token_position           = $token_position + 1;
 			}
 		}
 	}
+}
+
+/**
+ * Finds a 'core/pattern-template-content' in a hierarchy of blocks.
+ *
+ * @param WP_Block[] $blocks A hierarchy of blocks.
+ *
+ * @return WP_Block The 'core/pattern-template-content' block found within the block hierarchy.
+ */
+function block_core_pattern_template_get_template_content( $blocks ) {
+	foreach ( $blocks as $block ) {
+		// If a template content block is found at this level return it.
+		if ( 'core/pattern-template-content' === $block->name ) {
+			return $block;
+		}
+
+		// If a nested template is found, search its inner blocks.
+		if ( 'core/pattern-template' === $block->name ) {
+			return block_core_pattern_template_get_template_content( $block->inner_blocks );
+		}
+	}
+}
+
+/**
+ * Produces a list of template 'value' blocks from a hierarchy of blocks.
+ *
+ * @param WP_Block[] $blocks A hierarchy of blocks.
+ *
+ * @return WP_Block[] An array of value blocks found within the block hierarchy.
+ */
+function block_core_pattern_template_get_template_values( $blocks ) {
+	$values = array();
+
+	// If a nested template block is found at this level recurse down and get the children values.
+	foreach ( $blocks as $block ) {
+		if ( 'core/pattern-template' !== $block->name ) {
+			$values = block_core_pattern_template_get_template_values( $block->inner_blocks );
+		}
+	}
+
+	// As the recursive function unwinds, it'll set the $values for the deepest template first,
+	// then override those with the values from the next level up, until finally it reaches the
+	// top-level, overriding with the top-most values.
+	$index = 0;
+	foreach ( $blocks as $block ) {
+		// If a template content block is found at this level return it.
+		if ( 'core/pattern-template-content' !== $block->name ) {
+			$values[ $index ] = $block;
+			$index            = $index + 1;
+		}
+	}
+
+	return $values;
 }
 
 /**
@@ -65,21 +118,11 @@ function block_core_pattern_template_replace_content_tokens_with_placeholder_blo
 function render_block_core_pattern_template( $attributes, $content, $block ) {
 	$inner_blocks = $block->inner_blocks;
 
-	$content_block       = null;
-	$placeholders_blocks = array();
-
-	foreach ( $inner_blocks as $inner_block ) {
-		if ( 'core/pattern-template-content' === $inner_block->name ) {
-			$content_block = $inner_block;
-		} else {
-			array_push( $placeholders_blocks, $inner_block );
-		}
-	}
-
-	block_core_pattern_template_replace_content_tokens_with_placeholder_blocks( $content_block, $placeholders_blocks );
+	$content_block = block_core_pattern_template_get_template_content( $inner_blocks );
+	$value_blocks  = block_core_pattern_template_get_template_values( $inner_blocks );
+	block_core_pattern_template_insert_value_blocks_into_content( $content_block, $value_blocks );
 
 	$compiled_content = '';
-
 	foreach ( $content_block->inner_blocks as $inner_block ) {
 		$compiled_content .= $inner_block->render();
 	}

--- a/packages/block-library/src/pattern-template/index.php
+++ b/packages/block-library/src/pattern-template/index.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * Server-side rendering of the `core/pattern` block.
+ *
+ * @package WordPress
+ */
+
+/**
+ *  Registers the `core/pattern` block on the server.
+ *
+ * @return void
+ */
+function register_block_core_pattern_template() {
+	register_block_type_from_metadata(
+		__DIR__ . '/pattern-template',
+		array(
+			'render_callback' => 'render_block_core_pattern_template',
+		)
+	);
+}
+
+/**
+ * Replaces token blocks with the matching placeholder block.
+ *
+ * @param WP_Block_List $content_blocks     The content inner blocks.
+ * @param array         $placeholder_blocks The block's content.
+ *
+ * @return WP_Block_List The compiled block list.
+ */
+function block_core_pattern_template_replace_content_tokens_with_placeholder_blocks( $content_block, $placeholder_blocks ) {
+	$content_blocks              = $content_block->inner_blocks;
+	static $placeholder_position = 0;
+
+	// If there are no blocks, there's nothing to do.
+	if ( 0 === count( $content_blocks ) ) {
+		return $content_blocks;
+	}
+
+	foreach ( $content_blocks as $index => $inner_block ) {
+		// Recurse and update any inner blocks of this block first.
+		if ( count( $inner_block->inner_blocks ) ) {
+			block_core_pattern_template_replace_content_tokens_with_placeholder_blocks( $inner_block, $placeholder_blocks );
+		}
+
+		// If this is a token, replace it with the placeholder that's in this position.
+		if ( 'core/pattern-template-token' === $inner_block->name ) {
+			if ( isset( $placeholder_blocks[ $placeholder_position ] ) ) {
+				// TODO - it might be better to create a new inner blocks list instead of overwriting the existing one.
+				$content_blocks[ $index ] = $placeholder_blocks[ $placeholder_position ];
+				$placeholder_position     = $placeholder_position + 1;
+			}
+		}
+	}
+}
+
+/**
+ * Renders the `core/pattern` block on the server.
+ *
+ * @param array $attributes Block attributes.
+ * @param array $content    The block's content.
+ * @param array $block      The WP_Block object.
+ *
+ * @return string Returns the output of the pattern template.
+ */
+function render_block_core_pattern_template( $attributes, $content, $block ) {
+	$inner_blocks = $block->inner_blocks;
+
+	$content_block       = null;
+	$placeholders_blocks = array();
+
+	foreach ( $inner_blocks as $inner_block ) {
+		if ( 'core/pattern-template-content' === $inner_block->name ) {
+			$content_block = $inner_block;
+		} else {
+			array_push( $placeholders_blocks, $inner_block );
+		}
+	}
+
+	block_core_pattern_template_replace_content_tokens_with_placeholder_blocks( $content_block, $placeholders_blocks );
+
+	$compiled_content = '';
+
+	foreach ( $content_block->inner_blocks as $inner_block ) {
+		$compiled_content .= $inner_block->render();
+	}
+
+	return $compiled_content;
+}
+
+add_action( 'init', 'register_block_core_pattern_template' );

--- a/packages/block-library/src/pattern-template/index.php
+++ b/packages/block-library/src/pattern-template/index.php
@@ -22,7 +22,7 @@ function register_block_core_pattern_template() {
 /**
  * Replaces token blocks with the matching placeholder block.
  *
- * @param WP_Block_List $content_blocks     The content inner blocks.
+ * @param WP_Block_List $content_block      The content inner blocks.
  * @param array         $placeholder_blocks The block's content.
  *
  * @return WP_Block_List The compiled block list.
@@ -56,9 +56,9 @@ function block_core_pattern_template_replace_content_tokens_with_placeholder_blo
 /**
  * Renders the `core/pattern` block on the server.
  *
- * @param array $attributes Block attributes.
- * @param array $content    The block's content.
- * @param array $block      The WP_Block object.
+ * @param array    $attributes Block attributes.
+ * @param string   $content    The block's content.
+ * @param WP_Block $block      The WP_Block object.
  *
  * @return string Returns the output of the pattern template.
  */

--- a/packages/block-library/src/pattern-template/save.js
+++ b/packages/block-library/src/pattern-template/save.js
@@ -1,0 +1,8 @@
+/**
+ * WordPress dependencies
+ */
+import { useInnerBlocksProps, useBlockProps } from '@wordpress/block-editor';
+
+export default function save() {
+	return <div { ...useInnerBlocksProps.save( useBlockProps.save() ) } />;
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
A possible first step towards developing the templating concept described in https://github.com/WordPress/gutenberg/discussions/50456#discussioncomment-5914331.

Introduces three new blocks:
- Pattern Template - a general templating wrapper block (name tbc, I tried to avoid only 'template', as it might be confused with templates/template parts).
- Pattern Template Content - the first inner block of Pattern Template, contains the 'format string'.
- Pattern Template Token - a block that represents a token in the content. Using a block type was the easiest way to get tokens in content working, but there might be other options worth exploring.

At the moment there isn't much functionality. You can select a child block of the template content and click a 'Convert to placeholder' button, which swaps the content with a token, which represents what a user might do when designing a pattern. You can also remove a token, which puts the placeholder back in place.

The block renders dynamically via PHP and swaps the tokens for the placeholder values.

Next steps:
- [x] Allow templates to be nested so that the placeholder values can be overridden.
- [ ] Improve the editor UI so that the user can edit in place
- [ ] Work out how to integrate this with reusable blocks

## Testing Instructions
1. Insert a Pattern Template block.
2. A CTA 'pattern' should appear. (this initial set of blocks is currently hard coded)
3. Select one of the inner blocks and click 'Convert to placeholder'.
4. Observe the block is replaced with a token.

## Screenshots or screencast <!-- if applicable -->
