### PR TITLE
Experiment: Put directives on <figure> element and insert lightbox as its child

### DIFF
--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -68,7 +68,7 @@ function render_block_core_image( $attributes, $content ) {
 		$w->add_class( 'wp-lightbox-container' );
 		$w->set_attribute( 'data-wp-interactive', '' );
 		$w->set_attribute( 'data-wp-context', '{ "core": { "image": { "initialized": false, "lightboxEnabled": false } } }' );
-		$content = $w->get_updated_html();
+		$body_content = $w->get_updated_html();
 
 		// Wrap the image in the body content with a button.
 		$img = null;
@@ -77,7 +77,7 @@ function render_block_core_image( $attributes, $content ) {
 			 					<button type="button" aria-haspopup="dialog" aria-label="' . esc_attr( $aria_label ) . '" data-wp-on--click="actions.core.image.showLightbox"></button>'
 									. $img[0] .
 								'</div>';
-		$body_content = preg_replace( '/<img[^>]+>/', $button, $content );
+		$body_content = preg_replace( '/<img[^>]+>/', $button, $body_content );
 
 		$background_color  = esc_attr( wp_get_global_styles( array( 'color', 'background' ) ) );
 		$close_button_icon = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="30" height="30" aria-hidden="true" focusable="false"><path d="M13 11.8l6.1-6.3-1-1-6.1 6.2-6.1-6.2-1 1 6.1 6.3-6.5 6.7 1 1 6.5-6.6 6.5 6.6 1-1z"></path></svg>';

--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -62,7 +62,7 @@ function render_block_core_image( $attributes, $content ) {
 		$w = new WP_HTML_Tag_Processor( $content );
 		$w->next_tag(
 			array(
-				'tag_name'   => 'figure',
+				'tag_name' => 'figure',
 			)
 		);
 		$w->add_class( 'wp-lightbox-container' );
@@ -82,7 +82,7 @@ function render_block_core_image( $attributes, $content ) {
 		$background_color  = esc_attr( wp_get_global_styles( array( 'color', 'background' ) ) );
 		$close_button_icon = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="30" height="30" aria-hidden="true" focusable="false"><path d="M13 11.8l6.1-6.3-1-1-6.1 6.2-6.1-6.2-1 1 6.1 6.3-6.5 6.7 1 1 6.5-6.6 6.5 6.6 1-1z"></path></svg>';
 
-		$dialog_label = $alt_attribute ? esc_attr( $alt_attribute ) : esc_attr__( 'Image' );
+		$dialog_label       = $alt_attribute ? esc_attr( $alt_attribute ) : esc_attr__( 'Image' );
 		$close_button_label = esc_attr__( 'Close' );
 
 		$lightbox_html = <<<HTML

--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -62,7 +62,7 @@ function render_block_core_image( $attributes, $content ) {
 		$w = new WP_HTML_Tag_Processor( $content );
 		$w->next_tag( 'figure' );
 		$w->add_class( 'wp-lightbox-container' );
-		$w->set_attribute( 'data-wp-interactive', '' );
+		$w->set_attribute( 'data-wp-interactive', true );
 		$w->set_attribute( 'data-wp-context', '{ "core": { "image": { "initialized": false, "lightboxEnabled": false } } }' );
 		$body_content = $w->get_updated_html();
 

--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -60,11 +60,7 @@ function render_block_core_image( $attributes, $content ) {
 		$content = $processor->get_updated_html();
 
 		$w = new WP_HTML_Tag_Processor( $content );
-		$w->next_tag(
-			array(
-				'tag_name' => 'figure',
-			)
-		);
+		$w->next_tag( 'figure' );
 		$w->add_class( 'wp-lightbox-container' );
 		$w->set_attribute( 'data-wp-interactive', '' );
 		$w->set_attribute( 'data-wp-context', '{ "core": { "image": { "initialized": false, "lightboxEnabled": false } } }' );
@@ -106,7 +102,7 @@ function render_block_core_image( $attributes, $content ) {
 			</div>
 HTML;
 
-		return preg_replace( '/<\/figure>/', $lightbox_html . '</figure>', $body_content );
+		return str_replace( '</figure>', $lightbox_html . '</figure>', $body_content );
 	}
 
 	return $processor->get_updated_html();

--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -59,6 +59,17 @@ function render_block_core_image( $attributes, $content ) {
 		}
 		$content = $processor->get_updated_html();
 
+		$w = new WP_HTML_Tag_Processor( $content );
+		$w->next_tag(
+			array(
+				'tag_name'   => 'figure',
+			)
+		);
+		$w->add_class( 'wp-lightbox-container' );
+		$w->set_attribute( 'data-wp-interactive', '' );
+		$w->set_attribute( 'data-wp-context', '{ "core": { "image": { "initialized": false, "lightboxEnabled": false } } }' );
+		$content = $w->get_updated_html();
+
 		// Wrap the image in the body content with a button.
 		$img = null;
 		preg_match( '/<img[^>]+>/', $content, $img );
@@ -72,35 +83,30 @@ function render_block_core_image( $attributes, $content ) {
 		$close_button_icon = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="30" height="30" aria-hidden="true" focusable="false"><path d="M13 11.8l6.1-6.3-1-1-6.1 6.2-6.1-6.2-1 1 6.1 6.3-6.5 6.7 1 1 6.5-6.6 6.5 6.6 1-1z"></path></svg>';
 
 		$dialog_label = $alt_attribute ? esc_attr( $alt_attribute ) : esc_attr__( 'Image' );
-
 		$close_button_label = esc_attr__( 'Close' );
 
-		return
-			<<<HTML
-				<div class="wp-lightbox-container"
-					data-wp-interactive
-					data-wp-context='{ "core": { "image": { "initialized": false, "lightboxEnabled": false } } }'>
-						$body_content
-						<div data-wp-body="" class="wp-lightbox-overlay"
-							data-wp-bind--role="selectors.core.image.roleAttribute"
-							aria-label="$dialog_label"
-							data-wp-class--initialized="context.core.image.initialized"
-							data-wp-class--active="context.core.image.lightboxEnabled"
-							data-wp-bind--aria-hidden="!context.core.image.lightboxEnabled"
-							data-wp-bind--aria-modal="context.core.image.lightboxEnabled"
-							data-wp-effect="effects.core.image.initLightbox"
-							data-wp-on--keydown="actions.core.image.handleKeydown"
-							data-wp-on--mousewheel="actions.core.image.hideLightbox"
-							data-wp-on--click="actions.core.image.hideLightbox"
-							>
-								<button type="button" aria-label="$close_button_label" class="close-button" data-wp-on--click="actions.core.image.hideLightbox">
-									$close_button_icon
-								</button>
-								$content
-								<div class="scrim" style="background-color: $background_color"></div>
-						</div>
-				</div>
+		$lightbox_html = <<<HTML
+			<div data-wp-body="" class="wp-lightbox-overlay"
+				data-wp-bind--role="selectors.core.image.roleAttribute"
+				aria-label="$dialog_label"
+				data-wp-class--initialized="context.core.image.initialized"
+				data-wp-class--active="context.core.image.lightboxEnabled"
+				data-wp-bind--aria-hidden="!context.core.image.lightboxEnabled"
+				data-wp-bind--aria-modal="context.core.image.lightboxEnabled"
+				data-wp-effect="effects.core.image.initLightbox"
+				data-wp-on--keydown="actions.core.image.handleKeydown"
+				data-wp-on--mousewheel="actions.core.image.hideLightbox"
+				data-wp-on--click="actions.core.image.hideLightbox"
+				>
+					<button type="button" aria-label="$close_button_label" class="close-button" data-wp-on--click="actions.core.image.hideLightbox">
+						$close_button_icon
+					</button>
+					$content
+					<div class="scrim" style="background-color: $background_color"></div>
+			</div>
 HTML;
+
+		return preg_replace( '/<\/figure>/', $lightbox_html . '</figure>', $body_content );
 	}
 
 	return $processor->get_updated_html();


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This revises the HTML structure for the experimental [image lightbox](https://github.com/WordPress/gutenberg/pull/50373) by ensuring there is no wrapping `<div>`.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Addresses #51068 and related issues as detailed in the [following comment](https://github.com/WordPress/gutenberg/issues/51068#issuecomment-1568033497), namely that containing a wrapping `<div>` causes existing styles and functionality to break.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Adds directives to the `<figure>` element using the tag processor, and does a regex for the `<figure>` closing tag, adding the lightbox HTML as its child.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
1. Enable Gutenberg > Experiments > Core Blocks
2. Add an image to a post
3. Enable Advanced > Behaviors > Lightbox in the image block settings
4. Publish the post and inspect the source — see that the `data-wp-context` and `data-wp-island` attributes have been added to the `<figure>` element.
5. Click on the image; the lighbox should work.


### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
N/A