### PR TITLE
mapValues: use fromEntries, avoid re-creating object in each reducer call

### DIFF
--- a/packages/data/src/redux-store/index.js
+++ b/packages/data/src/redux-store/index.js
@@ -54,12 +54,11 @@ const trimUndefinedValues = ( array ) => {
  * @return {Array} Transformed object.
  */
 const mapValues = ( obj, callback ) =>
-	Object.entries( obj ?? {} ).reduce(
-		( acc, [ key, value ] ) => ( {
-			...acc,
-			[ key ]: callback( value, key ),
-		} ),
-		{}
+	Object.fromEntries(
+		Object.entries( obj ?? {} ).map( ( [ key, value ] ) => [
+			key,
+			callback( value, key ),
+		] )
 	);
 
 // Convert Map objects to plain objects


### PR DESCRIPTION
Improves the `mapValues` implementation in the `createReduxStore` code. Instead of constructing a new object in each `reduce` iteration, we use the `fromEntries( toEntries.map )` pattern.