### PR TITLE
Site editor: only show view site link in view mode

### DIFF
--- a/packages/edit-site/src/components/site-hub/index.js
+++ b/packages/edit-site/src/components/site-hub/index.js
@@ -156,14 +156,18 @@ const SiteHub = forwardRef( ( props, ref ) => {
 							{ decodeEntities( siteTitle ) }
 						</motion.div>
 					</AnimatePresence>
-					<Button
-						href={ homeUrl }
-						target="_blank"
-						label={ __( 'View site' ) }
-						aria-label={ __( 'View site (opens in a new tab)' ) }
-						icon={ external }
-						className="edit-site-site-hub__site-view-link"
-					/>
+					{ canvasMode === 'view' && (
+						<Button
+							href={ homeUrl }
+							target="_blank"
+							label={ __( 'View site' ) }
+							aria-label={ __(
+								'View site (opens in a new tab)'
+							) }
+							icon={ external }
+							className="edit-site-site-hub__site-view-link"
+						/>
+					) }
 				</HStack>
 				{ canvasMode === 'view' && (
 					<Button


### PR DESCRIPTION
## What?
Makes sure the view site link site editor hub only displays when `view` mode.

## Why?
Currently the link is still in the DOM when in the editor and moves off screen when keyboard editing in editor.
Fixes: #51257

## How?
Uses `canvasMode === 'view'` check.

## Testing Instructions

- Go to the Site editor.
- Check that the View Site icon still appears when you mouse over the top of left navigation
- Click on canvas to load editor
- Make sure the view site link is no longer in the DOM

## Screenshots or screencast <!-- if applicable -->

Before:
<img width="775" alt="Screenshot 2023-06-07 at 11 54 14 AM" src="https://github.com/WordPress/gutenberg/assets/3629020/e40da733-a679-4bd4-a765-bffdac4d45b4">

After:
<img width="773" alt="Screenshot 2023-06-07 at 11 51 44 AM" src="https://github.com/WordPress/gutenberg/assets/3629020/f02d6b07-a97e-41ee-8b23-ced50e7d8343">

