### PR TITLE
Update the bottom sticky section in the site editor details panel

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-screen/style.scss
@@ -12,7 +12,6 @@
 }
 
 .edit-site-sidebar-navigation-screen__content {
-	margin: 0 0 $grid-unit-20 0;
 	color: $gray-400;
 	padding: 0 $grid-unit-20;
 	.components-item-group {
@@ -88,9 +87,10 @@
 	bottom: 0;
 	background-color: $gray-900;
 	gap: 0;
-	padding: $grid-unit-40 0;
-	margin: $grid-unit-40 $grid-unit-20;
+	padding: $grid-unit-20 0;
+	margin: $grid-unit-20 0 0;
 	border-top: 1px solid $gray-800;
+	box-shadow: 0 #{-$grid-unit-10} $grid-unit-20 $gray-900;
 }
 
 .edit-site-sidebar-navigation-screen__footer {


### PR DESCRIPTION
## What?
Updates some appearance details of the bottom sticky section in the site editor details panel

## Why?
The width / spacing of menu items therein are not currently consistent with other similar items outside the sticky area.

It's currently possible to hover menu items that are 'behind' the sticky area.

Scrolling is currently a bit strange – the sticky area feels partially unstuck when you reach the bottom of the panel.

### Before

https://github.com/WordPress/gutenberg/assets/846565/3fe11f07-5fbe-45eb-a6e0-bd64970d7060



### After

https://github.com/WordPress/gutenberg/assets/846565/bd263b82-fa0e-4038-a0b4-aa4a98d1b9fc

