### PR TITLE
Add 'Mamaduka' as one of the code owners for Playwright tests

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -78,7 +78,7 @@
 /packages/prettier-config                       @ntwb @gziolo
 /packages/scripts                               @gziolo @ntwb @nerrad @ajitbohra @ryanwelcher
 /packages/stylelint-config                      @ntwb
-/test/e2e                                       @kevin940726
+/test/e2e                                       @kevin940726 @Mamaduka
 
 # UI Components
 /packages/components                            @ajitbohra


### PR DESCRIPTION
## What?
I am adding myself as one of the code owners for the Playwright e2e tests directory.

## Why?
I want to be notified when tests are added or updated. Also, I don't want @kevin940726 to have all the fun with tests 😄

## Testing Instructions
CI checks are green.
