### PR TITLE
Add Navigation Menus to Template Parts screen sidebar in Browse Mode

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/index.js
@@ -1,9 +1,6 @@
 /**
  * WordPress dependencies
  */
-/**
- * Internal dependencies
- */
 import { useEntityRecord, store as coreStore } from '@wordpress/core-data';
 import {
 	__experimentalUseNavigator as useNavigator,

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/index.js
@@ -1,6 +1,9 @@
 /**
  * WordPress dependencies
  */
+/**
+ * Internal dependencies
+ */
 import { useEntityRecord, store as coreStore } from '@wordpress/core-data';
 import {
 	__experimentalUseNavigator as useNavigator,
@@ -9,7 +12,6 @@ import {
 import { __, sprintf } from '@wordpress/i18n';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { decodeEntities } from '@wordpress/html-entities';
-
 import { store as noticesStore } from '@wordpress/notices';
 
 /**
@@ -18,8 +20,6 @@ import { store as noticesStore } from '@wordpress/notices';
 import { SidebarNavigationScreenWrapper } from '../sidebar-navigation-screen-navigation-menus';
 import ScreenNavigationMoreMenu from './more-menu';
 import NavigationMenuEditor from './navigation-menu-editor';
-
-export const noop = () => {};
 
 export default function SidebarNavigationScreenNavigationMenu() {
 	const {
@@ -229,7 +229,7 @@ export default function SidebarNavigationScreenNavigationMenu() {
 				'Navigation menus are a curated collection of blocks that allow visitors to get around your site.'
 			) }
 		>
-			<NavigationMenuEditor navigationMenu={ navigationMenu } />
+			<NavigationMenuEditor navigationMenuId={ navigationMenu?.id } />
 		</SidebarNavigationScreenWrapper>
 	);
 }

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/navigation-menu-editor.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/navigation-menu-editor.js
@@ -6,7 +6,6 @@ import { useSelect } from '@wordpress/data';
 import { BlockEditorProvider } from '@wordpress/block-editor';
 import { createBlock } from '@wordpress/blocks';
 import { privateApis as routerPrivateApis } from '@wordpress/router';
-
 /**
  * Internal dependencies
  */
@@ -17,11 +16,12 @@ import {
 	currentlyPreviewingTheme,
 } from '../../utils/is-previewing-theme';
 import NavigationMenuContent from '../sidebar-navigation-screen-navigation-menus/navigation-menu-content';
-import { noop } from '.';
 
 const { useHistory } = unlock( routerPrivateApis );
 
-export default function NavigationMenuEditor( { navigationMenu } ) {
+const noop = () => {};
+
+export default function NavigationMenuEditor( { navigationMenuId } ) {
 	const history = useHistory();
 
 	const onSelect = useCallback(
@@ -63,16 +63,14 @@ export default function NavigationMenuEditor( { navigationMenu } ) {
 	}, [] );
 
 	const blocks = useMemo( () => {
-		if ( ! navigationMenu ) {
+		if ( ! navigationMenuId ) {
 			return [];
 		}
 
-		return [
-			createBlock( 'core/navigation', { ref: navigationMenu?.id } ),
-		];
-	}, [ navigationMenu ] );
+		return [ createBlock( 'core/navigation', { ref: navigationMenuId } ) ];
+	}, [ navigationMenuId ] );
 
-	if ( ! navigationMenu || ! blocks?.length ) {
+	if ( ! navigationMenuId || ! blocks?.length ) {
 		return null;
 	}
 

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/navigation-menu-editor.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/navigation-menu-editor.js
@@ -6,16 +6,17 @@ import { useSelect } from '@wordpress/data';
 import { BlockEditorProvider } from '@wordpress/block-editor';
 import { createBlock } from '@wordpress/blocks';
 import { privateApis as routerPrivateApis } from '@wordpress/router';
+
 /**
  * Internal dependencies
  */
 import { unlock } from '../../lock-unlock';
 import { store as editSiteStore } from '../../store';
+import NavigationMenuContent from '../sidebar-navigation-screen-navigation-menus/navigation-menu-content';
 import {
 	isPreviewingTheme,
 	currentlyPreviewingTheme,
 } from '../../utils/is-previewing-theme';
-import NavigationMenuContent from '../sidebar-navigation-screen-navigation-menus/navigation-menu-content';
 
 const { useHistory } = unlock( routerPrivateApis );
 

--- a/packages/edit-site/src/components/sidebar-navigation-screen-template-part/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-template-part/index.js
@@ -93,7 +93,7 @@ export default function SidebarNavigationScreenTemplatePart() {
 		postId
 	);
 
-	const navigationBlocks = getBlocksFromBlocks(
+	const navigationBlocks = getBlocksOfTypeFromBlocks(
 		'core/navigation',
 		record?.blocks
 	);
@@ -123,13 +123,13 @@ export default function SidebarNavigationScreenTemplatePart() {
 }
 
 /**
- * Retrieves a list of specific blocks from a given set of blocks.
+ * Retrieves a list of specific blocks from a given tree of blocks.
  *
  * @param {string} targetBlock the name of the block to find.
  * @param {Array}  blocks      a list of blocks from the template part entity.
  * @return {Array} a list of any navigation blocks found in the blocks.
  */
-function getBlocksFromBlocks( targetBlock, blocks ) {
+function getBlocksOfTypeFromBlocks( targetBlock, blocks ) {
 	if ( ! targetBlock || ! blocks?.length ) return [];
 
 	const findInBlocks = ( _blocks ) => {

--- a/packages/edit-site/src/components/sidebar-navigation-screen-template-part/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-template-part/index.js
@@ -20,11 +20,14 @@ import { store as editSiteStore } from '../../store';
 import SidebarButton from '../sidebar-button';
 import { useAddedBy } from '../list/added-by';
 
+import TemplatePartNavigationMenus from './template-part-navigation-menus';
+
 function useTemplateTitleAndDescription( postType, postId ) {
 	const { getDescription, getTitle, record } = useEditedEntityRecord(
 		postType,
 		postId
 	);
+
 	const currentTheme = useSelect(
 		( select ) => select( coreStore ).getCurrentTheme(),
 		[]
@@ -82,10 +85,24 @@ export default function SidebarNavigationScreenTemplatePart() {
 	const { params } = useNavigator();
 	const { postType, postId } = params;
 	const { setCanvasMode } = unlock( useDispatch( editSiteStore ) );
+
+	const { record } = useEditedEntityRecord( postType, postId );
+
 	const { title, description } = useTemplateTitleAndDescription(
 		postType,
 		postId
 	);
+
+	const navigationBlocks = getBlocksFromBlocks(
+		'core/navigation',
+		record?.blocks
+	);
+
+	// Get a list of the navigation menu ids from the navigation blocks'
+	// ref attribute.
+	const navigationMenuIds = navigationBlocks?.map( ( block ) => {
+		return block.attributes.ref;
+	} );
 
 	return (
 		<SidebarNavigationScreen
@@ -98,6 +115,46 @@ export default function SidebarNavigationScreenTemplatePart() {
 				/>
 			}
 			description={ description }
+			content={
+				<TemplatePartNavigationMenus menus={ navigationMenuIds } />
+			}
 		/>
 	);
+}
+
+/**
+ * Retrieves a list of specific blocks from a given set of blocks.
+ *
+ * @param {string} targetBlock the name of the block to find.
+ * @param {Array}  blocks      a list of blocks from the template part entity.
+ * @return {Array} a list of any navigation blocks found in the blocks.
+ */
+function getBlocksFromBlocks( targetBlock, blocks ) {
+	if ( ! targetBlock || ! blocks?.length ) return [];
+
+	const findInBlocks = ( _blocks ) => {
+		if ( ! _blocks ) {
+			return [];
+		}
+
+		const navigationBlocks = [];
+
+		for ( const block of _blocks ) {
+			if ( block.name === targetBlock ) {
+				navigationBlocks.push( block );
+			}
+
+			if ( block?.innerBlocks ) {
+				const innerNavigationBlocks = findInBlocks( block.innerBlocks );
+
+				if ( innerNavigationBlocks.length ) {
+					navigationBlocks.push( ...innerNavigationBlocks );
+				}
+			}
+		}
+
+		return navigationBlocks;
+	};
+
+	return findInBlocks( blocks );
 }

--- a/packages/edit-site/src/components/sidebar-navigation-screen-template-part/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-template-part/style.scss
@@ -1,0 +1,3 @@
+.edit-site-sidebar-navigation-screen-template-part-navigation-menu__title.components-heading {
+	margin-bottom: $grid-unit-10;
+}

--- a/packages/edit-site/src/components/sidebar-navigation-screen-template-part/template-part-navigation-menu-list-item.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-template-part/template-part-navigation-menu-list-item.js
@@ -1,0 +1,26 @@
+/**
+ * WordPress dependencies
+ */
+import { useEntityProp } from '@wordpress/core-data';
+/**
+ * Internal dependencies
+ */
+import SidebarNavigationItem from '../sidebar-navigation-item';
+import { useLink } from '../routes/link';
+
+export default function TemplatePartNavigationMenuListItem( { id } ) {
+	const [ title ] = useEntityProp( 'postType', 'wp_navigation', 'title', id );
+
+	const linkInfo = useLink( {
+		postId: id,
+		postType: 'wp_navigation',
+	} );
+
+	if ( ! id ) return null;
+
+	return (
+		<SidebarNavigationItem withChevron { ...linkInfo }>
+			{ title }
+		</SidebarNavigationItem>
+	);
+}

--- a/packages/edit-site/src/components/sidebar-navigation-screen-template-part/template-part-navigation-menu-list-item.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-template-part/template-part-navigation-menu-list-item.js
@@ -2,6 +2,8 @@
  * WordPress dependencies
  */
 import { useEntityProp } from '@wordpress/core-data';
+import { __ } from '@wordpress/i18n';
+
 /**
  * Internal dependencies
  */
@@ -20,7 +22,7 @@ export default function TemplatePartNavigationMenuListItem( { id } ) {
 
 	return (
 		<SidebarNavigationItem withChevron { ...linkInfo }>
-			{ title }
+			{ title || __( '(no title)' ) }
 		</SidebarNavigationItem>
 	);
 }

--- a/packages/edit-site/src/components/sidebar-navigation-screen-template-part/template-part-navigation-menu-list.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-template-part/template-part-navigation-menu-list.js
@@ -1,0 +1,21 @@
+/**
+ * WordPress dependencies
+ */
+import { __experimentalItemGroup as ItemGroup } from '@wordpress/components';
+/**
+ * Internal dependencies
+ */
+import TemplatePartNavigationMenuListItem from './template-part-navigation-menu-list-item';
+
+export default function TemplatePartNavigationMenuList( { menus } ) {
+	return (
+		<ItemGroup className="edit-site-sidebar-navigation-screen-template-part-navigation-menu-list">
+			{ menus.map( ( menuId ) => (
+				<TemplatePartNavigationMenuListItem
+					key={ menuId }
+					id={ menuId }
+				/>
+			) ) }
+		</ItemGroup>
+	);
+}

--- a/packages/edit-site/src/components/sidebar-navigation-screen-template-part/template-part-navigation-menu.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-template-part/template-part-navigation-menu.js
@@ -4,6 +4,7 @@
 import { __ } from '@wordpress/i18n';
 import { __experimentalHeading as Heading } from '@wordpress/components';
 import { useEntityProp } from '@wordpress/core-data';
+
 /**
  * Internal dependencies
  */

--- a/packages/edit-site/src/components/sidebar-navigation-screen-template-part/template-part-navigation-menu.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-template-part/template-part-navigation-menu.js
@@ -1,0 +1,29 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { __experimentalHeading as Heading } from '@wordpress/components';
+import { useEntityProp } from '@wordpress/core-data';
+/**
+ * Internal dependencies
+ */
+import NavigationMenuEditor from '../sidebar-navigation-screen-navigation-menu/navigation-menu-editor';
+
+export default function TemplatePartNavigationMenu( { id } ) {
+	const [ title ] = useEntityProp( 'postType', 'wp_navigation', 'title', id );
+
+	if ( ! id ) return null;
+
+	return (
+		<>
+			<Heading
+				className="edit-site-sidebar-navigation-screen-template-part-navigation-menu__title"
+				size="12"
+				upperCase={ true }
+			>
+				{ title || __( 'Navigation Menu' ) }
+			</Heading>
+			<NavigationMenuEditor navigationMenuId={ id } />
+		</>
+	);
+}

--- a/packages/edit-site/src/components/sidebar-navigation-screen-template-part/template-part-navigation-menu.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-template-part/template-part-navigation-menu.js
@@ -22,7 +22,7 @@ export default function TemplatePartNavigationMenu( { id } ) {
 				size="12"
 				upperCase={ true }
 			>
-				{ title || __( 'Navigation Menu' ) }
+				{ title || __( 'Navigation' ) }
 			</Heading>
 			<NavigationMenuEditor navigationMenuId={ id } />
 		</>

--- a/packages/edit-site/src/components/sidebar-navigation-screen-template-part/template-part-navigation-menus.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-template-part/template-part-navigation-menus.js
@@ -1,0 +1,33 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { __experimentalHeading as Heading } from '@wordpress/components';
+/**
+ * Internal dependencies
+ */
+import TemplatePartNavigationMenu from './template-part-navigation-menu';
+import TemplatePartNavigationMenuList from './template-part-navigation-menu-list';
+
+export default function TemplatePartNavigationMenus( { menus } ) {
+	if ( ! menus.length ) return null;
+
+	// if there is a single menu then render TemplatePartNavigationMenu
+	if ( menus.length === 1 ) {
+		return <TemplatePartNavigationMenu id={ menus[ 0 ] } />;
+	}
+
+	// if there are multiple menus then render TemplatePartNavigationMenuList
+	return (
+		<>
+			<Heading
+				className="edit-site-sidebar-navigation-screen-template-part-navigation-menu__title"
+				size="12"
+				upperCase={ true }
+			>
+				{ __( 'Navigation Menus' ) }
+			</Heading>
+			<TemplatePartNavigationMenuList menus={ menus } />
+		</>
+	);
+}

--- a/packages/edit-site/src/components/sidebar-navigation-screen-template-part/template-part-navigation-menus.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-template-part/template-part-navigation-menus.js
@@ -25,7 +25,7 @@ export default function TemplatePartNavigationMenus( { menus } ) {
 				size="12"
 				upperCase={ true }
 			>
-				{ __( 'Navigation Menus' ) }
+				{ __( 'Navigation' ) }
 			</Heading>
 			<TemplatePartNavigationMenuList menus={ menus } />
 		</>

--- a/packages/edit-site/src/style.scss
+++ b/packages/edit-site/src/style.scss
@@ -33,6 +33,7 @@
 @import "./components/sidebar-navigation-screen-navigation-menu/style.scss";
 @import "./components/sidebar-navigation-screen-page/style.scss";
 @import "./components/sidebar-navigation-screen-template/style.scss";
+@import "./components/sidebar-navigation-screen-template-part/style.scss";
 @import "./components/sidebar-navigation-subtitle/style.scss";
 @import "./components/site-hub/style.scss";
 @import "./components/sidebar-navigation-screen-navigation-menus/style.scss";


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->



Displays any Navigation Menus in the Template Part in the sidebar of the single Templates Part screen in the Browse Mode sidebar.

⚠️ [This (other) PR](https://github.com/WordPress/gutenberg/pull/39286) really needs to land in order to appreciate _this_ one fully. Any reviews on that one would be appreciated 🙏 

Closes https://github.com/WordPress/gutenberg/issues/50704

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Part of requirements from https://github.com/WordPress/gutenberg/issues/50579.

When browsing a template part that contains Navigation block(s) such as the common `Header` template part, you want to be able to view or even edit any menus displayed there.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

[If there is a single menu](https://github.com/WordPress/gutenberg/issues/50704#issuecomment-1552625666) then it is displayed directly inline as an editable tree.

If there are multiple menus then [they are displayed as a list](https://github.com/WordPress/gutenberg/issues/50704#issuecomment-1558941421) and you can click through to [the Navigation block focus mode](https://github.com/WordPress/gutenberg/pull/39286) (not yet merged) to edit the menu.

## Todos

- [ ] ~Fix bug where clicking through to a single menu and then going back causes you to go to the `Navigation` section rather than back to the Template Part.~ Outside scope of this PR.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

- Create a few menus using a Nav block in the Post Editor.
- In Site Editor go to Header Template Part and make sure there is a single Nav block.
- In Site Editor go to Footer Template Part and add multiple Nav blocks with _and_ without menus assigned.
- Use Browse Mode to enter focus more for each Template Part in turn.
- Header should display the single menu in the sidebar and it should be directly editable.
- Footer should display a _list_ of menus and allow you to click through.
- Edits should work and be reflected.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/444434/1ed45725-069e-44e4-82b2-81aebd67bb49

