### PR TITLE
[Site Editor - Page Inspector]: Add ability to switch templates

### DIFF
--- a/docs/reference-guides/data/data-core-edit-site.md
+++ b/docs/reference-guides/data/data-core-edit-site.md
@@ -291,7 +291,7 @@ _Parameters_
 
 _Returns_
 
--   `number`: The resolved template ID for the page route.
+-   `Object`: Action object.
 
 ### setHasPageContentFocus
 

--- a/packages/base-styles/_z-index.scss
+++ b/packages/base-styles/_z-index.scss
@@ -127,6 +127,7 @@ $z-layers: (
 	".block-editor-template-part__selection-modal": 1000001,
 	".block-editor-block-rename-modal": 1000001,
 	".edit-site-list__rename-modal": 1000001,
+	".edit-site-swap-template-modal": 1000001,
 
 	// Note: The ConfirmDialog component's z-index is being set to 1000001 in packages/components/src/confirm-dialog/styles.ts
 	// because it uses emotion and not sass. We need it to render on top its parent popover.

--- a/packages/core-data/src/hooks/use-entity-record.ts
+++ b/packages/core-data/src/hooks/use-entity-record.ts
@@ -155,8 +155,8 @@ export default function useEntityRecord< RecordType >(
 
 	const mutations = useMemo(
 		() => ( {
-			edit: ( record ) =>
-				editEntityRecord( kind, name, recordId, record ),
+			edit: ( record, editOptions: any = {} ) =>
+				editEntityRecord( kind, name, recordId, record, editOptions ),
 			save: ( saveOptions: any = {} ) =>
 				saveEditedEntityRecord( kind, name, recordId, {
 					throwOnError: true,

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -497,12 +497,7 @@ __experimentalGetTemplateForLink.shouldInvalidate = ( action ) => {
 		( action.type === 'RECEIVE_ITEMS' || action.type === 'REMOVE_ITEMS' ) &&
 		action.invalidateCache &&
 		action.kind === 'postType' &&
-		( action.name === 'wp_template' ||
-			// Invalidate when a template is updated.
-			( [ 'page', 'post' ].includes( action.name ) &&
-				Object.keys( action.persistedEdits || {} ).includes(
-					'template'
-				) ) )
+		action.name === 'wp_template'
 	);
 };
 

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -497,7 +497,12 @@ __experimentalGetTemplateForLink.shouldInvalidate = ( action ) => {
 		( action.type === 'RECEIVE_ITEMS' || action.type === 'REMOVE_ITEMS' ) &&
 		action.invalidateCache &&
 		action.kind === 'postType' &&
-		action.name === 'wp_template'
+		( action.name === 'wp_template' ||
+			// Invalidate when a template is updated.
+			( [ 'page', 'post' ].includes( action.name ) &&
+				Object.keys( action.persistedEdits || {} ).includes(
+					'template'
+				) ) )
 	);
 };
 

--- a/packages/edit-site/src/components/sidebar-edit-mode/page-panels/edit-template.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/page-panels/edit-template.js
@@ -61,7 +61,10 @@ export default function EditTemplate() {
 			<DropdownMenu
 				popoverProps={ POPOVER_PROPS }
 				focusOnMount
-				toggleProps={ { variant: 'tertiary' } }
+				toggleProps={ {
+					variant: 'tertiary',
+					className: 'edit-site-summary-field__trigger',
+				} }
 				label={ __( 'Template options' ) }
 				text={ decodeEntities( template.title ) }
 				icon={ null }

--- a/packages/edit-site/src/components/sidebar-edit-mode/page-panels/edit-template.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/page-panels/edit-template.js
@@ -62,7 +62,7 @@ export default function EditTemplate() {
 				popoverProps={ POPOVER_PROPS }
 				focusOnMount
 				toggleProps={ { variant: 'tertiary' } }
-				label={ decodeEntities( template.title ) }
+				label={ __( 'Template options' ) }
 				text={ decodeEntities( template.title ) }
 				icon={ null }
 			>

--- a/packages/edit-site/src/components/sidebar-edit-mode/page-panels/edit-template.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/page-panels/edit-template.js
@@ -2,21 +2,31 @@
  * WordPress dependencies
  */
 import { useSelect, useDispatch } from '@wordpress/data';
-import { useMemo } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
-import { BlockContextProvider, BlockPreview } from '@wordpress/block-editor';
-import { Button, __experimentalVStack as VStack } from '@wordpress/components';
+import {
+	DropdownMenu,
+	MenuGroup,
+	MenuItem,
+	__experimentalHStack as HStack,
+	__experimentalText as Text,
+} from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { store as coreStore } from '@wordpress/core-data';
-import { parse } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
  */
 import { store as editSiteStore } from '../../../store';
+import SwapTemplateButton from './swap-template-button';
+import ResetDefaultTemplate from './reset-default-template';
+
+const POPOVER_PROPS = {
+	className: 'edit-site-page-panels-edit-template__dropdown',
+	placement: 'bottom-start',
+};
 
 export default function EditTemplate() {
-	const { context, hasResolved, template } = useSelect( ( select ) => {
+	const { hasResolved, template } = useSelect( ( select ) => {
 		const { getEditedPostContext, getEditedPostType, getEditedPostId } =
 			select( editSiteStore );
 		const { getEditedEntityRecord, hasFinishedResolution } =
@@ -39,39 +49,40 @@ export default function EditTemplate() {
 
 	const { setHasPageContentFocus } = useDispatch( editSiteStore );
 
-	const blockContext = useMemo(
-		() => ( { ...context, postType: null, postId: null } ),
-		[ context ]
-	);
-
-	const blocks = useMemo(
-		() =>
-			template.blocks ??
-			( template.content && typeof template.content !== 'function'
-				? parse( template.content )
-				: [] ),
-		[ template.blocks, template.content ]
-	);
-
 	if ( ! hasResolved ) {
 		return null;
 	}
 
 	return (
-		<VStack>
-			<div>{ decodeEntities( template.title ) }</div>
-			<div className="edit-site-page-panels__edit-template-preview">
-				<BlockContextProvider value={ blockContext }>
-					<BlockPreview viewportWidth={ 1024 } blocks={ blocks } />
-				</BlockContextProvider>
-			</div>
-			<Button
-				className="edit-site-page-panels__edit-template-button"
-				variant="secondary"
-				onClick={ () => setHasPageContentFocus( false ) }
+		<HStack className="edit-site-summary-field">
+			<Text className="edit-site-summary-field__label">
+				{ __( 'Template' ) }
+			</Text>
+			<DropdownMenu
+				popoverProps={ POPOVER_PROPS }
+				focusOnMount
+				toggleProps={ { variant: 'tertiary' } }
+				label={ decodeEntities( template.title ) }
+				text={ decodeEntities( template.title ) }
+				icon={ null }
 			>
-				{ __( 'Edit template' ) }
-			</Button>
-		</VStack>
+				{ ( { onClose } ) => (
+					<>
+						<MenuGroup>
+							<MenuItem
+								onClick={ () => {
+									setHasPageContentFocus( false );
+									onClose();
+								} }
+							>
+								{ __( 'Edit template' ) }
+							</MenuItem>
+							<SwapTemplateButton onClick={ onClose } />
+						</MenuGroup>
+						<ResetDefaultTemplate onClick={ onClose } />
+					</>
+				) }
+			</DropdownMenu>
+		</HStack>
 	);
 }

--- a/packages/edit-site/src/components/sidebar-edit-mode/page-panels/hooks.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/page-panels/hooks.js
@@ -1,0 +1,68 @@
+/**
+ * WordPress dependencies
+ */
+import { useSelect } from '@wordpress/data';
+import { useMemo } from '@wordpress/element';
+import { store as coreStore } from '@wordpress/core-data';
+
+/**
+ * Internal dependencies
+ */
+import { store as editSiteStore } from '../../../store';
+
+export function useEditedPostContext() {
+	return useSelect(
+		( select ) => select( editSiteStore ).getEditedPostContext(),
+		[]
+	);
+}
+
+export function useIsPostsPage() {
+	const { postId } = useEditedPostContext();
+	return useSelect(
+		( select ) =>
+			+postId ===
+			select( coreStore ).getEntityRecord( 'root', 'site' )
+				?.page_for_posts,
+		[ postId ]
+	);
+}
+
+export function useAvailableTemplates() {
+	const currentTemplateSlug = useCurrentTemplateSlug();
+	const isPostsPage = useIsPostsPage();
+	const templates = useSelect(
+		( select ) =>
+			select( coreStore ).getEntityRecords( 'postType', 'wp_template', {
+				per_page: -1,
+			} ),
+		[]
+	);
+	return useMemo(
+		() =>
+			// The posts page template cannot be changed.
+			! isPostsPage &&
+			templates?.filter(
+				( template ) =>
+					template.is_custom &&
+					template.slug !== currentTemplateSlug &&
+					!! template.content.raw // Skip empty templates.
+			),
+		[ templates, currentTemplateSlug, isPostsPage ]
+	);
+}
+
+export function useCurrentTemplateSlug() {
+	const { postType, postId } = useEditedPostContext();
+	return useSelect(
+		( select ) => {
+			const post = select( coreStore ).getEntityRecord(
+				'postType',
+				postType,
+				postId
+			);
+			return post?.template;
+		},
+		[ postType, postId ]
+	);
+}

--- a/packages/edit-site/src/components/sidebar-edit-mode/page-panels/hooks.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/page-panels/hooks.js
@@ -28,16 +28,20 @@ export function useIsPostsPage() {
 	);
 }
 
-export function useAvailableTemplates() {
-	const currentTemplateSlug = useCurrentTemplateSlug();
-	const isPostsPage = useIsPostsPage();
-	const templates = useSelect(
+function useTemplates() {
+	return useSelect(
 		( select ) =>
 			select( coreStore ).getEntityRecords( 'postType', 'wp_template', {
 				per_page: -1,
 			} ),
 		[]
 	);
+}
+
+export function useAvailableTemplates() {
+	const currentTemplateSlug = useCurrentTemplateSlug();
+	const isPostsPage = useIsPostsPage();
+	const templates = useTemplates();
 	return useMemo(
 		() =>
 			// The posts page template cannot be changed.
@@ -54,9 +58,10 @@ export function useAvailableTemplates() {
 
 export function useCurrentTemplateSlug() {
 	const { postType, postId } = useEditedPostContext();
-	return useSelect(
+	const templates = useTemplates();
+	const entityTemplate = useSelect(
 		( select ) => {
-			const post = select( coreStore ).getEntityRecord(
+			const post = select( coreStore ).getEditedEntityRecord(
 				'postType',
 				postType,
 				postId
@@ -65,4 +70,13 @@ export function useCurrentTemplateSlug() {
 		},
 		[ postType, postId ]
 	);
+
+	if ( ! entityTemplate ) {
+		return;
+	}
+	// If a page has a `template` set and is not included in the list
+	// of the theme's templates, do not return it, in order to resolve
+	// to the current theme's default template.
+	return templates?.find( ( template ) => template.slug === entityTemplate )
+		?.slug;
 }

--- a/packages/edit-site/src/components/sidebar-edit-mode/page-panels/hooks.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/page-panels/hooks.js
@@ -33,6 +33,7 @@ function useTemplates() {
 		( select ) =>
 			select( coreStore ).getEntityRecords( 'postType', 'wp_template', {
 				per_page: -1,
+				post_type: 'page',
 			} ),
 		[]
 	);

--- a/packages/edit-site/src/components/sidebar-edit-mode/page-panels/index.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/page-panels/index.js
@@ -20,7 +20,6 @@ import { store as editSiteStore } from '../../../store';
 import SidebarCard from '../sidebar-card';
 import PageContent from './page-content';
 import PageSummary from './page-summary';
-import EditTemplate from './edit-template';
 
 export default function PagePanels() {
 	const { id, type, hasResolved, status, date, password, title, modified } =
@@ -80,9 +79,6 @@ export default function PagePanels() {
 			</PanelBody>
 			<PanelBody title={ __( 'Content' ) }>
 				<PageContent />
-			</PanelBody>
-			<PanelBody title={ __( 'Template' ) }>
-				<EditTemplate />
 			</PanelBody>
 		</>
 	);

--- a/packages/edit-site/src/components/sidebar-edit-mode/page-panels/page-summary.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/page-panels/page-summary.js
@@ -7,6 +7,7 @@ import { __experimentalVStack as VStack } from '@wordpress/components';
  */
 import PageStatus from './page-status';
 import PublishDate from './publish-date';
+import EditTemplate from './edit-template';
 
 export default function PageSummary( {
 	status,
@@ -30,6 +31,7 @@ export default function PageSummary( {
 				postId={ postId }
 				postType={ postType }
 			/>
+			<EditTemplate />
 		</VStack>
 	);
 }

--- a/packages/edit-site/src/components/sidebar-edit-mode/page-panels/reset-default-template.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/page-panels/reset-default-template.js
@@ -4,7 +4,6 @@
 import { useDispatch } from '@wordpress/data';
 import { MenuGroup, MenuItem } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { store as noticesStore } from '@wordpress/notices';
 import { useEntityRecord } from '@wordpress/core-data';
 
 /**
@@ -23,7 +22,6 @@ export default function ResetDefaultTemplate( { onClick } ) {
 	const { postType, postId } = useEditedPostContext();
 	const entitiy = useEntityRecord( 'postType', postType, postId );
 	const { setPage } = useDispatch( editSiteStore );
-	const { createSuccessNotice } = useDispatch( noticesStore );
 	// The default template in a post is indicated by an empty string.
 	if ( ! currentTemplateSlug || isPostsPage ) {
 		return null;
@@ -33,13 +31,9 @@ export default function ResetDefaultTemplate( { onClick } ) {
 			<MenuItem
 				onClick={ async () => {
 					entitiy.edit( { template: '' }, { undoIgnore: true } );
-					await entitiy.save();
 					onClick();
 					await setPage( {
 						context: { postType, postId },
-					} );
-					createSuccessNotice( __( 'Default template applied.' ), {
-						type: 'snackbar',
 					} );
 				} }
 			>

--- a/packages/edit-site/src/components/sidebar-edit-mode/page-panels/reset-default-template.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/page-panels/reset-default-template.js
@@ -1,0 +1,50 @@
+/**
+ * WordPress dependencies
+ */
+import { useDispatch } from '@wordpress/data';
+import { MenuGroup, MenuItem } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { store as noticesStore } from '@wordpress/notices';
+import { useEntityRecord } from '@wordpress/core-data';
+
+/**
+ * Internal dependencies
+ */
+import {
+	useCurrentTemplateSlug,
+	useEditedPostContext,
+	useIsPostsPage,
+} from './hooks';
+import { store as editSiteStore } from '../../../store';
+
+export default function ResetDefaultTemplate( { onClick } ) {
+	const currentTemplateSlug = useCurrentTemplateSlug();
+	const isPostsPage = useIsPostsPage();
+	const { postType, postId } = useEditedPostContext();
+	const entitiy = useEntityRecord( 'postType', postType, postId );
+	const { setPage } = useDispatch( editSiteStore );
+	const { createSuccessNotice } = useDispatch( noticesStore );
+	// The default template in a post is indicated by an empty string.
+	if ( ! currentTemplateSlug || isPostsPage ) {
+		return null;
+	}
+	return (
+		<MenuGroup>
+			<MenuItem
+				onClick={ async () => {
+					entitiy.edit( { template: '' }, { undoIgnore: true } );
+					await entitiy.save();
+					onClick();
+					await setPage( {
+						context: { postType, postId },
+					} );
+					createSuccessNotice( __( 'Default template applied.' ), {
+						type: 'snackbar',
+					} );
+				} }
+			>
+				{ __( 'Reset' ) }
+			</MenuItem>
+		</MenuGroup>
+	);
+}

--- a/packages/edit-site/src/components/sidebar-edit-mode/page-panels/reset-default-template.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/page-panels/reset-default-template.js
@@ -20,7 +20,7 @@ export default function ResetDefaultTemplate( { onClick } ) {
 	const currentTemplateSlug = useCurrentTemplateSlug();
 	const isPostsPage = useIsPostsPage();
 	const { postType, postId } = useEditedPostContext();
-	const entitiy = useEntityRecord( 'postType', postType, postId );
+	const entity = useEntityRecord( 'postType', postType, postId );
 	const { setPage } = useDispatch( editSiteStore );
 	// The default template in a post is indicated by an empty string.
 	if ( ! currentTemplateSlug || isPostsPage ) {
@@ -30,7 +30,7 @@ export default function ResetDefaultTemplate( { onClick } ) {
 		<MenuGroup>
 			<MenuItem
 				onClick={ async () => {
-					entitiy.edit( { template: '' }, { undoIgnore: true } );
+					entity.edit( { template: '' }, { undoIgnore: true } );
 					onClick();
 					await setPage( {
 						context: { postType, postId },

--- a/packages/edit-site/src/components/sidebar-edit-mode/page-panels/style.scss
+++ b/packages/edit-site/src/components/sidebar-edit-mode/page-panels/style.scss
@@ -1,12 +1,33 @@
-.edit-site-page-panels__edit-template-preview {
-	border: 1px solid $gray-200;
-	height: 200px;
-	max-height: 200px;
-	overflow: hidden;
+.edit-site-page-panels__swap-template__confirm-modal__actions {
+	margin-top: $grid-unit-30;
 }
 
-.edit-site-page-panels__edit-template-button {
-	justify-content: center;
+.edit-site-page-panels__swap-template__modal-content .block-editor-block-patterns-list {
+	column-count: 2;
+	column-gap: $grid-unit-30;
+
+	// Small top padding required to avoid cutting off the visible outline when hovering items
+	padding-top: $border-width-focus-fallback;
+
+	@include break-medium() {
+		column-count: 3;
+	}
+
+	@include break-wide() {
+		column-count: 4;
+	}
+
+	.block-editor-block-patterns-list__list-item {
+		break-inside: avoid-column;
+	}
+
+	.block-editor-block-patterns-list__item {
+		// Avoid to override the BlockPatternList component
+		// default hover and focus styles.
+		&:not(:focus):not(:hover) .block-editor-block-preview__container {
+			box-shadow: 0 0 0 1px $gray-300;
+		}
+	}
 }
 
 .edit-site-change-status__content {
@@ -47,4 +68,3 @@
 		width: 30%;
 	}
 }
-

--- a/packages/edit-site/src/components/sidebar-edit-mode/page-panels/style.scss
+++ b/packages/edit-site/src/components/sidebar-edit-mode/page-panels/style.scss
@@ -57,11 +57,18 @@
 
 .edit-site-summary-field {
 	.components-dropdown {
-		flex-grow: 1;
+		width: 70%;
 	}
 
 	.edit-site-summary-field__trigger {
-		width: 100%;
+		max-width: 100%;
+
+		// Truncate
+		display: block;
+		text-align: left;
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
 	}
 
 	.edit-site-summary-field__label {

--- a/packages/edit-site/src/components/sidebar-edit-mode/page-panels/style.scss
+++ b/packages/edit-site/src/components/sidebar-edit-mode/page-panels/style.scss
@@ -1,3 +1,7 @@
+.edit-site-swap-template-modal {
+	z-index: z-index(".edit-site-swap-template-modal");
+}
+
 .edit-site-page-panels__swap-template__confirm-modal__actions {
 	margin-top: $grid-unit-30;
 }

--- a/packages/edit-site/src/components/sidebar-edit-mode/page-panels/swap-template-button.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/page-panels/swap-template-button.js
@@ -5,10 +5,9 @@ import { useDispatch } from '@wordpress/data';
 import { useMemo, useState, useCallback } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
 import { __experimentalBlockPatternsList as BlockPatternsList } from '@wordpress/block-editor';
-import { MenuItem, Modal, Button, Flex, FlexItem } from '@wordpress/components';
-import { __, sprintf } from '@wordpress/i18n';
+import { MenuItem, Modal } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
 import { useEntityRecord } from '@wordpress/core-data';
-import { store as noticesStore } from '@wordpress/notices';
 import { parse } from '@wordpress/blocks';
 import { useAsyncList } from '@wordpress/compose';
 
@@ -18,52 +17,25 @@ import { useAsyncList } from '@wordpress/compose';
 import { store as editSiteStore } from '../../../store';
 import { useAvailableTemplates, useEditedPostContext } from './hooks';
 
-const modalContentMap = {
-	templatesList: 1,
-	confirmSwap: 2,
-};
-
-export default function SwapTemplateButton() {
-	const [ selectedTemplate, setSelectedTemplate ] = useState();
+export default function SwapTemplateButton( { onClick } ) {
 	const [ showModal, setShowModal ] = useState( false );
-	const [ modalContent, setModalContent ] = useState(
-		modalContentMap.templatesList
-	);
 	const availableTemplates = useAvailableTemplates();
 	const onClose = useCallback( () => {
 		setShowModal( false );
-		setModalContent( modalContentMap.templatesList );
 	}, [] );
 	const { postType, postId } = useEditedPostContext();
 	const entitiy = useEntityRecord( 'postType', postType, postId );
 	const { setPage } = useDispatch( editSiteStore );
-	const { createSuccessNotice } = useDispatch( noticesStore );
 	if ( ! availableTemplates?.length ) {
 		return null;
 	}
-	const modalTitle =
-		modalContent === modalContentMap.templatesList
-			? __( 'Choose a template' )
-			: sprintf(
-					/* translators: The page's title. */
-					__( 'Save "%s"?' ),
-					decodeEntities( entitiy.record.title.rendered )
-			  );
-	const onConfirmSwap = async ( template ) => {
+	const onTemplateSelect = async ( template ) => {
 		entitiy.edit( { template: template.name }, { undoIgnore: true } );
-		await entitiy.save();
 		onClose();
+		onClick();
 		await setPage( {
 			context: { postType, postId },
 		} );
-		createSuccessNotice(
-			sprintf(
-				/* translators: The page's title. */
-				__( '"%s" applied.' ),
-				decodeEntities( template.title )
-			),
-			{ type: 'snackbar' }
-		);
 	};
 	return (
 		<>
@@ -72,56 +44,13 @@ export default function SwapTemplateButton() {
 			</MenuItem>
 			{ showModal && (
 				<Modal
-					title={ modalTitle }
+					title={ __( 'Choose a template' ) }
 					onRequestClose={ onClose }
-					isFullScreen={
-						modalContent === modalContentMap.templatesList
-					}
+					isFullScreen
 				>
-					{ modalContent === modalContentMap.templatesList && (
-						<div className="edit-site-page-panels__swap-template__modal-content">
-							<TemplatesList
-								onSelect={ ( template ) => {
-									setModalContent(
-										modalContentMap.confirmSwap
-									);
-									setSelectedTemplate( template );
-								} }
-							/>
-						</div>
-					) }
-					{ modalContent === modalContentMap.confirmSwap && (
-						<>
-							{ __(
-								'Template swaps are published immediately.'
-							) }
-							<Flex
-								className="edit-site-page-panels__swap-template__confirm-modal__actions"
-								justify="flex-end"
-								expanded={ false }
-							>
-								<FlexItem>
-									<Button
-										variant="tertiary"
-										onClick={ onClose }
-									>
-										{ __( 'Cancel' ) }
-									</Button>
-								</FlexItem>
-								<FlexItem>
-									<Button
-										variant="primary"
-										type="submit"
-										onClick={ () =>
-											onConfirmSwap( selectedTemplate )
-										}
-									>
-										{ __( 'Save' ) }
-									</Button>
-								</FlexItem>
-							</Flex>
-						</>
-					) }
+					<div className="edit-site-page-panels__swap-template__modal-content">
+						<TemplatesList onSelect={ onTemplateSelect } />
+					</div>
 				</Modal>
 			) }
 		</>

--- a/packages/edit-site/src/components/sidebar-edit-mode/page-panels/swap-template-button.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/page-panels/swap-template-button.js
@@ -1,0 +1,152 @@
+/**
+ * WordPress dependencies
+ */
+import { useDispatch } from '@wordpress/data';
+import { useMemo, useState, useCallback } from '@wordpress/element';
+import { decodeEntities } from '@wordpress/html-entities';
+import { __experimentalBlockPatternsList as BlockPatternsList } from '@wordpress/block-editor';
+import { MenuItem, Modal, Button, Flex, FlexItem } from '@wordpress/components';
+import { __, sprintf } from '@wordpress/i18n';
+import { useEntityRecord } from '@wordpress/core-data';
+import { store as noticesStore } from '@wordpress/notices';
+import { parse } from '@wordpress/blocks';
+import { useAsyncList } from '@wordpress/compose';
+
+/**
+ * Internal dependencies
+ */
+import { store as editSiteStore } from '../../../store';
+import { useAvailableTemplates, useEditedPostContext } from './hooks';
+
+const modalContentMap = {
+	templatesList: 1,
+	confirmSwap: 2,
+};
+
+export default function SwapTemplateButton() {
+	const [ selectedTemplate, setSelectedTemplate ] = useState();
+	const [ showModal, setShowModal ] = useState( false );
+	const [ modalContent, setModalContent ] = useState(
+		modalContentMap.templatesList
+	);
+	const availableTemplates = useAvailableTemplates();
+	const onClose = useCallback( () => {
+		setShowModal( false );
+		setModalContent( modalContentMap.templatesList );
+	}, [] );
+	const { postType, postId } = useEditedPostContext();
+	const entitiy = useEntityRecord( 'postType', postType, postId );
+	const { setPage } = useDispatch( editSiteStore );
+	const { createSuccessNotice } = useDispatch( noticesStore );
+	if ( ! availableTemplates?.length ) {
+		return null;
+	}
+	const modalTitle =
+		modalContent === modalContentMap.templatesList
+			? __( 'Choose a template' )
+			: sprintf(
+					/* translators: The page's title. */
+					__( 'Save "%s"?' ),
+					decodeEntities( entitiy.record.title.rendered )
+			  );
+	const onConfirmSwap = async ( template ) => {
+		entitiy.edit( { template: template.name }, { undoIgnore: true } );
+		await entitiy.save();
+		onClose();
+		await setPage( {
+			context: { postType, postId },
+		} );
+		createSuccessNotice(
+			sprintf(
+				/* translators: The page's title. */
+				__( '"%s" applied.' ),
+				decodeEntities( template.title )
+			),
+			{ type: 'snackbar' }
+		);
+	};
+	return (
+		<>
+			<MenuItem onClick={ () => setShowModal( true ) }>
+				{ __( 'Swap template' ) }
+			</MenuItem>
+			{ showModal && (
+				<Modal
+					title={ modalTitle }
+					onRequestClose={ onClose }
+					isFullScreen={
+						modalContent === modalContentMap.templatesList
+					}
+				>
+					{ modalContent === modalContentMap.templatesList && (
+						<div className="edit-site-page-panels__swap-template__modal-content">
+							<TemplatesList
+								onSelect={ ( template ) => {
+									setModalContent(
+										modalContentMap.confirmSwap
+									);
+									setSelectedTemplate( template );
+								} }
+							/>
+						</div>
+					) }
+					{ modalContent === modalContentMap.confirmSwap && (
+						<>
+							{ __(
+								'Template swaps are published immediately.'
+							) }
+							<Flex
+								className="edit-site-page-panels__swap-template__confirm-modal__actions"
+								justify="flex-end"
+								expanded={ false }
+							>
+								<FlexItem>
+									<Button
+										variant="tertiary"
+										onClick={ onClose }
+									>
+										{ __( 'Cancel' ) }
+									</Button>
+								</FlexItem>
+								<FlexItem>
+									<Button
+										variant="primary"
+										type="submit"
+										onClick={ () =>
+											onConfirmSwap( selectedTemplate )
+										}
+									>
+										{ __( 'Save' ) }
+									</Button>
+								</FlexItem>
+							</Flex>
+						</>
+					) }
+				</Modal>
+			) }
+		</>
+	);
+}
+
+function TemplatesList( { onSelect } ) {
+	const availableTemplates = useAvailableTemplates();
+	const templatesAsPatterns = useMemo(
+		() =>
+			availableTemplates.map( ( template ) => ( {
+				name: template.slug,
+				blocks: parse( template.content.raw ),
+				title: decodeEntities( template.title.rendered ),
+				id: template.id,
+			} ) ),
+		[ availableTemplates ]
+	);
+	const shownTemplates = useAsyncList( templatesAsPatterns );
+	return (
+		<BlockPatternsList
+			label={ __( 'Templates' ) }
+			blockPatterns={ templatesAsPatterns }
+			shownPatterns={ shownTemplates }
+			onClickPattern={ onSelect }
+		/>
+	);
+}

--- a/packages/edit-site/src/components/sidebar-edit-mode/page-panels/swap-template-button.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/page-panels/swap-template-button.js
@@ -31,11 +31,11 @@ export default function SwapTemplateButton( { onClick } ) {
 	}
 	const onTemplateSelect = async ( template ) => {
 		entitiy.edit( { template: template.name }, { undoIgnore: true } );
-		onClose();
-		onClick();
 		await setPage( {
 			context: { postType, postId },
 		} );
+		onClose(); // Close the template suggestions modal first.
+		onClick();
 	};
 	return (
 		<>

--- a/packages/edit-site/src/components/sidebar-edit-mode/page-panels/swap-template-button.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/page-panels/swap-template-button.js
@@ -46,6 +46,7 @@ export default function SwapTemplateButton( { onClick } ) {
 				<Modal
 					title={ __( 'Choose a template' ) }
 					onRequestClose={ onClose }
+					overlayClassName="edit-site-swap-template-modal"
 					isFullScreen
 				>
 					<div className="edit-site-page-panels__swap-template__modal-content">

--- a/packages/edit-site/src/store/actions.js
+++ b/packages/edit-site/src/store/actions.js
@@ -233,7 +233,7 @@ export function setHomeTemplateId() {
  *
  * @param {Object} context The context object.
  *
- * @return {number} The resolved template ID for the page route.
+ * @return {Object} Action object.
  */
 export function setEditedPostContext( context ) {
 	return {
@@ -268,7 +268,6 @@ export const setPage =
 			// If the entity is undefined for some reason, path will resolve to "/"
 			page.path = getPathAndQueryString( entity?.link );
 		}
-
 		const template = await registry
 			.resolveSelect( coreStore )
 			.__experimentalGetTemplateForLink( page.path );

--- a/test/e2e/specs/site-editor/pages.spec.js
+++ b/test/e2e/specs/site-editor/pages.spec.js
@@ -3,33 +3,48 @@
  */
 const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 
+async function draftNewPage( page ) {
+	await page.getByRole( 'button', { name: 'Pages' } ).click();
+	await page.getByRole( 'button', { name: 'Draft a new page' } ).click();
+	await page
+		.locator( 'role=dialog[name="Draft a new page"i]' )
+		.locator( 'role=textbox[name="Page title"i]' )
+		.fill( 'Test Page' );
+	await page.keyboard.press( 'Enter' );
+	await expect(
+		page.locator(
+			`role=button[name="Dismiss this notice"i] >> text='"Test Page" successfully created.'`
+		)
+	).toBeVisible();
+}
+
 test.describe( 'Pages', () => {
 	test.beforeAll( async ( { requestUtils } ) => {
 		await requestUtils.activateTheme( 'emptytheme' );
+		await Promise.all( [
+			requestUtils.deleteAllTemplates( 'wp_template' ),
+			requestUtils.deleteAllPages(),
+		] );
 	} );
 
 	test.afterAll( async ( { requestUtils } ) => {
 		await requestUtils.activateTheme( 'twentytwentyone' );
+		await Promise.all( [
+			requestUtils.deleteAllTemplates( 'wp_template' ),
+			requestUtils.deleteAllPages(),
+		] );
 	} );
 
-	test.beforeEach( async ( { admin } ) => {
+	test.beforeEach( async ( { requestUtils, admin } ) => {
+		await Promise.all( [
+			requestUtils.deleteAllTemplates( 'wp_template' ),
+			requestUtils.deleteAllPages(),
+		] );
 		await admin.visitSiteEditor();
 	} );
 
 	test( 'create a new page', async ( { page, editor } ) => {
-		// Draft a new page.
-		await page.getByRole( 'button', { name: 'Pages' } ).click();
-		await page.getByRole( 'button', { name: 'Draft a new page' } ).click();
-		await page
-			.locator( 'role=dialog[name="Draft a new page"i]' )
-			.locator( 'role=textbox[name="Page title"i]' )
-			.fill( 'Test Page' );
-		await page.keyboard.press( 'Enter' );
-		await expect(
-			page.locator(
-				`role=button[name="Dismiss this notice"i] >> text='"Test Page" successfully created.'`
-			)
-		).toBeVisible();
+		await draftNewPage( page );
 
 		// Insert into Page Content using default block.
 		await editor.canvas
@@ -79,15 +94,11 @@ test.describe( 'Pages', () => {
 
 		// Switch to template editing focus.
 		await editor.openDocumentSettingsSidebar();
-		await expect(
-			page.locator(
-				'.edit-site-page-panels__edit-template-preview iframe'
-			)
-		).toBeVisible();
 		await page
 			.getByRole( 'region', { name: 'Editor settings' } )
-			.getByRole( 'button', { name: 'Edit template' } )
+			.getByRole( 'button', { name: 'Template options' } )
 			.click();
+		await page.getByRole( 'button', { name: 'Edit template' } ).click();
 		await expect(
 			editor.canvas.getByRole( 'document', {
 				name: 'Block: Content',
@@ -124,5 +135,63 @@ test.describe( 'Pages', () => {
 				'role=region[name="Save panel"] >> role=checkbox[name="Test Page"]'
 			)
 		).toBeVisible();
+	} );
+	test( 'swap template and reset to default', async ( {
+		admin,
+		page,
+		editor,
+	} ) => {
+		// Create a custom template first.
+		const templateName = 'demo';
+		await page.getByRole( 'button', { name: 'Templates' } ).click();
+		await page.getByRole( 'button', { name: 'Add New Template' } ).click();
+		await page
+			.getByRole( 'button', {
+				name: 'A custom template can be manually applied to any post or page.',
+			} )
+			.click();
+		// Fill the template title and submit.
+		const newTemplateDialog = page.locator(
+			'role=dialog[name="Create custom template"i]'
+		);
+		const templateNameInput = newTemplateDialog.locator(
+			'role=textbox[name="Name"i]'
+		);
+		await templateNameInput.fill( templateName );
+		await page.keyboard.press( 'Enter' );
+		await page
+			.locator( '.block-editor-block-patterns-list__list-item' )
+			.click();
+		await editor.saveSiteEditorEntities();
+		await admin.visitSiteEditor();
+
+		// Create new page that has the default template so as to swap it.
+		await draftNewPage( page );
+		await editor.openDocumentSettingsSidebar();
+		const templateOptionsButton = page
+			.getByRole( 'region', { name: 'Editor settings' } )
+			.getByRole( 'button', { name: 'Template options' } );
+		await expect( templateOptionsButton ).toHaveText( 'Single Entries' );
+		await templateOptionsButton.click();
+		await page
+			.getByRole( 'menu', { name: 'Template options' } )
+			.getByText( 'Swap template' )
+			.click();
+		await page
+			.locator( '.block-editor-block-patterns-list__item-title', {
+				name: 'demo',
+			} )
+			.click();
+		await expect( templateOptionsButton ).toHaveText( 'demo' );
+		await editor.saveSiteEditorEntities();
+
+		// Now reset, and apply the default template back.
+		await templateOptionsButton.click();
+		const resetButton = page
+			.getByRole( 'menu', { name: 'Template options' } )
+			.getByText( 'Reset' );
+		await expect( resetButton ).toBeVisible();
+		await resetButton.click();
+		await expect( templateOptionsButton ).toHaveText( 'Single Entries' );
 	} );
 } );

--- a/test/e2e/specs/site-editor/pages.spec.js
+++ b/test/e2e/specs/site-editor/pages.spec.js
@@ -177,11 +177,12 @@ test.describe( 'Pages', () => {
 			.getByRole( 'menu', { name: 'Template options' } )
 			.getByText( 'Swap template' )
 			.click();
-		await page
-			.locator( '.block-editor-block-patterns-list__item-title', {
-				name: 'demo',
-			} )
-			.click();
+		const templateItem = page.locator(
+			'.block-editor-block-patterns-list__item-title'
+		);
+		// Empty theme's custom template with `postTypes: ['post']`, should not be suggested.
+		await expect( templateItem ).toHaveCount( 1 );
+		await templateItem.click();
 		await expect( templateOptionsButton ).toHaveText( 'demo' );
 		await editor.saveSiteEditorEntities();
 
@@ -193,5 +194,23 @@ test.describe( 'Pages', () => {
 		await expect( resetButton ).toBeVisible();
 		await resetButton.click();
 		await expect( templateOptionsButton ).toHaveText( 'Single Entries' );
+	} );
+	test( 'swap template options should respect the declared `postTypes`', async ( {
+		page,
+		editor,
+	} ) => {
+		await draftNewPage( page );
+		await editor.openDocumentSettingsSidebar();
+		const templateOptionsButton = page
+			.getByRole( 'region', { name: 'Editor settings' } )
+			.getByRole( 'button', { name: 'Template options' } );
+		await templateOptionsButton.click();
+		// Empty theme has only one custom template with `postTypes: ['post']`,
+		// so it should not be suggested.
+		await expect(
+			page
+				.getByRole( 'menu', { name: 'Template options' } )
+				.getByText( 'Swap template' )
+		).toHaveCount( 0 );
 	} );
 } );

--- a/test/emptytheme/templates/custom-template.html
+++ b/test/emptytheme/templates/custom-template.html
@@ -1,0 +1,3 @@
+<!-- wp:heading -->
+<h2 class="wp-block-heading">Custom template for Posts</h2>
+<!-- /wp:heading -->

--- a/test/emptytheme/theme.json
+++ b/test/emptytheme/theme.json
@@ -8,5 +8,12 @@
 			"wideSize": "1100px"
 		}
 	},
+	"customTemplates": [
+		{
+			"name": "custom-template",
+			"title": "Custom",
+			"postTypes": [ "post" ]
+		}
+	],
 	"patterns": [ "short-text-surrounded-by-round-images", "partner-logos" ]
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Resolves: https://github.com/WordPress/gutenberg/issues/51347

This is the first iteration to add the ability to switch templates in site editor's page inspector. Currently we show the `swap template` button if we have custom templates. Additionally we skip showing the button if we have only one custom template that is already assigned to the page.


## How?

For showing the templates list we use the `BlockPatternsList` component that handles many things already, like keyboard navigation, and for styling consistency with similar modal. Also in the future we could suggest patterns and create custom templates on the fly.

The challenging thing for me was that while we need to edit one entity(`page`), we also need to update the current block editors' edited entity(`template`). That's why I added the `setEditedPost` action, to update both at once. Furthermore the `undo` functionality was added through the `snackbar` because the specific `undo` needs a side effect(to update the edited entity). I'm open to suggestions for alternatives or something better. 





## Testing Instructions
1. Observe that with no custom templates or a single template assigned to the specific page being tested, the swap button doesn't appear
2. Have multiple custom templates and by clicking the `swap template` button the changes are applied and the `undo` in snackbar works properly.



## Screenshots or screencast <!-- if applicable -->


https://github.com/WordPress/gutenberg/assets/16275880/de612ac5-397b-43cc-9097-ae965e9a14c8


