### PR TITLE
Post editor: Make the Post Content block available as a child of the Query block

### DIFF
--- a/packages/edit-post/src/index.js
+++ b/packages/edit-post/src/index.js
@@ -79,7 +79,7 @@ export function initializeEditor(
 	}
 
 	/*
-	 * Prevent adding template part and post content block in the post editor.
+	 * Prevent adding template part in the post editor.
 	 * Only add the filter when the post editor is initialized, not imported.
 	 * Also only add the filter(s) after registerCoreBlocks()
 	 * so that common filters in the block library are not overwritten.
@@ -90,12 +90,32 @@ export function initializeEditor(
 		( canInsert, blockType ) => {
 			if (
 				! select( editPostStore ).isEditingTemplate() &&
-				( blockType.name === 'core/template-part' ||
-					blockType.name === 'core/post-content' )
+				blockType.name === 'core/template-part'
 			) {
 				return false;
 			}
 			return canInsert;
+		}
+	);
+	/*
+	 * Prevent adding post content block in the post editor unless in a query block.
+	 * Only add the filter when the post editor is initialized, not imported.
+	 * Also only add the filter(s) after registerCoreBlocks()
+	 * so that common filters in the block library are not overwritten.
+	 */
+	addFilter(
+		'blockEditor.__unstableCanInsertBlockType',
+		'removePostConentFromInserter',
+		( canInsert, blockType, rootClientId, { getBlock } ) => {
+			if ( blockType.name !== 'core/post-content' ) {
+				return canInsert;
+			}
+			const parentBlock = getBlock( rootClientId );
+
+			if ( parentBlock?.name === 'core/query' ) {
+				return canInsert;
+			}
+			return false;
 		}
 	);
 

