### PR TITLE
mapSelectorsWithResolvers: don't init hasResolver, mapSelectors already did it

### DIFF
--- a/packages/data/src/redux-store/index.js
+++ b/packages/data/src/redux-store/index.js
@@ -586,7 +586,6 @@ function mapSelectorsWithResolvers(
 	return mapValues( selectors, ( selector, selectorName ) => {
 		const resolver = resolvers[ selectorName ];
 		if ( ! resolver ) {
-			selector.hasResolver = false;
 			return selector;
 		}
 


### PR DESCRIPTION
Removes a redundant assignment to `selector.hasResolver` when mapping selectors with resolvers. The `mapSelectors` function already initialized the field to `false`. Now, `mapSelectorsWithResolvers` should be a complete noop when there is no resolvers for the selector, i.e., it should just return the selector without any change.