### PR TITLE
Site Editor: Fix gradient background color repeats

### DIFF
--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -226,7 +226,7 @@ function Iframe( {
 	// content.
 	const html =
 		'<!doctype html>' +
-		'<style>html{height:auto!important;}body{margin:0}</style>' +
+		'<style>html{height:auto!important;min-height:100%;}body{margin:0}</style>' +
 		( assets?.styles ?? '' );
 
 	const [ src, cleanup ] = useMemo( () => {


### PR DESCRIPTION
Fixes: #46782

## What?
This PR fixes a problem in the site editor where the background gradient repeats when the content is less than the height of the canvas.

![repeat](https://github.com/WordPress/gutenberg/assets/54422211/94ad5f87-b562-400a-a7fc-06ecda511a21)

## Why?

I have created some simple HTML to try to figure out the cause of this problem.

```html
<!DOCTYPE html>
<html>
<body>
<style>
body {
  margin: 0;
  height: 100px;
  border: 5px solid #000;
  box-sizing: border-box;
  background: linear-gradient(to bottom,  #e4f5fc 0%,#2ab0ed 100%);
}
</style>
Test
</body>
</html>
```

The height of the `body` element is 100px. And the same goes for `html` elements. However, when you define a background color on the `body` element, that background goes beyond the `html` element and fills the entire page.

This behavior does not occur with any element within the body element. I have also observed this problem in both Chrome and Firefox.

![test-html](https://github.com/WordPress/gutenberg/assets/54422211/e535fc0f-bf7e-4f66-a20d-491f7d37f7bd)

## How?
I found that this problem does not occur when the `html` element is above the document height. Therefore, I added `min-height:100%`.

## Testing Instructions
- Access the Site Editor.
- Change the style of TT3 to Sherbet.
- Display a Blank or 404 template (i.e., content is below document height).
- Make sure the background color is not repeated.
- Make sure that other iframe previews (global style preview, zoomed-out view, stylebook, etc.) are not affected in any way.

## Screenshots or screencast 

| Before | After |
|--------|--------|
| ![before](https://github.com/WordPress/gutenberg/assets/54422211/b399ab29-5f42-48ff-af4d-8ed4f8bf9915) | ![after](https://github.com/WordPress/gutenberg/assets/54422211/cc6c3015-1c09-4ab0-8d7a-528eec05956f) |
