### PR TITLE
Make getBlockEditingMode() return 'default' when parent is 'contentOnly'

### DIFF
--- a/packages/block-editor/src/store/test/private-selectors.js
+++ b/packages/block-editor/src/store/test/private-selectors.js
@@ -132,69 +132,113 @@ describe( 'private selectors', () => {
 				).toBe( 'default' );
 			} );
 
-			[ 'disabled', 'contentOnly' ].forEach( ( mode ) => {
-				it( `should return ${ mode } if explicitly set`, () => {
-					const state = {
-						...baseState,
-						blockEditingModes: new Map( [
-							[ 'b3247f75-fd94-4fef-97f9-5bfd162cc416', mode ],
-						] ),
-					};
-					expect(
-						getBlockEditingMode(
-							state,
-							'b3247f75-fd94-4fef-97f9-5bfd162cc416'
-						)
-					).toBe( mode );
-				} );
+			it( 'should return disabled if explicitly set', () => {
+				const state = {
+					...baseState,
+					blockEditingModes: new Map( [
+						[ 'b3247f75-fd94-4fef-97f9-5bfd162cc416', 'disabled' ],
+					] ),
+				};
+				expect(
+					getBlockEditingMode(
+						state,
+						'b3247f75-fd94-4fef-97f9-5bfd162cc416'
+					)
+				).toBe( 'disabled' );
+			} );
 
-				it( `should return ${ mode } if explicitly set on a parent`, () => {
-					const state = {
-						...baseState,
-						blockEditingModes: new Map( [
-							[ 'ef45d5fd-5234-4fd5-ac4f-c3736c7f9337', mode ],
-						] ),
-					};
-					expect(
-						getBlockEditingMode(
-							state,
-							'b3247f75-fd94-4fef-97f9-5bfd162cc416'
-						)
-					).toBe( mode );
-				} );
+			it( 'should return contentOnly if explicitly set', () => {
+				const state = {
+					...baseState,
+					blockEditingModes: new Map( [
+						[
+							'b3247f75-fd94-4fef-97f9-5bfd162cc416',
+							'contentOnly',
+						],
+					] ),
+				};
+				expect(
+					getBlockEditingMode(
+						state,
+						'b3247f75-fd94-4fef-97f9-5bfd162cc416'
+					)
+				).toBe( 'contentOnly' );
+			} );
 
-				it( `should return ${ mode } if overridden by a parent`, () => {
-					const state = {
-						...baseState,
-						blockEditingModes: new Map( [
-							[ '', mode ],
-							[
-								'ef45d5fd-5234-4fd5-ac4f-c3736c7f9337',
-								'default',
-							],
-							[ '9b9c5c3f-2e46-4f02-9e14-9fe9515b958f', mode ],
-						] ),
-					};
-					expect(
-						getBlockEditingMode(
-							state,
-							'b3247f75-fd94-4fef-97f9-5bfd162cc416'
-						)
-					).toBe( mode );
-				} );
+			it( 'should return disabled if explicitly set on a parent', () => {
+				const state = {
+					...baseState,
+					blockEditingModes: new Map( [
+						[ 'ef45d5fd-5234-4fd5-ac4f-c3736c7f9337', 'disabled' ],
+					] ),
+				};
+				expect(
+					getBlockEditingMode(
+						state,
+						'b3247f75-fd94-4fef-97f9-5bfd162cc416'
+					)
+				).toBe( 'disabled' );
+			} );
 
-				it( `should return ${ mode } if explicitly set on root`, () => {
-					const state = {
-						...baseState,
-						blockEditingModes: new Map( [ [ '', mode ] ] ),
-					};
-					expect(
-						getBlockEditingMode(
-							state,
-							'b3247f75-fd94-4fef-97f9-5bfd162cc416'
-						)
-					).toBe( mode );
-				} );
+			it( 'should return default if parent is set to contentOnly', () => {
+				const state = {
+					...baseState,
+					blockEditingModes: new Map( [
+						[
+							'ef45d5fd-5234-4fd5-ac4f-c3736c7f9337',
+							'contentOnly',
+						],
+					] ),
+				};
+				expect(
+					getBlockEditingMode(
+						state,
+						'b3247f75-fd94-4fef-97f9-5bfd162cc416'
+					)
+				).toBe( 'default' );
+			} );
+
+			it( 'should return disabled if overridden by a parent', () => {
+				const state = {
+					...baseState,
+					blockEditingModes: new Map( [
+						[ '', 'disabled' ],
+						[ 'ef45d5fd-5234-4fd5-ac4f-c3736c7f9337', 'default' ],
+						[ '9b9c5c3f-2e46-4f02-9e14-9fe9515b958f', 'disabled' ],
+					] ),
+				};
+				expect(
+					getBlockEditingMode(
+						state,
+						'b3247f75-fd94-4fef-97f9-5bfd162cc416'
+					)
+				).toBe( 'disabled' );
+			} );
+
+			it( 'should return disabled if explicitly set on root', () => {
+				const state = {
+					...baseState,
+					blockEditingModes: new Map( [ [ '', 'disabled' ] ] ),
+				};
+				expect(
+					getBlockEditingMode(
+						state,
+						'b3247f75-fd94-4fef-97f9-5bfd162cc416'
+					)
+				).toBe( 'disabled' );
+			} );
+
+			it( 'should return default if root is contentOnly', () => {
+				const state = {
+					...baseState,
+					blockEditingModes: new Map( [ [ '', 'contentOnly' ] ] ),
+				};
+				expect(
+					getBlockEditingMode(
+						state,
+						'b3247f75-fd94-4fef-97f9-5bfd162cc416'
+					)
+				).toBe( 'default' );
 			} );
 
 			it( 'should return disabled if parent is locked and the block has no content role', () => {


### PR DESCRIPTION



<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Follows https://github.com/WordPress/gutenberg/pull/50643.

Needed to fix the failing performance tests in https://github.com/WordPress/gutenberg/pull/50857.

Change the behaviour of `getBlockEditingMode()` so that a block's children is considered "content" that is editable when the editing mode is `'contentOnly'`. Therefore `getBlockEditingMode( foo )` should be `'default'` when `getBlockEditingMode( getParent( foo ) )` is `'contentOnly'`.

## Why?
The benefit of this is that block subtrees can be enabled by simply setting the parent container's editing mode to `'contentOnly'` rather than setting the editing mode of every descendant block to `'default'`. This is much more performant as each call to `setBlockEditingMode()` invalidates the cache.

To illustrate, this is what we had to do before to allow the full editing of nested blocks within the Post Content block:

```js
const withDisableNonContentBlocks = createHigherOrderComponent(
 	( BlockEdit ) => ( props ) => {
 		const mode = useSelect(
 			( select ) => {
 				if (
 					select( blockEditorStore ).getBlockParentsByBlockName(
 						props.clientId,
 						'core/post-content'
 					).length
 				) {
 					return 'default';
 				}
 			},
 			[ props.name, props.clientId ]
 		);
 		useBlockEditingMode( mode );
 		return <BlockEdit { ...props } />;
 	},
 	'withBlockEditingMode'
 );
addFilter(
 	'editor.BlockEdit',
 	'core/edit-site/disable-non-content-blocks',
 	withDisableNonContentBlocks
 );
```

But now we can simply do this:

```js
const withDisableNonContentBlocks = createHigherOrderComponent(
 	( BlockEdit ) => ( props ) => {
 		const mode = props.name === 'core/post-content' ? 'contentOnly' : undefined;
 		useBlockEditingMode( mode );
 		return <BlockEdit { ...props } />;
 	},
 	'withBlockEditingMode'
 );
addFilter(
 	'editor.BlockEdit',
 	'core/edit-site/disable-non-content-blocks',
 	withDisableNonContentBlocks
 );
```

It's much more performant because each nested block within Post Content (there could be thousands) doesn't need to call `setBlockEditingMode()`.

## Testing Instructions
Unit tests should cover this pretty well.

You can also check that `useBlockEditingMode` functions correctly by:

1. Apply the patch below by copying it and running `pbpaste | git apply`.

```diff
diff --git a/packages/edit-site/src/components/block-editor/index.js b/packages/edit-site/src/components/block-editor/index.js
index cc5e7c8d92..f97599a9b5 100644
--- a/packages/edit-site/src/components/block-editor/index.js
+++ b/packages/edit-site/src/components/block-editor/index.js
@@ -39,7 +39,9 @@ import EditorCanvas from './editor-canvas';
 import { unlock } from '../../private-apis';
 import EditorCanvasContainer from '../editor-canvas-container';
 
-const { ExperimentalBlockEditorProvider } = unlock( blockEditorPrivateApis );
+const { ExperimentalBlockEditorProvider, useBlockEditingMode } = unlock(
+	blockEditorPrivateApis
+);
 
 const LAYOUT = {
 	type: 'default',
@@ -47,6 +49,11 @@ const LAYOUT = {
 	alignments: [],
 };
 
+function SetRootBlockEditingMode( { mode } ) {
+	useBlockEditingMode( mode );
+	return null;
+}
+
 export default function BlockEditor() {
 	const { setIsInserterOpened } = useDispatch( editSiteStore );
 	const { storedSettings, templateType, canvasMode } = useSelect(
@@ -162,6 +169,7 @@ export default function BlockEditor() {
 			onChange={ onChange }
 			useSubRegistry={ false }
 		>
+			<SetRootBlockEditingMode mode="disabled" />
 			<TemplatePartConverter />
 			<SidebarInspectorFill>
 				<BlockInspector />
diff --git a/packages/edit-site/src/hooks/block-editing-mode.js b/packages/edit-site/src/hooks/block-editing-mode.js
new file mode 100644
index 0000000000..e6e45ef1db
--- /dev/null
+++ b/packages/edit-site/src/hooks/block-editing-mode.js
@@ -0,0 +1,33 @@
+/**
+ * WordPress dependencies
+ */
+import { createHigherOrderComponent } from '@wordpress/compose';
+import { addFilter } from '@wordpress/hooks';
+import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
+
+/**
+ * Internal dependencies
+ */
+import { unlock } from '../private-apis';
+
+const { useBlockEditingMode } = unlock( blockEditorPrivateApis );
+
+export const withBlockEditingMode = createHigherOrderComponent(
+	( BlockEdit ) => ( props ) => {
+		const isContent = [
+			'core/post-title',
+			'core/post-featured-image',
+			'core/post-content',
+		].includes( props.name );
+		const mode = isContent ? 'contentOnly' : undefined;
+		useBlockEditingMode( mode );
+		return <BlockEdit { ...props } />;
+	},
+	'withBlockEditingMode'
+);
+
+addFilter(
+	'editor.BlockEdit',
+	'core/edit-site/block-editing-mode',
+	withBlockEditingMode
+);
diff --git a/packages/edit-site/src/hooks/index.js b/packages/edit-site/src/hooks/index.js
index 513634c55b..de9dc8c3f7 100644
--- a/packages/edit-site/src/hooks/index.js
+++ b/packages/edit-site/src/hooks/index.js
@@ -1,6 +1,7 @@
 /**
  * Internal dependencies
  */
+import './block-editing-mode';
 import './components';
 import './push-changes-to-global-styles';
 import './template-part-edit';

```

2. Navigate to Appearance → Editor → Pages and select a page to edit.
3. All blocks should be locked except for the Post Title, Post Featured Image and Post Content blocks.

To test the existing `contentOnly` functionality for regressions:
1. Add a pattern that has a content lock, e.g. [this one](https://gist.github.com/richtabor/ddeea41ced691721318649bea8ce9db8).
2. Edit a post, page, or template.
3. Insert that pattern.