### PR TITLE
Fix Navigable Toolbar initialIndex

### DIFF
--- a/packages/block-editor/src/components/block-tools/selected-block-popover.js
+++ b/packages/block-editor/src/components/block-tools/selected-block-popover.js
@@ -102,6 +102,12 @@ function SelectedBlockPopover( {
 	// to it when re-mounting.
 	const initialToolbarItemIndexRef = useRef();
 
+	useEffect( () => {
+		// Resets the index whenever the active block changes so this is not
+		// persisted. See https://github.com/WordPress/gutenberg/pull/25760#issuecomment-717906169
+		initialToolbarItemIndexRef.current = undefined;
+	}, [ clientId ] );
+
 	const popoverProps = useBlockToolbarPopoverProps( {
 		contentElement: __unstableContentRef?.current,
 		clientId,

--- a/packages/block-editor/src/components/navigable-toolbar/index.js
+++ b/packages/block-editor/src/components/navigable-toolbar/index.js
@@ -120,6 +120,8 @@ function useToolbarFocus(
 	}, [ isAccessibleToolbar, initialFocusOnMount, focusToolbar ] );
 
 	useEffect( () => {
+		// Store ref so we have access on useEffect cleanup: https://legacy.reactjs.org/blog/2020/08/10/react-v17-rc.html#effect-cleanup-timing
+		const navigableToolbarRef = ref.current;
 		// If initialIndex is passed, we focus on that toolbar item when the
 		// toolbar gets mounted and initial focus is not forced.
 		// We have to wait for the next browser paint because block controls aren't
@@ -127,9 +129,9 @@ function useToolbarFocus(
 		let raf = 0;
 		if ( initialIndex && ! initialFocusOnMount ) {
 			raf = window.requestAnimationFrame( () => {
-				const items = getAllToolbarItemsIn( ref.current );
+				const items = getAllToolbarItemsIn( navigableToolbarRef );
 				const index = initialIndex || 0;
-				if ( items[ index ] && hasFocusWithin( ref.current ) ) {
+				if ( items[ index ] && hasFocusWithin( navigableToolbarRef ) ) {
 					items[ index ].focus( {
 						// When focusing newly mounted toolbars,
 						// the position of the popover is often not right on the first render
@@ -141,10 +143,10 @@ function useToolbarFocus(
 		}
 		return () => {
 			window.cancelAnimationFrame( raf );
-			if ( ! onIndexChange || ! ref.current ) return;
+			if ( ! onIndexChange || ! navigableToolbarRef ) return;
 			// When the toolbar element is unmounted and onIndexChange is passed, we
 			// pass the focused toolbar item index so it can be hydrated later.
-			const items = getAllToolbarItemsIn( ref.current );
+			const items = getAllToolbarItemsIn( navigableToolbarRef );
 			const index = items.findIndex( ( item ) => item.tabIndex === 0 );
 			onIndexChange( index );
 		};

--- a/packages/block-editor/src/components/navigable-toolbar/index.js
+++ b/packages/block-editor/src/components/navigable-toolbar/index.js
@@ -127,7 +127,7 @@ function useToolbarFocus(
 		// We have to wait for the next browser paint because block controls aren't
 		// rendered right away when the toolbar gets mounted.
 		let raf = 0;
-		if ( initialIndex && ! initialFocusOnMount ) {
+		if ( ! initialFocusOnMount ) {
 			raf = window.requestAnimationFrame( () => {
 				const items = getAllToolbarItemsIn( navigableToolbarRef );
 				const index = initialIndex || 0;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What and Why
There is a bug in the `<NavigableToolbar />` used in the block popover that incorrectly sets the active toolbar item to the last item in the toolbar. To reproduce this issue:

- Go to the block editor
- Type to start a paragraph
- Shift + tab to enter the toolbar
- Focus will be on the first item in the toolbar
- Tab to return to typing
- Arrow key left to hide the toolbar
- Shift + tab to enter toolbar again
- Focus will be on the last item the toolbar

The expected and intended behavior is that the toolbar will always return you to the last item you were interacting with. So, if you were at 0, it should return you to the 0 index item. If you're at 6, it should return you to the 6 index item. If you haven't interacted with it at all, you should go to the first (0) item.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
There are two issues:
1. This bug has been present since we upgraded from React 16, as React changed the way they [handle useEffect cleanups for refs](https://legacy.reactjs.org/blog/2020/08/10/react-v17-rc.html#effect-cleanup-timing). In React 16, the ref would be available in the useEffect cleanup. Since then, it needs to be stored earlier in the useEffect hook, so [that's what we did](1d19f0b5aa017859dcd93ad42b52bc7b8f9c36eb).
2. The initialIndex code wasn't being run if the index was 0. It would be expected that if the index was 0 or undefined, it would be set to the first item, but if it's undefined it was incorrectly being set to the last item somehow. I'm not sure where the origin of this is, or why the ref is undefined in some instances. There was already a check later on in the if statement to set the initialIndex to 0 if necessary, so we're relying on that again.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
- In the post editor, try to find an unexpected shift+tab return to toolbar index.
- Type to create a paragraph block
- shift + tab to enter the toolbar
- use arrow keys to move the focused toolbar item
- tab to enter the block content
- use arrow keys to move around, type, etc
- shift + tab to enter the toolbar
- the focus should be on the item you were previously on
- move to new blocks, repeat, etc. 
- Note, the index gets reset each time you interact with a new block. So if you interact with a toolbar, switch to a new block, and return the previous toolbar, the focus should be on the first item in the block toolbar.

## Screenshots or screencast <!-- if applicable -->
Before
![block toolbar focuses last item](https://github.com/WordPress/gutenberg/assets/967608/08fa0ff6-d3de-4d4c-bfd6-ce8b99aab225)

After
![fixed - navigable toolbar intitial index](https://github.com/WordPress/gutenberg/assets/967608/a6c883a7-dff8-4a6a-87dc-af4db06672a3)
