### PR TITLE
Bump Stylelint dependencies to latest v14.x compatible releases

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -54924,6 +54924,12 @@
 				}
 			}
 		},
+		"stylelint-config-recommended": {
+			"version": "9.0.0",
+			"resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-9.0.0.tgz",
+			"integrity": "sha512-9YQSrJq4NvvRuTbzDsWX3rrFOzOlYBmZP+o513BJN/yfEmGSr0AxdvrWs0P/ilSpVV/wisamAHu5XSk8Rcf4CQ==",
+			"dev": true
+		},
 		"stylelint-config-recommended-scss": {
 			"version": "8.0.0",
 			"resolved": "https://registry.npmjs.org/stylelint-config-recommended-scss/-/stylelint-config-recommended-scss-8.0.0.tgz",
@@ -54933,14 +54939,6 @@
 				"postcss-scss": "^4.0.2",
 				"stylelint-config-recommended": "^9.0.0",
 				"stylelint-scss": "^4.0.0"
-			},
-			"dependencies": {
-				"stylelint-config-recommended": {
-					"version": "9.0.0",
-					"resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-9.0.0.tgz",
-					"integrity": "sha512-9YQSrJq4NvvRuTbzDsWX3rrFOzOlYBmZP+o513BJN/yfEmGSr0AxdvrWs0P/ilSpVV/wisamAHu5XSk8Rcf4CQ==",
-					"dev": true
-				}
 			}
 		},
 		"stylelint-scss": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -18704,6 +18704,492 @@
 				"webpack-bundle-analyzer": "^4.4.2",
 				"webpack-cli": "^4.9.1",
 				"webpack-dev-server": "^4.4.0"
+			},
+			"dependencies": {
+				"@nodelib/fs.stat": {
+					"version": "2.0.5",
+					"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+					"integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+					"dev": true
+				},
+				"array-union": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+					"integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+					"dev": true
+				},
+				"astral-regex": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+					"integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
+					"dev": true
+				},
+				"balanced-match": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-2.0.0.tgz",
+					"integrity": "sha512-1ugUSr8BHXRnK23KfuYS+gVMC3LB8QGH9W1iGtDPsNWoQbgtXSExkBu2aDR4epiGWZOjZsj6lDl/N/AqqTC3UA==",
+					"dev": true
+				},
+				"camelcase-keys": {
+					"version": "6.2.2",
+					"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-6.2.2.tgz",
+					"integrity": "sha512-YrwaA0vEKazPBkn0ipTiMpSajYDSe+KjQfrjhcBMxJt/znbvlHd8Pw/Vamaz5EB4Wfhs3SUR3Z9mwRu/P3s3Yg==",
+					"dev": true,
+					"requires": {
+						"camelcase": "^5.3.1",
+						"map-obj": "^4.0.0",
+						"quick-lru": "^4.0.1"
+					}
+				},
+				"cosmiconfig": {
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
+					"integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
+					"dev": true,
+					"requires": {
+						"@types/parse-json": "^4.0.0",
+						"import-fresh": "^3.2.1",
+						"parse-json": "^5.0.0",
+						"path-type": "^4.0.0",
+						"yaml": "^1.10.0"
+					}
+				},
+				"debug": {
+					"version": "4.3.4",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+					"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+					"dev": true,
+					"requires": {
+						"ms": "2.1.2"
+					}
+				},
+				"emoji-regex": {
+					"version": "8.0.0",
+					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+					"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+					"dev": true
+				},
+				"fastest-levenshtein": {
+					"version": "1.0.16",
+					"resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
+					"integrity": "sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==",
+					"dev": true
+				},
+				"glob-parent": {
+					"version": "5.1.2",
+					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+					"integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+					"dev": true,
+					"requires": {
+						"is-glob": "^4.0.1"
+					}
+				},
+				"globby": {
+					"version": "11.1.0",
+					"resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+					"integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+					"dev": true,
+					"requires": {
+						"array-union": "^2.1.0",
+						"dir-glob": "^3.0.1",
+						"fast-glob": "^3.2.9",
+						"ignore": "^5.2.0",
+						"merge2": "^1.4.1",
+						"slash": "^3.0.0"
+					},
+					"dependencies": {
+						"fast-glob": {
+							"version": "3.2.12",
+							"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz",
+							"integrity": "sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==",
+							"dev": true,
+							"requires": {
+								"@nodelib/fs.stat": "^2.0.2",
+								"@nodelib/fs.walk": "^1.2.3",
+								"glob-parent": "^5.1.2",
+								"merge2": "^1.3.0",
+								"micromatch": "^4.0.4"
+							}
+						}
+					}
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+					"dev": true
+				},
+				"hosted-git-info": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
+					"integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
+					"dev": true,
+					"requires": {
+						"lru-cache": "^6.0.0"
+					}
+				},
+				"html-tags": {
+					"version": "3.3.1",
+					"resolved": "https://registry.npmjs.org/html-tags/-/html-tags-3.3.1.tgz",
+					"integrity": "sha512-ztqyC3kLto0e9WbNp0aeP+M3kTt+nbaIveGmUxAtZa+8iFgKLUOD4YKM5j+f3QD89bra7UeumolZHKuOXnTmeQ==",
+					"dev": true
+				},
+				"ignore": {
+					"version": "5.2.4",
+					"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
+					"integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
+					"dev": true
+				},
+				"import-fresh": {
+					"version": "3.3.0",
+					"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
+					"integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
+					"dev": true,
+					"requires": {
+						"parent-module": "^1.0.0",
+						"resolve-from": "^4.0.0"
+					},
+					"dependencies": {
+						"resolve-from": {
+							"version": "4.0.0",
+							"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+							"integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+							"dev": true
+						}
+					}
+				},
+				"indent-string": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+					"integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+					"dev": true
+				},
+				"is-core-module": {
+					"version": "2.12.1",
+					"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.12.1.tgz",
+					"integrity": "sha512-Q4ZuBAe2FUsKtyQJoQHlvP8OvBERxO3jEmy1I7hcRXcJBGGHFh/aJBswbXuS9sgrDH2QUO8ilkwNPHvHMd8clg==",
+					"dev": true,
+					"requires": {
+						"has": "^1.0.3"
+					}
+				},
+				"is-fullwidth-code-point": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+					"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+					"dev": true
+				},
+				"is-glob": {
+					"version": "4.0.3",
+					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+					"integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+					"dev": true,
+					"requires": {
+						"is-extglob": "^2.1.1"
+					}
+				},
+				"known-css-properties": {
+					"version": "0.26.0",
+					"resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.26.0.tgz",
+					"integrity": "sha512-5FZRzrZzNTBruuurWpvZnvP9pum+fe0HcK8z/ooo+U+Hmp4vtbyp1/QDsqmufirXy4egGzbaH/y2uCZf+6W5Kg==",
+					"dev": true
+				},
+				"lru-cache": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+					"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+					"dev": true,
+					"requires": {
+						"yallist": "^4.0.0"
+					}
+				},
+				"map-obj": {
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.3.0.tgz",
+					"integrity": "sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==",
+					"dev": true
+				},
+				"meow": {
+					"version": "9.0.0",
+					"resolved": "https://registry.npmjs.org/meow/-/meow-9.0.0.tgz",
+					"integrity": "sha512-+obSblOQmRhcyBt62furQqRAQpNyWXo8BuQ5bN7dG8wmwQ+vwHKp/rCFD4CrTP8CsDQD1sjoZ94K417XEUk8IQ==",
+					"dev": true,
+					"requires": {
+						"@types/minimist": "^1.2.0",
+						"camelcase-keys": "^6.2.2",
+						"decamelize": "^1.2.0",
+						"decamelize-keys": "^1.1.0",
+						"hard-rejection": "^2.1.0",
+						"minimist-options": "4.1.0",
+						"normalize-package-data": "^3.0.0",
+						"read-pkg-up": "^7.0.1",
+						"redent": "^3.0.0",
+						"trim-newlines": "^3.0.0",
+						"type-fest": "^0.18.0",
+						"yargs-parser": "^20.2.3"
+					}
+				},
+				"merge2": {
+					"version": "1.4.1",
+					"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+					"integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+					"dev": true
+				},
+				"ms": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+					"dev": true
+				},
+				"nanoid": {
+					"version": "3.3.6",
+					"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
+					"integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
+					"dev": true
+				},
+				"normalize-package-data": {
+					"version": "3.0.3",
+					"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
+					"integrity": "sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==",
+					"dev": true,
+					"requires": {
+						"hosted-git-info": "^4.0.1",
+						"is-core-module": "^2.5.0",
+						"semver": "^7.3.4",
+						"validate-npm-package-license": "^3.0.1"
+					}
+				},
+				"normalize-path": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+					"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+					"dev": true
+				},
+				"path-type": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+					"integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+					"dev": true
+				},
+				"postcss-selector-parser": {
+					"version": "6.0.13",
+					"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.13.tgz",
+					"integrity": "sha512-EaV1Gl4mUEV4ddhDnv/xtj7sxwrwxdetHdWUGnT4VJQf+4d05v6lHYZr8N573k5Z0BViss7BDhfWtKS3+sfAqQ==",
+					"dev": true,
+					"requires": {
+						"cssesc": "^3.0.0",
+						"util-deprecate": "^1.0.2"
+					}
+				},
+				"postcss-value-parser": {
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+					"integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+					"dev": true
+				},
+				"redent": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+					"integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+					"dev": true,
+					"requires": {
+						"indent-string": "^4.0.0",
+						"strip-indent": "^3.0.0"
+					}
+				},
+				"resolve-from": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+					"integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+					"dev": true
+				},
+				"signal-exit": {
+					"version": "3.0.7",
+					"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+					"integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+					"dev": true
+				},
+				"slice-ansi": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
+					"integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.0.0",
+						"astral-regex": "^2.0.0",
+						"is-fullwidth-code-point": "^3.0.0"
+					}
+				},
+				"source-map-js": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
+					"integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
+					"dev": true
+				},
+				"string-width": {
+					"version": "4.2.3",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+					"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+					"dev": true,
+					"requires": {
+						"emoji-regex": "^8.0.0",
+						"is-fullwidth-code-point": "^3.0.0",
+						"strip-ansi": "^6.0.1"
+					}
+				},
+				"strip-indent": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+					"integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+					"dev": true,
+					"requires": {
+						"min-indent": "^1.0.0"
+					}
+				},
+				"stylelint": {
+					"version": "14.16.1",
+					"resolved": "https://registry.npmjs.org/stylelint/-/stylelint-14.16.1.tgz",
+					"integrity": "sha512-ErlzR/T3hhbV+a925/gbfc3f3Fep9/bnspMiJPorfGEmcBbXdS+oo6LrVtoUZ/w9fqD6o6k7PtUlCOsCRdjX/A==",
+					"dev": true,
+					"requires": {
+						"@csstools/selector-specificity": "^2.0.2",
+						"balanced-match": "^2.0.0",
+						"colord": "^2.9.3",
+						"cosmiconfig": "^7.1.0",
+						"css-functions-list": "^3.1.0",
+						"debug": "^4.3.4",
+						"fast-glob": "^3.2.12",
+						"fastest-levenshtein": "^1.0.16",
+						"file-entry-cache": "^6.0.1",
+						"global-modules": "^2.0.0",
+						"globby": "^11.1.0",
+						"globjoin": "^0.1.4",
+						"html-tags": "^3.2.0",
+						"ignore": "^5.2.1",
+						"import-lazy": "^4.0.0",
+						"imurmurhash": "^0.1.4",
+						"is-plain-object": "^5.0.0",
+						"known-css-properties": "^0.26.0",
+						"mathml-tag-names": "^2.1.3",
+						"meow": "^9.0.0",
+						"micromatch": "^4.0.5",
+						"normalize-path": "^3.0.0",
+						"picocolors": "^1.0.0",
+						"postcss": "^8.4.19",
+						"postcss-media-query-parser": "^0.2.3",
+						"postcss-resolve-nested-selector": "^0.1.1",
+						"postcss-safe-parser": "^6.0.0",
+						"postcss-selector-parser": "^6.0.11",
+						"postcss-value-parser": "^4.2.0",
+						"resolve-from": "^5.0.0",
+						"string-width": "^4.2.3",
+						"strip-ansi": "^6.0.1",
+						"style-search": "^0.1.0",
+						"supports-hyperlinks": "^2.3.0",
+						"svg-tags": "^1.0.0",
+						"table": "^6.8.1",
+						"v8-compile-cache": "^2.3.0",
+						"write-file-atomic": "^4.0.2"
+					},
+					"dependencies": {
+						"fast-glob": {
+							"version": "3.2.12",
+							"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz",
+							"integrity": "sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==",
+							"dev": true,
+							"requires": {
+								"@nodelib/fs.stat": "^2.0.2",
+								"@nodelib/fs.walk": "^1.2.3",
+								"glob-parent": "^5.1.2",
+								"merge2": "^1.3.0",
+								"micromatch": "^4.0.4"
+							}
+						},
+						"postcss": {
+							"version": "8.4.24",
+							"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.24.tgz",
+							"integrity": "sha512-M0RzbcI0sO/XJNucsGjvWU9ERWxb/ytp1w6dKtxTKgixdtQDq4rmx/g8W1hnaheq9jgwL/oyEdH5Bc4WwJKMqg==",
+							"dev": true,
+							"requires": {
+								"nanoid": "^3.3.6",
+								"picocolors": "^1.0.0",
+								"source-map-js": "^1.0.2"
+							}
+						}
+					}
+				},
+				"supports-color": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				},
+				"supports-hyperlinks": {
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-2.3.0.tgz",
+					"integrity": "sha512-RpsAZlpWcDwOPQA22aCH4J0t7L8JmAvsCxfOSEwm7cQs3LshN36QaTkwd70DnBOXDWGssw2eUoc8CaRWT0XunA==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^4.0.0",
+						"supports-color": "^7.0.0"
+					}
+				},
+				"table": {
+					"version": "6.8.1",
+					"resolved": "https://registry.npmjs.org/table/-/table-6.8.1.tgz",
+					"integrity": "sha512-Y4X9zqrCftUhMeH2EptSSERdVKt/nEdijTOacGD/97EKjhQ/Qs8RTlEGABSJNNN8lac9kheH+af7yAkEWlgneA==",
+					"dev": true,
+					"requires": {
+						"ajv": "^8.0.1",
+						"lodash.truncate": "^4.4.2",
+						"slice-ansi": "^4.0.0",
+						"string-width": "^4.2.3",
+						"strip-ansi": "^6.0.1"
+					}
+				},
+				"trim-newlines": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.1.tgz",
+					"integrity": "sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==",
+					"dev": true
+				},
+				"type-fest": {
+					"version": "0.18.1",
+					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.18.1.tgz",
+					"integrity": "sha512-OIAYXk8+ISY+qTOwkHtKqzAuxchoMiD9Udx+FSGQDuiRR+PJKJHc2NJAXlbhkGwTt/4/nKZxELY1w3ReWOL8mw==",
+					"dev": true
+				},
+				"v8-compile-cache": {
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
+					"integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
+					"dev": true
+				},
+				"write-file-atomic": {
+					"version": "4.0.2",
+					"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.2.tgz",
+					"integrity": "sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==",
+					"dev": true,
+					"requires": {
+						"imurmurhash": "^0.1.4",
+						"signal-exit": "^3.0.7"
+					}
+				},
+				"yallist": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+					"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+					"dev": true
+				},
+				"yaml": {
+					"version": "1.10.2",
+					"resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+					"integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+					"dev": true
+				}
 			}
 		},
 		"@wordpress/server-side-render": {
@@ -18745,29 +19231,10 @@
 			},
 			"dependencies": {
 				"stylelint-config-recommended": {
-					"version": "10.0.1",
-					"resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-10.0.1.tgz",
-					"integrity": "sha512-TQ4xQ48tW4QSlODcti7pgSRqBZcUaBzuh0jPpfiMhwJKBPkqzTIAU+IrSWL/7BgXlOM90DjB7YaNgFpx8QWhuA==",
+					"version": "9.0.0",
+					"resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-9.0.0.tgz",
+					"integrity": "sha512-9YQSrJq4NvvRuTbzDsWX3rrFOzOlYBmZP+o513BJN/yfEmGSr0AxdvrWs0P/ilSpVV/wisamAHu5XSk8Rcf4CQ==",
 					"dev": true
-				},
-				"stylelint-config-recommended-scss": {
-					"version": "8.0.0",
-					"resolved": "https://registry.npmjs.org/stylelint-config-recommended-scss/-/stylelint-config-recommended-scss-8.0.0.tgz",
-					"integrity": "sha512-BxjxEzRaZoQb7Iinc3p92GS6zRdRAkIuEu2ZFLTxJK2e1AIcCb5B5MXY9KOXdGTnYFZ+KKx6R4Fv9zU6CtMYPQ==",
-					"dev": true,
-					"requires": {
-						"postcss-scss": "^4.0.2",
-						"stylelint-config-recommended": "^9.0.0",
-						"stylelint-scss": "^4.0.0"
-					},
-					"dependencies": {
-						"stylelint-config-recommended": {
-							"version": "9.0.0",
-							"resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-9.0.0.tgz",
-							"integrity": "sha512-9YQSrJq4NvvRuTbzDsWX3rrFOzOlYBmZP+o513BJN/yfEmGSr0AxdvrWs0P/ilSpVV/wisamAHu5XSk8Rcf4CQ==",
-							"dev": true
-						}
-					}
 				}
 			}
 		},
