### PR TITLE
Use generic div instead of nav for <SidebarNavigationScreen />

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen/index.js
@@ -102,14 +102,14 @@ export default function SidebarNavigationScreen( {
 					</>
 				) }
 
-				<nav className="edit-site-sidebar-navigation-screen__content">
+				<div className="edit-site-sidebar-navigation-screen__content">
 					{ description && (
 						<p className="edit-site-sidebar-navigation-screen__description">
 							{ description }
 						</p>
 					) }
 					{ content }
-				</nav>
+				</div>
 			</VStack>
 			{ footer && (
 				<footer className="edit-site-sidebar-navigation-screen__footer">


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Closes https://github.com/WordPress/gutenberg/issues/48652

## What?
The `<SidebarNavigationScreen />` of the editor used a `<nav>` element to wrap the content passed to it, but since its creation that content area has expanded to contain non-navigation content. 

## Why?
The entire area is wrapped in a Navigation region, so the `<nav>` element is no longer necessary or relevant in a lot of its uses.



## How?
Switch the `<nav>` to a generic `<div>`.

## Testing Instructions
- Go to the Site Editor
- Confirm there is no `<nav>` element in the sidebar markup

## Screenshots or screencast <!-- if applicable -->

Before:
<img width="803" alt="Navigation sidebar region on the site editor with a dev tools inspector showing it's a <nav> element when the contents are not navigation related" src="https://github.com/WordPress/gutenberg/assets/967608/33a700f3-9ebc-4f3b-8d90-911016f13d90">

After:
Same, but with a `<div>` instead of a `<nav>`