### PR TITLE
Styles Screen: Add link to global styles revisions

### DIFF
--- a/packages/edit-site/src/components/global-styles/ui.js
+++ b/packages/edit-site/src/components/global-styles/ui.js
@@ -237,7 +237,7 @@ function GlobalStylesBlockLink() {
 	}, [ selectedBlockClientId, selectedBlockName, blockHasGlobalStyles ] );
 }
 
-function GlobalStylesRevisionLink() {
+function GlobalStylesEditorCanvasContainerLink() {
 	const { goTo } = useNavigator();
 	const editorCanvasContainerView = useSelect(
 		( select ) =>
@@ -245,12 +245,18 @@ function GlobalStylesRevisionLink() {
 		[]
 	);
 
-	// If the user is in the global styles editor canvas container view, redirect
-	// them to the revisions screen. This effectively allows deep linking to the
-	// revisions screen from outside the global styles navigation provider.
+	// If the user switches the editor canvas container view, redirect
+	// to the appropriate screen. This effectively allows deep linking to the
+	// desired screens from outside the global styles navigation provider.
 	useEffect( () => {
 		if ( editorCanvasContainerView === 'global-styles-revisions' ) {
+			// Switching to the revisions container view should
+			// redirect to the revisions screen.
 			goTo( '/revisions' );
+		} else if ( editorCanvasContainerView === 'style-book' ) {
+			// Switching to the style book container view should
+			// redirect to the style book screen.
+			goTo( '/' );
 		}
 	}, [ editorCanvasContainerView, goTo ] );
 }
@@ -344,7 +350,7 @@ function GlobalStylesUI() {
 
 			<GlobalStylesActionMenu />
 			<GlobalStylesBlockLink />
-			<GlobalStylesRevisionLink />
+			<GlobalStylesEditorCanvasContainerLink />
 		</NavigatorProvider>
 	);
 }

--- a/packages/edit-site/src/components/global-styles/ui.js
+++ b/packages/edit-site/src/components/global-styles/ui.js
@@ -237,6 +237,24 @@ function GlobalStylesBlockLink() {
 	}, [ selectedBlockClientId, selectedBlockName, blockHasGlobalStyles ] );
 }
 
