### PR TITLE
Global styles: split styles menus in revisions and everything else

### DIFF
--- a/packages/edit-site/CHANGELOG.md
+++ b/packages/edit-site/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Enhancements
 -   Site editor sidebar: add home template details and controls [#51223](https://github.com/WordPress/gutenberg/pull/51223).
 -   Site editor sidebar: add footer to template part and ensure nested template areas display [#51669](https://github.com/WordPress/gutenberg/pull/51669).
+-   Global styles: split styles menus into revisions and other styles actions ([#51318](https://github.com/WordPress/gutenberg/pull/51318)).
 
 ## 5.12.0 (2023-06-07)
 

--- a/packages/edit-site/src/components/global-styles/style.scss
+++ b/packages/edit-site/src/components/global-styles/style.scss
@@ -179,3 +179,14 @@
 .edit-site-global-styles-sidebar__panel .block-editor-block-icon svg {
 	fill: currentColor;
 }
+
+[class][class].edit-site-global-styles-sidebar__revisions-count-badge {
+	align-items: center;
+	background: $gray-800;
+	border-radius: 2px;
+	color: $white;
+	display: inline-flex;
+	justify-content: center;
+	min-height: $icon-size;
+	min-width: $icon-size;
+}

--- a/packages/edit-site/src/components/global-styles/ui.js
+++ b/packages/edit-site/src/components/global-styles/ui.js
@@ -80,10 +80,7 @@ function GlobalStylesActionMenu() {
 
 	return (
 		<GlobalStylesMenuFill>
-			<DropdownMenu
-				icon={ moreVertical }
-				label={ __( 'Styles actions' ) }
-			>
+			<DropdownMenu icon={ moreVertical } label={ __( 'Actions' ) }>
 				{ () => (
 					<MenuGroup>
 						{ canEditCSS && (
@@ -147,10 +144,7 @@ function GlobalStylesRevisionsMenu() {
 
 	return (
 		<GlobalStylesMenuFill>
-			<DropdownMenu
-				icon={ backup }
-				label={ __( 'Styles revisions actions' ) }
-			>
+			<DropdownMenu icon={ backup } label={ __( 'Revisions' ) }>
 				{ () => (
 					<MenuGroup>
 						{ hasRevisions && (

--- a/packages/edit-site/src/components/global-styles/ui.js
+++ b/packages/edit-site/src/components/global-styles/ui.js
@@ -23,7 +23,7 @@ import {
 } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
 import { store as preferencesStore } from '@wordpress/preferences';
-import { backup, code, lifesaver, moreVertical } from '@wordpress/icons';
+import { code, lifesaver, moreVertical } from '@wordpress/icons';
 import { store as coreStore } from '@wordpress/core-data';
 import { useEffect } from '@wordpress/element';
 
@@ -52,57 +52,6 @@ const SLOT_FILL_NAME = 'GlobalStylesMenu';
 const { Slot: GlobalStylesMenuSlot, Fill: GlobalStylesMenuFill } =
 	createSlotFill( SLOT_FILL_NAME );
 
-function GlobalStylesActionMenu() {
-	const { toggle } = useDispatch( preferencesStore );
-	const { setIsListViewOpened } = useDispatch( editSiteStore );
-	const { canEditCSS } = useSelect( ( select ) => {
-		const { getEntityRecord, __experimentalGetCurrentGlobalStylesId } =
-			select( coreStore );
-
-		const globalStylesId = __experimentalGetCurrentGlobalStylesId();
-		const globalStyles = globalStylesId
-			? getEntityRecord( 'root', 'globalStyles', globalStylesId )
-			: undefined;
-
-		return {
-			canEditCSS:
-				!! globalStyles?._links?.[ 'wp:action-edit-css' ] ?? false,
-		};
-	}, [] );
-	const { goTo } = useNavigator();
-	const loadCustomCSS = () => goTo( '/css' );
-	const loadRevisions = () => {
-		setIsListViewOpened( false );
-		goTo( '/revisions' );
-		setEditorCanvasContainerView( 'global-styles-revisions' );
-	};
-	const hasRevisions = revisionsCount >= 2;
-
-	return (
-		<GlobalStylesMenuFill>
-			<DropdownMenu icon={ moreVertical } label={ __( 'Actions' ) }>
-				{ () => (
-					<MenuGroup>
-						{ canEditCSS && (
-							<MenuItem onClick={ loadCustomCSS } icon={ code }>
-								{ __( 'Additional CSS' ) }
-							</MenuItem>
-						) }
-						<MenuItem
-							icon={ lifesaver }
-							onClick={ () =>
-								toggle( 'core/edit-site', 'welcomeGuideStyles' )
-							}
-						>
-							{ __( 'Welcome Guide' ) }
-						</MenuItem>
-					</MenuGroup>
-				) }
-			</DropdownMenu>
-		</GlobalStylesMenuFill>
-	);
-}
-
 function RevisionsCountBadge( { className, children } ) {
 	return (
 		<span
@@ -115,8 +64,11 @@ function RevisionsCountBadge( { className, children } ) {
 		</span>
 	);
 }
-function GlobalStylesRevisionsMenu() {
-	const { revisionsCount } = useSelect( ( select ) => {
+
+function GlobalStylesActionMenu() {
+	const { toggle } = useDispatch( preferencesStore );
+	const { setIsListViewOpened } = useDispatch( editSiteStore );
+	const { canEditCSS, revisionsCount } = useSelect( ( select ) => {
 		const { getEntityRecord, __experimentalGetCurrentGlobalStylesId } =
 			select( coreStore );
 
@@ -126,6 +78,8 @@ function GlobalStylesRevisionsMenu() {
 			: undefined;
 
 		return {
+			canEditCSS:
+				!! globalStyles?._links?.[ 'wp:action-edit-css' ] ?? false,
 			revisionsCount:
 				globalStyles?._links?.[ 'version-history' ]?.[ 0 ]?.count ?? 0,
 		};
@@ -137,32 +91,63 @@ function GlobalStylesRevisionsMenu() {
 		useDispatch( editSiteStore )
 	);
 	const loadRevisions = () => {
+		setIsListViewOpened( false );
 		goTo( '/revisions' );
 		setEditorCanvasContainerView( 'global-styles-revisions' );
 	};
 	const hasRevisions = revisionsCount >= 2;
+	const loadCustomCSS = () => goTo( '/css' );
 
 	return (
 		<GlobalStylesMenuFill>
-			<DropdownMenu icon={ backup } label={ __( 'Revisions' ) }>
+			<DropdownMenu
+				icon={ moreVertical }
+				label={ __( 'Styles actions' ) }
+			>
 				{ () => (
-					<MenuGroup>
-						{ hasRevisions && (
+					<>
+						<MenuGroup label={ __( 'Tools' ) }>
+							{ canEditCSS && (
+								<MenuItem
+									onClick={ loadCustomCSS }
+									icon={ code }
+								>
+									{ __( 'Additional CSS' ) }
+								</MenuItem>
+							) }
 							<MenuItem
-								onClick={ loadRevisions }
-								icon={
-									<RevisionsCountBadge>
-										{ revisionsCount }
-									</RevisionsCountBadge>
+								icon={ lifesaver }
+								onClick={ () =>
+									toggle(
+										'core/edit-site',
+										'welcomeGuideStyles'
+									)
 								}
 							>
-								{ __( 'Revision history' ) }
+								{ __( 'Welcome Guide' ) }
 							</MenuItem>
-						) }
-						<MenuItem onClick={ onReset } disabled={ ! canReset }>
-							{ __( 'Reset to defaults' ) }
-						</MenuItem>
-					</MenuGroup>
+						</MenuGroup>
+						<MenuGroup label={ __( 'Revisions' ) }>
+							{ hasRevisions && (
+								<MenuItem
+									onClick={ loadRevisions }
+									icon={
+										<RevisionsCountBadge>
+											{ revisionsCount }
+										</RevisionsCountBadge>
+									}
+								>
+									{ __( 'Revision history' ) }
+								</MenuItem>
+							) }
+							<MenuItem
+								onClick={ onReset }
+								disabled={ ! canReset }
+							>
+								{ __( 'Reset to defaults' ) }
+							</MenuItem>
+						</MenuGroup>
+					</>
 				) }
 			</DropdownMenu>
 		</GlobalStylesMenuFill>
@@ -402,7 +387,6 @@ function GlobalStylesUI() {
 				<GlobalStylesStyleBook />
 			) }
 
-			<GlobalStylesRevisionsMenu />
 			<GlobalStylesActionMenu />
 			<GlobalStylesBlockLink />
 			<GlobalStylesEditorCanvasContainerLink />

--- a/packages/edit-site/src/components/global-styles/ui.js
+++ b/packages/edit-site/src/components/global-styles/ui.js
@@ -74,7 +74,7 @@ function GlobalStylesActionMenu() {
 	return (
 		<GlobalStylesMenuFill>
 			<DropdownMenu icon={ moreVertical } label={ __( 'More' ) }>
-				{ () => (
+				{ ( { onClose } ) => (
 					<MenuGroup>
 						{ canEditCSS && (
 							<MenuItem onClick={ loadCustomCSS }>
@@ -82,9 +82,13 @@ function GlobalStylesActionMenu() {
 							</MenuItem>
 						) }
 						<MenuItem
-							onClick={ () =>
-								toggle( 'core/edit-site', 'welcomeGuideStyles' )
-							}
+							onClick={ () => {
+								toggle(
+									'core/edit-site',
+									'welcomeGuideStyles'
+								);
+								onClose();
+							} }
 						>
 							{ __( 'Welcome Guide' ) }
 						</MenuItem>
@@ -139,7 +143,7 @@ function GlobalStylesRevisionsMenu() {
 	return (
 		<GlobalStylesMenuFill>
 			<DropdownMenu icon={ backup } label={ __( 'Revisions' ) }>
-				{ () => (
+				{ ( { onClose } ) => (
 					<MenuGroup>
 						{ hasRevisions && (
 							<MenuItem
@@ -153,7 +157,13 @@ function GlobalStylesRevisionsMenu() {
 								{ __( 'Revision history' ) }
 							</MenuItem>
 						) }
-						<MenuItem onClick={ onReset } disabled={ ! canReset }>
+						<MenuItem
+							onClick={ () => {
+								onReset();
+								onClose();
+							} }
+							disabled={ ! canReset }
+						>
 							{ __( 'Reset to defaults' ) }
 						</MenuItem>
 					</MenuGroup>

--- a/packages/edit-site/src/components/global-styles/ui.js
+++ b/packages/edit-site/src/components/global-styles/ui.js
@@ -7,6 +7,8 @@ import {
 	__experimentalUseNavigator as useNavigator,
 	createSlotFill,
 	DropdownMenu,
+	MenuGroup,
+	MenuItem,
 } from '@wordpress/components';
 import { getBlockTypes, store as blocksStore } from '@wordpress/blocks';
 import { useSelect, useDispatch } from '@wordpress/data';
@@ -83,43 +85,40 @@ function GlobalStylesActionMenu() {
 			<DropdownMenu
 				icon={ moreVertical }
 				label={ __( 'Styles actions' ) }
-				controls={ [
-					{
-						title: __( 'Reset to defaults' ),
-						onClick: onReset,
-						isDisabled: ! canReset,
-					},
-					{
-						title: __( 'Welcome Guide' ),
-						onClick: () =>
-							toggle( 'core/edit-site', 'welcomeGuideStyles' ),
-					},
-					...( canEditCSS
-						? [
-								{
-									title: __( 'Additional CSS' ),
-									onClick: loadCustomCSS,
-								},
-						  ]
-						: [] ),
-					...( hasRevisions
-						? [
-								{
-									title: sprintf(
-										/* translators: %d: number of revisions */
-										_n(
-											'%d Revision',
-											'%d Revisions',
-											revisionsCount
-										),
+			>
+				{ () => (
+					<MenuGroup>
+						{ canEditCSS && (
+							<MenuItem onClick={ loadCustomCSS }>
+								{ __( 'Additional CSS' ) }
+							</MenuItem>
+						) }
+						<MenuItem
+							onClick={ () =>
+								toggle( 'core/edit-site', 'welcomeGuideStyles' )
+							}
+						>
+							{ __( 'Welcome Guide' ) }
+						</MenuItem>
+						{ hasRevisions && (
+							<MenuItem onClick={ loadRevisions }>
+								{ sprintf(
+									/* translators: %d: number of revisions */
+									_n(
+										'%d Revision',
+										'%d Revisions',
 										revisionsCount
 									),
-									onClick: loadRevisions,
-								},
-						  ]
-						: [] ),
-				] }
-			/>
+									revisionsCount
+								) }
+							</MenuItem>
+						) }
+						<MenuItem onClick={ onReset } disabled={ ! canReset }>
+							{ __( 'Reset to defaults' ) }
+						</MenuItem>
+					</MenuGroup>
+				) }
+			</DropdownMenu>
 		</GlobalStylesMenuFill>
 	);
 }

--- a/packages/edit-site/src/components/sidebar-edit-mode/global-styles-sidebar.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/global-styles-sidebar.js
@@ -67,7 +67,11 @@ export default function GlobalStylesSidebar() {
 			closeLabel={ __( 'Close Styles' ) }
 			panelClassName="edit-site-global-styles-sidebar__panel"
 			header={
-				<Flex className="edit-site-global-styles-sidebar__header">
+				<Flex
+					className="edit-site-global-styles-sidebar__header"
+					role="menubar"
+					aria-label={ __( 'Styles actions' ) }
+				>
 					<FlexBlock style={ { minWidth: 'min-content' } }>
 						<strong>{ __( 'Styles' ) }</strong>
 					</FlexBlock>

--- a/packages/edit-site/src/components/sidebar-edit-mode/global-styles-sidebar.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/global-styles-sidebar.js
@@ -91,9 +91,7 @@ export default function GlobalStylesSidebar() {
 							} }
 						/>
 					</FlexItem>
-					<FlexItem>
-						<GlobalStylesMenuSlot />
-					</FlexItem>
+					<GlobalStylesMenuSlot />
 				</Flex>
 			}
 		>

--- a/test/e2e/specs/site-editor/user-global-styles-revisions.spec.js
+++ b/test/e2e/specs/site-editor/user-global-styles-revisions.spec.js
@@ -136,9 +136,11 @@ class UserGlobalStylesRevisions {
 
 	async openRevisions() {
 		await this.page
-			.getByRole( 'button', { name: 'Styles actions' } )
+			.getByRole( 'button', { name: 'Styles revisions actions' } )
 			.click();
-		await this.page.getByRole( 'menuitem', { name: 'Revisions' } ).click();
+		await this.page
+			.getByRole( 'menuitem', { name: /^Revision history/ } )
+			.click();
 	}
 
 	async openStylesPanel() {

--- a/test/e2e/specs/site-editor/user-global-styles-revisions.spec.js
+++ b/test/e2e/specs/site-editor/user-global-styles-revisions.spec.js
@@ -136,8 +136,9 @@ class UserGlobalStylesRevisions {
 
 	async openRevisions() {
 		await this.page
-			.getByRole( 'button', { name: 'Styles revisions actions' } )
+			.getByRole( 'menubar', { name: 'Styles actions' } )
 			.click();
+		await this.page.getByRole( 'button', { name: 'Revisions' } ).click();
 		await this.page
 			.getByRole( 'menuitem', { name: /^Revision history/ } )
 			.click();


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

This PR:

- Splits the “Reset to defaults” and “Revisions `n`” action buttons into separate dropdowns
- Adds a new icon (`backup`) to the styles header buttons row
- Swaps the order of “Additional CSS” and “Welcome guide” and adds icons for each


## Testing Instructions
1. Open the site editor, then the styles menu
2. Toggle the ellipsis and the (new) revisions menus, ensuring that the actions works as they do on trunk. Note, you'll need to alter global styles and save a couple of times so that the revisions menu item displays.
3. The menus should be navigable via keyboard

## Screenshots or screencast <!-- if applicable -->



https://github.com/WordPress/gutenberg/assets/6458278/55667355-8b09-47d0-9285-977156d466ca

<img width="321" alt="Screenshot 2023-06-15 at 10 59 50 am" src="https://github.com/WordPress/gutenberg/assets/6458278/d6630a32-9d7d-42d8-802d-33d94e59e935">


