### PR TITLE
Block Theme Previews: Add query param

### DIFF
--- a/lib/compat/wordpress-6.3/theme-previews.php
+++ b/lib/compat/wordpress-6.3/theme-previews.php
@@ -112,6 +112,19 @@ function block_theme_activate_nonce() {
 	<?php
 }
 
+function gutenberg_render_block_block_theme_previews( $block_content, $parsed_block, $block_class ) {
+	$tags = new WP_HTML_Tag_Processor( $block_content );
+	$tags->next_tag( 'a' );
+	$href = $tags->get_attribute( 'href' );
+
+	if ( ! empty( $href ) ) {
+		$href = add_query_arg( 'gutenberg_theme_preview', $_GET['gutenberg_theme_preview'], $href ); // TODO - escape
+		$tags->set_attribute( 'href', $href );
+		$block_content = $tags->get_updated_html( $tags );
+	}
+	return $block_content;
+}
+
 /**
  * Attaches filters to enable theme previews in the Site Editor.
  */
@@ -119,6 +132,7 @@ if ( ! empty( $_GET['gutenberg_theme_preview'] ) ) {
 	add_filter( 'stylesheet', 'gutenberg_get_theme_preview_path' );
 	add_filter( 'template', 'gutenberg_get_theme_preview_path' );
 	add_filter( 'init', 'gutenberg_attach_theme_preview_middleware' );
+	add_filter( 'render_block', 'gutenberg_render_block_block_theme_previews', 10, 3 );
 }
 
 add_action( 'admin_head', 'block_theme_activate_nonce' );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Persists the block theme preview query parameter on every link.

Related: https://github.com/WordPress/gutenberg/issues/50919

## Why?
So that users can browse their site when previewing a block theme.

## How?
Using the tag processor to update every link on the page.

## Testing Instructions
TBD

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
