### PR TITLE
Popover: Allow legitimate 0 positions to update popover position

### DIFF
--- a/packages/block-editor/src/components/url-popover/test/__snapshots__/index.js.snap
+++ b/packages/block-editor/src/components/url-popover/test/__snapshots__/index.js.snap
@@ -5,7 +5,7 @@ exports[`URLPopover matches the snapshot in its default state 1`] = `
   <span>
     <div
       class="components-popover block-editor-url-popover is-positioned"
-      style="position: absolute; top: 0px; left: 0px; transform: translateZ(0);"
+      style="position: absolute; top: 0px; left: 0px; transform: none;"
       tabindex="-1"
     >
       <div
@@ -53,7 +53,7 @@ exports[`URLPopover matches the snapshot when the settings are toggled open 1`] 
   <span>
     <div
       class="components-popover block-editor-url-popover is-positioned"
-      style="position: absolute; top: 0px; left: 0px; transform: translateZ(0);"
+      style="position: absolute; top: 0px; left: 0px; transform: none;"
       tabindex="-1"
     >
       <div
@@ -108,7 +108,7 @@ exports[`URLPopover matches the snapshot when there are no settings 1`] = `
   <span>
     <div
       class="components-popover block-editor-url-popover is-positioned"
-      style="position: absolute; top: 0px; left: 0px; transform: translateZ(0);"
+      style="position: absolute; top: 0px; left: 0px; transform: none;"
       tabindex="-1"
     >
       <div

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fix
+
+-   `Popover`: Allow legitimate 0 positions to update popover position ([#51320](https://github.com/WordPress/gutenberg/pull/51320)).
+
 ## 25.1.0 (2023-06-07)
 
 ### Enhancements

--- a/packages/components/src/popover/index.tsx
+++ b/packages/components/src/popover/index.tsx
@@ -52,6 +52,7 @@ import Button from '../button';
 import ScrollLock from '../scroll-lock';
 import { Slot, Fill, useSlot } from '../slot-fill';
 import {
+	computePopoverPosition,
 	getFrameOffset,
 	getFrameScale,
 	positionToPlacement,
@@ -499,14 +500,8 @@ const UnforwardedPopover = (
 							// to use `translateX` and `translateY` because those values would
 							// be overridden by the return value of the
 							// `placementToMotionAnimationProps` function in `AnimatedWrapper`
-							x:
-								x === null || Number.isNaN( x )
-									? 0
-									: Math.round( x ),
-							y:
-								y === null || Number.isNaN( y )
-									? 0
-									: Math.round( y ),
+							x: computePopoverPosition(x),
+							y: computePopoverPosition(y),
 					  }
 			}
 		>

--- a/packages/components/src/popover/index.tsx
+++ b/packages/components/src/popover/index.tsx
@@ -500,8 +500,8 @@ const UnforwardedPopover = (
 							// to use `translateX` and `translateY` because those values would
 							// be overridden by the return value of the
 							// `placementToMotionAnimationProps` function in `AnimatedWrapper`
-							x: computePopoverPosition(x),
-							y: computePopoverPosition(y),
+							x: computePopoverPosition( x ),
+							y: computePopoverPosition( y ),
 					  }
 			}
 		>

--- a/packages/components/src/popover/index.tsx
+++ b/packages/components/src/popover/index.tsx
@@ -499,8 +499,14 @@ const UnforwardedPopover = (
 							// to use `translateX` and `translateY` because those values would
 							// be overridden by the return value of the
 							// `placementToMotionAnimationProps` function in `AnimatedWrapper`
-							x: Math.round( x ?? 0 ) || undefined,
-							y: Math.round( y ?? 0 ) || undefined,
+							x:
+								x === null || Number.isNaN( x )
+									? 0
+									: Math.round( x ),
+							y:
+								y === null || Number.isNaN( y )
+									? 0
+									: Math.round( y ),
 					  }
 			}
 		>

