### PR TITLE
Avoid changing non-theme-preview requests

### DIFF
--- a/lib/compat/wordpress-6.3/theme-previews.php
+++ b/lib/compat/wordpress-6.3/theme-previews.php
@@ -14,7 +14,7 @@
 function gutenberg_get_theme_preview_path( $current_stylesheet = null ) {
 	// Don't allow non-admins to preview themes.
 	if ( ! current_user_can( 'switch_themes' ) ) {
-		return;
+		return $current_stylesheet;
 	}
 
 	$preview_stylesheet = ! empty( $_GET['theme_preview'] ) ? $_GET['theme_preview'] : null;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This PR prevents [Block Theme Previews](https://github.com/WordPress/gutenberg/pull/50030) from changing non-theme-preview requests. 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The current implementation would empty the original stylesheet when "there is a URL query (`?theme_preview=`) but no theme preview permission" (this behavior was introduced in https://github.com/WordPress/gutenberg/pull/50338). 
This unintentionally breaks functionality other than Block Theme Previews, so it has been modified not to change it except when Block Theme Previews should be applied.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

- Return the original value when Block Theme Previews should not be applied.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

- Open the Site Editor and add the following to your URL: ?theme_preview=[themePath] where themePath is the relative path to the theme you want to preview (e.g. twentytwentythree).

<!--
### Testing Instructions for Keyboard
 How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. 

## Screenshots or screencast 
-->