### PR TITLE
Consolidate duplicate block tests

### DIFF
--- a/test/e2e/specs/editor/various/duplicating-blocks.spec.js
+++ b/test/e2e/specs/editor/various/duplicating-blocks.spec.js
@@ -8,7 +8,7 @@ test.describe( 'Duplicating blocks', () => {
 		await admin.createNewPost();
 	} );
 
-	test( 'should duplicate blocks using the block settings menu', async ( {
+	test( 'should duplicate blocks using the block settings menu and keyboard shortcut', async ( {
 		page,
 		pageUtils,
 		editor,
@@ -16,11 +16,7 @@ test.describe( 'Duplicating blocks', () => {
 		await editor.insertBlock( { name: 'core/paragraph' } );
 		await page.keyboard.type( 'Clone me' );
 
-		// Select the test we just typed
-		// This doesn't do anything but we previously had a duplicationi bug
-		// When the selection was not collapsed.
-		await pageUtils.pressKeys( 'primary+a' );
-
+		// Test: Duplicate using the block settings menu.
 		await editor.clickBlockToolbarButton( 'Options' );
 		await page.click( 'role=menuitem[name=/Duplicate/i]' );
 
@@ -33,21 +29,16 @@ test.describe( 'Duplicating blocks', () => {
 <p>Clone me</p>
 <!-- /wp:paragraph -->`
 		);
-	} );
 
-	test( 'should duplicate blocks using the keyboard shortcut', async ( {
-		page,
-		pageUtils,
-		editor,
-	} ) => {
-		await editor.insertBlock( { name: 'core/paragraph' } );
-		await page.keyboard.type( 'Clone me' );
-
-		// Duplicate using the keyboard shortccut.
+		// Test: Duplicate using the keyboard shortccut.
 		await pageUtils.pressKeys( 'primaryShift+d' );
 
 		expect( await editor.getEditedPostContent() ).toBe(
 			`<!-- wp:paragraph -->
+<p>Clone me</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
 <p>Clone me</p>
 <!-- /wp:paragraph -->
 

--- a/test/e2e/specs/editor/various/duplicating-blocks.spec.js
+++ b/test/e2e/specs/editor/various/duplicating-blocks.spec.js
@@ -43,11 +43,6 @@ test.describe( 'Duplicating blocks', () => {
 		await editor.insertBlock( { name: 'core/paragraph' } );
 		await page.keyboard.type( 'Clone me' );
 
-		// Select the test we just typed
-		// This doesn't do anything but we previously had a duplicationi bug
-		// When the selection was not collapsed.
-		await pageUtils.pressKeys( 'primary+a' );
-
 		// Duplicate using the keyboard shortccut.
 		await pageUtils.pressKeys( 'primaryShift+d' );
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Removes a line that was added to circumvent a bug that is seemingly no longer relevant and consolidates test for speed.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Code cleanup. Consolidates similar tests into one longer test rather than needing to recreate a more time-consuming new admin post for each test.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
`npm run test:e2e:playwright duplicating-blocks`
