### PR TITLE
Query Pagination: address feedback from #50779

### DIFF
--- a/packages/block-library/src/query-pagination-next/edit.js
+++ b/packages/block-library/src/query-pagination-next/edit.js
@@ -22,16 +22,18 @@ export default function QueryPaginationNextEdit( {
 			onClick={ ( event ) => event.preventDefault() }
 			{ ...useBlockProps() }
 		>
-			<PlainText
-				__experimentalVersion={ 2 }
-				tagName="span"
-				aria-label={ __( 'Next page link' ) }
-				placeholder={ showLabel ? __( 'Next Page' ) : '' }
-				value={ showLabel ? label : '' }
-				onChange={ ( newLabel ) =>
-					setAttributes( { label: newLabel } )
-				}
-			/>
+			{ showLabel && (
+				<PlainText
+					__experimentalVersion={ 2 }
+					tagName="span"
+					aria-label={ __( 'Next page link' ) }
+					placeholder={ __( 'Next Page' ) }
+					value={ label }
+					onChange={ ( newLabel ) =>
+						setAttributes( { label: newLabel } )
+					}
+				/>
+			) }
 			{ displayArrow && (
 				<span
 					className={ `wp-block-query-pagination-next-arrow is-arrow-${ paginationArrow }` }

--- a/packages/block-library/src/query-pagination-previous/edit.js
+++ b/packages/block-library/src/query-pagination-previous/edit.js
@@ -30,16 +30,18 @@ export default function QueryPaginationPreviousEdit( {
 					{ displayArrow }
 				</span>
 			) }
-			<PlainText
-				__experimentalVersion={ 2 }
-				tagName="span"
-				aria-label={ __( 'Previous page link' ) }
-				placeholder={ showLabel ? __( 'Previous Page' ) : '' }
-				value={ showLabel ? label : '' }
-				onChange={ ( newLabel ) =>
-					setAttributes( { label: newLabel } )
-				}
-			/>
+			{ showLabel && (
+				<PlainText
+					__experimentalVersion={ 2 }
+					tagName="span"
+					aria-label={ __( 'Previous page link' ) }
+					placeholder={ __( 'Previous Page' ) }
+					value={ label }
+					onChange={ ( newLabel ) =>
+						setAttributes( { label: newLabel } )
+					}
+				/>
+			) }
 		</a>
 	);
 }

--- a/packages/block-library/src/query-pagination/edit.js
+++ b/packages/block-library/src/query-pagination/edit.js
@@ -10,6 +10,7 @@ import {
 } from '@wordpress/block-editor';
 import { useSelect } from '@wordpress/data';
 import { PanelBody } from '@wordpress/components';
+import { useEffect } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -53,9 +54,11 @@ export default function QueryPaginationEdit( {
 		allowedBlocks: ALLOWED_BLOCKS,
 	} );
 	// Always show label text if paginationArrow is set to 'none'.
-	if ( paginationArrow === 'none' ) {
-		setAttributes( { showLabel: true } );
-	}
+	useEffect( () => {
+		if ( paginationArrow === 'none' ) {
+			setAttributes( { showLabel: true } );
+		}
+	}, [ paginationArrow, setAttributes ] );
 	return (
 		<>
 			{ hasNextPreviousBlocks && (

--- a/packages/block-library/src/query-pagination/edit.js
+++ b/packages/block-library/src/query-pagination/edit.js
@@ -58,7 +58,7 @@ export default function QueryPaginationEdit( {
 		if ( paginationArrow === 'none' && ! showLabel ) {
 			setAttributes( { showLabel: true } );
 		}
-	}, [ paginationArrow, setAttributes ] );
+	}, [ paginationArrow, setAttributes, showLabel ] );
 	return (
 		<>
 			{ hasNextPreviousBlocks && (

--- a/packages/block-library/src/query-pagination/edit.js
+++ b/packages/block-library/src/query-pagination/edit.js
@@ -55,7 +55,7 @@ export default function QueryPaginationEdit( {
 	} );
 	// Always show label text if paginationArrow is set to 'none'.
 	useEffect( () => {
-		if ( paginationArrow === 'none' ) {
+		if ( paginationArrow === 'none' && ! showLabel ) {
 			setAttributes( { showLabel: true } );
 		}
 	}, [ paginationArrow, setAttributes ] );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What? / Why?
<!-- In a few words, what is the PR actually doing? -->
This PR addresses the feedback from @ntsekouras in https://github.com/WordPress/gutenberg/pull/50779 post-merge.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Addresses [this comment](https://github.com/WordPress/gutenberg/pull/50779#discussion_r1212998535):

> We need to wrap this in a `useEffect`, because it triggers React warning right now. Also we don't need to set the attribute if is already `true`.

Done ✅

Addresses [this comment](https://github.com/WordPress/gutenberg/pull/50779#discussion_r1213000070):

> Why still render the `PlainText` and only update the placeholder. This way you can still set it's value.

Done ✅

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
1. In the editor, insert a Query Pagination block
2. Go to the block settings and toggle through the different arrow options
3. The "Show pagination text" toggle should show when the arrow is set to "Arrow" or "Chevron"
4. The "Show pagination text" toggle should be hidden when the arrow is set to "None", and the labels should be visible in the block
5. The "Show pagination text" toggle should toggle the visibility of the pagination text labels in the editor and on the front end