### PR TITLE
Browse Mode: Remove horizontal scrollbar during screen transitions

### DIFF
--- a/packages/edit-site/src/components/sidebar/style.scss
+++ b/packages/edit-site/src/components/sidebar/style.scss
@@ -15,10 +15,6 @@
 	padding: $canvas-padding 0;
 }
 
-.edit-site-sidebar__content.edit-site-sidebar__content {
-	overflow-x: unset;
-}
-
 .edit-site-sidebar__content > div {
 	// This matches the logo padding
 	padding: 0 $grid-unit-15;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Remove the `overflow-x: unset;` rule for the browse mode sidebar content, as it resulted in horizontal scrollbars appearing during screen transitions in browsers that are set to always display scrollbars.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

To improve how it feels to navigate between screens on browsers / OSes that are set to always display scrollbars

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* Remove the `overflow-x: unset;` rule for the sidebar content

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

Set your OS's accessibility settings to always show scrollbars (if on a Mac). Here's how it looks in Monterey:

<img width="690" alt="image" src="https://github.com/WordPress/gutenberg/assets/14988353/deea2178-c225-4603-9928-0129846367fa">

1. Open up the site editor browse mode and navigate between screens. Without this PR applied, you'll sometimes see a horizontal scrollbar at the bottom — it's most noticeable when going to the Template screen
2. With this PR applied there should be no scrollbar

A question for the reviewer: was this rule needed? Will this removal break anything? I see the rule was added in https://github.com/WordPress/gutenberg/pull/45100 by @oandregal, but removing it doesn't _immediately_ appear to break anything, but I might have missed something!

## Screenshots or screencast <!-- if applicable -->

Look for the flash of horizontal scrollbar during screen transitions below:

| Before | After |
| --- | --- |
| ![2023-06-02 14 52 38](https://github.com/WordPress/gutenberg/assets/14988353/cff1ed8c-eada-41ae-b86f-91164bac132d) | ![2023-06-02 14 53 19](https://github.com/WordPress/gutenberg/assets/14988353/274e8e96-ba94-465c-af45-13a76662edcd) |


