### PR TITLE
Hide the save draft button for published posts

### DIFF
--- a/packages/editor/src/components/post-saved-state/index.js
+++ b/packages/editor/src/components/post-saved-state/index.js
@@ -47,8 +47,10 @@ export default function PostSavedState( {
 		isDirty,
 		isNew,
 		isPending,
+		isPublished,
 		isSaveable,
 		isSaving,
+		isScheduled,
 		hasPublishAction,
 	} = useSelect(
 		( select ) => {
@@ -100,6 +102,10 @@ export default function PostSavedState( {
 	// Once the post has been submitted for review this button
 	// is not needed for the contributor role.
 	if ( ! hasPublishAction && isPending ) {
+		return null;
+	}
+
+	if ( isPublished || isScheduled ) {
 		return null;
 	}
 


### PR DESCRIPTION
Related #50217 

## What?
This fixes a small regression introduced in #50217 where a "save draft" button started to appear in the top toolbar of the post editor for published posts.

## How?

The switch to draft button has been removed from the toolbar, but it shouldn't be replaced by the "save draft" button.

## Testing Instructions

1- Publish a post
2- No "save draft" button should appear in the top toolbar of the post editor.
