### PR TITLE
Show actions for empty menus in Navigation on Browse mode

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/index.js
@@ -211,6 +211,14 @@ export default function SidebarNavigationScreenNavigationMenu() {
 	if ( ! navigationMenu?.content?.raw ) {
 		return (
 			<SidebarNavigationScreenWrapper
+				actions={
+					<ScreenNavigationMoreMenu
+						menuTitle={ decodeEntities( menuTitle ) }
+						onDelete={ handleDelete }
+						onSave={ handleSave }
+						onDuplicate={ handleDuplicate }
+					/>
+				}
 				title={ decodeEntities( menuTitle ) }
 				description={ __( 'This Navigation Menu is empty.' ) }
 			/>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Follow up to https://github.com/WordPress/gutenberg/pull/50880 to allow taking rename, delete and duplicate actions on empty menus.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Because otherwise you can't delete empty menus!

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Provide the actions component for empty menus state.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

- Create an empty menu (no menu items) using the Nav block.
- Open Browse Mode -> Navigation
- Select your empty menu.
- See ellipsis menu next to title
- Make sure you can delete, duplicate and rename.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
<img width="711" alt="Screen Shot 2023-06-12 at 14 40 17" src="https://github.com/WordPress/gutenberg/assets/444434/f73c30b8-30b9-43ae-9951-4b6cde46d614">
