### PR TITLE
useEntityRecord: Fix destructure error when `enabled` option is `false`

### DIFF
--- a/packages/core-data/src/hooks/use-entity-record.ts
+++ b/packages/core-data/src/hooks/use-entity-record.ts
@@ -183,7 +183,6 @@ export default function useEntityRecord< RecordType >(
 		( query ) => {
 			if ( ! options.enabled ) {
 				return {
-					// Avoiding returning a new reference on every execution.
 					data: null,
 				};
 			}

--- a/packages/core-data/src/hooks/use-entity-record.ts
+++ b/packages/core-data/src/hooks/use-entity-record.ts
@@ -182,7 +182,10 @@ export default function useEntityRecord< RecordType >(
 	const { data: record, ...querySelectRest } = useQuerySelect(
 		( query ) => {
 			if ( ! options.enabled ) {
-				return null;
+				return {
+					// Avoiding returning a new reference on every execution.
+					data: null,
+				};
 			}
 			return query( coreStore ).getEntityRecord( kind, name, recordId );
 		},


### PR DESCRIPTION
Fixes: #51466
Related to #39288

## What?
This PR fixes an error that occurs when `{ enabled: false }` is specified in the fourth argument of `useEntityRecord`.

For example, when you write code like this:

```javascript
const { record, isResolving } = useEntityRecord( 'postType', 'page', 1, {
	enabled: false,
} );
```

The following error is logged in the browser console:

```
use-entity-record.ts:182 Uncaught TypeError: Cannot destructure property 'data' of '(0 , _use_query_select__WEBPACK_IMPORTED_MODULE_4__.default)(...)' as it is null.
```

## Why?
This is because if `enabed` is `false`, the internal `useQuerySelect` returns `null` and the `data` property cannot be destructured.

## How?
I referred to [getEntityRecords implementation](https://github.com/WordPress/gutenberg/blob/14dc7d2ad9151470431d584615aadddcb6e736ef/packages/core-data/src/hooks/use-entity-records.ts#L89-L94), but I think it should be the value of the `data` property that is null, not the entire object.

## Testing Instructions
Confirm that the following code does not cause an error.

The `record` variable should be the post object if the post exists, or `undefined` if it does not:

```javascript
const { record } = useEntityRecord( 'postType', 'page', 2 );
```

```javascript
const { record } = useEntityRecord( 'postType', 'page', 2, {
	enabled: true,
} );
```

The `record` variable should always be `null`:

```javascript
const { record } = useEntityRecord( 'postType', 'page', 2, {
	enabled: false,
} );
```