### PR TITLE
Limit Copy/Paste Styles menu item

### DIFF
--- a/packages/block-editor/src/components/block-actions/index.js
+++ b/packages/block-editor/src/components/block-actions/index.js
@@ -32,6 +32,15 @@ export default function BlockActions( {
 
 	const blocks = getBlocksByClientId( clientIds );
 	const rootClientId = getBlockRootClientId( clientIds[ 0 ] );
+
+	const canCopyStyles = blocks.every( ( block ) => {
+		return (
+			!! block &&
+			( hasBlockSupport( block.name, 'color' ) ||
+				hasBlockSupport( block.name, 'typography' ) )
+		);
+	} );
+
 	const canDuplicate = blocks.every( ( block ) => {
 		return (
 			!! block &&
@@ -64,6 +73,7 @@ export default function BlockActions( {
 	const pasteStyles = usePasteStyles();
 
 	return children( {
+		canCopyStyles,
 		canDuplicate,
 		canInsertDefaultBlock,
 		canMove,

--- a/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
@@ -189,6 +189,7 @@ export function BlockSettingsDropdown( {
 			__experimentalUpdateSelection={ ! __experimentalSelectBlock }
 		>
 			{ ( {
+				canCopyStyles,
 				canDuplicate,
 				canInsertDefaultBlock,
 				canMove,
@@ -330,16 +331,18 @@ export function BlockSettingsDropdown( {
 									</>
 								) }
 							</MenuGroup>
-							<MenuGroup>
-								<CopyMenuItem
-									blocks={ blocks }
-									onCopy={ onCopy }
-									label={ __( 'Copy styles' ) }
-								/>
-								<MenuItem onClick={ onPasteStyles }>
-									{ __( 'Paste styles' ) }
-								</MenuItem>
-							</MenuGroup>
+							{ canCopyStyles && (
+								<MenuGroup>
+									<CopyMenuItem
+										blocks={ blocks }
+										onCopy={ onCopy }
+										label={ __( 'Copy styles' ) }
+									/>
+									<MenuItem onClick={ onPasteStyles }>
+										{ __( 'Paste styles' ) }
+									</MenuItem>
+								</MenuGroup>
+							) }
 							<BlockSettingsMenuControls.Slot
 								fillProps={ {
 									onClose,


### PR DESCRIPTION
## What?
Limit Copy/Paste Styles menu item to only those blocks that have either 'color' or 'typography' supports

## Why?
Not all blocks have styles that can be copied or pasted, yet they all have the copy/paste option

## How?
A new property `canCopyStyles` is introduced, the value of which is derived from determining if the selected block has EITHER the `color` or `typography` support.

## Testing Instructions
* Open the Site Editor.
* Select a block (such as paragraph) that DOES have either `color` or `typography` support.  Select the "Block Actions"  menu for that block.  Note that the "Copy Styles" and "Paste Styles" are available.
<img width="584" alt="image" src="https://github.com/WordPress/gutenberg/assets/146530/ac635837-10d2-4edf-88ca-bc446b8f4c9e">
* Select a block (such as query block) that DOES NOT have either `color` or `typography` support.  Select the "Block Actions" menu for that block.  Note that the "Copy Styles" and "Paste Styles" are not present.
<img width="489" alt="image" src="https://github.com/WordPress/gutenberg/assets/146530/31538f70-94f4-4755-9b95-4a79f5bd2968">

Fixes #50745