### PR TITLE
ListView: Expand/Collapse subtree on double click on a List View item

### DIFF
--- a/packages/block-editor/src/components/list-view/block-select-button.js
+++ b/packages/block-editor/src/components/list-view/block-select-button.js
@@ -129,6 +129,7 @@ function ListViewBlockSelectButton(
 					className
 				) }
 				onClick={ onClick }
+				onDoubleClick={ onToggleExpanded }
 				onKeyDown={ onKeyDownHandler }
 				ref={ ref }
 				tabIndex={ tabIndex }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
#51253

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Double-clicking to expand seems like a natural behavior. For example, storybooks, Windows Explorer etc.

## How?
Add onDoubleClick event handler to `ListViewBlockSelectButton`.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Add Post.
2. Insert Columns or list.
3. Check List View.

## Screenshots or screencast 

https://github.com/WordPress/gutenberg/assets/1908815/ef570224-6922-4cbe-9ba4-d1d2372fc4a5


