### PR TITLE
Update/page list footer

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen-pages/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-pages/index.js
@@ -180,37 +180,38 @@ export default function SidebarNavigationScreenPages() {
 										</PageItem>
 									);
 								} ) }
-								<VStack className="edit-site-sidebar-navigation-screen__sticky-section">
-									{ dynamicPageTemplates?.map( ( item ) => (
-										<PageItem
-											postType="wp_template"
-											postId={ item.id }
-											key={ item.id }
-											icon={ layout }
-											withChevron
-										>
-											<Truncate numberOfLines={ 1 }>
-												{ decodeEntities(
-													item.title?.rendered ||
-														__( '(no title)' )
-												) }
-											</Truncate>
-										</PageItem>
-									) ) }
-									<SidebarNavigationItem
-										className="edit-site-sidebar-navigation-screen-pages__see-all"
-										href="edit.php?post_type=page"
-										onClick={ () => {
-											document.location =
-												'edit.php?post_type=page';
-										} }
-									>
-										{ __( 'Manage all pages' ) }
-									</SidebarNavigationItem>
-								</VStack>
 							</ItemGroup>
 						) }
 					</>
+				}
+				footer={
+					<VStack spacing={ 0 }>
+						{ dynamicPageTemplates?.map( ( item ) => (
+							<PageItem
+								postType="wp_template"
+								postId={ item.id }
+								key={ item.id }
+								icon={ layout }
+								withChevron
+							>
+								<Truncate numberOfLines={ 1 }>
+									{ decodeEntities(
+										item.title?.rendered ||
+											__( '(no title)' )
+									) }
+								</Truncate>
+							</PageItem>
+						) ) }
+						<SidebarNavigationItem
+							className="edit-site-sidebar-navigation-screen-pages__see-all"
+							href="edit.php?post_type=page"
+							onClick={ () => {
+								document.location = 'edit.php?post_type=page';
+							} }
+						>
+							{ __( 'Manage all pages' ) }
+						</SidebarNavigationItem>
+					</VStack>
 				}
 			/>
 		</>

--- a/packages/edit-site/src/components/sidebar-navigation-screen-templates/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-templates/index.js
@@ -147,33 +147,27 @@ export default function SidebarNavigationScreenTemplates() {
 									) }
 								</TemplateItem>
 							) ) }
-							{ ! isMobileViewport && (
-								<>
-									<SidebarNavigationItem
-										className="edit-site-sidebar-navigation-screen-templates__see-all"
-										withChevron
-										{ ...browseAllLink }
-									>
-										{ config[ postType ].labels.manage }
-									</SidebarNavigationItem>
-									{ !! config[ postType ].labels
-										.reusableBlocks && (
-										<SidebarNavigationItem
-											as="a"
-											href="edit.php?post_type=wp_block"
-											withChevron
-										>
-											{
-												config[ postType ].labels
-													.reusableBlocks
-											}
-										</SidebarNavigationItem>
-									) }
-								</>
-							) }
 						</ItemGroup>
 					) }
 				</>
+			}
+			footer={
+				! isMobileViewport && (
+					<>
+						<SidebarNavigationItem withChevron { ...browseAllLink }>
+							{ config[ postType ].labels.manage }
+						</SidebarNavigationItem>
+						{ !! config[ postType ].labels.reusableBlocks && (
+							<SidebarNavigationItem
+								as="a"
+								href="edit.php?post_type=wp_block"
+								withChevron
+							>
+								{ config[ postType ].labels.reusableBlocks }
+							</SidebarNavigationItem>
+						) }
+					</>
+				)
 			}
 		/>
 	);

--- a/packages/edit-site/src/components/sidebar-navigation-screen-templates/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-templates/style.scss
@@ -1,4 +1,0 @@
-.edit-site-sidebar-navigation-screen-templates__see-all {
-	/* Overrides the margin that comes from the Item component */
-	margin-top: $grid-unit-20 !important;
-}

--- a/packages/edit-site/src/components/sidebar-navigation-screen/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-screen/style.scss
@@ -82,7 +82,7 @@
 	}
 }
 
-.edit-site-sidebar-navigation-screen__sticky-section.edit-site-sidebar-navigation-screen__sticky-section {
+.edit-site-sidebar-navigation-screen__footer {
 	position: sticky;
 	bottom: 0;
 	background-color: $gray-900;
@@ -91,11 +91,4 @@
 	margin: $grid-unit-20 0 0;
 	border-top: 1px solid $gray-800;
 	box-shadow: 0 #{-$grid-unit-10} $grid-unit-20 $gray-900;
-}
-
-.edit-site-sidebar-navigation-screen__footer {
-	position: sticky;
-	bottom: 0;
-	background-color: $gray-900;
-	padding: $grid-unit-20 0;
 }

--- a/packages/edit-site/src/style.scss
+++ b/packages/edit-site/src/style.scss
@@ -33,7 +33,6 @@
 @import "./components/sidebar-navigation-screen-navigation-menu/style.scss";
 @import "./components/sidebar-navigation-screen-page/style.scss";
 @import "./components/sidebar-navigation-screen-template/style.scss";
-@import "./components/sidebar-navigation-screen-templates/style.scss";
 @import "./components/sidebar-navigation-subtitle/style.scss";
 @import "./components/site-hub/style.scss";
 @import "./components/sidebar-navigation-screen-navigation-menus/style.scss";

--- a/packages/edit-site/src/style.scss
+++ b/packages/edit-site/src/style.scss
@@ -31,7 +31,6 @@
 @import "./components/sidebar-navigation-screen-navigation-menu/style.scss";
 @import "./components/sidebar-navigation-screen-page/style.scss";
 @import "./components/sidebar-navigation-screen-template/style.scss";
-@import "./components/sidebar-navigation-screen-templates/style.scss";
 @import "./components/sidebar-navigation-subtitle/style.scss";
 @import "./components/site-hub/style.scss";
 @import "./components/sidebar-navigation-screen-navigation-menus/style.scss";


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Uses the new footer prop on `SidebarNavigationScreen` for pages and templates.

<img width="1040" alt="image" src="https://github.com/WordPress/gutenberg/assets/1072756/1017ded4-933a-4c64-9803-4a0775095b7c">


## Why?
To keep it consistent with other pages

## How?
Moved footer sections out of content and into footer and removed unnecessary css.

## Testing Instructions
1. Open site editor
2. Click on pages
3. Notice the manage all link and 404, Search are fixed to bottom
4. Do the same for templates

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