--- a/packages/components/src/popover/test/index.tsx
+++ b/packages/components/src/popover/test/index.tsx
@@ -12,7 +12,11 @@ import { useState } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import { positionToPlacement, placementToMotionAnimationProps } from '../utils';
+import {
+	computePopoverPosition,
+	positionToPlacement,
+	placementToMotionAnimationProps,
+} from '../utils';
 import Popover from '..';
 import type { PopoverProps } from '../types';
 
@@ -247,5 +251,22 @@ describe( 'Popover', () => {
 				}
 			);
 		} );
+	} );
+
+	describe( 'computePopoverPosition', () => {
+		it.each( [
+			[ 14, 14 ], // valid integers shouldn't be changes
+			[ 14.02, 14 ], // floating numbers are parsed to integers
+			[ 0, 0 ], // zero remains zero
+			[ null, 0 ],
+			[ NaN, 0 ],
+		] )(
+			'converts `%s` to `%s`',
+			( inputCoordinate, expectedCoordinated ) => {
+				expect( computePopoverPosition( inputCoordinate ) ).toEqual(
+					expectedCoordinated
+				);
+			}
+		);
 	} );
 } );

--- a/packages/components/src/popover/test/index.tsx
+++ b/packages/components/src/popover/test/index.tsx
@@ -258,8 +258,8 @@ describe( 'Popover', () => {
 			[ 14, 14 ], // valid integers shouldn't be changes
 			[ 14.02, 14 ], // floating numbers are parsed to integers
 			[ 0, 0 ], // zero remains zero
-			[ null, 0 ],
-			[ NaN, 0 ],
+			[ null, undefined ],
+			[ NaN, undefined ],
 		] )(
 			'converts `%s` to `%s`',
 			( inputCoordinate, expectedCoordinated ) => {

--- a/packages/components/src/popover/utils.ts
+++ b/packages/components/src/popover/utils.ts
@@ -321,12 +321,12 @@ export const getReferenceElement = ( {
 
 /**
  * Computes the final coordinate that needs to be applied to the floating
- * element when applying transform inline styles, defaulting to `0`
- * when appropriate.
+ * element when applying transform inline styles, defaulting to `undefined`
+ * if the provided value is `null` or `NaN`.
  *
  * @param c input coordinate (usually as returned from floating-ui)
  * @return The coordinate's value to be used for inline styles. An `undefined`
  *         return value means "no style set" for this coordinate.
  */
 export const computePopoverPosition = ( c: number | null ) =>
-	c === null || Number.isNaN( c ) ? 0 : Math.round( c );
+	c === null || Number.isNaN( c ) ? undefined : Math.round( c );

--- a/packages/components/src/popover/utils.ts
+++ b/packages/components/src/popover/utils.ts
@@ -318,3 +318,15 @@ export const getReferenceElement = ( {
 	// Convert any `undefined` value to `null`.
 	return referenceElement ?? null;
 };
+
+/**
+ * Computes the final coordinate that needs to be applied to the floating
+ * element when applying transform inline styles, defaulting to `0`
+ * when appropriate.
+ *
+ * @param c input coordinate (usually as returned from floating-ui)
+ * @return The coordinate's value to be used for inline styles. An `undefined`
+ *         return value means "no style set" for this coordinate.
+ */
+export const computePopoverPosition = ( c: number | null ) =>
+	c === null || Number.isNaN( c ) ? 0 : Math.round( c );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fix an issue with the Popover component where `0` values for `left` (or `top`) would not update the position of the popover component, as the final value was treated as `undefined` instead of `0`.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

This resolves a tricky edge case that sometimes occurs with the list view drop indicator line under specific conditions (more info in the testing instructions). But the idea behind this PR is that we most likely don't want to be passing `undefined` for the final style of the popover, or we risk persisting stale positions, as occurs in the list view drop indicator.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Ensure that `0` values are always applied to the style output of the popover component.

It looks like the issue was introduced in #46187 with some discussion occurring in https://github.com/WordPress/gutenberg/pull/46187/files#r1036857416. The fix here borrows from the idea in https://github.com/WordPress/gutenberg/pull/45545#discussion_r1035127580 but doesn't include an `undefined` fallback, as `Math.round()` never returns `null` or `undefined`, as far I can tell.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

These testing instructions are quire specific, as it's a tricky to reproduce issue:

To test, in a fresh post or page, add the following markup:


<details>

<summary>Some heavily nested block markup</summary>

```html
<!-- wp:group {"layout":{"type":"constrained"}} -->
<div class="wp-block-group"><!-- wp:paragraph -->
<p>A paragraph in a group level 1</p>
<!-- /wp:paragraph -->

<!-- wp:group {"layout":{"type":"constrained"}} -->
<div class="wp-block-group"><!-- wp:paragraph -->
<p>A paragraph in a group level 2</p>
<!-- /wp:paragraph -->

<!-- wp:group {"layout":{"type":"constrained"}} -->
<div class="wp-block-group"><!-- wp:paragraph -->
<p>A paragraph in a group level 3</p>
<!-- /wp:paragraph -->

<!-- wp:group {"layout":{"type":"constrained"}} -->
<div class="wp-block-group"><!-- wp:paragraph -->
<p>A paragraph in a group level 4</p>
<!-- /wp:paragraph -->

<!-- wp:group {"layout":{"type":"constrained"}} -->
<div class="wp-block-group"><!-- wp:paragraph -->
<p>A paragraph in a group level 5</p>
<!-- /wp:paragraph -->

<!-- wp:group {"layout":{"type":"constrained"}} -->
<div class="wp-block-group"><!-- wp:paragraph {"anchor":""} -->
<p>A paragraph in a group level 6</p>
<!-- /wp:paragraph -->

<!-- wp:group {"layout":{"type":"constrained"}} -->
<div class="wp-block-group"><!-- wp:paragraph {"anchor":""} -->
<p>A paragraph in a group level 7</p>
<!-- /wp:paragraph -->

<!-- wp:group {"layout":{"type":"constrained"}} -->
<div class="wp-block-group"><!-- wp:paragraph {"anchor":""} -->
<p>A paragraph in a group level 8</p>
<!-- /wp:paragraph --></div>
<!-- /wp:group --></div>
<!-- /wp:group --></div>
<!-- /wp:group --></div>
<!-- /wp:group --></div>
<!-- /wp:group --></div>
<!-- /wp:group --></div>
<!-- /wp:group --></div>
<!-- /wp:group -->

<!-- wp:heading -->
<h2 class="wp-block-heading">A heading</h2>
<!-- /wp:heading -->

<!-- wp:paragraph -->
<p>A paragraph</p>
<!-- /wp:paragraph -->
```
</details>

Prior to applying this PR, test the following (it might be easier to watch the steps in the screengrabs below):

* Open up the post or page with the above markup
* Open the list view
* Click on the "paragraph in group level 8" block in the editor canvas to expand it
* Click on the last paragraph in the editor canvas and press ENTER a number of times to add enough paragraph blocks to the list so that a vertical scrollbar is created in the list view — this action causes the horizontal scroll position of the list view to line up perfectly with the left edge of the list view items
* Without scrolling the list view horizontally, click and drag a list view item up to the position of the nested blocks, and then drag back down to the bottom-most blocks — notice that the list view drop indicator is unexpectedly indented to the right, matching the nested blocks instead of the root blocks. This is because the drop indicator is attempting to render at position `0` for the left position, but the drop indicator is retaining the previous `x` position styling.
* Apply this PR and retry the above steps.
* The drop indicator line should not be unexpectedly indented.

Note: if you are finding the issue difficult to reproduce, make sure that prior to adding the paragraph blocks, the list view is short enough that it does not yet have a vertical scrollbar. Changing the horizontal position of the list view is likely to make the list view items slightly off from flush with the left edge of the screen, so the issue won't appear.

## Screenshots or screencast <!-- if applicable -->

### Before

https://github.com/WordPress/gutenberg/assets/14988353/72d8c80e-2744-4a34-96b4-0b64da524d36

### After

https://github.com/WordPress/gutenberg/assets/14988353/b41c0955-f2bb-421e-83f7-5b7541a6daa5

