### PR TITLE
Performance improvement: Reduce the use of the `_wp_array_get` function

### DIFF
--- a/lib/block-supports/background.php
+++ b/lib/block-supports/background.php
@@ -51,9 +51,9 @@ function gutenberg_render_background_support( $block_content, $block ) {
 		return $block_content;
 	}
 
-	$background_image_source = _wp_array_get( $block_attributes, array( 'style', 'background', 'backgroundImage', 'source' ), null );
-	$background_image_url    = _wp_array_get( $block_attributes, array( 'style', 'background', 'backgroundImage', 'url' ), null );
-	$background_size         = _wp_array_get( $block_attributes, array( 'style', 'background', 'backgroundSize' ), 'cover' );
+	$background_image_source = $block_attributes['style']['background']['backgroundImage']['source'] ?? null;
+	$background_image_url    = $block_attributes['style']['background']['backgroundImage']['url'] ?? null;
+	$background_size         = $block_attributes['style']['background']['backgroundSize'] ?? 'cover';
 
 	$background_block_styles = array();
 

--- a/lib/block-supports/background.php
+++ b/lib/block-supports/background.php
@@ -51,9 +51,9 @@ function gutenberg_render_background_support( $block_content, $block ) {
 		return $block_content;
 	}
 
-	$background_image_source = $block_attributes['style']['background']['backgroundImage']['source'] ?? null;
-	$background_image_url    = $block_attributes['style']['background']['backgroundImage']['url'] ?? null;
-	$background_size         = $block_attributes['style']['background']['backgroundSize'] ?? 'cover';
+	$background_image_source = isset( $block_attributes['style']['background']['backgroundImage']['source'] ) ? $block_attributes['style']['background']['backgroundImage']['source'] : null;
+	$background_image_url    = isset( $block_attributes['style']['background']['backgroundImage']['url'] ) ? $block_attributes['style']['background']['backgroundImage']['url'] : null;
+	$background_size         = isset( $block_attributes['style']['background']['backgroundSize'] ) ? $block_attributes['style']['background']['backgroundSize'] : 'cover';
 
 	$background_block_styles = array();
 

--- a/lib/block-supports/background.php
+++ b/lib/block-supports/background.php
@@ -51,9 +51,9 @@ function gutenberg_render_background_support( $block_content, $block ) {
 		return $block_content;
 	}
 
-	$background_image_source = isset( $block_attributes['style']['background']['backgroundImage']['source'] ) ? $block_attributes['style']['background']['backgroundImage']['source'] : null;
-	$background_image_url    = isset( $block_attributes['style']['background']['backgroundImage']['url'] ) ? $block_attributes['style']['background']['backgroundImage']['url'] : null;
-	$background_size         = isset( $block_attributes['style']['background']['backgroundSize'] ) ? $block_attributes['style']['background']['backgroundSize'] : 'cover';
+	$background_image_source = $block_attributes['style']['background']['backgroundImage']['source'] ?? null;
+	$background_image_url    = $block_attributes['style']['background']['backgroundImage']['url'] ?? null;
+	$background_size         = $block_attributes['style']['background']['backgroundSize'] ?? 'cover';
 
 	$background_block_styles = array();
 

--- a/lib/block-supports/border.php
+++ b/lib/block-supports/border.php
@@ -95,7 +95,7 @@ function gutenberg_apply_border_support( $block_type, $block_attributes ) {
 	) {
 		$preset_border_color          = array_key_exists( 'borderColor', $block_attributes ) ? "var:preset|color|{$block_attributes['borderColor']}" : null;
 		$custom_border_color          = isset( $block_attributes['style']['border']['color'] )
-			? _wp_array_get( $block_attributes, array( 'style', 'border', 'color' ), null )
+			? $block_attributes['style']['border']['color']
 			: null;
 		$border_block_styles['color'] = $preset_border_color ? $preset_border_color : $custom_border_color;
 	}
