### PR TITLE
ListView: Converted additional content render into a Component

### DIFF
--- a/packages/block-editor/src/components/list-view/block-contents.js
+++ b/packages/block-editor/src/components/list-view/block-contents.js
@@ -47,7 +47,7 @@ const ListViewBlockContents = forwardRef(
 			[]
 		);
 
-		const { renderAdditionalBlockUI, insertedBlock, setInsertedBlock } =
+		const { AdditionalBlockContent, insertedBlock, setInsertedBlock } =
 			useListViewContext();
 
 		const isBlockMoveTarget =
@@ -67,12 +67,13 @@ const ListViewBlockContents = forwardRef(
 
 		return (
 			<>
-				{ renderAdditionalBlockUI &&
-					renderAdditionalBlockUI(
-						block,
-						insertedBlock,
-						setInsertedBlock
-					) }
+				{ AdditionalBlockContent && (
+					<AdditionalBlockContent
+						block={ block }
+						insertedBlock={ insertedBlock }
+						setInsertedBlock={ setInsertedBlock }
+					/>
+				) }
 				<BlockDraggable clientIds={ draggableClientIds }>
 					{ ( { draggable, onDragStart, onDragEnd } ) => (
 						<ListViewBlockSelectButton

--- a/packages/block-editor/src/components/list-view/index.js
+++ b/packages/block-editor/src/components/list-view/index.js
@@ -57,19 +57,19 @@ export const BLOCK_LIST_ITEM_HEIGHT = 36;
 /**
  * Show a hierarchical list of blocks.
  *
- * @param {Object}         props                         Components props.
- * @param {string}         props.id                      An HTML element id for the root element of ListView.
- * @param {Array}          props.blocks                  _deprecated_ Custom subset of block client IDs to be used instead of the default hierarchy.
- * @param {?HTMLElement}   props.dropZoneElement         Optional element to be used as the drop zone.
- * @param {?boolean}       props.showBlockMovers         Flag to enable block movers. Defaults to `false`.
- * @param {?boolean}       props.isExpanded              Flag to determine whether nested levels are expanded by default. Defaults to `false`.
- * @param {?boolean}       props.showAppender            Flag to show or hide the block appender. Defaults to `false`.
- * @param {?ComponentType} props.blockSettingsMenu       Optional more menu substitution. Defaults to the standard `BlockSettingsDropdown` component.
- * @param {string}         props.rootClientId            The client id of the root block from which we determine the blocks to show in the list.
- * @param {string}         props.description             Optional accessible description for the tree grid component.
- * @param {?Function}      props.onSelect                Optional callback to be invoked when a block is selected. Receives the block object that was selected.
- * @param {Function}       props.renderAdditionalBlockUI Function that renders additional block content UI.
- * @param {Ref}            ref                           Forwarded ref
+ * @param {Object}         props                        Components props.
+ * @param {string}         props.id                     An HTML element id for the root element of ListView.
+ * @param {Array}          props.blocks                 _deprecated_ Custom subset of block client IDs to be used instead of the default hierarchy.
+ * @param {?HTMLElement}   props.dropZoneElement        Optional element to be used as the drop zone.
+ * @param {?boolean}       props.showBlockMovers        Flag to enable block movers. Defaults to `false`.
+ * @param {?boolean}       props.isExpanded             Flag to determine whether nested levels are expanded by default. Defaults to `false`.
+ * @param {?boolean}       props.showAppender           Flag to show or hide the block appender. Defaults to `false`.
+ * @param {?ComponentType} props.blockSettingsMenu      Optional more menu substitution. Defaults to the standard `BlockSettingsDropdown` component.
+ * @param {string}         props.rootClientId           The client id of the root block from which we determine the blocks to show in the list.
+ * @param {string}         props.description            Optional accessible description for the tree grid component.
+ * @param {?Function}      props.onSelect               Optional callback to be invoked when a block is selected. Receives the block object that was selected.
+ * @param {?ComponentType} props.additionalBlockContent Component that renders additional block content UI.
+ * @param {Ref}            ref                          Forwarded ref
  */
 function ListViewComponent(
 	{
@@ -83,7 +83,7 @@ function ListViewComponent(
 		rootClientId,
 		description,
 		onSelect,
-		renderAdditionalBlockUI,
+		additionalBlockContent: AdditionalBlockContent,
 	},
 	ref
 ) {
@@ -224,7 +224,7 @@ function ListViewComponent(
 			collapse,
 			BlockSettingsMenu,
 			listViewInstanceId: instanceId,
-			renderAdditionalBlockUI,
+			AdditionalBlockContent,
 			insertedBlock,
 			setInsertedBlock,
 			treeGridElementRef: elementRef,
@@ -236,7 +236,7 @@ function ListViewComponent(
 			collapse,
 			BlockSettingsMenu,
 			instanceId,
-			renderAdditionalBlockUI,
+			AdditionalBlockContent,
 			insertedBlock,
 			setInsertedBlock,
 		]
@@ -297,7 +297,7 @@ export default forwardRef( ( props, ref ) => {
 			showAppender={ false }
 			rootClientId={ null }
 			onSelect={ null }
-			renderAdditionalBlockUI={ null }
+			additionalBlockContent={ null }
 			blockSettingsMenu={ undefined }
 		/>
 	);

--- a/packages/block-library/src/navigation/edit/menu-inspector-controls.js
+++ b/packages/block-library/src/navigation/edit/menu-inspector-controls.js
@@ -33,6 +33,48 @@ const BLOCKS_WITH_LINK_UI_SUPPORT = [
 	'core/navigation-submenu',
 ];
 
+function AdditionalBlockContent( { block, insertedBlock, setInsertedBlock } ) {
+	const { updateBlockAttributes } = useDispatch( blockEditorStore );
+
+	const supportsLinkControls = BLOCKS_WITH_LINK_UI_SUPPORT?.includes(
+		insertedBlock?.name
+	);
+	const blockWasJustInserted = insertedBlock?.clientId === block.clientId;
+	const showLinkControls = supportsLinkControls && blockWasJustInserted;
+
+	if ( ! showLinkControls ) {
+		return null;
+	}
+
+	const setInsertedBlockAttributes =
+		( _insertedBlockClientId ) => ( _updatedAttributes ) => {
+			if ( ! _insertedBlockClientId ) return;
+			updateBlockAttributes( _insertedBlockClientId, _updatedAttributes );
+		};
+
+	return (
+		<LinkUI
+			clientId={ insertedBlock?.clientId }
+			link={ insertedBlock?.attributes }
+			onClose={ () => {
+				setInsertedBlock( null );
+			} }
+			hasCreateSuggestion={ false }
+			onChange={ ( updatedValue ) => {
+				updateAttributes(
+					updatedValue,
+					setInsertedBlockAttributes( insertedBlock?.clientId ),
+					insertedBlock?.attributes
+				);
+				setInsertedBlock( null );
+			} }
+			onCancel={ () => {
+				setInsertedBlock( null );
+			} }
+		/>
+	);
+}
+
 const MainContent = ( {
 	clientId,
 	currentMenuId,
@@ -51,14 +93,6 @@ const MainContent = ( {
 		},
 		[ clientId ]
 	);
-
-	const { updateBlockAttributes } = useDispatch( blockEditorStore );
-
-	const setInsertedBlockAttributes =
-		( _insertedBlockClientId ) => ( _updatedAttributes ) => {
-			if ( ! _insertedBlockClientId ) return;
-			updateBlockAttributes( _insertedBlockClientId, _updatedAttributes );
-		};
 
 	const { navigationMenu } = useNavigationMenu( currentMenuId );
 
@@ -80,47 +114,6 @@ const MainContent = ( {
 				'You have not yet created any menus. Displaying a list of your Pages'
 		  );
 
-	const renderLinkUI = (
-		currentBlock,
-		lastInsertedBlock,
-		setLastInsertedBlock
-	) => {
-		const blockSupportsLinkUI = BLOCKS_WITH_LINK_UI_SUPPORT?.includes(
-			lastInsertedBlock?.name
-		);
-		const currentBlockWasJustInserted =
-			lastInsertedBlock?.clientId === currentBlock.clientId;
-
-		const shouldShowLinkUIForBlock =
-			blockSupportsLinkUI && currentBlockWasJustInserted;
-
-		return (
-			shouldShowLinkUIForBlock && (
-				<LinkUI
-					clientId={ lastInsertedBlock?.clientId }
-					link={ lastInsertedBlock?.attributes }
-					onClose={ () => {
-						setLastInsertedBlock( null );
-					} }
-					hasCreateSuggestion={ false }
-					onChange={ ( updatedValue ) => {
-						updateAttributes(
-							updatedValue,
-							setInsertedBlockAttributes(
-								lastInsertedBlock?.clientId
-							),
-							lastInsertedBlock?.attributes
-						);
-						setLastInsertedBlock( null );
-					} }
-					onCancel={ () => {
-						setLastInsertedBlock( null );
-					} }
-				/>
-			)
-		);
-	};
-
 	return (
 		<div className="wp-block-navigation__menu-inspector-controls">
 			{ clientIdsTree.length === 0 && (
@@ -135,7 +128,7 @@ const MainContent = ( {
 				description={ description }
 				showAppender
 				blockSettingsMenu={ LeafMoreMenu }
-				renderAdditionalBlockUI={ renderLinkUI }
+				additionalBlockContent={ AdditionalBlockContent }
 			/>
 		</div>
 	);


### PR DESCRIPTION
## What?
Resolves #50827.

PR updates the `ListView` to use a component for rendering additional block UI instead of a render callback.

## Why?
* Switching to a component can help us resolve potential positional argument issues.
* The prop is consumed and distributed using React context. The component makes it easier to pass stable references without using memoization hooks. The previous implementation would rerender the whole list view each time `MainContent` is rerendered.

## How?
* Change `renderAdditionalBlockUI` to `additionalBlockContent` and treat it like a component.
* Refactor and `renderLinkUI` function into a new component.

## Testing Instructions
* Open a Post or Page.
* Insert a Navigation block.
* Open Block Settings > List View.
* Confirm LinkControl is rendered when adding Custom Link or Submenu Link.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2023-06-03 at 08 27 20](https://github.com/WordPress/gutenberg/assets/240569/11b1c04f-78ef-4183-ab65-d02921d5795d)
