### PR TITLE
Fix pattern styles not loading on fresh reload of Library page

### DIFF
--- a/packages/edit-site/src/components/library/index.js
+++ b/packages/edit-site/src/components/library/index.js
@@ -1,6 +1,7 @@
 /**
  * WordPress dependencies
  */
+import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
 import { useSelect } from '@wordpress/data';
 import { EditorSnackbars } from '@wordpress/editor';
 import { __ } from '@wordpress/i18n';
@@ -13,6 +14,10 @@ import { getQueryArgs } from '@wordpress/url';
  */
 import Grid from './grid';
 import useTitle from '../routes/use-title';
+import { unlock } from '../../private-apis';
+import { store as editSiteStore } from '../../store';
+
+const { ExperimentalBlockEditorProvider } = unlock( blockEditorPrivateApis );
 
 const DEFAULT_TYPE = 'wp_template_part';
 const DEFAULT_CATEGORY = 'header';
@@ -36,6 +41,11 @@ export default function Library() {
 
 	useTitle( __( 'Library' ) );
 
+	const settings = useSelect(
+		( select ) => select( editSiteStore ).getSettings(),
+		[]
+	);
+
 	// If we only have a single region, due to not including a header on this page,
 	// do we need the aria-label section?
 	const regionLabels = { body: __( 'Library - Content' ) };
@@ -46,11 +56,16 @@ export default function Library() {
 			labels={ regionLabels }
 			notices={ <EditorSnackbars /> }
 			content={
-				<Grid
-					type={ type }
-					category={ category }
-					label={ __( 'Patterns list' ) }
-				/>
+				// Wrap everything in a block editor provider.
+				// This ensures 'styles' that are needed for the previews are synced
+				// from the site editor store to the block editor store.
+				<ExperimentalBlockEditorProvider settings={ settings }>
+					<Grid
+						type={ type }
+						category={ category }
+						label={ __( 'Patterns list' ) }
+					/>
+				</ExperimentalBlockEditorProvider>
 			}
 			shortcuts={ {
 				previous: previousShortcut,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes an issue where when loading the library page (from [[WIP] Site Editor: Add Library page for Template Parts and Patterns](https://github.com/WordPress/gutenberg/pull/51078#top)), the patterns would appear unstyled.

## How?
The issue was that the `styles` weren't being set in the block editor store's `settings`, which is where each individual pattern loads the styles from. 

Typically, the styles are first set in the `edit-site` store's settings and need to be synced across to the block editor store, and the way to do that is to use a `BlockEditorProvider`.

I used the `ExperimentalBlockEditor` provider as that's what other views in the site editor seem to do, but it's undocumented, so I have no idea what makes it different to the normal `BlockEditorProvider`.

## Testing Instructions
1. Open the Library page
2. Choose a pattern category on the left
3. Refresh
4. The patterns should be styled.

## Screenshots or screencast <!-- if applicable -->
#### Before
![Screen Shot 2023-05-31 at 1 29 28 pm](https://github.com/WordPress/gutenberg/assets/677833/906c8428-eebe-4812-ae0b-78ab0e0c37ad)

#### After
![Screen Shot 2023-05-31 at 1 29 07 pm](https://github.com/WordPress/gutenberg/assets/677833/8b86912d-6469-4743-89ce-24fd86fb4b4b)
