### PR TITLE
Add inert attribute to disabled blocks that have only disabled descendants

### DIFF
--- a/packages/block-editor/src/components/block-list/use-block-props/index.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/index.js
@@ -36,6 +36,7 @@ import { useBlockRefProvider } from './use-block-refs';
 import { useIntersectionObserver } from './use-intersection-observer';
 import { store as blockEditorStore } from '../../../store';
 import useBlockOverlayActive from '../../block-content-overlay';
+import { unlock } from '../../../lock-unlock';
 
 /**
  * If the block count exceeds the threshold, we disable the reordering animation
@@ -75,6 +76,7 @@ export function useBlockProps( props = {}, { __unstableIsHtml } = {} ) {
 		isPartOfSelection,
 		adjustScrolling,
 		enableAnimation,
+		isSubtreeDisabled,
 	} = useSelect(
 		( select ) => {
 			const {
@@ -88,7 +90,8 @@ export function useBlockProps( props = {}, { __unstableIsHtml } = {} ) {
 				isBlockMultiSelected,
 				isAncestorMultiSelected,
 				isFirstMultiSelectedBlock,
-			} = select( blockEditorStore );
+				isBlockSubtreeDisabled,
+			} = unlock( select( blockEditorStore ) );
 			const { getActiveBlockVariation } = select( blocksStore );
 			const isSelected = isBlockSelected( clientId );
 			const isPartOfMultiSelection =
@@ -111,6 +114,7 @@ export function useBlockProps( props = {}, { __unstableIsHtml } = {} ) {
 				enableAnimation:
 					! isTyping() &&
 					getGlobalBlockCount() <= BLOCK_ANIMATION_THRESHOLD,
+				isSubtreeDisabled: isBlockSubtreeDisabled( clientId ),
 			};
 		},
 		[ clientId ]
@@ -158,6 +162,7 @@ export function useBlockProps( props = {}, { __unstableIsHtml } = {} ) {
 		'data-block': clientId,
 		'data-type': name,
 		'data-title': blockTitle,
+		inert: isSubtreeDisabled ? 'true' : undefined,
 		className: classnames(
 			// The wp-block className is important for editor styles.
 			classnames( 'block-editor-block-list__block', {

--- a/packages/block-editor/src/store/private-selectors.js
+++ b/packages/block-editor/src/store/private-selectors.js
@@ -75,7 +75,7 @@ export function getLastInsertedBlocksClientIds( state ) {
 export const getBlockEditingMode = createRegistrySelector(
 	( select ) =>
 		( state, clientId = '' ) => {
-			const explicitEditingMode = getExplcitBlockEditingMode(
+			const explicitEditingMode = getExplicitBlockEditingMode(
 				state,
 				clientId
 			);
@@ -102,7 +102,7 @@ export const getBlockEditingMode = createRegistrySelector(
 		}
 );
 
-const getExplcitBlockEditingMode = createSelector(
+const getExplicitBlockEditingMode = createSelector(
 	( state, clientId = '' ) => {
 		while (
 			! state.blockEditingModes.has( clientId ) &&
@@ -136,7 +136,7 @@ export const isBlockSubtreeDisabled = createSelector(
 			);
 		};
 		return (
-			getExplcitBlockEditingMode( state, clientId ) === 'disabled' &&
+			getExplicitBlockEditingMode( state, clientId ) === 'disabled' &&
 			getBlockOrder( state, clientId ).every( isChildSubtreeDisabled )
 		);
 	},

--- a/packages/block-editor/src/store/test/private-selectors.js
+++ b/packages/block-editor/src/store/test/private-selectors.js
@@ -5,6 +5,7 @@ import {
 	isBlockInterfaceHidden,
 	getLastInsertedBlocksClientIds,
 	getBlockEditingMode,
+	isBlockSubtreeDisabled,
 } from '../private-selectors';
 
 describe( 'private selectors', () => {
@@ -51,7 +52,7 @@ describe( 'private selectors', () => {
 		} );
 	} );
 
-	describe( 'getBlockEditingMode', () => {
+	describe( 'block editing mode selectors', () => {
 		const baseState = {
 			settings: {},
 			blocks: {
@@ -62,6 +63,27 @@ describe( 'private selectors', () => {
 					[ '9b9c5c3f-2e46-4f02-9e14-9fe9515b958f', {} ], // |  Post Content
 					[ 'b3247f75-fd94-4fef-97f9-5bfd162cc416', {} ], // | |  Paragraph
 					[ 'e178812d-ce5e-48c7-a945-8ae4ffcbbb7c', {} ], // | |  Paragraph
+				] ),
+				order: new Map( [
+					[ '', [ '6cf70164-9097-4460-bcbf-200560546988' ] ],
+					[ '6cf70164-9097-4460-bcbf-200560546988', [] ],
+					[
+						'ef45d5fd-5234-4fd5-ac4f-c3736c7f9337',
+						[
+							'b26fc763-417d-4f01-b81c-2ec61e14a972',
+							'9b9c5c3f-2e46-4f02-9e14-9fe9515b958f',
+						],
+					],
+					[ 'b26fc763-417d-4f01-b81c-2ec61e14a972', [] ],
+					[
+						'9b9c5c3f-2e46-4f02-9e14-9fe9515b958f',
+						[
+							'b3247f75-fd94-4fef-97f9-5bfd162cc416',
+							'e178812d-ce5e-48c7-a945-8ae4ffcbbb7c',
+						],
+					],
+					[ 'b3247f75-fd94-4fef-97f9-5bfd162cc416', [] ],
+					[ 'e178812d-ce5e-48c7-a945-8ae4ffcbbb7c', [] ],
 				] ),
 				parents: new Map( [
 					[ '6cf70164-9097-4460-bcbf-200560546988', '' ],
@@ -91,120 +113,222 @@ describe( 'private selectors', () => {
 			blockEditingModes: new Map( [] ),
 		};
 
-		const __experimentalHasContentRoleAttribute = jest.fn( () => false );
-		getBlockEditingMode.registry = {
-			select: jest.fn( () => ( {
-				__experimentalHasContentRoleAttribute,
-			} ) ),
-		};
-
-		it( 'should return default by default', () => {
-			expect(
-				getBlockEditingMode(
-					baseState,
-					'b3247f75-fd94-4fef-97f9-5bfd162cc416'
-				)
-			).toBe( 'default' );
-		} );
-
-		[ 'disabled', 'contentOnly' ].forEach( ( mode ) => {
-			it( `should return ${ mode } if explicitly set`, () => {
-				const state = {
-					...baseState,
-					blockEditingModes: new Map( [
-						[ 'b3247f75-fd94-4fef-97f9-5bfd162cc416', mode ],
-					] ),
-				};
-				expect(
-					getBlockEditingMode(
-						state,
-						'b3247f75-fd94-4fef-97f9-5bfd162cc416'
-					)
-				).toBe( mode );
-			} );
-
-			it( `should return ${ mode } if explicitly set on a parent`, () => {
-				const state = {
-					...baseState,
-					blockEditingModes: new Map( [
-						[ 'ef45d5fd-5234-4fd5-ac4f-c3736c7f9337', mode ],
-					] ),
-				};
-				expect(
-					getBlockEditingMode(
-						state,
-						'b3247f75-fd94-4fef-97f9-5bfd162cc416'
-					)
-				).toBe( mode );
-			} );
-
-			it( `should return ${ mode } if overridden by a parent`, () => {
-				const state = {
-					...baseState,
-					blockEditingModes: new Map( [
-						[ '', mode ],
-						[ 'ef45d5fd-5234-4fd5-ac4f-c3736c7f9337', 'default' ],
-						[ '9b9c5c3f-2e46-4f02-9e14-9fe9515b958f', mode ],
-					] ),
-				};
-				expect(
-					getBlockEditingMode(
-						state,
-						'b3247f75-fd94-4fef-97f9-5bfd162cc416'
-					)
-				).toBe( mode );
-			} );
-
-			it( `should return ${ mode } if explicitly set on root`, () => {
-				const state = {
-					...baseState,
-					blockEditingModes: new Map( [ [ '', mode ] ] ),
-				};
-				expect(
-					getBlockEditingMode(
-						state,
-						'b3247f75-fd94-4fef-97f9-5bfd162cc416'
-					)
-				).toBe( mode );
-			} );
-		} );
-
-		it( 'should return disabled if parent is locked and the block has no content role', () => {
-			const state = {
-				...baseState,
-				blockListSettings: {
-					...baseState.blockListSettings,
-					'9b9c5c3f-2e46-4f02-9e14-9fe9515b958f': {
-						templateLock: 'contentOnly',
-					},
-				},
+		describe( 'getBlockEditingMode', () => {
+			const __experimentalHasContentRoleAttribute = jest.fn(
+				() => false
+			);
+			getBlockEditingMode.registry = {
+				select: jest.fn( () => ( {
+					__experimentalHasContentRoleAttribute,
+				} ) ),
 			};
-			__experimentalHasContentRoleAttribute.mockReturnValueOnce( false );
-			expect(
-				getBlockEditingMode(
-					state,
-					'b3247f75-fd94-4fef-97f9-5bfd162cc416'
-				)
-			).toBe( 'disabled' );
+
+			it( 'should return default by default', () => {
+				expect(
+					getBlockEditingMode(
+						baseState,
+						'b3247f75-fd94-4fef-97f9-5bfd162cc416'
+					)
+				).toBe( 'default' );
+			} );
+
+			[ 'disabled', 'contentOnly' ].forEach( ( mode ) => {
+				it( `should return ${ mode } if explicitly set`, () => {
+					const state = {
+						...baseState,
+						blockEditingModes: new Map( [
+							[ 'b3247f75-fd94-4fef-97f9-5bfd162cc416', mode ],
+						] ),
+					};
+					expect(
+						getBlockEditingMode(
+							state,
+							'b3247f75-fd94-4fef-97f9-5bfd162cc416'
+						)
+					).toBe( mode );
+				} );
+
+				it( `should return ${ mode } if explicitly set on a parent`, () => {
+					const state = {
+						...baseState,
+						blockEditingModes: new Map( [
+							[ 'ef45d5fd-5234-4fd5-ac4f-c3736c7f9337', mode ],
+						] ),
+					};
+					expect(
+						getBlockEditingMode(
+							state,
+							'b3247f75-fd94-4fef-97f9-5bfd162cc416'
+						)
+					).toBe( mode );
+				} );
+
+				it( `should return ${ mode } if overridden by a parent`, () => {
+					const state = {
+						...baseState,
+						blockEditingModes: new Map( [
+							[ '', mode ],
+							[
+								'ef45d5fd-5234-4fd5-ac4f-c3736c7f9337',
+								'default',
+							],
+							[ '9b9c5c3f-2e46-4f02-9e14-9fe9515b958f', mode ],
+						] ),
+					};
+					expect(
+						getBlockEditingMode(
+							state,
+							'b3247f75-fd94-4fef-97f9-5bfd162cc416'
+						)
+					).toBe( mode );
+				} );
+
+				it( `should return ${ mode } if explicitly set on root`, () => {
+					const state = {
+						...baseState,
+						blockEditingModes: new Map( [ [ '', mode ] ] ),
+					};
+					expect(
+						getBlockEditingMode(
+							state,
+							'b3247f75-fd94-4fef-97f9-5bfd162cc416'
+						)
+					).toBe( mode );
+				} );
+			} );
+
+			it( 'should return disabled if parent is locked and the block has no content role', () => {
+				const state = {
+					...baseState,
+					blockListSettings: {
+						...baseState.blockListSettings,
+						'9b9c5c3f-2e46-4f02-9e14-9fe9515b958f': {
+							templateLock: 'contentOnly',
+						},
+					},
+				};
+				__experimentalHasContentRoleAttribute.mockReturnValueOnce(
+					false
+				);
+				expect(
+					getBlockEditingMode(
+						state,
+						'b3247f75-fd94-4fef-97f9-5bfd162cc416'
+					)
+				).toBe( 'disabled' );
+			} );
+
+			it( 'should return contentOnly if parent is locked and the block has a content role', () => {
+				const state = {
+					...baseState,
+					blockListSettings: {
+						...baseState.blockListSettings,
+						'9b9c5c3f-2e46-4f02-9e14-9fe9515b958f': {
+							templateLock: 'contentOnly',
+						},
+					},
+				};
+				__experimentalHasContentRoleAttribute.mockReturnValueOnce(
+					true
+				);
+				expect(
+					getBlockEditingMode(
+						state,
+						'b3247f75-fd94-4fef-97f9-5bfd162cc416'
+					)
+				).toBe( 'contentOnly' );
+			} );
 		} );
 
-		it( 'should return contentOnly if parent is locked and the block has a content role', () => {
-			const state = {
-				...baseState,
-				blockListSettings: {
-					...baseState.blockListSettings,
-					'9b9c5c3f-2e46-4f02-9e14-9fe9515b958f': {
-						templateLock: 'contentOnly',
-					},
-				},
-			};
-			__experimentalHasContentRoleAttribute.mockReturnValueOnce( true );
-			expect(
-				getBlockEditingMode(
-					state,
-					'b3247f75-fd94-4fef-97f9-5bfd162cc416'
-				)
-			).toBe( 'contentOnly' );
+		describe( 'isBlockSubtreeDisabled', () => {
+			it( 'should return false when top level block is not disabled', () => {
+				const state = {
+					...baseState,
+					blockEditingModes: new Map( [] ),
+				};
+				expect(
+					isBlockSubtreeDisabled(
+						state,
+						'ef45d5fd-5234-4fd5-ac4f-c3736c7f9337'
+					)
+				).toBe( false );
+			} );
+
+			it( 'should return true when top level block is disabled and there are no editing modes within it', () => {
+				const state = {
+					...baseState,
+					blockEditingModes: new Map( [
+						[ 'ef45d5fd-5234-4fd5-ac4f-c3736c7f9337', 'disabled' ],
+					] ),
+				};
+				expect(
+					isBlockSubtreeDisabled(
+						state,
+						'ef45d5fd-5234-4fd5-ac4f-c3736c7f9337'
+					)
+				).toBe( true );
+			} );
+
+			it( 'should return true when top level block is disabled via inheritence and there are no editing modes within it', () => {
+				const state = {
+					...baseState,
+					blockEditingModes: new Map( [ [ '', 'disabled' ] ] ),
+				};
+				expect(
+					isBlockSubtreeDisabled(
+						state,
+						'ef45d5fd-5234-4fd5-ac4f-c3736c7f9337'
+					)
+				).toBe( true );
+			} );
+
+			it( 'should return true when top level block is disabled and there are disabled editing modes within it', () => {
+				const state = {
+					...baseState,
+					blockEditingModes: new Map( [
+						[ 'ef45d5fd-5234-4fd5-ac4f-c3736c7f9337', 'disabled' ],
+						[ 'b3247f75-fd94-4fef-97f9-5bfd162cc416', 'disabled' ],
+					] ),
+				};
+				expect(
+					isBlockSubtreeDisabled(
+						state,
+						'ef45d5fd-5234-4fd5-ac4f-c3736c7f9337'
+					)
+				).toBe( true );
+			} );
+
+			it( 'should return false when top level block is disabled and there are non-disabled editing modes within it', () => {
+				const state = {
+					...baseState,
+					blockEditingModes: new Map( [
+						[ 'ef45d5fd-5234-4fd5-ac4f-c3736c7f9337', 'disabled' ],
+						[ 'b3247f75-fd94-4fef-97f9-5bfd162cc416', 'default' ],
+					] ),
+				};
+				expect(
+					isBlockSubtreeDisabled(
+						state,
+						'ef45d5fd-5234-4fd5-ac4f-c3736c7f9337'
+					)
+				).toBe( false );
+			} );
+
+			it( 'should return false when top level block is disabled via inheritence and there are non-disabled editing modes within it', () => {
+				const state = {
+					...baseState,
+					blockEditingModes: new Map( [
+						[ '', 'disabled' ],
+						[ 'b3247f75-fd94-4fef-97f9-5bfd162cc416', 'default' ],
+					] ),
+				};
+				expect(
+					isBlockSubtreeDisabled(
+						state,
+						'ef45d5fd-5234-4fd5-ac4f-c3736c7f9337'
+					)
+				).toBe( false );
+			} );
 		} );
 	} );
 } );


### PR DESCRIPTION
## What?
Follows https://github.com/WordPress/gutenberg/pull/50643.

Currently if a block has an editing mode of `'disabled'` then it receives CSS that puts `pointer-events: none` on it.

In this PR we go further and set the `inert` HTML attribute so long as all of the block's descendants are also disabled.

This lets us apply inert to as many elements as possible while still preserving the ability to interact with non-disabled descendants of a disabled block. 

## Why?
The `inert` attribute has fewer bugs to do with triggering e.g. selection events, is better for assistive technologies, and is faster.

## How?
`useBlockProps()` has been updated to add `inert` if possible.

`BlockListBlock` still adds the `.is-editing-disabled` class (which has `pointer-events: none`) as it did before. The two coexist.

We don't check `contentOnly` template locking here because it's very unlikely that a block with `templateLock = 'contentOnly'` has no editable inner blocks. The point of using `'contentOnly'` locking is to have editable content within the pattern.

## Testing Instructions
1. Apply the patch below by copying it and running `pbpaste | git apply`.

```diff
diff --git a/packages/edit-site/src/components/block-editor/index.js b/packages/edit-site/src/components/block-editor/index.js
index cc5e7c8d92..f97599a9b5 100644
--- a/packages/edit-site/src/components/block-editor/index.js
+++ b/packages/edit-site/src/components/block-editor/index.js
@@ -39,7 +39,9 @@ import EditorCanvas from './editor-canvas';
 import { unlock } from '../../private-apis';
 import EditorCanvasContainer from '../editor-canvas-container';
 
-const { ExperimentalBlockEditorProvider } = unlock( blockEditorPrivateApis );
+const { ExperimentalBlockEditorProvider, useBlockEditingMode } = unlock(
+	blockEditorPrivateApis
+);
 
 const LAYOUT = {
 	type: 'default',
@@ -47,6 +49,11 @@ const LAYOUT = {
 	alignments: [],
 };
 
+function SetRootBlockEditingMode( { mode } ) {
+	useBlockEditingMode( mode );
+	return null;
+}
+
 export default function BlockEditor() {
 	const { setIsInserterOpened } = useDispatch( editSiteStore );
 	const { storedSettings, templateType, canvasMode } = useSelect(
@@ -162,6 +169,7 @@ export default function BlockEditor() {
 			onChange={ onChange }
 			useSubRegistry={ false }
 		>
+			<SetRootBlockEditingMode mode="disabled" />
 			<TemplatePartConverter />
 			<SidebarInspectorFill>
 				<BlockInspector />
diff --git a/packages/edit-site/src/hooks/block-editing-mode.js b/packages/edit-site/src/hooks/block-editing-mode.js
new file mode 100644
index 0000000000..24d63f122f
--- /dev/null
+++ b/packages/edit-site/src/hooks/block-editing-mode.js
@@ -0,0 +1,50 @@
+/**
+ * WordPress dependencies
+ */
+import { createHigherOrderComponent } from '@wordpress/compose';
+import { addFilter } from '@wordpress/hooks';
+import {
+	store as blockEditorStore,
+	privateApis as blockEditorPrivateApis,
+} from '@wordpress/block-editor';
+import { useSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { unlock } from '../private-apis';
+
+const { useBlockEditingMode } = unlock( blockEditorPrivateApis );
+
+export const withBlockEditingMode = createHigherOrderComponent(
+	( BlockEdit ) => ( props ) => {
+		const mode = useSelect( ( select ) => {
+			if (
+				[
+					'core/post-title',
+					'core/post-featured-image',
+					'core/post-content',
+				].includes( props.name )
+			) {
+				return 'contentOnly';
+			}
+			if (
+				select( blockEditorStore ).getBlockParentsByBlockName(
+					props.clientId,
+					'core/post-content'
+				).length
+			) {
+				return 'default';
+			}
+		} );
+		useBlockEditingMode( mode );
+		return <BlockEdit { ...props } />;
+	},
+	'withBlockEditingMode'
+);
+
+addFilter(
+	'editor.BlockEdit',
+	'core/edit-site/block-editing-mode',
+	withBlockEditingMode
+);
diff --git a/packages/edit-site/src/hooks/index.js b/packages/edit-site/src/hooks/index.js
index 513634c55b..de9dc8c3f7 100644
--- a/packages/edit-site/src/hooks/index.js
+++ b/packages/edit-site/src/hooks/index.js
@@ -1,6 +1,7 @@
 /**
  * Internal dependencies
  */
+import './block-editing-mode';
 import './components';
 import './push-changes-to-global-styles';
 import './template-part-edit';

```

2. In Chrome on macOS, navigate to Appearance → Editor → Pages and select a page to edit.
3. All blocks should be locked except for the Post Title, Post Featured Image and Post Content blocks. 
4. You should not be able to focus the Site Title block.

If the patch is annoying you could also merge this branch into https://github.com/WordPress/gutenberg/pull/50857 to test.