### PR TITLE
Add tests for WP_Classic_To_Block_Menu_Converter class

### DIFF
--- a/lib/experimental/class-wp-classic-to-block-menu-converter.php
+++ b/lib/experimental/class-wp-classic-to-block-menu-converter.php
@@ -20,6 +20,14 @@ class WP_Classic_To_Block_Menu_Converter {
 	 * @return string the serialized and normalized parsed blocks.
 	 */
 	public static function convert( $menu ) {
+
+		if ( ! is_nav_menu( $menu ) ) {
+			return new WP_Error(
+				'invalid_menu',
+				__( 'The menu provided is not a valid menu.', 'gutenberg' )
+			);
+		}
+
 		$menu_items = wp_get_nav_menu_items( $menu->term_id, array( 'update_post_term_cache' => false ) );
 
 		// Set up the $menu_item variables.

--- a/lib/experimental/class-wp-classic-to-block-menu-converter.php
+++ b/lib/experimental/class-wp-classic-to-block-menu-converter.php
@@ -30,6 +30,10 @@ class WP_Classic_To_Block_Menu_Converter {
 
 		$menu_items = wp_get_nav_menu_items( $menu->term_id, array( 'update_post_term_cache' => false ) );
 
+		if ( empty( $menu_items ) ) {
+			return array();
+		}
+
 		// Set up the $menu_item variables.
 		// Adds the class property classes for the current context, if applicable.
 		_wp_menu_item_classes_by_context( $menu_items );

--- a/phpunit/class-wp-classic-to-block-menu-converter-test.php
+++ b/phpunit/class-wp-classic-to-block-menu-converter-test.php
@@ -206,9 +206,9 @@ class WP_Classic_To_Block_Menu_Converter_Test extends WP_UnitTestCase {
 
 		$blocks = WP_Classic_To_Block_Menu_Converter::convert( $classic_nav_menu );
 
-		$this->assertEmpty( $blocks );
+		$this->assertEmpty( $blocks, 'Result should be empty.' );
 
-		$this->assertIsArray( $blocks );
+		$this->assertIsArray( $blocks, 'Result should be empty array.' );
 
 		wp_delete_nav_menu( $menu_id );
 	}

--- a/phpunit/class-wp-classic-to-block-menu-converter-test.php
+++ b/phpunit/class-wp-classic-to-block-menu-converter-test.php
@@ -5,7 +5,7 @@
  * @package WordPress
  */
 
- /**
+/**
  * Tests for the WP_Classic_To_Block_Menu_Converter_Test class.
  */
 class WP_Classic_To_Block_Menu_Converter_Test extends WP_UnitTestCase {
@@ -55,7 +55,7 @@ class WP_Classic_To_Block_Menu_Converter_Test extends WP_UnitTestCase {
 
 		$menu_id = wp_create_nav_menu( 'Classic Menu' );
 
-		$first_menu_item_id = wp_update_nav_menu_item(
+		wp_update_nav_menu_item(
 			$menu_id,
 			0,
 			array(
@@ -127,7 +127,7 @@ class WP_Classic_To_Block_Menu_Converter_Test extends WP_UnitTestCase {
 
 			$menu_id = wp_create_nav_menu( 'Classic Menu' );
 
-			$first_menu_item_id = wp_update_nav_menu_item(
+			wp_update_nav_menu_item(
 				$menu_id,
 				0,
 				array(

--- a/phpunit/class-wp-classic-to-block-menu-converter-test.php
+++ b/phpunit/class-wp-classic-to-block-menu-converter-test.php
@@ -12,7 +12,35 @@ class WP_Classic_To_Block_Menu_Converter_Test extends WP_UnitTestCase {
 		$this->assertTrue( class_exists( 'WP_Classic_To_Block_Menu_Converter' ) );
 	}
 
-	// test can convert classic menu to blocks using the converter
+	/**
+	 * @dataProvider provider_test_passing_non_menu_object_to_converter_returns_wp_error
+	 *
+	 * @return void
+	 */
+	public function test_passing_non_menu_object_to_converter_returns_wp_error( $data ) {
+
+		$result = WP_Classic_To_Block_Menu_Converter::convert( $data );
+
+		$this->assertTrue( is_wp_error( $result ), 'Should be a WP_Error instance' );
+
+		$this->assertEquals( 'invalid_menu', $result->get_error_code(), 'Error code should indicate invalidity of menu argument.' );
+
+		$this->assertEquals( 'The menu provided is not a valid menu.', $result->get_error_message(), 'Error message should communicate invalidity of menu argument.' );
+	}
+
+	public function provider_test_passing_non_menu_object_to_converter_returns_wp_error() {
+		return array(
+			array( 1 ),
+			array( -1 ),
+			array( '1' ),
+			array( 'not a menu object' ),
+			array( true ),
+			array( false ),
+			array( array() ),
+			array( new stdClass() ),
+		);
+	}
+
 	public function test_can_convert_classic_menu_to_blocks() {
 
 		$menu_id = wp_create_nav_menu( 'Classic Menu' );
@@ -45,17 +73,6 @@ class WP_Classic_To_Block_Menu_Converter_Test extends WP_UnitTestCase {
 				'menu-item-url'       => '/nested-menu-item-1',
 				'menu-item-status'    => 'publish',
 				'menu-item-parent-id' => $second_menu_item_id,
-			)
-		);
-
-		// create a menu item with a status of `draft`
-		wp_update_nav_menu_item(
-			$menu_id,
-			0,
-			array(
-				'menu-item-title'  => 'Draft Menu Item',
-				'menu-item-url'    => '/draft-menu-item',
-				'menu-item-status' => 'draft',
 			)
 		);
 
@@ -94,38 +111,93 @@ class WP_Classic_To_Block_Menu_Converter_Test extends WP_UnitTestCase {
 
 		$this->assertEquals( '/nested-menu-item-1', $nested_block['attrs']['url'], 'Nested block URL should match.' );
 
-		$this->assertArrayNotHasKey( 2, $parsed_blocks, 'Draft menu item should not be included in blocks.' );
-
+		wp_delete_nav_menu( $menu_id );
 	}
 
-	/**
-	 * @dataProvider provider_test_passing_non_menu_object_to_converter_returns_wp_error
-	 *
-	 * @return void
-	 */
-	public function test_passing_non_menu_object_to_converter_returns_wp_error( $data ) {
+	public function test_does_not_convert_menu_items_with_non_publish_status() {
 
-		$result = WP_Classic_To_Block_Menu_Converter::convert( $data );
+			$menu_id = wp_create_nav_menu( 'Classic Menu' );
 
-		$this->assertTrue( is_wp_error( $result ), 'Should be a WP_Error instance' );
+			$first_menu_item_id = wp_update_nav_menu_item(
+				$menu_id,
+				0,
+				array(
+					'menu-item-title'  => 'Classic Menu Item 1',
+					'menu-item-url'    => '/classic-menu-item-1',
+					'menu-item-status' => 'publish',
+				)
+			);
 
-		$this->assertEquals( 'invalid_menu', $result->get_error_code(), 'Error code should indicate invalidity of menu argument.' );
+			wp_update_nav_menu_item(
+				$menu_id,
+				0,
+				array(
+					'menu-item-status' => 'draft',
+					'menu-item-title'  => 'Draft Menu Item',
+					'menu-item-url'    => '/draft-menu-item',
+				)
+			);
 
-		$this->assertEquals( 'The menu provided is not a valid menu.', $result->get_error_message(), 'Error message should communicate invalidity of menu argument.' );
+			wp_update_nav_menu_item(
+				$menu_id,
+				0,
+				array(
+					'menu-item-status' => 'private',
+					'menu-item-title'  => 'Private Item',
+					'menu-item-url'    => '/private-menu-item',
+				)
+			);
+
+			wp_update_nav_menu_item(
+				$menu_id,
+				0,
+				array(
+					'menu-item-status' => 'pending',
+					'menu-item-title'  => 'Pending Menu Item',
+					'menu-item-url'    => '/pending-menu-item',
+				)
+			);
+
+			wp_update_nav_menu_item(
+				$menu_id,
+				0,
+				array(
+					'menu-item-status' => 'future',
+					'menu-item-title'  => 'Future Menu Item',
+					'menu-item-url'    => '/future-menu-item',
+				)
+			);
+
+			$classic_nav_menu = wp_get_nav_menu_object( $menu_id );
+
+			$blocks = WP_Classic_To_Block_Menu_Converter::convert( $classic_nav_menu );
+
+			$this->assertNotEmpty( $blocks );
+
+			$parsed_blocks = parse_blocks( $blocks );
+
+			$this->assertCount( 1, $parsed_blocks, 'Should only be one block in the array.' );
+
+			$this->assertEquals( 'core/navigation-link', $parsed_blocks[0]['blockName'], 'First block name should be "core/navigation-link"' );
+
+			$this->assertEquals( 'Classic Menu Item 1', $parsed_blocks[0]['attrs']['label'], 'First block label should match.' );
+
+			$this->assertEquals( '/classic-menu-item-1', $parsed_blocks[0]['attrs']['url'], 'First block URL should match.' );
+
+			wp_delete_nav_menu( $menu_id );
 	}
 
-	public function provider_test_passing_non_menu_object_to_converter_returns_wp_error() {
-        return array(
-            array( 1 ),
-            array( -1 ),
-            array( '1' ),
-            array( 'not a menu object' ),
-            array( true ),
-            array( false ),
-            array( array() ),
-            array( new stdClass() ),
-        );
+	public function test_returns_empty_array_for_menus_with_no_items() {
+		$menu_id = wp_create_nav_menu( 'Empty Menu' );
+
+		$classic_nav_menu = wp_get_nav_menu_object( $menu_id );
+
+		$blocks = WP_Classic_To_Block_Menu_Converter::convert( $classic_nav_menu );
+
+		$this->assertEmpty( $blocks );
+
+		$this->assertIsArray( $blocks );
+
+		wp_delete_nav_menu( $menu_id );
 	}
-
-
 }

--- a/phpunit/class-wp-classic-to-block-menu-converter-test.php
+++ b/phpunit/class-wp-classic-to-block-menu-converter-test.php
@@ -97,4 +97,35 @@ class WP_Classic_To_Block_Menu_Converter_Test extends WP_UnitTestCase {
 		$this->assertArrayNotHasKey( 2, $parsed_blocks, 'Draft menu item should not be included in blocks.' );
 
 	}
+
+	/**
+	 * @dataProvider provider_test_passing_non_menu_object_to_converter_returns_wp_error
+	 *
+	 * @return void
+	 */
+	public function test_passing_non_menu_object_to_converter_returns_wp_error( $data ) {
+
+		$result = WP_Classic_To_Block_Menu_Converter::convert( $data );
+
+		$this->assertTrue( is_wp_error( $result ), 'Should be a WP_Error instance' );
+
+		$this->assertEquals( 'invalid_menu', $result->get_error_code(), 'Error code should indicate invalidity of menu argument.' );
+
+		$this->assertEquals( 'The menu provided is not a valid menu.', $result->get_error_message(), 'Error message should communicate invalidity of menu argument.' );
+	}
+
+	public function provider_test_passing_non_menu_object_to_converter_returns_wp_error() {
+        return array(
+            array( 1 ),
+            array( -1 ),
+            array( '1' ),
+            array( 'not a menu object' ),
+            array( true ),
+            array( false ),
+            array( array() ),
+            array( new stdClass() ),
+        );
+	}
+
+
 }

--- a/phpunit/class-wp-classic-to-block-menu-converter-test.php
+++ b/phpunit/class-wp-classic-to-block-menu-converter-test.php
@@ -1,21 +1,25 @@
 <?php
-
 /**
+ * Tests WP_Classic_To_Block_Menu_Converter_Test
  *
- *
- * @package Gutenberg
+ * @package WordPress
  */
 
+ /**
+ * Tests for the WP_Classic_To_Block_Menu_Converter_Test class.
+ */
 class WP_Classic_To_Block_Menu_Converter_Test extends WP_UnitTestCase {
 
+	/**
+	 * @covers WP_Classic_To_Block_Menu_Converter::get_fallback
+	 */
 	public function test_class_exists() {
 		$this->assertTrue( class_exists( 'WP_Classic_To_Block_Menu_Converter' ) );
 	}
 
 	/**
+	 * @covers WP_Classic_To_Block_Menu_Converter::convert
 	 * @dataProvider provider_test_passing_non_menu_object_to_converter_returns_wp_error
-	 *
-	 * @return void
 	 */
 	public function test_passing_non_menu_object_to_converter_returns_wp_error( $data ) {
 
@@ -28,6 +32,9 @@ class WP_Classic_To_Block_Menu_Converter_Test extends WP_UnitTestCase {
 		$this->assertEquals( 'The menu provided is not a valid menu.', $result->get_error_message(), 'Error message should communicate invalidity of menu argument.' );
 	}
 
+	/**
+	 * @covers WP_Classic_To_Block_Menu_Converter::convert
+	 */
 	public function provider_test_passing_non_menu_object_to_converter_returns_wp_error() {
 		return array(
 			array( 1 ),
@@ -41,6 +48,9 @@ class WP_Classic_To_Block_Menu_Converter_Test extends WP_UnitTestCase {
 		);
 	}
 
+	/**
+	 * @covers WP_Classic_To_Block_Menu_Converter::convert
+	 */
 	public function test_can_convert_classic_menu_to_blocks() {
 
 		$menu_id = wp_create_nav_menu( 'Classic Menu' );
@@ -94,10 +104,6 @@ class WP_Classic_To_Block_Menu_Converter_Test extends WP_UnitTestCase {
 
 		$this->assertEquals( '/classic-menu-item-1', $first_block['attrs']['url'], 'First block URL should match.' );
 
-		// echo "<pre>";
-		// var_dump($parsed_blocks);
-		// echo "</pre>";
-
 		// Assert parent of nested menu item is a submenu block.
 		$this->assertEquals( 'core/navigation-submenu', $second_block['blockName'], 'Second block name should be "core/navigation-submenu"' );
 
@@ -114,6 +120,9 @@ class WP_Classic_To_Block_Menu_Converter_Test extends WP_UnitTestCase {
 		wp_delete_nav_menu( $menu_id );
 	}
 
+	/**
+	 * @covers WP_Classic_To_Block_Menu_Converter::convert
+	 */
 	public function test_does_not_convert_menu_items_with_non_publish_status() {
 
 			$menu_id = wp_create_nav_menu( 'Classic Menu' );
@@ -187,6 +196,9 @@ class WP_Classic_To_Block_Menu_Converter_Test extends WP_UnitTestCase {
 			wp_delete_nav_menu( $menu_id );
 	}
 
+	/**
+	 * @covers WP_Classic_To_Block_Menu_Converter::convert
+	 */
 	public function test_returns_empty_array_for_menus_with_no_items() {
 		$menu_id = wp_create_nav_menu( 'Empty Menu' );
 

--- a/phpunit/class-wp-classic-to-block-menu-converter-test.php
+++ b/phpunit/class-wp-classic-to-block-menu-converter-test.php
@@ -1,0 +1,100 @@
+<?php
+
+/**
+ *
+ *
+ * @package Gutenberg
+ */
+
+class WP_Classic_To_Block_Menu_Converter_Test extends WP_UnitTestCase {
+
+	public function test_class_exists() {
+		$this->assertTrue( class_exists( 'WP_Classic_To_Block_Menu_Converter' ) );
+	}
+
+	// test can convert classic menu to blocks using the converter
+	public function test_can_convert_classic_menu_to_blocks() {
+
+		$menu_id = wp_create_nav_menu( 'Classic Menu' );
+
+		$first_menu_item_id = wp_update_nav_menu_item(
+			$menu_id,
+			0,
+			array(
+				'menu-item-title'  => 'Classic Menu Item 1',
+				'menu-item-url'    => '/classic-menu-item-1',
+				'menu-item-status' => 'publish',
+			)
+		);
+
+		$second_menu_item_id = wp_update_nav_menu_item(
+			$menu_id,
+			0,
+			array(
+				'menu-item-title'  => 'Classic Menu Item 2',
+				'menu-item-url'    => '/classic-menu-item-2',
+				'menu-item-status' => 'publish',
+			)
+		);
+
+		wp_update_nav_menu_item(
+			$menu_id,
+			0,
+			array(
+				'menu-item-title'     => 'Nested Menu Item 1',
+				'menu-item-url'       => '/nested-menu-item-1',
+				'menu-item-status'    => 'publish',
+				'menu-item-parent-id' => $second_menu_item_id,
+			)
+		);
+
+		// create a menu item with a status of `draft`
+		wp_update_nav_menu_item(
+			$menu_id,
+			0,
+			array(
+				'menu-item-title'  => 'Draft Menu Item',
+				'menu-item-url'    => '/draft-menu-item',
+				'menu-item-status' => 'draft',
+			)
+		);
+
+		$classic_nav_menu = wp_get_nav_menu_object( $menu_id );
+
+		$blocks = WP_Classic_To_Block_Menu_Converter::convert( $classic_nav_menu );
+
+		$this->assertNotEmpty( $blocks );
+
+		$parsed_blocks = parse_blocks( $blocks );
+
+		$first_block  = $parsed_blocks[0];
+		$second_block = $parsed_blocks[1];
+		$nested_block = $parsed_blocks[1]['innerBlocks'][0];
+
+		$this->assertEquals( 'core/navigation-link', $first_block['blockName'], 'First block name should be "core/navigation-link"' );
+
+		$this->assertEquals( 'Classic Menu Item 1', $first_block['attrs']['label'], 'First block label should match.' );
+
+		$this->assertEquals( '/classic-menu-item-1', $first_block['attrs']['url'], 'First block URL should match.' );
+
+		// echo "<pre>";
+		// var_dump($parsed_blocks);
+		// echo "</pre>";
+
+		// Assert parent of nested menu item is a submenu block.
+		$this->assertEquals( 'core/navigation-submenu', $second_block['blockName'], 'Second block name should be "core/navigation-submenu"' );
+
+		$this->assertEquals( 'Classic Menu Item 2', $second_block['attrs']['label'], 'Second block label should match.' );
+
+		$this->assertEquals( '/classic-menu-item-2', $second_block['attrs']['url'], 'Second block URL should match.' );
+
+		$this->assertEquals( 'core/navigation-link', $nested_block['blockName'], 'Nested block name should be "core/navigation-link"' );
+
+		$this->assertEquals( 'Nested Menu Item 1', $nested_block['attrs']['label'], 'Nested block label should match.' );
+
+		$this->assertEquals( '/nested-menu-item-1', $nested_block['attrs']['url'], 'Nested block URL should match.' );
+
+		$this->assertArrayNotHasKey( 2, $parsed_blocks, 'Draft menu item should not be included in blocks.' );
+
+	}
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Adds direct test coverage for `WP_Classic_To_Block_Menu_Converter`.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Tests provider confidence. We also need these in order to ease the merge into Core.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

- Write PHP Unit tests
- Improve code against tests.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

Run 

```
npm run test:unit:php -- --filter WP_Classic_To_Block_Menu_Converter_Test --order-by=random
```

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
