### PR TITLE
Navigation: Fix ListView deprecation notice

### DIFF
--- a/packages/block-library/src/navigation/edit/menu-inspector-controls.js
+++ b/packages/block-library/src/navigation/edit/menu-inspector-controls.js
@@ -84,12 +84,9 @@ const MainContent = ( {
 } ) => {
 	const { PrivateListView } = unlock( blockEditorPrivateApis );
 
-	// Provide a hierarchy of clientIds for the given Navigation block (clientId).
-	// This is required else the list view will display the entire block tree.
-	const clientIdsTree = useSelect(
+	const hasChildren = useSelect(
 		( select ) => {
-			const { __unstableGetClientIdsTree } = select( blockEditorStore );
-			return __unstableGetClientIdsTree( clientId );
+			return !! select( blockEditorStore ).getBlockCount( clientId );
 		},
 		[ clientId ]
 	);
@@ -116,13 +113,12 @@ const MainContent = ( {
 
 	return (
 		<div className="wp-block-navigation__menu-inspector-controls">
-			{ clientIdsTree.length === 0 && (
+			{ ! hasChildren && (
 				<p className="wp-block-navigation__menu-inspector-controls__empty-message">
 					{ __( 'This navigation menu is empty.' ) }
 				</p>
 			) }
 			<PrivateListView
-				blocks={ clientIdsTree }
 				rootClientId={ clientId }
 				isExpanded
 				description={ description }

--- a/packages/block-library/src/navigation/edit/menu-inspector-controls.js
+++ b/packages/block-library/src/navigation/edit/menu-inspector-controls.js
@@ -32,6 +32,7 @@ const BLOCKS_WITH_LINK_UI_SUPPORT = [
 	'core/navigation-link',
 	'core/navigation-submenu',
 ];
+const { PrivateListView } = unlock( blockEditorPrivateApis );
 
 function AdditionalBlockContent( { block, insertedBlock, setInsertedBlock } ) {
 	const { updateBlockAttributes } = useDispatch( blockEditorStore );
@@ -82,8 +83,6 @@ const MainContent = ( {
 	isNavigationMenuMissing,
 	onCreateNew,
 } ) => {
-	const { PrivateListView } = unlock( blockEditorPrivateApis );
-
 	const hasChildren = useSelect(
 		( select ) => {
 			return !! select( blockEditorStore ).getBlockCount( clientId );


### PR DESCRIPTION
## What?
This is a follow-up to #49417.

PR fixes the deprecation notice for the Navigation block settings list view.

```
`blocks` property in `wp.blockEditor.__experimentalListView` is deprecated since version 6.3. Please use `rootClientId` property instead.
```

## How?
Only pass `rootClientId` as the deprecation message suggest.

## Testing Instructions
1. Open a Post or Page.
2. Insert a Navigation block.
3. Confirm the list view is rendered in the block settings as before.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2023-05-30 at 17 00 35](https://github.com/WordPress/gutenberg/assets/240569/20600aca-b882-4291-b5be-a449b6c28ce2)
