### PR TITLE
Remove value syncing in Link Control

### DIFF
--- a/packages/block-editor/src/components/link-control/README.md
+++ b/packages/block-editor/src/components/link-control/README.md
@@ -4,6 +4,26 @@ Renders a link control. A link control is a controlled input which maintains a v
 
 It is designed to provide a standardized UI for the creation of a link throughout the Editor, see History section at bottom for further background.
 
+## Best Practices
+
+### Ensuring unique instances
+
+It is possible that a given editor may render multiple instances of the `<LinkControl>` component. As a result, it is important to ensure each instance is unique across the editor to avoid state "leaking" between components.
+
+Why would this happen?
+
+React's reconciliation algorithm means that if you return the same element from a component, it keeps the nodes around as an optimization, even if the props change. This means that if you render two (or more) `<LinkControl>`s, it is possible that the `value` from one will appear in the other as you move between them.
+
+As a result it is recommended that consumers provide a `key` prop to each instance of `<LinkControl>`:
+
+```jsx
+<LinkControl key="some-unique-key" { ...props } />
+```
+
+This will cause React to return the same component/element type but force remount a new instance, thus avoiding the issues described above.
+
+For more information see: https://github.com/WordPress/gutenberg/pull/34742.
+
 ## Relationship to `<URLInput>`
 
 As of Gutenberg 7.4, `<LinkControl>` became the default link creation interface within the Block Editor, replacing previous disparate uses of `<URLInput>` and standardizing the UI.

--- a/packages/block-editor/src/components/link-control/test/index.js
+++ b/packages/block-editor/src/components/link-control/test/index.js
@@ -2509,48 +2509,6 @@ describe( 'Controlling link title text', () => {
 			screen.queryByRole( 'textbox', { name: 'Text' } )
 		).not.toBeInTheDocument();
 	} );
-
-	it( 'should reset state upon controlled value change', async () => {
-		const user = userEvent.setup();
-		const textValue = 'My new text value';
-		const mockOnChange = jest.fn();
-
-		const { rerender } = render(
-			<LinkControl
-				value={ selectedLink }
-				forceIsEditingLink
-				hasTextControl
-				onChange={ mockOnChange }
-			/>
-		);
-
-		await toggleSettingsDrawer( user );
-
-		const textInput = screen.queryByRole( 'textbox', { name: 'Text' } );
-
-		expect( textInput ).toBeVisible();
-
-		await user.clear( textInput );
-		await user.keyboard( textValue );
-
-		// Was originally title: 'Hello Page', but we've changed it.
-		rerender(
-			<LinkControl
-				value={ {
-					...selectedLink,
-					title: 'Something else',
-				} }
-				forceIsEditingLink
-				hasTextControl
-				onChange={ mockOnChange }
-			/>
-		);
-
-		// The text input should not be showing as the form is submitted.
-		expect( screen.queryByRole( 'textbox', { name: 'Text' } ) ).toHaveValue(
-			'Something else'
-		);
-	} );
 } );
 
 function getSettingsDrawerToggle() {

--- a/packages/block-editor/src/components/link-control/test/index.js
+++ b/packages/block-editor/src/components/link-control/test/index.js
@@ -2509,6 +2509,48 @@ describe( 'Controlling link title text', () => {
 			screen.queryByRole( 'textbox', { name: 'Text' } )
 		).not.toBeInTheDocument();
 	} );
