### PR TITLE
iframe compat layer: clarify how dependencies related to inline styles work

### DIFF
--- a/packages/block-editor/src/components/iframe/use-compatibility-styles.js
+++ b/packages/block-editor/src/components/iframe/use-compatibility-styles.js
@@ -72,23 +72,40 @@ export function useCompatibilityStyles() {
 				if ( matchFromRules( cssRules ) ) {
 					const isInline = ownerNode.tagName === 'STYLE';
 
-					// Add inline styles belonging to the stylesheet.
-					const inlineCssId = ownerNode.id.replace(
-						isInline ? '-inline-css' : '-css',
-						isInline ? '-css' : '-inline-css'
-					);
-					const otherElement = document.getElementById( inlineCssId );
-
-					// If the matched stylesheet is inline, add the main
-					// stylesheet before the inline style element.
-					if ( otherElement && isInline ) {
-						accumulator.push( otherElement.cloneNode( true ) );
+					if ( isInline ) {
+						// If the current target is inline,
+						// it could be a dependency of an existing stylesheet.
+						// Look for that dependency and add it BEFORE the current target.
+						const mainStylesCssId = ownerNode.id.replace(
+							'-inline-css',
+							'-css'
+						);
+						const mainStylesElement =
+							document.getElementById( mainStylesCssId );
+						if ( mainStylesElement ) {
+							accumulator.push(
+								mainStylesElement.cloneNode( true )
+							);
+						}
 					}
 
 					accumulator.push( ownerNode.cloneNode( true ) );
 
-					if ( otherElement && ! isInline ) {
-						accumulator.push( otherElement.cloneNode( true ) );
+					if ( ! isInline ) {
+						// If the current target is not inline,
+						// we still look for inline styles that could be relevant for the current target.
+						// If they exist, add them AFTER the current target.
+						const inlineStylesCssId = ownerNode.id.replace(
+							'-css',
+							'-inline-css'
+						);
+						const inlineStylesElement =
+							document.getElementById( inlineStylesCssId );
+						if ( inlineStylesElement ) {
+							accumulator.push(
+								inlineStylesElement.cloneNode( true )
+							);
+						}
 					}
 				}
 


### PR DESCRIPTION
## What?

Follow-up to https://github.com/WordPress/gutenberg/pull/48286

Code clarity improvement to clarify how the code processes inline styles:

- if the current target is an embedded stylesheet (aka inline styles, as in `my-stylesheet-inline-css`), look for a potential dependency (`my-stylesheet-css`) and add it before it.
- if the current target is a regular stylesheet (as in `my-stylesheet-css`), look for a potential inline styles dependency (`my-stylesheet-inline-css`) and add it after it.

## Why?

To improve readability.

## Testing Instructions

Make sure tests pass.

TwentyTwentyThree (block theme):

- load the post editor and verify it looks as expected
- make some style changes via global styles sidebar in site editor and verify they are reflected in the post editor

TwentyTwentyOne (classic theme):

- load the post editor and verify it looks as expected
- change the background color via "customizer > colors & dark mode > change background" and verify it is reflected in the post editor

