### PR TITLE
Move action-binding code to a bindAction function

### DIFF
--- a/packages/data/src/redux-store/index.js
+++ b/packages/data/src/redux-store/index.js
@@ -176,21 +176,24 @@ export default function createReduxStore( key, options ) {
 			lock( store, privateRegistrationFunctions );
 			const resolversCache = createResolversCache();
 
-			const actions = mapActions(
-				{
-					...metadataActions,
-					...options.actions,
-				},
-				store
-			);
+			function bindAction( action ) {
+				return ( ...args ) =>
+					Promise.resolve( store.dispatch( action( ...args ) ) );
+			}
+
+			const actions = {
+				...mapValues( metadataActions, bindAction ),
+				...mapValues( options.actions, bindAction ),
+			};
+
 			lock(
 				actions,
 				new Proxy( privateActions, {
 					get: ( target, prop ) => {
-						return (
-							mapActions( privateActions, store )[ prop ] ||
-							actions[ prop ]
-						);
+						const privateAction = privateActions[ prop ];
+						return privateAction
+							? bindAction( privateAction )
+							: actions[ prop ];
 					},
 				} )
 			);
@@ -377,24 +380,6 @@ function mapSelectors( selectors, store ) {
 	};
 
 	return mapValues( selectors, createStateSelector );
-}
-
-/**
- * Maps actions to dispatch from a given store.
- *
- * @param {Object} actions Actions to register.
- * @param {Object} store   The redux store to which the actions should be mapped.
- *
- * @return {Object} Actions mapped to the redux store provided.
- */
-function mapActions( actions, store ) {
-	const createBoundAction =
-		( action ) =>
-		( ...args ) => {
-			return Promise.resolve( store.dispatch( action( ...args ) ) );
-		};
-
-	return mapValues( actions, createBoundAction );
 }
 
 /**


### PR DESCRIPTION
Refactoring of the `mapActions` function, a spinoff from #51051. Which will build on these changes and implement returning stable references to private actions from `dispatch`, and exposing private actions to thunks.

The `mapActions` function is removed in favor of calling `mapValues( actions, bindAction )` directly. And in the private action proxy, we map only the _one_ action that the getter is requesting, not all of them.