### PR TITLE
Link Control: Add missing translation

### DIFF
--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -383,7 +383,7 @@ function LinkControl( {
 									__nextHasNoMarginBottom
 									ref={ textInputRef }
 									className="block-editor-link-control__setting block-editor-link-control__text-content"
-									label="Text"
+									label={ __( 'Text' ) }
 									value={ internalControlValue?.title }
 									onChange={ setInternalTextInputValue }
 									onKeyDown={ handleSubmitWithEnter }


### PR DESCRIPTION
## What?
This is a follow-up to #50963.

PR adds a missing translation handler for the link's text value control.

## Testing Instructions
Confirm Link Control works as before.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2023-05-30 at 11 07 48](https://github.com/WordPress/gutenberg/assets/240569/7bac4aeb-2a4e-4e17-ad31-c4e76333be5d)
