### PR TITLE
Fluid typography: ensure max viewport width is used in the editor

### DIFF
--- a/packages/block-editor/src/components/global-styles/test/typography-utils.js
+++ b/packages/block-editor/src/components/global-styles/test/typography-utils.js
@@ -172,6 +172,58 @@ describe( 'typography utils', () => {
 
 			{
 				message:
+					'returns clamp value where min and max fluid values defined',
+				preset: {
+					size: '80px',
+					fluid: {
+						min: '70px',
+						max: '125px',
+					},
+				},
+				typographySettings: {
+					fluid: true,
+				},
+				expected:
+					'clamp(70px, 4.375rem + ((1vw - 3.2px) * 4.297), 125px)',
+			},
+
+			{
+				message:
+					'should apply maxViewPortWidth as maximum viewport width',
+				preset: {
+					size: '80px',
+					fluid: {
+						min: '70px',
+						max: '125px',
+					},
+				},
+				typographySettings: {
+					fluid: {
+						maxViewPortWidth: '1100px',
+					},
+				},
+				expected:
+					'clamp(70px, 4.375rem + ((1vw - 3.2px) * 7.051), 125px)',
+			},
+
+			{
+				message: 'returns clamp value where max is equal to size',
+				preset: {
+					size: '7.8125rem',
+					fluid: {
+						min: '4.375rem',
+						max: '7.8125rem',
+					},
+				},
+				typographySettings: {
+					fluid: true,
+				},
+				expected:
+					'clamp(4.375rem, 4.375rem + ((1vw - 0.2rem) * 4.298), 7.8125rem)',
+			},
+
+			{
+				message:
 					'should return clamp value if min font size is greater than max',
 				preset: {
 					size: '3rem',

--- a/packages/block-editor/src/components/global-styles/typography-utils.js
+++ b/packages/block-editor/src/components/global-styles/typography-utils.js
@@ -20,17 +20,16 @@ import { getComputedFluidTypographyValue } from '../font-sizes/fluid-utils';
  * @property {?string|?number}               size  A default font size.
  * @property {string}                        name  A font size name, displayed in the UI.
  * @property {string}                        slug  A font size slug
- * @property {boolean|FluidPreset|undefined} fluid A font size slug
+ * @property {boolean|FluidPreset|undefined} fluid Specifics the minimum and maximum font size value of a fluid font size.
  */
 
 /**
  * @typedef {Object} TypographySettings
- * @property {?string|?number} size              A default font size.
- * @property {?string}         minViewPortWidth  Minimum viewport size from which type will have fluidity. Optional if size is specified.
- * @property {?string}         maxViewPortWidth  Maximum size up to which type will have fluidity. Optional if size is specified.
- * @property {?number}         scaleFactor       A scale factor to determine how fast a font scales within boundaries. Optional.
- * @property {?number}         minFontSizeFactor How much to scale defaultFontSize by to derive minimumFontSize. Optional.
- * @property {?string}         minFontSize       The smallest a calculated font size may be. Optional.
+ * @property {?string} minViewPortWidth  Minimum viewport size from which type will have fluidity. Optional if size is specified.
+ * @property {?string} maxViewPortWidth  Maximum size up to which type will have fluidity. Optional if size is specified.
+ * @property {?number} scaleFactor       A scale factor to determine how fast a font scales within boundaries. Optional.
+ * @property {?number} minFontSizeFactor How much to scale defaultFontSize by to derive minimumFontSize. Optional.
+ * @property {?string} minFontSize       The smallest a calculated font size may be. Optional.
  */
 
 /**
@@ -77,6 +76,7 @@ export function getTypographyFontSizeValue( preset, typographySettings ) {
 		maximumFontSize: preset?.fluid?.max,
 		fontSize: defaultSize,
 		minimumFontSizeLimit: fluidTypographySettings?.minFontSize,
+		maximumViewPortWidth: fluidTypographySettings?.maxViewPortWidth,
 	} );
 
 	if ( !! fluidFontSizeValue ) {

--- a/packages/block-editor/src/components/global-styles/typography-utils.js
+++ b/packages/block-editor/src/components/global-styles/typography-utils.js
@@ -20,7 +20,7 @@ import { getComputedFluidTypographyValue } from '../font-sizes/fluid-utils';
  * @property {?string|?number}               size  A default font size.
  * @property {string}                        name  A font size name, displayed in the UI.
  * @property {string}                        slug  A font size slug
- * @property {boolean|FluidPreset|undefined} fluid Specifics the minimum and maximum font size value of a fluid font size.
+ * @property {boolean|FluidPreset|undefined} fluid Specifies the minimum and maximum font size value of a fluid font size.
  */
 
 /**

--- a/packages/block-editor/src/components/global-styles/use-global-styles-output.js
+++ b/packages/block-editor/src/components/global-styles/use-global-styles-output.js
@@ -398,7 +398,12 @@ export function getStylesDeclarations(
 			 */
 			ruleValue = getTypographyFontSizeValue(
 				{ size: ruleValue },
-				tree?.settings?.typography
+				{
+					fluid: {
+						maxViewPortWidth: tree?.settings?.layout?.wideSize,
+						...tree?.settings?.typography?.fluid,
+					},
+				}
 			);
 		}
 

--- a/packages/block-editor/src/components/global-styles/use-global-styles-output.js
+++ b/packages/block-editor/src/components/global-styles/use-global-styles-output.js
@@ -401,9 +401,8 @@ export function getStylesDeclarations(
 				tree?.settings?.layout?.wideSize
 					? {
 							fluid: {
-								maxViewPortWidth:
-									tree?.settings?.layout?.wideSize,
-								...tree?.settings?.typography?.fluid,
+								maxViewPortWidth: tree.settings.layout.wideSize,
+								...tree.settings.typography.fluid,
 							},
 					  }
 					: {

--- a/packages/block-editor/src/components/global-styles/use-global-styles-output.js
+++ b/packages/block-editor/src/components/global-styles/use-global-styles-output.js
@@ -396,14 +396,22 @@ export function getStylesDeclarations(
 			 * Values that already have a "clamp()" function will not pass the test,
 			 * and therefore the original $value will be returned.
 			 */
+			const typographySettings =
+				!! tree?.settings?.typography?.fluid &&
+				tree?.settings?.layout?.wideSize
+					? {
+							fluid: {
+								maxViewPortWidth:
+									tree?.settings?.layout?.wideSize,
+								...tree?.settings?.typography?.fluid,
+							},
+					  }
+					: {
+							fluid: tree?.settings?.typography?.fluid,
+					  };
 			ruleValue = getTypographyFontSizeValue(
 				{ size: ruleValue },
-				{
-					fluid: {
-						maxViewPortWidth: tree?.settings?.layout?.wideSize,
-						...tree?.settings?.typography?.fluid,
-					},
-				}
+				typographySettings
 			);
 		}
 

--- a/packages/block-editor/src/components/global-styles/utils.js
+++ b/packages/block-editor/src/components/global-styles/utils.js
@@ -74,12 +74,19 @@ export const PRESET_METADATA = [
 	{
 		path: [ 'typography', 'fontSizes' ],
 		valueFunc: ( preset, settings ) =>
-			getTypographyFontSizeValue( preset, {
-				fluid: {
-					maxViewPortWidth: settings?.layout?.wideSize,
-					...settings?.typography?.fluid,
-				},
-			} ),
+			getTypographyFontSizeValue(
+				preset,
+				!! settings?.typography?.fluid && settings?.layout?.wideSize
+					? {
+							fluid: {
+								maxViewPortWidth: settings?.layout?.wideSize,
+								...settings?.typography?.fluid,
+							},
+					  }
+					: {
+							fluid: settings?.typography?.fluid,
+					  }
+			),
 		valueKey: 'size',
 		cssVarInfix: 'font-size',
 		classes: [ { classSuffix: 'font-size', propertyName: 'font-size' } ],

--- a/packages/block-editor/src/components/global-styles/utils.js
+++ b/packages/block-editor/src/components/global-styles/utils.js
@@ -73,8 +73,13 @@ export const PRESET_METADATA = [
 	},
 	{
 		path: [ 'typography', 'fontSizes' ],
-		valueFunc: ( preset, { typography: typographySettings } ) =>
-			getTypographyFontSizeValue( preset, typographySettings ),
+		valueFunc: ( preset, settings ) =>
+			getTypographyFontSizeValue( preset, {
+				fluid: {
+					maxViewPortWidth: settings?.layout?.wideSize,
+					...settings?.typography?.fluid,
+				},
+			} ),
 		valueKey: 'size',
 		cssVarInfix: 'font-size',
 		classes: [ { classSuffix: 'font-size', propertyName: 'font-size' } ],

--- a/phpunit/block-supports/typography-test.php
+++ b/phpunit/block-supports/typography-test.php
@@ -432,6 +432,30 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 				'expected_output'             => 'clamp(17.905px, 1.119rem + ((1vw - 3.2px) * 0.789), 28px)',
 			),
 
+			'returns clamp value where min and max fluid values defined' => array(
+				'font_size'                   => array(
+					'size'  => '80px',
+					'fluid' => array(
+						'min' => '70px',
+						'max' => '125px',
+					),
+				),
+				'should_use_fluid_typography' => true,
+				'expected_output'             => 'clamp(70px, 4.375rem + ((1vw - 3.2px) * 4.297), 125px)',
+			),
+
+			'returns clamp value where max is equal to size' => array(
+				'font_size'                   => array(
+					'size'  => '7.8125rem',
+					'fluid' => array(
+						'min' => '4.375rem',
+						'max' => '7.8125rem',
+					),
+				),
+				'should_use_fluid_typography' => true,
+				'expected_output'             => 'clamp(4.375rem, 4.375rem + ((1vw - 0.2rem) * 4.298), 7.8125rem)',
+			),
+
 			'returns clamp value if min font size is greater than max' => array(
 				'font_size'                   => array(
 					'size'  => '3rem',

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -487,7 +487,7 @@
 										"type": "string"
 									},
 									"fluid": {
-										"description": "Specifics the minimum and maximum font size value of a fluid font size. Set to `false` to bypass fluid calculations and use the static `size` value.",
+										"description": "Specifies the minimum and maximum font size value of a fluid font size. Set to `false` to bypass fluid calculations and use the static `size` value.",
 										"oneOf": [
 											{
 												"type": "object",


### PR DESCRIPTION
Tracking issue: 
- https://github.com/WordPress/gutenberg/issues/44888

Fixes https://github.com/WordPress/gutenberg/issues/50929

## What?
#49815 added `settings.layout.wideSize` as the default value for the maximum viewport size in relation to calculating fluid font-size values.

Unfortunately this `maxViewPortWidth` value was not being passed to `getTypographyFontSizeValue()`.

This commit correct this omission and adds extra unit tests to both the JS and PHP versions.

Props to @WraithKenny for spotting it 🙇 

## Why?
As described in #50929, the site editor is outputting the wrong value when a `settings.layout.wideSize` value is set for the  theme. This is because it is completely ignored said value.

The backend outputs the correct value since it is taking into account `settings.layout.wideSize`.

## How?
Ensuring that `settings.layout.wideSize` is passed to `getTypographyFontSizeValue()`.

## Testing Instructions

Run tests!

```shell
npm run test:unit:php -- --filter WP_Block_Supports_Typography_Test
npm run test:unit packages/block-editor/src/components/global-styles/test/use-global-styles-output.js
npm run test:unit packages/block-editor/src/components/global-styles/test/typography-utils.js 
```

You can test using twentytwentythree theme!

Add some text to the site editor and to a post. Apply a font size, e.g., `xx-large`

```html
<!-- wp:paragraph {"fontSize":"xx-large"} -->
<p class="has-xx-large-font-size">Extra extra large</p>
<!-- /wp:paragraph -->
```

Save the post/site.

Now inspect the font-size CSS value while still in the editor.

Compare this value with what you see on the frontend.

The CSS preset value should match in the post editor, site editor and frontend.

Here's the class:

```css
.has-xx-large-font-size {
	font-size: var(--wp--preset--font-size--xx-large) !important;
}
```

And the preset:

```css
-wp--preset--font-size--xx-large: clamp(4rem, 4rem + ((1vw - 0.2rem) * 10.909), 10rem);
```


If you'd like to play around with the values, here is some test HTML and JSON.

<details>

<summary>Here is some example HTML</summary>

```html
<!-- wp:paragraph {"fontSize":"medium"} -->
<p class="has-medium-font-size">Medium</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph {"fontSize":"large"} -->
<p class="has-large-font-size">Large</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph {"fontSize":"x-large"} -->
<p class="has-x-large-font-size">Extra large</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph {"fontSize":"xx-large"} -->
<p class="has-xx-large-font-size">Extra extra large</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph -->
<p></p>
<!-- /wp:paragraph -->
```

</details>

<details>

<summary>Here is some example theme.json</summary>

```json
{
	"$schema": "https://schemas.wp.org/trunk/theme.json",
	"version": 2,
	"settings": {
		"appearanceTools": true,
		"layout": {
			"contentSize": "840px",
			"wideSize": "1100px"
		},
		"typography": {
			"fluid": true,
			"fontSizes": [
				{
					"fluid": {
						"min": "0.875rem",
						"max": "1rem"
					},
					"size": "1rem",
					"slug": "small"
				},
				{
					"fluid": {
						"min": "1rem",
						"max": "1.125rem"
					},
					"size": "1.125rem",
					"slug": "medium"
				},
				{
					"fluid": {
						"min": "1.75rem",
						"max": "1.875rem"
					},
					"size": "1.75rem",
					"slug": "large"
				},
				{
					"fluid": {
						"max": "125px",
						"min": "70px"
					},
					"size": "80px",
					"slug": "x-large"
				},
				{
					"fluid": {
						"max": "7.8125rem",
						"min": "4.375rem"
					},
					"size": "7.8125rem",
					"slug": "xx-large"
				}
			]
		}
	}
}

```

</details>


