### PR TITLE
Remove Details block setting field from the experiments page

### DIFF
--- a/lib/experiments-page.php
+++ b/lib/experiments-page.php
@@ -78,18 +78,6 @@ function gutenberg_initialize_experiments_settings() {
 	);
 
 	add_settings_field(
-		'gutenberg-details-blocks',
-		__( 'Details block', 'gutenberg' ),
-		'gutenberg_display_experiment_field',
-		'gutenberg-experiments',
-		'gutenberg_experiments_section',
-		array(
-			'label' => __( 'Test the Details block', 'gutenberg' ),
-			'id'    => 'gutenberg-details-blocks',
-		)
-	);
-
-	add_settings_field(
 		'gutenberg-interactivity-api-core-blocks',
 		__( 'Interactivity API and Behaviors UI', 'gutenberg' ),
 		'gutenberg_display_experiment_field',


### PR DESCRIPTION
Follow-up on #50030
Related to: #50997

## What?
This PR removes Details block setting field from the experiments page.

## Why?
The Details block was stabilized in #50997. The setting field has been removed from the Experiments page accordingly.

However, in #50983, the setting appears to have been restored. Perhaps an unintended line change was made due to merge timing.

## Testing Instructions
Access the Experiments page and confirm that the setting field for the Details block is not present.