### PR TITLE
Update: Adjust modal radius to be between frame and buttons.

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -27,6 +27,7 @@
 -   `ColorPalette`: Improve readability of color name and value, and improve rendering of partially transparent colors ([#50450](https://github.com/WordPress/gutenberg/pull/50450)).
 -   `Button`: Add `__next32pxSmallSize` prop to opt into the new 32px size when the `isSmall` prop is enabled ([#51012](https://github.com/WordPress/gutenberg/pull/51012)).
 -   `ItemGroup`: Update styles so all SVGs inherit color from their parent element ([#50819](https://github.com/WordPress/gutenberg/pull/50819)).
+-   `Modal`: Update corner radius to be between buttons and the site view frame, in a 2-4-8 system. ([#51254](https://github.com/WordPress/gutenberg/pull/51254)).
 
 ### Experimental
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancements
+
+-   `Modal`: Update corner radius to be between buttons and the site view frame, in a 2-4-8 system. ([#51254](https://github.com/WordPress/gutenberg/pull/51254)).
+
 ### Bug Fix
 
 -   `Popover`: Allow legitimate 0 positions to update popover position ([#51320](https://github.com/WordPress/gutenberg/pull/51320)).
@@ -27,7 +31,6 @@
 -   `ColorPalette`: Improve readability of color name and value, and improve rendering of partially transparent colors ([#50450](https://github.com/WordPress/gutenberg/pull/50450)).
 -   `Button`: Add `__next32pxSmallSize` prop to opt into the new 32px size when the `isSmall` prop is enabled ([#51012](https://github.com/WordPress/gutenberg/pull/51012)).
 -   `ItemGroup`: Update styles so all SVGs inherit color from their parent element ([#50819](https://github.com/WordPress/gutenberg/pull/50819)).
--   `Modal`: Update corner radius to be between buttons and the site view frame, in a 2-4-8 system. ([#51254](https://github.com/WordPress/gutenberg/pull/51254)).
 
 ### Experimental
 

--- a/packages/components/src/modal/style.scss
+++ b/packages/components/src/modal/style.scss
@@ -20,7 +20,7 @@
 	width: 100%;
 	background: $white;
 	box-shadow: $shadow-modal;
-	border-radius: $grid-unit-10 $grid-unit-10 0 0;
+	border-radius: $grid-unit-05 $grid-unit-05 0 0;
 	overflow: hidden;
 	// Have the content element fill the vertical space yet not overflow.
 	display: flex;
@@ -31,7 +31,7 @@
 
 	// Show a centered modal on bigger screens.
 	@include break-small() {
-		border-radius: $grid-unit-10;
+		border-radius: $grid-unit-05;
 		margin: auto;
 		width: auto;
 		min-width: $modal-min-width;


### PR DESCRIPTION
## What?

Recently, the radius of all modals was changed from 2px to 8px. 2px for buttons, 8 for the larger frame.

This PR adjusts the radius of modals to 4px, which is between the two.

<img width="1392" alt="4px" src="https://github.com/WordPress/gutenberg/assets/1204802/60fecb95-93f1-4a0b-bc2f-38db57b48350">

## Why?

This harmonizes better with the 2px buttons that often sit inside confirm dialogs. 

<img width="282" alt="Screenshot 2023-06-06 at 08 51 45" src="https://github.com/WordPress/gutenberg/assets/1204802/737cd1d7-9ea7-4340-89fa-aab181ad6eac">

## Testing Instructions

Test modals, such as ellipsis > keyboard shortcuts. Observe the smaller radius.