### PR TITLE
Lodash: Remove `_.isEmpty()` from `Fill` props

### DIFF
--- a/packages/block-editor/src/components/block-controls/fill.js
+++ b/packages/block-editor/src/components/block-controls/fill.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { isEmpty } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import {
@@ -38,7 +33,10 @@ export default function BlockControlsFill( {
 					// Children passed to BlockControlsFill will not have access to any
 					// React Context whose Provider is part of the BlockControlsSlot tree.
 					// So we re-create the Provider in this subtree.
-					const value = ! isEmpty( fillProps ) ? fillProps : null;
+					const value =
+						fillProps && Object.keys( fillProps ).length > 0
+							? fillProps
+							: null;
 					return (
 						<ToolbarContext.Provider value={ value }>
 							{ group === 'default' && (

--- a/packages/block-editor/src/components/inspector-controls/fill.js
+++ b/packages/block-editor/src/components/inspector-controls/fill.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { isEmpty } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import {
@@ -82,7 +77,8 @@ function ToolsPanelInspectorControl( { children, resetAllFilter, fillProps } ) {
 	// access to any React Context whose Provider is part of
 	// the InspectorControlsSlot tree. So we re-create the
 	// Provider in this subtree.
-	const value = ! isEmpty( fillProps ) ? fillProps : null;
+	const value =
+		fillProps && Object.keys( fillProps ).length > 0 ? fillProps : null;
 	return (
 		<ToolsPanelContext.Provider value={ value }>
 			{ children }


### PR DESCRIPTION
## What?
This PR removes Lodash's `_.isEmpty()` from the usages that check `Fill` props.

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?

We're checking if the props are truthy, and if they are, we verify that it's not an empty object by using `Object.keys().length`.

## Testing Instructions

* Verify block controls still appear when you select a block and while you're typing in a block.
* Verify block inspector controls still appear in the sidebar while editing a block (block style controls for example).
* Verify all checks are green.