### PR TITLE
DocumentActions: Animate between page and template mode

### DIFF
--- a/packages/edit-site/src/components/header-edit-mode/document-actions/index.js
+++ b/packages/edit-site/src/components/header-edit-mode/document-actions/index.js
@@ -85,10 +85,7 @@ function PageDocumentActions() {
 	) : (
 		<TemplateDocumentActions
 			className="is-animated"
-			onBack={ () => {
-				setHasEditedTemplate( true );
-				setHasPageContentLock( true );
-			} }
+			onBack={ () => setHasPageContentLock( true ) }
 		/>
 	);
 }

--- a/packages/edit-site/src/components/header-edit-mode/document-actions/index.js
+++ b/packages/edit-site/src/components/header-edit-mode/document-actions/index.js
@@ -22,6 +22,7 @@ import {
 } from '@wordpress/icons';
 import { useEntityRecord } from '@wordpress/core-data';
 import { displayShortcut } from '@wordpress/keycodes';
+import { useState, useEffect, useRef } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -51,6 +52,15 @@ function PageDocumentActions() {
 
 	const { setHasPageContentLock } = useDispatch( editSiteStore );
 
+	const [ hasEditedTemplate, setHasEditedTemplate ] = useState( false );
+	const prevHasPageContentLock = useRef( false );
+	useEffect( () => {
+		if ( prevHasPageContentLock.current && ! hasPageContentLock ) {
+			setHasEditedTemplate( true );
+		}
+		prevHasPageContentLock.current = hasPageContentLock;
+	}, [ hasPageContentLock ] );
+
 	if ( ! hasResolved ) {
 		return null;
 	}
@@ -64,17 +74,26 @@ function PageDocumentActions() {
 	}
 
 	return hasPageContentLock ? (
-		<BaseDocumentActions isPage icon={ pageIcon }>
+		<BaseDocumentActions
+			className={ classnames( 'is-page', {
+				'is-animated': hasEditedTemplate,
+			} ) }
+			icon={ pageIcon }
+		>
 			{ editedRecord.title }
 		</BaseDocumentActions>
 	) : (
 		<TemplateDocumentActions
-			onBack={ () => setHasPageContentLock( true ) }
+			className="is-animated"
+			onBack={ () => {
+				setHasEditedTemplate( true );
+				setHasPageContentLock( true );
+			} }
 		/>
 	);
 }
 