@@ -104,7 +104,7 @@ function gutenberg_apply_border_support( $block_type, $block_attributes ) {
 	if ( $has_border_color_support || $has_border_width_support ) {
 		foreach ( array( 'top', 'right', 'bottom', 'left' ) as $side ) {
 			$border                       = isset( $block_attributes['style']['border'][ $side ] )
-				? _wp_array_get( $block_attributes, array( 'style', 'border', $side ), null )
+				? $block_attributes['style']['border'][ $side ]
 				: null;
 			$border_side_values           = array(
 				'width' => isset( $border['width'] ) && ! wp_should_skip_block_supports_serialization( $block_type, '__experimentalBorder', 'width' ) ? $border['width'] : null,

--- a/lib/block-supports/border.php
+++ b/lib/block-supports/border.php
@@ -94,14 +94,14 @@ function gutenberg_apply_border_support( $block_type, $block_attributes ) {
 		! wp_should_skip_block_supports_serialization( $block_type, '__experimentalBorder', 'color' )
 	) {
 		$preset_border_color          = array_key_exists( 'borderColor', $block_attributes ) ? "var:preset|color|{$block_attributes['borderColor']}" : null;
-		$custom_border_color          = $block_attributes['style']['border']['color'] ?? null;
+		$custom_border_color          = isset( $block_attributes['style']['border']['color'] ) ? $block_attributes['style']['border']['color'] : null;
 		$border_block_styles['color'] = $preset_border_color ? $preset_border_color : $custom_border_color;
 	}
 
 	// Generate styles for individual border sides.
 	if ( $has_border_color_support || $has_border_width_support ) {
 		foreach ( array( 'top', 'right', 'bottom', 'left' ) as $side ) {
-			$border                       = $block_attributes['style']['border'][ $side ] ?? null;
+			$border                       = isset( $block_attributes['style']['border'][ $side ] ) ? $block_attributes['style']['border'][ $side ] : null;
 			$border_side_values           = array(
 				'width' => isset( $border['width'] ) && ! wp_should_skip_block_supports_serialization( $block_type, '__experimentalBorder', 'width' ) ? $border['width'] : null,
 				'color' => isset( $border['color'] ) && ! wp_should_skip_block_supports_serialization( $block_type, '__experimentalBorder', 'color' ) ? $border['color'] : null,

--- a/lib/block-supports/border.php
+++ b/lib/block-supports/border.php
@@ -142,11 +142,11 @@ function gutenberg_apply_border_support( $block_type, $block_attributes ) {
  */
 function gutenberg_has_border_feature_support( $block_type, $feature, $default_value = false ) {
 	// Check if all border support features have been opted into via `"__experimentalBorder": true`.
-	if (
-		property_exists( $block_type, 'supports' ) &&
-		( true === _wp_array_get( $block_type->supports, array( '__experimentalBorder' ), $default_value ) )
-	) {
-		return true;
+	if ( property_exists( $block_type, 'supports' ) ) {
+		$block_type_supports_border = $block_type->supports['__experimentalBorder'] ?? $default_value;
+		if ( true === $block_type_supports_border ) {
+			return true;
+		}
 	}
 
 	// Check if the specific feature has been opted into individually

--- a/lib/block-supports/border.php
+++ b/lib/block-supports/border.php
@@ -94,14 +94,18 @@ function gutenberg_apply_border_support( $block_type, $block_attributes ) {
 		! wp_should_skip_block_supports_serialization( $block_type, '__experimentalBorder', 'color' )
 	) {
 		$preset_border_color          = array_key_exists( 'borderColor', $block_attributes ) ? "var:preset|color|{$block_attributes['borderColor']}" : null;
-		$custom_border_color          = _wp_array_get( $block_attributes, array( 'style', 'border', 'color' ), null );
+		$custom_border_color          = isset( $block_attributes['style']['border']['color'] )
+			? _wp_array_get( $block_attributes, array( 'style', 'border', 'color' ), null )
+			: null;
 		$border_block_styles['color'] = $preset_border_color ? $preset_border_color : $custom_border_color;
 	}
 
 	// Generate styles for individual border sides.
 	if ( $has_border_color_support || $has_border_width_support ) {
 		foreach ( array( 'top', 'right', 'bottom', 'left' ) as $side ) {
-			$border                       = _wp_array_get( $block_attributes, array( 'style', 'border', $side ), null );
+			$border                       = isset( $block_attributes['style']['border'][ $side ] )
+				? _wp_array_get( $block_attributes, array( 'style', 'border', $side ), null )
+				: null;
 			$border_side_values           = array(
 				'width' => isset( $border['width'] ) && ! wp_should_skip_block_supports_serialization( $block_type, '__experimentalBorder', 'width' ) ? $border['width'] : null,
 				'color' => isset( $border['color'] ) && ! wp_should_skip_block_supports_serialization( $block_type, '__experimentalBorder', 'color' ) ? $border['color'] : null,

--- a/lib/block-supports/border.php
+++ b/lib/block-supports/border.php
@@ -94,18 +94,14 @@ function gutenberg_apply_border_support( $block_type, $block_attributes ) {
 		! wp_should_skip_block_supports_serialization( $block_type, '__experimentalBorder', 'color' )
 	) {
 		$preset_border_color          = array_key_exists( 'borderColor', $block_attributes ) ? "var:preset|color|{$block_attributes['borderColor']}" : null;
-		$custom_border_color          = isset( $block_attributes['style']['border']['color'] )
-			? $block_attributes['style']['border']['color']
-			: null;
+		$custom_border_color          = $block_attributes['style']['border']['color'] ?? null;
 		$border_block_styles['color'] = $preset_border_color ? $preset_border_color : $custom_border_color;
 	}
 
 	// Generate styles for individual border sides.
 	if ( $has_border_color_support || $has_border_width_support ) {
 		foreach ( array( 'top', 'right', 'bottom', 'left' ) as $side ) {
-			$border                       = isset( $block_attributes['style']['border'][ $side ] )
-				? $block_attributes['style']['border'][ $side ]
-				: null;
+			$border                       = $block_attributes['style']['border'][ $side ] ?? null;
 			$border_side_values           = array(
 				'width' => isset( $border['width'] ) && ! wp_should_skip_block_supports_serialization( $block_type, '__experimentalBorder', 'width' ) ? $border['width'] : null,
 				'color' => isset( $border['color'] ) && ! wp_should_skip_block_supports_serialization( $block_type, '__experimentalBorder', 'color' ) ? $border['color'] : null,

--- a/lib/block-supports/border.php
+++ b/lib/block-supports/border.php
@@ -94,14 +94,14 @@ function gutenberg_apply_border_support( $block_type, $block_attributes ) {
 		! wp_should_skip_block_supports_serialization( $block_type, '__experimentalBorder', 'color' )
 	) {
 		$preset_border_color          = array_key_exists( 'borderColor', $block_attributes ) ? "var:preset|color|{$block_attributes['borderColor']}" : null;
-		$custom_border_color          = isset( $block_attributes['style']['border']['color'] ) ? $block_attributes['style']['border']['color'] : null;
+		$custom_border_color          = $block_attributes['style']['border']['color'] ?? null;
 		$border_block_styles['color'] = $preset_border_color ? $preset_border_color : $custom_border_color;
 	}
 
 	// Generate styles for individual border sides.
 	if ( $has_border_color_support || $has_border_width_support ) {
 		foreach ( array( 'top', 'right', 'bottom', 'left' ) as $side ) {
-			$border                       = isset( $block_attributes['style']['border'][ $side ] ) ? $block_attributes['style']['border'][ $side ] : null;
+			$border                       = $block_attributes['style']['border'][ $side ] ?? null;
 			$border_side_values           = array(
 				'width' => isset( $border['width'] ) && ! wp_should_skip_block_supports_serialization( $block_type, '__experimentalBorder', 'width' ) ? $border['width'] : null,
 				'color' => isset( $border['color'] ) && ! wp_should_skip_block_supports_serialization( $block_type, '__experimentalBorder', 'color' ) ? $border['color'] : null,

--- a/lib/block-supports/colors.php
+++ b/lib/block-supports/colors.php
@@ -65,7 +65,7 @@ function gutenberg_register_colors_support( $block_type ) {
  * @return array Colors CSS classes and inline styles.
  */
 function gutenberg_apply_colors_support( $block_type, $block_attributes ) {
-	$color_support = $block_type->supports['color'] && $block_type->supports['color']
+	$color_support = isset( $block_type->supports['color'] ) && $block_type->supports['color']
 		? _wp_array_get( $block_type->supports, array( 'color' ), false )
 		: false;
 

--- a/lib/block-supports/colors.php
+++ b/lib/block-supports/colors.php
@@ -65,7 +65,9 @@ function gutenberg_register_colors_support( $block_type ) {
  * @return array Colors CSS classes and inline styles.
  */
 function gutenberg_apply_colors_support( $block_type, $block_attributes ) {
-	$color_support = _wp_array_get( $block_type->supports, array( 'color' ), false );
+	$color_support = $block_type->supports['color'] && $block_type->supports['color']
+		? _wp_array_get( $block_type->supports, array( 'color' ), false )
+		: false;
 
 	if (
 		is_array( $color_support ) &&
@@ -74,23 +76,27 @@ function gutenberg_apply_colors_support( $block_type, $block_attributes ) {
 		return array();
 	}
 
-	$has_text_colors_support       = true === $color_support || ( is_array( $color_support ) && _wp_array_get( $color_support, array( 'text' ), true ) );
-	$has_background_colors_support = true === $color_support || ( is_array( $color_support ) && _wp_array_get( $color_support, array( 'background' ), true ) );
-	$has_gradients_support         = _wp_array_get( $color_support, array( 'gradients' ), false );
+	$has_text_colors_support       = true === $color_support || ( is_array( $color_support ) && ( ! isset( $color_support['text'] ) || $color_support['text'] ) );
+	$has_background_colors_support = true === $color_support || ( is_array( $color_support ) && ! isset( $color_support['background'] ) || $color_support['background'] );
+	$has_gradients_support         = isset( $color_support['gradients'] ) && $color_support['gradients'];
 	$color_block_styles            = array();
 
 	// Text colors.
 	// Check support for text colors.
 	if ( $has_text_colors_support && ! wp_should_skip_block_supports_serialization( $block_type, 'color', 'text' ) ) {
 		$preset_text_color          = array_key_exists( 'textColor', $block_attributes ) ? "var:preset|color|{$block_attributes['textColor']}" : null;
-		$custom_text_color          = _wp_array_get( $block_attributes, array( 'style', 'color', 'text' ), null );
+		$custom_text_color          = isset( $block_attributes['style']['color']['text'] )
+			? _wp_array_get( $block_attributes, array( 'style', 'color', 'text' ), null )
+			: null;
 		$color_block_styles['text'] = $preset_text_color ? $preset_text_color : $custom_text_color;
 	}
 
 	// Background colors.
 	if ( $has_background_colors_support && ! wp_should_skip_block_supports_serialization( $block_type, 'color', 'background' ) ) {
 		$preset_background_color          = array_key_exists( 'backgroundColor', $block_attributes ) ? "var:preset|color|{$block_attributes['backgroundColor']}" : null;
-		$custom_background_color          = _wp_array_get( $block_attributes, array( 'style', 'color', 'background' ), null );
+		$custom_background_color          = isset( $block_attributes['style']['color']['background'] )
+			? _wp_array_get( $block_attributes, array( 'style', 'color', 'background' ), null )
+			: null;
 		$color_block_styles['background'] = $preset_background_color ? $preset_background_color : $custom_background_color;
 	}
 
@@ -98,7 +104,9 @@ function gutenberg_apply_colors_support( $block_type, $block_attributes ) {
 
 	if ( $has_gradients_support && ! wp_should_skip_block_supports_serialization( $block_type, 'color', 'gradients' ) ) {
 		$preset_gradient_color          = array_key_exists( 'gradient', $block_attributes ) ? "var:preset|gradient|{$block_attributes['gradient']}" : null;
-		$custom_gradient_color          = _wp_array_get( $block_attributes, array( 'style', 'color', 'gradient' ), null );
+		$custom_gradient_color          = isset( $block_attributes['style']['color']['gradient'] )
+			? _wp_array_get( $block_attributes, array( 'style', 'color', 'gradient' ), null )
+			: null;
 		$color_block_styles['gradient'] = $preset_gradient_color ? $preset_gradient_color : $custom_gradient_color;
 	}
 

--- a/lib/block-supports/colors.php
+++ b/lib/block-supports/colors.php
@@ -11,7 +11,10 @@
  * @param WP_Block_Type $block_type Block Type.
  */
 function gutenberg_register_colors_support( $block_type ) {
-	$color_support                 = property_exists( $block_type, 'supports' ) && isset( $block_type->supports['color'] ) ? $block_type->supports['color'] : false;
+	$color_support = false;
+	if ( property_exists( $block_type, 'supports' ) ) {
+		$color_support = $block_type->supports['color'] ?? false;
+	}
 	$has_text_colors_support       = true === $color_support || ( is_array( $color_support ) && ( ( isset( $color_support['text'] ) && $color_support['text'] ) || ! isset( $color_support['text'] ) ) );
 	$has_background_colors_support = true === $color_support || ( is_array( $color_support ) && ( ( isset( $color_support['background'] ) && $color_support['background'] ) || ! isset( $color_support['background'] ) ) );
 	$has_gradients_support         = $color_support['gradients'] ?? false;

--- a/lib/block-supports/colors.php
+++ b/lib/block-supports/colors.php
@@ -13,14 +13,14 @@
 function gutenberg_register_colors_support( $block_type ) {
 	$color_support = false;
 	if ( property_exists( $block_type, 'supports' ) ) {
-		$color_support = $block_type->supports['color'] ?? false;
+		$color_support = isset( $block_type->supports['color'] ) ? $block_type->supports['color'] : false;
 	}
 	$has_text_colors_support       = true === $color_support || ( is_array( $color_support ) && ( ( isset( $color_support['text'] ) && $color_support['text'] ) || ! isset( $color_support['text'] ) ) );
 	$has_background_colors_support = true === $color_support || ( is_array( $color_support ) && ( ( isset( $color_support['background'] ) && $color_support['background'] ) || ! isset( $color_support['background'] ) ) );
-	$has_gradients_support         = $color_support['gradients'] ?? false;
-	$has_link_colors_support       = $color_support['link'] ?? false;
-	$has_button_colors_support     = $color_support['button'] ?? false;
-	$has_heading_colors_support    = $color_support['heading'] ?? false;
+	$has_gradients_support         = isset( $color_support['gradients'] ) ? $color_support['gradients'] : false;
+	$has_link_colors_support       = isset( $color_support['link'] ) ? $color_support['link'] : false;
+	$has_button_colors_support     = isset( $color_support['button'] ) ? $color_support['button'] : false;
+	$has_heading_colors_support    = isset( $color_support['heading'] ) ? $color_support['heading'] : false;
 	$has_color_support             = $has_text_colors_support ||
 		$has_background_colors_support ||
 		$has_gradients_support ||
@@ -68,7 +68,7 @@ function gutenberg_register_colors_support( $block_type ) {
  * @return array Colors CSS classes and inline styles.
  */
 function gutenberg_apply_colors_support( $block_type, $block_attributes ) {
-	$color_support = $block_type->supports['color'] ?? false;
+	$color_support = isset( $block_type->supports['color'] ) ? $block_type->supports['color'] : false;
 
 	if (
 		is_array( $color_support ) &&
@@ -79,21 +79,21 @@ function gutenberg_apply_colors_support( $block_type, $block_attributes ) {
 
 	$has_text_colors_support       = true === $color_support || ( is_array( $color_support ) && ( ( isset( $color_support['text'] ) && $color_support['text'] ) || ! isset( $color_support['text'] ) ) );
 	$has_background_colors_support = true === $color_support || ( is_array( $color_support ) && ( ( isset( $color_support['background'] ) && $color_support['background'] ) || ! isset( $color_support['background'] ) ) );
-	$has_gradients_support         = $color_support['gradients'] ?? false;
+	$has_gradients_support         = isset( $color_support['gradients'] ) ? $color_support['gradients'] : false;
 	$color_block_styles            = array();
 
 	// Text colors.
 	// Check support for text colors.
 	if ( $has_text_colors_support && ! wp_should_skip_block_supports_serialization( $block_type, 'color', 'text' ) ) {
 		$preset_text_color          = array_key_exists( 'textColor', $block_attributes ) ? "var:preset|color|{$block_attributes['textColor']}" : null;
-		$custom_text_color          = $block_attributes['style']['color']['text'] ?? null;
+		$custom_text_color          = isset( $block_attributes['style']['color']['text'] ) ? $block_attributes['style']['color']['text'] : null;
 		$color_block_styles['text'] = $preset_text_color ? $preset_text_color : $custom_text_color;
 	}
 
 	// Background colors.
 	if ( $has_background_colors_support && ! wp_should_skip_block_supports_serialization( $block_type, 'color', 'background' ) ) {
 		$preset_background_color          = array_key_exists( 'backgroundColor', $block_attributes ) ? "var:preset|color|{$block_attributes['backgroundColor']}" : null;
-		$custom_background_color          = $block_attributes['style']['color']['background'] ?? null;
+		$custom_background_color          = isset( $block_attributes['style']['color']['background'] ) ? $block_attributes['style']['color']['background'] : null;
 		$color_block_styles['background'] = $preset_background_color ? $preset_background_color : $custom_background_color;
 	}
 
@@ -101,7 +101,7 @@ function gutenberg_apply_colors_support( $block_type, $block_attributes ) {
 
 	if ( $has_gradients_support && ! wp_should_skip_block_supports_serialization( $block_type, 'color', 'gradients' ) ) {
 		$preset_gradient_color          = array_key_exists( 'gradient', $block_attributes ) ? "var:preset|gradient|{$block_attributes['gradient']}" : null;
-		$custom_gradient_color          = $block_attributes['style']['color']['gradient'] ?? null;
+		$custom_gradient_color          = isset( $block_attributes['style']['color']['gradient'] ) ? $block_attributes['style']['color']['gradient'] : null;
 		$color_block_styles['gradient'] = $preset_gradient_color ? $preset_gradient_color : $custom_gradient_color;
 	}
 

--- a/lib/block-supports/colors.php
+++ b/lib/block-supports/colors.php
@@ -77,7 +77,7 @@ function gutenberg_apply_colors_support( $block_type, $block_attributes ) {
 	}
 
 	$has_text_colors_support       = true === $color_support || ( is_array( $color_support ) && ( ! isset( $color_support['text'] ) || $color_support['text'] ) );
-	$has_background_colors_support = true === $color_support || ( is_array( $color_support ) && ! isset( $color_support['background'] ) || $color_support['background'] );
+	$has_background_colors_support = true === $color_support || ( is_array( $color_support ) && ( ! isset( $color_support['background'] ) || $color_support['background'] ) );
 	$has_gradients_support         = isset( $color_support['gradients'] ) && $color_support['gradients'];
 	$color_block_styles            = array();
 

--- a/lib/block-supports/colors.php
+++ b/lib/block-supports/colors.php
@@ -81,7 +81,9 @@ function gutenberg_apply_colors_support( $block_type, $block_attributes ) {
 		return array();
 	}
 
-	$has_text_colors_support       = true === $color_support || ( is_array( $color_support ) && ( ( isset( $color_support['text'] ) && $color_support['text'] ) || ! isset( $color_support['text'] ) ) );
+	$has_text_colors_support       = true === $color_support ||
+		( isset( $color_support['text'] ) && $color_support['text'] ) ||
+		( is_array( $color_support ) && ! isset( $color_support['text'] ) );
 	$has_background_colors_support = true === $color_support ||
 		( isset( $color_support['background'] ) && $color_support['background'] ) ||
 		( is_array( $color_support ) && ! isset( $color_support['background'] ) );

--- a/lib/block-supports/colors.php
+++ b/lib/block-supports/colors.php
@@ -66,7 +66,7 @@ function gutenberg_register_colors_support( $block_type ) {
  */
 function gutenberg_apply_colors_support( $block_type, $block_attributes ) {
 	$color_support = isset( $block_type->supports['color'] ) && $block_type->supports['color']
-		? _wp_array_get( $block_type->supports, array( 'color' ), false )
+		? $block_type->supports['color']
 		: false;
 
 	if (
@@ -86,7 +86,7 @@ function gutenberg_apply_colors_support( $block_type, $block_attributes ) {
 	if ( $has_text_colors_support && ! wp_should_skip_block_supports_serialization( $block_type, 'color', 'text' ) ) {
 		$preset_text_color          = array_key_exists( 'textColor', $block_attributes ) ? "var:preset|color|{$block_attributes['textColor']}" : null;
 		$custom_text_color          = isset( $block_attributes['style']['color']['text'] )
-			? _wp_array_get( $block_attributes, array( 'style', 'color', 'text' ), null )
+			? $block_attributes['style']['color']['text']
 			: null;
 		$color_block_styles['text'] = $preset_text_color ? $preset_text_color : $custom_text_color;
 	}
@@ -95,7 +95,7 @@ function gutenberg_apply_colors_support( $block_type, $block_attributes ) {
 	if ( $has_background_colors_support && ! wp_should_skip_block_supports_serialization( $block_type, 'color', 'background' ) ) {
 		$preset_background_color          = array_key_exists( 'backgroundColor', $block_attributes ) ? "var:preset|color|{$block_attributes['backgroundColor']}" : null;
 		$custom_background_color          = isset( $block_attributes['style']['color']['background'] )
-			? _wp_array_get( $block_attributes, array( 'style', 'color', 'background' ), null )
+			? $block_attributes['style']['color']['background']
 			: null;
 		$color_block_styles['background'] = $preset_background_color ? $preset_background_color : $custom_background_color;
 	}
@@ -105,7 +105,7 @@ function gutenberg_apply_colors_support( $block_type, $block_attributes ) {
 	if ( $has_gradients_support && ! wp_should_skip_block_supports_serialization( $block_type, 'color', 'gradients' ) ) {
 		$preset_gradient_color          = array_key_exists( 'gradient', $block_attributes ) ? "var:preset|gradient|{$block_attributes['gradient']}" : null;
 		$custom_gradient_color          = isset( $block_attributes['style']['color']['gradient'] )
-			? _wp_array_get( $block_attributes, array( 'style', 'color', 'gradient' ), null )
+			? $block_attributes['style']['color']['gradient']
 			: null;
 		$color_block_styles['gradient'] = $preset_gradient_color ? $preset_gradient_color : $custom_gradient_color;
 	}

--- a/lib/block-supports/colors.php
+++ b/lib/block-supports/colors.php
@@ -13,14 +13,14 @@
 function gutenberg_register_colors_support( $block_type ) {
 	$color_support = false;
 	if ( property_exists( $block_type, 'supports' ) ) {
-		$color_support = isset( $block_type->supports['color'] ) ? $block_type->supports['color'] : false;
+		$color_support = $block_type->supports['color'] ?? false;
 	}
 	$has_text_colors_support       = true === $color_support || ( is_array( $color_support ) && ( ( isset( $color_support['text'] ) && $color_support['text'] ) || ! isset( $color_support['text'] ) ) );
 	$has_background_colors_support = true === $color_support || ( is_array( $color_support ) && ( ( isset( $color_support['background'] ) && $color_support['background'] ) || ! isset( $color_support['background'] ) ) );
-	$has_gradients_support         = isset( $color_support['gradients'] ) ? $color_support['gradients'] : false;
-	$has_link_colors_support       = isset( $color_support['link'] ) ? $color_support['link'] : false;
-	$has_button_colors_support     = isset( $color_support['button'] ) ? $color_support['button'] : false;
-	$has_heading_colors_support    = isset( $color_support['heading'] ) ? $color_support['heading'] : false;
+	$has_gradients_support         = $color_support['gradients'] ?? false;
+	$has_link_colors_support       = $color_support['link'] ?? false;
+	$has_button_colors_support     = $color_support['button'] ?? false;
+	$has_heading_colors_support    = $color_support['heading'] ?? false;
 	$has_color_support             = $has_text_colors_support ||
 		$has_background_colors_support ||
 		$has_gradients_support ||
@@ -68,7 +68,7 @@ function gutenberg_register_colors_support( $block_type ) {
  * @return array Colors CSS classes and inline styles.
  */
 function gutenberg_apply_colors_support( $block_type, $block_attributes ) {
-	$color_support = isset( $block_type->supports['color'] ) ? $block_type->supports['color'] : false;
+	$color_support = $block_type->supports['color'] ?? false;
 
 	if (
 		is_array( $color_support ) &&
@@ -79,21 +79,21 @@ function gutenberg_apply_colors_support( $block_type, $block_attributes ) {
 
 	$has_text_colors_support       = true === $color_support || ( is_array( $color_support ) && ( ( isset( $color_support['text'] ) && $color_support['text'] ) || ! isset( $color_support['text'] ) ) );
 	$has_background_colors_support = true === $color_support || ( is_array( $color_support ) && ( ( isset( $color_support['background'] ) && $color_support['background'] ) || ! isset( $color_support['background'] ) ) );
-	$has_gradients_support         = isset( $color_support['gradients'] ) ? $color_support['gradients'] : false;
+	$has_gradients_support         = $color_support['gradients'] ?? false;
 	$color_block_styles            = array();
 
 	// Text colors.
 	// Check support for text colors.
 	if ( $has_text_colors_support && ! wp_should_skip_block_supports_serialization( $block_type, 'color', 'text' ) ) {
 		$preset_text_color          = array_key_exists( 'textColor', $block_attributes ) ? "var:preset|color|{$block_attributes['textColor']}" : null;
-		$custom_text_color          = isset( $block_attributes['style']['color']['text'] ) ? $block_attributes['style']['color']['text'] : null;
+		$custom_text_color          = $block_attributes['style']['color']['text'] ?? null;
 		$color_block_styles['text'] = $preset_text_color ? $preset_text_color : $custom_text_color;
 	}
 
 	// Background colors.
 	if ( $has_background_colors_support && ! wp_should_skip_block_supports_serialization( $block_type, 'color', 'background' ) ) {
 		$preset_background_color          = array_key_exists( 'backgroundColor', $block_attributes ) ? "var:preset|color|{$block_attributes['backgroundColor']}" : null;
-		$custom_background_color          = isset( $block_attributes['style']['color']['background'] ) ? $block_attributes['style']['color']['background'] : null;
+		$custom_background_color          = $block_attributes['style']['color']['background'] ?? null;
 		$color_block_styles['background'] = $preset_background_color ? $preset_background_color : $custom_background_color;
 	}
 
@@ -101,7 +101,7 @@ function gutenberg_apply_colors_support( $block_type, $block_attributes ) {
 
 	if ( $has_gradients_support && ! wp_should_skip_block_supports_serialization( $block_type, 'color', 'gradients' ) ) {
 		$preset_gradient_color          = array_key_exists( 'gradient', $block_attributes ) ? "var:preset|gradient|{$block_attributes['gradient']}" : null;
-		$custom_gradient_color          = isset( $block_attributes['style']['color']['gradient'] ) ? $block_attributes['style']['color']['gradient'] : null;
+		$custom_gradient_color          = $block_attributes['style']['color']['gradient'] ?? null;
 		$color_block_styles['gradient'] = $preset_gradient_color ? $preset_gradient_color : $custom_gradient_color;
 	}
 

--- a/lib/block-supports/colors.php
+++ b/lib/block-supports/colors.php
@@ -15,8 +15,12 @@ function gutenberg_register_colors_support( $block_type ) {
 	if ( property_exists( $block_type, 'supports' ) ) {
 		$color_support = $block_type->supports['color'] ?? false;
 	}
-	$has_text_colors_support       = true === $color_support || ( is_array( $color_support ) && ( ( isset( $color_support['text'] ) && $color_support['text'] ) || ! isset( $color_support['text'] ) ) );
-	$has_background_colors_support = true === $color_support || ( is_array( $color_support ) && ( ( isset( $color_support['background'] ) && $color_support['background'] ) || ! isset( $color_support['background'] ) ) );
+	$has_text_colors_support       = true === $color_support ||
+		( isset( $color_support['text'] ) && $color_support['text'] ) ||
+		( is_array( $color_support ) && ! isset( $color_support['text'] ) );
+	$has_background_colors_support = true === $color_support ||
+		( isset( $color_support['background'] ) && $color_support['background'] ) ||
+		( is_array( $color_support ) && ! isset( $color_support['background'] ) );
 	$has_gradients_support         = $color_support['gradients'] ?? false;
 	$has_link_colors_support       = $color_support['link'] ?? false;
 	$has_button_colors_support     = $color_support['button'] ?? false;
@@ -78,7 +82,9 @@ function gutenberg_apply_colors_support( $block_type, $block_attributes ) {
 	}
 
 	$has_text_colors_support       = true === $color_support || ( is_array( $color_support ) && ( ( isset( $color_support['text'] ) && $color_support['text'] ) || ! isset( $color_support['text'] ) ) );
-	$has_background_colors_support = true === $color_support || ( is_array( $color_support ) && ( ( isset( $color_support['background'] ) && $color_support['background'] ) || ! isset( $color_support['background'] ) ) );
+	$has_background_colors_support = true === $color_support ||
+		( isset( $color_support['background'] ) && $color_support['background'] ) ||
+		( is_array( $color_support ) && ! isset( $color_support['background'] ) );
 	$has_gradients_support         = $color_support['gradients'] ?? false;
 	$color_block_styles            = array();
 

--- a/lib/block-supports/colors.php
+++ b/lib/block-supports/colors.php
@@ -11,13 +11,13 @@
  * @param WP_Block_Type $block_type Block Type.
  */
 function gutenberg_register_colors_support( $block_type ) {
-	$color_support                 = property_exists( $block_type, 'supports' ) ? _wp_array_get( $block_type->supports, array( 'color' ), false ) : false;
-	$has_text_colors_support       = true === $color_support || ( is_array( $color_support ) && _wp_array_get( $color_support, array( 'text' ), true ) );
-	$has_background_colors_support = true === $color_support || ( is_array( $color_support ) && _wp_array_get( $color_support, array( 'background' ), true ) );
-	$has_gradients_support         = _wp_array_get( $color_support, array( 'gradients' ), false );
-	$has_link_colors_support       = _wp_array_get( $color_support, array( 'link' ), false );
-	$has_button_colors_support     = _wp_array_get( $color_support, array( 'button' ), false );
-	$has_heading_colors_support    = _wp_array_get( $color_support, array( 'heading' ), false );
+	$color_support                 = property_exists( $block_type, 'supports' ) && isset( $block_type->supports['color'] ) ? $block_type->supports['color'] : false;
+	$has_text_colors_support       = true === $color_support || ( is_array( $color_support ) && ( ( isset( $color_support['text'] ) && $color_support['text'] ) || ! isset( $color_support['text'] ) ) );
+	$has_background_colors_support = true === $color_support || ( is_array( $color_support ) && ( ( isset( $color_support['background'] ) && $color_support['background'] ) || ! isset( $color_support['background'] ) ) );
+	$has_gradients_support         = $color_support['gradients'] ?? false;
+	$has_link_colors_support       = $color_support['link'] ?? false;
+	$has_button_colors_support     = $color_support['button'] ?? false;
+	$has_heading_colors_support    = $color_support['heading'] ?? false;
 	$has_color_support             = $has_text_colors_support ||
 		$has_background_colors_support ||
 		$has_gradients_support ||
@@ -65,9 +65,7 @@ function gutenberg_register_colors_support( $block_type ) {
  * @return array Colors CSS classes and inline styles.
  */
 function gutenberg_apply_colors_support( $block_type, $block_attributes ) {
-	$color_support = isset( $block_type->supports['color'] ) && $block_type->supports['color']
-		? $block_type->supports['color']
-		: false;
+	$color_support = $block_type->supports['color'] ?? false;
 
 	if (
 		is_array( $color_support ) &&
@@ -76,27 +74,23 @@ function gutenberg_apply_colors_support( $block_type, $block_attributes ) {
 		return array();
 	}
 
-	$has_text_colors_support       = true === $color_support || ( is_array( $color_support ) && ( ! isset( $color_support['text'] ) || $color_support['text'] ) );
-	$has_background_colors_support = true === $color_support || ( is_array( $color_support ) && ( ! isset( $color_support['background'] ) || $color_support['background'] ) );
-	$has_gradients_support         = isset( $color_support['gradients'] ) && $color_support['gradients'];
+	$has_text_colors_support       = true === $color_support || ( is_array( $color_support ) && ( ( isset( $color_support['text'] ) && $color_support['text'] ) || ! isset( $color_support['text'] ) ) );
+	$has_background_colors_support = true === $color_support || ( is_array( $color_support ) && ( ( isset( $color_support['background'] ) && $color_support['background'] ) || ! isset( $color_support['background'] ) ) );
+	$has_gradients_support         = $color_support['gradients'] ?? false;
 	$color_block_styles            = array();
 
 	// Text colors.
 	// Check support for text colors.
 	if ( $has_text_colors_support && ! wp_should_skip_block_supports_serialization( $block_type, 'color', 'text' ) ) {
 		$preset_text_color          = array_key_exists( 'textColor', $block_attributes ) ? "var:preset|color|{$block_attributes['textColor']}" : null;
-		$custom_text_color          = isset( $block_attributes['style']['color']['text'] )
-			? $block_attributes['style']['color']['text']
-			: null;
+		$custom_text_color          = $block_attributes['style']['color']['text'] ?? null;
 		$color_block_styles['text'] = $preset_text_color ? $preset_text_color : $custom_text_color;
 	}
 
 	// Background colors.
 	if ( $has_background_colors_support && ! wp_should_skip_block_supports_serialization( $block_type, 'color', 'background' ) ) {
 		$preset_background_color          = array_key_exists( 'backgroundColor', $block_attributes ) ? "var:preset|color|{$block_attributes['backgroundColor']}" : null;
-		$custom_background_color          = isset( $block_attributes['style']['color']['background'] )
-			? $block_attributes['style']['color']['background']
-			: null;
+		$custom_background_color          = $block_attributes['style']['color']['background'] ?? null;
 		$color_block_styles['background'] = $preset_background_color ? $preset_background_color : $custom_background_color;
 	}
 
@@ -104,9 +98,7 @@ function gutenberg_apply_colors_support( $block_type, $block_attributes ) {
 
 	if ( $has_gradients_support && ! wp_should_skip_block_supports_serialization( $block_type, 'color', 'gradients' ) ) {
 		$preset_gradient_color          = array_key_exists( 'gradient', $block_attributes ) ? "var:preset|gradient|{$block_attributes['gradient']}" : null;
-		$custom_gradient_color          = isset( $block_attributes['style']['color']['gradient'] )
-			? $block_attributes['style']['color']['gradient']
-			: null;
+		$custom_gradient_color          = $block_attributes['style']['color']['gradient'] ?? null;
 		$color_block_styles['gradient'] = $preset_gradient_color ? $preset_gradient_color : $custom_gradient_color;
 	}
 

--- a/lib/block-supports/dimensions.php
+++ b/lib/block-supports/dimensions.php
@@ -64,7 +64,7 @@ function gutenberg_apply_dimensions_support( $block_type, $block_attributes ) { 
 	$dimensions_block_styles['minHeight'] = null;
 	if ( $has_min_height_support && ! $skip_min_height ) {
 		$dimensions_block_styles['minHeight'] = isset( $block_styles['dimensions']['minHeight'] )
-			? _wp_array_get( $block_styles, array( 'dimensions', 'minHeight' ), null )
+			? $block_styles['dimensions']['minHeight']
 			: null;
 	}
 	$styles = gutenberg_style_engine_get_styles( array( 'dimensions' => $dimensions_block_styles ) );

--- a/lib/block-supports/dimensions.php
+++ b/lib/block-supports/dimensions.php
@@ -61,8 +61,13 @@ function gutenberg_apply_dimensions_support( $block_type, $block_attributes ) { 
 
 	$skip_min_height                      = wp_should_skip_block_supports_serialization( $block_type, 'dimensions', 'minHeight' );
 	$dimensions_block_styles              = array();
-	$dimensions_block_styles['minHeight'] = $has_min_height_support && ! $skip_min_height ? _wp_array_get( $block_styles, array( 'dimensions', 'minHeight' ), null ) : null;
-	$styles                               = gutenberg_style_engine_get_styles( array( 'dimensions' => $dimensions_block_styles ) );
+	$dimensions_block_styles['minHeight'] = null;
+	if ( $has_min_height_support && ! $skip_min_height ) {
+		$dimensions_block_styles['minHeight'] = isset( $block_styles['dimensions']['minHeight'] )
+			? _wp_array_get( $block_styles, array( 'dimensions', 'minHeight' ), null )
+			: null;
+	}
+	$styles = gutenberg_style_engine_get_styles( array( 'dimensions' => $dimensions_block_styles ) );
 
 	if ( ! empty( $styles['css'] ) ) {
 		$attributes['style'] = $styles['css'];

--- a/lib/block-supports/dimensions.php
+++ b/lib/block-supports/dimensions.php
@@ -63,7 +63,7 @@ function gutenberg_apply_dimensions_support( $block_type, $block_attributes ) { 
 	$dimensions_block_styles              = array();
 	$dimensions_block_styles['minHeight'] = null;
 	if ( $has_min_height_support && ! $skip_min_height ) {
-		$dimensions_block_styles['minHeight'] = $block_styles['dimensions']['minHeight'] ?? null;
+		$dimensions_block_styles['minHeight'] = isset( $block_styles['dimensions']['minHeight'] ) ? $block_styles['dimensions']['minHeight'] : null;
 	}
 	$styles = gutenberg_style_engine_get_styles( array( 'dimensions' => $dimensions_block_styles ) );
 

--- a/lib/block-supports/dimensions.php
+++ b/lib/block-supports/dimensions.php
@@ -63,9 +63,7 @@ function gutenberg_apply_dimensions_support( $block_type, $block_attributes ) { 
 	$dimensions_block_styles              = array();
 	$dimensions_block_styles['minHeight'] = null;
 	if ( $has_min_height_support && ! $skip_min_height ) {
-		$dimensions_block_styles['minHeight'] = isset( $block_styles['dimensions']['minHeight'] )
-			? $block_styles['dimensions']['minHeight']
-			: null;
+		$dimensions_block_styles['minHeight'] = $block_styles['dimensions']['minHeight'] ?? null;
 	}
 	$styles = gutenberg_style_engine_get_styles( array( 'dimensions' => $dimensions_block_styles ) );
 

--- a/lib/block-supports/dimensions.php
+++ b/lib/block-supports/dimensions.php
@@ -63,7 +63,7 @@ function gutenberg_apply_dimensions_support( $block_type, $block_attributes ) { 
 	$dimensions_block_styles              = array();
 	$dimensions_block_styles['minHeight'] = null;
 	if ( $has_min_height_support && ! $skip_min_height ) {
-		$dimensions_block_styles['minHeight'] = isset( $block_styles['dimensions']['minHeight'] ) ? $block_styles['dimensions']['minHeight'] : null;
+		$dimensions_block_styles['minHeight'] = $block_styles['dimensions']['minHeight'] ?? null;
 	}
 	$styles = gutenberg_style_engine_get_styles( array( 'dimensions' => $dimensions_block_styles ) );
 

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -222,7 +222,7 @@ function gutenberg_register_layout_support( $block_type ) {
  * @return string CSS styles on success. Else, empty string.
  */
 function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support = false, $gap_value = null, $should_skip_gap_serialization = false, $fallback_gap_value = '0.5em', $block_spacing = null ) {
-	$layout_type   = isset( $layout['type'] ) ? $layout['type'] : 'default';
+	$layout_type   = $layout['type'] ?? 'default';
 	$layout_styles = array();
 
 	if ( 'default' === $layout_type ) {
@@ -403,7 +403,7 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 			foreach ( $gap_sides as $gap_side ) {
 				$process_value = $gap_value;
 				if ( is_array( $gap_value ) ) {
-					$gap_value = $gap_value[ $gap_side ] ?? $fallback_gap_value;
+					$process_value = $gap_value[ $gap_side ] ?? $fallback_gap_value;
 				}
 				// Get spacing CSS variable from preset value if provided.
 				if ( is_string( $process_value ) && str_contains( $process_value, 'var:preset|spacing|' ) ) {

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -602,7 +602,7 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 	}
 
 	$global_settings = gutenberg_get_global_settings();
-	if ( isset( $block_type->supports['layout']['default'] ) ! empty( $block_type->supports['layout']['default'] ) ) {
+	if ( isset( $block_type->supports['layout']['default'] ) && ! empty( $block_type->supports['layout']['default'] ) ) {
 		$fallback_layout = isset( $block_type->supports['layout']['default'] )
 			? $block_type->supports['layout']['default']
 			: array();

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -604,7 +604,7 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 	if ( empty( $fallback_layout ) ) {
 		$fallback_layout = $block_type->supports['__experimentalLayout']['default'] ?? array();
 	}
-	$used_layout = isset( $block['attrs']['layout'] ) ? $block['attrs']['layout'] : $fallback_layout;
+	$used_layout = $block['attrs']['layout'] ?? $fallback_layout;
 
 	$class_names        = array();
 	$layout_definitions = gutenberg_get_layout_definitions();

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -401,7 +401,12 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 			$gap_sides          = is_array( $gap_value ) ? array( 'top', 'left' ) : array( 'top' );
 
 			foreach ( $gap_sides as $gap_side ) {
-				$process_value = is_string( $gap_value ) ? $gap_value : _wp_array_get( $gap_value, array( $gap_side ), $fallback_gap_value );
+				$process_value = $gap_value;
+				if ( ! is_string( $gap_value ) ) {
+					$process_value = isset( $gap_value[ $gap_side ] )
+						? _wp_array_get( $gap_value, array( $gap_side ), $fallback_gap_value )
+						: $fallback_gap_value;
+				}
 				// Get spacing CSS variable from preset value if provided.
 				if ( is_string( $process_value ) && str_contains( $process_value, 'var:preset|spacing|' ) ) {
 					$index_to_splice = strrpos( $process_value, '|' ) + 1;
@@ -482,7 +487,12 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 			$gap_sides          = is_array( $gap_value ) ? array( 'top', 'left' ) : array( 'top' );
 
 			foreach ( $gap_sides as $gap_side ) {
-				$process_value = is_string( $gap_value ) ? $gap_value : _wp_array_get( $gap_value, array( $gap_side ), $fallback_gap_value );
+				$process_value = $gap_value;
+				if ( ! is_string( $gap_value ) ) {
+					$process_value = isset( $gap_value[ $gap_side ] )
+						? _wp_array_get( $gap_value, array( $gap_side ), $fallback_gap_value )
+						: $fallback_gap_value;
+				}
 				// Get spacing CSS variable from preset value if provided.
 				if ( is_string( $process_value ) && str_contains( $process_value, 'var:preset|spacing|' ) ) {
 					$index_to_splice = strrpos( $process_value, '|' ) + 1;
@@ -606,7 +616,9 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 		$used_layout['type'] = 'constrained';
 	}
 
-	$root_padding_aware_alignments = _wp_array_get( $global_settings, array( 'useRootPaddingAwareAlignments' ), false );
+	$root_padding_aware_alignments = isset( $global_settings['useRootPaddingAwareAlignments'] )
+		? _wp_array_get( $global_settings, array( 'useRootPaddingAwareAlignments' ), false )
+		: false;
 
 	if ( $root_padding_aware_alignments && isset( $used_layout['type'] ) && 'constrained' === $used_layout['type'] ) {
 		$class_names[] = 'has-global-padding';
@@ -632,9 +644,13 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 
 	// Get classname for layout type.
 	if ( isset( $used_layout['type'] ) ) {
-		$layout_classname = _wp_array_get( $layout_definitions, array( $used_layout['type'], 'className' ), '' );
+		$layout_classname = isset( $layout_definitions[ $used_layout['type'] ]['className'] )
+			? _wp_array_get( $layout_definitions, array( $used_layout['type'], 'className' ), '' )
+			: '';
 	} else {
-		$layout_classname = _wp_array_get( $layout_definitions, array( 'default', 'className' ), '' );
+		$layout_classname = isset( $layout_definitions['default']['className'] )
+			? _wp_array_get( $layout_definitions, array( 'default', 'className' ), '' )
+			: '';
 	}
 
 	if ( $layout_classname && is_string( $layout_classname ) ) {
@@ -647,7 +663,9 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 	 */
 	if ( ! current_theme_supports( 'disable-layout-styles' ) ) {
 
-		$gap_value = _wp_array_get( $block, array( 'attrs', 'style', 'spacing', 'blockGap' ) );
+		$gap_value = isset( $block['attrs']['style']['spacing']['blockGap'] )
+			? _wp_array_get( $block, array( 'attrs', 'style', 'spacing', 'blockGap' ) )
+			: null;
 
 		/*
 		 * Skip if gap value contains unsupported characters.
@@ -662,8 +680,12 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 			$gap_value = $gap_value && preg_match( '%[\\\(&=}]|/\*%', $gap_value ) ? null : $gap_value;
 		}
 
-		$fallback_gap_value = _wp_array_get( $block_type->supports, array( 'spacing', 'blockGap', '__experimentalDefault' ), '0.5em' );
-		$block_spacing      = _wp_array_get( $block, array( 'attrs', 'style', 'spacing' ), null );
+		$fallback_gap_value = isset( $block_type->supports['spacing']['blockGap']['__experimentalDefault'] )
+			? _wp_array_get( $block_type->supports, array( 'spacing', 'blockGap', '__experimentalDefault' ), '0.5em' )
+			: '0.5em';
+		$block_spacing      = isset( $block['attrs']['style']['spacing'] )
+			? _wp_array_get( $block, array( 'attrs', 'style', 'spacing' ), null )
+			: null;
 
 		/*
 		 * If a block's block.json skips serialization for spacing or spacing.blockGap,
@@ -671,8 +693,10 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 		 */
 		$should_skip_gap_serialization = wp_should_skip_block_supports_serialization( $block_type, 'spacing', 'blockGap' );
 
-		$block_gap             = _wp_array_get( $global_settings, array( 'spacing', 'blockGap' ), null );
-		$has_block_gap_support = isset( $block_gap );
+		$block_gap             = isset( $global_settings['spacing']['blockGap'] )
+			? _wp_array_get( $global_settings, array( 'spacing', 'blockGap' ), null )
+			: null;
+		$has_block_gap_support = null !== $block_gap;
 
 		$style = gutenberg_get_layout_style(
 			".$container_class.$container_class",

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -403,7 +403,7 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 			foreach ( $gap_sides as $gap_side ) {
 				$process_value = $gap_value;
 				if ( is_array( $gap_value ) ) {
-					$gap_value = $gap_value[ $gap_side ] ?? $fallback_gap_value;
+					$gap_value = isset( $gap_value[ $gap_side ] ) ? $gap_value[ $gap_side ] : $fallback_gap_value;
 				}
 				// Get spacing CSS variable from preset value if provided.
 				if ( is_string( $process_value ) && str_contains( $process_value, 'var:preset|spacing|' ) ) {
@@ -487,7 +487,7 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 			foreach ( $gap_sides as $gap_side ) {
 				$process_value = $gap_value;
 				if ( is_array( $gap_value ) ) {
-					$process_value = $gap_value[ $gap_side ] ?? $fallback_gap_value;
+					$process_value = isset( $gap_value[ $gap_side ] ) ? $gap_value[ $gap_side ] : $fallback_gap_value;
 				}
 				// Get spacing CSS variable from preset value if provided.
 				if ( is_string( $process_value ) && str_contains( $process_value, 'var:preset|spacing|' ) ) {
@@ -537,7 +537,7 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 function gutenberg_render_layout_support_flag( $block_content, $block ) {
 	$block_type            = WP_Block_Type_Registry::get_instance()->get_registered( $block['blockName'] );
 	$block_supports_layout = block_has_support( $block_type, array( 'layout' ), false ) || block_has_support( $block_type, array( '__experimentalLayout' ), false );
-	$layout_from_parent    = $block['attrs']['style']['layout']['selfStretch'] ?? null;
+	$layout_from_parent    = isset( $block['attrs']['style']['layout']['selfStretch'] ) ? $block['attrs']['style']['layout']['selfStretch'] : null;
 
 	if ( ! $block_supports_layout && ! $layout_from_parent ) {
 		return $block_content;
@@ -600,11 +600,11 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 	}
 
 	$global_settings = gutenberg_get_global_settings();
-	$fallback_layout = $block_type->supports['layout']['default'] ?? array();
+	$fallback_layout = isset( $block_type->supports['layout']['default'] ) ? $block_type->supports['layout']['default'] : array();
 	if ( empty( $fallback_layout ) ) {
-		$fallback_layout = $block_type->supports['__experimentalLayout']['default'] ?? array();
+		$fallback_layout = isset( $block_type->supports['__experimentalLayout']['default'] ) ? $block_type->supports['__experimentalLayout']['default'] : array();
 	}
-	$used_layout = $block['attrs']['layout'] ?? $fallback_layout;
+	$used_layout = isset( $block['attrs']['layout'] ) ? $block['attrs']['layout'] : $fallback_layout;
 
 	$class_names        = array();
 	$layout_definitions = gutenberg_get_layout_definitions();
@@ -615,7 +615,7 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 		$used_layout['type'] = 'constrained';
 	}
 
-	$root_padding_aware_alignments = $global_settings['useRootPaddingAwareAlignments'] ?? false;
+	$root_padding_aware_alignments = isset( $global_settings['useRootPaddingAwareAlignments'] ) ? $global_settings['useRootPaddingAwareAlignments'] : false;
 
 	if ( $root_padding_aware_alignments && isset( $used_layout['type'] ) && 'constrained' === $used_layout['type'] ) {
 		$class_names[] = 'has-global-padding';
@@ -641,9 +641,9 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 
 	// Get classname for layout type.
 	if ( isset( $used_layout['type'] ) ) {
-		$layout_classname = $layout_definitions[ $used_layout['type'] ]['className'] ?? '';
+		$layout_classname = isset( $layout_definitions[ $used_layout['type'] ]['className'] ) ? $layout_definitions[ $used_layout['type'] ]['className'] : '';
 	} else {
-		$layout_classname = $layout_definitions['default']['className'] ?? '';
+		$layout_classname = isset( $layout_definitions['default']['className'] ) ? $layout_definitions['default']['className'] : '';
 	}
 
 	if ( $layout_classname && is_string( $layout_classname ) ) {
@@ -656,7 +656,7 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 	 */
 	if ( ! current_theme_supports( 'disable-layout-styles' ) ) {
 
-		$gap_value = $block['attrs']['style']['spacing']['blockGap'] ?? null;
+		$gap_value = isset( $block['attrs']['style']['spacing']['blockGap'] ) ? $block['attrs']['style']['spacing']['blockGap'] : null;
 
 		/*
 		 * Skip if gap value contains unsupported characters.
@@ -671,8 +671,8 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 			$gap_value = $gap_value && preg_match( '%[\\\(&=}]|/\*%', $gap_value ) ? null : $gap_value;
 		}
 
-		$fallback_gap_value = $block_type->supports['spacing']['blockGap']['__experimentalDefault'] ?? '0.5em';
-		$block_spacing      = $block['attrs']['style']['spacing'] ?? null;
+		$fallback_gap_value = isset( $block_type->supports['spacing']['blockGap']['__experimentalDefault'] ) ? $block_type->supports['spacing']['blockGap']['__experimentalDefault'] : '0.5em';
+		$block_spacing      = isset( $block['attrs']['style']['spacing'] ) ? $block['attrs']['style']['spacing'] : null;
 
 		/*
 		 * If a block's block.json skips serialization for spacing or spacing.blockGap,
@@ -680,7 +680,7 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 		 */
 		$should_skip_gap_serialization = wp_should_skip_block_supports_serialization( $block_type, 'spacing', 'blockGap' );
 
-		$block_gap             = $global_settings['spacing']['blockGap'] ?? null;
+		$block_gap             = isset( $global_settings['spacing']['blockGap'] ) ? $global_settings['spacing']['blockGap'] : null;
 		$has_block_gap_support = isset( $block_gap );
 
 		$style = gutenberg_get_layout_style(
@@ -759,7 +759,7 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 	 * @var string|null
 	 */
 	$inner_block_wrapper_classes = null;
-	$first_chunk                 = $block['innerContent'][0] ?? null;
+	$first_chunk                 = isset( $block['innerContent'][0] ) ? $block['innerContent'][0] : null;
 	if ( is_string( $first_chunk ) && count( $block['innerContent'] ) > 1 ) {
 		$first_chunk_processor = new WP_HTML_Tag_Processor( $first_chunk );
 		while ( $first_chunk_processor->next_tag() ) {

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -402,10 +402,8 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 
 			foreach ( $gap_sides as $gap_side ) {
 				$process_value = $gap_value;
-				if ( ! is_string( $gap_value ) ) {
-					$process_value = isset( $gap_value[ $gap_side ] )
-						? $gap_value[ $gap_side ]
-						: $fallback_gap_value;
+				if ( is_array( $gap_value ) ) {
+					$gap_value = $gap_value[ $gap_side ] ?? $fallback_gap_value;
 				}
 				// Get spacing CSS variable from preset value if provided.
 				if ( is_string( $process_value ) && str_contains( $process_value, 'var:preset|spacing|' ) ) {
@@ -488,8 +486,8 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 
 			foreach ( $gap_sides as $gap_side ) {
 				$process_value = $gap_value;
-				if ( ! is_string( $gap_value ) ) {
-					$process_value = isset( $gap_value[ $gap_side ] ) ? $gap_value[ $gap_side ] : $fallback_gap_value;
+				if ( is_array( $gap_value ) ) {
+					$process_value = $gap_value[ $gap_side ] ?? $fallback_gap_value;
 				}
 				// Get spacing CSS variable from preset value if provided.
 				if ( is_string( $process_value ) && str_contains( $process_value, 'var:preset|spacing|' ) ) {
@@ -602,14 +600,9 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 	}
 
 	$global_settings = gutenberg_get_global_settings();
-	if ( isset( $block_type->supports['layout']['default'] ) && ! empty( $block_type->supports['layout']['default'] ) ) {
-		$fallback_layout = isset( $block_type->supports['layout']['default'] )
-			? $block_type->supports['layout']['default']
-			: array();
-	} else {
-		$fallback_layout = isset( $block_type->supports['__experimentalLayout']['default'] )
-			? $block_type->supports['__experimentalLayout']['default']
-			: array();
+	$fallback_layout = $block_type->supports['layout']['default'] ?? array();
+	if ( empty( $fallback_layout ) ) {
+		$fallback_layout = $block_type->supports['__experimentalLayout']['default'] ?? array();
 	}
 	$used_layout = isset( $block['attrs']['layout'] ) ? $block['attrs']['layout'] : $fallback_layout;
 
@@ -622,9 +615,7 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 		$used_layout['type'] = 'constrained';
 	}
 
-	$root_padding_aware_alignments = isset( $global_settings['useRootPaddingAwareAlignments'] )
-		? $global_settings['useRootPaddingAwareAlignments']
-		: false;
+	$root_padding_aware_alignments = $global_settings['useRootPaddingAwareAlignments'] ?? false;
 
 	if ( $root_padding_aware_alignments && isset( $used_layout['type'] ) && 'constrained' === $used_layout['type'] ) {
 		$class_names[] = 'has-global-padding';
@@ -650,13 +641,9 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 
 	// Get classname for layout type.
 	if ( isset( $used_layout['type'] ) ) {
-		$layout_classname = isset( $layout_definitions[ $used_layout['type'] ]['className'] )
-			? $layout_definitions[ $used_layout['type'] ]['className']
-			: '';
+		$layout_classname = $layout_definitions[ $used_layout['type'] ]['className'] ?? '';
 	} else {
-		$layout_classname = isset( $layout_definitions['default']['className'] )
-			? $layout_definitions['default']['className']
-			: '';
+		$layout_classname = $layout_definitions['default']['className'] ?? '';
 	}
 
 	if ( $layout_classname && is_string( $layout_classname ) ) {
@@ -669,9 +656,7 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 	 */
 	if ( ! current_theme_supports( 'disable-layout-styles' ) ) {
 
-		$gap_value = isset( $block['attrs']['style']['spacing']['blockGap'] )
-			? $block['attrs']['style']['spacing']['blockGap']
-			: null;
+		$gap_value = $block['attrs']['style']['spacing']['blockGap'] ?? null;
 
 		/*
 		 * Skip if gap value contains unsupported characters.
@@ -686,12 +671,8 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 			$gap_value = $gap_value && preg_match( '%[\\\(&=}]|/\*%', $gap_value ) ? null : $gap_value;
 		}
 
-		$fallback_gap_value = isset( $block_type->supports['spacing']['blockGap']['__experimentalDefault'] )
-			? $block_type->supports['spacing']['blockGap']['__experimentalDefault']
-			: '0.5em';
-		$block_spacing      = isset( $block['attrs']['style']['spacing'] )
-			? $block['attrs']['style']['spacing']
-			: null;
+		$fallback_gap_value = $block_type->supports['spacing']['blockGap']['__experimentalDefault'] ?? '0.5em';
+		$block_spacing      = $block['attrs']['style']['spacing'] ?? null;
 
 		/*
 		 * If a block's block.json skips serialization for spacing or spacing.blockGap,
@@ -699,10 +680,8 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 		 */
 		$should_skip_gap_serialization = wp_should_skip_block_supports_serialization( $block_type, 'spacing', 'blockGap' );
 
-		$block_gap             = isset( $global_settings['spacing']['blockGap'] )
-			? $global_settings['spacing']['blockGap']
-			: null;
-		$has_block_gap_support = null !== $block_gap;
+		$block_gap             = $global_settings['spacing']['blockGap'] ?? null;
+		$has_block_gap_support = isset( $block_gap );
 
 		$style = gutenberg_get_layout_style(
 			".$container_class.$container_class",

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -403,7 +403,7 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 			foreach ( $gap_sides as $gap_side ) {
 				$process_value = $gap_value;
 				if ( is_array( $gap_value ) ) {
-					$gap_value = isset( $gap_value[ $gap_side ] ) ? $gap_value[ $gap_side ] : $fallback_gap_value;
+					$gap_value = $gap_value[ $gap_side ] ?? $fallback_gap_value;
 				}
 				// Get spacing CSS variable from preset value if provided.
 				if ( is_string( $process_value ) && str_contains( $process_value, 'var:preset|spacing|' ) ) {
@@ -487,7 +487,7 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 			foreach ( $gap_sides as $gap_side ) {
 				$process_value = $gap_value;
 				if ( is_array( $gap_value ) ) {
-					$process_value = isset( $gap_value[ $gap_side ] ) ? $gap_value[ $gap_side ] : $fallback_gap_value;
+					$process_value = $gap_value[ $gap_side ] ?? $fallback_gap_value;
 				}
 				// Get spacing CSS variable from preset value if provided.
 				if ( is_string( $process_value ) && str_contains( $process_value, 'var:preset|spacing|' ) ) {
@@ -537,7 +537,7 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 function gutenberg_render_layout_support_flag( $block_content, $block ) {
 	$block_type            = WP_Block_Type_Registry::get_instance()->get_registered( $block['blockName'] );
 	$block_supports_layout = block_has_support( $block_type, array( 'layout' ), false ) || block_has_support( $block_type, array( '__experimentalLayout' ), false );
-	$layout_from_parent    = isset( $block['attrs']['style']['layout']['selfStretch'] ) ? $block['attrs']['style']['layout']['selfStretch'] : null;
+	$layout_from_parent    = $block['attrs']['style']['layout']['selfStretch'] ?? null;
 
 	if ( ! $block_supports_layout && ! $layout_from_parent ) {
 		return $block_content;
@@ -600,11 +600,11 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 	}
 
 	$global_settings = gutenberg_get_global_settings();
-	$fallback_layout = isset( $block_type->supports['layout']['default'] ) ? $block_type->supports['layout']['default'] : array();
+	$fallback_layout = $block_type->supports['layout']['default'] ?? array();
 	if ( empty( $fallback_layout ) ) {
-		$fallback_layout = isset( $block_type->supports['__experimentalLayout']['default'] ) ? $block_type->supports['__experimentalLayout']['default'] : array();
+		$fallback_layout = $block_type->supports['__experimentalLayout']['default'] ?? array();
 	}
-	$used_layout = isset( $block['attrs']['layout'] ) ? $block['attrs']['layout'] : $fallback_layout;
+	$used_layout = $block['attrs']['layout'] ?? $fallback_layout;
 
 	$class_names        = array();
 	$layout_definitions = gutenberg_get_layout_definitions();
@@ -615,7 +615,7 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 		$used_layout['type'] = 'constrained';
 	}
 
-	$root_padding_aware_alignments = isset( $global_settings['useRootPaddingAwareAlignments'] ) ? $global_settings['useRootPaddingAwareAlignments'] : false;
+	$root_padding_aware_alignments = $global_settings['useRootPaddingAwareAlignments'] ?? false;
 
 	if ( $root_padding_aware_alignments && isset( $used_layout['type'] ) && 'constrained' === $used_layout['type'] ) {
 		$class_names[] = 'has-global-padding';
@@ -641,9 +641,9 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 
 	// Get classname for layout type.
 	if ( isset( $used_layout['type'] ) ) {
-		$layout_classname = isset( $layout_definitions[ $used_layout['type'] ]['className'] ) ? $layout_definitions[ $used_layout['type'] ]['className'] : '';
+		$layout_classname = $layout_definitions[ $used_layout['type'] ]['className'] ?? '';
 	} else {
-		$layout_classname = isset( $layout_definitions['default']['className'] ) ? $layout_definitions['default']['className'] : '';
+		$layout_classname = $layout_definitions['default']['className'] ?? '';
 	}
 
 	if ( $layout_classname && is_string( $layout_classname ) ) {
@@ -656,7 +656,7 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 	 */
 	if ( ! current_theme_supports( 'disable-layout-styles' ) ) {
 
-		$gap_value = isset( $block['attrs']['style']['spacing']['blockGap'] ) ? $block['attrs']['style']['spacing']['blockGap'] : null;
+		$gap_value = $block['attrs']['style']['spacing']['blockGap'] ?? null;
 
 		/*
 		 * Skip if gap value contains unsupported characters.
@@ -671,8 +671,8 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 			$gap_value = $gap_value && preg_match( '%[\\\(&=}]|/\*%', $gap_value ) ? null : $gap_value;
 		}
 
-		$fallback_gap_value = isset( $block_type->supports['spacing']['blockGap']['__experimentalDefault'] ) ? $block_type->supports['spacing']['blockGap']['__experimentalDefault'] : '0.5em';
-		$block_spacing      = isset( $block['attrs']['style']['spacing'] ) ? $block['attrs']['style']['spacing'] : null;
+		$fallback_gap_value = $block_type->supports['spacing']['blockGap']['__experimentalDefault'] ?? '0.5em';
+		$block_spacing      = $block['attrs']['style']['spacing'] ?? null;
 
 		/*
 		 * If a block's block.json skips serialization for spacing or spacing.blockGap,
@@ -680,7 +680,7 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 		 */
 		$should_skip_gap_serialization = wp_should_skip_block_supports_serialization( $block_type, 'spacing', 'blockGap' );
 
-		$block_gap             = isset( $global_settings['spacing']['blockGap'] ) ? $global_settings['spacing']['blockGap'] : null;
+		$block_gap             = $global_settings['spacing']['blockGap'] ?? null;
 		$has_block_gap_support = isset( $block_gap );
 
 		$style = gutenberg_get_layout_style(
@@ -759,7 +759,7 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 	 * @var string|null
 	 */
 	$inner_block_wrapper_classes = null;
-	$first_chunk                 = isset( $block['innerContent'][0] ) ? $block['innerContent'][0] : null;
+	$first_chunk                 = $block['innerContent'][0] ?? null;
 	if ( is_string( $first_chunk ) && count( $block['innerContent'] ) > 1 ) {
 		$first_chunk_processor = new WP_HTML_Tag_Processor( $first_chunk );
 		while ( $first_chunk_processor->next_tag() ) {

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -404,7 +404,7 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 				$process_value = $gap_value;
 				if ( ! is_string( $gap_value ) ) {
 					$process_value = isset( $gap_value[ $gap_side ] )
-						? _wp_array_get( $gap_value, array( $gap_side ), $fallback_gap_value )
+						? $gap_value[ $gap_side ]
 						: $fallback_gap_value;
 				}
 				// Get spacing CSS variable from preset value if provided.
@@ -489,9 +489,7 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 			foreach ( $gap_sides as $gap_side ) {
 				$process_value = $gap_value;
 				if ( ! is_string( $gap_value ) ) {
-					$process_value = isset( $gap_value[ $gap_side ] )
-						? _wp_array_get( $gap_value, array( $gap_side ), $fallback_gap_value )
-						: $fallback_gap_value;
+					$process_value = isset( $gap_value[ $gap_side ] ) ? $gap_value[ $gap_side ] : $fallback_gap_value;
 				}
 				// Get spacing CSS variable from preset value if provided.
 				if ( is_string( $process_value ) && str_contains( $process_value, 'var:preset|spacing|' ) ) {
@@ -604,8 +602,16 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 	}
 
 	$global_settings = gutenberg_get_global_settings();
-	$fallback_layout = ! empty( _wp_array_get( $block_type->supports, array( 'layout', 'default' ), array() ) ) ? _wp_array_get( $block_type->supports, array( 'layout', 'default' ), array() ) : _wp_array_get( $block_type->supports, array( '__experimentalLayout', 'default' ), array() );
-	$used_layout     = isset( $block['attrs']['layout'] ) ? $block['attrs']['layout'] : $fallback_layout;
+	if ( isset( $block_type->supports['layout']['default'] ) ! empty( $block_type->supports['layout']['default'] ) ) {
+		$fallback_layout = isset( $block_type->supports['layout']['default'] )
+			? $block_type->supports['layout']['default']
+			: array();
+	} else {
+		$fallback_layout = isset( $block_type->supports['__experimentalLayout']['default'] )
+			? $block_type->supports['__experimentalLayout']['default']
+			: array();
+	}
+	$used_layout = isset( $block['attrs']['layout'] ) ? $block['attrs']['layout'] : $fallback_layout;
 
 	$class_names        = array();
 	$layout_definitions = gutenberg_get_layout_definitions();
@@ -617,7 +623,7 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 	}
 
 	$root_padding_aware_alignments = isset( $global_settings['useRootPaddingAwareAlignments'] )
-		? _wp_array_get( $global_settings, array( 'useRootPaddingAwareAlignments' ), false )
+		? $global_settings['useRootPaddingAwareAlignments']
 		: false;
 
 	if ( $root_padding_aware_alignments && isset( $used_layout['type'] ) && 'constrained' === $used_layout['type'] ) {
@@ -645,11 +651,11 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 	// Get classname for layout type.
 	if ( isset( $used_layout['type'] ) ) {
 		$layout_classname = isset( $layout_definitions[ $used_layout['type'] ]['className'] )
-			? _wp_array_get( $layout_definitions, array( $used_layout['type'], 'className' ), '' )
+			? $layout_definitions[ $used_layout['type'] ]['className']
 			: '';
 	} else {
 		$layout_classname = isset( $layout_definitions['default']['className'] )
-			? _wp_array_get( $layout_definitions, array( 'default', 'className' ), '' )
+			? $layout_definitions['default']['className']
 			: '';
 	}
 
@@ -664,7 +670,7 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 	if ( ! current_theme_supports( 'disable-layout-styles' ) ) {
 
 		$gap_value = isset( $block['attrs']['style']['spacing']['blockGap'] )
-			? _wp_array_get( $block, array( 'attrs', 'style', 'spacing', 'blockGap' ) )
+			? $block['attrs']['style']['spacing']['blockGap']
 			: null;
 
 		/*
@@ -681,10 +687,10 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 		}
 
 		$fallback_gap_value = isset( $block_type->supports['spacing']['blockGap']['__experimentalDefault'] )
-			? _wp_array_get( $block_type->supports, array( 'spacing', 'blockGap', '__experimentalDefault' ), '0.5em' )
+			? $block_type->supports['spacing']['blockGap']['__experimentalDefault']
 			: '0.5em';
 		$block_spacing      = isset( $block['attrs']['style']['spacing'] )
-			? _wp_array_get( $block, array( 'attrs', 'style', 'spacing' ), null )
+			? $block['attrs']['style']['spacing']
 			: null;
 
 		/*
@@ -694,7 +700,7 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 		$should_skip_gap_serialization = wp_should_skip_block_supports_serialization( $block_type, 'spacing', 'blockGap' );
 
 		$block_gap             = isset( $global_settings['spacing']['blockGap'] )
-			? _wp_array_get( $global_settings, array( 'spacing', 'blockGap' ), null )
+			? $global_settings['spacing']['blockGap']
 			: null;
 		$has_block_gap_support = null !== $block_gap;
 

--- a/lib/block-supports/position.php
+++ b/lib/block-supports/position.php
@@ -54,15 +54,11 @@ function gutenberg_render_position_support( $block_content, $block ) {
 		$allowed_position_types[] = 'fixed';
 	}
 
-	$style_attribute = isset( $block['attrs']['style'] )
-		? _wp_array_get( $block, array( 'attrs', 'style' ), array() )
-		: array();
+	$style_attribute = isset( $block['attrs']['style'] ) ? $block['attrs']['style'] : array();
 	$class_name      = wp_unique_id( 'wp-container-' );
 	$selector        = ".$class_name";
 	$position_styles = array();
-	$position_type   = isset( $style_attribute['position']['type'] )
-		? _wp_array_get( $style_attribute, array( 'position', 'type' ), '' )
-		: '';
+	$position_type   = isset( $style_attribute['position']['type'] ) ? $style_attribute['position']['type'] : '';
 	$wrapper_classes = array();
 
 	if (
@@ -73,9 +69,7 @@ function gutenberg_render_position_support( $block_content, $block ) {
 		$sides             = array( 'top', 'right', 'bottom', 'left' );
 
 		foreach ( $sides as $side ) {
-			$side_value = isset( $style_attribute['position'][ $side ] )
-				? _wp_array_get( $style_attribute, array( 'position', $side ) )
-				: null;
+			$side_value = isset( $style_attribute['position'][ $side ] ) ? $style_attribute['position'][ $side ] : null;
 
 			if ( null !== $side_value ) {
 				/*

--- a/lib/block-supports/position.php
+++ b/lib/block-supports/position.php
@@ -43,24 +43,26 @@ function gutenberg_render_position_support( $block_content, $block ) {
 		return $block_content;
 	}
 
-	$global_settings          = gutenberg_get_global_settings();
-	$theme_has_sticky_support = _wp_array_get( $global_settings, array( 'position', 'sticky' ), false );
-	$theme_has_fixed_support  = _wp_array_get( $global_settings, array( 'position', 'fixed' ), false );
+	$global_settings = gutenberg_get_global_settings();
 
 	// Only allow output for position types that the theme supports.
 	$allowed_position_types = array();
-	if ( true === $theme_has_sticky_support ) {
+	if ( isset( $global_settings['position']['sticky'] ) && true === $global_settings['position']['sticky'] ) {
 		$allowed_position_types[] = 'sticky';
 	}
-	if ( true === $theme_has_fixed_support ) {
+	if ( isset( $global_settings['position']['fixed'] ) && true === $global_settings['position']['fixed'] ) {
 		$allowed_position_types[] = 'fixed';
 	}
 
-	$style_attribute = _wp_array_get( $block, array( 'attrs', 'style' ), null );
+	$style_attribute = isset( $block['attrs']['style'] )
+		? _wp_array_get( $block, array( 'attrs', 'style' ), array() )
+		: array();
 	$class_name      = wp_unique_id( 'wp-container-' );
 	$selector        = ".$class_name";
 	$position_styles = array();
-	$position_type   = _wp_array_get( $style_attribute, array( 'position', 'type' ), '' );
+	$position_type   = isset( $style_attribute['position']['type'] )
+		? _wp_array_get( $style_attribute, array( 'position', 'type' ), '' )
+		: '';
 	$wrapper_classes = array();
 
 	if (
@@ -71,7 +73,10 @@ function gutenberg_render_position_support( $block_content, $block ) {
 		$sides             = array( 'top', 'right', 'bottom', 'left' );
 
 		foreach ( $sides as $side ) {
-			$side_value = _wp_array_get( $style_attribute, array( 'position', $side ) );
+			$side_value = isset( $style_attribute['position'][ $side ] )
+				? _wp_array_get( $style_attribute, array( 'position', $side ) )
+				: null;
+
 			if ( null !== $side_value ) {
 				/*
 				 * For fixed or sticky top positions,

--- a/lib/block-supports/position.php
+++ b/lib/block-supports/position.php
@@ -44,8 +44,8 @@ function gutenberg_render_position_support( $block_content, $block ) {
 	}
 
 	$global_settings          = gutenberg_get_global_settings();
-	$theme_has_sticky_support = isset( $global_settings['position']['sticky'] ) ? $global_settings['position']['sticky'] : false;
-	$theme_has_fixed_support  = isset( $global_settings['position']['fixed'] ) ? $global_settings['position']['fixed'] : false;
+	$theme_has_sticky_support = $global_settings['position']['sticky'] ?? false;
+	$theme_has_fixed_support  = $global_settings['position']['fixed'] ?? false;
 
 	// Only allow output for position types that the theme supports.
 	$allowed_position_types = array();
@@ -56,11 +56,11 @@ function gutenberg_render_position_support( $block_content, $block ) {
 		$allowed_position_types[] = 'fixed';
 	}
 
-	$style_attribute = isset( $block['attrs']['style'] ) ? $block['attrs']['style'] : null;
+	$style_attribute = $block['attrs']['style'] ?? null;
 	$class_name      = wp_unique_id( 'wp-container-' );
 	$selector        = ".$class_name";
 	$position_styles = array();
-	$position_type   = isset( $style_attribute['position']['type'] ) ? $style_attribute['position']['type'] : '';
+	$position_type   = $style_attribute['position']['type'] ?? '';
 	$wrapper_classes = array();
 
 	if (
@@ -71,7 +71,7 @@ function gutenberg_render_position_support( $block_content, $block ) {
 		$sides             = array( 'top', 'right', 'bottom', 'left' );
 
 		foreach ( $sides as $side ) {
-			$side_value = isset( $style_attribute['position'][ $side ] ) ? $style_attribute['position'][ $side ] : null;
+			$side_value = $style_attribute['position'][ $side ] ?? null;
 			if ( null !== $side_value ) {
 				/*
 				 * For fixed or sticky top positions,

--- a/lib/block-supports/position.php
+++ b/lib/block-supports/position.php
@@ -43,22 +43,24 @@ function gutenberg_render_position_support( $block_content, $block ) {
 		return $block_content;
 	}
 
-	$global_settings = gutenberg_get_global_settings();
+	$global_settings          = gutenberg_get_global_settings();
+	$theme_has_sticky_support = $global_settings['position']['sticky'] ?? false;
+	$theme_has_fixed_support  = $global_settings['position']['fixed'] ?? false;
 
 	// Only allow output for position types that the theme supports.
 	$allowed_position_types = array();
-	if ( isset( $global_settings['position']['sticky'] ) && true === $global_settings['position']['sticky'] ) {
+	if ( true === $theme_has_sticky_support ) {
 		$allowed_position_types[] = 'sticky';
 	}
-	if ( isset( $global_settings['position']['fixed'] ) && true === $global_settings['position']['fixed'] ) {
+	if ( true === $theme_has_fixed_support ) {
 		$allowed_position_types[] = 'fixed';
 	}
 
-	$style_attribute = isset( $block['attrs']['style'] ) ? $block['attrs']['style'] : array();
+	$style_attribute = $block['attrs']['style'] ?? null;
 	$class_name      = wp_unique_id( 'wp-container-' );
 	$selector        = ".$class_name";
 	$position_styles = array();
-	$position_type   = isset( $style_attribute['position']['type'] ) ? $style_attribute['position']['type'] : '';
+	$position_type   = $style_attribute['position']['type'] ?? '';
 	$wrapper_classes = array();
 
 	if (
@@ -69,8 +71,7 @@ function gutenberg_render_position_support( $block_content, $block ) {
 		$sides             = array( 'top', 'right', 'bottom', 'left' );
 
 		foreach ( $sides as $side ) {
-			$side_value = isset( $style_attribute['position'][ $side ] ) ? $style_attribute['position'][ $side ] : null;
-
+			$side_value = $style_attribute['position'][ $side ] ?? null;
 			if ( null !== $side_value ) {
 				/*
 				 * For fixed or sticky top positions,

--- a/lib/block-supports/position.php
+++ b/lib/block-supports/position.php
@@ -44,8 +44,8 @@ function gutenberg_render_position_support( $block_content, $block ) {
 	}
 
 	$global_settings          = gutenberg_get_global_settings();
-	$theme_has_sticky_support = $global_settings['position']['sticky'] ?? false;
-	$theme_has_fixed_support  = $global_settings['position']['fixed'] ?? false;
+	$theme_has_sticky_support = isset( $global_settings['position']['sticky'] ) ? $global_settings['position']['sticky'] : false;
+	$theme_has_fixed_support  = isset( $global_settings['position']['fixed'] ) ? $global_settings['position']['fixed'] : false;
 
 	// Only allow output for position types that the theme supports.
 	$allowed_position_types = array();
@@ -56,11 +56,11 @@ function gutenberg_render_position_support( $block_content, $block ) {
 		$allowed_position_types[] = 'fixed';
 	}
 
-	$style_attribute = $block['attrs']['style'] ?? null;
+	$style_attribute = isset( $block['attrs']['style'] ) ? $block['attrs']['style'] : null;
 	$class_name      = wp_unique_id( 'wp-container-' );
 	$selector        = ".$class_name";
 	$position_styles = array();
-	$position_type   = $style_attribute['position']['type'] ?? '';
+	$position_type   = isset( $style_attribute['position']['type'] ) ? $style_attribute['position']['type'] : '';
 	$wrapper_classes = array();
 
 	if (
@@ -71,7 +71,7 @@ function gutenberg_render_position_support( $block_content, $block ) {
 		$sides             = array( 'top', 'right', 'bottom', 'left' );
 
 		foreach ( $sides as $side ) {
-			$side_value = $style_attribute['position'][ $side ] ?? null;
+			$side_value = isset( $style_attribute['position'][ $side ] ) ? $style_attribute['position'][ $side ] : null;
 			if ( null !== $side_value ) {
 				/*
 				 * For fixed or sticky top positions,

--- a/lib/block-supports/settings.php
+++ b/lib/block-supports/settings.php
@@ -26,8 +26,7 @@ function _gutenberg_add_block_level_presets_class( $block_content, $block ) {
 	}
 
 	// return early if no settings are found on the block attributes.
-	$block_settings = _wp_array_get( $block, array( 'attrs', 'settings' ), null );
-	if ( empty( $block_settings ) ) {
+	if ( ! isset( $block['attrs']['settings'] ) || empty( $block['attrs']['settings'] ) ) {
 		return $block_content;
 	}
 
@@ -59,8 +58,7 @@ function _gutenberg_add_block_level_preset_styles( $pre_render, $block ) {
 	}
 
 	// return early if no settings are found on the block attributes.
-	$block_settings = _wp_array_get( $block, array( 'attrs', 'settings' ), null );
-	if ( empty( $block_settings ) ) {
+	if ( ! isset( $block['attrs']['settings'] ) || empty( $block['attrs']['settings'] ) ) {
 		return null;
 	}
 

--- a/lib/block-supports/settings.php
+++ b/lib/block-supports/settings.php
@@ -26,7 +26,7 @@ function _gutenberg_add_block_level_presets_class( $block_content, $block ) {
 	}
 
 	// return early if no settings are found on the block attributes.
-	$block_settings = $block['attrs']['settings'] ?? null;
+	$block_settings = isset( $block['attrs']['settings'] ) ? $block['attrs']['settings'] : null;
 	if ( empty( $block_settings ) ) {
 		return $block_content;
 	}
@@ -59,7 +59,7 @@ function _gutenberg_add_block_level_preset_styles( $pre_render, $block ) {
 	}
 
 	// return early if no settings are found on the block attributes.
-	$block_settings = $block['attrs']['settings'] ?? null;
+	$block_settings = isset( $block['attrs']['settings'] ) ? $block['attrs']['settings'] : null;
 	if ( empty( $block_settings ) ) {
 		return null;
 	}

--- a/lib/block-supports/settings.php
+++ b/lib/block-supports/settings.php
@@ -26,7 +26,7 @@ function _gutenberg_add_block_level_presets_class( $block_content, $block ) {
 	}
 
 	// return early if no settings are found on the block attributes.
-	$block_settings = isset( $block['attrs']['settings'] ) ? $block['attrs']['settings'] : null;
+	$block_settings = $block['attrs']['settings'] ?? null;
 	if ( empty( $block_settings ) ) {
 		return $block_content;
 	}
@@ -59,7 +59,7 @@ function _gutenberg_add_block_level_preset_styles( $pre_render, $block ) {
 	}
 
 	// return early if no settings are found on the block attributes.
-	$block_settings = isset( $block['attrs']['settings'] ) ? $block['attrs']['settings'] : null;
+	$block_settings = $block['attrs']['settings'] ?? null;
 	if ( empty( $block_settings ) ) {
 		return null;
 	}

--- a/lib/block-supports/settings.php
+++ b/lib/block-supports/settings.php
@@ -26,7 +26,9 @@ function _gutenberg_add_block_level_presets_class( $block_content, $block ) {
 	}
 
 	// return early if no settings are found on the block attributes.
-	$block_settings = _wp_array_get( $block, array( 'attrs', 'settings' ), null );
+	$block_settings = isset( $block['attrs']['settings'] )
+		? _wp_array_get( $block, array( 'attrs', 'settings' ), null )
+		: null;
 	if ( empty( $block_settings ) ) {
 		return $block_content;
 	}
@@ -59,7 +61,9 @@ function _gutenberg_add_block_level_preset_styles( $pre_render, $block ) {
 	}
 
 	// return early if no settings are found on the block attributes.
-	$block_settings = _wp_array_get( $block, array( 'attrs', 'settings' ), null );
+	$block_settings = isset( $block['attrs']['settings'] )
+		? _wp_array_get( $block, array( 'attrs', 'settings' ), null )
+		: null;
 	if ( empty( $block_settings ) ) {
 		return null;
 	}

--- a/lib/block-supports/settings.php
+++ b/lib/block-supports/settings.php
@@ -26,7 +26,8 @@ function _gutenberg_add_block_level_presets_class( $block_content, $block ) {
 	}
 
 	// return early if no settings are found on the block attributes.
-	if ( ! isset( $block['attrs']['settings'] ) || empty( $block['attrs']['settings'] ) ) {
+	$block_settings = _wp_array_get( $block, array( 'attrs', 'settings' ), null );
+	if ( empty( $block_settings ) ) {
 		return $block_content;
 	}
 
@@ -58,7 +59,8 @@ function _gutenberg_add_block_level_preset_styles( $pre_render, $block ) {
 	}
 
 	// return early if no settings are found on the block attributes.
-	if ( ! isset( $block['attrs']['settings'] ) || empty( $block['attrs']['settings'] ) ) {
+	$block_settings = _wp_array_get( $block, array( 'attrs', 'settings' ), null );
+	if ( empty( $block_settings ) ) {
 		return null;
 	}
 

--- a/lib/block-supports/settings.php
+++ b/lib/block-supports/settings.php
@@ -26,9 +26,7 @@ function _gutenberg_add_block_level_presets_class( $block_content, $block ) {
 	}
 
 	// return early if no settings are found on the block attributes.
-	$block_settings = isset( $block['attrs']['settings'] )
-		? _wp_array_get( $block, array( 'attrs', 'settings' ), null )
-		: null;
+	$block_settings = isset( $block['attrs']['settings'] ) ? $block['attrs']['settings'] : null;
 	if ( empty( $block_settings ) ) {
 		return $block_content;
 	}
@@ -61,9 +59,7 @@ function _gutenberg_add_block_level_preset_styles( $pre_render, $block ) {
 	}
 
 	// return early if no settings are found on the block attributes.
-	$block_settings = isset( $block['attrs']['settings'] )
-		? _wp_array_get( $block, array( 'attrs', 'settings' ), null )
-		: null;
+	$block_settings = isset( $block['attrs']['settings'] ) ? $block['attrs']['settings'] : null;
 	if ( empty( $block_settings ) ) {
 		return null;
 	}

--- a/lib/block-supports/spacing.php
+++ b/lib/block-supports/spacing.php
@@ -52,12 +52,24 @@ function gutenberg_apply_spacing_support( $block_type, $block_attributes ) {
 		return $attributes;
 	}
 
-	$skip_padding                    = wp_should_skip_block_supports_serialization( $block_type, 'spacing', 'padding' );
-	$skip_margin                     = wp_should_skip_block_supports_serialization( $block_type, 'spacing', 'margin' );
-	$spacing_block_styles            = array();
-	$spacing_block_styles['padding'] = $has_padding_support && ! $skip_padding ? _wp_array_get( $block_styles, array( 'spacing', 'padding' ), null ) : null;
-	$spacing_block_styles['margin']  = $has_margin_support && ! $skip_margin ? _wp_array_get( $block_styles, array( 'spacing', 'margin' ), null ) : null;
-	$styles                          = gutenberg_style_engine_get_styles( array( 'spacing' => $spacing_block_styles ) );
+	$skip_padding         = wp_should_skip_block_supports_serialization( $block_type, 'spacing', 'padding' );
+	$skip_margin          = wp_should_skip_block_supports_serialization( $block_type, 'spacing', 'margin' );
+	$spacing_block_styles = array(
+		'padding' => null,
+		'margin'  => null,
+	);
+
+	if ( $has_padding_support && ! $skip_padding ) {
+		$spacing_block_styles['padding'] = isset( $block_styles['spacing']['padding'] )
+			? _wp_array_get( $block_styles, array( 'spacing', 'padding' ), null )
+			: null;
+	}
+	if ( $has_margin_support && ! $skip_margin ) {
+		$spacing_block_styles['margin'] = isset( $block_styles['spacing']['margin'] )
+			? _wp_array_get( $block_styles, array( 'spacing', 'margin' ), null )
+			: null;
+	}
+	$styles = gutenberg_style_engine_get_styles( array( 'spacing' => $spacing_block_styles ) );
 
 	if ( ! empty( $styles['css'] ) ) {
 		$attributes['style'] = $styles['css'];

--- a/lib/block-supports/spacing.php
+++ b/lib/block-supports/spacing.php
@@ -61,12 +61,12 @@ function gutenberg_apply_spacing_support( $block_type, $block_attributes ) {
 
 	if ( $has_padding_support && ! $skip_padding ) {
 		$spacing_block_styles['padding'] = isset( $block_styles['spacing']['padding'] )
-			? _wp_array_get( $block_styles, array( 'spacing', 'padding' ), null )
+			? $block_styles['spacing']['padding']
 			: null;
 	}
 	if ( $has_margin_support && ! $skip_margin ) {
 		$spacing_block_styles['margin'] = isset( $block_styles['spacing']['margin'] )
-			? _wp_array_get( $block_styles, array( 'spacing', 'margin' ), null )
+			? $block_styles['spacing']['margin']
 			: null;
 	}
 	$styles = gutenberg_style_engine_get_styles( array( 'spacing' => $spacing_block_styles ) );

--- a/lib/block-supports/spacing.php
+++ b/lib/block-supports/spacing.php
@@ -58,16 +58,11 @@ function gutenberg_apply_spacing_support( $block_type, $block_attributes ) {
 		'padding' => null,
 		'margin'  => null,
 	);
-
 	if ( $has_padding_support && ! $skip_padding ) {
-		$spacing_block_styles['padding'] = isset( $block_styles['spacing']['padding'] )
-			? $block_styles['spacing']['padding']
-			: null;
+		$spacing_block_styles['padding'] = $block_styles['spacing']['padding'] ?? null;
 	}
 	if ( $has_margin_support && ! $skip_margin ) {
-		$spacing_block_styles['margin'] = isset( $block_styles['spacing']['margin'] )
-			? $block_styles['spacing']['margin']
-			: null;
+		$spacing_block_styles['margin'] = $block_styles['spacing']['margin'] ?? null;
 	}
 	$styles = gutenberg_style_engine_get_styles( array( 'spacing' => $spacing_block_styles ) );
 

--- a/lib/block-supports/spacing.php
+++ b/lib/block-supports/spacing.php
@@ -59,10 +59,10 @@ function gutenberg_apply_spacing_support( $block_type, $block_attributes ) {
 		'margin'  => null,
 	);
 	if ( $has_padding_support && ! $skip_padding ) {
-		$spacing_block_styles['padding'] = isset( $block_styles['spacing']['padding'] ) ? $block_styles['spacing']['padding'] : null;
+		$spacing_block_styles['padding'] = $block_styles['spacing']['padding'] ?? null;
 	}
 	if ( $has_margin_support && ! $skip_margin ) {
-		$spacing_block_styles['margin'] = isset( $block_styles['spacing']['margin'] ) ? $block_styles['spacing']['margin'] : null;
+		$spacing_block_styles['margin'] = $block_styles['spacing']['margin'] ?? null;
 	}
 	$styles = gutenberg_style_engine_get_styles( array( 'spacing' => $spacing_block_styles ) );
 

--- a/lib/block-supports/spacing.php
+++ b/lib/block-supports/spacing.php
@@ -59,10 +59,10 @@ function gutenberg_apply_spacing_support( $block_type, $block_attributes ) {
 		'margin'  => null,
 	);
 	if ( $has_padding_support && ! $skip_padding ) {
-		$spacing_block_styles['padding'] = $block_styles['spacing']['padding'] ?? null;
+		$spacing_block_styles['padding'] = isset( $block_styles['spacing']['padding'] ) ? $block_styles['spacing']['padding'] : null;
 	}
 	if ( $has_margin_support && ! $skip_margin ) {
-		$spacing_block_styles['margin'] = $block_styles['spacing']['margin'] ?? null;
+		$spacing_block_styles['margin'] = isset( $block_styles['spacing']['margin'] ) ? $block_styles['spacing']['margin'] : null;
 	}
 	$styles = gutenberg_style_engine_get_styles( array( 'spacing' => $spacing_block_styles ) );
 

--- a/lib/block-supports/typography.php
+++ b/lib/block-supports/typography.php
@@ -16,7 +16,7 @@ function gutenberg_register_typography_support( $block_type ) {
 	}
 
 	$typography_supports = isset( $block_type->supports['typography'] )
-		? _wp_array_get( $block_type->supports, array( 'typography' ), false )
+		? $block_type->supports['typography']
 		: false;
 	if ( false === $typography_supports ) {
 		return;
@@ -83,7 +83,7 @@ function gutenberg_apply_typography_support( $block_type, $block_attributes ) {
 	}
 
 	$typography_supports = isset( $block_type->supports['typography'] ) && $block_type->supports['typography']
-		? _wp_array_get( $block_type->supports, array( 'typography' ), array() )
+		? $block_type->supports['typography']
 		: array();
 	if ( ! $typography_supports || array() === $typography_supports ) {
 		return array();
@@ -145,13 +145,13 @@ function gutenberg_apply_typography_support( $block_type, $block_attributes ) {
 
 	if ( $has_line_height_support && ! $should_skip_line_height ) {
 			$typography_block_styles['lineHeight'] = isset( $block_attributes['style']['typography']['lineHeight'] )
-				? _wp_array_get( $block_attributes, array( 'style', 'typography', 'lineHeight' ), null )
+				? $block_attributes['style']['typography']['lineHeight']
 				: null;
 	}
 
 	if ( $has_text_columns_support && ! $should_skip_text_columns && isset( $block_attributes['style']['typography']['textColumns'] ) ) {
 		$typography_block_styles['textColumns'] = isset( $block_attributes['style']['typography']['textColumns'] )
-			? _wp_array_get( $block_attributes, array( 'style', 'typography', 'textColumns' ), null )
+			? $block_attributes['style']['typography']['textColumns']
 			: null;
 	}
 

--- a/lib/block-supports/typography.php
+++ b/lib/block-supports/typography.php
@@ -15,21 +15,23 @@ function gutenberg_register_typography_support( $block_type ) {
 		return;
 	}
 
-	$typography_supports = _wp_array_get( $block_type->supports, array( 'typography' ), false );
-	if ( ! $typography_supports ) {
+	$typography_supports = isset( $block_type->supports['typography'] )
+		? _wp_array_get( $block_type->supports, array( 'typography' ), false )
+		: false;
+	if ( false === $typography_supports ) {
 		return;
 	}
 
-	$has_font_family_support     = _wp_array_get( $typography_supports, array( '__experimentalFontFamily' ), false );
-	$has_font_size_support       = _wp_array_get( $typography_supports, array( 'fontSize' ), false );
-	$has_font_style_support      = _wp_array_get( $typography_supports, array( '__experimentalFontStyle' ), false );
-	$has_font_weight_support     = _wp_array_get( $typography_supports, array( '__experimentalFontWeight' ), false );
-	$has_letter_spacing_support  = _wp_array_get( $typography_supports, array( '__experimentalLetterSpacing' ), false );
-	$has_line_height_support     = _wp_array_get( $typography_supports, array( 'lineHeight' ), false );
-	$has_text_columns_support    = _wp_array_get( $typography_supports, array( 'textColumns' ), false );
-	$has_text_decoration_support = _wp_array_get( $typography_supports, array( '__experimentalTextDecoration' ), false );
-	$has_text_transform_support  = _wp_array_get( $typography_supports, array( '__experimentalTextTransform' ), false );
-	$has_writing_mode_support    = _wp_array_get( $typography_supports, array( '__experimentalWritingMode' ), false );
+	$has_font_family_support     = isset( $typography_supports['__experimentalFontFamily'] ) && $typography_supports['__experimentalFontFamily'];
+	$has_font_size_support       = isset( $typography_supports['fontSize'] ) && $typography_supports['fontSize'];
+	$has_font_style_support      = isset( $typography_supports['__experimentalFontStyle'] ) && $typography_supports['__experimentalFontStyle'];
+	$has_font_weight_support     = isset( $typography_supports['__experimentalFontWeight'] ) && $typography_supports['__experimentalFontWeight'];
+	$has_letter_spacing_support  = isset( $typography_supports['__experimentalLetterSpacing'] ) && $typography_supports['__experimentalLetterSpacing'];
+	$has_line_height_support     = isset( $typography_supports['lineHeight'] ) && $typography_supports['lineHeight'];
+	$has_text_columns_support    = isset( $typography_supports['textColumns'] ) && $typography_supports['textColumns'];
+	$has_text_decoration_support = isset( $typography_supports['__experimentalTextDecoration'] ) && $typography_supports['__experimentalTextDecoration'];
+	$has_text_transform_support  = isset( $typography_supports['__experimentalTextTransform'] ) && $typography_supports['__experimentalTextTransform'];
+    $has_writing_mode_support    = isset( $typography_supports['__experimentalWritingMode'] ) && $typography_supports['__experimentalWritingMode'];
 
 	$has_typography_support = $has_font_family_support
 		|| $has_font_size_support
@@ -80,8 +82,10 @@ function gutenberg_apply_typography_support( $block_type, $block_attributes ) {
 		return array();
 	}
 
-	$typography_supports = _wp_array_get( $block_type->supports, array( 'typography' ), false );
-	if ( ! $typography_supports ) {
+	$typography_supports = isset( $block_type->supports['typography'] ) && $block_type->supports['typography']
+		? _wp_array_get( $block_type->supports, array( 'typography' ), array() )
+		: array();
+	if ( ! $typography_supports || array() === $typography_supports ) {
 		return array();
 	}
 
@@ -89,16 +93,16 @@ function gutenberg_apply_typography_support( $block_type, $block_attributes ) {
 		return array();
 	}
 
-	$has_font_family_support     = _wp_array_get( $typography_supports, array( '__experimentalFontFamily' ), false );
-	$has_font_size_support       = _wp_array_get( $typography_supports, array( 'fontSize' ), false );
-	$has_font_style_support      = _wp_array_get( $typography_supports, array( '__experimentalFontStyle' ), false );
-	$has_font_weight_support     = _wp_array_get( $typography_supports, array( '__experimentalFontWeight' ), false );
-	$has_letter_spacing_support  = _wp_array_get( $typography_supports, array( '__experimentalLetterSpacing' ), false );
-	$has_line_height_support     = _wp_array_get( $typography_supports, array( 'lineHeight' ), false );
-	$has_text_columns_support    = _wp_array_get( $typography_supports, array( 'textColumns' ), false );
-	$has_text_decoration_support = _wp_array_get( $typography_supports, array( '__experimentalTextDecoration' ), false );
-	$has_text_transform_support  = _wp_array_get( $typography_supports, array( '__experimentalTextTransform' ), false );
-	$has_writing_mode_support    = _wp_array_get( $typography_supports, array( '__experimentalWritingMode' ), false );
+	$has_font_family_support     = isset( $typography_supports['__experimentalFontFamily'] ) && $typography_supports['__experimentalFontFamily'];
+	$has_font_size_support       = isset( $typography_supports['fontSize'] ) && $typography_supports['fontSize'];
+	$has_font_style_support      = isset( $typography_supports['__experimentalFontStyle'] ) && $typography_supports['__experimentalFontStyle'];
+	$has_font_weight_support     = isset( $typography_supports['__experimentalFontWeight'] ) && $typography_supports['__experimentalFontWeight'];
+	$has_letter_spacing_support  = isset( $typography_supports['__experimentalLetterSpacing'] ) && $typography_supports['__experimentalLetterSpacing'];
+	$has_line_height_support     = isset( $typography_supports['lineHeight'] ) && $typography_supports['lineHeight'];
+	$has_text_columns_support    = isset( $typography_supports['textColumns'] ) && $typography_supports['textColumns'];
+	$has_text_decoration_support = isset( $typography_supports['__experimentalTextDecoration'] ) && $typography_supports['__experimentalTextDecoration'];
+	$has_text_transform_support  = isset( $typography_supports['__experimentalTextTransform'] ) && $typography_supports['__experimentalTextTransform'];
+	$has_writing_mode_support.   = isset( $typography_supports['__experimentalWritingMode'] ) && $typography_supports['__experimentalWritingMode'];
 
 	// Whether to skip individual block support features.
 	$should_skip_font_size       = wp_should_skip_block_supports_serialization( $block_type, 'typography', 'fontSize' );
@@ -114,7 +118,7 @@ function gutenberg_apply_typography_support( $block_type, $block_attributes ) {
 
 	$typography_block_styles = array();
 	if ( $has_font_size_support && ! $should_skip_font_size ) {
-		$preset_font_size                    = array_key_exists( 'fontSize', $block_attributes ) ? "var:preset|font-size|{$block_attributes['fontSize']}" : null;
+		$preset_font_size                    = isset( $block_attributes['fontSize'] ) ? "var:preset|font-size|{$block_attributes['fontSize']}" : null;
 		$custom_font_size                    = isset( $block_attributes['style']['typography']['fontSize'] ) ? $block_attributes['style']['typography']['fontSize'] : null;
 		$typography_block_styles['fontSize'] = $preset_font_size ? $preset_font_size : gutenberg_get_typography_font_size_value(
 			array(
@@ -140,11 +144,15 @@ function gutenberg_apply_typography_support( $block_type, $block_attributes ) {
 	}
 
 	if ( $has_line_height_support && ! $should_skip_line_height ) {
-			$typography_block_styles['lineHeight'] = _wp_array_get( $block_attributes, array( 'style', 'typography', 'lineHeight' ), null );
+			$typography_block_styles['lineHeight'] = isset( $block_attributes['style']['typography']['lineHeight'] )
+				? _wp_array_get( $block_attributes, array( 'style', 'typography', 'lineHeight' ), null )
+				: null;
 	}
 
 	if ( $has_text_columns_support && ! $should_skip_text_columns && isset( $block_attributes['style']['typography']['textColumns'] ) ) {
-		$typography_block_styles['textColumns'] = _wp_array_get( $block_attributes, array( 'style', 'typography', 'textColumns' ), null );
+		$typography_block_styles['textColumns'] = isset( $block_attributes['style']['typography']['textColumns'] )
+			? _wp_array_get( $block_attributes, array( 'style', 'typography', 'textColumns' ), null )
+			: null;
 	}
 
 	if ( $has_text_decoration_support && ! $should_skip_text_decoration && isset( $block_attributes['style']['typography']['textDecoration'] ) ) {

--- a/lib/block-supports/typography.php
+++ b/lib/block-supports/typography.php
@@ -102,7 +102,7 @@ function gutenberg_apply_typography_support( $block_type, $block_attributes ) {
 	$has_text_columns_support    = isset( $typography_supports['textColumns'] ) && $typography_supports['textColumns'];
 	$has_text_decoration_support = isset( $typography_supports['__experimentalTextDecoration'] ) && $typography_supports['__experimentalTextDecoration'];
 	$has_text_transform_support  = isset( $typography_supports['__experimentalTextTransform'] ) && $typography_supports['__experimentalTextTransform'];
-	$has_writing_mode_support.   = isset( $typography_supports['__experimentalWritingMode'] ) && $typography_supports['__experimentalWritingMode'];
+	$has_writing_mode_support    = isset( $typography_supports['__experimentalWritingMode'] ) && $typography_supports['__experimentalWritingMode'];
 
 	// Whether to skip individual block support features.
 	$should_skip_font_size       = wp_should_skip_block_supports_serialization( $block_type, 'typography', 'fontSize' );

--- a/lib/block-supports/typography.php
+++ b/lib/block-supports/typography.php
@@ -31,7 +31,7 @@ function gutenberg_register_typography_support( $block_type ) {
 	$has_text_columns_support    = isset( $typography_supports['textColumns'] ) && $typography_supports['textColumns'];
 	$has_text_decoration_support = isset( $typography_supports['__experimentalTextDecoration'] ) && $typography_supports['__experimentalTextDecoration'];
 	$has_text_transform_support  = isset( $typography_supports['__experimentalTextTransform'] ) && $typography_supports['__experimentalTextTransform'];
-    $has_writing_mode_support    = isset( $typography_supports['__experimentalWritingMode'] ) && $typography_supports['__experimentalWritingMode'];
+	$has_writing_mode_support    = isset( $typography_supports['__experimentalWritingMode'] ) && $typography_supports['__experimentalWritingMode'];
 
 	$has_typography_support = $has_font_family_support
 		|| $has_font_size_support

--- a/lib/block-supports/typography.php
+++ b/lib/block-supports/typography.php
@@ -15,21 +15,21 @@ function gutenberg_register_typography_support( $block_type ) {
 		return;
 	}
 
-	$typography_supports = $block_type->supports['typography'] ?? false;
+	$typography_supports = isset( $block_type->supports['typography'] ) ? $block_type->supports['typography'] : false;
 	if ( ! $typography_supports ) {
 		return;
 	}
 
-	$has_font_family_support     = $typography_supports['__experimentalFontFamily'] ?? false;
-	$has_font_size_support       = $typography_supports['fontSize'] ?? false;
-	$has_font_style_support      = $typography_supports['__experimentalFontStyle'] ?? false;
-	$has_font_weight_support     = $typography_supports['__experimentalFontWeight'] ?? false;
-	$has_letter_spacing_support  = $typography_supports['__experimentalLetterSpacing'] ?? false;
-	$has_line_height_support     = $typography_supports['lineHeight'] ?? false;
-	$has_text_columns_support    = $typography_supports['textColumns'] ?? false;
-	$has_text_decoration_support = $typography_supports['__experimentalTextDecoration'] ?? false;
-	$has_text_transform_support  = $typography_supports['__experimentalTextTransform'] ?? false;
-	$has_writing_mode_support    = $typography_supports['__experimentalWritingMode'] ?? false;
+	$has_font_family_support     = isset( $typography_supports['__experimentalFontFamily'] ) ? $typography_supports['__experimentalFontFamily'] : false;
+	$has_font_size_support       = isset( $typography_supports['fontSize'] ) ? $typography_supports['fontSize'] : false;
+	$has_font_style_support      = isset( $typography_supports['__experimentalFontStyle'] ) ? $typography_supports['__experimentalFontStyle'] : false;
+	$has_font_weight_support     = isset( $typography_supports['__experimentalFontWeight'] ) ? $typography_supports['__experimentalFontWeight'] : false;
+	$has_letter_spacing_support  = isset( $typography_supports['__experimentalLetterSpacing'] ) ? $typography_supports['__experimentalLetterSpacing'] : false;
+	$has_line_height_support     = isset( $typography_supports['lineHeight'] ) ? $typography_supports['lineHeight'] : false;
+	$has_text_columns_support    = isset( $typography_supports['textColumns'] ) ? $typography_supports['textColumns'] : false;
+	$has_text_decoration_support = isset( $typography_supports['__experimentalTextDecoration'] ) ? $typography_supports['__experimentalTextDecoration'] : false;
+	$has_text_transform_support  = isset( $typography_supports['__experimentalTextTransform'] ) ? $typography_supports['__experimentalTextTransform'] : false;
+	$has_writing_mode_support    = isset( $typography_supports['__experimentalWritingMode'] ) ? $typography_supports['__experimentalWritingMode'] : false;
 
 	$has_typography_support = $has_font_family_support
 		|| $has_font_size_support
@@ -80,7 +80,7 @@ function gutenberg_apply_typography_support( $block_type, $block_attributes ) {
 		return array();
 	}
 
-	$typography_supports = $block_type->supports['typography'] ?? false;
+	$typography_supports = isset( $block_type->supports['typography'] ) ? $block_type->supports['typography'] : false;
 	if ( ! $typography_supports ) {
 		return array();
 	}
@@ -89,16 +89,16 @@ function gutenberg_apply_typography_support( $block_type, $block_attributes ) {
 		return array();
 	}
 
-	$has_font_family_support     = $typography_supports['__experimentalFontFamily'] ?? false;
-	$has_font_size_support       = $typography_supports['fontSize'] ?? false;
-	$has_font_style_support      = $typography_supports['__experimentalFontStyle'] ?? false;
-	$has_font_weight_support     = $typography_supports['__experimentalFontWeight'] ?? false;
-	$has_letter_spacing_support  = $typography_supports['__experimentalLetterSpacing'] ?? false;
-	$has_line_height_support     = $typography_supports['lineHeight'] ?? false;
-	$has_text_columns_support    = $typography_supports['textColumns'] ?? false;
-	$has_text_decoration_support = $typography_supports['__experimentalTextDecoration'] ?? false;
-	$has_text_transform_support  = $typography_supports['__experimentalTextTransform'] ?? false;
-	$has_writing_mode_support    = $typography_supports['__experimentalWritingMode'] ?? false;
+	$has_font_family_support     = isset( $typography_supports['__experimentalFontFamily'] ) ? $typography_supports['__experimentalFontFamily'] : false;
+	$has_font_size_support       = isset( $typography_supports['fontSize'] ) ? $typography_supports['fontSize'] : false;
+	$has_font_style_support      = isset( $typography_supports['__experimentalFontStyle'] ) ? $typography_supports['__experimentalFontStyle'] : false;
+	$has_font_weight_support     = isset( $typography_supports['__experimentalFontWeight'] ) ? $typography_supports['__experimentalFontWeight'] : false;
+	$has_letter_spacing_support  = isset( $typography_supports['__experimentalLetterSpacing'] ) ? $typography_supports['__experimentalLetterSpacing'] : false;
+	$has_line_height_support     = isset( $typography_supports['lineHeight'] ) ? $typography_supports['lineHeight'] : false;
+	$has_text_columns_support    = isset( $typography_supports['textColumns'] ) ? $typography_supports['textColumns'] : false;
+	$has_text_decoration_support = isset( $typography_supports['__experimentalTextDecoration'] ) ? $typography_supports['__experimentalTextDecoration'] : false;
+	$has_text_transform_support  = isset( $typography_supports['__experimentalTextTransform'] ) ? $typography_supports['__experimentalTextTransform'] : false;
+	$has_writing_mode_support    = isset( $typography_supports['__experimentalWritingMode'] ) ? $typography_supports['__experimentalWritingMode'] : false;
 
 	// Whether to skip individual block support features.
 	$should_skip_font_size       = wp_should_skip_block_supports_serialization( $block_type, 'typography', 'fontSize' );
@@ -140,11 +140,11 @@ function gutenberg_apply_typography_support( $block_type, $block_attributes ) {
 	}
 
 	if ( $has_line_height_support && ! $should_skip_line_height ) {
-			$typography_block_styles['lineHeight'] = $block_attributes['style']['typography']['lineHeight'] ?? null;
+			$typography_block_styles['lineHeight'] = isset( $block_attributes['style']['typography']['lineHeight'] ) ? $block_attributes['style']['typography']['lineHeight'] : null;
 	}
 
 	if ( $has_text_columns_support && ! $should_skip_text_columns && isset( $block_attributes['style']['typography']['textColumns'] ) ) {
-		$typography_block_styles['textColumns'] = $block_attributes['style']['typography']['textColumns'] ?? null;
+		$typography_block_styles['textColumns'] = isset( $block_attributes['style']['typography']['textColumns'] ) ? $block_attributes['style']['typography']['textColumns'] : null;
 	}
 
 	if ( $has_text_decoration_support && ! $should_skip_text_decoration && isset( $block_attributes['style']['typography']['textDecoration'] ) ) {
@@ -163,7 +163,7 @@ function gutenberg_apply_typography_support( $block_type, $block_attributes ) {
 	}
 
 	if ( $has_writing_mode_support && ! $should_skip_writing_mode && isset( $block_attributes['style']['typography']['writingMode'] ) ) {
-		$typography_block_styles['writingMode'] = $block_attributes['style']['typography']['writingMode'] ?? null;
+		$typography_block_styles['writingMode'] = isset( $block_attributes['style']['typography']['writingMode'] ) ? $block_attributes['style']['typography']['writingMode'] : null;
 	}
 
 	$attributes = array();

--- a/lib/block-supports/typography.php
+++ b/lib/block-supports/typography.php
@@ -15,23 +15,21 @@ function gutenberg_register_typography_support( $block_type ) {
 		return;
 	}
 
-	$typography_supports = isset( $block_type->supports['typography'] )
-		? $block_type->supports['typography']
-		: false;
-	if ( false === $typography_supports ) {
+	$typography_supports = $block_type->supports['typography'] ?? false;
+	if ( ! $typography_supports ) {
 		return;
 	}
 
-	$has_font_family_support     = isset( $typography_supports['__experimentalFontFamily'] ) && $typography_supports['__experimentalFontFamily'];
-	$has_font_size_support       = isset( $typography_supports['fontSize'] ) && $typography_supports['fontSize'];
-	$has_font_style_support      = isset( $typography_supports['__experimentalFontStyle'] ) && $typography_supports['__experimentalFontStyle'];
-	$has_font_weight_support     = isset( $typography_supports['__experimentalFontWeight'] ) && $typography_supports['__experimentalFontWeight'];
-	$has_letter_spacing_support  = isset( $typography_supports['__experimentalLetterSpacing'] ) && $typography_supports['__experimentalLetterSpacing'];
-	$has_line_height_support     = isset( $typography_supports['lineHeight'] ) && $typography_supports['lineHeight'];
-	$has_text_columns_support    = isset( $typography_supports['textColumns'] ) && $typography_supports['textColumns'];
-	$has_text_decoration_support = isset( $typography_supports['__experimentalTextDecoration'] ) && $typography_supports['__experimentalTextDecoration'];
-	$has_text_transform_support  = isset( $typography_supports['__experimentalTextTransform'] ) && $typography_supports['__experimentalTextTransform'];
-	$has_writing_mode_support    = isset( $typography_supports['__experimentalWritingMode'] ) && $typography_supports['__experimentalWritingMode'];
+	$has_font_family_support     = $typography_supports['__experimentalFontFamily'] ?? false;
+	$has_font_size_support       = $typography_supports['fontSize'] ?? false;
+	$has_font_style_support      = $typography_supports['__experimentalFontStyle'] ?? false;
+	$has_font_weight_support     = $typography_supports['__experimentalFontWeight'] ?? false;
+	$has_letter_spacing_support  = $typography_supports['__experimentalLetterSpacing'] ?? false;
+	$has_line_height_support     = $typography_supports['lineHeight'] ?? false;
+	$has_text_columns_support    = $typography_supports['textColumns'] ?? false;
+	$has_text_decoration_support = $typography_supports['__experimentalTextDecoration'] ?? false;
+	$has_text_transform_support  = $typography_supports['__experimentalTextTransform'] ?? false;
+	$has_writing_mode_support    = $typography_supports['__experimentalWritingMode'] ?? false;
 
 	$has_typography_support = $has_font_family_support
 		|| $has_font_size_support
@@ -82,10 +80,8 @@ function gutenberg_apply_typography_support( $block_type, $block_attributes ) {
 		return array();
 	}
 
-	$typography_supports = isset( $block_type->supports['typography'] ) && $block_type->supports['typography']
-		? $block_type->supports['typography']
-		: array();
-	if ( ! $typography_supports || array() === $typography_supports ) {
+	$typography_supports = $block_type->supports['typography'] ?? false;
+	if ( ! $typography_supports ) {
 		return array();
 	}
 
@@ -93,16 +89,16 @@ function gutenberg_apply_typography_support( $block_type, $block_attributes ) {
 		return array();
 	}
 
-	$has_font_family_support     = isset( $typography_supports['__experimentalFontFamily'] ) && $typography_supports['__experimentalFontFamily'];
-	$has_font_size_support       = isset( $typography_supports['fontSize'] ) && $typography_supports['fontSize'];
-	$has_font_style_support      = isset( $typography_supports['__experimentalFontStyle'] ) && $typography_supports['__experimentalFontStyle'];
-	$has_font_weight_support     = isset( $typography_supports['__experimentalFontWeight'] ) && $typography_supports['__experimentalFontWeight'];
-	$has_letter_spacing_support  = isset( $typography_supports['__experimentalLetterSpacing'] ) && $typography_supports['__experimentalLetterSpacing'];
-	$has_line_height_support     = isset( $typography_supports['lineHeight'] ) && $typography_supports['lineHeight'];
-	$has_text_columns_support    = isset( $typography_supports['textColumns'] ) && $typography_supports['textColumns'];
-	$has_text_decoration_support = isset( $typography_supports['__experimentalTextDecoration'] ) && $typography_supports['__experimentalTextDecoration'];
-	$has_text_transform_support  = isset( $typography_supports['__experimentalTextTransform'] ) && $typography_supports['__experimentalTextTransform'];
-	$has_writing_mode_support    = isset( $typography_supports['__experimentalWritingMode'] ) && $typography_supports['__experimentalWritingMode'];
+	$has_font_family_support     = $typography_supports['__experimentalFontFamily'] ?? false;
+	$has_font_size_support       = $typography_supports['fontSize'] ?? false;
+	$has_font_style_support      = $typography_supports['__experimentalFontStyle'] ?? false;
+	$has_font_weight_support     = $typography_supports['__experimentalFontWeight'] ?? false;
+	$has_letter_spacing_support  = $typography_supports['__experimentalLetterSpacing'] ?? false;
+	$has_line_height_support     = $typography_supports['lineHeight'] ?? false;
+	$has_text_columns_support    = $typography_supports['textColumns'] ?? false;
+	$has_text_decoration_support = $typography_supports['__experimentalTextDecoration'] ?? false;
+	$has_text_transform_support  = $typography_supports['__experimentalTextTransform'] ?? false;
+	$has_writing_mode_support    = $typography_supports['__experimentalWritingMode'] ?? false;
 
 	// Whether to skip individual block support features.
 	$should_skip_font_size       = wp_should_skip_block_supports_serialization( $block_type, 'typography', 'fontSize' );
@@ -118,7 +114,7 @@ function gutenberg_apply_typography_support( $block_type, $block_attributes ) {
 
 	$typography_block_styles = array();
 	if ( $has_font_size_support && ! $should_skip_font_size ) {
-		$preset_font_size                    = isset( $block_attributes['fontSize'] ) ? "var:preset|font-size|{$block_attributes['fontSize']}" : null;
+		$preset_font_size                    = array_key_exists( 'fontSize', $block_attributes ) ? "var:preset|font-size|{$block_attributes['fontSize']}" : null;
 		$custom_font_size                    = isset( $block_attributes['style']['typography']['fontSize'] ) ? $block_attributes['style']['typography']['fontSize'] : null;
 		$typography_block_styles['fontSize'] = $preset_font_size ? $preset_font_size : gutenberg_get_typography_font_size_value(
 			array(
@@ -144,15 +140,11 @@ function gutenberg_apply_typography_support( $block_type, $block_attributes ) {
 	}
 
 	if ( $has_line_height_support && ! $should_skip_line_height ) {
-			$typography_block_styles['lineHeight'] = isset( $block_attributes['style']['typography']['lineHeight'] )
-				? $block_attributes['style']['typography']['lineHeight']
-				: null;
+			$typography_block_styles['lineHeight'] = $block_attributes['style']['typography']['lineHeight'] ?? null;
 	}
 
 	if ( $has_text_columns_support && ! $should_skip_text_columns && isset( $block_attributes['style']['typography']['textColumns'] ) ) {
-		$typography_block_styles['textColumns'] = isset( $block_attributes['style']['typography']['textColumns'] )
-			? $block_attributes['style']['typography']['textColumns']
-			: null;
+		$typography_block_styles['textColumns'] = $block_attributes['style']['typography']['textColumns'] ?? null;
 	}
 
 	if ( $has_text_decoration_support && ! $should_skip_text_decoration && isset( $block_attributes['style']['typography']['textDecoration'] ) ) {
@@ -171,7 +163,7 @@ function gutenberg_apply_typography_support( $block_type, $block_attributes ) {
 	}
 
 	if ( $has_writing_mode_support && ! $should_skip_writing_mode && isset( $block_attributes['style']['typography']['writingMode'] ) ) {
-		$typography_block_styles['writingMode'] = _wp_array_get( $block_attributes, array( 'style', 'typography', 'writingMode' ), null );
+		$typography_block_styles['writingMode'] = $block_attributes['style']['typography']['writingMode'] ?? null;
 	}
 
 	$attributes = array();

--- a/lib/block-supports/typography.php
+++ b/lib/block-supports/typography.php
@@ -15,21 +15,21 @@ function gutenberg_register_typography_support( $block_type ) {
 		return;
 	}
 
-	$typography_supports = isset( $block_type->supports['typography'] ) ? $block_type->supports['typography'] : false;
+	$typography_supports = $block_type->supports['typography'] ?? false;
 	if ( ! $typography_supports ) {
 		return;
 	}
 
-	$has_font_family_support     = isset( $typography_supports['__experimentalFontFamily'] ) ? $typography_supports['__experimentalFontFamily'] : false;
-	$has_font_size_support       = isset( $typography_supports['fontSize'] ) ? $typography_supports['fontSize'] : false;
-	$has_font_style_support      = isset( $typography_supports['__experimentalFontStyle'] ) ? $typography_supports['__experimentalFontStyle'] : false;
-	$has_font_weight_support     = isset( $typography_supports['__experimentalFontWeight'] ) ? $typography_supports['__experimentalFontWeight'] : false;
-	$has_letter_spacing_support  = isset( $typography_supports['__experimentalLetterSpacing'] ) ? $typography_supports['__experimentalLetterSpacing'] : false;
-	$has_line_height_support     = isset( $typography_supports['lineHeight'] ) ? $typography_supports['lineHeight'] : false;
-	$has_text_columns_support    = isset( $typography_supports['textColumns'] ) ? $typography_supports['textColumns'] : false;
-	$has_text_decoration_support = isset( $typography_supports['__experimentalTextDecoration'] ) ? $typography_supports['__experimentalTextDecoration'] : false;
-	$has_text_transform_support  = isset( $typography_supports['__experimentalTextTransform'] ) ? $typography_supports['__experimentalTextTransform'] : false;
-	$has_writing_mode_support    = isset( $typography_supports['__experimentalWritingMode'] ) ? $typography_supports['__experimentalWritingMode'] : false;
+	$has_font_family_support     = $typography_supports['__experimentalFontFamily'] ?? false;
+	$has_font_size_support       = $typography_supports['fontSize'] ?? false;
+	$has_font_style_support      = $typography_supports['__experimentalFontStyle'] ?? false;
+	$has_font_weight_support     = $typography_supports['__experimentalFontWeight'] ?? false;
+	$has_letter_spacing_support  = $typography_supports['__experimentalLetterSpacing'] ?? false;
+	$has_line_height_support     = $typography_supports['lineHeight'] ?? false;
+	$has_text_columns_support    = $typography_supports['textColumns'] ?? false;
+	$has_text_decoration_support = $typography_supports['__experimentalTextDecoration'] ?? false;
+	$has_text_transform_support  = $typography_supports['__experimentalTextTransform'] ?? false;
+	$has_writing_mode_support    = $typography_supports['__experimentalWritingMode'] ?? false;
 
 	$has_typography_support = $has_font_family_support
 		|| $has_font_size_support
@@ -80,7 +80,7 @@ function gutenberg_apply_typography_support( $block_type, $block_attributes ) {
 		return array();
 	}
 
-	$typography_supports = isset( $block_type->supports['typography'] ) ? $block_type->supports['typography'] : false;
+	$typography_supports = $block_type->supports['typography'] ?? false;
 	if ( ! $typography_supports ) {
 		return array();
 	}
@@ -89,16 +89,16 @@ function gutenberg_apply_typography_support( $block_type, $block_attributes ) {
 		return array();
 	}
 
-	$has_font_family_support     = isset( $typography_supports['__experimentalFontFamily'] ) ? $typography_supports['__experimentalFontFamily'] : false;
-	$has_font_size_support       = isset( $typography_supports['fontSize'] ) ? $typography_supports['fontSize'] : false;
-	$has_font_style_support      = isset( $typography_supports['__experimentalFontStyle'] ) ? $typography_supports['__experimentalFontStyle'] : false;
-	$has_font_weight_support     = isset( $typography_supports['__experimentalFontWeight'] ) ? $typography_supports['__experimentalFontWeight'] : false;
-	$has_letter_spacing_support  = isset( $typography_supports['__experimentalLetterSpacing'] ) ? $typography_supports['__experimentalLetterSpacing'] : false;
-	$has_line_height_support     = isset( $typography_supports['lineHeight'] ) ? $typography_supports['lineHeight'] : false;
-	$has_text_columns_support    = isset( $typography_supports['textColumns'] ) ? $typography_supports['textColumns'] : false;
-	$has_text_decoration_support = isset( $typography_supports['__experimentalTextDecoration'] ) ? $typography_supports['__experimentalTextDecoration'] : false;
-	$has_text_transform_support  = isset( $typography_supports['__experimentalTextTransform'] ) ? $typography_supports['__experimentalTextTransform'] : false;
-	$has_writing_mode_support    = isset( $typography_supports['__experimentalWritingMode'] ) ? $typography_supports['__experimentalWritingMode'] : false;
+	$has_font_family_support     = $typography_supports['__experimentalFontFamily'] ?? false;
+	$has_font_size_support       = $typography_supports['fontSize'] ?? false;
+	$has_font_style_support      = $typography_supports['__experimentalFontStyle'] ?? false;
+	$has_font_weight_support     = $typography_supports['__experimentalFontWeight'] ?? false;
+	$has_letter_spacing_support  = $typography_supports['__experimentalLetterSpacing'] ?? false;
+	$has_line_height_support     = $typography_supports['lineHeight'] ?? false;
+	$has_text_columns_support    = $typography_supports['textColumns'] ?? false;
+	$has_text_decoration_support = $typography_supports['__experimentalTextDecoration'] ?? false;
+	$has_text_transform_support  = $typography_supports['__experimentalTextTransform'] ?? false;
+	$has_writing_mode_support    = $typography_supports['__experimentalWritingMode'] ?? false;
 
 	// Whether to skip individual block support features.
 	$should_skip_font_size       = wp_should_skip_block_supports_serialization( $block_type, 'typography', 'fontSize' );
@@ -140,11 +140,11 @@ function gutenberg_apply_typography_support( $block_type, $block_attributes ) {
 	}
 
 	if ( $has_line_height_support && ! $should_skip_line_height ) {
-			$typography_block_styles['lineHeight'] = isset( $block_attributes['style']['typography']['lineHeight'] ) ? $block_attributes['style']['typography']['lineHeight'] : null;
+			$typography_block_styles['lineHeight'] = $block_attributes['style']['typography']['lineHeight'] ?? null;
 	}
 
 	if ( $has_text_columns_support && ! $should_skip_text_columns && isset( $block_attributes['style']['typography']['textColumns'] ) ) {
-		$typography_block_styles['textColumns'] = isset( $block_attributes['style']['typography']['textColumns'] ) ? $block_attributes['style']['typography']['textColumns'] : null;
+		$typography_block_styles['textColumns'] = $block_attributes['style']['typography']['textColumns'] ?? null;
 	}
 
 	if ( $has_text_decoration_support && ! $should_skip_text_decoration && isset( $block_attributes['style']['typography']['textDecoration'] ) ) {
@@ -163,7 +163,7 @@ function gutenberg_apply_typography_support( $block_type, $block_attributes ) {
 	}
 
 	if ( $has_writing_mode_support && ! $should_skip_writing_mode && isset( $block_attributes['style']['typography']['writingMode'] ) ) {
-		$typography_block_styles['writingMode'] = isset( $block_attributes['style']['typography']['writingMode'] ) ? $block_attributes['style']['typography']['writingMode'] : null;
+		$typography_block_styles['writingMode'] = $block_attributes['style']['typography']['writingMode'] ?? null;
 	}
 
 	$attributes = array();

--- a/lib/class-wp-duotone-gutenberg.php
+++ b/lib/class-wp-duotone-gutenberg.php
@@ -655,16 +655,17 @@ class WP_Duotone_Gutenberg {
 			// `supports.filter.duotone` has not been set and the experimental
 			// property has been, the experimental property value is copied into
 			// `supports.filter.duotone`.
-			$duotone_support = _wp_array_get( $block_type->supports, array( 'filter', 'duotone' ), false );
+			$duotone_support = isset( $block_type->supports['filter']['duotone'] );
 			if ( ! $duotone_support ) {
 				return null;
 			}
 
 			// If the experimental duotone support was set, that value is to be
 			// treated as a selector and requires scoping.
-			$experimental_duotone = _wp_array_get( $block_type->supports, array( 'color', '__experimentalDuotone' ), false );
-			if ( $experimental_duotone ) {
-				$root_selector = wp_get_block_css_selector( $block_type );
+			$supports_experimental_duotone = isset( $block_type->supports['color']['__experimentalDuotone'] );
+			if ( $supports_experimental_duotone ) {
+				$experimental_duotone = _wp_array_get( $block_type->supports, array( 'color', '__experimentalDuotone' ), false );
+				$root_selector        = wp_get_block_css_selector( $block_type );
 				return is_string( $experimental_duotone )
 					? WP_Theme_JSON_Gutenberg::scope_selector( $root_selector, $experimental_duotone )
 					: $root_selector;
@@ -750,7 +751,7 @@ class WP_Duotone_Gutenberg {
 		if ( property_exists( $block_type, 'supports' ) ) {
 			// Previous `color.__experimentalDuotone` support flag is migrated
 			// to `filter.duotone` via `block_type_metadata_settings` filter.
-			$has_duotone_support = _wp_array_get( $block_type->supports, array( 'filter', 'duotone' ), null );
+			$has_duotone_support = isset( $block_type->supports['filter']['duotone'] );
 		}
 
 		if ( $has_duotone_support ) {
@@ -995,10 +996,10 @@ class WP_Duotone_Gutenberg {
 	 * @return array Filtered block type settings.
 	 */
 	public static function migrate_experimental_duotone_support_flag( $settings, $metadata ) {
-		$duotone_support = _wp_array_get( $metadata, array( 'supports', 'color', '__experimentalDuotone' ), null );
+		$duotone_support = isset( $metadata['supports']['color']['__experimentalDuotone'] );
 
-		if ( ! isset( $settings['supports']['filter']['duotone'] ) && null !== $duotone_support ) {
-			_wp_array_set( $settings, array( 'supports', 'filter', 'duotone' ), (bool) $duotone_support );
+		if ( ! isset( $settings['supports']['filter']['duotone'] ) && $duotone_support ) {
+			_wp_array_set( $settings, array( 'supports', 'filter', 'duotone' ), $duotone_support );
 		}
 
 		return $settings;

--- a/lib/class-wp-duotone-gutenberg.php
+++ b/lib/class-wp-duotone-gutenberg.php
@@ -664,7 +664,7 @@ class WP_Duotone_Gutenberg {
 			// treated as a selector and requires scoping.
 			$supports_experimental_duotone = isset( $block_type->supports['color']['__experimentalDuotone'] );
 			if ( $supports_experimental_duotone ) {
-				$experimental_duotone = _wp_array_get( $block_type->supports, array( 'color', '__experimentalDuotone' ), false );
+				$experimental_duotone = $block_type->supports['color']['__experimentalDuotone'];
 				$root_selector        = wp_get_block_css_selector( $block_type );
 				return is_string( $experimental_duotone )
 					? WP_Theme_JSON_Gutenberg::scope_selector( $root_selector, $experimental_duotone )
@@ -776,7 +776,7 @@ class WP_Duotone_Gutenberg {
 	public static function set_global_styles_presets() {
 		// Get the per block settings from the theme.json.
 		$tree              = gutenberg_get_global_settings();
-		$presets_by_origin = _wp_array_get( $tree, array( 'color', 'duotone' ), array() );
+		$presets_by_origin = isset( $tree['color']['duotone'] ) ? $tree['color']['duotone'] : array();
 
 		foreach ( $presets_by_origin as $presets ) {
 			foreach ( $presets as $preset ) {

--- a/lib/class-wp-duotone-gutenberg.php
+++ b/lib/class-wp-duotone-gutenberg.php
@@ -655,17 +655,16 @@ class WP_Duotone_Gutenberg {
 			// `supports.filter.duotone` has not been set and the experimental
 			// property has been, the experimental property value is copied into
 			// `supports.filter.duotone`.
-			$duotone_support = isset( $block_type->supports['filter']['duotone'] );
+			$duotone_support = $block_type->supports['filter']['duotone'] ?? false;
 			if ( ! $duotone_support ) {
 				return null;
 			}
 
 			// If the experimental duotone support was set, that value is to be
 			// treated as a selector and requires scoping.
-			$supports_experimental_duotone = isset( $block_type->supports['color']['__experimentalDuotone'] );
-			if ( $supports_experimental_duotone ) {
-				$experimental_duotone = $block_type->supports['color']['__experimentalDuotone'];
-				$root_selector        = wp_get_block_css_selector( $block_type );
+			$experimental_duotone = $block_type->supports['color']['__experimentalDuotone'] ?? false;
+			if ( $experimental_duotone ) {
+				$root_selector = wp_get_block_css_selector( $block_type );
 				return is_string( $experimental_duotone )
 					? WP_Theme_JSON_Gutenberg::scope_selector( $root_selector, $experimental_duotone )
 					: $root_selector;
@@ -751,7 +750,7 @@ class WP_Duotone_Gutenberg {
 		if ( property_exists( $block_type, 'supports' ) ) {
 			// Previous `color.__experimentalDuotone` support flag is migrated
 			// to `filter.duotone` via `block_type_metadata_settings` filter.
-			$has_duotone_support = isset( $block_type->supports['filter']['duotone'] );
+			$has_duotone_support = $block_type->supports['filter']['duotone'] ?? null;
 		}
 
 		if ( $has_duotone_support ) {
@@ -776,7 +775,7 @@ class WP_Duotone_Gutenberg {
 	public static function set_global_styles_presets() {
 		// Get the per block settings from the theme.json.
 		$tree              = gutenberg_get_global_settings();
-		$presets_by_origin = isset( $tree['color']['duotone'] ) ? $tree['color']['duotone'] : array();
+		$presets_by_origin = $tree['color']['duotone'] ?? array();
 
 		foreach ( $presets_by_origin as $presets ) {
 			foreach ( $presets as $preset ) {
@@ -996,10 +995,10 @@ class WP_Duotone_Gutenberg {
 	 * @return array Filtered block type settings.
 	 */
 	public static function migrate_experimental_duotone_support_flag( $settings, $metadata ) {
-		$duotone_support = isset( $metadata['supports']['color']['__experimentalDuotone'] );
+		$duotone_support = $metadata['supports']['color']['__experimentalDuotone'] ?? null;
 
-		if ( ! isset( $settings['supports']['filter']['duotone'] ) && $duotone_support ) {
-			_wp_array_set( $settings, array( 'supports', 'filter', 'duotone' ), $duotone_support );
+		if ( ! isset( $settings['supports']['filter']['duotone'] ) && null !== $duotone_support ) {
+			_wp_array_set( $settings, array( 'supports', 'filter', 'duotone' ), (bool) $duotone_support );
 		}
 
 		return $settings;

--- a/lib/class-wp-duotone-gutenberg.php
+++ b/lib/class-wp-duotone-gutenberg.php
@@ -655,14 +655,14 @@ class WP_Duotone_Gutenberg {
 			// `supports.filter.duotone` has not been set and the experimental
 			// property has been, the experimental property value is copied into
 			// `supports.filter.duotone`.
-			$duotone_support = isset( $block_type->supports['filter']['duotone'] ) ? $block_type->supports['filter']['duotone'] : false;
+			$duotone_support = $block_type->supports['filter']['duotone'] ?? false;
 			if ( ! $duotone_support ) {
 				return null;
 			}
 
 			// If the experimental duotone support was set, that value is to be
 			// treated as a selector and requires scoping.
-			$experimental_duotone = isset( $block_type->supports['color']['__experimentalDuotone'] ) ? $block_type->supports['color']['__experimentalDuotone'] : false;
+			$experimental_duotone = $block_type->supports['color']['__experimentalDuotone'] ?? false;
 			if ( $experimental_duotone ) {
 				$root_selector = wp_get_block_css_selector( $block_type );
 				return is_string( $experimental_duotone )
@@ -750,7 +750,7 @@ class WP_Duotone_Gutenberg {
 		if ( property_exists( $block_type, 'supports' ) ) {
 			// Previous `color.__experimentalDuotone` support flag is migrated
 			// to `filter.duotone` via `block_type_metadata_settings` filter.
-			$has_duotone_support = isset( $block_type->supports['filter']['duotone'] ) ? $block_type->supports['filter']['duotone'] : null;
+			$has_duotone_support = $block_type->supports['filter']['duotone'] ?? null;
 		}
 
 		if ( $has_duotone_support ) {
@@ -775,7 +775,7 @@ class WP_Duotone_Gutenberg {
 	public static function set_global_styles_presets() {
 		// Get the per block settings from the theme.json.
 		$tree              = gutenberg_get_global_settings();
-		$presets_by_origin = isset( $tree['color']['duotone'] ) ? $tree['color']['duotone'] : array();
+		$presets_by_origin = $tree['color']['duotone'] ?? array();
 
 		foreach ( $presets_by_origin as $presets ) {
 			foreach ( $presets as $preset ) {
@@ -995,7 +995,7 @@ class WP_Duotone_Gutenberg {
 	 * @return array Filtered block type settings.
 	 */
 	public static function migrate_experimental_duotone_support_flag( $settings, $metadata ) {
-		$duotone_support = isset( $metadata['supports']['color']['__experimentalDuotone'] ) ? $metadata['supports']['color']['__experimentalDuotone'] : null;
+		$duotone_support = $metadata['supports']['color']['__experimentalDuotone'] ?? null;
 
 		if ( ! isset( $settings['supports']['filter']['duotone'] ) && null !== $duotone_support ) {
 			_wp_array_set( $settings, array( 'supports', 'filter', 'duotone' ), (bool) $duotone_support );

--- a/lib/class-wp-duotone-gutenberg.php
+++ b/lib/class-wp-duotone-gutenberg.php
@@ -655,14 +655,14 @@ class WP_Duotone_Gutenberg {
 			// `supports.filter.duotone` has not been set and the experimental
 			// property has been, the experimental property value is copied into
 			// `supports.filter.duotone`.
-			$duotone_support = $block_type->supports['filter']['duotone'] ?? false;
+			$duotone_support = isset( $block_type->supports['filter']['duotone'] ) ? $block_type->supports['filter']['duotone'] : false;
 			if ( ! $duotone_support ) {
 				return null;
 			}
 
 			// If the experimental duotone support was set, that value is to be
 			// treated as a selector and requires scoping.
-			$experimental_duotone = $block_type->supports['color']['__experimentalDuotone'] ?? false;
+			$experimental_duotone = isset( $block_type->supports['color']['__experimentalDuotone'] ) ? $block_type->supports['color']['__experimentalDuotone'] : false;
 			if ( $experimental_duotone ) {
 				$root_selector = wp_get_block_css_selector( $block_type );
 				return is_string( $experimental_duotone )
@@ -750,7 +750,7 @@ class WP_Duotone_Gutenberg {
 		if ( property_exists( $block_type, 'supports' ) ) {
 			// Previous `color.__experimentalDuotone` support flag is migrated
 			// to `filter.duotone` via `block_type_metadata_settings` filter.
-			$has_duotone_support = $block_type->supports['filter']['duotone'] ?? null;
+			$has_duotone_support = isset( $block_type->supports['filter']['duotone'] ) ? $block_type->supports['filter']['duotone'] : null;
 		}
 
 		if ( $has_duotone_support ) {
@@ -775,7 +775,7 @@ class WP_Duotone_Gutenberg {
 	public static function set_global_styles_presets() {
 		// Get the per block settings from the theme.json.
 		$tree              = gutenberg_get_global_settings();
-		$presets_by_origin = $tree['color']['duotone'] ?? array();
+		$presets_by_origin = isset( $tree['color']['duotone'] ) ? $tree['color']['duotone'] : array();
 
 		foreach ( $presets_by_origin as $presets ) {
 			foreach ( $presets as $preset ) {
@@ -995,7 +995,7 @@ class WP_Duotone_Gutenberg {
 	 * @return array Filtered block type settings.
 	 */
 	public static function migrate_experimental_duotone_support_flag( $settings, $metadata ) {
-		$duotone_support = $metadata['supports']['color']['__experimentalDuotone'] ?? null;
+		$duotone_support = isset( $metadata['supports']['color']['__experimentalDuotone'] ) ? $metadata['supports']['color']['__experimentalDuotone'] : null;
 
 		if ( ! isset( $settings['supports']['filter']['duotone'] ) && null !== $duotone_support ) {
 			_wp_array_set( $settings, array( 'supports', 'filter', 'duotone' ), (bool) $duotone_support );

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -928,11 +928,14 @@ class WP_Theme_JSON_Gutenberg {
 
 			// Keep backwards compatibility for support.color.__experimentalDuotone.
 			if ( null === $duotone_selector ) {
-				$duotone_support = _wp_array_get( $block_type->supports, array( 'color', '__experimentalDuotone' ), null );
+				$duotone_support = isset( $block_type->supports['color']['__experimentalDuotone'] );
 
 				if ( $duotone_support ) {
 					$root_selector    = wp_get_block_css_selector( $block_type );
-					$duotone_selector = WP_Theme_JSON_Gutenberg::scope_selector( $root_selector, $duotone_support );
+					$duotone_selector = WP_Theme_JSON_Gutenberg::scope_selector(
+						$root_selector,
+						_wp_array_get( $block_type->supports, array( 'color', '__experimentalDuotone' ), null )
+					);
 				}
 			}
 
@@ -1161,12 +1164,17 @@ class WP_Theme_JSON_Gutenberg {
 	 */
 	public function get_custom_css() {
 		// Add the global styles root CSS.
-		$stylesheet = _wp_array_get( $this->theme_json, array( 'styles', 'css' ), '' );
+		$stylesheet = isset( $this->theme_json['styles']['css'] )
+			? _wp_array_get( $this->theme_json, array( 'styles', 'css' ), '' )
+			: '';
 
 		// Add the global styles block CSS.
 		if ( isset( $this->theme_json['styles']['blocks'] ) ) {
 			foreach ( $this->theme_json['styles']['blocks'] as $name => $node ) {
-				$custom_block_css = _wp_array_get( $this->theme_json, array( 'styles', 'blocks', $name, 'css' ) );
+				$custom_block_css = isset( $this->theme_json['styles']['blocks'][ $name ]['css'] )
+					? _wp_array_get( $this->theme_json, array( 'styles', 'blocks', $name, 'css' ) )
+					: '';
+
 				if ( $custom_block_css ) {
 					$selector    = static::$blocks_metadata[ $name ]['selector'];
 					$stylesheet .= $this->process_blocks_custom_css( $custom_block_css, $selector );
@@ -1284,7 +1292,7 @@ class WP_Theme_JSON_Gutenberg {
 		}
 
 		$selector                 = isset( $block_metadata['selector'] ) ? $block_metadata['selector'] : '';
-		$has_block_gap_support    = _wp_array_get( $this->theme_json, array( 'settings', 'spacing', 'blockGap' ) ) !== null;
+		$has_block_gap_support    = isset( $this->theme_json['settings']['spacing']['blockGap'] );
 		$has_fallback_gap_support = ! $has_block_gap_support; // This setting isn't useful yet: it exists as a placeholder for a future explicit fallback gap styles support.
 		$node                     = _wp_array_get( $this->theme_json, $block_metadata['path'], array() );
 		$layout_definitions       = gutenberg_get_layout_definitions();
@@ -1297,7 +1305,9 @@ class WP_Theme_JSON_Gutenberg {
 			// Use a fallback gap value if block gap support is not available.
 			if ( ! $has_block_gap_support ) {
 				$block_gap_value = static::ROOT_BLOCK_SELECTOR === $selector ? '0.5em' : null;
-				if ( ! empty( $block_type ) ) {
+				if ( ! empty( $block_type )
+					&& isset( $block_type->supports['spacing']['blockGap']['__experimentalDefault'] )
+				) {
 					$block_gap_value = _wp_array_get( $block_type->supports, array( 'spacing', 'blockGap', '__experimentalDefault' ), null );
 				}
 			} else {
@@ -1814,7 +1824,9 @@ class WP_Theme_JSON_Gutenberg {
 	 */
 	protected static function compute_theme_vars( $settings ) {
 		$declarations  = array();
-		$custom_values = _wp_array_get( $settings, array( 'custom' ), array() );
+		$custom_values = isset( $settings['custom'] )
+			? _wp_array_get( $settings, array( 'custom' ), array() )
+			: array();
 		$css_vars      = static::flatten_tree( $custom_values );
 		foreach ( $css_vars as $key => $value ) {
 			$declarations[] = array(
@@ -2326,7 +2338,9 @@ class WP_Theme_JSON_Gutenberg {
 		$node             = _wp_array_get( $this->theme_json, $block_metadata['path'], array() );
 		$use_root_padding = isset( $this->theme_json['settings']['useRootPaddingAwareAlignments'] ) && true === $this->theme_json['settings']['useRootPaddingAwareAlignments'];
 		$selector         = $block_metadata['selector'];
-		$settings         = _wp_array_get( $this->theme_json, array( 'settings' ) );
+		$settings         = isset( $this->theme_json['settings'] )
+			? _wp_array_get( $this->theme_json, array( 'settings' ) )
+			: array();
 
 		$feature_declarations = static::get_feature_declarations_for_node( $block_metadata, $node );
 
@@ -2479,7 +2493,7 @@ class WP_Theme_JSON_Gutenberg {
 	 */
 	public function get_root_layout_rules( $selector, $block_metadata ) {
 		$css              = '';
-		$settings         = _wp_array_get( $this->theme_json, array( 'settings' ) );
+		$settings         = isset( $this->theme_json['settings'] ) ? _wp_array_get( $this->theme_json, array( 'settings' ) ) : array();
 		$use_root_padding = isset( $this->theme_json['settings']['useRootPaddingAwareAlignments'] ) && true === $this->theme_json['settings']['useRootPaddingAwareAlignments'];
 
 		/*
@@ -2528,9 +2542,10 @@ class WP_Theme_JSON_Gutenberg {
 		$css .= '.wp-site-blocks > .alignright { float: right; margin-left: 2em; }';
 		$css .= '.wp-site-blocks > .aligncenter { justify-content: center; margin-left: auto; margin-right: auto; }';
 
-		$block_gap_value       = _wp_array_get( $this->theme_json, array( 'styles', 'spacing', 'blockGap' ), '0.5em' );
-		$has_block_gap_support = _wp_array_get( $this->theme_json, array( 'settings', 'spacing', 'blockGap' ) ) !== null;
-		if ( $has_block_gap_support ) {
+		$block_gap_value = isset( $this->theme_json['styles']['spacing']['blockGap'] )
+			? _wp_array_get( $this->theme_json, array( 'styles', 'spacing', 'blockGap' ), '0.5em' )
+			: '0.5em';
+		if ( isset( $this->theme_json['settings']['spacing']['blockGap'] ) ) {
 			$block_gap_value = static::get_property_value( $this->theme_json, array( 'styles', 'spacing', 'blockGap' ) );
 			$css            .= ":where(.wp-site-blocks) > * { margin-block-start: $block_gap_value; margin-block-end: 0; }";
 			$css            .= ':where(.wp-site-blocks) > :first-child:first-child { margin-block-start: 0; }';
@@ -3360,7 +3375,9 @@ class WP_Theme_JSON_Gutenberg {
 	 * @return null|void
 	 */
 	public function set_spacing_sizes() {
-		$spacing_scale = _wp_array_get( $this->theme_json, array( 'settings', 'spacing', 'spacingScale' ), array() );
+		$spacing_scale = isset( $this->theme_json['settings']['spacing']['spacingScale'] )
+			? _wp_array_get( $this->theme_json, array( 'settings', 'spacing', 'spacingScale' ), array() )
+			: array();
 
 		// Gutenberg didn't have the 1st isset check.
 		if ( ! isset( $spacing_scale['steps'] )
@@ -3546,7 +3563,9 @@ class WP_Theme_JSON_Gutenberg {
 			return $declarations;
 		}
 
-		$settings = _wp_array_get( $this->theme_json, array( 'settings' ) );
+		$settings = isset( $this->theme_json['settings'] )
+			? _wp_array_get( $this->theme_json, array( 'settings' ) )
+			: array();
 
 		foreach ( $metadata['selectors'] as $feature => $feature_selectors ) {
 			// Skip if this is the block's root selector or the block doesn't

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -934,7 +934,7 @@ class WP_Theme_JSON_Gutenberg {
 					$root_selector    = wp_get_block_css_selector( $block_type );
 					$duotone_selector = WP_Theme_JSON_Gutenberg::scope_selector(
 						$root_selector,
-						_wp_array_get( $block_type->supports, array( 'color', '__experimentalDuotone' ), null )
+						$block_type->supports['color']['__experimentalDuotone']
 					);
 				}
 			}
@@ -1164,15 +1164,13 @@ class WP_Theme_JSON_Gutenberg {
 	 */
 	public function get_custom_css() {
 		// Add the global styles root CSS.
-		$stylesheet = isset( $this->theme_json['styles']['css'] )
-			? _wp_array_get( $this->theme_json, array( 'styles', 'css' ), '' )
-			: '';
+		$stylesheet = isset( $this->theme_json['styles']['css'] ) ? $this->theme_json['styles']['css'] : '';
 
 		// Add the global styles block CSS.
 		if ( isset( $this->theme_json['styles']['blocks'] ) ) {
 			foreach ( $this->theme_json['styles']['blocks'] as $name => $node ) {
 				$custom_block_css = isset( $this->theme_json['styles']['blocks'][ $name ]['css'] )
-					? _wp_array_get( $this->theme_json, array( 'styles', 'blocks', $name, 'css' ) )
+					? $this->theme_json['styles']['blocks'][ $name ]['css']
 					: '';
 
 				if ( $custom_block_css ) {
@@ -1308,7 +1306,7 @@ class WP_Theme_JSON_Gutenberg {
 				if ( ! empty( $block_type )
 					&& isset( $block_type->supports['spacing']['blockGap']['__experimentalDefault'] )
 				) {
-					$block_gap_value = _wp_array_get( $block_type->supports, array( 'spacing', 'blockGap', '__experimentalDefault' ), null );
+					$block_gap_value = $block_type->supports['spacing']['blockGap']['__experimentalDefault'];
 				}
 			} else {
 				$block_gap_value = static::get_property_value( $node, array( 'spacing', 'blockGap' ) );
@@ -1824,9 +1822,7 @@ class WP_Theme_JSON_Gutenberg {
 	 */
 	protected static function compute_theme_vars( $settings ) {
 		$declarations  = array();
-		$custom_values = isset( $settings['custom'] )
-			? _wp_array_get( $settings, array( 'custom' ), array() )
-			: array();
+		$custom_values = isset( $settings['custom'] ) ? $settings['custom'] : array();
 		$css_vars      = static::flatten_tree( $custom_values );
 		foreach ( $css_vars as $key => $value ) {
 			$declarations[] = array(
@@ -2338,9 +2334,7 @@ class WP_Theme_JSON_Gutenberg {
 		$node             = _wp_array_get( $this->theme_json, $block_metadata['path'], array() );
 		$use_root_padding = isset( $this->theme_json['settings']['useRootPaddingAwareAlignments'] ) && true === $this->theme_json['settings']['useRootPaddingAwareAlignments'];
 		$selector         = $block_metadata['selector'];
-		$settings         = isset( $this->theme_json['settings'] )
-			? _wp_array_get( $this->theme_json, array( 'settings' ) )
-			: array();
+		$settings         = isset( $this->theme_json['settings'] ) ? $this->theme_json['settings'] : array();
 
 		$feature_declarations = static::get_feature_declarations_for_node( $block_metadata, $node );
 
@@ -2493,7 +2487,7 @@ class WP_Theme_JSON_Gutenberg {
 	 */
 	public function get_root_layout_rules( $selector, $block_metadata ) {
 		$css              = '';
-		$settings         = isset( $this->theme_json['settings'] ) ? _wp_array_get( $this->theme_json, array( 'settings' ) ) : array();
+		$settings         = isset( $this->theme_json['settings'] ) ? $this->theme_json['settings'] : array();
 		$use_root_padding = isset( $this->theme_json['settings']['useRootPaddingAwareAlignments'] ) && true === $this->theme_json['settings']['useRootPaddingAwareAlignments'];
 
 		/*
@@ -2543,7 +2537,7 @@ class WP_Theme_JSON_Gutenberg {
 		$css .= '.wp-site-blocks > .aligncenter { justify-content: center; margin-left: auto; margin-right: auto; }';
 
 		$block_gap_value = isset( $this->theme_json['styles']['spacing']['blockGap'] )
-			? _wp_array_get( $this->theme_json, array( 'styles', 'spacing', 'blockGap' ), '0.5em' )
+			? $this->theme_json['styles']['spacing']['blockGap']
 			: '0.5em';
 		if ( isset( $this->theme_json['settings']['spacing']['blockGap'] ) ) {
 			$block_gap_value = static::get_property_value( $this->theme_json, array( 'styles', 'spacing', 'blockGap' ) );
@@ -3376,7 +3370,7 @@ class WP_Theme_JSON_Gutenberg {
 	 */
 	public function set_spacing_sizes() {
 		$spacing_scale = isset( $this->theme_json['settings']['spacing']['spacingScale'] )
-			? _wp_array_get( $this->theme_json, array( 'settings', 'spacing', 'spacingScale' ), array() )
+			? $this->theme_json['settings']['spacing']['spacingScale']
 			: array();
 
 		// Gutenberg didn't have the 1st isset check.
@@ -3563,9 +3557,7 @@ class WP_Theme_JSON_Gutenberg {
 			return $declarations;
 		}
 
-		$settings = isset( $this->theme_json['settings'] )
-			? _wp_array_get( $this->theme_json, array( 'settings' ) )
-			: array();
+		$settings = isset( $this->theme_json['settings'] ) ? $this->theme_json['settings'] : array();
 
 		foreach ( $metadata['selectors'] as $feature => $feature_selectors ) {
 			// Skip if this is the block's root selector or the block doesn't

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -928,7 +928,7 @@ class WP_Theme_JSON_Gutenberg {
 
 			// Keep backwards compatibility for support.color.__experimentalDuotone.
 			if ( null === $duotone_selector ) {
-				$duotone_support = isset( $block_type->supports['color']['__experimentalDuotone'] ) ? $block_type->supports['color']['__experimentalDuotone'] : null;
+				$duotone_support = $block_type->supports['color']['__experimentalDuotone'] ?? null;
 
 				if ( $duotone_support ) {
 					$root_selector    = wp_get_block_css_selector( $block_type );
@@ -1161,12 +1161,12 @@ class WP_Theme_JSON_Gutenberg {
 	 */
 	public function get_custom_css() {
 		// Add the global styles root CSS.
-		$stylesheet = isset( $this->theme_json['styles']['css'] ) ? $this->theme_json['styles']['css'] : '';
+		$stylesheet = $this->theme_json['styles']['css'] ?? '';
 
 		// Add the global styles block CSS.
 		if ( isset( $this->theme_json['styles']['blocks'] ) ) {
 			foreach ( $this->theme_json['styles']['blocks'] as $name => $node ) {
-				$custom_block_css = isset( $this->theme_json['styles']['blocks'][ $name ]['css'] ) ? $this->theme_json['styles']['blocks'][ $name ]['css'] : null;
+				$custom_block_css = $this->theme_json['styles']['blocks'][ $name ]['css'] ?? null;
 				if ( $custom_block_css ) {
 					$selector    = static::$blocks_metadata[ $name ]['selector'];
 					$stylesheet .= $this->process_blocks_custom_css( $custom_block_css, $selector );
@@ -1298,7 +1298,7 @@ class WP_Theme_JSON_Gutenberg {
 			if ( ! $has_block_gap_support ) {
 				$block_gap_value = static::ROOT_BLOCK_SELECTOR === $selector ? '0.5em' : null;
 				if ( ! empty( $block_type ) ) {
-					$block_gap_value = isset( $block_type->supports['spacing']['blockGap']['__experimentalDefault'] ) ? $block_type->supports['spacing']['blockGap']['__experimentalDefault'] : null;
+					$block_gap_value = $block_type->supports['spacing']['blockGap']['__experimentalDefault'] ?? null;
 				}
 			} else {
 				$block_gap_value = static::get_property_value( $node, array( 'spacing', 'blockGap' ) );
@@ -1324,8 +1324,8 @@ class WP_Theme_JSON_Gutenberg {
 						continue;
 					}
 
-					$class_name    = isset( $layout_definition['className'] ) ? $layout_definition['className'] : false;
-					$spacing_rules = isset( $layout_definition['spacingStyles'] ) ? $layout_definition['spacingStyles'] : array();
+					$class_name    = $layout_definition['className'] ?? false;
+					$spacing_rules = $layout_definition['spacingStyles'] ?? array();
 
 					if (
 						! empty( $class_name ) &&
@@ -1381,8 +1381,8 @@ class WP_Theme_JSON_Gutenberg {
 		) {
 			$valid_display_modes = array( 'block', 'flex', 'grid' );
 			foreach ( $layout_definitions as $layout_definition ) {
-				$class_name       = isset( $layout_definition['className'] ) ? $layout_definition['className'] : false;
-				$base_style_rules = isset( $layout_definition['baseStyles'] ) ? $layout_definition['baseStyles'] : array();
+				$class_name       = $layout_definition['className'] ?? false;
+				$base_style_rules = $layout_definition['baseStyles'] ?? array();
 
 				if (
 					! empty( $class_name ) &&
@@ -1814,7 +1814,7 @@ class WP_Theme_JSON_Gutenberg {
 	 */
 	protected static function compute_theme_vars( $settings ) {
 		$declarations  = array();
-		$custom_values = isset( $settings['custom'] ) ? $settings['custom'] : array();
+		$custom_values = $settings['custom'] ?? array();
 		$css_vars      = static::flatten_tree( $custom_values );
 		foreach ( $css_vars as $key => $value ) {
 			$declarations[] = array(
@@ -2326,7 +2326,7 @@ class WP_Theme_JSON_Gutenberg {
 		$node             = _wp_array_get( $this->theme_json, $block_metadata['path'], array() );
 		$use_root_padding = isset( $this->theme_json['settings']['useRootPaddingAwareAlignments'] ) && true === $this->theme_json['settings']['useRootPaddingAwareAlignments'];
 		$selector         = $block_metadata['selector'];
-		$settings         = isset( $this->theme_json['settings'] ) ? $this->theme_json['settings'] : null;
+		$settings         = $this->theme_json['settings'] ?? null;
 
 		$feature_declarations = static::get_feature_declarations_for_node( $block_metadata, $node );
 
@@ -2479,7 +2479,7 @@ class WP_Theme_JSON_Gutenberg {
 	 */
 	public function get_root_layout_rules( $selector, $block_metadata ) {
 		$css              = '';
-		$settings         = isset( $this->theme_json['settings'] ) ? $this->theme_json['settings'] : array();
+		$settings         = $this->theme_json['settings'] ?? array();
 		$use_root_padding = isset( $this->theme_json['settings']['useRootPaddingAwareAlignments'] ) && true === $this->theme_json['settings']['useRootPaddingAwareAlignments'];
 
 		/*
@@ -2528,7 +2528,7 @@ class WP_Theme_JSON_Gutenberg {
 		$css .= '.wp-site-blocks > .alignright { float: right; margin-left: 2em; }';
 		$css .= '.wp-site-blocks > .aligncenter { justify-content: center; margin-left: auto; margin-right: auto; }';
 
-		$block_gap_value       = isset( $this->theme_json['styles']['spacing']['blockGap'] ) ? $this->theme_json['styles']['spacing']['blockGap'] : '0.5em';
+		$block_gap_value       = $this->theme_json['styles']['spacing']['blockGap'] ?? '0.5em';
 		$has_block_gap_support = isset( $this->theme_json['settings']['spacing']['blockGap'] );
 		if ( $has_block_gap_support ) {
 			$block_gap_value = static::get_property_value( $this->theme_json, array( 'styles', 'spacing', 'blockGap' ) );
@@ -3360,7 +3360,7 @@ class WP_Theme_JSON_Gutenberg {
 	 * @return null|void
 	 */
 	public function set_spacing_sizes() {
-		$spacing_scale = isset( $this->theme_json['settings']['spacing']['spacingScale'] ) ? $this->theme_json['settings']['spacing']['spacingScale'] : array();
+		$spacing_scale = $this->theme_json['settings']['spacing']['spacingScale'] ?? array();
 
 		// Gutenberg didn't have the 1st isset check.
 		if ( ! isset( $spacing_scale['steps'] )
@@ -3546,7 +3546,7 @@ class WP_Theme_JSON_Gutenberg {
 			return $declarations;
 		}
 
-		$settings = isset( $this->theme_json['settings'] ) ? $this->theme_json['settings'] : null;
+		$settings = $this->theme_json['settings'] ?? null;
 
 		foreach ( $metadata['selectors'] as $feature => $feature_selectors ) {
 			// Skip if this is the block's root selector or the block doesn't

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -928,14 +928,11 @@ class WP_Theme_JSON_Gutenberg {
 
 			// Keep backwards compatibility for support.color.__experimentalDuotone.
 			if ( null === $duotone_selector ) {
-				$duotone_support = isset( $block_type->supports['color']['__experimentalDuotone'] );
+				$duotone_support = $block_type->supports['color']['__experimentalDuotone'] ?? null;
 
 				if ( $duotone_support ) {
 					$root_selector    = wp_get_block_css_selector( $block_type );
-					$duotone_selector = WP_Theme_JSON_Gutenberg::scope_selector(
-						$root_selector,
-						$block_type->supports['color']['__experimentalDuotone']
-					);
+					$duotone_selector = WP_Theme_JSON_Gutenberg::scope_selector( $root_selector, $duotone_support );
 				}
 			}
 
@@ -1164,15 +1161,12 @@ class WP_Theme_JSON_Gutenberg {
 	 */
 	public function get_custom_css() {
 		// Add the global styles root CSS.
-		$stylesheet = isset( $this->theme_json['styles']['css'] ) ? $this->theme_json['styles']['css'] : '';
+		$stylesheet = $this->theme_json['styles']['css'] ?? '';
 
 		// Add the global styles block CSS.
 		if ( isset( $this->theme_json['styles']['blocks'] ) ) {
 			foreach ( $this->theme_json['styles']['blocks'] as $name => $node ) {
-				$custom_block_css = isset( $this->theme_json['styles']['blocks'][ $name ]['css'] )
-					? $this->theme_json['styles']['blocks'][ $name ]['css']
-					: '';
-
+				$custom_block_css = $this->theme_json['styles']['blocks'][ $name ]['css'] ?? null;
 				if ( $custom_block_css ) {
 					$selector    = static::$blocks_metadata[ $name ]['selector'];
 					$stylesheet .= $this->process_blocks_custom_css( $custom_block_css, $selector );
@@ -1303,10 +1297,8 @@ class WP_Theme_JSON_Gutenberg {
 			// Use a fallback gap value if block gap support is not available.
 			if ( ! $has_block_gap_support ) {
 				$block_gap_value = static::ROOT_BLOCK_SELECTOR === $selector ? '0.5em' : null;
-				if ( ! empty( $block_type )
-					&& isset( $block_type->supports['spacing']['blockGap']['__experimentalDefault'] )
-				) {
-					$block_gap_value = $block_type->supports['spacing']['blockGap']['__experimentalDefault'];
+				if ( ! empty( $block_type ) ) {
+					$block_gap_value = $block_type->supports['spacing']['blockGap']['__experimentalDefault'] ?? null;
 				}
 			} else {
 				$block_gap_value = static::get_property_value( $node, array( 'spacing', 'blockGap' ) );
@@ -1332,8 +1324,8 @@ class WP_Theme_JSON_Gutenberg {
 						continue;
 					}
 
-					$class_name    = _wp_array_get( $layout_definition, array( 'className' ), false );
-					$spacing_rules = _wp_array_get( $layout_definition, array( 'spacingStyles' ), array() );
+					$class_name    = $layout_definition['className'] ?? false;
+					$spacing_rules = $layout_definition['spacingStyles'] ?? array();
 
 					if (
 						! empty( $class_name ) &&
@@ -1389,8 +1381,8 @@ class WP_Theme_JSON_Gutenberg {
 		) {
 			$valid_display_modes = array( 'block', 'flex', 'grid' );
 			foreach ( $layout_definitions as $layout_definition ) {
-				$class_name       = _wp_array_get( $layout_definition, array( 'className' ), false );
-				$base_style_rules = _wp_array_get( $layout_definition, array( 'baseStyles' ), array() );
+				$class_name       = $layout_definition['className'] ?? false;
+				$base_style_rules = $layout_definition['baseStyles'] ?? array();
 
 				if (
 					! empty( $class_name ) &&
@@ -1822,7 +1814,7 @@ class WP_Theme_JSON_Gutenberg {
 	 */
 	protected static function compute_theme_vars( $settings ) {
 		$declarations  = array();
-		$custom_values = isset( $settings['custom'] ) ? $settings['custom'] : array();
+		$custom_values = $settings['custom'] ?? array();
 		$css_vars      = static::flatten_tree( $custom_values );
 		foreach ( $css_vars as $key => $value ) {
 			$declarations[] = array(
@@ -2334,7 +2326,7 @@ class WP_Theme_JSON_Gutenberg {
 		$node             = _wp_array_get( $this->theme_json, $block_metadata['path'], array() );
 		$use_root_padding = isset( $this->theme_json['settings']['useRootPaddingAwareAlignments'] ) && true === $this->theme_json['settings']['useRootPaddingAwareAlignments'];
 		$selector         = $block_metadata['selector'];
-		$settings         = isset( $this->theme_json['settings'] ) ? $this->theme_json['settings'] : array();
+		$settings         = $this->theme_json['settings'] ?? null;
 
 		$feature_declarations = static::get_feature_declarations_for_node( $block_metadata, $node );
 
@@ -2487,7 +2479,7 @@ class WP_Theme_JSON_Gutenberg {
 	 */
 	public function get_root_layout_rules( $selector, $block_metadata ) {
 		$css              = '';
-		$settings         = isset( $this->theme_json['settings'] ) ? $this->theme_json['settings'] : array();
+		$settings         = $this->theme_json['settings'] ?? array();
 		$use_root_padding = isset( $this->theme_json['settings']['useRootPaddingAwareAlignments'] ) && true === $this->theme_json['settings']['useRootPaddingAwareAlignments'];
 
 		/*
@@ -2536,10 +2528,9 @@ class WP_Theme_JSON_Gutenberg {
 		$css .= '.wp-site-blocks > .alignright { float: right; margin-left: 2em; }';
 		$css .= '.wp-site-blocks > .aligncenter { justify-content: center; margin-left: auto; margin-right: auto; }';
 
-		$block_gap_value = isset( $this->theme_json['styles']['spacing']['blockGap'] )
-			? $this->theme_json['styles']['spacing']['blockGap']
-			: '0.5em';
-		if ( isset( $this->theme_json['settings']['spacing']['blockGap'] ) ) {
+		$block_gap_value       = $this->theme_json['styles']['spacing']['blockGap'] ?? '0.5em';
+		$has_block_gap_support = isset( $this->theme_json['settings']['spacing']['blockGap'] );
+		if ( $has_block_gap_support ) {
 			$block_gap_value = static::get_property_value( $this->theme_json, array( 'styles', 'spacing', 'blockGap' ) );
 			$css            .= ":where(.wp-site-blocks) > * { margin-block-start: $block_gap_value; margin-block-end: 0; }";
 			$css            .= ':where(.wp-site-blocks) > :first-child:first-child { margin-block-start: 0; }';
@@ -3369,9 +3360,7 @@ class WP_Theme_JSON_Gutenberg {
 	 * @return null|void
 	 */
 	public function set_spacing_sizes() {
-		$spacing_scale = isset( $this->theme_json['settings']['spacing']['spacingScale'] )
-			? $this->theme_json['settings']['spacing']['spacingScale']
-			: array();
+		$spacing_scale = $this->theme_json['settings']['spacing']['spacingScale'] ?? array();
 
 		// Gutenberg didn't have the 1st isset check.
 		if ( ! isset( $spacing_scale['steps'] )
@@ -3557,7 +3546,7 @@ class WP_Theme_JSON_Gutenberg {
 			return $declarations;
 		}
 
-		$settings = isset( $this->theme_json['settings'] ) ? $this->theme_json['settings'] : array();
+		$settings = $this->theme_json['settings'] ?? null;
 
 		foreach ( $metadata['selectors'] as $feature => $feature_selectors ) {
 			// Skip if this is the block's root selector or the block doesn't

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -928,7 +928,7 @@ class WP_Theme_JSON_Gutenberg {
 
 			// Keep backwards compatibility for support.color.__experimentalDuotone.
 			if ( null === $duotone_selector ) {
-				$duotone_support = $block_type->supports['color']['__experimentalDuotone'] ?? null;
+				$duotone_support = isset( $block_type->supports['color']['__experimentalDuotone'] ) ? $block_type->supports['color']['__experimentalDuotone'] : null;
 
 				if ( $duotone_support ) {
 					$root_selector    = wp_get_block_css_selector( $block_type );
@@ -1161,12 +1161,12 @@ class WP_Theme_JSON_Gutenberg {
 	 */
 	public function get_custom_css() {
 		// Add the global styles root CSS.
-		$stylesheet = $this->theme_json['styles']['css'] ?? '';
+		$stylesheet = isset( $this->theme_json['styles']['css'] ) ? $this->theme_json['styles']['css'] : '';
 
 		// Add the global styles block CSS.
 		if ( isset( $this->theme_json['styles']['blocks'] ) ) {
 			foreach ( $this->theme_json['styles']['blocks'] as $name => $node ) {
-				$custom_block_css = $this->theme_json['styles']['blocks'][ $name ]['css'] ?? null;
+				$custom_block_css = isset( $this->theme_json['styles']['blocks'][ $name ]['css'] ) ? $this->theme_json['styles']['blocks'][ $name ]['css'] : null;
 				if ( $custom_block_css ) {
 					$selector    = static::$blocks_metadata[ $name ]['selector'];
 					$stylesheet .= $this->process_blocks_custom_css( $custom_block_css, $selector );
@@ -1298,7 +1298,7 @@ class WP_Theme_JSON_Gutenberg {
 			if ( ! $has_block_gap_support ) {
 				$block_gap_value = static::ROOT_BLOCK_SELECTOR === $selector ? '0.5em' : null;
 				if ( ! empty( $block_type ) ) {
-					$block_gap_value = $block_type->supports['spacing']['blockGap']['__experimentalDefault'] ?? null;
+					$block_gap_value = isset( $block_type->supports['spacing']['blockGap']['__experimentalDefault'] ) ? $block_type->supports['spacing']['blockGap']['__experimentalDefault'] : null;
 				}
 			} else {
 				$block_gap_value = static::get_property_value( $node, array( 'spacing', 'blockGap' ) );
@@ -1324,8 +1324,8 @@ class WP_Theme_JSON_Gutenberg {
 						continue;
 					}
 
-					$class_name    = $layout_definition['className'] ?? false;
-					$spacing_rules = $layout_definition['spacingStyles'] ?? array();
+					$class_name    = isset( $layout_definition['className'] ) ? $layout_definition['className'] : false;
+					$spacing_rules = isset( $layout_definition['spacingStyles'] ) ? $layout_definition['spacingStyles'] : array();
 
 					if (
 						! empty( $class_name ) &&
@@ -1381,8 +1381,8 @@ class WP_Theme_JSON_Gutenberg {
 		) {
 			$valid_display_modes = array( 'block', 'flex', 'grid' );
 			foreach ( $layout_definitions as $layout_definition ) {
-				$class_name       = $layout_definition['className'] ?? false;
-				$base_style_rules = $layout_definition['baseStyles'] ?? array();
+				$class_name       = isset( $layout_definition['className'] ) ? $layout_definition['className'] : false;
+				$base_style_rules = isset( $layout_definition['baseStyles'] ) ? $layout_definition['baseStyles'] : array();
 
 				if (
 					! empty( $class_name ) &&
@@ -1814,7 +1814,7 @@ class WP_Theme_JSON_Gutenberg {
 	 */
 	protected static function compute_theme_vars( $settings ) {
 		$declarations  = array();
-		$custom_values = $settings['custom'] ?? array();
+		$custom_values = isset( $settings['custom'] ) ? $settings['custom'] : array();
 		$css_vars      = static::flatten_tree( $custom_values );
 		foreach ( $css_vars as $key => $value ) {
 			$declarations[] = array(
@@ -2326,7 +2326,7 @@ class WP_Theme_JSON_Gutenberg {
 		$node             = _wp_array_get( $this->theme_json, $block_metadata['path'], array() );
 		$use_root_padding = isset( $this->theme_json['settings']['useRootPaddingAwareAlignments'] ) && true === $this->theme_json['settings']['useRootPaddingAwareAlignments'];
 		$selector         = $block_metadata['selector'];
-		$settings         = $this->theme_json['settings'] ?? null;
+		$settings         = isset( $this->theme_json['settings'] ) ? $this->theme_json['settings'] : null;
 
 		$feature_declarations = static::get_feature_declarations_for_node( $block_metadata, $node );
 
@@ -2479,7 +2479,7 @@ class WP_Theme_JSON_Gutenberg {
 	 */
 	public function get_root_layout_rules( $selector, $block_metadata ) {
 		$css              = '';
-		$settings         = $this->theme_json['settings'] ?? array();
+		$settings         = isset( $this->theme_json['settings'] ) ? $this->theme_json['settings'] : array();
 		$use_root_padding = isset( $this->theme_json['settings']['useRootPaddingAwareAlignments'] ) && true === $this->theme_json['settings']['useRootPaddingAwareAlignments'];
 
 		/*
@@ -2528,7 +2528,7 @@ class WP_Theme_JSON_Gutenberg {
 		$css .= '.wp-site-blocks > .alignright { float: right; margin-left: 2em; }';
 		$css .= '.wp-site-blocks > .aligncenter { justify-content: center; margin-left: auto; margin-right: auto; }';
 
-		$block_gap_value       = $this->theme_json['styles']['spacing']['blockGap'] ?? '0.5em';
+		$block_gap_value       = isset( $this->theme_json['styles']['spacing']['blockGap'] ) ? $this->theme_json['styles']['spacing']['blockGap'] : '0.5em';
 		$has_block_gap_support = isset( $this->theme_json['settings']['spacing']['blockGap'] );
 		if ( $has_block_gap_support ) {
 			$block_gap_value = static::get_property_value( $this->theme_json, array( 'styles', 'spacing', 'blockGap' ) );
@@ -3360,7 +3360,7 @@ class WP_Theme_JSON_Gutenberg {
 	 * @return null|void
 	 */
 	public function set_spacing_sizes() {
-		$spacing_scale = $this->theme_json['settings']['spacing']['spacingScale'] ?? array();
+		$spacing_scale = isset( $this->theme_json['settings']['spacing']['spacingScale'] ) ? $this->theme_json['settings']['spacing']['spacingScale'] : array();
 
 		// Gutenberg didn't have the 1st isset check.
 		if ( ! isset( $spacing_scale['steps'] )
@@ -3546,7 +3546,7 @@ class WP_Theme_JSON_Gutenberg {
 			return $declarations;
 		}
 
-		$settings = $this->theme_json['settings'] ?? null;
+		$settings = isset( $this->theme_json['settings'] ) ? $this->theme_json['settings'] : null;
 
 		foreach ( $metadata['selectors'] as $feature => $feature_selectors ) {
 			// Skip if this is the block's root selector or the block doesn't

--- a/lib/class-wp-theme-json-resolver-gutenberg.php
+++ b/lib/class-wp-theme-json-resolver-gutenberg.php
@@ -383,7 +383,7 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 
 			if (
 				isset( $block_type->supports['spacing']['blockGap']['__experimentalDefault'] ) &&
-				null === _wp_array_get( $config, array( 'styles', 'blocks', $block_name, 'spacing', 'blockGap' ), null )
+				! isset( $config['styles']['blocks'][ $block_name ]['spacing']['blockGap'] )
 			) {
 				// Ensure an empty placeholder value exists for the block, if it provides a default blockGap value.
 				// The real blockGap value to be used will be determined when the styles are rendered for output.

--- a/lib/experimental/blocks.php
+++ b/lib/experimental/blocks.php
@@ -141,7 +141,7 @@ if ( $gutenberg_experiments && array_key_exists( 'gutenberg-connections', $guten
 		}
 
 		// Get all the attributes that have a connection.
-		$connected_attributes = _wp_array_get( $block['attrs'], array( 'connections', 'attributes' ), false );
+		$connected_attributes = $block['attrs']['connections']['attributes'] ?? false;
 		if ( ! $connected_attributes ) {
 			return $block_content;
 		}

--- a/lib/experimental/blocks.php
+++ b/lib/experimental/blocks.php
@@ -141,7 +141,7 @@ if ( $gutenberg_experiments && array_key_exists( 'gutenberg-connections', $guten
 		}
 
 		// Get all the attributes that have a connection.
-		$connected_attributes = isset( $block['attrs']['connections']['attributes'] ) ? $block['attrs']['connections']['attributes'] : false;
+		$connected_attributes = $block['attrs']['connections']['attributes'] ?? false;
 		if ( ! $connected_attributes ) {
 			return $block_content;
 		}

--- a/lib/experimental/blocks.php
+++ b/lib/experimental/blocks.php
@@ -141,7 +141,7 @@ if ( $gutenberg_experiments && array_key_exists( 'gutenberg-connections', $guten
 		}
 
 		// Get all the attributes that have a connection.
-		$connected_attributes = $block['attrs']['connections']['attributes'] ?? false;
+		$connected_attributes = isset( $block['attrs']['connections']['attributes'] ) ? $block['attrs']['connections']['attributes'] : false;
 		if ( ! $connected_attributes ) {
 			return $block_content;
 		}

--- a/packages/block-library/src/avatar/index.php
+++ b/packages/block-library/src/avatar/index.php
@@ -112,12 +112,12 @@ function get_block_core_avatar_border_attributes( $attributes ) {
 
 	// Border color.
 	$preset_color           = array_key_exists( 'borderColor', $attributes ) ? "var:preset|color|{$attributes['borderColor']}" : null;
-	$custom_color           = _wp_array_get( $attributes, array( 'style', 'border', 'color' ), null );
+	$custom_color           = isset( $attributes['style']['border']['color'] ) ? $attributes['style']['border']['color'] : null;
 	$border_styles['color'] = $preset_color ? $preset_color : $custom_color;
 
 	// Individual border styles e.g. top, left etc.
 	foreach ( $sides as $side ) {
-		$border                 = _wp_array_get( $attributes, array( 'style', 'border', $side ), null );
+		$border                 = isset( $attributes['style']['border'][ $side ] ) ? $attributes['style']['border'][ $side ] : null;
 		$border_styles[ $side ] = array(
 			'color' => isset( $border['color'] ) ? $border['color'] : null,
 			'style' => isset( $border['style'] ) ? $border['style'] : null,

--- a/packages/block-library/src/avatar/index.php
+++ b/packages/block-library/src/avatar/index.php
@@ -112,12 +112,12 @@ function get_block_core_avatar_border_attributes( $attributes ) {
 
 	// Border color.
 	$preset_color           = array_key_exists( 'borderColor', $attributes ) ? "var:preset|color|{$attributes['borderColor']}" : null;
-	$custom_color           = isset( $attributes['style']['border']['color'] ) ? $attributes['style']['border']['color'] : null;
+	$custom_color           = $attributes['style']['border']['color'] ?? null;
 	$border_styles['color'] = $preset_color ? $preset_color : $custom_color;
 
 	// Individual border styles e.g. top, left etc.
 	foreach ( $sides as $side ) {
-		$border                 = isset( $attributes['style']['border'][ $side ] ) ? $attributes['style']['border'][ $side ] : null;
+		$border                 = $attributes['style']['border'][ $side ] ?? null;
 		$border_styles[ $side ] = array(
 			'color' => isset( $border['color'] ) ? $border['color'] : null,
 			'style' => isset( $border['style'] ) ? $border['style'] : null,

--- a/packages/block-library/src/avatar/index.php
+++ b/packages/block-library/src/avatar/index.php
@@ -112,12 +112,12 @@ function get_block_core_avatar_border_attributes( $attributes ) {
 
 	// Border color.
 	$preset_color           = array_key_exists( 'borderColor', $attributes ) ? "var:preset|color|{$attributes['borderColor']}" : null;
-	$custom_color           = $attributes['style']['border']['color'] ?? null;
+	$custom_color           = isset( $attributes['style']['border']['color'] ) ? $attributes['style']['border']['color'] : null;
 	$border_styles['color'] = $preset_color ? $preset_color : $custom_color;
 
 	// Individual border styles e.g. top, left etc.
 	foreach ( $sides as $side ) {
-		$border                 = $attributes['style']['border'][ $side ] ?? null;
+		$border                 = isset( $attributes['style']['border'][ $side ] ) ? $attributes['style']['border'][ $side ] : null;
 		$border_styles[ $side ] = array(
 			'color' => isset( $border['color'] ) ? $border['color'] : null,
 			'style' => isset( $border['style'] ) ? $border['style'] : null,

--- a/packages/block-library/src/calendar/index.php
+++ b/packages/block-library/src/calendar/index.php
@@ -44,12 +44,12 @@ function render_block_core_calendar( $attributes ) {
 
 	// Text color.
 	$preset_text_color          = array_key_exists( 'textColor', $attributes ) ? "var:preset|color|{$attributes['textColor']}" : null;
-	$custom_text_color          = _wp_array_get( $attributes, array( 'style', 'color', 'text' ), null );
+	$custom_text_color          = isset( $attributes['style']['color']['text'] ) ? $attributes['style']['color']['text'] : null;
 	$color_block_styles['text'] = $preset_text_color ? $preset_text_color : $custom_text_color;
 
 	// Background Color.
 	$preset_background_color          = array_key_exists( 'backgroundColor', $attributes ) ? "var:preset|color|{$attributes['backgroundColor']}" : null;
-	$custom_background_color          = _wp_array_get( $attributes, array( 'style', 'color', 'background' ), null );
+	$custom_background_color          = isset( $attributes['style']['color']['background'] ) ? $attributes['style']['color']['background'] : null;
 	$color_block_styles['background'] = $preset_background_color ? $preset_background_color : $custom_background_color;
 
 	// Generate color styles and classes.

--- a/packages/block-library/src/calendar/index.php
+++ b/packages/block-library/src/calendar/index.php
@@ -44,12 +44,12 @@ function render_block_core_calendar( $attributes ) {
 
 	// Text color.
 	$preset_text_color          = array_key_exists( 'textColor', $attributes ) ? "var:preset|color|{$attributes['textColor']}" : null;
-	$custom_text_color          = isset( $attributes['style']['color']['text'] ) ? $attributes['style']['color']['text'] : null;
+	$custom_text_color          = $attributes['style']['color']['text'] ?? null;
 	$color_block_styles['text'] = $preset_text_color ? $preset_text_color : $custom_text_color;
 
 	// Background Color.
 	$preset_background_color          = array_key_exists( 'backgroundColor', $attributes ) ? "var:preset|color|{$attributes['backgroundColor']}" : null;
-	$custom_background_color          = isset( $attributes['style']['color']['background'] ) ? $attributes['style']['color']['background'] : null;
+	$custom_background_color          = $attributes['style']['color']['background'] ?? null;
 	$color_block_styles['background'] = $preset_background_color ? $preset_background_color : $custom_background_color;
 
 	// Generate color styles and classes.

--- a/packages/block-library/src/calendar/index.php
+++ b/packages/block-library/src/calendar/index.php
@@ -44,12 +44,12 @@ function render_block_core_calendar( $attributes ) {
 
 	// Text color.
 	$preset_text_color          = array_key_exists( 'textColor', $attributes ) ? "var:preset|color|{$attributes['textColor']}" : null;
-	$custom_text_color          = $attributes['style']['color']['text'] ?? null;
+	$custom_text_color          = isset( $attributes['style']['color']['text'] ) ? $attributes['style']['color']['text'] : null;
 	$color_block_styles['text'] = $preset_text_color ? $preset_text_color : $custom_text_color;
 
 	// Background Color.
 	$preset_background_color          = array_key_exists( 'backgroundColor', $attributes ) ? "var:preset|color|{$attributes['backgroundColor']}" : null;
-	$custom_background_color          = $attributes['style']['color']['background'] ?? null;
+	$custom_background_color          = isset( $attributes['style']['color']['background'] ) ? $attributes['style']['color']['background'] : null;
 	$color_block_styles['background'] = $preset_background_color ? $preset_background_color : $custom_background_color;
 
 	// Generate color styles and classes.

--- a/packages/block-library/src/gallery/index.php
+++ b/packages/block-library/src/gallery/index.php
@@ -44,7 +44,9 @@ add_filter( 'render_block_data', 'block_core_gallery_data_id_backcompatibility' 
  * @return string The content of the block being rendered.
  */
 function block_core_gallery_render( $attributes, $content ) {
-	$gap = _wp_array_get( $attributes, array( 'style', 'spacing', 'blockGap' ) );
+	$gap = isset( $attributes['style']['spacing']['blockGap'] )
+		? _wp_array_get( $attributes, array( 'style', 'spacing', 'blockGap' ) )
+		: null;
 	// Skip if gap value contains unsupported characters.
 	// Regex for CSS value borrowed from `safecss_filter_attr`, and used here
 	// because we only want to match against the value, not the CSS attribute.

--- a/packages/block-library/src/gallery/index.php
+++ b/packages/block-library/src/gallery/index.php
@@ -45,7 +45,7 @@ add_filter( 'render_block_data', 'block_core_gallery_data_id_backcompatibility' 
  */
 function block_core_gallery_render( $attributes, $content ) {
 	$gap = isset( $attributes['style']['spacing']['blockGap'] )
-		? _wp_array_get( $attributes, array( 'style', 'spacing', 'blockGap' ) )
+		? $attributes['style']['spacing']['blockGap']
 		: null;
 	// Skip if gap value contains unsupported characters.
 	// Regex for CSS value borrowed from `safecss_filter_attr`, and used here

--- a/packages/block-library/src/gallery/index.php
+++ b/packages/block-library/src/gallery/index.php
@@ -44,7 +44,7 @@ add_filter( 'render_block_data', 'block_core_gallery_data_id_backcompatibility' 
  * @return string The content of the block being rendered.
  */
 function block_core_gallery_render( $attributes, $content ) {
-	$gap = isset( $attributes['style']['spacing']['blockGap'] ) ? $attributes['style']['spacing']['blockGap'] : null;
+	$gap = $attributes['style']['spacing']['blockGap'] ?? null;
 	// Skip if gap value contains unsupported characters.
 	// Regex for CSS value borrowed from `safecss_filter_attr`, and used here
 	// because we only want to match against the value, not the CSS attribute.

--- a/packages/block-library/src/gallery/index.php
+++ b/packages/block-library/src/gallery/index.php
@@ -44,7 +44,7 @@ add_filter( 'render_block_data', 'block_core_gallery_data_id_backcompatibility' 
  * @return string The content of the block being rendered.
  */
 function block_core_gallery_render( $attributes, $content ) {
-	$gap = $attributes['style']['spacing']['blockGap'] ?? null;
+	$gap = isset( $attributes['style']['spacing']['blockGap'] ) ? $attributes['style']['spacing']['blockGap'] : null;
 	// Skip if gap value contains unsupported characters.
 	// Regex for CSS value borrowed from `safecss_filter_attr`, and used here
 	// because we only want to match against the value, not the CSS attribute.

--- a/packages/block-library/src/gallery/index.php
+++ b/packages/block-library/src/gallery/index.php
@@ -44,9 +44,7 @@ add_filter( 'render_block_data', 'block_core_gallery_data_id_backcompatibility' 
  * @return string The content of the block being rendered.
  */
 function block_core_gallery_render( $attributes, $content ) {
-	$gap = isset( $attributes['style']['spacing']['blockGap'] )
-		? $attributes['style']['spacing']['blockGap']
-		: null;
+	$gap = $attributes['style']['spacing']['blockGap'] ?? null;
 	// Skip if gap value contains unsupported characters.
 	// Regex for CSS value borrowed from `safecss_filter_attr`, and used here
 	// because we only want to match against the value, not the CSS attribute.

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -530,7 +530,7 @@ function render_block_core_navigation( $attributes, $content, $block ) {
 
 	// Manually add block support text decoration as CSS class.
 	$text_decoration       = isset( $attributes['style']['typography']['textDecoration'] )
-		? _wp_array_get( $attributes, array( 'style', 'typography', 'textDecoration' ), null )
+		? $attributes['style']['typography']['textDecoration']
 		: null;
 	$text_decoration_class = sprintf( 'has-text-decoration-%s', $text_decoration );
 

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -529,7 +529,9 @@ function render_block_core_navigation( $attributes, $content, $block ) {
 	}
 
 	// Manually add block support text decoration as CSS class.
-	$text_decoration       = _wp_array_get( $attributes, array( 'style', 'typography', 'textDecoration' ), null );
+	$text_decoration       = isset( $attributes['style']['typography']['textDecoration'] )
+		? _wp_array_get( $attributes, array( 'style', 'typography', 'textDecoration' ), null )
+		: null;
 	$text_decoration_class = sprintf( 'has-text-decoration-%s', $text_decoration );
 
 	$colors     = block_core_navigation_build_css_colors( $attributes );

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -529,7 +529,7 @@ function render_block_core_navigation( $attributes, $content, $block ) {
 	}
 
 	// Manually add block support text decoration as CSS class.
-	$text_decoration       = isset( $attributes['style']['typography']['textDecoration'] ) ? $attributes['style']['typography']['textDecoration'] : null;
+	$text_decoration       = $attributes['style']['typography']['textDecoration'] ?? null;
 	$text_decoration_class = sprintf( 'has-text-decoration-%s', $text_decoration );
 
 	$colors     = block_core_navigation_build_css_colors( $attributes );

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -529,7 +529,7 @@ function render_block_core_navigation( $attributes, $content, $block ) {
 	}
 
 	// Manually add block support text decoration as CSS class.
-	$text_decoration       = $attributes['style']['typography']['textDecoration'] ?? null;
+	$text_decoration       = isset( $attributes['style']['typography']['textDecoration'] ) ? $attributes['style']['typography']['textDecoration'] : null;
 	$text_decoration_class = sprintf( 'has-text-decoration-%s', $text_decoration );
 
 	$colors     = block_core_navigation_build_css_colors( $attributes );

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -529,9 +529,7 @@ function render_block_core_navigation( $attributes, $content, $block ) {
 	}
 
 	// Manually add block support text decoration as CSS class.
-	$text_decoration       = isset( $attributes['style']['typography']['textDecoration'] )
-		? $attributes['style']['typography']['textDecoration']
-		: null;
+	$text_decoration       = $attributes['style']['typography']['textDecoration'] ?? null;
 	$text_decoration_class = sprintf( 'has-text-decoration-%s', $text_decoration );
 
 	$colors     = block_core_navigation_build_css_colors( $attributes );

--- a/packages/block-library/src/post-featured-image/index.php
+++ b/packages/block-library/src/post-featured-image/index.php
@@ -184,16 +184,12 @@ function get_block_core_post_featured_image_border_attributes( $attributes ) {
 
 	// Border color.
 	$preset_color           = array_key_exists( 'borderColor', $attributes ) ? "var:preset|color|{$attributes['borderColor']}" : null;
-	$custom_color           = isset( $attributes['style']['border']['color'] )
-		? _wp_array_get( $attributes, array( 'style', 'border', 'color' ), null )
-		: null;
+	$custom_color           = isset( $attributes['style']['border']['color'] ) ? $attributes['style']['border']['color'] : null;
 	$border_styles['color'] = $preset_color ? $preset_color : $custom_color;
 
 	// Individual border styles e.g. top, left etc.
 	foreach ( $sides as $side ) {
-		$border                 = isset( $attributes['style']['border'][ $side ] )
-			? _wp_array_get( $attributes, array( 'style', 'border', $side ), array() )
-			: array();
+		$border                 = isset( $attributes['style']['border'][ $side ] ) ? $attributes['style']['border'][ $side ] : array();
 		$border_styles[ $side ] = array(
 			'color' => isset( $border['color'] ) ? $border['color'] : null,
 			'style' => isset( $border['style'] ) ? $border['style'] : null,

--- a/packages/block-library/src/post-featured-image/index.php
+++ b/packages/block-library/src/post-featured-image/index.php
@@ -184,12 +184,12 @@ function get_block_core_post_featured_image_border_attributes( $attributes ) {
 
 	// Border color.
 	$preset_color           = array_key_exists( 'borderColor', $attributes ) ? "var:preset|color|{$attributes['borderColor']}" : null;
-	$custom_color           = isset( $attributes['style']['border']['color'] ) ? $attributes['style']['border']['color'] : null;
+	$custom_color           = $attributes['style']['border']['color'] ?? null;
 	$border_styles['color'] = $preset_color ? $preset_color : $custom_color;
 
 	// Individual border styles e.g. top, left etc.
 	foreach ( $sides as $side ) {
-		$border                 = isset( $attributes['style']['border'][ $side ] ) ? $attributes['style']['border'][ $side ] : array();
+		$border                 = $attributes['style']['border'][ $side ] ?? null;
 		$border_styles[ $side ] = array(
 			'color' => isset( $border['color'] ) ? $border['color'] : null,
 			'style' => isset( $border['style'] ) ? $border['style'] : null,

--- a/packages/block-library/src/post-featured-image/index.php
+++ b/packages/block-library/src/post-featured-image/index.php
@@ -184,12 +184,16 @@ function get_block_core_post_featured_image_border_attributes( $attributes ) {
 
 	// Border color.
 	$preset_color           = array_key_exists( 'borderColor', $attributes ) ? "var:preset|color|{$attributes['borderColor']}" : null;
-	$custom_color           = _wp_array_get( $attributes, array( 'style', 'border', 'color' ), null );
+	$custom_color           = isset( $attributes['style']['border']['color'] )
+		? _wp_array_get( $attributes, array( 'style', 'border', 'color' ), null )
+		: null;
 	$border_styles['color'] = $preset_color ? $preset_color : $custom_color;
 
 	// Individual border styles e.g. top, left etc.
 	foreach ( $sides as $side ) {
-		$border                 = _wp_array_get( $attributes, array( 'style', 'border', $side ), null );
+		$border                 = isset( $attributes['style']['border'][ $side ] )
+			? _wp_array_get( $attributes, array( 'style', 'border', $side ), array() )
+			: array();
 		$border_styles[ $side ] = array(
 			'color' => isset( $border['color'] ) ? $border['color'] : null,
 			'style' => isset( $border['style'] ) ? $border['style'] : null,

--- a/packages/block-library/src/post-featured-image/index.php
+++ b/packages/block-library/src/post-featured-image/index.php
@@ -184,12 +184,12 @@ function get_block_core_post_featured_image_border_attributes( $attributes ) {
 
 	// Border color.
 	$preset_color           = array_key_exists( 'borderColor', $attributes ) ? "var:preset|color|{$attributes['borderColor']}" : null;
-	$custom_color           = $attributes['style']['border']['color'] ?? null;
+	$custom_color           = isset( $attributes['style']['border']['color'] ) ? $attributes['style']['border']['color'] : null;
 	$border_styles['color'] = $preset_color ? $preset_color : $custom_color;
 
 	// Individual border styles e.g. top, left etc.
 	foreach ( $sides as $side ) {
-		$border                 = $attributes['style']['border'][ $side ] ?? null;
+		$border                 = isset( $attributes['style']['border'][ $side ] ) ? $attributes['style']['border'][ $side ] : null;
 		$border_styles[ $side ] = array(
 			'color' => isset( $border['color'] ) ? $border['color'] : null,
 			'style' => isset( $border['style'] ) ? $border['style'] : null,

--- a/packages/block-library/src/post-featured-image/index.php
+++ b/packages/block-library/src/post-featured-image/index.php
@@ -184,12 +184,12 @@ function get_block_core_post_featured_image_border_attributes( $attributes ) {
 
 	// Border color.
 	$preset_color           = array_key_exists( 'borderColor', $attributes ) ? "var:preset|color|{$attributes['borderColor']}" : null;
-	$custom_color           = isset( $attributes['style']['border']['color'] ) ? $attributes['style']['border']['color'] : null;
+	$custom_color           = $attributes['style']['border']['color'] ?? null;
 	$border_styles['color'] = $preset_color ? $preset_color : $custom_color;
 
 	// Individual border styles e.g. top, left etc.
 	foreach ( $sides as $side ) {
-		$border                 = isset( $attributes['style']['border'][ $side ] ) ? $attributes['style']['border'][ $side ] : null;
+		$border                 = $attributes['style']['border'][ $side ] ?? null;
 		$border_styles[ $side ] = array(
 			'color' => isset( $border['color'] ) ? $border['color'] : null,
 			'style' => isset( $border['style'] ) ? $border['style'] : null,

--- a/packages/block-library/src/search/index.php
+++ b/packages/block-library/src/search/index.php
@@ -266,7 +266,7 @@ function classnames_for_block_core_search( $attributes ) {
  * @return void
  */
 function apply_block_core_search_border_style( $attributes, $property, $side, &$wrapper_styles, &$button_styles, &$input_styles ) {
-	$is_button_inside = 'button-inside' === _wp_array_get( $attributes, array( 'buttonPosition' ), false );
+	$is_button_inside = isset( $attributes['buttonPosition'] ) && 'button-inside' === $attributes['buttonPosition'];
 
 	$path = array( 'style', 'border', $property );
 

--- a/packages/style-engine/docs/using-the-style-engine-with-block-supports.md
+++ b/packages/style-engine/docs/using-the-style-engine-with-block-supports.md
@@ -133,8 +133,18 @@ function gutenberg_apply_colors_support( $block_type, $block_attributes ) {
 	$color_block_styles = array();
 
 	// Set the color style values according to whether the block has support and does not skip serialization.
-	$spacing_block_styles['text']       = $has_text_support && ! $skips_serialization_of_color_text ? _wp_array_get( $block_color_styles, array( 'text' ), null ) : null;
-	$spacing_block_styles['background'] = $has_background_support && ! $skips_serialization_of_color_background ? _wp_array_get( $block_color_styles, array( 'background' ), null ) : null;
+	$spacing_block_styles['text']       = null;
+	if ( $has_text_support && ! $skips_serialization_of_color_text ) {
+		$spacing_block_styles['text'] = isset( $block_color_styles['text'] )
+			? _wp_array_get( $block_color_styles, array( 'text' ), null )
+			: null;
+	}
+	$spacing_block_styles['background'] = null;
+	if ( $has_background_support && ! $skips_serialization_of_color_background ) {
+		$spacing_block_styles['background'] = isset( $block_color_styles['background'] )
+			? _wp_array_get( $block_color_styles, array( 'background' ), null )
+			: null;
+	}
 
 	// Pass the color styles, excluding those that have no support or skip serialization, to the Style Engine.
 	$styles = wp_style_engine_get_styles( array( 'color' => $block_color_styles ) );

--- a/packages/style-engine/docs/using-the-style-engine-with-block-supports.md
+++ b/packages/style-engine/docs/using-the-style-engine-with-block-supports.md
@@ -135,14 +135,12 @@ function gutenberg_apply_colors_support( $block_type, $block_attributes ) {
 	// Set the color style values according to whether the block has support and does not skip serialization.
 	$spacing_block_styles['text']       = null;
 	if ( $has_text_support && ! $skips_serialization_of_color_text ) {
-		$spacing_block_styles['text'] = isset( $block_color_styles['text'] )
-			? _wp_array_get( $block_color_styles, array( 'text' ), null )
-			: null;
+		$spacing_block_styles['text'] = isset( $block_color_styles['text'] ) ? $block_color_styles['text'] : null;
 	}
 	$spacing_block_styles['background'] = null;
 	if ( $has_background_support && ! $skips_serialization_of_color_background ) {
 		$spacing_block_styles['background'] = isset( $block_color_styles['background'] )
-			? _wp_array_get( $block_color_styles, array( 'background' ), null )
+			? $block_color_styles['background']
 			: null;
 	}
 

--- a/packages/style-engine/docs/using-the-style-engine-with-block-supports.md
+++ b/packages/style-engine/docs/using-the-style-engine-with-block-supports.md
@@ -134,14 +134,12 @@ function gutenberg_apply_colors_support( $block_type, $block_attributes ) {
 
 	// Set the color style values according to whether the block has support and does not skip serialization.
 	$spacing_block_styles['text']       = null;
-	if ( $has_text_support && ! $skips_serialization_of_color_text ) {
-		$spacing_block_styles['text'] = isset( $block_color_styles['text'] ) ? $block_color_styles['text'] : null;
-	}
 	$spacing_block_styles['background'] = null;
-	if ( $has_background_support && ! $skips_serialization_of_color_background ) {
-		$spacing_block_styles['background'] = isset( $block_color_styles['background'] )
-			? $block_color_styles['background']
-			: null;
+	if ( $has_text_support && ! $skips_serialization_of_color_text ) {
+		$spacing_block_styles['text'] = $block_color_styles['text'] ?? null;
+	}
+	if $has_background_support && ! $skips_serialization_of_color_background ) {
+		$spacing_block_styles['background'] = $block_color_styles['background'] ?? null;
 	}
 
 	// Pass the color styles, excluding those that have no support or skip serialization, to the Style Engine.

--- a/packages/style-engine/docs/using-the-style-engine-with-block-supports.md
+++ b/packages/style-engine/docs/using-the-style-engine-with-block-supports.md
@@ -136,10 +136,10 @@ function gutenberg_apply_colors_support( $block_type, $block_attributes ) {
 	$spacing_block_styles['text']       = null;
 	$spacing_block_styles['background'] = null;
 	if ( $has_text_support && ! $skips_serialization_of_color_text ) {
-		$spacing_block_styles['text'] = $block_color_styles['text'] ?? null;
+		$spacing_block_styles['text'] = isset( $block_color_styles['text'] ) ? $block_color_styles['text'] : null;
 	}
 	if $has_background_support && ! $skips_serialization_of_color_background ) {
-		$spacing_block_styles['background'] = $block_color_styles['background'] ?? null;
+		$spacing_block_styles['background'] = isset( $block_color_styles['background'] ) ? $block_color_styles['background'] : null;
 	}
 
 	// Pass the color styles, excluding those that have no support or skip serialization, to the Style Engine.

--- a/packages/style-engine/docs/using-the-style-engine-with-block-supports.md
+++ b/packages/style-engine/docs/using-the-style-engine-with-block-supports.md
@@ -136,10 +136,10 @@ function gutenberg_apply_colors_support( $block_type, $block_attributes ) {
 	$spacing_block_styles['text']       = null;
 	$spacing_block_styles['background'] = null;
 	if ( $has_text_support && ! $skips_serialization_of_color_text ) {
-		$spacing_block_styles['text'] = isset( $block_color_styles['text'] ) ? $block_color_styles['text'] : null;
+		$spacing_block_styles['text'] = $block_color_styles['text'] ?? null;
 	}
 	if $has_background_support && ! $skips_serialization_of_color_background ) {
-		$spacing_block_styles['background'] = isset( $block_color_styles['background'] ) ? $block_color_styles['background'] : null;
+		$spacing_block_styles['background'] = $block_color_styles['background'] ?? null;
 	}
 
 	// Pass the color styles, excluding those that have no support or skip serialization, to the Style Engine.


### PR DESCRIPTION
## What?
`_wp_array_get()` is an expensive function, and it's called thousands of times on each page-view on the frontend. In https://core.trac.wordpress.org/ticket/58376 we improved slightly the performance of that function, but the fact remains that it's called more times than it should.

## Why?
Because performance & sustainability.

## How?
Inspiration came from a discussion with @jrfnl 

In many cases, we can replace `_wp_array_get()` with a much simpler and faster `isset()` check. 
The `isset()` function is capable of checking nested arrays, so `isset( $foo['a']['b']['c'] )` will return false even if `$foo['a']` is unset, without throwing any errors/warnings etc. 
When `_wp_array_get()` cannot be directly replaced with `isset()`, it would be good practice to wrap it in an `isset` function so `_wp_array_get` will only run when it needs to.

In order to simplify the syntax, instead of using `isset()` checks, we can use the [Null coalescing operator](https://www.php.net/manual/en/migration70.new-features.php#migration70.new-features.null-coalesce-op), which further simplifies the whole implementation. 
So we can replace for example this line:
```php
$has_font_family_support = _wp_array_get( $typography_supports, array( '__experimentalFontFamily' ), false );
```
with this:
```php
$has_font_family_support = $typography_supports['__experimentalFontFamily'] ?? false;
```
which would be the equivalent of this:
```php
$has_font_family_support = isset( $typography_supports['__experimentalFontFamily'] )
    ? $typography_supports['__experimentalFontFamily']
    : false;
```

**The resulting code is shorter, easier to understand, and faster.**

Of course the above modifications can only work when we know the path we're looking for. If we don't, then `_wp_array_get` should still be used.