### PR TITLE
Fix styling of actions in site editor navigation sidebar

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen-global-styles/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-global-styles/index.js
@@ -118,7 +118,7 @@ export default function SidebarNavigationScreenGlobalStyles() {
 				) }
 				content={ <SidebarNavigationScreenGlobalStylesContent /> }
 				actions={
-					<div>
+					<>
 						{ ! isMobileViewport && (
 							<SidebarButton
 								icon={ seen }
@@ -138,7 +138,7 @@ export default function SidebarNavigationScreenGlobalStyles() {
 							label={ __( 'Edit styles' ) }
 							onClick={ async () => await openGlobalStyles() }
 						/>
-					</div>
+					</>
 				}
 			/>
 			{ isStyleBookOpened && ! isMobileViewport && (

--- a/packages/edit-site/src/components/sidebar-navigation-screen-page/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-page/index.js
@@ -79,7 +79,7 @@ export default function SidebarNavigationScreenPage() {
 				record?.title?.rendered || __( '(no title)' )
 			) }
 			actions={
-				<div>
+				<>
 					<PageActions
 						postId={ postId }
 						toggleProps={ { as: SidebarButton } }
@@ -92,7 +92,7 @@ export default function SidebarNavigationScreenPage() {
 						label={ __( 'Edit' ) }
 						icon={ pencil }
 					/>
-				</div>
+				</>
 			}
 			meta={
 				<ExternalLink

--- a/packages/edit-site/src/components/sidebar-navigation-screen-template/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-template/index.js
@@ -92,7 +92,7 @@ export default function SidebarNavigationScreenTemplate() {
 		<SidebarNavigationScreen
 			title={ title }
 			actions={
-				<div>
+				<>
 					<TemplateActions
 						postType={ postType }
 						postId={ postId }
@@ -106,7 +106,7 @@ export default function SidebarNavigationScreenTemplate() {
 						label={ __( 'Edit' ) }
 						icon={ pencil }
 					/>
-				</div>
+				</>
 			}
 			description={ description }
 		/>

--- a/packages/edit-site/src/components/sidebar-navigation-screen/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen/index.js
@@ -83,7 +83,11 @@ export default function SidebarNavigationScreen( {
 								title
 						  ) }
 				</Heading>
-				{ actions }
+				{ actions && (
+					<div className="edit-site-sidebar-navigation-screen__actions">
+						{ actions }
+					</div>
+				) }
 			</HStack>
 			{ meta && (
 				<>

--- a/packages/edit-site/src/components/sidebar-navigation-screen/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-screen/style.scss
@@ -57,6 +57,10 @@
 	padding: $grid-unit-15 * 0.5 0 0 0;
 }
 
+.edit-site-sidebar-navigation-screen__actions {
+	flex-shrink: 0;
+}
+
 .edit-site-sidebar-navigation-screen__content .edit-site-global-styles-style-variations-container {
 	.edit-site-global-styles-variations_item-preview {
 		border: $gray-900 $border-width solid;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Recently we added some actions in site editor's navigation sidebar([1](https://github.com/WordPress/gutenberg/pull/51101), [2](https://github.com/WordPress/gutenberg/pull/51054)). When we have more than one action there and have big titles, the buttons aren't displayed properly(stylistically). 

This PR adds a `div` wrapper if actions are provided to `SidebarNavigationScreen` component and their proper width is set.



## Testing Instructions
1. In site editor navigation sidebar ensure everything is displayed properly as before
2. Go to Pages or Templates/Template Parts and select one with a big title
3. Observe that the buttons display properly in the same line

#### Before
<img width="176" alt="Screenshot 2023-06-01 at 11 14 15 AM" src="https://github.com/WordPress/gutenberg/assets/16275880/3a8ea93e-a0c3-4b48-80d8-56fd2b1a50ad">


#### After
<img width="176" alt="Screenshot 2023-06-01 at 11 14 41 AM" src="https://github.com/WordPress/gutenberg/assets/16275880/3b9a482c-448f-477a-979d-c758f7f6b96d">

