### PR TITLE
Docs: Fix formatting and use sentence case for titles in Scripts doc.

### DIFF
--- a/docs/contributors/code/scripts.md
+++ b/docs/contributors/code/scripts.md
@@ -2,7 +2,7 @@
 
 The editor provides several vendor and internal scripts to plugin developers. Script names, handles, and descriptions are documented in the table below.
 
-## WP Scripts
+## WordPress scripts
 
 The editor includes a number of packages to enable various pieces of functionality. Plugin developers can utilize them to create blocks, editor plugins, or generic plugins.
 
@@ -40,7 +40,7 @@ The editor includes a number of packages to enable various pieces of functionali
 | [Viewport](/packages/viewport/README.md)                                                     | wp-viewport                           | Module for responding to changes in the browser viewport size                                                                                                 |
 | [Wordcount](/packages/wordcount/README.md)                                                   | wp-wordcount                          | WordPress word count utility                                                                                                                                  |
 
-## Vendor Scripts
+## Vendor scripts
 
 The editor also uses some popular third-party packages and scripts. Plugin developers can use these scripts as well without bundling them in their code (and increasing file sizes).
 
@@ -51,9 +51,10 @@ The editor also uses some popular third-party packages and scripts. Plugin devel
 | [Moment](https://momentjs.com/)                      | moment    | Parse, validate, manipulate, and display dates and times in JavaScript                                |
 | [Lodash](https://lodash.com)                         | lodash    | Lodash is a JavaScript library which provides utility functions for common programming tasks          |
 
-## Polyfill Scripts
+## Polyfill scripts
 
 The editor also provides polyfills for certain features that may not be available in all modern browsers.
+
 It is recommended to use the main `wp-polyfill` script handle which takes care of loading all the below mentioned polyfills.
 
 | Script Name                                                               | Handle                      | Description                                                                                          |
@@ -67,12 +68,6 @@ It is recommended to use the main `wp-polyfill` script handle which takes care o
 
 ## Bundling and code sharing
 
-When using a JavaScript bundler like [webpack](https://webpack.js.org/), the scripts mentioned here
-can be excluded from the bundle and provided by WordPress in the form of script dependencies [see
-`wp_enqueue_script`](https://developer.wordpress.org/reference/functions/wp_enqueue_script/#default-scripts-included-and-registered-by-wordpress).
+When using a JavaScript bundler like [webpack](https://webpack.js.org/), the scripts mentioned here can be excluded from the bundle and provided by WordPress in the form of script dependencies see [`wp_enqueue_script`](https://developer.wordpress.org/reference/functions/wp_enqueue_script/#default-scripts-included-and-registered-by-wordpress).
 
-The
-[`@wordpress/dependency-extraction-webpack-plugin`](https://github.com/WordPress/gutenberg/tree/HEAD/packages/dependency-extraction-webpack-plugin)
-provides a webpack plugin to help extract WordPress dependencies from bundles. `@wordpress/scripts`
-[`build`](https://github.com/WordPress/gutenberg/tree/HEAD/packages/scripts#build) script includes
-the plugin by default.
+The [`@wordpress/dependency-extraction-webpack-plugin`](https://github.com/WordPress/gutenberg/tree/HEAD/packages/dependency-extraction-webpack-plugin) provides a webpack plugin to help extract WordPress dependencies from bundles. The `@wordpress/scripts` [`build`](https://github.com/WordPress/gutenberg/tree/HEAD/packages/scripts#build) script includes the plugin by default.


### PR DESCRIPTION
## What? Why? How?
This PR fixes a few minor formatting issues in the [Scripts](https://developer.wordpress.org/block-editor/contributors/code/scripts/) doc caused by unneeded line breaks. While I was at it, I also changed the titles to sentence case.

_(Note the content of the doc also needs some updating, but I'll save that for a more expansive PR.)_
