### PR TITLE
Add template actions in site editor navigation sidebar

### DIFF
--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -180,12 +180,7 @@ export default function Editor( { isLoading } ) {
 									'is-loading': isLoading,
 								}
 							) }
-							notices={
-								( isEditMode ||
-									window?.__experimentalEnableThemePreviews ) && (
-									<EditorSnackbars />
-								)
-							}
+							notices={ <EditorSnackbars /> }
 							content={
 								<>
 									<GlobalStylesRenderer />

--- a/packages/edit-site/src/components/editor/style.scss
+++ b/packages/edit-site/src/components/editor/style.scss
@@ -20,7 +20,7 @@
 
 // Adjust the position of the notices
 .edit-site .components-editor-notices__snackbar {
-	position: fixed;
+	position: absolute;
 	right: 0;
 	bottom: 40px;
 	padding-left: 16px;

--- a/packages/edit-site/src/components/list/table.js
+++ b/packages/edit-site/src/components/list/table.js
@@ -127,7 +127,8 @@ export default function Table( { templateType } ) {
 						</td>
 						<td className="edit-site-list-table-column" role="cell">
 							<TemplateActions
-								template={ template }
+								postType={ template.type }
+								postId={ template.id }
 								className="edit-site-list-table__actions"
 							/>
 						</td>

--- a/packages/edit-site/src/components/list/table.js
+++ b/packages/edit-site/src/components/list/table.js
@@ -13,8 +13,8 @@ import { decodeEntities } from '@wordpress/html-entities';
 /**
  * Internal dependencies
  */
+import TemplateActions from '../template-actions';
 import Link from '../routes/link';
-import Actions from './actions';
 import AddedBy from './added-by';
 
 export default function Table( { templateType } ) {
@@ -126,7 +126,10 @@ export default function Table( { templateType } ) {
 							) : null }
 						</td>
 						<td className="edit-site-list-table-column" role="cell">
-							<Actions template={ template } />
+							<TemplateActions
+								template={ template }
+								className="edit-site-list-table__actions"
+							/>
 						</td>
 					</tr>
 				) ) }

--- a/packages/edit-site/src/components/sidebar-navigation-screen-template/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-template/index.js
@@ -19,6 +19,7 @@ import { unlock } from '../../private-apis';
 import { store as editSiteStore } from '../../store';
 import SidebarButton from '../sidebar-button';
 import { useAddedBy } from '../list/added-by';
