### PR TITLE
Scripts: Optimize updating render paths when developing blocks

### DIFF
--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 -   The bundled `terser-webpack-plugin` dependency has been updated from requiring `^5.1.4` to requiring `^5.3.9` ([#50994](https://github.com/WordPress/gutenberg/pull/50994)).
 
+### Bug Fixes
+
+-   Ensure files listed in `render` field of `block.json` files are always copied to the build folder when using `start`([#50939](https://github.com/WordPress/gutenberg/pull/50939)).
+
 ## 26.5.0 (2023-05-24)
 
 ## 26.4.0 (2023-05-10)

--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -5,10 +5,11 @@
 ### Enhancements
 
 -   The bundled `terser-webpack-plugin` dependency has been updated from requiring `^5.1.4` to requiring `^5.3.9` ([#50994](https://github.com/WordPress/gutenberg/pull/50994)).
+-   Optimize updating render paths when developing blocks with the `start` command ([#51162](https://github.com/WordPress/gutenberg/pull/51162)).
 
 ### Bug Fixes
 
--   Ensure files listed in `render` field of `block.json` files are always copied to the build folder when using `start`([#50939](https://github.com/WordPress/gutenberg/pull/50939)).
+-   Ensure files listed in `render` field of `block.json` files are always copied to the build folder when using the `start` command ([#50939](https://github.com/WordPress/gutenberg/pull/50939)).
 
 ## 26.5.0 (2023-05-24)
 

--- a/packages/scripts/config/webpack.config.js
+++ b/packages/scripts/config/webpack.config.js
@@ -38,8 +38,27 @@ if ( ! browserslist.findConfig( '.' ) ) {
 }
 const hasReactFastRefresh = hasArgInCLI( '--hot' ) && ! isProduction;
 
-// Get paths of the `render` props included in `block.json` files
-let renderPaths = getRenderPropPaths();
+/**
+ * The plugin recomputes the render paths once on each compilation. It is necessary to avoid repeating processing
+ * when filtering every discovered PHP file in the source folder. This is the most performant way to ensure that
+ * changes in `block.json` files are picked up in watch mode.
+ */
+class RenderPathsPlugin {
+	/**
+	 * Paths with the `render` props included in `block.json` files.
+	 *
+	 * @type {string[]}
+	 */
+	static renderPaths;
+
+	apply( compiler ) {
+		const pluginName = this.constructor.name;
+
+		compiler.hooks.thisCompilation.tap( pluginName, () => {
+			this.constructor.renderPaths = getRenderPropPaths();
+		} );
+	}
+}
 
 const cssLoaders = [
 	{
@@ -234,6 +253,7 @@ const config = {
 			// multiple configurations returned in the webpack config.
 			cleanStaleWebpackAssets: false,
 		} ),
+		new RenderPathsPlugin(),
 		new CopyWebpackPlugin( {
 			patterns: [
 				{
@@ -275,10 +295,9 @@ const config = {
 					context: getWordPressSrcDirectory(),
 					noErrorOnMissing: true,
 					filter: ( filepath ) => {
-						renderPaths = getRenderPropPaths();
 						return (
 							process.env.WP_COPY_PHP_FILES_TO_DIST ||
-							renderPaths.includes( filepath )
+							RenderPathsPlugin.renderPaths.includes( filepath )
 						);
 					},
 				},


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Follow-up for #50939.
Previously discussed in https://github.com/WordPress/gutenberg/pull/43917#discussion_r963821431.

The original issue was reported in 

> If you have `@wordpress/scripts` running with the `start` script, and add a `"render": "file:./render.php"` to your `block.json` file, the script doesn't detect it. But if you end the process and restart it, then it does.

The issue got fixed with https://github.com/WordPress/gutenberg/pull/50939, but the approach wasn't optimal in terms of performance.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

As correctly pointed out by @luisherranz in https://github.com/WordPress/gutenberg/pull/43917#discussion_r964473960 when developing the feature:

> Taking the function out of the filter was actually my suggestion to avoid reading/parsing all the block.json files per each PHP file of the project. That can slow things down for projects with multiple blocks and hundreds of PHP files (imagine something similar to WooCommerce).

While the fix works, we can improve the performance.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

The proposed fix introduces a custom webpack plugin that uses the existing utility `getRenderPropPaths` to update the list of detected PHP files in the `render` field defined in `block.json` files. The idea behind it is to use the [`thisCompilation` webpack hook](https://webpack.js.org/api/compiler-hooks/#thiscompilation) that also `CopyWebpackPlugin` uses when copying files. This way, we can run the logic only once when changes to files on the disk are detected rather than whenever the `filter` callback gets executed for every PHP file living in the source folder.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

It can be tested with the testing instructions from https://github.com/WordPress/gutenberg/issues/49790.

I tested it myself by building the custom block using:

1. Open the branch from this PR.
2. Run `npx wp-create-block example-dynamic --no-wp-scripts --variant=dynamic` to create a custom dynamic block.
3. Go to the folder with the block with `cd example-dynamic`.
4. Run `../node_modules/.bin/wp-scripts build` to ensure that `src/render.php` file gets copied to the `build` folder:
<img width="494" alt="Screenshot 2023-06-01 at 13 06 10" src="https://github.com/WordPress/gutenberg/assets/699132/8c2dc701-cf02-44db-94c8-bdb39c44aa06">

5. Remove `render` field from `src/block.json`.
6. Run `../node_modules/.bin/wp-scripts start` to begin development in the watch mode.
7. There should be no `render.php` file in the `build` folder.
8. Add back `render` field to the `src/block.json` file.
9. There should be `render.php` file in the `build` folder.