### PR TITLE
Edit Site: Add a loading timeout

### DIFF
--- a/packages/edit-site/src/components/layout/hooks.js
+++ b/packages/edit-site/src/components/layout/hooks.js
@@ -10,6 +10,8 @@ import { store as coreStore } from '@wordpress/core-data';
  */
 import useEditedEntityRecord from '../use-edited-entity-record';
 
+const MAX_LOADING_TIME = 30000; // 30 seconds
+
 export function useIsSiteEditorLoading() {
 	const { isLoaded: hasLoadedPost } = useEditedEntityRecord();
 	const [ loaded, setLoaded ] = useState( false );
@@ -21,6 +23,25 @@ export function useIsSiteEditorLoading() {
 		},
 		[ loaded ]
 	);
+
+	/*
+	 * If the maximum expected loading time has passed, we're marking the
+	 * editor as loaded, in order to prevent any failed requests from blocking
+	 * the editor canvas from appearing.
+	 */
+	useEffect( () => {
+		let timeout;
+
+		if ( ! loaded ) {
+			timeout = setTimeout( () => {
+				setLoaded( true );
+			}, MAX_LOADING_TIME );
+		}
+
+		return () => {
+			clearTimeout( timeout );
+		};
+	}, [ loaded ] );
 
 	useEffect( () => {
 		if ( inLoadingPause ) {

--- a/packages/edit-site/src/components/layout/hooks.js
+++ b/packages/edit-site/src/components/layout/hooks.js
@@ -10,7 +10,7 @@ import { store as coreStore } from '@wordpress/core-data';
  */
 import useEditedEntityRecord from '../use-edited-entity-record';
 
-const MAX_LOADING_TIME = 30000; // 30 seconds
+const MAX_LOADING_TIME = 10000; // 10 seconds
 
 export function useIsSiteEditorLoading() {
 	const { isLoaded: hasLoadedPost } = useEditedEntityRecord();


### PR DESCRIPTION
## What?
This PR adds an arbitrary timeout to the site editor loading experience we introduced in #50222, so if a request hangs, it won't block the entire editor frame canvas forever.

## Why?
While doing some production testing of the improved site editor loading experience, I noticed that if there's a failure during loading, it will block the editor loading and keep it in an infinite loading state.

The front-end of an app should not be blocked by a server-side error, therefore, after we consider we've timed out, we should re-enable the editor for interaction

## How?
We're adding an arbitrary ~30~10-second timeout, which should be more than enough time to load most of the site editor instances. I'm happy to alter that value if there are better suggestions.

cc @fullofcaffeine since we've been discussing this as one of the potential improvements we can make.

One additional improvement I think we can make is to add some error notices that appear when a request has failed. It could help the user understand what is going on. Maybe those notices could offer additional actions, like reloading the page or re-triggering the request. 

## Testing Instructions
* Open the site editor.
* Verify if keeps loading properly as it did before, and once it has been marked as loaded, everything has actually loaded.
* Add a `sleep(60)` to the `get_items()` method of one of the endpoints used in your theme - like `WP_REST_Block_Pattern_Categories_Controller` for example.
* Open the site editor.
* Verify that after ~30~10 seconds, the editor will be marked as loaded, even though the network request would still be pending.

### Testing Instructions for Keyboard
None

## Screenshots or screencast <!-- if applicable -->
Here's a preview of when I added `sleep(60)` to the `get_items()` method of `WP_REST_Block_Pattern_Categories_Controller`:

https://github.com/WordPress/gutenberg/assets/8436925/0c69a3dd-0371-478f-b068-44e416189d33

You can see that the editor appears after the timeout(~30~10 seconds), even though the block patterns are still loading.

Without such a long-loading request, the editor will continue loading as it did before.