### PR TITLE
ListView: Update drop indicator line positioning to support rtl languages

### DIFF
--- a/packages/block-editor/src/components/list-view/drop-indicator.js
+++ b/packages/block-editor/src/components/list-view/drop-indicator.js
@@ -100,7 +100,10 @@ export default function ListViewDropIndicator( {
 
 				const scrollContainerWidth = scrollContainer.clientWidth;
 
-				if ( scrollContainerWidth < width ) {
+				if (
+					scrollContainerWidth <
+					width + distanceBetweenContainerAndTarget
+				) {
 					width =
 						scrollContainerWidth -
 						distanceBetweenContainerAndTarget;

--- a/packages/block-editor/src/components/list-view/test/use-list-view-drop-zone.js
+++ b/packages/block-editor/src/components/list-view/test/use-list-view-drop-zone.js
@@ -103,78 +103,118 @@ describe( 'getListViewDropTarget', () => {
 	];
 
 	it( 'should return the correct target when dragging a block over the top half of the first block', () => {
-		const position = { x: 50, y: 70 };
-		const target = getListViewDropTarget( blocksData, position );
+		[
+			{ position: { x: 50, y: 70 }, rtl: false },
+			{ position: { x: 250, y: 70 }, rtl: true },
+		].forEach( ( { position, rtl } ) => {
+			const target = getListViewDropTarget( blocksData, position, rtl );
 
-		expect( target ).toEqual( {
-			blockIndex: 0,
-			clientId: 'block-1',
-			dropPosition: 'top',
-			rootClientId: '',
+			expect( target ).toEqual( {
+				blockIndex: 0,
+				clientId: 'block-1',
+				dropPosition: 'top',
+				rootClientId: '',
+			} );
 		} );
 	} );
 
 	it( 'should nest when dragging a block over the bottom half of an expanded block', () => {
-		const position = { x: 50, y: 90 };
-		const target = getListViewDropTarget( blocksData, position );
+		[
+			{ position: { x: 50, y: 90 }, rtl: false },
+			{ position: { x: 250, y: 90 }, rtl: true },
+		].forEach( ( { position, rtl } ) => {
+			const target = getListViewDropTarget( blocksData, position, rtl );
 
-		expect( target ).toEqual( {
-			blockIndex: 0,
-			dropPosition: 'inside',
-			rootClientId: 'block-1',
+			expect( target ).toEqual( {
+				blockIndex: 0,
+				dropPosition: 'inside',
+				rootClientId: 'block-1',
+			} );
 		} );
 	} );
 
 	it( 'should nest when dragging a block over the right side of the bottom half of a block nested to three levels', () => {
-		const position = { x: 250, y: 180 };
-		const target = getListViewDropTarget( blocksData, position );
+		[
+			{ position: { x: 250, y: 180 }, rtl: false },
+			{ position: { x: 50, y: 180 }, rtl: true },
+		].forEach( ( { position, rtl } ) => {
+			const target = getListViewDropTarget( blocksData, position, rtl );
 
-		expect( target ).toEqual( {
-			blockIndex: 0,
-			dropPosition: 'inside',
-			rootClientId: 'block-3',
+			expect( target ).toEqual( {
+				blockIndex: 0,
+				dropPosition: 'inside',
+				rootClientId: 'block-3',
+			} );
 		} );
 	} );
 
 	it( 'should drag below when positioned at the bottom half of a block nested to three levels, and over the third level horizontally', () => {
-		const position = { x: 10 + NESTING_LEVEL_INDENTATION * 3, y: 180 };
-		const target = getListViewDropTarget( blocksData, position );
+		[
+			{
+				position: { x: 10 + NESTING_LEVEL_INDENTATION * 3, y: 180 },
+				rtl: false,
+			},
+			{
+				position: { x: 300 - NESTING_LEVEL_INDENTATION * 3, y: 180 },
+				rtl: true,
+			},
+		].forEach( ( { position, rtl } ) => {
+			const target = getListViewDropTarget( blocksData, position, rtl );
 
-		expect( target ).toEqual( {
-			blockIndex: 1,
-			clientId: 'block-3',
-			dropPosition: 'bottom',
-			rootClientId: 'block-2',
+			expect( target ).toEqual( {
+				blockIndex: 1,
+				clientId: 'block-3',
+				dropPosition: 'bottom',
+				rootClientId: 'block-2',
+			} );
 		} );
 	} );
 
-	it( 'should drag one level up below when positioned at the bottom half of a block nested to three levels, and over the second level horizontally', () => {
-		const position = { x: 10 + NESTING_LEVEL_INDENTATION * 2, y: 180 };
-		const target = getListViewDropTarget( blocksData, position );
+	it( 'should drag one level up when positioned at the bottom half of a block nested to three levels, and over the second level horizontally', () => {
+		[
+			{
+				position: { x: 10 + NESTING_LEVEL_INDENTATION * 2, y: 180 },
+				rtl: false,
+			},
+			{
+				position: { x: 300 - NESTING_LEVEL_INDENTATION * 2, y: 180 },
+				rtl: true,
+			},
+		].forEach( ( { position, rtl } ) => {
+			const target = getListViewDropTarget( blocksData, position, rtl );
 
-		expect( target ).toEqual( {
-			blockIndex: 1,
-			clientId: 'block-3',
-			dropPosition: 'bottom',
-			rootClientId: 'block-1',
+			expect( target ).toEqual( {
+				blockIndex: 1,
+				clientId: 'block-3',
+				dropPosition: 'bottom',
+				rootClientId: 'block-1',
+			} );
 		} );
 	} );
 
 	it( 'should drag two levels up below when positioned at the bottom half of a block nested to three levels, and over the first level horizontally', () => {
-		const position = { x: 10 + NESTING_LEVEL_INDENTATION, y: 180 };
-		const target = getListViewDropTarget( blocksData, position );
+		[
+			{
+				position: { x: 10 + NESTING_LEVEL_INDENTATION, y: 180 },
+				rtl: false,
+			},
+			{
+				position: { x: 300 - NESTING_LEVEL_INDENTATION, y: 180 },
+				rtl: true,
+			},
+		].forEach( ( { position, rtl } ) => {
+			const target = getListViewDropTarget( blocksData, position, rtl );
 
-		expect( target ).toEqual( {
-			blockIndex: 1,
-			clientId: 'block-3',
-			dropPosition: 'bottom',
-			rootClientId: '',
+			expect( target ).toEqual( {
+				blockIndex: 1,
+				clientId: 'block-3',
+				dropPosition: 'bottom',
+				rootClientId: '',
+			} );
 		} );
 	} );
 
 	it( 'should nest and append to end when dragging a block over the right side and bottom half of a collapsed block with children', () => {
-		const position = { x: 160, y: 90 };
-
 		const collapsedBlockData = [ ...blocksData ];
 
 		// Set the first block to be collapsed.
@@ -186,38 +226,64 @@ describe( 'getListViewDropTarget', () => {
 		// Hide the first block's children.
 		collapsedBlockData.splice( 1, 1 );
 
-		const target = getListViewDropTarget( collapsedBlockData, position );
+		[
+			{
+				position: { x: 250, y: 90 },
+				rtl: false,
+			},
+			{
+				position: { x: 50, y: 90 },
+				rtl: true,
+			},
+		].forEach( ( { position, rtl } ) => {
+			const target = getListViewDropTarget(
+				collapsedBlockData,
+				position,
+				rtl
+			);
 
-		expect( target ).toEqual( {
-			blockIndex: 1,
-			dropPosition: 'inside',
-			rootClientId: 'block-1',
+			expect( target ).toEqual( {
+				blockIndex: 1,
+				dropPosition: 'inside',
+				rootClientId: 'block-1',
+			} );
 		} );
 	} );
 
 	it( 'should nest and prepend when dragging a block over the right side and bottom half of an expanded block with children', () => {
-		const position = { x: 160, y: 90 };
-
 		const collapsedBlockData = [ ...blocksData ];
 
-		// Set the first block to be collapsed.
+		// Set the first block to be expanded.
 		collapsedBlockData[ 0 ] = {
 			...collapsedBlockData[ 0 ],
 			isExpanded: true,
 		};
 
-		const target = getListViewDropTarget( collapsedBlockData, position );
+		[
+			{
+				position: { x: 250, y: 90 },
+				rtl: false,
+			},
+			{
+				position: { x: 50, y: 90 },
+				rtl: true,
+			},
+		].forEach( ( { position, rtl } ) => {
+			const target = getListViewDropTarget(
+				collapsedBlockData,
+				position,
+				rtl
+			);
 
-		expect( target ).toEqual( {
-			blockIndex: 0,
-			dropPosition: 'inside',
-			rootClientId: 'block-1',
+			expect( target ).toEqual( {
+				blockIndex: 0,
+				dropPosition: 'inside',
+				rootClientId: 'block-1',
+			} );
 		} );
 	} );
 
 	it( 'should drag below when dragging a block over the left side and bottom half of a collapsed block with children', () => {
-		const position = { x: 30, y: 90 };
-
 		const collapsedBlockData = [ ...blocksData ];
 
 		// Set the first block to be collapsed.
@@ -229,19 +295,32 @@ describe( 'getListViewDropTarget', () => {
 		// Hide the first block's children.
 		collapsedBlockData.splice( 1, 1 );
 
-		const target = getListViewDropTarget( collapsedBlockData, position );
+		[
+			{
+				position: { x: 30, y: 90 },
+				rtl: false,
+			},
+			{
+				position: { x: 270, y: 90 },
+				rtl: true,
+			},
+		].forEach( ( { position, rtl } ) => {
+			const target = getListViewDropTarget(
+				collapsedBlockData,
+				position,
+				rtl
+			);
 
-		expect( target ).toEqual( {
-			blockIndex: 1,
-			clientId: 'block-1',
-			dropPosition: 'bottom',
-			rootClientId: '',
+			expect( target ).toEqual( {
+				blockIndex: 1,
+				clientId: 'block-1',
+				dropPosition: 'bottom',
+				rootClientId: '',
+			} );
 		} );
 	} );
 
 	it( 'should drag below when attempting to nest but the dragged block is not allowed as a child', () => {
-		const position = { x: 70, y: 90 };
-
 		const childNotAllowedBlockData = [ ...blocksData ];
 
 		// Set the first block to not be allowed as a child.
@@ -250,16 +329,28 @@ describe( 'getListViewDropTarget', () => {
 			canInsertDraggedBlocksAsChild: false,
 		};
 
-		const target = getListViewDropTarget(
-			childNotAllowedBlockData,
-			position
-		);
+		[
+			{
+				position: { x: 70, y: 90 },
+				rtl: false,
+			},
+			{
+				position: { x: 230, y: 90 },
+				rtl: true,
+			},
+		].forEach( ( { position, rtl } ) => {
+			const target = getListViewDropTarget(
+				childNotAllowedBlockData,
+				position,
+				rtl
+			);
 
-		expect( target ).toEqual( {
-			blockIndex: 1,
-			clientId: 'block-1',
-			dropPosition: 'bottom',
-			rootClientId: '',
+			expect( target ).toEqual( {
+				blockIndex: 1,
+				clientId: 'block-1',
+				dropPosition: 'bottom',
+				rootClientId: '',
+			} );
 		} );
 	} );
 
@@ -288,14 +379,18 @@ describe( 'getListViewDropTarget', () => {
 		// This position is to the right of the block, but below the bottom of the block.
 		// This should result in the block being moved below the bottom-most block, and
 		// not being treated as a nesting gesture.
-		const position = { x: 160, y: 250 };
-		const target = getListViewDropTarget( singleBlock, position );
+		[
+			{ position: { x: 160, y: 250 }, rtl: false },
+			{ position: { x: 140, y: 250 }, rtl: true },
+		].forEach( ( { position, rtl } ) => {
+			const target = getListViewDropTarget( singleBlock, position, rtl );
 
-		expect( target ).toEqual( {
-			blockIndex: 1,
-			clientId: 'block-1',
-			dropPosition: 'bottom',
-			rootClientId: '',
+			expect( target ).toEqual( {
+				blockIndex: 1,
+				clientId: 'block-1',
+				dropPosition: 'bottom',
+				rootClientId: '',
+			} );
 		} );
 	} );
 } );

--- a/packages/block-editor/src/components/list-view/use-list-view-drop-zone.js
+++ b/packages/block-editor/src/components/list-view/use-list-view-drop-zone.js
@@ -279,6 +279,37 @@ export function getListViewDropTarget( blocksData, position, rtl = false ) {
 	const isDraggingBelow = candidateEdge === 'bottom';
 
 	// If the user is dragging towards the bottom of the block check whether
+	// they might be trying to nest the block as a child.
+	// If the block already has inner blocks, and is expanded, this should be treated
+	// as nesting since the next block in the tree will be the first child.
+	// However, if the block is collapsed, dragging beneath the block should
+	// still be allowed, as the next visible block in the tree will be a sibling.
+	if (
+		isDraggingBelow &&
+		candidateBlockData.canInsertDraggedBlocksAsChild &&
+		( ( candidateBlockData.innerBlockCount > 0 &&
+			candidateBlockData.isExpanded ) ||
+			isNestingGesture(
+				position,
+				candidateRect,
+				candidateBlockParents.length,
+				rtl
+			) )
+	) {
+		// If the block is expanded, insert the block as the first child.
+		// Otherwise, for collapsed blocks, insert the block as the last child.
+		const newBlockIndex = candidateBlockData.isExpanded
+			? 0
+			: candidateBlockData.innerBlockCount || 0;
+
+		return {
+			rootClientId: candidateBlockData.clientId,
+			blockIndex: newBlockIndex,
+			dropPosition: 'inside',
+		};
+	}
+
+	// If the user is dragging towards the bottom of the block check whether
 	// they might be trying to move the block to be at a parent level.
 	if (
 		isDraggingBelow &&
@@ -348,37 +379,6 @@ export function getListViewDropTarget( blocksData, position, rtl = false ) {
 				};
 			}
 		}
-	}
-
-	// If the user is dragging towards the bottom of the block check whether
-	// they might be trying to nest the block as a child.
-	// If the block already has inner blocks, and is expanded, this should be treated
-	// as nesting since the next block in the tree will be the first child.
-	// However, if the block is collapsed, dragging beneath the block should
-	// still be allowed, as the next visible block in the tree will be a sibling.
-	if (
-		isDraggingBelow &&
-		candidateBlockData.canInsertDraggedBlocksAsChild &&
-		( ( candidateBlockData.innerBlockCount > 0 &&
-			candidateBlockData.isExpanded ) ||
-			isNestingGesture(
-				position,
-				candidateRect,
-				candidateBlockParents.length,
-				rtl
-			) )
-	) {
-		// If the block is expanded, insert the block as the first child.
-		// Otherwise, for collapsed blocks, insert the block as the last child.
-		const newBlockIndex = candidateBlockData.isExpanded
-			? 0
-			: candidateBlockData.innerBlockCount || 0;
-
-		return {
-			rootClientId: candidateBlockData.clientId,
-			blockIndex: newBlockIndex,
-			dropPosition: 'inside',
-		};
 	}
 
 	// If dropping as a sibling, but block cannot be inserted in


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Update the `ListView`'s drop indicator line and drop zone logic to add support for RTL languages.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

In RTL languages the nesting for list view items is also displayed right-to-left, however prior to this PR, the drop indicator logic rendered as though it should always be left aligned. This would make the drag and drop behaviour appear to be broken in RTL languages.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* Update the drop indicator line rendering positioning and width to be aware or RTL, and adjust the width and left position of the indicator line accordingly.
* Update the drop zone logic and how we detect nesting and up gestures so that the calculations are performed from the correct side of the target element. I.e. relative to the left edge in LTR languages, and relative to the right edge in RTL languages.
* Add a single call to `isRTL()` in the drop zone logic and pass that value down, so that a) it's easier to write tests, and b) so that we're just checking a boolean in all the regular calls to check for RTL.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

Thank you for taking a look at this PR! There are lots of edge cases when it comes to testing list view drag and drop, so manually testing could take a while. ☕ ⌛ 


<details>

<summary>Some heavily nested block markup</summary>

```html
<!-- wp:group {"layout":{"type":"constrained"}} -->
<div class="wp-block-group"><!-- wp:paragraph -->
<p>A paragraph in a group level 1</p>
<!-- /wp:paragraph -->

<!-- wp:group {"layout":{"type":"constrained"}} -->
<div class="wp-block-group"><!-- wp:paragraph -->
<p>A paragraph in a group level 2</p>
<!-- /wp:paragraph -->

<!-- wp:group {"layout":{"type":"constrained"}} -->
<div class="wp-block-group"><!-- wp:paragraph -->
<p>A paragraph in a group level 3</p>
<!-- /wp:paragraph -->

<!-- wp:group {"layout":{"type":"constrained"}} -->
<div class="wp-block-group"><!-- wp:paragraph -->
<p>A paragraph in a group level 4</p>
<!-- /wp:paragraph -->

<!-- wp:group {"layout":{"type":"constrained"}} -->
<div class="wp-block-group"><!-- wp:paragraph -->
<p>A paragraph in a group level 5</p>
<!-- /wp:paragraph -->

<!-- wp:group {"layout":{"type":"constrained"}} -->
<div class="wp-block-group"><!-- wp:paragraph {"anchor":""} -->
<p>A paragraph in a group level 6</p>
<!-- /wp:paragraph -->

<!-- wp:group {"layout":{"type":"constrained"}} -->
<div class="wp-block-group"><!-- wp:paragraph {"anchor":""} -->
<p>A paragraph in a group level 7</p>
<!-- /wp:paragraph -->

<!-- wp:group {"layout":{"type":"constrained"}} -->
<div class="wp-block-group"><!-- wp:paragraph {"anchor":""} -->
<p>A paragraph in a group level 8</p>
<!-- /wp:paragraph --></div>
<!-- /wp:group --></div>
<!-- /wp:group --></div>
<!-- /wp:group --></div>
<!-- /wp:group --></div>
<!-- /wp:group --></div>
<!-- /wp:group --></div>
<!-- /wp:group --></div>
<!-- /wp:group -->

<!-- wp:heading -->
<h2 class="wp-block-heading">A heading</h2>
<!-- /wp:heading -->

<!-- wp:paragraph -->
<p>A paragraph</p>
<!-- /wp:paragraph -->
```
</details>


Test the following in both RTL and LTR languages to ensure that RTL support is added, while not introducing any regressions for LTR languages.

1. In a post, page, or the site editor, add a range of nested blocks, deep enough to cause a horizontal scrollbar (e.g. 5 or more levels of nesting).
2. Try dragging a paragraph block to all levels of nesting.
3. Ensure the drop indicator line accurately reflects the position you are attempting to drop to.
4. Try a list view that is short, but scrolls horizontally (heavy level of nesting, with few blocks).
5. Try a long list view that does not scroll horizontally (minimal nesting).
6. Try a long list view that also scrolls horizontally (lots of blocks, lots of nesting).

## Screenshots or screencast <!-- if applicable -->

| Before (note the move up behaviour is incorrectly happening at the left hand side, and the line is displayed from the right edge | After (note the move up behaviour is correctly happening at the right hand side, and the line is displayed from the left edge |
| --- | --- |
| ![2023-06-07 16 10 53](https://github.com/WordPress/gutenberg/assets/14988353/ff1c243c-6221-4523-b72d-cdc3c91e1c9d) | ![2023-06-07 16 08 52](https://github.com/WordPress/gutenberg/assets/14988353/123372ff-bfc5-4ba5-98d9-377b7a2a057e) |