### PR TITLE
Indicate Draft status of menus in Nav block menu selector

### DIFF
--- a/packages/block-library/src/navigation/edit/navigation-menu-selector.js
+++ b/packages/block-library/src/navigation/edit/navigation-menu-selector.js
@@ -25,12 +25,15 @@ function buildMenuLabel( title, id, status ) {
 		return sprintf( __( '(no title %s)' ), id );
 	}
 
-	if ( status === 'draft' ) {
-		/* translators: %s is the title of the menu. */
-		return sprintf( __( '%s (draft)' ), decodeEntities( title?.rendered ) );
+	if ( status === 'publish' ) {
+		return decodeEntities( title?.rendered );
 	}
 
-	return decodeEntities( title?.rendered );
+	// translators: %1s: title of the menu; %2s: status of the menu (draft, pending, etc.).
+	return sprintf( __( '%1$s (%2$s)' ), [
+		decodeEntities( title?.rendered ),
+		status,
+	] );
 }
 
 function NavigationMenuSelector( {

--- a/packages/block-library/src/navigation/edit/navigation-menu-selector.js
+++ b/packages/block-library/src/navigation/edit/navigation-menu-selector.js
@@ -29,11 +29,12 @@ function buildMenuLabel( title, id, status ) {
 		return decodeEntities( title?.rendered );
 	}
 
-	// translators: %1s: title of the menu; %2s: status of the menu (draft, pending, etc.).
-	return sprintf( __( '%1$s (%2$s)' ), [
+	return sprintf(
+		// translators: %1s: title of the menu; %2s: status of the menu (draft, pending, etc.).
+		__( '%1$s (%2$s)' ),
 		decodeEntities( title?.rendered ),
-		status,
-	] );
+		status
+	);
 }
 
 function NavigationMenuSelector( {

--- a/packages/block-library/src/navigation/edit/navigation-menu-selector.js
+++ b/packages/block-library/src/navigation/edit/navigation-menu-selector.js
@@ -19,12 +19,18 @@ import { useEntityProp } from '@wordpress/core-data';
 import useNavigationMenu from '../use-navigation-menu';
 import useNavigationEntities from '../use-navigation-entities';
 
-function buildMenuLabel( title, id ) {
-	const label =
-		decodeEntities( title?.rendered ) ||
+function buildMenuLabel( title, id, status ) {
+	if ( ! title?.rendered ) {
 		/* translators: %s is the index of the menu in the list of menus. */
-		sprintf( __( '(no title %s)' ), id );
-	return label;
+		return sprintf( __( '(no title %s)' ), id );
+	}
+
+	if ( status === 'draft' ) {
+		/* translators: %s is the title of the menu. */
+		return sprintf( __( '%s (draft)' ), decodeEntities( title?.rendered ) );
+	}
+
+	return decodeEntities( title?.rendered );
 }
 
 function NavigationMenuSelector( {
@@ -61,8 +67,8 @@ function NavigationMenuSelector( {
 
 	const menuChoices = useMemo( () => {
 		return (
-			navigationMenus?.map( ( { id, title }, index ) => {
-				const label = buildMenuLabel( title, index + 1 );
+			navigationMenus?.map( ( { id, title, status }, index ) => {
+				const label = buildMenuLabel( title, index + 1, status );
 
 				return {
 					value: id,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Adds a status indicator "Draft" to show which menus are draft status in the Nav block's menu selector.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Because you can't tell which menus are published vs which are not and that is not helpful for users.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Add status to the title.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

- Create a draft menu and some published ones.
- Select Nav block
- Go to List View Tab in Inpsector Controls
- Click ellipsis menu
- See list of menus with "(Draft)" in it.


### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
<img width="538" alt="Screen Shot 2023-06-12 at 16 33 51" src="https://github.com/WordPress/gutenberg/assets/444434/18494030-7092-494d-862c-4bd9675058fb">
