### PR TITLE
PreferenceToggleMenuItem: add missing useSelect dependency

### DIFF
--- a/packages/preferences/src/components/preference-toggle-menu-item/index.js
+++ b/packages/preferences/src/components/preference-toggle-menu-item/index.js
@@ -25,7 +25,7 @@ export default function PreferenceToggleMenuItem( {
 } ) {
 	const isActive = useSelect(
 		( select ) => !! select( preferencesStore ).get( scope, name ),
-		[ name ]
+		[ scope, name ]
 	);
 	const { toggle } = useDispatch( preferencesStore );
 	const speakMessage = () => {


### PR DESCRIPTION
Fixes a missing dependency on the `scope` prop in `useSelect`. ESLint was showing a warning about it, and the situation is not complicated at all. When the incoming `scope` prop changes, of course we want to calculate the `isActive` value using the new one.