-function TemplateDocumentActions( { onBack } ) {
+function TemplateDocumentActions( { className, onBack } ) {
 	const { isLoaded, record, getTitle, icon } = useEditedEntityRecord();
 
 	if ( ! isLoaded ) {
@@ -95,7 +114,11 @@ function TemplateDocumentActions( { onBack } ) {
 			: __( 'template' );
 
 	return (
-		<BaseDocumentActions icon={ icon } onBack={ onBack }>
+		<BaseDocumentActions
+			className={ className }
+			icon={ icon }
+			onBack={ onBack }
+		>
 			<VisuallyHidden as="span">
 				{ sprintf(
 					/* translators: %s: the entity being edited, like "template"*/
@@ -108,10 +131,12 @@ function TemplateDocumentActions( { onBack } ) {
 	);
 }
 
-function BaseDocumentActions( { icon, children, onBack, isPage = false } ) {
+function BaseDocumentActions( { className, icon, children, onBack } ) {
 	const { open: openCommandCenter } = useDispatch( commandsStore );
 	return (
-		<div className="edit-site-document-actions">
+		<div
+			className={ classnames( 'edit-site-document-actions', className ) }
+		>
 			{ onBack && (
 				<Button
 					className="edit-site-document-actions__back"
@@ -129,14 +154,9 @@ function BaseDocumentActions( { icon, children, onBack, isPage = false } ) {
 				onClick={ () => openCommandCenter() }
 			>
 				<HStack
+					className="edit-site-document-actions__title"
 					spacing={ 1 }
 					justify="center"
-					className={ classnames(
-						'edit-site-document-actions__title',
-						{
-							'is-page': isPage,
-						}
-					) }
 				>
 					<BlockIcon icon={ icon } />
 					<Text size="body" as="h1">

--- a/packages/edit-site/src/components/header-edit-mode/document-actions/style.scss
+++ b/packages/edit-site/src/components/header-edit-mode/document-actions/style.scss
@@ -10,6 +10,7 @@
 	background: $gray-100;
 	border-radius: 4px;
 	width: min(100%, 450px);
+	overflow: hidden;
 
 	&:hover {
 		color: currentColor;
@@ -30,12 +31,6 @@
 	color: var(--wp-block-synced-color);
 	overflow: hidden;
 	grid-column: 2 / 3;
-	&.is-page {
-		color: $gray-800;
-		h1 {
-			color: $gray-800;
-		}
-	}
 
 	h1 {
 		white-space: nowrap;
@@ -43,11 +38,30 @@
 		text-overflow: ellipsis;
 		color: var(--wp-block-synced-color);
 	}
+
+	.edit-site-document-actions.is-page & {
+		color: $gray-800;
+
+		h1 {
+			color: $gray-800;
+		}
+	}
+
+	.edit-site-document-actions.is-animated & {
+		animation: edit-site-document-actions__slide-in-left 0.2s;
+		@include reduce-motion("animation");
+	}
+
+	.edit-site-document-actions.is-animated.is-page & {
+		animation: edit-site-document-actions__slide-in-right 0.2s;
+		@include reduce-motion("animation");
+	}
 }
 
 .edit-site-document-actions__shortcut {
 	color: $gray-700;
 	text-align: right;
+
 	&:hover {
 		color: $gray-700;
 	}
@@ -59,4 +73,31 @@
 	grid-column: 1 / 2;
 	grid-row: 1;
 	z-index: 1;
+
+	.edit-site-document-actions.is-animated & {
+		animation: edit-site-document-actions__slide-in-left 0.2s;
+		@include reduce-motion("animation");
+	}
+}
+
+@keyframes edit-site-document-actions__slide-in-right {
+	from {
+		transform: translateX(-40%);
+		opacity: 0;
+	}
+	to {
+		transform: translateX(0);
+		opacity: 1;
+	}
+}
+
+@keyframes edit-site-document-actions__slide-in-left {
+	from {
+		transform: translateX(40%);
+		opacity: 0;
+	}
+	to {
+		transform: translateX(0);
+		opacity: 1;
+	}
 }

--- a/packages/edit-site/src/components/header-edit-mode/document-actions/style.scss
+++ b/packages/edit-site/src/components/header-edit-mode/document-actions/style.scss
@@ -48,12 +48,12 @@
 	}
 
 	.edit-site-document-actions.is-animated & {
-		animation: edit-site-document-actions__slide-in-left 0.2s;
+		animation: edit-site-document-actions__slide-in-left 0.3s;
 		@include reduce-motion("animation");
 	}
 
 	.edit-site-document-actions.is-animated.is-page & {
-		animation: edit-site-document-actions__slide-in-right 0.2s;
+		animation: edit-site-document-actions__slide-in-right 0.3s;
 		@include reduce-motion("animation");
 	}
 }
@@ -75,14 +75,14 @@
 	z-index: 1;
 
 	.edit-site-document-actions.is-animated & {
-		animation: edit-site-document-actions__slide-in-left 0.2s;
+		animation: edit-site-document-actions__slide-in-left 0.3s;
 		@include reduce-motion("animation");
 	}
 }
 
 @keyframes edit-site-document-actions__slide-in-right {
 	from {
-		transform: translateX(-40%);
+		transform: translateX(-15%);
 		opacity: 0;
 	}
 	to {
@@ -93,7 +93,7 @@
 
 @keyframes edit-site-document-actions__slide-in-left {
 	from {
-		transform: translateX(40%);
+		transform: translateX(15%);
 		opacity: 0;
 	}
 	to {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Follows https://github.com/WordPress/gutenberg/pull/50857.

Makes the `DocumentActions` control (at the top of the screen) animate between page editing mode and template editing mode.

## Why?
- Helps to draw attention to the _Back_ button which is useful given the _Edit template_ button is so far away.
- Reinforces the visual metaphor of moving backwards and forwards.
- Slidey slidey.

## How?
I just used CSS `@keyframes`. Briefly considered `framer` but it would require refactoring `DocumentActions` a little bit to get the `exit` effect working and also it would be a new dependency in `@wordpress/edit-site`. KISS.

## Testing Instructions
1. Go to Appearance → Editor → Pages and select a page. The document actions at the top of screen should **not** animate.
2. Select _Edit template_ in the sidebar. The document actions at the top of screen should animate.
3. Click _Back_. The document actions at the top of screen should animate.

## Screenshots or screencast 

https://github.com/WordPress/gutenberg/assets/612155/a7fa7a9e-463b-4056-bb6c-f3318750ccbc


