### PR TITLE
Try to fix infinite growing block previews

### DIFF
--- a/packages/compose/src/hooks/use-resize-observer/index.tsx
+++ b/packages/compose/src/hooks/use-resize-observer/index.tsx
@@ -319,6 +319,9 @@ function useResizeObserver< T extends HTMLElement >(
  * Hook which allows to listen the resize event of any target element when it changes sizes.
  * _Note: `useResizeObserver` will report `null` until after first render.
  *
+ * @param options          - Options to configure the hook.
+ * @param options.onResize - Callback to be called when the size changes.
+ *
  * @example
  *
  * ```js
@@ -334,11 +337,10 @@ function useResizeObserver< T extends HTMLElement >(
  * };
  * ```
  */
-export default function useResizeAware(): [
-	WPElement,
-	{ width: number | null; height: number | null }
-] {
-	const { ref, width, height } = useResizeObserver();
+export default function useResizeAware( options?: {
+	onResize?: ResizeHandler;
+} ): [ WPElement, { width: number | null; height: number | null } ] {
+	const { ref, width, height } = useResizeObserver( options );
 	const sizes = useMemo( () => {
 		return { width: width ?? null, height: height ?? null };
 	}, [ width, height ] );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
See https://github.com/WordPress/gutenberg/issues/50449#issuecomment-1590514366. It's still only a draft PR for demonstration. Hopefully, when it's ready, it can fix https://github.com/WordPress/gutenberg/issues/50449 and https://github.com/WordPress/gutenberg/issues/43865. Related to https://github.com/WordPress/gutenberg/pull/38181#issuecomment-1021835774.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The growing block previews experience is a weird UX 😅 .

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
There are no perfect solutions. We can't force **every** block preview to render it's full content inside a iframe, because it might have a `120vh` element that keeps pushing the height of the iframe.

Instead, what this PR is trying to do is to render a "more content" indicator for previews that still keep growing after loaded.

The actual design is TBD and **should** be changed though 😅 . This PR is just a naive approach.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
1. Open a post
2. Open the inserter
3. Click on the "Banners" category
4. Check that the "Cover Poster on Left, Paragraph on Right" pattern stops growing after a certain height
5. And it shows a white gradient background at the bottom indicating there's more content.

## Screenshots or screencast <!-- if applicable -->
![image](https://github.com/WordPress/gutenberg/assets/7753001/6c41baf0-3050-47ad-99d5-f586457e372f)
