### PR TITLE
Remove legacy logic for `__unstableResolvedAssets`

### DIFF
--- a/lib/compat/wordpress-6.2/script-loader.php
+++ b/lib/compat/wordpress-6.2/script-loader.php
@@ -64,89 +64,10 @@ function gutenberg_enqueue_block_support_styles( $style, $priority = 10 ) {
 	);
 }
 
-/**
- * Sets the content assets for the block editor.
- *
- * Note for core merge: see inline comment on what's been updated.
- */
-function gutenberg_resolve_assets_override() {
-	global $pagenow;
-
-	$script_handles = array(
-		'wp-polyfill',
-	);
-	// Note for core merge: only 'wp-edit-blocks' should be in this array.
-	$style_handles = array(
-		'wp-edit-blocks',
-	);
-
-	if ( current_theme_supports( 'wp-block-styles' ) ) {
-		$style_handles[] = 'wp-block-library-theme';
-	}
-
-	if ( 'widgets.php' === $pagenow || 'customize.php' === $pagenow ) {
-		$style_handles[] = 'wp-widgets';
-		$style_handles[] = 'wp-edit-widgets';
-	}
-
-	$block_registry = WP_Block_Type_Registry::get_instance();
-
-	foreach ( $block_registry->get_all_registered() as $block_type ) {
-		// In older WordPress versions, like 6.0, these properties are not defined.
-		if ( isset( $block_type->style_handles ) && is_array( $block_type->style_handles ) ) {
-			$style_handles = array_merge( $style_handles, $block_type->style_handles );
-		}
-
-		if ( isset( $block_type->editor_style_handles ) && is_array( $block_type->editor_style_handles ) ) {
-			$style_handles = array_merge( $style_handles, $block_type->editor_style_handles );
-		}
-
-		if ( isset( $block_type->script_handles ) && is_array( $block_type->script_handles ) ) {
-			$script_handles = array_merge( $script_handles, $block_type->script_handles );
-		}
-	}
-
-	$style_handles = array_unique( $style_handles );
-	$done          = wp_styles()->done;
-
-	ob_start();
-
-	// We do not need reset styles for the iframed editor.
-	wp_styles()->done = array( 'wp-reset-editor-styles' );
-	wp_styles()->do_items( $style_handles );
-	wp_styles()->done = $done;
-
-	$styles = ob_get_clean();
-
-	$script_handles = array_unique( $script_handles );
-	$done           = wp_scripts()->done;
-
-	ob_start();
-
-	wp_scripts()->done = array();
-	wp_scripts()->do_items( $script_handles );
-	wp_scripts()->done = $done;
-
-	$scripts = ob_get_clean();
-
-	// Generate font @font-face styles.
-	if ( function_exists( 'wp_print_fonts' ) ) {
-		ob_start();
-		wp_print_fonts( true );
-		$styles .= ob_get_clean();
-	}
-
-	return array(
-		'styles'  => $styles,
-		'scripts' => $scripts,
-	);
-}
-
 add_filter(
 	'block_editor_settings_all',
 	function( $settings ) {
 		// We must override what core is passing now.
-		$settings['__unstableResolvedAssets']    = gutenberg_resolve_assets_override();
 		$settings['__unstableIsBlockBasedTheme'] = wp_is_block_theme();
 		return $settings;
 	},

--- a/lib/compat/wordpress-6.3/script-loader.php
+++ b/lib/compat/wordpress-6.3/script-loader.php
@@ -80,6 +80,5 @@ add_filter(
 		// We must override what core is passing now.
 		$settings['__unstableResolvedAssets'] = _gutenberg_get_iframed_editor_assets();
 		return $settings;
-	},
-	100
+	}
 );


### PR DESCRIPTION
## What?

This removes the `_gutenberg_resolve_assets_override` function that lives at `lib/compat/wordpress-6.2/script-loader.php`. 

## Why?

The purpose of that function is to prepare the data for the `__unstableResolvedAssets` setting. However, we already do that in the [_gutenberg_get_iframed_editor_assets](https://github.com/WordPress/gutenberg/blob/5cc940b4d9aa06432ddb5217792cfe6784a46152/lib/compat/wordpress-6.3/script-loader.php#L29) function that lives at `lib/compat/wordpress-6.2/script-loader.php`, so it loads later. We don't want to run the same logic twice.

## How?

Remove the older code.

## Testing Instructions

Verify that iframe tests pass.
