### PR TITLE
Change label and description for the `gutenberg-interactivity-api-core-blocks` experiments setting.

### DIFF
--- a/lib/experiments-page.php
+++ b/lib/experiments-page.php
@@ -91,12 +91,12 @@ function gutenberg_initialize_experiments_settings() {
 
 	add_settings_field(
 		'gutenberg-interactivity-api-core-blocks',
-		__( 'Core blocks', 'gutenberg' ),
+		__( 'Interactivity API and Behaviors UI', 'gutenberg' ),
 		'gutenberg_display_experiment_field',
 		'gutenberg-experiments',
 		'gutenberg_experiments_section',
 		array(
-			'label' => __( 'Test the core blocks using the Interactivity API', 'gutenberg' ),
+			'label' => __( 'Use the Interactivity API in File, Navigation and Image core blocks. It also enables the <a href="https://github.com/WordPress/gutenberg/issues/50029">Behaviors UI</a> in the Image block.', 'gutenberg' ),
 			'id'    => 'gutenberg-interactivity-api-core-blocks',
 		)
 	);


### PR DESCRIPTION
## Why?
The previous label and description were not descriptive enough. They also did not mention that enabling this option enables the Behaviors UI in the Image block.

## Screenshots or screencast

<img width="1026" alt="Screenshot 2023-05-29 at 17 11 57" src="https://github.com/WordPress/gutenberg/assets/5417266/0607e358-290b-4967-afa3-cd79ca555e43">
