### PR TITLE
Remove reset button in behaviors, use dropdown option instead

### DIFF
--- a/packages/block-editor/src/hooks/behaviors.js
+++ b/packages/block-editor/src/hooks/behaviors.js
@@ -2,11 +2,7 @@
  * WordPress dependencies
  */
 import { addFilter } from '@wordpress/hooks';
-import {
-	SelectControl,
-	Button,
-	__experimentalHStack as HStack,
-} from '@wordpress/components';
+import { SelectControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { hasBlockSupport } from '@wordpress/blocks';
 import { createHigherOrderComponent } from '@wordpress/compose';
@@ -48,6 +44,11 @@ function BehaviorsControl( {
 		label: __( 'No behaviors' ),
 	};
 
+	const defaultBehaviorsOption = {
+		value: 'default',
+		label: __( 'Default' ),
+	};
+
 	const behaviorsOptions = Object.entries( settings )
 		.filter(
 			( [ behaviorName, behaviorValue ] ) =>
@@ -65,7 +66,11 @@ function BehaviorsControl( {
 	// If every behavior is disabled, do not show the behaviors inspector control.
 	if ( behaviorsOptions.length === 0 ) return null;
 
-	const options = [ noBehaviorsOption, ...behaviorsOptions ];
+	const options = [
+		defaultBehaviorsOption,
+		noBehaviorsOption,
+		...behaviorsOptions,
+	];
 
 	// Block behaviors take precedence over theme behaviors.
 	const behaviors = merge( themeBehaviors, blockBehaviors || {} );
@@ -77,28 +82,17 @@ function BehaviorsControl( {
 	return (
 		<InspectorControls group="advanced">
 			{ /* This div is needed to prevent a margin bottom between the dropdown and the button. */ }
-			<div>
-				<SelectControl
-					label={ __( 'Behaviors' ) }
-					// At the moment we are only supporting one behavior (Lightbox)
-					value={ behaviors?.lightbox ? 'lightbox' : '' }
-					options={ options }
-					onChange={ onChange }
-					hideCancelButton={ true }
-					help={ helpText }
-					size="__unstable-large"
-					disabled={ disabled }
-				/>
-			</div>
-			<HStack justify="flex-end">
-				<Button
-					isSmall
-					disabled={ disabled }
-					onClick={ () => onChange( undefined ) }
-				>
-					{ __( 'Reset' ) }
-				</Button>
-			</HStack>
+			<SelectControl
+				label={ __( 'Behaviors' ) }
+				// At the moment we are only supporting one behavior (Lightbox)
+				value={ behaviors?.lightbox ? 'lightbox' : '' }
+				options={ options }
+				onChange={ onChange }
+				hideCancelButton={ true }
+				help={ helpText }
+				size="__unstable-large"
+				disabled={ disabled }
+			/>
 		</InspectorControls>
 	);
 }
@@ -130,7 +124,7 @@ export const withBehaviors = createHigherOrderComponent( ( BlockEdit ) => {
 					blockName={ props.name }
 					blockBehaviors={ props.attributes.behaviors }
 					onChange={ ( nextValue ) => {
-						if ( nextValue === undefined ) {
+						if ( nextValue === 'default' ) {
 							props.setAttributes( {
 								behaviors: undefined,
 							} );

--- a/packages/block-editor/src/hooks/behaviors.js
+++ b/packages/block-editor/src/hooks/behaviors.js
@@ -65,7 +65,7 @@ function BehaviorsControl( {
 	];
 
 	// If every behavior is disabled, do not show the behaviors inspector control.
-	if ( options.length === 0 ) {
+	if ( behaviorsOptions.length === 0 ) {
 		return null;
 	}
 	// Block behaviors take precedence over theme behaviors.
@@ -89,7 +89,6 @@ function BehaviorsControl( {
 		<InspectorControls group="advanced">
 			<SelectControl
 				label={ __( 'Behaviors' ) }
-				// At the moment we are only supporting one behavior (Lightbox)
 				value={ value() }
 				options={ options }
 				onChange={ onChange }

--- a/test/e2e/specs/editor/various/behaviors.spec.js
+++ b/test/e2e/specs/editor/various/behaviors.spec.js
@@ -83,7 +83,7 @@ test.describe( 'Testing behaviors functionality', () => {
 		await expect( select ).toHaveValue( '' );
 
 		// By default, you should be able to select the Lightbox behavior.
-		await expect( select.getByRole( 'option' ) ).toHaveCount( 2 );
+		await expect( select.getByRole( 'option' ) ).toHaveCount( 3 );
 	} );
 
 	test( 'Behaviors UI can be disabled in the `theme.json`', async ( {
@@ -162,8 +162,8 @@ test.describe( 'Testing behaviors functionality', () => {
 		// attributes takes precedence over the theme's value.
 		await expect( select ).toHaveValue( 'lightbox' );
 
-		// There should be 2 options available: `No behaviors` and `Lightbox`.
-		await expect( select.getByRole( 'option' ) ).toHaveCount( 2 );
+		// There should be 3 options available: `No behaviors` and `Lightbox`.
+		await expect( select.getByRole( 'option' ) ).toHaveCount( 3 );
 
 		// We can change the value of the behaviors dropdown to `No behaviors`.
 		await select.selectOption( { label: 'No behaviors' } );
@@ -210,7 +210,7 @@ test.describe( 'Testing behaviors functionality', () => {
 		await expect( select ).toHaveValue( 'lightbox' );
 
 		// There should be 2 options available: `No behaviors` and `Lightbox`.
-		await expect( select.getByRole( 'option' ) ).toHaveCount( 2 );
+		await expect( select.getByRole( 'option' ) ).toHaveCount( 3 );
 
 		// We can change the value of the behaviors dropdown to `No behaviors`.
 		await select.selectOption( { label: 'No behaviors' } );
@@ -254,7 +254,7 @@ test.describe( 'Testing behaviors functionality', () => {
 		await expect( select ).toBeDisabled();
 	} );
 
-	test( 'Lightbox behavior control has a Reset button that removes the markup', async ( {
+	test( 'Lightbox behavior control has a default option that removes the markup', async ( {
 		admin,
 		editor,
 		requestUtils,
@@ -293,13 +293,11 @@ test.describe( 'Testing behaviors functionality', () => {
 			.last()
 			.click();
 
-		const resetButton = editorSettings.getByRole( 'button', {
-			name: 'Reset',
+		const select = editorSettings.getByRole( 'combobox', {
+			name: 'Behavior',
 		} );
 
-		expect( resetButton ).toBeDefined();
-
-		await resetButton.last().click();
+		await select.selectOption( { label: 'Default' } );
 		expect( await editor.getEditedPostContent() )
 			.toBe( `<!-- wp:image {"id":${ media.id }} -->
 <figure class="wp-block-image"><img src="http://localhost:8889/wp-content/uploads/${ year }/${ month }/1024x768_e2e_test_image_size.jpeg" alt="1024x768_e2e_test_image_size.jpeg" class="wp-image-${ media.id }"/></figure>

--- a/test/e2e/specs/editor/various/behaviors.spec.js
+++ b/test/e2e/specs/editor/various/behaviors.spec.js
@@ -49,43 +49,6 @@ test.describe( 'Testing behaviors functionality', () => {
 		await page.waitForLoadState();
 	} );
 
-	test( '`No Behaviors` should be the default as defined in the core theme.json', async ( {
-		admin,
-		editor,
-		requestUtils,
-		page,
-		behaviorUtils,
-	} ) => {
-		await requestUtils.activateTheme( 'twentytwentyone' );
-		await admin.createNewPost();
-		const media = await behaviorUtils.createMedia();
-		await editor.insertBlock( {
-			name: 'core/image',
-			attributes: {
-				alt: filename,
-				id: media.id,
-				url: media.source_url,
-			},
-		} );
-
-		await editor.openDocumentSettingsSidebar();
-		const editorSettings = page.getByRole( 'region', {
-			name: 'Editor settings',
-		} );
-		await editorSettings
-			.getByRole( 'button', { name: 'Advanced' } )
-			.click();
-		const select = editorSettings.getByRole( 'combobox', {
-			name: 'Behavior',
-		} );
-
-		// By default, no behaviors should be selected.
-		await expect( select ).toHaveValue( '' );
-
-		// By default, you should be able to select the Lightbox behavior.
-		await expect( select.getByRole( 'option' ) ).toHaveCount( 3 );
-	} );
-
 	test( 'Behaviors UI can be disabled in the `theme.json`', async ( {
 		admin,
 		editor,
@@ -171,50 +134,6 @@ test.describe( 'Testing behaviors functionality', () => {
 
 		// Here we should also check that the block renders on the frontend with the
 		// lightbox even though the theme.json has it set to false.
-	} );
-
-	test( 'You can set the default value for the behaviors in the theme.json', async ( {
-		admin,
-		editor,
-		requestUtils,
-		page,
-		behaviorUtils,
-	} ) => {
-		// In this theme, the default value for settings.behaviors.blocks.core/image.lightbox is `true`.
-		await requestUtils.activateTheme( 'behaviors-enabled' );
-		await admin.createNewPost();
-		const media = await behaviorUtils.createMedia();
-
-		await editor.insertBlock( {
-			name: 'core/image',
-			attributes: {
-				alt: filename,
-				id: media.id,
-				url: media.source_url,
-			},
-		} );
-
-		await editor.openDocumentSettingsSidebar();
-		const editorSettings = page.getByRole( 'region', {
-			name: 'Editor settings',
-		} );
-		await editorSettings
-			.getByRole( 'button', { name: 'Advanced' } )
-			.click();
-		const select = editorSettings.getByRole( 'combobox', {
-			name: 'Behavior',
-		} );
-
-		// The behaviors dropdown should be present and the value should be set to
-		// `lightbox`.
-		await expect( select ).toHaveValue( 'lightbox' );
-
-		// There should be 2 options available: `No behaviors` and `Lightbox`.
-		await expect( select.getByRole( 'option' ) ).toHaveCount( 3 );
-
-		// We can change the value of the behaviors dropdown to `No behaviors`.
-		await select.selectOption( { label: 'No behaviors' } );
-		await expect( select ).toHaveValue( '' );
 	} );
 
 	test( 'Lightbox behavior is disabled if the Image has a link', async ( {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
After a conversation in another draft PR regarding behaviors. I did a proof of concept of having a default option in the dropdown.

Conversation:
https://github.com/WordPress/gutenberg/pull/51357#issuecomment-1589450641

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
A reset button is not a pattern we are using widely. Also, I still don't know how the interface will be with more than one behavior applied.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Converted the reset button into a dropdown option.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
1. Open a Post or Page, add an image.
2. Enable the Behaviors UI experiment in Gutenberg experiments page.
3. Set Lightbox as default behavior in theme.json (not required)
4. With the image selected, choose a behavior, check the markup, use default option, check that the attribute dissapears.

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/37012961/dfb7147c-2dac-446f-b858-de08c13d98bc

