### PR TITLE
Bug fix: Add duotone class to lightbox experiment

### DIFF
--- a/lib/class-wp-duotone-gutenberg.php
+++ b/lib/class-wp-duotone-gutenberg.php
@@ -881,7 +881,12 @@ class WP_Duotone_Gutenberg {
 
 		// Like the layout hook, this assumes the hook only applies to blocks with a single wrapper.
 		$tags = new WP_HTML_Tag_Processor( $block_content );
-		if ( $tags->next_tag() ) {
+		while ( $tags->next_tag(
+			array(
+				'tag_name'   => 'figure',
+				'class_name' => 'wp-block-image',
+			)
+		) ) {
 			$tags->add_class( $filter_id );
 		}
 

--- a/lib/class-wp-duotone-gutenberg.php
+++ b/lib/class-wp-duotone-gutenberg.php
@@ -881,12 +881,7 @@ class WP_Duotone_Gutenberg {
 
 		// Like the layout hook, this assumes the hook only applies to blocks with a single wrapper.
 		$tags = new WP_HTML_Tag_Processor( $block_content );
-		while ( $tags->next_tag(
-			array(
-				'tag_name'   => 'figure',
-				'class_name' => 'wp-block-image',
-			)
-		) ) {
+		if ( $tags->next_tag() ) {
 			$tags->add_class( $filter_id );
 		}
 

--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -62,7 +62,7 @@ function render_block_core_image( $attributes, $content ) {
 		$w = new WP_HTML_Tag_Processor( $content );
 		$w->next_tag(
 			array(
-				'tag_name'   => 'figure',
+				'tag_name' => 'figure',
 			)
 		);
 		$w->add_class( 'wp-lightbox-container' );
@@ -82,7 +82,7 @@ function render_block_core_image( $attributes, $content ) {
 		$background_color  = esc_attr( wp_get_global_styles( array( 'color', 'background' ) ) );
 		$close_button_icon = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="30" height="30" aria-hidden="true" focusable="false"><path d="M13 11.8l6.1-6.3-1-1-6.1 6.2-6.1-6.2-1 1 6.1 6.3-6.5 6.7 1 1 6.5-6.6 6.5 6.6 1-1z"></path></svg>';
 
-		$dialog_label = $alt_attribute ? esc_attr( $alt_attribute ) : esc_attr__( 'Image' );
+		$dialog_label       = $alt_attribute ? esc_attr( $alt_attribute ) : esc_attr__( 'Image' );
 		$close_button_label = esc_attr__( 'Close' );
 
 		$lightbox_html = <<<HTML

--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -59,6 +59,17 @@ function render_block_core_image( $attributes, $content ) {
 		}
 		$content = $processor->get_updated_html();
 
+		$w = new WP_HTML_Tag_Processor( $content );
+		$w->next_tag(
+			array(
+				'tag_name'   => 'figure',
+			)
+		);
+		$w->add_class( 'wp-lightbox-container' );
+		$w->set_attribute( 'data-wp-island', '' );
+		$w->set_attribute( 'data-wp-context', '{ "core": { "image": { "initialized": false, "lightboxEnabled": false } } }' );
+		$content = $w->get_updated_html();
+
 		// Wrap the image in the body content with a button.
 		$img = null;
 		preg_match( '/<img[^>]+>/', $content, $img );
@@ -72,35 +83,30 @@ function render_block_core_image( $attributes, $content ) {
 		$close_button_icon = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="30" height="30" aria-hidden="true" focusable="false"><path d="M13 11.8l6.1-6.3-1-1-6.1 6.2-6.1-6.2-1 1 6.1 6.3-6.5 6.7 1 1 6.5-6.6 6.5 6.6 1-1z"></path></svg>';
 
 		$dialog_label = $alt_attribute ? esc_attr( $alt_attribute ) : esc_attr__( 'Image' );
-
 		$close_button_label = esc_attr__( 'Close' );
 
-		return
-			<<<HTML
-				<div class="wp-lightbox-container"
-					data-wp-island
-					data-wp-context='{ "core": { "image": { "initialized": false, "lightboxEnabled": false } } }'>
-						$body_content
-						<div data-wp-body="" class="wp-lightbox-overlay"
-							data-wp-bind.role="selectors.core.image.roleAttribute"
-							aria-label="$dialog_label"
-							data-wp-class.initialized="context.core.image.initialized"
-							data-wp-class.active="context.core.image.lightboxEnabled"
-							data-wp-bind.aria-hidden="!context.core.image.lightboxEnabled"
-							data-wp-bind.aria-modal="context.core.image.lightboxEnabled"
-							data-wp-effect="effects.core.image.initLightbox"
-							data-wp-on.keydown="actions.core.image.handleKeydown"
-							data-wp-on.mousewheel="actions.core.image.hideLightbox"
-							data-wp-on.click="actions.core.image.hideLightbox"
-							>
-								<button type="button" aria-label="$close_button_label" class="close-button" data-wp-on.click="actions.core.image.hideLightbox">
-									$close_button_icon
-								</button>
-								$content
-								<div class="scrim" style="background-color: $background_color"></div>
-						</div>
-				</div>
+		$lightbox_html = <<<HTML
+			<div data-wp-body="" class="wp-lightbox-overlay"
+				data-wp-bind.role="selectors.core.image.roleAttribute"
+				aria-label="$dialog_label"
+				data-wp-class.initialized="context.core.image.initialized"
+				data-wp-class.active="context.core.image.lightboxEnabled"
+				data-wp-bind.aria-hidden="!context.core.image.lightboxEnabled"
+				data-wp-bind.aria-modal="context.core.image.lightboxEnabled"
+				data-wp-effect="effects.core.image.initLightbox"
+				data-wp-on.keydown="actions.core.image.handleKeydown"
+				data-wp-on.mousewheel="actions.core.image.hideLightbox"
+				data-wp-on.click="actions.core.image.hideLightbox"
+				>
+					<button type="button" aria-label="$close_button_label" class="close-button" data-wp-on.click="actions.core.image.hideLightbox">
+						$close_button_icon
+					</button>
+					$content
+					<div class="scrim" style="background-color: $background_color"></div>
+			</div>
 HTML;
+
+		return preg_replace( '/<\/figure>/', $lightbox_html . '</figure>', $body_content );
 	}
 
 	return $processor->get_updated_html();


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Addresses #50973 

Fixes a bug wherein duotone filters were not being applied to images with the lightbox behavior enabled

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Basic functionality should work for image when the lightbox is activated


## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Rather than putting the duotone class on the parent tag of the block in question, it loops through the elements and adds the class to the `<figure>` elements.

Note: This uses @SantosGuillamot's suggested code from the [following comment](https://github.com/WordPress/gutenberg/issues/50973#issuecomment-1567280396) on the related issue.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
1. Enable Gutenberg > Experiments > Core Blocks in the admin
2. Add an image to a post
3. Enable the lightbox by enabling Advanced > Behaviors > Lightbox in the block settings
4. Add a duotone via Styles > Filters > Duotone in the block settings
5. Publish and view the post to see the duotone has been applied to the image
6. Click on the image to open the lightbox and ensure the duotone has been applied there as well

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
N/A