### PR TITLE
Styles Navigation Screen: close style book using location

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen-main/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-main/index.js
@@ -33,7 +33,7 @@ export default function SidebarNavigationScreenMain() {
 		if ( location?.path === '/' ) {
 			setEditorCanvasContainerView( undefined );
 		}
-	}, [ setEditorCanvasContainerView ] );
+	}, [ setEditorCanvasContainerView, location?.path ] );
 
 	return (
 		<SidebarNavigationScreen

--- a/packages/edit-site/src/components/sidebar-navigation-screen-main/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-main/index.js
@@ -4,10 +4,11 @@
 import {
 	__experimentalItemGroup as ItemGroup,
 	__experimentalNavigatorButton as NavigatorButton,
+	__experimentalUseNavigator as useNavigator,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { layout, symbol, navigation, styles, page } from '@wordpress/icons';
-import { useDispatch, useSelect } from '@wordpress/data';
+import { useDispatch } from '@wordpress/data';
 
 import { useEffect } from '@wordpress/element';
 
@@ -22,20 +23,17 @@ import { store as editSiteStore } from '../../store';
 import SidebarNavigationScreenNavigationMenuButton from '../sidebar-navigation-screen-navigation-menus/navigator-button';
 
 export default function SidebarNavigationScreenMain() {
-	const editorCanvasContainerView = useSelect( ( select ) => {
-		return unlock( select( editSiteStore ) ).getEditorCanvasContainerView();
-	}, [] );
-
+	const { location } = useNavigator();
 	const { setEditorCanvasContainerView } = unlock(
 		useDispatch( editSiteStore )
 	);
 
 	// Clear the editor canvas container view when accessing the main navigation screen.
 	useEffect( () => {
-		if ( editorCanvasContainerView ) {
+		if ( location === '/' ) {
 			setEditorCanvasContainerView( undefined );
 		}
-	}, [ editorCanvasContainerView, setEditorCanvasContainerView ] );
+	}, [ setEditorCanvasContainerView ] );
 
 	return (
 		<SidebarNavigationScreen

--- a/packages/edit-site/src/components/sidebar-navigation-screen-main/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-main/index.js
@@ -30,7 +30,7 @@ export default function SidebarNavigationScreenMain() {
 
 	// Clear the editor canvas container view when accessing the main navigation screen.
 	useEffect( () => {
-		if ( location === '/' ) {
+		if ( location?.path === '/' ) {
 			setEditorCanvasContainerView( undefined );
 		}
 	}, [ setEditorCanvasContainerView ] );


### PR DESCRIPTION
(Maybe) Fixes #50799, fixes #50807, fixes #50837, fixes #50838, fixes #50839



## What?
Using location to determine whether to reset `editorCanvasContainerView` instead selector to avoid e2e fails. 

## Why?
playwright runs faster than the useEffect resetting the value. (thanks @kevin940726 !)



## Testing Instructions
`npm run test:e2e:playwright -- --headed site-editor/style-book.spec`


