### PR TITLE
Fix invalid Spacer markup when set to fill

### DIFF
--- a/packages/block-library/src/spacer/edit.js
+++ b/packages/block-library/src/spacer/edit.js
@@ -277,13 +277,14 @@ const SpacerEdit = ( {
 					getCustomValueFromPreset( height, spacingSizes ) ||
 					getCustomValueFromPreset( width, spacingSizes ) ||
 					'100px';
+				const nonZeroNewSize = newSize === '0px' ? '100px' : newSize;
 				setAttributes( {
 					height: '0px',
 					style: {
 						...blockStyle,
 						layout: {
 							...layout,
-							flexSize: newSize,
+							flexSize: nonZeroNewSize,
 							selfStretch: 'fixed',
 						},
 					},
@@ -299,7 +300,8 @@ const SpacerEdit = ( {
 				} );
 			} else {
 				setAttributes( {
-					height: undefined,
+					// The height value is required for block validation.
+					height: '0px',
 				} );
 			}
 		} else if ( ! isFlexLayout && ( selfStretch || flexSize ) ) {

--- a/packages/block-library/src/spacer/edit.js
+++ b/packages/block-library/src/spacer/edit.js
@@ -277,14 +277,13 @@ const SpacerEdit = ( {
 					getCustomValueFromPreset( height, spacingSizes ) ||
 					getCustomValueFromPreset( width, spacingSizes ) ||
 					'100px';
-				const nonZeroNewSize = newSize === '0px' ? '100px' : newSize;
 				setAttributes( {
 					height: '0px',
 					style: {
 						...blockStyle,
 						layout: {
 							...layout,
-							flexSize: nonZeroNewSize,
+							flexSize: newSize,
 							selfStretch: 'fixed',
 						},
 					},
@@ -300,8 +299,7 @@ const SpacerEdit = ( {
 				} );
 			} else {
 				setAttributes( {
-					// The height value is required for block validation.
-					height: '0px',
+					height: undefined,
 				} );
 			}
 		} else if ( ! isFlexLayout && ( selfStretch || flexSize ) ) {

--- a/packages/block-library/src/spacer/save.js
+++ b/packages/block-library/src/spacer/save.js
@@ -3,12 +3,17 @@
  */
 import { useBlockProps, getSpacingPresetCssVar } from '@wordpress/block-editor';
 
-export default function save( { attributes: { height, width } } ) {
+export default function save( { attributes } ) {
+	const { height, width, style } = attributes;
+	const { layout: { selfStretch } = {} } = style || {};
+	// If self-stretch is set to fill, avoid setting default height.
+	const finalHeight =
+		selfStretch === 'fill' || selfStretch === 'fit' ? undefined : height;
 	return (
 		<div
 			{ ...useBlockProps.save( {
 				style: {
-					height: getSpacingPresetCssVar( height ),
+					height: getSpacingPresetCssVar( finalHeight ),
 					width: getSpacingPresetCssVar( width ),
 				},
 				'aria-hidden': true,

--- a/packages/block-library/src/spacer/save.js
+++ b/packages/block-library/src/spacer/save.js
@@ -6,7 +6,7 @@ import { useBlockProps, getSpacingPresetCssVar } from '@wordpress/block-editor';
 export default function save( { attributes } ) {
 	const { height, width, style } = attributes;
 	const { layout: { selfStretch } = {} } = style || {};
-	// If self-stretch is set to fill, avoid setting default height.
+	// If selfStretch is set to 'fill' or 'fit', don't set default height.
 	const finalHeight =
 		selfStretch === 'fill' || selfStretch === 'fit' ? undefined : height;
 	return (


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes #51235.

When spacer block is in vertical mode, inside a flex container (e.g a Stack block) and set to "fill" or "fit", the block markup is flagged as invalid due to a missing height attribute. This fixes the issue by making sure the default height value doesn't automatically get added in the save function if the block is in a flex container and set to "fit" or "fill".


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Paste the markup from [this comment](https://github.com/WordPress/gutenberg/issues/51235#issuecomment-1579284684) in the block editor;
2. There should be no invalid block warnings.
3. Try adding a Spacer to the page outside of any flex block: it should still get the default 100px height.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
