### PR TITLE
DropdownMenu v2: change default placement to match the legacy DropdownMenu component

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### Experimental
 
 -   `DropdownMenu` v2: Tweak styles ([#50967](https://github.com/WordPress/gutenberg/pull/50967), [#51097](https://github.com/WordPress/gutenberg/pull/51097)).
+-   `DropdownMenu` v2: change default placement to match the legacy `DropdownMenu` component  ([#51133](https://github.com/WordPress/gutenberg/pull/51133)).
 -   `DropdownMenu` v2: Render in the default `Popover.Slot` ([#51046](https://github.com/WordPress/gutenberg/pull/51046)).
 
 ## 25.0.0 (2023-05-24)

--- a/packages/components/src/dropdown-menu-v2/README.md
+++ b/packages/components/src/dropdown-menu-v2/README.md
@@ -110,7 +110,7 @@ The distance in pixels from the trigger.
 The preferred alignment against the trigger. May change when collisions occur.
 
 - Required: no
-- Default: `"center"`
+- Default: `"start"`
 
 ##### `alignOffset`: `number`
 

--- a/packages/components/src/dropdown-menu-v2/types.ts
+++ b/packages/components/src/dropdown-menu-v2/types.ts
@@ -44,7 +44,7 @@ export type DropdownMenuProps = {
 	 * The preferred alignment against the trigger.
 	 * May change when collisions occur.
 	 *
-	 * @default 'center'
+	 * @default 'start'
 	 */
 	align?: DropdownMenuPrimitive.DropdownMenuContentProps[ 'align' ];
 	/**


### PR DESCRIPTION
Part of #50459

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

The legacy `DropdownMenu` component shows its popover in the `bottom-start` placement since it fallbacks to the [default value of the `Popover` component for its `placement` prop](https://github.com/WordPress/gutenberg/blob/trunk/packages/components/src/popover/index.tsx#L163).

This PR updates the default value of the `DropdownMenu` v2 component to be the same as the legacy `DropdownMenu`

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Consistency and less disruption when updating from legacy to v2

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Change default prop assignment, update docs

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

Open Storybook, notice how the popover of the `DropdownMenu` v2 component is not opening against the edge of the viewport, but is instead aligned with the left side of the trigger button.

## Screenshots or screencast <!-- if applicable -->

| Before (trunk) | This PR |
|---|---|
| ![Screenshot 2023-05-31 at 14 41 39](https://github.com/WordPress/gutenberg/assets/1083581/f977bbd3-afb6-430b-abd2-01c5acf961e0) | ![Screenshot 2023-05-31 at 14 41 25](https://github.com/WordPress/gutenberg/assets/1083581/57c93a42-d784-4bfa-a9aa-15939cb9e484) |


(ignore the border styles)
