### PR TITLE
Bug fix: Vertical images in experimental lightbox

### DIFF
--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -75,6 +75,12 @@ function render_block_core_image( $attributes, $content ) {
 								'</div>';
 		$body_content = preg_replace( '/<img[^>]+>/', $button, $body_content );
 
+		// Add directive to expand modal image if appropriate.
+		$m = new WP_HTML_Tag_Processor( $content );
+		$m->next_tag( 'img' );
+		$m->set_attribute( 'data-wp-bind--style', 'selectors.core.image.styleWidth' );
+		$modal_content = $m->get_updated_html();
+
 		$background_color  = esc_attr( wp_get_global_styles( array( 'color', 'background' ) ) );
 		$close_button_icon = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="30" height="30" aria-hidden="true" focusable="false"><path d="M13 11.8l6.1-6.3-1-1-6.1 6.2-6.1-6.2-1 1 6.1 6.3-6.5 6.7 1 1 6.5-6.6 6.5 6.6 1-1z"></path></svg>';
 
@@ -97,7 +103,7 @@ function render_block_core_image( $attributes, $content ) {
 					<button type="button" aria-label="$close_button_label" class="close-button" data-wp-on--click="actions.core.image.hideLightbox">
 						$close_button_icon
 					</button>
-					$content
+					$modal_content
 					<div class="scrim" style="background-color: $background_color"></div>
 			</div>
 HTML;

--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -78,7 +78,8 @@ function render_block_core_image( $attributes, $content ) {
 		// Add directive to expand modal image if appropriate.
 		$m = new WP_HTML_Tag_Processor( $content );
 		$m->next_tag( 'img' );
-		$m->set_attribute( 'data-wp-bind--style', 'selectors.core.image.styleWidth' );
+		$m->set_attribute( 'data-wp-context', '{ "core": { "image": { "imageSrc": "' . wp_get_attachment_url($attributes['id']) . '"} } }' );
+		$m->set_attribute( 'data-wp-bind--src', 'selectors.core.image.imageSrc' );
 		$modal_content = $m->get_updated_html();
 
 		$background_color  = esc_attr( wp_get_global_styles( array( 'color', 'background' ) ) );

--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -78,7 +78,7 @@ function render_block_core_image( $attributes, $content ) {
 		// Add directive to expand modal image if appropriate.
 		$m = new WP_HTML_Tag_Processor( $content );
 		$m->next_tag( 'img' );
-		$m->set_attribute( 'data-wp-context', '{ "core": { "image": { "imageSrc": "' . wp_get_attachment_url($attributes['id']) . '"} } }' );
+		$m->set_attribute( 'data-wp-context', '{ "core": { "image": { "imageSrc": "' . wp_get_attachment_url( $attributes['id'] ) . '"} } }' );
 		$m->set_attribute( 'data-wp-bind--src', 'selectors.core.image.imageSrc' );
 		$modal_content = $m->get_updated_html();
 

--- a/packages/block-library/src/image/interactivity.js
+++ b/packages/block-library/src/image/interactivity.js
@@ -91,7 +91,7 @@ store( {
 				},
 				styleWidth: ( { context } ) => {
 					if ( context.core.image.imageRef ) {
-						return context.core.image.imageRef.offsetWidth >=
+						return context.core.image.imageRef.offsetWidth >
 							context.core.image.imageRef.offsetHeight
 							? 'width: 100%;'
 							: 'width: auto;';

--- a/packages/block-library/src/image/interactivity.js
+++ b/packages/block-library/src/image/interactivity.js
@@ -89,13 +89,10 @@ store( {
 				roleAttribute: ( { context } ) => {
 					return context.core.image.lightboxEnabled ? 'dialog' : '';
 				},
-				styleWidth: ( { context } ) => {
-					if ( context.core.image.imageRef ) {
-						return context.core.image.imageRef.offsetWidth >
-							context.core.image.imageRef.offsetHeight
-							? 'width: 100%;'
-							: 'width: auto;';
-					}
+				imageSrc: ( { context } ) => {
+					return context.core.image.initialized
+						? context.core.image.imageSrc
+						: '';
 				},
 			},
 		},

--- a/packages/block-library/src/image/interactivity.js
+++ b/packages/block-library/src/image/interactivity.js
@@ -89,6 +89,14 @@ store( {
 				roleAttribute: ( { context } ) => {
 					return context.core.image.lightboxEnabled ? 'dialog' : '';
 				},
+				styleWidth: ( { context } ) => {
+					if ( context.core.image.imageRef ) {
+						return context.core.image.imageRef.offsetWidth >=
+							context.core.image.imageRef.offsetHeight
+							? 'width: 100%;'
+							: 'width: auto;';
+					}
+				},
 			},
 		},
 	},
@@ -96,6 +104,7 @@ store( {
 		core: {
 			image: {
 				initLightbox: async ( { context, ref } ) => {
+					context.core.image.imageRef = ref.querySelector( 'img' );
 					if ( context.core.image.lightboxEnabled ) {
 						const focusableElements =
 							ref.querySelectorAll( focusableSelectors );

--- a/packages/block-library/src/image/style.scss
+++ b/packages/block-library/src/image/style.scss
@@ -204,18 +204,16 @@
 		justify-content: center;
 		align-items: center;
 		flex-direction: column;
-		padding: 20px;
 
 		figcaption {
 			margin: 10px 0 0 0;
+			display: none;
 		}
 
 		img {
 			max-width: 100%;
 			max-height: 100%;
 			width: auto;
-			min-height: 0;
-			min-width: 0;
 		}
 	}
 

--- a/packages/block-library/src/image/style.scss
+++ b/packages/block-library/src/image/style.scss
@@ -195,14 +195,28 @@
 	}
 
 	.wp-block-image {
+		width: 100%;
+		height: 100%;
+		position: absolute;
+		z-index: 3000000;
+		box-sizing: border-box;
 		display: flex;
 		justify-content: center;
 		align-items: center;
-		width: 100%;
-		height: 100%;
-		z-index: 3000000;
-		position: absolute;
 		flex-direction: column;
+		padding: 20px;
+
+		figcaption {
+			margin: 10px 0 0 0;
+		}
+
+		img {
+			max-width: 100%;
+			max-height: 100%;
+			width: auto;
+			min-height: 0;
+			min-width: 0;
+		}
 	}
 
 	button {

--- a/test/e2e/specs/editor/blocks/image.spec.js
+++ b/test/e2e/specs/editor/blocks/image.spec.js
@@ -828,10 +828,10 @@ test.describe( 'Image - interactivity', () => {
 		const lightbox = page.locator( '.wp-lightbox-overlay' );
 		await expect( lightbox ).toBeHidden();
 
+		await page.getByRole( 'button', { name: 'Enlarge image' } ).click();
+
 		const image = lightbox.locator( 'img' );
 		await expect( image ).toHaveAttribute( 'src', new RegExp( filename ) );
-
-		await page.getByRole( 'button', { name: 'Enlarge image' } ).click();
 
 		await expect( lightbox ).toBeVisible();
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
It revises the CSS to fix the display of vertical images in the [experimental lightbox](https://github.com/WordPress/gutenberg/pull/50373).

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Address #51125 
Vertical images should be contained within the viewport when being viewed in the lightbox.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
It revises the CSS to make sure the image doesn't expand beyond the appropriate borders of the lightbox. It also improves the style for the caption.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
1. Ensure the Interactivity API and Behaviors UI setting is enabled in Gutenberg > Experiments in the admin.
2. Create a new post and an image whose height is larger than its width; set the image's resolution to _large_ or _full size_.
3. Activate the image's lightbox via Advanced > Behaviors > Lightbox.
4. Publish and view the post.
5. Click on the image; see that the image is fully visible and contained within the lightbox.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
N/A

## Screenshots or screencast <!-- if applicable -->