### PR TITLE
List block: Add numbering type selection

### DIFF
--- a/packages/block-library/src/list/ordered-list-settings.js
+++ b/packages/block-library/src/list/ordered-list-settings.js
@@ -3,9 +3,14 @@
  */
 import { __ } from '@wordpress/i18n';
 import { InspectorControls } from '@wordpress/block-editor';
-import { TextControl, PanelBody, ToggleControl } from '@wordpress/components';
+import {
+	TextControl,
+	PanelBody,
+	ToggleControl,
+	SelectControl,
+} from '@wordpress/components';
 
-const OrderedListSettings = ( { setAttributes, reversed, start } ) => (
+const OrderedListSettings = ( { setAttributes, reversed, start, type } ) => (
 	<InspectorControls>
 		<PanelBody title={ __( 'Ordered list settings' ) }>
 			<TextControl
@@ -23,6 +28,21 @@ const OrderedListSettings = ( { setAttributes, reversed, start } ) => (
 				} }
 				value={ Number.isInteger( start ) ? start.toString( 10 ) : '' }
 				step="1"
+			/>
+			<SelectControl
+				__nextHasNoMarginBottom
+				label={ __( 'Numbering type' ) }
+				options={ [
+					{ value: '1', label: __( 'Numbers' ) },
+					{ value: 'A', label: __( 'Uppercase letters' ) },
+					{ value: 'a', label: __( 'Lowercase letter' ) },
+					{ value: 'I', label: __( 'Uppercase roman numerals' ) },
+					{ value: 'i', label: __( 'Lowercase roman numerals' ) },
+				] }
+				value={ type }
+				onChange={ ( newValue ) => {
+					setAttributes( { type: newValue } );
+				} }
 			/>
 			<ToggleControl
 				__nextHasNoMarginBottom

--- a/packages/block-library/src/list/ordered-list-settings.js
+++ b/packages/block-library/src/list/ordered-list-settings.js
@@ -31,7 +31,7 @@ const OrderedListSettings = ( { setAttributes, reversed, start, type } ) => (
 			/>
 			<SelectControl
 				__nextHasNoMarginBottom
-				label={ __( 'Numbering type' ) }
+				label={ __( 'Numbering style' ) }
 				options={ [
 					{ value: '1', label: __( 'Numbers' ) },
 					{ value: 'A', label: __( 'Uppercase letters' ) },

--- a/packages/block-library/src/list/ordered-list-settings.js
+++ b/packages/block-library/src/list/ordered-list-settings.js
@@ -11,7 +11,7 @@ import {
 } from '@wordpress/components';
 
 const OrderedListSettings = ( { setAttributes, reversed, start, type } ) => (
-	<InspectorControls>
+	<InspectorControls group="styles">
 		<PanelBody title={ __( 'Ordered list settings' ) }>
 			<TextControl
 				__nextHasNoMarginBottom
@@ -35,7 +35,7 @@ const OrderedListSettings = ( { setAttributes, reversed, start, type } ) => (
 				options={ [
 					{ value: '1', label: __( 'Numbers' ) },
 					{ value: 'A', label: __( 'Uppercase letters' ) },
-					{ value: 'a', label: __( 'Lowercase letter' ) },
+					{ value: 'a', label: __( 'Lowercase letters' ) },
 					{ value: 'I', label: __( 'Uppercase roman numerals' ) },
 					{ value: 'i', label: __( 'Lowercase roman numerals' ) },
 				] }

--- a/packages/block-library/src/list/ordered-list-settings.js
+++ b/packages/block-library/src/list/ordered-list-settings.js
@@ -36,7 +36,7 @@ const OrderedListSettings = ( { setAttributes, reversed, start, type } ) => (
 					{ value: '1', label: __( 'Numbers' ) },
 					{ value: 'A', label: __( 'Uppercase letters' ) },
 					{ value: 'a', label: __( 'Lowercase letters' ) },
-					{ value: 'I', label: __( 'Uppercase roman numerals' ) },
+					{ value: 'I', label: __( 'Uppercase Roman numerals' ) },
 					{ value: 'i', label: __( 'Lowercase roman numerals' ) },
 				] }
 				value={ type }

--- a/packages/block-library/src/list/ordered-list-settings.js
+++ b/packages/block-library/src/list/ordered-list-settings.js
@@ -37,7 +37,7 @@ const OrderedListSettings = ( { setAttributes, reversed, start, type } ) => (
 					{ value: 'A', label: __( 'Uppercase letters' ) },
 					{ value: 'a', label: __( 'Lowercase letters' ) },
 					{ value: 'I', label: __( 'Uppercase Roman numerals' ) },
-					{ value: 'i', label: __( 'Lowercase roman numerals' ) },
+					{ value: 'i', label: __( 'Lowercase Roman numerals' ) },
 				] }
 				value={ type }
 				onChange={ ( newValue ) => setAttributes( { type: newValue } ) }

--- a/packages/block-library/src/list/ordered-list-settings.js
+++ b/packages/block-library/src/list/ordered-list-settings.js
@@ -11,7 +11,7 @@ import {
 } from '@wordpress/components';
 
 const OrderedListSettings = ( { setAttributes, reversed, start, type } ) => (
-	<InspectorControls group="styles">
+	<InspectorControls>
 		<PanelBody title={ __( 'Ordered list settings' ) }>
 			<TextControl
 				__nextHasNoMarginBottom

--- a/packages/block-library/src/list/ordered-list-settings.js
+++ b/packages/block-library/src/list/ordered-list-settings.js
@@ -40,9 +40,7 @@ const OrderedListSettings = ( { setAttributes, reversed, start, type } ) => (
 					{ value: 'i', label: __( 'Lowercase roman numerals' ) },
 				] }
 				value={ type }
-				onChange={ ( newValue ) => {
-					setAttributes( { type: newValue } );
-				} }
+				onChange={ ( newValue ) => setAttributes( { type: newValue } ) }
 			/>
 			<ToggleControl
 				__nextHasNoMarginBottom

--- a/test/integration/fixtures/blocks/core__list__ol-with-type.html
+++ b/test/integration/fixtures/blocks/core__list__ol-with-type.html
@@ -1,0 +1,7 @@
+<!-- wp:list {"ordered":true,"type":"A"} -->
+<ol type="A">
+	<!-- wp:list-item -->
+	<li>Item 1</li>
+	<!-- /wp:list-item -->
+</ol>
+<!-- /wp:list -->

--- a/test/integration/fixtures/blocks/core__list__ol-with-type.json
+++ b/test/integration/fixtures/blocks/core__list__ol-with-type.json
@@ -1,0 +1,21 @@
+[
+	{
+		"name": "core/list",
+		"isValid": true,
+		"attributes": {
+			"ordered": true,
+			"values": "",
+			"type": "A"
+		},
+		"innerBlocks": [
+			{
+				"name": "core/list-item",
+				"isValid": true,
+				"attributes": {
+					"content": "Item 1"
+				},
+				"innerBlocks": []
+			}
+		]
+	}
+]

--- a/test/integration/fixtures/blocks/core__list__ol-with-type.parsed.json
+++ b/test/integration/fixtures/blocks/core__list__ol-with-type.parsed.json
@@ -1,0 +1,20 @@
+[
+	{
+		"blockName": "core/list",
+		"attrs": {
+			"ordered": true,
+			"type": "A"
+		},
+		"innerBlocks": [
+			{
+				"blockName": "core/list-item",
+				"attrs": {},
+				"innerBlocks": [],
+				"innerHTML": "\n\t<li>Item 1</li>\n\t",
+				"innerContent": [ "\n\t<li>Item 1</li>\n\t" ]
+			}
+		],
+		"innerHTML": "\n<ol type=\"A\">\n\t\n</ol>\n",
+		"innerContent": [ "\n<ol type=\"A\">\n\t", null, "\n</ol>\n" ]
+	}
+]

--- a/test/integration/fixtures/blocks/core__list__ol-with-type.serialized.html
+++ b/test/integration/fixtures/blocks/core__list__ol-with-type.serialized.html
@@ -1,0 +1,5 @@
+<!-- wp:list {"ordered":true,"type":"A"} -->
+<ol type="A"><!-- wp:list-item -->
+<li>Item 1</li>
+<!-- /wp:list-item --></ol>
+<!-- /wp:list -->


### PR DESCRIPTION
## What?
Adds the ability to choose the number type to the List block, eg. `1, A, a, i, I`.

## Why?
Fixes: #17738

## How?
Used the existing `type` attribute, that didn't seem to be used for anything currently.

## Testing Instructions

- Add a list block and add some items and set the type of list to ordered
- In the Inspector Panel change the number type and check that the correct style displays in the editor
- Check that the selected styles display correctly in the frontend

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/3629020/9330f893-88f5-46d0-b935-924af066740e


