### PR TITLE
Improvements to how blocks with a 'disabled' editing mode behave

### DIFF
--- a/packages/block-editor/src/components/block-list-appender/index.js
+++ b/packages/block-editor/src/components/block-list-appender/index.js
@@ -15,6 +15,7 @@ import { getDefaultBlockName } from '@wordpress/blocks';
 import DefaultBlockAppender from '../default-block-appender';
 import ButtonBlockAppender from '../button-block-appender';
 import { store as blockEditorStore } from '../../store';
+import { unlock } from '../../lock-unlock';
 
 function DefaultAppender( { rootClientId } ) {
 	const canInsertDefaultBlock = useSelect( ( select ) =>
@@ -46,13 +47,15 @@ function useAppender( rootClientId, CustomAppender ) {
 				getTemplateLock,
 				getSelectedBlockClientId,
 				__unstableGetEditorMode,
-			} = select( blockEditorStore );
+				getBlockEditingMode,
+			} = unlock( select( blockEditorStore ) );
 
 			const selectedBlockClientId = getSelectedBlockClientId();
 
 			return {
 				hideInserter:
 					!! getTemplateLock( rootClientId ) ||
+					getBlockEditingMode( rootClientId ) === 'disabled' ||
 					__unstableGetEditorMode() === 'zoom-out',
 				isParentSelected:
 					rootClientId === selectedBlockClientId ||

--- a/packages/block-editor/src/components/block-list/content.scss
+++ b/packages/block-editor/src/components/block-list/content.scss
@@ -161,15 +161,6 @@
 	padding: 0;
 }
 
-.block-editor-block-list__layout,
-.block-editor-block-list__block {
-	pointer-events: initial;
-
-	&.is-editing-disabled {
-		pointer-events: none;
-	}
-}
-
 .block-editor-block-list__layout .block-editor-block-list__block {
 	// With `position: static`, Safari marks a full-width selection rectangle, including margins.
 	// With `position: relative`, Safari marks an inline selection rectangle, similar to that of
@@ -178,11 +169,16 @@
 	// We choose relative, as that matches the multi-selection, which is limited to the block footprint.
 	position: relative;
 
-	// Re-enable text-selection on editable blocks.
-	user-select: text;
-
 	// Break long strings of text without spaces so they don't overflow the block.
 	overflow-wrap: break-word;
+
+	pointer-events: auto;
+	user-select: text;
+
+	&.is-editing-disabled {
+		pointer-events: none;
+		user-select: none;
+	}
 
 	.reusable-block-edit-panel * {
 		z-index: z-index(".block-editor-block-list__block .reusable-block-edit-panel *");

--- a/packages/block-editor/src/store/private-selectors.js
+++ b/packages/block-editor/src/store/private-selectors.js
@@ -6,7 +6,7 @@ import createSelector from 'rememo';
 /**
  * WordPress dependencies
  */
-import { createRegistrySelector } from '@wordpress/data';
+import { select } from '@wordpress/data';
 import { store as blocksStore } from '@wordpress/blocks';
 
 /**
@@ -71,37 +71,35 @@ export function getLastInsertedBlocksClientIds( state ) {
  * @return {BlockEditingMode} The block editing mode. One of `'disabled'`,
  *                            `'contentOnly'`, or `'default'`.
  */
-export const getBlockEditingMode = createRegistrySelector(
-	( select ) =>
-		( state, clientId = '' ) => {
-			const explicitEditingMode = getExplcitBlockEditingMode(
-				state,
-				clientId
-			);
-			const rootClientId = getBlockRootClientId( state, clientId );
-			const templateLock = getTemplateLock( state, rootClientId );
-			const name = getBlockName( state, clientId );
-			const isContent =
-				select( blocksStore ).__experimentalHasContentRoleAttribute(
-					name
-				);
-			if (
-				explicitEditingMode === 'disabled' ||
-				( templateLock === 'contentOnly' && ! isContent )
-			) {
-				return 'disabled';
-			}
-			if (
-				explicitEditingMode === 'contentOnly' ||
-				( templateLock === 'contentOnly' && isContent )
-			) {
-				return 'contentOnly';
-			}
-			return 'default';
-		}
-);
+export const getBlockEditingMode = ( state, clientId = '' ) => {
+	const explicitEditingMode = getExplicitBlockEditingMode( state, clientId );
+	const rootClientId = getBlockRootClientId( state, clientId );
+	const templateLock = getTemplateLock( state, rootClientId );
+	const name = getBlockName( state, clientId );
+	// TODO: Terrible hack! We're calling the global select() function here
+	// instead of using createRegistrySelector(). The problem with using
+	// createRegistrySelector() is that then the public block-editor selectors
+	// (e.g. canInsertBlockTypeUnmemoized) can't call this private block-editor
+	// selector due to a bug in @wordpress/data. See
+	// https://github.com/WordPress/gutenberg/pull/50985.
+	const isContent =
+		select( blocksStore ).__experimentalHasContentRoleAttribute( name );
+	if (
+		explicitEditingMode === 'disabled' ||
+		( templateLock === 'contentOnly' && ! isContent )
+	) {
+		return 'disabled';
+	}
+	if (
+		explicitEditingMode === 'contentOnly' ||
+		( templateLock === 'contentOnly' && isContent )
+	) {
+		return 'contentOnly';
+	}
+	return 'default';
+};
 
-const getExplcitBlockEditingMode = createSelector(
+const getExplicitBlockEditingMode = createSelector(
 	( state, clientId = '' ) => {
 		while (
 			! state.blockEditingModes.has( clientId ) &&

--- a/packages/block-editor/src/store/test/private-selectors.js
+++ b/packages/block-editor/src/store/test/private-selectors.js
@@ -1,4 +1,9 @@
 /**
+ * WordPress dependencies
+ */
+import { select } from '@wordpress/data';
+
+/**
  * Internal dependencies
  */
 import {
@@ -6,6 +11,10 @@ import {
 	getLastInsertedBlocksClientIds,
 	getBlockEditingMode,
 } from '../private-selectors';
+
+jest.mock( '@wordpress/data/src/select', () => ( {
+	select: jest.fn(),
+} ) );
 
 describe( 'private selectors', () => {
 	describe( 'isBlockInterfaceHidden', () => {
@@ -92,11 +101,9 @@ describe( 'private selectors', () => {
 		};
 
 		const __experimentalHasContentRoleAttribute = jest.fn( () => false );
-		getBlockEditingMode.registry = {
-			select: jest.fn( () => ( {
-				__experimentalHasContentRoleAttribute,
-			} ) ),
-		};
+		select.mockReturnValue( {
+			__experimentalHasContentRoleAttribute,
+		} );
 
 		it( 'should return default by default', () => {
 			expect(

--- a/packages/block-editor/src/store/test/selectors.js
+++ b/packages/block-editor/src/store/test/selectors.js
@@ -2693,11 +2693,13 @@ describe( 'selectors', () => {
 				blocks: {
 					byClientId: new Map(),
 					attributes: new Map(),
+					parents: new Map(),
 				},
 				blockListSettings: {},
 				settings: {
 					allowedBlockTypes: [ 'core/test-block-a' ],
 				},
+				blockEditingModes: new Map(),
 			};
 			expect( canInsertBlockType( state, 'core/test-block-a' ) ).toBe(
 				true
@@ -2720,14 +2722,36 @@ describe( 'selectors', () => {
 			);
 		} );
 
+		it( 'should deny blocks when the editor has a disabled editing mode', () => {
+			const state = {
+				blocks: {
+					byClientId: new Map(),
+					attributes: new Map(),
+					parents: new Map(),
+				},
+				blockListSettings: {},
+				settings: {},
+				blockEditingModes: new Map(
+					Object.entries( {
+						'': 'disabled',
+					} )
+				),
+			};
+			expect( canInsertBlockType( state, 'core/test-block-a' ) ).toBe(
+				false
+			);
+		} );
+
 		it( 'should deny blocks that restrict parent from being inserted into the root', () => {
 			const state = {
 				blocks: {
 					byClientId: new Map(),
 					attributes: new Map(),
+					parents: new Map(),
 				},
 				blockListSettings: {},
 				settings: {},
+				blockEditingModes: new Map(),
 			};
 			expect( canInsertBlockType( state, 'core/test-block-c' ) ).toBe(
 				false
@@ -2747,9 +2771,11 @@ describe( 'selectors', () => {
 							block1: {},
 						} )
 					),
+					parents: new Map(),
 				},
 				blockListSettings: {},
 				settings: {},
+				blockEditingModes: new Map(),
 			};
 			expect(
 				canInsertBlockType( state, 'core/test-block-c', 'block1' )
@@ -2769,11 +2795,13 @@ describe( 'selectors', () => {
 							block1: {},
 						} )
 					),
+					parents: new Map(),
 				},
 				blockListSettings: {
 					block1: {},
 				},
 				settings: {},
+				blockEditingModes: new Map(),
 			};
 			expect(
 				canInsertBlockType( state, 'core/test-block-c', 'block1' )
@@ -2793,11 +2821,13 @@ describe( 'selectors', () => {
 							block1: {},
 						} )
 					),
+					parents: new Map(),
 				},
 				blockListSettings: {
 					block1: {},
 				},
 				settings: {},
+				blockEditingModes: new Map(),
 			};
 			expect(
 				canInsertBlockType( state, 'core/test-block-c', 'block1' )
@@ -2817,6 +2847,7 @@ describe( 'selectors', () => {
 							block1: {},
 						} )
 					),
+					parents: new Map(),
 				},
 				blockListSettings: {
 					block1: {
@@ -2824,6 +2855,7 @@ describe( 'selectors', () => {
 					},
 				},
 				settings: {},
+				blockEditingModes: new Map(),
 			};
 			expect(
 				canInsertBlockType( state, 'core/test-block-b', 'block1' )
@@ -2843,6 +2875,7 @@ describe( 'selectors', () => {
 							block1: {},
 						} )
 					),
+					parents: new Map(),
 				},
 				blockListSettings: {
 					block1: {
@@ -2850,10 +2883,39 @@ describe( 'selectors', () => {
 					},
 				},
 				settings: {},
+				blockEditingModes: new Map(),
 			};
 			expect(
 				canInsertBlockType( state, 'core/test-block-b', 'block1' )
 			).toBe( true );
+		} );
+
+		it( 'should deny blocks from being inserted into a block that has a disabled editing mode', () => {
+			const state = {
+				blocks: {
+					byClientId: new Map(
+						Object.entries( {
+							block1: { name: 'core/test-block-a' },
+						} )
+					),
+					attributes: new Map(
+						Object.entries( {
+							block1: {},
+						} )
+					),
+					parents: new Map(),
+				},
+				blockListSettings: {},
+				settings: {},
+				blockEditingModes: new Map(
+					Object.entries( {
+						block1: 'disabled',
+					} )
+				),
+			};
+			expect(
+				canInsertBlockType( state, 'core/test-block-b', 'block1' )
+			).toBe( false );
 		} );
 
 		it( 'should prioritise parent over allowedBlocks', () => {
@@ -2869,6 +2931,7 @@ describe( 'selectors', () => {
 							block1: {},
 						} )
 					),
+					parents: new Map(),
 				},
 				blockListSettings: {
 					block1: {
@@ -2876,6 +2939,7 @@ describe( 'selectors', () => {
 					},
 				},
 				settings: {},
+				blockEditingModes: new Map(),
 			};
 			expect(
 				canInsertBlockType( state, 'core/test-block-c', 'block1' )
@@ -2895,9 +2959,11 @@ describe( 'selectors', () => {
 							block1: {},
 						} )
 					),
+					parents: new Map(),
 				},
 				blockListSettings: {},
 				settings: {},
+				blockEditingModes: new Map(),
 			};
 			expect(
 				canInsertBlockType( state, 'core/post-content-child', 'block1' )
@@ -2909,9 +2975,11 @@ describe( 'selectors', () => {
 				blocks: {
 					byClientId: new Map(),
 					attributes: new Map(),
+					parents: new Map(),
 				},
 				blockListSettings: {},
 				settings: {},
+				blockEditingModes: new Map(),
 			};
 			expect(
 				canInsertBlockType( state, 'core/post-content-child' )
@@ -2944,6 +3012,7 @@ describe( 'selectors', () => {
 					block2: {},
 				},
 				settings: {},
+				blockEditingModes: new Map(),
 			};
 			expect(
 				canInsertBlockType(
@@ -2984,6 +3053,7 @@ describe( 'selectors', () => {
 					block3: {},
 				},
 				settings: {},
+				blockEditingModes: new Map(),
 			};
 			expect(
 				canInsertBlockType(
@@ -3023,6 +3093,7 @@ describe( 'selectors', () => {
 					block3: {},
 				},
 				settings: {},
+				blockEditingModes: new Map(),
 			};
 			expect(
 				canInsertBlockType(
@@ -3062,6 +3133,7 @@ describe( 'selectors', () => {
 					block3: {},
 				},
 				settings: {},
+				blockEditingModes: new Map(),
 			};
 			expect(
 				canInsertBlockType(
@@ -3100,6 +3172,7 @@ describe( 'selectors', () => {
 					},
 				},
 				settings: {},
+				blockEditingModes: new Map(),
 			};
 			expect(
 				canInsertBlockType(
@@ -3136,6 +3209,7 @@ describe( 'selectors', () => {
 					block2: {},
 				},
 				settings: {},
+				blockEditingModes: new Map(),
 			};
 			expect(
 				canInsertBlockType(
@@ -3165,6 +3239,7 @@ describe( 'selectors', () => {
 							3: {},
 						} )
 					),
+					parents: new Map(),
 				},
 				blockListSettings: {
 					1: {
@@ -3175,6 +3250,7 @@ describe( 'selectors', () => {
 					},
 				},
 				settings: {},
+				blockEditingModes: new Map(),
 			};
 			expect( canInsertBlocks( state, [ '2', '3' ], '1' ) ).toBe( true );
 		} );
@@ -3196,6 +3272,7 @@ describe( 'selectors', () => {
 							3: {},
 						} )
 					),
+					parents: new Map(),
 				},
 				blockListSettings: {
 					1: {
@@ -3203,6 +3280,7 @@ describe( 'selectors', () => {
 					},
 				},
 				settings: {},
+				blockEditingModes: new Map(),
 			};
 			expect( canInsertBlocks( state, [ '2', '3' ], '1' ) ).toBe( false );
 		} );
@@ -3241,6 +3319,7 @@ describe( 'selectors', () => {
 				// See: https://github.com/WordPress/gutenberg/issues/14580
 				preferences: {},
 				blockListSettings: {},
+				blockEditingModes: new Map(),
 			};
 			const items = getInserterItems( state );
 			const testBlockAItem = items.find(
@@ -3349,6 +3428,7 @@ describe( 'selectors', () => {
 					block3: {},
 					block4: {},
 				},
+				blockEditingModes: new Map(),
 			};
 
 			const stateSecondBlockRestricted = {
@@ -3436,6 +3516,7 @@ describe( 'selectors', () => {
 				},
 				blockListSettings: {},
 				settings: {},
+				blockEditingModes: new Map(),
 			};
 			const items = getInserterItems( state );
 			const testBlockBItem = items.find(
@@ -3460,6 +3541,7 @@ describe( 'selectors', () => {
 				},
 				blockListSettings: {},
 				settings: {},
+				blockEditingModes: new Map(),
 			};
 			const items = getInserterItems( state );
 			const reusableBlock2Item = items.find(
@@ -3551,6 +3633,7 @@ describe( 'selectors', () => {
 				settings: {},
 				preferences: {},
 				blockListSettings: {},
+				blockEditingModes: new Map(),
 			};
 			const blocks = [ { name: 'core/with-tranforms-a' } ];
 			const items = getBlockTransformItems( state, blocks );
@@ -3591,6 +3674,7 @@ describe( 'selectors', () => {
 				settings: {},
 				preferences: {},
 				blockListSettings: {},
+				blockEditingModes: new Map(),
 			};
 			const block = { name: 'core/with-tranforms-a' };
 			const items = getBlockTransformItems( state, block );
@@ -3629,6 +3713,7 @@ describe( 'selectors', () => {
 					},
 					block2: {},
 				},
+				blockEditingModes: new Map(),
 			};
 			const blocks = [
 				{ clientId: 'block2', name: 'core/with-tranforms-a' },
@@ -3676,6 +3761,7 @@ describe( 'selectors', () => {
 				},
 				blockListSettings: {},
 				settings: {},
+				blockEditingModes: new Map(),
 			};
 			const blocks = [ { name: 'core/with-tranforms-a' } ];
 			const items = getBlockTransformItems( state, blocks );
@@ -3709,6 +3795,7 @@ describe( 'selectors', () => {
 				},
 				blockListSettings: {},
 				settings: {},
+				blockEditingModes: new Map(),
 			};
 			const blocks = [ { name: 'core/with-tranforms-c' } ];
 			const items = getBlockTransformItems( state, blocks );
@@ -4121,6 +4208,12 @@ describe( 'selectors', () => {
 						block2: {},
 					} )
 				),
+				parents: new Map(
+					Object.entries( {
+						block1: '',
+						block2: '',
+					} )
+				),
 			},
 			blockListSettings: {
 				block1: {
@@ -4152,6 +4245,7 @@ describe( 'selectors', () => {
 					},
 				],
 			},
+			blockEditingModes: new Map(),
 		};
 
 		it( 'should return all patterns for root level', () => {
@@ -4249,6 +4343,7 @@ describe( 'selectors', () => {
 						block1: { name: 'core/test-block-a' },
 					} )
 				),
+				parents: new Map(),
 			},
 			blockListSettings: {
 				block1: {
@@ -4279,6 +4374,7 @@ describe( 'selectors', () => {
 					},
 				],
 			},
+			blockEditingModes: new Map(),
 		};
 		it( 'should return empty array if no block name is provided', () => {
 			expect( getPatternsByBlockTypes( state ) ).toEqual( [] );
@@ -4329,6 +4425,7 @@ describe( 'selectors', () => {
 						block2: { name: 'core/test-block-b' },
 					} )
 				),
+				parents: new Map(),
 				controlledInnerBlocks: { 'block2-clientId': true },
 			},
 			blockListSettings: {
@@ -4371,6 +4468,7 @@ describe( 'selectors', () => {
 					},
 				],
 			},
+			blockEditingModes: new Map(),
 		};
 		describe( 'should return empty array', () => {
 			it( 'when no blocks are selected', () => {
@@ -4591,6 +4689,7 @@ describe( 'getInserterItems with core blocks prioritization', () => {
 			settings: {},
 			preferences: {},
 			blockListSettings: {},
+			blockEditingModes: new Map(),
 		};
 		const items = getInserterItems( state );
 		const expectedResult = [


### PR DESCRIPTION
## What?
Follows https://github.com/WordPress/gutenberg/pull/50643.

Split out of https://github.com/WordPress/gutenberg/pull/50857.

Various improvements to how blocks that have `useBlockEditingMode( 'disabled' )` behave.

- Prevent `DefaultAppender` from appearing in a disabled block.
- Disable selection (using `user-select: none`) in disabled blocks.
- Prevent blocks from being inserted into a disabled block via global inserter.
- Prevent disabled blocks from being removed via keyboard shortcut.
- Prevent disabled blocks from being moved via List View drag and drop.
- Prevent block overlay from appearing on a disabled block.

## Why?
See https://github.com/WordPress/gutenberg/pull/50857.

## How?
Mostly the changes are at the model level (`canInsertBlockType`, `canMoveBlock`, `canRemoveBlock`, etc.). Most of the block editor uses these methods to determine which bits of UI to display.

## Testing Instructions
1. Apply the patch below by copying it and running `pbpaste | git apply`.

```diff
diff --git a/packages/edit-site/src/components/block-editor/index.js b/packages/edit-site/src/components/block-editor/index.js
index cc5e7c8d92..f97599a9b5 100644
--- a/packages/edit-site/src/components/block-editor/index.js
+++ b/packages/edit-site/src/components/block-editor/index.js
@@ -39,7 +39,9 @@ import EditorCanvas from './editor-canvas';
 import { unlock } from '../../private-apis';
 import EditorCanvasContainer from '../editor-canvas-container';
 
-const { ExperimentalBlockEditorProvider } = unlock( blockEditorPrivateApis );
+const { ExperimentalBlockEditorProvider, useBlockEditingMode } = unlock(
+	blockEditorPrivateApis
+);
 
 const LAYOUT = {
 	type: 'default',
@@ -47,6 +49,11 @@ const LAYOUT = {
 	alignments: [],
 };
 
+function SetRootBlockEditingMode( { mode } ) {
+	useBlockEditingMode( mode );
+	return null;
+}
+
 export default function BlockEditor() {
 	const { setIsInserterOpened } = useDispatch( editSiteStore );
 	const { storedSettings, templateType, canvasMode } = useSelect(
@@ -162,6 +169,7 @@ export default function BlockEditor() {
 			onChange={ onChange }
 			useSubRegistry={ false }
 		>
+			<SetRootBlockEditingMode mode="disabled" />
 			<TemplatePartConverter />
 			<SidebarInspectorFill>
 				<BlockInspector />
diff --git a/packages/edit-site/src/hooks/block-editing-mode.js b/packages/edit-site/src/hooks/block-editing-mode.js
new file mode 100644
index 0000000000..24d63f122f
--- /dev/null
+++ b/packages/edit-site/src/hooks/block-editing-mode.js
@@ -0,0 +1,50 @@
+/**
+ * WordPress dependencies
+ */
+import { createHigherOrderComponent } from '@wordpress/compose';
+import { addFilter } from '@wordpress/hooks';
+import {
+	store as blockEditorStore,
+	privateApis as blockEditorPrivateApis,
+} from '@wordpress/block-editor';
+import { useSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { unlock } from '../private-apis';
+
+const { useBlockEditingMode } = unlock( blockEditorPrivateApis );
+
+export const withBlockEditingMode = createHigherOrderComponent(
+	( BlockEdit ) => ( props ) => {
+		const mode = useSelect( ( select ) => {
+			if (
+				[
+					'core/post-title',
+					'core/post-featured-image',
+					'core/post-content',
+				].includes( props.name )
+			) {
+				return 'contentOnly';
+			}
+			if (
+				select( blockEditorStore ).getBlockParentsByBlockName(
+					props.clientId,
+					'core/post-content'
+				).length
+			) {
+				return 'default';
+			}
+		} );
+		useBlockEditingMode( mode );
+		return <BlockEdit { ...props } />;
+	},
+	'withBlockEditingMode'
+);
+
+addFilter(
+	'editor.BlockEdit',
+	'core/edit-site/block-editing-mode',
+	withBlockEditingMode
+);
diff --git a/packages/edit-site/src/hooks/index.js b/packages/edit-site/src/hooks/index.js
index 513634c55b..de9dc8c3f7 100644
--- a/packages/edit-site/src/hooks/index.js
+++ b/packages/edit-site/src/hooks/index.js
@@ -1,6 +1,7 @@
 /**
  * Internal dependencies
  */
+import './block-editing-mode';
 import './components';
 import './push-changes-to-global-styles';
 import './template-part-edit';

```

2. Navigate to Appearance → Editor → Pages and select a page to edit.
3. All blocks should be locked except for the Post Title, Post Featured Image and Post Content blocks.
4. Check:
  - That the appender does not appear at the bottom of the editor, but does appear in the Post Content block.
  - That double clicking or dragging on a disabled block doesn't select it.
  - That when you open the global inserter with no block selected, you can't select a block to insert.
  - That blocks in the List View can't be dragged and dropped.