### PR TITLE
Styles Screen: Ensure variations previews will render in mobile viewports

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen-global-styles/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-global-styles/index.js
@@ -7,6 +7,7 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 import { __experimentalNavigatorButton as NavigatorButton } from '@wordpress/components';
 import { useViewportMatch } from '@wordpress/compose';
+import { BlockEditorProvider } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
@@ -18,6 +19,8 @@ import { store as editSiteStore } from '../../store';
 import SidebarButton from '../sidebar-button';
 import SidebarNavigationItem from '../sidebar-navigation-item';
 import StyleBook from '../style-book';
+
+const noop = () => {};
 
 export function SidebarNavigationItemGlobalStyles( props ) {
 	const { openGeneralSidebar } = useDispatch( editSiteStore );
@@ -48,6 +51,33 @@ export function SidebarNavigationItemGlobalStyles( props ) {
 				openGeneralSidebar( 'edit-site/global-styles' );
 			} }
 		/>
+	);
+}
+
+function SidebarNavigationScreenGlobalStylesContent() {
+	const { storedSettings } = useSelect( ( select ) => {
+		const { getSettings } = unlock( select( editSiteStore ) );
+
+		return {
+			storedSettings: getSettings( false ),
+		};
+	}, [] );
+
+	// Wrap in a BlockEditorProvider to ensure that the Iframe's dependencies are
+	// loaded. This is necessary because the Iframe component waits until
+	// the block editor store's `__internalIsInitialized` is true before
+	// rendering the iframe. Without this, the iframe previews will not render
+	// in mobile viewport sizes, where the editor canvas is hidden.
+	return (
+		<BlockEditorProvider
+			settings={ storedSettings }
+			onChange={ noop }
+			onInput={ noop }
+		>
+			<div className="edit-site-sidebar-navigation-screen-global-styles__content">
+				<StyleVariationsContainer />
+			</div>
+		</BlockEditorProvider>
 	);
 }
 
@@ -86,7 +116,7 @@ export default function SidebarNavigationScreenGlobalStyles() {
 				description={ __(
 					'Choose a different style combination for the theme styles.'
 				) }
-				content={ <StyleVariationsContainer /> }
+				content={ <SidebarNavigationScreenGlobalStylesContent /> }
 				actions={
 					<div>
 						{ ! isMobileViewport && (


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Part of https://github.com/WordPress/gutenberg/issues/50429

Fix a bug where on mobile viewports, the style variations previews were not rendering in the browse mode Styles screen. Note — this bug would only occur if you're _always_ in a mobile viewport size for the duration of your visit to the site editor. If the editor canvas is at all visible, then the style variations will render, so it's an easy bug to miss when testing in a desktop browser.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

It turns out that for the `Iframe` block editor component to successfully render an `iframe` element, it performs a check that the block editor settings are initialised ([here](https://github.com/WordPress/gutenberg/blob/3631e92e678753e2fbb01936f517155cc37e0ee5/packages/block-editor/src/components/iframe/index.js#L330)). This internal state (`__internalIsInitialized`) is set [here](https://github.com/WordPress/gutenberg/blob/312d524360168b37af42b05520cdd52e132a04e4/packages/block-editor/src/components/provider/index.js#L29) within the `BlockEditorProvider`.

In desktop screen sizes, this setting appears to be set already when accessing the Styles screen because the editor canvas has already been rendered, so an editor provider is already in use. However, in mobile viewports, the editor canvas isn't rendered yet, so the state isn't available yet.

Since the previews should have access to settings, etc, I borrowed a similar approach from the Navigation screen introduced in https://github.com/WordPress/gutenberg/pull/50840, and added a `BlockEditorProvider` to the global styles screen in browse mode.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* Wrap the `<StyleVariationsContainer />` in the Styles screen in a `BlockEditorProvider`.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. With your browser set to a mobile viewport, open up the site editor in browse mode, and navigate to the Styles screen
2. Prior to this PR, if you were always on a mobile viewport, or if you reload the page on this screen, the styles variations previews will not render.
3. With this PR applied, reload the Styles screen, and the variations previews should render correctly and be usable

## Screenshots or screencast <!-- if applicable -->

The below screengrabs depict reloading the Styles screen in the site editor browse mode in a mobile viewport size.

| Before | After |
| --- | --- |
| ![2023-05-30 16 16 07](https://github.com/WordPress/gutenberg/assets/14988353/1ddbc101-64aa-4bdd-8a5b-107b6d64ee2e) | ![2023-05-30 16 15 31](https://github.com/WordPress/gutenberg/assets/14988353/e79239c4-24c7-4ce4-ad8b-d1ef5a82aa13) |