### PR TITLE
[RNMobile] Fix Gallery v1 caption selector

### DIFF
--- a/packages/block-library/src/gallery/v1/save.js
+++ b/packages/block-library/src/gallery/v1/save.js
@@ -70,7 +70,7 @@ export default function saveV1( { attributes } ) {
 									<RichText.Content
 										tagName="figcaption"
 										className={ classnames(
-											'blocks-gallery-item',
+											'blocks-gallery-item__caption',
 											__experimentalGetElementClassName(
 												'caption'
 											)


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes an issue on mobile with Gallery block v1 when a caption is added to an image. Gallery block v2 behavior is not affected. 

H/T @mkevins for collaborating on this fix. 🎉 

## Why?
When a caption is added to an image in a v1 Gallery, the caption's class selector is `blocks-gallery-item`, which causes the caption to be interpreted as a second gallery item on mobile, as `blocks-gallery-item` is the selector for gallery items. The caption's class name should be `blocks-gallery-item__caption`, which correctly attributes the caption as a caption when parsed, and also matches the web behavior for the v1 Gallery block.

Fixes:
- https://github.com/wordpress-mobile/WordPress-Android/issues/17712
- https://github.com/WordPress/gutenberg/issues/47782

## How?
Updates the image caption class name from `block-gallery-item` to `block-gallery-item__caption`.

```
{ ! RichText.isEmpty( image.caption ) && (
	<RichText.Content
		tagName="figcaption"
		className={ classnames(
			'blocks-gallery-item__caption',
			__experimentalGetElementClassName(
				'caption'
			)
		) }
		value={ image.caption }
	/>
) }
```

Gallery block v1 HTML generated from **web** (hint: scroll to the end to note differences):
```
<!-- wp:gallery {"ids":[24],"linkTo":"none"} -->
<figure class="wp-block-gallery columns-1 is-cropped"><ul class="blocks-gallery-grid"><li class="blocks-gallery-item"><figure><img src="https://insufficient-octopus.jurassic.ninja/wp-content/uploads/2023/05/102874968_gettyimages-856084532.jpg" alt="" data-id="24" data-full-url="https://insufficient-octopus.jurassic.ninja/wp-content/uploads/2023/05/102874968_gettyimages-856084532.jpg" data-link="https://insufficient-octopus.jurassic.ninja/?attachment_id=24" class="wp-image-24"/><figcaption class="blocks-gallery-item__caption">Caption Caption</figcaption></figure></li></ul></figure>
<!-- /wp:gallery -->
```

Gallery block v1 HTML generated from **mobile** (**without** the change included in this PR):

```
<!-- wp:gallery {"ids":[24],"linkTo":"none","className":"columns-1"} -->
<figure class="wp-block-gallery columns-1 is-cropped"><ul class="blocks-gallery-grid"><li class="blocks-gallery-item"><figure><img src="https://insufficient-octopus.jurassic.ninja/wp-content/uploads/2023/05/102874968_gettyimages-856084532.jpg" alt="" data-id="24" class="wp-image-24"/><figcaption class="blocks-gallery-item wp-element-caption">Caption Caption</figcaption></figure></li></ul></figure>
<!-- /wp:gallery -->
```

Gallery block v1 HTML generated from **mobile** (**with** the change included in this PR):
```
<!-- wp:gallery {"ids":[24],"linkTo":"none"} -->
<figure class="wp-block-gallery columns-1 is-cropped"><ul class="blocks-gallery-grid"><li class="blocks-gallery-item"><figure><img src="https://insufficient-octopus.jurassic.ninja/wp-content/uploads/2023/05/102874968_gettyimages-856084532.jpg" alt="" data-id="24" class="wp-image-24"/><figcaption class="blocks-gallery-item__caption wp-element-caption">Caption <br>Caption</figcaption></figure></li></ul></figure>
<!-- /wp:gallery -->
```

Note: the extra `wp-element-caption` class in the mobile examples is used for testing, referenced in the commit messages of https://github.com/WordPress/gutenberg/pull/41140.

It's also important to note that the web version of Gallery block v1 is using the correct caption selector, `block-gallery-item__caption`. Without further investigation, it is unclear how this was handled in web, which apparently is bypassing the code that was changed in this file, but breaks in mobile. Perhaps @scruffian can provide more insight how the caption class is generated for Gallery block v1 web.

Also to note: as this change only affects the deprecated Gallery block v1, what (if any) additional test coverage should we consider adding, besides manual testing?

## Testing Instructions
0. Ensure you are using a self-hosted site that will invoke the v1 Gallery block. You can do this by using v11.8.3 of the Gutenberg plugin. You can also verify by checking the generated HTML. Gallery block v1 will use [`figure` + `ul` + `li` + `image`], and Gallery block v2 will use [`figure` + `image`].
1. Create a post.
2. Add a Gallery and add a caption to the **image**.
3. Save post as Draft, and re-open post.
4. Observe Gallery does not report a block recovery message, and that the caption still exists. 


## Screenshots or screencast <!-- if applicable -->

Before | After
-|-
<video src="https://user-images.githubusercontent.com/643285/227e311d-9bfc-43bc-a07a-fbdaa9b39ef0.mov"/> | <video src="https://user-images.githubusercontent.com/643285/dbdcef44-1f23-4b13-bfd6-7d8f0a8bea3f.mov"/>

