### PR TITLE
Docs: Fix code example error in the Curating the Editor doc.

### DIFF
--- a/docs/how-to-guides/curating-the-editor-experience.md
+++ b/docs/how-to-guides/curating-the-editor-experience.md
@@ -343,7 +343,7 @@ addFilter(
 	'blockEditor.useSetting.before',
 	'example/useSetting.before',
 	( settingValue, settingName, clientId, blockName ) => {
-		if ( blockName === Media & Text block'core/column' && settingName === 'spacing.units' ) {
+		if ( blockName === 'core/column' && settingName === 'spacing.units' ) {
 			return [ 'px' ];
 		}
 		return settingValue;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What? Why? How?
This PR fixes an error in the [code example](https://developer.wordpress.org/block-editor/how-to-guides/curating-the-editor-experience/#limiting-interface-options-with-client-side-filters) for client-side filters. It looks like it was a copy/paste error that slipped through the review process. 
