### PR TITLE
Query: Fix deprecation error when migrating layout

### DIFF
--- a/packages/block-library/src/query/deprecated.js
+++ b/packages/block-library/src/query/deprecated.js
@@ -143,6 +143,8 @@ const migrateToConstrainedLayout = ( attributes ) => {
 			},
 		};
 	}
+
+	return attributes;
 };
 
 const findPostTemplateBlock = ( innerBlocks = [] ) => {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes #51308

Fix an editor crash when some deprecated markup for Query block, containing a constrained layout object, is migrated.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

In `migrateToConstrainedLayout` we need to return `attributes` for blocks that have layout but don't need to be migrated. This is because the return of this function will later be used in `migrateDisplayLayout` so if the value is `undefined`, an error will be thrown.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* Ensure `migrateToConstrainedLayout` always returns an attributes object.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

In the code editor, copy + paste the following deprecated markup:

```
<!-- wp:query {"queryId":2,"query":{"perPage":3,"pages":0,"offset":0,"categoryIds":[],"tagIds":[],"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false,"taxQuery":{"category":[1]}},"layout":{"type":"constrained"}} -->
<div class="wp-block-query"><!-- wp:post-template -->
<!-- wp:post-featured-image /-->

<!-- wp:post-date /-->

<!-- wp:post-title /-->
<!-- /wp:post-template -->

<!-- wp:query-pagination -->
<!-- wp:query-pagination-previous /-->

<!-- wp:query-pagination-numbers /-->

<!-- wp:query-pagination-next /-->
<!-- /wp:query-pagination -->

<!-- wp:query-no-results -->
<!-- wp:paragraph {"placeholder":"Add text or blocks that will display when a query returns no results."} -->
<p></p>
<!-- /wp:paragraph -->
<!-- /wp:query-no-results --></div>
<!-- /wp:query -->
```

* Without this PR applied, the editor will crash
* With this PR applied, switch to the visual editor view, and the block should function correctly
* Double-check that this change doesn't adversely affect anything else

## Screenshots or screencast <!-- if applicable -->

| Before | After |
| --- | --- |
| ![2023-06-08 10 54 35](https://github.com/WordPress/gutenberg/assets/14988353/a764054d-4bbb-40c2-818e-612f88685560) | ![2023-06-08 10 55 31](https://github.com/WordPress/gutenberg/assets/14988353/b64f37a0-7668-42a9-b455-dd6ec5e1667d) |