### PR TITLE
Change "Copy block" to "Copy"

### DIFF
--- a/packages/block-editor/src/components/block-mobile-toolbar/block-actions-menu.native.js
+++ b/packages/block-editor/src/components/block-mobile-toolbar/block-actions-menu.native.js
@@ -156,7 +156,7 @@ const BlockActionsMenu = ( {
 		},
 		copyButton: {
 			id: 'copyButtonOption',
-			label: __( 'Copy block' ),
+			label: __( 'Copy' ),
 			value: 'copyButtonOption',
 			onSelect: () => {
 				const serializedBlock = serialize(

--- a/packages/block-editor/src/components/block-mobile-toolbar/test/block-actions-menu.native.js
+++ b/packages/block-editor/src/components/block-mobile-toolbar/test/block-actions-menu.native.js
@@ -246,7 +246,7 @@ describe( 'Block Actions Menu', () => {
 			fireEvent.press( getByLabelText( /Open Block Actions Menu/ ) );
 
 			// Tap on the Copy button
-			fireEvent.press( getByLabelText( /Copy block/ ) );
+			fireEvent.press( getByLabelText( /Copy/ ) );
 
 			// Get Paragraph block
 			paragraphBlock = await getBlock( screen, 'Paragraph' );
@@ -293,7 +293,7 @@ describe( 'Block Actions Menu', () => {
 			fireEvent.press( getByLabelText( /Open Block Actions Menu/ ) );
 
 			// Tap on the Copy button
-			fireEvent.press( getByLabelText( /Copy block/ ) );
+			fireEvent.press( getByLabelText( /Copy/ ) );
 
 			// Get Paragraph block
 			paragraphBlock = await getBlock( screen, 'Paragraph' );

--- a/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
@@ -41,7 +41,7 @@ const POPOVER_PROPS = {
 function CopyMenuItem( { blocks, onCopy, label } ) {
 	const ref = useCopyToClipboard( () => serialize( blocks ), onCopy );
 	const copyMenuItemBlocksLabel =
-		blocks.length > 1 ? __( 'Copy blocks' ) : __( 'Copy block' );
+		blocks.length > 1 ? __( 'Copy blocks' ) : __( 'Copy' );
 	const copyMenuItemLabel = label ? label : copyMenuItemBlocksLabel;
 	return <MenuItem ref={ ref }>{ copyMenuItemLabel }</MenuItem>;
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Part of https://github.com/WordPress/gutenberg/issues/49271 to make the block options menu more scannable. 

We don't need to be so specific by appending "block" onto the copy action as: 
1. We don't do it elsewhere in the menu here (unnecessary context/less scannable).
2. The control actually copies the block with its styles. 

## How?
Copy change.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a Post or Page.
2. Insert a Heading block.
3. Select the block options toolbar.
4. See "Copy" at the top, instead of "Copy block"

## Screenshots or screencast <!-- if applicable -->

| Before  | After |
| ------------- | ------------- |
|<img width="699" alt="CleanShot 2023-06-15 at 07 59 55" src="https://github.com/WordPress/gutenberg/assets/1813435/4d90f859-4fd3-499b-99ef-92aec971b95b">|<img width="709" alt="CleanShot 2023-06-15 at 07 58 23" src="https://github.com/WordPress/gutenberg/assets/1813435/e3181efa-9dfc-41a1-afc3-555bd0233284">|

Related: https://github.com/WordPress/gutenberg/pull/51400

