### PR TITLE
Formats: Avoid rerendering language edit component when typing

### DIFF
--- a/packages/format-library/src/language/index.js
+++ b/packages/format-library/src/language/index.js
@@ -29,21 +29,10 @@ export const language = {
 	title,
 };
 
-function Edit( props ) {
-	const { contentRef, isActive, onChange, value } = props;
-	const popoverAnchor = useAnchor( {
-		editableContentElement: contentRef.current,
-		settings: language,
-	} );
-
-	const [ lang, setLang ] = useState( '' );
-	const [ dir, setDir ] = useState( 'ltr' );
-
+function Edit( { isActive, value, onChange, contentRef } ) {
 	const [ isPopoverVisible, setIsPopoverVisible ] = useState( false );
 	const togglePopover = () => {
 		setIsPopoverVisible( ( state ) => ! state );
-		setLang( '' );
-		setDir( 'ltr' );
 	};
 
 	return (
@@ -62,63 +51,81 @@ function Edit( props ) {
 				isActive={ isActive }
 				role="menuitemcheckbox"
 			/>
-
 			{ isPopoverVisible && (
-				<Popover
-					className="block-editor-format-toolbar__language-popover"
-					anchor={ popoverAnchor }
-					placement="bottom"
+				<InlineLanguageUI
+					value={ value }
+					onChange={ onChange }
 					onClose={ togglePopover }
-				>
-					<form
-						className="block-editor-format-toolbar__language-container-content"
-						onSubmit={ ( event ) => {
-							onChange(
-								applyFormat( value, {
-									type: name,
-									attributes: {
-										lang,
-										dir,
-									},
-								} )
-							);
-							togglePopover();
-							event.preventDefault();
-						} }
-					>
-						<TextControl
-							label={ title }
-							value={ lang }
-							onChange={ ( val ) => setLang( val ) }
-							help={ __(
-								'A valid language attribute, like "en" or "fr".'
-							) }
-						/>
-						<SelectControl
-							label={ __( 'Text direction' ) }
-							value={ dir }
-							options={ [
-								{
-									label: __( 'Left to right' ),
-									value: 'ltr',
-								},
-								{
-									label: __( 'Right to left' ),
-									value: 'rtl',
-								},
-							] }
-							onChange={ ( val ) => setDir( val ) }
-						/>
-						<HStack alignment="right">
-							<Button
-								variant="primary"
-								type="submit"
-								text={ __( 'Apply' ) }
-							/>
-						</HStack>
-					</form>
-				</Popover>
+					contentRef={ contentRef }
+				/>
 			) }
 		</>
+	);
+}
+
+function InlineLanguageUI( { value, contentRef, onChange, onClose } ) {
+	const popoverAnchor = useAnchor( {
+		editableContentElement: contentRef.current,
+		settings: language,
+	} );
+
+	const [ lang, setLang ] = useState( '' );
+	const [ dir, setDir ] = useState( 'ltr' );
+
+	return (
+		<Popover
+			className="block-editor-format-toolbar__language-popover"
+			anchor={ popoverAnchor }
+			placement="bottom"
+			onClose={ onClose }
+		>
+			<form
+				className="block-editor-format-toolbar__language-container-content"
+				onSubmit={ ( event ) => {
+					event.preventDefault();
+					onChange(
+						applyFormat( value, {
+							type: name,
+							attributes: {
+								lang,
+								dir,
+							},
+						} )
+					);
+					onClose();
+				} }
+			>
+				<TextControl
+					label={ title }
+					value={ lang }
+					onChange={ ( val ) => setLang( val ) }
+					help={ __(
+						'A valid language attribute, like "en" or "fr".'
+					) }
+				/>
+				<SelectControl
+					label={ __( 'Text direction' ) }
+					value={ dir }
+					options={ [
+						{
+							label: __( 'Left to right' ),
+							value: 'ltr',
+						},
+						{
+							label: __( 'Right to left' ),
+							value: 'rtl',
+						},
+					] }
+					onChange={ ( val ) => setDir( val ) }
+				/>
+				<HStack alignment="right">
+					<Button
+						variant="primary"
+						type="submit"
+						text={ __( 'Apply' ) }
+					/>
+				</HStack>
+			</form>
+		</Popover>
 	);
 }


### PR DESCRIPTION
## What?
While profiling a different UI part, I noticed the Language format edit component did extra rerendering due to the `useAnchor` hook.

## Why?
There's no need to calculate anchor props when a user is typing. The value is only needed when opening the inline UI.

## How?
Extracts Popover and related hooks into a new `InlineLanguageUI` component. This matches a pattern in other formats that use inline popovers.

## Testing Instructions
1. Open a Post or Page.
2. Insert paragraph block and add text.
3. Select part of the text.
4. Confirm Language selection works as before.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2023-06-13 at 11 08 43](https://github.com/WordPress/gutenberg/assets/240569/265e9cfa-4d58-4ba0-9955-fe6528d6ef1e)
