### PR TITLE
Block Controls SlotFill: refactor to allow passing multiple contexts, including internal components context

### DIFF
--- a/packages/block-editor/src/components/block-controls/fill.js
+++ b/packages/block-editor/src/components/block-controls/fill.js
@@ -39,8 +39,8 @@ export default function BlockControlsFill( {
 					// `fillProps` is an array of context provider entries, provided by slot,
 					// that should wrap the fill markup.
 					return fillProps.reduce(
-						( inner, [ Provider, value ] ) => (
-							<Provider value={ value }>{ inner }</Provider>
+						( inner, [ Provider, props ] ) => (
+							<Provider { ...props }>{ inner }</Provider>
 						),
 						innerMarkup
 					);

--- a/packages/block-editor/src/components/block-controls/fill.js
+++ b/packages/block-editor/src/components/block-controls/fill.js
@@ -3,7 +3,6 @@
  */
 import {
 	__experimentalStyleProvider as StyleProvider,
-	__experimentalToolbarContext as ToolbarContext,
 	ToolbarGroup,
 } from '@wordpress/components';
 
@@ -26,24 +25,24 @@ export default function BlockControlsFill( {
 		return null;
 	}
 
+	const innerMarkup = (
+		<>
+			{ group === 'default' && <ToolbarGroup controls={ controls } /> }
+			{ children }
+		</>
+	);
+
 	return (
 		<StyleProvider document={ document }>
 			<Fill>
-				{ ( fillProps ) => {
-					// Children passed to BlockControlsFill will not have access to any
-					// React Context whose Provider is part of the BlockControlsSlot tree.
-					// So we re-create the Provider in this subtree.
-					const value =
-						fillProps && Object.keys( fillProps ).length > 0
-							? fillProps
-							: null;
-					return (
-						<ToolbarContext.Provider value={ value }>
-							{ group === 'default' && (
-								<ToolbarGroup controls={ controls } />
-							) }
-							{ children }
-						</ToolbarContext.Provider>
+				{ ( fillProps = [] ) => {
+					// `fillProps` is an array of context provider entries, provided by slot,
+					// that should wrap the fill markup.
+					return fillProps.reduce(
+						( inner, [ Provider, value ] ) => (
+							<Provider value={ value }>{ inner }</Provider>
+						),
+						innerMarkup
 					);
 				} }
 			</Fill>

--- a/packages/block-editor/src/components/block-controls/fill.js
+++ b/packages/block-editor/src/components/block-controls/fill.js
@@ -35,10 +35,11 @@ export default function BlockControlsFill( {
 	return (
 		<StyleProvider document={ document }>
 			<Fill>
-				{ ( fillProps = [] ) => {
-					// `fillProps` is an array of context provider entries, provided by slot,
+				{ ( fillProps ) => {
+					// `fillProps.forwardedContext` is an array of context provider entries, provided by slot,
 					// that should wrap the fill markup.
-					return fillProps.reduce(
+					const { forwardedContext = [] } = fillProps;
+					return forwardedContext.reduce(
 						( inner, [ Provider, props ] ) => (
 							<Provider { ...props }>{ inner }</Provider>
 						),

--- a/packages/block-editor/src/components/block-controls/slot.js
+++ b/packages/block-editor/src/components/block-controls/slot.js
@@ -3,7 +3,7 @@
  */
 import { useContext, useMemo } from '@wordpress/element';
 import {
-	__experimentalComponentsContext as ComponentsContext,
+	privateApis,
 	__experimentalToolbarContext as ToolbarContext,
 	ToolbarGroup,
 	__experimentalUseSlotFills as useSlotFills,
@@ -14,6 +14,9 @@ import warning from '@wordpress/warning';
  * Internal dependencies
  */
 import groups from './groups';
+import { unlock } from '../../lock-unlock';
+
+const { ComponentsContext } = unlock( privateApis );
 
 export default function BlockControlsSlot( { group = 'default', ...props } ) {
 	const toolbarState = useContext( ToolbarContext );

--- a/packages/block-editor/src/components/block-controls/slot.js
+++ b/packages/block-editor/src/components/block-controls/slot.js
@@ -1,8 +1,9 @@
 /**
  * WordPress dependencies
  */
-import { useContext } from '@wordpress/element';
+import { useContext, useMemo } from '@wordpress/element';
 import {
+	__experimentalComponentsContext as ComponentsContext,
 	__experimentalToolbarContext as ToolbarContext,
 	ToolbarGroup,
 	__experimentalUseSlotFills as useSlotFills,
@@ -15,7 +16,16 @@ import warning from '@wordpress/warning';
 import groups from './groups';
 
 export default function BlockControlsSlot( { group = 'default', ...props } ) {
-	const accessibleToolbarState = useContext( ToolbarContext );
+	const toolbarState = useContext( ToolbarContext );
+	const contextState = useContext( ComponentsContext );
+	const fillProps = useMemo(
+		() => [
+			[ ToolbarContext.Provider, toolbarState ],
+			[ ComponentsContext.Provider, contextState ],
+		],
+		[ toolbarState, contextState ]
+	);
+
 	const Slot = groups[ group ]?.Slot;
 	const fills = useSlotFills( Slot?.__unstableName );
 	if ( ! Slot ) {
@@ -27,23 +37,11 @@ export default function BlockControlsSlot( { group = 'default', ...props } ) {
 		return null;
 	}
 
+	const slot = <Slot { ...props } bubblesVirtually fillProps={ fillProps } />;
+
 	if ( group === 'default' ) {
-		return (
-			<Slot
-				{ ...props }
-				bubblesVirtually
-				fillProps={ accessibleToolbarState }
-			/>
-		);
+		return slot;
 	}
 
-	return (
-		<ToolbarGroup>
-			<Slot
-				{ ...props }
-				bubblesVirtually
-				fillProps={ accessibleToolbarState }
-			/>
-		</ToolbarGroup>
-	);
+	return <ToolbarGroup>{ slot }</ToolbarGroup>;
 }

--- a/packages/block-editor/src/components/block-controls/slot.js
+++ b/packages/block-editor/src/components/block-controls/slot.js
@@ -23,8 +23,8 @@ export default function BlockControlsSlot( { group = 'default', ...props } ) {
 	const contextState = useContext( ComponentsContext );
 	const fillProps = useMemo(
 		() => [
-			[ ToolbarContext.Provider, toolbarState ],
-			[ ComponentsContext.Provider, contextState ],
+			[ ToolbarContext.Provider, { value: toolbarState } ],
+			[ ComponentsContext.Provider, { value: contextState } ],
 		],
 		[ toolbarState, contextState ]
 	);

--- a/packages/block-editor/src/components/block-controls/slot.js
+++ b/packages/block-editor/src/components/block-controls/slot.js
@@ -22,10 +22,12 @@ export default function BlockControlsSlot( { group = 'default', ...props } ) {
 	const toolbarState = useContext( ToolbarContext );
 	const contextState = useContext( ComponentsContext );
 	const fillProps = useMemo(
-		() => [
-			[ ToolbarContext.Provider, { value: toolbarState } ],
-			[ ComponentsContext.Provider, { value: contextState } ],
-		],
+		() => ( {
+			forwardedContext: [
+				[ ToolbarContext.Provider, { value: toolbarState } ],
+				[ ComponentsContext.Provider, { value: contextState } ],
+			],
+		} ),
 		[ toolbarState, contextState ]
 	);
 

--- a/packages/block-editor/src/components/block-controls/slot.native.js
+++ b/packages/block-editor/src/components/block-controls/slot.native.js
@@ -1,11 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useContext, useMemo } from '@wordpress/element';
-import {
-	__experimentalToolbarContext as ToolbarContext,
-	ToolbarGroup,
-} from '@wordpress/components';
+import { ToolbarGroup } from '@wordpress/components';
 import warning from '@wordpress/warning';
 
 /**
@@ -14,12 +10,6 @@ import warning from '@wordpress/warning';
 import groups from './groups';
 
 export default function BlockControlsSlot( { group = 'default', ...props } ) {
-	const toolbarState = useContext( ToolbarContext );
-	const fillProps = useMemo(
-		() => [ [ ToolbarContext.Provider, { value: toolbarState } ] ],
-		[ toolbarState ]
-	);
-
 	const Slot = groups[ group ]?.Slot;
 	if ( ! Slot ) {
 		warning( `Unknown BlockControls group "${ group }" provided.` );
@@ -27,11 +17,11 @@ export default function BlockControlsSlot( { group = 'default', ...props } ) {
 	}
 
 	if ( group === 'default' ) {
-		return <Slot { ...props } fillProps={ fillProps } />;
+		return <Slot { ...props } />;
 	}
 
 	return (
-		<Slot { ...props } fillProps={ fillProps }>
+		<Slot { ...props }>
 			{ ( fills ) => {
 				if ( ! fills.length ) {
 					return null;

--- a/packages/block-editor/src/components/block-controls/slot.native.js
+++ b/packages/block-editor/src/components/block-controls/slot.native.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useContext } from '@wordpress/element';
+import { useContext, useMemo } from '@wordpress/element';
 import {
 	__experimentalToolbarContext as ToolbarContext,
 	ToolbarGroup,
@@ -14,7 +14,12 @@ import warning from '@wordpress/warning';
 import groups from './groups';
 
 export default function BlockControlsSlot( { group = 'default', ...props } ) {
-	const accessibleToolbarState = useContext( ToolbarContext );
+	const toolbarState = useContext( ToolbarContext );
+	const fillProps = useMemo(
+		() => [ [ ToolbarContext.Provider, toolbarState ] ],
+		[ toolbarState ]
+	);
+
 	const Slot = groups[ group ]?.Slot;
 	if ( ! Slot ) {
 		warning( `Unknown BlockControls group "${ group }" provided.` );
@@ -22,11 +27,11 @@ export default function BlockControlsSlot( { group = 'default', ...props } ) {
 	}
 
 	if ( group === 'default' ) {
-		return <Slot { ...props } fillProps={ accessibleToolbarState } />;
+		return <Slot { ...props } fillProps={ fillProps } />;
 	}
 
 	return (
-		<Slot { ...props } fillProps={ accessibleToolbarState }>
+		<Slot { ...props } fillProps={ fillProps }>
 			{ ( fills ) => {
 				if ( ! fills.length ) {
 					return null;

--- a/packages/block-editor/src/components/block-controls/slot.native.js
+++ b/packages/block-editor/src/components/block-controls/slot.native.js
@@ -16,7 +16,7 @@ import groups from './groups';
 export default function BlockControlsSlot( { group = 'default', ...props } ) {
 	const toolbarState = useContext( ToolbarContext );
 	const fillProps = useMemo(
-		() => [ [ ToolbarContext.Provider, toolbarState ] ],
+		() => [ [ ToolbarContext.Provider, { value: toolbarState } ] ],
 		[ toolbarState ]
 	);
 

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -213,6 +213,7 @@ export {
 } from './higher-order/with-focus-return';
 export { default as withNotices } from './higher-order/with-notices';
 export { default as withSpokenMessages } from './higher-order/with-spoken-messages';
+export { ComponentsContext as __experimentalComponentsContext } from './ui/context/context-system-provider';
 
 // Private APIs.
 export { privateApis } from './private-apis';

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -213,7 +213,6 @@ export {
 } from './higher-order/with-focus-return';
 export { default as withNotices } from './higher-order/with-notices';
 export { default as withSpokenMessages } from './higher-order/with-spoken-messages';
-export { ComponentsContext as __experimentalComponentsContext } from './ui/context/context-system-provider';
 
 // Private APIs.
 export { privateApis } from './private-apis';

--- a/packages/components/src/private-apis.ts
+++ b/packages/components/src/private-apis.ts
@@ -21,6 +21,7 @@ import {
 	DropdownSubMenu as DropdownSubMenuV2,
 	DropdownSubMenuTrigger as DropdownSubMenuTriggerV2,
 } from './dropdown-menu-v2';
+import { ComponentsContext } from './ui/context/context-system-provider';
 
 export const { lock, unlock } =
 	__dangerousOptInToUnstableAPIsOnlyForCoreModules(
@@ -33,6 +34,7 @@ lock( privateApis, {
 	CustomSelectControl,
 	__experimentalPopoverLegacyPositionToPlacement,
 	createPrivateSlotFill,
+	ComponentsContext,
 	DropdownMenuV2,
 	DropdownMenuCheckboxItemV2,
 	DropdownMenuGroupV2,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

While working on #51154, with the help of @jsnajdr we realised that components rendering in the block toolbar via the block controls `SlotFill` wouldn't have access to the internal components context.

This PR extracts @jsnajdr 's proposed solution, so that it can be reviewed and merged separately from the rest of the changes in that PR.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

In order to function as expected, components from `@wordpress/components` need to access data passed via React Context. The issue is that, when using `SlotFill`, the components rendered in the `Fill` don't normally have access to the context in which the `Fill` renders.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

The solution is to manually forward these contexts in the `SlotFill` component. This PR refactors the code taking care of context forwarding, making it more general and thus allowing for an additional context (the internal components' context) to also be forwarded.

The internal components context is a private API, and is made available to other packages via `lock`/`unlock`.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

This PR is not expected to cause any differences in how the block editor works — it is just an internal change that will allow more components to work seamlessly.

Play around with the block toolbar in the block editor, everything should keep working as on `trunk`.
