### PR TITLE
Block Editor Settings: use v2 DropdownMenu

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18617,6 +18617,7 @@
 				"@wordpress/i18n": "file:packages/i18n",
 				"@wordpress/icons": "file:packages/icons",
 				"@wordpress/notices": "file:packages/notices",
+				"@wordpress/private-apis": "file:packages/private-apis",
 				"@wordpress/url": "file:packages/url"
 			}
 		},

--- a/packages/block-editor/src/components/block-lock/menu-item.js
+++ b/packages/block-editor/src/components/block-lock/menu-item.js
@@ -42,7 +42,11 @@ export default function BlockLockMenuItem( { clientId } ) {
 						size={ 24 }
 					/>
 				}
-				onClick={ toggleModal }
+				onSelect={ ( event ) => {
+					toggleModal();
+					// Keep the dropdown menu open
+					event.preventDefault();
+				} }
 			>
 				{ label }
 			</DropdownMenuItemV2>

--- a/packages/block-editor/src/components/block-lock/menu-item.js
+++ b/packages/block-editor/src/components/block-lock/menu-item.js
@@ -3,7 +3,10 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useReducer } from '@wordpress/element';
-import { MenuItem } from '@wordpress/components';
+import {
+	Icon,
+	privateApis as componentsPrivateApis,
+} from '@wordpress/components';
 import { lockOutline, unlock } from '@wordpress/icons';
 
 /**
@@ -11,6 +14,9 @@ import { lockOutline, unlock } from '@wordpress/icons';
  */
 import useBlockLock from './use-block-lock';
 import BlockLockModal from './modal';
