### PR TITLE
Remove custom padding on style revisions button

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen-global-styles/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-global-styles/style.scss
@@ -1,6 +1,3 @@
-.edit-site-sidebar-navigation-screen-global-styles__footer {
-	padding-left: $grid-unit-15;
-}
 
 .edit-site-sidebar-navigation-screen-global-styles__revisions {
 	border-radius: $radius-block-ui;


### PR DESCRIPTION
Follow-up to https://github.com/WordPress/gutenberg/pull/51149.

## What?
Removes unnecessary padding on the revisions button in the Styles panel

## Why?
It was slightly breaking alignment.

### Before
<img width="89" alt="Screenshot 2023-06-06 at 14 52 44" src="https://github.com/WordPress/gutenberg/assets/846565/738ffcb5-dd79-4ea6-b27d-d3b48bd0bb79">

### After
<img width="63" alt="Screenshot 2023-06-06 at 14 54 28" src="https://github.com/WordPress/gutenberg/assets/846565/01b3b003-a8cb-45e9-a053-cf71914f9db7">