--- a/packages/edit-post/src/index.js
+++ b/packages/edit-post/src/index.js
@@ -79,44 +79,33 @@ export function initializeEditor(
 	}
 
 	/*
-	 * Prevent adding template part in the post editor.
+	 * Prevent adding template part and post content (except in query block) in the post editor.
 	 * Only add the filter when the post editor is initialized, not imported.
 	 * Also only add the filter(s) after registerCoreBlocks()
 	 * so that common filters in the block library are not overwritten.
 	 */
 	addFilter(
 		'blockEditor.__unstableCanInsertBlockType',
-		'removeTemplatePartsFromInserter',
-		( canInsert, blockType ) => {
-			if (
-				! select( editPostStore ).isEditingTemplate() &&
-				blockType.name === 'core/template-part'
-			) {
-				return false;
-			}
-			return canInsert;
-		}
-	);
-	/*
-	 * Prevent adding post content block in the post editor unless in a query block.
-	 * Only add the filter when the post editor is initialized, not imported.
-	 * Also only add the filter(s) after registerCoreBlocks()
-	 * so that common filters in the block library are not overwritten.
-	 */
-	addFilter(
-		'blockEditor.__unstableCanInsertBlockType',
-		'removePostContentFromInserter',
+		'removeTemplatePartsAndPostContentFromInserter',
 		(
 			canInsert,
 			blockType,
 			rootClientId,
 			{ getBlockParentsByBlockName }
 		) => {
-			if ( blockType.name !== 'core/post-content' ) {
+			if ( select( editPostStore ).isEditingTemplate() ) {
 				return canInsert;
 			}
-			return getBlockParentsByBlockName( rootClientId, 'core/query' )
-				.length;
+			if ( blockType.name === 'core/template-part' ) {
+				return false;
+			}
+			if ( blockType.name === 'core/post-content' ) {
+				return (
+					getBlockParentsByBlockName( rootClientId, 'core/query' )
+						.length > 0
+				);
+			}
+			return canInsert;
 		}
 	);
 

--- a/packages/edit-post/src/index.js
+++ b/packages/edit-post/src/index.js
@@ -79,7 +79,7 @@ export function initializeEditor(
 	}
 
 	/*
-	 * Prevent adding template part and post content block in the post editor.
+	 * Prevent adding template part in the post editor.
 	 * Only add the filter when the post editor is initialized, not imported.
 	 * Also only add the filter(s) after registerCoreBlocks()
 	 * so that common filters in the block library are not overwritten.
@@ -99,7 +99,7 @@ export function initializeEditor(
 	);
 
 	/*
-	 * Prevent adding post content (except in query block) in the post editor.
+	 * Prevent adding post content block (except in query block) in the post editor.
 	 * Only add the filter when the post editor is initialized, not imported.
 	 * Also only add the filter(s) after registerCoreBlocks()
 	 * so that common filters in the block library are not overwritten.

--- a/packages/edit-post/src/index.js
+++ b/packages/edit-post/src/index.js
@@ -79,27 +79,44 @@ export function initializeEditor(
 	}
 
 	/*
-	 * Prevent adding template part and post content (except in query block) in the post editor.
+	 * Prevent adding template part and post content block in the post editor.
 	 * Only add the filter when the post editor is initialized, not imported.
 	 * Also only add the filter(s) after registerCoreBlocks()
 	 * so that common filters in the block library are not overwritten.
 	 */
 	addFilter(
 		'blockEditor.__unstableCanInsertBlockType',
-		'removeTemplatePartsAndPostContentFromInserter',
+		'removeTemplatePartsFromInserter',
+		( canInsert, blockType ) => {
+			if (
+				! select( editPostStore ).isEditingTemplate() &&
+				blockType.name === 'core/template-part'
+			) {
+				return false;
+			}
+			return canInsert;
+		}
+	);
+
+	/*
+	 * Prevent adding post content (except in query block) in the post editor.
+	 * Only add the filter when the post editor is initialized, not imported.
+	 * Also only add the filter(s) after registerCoreBlocks()
+	 * so that common filters in the block library are not overwritten.
+	 */
+	addFilter(
+		'blockEditor.__unstableCanInsertBlockType',
+		'removePostContentFromInserter',
 		(
 			canInsert,
 			blockType,
 			rootClientId,
 			{ getBlockParentsByBlockName }
 		) => {
-			if ( select( editPostStore ).isEditingTemplate() ) {
-				return canInsert;
-			}
-			if ( blockType.name === 'core/template-part' ) {
-				return false;
-			}
-			if ( blockType.name === 'core/post-content' ) {
+			if (
+				! select( editPostStore ).isEditingTemplate() &&
+				blockType.name === 'core/post-content'
+			) {
 				return (
 					getBlockParentsByBlockName( rootClientId, 'core/query' )
 						.length > 0

--- a/packages/edit-post/src/index.js
+++ b/packages/edit-post/src/index.js
@@ -105,17 +105,18 @@ export function initializeEditor(
 	 */
 	addFilter(
 		'blockEditor.__unstableCanInsertBlockType',
-		'removePostConentFromInserter',
-		( canInsert, blockType, rootClientId, { getBlock } ) => {
+		'removePostContentFromInserter',
+		(
+			canInsert,
+			blockType,
+			rootClientId,
+			{ getBlockParentsByBlockName }
+		) => {
 			if ( blockType.name !== 'core/post-content' ) {
 				return canInsert;
 			}
-			const parentBlock = getBlock( rootClientId );
-
-			if ( parentBlock?.name === 'core/query' ) {
-				return canInsert;
-			}
-			return false;
+			return getBlockParentsByBlockName( rootClientId, 'core/query' )
+				.length;
 		}
 	);
 


### PR DESCRIPTION
## What?
Only removes the Post Content block from the post editor if the parent block is not the Query block.

## Why?
Possible fix for [issue noted here](https://github.com/WordPress/gutenberg/pull/50620#issuecomment-1586157695). 

## How?
Before setting the `canInsert` flag check the root block of the currently selected block.

## Testing Instructions

- In the post editor check that the Post Content block is not available
- Add a Query block and when the Query block is the parent check that the Post Content block is available

## Screenshots or screencast <!-- if applicable -->

Before:
<img width="877" alt="Screenshot 2023-06-12 at 1 30 24 PM" src="https://github.com/WordPress/gutenberg/assets/3629020/fc5384d8-0a61-49a6-a3f7-3be9ed6889f7">

After:
<img width="874" alt="Screenshot 2023-06-12 at 1 29 05 PM" src="https://github.com/WordPress/gutenberg/assets/3629020/8dd606c5-b2c7-45f0-a437-44c04d1dff05">
