### PR TITLE
Add distraction free to site editor

### DIFF
--- a/packages/base-styles/_z-index.scss
+++ b/packages/base-styles/_z-index.scss
@@ -182,6 +182,7 @@ $z-layers: (
 	".customize-widgets__block-toolbar": 7,
 
 	// Site editor layout
+	".edit-site-layout__header-container": 4,
 	".edit-site-layout__hub": 3,
 	".edit-site-layout__header": 2,
 	".edit-site-page-header": 2,

--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -711,6 +711,7 @@ _Properties_
 -   _maxWidth_ `number`: Max width to constraint resizing
 -   _allowedBlockTypes_ `boolean|Array`: Allowed block types
 -   _hasFixedToolbar_ `boolean`: Whether or not the editor toolbar is fixed
+-   _distractionFree_ `boolean`: Whether or not the editor UI is distraction free
 -   _focusMode_ `boolean`: Whether the focus mode is enabled or not
 -   _styles_ `Array`: Editor Styles
 -   _keepCaretInsideBlock_ `boolean`: Whether caret should move between blocks in edit mode

--- a/packages/block-editor/src/store/defaults.js
+++ b/packages/block-editor/src/store/defaults.js
@@ -18,6 +18,7 @@ export const PREFERENCES_DEFAULTS = {
  * @property {number}        maxWidth                               Max width to constraint resizing
  * @property {boolean|Array} allowedBlockTypes                      Allowed block types
  * @property {boolean}       hasFixedToolbar                        Whether or not the editor toolbar is fixed
+ * @property {boolean}       distractionFree                        Whether or not the editor UI is distraction free
  * @property {boolean}       focusMode                              Whether the focus mode is enabled or not
  * @property {Array}         styles                                 Editor Styles
  * @property {boolean}       keepCaretInsideBlock                   Whether caret should move between blocks in edit mode

--- a/packages/block-editor/src/utils/use-should-contextual-toolbar-show.js
+++ b/packages/block-editor/src/utils/use-should-contextual-toolbar-show.js
@@ -39,7 +39,7 @@ export function useShouldContextualToolbarShow() {
 
 			const isEditMode = __unstableGetEditorMode() === 'edit';
 			const hasFixedToolbar = getSettings().hasFixedToolbar;
-			const isDistractionFree = getSettings().distractionFree;
+			const isDistractionFree = getSettings().isDistractionFree;
 			const selectedBlockId =
 				getFirstMultiSelectedBlockClientId() ||
 				getSelectedBlockClientId();

--- a/packages/block-editor/src/utils/use-should-contextual-toolbar-show.js
+++ b/packages/block-editor/src/utils/use-should-contextual-toolbar-show.js
@@ -39,7 +39,7 @@ export function useShouldContextualToolbarShow() {
 
 			const isEditMode = __unstableGetEditorMode() === 'edit';
 			const hasFixedToolbar = getSettings().hasFixedToolbar;
-			const isDistractionFree = getSettings().isDistractionFree;
+			const isDistractionFree = getSettings().distractionFree;
 			const selectedBlockId =
 				getFirstMultiSelectedBlockClientId() ||
 				getSelectedBlockClientId();

--- a/packages/edit-post/src/components/header/index.js
+++ b/packages/edit-post/src/components/header/index.js
@@ -20,6 +20,16 @@ import MainDashboardButton from './main-dashboard-button';
 import { store as editPostStore } from '../../store';
 import DocumentTitle from './document-title';
 
+const slideY = {
+	hidden: { y: '-50px' },
+	hover: { y: 0, transition: { type: 'tween', delay: 0.2 } },
+};
+
+const slideX = {
+	hidden: { x: '-100%' },
+	hover: { x: 0, transition: { type: 'tween', delay: 0.2 } },
+};
+
 function Header( { setEntitiesSavedStatesCallback } ) {
 	const isLargeViewport = useViewportMatch( 'large' );
 	const {
@@ -38,16 +48,6 @@ function Header( { setEntitiesSavedStatesCallback } ) {
 		} ),
 		[]
 	);
-
-	const slideY = {
-		hidden: { y: '-50px' },
-		hover: { y: 0, transition: { type: 'tween', delay: 0.2 } },
-	};
-
-	const slideX = {
-		hidden: { x: '-100%' },
-		hover: { x: 0, transition: { type: 'tween', delay: 0.2 } },
-	};
 
 	return (
 		<div className="edit-post-header">

--- a/packages/edit-post/src/components/keyboard-shortcuts/index.js
+++ b/packages/edit-post/src/components/keyboard-shortcuts/index.js
@@ -223,8 +223,6 @@ function KeyboardShortcuts() {
 	} );
 
 	useShortcut( 'core/edit-post/toggle-distraction-free', () => {
-		closeGeneralSidebar();
-		setIsListViewOpened( false );
 		toggleDistractionFree();
 		toggleFeature( 'distractionFree' );
 		createInfoNotice(

--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -180,6 +180,7 @@ export default function Editor( { isLoading } ) {
 						<SidebarComplementaryAreaFills />
 						{ isEditMode && <StartTemplateOptions /> }
 						<InterfaceSkeleton
+							isDistractionFree={ true }
 							enableRegionNavigation={ false }
 							className={ classnames(
 								'edit-site-editor__interface-skeleton',

--- a/packages/edit-site/src/components/editor/style.scss
+++ b/packages/edit-site/src/components/editor/style.scss
@@ -6,6 +6,10 @@
 	&.is-loading {
 		opacity: 0;
 	}
+
+	.interface-interface-skeleton__header {
+		border: 0;
+	}
 }
 
 .edit-site-editor__toggle-save-panel {

--- a/packages/edit-site/src/components/header-edit-mode/index.js
+++ b/packages/edit-site/src/components/header-edit-mode/index.js
@@ -21,6 +21,7 @@ import { PinnedItems } from '@wordpress/interface';
 import { _x, __ } from '@wordpress/i18n';
 import { listView, plus, external, chevronUpDown } from '@wordpress/icons';
 import {
+	__unstableMotion as motion,
 	Button,
 	ToolbarItem,
 	MenuGroup,
@@ -161,6 +162,11 @@ export default function HeaderEditMode() {
 		window?.__experimentalEnableZoomedOutView && isVisualMode;
 	const isZoomedOutView = blockEditorMode === 'zoom-out';
 
+	const slideY = {
+		hidden: { y: '-50px' },
+		hover: { y: 0, transition: { type: 'tween', delay: 0.2 } },
+	};
+
 	return (
 		<div
 			className={ classnames( 'edit-site-header-edit-mode', {
@@ -169,6 +175,8 @@ export default function HeaderEditMode() {
 		>
 			{ hasDefaultEditorCanvasView && (
 				<NavigableToolbar
+					as={ isDistractionFree ? motion.div : 'div' }
+					variants={ slideY }
 					className="edit-site-header-edit-mode__start"
 					aria-label={ __( 'Document tools' ) }
 					shouldUseKeyboardFocusShortcut={
@@ -276,7 +284,10 @@ export default function HeaderEditMode() {
 			) }
 
 			<div className="edit-site-header-edit-mode__end">
-				<div className="edit-site-header-edit-mode__actions">
+				<motion.div
+					variants={ slideY }
+					className="edit-site-header-edit-mode__actions"
+				>
 					{ ! isFocusMode && hasDefaultEditorCanvasView && (
 						<div
 							className={ classnames(
@@ -312,7 +323,7 @@ export default function HeaderEditMode() {
 						<PinnedItems.Slot scope="core/edit-site" />
 					) }
 					<MoreMenu showIconLabels={ showIconLabels } />
-				</div>
+				</motion.div>
 			</div>
 		</div>
 	);

--- a/packages/edit-site/src/components/header-edit-mode/index.js
+++ b/packages/edit-site/src/components/header-edit-mode/index.js
@@ -7,7 +7,7 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { useCallback, useRef } from '@wordpress/element';
-import { useViewportMatch } from '@wordpress/compose';
+import { useViewportMatch, useReducedMotion } from '@wordpress/compose';
 import { store as coreStore } from '@wordpress/core-data';
 import {
 	ToolSelector,
@@ -114,6 +114,7 @@ export default function HeaderEditMode() {
 		setIsListViewOpened,
 	} = useDispatch( editSiteStore );
 	const { __unstableSetEditorMode } = useDispatch( blockEditorStore );
+	const disableMotion = useReducedMotion();
 
 	const isLargeViewport = useViewportMatch( 'medium' );
 
@@ -162,9 +163,15 @@ export default function HeaderEditMode() {
 		window?.__experimentalEnableZoomedOutView && isVisualMode;
 	const isZoomedOutView = blockEditorMode === 'zoom-out';
 
-	const slideY = {
-		hidden: { y: '-50px' },
-		hover: { y: 0, transition: { type: 'tween', delay: 0.2 } },
+	const toolbarVariants = {
+		isDistractionFree: { y: '-50px' },
+		isDistractionFreeHovering: { y: 0 },
+	};
+
+	const toolbarTransition = {
+		type: 'tween',
+		duration: disableMotion ? 0 : 0.2,
+		ease: 'easeOut',
 	};
 
 	return (
@@ -176,12 +183,13 @@ export default function HeaderEditMode() {
 			{ hasDefaultEditorCanvasView && (
 				<NavigableToolbar
 					as={ isDistractionFree ? motion.div : 'div' }
-					variants={ slideY }
 					className="edit-site-header-edit-mode__start"
 					aria-label={ __( 'Document tools' ) }
 					shouldUseKeyboardFocusShortcut={
 						! blockToolbarCanBeFocused
 					}
+					variants={ toolbarVariants }
+					transition={ toolbarTransition }
 				>
 					<div className="edit-site-header-edit-mode__toolbar">
 						{ ! isDistractionFree && (
@@ -285,8 +293,9 @@ export default function HeaderEditMode() {
 
 			<div className="edit-site-header-edit-mode__end">
 				<motion.div
-					variants={ slideY }
 					className="edit-site-header-edit-mode__actions"
+					variants={ toolbarVariants }
+					transition={ toolbarTransition }
 				>
 					{ ! isFocusMode && hasDefaultEditorCanvasView && (
 						<div

--- a/packages/edit-site/src/components/header-edit-mode/index.js
+++ b/packages/edit-site/src/components/header-edit-mode/index.js
@@ -166,6 +166,8 @@ export default function HeaderEditMode() {
 	const toolbarVariants = {
 		isDistractionFree: { y: '-50px' },
 		isDistractionFreeHovering: { y: 0 },
+		view: { y: 0 },
+		edit: { y: 0 },
 	};
 
 	const toolbarTransition = {
@@ -182,7 +184,7 @@ export default function HeaderEditMode() {
 		>
 			{ hasDefaultEditorCanvasView && (
 				<NavigableToolbar
-					as={ isDistractionFree ? motion.div : 'div' }
+					as={ motion.div }
 					className="edit-site-header-edit-mode__start"
 					aria-label={ __( 'Document tools' ) }
 					shouldUseKeyboardFocusShortcut={

--- a/packages/edit-site/src/components/header-edit-mode/index.js
+++ b/packages/edit-site/src/components/header-edit-mode/index.js
@@ -60,6 +60,7 @@ export default function HeaderEditMode() {
 		isListViewOpen,
 		listViewShortcut,
 		isVisualMode,
+		isDistractionFree,
 		blockEditorMode,
 		homeUrl,
 		showIconLabels,
@@ -99,6 +100,10 @@ export default function HeaderEditMode() {
 			editorCanvasView: unlock(
 				select( editSiteStore )
 			).getEditorCanvasContainerView(),
+			isDistractionFree: select( preferencesStore ).get(
+				'core/edit-site',
+				'distractionFree'
+			),
 		};
 	}, [] );
 
@@ -171,19 +176,23 @@ export default function HeaderEditMode() {
 					}
 				>
 					<div className="edit-site-header-edit-mode__toolbar">
-						<ToolbarItem
-							ref={ inserterButton }
-							as={ Button }
-							className="edit-site-header-edit-mode__inserter-toggle"
-							variant="primary"
-							isPressed={ isInserterOpen }
-							onMouseDown={ preventDefault }
-							onClick={ toggleInserter }
-							disabled={ ! isVisualMode }
-							icon={ plus }
-							label={ showIconLabels ? shortLabel : longLabel }
-							showTooltip={ ! showIconLabels }
-						/>
+						{ ! isDistractionFree && (
+							<ToolbarItem
+								ref={ inserterButton }
+								as={ Button }
+								className="edit-site-header-edit-mode__inserter-toggle"
+								variant="primary"
+								isPressed={ isInserterOpen }
+								onMouseDown={ preventDefault }
+								onClick={ toggleInserter }
+								disabled={ ! isVisualMode }
+								icon={ plus }
+								label={
+									showIconLabels ? shortLabel : longLabel
+								}
+								showTooltip={ ! showIconLabels }
+							/>
+						) }
 						{ isLargeViewport && (
 							<>
 								<ToolbarItem
@@ -208,54 +217,63 @@ export default function HeaderEditMode() {
 										showIconLabels ? 'tertiary' : undefined
 									}
 								/>
-								<ToolbarItem
-									as={ Button }
-									className="edit-site-header-edit-mode__list-view-toggle"
-									disabled={
-										! isVisualMode || isZoomedOutView
-									}
-									icon={ listView }
-									isPressed={ isListViewOpen }
-									/* translators: button label text should, if possible, be under 16 characters. */
-									label={ __( 'List View' ) }
-									onClick={ toggleListView }
-									shortcut={ listViewShortcut }
-									showTooltip={ ! showIconLabels }
-									variant={
-										showIconLabels ? 'tertiary' : undefined
-									}
-								/>
-								{ isZoomedOutViewExperimentEnabled && (
+								{ ! isDistractionFree && (
 									<ToolbarItem
 										as={ Button }
-										className="edit-site-header-edit-mode__zoom-out-view-toggle"
-										icon={ chevronUpDown }
-										isPressed={ isZoomedOutView }
+										className="edit-site-header-edit-mode__list-view-toggle"
+										disabled={
+											! isVisualMode || isZoomedOutView
+										}
+										icon={ listView }
+										isPressed={ isListViewOpen }
 										/* translators: button label text should, if possible, be under 16 characters. */
-										label={ __( 'Zoom-out View' ) }
-										onClick={ () => {
-											setPreviewDeviceType( 'desktop' );
-											__unstableSetEditorMode(
-												isZoomedOutView
-													? 'edit'
-													: 'zoom-out'
-											);
-										} }
+										label={ __( 'List View' ) }
+										onClick={ toggleListView }
+										shortcut={ listViewShortcut }
+										showTooltip={ ! showIconLabels }
+										variant={
+											showIconLabels
+												? 'tertiary'
+												: undefined
+										}
 									/>
 								) }
+								{ isZoomedOutViewExperimentEnabled &&
+									! isDistractionFree && (
+										<ToolbarItem
+											as={ Button }
+											className="edit-site-header-edit-mode__zoom-out-view-toggle"
+											icon={ chevronUpDown }
+											isPressed={ isZoomedOutView }
+											/* translators: button label text should, if possible, be under 16 characters. */
+											label={ __( 'Zoom-out View' ) }
+											onClick={ () => {
+												setPreviewDeviceType(
+													'desktop'
+												);
+												__unstableSetEditorMode(
+													isZoomedOutView
+														? 'edit'
+														: 'zoom-out'
+												);
+											} }
+										/>
+									) }
 							</>
 						) }
 					</div>
 				</NavigableToolbar>
 			) }
 
-			<div className="edit-site-header-edit-mode__center">
-				{ ! hasDefaultEditorCanvasView ? (
-					getEditorCanvasContainerTitle( editorCanvasView )
-				) : (
-					<DocumentActions />
-				) }
-			</div>
+			{ ! isDistractionFree && (
+				<div className="edit-site-header-edit-mode__center">
+					{ ! hasDefaultEditorCanvasView ? (
+						getEditorCanvasContainerTitle( editorCanvasView )
+					) : (
+						<DocumentActions />
+					) }
+				</div>
+			) }
 
 			<div className="edit-site-header-edit-mode__end">
 				<div className="edit-site-header-edit-mode__actions">
@@ -290,7 +308,9 @@ export default function HeaderEditMode() {
 						</div>
 					) }
 					<SaveButton />
-					<PinnedItems.Slot scope="core/edit-site" />
+					{ ! isDistractionFree && (
+						<PinnedItems.Slot scope="core/edit-site" />
+					) }
 					<MoreMenu showIconLabels={ showIconLabels } />
 				</div>
 			</div>

--- a/packages/edit-site/src/components/header-edit-mode/more-menu/index.js
+++ b/packages/edit-site/src/components/header-edit-mode/more-menu/index.js
@@ -3,12 +3,17 @@
  */
 import { __, _x } from '@wordpress/i18n';
 import { useReducer } from '@wordpress/element';
+import { useSelect, useDispatch, useRegistry } from '@wordpress/data';
 import { useShortcut } from '@wordpress/keyboard-shortcuts';
 import { displayShortcut } from '@wordpress/keycodes';
 import { external } from '@wordpress/icons';
 import { MenuGroup, MenuItem, VisuallyHidden } from '@wordpress/components';
 import { ActionItem, MoreMenuDropdown } from '@wordpress/interface';
-import { PreferenceToggleMenuItem } from '@wordpress/preferences';
+import {
+	PreferenceToggleMenuItem,
+	store as preferencesStore,
+} from '@wordpress/preferences';
+import { store as blockEditorStore } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
@@ -20,6 +25,7 @@ import SiteExport from './site-export';
 import WelcomeGuideMenuItem from './welcome-guide-menu-item';
 import CopyContentMenuItem from './copy-content-menu-item';
 import ModeSwitcher from '../mode-switcher';
+import { store as siteEditorStore } from '../../../store';
 
 export default function MoreMenu( { showIconLabels } ) {
 	const [ isModalActive, toggleModal ] = useReducer(
@@ -31,6 +37,39 @@ export default function MoreMenu( { showIconLabels } ) {
 		( isActive ) => ! isActive,
 		false
 	);
+
+	const registry = useRegistry();
+	const isDistractionFree = useSelect(
+		( select ) =>
+			select( preferencesStore ).get(
+				'core/edit-site',
+				'distractionFree'
+			),
+		[]
+	);
+
+	const blocks = useSelect(
+		( select ) => select( blockEditorStore ).getBlocks(),
+		[]
+	);
+
+	const { setIsInserterOpened, setIsListViewOpened, closeGeneralSidebar } =
+		useDispatch( siteEditorStore );
+	const { set: setPreference } = useDispatch( preferencesStore );
+
+	const { selectBlock } = useDispatch( blockEditorStore );
+
+	const toggleDistractionFree = () => {
+		registry.batch( () => {
+			setPreference( 'core/edit-site', 'fixedToolbar', false );
+			setIsInserterOpened( false );
+			setIsListViewOpened( false );
+			closeGeneralSidebar();
+			if ( ! isDistractionFree && !! blocks.length ) {
+				selectBlock( blocks[ 0 ].clientId );
+			}
+		} );
+	};
 
 	useShortcut( 'core/edit-site/keyboard-shortcuts', toggleModal );
 
@@ -48,6 +87,7 @@ export default function MoreMenu( { showIconLabels } ) {
 							<PreferenceToggleMenuItem
 								scope="core/edit-site"
 								name="fixedToolbar"
+								disabled={ isDistractionFree }
 								label={ __( 'Top toolbar' ) }
 								info={ __(
 									'Access all block and document tools in a single place'
@@ -69,6 +109,22 @@ export default function MoreMenu( { showIconLabels } ) {
 								) }
 								messageDeactivated={ __(
 									'Spotlight mode deactivated'
+								) }
+							/>
+							<PreferenceToggleMenuItem
+								scope="core/edit-site"
+								name="distractionFree"
+								onToggle={ toggleDistractionFree }
+								label={ __( 'Distraction free' ) }
+								info={ __( 'Write with calmness' ) }
+								messageActivated={ __(
+									'Distraction free mode activated'
+								) }
+								messageDeactivated={ __(
+									'Distraction free mode deactivated'
+								) }
+								shortcut={ displayShortcut.primaryShift(
+									'\\'
 								) }
 							/>
 							<ModeSwitcher />

--- a/packages/edit-site/src/components/header-edit-mode/more-menu/index.js
+++ b/packages/edit-site/src/components/header-edit-mode/more-menu/index.js
@@ -13,7 +13,6 @@ import {
 	PreferenceToggleMenuItem,
 	store as preferencesStore,
 } from '@wordpress/preferences';
-import { store as blockEditorStore } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
@@ -48,16 +47,9 @@ export default function MoreMenu( { showIconLabels } ) {
 		[]
 	);
 
-	const blocks = useSelect(
-		( select ) => select( blockEditorStore ).getBlocks(),
-		[]
-	);
-
 	const { setIsInserterOpened, setIsListViewOpened, closeGeneralSidebar } =
 		useDispatch( siteEditorStore );
 	const { set: setPreference } = useDispatch( preferencesStore );
-
-	const { selectBlock } = useDispatch( blockEditorStore );
 
 	const toggleDistractionFree = () => {
 		registry.batch( () => {
@@ -65,9 +57,6 @@ export default function MoreMenu( { showIconLabels } ) {
 			setIsInserterOpened( false );
 			setIsListViewOpened( false );
 			closeGeneralSidebar();
-			if ( ! isDistractionFree && !! blocks.length ) {
-				selectBlock( blocks[ 0 ].clientId );
-			}
 		} );
 	};
 

--- a/packages/edit-site/src/components/keyboard-shortcuts/edit-mode.js
+++ b/packages/edit-site/src/components/keyboard-shortcuts/edit-mode.js
@@ -1,12 +1,15 @@
 /**
  * WordPress dependencies
  */
+import { __ } from '@wordpress/i18n';
 import { useShortcut } from '@wordpress/keyboard-shortcuts';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 import { store as interfaceStore } from '@wordpress/interface';
 import { createBlock } from '@wordpress/blocks';
+import { store as preferencesStore } from '@wordpress/preferences';
+import { store as noticesStore } from '@wordpress/notices';
 
 /**
  * Internal dependencies
@@ -29,14 +32,30 @@ function KeyboardShortcutsEditMode() {
 		[]
 	);
 	const { redo, undo } = useDispatch( coreStore );
-	const { setIsListViewOpened, switchEditorMode } =
-		useDispatch( editSiteStore );
+	const {
+		isFeatureActive,
+		setIsListViewOpened,
+		switchEditorMode,
+		toggleFeature,
+		setIsInserterOpened,
+		closeGeneralSidebar,
+	} = useDispatch( editSiteStore );
 	const { enableComplementaryArea, disableComplementaryArea } =
 		useDispatch( interfaceStore );
 
 	const { replaceBlocks } = useDispatch( blockEditorStore );
 	const { getBlockName, getSelectedBlockClientId, getBlockAttributes } =
 		useSelect( blockEditorStore );
+
+	const { set: setPreference } = useDispatch( preferencesStore );
+	const { createInfoNotice } = useDispatch( noticesStore );
+
+	const toggleDistractionFree = () => {
+		setPreference( 'core/edit-site', 'fixedToolbar', false );
+		setIsInserterOpened( false );
+		setIsListViewOpened( false );
+		closeGeneralSidebar();
+	};
 
 	const handleTextLevelShortcut = ( event, level ) => {
 		event.preventDefault();
@@ -111,6 +130,20 @@ function KeyboardShortcutsEditMode() {
 		useShortcut(
 			`core/edit-site/transform-paragraph-to-heading-${ level }`,
 			( event ) => handleTextLevelShortcut( event, level )
+		);
+	} );
+
+	useShortcut( 'core/edit-site/toggle-distraction-free', () => {
+		toggleDistractionFree();
+		toggleFeature( 'distractionFree' );
+		createInfoNotice(
+			isFeatureActive( 'distractionFree' )
+				? __( 'Distraction free mode turned on.' )
+				: __( 'Distraction free mode turned off.' ),
+			{
+				id: 'core/edit-site/distraction-free-mode/notice',
+				type: 'snackbar',
+			}
 		);
 	} );
 

--- a/packages/edit-site/src/components/keyboard-shortcuts/register.js
+++ b/packages/edit-site/src/components/keyboard-shortcuts/register.js
@@ -149,6 +149,16 @@ function KeyboardShortcutsRegister() {
 				},
 			} );
 		} );
+
+		registerShortcut( {
+			name: 'core/edit-site/toggle-distraction-free',
+			category: 'global',
+			description: __( 'Toggle distraction free mode.' ),
+			keyCombination: {
+				modifier: 'primaryShift',
+				character: '\\',
+			},
+		} );
 	}, [ registerShortcut ] );
 
 	return null;

--- a/packages/edit-site/src/components/layout/index.js
+++ b/packages/edit-site/src/components/layout/index.js
@@ -168,72 +168,64 @@ export default function Layout() {
 					}
 				) }
 			>
-				{ isEditing && (
-					<motion.div
-						className="edit-site-layout__header-container"
-						variants={ headerVariants }
-						initial={
-							isDistractionFree
-								? 'hidden'
-								: 'distractionFreeInactive'
-						}
-						whileHover={
-							isDistractionFree
-								? 'hover'
-								: 'distractionFreeInactive'
-						}
-						animate={
-							isDistractionFree
-								? 'hidden'
-								: 'distractionFreeInactive'
-						}
-						transition={ { type: 'tween', delay: 0.2 } }
-					>
-						{ isDistractionFree && (
-							<SiteHub
+				<motion.div
+					className="edit-site-layout__header-container"
+					variants={ isEditing ? headerVariants : null }
+					initial={
+						isDistractionFree ? 'hidden' : 'distractionFreeInactive'
+					}
+					whileHover={
+						isDistractionFree ? 'hover' : 'distractionFreeInactive'
+					}
+					animate={
+						isDistractionFree ? 'hidden' : 'distractionFreeInactive'
+					}
+					transition={ { type: 'tween', delay: 0.2 } }
+				>
+					{ isDistractionFree && isEditing && (
+						<SiteHub
+							as={ motion.div }
+							variants={ slideX }
+							ref={ hubRef }
+							className="edit-site-layout__hub"
+						/>
+					) }
+
+					{ ( ! isDistractionFree || ! isEditing ) && (
+						<SiteHub
+							ref={ hubRef }
+							className="edit-site-layout__hub"
+						/>
+					) }
+
+					<AnimatePresence initial={ false }>
+						{ isEditorPage && isEditing && (
+							<NavigableRegion
+								className="edit-site-layout__header"
+								ariaLabel={ __( 'Editor top bar' ) }
 								as={ motion.div }
-								variants={ slideX }
-								ref={ hubRef }
-								className="edit-site-layout__hub"
-							/>
+								animate={ {
+									y: 0,
+								} }
+								initial={ {
+									y: '-100%',
+								} }
+								exit={ {
+									y: '-100%',
+								} }
+								transition={ {
+									type: 'tween',
+									duration: disableMotion
+										? 0
+										: ANIMATION_DURATION,
+									ease: 'easeOut',
+								} }
+							>
+								{ isEditing && <Header /> }
+							</NavigableRegion>
 						) }
-
-						{ ! isDistractionFree && (
-							<SiteHub
-								ref={ hubRef }
-								className="edit-site-layout__hub"
-							/>
-						) }
-
-						<AnimatePresence initial={ false }>
-							{ isEditorPage && isEditing && (
-								<NavigableRegion
-									className="edit-site-layout__header"
-									ariaLabel={ __( 'Editor top bar' ) }
-									as={ motion.div }
-									animate={ {
-										y: 0,
-									} }
-									initial={ {
-										y: '-100%',
-									} }
-									exit={ {
-										y: '-100%',
-									} }
-									transition={ {
-										type: 'tween',
-										duration: disableMotion
-											? 0
-											: ANIMATION_DURATION,
-										ease: 'easeOut',
-									} }
-								>
-									{ isEditing && <Header /> }
-								</NavigableRegion>
-							) }
-						</AnimatePresence>
-					</motion.div>
-				) }
+					</AnimatePresence>
+				</motion.div>
 
 				<div className="edit-site-layout__content">
 					<AnimatePresence initial={ false }>

--- a/packages/edit-site/src/components/layout/index.js
+++ b/packages/edit-site/src/components/layout/index.js
@@ -219,16 +219,6 @@ export default function Layout() {
 									view: { opacity: 1 },
 									edit: { opacity: 1 },
 								} }
-								initial={ {
-									isDistractionFree: {
-										opacity: 0,
-									},
-								} }
-								exit={ {
-									isDistractionFree: {
-										opacity: 0,
-									},
-								} }
 								transition={ {
 									type: 'tween',
 									duration: disableMotion

--- a/packages/edit-site/src/components/layout/index.js
+++ b/packages/edit-site/src/components/layout/index.js
@@ -72,6 +72,7 @@ export default function Layout() {
 	const isMobileViewport = useViewportMatch( 'medium', '<' );
 	const isListPage = getIsListPage( params, isMobileViewport );
 	const isEditorPage = ! isListPage;
+<<<<<<< HEAD
 	const { hasFixedToolbar, canvasMode, previousShortcut, nextShortcut } =
 		useSelect( ( select ) => {
 			const { getAllShortcutKeyCombinations } = select(
@@ -89,6 +90,10 @@ export default function Layout() {
 				hasFixedToolbar: select( preferencesStore ).get(
 					'core/edit-site',
 					'fixedToolbar'
+				),
+				isDistractionFree: select( preferencesStore ).get(
+					'core/edit-site',
+					'distractionFree'
 				),
 			};
 		}, [] );
@@ -129,6 +134,15 @@ export default function Layout() {
 		return null;
 	}
 
+	const headerVariants = {
+		hidden:
+			isDistractionFree && isEditing ? { opacity: 0 } : { opacity: 1 },
+		hover: {
+			opacity: 1,
+			transition: { type: 'tween', delay: 0.2, delayChildren: 0.2 },
+		},
+	};
+
 	return (
 		<>
 			<CommandMenu />
@@ -142,41 +156,94 @@ export default function Layout() {
 					'edit-site-layout',
 					navigateRegionsProps.className,
 					{
+						'is-distraction-free': isDistractionFree && isEditing,
 						'is-full-canvas': isFullCanvas,
 						'is-edit-mode': isEditing,
 						'has-fixed-toolbar': hasFixedToolbar,
 					}
 				) }
 			>
-				<SiteHub ref={ hubRef } className="edit-site-layout__hub" />
+				{ isDistractionFree && isEditing && (
+					<motion.div
+						className="edit-site-layout__header-container"
+						initial={
+							isDistractionFree && isEditing ? 'hidden' : 'hover'
+						}
+						whileHover="hover"
+						variants={ headerVariants }
+						transition={ { type: 'tween', delay: 0.8 } }
+					>
+						<SiteHub
+							ref={ hubRef }
+							className="edit-site-layout__hub"
+						/>
 
-				<AnimatePresence initial={ false }>
-					{ isEditorPage && isEditing && (
-						<NavigableRegion
-							className="edit-site-layout__header"
-							ariaLabel={ __( 'Editor top bar' ) }
-							as={ motion.div }
-							animate={ {
-								y: 0,
-							} }
-							initial={ {
-								y: '-100%',
-							} }
-							exit={ {
-								y: '-100%',
-							} }
-							transition={ {
-								type: 'tween',
-								duration: disableMotion
-									? 0
-									: ANIMATION_DURATION,
-								ease: 'easeOut',
-							} }
-						>
-							{ isEditing && <Header /> }
-						</NavigableRegion>
-					) }
-				</AnimatePresence>
+						<AnimatePresence initial={ false }>
+							{ isEditorPage && isEditing && (
+								<NavigableRegion
+									className="edit-site-layout__header"
+									ariaLabel={ __( 'Editor top bar' ) }
+									as={ motion.div }
+									animate={ {
+										y: 0,
+									} }
+									initial={ {
+										y: '-100%',
+									} }
+									exit={ {
+										y: '-100%',
+									} }
+									transition={ {
+										type: 'tween',
+										duration: disableMotion
+											? 0
+											: ANIMATION_DURATION,
+										ease: 'easeOut',
+									} }
+								>
+									{ isEditing && <Header /> }
+								</NavigableRegion>
+							) }
+						</AnimatePresence>
+					</motion.div>
+				) }
+
+				{ ( ! isDistractionFree || ! isEditing ) && (
+					<>
+						<SiteHub
+							ref={ hubRef }
+							className="edit-site-layout__hub"
+						/>
+
+						<AnimatePresence initial={ false }>
+							{ isEditorPage && isEditing && (
+								<NavigableRegion
+									className="edit-site-layout__header"
+									ariaLabel={ __( 'Editor top bar' ) }
+									as={ motion.div }
+									animate={ {
+										y: 0,
+									} }
+									initial={ {
+										y: '-100%',
+									} }
+									exit={ {
+										y: '-100%',
+									} }
+									transition={ {
+										type: 'tween',
+										duration: disableMotion
+											? 0
+											: ANIMATION_DURATION,
+										ease: 'easeOut',
+									} }
+								>
+									{ isEditing && <Header /> }
+								</NavigableRegion>
+							) }
+						</AnimatePresence>
+					</>
+				) }
 
 				<div className="edit-site-layout__content">
 					<AnimatePresence initial={ false }>

--- a/packages/edit-site/src/components/layout/index.js
+++ b/packages/edit-site/src/components/layout/index.js
@@ -180,9 +180,19 @@ export default function Layout() {
 					variants={ {
 						isDistractionFree: {
 							opacity: 0,
+							transition: {
+								type: 'tween',
+								delay: 0.8,
+								delayChildren: 0.8,
+							}, // How long to wait before the header exits
 						},
 						isDistractionFreeHovering: {
 							opacity: 1,
+							transition: {
+								type: 'tween',
+								delay: 0.2,
+								delayChildren: 0.2,
+							}, // How long to wait before the header shows
 						},
 						view: { opacity: 1 },
 						edit: { opacity: 1 },
@@ -193,7 +203,6 @@ export default function Layout() {
 							: undefined
 					}
 					animate={ headerAnimationState }
-					transition={ { type: 'tween', delay: 0.2 } }
 				>
 					<SiteHub
 						as={ motion.div }
@@ -221,11 +230,8 @@ export default function Layout() {
 								} }
 								transition={ {
 									type: 'tween',
-									duration: disableMotion
-										? 0
-										: ANIMATION_DURATION,
+									duration: disableMotion ? 0 : 0.2,
 									ease: 'easeOut',
-									delayChildren: 0.2,
 								} }
 							>
 								{ isEditing && <Header /> }

--- a/packages/edit-site/src/components/layout/index.js
+++ b/packages/edit-site/src/components/layout/index.js
@@ -72,31 +72,36 @@ export default function Layout() {
 	const isMobileViewport = useViewportMatch( 'medium', '<' );
 	const isListPage = getIsListPage( params, isMobileViewport );
 	const isEditorPage = ! isListPage;
-<<<<<<< HEAD
-	const { hasFixedToolbar, canvasMode, previousShortcut, nextShortcut } =
-		useSelect( ( select ) => {
-			const { getAllShortcutKeyCombinations } = select(
-				keyboardShortcutsStore
-			);
-			const { getCanvasMode } = unlock( select( editSiteStore ) );
-			return {
-				canvasMode: getCanvasMode(),
-				previousShortcut: getAllShortcutKeyCombinations(
-					'core/edit-site/previous-region'
-				),
-				nextShortcut: getAllShortcutKeyCombinations(
-					'core/edit-site/next-region'
-				),
-				hasFixedToolbar: select( preferencesStore ).get(
-					'core/edit-site',
-					'fixedToolbar'
-				),
-				isDistractionFree: select( preferencesStore ).get(
-					'core/edit-site',
-					'distractionFree'
-				),
-			};
-		}, [] );
+
+	const {
+		isDistractionFree,
+		hasFixedToolbar,
+		canvasMode,
+		previousShortcut,
+		nextShortcut,
+	} = useSelect( ( select ) => {
+		const { getAllShortcutKeyCombinations } = select(
+			keyboardShortcutsStore
+		);
+		const { getCanvasMode } = unlock( select( editSiteStore ) );
+		return {
+			canvasMode: getCanvasMode(),
+			previousShortcut: getAllShortcutKeyCombinations(
+				'core/edit-site/previous-region'
+			),
+			nextShortcut: getAllShortcutKeyCombinations(
+				'core/edit-site/next-region'
+			),
+			hasFixedToolbar: select( preferencesStore ).get(
+				'core/edit-site',
+				'fixedToolbar'
+			),
+			isDistractionFree: select( preferencesStore ).get(
+				'core/edit-site',
+				'distractionFree'
+			),
+		};
+	}, [] );
 	const isEditing = canvasMode === 'edit';
 	const navigateRegionsProps = useNavigateRegions( {
 		previous: previousShortcut,

--- a/packages/edit-site/src/components/layout/index.js
+++ b/packages/edit-site/src/components/layout/index.js
@@ -135,12 +135,12 @@ export default function Layout() {
 	}
 
 	const headerVariants = {
-		hidden:
-			isDistractionFree && isEditing ? { opacity: 0 } : { opacity: 1 },
+		hidden: { opacity: 0 },
 		hover: {
 			opacity: 1,
 			transition: { type: 'tween', delay: 0.2, delayChildren: 0.2 },
 		},
+		distractionFreeInactive: { opacity: 1 },
 	};
 
 	return (
@@ -163,20 +163,33 @@ export default function Layout() {
 					}
 				) }
 			>
-				{ isDistractionFree && isEditing && (
+				{ isEditing && (
 					<motion.div
 						className="edit-site-layout__header-container"
-						initial={
-							isDistractionFree && isEditing ? 'hidden' : 'hover'
-						}
-						whileHover="hover"
 						variants={ headerVariants }
+						initial={
+							isDistractionFree
+								? 'hidden'
+								: 'distractionFreeInactive'
+						}
+						whileHover={
+							isDistractionFree
+								? 'hover'
+								: 'distractionFreeInactive'
+						}
+						animate={
+							isDistractionFree
+								? 'hidden'
+								: 'distractionFreeInactive'
+						}
 						transition={ { type: 'tween', delay: 0.8 } }
 					>
-						<SiteHub
-							ref={ hubRef }
-							className="edit-site-layout__hub"
-						/>
+						<motion.div>
+							<SiteHub
+								ref={ hubRef }
+								className="edit-site-layout__hub"
+							/>
+						</motion.div>
 
 						<AnimatePresence initial={ false }>
 							{ isEditorPage && isEditing && (
@@ -206,43 +219,6 @@ export default function Layout() {
 							) }
 						</AnimatePresence>
 					</motion.div>
-				) }
-
-				{ ( ! isDistractionFree || ! isEditing ) && (
-					<>
-						<SiteHub
-							ref={ hubRef }
-							className="edit-site-layout__hub"
-						/>
-
-						<AnimatePresence initial={ false }>
-							{ isEditorPage && isEditing && (
-								<NavigableRegion
-									className="edit-site-layout__header"
-									ariaLabel={ __( 'Editor top bar' ) }
-									as={ motion.div }
-									animate={ {
-										y: 0,
-									} }
-									initial={ {
-										y: '-100%',
-									} }
-									exit={ {
-										y: '-100%',
-									} }
-									transition={ {
-										type: 'tween',
-										duration: disableMotion
-											? 0
-											: ANIMATION_DURATION,
-										ease: 'easeOut',
-									} }
-								>
-									{ isEditing && <Header /> }
-								</NavigableRegion>
-							) }
-						</AnimatePresence>
-					</>
 				) }
 
 				<div className="edit-site-layout__content">

--- a/packages/edit-site/src/components/layout/index.js
+++ b/packages/edit-site/src/components/layout/index.js
@@ -143,6 +143,11 @@ export default function Layout() {
 		distractionFreeInactive: { opacity: 1 },
 	};
 
+	const slideX = {
+		hidden: { x: '-100%' },
+		hover: { x: 0, transition: { type: 'tween', delay: 0.2 } },
+	};
+
 	return (
 		<>
 			<CommandMenu />
@@ -182,14 +187,23 @@ export default function Layout() {
 								? 'hidden'
 								: 'distractionFreeInactive'
 						}
-						transition={ { type: 'tween', delay: 0.8 } }
+						transition={ { type: 'tween', delay: 0.2 } }
 					>
-						<motion.div>
+						{ isDistractionFree && (
+							<SiteHub
+								as={ motion.div }
+								variants={ slideX }
+								ref={ hubRef }
+								className="edit-site-layout__hub"
+							/>
+						) }
+
+						{ ! isDistractionFree && (
 							<SiteHub
 								ref={ hubRef }
 								className="edit-site-layout__hub"
 							/>
-						</motion.div>
+						) }
 
 						<AnimatePresence initial={ false }>
 							{ isEditorPage && isEditing && (

--- a/packages/edit-site/src/components/layout/index.js
+++ b/packages/edit-site/src/components/layout/index.js
@@ -59,20 +59,6 @@ const { useGlobalStyle } = unlock( blockEditorPrivateApis );
 
 const ANIMATION_DURATION = 0.5;
 
-const headerVariants = {
-	hidden: { opacity: 0 },
-	hover: {
-		opacity: 1,
-		transition: { type: 'tween', delay: 0.2, delayChildren: 0.2 },
-	},
-	distractionFreeInactive: { opacity: 1 },
-};
-
-const slideX = {
-	hidden: { x: '-100%' },
-	hover: { x: 0, transition: { type: 'tween', delay: 0.2 } },
-};
-
 export default function Layout() {
 	// This ensures the edited entity id and type are initialized properly.
 	useInitEditedEntityFromURL();
@@ -131,6 +117,27 @@ export default function Layout() {
 	const [ isResizing ] = useState( false );
 	const isEditorLoading = useIsSiteEditorLoading();
 
+	// This determines which animation variant should apply to the header.
+	// There is also a `isDistractionFreeHovering` state that gets priority
+	// when hovering the `edit-site-layout__header-container` in distraction
+	// free mode. It's set via framer and trickles down to all the children
+	// so they can use this variant state too.
+	//
+	// TODO: The issue with this is we want to have the hover state stick when hovering
+	// a popover opened via the header. We'll probably need to lift this state to
+	// handle it ourselves. Also, focusWithin the header needs to be handled.
+	let headerAnimationState;
+
+	if ( canvasMode === 'view' ) {
+		// We need 'view' to always take priority so 'isDistractionFree'
+		// doesn't bleed over into the view (sidebar) state
+		headerAnimationState = 'view';
+	} else if ( isDistractionFree ) {
+		headerAnimationState = 'isDistractionFree';
+	} else {
+		headerAnimationState = canvasMode; // edit, view, init
+	}
+
 	// Sets the right context for the command center
 	const commandContext =
 		canvasMode === 'edit' && isEditorPage
@@ -170,33 +177,35 @@ export default function Layout() {
 			>
 				<motion.div
 					className="edit-site-layout__header-container"
-					variants={ isEditing ? headerVariants : null }
-					initial={
-						isDistractionFree ? 'hidden' : 'distractionFreeInactive'
-					}
+					variants={ {
+						isDistractionFree: {
+							opacity: 0,
+						},
+						isDistractionFreeHovering: {
+							opacity: 1,
+						},
+						view: { opacity: 1 },
+						edit: { opacity: 1 },
+					} }
 					whileHover={
-						isDistractionFree ? 'hover' : 'distractionFreeInactive'
+						isDistractionFree
+							? 'isDistractionFreeHovering'
+							: undefined
 					}
-					animate={
-						isDistractionFree ? 'hidden' : 'distractionFreeInactive'
-					}
+					animate={ headerAnimationState }
 					transition={ { type: 'tween', delay: 0.2 } }
 				>
-					{ isDistractionFree && isEditing && (
-						<SiteHub
-							as={ motion.div }
-							variants={ slideX }
-							ref={ hubRef }
-							className="edit-site-layout__hub"
-						/>
-					) }
-
-					{ ( ! isDistractionFree || ! isEditing ) && (
-						<SiteHub
-							ref={ hubRef }
-							className="edit-site-layout__hub"
-						/>
-					) }
+					<SiteHub
+						as={ motion.div }
+						variants={ {
+							isDistractionFree: { x: '-100%' },
+							isDistractionFreeHovering: { x: 0 },
+							view: { x: 0 },
+							edit: { x: 0 },
+						} }
+						ref={ hubRef }
+						className="edit-site-layout__hub"
+					/>
 
 					<AnimatePresence initial={ false }>
 						{ isEditorPage && isEditing && (
@@ -204,14 +213,21 @@ export default function Layout() {
 								className="edit-site-layout__header"
 								ariaLabel={ __( 'Editor top bar' ) }
 								as={ motion.div }
-								animate={ {
-									y: 0,
+								variants={ {
+									isDistractionFree: { opacity: 0 },
+									isDistractionFreeHovering: { opacity: 1 },
+									view: { opacity: 1 },
+									edit: { opacity: 1 },
 								} }
 								initial={ {
-									y: '-100%',
+									isDistractionFree: {
+										opacity: 0,
+									},
 								} }
 								exit={ {
-									y: '-100%',
+									isDistractionFree: {
+										opacity: 0,
+									},
 								} }
 								transition={ {
 									type: 'tween',
@@ -219,6 +235,7 @@ export default function Layout() {
 										? 0
 										: ANIMATION_DURATION,
 									ease: 'easeOut',
+									delayChildren: 0.2,
 								} }
 							>
 								{ isEditing && <Header /> }

--- a/packages/edit-site/src/components/layout/index.js
+++ b/packages/edit-site/src/components/layout/index.js
@@ -59,6 +59,20 @@ const { useGlobalStyle } = unlock( blockEditorPrivateApis );
 
 const ANIMATION_DURATION = 0.5;
 
+const headerVariants = {
+	hidden: { opacity: 0 },
+	hover: {
+		opacity: 1,
+		transition: { type: 'tween', delay: 0.2, delayChildren: 0.2 },
+	},
+	distractionFreeInactive: { opacity: 1 },
+};
+
+const slideX = {
+	hidden: { x: '-100%' },
+	hover: { x: 0, transition: { type: 'tween', delay: 0.2 } },
+};
+
 export default function Layout() {
 	// This ensures the edited entity id and type are initialized properly.
 	useInitEditedEntityFromURL();
@@ -133,20 +147,6 @@ export default function Layout() {
 	if ( canvasMode === 'init' ) {
 		return null;
 	}
-
-	const headerVariants = {
-		hidden: { opacity: 0 },
-		hover: {
-			opacity: 1,
-			transition: { type: 'tween', delay: 0.2, delayChildren: 0.2 },
-		},
-		distractionFreeInactive: { opacity: 1 },
-	};
-
-	const slideX = {
-		hidden: { x: '-100%' },
-		hover: { x: 0, transition: { type: 'tween', delay: 0.2 } },
-	};
 
 	return (
 		<>

--- a/packages/edit-site/src/components/layout/style.scss
+++ b/packages/edit-site/src/components/layout/style.scss
@@ -258,3 +258,27 @@
 	}
 }
 
+.is-edit-mode.is-distraction-free {
+
+	.edit-site-layout__header-container {
+		position: absolute;
+		top: 0;
+		left: 0;
+		right: 0;
+		z-index: 9998;
+		width: 100%;
+	}
+
+	.edit-site-site-hub,
+	.edit-site-layout__header {
+		position: absolute;
+		top: 0;
+		z-index: 9999;
+	}
+	.edit-site-site-hub {
+		z-index: 10000;
+	}
+	.edit-site-layout__header {
+		width: 100%;
+	}
+}

--- a/packages/edit-site/src/components/layout/style.scss
+++ b/packages/edit-site/src/components/layout/style.scss
@@ -253,6 +253,9 @@
 	// so the fixed toolbar can be positioned on top of it
 	// but only on desktop
 	@include break-medium() {
+		.edit-site-layout__canvas-container {
+			z-index: 5;
+		}
 		.edit-site-site-hub {
 			z-index: 4;
 		}
@@ -270,7 +273,7 @@
 		top: 0;
 		left: 0;
 		right: 0;
-		z-index: 9998;
+		z-index: z-index(".edit-site-layout__header-container");
 		width: 100%;
 
 		// We need ! important because we override inline styles

--- a/packages/edit-site/src/components/layout/style.scss
+++ b/packages/edit-site/src/components/layout/style.scss
@@ -36,6 +36,10 @@
 	}
 }
 
+.edit-site-layout__header-container {
+	z-index: z-index(".edit-site-layout__header-container");
+}
+
 .edit-site-layout__header {
 	height: $header-height;
 	display: flex;
@@ -261,6 +265,7 @@
 .is-edit-mode.is-distraction-free {
 
 	.edit-site-layout__header-container {
+		height: $header-height;
 		position: absolute;
 		top: 0;
 		left: 0;

--- a/packages/edit-site/src/components/layout/style.scss
+++ b/packages/edit-site/src/components/layout/style.scss
@@ -272,6 +272,19 @@
 		right: 0;
 		z-index: 9998;
 		width: 100%;
+
+		// We need ! important because we override inline styles
+		// set by the motion component.
+		&:focus-within {
+			opacity: 1 !important;
+			div {
+				transform: translateX(0) translateY(0) translateZ(0) !important;
+			}
+
+			.edit-site-layout__header {
+				opacity: 1 !important;
+			}
+		}
 	}
 
 	.edit-site-site-hub,
@@ -286,4 +299,5 @@
 	.edit-site-layout__header {
 		width: 100%;
 	}
+
 }

--- a/packages/edit-site/src/components/layout/style.scss
+++ b/packages/edit-site/src/components/layout/style.scss
@@ -291,10 +291,10 @@
 	.edit-site-layout__header {
 		position: absolute;
 		top: 0;
-		z-index: 9999;
+		z-index: z-index(".edit-site-layout__header");
 	}
 	.edit-site-site-hub {
-		z-index: 10000;
+		z-index: z-index(".edit-site-layout__hub");
 	}
 	.edit-site-layout__header {
 		width: 100%;

--- a/packages/edit-site/src/components/preferences-modal/enable-feature.js
+++ b/packages/edit-site/src/components/preferences-modal/enable-feature.js
@@ -6,14 +6,17 @@ import { ___unstablePreferencesModalBaseOption as BaseOption } from '@wordpress/
 import { store as preferencesStore } from '@wordpress/preferences';
 
 export default function EnableFeature( props ) {
-	const { featureName, ...remainingProps } = props;
+	const { featureName, onToggle = () => {}, ...remainingProps } = props;
 	const isChecked = useSelect(
 		( select ) =>
 			!! select( preferencesStore ).get( 'core/edit-site', featureName ),
 		[ featureName ]
 	);
 	const { toggle } = useDispatch( preferencesStore );
-	const onChange = () => toggle( 'core/edit-site', featureName );
+	const onChange = () => {
+		onToggle();
+		toggle( 'core/edit-site', featureName );
+	};
 	return (
 		<BaseOption
 			onChange={ onChange }

--- a/packages/edit-site/src/components/preferences-modal/index.js
+++ b/packages/edit-site/src/components/preferences-modal/index.js
@@ -8,16 +8,33 @@ import {
 } from '@wordpress/interface';
 import { useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { useDispatch, useRegistry } from '@wordpress/data';
+import { store as preferencesStore } from '@wordpress/preferences';
 
 /**
  * Internal dependencies
  */
 import EnableFeature from './enable-feature';
+import { store as siteEditorStore } from '../../store';
 
 export default function EditSitePreferencesModal( {
 	isModalActive,
 	toggleModal,
 } ) {
+	const registry = useRegistry();
+	const { closeGeneralSidebar, setIsListViewOpened, setIsInserterOpened } =
+		useDispatch( siteEditorStore );
+
+	const { set: setPreference } = useDispatch( preferencesStore );
+	const toggleDistractionFree = () => {
+		registry.batch( () => {
+			setPreference( 'core/edit-site', 'fixedToolbar', false );
+			setIsInserterOpened( false );
+			setIsListViewOpened( false );
+			closeGeneralSidebar();
+		} );
+	};
+
 	const sections = useMemo( () => [
 		{
 			name: 'general',
@@ -29,6 +46,14 @@ export default function EditSitePreferencesModal( {
 						'Customize options related to the block editor interface and editing flow.'
 					) }
 				>
+					<EnableFeature
+						featureName="distractionFree"
+						onToggle={ toggleDistractionFree }
+						help={ __(
+							'Reduce visual distractions by hiding the toolbar and other elements to focus on writing.'
+						) }
+						label={ __( 'Distraction free' ) }
+					/>
 					<EnableFeature
 						featureName="focusMode"
 						help={ __(

--- a/packages/edit-site/src/components/sidebar-navigation-screen-global-styles/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-global-styles/index.js
@@ -15,6 +15,7 @@ import { useViewportMatch } from '@wordpress/compose';
 import { BlockEditorProvider } from '@wordpress/block-editor';
 import { humanTimeDiff } from '@wordpress/date';
 import { useCallback } from '@wordpress/element';
+import { store as noticesStore } from '@wordpress/notices';
 
 /**
  * Internal dependencies
@@ -31,8 +32,9 @@ import useGlobalStylesRevisions from '../global-styles/screen-revisions/use-glob
 const noop = () => {};
 
 export function SidebarNavigationItemGlobalStyles( props ) {
-	const { openGeneralSidebar } = useDispatch( editSiteStore );
+	const { openGeneralSidebar, toggleFeature } = useDispatch( editSiteStore );
 	const { setCanvasMode } = unlock( useDispatch( editSiteStore ) );
+	const { createNotice } = useDispatch( noticesStore );
 	const hasGlobalStyleVariations = useSelect(
 		( select ) =>
 			!! select(
@@ -53,9 +55,19 @@ export function SidebarNavigationItemGlobalStyles( props ) {
 		<SidebarNavigationItem
 			{ ...props }
 			onClick={ () => {
-				// switch to edit mode.
+				// Disable distraction free mode.
+				toggleFeature( 'distractionFree', false );
+				createNotice(
+					'info',
+					__( 'Distraction free mode turned off' ),
+					{
+						isDismissible: true,
+						type: 'snackbar',
+					}
+				);
+				// Switch to edit mode.
 				setCanvasMode( 'edit' );
-				// open global styles sidebar.
+				// Open global styles sidebar.
 				openGeneralSidebar( 'edit-site/global-styles' );
 			} }
 		/>

--- a/packages/edit-site/src/index.js
+++ b/packages/edit-site/src/index.js
@@ -63,6 +63,7 @@ export function initializeEditor( id, settings ) {
 		editorMode: 'visual',
 		fixedToolbar: false,
 		focusMode: false,
+		distractionFree: false,
 		keepCaretInsideBlock: false,
 		welcomeGuide: true,
 		welcomeGuideStyles: true,

--- a/packages/edit-site/src/store/selectors.js
+++ b/packages/edit-site/src/store/selectors.js
@@ -107,6 +107,10 @@ export const getSettings = createSelector(
 			...state.settings,
 			outlineMode: true,
 			focusMode: !! __unstableGetPreference( state, 'focusMode' ),
+			distractionFree: !! __unstableGetPreference(
+				state,
+				'distractionFree'
+			),
 			hasFixedToolbar: !! __unstableGetPreference(
 				state,
 				'fixedToolbar'
@@ -143,6 +147,7 @@ export const getSettings = createSelector(
 		getCanUserCreateMedia( state ),
 		state.settings,
 		__unstableGetPreference( state, 'focusMode' ),
+		__unstableGetPreference( state, 'distractionFree' ),
 		__unstableGetPreference( state, 'fixedToolbar' ),
 		__unstableGetPreference( state, 'keepCaretInsideBlock' ),
 		__unstableGetPreference( state, 'showIconLabels' ),

--- a/packages/edit-site/src/store/selectors.js
+++ b/packages/edit-site/src/store/selectors.js
@@ -107,7 +107,7 @@ export const getSettings = createSelector(
 			...state.settings,
 			outlineMode: true,
 			focusMode: !! __unstableGetPreference( state, 'focusMode' ),
-			distractionFree: !! __unstableGetPreference(
+			isDistractionFree: !! __unstableGetPreference(
 				state,
 				'distractionFree'
 			),

--- a/packages/edit-site/src/store/test/selectors.js
+++ b/packages/edit-site/src/store/test/selectors.js
@@ -77,6 +77,7 @@ describe( 'selectors', () => {
 				outlineMode: true,
 				focusMode: false,
 				hasFixedToolbar: false,
+				isDistractionFree: false,
 				keepCaretInsideBlock: false,
 				showIconLabels: false,
 				__experimentalSetIsInserterOpened: setInserterOpened,

--- a/packages/edit-site/src/store/test/selectors.js
+++ b/packages/edit-site/src/store/test/selectors.js
@@ -102,6 +102,7 @@ describe( 'selectors', () => {
 				key: 'value',
 				focusMode: true,
 				hasFixedToolbar: true,
+				isDistractionFree: false,
 				keepCaretInsideBlock: false,
 				showIconLabels: false,
 				__experimentalSetIsInserterOpened: setInserterOpened,

--- a/packages/editor/src/components/provider/use-block-editor-settings.js
+++ b/packages/editor/src/components/provider/use-block-editor-settings.js
@@ -47,6 +47,7 @@ const BLOCK_EDITOR_SETTINGS = [
 	'enableCustomUnits',
 	'enableOpenverseMediaCategory',
 	'focusMode',
+	'distractionFree',
 	'fontSizes',
 	'gradients',
 	'generateAnchors',

--- a/packages/interface/src/components/interface-skeleton/index.js
+++ b/packages/interface/src/components/interface-skeleton/index.js
@@ -33,6 +33,15 @@ function useHTMLClass( className ) {
 	}, [ className ] );
 }
 
+const headerVariants = {
+	hidden: { opacity: 0 },
+	hover: {
+		opacity: 1,
+		transition: { type: 'tween', delay: 0.2, delayChildren: 0.2 },
+	},
+	distractionFreeInactive: { opacity: 1, transition: { delay: 0 } },
+};
+
 function InterfaceSkeleton(
 	{
 		isDistractionFree,
@@ -73,15 +82,6 @@ function InterfaceSkeleton(
 	};
 
 	const mergedLabels = { ...defaultLabels, ...labels };
-
-	const headerVariants = {
-		hidden: { opacity: 0 },
-		hover: {
-			opacity: 1,
-			transition: { type: 'tween', delay: 0.2, delayChildren: 0.2 },
-		},
-		distractionFreeInactive: { opacity: 1, transition: { delay: 0 } },
-	};
 
 	return (
 		<div


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Closes #49175
This PR brings over distraction free mode to the site editor.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

- Because distraction free work is a good environment to cultivate
- Because the command center makes full chrome UI useless for power users
- Because it enables a really 1:1 preview - while maintaining everything editable

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

1. Adds a setting to the more menu of the site editor
2. Look for distraction free being off for displaying some chrome

A part of the work just works as the block editor and interface packages already know about this setting from the previous work on the post editor.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Have a block theme active
4. Go to Appearance -> Editor
5. Click on the preview frame
6. From the top right dotted menu choose DIstraction Free
7. Test it out

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

N/A

## Screenshots or screencast <!-- if applicable -->


https://github.com/WordPress/gutenberg/assets/107534/e0d7afd9-1ea0-4e79-a486-3d027fa6c4cc


## To do

- [ ] Add distraction free to the preferences modal to the site editor
- [ ] Add distraction free keyboard shortcut to the site editor
- [x] Add animation to parts of the header



