### PR TITLE
Fix broken links in editor documentation

### DIFF
--- a/docs/contributors/code/react-native/getting-started-react-native.md
+++ b/docs/contributors/code/react-native/getting-started-react-native.md
@@ -111,7 +111,7 @@ This project is set up to use [jest](https://facebook.github.io/jest/) for tests
 This repository uses Appium to run UI tests. The tests live in `__device-tests__` and are written using Appium to run tests against simulators and real devices. To run these you'll need to check off a few things:
 
 -   When running the tests, you'll need to ensure the Metro bundler (`npm run native start`) is not running.
--   [Appium CLI](https://appium.io/docs/en/about-appium/getting-started/) installed and available globally. We also recommend using [appium-doctor](https://github.com/appium/appium-doctor) to ensure all of Appium's dependencies are good to go. You don't have to worry about starting the server yourself, the tests handle starting the server on port 4723, just be sure that the port is free or feel free to change the port number in the test file.
+-   [Appium CLI](https://github.com/appium/appium/blob/1.x/docs/en/about-appium/getting-started.md) installed and available globally. We also recommend using [appium-doctor](https://github.com/appium/appium-doctor) to ensure all of Appium's dependencies are good to go. You don't have to worry about starting the server yourself, the tests handle starting the server on port 4723, just be sure that the port is free or feel free to change the port number in the test file.
 -   For iOS a simulator should automatically launch but for Android you'll need to have an emulator _with at least platform version 8.0_ fired up and running.
 
 Then, to run the UI tests on iOS:

--- a/packages/README.md
+++ b/packages/README.md
@@ -180,7 +180,7 @@ While other section naming can be used when appropriate, it's important that are
 
 When in doubt, refer to [Semantic Versioning specification](https://semver.org/).
 
-If you are publishing new versions of packages, note that there are versioning recommendations outlined in the [Gutenberg Release Process document](https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/release.md) which prescribe _minimum_ version bumps for specific types of releases. The chosen version should be the greater of the two between the semantic versioning and Gutenberg release minimum version bumps.
+If you are publishing new versions of packages, note that there are versioning recommendations outlined in the [Gutenberg Release Process document](https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/release.md) which prescribe _minimum_ version bumps for specific types of releases. The chosen version should be the greater of the two between the semantic versioning and Gutenberg release minimum version bumps.
 
 ## TypeScript
 

--- a/packages/react-native-editor/__device-tests__/CONTRIBUTING.md
+++ b/packages/react-native-editor/__device-tests__/CONTRIBUTING.md
@@ -38,7 +38,7 @@ Using one or a combination of these tools will make it much easier to identify w
 
 -   You'll write any functions needed to interact with the page in the `EditorPage` page object and then call those interactions within the test. The code you'll need to write to actually do the finding will use a combination of
 
--   Appium's spec https://appium.io/docs/en/about-appium/intro/ which you can find examples of a variety of functions under the commands tab
+-   Appium's spec https://appium.io/docs/en/2.0/ which you can find examples of a variety of functions under the commands tab
 -   WebDriver I/O Appium protocols https://webdriver.io/docs/api/appium.html which provides examples and descriptions of what those look like.
 
 It takes some getting used to but looking at the existing code should be helpful in identifying common commands that it'd help to be familiar with.

--- a/packages/react-native-editor/__device-tests__/CONTRIBUTING.md
+++ b/packages/react-native-editor/__device-tests__/CONTRIBUTING.md
@@ -38,7 +38,7 @@ Using one or a combination of these tools will make it much easier to identify w
 
 -   You'll write any functions needed to interact with the page in the `EditorPage` page object and then call those interactions within the test. The code you'll need to write to actually do the finding will use a combination of
 
--   Appium's spec https://appium.io/docs/en/2.0/ which you can find examples of a variety of functions under the commands tab
+-   Appium's spec https://github.com/appium/appium/blob/1.x/docs/en/about-appium/intro.md which you can find examples of a variety of functions under the commands tab
 -   WebDriver I/O Appium protocols https://webdriver.io/docs/api/appium.html which provides examples and descriptions of what those look like.
 
 It takes some getting used to but looking at the existing code should be helpful in identifying common commands that it'd help to be familiar with.

--- a/packages/react-native-editor/__device-tests__/README.md
+++ b/packages/react-native-editor/__device-tests__/README.md
@@ -59,7 +59,7 @@ Appium uses a config object that contains `capabilities` to define how it will c
 -   `platformVersion` which is the platform version of a connected adb device. e.g `9.0` for Android or `12.2` for iOS. The version used here is upper bounded by the max allowed on CI but feel free to change this value locally as needed.
 -   `app` which is the absolute path to the `.app` or `.apk` file or the path relative to the **Appium root**. It's important to note that when using the relative paths it's not to the project folder but to the appium server, since by default we start up appium in the project root when running the paths appear relative to the root but if you were using another instance of the Appium server the relative path would need to come from there.
 
-A full spec on the capabilities can be found [here](http://appium.io/docs/en/writing-running-appium/caps/). If you'd like to change configurations like
+A full spec on the capabilities can be found [here](https://appium.io/docs/en/2.0/guides/caps/). If you'd like to change configurations like
 what port appium runs on or what device or emulator the tests should be executed on that file would be where you'd like to make that update.
 
 ## The run process
@@ -75,4 +75,4 @@ After the build is complete, an appium server is fired up on port 4723 and the d
 
 ---
 
-To read more about writing your own tests please read the [contributing guide](https://github.com/WordPress/gutenberg/blob/HEAD/packages/react-native-editor/__device-tests__/CONTRIBUTING.md)
+To read more about writing your own tests please read the [contributing guide](https://github.com/WordPress/gutenberg/blob/HEAD/packages/react-native-editor/__device-tests__/CONTRIBUTING.md).

--- a/packages/react-native-editor/__device-tests__/README.md
+++ b/packages/react-native-editor/__device-tests__/README.md
@@ -59,7 +59,7 @@ Appium uses a config object that contains `capabilities` to define how it will c
 -   `platformVersion` which is the platform version of a connected adb device. e.g `9.0` for Android or `12.2` for iOS. The version used here is upper bounded by the max allowed on CI but feel free to change this value locally as needed.
 -   `app` which is the absolute path to the `.app` or `.apk` file or the path relative to the **Appium root**. It's important to note that when using the relative paths it's not to the project folder but to the appium server, since by default we start up appium in the project root when running the paths appear relative to the root but if you were using another instance of the Appium server the relative path would need to come from there.
 
-A full spec on the capabilities can be found [here](https://appium.io/docs/en/2.0/guides/caps/). If you'd like to change configurations like
+A full spec on the capabilities can be found [here](https://github.com/appium/appium/blob/1.x/docs/en/writing-running-appium/caps.md). If you'd like to change configurations like
 what port appium runs on or what device or emulator the tests should be executed on that file would be where you'd like to make that update.
 
 ## The run process


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes a handful of broken links in the Editor documentation.

## Why?
To encourage external code contributions, and also not have broken links in documentation.

## How?
Finds and replaces the related updated link URL for broken links.


## Testing Instructions
Referenced documentation links should not 404.

