### PR TITLE
Global styles revisions: ensure redirect runs once for back button 

### DIFF
--- a/packages/edit-site/src/components/global-styles/ui.js
+++ b/packages/edit-site/src/components/global-styles/ui.js
@@ -261,7 +261,9 @@ function GlobalStylesEditorCanvasContainerLink() {
 			// redirect from the revisions screen to the root global styles screen.
 			goTo( '/' );
 		}
-	}, [ editorCanvasContainerView, location?.path, goTo ] );
+		// location?.path is not a dependency because we don't want to track it.
+		// Doing so will cause an infinite loop.
+	}, [ editorCanvasContainerView, goTo ] );
 }
 
 function GlobalStylesUI() {

--- a/packages/edit-site/src/components/global-styles/ui.js
+++ b/packages/edit-site/src/components/global-styles/ui.js
@@ -262,7 +262,9 @@ function GlobalStylesEditorCanvasContainerLink() {
 			goTo( '/' );
 		}
 		// location?.path is not a dependency because we don't want to track it.
-		// Doing so will cause an infinite loop.
+		// Doing so will cause an infinite loop. We could abstract logic to avoid
+		// having to disable the check later.
+		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [ editorCanvasContainerView, goTo ] );
 }
 


### PR DESCRIPTION
## What?

I can't click the back button on the global styles revisions panel!
![2023-06-08 15 00 54](https://github.com/WordPress/gutenberg/assets/6458278/36a3115e-f40c-4b61-a231-3c565ce0559d)


## Why?

The `useEffect` callback in [GlobalStylesEditorCanvasContainerLink](https://github.com/WordPress/gutenberg/blob/9a23fb29f7630c654981ee67bcaec8e282b1e23f/packages/edit-site/src/components/global-styles/ui.js#L252-L252) is triggered every time `location?.path` changes. So when the path changes and `editorCanvasContainerView === 'global-styles-revisions'` is already `true` it'll try to execute `goTo( '/revisions' )` again. Woot!

## How?

Removing `location?.path` from the dependency to avoid infinite loop and to ensure the internal functions are run once, and as intended

## Testing Instructions
1. Head over to the site editor and make save a few changes to global styles
2. Open the Revisions panel from the drop down
3. Now click back. You should land on the main styles panel.
4. Ensure that the test steps in https://github.com/WordPress/gutenberg/pull/51149 still work.