+import TemplateActions from '../template-actions';
 
 function useTemplateTitleAndDescription( postType, postId ) {
 	const { getDescription, getTitle, record } = useEditedEntityRecord(
@@ -83,14 +84,16 @@ function useTemplateTitleAndDescription( postType, postId ) {
 		</>
 	);
 
-	return { title, description };
+	return { title, description, template: record };
 }
 
 export default function SidebarNavigationScreenTemplate() {
-	const { params } = useNavigator();
-	const { postType, postId } = params;
+	const navigator = useNavigator();
+	const {
+		params: { postType, postId },
+	} = navigator;
 	const { setCanvasMode } = unlock( useDispatch( editSiteStore ) );
-	const { title, description } = useTemplateTitleAndDescription(
+	const { title, description, template } = useTemplateTitleAndDescription(
 		postType,
 		postId
 	);
@@ -99,11 +102,20 @@ export default function SidebarNavigationScreenTemplate() {
 		<SidebarNavigationScreen
 			title={ title }
 			actions={
-				<SidebarButton
-					onClick={ () => setCanvasMode( 'edit' ) }
-					label={ __( 'Edit' ) }
-					icon={ pencil }
-				/>
+				<div>
+					<TemplateActions
+						template={ template }
+						toggleProps={ { as: SidebarButton } }
+						onRemove={ () => {
+							navigator.goTo( `/${ postType }/all` );
+						} }
+					/>
+					<SidebarButton
+						onClick={ () => setCanvasMode( 'edit' ) }
+						label={ __( 'Edit' ) }
+						icon={ pencil }
+					/>
+				</div>
 			}
 			description={ description }
 		/>

--- a/packages/edit-site/src/components/sidebar-navigation-screen-template/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-template/index.js
@@ -84,7 +84,7 @@ function useTemplateTitleAndDescription( postType, postId ) {
 		</>
 	);
 
-	return { title, description, template: record };
+	return { title, description };
 }
 
 export default function SidebarNavigationScreenTemplate() {
@@ -93,7 +93,7 @@ export default function SidebarNavigationScreenTemplate() {
 		params: { postType, postId },
 	} = navigator;
 	const { setCanvasMode } = unlock( useDispatch( editSiteStore ) );
-	const { title, description, template } = useTemplateTitleAndDescription(
+	const { title, description } = useTemplateTitleAndDescription(
 		postType,
 		postId
 	);
@@ -104,7 +104,8 @@ export default function SidebarNavigationScreenTemplate() {
 			actions={
 				<div>
 					<TemplateActions
-						template={ template }
+						postType={ postType }
+						postId={ postId }
 						toggleProps={ { as: SidebarButton } }
 						onRemove={ () => {
 							navigator.goTo( `/${ postType }/all` );

--- a/packages/edit-site/src/components/template-actions/index.js
+++ b/packages/edit-site/src/components/template-actions/index.js
@@ -11,12 +11,17 @@ import { store as noticesStore } from '@wordpress/notices';
 /**
  * Internal dependencies
  */
-import { store as editSiteStore } from '../../../store';
-import isTemplateRemovable from '../../../utils/is-template-removable';
-import isTemplateRevertable from '../../../utils/is-template-revertable';
+import { store as editSiteStore } from '../../store';
+import isTemplateRemovable from '../../utils/is-template-removable';
+import isTemplateRevertable from '../../utils/is-template-revertable';
 import RenameMenuItem from './rename-menu-item';
 
-export default function Actions( { template } ) {
+export default function TemplateActions( {
+	template,
+	className,
+	toggleProps,
+	onRemove,
+} ) {
 	const { removeTemplate, revertTemplate } = useDispatch( editSiteStore );
 	const { saveEditedEntityRecord } = useDispatch( coreStore );
 	const { createSuccessNotice, createErrorNotice } =
@@ -62,7 +67,8 @@ export default function Actions( { template } ) {
 		<DropdownMenu
 			icon={ moreVertical }
 			label={ __( 'Actions' ) }
-			className="edit-site-list-table__actions"
+			className={ className }
+			toggleProps={ toggleProps }
 		>
 			{ ( { onClose } ) => (
 				<MenuGroup>
@@ -77,6 +83,7 @@ export default function Actions( { template } ) {
 								isTertiary
 								onClick={ () => {
 									removeTemplate( template );
+									onRemove?.();
 									onClose();
 								} }
 							>

--- a/packages/edit-site/src/components/template-actions/index.js
+++ b/packages/edit-site/src/components/template-actions/index.js
@@ -46,7 +46,7 @@ export default function TemplateActions( {
 				sprintf(
 					/* translators: The template/part's name. */
 					__( '"%s" reverted.' ),
-					template.title.rendered
+					template.title.rendered || template.title
 				),
 				{
 					type: 'snackbar',

--- a/packages/edit-site/src/components/template-actions/index.js
+++ b/packages/edit-site/src/components/template-actions/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useDispatch } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 import { __, sprintf } from '@wordpress/i18n';
 import { DropdownMenu, MenuGroup, MenuItem } from '@wordpress/components';
@@ -17,11 +17,17 @@ import isTemplateRevertable from '../../utils/is-template-revertable';
 import RenameMenuItem from './rename-menu-item';
 
 export default function TemplateActions( {
-	template,
+	postType,
+	postId,
 	className,
 	toggleProps,
 	onRemove,
 } ) {
+	const template = useSelect(
+		( select ) =>
+			select( coreStore ).getEntityRecord( 'postType', postType, postId ),
+		[ postType, postId ]
+	);
 	const { removeTemplate, revertTemplate } = useDispatch( editSiteStore );
 	const { saveEditedEntityRecord } = useDispatch( coreStore );
 	const { createSuccessNotice, createErrorNotice } =
@@ -46,7 +52,7 @@ export default function TemplateActions( {
 				sprintf(
 					/* translators: The template/part's name. */
 					__( '"%s" reverted.' ),
-					template.title.rendered || template.title
+					template.title.rendered
 				),
 				{
 					type: 'snackbar',

--- a/packages/edit-site/src/components/template-actions/rename-menu-item.js
+++ b/packages/edit-site/src/components/template-actions/rename-menu-item.js
@@ -16,7 +16,9 @@ import { store as coreStore } from '@wordpress/core-data';
 import { store as noticesStore } from '@wordpress/notices';
 
 export default function RenameMenuItem( { template, onClose } ) {
-	const [ title, setTitle ] = useState( () => template.title.rendered );
+	const [ title, setTitle ] = useState(
+		() => template.title?.rendered || template.title
+	);
 	const [ isModalOpen, setIsModalOpen ] = useState( false );
 
 	const { editEntityRecord, saveEditedEntityRecord } =
@@ -67,7 +69,7 @@ export default function RenameMenuItem( { template, onClose } ) {
 			<MenuItem
 				onClick={ () => {
 					setIsModalOpen( true );
-					setTitle( template.title.rendered );
+					setTitle( template.title?.rendered || template.title );
 				} }
 			>
 				{ __( 'Rename' ) }

--- a/packages/edit-site/src/components/template-actions/rename-menu-item.js
+++ b/packages/edit-site/src/components/template-actions/rename-menu-item.js
@@ -16,9 +16,7 @@ import { store as coreStore } from '@wordpress/core-data';
 import { store as noticesStore } from '@wordpress/notices';
 
 export default function RenameMenuItem( { template, onClose } ) {
-	const [ title, setTitle ] = useState(
-		() => template.title?.rendered || template.title
-	);
+	const [ title, setTitle ] = useState( () => template.title.rendered );
 	const [ isModalOpen, setIsModalOpen ] = useState( false );
 
 	const { editEntityRecord, saveEditedEntityRecord } =
@@ -69,7 +67,7 @@ export default function RenameMenuItem( { template, onClose } ) {
 			<MenuItem
 				onClick={ () => {
 					setIsModalOpen( true );
-					setTitle( template.title?.rendered || template.title );
+					setTitle( template.title.rendered );
 				} }
 			>
 				{ __( 'Rename' ) }

--- a/packages/edit-site/src/store/actions.js
+++ b/packages/edit-site/src/store/actions.js
@@ -144,7 +144,7 @@ export const removeTemplate =
 				sprintf(
 					/* translators: The template/part's name. */
 					__( '"%s" deleted.' ),
-					template.title.rendered
+					template.title?.rendered || template.title
 				),
 				{ type: 'snackbar', id: 'site-editor-template-deleted-success' }
 			);

--- a/packages/edit-site/src/store/actions.js
+++ b/packages/edit-site/src/store/actions.js
@@ -12,6 +12,7 @@ import { store as interfaceStore } from '@wordpress/interface';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 import { speak } from '@wordpress/a11y';
 import { store as preferencesStore } from '@wordpress/preferences';
+import { decodeEntities } from '@wordpress/html-entities';
 
 /**
  * Internal dependencies
@@ -144,7 +145,7 @@ export const removeTemplate =
 				sprintf(
 					/* translators: The template/part's name. */
 					__( '"%s" deleted.' ),
-					template.title?.rendered || template.title
+					decodeEntities( template.title.rendered )
 				),
 				{ type: 'snackbar', id: 'site-editor-template-deleted-success' }
 			);


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Part of: https://github.com/WordPress/gutenberg/issues/50379

This PR adds the template and template part actions regarding:
1. Rename/Delete for for user-generated ones(custom)
2. Clear customizations - for theme templates that have been customised
<!-- In a few words, what is the PR actually doing? -->

## Notes

There is a problem we need to solve regarding the `snackbar` notices. Currently we show them only in [edit mode](https://github.com/WordPress/gutenberg/blob/trunk/packages/edit-site/src/components/editor/index.js#L183). This is also related to my initial redirection on deletion to the list of templates/template types, as they [show them](https://github.com/WordPress/gutenberg/blob/trunk/packages/edit-site/src/components/list/index.js#L68).

What this means is the notices handling here is incomplete because the renaming actions and the rest that will be needed(delete page, etc..) are not shown in view mode. So it needs this issue [solved](https://github.com/WordPress/gutenberg/issues/50175), which had an exploration but got reverted. 


## Testing Instructions in site editor
1. At a custom template or template part observe the `Actions` drop down menu and try the actions
2. At a theme template that have been customized,  observe the `Actions` drop down menu and try the actions


## Screenshots or screencast <!-- if applicable -->


https://github.com/WordPress/gutenberg/assets/16275880/fe35467e-82e9-4773-9a92-b46501da21e9


