### PR TITLE
[RNMobile] Avoid "429 - Too Many Request" error when fetching translations

### DIFF
--- a/packages/react-native-editor/bin/i18n-translations-download.js
+++ b/packages/react-native-editor/bin/i18n-translations-download.js
@@ -62,6 +62,8 @@ const supportedLocales = [
 
 const TRANSLATION_FETCH_BATCH_COUNT = 10;
 const TRANSLATION_FETCH_BATCH_DELAY = 250;
+const MAX_RETRIES = 5;
+const RETRY_DELAY = 2000;
 
 const getLanguageUrl = ( locale, projectSlug ) =>
 	`https://translate.wordpress.org/projects/${ projectSlug }/dev/${ locale }/default/export-translations\?format\=json`;
@@ -69,26 +71,45 @@ const getLanguageUrl = ( locale, projectSlug ) =>
 const getTranslationFilePath = ( locale ) => `./data/${ locale }.json`;
 
 const fetchTranslation = ( locale, projectSlug ) => {
+	let retryCount = MAX_RETRIES;
 	const localeUrl = getLanguageUrl( locale, projectSlug );
-	return fetch( localeUrl )
-		.then( ( response ) => {
-			if ( ! response.ok ) {
+	const request = () =>
+		fetch( localeUrl )
+			.then( ( response ) => {
+				if ( ! response.ok ) {
+					const { status, statusText } = response;
+
+					// Retry when encountering "429 - Too Many Requests" error
+					if ( status === 429 && retryCount > 0 ) {
+						console.log(
+							`Translation file ${ localeUrl } for project slug ${ projectSlug } failed with error 429 - Too Many Requests, retrying (${ retryCount })...`
+						);
+						retryCount--;
+						return new Promise( ( resolve ) =>
+							setTimeout(
+								() => request().then( resolve ),
+								RETRY_DELAY
+							)
+						);
+					}
+
+					console.error(
+						`Could not find translation file ${ localeUrl } for project slug ${ projectSlug }`,
+						{ status, statusText }
+					);
+					return { locale, status, statusText };
+				}
+				return response.json();
+			} )
+			.then( ( body ) => {
+				return { response: body, locale };
+			} )
+			.catch( () => {
 				console.error(
-					`Could not find translation file ${ localeUrl } for project slug ${ projectSlug }`,
-					{ status: response.status, statusText: response.statusText }
+					`Could not find translation file ${ localeUrl } for project slug ${ projectSlug }`
 				);
-				return;
-			}
-			return response.json();
-		} )
-		.then( ( body ) => {
-			return { response: body, locale };
-		} )
-		.catch( () => {
-			console.error(
-				`Could not find translation file ${ localeUrl } for project slug ${ projectSlug }`
-			);
-		} );
+			} );
+	return request();
 };
 
 const fetchTranslations = ( {

--- a/packages/react-native-editor/bin/i18n-translations-download.js
+++ b/packages/react-native-editor/bin/i18n-translations-download.js
@@ -60,8 +60,6 @@ const supportedLocales = [
 	'zh-tw', // Chinese (Taiwan)
 ];
 
-const TRANSLATION_FETCH_BATCH_COUNT = 10;
-const TRANSLATION_FETCH_BATCH_DELAY = 250;
 const MAX_RETRIES = 5;
 const RETRY_DELAY = 2000;
 
@@ -123,17 +121,8 @@ const fetchTranslations = ( {
 		supportedLocales
 	);
 
-	const fetchPromises = supportedLocales.map(
-		( locale, index ) =>
-			new Promise( ( resolve ) =>
-				// Fetch requests are made in batches to avoid the error 429 - Too Many Requests
-				setTimeout(
-					() =>
-						fetchTranslation( locale, projectSlug ).then( resolve ),
-					TRANSLATION_FETCH_BATCH_DELAY *
-						Math.floor( index / TRANSLATION_FETCH_BATCH_COUNT )
-				)
-			)
+	const fetchPromises = supportedLocales.map( ( locale ) =>
+		fetchTranslation( locale, projectSlug )
 	);
 
 	// Create data folder if it doesn't exist

--- a/packages/react-native-editor/bin/i18n-translations-download.js
+++ b/packages/react-native-editor/bin/i18n-translations-download.js
@@ -71,7 +71,16 @@ const getTranslationFilePath = ( locale ) => `./data/${ locale }.json`;
 const fetchTranslation = ( locale, projectSlug ) => {
 	const localeUrl = getLanguageUrl( locale, projectSlug );
 	return fetch( localeUrl )
-		.then( ( response ) => response.json() )
+		.then( ( response ) => {
+			if ( ! response.ok ) {
+				console.error(
+					`Could not find translation file ${ localeUrl } for project slug ${ projectSlug }`,
+					{ status: response.status, statusText: response.statusText }
+				);
+				return;
+			}
+			return response.json();
+		} )
 		.then( ( body ) => {
 			return { response: body, locale };
 		} )

--- a/packages/react-native-editor/bin/i18n-translations-download.js
+++ b/packages/react-native-editor/bin/i18n-translations-download.js
@@ -116,7 +116,16 @@ const fetchTranslations = ( {
 	let extraTranslations = [];
 
 	return Promise.all( fetchPromises ).then( ( results ) => {
-		const fetchedTranslations = results.filter( Boolean );
+		const fetchedTranslations = results.filter(
+			( result ) => result.response
+		);
+
+		// Abort process if any translation can't be fetched
+		if ( fetchedTranslations.length !== supportedLocales.length ) {
+			process.exit( 1 );
+			return;
+		}
+
 		const translationFilePromises = fetchedTranslations.map(
 			( languageResult ) => {
 				return new Promise( ( resolve, reject ) => {

--- a/packages/react-native-editor/bin/i18n-translations-download.js
+++ b/packages/react-native-editor/bin/i18n-translations-download.js
@@ -60,6 +60,9 @@ const supportedLocales = [
 	'zh-tw', // Chinese (Taiwan)
 ];
 
+const TRANSLATION_FETCH_BATCH_COUNT = 10;
+const TRANSLATION_FETCH_BATCH_DELAY = 250;
+
 const getLanguageUrl = ( locale, projectSlug ) =>
 	`https://translate.wordpress.org/projects/${ projectSlug }/dev/${ locale }/default/export-translations\?format\=json`;
 
@@ -90,8 +93,17 @@ const fetchTranslations = ( {
 		supportedLocales
 	);
 
-	const fetchPromises = supportedLocales.map( ( locale ) =>
-		fetchTranslation( locale, projectSlug )
+	const fetchPromises = supportedLocales.map(
+		( locale, index ) =>
+			new Promise( ( resolve ) =>
+				// Fetch requests are made in batches to avoid the error 429 - Too Many Requests
+				setTimeout(
+					() =>
+						fetchTranslation( locale, projectSlug ).then( resolve ),
+					TRANSLATION_FETCH_BATCH_DELAY *
+						Math.floor( index / TRANSLATION_FETCH_BATCH_COUNT )
+				)
+			)
 	);
 
 	// Create data folder if it doesn't exist

--- a/packages/react-native-editor/bin/i18n-translations-download.js
+++ b/packages/react-native-editor/bin/i18n-translations-download.js
@@ -64,7 +64,7 @@ const MAX_RETRIES = 5;
 const RETRY_DELAY = 2000;
 
 const getLanguageUrl = ( locale, projectSlug ) =>
-	`https://translate.wordpress.org/projects/${ projectSlug }/dev/${ locale }/default/export-translations\?format\=json`;
+	`https://translate.wordpress.org/projects/${ projectSlug }/dev/${ locale }/default/export-translations/\?format\=json`;
 
 const getTranslationFilePath = ( locale ) => `./data/${ locale }.json`;
 


### PR DESCRIPTION
**Related PRs:**
* https://github.com/wordpress-mobile/gutenberg-mobile/pull/5820

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Update the script for downloading the translations to avoid the "429 - Too Many Request" error.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

I recently experienced errors when downloading translations as part of React Native bundle generation. We need to ensure that translations are downloaded to include them in the bundle.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* In case a request fails with error 429 (Too Many Requests), wait for a couple of seconds and retry the request.
* Ensure that the fetch translations script aborts the process when any translation download fails. This will make other scripts that depend on this one, like the bundle generation, fail instead of continuing without the translations.
* Avoid parsing the fetch response if there's an error. Plus, we'll print the HTTP code to make it easier to debug potential failures.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
1. Run the command `npm run native i18n:fetch-translations` multiple times. This can be tested with the following command:
```
for i in {1..10}; do npm run native i18n:fetch-translations || { echo "Error: Command failed. Aborting..."; break; }; done
```
2. Observe that no error is logged except the warning message `Translation file <URL> for project slug wp-plugins/gutenberg failed with error 429 - Too Many Requests, retrying (5)...`.
3. In case translation downloads are retried, observe the script succeeds.
4. Observe that all translations are downloaded in folder `packages/react-native-editor/i18n-cache/gutenberg/data`.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
N/A

## Screenshots or screencast <!-- if applicable -->
N/A