### PR TITLE
Performance: Skip some duplicate iteration

### DIFF
--- a/packages/block-editor/src/components/rich-text/use-format-types.js
+++ b/packages/block-editor/src/components/rich-text/use-format-types.js
@@ -30,22 +30,27 @@ const interactiveContentTags = new Set( [
 
 function prefixSelectKeys( selected, prefix ) {
 	if ( typeof selected !== 'object' ) return { [ prefix ]: selected };
-	return Object.fromEntries(
-		Object.entries( selected ).map( ( [ key, value ] ) => [
-			`${ prefix }.${ key }`,
-			value,
-		] )
-	);
+
+	const keys = {};
+	for ( const key in selected ) {
+		keys[ `${ prefix }.${ key }` ] = selected[ key ];
+	}
+	return keys;
 }
 
 function getPrefixedSelectKeys( selected, prefix ) {
 	if ( selected[ prefix ] ) return selected[ prefix ];
-	return Object.keys( selected )
-		.filter( ( key ) => key.startsWith( prefix + '.' ) )
-		.reduce( ( accumulator, key ) => {
-			accumulator[ key.slice( prefix.length + 1 ) ] = selected[ key ];
-			return accumulator;
-		}, {} );
+
+	const keys = {};
+	const fullPrefix = `${ prefix }.`;
+	for ( const key in selected ) {
+		if ( key[ 0 ] !== prefix[ 0 ] || ! key.startsWith( fullPrefix ) ) {
+			continue;
+		}
+
+		keys[ key.slice( fullPrefix.length ) ] = selected[ key ];
+	}
+	return keys;
 }
 
 /**

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -1648,7 +1648,7 @@ export const blockListSettings = ( state = {}, action ) => {
 		case 'REPLACE_BLOCKS':
 		case 'REMOVE_BLOCKS': {
 			const withoutRemovedBlocks = Object.assign( {}, state );
-			for ( const id in action.clientIds ) {
+			for ( const id of action.clientIds ) {
 				delete withoutRemovedBlocks[ id ];
 			}
 			return withoutRemovedBlocks;


### PR DESCRIPTION
No significant measurable performance impact.

## Results

Final results over 40 hours of testing at `--rounds 180`

```
>> post-editor

┌──────────────────────┬─────────────────────────────────────────────┬──────────────┐
│       (index)        │ performance/try-not-iterating-so-many-times │    trunk     │
├──────────────────────┼─────────────────────────────────────────────┼──────────────┤
│    serverResponse    │                 '258.04 ms'                 │ '256.69 ms'  │
│      firstPaint      │                 '96.18 ms'                  │  '95.82 ms'  │
│   domContentLoaded   │                 '340.66 ms'                 │ '339.77 ms'  │
│        loaded        │                 '341.44 ms'                 │ '340.57 ms'  │
│ firstContentfulPaint │                 '837.72 ms'                 │ '834.04 ms'  │
│      firstBlock      │                '8756.22 ms'                 │ '8500.29 ms' │
│         type         │                 '71.45 ms'                  │  '70.42 ms'  │
│       minType        │                 '68.16 ms'                  │  '67.47 ms'  │
│       maxType        │                 '76.46 ms'                  │  '75.98 ms'  │
│    typeContainer     │                 '12.76 ms'                  │  '12.8 ms'   │
│   minTypeContainer   │                 '11.26 ms'                  │  '11.32 ms'  │
│   maxTypeContainer   │                 '15.62 ms'                  │  '15.81 ms'  │
│        focus         │                 '46.03 ms'                  │  '45.3 ms'   │
│       minFocus       │                 '39.74 ms'                  │  '39.2 ms'   │
│       maxFocus       │                 '70.45 ms'                  │  '69.16 ms'  │
│     inserterOpen     │                 '29.94 ms'                  │  '29.89 ms'  │
│   minInserterOpen    │                 '19.43 ms'                  │  '19.32 ms'  │
│   maxInserterOpen    │                 '106.3 ms'                  │ '106.18 ms'  │
│    inserterSearch    │                  '8.79 ms'                  │  '9.39 ms'   │
│  minInserterSearch   │                  '3.64 ms'                  │  '3.73 ms'   │
│  maxInserterSearch   │                 '15.49 ms'                  │  '16.6 ms'   │
│    inserterHover     │                 '31.75 ms'                  │  '31.31 ms'  │
│   minInserterHover   │                  '28.5 ms'                  │  '27.95 ms'  │
│   maxInserterHover   │                 '35.68 ms'                  │  '35.36 ms'  │
│     listViewOpen     │                 '299.08 ms'                 │ '301.81 ms'  │
│   minListViewOpen    │                 '282.7 ms'                  │  '282.6 ms'  │
│   maxListViewOpen    │                 '383.9 ms'                  │ '388.18 ms'  │
└──────────────────────┴─────────────────────────────────────────────┴──────────────┘

>> site-editor

┌──────────────────────┬─────────────────────────────────────────────┬─────────────┐
│       (index)        │ performance/try-not-iterating-so-many-times │    trunk    │
├──────────────────────┼─────────────────────────────────────────────┼─────────────┤
│    serverResponse    │                 '115.2 ms'                  │ '112.55 ms' │
│      firstPaint      │                 '177.17 ms'                 │ '176.62 ms' │
│   domContentLoaded   │                 '352.37 ms'                 │ '351.97 ms' │
│        loaded        │                 '352.72 ms'                 │ '352.45 ms' │
│ firstContentfulPaint │                  '425 ms'                   │ '424.5 ms'  │
│      firstBlock      │                '9741.43 ms'                 │ '9667.3 ms' │
│         type         │                 '52.32 ms'                  │ '52.42 ms'  │
│       minType        │                 '49.78 ms'                  │ '49.98 ms'  │
│       maxType        │                 '115.02 ms'                 │ '115.02 ms' │
└──────────────────────┴─────────────────────────────────────────────┴─────────────┘

>> front-end-classic-theme

┌────────────────────────┬─────────────────────────────────────────────┬────────────┐
│        (index)         │ performance/try-not-iterating-so-many-times │   trunk    │
├────────────────────────┼─────────────────────────────────────────────┼────────────┤
│    timeToFirstByte     │                 '30.45 ms'                  │ '30.35 ms' │
│ largestContentfulPaint │                 '57.75 ms'                  │ '57.8 ms'  │
│      lcpMinusTtfb      │                  '27.2 ms'                  │ '27.35 ms' │
└────────────────────────┴─────────────────────────────────────────────┴────────────┘

>> front-end-block-theme

┌────────────────────────┬─────────────────────────────────────────────┬────────────┐
│        (index)         │ performance/try-not-iterating-so-many-times │   trunk    │
├────────────────────────┼─────────────────────────────────────────────┼────────────┤
│    timeToFirstByte     │                  '55.8 ms'                  │ '55.85 ms' │
│ largestContentfulPaint │                 '80.07 ms'                  │ '80.12 ms' │
│      lcpMinusTtfb      │                 '24.27 ms'                  │ '24.2 ms'  │
└────────────────────────┴─────────────────────────────────────────────┴────────────┘
```

<details><summary>`--rounds 60`</summary>

```
>> post-editor

┌──────────────────────┬─────────────────────────────────────────────┬──────────────┐
│       (index)        │ performance/try-not-iterating-so-many-times │    trunk     │
├──────────────────────┼─────────────────────────────────────────────┼──────────────┤
│    serverResponse    │                 '253.13 ms'                 │ '254.96 ms'  │
│      firstPaint      │                 '89.06 ms'                  │  '88.16 ms'  │
│   domContentLoaded   │                 '323.18 ms'                 │  '323.8 ms'  │
│        loaded        │                 '323.82 ms'                 │ '324.47 ms'  │
│ firstContentfulPaint │                 '800.25 ms'                 │ '802.72 ms'  │
│      firstBlock      │                '8212.08 ms'                 │ '8140.51 ms' │
│         type         │                 '68.64 ms'                  │  '67.6 ms'   │
│       minType        │                   '66 ms'                   │  '65.04 ms'  │
│       maxType        │                 '74.19 ms'                  │  '72.74 ms'  │
│    typeContainer     │                 '12.24 ms'                  │  '12.22 ms'  │
│   minTypeContainer   │                 '10.86 ms'                  │  '10.82 ms'  │
│   maxTypeContainer   │                 '15.14 ms'                  │  '14.75 ms'  │
│        focus         │                 '43.54 ms'                  │  '43.4 ms'   │
│       minFocus       │                 '38.08 ms'                  │  '37.56 ms'  │
│       maxFocus       │                 '67.03 ms'                  │  '66.47 ms'  │
│     inserterOpen     │                 '28.86 ms'                  │  '28.71 ms'  │
│   minInserterOpen    │                 '18.35 ms'                  │  '18.46 ms'  │
│   maxInserterOpen    │                 '103.99 ms'                 │  '103.1 ms'  │
│    inserterSearch    │                  '9.37 ms'                  │  '9.29 ms'   │
│  minInserterSearch   │                  '3.49 ms'                  │  '3.46 ms'   │
│  maxInserterSearch   │                 '15.37 ms'                  │  '15.41 ms'  │
│    inserterHover     │                 '31.23 ms'                  │  '30.13 ms'  │
│   minInserterHover   │                 '28.34 ms'                  │  '27.43 ms'  │
│   maxInserterHover   │                  '34.6 ms'                  │  '33.72 ms'  │
│     listViewOpen     │                 '260.99 ms'                 │ '259.16 ms'  │
│   minListViewOpen    │                 '244.31 ms'                 │ '243.25 ms'  │
│   maxListViewOpen    │                 '345.08 ms'                 │ '344.35 ms'  │
└──────────────────────┴─────────────────────────────────────────────┴──────────────┘

>> site-editor

┌──────────────────────┬─────────────────────────────────────────────┬──────────────┐
│       (index)        │ performance/try-not-iterating-so-many-times │    trunk     │
├──────────────────────┼─────────────────────────────────────────────┼──────────────┤
│    serverResponse    │                 '117.22 ms'                 │  '117.2 ms'  │
│      firstPaint      │                 '187.7 ms'                  │ '188.08 ms'  │
│   domContentLoaded   │                 '365.93 ms'                 │ '368.42 ms'  │
│        loaded        │                 '366.28 ms'                 │ '368.98 ms'  │
│ firstContentfulPaint │                 '439.78 ms'                 │  '442.5 ms'  │
│      firstBlock      │                '9628.63 ms'                 │ '9537.32 ms' │
│         type         │                 '55.27 ms'                  │  '55.66 ms'  │
│       minType        │                 '50.97 ms'                  │  '50.62 ms'  │
│       maxType        │                 '124.55 ms'                 │ '125.59 ms'  │
└──────────────────────┴─────────────────────────────────────────────┴──────────────┘

>> front-end-classic-theme

┌────────────────────────┬─────────────────────────────────────────────┬────────────┐
│        (index)         │ performance/try-not-iterating-so-many-times │   trunk    │
├────────────────────────┼─────────────────────────────────────────────┼────────────┤
│    timeToFirstByte     │                 '32.25 ms'                  │ '32.75 ms' │
│ largestContentfulPaint │                  '65.4 ms'                  │ '65.77 ms' │
│      lcpMinusTtfb      │                  '31.5 ms'                  │ '31.6 ms'  │
└────────────────────────┴─────────────────────────────────────────────┴────────────┘

>> front-end-block-theme

┌────────────────────────┬─────────────────────────────────────────────┬────────────┐
│        (index)         │ performance/try-not-iterating-so-many-times │   trunk    │
├────────────────────────┼─────────────────────────────────────────────┼────────────┤
│    timeToFirstByte     │                 '55.78 ms'                  │ '55.78 ms' │
│ largestContentfulPaint │                 '80.77 ms'                  │ '80.2 ms'  │
│      lcpMinusTtfb      │                 '24.52 ms'                  │ '24.3 ms'  │
└────────────────────────┴─────────────────────────────────────────────┴────────────┘
```
</details>

These were run with `--rounds 50`

<details><summary>post-editor</summary>
<pre><code>
>> post-editor                                                                                                             [37/1752]

┌──────────────────────┬─────────────────────────────────────────────┬──────────────┐
│       (index)        │ performance/try-not-iterating-so-many-times │    trunk     │
├──────────────────────┼─────────────────────────────────────────────┼──────────────┤
│    serverResponse    │                 '249.24 ms'                 │ '252.41 ms'  │
│      firstPaint      │                 '85.59 ms'                  │  '87.79 ms'  │
│   domContentLoaded   │                 '319.16 ms'                 │  '323.2 ms'  │
│        loaded        │                 '319.78 ms'                 │ '323.79 ms'  │
│ firstContentfulPaint │                 '793.14 ms'                 │ '796.79 ms'  │
│      firstBlock      │                '8100.44 ms'                 │ '8052.94 ms' │
│         type         │                  '67.2 ms'                  │  '66.67 ms'  │
│       minType        │                 '64.41 ms'                  │  '64.35 ms'  │
│       maxType        │                 '72.11 ms'                  │  '72.04 ms'  │
│    typeContainer     │                 '12.27 ms'                  │  '12.08 ms'  │
│   minTypeContainer   │                 '11.03 ms'                  │  '10.97 ms'  │
│   maxTypeContainer   │                  '14.6 ms'                  │  '14.33 ms'  │
│        focus         │                  '42.8 ms'                  │  '42.55 ms'  │
│       minFocus       │                 '37.16 ms'                  │  '36.54 ms'  │
│       maxFocus       │                 '65.05 ms'                  │  '66.08 ms'  │
│     inserterOpen     │                 '28.43 ms'                  │  '28.57 ms'  │
│   minInserterOpen    │                 '18.16 ms'                  │  '18.27 ms'  │
│   maxInserterOpen    │                 '102.93 ms'                 │ '103.74 ms'  │
│    inserterSearch    │                  '9.45 ms'                  │  '9.46 ms'   │
│  minInserterSearch   │                  '3.39 ms'                  │  '3.34 ms'   │
│  maxInserterSearch   │                 '15.68 ms'                  │  '15.59 ms'  │
│    inserterHover     │                 '30.43 ms'                  │  '29.62 ms'  │
│   minInserterHover   │                 '27.65 ms'                  │  '27.12 ms'  │
│   maxInserterHover   │                 '33.59 ms'                  │  '33.16 ms'  │
│     listViewOpen     │                 '253.39 ms'                 │ '251.84 ms'  │
│   minListViewOpen    │                 '234.69 ms'                 │ '234.64 ms'  │
│   maxListViewOpen    │                 '336.57 ms'                 │ '336.27 ms'  │
└──────────────────────┴─────────────────────────────────────────────┴──────────────┘
</code></pre></details>

<details><summary>site-editor</summary>
<pre><code>
>> site-editor

┌──────────────────────┬─────────────────────────────────────────────┬──────────────┐
│       (index)        │ performance/try-not-iterating-so-many-times │    trunk     │
├──────────────────────┼─────────────────────────────────────────────┼──────────────┤
│    serverResponse    │                 '106.57 ms'                 │ '108.35 ms'  │
│      firstPaint      │                 '165.22 ms'                 │ '165.23 ms'  │
│   domContentLoaded   │                 '329.77 ms'                 │ '330.82 ms'  │
│        loaded        │                 '330.05 ms'                 │ '331.17 ms'  │
│ firstContentfulPaint │                 '399.55 ms'                 │ '399.72 ms'  │
│      firstBlock      │                '8966.08 ms'                 │ '8842.62 ms' │
│         type         │                  '49.6 ms'                  │  '49.26 ms'  │
│       minType        │                 '47.42 ms'                  │  '47.14 ms'  │
│       maxType        │                 '107.03 ms'                 │ '106.34 ms'  │
└──────────────────────┴─────────────────────────────────────────────┴──────────────┘
</code></pre></details>

<details><summary>themes</summary>
<pre><code>
>> front-end-classic-theme

┌────────────────────────┬─────────────────────────────────────────────┬────────────┐
│        (index)         │ performance/try-not-iterating-so-many-times │   trunk    │
├────────────────────────┼─────────────────────────────────────────────┼────────────┤
│    timeToFirstByte     │                 '29.08 ms'                  │ '28.98 ms' │
│ largestContentfulPaint │                   '55 ms'                   │ '54.57 ms' │
│      lcpMinusTtfb      │                 '25.87 ms'                  │ '25.47 ms' │
└────────────────────────┴─────────────────────────────────────────────┴────────────┘

>> front-end-block-theme

┌────────────────────────┬─────────────────────────────────────────────┬────────────┐
│        (index)         │ performance/try-not-iterating-so-many-times │   trunk    │
├────────────────────────┼─────────────────────────────────────────────┼────────────┤
│    timeToFirstByte     │                 '54.05 ms'                  │ '54.05 ms' │
│ largestContentfulPaint │                 '77.15 ms'                  │ '76.75 ms' │
│      lcpMinusTtfb      │                 '22.87 ms'                  │ '22.6 ms'  │
└────────────────────────┴─────────────────────────────────────────────┴────────────┘
</code></pre></details>