### PR TITLE
Rename directives suffix character and island directive in the Interactivity API

### DIFF
--- a/lib/experimental/interactivity-api/blocks.php
+++ b/lib/experimental/interactivity-api/blocks.php
@@ -21,9 +21,9 @@ function gutenberg_block_core_file_add_directives_to_content( $block_content, $b
 	}
 	$processor = new WP_HTML_Tag_Processor( $block_content );
 	$processor->next_tag();
-	$processor->set_attribute( 'data-wp-island', '' );
+	$processor->set_attribute( 'data-wp-interactive', '' );
 	$processor->next_tag( 'object' );
-	$processor->set_attribute( 'data-wp-bind.hidden', '!selectors.core.file.hasPdfPreview' );
+	$processor->set_attribute( 'data-wp-bind--hidden', '!selectors.core.file.hasPdfPreview' );
 	$processor->set_attribute( 'hidden', true );
 	return $processor->get_updated_html();
 }
@@ -34,34 +34,34 @@ add_filter( 'render_block_core/file', 'gutenberg_block_core_file_add_directives_
  * The final HTML of the navigation block will look similar to this:
  *
  * <nav
- *   data-wp-island
+ *   data-wp-interactive
  *   data-wp-context='{ "core": { "navigation": { "isMenuOpen": { "click": false, "hover": false }, "overlay": true, "roleAttribute": "" } } }'
  * >
  *   <button
  *     class="wp-block-navigation__responsive-container-open"
- *     data-wp-on.click="actions.core.navigation.openMenuOnClick"
- *     data-wp-on.keydown="actions.core.navigation.handleMenuKeydown"
+ *     data-wp-on--click="actions.core.navigation.openMenuOnClick"
+ *     data-wp-on--keydown="actions.core.navigation.handleMenuKeydown"
  *   >
  *   <div
  *     class="wp-block-navigation__responsive-container"
- *     data-wp-class.has-modal-open="selectors.core.navigation.isMenuOpen"
- *     data-wp-class.is-menu-open="selectors.core.navigation.isMenuOpen"
- *     data-wp-bind.aria-hidden="!selectors.core.navigation.isMenuOpen"
+ *     data-wp-class--has-modal-open="selectors.core.navigation.isMenuOpen"
+ *     data-wp-class--is-menu-open="selectors.core.navigation.isMenuOpen"
+ *     data-wp-bind--aria-hidden="!selectors.core.navigation.isMenuOpen"
  *     data-wp-effect="effects.core.navigation.initMenu"
- *     data-wp-on.keydown="actions.core.navigation.handleMenuKeydown"
- *     data-wp-on.focusout="actions.core.navigation.handleMenuFocusout"
+ *     data-wp-on--keydown="actions.core.navigation.handleMenuKeydown"
+ *     data-wp-on--focusout="actions.core.navigation.handleMenuFocusout"
  *     tabindex="-1"
  *   >
  *     <div class="wp-block-navigation__responsive-close">
  *       <div
  *         class="wp-block-navigation__responsive-dialog"
- *         data-wp-bind.aria-modal="selectors.core.navigation.isMenuOpen"
- *         data-wp-bind.role="selectors.core.navigation.roleAttribute"
+ *         data-wp-bind--aria-modal="selectors.core.navigation.isMenuOpen"
+ *         data-wp-bind--role="selectors.core.navigation.roleAttribute"
  *         data-wp-effect="effects.core.navigation.focusFirstElement"
  *       >
  *         <button
  *           class="wp-block-navigation__responsive-container-close"
- *           data-wp-on.click="actions.core.navigation.closeMenuOnclick"
+ *           data-wp-on--click="actions.core.navigation.closeMenuOnclick"
  *         >
  *           <svg>
  *         <button>
@@ -80,7 +80,7 @@ function gutenberg_block_core_navigation_add_directives_to_markup( $block_conten
 	$w = new WP_HTML_Tag_Processor( $block_content );
 	// Add directives to the `<nav>` element.
 	if ( $w->next_tag( 'nav' ) ) {
-		$w->set_attribute( 'data-wp-island', '' );
+		$w->set_attribute( 'data-wp-interactive', '' );
 		$w->set_attribute( 'data-wp-context', '{ "core": { "navigation": { "isMenuOpen": { "click": false, "hover": false }, "overlay": true, "roleAttribute": "" } } }' );
 	};
 
@@ -91,8 +91,8 @@ function gutenberg_block_core_navigation_add_directives_to_markup( $block_conten
 			'class_name' => 'wp-block-navigation__responsive-container-open',
 		)
 	) ) {
-		$w->set_attribute( 'data-wp-on.click', 'actions.core.navigation.openMenuOnClick' );
-		$w->set_attribute( 'data-wp-on.keydown', 'actions.core.navigation.handleMenuKeydown' );
+		$w->set_attribute( 'data-wp-on--click', 'actions.core.navigation.openMenuOnClick' );
+		$w->set_attribute( 'data-wp-on--keydown', 'actions.core.navigation.handleMenuKeydown' );
 		$w->remove_attribute( 'data-micromodal-trigger' );
 	} else {
 		// If the open modal button not found, we handle submenus immediately.
@@ -110,11 +110,11 @@ function gutenberg_block_core_navigation_add_directives_to_markup( $block_conten
 			'class_name' => 'wp-block-navigation__responsive-container',
 		)
 	) ) {
-		$w->set_attribute( 'data-wp-class.has-modal-open', 'selectors.core.navigation.isMenuOpen' );
-		$w->set_attribute( 'data-wp-class.is-menu-open', 'selectors.core.navigation.isMenuOpen' );
+		$w->set_attribute( 'data-wp-class--has-modal-open', 'selectors.core.navigation.isMenuOpen' );
+		$w->set_attribute( 'data-wp-class--is-menu-open', 'selectors.core.navigation.isMenuOpen' );
 		$w->set_attribute( 'data-wp-effect', 'effects.core.navigation.initMenu' );
-		$w->set_attribute( 'data-wp-on.keydown', 'actions.core.navigation.handleMenuKeydown' );
-		$w->set_attribute( 'data-wp-on.focusout', 'actions.core.navigation.handleMenuFocusout' );
+		$w->set_attribute( 'data-wp-on--keydown', 'actions.core.navigation.handleMenuKeydown' );
+		$w->set_attribute( 'data-wp-on--focusout', 'actions.core.navigation.handleMenuFocusout' );
 		$w->set_attribute( 'tabindex', '-1' );
 	};
 
