### PR TITLE
Convert EmbedPreview component to functional component

### DIFF
--- a/packages/block-library/src/embed/embed-preview.js
+++ b/packages/block-library/src/embed/embed-preview.js
@@ -14,7 +14,7 @@ import clsx from 'clsx';
 import { __, sprintf } from '@wordpress/i18n';
 import { Placeholder, SandBox } from '@wordpress/components';
 import { BlockIcon } from '@wordpress/block-editor';
-import { useState, useEffect } from '@wordpress/element';
+import { useState } from '@wordpress/element';
 import { getAuthority } from '@wordpress/url';
 
 /**
@@ -38,11 +38,12 @@ export default function EmbedPreview( {
 } ) {
 	const [ interactive, setInteractive ] = useState( false );
 
-	useEffect( () => {
-		if ( isSelected && interactive ) {
-			setInteractive( false );
-		}
-	}, [ isSelected ] );
+	if ( ! isSelected && interactive ) {
+		// We only want to change this when the block is not selected, because changing it when
+		// the block becomes selected makes the overlap disappear too early. Hiding the overlay
+		// happens on mouseup when the overlay is clicked.
+		setInteractive( false );
+	}
 
 	const hideOverlay = () => {
 		// This is called onMouseUp on the overlay. We can't respond to the `isSelected` prop

--- a/packages/block-library/src/embed/embed-preview.js
+++ b/packages/block-library/src/embed/embed-preview.js
@@ -14,7 +14,7 @@ import clsx from 'clsx';
 import { __, sprintf } from '@wordpress/i18n';
 import { Placeholder, SandBox } from '@wordpress/components';
 import { BlockIcon } from '@wordpress/block-editor';
-import { Component } from '@wordpress/element';
+import { useState, useEffect } from '@wordpress/element';
 import { getAuthority } from '@wordpress/url';
 
 /**
@@ -23,129 +23,112 @@ import { getAuthority } from '@wordpress/url';
 import WpEmbedPreview from './wp-embed-preview';
 import { Caption } from '../utils/caption';
 
-class EmbedPreview extends Component {
-	constructor() {
-		super( ...arguments );
-		this.hideOverlay = this.hideOverlay.bind( this );
-		this.state = {
-			interactive: false,
-		};
-	}
+export default function EmbedPreview( {
+	preview,
+	previewable,
+	url,
+	type,
+	isSelected,
+	className,
+	icon,
+	label,
+	insertBlocksAfter,
+	attributes,
+	setAttributes,
+} ) {
+	const [ interactive, setInteractive ] = useState( false );
 
-	static getDerivedStateFromProps( nextProps, state ) {
-		if ( ! nextProps.isSelected && state.interactive ) {
-			// We only want to change this when the block is not selected, because changing it when
-			// the block becomes selected makes the overlap disappear too early. Hiding the overlay
-			// happens on mouseup when the overlay is clicked.
-			return { interactive: false };
+	useEffect( () => {
+		if ( isSelected && interactive ) {
+			setInteractive( false );
 		}
+	}, [ isSelected ] );
 
-		return null;
-	}
-
-	hideOverlay() {
+	const hideOverlay = () => {
 		// This is called onMouseUp on the overlay. We can't respond to the `isSelected` prop
 		// changing, because that happens on mouse down, and the overlay immediately disappears,
 		// and the mouse event can end up in the preview content. We can't use onClick on
 		// the overlay to hide it either, because then the editor misses the mouseup event, and
 		// thinks we're multi-selecting blocks.
-		this.setState( { interactive: true } );
-	}
+		setInteractive( true );
+	};
 
-	render() {
-		const {
-			preview,
-			previewable,
-			url,
-			type,
-			className,
-			icon,
-			label,
-			insertBlocksAfter,
-			attributes,
-			setAttributes,
-			isSelected,
-		} = this.props;
-		const { scripts } = preview;
-		const { interactive } = this.state;
+	const { scripts } = preview;
 
-		const html = 'photo' === type ? getPhotoHtml( preview ) : preview.html;
-		const embedSourceUrl = getAuthority( url );
-		const iframeTitle = sprintf(
-			// translators: %s: host providing embed content e.g: www.youtube.com
-			__( 'Embedded content from %s' ),
-			embedSourceUrl
-		);
-		const sandboxClassnames = clsx(
-			type,
-			className,
-			'wp-block-embed__wrapper'
-		);
+	const html = 'photo' === type ? getPhotoHtml( preview ) : preview.html;
+	const embedSourceUrl = getAuthority( url );
+	const iframeTitle = sprintf(
+		// translators: %s: host providing embed content e.g: www.youtube.com
+		__( 'Embedded content from %s' ),
+		embedSourceUrl
+	);
+	const sandboxClassnames = clsx(
+		type,
+		className,
+		'wp-block-embed__wrapper'
+	);
 
-		// Disabled because the overlay div doesn't actually have a role or functionality
-		// as far as the user is concerned. We're just catching the first click so that
-		// the block can be selected without interacting with the embed preview that the overlay covers.
-		/* eslint-disable jsx-a11y/no-static-element-interactions */
-		const embedWrapper =
-			'wp-embed' === type ? (
-				<WpEmbedPreview html={ html } />
-			) : (
-				<div className="wp-block-embed__wrapper">
-					<SandBox
-						html={ html }
-						scripts={ scripts }
-						title={ iframeTitle }
-						type={ sandboxClassnames }
-						onFocus={ this.hideOverlay }
-					/>
-					{ ! interactive && (
-						<div
-							className="block-library-embed__interactive-overlay"
-							onMouseUp={ this.hideOverlay }
-						/>
-					) }
-				</div>
-			);
-		/* eslint-enable jsx-a11y/no-static-element-interactions */
-
-		return (
-			<figure
-				className={ clsx( className, 'wp-block-embed', {
-					'is-type-video': 'video' === type,
-				} ) }
-			>
-				{ previewable ? (
-					embedWrapper
-				) : (
-					<Placeholder
-						icon={ <BlockIcon icon={ icon } showColors /> }
-						label={ label }
-					>
-						<p className="components-placeholder__error">
-							<a href={ url }>{ url }</a>
-						</p>
-						<p className="components-placeholder__error">
-							{ sprintf(
-								/* translators: %s: host providing embed content e.g: www.youtube.com */
-								__(
-									"Embedded content from %s can't be previewed in the editor."
-								),
-								embedSourceUrl
-							) }
-						</p>
-					</Placeholder>
-				) }
-				<Caption
-					attributes={ attributes }
-					setAttributes={ setAttributes }
-					isSelected={ isSelected }
-					insertBlocksAfter={ insertBlocksAfter }
-					label={ __( 'Embed caption text' ) }
-					showToolbarButton={ isSelected }
+	// Disabled because the overlay div doesn't actually have a role or functionality
+	// as far as the user is concerned. We're just catching the first click so that
+	// the block can be selected without interacting with the embed preview that the overlay covers.
+	/* eslint-disable jsx-a11y/no-static-element-interactions */
+	const embedWrapper =
+		'wp-embed' === type ? (
+			<WpEmbedPreview html={ html } />
+		) : (
+			<div className="wp-block-embed__wrapper">
+				<SandBox
+					html={ html }
+					scripts={ scripts }
+					title={ iframeTitle }
+					type={ sandboxClassnames }
+					onFocus={ hideOverlay }
 				/>
-			</figure>
+				{ ! interactive && (
+					<div
+						className="block-library-embed__interactive-overlay"
+						onMouseUp={ hideOverlay }
+					/>
+				) }
+			</div>
 		);
-	}
-}
+	/* eslint-enable jsx-a11y/no-static-element-interactions */
 
