### PR TITLE
[RNMobile] Fix Android-only issue related to block toolbar not being displayed on some blocks in UBE

### DIFF
--- a/packages/react-native-bridge/common/gutenberg-web-single-block/editor-behavior-overrides.js
+++ b/packages/react-native-bridge/common/gutenberg-web-single-block/editor-behavior-overrides.js
@@ -77,9 +77,8 @@ if ( isAndroid() ) {
 	manageTextSelectonContextMenu();
 }
 
-const editor = document.querySelector( '#editor' );
-
 function _toggleBlockSelectedClass( isBlockSelected ) {
+	const editor = document.querySelector( '#editor' );
 	if ( isBlockSelected ) {
 		editor.classList.add( 'is-block-selected' );
 	} else {

--- a/packages/react-native-editor/CHANGELOG.md
+++ b/packages/react-native-editor/CHANGELOG.md
@@ -10,6 +10,7 @@ For each user feature we should also add a importance categorization label  to i
 -->
 
 ## Unreleased
+-   [**] Fix Android-only issue related to block toolbar not being displayed on some blocks in UBE [#51131]
 
 ## 1.96.0
 -   [**] Tapping on all nested blocks gets focus directly instead of having to tap multiple times depending on the nesting levels. [#50672]


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

We identified that on the native unsupported blocks Archive, Calendar, Rating, Slideshow, when editing them via UBE (Unsupported Block Editor), the toolbar is not displayed when selecting the block. **This issue can only be reproduced in the Android app.**

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Not being able to use the block toolbar for some blocks impacts negatively the experience when using UBE.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

The cause of the issue was that the `editor` variable could be already defined in some cases:
https://github.com/WordPress/gutenberg/blob/a450434af1d36a1bcd636db9d770ea40564f476f/packages/react-native-bridge/common/gutenberg-web-single-block/editor-behavior-overrides.js#L80

<img width="800" alt="Screenshot 2023-05-31 at 13 33 01" src="https://github.com/WordPress/gutenberg/assets/14905380/fc5ea674-bccc-4663-bc90-1a5e572ea5c1">

To solve this, we now query the editor element within the function where is needed, which is called when selecting/unselecting the block.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
1. In the browser, add any of the following blocks to a post: Archive, Calendar, Rating, Slideshow.
2. Save the post.
3. Open the post in the app.
4. Observe that the blocks from step 1 are displayed as unsupported.
5. Tap two times on any of the blocks.
6. Observe that a bottom sheet is displayed allowing the user to edit the block using the web editor.
7. Tap on the option "Edit using web editor".
8. Wait until the web editor is loaded.
9. Select the block.
10. Observe that at the top the block toolbar is displayed.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
N/A

## Screenshots or screencast <!-- if applicable -->
| Block unselected | Block selected |
|--------|--------|
| <img src=https://github.com/WordPress/gutenberg/assets/14905380/c741b78e-34b9-4e26-a7c8-333ad1c2771e width=300> | <img src=https://github.com/WordPress/gutenberg/assets/14905380/dee0786b-6e51-4808-b601-f34ff7a88ef4 width=300> | 
