### PR TITLE
Unify animation metrics in site editor

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 -   `BorderControl`: Improve color code readability in aria-label ([#51197](https://github.com/WordPress/gutenberg/pull/51197)).
 -   `Dropdown` and `DropdownMenu`: use internal context system to automatically pick the toolbar popover variant when rendered inside the `Toolbar` component ([#51154](https://github.com/WordPress/gutenberg/pull/51154)).
+-   `Navigator`: Small reduction in animation speed. ([#51525](https://github.com/WordPress/gutenberg/pull/51525)).
+
 
 ### Bug Fix
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -6,14 +6,16 @@
 
 -   `Popover`: Allow legitimate 0 positions to update popover position ([#51320](https://github.com/WordPress/gutenberg/pull/51320)).
 
+### Enhancements
+
+-   `Navigator`: Small reduction in animation speed. ([#51525](https://github.com/WordPress/gutenberg/pull/51525)).
+
 ## 25.1.0 (2023-06-07)
 
 ### Enhancements
 
 -   `BorderControl`: Improve color code readability in aria-label ([#51197](https://github.com/WordPress/gutenberg/pull/51197)).
 -   `Dropdown` and `DropdownMenu`: use internal context system to automatically pick the toolbar popover variant when rendered inside the `Toolbar` component ([#51154](https://github.com/WordPress/gutenberg/pull/51154)).
--   `Navigator`: Small reduction in animation speed. ([#51525](https://github.com/WordPress/gutenberg/pull/51525)).
-
 
 ### Bug Fix
 

--- a/packages/components/src/navigator/navigator-screen/component.tsx
+++ b/packages/components/src/navigator/navigator-screen/component.tsx
@@ -35,8 +35,8 @@ import { NavigatorContext } from '../context';
 import type { NavigatorScreenProps } from '../types';
 
 const animationEnterDelay = 0;
-const animationEnterDuration = 0.3;
-const animationExitDuration = 0.3;
+const animationEnterDuration = 0.2;
+const animationExitDuration = 0.2;
 const animationExitDelay = 0;
 
 // Props specific to `framer-motion` can't be currently passed to `NavigatorScreen`,

--- a/packages/components/src/navigator/navigator-screen/component.tsx
+++ b/packages/components/src/navigator/navigator-screen/component.tsx
@@ -35,8 +35,8 @@ import { NavigatorContext } from '../context';
 import type { NavigatorScreenProps } from '../types';
 
 const animationEnterDelay = 0;
-const animationEnterDuration = 0.14;
-const animationExitDuration = 0.14;
+const animationEnterDuration = 0.3;
+const animationExitDuration = 0.3;
 const animationExitDelay = 0;
 
 // Props specific to `framer-motion` can't be currently passed to `NavigatorScreen`,

--- a/packages/edit-site/src/components/layout/index.js
+++ b/packages/edit-site/src/components/layout/index.js
@@ -54,7 +54,7 @@ const { useCommands } = unlock( coreCommandsPrivateApis );
 const { useCommandContext } = unlock( commandsPrivateApis );
 const { useLocation } = unlock( routerPrivateApis );
 
-const ANIMATION_DURATION = 0.5;
+const ANIMATION_DURATION = 0.3;
 
 export default function Layout() {
 	// This ensures the edited entity id and type are initialized properly.
@@ -161,7 +161,7 @@ export default function Layout() {
 								duration: disableMotion
 									? 0
 									: ANIMATION_DURATION,
-								ease: 'easeOut',
+								ease: 'easeInOut',
 							} }
 						>
 							{ isEditing && <Header /> }
@@ -185,7 +185,7 @@ export default function Layout() {
 								transition={ {
 									type: 'tween',
 									duration: ANIMATION_DURATION,
-									ease: 'easeOut',
+									ease: 'easeInOut',
 								} }
 								className="edit-site-layout__sidebar"
 							>
@@ -226,7 +226,7 @@ export default function Layout() {
 																	isResizing
 																		? 0
 																		: 0.5,
-																ease: 'easeOut',
+																ease: 'easeInOut',
 															},
 													  }
 													: {}
@@ -240,7 +240,7 @@ export default function Layout() {
 													disableMotion || isResizing
 														? 0
 														: ANIMATION_DURATION,
-												ease: 'easeOut',
+												ease: 'easeInOut',
 											} }
 										>
 											<ErrorBoundary>

--- a/packages/edit-site/src/components/layout/index.js
+++ b/packages/edit-site/src/components/layout/index.js
@@ -54,7 +54,7 @@ const { useCommands } = unlock( coreCommandsPrivateApis );
 const { useCommandContext } = unlock( commandsPrivateApis );
 const { useLocation } = unlock( routerPrivateApis );
 
-const ANIMATION_DURATION = 0.3;
+const ANIMATION_DURATION = 0.45;
 
 export default function Layout() {
 	// This ensures the edited entity id and type are initialized properly.

--- a/packages/edit-site/src/components/layout/index.js
+++ b/packages/edit-site/src/components/layout/index.js
@@ -54,7 +54,7 @@ const { useCommands } = unlock( coreCommandsPrivateApis );
 const { useCommandContext } = unlock( commandsPrivateApis );
 const { useLocation } = unlock( routerPrivateApis );
 
-const ANIMATION_DURATION = 0.45;
+const ANIMATION_DURATION = 0.4;
 
 export default function Layout() {
 	// This ensures the edited entity id and type are initialized properly.


### PR DESCRIPTION
## What?
Unifies animation duration and easing metrics in the site editor animation. Specifically the Navigator and the View/Edit toggle. 

## Why?
I appreciate this may be subjective, hence the Try branch, but I find consistent timing / behavior across animations that are often experienced in close proximity creates a stronger feeling of cohesion in the design.  

## Testing Instructions
* Open the Site Editor in two browser tabs. One on this branch, and one on trunk.
* In both tabs navigate around panels in the sidebar, and in/out of edit view.
* See if you have a preference :) 

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/846565/e69ce868-3341-4700-830e-4ef6a5196d02

