### PR TITLE
DropdownMenu v2: Render in the default Popover.Slot

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Experimental
 
 -   `DropdownMenu` v2: Tweak styles ([#50967](https://github.com/WordPress/gutenberg/pull/50967)).
+-   `DropdownMenu` v2: Render in the default `Popover.Slot` ([#51046](https://github.com/WordPress/gutenberg/pull/51046)).
 
 
 ## 25.0.0 (2023-05-24)

--- a/packages/components/src/dropdown-menu-v2/index.tsx
+++ b/packages/components/src/dropdown-menu-v2/index.tsx
@@ -16,6 +16,7 @@ import { SVG, Circle } from '@wordpress/primitives';
  */
 import { useSlot } from '../slot-fill';
 import Icon from '../icon';
+import { SLOT_NAME as POPOVER_DEFAULT_SLOT_NAME } from '../popover';
 import * as DropdownMenuStyled from './styles';
 import type {
 	DropdownMenuProps,
@@ -59,10 +60,10 @@ export const DropdownMenu = ( {
 	// Render props
 	children,
 	trigger,
-	// Other props
-	slotName,
 }: DropdownMenuProps ) => {
-	const slot = useSlot( slotName );
+	// Render the portal in the default slot used by the legacy Popover component.
+	const slot = useSlot( POPOVER_DEFAULT_SLOT_NAME );
+	const portalContainer = slot.ref?.current;
 
 	return (
 		<DropdownMenuPrimitive.Root
@@ -75,7 +76,7 @@ export const DropdownMenu = ( {
 			<DropdownMenuPrimitive.Trigger asChild>
 				{ trigger }
 			</DropdownMenuPrimitive.Trigger>
-			<DropdownMenuPrimitive.Portal container={ slot.ref?.current }>
+			<DropdownMenuPrimitive.Portal container={ portalContainer }>
 				<DropdownMenuStyled.Content
 					side={ side }
 					align={ align }
@@ -84,7 +85,7 @@ export const DropdownMenu = ( {
 					loop={ true }
 				>
 					<DropdownMenuPrivateContext.Provider
-						value={ { portalContainer: slot.ref?.current } }
+						value={ { portalContainer } }
 					>
 						{ children }
 					</DropdownMenuPrivateContext.Provider>

--- a/packages/components/src/dropdown-menu-v2/index.tsx
+++ b/packages/components/src/dropdown-menu-v2/index.tsx
@@ -14,6 +14,7 @@ import { SVG, Circle } from '@wordpress/primitives';
 /**
  * Internal dependencies
  */
+import { useSlot } from '../slot-fill';
 import Icon from '../icon';
 import * as DropdownMenuStyled from './styles';
 import type {
@@ -52,7 +53,11 @@ export const DropdownMenu = ( {
 	// Render props
 	children,
 	trigger,
+	// Other props
+	slotName,
 }: DropdownMenuProps ) => {
+	const slot = useSlot( slotName );
+
 	return (
 		<DropdownMenuPrimitive.Root
 			defaultOpen={ defaultOpen }
@@ -64,7 +69,7 @@ export const DropdownMenu = ( {
 			<DropdownMenuPrimitive.Trigger asChild>
 				{ trigger }
 			</DropdownMenuPrimitive.Trigger>
-			<DropdownMenuPrimitive.Portal>
+			<DropdownMenuPrimitive.Portal container={ slot.ref?.current }>
 				<DropdownMenuStyled.Content
 					side={ side }
 					align={ align }

--- a/packages/components/src/dropdown-menu-v2/index.tsx
+++ b/packages/components/src/dropdown-menu-v2/index.tsx
@@ -6,7 +6,7 @@ import * as DropdownMenuPrimitive from '@radix-ui/react-dropdown-menu';
 /**
  * WordPress dependencies
  */
-import { forwardRef } from '@wordpress/element';
+import { forwardRef, createContext, useContext } from '@wordpress/element';
 import { isRTL } from '@wordpress/i18n';
 import { check, chevronRightSmall, lineSolid } from '@wordpress/icons';
 import { SVG, Circle } from '@wordpress/primitives';
@@ -34,6 +34,12 @@ import type {
 const SUB_MENU_OFFSET_SIDE = 12;
 // Opposite amount of the top padding of the menu item
 const SUB_MENU_OFFSET_ALIGN = -8;
+
+const DropdownMenuPrivateContext = createContext< {
+	portalContainer: HTMLElement | null;
+} >( {
+	portalContainer: null,
+} );
 
 /**
  * `DropdownMenu` displays a menu to the user (such as a set of actions
@@ -77,7 +83,11 @@ export const DropdownMenu = ( {
 					alignOffset={ alignOffset }
 					loop={ true }
 				>
-					{ children }
+					<DropdownMenuPrivateContext.Provider
+						value={ { portalContainer: slot.ref?.current } }
+					>
+						{ children }
+					</DropdownMenuPrivateContext.Provider>
 				</DropdownMenuStyled.Content>
 			</DropdownMenuPrimitive.Portal>
 		</DropdownMenuPrimitive.Root>
@@ -123,6 +133,8 @@ export const DropdownSubMenu = ( {
 	children,
 	trigger,
 }: DropdownSubMenuProps ) => {
+	const { portalContainer } = useContext( DropdownMenuPrivateContext );
+
 	return (
 		<DropdownMenuPrimitive.Sub
 			defaultOpen={ defaultOpen }
@@ -135,7 +147,7 @@ export const DropdownSubMenu = ( {
 			>
 				{ trigger }
 			</DropdownMenuStyled.SubTrigger>
-			<DropdownMenuPrimitive.Portal>
+			<DropdownMenuPrimitive.Portal container={ portalContainer }>
 				<DropdownMenuStyled.SubContent
 					loop
 					sideOffset={ SUB_MENU_OFFSET_SIDE }

--- a/packages/components/src/dropdown-menu-v2/stories/index.tsx
+++ b/packages/components/src/dropdown-menu-v2/stories/index.tsx
@@ -20,6 +20,8 @@ import {
 	DropdownSubMenuTrigger,
 } from '..';
 import Button from '../../button';
+import Popover from '../../popover';
+import { Provider as SlotFillProvider } from '../../slot-fill';
 
 /**
  * WordPress dependencies
@@ -31,6 +33,8 @@ import { menu, wordpress } from '@wordpress/icons';
  * Internal dependencies
  */
 import Icon from '../../icon';
+
+const SLOT_NAME = 'dropdown-storybook-popover-slot';
 
 const meta: ComponentMeta< typeof DropdownMenu > = {
 	title: 'Components (Experimental)/DropdownMenu v2',
@@ -127,7 +131,11 @@ const RadioItemsGroup = () => {
 };
 
 const Template: ComponentStory< typeof DropdownMenu > = ( props ) => (
-	<DropdownMenu { ...props } />
+	<SlotFillProvider>
+		{ /* @ts-expect-error Slot is not currently typed on Popover */ }
+		<Popover.Slot name={ SLOT_NAME } />
+		<DropdownMenu { ...props } />
+	</SlotFillProvider>
 );
 export const Default = Template.bind( {} );
 Default.args = {
@@ -190,4 +198,10 @@ Default.args = {
 			<RadioItemsGroup />
 		</>
 	),
+};
+
+export const WithCustomSlot = Template.bind( {} );
+WithCustomSlot.args = {
+	...Default.args,
+	slotName: SLOT_NAME,
 };

--- a/packages/components/src/dropdown-menu-v2/stories/index.tsx
+++ b/packages/components/src/dropdown-menu-v2/stories/index.tsx
@@ -34,8 +34,6 @@ import { menu, wordpress } from '@wordpress/icons';
  */
 import Icon from '../../icon';
 
-const SLOT_NAME = 'dropdown-storybook-popover-slot';
-
 const meta: ComponentMeta< typeof DropdownMenu > = {
 	title: 'Components (Experimental)/DropdownMenu v2',
 	component: DropdownMenu,
@@ -132,9 +130,9 @@ const RadioItemsGroup = () => {
 
 const Template: ComponentStory< typeof DropdownMenu > = ( props ) => (
 	<SlotFillProvider>
-		{ /* @ts-expect-error Slot is not currently typed on Popover */ }
-		<Popover.Slot name={ SLOT_NAME } />
 		<DropdownMenu { ...props } />
+		{ /* @ts-expect-error Slot is not currently typed on Popover */ }
+		<Popover.Slot />
 	</SlotFillProvider>
 );
 export const Default = Template.bind( {} );
@@ -198,10 +196,4 @@ Default.args = {
 			<RadioItemsGroup />
 		</>
 	),
-};
-
-export const WithCustomSlot = Template.bind( {} );
-WithCustomSlot.args = {
-	...Default.args,
-	slotName: SLOT_NAME,
 };

--- a/packages/components/src/dropdown-menu-v2/types.ts
+++ b/packages/components/src/dropdown-menu-v2/types.ts
@@ -61,6 +61,12 @@ export type DropdownMenuProps = {
 	 * The contents of the dropdown
 	 */
 	children: React.ReactNode;
+	/**
+	 * The name of the slot where the dropdown content should render.
+	 *
+	 * @default TODO
+	 */
+	slotName?: string;
 };
 
 export type DropdownSubMenuTriggerProps = {

--- a/packages/components/src/dropdown-menu-v2/types.ts
+++ b/packages/components/src/dropdown-menu-v2/types.ts
@@ -61,12 +61,6 @@ export type DropdownMenuProps = {
 	 * The contents of the dropdown
 	 */
 	children: React.ReactNode;
-	/**
-	 * The name of the slot where the dropdown content should render.
-	 *
-	 * @default TODO
-	 */
-	slotName?: string;
 };
 
 export type DropdownSubMenuTriggerProps = {

--- a/packages/components/src/popover/index.tsx
+++ b/packages/components/src/popover/index.tsx
@@ -74,7 +74,7 @@ import { overlayMiddlewares } from './overlay-middlewares';
  *
  * @type {string}
  */
-const SLOT_NAME = 'Popover';
+export const SLOT_NAME = 'Popover';
 
 // An SVG displaying a triangle facing down, filled with a solid
 // color and bordered in such a way to create an arrow-like effect.


### PR DESCRIPTION
Part of #50459

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Tweak the new `DropdownMenu`'s behavior so that, instead of appending its contents in the `document.body`, it renders by default in the `Popover.Slot` slot (thus behaving the same way as the legacy `DropdownMenu` component).

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

This is to integrate the new component better with how the editor expects its popover-based components to function.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

- Using the `useSlot` hook to get the reference to the actual DOM element
- Using the `Popover`'s default slot name
- Using React Context to share the DOM element between the main dropdown menu and its submenus


## Further considerations

We purposefully decided not to expose any new prop on `DropdownMenu` for now:

- we may do so only if / when it will be clear that changing the location of the portal is an actual need
- we are still investigating whether we'd like to expose a `slotName` prop (thus keeping  the integration with `SlotFill` an implementation detail of the component), or a `portalContainer` prop (thus making the component more generic and reusable also for consumers that don't necessarily rely on `SlotFill`)

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

Open the Storybook example, and verify that the contents of the dropdown menu (including its submenus) all render inside the `<div class="popover-slot" />` element.
