### PR TITLE
Add taxonomy attributes to categories block #51388

### DIFF
--- a/packages/block-library/src/categories/block.json
+++ b/packages/block-library/src/categories/block.json
@@ -29,7 +29,7 @@
 		},
 		"taxonomy": {
 			"type": "string",
-			"default": 'category'
+			"default": "category"
 		}
 	},
 	"supports": {

--- a/packages/block-library/src/categories/block.json
+++ b/packages/block-library/src/categories/block.json
@@ -26,6 +26,10 @@
 		"showEmpty": {
 			"type": "boolean",
 			"default": false
+		},
+		"taxonomy": {
+			"type": "string",
+			"default": 'category'
 		}
 	},
 	"supports": {

--- a/packages/block-library/src/categories/block.json
+++ b/packages/block-library/src/categories/block.json
@@ -28,8 +28,7 @@
 			"default": false
 		},
 		"taxonomy": {
-			"type": "string",
-			"default": "category"
+			"type": "string"
 		}
 	},
 	"supports": {

--- a/packages/block-library/src/categories/index.php
+++ b/packages/block-library/src/categories/index.php
@@ -19,6 +19,7 @@ function render_block_core_categories( $attributes ) {
 	$args = array(
 		'echo'         => false,
 		'hierarchical' => ! empty( $attributes['showHierarchy'] ),
+		'taxonomy'     => $attributes['taxonomy'],
 		'orderby'      => 'name',
 		'show_count'   => ! empty( $attributes['showPostCounts'] ),
 		'title_li'     => '',

--- a/packages/block-library/src/categories/index.php
+++ b/packages/block-library/src/categories/index.php
@@ -19,7 +19,7 @@ function render_block_core_categories( $attributes ) {
 	$args = array(
 		'echo'         => false,
 		'hierarchical' => ! empty( $attributes['showHierarchy'] ),
-		'taxonomy'     => $attributes['taxonomy'],
+		'taxonomy'     => isset( $attributes['taxonomy'] ) ? $attributes['taxonomy'] : 'category',
 		'orderby'      => 'name',
 		'show_count'   => ! empty( $attributes['showPostCounts'] ),
 		'title_li'     => '',

--- a/packages/block-library/src/categories/index.php
+++ b/packages/block-library/src/categories/index.php
@@ -19,12 +19,16 @@ function render_block_core_categories( $attributes ) {
 	$args = array(
 		'echo'         => false,
 		'hierarchical' => ! empty( $attributes['showHierarchy'] ),
-		'taxonomy'     => isset( $attributes['taxonomy'] ) ? $attributes['taxonomy'] : 'category',
 		'orderby'      => 'name',
 		'show_count'   => ! empty( $attributes['showPostCounts'] ),
 		'title_li'     => '',
 		'hide_empty'   => empty( $attributes['showEmpty'] ),
 	);
+	
+	if( isset( $attributes['taxonomy'] ) ){
+		$args['taxonomy'] = $attributes['taxonomy'];
+	}
+	
 	if ( ! empty( $attributes['showOnlyTopLevel'] ) && $attributes['showOnlyTopLevel'] ) {
 		$args['parent'] = 0;
 	}


### PR DESCRIPTION
## What?
Fix #51388

## Why?
Make it possible to create taxonomy variations.

## How?
Simply add a taxonmy attribute
