### PR TITLE
Bugfix/command centre accessibility issue

### DIFF
--- a/packages/edit-site/src/components/header-edit-mode/document-actions/index.js
+++ b/packages/edit-site/src/components/header-edit-mode/document-actions/index.js
@@ -12,7 +12,6 @@ import {
 	Button,
 	VisuallyHidden,
 	__experimentalText as Text,
-	__experimentalHStack as HStack,
 } from '@wordpress/components';
 import { BlockIcon } from '@wordpress/block-editor';
 import { store as commandsStore } from '@wordpress/commands';
@@ -144,6 +143,13 @@ function BaseDocumentActions( { className, icon, children, onBack } ) {
 		<div
 			className={ classnames( 'edit-site-document-actions', className ) }
 		>
+			<Text
+				size="body"
+				as="h1"
+				className="edit-site-document-actions__title"
+			>
+				{ children }
+			</Text>
 			{ onBack && (
 				<Button
 					className="edit-site-document-actions__back"
@@ -160,16 +166,8 @@ function BaseDocumentActions( { className, icon, children, onBack } ) {
 				className="edit-site-document-actions__command"
 				onClick={ () => openCommandCenter() }
 			>
-				<HStack
-					className="edit-site-document-actions__title"
-					spacing={ 1 }
-					justify="center"
-				>
-					<BlockIcon icon={ icon } />
-					<Text size="body" as="h1">
-						{ children }
-					</Text>
-				</HStack>
+				<BlockIcon icon={ icon } />
+				<Text as="span">{ __( 'Open command center' ) }</Text>
 				<span className="edit-site-document-actions__shortcut">
 					{ displayShortcut.primary( 'k' ) }
 				</span>

--- a/packages/edit-site/src/components/header-edit-mode/document-actions/index.js
+++ b/packages/edit-site/src/components/header-edit-mode/document-actions/index.js
@@ -143,13 +143,12 @@ function BaseDocumentActions( { className, icon, children, onBack } ) {
 		<div
 			className={ classnames( 'edit-site-document-actions', className ) }
 		>
-			<Text
-				size="body"
+			<VisuallyHidden
 				as="h1"
 				className="edit-site-document-actions__title"
 			>
 				{ children }
-			</Text>
+			</VisuallyHidden>
 			{ onBack && (
 				<Button
 					className="edit-site-document-actions__back"
@@ -167,7 +166,7 @@ function BaseDocumentActions( { className, icon, children, onBack } ) {
 				onClick={ () => openCommandCenter() }
 			>
 				<BlockIcon icon={ icon } />
-				<Text as="span">{ __( 'Open command center' ) }</Text>
+				<Text as="span">{ __( 'Command center' ) }</Text>
 				<span className="edit-site-document-actions__shortcut">
 					{ displayShortcut.primary( 'k' ) }
 				</span>

--- a/packages/edit-site/src/components/header-edit-mode/document-actions/style.scss
+++ b/packages/edit-site/src/components/header-edit-mode/document-actions/style.scss
@@ -1,44 +1,26 @@
 .edit-site-document-actions {
-	display: grid;
-	grid-template-columns: 1fr 2fr 1fr;
-	height: $button-size;
-	// Flex items will, by default, refuse to shrink below a minimum
-	// intrinsic width. In order to shrink this flexbox item, and
-	// subsequently truncate child text, we set an explicit min-width.
-	// See https://dev.w3.org/csswg/css-flexbox/#min-size-auto
-	min-width: 0;
-	background: $gray-100;
-	border-radius: 4px;
-	width: min(100%, 450px);
-	overflow: hidden;
-
-	&:hover {
-		color: currentColor;
-		background: $gray-200;
-	}
+	align-items: center;
+	display: flex;
+	justify-items: center;
 }
 
 .edit-site-document-actions__command {
-	grid-column: 1 / -1;
-	display: grid;
-	grid-template-columns: 1fr 2fr 1fr;
-	grid-row: 1;
+	align-items: center;
+	background-color: $gray-100;
+	border-radius: 4px;
+	display: flex;
+	height: auto;
+	justify-content: space-between;
+	margin-left: 1rem;
+	width: min(100%, 450px);
+
+	> span + span {
+		padding-left: clamp(0.25rem, 0.5rem, 1rem);
+	}
 }
 
 
 .edit-site-document-actions__title {
-	flex-grow: 1;
-	color: var(--wp-block-synced-color);
-	overflow: hidden;
-	grid-column: 2 / 3;
-
-	h1 {
-		white-space: nowrap;
-		overflow: hidden;
-		text-overflow: ellipsis;
-		color: var(--wp-block-synced-color);
-	}
-
 	.edit-site-document-actions.is-page & {
 		color: $gray-800;
 

--- a/packages/edit-site/src/components/header-edit-mode/document-actions/style.scss
+++ b/packages/edit-site/src/components/header-edit-mode/document-actions/style.scss
@@ -11,7 +11,6 @@
 	display: flex;
 	height: auto;
 	justify-content: space-between;
-	margin-left: 1rem;
 	width: min(100%, 450px);
 
 	> span + span {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixed accessibility issues and html validation issues from site-editor top bar. Made sure button has clear :focus styles

## Why?
Issue was brought up by #51460 

## How?
Moved "Current template" name from the button to before it. Changed button label to reflect what the button actually does.

I am not satisfied that I set h1 (Current template name) as visually hidden. But it simply does not fit in smaller screens.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a Post or Page
2. Start hitting tab button to confirm the "Command center" button has :focus style
3. Check page with voice over to confirm it describes what the "Command center" button does
4. Analyze page heading structure of your browser plugin of your choice that there is "visible" h1 in the page

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
![Screenshot 2023-06-15 at 9 53 40](https://github.com/WordPress/gutenberg/assets/62872075/114adcb8-abd4-409d-88ab-aea36c007379)
