### PR TITLE
Image lightbox: Add support for external urls in the lightbox

### DIFF
--- a/lib/block-supports/behaviors.php
+++ b/lib/block-supports/behaviors.php
@@ -94,7 +94,12 @@ function gutenberg_render_behaviors_support_lightbox( $block_content, $block ) {
 	// Add directive to expand modal image if appropriate.
 	$m = new WP_HTML_Tag_Processor( $content );
 	$m->next_tag( 'img' );
-	$m->set_attribute( 'data-wp-context', '{ "core": { "image": { "imageSrc": "' . wp_get_attachment_url( $block['attrs']['id'] ) . '"} } }' );
+	if ( isset( $block['attrs']['id'] ) ) {
+		$img_src = wp_get_attachment_url( $block['attrs']['id'] );
+	} else {
+		$img_src = $m->get_attribute( 'src' );
+	}
+	$m->set_attribute( 'data-wp-context', '{ "core": { "image": { "imageSrc": "' . $img_src . '"} } }' );
 	$m->set_attribute( 'data-wp-bind--src', 'selectors.core.image.imageSrc' );
 	$modal_content = $m->get_updated_html();
 


### PR DESCRIPTION
## What?
Fixes #51276 : Image: Lightbox doesn't work on image inserted from URL.

## Why?
Right now, the lightbox functionality, currently in experimental, doesn't work with image that point to an external url.

## How?
I added a conditional that checks if the image id exists. If it does, the lightbox gets the URL from the attachment URL and, if not, it does use the external URL.

## Testing Instructions
* Enable the Interactivity API experiment in Gutenberg->Experiment.
* Add an image with a source URL.
* Check that the lightbox works as expected.