### PR TITLE
Add missing tests for image block

### DIFF
--- a/test/e2e/specs/editor/blocks/image.spec.js
+++ b/test/e2e/specs/editor/blocks/image.spec.js
@@ -782,6 +782,45 @@ test.describe( 'Image', () => {
 		await expect( imageDom ).toBeVisible();
 		await expect( imageDom ).toHaveAttribute( 'src', imgUrl );
 	} );
+
+	test( 'adding a link should reflect configuration in published post content', async ( {
+		editor,
+		page,
+		imageBlockUtils,
+	} ) => {
+		await editor.insertBlock( { name: 'core/image' } );
+		const imageBlock = editor.canvas.locator(
+			'role=document[name="Block: Image"i]'
+		);
+		await expect( imageBlock ).toBeVisible();
+
+		await imageBlockUtils.upload(
+			imageBlock.locator( 'data-testid=form-file-upload-input' )
+		);
+
+		await page
+			.getByLabel( 'Block tools' )
+			.getByLabel( 'Insert link' )
+			.click();
+
+		const form = page.locator( '.block-editor-url-popover__link-editor' );
+
+		const url = 'https://wordpress.org';
+
+		await form.getByLabel( 'URL' ).fill( url );
+
+		await form.getByRole( 'button', { name: 'Apply' } ).click();
+
+		const postId = await editor.publishPost();
+		await page.goto( `/?p=${ postId }` );
+
+		const figureDom = page.getByRole( 'figure' );
+		await expect( figureDom ).toBeVisible();
+
+		const linkDom = figureDom.locator( 'a' );
+		await expect( linkDom ).toBeVisible();
+		await expect( linkDom ).toHaveAttribute( 'href', url );
+	} );
 } );
 
 test.describe( 'Image - interactivity', () => {

--- a/test/e2e/specs/editor/blocks/image.spec.js
+++ b/test/e2e/specs/editor/blocks/image.spec.js
@@ -972,7 +972,6 @@ test.describe( 'Image - interactivity', () => {
 			} );
 			await behaviorSelect.selectOption( 'lightbox' );
 
-			//await imageBlock.click();
 			await page
 				.getByLabel( 'Block tools' )
 				.getByLabel( 'Insert link' )

--- a/test/e2e/specs/editor/blocks/image.spec.js
+++ b/test/e2e/specs/editor/blocks/image.spec.js
@@ -991,6 +991,7 @@ test.describe( 'Image - interactivity', () => {
 			const postId = await editor.publishPost();
 			await page.goto( `/?p=${ postId }` );
 
+			// The lightbox overlay should not appear in the DOM at all
 			expect(
 				await page.locator( '.wp-lightbox-overlay' ).count()
 			).toEqual( 0 );

--- a/test/e2e/specs/editor/blocks/image.spec.js
+++ b/test/e2e/specs/editor/blocks/image.spec.js
@@ -991,10 +991,10 @@ test.describe( 'Image - interactivity', () => {
 			const postId = await editor.publishPost();
 			await page.goto( `/?p=${ postId }` );
 
-			// The lightbox overlay should not appear in the DOM at all
-			expect(
-				await page.locator( '.wp-lightbox-overlay' ).count()
-			).toEqual( 0 );
+			// The lightbox markup should not appear in the DOM at all
+			await expect(
+				page.getByRole( 'button', { name: 'Enlarge image' } )
+			).not.toBeInViewport();
 		} );
 
 		test.describe( 'keyboard navigation', () => {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
A follow up to #51278, this adds a test to ensure that the experimental lightbox works as expected when inserting an image from URL.

It also adds other missing checks:
- Inserting an image via URL works and renders the image appropriately on the frontend
- Adding a link to an image will work as expected
- When a lightbox is configured, an image src should only load when the lightbox is opened
- Adding a link to an image will override the lightbox

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
This will help us ensure the image default behavior, as well as lightbox, perform as expected.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
N/A

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
Run the tests locally using `npm run test:e2e:playwright -- image.spec.js`

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
N/A