@@ -135,8 +135,8 @@ function gutenberg_block_core_navigation_add_directives_to_markup( $block_conten
 			'class_name' => 'wp-block-navigation__responsive-dialog',
 		)
 	) ) {
-		$w->set_attribute( 'data-wp-bind.aria-modal', 'selectors.core.navigation.isMenuOpen' );
-		$w->set_attribute( 'data-wp-bind.role', 'selectors.core.navigation.roleAttribute' );
+		$w->set_attribute( 'data-wp-bind--aria-modal', 'selectors.core.navigation.isMenuOpen' );
+		$w->set_attribute( 'data-wp-bind--role', 'selectors.core.navigation.roleAttribute' );
 		$w->set_attribute( 'data-wp-effect', 'effects.core.navigation.focusFirstElement' );
 	};
 
@@ -147,7 +147,7 @@ function gutenberg_block_core_navigation_add_directives_to_markup( $block_conten
 			'class_name' => 'wp-block-navigation__responsive-container-close',
 		)
 	) ) {
-		$w->set_attribute( 'data-wp-on.click', 'actions.core.navigation.closeMenuOnClick' );
+		$w->set_attribute( 'data-wp-on--click', 'actions.core.navigation.closeMenuOnClick' );
 		$w->remove_attribute( 'data-micromodal-close' );
 	};
 