+import { unlock as unlockPrivateApis } from '../../lock-unlock';
+
+const { DropdownMenuItemV2 } = unlockPrivateApis( componentsPrivateApis );
 
 export default function BlockLockMenuItem( { clientId } ) {
 	const { canLock, isLocked } = useBlockLock( clientId );
@@ -28,12 +34,18 @@ export default function BlockLockMenuItem( { clientId } ) {
 
 	return (
 		<>
-			<MenuItem
-				icon={ isLocked ? unlock : lockOutline }
+			{ /* TODO: check if this used in other legacy dropdown menus */ }
+			<DropdownMenuItemV2
+				prefix={
+					<Icon
+						icon={ isLocked ? unlock : lockOutline }
+						size={ 24 }
+					/>
+				}
 				onClick={ toggleModal }
 			>
 				{ label }
-			</MenuItem>
+			</DropdownMenuItemV2>
 			{ isModalOpen && (
 				<BlockLockModal clientId={ clientId } onClose={ toggleModal } />
 			) }

--- a/packages/block-editor/src/components/block-settings-menu-controls/README.md
+++ b/packages/block-editor/src/components/block-settings-menu-controls/README.md
@@ -6,12 +6,14 @@ Block Settings Menu Controls appear in the block settings dropdown menu when the
 
 ```jsx
 import { BlockSettingsMenuControls } from '@wordress/block-editor';
-import MyButton from './my-toggle-button';
+import MyToggleButton from './my-toggle-button';
 
 function ReusableBlocksMenuItems() {
 	return (
 		<BlockSettingsMenuControls>
-			{ ( { onClose } ) => <MyToggleButton onToggle={ onClose } /> }
+			{/* Is this a breaking change? */}
+			{/* Should this use a menu item example? */}
+			{ () => <MyToggleButton onToggle={ /* ... */ } /> }
 		</BlockSettingsMenuControls>
 	);
 }

--- a/packages/block-editor/src/components/block-settings-menu-controls/README.md
+++ b/packages/block-editor/src/components/block-settings-menu-controls/README.md
@@ -13,7 +13,7 @@ function ReusableBlocksMenuItems() {
 		<BlockSettingsMenuControls>
 			{/* Is this a breaking change? */}
 			{/* Should this use a menu item example? */}
-			{ () => <MyToggleButton onToggle={ /* ... */ } /> }
+			<MyToggleButton onToggle={ /* ... */ } />
 		</BlockSettingsMenuControls>
 	);
 }

--- a/packages/block-editor/src/components/block-settings-menu-controls/index.js
+++ b/packages/block-editor/src/components/block-settings-menu-controls/index.js
@@ -7,7 +7,6 @@ import {
 	privateApis as componentsPrivateApis,
 } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
-import { pipe } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
 
 /**

--- a/packages/block-editor/src/components/block-settings-menu-controls/index.js
+++ b/packages/block-editor/src/components/block-settings-menu-controls/index.js
@@ -88,7 +88,6 @@ const BlockSettingsMenuControlsSlot = ( {
 							{ showConvertToGroupButton && (
 								<ConvertToGroupButton
 									{ ...convertToGroupButtonProps }
-									onClose={ fillProps?.onClose }
 								/>
 							) }
 							{ showLockButton && (
@@ -99,11 +98,7 @@ const BlockSettingsMenuControlsSlot = ( {
 							{ fills }
 							{ fillProps?.canMove && ! fillProps?.onlyBlock && (
 								<DropdownMenuItemV2
-									onSelect={ pipe(
-										// TODO: onclose?
-										// fillProps?.onClose,
-										fillProps?.onMoveTo
-									) }
+									onSelect={ fillProps?.onMoveTo }
 								>
 									{ __( 'Move to' ) }
 								</DropdownMenuItemV2>
@@ -111,7 +106,6 @@ const BlockSettingsMenuControlsSlot = ( {
 							{ fillProps?.count === 1 && (
 								<BlockModeToggle
 									clientId={ fillProps?.firstBlockClientId }
-									onToggle={ fillProps?.onClose }
 								/>
 							) }
 						</DropdownMenuGroupV2>

--- a/packages/block-editor/src/components/block-settings-menu-controls/index.js
+++ b/packages/block-editor/src/components/block-settings-menu-controls/index.js
@@ -3,9 +3,8 @@
  */
 import {
 	createSlotFill,
-	MenuGroup,
-	MenuItem,
 	__experimentalStyleProvider as StyleProvider,
+	privateApis as componentsPrivateApis,
 } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { pipe } from '@wordpress/compose';
@@ -21,8 +20,13 @@ import {
 import { BlockLockMenuItem, useBlockLock } from '../block-lock';
 import { store as blockEditorStore } from '../../store';
 import BlockModeToggle from '../block-settings-menu/block-mode-toggle';
+import { unlock } from '../../lock-unlock';
 
 const { Fill, Slot } = createSlotFill( 'BlockSettingsMenuControls' );
+
+const { DropdownMenuGroupV2, DropdownMenuItemV2 } = unlock(
+	componentsPrivateApis
+);
 
 const BlockSettingsMenuControlsSlot = ( {
 	fillProps,
@@ -77,7 +81,9 @@ const BlockSettingsMenuControlsSlot = ( {
 				}
 
 				return (
-					<MenuGroup>
+					// TODO: separator?
+					// TODO: check if this used in other legacy dropdown menus
+					<DropdownMenuGroupV2>
 						{ showConvertToGroupButton && (
 							<ConvertToGroupButton
 								{ ...convertToGroupButtonProps }
@@ -91,14 +97,15 @@ const BlockSettingsMenuControlsSlot = ( {
 						) }
 						{ fills }
 						{ fillProps?.canMove && ! fillProps?.onlyBlock && (
-							<MenuItem
-								onClick={ pipe(
-									fillProps?.onClose,
+							<DropdownMenuItemV2
+								onSelect={ pipe(
+									// TODO: onclose?
+									// fillProps?.onClose,
 									fillProps?.onMoveTo
 								) }
 							>
 								{ __( 'Move to' ) }
-							</MenuItem>
+							</DropdownMenuItemV2>
 						) }
 						{ fillProps?.count === 1 && (
 							<BlockModeToggle
@@ -106,7 +113,7 @@ const BlockSettingsMenuControlsSlot = ( {
 								onToggle={ fillProps?.onClose }
 							/>
 						) }
-					</MenuGroup>
+					</DropdownMenuGroupV2>
 				);
 			} }
 		</Slot>

--- a/packages/block-editor/src/components/block-settings-menu-controls/index.js
+++ b/packages/block-editor/src/components/block-settings-menu-controls/index.js
@@ -24,9 +24,8 @@ import { unlock } from '../../lock-unlock';
 
 const { Fill, Slot } = createSlotFill( 'BlockSettingsMenuControls' );
 
-const { DropdownMenuGroupV2, DropdownMenuItemV2 } = unlock(
-	componentsPrivateApis
-);
+const { DropdownMenuGroupV2, DropdownMenuItemV2, DropdownMenuSeparatorV2 } =
+	unlock( componentsPrivateApis );
 
 const BlockSettingsMenuControlsSlot = ( {
 	fillProps,
@@ -81,39 +80,42 @@ const BlockSettingsMenuControlsSlot = ( {
 				}
 
 				return (
-					// TODO: separator?
-					// TODO: check if this used in other legacy dropdown menus
-					<DropdownMenuGroupV2>
-						{ showConvertToGroupButton && (
-							<ConvertToGroupButton
-								{ ...convertToGroupButtonProps }
-								onClose={ fillProps?.onClose }
-							/>
-						) }
-						{ showLockButton && (
-							<BlockLockMenuItem
-								clientId={ selectedClientIds[ 0 ] }
-							/>
-						) }
-						{ fills }
-						{ fillProps?.canMove && ! fillProps?.onlyBlock && (
-							<DropdownMenuItemV2
-								onSelect={ pipe(
-									// TODO: onclose?
-									// fillProps?.onClose,
-									fillProps?.onMoveTo
-								) }
-							>
-								{ __( 'Move to' ) }
-							</DropdownMenuItemV2>
-						) }
-						{ fillProps?.count === 1 && (
-							<BlockModeToggle
-								clientId={ fillProps?.firstBlockClientId }
-								onToggle={ fillProps?.onClose }
-							/>
-						) }
-					</DropdownMenuGroupV2>
+					<>
+						{ /* TODO: check if this used in other legacy dropdown
+						menus */ }
+						<DropdownMenuSeparatorV2 />
+						<DropdownMenuGroupV2>
+							{ showConvertToGroupButton && (
+								<ConvertToGroupButton
+									{ ...convertToGroupButtonProps }
+									onClose={ fillProps?.onClose }
+								/>
+							) }
+							{ showLockButton && (
+								<BlockLockMenuItem
+									clientId={ selectedClientIds[ 0 ] }
+								/>
+							) }
+							{ fills }
+							{ fillProps?.canMove && ! fillProps?.onlyBlock && (
+								<DropdownMenuItemV2
+									onSelect={ pipe(
+										// TODO: onclose?
+										// fillProps?.onClose,
+										fillProps?.onMoveTo
+									) }
+								>
+									{ __( 'Move to' ) }
+								</DropdownMenuItemV2>
+							) }
+							{ fillProps?.count === 1 && (
+								<BlockModeToggle
+									clientId={ fillProps?.firstBlockClientId }
+									onToggle={ fillProps?.onClose }
+								/>
+							) }
+						</DropdownMenuGroupV2>
+					</>
 				);
 			} }
 		</Slot>

--- a/packages/block-editor/src/components/block-settings-menu/block-convert-button.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-convert-button.js
@@ -2,7 +2,14 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { MenuItem } from '@wordpress/components';
+import { privateApis as componentsPrivateApis } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import { unlock } from '../../lock-unlock';
+
+const { DropdownMenuItemV2 } = unlock( componentsPrivateApis );
 
 export default function BlockConvertButton( { shouldRender, onClick, small } ) {
 	if ( ! shouldRender ) {
@@ -10,5 +17,10 @@ export default function BlockConvertButton( { shouldRender, onClick, small } ) {
 	}
 
 	const label = __( 'Convert to Blocks' );
-	return <MenuItem onClick={ onClick }>{ ! small && label }</MenuItem>;
+	return (
+		/* TODO: check if this used in other legacy dropdown menus */
+		<DropdownMenuItemV2 onSelect={ onClick }>
+			{ ! small && label }
+		</DropdownMenuItemV2>
+	);
 }

--- a/packages/block-editor/src/components/block-settings-menu/block-mode-toggle.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-mode-toggle.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { MenuItem } from '@wordpress/components';
+import { privateApis as componentsPrivateApis } from '@wordpress/components';
 import { getBlockType, hasBlockSupport } from '@wordpress/blocks';
 import { withSelect, withDispatch } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
@@ -11,6 +11,9 @@ import { compose } from '@wordpress/compose';
  * Internal dependencies
  */
 import { store as blockEditorStore } from '../../store';
+import { unlock } from '../../lock-unlock';
+
+const { DropdownMenuItemV2 } = unlock( componentsPrivateApis );
 
 const noop = () => {};
 
@@ -32,7 +35,13 @@ export function BlockModeToggle( {
 	const label =
 		mode === 'visual' ? __( 'Edit as HTML' ) : __( 'Edit visually' );
 
-	return <MenuItem onClick={ onToggleMode }>{ ! small && label }</MenuItem>;
+	return (
+		// TODO: should prevent default?
+		// TODO: check if this used in other legacy dropdown menus
+		<DropdownMenuItemV2 onSelect={ onToggleMode }>
+			{ ! small && label }
+		</DropdownMenuItemV2>
+	);
 }
 
 export default compose( [

--- a/packages/block-editor/src/components/block-settings-menu/block-mode-toggle.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-mode-toggle.js
@@ -36,9 +36,9 @@ export function BlockModeToggle( {
 		mode === 'visual' ? __( 'Edit as HTML' ) : __( 'Edit visually' );
 
 	return (
-		// TODO: should prevent default?
 		// TODO: check if this used in other legacy dropdown menus
 		<DropdownMenuItemV2 onSelect={ onToggleMode }>
+			{ /* TODO: what if `small` is true? What contents are displayed? */ }
 			{ ! small && label }
 		</DropdownMenuItemV2>
 	);

--- a/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
@@ -52,6 +52,30 @@ function CopyMenuItem( { blocks, onCopy, label } ) {
 	return <MenuItem ref={ ref }>{ copyMenuItemLabel }</MenuItem>;
 }
 
+const ShortcutItemSuffix = ( { shortcut, className } ) => {
+	if ( ! shortcut ) {
+		return null;
+	}
+
+	let displayText;
+	let ariaLabel;
+
+	if ( typeof shortcut === 'string' ) {
+		displayText = shortcut;
+	}
+
+	if ( shortcut !== null && typeof shortcut === 'object' ) {
+		displayText = shortcut.display;
+		ariaLabel = shortcut.ariaLabel;
+	}
+
+	return (
+		<span className={ className } aria-label={ ariaLabel }>
+			{ displayText }
+		</span>
+	);
+};
+
 export function BlockSettingsDropdown( {
 	clientIds,
 	__experimentalSelectBlock,

--- a/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
@@ -372,6 +372,7 @@ export function BlockSettingsDropdown( {
 					align="start"
 					side="bottom"
 					sideOffset={ 12 }
+					className="block-editor-block-settings-menu__content"
 					onKeyDown={ ( event ) => {
 						if ( event.defaultPrevented ) return;
 

--- a/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
@@ -375,6 +375,7 @@ export function BlockSettingsDropdown( {
 					onKeyDown={ ( event ) => {
 						if ( event.defaultPrevented ) return;
 
+						// TODO: can use `onEscapeKeyDown` prop instead?
 						if ( event.key === 'Escape' ) {
 							setIsDropdownOpen( false );
 							event.preventDefault();

--- a/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
@@ -340,9 +340,7 @@ export function BlockSettingsDropdown( {
 			} ) => (
 				<DropdownMenuV2
 					open={ isDropdownOpen }
-					onOpenChange={ ( open ) => {
-						setIsDropdownOpen( open );
-					} }
+					onOpenChange={ setIsDropdownOpen }
 					trigger={
 						<Button
 							{ ...toggleProps }

--- a/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
@@ -166,7 +166,15 @@ export function BlockSettingsDropdown( {
 	children,
 	__unstableDisplayLocation,
 	toggleProps,
-	// Investigate which props are usually forwarded to this component
+	label,
+	icon,
+	disableOpenOnArrowDown,
+	// Unused (avoid forwarding with rest props)
+	block,
+	expand,
+	expandedState,
+	setInsertedBlock,
+	// Rest props
 	...props
 } ) {
 	const blockClientIds = Array.isArray( clientIds )
@@ -323,9 +331,18 @@ export function BlockSettingsDropdown( {
 					trigger={
 						<Button
 							{ ...toggleProps }
+							onKeyDown={ ( event ) => {
+								if (
+									disableOpenOnArrowDown &&
+									event.key === 'ArrowDown'
+								) {
+									event.preventDefault();
+								}
+								toggleProps?.onKeyDown?.( event );
+							} }
 							__next40pxDefaultSize
-							label={ __( 'Options' ) }
-							icon={ moreVertical }
+							label={ label ?? __( 'Options' ) }
+							icon={ icon ?? moreVertical }
 						/>
 					}
 					align="start"

--- a/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
@@ -247,50 +247,6 @@ export function BlockSettingsDropdown( {
 					align="start"
 					side="bottom"
 					sideOffset={ 12 }
-					menuProps={ {
-						/**
-						 * @param {KeyboardEvent} event
-						 */
-						onKeyDown( event ) {
-							if ( event.defaultPrevented ) return;
-
-							if (
-								isMatch( 'core/block-editor/remove', event ) &&
-								canRemove
-							) {
-								event.preventDefault();
-								updateSelectionAfterRemove( onRemove() );
-							} else if (
-								isMatch(
-									'core/block-editor/duplicate',
-									event
-								) &&
-								canDuplicate
-							) {
-								event.preventDefault();
-								updateSelectionAfterDuplicate( onDuplicate() );
-							} else if (
-								isMatch(
-									'core/block-editor/insert-after',
-									event
-								) &&
-								canInsertDefaultBlock
-							) {
-								event.preventDefault();
-								onInsertAfter();
-							} else if (
-								isMatch(
-									'core/block-editor/insert-before',
-									event
-								) &&
-								canInsertDefaultBlock
-							) {
-								event.preventDefault();
-								onInsertBefore();
-							}
-						},
-					} }
-					// Missing: onkeydown on the menu
 					// Missing: pressing esc is not just closing the menu, but also the toolbar?
 					{ ...props }
 				>

--- a/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
@@ -12,16 +12,11 @@ import {
 } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { moreVertical } from '@wordpress/icons';
-import {
-	Children,
-	cloneElement,
-	useCallback,
-	useRef,
-} from '@wordpress/element';
+import { useCallback, useRef } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import {
 	store as keyboardShortcutsStore,
-	__unstableUseShortcutEventMatch,
+	// __unstableUseShortcutEventMatch,
 } from '@wordpress/keyboard-shortcuts';
 import { pipe, useCopyToClipboard } from '@wordpress/compose';
 
@@ -50,7 +45,13 @@ function CopyMenuItem( { blocks, onCopy, label } ) {
 		blocks.length > 1 ? __( 'Copy blocks' ) : __( 'Copy' );
 	const copyMenuItemLabel = label ? label : copyMenuItemBlocksLabel;
 	return (
-		<DropdownMenuItemV2 ref={ ref }>
+		<DropdownMenuItemV2
+			ref={ ref }
+			onSelect={ ( event ) => {
+				// Keep the dropdown menu open.
+				event.preventDefault();
+			} }
+		>
 			{ copyMenuItemLabel }
 		</DropdownMenuItemV2>
 	);
@@ -152,7 +153,7 @@ export function BlockSettingsDropdown( {
 			),
 		};
 	}, [] );
-	const isMatch = __unstableUseShortcutEventMatch();
+	// const isMatch = __unstableUseShortcutEventMatch();
 
 	const { selectBlock, toggleBlockHighlight } =
 		useDispatch( blockEditorStore );
@@ -251,12 +252,9 @@ export function BlockSettingsDropdown( {
 					{ ...props }
 				>
 					<DropdownMenuGroupV2>
-						<__unstableBlockSettingsMenuFirstItem.Slot
-						// fillProps={ { onClose } } TODO: onClose missing
-						/>
+						<__unstableBlockSettingsMenuFirstItem.Slot />
 						{ ! parentBlockIsSelected && !! firstParentClientId && (
 							<DropdownMenuItemV2
-								// TODO: add onMouseMove and onMouseLeave to dropdownmenuitem
 								{ ...showParentOutlineGestures }
 								ref={ selectParentButtonRef }
 								prefix={
@@ -282,7 +280,6 @@ export function BlockSettingsDropdown( {
 						{ canDuplicate && (
 							<DropdownMenuItemV2
 								onSelect={ pipe(
-									// onClose, TODO: missing onClose
 									onDuplicate,
 									updateSelectionAfterDuplicate
 								) }
@@ -298,10 +295,7 @@ export function BlockSettingsDropdown( {
 						{ canInsertDefaultBlock && (
 							<>
 								<DropdownMenuItemV2
-									onSelect={ pipe(
-										// onClose, TODO: add onClose
-										onInsertBefore
-									) }
+									onSelect={ onInsertBefore }
 									suffix={
 										<Shortcut
 											shortcut={ shortcuts.insertBefore }
@@ -311,10 +305,7 @@ export function BlockSettingsDropdown( {
 									{ __( 'Add before' ) }
 								</DropdownMenuItemV2>
 								<DropdownMenuItemV2
-									onSelect={ pipe(
-										// onClose, TODO: add onClose
-										onInsertAfter
-									) }
+									onSelect={ onInsertAfter }
 									suffix={
 										<Shortcut
 											shortcut={ shortcuts.insertAfter }
@@ -334,14 +325,19 @@ export function BlockSettingsDropdown( {
 								onCopy={ onCopy }
 								label={ __( 'Copy styles' ) }
 							/>
-							<DropdownMenuItemV2 onSelect={ onPasteStyles }>
+							<DropdownMenuItemV2
+								onSelect={ ( event ) => {
+									onPasteStyles();
+									// Keep the dropdown menu open.
+									event.preventDefault();
+								} }
+							>
 								{ __( 'Paste styles' ) }
 							</DropdownMenuItemV2>
 						</DropdownMenuGroupV2>
 					) }
 					<BlockSettingsMenuControls.Slot
 						fillProps={ {
-							// onClose,
 							canMove,
 							onMoveTo,
 							onlyBlock,
@@ -351,22 +347,13 @@ export function BlockSettingsDropdown( {
 						clientIds={ clientIds }
 						__unstableDisplayLocation={ __unstableDisplayLocation }
 					/>
-					{ typeof children === 'function'
-						? children( {
-								/*onClose*/
-						  } )
-						: Children.map( ( child ) =>
-								cloneElement( child, {
-									/*onClose*/
-								} )
-						  ) }
+					{ typeof children === 'function' ? children() : children }
 					{ canRemove && (
 						<>
 							<DropdownMenuSeparatorV2 />
 							<DropdownMenuGroupV2>
 								<DropdownMenuItemV2
 									onClick={ pipe(
-										// onClose,
 										onRemove,
 										updateSelectionAfterRemove
 									) }

--- a/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
@@ -312,6 +312,12 @@ export function BlockSettingsDropdown( {
 	const parentBlockIsSelected =
 		selectedBlockClientIds?.includes( firstParentClientId );
 
+	const [ isDropdownOpen, setIsDropdownOpen ] = useState( false );
+
+	const closeDropdown = useCallback( () => {
+		setIsDropdownOpen( false );
+	}, [] );
+
 	return (
 		<BlockActions
 			clientIds={ clientIds }
@@ -333,6 +339,10 @@ export function BlockSettingsDropdown( {
 				blocks,
 			} ) => (
 				<DropdownMenuV2
+					open={ isDropdownOpen }
+					onOpenChange={ ( open ) => {
+						setIsDropdownOpen( open );
+					} }
 					trigger={
 						<Button
 							{ ...toggleProps }
@@ -359,6 +369,11 @@ export function BlockSettingsDropdown( {
 					sideOffset={ 12 }
 					onKeyDown={ ( event ) => {
 						if ( event.defaultPrevented ) return;
+
+						if ( event.key === 'Escape' ) {
+							setIsDropdownOpen( false );
+							event.preventDefault();
+						}
 
 						if (
 							isMatch( 'core/block-editor/remove', event ) &&
@@ -396,7 +411,9 @@ export function BlockSettingsDropdown( {
 					{ ...props }
 				>
 					<DropdownMenuGroupV2>
-						<__unstableBlockSettingsMenuFirstItem.Slot />
+						<__unstableBlockSettingsMenuFirstItem.Slot
+							fillProps={ { onClose: closeDropdown } }
+						/>
 						{ ! parentBlockIsSelected && !! firstParentClientId && (
 							<DropdownMenuItemV2
 								{ ...showParentOutlineGestures }
@@ -474,6 +491,7 @@ export function BlockSettingsDropdown( {
 					) }
 					<BlockSettingsMenuControls.Slot
 						fillProps={ {
+							onClose: closeDropdown,
 							canMove,
 							onMoveTo,
 							onlyBlock,

--- a/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
@@ -6,7 +6,10 @@ import {
 	serialize,
 	store as blocksStore,
 } from '@wordpress/blocks';
-import { DropdownMenu, MenuGroup, MenuItem } from '@wordpress/components';
+import {
+	Button,
+	privateApis as componentsPrivateApis,
+} from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { moreVertical } from '@wordpress/icons';
 import {
@@ -32,11 +35,14 @@ import __unstableBlockSettingsMenuFirstItem from './block-settings-menu-first-it
 import BlockSettingsMenuControls from '../block-settings-menu-controls';
 import { store as blockEditorStore } from '../../store';
 import { useShowMoversGestures } from '../block-toolbar/utils';
+import { unlock } from '../../lock-unlock';
 
-const POPOVER_PROPS = {
-	className: 'block-editor-block-settings-menu__popover',
-	placement: 'bottom-start',
-};
+const {
+	DropdownMenuV2,
+	DropdownMenuGroupV2,
+	DropdownMenuItemV2,
+	DropdownMenuSeparatorV2,
+} = unlock( componentsPrivateApis );
 
 function CopyMenuItem( { blocks, onCopy, label } ) {
 	const ref = useCopyToClipboard( () => serialize( blocks ), onCopy );
@@ -51,6 +57,8 @@ export function BlockSettingsDropdown( {
 	__experimentalSelectBlock,
 	children,
 	__unstableDisplayLocation,
+	toggleProps,
+	// Investigate which props are usually forwarded to this component
 	...props
 } ) {
 	const blockClientIds = Array.isArray( clientIds )
@@ -203,12 +211,18 @@ export function BlockSettingsDropdown( {
 				onMoveTo,
 				blocks,
 			} ) => (
-				<DropdownMenu
-					icon={ moreVertical }
-					label={ __( 'Options' ) }
-					className="block-editor-block-settings-menu"
-					popoverProps={ POPOVER_PROPS }
-					noIcons
+				<DropdownMenuV2
+					trigger={
+						<Button
+							{ ...toggleProps }
+							__next40pxDefaultSize
+							label={ __( 'Options' ) }
+							icon={ moreVertical }
+						/>
+					}
+					align="start"
+					side="bottom"
+					sideOffset={ 12 }
 					menuProps={ {
 						/**
 						 * @param {KeyboardEvent} event
@@ -252,6 +266,8 @@ export function BlockSettingsDropdown( {
 							}
 						},
 					} }
+					// Missing: onkeydown on the menu
+					// Missing: pressing esc is not just closing the menu, but also the toolbar?
 					{ ...props }
 				>
 					{ ( { onClose } ) => (
@@ -378,7 +394,7 @@ export function BlockSettingsDropdown( {
 							) }
 						</>
 					) }
-				</DropdownMenu>
+				</DropdownMenuV2>
 			) }
 		</BlockActions>
 	);

--- a/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
@@ -318,6 +318,13 @@ export function BlockSettingsDropdown( {
 		setIsDropdownOpen( false );
 	}, [] );
 
+	// Save the dropdownTriggerId in case it is enforced via toggleProps, so that
+	// it can be passed as the value for the `aria-labelledby` prop for the
+	// dropdown content. This would normally work out of the box for the
+	// `DropdownMenu` component, but in this case the toggle may receive an
+	// external id from the parent `ToolbarItem` that can't be ignored.
+	const dropdownTriggerId = toggleProps?.id;
+
 	return (
 		<BlockActions
 			clientIds={ clientIds }
@@ -405,6 +412,7 @@ export function BlockSettingsDropdown( {
 							onInsertBefore();
 						}
 					} }
+					aria-labelledby={ dropdownTriggerId }
 					{ ...props }
 				>
 					<DropdownMenuGroupV2>

--- a/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
@@ -49,7 +49,11 @@ function CopyMenuItem( { blocks, onCopy, label } ) {
 	const copyMenuItemBlocksLabel =
 		blocks.length > 1 ? __( 'Copy blocks' ) : __( 'Copy' );
 	const copyMenuItemLabel = label ? label : copyMenuItemBlocksLabel;
-	return <MenuItem ref={ ref }>{ copyMenuItemLabel }</MenuItem>;
+	return (
+		<DropdownMenuItemV2 ref={ ref }>
+			{ copyMenuItemLabel }
+		</DropdownMenuItemV2>
+	);
 }
 
 const ShortcutItemSuffix = ( { shortcut, className } ) => {
@@ -294,128 +298,135 @@ export function BlockSettingsDropdown( {
 					// Missing: pressing esc is not just closing the menu, but also the toolbar?
 					{ ...props }
 				>
-					{ ( { onClose } ) => (
-						<>
-							<MenuGroup>
-								<__unstableBlockSettingsMenuFirstItem.Slot
-									fillProps={ { onClose } }
-								/>
-								{ ! parentBlockIsSelected &&
-									!! firstParentClientId && (
-										<MenuItem
-											{ ...showParentOutlineGestures }
-											ref={ selectParentButtonRef }
-											icon={
-												<BlockIcon
-													icon={
-														parentBlockType.icon
-													}
-												/>
-											}
-											onClick={ () =>
-												selectBlock(
-													firstParentClientId
-												)
-											}
-										>
-											{ sprintf(
-												/* translators: %s: Name of the block's parent. */
-												__(
-													'Select parent block (%s)'
-												),
-												parentBlockType.title
-											) }
-										</MenuItem>
-									) }
-								{ count === 1 && (
-									<BlockHTMLConvertButton
-										clientId={ firstBlockClientId }
-									/>
-								) }
-								<CopyMenuItem
-									blocks={ blocks }
-									onCopy={ onCopy }
-								/>
-								{ canDuplicate && (
-									<MenuItem
-										onClick={ pipe(
-											onClose,
-											onDuplicate,
-											updateSelectionAfterDuplicate
-										) }
-										shortcut={ shortcuts.duplicate }
-									>
-										{ __( 'Duplicate' ) }
-									</MenuItem>
-								) }
-								{ canInsertDefaultBlock && (
-									<>
-										<MenuItem
-											onClick={ pipe(
-												onClose,
-												onInsertBefore
-											) }
-											shortcut={ shortcuts.insertBefore }
-										>
-											{ __( 'Add before' ) }
-										</MenuItem>
-										<MenuItem
-											onClick={ pipe(
-												onClose,
-												onInsertAfter
-											) }
-											shortcut={ shortcuts.insertAfter }
-										>
-											{ __( 'Add after' ) }
-										</MenuItem>
-									</>
-								) }
-							</MenuGroup>
-							{ canCopyStyles && (
-								<MenuGroup>
-									<CopyMenuItem
-										blocks={ blocks }
-										onCopy={ onCopy }
-										label={ __( 'Copy styles' ) }
-									/>
-									<MenuItem onClick={ onPasteStyles }>
-										{ __( 'Paste styles' ) }
-									</MenuItem>
-								</MenuGroup>
-							) }
-							<BlockSettingsMenuControls.Slot
-								fillProps={ {
-									onClose,
-									canMove,
-									onMoveTo,
-									onlyBlock,
-									count,
-									firstBlockClientId,
-								} }
-								clientIds={ clientIds }
-								__unstableDisplayLocation={
-									__unstableDisplayLocation
+					<DropdownMenuGroupV2>
+						<__unstableBlockSettingsMenuFirstItem.Slot
+						// fillProps={ { onClose } } TODO: onClose missing
+						/>
+						{ ! parentBlockIsSelected && !! firstParentClientId && (
+							<DropdownMenuItemV2
+								// TODO: add onMouseMove and onMouseLeave to dropdownmenuitem
+								{ ...showParentOutlineGestures }
+								ref={ selectParentButtonRef }
+								prefix={
+									<BlockIcon icon={ parentBlockType.icon } />
 								}
+								onSelect={ () =>
+									selectBlock( firstParentClientId )
+								}
+							>
+								{ sprintf(
+									/* translators: %s: Name of the block's parent. */
+									__( 'Select parent block (%s)' ),
+									parentBlockType.title
+								) }
+							</DropdownMenuItemV2>
+						) }
+						{ count === 1 && (
+							<BlockHTMLConvertButton
+								clientId={ firstBlockClientId }
 							/>
-							{ typeof children === 'function'
-								? children( { onClose } )
-								: Children.map( ( child ) =>
-										cloneElement( child, { onClose } )
-								  ) }
-							{ canRemove && (
-								<MenuGroup>
-									<MenuItem
-										onClick={ pipe(
-											onClose,
-											onRemove,
-											updateSelectionAfterRemove
-										) }
-										shortcut={ shortcuts.remove }
-									>
-										{ removeBlockLabel }
-									</MenuItem>
-								</MenuGroup>
-							) }
+						) }
+						<CopyMenuItem blocks={ blocks } onCopy={ onCopy } />
+						{ canDuplicate && (
+							<DropdownMenuItemV2
+								onSelect={ pipe(
+									// onClose, TODO: missing onClose
+									onDuplicate,
+									updateSelectionAfterDuplicate
+								) }
+								suffix={
+									<ShortcutItemSuffix
+										shortcut={ shortcuts.duplicate }
+									/>
+								}
+							>
+								{ __( 'Duplicate' ) }
+							</DropdownMenuItemV2>
+						) }
+						{ canInsertDefaultBlock && (
+							<>
+								<DropdownMenuItemV2
+									onSelect={ pipe(
+										// onClose, TODO: add onClose
+										onInsertBefore
+									) }
+									suffix={
+										<ShortcutItemSuffix
+											shortcut={ shortcuts.insertBefore }
+										/>
+									}
+								>
+									{ __( 'Add before' ) }
+								</DropdownMenuItemV2>
+								<DropdownMenuItemV2
+									onSelect={ pipe(
+										// onClose, TODO: add onClose
+										onInsertAfter
+									) }
+									suffix={
+										<ShortcutItemSuffix
+											shortcut={ shortcuts.insertAfter }
+										/>
+									}
+								>
+									{ __( 'Add after' ) }
+								</DropdownMenuItemV2>
+							</>
+						) }
+					</DropdownMenuGroupV2>
+					<DropdownMenuSeparatorV2 />
+					{ canCopyStyles && (
+						<DropdownMenuGroupV2>
+							<CopyMenuItem
+								blocks={ blocks }
+								onCopy={ onCopy }
+								label={ __( 'Copy styles' ) }
+							/>
+							<DropdownMenuItemV2 onSelect={ onPasteStyles }>
+								{ __( 'Paste styles' ) }
+							</DropdownMenuItemV2>
+						</DropdownMenuGroupV2>
+					) }
+					<BlockSettingsMenuControls.Slot
+						fillProps={ {
+							// onClose,
+							canMove,
+							onMoveTo,
+							onlyBlock,
+							count,
+							firstBlockClientId,
+						} }
+						clientIds={ clientIds }
+						__unstableDisplayLocation={ __unstableDisplayLocation }
+					/>
+					{ typeof children === 'function'
+						? children( {
+								/*onClose*/
+						  } )
+						: Children.map( ( child ) =>
+								cloneElement( child, {
+									/*onClose*/
+								} )
+						  ) }
+					{ canRemove && (
+						<>
+							<DropdownMenuSeparatorV2 />
+							<DropdownMenuGroupV2>
+								<DropdownMenuItemV2
+									onClick={ pipe(
+										// onClose,
+										onRemove,
+										updateSelectionAfterRemove
+									) }
+									suffix={
+										<ShortcutItemSuffix
+											shortcut={ shortcuts.remove }
+										/>
+									}
+								>
+									{ removeBlockLabel }
+								</DropdownMenuItemV2>
+							</DropdownMenuGroupV2>
 						</>
 					) }
 				</DropdownMenuV2>

--- a/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
  * WordPress dependencies
  */
 import {
@@ -331,6 +336,10 @@ export function BlockSettingsDropdown( {
 					trigger={
 						<Button
 							{ ...toggleProps }
+							className={ classnames(
+								'block-editor-block-settings-menu__trigger',
+								toggleProps?.className
+							) }
 							onKeyDown={ ( event ) => {
 								if (
 									disableOpenOnArrowDown &&

--- a/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
@@ -407,7 +407,6 @@ export function BlockSettingsDropdown( {
 							onInsertBefore();
 						}
 					} }
-					// Missing: pressing esc is not just closing the menu, but also the toolbar?
 					{ ...props }
 				>
 					<DropdownMenuGroupV2>

--- a/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
@@ -428,7 +428,7 @@ export function BlockSettingsDropdown( {
 							<DropdownMenuSeparatorV2 />
 							<DropdownMenuGroupV2>
 								<DropdownMenuItemV2
-									onClick={ pipe(
+									onSelect={ pipe(
 										onRemove,
 										updateSelectionAfterRemove
 									) }

--- a/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
@@ -56,7 +56,7 @@ function CopyMenuItem( { blocks, onCopy, label } ) {
 	);
 }
 
-const ShortcutItemSuffix = ( { shortcut, className } ) => {
+const Shortcut = ( { shortcut } ) => {
 	if ( ! shortcut ) {
 		return null;
 	}
@@ -73,11 +73,7 @@ const ShortcutItemSuffix = ( { shortcut, className } ) => {
 		ariaLabel = shortcut.ariaLabel;
 	}
 
-	return (
-		<span className={ className } aria-label={ ariaLabel }>
-			{ displayText }
-		</span>
-	);
+	return <span aria-label={ ariaLabel }>{ displayText }</span>;
 };
 
 export function BlockSettingsDropdown( {
@@ -335,7 +331,7 @@ export function BlockSettingsDropdown( {
 									updateSelectionAfterDuplicate
 								) }
 								suffix={
-									<ShortcutItemSuffix
+									<Shortcut
 										shortcut={ shortcuts.duplicate }
 									/>
 								}
@@ -351,7 +347,7 @@ export function BlockSettingsDropdown( {
 										onInsertBefore
 									) }
 									suffix={
-										<ShortcutItemSuffix
+										<Shortcut
 											shortcut={ shortcuts.insertBefore }
 										/>
 									}
@@ -364,7 +360,7 @@ export function BlockSettingsDropdown( {
 										onInsertAfter
 									) }
 									suffix={
-										<ShortcutItemSuffix
+										<Shortcut
 											shortcut={ shortcuts.insertAfter }
 										/>
 									}
@@ -419,7 +415,7 @@ export function BlockSettingsDropdown( {
 										updateSelectionAfterRemove
 									) }
 									suffix={
-										<ShortcutItemSuffix
+										<Shortcut
 											shortcut={ shortcuts.remove }
 										/>
 									}

--- a/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
@@ -16,7 +16,7 @@ import { useCallback, useRef, useEffect, useState } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import {
 	store as keyboardShortcutsStore,
-	// __unstableUseShortcutEventMatch,
+	__unstableUseShortcutEventMatch,
 } from '@wordpress/keyboard-shortcuts';
 import { pipe } from '@wordpress/compose';
 
@@ -236,7 +236,7 @@ export function BlockSettingsDropdown( {
 			),
 		};
 	}, [] );
-	// const isMatch = __unstableUseShortcutEventMatch();
+	const isMatch = __unstableUseShortcutEventMatch();
 
 	const { selectBlock, toggleBlockHighlight } =
 		useDispatch( blockEditorStore );
@@ -331,6 +331,41 @@ export function BlockSettingsDropdown( {
 					align="start"
 					side="bottom"
 					sideOffset={ 12 }
+					onKeyDown={ ( event ) => {
+						if ( event.defaultPrevented ) return;
+
+						if (
+							isMatch( 'core/block-editor/remove', event ) &&
+							canRemove
+						) {
+							event.preventDefault();
+							updateSelectionAfterRemove( onRemove() );
+						} else if (
+							isMatch( 'core/block-editor/duplicate', event ) &&
+							canDuplicate
+						) {
+							event.preventDefault();
+							updateSelectionAfterDuplicate( onDuplicate() );
+						} else if (
+							isMatch(
+								'core/block-editor/insert-after',
+								event
+							) &&
+							canInsertDefaultBlock
+						) {
+							event.preventDefault();
+							onInsertAfter();
+						} else if (
+							isMatch(
+								'core/block-editor/insert-before',
+								event
+							) &&
+							canInsertDefaultBlock
+						) {
+							event.preventDefault();
+							onInsertBefore();
+						}
+					} }
 					// Missing: pressing esc is not just closing the menu, but also the toolbar?
 					{ ...props }
 				>

--- a/packages/block-editor/src/components/block-settings-menu/style.scss
+++ b/packages/block-editor/src/components/block-settings-menu/style.scss
@@ -1,3 +1,7 @@
+// TODO: these styles are still probably relevant since they are used by other
+// dropdown menus using the same classname. Next steps:
+// - consider moving these styles closer to those components
+// - consider refactoring those menus too
 .block-editor-block-settings-menu__popover .components-dropdown-menu__menu {
 	padding: 0;
 }

--- a/packages/block-editor/src/components/block-settings-menu/style.scss
+++ b/packages/block-editor/src/components/block-settings-menu/style.scss
@@ -1,7 +1,0 @@
-// TODO: these styles are still probably relevant since they are used by other
-// dropdown menus using the same classname. Next steps:
-// - consider moving these styles closer to those components
-// - consider refactoring those menus too
-.block-editor-block-settings-menu__popover .components-dropdown-menu__menu {
-	padding: 0;
-}

--- a/packages/block-editor/src/components/block-settings-menu/style.scss
+++ b/packages/block-editor/src/components/block-settings-menu/style.scss
@@ -1,0 +1,7 @@
+.block-editor-block-settings-menu__content {
+	// The "16px" are necessary to set the max-height correctly when meeting the viewport:
+	// - 12px are because of the offset (see the `sideOffset` prop)
+	// - 4px extra are necessary, probably to take into account borders etc?
+	max-height: calc(var(--radix-dropdown-menu-content-available-height) - 16px);
+	overflow-y: auto;
+}

--- a/packages/block-editor/src/components/block-settings-menu/test/block-mode-toggle.js
+++ b/packages/block-editor/src/components/block-settings-menu/test/block-mode-toggle.js
@@ -4,14 +4,24 @@
 import { render, screen } from '@testing-library/react';
 
 /**
+ * WordPress dependencies
+ */
+import { privateApis as componentsPrivateApis } from '@wordpress/components';
+
+/**
  * Internal dependencies
  */
 import { BlockModeToggle } from '../block-mode-toggle';
+import { unlock } from '../../../lock-unlock';
+
+const { DropdownMenuV2 } = unlock( componentsPrivateApis );
 
 describe( 'BlockModeToggle', () => {
 	it( "should not render the HTML mode button if the block doesn't support it", () => {
 		render(
-			<BlockModeToggle blockType={ { supports: { html: false } } } />
+			<DropdownMenuV2 defaultOpen>
+				<BlockModeToggle blockType={ { supports: { html: false } } } />
+			</DropdownMenuV2>
 		);
 
 		expect(
@@ -21,10 +31,12 @@ describe( 'BlockModeToggle', () => {
 
 	it( 'should render the HTML mode button', () => {
 		render(
-			<BlockModeToggle
-				blockType={ { supports: { html: true } } }
-				mode="visual"
-			/>
+			<DropdownMenuV2 defaultOpen>
+				<BlockModeToggle
+					blockType={ { supports: { html: true } } }
+					mode="visual"
+				/>
+			</DropdownMenuV2>
 		);
 
 		expect(
@@ -34,10 +46,12 @@ describe( 'BlockModeToggle', () => {
 
 	it( 'should render the Visual mode button', () => {
 		render(
-			<BlockModeToggle
-				blockType={ { supports: { html: true } } }
-				mode="html"
-			/>
+			<DropdownMenuV2 defaultOpen>
+				<BlockModeToggle
+					blockType={ { supports: { html: true } } }
+					mode="html"
+				/>
+			</DropdownMenuV2>
 		);
 
 		expect(
@@ -47,11 +61,13 @@ describe( 'BlockModeToggle', () => {
 
 	it( 'should not render the Visual mode button if code editing is disabled', () => {
 		render(
-			<BlockModeToggle
-				blockType={ { supports: { html: true } } }
-				mode="html"
-				isCodeEditingEnabled={ false }
-			/>
+			<DropdownMenuV2 defaultOpen>
+				<BlockModeToggle
+					blockType={ { supports: { html: true } } }
+					mode="html"
+					isCodeEditingEnabled={ false }
+				/>
+			</DropdownMenuV2>
 		);
 
 		expect(

--- a/packages/block-editor/src/components/convert-to-group-buttons/index.js
+++ b/packages/block-editor/src/components/convert-to-group-buttons/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { MenuItem } from '@wordpress/components';
+import { privateApis as componentsPrivateApis } from '@wordpress/components';
 import { _x } from '@wordpress/i18n';
 import { switchToBlockType } from '@wordpress/blocks';
 import { useDispatch } from '@wordpress/data';
@@ -12,6 +12,9 @@ import { useDispatch } from '@wordpress/data';
 import { store as blockEditorStore } from '../../store';
 import useConvertToGroupButtonProps from './use-convert-to-group-button-props';
 import BlockGroupToolbar from './toolbar';
+import { unlock } from '../../lock-unlock';
+
+const { DropdownMenuItemV2 } = unlock( componentsPrivateApis );
 
 function ConvertToGroupButton( {
 	clientIds,
@@ -20,7 +23,8 @@ function ConvertToGroupButton( {
 	onUngroup,
 	blocksSelection,
 	groupingBlockName,
-	onClose = () => {},
+	// TODO: onclose
+	// onClose = () => {},
 } ) {
 	const { replaceBlocks } = useDispatch( blockEditorStore );
 	const onConvertToGroup = () => {
@@ -52,30 +56,31 @@ function ConvertToGroupButton( {
 		return null;
 	}
 
+	// TODO: check if this used in other legacy dropdown menus
 	return (
 		<>
 			{ isGroupable && (
-				<MenuItem
-					onClick={ () => {
+				<DropdownMenuItemV2
+					onSelect={ () => {
 						onConvertToGroup();
-						onClose();
+						// onClose();
 					} }
 				>
 					{ _x( 'Group', 'verb' ) }
-				</MenuItem>
+				</DropdownMenuItemV2>
 			) }
 			{ isUngroupable && (
-				<MenuItem
+				<DropdownMenuItemV2
 					onClick={ () => {
 						onConvertFromGroup();
-						onClose();
+						// onClose();
 					} }
 				>
 					{ _x(
 						'Ungroup',
 						'Ungrouping blocks from within a grouping block back into individual blocks within the Editor '
 					) }
-				</MenuItem>
+				</DropdownMenuItemV2>
 			) }
 		</>
 	);

--- a/packages/block-editor/src/components/convert-to-group-buttons/index.js
+++ b/packages/block-editor/src/components/convert-to-group-buttons/index.js
@@ -23,8 +23,6 @@ function ConvertToGroupButton( {
 	onUngroup,
 	blocksSelection,
 	groupingBlockName,
-	// TODO: onclose
-	// onClose = () => {},
 } ) {
 	const { replaceBlocks } = useDispatch( blockEditorStore );
 	const onConvertToGroup = () => {
@@ -63,7 +61,6 @@ function ConvertToGroupButton( {
 				<DropdownMenuItemV2
 					onSelect={ () => {
 						onConvertToGroup();
-						// onClose();
 					} }
 				>
 					{ _x( 'Group', 'verb' ) }

--- a/packages/block-editor/src/components/convert-to-group-buttons/index.js
+++ b/packages/block-editor/src/components/convert-to-group-buttons/index.js
@@ -70,7 +70,6 @@ function ConvertToGroupButton( {
 				<DropdownMenuItemV2
 					onClick={ () => {
 						onConvertFromGroup();
-						// onClose();
 					} }
 				>
 					{ _x(

--- a/packages/block-editor/src/components/list-view/block.js
+++ b/packages/block-editor/src/components/list-view/block.js
@@ -345,7 +345,7 @@ function ListViewBlock( {
 						<BlockSettingsMenu
 							clientIds={ dropdownClientIds }
 							block={ block }
-							icon={ moreVertical }
+							icon={ moreVertical } // can be probably removed?
 							label={ settingsAriaLabel }
 							toggleProps={ {
 								ref,

--- a/packages/block-editor/src/hooks/content-lock-ui.js
+++ b/packages/block-editor/src/hooks/content-lock-ui.js
@@ -130,11 +130,7 @@ export const withBlockControls = createHigherOrderComponent(
 				) }
 				{ showStartEditingAsBlocks && (
 					<BlockSettingsMenuControls>
-						{ (
-							{
-								/*onClose*/
-							}
-						) => (
+						{ () => (
 							/* TODO: check if this used in other legacy dropdown menus */
 							<DropdownMenuItemV2
 								onSelect={ () => {
@@ -154,7 +150,6 @@ export const withBlockControls = createHigherOrderComponent(
 									__unstableSetTemporarilyEditingAsBlocks(
 										props.clientId
 									);
-									// onClose(); TODO: onClose
 								} }
 							>
 								{ __( 'Modify' ) }

--- a/packages/block-editor/src/hooks/content-lock-ui.js
+++ b/packages/block-editor/src/hooks/content-lock-ui.js
@@ -130,31 +130,27 @@ export const withBlockControls = createHigherOrderComponent(
 				) }
 				{ showStartEditingAsBlocks && (
 					<BlockSettingsMenuControls>
-						{ () => (
-							/* TODO: check if this used in other legacy dropdown menus */
-							<DropdownMenuItemV2
-								onSelect={ () => {
-									__unstableMarkNextChangeAsNotPersistent();
-									updateBlockAttributes( props.clientId, {
-										templateLock: undefined,
-									} );
-									updateBlockListSettings( props.clientId, {
-										...getBlockListSettings(
-											props.clientId
-										),
-										templateLock: false,
-									} );
-									focusModeToRevert.current =
-										getSettings().focusMode;
-									updateSettings( { focusMode: true } );
-									__unstableSetTemporarilyEditingAsBlocks(
-										props.clientId
-									);
-								} }
-							>
-								{ __( 'Modify' ) }
-							</DropdownMenuItemV2>
-						) }
+						{ /* TODO: check if this used in other legacy dropdown menus */ }
+						<DropdownMenuItemV2
+							onSelect={ () => {
+								__unstableMarkNextChangeAsNotPersistent();
+								updateBlockAttributes( props.clientId, {
+									templateLock: undefined,
+								} );
+								updateBlockListSettings( props.clientId, {
+									...getBlockListSettings( props.clientId ),
+									templateLock: false,
+								} );
+								focusModeToRevert.current =
+									getSettings().focusMode;
+								updateSettings( { focusMode: true } );
+								__unstableSetTemporarilyEditingAsBlocks(
+									props.clientId
+								);
+							} }
+						>
+							{ __( 'Modify' ) }
+						</DropdownMenuItemV2>
 					</BlockSettingsMenuControls>
 				) }
 				<BlockEdit key="edit" { ...props } />

--- a/packages/block-editor/src/hooks/content-lock-ui.js
+++ b/packages/block-editor/src/hooks/content-lock-ui.js
@@ -1,7 +1,10 @@
 /**
  * WordPress dependencies
  */
-import { ToolbarButton, MenuItem } from '@wordpress/components';
+import {
+	ToolbarButton,
+	privateApis as componentsPrivateApis,
+} from '@wordpress/components';
 import { createHigherOrderComponent } from '@wordpress/compose';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { addFilter } from '@wordpress/hooks';
@@ -13,6 +16,9 @@ import { useEffect, useRef, useCallback } from '@wordpress/element';
  */
 import { store as blockEditorStore } from '../store';
 import { BlockControls, BlockSettingsMenuControls } from '../components';
+import { unlock } from '../lock-unlock';
+
+const { DropdownMenuItemV2 } = unlock( componentsPrivateApis );
 
 function StopEditingAsBlocksOnOutsideSelect( {
 	clientId,
@@ -124,9 +130,14 @@ export const withBlockControls = createHigherOrderComponent(
 				) }
 				{ showStartEditingAsBlocks && (
 					<BlockSettingsMenuControls>
-						{ ( { onClose } ) => (
-							<MenuItem
-								onClick={ () => {
+						{ (
+							{
+								/*onClose*/
+							}
+						) => (
+							/* TODO: check if this used in other legacy dropdown menus */
+							<DropdownMenuItemV2
+								onSelect={ () => {
 									__unstableMarkNextChangeAsNotPersistent();
 									updateBlockAttributes( props.clientId, {
 										templateLock: undefined,
@@ -143,11 +154,11 @@ export const withBlockControls = createHigherOrderComponent(
 									__unstableSetTemporarilyEditingAsBlocks(
 										props.clientId
 									);
-									onClose();
+									// onClose(); TODO: onClose
 								} }
 							>
 								{ __( 'Modify' ) }
-							</MenuItem>
+							</DropdownMenuItemV2>
 						) }
 					</BlockSettingsMenuControls>
 				) }

--- a/packages/block-editor/src/style.scss
+++ b/packages/block-editor/src/style.scss
@@ -14,7 +14,6 @@
 @import "./components/block-patterns-list/style.scss";
 @import "./components/block-popover/style.scss";
 @import "./components/block-preview/style.scss";
-@import "./components/block-settings-menu/style.scss";
 @import "./components/block-styles/style.scss";
 @import "./components/block-switcher/style.scss";
 @import "./components/block-types-list/style.scss";

--- a/packages/block-editor/src/style.scss
+++ b/packages/block-editor/src/style.scss
@@ -14,6 +14,7 @@
 @import "./components/block-patterns-list/style.scss";
 @import "./components/block-popover/style.scss";
 @import "./components/block-preview/style.scss";
+@import "./components/block-settings-menu/style.scss";
 @import "./components/block-styles/style.scss";
 @import "./components/block-switcher/style.scss";
 @import "./components/block-types-list/style.scss";

--- a/packages/block-library/src/navigation/edit/leaf-more-menu.js
+++ b/packages/block-library/src/navigation/edit/leaf-more-menu.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
  * WordPress dependencies
  */
 import { createBlock } from '@wordpress/blocks';
@@ -14,12 +19,6 @@ import { __, sprintf } from '@wordpress/i18n';
 import { BlockTitle, store as blockEditorStore } from '@wordpress/block-editor';
 
 const POPOVER_PROPS = {
-	// This was using the same class of the block settings dropdown:
-	// - check if there are no common components that were supposed to be rendered
-	//   in both menus
-	// - should this dropdown be refactored too?
-	// - should we restore the deleted styles, otherwise?
-	className: 'block-editor-block-settings-menu__popover',
 	placement: 'bottom-start',
 };
 
@@ -97,6 +96,7 @@ function AddSubmenuItem( {
 }
 
 export default function LeafMoreMenu( props ) {
+	// TODO: consider if this menu can be refactored later
 	const { block } = props;
 	const { clientId } = block;
 
@@ -122,11 +122,16 @@ export default function LeafMoreMenu( props ) {
 		<DropdownMenu
 			icon={ moreVertical }
 			label={ __( 'Options' ) }
-			// Same for this class
-			className="block-editor-block-settings-menu"
 			popoverProps={ POPOVER_PROPS }
 			noIcons
 			{ ...props }
+			toggleProps={ {
+				...props.toggleProps,
+				className: classnames(
+					'block-library-navigation-leaf-more-menu__trigger',
+					props.toggleProps?.className
+				),
+			} }
 		>
 			{ ( { onClose } ) => (
 				<>

--- a/packages/block-library/src/navigation/edit/leaf-more-menu.js
+++ b/packages/block-library/src/navigation/edit/leaf-more-menu.js
@@ -14,6 +14,11 @@ import { __, sprintf } from '@wordpress/i18n';
 import { BlockTitle, store as blockEditorStore } from '@wordpress/block-editor';
 
 const POPOVER_PROPS = {
+	// This was using the same class of the block settings dropdown:
+	// - check if there are no common components that were supposed to be rendered
+	//   in both menus
+	// - should this dropdown be refactored too?
+	// - should we restore the deleted styles, otherwise?
 	className: 'block-editor-block-settings-menu__popover',
 	placement: 'bottom-start',
 };
@@ -117,6 +122,7 @@ export default function LeafMoreMenu( props ) {
 		<DropdownMenu
 			icon={ moreVertical }
 			label={ __( 'Options' ) }
+			// Same for this class
 			className="block-editor-block-settings-menu"
 			popoverProps={ POPOVER_PROPS }
 			noIcons

--- a/packages/block-library/src/template-part/edit/index.js
+++ b/packages/block-library/src/template-part/edit/index.js
@@ -11,7 +11,11 @@ import {
 	__experimentalRecursionProvider as RecursionProvider,
 	__experimentalUseHasRecursion as useHasRecursion,
 } from '@wordpress/block-editor';
-import { Spinner, Modal, MenuItem } from '@wordpress/components';
+import {
+	Spinner,
+	Modal,
+	privateApis as componentsPrivateApis,
+} from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { store as coreStore } from '@wordpress/core-data';
 import { useState, createInterpolateElement } from '@wordpress/element';
@@ -29,6 +33,9 @@ import {
 	useAlternativeTemplateParts,
 	useTemplatePartArea,
 } from './utils/hooks';
+import { unlock } from '../../lock-unlock';
+
+const { DropdownMenuItemV2 } = unlock( componentsPrivateApis );
 
 export default function TemplatePartEdit( {
 	attributes,
@@ -157,8 +164,10 @@ export default function TemplatePartEdit( {
 				{ canReplace && (
 					<BlockSettingsMenuControls>
 						{ () => (
-							<MenuItem
-								onClick={ () => {
+							/* TODO: check if this used in other legacy dropdown menus */
+							<DropdownMenuItemV2
+								onSelect={ () => {
+									// TODO: should call preventDefault?
 									setIsTemplatePartSelectionOpen( true );
 								} }
 							>
@@ -173,7 +182,7 @@ export default function TemplatePartEdit( {
 										),
 									}
 								) }
-							</MenuItem>
+							</DropdownMenuItemV2>
 						) }
 					</BlockSettingsMenuControls>
 				) }

--- a/packages/block-library/src/template-part/edit/index.js
+++ b/packages/block-library/src/template-part/edit/index.js
@@ -163,28 +163,26 @@ export default function TemplatePartEdit( {
 				) }
 				{ canReplace && (
 					<BlockSettingsMenuControls>
-						{ () => (
-							/* TODO: check if this used in other legacy dropdown menus */
-							<DropdownMenuItemV2
-								onSelect={ ( event ) => {
-									setIsTemplatePartSelectionOpen( true );
-									// Keep the dropdown menu open
-									event.preventDefault();
-								} }
-							>
-								{ createInterpolateElement(
-									__( 'Replace <BlockTitle />' ),
-									{
-										BlockTitle: (
-											<BlockTitle
-												clientId={ clientId }
-												maximumLength={ 25 }
-											/>
-										),
-									}
-								) }
-							</DropdownMenuItemV2>
-						) }
+						{ /* TODO: check if this used in other legacy dropdown menus */ }
+						<DropdownMenuItemV2
+							onSelect={ ( event ) => {
+								setIsTemplatePartSelectionOpen( true );
+								// Keep the dropdown menu open
+								event.preventDefault();
+							} }
+						>
+							{ createInterpolateElement(
+								__( 'Replace <BlockTitle />' ),
+								{
+									BlockTitle: (
+										<BlockTitle
+											clientId={ clientId }
+											maximumLength={ 25 }
+										/>
+									),
+								}
+							) }
+						</DropdownMenuItemV2>
 					</BlockSettingsMenuControls>
 				) }
 				{ isEntityAvailable && (

--- a/packages/block-library/src/template-part/edit/index.js
+++ b/packages/block-library/src/template-part/edit/index.js
@@ -166,9 +166,10 @@ export default function TemplatePartEdit( {
 						{ () => (
 							/* TODO: check if this used in other legacy dropdown menus */
 							<DropdownMenuItemV2
-								onSelect={ () => {
-									// TODO: should call preventDefault?
+								onSelect={ ( event ) => {
 									setIsTemplatePartSelectionOpen( true );
+									// Keep the dropdown menu open
+									event.preventDefault();
 								} }
 							>
 								{ createInterpolateElement(

--- a/packages/block-library/src/template-part/edit/index.js
+++ b/packages/block-library/src/template-part/edit/index.js
@@ -163,7 +163,6 @@ export default function TemplatePartEdit( {
 				) }
 				{ canReplace && (
 					<BlockSettingsMenuControls>
-						{ /* TODO: check if this used in other legacy dropdown menus */ }
 						<DropdownMenuItemV2
 							onSelect={ ( event ) => {
 								setIsTemplatePartSelectionOpen( true );

--- a/packages/components/src/dropdown-menu-v2/index.tsx
+++ b/packages/components/src/dropdown-menu-v2/index.tsx
@@ -210,19 +210,22 @@ export const DropdownMenuItem = forwardRef(
 		{ children, prefix, suffix, ...props }: DropdownMenuItemProps,
 		forwardedRef: React.ForwardedRef< any >
 	) => {
+		const Component = props.href ? 'a' : 'div';
 		return (
-			<DropdownMenuStyled.Item { ...props } ref={ forwardedRef }>
-				{ prefix && (
-					<DropdownMenuStyled.ItemPrefixWrapper>
-						{ prefix }
-					</DropdownMenuStyled.ItemPrefixWrapper>
-				) }
-				{ children }
-				{ suffix && (
-					<DropdownMenuStyled.ItemSuffixWrapper>
-						{ suffix }
-					</DropdownMenuStyled.ItemSuffixWrapper>
-				) }
+			<DropdownMenuStyled.Item { ...props } asChild ref={ forwardedRef }>
+				<Component>
+					{ prefix && (
+						<DropdownMenuStyled.ItemPrefixWrapper>
+							{ prefix }
+						</DropdownMenuStyled.ItemPrefixWrapper>
+					) }
+					{ children }
+					{ suffix && (
+						<DropdownMenuStyled.ItemSuffixWrapper>
+							{ suffix }
+						</DropdownMenuStyled.ItemSuffixWrapper>
+					) }
+				</Component>
 			</DropdownMenuStyled.Item>
 		);
 	}

--- a/packages/components/src/dropdown-menu-v2/index.tsx
+++ b/packages/components/src/dropdown-menu-v2/index.tsx
@@ -62,6 +62,8 @@ const UnconnectedDropdownMenu = ( props: DropdownMenuProps ) => {
 		sideOffset = 0,
 		align = 'center',
 		alignOffset = 0,
+		// Other content props
+		onKeyDown,
 		// Render props
 		children,
 		trigger,
@@ -104,6 +106,7 @@ const UnconnectedDropdownMenu = ( props: DropdownMenuProps ) => {
 					alignOffset={ alignOffset }
 					loop={ true }
 					variant={ variant }
+					onKeyDown={ onKeyDown }
 				>
 					<DropdownMenuPrivateContext.Provider
 						value={ privateContextValue }

--- a/packages/components/src/dropdown-menu-v2/index.tsx
+++ b/packages/components/src/dropdown-menu-v2/index.tsx
@@ -64,6 +64,9 @@ const UnconnectedDropdownMenu = ( props: DropdownMenuProps ) => {
 		alignOffset = 0,
 		// Other content props
 		onKeyDown,
+		id,
+		className,
+		'aria-labelledby': ariaLabelledBy,
 		// Render props
 		children,
 		trigger,
@@ -87,6 +90,15 @@ const UnconnectedDropdownMenu = ( props: DropdownMenuProps ) => {
 		[ variant, portalContainer ]
 	);
 
+	// Only pass those props to `DropdownMenuStyled.Content` if they are defined,
+	// as it would otherwise override internal values
+	const extraContentProps = {
+		...( onKeyDown ? { onKeyDown } : null ),
+		...( id ? { id } : null ),
+		...( className ? { className } : null ),
+		...( ariaLabelledBy ? { 'aria-labelledby': ariaLabelledBy } : null ),
+	};
+
 	return (
 		<DropdownMenuPrimitive.Root
 			defaultOpen={ defaultOpen }
@@ -106,7 +118,7 @@ const UnconnectedDropdownMenu = ( props: DropdownMenuProps ) => {
 					alignOffset={ alignOffset }
 					loop={ true }
 					variant={ variant }
-					onKeyDown={ onKeyDown }
+					{ ...extraContentProps }
 				>
 					<DropdownMenuPrivateContext.Provider
 						value={ privateContextValue }

--- a/packages/components/src/dropdown-menu-v2/index.tsx
+++ b/packages/components/src/dropdown-menu-v2/index.tsx
@@ -19,7 +19,7 @@ import { SVG, Circle } from '@wordpress/primitives';
 /**
  * Internal dependencies
  */
-import { useContextSystem, contextConnectWithoutRef } from '../ui/context';
+import { useContextSystem, contextConnect } from '../ui/context';
 import { useSlot } from '../slot-fill';
 import Icon from '../icon';
 import { SLOT_NAME as POPOVER_DEFAULT_SLOT_NAME } from '../popover';
@@ -50,7 +50,10 @@ const DropdownMenuPrivateContext =
 		portalContainer: null,
 	} );
 
-const UnconnectedDropdownMenu = ( props: DropdownMenuProps ) => {
+const UnconnectedDropdownMenu = (
+	props: DropdownMenuProps,
+	forwardedRef: React.ForwardedRef< any >
+) => {
 	const {
 		// Root props
 		defaultOpen,
@@ -112,6 +115,7 @@ const UnconnectedDropdownMenu = ( props: DropdownMenuProps ) => {
 			</DropdownMenuPrimitive.Trigger>
 			<DropdownMenuPrimitive.Portal container={ portalContainer }>
 				<DropdownMenuStyled.Content
+					ref={ forwardedRef }
 					side={ side }
 					align={ align }
 					sideOffset={ sideOffset }
@@ -135,7 +139,7 @@ const UnconnectedDropdownMenu = ( props: DropdownMenuProps ) => {
  * `DropdownMenu` displays a menu to the user (such as a set of actions
  * or functions) triggered by a button.
  */
-export const DropdownMenu = contextConnectWithoutRef(
+export const DropdownMenu = contextConnect(
 	UnconnectedDropdownMenu,
 	'DropdownMenu'
 );

--- a/packages/components/src/dropdown-menu-v2/styles.ts
+++ b/packages/components/src/dropdown-menu-v2/styles.ts
@@ -174,15 +174,17 @@ const baseItem = css`
 	position: relative;
 	user-select: none;
 	outline: none;
+	cursor: pointer;
 
 	&[data-disabled] {
 		/*
-			TODO:
-			  - we need a disabled color in the Theme variables
-			  - design specs use opacity instead of setting a new text color
+		TODO:
+		- we need a disabled color in the Theme variables
+		- design specs use opacity instead of setting a new text color
 		*/
 		opacity: 0.5;
 		pointer-events: none;
+		cursor: default;
 	}
 
 	/* Hover and Focus styles */

--- a/packages/components/src/dropdown-menu-v2/styles.ts
+++ b/packages/components/src/dropdown-menu-v2/styles.ts
@@ -176,6 +176,14 @@ const baseItem = css`
 	outline: none;
 	cursor: pointer;
 
+	/* Undo existing base focus/hover/active styles */
+	&:focus,
+	&:hover,
+	&:active {
+		color: ${ COLORS.gray[ 900 ] };
+		box-shadow: none;
+	}
+
 	&[data-disabled] {
 		/*
 		TODO:

--- a/packages/components/src/dropdown-menu-v2/styles.ts
+++ b/packages/components/src/dropdown-menu-v2/styles.ts
@@ -75,6 +75,8 @@ const baseContent = (
 	animation-duration: ${ ANIMATION_PARAMS.DURATION };
 	animation-timing-function: ${ ANIMATION_PARAMS.EASING };
 	will-change: transform, opacity;
+	/* Following z-index('.components-popover'), as per base styles */
+	z-index: 1000000;
 
 	&[data-side='top'] {
 		animation-name: ${ slideDownAndFade };

--- a/packages/components/src/dropdown-menu-v2/styles.ts
+++ b/packages/components/src/dropdown-menu-v2/styles.ts
@@ -97,6 +97,16 @@ const baseContent = (
 	@media ( prefers-reduced-motion ) {
 		animation-duration: 0s;
 	}
+
+	/*
+	 * Styles to ensure a minimum level of back compat in case the legacy
+	 * MenuItem components were rendered inside the dropdown menu.
+	 **/
+	.components-menu-item__button,
+	.components-menu-item__button.components-button {
+		display: flex;
+		width: auto;
+	}
 `;
 
 const itemPrefix = css`

--- a/packages/components/src/dropdown-menu-v2/types.ts
+++ b/packages/components/src/dropdown-menu-v2/types.ts
@@ -147,6 +147,21 @@ export type DropdownMenuItemProps = {
 	 * The contents of the item's suffix
 	 */
 	suffix?: React.ReactNode;
+	/**
+	 * If specified, the menu item will render as an anchor tag and allow
+	 * navigation to the provided URL.
+	 */
+	href?: HTMLAnchorElement[ 'href' ];
+	/**
+	 * Equivalent to the `rel` attribute for an HTML Anchor Tag. It should
+	 * be only specified when passing a non-empty `href` prop.
+	 */
+	rel?: HTMLAnchorElement[ 'rel' ];
+	/**
+	 * Equivalent to the `target` attribute for an HTML Anchor Tag. It should
+	 * be only specified when passing a non-empty `href` prop.
+	 */
+	target?: HTMLAnchorElement[ 'target' ];
 } & Pick<
 	DropdownMenuPrimitive.DropdownMenuItemProps,
 	'onClick' | 'onMouseEnter' | 'onMouseMove' | 'onMouseLeave'

--- a/packages/components/src/dropdown-menu-v2/types.ts
+++ b/packages/components/src/dropdown-menu-v2/types.ts
@@ -147,7 +147,10 @@ export type DropdownMenuItemProps = {
 	 * The contents of the item's suffix
 	 */
 	suffix?: React.ReactNode;
-};
+} & Pick<
+	DropdownMenuPrimitive.DropdownMenuItemProps,
+	'onClick' | 'onMouseEnter' | 'onMouseMove' | 'onMouseLeave'
+>;
 
 export type DropdownMenuCheckboxItemProps = {
 	/**

--- a/packages/components/src/dropdown-menu-v2/types.ts
+++ b/packages/components/src/dropdown-menu-v2/types.ts
@@ -61,7 +61,7 @@ export type DropdownMenuProps = {
 	 * The contents of the dropdown
 	 */
 	children: React.ReactNode;
-};
+} & Pick< DropdownMenuPrimitive.DropdownMenuContentProps, 'onKeyDown' >;
 
 export type DropdownSubMenuTriggerProps = {
 	/**

--- a/packages/components/src/dropdown-menu-v2/types.ts
+++ b/packages/components/src/dropdown-menu-v2/types.ts
@@ -61,7 +61,10 @@ export type DropdownMenuProps = {
 	 * The contents of the dropdown
 	 */
 	children: React.ReactNode;
-} & Pick< DropdownMenuPrimitive.DropdownMenuContentProps, 'onKeyDown' >;
+} & Pick<
+	DropdownMenuPrimitive.DropdownMenuContentProps,
+	'onKeyDown' | 'id' | 'className' | 'aria-labelledby'
+>;
 
 export type DropdownSubMenuTriggerProps = {
 	/**

--- a/packages/components/src/modal/style.scss
+++ b/packages/components/src/modal/style.scss
@@ -8,6 +8,7 @@
 	background-color: rgba($black, 0.35);
 	z-index: z-index(".components-modal__screen-overlay");
 	display: flex;
+	pointer-events: all;
 	// backdrop-filter: blur($grid-unit);
 	// This animates the appearance of the white background.
 	@include edit-post__fade-in-animation();

--- a/packages/compose/README.md
+++ b/packages/compose/README.md
@@ -228,6 +228,7 @@ _Parameters_
 
 -   _text_ `string | (() => string)`: The text to copy. Use a function if not already available and expensive to compute.
 -   _onSuccess_ `Function`: Called when to text is copied.
+-   _container_ `Element=`: The container in which the copy action will be performed. Useful when there are active focus traps, like when using modal components.
 
 _Returns_
 

--- a/packages/compose/src/hooks/use-copy-to-clipboard/index.js
+++ b/packages/compose/src/hooks/use-copy-to-clipboard/index.js
@@ -31,14 +31,16 @@ function useUpdatedRef( value ) {
  * @param {string | (() => string)} text      The text to copy. Use a function if not
  *                                            already available and expensive to compute.
  * @param {Function}                onSuccess Called when to text is copied.
+ * @param {Element=}                container The container in which the copy action will be performed. Useful when there are active focus traps, like when using modal components.
  *
  * @return {import('react').Ref<TElementType>} A ref to assign to the target element.
  */
-export default function useCopyToClipboard( text, onSuccess ) {
+export default function useCopyToClipboard( text, onSuccess, container ) {
 	// Store the dependencies as refs and continuously update them so they're
 	// fresh when the callback is called.
 	const textRef = useUpdatedRef( text );
 	const onSuccessRef = useUpdatedRef( onSuccess );
+	const containerRef = useUpdatedRef( container );
 	return useRefEffect( ( node ) => {
 		// Clipboard listens to click events.
 		const clipboard = new Clipboard( node, {
@@ -47,6 +49,7 @@ export default function useCopyToClipboard( text, onSuccess ) {
 					? textRef.current()
 					: textRef.current || '';
 			},
+			container: containerRef.current ?? undefined,
 		} );
 
 		clipboard.on( 'success', ( { clearSelection } ) => {

--- a/packages/customize-widgets/src/components/block-inspector-button/index.js
+++ b/packages/customize-widgets/src/components/block-inspector-button/index.js
@@ -3,11 +3,18 @@
  */
 import { useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { MenuItem } from '@wordpress/components';
+import { privateApis as componentsPrivateApis } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 
-function BlockInspectorButton( { inspector, closeMenu, ...props } ) {
+/**
+ * Internal dependencies
+ */
+import { unlock } from '../../lock-unlock';
+
+const { DropdownMenuItemV2 } = unlock( componentsPrivateApis );
+
+function BlockInspectorButton( { inspector, ...props } ) {
 	const selectedBlockClientId = useSelect(
 		( select ) => select( blockEditorStore ).getSelectedBlockClientId(),
 		[]
@@ -19,19 +26,18 @@ function BlockInspectorButton( { inspector, closeMenu, ...props } ) {
 	);
 
 	return (
-		<MenuItem
-			onClick={ () => {
+		/* TODO: check if this used in other legacy dropdown menus */
+		<DropdownMenuItemV2
+			onSelect={ () => {
 				// Open the inspector.
 				inspector.open( {
 					returnFocusWhenClose: selectedBlock,
 				} );
-				// Then close the dropdown menu.
-				closeMenu();
 			} }
 			{ ...props }
 		>
 			{ __( 'Show more settings' ) }
-		</MenuItem>
+		</DropdownMenuItemV2>
 	);
 }
 

--- a/packages/customize-widgets/src/components/sidebar-block-editor/index.js
+++ b/packages/customize-widgets/src/components/sidebar-block-editor/index.js
@@ -139,12 +139,7 @@ export default function SidebarBlockEditor( {
 			</SidebarEditorProvider>
 
 			<__unstableBlockSettingsMenuFirstItem>
-				{ ( { onClose } ) => (
-					<BlockInspectorButton
-						inspector={ inspector }
-						closeMenu={ onClose }
-					/>
-				) }
+				<BlockInspectorButton inspector={ inspector } />
 			</__unstableBlockSettingsMenuFirstItem>
 		</>
 	);

--- a/packages/e2e-tests/specs/editor/various/block-grouping.test.js
+++ b/packages/e2e-tests/specs/editor/various/block-grouping.test.js
@@ -191,10 +191,11 @@ describe( 'Block Grouping', () => {
 		it( 'does not show group option in the options toolbar if Grouping block is disabled', async () => {
 			await clickBlockToolbarButton( 'Options' );
 
+			// TODO: need to improve the selector / maybe even use puppeteer-testing-library
 			const blockOptionsDropdownHTML = await page.evaluate(
 				() =>
 					document.querySelector(
-						'.block-editor-block-settings-menu__popover'
+						'[data-radix-menu-content][role="menu"]'
 					).innerHTML
 			);
 

--- a/packages/e2e-tests/specs/editor/various/block-grouping.test.js
+++ b/packages/e2e-tests/specs/editor/various/block-grouping.test.js
@@ -1,4 +1,10 @@
 /**
+ * External dependencies
+ */
+// eslint-disable-next-line no-restricted-imports
+import { find, QueryEmptyError } from 'puppeteer-testing-library';
+
+/**
  * WordPress dependencies
  */
 import {
@@ -189,17 +195,28 @@ describe( 'Block Grouping', () => {
 		} );
 
 		it( 'does not show group option in the options toolbar if Grouping block is disabled', async () => {
+			// Click on dropdown menu trigger
 			await clickBlockToolbarButton( 'Options' );
 
-			// TODO: need to improve the selector / maybe even use puppeteer-testing-library
-			const blockOptionsDropdownHTML = await page.evaluate(
-				() =>
-					document.querySelector(
-						'[data-radix-menu-content][role="menu"]'
-					).innerHTML
-			);
+			// Wait for menu to be visible
+			const blockOptionsDropdownHTML = await find( {
+				role: 'menu',
+				name: 'Options',
+			} );
 
-			expect( blockOptionsDropdownHTML ).not.toContain( 'Group' );
+			// Make sure that "Group" menu item is not rendered.
+			await expect(
+				find(
+					{
+						role: 'menuitem',
+						name: /^Group/,
+					},
+					{
+						root: blockOptionsDropdownHTML,
+						timeout: 0,
+					}
+				)
+			).rejects.toThrow( QueryEmptyError );
 		} );
 	} );
 

--- a/packages/edit-post/src/components/block-settings-menu/plugin-block-settings-menu-item.js
+++ b/packages/edit-post/src/components/block-settings-menu/plugin-block-settings-menu-item.js
@@ -2,8 +2,18 @@
  * WordPress dependencies
  */
 import { BlockSettingsMenuControls } from '@wordpress/block-editor';
-import { MenuItem } from '@wordpress/components';
+import {
+	Icon,
+	privateApis as componentsPrivateApis,
+} from '@wordpress/components';
 import { compose } from '@wordpress/compose';
+
+/**
+ * Internal dependencies
+ */
+import { unlock } from '../../lock-unlock';
+
+const { DropdownMenuItemV2 } = unlock( componentsPrivateApis );
 
 const isEverySelectedBlockAllowed = ( selected, allowed ) =>
 	selected.filter( ( id ) => ! allowed.includes( id ) ).length === 0;
@@ -87,19 +97,23 @@ const PluginBlockSettingsMenuItem = ( {
 	role,
 } ) => (
 	<BlockSettingsMenuControls>
-		{ ( { selectedBlocks, onClose } ) => {
+		{ ( { selectedBlocks /*onClose*/ } ) => {
 			if ( ! shouldRenderItem( selectedBlocks, allowedBlocks ) ) {
 				return null;
 			}
 			return (
-				<MenuItem
-					onClick={ compose( onClick, onClose ) }
-					icon={ icon }
-					label={ small ? label : undefined }
-					role={ role }
+				/* TODO: check if this used in other legacy dropdown menus */
+				<DropdownMenuItemV2
+					onClick={ compose(
+						onClick
+						// onClose TODO: onClose
+					) }
+					prefix={ <Icon icon={ icon } size={ 24 } /> }
+					label={ small ? label : undefined } // TODO: should item accept label? It's probably supposed to add an aria-label and potentially even a tooltip
+					role={ role } // TODO: should item accept role?
 				>
 					{ ! small && label }
-				</MenuItem>
+				</DropdownMenuItemV2>
 			);
 		} }
 	</BlockSettingsMenuControls>

--- a/packages/edit-post/src/components/block-settings-menu/plugin-block-settings-menu-item.js
+++ b/packages/edit-post/src/components/block-settings-menu/plugin-block-settings-menu-item.js
@@ -104,10 +104,7 @@ const PluginBlockSettingsMenuItem = ( {
 			return (
 				/* TODO: check if this used in other legacy dropdown menus */
 				<DropdownMenuItemV2
-					onClick={ compose(
-						onClick
-						// onClose TODO: onClose
-					) }
+					onSelect={ onClick }
 					prefix={ <Icon icon={ icon } size={ 24 } /> }
 					label={ small ? label : undefined } // TODO: should item accept label? It's probably supposed to add an aria-label and potentially even a tooltip
 					role={ role } // TODO: should item accept role?

--- a/packages/edit-post/src/components/block-settings-menu/plugin-block-settings-menu-item.js
+++ b/packages/edit-post/src/components/block-settings-menu/plugin-block-settings-menu-item.js
@@ -6,7 +6,6 @@ import {
 	Icon,
 	privateApis as componentsPrivateApis,
 } from '@wordpress/components';
-import { compose } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -97,7 +96,7 @@ const PluginBlockSettingsMenuItem = ( {
 	role,
 } ) => (
 	<BlockSettingsMenuControls>
-		{ ( { selectedBlocks /*onClose*/ } ) => {
+		{ ( { selectedBlocks } ) => {
 			if ( ! shouldRenderItem( selectedBlocks, allowedBlocks ) ) {
 				return null;
 			}

--- a/packages/edit-post/src/components/block-settings-menu/plugin-block-settings-menu-item.js
+++ b/packages/edit-post/src/components/block-settings-menu/plugin-block-settings-menu-item.js
@@ -101,7 +101,6 @@ const PluginBlockSettingsMenuItem = ( {
 				return null;
 			}
 			return (
-				/* TODO: check if this used in other legacy dropdown menus */
 				<DropdownMenuItemV2
 					onSelect={ onClick }
 					prefix={ <Icon icon={ icon } size={ 24 } /> }

--- a/packages/edit-post/src/components/visual-editor/block-inspector-button.js
+++ b/packages/edit-post/src/components/visual-editor/block-inspector-button.js
@@ -34,6 +34,7 @@ export function BlockInspectorButton( { onClick = noop, small = false } ) {
 		: __( 'Show more settings' );
 
 	return (
+		// Is this dead code?
 		<MenuItem
 			onClick={ () => {
 				if ( areAdvancedSettingsOpened ) {

--- a/packages/edit-site/src/components/block-editor/block-inspector-button.js
+++ b/packages/edit-site/src/components/block-editor/block-inspector-button.js
@@ -15,6 +15,7 @@ import { store as editSiteStore } from '../../store';
 import { STORE_NAME } from '../../store/constants';
 import { SIDEBAR_BLOCK } from '../sidebar-edit-mode/constants';
 
+// Is this dead code?
 export default function BlockInspectorButton( { onClick = () => {} } ) {
 	const { shortcut, isBlockInspectorOpen } = useSelect(
 		( select ) => ( {

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/leaf-more-menu.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/leaf-more-menu.js
@@ -9,6 +9,11 @@ import { __, sprintf } from '@wordpress/i18n';
 import { BlockTitle, store as blockEditorStore } from '@wordpress/block-editor';
 
 const POPOVER_PROPS = {
+	// This was using the same class of the block settings dropdown:
+	// - check if there are no common components that were supposed to be rendered
+	//   in both menus
+	// - should this dropdown be refactored too?
+	// - should we restore the deleted styles, otherwise?
 	className: 'block-editor-block-settings-menu__popover',
 	placement: 'bottom-start',
 };
@@ -38,6 +43,7 @@ export default function LeafMoreMenu( props ) {
 		<DropdownMenu
 			icon={ moreVertical }
 			label={ __( 'Options' ) }
+			// Same for this class
 			className="block-editor-block-settings-menu"
 			popoverProps={ POPOVER_PROPS }
 			noIcons

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/leaf-more-menu.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/leaf-more-menu.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
  * WordPress dependencies
  */
 
@@ -9,16 +14,11 @@ import { __, sprintf } from '@wordpress/i18n';
 import { BlockTitle, store as blockEditorStore } from '@wordpress/block-editor';
 
 const POPOVER_PROPS = {
-	// This was using the same class of the block settings dropdown:
-	// - check if there are no common components that were supposed to be rendered
-	//   in both menus
-	// - should this dropdown be refactored too?
-	// - should we restore the deleted styles, otherwise?
-	className: 'block-editor-block-settings-menu__popover',
 	placement: 'bottom-start',
 };
 
 export default function LeafMoreMenu( props ) {
+	// TODO: consider if this menu can be refactored later
 	const { block } = props;
 	const { clientId } = block;
 	const { moveBlocksDown, moveBlocksUp, removeBlocks } =
@@ -43,11 +43,16 @@ export default function LeafMoreMenu( props ) {
 		<DropdownMenu
 			icon={ moreVertical }
 			label={ __( 'Options' ) }
-			// Same for this class
-			className="block-editor-block-settings-menu"
 			popoverProps={ POPOVER_PROPS }
 			noIcons
 			{ ...props }
+			toggleProps={ {
+				...props.toggleProps,
+				className: classnames(
+					'edit-site-navigation-leaf-more-menu__trigger',
+					props.toggleProps?.className
+				),
+			} }
 		>
 			{ ( { onClose } ) => (
 				<>

--- a/packages/edit-site/src/components/template-part-converter/convert-to-regular.js
+++ b/packages/edit-site/src/components/template-part-converter/convert-to-regular.js
@@ -3,10 +3,17 @@
  */
 import { useSelect, useDispatch } from '@wordpress/data';
 import { store as blockEditorStore } from '@wordpress/block-editor';
-import { MenuItem } from '@wordpress/components';
+import { privateApis as componentsPrivateApis } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
-export default function ConvertToRegularBlocks( { clientId, onClose } ) {
+/**
+ * Internal dependencies
+ */
+import { unlock } from '../../lock-unlock';
+
+const { DropdownMenuItemV2 } = unlock( componentsPrivateApis );
+
+export default function ConvertToRegularBlocks( { clientId /*onClose*/ } ) {
 	const { getBlocks } = useSelect( blockEditorStore );
 	const { replaceBlocks } = useDispatch( blockEditorStore );
 
@@ -20,13 +27,14 @@ export default function ConvertToRegularBlocks( { clientId, onClose } ) {
 	}
 
 	return (
-		<MenuItem
-			onClick={ () => {
+		/* TODO: check if this used in other legacy dropdown menus */
+		<DropdownMenuItemV2
+			onSelect={ () => {
 				replaceBlocks( clientId, getBlocks( clientId ) );
-				onClose();
+				// onClose(); TODO: onClose
 			} }
 		>
 			{ __( 'Detach blocks from template part' ) }
-		</MenuItem>
+		</DropdownMenuItemV2>
 	);
 }

--- a/packages/edit-site/src/components/template-part-converter/convert-to-regular.js
+++ b/packages/edit-site/src/components/template-part-converter/convert-to-regular.js
@@ -13,7 +13,7 @@ import { unlock } from '../../lock-unlock';
 
 const { DropdownMenuItemV2 } = unlock( componentsPrivateApis );
 
-export default function ConvertToRegularBlocks( { clientId /*onClose*/ } ) {
+export default function ConvertToRegularBlocks( { clientId } ) {
 	const { getBlocks } = useSelect( blockEditorStore );
 	const { replaceBlocks } = useDispatch( blockEditorStore );
 
@@ -31,7 +31,6 @@ export default function ConvertToRegularBlocks( { clientId /*onClose*/ } ) {
 		<DropdownMenuItemV2
 			onSelect={ () => {
 				replaceBlocks( clientId, getBlocks( clientId ) );
-				// onClose(); TODO: onClose
 			} }
 		>
 			{ __( 'Detach blocks from template part' ) }

--- a/packages/edit-site/src/components/template-part-converter/convert-to-template-part.js
+++ b/packages/edit-site/src/components/template-part-converter/convert-to-template-part.js
@@ -3,7 +3,10 @@
  */
 import { useDispatch, useSelect } from '@wordpress/data';
 import { store as blockEditorStore } from '@wordpress/block-editor';
-import { MenuItem } from '@wordpress/components';
+import {
+	Icon,
+	privateApis as componentsPrivateApis,
+} from '@wordpress/components';
 import { createBlock, serialize } from '@wordpress/blocks';
 import { __ } from '@wordpress/i18n';
 import { useState } from '@wordpress/element';
@@ -21,6 +24,9 @@ import {
 	getUniqueTemplatePartTitle,
 	getCleanTemplatePartSlug,
 } from '../../utils/template-part-create';
+import { unlock } from '../../lock-unlock';
+
+const { DropdownMenuItemV2 } = unlock( componentsPrivateApis );
 
 export default function ConvertToTemplatePart( { clientIds, blocks } ) {
 	const [ isModalOpen, setIsModalOpen ] = useState( false );
@@ -75,14 +81,16 @@ export default function ConvertToTemplatePart( { clientIds, blocks } ) {
 
 	return (
 		<>
-			<MenuItem
-				icon={ symbolFilled }
-				onClick={ () => {
+			{ /* TODO: check if this used in other legacy dropdown menus */ }
+			<DropdownMenuItemV2
+				prefix={ <Icon icon={ symbolFilled } size={ 24 } /> }
+				onSelect={ () => {
 					setIsModalOpen( true );
+					// TODO: should call prevent default?
 				} }
 			>
 				{ __( 'Create Template part' ) }
-			</MenuItem>
+			</DropdownMenuItemV2>
 			{ isModalOpen && (
 				<CreateTemplatePartModal
 					closeModal={ () => {

--- a/packages/edit-site/src/components/template-part-converter/convert-to-template-part.js
+++ b/packages/edit-site/src/components/template-part-converter/convert-to-template-part.js
@@ -84,9 +84,10 @@ export default function ConvertToTemplatePart( { clientIds, blocks } ) {
 			{ /* TODO: check if this used in other legacy dropdown menus */ }
 			<DropdownMenuItemV2
 				prefix={ <Icon icon={ symbolFilled } size={ 24 } /> }
-				onSelect={ () => {
+				onSelect={ ( event ) => {
 					setIsModalOpen( true );
-					// TODO: should call prevent default?
+					// Keep the dropdown menu open
+					event.preventDefault();
 				} }
 			>
 				{ __( 'Create Template part' ) }

--- a/packages/edit-site/src/components/template-part-converter/index.js
+++ b/packages/edit-site/src/components/template-part-converter/index.js
@@ -16,17 +16,16 @@ import ConvertToTemplatePart from './convert-to-template-part';
 export default function TemplatePartConverter() {
 	return (
 		<BlockSettingsMenuControls>
-			{ ( { selectedClientIds, onClose } ) => (
+			{ ( { selectedClientIds } ) => (
 				<TemplatePartConverterMenuItem
 					clientIds={ selectedClientIds }
-					onClose={ onClose }
 				/>
 			) }
 		</BlockSettingsMenuControls>
 	);
 }
 
-function TemplatePartConverterMenuItem( { clientIds, onClose } ) {
+function TemplatePartConverterMenuItem( { clientIds } ) {
 	const blocks = useSelect(
 		( select ) =>
 			select( blockEditorStore ).getBlocksByClientId( clientIds ),
@@ -35,12 +34,7 @@ function TemplatePartConverterMenuItem( { clientIds, onClose } ) {
 
 	// Allow converting a single template part to standard blocks.
 	if ( blocks.length === 1 && blocks[ 0 ]?.name === 'core/template-part' ) {
-		return (
-			<ConvertToRegularBlocks
-				clientId={ clientIds[ 0 ] }
-				onClose={ onClose }
-			/>
-		);
+		return <ConvertToRegularBlocks clientId={ clientIds[ 0 ] } />;
 	}
 	return <ConvertToTemplatePart clientIds={ clientIds } blocks={ blocks } />;
 }

--- a/packages/private-apis/src/implementation.js
+++ b/packages/private-apis/src/implementation.js
@@ -22,6 +22,7 @@ const CORE_MODULES_USING_PRIVATE_APIS = [
 	'@wordpress/edit-site',
 	'@wordpress/edit-widgets',
 	'@wordpress/editor',
+	'@wordpress/reusable-blocks',
 	'@wordpress/router',
 ];
 

--- a/packages/react-native-bridge/common/gutenberg-web-single-block/editor-style-overrides.css
+++ b/packages/react-native-bridge/common/gutenberg-web-single-block/editor-style-overrides.css
@@ -45,7 +45,10 @@
 }
 
 /* Hide block actions unrelated to editing a single block */
-.block-editor-block-settings-menu {
+/* TODO: check with mobile folks if these overrides are needed */
+.block-editor-block-settings-menu__trigger,
+.block-library-navigation-leaf-more-menu__trigger,
+.edit-site-navigation-leaf-more-menu__trigger {
 	display: none;
 }
 

--- a/packages/reusable-blocks/package.json
+++ b/packages/reusable-blocks/package.json
@@ -37,6 +37,7 @@
 		"@wordpress/i18n": "file:../i18n",
 		"@wordpress/icons": "file:../icons",
 		"@wordpress/notices": "file:../notices",
+		"@wordpress/private-apis": "file:../private-apis",
 		"@wordpress/url": "file:../url"
 	},
 	"peerDependencies": {

--- a/packages/reusable-blocks/src/components/reusable-blocks-menu-items/reusable-block-convert-button.js
+++ b/packages/reusable-blocks/src/components/reusable-blocks-menu-items/reusable-block-convert-button.js
@@ -112,12 +112,14 @@ export default function ReusableBlockConvertButton( {
 	/* TODO: check if this used in other legacy dropdown menus */
 	return (
 		<BlockSettingsMenuControls>
-			{ ( { onClose } ) => (
+			{ () => (
 				<>
 					<DropdownMenuItemV2
 						prefix={ <Icon icon={ symbol } size={ 24 } /> }
-						onSelect={ () => {
+						onSelect={ ( event ) => {
 							setIsModalOpen( true );
+							// Keep the dropdown menu open
+							event.preventDefault();
 						} }
 					>
 						{ __( 'Create Reusable block' ) }
@@ -137,7 +139,12 @@ export default function ReusableBlockConvertButton( {
 									onConvert( title );
 									setIsModalOpen( false );
 									setTitle( '' );
-									onClose();
+									// TODO: the modal is expected to close the dropdown!
+									// - can we keep it open?
+									// - can we close the dropdown when the modal is opened instead?
+									// - otherwise, how do we go about it? We'd need to switch to
+									//   controlled mode at the root, and pass `onClose` around
+									// onClose();
 								} }
 							>
 								<VStack spacing="5">

--- a/packages/reusable-blocks/src/components/reusable-blocks-menu-items/reusable-block-convert-button.js
+++ b/packages/reusable-blocks/src/components/reusable-blocks-menu-items/reusable-block-convert-button.js
@@ -8,12 +8,13 @@ import {
 } from '@wordpress/block-editor';
 import { useCallback, useState } from '@wordpress/element';
 import {
-	MenuItem,
+	Icon,
 	Modal,
 	Button,
 	TextControl,
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
+	privateApis as componentsPrivateApis,
 } from '@wordpress/components';
 import { symbol } from '@wordpress/icons';
 import { useDispatch, useSelect } from '@wordpress/data';
@@ -25,6 +26,9 @@ import { store as coreStore } from '@wordpress/core-data';
  * Internal dependencies
  */
 import { store } from '../../store';
+import { unlock } from '../../lock-unlock';
+
+const { DropdownMenuItemV2 } = unlock( componentsPrivateApis );
 
 /**
  * Menu control to convert block(s) to reusable block.
@@ -105,18 +109,19 @@ export default function ReusableBlockConvertButton( {
 		return null;
 	}
 
+	/* TODO: check if this used in other legacy dropdown menus */
 	return (
 		<BlockSettingsMenuControls>
 			{ ( { onClose } ) => (
 				<>
-					<MenuItem
-						icon={ symbol }
-						onClick={ () => {
+					<DropdownMenuItemV2
+						prefix={ <Icon icon={ symbol } size={ 24 } /> }
+						onSelect={ () => {
 							setIsModalOpen( true );
 						} }
 					>
 						{ __( 'Create Reusable block' ) }
-					</MenuItem>
+					</DropdownMenuItemV2>
 					{ isModalOpen && (
 						<Modal
 							title={ __( 'Create Reusable block' ) }

--- a/packages/reusable-blocks/src/components/reusable-blocks-menu-items/reusable-block-convert-button.js
+++ b/packages/reusable-blocks/src/components/reusable-blocks-menu-items/reusable-block-convert-button.js
@@ -112,69 +112,67 @@ export default function ReusableBlockConvertButton( {
 	/* TODO: check if this used in other legacy dropdown menus */
 	return (
 		<BlockSettingsMenuControls>
-			{ () => (
-				<>
-					<DropdownMenuItemV2
-						prefix={ <Icon icon={ symbol } size={ 24 } /> }
-						onSelect={ ( event ) => {
-							setIsModalOpen( true );
-							// Keep the dropdown menu open
-							event.preventDefault();
+			<>
+				<DropdownMenuItemV2
+					prefix={ <Icon icon={ symbol } size={ 24 } /> }
+					onSelect={ ( event ) => {
+						setIsModalOpen( true );
+						// Keep the dropdown menu open
+						event.preventDefault();
+					} }
+				>
+					{ __( 'Create Reusable block' ) }
+				</DropdownMenuItemV2>
+				{ isModalOpen && (
+					<Modal
+						title={ __( 'Create Reusable block' ) }
+						onRequestClose={ () => {
+							setIsModalOpen( false );
+							setTitle( '' );
 						} }
+						overlayClassName="reusable-blocks-menu-items__convert-modal"
 					>
-						{ __( 'Create Reusable block' ) }
-					</DropdownMenuItemV2>
-					{ isModalOpen && (
-						<Modal
-							title={ __( 'Create Reusable block' ) }
-							onRequestClose={ () => {
+						<form
+							onSubmit={ ( event ) => {
+								event.preventDefault();
+								onConvert( title );
 								setIsModalOpen( false );
 								setTitle( '' );
+								// TODO: the modal is expected to close the dropdown!
+								// - can we keep it open?
+								// - can we close the dropdown when the modal is opened instead?
+								// - otherwise, how do we go about it? We'd need to switch to
+								//   controlled mode at the root, and pass `onClose` around
+								// onClose();
 							} }
-							overlayClassName="reusable-blocks-menu-items__convert-modal"
 						>
-							<form
-								onSubmit={ ( event ) => {
-									event.preventDefault();
-									onConvert( title );
-									setIsModalOpen( false );
-									setTitle( '' );
-									// TODO: the modal is expected to close the dropdown!
-									// - can we keep it open?
-									// - can we close the dropdown when the modal is opened instead?
-									// - otherwise, how do we go about it? We'd need to switch to
-									//   controlled mode at the root, and pass `onClose` around
-									// onClose();
-								} }
-							>
-								<VStack spacing="5">
-									<TextControl
-										__nextHasNoMarginBottom
-										label={ __( 'Name' ) }
-										value={ title }
-										onChange={ setTitle }
-									/>
-									<HStack justify="right">
-										<Button
-											variant="tertiary"
-											onClick={ () => {
-												setIsModalOpen( false );
-												setTitle( '' );
-											} }
-										>
-											{ __( 'Cancel' ) }
-										</Button>
+							<VStack spacing="5">
+								<TextControl
+									__nextHasNoMarginBottom
+									label={ __( 'Name' ) }
+									value={ title }
+									onChange={ setTitle }
+								/>
+								<HStack justify="right">
+									<Button
+										variant="tertiary"
+										onClick={ () => {
+											setIsModalOpen( false );
+											setTitle( '' );
+										} }
+									>
+										{ __( 'Cancel' ) }
+									</Button>
 
-										<Button variant="primary" type="submit">
-											{ __( 'Save' ) }
-										</Button>
-									</HStack>
-								</VStack>
-							</form>
-						</Modal>
-					) }
-				</>
-			) }
+									<Button variant="primary" type="submit">
+										{ __( 'Save' ) }
+									</Button>
+								</HStack>
+							</VStack>
+						</form>
+					</Modal>
+				) }
+			</>
 		</BlockSettingsMenuControls>
 	);
 }

--- a/packages/reusable-blocks/src/components/reusable-blocks-menu-items/reusable-block-convert-button.js
+++ b/packages/reusable-blocks/src/components/reusable-blocks-menu-items/reusable-block-convert-button.js
@@ -112,67 +112,67 @@ export default function ReusableBlockConvertButton( {
 	/* TODO: check if this used in other legacy dropdown menus */
 	return (
 		<BlockSettingsMenuControls>
-			<>
-				<DropdownMenuItemV2
-					prefix={ <Icon icon={ symbol } size={ 24 } /> }
-					onSelect={ ( event ) => {
-						setIsModalOpen( true );
-						// Keep the dropdown menu open
-						event.preventDefault();
-					} }
-				>
-					{ __( 'Create Reusable block' ) }
-				</DropdownMenuItemV2>
-				{ isModalOpen && (
-					<Modal
-						title={ __( 'Create Reusable block' ) }
-						onRequestClose={ () => {
-							setIsModalOpen( false );
-							setTitle( '' );
+			{ ( { onClose } ) => (
+				<>
+					<DropdownMenuItemV2
+						prefix={ <Icon icon={ symbol } size={ 24 } /> }
+						onSelect={ ( event ) => {
+							setIsModalOpen( true );
+							// Keep the dropdown menu open
+							event.preventDefault();
 						} }
-						overlayClassName="reusable-blocks-menu-items__convert-modal"
 					>
-						<form
-							onSubmit={ ( event ) => {
-								event.preventDefault();
-								onConvert( title );
+						{ __( 'Create Reusable block' ) }
+					</DropdownMenuItemV2>
+					{ isModalOpen && (
+						<Modal
+							title={ __( 'Create Reusable block' ) }
+							onRequestClose={ () => {
 								setIsModalOpen( false );
 								setTitle( '' );
-								// TODO: the modal is expected to close the dropdown!
-								// - can we keep it open?
-								// - can we close the dropdown when the modal is opened instead?
-								// - otherwise, how do we go about it? We'd need to switch to
-								//   controlled mode at the root, and pass `onClose` around
-								// onClose();
 							} }
+							overlayClassName="reusable-blocks-menu-items__convert-modal"
 						>
-							<VStack spacing="5">
-								<TextControl
-									__nextHasNoMarginBottom
-									label={ __( 'Name' ) }
-									value={ title }
-									onChange={ setTitle }
-								/>
-								<HStack justify="right">
-									<Button
-										variant="tertiary"
-										onClick={ () => {
-											setIsModalOpen( false );
-											setTitle( '' );
-										} }
-									>
-										{ __( 'Cancel' ) }
-									</Button>
+							<form
+								onSubmit={ ( event ) => {
+									event.preventDefault();
+									onConvert( title );
+									setIsModalOpen( false );
+									setTitle( '' );
+									// The dropdown seems to close automatically due to the old
+									// regular block being replaced by the new block, although
+									// I've kept this line around for now.
+									onClose();
+								} }
+							>
+								<VStack spacing="5">
+									<TextControl
+										__nextHasNoMarginBottom
+										label={ __( 'Name' ) }
+										value={ title }
+										onChange={ setTitle }
+									/>
+									<HStack justify="right">
+										<Button
+											variant="tertiary"
+											onClick={ () => {
+												setIsModalOpen( false );
+												setTitle( '' );
+											} }
+										>
+											{ __( 'Cancel' ) }
+										</Button>
 
-									<Button variant="primary" type="submit">
-										{ __( 'Save' ) }
-									</Button>
-								</HStack>
-							</VStack>
-						</form>
-					</Modal>
-				) }
-			</>
+										<Button variant="primary" type="submit">
+											{ __( 'Save' ) }
+										</Button>
+									</HStack>
+								</VStack>
+							</form>
+						</Modal>
+					) }
+				</>
+			) }
 		</BlockSettingsMenuControls>
 	);
 }

--- a/packages/reusable-blocks/src/components/reusable-blocks-menu-items/reusable-blocks-manage-button.js
+++ b/packages/reusable-blocks/src/components/reusable-blocks-menu-items/reusable-blocks-manage-button.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { MenuItem } from '@wordpress/components';
+import { privateApis as componentsPrivateApis } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { isReusableBlock } from '@wordpress/blocks';
 import { useSelect, useDispatch } from '@wordpress/data';
@@ -16,6 +16,9 @@ import { store as coreStore } from '@wordpress/core-data';
  * Internal dependencies
  */
 import { store as reusableBlocksStore } from '../../store';
+import { unlock } from '../../lock-unlock';
+
+const { DropdownMenuItemV2 } = unlock( componentsPrivateApis );
 
 function ReusableBlocksManageButton( { clientId } ) {
 	const { canRemove, isVisible, innerBlockCount } = useSelect(
@@ -50,17 +53,20 @@ function ReusableBlocksManageButton( { clientId } ) {
 
 	return (
 		<BlockSettingsMenuControls>
-			<MenuItem
+			{ /* TODO: check if this used in other legacy dropdown menus */ }
+			<DropdownMenuItemV2
 				href={ addQueryArgs( 'edit.php', { post_type: 'wp_block' } ) }
 			>
 				{ __( 'Manage Reusable blocks' ) }
-			</MenuItem>
+			</DropdownMenuItemV2>
 			{ canRemove && (
-				<MenuItem onClick={ () => convertBlockToStatic( clientId ) }>
+				<DropdownMenuItemV2
+					onSelect={ () => convertBlockToStatic( clientId ) }
+				>
 					{ innerBlockCount > 1
 						? __( 'Convert to regular blocks' )
 						: __( 'Convert to regular block' ) }
-				</MenuItem>
+				</DropdownMenuItemV2>
 			) }
 		</BlockSettingsMenuControls>
 	);

--- a/packages/reusable-blocks/src/lock-unlock.js
+++ b/packages/reusable-blocks/src/lock-unlock.js
@@ -1,0 +1,10 @@
+/**
+ * WordPress dependencies
+ */
+import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/private-apis';
+
+export const { lock, unlock } =
+	__dangerousOptInToUnstableAPIsOnlyForCoreModules(
+		'I know using unstable features means my plugin or theme will inevitably break on the next WordPress release.',
+		'@wordpress/reusable-blocks'
+	);


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

⚠️ ⚠️ ⚠️  WIP ⚠️ ⚠️ ⚠️ 

Part of #50459

## What?
<!-- In a few words, what is the PR actually doing? -->

This PR refactors the block toolbar's "settings" dropdown menu — the menu that is toggled by pressing the last button (labelled "Options" and associated to a vertical "..." icon.

The refactor involved migrating from the legacy `DropdownMenu` component to the new version (currently still experimental and only available as a locked private API of the `@wordpress/components` package).

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The main advantage of migrating to the new version of the component is the support for nested menus.

This PR also represents the first "real world" usage of the experimental component (ie. not isolated in Storybook), which will expose a number of issues related to integrating the component with the existing set of components and constraints of the block editor.

**Is this PR including breaking changes?**

No, this PR does not include breaking changes. The dropdown menu and all its items have been refactored to use the new experimental version of the `DropdownMenu` component, without otherwise changing any public-facing APIs (including the `fillProps` passed to the different slotfills).

Even if a third-party developer was to add a legacy `MenuItem` to the block settings dropdown via the `BlockSettingsMenuControls` slotfill, the `MenuItem` would continue to render without any errors, and clicking on the item would still cause the expected results. The only difference may be visual, as the new dropdownmenu components have slightly different styles and spacing.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

These are the changes being proposed in this PR. As the PR grows in scope, we may decide to split some of the proposed changes to separate, smaller PRs.

### 📝 Changes

<details>
<summary>Expand to show the detailed list of changes</summary>

**General changes:**
- Swapped legacy components (namely `DropdownMenu`, `MenuGroup`, `MenuItem`) with the new equivalent experimental components. Main differences:
  - Instead of `toggleProps` prop, the component requires a trigger to be explicitly passed via the `trigger` prop. I've therefore passed a `Button` component as the trigger and forwarded the `trigger` props to it
  - Instead of the `menuProps` prop, the component can accept certain props directly (like `onKeyDown`)
  - The component doesn't accept the `disableOpenOnArrowDown` prop. I've implemented the same functionality by controlling the `DropdownMenu` component with internal state and added a keyboard event listener on the trigger to `preventDefault` when the arrow down key is pressed.
  - The new `DropdownMenuItem` component doesn't accept a `shortcut` prop. Instead, I've created a custom `Shortcut` component and passed it via the `suffix` prop
  -  On a similar note, the new `DropdownMenuItem` component doesn't accept an `icon` prop. Instead, I've used the `prefix` prop and passed the icon via the `Icon` component
  - Renamed `onClick` props to `onSelect` for the new `DropdownMenuItem`.
  - The old `DropdownMenu` component accepted, as `children`, a render function. This function accepted an object containing the `onClose` callback, which could be used to programmatically close the dropdown menu. The new `DropdownMenu` component doesn't expose this functionality, but an equivalent callback has been created and passed to the children components for backward-compat reasons.
  - The new `DropdownMenuItem` component automatically closes the dropdown menu when clicked. This meant that a lot of the calls to the `onClose` callback have been removed, and that explicit `event.preventDefault()` calls have been added where the menu needs to stay open after clicking the menu item.
  - The new `DropdownMenuGroup` component doesn't render a line to visually demarcate the group. Instead, I used the new `DropdownMenuSeparator` component.
- Refactored the "copy" functionality away from the `useCopyToClipboard` hook, and instead implemented a custom solution using native web APIs instead (more details on this below)
- Overhauled some classnames and styles associated to the dropdown. In particular, styles the `packages/block-editor/src/components/block-settings-menu/style.scss` were deleted, since they were targeting the legacy dropdown. As a consequence, I also removed all occurrences of the `block-editor-block-settings-menu` and `block-editor-block-settings-menu__popover` classes from the repository.
  - Instead, I've added new classnames for the button trigger, which seem to be needed in order to hide the dropdown in react-native environments. While doing so, I've created three different classnames, instead of reusing the same classname across packages.
  - Another consequence of this change is that one of the puppeteer e2e test required refactoring.
- Added styles for the dropdown menu's content to allow for the menu to resize and show a scrollbar when there isn't enough space for it to display fully
- The `useCopyToClipboard` hook has been updated to support an `container` argument, useful to circumvent the focus trap added by the `DropdownMenu` component

**Changes applied to the experimental `DropdownMenu` component:**
- Added support for the `onKeyDown` prop on the root `DropdownMenu` component. This is to support the use-case of the block toolbar settings menu, which uses the prop to support keyboard shortcuts ([source](https://github.com/WordPress/gutenberg/pull/50422#discussion_r1228012486))
- Changed cursor styles to show a pointer over the menu items (apart from disabled items)
- Added the same `z-index` for content wrapper elements as the legacy `Popover` menu, to avoid stacking order bugs when other modals are opened.
- Added support for a few pointer-related callback props on `DropdownMenuItem`. This is to support the use-case of the "select parent block" menu item, which is supposed to highlight the parent block when hovering the menu item
- Added support for the `href`, `rel`, and `target` props on `DropdownMenuItem`. This is to support the use-case of the "Manage reusable blocks" menu item, which is supposed to link away from the editor. When the `href` prop is not empty, the `DropdownMenuItem` automatically renders as an `<a />` tag instead of a `<div />`. Some extra styles were also necessary to override the default Gutenberg styles associated with anchor tags.
- Allow passing a few more HTML attributes to `DropdownMenu`, like `id`, `aria-labelledby`, `className`. These attributes are often used by consumers of the component, and were necessary in ensuring that the trigger's id was passed correctly to the menu's context in this specific PR instance
- Added some additional styles to the content wrappers to make legacy `MenuItem` components look better

**Changes applied to the `Modal` component:**
- Added `pointer-events: all` to the modal wrapper. This is to override styles added by the Radix DropdownMenu, which sets `pointer-events: none` when opened in a modal way. Without the style override, the modal would not receive pointer events.
  - Note that this doesn't seem to be enough in order to make modals opened _on top_ of the `DropdownMenu` behave as expected.

</details>

### 🛑 Pending issues

<details>
<summary>The new DropdownMenu component interferes with Modal components opened on top of the dropdown</summary>

Due to how the new `DropdownMenu` component is implemented, Modals rendered on top of open dropdown menus don't react to pointer events and don't get keyboard focus.

I was able to (potentially) solve the pointer events problem (by forcing `pointer-events: all` on the modal), although that solution would require more testing to make sure it's robust (for example, what happens if a modal DropdownMenu is opened inside a modal?).

What I haven't been able to solve so far regards keyboard focus. The new `DropdownMenu` component, in fact, seems to trap keyboard focus on the dropdown. And therefore, when opening a modal on top of an opened dropdown menu, the keyboard focus stays on the dropdown menu (this can be verified because, when typing letters, the dropdown menu still highlights the matching menu item.

It looks like we'd need to use the `Dialog` component from Radix to have modals work as expected: https://codesandbox.io/s/dropdownmenu-dialog-items-forked-9sy6j8?file=/src/App.js
</details>

### 💬 Pending discussions

<details>
<summary>Where and how to implement the resize behavior when meeting the edge of the viewport</summary>

Radix's `DropdownMenu` offers this behavior by exposing the `--radix-dropdown-menu-content-available-height` CSS variable, and letting the consumer of the component actually implement the resizing behaviour. This is what I've done so far in this PR, but we should ask ourselves a few questions:

- Should we offer this same functionality directly in the `DropdownMenu` component? If so, we should think carefully about how to expose it and future-proof it against potential radix changes
- In case we keep it out of `DropdownMenu`, would it be ok that consumers of the component use a CSS variable that clearly states '"radix" ? It would be good to keep radix as an implementation detail.
</details>

<details>
<summary>Decide the best way to allow `DropdownMenuItem` to render as an anchor tag</summary>

Currently, the `DropdownMenuItem` exposes the `href` prop and internally decided to render an `<a />` or a `<div />`. This approach is simple and mimics the APIs of the legacy `MenuItem` and the `Button` component, but it lacks in scalability (what if we needed to render something else as a menu item?)

Alternative approaches:
- expose the `asChild` prop, allowing consumers of the component to pass whatever component they want
- always leave `asChild` set to `true` in the internal implementation, requiring consumers of the component to always specify a "menu item wrapper" element
</details>

<details>
<summary>Reflect on which props we should expose on `DropdownMenu` and `DropdownMenuItem`</summary>

Using the components in a real-world scenario highlighted the need for consumers of the components to pass certain HTML attributes, like `className`, `onKeyDown`, and `aria-labelledby`.

So far, our strategy on these components has been to reduce the amount of props exposed as much as possible, but I wonder if we should reconsider that and allow a wider range of props (ie. standard HTML attributes?)
</details>

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

Make sure that:

- the block toolbar settings dropdown menu opens/closes correctly
- the block toolbar settings dropdown menu positions itself correctly when meeting the edge of the viewport (including nested menus?)
- modal behavior: when the new dropdown is visible, the rest of the page is not interactive (ie. does not scroll / react to pointer events / content is not accessible)
- all menu items are shown/hidden following the correct logic
- all menu items behave as expected when clicked (both the functionality that they execute when clicked, and the fact that the dropdown menu is closed or stays open)
- make sure that all other v1 dropdown menus are still working as expected, especially the ones that share a lot of the same functionality (like the one in the list view)
- keyboard shortcuts work as expected (including [onKeyDown ev listener](https://github.com/WordPress/gutenberg/pull/50422#pullrequestreview-1476985805))
- All the menu items refactored to the new dropdownmenu component are not rendered in other legacy menus

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

| `trunk` | this PR (wip) |
|---|---|
| ![Screenshot 2023-06-12 at 12 02 40](https://github.com/WordPress/gutenberg/assets/1083581/2b823efb-da40-43b3-b918-8f693c739148) | ![Screenshot 2023-06-12 at 13 35 45](https://github.com/WordPress/gutenberg/assets/1083581/03f80f8a-1005-47e4-aed9-7276fb3f3f08) |