### PR TITLE
Image Lightbox: Add a reset button.

### DIFF
--- a/packages/block-editor/src/hooks/behaviors.js
+++ b/packages/block-editor/src/hooks/behaviors.js
@@ -2,7 +2,11 @@
  * WordPress dependencies
  */
 import { addFilter } from '@wordpress/hooks';
-import { SelectControl } from '@wordpress/components';
+import {
+	SelectControl,
+	Button,
+	__experimentalHStack as HStack,
+} from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { createHigherOrderComponent } from '@wordpress/compose';
 import { useSelect } from '@wordpress/data';
@@ -10,8 +14,8 @@ import { useSelect } from '@wordpress/data';
 /**
  * Internal dependencies
  */
-import { InspectorControls } from '../components';
 import { store as blockEditorStore } from '../store';
+import { InspectorControls } from '../components';
 
 /**
  * External dependencies
@@ -72,18 +76,29 @@ function BehaviorsControl( {
 
 	return (
 		<InspectorControls group="advanced">
-			<SelectControl
-				__nextHasNoMarginBottom
-				label={ __( 'Behaviors' ) }
-				// At the moment we are only supporting one behavior (Lightbox)
-				value={ behaviors?.lightbox ? 'lightbox' : '' }
-				options={ options }
-				onChange={ onChange }
-				hideCancelButton={ true }
-				help={ helpText }
-				size="__unstable-large"
-				disabled={ disabled }
-			/>
+			{ /* This div is needed to prevent a margin bottom between the dropdown and the button. */ }
+			<div>
+				<SelectControl
+					label={ __( 'Behaviors' ) }
+					// At the moment we are only supporting one behavior (Lightbox)
+					value={ behaviors?.lightbox ? 'lightbox' : '' }
+					options={ options }
+					onChange={ onChange }
+					hideCancelButton={ true }
+					help={ helpText }
+					size="__unstable-large"
+					disabled={ disabled }
+				/>
+			</div>
+			<HStack justify="flex-end">
+				<Button
+					isSmall
+					disabled={ disabled }
+					onClick={ () => onChange( undefined ) }
+				>
+					{ __( 'Reset' ) }
+				</Button>
+			</HStack>
 		</InspectorControls>
 	);
 }
@@ -115,13 +130,19 @@ export const withBehaviors = createHigherOrderComponent( ( BlockEdit ) => {
 					blockName={ props.name }
 					blockBehaviors={ props.attributes.behaviors }
 					onChange={ ( nextValue ) => {
-						// If the user selects something, it means that they want to
-						// change the default value (true) so we save it in the attributes.
-						props.setAttributes( {
-							behaviors: {
-								lightbox: nextValue === 'lightbox',
-							},
-						} );
+						if ( nextValue === undefined ) {
+							props.setAttributes( {
+								behaviors: undefined,
+							} );
+						} else {
+							// If the user selects something, it means that they want to
+							// change the default value (true) so we save it in the attributes.
+							props.setAttributes( {
+								behaviors: {
+									lightbox: nextValue === 'lightbox',
+								},
+							} );
+						}
 					} }
 					disabled={ blockHasLink }
 				/>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Add a `reset` button to the behaviors that removes the attribute from the block code. The behavior applied in this case would be the default one set in the `theme.json` file.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Right now, if the user chooses a behavior, it will stay in the block markup forever, being true or false. This way the user can remove it and the default will be applied.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Adding a reset a button.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
1) Add the behavior to your theme.json. Set it as true or false.
2) Add a post/page with an image. Enable/disable the lightbox, check that the attribute is added to the markup, on the code editor.
3) Click on reset, check that the attribute is removed from the block markup, on the code editor.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/37012961/137099a2-a354-4378-b988-82fc78dfed83

_The e2e tests will come in a new PR if this one gets merged before I finish them._: Added