@@ -165,15 +165,15 @@ function gutenberg_block_core_navigation_add_directives_to_markup( $block_conten
  *   class="has-child"
  *   data-wp-context='{ "core": { "navigation": { "isMenuOpen": { "click": false, "hover": false, "overlay": false } } }'
  *   data-wp-effect="effects.core.navigation.initMenu"
- *   data-wp-on.keydown="actions.core.navigation.handleMenuKeydown"
- *   data-wp-on.focusout="actions.core.navigation.handleMenuFocusout"
- *   data-wp-on.mouseenter="actions.core.navigation.openMenuOnHover"
- *   data-wp-on.mouseleave="actions.core.navigation.closeMenuOnHover"
+ *   data-wp-on--keydown="actions.core.navigation.handleMenuKeydown"
+ *   data-wp-on--focusout="actions.core.navigation.handleMenuFocusout"
+ *   data-wp-on--mouseenter="actions.core.navigation.openMenuOnHover"
+ *   data-wp-on--mouseleave="actions.core.navigation.closeMenuOnHover"
  * >
  *   <button
  *     class="wp-block-navigation-submenu__toggle"
- *     data-wp-on.click="actions.core.navigation.toggleMenuOnClick"
- *     data-wp-bind.aria-expanded="selectors.core.navigation.isMenuOpen"
+ *     data-wp-on--click="actions.core.navigation.toggleMenuOnClick"
+ *     data-wp-bind--aria-expanded="selectors.core.navigation.isMenuOpen"
  *   >
  *   </button>
  *   <span>Title</span>
@@ -197,11 +197,11 @@ function gutenberg_block_core_navigation_add_directives_to_submenu( $w, $block_a
 		// Add directives to the parent `<li>`.
 		$w->set_attribute( 'data-wp-context', '{ "core": { "navigation": { "isMenuOpen": { "click": false, "hover": false }, "overlay": false } } }' );
 		$w->set_attribute( 'data-wp-effect', 'effects.core.navigation.initMenu' );
-		$w->set_attribute( 'data-wp-on.focusout', 'actions.core.navigation.handleMenuFocusout' );
-		$w->set_attribute( 'data-wp-on.keydown', 'actions.core.navigation.handleMenuKeydown' );
+		$w->set_attribute( 'data-wp-on--focusout', 'actions.core.navigation.handleMenuFocusout' );
+		$w->set_attribute( 'data-wp-on--keydown', 'actions.core.navigation.handleMenuKeydown' );
 		if ( ! isset( $block_attributes['openSubmenusOnClick'] ) || false === $block_attributes['openSubmenusOnClick'] ) {
-			$w->set_attribute( 'data-wp-on.mouseenter', 'actions.core.navigation.openMenuOnHover' );
-			$w->set_attribute( 'data-wp-on.mouseleave', 'actions.core.navigation.closeMenuOnHover' );
+			$w->set_attribute( 'data-wp-on--mouseenter', 'actions.core.navigation.openMenuOnHover' );
+			$w->set_attribute( 'data-wp-on--mouseleave', 'actions.core.navigation.closeMenuOnHover' );
 		}
 
 		// Add directives to the toggle submenu button.
@@ -211,8 +211,8 @@ function gutenberg_block_core_navigation_add_directives_to_submenu( $w, $block_a
 				'class_name' => 'wp-block-navigation-submenu__toggle',
 			)
 		) ) {
-			$w->set_attribute( 'data-wp-on.click', 'actions.core.navigation.toggleMenuOnClick' );
-			$w->set_attribute( 'data-wp-bind.aria-expanded', 'selectors.core.navigation.isMenuOpen' );
+			$w->set_attribute( 'data-wp-on--click', 'actions.core.navigation.toggleMenuOnClick' );
+			$w->set_attribute( 'data-wp-bind--aria-expanded', 'selectors.core.navigation.isMenuOpen' );
 		};
 
 		// Iterate through subitems if exist.

