### PR TITLE
Latest posts: make more link consistent between frontend and editor

### DIFF
--- a/packages/block-library/src/latest-posts/edit.js
+++ b/packages/block-library/src/latest-posts/edit.js
@@ -32,6 +32,7 @@ import { pin, list, grid } from '@wordpress/icons';
 import { store as coreStore } from '@wordpress/core-data';
 import { store as noticeStore } from '@wordpress/notices';
 import { useInstanceId } from '@wordpress/compose';
+import { createInterpolateElement } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -479,15 +480,22 @@ export default function LatestPostsEdit( { attributes, setAttributes } ) {
 								.trim()
 								.split( ' ', excerptLength )
 								.join( ' ' ) }
-							{ /* translators: excerpt truncation character, default …  */ }
-							{ __( ' … ' ) }
-							<a
-								href={ post.link }
-								rel="noopener noreferrer"
-								onClick={ showRedirectionPreventedNotice }
-							>
-								{ __( 'Read more' ) }
-							</a>
+							{ createInterpolateElement(
+								/* translators: excerpt truncation character, default …  */
+								__( ' … <a>Read more</a>' ),
+								{
+									a: (
+										// eslint-disable-next-line jsx-a11y/anchor-has-content
+										<a
+											href={ post.link }
+											rel="noopener noreferrer"
+											onClick={
+												showRedirectionPreventedNotice
+											}
+										/>
+									),
+								}
+							) }
 						</>
 					) : (
 						excerpt

--- a/packages/block-library/src/latest-posts/index.php
+++ b/packages/block-library/src/latest-posts/index.php
@@ -48,6 +48,14 @@ function render_block_core_latest_posts( $attributes ) {
 	$block_core_latest_posts_excerpt_length = $attributes['excerptLength'];
 	add_filter( 'excerpt_length', 'block_core_latest_posts_get_excerpt_length', 20 );
 
+	$filter_latest_posts_excerpt_more = static function( $more ) use ( $attributes ) {
+		$use_excerpt = 'excerpt' === $attributes['displayPostContentRadio'];
+		/* translators: %1$s is a URL to a post, excerpt truncation character, default … */
+		return $use_excerpt ? sprintf( __( ' … <a href="%1$s" rel="noopener noreferrer">Read more</a>', 'gutenberg' ), esc_url( get_permalink() ) ) : $more;
+	};
+
+	add_filter( 'excerpt_more', $filter_latest_posts_excerpt_more );
+
 	if ( isset( $attributes['categories'] ) ) {
 		$args['category__in'] = array_column( $attributes['categories'], 'id' );
 	}


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/50492


## What?
This commit makes rendering Read more on latest post excerpts more consistent ensuring that the ellipsis and "Read more" appear in the editor and frontend, and that they are also translatable.

## Why?
With any block theme active, the Latest Posts block displays an unlinked `[...]`. In the editor, however, a "Read More" link is rendered.

<img width="695" alt="Screenshot 2023-06-02 at 3 16 12 pm" src="https://github.com/WordPress/gutenberg/assets/6458278/9374db01-011e-4220-b830-547519f942fb">


## How?
On the frontend, via the [excerpt_more](https://developer.wordpress.org/reference/hooks/excerpt_more/) hook.

If the block's attributes indicate that excerpts are activated it will render `"… Read more"`, with the ellipses contained _within_ the translate function.

## Testing Instructions
1. Create a few posts with text content.
2. Create another new post in a block theme and add a latest posts block
3. In the block setting sidebar, activate Post content > Excerpts radio button
4. Save the post and preview in the frontend
5. Ensure the "Read more" link is consistent between editor and frontend
6. Check in an RTL like Arabic or Hebrew



### Editor
<img width="1191" alt="Screenshot 2023-06-02 at 3 11 08 pm" src="https://github.com/WordPress/gutenberg/assets/6458278/0f35fbf4-eed3-45c7-8332-b9c2846f3d55">


### Frontend

<img width="696" alt="Screenshot 2023-06-02 at 3 09 59 pm" src="https://github.com/WordPress/gutenberg/assets/6458278/6bae7a1e-eb49-4929-8070-a6407e98a95c">

