### PR TITLE
Term Description: Handle default margin styles

### DIFF
--- a/packages/block-library/src/style.scss
+++ b/packages/block-library/src/style.scss
@@ -51,6 +51,7 @@
 @import "./spacer/style.scss";
 @import "./tag-cloud/style.scss";
 @import "./table/style.scss";
+@import "./term-description/style.scss";
 @import "./text-columns/style.scss";
 @import "./verse/style.scss";
 @import "./video/style.scss";

--- a/packages/block-library/src/term-description/style.scss
+++ b/packages/block-library/src/term-description/style.scss
@@ -1,0 +1,11 @@
+// Lowest specificity on wrapper margins to avoid overriding layout styles.
+:where(.wp-block-term-description) {
+	margin-top: var(--wp--style--block-gap);
+	margin-bottom: var(--wp--style--block-gap);
+}
+
+// Zero out the margin on the description paragraph.
+.wp-block-term-description p {
+	margin-top: 0;
+	margin-bottom: 0;
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Fixes https://github.com/WordPress/gutenberg/issues/50515.

This PR attempts to zero out the paragraph margins on the Term Description block and apply the current block gap size as margins on the block wrapper. Currently, the block is using the default browser-inherited styles.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
At the moment, the Term Description block is unstyled. By inheriting the user agent styles, there's no connection to the rest of the site.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Added a stylesheet for the Term Description block that: zeros the default margins for the paragraph element, and applies the block gap size (`--wp--style--block-gap`) to the Term Description wrapper.

I added the block gap to the wrapper as otherwise there is no spacing around the Term Description block by default. By using the block gap variable, the size of this spacing is at least in line with the current theme.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
1. Insert a Term Description block in a template
2. View the block in the editor and the front end
3. Ensure the new styles are applied to both the wrapper and the inner paragraph

## Screenshots or screencast <!-- if applicable -->
| Before | After |
| ------ | ----- |
| <img width="439" alt="Screenshot 2023-05-31 at 14 32 12" src="https://github.com/WordPress/gutenberg/assets/1645628/dbd9f9ba-88d4-49b8-9c84-246bdc4388eb"> | <img width="439" alt="Screenshot 2023-05-31 at 14 32 23" src="https://github.com/WordPress/gutenberg/assets/1645628/e591b71d-8517-437f-97df-57006df73189"> |