### PR TITLE
Update BlockEditorProvider tests

### DIFF
--- a/packages/block-editor/src/components/provider/test/experimental-provider.js
+++ b/packages/block-editor/src/components/provider/test/experimental-provider.js
@@ -29,18 +29,21 @@ describe( 'BlockEditorProvider', () => {
 	beforeEach( () => {
 		registry = undefined;
 	} );
-	it( 'should strip experimental settings', async () => {
+	it( 'should not allow updating experimental settings', async () => {
 		render(
 			<BlockEditorProvider
 				settings={ {
-					inserterMediaCategories: true,
+					blockInspectorAnimation: true,
 				} }
 			>
 				<HasEditorSetting setRegistry={ setRegistry } />
 			</BlockEditorProvider>
 		);
 		const settings = registry.select( blockEditorStore ).getSettings();
-		expect( settings ).not.toHaveProperty( 'inserterMediaCategories' );
+		// `blockInspectorAnimation` setting is one of the block editor's
+		// default settings, so it has a value. We're testing that its
+		// value was not updated.
+		expect( settings.blockInspectorAnimation ).not.toBe( true );
 	} );
 	it( 'should preserve stable settings', async () => {
 		render(
@@ -65,18 +68,18 @@ describe( 'ExperimentalBlockEditorProvider', () => {
 	beforeEach( () => {
 		registry = undefined;
 	} );
-	it( 'should preserve experimental settings', async () => {
+	it( 'should allow updating/adding experimental settings', async () => {
 		render(
 			<ExperimentalBlockEditorProvider
 				settings={ {
-					inserterMediaCategories: true,
+					blockInspectorAnimation: true,
 				} }
 			>
 				<HasEditorSetting setRegistry={ setRegistry } />
 			</ExperimentalBlockEditorProvider>
 		);
 		const settings = registry.select( blockEditorStore ).getSettings();
-		expect( settings ).toHaveProperty( 'inserterMediaCategories' );
+		expect( settings.blockInspectorAnimation ).toBe( true );
 	} );
 	it( 'should preserve stable settings', async () => {
 		render(


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
While exploring something about the private block editor settings(specifically `inserterMediaCategories`) I realized that the tests fro block editor provider could be improved.

When ExperimentalBlockEditorProvider [was introduced](https://github.com/WordPress/gutenberg/pull/47319) the tests were testing about the existence of the private setting that was not part of the default block editor settings. What this means is that for example the `blockInspectorAnimation` is in default settings so the setting is there.

What we cannot do without `ExperimentalBlockEditorProvider` is to update the private settings, so I updated the tests to check about that.
