### PR TITLE
Fix createI18n package import location

### DIFF
--- a/packages/react-i18n/README.md
+++ b/packages/react-i18n/README.md
@@ -23,7 +23,7 @@ The `I18nProvider` should be mounted above any localized components:
 _Usage_
 
 ```js
-import { createI18n } from '@wordpress/react-i18n';
+import { createI18n } from '@wordpress/i18n';
 import { I18nProvider } from '@wordpress/react-i18n';
 const i18n = createI18n();
 


### PR DESCRIPTION
createI18n is exported from i18n package,
not from react-i18n package.

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixing a documentation code example typo.

## Why?
Because the code example does not run correctly without this fix.

## How?
It is a documentation change.

## Testing Instructions
To test the actual code, try importing `createI18n` from `@wordpress/react-i18n`. It will fail. Then try from `@wordpress/i18n` and it will success.

### Testing Instructions for Keyboard
n/a
