### PR TITLE
Remove select() hack from getBlockEditingMode()

### DIFF
--- a/packages/block-editor/src/store/index.js
+++ b/packages/block-editor/src/store/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { createReduxStore, registerStore } from '@wordpress/data';
+import { createReduxStore, register } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -35,11 +35,7 @@ export const store = createReduxStore( STORE_NAME, {
 	persist: [ 'preferences' ],
 } );
 
-// We will be able to use the `register` function once we switch
-// the "preferences" persistence to use the new preferences package.
-const registeredStore = registerStore( STORE_NAME, {
-	...storeConfig,
-	persist: [ 'preferences' ],
-} );
-unlock( registeredStore ).registerPrivateActions( privateActions );
-unlock( registeredStore ).registerPrivateSelectors( privateSelectors );
+unlock( store ).registerPrivateActions( privateActions );
+unlock( store ).registerPrivateSelectors( privateSelectors );
+
+register( store );

--- a/packages/block-editor/src/store/private-selectors.js
+++ b/packages/block-editor/src/store/private-selectors.js
@@ -6,8 +6,8 @@ import createSelector from 'rememo';
 /**
  * WordPress dependencies
  */
-import { select } from '@wordpress/data';
 import { store as blocksStore } from '@wordpress/blocks';
+import { createRegistrySelector } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -72,40 +72,35 @@ export function getLastInsertedBlocksClientIds( state ) {
  * @return {BlockEditingMode} The block editing mode. One of `'disabled'`,
  *                            `'contentOnly'`, or `'default'`.
  */
-export const getBlockEditingMode = createSelector(
-	( state, clientId = '' ) => {
-		if ( state.blockEditingModes.has( clientId ) ) {
-			return state.blockEditingModes.get( clientId );
-		}
-		if ( ! clientId ) {
-			return 'default';
-		}
-		const rootClientId = getBlockRootClientId( state, clientId );
-		const templateLock = getTemplateLock( state, rootClientId );
-		if ( templateLock === 'contentOnly' ) {
-			const name = getBlockName( state, clientId );
-			// TODO: Terrible hack! We're calling the global select() function
-			// here instead of using createRegistrySelector(). The problem with
-			// using createRegistrySelector() is that then the public
-			// block-editor selectors (e.g. canInsertBlockTypeUnmemoized) can't
-			// call this private block-editor selector due to a bug in
-			// @wordpress/data. See
-			// https://github.com/WordPress/gutenberg/pull/50985.
-			const isContent =
-				select( blocksStore ).__experimentalHasContentRoleAttribute(
-					name
-				);
-			return isContent ? 'contentOnly' : 'disabled';
-		}
-		const parentMode = getBlockEditingMode( state, rootClientId );
-		return parentMode === 'contentOnly' ? 'default' : parentMode;
-	},
-	( state ) => [
-		state.blockEditingModes,
-		state.blocks.parents,
-		state.settings.templateLock,
-		state.blockListSettings,
-	]
+export const getBlockEditingMode = createRegistrySelector( ( select ) =>
+	createSelector(
+		( state, clientId = '' ) => {
+			if ( state.blockEditingModes.has( clientId ) ) {
+				return state.blockEditingModes.get( clientId );
+			}
+			if ( ! clientId ) {
+				return 'default';
+			}
+			const rootClientId = getBlockRootClientId( state, clientId );
+			const templateLock = getTemplateLock( state, rootClientId );
+			if ( templateLock === 'contentOnly' ) {
+				const name = getBlockName( state, clientId );
+				const isContent =
+					select( blocksStore ).__experimentalHasContentRoleAttribute(
+						name
+					);
+				return isContent ? 'contentOnly' : 'disabled';
+			}
+			const parentMode = getBlockEditingMode( state, rootClientId );
+			return parentMode === 'contentOnly' ? 'default' : parentMode;
+		},
+		( state ) => [
+			state.blockEditingModes,
+			state.blocks.parents,
+			state.settings.templateLock,
+			state.blockListSettings,
+		]
+	)
 );
 
 /**

--- a/packages/block-editor/src/store/test/private-selectors.js
+++ b/packages/block-editor/src/store/test/private-selectors.js
@@ -1,9 +1,4 @@
 /**
- * WordPress dependencies
- */
-import { select } from '@wordpress/data';
-
-/**
  * Internal dependencies
  */
 import {
@@ -126,9 +121,11 @@ describe( 'private selectors', () => {
 			const __experimentalHasContentRoleAttribute = jest.fn(
 				() => false
 			);
-			select.mockReturnValue( {
-				__experimentalHasContentRoleAttribute,
-			} );
+			getBlockEditingMode.registry = {
+				select: jest.fn( () => ( {
+					__experimentalHasContentRoleAttribute,
+				} ) ),
+			};
 
 			it( 'should return default by default', () => {
 				expect(

--- a/packages/block-editor/src/store/test/private-selectors.js
+++ b/packages/block-editor/src/store/test/private-selectors.js
@@ -122,9 +122,9 @@ describe( 'private selectors', () => {
 				() => false
 			);
 			getBlockEditingMode.registry = {
-				select: jest.fn( () => ( {
+				select: () => ( {
 					__experimentalHasContentRoleAttribute,
-				} ) ),
+				} ),
 			};
 
 			it( 'should return default by default', () => {

--- a/packages/block-editor/src/store/test/selectors.js
+++ b/packages/block-editor/src/store/test/selectors.js
@@ -73,6 +73,13 @@ const {
 	wasBlockJustInserted,
 	__experimentalGetGlobalBlocksByName,
 } = selectors;
+import { getBlockEditingMode } from '../private-selectors';
+
+getBlockEditingMode.registry = {
+	select: () => ( {
+		__experimentalHasContentRoleAttribute: jest.fn( () => false ),
+	} ),
+};
 
 describe( 'selectors', () => {
 	let cachedSelectors;


### PR DESCRIPTION
## What?
Now that https://github.com/WordPress/gutenberg/pull/51051 is merged we can remove a hack that I added in https://github.com/WordPress/gutenberg/pull/51148 to work around an issue with private registry selectors (described here: https://github.com/WordPress/gutenberg/pull/50985).

## Why?
Relying on the global `select` function is never ideal as `select` may differ if the selector is ran within a different `RegistryProvider` context.

## How?
Use `createRegistrySelector` again.

The way that https://github.com/WordPress/gutenberg/pull/51051 is designed means that we have to update `block-editor` to register private selectors and actions _before_ it registers the store.

Despite the inline comment to the contrary I don't think using `register()` instead of `registerStore()` will actually make any difference because both functions result in the same execution of `registerStoreInstance` internally.

https://github.com/WordPress/gutenberg/blob/f9e405e0e53d61cd36af4f3b34f2de75874de1e1/packages/data/src/registry.js#L304-L313

https://github.com/WordPress/gutenberg/blob/f9e405e0e53d61cd36af4f3b34f2de75874de1e1/packages/data/src/registry.js#L282-L286

## Testing Instructions

Same as in https://github.com/WordPress/gutenberg/pull/50857.

1. Go to _Appearance → Editor → Pages_ and select a page.
1. Test the new switching functionality.
1. Check that navigating to _Appearance → Editor → Templates_ and selecting a template results in the same site editor experience as before (no switching functionality).