### PR TITLE
Get Navigation overlay icons from block editor settings

### DIFF
--- a/lib/block-editor-settings.php
+++ b/lib/block-editor-settings.php
@@ -146,6 +146,18 @@ function gutenberg_get_block_editor_settings( $settings ) {
 			);
 	}
 
+	$settings['navigationBlockOverlayIcons'] = array(
+		array(
+			'label' => __( 'Handle icon', 'gutenberg' ),
+			'icon'  => 'handle',
+		),
+		array(
+			'label' => __( 'Menu icon', 'gutenberg' ),
+			'icon'  => 'menu',
+		),
+
+	);
+
 	return $settings;
 }
 add_filter( 'block_editor_settings_all', 'gutenberg_get_block_editor_settings', 0 );

--- a/packages/block-library/src/navigation/edit/overlay-menu-preview.js
+++ b/packages/block-library/src/navigation/edit/overlay-menu-preview.js
@@ -7,6 +7,8 @@ import {
 	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { useSelect } from '@wordpress/data';
+import { store as blockEditorStore } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
@@ -14,6 +16,16 @@ import { __ } from '@wordpress/i18n';
 import OverlayMenuIcon from './overlay-menu-icon';
 
 export default function OverlayMenuPreview( { setAttributes, hasIcon, icon } ) {
+	// get the icons from the block editor settings via a useSelect.
+	// they are under the key "navigationBlockOverlayIcons"
+
+	const navigationBlockOverlayIcons = useSelect(
+		( select ) =>
+			select( blockEditorStore ).getSettings()
+				.navigationBlockOverlayIcons,
+		[]
+	);
+
 	return (
 		<>
 			<ToggleControl
@@ -33,16 +45,16 @@ export default function OverlayMenuPreview( { setAttributes, hasIcon, icon } ) {
 				onChange={ ( value ) => setAttributes( { icon: value } ) }
 				isBlock
 			>
-				<ToggleGroupControlOption
-					value="handle"
-					aria-label={ __( 'handle' ) }
-					label={ <OverlayMenuIcon icon="handle" /> }
-				/>
-				<ToggleGroupControlOption
-					value="menu"
-					aria-label={ __( 'menu' ) }
-					label={ <OverlayMenuIcon icon="menu" /> }
-				/>
+				{ navigationBlockOverlayIcons.map(
+					( { label, icon: _icon } ) => (
+						<ToggleGroupControlOption
+							key={ _icon }
+							value={ _icon }
+							aria-label={ label }
+							label={ <OverlayMenuIcon icon={ _icon } /> }
+						/>
+					)
+				) }
 			</ToggleGroupControl>
 		</>
 	);


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Experiment relating to https://github.com/WordPress/gutenberg/issues/37930

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
