### PR TITLE
Env: Migrate to Compose V2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25688,15 +25688,6 @@
 				"node": ">=6"
 			}
 		},
-		"node_modules/docker-compose": {
-			"version": "0.22.2",
-			"resolved": "https://registry.npmjs.org/docker-compose/-/docker-compose-0.22.2.tgz",
-			"integrity": "sha512-iXWb5+LiYmylIMFXvGTYsjI1F+Xyx78Jm/uj1dxwwZLbWkUdH6yOXY5Nr3RjbYX15EgbGJCq78d29CmWQQQMPg==",
-			"dev": true,
-			"engines": {
-				"node": ">= 6.0.0"
-			}
-		},
 		"node_modules/doctrine": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
@@ -55484,7 +55475,7 @@
 			"dependencies": {
 				"chalk": "^4.0.0",
 				"copy-dir": "^1.3.0",
-				"docker-compose": "^0.22.2",
+				"docker-compose": "^0.24.3",
 				"extract-zip": "^1.6.7",
 				"got": "^11.8.5",
 				"inquirer": "^7.1.0",
@@ -55511,6 +55502,18 @@
 			},
 			"engines": {
 				"node": ">=12"
+			}
+		},
+		"packages/env/node_modules/docker-compose": {
+			"version": "0.24.2",
+			"resolved": "https://registry.npmjs.org/docker-compose/-/docker-compose-0.24.2.tgz",
+			"integrity": "sha512-2/WLvA7UZ6A2LDLQrYW0idKipmNBWhtfvrn2yzjC5PnHDzuFVj1zAZN6MJxVMKP0zZH8uzAK6OwVZYHGuyCmTw==",
+			"dev": true,
+			"dependencies": {
+				"yaml": "^2.2.2"
+			},
+			"engines": {
+				"node": ">= 6.0.0"
 			}
 		},
 		"packages/env/node_modules/emoji-regex": {
@@ -55564,6 +55567,15 @@
 			"resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
 			"integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
 			"dev": true
+		},
+		"packages/env/node_modules/yaml": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.2.tgz",
+			"integrity": "sha512-N/lyzTPaJasoDmfV7YTrYCI0G/3ivm/9wdG0aHuheKowWQwGTsK0Eoiw6utmzAnI6pkJa0DUVygvp3spqqEKXg==",
+			"dev": true,
+			"engines": {
+				"node": ">= 14"
+			}
 		},
 		"packages/env/node_modules/yargs": {
 			"version": "17.7.2",
@@ -70702,7 +70714,7 @@
 			"requires": {
 				"chalk": "^4.0.0",
 				"copy-dir": "^1.3.0",
-				"docker-compose": "^0.22.2",
+				"docker-compose": "^0.24.3",
 				"extract-zip": "^1.6.7",
 				"got": "^11.8.5",
 				"inquirer": "^7.1.0",
@@ -70723,6 +70735,14 @@
 						"string-width": "^4.2.0",
 						"strip-ansi": "^6.0.1",
 						"wrap-ansi": "^7.0.0"
+					}
+				},
+				"docker-compose": {
+					"version": "https://registry.npmjs.org/docker-compose/-/docker-compose-0.24.2.tgz",
+					"integrity": "sha512-2/WLvA7UZ6A2LDLQrYW0idKipmNBWhtfvrn2yzjC5PnHDzuFVj1zAZN6MJxVMKP0zZH8uzAK6OwVZYHGuyCmTw==",
+					"dev": true,
+					"requires": {
+						"yaml": "^2.2.2"
 					}
 				},
 				"emoji-regex": {
@@ -70763,6 +70783,12 @@
 					"version": "5.0.8",
 					"resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
 					"integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+					"dev": true
+				},
+				"yaml": {
+					"version": "2.3.2",
+					"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.2.tgz",
+					"integrity": "sha512-N/lyzTPaJasoDmfV7YTrYCI0G/3ivm/9wdG0aHuheKowWQwGTsK0Eoiw6utmzAnI6pkJa0DUVygvp3spqqEKXg==",
 					"dev": true
 				},
 				"yargs": {
@@ -76980,12 +77006,6 @@
 			"requires": {
 				"@leichtgewicht/ip-codec": "^2.0.1"
 			}
-		},
-		"docker-compose": {
-			"version": "0.22.2",
-			"resolved": "https://registry.npmjs.org/docker-compose/-/docker-compose-0.22.2.tgz",
-			"integrity": "sha512-iXWb5+LiYmylIMFXvGTYsjI1F+Xyx78Jm/uj1dxwwZLbWkUdH6yOXY5Nr3RjbYX15EgbGJCq78d29CmWQQQMPg==",
-			"dev": true
 		},
 		"doctrine": {
 			"version": "2.1.0",

--- a/packages/env/CHANGELOG.md
+++ b/packages/env/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Change
+
+- Update Docker usage to `docker compose` V2 following [deprecation](https://docs.docker.com/compose/migrate/) of `docker-compose` V1.
+
 ## 8.13.0 (2023-11-29)
 
 ## 8.12.0 (2023-11-16)

--- a/packages/env/lib/cli.js
+++ b/packages/env/lib/cli.js
@@ -58,10 +58,10 @@ const withSpinner =
 					'err' in error &&
 					'out' in error
 				) {
-					// Error is a docker-compose error. That means something docker-related failed.
+					// Error is a docker compose error. That means something docker-related failed.
 					// https://github.com/PDMLab/docker-compose/blob/HEAD/src/index.ts
 					spinner.fail(
-						'Error while running docker-compose command.'
+						'Error while running docker compose command.'
 					);
 					if ( error.out ) {
 						process.stdout.write( error.out );

--- a/packages/env/lib/commands/clean.js
+++ b/packages/env/lib/commands/clean.js
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-const dockerCompose = require( 'docker-compose' );
+const { v2: dockerCompose } = require( 'docker-compose' );
 
 /**
  * Internal dependencies

--- a/packages/env/lib/commands/destroy.js
+++ b/packages/env/lib/commands/destroy.js
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-const dockerCompose = require( 'docker-compose' );
+const { v2: dockerCompose } = require( 'docker-compose' );
 const util = require( 'util' );
 const fs = require( 'fs' ).promises;
 const path = require( 'path' );

--- a/packages/env/lib/commands/logs.js
+++ b/packages/env/lib/commands/logs.js
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-const dockerCompose = require( 'docker-compose' );
+const { v2: dockerCompose } = require( 'docker-compose' );
 
 /**
  * Internal dependencies

--- a/packages/env/lib/commands/run.js
+++ b/packages/env/lib/commands/run.js
@@ -78,6 +78,7 @@ function spawnCommandDirectly( config, container, command, envCwd, spinner ) {
 	);
 
 	const composeCommand = [
+		'compose',
 		'-f',
 		config.dockerComposeConfigPath,
 		'exec',
@@ -98,7 +99,7 @@ function spawnCommandDirectly( config, container, command, envCwd, spinner ) {
 		// cannot use it to spawn an interactive command. Thus, we run docker-
 		// compose on the CLI directly.
 		const childProc = spawn(
-			'docker-compose',
+			'docker',
 			composeCommand,
 			{ stdio: 'inherit' },
 			spinner

--- a/packages/env/lib/commands/start.js
+++ b/packages/env/lib/commands/start.js
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-const dockerCompose = require( 'docker-compose' );
+const { v2: dockerCompose } = require( 'docker-compose' );
 const util = require( 'util' );
 const path = require( 'path' );
 const fs = require( 'fs' ).promises;

--- a/packages/env/lib/commands/stop.js
+++ b/packages/env/lib/commands/stop.js
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-const dockerCompose = require( 'docker-compose' );
+const { v2: dockerCompose } = require( 'docker-compose' );
 
 /**
  * Internal dependencies

--- a/packages/env/lib/test/cli.js
+++ b/packages/env/lib/test/cli.js
@@ -138,7 +138,7 @@ describe( 'env cli', () => {
 		await env.start.mock.results[ 0 ].value.catch( () => {} );
 
 		expect( spinner.fail ).toHaveBeenCalledWith(
-			'Error while running docker-compose command.'
+			'Error while running docker compose command.'
 		);
 		expect( process.stderr.write ).toHaveBeenCalledWith( 'failure error' );
 		expect( process.exit ).toHaveBeenCalledWith( 1 );

--- a/packages/env/lib/wordpress.js
+++ b/packages/env/lib/wordpress.js
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-const dockerCompose = require( 'docker-compose' );
+const { v2: dockerCompose } = require( 'docker-compose' );
 const util = require( 'util' );
 const fs = require( 'fs' ).promises;
 const path = require( 'path' );

--- a/packages/env/package.json
+++ b/packages/env/package.json
@@ -34,7 +34,7 @@
 	"dependencies": {
 		"chalk": "^4.0.0",
 		"copy-dir": "^1.3.0",
-		"docker-compose": "^0.22.2",
+		"docker-compose": "^0.24.3",
 		"extract-zip": "^1.6.7",
 		"got": "^11.8.5",
 		"inquirer": "^7.1.0",

--- a/test/unit/jest.config.js
+++ b/test/unit/jest.config.js
@@ -39,6 +39,10 @@ module.exports = {
 	transform: {
 		'^.+\\.[jt]sx?$': '<rootDir>/test/unit/scripts/babel-transformer.js',
 	},
+	transformIgnorePatterns: [
+		'/node_modules/(?!(docker-compose|yaml)/)',
+		'\\.pnp\\.[^\\/]+$',
+	],
 	snapshotSerializers: [
 		'@emotion/jest/serializer',
 		'snapshot-diff/serializer',


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/51249

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

This PR updates `docker-compose` command to v2 `docker compose`.

## Why?
As explained in https://github.com/WordPress/gutenberg/issues/51249 , `docker-compose` v1 is now [deprecated in favor of v2](https://docs.docker.com/compose/migrate/).

## How?
- Update of [docker-compose](https://www.npmjs.com/package/docker-compose) package, the new version [includes support for v2](https://github.com/PDMLab/docker-compose/blob/master/CHANGELOG.md#0240-2023-04-28)
- Update of a command using hardcoded `docker-compose`
- Update of some comments

## Testing Instructions
Run all modified commands:
- `wp-env start`
- `wp-env logs`
- `wp-env run cli wp user list`
- `wp-env stop`
- `wp-env clean`
- `wp-env destroy`

