### PR TITLE
Try providing a non-zero value for client width in image editor.

### DIFF
--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -516,7 +516,7 @@ export default function Image( {
 	}
 
 	// clientWidth needs to be a number for the image Cropper to work, but sometimes it's 0
-	// So we try using the imageRef width first and fallback om clientWidth.
+	// So we try using the imageRef width first and fallback to clientWidth.
 	const fallbackClientWidth = imageRef.current?.width || clientWidth;
 
 	if ( canEditImage && isEditingImage ) {

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -155,7 +155,7 @@ export default function Image( {
 	] = useState( {} );
 	const [ isEditingImage, setIsEditingImage ] = useState( false );
 	const [ externalBlob, setExternalBlob ] = useState();
-	const clientWidth = useClientWidth( containerRef, [ align ] );
+	const clientWidth = useClientWidth( containerRef );
 	const hasNonContentControls = blockEditingMode === 'default';
 	const isResizable =
 		allowResize &&

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -155,7 +155,7 @@ export default function Image( {
 	] = useState( {} );
 	const [ isEditingImage, setIsEditingImage ] = useState( false );
 	const [ externalBlob, setExternalBlob ] = useState();
-	const clientWidth = useClientWidth( containerRef );
+	const clientWidth = useClientWidth( containerRef, [ align ] );
 	const hasNonContentControls = blockEditingMode === 'default';
 	const isResizable =
 		allowResize &&
@@ -515,6 +515,10 @@ export default function Image( {
 			: naturalHeight;
 	}
 
+	// clientWidth needs to be a number for the image Cropper to work, but sometimes it's 0
+	// So we try using the imageRef width first and fallback om clientWidth.
+	const fallbackClientWidth = imageRef.current?.width || clientWidth;
+
 	if ( canEditImage && isEditingImage ) {
 		img = (
 			<ImageEditor
@@ -522,7 +526,7 @@ export default function Image( {
 				url={ url }
 				width={ width }
 				height={ height }
-				clientWidth={ clientWidth }
+				clientWidth={ fallbackClientWidth }
 				naturalHeight={ naturalHeight }
 				naturalWidth={ naturalWidth }
 				onSaveImage={ ( imageAttributes ) =>

--- a/packages/block-library/src/image/use-client-width.js
+++ b/packages/block-library/src/image/use-client-width.js
@@ -5,6 +5,7 @@ import { useState, useEffect } from '@wordpress/element';
 
 export default function useClientWidth( ref, dependencies ) {
 	const [ clientWidth, setClientWidth ] = useState();
+
 	function calculateClientWidth() {
 		setClientWidth( ref.current?.clientWidth );
 	}

--- a/packages/block-library/src/image/use-client-width.js
+++ b/packages/block-library/src/image/use-client-width.js
@@ -3,13 +3,13 @@
  */
 import { useState, useEffect } from '@wordpress/element';
 
-export default function useClientWidth( ref ) {
+export default function useClientWidth( ref, dependencies ) {
 	const [ clientWidth, setClientWidth ] = useState();
 	function calculateClientWidth() {
 		setClientWidth( ref.current?.clientWidth );
 	}
 
-	useEffect( calculateClientWidth );
+	useEffect( calculateClientWidth, dependencies );
 	useEffect( () => {
 		const { defaultView } = ref.current.ownerDocument;
 

--- a/packages/block-library/src/image/use-client-width.js
+++ b/packages/block-library/src/image/use-client-width.js
@@ -3,14 +3,13 @@
  */
 import { useState, useEffect } from '@wordpress/element';
 
-export default function useClientWidth( ref, dependencies ) {
+export default function useClientWidth( ref ) {
 	const [ clientWidth, setClientWidth ] = useState();
-
 	function calculateClientWidth() {
 		setClientWidth( ref.current?.clientWidth );
 	}
 
-	useEffect( calculateClientWidth, dependencies );
+	useEffect( calculateClientWidth );
 	useEffect( () => {
 		const { defaultView } = ref.current.ownerDocument;
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes #51250.

The initial calculation from useClientWidth hook is sometimes zero, and we don't want it to recalculate every time image width changes because it can go into an infinite loop. The problem is that clientWidth provides the dimensions for the image editor so, if that value is zero, the image editor is 0px wide. 

I've tried to fix that by instead passing the current width of the image to the image editor, with client width as a fallback in case that's undefined. I've tested with images inside and outside of flex and non-flex containers, and with different alignments, and it seems to work fine in all cases, but would be good to test further!

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. In a Row block, add a couple of Image blocks;
2. Try using the Crop function on one of the images;
3. Verify that while cropping the image remains at its expected size.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
<img width="1058" alt="Screenshot 2023-06-07 at 4 21 23 pm" src="https://github.com/WordPress/gutenberg/assets/8096000/7e4188cf-e7de-4a4b-9fe4-785c727cf081">
