### PR TITLE
Post Content: Add color controls

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -563,7 +563,7 @@ Displays the contents of a post or page. ([Source](https://github.com/WordPress/
 
 -	**Name:** core/post-content
 -	**Category:** theme
--	**Supports:** align (full, wide), dimensions (minHeight), layout, typography (fontSize, lineHeight), ~~html~~
+-	**Supports:** align (full, wide), color (background, gradients, link, text), dimensions (minHeight), layout, typography (fontSize, lineHeight), ~~html~~
 -	**Attributes:** 
 
 ## Post Date

--- a/packages/block-library/src/post-content/block.json
+++ b/packages/block-library/src/post-content/block.json
@@ -14,6 +14,14 @@
 		"dimensions": {
 			"minHeight": true
 		},
+		"color": {
+			"gradients": true,
+			"link": true,
+			"__experimentalDefaultControls": {
+				"background": false,
+				"text": false
+			}
+		},
 		"typography": {
 			"fontSize": true,
 			"lineHeight": true,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This enables color controls for the Post Content block. Fixes #50327.

## Why?
Themes often want to control these colors using Global Styles, so we should make it possible for users to change them. See https://github.com/WordPress/gutenberg/issues/51265 for an example of why this is needed.

## How?
Add the color supports to the block JSON file.

## Testing Instructions
1. Open the Site Editor
2. Open the Global Styles panel
<img width="80" alt="Screenshot 2023-06-08 at 12 47 13" src="https://github.com/WordPress/gutenberg/assets/275961/e7edf627-e2cf-46dc-9ef3-1a7b7c692368">

3. Open the blocks section
<img width="282" alt="Screenshot 2023-06-08 at 12 47 39" src="https://github.com/WordPress/gutenberg/assets/275961/13098156-1084-424b-923f-7a35fecab788">

4. Find the post content block
<img width="278" alt="Screenshot 2023-06-08 at 12 48 10" src="https://github.com/WordPress/gutenberg/assets/275961/17a5ae7f-4fc0-410b-b74c-1541eb89dc23">

5. Select the block and confirm that there are color controls:
<img width="284" alt="Screenshot 2023-06-08 at 12 49 37" src="https://github.com/WordPress/gutenberg/assets/275961/8ef601dc-69d4-4467-a631-eb77740695e5">

6. Set the color controls and confirm that they work in the front end of the site
<img width="703" alt="Screenshot 2023-06-08 at 12 50 34" src="https://github.com/WordPress/gutenberg/assets/275961/668165f3-f996-43a3-aca3-4b9447cf6c14">

7. Confirm that they also work in the Post Editor:
