### PR TITLE
[Site Editor]: Add `delete` action for pages in navigation sidebar

### DIFF
--- a/packages/edit-site/src/components/page-actions/delete-page-menu-item.js
+++ b/packages/edit-site/src/components/page-actions/delete-page-menu-item.js
@@ -50,6 +50,8 @@ export default function DeletePageMenuItem( { postId, onRemove } ) {
 					: __( 'An error occurred while deleting the page.' );
 
 			createErrorNotice( errorMessage, { type: 'snackbar' } );
+		} finally {
+			setIsModalOpen( false );
 		}
 	}
 	return (

--- a/packages/edit-site/src/components/page-actions/delete-page-menu-item.js
+++ b/packages/edit-site/src/components/page-actions/delete-page-menu-item.js
@@ -1,0 +1,63 @@
+/**
+ * WordPress dependencies
+ */
+import { useDispatch, useSelect } from '@wordpress/data';
+import { decodeEntities } from '@wordpress/html-entities';
+import { useState } from '@wordpress/element';
+import { store as coreStore } from '@wordpress/core-data';
+import { __, sprintf } from '@wordpress/i18n';
+import {
+	MenuItem,
+	__experimentalConfirmDialog as ConfirmDialog,
+} from '@wordpress/components';
+import { store as noticesStore } from '@wordpress/notices';
+
+export default function DeletePageMenuItem( { postId, onRemove } ) {
+	const [ isModalOpen, setIsModalOpen ] = useState( false );
+	const { createSuccessNotice, createErrorNotice } =
+		useDispatch( noticesStore );
+	const { deleteEntityRecord } = useDispatch( coreStore );
+	const page = useSelect(
+		( select ) =>
+			select( coreStore ).getEntityRecord( 'postType', 'page', postId ),
+		[ postId ]
+	);
+	async function removePage() {
+		try {
+			await deleteEntityRecord( 'postType', 'page', postId );
+			createSuccessNotice(
+				sprintf(
+					/* translators: The page's title. */
+					__( '"%s" deleted.' ),
+					decodeEntities( page.title.rendered )
+				),
+				{
+					type: 'snackbar',
+					id: 'edit-site-page-removed',
+				}
+			);
+			onRemove?.();
+		} catch ( error ) {
+			const errorMessage =
+				error.message && error.code !== 'unknown_error'
+					? error.message
+					: __( 'An error occurred while deleting the entity.' );
+
+			createErrorNotice( errorMessage, { type: 'snackbar' } );
+		}
+	}
+	return (
+		<>
+			<MenuItem onClick={ () => setIsModalOpen( true ) } isDestructive>
+				{ __( 'Delete' ) }
+			</MenuItem>
+			<ConfirmDialog
+				isOpen={ isModalOpen }
+				onConfirm={ removePage }
+				onCancel={ () => setIsModalOpen( false ) }
+			>
+				{ __( 'Are you sure you want to delete this page?' ) }
+			</ConfirmDialog>
+		</>
+	);
+}

--- a/packages/edit-site/src/components/page-actions/delete-page-menu-item.js
+++ b/packages/edit-site/src/components/page-actions/delete-page-menu-item.js
@@ -24,7 +24,13 @@ export default function DeletePageMenuItem( { postId, onRemove } ) {
 	);
 	async function removePage() {
 		try {
-			await deleteEntityRecord( 'postType', 'page', postId );
+			await deleteEntityRecord(
+				'postType',
+				'page',
+				postId,
+				{},
+				{ throwOnError: true }
+			);
 			createSuccessNotice(
 				sprintf(
 					/* translators: The page's title. */
@@ -41,7 +47,7 @@ export default function DeletePageMenuItem( { postId, onRemove } ) {
 			const errorMessage =
 				error.message && error.code !== 'unknown_error'
 					? error.message
-					: __( 'An error occurred while deleting the entity.' );
+					: __( 'An error occurred while deleting the page.' );
 
 			createErrorNotice( errorMessage, { type: 'snackbar' } );
 		}

--- a/packages/edit-site/src/components/page-actions/index.js
+++ b/packages/edit-site/src/components/page-actions/index.js
@@ -1,0 +1,36 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { DropdownMenu, MenuGroup } from '@wordpress/components';
+import { moreVertical } from '@wordpress/icons';
+
+/**
+ * Internal dependencies
+ */
+import DeletePageMenuItem from './delete-page-menu-item';
+
+export default function PageActions( {
+	postId,
+	className,
+	toggleProps,
+	onRemove,
+} ) {
+	return (
+		<DropdownMenu
+			icon={ moreVertical }
+			label={ __( 'Actions' ) }
+			className={ className }
+			toggleProps={ toggleProps }
+		>
+			{ () => (
+				<MenuGroup>
+					<DeletePageMenuItem
+						postId={ postId }
+						onRemove={ onRemove }
+					/>
+				</MenuGroup>
+			) }
+		</DropdownMenu>
+	);
+}

--- a/packages/edit-site/src/components/sidebar-navigation-screen-page/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-page/index.js
@@ -33,8 +33,10 @@ import { store as editSiteStore } from '../../store';
 import SidebarButton from '../sidebar-button';
 import SidebarNavigationSubtitle from '../sidebar-navigation-subtitle';
 import PageDetails from './page-details';
+import PageActions from '../page-actions';
 
 export default function SidebarNavigationScreenPage() {
+	const navigator = useNavigator();
 	const { setCanvasMode } = unlock( useDispatch( editSiteStore ) );
 	const {
 		params: { postId },
@@ -77,11 +79,20 @@ export default function SidebarNavigationScreenPage() {
 				record?.title?.rendered || __( '(no title)' )
 			) }
 			actions={
-				<SidebarButton
-					onClick={ () => setCanvasMode( 'edit' ) }
-					label={ __( 'Edit' ) }
-					icon={ pencil }
-				/>
+				<div>
+					<PageActions
+						postId={ postId }
+						toggleProps={ { as: SidebarButton } }
+						onRemove={ () => {
+							navigator.goTo( '/page' );
+						} }
+					/>
+					<SidebarButton
+						onClick={ () => setCanvasMode( 'edit' ) }
+						label={ __( 'Edit' ) }
+						icon={ pencil }
+					/>
+				</div>
 			}
 			meta={
 				<ExternalLink


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Part of: https://github.com/WordPress/gutenberg/issues/50379


This PR adds a `delete` action for pages in site editor's navigation sidebar with a confirmation dialog.

## Testing Instructions
1. In site editor go to `pages`
2. Select a page and observe the actions menu
3. Delete a page 


## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/16275880/a699e3a5-316b-4ef7-afd9-e5f54e2f605d


