### PR TITLE
Fix headings in the View component readme.

### DIFF
--- a/packages/components/src/view/README.md
+++ b/packages/components/src/view/README.md
@@ -27,13 +27,13 @@ function Example() {
 
 ## Props
 
-##### as
+### as
 
 **Type**: `string`,`E`
 
 Render the component as another React Component or HTML Element.
 
-##### css
+### css
 
 **Type**: `InterpolatedCSS`
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Quick PR to fix the headings hierarchy in the View component readme file.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The headings hierarchy should not skip levels. 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

- Check the View component Readme file.
- Before: Observe that the headings after the 'Props' H2 heading are H5.
- After: Observe that the headings after the 'Props' H2 heading are H3.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
