### PR TITLE
Block Toolbar: Update the 'Unlock' button label

### DIFF
--- a/packages/block-editor/src/components/block-lock/toolbar.js
+++ b/packages/block-editor/src/components/block-lock/toolbar.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __, sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { ToolbarButton, ToolbarGroup } from '@wordpress/components';
 import { useReducer } from '@wordpress/element';
 import { lock } from '@wordpress/icons';
@@ -11,10 +11,8 @@ import { lock } from '@wordpress/icons';
  */
 import BlockLockModal from './modal';
 import useBlockLock from './use-block-lock';
-import useBlockDisplayInformation from '../use-block-display-information';
 
 export default function BlockLockToolbar( { clientId } ) {
-	const blockInformation = useBlockDisplayInformation( clientId );
 	const { canEdit, canMove, canRemove, canLock } = useBlockLock( clientId );
 
 	const [ isModalOpen, toggleModal ] = useReducer(
@@ -35,11 +33,7 @@ export default function BlockLockToolbar( { clientId } ) {
 			<ToolbarGroup className="block-editor-block-lock-toolbar">
 				<ToolbarButton
 					icon={ lock }
-					label={ sprintf(
-						/* translators: %s: block name */
-						__( 'Unlock %s' ),
-						blockInformation.title
-					) }
+					label={ __( 'Unlock' ) }
 					onClick={ toggleModal }
 				/>
 			</ToolbarGroup>

--- a/test/e2e/specs/editor/various/block-locking.spec.js
+++ b/test/e2e/specs/editor/various/block-locking.spec.js
@@ -73,7 +73,7 @@ test.describe( 'Block Locking', () => {
 			await page.click( 'role=checkbox[name="Lock all"]' );
 			await page.click( 'role=button[name="Apply"]' );
 
-			await editor.clickBlockToolbarButton( 'Unlock Paragraph' );
+			await editor.clickBlockToolbarButton( 'Unlock' );
 			await page.click( 'role=checkbox[name="Lock all"]' );
 			await page.click( 'role=button[name="Apply"]' );
 


### PR DESCRIPTION
## What?
See https://github.com/WordPress/gutenberg/issues/49865#issuecomment-1554786897.

PR removes the block name from the 'Unlock' button label string to make it less verbose.

## Testing Instructions
1. Open a Post or Page.
2. Insert any block and lock it.
4. Confirm unlock button label doesn't include the block name.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2023-05-30 at 12 52 35](https://github.com/WordPress/gutenberg/assets/240569/9733034b-fa6a-4e26-9d73-b728f66e8842)
