### PR TITLE
[Block Library - Post Terms]: Custom taxonomies do not show icons when transforming from the toolbar.

### DIFF
--- a/packages/block-library/src/post-terms/hooks.js
+++ b/packages/block-library/src/post-terms/hooks.js
@@ -17,9 +17,7 @@ export default function enhanceVariations( settings, name ) {
 	const variations = settings.variations.map( ( variation ) => ( {
 		...variation,
 		...{
-			icon: variationIconMap[ variation.name ]
-				? variationIconMap[ variation.name ]
-				: postCategories,
+			icon: variationIconMap[ variation.name ] ?? postCategories,
 		},
 	} ) );
 	return {

--- a/packages/block-library/src/post-terms/hooks.js
+++ b/packages/block-library/src/post-terms/hooks.js
@@ -16,9 +16,11 @@ export default function enhanceVariations( settings, name ) {
 	}
 	const variations = settings.variations.map( ( variation ) => ( {
 		...variation,
-		...( variationIconMap[ variation.name ] && {
-			icon: variationIconMap[ variation.name ],
-		} ),
+		...{
+			icon: variationIconMap[ variation.name ]
+				? variationIconMap[ variation.name ]
+				: postCategories,
+		},
 	} ) );
 	return {
 		...settings,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Custom taxonomies do not show icons when transforming from toolbar in post terms block.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Create a custom taxonomy
2. Insert a post terms Block.
3. Do a transform from the toolbar. At that time, confirm that the icon is set in the custom taxonomy.

## Screenshots or screencast <!-- if applicable -->

### trunk
https://github.com/WordPress/gutenberg/assets/42362903/190bc997-daba-424d-966c-80671706c853

### this branch
https://github.com/WordPress/gutenberg/assets/42362903/d0937126-bf17-40fc-ab6e-d15bbdbc8dd7