### PR TITLE
Try: Update template titles

### DIFF
--- a/lib/compat/wordpress-6.2/block-template-utils.php
+++ b/lib/compat/wordpress-6.2/block-template-utils.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ * Temporary compatibility shims for features present in Gutenberg.
+ * This file should be removed when WordPress 6.2.0 becomes the lowest
+ * supported version by this plugin.
+ *
+ * @package gutenberg
+ */
+
+/**
+ * Helper function to get the Template Hierarchy for a given slug.
+ * We need to Handle special cases here like `front-page`, `singular` and `archive` templates.
+ *
+ * Noting that we always add `index` as the last fallback template.
+ *
+ * @param string  $slug            The template slug to be created.
+ * @param boolean $is_custom       Indicates if a template is custom or part of the template hierarchy.
+ * @param string  $template_prefix The template prefix for the created template. This is used to extract the main template type ex. in `taxonomy-books` we extract the `taxonomy`.
+ *
+ * @return array<string> The template hierarchy.
+ */
+function gutenberg_get_template_hierarchy( $slug, $is_custom = false, $template_prefix = '' ) {
+	if ( 'index' === $slug ) {
+		return array( 'index' );
+	}
+	if ( $is_custom ) {
+		return array( 'page', 'singular', 'index' );
+	}
+	if ( 'front-page' === $slug ) {
+		return array( 'front-page', 'home', 'index' );
+	}
+
+	$matches = array();
+
+	$template_hierarchy = array( $slug );
+	// Most default templates don't have `$template_prefix` assigned.
+	if ( ! empty( $template_prefix ) ) {
+		list( $type ) = explode( '-', $template_prefix );
+		// We need these checks because we always add the `$slug` above.
+		if ( ! in_array( $template_prefix, array( $slug, $type ), true ) ) {
+			$template_hierarchy[] = $template_prefix;
+		}
+		if ( $slug !== $type ) {
+			$template_hierarchy[] = $type;
+		}
+	} elseif ( preg_match( '/^(author|category|archive|tag|page)-.+$/', $slug, $matches ) ) {
+		$template_hierarchy[] = $matches[1];
+	} elseif ( preg_match( '/^(taxonomy|single)-(.+)$/', $slug, $matches ) ) {
+		$type           = $matches[1];
+		$slug_remaining = $matches[2];
+
+		$items = 'single' === $type ? get_post_types() : get_taxonomies();
+		foreach ( $items as $item ) {
+			if ( ! str_starts_with( $slug_remaining, $item ) ) {
+					continue;
+			}
+
+			// If $slug_remaining is equal to $post_type or $taxonomy we have
+			// the single-$post_type template or the taxonomy-$taxonomy template.
+			if ( $slug_remaining === $item ) {
+				$template_hierarchy[] = $type;
+				break;
+			}
+
+			// If $slug_remaining is single-$post_type-$slug template.
+			if ( strlen( $slug_remaining ) > strlen( $item ) + 1 ) {
+				$template_hierarchy[] = "$type-$item";
+				$template_hierarchy[] = $type;
+				break;
+			}
+		}
+	}
+	// Handle `archive` template.
+	if (
+		str_starts_with( $slug, 'author' ) ||
+		str_starts_with( $slug, 'taxonomy' ) ||
+		str_starts_with( $slug, 'category' ) ||
+		str_starts_with( $slug, 'tag' ) ||
+		'date' === $slug
+	) {
+		$template_hierarchy[] = 'archive';
+	}
+	// Handle `single` template.
+	if ( 'attachment' === $slug ) {
+		$template_hierarchy[] = 'single';
+	}
+	// Handle `singular` template.
+	if (
+		str_starts_with( $slug, 'single' ) ||
+		str_starts_with( $slug, 'page' ) ||
+		'attachment' === $slug
+	) {
+		$template_hierarchy[] = 'singular';
+	}
+	$template_hierarchy[] = 'index';
+	return $template_hierarchy;
+}

