### PR TITLE
Add commands to access template, template parts and styles

### DIFF
--- a/packages/core-commands/src/site-editor-navigation-commands.js
+++ b/packages/core-commands/src/site-editor-navigation-commands.js
@@ -119,8 +119,44 @@ function useSiteEditorBasicNavigationCommands() {
 	const commands = useMemo( () => {
 		const result = [];
 		result.push( {
+			name: 'core/edit-site/open-navigation',
+			label: __( 'Open navigation' ),
+			icon: styles,
+			callback: ( { close } ) => {
+				const args = {
+					path: '/navigation',
+				};
+				const targetUrl = addQueryArgs( 'site-editor.php', args );
+				if ( isSiteEditor ) {
+					history.push( args );
+				} else {
+					document.location = targetUrl;
+				}
+				close();
+			},
+		} );
+
+		result.push( {
+			name: 'core/edit-site/open-pages',
+			label: __( 'Open pages' ),
+			icon: styles,
+			callback: ( { close } ) => {
+				const args = {
+					path: '/page',
+				};
+				const targetUrl = addQueryArgs( 'site-editor.php', args );
+				if ( isSiteEditor ) {
+					history.push( args );
+				} else {
+					document.location = targetUrl;
+				}
+				close();
+			},
+		} );
+
+		result.push( {
 			name: 'core/edit-site/open-styles',
-			label: __( 'Open Styles' ),
+			label: __( 'Open style variations' ),
 			icon: styles,
 			callback: ( { close } ) => {
 				const args = {
@@ -138,7 +174,7 @@ function useSiteEditorBasicNavigationCommands() {
 
 		result.push( {
 			name: 'core/edit-site/open-templates',
-			label: __( 'View all templates' ),
+			label: __( 'Open templates' ),
 			icon: layout,
 			callback: ( { close } ) => {
 				const args = {
@@ -156,7 +192,7 @@ function useSiteEditorBasicNavigationCommands() {
 
 		result.push( {
 			name: 'core/edit-site/open-template-parts',
-			label: __( 'View all template parts' ),
+			label: __( 'Open library' ),
 			icon: symbolFilled,
 			callback: ( { close } ) => {
 				const args = {
@@ -200,5 +236,6 @@ export function useSiteEditorNavigationCommands() {
 	useCommandLoader( {
 		name: 'core/edit-site/basic-navigation',
 		hook: useSiteEditorBasicNavigationCommands,
+		context: 'site-editor',
 	} );
 }

--- a/packages/core-commands/src/site-editor-navigation-commands.js
+++ b/packages/core-commands/src/site-editor-navigation-commands.js
@@ -6,7 +6,14 @@ import { __ } from '@wordpress/i18n';
 import { useMemo } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
-import { post, page, layout, symbolFilled, styles } from '@wordpress/icons';
+import {
+	post,
+	page,
+	layout,
+	symbolFilled,
+	styles,
+	navigation,
+} from '@wordpress/icons';
 import { privateApis as routerPrivateApis } from '@wordpress/router';
 import { getQueryArg, addQueryArgs, getPath } from '@wordpress/url';
 
@@ -121,7 +128,7 @@ function useSiteEditorBasicNavigationCommands() {
 		result.push( {
 			name: 'core/edit-site/open-navigation',
 			label: __( 'Open navigation' ),
-			icon: styles,
+			icon: navigation,
 			callback: ( { close } ) => {
 				const args = {
 					path: '/navigation',
@@ -139,7 +146,7 @@ function useSiteEditorBasicNavigationCommands() {
 		result.push( {
 			name: 'core/edit-site/open-pages',
 			label: __( 'Open pages' ),
-			icon: styles,
+			icon: page,
 			callback: ( { close } ) => {
 				const args = {
 					path: '/page',

--- a/packages/core-commands/src/site-editor-navigation-commands.js
+++ b/packages/core-commands/src/site-editor-navigation-commands.js
@@ -6,7 +6,7 @@ import { __ } from '@wordpress/i18n';
 import { useMemo } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
-import { post, page, layout, symbolFilled } from '@wordpress/icons';
+import { post, page, layout, symbolFilled, styles } from '@wordpress/icons';
 import { privateApis as routerPrivateApis } from '@wordpress/router';
 import { getQueryArg, addQueryArgs, getPath } from '@wordpress/url';
 
@@ -55,9 +55,6 @@ const getNavigationCommandLoaderPerPostType = ( postType ) =>
 						'getEntityRecords',
 						[ 'postType', postType, query ]
 					),
-					// We're using the string literal to check whether we're in the site editor.
-					/* eslint-disable-next-line @wordpress/data-no-store-string-literals */
-					isSiteEditor: !! select( 'edit-site' ),
 				};
 			},
 			[ supportsSearch, search ]
@@ -114,6 +111,75 @@ const useTemplateNavigationCommandLoader =
 const useTemplatePartNavigationCommandLoader =
 	getNavigationCommandLoaderPerPostType( 'wp_template_part' );
 
+function useSiteEditorBasicNavigationCommands() {
+	const history = useHistory();
+	const isSiteEditor = getPath( window.location.href )?.includes(
+		'site-editor.php'
+	);
+	const commands = useMemo( () => {
+		const result = [];
+		result.push( {
+			name: 'core/edit-site/open-styles',
+			label: __( 'Open Styles' ),
+			icon: styles,
+			callback: ( { close } ) => {
+				const args = {
+					path: '/wp_global_styles',
+				};
+				const targetUrl = addQueryArgs( 'site-editor.php', args );
+				if ( isSiteEditor ) {
+					history.push( args );
+				} else {
+					document.location = targetUrl;
+				}
+				close();
+			},
+		} );
+
+		result.push( {
+			name: 'core/edit-site/open-templates',
+			label: __( 'View all templates' ),
+			icon: layout,
+			callback: ( { close } ) => {
+				const args = {
+					path: '/wp_template',
+				};
+				const targetUrl = addQueryArgs( 'site-editor.php', args );
+				if ( isSiteEditor ) {
+					history.push( args );
+				} else {
+					document.location = targetUrl;
+				}
+				close();
+			},
+		} );
+
+		result.push( {
+			name: 'core/edit-site/open-template-parts',
+			label: __( 'View all template parts' ),
+			icon: symbolFilled,
+			callback: ( { close } ) => {
+				const args = {
+					path: '/wp_template_part',
+				};
+				const targetUrl = addQueryArgs( 'site-editor.php', args );
+				if ( isSiteEditor ) {
+					history.push( args );
+				} else {
+					document.location = targetUrl;
+				}
+				close();
+			},
+		} );
+		return result;
+	}, [ history, isSiteEditor ] );
+
+	return {
+		commands,
+		isLoading: false,
+	};
+}
+
 export function useSiteEditorNavigationCommands() {
 	useCommandLoader( {
 		name: 'core/edit-site/navigate-pages',
@@ -130,5 +196,9 @@ export function useSiteEditorNavigationCommands() {
 	useCommandLoader( {
 		name: 'core/edit-site/navigate-template-parts',
 		hook: useTemplatePartNavigationCommandLoader,
+	} );
+	useCommandLoader( {
+		name: 'core/edit-site/basic-navigation',
+		hook: useSiteEditorBasicNavigationCommands,
 	} );
 }


### PR DESCRIPTION
Related #50407 

## What?

This PR just starts the work to add more commands to the command center. As it stands the PR adds:

 - Open Styles: to open the styles panel in the site editor
 - View all templates: to open the templates panel in the site editor
 - View all template parts: to open the template parts panel in the site editor. 

Notes:

 - I was wondering if I should rename the last one "Open Library" to match the existing name in the site editor.
 - These commands work also in the post editor
 - I didn't make these commands contextual, meaning that these commands don't show up directly when you open the command center from within the site editor view mode but I can do so if this is the desired behavior.
 - I wanted to add "open styles book" but found that open a style book can't be done from the URL directly, a direct action need to be taken within the site editor which means that for these kind of commands we have two options: add a path that triggers this automatically or only add these commands when you're using the command center within the site editor.

## Testing Instructions

1- Open either the site or post editors
2- Type "Open styles" or "View templates" or "View template parts" to try these commands.