### PR TITLE
[Fonts API] Make local font asset file URL absolute

### DIFF
--- a/lib/experimental/fonts-api/class-wp-fonts-provider-local.php
+++ b/lib/experimental/fonts-api/class-wp-fonts-provider-local.php
@@ -207,11 +207,6 @@ class WP_Fonts_Provider_Local extends WP_Fonts_Provider {
 		$src = '';
 
 		foreach ( $value as $item ) {
-
-			if ( str_starts_with( $item['url'], get_site_url() ) ) {
-				$item['url'] = wp_make_link_relative( $item['url'] );
-			}
-
 			$src .= ( 'data' === $item['format'] )
 				? ", url({$item['url']})"
 				: ", url('{$item['url']}') format('{$item['format']}')";


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/50965

## What?

Makes all local font asset file URL absolute, rather than local.

## Why?

The font asset files are not being loaded within an iframe. Why? The relative URL to the asset files are relative to the iframe's #50875 was merged. By making the URLs absolute, it ensures each font asset file does properly relate to the actual location of the files.

## How?

In the `WP_Fonts_Provider_Local::compile_src()`, the code for making the URLs relative is removed. In this way, all URLs should be absolute, assuming their src path was defined as absolute or it used `file:./` placeholder (where the API handles the conversion).

## Testing Instructions

### Before using 15.8.1

1. [Install Gutenberg 15.8.1](https://downloads.wordpress.org/plugin/gutenberg.15.8.1.zip) and then activate the plugin.
2. Install and activate the Frost theme.
3. Inspecting the font asset files:
    * In your favorite browser, open the dev tools.
    * Go to the "Network".
    * Select to view all "Fonts".
    * If available, disable the browser cache. (Firefox as a checkbox next to "Disable Cache")
4. Go to or refresh the Site Editor.
5. In the Network tab, the `Outfit-Variable.woff2` file should be listed.

Notice the font is listed using 15.8.1 - it works ✅ 

<img width="2495" alt="Firefox Network tab: font file is listed with Gutenberg 15.8.1" src="https://github.com/WordPress/gutenberg/assets/7284611/92c9ae15-11d3-4e2e-b512-9e8d23354cff">

### Before: Reproduce the bug with Gutenberg 15.9.0:

1. Go to Plugins.
2. Upgrade the Gutenberg plugin to 15.9.0.
3. Go to or refresh the Site Editor.
4. In the Network tab, the `Outfit-Variable.woff2` file should be listed, but it's not. This is the bug / regression  ❌ 🐞

<img width="2520" alt="Firefox Network tab: before this bugfix" src="https://github.com/WordPress/gutenberg/assets/7284611/2091e17b-8045-46ed-901e-d47677eb78f8">

### After: Bugfix

1. Apply the code change to your test site.
2. Refresh the Site Editor.
3.  In the Network tab, the `Outfit-Variable.woff2` should be listed.

Expectation: The font file from the Frost theme, i.e. `Outfit-Variable.woff2` should appear in the Network tab with a 200 status 🟢 

<img width="2488" alt="Firefox Network tab: after this bugfix" src="https://github.com/WordPress/gutenberg/assets/7284611/f7a89dec-26ff-40d9-9d94-2c8dd57fd525">