### PR TITLE
Lodash: Remove last vestiges of `_.isEmpty()`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -88,6 +88,7 @@ const restrictedImports = [
 			'invoke',
 			'isArray',
 			'isBoolean',
+			'isEmpty',
 			'isEqual',
 			'isFinite',
 			'isFunction',

--- a/bin/packages/get-packages.js
+++ b/bin/packages/get-packages.js
@@ -3,7 +3,6 @@
  */
 const fs = require( 'fs' );
 const path = require( 'path' );
-const { isEmpty } = require( 'lodash' );
 
 /**
  * Absolute path to packages directory.
@@ -43,7 +42,7 @@ function hasModuleField( file ) {
 		return false;
 	}
 
-	return ! isEmpty( pkg.module );
+	return !! pkg.module;
 }
 
 /**

--- a/packages/dependency-extraction-webpack-plugin/test/__snapshots__/build.js.snap
+++ b/packages/dependency-extraction-webpack-plugin/test/__snapshots__/build.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`DependencyExtractionWebpackPlugin Webpack \`combine-assets\` should produce expected output: Asset file 'assets.php' should match snapshot 1`] = `
-"<?php return array('fileA.js' => array('dependencies' => array('lodash', 'wp-blob'), 'version' => 'cf268e19006bef774112'), 'fileB.js' => array('dependencies' => array('wp-token-list'), 'version' => '7f3970305cf0aecb54ab'));
+"<?php return array('fileA.js' => array('dependencies' => array('lodash', 'wp-blob'), 'version' => 'cbe985cf6e1a25d848e5'), 'fileB.js' => array('dependencies' => array('wp-token-list'), 'version' => '7f3970305cf0aecb54ab'));
 "
 `;
 
@@ -73,7 +73,7 @@ exports[`DependencyExtractionWebpackPlugin Webpack \`function-output-filename\` 
 `;
 
 exports[`DependencyExtractionWebpackPlugin Webpack \`has-extension-suffix\` should produce expected output: Asset file 'index.min.asset.php' should match snapshot 1`] = `
-"<?php return array('dependencies' => array('lodash', 'wp-blob'), 'version' => '49dba68ef238f954b358');
+"<?php return array('dependencies' => array('lodash', 'wp-blob'), 'version' => 'c3f17b34fdd974d57d0f');
 "
 `;
 

--- a/packages/dependency-extraction-webpack-plugin/test/fixtures/combine-assets/file-a.js
+++ b/packages/dependency-extraction-webpack-plugin/test/fixtures/combine-assets/file-a.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+// eslint-disable-next-line no-restricted-imports
 import { isEmpty } from 'lodash';
 
 /**

--- a/packages/dependency-extraction-webpack-plugin/test/fixtures/has-extension-suffix/index.js
+++ b/packages/dependency-extraction-webpack-plugin/test/fixtures/has-extension-suffix/index.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+// eslint-disable-next-line no-restricted-imports
 import { isEmpty } from 'lodash';
 
 /**


### PR DESCRIPTION
## What?
This PR removes remaining Lodash's `_.isEmpty()` usages completely and deprecates the function.

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?

We're falling back to boolean checks where applicable, and ignoring 2 usages since they are intentionally used in test fixtures and don't represent an actual, real production `import`.

## Testing Instructions

* Verify you can still build Gutenberg locally.
* Verify all checks are green.