### PR TITLE
Search Block: Fix problem with buttons not outputting primary status

### DIFF
--- a/packages/block-library/src/search/edit.js
+++ b/packages/block-library/src/search/edit.js
@@ -440,8 +440,8 @@ export default function SearchEdit( {
 										key={ widthValue }
 										isSmall
 										variant={
-											`${ widthValue }%` ===
-											`${ width }${ widthUnit }`
+											widthValue === width &&
+											widthUnit === '%'
 												? 'primary'
 												: undefined
 										}


### PR DESCRIPTION
## What?
This PR fixes a problem where the width value matches the value of one of the buttons, but does not become the `primary` status.

![search](https://github.com/WordPress/gutenberg/assets/54422211/f63b2570-69a2-489c-884c-dd13e95a456c)

## Why?
This issue is very strange. As far as the code base is concerned, if the value set matches one of the buttons and the unit is a percentage, it should be `"primary"`.

https://github.com/WordPress/gutenberg/blob/12a01d58762215def030ab7f262a68210d1f42cc/packages/block-library/src/search/edit.js#L442-L447

However, the actual value that the `Button` component receives in the `variant` prop is the number zero.

![variant_zero](https://github.com/WordPress/gutenberg/assets/54422211/8dbda8df-0fc0-4e73-b1a4-50825a0d7d75)

I am wondering why it is a numeric zero and not a `primary` string. At least as of #24666, when this feature was implemented, it appears that the primary state was correctly applied.

As far as the built source is concerned, it is indeed replaced by zero. This may be due to an update to `babel`.

![babel](https://github.com/WordPress/gutenberg/assets/54422211/4bfc9f51-75a6-44fa-a139-9627a3d14cf8)

## How?
After much trial and error, I found that comparing each variable individually, without comparing concatenated strings, correctly outputs the primary status.

## Testing Instructions
When any button is pressed or a number or unit is changed, make sure that the corresponding button becomes the primary status.

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/54422211/d6578651-476a-4229-b66b-aa1234cdeef2