--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -63,7 +63,7 @@ function render_block_core_image( $attributes, $content ) {
 		$img = null;
 		preg_match( '/<img[^>]+>/', $content, $img );
 		$button       = '<div class="img-container">
-			 					<button type="button" aria-haspopup="dialog" aria-label="' . esc_attr( $aria_label ) . '" data-wp-on.click="actions.core.image.showLightbox"></button>'
+			 					<button type="button" aria-haspopup="dialog" aria-label="' . esc_attr( $aria_label ) . '" data-wp-on--click="actions.core.image.showLightbox"></button>'
 									. $img[0] .
 								'</div>';
 		$body_content = preg_replace( '/<img[^>]+>/', $button, $content );
@@ -78,22 +78,22 @@ function render_block_core_image( $attributes, $content ) {
 		return
 			<<<HTML
 				<div class="wp-lightbox-container"
-					data-wp-island
+					data-wp-interactive
 					data-wp-context='{ "core": { "image": { "initialized": false, "lightboxEnabled": false } } }'>
 						$body_content
 						<div data-wp-body="" class="wp-lightbox-overlay"
-							data-wp-bind.role="selectors.core.image.roleAttribute"
+							data-wp-bind--role="selectors.core.image.roleAttribute"
 							aria-label="$dialog_label"
-							data-wp-class.initialized="context.core.image.initialized"
-							data-wp-class.active="context.core.image.lightboxEnabled"
-							data-wp-bind.aria-hidden="!context.core.image.lightboxEnabled"
-							data-wp-bind.aria-modal="context.core.image.lightboxEnabled"
+							data-wp-class--initialized="context.core.image.initialized"
+							data-wp-class--active="context.core.image.lightboxEnabled"
+							data-wp-bind--aria-hidden="!context.core.image.lightboxEnabled"
+							data-wp-bind--aria-modal="context.core.image.lightboxEnabled"
 							data-wp-effect="effects.core.image.initLightbox"
-							data-wp-on.keydown="actions.core.image.handleKeydown"
-							data-wp-on.mousewheel="actions.core.image.hideLightbox"
-							data-wp-on.click="actions.core.image.hideLightbox"
+							data-wp-on--keydown="actions.core.image.handleKeydown"
+							data-wp-on--mousewheel="actions.core.image.hideLightbox"
+							data-wp-on--click="actions.core.image.hideLightbox"
 							>
-								<button type="button" aria-label="$close_button_label" class="close-button" data-wp-on.click="actions.core.image.hideLightbox">
+								<button type="button" aria-label="$close_button_label" class="close-button" data-wp-on--click="actions.core.image.hideLightbox">
 									$close_button_icon
 								</button>
 								$content

--- a/packages/block-library/src/utils/interactivity/constants.js
+++ b/packages/block-library/src/utils/interactivity/constants.js
@@ -1,1 +1,1 @@
-export const directivePrefix = 'data-wp-';
+export const directivePrefix = 'wp';

--- a/packages/block-library/src/utils/interactivity/directives.js
+++ b/packages/block-library/src/utils/interactivity/directives.js
@@ -67,7 +67,7 @@ export default () => {
 		);
 	} );
 
