### PR TITLE
Image: Fix design of close button for the lightbox (correct PR)

### DIFF
--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -75,6 +75,12 @@ function render_block_core_image( $attributes, $content ) {
 								'</div>';
 		$body_content = preg_replace( '/<img[^>]+>/', $button, $body_content );
 
+		// Add directive to expand modal image if appropriate.
+		$m = new WP_HTML_Tag_Processor( $content );
+		$m->next_tag( 'img' );
+		$m->set_attribute( 'data-wp-bind--style', 'selectors.core.image.styleWidth' );
+		$modal_content = $m->get_updated_html();
+
 		$background_color  = esc_attr( wp_get_global_styles( array( 'color', 'background' ) ) );
 		$close_button_icon = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="30" height="30" aria-hidden="true" focusable="false"><path d="M13 11.8l6.1-6.3-1-1-6.1 6.2-6.1-6.2-1 1 6.1 6.3-6.5 6.7 1 1 6.5-6.6 6.5 6.6 1-1z"></path></svg>';
 
@@ -97,7 +103,7 @@ function render_block_core_image( $attributes, $content ) {
 					<button type="button" aria-label="$close_button_label" class="close-button" data-wp-on--click="actions.core.image.hideLightbox">
 						$close_button_icon
 					</button>
-					$content
+					$modal_content
 					<div class="scrim" style="background-color: $background_color"></div>
 			</div>
 HTML;

--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -78,7 +78,8 @@ function render_block_core_image( $attributes, $content ) {
 		// Add directive to expand modal image if appropriate.
 		$m = new WP_HTML_Tag_Processor( $content );
 		$m->next_tag( 'img' );
-		$m->set_attribute( 'data-wp-bind--style', 'selectors.core.image.styleWidth' );
+		$m->set_attribute( 'data-wp-context', '{ "core": { "image": { "imageSrc": "' . wp_get_attachment_url($attributes['id']) . '"} } }' );
+		$m->set_attribute( 'data-wp-bind--src', 'selectors.core.image.imageSrc' );
 		$modal_content = $m->get_updated_html();
 
 		$background_color  = esc_attr( wp_get_global_styles( array( 'color', 'background' ) ) );

--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -78,7 +78,7 @@ function render_block_core_image( $attributes, $content ) {
 		// Add directive to expand modal image if appropriate.
 		$m = new WP_HTML_Tag_Processor( $content );
 		$m->next_tag( 'img' );
-		$m->set_attribute( 'data-wp-context', '{ "core": { "image": { "imageSrc": "' . wp_get_attachment_url($attributes['id']) . '"} } }' );
+		$m->set_attribute( 'data-wp-context', '{ "core": { "image": { "imageSrc": "' . wp_get_attachment_url( $attributes['id'] ) . '"} } }' );
 		$m->set_attribute( 'data-wp-bind--src', 'selectors.core.image.imageSrc' );
 		$modal_content = $m->get_updated_html();
 

--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -82,7 +82,7 @@ function render_block_core_image( $attributes, $content ) {
 		$m->set_attribute( 'data-wp-bind--src', 'selectors.core.image.imageSrc' );
 		$modal_content = $m->get_updated_html();
 
-		$background_color   = esc_attr( wp_get_global_styles( array( 'color', 'background' ) ) );
+		$background_color = esc_attr( wp_get_global_styles( array( 'color', 'background' ) ) );
 
 		$close_button_icon  = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="15" height="15" aria-hidden="true" focusable="false"><path d="M13 11.8l6.1-6.3-1-1-6.1 6.2-6.1-6.2-1 1 6.1 6.3-6.5 6.7 1 1 6.5-6.6 6.5 6.6 1-1z"></path></svg>';
 		$close_button_color = esc_attr( wp_get_global_styles( array( 'color', 'text' ) ) );

--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -82,8 +82,10 @@ function render_block_core_image( $attributes, $content ) {
 		$m->set_attribute( 'data-wp-bind--src', 'selectors.core.image.imageSrc' );
 		$modal_content = $m->get_updated_html();
 
-		$background_color  = esc_attr( wp_get_global_styles( array( 'color', 'background' ) ) );
-		$close_button_icon = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="30" height="30" aria-hidden="true" focusable="false"><path d="M13 11.8l6.1-6.3-1-1-6.1 6.2-6.1-6.2-1 1 6.1 6.3-6.5 6.7 1 1 6.5-6.6 6.5 6.6 1-1z"></path></svg>';
+		$background_color   = esc_attr( wp_get_global_styles( array( 'color', 'background' ) ) );
+
+		$close_button_icon  = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="15" height="15" aria-hidden="true" focusable="false"><path d="M13 11.8l6.1-6.3-1-1-6.1 6.2-6.1-6.2-1 1 6.1 6.3-6.5 6.7 1 1 6.5-6.6 6.5 6.6 1-1z"></path></svg>';
+		$close_button_color = esc_attr( wp_get_global_styles( array( 'color', 'text' ) ) );
 
 		$dialog_label       = $alt_attribute ? esc_attr( $alt_attribute ) : esc_attr__( 'Image' );
 		$close_button_label = esc_attr__( 'Close' );
@@ -101,7 +103,7 @@ function render_block_core_image( $attributes, $content ) {
 				data-wp-on--mousewheel="actions.core.image.hideLightbox"
 				data-wp-on--click="actions.core.image.hideLightbox"
 				>
-					<button type="button" aria-label="$close_button_label" class="close-button" data-wp-on--click="actions.core.image.hideLightbox">
+					<button type="button" aria-label="$close_button_label" style="fill: $close_button_color" class="close-button" data-wp-on--click="actions.core.image.hideLightbox">
 						$close_button_icon
 					</button>
 					$modal_content

--- a/packages/block-library/src/image/interactivity.js
+++ b/packages/block-library/src/image/interactivity.js
@@ -91,7 +91,7 @@ store( {
 				},
 				styleWidth: ( { context } ) => {
 					if ( context.core.image.imageRef ) {
-						return context.core.image.imageRef.offsetWidth >=
+						return context.core.image.imageRef.offsetWidth >
 							context.core.image.imageRef.offsetHeight
 							? 'width: 100%;'
 							: 'width: auto;';

--- a/packages/block-library/src/image/interactivity.js
+++ b/packages/block-library/src/image/interactivity.js
@@ -89,13 +89,10 @@ store( {
 				roleAttribute: ( { context } ) => {
 					return context.core.image.lightboxEnabled ? 'dialog' : '';
 				},
-				styleWidth: ( { context } ) => {
-					if ( context.core.image.imageRef ) {
-						return context.core.image.imageRef.offsetWidth >
-							context.core.image.imageRef.offsetHeight
-							? 'width: 100%;'
-							: 'width: auto;';
-					}
+				imageSrc: ( { context } ) => {
+					return context.core.image.initialized
+						? context.core.image.imageSrc
+						: '';
 				},
 			},
 		},

--- a/packages/block-library/src/image/interactivity.js
+++ b/packages/block-library/src/image/interactivity.js
@@ -101,7 +101,6 @@ store( {
 		core: {
 			image: {
 				initLightbox: async ( { context, ref } ) => {
-					context.core.image.imageRef = ref.querySelector( 'img' );
 					if ( context.core.image.lightboxEnabled ) {
 						const focusableElements =
 							ref.querySelectorAll( focusableSelectors );

--- a/packages/block-library/src/image/interactivity.js
+++ b/packages/block-library/src/image/interactivity.js
@@ -89,6 +89,14 @@ store( {
 				roleAttribute: ( { context } ) => {
 					return context.core.image.lightboxEnabled ? 'dialog' : '';
 				},
+				styleWidth: ( { context } ) => {
+					if ( context.core.image.imageRef ) {
+						return context.core.image.imageRef.offsetWidth >=
+							context.core.image.imageRef.offsetHeight
+							? 'width: 100%;'
+							: 'width: auto;';
+					}
+				},
 			},
 		},
 	},
@@ -96,6 +104,7 @@ store( {
 		core: {
 			image: {
 				initLightbox: async ( { context, ref } ) => {
+					context.core.image.imageRef = ref.querySelector( 'img' );
 					if ( context.core.image.lightboxEnabled ) {
 						const focusableElements =
 							ref.querySelectorAll( focusableSelectors );

--- a/packages/block-library/src/image/style.scss
+++ b/packages/block-library/src/image/style.scss
@@ -204,18 +204,16 @@
 		justify-content: center;
 		align-items: center;
 		flex-direction: column;
-		padding: 20px;
 
 		figcaption {
 			margin: 10px 0 0 0;
+			display: none;
 		}
 
 		img {
 			max-width: 100%;
 			max-height: 100%;
 			width: auto;
-			min-height: 0;
-			min-width: 0;
 		}
 	}
 

--- a/packages/block-library/src/image/style.scss
+++ b/packages/block-library/src/image/style.scss
@@ -186,10 +186,10 @@
 	visibility: hidden;
 
 	.close-button {
-		font-size: 40px;
 		position: absolute;
-		top: 20px;
-		right: 20px;
+		top: 12.5px;
+		right: 12.5px;
+		padding: 0;
 		cursor: pointer;
 		z-index: 5000000;
 	}
@@ -204,6 +204,7 @@
 		justify-content: center;
 		align-items: center;
 		flex-direction: column;
+		padding: 30px;
 
 		figcaption {
 			margin: 10px 0 0 0;
@@ -228,7 +229,7 @@
 		position: absolute;
 		z-index: 2000000;
 		background-color: rgb(255, 255, 255);
-		opacity: 0.9;
+		opacity: 0.85;
 	}
 
 	&.initialized {

--- a/packages/block-library/src/image/style.scss
+++ b/packages/block-library/src/image/style.scss
@@ -229,7 +229,7 @@
 		position: absolute;
 		z-index: 2000000;
 		background-color: rgb(255, 255, 255);
-		opacity: 0.85;
+		opacity: 0.9;
 	}
 
 	&.initialized {

--- a/packages/block-library/src/image/style.scss
+++ b/packages/block-library/src/image/style.scss
@@ -195,14 +195,28 @@
 	}
 
 	.wp-block-image {
+		width: 100%;
+		height: 100%;
+		position: absolute;
+		z-index: 3000000;
+		box-sizing: border-box;
 		display: flex;
 		justify-content: center;
 		align-items: center;
-		width: 100%;
-		height: 100%;
-		z-index: 3000000;
-		position: absolute;
 		flex-direction: column;
+		padding: 20px;
+
+		figcaption {
+			margin: 10px 0 0 0;
+		}
+
+		img {
+			max-width: 100%;
+			max-height: 100%;
+			width: auto;
+			min-height: 0;
+			min-width: 0;
+		}
 	}
 
 	button {

--- a/packages/block-library/src/image/style.scss
+++ b/packages/block-library/src/image/style.scss
@@ -207,7 +207,6 @@
 		padding: 30px;
 
 		figcaption {
-			margin: 10px 0 0 0;
 			display: none;
 		}
 

--- a/test/e2e/specs/editor/blocks/image.spec.js
+++ b/test/e2e/specs/editor/blocks/image.spec.js
@@ -840,10 +840,10 @@ test.describe( 'Image - interactivity', () => {
 		const lightbox = page.locator( '.wp-lightbox-overlay' );
 		await expect( lightbox ).toBeHidden();
 
+		await page.getByRole( 'button', { name: 'Enlarge image' } ).click();
+
 		const image = lightbox.locator( 'img' );
 		await expect( image ).toHaveAttribute( 'src', new RegExp( filename ) );
-
-		await page.getByRole( 'button', { name: 'Enlarge image' } ).click();
 
 		await expect( lightbox ).toBeVisible();
 


### PR DESCRIPTION
## What?
This PR changes the design of the close button in the lightbox so that it is easily visible at all times.
Additionally, it ensures the image is contained within the lightbox so that the [close button design](https://github.com/WordPress/gutenberg/issues/51126#issuecomment-1573835454 ) is implemented as closely as possible.

## Why?
Fixes https://github.com/WordPress/gutenberg/issues/51126, wherein the close button was appearing on top of images and was hard to see in cases where the image was dark, and also fixes https://github.com/WordPress/gutenberg/issues/51125, https://github.com/WordPress/gutenberg/issues/51170, and https://github.com/WordPress/gutenberg/issues/51171 as a part of those changes.

## How?
It rebases on top of and replaces https://github.com/WordPress/gutenberg/pull/51164 to make use of those fixes, then uses and sets the close button color to be the theme contrast color, adds padding, and makes the close button smaller.

## Testing Instructions
1. Ensure the Interactivity API and Behaviors UI setting is enabled in Gutenberg > Experiments in the admin.
2. Create a new post and insert a vertically oriented image as well as a horizontally oriented one.
3. Activate the image lightboxes via Advanced > Behaviors > Lightbox in block settings.
4. Publish and view the post.
5. Click on the images; in the lightbox, the close button should be clearly visible and unobscured by the image.
6. Change the theme background color and contrast color. (Note: Manually setting these colors individually will not work, I believe due to https://github.com/WordPress/gutenberg/issues/49712, but you can experiment with changing theme styles.)
7. Test again to ensure that the colors are applied as expected.

## Testing Instructions for Keyboard
- When viewing the post, tab to the image instead and press Enter or Space to open the lightbox.
- See that the close button and focus are visible.