### PR TITLE
Mobile - Image block - Fix issue with set width and height images

### DIFF
--- a/packages/components/src/mobile/image/index.native.js
+++ b/packages/components/src/mobile/image/index.native.js
@@ -178,7 +178,7 @@ const ImageComponent = ( {
 			imageData &&
 			containerSize && {
 				height:
-					imageData?.width > containerSize?.width
+					imageData?.width > containerSize?.width && ! imageWidth
 						? containerSize?.width / imageData?.aspectRatio
 						: undefined,
 			},

--- a/packages/react-native-editor/CHANGELOG.md
+++ b/packages/react-native-editor/CHANGELOG.md
@@ -10,6 +10,7 @@ For each user feature we should also add a importance categorization label  to i
 -->
 
 ## Unreleased
+-   [*] Image block - Fix issue where in some cases the image doesn't display the right aspect ratio [#51463]
 
 ## 1.97.0
 -   [**] [iOS] Fix dictation regression, in which typing/dictating at the same time caused content loss. [#49452]


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/5091

## What?
Fixes an issue with the Image block and set width and height values for some images.

## Why?
To show the right aspect ratio regardless if the image has a set with/heigh value or not.

## How?
By avoiding setting a set height value (from the container) if the image has a set width value.

Currently you can't set a custom width/height from the mobile editor but you can from the Web editor.

## Testing Instructions

- Download [this image](https://newspaceeconomy.files.wordpress.com/2022/07/306826ab-4675-4932-b71b-ee2998fb531e.jpeg).
- Go to the web version of the editor.
- Create a post.
- Add an Image block and insert the image previously downloaded in step 1.
- Open the Image block settings.
- Change the Image size to Full Size.
- Change Image dimensions to 25%.
- Save the post.
- Go to the app.
- Open the saved post.
- Expect the image showing the right aspect ratio

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

Before iOS | After iOS
-|-
<kbd><img src="https://github.com/WordPress/gutenberg/assets/4885740/12e4ac09-351f-4b31-aa9d-36518180a291" width=250 /></kbd> | <kbd><img src="https://github.com/WordPress/gutenberg/assets/4885740/491e8553-df5f-4f95-ab39-014032ed1add" width=250 /></kbd>

Before Android | After Android
-|-
<kbd><img src="https://github.com/WordPress/gutenberg/assets/4885740/dbdcc9c1-04ec-4635-b7d2-2af0a7770e37" width=250 /></kbd> | <kbd><img src="https://github.com/WordPress/gutenberg/assets/4885740/0169f176-bf74-42ec-8e53-2c22bac5c8fd" width=250 /></kbd>
