### PR TITLE
Update React docs link for propTypes

### DIFF
--- a/docs/contributors/code/coding-guidelines.md
+++ b/docs/contributors/code/coding-guidelines.md
@@ -771,9 +771,9 @@ Documenting a function component should be treated the same as any other functio
  *
  * @return {?string} Block title.
  */
-````
+```
 
-For class components, there is no recommendation for documenting the props of the component. Gutenberg does not use or endorse the [`propTypes` static class member](https://reactjs.org/docs/typechecking-with-proptypes.html).
+For class components, there is no recommendation for documenting the props of the component. Gutenberg does not use or endorse the [`propTypes` static class member](https://react.dev/reference/react/Component#static-proptypes).
 
 ## PHP
 


### PR DESCRIPTION


<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
The former link now redirects to legacy docs at https://legacy.reactjs.org/docs/typechecking-with-proptypes.html , with a warning link to the current docs at https://react.dev/reference/react/Component#static-proptypes

This updates to the new link

## Why?
Prevent linkrot

## How?
Updates link

## Testing Instructions

1. Verify that the link goes to the correct location
2. Verify that the information on the new page is the same as the old page.

### Testing Instructions for Keyboard

n/a; this is replacing the `href` of a link in docs, not changing any user interaction