+
+	it( 'should reset state upon controlled value change', async () => {
+		const user = userEvent.setup();
+		const textValue = 'My new text value';
+		const mockOnChange = jest.fn();
+
+		const { rerender } = render(
+			<LinkControl
+				value={ selectedLink }
+				forceIsEditingLink
+				hasTextControl
+				onChange={ mockOnChange }
+			/>
+		);
+
+		await toggleSettingsDrawer( user );
+
+		const textInput = screen.queryByRole( 'textbox', { name: 'Text' } );
+
+		expect( textInput ).toBeVisible();
+
+		await user.clear( textInput );
+		await user.keyboard( textValue );
+
+		// Was originally title: 'Hello Page', but we've changed it.
+		rerender(
+			<LinkControl
+				value={ {
+					...selectedLink,
+					title: 'Something else',
+				} }
+				forceIsEditingLink
+				hasTextControl
+				onChange={ mockOnChange }
+			/>
+		);
+
+		// The text input should not be showing as the form is submitted.
+		expect( screen.queryByRole( 'textbox', { name: 'Text' } ) ).toHaveValue(
+			'Something else'
+		);
+	} );
 } );
 
 function getSettingsDrawerToggle() {

--- a/packages/block-editor/src/components/link-control/use-internal-value.js
+++ b/packages/block-editor/src/components/link-control/use-internal-value.js
@@ -1,21 +1,10 @@
 /**
  * WordPress dependencies
  */
-import { useState, useEffect } from '@wordpress/element';
+import { useState } from '@wordpress/element';
 
 export default function useInternalValue( value ) {
 	const [ internalValue, setInternalValue ] = useState( value || {} );
-
-	// If the value prop changes, update the internal state.
-	useEffect( () => {
-		setInternalValue( ( prevValue ) => {
-			if ( value && value !== prevValue ) {
-				return value;
-			}
-
-			return prevValue;
-		} );
-	}, [ value ] );
 
 	const setInternalURLInputValue = ( nextValue ) => {
 		setInternalValue( {

--- a/packages/block-editor/src/components/link-control/use-internal-value.js
+++ b/packages/block-editor/src/components/link-control/use-internal-value.js
@@ -5,6 +5,18 @@ import { useState } from '@wordpress/element';
 
 export default function useInternalValue( value ) {
 	const [ internalValue, setInternalValue ] = useState( value || {} );
+	const [ previousValue, setPreviousValue ] = useState( value );
+
+	// If the value prop changes, update the internal state.
+	// See:
+	// - https://github.com/WordPress/gutenberg/pull/51387#issuecomment-1722927384.
+	// - https://react.dev/reference/react/useState#storing-information-from-previous-renders.
+	if ( value !== previousValue ) {
+		setPreviousValue( value );
+		if ( value !== internalValue ) {
+			setInternalValue( value );
+		}
+	}
 
 	const setInternalURLInputValue = ( nextValue ) => {
 		setInternalValue( {

--- a/packages/block-editor/src/components/link-control/use-internal-value.js
+++ b/packages/block-editor/src/components/link-control/use-internal-value.js
@@ -3,6 +3,11 @@
  */
 import { useState } from '@wordpress/element';
 
+/**
+ * External dependencies
+ */
+import fastDeepEqual from 'fast-deep-equal';
+
 export default function useInternalValue( value ) {
 	const [ internalValue, setInternalValue ] = useState( value || {} );
 	const [ previousValue, setPreviousValue ] = useState( value );
@@ -11,11 +16,9 @@ export default function useInternalValue( value ) {
 	// See:
 	// - https://github.com/WordPress/gutenberg/pull/51387#issuecomment-1722927384.
 	// - https://react.dev/reference/react/useState#storing-information-from-previous-renders.
-	if ( value !== previousValue ) {
+	if ( ! fastDeepEqual( value, previousValue ) ) {
 		setPreviousValue( value );
-		if ( value !== internalValue ) {
-			setInternalValue( value );
-		}
+		setInternalValue( value );
 	}
 
 	const setInternalURLInputValue = ( nextValue ) => {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Removes the (potentially) unwanted value syncing in Link Control component.

Closes https://github.com/WordPress/gutenberg/issues/51256

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

It might be unnecessary as per https://github.com/WordPress/gutenberg/issues/51256

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Remove the effectful code.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

Run the tests with

```
npm run test:unit packages/block-editor/src/components/link-control/
```



### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
