### PR TITLE
Social Icons: Manually set Snapchat label color.

### DIFF
--- a/packages/block-library/src/social-links/style.scss
+++ b/packages/block-library/src/social-links/style.scss
@@ -142,3 +142,13 @@
 		padding-right: calc((2/3) * 1em);
 	}
 }
+
+// Ensure the Snapchat label is visible when no custom
+// icon color or background color is set.
+.wp-block-social-links:not(.has-icon-color):not(.has-icon-background-color) {
+	.wp-social-link-snapchat {
+		.wp-block-social-link-label {
+			color: #000;
+		}
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/47392

## What?
This PR manually sets the color of the Snapchat icon label when no custom icon color or background color is set. 

## Why?
Unlike all other icons, the Snapchat icon includes both `stroke` and `color` values because the logo is white on a light yellow background, and the icon needs a black border to show up. Unfortunately, when icon labels are enabled, the font color is white since `color` is set to `#ffffff`. This makes it impossible to read the Snapchat label. 

## How?
This PR manually sets the color value of the label to black when no custom icon or background color is selected. This approach ensures backward compatibility with minimal modification to the way the block is built. Ideally, we should not have an icon with two colors, but there is no getting around this for the Snapchat logo. Therefore, this one-off solution seems the best path forward. 

## Testing Instructions
1. Add a Social Icons block and add a Snapchat icon
2. Enable "Show labels"
3. See that the label is black
4. Change the icon color and see the label color updates according
5. Reset the custom icon color
6. Change the icon background color and see the label color reverts to white

## Screenshots or screencast

| Before  | After |
| -- | -- |
| <img width="1144" alt="image" src="https://github.com/WordPress/gutenberg/assets/4832319/af3e93f2-33a4-4d8c-81ac-fb177d5d9e65"><img width="1145" alt="image" src="https://github.com/WordPress/gutenberg/assets/4832319/70c4ad98-d4f6-447e-8064-7a378761f587">  | <img width="1144" alt="image" src="https://github.com/WordPress/gutenberg/assets/4832319/d29087af-6e8a-4d66-8e80-645ab9c28898"><img width="1145" alt="image" src="https://github.com/WordPress/gutenberg/assets/4832319/f8c33a03-c62c-4f29-a09f-6b6f68425499">  |
