### PR TITLE
Make sure post content always has correct layout.

### DIFF
--- a/packages/edit-post/src/components/visual-editor/index.js
+++ b/packages/edit-post/src/components/visual-editor/index.js
@@ -372,8 +372,15 @@ export default function VisualEditor( { styles } ) {
 							! isTemplateMode && (
 								<>
 									<LayoutStyle
-										selector=".edit-post-visual-editor__post-title-wrapper, .block-editor-block-list__layout.is-root-container"
+										selector=".edit-post-visual-editor__post-title-wrapper"
 										layout={ fallbackLayout }
+										layoutDefinitions={
+											globalLayoutSettings?.definitions
+										}
+									/>
+									<LayoutStyle
+										selector=".block-editor-block-list__layout.is-root-container"
+										layout={ blockListLayout }
 										layoutDefinitions={
 											globalLayoutSettings?.definitions
 										}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes #51371 by separating out the default styles for Post Content and Post Title in the post editor. Post Title doesn't have layout attributes, so it should be provided with a fallback style. Post Content does have layout, so it should always respect its layout settings.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Open a post and edit its template (from the Template dropdown in the post sidebar) so that Post Content block has "Inner blocks use content width" unset.
2. Go back to the post editor and check that all content blocks now have no margins (they should stick to the left hand side of the editor window).
3. Test other Post Content layout settings (e.g. custom content width, justified right) to see if they still work.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