@@ -40295,12 +40762,6 @@
 			"integrity": "sha512-ZRbnvdg/NxqzC7L9Uyqzf4psi1OM4Cuc+sJAkQPjO6XkQIJTNbfK2Rsmbw8fx1p2mkZdp2FZYo2+LwXYY/uwIA==",
 			"dev": true
 		},
-		"known-css-properties": {
-			"version": "0.26.0",
-			"resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.26.0.tgz",
-			"integrity": "sha512-5FZRzrZzNTBruuurWpvZnvP9pum+fe0HcK8z/ooo+U+Hmp4vtbyp1/QDsqmufirXy4egGzbaH/y2uCZf+6W5Kg==",
-			"dev": true
-		},
 		"language-subtag-registry": {
 			"version": "0.3.21",
 			"resolved": "https://registry.npmjs.org/language-subtag-registry/-/language-subtag-registry-0.3.21.tgz",
@@ -54510,435 +54971,21 @@
 				"postcss-selector-parser": "^6.0.4"
 			}
 		},
-		"stylelint": {
-			"version": "14.16.1",
-			"resolved": "https://registry.npmjs.org/stylelint/-/stylelint-14.16.1.tgz",
-			"integrity": "sha512-ErlzR/T3hhbV+a925/gbfc3f3Fep9/bnspMiJPorfGEmcBbXdS+oo6LrVtoUZ/w9fqD6o6k7PtUlCOsCRdjX/A==",
+		"stylelint-config-recommended-scss": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/stylelint-config-recommended-scss/-/stylelint-config-recommended-scss-8.0.0.tgz",
+			"integrity": "sha512-BxjxEzRaZoQb7Iinc3p92GS6zRdRAkIuEu2ZFLTxJK2e1AIcCb5B5MXY9KOXdGTnYFZ+KKx6R4Fv9zU6CtMYPQ==",
 			"dev": true,
 			"requires": {
-				"@csstools/selector-specificity": "^2.0.2",
-				"balanced-match": "^2.0.0",
-				"colord": "^2.9.3",
-				"cosmiconfig": "^7.1.0",
-				"css-functions-list": "^3.1.0",
-				"debug": "^4.3.4",
-				"fast-glob": "^3.2.12",
-				"fastest-levenshtein": "^1.0.16",
-				"file-entry-cache": "^6.0.1",
-				"global-modules": "^2.0.0",
-				"globby": "^11.1.0",
-				"globjoin": "^0.1.4",
-				"html-tags": "^3.2.0",
-				"ignore": "^5.2.1",
-				"import-lazy": "^4.0.0",
-				"imurmurhash": "^0.1.4",
-				"is-plain-object": "^5.0.0",
-				"known-css-properties": "^0.26.0",
-				"mathml-tag-names": "^2.1.3",
-				"meow": "^9.0.0",
-				"micromatch": "^4.0.5",
-				"normalize-path": "^3.0.0",
-				"picocolors": "^1.0.0",
-				"postcss": "^8.4.19",
-				"postcss-media-query-parser": "^0.2.3",
-				"postcss-resolve-nested-selector": "^0.1.1",
-				"postcss-safe-parser": "^6.0.0",
-				"postcss-selector-parser": "^6.0.11",
-				"postcss-value-parser": "^4.2.0",
-				"resolve-from": "^5.0.0",
-				"string-width": "^4.2.3",
-				"strip-ansi": "^6.0.1",
-				"style-search": "^0.1.0",
-				"supports-hyperlinks": "^2.3.0",
-				"svg-tags": "^1.0.0",
-				"table": "^6.8.1",
-				"v8-compile-cache": "^2.3.0",
-				"write-file-atomic": "^4.0.2"
+				"postcss-scss": "^4.0.2",
+				"stylelint-config-recommended": "^9.0.0",
+				"stylelint-scss": "^4.0.0"
 			},
 			"dependencies": {
-				"@nodelib/fs.stat": {
-					"version": "2.0.5",
-					"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
-					"integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
-					"dev": true
-				},
-				"array-union": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
-					"integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
-					"dev": true
-				},
-				"balanced-match": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-2.0.0.tgz",
-					"integrity": "sha512-1ugUSr8BHXRnK23KfuYS+gVMC3LB8QGH9W1iGtDPsNWoQbgtXSExkBu2aDR4epiGWZOjZsj6lDl/N/AqqTC3UA==",
-					"dev": true
-				},
-				"camelcase-keys": {
-					"version": "6.2.2",
-					"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-6.2.2.tgz",
-					"integrity": "sha512-YrwaA0vEKazPBkn0ipTiMpSajYDSe+KjQfrjhcBMxJt/znbvlHd8Pw/Vamaz5EB4Wfhs3SUR3Z9mwRu/P3s3Yg==",
-					"dev": true,
-					"requires": {
-						"camelcase": "^5.3.1",
-						"map-obj": "^4.0.0",
-						"quick-lru": "^4.0.1"
-					}
-				},
-				"cosmiconfig": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
-					"integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
-					"dev": true,
-					"requires": {
-						"@types/parse-json": "^4.0.0",
-						"import-fresh": "^3.2.1",
-						"parse-json": "^5.0.0",
-						"path-type": "^4.0.0",
-						"yaml": "^1.10.0"
-					}
-				},
-				"debug": {
-					"version": "4.3.4",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-					"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-					"dev": true,
-					"requires": {
-						"ms": "2.1.2"
-					}
-				},
-				"emoji-regex": {
-					"version": "8.0.0",
-					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-					"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-					"dev": true
-				},
-				"fast-glob": {
-					"version": "3.2.12",
-					"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz",
-					"integrity": "sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==",
-					"dev": true,
-					"requires": {
-						"@nodelib/fs.stat": "^2.0.2",
-						"@nodelib/fs.walk": "^1.2.3",
-						"glob-parent": "^5.1.2",
-						"merge2": "^1.3.0",
-						"micromatch": "^4.0.4"
-					}
-				},
-				"fastest-levenshtein": {
-					"version": "1.0.16",
-					"resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
-					"integrity": "sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==",
-					"dev": true
-				},
-				"glob-parent": {
-					"version": "5.1.2",
-					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-					"integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-					"dev": true,
-					"requires": {
-						"is-glob": "^4.0.1"
-					}
-				},
-				"globby": {
-					"version": "11.1.0",
-					"resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
-					"integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
-					"dev": true,
-					"requires": {
-						"array-union": "^2.1.0",
-						"dir-glob": "^3.0.1",
-						"fast-glob": "^3.2.9",
-						"ignore": "^5.2.0",
-						"merge2": "^1.4.1",
-						"slash": "^3.0.0"
-					}
-				},
-				"has-flag": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-					"dev": true
-				},
-				"hosted-git-info": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
-					"integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
-					"dev": true,
-					"requires": {
-						"lru-cache": "^6.0.0"
-					}
-				},
-				"html-tags": {
-					"version": "3.3.1",
-					"resolved": "https://registry.npmjs.org/html-tags/-/html-tags-3.3.1.tgz",
-					"integrity": "sha512-ztqyC3kLto0e9WbNp0aeP+M3kTt+nbaIveGmUxAtZa+8iFgKLUOD4YKM5j+f3QD89bra7UeumolZHKuOXnTmeQ==",
-					"dev": true
-				},
-				"ignore": {
-					"version": "5.2.4",
-					"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
-					"integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
-					"dev": true
-				},
-				"import-fresh": {
-					"version": "3.3.0",
-					"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
-					"integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
-					"dev": true,
-					"requires": {
-						"parent-module": "^1.0.0",
-						"resolve-from": "^4.0.0"
-					},
-					"dependencies": {
-						"resolve-from": {
-							"version": "4.0.0",
-							"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-							"integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-							"dev": true
-						}
-					}
-				},
-				"indent-string": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
-					"integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
-					"dev": true
-				},
-				"is-core-module": {
-					"version": "2.12.1",
-					"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.12.1.tgz",
-					"integrity": "sha512-Q4ZuBAe2FUsKtyQJoQHlvP8OvBERxO3jEmy1I7hcRXcJBGGHFh/aJBswbXuS9sgrDH2QUO8ilkwNPHvHMd8clg==",
-					"dev": true,
-					"requires": {
-						"has": "^1.0.3"
-					}
-				},
-				"is-fullwidth-code-point": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-					"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-					"dev": true
-				},
-				"is-glob": {
-					"version": "4.0.3",
-					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
-					"integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-					"dev": true,
-					"requires": {
-						"is-extglob": "^2.1.1"
-					}
-				},
-				"lru-cache": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-					"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-					"dev": true,
-					"requires": {
-						"yallist": "^4.0.0"
-					}
-				},
-				"map-obj": {
-					"version": "4.3.0",
-					"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.3.0.tgz",
-					"integrity": "sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==",
-					"dev": true
-				},
-				"meow": {
+				"stylelint-config-recommended": {
 					"version": "9.0.0",
-					"resolved": "https://registry.npmjs.org/meow/-/meow-9.0.0.tgz",
-					"integrity": "sha512-+obSblOQmRhcyBt62furQqRAQpNyWXo8BuQ5bN7dG8wmwQ+vwHKp/rCFD4CrTP8CsDQD1sjoZ94K417XEUk8IQ==",
-					"dev": true,
-					"requires": {
-						"@types/minimist": "^1.2.0",
-						"camelcase-keys": "^6.2.2",
-						"decamelize": "^1.2.0",
-						"decamelize-keys": "^1.1.0",
-						"hard-rejection": "^2.1.0",
-						"minimist-options": "4.1.0",
-						"normalize-package-data": "^3.0.0",
-						"read-pkg-up": "^7.0.1",
-						"redent": "^3.0.0",
-						"trim-newlines": "^3.0.0",
-						"type-fest": "^0.18.0",
-						"yargs-parser": "^20.2.3"
-					}
-				},
-				"merge2": {
-					"version": "1.4.1",
-					"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
-					"integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-					"dev": true
-				},
-				"ms": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-					"dev": true
-				},
-				"nanoid": {
-					"version": "3.3.6",
-					"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
-					"integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
-					"dev": true
-				},
-				"normalize-package-data": {
-					"version": "3.0.3",
-					"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
-					"integrity": "sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==",
-					"dev": true,
-					"requires": {
-						"hosted-git-info": "^4.0.1",
-						"is-core-module": "^2.5.0",
-						"semver": "^7.3.4",
-						"validate-npm-package-license": "^3.0.1"
-					}
-				},
-				"normalize-path": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-					"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-					"dev": true
-				},
-				"path-type": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-					"integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
-					"dev": true
-				},
-				"postcss": {
-					"version": "8.4.24",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.24.tgz",
-					"integrity": "sha512-M0RzbcI0sO/XJNucsGjvWU9ERWxb/ytp1w6dKtxTKgixdtQDq4rmx/g8W1hnaheq9jgwL/oyEdH5Bc4WwJKMqg==",
-					"dev": true,
-					"requires": {
-						"nanoid": "^3.3.6",
-						"picocolors": "^1.0.0",
-						"source-map-js": "^1.0.2"
-					}
-				},
-				"postcss-selector-parser": {
-					"version": "6.0.13",
-					"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.13.tgz",
-					"integrity": "sha512-EaV1Gl4mUEV4ddhDnv/xtj7sxwrwxdetHdWUGnT4VJQf+4d05v6lHYZr8N573k5Z0BViss7BDhfWtKS3+sfAqQ==",
-					"dev": true,
-					"requires": {
-						"cssesc": "^3.0.0",
-						"util-deprecate": "^1.0.2"
-					}
-				},
-				"postcss-value-parser": {
-					"version": "4.2.0",
-					"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
-					"integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
-					"dev": true
-				},
-				"redent": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
-					"integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
-					"dev": true,
-					"requires": {
-						"indent-string": "^4.0.0",
-						"strip-indent": "^3.0.0"
-					}
-				},
-				"resolve-from": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
-					"integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
-					"dev": true
-				},
-				"signal-exit": {
-					"version": "3.0.7",
-					"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-					"integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-					"dev": true
-				},
-				"source-map-js": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
-					"integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
-					"dev": true
-				},
-				"string-width": {
-					"version": "4.2.3",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-					"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-					"dev": true,
-					"requires": {
-						"emoji-regex": "^8.0.0",
-						"is-fullwidth-code-point": "^3.0.0",
-						"strip-ansi": "^6.0.1"
-					}
-				},
-				"strip-indent": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
-					"integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
-					"dev": true,
-					"requires": {
-						"min-indent": "^1.0.0"
-					}
-				},
-				"supports-color": {
-					"version": "7.2.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^4.0.0"
-					}
-				},
-				"supports-hyperlinks": {
-					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-2.3.0.tgz",
-					"integrity": "sha512-RpsAZlpWcDwOPQA22aCH4J0t7L8JmAvsCxfOSEwm7cQs3LshN36QaTkwd70DnBOXDWGssw2eUoc8CaRWT0XunA==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^4.0.0",
-						"supports-color": "^7.0.0"
-					}
-				},
-				"trim-newlines": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.1.tgz",
-					"integrity": "sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==",
-					"dev": true
-				},
-				"type-fest": {
-					"version": "0.18.1",
-					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.18.1.tgz",
-					"integrity": "sha512-OIAYXk8+ISY+qTOwkHtKqzAuxchoMiD9Udx+FSGQDuiRR+PJKJHc2NJAXlbhkGwTt/4/nKZxELY1w3ReWOL8mw==",
-					"dev": true
-				},
-				"v8-compile-cache": {
-					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
-					"integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
-					"dev": true
-				},
-				"write-file-atomic": {
-					"version": "4.0.2",
-					"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.2.tgz",
-					"integrity": "sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==",
-					"dev": true,
-					"requires": {
-						"imurmurhash": "^0.1.4",
-						"signal-exit": "^3.0.7"
-					}
-				},
-				"yallist": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-					"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-					"dev": true
-				},
-				"yaml": {
-					"version": "1.10.2",
-					"resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-					"integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+					"resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-9.0.0.tgz",
+					"integrity": "sha512-9YQSrJq4NvvRuTbzDsWX3rrFOzOlYBmZP+o513BJN/yfEmGSr0AxdvrWs0P/ilSpVV/wisamAHu5XSk8Rcf4CQ==",
 					"dev": true
 				}
 			}
