### PR TITLE
Private actions and selectors: return stable references, expose to thunks

### DIFF
--- a/packages/data/src/factory.js
+++ b/packages/data/src/factory.js
@@ -47,7 +47,7 @@ export function createRegistrySelector( registrySelector ) {
 
 	/**
 	 * Flag indicating that the selector is a registry selector that needs the correct registry
-	 * reference to be assigned to `selecto.registry` to make it work correctly.
+	 * reference to be assigned to `selector.registry` to make it work correctly.
 	 * be mapped as a registry selector.
 	 *
 	 * @type {boolean}

--- a/packages/data/src/redux-store/index.js
+++ b/packages/data/src/redux-store/index.js
@@ -248,6 +248,13 @@ export default function createReduxStore( key, options ) {
 			}
 
 			const boundPrivateSelectors = createBindingCache( bindSelector );
+
+			// Pre-bind the private selectors that have been registered by the time of
+			// instantiation, so that registry selectors are bound to the registry.
+			for ( const privateSelector of Object.values( privateSelectors ) ) {
+				boundPrivateSelectors.get( privateSelector );
+			}
+
 			const allSelectors = new Proxy( () => {}, {
 				get: ( target, prop ) => {
 					const privateSelector = privateSelectors[ prop ];

--- a/packages/data/src/test/privateAPIs.js
+++ b/packages/data/src/test/privateAPIs.js
@@ -208,18 +208,21 @@ describe( 'Private data APIs', () => {
 			const otherStore = createReduxStore( 'other', {
 				reducer: ( state = {} ) => state,
 			} );
-			registry.register( otherStore );
 			unlock( otherStore ).registerPrivateSelectors( {
 				getPrice: createRegistrySelector(
 					( select ) => () => select( groceryStore ).getPublicPrice()
 				),
 			} );
+			registry.register( otherStore );
 			const privateSelectors = unlock( registry.select( otherStore ) );
 			expect( privateSelectors.getPrice() ).toEqual( 1000 );
 		} );
 
 		it( 'should support calling a private registry selector from a public selector', () => {
 			const groceryStore = createStore();
+			const getPriceWithShipping = createRegistrySelector(
+				( select ) => () => select( groceryStore ).getPublicPrice() + 5
+			);
 			const store = createReduxStore( 'a', {
 				reducer: ( state = {} ) => state,
 				selectors: {
@@ -227,13 +230,10 @@ describe( 'Private data APIs', () => {
 						getPriceWithShipping( state ) * 1.1,
 				},
 			} );
-			registry.register( store );
-			const getPriceWithShipping = createRegistrySelector(
-				( select ) => () => select( groceryStore ).getPublicPrice() + 5
-			);
 			unlock( store ).registerPrivateSelectors( {
 				getPriceWithShipping,
 			} );
+			registry.register( store );
 			expect(
 				registry.select( store ).getPriceWithShippingAndTax()
 			).toEqual( 1105.5 );

--- a/packages/data/src/test/privateAPIs.js
+++ b/packages/data/src/test/privateAPIs.js
@@ -147,6 +147,16 @@ describe( 'Private data APIs', () => {
 			expect( unlockedSelectors.getPublicPrice() ).toEqual( 1000 );
 		} );
 
+		it( 'should return stable references to selectors', () => {
+			const groceryStore = createStore();
+			unlock( groceryStore ).registerPrivateSelectors( {
+				getSecretDiscount,
+			} );
+			const select = unlock( registry.select( groceryStore ) );
+			expect( select.getPublicPrice ).toBe( select.getPublicPrice );
+			expect( select.getSecretDiscount ).toBe( select.getSecretDiscount );
+		} );
+
 		it( 'should support registerStore', () => {
 			const groceryStore = registry.registerStore(
 				storeName,
@@ -261,6 +271,16 @@ describe( 'Private data APIs', () => {
 			expect(
 				registry.select( groceryStore ).getState().secretDiscount
 			).toEqual( 400 );
+		} );
+
+		it( 'should return stable references to actions', () => {
+			const groceryStore = createStore();
+			unlock( groceryStore ).registerPrivateActions( {
+				setSecretDiscount,
+			} );
+			const disp = unlock( registry.dispatch( groceryStore ) );
+			expect( disp.setPublicPrice ).toBe( disp.setPublicPrice );
+			expect( disp.setSecretDiscount ).toBe( disp.setSecretDiscount );
 		} );
 
 		it( 'should dispatch public actions on the unlocked store', () => {


### PR DESCRIPTION
Solves two problems with private actions and selectors:
- makes sure that `const { setFoo } = unlock( useDispatch() )` always returns the same `setFoo` on each call, and analogously also for `useSelect`. This wasn't true before, as the private actions and selectors were re-bound on each call of the `dispatch` getter. Action references are sometimes used as effect dependencies, with possibly disastrous consequences if they are not constant.
- exposes unlocked `dispatch` and `select` objects (proxies) to thunks. Thunks are considered private code of the store, and should have access to all private APIs.

The PR contains a larger exploratory refactor of how the actions and selectors are bound to the store, best to review commit by commit.