--- a/lib/compat/wordpress-6.2/block-template-utils.php
+++ b/lib/compat/wordpress-6.2/block-template-utils.php
@@ -110,7 +110,7 @@ function gutenberg_get_template_hierarchy( $slug, $is_custom = false, $template_
 function gutenberg_get_default_block_template_types( $default_template_types ) {
 	if ( isset( $default_template_types['index'] ) ) {
 		$default_template_types['index'] = array(
-			'title'       => _x( 'Index', 'Template name', 'gutenberg' ),
+			'title'       => _x( 'All Posts & Pages', 'Template name', 'gutenberg' ),
 			'description' => __(
 				'Used as a fallback template for all pages when a more specific template is not defined.',
 				'gutenberg'
@@ -119,7 +119,7 @@ function gutenberg_get_default_block_template_types( $default_template_types ) {
 	}
 	if ( isset( $default_template_types['home'] ) ) {
 		$default_template_types['home'] = array(
-			'title'       => _x( 'Home', 'Template name', 'gutenberg' ),
+			'title'       => _x( 'Blog page', 'Template name', 'gutenberg' ),
 			'description' => __(
 				'Displays the latest posts as either the site homepage or a custom page defined under reading settings. If it exists, the Front Page template overrides this template when posts are shown on the front page.',
 				'gutenberg'
@@ -128,7 +128,7 @@ function gutenberg_get_default_block_template_types( $default_template_types ) {
 	}
 	if ( isset( $default_template_types['front-page'] ) ) {
 		$default_template_types['front-page'] = array(
-			'title'       => _x( 'Front Page', 'Template name', 'gutenberg' ),
+			'title'       => _x( 'Homepage', 'Template name', 'gutenberg' ),
 			'description' => __(
 				"Displays your site's front page, whether it is set to display latest posts or a static page. The Front Page template takes precedence over all templates.",
 				'gutenberg'
@@ -137,7 +137,7 @@ function gutenberg_get_default_block_template_types( $default_template_types ) {
 	}
 	if ( isset( $default_template_types['singular'] ) ) {
 		$default_template_types['singular'] = array(
-			'title'       => _x( 'Singular', 'Template name', 'gutenberg' ),
+			'title'       => _x( 'Single Entires', 'Template name', 'gutenberg' ),
 			'description' => __(
 				'Displays any single entry, such as a post or a page. This template will serve as a fallback when a more specific template (e.g., Single Post, Page, or Attachment) cannot be found.',
 				'gutenberg'
@@ -146,19 +146,19 @@ function gutenberg_get_default_block_template_types( $default_template_types ) {
 	}
 	if ( isset( $default_template_types['single'] ) ) {
 		$default_template_types['single'] = array(
-			'title'       => _x( 'Single', 'Template name', 'gutenberg' ),
+			'title'       => _x( 'Single Posts', 'Template name', 'gutenberg' ),
 			'description' => __( 'Displays single posts on your website unless a custom template has been applied to that post or a dedicated template exists.', 'gutenberg' ),
 		);
 	}
 	if ( isset( $default_template_types['page'] ) ) {
 		$default_template_types['page'] = array(
-			'title'       => _x( 'Page', 'Template name', 'gutenberg' ),
+			'title'       => _x( 'Pages', 'Template name', 'gutenberg' ),
 			'description' => __( 'Display all static pages unless a custom template has been applied or a dedicated template exists.', 'gutenberg' ),
 		);
 	}
 	if ( isset( $default_template_types['archive'] ) ) {
 		$default_template_types['archive'] = array(
-			'title'       => _x( 'Archive', 'Template name', 'gutenberg' ),
+			'title'       => _x( 'All Archives', 'Template name', 'gutenberg' ),
 			'description' => __(
 				'Displays any archive, including posts by a single author, category, tag, taxonomy, custom post type, and date. This template will serve as a fallback when more specific templates (e.g., Category or Tag) cannot be found.',
 				'gutenberg'
@@ -167,7 +167,7 @@ function gutenberg_get_default_block_template_types( $default_template_types ) {
 	}
 	if ( isset( $default_template_types['author'] ) ) {
 		$default_template_types['author'] = array(
-			'title'       => _x( 'Author', 'Template name', 'gutenberg' ),
+			'title'       => _x( 'Author Archives', 'Template name', 'gutenberg' ),
 			'description' => __(
 				"Displays a single author's post archive. This template will serve as a fallback when a more a specific template (e.g., Author: Admin) cannot be found.",
 				'gutenberg'
@@ -176,7 +176,7 @@ function gutenberg_get_default_block_template_types( $default_template_types ) {
 	}
 	if ( isset( $default_template_types['category'] ) ) {
 		$default_template_types['category'] = array(
-			'title'       => _x( 'Category', 'Template name', 'gutenberg' ),
+			'title'       => _x( 'Category Archives', 'Template name', 'gutenberg' ),
 			'description' => __(
 				'Displays a post category archive. This template will serve as a fallback when more specific template (e.g., Category: Recipes) cannot be found.',
 				'gutenberg'
@@ -194,13 +194,13 @@ function gutenberg_get_default_block_template_types( $default_template_types ) {
 	}
 	if ( isset( $default_template_types['date'] ) ) {
 		$default_template_types['date'] = array(
-			'title'       => _x( 'Date', 'Template name', 'gutenberg' ),
+			'title'       => _x( 'Date Archives', 'Template name', 'gutenberg' ),
 			'description' => __( 'Displays a post archive when a specific date is visited (e.g., example.com/2023/).', 'gutenberg' ),
 		);
 	}
 	if ( isset( $default_template_types['tag'] ) ) {
 		$default_template_types['tag'] = array(
-			'title'       => _x( 'Tag', 'Template name', 'gutenberg' ),
+			'title'       => _x( 'Tag Archives', 'Template name', 'gutenberg' ),
 			'description' => __(
 				'Displays a post tag archive. This template will serve as a fallback when more specific template (e.g., Tag: Pizza) cannot be found.',
 				'gutenberg'
@@ -209,13 +209,13 @@ function gutenberg_get_default_block_template_types( $default_template_types ) {
 	}
 	if ( isset( $default_template_types['attachment'] ) ) {
 		$default_template_types['attachment'] = array(
-			'title'       => _x( 'Media', 'Template name', 'gutenberg' ),
+			'title'       => _x( 'Attachment Pages', 'Template name', 'gutenberg' ),
 			'description' => __( 'Displays when a visitor views the dedicated page that exists for any media attachment.', 'gutenberg' ),
 		);
 	}
 	if ( isset( $default_template_types['search'] ) ) {
 		$default_template_types['search'] = array(
-			'title'       => _x( 'Search', 'Template name', 'gutenberg' ),
+			'title'       => _x( 'Search Results', 'Template name', 'gutenberg' ),
 			'description' => __( 'Displays when a visitor performs a search on your website.', 'gutenberg' ),
 		);
 	}
@@ -230,7 +230,7 @@ function gutenberg_get_default_block_template_types( $default_template_types ) {
 	}
 	if ( isset( $default_template_types['404'] ) ) {
 		$default_template_types['404'] = array(
-			'title'       => _x( '404', 'Template name', 'gutenberg' ),
+			'title'       => _x( 'Error: 404', 'Template name', 'gutenberg' ),
 			'description' => __( 'Displays when a visitor views a non-existent page, such as a dead link or a mistyped URL.', 'gutenberg' ),
 		);
 	}

--- a/lib/compat/wordpress-6.2/block-template-utils.php
+++ b/lib/compat/wordpress-6.2/block-template-utils.php
@@ -121,7 +121,7 @@ function gutenberg_get_default_block_template_types( $default_template_types ) {
 		$default_template_types['home'] = array(
 			'title'       => _x( 'Blog page', 'Template name', 'gutenberg' ),
 			'description' => __(
-				'Displays the latest posts as either the site homepage or a custom page defined under reading settings. If it exists, the Front Page template overrides this template when posts are shown on the front page.',
+				'Displays the latest posts as either the site homepage or a custom page defined under reading settings. If it exists, the Homepage template overrides this template when posts are shown on the homepage.',
 				'gutenberg'
 			),
 		);
@@ -130,7 +130,7 @@ function gutenberg_get_default_block_template_types( $default_template_types ) {
 		$default_template_types['front-page'] = array(
 			'title'       => _x( 'Homepage', 'Template name', 'gutenberg' ),
 			'description' => __(
-				"Displays your site's front page, whether it is set to display latest posts or a static page. The Front Page template takes precedence over all templates.",
+				"Displays your site's homepage, whether it is set to display latest posts or a static page. The Homepage template takes precedence over all templates.",
 				'gutenberg'
 			),
 		);

--- a/lib/compat/wordpress-6.2/block-template-utils.php
+++ b/lib/compat/wordpress-6.2/block-template-utils.php
@@ -110,7 +110,7 @@ function gutenberg_get_template_hierarchy( $slug, $is_custom = false, $template_
 function gutenberg_get_default_block_template_types( $default_template_types ) {
 	if ( isset( $default_template_types['index'] ) ) {
 		$default_template_types['index'] = array(
-			'title'       => _x( 'All Posts & Pages', 'Template name', 'gutenberg' ),
+			'title'       => _x( 'Index', 'Template name', 'gutenberg' ),
 			'description' => __(
 				'Used as a fallback template for all pages when a more specific template is not defined.',
 				'gutenberg'

--- a/lib/compat/wordpress-6.2/block-template-utils.php
+++ b/lib/compat/wordpress-6.2/block-template-utils.php
@@ -137,7 +137,7 @@ function gutenberg_get_default_block_template_types( $default_template_types ) {
 	}
 	if ( isset( $default_template_types['singular'] ) ) {
 		$default_template_types['singular'] = array(
-			'title'       => _x( 'Single Entires', 'Template name', 'gutenberg' ),
+			'title'       => _x( 'Single Entries', 'Template name', 'gutenberg' ),
 			'description' => __(
 				'Displays any single entry, such as a post or a page. This template will serve as a fallback when a more specific template (e.g., Single Post, Page, or Attachment) cannot be found.',
 				'gutenberg'

--- a/lib/compat/wordpress-6.2/block-template-utils.php
+++ b/lib/compat/wordpress-6.2/block-template-utils.php
@@ -230,7 +230,7 @@ function gutenberg_get_default_block_template_types( $default_template_types ) {
 	}
 	if ( isset( $default_template_types['404'] ) ) {
 		$default_template_types['404'] = array(
-			'title'       => _x( 'Error: 404', 'Template name', 'gutenberg' ),
+			'title'       => _x( 'Page: 404', 'Template name', 'gutenberg' ),
 			'description' => __( 'Displays when a visitor views a non-existent page, such as a dead link or a mistyped URL.', 'gutenberg' ),
 		);
 	}

--- a/lib/compat/wordpress-6.2/block-template-utils.php
+++ b/lib/compat/wordpress-6.2/block-template-utils.php
@@ -121,16 +121,16 @@ function gutenberg_get_default_block_template_types( $default_template_types ) {
 		$default_template_types['home'] = array(
 			'title'       => _x( 'Blog page', 'Template name', 'gutenberg' ),
 			'description' => __(
-				'Displays the latest posts as either the site homepage or a custom page defined under reading settings. If it exists, the Homepage template overrides this template when posts are shown on the homepage.',
+				'Displays the latest posts as either the site homepage or a custom page defined under reading settings. If it exists, the Front Page template overrides this template when posts are shown on the homepage.',
 				'gutenberg'
 			),
 		);
 	}
 	if ( isset( $default_template_types['front-page'] ) ) {
 		$default_template_types['front-page'] = array(
-			'title'       => _x( 'Homepage', 'Template name', 'gutenberg' ),
+			'title'       => _x( 'Front Page', 'Template name', 'gutenberg' ),
 			'description' => __(
-				"Displays your site's homepage, whether it is set to display latest posts or a static page. The Homepage template takes precedence over all templates.",
+				"Displays your site's homepage, whether it is set to display latest posts or a static page. The Front Page template takes precedence over all templates.",
 				'gutenberg'
 			),
 		);

--- a/lib/compat/wordpress-6.2/block-template-utils.php
+++ b/lib/compat/wordpress-6.2/block-template-utils.php
@@ -119,9 +119,9 @@ function gutenberg_get_default_block_template_types( $default_template_types ) {
 	}
 	if ( isset( $default_template_types['home'] ) ) {
 		$default_template_types['home'] = array(
-			'title'       => _x( 'Blog page', 'Template name', 'gutenberg' ),
+			'title'       => _x( 'Blog home page', 'Template name', 'gutenberg' ),
 			'description' => __(
-				'Displays the latest posts as either the site homepage or a custom page defined under reading settings. If it exists, the Front Page template overrides this template when posts are shown on the homepage.',
+				'Displays the latest posts as either the site homepage or as the "Posts page" as defined under reading settings. If it exists, the Front Page template overrides this template when posts are shown on the homepage.',
 				'gutenberg'
 			),
 		);

--- a/lib/compat/wordpress-6.3/block-template-utils.php
+++ b/lib/compat/wordpress-6.3/block-template-utils.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Temporary compatibility shims for features present in Gutenberg.
- * This file should be removed when WordPress 6.1.0 becomes the lowest
+ * This file should be removed when WordPress 6.2.0 becomes the lowest
  * supported version by this plugin.
  *
  * @package gutenberg
@@ -119,7 +119,7 @@ function gutenberg_get_default_block_template_types( $default_template_types ) {
 	}
 	if ( isset( $default_template_types['home'] ) ) {
 		$default_template_types['home'] = array(
-			'title'       => _x( 'Blog home page', 'Template name', 'gutenberg' ),
+			'title'       => _x( 'Home', 'Template name', 'gutenberg' ),
 			'description' => __(
 				'Displays the latest posts as either the site homepage or as the "Posts page" as defined under reading settings. If it exists, the Front Page template overrides this template when posts are shown on the homepage.',
 				'gutenberg'

--- a/lib/compat/wordpress-6.3/block-template-utils.php
+++ b/lib/compat/wordpress-6.3/block-template-utils.php
@@ -1,101 +1,11 @@
 <?php
 /**
  * Temporary compatibility shims for features present in Gutenberg.
- * This file should be removed when WordPress 6.2.0 becomes the lowest
+ * This file should be removed when WordPress 6.3.0 becomes the lowest
  * supported version by this plugin.
  *
  * @package gutenberg
  */
-
-/**
- * Helper function to get the Template Hierarchy for a given slug.
- * We need to Handle special cases here like `front-page`, `singular` and `archive` templates.
- *
- * Noting that we always add `index` as the last fallback template.
- *
- * @param string  $slug            The template slug to be created.
- * @param boolean $is_custom       Indicates if a template is custom or part of the template hierarchy.
- * @param string  $template_prefix The template prefix for the created template. This is used to extract the main template type ex. in `taxonomy-books` we extract the `taxonomy`.
- *
- * @return array<string> The template hierarchy.
- */
-function gutenberg_get_template_hierarchy( $slug, $is_custom = false, $template_prefix = '' ) {
-	if ( 'index' === $slug ) {
-		return array( 'index' );
-	}
-	if ( $is_custom ) {
-		return array( 'page', 'singular', 'index' );
-	}
-	if ( 'front-page' === $slug ) {
-		return array( 'front-page', 'home', 'index' );
-	}
-
-	$matches = array();
-
-	$template_hierarchy = array( $slug );
-	// Most default templates don't have `$template_prefix` assigned.
-	if ( ! empty( $template_prefix ) ) {
-		list( $type ) = explode( '-', $template_prefix );
-		// We need these checks because we always add the `$slug` above.
-		if ( ! in_array( $template_prefix, array( $slug, $type ), true ) ) {
-			$template_hierarchy[] = $template_prefix;
-		}
-		if ( $slug !== $type ) {
-			$template_hierarchy[] = $type;
-		}
-	} elseif ( preg_match( '/^(author|category|archive|tag|page)-.+$/', $slug, $matches ) ) {
-		$template_hierarchy[] = $matches[1];
-	} elseif ( preg_match( '/^(taxonomy|single)-(.+)$/', $slug, $matches ) ) {
-		$type           = $matches[1];
-		$slug_remaining = $matches[2];
-
-		$items = 'single' === $type ? get_post_types() : get_taxonomies();
-		foreach ( $items as $item ) {
-			if ( ! str_starts_with( $slug_remaining, $item ) ) {
-					continue;
-			}
-
-			// If $slug_remaining is equal to $post_type or $taxonomy we have
-			// the single-$post_type template or the taxonomy-$taxonomy template.
-			if ( $slug_remaining === $item ) {
-				$template_hierarchy[] = $type;
-				break;
-			}
-
-			// If $slug_remaining is single-$post_type-$slug template.
-			if ( strlen( $slug_remaining ) > strlen( $item ) + 1 ) {
-				$template_hierarchy[] = "$type-$item";
-				$template_hierarchy[] = $type;
-				break;
-			}
-		}
-	}
-	// Handle `archive` template.
-	if (
-		str_starts_with( $slug, 'author' ) ||
-		str_starts_with( $slug, 'taxonomy' ) ||
-		str_starts_with( $slug, 'category' ) ||
-		str_starts_with( $slug, 'tag' ) ||
-		'date' === $slug
-	) {
-		$template_hierarchy[] = 'archive';
-	}
-	// Handle `single` template.
-	if ( 'attachment' === $slug ) {
-		$template_hierarchy[] = 'single';
-	}
-	// Handle `singular` template.
-	if (
-		str_starts_with( $slug, 'single' ) ||
-		str_starts_with( $slug, 'page' ) ||
-		'attachment' === $slug
-	) {
-		$template_hierarchy[] = 'singular';
-	}
-	$template_hierarchy[] = 'index';
-	return $template_hierarchy;
-}
-
 
 /**
  * Updates the list of default template types, containing their

--- a/lib/load.php
+++ b/lib/load.php
@@ -74,6 +74,7 @@ require __DIR__ . '/compat/plugin/edit-site-routes-backwards-compat.php';
 // WordPress 6.2 compat.
 require __DIR__ . '/compat/wordpress-6.2/blocks.php';
 require __DIR__ . '/compat/wordpress-6.2/script-loader.php';
+require __DIR__ . '/compat/wordpress-6.2/block-template-utils.php';
 require __DIR__ . '/compat/wordpress-6.2/get-global-styles-and-settings.php';
 require __DIR__ . '/compat/wordpress-6.2/default-filters.php';
 require __DIR__ . '/compat/wordpress-6.2/site-editor.php';
@@ -81,10 +82,6 @@ require __DIR__ . '/compat/wordpress-6.2/block-editor.php';
 require __DIR__ . '/compat/wordpress-6.2/theme.php';
 require __DIR__ . '/compat/wordpress-6.2/widgets.php';
 require __DIR__ . '/compat/wordpress-6.2/menu.php';
-
-// WordPress 6.3 compat.
-require __DIR__ . '/compat/wordpress-6.3/get-global-styles-and-settings.php';
-require __DIR__ . '/compat/wordpress-6.3/block-template-utils.php';
 
 if ( ! class_exists( 'WP_HTML_Tag_Processor' ) ) {
 	require __DIR__ . '/compat/wordpress-6.2/html-api/class-wp-html-attribute-token.php';
@@ -94,6 +91,8 @@ if ( ! class_exists( 'WP_HTML_Tag_Processor' ) ) {
 }
 
 // WordPress 6.3 compat.
+require __DIR__ . '/compat/wordpress-6.3/get-global-styles-and-settings.php';
+require __DIR__ . '/compat/wordpress-6.3/block-template-utils.php';
 require __DIR__ . '/compat/wordpress-6.3/html-api/class-gutenberg-html-tag-processor-6-3.php';
 require __DIR__ . '/compat/wordpress-6.3/script-loader.php';
 require __DIR__ . '/compat/wordpress-6.3/blocks.php';

--- a/lib/load.php
+++ b/lib/load.php
@@ -74,7 +74,6 @@ require __DIR__ . '/compat/plugin/edit-site-routes-backwards-compat.php';
 // WordPress 6.2 compat.
 require __DIR__ . '/compat/wordpress-6.2/blocks.php';
 require __DIR__ . '/compat/wordpress-6.2/script-loader.php';
-require __DIR__ . '/compat/wordpress-6.2/block-template-utils.php';
 require __DIR__ . '/compat/wordpress-6.2/get-global-styles-and-settings.php';
 require __DIR__ . '/compat/wordpress-6.2/default-filters.php';
 require __DIR__ . '/compat/wordpress-6.2/site-editor.php';
@@ -85,6 +84,7 @@ require __DIR__ . '/compat/wordpress-6.2/menu.php';
 
 // WordPress 6.3 compat.
 require __DIR__ . '/compat/wordpress-6.3/get-global-styles-and-settings.php';
+require __DIR__ . '/compat/wordpress-6.3/block-template-utils.php';
 
 if ( ! class_exists( 'WP_HTML_Tag_Processor' ) ) {
 	require __DIR__ . '/compat/wordpress-6.2/html-api/class-wp-html-attribute-token.php';

--- a/packages/e2e-tests/specs/experiments/blocks/post-comments-form.test.js
+++ b/packages/e2e-tests/specs/experiments/blocks/post-comments-form.test.js
@@ -37,7 +37,7 @@ describe( 'Post Comments Form', () => {
 			);
 			await expect( page ).toClick(
 				'.edit-site-sidebar-navigation-item',
-				{ text: /singular/i }
+				{ text: /single entries/i }
 			);
 			await enterEditMode();
 

--- a/packages/e2e-tests/specs/site-editor/settings-sidebar.test.js
+++ b/packages/e2e-tests/specs/site-editor/settings-sidebar.test.js
@@ -79,7 +79,7 @@ describe( 'Settings sidebar', () => {
 					'Used as a fallback template for all pages when a more specific template is not defined.',
 			} );
 			expect( templateCardAfterNavigation ).toMatchObject( {
-				title: 'Singular',
+				title: 'Single Entries',
 				description:
 					'Displays any single entry, such as a post or a page. This template will serve as a fallback when a more specific template (e.g., Single Post, Page, or Attachment) cannot be found.',
 			} );

--- a/test/e2e/specs/editor/various/post-editor-template-mode.spec.js
+++ b/test/e2e/specs/editor/various/post-editor-template-mode.spec.js
@@ -151,7 +151,7 @@ class PostEditorTemplateMode {
 
 		await expect(
 			this.editorTopBar.getByRole( 'heading[level=1]' )
-		).toHaveText( 'Editing template: Singular' );
+		).toHaveText( 'Editing template: Single Entries' );
 	}
 
 	async createPostAndSaveDraft() {


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/50395

## What?
Update template titles. 

## Why?
See https://github.com/WordPress/gutenberg/issues/47551, https://github.com/WordPress/gutenberg/issues/44524. In short: Template names are not always particularly intuitive. This PR sacrifices a little brevity in order to (potentially) address that.

## How?
Update `title`s in `$default_template_types`. Here's the full list of changes:

* Home → Blog Page
* Front Page → Homepage
* Singular → Single Entries
* Page → Pages
* Archive → All Archives
* Category → Category Archives
* Tag → Tag Archives
* Date → Date Archives
* Author → Author Archives
* Media → Attachment Pages
* Search → Search Results
* 404 → Page: 404

## Testing Instructions
* Open any UI where template names are encountered, e.g.: Templates List, Add template modal, Template Inspector in the Editor
* Observe that core templates have new names

## Screenshots
Note the names in the modal, and in the sidebar.

### Before
<img width="1364" alt="Screenshot 2023-06-12 at 16 53 11" src="https://github.com/WordPress/gutenberg/assets/846565/6cbaad3b-e06d-4b84-ac1c-9355d85904ed">


### After
<img width="1362" alt="Screenshot 2023-06-12 at 16 52 50" src="https://github.com/WordPress/gutenberg/assets/846565/e9ddd59e-c7e7-4f08-b431-2e210e443c25">


Caveat: Any theme templates that have been customised will retain their old names. I'm not sure how to address that, if we should, or if it's even possible. 
