### PR TITLE
Site editor: update untitled copy and rendering

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen-page/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-page/index.js
@@ -145,9 +145,9 @@ export default function SidebarNavigationScreenPage() {
 				: null;
 
 			if ( _parentTitle?.title ) {
-				_parentTitle = _parentTitle.title?.rendered
-					? decodeEntities( _parentTitle.title.rendered )
-					: __( 'Untitled' );
+				_parentTitle = decodeEntities(
+					_parentTitle.title?.rendered || __( '(no title)' )
+				);
 			} else {
 				_parentTitle = __( 'Top level' );
 			}
@@ -181,7 +181,9 @@ export default function SidebarNavigationScreenPage() {
 
 	return record ? (
 		<SidebarNavigationScreen
-			title={ decodeEntities( record?.title?.rendered ) }
+			title={ decodeEntities(
+				record?.title?.rendered || __( '(no title)' )
+			) }
 			actions={
 				<SidebarButton
 					onClick={ () => setCanvasMode( 'edit' ) }
@@ -218,8 +220,9 @@ export default function SidebarNavigationScreenPage() {
 										altText
 											? decodeEntities( altText )
 											: decodeEntities(
-													record.title?.rendered
-											  ) || __( 'Featured image' )
+													record.title?.rendered ||
+														__( 'Featured image' )
+											  )
 									}
 									src={ mediaSourceUrl }
 								/>

--- a/packages/edit-site/src/components/sidebar-navigation-screen-pages/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-pages/index.js
@@ -111,8 +111,9 @@ export default function SidebarNavigationScreenPages() {
 								>
 									<Truncate numberOfLines={ 1 }>
 										{ decodeEntities(
-											homeTemplate.title?.rendered
-										) ?? __( '(no title)' ) }
+											homeTemplate.title?.rendered ||
+												__( '(no title)' )
+										) }
 									</Truncate>
 								</PageItem>
 							) }
@@ -137,8 +138,9 @@ export default function SidebarNavigationScreenPages() {
 									>
 										<Truncate numberOfLines={ 1 }>
 											{ decodeEntities(
-												item.title?.rendered
-											) ?? __( '(no title)' ) }
+												item?.title?.rendered ||
+													__( '(no title)' )
+											) }
 										</Truncate>
 									</PageItem>
 								);
@@ -154,8 +156,9 @@ export default function SidebarNavigationScreenPages() {
 									>
 										<Truncate numberOfLines={ 1 }>
 											{ decodeEntities(
-												item.title?.rendered
-											) ?? __( '(no title)' ) }
+												item.title?.rendered ||
+													__( '(no title)' )
+											) }
 										</Truncate>
 									</PageItem>
 								) ) }


### PR DESCRIPTION
## What?
- Updates Untitled copy to be consistent with pages view `"Untitled"` to `"(no title)"`
- Uses logical OR operator `'||'` to check for rendered titles run through `decodeEntities()`

## Why?
We can't perform nullish coalescing (??) checks on `decodeEntities()` to verify falsy values because `decodeEntities()`  will return an empty string if it encounters one. `record.title?.rendered` contains an empty string.

`??` returns the right-hand side operand if the left operand is `null` or `undefined` only.

## Testing Instructions
1. Using a block theme like Twenty Twenty Three, create a new page with content but no title.
2. Head over to the site editor (`wp-admin/site-editor.php`) and select the "Pages"
3. Check that the untitled page's title appears as `"(no title)"`
4. Select the untitled page and verify that `"(no title)"` displays


## Screenshots or screencast <!-- if applicable -->

| Before | After |
| ------------- | ------------- |
| <img width="351" alt="Screenshot 2023-05-30 at 12 50 09 pm" src="https://github.com/WordPress/gutenberg/assets/6458278/b70566e1-d528-4b12-9efb-f99cf00aebb5">  | <img width="350" alt="Screenshot 2023-05-30 at 12 59 22 pm" src="https://github.com/WordPress/gutenberg/assets/6458278/01642dfe-2e20-4212-bad0-c3352cdcc80f">  |
| <img width="350" alt="Screenshot 2023-05-30 at 12 50 16 pm" src="https://github.com/WordPress/gutenberg/assets/6458278/6f533375-f218-416d-bc41-b713befd6a0b">  | <img width="348" alt="Screenshot 2023-05-30 at 12 59 28 pm" src="https://github.com/WordPress/gutenberg/assets/6458278/99f70bd0-ab47-4cc0-ba2e-a1e7a57fb86a">  |





