### PR TITLE
Gallery block - Add default value for innerBlockImages

### DIFF
--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -144,7 +144,10 @@ function GalleryEdit( props ) {
 
 	const innerBlockImages = useSelect(
 		( select ) => {
-			return select( blockEditorStore ).getBlock( clientId )?.innerBlocks;
+			const innerBlocks =
+				select( blockEditorStore ).getBlock( clientId )?.innerBlocks ??
+				[];
+			return innerBlocks;
 		},
 		[ clientId ]
 	);

--- a/packages/block-library/src/gallery/test/__snapshots__/index.native.js.snap
+++ b/packages/block-library/src/gallery/test/__snapshots__/index.native.js.snap
@@ -110,6 +110,12 @@ exports[`Gallery block rearranges gallery items 1`] = `
 <!-- /wp:gallery -->"
 `;
 
+exports[`Gallery block renders gallery block placeholder correctly if the block doesn't have inner blocks 1`] = `
+"<!-- wp:gallery {"linkTo":"none"} -->
+<figure class="wp-block-gallery has-nested-images columns-default is-cropped"></figure>
+<!-- /wp:gallery -->"
+`;
+
 exports[`Gallery block sets caption to gallery 1`] = `
 "<!-- wp:gallery {"linkTo":"none"} -->
 <figure class="wp-block-gallery has-nested-images columns-default is-cropped"><!-- wp:image {"id":2000} -->

--- a/packages/block-library/src/gallery/test/index.native.js
+++ b/packages/block-library/src/gallery/test/index.native.js
@@ -27,6 +27,8 @@ import {
 	requestImageFailedRetryDialog,
 	requestImageUploadCancelDialog,
 } from '@wordpress/react-native-bridge';
+import { store as blockEditorStore } from '@wordpress/block-editor';
+import { select } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -73,6 +75,24 @@ describe( 'Gallery block', () => {
 
 		expect( getBlock( screen, 'Gallery' ) ).toBeVisible();
 		expect( getEditorHtml() ).toMatchSnapshot();
+	} );
+
+	it( "renders gallery block placeholder correctly if the block doesn't have inner blocks", async () => {
+		const getBlockSpy = jest
+			.spyOn( select( blockEditorStore ), 'getBlock' )
+			.mockReturnValue( {
+				innerBlocks: undefined,
+				attributes: {
+					content: '',
+				},
+			} );
+
+		const screen = await addGalleryBlock();
+
+		expect( getBlock( screen, 'Gallery' ) ).toBeVisible();
+		expect( getEditorHtml() ).toMatchSnapshot();
+
+		getBlockSpy.mockReset();
 	} );
 
 	it( 'selects a gallery item', async () => {


### PR DESCRIPTION
## What?
This PR adds a default value to `innerBlockImages` in case of `undefined` values.

## Why?
Some parts of the code expect `innerBlockImages` to be defined as well as other values that come from that variable. Some have optional chaining cases but others don't and we are getting some crashes on the mobile editor. Unfourtnaley I couldn't find the exact steps to reproduce the crash but by looking at the code and the stack traces, this code change should address them.

- https://github.com/wordpress-mobile/gutenberg-mobile/issues/5389
- https://github.com/wordpress-mobile/WordPress-iOS/issues/20573

## How?
By setting a default empty array value to `innerBlockImages`.

## Testing Instructions

- Test adding a Gallery block and images to it
- Test removing all images from the Gallery block

### Testing Instructions for Keyboard
N/A

## Screenshots or screencast <!-- if applicable -->

## Web

https://github.com/WordPress/gutenberg/assets/4885740/f626b2fc-6cd2-452c-b9ed-207aefde39a8

## Mobile

https://github.com/WordPress/gutenberg/assets/4885740/3ab64cdb-7293-4c11-94cc-bd79630d9c68