### PR TITLE
Fix fixed toolbar in customize widgets

### DIFF
--- a/packages/customize-widgets/src/style.scss
+++ b/packages/customize-widgets/src/style.scss
@@ -29,7 +29,7 @@
 		position: sticky;
 		top: 0;
 		left: 0;
-		z-index: z-index(".block-editor-block-popover");
+		z-index: z-index(".block-editor-block-list__insertion-point");
 		width: calc(100% + 2 * 12px); //12px is the padding of customizer sidebar content
 
 		overflow-y: hidden;

--- a/packages/customize-widgets/src/style.scss
+++ b/packages/customize-widgets/src/style.scss
@@ -17,3 +17,35 @@
 .customize-widgets-popover {
 	@include reset;
 }
+
+/**
+	Fixed bloock toolbar overrides. We can't detect each editor instance
+	in the styles of the block editor component so we need to override
+	the fixed styles here because the breakpoint css does not fire in the
+	customizer's left panel.
+*/
+.block-editor-block-contextual-toolbar {
+	&.is-fixed {
+		position: sticky;
+		top: 0;
+		left: 0;
+		z-index: z-index(".block-editor-block-popover");
+		display: block;
+		width: calc(100% + 2 * 12px); //12px is the padding of customizer sidebar content
+
+		overflow-y: hidden;
+
+		border: none;
+		border-bottom: $border-width solid $gray-200;
+		border-radius: 0;
+
+		.block-editor-block-toolbar .components-toolbar-group,
+		.block-editor-block-toolbar .components-toolbar {
+			border-right-color: $gray-200;
+		}
+
+		.block-editor-block-toolbar__group-collapse-fixed-toolbar {
+			display: none;
+		}
+	}
+}

--- a/packages/customize-widgets/src/style.scss
+++ b/packages/customize-widgets/src/style.scss
@@ -30,7 +30,6 @@
 		top: 0;
 		left: 0;
 		z-index: z-index(".block-editor-block-popover");
-		display: block;
 		width: calc(100% + 2 * 12px); //12px is the padding of customizer sidebar content
 
 		overflow-y: hidden;
@@ -44,8 +43,8 @@
 			border-right-color: $gray-200;
 		}
 
-		.block-editor-block-toolbar__group-collapse-fixed-toolbar {
-			display: none;
+		&.is-collapsed {
+			margin-left: -12px; //12px is the padding of customizer sidebar content
 		}
 	}
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes #51037.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Because in the customizer's widget editor the fixed top toolbar was inheriting the styles from the desktopn breakpoint - but in the customizer we have a small tall editor - yet the breakpoints don't fire in that panel.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Overriding the styles to be like those on mobile breakpoints in the block toolbar fixed version.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Switch to a classic theme
2. Go to Appearance > Customize > Widgets > [ Sidebar ]
3. Switch the top toolbar option on


### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

N/A

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/107534/c768ead2-bf66-44c4-bfec-7f414d0fdc3b

