### PR TITLE
Add 'Edit template' and 'Back to page' commands

### DIFF
--- a/packages/edit-site/src/hooks/commands/use-edit-mode-commands.js
+++ b/packages/edit-site/src/hooks/commands/use-edit-mode-commands.js
@@ -1,9 +1,9 @@
 /**
  * WordPress dependencies
  */
-import { useDispatch } from '@wordpress/data';
+import { useSelect, useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
-import { trash, backup } from '@wordpress/icons';
+import { trash, backup, layout, page } from '@wordpress/icons';
 import { useCommandLoader } from '@wordpress/commands';
 import { privateApis as routerPrivateApis } from '@wordpress/router';
 
@@ -19,16 +19,25 @@ import { unlock } from '../../lock-unlock';
 const { useHistory } = unlock( routerPrivateApis );
 
 function useEditModeCommandLoader() {
-	const { removeTemplate, revertTemplate } = useDispatch( editSiteStore );
-	const history = useHistory();
 	const { isLoaded, record: template } = useEditedEntityRecord();
-	const isRemovable =
-		isLoaded && !! template && isTemplateRemovable( template );
-	const isRevertable =
-		isLoaded && !! template && isTemplateRevertable( template );
+	const { removeTemplate, revertTemplate, setHasPageContentFocus } =
+		useDispatch( editSiteStore );
+	const history = useHistory();
+	const { isPage, hasPageContentFocus } = useSelect(
+		( select ) => ( {
+			isPage: select( editSiteStore ).isPage(),
+			hasPageContentFocus: select( editSiteStore ).hasPageContentFocus(),
+		} ),
+		[]
+	);
+
+	if ( ! isLoaded ) {
+		return { isLoading: true, commands: [] };
+	}
 
 	const commands = [];
-	if ( isRemovable ) {
+
+	if ( isTemplateRemovable( template ) && ! hasPageContentFocus ) {
 		const label =
 			template.type === 'wp_template'
 				? __( 'Delete template' )
@@ -48,7 +57,8 @@ function useEditModeCommandLoader() {
 			},
 		} );
 	}
-	if ( isRevertable ) {
+
+	if ( isTemplateRevertable( template ) && ! hasPageContentFocus ) {
 		const label =
 			template.type === 'wp_template'
 				? __( 'Reset template' )
@@ -62,6 +72,32 @@ function useEditModeCommandLoader() {
 				close();
 			},
 		} );
+	}
+
+	if ( isPage ) {
+		if ( hasPageContentFocus ) {
+			commands.push( {
+				name: 'core/switch-to-template-focus',
+				label: __( 'Edit template' ),
+				icon: layout,
+				context: 'site-editor-edit',
+				callback: ( { close } ) => {
+					setHasPageContentFocus( false );
+					close();
+				},
+			} );
+		} else {
+			commands.push( {
+				name: 'core/switch-to-page-focus',
+				label: __( 'Back to page' ),
+				icon: page,
+				context: 'site-editor-edit',
+				callback: ( { close } ) => {
+					setHasPageContentFocus( true );
+					close();
+				},
+			} );
+		}
 	}
 
 	return {

--- a/packages/edit-site/src/hooks/commands/use-edit-mode-commands.js
+++ b/packages/edit-site/src/hooks/commands/use-edit-mode-commands.js
@@ -37,43 +37,6 @@ function useEditModeCommandLoader() {
 
 	const commands = [];
 
-	if ( isTemplateRemovable( template ) && ! hasPageContentFocus ) {
-		const label =
-			template.type === 'wp_template'
-				? __( 'Delete template' )
-				: __( 'Delete template part' );
-		commands.push( {
-			name: 'core/remove-template',
-			label,
-			icon: trash,
-			context: 'site-editor-edit',
-			callback: ( { close } ) => {
-				removeTemplate( template );
-				// Navigate to the template list
-				history.push( {
-					path: '/' + template.type,
-				} );
-				close();
-			},
-		} );
-	}
-
-	if ( isTemplateRevertable( template ) && ! hasPageContentFocus ) {
-		const label =
-			template.type === 'wp_template'
-				? __( 'Reset template' )
-				: __( 'Reset template part' );
-		commands.push( {
-			name: 'core/reset-template',
-			label,
-			icon: backup,
-			callback: ( { close } ) => {
-				revertTemplate( template );
-				close();
-			},
-		} );
-	}
-
 	if ( isPage ) {
 		if ( hasPageContentFocus ) {
 			commands.push( {
@@ -98,6 +61,43 @@ function useEditModeCommandLoader() {
 				},
 			} );
 		}
+	}
+
+	if ( isTemplateRevertable( template ) && ! hasPageContentFocus ) {
+		const label =
+			template.type === 'wp_template'
+				? __( 'Reset template' )
+				: __( 'Reset template part' );
+		commands.push( {
+			name: 'core/reset-template',
+			label,
+			icon: backup,
+			callback: ( { close } ) => {
+				revertTemplate( template );
+				close();
+			},
+		} );
+	}
+
+	if ( isTemplateRemovable( template ) && ! hasPageContentFocus ) {
+		const label =
+			template.type === 'wp_template'
+				? __( 'Delete template' )
+				: __( 'Delete template part' );
+		commands.push( {
+			name: 'core/remove-template',
+			label,
+			icon: trash,
+			context: 'site-editor-edit',
+			callback: ( { close } ) => {
+				removeTemplate( template );
+				// Navigate to the template list
+				history.push( {
+					path: '/' + template.type,
+				} );
+				close();
+			},
+		} );
 	}
 
 	return {


### PR DESCRIPTION
## What?
Adds contextual 'Edit template' and 'Back to page' commands to the command centre when the user is editing a page in the site editor.

Also fixes https://github.com/WordPress/gutenberg/issues/51262 by hiding template-specific commands when the user is focused on editing page content.

## Why?
Nice to have commands available for power users.

## How?

## Testing Instructions
1. Go to _Appearance → Editor → Pages_ and select a page.
1. Open the command centre. (Cmd+K)
1. You should see an _Edit template_ command.
1. Edit the page's template.
1. Open the command centre. (Cmd+K)
1. You should see a _Back to page_ command.

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/612155/6f902e25-595c-4e19-a922-4cd3af28d57b