@@ -55399,61 +55446,6 @@
 			"resolved": "https://registry.npmjs.org/synchronous-promise/-/synchronous-promise-2.0.15.tgz",
 			"integrity": "sha512-k8uzYIkIVwmT+TcglpdN50pS2y1BDcUnBPK9iJeGu0Pl1lOI8pD6wtzgw91Pjpe+RxtTncw32tLxs/R0yNL2Mg==",
 			"dev": true
-		},
-		"table": {
-			"version": "6.8.1",
-			"resolved": "https://registry.npmjs.org/table/-/table-6.8.1.tgz",
-			"integrity": "sha512-Y4X9zqrCftUhMeH2EptSSERdVKt/nEdijTOacGD/97EKjhQ/Qs8RTlEGABSJNNN8lac9kheH+af7yAkEWlgneA==",
-			"dev": true,
-			"requires": {
-				"ajv": "^8.0.1",
-				"lodash.truncate": "^4.4.2",
-				"slice-ansi": "^4.0.0",
-				"string-width": "^4.2.3",
-				"strip-ansi": "^6.0.1"
-			},
-			"dependencies": {
-				"astral-regex": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
-					"integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
-					"dev": true
-				},
-				"emoji-regex": {
-					"version": "8.0.0",
-					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-					"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-					"dev": true
-				},
-				"is-fullwidth-code-point": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-					"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-					"dev": true
-				},
-				"slice-ansi": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
-					"integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^4.0.0",
-						"astral-regex": "^2.0.0",
-						"is-fullwidth-code-point": "^3.0.0"
-					}
-				},
-				"string-width": {
-					"version": "4.2.3",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-					"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-					"dev": true,
-					"requires": {
-						"emoji-regex": "^8.0.0",
-						"is-fullwidth-code-point": "^3.0.0",
-						"strip-ansi": "^6.0.1"
-					}
-				}
-			}
 		},
 		"tannin": {
 			"version": "1.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2023,6 +2023,12 @@
 			"dev": true,
 			"optional": true
 		},
+		"@csstools/selector-specificity": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-2.2.0.tgz",
+			"integrity": "sha512-+OJ9konv95ClSTOJCmMZqpd5+YGsB2S+x6w3E1oaM8UuR5j8nTNHYSz8c9BEPGDOCMQYIEEGlVPj/VY64iTbGw==",
+			"dev": true
+		},
 		"@discoveryjs/json-ext": {
 			"version": "0.5.5",
 			"resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.5.tgz",
@@ -18691,7 +18697,7 @@
 				"sass": "^1.35.2",
 				"sass-loader": "^12.1.0",
 				"source-map-loader": "^3.0.0",
-				"stylelint": "^14.2.0",
+				"stylelint": "14.16.1",
 				"terser-webpack-plugin": "^5.3.9",
 				"url-loader": "^4.1.1",
 				"webpack": "^5.47.1",
@@ -18734,8 +18740,35 @@
 			"version": "file:packages/stylelint-config",
 			"dev": true,
 			"requires": {
-				"stylelint-config-recommended": "^12.0.0",
-				"stylelint-config-recommended-scss": "^12.0.0"
+				"stylelint-config-recommended": "9",
+				"stylelint-config-recommended-scss": "8"
+			},
+			"dependencies": {
+				"stylelint-config-recommended": {
+					"version": "10.0.1",
+					"resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-10.0.1.tgz",
+					"integrity": "sha512-TQ4xQ48tW4QSlODcti7pgSRqBZcUaBzuh0jPpfiMhwJKBPkqzTIAU+IrSWL/7BgXlOM90DjB7YaNgFpx8QWhuA==",
+					"dev": true
+				},
+				"stylelint-config-recommended-scss": {
+					"version": "8.0.0",
+					"resolved": "https://registry.npmjs.org/stylelint-config-recommended-scss/-/stylelint-config-recommended-scss-8.0.0.tgz",
+					"integrity": "sha512-BxjxEzRaZoQb7Iinc3p92GS6zRdRAkIuEu2ZFLTxJK2e1AIcCb5B5MXY9KOXdGTnYFZ+KKx6R4Fv9zU6CtMYPQ==",
+					"dev": true,
+					"requires": {
+						"postcss-scss": "^4.0.2",
+						"stylelint-config-recommended": "^9.0.0",
+						"stylelint-scss": "^4.0.0"
+					},
+					"dependencies": {
+						"stylelint-config-recommended": {
+							"version": "9.0.0",
+							"resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-9.0.0.tgz",
+							"integrity": "sha512-9YQSrJq4NvvRuTbzDsWX3rrFOzOlYBmZP+o513BJN/yfEmGSr0AxdvrWs0P/ilSpVV/wisamAHu5XSk8Rcf4CQ==",
+							"dev": true
+						}
+					}
+				}
 			}
 		},
 		"@wordpress/token-list": {
@@ -29272,23 +29305,6 @@
 				}
 			}
 		},
-		"clone-regexp": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/clone-regexp/-/clone-regexp-2.2.0.tgz",
-			"integrity": "sha512-beMpP7BOtTipFuW8hrJvREQ2DrRu3BE7by0ZpibtfBA+qfHYvMGTc2Yb1JMYPKg/JUw0CHYvpg796aNTSW9z7Q==",
-			"dev": true,
-			"requires": {
-				"is-regexp": "^2.0.0"
-			},
-			"dependencies": {
-				"is-regexp": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-2.1.0.tgz",
-					"integrity": "sha512-OZ4IlER3zmRIoB9AqNhEggVxqIH4ofDns5nRrPS6yQxXE1TPCUpFznBfRQmQa8uC+pXqjMnukiJBxCisIxiLGA==",
-					"dev": true
-				}
-			}
-		},
 		"clone-response": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.3.tgz",
@@ -30803,6 +30819,12 @@
 			"requires": {
 				"timsort": "^0.3.0"
 			}
+		},
+		"css-functions-list": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/css-functions-list/-/css-functions-list-3.1.0.tgz",
+			"integrity": "sha512-/9lCvYZaUbBGvYUgYGFJ4dcYiyqdhSjG7IPVluoV8A1ILjkF7ilmhp1OGUz8n+nmBcu0RNrQAzgD8B6FJbrt2w==",
+			"dev": true
 		},
 		"css-loader": {
 			"version": "6.2.0",
@@ -34025,15 +34047,6 @@
 				}
 			}
 		},
-		"execall": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/execall/-/execall-2.0.0.tgz",
-			"integrity": "sha512-0FU2hZ5Hh6iQnarpRtQurM/aAvp3RIbfvgLHrcqJYzhXyV2KFruhuChf9NC6waAhiUR7FFtlugkI4p7f2Fqlow==",
-			"dev": true,
-			"requires": {
-				"clone-regexp": "^2.1.0"
-			}
-		},
 		"exit": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
@@ -36310,7 +36323,7 @@
 		"globjoin": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/globjoin/-/globjoin-0.1.4.tgz",
-			"integrity": "sha1-L0SUrIkZ43Z8XLtpHp9GMyQoXUM=",
+			"integrity": "sha512-xYfnw62CKG8nLkZBfWbhWwDw02CHty86jfPcc2cr3ZfeuK9ysoVPPEUxf21bAD/rWAgk52SuBrLJlefNy8mvFg==",
 			"dev": true
 		},
 		"good-listener": {
@@ -40283,9 +40296,9 @@
 			"dev": true
 		},
 		"known-css-properties": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.24.0.tgz",
