### PR TITLE
Navigation: Memoize link value passed to the LinkControl

### DIFF
--- a/packages/block-library/src/navigation-link/link-ui.js
+++ b/packages/block-library/src/navigation-link/link-ui.js
@@ -9,7 +9,7 @@ import {
 	BlockIcon,
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
-import { createInterpolateElement } from '@wordpress/element';
+import { createInterpolateElement, useMemo } from '@wordpress/element';
 import { store as coreStore } from '@wordpress/core-data';
 import { decodeEntities } from '@wordpress/html-entities';
 import { switchToBlockType } from '@wordpress/blocks';
@@ -154,11 +154,17 @@ export function LinkUI( props ) {
 	}
 
 	const { label, url, opensInNewTab, type, kind } = props.link;
-	const link = {
-		url,
-		opensInNewTab,
-		title: label && stripHTML( label ),
-	};
+
+	// Memoize link value to avoid overriding the LinkControl's internal state.
+	// This is a temporary fix. See https://github.com/WordPress/gutenberg/issues/50976#issuecomment-1568226407.
+	const link = useMemo(
+		() => ( {
+			url,
+			opensInNewTab,
+			title: label && stripHTML( label ),
+		} ),
+		[ label, opensInNewTab, url ]
+	);
 
 	return (
 		<Popover


### PR DESCRIPTION
## What?
Fixes #50976.
This is a regression after #50668.

PR updates the `LinkUI` component to pass memoized link value to `LinkControl` and avoid losing internal state value when the component rerenders.

## Why?

The `LinkControl` uses the `value` as a source of truth; if it changes, the component resets the internal state. See #49509.

The `value` is an object; we should pass referentially stable objects to avoid unnecessary [state synchronizations](https://github.com/WordPress/gutenberg/blob/96d03d661320f627b67e85854d99c55bed808812/packages/block-editor/src/components/link-control/use-internal-value.js#L9-L18).

## Testing Instructions
1. Open a Post or Page.
2. Insert a Navigation block.
3. Open Navigation block settings > Menu list view.
4. Select "Add submenu link" from the menu item options.
5. Type or paste any URL in the LinkControl input field.
6. Hover/over other menu items in the list view.
7. Confirm entered URL isn't cleared from the input.

## Screenshots or screencast <!-- if applicable -->

**Before**

https://github.com/WordPress/gutenberg/assets/240569/82017d40-152c-4062-ab51-66cff08fe237

**After**

https://github.com/WordPress/gutenberg/assets/240569/8b47504f-bea1-4fba-a051-7bbcc82c19e0

