### PR TITLE
Marks the selectors and actions of the commands store as a public API

### DIFF
--- a/packages/commands/README.md
+++ b/packages/commands/README.md
@@ -24,6 +24,18 @@ Undocumented declaration.
 
 Undocumented declaration.
 
+### store
+
+Store definition for the commands namespace.
+
+_Related_
+
+-   <https://github.com/WordPress/gutenberg/blob/HEAD/packages/data/README.md#createReduxStore>
+
+_Type_
+
+-   `Object`
+
 ### useCommand
 
 Attach a command to the Global command menu.

--- a/packages/commands/src/hooks/use-command-context.js
+++ b/packages/commands/src/hooks/use-command-context.js
@@ -8,6 +8,7 @@ import { useDispatch, useSelect } from '@wordpress/data';
  * Internal dependencies
  */
 import { store as commandsStore } from '../store';
+import { unlock } from '../lock-unlock';
 
 /**
  * Sets the active context of the command center
@@ -17,7 +18,7 @@ import { store as commandsStore } from '../store';
 export default function useCommandContext( context ) {
 	const { getContext } = useSelect( commandsStore );
 	const initialContext = useRef( getContext() );
-	const { setContext } = useDispatch( commandsStore );
+	const { setContext } = unlock( useDispatch( commandsStore ) );
 
 	useEffect( () => {
 		setContext( context );

--- a/packages/commands/src/index.js
+++ b/packages/commands/src/index.js
@@ -2,3 +2,4 @@ export { CommandMenu } from './components/command-menu';
 export { privateApis } from './private-apis';
 export { default as useCommand } from './hooks/use-command';
 export { default as useCommandLoader } from './hooks/use-command-loader';
+export { store } from './store';

--- a/packages/commands/src/lock-unlock.js
+++ b/packages/commands/src/lock-unlock.js
@@ -1,0 +1,10 @@
+/**
+ * WordPress dependencies
+ */
+import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/private-apis';
+
+export const { lock, unlock } =
+	__dangerousOptInToUnstableAPIsOnlyForCoreModules(
+		'I know using unstable features means my plugin or theme will inevitably break on the next WordPress release.',
+		'@wordpress/commands'
+	);

--- a/packages/commands/src/private-apis.js
+++ b/packages/commands/src/private-apis.js
@@ -1,22 +1,10 @@
 /**
- * WordPress dependencies
- */
-import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/private-apis';
-
-/**
  * Internal dependencies
  */
 import { default as useCommandContext } from './hooks/use-command-context';
-import { store } from './store';
-
-export const { lock, unlock } =
-	__dangerousOptInToUnstableAPIsOnlyForCoreModules(
-		'I know using unstable features means my plugin or theme will inevitably break on the next WordPress release.',
-		'@wordpress/commands'
-	);
+import { lock } from './lock-unlock';
 
 export const privateApis = {};
 lock( privateApis, {
 	useCommandContext,
-	store,
 } );

--- a/packages/commands/src/store/actions.js
+++ b/packages/commands/src/store/actions.js
@@ -104,17 +104,3 @@ export function close() {
 		type: 'CLOSE',
 	};
 }
-
-/**
- * Sets the active context.
- *
- * @param {string} context Context.
- *
- * @return {Object} action.
- */
-export function setContext( context ) {
-	return {
-		type: 'SET_CONTEXT',
-		context,
-	};
-}

--- a/packages/commands/src/store/index.js
+++ b/packages/commands/src/store/index.js
@@ -9,6 +9,8 @@ import { createReduxStore, register } from '@wordpress/data';
 import reducer from './reducer';
 import * as actions from './actions';
 import * as selectors from './selectors';
+import * as privateActions from './private-actions';
+import { unlock } from '../lock-unlock';
 
 const STORE_NAME = 'core/commands';
 
@@ -26,3 +28,4 @@ export const store = createReduxStore( STORE_NAME, {
 } );
 
 register( store );
