### PR TITLE
Fix document title back and shortcut color contrast.

### DIFF
--- a/packages/edit-site/src/components/header-edit-mode/document-actions/style.scss
+++ b/packages/edit-site/src/components/header-edit-mode/document-actions/style.scss
@@ -58,13 +58,17 @@
 	}
 }
 
-.edit-site-document-actions__shortcut {
-	color: $gray-700;
-	text-align: right;
+.edit-site-document-actions__shortcut,
+.edit-site-document-actions__back {
+	color: darken($gray-700, 3%); // Darken the secondary color to meet requirements against a gray background.
 
-	&:hover {
-		color: $gray-700;
+	.edit-site-document-actions:hover & {
+		color: $gray-900;
 	}
+}
+
+.edit-site-document-actions__shortcut {
+	text-align: right;
 }
 
 .edit-site-document-actions__back {

--- a/packages/edit-site/src/components/header-edit-mode/document-actions/style.scss
+++ b/packages/edit-site/src/components/header-edit-mode/document-actions/style.scss
@@ -60,7 +60,7 @@
 
 .edit-site-document-actions__shortcut,
 .edit-site-document-actions__back {
-	color: darken($gray-700, 3%); // Darken the secondary color to meet requirements against a gray background.
+	color: $gray-800;
 
 	.edit-site-document-actions:hover & {
 		color: $gray-900;


### PR DESCRIPTION
## What?

The document title element in the site editor had too low contrast for the shortcut indication. This PR fixes it:

![document title colors](https://github.com/WordPress/gutenberg/assets/1204802/a03453a6-790e-4bb6-8254-459b3a96509d)

The new contrast is:

* In its resting state (not hovered), #6d6d6d on a #f0f0f0 background, giving 4.54:1 ratio
* In its hovered state, #1e1e1e on a #e0e0e0 background, giving 12.62:1 ratio

This behavior applies to both back button and shortcut tip.
