### PR TITLE
Update the Save Button label when you're previewing a theme

### DIFF
--- a/packages/edit-site/src/components/save-button/index.js
+++ b/packages/edit-site/src/components/save-button/index.js
@@ -39,21 +39,24 @@ export default function SaveButton( {
 	const disabled = isSaving || ! activateSaveEnabled;
 
 	const getLabel = () => {
-		if ( isSaving ) {
-			return __( 'Saving' );
-		}
-		if ( disabled ) {
-			return __( 'Saved' );
-		}
-
-		if ( defaultLabel ) return defaultLabel;
-
-		if ( isPreviewingTheme() && isDirty ) {
-			return __( 'Activate & Save' );
-		} else if ( isPreviewingTheme() ) {
+		if ( isPreviewingTheme() ) {
+			if ( isSaving ) {
+				return __( 'Activating' );
+			} else if ( disabled ) {
+				return __( 'Saved' );
+			} else if ( isDirty ) {
+				return __( 'Activate & Save' );
+			}
 			return __( 'Activate' );
 		}
 
+		if ( isSaving ) {
+			return __( 'Saving' );
+		} else if ( disabled ) {
+			return __( 'Saved' );
+		} else if ( defaultLabel ) {
+			return defaultLabel;
+		}
 		return __( 'Save' );
 	};
 	const label = getLabel();


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Update the Save Button label when you're [previewing a theme](https://github.com/WordPress/gutenberg/pull/50030).

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The Site Edotor's Save Button was updated in https://github.com/WordPress/gutenberg/pull/50567, but it needed to make sense when previewing a theme. See https://github.com/WordPress/gutenberg/pull/50983/#issuecomment-1581977899.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

- Early return a label if `isPreviewingTheme()` is true

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

- Go to `/wp-admin/themes.php`
- Click the `Live Preview` button on a theme installed

## Screenshots or screencast <!-- if applicable -->


https://github.com/WordPress/gutenberg/assets/5287479/2ad82e2a-958f-407c-8999-6b889b4c832e

