### PR TITLE
BorderControl: Improve color code readability in aria-label

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancements
+
+-   `BorderControl`: Improve color code readability in aria-label ([#51197](https://github.com/WordPress/gutenberg/pull/51197)).
+
 ### Bug Fix
 
 -   `FocalPointUnitControl`: Add aria-labels ([#50993](https://github.com/WordPress/gutenberg/pull/50993)).

--- a/packages/components/src/border-control/border-control-dropdown/component.tsx
+++ b/packages/components/src/border-control/border-control-dropdown/component.tsx
@@ -29,7 +29,7 @@ import { isMultiplePaletteArray } from '../../color-palette/utils';
 import type { DropdownProps as DropdownComponentProps } from '../../dropdown/types';
 import type { ColorProps, DropdownProps } from '../types';
 
-const getAriaLabelValue = ( colorValue: string ) => {
+const getAriaLabelColorValue = ( colorValue: string ) => {
 	const isHex = colorValue.startsWith( '#' );
 
 	// Leave hex values as-is. Remove the `var()` wrapper from CSS vars.
@@ -76,7 +76,7 @@ const getToggleAriaLabel = (
 ) => {
 	if ( isStyleEnabled ) {
 		if ( colorObject ) {
-			const ariaLabelValue = getAriaLabelValue( colorObject.color );
+			const ariaLabelValue = getAriaLabelColorValue( colorObject.color );
 			return style
 				? sprintf(
 						// translators: %1$s: The name of the color e.g. "vivid red". %2$s: The color's hex code, with added hyphens e.g: "#-f-0-0". %3$s: The current border style selection e.g. "solid".
@@ -94,7 +94,7 @@ const getToggleAriaLabel = (
 		}
 
 		if ( colorValue ) {
-			const ariaLabelValue = getAriaLabelValue( colorValue );
+			const ariaLabelValue = getAriaLabelColorValue( colorValue );
 			return style
 				? sprintf(
 						// translators: %1$s: The color's hex code, with added hyphens e.g: "#-f-0-0". %2$s: The current border style selection e.g. "solid".
@@ -117,7 +117,7 @@ const getToggleAriaLabel = (
 			// translators: %1$s: The name of the color e.g. "vivid red". %2$s: The color's hex code, with added hyphens e.g: "#-f-0-0".
 			'Border color picker. The currently selected color is called "%1$s" and has a value of "%2$s".',
 			colorObject.name,
-			getAriaLabelValue( colorObject.color )
+			getAriaLabelColorValue( colorObject.color )
 		);
 	}
 
@@ -125,7 +125,7 @@ const getToggleAriaLabel = (
 		return sprintf(
 			// translators: %1$s: The color's hex code, with added hyphens e.g: "#-f-0-0".
 			'Border color picker. The currently selected color has a value of "%1$s".',
-			getAriaLabelValue( colorValue )
+			getAriaLabelColorValue( colorValue )
 		);
 	}
 

--- a/packages/components/src/border-control/border-control-dropdown/component.tsx
+++ b/packages/components/src/border-control/border-control-dropdown/component.tsx
@@ -29,6 +29,15 @@ import { isMultiplePaletteArray } from '../../color-palette/utils';
 import type { DropdownProps as DropdownComponentProps } from '../../dropdown/types';
 import type { ColorProps, DropdownProps } from '../types';
 
+const getAriaLabelValue = ( colorValue: string ) => {
+	const isHex = colorValue.startsWith( '#' );
+
+	// Leave hex values as-is. Remove the `var()` wrapper from CSS vars.
+	const displayValue = colorValue.replace( /^var\((.+)\)$/, '$1' );
+
+	return isHex ? displayValue.split( '' ).join( '-' ) : displayValue;
+};
+
 const getColorObject = (
 	colorValue: CSSProperties[ 'borderColor' ],
 	colors: ColorProps[ 'colors' ] | undefined
@@ -67,34 +76,36 @@ const getToggleAriaLabel = (
 ) => {
 	if ( isStyleEnabled ) {
 		if ( colorObject ) {
+			const ariaLabelValue = getAriaLabelValue( colorObject.color );
 			return style
 				? sprintf(
-						// translators: %1$s: The name of the color e.g. "vivid red". %2$s: The color's hex code e.g.: "#f00:". %3$s: The current border style selection e.g. "solid".
+						// translators: %1$s: The name of the color e.g. "vivid red". %2$s: The color's hex code, with added hyphens e.g: "#-f-0-0". %3$s: The current border style selection e.g. "solid".
 						'Border color and style picker. The currently selected color is called "%1$s" and has a value of "%2$s". The currently selected style is "%3$s".',
 						colorObject.name,
-						colorObject.color,
+						ariaLabelValue,
 						style
 				  )
 				: sprintf(
-						// translators: %1$s: The name of the color e.g. "vivid red". %2$s: The color's hex code e.g.: "#f00:".
+						// translators: %1$s: The name of the color e.g. "vivid red". %2$s: The color's hex code, with added hyphens e.g: "#-f-0-0".
 						'Border color and style picker. The currently selected color is called "%1$s" and has a value of "%2$s".',
 						colorObject.name,
-						colorObject.color
+						ariaLabelValue
 				  );
 		}
 
 		if ( colorValue ) {
+			const ariaLabelValue = getAriaLabelValue( colorValue );
 			return style
 				? sprintf(
-						// translators: %1$s: The color's hex code e.g.: "#f00:". %2$s: The current border style selection e.g. "solid".
+						// translators: %1$s: The color's hex code, with added hyphens e.g: "#-f-0-0". %2$s: The current border style selection e.g. "solid".
 						'Border color and style picker. The currently selected color has a value of "%1$s". The currently selected style is "%2$s".',
-						colorValue,
+						ariaLabelValue,
 						style
 				  )
 				: sprintf(
-						// translators: %1$s: The color's hex code e.g.: "#f00:".
+						// translators: %1$s: The color's hex code, with added hyphens e.g: "#-f-0-0".
 						'Border color and style picker. The currently selected color has a value of "%1$s".',
-						colorValue
+						ariaLabelValue
 				  );
 		}
 
@@ -103,18 +114,18 @@ const getToggleAriaLabel = (
 
 	if ( colorObject ) {
 		return sprintf(
-			// translators: %1$s: The name of the color e.g. "vivid red". %2$s: The color's hex code e.g.: "#f00:".
+			// translators: %1$s: The name of the color e.g. "vivid red". %2$s: The color's hex code, with added hyphens e.g: "#-f-0-0".
 			'Border color picker. The currently selected color is called "%1$s" and has a value of "%2$s".',
 			colorObject.name,
-			colorObject.color
+			getAriaLabelValue( colorObject.color )
 		);
 	}
 
 	if ( colorValue ) {
 		return sprintf(
-			// translators: %1$s: The color's hex code e.g.: "#f00:".
+			// translators: %1$s: The color's hex code, with added hyphens e.g: "#-f-0-0".
 			'Border color picker. The currently selected color has a value of "%1$s".',
-			colorValue
+			getAriaLabelValue( colorValue )
 		);
 	}
 

--- a/packages/components/src/border-control/test/index.js
+++ b/packages/components/src/border-control/test/index.js
@@ -215,7 +215,7 @@ describe( 'BorderControl', () => {
 
 				expect(
 					screen.getByLabelText(
-						'Border color and style picker. The currently selected color is called "Blue" and has a value of "#72aee6".'
+						'Border color and style picker. The currently selected color is called "Blue" and has a value of "#-7-2-a-e-e-6".'
 					)
 				).toBeInTheDocument();
 			} );
@@ -226,7 +226,7 @@ describe( 'BorderControl', () => {
 
 				expect(
 					screen.getByLabelText(
-						'Border color and style picker. The currently selected color has a value of "#4b1d80".'
+						'Border color and style picker. The currently selected color has a value of "#-4-b-1-d-8-0".'
 					)
 				).toBeInTheDocument();
 			} );
@@ -239,7 +239,7 @@ describe( 'BorderControl', () => {
 
 				expect(
 					screen.getByLabelText(
-						'Border color and style picker. The currently selected color is called "Blue" and has a value of "#72aee6". The currently selected style is "dotted".'
+						'Border color and style picker. The currently selected color is called "Blue" and has a value of "#-7-2-a-e-e-6". The currently selected style is "dotted".'
 					)
 				).toBeInTheDocument();
 			} );
@@ -252,7 +252,7 @@ describe( 'BorderControl', () => {
 
 				expect(
 					screen.getByLabelText(
-						'Border color and style picker. The currently selected color has a value of "#4b1d80". The currently selected style is "dashed".'
+						'Border color and style picker. The currently selected color has a value of "#-4-b-1-d-8-0". The currently selected style is "dashed".'
 					)
 				).toBeInTheDocument();
 			} );
@@ -280,7 +280,7 @@ describe( 'BorderControl', () => {
 
 				expect(
 					screen.getByLabelText(
-						'Border color picker. The currently selected color is called "Blue" and has a value of "#72aee6".'
+						'Border color picker. The currently selected color is called "Blue" and has a value of "#-7-2-a-e-e-6".'
 					)
 				).toBeInTheDocument();
 			} );
@@ -294,7 +294,7 @@ describe( 'BorderControl', () => {
 
 				expect(
 					screen.getByLabelText(
-						'Border color picker. The currently selected color has a value of "#4b1d80".'
+						'Border color picker. The currently selected color has a value of "#-4-b-1-d-8-0".'
 					)
 				).toBeInTheDocument();
 			} );


### PR DESCRIPTION
Related to: #50450

## What?
This PR makes the following changes to the `BorderControl` component to improve the readability of the aria-label attribute.

- If the color is a HEX color: from `#000000` to `#-0-0-0-0-0-0`
- If the color is a CSS variable: from `var(--custom)` to `--custom`

![aria-label-color](https://github.com/WordPress/gutenberg/assets/54422211/a3a68163-b1da-4a69-8571-d2faa7206a11)

## Why?
I learned that in #50450, where the color name readability was improved, the `aria-label` of the button was updated at the same time. I also learned that the `BorderControl` component has a similar `aria-label`.

I think this component should also have an `aria-label` based on the same rules.

## How?
I used the same logic that is used in #50450 to change from the color value to the value to be displayed.

## Testing Instructions

- Run storybook.
- To test CSS variables as well, you may want to update `colors` in the Controls tab as follows:

```
[
  {
    "name": "Blue 20",
    "color": "#72aee6"
  },
  {
    "name": "Red 40",
    "color": "#e65054"
  },
  {
    "name": "Yellow 10",
    "color": "#f2d675"
  },
  {
    "name": "Custom Variable",
    "color": "var(--custom)"
  }
]
```

- Confirm that the color indicator to the left of the input field outputs an `aria-label` containing the appropriate color code when the color is changed.

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/54422211/f24e999d-7ca2-47e9-ad99-daeb53fcc648

