### PR TITLE
npm lockfile: hoist reakit and date-fns packages to the top

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17463,53 +17463,15 @@
 				"valtio": "1.7.0"
 			},
 			"dependencies": {
-				"date-fns": {
-					"version": "2.29.3",
-					"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.29.3.tgz",
-					"integrity": "sha512-dDCnyH2WnnKusqvZZ6+jA1O51Ibt8ZMRNkDZdyAyK4YfbDwa/cEmuztzG5pk6hqlp9aSBPYcjOlktquahGwGeA=="
-				},
 				"deepmerge": {
-					"version": "4.3.0",
-					"resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.0.tgz",
-					"integrity": "sha512-z2wJZXrmeHdvYJp/Ux55wIjqo81G5Bp4c+oELTW+7ar6SogWHajt5a9gO3s3IDaGSAXjDk0vlQKN3rms8ab3og=="
+					"version": "4.3.1",
+					"resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+					"integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A=="
 				},
 				"path-to-regexp": {
 					"version": "6.2.1",
 					"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.1.tgz",
 					"integrity": "sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw=="
-				},
-				"reakit": {
-					"version": "1.3.11",
-					"resolved": "https://registry.npmjs.org/reakit/-/reakit-1.3.11.tgz",
-					"integrity": "sha512-mYxw2z0fsJNOQKAEn5FJCPTU3rcrY33YZ/HzoWqZX0G7FwySp1wkCYW79WhuYMNIUFQ8s3Baob1RtsEywmZSig==",
-					"requires": {
-						"@popperjs/core": "^2.5.4",
-						"body-scroll-lock": "^3.1.5",
-						"reakit-system": "^0.15.2",
-						"reakit-utils": "^0.15.2",
-						"reakit-warning": "^0.6.2"
-					}
-				},
-				"reakit-system": {
-					"version": "0.15.2",
-					"resolved": "https://registry.npmjs.org/reakit-system/-/reakit-system-0.15.2.tgz",
-					"integrity": "sha512-TvRthEz0DmD0rcJkGamMYx+bATwnGNWJpe/lc8UV2Js8nnPvkaxrHk5fX9cVASFrWbaIyegZHCWUBfxr30bmmA==",
-					"requires": {
-						"reakit-utils": "^0.15.2"
-					}
-				},
-				"reakit-utils": {
-					"version": "0.15.2",
-					"resolved": "https://registry.npmjs.org/reakit-utils/-/reakit-utils-0.15.2.tgz",
-					"integrity": "sha512-i/RYkq+W6hvfFmXw5QW7zvfJJT/K8a4qZ0hjA79T61JAFPGt23DsfxwyBbyK91GZrJ9HMrXFVXWMovsKBc1qEQ=="
-				},
-				"reakit-warning": {
-					"version": "0.6.2",
-					"resolved": "https://registry.npmjs.org/reakit-warning/-/reakit-warning-0.6.2.tgz",
-					"integrity": "sha512-z/3fvuc46DJyD3nJAUOto6inz2EbSQTjvI/KBQDqxwB0y02HDyeP8IWOJxvkuAUGkWpeSx+H3QWQFSNiPcHtmw==",
-					"requires": {
-						"reakit-utils": "^0.15.2"
-					}
 				}
 			}
 		},
@@ -29377,7 +29339,7 @@
 				"color-name": {
 					"version": "1.1.3",
 					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-					"integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
+					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
 				}
 			}
 		},
@@ -29682,6 +29644,12 @@
 					"version": "2.6.0",
 					"resolved": "https://registry.npmjs.org/commander/-/commander-2.6.0.tgz",
 					"integrity": "sha1-nfflL7Kgyw+4kFjugMMQQiXzfh0=",
