### PR TITLE
Allow setting block editing mode with specific clientId when no context available

### DIFF
--- a/packages/block-editor/src/components/block-editing-mode/index.js
+++ b/packages/block-editor/src/components/block-editing-mode/index.js
@@ -40,13 +40,20 @@ import { BlockListBlockContext } from '../block-list/block-list-block-context';
  *
  * If called outside of a block context, the mode is applied to all blocks.
  *
- * @param {?BlockEditingMode} mode The editing mode to apply. If undefined, the
- *                                 current editing mode is not changed.
+ * @param {?BlockEditingMode} mode     The editing mode to apply. If undefined, the
+ *                                     current editing mode is not changed.
+ * @param {?string}           clientId The block client ID.
  *
  * @return {BlockEditingMode} The current editing mode.
  */
-export function useBlockEditingMode( mode ) {
-	const { clientId = '' } = useContext( BlockListBlockContext ) ?? {};
+export function useBlockEditingMode( mode, clientId ) {
+	const blockContextAll = useContext( BlockListBlockContext ) ?? {};
+	const { clientId: contextClientId = '' } = blockContextAll;
+
+	if ( ! clientId ) {
+		clientId = contextClientId;
+	}
+
 	const blockEditingMode = useSelect(
 		( select ) =>
 			unlock( select( blockEditorStore ) ).getBlockEditingMode(
@@ -66,6 +73,6 @@ export function useBlockEditingMode( mode ) {
 				unsetBlockEditingMode( clientId );
 			}
 		};
-	}, [ clientId, mode ] );
+	}, [ clientId, mode, setBlockEditingMode, unsetBlockEditingMode ] );
 	return blockEditingMode;
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Allows consumers of `useBlockEditingMode` to pass a _specific_ clientId for situations where `BlockListBlockContext` is not available.

Co-authored-by: Ben Dwyer <275961+scruffian@users.noreply.github.com>

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

In https://github.com/WordPress/gutenberg/pull/39286 we realised that in certain situations you will need to set the mode when you are outside a block list context. This change enables that whilst preserving the utility of the hook in "get" usage.

Here is the [specific code](https://github.com/WordPress/gutenberg/pull/39286/files#r1219743313).

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Adds an optional `clientId` argument which will take precedence over the value from context if provided.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

The same change is in https://github.com/WordPress/gutenberg/pull/39286 so test there following the testing instructions and clicking through into focus mode for a Navigation and checking that the "edit" controls are disabled for the Navigation block.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
