### PR TITLE
Allow disabling focus every time a page is switched in Guide component

### DIFF
--- a/packages/components/src/guide/index.tsx
+++ b/packages/components/src/guide/index.tsx
@@ -58,6 +58,7 @@ function Guide( {
 	finishButtonText = __( 'Finish' ),
 	onFinish,
 	pages = [],
+	focusOnPageChange = true,
 }: GuideProps ) {
 	const guideContainer = useRef< HTMLDivElement >( null );
 	const [ currentPage, setCurrentPage ] = useState( 0 );
@@ -74,12 +75,12 @@ function Guide( {
 	useEffect( () => {
 		// Each time we change the current page, start from the first element of the page.
 		// This also solves any focus loss that can happen.
-		if ( guideContainer.current ) {
+		if ( guideContainer.current && focusOnPageChange ) {
 			(
 				focus.tabbable.find( guideContainer.current ) as HTMLElement[]
 			 )[ 0 ]?.focus();
 		}
-	}, [ currentPage ] );
+	}, [ currentPage, focusOnPageChange ] );
 
 	if ( Children.count( children ) ) {
 		pages =

--- a/packages/components/src/guide/types.ts
+++ b/packages/components/src/guide/types.ts
@@ -50,6 +50,12 @@ export type GuideProps = {
 	 * @default []
 	 */
 	pages?: Page[];
+	/**
+	 * Used to control if the component re-focuses on the page content when the page changes.
+	 *
+	 * @default true
+	 */
+	focusOnPageChange?: boolean;
 };
 
 export type PageControlProps = {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Allow disabling focus every time a page is switched in Guide component

Fixes #51243.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

There are scenarios where it is not needed, and it's causing the Close button tooltip to appear every time the page switches.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Add a new prop to allow bypassing the effect of re-focusing every time the page changes.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Open storybook by running `npm run storybook:dev`
2. Go to Guide component
3. In the Controls tab, set `focusOnPageChange` to false
4. Click 'Open guide'
5. Navigate between pages by pressing the dots and by pressing Previous and next buttons
6. Verify that the 'Close' button does not focus every time the page switches.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
Ths same steps described above can be executed only with the keyboard.

## Screenshots or screencast <!-- if applicable -->