+function GlobalStylesRevisionLink() {
+	const { goTo } = useNavigator();
+	const editorCanvasContainerView = useSelect(
+		( select ) =>
+			unlock( select( editSiteStore ) ).getEditorCanvasContainerView(),
+		[]
+	);
+
+	// If the user is in the global styles editor canvas container view, redirect
+	// them to the revisions screen. This effectively allows deep linking to the
+	// revisions screen from outside of the global styles navigation provider.
+	useEffect( () => {
+		if ( editorCanvasContainerView === 'global-styles-revisions' ) {
+			goTo( '/revisions' );
+		}
+	}, [ editorCanvasContainerView, goTo ] );
+}
+
 function GlobalStylesUI() {
 	const blocks = getBlockTypes();
 	const editorCanvasContainerView = useSelect(
@@ -326,6 +344,7 @@ function GlobalStylesUI() {
 
 			<GlobalStylesActionMenu />
 			<GlobalStylesBlockLink />
+			<GlobalStylesRevisionLink />
 		</NavigatorProvider>
 	);
 }

--- a/packages/edit-site/src/components/global-styles/ui.js
+++ b/packages/edit-site/src/components/global-styles/ui.js
@@ -247,7 +247,7 @@ function GlobalStylesRevisionLink() {
 
 	// If the user is in the global styles editor canvas container view, redirect
 	// them to the revisions screen. This effectively allows deep linking to the
-	// revisions screen from outside of the global styles navigation provider.
+	// revisions screen from outside the global styles navigation provider.
 	useEffect( () => {
 		if ( editorCanvasContainerView === 'global-styles-revisions' ) {
 			goTo( '/revisions' );

--- a/packages/edit-site/src/components/global-styles/ui.js
+++ b/packages/edit-site/src/components/global-styles/ui.js
@@ -238,7 +238,7 @@ function GlobalStylesBlockLink() {
 }
 
 function GlobalStylesEditorCanvasContainerLink() {
-	const { goTo } = useNavigator();
+	const { goTo, location } = useNavigator();
 	const editorCanvasContainerView = useSelect(
 		( select ) =>
 			unlock( select( editSiteStore ) ).getEditorCanvasContainerView(),
@@ -253,12 +253,15 @@ function GlobalStylesEditorCanvasContainerLink() {
 			// Switching to the revisions container view should
 			// redirect to the revisions screen.
 			goTo( '/revisions' );
-		} else if ( editorCanvasContainerView === 'style-book' ) {
+		} else if (
+			editorCanvasContainerView === 'style-book' &&
+			location?.path === '/revisions'
+		) {
 			// Switching to the style book container view should
 			// redirect to the style book screen.
 			goTo( '/' );
 		}
-	}, [ editorCanvasContainerView, goTo ] );
+	}, [ editorCanvasContainerView, location?.path, goTo ] );
 }
 
 function GlobalStylesUI() {

--- a/packages/edit-site/src/components/global-styles/ui.js
+++ b/packages/edit-site/src/components/global-styles/ui.js
@@ -254,11 +254,11 @@ function GlobalStylesEditorCanvasContainerLink() {
 			// redirect to the revisions screen.
 			goTo( '/revisions' );
 		} else if (
-			editorCanvasContainerView === 'style-book' &&
+			!! editorCanvasContainerView &&
 			location?.path === '/revisions'
 		) {
-			// Switching to the style book container view should
-			// redirect to the style book screen.
+			// Switching to any container other than revisions should
+			// redirect from the revisions screen to the root global styles screen.
 			goTo( '/' );
 		}
 	}, [ editorCanvasContainerView, location?.path, goTo ] );

--- a/packages/edit-site/src/components/sidebar-navigation-screen-global-styles/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-global-styles/index.js
@@ -119,6 +119,7 @@ function SidebarNavigationScreenGlobalStylesFooter( { onClickRevisions } ) {
 				onClick={ onClickRevisions }
 			>
 				<HStack
+					as="span"
 					alignment="center"
 					spacing={ 5 }
 					direction="row"

--- a/packages/edit-site/src/components/sidebar-navigation-screen-global-styles/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-global-styles/index.js
@@ -107,7 +107,6 @@ function SidebarNavigationScreenGlobalStylesFooter( { onClickRevisions } ) {
 	}, [] );
 
 	const hasRevisions = revisionsCount >= 2;
-
 	const { modified } = revisions?.[ 0 ] || {};
 
 	if ( ! hasRevisions || isLoading || ! modified ) {
@@ -118,6 +117,7 @@ function SidebarNavigationScreenGlobalStylesFooter( { onClickRevisions } ) {
 		<VStack>
 			<SidebarNavigationItem
 				className="edit-site-sidebar-navigation-screen-global-styles__revisions"
+				label={ __( 'Revisions' ) }
 				onClick={ onClickRevisions }
 			>
 				<HStack
@@ -129,17 +129,12 @@ function SidebarNavigationScreenGlobalStylesFooter( { onClickRevisions } ) {
 					<span className="edit-site-sidebar-navigation-screen-global-styles__revisions__label">
 						{ __( 'Last modified' ) }
 					</span>
-
 					<span>
 						<time dateTime={ modified }>
 							{ humanTimeDiff( modified ) }
 						</time>
 					</span>
-
-					<Icon
-						icon={ backup }
-						style={ { fill: 'currentcolor', marginRight: '8px' } }
-					/>
+					<Icon icon={ backup } style={ { fill: 'currentcolor' } } />
 				</HStack>
 			</SidebarNavigationItem>
 		</VStack>

--- a/packages/edit-site/src/components/sidebar-navigation-screen-global-styles/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-global-styles/index.js
@@ -112,7 +112,7 @@ function SidebarNavigationScreenGlobalStylesFooter( { onClickRevisions } ) {
 	}
 
 	return (
-		<VStack>
+		<VStack className="edit-site-sidebar-navigation-screen-global-styles__footer">
 			<SidebarNavigationItem
 				className="edit-site-sidebar-navigation-screen-global-styles__revisions"
 				label={ __( 'Revisions' ) }

--- a/packages/edit-site/src/components/sidebar-navigation-screen-global-styles/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-global-styles/index.js
@@ -77,15 +77,13 @@ function SidebarNavigationScreenGlobalStylesContent() {
 	// rendering the iframe. Without this, the iframe previews will not render
 	// in mobile viewport sizes, where the editor canvas is hidden.
 	return (
-		<>
-			<BlockEditorProvider
-				settings={ storedSettings }
-				onChange={ noop }
-				onInput={ noop }
-			>
-				<StyleVariationsContainer />
-			</BlockEditorProvider>
-		</>
+		<BlockEditorProvider
+			settings={ storedSettings }
+			onChange={ noop }
+			onInput={ noop }
+		>
+			<StyleVariationsContainer />
+		</BlockEditorProvider>
 	);
 }
 
@@ -107,7 +105,7 @@ function SidebarNavigationScreenGlobalStylesFooter( { onClickRevisions } ) {
 	}, [] );
 
 	const hasRevisions = revisionsCount >= 2;
-	const { modified } = revisions?.[ 0 ] || {};
+	const modified = revisions?.[ 0 ]?.modified;
 
 	if ( ! hasRevisions || isLoading || ! modified ) {
 		return null;
@@ -164,13 +162,13 @@ export default function SidebarNavigationScreenGlobalStyles() {
 		[ setCanvasMode, openGeneralSidebar ]
 	);
 
-	const openStyleBook = async () => {
+	const openStyleBook = useCallback( async () => {
 		await openGlobalStyles();
 		// Open the Style Book once the canvas mode is set to edit,
 		// and the global styles sidebar is open. This ensures that
 		// the Style Book is not prematurely closed.
 		setEditorCanvasContainerView( 'style-book' );
-	};
+	}, [ openGlobalStyles, setEditorCanvasContainerView ] );
 
 	const openRevisions = useCallback( async () => {
 		await openGlobalStyles();

--- a/packages/edit-site/src/components/sidebar-navigation-screen-global-styles/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-global-styles/style.scss
@@ -1,0 +1,9 @@
+.edit-site-sidebar-navigation-screen-global-styles__revisions {
+	&:not(:hover) {
+		color: $gray-200;
+
+		.edit-site-sidebar-navigation-screen-global-styles__revisions__label {
+			color: $gray-600;
+		}
+	}
+}

--- a/packages/edit-site/src/components/sidebar-navigation-screen-global-styles/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-global-styles/style.scss
@@ -1,4 +1,10 @@
+.edit-site-sidebar-navigation-screen-global-styles__footer {
+	padding-left: $grid-unit-15;
+}
+
 .edit-site-sidebar-navigation-screen-global-styles__revisions {
+	border-radius: $radius-block-ui;
+
 	&:not(:hover) {
 		color: $gray-200;
 

--- a/packages/edit-site/src/components/sidebar-navigation-screen-page/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-page/index.js
@@ -147,7 +147,10 @@ export default function SidebarNavigationScreenPage() {
 					<HStack
 						spacing={ 5 }
 						alignment="left"
-						className="edit-site-sidebar-navigation-screen-page__details"
+						className={ classnames(
+							'edit-site-sidebar-navigation-screen-page__details',
+							'edit-site-sidebar-navigation-screen-page__footer'
+						) }
 					>
 						<Text className="edit-site-sidebar-navigation-screen-page__details-label">
 							{ __( 'Last modified' ) }

--- a/packages/edit-site/src/components/sidebar-navigation-screen-page/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-page/index.js
@@ -147,10 +147,7 @@ export default function SidebarNavigationScreenPage() {
 					<HStack
 						spacing={ 5 }
 						alignment="left"
-						className={ classnames(
-							'edit-site-sidebar-navigation-screen-page__details',
-							'edit-site-sidebar-navigation-screen-page__footer'
-						) }
+						className="edit-site-sidebar-navigation-screen-page__details edit-site-sidebar-navigation-screen-page__footer"
 					>
 						<Text className="edit-site-sidebar-navigation-screen-page__details-label">
 							{ __( 'Last modified' ) }

--- a/packages/edit-site/src/components/sidebar-navigation-screen-page/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-page/style.scss
@@ -61,6 +61,12 @@
 	}
 }
 
+.edit-site-sidebar-navigation-screen-page__footer {
+	padding-top: $grid-unit-10;
+	padding-bottom: $grid-unit-10;
+	padding-left: $grid-unit-20;
+}
+
 .edit-site-sidebar-navigation-screen-page__details {
 	.edit-site-sidebar-navigation-screen-page__details-label {
 		color: $gray-600;

--- a/packages/edit-site/src/components/sidebar-navigation-screen/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen/index.js
@@ -42,74 +42,80 @@ export default function SidebarNavigationScreen( {
 	const theme = getTheme( currentlyPreviewingTheme() );
 
 	return (
-		<VStack spacing={ 0 }>
-			<HStack
-				spacing={ 4 }
-				alignment="flex-start"
-				className="edit-site-sidebar-navigation-screen__title-icon"
+		<>
+			<VStack
+				className="edit-site-sidebar-navigation-screen__main"
+				spacing={ 0 }
+				justify="flex-start"
 			>
-				{ ! isRoot ? (
-					<NavigatorToParentButton
-						as={ SidebarButton }
-						icon={ isRTL() ? chevronRight : chevronLeft }
-						label={ __( 'Back' ) }
-					/>
-				) : (
-					<SidebarButton
-						icon={ isRTL() ? chevronRight : chevronLeft }
-						label={
-							! isPreviewingTheme()
-								? __( 'Go back to the Dashboard' )
-								: __( 'Go back to the theme showcase' )
-						}
-						href={
-							! isPreviewingTheme()
-								? dashboardLink || 'index.php'
-								: 'themes.php'
-						}
-					/>
-				) }
-				<Heading
-					className="edit-site-sidebar-navigation-screen__title"
-					color={ 'white' }
-					level={ 2 }
-					size={ 20 }
+				<HStack
+					spacing={ 4 }
+					alignment="flex-start"
+					className="edit-site-sidebar-navigation-screen__title-icon"
 				>
-					{ ! isPreviewingTheme()
-						? title
-						: sprintf(
-								'Previewing %1$s: %2$s',
-								theme?.name?.rendered,
-								title
-						  ) }
-				</Heading>
-				{ actions && (
-					<div className="edit-site-sidebar-navigation-screen__actions">
-						{ actions }
-					</div>
+					{ ! isRoot ? (
+						<NavigatorToParentButton
+							as={ SidebarButton }
+							icon={ isRTL() ? chevronRight : chevronLeft }
+							label={ __( 'Back' ) }
+						/>
+					) : (
+						<SidebarButton
+							icon={ isRTL() ? chevronRight : chevronLeft }
+							label={
+								! isPreviewingTheme()
+									? __( 'Go back to the Dashboard' )
+									: __( 'Go back to the theme showcase' )
+							}
+							href={
+								! isPreviewingTheme()
+									? dashboardLink || 'index.php'
+									: 'themes.php'
+							}
+						/>
+					) }
+					<Heading
+						className="edit-site-sidebar-navigation-screen__title"
+						color={ 'white' }
+						level={ 2 }
+						size={ 20 }
+					>
+						{ ! isPreviewingTheme()
+							? title
+							: sprintf(
+									'Previewing %1$s: %2$s',
+									theme?.name?.rendered,
+									title
+							  ) }
+					</Heading>
+					{ actions && (
+						<div className="edit-site-sidebar-navigation-screen__actions">
+							{ actions }
+						</div>
+					) }
+				</HStack>
+				{ meta && (
+					<>
+						<div className="edit-site-sidebar-navigation-screen__meta">
+							{ meta }
+						</div>
+					</>
 				) }
-			</HStack>
-			{ meta && (
-				<>
-					<div className="edit-site-sidebar-navigation-screen__meta">
-						{ meta }
-					</div>
-				</>
-			) }
 
-			<nav className="edit-site-sidebar-navigation-screen__content">
-				{ description && (
-					<p className="edit-site-sidebar-navigation-screen__description">
-						{ description }
-					</p>
-				) }
-				{ content }
-			</nav>
+				<nav className="edit-site-sidebar-navigation-screen__content">
+					{ description && (
+						<p className="edit-site-sidebar-navigation-screen__description">
+							{ description }
+						</p>
+					) }
+					{ content }
+				</nav>
+			</VStack>
 			{ footer && (
-				<footer className="edit-site-sidebar-navigation-screen__sticky-section">
+				<footer className="edit-site-sidebar-navigation-screen__footer">
 					{ footer }
 				</footer>
 			) }
-		</VStack>
+		</>
 	);
 }

--- a/packages/edit-site/src/components/sidebar-navigation-screen/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-screen/style.scss
@@ -5,6 +5,12 @@
 	position: relative;
 }
 
+.edit-site-sidebar-navigation-screen__main {
+	// Ensure the sidebar is always at least as tall as the viewport.
+	// This allows the footer section to be sticky at the bottom of the viewport.
+	flex-grow: 1;
+}
+
 .edit-site-sidebar-navigation-screen__content {
 	margin: 0 0 $grid-unit-20 0;
 	color: $gray-400;
@@ -85,4 +91,11 @@
 	padding: $grid-unit-40 0;
 	margin: $grid-unit-40 $grid-unit-20;
 	border-top: 1px solid $gray-800;
+}
+
+.edit-site-sidebar-navigation-screen__footer {
+	position: sticky;
+	bottom: 0;
+	background-color: $gray-900;
+	padding: $grid-unit-20 0;
 }

--- a/packages/edit-site/src/components/sidebar/style.scss
+++ b/packages/edit-site/src/components/sidebar/style.scss
@@ -5,6 +5,9 @@
 	.components-navigator-screen {
 		@include custom-scrollbars-on-hover(transparent, $gray-700);
 		scrollbar-gutter: stable;
+		display: flex;
+		flex-direction: column;
+		height: 100%;
 	}
 }
 

--- a/packages/edit-site/src/style.scss
+++ b/packages/edit-site/src/style.scss
@@ -27,6 +27,7 @@
 @import "./components/sidebar-button/style.scss";
 @import "./components/sidebar-navigation-item/style.scss";
 @import "./components/sidebar-navigation-screen/style.scss";
+@import "./components/sidebar-navigation-screen-global-styles/style.scss";
 @import "./components/sidebar-navigation-screen-page/style.scss";
 @import "./components/sidebar-navigation-screen-template/style.scss";
 @import "./components/sidebar-navigation-screen-templates/style.scss";


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes https://github.com/WordPress/gutenberg/issues/50429

Add a revisions button to the Styles screen in the site editor's browse mode. Clicking the button exits browse mode, and opens up the site editor proper, with the Revisions screen open.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

As mentioned in #50429, it's helpful to provide quick access to the revisions for global styles.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* Add a button to the footer area for the global styles screen in browse mode, displaying the last modified date of the latest revision, the human time, and a revisions icon
* If there are no revisions, or if the revisions haven't loaded, don't display a button at all
* Clicking the button switches to the edit mode for the canvas, and opens the global styles revisions container
* Because we can't update navigation for the global styles sidebar within the editor from outside its navigation provider, add a `useEffect` so that switching to the global styles revisions editor canvas container causes the path to be updated to navigate to the revisions screen. This follows similar behaviour introduced in #49350 by @ntsekouras for linking to the block type panel. I tried a few different approaches, and this seemed the simplest, but happy for any feedback if folks think there are any issues with it!

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. In a blocks-based theme with global styles revisions, open up the site editor and navigate to Styles in browse mode
2. Notice that there should now be a button in the footer area beneath the style variations for selecting revisions
3. Click the button, and the Revisions view in the site editor should open up
4. Click the W icon to go back to the Styles screen
5. Click the editor canvas, and it should open up, but the Revisions screen should not be open
6. Double-check that opening/closing the Revisions screen otherwise works as before

## Questions for the reviewer

* The button design doesn't _quite_ match #50429 — I tried to keep things simple and re-use the footer area of the screen. Please let me know if the button styling should be tweaked. For example, the text elements are spaced via `space-between` but I wasn't sure if more specific spacing was required.
* The text says `Last modified` irrespective of the saved status of the current revision — so if changes have been made but not saved, the text is the same. Is this okay? We already have `1 unsaved change` next to the Save button when there are unsaved changes, so I thought it could be redundant to swap out `Last modified` for `unsaved` 🤔 

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

Check that the button on the Styles screen can be tabbed to. Is the label `Revisions` enough for this button?

## Screenshots or screencast <!-- if applicable -->

The Styles screen — note the addition of the `Last modified` button / row at the bottom left:

![image](https://github.com/WordPress/gutenberg/assets/14988353/afcb9b41-d24a-4de9-87c6-85d7f3b5e458)

https://github.com/WordPress/gutenberg/assets/14988353/6ee1d676-f6e6-4805-9ef5-1f927e28e566