### PR TITLE
Post Author - don't show 0 in inspector controls

### DIFF
--- a/packages/block-library/src/post-author/edit.js
+++ b/packages/block-library/src/post-author/edit.js
@@ -93,14 +93,14 @@ function PostAuthorEdit( {
 	};
 
 	const showCombobox = authorOptions.length >= minimumUsersForCombobox;
+	const showAuthorControl =
+		!! postId && ! isDescendentOfQueryLoop && authorOptions.length > 0;
 
 	return (
 		<>
 			<InspectorControls>
 				<PanelBody title={ __( 'Settings' ) }>
-					{ !! postId &&
-						! isDescendentOfQueryLoop &&
-						authorOptions.length &&
+					{ showAuthorControl &&
 						( ( showCombobox && (
 							<ComboboxControl
 								__nextHasNoMarginBottom


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
This is a small fix addressing "0" displayed when user has no rights for fetching post authors.

Fixes: https://github.com/WordPress/gutenberg/issues/51342

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Even though `0` is a falsy value and it seems fine for using when rendering components conditionally, React will render it as `0` (when value is `false`, React renders nothing).

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

When user has no access to authors, authors array was empty and when used as `authorOptions.length`, React would render "0". Changing it to a boolean condition ensures that nothing is rendered instead.

Another approach could be using a ternary operator and returning `null` if the condition is falsy.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
1. As an admin user, create a new page with any content
2. Log in as an Editor
3. Edit page added in step 1
4. Add Post Author block
5. Ensure that "0" doesn't show in Inspector controls in the "Settings" section. Just above "show avatar".

## Screenshots or screencast <!-- if applicable -->

Before:

<img width="279" alt="Screenshot 2023-06-08 at 16 23 13" src="https://github.com/WordPress/gutenberg/assets/4765119/c4c42b1e-9e27-42b2-99a5-f1f28796036e">


After:


<img width="276" alt="Screenshot 2023-06-08 at 16 40 15" src="https://github.com/WordPress/gutenberg/assets/4765119/6c2c9f49-2855-42ce-bea7-8b86f6d08604">