+unlock( store ).registerPrivateActions( privateActions );

--- a/packages/commands/src/store/private-actions.js
+++ b/packages/commands/src/store/private-actions.js
@@ -1,0 +1,13 @@
+/**
+ * Sets the active context.
+ *
+ * @param {string} context Context.
+ *
+ * @return {Object} action.
+ */
+export function setContext( context ) {
+	return {
+		type: 'SET_CONTEXT',
+		context,
+	};
+}

--- a/packages/edit-post/src/components/header/document-title/index.js
+++ b/packages/edit-post/src/components/header/document-title/index.js
@@ -11,16 +11,13 @@ import {
 	__experimentalText as Text,
 } from '@wordpress/components';
 import { layout, chevronLeftSmall, chevronRightSmall } from '@wordpress/icons';
-import { privateApis as commandsPrivateApis } from '@wordpress/commands';
+import { store as commandsStore } from '@wordpress/commands';
 import { displayShortcut } from '@wordpress/keycodes';
 
 /**
  * Internal dependencies
  */
-import { unlock } from '../../../private-apis';
 import { store as editPostStore } from '../../../store';
-
-const { store: commandsStore } = unlock( commandsPrivateApis );
 
 function DocumentTitle() {
 	const { template, isEditing } = useSelect( ( select ) => {

--- a/packages/edit-site/src/components/header-edit-mode/document-actions/index.js
+++ b/packages/edit-site/src/components/header-edit-mode/document-actions/index.js
@@ -15,7 +15,7 @@ import {
 	__experimentalHStack as HStack,
 } from '@wordpress/components';
 import { BlockIcon } from '@wordpress/block-editor';
-import { privateApis as commandsPrivateApis } from '@wordpress/commands';
+import { store as commandsStore } from '@wordpress/commands';
 import {
 	chevronLeftSmall as chevronLeftSmallIcon,
 	page as pageIcon,
@@ -27,10 +27,7 @@ import { displayShortcut } from '@wordpress/keycodes';
  * Internal dependencies
  */
 import useEditedEntityRecord from '../../use-edited-entity-record';
-import { unlock } from '../../../private-apis';
 import { store as editSiteStore } from '../../../store';
-
-const { store: commandsStore } = unlock( commandsPrivateApis );
 
 export default function DocumentActions() {
 	const isPage = useSelect( ( select ) => select( editSiteStore ).isPage() );

--- a/packages/edit-site/src/components/site-hub/index.js
+++ b/packages/edit-site/src/components/site-hub/index.js
@@ -20,7 +20,7 @@ import { store as coreStore } from '@wordpress/core-data';
 import { decodeEntities } from '@wordpress/html-entities';
 import { forwardRef } from '@wordpress/element';
 import { search, external } from '@wordpress/icons';
-import { privateApis as commandsPrivateApis } from '@wordpress/commands';
+import { store as commandsStore } from '@wordpress/commands';
 
 /**
  * Internal dependencies
@@ -28,8 +28,6 @@ import { privateApis as commandsPrivateApis } from '@wordpress/commands';
 import { store as editSiteStore } from '../../store';
 import SiteIcon from '../site-icon';
 import { unlock } from '../../private-apis';
-
-const { store: commandsStore } = unlock( commandsPrivateApis );
 
 const HUB_ANIMATION_DURATION = 0.3;
 


### PR DESCRIPTION
## What?

There has been a clear interest from folks to have a direct access to the "store" API (selectors and actions) of the commands center to enable:

 - API access without React (no hooks)
 - Access to unregistration APIs (removing commands registered by Core for instance)

This Pr makes the "commandsStore" a public API like any other store but marks some specific actions of the store (setContext) as private. That one is something we don't want to open yet to third-parties.

## Testing Instructions

1- Open the site editor
2- Check that the command center still works
3- Check that you can call selectors from the console `wp.data.select( wp.commands.store ).getCommands()`
