### PR TITLE
Experiment: Auto-inserting block patterns on the frontend

### DIFF
--- a/lib/experimental/blocks.php
+++ b/lib/experimental/blocks.php
@@ -163,7 +163,7 @@ END;
 		}
 	}
 
-	if ( $block['blockName'] === $block_name ) {
+	if ( $block_name === $block['blockName'] ) {
 		if ( 'before' === $block_position ) {
 			$block_content = $inserted_content . $block_content;
 		} elseif ( 'after' === $block_position ) {

--- a/lib/experimental/blocks.php
+++ b/lib/experimental/blocks.php
@@ -140,6 +140,7 @@ add_filter( 'render_block_data', 'gutenberg_auto_insert_child_block', 10, 3 );
  * @param array    $block         The full block, including name and attributes.
  */
 function gutenberg_auto_insert_blocks( $block_content, $block ) {
+	// TODO: Implement an API for users to set the following two parameters.
 	$block_name     = 'core/post-content';
 	$block_position = 'after';
 

--- a/lib/experimental/blocks.php
+++ b/lib/experimental/blocks.php
@@ -113,18 +113,19 @@ function gutenberg_auto_insert_child_block( $parsed_block ) {
 
 	if ( $block_name === $parsed_block['blockName'] ) {
 		$inserted_block_markup = '<!-- wp:avatar {"size":40,"style":{"border":{"radius":"10px"}}} /-->';
-		$inserted_blocks = parse_blocks( $inserted_block_markup );
+		$inserted_blocks       = parse_blocks( $inserted_block_markup );
+		$inserted_block        = $inserted_blocks[0];
 
 		if ( 'first-child' === $block_position ) {
-			array_unshift( $parsed_block['innerBlocks'], $inserted_blocks[0] );
+			array_unshift( $parsed_block['innerBlocks'], $inserted_block );
 			// Since WP_Block::render() iterates over `inner_content` (rather than `inner_blocks`)
 			// when rendering blocks, we also need to prepend the new block to that array.
-			array_unshift( $parsed_block['innerContent'], $inserted_blocks[0] );
+			array_unshift( $parsed_block['innerContent'], $inserted_block );
 		} elseif ( 'last-child' === $block_position ) {
-			array_push( $parsed_block['innerBlocks'], $inserted_blocks[0] );
+			array_push( $parsed_block['innerBlocks'], $inserted_block );
 			// Since WP_Block::render() iterates over `inner_content` (rather than `inner_blocks`)
 			// when rendering blocks, we also need to append the new block to that array.
-			array_push( $parsed_block['innerContent'], $inserted_blocks[0] );
+			array_push( $parsed_block['innerContent'], $inserted_block );
 		}
 	}
 	return $parsed_block;

--- a/lib/experimental/blocks.php
+++ b/lib/experimental/blocks.php
@@ -112,12 +112,15 @@ function gutenberg_auto_insert_blocks( $block_content, $block, $instance ) {
 	$block_name = 'core/comment-content';
 	$block_position = 'after'; // Child blocks could be a bit trickier.
 
-	// TODO: Parse actually inserted block.
-	$inserted_content = 'LIKE';
-
 	// Can we void infinite loops?
 
 	if ( $block['blockName'] === $block_name ) {
+		$inserted_block_markup = '<!-- wp:social-links -->
+		<ul class="wp-block-social-links"><!-- wp:social-link {"url":"https://wordpress.org","service":"wordpress"} /--></ul>
+		<!-- /wp:social-links -->';
+		$inserted_blocks = parse_blocks( $inserted_block_markup );
+		$inserted_content = render_block( $inserted_blocks[0] );
+
 		if ( 'before' === $block_position ) {
 			$block_content = $inserted_content . $block_content;
 		} elseif ( 'after' === $block_position ) {

--- a/lib/experimental/blocks.php
+++ b/lib/experimental/blocks.php
@@ -121,13 +121,12 @@ add_filter( 'render_block_data', 'gutenberg_auto_insert_child_block', 10, 3 );
  *
  * @param string   $block_content The block content.
  * @param array    $block         The full block, including name and attributes.
- * @param WP_Block $instance      The block instance.
  */
-function gutenberg_auto_insert_blocks( $block_content, $block, $instance ) {
-	// $block_name = 'core/post-content';
+function gutenberg_auto_insert_blocks( $block_content, $block ) {
+	// $block_name     = 'core/post-content';
 	// $block_position = 'after'; // Child blocks could be a bit trickier.
 
-	$block_name = 'core/comment-template';
+	$block_name     = 'core/comment-template';
 	$block_position = 'last-child';
 
 	// Can we void infinite loops?
@@ -145,12 +144,12 @@ function gutenberg_auto_insert_blocks( $block_content, $block, $instance ) {
 		return $block_content;
 	}
 
-
 	$inserted_block_markup = <<<END
 <!-- wp:social-links -->
 <ul class="wp-block-social-links"><!-- wp:social-link {"url":"https://wordpress.org","service":"wordpress"} /--></ul>
 <!-- /wp:social-links -->
 END;
+
 	$inserted_blocks  = parse_blocks( $inserted_block_markup );
 	$inserted_content = render_block( $inserted_blocks[0] );
 
@@ -173,4 +172,4 @@ END;
 
 	return $block_content;
 }
-add_filter( 'render_block', 'gutenberg_auto_insert_blocks', 10, 3 );
+add_filter( 'render_block', 'gutenberg_auto_insert_blocks', 10, 2 );

--- a/lib/experimental/blocks.php
+++ b/lib/experimental/blocks.php
@@ -131,13 +131,15 @@ function gutenberg_auto_insert_child_block( $parsed_block ) {
 	if ( 'first-child' === $block_position ) {
 		array_unshift( $parsed_block['innerBlocks'], $inserted_block );
 		// Since WP_Block::render() iterates over `inner_content` (rather than `inner_blocks`)
-		// when rendering blocks, we also need to prepend the new block to that array.
-		array_unshift( $parsed_block['innerContent'], $inserted_block );
+		// when rendering blocks, we also need to prepend a value (`null`, to mark a block
+		// location) to that array.
+		array_unshift( $parsed_block['innerContent'], null );
 	} elseif ( 'last-child' === $block_position ) {
 		array_push( $parsed_block['innerBlocks'], $inserted_block );
 		// Since WP_Block::render() iterates over `inner_content` (rather than `inner_blocks`)
-		// when rendering blocks, we also need to append the new block to that array.
-		array_push( $parsed_block['innerContent'], $inserted_block );
+		// when rendering blocks, we also need to prepend a value (`null`, to mark a block
+		// location) to that array.
+		array_push( $parsed_block['innerContent'], null );
 	}
 
 	return $parsed_block;

--- a/lib/experimental/blocks.php
+++ b/lib/experimental/blocks.php
@@ -109,8 +109,18 @@ add_filter( 'register_block_type_args', 'gutenberg_register_metadata_attribute' 
  * @param WP_Block|null $parent_block If this is a nested block, a reference to the parent block.
  */
 function gutenberg_auto_insert_child_block( $parsed_block, $source_block, $parent_block ) {
-	if ( isset( $parent_block ) ) {
-		$parsed_block['parentBlock'] = $parent_block->name;
+	if ( 'core/comment-template' === $parsed_block['blockName'] ) {
+		$inserted_block_markup = <<<END
+<!-- wp:social-links -->
+<ul class="wp-block-social-links"><!-- wp:social-link {"url":"https://wordpress.org","service":"wordpress"} /--></ul>
+<!-- /wp:social-links -->'
+END;
+		$inserted_blocks = parse_blocks( $inserted_block_markup );
+
+		$parsed_block['innerBlocks'][] = $inserted_blocks[0];
+		// Since WP_Block::render() iterates over `inner_content` (rather than `inner_blocks`)
+		// when rendering blocks, we also need to append the new block to that array.
+		$parsed_block['innerContent'][] = $inserted_blocks[0];
 	}
 	return $parsed_block;
 }

--- a/lib/experimental/blocks.php
+++ b/lib/experimental/blocks.php
@@ -131,10 +131,12 @@ function gutenberg_auto_insert_blocks( $block_content, $block, $instance ) {
 
 	// Can we void infinite loops?
 
-	if ( 'core/comment-template' === $block['parentBlock'] ) {
-		$inserted_block_markup = '<!-- wp:social-links -->
-		<ul class="wp-block-social-links"><!-- wp:social-link {"url":"https://wordpress.org","service":"wordpress"} /--></ul>
-		<!-- /wp:social-links -->';
+	if ( isset( $block['parentBlock'] ) && 'core/comment-template' === $block['parentBlock'] ) {
+		$inserted_block_markup = <<<END
+<!-- wp:social-links -->
+<ul class="wp-block-social-links"><!-- wp:social-link {"url":"https://wordpress.org","service":"wordpress"} /--></ul>
+<!-- /wp:social-links -->
+END;
 		$inserted_blocks = parse_blocks( $inserted_block_markup );
 		$inserted_content = render_block( $inserted_blocks[0] );
 
@@ -142,9 +144,11 @@ function gutenberg_auto_insert_blocks( $block_content, $block, $instance ) {
 	}
 
 	if ( $block['blockName'] === $block_name ) {
-		$inserted_block_markup = '<!-- wp:social-links -->
-		<ul class="wp-block-social-links"><!-- wp:social-link {"url":"https://wordpress.org","service":"wordpress"} /--></ul>
-		<!-- /wp:social-links -->';
+		$inserted_block_markup = <<<END
+<!-- wp:social-links -->
+<ul class="wp-block-social-links"><!-- wp:social-link {"url":"https://wordpress.org","service":"wordpress"} /--></ul>
+<!-- /wp:social-links -->
+END;
 		$inserted_blocks = parse_blocks( $inserted_block_markup );
 		$inserted_content = render_block( $inserted_blocks[0] );
 

--- a/lib/experimental/blocks.php
+++ b/lib/experimental/blocks.php
@@ -109,8 +109,6 @@ add_filter( 'register_block_type_args', 'gutenberg_register_metadata_attribute' 
  * @param WP_Block|null $parent_block If this is a nested block, a reference to the parent block.
  */
 function gutenberg_auto_insert_child_block( $parsed_block, $source_block, $parent_block ) {
-	// first or last child
-	// of comment-template
 	if ( isset( $parent_block ) ) {
 		$parsed_block['parentBlock'] = $parent_block->name;
 	}
@@ -131,25 +129,21 @@ function gutenberg_auto_insert_blocks( $block_content, $block, $instance ) {
 
 	// Can we void infinite loops?
 
-	if ( isset( $block['parentBlock'] ) && 'core/comment-template' === $block['parentBlock'] ) {
-		$inserted_block_markup = <<<END
+	$inserted_block_markup = <<<END
 <!-- wp:social-links -->
 <ul class="wp-block-social-links"><!-- wp:social-link {"url":"https://wordpress.org","service":"wordpress"} /--></ul>
 <!-- /wp:social-links -->
 END;
-		$inserted_blocks = parse_blocks( $inserted_block_markup );
+
+	if ( isset( $block['parentBlock'] ) && 'core/comment-template' === $block['parentBlock'] ) {
+		$inserted_blocks  = parse_blocks( $inserted_block_markup );
 		$inserted_content = render_block( $inserted_blocks[0] );
 
 		$block_content = $block_content . $inserted_content; // after!
 	}
 
 	if ( $block['blockName'] === $block_name ) {
-		$inserted_block_markup = <<<END
-<!-- wp:social-links -->
-<ul class="wp-block-social-links"><!-- wp:social-link {"url":"https://wordpress.org","service":"wordpress"} /--></ul>
-<!-- /wp:social-links -->
-END;
-		$inserted_blocks = parse_blocks( $inserted_block_markup );
+		$inserted_blocks  = parse_blocks( $inserted_block_markup );
 		$inserted_content = render_block( $inserted_blocks[0] );
 
 		if ( 'before' === $block_position ) {

--- a/lib/experimental/blocks.php
+++ b/lib/experimental/blocks.php
@@ -159,21 +159,23 @@ function gutenberg_auto_insert_blocks( $block_content, $block ) {
 
 	// Can we avoid infinite loops?
 
-	if ( $block_name === $block['blockName'] ) {
-		$inserted_block_markup = <<<END
+	if ( $block_name !== $block['blockName'] ) {
+		return $block_content;
+	}
+
+	$inserted_block_markup = <<<END
 <!-- wp:social-links -->
 <ul class="wp-block-social-links"><!-- wp:social-link {"url":"https://wordpress.org","service":"wordpress"} /--></ul>
 <!-- /wp:social-links -->'
 END;
 
-		$inserted_blocks  = parse_blocks( $inserted_block_markup );
-		$inserted_content = render_block( $inserted_blocks[0] );
+	$inserted_blocks  = parse_blocks( $inserted_block_markup );
+	$inserted_content = render_block( $inserted_blocks[0] );
 
-		if ( 'before' === $block_position ) {
-			$block_content = $inserted_content . $block_content;
-		} elseif ( 'after' === $block_position ) {
-			$block_content = $block_content . $inserted_content;
-		}
+	if ( 'before' === $block_position ) {
+		$block_content = $inserted_content . $block_content;
+	} elseif ( 'after' === $block_position ) {
+		$block_content = $block_content . $inserted_content;
 	}
 
 	return $block_content;

--- a/lib/experimental/blocks.php
+++ b/lib/experimental/blocks.php
@@ -152,19 +152,12 @@ function gutenberg_auto_insert_blocks( $block_content, $block ) {
 
 	// Can we void infinite loops?
 
-	if (
-		$block_name !== $block['blockName'] ||
-		! in_array( $block_position, array( 'before', 'after' ), true )
-	) {
-		return $block_content;
-	}
-
-	$inserted_block_markup = '<!-- wp:avatar {"size":40,"style":{"border":{"radius":"10px"}}} /-->';
-
-	$inserted_blocks  = parse_blocks( $inserted_block_markup );
-	$inserted_content = render_block( $inserted_blocks[0] );
-
 	if ( $block_name === $block['blockName'] ) {
+		$inserted_block_markup = '<!-- wp:avatar {"size":40,"style":{"border":{"radius":"10px"}}} /-->';
+
+		$inserted_blocks  = parse_blocks( $inserted_block_markup );
+		$inserted_content = render_block( $inserted_blocks[0] );
+
 		if ( 'before' === $block_position ) {
 			$block_content = $inserted_content . $block_content;
 		} elseif ( 'after' === $block_position ) {

--- a/lib/experimental/blocks.php
+++ b/lib/experimental/blocks.php
@@ -100,3 +100,31 @@ function gutenberg_register_metadata_attribute( $args ) {
 	return $args;
 }
 add_filter( 'register_block_type_args', 'gutenberg_register_metadata_attribute' );
+
+/**
+ * Auto-insert blocks relative to a given block.
+ *
+ * @param string   $block_content The block content.
+ * @param array    $block         The full block, including name and attributes.
+ * @param WP_Block $instance      The block instance.
+ */
+function gutenberg_auto_insert_blocks( $block_content, $block, $instance ) {
+	$block_name = 'core/comment-content';
+	$block_position = 'after'; // Child blocks could be a bit trickier.
+
+	// TODO: Parse actually inserted block.
+	$inserted_content = 'LIKE';
+
+	// Can we void infinite loops?
+
+	if ( $block['blockName'] === $block_name ) {
+		if ( 'before' === $block_position ) {
+			$block_content = $inserted_content . $block_content;
+		} elseif ( 'after' === $block_position ) {
+			$block_content = $block_content . $inserted_content;
+		}
+	}
+
+	return $block_content;
+}
+add_filter( 'render_block', 'gutenberg_auto_insert_blocks', 10, 3 );

--- a/lib/experimental/blocks.php
+++ b/lib/experimental/blocks.php
@@ -144,11 +144,7 @@ function gutenberg_auto_insert_blocks( $block_content, $block ) {
 		return $block_content;
 	}
 
-	$inserted_block_markup = <<<END
-<!-- wp:social-links -->
-<ul class="wp-block-social-links"><!-- wp:social-link {"url":"https://wordpress.org","service":"wordpress"} /--></ul>
-<!-- /wp:social-links -->
-END;
+	$inserted_block_markup = '<!-- wp:avatar {"size":40,"style":{"border":{"radius":"10px"}}} /-->';
 
 	$inserted_blocks  = parse_blocks( $inserted_block_markup );
 	$inserted_content = render_block( $inserted_blocks[0] );

--- a/lib/experimental/blocks.php
+++ b/lib/experimental/blocks.php
@@ -148,19 +148,13 @@ function gutenberg_auto_insert_blocks( $block_content, $block ) {
 	// $block_position = 'after'; // Child blocks could be a bit trickier.
 
 	$block_name     = 'core/comment-template';
-	$block_position = 'last-child';
+	$block_position = 'after';
 
 	// Can we void infinite loops?
 
 	if (
-		! (
-			$block_name === $block['blockName'] &&
-			( 'before' === $block_position || 'after' === $block_position )
-		) && ! (
-			isset( $block['parentBlock'] ) &&
-			$block_name === $block['parentBlock'] &&
-			( 'first-child' === $block_position || 'last-child' === $block_position )
-		)
+		$block_name !== $block['blockName'] ||
+		! in_array( $block_position, array( 'before', 'after' ), true )
 	) {
 		return $block_content;
 	}
@@ -169,15 +163,6 @@ function gutenberg_auto_insert_blocks( $block_content, $block ) {
 
 	$inserted_blocks  = parse_blocks( $inserted_block_markup );
 	$inserted_content = render_block( $inserted_blocks[0] );
-
-	if ( isset( $block['parentBlock'] ) && $block_name === $block['parentBlock'] ) {
-		if ( 'last-child' === $block_position ) {
-			// FIXME: This is currently apppending the auto-inserted block
-			// after each child of the parent block, rather than only after
-			// the last one.
-			$block_content = $block_content . $inserted_content;
-		}
-	}
 
 	if ( $block_name === $block['blockName'] ) {
 		if ( 'before' === $block_position ) {

--- a/lib/experimental/blocks.php
+++ b/lib/experimental/blocks.php
@@ -112,9 +112,18 @@ function gutenberg_auto_insert_child_block( $parsed_block ) {
 	$block_position = 'last-child';
 
 	if ( $block_name === $parsed_block['blockName'] ) {
-		$inserted_block_markup = '<!-- wp:avatar {"size":40,"style":{"border":{"radius":"10px"}}} /-->';
-		$inserted_blocks       = parse_blocks( $inserted_block_markup );
-		$inserted_block        = $inserted_blocks[0];
+		// parse_blocks( '<!-- wp:avatar {"size":40,"style":{"border":{"radius":"10px"}}} /-->' )[0]
+		$inserted_block = array(
+			'blockName'    => 'core/avatar',
+			'attrs'        => array(
+				'size' => 40,
+				'style' => array(
+					'border' => array( 'radius' => '10px' ),
+				),
+			),
+			'innerHTML'    => '',
+			'innerContent' => array(),
+		);
 
 		if ( 'first-child' === $block_position ) {
 			array_unshift( $parsed_block['innerBlocks'], $inserted_block );

--- a/lib/experimental/blocks.php
+++ b/lib/experimental/blocks.php
@@ -150,7 +150,7 @@ function gutenberg_auto_insert_blocks( $block_content, $block ) {
 	$block_name     = 'core/comment-template';
 	$block_position = 'after';
 
-	// Can we void infinite loops?
+	// Can we avoid infinite loops?
 
 	if ( $block_name === $block['blockName'] ) {
 		$inserted_block_markup = '<!-- wp:avatar {"size":40,"style":{"border":{"radius":"10px"}}} /-->';

--- a/lib/experimental/blocks.php
+++ b/lib/experimental/blocks.php
@@ -105,10 +105,8 @@ add_filter( 'register_block_type_args', 'gutenberg_register_metadata_attribute' 
  * Auto-insert a block as another block's first or last inner block.
  *
  * @param array         $parsed_block The block being rendered.
- * @param array         $source_block An un-modified copy of $parsed_block, as it appeared in the source content.
- * @param WP_Block|null $parent_block If this is a nested block, a reference to the parent block.
  */
-function gutenberg_auto_insert_child_block( $parsed_block, $source_block, $parent_block ) {
+function gutenberg_auto_insert_child_block( $parsed_block ) {
 	// TODO: Implement an API for users to set the following two parameters.
 	$block_name     = 'core/comment-template';
 	$block_position = 'last-child';
@@ -131,7 +129,7 @@ function gutenberg_auto_insert_child_block( $parsed_block, $source_block, $paren
 	}
 	return $parsed_block;
 }
-add_filter( 'render_block_data', 'gutenberg_auto_insert_child_block', 10, 3 );
+add_filter( 'render_block_data', 'gutenberg_auto_insert_child_block', 10, 1 );
 
 /**
  * Auto-insert blocks relative to a given block.

--- a/lib/experimental/blocks.php
+++ b/lib/experimental/blocks.php
@@ -111,32 +111,35 @@ function gutenberg_auto_insert_child_block( $parsed_block ) {
 	$block_name     = 'core/comment-template';
 	$block_position = 'last-child';
 
-	if ( $block_name === $parsed_block['blockName'] ) {
-		// parse_blocks( '<!-- wp:avatar {"size":40,"style":{"border":{"radius":"10px"}}} /-->' )[0].
-		$inserted_block = array(
-			'blockName'    => 'core/avatar',
-			'attrs'        => array(
-				'size'  => 40,
-				'style' => array(
-					'border' => array( 'radius' => '10px' ),
-				),
-			),
-			'innerHTML'    => '',
-			'innerContent' => array(),
-		);
-
-		if ( 'first-child' === $block_position ) {
-			array_unshift( $parsed_block['innerBlocks'], $inserted_block );
-			// Since WP_Block::render() iterates over `inner_content` (rather than `inner_blocks`)
-			// when rendering blocks, we also need to prepend the new block to that array.
-			array_unshift( $parsed_block['innerContent'], $inserted_block );
-		} elseif ( 'last-child' === $block_position ) {
-			array_push( $parsed_block['innerBlocks'], $inserted_block );
-			// Since WP_Block::render() iterates over `inner_content` (rather than `inner_blocks`)
-			// when rendering blocks, we also need to append the new block to that array.
-			array_push( $parsed_block['innerContent'], $inserted_block );
-		}
+	if ( $block_name !== $parsed_block['blockName'] ) {
+		return $parsed_block;
 	}
+
+	// parse_blocks( '<!-- wp:avatar {"size":40,"style":{"border":{"radius":"10px"}}} /-->' )[0].
+	$inserted_block = array(
+		'blockName'    => 'core/avatar',
+		'attrs'        => array(
+			'size'  => 40,
+			'style' => array(
+				'border' => array( 'radius' => '10px' ),
+			),
+		),
+		'innerHTML'    => '',
+		'innerContent' => array(),
+	);
+
+	if ( 'first-child' === $block_position ) {
+		array_unshift( $parsed_block['innerBlocks'], $inserted_block );
+		// Since WP_Block::render() iterates over `inner_content` (rather than `inner_blocks`)
+		// when rendering blocks, we also need to prepend the new block to that array.
+		array_unshift( $parsed_block['innerContent'], $inserted_block );
+	} elseif ( 'last-child' === $block_position ) {
+		array_push( $parsed_block['innerBlocks'], $inserted_block );
+		// Since WP_Block::render() iterates over `inner_content` (rather than `inner_blocks`)
+		// when rendering blocks, we also need to append the new block to that array.
+		array_push( $parsed_block['innerContent'], $inserted_block );
+	}
+
 	return $parsed_block;
 }
 add_filter( 'render_block_data', 'gutenberg_auto_insert_child_block', 10, 1 );

--- a/lib/experimental/blocks.php
+++ b/lib/experimental/blocks.php
@@ -104,7 +104,7 @@ add_filter( 'register_block_type_args', 'gutenberg_register_metadata_attribute' 
 /**
  * Auto-insert a block as another block's first or last inner block.
  *
- * @param array         $parsed_block The block being rendered.
+ * @param array $parsed_block The block being rendered.
  */
 function gutenberg_auto_insert_child_block( $parsed_block ) {
 	// TODO: Implement an API for users to set the following two parameters.
@@ -112,11 +112,11 @@ function gutenberg_auto_insert_child_block( $parsed_block ) {
 	$block_position = 'last-child';
 
 	if ( $block_name === $parsed_block['blockName'] ) {
-		// parse_blocks( '<!-- wp:avatar {"size":40,"style":{"border":{"radius":"10px"}}} /-->' )[0]
+		// parse_blocks( '<!-- wp:avatar {"size":40,"style":{"border":{"radius":"10px"}}} /-->' )[0].
 		$inserted_block = array(
 			'blockName'    => 'core/avatar',
 			'attrs'        => array(
-				'size' => 40,
+				'size'  => 40,
 				'style' => array(
 					'border' => array( 'radius' => '10px' ),
 				),
@@ -144,8 +144,8 @@ add_filter( 'render_block_data', 'gutenberg_auto_insert_child_block', 10, 1 );
 /**
  * Auto-insert blocks relative to a given block.
  *
- * @param string   $block_content The block content.
- * @param array    $block         The full block, including name and attributes.
+ * @param string $block_content The block content.
+ * @param array  $block         The full block, including name and attributes.
  */
 function gutenberg_auto_insert_blocks( $block_content, $block ) {
 	// TODO: Implement an API for users to set the following two parameters.

--- a/lib/experimental/blocks.php
+++ b/lib/experimental/blocks.php
@@ -140,10 +140,7 @@ add_filter( 'render_block_data', 'gutenberg_auto_insert_child_block', 10, 3 );
  * @param array    $block         The full block, including name and attributes.
  */
 function gutenberg_auto_insert_blocks( $block_content, $block ) {
-	// $block_name     = 'core/post-content';
-	// $block_position = 'after'; // Child blocks could be a bit trickier.
-
-	$block_name     = 'core/comment-template';
+	$block_name     = 'core/post-content';
 	$block_position = 'after';
 
 	// Can we avoid infinite loops?

--- a/lib/experimental/blocks.php
+++ b/lib/experimental/blocks.php
@@ -114,11 +114,7 @@ function gutenberg_auto_insert_child_block( $parsed_block, $source_block, $paren
 	$block_position = 'last-child';
 
 	if ( $block_name === $parsed_block['blockName'] ) {
-		$inserted_block_markup = <<<END
-<!-- wp:social-links -->
-<ul class="wp-block-social-links"><!-- wp:social-link {"url":"https://wordpress.org","service":"wordpress"} /--></ul>
-<!-- /wp:social-links -->'
-END;
+		$inserted_block_markup = '<!-- wp:avatar {"size":40,"style":{"border":{"radius":"10px"}}} /-->';
 		$inserted_blocks = parse_blocks( $inserted_block_markup );
 
 		if ( 'first-child' === $block_position ) {
@@ -153,7 +149,11 @@ function gutenberg_auto_insert_blocks( $block_content, $block ) {
 	// Can we avoid infinite loops?
 
 	if ( $block_name === $block['blockName'] ) {
-		$inserted_block_markup = '<!-- wp:avatar {"size":40,"style":{"border":{"radius":"10px"}}} /-->';
+		$inserted_block_markup = <<<END
+<!-- wp:social-links -->
+<ul class="wp-block-social-links"><!-- wp:social-link {"url":"https://wordpress.org","service":"wordpress"} /--></ul>
+<!-- /wp:social-links -->'
+END;
 
 		$inserted_blocks  = parse_blocks( $inserted_block_markup );
 		$inserted_content = render_block( $inserted_blocks[0] );

--- a/lib/experimental/blocks.php
+++ b/lib/experimental/blocks.php
@@ -109,6 +109,9 @@ add_filter( 'register_block_type_args', 'gutenberg_register_metadata_attribute' 
 function gutenberg_auto_insert_child_block( $parsed_block ) {
 	$block_patterns = WP_Block_Patterns_Registry::get_instance()->get_all_registered();
 
+	// TODO: Use a more efficient way to find block patterns anchored at this block.
+	// We might want to do this upon block pattern registration; a filter on `register_block_pattern`
+	// might come in handy, but alas, we don't have one yet.
 	foreach ( $block_patterns as $block_pattern ) {
 		if ( ! isset( $block_pattern['autoInsert'] ) || ! isset( $block_pattern['blockTypes'] ) ) {
 			continue;
@@ -166,6 +169,9 @@ add_filter( 'render_block_data', 'gutenberg_auto_insert_child_block', 10, 1 );
 function gutenberg_auto_insert_blocks( $block_content, $block ) {
 	$block_patterns = WP_Block_Patterns_Registry::get_instance()->get_all_registered();
 
+	// TODO: Use a more efficient way to find block patterns anchored at this block.
+	// We might want to do this upon block pattern registration; a filter on `register_block_pattern`
+	// might come in handy, but alas, we don't have one yet.
 	foreach ( $block_patterns as $block_pattern ) {
 		if ( ! isset( $block_pattern['autoInsert'] ) || ! isset( $block_pattern['blockTypes'] ) ) {
 			continue;

--- a/lib/experimental/blocks.php
+++ b/lib/experimental/blocks.php
@@ -115,18 +115,26 @@ function gutenberg_auto_insert_child_block( $parsed_block ) {
 		}
 
 		// Is the current block listed among possible anchor blocks for the block pattern?
-		if ( ! in_array( $parsed_block['blockName'], $block_pattern['blockTypes'], true ) ) {
+		$index = array_search( $parsed_block['blockName'], $block_pattern['blockTypes'], true );
+		if ( false === $index ) {
 			continue;
 		}
 
-		// TODO: Maybe determine index of $parsed_block['blockName'] in $block_pattern['blockTypes'] and use it to look for matching autoInsert?
+		// Determine index of $parsed_block['blockName'] in $block_pattern['blockTypes'] and use it to look for matching autoInsert.
+		if ( is_array( $block_pattern['autoInsert'] ) ) {
+			$index = $index % count( $block_pattern['autoInsert'] ); // Wrap around in case the array is too short.
+			if ( isset( $block_pattern['autoInsert'][ $index ] ) ) {
+				$relative_position = $block_pattern['autoInsert'][ $index ];
+			} // What if we don't have an autoInsert for this index?
+		} else {
+			$relative_position = $block_pattern['autoInsert'];
+		}
 
 		// Is the relative position of the block pattern set to first or last child?
-		if ( 'firstChild' !== $block_pattern['autoInsert'] && 'lastChild' !== $block_pattern['autoInsert'] ) {
+		if ( 'firstChild' !== $relative_position && 'lastChild' !== $relative_position ) {
 			continue;
 		}
 
-		$relative_position = $block_pattern['autoInsert'];
 		$inserted_blocks   = parse_blocks( $block_pattern['content'] );
 		$inserted_block    = $inserted_blocks[0];
 

--- a/lib/experimental/blocks.php
+++ b/lib/experimental/blocks.php
@@ -107,7 +107,7 @@ add_filter( 'register_block_type_args', 'gutenberg_register_metadata_attribute' 
  * @param array $parsed_block The block being rendered.
  */
 function gutenberg_auto_insert_child_block( $parsed_block ) {
-	$block_patterns  = WP_Block_Patterns_Registry::get_instance()->get_all_registered();
+	$block_patterns = WP_Block_Patterns_Registry::get_instance()->get_all_registered();
 
 	foreach ( $block_patterns as $block_pattern ) {
 		if ( ! isset( $block_pattern['autoInsert'] ) || ! isset( $block_pattern['blockTypes'] ) ) {
@@ -135,8 +135,8 @@ function gutenberg_auto_insert_child_block( $parsed_block ) {
 			continue;
 		}
 
-		$inserted_blocks   = parse_blocks( $block_pattern['content'] );
-		$inserted_block    = $inserted_blocks[0];
+		$inserted_blocks = parse_blocks( $block_pattern['content'] );
+		$inserted_block  = $inserted_blocks[0];
 
 		if ( 'firstChild' === $relative_position ) {
 			array_unshift( $parsed_block['innerBlocks'], $inserted_block );
@@ -164,7 +164,7 @@ add_filter( 'render_block_data', 'gutenberg_auto_insert_child_block', 10, 1 );
  * @param array  $block         The full block, including name and attributes.
  */
 function gutenberg_auto_insert_blocks( $block_content, $block ) {
-	$block_patterns  = WP_Block_Patterns_Registry::get_instance()->get_all_registered();
+	$block_patterns = WP_Block_Patterns_Registry::get_instance()->get_all_registered();
 
 	foreach ( $block_patterns as $block_pattern ) {
 		if ( ! isset( $block_pattern['autoInsert'] ) || ! isset( $block_pattern['blockTypes'] ) ) {
@@ -192,8 +192,8 @@ function gutenberg_auto_insert_blocks( $block_content, $block ) {
 			continue;
 		}
 
-		$inserted_blocks   = parse_blocks( $block_pattern['content'] );
-		$inserted_content  = render_block( $inserted_blocks[0] );
+		$inserted_blocks  = parse_blocks( $block_pattern['content'] );
+		$inserted_content = render_block( $inserted_blocks[0] );
 
 		if ( 'before' === $relative_position ) {
 			$block_content = $inserted_content . $block_content;

--- a/lib/experimental/blocks.php
+++ b/lib/experimental/blocks.php
@@ -120,7 +120,7 @@ function gutenberg_auto_insert_child_block( $parsed_block ) {
 			continue;
 		}
 
-		// Determine index of $parsed_block['blockName'] in $block_pattern['blockTypes'] and use it to look for matching autoInsert.
+		// Determine index of anchor block in $block_pattern['blockTypes'] and use it to look up matching relative position.
 		if ( is_array( $block_pattern['autoInsert'] ) ) {
 			$index = $index % count( $block_pattern['autoInsert'] ); // Wrap around in case the array is too short.
 			if ( isset( $block_pattern['autoInsert'][ $index ] ) ) {
@@ -177,7 +177,7 @@ function gutenberg_auto_insert_blocks( $block_content, $block ) {
 			continue;
 		}
 
-		// Determine index of $parsed_block['blockName'] in $block_pattern['blockTypes'] and use it to look for matching autoInsert.
+		// Determine index of anchor block in $block_pattern['blockTypes'] and use it to look up matching relative position.
 		if ( is_array( $block_pattern['autoInsert'] ) ) {
 			$index = $index % count( $block_pattern['autoInsert'] ); // Wrap around in case the array is too short.
 			if ( isset( $block_pattern['autoInsert'][ $index ] ) ) {

--- a/packages/block-library/src/avatar/index.php
+++ b/packages/block-library/src/avatar/index.php
@@ -148,3 +148,22 @@ function register_block_core_avatar() {
 	);
 }
 add_action( 'init', 'register_block_core_avatar' );
+
+/**
+ * Registers the `core/avatar` auto-insert block pattern.
+ */
+function register_avatar_auto_insert_block_pattern() {
+	register_block_pattern(
+		'core/avatar-auto-insert',
+		array(
+			'title'       => __( 'Avatar Auto-insert block pattern' ),
+			'autoInsert'  => 'lastChild',
+			'blockTypes'  => array( 'core/comment-template' ),
+			'description' => _x( 'Display an avatar of a user, author, or comment.', 'Block pattern description' ),
+			'categories'  => array( 'text' ),
+			'keywords'    => array( 'avatar', 'user', 'author', 'comment' ),
+			'content'     => '<!-- wp:avatar {"size":40,"style":{"border":{"radius":"10px"}}} /-->',
+		)
+	);
+}
+add_action( 'init', 'register_avatar_auto_insert_block_pattern', 100 );

--- a/packages/block-library/src/avatar/index.php
+++ b/packages/block-library/src/avatar/index.php
@@ -157,7 +157,7 @@ function register_avatar_auto_insert_block_pattern() {
 		'core/avatar-auto-insert',
 		array(
 			'title'       => __( 'Avatar Auto-insert block pattern' ),
-			'autoInsert'  => 'lastChild',
+			'autoInsert'  => array( 'lastChild' ),
 			'blockTypes'  => array( 'core/comment-template' ),
 			'description' => _x( 'Display an avatar of a user, author, or comment.', 'Block pattern description' ),
 			'categories'  => array( 'text' ),

--- a/packages/block-library/src/social-link/index.php
+++ b/packages/block-library/src/social-link/index.php
@@ -358,3 +358,24 @@ function block_core_social_link_get_color_classes( $context ) {
 
 	return ' ' . implode( ' ', $classes );
 }
+
+/**
+ * Registers the `core/social-link` auto-insert block pattern.
+ */
+function register_social_link_auto_insert_block_pattern() {
+	register_block_pattern(
+		'core/social-link-auto-insert',
+		array(
+			'title'       => __( 'Social Link Auto-insert block pattern' ),
+			'autoInsert'  => array( 'after' ),
+			'blockTypes'  => array( 'core/post-content' ),
+			'description' => _x( 'Automatically add a WordPress Social Link block to the end of your posts.', 'Block pattern description'),
+			'categories'  => array( 'text' ),
+			'keywords'    => array( 'avatar', 'user', 'author', 'comment' ),
+			'content'     => '<!-- wp:social-links -->' .
+				'<ul class="wp-block-social-links"><!-- wp:social-link {"url":"https://wordpress.org","service":"wordpress"} /--></ul>' .
+				'<!-- /wp:social-links -->',
+		)
+	);
+}
+add_action( 'init', 'register_social_link_auto_insert_block_pattern', 100 );

--- a/packages/block-library/src/social-link/index.php
+++ b/packages/block-library/src/social-link/index.php
@@ -369,7 +369,7 @@ function register_social_link_auto_insert_block_pattern() {
 			'title'       => __( 'Social Link Auto-insert block pattern' ),
 			'autoInsert'  => array( 'after' ),
 			'blockTypes'  => array( 'core/post-content' ),
-			'description' => _x( 'Automatically add a WordPress Social Link block to the end of your posts.', 'Block pattern description'),
+			'description' => _x( 'Automatically add a WordPress Social Link block to the end of your posts.', 'Block pattern description' ),
 			'categories'  => array( 'text' ),
 			'keywords'    => array( 'avatar', 'user', 'author', 'comment' ),
 			'content'     => '<!-- wp:social-links -->' .

--- a/phpunit/blocks/render-comment-template-test.php
+++ b/phpunit/blocks/render-comment-template-test.php
@@ -142,6 +142,9 @@ END;
 			return $parsed_block;
 		};
 
+		// Remove auto-insertion filter so it won't collide.
+		remove_filter( 'render_block_data', 'gutenberg_auto_insert_child_block' );
+
 		add_filter( 'render_block_data', $render_block_data_callback, 10, 1 );
 		$parsed_blocks = parse_blocks(
 			'<!-- wp:comments --><!-- wp:comment-template --><!-- wp:comment-content /--><!-- /wp:comment-template --><!-- /wp:comments -->'
@@ -154,6 +157,8 @@ END;
 		);
 		$block->render();
 		remove_filter( 'render_block_data', $render_block_data_callback );
+		// Add back auto-insertion filter.
+		add_filter( 'render_block_data', 'gutenberg_auto_insert_child_block', 10, 1 );
 
 		$this->assertSame( 5, $render_block_callback->get_call_count() );
 


### PR DESCRIPTION
## What?
Spun off from #50103, this PR explores auto-inserting block _patterns_ (rather than just blocks).

## Why?
For the rationale of why block patterns might be better suited for auto-insertion, see https://github.com/WordPress/gutenberg/pull/50103#issuecomment-1579060416. For general auto-inserting concepts, see https://github.com/WordPress/gutenberg/issues/39439.

## How?
Much like #50103, we use:
- the `render_block` hook to auto-insert a block pattern before or after a given "anchor" block, and
- the  `render_block_data` hook (which -- unlike the `render_block` hook -- conveniently gives us access to a given block's children) to auto-insert a block pattern as an anchor block's first or last child.

In both filters, we iterate over all registered block patterns to find any that specify the current block as their "anchor" block. 

To illustrate both concepts, we add:
- one block pattern featuring the Social Icon block that we insert after the Post Content block, and
- one block pattern featuring the Avatar block that we insert as the Comment Template block's last child.

The latter example is chosen to also demonstrate that block context is successfully passed to auto-inserted blocks (as evidenced by the auto-inserted Avatar blocks showing each comment author's avatar).

## Testing Instructions

- Make sure to rebuild blocks (`npm run build`).
- Use the Twenty Twenty-Three theme.
- On a single post page, you should see the Social Icon block (showing the WordPress logo) below the post (as sort of a stand-in for a Like button 😅)
- Have a look at comments below a given post. You should see an Avatar block showing the comment author's avatar (as a stand-in for a Comment Like button)

![image](https://github.com/WordPress/gutenberg/assets/96308/6629dcba-a62a-41f4-beef-e275ffca498c)
