### PR TITLE
Color Panel: Fix rendering of tabs with no color

### DIFF
--- a/packages/block-editor/src/components/global-styles/color-panel.js
+++ b/packages/block-editor/src/components/global-styles/color-panel.js
@@ -525,14 +525,14 @@ export default function ColorPanel( {
 			isShownByDefault: defaultControls.background,
 			indicators: [ gradient ?? backgroundColor ],
 			tabs: [
-				{
+				hasSolidColors && {
 					key: 'background',
 					label: __( 'Solid' ),
 					inheritedValue: backgroundColor,
 					setValue: setBackgroundColor,
 					userValue: userBackgroundColor,
 				},
-				{
+				hasGradientColors && {
 					key: 'gradient',
 					label: __( 'Gradient' ),
 					inheritedValue: gradient,
@@ -540,7 +540,7 @@ export default function ColorPanel( {
 					userValue: userGradient,
 					isGradient: true,
 				},
-			],
+			].filter( Boolean ),
 		},
 		showLinkPanel && {
 			key: 'link',


### PR DESCRIPTION
Fixes: #50267

Might be related to: #48893

## What?
This PR fixes a problem in the ColorPanel component where Background or Gradient tabs are rendered even when there is no color available.

![empty-tab](https://github.com/WordPress/gutenberg/assets/54422211/2589eff1-29c1-4da7-a46b-f02b7ea94a37)

## Why?
When adding the tabs to be displayed to the `tabs` property array, there appears to be no check to see if they have available colors.

## How?
Check to see if it actually has available colors, as it does [when generating element-level tabs](https://github.com/WordPress/gutenberg/blob/3547e1c6afb89fee68341df7668797a21f0e3f9c/packages/block-editor/src/components/global-styles/color-panel.js#L667-L683).

## Testing Instructions

Enable Emptytheme and update `theme.json` as follows in each case, cnfirm that the expected results are obtained.

### Disable all gradient panels

No tabs should exist, only the background panel should appear in all color panels.

<details>
<summary>theme.json</summary>

```json
{
	"$schema": "https://schemas.wp.org/trunk/theme.json",
	"version": 2,
	"settings": {
		"appearanceTools": true,
		"color": {
			"customGradient": false,
			"defaultGradients": false,
			"gradients": []
		}
	}
}
```

</details> 

### Disable all background panels

No tabs should exist, only solid gradient panel should appear in all color panels.

<details>
<summary>theme.json</summary>

```json
	"$schema": "https://schemas.wp.org/trunk/theme.json",
	"version": 2,
	"settings": {
		"appearanceTools": true,
		"color": {
			"defaultPalette": false,
			"custom": false,
			"palette": []
		}
	}
}
```

</details> 

### Disable paragraph block gradient panel

Only for paragraph blocks, there should be no tabs, only background panel

<details>
<summary>theme.json</summary>

```json
{
	"$schema": "https://schemas.wp.org/trunk/theme.json",
	"version": 2,
	"settings": {
		"appearanceTools": true,
		"blocks": {
			"core/paragraph": {
				"color": {
					"customGradient": false,
					"defaultGradients": false,
					"gradients": []
				}
			}
		}
	}
}
```

</details> 

### Disable paragraph block background panel

Only for paragraph blocks, there should be no tabs, only gradient panel

<details>
<summary>theme.json</summary>

```json
{
	"$schema": "https://schemas.wp.org/trunk/theme.json",
	"version": 2,
	"settings": {
		"appearanceTools": true,
		"blocks": {
			"core/paragraph": {
				"color": {
					"defaultPalette": false,
					"custom": false,
					"palette": []
				}
			}
		}
	}
}
```

</details> 

### Disable all gradient panels except the paragraph block

Except for the paragraph block, it should have no tabs, only background panel

<details>
<summary>theme.json</summary>

```json
{
	"$schema": "https://schemas.wp.org/trunk/theme.json",
	"version": 2,
	"settings": {
		"appearanceTools": true,
		"color": {
			"customGradient": false,
			"defaultGradients": false,
			"gradients": []
		},
		"blocks": {
			"core/paragraph": {
				"color": {
					"customGradient": true,
					"defaultGradients": true
				}
			}
		}
	}
}
```

</details> 

### Disable all background panels except the paragraph block

Except for the paragraph block, it should have no tabs, only gradient panel

<details>
<summary>theme.json</summary>

```json
{
	"$schema": "https://schemas.wp.org/trunk/theme.json",
	"version": 2,
	"settings": {
		"appearanceTools": true,
		"color": {
			"defaultPalette": false,
			"custom": false,
			"palette": []
		},
		"blocks": {
			"core/paragraph": {
				"color": {
					"defaultPalette": true,
					"custom": true
				}
			}
		}
	}
}
```

</details> 
