### PR TITLE
DropdownMenu v2: tweak styles, add toolbar-specific styles

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -16,7 +16,7 @@
 
 ### Experimental
 
--   `DropdownMenu` v2: Tweak styles ([#50967](https://github.com/WordPress/gutenberg/pull/50967)).
+-   `DropdownMenu` v2: Tweak styles ([#50967](https://github.com/WordPress/gutenberg/pull/50967), [#51097](https://github.com/WordPress/gutenberg/pull/51097)).
 -   `DropdownMenu` v2: Render in the default `Popover.Slot` ([#51046](https://github.com/WordPress/gutenberg/pull/51046)).
 
 ## 25.0.0 (2023-05-24)

--- a/packages/components/src/dropdown-menu-v2/index.tsx
+++ b/packages/components/src/dropdown-menu-v2/index.tsx
@@ -40,7 +40,7 @@ import type {
 } from './types';
 
 // Menu content's side padding + 4px
-const SUB_MENU_OFFSET_SIDE = 12;
+const SUB_MENU_OFFSET_SIDE = 16;
 // Opposite amount of the top padding of the menu item
 const SUB_MENU_OFFSET_ALIGN = -8;
 

--- a/packages/components/src/dropdown-menu-v2/index.tsx
+++ b/packages/components/src/dropdown-menu-v2/index.tsx
@@ -14,6 +14,7 @@ import { SVG, Circle } from '@wordpress/primitives';
 /**
  * Internal dependencies
  */
+import { useContextSystem } from '../ui/context';
 import { useSlot } from '../slot-fill';
 import Icon from '../icon';
 import { SLOT_NAME as POPOVER_DEFAULT_SLOT_NAME } from '../popover';
@@ -29,6 +30,7 @@ import type {
 	DropdownMenuRadioItemProps,
 	DropdownMenuSeparatorProps,
 	DropdownSubMenuTriggerProps,
+	DropdownMenuContext,
 } from './types';
 
 // Menu content's side padding + 4px
@@ -46,21 +48,29 @@ const DropdownMenuPrivateContext = createContext< {
  * `DropdownMenu` displays a menu to the user (such as a set of actions
  * or functions) triggered by a button.
  */
-export const DropdownMenu = ( {
-	// Root props
-	defaultOpen,
-	open,
-	onOpenChange,
-	modal = true,
-	// Content positioning props
-	side = 'bottom',
-	sideOffset = 0,
-	align = 'center',
-	alignOffset = 0,
-	// Render props
-	children,
-	trigger,
-}: DropdownMenuProps ) => {
+export const DropdownMenu = ( props: DropdownMenuProps ) => {
+	const {
+		// Root props
+		defaultOpen,
+		open,
+		onOpenChange,
+		modal = true,
+		// Content positioning props
+		side = 'bottom',
+		sideOffset = 0,
+		align = 'center',
+		alignOffset = 0,
+		// Render props
+		children,
+		trigger,
+
+		// From internal components context
+		variant,
+	} = useContextSystem<
+		// Adding `className` to the context type to avoid a TS error
+		DropdownMenuProps & DropdownMenuContext & { className?: string }
+	>( props, 'DropdownMenuV2' );
+
 	// Render the portal in the default slot used by the legacy Popover component.
 	const slot = useSlot( POPOVER_DEFAULT_SLOT_NAME );
 	const portalContainer = slot.ref?.current;
@@ -83,6 +93,7 @@ export const DropdownMenu = ( {
 					sideOffset={ sideOffset }
 					alignOffset={ alignOffset }
 					loop={ true }
+					variant={ variant }
 				>
 					<DropdownMenuPrivateContext.Provider
 						value={ { portalContainer } }

--- a/packages/components/src/dropdown-menu-v2/index.tsx
+++ b/packages/components/src/dropdown-menu-v2/index.tsx
@@ -31,6 +31,7 @@ import type {
 	DropdownMenuSeparatorProps,
 	DropdownSubMenuTriggerProps,
 	DropdownMenuContext,
+	DropdownMenuPrivateContext as DropdownMenuPrivateContextType,
 } from './types';
 
 // Menu content's side padding + 4px
@@ -38,11 +39,11 @@ const SUB_MENU_OFFSET_SIDE = 12;
 // Opposite amount of the top padding of the menu item
 const SUB_MENU_OFFSET_ALIGN = -8;
 
-const DropdownMenuPrivateContext = createContext< {
-	portalContainer: HTMLElement | null;
-} >( {
-	portalContainer: null,
-} );
+const DropdownMenuPrivateContext =
+	createContext< DropdownMenuPrivateContextType >( {
+		variant: undefined,
+		portalContainer: null,
+	} );
 
 /**
  * `DropdownMenu` displays a menu to the user (such as a set of actions
@@ -96,7 +97,7 @@ export const DropdownMenu = ( props: DropdownMenuProps ) => {
 					variant={ variant }
 				>
 					<DropdownMenuPrivateContext.Provider
-						value={ { portalContainer } }
+						value={ { variant, portalContainer } }
 					>
 						{ children }
 					</DropdownMenuPrivateContext.Provider>
@@ -145,7 +146,9 @@ export const DropdownSubMenu = ( {
 	children,
 	trigger,
 }: DropdownSubMenuProps ) => {
-	const { portalContainer } = useContext( DropdownMenuPrivateContext );
+	const { variant, portalContainer } = useContext(
+		DropdownMenuPrivateContext
+	);
 
 	return (
 		<DropdownMenuPrimitive.Sub
@@ -164,6 +167,7 @@ export const DropdownSubMenu = ( {
 					loop
 					sideOffset={ SUB_MENU_OFFSET_SIDE }
 					alignOffset={ SUB_MENU_OFFSET_ALIGN }
+					variant={ variant }
 				>
 					{ children }
 				</DropdownMenuStyled.SubContent>
@@ -265,6 +269,7 @@ export const DropdownMenuRadioItem = ( {
 	);
 };
 
-export const DropdownMenuSeparator = ( props: DropdownMenuSeparatorProps ) => (
-	<DropdownMenuStyled.Separator { ...props } />
-);
+export const DropdownMenuSeparator = ( props: DropdownMenuSeparatorProps ) => {
+	const { variant } = useContext( DropdownMenuPrivateContext );
+	return <DropdownMenuStyled.Separator { ...props } variant={ variant } />;
+};

--- a/packages/components/src/dropdown-menu-v2/index.tsx
+++ b/packages/components/src/dropdown-menu-v2/index.tsx
@@ -6,7 +6,12 @@ import * as DropdownMenuPrimitive from '@radix-ui/react-dropdown-menu';
 /**
  * WordPress dependencies
  */
-import { forwardRef, createContext, useContext } from '@wordpress/element';
+import {
+	forwardRef,
+	createContext,
+	useContext,
+	useMemo,
+} from '@wordpress/element';
 import { isRTL } from '@wordpress/i18n';
 import { check, chevronRightSmall, lineSolid } from '@wordpress/icons';
 import { SVG, Circle } from '@wordpress/primitives';
@@ -72,6 +77,14 @@ const UnconnectedDropdownMenu = ( props: DropdownMenuProps ) => {
 	const slot = useSlot( POPOVER_DEFAULT_SLOT_NAME );
 	const portalContainer = slot.ref?.current;
 
+	const privateContextValue = useMemo(
+		() => ( {
+			variant,
+			portalContainer,
+		} ),
+		[ variant, portalContainer ]
+	);
+
 	return (
 		<DropdownMenuPrimitive.Root
 			defaultOpen={ defaultOpen }
@@ -93,7 +106,7 @@ const UnconnectedDropdownMenu = ( props: DropdownMenuProps ) => {
 					variant={ variant }
 				>
 					<DropdownMenuPrivateContext.Provider
-						value={ { variant, portalContainer } }
+						value={ privateContextValue }
 					>
 						{ children }
 					</DropdownMenuPrivateContext.Provider>

--- a/packages/components/src/dropdown-menu-v2/index.tsx
+++ b/packages/components/src/dropdown-menu-v2/index.tsx
@@ -14,7 +14,7 @@ import { SVG, Circle } from '@wordpress/primitives';
 /**
  * Internal dependencies
  */
-import { useContextSystem } from '../ui/context';
+import { useContextSystem, contextConnectWithoutRef } from '../ui/context';
 import { useSlot } from '../slot-fill';
 import Icon from '../icon';
 import { SLOT_NAME as POPOVER_DEFAULT_SLOT_NAME } from '../popover';
@@ -45,11 +45,7 @@ const DropdownMenuPrivateContext =
 		portalContainer: null,
 	} );
 
-/**
- * `DropdownMenu` displays a menu to the user (such as a set of actions
- * or functions) triggered by a button.
- */
-export const DropdownMenu = ( props: DropdownMenuProps ) => {
+const UnconnectedDropdownMenu = ( props: DropdownMenuProps ) => {
 	const {
 		// Root props
 		defaultOpen,
@@ -70,7 +66,7 @@ export const DropdownMenu = ( props: DropdownMenuProps ) => {
 	} = useContextSystem<
 		// Adding `className` to the context type to avoid a TS error
 		DropdownMenuProps & DropdownMenuContext & { className?: string }
-	>( props, 'DropdownMenuV2' );
+	>( props, 'DropdownMenu' );
 
 	// Render the portal in the default slot used by the legacy Popover component.
 	const slot = useSlot( POPOVER_DEFAULT_SLOT_NAME );
@@ -106,6 +102,15 @@ export const DropdownMenu = ( props: DropdownMenuProps ) => {
 		</DropdownMenuPrimitive.Root>
 	);
 };
+
+/**
+ * `DropdownMenu` displays a menu to the user (such as a set of actions
+ * or functions) triggered by a button.
+ */
+export const DropdownMenu = contextConnectWithoutRef(
+	UnconnectedDropdownMenu,
+	'DropdownMenu'
+);
 
 export const DropdownSubMenuTrigger = ( {
 	prefix,

--- a/packages/components/src/dropdown-menu-v2/stories/index.tsx
+++ b/packages/components/src/dropdown-menu-v2/stories/index.tsx
@@ -7,6 +7,7 @@ import styled from '@emotion/styled';
 /**
  * Internal dependencies
  */
+import { COLORS } from '../../utils';
 import {
 	DropdownMenu,
 	DropdownMenuItem,
@@ -74,8 +75,8 @@ const meta: ComponentMeta< typeof DropdownMenu > = {
 export default meta;
 
 const ItemHelpText = styled.span`
-	font-size: 10px;
-	color: #777;
+	font-size: 12px;
+	color: ${ COLORS.gray[ '700' ] };
 
 	/* "> * > &" syntax is to target only immediate parent menu item */
 	[data-highlighted] > * > &,
@@ -145,7 +146,7 @@ Default.args = {
 			<DropdownMenuGroup>
 				<DropdownMenuItem>Menu item</DropdownMenuItem>
 				<DropdownMenuItem
-					prefix={ <Icon icon={ wordpress } size={ 18 } /> }
+					prefix={ <Icon icon={ wordpress } size={ 24 } /> }
 				>
 					Menu item with prefix
 				</DropdownMenuItem>

--- a/packages/components/src/dropdown-menu-v2/stories/index.tsx
+++ b/packages/components/src/dropdown-menu-v2/stories/index.tsx
@@ -33,6 +33,7 @@ import { menu, wordpress } from '@wordpress/icons';
  * Internal dependencies
  */
 import Icon from '../../icon';
+import { ContextSystemProvider } from '../../ui/context';
 
 const meta: ComponentMeta< typeof DropdownMenu > = {
 	title: 'Components (Experimental)/DropdownMenu v2',
@@ -196,4 +197,20 @@ Default.args = {
 			<RadioItemsGroup />
 		</>
 	),
+};
+
+const toolbarVariantContextValue = {
+	DropdownMenu: {
+		variant: 'toolbar',
+	},
+};
+export const ToolbarVariant: ComponentStory< typeof DropdownMenu > = (
+	props
+) => (
+	<ContextSystemProvider value={ toolbarVariantContextValue }>
+		<DropdownMenu { ...props } />
+	</ContextSystemProvider>
+);
+ToolbarVariant.args = {
+	...Default.args,
 };

--- a/packages/components/src/dropdown-menu-v2/styles.ts
+++ b/packages/components/src/dropdown-menu-v2/styles.ts
@@ -11,6 +11,7 @@ import * as DropdownMenu from '@radix-ui/react-dropdown-menu';
 import { COLORS, font, rtl, CONFIG } from '../utils';
 import { space } from '../ui/utils/space';
 import Icon from '../icon';
+import type { DropdownMenuContext } from './types';
 
 const ANIMATION_PARAMS = {
 	SLIDE_AMOUNT: '2px',
@@ -22,6 +23,14 @@ const CONTENT_WRAPPER_PADDING = space( 2 );
 const ITEM_PREFIX_WIDTH = space( 7 );
 const ITEM_PADDING_INLINE_START = space( 2 );
 const ITEM_PADDING_INLINE_END = space( 2.5 );
+
+// TODO: should bring this into the config, and make themeable
+const TOOLBAR_VARIANT_BORDER_COLOR = COLORS.gray[ '900' ];
+const DEFAULT_BOX_SHADOW = `0.1px 4px 16.4px -0.5px rgba( 0, 0, 0, 0.1 ),
+0px 5.5px 7.8px -0.3px rgba( 0, 0, 0, 0.1 ),
+0px 2.7px 3.8px -0.2px rgba( 0, 0, 0, 0.1 ),
+0px 0.7px 1px rgba( 0, 0, 0, 0.1 )`;
+const TOOLBAR_VARIANT_BOX_SHADOW = `0 0 0 ${ CONFIG.borderWidth } ${ TOOLBAR_VARIANT_BORDER_COLOR }`;
 
 const slideUpAndFade = keyframes( {
 	'0%': {
@@ -55,15 +64,14 @@ const slideLeftAndFade = keyframes( {
 	'100%': { opacity: 1, transform: 'translateX(0)' },
 } );
 
-const baseContent = css`
+const baseContent = ( variant: DropdownMenuContext[ 'variant' ] ) => css`
 	min-width: 220px;
 	background-color: ${ COLORS.ui.background };
 	border-radius: ${ CONFIG.radiusBlockUi };
 	padding: ${ CONTENT_WRAPPER_PADDING };
-	box-shadow: 0.1px 4px 16.4px -0.5px rgba( 0, 0, 0, 0.1 ),
-		0px 5.5px 7.8px -0.3px rgba( 0, 0, 0, 0.1 ),
-		0px 2.7px 3.8px -0.2px rgba( 0, 0, 0, 0.1 ),
-		0px 0.7px 1px rgba( 0, 0, 0, 0.1 );
+	box-shadow: ${ variant === 'toolbar'
+		? TOOLBAR_VARIANT_BOX_SHADOW
+		: DEFAULT_BOX_SHADOW };
 	animation-duration: ${ ANIMATION_PARAMS.DURATION };
 	animation-timing-function: ${ ANIMATION_PARAMS.EASING };
 	will-change: transform, opacity;
@@ -193,8 +201,10 @@ const baseItem = css`
 	}
 `;
 
-export const Content = styled( DropdownMenu.Content )`
-	${ baseContent }
+export const Content = styled( DropdownMenu.Content )<
+	Pick< DropdownMenuContext, 'variant' >
+>`
+	${ ( props ) => baseContent( props.variant ) }
 `;
 export const SubContent = styled( DropdownMenu.SubContent )`
 	${ baseContent }

--- a/packages/components/src/dropdown-menu-v2/styles.ts
+++ b/packages/components/src/dropdown-menu-v2/styles.ts
@@ -206,8 +206,10 @@ export const Content = styled( DropdownMenu.Content )<
 >`
 	${ ( props ) => baseContent( props.variant ) }
 `;
-export const SubContent = styled( DropdownMenu.SubContent )`
-	${ baseContent }
+export const SubContent = styled( DropdownMenu.SubContent )<
+	Pick< DropdownMenuContext, 'variant' >
+>`
+	${ ( props ) => baseContent( props.variant ) }
 `;
 
 export const Item = styled( DropdownMenu.Item )`
@@ -245,10 +247,15 @@ export const Label = styled( DropdownMenu.Label )`
 	text-transform: uppercase;
 `;
 
-export const Separator = styled( DropdownMenu.Separator )`
-	height: 1px;
+export const Separator = styled( DropdownMenu.Separator )<
+	Pick< DropdownMenuContext, 'variant' >
+>`
+	height: ${ CONFIG.borderWidth };
 	/* TODO: doesn't match border color from variables */
-	background-color: ${ COLORS.ui.borderDisabled };
+	background-color: ${ ( props ) =>
+		props.variant === 'toolbar'
+			? TOOLBAR_VARIANT_BORDER_COLOR
+			: COLORS.ui.borderDisabled };
 	/* Negative horizontal margin to make separator go from side to side */
 	margin: ${ space( 2 ) } calc( -1 * ${ CONTENT_WRAPPER_PADDING } );
 `;

--- a/packages/components/src/dropdown-menu-v2/styles.ts
+++ b/packages/components/src/dropdown-menu-v2/styles.ts
@@ -25,11 +25,9 @@ const ITEM_PADDING_INLINE_START = space( 2 );
 const ITEM_PADDING_INLINE_END = space( 2.5 );
 
 // TODO: should bring this into the config, and make themeable
+const DEFAULT_BORDER_COLOR = COLORS.ui.borderDisabled;
 const TOOLBAR_VARIANT_BORDER_COLOR = COLORS.gray[ '900' ];
-const DEFAULT_BOX_SHADOW = `0.1px 4px 16.4px -0.5px rgba( 0, 0, 0, 0.1 ),
-0px 5.5px 7.8px -0.3px rgba( 0, 0, 0, 0.1 ),
-0px 2.7px 3.8px -0.2px rgba( 0, 0, 0, 0.1 ),
-0px 0.7px 1px rgba( 0, 0, 0, 0.1 )`;
+const DEFAULT_BOX_SHADOW = `0 0 0 ${ CONFIG.borderWidth } ${ DEFAULT_BORDER_COLOR }, ${ CONFIG.popoverShadow }`;
 const TOOLBAR_VARIANT_BOX_SHADOW = `0 0 0 ${ CONFIG.borderWidth } ${ TOOLBAR_VARIANT_BORDER_COLOR }`;
 
 const slideUpAndFade = keyframes( {
@@ -255,7 +253,7 @@ export const Separator = styled( DropdownMenu.Separator )<
 	background-color: ${ ( props ) =>
 		props.variant === 'toolbar'
 			? TOOLBAR_VARIANT_BORDER_COLOR
-			: COLORS.ui.borderDisabled };
+			: DEFAULT_BORDER_COLOR };
 	/* Negative horizontal margin to make separator go from side to side */
 	margin: ${ space( 2 ) } calc( -1 * ${ CONTENT_WRAPPER_PADDING } );
 `;

--- a/packages/components/src/dropdown-menu-v2/styles.ts
+++ b/packages/components/src/dropdown-menu-v2/styles.ts
@@ -8,7 +8,7 @@ import * as DropdownMenu from '@radix-ui/react-dropdown-menu';
 /**
  * Internal dependencies
  */
-import { COLORS, font, rtl } from '../utils';
+import { COLORS, font, rtl, CONFIG } from '../utils';
 import { space } from '../ui/utils/space';
 import Icon from '../icon';
 
@@ -58,7 +58,7 @@ const slideLeftAndFade = keyframes( {
 const baseContent = css`
 	min-width: 220px;
 	background-color: ${ COLORS.ui.background };
-	border-radius: 6px;
+	border-radius: ${ CONFIG.radiusBlockUi };
 	padding: ${ CONTENT_WRAPPER_PADDING };
 	box-shadow: 0.1px 4px 16.4px -0.5px rgba( 0, 0, 0, 0.1 ),
 		0px 5.5px 7.8px -0.3px rgba( 0, 0, 0, 0.1 ),
@@ -156,7 +156,7 @@ const baseItem = css`
 	font-weight: normal;
 	line-height: 20px;
 	color: ${ COLORS.gray[ 900 ] };
-	border-radius: 3px;
+	border-radius: ${ CONFIG.radiusBlockUi };
 	display: flex;
 	align-items: center;
 	padding: ${ space( 2 ) } ${ ITEM_PADDING_INLINE_END } ${ space( 2 ) }

--- a/packages/components/src/dropdown-menu-v2/types.ts
+++ b/packages/components/src/dropdown-menu-v2/types.ts
@@ -248,3 +248,11 @@ export type DropdownMenuGroupProps = {
 };
 
 export type DropdownMenuSeparatorProps = {};
+
+export type DropdownMenuContext = {
+	/**
+	 * This variant can be used to change the appearance of the component in
+	 * specific contexts, ie. when rendered inside the `Toolbar` component.
+	 */
+	variant?: 'toolbar';
+};

--- a/packages/components/src/dropdown-menu-v2/types.ts
+++ b/packages/components/src/dropdown-menu-v2/types.ts
@@ -256,3 +256,10 @@ export type DropdownMenuContext = {
 	 */
 	variant?: 'toolbar';
 };
+
+export type DropdownMenuPrivateContext = Pick<
+	DropdownMenuContext,
+	'variant'
+> & {
+	portalContainer: HTMLElement | null;
+};

--- a/packages/components/src/toolbar/toolbar/index.tsx
+++ b/packages/components/src/toolbar/toolbar/index.tsx
@@ -21,6 +21,10 @@ import {
 	ContextSystemProvider,
 } from '../../ui/context';
 
+// TODO:
+// - (optional) make the legacy `DropdownMenu` read the context variable
+// - swap the legacy `DropdownMenu` with the new version of the component
+//   once it's stable
 const CONTEXT_SYSTEM_VALUE = {
 	DropdownMenu: {
 		// Note: the legacy `DropdownMenu` component is not yet reactive to this

--- a/packages/components/src/toolbar/toolbar/index.tsx
+++ b/packages/components/src/toolbar/toolbar/index.tsx
@@ -16,7 +16,18 @@ import deprecated from '@wordpress/deprecated';
 import ToolbarGroup from '../toolbar-group';
 import ToolbarContainer from './toolbar-container';
 import type { ToolbarProps } from './types';
-import type { WordPressComponentProps } from '../../ui/context';
+import {
+	WordPressComponentProps,
+	ContextSystemProvider,
+} from '../../ui/context';
+
+const CONTEXT_SYSTEM_VALUE = {
+	DropdownMenu: {
+		// Note: the legacy `DropdownMenu` component is not yet reactive to this
+		// context variant. See https://github.com/WordPress/gutenberg/pull/51097.
+		variant: 'toolbar',
+	},
+};
 
 function UnforwardedToolbar(
 	{
@@ -40,12 +51,14 @@ function UnforwardedToolbar(
 		className
 	);
 	return (
-		<ToolbarContainer
-			className={ finalClassName }
-			label={ label }
-			ref={ ref }
-			{ ...props }
-		/>
+		<ContextSystemProvider value={ CONTEXT_SYSTEM_VALUE }>
+			<ToolbarContainer
+				className={ finalClassName }
+				label={ label }
+				ref={ ref }
+				{ ...props }
+			/>
+		</ContextSystemProvider>
 	);
 }
 

--- a/packages/components/src/ui/context/index.ts
+++ b/packages/components/src/ui/context/index.ts
@@ -4,6 +4,7 @@ export {
 } from './context-system-provider';
 export {
 	contextConnect,
+	contextConnectWithoutRef,
 	hasConnectNamespace,
 	getConnectNamespace,
 } from './context-connect';

--- a/packages/components/src/utils/config-values.js
+++ b/packages/components/src/utils/config-values.js
@@ -67,6 +67,7 @@ export default Object.assign( {}, CONTROL_PROPS, TOGGLE_GROUP_CONTROL_PROPS, {
 	cardPaddingSmall: `${ space( 4 ) }`,
 	cardPaddingMedium: `${ space( 4 ) } ${ space( 6 ) }`,
 	cardPaddingLarge: `${ space( 6 ) } ${ space( 8 ) }`,
+	popoverShadow: `0 0.7px 1px rgba(0, 0, 0, 0.1), 0 1.2px 1.7px -0.2px rgba(0, 0, 0, 0.1), 0 2.3px 3.3px -0.5px rgba(0, 0, 0, 0.1)`,
 	surfaceBackgroundColor: COLORS.white,
 	surfaceBackgroundSubtleColor: '#F3F3F3',
 	surfaceBackgroundTintColor: '#F5F5F5',


### PR DESCRIPTION
Part of #50459

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Refine `DropdownMenu` v2 styles:

- updated the border radius of both content wrapper and single items to `2px`;
- updated the box shadow to be the same as the `Popover` component;
- tweak Storybook example to resemble more closely a typical usage of the component;
- added a toolbar-specific `variant` that can be set via only by other components in `@wordpress/components`, which causes:
  - content (and sub-content) wrappers to show a dark border, and remove the drop shadow;
  - separators to also render in the same border color.

**Note: this PR only focuses on tweaking styles on the `DropdownMenu` component. It does NOT make any changes to the `Toolbar` and `ToolbarDropdown` components (and therefore it doesn't impact current dropdowns in the editor). Those changes will be part of a separate PR, and will need some thorough testing around integrating the new `DropdownMenu` component in the editor.**

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Adapting to design specs.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

The answer is mostly React Context:

- We use the package's [context system](https://github.com/WordPress/gutenberg/blob/trunk/packages/components/CONTRIBUTING.md#context-system) to expose a `variant` property. This property can only be set using the packages' context system, meaning only other components from `@wordpress/components` will be able to trigger this variant. The plan is for this property to be set by the `Toolbar` components
- Internally in the `DropdownMenu` component, we use another instance of React Content to propagate the received `variant` down to all subcomponents. This is to ensure that also the sub-content wrapper and the separator can render accordingly to the chosen variant.

I will add more details about the implementation through inline comments.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

For now, the only way to test the new styles is via Storybook:

- Open the default Storybook example, notice how the border radii have been updated to `2px` for both the content wrappers and each item
- Open the new `Toolbar Variant` Storybook example, and notice how the component renders with darker borders (including nested menus and separators).

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/1083581/f18b7e52-2684-44c1-ad0f-6da7765d875d