-export default EmbedPreview;
+	return (
+		<figure
+			className={ clsx( className, 'wp-block-embed', {
+				'is-type-video': 'video' === type,
+			} ) }
+		>
+			{ previewable ? (
+				embedWrapper
+			) : (
+				<Placeholder
+					icon={ <BlockIcon icon={ icon } showColors /> }
+					label={ label }
+				>
+					<p className="components-placeholder__error">
+						<a href={ url }>{ url }</a>
+					</p>
+					<p className="components-placeholder__error">
+						{ sprintf(
+							/* translators: %s: host providing embed content e.g: www.youtube.com */
+							__(
+								"Embedded content from %s can't be previewed in the editor."
+							),
+							embedSourceUrl
+						) }
+					</p>
+				</Placeholder>
+			) }
+			<Caption
+				attributes={ attributes }
+				setAttributes={ setAttributes }
+				isSelected={ isSelected }
+				insertBlocksAfter={ insertBlocksAfter }
+				label={ __( 'Embed caption text' ) }
+				showToolbarButton={ isSelected }
+			/>
+		</figure>
+	);
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

This PR converts the `EmbedPreview` component to a functional component.

## Why?

React class components are outdated and functional components are encouraged, this is part of the https://github.com/WordPress/gutenberg/issues/22890 to convert all class components to functional components.

## How?
Converts `EmbedPreview` component to a functional component.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Open a Post or Page
2. Add an Embed block
3. Grab a link from YouTube or Tumblr or any of the sites listed here: https://wordpress.org/documentation/article/embeds/#list-of-sites-you-can-embed-from and add it to the Embed component
4. Make sure it saves correctly and no new errors are shown in the console.
5. Do a smoke test to make sure it continues to work as before ( changing the width in the toolbar, or changing the url, clicking around in the video/image to make sure things are interactive.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
N/A

## Screenshots or screencast <!-- if applicable -->

N/A
