### PR TITLE
Show pages with any status in the command center

### DIFF
--- a/packages/core-commands/src/site-editor-navigation-commands.js
+++ b/packages/core-commands/src/site-editor-navigation-commands.js
@@ -38,6 +38,13 @@ const getNavigationCommandLoaderPerPostType = ( postType ) =>
 							search: !! search ? search : undefined,
 							per_page: 10,
 							orderby: search ? 'relevance' : 'date',
+							status: [
+								'publish',
+								'future',
+								'draft',
+								'pending',
+								'private',
+							],
 					  }
 					: {
 							per_page: -1,


### PR DESCRIPTION
closes #51204 

## What?

Shows pages with any status (draft, published, scheduled...) in the command center navigation.

## Testing Instructions

1- Create a draft page
2- Open the site editor
3- Open the command center
4- Search for the draft page you just created
5- You should be able to click to edit it
