### PR TITLE
Link Control: Fix the 'Save' button's disabled state

### DIFF
--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -307,6 +307,7 @@ function LinkControl( {
 	const showTextControl = hasLinkValue && hasTextControl;
 
 	const isEditing = ( isEditingLink || ! value ) && ! isCreatingPage;
+	const isDisabled = ! valueHasChanges || currentInputIsEmpty;
 
 	return (
 		<div
@@ -402,11 +403,9 @@ function LinkControl( {
 					<div className="block-editor-link-control__search-actions">
 						<Button
 							variant="primary"
-							onClick={ handleSubmit }
+							onClick={ isDisabled ? noop : handleSubmit }
 							className="block-editor-link-control__search-submit"
-							disabled={
-								! valueHasChanges || currentInputIsEmpty
-							}
+							aria-disabled={ isDisabled }
 						>
 							{ __( 'Save' ) }
 						</Button>

--- a/packages/block-editor/src/components/link-control/test/index.js
+++ b/packages/block-editor/src/components/link-control/test/index.js
@@ -658,7 +658,10 @@ describe( 'Manual link entry', () => {
 					name: 'Save',
 				} );
 
-				expect( submitButton ).toBeDisabled();
+				expect( submitButton ).toHaveAttribute(
+					'aria-disabled',
+					'true'
+				);
 				expect( submitButton ).toBeVisible();
 
 				if ( searchString.length ) {
@@ -678,7 +681,10 @@ describe( 'Manual link entry', () => {
 
 				// Verify the UI hasn't allowed submission.
 				expect( searchInput ).toBeVisible();
-				expect( submitButton ).toBeDisabled();
+				expect( submitButton ).toHaveAttribute(
+					'aria-disabled',
+					'true'
+				);
 				expect( submitButton ).toBeVisible();
 			}
 		);
@@ -699,7 +705,10 @@ describe( 'Manual link entry', () => {
 					name: 'Save',
 				} );
 
-				expect( submitButton ).toBeDisabled();
+				expect( submitButton ).toHaveAttribute(
+					'aria-disabled',
+					'true'
+				);
 				expect( submitButton ).toBeVisible();
 
 				// Simulate searching for a term.
@@ -720,7 +729,10 @@ describe( 'Manual link entry', () => {
 
 				// Verify the UI hasn't allowed submission.
 				expect( searchInput ).toBeVisible();
-				expect( submitButton ).toBeDisabled();
+				expect( submitButton ).toHaveAttribute(
+					'aria-disabled',
+					'true'
+				);
 				expect( submitButton ).toBeVisible();
 			}
 		);
@@ -1812,7 +1824,7 @@ describe( 'Addition Settings UI', () => {
 			name: 'Save',
 		} );
 
-		expect( submitButton ).toBeDisabled();
+		expect( submitButton ).toHaveAttribute( 'aria-disabled', 'true' );
 
 		await toggleSettingsDrawer( user );
 

--- a/packages/e2e-tests/specs/editor/various/links.test.js
+++ b/packages/e2e-tests/specs/editor/various/links.test.js
@@ -664,7 +664,7 @@ describe( 'Links', () => {
 			await page.waitForXPath( `//label[text()='Open in new tab']` );
 
 			// Move focus back to RichText for the underlying link.
-			await pressKeyTimes( 'Tab', 3 );
+			await pressKeyTimes( 'Tab', 4 );
 
 			// Make a selection within the RichText.
 			await pressKeyWithModifier( 'shift', 'ArrowRight' );


### PR DESCRIPTION
## What?

PR swaps the `disabled` prop with `aria-disabled` for the Link Control's save button.

## Why?

Using the `disabled` attribute isn't ideal, as the button can't be navigated with the keyboard. So instead, the component should use `aria-disabled` and `noop` for the event when the save action is disabled.

See [Focusability of disabled controls](https://www.w3.org/WAI/ARIA/apg/practices/keyboard-interface/#focusabilityofdisabledcontrols) in the ARIA practices.

## Testing Instructions
 1. Open a Post or Page.
 2. Insert a Paragraph block and add links.
 3. Open the newly added link for editing.
 4. Confirm that the "Save" button is disabled.
 5. Confirm you can still navigate to the disabled button.
 6. Editing enabled the button, and changes can be saved.

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/240569/7f7c702f-9071-4160-b3f0-fc804c76e0ee

