### PR TITLE
Image: fix pasting blob URLs

### DIFF
--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -6,7 +6,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { getBlobByURL, isBlobURL, revokeBlobURL } from '@wordpress/blob';
+import { isBlobURL, revokeBlobURL } from '@wordpress/blob';
 import { Placeholder } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import {
@@ -273,21 +273,24 @@ export function ImageEdit( {
 			return;
 		}
 
-		const file = getBlobByURL( url );
-
-		if ( file ) {
-			mediaUpload( {
-				filesList: [ file ],
-				onFileChange: ( [ img ] ) => {
-					onSelectImage( img );
-				},
-				allowedTypes: ALLOWED_MEDIA_TYPES,
-				onError: ( message ) => {
-					isTemp = false;
-					onUploadError( message );
-				},
+		// Do not use getBlobByURL as it will only work for blobs created by us.
+		// Pasting might give us a blob URL that is not in the cache.
+		window
+			.fetch( url )
+			.then( ( r ) => r.blob() )
+			.then( ( file ) => {
+				mediaUpload( {
+					filesList: [ file ],
+					onFileChange: ( [ img ] ) => {
+						onSelectImage( img );
+					},
+					allowedTypes: ALLOWED_MEDIA_TYPES,
+					onError: ( message ) => {
+						isTemp = false;
+						onUploadError( message );
+					},
+				} );
 			} );
-		}
 	}, [] );
 
 	// If an image is temporary, revoke the Blob url when it is uploaded (and is


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Fixes pasting blob URLs (that were not created by us).

## Why?

Pasting content that includes images with blob URLs will not trigger upload for those images.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Instead of getting the blob from cache, always use fetch (which is a local fetch btw).

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

Go to Apple Notes. Add some text, add an image, and add some more text. Select all content and paste it into the title of a new post. The image should be present and upload.

Note that pasting in the post body only pastes the image, but that a bug the be fixed separately. Cc @mcsf 

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
