### PR TITLE
List draft navigations in Browse mode Navigation section

### DIFF
--- a/lib/compat/wordpress-6.3/navigation-block-preloading.php
+++ b/lib/compat/wordpress-6.3/navigation-block-preloading.php
@@ -33,6 +33,8 @@ function gutenberg_preload_navigation_posts( $preload_paths, $context ) {
 			array(
 				'context'   => 'edit',
 				'per_page'  => 100,
+				'order'    => 'desc',
+				'orderby'  => 'date',
 				'_locale'   => 'user',
 				// array indices are required to avoid query being encoded and not matching in cache.
 				'status[0]' => 'publish',
@@ -51,7 +53,8 @@ function gutenberg_preload_navigation_posts( $preload_paths, $context ) {
 				'per_page' => 100,
 				'order'    => 'desc',
 				'orderby'  => 'date',
-				'status'   => 'publish',
+				'status[0]' => 'publish',
+				'status[1]' => 'draft',
 			),
 			$navigation_rest_route
 		),

--- a/lib/compat/wordpress-6.3/navigation-block-preloading.php
+++ b/lib/compat/wordpress-6.3/navigation-block-preloading.php
@@ -33,8 +33,8 @@ function gutenberg_preload_navigation_posts( $preload_paths, $context ) {
 			array(
 				'context'   => 'edit',
 				'per_page'  => 100,
-				'order'    => 'desc',
-				'orderby'  => 'date',
+				'order'     => 'desc',
+				'orderby'   => 'date',
 				'_locale'   => 'user',
 				// array indices are required to avoid query being encoded and not matching in cache.
 				'status[0]' => 'publish',
@@ -49,10 +49,10 @@ function gutenberg_preload_navigation_posts( $preload_paths, $context ) {
 	$preload_paths[] = array(
 		add_query_arg(
 			array(
-				'context'  => 'edit',
-				'per_page' => 100,
-				'order'    => 'desc',
-				'orderby'  => 'date',
+				'context'   => 'edit',
+				'per_page'  => 100,
+				'order'     => 'desc',
+				'orderby'   => 'date',
 				'status[0]' => 'publish',
 				'status[1]' => 'draft',
 			),

--- a/packages/block-library/src/navigation/constants.js
+++ b/packages/block-library/src/navigation/constants.js
@@ -24,7 +24,7 @@ export const SELECT_NAVIGATION_MENUS_ARGS = [
 	'postType',
 	'wp_navigation',
 	{
-		per_page: -1,
+		per_page: 100,
 		status: [ 'publish', 'draft' ],
 		order: 'desc',
 		orderby: 'date',

--- a/packages/block-library/src/navigation/constants.js
+++ b/packages/block-library/src/navigation/constants.js
@@ -19,3 +19,14 @@ export const PRIORITIZED_INSERTER_BLOCKS = [
 	'core/navigation-link/page',
 	'core/navigation-link',
 ];
+
+export const SELECT_NAVIGATION_MENUS_ARGS = [
+	'postType',
+	'wp_navigation',
+	{
+		per_page: -1,
+		status: [ 'publish', 'draft' ],
+		order: 'desc',
+		orderby: 'date',
+	},
+];

--- a/packages/block-library/src/navigation/edit/unsaved-inner-blocks.js
+++ b/packages/block-library/src/navigation/edit/unsaved-inner-blocks.js
@@ -11,7 +11,11 @@ import { useContext, useEffect, useRef, useMemo } from '@wordpress/element';
  * Internal dependencies
  */
 import { areBlocksDirty } from './are-blocks-dirty';
-import { DEFAULT_BLOCK, ALLOWED_BLOCKS } from '../constants';
+import {
+	DEFAULT_BLOCK,
+	ALLOWED_BLOCKS,
+	SELECT_NAVIGATION_MENUS_ARGS,
+} from '../constants';
 
 const EMPTY_OBJECT = {};
 
@@ -82,16 +86,7 @@ export default function UnsavedInnerBlocks( {
 				isSaving: isSavingEntityRecord( 'postType', 'wp_navigation' ),
 				hasResolvedAllNavigationMenus: hasFinishedResolution(
 					'getEntityRecords',
-					[
-						'postType',
-						'wp_navigation',
-						{
-							per_page: -1,
-							status: [ 'publish', 'draft' ],
-							order: 'desc',
-							orderby: 'date',
-						},
-					]
+					SELECT_NAVIGATION_MENUS_ARGS
 				),
 			};
 		},

--- a/packages/block-library/src/navigation/edit/unsaved-inner-blocks.js
+++ b/packages/block-library/src/navigation/edit/unsaved-inner-blocks.js
@@ -85,7 +85,12 @@ export default function UnsavedInnerBlocks( {
 					[
 						'postType',
 						'wp_navigation',
-						{ per_page: -1, status: [ 'publish', 'draft' ] },
+						{
+							per_page: -1,
+							status: [ 'publish', 'draft' ],
+							order: 'desc',
+							orderby: 'date',
+						},
 					]
 				),
 			};

--- a/packages/block-library/src/navigation/test/use-navigation-menu.js
+++ b/packages/block-library/src/navigation/test/use-navigation-menu.js
@@ -8,6 +8,7 @@ import { store as coreStore } from '@wordpress/core-data';
  * Internal dependencies
  */
 import useNavigationMenu from '../use-navigation-menu';
+import { SELECT_NAVIGATION_MENUS_ARGS } from '../constants';
 
 function createRegistryWithStores() {
 	// Create a registry and register used stores.
@@ -33,19 +34,19 @@ jest.mock( '@wordpress/data/src/components/use-select', () => {
 
 function resolveRecords( registry, menus ) {
 	const dispatch = registry.dispatch( coreStore );
-	dispatch.startResolution( 'getEntityRecords', [
-		'postType',
-		'wp_navigation',
-		{ per_page: -1, status: [ 'publish', 'draft' ] },
-	] );
-	dispatch.finishResolution( 'getEntityRecords', [
-		'postType',
-		'wp_navigation',
-		{ per_page: -1, status: [ 'publish', 'draft' ] },
-	] );
+	dispatch.startResolution(
+		'getEntityRecords',
+		SELECT_NAVIGATION_MENUS_ARGS
+	);
+	dispatch.finishResolution(
+		'getEntityRecords',
+		SELECT_NAVIGATION_MENUS_ARGS
+	);
 	dispatch.receiveEntityRecords( 'postType', 'wp_navigation', menus, {
-		per_page: -1,
+		per_page: 100,
 		status: [ 'publish', 'draft' ],
+		order: 'desc',
+		orderby: 'date',
 	} );
 }
 

--- a/packages/block-library/src/navigation/test/use-navigation-menu.js
+++ b/packages/block-library/src/navigation/test/use-navigation-menu.js
@@ -8,7 +8,6 @@ import { store as coreStore } from '@wordpress/core-data';
  * Internal dependencies
  */
 import useNavigationMenu from '../use-navigation-menu';
-import { SELECT_NAVIGATION_MENUS_ARGS } from '../constants';
 
 function createRegistryWithStores() {
 	// Create a registry and register used stores.
@@ -34,14 +33,26 @@ jest.mock( '@wordpress/data/src/components/use-select', () => {
 
 function resolveRecords( registry, menus ) {
 	const dispatch = registry.dispatch( coreStore );
-	dispatch.startResolution(
-		'getEntityRecords',
-		SELECT_NAVIGATION_MENUS_ARGS
-	);
-	dispatch.finishResolution(
-		'getEntityRecords',
-		SELECT_NAVIGATION_MENUS_ARGS
-	);
+	dispatch.startResolution( 'getEntityRecords', [
+		'postType',
+		'wp_navigation',
+		{
+			per_page: 100,
+			status: [ 'publish', 'draft' ],
+			order: 'desc',
+			orderby: 'date',
+		},
+	] );
+	dispatch.finishResolution( 'getEntityRecords', [
+		'postType',
+		'wp_navigation',
+		{
+			per_page: 100,
+			status: [ 'publish', 'draft' ],
+			order: 'desc',
+			orderby: 'date',
+		},
+	] );
 	dispatch.receiveEntityRecords( 'postType', 'wp_navigation', menus, {
 		per_page: 100,
 		status: [ 'publish', 'draft' ],

--- a/packages/block-library/src/navigation/use-navigation-menu.js
+++ b/packages/block-library/src/navigation/use-navigation-menu.js
@@ -71,7 +71,12 @@ function selectNavigationMenus( select ) {
 	const args = [
 		'postType',
 		'wp_navigation',
-		{ per_page: -1, status: [ 'publish', 'draft' ] },
+		{
+			per_page: -1,
+			status: [ 'publish', 'draft' ],
+			order: 'desc',
+			orderby: 'date',
+		},
 	];
 	return {
 		navigationMenus: getEntityRecords( ...args ),

--- a/packages/block-library/src/navigation/use-navigation-menu.js
+++ b/packages/block-library/src/navigation/use-navigation-menu.js
@@ -7,6 +7,11 @@ import {
 } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
 
+/**
+ * Internal dependencies
+ */
+import { SELECT_NAVIGATION_MENUS_ARGS } from './constants';
+
 export default function useNavigationMenu( ref ) {
 	const permissions = useResourcePermissions( 'navigation', ref );
 
@@ -68,22 +73,15 @@ function selectNavigationMenus( select ) {
 	const { getEntityRecords, hasFinishedResolution, isResolving } =
 		select( coreStore );
 
-	const args = [
-		'postType',
-		'wp_navigation',
-		{
-			per_page: -1,
-			status: [ 'publish', 'draft' ],
-			order: 'desc',
-			orderby: 'date',
-		},
-	];
 	return {
-		navigationMenus: getEntityRecords( ...args ),
-		isResolvingNavigationMenus: isResolving( 'getEntityRecords', args ),
+		navigationMenus: getEntityRecords( ...SELECT_NAVIGATION_MENUS_ARGS ),
+		isResolvingNavigationMenus: isResolving(
+			'getEntityRecords',
+			SELECT_NAVIGATION_MENUS_ARGS
+		),
 		hasResolvedNavigationMenus: hasFinishedResolution(
 			'getEntityRecords',
-			args
+			SELECT_NAVIGATION_MENUS_ARGS
 		),
 	};
 }

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/constants.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/constants.js
@@ -1,6 +1,8 @@
 // This requested is preloaded in `gutenberg_preload_navigation_posts`.
 // As unbounded queries are limited to 100 by `fetchAllMiddleware`
 // on apiFetch this query is limited to 100.
+// These parameters must be kept aligned with those in
+// lib/compat/wordpress-6.3/navigation-block-preloading.php
 export const PRELOADED_NAVIGATION_MENUS_QUERY = {
 	per_page: 100,
 	status: [ 'publish', 'draft' ],

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/constants.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/constants.js
@@ -3,7 +3,7 @@
 // on apiFetch this query is limited to 100.
 export const PRELOADED_NAVIGATION_MENUS_QUERY = {
 	per_page: 100,
-	status: 'publish',
+	status: [ 'publish', 'draft' ],
 	order: 'desc',
 	orderby: 'date',
 };

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { useEntityRecords } from '@wordpress/core-data';
 
 import { decodeEntities } from '@wordpress/html-entities';
@@ -20,6 +20,25 @@ import { PRELOADED_NAVIGATION_MENUS_QUERY } from './constants';
 import { useLink } from '../routes/link';
 import SingleNavigationMenu from '../sidebar-navigation-screen-navigation-menu/single-navigation-menu';
 import useNavigationMenuHandlers from '../sidebar-navigation-screen-navigation-menu/use-navigation-menu-handlers';
+
+// Copied from packages/block-library/src/navigation/edit/navigation-menu-selector.js.
+function buildMenuLabel( title, id, status ) {
+	if ( ! title?.rendered ) {
+		/* translators: %s is the index of the menu in the list of menus. */
+		return sprintf( __( '(no title %s)' ), id );
+	}
+
+	if ( status === 'publish' ) {
+		return decodeEntities( title?.rendered );
+	}
+
+	return sprintf(
+		// translators: %1s: title of the menu; %2s: status of the menu (draft, pending, etc.).
+		__( '%1$s (%2$s)' ),
+		decodeEntities( title?.rendered ),
+		status
+	);
+}
 
 export default function SidebarNavigationScreenNavigationMenus() {
 	const { records: navigationMenus, isResolving: isLoading } =
@@ -67,16 +86,14 @@ export default function SidebarNavigationScreenNavigationMenus() {
 	return (
 		<SidebarNavigationScreenWrapper>
 			<ItemGroup>
-				{ navigationMenus?.map( ( navMenu ) => (
+				{ navigationMenus?.map( ( { id, title, status }, index ) => (
 					<NavMenuItem
-						postId={ navMenu.id }
-						key={ navMenu.id }
+						postId={ id }
+						key={ id }
 						withChevron
 						icon={ navigation }
 					>
-						{ decodeEntities(
-							navMenu.title?.rendered || navMenu.slug
-						) }
+						{ buildMenuLabel( title, index + 1, status ) }
 					</NavMenuItem>
 				) ) }
 			</ItemGroup>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
List draft navigations as well as published ones in the navigation sidebar, so that the browse mode matches the block.
Fixes #51417.

## Why?
So that the same list appears in both places.

## How?
Change the preload query. The other alternative is to hide the draft ones in the block.

## Testing Instructions
Check that the list of navigations in the sidebar in browse mode is the same as the list in the block inspector controls.


