### PR TITLE
Prevent freeform and shortcode blocks from converting HTML entities

### DIFF
--- a/packages/block-library/src/freeform/block.json
+++ b/packages/block-library/src/freeform/block.json
@@ -9,7 +9,7 @@
 	"attributes": {
 		"content": {
 			"type": "string",
-			"source": "html"
+			"source": "raw"
 		}
 	},
 	"supports": {

--- a/packages/block-library/src/shortcode/block.json
+++ b/packages/block-library/src/shortcode/block.json
@@ -9,7 +9,7 @@
 	"attributes": {
 		"text": {
 			"type": "string",
-			"source": "html"
+			"source": "raw"
 		}
 	},
 	"supports": {

--- a/packages/e2e-tests/specs/editor/various/invalid-block.test.js
+++ b/packages/e2e-tests/specs/editor/various/invalid-block.test.js
@@ -75,7 +75,7 @@ describe( 'invalid blocks', () => {
 		expect( hasAlert ).toBe( false );
 	} );
 
-	it( 'should strip potentially malicious script tags', async () => {
+	it( 'should not trigger malicious script tags when using a shortcode block', async () => {
 		let hasAlert = false;
 
 		page.on( 'dialog', () => {
@@ -94,9 +94,6 @@ describe( 'invalid blocks', () => {
 
 		// Give the browser time to show the alert.
 		await page.evaluate( () => new Promise( window.requestIdleCallback ) );
-
-		expect( console ).toHaveWarned();
-		expect( console ).toHaveErrored();
 		expect( hasAlert ).toBe( false );
 	} );
 } );


### PR DESCRIPTION
closes #26362
closes #33813 
closes #49664 

## What?

One unexpected side effect of using the `html`/`text` source for a block attribute is that HTML entities get converted automatically when parsing the block. That's because the library we use to parse the HTML `hpq` relies on `element.innerHTML` or `element.textContent` to parse the HTML and browsers automatically convert entities when doing that. This can lead to unexpected results for some blocks like the freeform/html or shortcode blocks. I think ideally our attribute parser shouldn't touch the markup at all and not perform any conversion but that's very hard to do with our current hpq approach. As a workaround for some of these blocks we can switch to the `raw` attribute s

## Testing Instructions

1- Add a shortcode block
2- Paste the following shortcode `[wp_random_shortcode url="https://wordpress.org?a=x&b=y"]`
3- the `&` shouldn't get encoded.

It's very hard to predict exactly how this will impact the blocks but it seems that "not touching the source" is a better behavior.