### PR TITLE
Edit Site: Refactor the NavigationMenuContent component and fix the deprecation notice

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/navigation-menu-content.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/navigation-menu-content.js
@@ -40,21 +40,30 @@ const PAGES_QUERY = [
 export default function NavigationMenuContent( { rootClientId, onSelect } ) {
 	const { listViewRootClientId, isLoading } = useSelect(
 		( select ) => {
-			const { areInnerBlocksControlled, getBlockName, getBlockOrder } =
-				select( blockEditorStore );
+			const {
+				areInnerBlocksControlled,
+				getBlockName,
+				getBlockCount,
+				getBlockOrder,
+			} = select( blockEditorStore );
 			const { isResolving } = select( coreStore );
 
 			const blockClientIds = getBlockOrder( rootClientId );
+
 			const hasOnlyPageListBlock =
 				blockClientIds.length === 1 &&
 				getBlockName( blockClientIds[ 0 ] ) === 'core/page-list';
+			const pageListHasBlocks =
+				hasOnlyPageListBlock &&
+				getBlockCount( blockClientIds[ 0 ] ) > 0;
 
 			const isLoadingPages = isResolving(
 				'getEntityRecords',
 				PAGES_QUERY
 			);
+
 			return {
-				listViewRootClientId: hasOnlyPageListBlock
+				listViewRootClientId: pageListHasBlocks
 					? blockClientIds[ 0 ]
 					: rootClientId,
 				// This is a small hack to wait for the navigation block


### PR DESCRIPTION
## What?

PR fixes `blocks` property deprecation notice for Navigation menus in the Site Editor sidebar and refactors selectors to work with the `rootClientId` prop.

I've also removed the artificial loading delay. The original flickering issue isn't noticeable now that the "skeleton" loader has been removed (#50326).

**What is causing the "flickering:"**

The list view starts rendering the `rootClientId` blocks while the "is single list block" value is resolved and then switches to rendering page list items. You can test this by logging the following condition:

```js
// trunk
console.log( isSinglePageList ? 'rendering page list' : 'rendering navigation block' );

// This branch
console.log( rootClientId !== listViewRootClientId ? 'rendering page list' : 'rendering navigation block' );
```

## Why?
The core shouldn't use deprecated properties/methods.

## How?
Updates the `PrivateListView` component to `rootClientId` instead of the `blocks` prop.

## Testing Instructions
First, please ensure the testing site has at least one Navigation menu with custom links/pages and one showing "Page List."

1. Open a Site Editor.
2. Select Navigation in the sidebar.
3. Select the menu displaying the "Page List" block.
4. Confirm it doesn't display the "Page List" block itself and displays only page items.
5. Select the other menu with custom links and pages.
6. Confirm it's displayed as before.

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/240569/fa3621f4-4561-46a1-a415-fad65e30ad69

