### PR TITLE
Remove unused prop from GroupPlaceHolder component

### DIFF
--- a/packages/block-library/src/group/edit.js
+++ b/packages/block-library/src/group/edit.js
@@ -162,7 +162,6 @@ function GroupEdit( {
 				<View>
 					{ innerBlocksProps.children }
 					<GroupPlaceHolder
-						clientId={ clientId }
 						name={ name }
 						onSelect={ selectVariation }
 					/>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
The `GroupPlaceHolder` component does not have any `clientId` prop, so adding this prop in the `GroupEdit` component has no effect. This PR simply removes this unused prop in the `GroupEdit` component.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The `clientId` prop has no effect in `GroupPlaceHolder` component.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Simply removed the prop.
