### PR TITLE
MediaPlaceholder: Fix position of URLPopover

### DIFF
--- a/packages/block-editor/src/components/media-placeholder/index.js
+++ b/packages/block-editor/src/components/media-placeholder/index.js
@@ -30,8 +30,14 @@ import { store as blockEditorStore } from '../../store';
 
 const noop = () => {};
 
-const InsertFromURLPopover = ( { src, onChange, onSubmit, onClose } ) => (
-	<URLPopover onClose={ onClose }>
+const InsertFromURLPopover = ( {
+	src,
+	onChange,
+	onSubmit,
+	onClose,
+	popoverAnchor,
+} ) => (
+	<URLPopover anchor={ popoverAnchor } onClose={ onClose }>
 		<form
 			className="block-editor-media-placeholder__url-input-form"
 			onSubmit={ onSubmit }
@@ -53,6 +59,44 @@ const InsertFromURLPopover = ( { src, onChange, onSubmit, onClose } ) => (
 		</form>
 	</URLPopover>
 );
+
+const URLSelectionUI = ( {
+	isURLInputVisible,
+	src,
+	onChangeSrc,
+	onSubmitSrc,
+	openURLInput,
+	closeURLInput,
+} ) => {
+	// Use internal state instead of a ref to make sure that the component
+	// re-renders when the popover's anchor updates.
+	const [ popoverAnchor, setPopoverAnchor ] = useState( null );
+
+	return (
+		<div
+			className="block-editor-media-placeholder__url-input-container"
+			ref={ setPopoverAnchor }
+		>
+			<Button
+				className="block-editor-media-placeholder__button"
+				onClick={ openURLInput }
+				isPressed={ isURLInputVisible }
+				variant="tertiary"
+			>
+				{ __( 'Insert from URL' ) }
+			</Button>
+			{ isURLInputVisible && (
+				<InsertFromURLPopover
+					src={ src }
+					onChange={ onChangeSrc }
+					onSubmit={ onSubmitSrc }
+					onClose={ closeURLInput }
+					popoverAnchor={ popoverAnchor }
+				/>
+			) }
+		</div>
+	);
+};
 
 export function MediaPlaceholder( {
 	value = {},
@@ -359,24 +403,14 @@ export function MediaPlaceholder( {
 	const renderUrlSelectionUI = () => {
 		return (
 			onSelectURL && (
-				<div className="block-editor-media-placeholder__url-input-container">
-					<Button
-						className="block-editor-media-placeholder__button"
-						onClick={ openURLInput }
-						isPressed={ isURLInputVisible }
-						variant="tertiary"
-					>
-						{ __( 'Insert from URL' ) }
-					</Button>
-					{ isURLInputVisible && (
-						<InsertFromURLPopover
-							src={ src }
-							onChange={ onChangeSrc }
-							onSubmit={ onSubmitSrc }
-							onClose={ closeURLInput }
-						/>
-					) }
-				</div>
+				<URLSelectionUI
+					isURLInputVisible={ isURLInputVisible }
+					src={ src }
+					onChangeSrc={ onChangeSrc }
+					onSubmitSrc={ onSubmitSrc }
+					openURLInput={ openURLInput }
+					closeURLInput={ closeURLInput }
+				/>
 			)
 		);
 	};


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fix the position of the URLPopover used in the MediaPlaceholder component by explicitly providing a ref.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

I noticed that the position of the URLPopover in the MediaPlaceholder component was incorrect. After doing a `git bisect` it appears that the issue has been present since #46212 when the post editor was updated to use an iframe. The issue was most noticeable with the list view open.

I'm not 100% sure the exact cause, but my suspicion is that when using an implicit parent approach for the `Popover` component, it doesn't play nicely when it has to cross iframe boundaries sometimes. Without going too much further into it, this fix of explicitly passing down a `ref` to the expected container appears to work.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* Move the innards of `renderUrlSelectionUI` over to a separate component, add a `useState` to grab a ref for the input container. Pass the `ref` to the `URLPopover`.
* I preserved the `renderUrlSelectionUI` function as-is to try to keep this diff as small as possible, since that function call is used in several places. It seemed a bit neater to preserve that function call than replace it with `<URLSelectionUI />` directly.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Test with a blocks theme, e.g. TT3
2. With the List View open in a post or page, add an Image block
3. Click on the Insert from URL button
4. Note that on `trunk` the position of the popover will be incorrect. With this PR applied, the popover should be positioned beneath the input container

## Screenshots or screencast <!-- if applicable -->

| Before | After |
| --- | --- |
| <img width="965" alt="image" src="https://github.com/WordPress/gutenberg/assets/14988353/53857046-d498-4b7f-90d5-806d2eada9ef"> | <img width="965" alt="image" src="https://github.com/WordPress/gutenberg/assets/14988353/be3c0134-26ff-43a6-b278-cfdf7ed377ec"> |