+					"dev": true
+				},
+				"date-fns": {
+					"version": "1.30.1",
+					"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.30.1.tgz",
+					"integrity": "sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==",
 					"dev": true
 				},
 				"has-ansi": {
@@ -31122,10 +31090,27 @@
 			}
 		},
 		"date-fns": {
-			"version": "1.29.0",
-			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.29.0.tgz",
-			"integrity": "sha512-lbTXWZ6M20cWH8N9S6afb0SBm6tMk+uUg6z3MqHPKE9atmsY3kJkTm8vKe93izJ2B2+q5MV990sM2CHgtAZaOw==",
-			"dev": true
+			"version": "2.30.0",
+			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
+			"integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
+			"requires": {
+				"@babel/runtime": "^7.21.0"
+			},
+			"dependencies": {
+				"@babel/runtime": {
+					"version": "7.22.5",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.5.tgz",
+					"integrity": "sha512-ecjvYlnAaZ/KVneE/OdKYBYfgXV3Ptu6zQWmgEF7vwKhQnvVS6bjMD2XYgj+SNvQ1GfK/pjgokfPkC/2CO8CuA==",
+					"requires": {
+						"regenerator-runtime": "^0.13.11"
+					}
+				},
+				"regenerator-runtime": {
+					"version": "0.13.11",
+					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+					"integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
+				}
+			}
 		},
 		"dateformat": {
 			"version": "3.0.3",
@@ -33888,7 +33873,7 @@
 		"eventemitter2": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-1.0.5.tgz",
-			"integrity": "sha512-EUFhWUYzqqBZlzBMI+dPU8rnKXfQZEUnitnccQuEIAnvWFHCpt3+4fts2+4dpxLtlsiseVXCMFg37KjYChSxpg=="
+			"integrity": "sha1-+YNhBRexc3wLncZDvsqTiTwE3xg="
 		},
 		"eventemitter3": {
 			"version": "4.0.7",
@@ -34834,7 +34819,7 @@
 		"filter-obj": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/filter-obj/-/filter-obj-1.1.0.tgz",
-			"integrity": "sha512-8rXg1ZnX7xzy2NGDVkBVaAy+lSlPNwad13BtgSlLuxfIslyt5Vg64U7tFcCt4WS1R0hvtnQybT/IyCkGZ3DpXQ=="
+			"integrity": "sha1-mzERErxsYSehbgFsbF1/GeCAXFs="
 		},
 		"finalhandler": {
 			"version": "1.1.2",
@@ -37021,7 +37006,7 @@
 		"htmlparser2-without-node-native": {
 			"version": "3.9.2",
 			"resolved": "https://registry.npmjs.org/htmlparser2-without-node-native/-/htmlparser2-without-node-native-3.9.2.tgz",
-			"integrity": "sha512-+FplQXqmY5fRx6vCIp2P5urWaoBCpTNJMXnKP/6mNCcyb+AZWWJzA8D03peXfozlxDL+vpgLK5dJblqEgu8j6A==",
+			"integrity": "sha1-s+0FDYd9D/NGWWnjOYd7f59mMfY=",
 			"requires": {
 				"domelementtype": "^1.3.0",
 				"domhandler": "^2.3.0",
@@ -38795,7 +38780,7 @@
 		"jed": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/jed/-/jed-1.1.1.tgz",
-			"integrity": "sha512-z35ZSEcXHxLW4yumw0dF6L464NT36vmx3wxJw8MDpraBcWuNVgUPZgPJKcu1HekNgwlMFNqol7i/IpSbjhqwqA=="
+			"integrity": "sha1-elSbvZ/+FYWwzQoZHiAwVb7ldLQ="
 		},
 		"jest": {
 			"version": "29.5.0",
@@ -41068,6 +41053,12 @@
 						"escape-string-regexp": "^1.0.5",
 						"supports-color": "^5.3.0"
 					}
+				},
+				"date-fns": {
+					"version": "1.30.1",
+					"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.30.1.tgz",
+					"integrity": "sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==",
+					"dev": true
 				}
 			}
 		},
@@ -41171,7 +41162,7 @@
 		"lodash.isequal": {
 			"version": "4.5.0",
 			"resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-			"integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ=="
+			"integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
 		},
 		"lodash.ismatch": {
 			"version": "4.4.0",
@@ -50611,6 +50602,39 @@
 			"resolved": "https://registry.npmjs.org/readline/-/readline-1.3.0.tgz",
 			"integrity": "sha1-xYDXfvLPyHUrEySYBg3JeTp6wBw="
 		},
