### PR TITLE
Change resource URL in source map for @wordpress packages.

### DIFF
--- a/tools/webpack/packages.js
+++ b/tools/webpack/packages.js
@@ -148,7 +148,7 @@ module.exports = {
 				resourcePath = `${ resourcePath.split( '@wordpress' )[ 1 ] }`;
 				return `../../packages/${ resourcePath }`;
 			}
-			return `webpack://${ info.namespace }/${ resourcePath }?${ info.loaders }`;
+			return `webpack://${ info.namespace }/${ resourcePath }`;
 		},
 	},
 	plugins: [

--- a/tools/webpack/packages.js
+++ b/tools/webpack/packages.js
@@ -143,9 +143,9 @@ module.exports = {
 		filename: './build/[name]/index.min.js',
 		path: join( __dirname, '..', '..' ),
 		devtoolModuleFilenameTemplate: ( info ) => {
-			if ( info.resourcePath.includes( '@wordpress' ) ) {
+			if ( info.resourcePath.includes( '/@wordpress/' ) ) {
 				const resourcePath =
-					info.resourcePath.split( '@wordpress' )[ 1 ];
+					info.resourcePath.split( '/@wordpress/' )[ 1 ];
 				return `../../packages/${ resourcePath }`;
 			}
 			return `webpack://${ info.namespace }/${ info.resourcePath }`;

--- a/tools/webpack/packages.js
+++ b/tools/webpack/packages.js
@@ -144,9 +144,8 @@ module.exports = {
 		path: join( __dirname, '..', '..' ),
 		devtoolModuleFilenameTemplate: ( info ) => {
 			if ( info.resourcePath.includes( '@wordpress' ) ) {
-				const resourcePath = `${
-					info.resourcePath.split( '@wordpress' )[ 1 ]
-				}`;
+				const resourcePath =
+					info.resourcePath.split( '@wordpress' )[ 1 ];
 				return `../../packages/${ resourcePath }`;
 			}
 			return `webpack://${ info.namespace }/${ info.resourcePath }`;

--- a/tools/webpack/packages.js
+++ b/tools/webpack/packages.js
@@ -142,6 +142,14 @@ module.exports = {
 		devtoolNamespace: 'wp',
 		filename: './build/[name]/index.min.js',
 		path: join( __dirname, '..', '..' ),
+		devtoolModuleFilenameTemplate: ( info ) => {
+			let resourcePath = info.resourcePath;
+			if ( info.resourcePath.includes( '@wordpress' ) ) {
+				resourcePath = `${ resourcePath.split( '@wordpress' )[ 1 ] }`;
+				return `../../packages/${ resourcePath }`;
+			}
+			return `webpack://${ info.namespace }/${ resourcePath }?${ info.loaders }`;
+		},
 	},
 	plugins: [
 		...plugins,

--- a/tools/webpack/packages.js
+++ b/tools/webpack/packages.js
@@ -143,12 +143,13 @@ module.exports = {
 		filename: './build/[name]/index.min.js',
 		path: join( __dirname, '..', '..' ),
 		devtoolModuleFilenameTemplate: ( info ) => {
-			let resourcePath = info.resourcePath;
 			if ( info.resourcePath.includes( '@wordpress' ) ) {
-				resourcePath = `${ resourcePath.split( '@wordpress' )[ 1 ] }`;
+				const resourcePath = `${
+					info.resourcePath.split( '@wordpress' )[ 1 ]
+				}`;
 				return `../../packages/${ resourcePath }`;
 			}
-			return `webpack://${ info.namespace }/${ resourcePath }`;
+			return `webpack://${ info.namespace }/${ info.resourcePath }`;
 		},
 	},
 	plugins: [


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Change the URL of `@wordpress` packages referenced in the source map. Specifically, the following will be used.

before: `webpack://wp/packages/a11y/build-module/@wordpress/a11y/src/index.js`
after: `../../packages/a11y/src/index.js`

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
When VS Code and a browser are linked, the actual file can be referenced from the debug console. Also, operations such as breakpoints can be performed from VS Code.

The lanch.json configuration is as follows

```
{
	"version": "0.2.0",
	"configurations": [
		{
			"name": "Launch localhost",
			"type": "chrome",
			"request": "launch",
			"url": "http://localhost:8888/",
			"sourceMaps":true, 
			"trace": true
		},
	]
}
```


## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Set [`devtoolModuleFilenameTemplate`](https://webpack.js.org/configuration/output/#outputdevtoolmodulefilenametemplate) 

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/1908815/e050a1e2-b836-4c33-a582-7d368c785b30

