### PR TITLE
Reduce number of List View re-renders while typing

### DIFF
--- a/packages/block-editor/src/components/list-view/use-list-view-client-ids.js
+++ b/packages/block-editor/src/components/list-view/use-list-view-client-ids.js
@@ -10,26 +10,20 @@ import { useSelect } from '@wordpress/data';
 import { store as blockEditorStore } from '../../store';
 import { unlock } from '../../lock-unlock';
 
-const NON_DISABLED_EDITING_MODES = [ 'default', 'contentOnly' ];
-
 export default function useListViewClientIds( { blocks, rootClientId } ) {
 	return useSelect(
 		( select ) => {
 			const {
 				getDraggedBlockClientIds,
 				getSelectedBlockClientIds,
-				getClientIdsTreeWithBlockEditingMode,
+				getListViewClientIdsTree,
 			} = unlock( select( blockEditorStore ) );
 
 			return {
 				selectedClientIds: getSelectedBlockClientIds(),
 				draggedClientIds: getDraggedBlockClientIds(),
 				clientIdsTree:
-					blocks ??
-					getClientIdsTreeWithBlockEditingMode(
-						NON_DISABLED_EDITING_MODES,
-						rootClientId
-					),
+					blocks ?? getListViewClientIdsTree( rootClientId ),
 			};
 		},
 		[ blocks, rootClientId ]

--- a/packages/block-editor/src/components/list-view/use-list-view-client-ids.js
+++ b/packages/block-editor/src/components/list-view/use-list-view-client-ids.js
@@ -10,37 +10,26 @@ import { useSelect } from '@wordpress/data';
 import { store as blockEditorStore } from '../../store';
 import { unlock } from '../../lock-unlock';
 
+const NON_DISABLED_EDITING_MODES = [ 'default', 'contentOnly' ];
+
 export default function useListViewClientIds( { blocks, rootClientId } ) {
 	return useSelect(
 		( select ) => {
 			const {
 				getDraggedBlockClientIds,
 				getSelectedBlockClientIds,
-				__unstableGetClientIdsTree,
-				getBlockEditingMode,
+				getClientIdsTreeWithBlockEditingMode,
 			} = unlock( select( blockEditorStore ) );
-
-			const removeDisabledBlocks = ( tree ) => {
-				return tree.flatMap( ( { clientId, innerBlocks, ...rest } ) => {
-					if ( getBlockEditingMode( clientId ) === 'disabled' ) {
-						return removeDisabledBlocks( innerBlocks );
-					}
-					return [
-						{
-							clientId,
-							innerBlocks: removeDisabledBlocks( innerBlocks ),
-							...rest,
-						},
-					];
-				} );
-			};
 
 			return {
 				selectedClientIds: getSelectedBlockClientIds(),
 				draggedClientIds: getDraggedBlockClientIds(),
-				clientIdsTree: removeDisabledBlocks(
-					blocks ?? __unstableGetClientIdsTree( rootClientId )
-				),
+				clientIdsTree:
+					blocks ??
+					getClientIdsTreeWithBlockEditingMode(
+						NON_DISABLED_EDITING_MODES,
+						rootClientId
+					),
 			};
 		},
 		[ blocks, rootClientId ]

--- a/packages/block-editor/src/store/private-selectors.js
+++ b/packages/block-editor/src/store/private-selectors.js
@@ -135,3 +135,47 @@ export const isBlockSubtreeDisabled = createSelector(
 	},
 	( state ) => [ state.blockEditingModes, state.blocks.parents ]
 );
+
+/**
+ * Returns a tree of block objects with only clientID and innerBlocks set. Only
+ * blocks with the given editing mode are included in the tree.
+ *
+ * @param {Object}                              state        Global application state.
+ * @param {BlockEditingMode|BlockEditingMode[]} mode         The editing mode(s)
+ *                                                           to filter by.
+ * @param {?string}                             rootClientId Optional root
+ *                                                           client ID of block
+ *                                                           list.
+ *
+ * @return {Object[]} Tree of block objects with only clientID and innerBlocks set.
+ */
+export const getClientIdsTreeWithBlockEditingMode = createSelector(
+	( state, mode, rootClientId = '' ) => {
+		const modes = Array.isArray( mode ) ? mode : [ mode ];
+		return getBlockOrder( state, rootClientId ).flatMap( ( clientId ) => {
+			if ( modes.includes( getBlockEditingMode( state, clientId ) ) ) {
+				return [
+					{
+						clientId,
+						innerBlocks: getClientIdsTreeWithBlockEditingMode(
+							state,
+							mode,
+							clientId
+						),
+					},
+				];
+			}
+			return getClientIdsTreeWithBlockEditingMode(
+				state,
+				mode,
+				clientId
+			);
+		} );
+	},
+	( state ) => [
+		state.blocks.order,
+		state.blockEditingModes,
+		state.settings.templateLock,
+		state.blockListSettings,
+	]
+);

--- a/packages/block-editor/src/store/private-selectors.js
+++ b/packages/block-editor/src/store/private-selectors.js
@@ -137,39 +137,29 @@ export const isBlockSubtreeDisabled = createSelector(
 );
 
 /**
- * Returns a tree of block objects with only clientID and innerBlocks set. Only
- * blocks with the given editing mode are included in the tree.
+ * Returns a tree of block objects with only clientID and innerBlocks set.
+ * Blocks with a 'disabled' editing mode are not included.
  *
- * @param {Object}                              state        Global application state.
- * @param {BlockEditingMode|BlockEditingMode[]} mode         The editing mode(s)
- *                                                           to filter by.
- * @param {?string}                             rootClientId Optional root
- *                                                           client ID of block
- *                                                           list.
+ * @param {Object}  state        Global application state.
+ * @param {?string} rootClientId Optional root client ID of block list.
  *
  * @return {Object[]} Tree of block objects with only clientID and innerBlocks set.
  */
-export const getClientIdsTreeWithBlockEditingMode = createSelector(
-	( state, mode, rootClientId = '' ) => {
-		const modes = Array.isArray( mode ) ? mode : [ mode ];
+export const getListViewClientIdsTree = createSelector(
+	( state, rootClientId = '' ) => {
 		return getBlockOrder( state, rootClientId ).flatMap( ( clientId ) => {
-			if ( modes.includes( getBlockEditingMode( state, clientId ) ) ) {
+			if ( getBlockEditingMode( state, clientId ) !== 'disabled' ) {
 				return [
 					{
 						clientId,
-						innerBlocks: getClientIdsTreeWithBlockEditingMode(
+						innerBlocks: getListViewClientIdsTree(
 							state,
-							mode,
 							clientId
 						),
 					},
 				];
 			}
-			return getClientIdsTreeWithBlockEditingMode(
-				state,
-				mode,
-				clientId
-			);
+			return getListViewClientIdsTree( state, clientId );
 		} );
 	},
 	( state ) => [

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -187,16 +187,27 @@ export function getBlocks( state, rootClientId ) {
  * Returns a stripped down block object containing only its client ID,
  * and its inner blocks' client IDs.
  *
+ * @deprecated
+ *
  * @param {Object} state    Editor state.
  * @param {string} clientId Client ID of the block to get.
  *
  * @return {Object} Client IDs of the post blocks.
  */
 export const __unstableGetClientIdWithClientIdsTree = createSelector(
-	( state, clientId ) => ( {
-		clientId,
-		innerBlocks: __unstableGetClientIdsTree( state, clientId ),
-	} ),
+	( state, clientId ) => {
+		deprecated(
+			"wp.data.select( 'core/block-editor' ).__unstableGetClientIdWithClientIdsTree",
+			{
+				since: '6.3',
+				version: '6.5',
+			}
+		);
+		return {
+			clientId,
+			innerBlocks: __unstableGetClientIdsTree( state, clientId ),
+		};
+	},
 	( state ) => [ state.blocks.order ]
 );
 
@@ -205,16 +216,26 @@ export const __unstableGetClientIdWithClientIdsTree = createSelector(
  * given root, consisting of stripped down block objects containing only
  * their client IDs, and their inner blocks' client IDs.
  *
+ * @deprecated
+ *
  * @param {Object}  state        Editor state.
  * @param {?string} rootClientId Optional root client ID of block list.
  *
  * @return {Object[]} Client IDs of the post blocks.
  */
 export const __unstableGetClientIdsTree = createSelector(
-	( state, rootClientId = '' ) =>
-		getBlockOrder( state, rootClientId ).map( ( clientId ) =>
+	( state, rootClientId = '' ) => {
+		deprecated(
+			"wp.data.select( 'core/block-editor' ).__unstableGetClientIdsTree",
+			{
+				since: '6.3',
+				version: '6.5',
+			}
+		);
+		return getBlockOrder( state, rootClientId ).map( ( clientId ) =>
 			__unstableGetClientIdWithClientIdsTree( state, clientId )
-		),
+		);
+	},
 	( state ) => [ state.blocks.order ]
 );
 

--- a/packages/block-editor/src/store/test/private-selectors.js
+++ b/packages/block-editor/src/store/test/private-selectors.js
@@ -11,6 +11,7 @@ import {
 	getLastInsertedBlocksClientIds,
 	getBlockEditingMode,
 	isBlockSubtreeDisabled,
+	getClientIdsTreeWithBlockEditingMode,
 } from '../private-selectors';
 
 jest.mock( '@wordpress/data/src/select', () => ( {
@@ -74,7 +75,13 @@ describe( 'private selectors', () => {
 					[ 'e178812d-ce5e-48c7-a945-8ae4ffcbbb7c', {} ], // | |  Paragraph
 				] ),
 				order: new Map( [
-					[ '', [ '6cf70164-9097-4460-bcbf-200560546988' ] ],
+					[
+						'',
+						[
+							'6cf70164-9097-4460-bcbf-200560546988',
+							'ef45d5fd-5234-4fd5-ac4f-c3736c7f9337',
+						],
+					],
 					[ '6cf70164-9097-4460-bcbf-200560546988', [] ],
 					[
 						'ef45d5fd-5234-4fd5-ac4f-c3736c7f9337',
@@ -379,6 +386,154 @@ describe( 'private selectors', () => {
 						'ef45d5fd-5234-4fd5-ac4f-c3736c7f9337'
 					)
 				).toBe( false );
+			} );
+		} );
+
+		describe( 'getClientIdsTreeWithBlockEditingMode', () => {
+			it( 'should return tree containing only clientId and innerBlocks', () => {
+				const state = {
+					...baseState,
+					blockEditingModes: new Map( [] ),
+				};
+				expect(
+					getClientIdsTreeWithBlockEditingMode( state, 'default' )
+				).toEqual( [
+					{
+						clientId: '6cf70164-9097-4460-bcbf-200560546988',
+						innerBlocks: [],
+					},
+					{
+						clientId: 'ef45d5fd-5234-4fd5-ac4f-c3736c7f9337',
+						innerBlocks: [
+							{
+								clientId:
+									'b26fc763-417d-4f01-b81c-2ec61e14a972',
+								innerBlocks: [],
+							},
+							{
+								clientId:
+									'9b9c5c3f-2e46-4f02-9e14-9fe9515b958f',
+								innerBlocks: [
+									{
+										clientId:
+											'b3247f75-fd94-4fef-97f9-5bfd162cc416',
+										innerBlocks: [],
+									},
+									{
+										clientId:
+											'e178812d-ce5e-48c7-a945-8ae4ffcbbb7c',
+										innerBlocks: [],
+									},
+								],
+							},
+						],
+					},
+				] );
+			} );
+
+			it( 'should return a subtree when rootBlockClientId is given', () => {
+				const state = {
+					...baseState,
+					blockEditingModes: new Map( [] ),
+				};
+				expect(
+					getClientIdsTreeWithBlockEditingMode(
+						state,
+						'default',
+						'ef45d5fd-5234-4fd5-ac4f-c3736c7f9337'
+					)
+				).toEqual( [
+					{
+						clientId: 'b26fc763-417d-4f01-b81c-2ec61e14a972',
+						innerBlocks: [],
+					},
+					{
+						clientId: '9b9c5c3f-2e46-4f02-9e14-9fe9515b958f',
+						innerBlocks: [
+							{
+								clientId:
+									'b3247f75-fd94-4fef-97f9-5bfd162cc416',
+								innerBlocks: [],
+							},
+							{
+								clientId:
+									'e178812d-ce5e-48c7-a945-8ae4ffcbbb7c',
+								innerBlocks: [],
+							},
+						],
+					},
+				] );
+			} );
+
+			it( 'should filter by a single mode', () => {
+				const state = {
+					...baseState,
+					blockEditingModes: new Map( [
+						[
+							'b26fc763-417d-4f01-b81c-2ec61e14a972',
+							'contentOnly',
+						],
+						[ '9b9c5c3f-2e46-4f02-9e14-9fe9515b958f', 'disabled' ],
+					] ),
+				};
+				expect(
+					getClientIdsTreeWithBlockEditingMode( state, 'disabled' )
+				).toEqual( [
+					{
+						clientId: '9b9c5c3f-2e46-4f02-9e14-9fe9515b958f',
+						innerBlocks: [
+							{
+								clientId:
+									'b3247f75-fd94-4fef-97f9-5bfd162cc416',
+								innerBlocks: [],
+							},
+							{
+								clientId:
+									'e178812d-ce5e-48c7-a945-8ae4ffcbbb7c',
+								innerBlocks: [],
+							},
+						],
+					},
+				] );
+			} );
+
+			it( 'should filter by multiple modes', () => {
+				const state = {
+					...baseState,
+					blockEditingModes: new Map( [
+						[
+							'b26fc763-417d-4f01-b81c-2ec61e14a972',
+							'contentOnly',
+						],
+						[ '9b9c5c3f-2e46-4f02-9e14-9fe9515b958f', 'disabled' ],
+					] ),
+				};
+				expect(
+					getClientIdsTreeWithBlockEditingMode( state, [
+						'contentOnly',
+						'disabled',
+					] )
+				).toEqual( [
+					{
+						clientId: 'b26fc763-417d-4f01-b81c-2ec61e14a972',
+						innerBlocks: [],
+					},
+					{
+						clientId: '9b9c5c3f-2e46-4f02-9e14-9fe9515b958f',
+						innerBlocks: [
+							{
+								clientId:
+									'b3247f75-fd94-4fef-97f9-5bfd162cc416',
+								innerBlocks: [],
+							},
+							{
+								clientId:
+									'e178812d-ce5e-48c7-a945-8ae4ffcbbb7c',
+								innerBlocks: [],
+							},
+						],
+					},
+				] );
 			} );
 		} );
 	} );

--- a/packages/block-editor/src/store/test/private-selectors.js
+++ b/packages/block-editor/src/store/test/private-selectors.js
@@ -11,7 +11,7 @@ import {
 	getLastInsertedBlocksClientIds,
 	getBlockEditingMode,
 	isBlockSubtreeDisabled,
-	getClientIdsTreeWithBlockEditingMode,
+	getListViewClientIdsTree,
 } from '../private-selectors';
 
 jest.mock( '@wordpress/data/src/select', () => ( {
@@ -388,153 +388,170 @@ describe( 'private selectors', () => {
 				).toBe( false );
 			} );
 		} );
+	} );
 
-		describe( 'getClientIdsTreeWithBlockEditingMode', () => {
-			it( 'should return tree containing only clientId and innerBlocks', () => {
-				const state = {
-					...baseState,
-					blockEditingModes: new Map( [] ),
-				};
-				expect(
-					getClientIdsTreeWithBlockEditingMode( state, 'default' )
-				).toEqual( [
-					{
-						clientId: '6cf70164-9097-4460-bcbf-200560546988',
-						innerBlocks: [],
-					},
-					{
-						clientId: 'ef45d5fd-5234-4fd5-ac4f-c3736c7f9337',
-						innerBlocks: [
-							{
-								clientId:
-									'b26fc763-417d-4f01-b81c-2ec61e14a972',
-								innerBlocks: [],
-							},
-							{
-								clientId:
-									'9b9c5c3f-2e46-4f02-9e14-9fe9515b958f',
-								innerBlocks: [
-									{
-										clientId:
-											'b3247f75-fd94-4fef-97f9-5bfd162cc416',
-										innerBlocks: [],
-									},
-									{
-										clientId:
-											'e178812d-ce5e-48c7-a945-8ae4ffcbbb7c',
-										innerBlocks: [],
-									},
-								],
-							},
+	describe( 'getListViewClientIdsTree', () => {
+		const baseState = {
+			settings: {},
+			blocks: {
+				byClientId: new Map( [
+					[ '6cf70164-9097-4460-bcbf-200560546988', {} ], // Header
+					[ 'ef45d5fd-5234-4fd5-ac4f-c3736c7f9337', {} ], // Group
+					[ 'b26fc763-417d-4f01-b81c-2ec61e14a972', {} ], // |  Post Title
+					[ '9b9c5c3f-2e46-4f02-9e14-9fe9515b958f', {} ], // |  Post Content
+					[ 'b3247f75-fd94-4fef-97f9-5bfd162cc416', {} ], // | |  Paragraph
+					[ 'e178812d-ce5e-48c7-a945-8ae4ffcbbb7c', {} ], // | |  Paragraph
+				] ),
+				order: new Map( [
+					[
+						'',
+						[
+							'6cf70164-9097-4460-bcbf-200560546988',
+							'ef45d5fd-5234-4fd5-ac4f-c3736c7f9337',
 						],
-					},
-				] );
-			} );
-
-			it( 'should return a subtree when rootBlockClientId is given', () => {
-				const state = {
-					...baseState,
-					blockEditingModes: new Map( [] ),
-				};
-				expect(
-					getClientIdsTreeWithBlockEditingMode(
-						state,
-						'default',
-						'ef45d5fd-5234-4fd5-ac4f-c3736c7f9337'
-					)
-				).toEqual( [
-					{
-						clientId: 'b26fc763-417d-4f01-b81c-2ec61e14a972',
-						innerBlocks: [],
-					},
-					{
-						clientId: '9b9c5c3f-2e46-4f02-9e14-9fe9515b958f',
-						innerBlocks: [
-							{
-								clientId:
-									'b3247f75-fd94-4fef-97f9-5bfd162cc416',
-								innerBlocks: [],
-							},
-							{
-								clientId:
-									'e178812d-ce5e-48c7-a945-8ae4ffcbbb7c',
-								innerBlocks: [],
-							},
-						],
-					},
-				] );
-			} );
-
-			it( 'should filter by a single mode', () => {
-				const state = {
-					...baseState,
-					blockEditingModes: new Map( [
+					],
+					[ '6cf70164-9097-4460-bcbf-200560546988', [] ],
+					[
+						'ef45d5fd-5234-4fd5-ac4f-c3736c7f9337',
 						[
 							'b26fc763-417d-4f01-b81c-2ec61e14a972',
-							'contentOnly',
+							'9b9c5c3f-2e46-4f02-9e14-9fe9515b958f',
 						],
-						[ '9b9c5c3f-2e46-4f02-9e14-9fe9515b958f', 'disabled' ],
-					] ),
-				};
-				expect(
-					getClientIdsTreeWithBlockEditingMode( state, 'disabled' )
-				).toEqual( [
-					{
-						clientId: '9b9c5c3f-2e46-4f02-9e14-9fe9515b958f',
-						innerBlocks: [
-							{
-								clientId:
-									'b3247f75-fd94-4fef-97f9-5bfd162cc416',
-								innerBlocks: [],
-							},
-							{
-								clientId:
-									'e178812d-ce5e-48c7-a945-8ae4ffcbbb7c',
-								innerBlocks: [],
-							},
-						],
-					},
-				] );
-			} );
-
-			it( 'should filter by multiple modes', () => {
-				const state = {
-					...baseState,
-					blockEditingModes: new Map( [
+					],
+					[ 'b26fc763-417d-4f01-b81c-2ec61e14a972', [] ],
+					[
+						'9b9c5c3f-2e46-4f02-9e14-9fe9515b958f',
 						[
-							'b26fc763-417d-4f01-b81c-2ec61e14a972',
-							'contentOnly',
+							'b3247f75-fd94-4fef-97f9-5bfd162cc416',
+							'e178812d-ce5e-48c7-a945-8ae4ffcbbb7c',
 						],
-						[ '9b9c5c3f-2e46-4f02-9e14-9fe9515b958f', 'disabled' ],
-					] ),
-				};
-				expect(
-					getClientIdsTreeWithBlockEditingMode( state, [
-						'contentOnly',
-						'disabled',
-					] )
-				).toEqual( [
-					{
-						clientId: 'b26fc763-417d-4f01-b81c-2ec61e14a972',
-						innerBlocks: [],
-					},
-					{
-						clientId: '9b9c5c3f-2e46-4f02-9e14-9fe9515b958f',
-						innerBlocks: [
-							{
-								clientId:
-									'b3247f75-fd94-4fef-97f9-5bfd162cc416',
-								innerBlocks: [],
-							},
-							{
-								clientId:
-									'e178812d-ce5e-48c7-a945-8ae4ffcbbb7c',
-								innerBlocks: [],
-							},
-						],
-					},
-				] );
-			} );
+					],
+					[ 'b3247f75-fd94-4fef-97f9-5bfd162cc416', [] ],
+					[ 'e178812d-ce5e-48c7-a945-8ae4ffcbbb7c', [] ],
+				] ),
+				parents: new Map( [
+					[ '6cf70164-9097-4460-bcbf-200560546988', '' ],
+					[ 'ef45d5fd-5234-4fd5-ac4f-c3736c7f9337', '' ],
+					[
+						'b26fc763-417d-4f01-b81c-2ec61e14a972',
+						'ef45d5fd-5234-4fd5-ac4f-c3736c7f9337',
+					],
+					[
+						'9b9c5c3f-2e46-4f02-9e14-9fe9515b958f',
+						'ef45d5fd-5234-4fd5-ac4f-c3736c7f9337',
+					],
+					[
+						'b3247f75-fd94-4fef-97f9-5bfd162cc416',
+						'9b9c5c3f-2e46-4f02-9e14-9fe9515b958f',
+					],
+					[
+						'e178812d-ce5e-48c7-a945-8ae4ffcbbb7c',
+						'9b9c5c3f-2e46-4f02-9e14-9fe9515b958f',
+					],
+				] ),
+			},
+			blockListSettings: {
+				'ef45d5fd-5234-4fd5-ac4f-c3736c7f9337': {},
+				'9b9c5c3f-2e46-4f02-9e14-9fe9515b958f': {},
+			},
+		};
+
+		it( 'should return tree containing only clientId and innerBlocks', () => {
+			const state = {
+				...baseState,
+				blockEditingModes: new Map( [] ),
+			};
+			expect( getListViewClientIdsTree( state ) ).toEqual( [
+				{
+					clientId: '6cf70164-9097-4460-bcbf-200560546988',
+					innerBlocks: [],
+				},
+				{
+					clientId: 'ef45d5fd-5234-4fd5-ac4f-c3736c7f9337',
+					innerBlocks: [
+						{
+							clientId: 'b26fc763-417d-4f01-b81c-2ec61e14a972',
+							innerBlocks: [],
+						},
+						{
+							clientId: '9b9c5c3f-2e46-4f02-9e14-9fe9515b958f',
+							innerBlocks: [
+								{
+									clientId:
+										'b3247f75-fd94-4fef-97f9-5bfd162cc416',
+									innerBlocks: [],
+								},
+								{
+									clientId:
+										'e178812d-ce5e-48c7-a945-8ae4ffcbbb7c',
+									innerBlocks: [],
+								},
+							],
+						},
+					],
+				},
+			] );
+		} );
+
+		it( 'should return a subtree when rootBlockClientId is given', () => {
+			const state = {
+				...baseState,
+				blockEditingModes: new Map( [] ),
+			};
+			expect(
+				getListViewClientIdsTree(
+					state,
+					'ef45d5fd-5234-4fd5-ac4f-c3736c7f9337'
+				)
+			).toEqual( [
+				{
+					clientId: 'b26fc763-417d-4f01-b81c-2ec61e14a972',
+					innerBlocks: [],
+				},
+				{
+					clientId: '9b9c5c3f-2e46-4f02-9e14-9fe9515b958f',
+					innerBlocks: [
+						{
+							clientId: 'b3247f75-fd94-4fef-97f9-5bfd162cc416',
+							innerBlocks: [],
+						},
+						{
+							clientId: 'e178812d-ce5e-48c7-a945-8ae4ffcbbb7c',
+							innerBlocks: [],
+						},
+					],
+				},
+			] );
+		} );
+
+		it( 'should filter out disabled blocks', () => {
+			const state = {
+				...baseState,
+				blockEditingModes: new Map( [
+					[ '', 'disabled' ],
+					[ 'b26fc763-417d-4f01-b81c-2ec61e14a972', 'contentOnly' ],
+					[ '9b9c5c3f-2e46-4f02-9e14-9fe9515b958f', 'contentOnly' ],
+				] ),
+			};
+			expect( getListViewClientIdsTree( state ) ).toEqual( [
+				{
+					clientId: 'b26fc763-417d-4f01-b81c-2ec61e14a972',
+					innerBlocks: [],
+				},
+				{
+					clientId: '9b9c5c3f-2e46-4f02-9e14-9fe9515b958f',
+					innerBlocks: [
+						{
+							clientId: 'b3247f75-fd94-4fef-97f9-5bfd162cc416',
+							innerBlocks: [],
+						},
+						{
+							clientId: 'e178812d-ce5e-48c7-a945-8ae4ffcbbb7c',
+							innerBlocks: [],
+						},
+					],
+				},
+			] );
 		} );
 	} );
 } );

--- a/packages/block-editor/src/store/test/selectors.js
+++ b/packages/block-editor/src/store/test/selectors.js
@@ -4734,6 +4734,7 @@ describe( '__unstableGetClientIdWithClientIdsTree', () => {
 				{ clientId: 'baz', innerBlocks: [] },
 			],
 		} );
+		expect( console ).toHaveWarned();
 	} );
 } );
 describe( '__unstableGetClientIdsTree', () => {


### PR DESCRIPTION
## What?
Follows https://github.com/WordPress/gutenberg/pull/50643.

Fixes this comment left by @Mamaduka https://github.com/WordPress/gutenberg/pull/50643#discussion_r1210261515.

Reduces the number of times List View re-renders while typing into post content.

## Why?
Typing performance!

## How?
- Moves the logic of filtering out disabled blocks from the client IDs tree into a selector so that it can be memoized and return stable objects.
- Deprecates `__unstableGetClientIdsTree` as it's not used anymore. I checked wpdirectory.net and the only hits are plugins that bundle `@wordpress/block-editor`.

## Testing Instructions
1. Go to  Appearance → Editor.
2. Go to Pages and select a page to edit.
3. Open React DevTools and enable component render highlighting.
4. Open the List View.
5. Type text into the Post Content block.

## Screenshots or screencast <!-- if applicable -→

Before:

https://github.com/WordPress/gutenberg/assets/612155/537fa185-ebdd-447c-9d3b-c85389457c13

After:

https://github.com/WordPress/gutenberg/assets/612155/d59734dd-1bc1-4b6e-95d2-884a00a1f7a9