-			"integrity": "sha512-RTSoaUAfLvpR357vWzAz/50Q/BmHfmE6ETSWfutT0AJiw10e6CmcdYRQJlLRd95B53D0Y2aD1jSxD3V3ySF+PA==",
+			"version": "0.26.0",
+			"resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.26.0.tgz",
+			"integrity": "sha512-5FZRzrZzNTBruuurWpvZnvP9pum+fe0HcK8z/ooo+U+Hmp4vtbyp1/QDsqmufirXy4egGzbaH/y2uCZf+6W5Kg==",
 			"dev": true
 		},
 		"language-subtag-registry": {
@@ -41203,7 +41216,7 @@
 		"lodash.truncate": {
 			"version": "4.4.2",
 			"resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
-			"integrity": "sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM=",
+			"integrity": "sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==",
 			"dev": true
 		},
 		"lodash.union": {
@@ -44435,12 +44448,6 @@
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
 			"integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI=",
-			"dev": true
-		},
-		"normalize-selector": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/normalize-selector/-/normalize-selector-0.2.0.tgz",
-			"integrity": "sha1-0LFF62kRicY6eNIB3E/bEpPvDAM=",
 			"dev": true
 		},
 		"normalize-url": {
@@ -54481,7 +54488,7 @@
 		"style-search": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/style-search/-/style-search-0.1.0.tgz",
-			"integrity": "sha1-eVjHk+R+MuB9K1yv5cC/jhLneQI=",
+			"integrity": "sha512-Dj1Okke1C3uKKwQcetra4jSuk0DqbzbYtXipzFlFMZtowbF1x7BKJwB9AayVMyFARvU8EDrZdcax4At/452cAg==",
 			"dev": true
 		},
 		"style-to-object": {
@@ -54504,62 +54511,55 @@
 			}
 		},
 		"stylelint": {
-			"version": "14.2.0",
-			"resolved": "https://registry.npmjs.org/stylelint/-/stylelint-14.2.0.tgz",
-			"integrity": "sha512-i0DrmDXFNpDsWiwx6SPRs4/pyw4kvZgqpDGvsTslQMY7hpUl6r33aQvNSn6cnTg2wtZ9rreFElI7XAKpOWi1vQ==",
+			"version": "14.16.1",
+			"resolved": "https://registry.npmjs.org/stylelint/-/stylelint-14.16.1.tgz",
+			"integrity": "sha512-ErlzR/T3hhbV+a925/gbfc3f3Fep9/bnspMiJPorfGEmcBbXdS+oo6LrVtoUZ/w9fqD6o6k7PtUlCOsCRdjX/A==",
 			"dev": true,
 			"requires": {
+				"@csstools/selector-specificity": "^2.0.2",
 				"balanced-match": "^2.0.0",
-				"colord": "^2.9.2",
-				"cosmiconfig": "^7.0.1",
-				"debug": "^4.3.3",
-				"execall": "^2.0.0",
-				"fast-glob": "^3.2.7",
-				"fastest-levenshtein": "^1.0.12",
+				"colord": "^2.9.3",
+				"cosmiconfig": "^7.1.0",
+				"css-functions-list": "^3.1.0",
+				"debug": "^4.3.4",
+				"fast-glob": "^3.2.12",
+				"fastest-levenshtein": "^1.0.16",
 				"file-entry-cache": "^6.0.1",
-				"get-stdin": "^8.0.0",
 				"global-modules": "^2.0.0",
-				"globby": "^11.0.4",
+				"globby": "^11.1.0",
 				"globjoin": "^0.1.4",
-				"html-tags": "^3.1.0",
-				"ignore": "^5.2.0",
+				"html-tags": "^3.2.0",
+				"ignore": "^5.2.1",
 				"import-lazy": "^4.0.0",
 				"imurmurhash": "^0.1.4",
 				"is-plain-object": "^5.0.0",
-				"known-css-properties": "^0.24.0",
+				"known-css-properties": "^0.26.0",
 				"mathml-tag-names": "^2.1.3",
 				"meow": "^9.0.0",
-				"micromatch": "^4.0.4",
+				"micromatch": "^4.0.5",
 				"normalize-path": "^3.0.0",
-				"normalize-selector": "^0.2.0",
 				"picocolors": "^1.0.0",
-				"postcss": "^8.3.11",
+				"postcss": "^8.4.19",
 				"postcss-media-query-parser": "^0.2.3",
 				"postcss-resolve-nested-selector": "^0.1.1",
 				"postcss-safe-parser": "^6.0.0",
-				"postcss-selector-parser": "^6.0.7",
-				"postcss-value-parser": "^4.1.0",
+				"postcss-selector-parser": "^6.0.11",
+				"postcss-value-parser": "^4.2.0",
 				"resolve-from": "^5.0.0",
-				"specificity": "^0.4.1",
 				"string-width": "^4.2.3",
 				"strip-ansi": "^6.0.1",
 				"style-search": "^0.1.0",
+				"supports-hyperlinks": "^2.3.0",
 				"svg-tags": "^1.0.0",
-				"table": "^6.7.5",
+				"table": "^6.8.1",
 				"v8-compile-cache": "^2.3.0",
-				"write-file-atomic": "^3.0.3"
+				"write-file-atomic": "^4.0.2"
 			},
 			"dependencies": {
 				"@nodelib/fs.stat": {
 					"version": "2.0.5",
 					"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
 					"integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
-					"dev": true
-				},
-				"ansi-regex": {
-					"version": "5.0.1",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-					"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
 					"dev": true
 				},
 				"array-union": {
@@ -54574,21 +54574,6 @@
 					"integrity": "sha512-1ugUSr8BHXRnK23KfuYS+gVMC3LB8QGH9W1iGtDPsNWoQbgtXSExkBu2aDR4epiGWZOjZsj6lDl/N/AqqTC3UA==",
 					"dev": true
 				},
-				"braces": {
-					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-					"integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-					"dev": true,
-					"requires": {
-						"fill-range": "^7.0.1"
-					}
-				},
-				"camelcase": {
-					"version": "5.3.1",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-					"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-					"dev": true
-				},
 				"camelcase-keys": {
 					"version": "6.2.2",
 					"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-6.2.2.tgz",
@@ -54601,9 +54586,9 @@
 					}
 				},
 				"cosmiconfig": {
-					"version": "7.0.1",
-					"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.1.tgz",
-					"integrity": "sha512-a1YWNUV2HwGimB7dU2s1wUMurNKjpx60HxBB6xUM8Re+2s1g1IIfJvFR0/iCF+XHdE0GMTKTuLR32UQff4TEyQ==",
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
+					"integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
 					"dev": true,
 					"requires": {
 						"@types/parse-json": "^4.0.0",
@@ -54614,9 +54599,9 @@
 					}
 				},
 				"debug": {
-					"version": "4.3.3",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-					"integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+					"version": "4.3.4",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+					"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
 					"dev": true,
 					"requires": {
 						"ms": "2.1.2"
@@ -54628,19 +54613,23 @@
 					"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
 					"dev": true
 				},
-				"fill-range": {
-					"version": "7.0.1",
-					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-					"integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+				"fast-glob": {
+					"version": "3.2.12",
+					"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz",
+					"integrity": "sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==",
 					"dev": true,
 					"requires": {
-						"to-regex-range": "^5.0.1"
+						"@nodelib/fs.stat": "^2.0.2",
+						"@nodelib/fs.walk": "^1.2.3",
+						"glob-parent": "^5.1.2",
+						"merge2": "^1.3.0",
+						"micromatch": "^4.0.4"
 					}
 				},
-				"get-stdin": {
-					"version": "8.0.0",
-					"resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-8.0.0.tgz",
-					"integrity": "sha512-sY22aA6xchAzprjyqmSEQv4UbAAzRN0L2dQB0NlN5acTTK9Don6nhoc3eAbUnpZiCANAMfd/+40kVdKfFygohg==",
+				"fastest-levenshtein": {
+					"version": "1.0.16",
+					"resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
+					"integrity": "sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==",
 					"dev": true
 				},
 				"glob-parent": {
@@ -54664,22 +54653,13 @@
 						"ignore": "^5.2.0",
 						"merge2": "^1.4.1",
 						"slash": "^3.0.0"
-					},
-					"dependencies": {
-						"fast-glob": {
-							"version": "3.2.11",
-							"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
-							"integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
-							"dev": true,
-							"requires": {
-								"@nodelib/fs.stat": "^2.0.2",
-								"@nodelib/fs.walk": "^1.2.3",
-								"glob-parent": "^5.1.2",
-								"merge2": "^1.3.0",
-								"micromatch": "^4.0.4"
-							}
-						}
 					}
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+					"dev": true
 				},
 				"hosted-git-info": {
 					"version": "4.1.0",
@@ -54690,10 +54670,16 @@
 						"lru-cache": "^6.0.0"
 					}
 				},
+				"html-tags": {
+					"version": "3.3.1",
+					"resolved": "https://registry.npmjs.org/html-tags/-/html-tags-3.3.1.tgz",
+					"integrity": "sha512-ztqyC3kLto0e9WbNp0aeP+M3kTt+nbaIveGmUxAtZa+8iFgKLUOD4YKM5j+f3QD89bra7UeumolZHKuOXnTmeQ==",
+					"dev": true
+				},
 				"ignore": {
-					"version": "5.2.0",
-					"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
-					"integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
+					"version": "5.2.4",
+					"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
+					"integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
 					"dev": true
 				},
 				"import-fresh": {
@@ -54721,9 +54707,9 @@
 					"dev": true
 				},
 				"is-core-module": {
-					"version": "2.8.1",
-					"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.1.tgz",
-					"integrity": "sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==",
+					"version": "2.12.1",
+					"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.12.1.tgz",
+					"integrity": "sha512-Q4ZuBAe2FUsKtyQJoQHlvP8OvBERxO3jEmy1I7hcRXcJBGGHFh/aJBswbXuS9sgrDH2QUO8ilkwNPHvHMd8clg==",
 					"dev": true,
 					"requires": {
 						"has": "^1.0.3"
@@ -54743,18 +54729,6 @@
 					"requires": {
 						"is-extglob": "^2.1.1"
 					}
-				},
-				"is-number": {
-					"version": "7.0.0",
-					"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-					"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-					"dev": true
-				},
-				"is-plain-object": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
-					"integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
-					"dev": true
 				},
 				"lru-cache": {
 					"version": "6.0.0",
@@ -54797,39 +54771,16 @@
 					"integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
 					"dev": true
 				},
-				"micromatch": {
-					"version": "4.0.4",
-					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
-					"integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
-					"dev": true,
-					"requires": {
-						"braces": "^3.0.1",
-						"picomatch": "^2.2.3"
-					}
-				},
-				"minimist-options": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-4.1.0.tgz",
-					"integrity": "sha512-Q4r8ghd80yhO/0j1O3B2BjweX3fiHg9cdOwjJd2J76Q135c+NDxGCqdYKQ1SKBuFfgWbAUzBfvYjPUEeNgqN1A==",
-					"dev": true,
-					"requires": {
-						"arrify": "^1.0.1",
-						"is-plain-obj": "^1.1.0",
-						"kind-of": "^6.0.3"
-					},
-					"dependencies": {
-						"is-plain-obj": {
-							"version": "1.1.0",
-							"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-							"integrity": "sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==",
-							"dev": true
-						}
-					}
-				},
 				"ms": {
 					"version": "2.1.2",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
 					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+					"dev": true
+				},
+				"nanoid": {
+					"version": "3.3.6",
+					"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
+					"integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
 					"dev": true
 				},
 				"normalize-package-data": {
@@ -54856,16 +54807,21 @@
 					"integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
 					"dev": true
 				},
-				"picomatch": {
-					"version": "2.3.1",
-					"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-					"integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-					"dev": true
+				"postcss": {
+					"version": "8.4.24",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.24.tgz",
+					"integrity": "sha512-M0RzbcI0sO/XJNucsGjvWU9ERWxb/ytp1w6dKtxTKgixdtQDq4rmx/g8W1hnaheq9jgwL/oyEdH5Bc4WwJKMqg==",
+					"dev": true,
+					"requires": {
+						"nanoid": "^3.3.6",
+						"picocolors": "^1.0.0",
+						"source-map-js": "^1.0.2"
+					}
 				},
 				"postcss-selector-parser": {
-					"version": "6.0.8",
-					"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.8.tgz",
-					"integrity": "sha512-D5PG53d209Z1Uhcc0qAZ5U3t5HagH3cxu+WLZ22jt3gLUpXM4eXXfiO14jiDWST3NNooX/E8wISfOhZ9eIjGTQ==",
+					"version": "6.0.13",
+					"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.13.tgz",
+					"integrity": "sha512-EaV1Gl4mUEV4ddhDnv/xtj7sxwrwxdetHdWUGnT4VJQf+4d05v6lHYZr8N573k5Z0BViss7BDhfWtKS3+sfAqQ==",
 					"dev": true,
 					"requires": {
 						"cssesc": "^3.0.0",
@@ -54876,12 +54832,6 @@
 					"version": "4.2.0",
 					"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
 					"integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
-					"dev": true
-				},
-				"quick-lru": {
-					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
-					"integrity": "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==",
 					"dev": true
 				},
 				"redent": {
@@ -54900,6 +54850,18 @@
 					"integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
 					"dev": true
 				},
+				"signal-exit": {
+					"version": "3.0.7",
+					"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+					"integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+					"dev": true
+				},
+				"source-map-js": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
+					"integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
+					"dev": true
+				},
 				"string-width": {
 					"version": "4.2.3",
 					"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
@@ -54911,15 +54873,6 @@
 						"strip-ansi": "^6.0.1"
 					}
 				},
