### PR TITLE
wp-env: try to fix failing PHP Github actions

### DIFF
--- a/packages/env/lib/init-config.js
+++ b/packages/env/lib/init-config.js
@@ -201,6 +201,9 @@ RUN apt-get -qy update
 # Install some basic PHP dependencies.
 RUN apt-get -qy install $PHPIZE_DEPS && touch /usr/local/etc/php/php.ini
 
+# Install git
+RUN apt-get -qy install git
+
 # Set up sudo so they can have root access.
 RUN apt-get -qy install sudo
 RUN echo "#$HOST_UID ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers`;

--- a/packages/env/lib/init-config.js
+++ b/packages/env/lib/init-config.js
@@ -124,6 +124,7 @@ function wordpressDockerFileContents( env, config ) {
 # Update apt sources for archived versions of Debian.
 
 # stretch (https://lists.debian.org/debian-devel-announce/2023/03/msg00006.html)
+RUN touch /etc/apt/sources.list
 RUN sed -i 's|deb.debian.org/debian stretch|archive.debian.org/debian stretch|g' /etc/apt/sources.list
 RUN sed -i 's|security.debian.org/debian-security stretch|archive.debian.org/debian-security stretch|g' /etc/apt/sources.list
 RUN sed -i '/stretch-updates/d' /etc/apt/sources.list
@@ -167,7 +168,7 @@ RUN adduser -h /home/$HOST_USERNAME -G $( getent group $HOST_GID | cut -d: -f1 )
 
 # Install any dependencies we need in the container.
 ${ installDependencies( 'cli', env, config ) }
-	
+
 # Switch back to the original user now that we're done.
 USER www-data
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Try to fix failing PHP Github actions by attempting to resolve an error during `wp-env` setup.

I noticed that the error claims that `/etc/apt/sources.list` does not exist. This is a naive PR, but I thought I'd try adding a `touch` command to ensure the file exists. This is the error:

![image](https://github.com/WordPress/gutenberg/assets/14988353/d760ee6c-d183-4a1b-9297-1c56e5c91f72)

After adding the `touch` command, I noticed that it was complaining that `git` wasn't available, so I've added that in, too.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Currently all PHP Github actions appear to be failing. This PR attempts to get them working again, in a naive way.

I'm not too sure the exact cause of the errors occurring, but it looks like the official WordPress docker images were recently updated (e.g. [WordPress 8.2 image](https://hub.docker.com/layers/library/wordpress/php8.2/images/sha256-49be2e34db386890752ae32edbfb26ccd574267193ac007fe837d26a2a83a7e4?context=explore)) and are now based on `debian:12-slim`. [Debian 12 (bookworm)](https://www.debian.org/News/2023/20230610) was released about five days ago, so I imagine it's connected to that.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* Add a `touch` command to ensure that `/etc/apt/sources.list` exists.
* Add a command to install `git` as otherwise the composer command failed.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

See if PHP actions will pass.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
