### PR TITLE
Fix site editor rendering of Categories block

### DIFF
--- a/packages/block-library/src/post-terms/edit.js
+++ b/packages/block-library/src/post-terms/edit.js
@@ -69,10 +69,6 @@ export default function PostTermsEdit( {
 		} ),
 	} );
 
-	if ( ! hasPost || ! term ) {
-		return <div { ...blockProps }>{ blockInformation.title }</div>;
-	}
-
 	return (
 		<>
 			<BlockControls>
@@ -96,7 +92,7 @@ export default function PostTermsEdit( {
 				/>
 			</InspectorControls>
 			<div { ...blockProps }>
-				{ isLoading && <Spinner /> }
+				{ isLoading && hasPost && <Spinner /> }
 				{ ! isLoading && hasPostTerms && ( isSelected || prefix ) && (
 					<RichText
 						allowedFormats={ ALLOWED_FORMATS }
@@ -111,7 +107,11 @@ export default function PostTermsEdit( {
 						tagName="span"
 					/>
 				) }
-				{ ! isLoading &&
+				{ ( ! hasPost || ! term ) && (
+					<span>{ blockInformation.title }</span>
+				) }
+				{ hasPost &&
+					! isLoading &&
 					hasPostTerms &&
 					postTerms
 						.map( ( postTerm ) => (
@@ -132,7 +132,8 @@ export default function PostTermsEdit( {
 								{ curr }
 							</>
 						) ) }
-				{ ! isLoading &&
+				{ hasPost &&
+					! isLoading &&
 					! hasPostTerms &&
 					( selectedTerm?.labels?.no_terms ||
 						__( 'Term items not found.' ) ) }


### PR DESCRIPTION
## What?
The Categories block would not render properly within the site editor. Specifically:

- Prefix and Suffix options were not shown when the block was selected.
- Separator was not available in the advanced panel.
- Alignment toolbar was not available in the toolbar.

## Why?

#48940 reported the issue of missing the alignment toolbar. As I was investigating that, I found out a few more things were missing.

## How?
The component was returning early in case no `postId` was found. Since no `postId` is present in the site editor, the early return was triggered. This PR makes sure that even in case we are in the site editor, we still output all the inspector controls, toolbars and prefix/suffix.

## Testing Instructions
1. Go to the Site Editor.
2. Edit a Single Post template.
3. Add the Categories block.
4. Make sure that:
  1. Text alignment options are available in the toolbar.
  2. Prefix and suffix are available when the block is selected.
  3. Separator is available in the inspector controls (under “Advanced”).
  4. There is no loading state.
  5. Still shows the “Categories” placeholder.
5. Go to the Post Editor.
6. Add the Categories block.
7. Make sure that:
  1. There is a loading state.
  2. Shows the correct categories.