-				"strip-ansi": {
-					"version": "6.0.1",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-					"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-					"dev": true,
-					"requires": {
-						"ansi-regex": "^5.0.1"
-					}
-				},
 				"strip-indent": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
@@ -54929,13 +54882,23 @@
 						"min-indent": "^1.0.0"
 					}
 				},
-				"to-regex-range": {
-					"version": "5.0.1",
-					"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-					"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+				"supports-color": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
 					"dev": true,
 					"requires": {
-						"is-number": "^7.0.0"
+						"has-flag": "^4.0.0"
+					}
+				},
+				"supports-hyperlinks": {
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-2.3.0.tgz",
+					"integrity": "sha512-RpsAZlpWcDwOPQA22aCH4J0t7L8JmAvsCxfOSEwm7cQs3LshN36QaTkwd70DnBOXDWGssw2eUoc8CaRWT0XunA==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^4.0.0",
+						"supports-color": "^7.0.0"
 					}
 				},
 				"trim-newlines": {
@@ -54957,15 +54920,13 @@
 					"dev": true
 				},
 				"write-file-atomic": {
-					"version": "3.0.3",
-					"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
-					"integrity": "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==",
+					"version": "4.0.2",
+					"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.2.tgz",
+					"integrity": "sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==",
 					"dev": true,
 					"requires": {
 						"imurmurhash": "^0.1.4",
-						"is-typedarray": "^1.0.0",
-						"signal-exit": "^3.0.2",
-						"typedarray-to-buffer": "^3.1.5"
+						"signal-exit": "^3.0.7"
 					}
 				},
 				"yallist": {
@@ -54982,27 +54943,10 @@
 				}
 			}
 		},
-		"stylelint-config-recommended": {
-			"version": "12.0.0",
-			"resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-12.0.0.tgz",
-			"integrity": "sha512-x6x8QNARrGO2sG6iURkzqL+Dp+4bJorPMMRNPScdvaUK8PsynriOcMW7AFDKqkWAS5wbue/u8fUT/4ynzcmqdQ==",
-			"dev": true
-		},
-		"stylelint-config-recommended-scss": {
-			"version": "12.0.0",
-			"resolved": "https://registry.npmjs.org/stylelint-config-recommended-scss/-/stylelint-config-recommended-scss-12.0.0.tgz",
-			"integrity": "sha512-5Bb2mlGy6WLa30oNeKpZvavv2lowJUsUJO25+OA68GFTemlwd1zbFsL7q0bReKipOSU3sG47hKneZ6Nd+ctrFA==",
-			"dev": true,
-			"requires": {
-				"postcss-scss": "^4.0.6",
-				"stylelint-config-recommended": "^12.0.0",
-				"stylelint-scss": "^5.0.0"
-			}
-		},
 		"stylelint-scss": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/stylelint-scss/-/stylelint-scss-5.0.0.tgz",
-			"integrity": "sha512-5Ee5kG3JIcP2jk2PMoFMiNmW/815V+wK5o37X5ke90ihWMpPXI9iyqeA6zEWipWSRXeQc0kqbd7hKqiR+wPKNA==",
+			"version": "4.7.0",
+			"resolved": "https://registry.npmjs.org/stylelint-scss/-/stylelint-scss-4.7.0.tgz",
+			"integrity": "sha512-TSUgIeS0H3jqDZnby1UO1Qv3poi1N8wUYIJY6D1tuUq2MN3lwp/rITVo0wD+1SWTmRm0tNmGO0b7nKInnqF6Hg==",
 			"dev": true,
 			"requires": {
 				"postcss-media-query-parser": "^0.2.3",
@@ -55089,7 +55033,7 @@
 		"svg-tags": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/svg-tags/-/svg-tags-1.0.0.tgz",
-			"integrity": "sha1-WPcc7jvVGbWdSyqEO2x95krAR2Q=",
+			"integrity": "sha512-ovssysQTa+luh7A5Weu3Rta6FJlFBBbInjOh722LIt6klpU2/HtdUbszju/G4devcvk8PGt7FCLv5wftu3THUA==",
 			"dev": true
 		},
 		"svgo": {
@@ -55457,9 +55401,9 @@
 			"dev": true
 		},
 		"table": {
-			"version": "6.8.0",
-			"resolved": "https://registry.npmjs.org/table/-/table-6.8.0.tgz",
-			"integrity": "sha512-s/fitrbVeEyHKFa7mFdkuQMWlH1Wgw/yEXMt5xACT4ZpzWFluehAxRtUUQKPuWhaLAWhFcVx6w3oC8VKaUfPGA==",
+			"version": "6.8.1",
+			"resolved": "https://registry.npmjs.org/table/-/table-6.8.1.tgz",
+			"integrity": "sha512-Y4X9zqrCftUhMeH2EptSSERdVKt/nEdijTOacGD/97EKjhQ/Qs8RTlEGABSJNNN8lac9kheH+af7yAkEWlgneA==",
 			"dev": true,
 			"requires": {
 				"ajv": "^8.0.1",
@@ -55469,40 +55413,10 @@
 				"strip-ansi": "^6.0.1"
 			},
 			"dependencies": {
-				"ansi-regex": {
-					"version": "5.0.1",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-					"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-					"dev": true
-				},
-				"ansi-styles": {
-					"version": "4.3.0",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-					"dev": true,
-					"requires": {
-						"color-convert": "^2.0.1"
-					}
-				},
 				"astral-regex": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
 					"integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
-					"dev": true
-				},
-				"color-convert": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-					"dev": true,
-					"requires": {
-						"color-name": "~1.1.4"
-					}
-				},
-				"color-name": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
 					"dev": true
 				},
 				"emoji-regex": {
@@ -55537,15 +55451,6 @@
 						"emoji-regex": "^8.0.0",
 						"is-fullwidth-code-point": "^3.0.0",
 						"strip-ansi": "^6.0.1"
-					}
-				},
-				"strip-ansi": {
-					"version": "6.0.1",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-					"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-					"dev": true,
-					"requires": {
-						"ansi-regex": "^5.0.1"
 					}
 				}
 			}

--- a/package-lock.json
+++ b/package-lock.json
@@ -18704,492 +18704,6 @@
 				"webpack-bundle-analyzer": "^4.4.2",
 				"webpack-cli": "^4.9.1",
 				"webpack-dev-server": "^4.4.0"
