### PR TITLE
Improve image block lightbox escaping

### DIFF
--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -68,7 +68,7 @@ function render_block_core_image( $attributes, $content ) {
 								'</div>';
 		$body_content = preg_replace( '/<img[^>]+>/', $button, $content );
 
-		$background_color  = wp_get_global_styles( array( 'color', 'background' ) );
+		$background_color  = esc_attr( wp_get_global_styles( array( 'color', 'background' ) ) );
 		$close_button_icon = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="30" height="30" aria-hidden="true" focusable="false"><path d="M13 11.8l6.1-6.3-1-1-6.1 6.2-6.1-6.2-1 1 6.1 6.3-6.5 6.7 1 1 6.5-6.6 6.5 6.6 1-1z"></path></svg>';
 
 		$dialog_label = $alt_attribute ? esc_attr( $alt_attribute ) : esc_attr__( 'Image' );

--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -71,9 +71,9 @@ function render_block_core_image( $attributes, $content ) {
 		$background_color  = wp_get_global_styles( array( 'color', 'background' ) );
 		$close_button_icon = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="30" height="30" aria-hidden="true" focusable="false"><path d="M13 11.8l6.1-6.3-1-1-6.1 6.2-6.1-6.2-1 1 6.1 6.3-6.5 6.7 1 1 6.5-6.6 6.5 6.6 1-1z"></path></svg>';
 
-		$dialog_label = $alt_attribute ? $alt_attribute : __( 'Image' );
+		$dialog_label = $alt_attribute ? esc_attr( $alt_attribute ) : esc_attr__( 'Image' );
 
-		$close_button_label = __( 'Close' );
+		$close_button_label = esc_attr__( 'Close' );
 
 		return
 			<<<HTML


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Improve the image block lightbox escaping.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The functionality can be broken by using some special characters in the image alt.

Example:

https://github.com/WordPress/gutenberg/assets/252415/80cdb3bd-e5c5-49d7-9041-290c7114e7a0


## How?

Escaping all attributes.

## Testing Instructions

1. in the admin, enable Gutenberg > Experiments > Core Blocks
2. Add an image to a post, use `<html>` in the alt text.
3. Test enabling and disabling the lightbox using the image's Advanced panel
4. View the post
5. Click on the image
6. Confirm that the lightbox is opened.
