### PR TITLE
Add style variation classes to rendered body

### DIFF
--- a/lib/global-styles-and-settings.php
+++ b/lib/global-styles-and-settings.php
@@ -290,3 +290,13 @@ function gutenberg_get_global_styles( $path = array(), $context = array() ) {
 function gutenberg_get_theme_directory_pattern_slugs() {
 	return WP_Theme_JSON_Resolver_Gutenberg::get_theme_data( array(), array( 'with_supports' => false ) )->get_patterns();
 }
+
+function add_variation_class_to_body( $classes ) {
+	$custom = wp_get_global_settings( array( 'custom' ) );
+	if ( isset($custom['variation']) && 'Default' !== $custom['variation'] ) {
+		$classes[] = 'uses-style-variation';
+		$classes[] = _wp_to_kebab_case('is style variation ' . $custom['variation']);
+	}
+	return $classes;
+}
+add_filter( 'body_class','add_variation_class_to_body' );

--- a/lib/global-styles-and-settings.php
+++ b/lib/global-styles-and-settings.php
@@ -291,12 +291,20 @@ function gutenberg_get_theme_directory_pattern_slugs() {
 	return WP_Theme_JSON_Resolver_Gutenberg::get_theme_data( array(), array( 'with_supports' => false ) )->get_patterns();
 }
 
-function add_variation_class_to_body( $classes ) {
+/**
+ * Adds the `uses-style-variation` and `is-style-variation-name` classes to the body if a theme style variation is used.
+ *
+ * @since 6.4.0
+ *
+ * @param array $classes Classes for the body element.
+ * @return array Filtered classes for the body element.
+ */
+function gutenberg_add_variation_class_to_body( $classes ) {
 	$custom = wp_get_global_settings( array( 'custom' ) );
-	if ( isset($custom['variation']) && 'Default' !== $custom['variation'] ) {
+	if ( isset( $custom['variation'] ) && 'Default' !== $custom['variation'] ) {
 		$classes[] = 'uses-style-variation';
-		$classes[] = _wp_to_kebab_case('is style variation ' . $custom['variation']);
+		$classes[] = _wp_to_kebab_case( 'is style variation ' . $custom['variation'] );
 	}
 	return $classes;
 }
-add_filter( 'body_class','add_variation_class_to_body' );
+add_filter( 'body_class', 'gutenberg_add_variation_class_to_body' );

--- a/packages/edit-site/src/components/global-styles/style-variations-container.js
+++ b/packages/edit-site/src/components/global-styles/style-variations-container.js
@@ -43,7 +43,14 @@ function Variation( { variation } ) {
 	const selectVariation = () => {
 		setUserConfig( () => {
 			return {
-				settings: variation.settings,
+				settings: {
+					...( 'Default' !== variation.title && {
+						custom: {
+							variation: variation.title,
+						},
+					} ),
+					...variation.settings,
+				},
 				styles: variation.styles,
 			};
 		} );


### PR DESCRIPTION
Fixes: #43405

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Add a mechanism to store what style variation is used and leverage that to add a style variation specific class to the rendered body.

## Why?
So that variation-specific CSS can be added to a theme.

## How?
When a variation is selected the Title of that variation (defined in the variation's JSON) is stored as a 'custom' Global Styles variable.  (This should probably be stored in a better place, but I was mostly ripping out a Proof Of Concept today.)
When the page is rendered if the custom variable is available the classes `uses-style-variation` and `is-style-variation-VARIATION-TITLE` are added to the `body`.

## Testing Instructions
* Activate a theme with style variations (Such as Blockbase)
* Select a style variation via Global Styles panel and save.
* Render any page
* Note that the expected classes have been added

* Select the default style variation and save.
* render any page
* note that there are no additional classes
