### PR TITLE
Data: fix a bug where private selectors on a store with resolvers are inaccessible

### DIFF
--- a/packages/data/src/redux-store/index.js
+++ b/packages/data/src/redux-store/index.js
@@ -214,6 +214,18 @@ export default function createReduxStore( key, options ) {
 				},
 				store
 			);
+
+			let resolvers;
+			if ( options.resolvers ) {
+				resolvers = mapResolvers( options.resolvers );
+				selectors = mapSelectorsWithResolvers(
+					selectors,
+					resolvers,
+					store,
+					resolversCache
+				);
+			}
+
 			lock(
 				selectors,
 				new Proxy( privateSelectors, {
@@ -234,17 +246,6 @@ export default function createReduxStore( key, options ) {
 					},
 				} )
 			);
-
-			let resolvers;
-			if ( options.resolvers ) {
-				resolvers = mapResolvers( options.resolvers );
-				selectors = mapSelectorsWithResolvers(
-					selectors,
-					resolvers,
-					store,
-					resolversCache
-				);
-			}
 
 			const resolveSelectors = mapResolveSelectors( selectors, store );
 			const suspendSelectors = mapSuspendSelectors( selectors, store );


### PR DESCRIPTION
Fixes a bug with private selectors and resolvers:
- create a data store where some selector (public) has a resolver, i.e., the store config has a `resolvers` option
- register a private selector in the store
- accessing the private selector with `unlock( registry.select( store ) )` throws a "object was not locked before" error

That's because the `createReduxStore` code first creates the `selectors` object, then locks it with `lock( selectors )`, and then, if resolvers are configured, does `selectors = mapValues( selectors, addResolvers )`.

That means `registry.select` doesn't return the locked object, but the result of `mapValues`. The originally locked object is garbage collected.

I'm adding a unit test, and a fix that merely swaps the order of "lock" and "map resolvers" operations.

Discovered when working on #51051. 🙂 