### PR TITLE
Templates and Library panels: make secondary links sticky

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen-templates/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-templates/index.js
@@ -5,6 +5,7 @@ import {
 	__experimentalItemGroup as ItemGroup,
 	__experimentalItem as Item,
 	__experimentalUseNavigator as useNavigator,
+	__experimentalVStack as VStack,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useEntityRecords } from '@wordpress/core-data';
@@ -147,29 +148,32 @@ export default function SidebarNavigationScreenTemplates() {
 									) }
 								</TemplateItem>
 							) ) }
+
 							{ ! isMobileViewport && (
-								<>
-									<SidebarNavigationItem
-										className="edit-site-sidebar-navigation-screen-templates__see-all"
-										withChevron
-										{ ...browseAllLink }
-									>
-										{ config[ postType ].labels.manage }
-									</SidebarNavigationItem>
-									{ !! config[ postType ].labels
-										.reusableBlocks && (
+								<VStack className="edit-site-sidebar-navigation-screen__sticky-section">
+									<>
 										<SidebarNavigationItem
-											as="a"
-											href="edit.php?post_type=wp_block"
+											className="edit-site-sidebar-navigation-screen-templates__see-all"
 											withChevron
+											{ ...browseAllLink }
 										>
-											{
-												config[ postType ].labels
-													.reusableBlocks
-											}
+											{ config[ postType ].labels.manage }
 										</SidebarNavigationItem>
-									) }
-								</>
+										{ !! config[ postType ].labels
+											.reusableBlocks && (
+											<SidebarNavigationItem
+												as="a"
+												href="edit.php?post_type=wp_block"
+												withChevron
+											>
+												{
+													config[ postType ].labels
+														.reusableBlocks
+												}
+											</SidebarNavigationItem>
+										) }
+									</>
+								</VStack>
 							) }
 						</ItemGroup>
 					) }

--- a/packages/edit-site/src/components/sidebar-navigation-screen-templates/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-templates/style.scss
@@ -1,4 +1,0 @@
-.edit-site-sidebar-navigation-screen-templates__see-all {
-	/* Overrides the margin that comes from the Item component */
-	margin-top: $grid-unit-20 !important;
-}

--- a/packages/edit-site/src/style.scss
+++ b/packages/edit-site/src/style.scss
@@ -31,7 +31,6 @@
 @import "./components/sidebar-navigation-screen-navigation-menu/style.scss";
 @import "./components/sidebar-navigation-screen-page/style.scss";
 @import "./components/sidebar-navigation-screen-template/style.scss";
-@import "./components/sidebar-navigation-screen-templates/style.scss";
 @import "./components/sidebar-navigation-subtitle/style.scss";
 @import "./components/site-hub/style.scss";
 @import "./components/sidebar-navigation-screen-navigation-menus/style.scss";


### PR DESCRIPTION
## What?
Make the secondary links in the Templates and Library panels sticky. The secondary links are:

Templates: 'Manage all templates'

Library: 'Manage all template parts', 'Manage reusable blocks'.

## Why?
1. Consistency – the secondary links in the Pages panel already behave this way.
2. Usability – when the lists are long, it can be frustrating that the 'manage' links can only be accessed by scrolling.

## How?
Add `.edit-site-sidebar-navigation-screen__sticky-section` to the `VStack` containing the secondary links.

## Testing Instructions
1. Open Library panel.
2. Resize the viewport so that the sidebar scrolls if necessary.
3. Notice that the 'Manage' links are always visible regardless of scroll position.
4. Repeat for the Templates panel.

## Before

https://github.com/WordPress/gutenberg/assets/846565/7ca6c97b-23bc-4b3f-b21e-4d78ce6ed706


## After


https://github.com/WordPress/gutenberg/assets/846565/b6c7e455-efcc-46a7-9500-4e8b36e226e5

