### PR TITLE
Block Editor: Improve data selector for BlockQuickNavigationItem

### DIFF
--- a/packages/block-editor/src/components/block-quick-navigation/index.js
+++ b/packages/block-editor/src/components/block-quick-navigation/index.js
@@ -69,7 +69,6 @@ function BlockQuickNavigationItem( { clientId } ) {
 
 	return (
 		<Button
-			key={ clientId }
 			isPressed={ isSelected }
 			onClick={ () => selectBlock( clientId ) }
 		>

--- a/packages/block-editor/src/components/block-quick-navigation/index.js
+++ b/packages/block-editor/src/components/block-quick-navigation/index.js
@@ -8,7 +8,10 @@ import {
 	__experimentalHStack as HStack,
 	FlexItem,
 } from '@wordpress/components';
-import { getBlockType, __experimentalGetBlockLabel } from '@wordpress/blocks';
+import {
+	__experimentalGetBlockLabel,
+	store as blocksStore,
+} from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -33,7 +36,7 @@ export default function BlockQuickNavigation( { clientIds } ) {
 }
 
 function BlockQuickNavigationItem( { clientId } ) {
-	const { name, attributes, isSelected } = useSelect(
+	const { name, icon, isSelected } = useSelect(
 		( select ) => {
 			const {
 				getBlockName,
@@ -41,9 +44,20 @@ function BlockQuickNavigationItem( { clientId } ) {
 				isBlockSelected,
 				hasSelectedInnerBlock,
 			} = select( blockEditorStore );
+			const { getBlockType } = select( blocksStore );
+
+			const blockType = getBlockType( getBlockName( clientId ) );
+			const attributes = getBlockAttributes( clientId );
+
 			return {
-				name: getBlockName( clientId ),
-				attributes: getBlockAttributes( clientId ),
+				name:
+					blockType &&
+					__experimentalGetBlockLabel(
+						blockType,
+						attributes,
+						'list-view'
+					),
+				icon: blockType?.icon,
 				isSelected:
 					isBlockSelected( clientId ) ||
 					hasSelectedInnerBlock( clientId, /* deep: */ true ),
@@ -52,7 +66,7 @@ function BlockQuickNavigationItem( { clientId } ) {
 		[ clientId ]
 	);
 	const { selectBlock } = useDispatch( blockEditorStore );
-	const blockType = getBlockType( name );
+
 	return (
 		<Button
 			key={ clientId }
@@ -60,14 +74,8 @@ function BlockQuickNavigationItem( { clientId } ) {
 			onClick={ () => selectBlock( clientId ) }
 		>
 			<HStack justify="flex-start">
-				<BlockIcon icon={ blockType.icon } />
-				<FlexItem>
-					{ __experimentalGetBlockLabel(
-						blockType,
-						attributes,
-						'list-view'
-					) }
-				</FlexItem>
+				<BlockIcon icon={ icon } />
+				<FlexItem>{ name }</FlexItem>
 			</HStack>
 		</Button>
 	);


### PR DESCRIPTION
## What?
This is a follow-up to #51281.

PR updates the selector in `BlockQuickNavigationItem` to only return data needed for rendering.

## Why?
The block attributes change often, and not every block has special handlers for the label. Returning the block name from the `mapSelect` will prevent unwanted rerenders.

## How?
* Move `__experimentalGetBlockLabel` inside the selector.
* Update the code to use the `getBlockType` selector.
* Remove unnecessary `key` prop for the button.

## Testing Instructions
1. Open a Post or Page.
2. Insert a content-locked block. I'm using this example - https://gist.github.com/richtabor/ddeea41ced691721318649bea8ce9db8.
3. Confirm block navigation in the sidebar works as before.

## Screenshots or screencast <!-- if applicable -->

**Before**

https://github.com/WordPress/gutenberg/assets/240569/8f4b925b-8162-4e8c-950e-69b3cf0ba6de

**After**

https://github.com/WordPress/gutenberg/assets/240569/00748b64-452a-4a2a-9319-d3ec7257cbda