### PR TITLE
[ Latest Posts block] Option to always show the [Read more ...]

### DIFF
--- a/packages/block-library/src/latest-posts/edit.js
+++ b/packages/block-library/src/latest-posts/edit.js
@@ -528,6 +528,7 @@ export default function LatestPostsEdit( { attributes, setAttributes } ) {
 											.split( ' ', excerptLength )
 											.join( ' ' ) }
 										{ /* translators: excerpt truncation character, default …  */ }
+										{ <br></br> }
 										<a
 											href={ post.link }
 											rel="noopener noreferrer"

--- a/packages/block-library/src/latest-posts/edit.js
+++ b/packages/block-library/src/latest-posts/edit.js
@@ -32,7 +32,6 @@ import { pin, list, grid } from '@wordpress/icons';
 import { store as coreStore } from '@wordpress/core-data';
 import { store as noticeStore } from '@wordpress/notices';
 import { useInstanceId } from '@wordpress/compose';
-import { createInterpolateElement } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -470,37 +469,6 @@ export default function LatestPostsEdit( { attributes, setAttributes } ) {
 						/>
 					);
 
-					const needsReadMore =
-						excerptLength < excerpt.trim().split( ' ' ).length &&
-						post.excerpt.raw === '';
-
-					const postExcerpt = needsReadMore ? (
-						<>
-							{ excerpt
-								.trim()
-								.split( ' ', excerptLength )
-								.join( ' ' ) }
-							{ createInterpolateElement(
-								/* translators: excerpt truncation character, default …  */
-								__( ' … <a>Read more</a>' ),
-								{
-									a: (
-										// eslint-disable-next-line jsx-a11y/anchor-has-content
-										<a
-											href={ post.link }
-											rel="noopener noreferrer"
-											onClick={
-												showRedirectionPreventedNotice
-											}
-										/>
-									),
-								}
-							) }
-						</>
-					) : (
-						excerpt
-					);
-
 					return (
 						<li key={ post.id }>
 							{ renderFeaturedImage && (
@@ -555,7 +523,25 @@ export default function LatestPostsEdit( { attributes, setAttributes } ) {
 							{ displayPostContent &&
 								displayPostContentRadio === 'excerpt' && (
 									<div className="wp-block-latest-posts__post-excerpt">
-										{ postExcerpt }
+										{ excerpt
+											.trim()
+											.split( ' ', excerptLength )
+											.join( ' ' ) }
+										{ /* translators: excerpt truncation character, default …  */ }
+										<a
+											href={ post.link }
+											rel="noopener noreferrer"
+											onClick={
+												showRedirectionPreventedNotice
+											}
+											aria-label={ sprintf(
+												/* translators: byline. %s: Read more about current post. */
+												__( 'Read more about %s' ),
+												titleTrimmed
+											) }
+										>
+											{ __( 'Read more' ) }
+										</a>
 									</div>
 								) }
 							{ displayPostContent &&

--- a/packages/block-library/src/latest-posts/index.php
+++ b/packages/block-library/src/latest-posts/index.php
@@ -163,7 +163,7 @@ function render_block_core_latest_posts( $attributes ) {
 				'<a class="wp-block-latest-posts__post-read-more" href="%1$s" aria-label="%2$s">%3$s</a>',
 				esc_url( $post_link ),
 				esc_attr( __( 'Read more about ' . $title ) ),
-+				__( 'Read more' )
+				__( 'Read more' )
 			);
 		}
 

--- a/packages/block-library/src/latest-posts/index.php
+++ b/packages/block-library/src/latest-posts/index.php
@@ -159,6 +159,12 @@ function render_block_core_latest_posts( $attributes ) {
 				'<div class="wp-block-latest-posts__post-excerpt">%1$s</div>',
 				$trimmed_excerpt
 			);
+			$list_items_markup .= sprintf(
+				'<a class="wp-block-latest-posts__post-read-more" href="%1$s" aria-label="%2$s">%3$s</a>',
+				esc_url( $post_link ),
+				esc_attr( __( 'Read more about ' . $title ) ),
++				__( 'Read more' )
+			);
 		}
 
 		if ( isset( $attributes['displayPostContent'] ) && $attributes['displayPostContent']

--- a/packages/dependency-extraction-webpack-plugin/test/__snapshots__/build.js.snap
+++ b/packages/dependency-extraction-webpack-plugin/test/__snapshots__/build.js.snap
@@ -31,12 +31,30 @@ exports[`DependencyExtractionWebpackPlugin Webpack \`combine-assets\` should pro
 ]
 `;
 
+exports[`DependencyExtractionWebpackPlugin Webpack \`dynamic-import\` should produce expected output: Asset file 'assets.php' should match snapshot 1`] = `
+"<?php return array('fileA.js' => array('dependencies' => array('lodash', 'wp-blob'), 'version' => 'cbe985cf6e1a25d848e5'), 'fileB.js' => array('dependencies' => array('wp-token-list'), 'version' => '7f3970305cf0aecb54ab'));
+"
+`;
+
 exports[`DependencyExtractionWebpackPlugin Webpack \`dynamic-import\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
 "<?php return array('dependencies' => array('wp-blob'), 'version' => 'c8be4fceac30d1d00ca7');
 "
 `;
 
 exports[`DependencyExtractionWebpackPlugin Webpack \`dynamic-import\` should produce expected output: External modules should match snapshot 1`] = `
+[
+  {
+    "externalType": "window",
+    "request": [
+      "wp",
+      "blob",
+    ],
+    "userRequest": "@wordpress/blob",
+  },
+]
+`;
+
+exports[`DependencyExtractionWebpackPlugin Webpack \`dynamic-import\` should produce expected output: External modules should match snapshot 2`] = `
 [
   {
     "externalType": "window",
@@ -290,7 +308,30 @@ exports[`DependencyExtractionWebpackPlugin Webpack \`wordpress-require\` should 
 "
 `;
 
+exports[`DependencyExtractionWebpackPlugin Webpack \`wordpress-require\` should produce expected output: Asset file 'main.asset.php' should match snapshot 2`] = `
+"<?php return array('dependencies' => array('lodash', 'wp-blob'), 'version' => '40370eb4ce6428562da6');
+"
+`;
+
 exports[`DependencyExtractionWebpackPlugin Webpack \`wordpress-require\` should produce expected output: External modules should match snapshot 1`] = `
+[
+  {
+    "externalType": "window",
+    "request": "lodash",
+    "userRequest": "lodash",
+  },
+  {
+    "externalType": "window",
+    "request": [
+      "wp",
+      "blob",
+    ],
+    "userRequest": "@wordpress/blob",
+  },
+]
+`;
+
+exports[`DependencyExtractionWebpackPlugin Webpack \`wordpress-require\` should produce expected output: External modules should match snapshot 2`] = `
 [
   {
     "externalType": "window",

--- a/packages/edit-post/src/components/preferences-modal/options/test/__snapshots__/enable-custom-fields.js.snap
+++ b/packages/edit-post/src/components/preferences-modal/options/test/__snapshots__/enable-custom-fields.js.snap
@@ -1,5 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`CustomFieldsConfirmation submits the toggle-custom-fields-form 1`] = `<div />`;
+
+exports[`CustomFieldsConfirmation submits the toggle-custom-fields-form 2`] = `<div />`;
+
 exports[`EnableCustomFieldsOption renders a checked checkbox and a confirmation message when toggled on 1`] = `
 .emotion-0 {
   font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Oxygen-Sans,Ubuntu,Cantarell,'Helvetica Neue',sans-serif;


### PR DESCRIPTION
link #22269

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Added Read More Link in Latest Post Block

## Why?
https://github.com/WordPress/gutenberg/issues/22269

## How?
- Add Read More link in Latest Post Block

## Testing Instructions
- Create Post and Add Excerpt Words 
- Go to Page 
- Select "Latest Post" Block 
- if Post Content option Enable then show Excerpt with Read more link

### Testing Instructions for Keyboard


## Screenshots or screencast <!-- if applicable -->
<img width="530" alt="image" src="https://github.com/WordPress/gutenberg/assets/49809429/0ee63dbb-207a-4ff6-a549-165ee0a06f21">

