### PR TITLE
Add gettext content when translating 'Header'.

### DIFF
--- a/packages/interface/src/components/interface-skeleton/index.js
+++ b/packages/interface/src/components/interface-skeleton/index.js
@@ -59,7 +59,7 @@ function InterfaceSkeleton(
 
 	const defaultLabels = {
 		/* translators: accessibility text for the top bar landmark region. */
-		header: __( 'Header' ),
+		header: _x( 'Header', 'header landmark area' ),
 		/* translators: accessibility text for the content landmark region. */
 		body: __( 'Content' ),
 		/* translators: accessibility text for the secondary sidebar landmark region. */

--- a/packages/interface/src/components/interface-skeleton/index.js
+++ b/packages/interface/src/components/interface-skeleton/index.js
@@ -11,7 +11,7 @@ import {
 	__unstableUseNavigateRegions as useNavigateRegions,
 	__unstableMotion as motion,
 } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import { useMergeRefs } from '@wordpress/compose';
 
 /**


### PR DESCRIPTION
Fixes #51063.

## What?
Use _x() with appropriate context when translating the word 'Header'. 

## Why?
The word 'Header' appears in different context in both Gutenberg and core, which makes it hard to translate.

## How?
Add context to translatable strings when the context requires different translations.

## Testing Instructions
Not sure about that, couldn't find information on how Gutenberg translation files are generated.
