### PR TITLE
Elements: Add support for text based inputs

### DIFF
--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -497,19 +497,20 @@ class WP_Theme_JSON_Gutenberg {
 	 * @var string[]
 	 */
 	const ELEMENTS = array(
-		'link'    => 'a:where(:not(.wp-element-button))', // The `where` is needed to lower the specificity.
-		'heading' => 'h1, h2, h3, h4, h5, h6',
-		'h1'      => 'h1',
-		'h2'      => 'h2',
-		'h3'      => 'h3',
-		'h4'      => 'h4',
-		'h5'      => 'h5',
-		'h6'      => 'h6',
+		'link'     => 'a:where(:not(.wp-element-button))', // The `where` is needed to lower the specificity.
+		'heading'  => 'h1, h2, h3, h4, h5, h6',
+		'h1'       => 'h1',
+		'h2'       => 'h2',
+		'h3'       => 'h3',
+		'h4'       => 'h4',
+		'h5'       => 'h5',
+		'h6'       => 'h6',
 		// We have the .wp-block-button__link class so that this will target older buttons that have been serialized.
-		'button'  => '.wp-element-button, .wp-block-button__link',
+		'button'   => '.wp-element-button, .wp-block-button__link',
 		// The block classes are necessary to target older content that won't use the new class names.
-		'caption' => '.wp-element-caption, .wp-block-audio figcaption, .wp-block-embed figcaption, .wp-block-gallery figcaption, .wp-block-image figcaption, .wp-block-table figcaption, .wp-block-video figcaption',
-		'cite'    => 'cite',
+		'caption'  => '.wp-element-caption, .wp-block-audio figcaption, .wp-block-embed figcaption, .wp-block-gallery figcaption, .wp-block-image figcaption, .wp-block-table figcaption, .wp-block-video figcaption',
+		'cite'     => 'cite',
+		'textarea' => 'textarea',
 	);
 
 	const __EXPERIMENTAL_ELEMENT_CLASS_NAMES = array(

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -510,7 +510,7 @@ class WP_Theme_JSON_Gutenberg {
 		// The block classes are necessary to target older content that won't use the new class names.
 		'caption'   => '.wp-element-caption, .wp-block-audio figcaption, .wp-block-embed figcaption, .wp-block-gallery figcaption, .wp-block-image figcaption, .wp-block-table figcaption, .wp-block-video figcaption',
 		'cite'      => 'cite',
-		'textInput' => 'textarea, input:not([type=checkbox|type=radio|type=submit])',
+		'textInput' => 'textarea, input:not([type=checkbox]):not([type=radio]):not([type=submit])',
 	);
 
 	const __EXPERIMENTAL_ELEMENT_CLASS_NAMES = array(

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -510,7 +510,7 @@ class WP_Theme_JSON_Gutenberg {
 		// The block classes are necessary to target older content that won't use the new class names.
 		'caption'   => '.wp-element-caption, .wp-block-audio figcaption, .wp-block-embed figcaption, .wp-block-gallery figcaption, .wp-block-image figcaption, .wp-block-table figcaption, .wp-block-video figcaption',
 		'cite'      => 'cite',
-		'textInput' => 'textarea, input:not([type=checkbox]):not([type=radio]):not([type=submit])',
+		'textInput' => 'textarea, input:where(not([type=checkbox]):not([type=radio]):not([type=submit]))',
 	);
 
 	const __EXPERIMENTAL_ELEMENT_CLASS_NAMES = array(

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -497,20 +497,20 @@ class WP_Theme_JSON_Gutenberg {
 	 * @var string[]
 	 */
 	const ELEMENTS = array(
-		'link'     => 'a:where(:not(.wp-element-button))', // The `where` is needed to lower the specificity.
-		'heading'  => 'h1, h2, h3, h4, h5, h6',
-		'h1'       => 'h1',
-		'h2'       => 'h2',
-		'h3'       => 'h3',
-		'h4'       => 'h4',
-		'h5'       => 'h5',
-		'h6'       => 'h6',
+		'link'      => 'a:where(:not(.wp-element-button))', // The `where` is needed to lower the specificity.
+		'heading'   => 'h1, h2, h3, h4, h5, h6',
+		'h1'        => 'h1',
+		'h2'        => 'h2',
+		'h3'        => 'h3',
+		'h4'        => 'h4',
+		'h5'        => 'h5',
+		'h6'        => 'h6',
 		// We have the .wp-block-button__link class so that this will target older buttons that have been serialized.
-		'button'   => '.wp-element-button, .wp-block-button__link',
+		'button'    => '.wp-element-button, .wp-block-button__link',
 		// The block classes are necessary to target older content that won't use the new class names.
-		'caption'  => '.wp-element-caption, .wp-block-audio figcaption, .wp-block-embed figcaption, .wp-block-gallery figcaption, .wp-block-image figcaption, .wp-block-table figcaption, .wp-block-video figcaption',
-		'cite'     => 'cite',
-		'textarea' => 'textarea',
+		'caption'   => '.wp-element-caption, .wp-block-audio figcaption, .wp-block-embed figcaption, .wp-block-gallery figcaption, .wp-block-image figcaption, .wp-block-table figcaption, .wp-block-video figcaption',
+		'cite'      => 'cite',
+		'textInput' => 'textarea, input:not([type=checkbox|type=radio|type=submit])',
 	);
 
 	const __EXPERIMENTAL_ELEMENT_CLASS_NAMES = array(

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -510,7 +510,7 @@ class WP_Theme_JSON_Gutenberg {
 		// The block classes are necessary to target older content that won't use the new class names.
 		'caption'   => '.wp-element-caption, .wp-block-audio figcaption, .wp-block-embed figcaption, .wp-block-gallery figcaption, .wp-block-image figcaption, .wp-block-table figcaption, .wp-block-video figcaption',
 		'cite'      => 'cite',
-		'textInput' => 'textarea, input:where(:not([type=checkbox]):not([type=radio]):not([type=submit]))',
+		'textInput' => 'textarea, input:where([type=email],[type=number],[type=password],[type=search],[type=tel],[type=text],[type=tel],[type=url])',
 	);
 
 	const __EXPERIMENTAL_ELEMENT_CLASS_NAMES = array(

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -510,7 +510,7 @@ class WP_Theme_JSON_Gutenberg {
 		// The block classes are necessary to target older content that won't use the new class names.
 		'caption'   => '.wp-element-caption, .wp-block-audio figcaption, .wp-block-embed figcaption, .wp-block-gallery figcaption, .wp-block-image figcaption, .wp-block-table figcaption, .wp-block-video figcaption',
 		'cite'      => 'cite',
-		'textInput' => 'textarea, input:where(not([type=checkbox]):not([type=radio]):not([type=submit]))',
+		'textInput' => 'textarea, input:where(:not([type=checkbox]):not([type=radio]):not([type=submit]))',
 	);
 
 	const __EXPERIMENTAL_ELEMENT_CLASS_NAMES = array(


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Adds support for textarea and text-based inputs elements to theme.json.

## Why?
Many themes want to control the display of textareas and other inputs, and this will allow them to do it: eg. https://github.com/WordPress/community-themes/pull/41/files

## How?
Adds `textInput` to the valid elements, with a selector to target `textarea` and other text based `input` elements. The other changes are whitespace. We'll have to followup with a PR to add this to the UI later.

## Testing Instructions
This can be tested in the bluenote theme, using this PR: https://github.com/WordPress/community-themes/pull/41/files. You will need to add a post comment form block to a template to see it.

## Screenshots or screencast <!-- if applicable -->
<img width="954" alt="Screenshot 2023-06-08 at 15 26 45" src="https://github.com/WordPress/gutenberg/assets/275961/42aba7fd-6be7-4e8a-9fb1-28e9a4362a99">
