### PR TITLE
Button: Remove unnecessary margin from dashicon

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -24,6 +24,7 @@
 ### Bug Fix
 
 -   `FocalPointUnitControl`: Add aria-labels ([#50993](https://github.com/WordPress/gutenberg/pull/50993)).
+-   `Button`: Remove unnecessary margin from dashicon ([#51395](https://github.com/WordPress/gutenberg/pull/51395)).
 
 ### Enhancements
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bug Fix
 
 -   `Popover`: Allow legitimate 0 positions to update popover position ([#51320](https://github.com/WordPress/gutenberg/pull/51320)).
+-   `Button`: Remove unnecessary margin from dashicon ([#51395](https://github.com/WordPress/gutenberg/pull/51395)).
 
 ### Internal
 
@@ -24,7 +25,6 @@
 ### Bug Fix
 
 -   `FocalPointUnitControl`: Add aria-labels ([#50993](https://github.com/WordPress/gutenberg/pull/50993)).
--   `Button`: Remove unnecessary margin from dashicon ([#51395](https://github.com/WordPress/gutenberg/pull/51395)).
 
 ### Enhancements
 

--- a/packages/components/src/button/stories/e2e/index.tsx
+++ b/packages/components/src/button/stories/e2e/index.tsx
@@ -56,3 +56,25 @@ export const Icon = VariantStates.bind( {} );
 Icon.args = {
 	icon: wordpress,
 };
+
+export const Dashicons: ComponentStory< typeof Button > = ( props ) => {
+	return (
+		<div style={ { display: 'flex', gap: 8 } }>
+			<Button { ...props } />
+			<Button { ...props }>Children</Button>
+			<Button { ...props } iconPosition="right">
+				Children (icon right)
+			</Button>
+			<Button { ...props } text="Text" />
+			<Button
+				{ ...props }
+				text="Text (icon right)"
+				iconPosition="right"
+			/>
+		</div>
+	);
+};
+Dashicons.args = {
+	icon: 'editor-help',
+	variant: 'primary',
+};

--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -168,11 +168,6 @@
 			background: rgba(var(--wp-admin-theme-color--rgb), 0.08);
 		}
 
-		.dashicon {
-			display: inline-block;
-			flex: 0 0 auto;
-		}
-
 		// Pull left if the tertiary button stands alone after a description, so as to vertically align with items above.
 		p + & {
 			margin-left: -($grid-unit-15 * 0.5);
@@ -296,10 +291,11 @@
 		}
 
 		.dashicon {
-			display: inline-block;
-			flex: 0 0 auto;
-			margin-left: 2px;
-			margin-right: 2px;
+			display: inline-flex;
+			justify-content: center;
+			align-items: center;
+			padding: 2px;
+			box-sizing: content-box;
 		}
 
 		&.has-text {
@@ -307,10 +303,6 @@
 			padding-right: $grid-unit-15;
 			padding-left: $grid-unit-10;
 			gap: $grid-unit-05;
-		}
-
-		&.has-text .dashicon {
-			margin-right: $grid-unit-10 + 2px;
 		}
 	}
 

--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -291,11 +291,8 @@
 		}
 
 		.dashicon {
-			display: inline-flex;
-			justify-content: center;
-			align-items: center;
-			padding: 2px;
-			box-sizing: content-box;
+			margin-left: 2px;
+			margin-right: 2px;
 		}
 
 		&.has-text {

--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -291,8 +291,11 @@
 		}
 
 		.dashicon {
-			margin-left: 2px;
-			margin-right: 2px;
+			display: inline-flex;
+			justify-content: center;
+			align-items: center;
+			padding: 2px;
+			box-sizing: content-box;
 		}
 
 		&.has-text {

--- a/test/storybook-playwright/specs/button.spec.ts
+++ b/test/storybook-playwright/specs/button.spec.ts
@@ -54,4 +54,20 @@ test.describe( 'Button', () => {
 			} );
 		} );
 	} );
+
+	test.describe( 'dashicon', () => {
+		test.beforeEach( async ( { page } ) => {
+			await gotoStoryId( page, 'components-button--dashicons', {
+				decorators: { css: 'wordpress' },
+			} );
+			// Wait for dashicons font to load
+			await page.waitForFunction( () =>
+				document.fonts.check( '20px dashicons' )
+			);
+		} );
+
+		test( 'should render with correct spacing', async ( { page } ) => {
+			expect( await page.screenshot() ).toMatchSnapshot();
+		} );
+	} );
 } );

--- a/test/storybook-playwright/utils.ts
+++ b/test/storybook-playwright/utils.ts
@@ -21,7 +21,7 @@ const buildDecoratorString = ( decorators: Decorators = {} ) => {
 	return decoratorParamStrings.join( ';' );
 };
 
-export const gotoStoryId = (
+export const gotoStoryId = async (
 	page: Page,
 	storyId: string,
 	{ decorators }: Options = {}
@@ -35,7 +35,7 @@ export const gotoStoryId = (
 
 	params.set( 'id', storyId );
 
-	page.goto(
+	await page.goto(
 		`http://localhost:${ STORYBOOK_PORT }/iframe.html?${ params.toString() }`,
 		{ waitUntil: 'load' }
 	);


### PR DESCRIPTION
## What?

This PR removes the extra space that is added between the icon and the text when the dashicon is used in a `Button` component.

![before_dropdown](https://github.com/WordPress/gutenberg/assets/54422211/16857c96-56ce-4cd0-9526-47130f23c938)

## Why?
In #50277, the [gap](url) is now used for spacing between icon and text. However, for dashicon, `margin-right` was still used for the spading between the icon and the text.

## How?
Removed unnecessary margin style. At the same time, I also removed unnecessary styles (`display: inline-block; flex: 0 0 auto;`) from the dashicon since it's a child of flex.

## Testing Instructions

Update the Edit component (`packages/block-library/src/code/edit.js`) of the code block as follows:

```javascript
/**
 * WordPress dependencies
 */
import { useBlockProps } from '@wordpress/block-editor';
import { Button, Flex } from '@wordpress/components';
import { help } from '@wordpress/icons';

export default function CodeEdit() {
	const blockProps = useBlockProps();
	return (
		<div { ...blockProps }>
			<p>Button with Icon component</p>
			<Flex justify="flex-start" gap={ 3 } wrap={ true }>
				<Button icon={ help } variant="primary">
					Push Me
				</Button>
				<Button icon={ help } variant="secondary">
					Push Me
				</Button>
				<Button icon={ help } variant="tertiary">
					Push Me
				</Button>
				<Button icon={ help } variant="primary" />
			</Flex>
			<p>Button with dashicon</p>
			<Flex justify="flex-start" gap={ 3 } wrap={ true }>
				<Button icon="editor-help" variant="primary">
					Push Me
				</Button>
				<Button icon="editor-help" variant="secondary">
					Push Me
				</Button>
				<Button icon="editor-help" variant="tertiary">
					Push Me
				</Button>
				<Button icon="editor-help" variant="primary" />
			</Flex>
		</div>
	);
}
```

Confirm that the width of the `Button` component with the `Icon` component matches the width of the `Button` compoent with the dashicon.

## Screenshots or screencast <!-- if applicable -->

![after](https://github.com/WordPress/gutenberg/assets/54422211/c4c01306-f6fc-44c5-88de-9a0e9ca6f0c9)


