### PR TITLE
Image block: Add animation toggle to lightbox behavior

### DIFF
--- a/lib/block-supports/behaviors.php
+++ b/lib/block-supports/behaviors.php
@@ -77,11 +77,19 @@ function gutenberg_render_behaviors_support_lightbox( $block_content, $block ) {
 
 	$lightbox_animation = $lightbox_settings['animation'];
 
+	$z = new WP_HTML_Tag_Processor( $content );
+	$z->next_tag('img');
+	if ( isset( $block['attrs']['id'] ) ) {
+		$img_src = wp_get_attachment_url( $block['attrs']['id'] );
+	} else {
+		$img_src = $m->get_attribute( 'src' );
+	}
+
 	$w = new WP_HTML_Tag_Processor( $content );
 	$w->next_tag( 'figure' );
 	$w->add_class( 'wp-lightbox-container' );
 	$w->set_attribute( 'data-wp-interactive', true );
-	$w->set_attribute( 'data-wp-context', '{ "core": { "image": { "initialized": false, "lightboxEnabled": false, "lightboxAnimation": "' . $lightbox_animation . '" } } }' );
+	$w->set_attribute( 'data-wp-context', '{ "core": { "image": { "initialized": false, "imageSrc": "' . $img_src . '", "lightboxEnabled": false, "lightboxAnimation": "' . $lightbox_animation . '" } } }' );
 	$body_content = $w->get_updated_html();
 
 	// Wrap the image in the body content with a button.
@@ -96,16 +104,7 @@ function gutenberg_render_behaviors_support_lightbox( $block_content, $block ) {
 	// Add directive to expand modal image if appropriate.
 	$m = new WP_HTML_Tag_Processor( $content );
 	$m->next_tag( 'img' );
-	if ( isset( $block['attrs']['id'] ) ) {
-		$img_src = wp_get_attachment_url( $block['attrs']['id'] );
-	} else {
-		$img_src = $m->get_attribute( 'src' );
-	}
-
-	// Need to figure out how to smoothly transition image animation when using larger image
-	//
-	// $m->set_attribute( 'data-wp-context', '{ "core": { "image": { "imageSrc": "' . $img_src . '"} } }' );
-	// $m->set_attribute( 'data-wp-bind--src', 'selectors.core.image.imageSrc' );
+	$m->set_attribute( 'data-wp-bind--src', 'selectors.core.image.imageSrc' );
 	$modal_content = $m->get_updated_html();
 
 	$background_color = esc_attr( wp_get_global_styles( array( 'color', 'background' ) ) );

--- a/lib/block-supports/behaviors.php
+++ b/lib/block-supports/behaviors.php
@@ -78,11 +78,11 @@ function gutenberg_render_behaviors_support_lightbox( $block_content, $block ) {
 	$lightbox_animation = $lightbox_settings['animation'];
 
 	$z = new WP_HTML_Tag_Processor( $content );
-	$z->next_tag('img');
+	$z->next_tag( 'img' );
 	if ( isset( $block['attrs']['id'] ) ) {
 		$img_src = wp_get_attachment_url( $block['attrs']['id'] );
 	} else {
-		$img_src = $m->get_attribute( 'src' );
+		$img_src = $z->get_attribute( 'src' );
 	}
 
 	$w = new WP_HTML_Tag_Processor( $content );

--- a/lib/block-supports/behaviors.php
+++ b/lib/block-supports/behaviors.php
@@ -89,7 +89,7 @@ function gutenberg_render_behaviors_support_lightbox( $block_content, $block ) {
 	$w->next_tag( 'figure' );
 	$w->add_class( 'wp-lightbox-container' );
 	$w->set_attribute( 'data-wp-interactive', true );
-	$w->set_attribute( 'data-wp-context', '{ "core": { "image": { "initialized": false, "imageSrc": "' . $img_src . '", "lightboxEnabled": false, "lightboxAnimation": "' . $lightbox_animation . '" } } }' );
+	$w->set_attribute( 'data-wp-context', '{ "core": { "image": { "initialized": false, "imageSrc": "' . $img_src . '", "lightboxEnabled": false, "lightboxAnimation": "' . $lightbox_animation . '", "animateOutEnabled": false } } }' );
 	$body_content = $w->get_updated_html();
 
 	// Wrap the image in the body content with a button.
@@ -120,6 +120,7 @@ function gutenberg_render_behaviors_support_lightbox( $block_content, $block ) {
             aria-label="$dialog_label"
             data-wp-class--initialized="context.core.image.initialized"
             data-wp-class--active="context.core.image.lightboxEnabled"
+			data-wp-class--animateOutEnabled="context.core.image.animateOutEnabled"
             data-wp-bind--aria-hidden="!context.core.image.lightboxEnabled"
             data-wp-bind--aria-modal="context.core.image.lightboxEnabled"
             data-wp-effect="effects.core.image.initLightbox"

--- a/lib/block-supports/behaviors.php
+++ b/lib/block-supports/behaviors.php
@@ -75,8 +75,12 @@ function gutenberg_render_behaviors_support_lightbox( $block_content, $block ) {
 	}
 	$content = $processor->get_updated_html();
 
-	$lightbox_animation = $lightbox_settings['animation'];
+	$lightbox_animation = '';
+	if ( isset( $lightbox_settings['animation'] ) ) {
+		$lightbox_animation = $lightbox_settings['animation'];
+	}
 
+	// We want to store the src in the context so we can set it dynamically when the lightbox is opened.
 	$z = new WP_HTML_Tag_Processor( $content );
 	$z->next_tag( 'img' );
 	if ( isset( $block['attrs']['id'] ) ) {
@@ -89,7 +93,10 @@ function gutenberg_render_behaviors_support_lightbox( $block_content, $block ) {
 	$w->next_tag( 'figure' );
 	$w->add_class( 'wp-lightbox-container' );
 	$w->set_attribute( 'data-wp-interactive', true );
-	$w->set_attribute( 'data-wp-context', '{ "core": { "image": { "initialized": false, "imageSrc": "' . $img_src . '", "lightboxEnabled": false, "lightboxAnimation": "' . $lightbox_animation . '", "animateOutEnabled": false } } }' );
+	$w->set_attribute(
+		'data-wp-context',
+		sprintf( '{ "core":{ "image": { "initialized": false, "imageSrc": "%s", "lightboxEnabled": false, "lightboxAnimation": "%s", "hideAnimationEnabled": false } } }', $img_src, $lightbox_animation )
+	);
 	$body_content = $w->get_updated_html();
 
 	// Wrap the image in the body content with a button.
@@ -101,7 +108,7 @@ function gutenberg_render_behaviors_support_lightbox( $block_content, $block ) {
 		'</div>';
 	$body_content = preg_replace( '/<img[^>]+>/', $button, $body_content );
 
-	// Add directive to expand modal image if appropriate.
+	// Add src to the modal image.
 	$m = new WP_HTML_Tag_Processor( $content );
 	$m->next_tag( 'img' );
 	$m->set_attribute( 'data-wp-bind--src', 'selectors.core.image.imageSrc' );
@@ -120,7 +127,7 @@ function gutenberg_render_behaviors_support_lightbox( $block_content, $block ) {
             aria-label="$dialog_label"
             data-wp-class--initialized="context.core.image.initialized"
             data-wp-class--active="context.core.image.lightboxEnabled"
-			data-wp-class--animateOutEnabled="context.core.image.animateOutEnabled"
+			data-wp-class--hideAnimationEnabled="context.core.image.hideAnimationEnabled"
             data-wp-bind--aria-hidden="!context.core.image.lightboxEnabled"
             data-wp-bind--aria-modal="context.core.image.lightboxEnabled"
             data-wp-effect="effects.core.image.initLightbox"

--- a/lib/theme.json
+++ b/lib/theme.json
@@ -3,7 +3,10 @@
 	"behaviors": {
 		"blocks": {
 			"core/image": {
-				"lightbox": false
+				"lightbox": {
+					"enabled": false,
+					"animation": ""
+				}
 			}
 		}
 	},

--- a/packages/block-editor/src/hooks/behaviors.js
+++ b/packages/block-editor/src/hooks/behaviors.js
@@ -87,17 +87,43 @@ function BehaviorsControl( {
 
 	return (
 		<InspectorControls group="advanced">
-			<SelectControl
-				label={ __( 'Behaviors' ) }
-				// At the moment we are only supporting one behavior (Lightbox)
-				value={ value() }
-				options={ options }
-				onChange={ onChange }
-				hideCancelButton={ true }
-				help={ helpText }
-				size="__unstable-large"
-				disabled={ disabled }
-			/>
+			{ /* This div is needed to prevent a margin bottom between the dropdown and the button. */ }
+			<div>
+				<SelectControl
+					label={ __( 'Behaviors' ) }
+					// At the moment we are only supporting one behavior (Lightbox)
+					value={ value() }
+					options={ options }
+					onChange={ onChange }
+					hideCancelButton={ true }
+					help={ helpText }
+					size="__unstable-large"
+					disabled={ disabled }
+				/>
+				{ behaviors?.lightbox.enabled && (
+					<SelectControl
+						label={ __( 'Lightbox Animation' ) }
+						// At the moment we are only supporting one behavior (Lightbox)
+						value={
+							behaviors?.lightbox.animation
+								? behaviors?.lightbox.animation
+								: ''
+						}
+						options={ [
+							{
+								value: 'zoom',
+								label: __( 'Zoom' ),
+							},
+							{ value: 'fade', label: 'Fade' },
+						] }
+						onChange={ onChange }
+						hideCancelButton={ false }
+						help={ __( 'Select animation.' ) }
+						size="__unstable-large"
+						disabled={ disabled }
+					/>
+				) }
+			</div>
 		</InspectorControls>
 	);
 }
@@ -136,9 +162,22 @@ export const withBehaviors = createHigherOrderComponent( ( BlockEdit ) => {
 						} else {
 							// If the user selects something, it means that they want to
 							// change the default value (true) so we save it in the attributes.
+							const enabled =
+								nextValue === 'lightbox' ||
+								nextValue === 'zoom' ||
+								nextValue === 'fade'
+									? true
+									: false;
+							const animation =
+								nextValue === 'zoom' || nextValue === 'fade'
+									? nextValue
+									: 'zoom';
 							props.setAttributes( {
 								behaviors: {
-									lightbox: nextValue === 'lightbox',
+									lightbox: {
+										enabled,
+										animation,
+									},
 								},
 							} );
 						}

--- a/packages/block-editor/src/hooks/behaviors.js
+++ b/packages/block-editor/src/hooks/behaviors.js
@@ -73,7 +73,7 @@ function BehaviorsControl( {
 
 	const helpText = disabled
 		? __( 'The lightbox behavior is disabled for linked images.' )
-		: __( 'Add behaviors.' );
+		: '';
 
 	const value = () => {
 		if ( blockBehaviors === undefined ) {
@@ -102,7 +102,7 @@ function BehaviorsControl( {
 				/>
 				{ behaviors?.lightbox.enabled && (
 					<SelectControl
-						label={ __( 'Lightbox Animation' ) }
+						label={ __( 'Animation' ) }
 						// At the moment we are only supporting one behavior (Lightbox)
 						value={
 							behaviors?.lightbox.animation
@@ -118,7 +118,6 @@ function BehaviorsControl( {
 						] }
 						onChange={ onChange }
 						hideCancelButton={ false }
-						help={ __( 'Select animation.' ) }
 						size="__unstable-large"
 						disabled={ disabled }
 					/>

--- a/packages/block-editor/src/hooks/behaviors.js
+++ b/packages/block-editor/src/hooks/behaviors.js
@@ -2,11 +2,7 @@
  * WordPress dependencies
  */
 import { addFilter } from '@wordpress/hooks';
-import {
-	SelectControl,
-	Button,
-	__experimentalHStack as HStack,
-} from '@wordpress/components';
+import { SelectControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { hasBlockSupport } from '@wordpress/blocks';
 import { createHigherOrderComponent } from '@wordpress/compose';
@@ -48,6 +44,11 @@ function BehaviorsControl( {
 		label: __( 'No behaviors' ),
 	};
 
+	const defaultBehaviorsOption = {
+		value: 'default',
+		label: __( 'Default' ),
+	};
+
 	const behaviorsOptions = Object.entries( settings )
 		.filter(
 			( [ behaviorName, behaviorValue ] ) =>
@@ -65,7 +66,11 @@ function BehaviorsControl( {
 	// If every behavior is disabled, do not show the behaviors inspector control.
 	if ( behaviorsOptions.length === 0 ) return null;
 
-	const options = [ noBehaviorsOption, ...behaviorsOptions ];
+	const options = [
+		defaultBehaviorsOption,
+		noBehaviorsOption,
+		...behaviorsOptions,
+	];
 
 	// Block behaviors take precedence over theme behaviors.
 	const behaviors = merge( themeBehaviors, blockBehaviors || {} );
@@ -77,28 +82,17 @@ function BehaviorsControl( {
 	return (
 		<InspectorControls group="advanced">
 			{ /* This div is needed to prevent a margin bottom between the dropdown and the button. */ }
-			<div>
-				<SelectControl
-					label={ __( 'Behaviors' ) }
-					// At the moment we are only supporting one behavior (Lightbox)
-					value={ behaviors?.lightbox ? 'lightbox' : '' }
-					options={ options }
-					onChange={ onChange }
-					hideCancelButton={ true }
-					help={ helpText }
-					size="__unstable-large"
-					disabled={ disabled }
-				/>
-			</div>
-			<HStack justify="flex-end">
-				<Button
-					isSmall
-					disabled={ disabled }
-					onClick={ () => onChange( undefined ) }
-				>
-					{ __( 'Reset' ) }
-				</Button>
-			</HStack>
+			<SelectControl
+				label={ __( 'Behaviors' ) }
+				// At the moment we are only supporting one behavior (Lightbox)
+				value={ behaviors?.lightbox ? 'lightbox' : '' }
+				options={ options }
+				onChange={ onChange }
+				hideCancelButton={ true }
+				help={ helpText }
+				size="__unstable-large"
+				disabled={ disabled }
+			/>
 		</InspectorControls>
 	);
 }
@@ -130,7 +124,7 @@ export const withBehaviors = createHigherOrderComponent( ( BlockEdit ) => {
 					blockName={ props.name }
 					blockBehaviors={ props.attributes.behaviors }
 					onChange={ ( nextValue ) => {
-						if ( nextValue === undefined ) {
+						if ( nextValue === 'default' ) {
 							props.setAttributes( {
 								behaviors: undefined,
 							} );

--- a/packages/block-editor/src/hooks/behaviors.js
+++ b/packages/block-editor/src/hooks/behaviors.js
@@ -17,7 +17,8 @@ import { InspectorControls } from '../components';
 function BehaviorsControl( {
 	blockName,
 	blockBehaviors,
-	onChange,
+	onChangeBehavior,
+	onChangeAnimation,
 	disabled = false,
 } ) {
 	const { settings, themeBehaviors } = useSelect(
@@ -79,7 +80,7 @@ function BehaviorsControl( {
 		if ( blockBehaviors === undefined ) {
 			return 'default';
 		}
-		if ( behaviors?.lightbox ) {
+		if ( behaviors?.lightbox.enabled ) {
 			return 'lightbox';
 		}
 		return '';
@@ -94,7 +95,7 @@ function BehaviorsControl( {
 					// At the moment we are only supporting one behavior (Lightbox)
 					value={ value() }
 					options={ options }
-					onChange={ onChange }
+					onChange={ onChangeBehavior }
 					hideCancelButton={ true }
 					help={ helpText }
 					size="__unstable-large"
@@ -116,7 +117,7 @@ function BehaviorsControl( {
 							},
 							{ value: 'fade', label: 'Fade' },
 						] }
-						onChange={ onChange }
+						onChange={ onChangeAnimation }
 						hideCancelButton={ false }
 						size="__unstable-large"
 						disabled={ disabled }
@@ -153,7 +154,7 @@ export const withBehaviors = createHigherOrderComponent( ( BlockEdit ) => {
 				<BehaviorsControl
 					blockName={ props.name }
 					blockBehaviors={ props.attributes.behaviors }
-					onChange={ ( nextValue ) => {
+					onChangeBehavior={ ( nextValue ) => {
 						if ( nextValue === 'default' ) {
 							props.setAttributes( {
 								behaviors: undefined,
@@ -161,25 +162,26 @@ export const withBehaviors = createHigherOrderComponent( ( BlockEdit ) => {
 						} else {
 							// If the user selects something, it means that they want to
 							// change the default value (true) so we save it in the attributes.
-							const enabled =
-								nextValue === 'lightbox' ||
-								nextValue === 'zoom' ||
-								nextValue === 'fade'
-									? true
-									: false;
-							const animation =
-								nextValue === 'zoom' || nextValue === 'fade'
-									? nextValue
-									: 'zoom';
 							props.setAttributes( {
 								behaviors: {
 									lightbox: {
-										enabled,
-										animation,
+										enabled: nextValue === 'lightbox',
 									},
 								},
 							} );
 						}
+					} }
+					onChangeAnimation={ ( nextValue ) => {
+						props.setAttributes( {
+							behaviors: {
+								lightbox: {
+									enabled:
+										props.attributes.behaviors.lightbox
+											.enabled,
+									animation: nextValue,
+								},
+							},
+						} );
 					} }
 					disabled={ blockHasLink }
 				/>

--- a/packages/block-editor/src/hooks/behaviors.js
+++ b/packages/block-editor/src/hooks/behaviors.js
@@ -166,6 +166,10 @@ export const withBehaviors = createHigherOrderComponent( ( BlockEdit ) => {
 								behaviors: {
 									lightbox: {
 										enabled: nextValue === 'lightbox',
+										animation:
+											nextValue === 'lightbox'
+												? 'zoom'
+												: '',
 									},
 								},
 							} );

--- a/packages/block-editor/src/hooks/behaviors.js
+++ b/packages/block-editor/src/hooks/behaviors.js
@@ -66,7 +66,7 @@ function BehaviorsControl( {
 	];
 
 	// If every behavior is disabled, do not show the behaviors inspector control.
-	if ( options.length === 0 ) {
+	if ( behaviorsOptions.length === 0 ) {
 		return null;
 	}
 	// Block behaviors take precedence over theme behaviors.

--- a/packages/block-library/src/image/interactivity.js
+++ b/packages/block-library/src/image/interactivity.js
@@ -26,9 +26,6 @@ store( {
 					context.core.image.lastFocusedElement =
 						window.document.activeElement;
 					context.core.image.scrollPosition = window.scrollY;
-					document.documentElement.classList.add(
-						'has-lightbox-open'
-					);
 
 					const imgDom = document.createElement( 'img' );
 					imgDom.onload = function () {
@@ -144,6 +141,9 @@ store( {
 								scaleHeight
 							);
 						}
+						document.documentElement.classList.add(
+							'has-lightbox-open'
+						);
 					};
 					imgDom.setAttribute( 'src', context.core.image.imageSrc );
 				},

--- a/packages/block-library/src/image/interactivity.js
+++ b/packages/block-library/src/image/interactivity.js
@@ -166,28 +166,12 @@ function setZoomStyles( imgDom, context, event ) {
 	let targetWidth = imgDom.naturalWidth;
 	let targetHeight = imgDom.naturalHeight;
 
-	const figureStyle = window.getComputedStyle( context.core.image.figureRef );
-	const topPadding = parseInt(
-		figureStyle.getPropertyValue( 'padding-top' )
-	);
-	const bottomPadding = parseInt(
-		figureStyle.getPropertyValue( 'padding-bottom' )
-	);
+	const verticalPadding = 40;
 
 	// As per the design, let's allow the image to stretch
 	// to the full width of its containing figure, but for the height,
-	// constrain it to the padding settings
+	// constrain it with a fixed padding
 	const containerWidth = context.core.image.figureRef.clientWidth;
-	const containerHeight =
-		context.core.image.figureRef.clientHeight - topPadding - bottomPadding;
-
-	// Check difference between the image and figure dimensions
-	const widthOverflow = Math.abs(
-		Math.min( containerWidth - targetWidth, 0 )
-	);
-	const heightOverflow = Math.abs(
-		Math.min( containerHeight - targetHeight, 0 )
-	);
 
 	// The lightbox image has `positione:absolute` and
 	// ignores its parent's padding, so let's set the padding here,
@@ -199,9 +183,24 @@ function setZoomStyles( imgDom, context, event ) {
 		horizontalPadding = 80;
 	}
 
-	// If image is larger than its container, resize along its largest axis
+	const containerHeight =
+		context.core.image.figureRef.clientHeight - verticalPadding * 2;
+
+	// Check difference between the image and figure dimensions
+	const widthOverflow = Math.abs(
+		Math.min( containerWidth - targetWidth, 0 )
+	);
+	const heightOverflow = Math.abs(
+		Math.min( containerHeight - targetHeight, 0 )
+	);
+
+	// If image is larger than its container any dimension, resize along its largest axis.
+	// For vertically oriented devices, always maximize the width.
 	if ( widthOverflow > 0 || heightOverflow > 0 ) {
-		if ( widthOverflow > heightOverflow ) {
+		if (
+			widthOverflow >= heightOverflow ||
+			containerHeight >= containerWidth
+		) {
 			targetWidth = containerWidth - horizontalPadding * 2;
 			targetHeight =
 				imgDom.naturalHeight * ( targetWidth / imgDom.naturalWidth );
@@ -229,9 +228,9 @@ function setZoomStyles( imgDom, context, event ) {
 	}
 	let targetTop = 0;
 	if ( targetHeight >= containerHeight ) {
-		targetTop = topPadding;
+		targetTop = verticalPadding;
 	} else {
-		targetTop = ( containerHeight - targetHeight ) / 2 + topPadding;
+		targetTop = ( containerHeight - targetHeight ) / 2 + verticalPadding;
 	}
 
 	const root = document.documentElement;

--- a/packages/block-library/src/image/style.scss
+++ b/packages/block-library/src/image/style.scss
@@ -231,19 +231,50 @@
 		opacity: 0.9;
 	}
 
-	&.initialized {
-		animation: both turn-off-visibility 300ms;
-
-		img {
-			animation: both turn-off-visibility 250ms;
-		}
-
+	&.fade {
 		&.active {
 			visibility: visible;
 			animation: both turn-on-visibility 250ms;
 
 			img {
 				animation: both turn-on-visibility 300ms;
+			}
+		}
+		&.initialized {
+			&:not(.active) {
+				animation: both turn-off-visibility 300ms;
+
+				img {
+					animation: both turn-off-visibility 250ms;
+				}
+			}
+		}
+	}
+
+	&.zoom {
+		img {
+			position: absolute;
+			transform-origin: top left;
+		}
+
+		&.active {
+			opacity: 1;
+			visibility: visible;
+			.wp-block-image img {
+				animation: lightbox-zoom-in .4s forwards;
+			}
+			.scrim {
+				animation: turn-on-visibility .4s forwards;
+			}
+		}
+		&.initialized {
+			&:not(.active) {
+				.wp-block-image img {
+					animation: lightbox-zoom-out .4s forwards;
+				}
+				.scrim {
+					animation: turn-off-visibility .4s forwards;
+				}
 			}
 		}
 	}
@@ -273,6 +304,39 @@
 	}
 }
 
-html.has-lightbox-open {
-	overflow: hidden;
+// This line causes the zoom animation to jump
+//
+// html.has-lightbox-open {
+// 	overflow: hidden;
+// }
+
+@keyframes lightbox-zoom-in {
+	0% {
+		left: var(--lightbox-left-position);
+		top: var(--lightbox-top-position);
+		transform: scale(var(--lightbox-scale-width), var(--lightbox-scale-height));
+	}
+	100% {
+		left: 50%;
+		top: 50%;
+		transform: translate(-50%, -50%) scale(1, 1);
+	}
+}
+
+@keyframes lightbox-zoom-out {
+	0% {
+		visibility: visible;
+		left: 50%;
+		top: 50%;
+		transform: translate(-50%, -50%) scale(1, 1);
+	}
+	99% {
+		visibility: visible;
+	}
+	100% {
+
+		left: var(--lightbox-left-position);
+		top: var(--lightbox-top-position);
+		transform: scale(var(--lightbox-scale-width), var(--lightbox-scale-height));
+	}
 }

--- a/packages/block-library/src/image/style.scss
+++ b/packages/block-library/src/image/style.scss
@@ -255,6 +255,8 @@
 		img {
 			position: absolute;
 			transform-origin: top left;
+			width: var(--lightbox-image-max-width);
+			height: var(--lightbox-image-max-height);
 		}
 
 		&.active {

--- a/packages/block-library/src/image/style.scss
+++ b/packages/block-library/src/image/style.scss
@@ -308,9 +308,9 @@
 
 // This line causes the zoom animation to jump
 //
-// html.has-lightbox-open {
-// 	overflow: hidden;
-// }
+html.has-lightbox-open {
+	overflow: hidden;
+}
 
 @keyframes lightbox-zoom-in {
 	0% {

--- a/packages/block-library/src/image/style.scss
+++ b/packages/block-library/src/image/style.scss
@@ -204,7 +204,6 @@
 		justify-content: center;
 		align-items: center;
 		flex-direction: column;
-		padding: 30px;
 
 		figcaption {
 			display: none;

--- a/packages/block-library/src/image/style.scss
+++ b/packages/block-library/src/image/style.scss
@@ -240,7 +240,7 @@
 				animation: both turn-on-visibility 300ms;
 			}
 		}
-		&.initialized {
+		&.animateoutenabled {
 			&:not(.active) {
 				animation: both turn-off-visibility 300ms;
 

--- a/packages/block-library/src/image/style.scss
+++ b/packages/block-library/src/image/style.scss
@@ -263,19 +263,19 @@
 			opacity: 1;
 			visibility: visible;
 			.wp-block-image img {
-				animation: lightbox-zoom-in .4s forwards;
+				animation: lightbox-zoom-in 0.4s forwards;
 			}
 			.scrim {
-				animation: turn-on-visibility .4s forwards;
+				animation: turn-on-visibility 0.4s forwards;
 			}
 		}
-		&.initialized {
+		&.animateoutenabled {
 			&:not(.active) {
 				.wp-block-image img {
-					animation: lightbox-zoom-out .4s forwards;
+					animation: lightbox-zoom-out 0.4s forwards;
 				}
 				.scrim {
-					animation: turn-off-visibility .4s forwards;
+					animation: turn-off-visibility 0.4s forwards;
 				}
 			}
 		}
@@ -314,31 +314,31 @@
 
 @keyframes lightbox-zoom-in {
 	0% {
-		left: var(--lightbox-left-position);
-		top: var(--lightbox-top-position);
+		left: var(--lightbox-initial-left-position);
+		top: var(--lightbox-initial-top-position);
 		transform: scale(var(--lightbox-scale-width), var(--lightbox-scale-height));
 	}
 	100% {
-		left: 50%;
-		top: 50%;
-		transform: translate(-50%, -50%) scale(1, 1);
+		left: var(--lightbox-target-left-position);
+		top: var(--lightbox-target-top-position);
+		transform: scale(1, 1);
 	}
 }
 
 @keyframes lightbox-zoom-out {
 	0% {
 		visibility: visible;
-		left: 50%;
-		top: 50%;
-		transform: translate(-50%, -50%) scale(1, 1);
+		left: var(--lightbox-target-left-position);
+		top: var(--lightbox-target-top-position);
+		transform: scale(1, 1);
 	}
 	99% {
 		visibility: visible;
 	}
 	100% {
 
-		left: var(--lightbox-left-position);
-		top: var(--lightbox-top-position);
+		left: var(--lightbox-initial-left-position);
+		top: var(--lightbox-initial-top-position);
 		transform: scale(var(--lightbox-scale-width), var(--lightbox-scale-height));
 	}
 }

--- a/packages/block-library/src/image/style.scss
+++ b/packages/block-library/src/image/style.scss
@@ -234,18 +234,18 @@
 	&.fade {
 		&.active {
 			visibility: visible;
-			animation: both turn-on-visibility 250ms;
+			animation: both turn-on-visibility 0.25s;
 
 			img {
-				animation: both turn-on-visibility 300ms;
+				animation: both turn-on-visibility 0.3s;
 			}
 		}
-		&.animateoutenabled {
+		&.hideanimationenabled {
 			&:not(.active) {
-				animation: both turn-off-visibility 300ms;
+				animation: both turn-off-visibility 0.3s;
 
 				img {
-					animation: both turn-off-visibility 250ms;
+					animation: both turn-off-visibility 0.25s;
 				}
 			}
 		}
@@ -266,20 +266,20 @@
 				animation: lightbox-zoom-in 0.4s forwards;
 
 				@media (prefers-reduced-motion) {
-					animation: both turn-on-visibility 0.3s;
+					animation: both turn-on-visibility 0.4s;
 				}
 			}
 			.scrim {
 				animation: turn-on-visibility 0.4s forwards;
 			}
 		}
-		&.animateoutenabled {
+		&.hideanimationenabled {
 			&:not(.active) {
 				.wp-block-image img {
 					animation: lightbox-zoom-out 0.4s forwards;
 
 					@media (prefers-reduced-motion) {
-						animation: both turn-on-visibility 0.3s;
+						animation: both turn-off-visibility 0.4s;
 					}
 				}
 				.scrim {
@@ -288,6 +288,10 @@
 			}
 		}
 	}
+}
+
+html.has-lightbox-open {
+	overflow: hidden;
 }
 
 @keyframes turn-on-visibility {
@@ -314,12 +318,6 @@
 	}
 }
 
-// This line causes the zoom animation to jump
-//
-html.has-lightbox-open {
-	overflow: hidden;
-}
-
 @keyframes lightbox-zoom-in {
 	0% {
 		left: var(--lightbox-initial-left-position);
@@ -344,7 +342,6 @@ html.has-lightbox-open {
 		visibility: visible;
 	}
 	100% {
-
 		left: var(--lightbox-initial-left-position);
 		top: var(--lightbox-initial-top-position);
 		transform: scale(var(--lightbox-scale-width), var(--lightbox-scale-height));

--- a/packages/block-library/src/image/style.scss
+++ b/packages/block-library/src/image/style.scss
@@ -264,6 +264,10 @@
 			visibility: visible;
 			.wp-block-image img {
 				animation: lightbox-zoom-in 0.4s forwards;
+
+				@media (prefers-reduced-motion) {
+					animation: both turn-on-visibility 0.3s;
+				}
 			}
 			.scrim {
 				animation: turn-on-visibility 0.4s forwards;
@@ -273,6 +277,10 @@
 			&:not(.active) {
 				.wp-block-image img {
 					animation: lightbox-zoom-out 0.4s forwards;
+
+					@media (prefers-reduced-motion) {
+						animation: both turn-on-visibility 0.3s;
+					}
 				}
 				.scrim {
 					animation: turn-off-visibility 0.4s forwards;

--- a/test/e2e/specs/editor/blocks/image.spec.js
+++ b/test/e2e/specs/editor/blocks/image.spec.js
@@ -811,7 +811,12 @@ test.describe( 'Image - interactivity', () => {
 
 		let blocks = await editor.getBlocks();
 		expect( blocks[ 0 ].attributes ).toMatchObject( {
-			behaviors: { lightbox: true },
+			behaviors: {
+				lightbox: {
+					animation: 'zoom',
+					enabled: true,
+				},
+			},
 			linkDestination: 'none',
 		} );
 		expect( blocks[ 0 ].attributes.url ).toContain( filename );
@@ -819,7 +824,12 @@ test.describe( 'Image - interactivity', () => {
 		await page.getByLabel( 'Behaviors' ).selectOption( '' );
 		blocks = await editor.getBlocks();
 		expect( blocks[ 0 ].attributes ).toMatchObject( {
-			behaviors: { lightbox: false },
+			behaviors: {
+				lightbox: {
+					animation: '',
+					enabled: false,
+				},
+			},
 			linkDestination: 'none',
 		} );
 		expect( blocks[ 0 ].attributes.url ).toContain( filename );

--- a/test/e2e/specs/editor/various/behaviors.spec.js
+++ b/test/e2e/specs/editor/various/behaviors.spec.js
@@ -83,7 +83,7 @@ test.describe( 'Testing behaviors functionality', () => {
 		await expect( select ).toHaveValue( '' );
 
 		// By default, you should be able to select the Lightbox behavior.
-		await expect( select.getByRole( 'option' ) ).toHaveCount( 2 );
+		await expect( select.getByRole( 'option' ) ).toHaveCount( 3 );
 	} );
 
 	test( 'Behaviors UI can be disabled in the `theme.json`', async ( {
@@ -162,8 +162,8 @@ test.describe( 'Testing behaviors functionality', () => {
 		// attributes takes precedence over the theme's value.
 		await expect( select ).toHaveValue( 'lightbox' );
 
-		// There should be 2 options available: `No behaviors` and `Lightbox`.
-		await expect( select.getByRole( 'option' ) ).toHaveCount( 2 );
+		// There should be 3 options available: `No behaviors` and `Lightbox`.
+		await expect( select.getByRole( 'option' ) ).toHaveCount( 3 );
 
 		// We can change the value of the behaviors dropdown to `No behaviors`.
 		await select.selectOption( { label: 'No behaviors' } );
@@ -210,7 +210,7 @@ test.describe( 'Testing behaviors functionality', () => {
 		await expect( select ).toHaveValue( 'lightbox' );
 
 		// There should be 2 options available: `No behaviors` and `Lightbox`.
-		await expect( select.getByRole( 'option' ) ).toHaveCount( 2 );
+		await expect( select.getByRole( 'option' ) ).toHaveCount( 3 );
 
 		// We can change the value of the behaviors dropdown to `No behaviors`.
 		await select.selectOption( { label: 'No behaviors' } );
@@ -254,7 +254,7 @@ test.describe( 'Testing behaviors functionality', () => {
 		await expect( select ).toBeDisabled();
 	} );
 
-	test( 'Lightbox behavior control has a Reset button that removes the markup', async ( {
+	test( 'Lightbox behavior control has a default option that removes the markup', async ( {
 		admin,
 		editor,
 		requestUtils,
@@ -293,13 +293,11 @@ test.describe( 'Testing behaviors functionality', () => {
 			.last()
 			.click();
 
-		const resetButton = editorSettings.getByRole( 'button', {
-			name: 'Reset',
+		const select = editorSettings.getByRole( 'combobox', {
+			name: 'Behavior',
 		} );
 
-		expect( resetButton ).toBeDefined();
-
-		await resetButton.last().click();
+		await select.selectOption( { label: 'Default' } );
 		expect( await editor.getEditedPostContent() )
 			.toBe( `<!-- wp:image {"id":${ media.id }} -->
 <figure class="wp-block-image"><img src="http://localhost:8889/wp-content/uploads/${ year }/${ month }/1024x768_e2e_test_image_size.jpeg" alt="1024x768_e2e_test_image_size.jpeg" class="wp-image-${ media.id }"/></figure>

--- a/test/e2e/specs/editor/various/behaviors.spec.js
+++ b/test/e2e/specs/editor/various/behaviors.spec.js
@@ -49,43 +49,6 @@ test.describe( 'Testing behaviors functionality', () => {
 		await page.waitForLoadState();
 	} );
 
-	test( '`No Behaviors` should be the default as defined in the core theme.json', async ( {
-		admin,
-		editor,
-		requestUtils,
-		page,
-		behaviorUtils,
-	} ) => {
-		await requestUtils.activateTheme( 'twentytwentyone' );
-		await admin.createNewPost();
-		const media = await behaviorUtils.createMedia();
-		await editor.insertBlock( {
-			name: 'core/image',
-			attributes: {
-				alt: filename,
-				id: media.id,
-				url: media.source_url,
-			},
-		} );
-
-		await editor.openDocumentSettingsSidebar();
-		const editorSettings = page.getByRole( 'region', {
-			name: 'Editor settings',
-		} );
-		await editorSettings
-			.getByRole( 'button', { name: 'Advanced' } )
-			.click();
-		const select = editorSettings.getByRole( 'combobox', {
-			name: 'Behavior',
-		} );
-
-		// By default, no behaviors should be selected.
-		await expect( select ).toHaveValue( '' );
-
-		// By default, you should be able to select the Lightbox behavior.
-		await expect( select.getByRole( 'option' ) ).toHaveCount( 3 );
-	} );
-
 	test( 'Behaviors UI can be disabled in the `theme.json`', async ( {
 		admin,
 		editor,
@@ -143,7 +106,12 @@ test.describe( 'Testing behaviors functionality', () => {
 				id: media.id,
 				url: media.source_url,
 				// Explicitly set the value for behaviors to true.
-				behaviors: { lightbox: true },
+				behaviors: {
+					lightbox: {
+						enabled: true,
+						animation: 'zoom',
+					},
+				},
 			},
 		} );
 
@@ -171,50 +139,6 @@ test.describe( 'Testing behaviors functionality', () => {
 
 		// Here we should also check that the block renders on the frontend with the
 		// lightbox even though the theme.json has it set to false.
-	} );
-
-	test( 'You can set the default value for the behaviors in the theme.json', async ( {
-		admin,
-		editor,
-		requestUtils,
-		page,
-		behaviorUtils,
-	} ) => {
-		// In this theme, the default value for settings.behaviors.blocks.core/image.lightbox is `true`.
-		await requestUtils.activateTheme( 'behaviors-enabled' );
-		await admin.createNewPost();
-		const media = await behaviorUtils.createMedia();
-
-		await editor.insertBlock( {
-			name: 'core/image',
-			attributes: {
-				alt: filename,
-				id: media.id,
-				url: media.source_url,
-			},
-		} );
-
-		await editor.openDocumentSettingsSidebar();
-		const editorSettings = page.getByRole( 'region', {
-			name: 'Editor settings',
-		} );
-		await editorSettings
-			.getByRole( 'button', { name: 'Advanced' } )
-			.click();
-		const select = editorSettings.getByRole( 'combobox', {
-			name: 'Behavior',
-		} );
-
-		// The behaviors dropdown should be present and the value should be set to
-		// `lightbox`.
-		await expect( select ).toHaveValue( 'lightbox' );
-
-		// There should be 2 options available: `No behaviors` and `Lightbox`.
-		await expect( select.getByRole( 'option' ) ).toHaveCount( 3 );
-
-		// We can change the value of the behaviors dropdown to `No behaviors`.
-		await select.selectOption( { label: 'No behaviors' } );
-		await expect( select ).toHaveValue( '' );
 	} );
 
 	test( 'Lightbox behavior is disabled if the Image has a link', async ( {

--- a/test/gutenberg-test-themes/behaviors-enabled/theme.json
+++ b/test/gutenberg-test-themes/behaviors-enabled/theme.json
@@ -3,7 +3,10 @@
 	"behaviors": {
 		"blocks": {
 			"core/image": {
-				"lightbox": true
+				"lightbox": {
+					"enabled": true,
+					"animation": "zoom"
+				}
 			}
 		}
 	}

--- a/test/gutenberg-test-themes/behaviors-ui-disabled/theme.json
+++ b/test/gutenberg-test-themes/behaviors-ui-disabled/theme.json
@@ -3,9 +3,7 @@
 	"settings": {
 		"blocks": {
 			"core/image": {
-				"behaviors": {
-					"lightbox": false
-				}
+				"behaviors": false
 			}
 		}
 	}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
This adds a dropdown allowing users to select between the zoom animation or the fade animation for the experimental image lightbox.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Addresses https://github.com/WordPress/gutenberg/issues/51055
We'd like to give users the option to opt for their preferred animation and get feedback on the UX for this functionality.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
It adds the option and some conditionals to the behaviors UI in block supports, and also adds the styles needed to make the zoom work.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
1. Ensure the Gutenberg Interactivity API experiments are enabled.
2. Add two image blocks to the post:
-- A horizontal image
-- A vertical image
3. Enable the lightbox for the images in Advanced > Behaviors under the block settings.
4. See that a new dropdown to configure the Animation is activated, which should have `zoom` set as the default.
5. Publish and view the post.
6. Click on the image to see the zoom animation.
7. If possible, test using a physical mobile device as well.
8. Try changing the Animation to `fade` to ensure that works.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
N/A

<!--  ## Screenshots or screencast if applicable -->