-	// data-wp-effect.[name]
+	// data-wp-effect--[name]
 	directive( 'effect', ( { directives: { effect }, context, evaluate } ) => {
 		const contextValue = useContext( context );
 		Object.values( effect ).forEach( ( path ) => {
@@ -77,7 +77,7 @@ export default () => {
 		} );
 	} );
 
-	// data-wp-init.[name]
+	// data-wp-init--[name]
 	directive( 'init', ( { directives: { init }, context, evaluate } ) => {
 		const contextValue = useContext( context );
 		Object.values( init ).forEach( ( path ) => {
@@ -87,7 +87,7 @@ export default () => {
 		} );
 	} );
 
-	// data-wp-on.[event]
+	// data-wp-on--[event]
 	directive( 'on', ( { directives: { on }, element, evaluate, context } ) => {
 		const contextValue = useContext( context );
 		Object.entries( on ).forEach( ( [ name, path ] ) => {
@@ -97,7 +97,7 @@ export default () => {
 		} );
 	} );
 
-	// data-wp-class.[classname]
+	// data-wp-class--[classname]
 	directive(
 		'class',
 		( {
@@ -142,7 +142,7 @@ export default () => {
 		}
 	);
 
-	// data-wp-bind.[attribute]
+	// data-wp-bind--[attribute]
 	directive(
 		'bind',
 		( { directives: { bind }, element, context, evaluate } ) => {

--- a/packages/block-library/src/utils/interactivity/hydration.js
+++ b/packages/block-library/src/utils/interactivity/hydration.js
@@ -11,7 +11,7 @@ import { directivePrefix } from './constants';
 
 export const init = async () => {
 	document
-		.querySelectorAll( `[${ directivePrefix }island]` )
+		.querySelectorAll( `[data-${ directivePrefix }-interactive]` )
 		.forEach( ( node ) => {
 			if ( ! hydratedIslands.has( node ) ) {
 				const fragment = createRootFragment( node.parentNode, node );

--- a/packages/block-library/src/utils/interactivity/vdom.js
+++ b/packages/block-library/src/utils/interactivity/vdom.js
@@ -7,9 +7,23 @@ import { h } from 'preact';
  */
 import { directivePrefix as p } from './constants';
 
-const ignoreAttr = `${ p }ignore`;
-const islandAttr = `${ p }island`;
-const directiveParser = new RegExp( `${ p }([^.]+)\.?(.*)$` );
+const ignoreAttr = `data-${ p }-ignore`;
+const islandAttr = `data-${ p }-interactive`;
+const fullPrefix = `data-${ p }-`;
+
+// Regular expression for directive parsing.
+const directiveParser = new RegExp(
+	`^data-${ p }-` + // ${p} must be a prefix string, like 'wp'.
+		// Match alphanumeric characters including hyphen-separated
+		// segments. It excludes underscore intentionally to prevent confusion.
+		// E.g., "custom-directive".
+		'([a-z0-9]+(?:-[a-z0-9]+)*)' +
+		// (Optional) Match '--' followed by any alphanumeric charachters. It
+		// excludes underscore intentionally to prevent confusion, but it can
+		// contain multiple hyphens. E.g., "--custom-prefix--with-more-info".
+		'(?:--([a-z0-9][a-z0-9-]+))?$',
+	'i' // Case insensitive.
+);
 
 export const hydratedIslands = new WeakSet();
 
@@ -44,7 +58,10 @@ export function toVdom( root ) {
 
 		for ( let i = 0; i < attributes.length; i++ ) {
 			const n = attributes[ i ].name;
-			if ( n[ p.length ] && n.slice( 0, p.length ) === p ) {
+			if (
+				n[ fullPrefix.length ] &&
+				n.slice( 0, fullPrefix.length ) === fullPrefix
+			) {
 				if ( n === ignoreAttr ) {
 					ignore = true;
 				} else if ( n === islandAttr ) {


### PR DESCRIPTION
## What?
Incorporate [the changes made in the Block Interactivity Experiments repo](https://github.com/WordPress/block-interactivity-experiments/pull/239) to:

* Rename the directive syntax from `data-wp-on.click` to `data-wp-on--click`.
* Rename `data-wp-island` to `data-wp-interactive.

Apart from that, I updated the current blocks using the Interactivity API as an experiment to match these changes.


## Why?
In the Block Interactivity Experiments repo, these changes were made because:

1. JSX doesn't support attributes with dots in them.
2. The term island has no meaning in WordPress, and we don't intend to embrace it.

## How?
I just copied and paste the changes from the original pull request and:
* Change the directives to use `data-wp-on--` instead of the dot.
* Change `data-wp-island` for `data-wp-interactive`.

## Testing Instructions
1. Enable the Interactivity API experiment in Gutenberg -> Experiments.
2. Check that the Interactive blocks work as expected:
    * Add a navigation block and tests that submenu and the overlay menu work.
    * Add an image with the lightbox and test that the lightbox works.
    * Add a file block and test that the preview is only shown on desktop.