### PR TITLE
Navigation: Don't interfere with pointer events

### DIFF
--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -503,30 +503,6 @@ body.editor-styles-wrapper .wp-block-navigation__responsive-container.is-menu-op
 	left: 0;
 }
 
-// Without this, the block cannot be selected, nor does the right container get focus.
-// @todo: this is disruptive. Ideally we can retire a few of the containers,
-// so focus is applied naturally on the block container.
-// It's important the right container has focus, otherwise you can't press
-// "Delete" to remove the block.
-.wp-block-navigation:not(.is-editing-disabled) {
-	.wp-block-navigation__responsive-container,
-	.wp-block-navigation__responsive-close {
-		@include break-small() {
-			pointer-events: none;
-
-			.wp-block-navigation__responsive-container-close,
-			.block-editor-block-list__layout * {
-				pointer-events: all;
-			}
-		}
-
-		// Page List items should remain inert.
-		.wp-block-pages-list__item__link {
-			pointer-events: none;
-		}
-	}
-}
-
 // The menu and close buttons need higher specificity in the editor.
 .components-button.wp-block-navigation__responsive-container-open.wp-block-navigation__responsive-container-open,
 .components-button.wp-block-navigation__responsive-container-close.wp-block-navigation__responsive-container-close {


### PR DESCRIPTION
## What?
This CSS was messing with pointer events which made it possible to select a block that was behind the navigation overlay.

## Why?
Users shouldn't be able to select blocks that are behind the navigation overlay when it is open.

## How?
This code was messing around with the pointer events in the navigation block. Just deleting it seems to restore the behaviour we want and doesn't seem to cause any other issues.

## Testing Instructions
1. Add a navigation block and set the overlay menu  to "Always" show.
2. In the site editor, open the overlay menu
3. Click on a part of the overlay which has a block behind it
4. In trunk you'll be able to select that block, in this branch you will not.
5. Check that the block can still be selected and deleted as before

### Testing Instructions for Keyboard
Follow the steps above and confirm that the block can still be used with a keyboard.

## Screenshots or screencast <!-- if applicable -->
See https://github.com/WordPress/gutenberg/issues/51291