### PR TITLE
Focus first focusable on Link UI

### DIFF
--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -181,12 +181,6 @@ function LinkControl( {
 			isMounting.current = false;
 			return;
 		}
-		// Unless we are mounting, we always want to focus either:
-		// - the URL input
-		// - the first focusable element in the Link UI.
-		// But in editing mode if there is a text input present then
-		// the URL input is at index 1. If not then it is at index 0.
-		const whichFocusTargetIndex = textInputRef?.current ? 1 : 0;
 
 		// Scenario - when:
 		// - switching between editable and non editable LinkControl
@@ -194,9 +188,8 @@ function LinkControl( {
 		// ...then move focus to the *first* element to avoid focus loss
 		// and to ensure focus is *within* the Link UI.
 		const nextFocusTarget =
-			focus.focusable.find( wrapperNode.current )[
-				whichFocusTargetIndex
-			] || wrapperNode.current;
+			focus.focusable.find( wrapperNode.current )[ 0 ] ||
+			wrapperNode.current;
 
 		nextFocusTarget.focus();
 

--- a/packages/e2e-tests/specs/editor/various/links.test.js
+++ b/packages/e2e-tests/specs/editor/various/links.test.js
@@ -614,7 +614,9 @@ describe( 'Links', () => {
 			);
 			await editButton.click();
 
-			// Tabbing should land us in the text input.
+			// tab forward to the text input.
+			await page.keyboard.press( 'Tab' );
+
 			const textInputValue = await page.evaluate(
 				() => document.activeElement.value
 			);

--- a/packages/e2e-tests/specs/editor/various/links.test.js
+++ b/packages/e2e-tests/specs/editor/various/links.test.js
@@ -585,7 +585,9 @@ describe( 'Links', () => {
 
 			await editButton.click();
 
-			// Tabbing back should land us in the text input.
+			// Tabbing forward should land us in the "Text" input.
+			await page.keyboard.press( 'Tab' );
+
 			const textInputValue = await page.evaluate(
 				() => document.activeElement.value
 			);


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Always focus the first focusable element when the Link UI opens

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
When something takes focus (like a popover or modal), it should also place focus on the first focusable element. It's an unexpected pattern for it to be placed on the second input.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Instead of guessing the placement of the URL input, always focus the first one (which does happen to be the URL input as of https://github.com/WordPress/gutenberg/pull/50957).

## Testing Instructions
- Add a link to paragraph text
- Edit the link
- First input should be focused

## Screenshots or screencast <!-- if applicable -->
<img width="416" alt="Link UI on post editor for an inline link with the focus placed on the first focusable element (the URL input)" src="https://github.com/WordPress/gutenberg/assets/967608/dca86f8f-3a12-4cd2-9221-d80e7195caa5">
