### PR TITLE
PageContent: Fix unlock import

### DIFF
--- a/packages/edit-site/src/components/sidebar-edit-mode/page-panels/page-content.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/page-panels/page-content.js
@@ -11,7 +11,7 @@ import {
  * Internal dependencies
  */
 import { PAGE_CONTENT_BLOCK_TYPES } from '../../page-content-focus/constants';
-import { unlock } from '../../../private-apis';
+import { unlock } from '../../../lock-unlock';
 
 const { BlockQuickNavigation } = unlock( blockEditorPrivateApis );
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

A small follow-up to https://github.com/WordPress/gutenberg/pull/51281 and https://github.com/WordPress/gutenberg/pull/51322 to fix up an import so that `unlock` is imported from the correct location.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The above two PRs were merged in quick succession, so unfortunately this import was missed.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Update the import line for the `PageContent` component, so that it imports from `lock-unlock` as in #51322.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

* Check that the static analysis / linting jobs pass
* To be thorough, open up the site editor browse mode, select Pages, and click to edit a page in your site
* In the right-hand sidebar, you should see the block quick navigation

## Screenshots or screencast <!-- if applicable -->

This is the component that should still be rendering correctly:

<img width="326" alt="image" src="https://github.com/WordPress/gutenberg/assets/14988353/6de176ce-d7e4-4ce6-bb48-09fe65cd5b13">
