### PR TITLE
ListView: Remove unused 'useSelect' dependency

### DIFF
--- a/packages/block-editor/src/components/list-view/block-contents.js
+++ b/packages/block-editor/src/components/list-view/block-contents.js
@@ -44,7 +44,7 @@ const ListViewBlockContents = forwardRef(
 					selectedBlockInBlockEditor: getSelectedBlockClientId(),
 				};
 			},
-			[ clientId ]
+			[]
 		);
 
 		const { renderAdditionalBlockUI, insertedBlock, setInsertedBlock } =


### PR DESCRIPTION
## What?
PR removes the `clientId` dependency for the `useSelect` hook in the `ListViewBlockContents` component and fixes ESLint warning.

## Testing Instructions
1. Open a Post or Page.
2. Confirm that you can move blocks by dragging in the list view.