+		"reakit": {
+			"version": "1.3.11",
+			"resolved": "https://registry.npmjs.org/reakit/-/reakit-1.3.11.tgz",
+			"integrity": "sha512-mYxw2z0fsJNOQKAEn5FJCPTU3rcrY33YZ/HzoWqZX0G7FwySp1wkCYW79WhuYMNIUFQ8s3Baob1RtsEywmZSig==",
+			"requires": {
+				"@popperjs/core": "^2.5.4",
+				"body-scroll-lock": "^3.1.5",
+				"reakit-system": "^0.15.2",
+				"reakit-utils": "^0.15.2",
+				"reakit-warning": "^0.6.2"
+			}
+		},
+		"reakit-system": {
+			"version": "0.15.2",
+			"resolved": "https://registry.npmjs.org/reakit-system/-/reakit-system-0.15.2.tgz",
+			"integrity": "sha512-TvRthEz0DmD0rcJkGamMYx+bATwnGNWJpe/lc8UV2Js8nnPvkaxrHk5fX9cVASFrWbaIyegZHCWUBfxr30bmmA==",
+			"requires": {
+				"reakit-utils": "^0.15.2"
+			}
+		},
+		"reakit-utils": {
+			"version": "0.15.2",
+			"resolved": "https://registry.npmjs.org/reakit-utils/-/reakit-utils-0.15.2.tgz",
+			"integrity": "sha512-i/RYkq+W6hvfFmXw5QW7zvfJJT/K8a4qZ0hjA79T61JAFPGt23DsfxwyBbyK91GZrJ9HMrXFVXWMovsKBc1qEQ=="
+		},
+		"reakit-warning": {
+			"version": "0.6.2",
+			"resolved": "https://registry.npmjs.org/reakit-warning/-/reakit-warning-0.6.2.tgz",
+			"integrity": "sha512-z/3fvuc46DJyD3nJAUOto6inz2EbSQTjvI/KBQDqxwB0y02HDyeP8IWOJxvkuAUGkWpeSx+H3QWQFSNiPcHtmw==",
+			"requires": {
+				"reakit-utils": "^0.15.2"
+			}
+		},
 		"reassure": {
 			"version": "0.7.1",
 			"resolved": "https://registry.npmjs.org/reassure/-/reassure-0.7.1.tgz",
@@ -52744,7 +52768,7 @@
 		"simple-swizzle": {
 			"version": "0.2.2",
 			"resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
-			"integrity": "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==",
+			"integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
 			"requires": {
 				"is-arrayish": "^0.3.1"
 			},
@@ -53419,7 +53443,7 @@
 		"strict-uri-encode": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
-			"integrity": "sha512-QwiXZgpRcKkhTj2Scnn++4PKtWsH0kpzZ62L2R6c/LUVYv7hVnZqcg2+sMuT6R7Jusu1vviK/MFsu6kNJfWlEQ=="
+			"integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY="
 		},
 		"string-hash-64": {
 			"version": "1.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17795,13 +17795,6 @@
 				"memize": "^2.1.0",
 				"react-autosize-textarea": "^7.1.0",
 				"rememo": "^4.0.2"
-			},
-			"dependencies": {
-				"colord": {
-					"version": "2.9.2",
-					"resolved": "https://registry.npmjs.org/colord/-/colord-2.9.2.tgz",
-					"integrity": "sha512-Uqbg+J445nc1TKn4FoDPS6ZZqAvEDnwrH42yo8B40JSOgSLxMZ/gt3h4nmCtPLQeXhjJJkqBx7SCY35WnIixaQ=="
-				}
 			}
 		},
 		"@wordpress/edit-widgets": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -17170,14 +17170,6 @@
 				"deepmerge": "^4.3.0",
 				"gettext-parser": "^1.3.1",
 				"is-plain-object": "^5.0.0"
