### PR TITLE
[Block Theme Previews] Change the URL query string for more safety

### DIFF
--- a/lib/compat/wordpress-6.3/theme-previews.php
+++ b/lib/compat/wordpress-6.3/theme-previews.php
@@ -17,7 +17,7 @@ function gutenberg_get_theme_preview_path( $current_stylesheet = null ) {
 		return $current_stylesheet;
 	}
 
-	$preview_stylesheet = ! empty( $_GET['theme_preview'] ) ? $_GET['theme_preview'] : null;
+	$preview_stylesheet = ! empty( $_GET['gutenberg_theme_preview'] ) ? $_GET['gutenberg_theme_preview'] : null;
 	$wp_theme           = wp_get_theme( $preview_stylesheet );
 	if ( ! is_wp_error( $wp_theme->errors() ) ) {
 		if ( current_filter() === 'template' ) {
@@ -45,7 +45,7 @@ function gutenberg_attach_theme_preview_middleware() {
 		'wp-api-fetch',
 		sprintf(
 			'wp.apiFetch.use( wp.apiFetch.createThemePreviewMiddleware( %s ) );',
-			wp_json_encode( sanitize_text_field( $_GET['theme_preview'] ) )
+			wp_json_encode( sanitize_text_field( $_GET['gutenberg_theme_preview'] ) )
 		),
 		'after'
 	);
@@ -88,7 +88,7 @@ function add_live_preview_button() {
 			livePreviewButton.setAttribute('class', 'button button-primary');
 			livePreviewButton.setAttribute(
 				'href',
-				`/wp-admin/site-editor.php?theme_preview=${themePath}&return=themes.php`
+				`/wp-admin/site-editor.php?gutenberg_theme_preview=${themePath}&return=themes.php`
 			);
 			livePreviewButton.innerHTML = '<?php echo esc_html_e( 'Live Preview' ); ?>';
 			themeInfo.querySelector('.theme-actions').appendChild(livePreviewButton);
@@ -118,7 +118,7 @@ if ( $gutenberg_experiments && array_key_exists( 'gutenberg-theme-previews', $gu
 	/**
 	 * Attaches filters to enable theme previews in the Site Editor.
 	 */
-	if ( ! empty( $_GET['theme_preview'] ) ) {
+	if ( ! empty( $_GET['gutenberg_theme_preview'] ) ) {
 		add_filter( 'stylesheet', 'gutenberg_get_theme_preview_path' );
 		add_filter( 'template', 'gutenberg_get_theme_preview_path' );
 		add_filter( 'init', 'gutenberg_attach_theme_preview_middleware' );

--- a/packages/api-fetch/src/middlewares/theme-preview.js
+++ b/packages/api-fetch/src/middlewares/theme-preview.js
@@ -4,7 +4,7 @@
 import { addQueryArgs, hasQueryArg } from '@wordpress/url';
 
 /**
- * This appends a `theme_preview` parameter to the REST API request URL if
+ * This appends a `gutenberg_theme_preview` parameter to the REST API request URL if
  * the admin URL contains a `theme` GET parameter.
  *
  * @param {Record<string, any>} themePath
@@ -13,19 +13,19 @@ import { addQueryArgs, hasQueryArg } from '@wordpress/url';
 const createThemePreviewMiddleware = ( themePath ) => ( options, next ) => {
 	if (
 		typeof options.url === 'string' &&
-		! hasQueryArg( options.url, 'theme_preview' )
+		! hasQueryArg( options.url, 'gutenberg_theme_preview' )
 	) {
 		options.url = addQueryArgs( options.url, {
-			theme_preview: themePath,
+			gutenberg_theme_preview: themePath,
 		} );
 	}
 
 	if (
 		typeof options.path === 'string' &&
-		! hasQueryArg( options.path, 'theme_preview' )
+		! hasQueryArg( options.path, 'gutenberg_theme_preview' )
 	) {
 		options.path = addQueryArgs( options.path, {
-			theme_preview: themePath,
+			gutenberg_theme_preview: themePath,
 		} );
 	}
 

--- a/packages/edit-site/src/components/routes/link.js
+++ b/packages/edit-site/src/components/routes/link.js
@@ -37,7 +37,7 @@ export function useLink( params = {}, state, shouldReplace = false ) {
 	if ( isPreviewingTheme() ) {
 		params = {
 			...params,
-			theme_preview: currentlyPreviewingTheme(),
+			gutenberg_theme_preview: currentlyPreviewingTheme(),
 		};
 	}
 

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/index.js
@@ -100,7 +100,7 @@ function NavigationMenuEditor( { navigationMenu } ) {
 					postType: attributes.type,
 					postId: attributes.id,
 					...( isPreviewingTheme() && {
-						theme_preview: currentlyPreviewingTheme(),
+						gutenberg_theme_preview: currentlyPreviewingTheme(),
 					} ),
 				} );
 			}
@@ -109,7 +109,7 @@ function NavigationMenuEditor( { navigationMenu } ) {
 					postType: 'page',
 					postId: attributes.id,
 					...( isPreviewingTheme() && {
-						theme_preview: currentlyPreviewingTheme(),
+						gutenberg_theme_preview: currentlyPreviewingTheme(),
 					} ),
 				} );
 			}

--- a/packages/edit-site/src/utils/is-previewing-theme.js
+++ b/packages/edit-site/src/utils/is-previewing-theme.js
@@ -4,12 +4,15 @@
 import { getQueryArg } from '@wordpress/url';
 
 export function isPreviewingTheme() {
-	return getQueryArg( window.location.href, 'theme_preview' ) !== undefined;
+	return (
+		getQueryArg( window.location.href, 'gutenberg_theme_preview' ) !==
+		undefined
+	);
 }
 
 export function currentlyPreviewingTheme() {
 	if ( isPreviewingTheme() ) {
-		return getQueryArg( window.location.href, 'theme_preview' );
+		return getQueryArg( window.location.href, 'gutenberg_theme_preview' );
 	}
 	return null;
 }

--- a/packages/edit-site/src/utils/use-activate-theme.js
+++ b/packages/edit-site/src/utils/use-activate-theme.js
@@ -31,7 +31,8 @@ export function useActivateTheme() {
 				'&_wpnonce=' +
 				window.BLOCK_THEME_ACTIVATE_NONCE;
 			await window.fetch( activationURL );
-			const { theme_preview: themePreview, ...params } = location.params;
+			const { gutenberg_theme_preview: themePreview, ...params } =
+				location.params;
 			history.replace( params );
 		}
 	};


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Changed the URL query string name to trigger Block Theme Previews (from `?theme_preview` to `?gutenberg_theme_preview`).

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The original URL query string had a wide impact in terms of WordPress context. (e.g. WordPress.com is using `$_GET['theme_preview']` as well). c.f. https://github.com/WordPress/gutenberg/pull/50983#issuecomment-1569353342

<!-- 
## How?
How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

- Go to `/wp-admin/themes.php`
- Click the `Live Preview` button on a theme installed

or

- Open the Site Editor and add the following to your URL: ?gutenberg_theme_preview=[themePath] where themePath is the relative path to the theme you want to preview (e.g. twentytwentythree).

## Screenshots or screencast <!-- if applicable -->


https://github.com/WordPress/gutenberg/assets/5287479/9009bc4b-cf25-41b4-955d-1e8a9cc860bd