-			},
-			"dependencies": {
-				"@nodelib/fs.stat": {
-					"version": "2.0.5",
-					"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
-					"integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
-					"dev": true
-				},
-				"array-union": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
-					"integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
-					"dev": true
-				},
-				"astral-regex": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
-					"integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
-					"dev": true
-				},
-				"balanced-match": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-2.0.0.tgz",
-					"integrity": "sha512-1ugUSr8BHXRnK23KfuYS+gVMC3LB8QGH9W1iGtDPsNWoQbgtXSExkBu2aDR4epiGWZOjZsj6lDl/N/AqqTC3UA==",
-					"dev": true
-				},
-				"camelcase-keys": {
-					"version": "6.2.2",
-					"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-6.2.2.tgz",
-					"integrity": "sha512-YrwaA0vEKazPBkn0ipTiMpSajYDSe+KjQfrjhcBMxJt/znbvlHd8Pw/Vamaz5EB4Wfhs3SUR3Z9mwRu/P3s3Yg==",
-					"dev": true,
-					"requires": {
-						"camelcase": "^5.3.1",
-						"map-obj": "^4.0.0",
-						"quick-lru": "^4.0.1"
-					}
-				},
-				"cosmiconfig": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
-					"integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
-					"dev": true,
-					"requires": {
-						"@types/parse-json": "^4.0.0",
-						"import-fresh": "^3.2.1",
-						"parse-json": "^5.0.0",
-						"path-type": "^4.0.0",
-						"yaml": "^1.10.0"
-					}
-				},
-				"debug": {
-					"version": "4.3.4",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-					"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-					"dev": true,
-					"requires": {
-						"ms": "2.1.2"
-					}
-				},
-				"emoji-regex": {
-					"version": "8.0.0",
-					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-					"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-					"dev": true
-				},
-				"fastest-levenshtein": {
-					"version": "1.0.16",
-					"resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
-					"integrity": "sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==",
-					"dev": true
-				},
-				"glob-parent": {
-					"version": "5.1.2",
-					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-					"integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-					"dev": true,
-					"requires": {
-						"is-glob": "^4.0.1"
-					}
-				},
-				"globby": {
-					"version": "11.1.0",
-					"resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
-					"integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
-					"dev": true,
-					"requires": {
-						"array-union": "^2.1.0",
-						"dir-glob": "^3.0.1",
-						"fast-glob": "^3.2.9",
-						"ignore": "^5.2.0",
-						"merge2": "^1.4.1",
-						"slash": "^3.0.0"
-					},
-					"dependencies": {
-						"fast-glob": {
-							"version": "3.2.12",
-							"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz",
-							"integrity": "sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==",
-							"dev": true,
-							"requires": {
-								"@nodelib/fs.stat": "^2.0.2",
-								"@nodelib/fs.walk": "^1.2.3",
-								"glob-parent": "^5.1.2",
-								"merge2": "^1.3.0",
-								"micromatch": "^4.0.4"
-							}
-						}
-					}
-				},
-				"has-flag": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-					"dev": true
-				},
-				"hosted-git-info": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
-					"integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
-					"dev": true,
-					"requires": {
-						"lru-cache": "^6.0.0"
-					}
-				},
-				"html-tags": {
-					"version": "3.3.1",
-					"resolved": "https://registry.npmjs.org/html-tags/-/html-tags-3.3.1.tgz",
-					"integrity": "sha512-ztqyC3kLto0e9WbNp0aeP+M3kTt+nbaIveGmUxAtZa+8iFgKLUOD4YKM5j+f3QD89bra7UeumolZHKuOXnTmeQ==",
-					"dev": true
-				},
-				"ignore": {
-					"version": "5.2.4",
-					"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
-					"integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
-					"dev": true
-				},
-				"import-fresh": {
-					"version": "3.3.0",
-					"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
-					"integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
-					"dev": true,
-					"requires": {
-						"parent-module": "^1.0.0",
-						"resolve-from": "^4.0.0"
-					},
-					"dependencies": {
-						"resolve-from": {
-							"version": "4.0.0",
-							"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-							"integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-							"dev": true
-						}
-					}
-				},
-				"indent-string": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
-					"integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
-					"dev": true
-				},
-				"is-core-module": {
-					"version": "2.12.1",
-					"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.12.1.tgz",
-					"integrity": "sha512-Q4ZuBAe2FUsKtyQJoQHlvP8OvBERxO3jEmy1I7hcRXcJBGGHFh/aJBswbXuS9sgrDH2QUO8ilkwNPHvHMd8clg==",
-					"dev": true,
-					"requires": {
-						"has": "^1.0.3"
-					}
-				},
-				"is-fullwidth-code-point": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-					"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-					"dev": true
-				},
-				"is-glob": {
-					"version": "4.0.3",
-					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
-					"integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-					"dev": true,
-					"requires": {
-						"is-extglob": "^2.1.1"
-					}
-				},
-				"known-css-properties": {
-					"version": "0.26.0",
-					"resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.26.0.tgz",
-					"integrity": "sha512-5FZRzrZzNTBruuurWpvZnvP9pum+fe0HcK8z/ooo+U+Hmp4vtbyp1/QDsqmufirXy4egGzbaH/y2uCZf+6W5Kg==",
-					"dev": true
-				},
-				"lru-cache": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-					"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-					"dev": true,
-					"requires": {
-						"yallist": "^4.0.0"
-					}
-				},
-				"map-obj": {
-					"version": "4.3.0",
-					"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.3.0.tgz",
-					"integrity": "sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==",
-					"dev": true
-				},
-				"meow": {
-					"version": "9.0.0",
-					"resolved": "https://registry.npmjs.org/meow/-/meow-9.0.0.tgz",
-					"integrity": "sha512-+obSblOQmRhcyBt62furQqRAQpNyWXo8BuQ5bN7dG8wmwQ+vwHKp/rCFD4CrTP8CsDQD1sjoZ94K417XEUk8IQ==",
-					"dev": true,
-					"requires": {
-						"@types/minimist": "^1.2.0",
-						"camelcase-keys": "^6.2.2",
-						"decamelize": "^1.2.0",
-						"decamelize-keys": "^1.1.0",
-						"hard-rejection": "^2.1.0",
-						"minimist-options": "4.1.0",
-						"normalize-package-data": "^3.0.0",
-						"read-pkg-up": "^7.0.1",
-						"redent": "^3.0.0",
-						"trim-newlines": "^3.0.0",
-						"type-fest": "^0.18.0",
-						"yargs-parser": "^20.2.3"
-					}
-				},
-				"merge2": {
-					"version": "1.4.1",
-					"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
-					"integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-					"dev": true
-				},
-				"ms": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-					"dev": true
-				},
-				"nanoid": {
-					"version": "3.3.6",
-					"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
-					"integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
-					"dev": true
-				},
-				"normalize-package-data": {
-					"version": "3.0.3",
-					"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
-					"integrity": "sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==",
-					"dev": true,
-					"requires": {
-						"hosted-git-info": "^4.0.1",
-						"is-core-module": "^2.5.0",
-						"semver": "^7.3.4",
-						"validate-npm-package-license": "^3.0.1"
-					}
-				},
-				"normalize-path": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-					"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-					"dev": true
-				},
-				"path-type": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-					"integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
-					"dev": true
-				},
-				"postcss-selector-parser": {
-					"version": "6.0.13",
-					"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.13.tgz",
-					"integrity": "sha512-EaV1Gl4mUEV4ddhDnv/xtj7sxwrwxdetHdWUGnT4VJQf+4d05v6lHYZr8N573k5Z0BViss7BDhfWtKS3+sfAqQ==",
-					"dev": true,
-					"requires": {
-						"cssesc": "^3.0.0",
-						"util-deprecate": "^1.0.2"
-					}
-				},
-				"postcss-value-parser": {
-					"version": "4.2.0",
-					"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
-					"integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
-					"dev": true
-				},
-				"redent": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
-					"integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
-					"dev": true,
-					"requires": {
-						"indent-string": "^4.0.0",
-						"strip-indent": "^3.0.0"
-					}
-				},
-				"resolve-from": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
-					"integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
-					"dev": true
-				},
-				"signal-exit": {
-					"version": "3.0.7",
-					"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-					"integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-					"dev": true
-				},
-				"slice-ansi": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
-					"integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^4.0.0",
-						"astral-regex": "^2.0.0",
-						"is-fullwidth-code-point": "^3.0.0"
-					}
-				},
-				"source-map-js": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
-					"integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
-					"dev": true
-				},
-				"string-width": {
-					"version": "4.2.3",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-					"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-					"dev": true,
-					"requires": {
-						"emoji-regex": "^8.0.0",
-						"is-fullwidth-code-point": "^3.0.0",
-						"strip-ansi": "^6.0.1"
-					}
-				},
-				"strip-indent": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
-					"integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
-					"dev": true,
-					"requires": {
-						"min-indent": "^1.0.0"
-					}
-				},
-				"stylelint": {
-					"version": "14.16.1",
-					"resolved": "https://registry.npmjs.org/stylelint/-/stylelint-14.16.1.tgz",
-					"integrity": "sha512-ErlzR/T3hhbV+a925/gbfc3f3Fep9/bnspMiJPorfGEmcBbXdS+oo6LrVtoUZ/w9fqD6o6k7PtUlCOsCRdjX/A==",
-					"dev": true,
-					"requires": {
-						"@csstools/selector-specificity": "^2.0.2",
-						"balanced-match": "^2.0.0",
-						"colord": "^2.9.3",
-						"cosmiconfig": "^7.1.0",
-						"css-functions-list": "^3.1.0",
-						"debug": "^4.3.4",
-						"fast-glob": "^3.2.12",
-						"fastest-levenshtein": "^1.0.16",
-						"file-entry-cache": "^6.0.1",
-						"global-modules": "^2.0.0",
-						"globby": "^11.1.0",
-						"globjoin": "^0.1.4",
-						"html-tags": "^3.2.0",
-						"ignore": "^5.2.1",
-						"import-lazy": "^4.0.0",
-						"imurmurhash": "^0.1.4",
-						"is-plain-object": "^5.0.0",
-						"known-css-properties": "^0.26.0",
-						"mathml-tag-names": "^2.1.3",
-						"meow": "^9.0.0",
-						"micromatch": "^4.0.5",
-						"normalize-path": "^3.0.0",
-						"picocolors": "^1.0.0",
-						"postcss": "^8.4.19",
-						"postcss-media-query-parser": "^0.2.3",
-						"postcss-resolve-nested-selector": "^0.1.1",
-						"postcss-safe-parser": "^6.0.0",
-						"postcss-selector-parser": "^6.0.11",
-						"postcss-value-parser": "^4.2.0",
-						"resolve-from": "^5.0.0",
-						"string-width": "^4.2.3",
-						"strip-ansi": "^6.0.1",
-						"style-search": "^0.1.0",
-						"supports-hyperlinks": "^2.3.0",
-						"svg-tags": "^1.0.0",
-						"table": "^6.8.1",
-						"v8-compile-cache": "^2.3.0",
-						"write-file-atomic": "^4.0.2"
-					},
-					"dependencies": {
-						"fast-glob": {
-							"version": "3.2.12",
-							"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz",
-							"integrity": "sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==",
-							"dev": true,
-							"requires": {
-								"@nodelib/fs.stat": "^2.0.2",
-								"@nodelib/fs.walk": "^1.2.3",
-								"glob-parent": "^5.1.2",
-								"merge2": "^1.3.0",
-								"micromatch": "^4.0.4"
-							}
-						},
-						"postcss": {
-							"version": "8.4.24",
-							"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.24.tgz",
-							"integrity": "sha512-M0RzbcI0sO/XJNucsGjvWU9ERWxb/ytp1w6dKtxTKgixdtQDq4rmx/g8W1hnaheq9jgwL/oyEdH5Bc4WwJKMqg==",
-							"dev": true,
-							"requires": {
-								"nanoid": "^3.3.6",
-								"picocolors": "^1.0.0",
-								"source-map-js": "^1.0.2"
-							}
-						}
-					}
-				},
-				"supports-color": {
-					"version": "7.2.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^4.0.0"
-					}
-				},
-				"supports-hyperlinks": {
-					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-2.3.0.tgz",
-					"integrity": "sha512-RpsAZlpWcDwOPQA22aCH4J0t7L8JmAvsCxfOSEwm7cQs3LshN36QaTkwd70DnBOXDWGssw2eUoc8CaRWT0XunA==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^4.0.0",
-						"supports-color": "^7.0.0"
-					}
-				},
-				"table": {
-					"version": "6.8.1",
-					"resolved": "https://registry.npmjs.org/table/-/table-6.8.1.tgz",
-					"integrity": "sha512-Y4X9zqrCftUhMeH2EptSSERdVKt/nEdijTOacGD/97EKjhQ/Qs8RTlEGABSJNNN8lac9kheH+af7yAkEWlgneA==",
-					"dev": true,
-					"requires": {
-						"ajv": "^8.0.1",
-						"lodash.truncate": "^4.4.2",
-						"slice-ansi": "^4.0.0",
-						"string-width": "^4.2.3",
-						"strip-ansi": "^6.0.1"
-					}
-				},
-				"trim-newlines": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.1.tgz",
-					"integrity": "sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==",
-					"dev": true
-				},
-				"type-fest": {
-					"version": "0.18.1",
-					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.18.1.tgz",
-					"integrity": "sha512-OIAYXk8+ISY+qTOwkHtKqzAuxchoMiD9Udx+FSGQDuiRR+PJKJHc2NJAXlbhkGwTt/4/nKZxELY1w3ReWOL8mw==",
-					"dev": true
-				},
-				"v8-compile-cache": {
-					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
-					"integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
-					"dev": true
-				},
-				"write-file-atomic": {
-					"version": "4.0.2",
-					"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.2.tgz",
-					"integrity": "sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==",
-					"dev": true,
-					"requires": {
-						"imurmurhash": "^0.1.4",
-						"signal-exit": "^3.0.7"
-					}
-				},
-				"yallist": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-					"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-					"dev": true
-				},
-				"yaml": {
-					"version": "1.10.2",
-					"resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-					"integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
-					"dev": true
-				}
 			}
 		},
 		"@wordpress/server-side-render": {
@@ -40505,7 +40019,7 @@
 		"json-stable-stringify-without-jsonify": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
-			"integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+			"integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
 			"dev": true
 		},
 		"json-stringify-nice": {
@@ -40760,6 +40274,12 @@
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/klona/-/klona-2.0.4.tgz",
 			"integrity": "sha512-ZRbnvdg/NxqzC7L9Uyqzf4psi1OM4Cuc+sJAkQPjO6XkQIJTNbfK2Rsmbw8fx1p2mkZdp2FZYo2+LwXYY/uwIA==",
+			"dev": true
+		},
+		"known-css-properties": {
+			"version": "0.26.0",
+			"resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.26.0.tgz",
+			"integrity": "sha512-5FZRzrZzNTBruuurWpvZnvP9pum+fe0HcK8z/ooo+U+Hmp4vtbyp1/QDsqmufirXy4egGzbaH/y2uCZf+6W5Kg==",
 			"dev": true
 		},
 		"language-subtag-registry": {
@@ -54971,6 +54491,439 @@
 				"postcss-selector-parser": "^6.0.4"
 			}
 		},
