### PR TITLE
[`@wordpress/e2e-test-utils-playwright`] Add `openPostInEditor` function

### DIFF
--- a/packages/e2e-test-utils-playwright/src/admin/index.ts
+++ b/packages/e2e-test-utils-playwright/src/admin/index.ts
@@ -8,6 +8,7 @@ import type { Browser, Page, BrowserContext } from '@playwright/test';
  */
 import { createNewPost } from './create-new-post';
 import { getPageError } from './get-page-error';
+import { openPostInEditor } from './open-post-in-editor';
 import { visitAdminPage } from './visit-admin-page';
 import { visitSiteEditor } from './visit-site-editor';
 import type { PageUtils } from '../page-utils';
@@ -34,6 +35,8 @@ export class Admin {
 	createNewPost: typeof createNewPost = createNewPost.bind( this );
 	/** @borrows getPageError as this.getPageError */
 	getPageError: typeof getPageError = getPageError.bind( this );
+	/** @borrows openPostInEditor as this.openPostInEditor */
+	openPostInEditor: typeof openPostInEditor = openPostInEditor.bind( this );
 	/** @borrows visitAdminPage as this.visitAdminPage */
 	visitAdminPage: typeof visitAdminPage = visitAdminPage.bind( this );
 	/** @borrows visitSiteEditor as this.visitSiteEditor */

--- a/packages/e2e-test-utils-playwright/src/admin/open-post-in-editor.ts
+++ b/packages/e2e-test-utils-playwright/src/admin/open-post-in-editor.ts
@@ -1,0 +1,29 @@
+/**
+ * Internal dependencies
+ */
+import type { Admin } from './index';
+
+/**
+ * Opens the specified post in the block editor.
+ *
+ * @param postName The name of the post to open.
+ * @param postType The type of post to open.
+ */
+export async function openPostInEditor(
+	this: Admin,
+	postName: string,
+	postType = 'post'
+) {
+	await this.page.goto(
+		`/wp-admin/edit.php?post_type=${ postType }&s=${ encodeURIComponent(
+			postName
+		) }`
+	);
+
+	// This is the link to the edit page of the block, this is the page's title.
+	await this.page
+		.getByRole( 'link', { name: `“${ postName }” (Edit)` } )
+		.click();
+
+	await this.page.waitForLoadState( 'networkidle' );
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Adds an `openPostInEditor` function to the `Admin` class. This function will search for (by title), then open the specified page in the editor.

## Why?
When testing, people may set up their test env with pre-published pages containing blocks they wish to test. The tests may need to open these pages to update block-specific settings to test different code paths.

It is not guaranteed that the IDs of the specific pages will be the same across runs, so it makes sense to be able to open the page by name, like a user would.

## How?

It opens the admin page for the specified post type and searches for the specified post name. When the search is complete, it finds the link to edit the post and then clicks it. When the network is idle the function returns.

## Testing Instructions

Set up `wp-env`.

Add a new test file, `test/e2e/specs/editor/various/open-in-editor.spec.js` and add the following code:

```js
/**
 * WordPress dependencies
 */
const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );

test.describe( 'openInEditor', () => {
	test( 'should open the page', async ( { admin, editor } ) => {
		await admin.createNewPost( {
			postType: 'post',
			title: 'My test post',
			content: '',
			excerpt: '',
		} );
		await editor.publishPost();
		await admin.openPostInEditor( 'My test post' );
		expect( await admin.page.title() ).toContain( 'My test post' );

		await admin.createNewPost( {
			postType: 'page',
			title: 'My test page',
			content: '',
			excerpt: '',
		} );
		await editor.publishPost();
		await admin.openPostInEditor( 'My test page', 'page' );
		expect( await admin.page.title() ).toContain( 'My test page' );
	} );
} );
```

Run `npm run test:e2e:playwright -- open-in-editor` and ensure the test passes.

Note: If you run this multiple times it will fail because the pages will be duplicated, so be sure to clear them between runs!

Open a test file, for example: 

### Testing Instructions for Keyboard

This PR does not affect the UI.