### PR TITLE
DimensionsPanel: Fix site editor error on Columns block level screen

### DIFF
--- a/packages/block-editor/src/components/global-styles/dimensions-panel.js
+++ b/packages/block-editor/src/components/global-styles/dimensions-panel.js
@@ -208,7 +208,7 @@ export default function DimensionsPanel( {
 	includeLayoutControls = false,
 } ) {
 	const decodeValue = ( rawValue ) => {
-		if ( typeof rawValue === 'object' ) {
+		if ( rawValue && typeof rawValue === 'object' ) {
 			return Object.keys( rawValue ).reduce( ( acc, key ) => {
 				acc[ key ] = getValueFromVariable(
 					{ settings },


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Related to: https://github.com/WordPress/gutenberg/pull/50956

Fixes a site editor error when accessing the Columns block level screen, by ensuring that `rawValue` is truthy before attempting to access its keys.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Sometimes values can be `null` and unfortunately `typeof null` in JavaScript equals `object`, so a `null` value in `decodeValues` can be passed to `Object.keys()` which throws an error.

I believe the value that was null in this case is `blockGap`. Further down in the function it looks like `setGapValues` will set gap values to `null`.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* Add a truthy check for `rawValue` before passing to `Object.keys`

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Before applying this PR, see if you can reproduce the issue — open up the site editor, and navigate to the block level styles for Columns block. In my environment this throws an error. If it doesn't throw an error for you (you might already have a block spacing value set) then attempt to reset the block spacing value, and it should throw an error.
2. With this PR applied, attempt to navigate to the Columns block in global styles, and adjust some styling rules (e.g. horizontal block spacing) and save. It should work as expected.

## Screenshots or screencast <!-- if applicable -->

Before this PR:

![2023-06-06 12 50 37](https://github.com/WordPress/gutenberg/assets/14988353/fac67ef0-27b5-48d4-8135-976ac90af037)