+		"stylelint": {
+			"version": "14.16.1",
+			"resolved": "https://registry.npmjs.org/stylelint/-/stylelint-14.16.1.tgz",
+			"integrity": "sha512-ErlzR/T3hhbV+a925/gbfc3f3Fep9/bnspMiJPorfGEmcBbXdS+oo6LrVtoUZ/w9fqD6o6k7PtUlCOsCRdjX/A==",
+			"dev": true,
+			"requires": {
+				"@csstools/selector-specificity": "^2.0.2",
+				"balanced-match": "^2.0.0",
+				"colord": "^2.9.3",
+				"cosmiconfig": "^7.1.0",
+				"css-functions-list": "^3.1.0",
+				"debug": "^4.3.4",
+				"fast-glob": "^3.2.12",
+				"fastest-levenshtein": "^1.0.16",
+				"file-entry-cache": "^6.0.1",
+				"global-modules": "^2.0.0",
+				"globby": "^11.1.0",
+				"globjoin": "^0.1.4",
+				"html-tags": "^3.2.0",
+				"ignore": "^5.2.1",
+				"import-lazy": "^4.0.0",
+				"imurmurhash": "^0.1.4",
+				"is-plain-object": "^5.0.0",
+				"known-css-properties": "^0.26.0",
+				"mathml-tag-names": "^2.1.3",
+				"meow": "^9.0.0",
+				"micromatch": "^4.0.5",
+				"normalize-path": "^3.0.0",
+				"picocolors": "^1.0.0",
+				"postcss": "^8.4.19",
+				"postcss-media-query-parser": "^0.2.3",
+				"postcss-resolve-nested-selector": "^0.1.1",
+				"postcss-safe-parser": "^6.0.0",
+				"postcss-selector-parser": "^6.0.11",
+				"postcss-value-parser": "^4.2.0",
+				"resolve-from": "^5.0.0",
+				"string-width": "^4.2.3",
+				"strip-ansi": "^6.0.1",
+				"style-search": "^0.1.0",
+				"supports-hyperlinks": "^2.3.0",
+				"svg-tags": "^1.0.0",
+				"table": "^6.8.1",
+				"v8-compile-cache": "^2.3.0",
+				"write-file-atomic": "^4.0.2"
+			},
+			"dependencies": {
+				"@nodelib/fs.stat": {
+					"version": "2.0.5",
+					"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+					"integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+					"dev": true
+				},
+				"array-union": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+					"integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+					"dev": true
+				},
+				"balanced-match": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-2.0.0.tgz",
+					"integrity": "sha512-1ugUSr8BHXRnK23KfuYS+gVMC3LB8QGH9W1iGtDPsNWoQbgtXSExkBu2aDR4epiGWZOjZsj6lDl/N/AqqTC3UA==",
+					"dev": true
+				},
+				"camelcase-keys": {
+					"version": "6.2.2",
+					"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-6.2.2.tgz",
+					"integrity": "sha512-YrwaA0vEKazPBkn0ipTiMpSajYDSe+KjQfrjhcBMxJt/znbvlHd8Pw/Vamaz5EB4Wfhs3SUR3Z9mwRu/P3s3Yg==",
+					"dev": true,
+					"requires": {
+						"camelcase": "^5.3.1",
+						"map-obj": "^4.0.0",
+						"quick-lru": "^4.0.1"
+					}
+				},
+				"cosmiconfig": {
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
+					"integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
+					"dev": true,
+					"requires": {
+						"@types/parse-json": "^4.0.0",
+						"import-fresh": "^3.2.1",
+						"parse-json": "^5.0.0",
+						"path-type": "^4.0.0",
+						"yaml": "^1.10.0"
+					}
+				},
+				"debug": {
+					"version": "4.3.4",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+					"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+					"dev": true,
+					"requires": {
+						"ms": "2.1.2"
+					}
+				},
+				"emoji-regex": {
+					"version": "8.0.0",
+					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+					"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+					"dev": true
+				},
+				"fast-glob": {
+					"version": "3.2.12",
+					"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz",
+					"integrity": "sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==",
+					"dev": true,
+					"requires": {
+						"@nodelib/fs.stat": "^2.0.2",
+						"@nodelib/fs.walk": "^1.2.3",
+						"glob-parent": "^5.1.2",
+						"merge2": "^1.3.0",
+						"micromatch": "^4.0.4"
+					}
+				},
+				"fastest-levenshtein": {
+					"version": "1.0.16",
+					"resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
+					"integrity": "sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==",
+					"dev": true
+				},
+				"glob-parent": {
+					"version": "5.1.2",
+					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+					"integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+					"dev": true,
+					"requires": {
+						"is-glob": "^4.0.1"
+					}
+				},
+				"globby": {
+					"version": "11.1.0",
+					"resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+					"integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+					"dev": true,
+					"requires": {
+						"array-union": "^2.1.0",
+						"dir-glob": "^3.0.1",
+						"fast-glob": "^3.2.9",
+						"ignore": "^5.2.0",
+						"merge2": "^1.4.1",
+						"slash": "^3.0.0"
+					}
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+					"dev": true
+				},
+				"hosted-git-info": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
+					"integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
+					"dev": true,
+					"requires": {
+						"lru-cache": "^6.0.0"
+					}
+				},
+				"html-tags": {
+					"version": "3.3.1",
+					"resolved": "https://registry.npmjs.org/html-tags/-/html-tags-3.3.1.tgz",
+					"integrity": "sha512-ztqyC3kLto0e9WbNp0aeP+M3kTt+nbaIveGmUxAtZa+8iFgKLUOD4YKM5j+f3QD89bra7UeumolZHKuOXnTmeQ==",
+					"dev": true
+				},
+				"ignore": {
+					"version": "5.2.4",
+					"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
+					"integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
+					"dev": true
+				},
+				"import-fresh": {
+					"version": "3.3.0",
+					"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
+					"integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
+					"dev": true,
+					"requires": {
+						"parent-module": "^1.0.0",
+						"resolve-from": "^4.0.0"
+					},
+					"dependencies": {
+						"resolve-from": {
+							"version": "4.0.0",
+							"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+							"integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+							"dev": true
+						}
+					}
+				},
+				"indent-string": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+					"integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+					"dev": true
+				},
+				"is-core-module": {
+					"version": "2.12.1",
+					"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.12.1.tgz",
+					"integrity": "sha512-Q4ZuBAe2FUsKtyQJoQHlvP8OvBERxO3jEmy1I7hcRXcJBGGHFh/aJBswbXuS9sgrDH2QUO8ilkwNPHvHMd8clg==",
+					"dev": true,
+					"requires": {
+						"has": "^1.0.3"
+					}
+				},
+				"is-fullwidth-code-point": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+					"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+					"dev": true
+				},
+				"is-glob": {
+					"version": "4.0.3",
+					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+					"integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+					"dev": true,
+					"requires": {
+						"is-extglob": "^2.1.1"
+					}
+				},
+				"lru-cache": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+					"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+					"dev": true,
+					"requires": {
+						"yallist": "^4.0.0"
+					}
+				},
+				"map-obj": {
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.3.0.tgz",
+					"integrity": "sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==",
+					"dev": true
+				},
+				"meow": {
+					"version": "9.0.0",
+					"resolved": "https://registry.npmjs.org/meow/-/meow-9.0.0.tgz",
+					"integrity": "sha512-+obSblOQmRhcyBt62furQqRAQpNyWXo8BuQ5bN7dG8wmwQ+vwHKp/rCFD4CrTP8CsDQD1sjoZ94K417XEUk8IQ==",
+					"dev": true,
+					"requires": {
+						"@types/minimist": "^1.2.0",
+						"camelcase-keys": "^6.2.2",
+						"decamelize": "^1.2.0",
+						"decamelize-keys": "^1.1.0",
+						"hard-rejection": "^2.1.0",
+						"minimist-options": "4.1.0",
+						"normalize-package-data": "^3.0.0",
+						"read-pkg-up": "^7.0.1",
+						"redent": "^3.0.0",
+						"trim-newlines": "^3.0.0",
+						"type-fest": "^0.18.0",
+						"yargs-parser": "^20.2.3"
+					}
+				},
+				"merge2": {
+					"version": "1.4.1",
+					"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+					"integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+					"dev": true
+				},
+				"ms": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+					"dev": true
+				},
+				"nanoid": {
+					"version": "3.3.6",
+					"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
+					"integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
+					"dev": true
+				},
+				"normalize-package-data": {
+					"version": "3.0.3",
+					"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
+					"integrity": "sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==",
+					"dev": true,
+					"requires": {
+						"hosted-git-info": "^4.0.1",
+						"is-core-module": "^2.5.0",
+						"semver": "^7.3.4",
+						"validate-npm-package-license": "^3.0.1"
+					}
+				},
+				"normalize-path": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+					"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+					"dev": true
+				},
+				"path-type": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+					"integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+					"dev": true
+				},
+				"postcss": {
+					"version": "8.4.24",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.24.tgz",
+					"integrity": "sha512-M0RzbcI0sO/XJNucsGjvWU9ERWxb/ytp1w6dKtxTKgixdtQDq4rmx/g8W1hnaheq9jgwL/oyEdH5Bc4WwJKMqg==",
+					"dev": true,
+					"requires": {
+						"nanoid": "^3.3.6",
+						"picocolors": "^1.0.0",
+						"source-map-js": "^1.0.2"
+					}
+				},
+				"postcss-selector-parser": {
+					"version": "6.0.13",
+					"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.13.tgz",
+					"integrity": "sha512-EaV1Gl4mUEV4ddhDnv/xtj7sxwrwxdetHdWUGnT4VJQf+4d05v6lHYZr8N573k5Z0BViss7BDhfWtKS3+sfAqQ==",
+					"dev": true,
+					"requires": {
+						"cssesc": "^3.0.0",
+						"util-deprecate": "^1.0.2"
+					}
+				},
+				"postcss-value-parser": {
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+					"integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+					"dev": true
+				},
+				"redent": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+					"integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+					"dev": true,
+					"requires": {
+						"indent-string": "^4.0.0",
+						"strip-indent": "^3.0.0"
+					}
+				},
+				"resolve-from": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+					"integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+					"dev": true
+				},
+				"signal-exit": {
+					"version": "3.0.7",
+					"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+					"integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+					"dev": true
+				},
+				"source-map-js": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
+					"integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
+					"dev": true
+				},
+				"string-width": {
+					"version": "4.2.3",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+					"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+					"dev": true,
+					"requires": {
+						"emoji-regex": "^8.0.0",
+						"is-fullwidth-code-point": "^3.0.0",
+						"strip-ansi": "^6.0.1"
+					}
+				},
+				"strip-indent": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+					"integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+					"dev": true,
+					"requires": {
+						"min-indent": "^1.0.0"
+					}
+				},
+				"supports-color": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				},
+				"supports-hyperlinks": {
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-2.3.0.tgz",
+					"integrity": "sha512-RpsAZlpWcDwOPQA22aCH4J0t7L8JmAvsCxfOSEwm7cQs3LshN36QaTkwd70DnBOXDWGssw2eUoc8CaRWT0XunA==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^4.0.0",
+						"supports-color": "^7.0.0"
+					}
+				},
+				"trim-newlines": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.1.tgz",
+					"integrity": "sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==",
+					"dev": true
+				},
+				"type-fest": {
+					"version": "0.18.1",
+					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.18.1.tgz",
+					"integrity": "sha512-OIAYXk8+ISY+qTOwkHtKqzAuxchoMiD9Udx+FSGQDuiRR+PJKJHc2NJAXlbhkGwTt/4/nKZxELY1w3ReWOL8mw==",
+					"dev": true
+				},
+				"v8-compile-cache": {
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
+					"integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
+					"dev": true
+				},
+				"write-file-atomic": {
+					"version": "4.0.2",
+					"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.2.tgz",
+					"integrity": "sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==",
+					"dev": true,
+					"requires": {
+						"imurmurhash": "^0.1.4",
+						"signal-exit": "^3.0.7"
+					}
+				},
+				"yallist": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+					"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+					"dev": true
+				},
+				"yaml": {
+					"version": "1.10.2",
+					"resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+					"integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+					"dev": true
+				}
+			}
+		},
 		"stylelint-config-recommended-scss": {
 			"version": "8.0.0",
 			"resolved": "https://registry.npmjs.org/stylelint-config-recommended-scss/-/stylelint-config-recommended-scss-8.0.0.tgz",
@@ -55447,6 +55400,61 @@
 			"integrity": "sha512-k8uzYIkIVwmT+TcglpdN50pS2y1BDcUnBPK9iJeGu0Pl1lOI8pD6wtzgw91Pjpe+RxtTncw32tLxs/R0yNL2Mg==",
 			"dev": true
 		},
+		"table": {
+			"version": "6.8.1",
+			"resolved": "https://registry.npmjs.org/table/-/table-6.8.1.tgz",
+			"integrity": "sha512-Y4X9zqrCftUhMeH2EptSSERdVKt/nEdijTOacGD/97EKjhQ/Qs8RTlEGABSJNNN8lac9kheH+af7yAkEWlgneA==",
+			"dev": true,
+			"requires": {
+				"ajv": "^8.0.1",
+				"lodash.truncate": "^4.4.2",
+				"slice-ansi": "^4.0.0",
+				"string-width": "^4.2.3",
+				"strip-ansi": "^6.0.1"
+			},
+			"dependencies": {
+				"astral-regex": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+					"integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
+					"dev": true
+				},
+				"emoji-regex": {
+					"version": "8.0.0",
+					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+					"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+					"dev": true
+				},
+				"is-fullwidth-code-point": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+					"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+					"dev": true
+				},
+				"slice-ansi": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
+					"integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.0.0",
+						"astral-regex": "^2.0.0",
+						"is-fullwidth-code-point": "^3.0.0"
+					}
+				},
+				"string-width": {
+					"version": "4.2.3",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+					"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+					"dev": true,
+					"requires": {
+						"emoji-regex": "^8.0.0",
+						"is-fullwidth-code-point": "^3.0.0",
+						"strip-ansi": "^6.0.1"
+					}
+				}
+			}
+		},
 		"tannin": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/tannin/-/tannin-1.2.0.tgz",
@@ -55740,7 +55748,7 @@
 		"text-table": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-			"integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+			"integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
 			"dev": true
 		},
 		"throat": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -18734,8 +18734,8 @@
 			"version": "file:packages/stylelint-config",
 			"dev": true,
 			"requires": {
-				"stylelint-config-recommended": "^6.0.0",
-				"stylelint-config-recommended-scss": "^5.0.2"
+				"stylelint-config-recommended": "^12.0.0",
+				"stylelint-config-recommended-scss": "^12.0.0"
 			}
 		},
 		"@wordpress/token-list": {
@@ -47990,6 +47990,12 @@
 			"integrity": "sha512-FARHN8pwH+WiS2OPCxJI8FuRJpTVnn6ZNFiqAM2aeW2LwTHWWmWgIyKC6cUo0L8aeKiF/14MNvnpls6R2PBeMQ==",
 			"dev": true
 		},
+		"postcss-scss": {
+			"version": "4.0.6",
+			"resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-4.0.6.tgz",
+			"integrity": "sha512-rLDPhJY4z/i4nVFZ27j9GqLxj1pwxE80eAzUNRMXtcpipFYIeowerzBgG3yJhMtObGEXidtIgbUpQ3eLDsf5OQ==",
+			"dev": true
+		},
 		"postcss-selector-parser": {
 			"version": "6.0.4",
 			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.4.tgz",
@@ -54977,47 +54983,38 @@
 			}
 		},
 		"stylelint-config-recommended": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-6.0.0.tgz",
-			"integrity": "sha512-ZorSSdyMcxWpROYUvLEMm0vSZud2uB7tX1hzBZwvVY9SV/uly4AvvJPPhCcymZL3fcQhEQG5AELmrxWqtmzacw==",
+			"version": "12.0.0",
+			"resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-12.0.0.tgz",
+			"integrity": "sha512-x6x8QNARrGO2sG6iURkzqL+Dp+4bJorPMMRNPScdvaUK8PsynriOcMW7AFDKqkWAS5wbue/u8fUT/4ynzcmqdQ==",
 			"dev": true
 		},
 		"stylelint-config-recommended-scss": {
-			"version": "5.0.2",
-			"resolved": "https://registry.npmjs.org/stylelint-config-recommended-scss/-/stylelint-config-recommended-scss-5.0.2.tgz",
-			"integrity": "sha512-b14BSZjcwW0hqbzm9b0S/ScN2+3CO3O4vcMNOw2KGf8lfVSwJ4p5TbNEXKwKl1+0FMtgRXZj6DqVUe/7nGnuBg==",
+			"version": "12.0.0",
+			"resolved": "https://registry.npmjs.org/stylelint-config-recommended-scss/-/stylelint-config-recommended-scss-12.0.0.tgz",
+			"integrity": "sha512-5Bb2mlGy6WLa30oNeKpZvavv2lowJUsUJO25+OA68GFTemlwd1zbFsL7q0bReKipOSU3sG47hKneZ6Nd+ctrFA==",
 			"dev": true,
 			"requires": {
-				"postcss-scss": "^4.0.2",
-				"stylelint-config-recommended": "^6.0.0",
-				"stylelint-scss": "^4.0.0"
-			},
-			"dependencies": {
-				"postcss-scss": {
-					"version": "4.0.3",
-					"resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-4.0.3.tgz",
-					"integrity": "sha512-j4KxzWovfdHsyxwl1BxkUal/O4uirvHgdzMKS1aWJBAV0qh2qj5qAZqpeBfVUYGWv+4iK9Az7SPyZ4fyNju1uA==",
-					"dev": true
-				}
+				"postcss-scss": "^4.0.6",
+				"stylelint-config-recommended": "^12.0.0",
+				"stylelint-scss": "^5.0.0"
 			}
 		},
 		"stylelint-scss": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/stylelint-scss/-/stylelint-scss-4.1.0.tgz",