-			},
-			"dependencies": {
-				"deepmerge": {
-					"version": "4.3.0",
-					"resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.0.tgz",
-					"integrity": "sha512-z2wJZXrmeHdvYJp/Ux55wIjqo81G5Bp4c+oELTW+7ar6SogWHajt5a9gO3s3IDaGSAXjDk0vlQKN3rms8ab3og==",
-					"dev": true
-				}
 			}
 		},
 		"@wordpress/babel-preset-default": {
@@ -17281,13 +17273,6 @@
 				"rememo": "^4.0.2",
 				"remove-accents": "^0.4.2",
 				"traverse": "^0.6.6"
-			},
-			"dependencies": {
-				"deepmerge": {
-					"version": "4.3.1",
-					"resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
-					"integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A=="
-				}
 			}
 		},
 		"@wordpress/block-library": {
@@ -17382,13 +17367,6 @@
 				"showdown": "^1.9.1",
 				"simple-html-tokenizer": "^0.5.7",
 				"uuid": "^8.3.0"
-			},
-			"dependencies": {
-				"deepmerge": {
-					"version": "4.3.1",
-					"resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
-					"integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A=="
-				}
 			}
 		},
 		"@wordpress/browserslist-config": {
@@ -17463,11 +17441,6 @@
 				"valtio": "1.7.0"
 			},
 			"dependencies": {
-				"deepmerge": {
-					"version": "4.3.1",
-					"resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
-					"integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A=="
-				},
 				"path-to-regexp": {
 					"version": "6.2.1",
 					"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.1.tgz",
@@ -17598,13 +17571,6 @@
 				"redux": "^4.1.2",
 				"turbo-combine-reducers": "^1.0.2",
 				"use-memo-one": "^1.1.1"
-			},
-			"dependencies": {
-				"deepmerge": {
-					"version": "4.3.0",
-					"resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.0.tgz",
-					"integrity": "sha512-z2wJZXrmeHdvYJp/Ux55wIjqo81G5Bp4c+oELTW+7ar6SogWHajt5a9gO3s3IDaGSAXjDk0vlQKN3rms8ab3og=="
-				}
 			}
 		},
 		"@wordpress/data-controls": {
@@ -17835,11 +17801,6 @@
 					"version": "2.9.2",
 					"resolved": "https://registry.npmjs.org/colord/-/colord-2.9.2.tgz",
 					"integrity": "sha512-Uqbg+J445nc1TKn4FoDPS6ZZqAvEDnwrH42yo8B40JSOgSLxMZ/gt3h4nmCtPLQeXhjJJkqBx7SCY35WnIixaQ=="
-				},
-				"deepmerge": {
-					"version": "4.3.1",
-					"resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
-					"integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A=="
 				}
 			}
 		},
@@ -31245,10 +31206,9 @@
 			"dev": true
 		},
 		"deepmerge": {
-			"version": "4.2.2",
-			"resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
-			"integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
-			"dev": true
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+			"integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A=="
 		},
 		"deepsignal": {
 			"version": "1.3.0",


### PR DESCRIPTION
While looking at output of `npm run build:analyze-bundles`, I noticed that our lockfile installs the `reakit` and `date-fns` packages into suboptimal `packages/components/node_modules` directory instead of the top-level `node_modules` where they should be. The top-level `reakit` slot is free, there is no conflict with any other package. And the `date-fns` slot was occupied by old 1.x version used by `concurrently`, while all other packages use 2.x and are forced to install their own copies, duplicated many times over.

This PR fixes that. Before it, the `components` package had its 3rd party dependencies in two directories:

<img width="646" alt="Screenshot 2023-06-14 at 19 46 32" src="https://github.com/WordPress/gutenberg/assets/664258/3b36ca81-fed8-48b8-8d4b-79ec2bdb6b3f">

while now all dependencies are neatly sorted in one directory:

<img width="647" alt="Screenshot 2023-06-14 at 19 52 47" src="https://github.com/WordPress/gutenberg/assets/664258/b6a8db09-622b-43ef-85b3-0155f7349ea7">

You can see clearly, for example, that `reakit` is the third largest dependency after `framer-motion` and `radix-ui`.