### PR TITLE
Disable Lightbox UI if link has an image

### DIFF
--- a/packages/block-editor/src/hooks/behaviors.js
+++ b/packages/block-editor/src/hooks/behaviors.js
@@ -18,7 +18,12 @@ import { store as blockEditorStore } from '../store';
  */
 import merge from 'deepmerge';
 
-function BehaviorsControl( { blockName, blockBehaviors, onChange } ) {
+function BehaviorsControl( {
+	blockName,
+	blockBehaviors,
+	onChange,
+	disabled = false,
+} ) {
 	const { settings, themeBehaviors } = useSelect(
 		( select ) => {
 			const { getBehaviors, getSettings } = select( blockEditorStore );
@@ -61,6 +66,10 @@ function BehaviorsControl( { blockName, blockBehaviors, onChange } ) {
 
 	const options = [ noBehaviorsOption, ...behaviorsOptions ];
 
+	const helpText = disabled
+		? __( 'The lightbox behavior is disabled for linked images.' )
+		: __( 'Add behaviors.' );
+
 	return (
 		<InspectorControls group="advanced">
 			<SelectControl
@@ -71,8 +80,9 @@ function BehaviorsControl( { blockName, blockBehaviors, onChange } ) {
 				options={ options }
 				onChange={ onChange }
 				hideCancelButton={ true }
-				help={ __( 'Add behaviors.' ) }
+				help={ helpText }
 				size="__unstable-large"
+				disabled={ disabled }
 			/>
 		</InspectorControls>
 	);
@@ -95,7 +105,9 @@ export const withBehaviors = createHigherOrderComponent( ( BlockEdit ) => {
 		if ( props.name !== 'core/image' ) {
 			return blockEdit;
 		}
-
+		const blockHasLink =
+			typeof props.attributes?.linkDestination !== 'undefined' &&
+			props.attributes?.linkDestination !== 'none';
 		return (
 			<>
 				{ blockEdit }
@@ -111,6 +123,7 @@ export const withBehaviors = createHigherOrderComponent( ( BlockEdit ) => {
 							},
 						} );
 					} }
+					disabled={ blockHasLink }
 				/>
 			</>
 		);

--- a/test/e2e/specs/editor/various/behaviors.spec.js
+++ b/test/e2e/specs/editor/various/behaviors.spec.js
@@ -216,6 +216,43 @@ test.describe( 'Testing behaviors functionality', () => {
 		await select.selectOption( { label: 'No behaviors' } );
 		await expect( select ).toHaveValue( '' );
 	} );
+
+	test( 'Lightbox behavior is disabled if the Image has a link', async ( {
+		admin,
+		editor,
+		requestUtils,
+		page,
+		behaviorUtils,
+	} ) => {
+		// In this theme, the default value for settings.behaviors.blocks.core/image.lightbox is `true`.
+		await requestUtils.activateTheme( 'behaviors-enabled' );
+		await admin.createNewPost();
+		const media = await behaviorUtils.createMedia();
+
+		await editor.insertBlock( {
+			name: 'core/image',
+			attributes: {
+				alt: filename,
+				id: media.id,
+				url: media.source_url,
+				linkDestination: 'custom',
+			},
+		} );
+
+		await editor.openDocumentSettingsSidebar();
+		const editorSettings = page.getByRole( 'region', {
+			name: 'Editor settings',
+		} );
+		await editorSettings
+			.getByRole( 'button', { name: 'Advanced' } )
+			.click();
+		const select = editorSettings.getByRole( 'combobox', {
+			name: 'Behavior',
+		} );
+
+		// The behaviors dropdown should be present but disabled.
+		await expect( select ).toBeDisabled();
+	} );
 } );
 
 class BehaviorUtils {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Fixes #51127

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Right now, if an image has a link attached, if the user interacts with it, it will go to that link. For that reason, we could not be able to apply the Lightbox feature.

As @jasmussen mentioned:
> Note that if I also link the image to a destination, if I click the link, the lightbox invokes quickly, and then shortly after, the link is navigated to. We should probably just disable the lightbox entirely when an image is linked. This is likely worth doing also for the checkbox itself, or the design tool when we get a chance to upgrade it: it could be grayed out and have help-text that says something like "The lightbox behavior is disabled for linked images."


## Testing Instructions
1. Open a post or a page.
2. Add a couple of images, add a link to one of them.
3. Check that the behavior UI is disabled if it has a link, enabled otherwise.



### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
Lightbox enabled in an image without a link
![Screenshot 2023-06-01 at 18 18 22](https://github.com/WordPress/gutenberg/assets/37012961/b66ce19f-4df0-4f1b-bbed-5fa229d5a1f4)

Lightbox disabled in an image with a link
![Screenshot 2023-06-01 at 18 18 00](https://github.com/WordPress/gutenberg/assets/37012961/a223d775-affb-47b9-a21f-b5534d9472f7)