-			"integrity": "sha512-BNYTo7MMamhFOlcaAWp2dMpjg6hPyM/FFqfDIYzmYVLMmQJqc8lWRIiTqP4UX5bresj9Vo0dKC6odSh43VP2NA==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/stylelint-scss/-/stylelint-scss-5.0.0.tgz",
+			"integrity": "sha512-5Ee5kG3JIcP2jk2PMoFMiNmW/815V+wK5o37X5ke90ihWMpPXI9iyqeA6zEWipWSRXeQc0kqbd7hKqiR+wPKNA==",
 			"dev": true,
 			"requires": {
-				"lodash": "^4.17.21",
 				"postcss-media-query-parser": "^0.2.3",
 				"postcss-resolve-nested-selector": "^0.1.1",
-				"postcss-selector-parser": "^6.0.6",
-				"postcss-value-parser": "^4.1.0"
+				"postcss-selector-parser": "^6.0.11",
+				"postcss-value-parser": "^4.2.0"
 			},
 			"dependencies": {
 				"postcss-selector-parser": {
-					"version": "6.0.8",
-					"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.8.tgz",
-					"integrity": "sha512-D5PG53d209Z1Uhcc0qAZ5U3t5HagH3cxu+WLZ22jt3gLUpXM4eXXfiO14jiDWST3NNooX/E8wISfOhZ9eIjGTQ==",
+					"version": "6.0.13",
+					"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.13.tgz",
+					"integrity": "sha512-EaV1Gl4mUEV4ddhDnv/xtj7sxwrwxdetHdWUGnT4VJQf+4d05v6lHYZr8N573k5Z0BViss7BDhfWtKS3+sfAqQ==",
 					"dev": true,
 					"requires": {
 						"cssesc": "^3.0.0",

--- a/packages/components/src/resizable-box/style.scss
+++ b/packages/components/src/resizable-box/style.scss
@@ -152,18 +152,18 @@ See https://bugs.webkit.org/show_bug.cgi?id=187903. */
 
 /*!rtl:begin:ignore*/
 .components-resizable-box__handle-right {
-	right: calc(#{$resize-handler-container-size * 0.5} * -1);
+	right: calc(#{ $resize-handler-container-size * 0.5 } * -1);
 }
 
 .components-resizable-box__handle-left {
-	left: calc(#{$resize-handler-container-size * 0.5} * -1);
+	left: calc(#{ $resize-handler-container-size * 0.5 } * -1);
 }
 
 .components-resizable-box__handle-top {
-	top: calc(#{$resize-handler-container-size * 0.5} * -1);
+	top: calc(#{ $resize-handler-container-size * 0.5 } * -1);
 }
 
 .components-resizable-box__handle-bottom {
-	bottom: calc(#{$resize-handler-container-size * 0.5} * -1);
+	bottom: calc(#{ $resize-handler-container-size * 0.5 } * -1);
 }
 /*!rtl:end:ignore*/

--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+-   Increased minimum dependency of `stylelint` to `14.16.1`.
+
 ### Enhancements
 
 -   The bundled `terser-webpack-plugin` dependency has been updated from requiring `^5.1.4` to requiring `^5.3.9` ([#50994](https://github.com/WordPress/gutenberg/pull/50994)).

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -81,7 +81,7 @@
 		"sass": "^1.35.2",
 		"sass-loader": "^12.1.0",
 		"source-map-loader": "^3.0.0",
-		"stylelint": "^14.2.0",
+		"stylelint": "14.16.1",
 		"terser-webpack-plugin": "^5.3.9",
 		"url-loader": "^4.1.1",
 		"webpack": "^5.47.1",

--- a/packages/stylelint-config/CHANGELOG.md
+++ b/packages/stylelint-config/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Unreleased
 
 -   Increased minimum peer dependency of `stylelint` to `14.16.1`.
+-   Updated: `stylelint-config-recommended` to 9.0.0.
+-   Updated: `stylelint-config-recommended-scss` to 8.0.0.
 
 ## 21.17.0 (2023-05-24)
 

--- a/packages/stylelint-config/CHANGELOG.md
+++ b/packages/stylelint-config/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+-   Increased minimum peer dependency of `stylelint` to `14.16.1`.
+
 ## 21.17.0 (2023-05-24)
 
 ## 21.16.0 (2023-05-10)

--- a/packages/stylelint-config/package.json
+++ b/packages/stylelint-config/package.json
@@ -31,7 +31,7 @@
 	],
 	"main": "index.js",
 	"dependencies": {
-		"stylelint-config-recommended": "^12.0.0",
+		"stylelint-config-recommended": "9",
 		"stylelint-config-recommended-scss": "8"
 	},
 	"peerDependencies": {

--- a/packages/stylelint-config/package.json
+++ b/packages/stylelint-config/package.json
@@ -32,7 +32,7 @@
 	"main": "index.js",
 	"dependencies": {
 		"stylelint-config-recommended": "^12.0.0",
-		"stylelint-config-recommended-scss": "^12.0.0"
+		"stylelint-config-recommended-scss": "8"
 	},
 	"peerDependencies": {
 		"stylelint": "^14.16.1"

--- a/packages/stylelint-config/package.json
+++ b/packages/stylelint-config/package.json
@@ -35,7 +35,7 @@
 		"stylelint-config-recommended-scss": "^12.0.0"
 	},
 	"peerDependencies": {
-		"stylelint": "^14.2"
+		"stylelint": "^14.16.1"
 	},
 	"npmpackagejsonlint": {
 		"extends": "@wordpress/npm-package-json-lint-config",

--- a/packages/stylelint-config/package.json
+++ b/packages/stylelint-config/package.json
@@ -31,8 +31,8 @@
 	],
 	"main": "index.js",
 	"dependencies": {
-		"stylelint-config-recommended": "^6.0.0",
-		"stylelint-config-recommended-scss": "^5.0.2"
+		"stylelint-config-recommended": "^12.0.0",
+		"stylelint-config-recommended-scss": "^12.0.0"
 	},
 	"peerDependencies": {
 		"stylelint": "^14.2"

--- a/packages/stylelint-config/test/__snapshots__/scss.js.snap
+++ b/packages/stylelint-config/test/__snapshots__/scss.js.snap
@@ -4,6 +4,8 @@ exports[`flags warnings with invalid scss snapshot matches warnings 1`] = `
 [
   {
     "column": 1,
+    "endColumn": 2,
+    "endLine": 16,
     "line": 14,
     "rule": "scss/at-else-empty-line-before",
     "severity": "error",
@@ -11,6 +13,8 @@ exports[`flags warnings with invalid scss snapshot matches warnings 1`] = `
   },
   {
     "column": 2,
+    "endColumn": 3,
+    "endLine": 12,
     "line": 12,
     "rule": "scss/at-if-closing-brace-newline-after",
     "severity": "error",
@@ -18,6 +22,8 @@ exports[`flags warnings with invalid scss snapshot matches warnings 1`] = `
   },
   {
     "column": 2,
+    "endColumn": 3,
+    "endLine": 12,
     "line": 12,
     "rule": "scss/at-if-closing-brace-space-after",
     "severity": "error",
@@ -25,6 +31,8 @@ exports[`flags warnings with invalid scss snapshot matches warnings 1`] = `
   },
   {
     "column": 1,
+    "endColumn": 9,
+    "endLine": 1,
     "line": 1,
     "rule": "scss/at-rule-no-unknown",
     "severity": "error",
@@ -32,6 +40,8 @@ exports[`flags warnings with invalid scss snapshot matches warnings 1`] = `
   },
   {
     "column": 2,
+    "endColumn": 15,
+    "endLine": 22,
     "line": 22,
     "rule": "at-rule-empty-line-before",
     "severity": "error",
@@ -39,6 +49,8 @@ exports[`flags warnings with invalid scss snapshot matches warnings 1`] = `
   },
   {
     "column": 5,
+    "endColumn": 6,
+    "endLine": 14,
     "line": 14,
     "rule": "block-opening-brace-space-before",
     "severity": "error",
@@ -46,6 +58,8 @@ exports[`flags warnings with invalid scss snapshot matches warnings 1`] = `
   },
   {
     "column": 15,
+    "endColumn": 16,
+    "endLine": 28,
     "line": 28,
     "rule": "no-extra-semicolons",
     "severity": "error",
@@ -53,6 +67,8 @@ exports[`flags warnings with invalid scss snapshot matches warnings 1`] = `
   },
   {
     "column": 7,
+    "endColumn": 8,
+    "endLine": 31,
     "line": 31,
     "rule": "number-leading-zero",
     "severity": "error",

--- a/packages/stylelint-config/test/__snapshots__/selectors-scss.js.snap
+++ b/packages/stylelint-config/test/__snapshots__/selectors-scss.js.snap
@@ -4,6 +4,8 @@ exports[`flags warnings with invalid selectors scss snapshot matches warnings 1`
 [
   {
     "column": 2,
+    "endColumn": 3,
+    "endLine": 5,
     "line": 3,
     "rule": "scss/selector-no-redundant-nesting-selector",
     "severity": "error",
@@ -11,6 +13,8 @@ exports[`flags warnings with invalid selectors scss snapshot matches warnings 1`
   },
   {
     "column": 2,
+    "endColumn": 3,
+    "endLine": 12,
     "line": 10,
     "rule": "scss/selector-no-redundant-nesting-selector",
     "severity": "error",
@@ -18,6 +22,8 @@ exports[`flags warnings with invalid selectors scss snapshot matches warnings 1`
   },
   {
     "column": 2,
+    "endColumn": 3,
+    "endLine": 19,
     "line": 17,
     "rule": "scss/selector-no-redundant-nesting-selector",
     "severity": "error",
@@ -25,6 +31,8 @@ exports[`flags warnings with invalid selectors scss snapshot matches warnings 1`
   },
   {
     "column": 2,
+    "endColumn": 3,
+    "endLine": 26,
     "line": 24,
     "rule": "scss/selector-no-redundant-nesting-selector",
     "severity": "error",
@@ -32,6 +40,8 @@ exports[`flags warnings with invalid selectors scss snapshot matches warnings 1`
   },
   {
     "column": 2,
+    "endColumn": 3,
+    "endLine": 33,
     "line": 31,
     "rule": "scss/selector-no-redundant-nesting-selector",
     "severity": "error",
@@ -39,6 +49,8 @@ exports[`flags warnings with invalid selectors scss snapshot matches warnings 1`
   },
   {
     "column": 10,
+    "endColumn": 11,
+    "endLine": 31,
     "line": 31,
     "rule": "selector-pseudo-element-colon-notation",
     "severity": "error",


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Bumps `stylelint` from v14.2 to v14.16.1
- https://github.com/stylelint/stylelint/releases/tag/14.16.1
- This is the latest in the v14.x branch, before the v15.x rule removals

Bumps `stylelint-config-recommended` from v6.0.0 to v9.0.0
- https://github.com/stylelint/stylelint-config-recommended/releases/tag/9.0.0
- This release is the latest release compatible with Stylelint v14.x

Bumps `stylelint-config-recommended-scss` from v5.0.2 to v8.0.0
- https://github.com/stylelint-scss/stylelint-config-recommended-scss/releases/tag/v8.0.0
- This release is the latest release compatible with Stylelint v14.x

Dependencies changes remove `^` semver caret, because Lerna is not a fan of installing specific versions, it's moot as each of these dependency bumps are the latest andlast releases in each of these _major_ versions of each package


## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

With the Gutenberg project blocked from using Stylelint v15 because of the removal of "stylistic" rules this PR seeks to update Stylelint dependencies to latest compatible with Stylelint v14

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Packages were updated using the guide here: https://github.com/WordPress/gutenberg/blob/trunk/packages/README.md

Each package was first removed from each package from the `dependencies` section of the package `package.json` file

Each package upgrade was then added using Lerna v5.x
- `lerna add stylelint-config-recommended@9 packages/stylelint-config/`
- `lerna add stylelint-config-recommended-scss@8 packages/stylelint-config/`
- `lerna add stylelint@14.16.1 packages/scripts/`


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Checkout the `bump-stylelint-config-recommended-packages` branch
2. Run `npm install`
3. Run `npm run build`
4. Run `npm run lint:css`

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->


## Notes <!-- if applicable -->

See this issue comment in relation to why Stylelint is not being bumped to v15 at this stage https://github.com/WordPress/gutenberg/pull/50336#issuecomment-1554215986
- tl;dr: Stylelint v15 removes "stylistic" rules (formatting) in favour of using Prettier for "formatting" and retaining only "syntax" rules that affect "functionality" rather than "style"

## CI Failures <!-- if applicable -->

- ✅ Getting closer,some deps were not correctly bootstrapped with Lerna, that's fixed
- 🚧 Looking into `TypeError [ERR_INVALID_URL_SCHEME]: The URL must be of scheme file` issue
  - [Stylelint 14.5.1](https://github.com/stylelint/stylelint/issues/5919) Resolved this issue, so it shouldn't be an issue here