### PR TITLE
Color Randomizer: Fix an error when the theme has no color palette

### DIFF
--- a/packages/edit-site/src/components/global-styles/palette.js
+++ b/packages/edit-site/src/components/global-styles/palette.js
@@ -91,7 +91,7 @@ function Palette( { name } ) {
 					</HStack>
 				</NavigationButtonAsItem>
 			</ItemGroup>
-			{ randomizeThemeColors && (
+			{ themeColors?.length > 0 && (
 				<Button
 					variant="secondary"
 					icon={ shuffle }


### PR DESCRIPTION
Fixes: #50150
Follow-up on #40988

## What?
This PR fixes a browser console error that occurs when the "Randomize colors" button is pressed if the theme has no color palette.

![browser-error](https://github.com/WordPress/gutenberg/assets/54422211/8c9505c5-13c3-4245-8c3d-5a6d20b8e91a)

## Why?
To determine whether to display this button, `randomizeThemeColors` is used, which always returns true because it is a function. As a result, color randomization cannot be handled correctly.

## How?
I have hidden the button if the theme has no color.

## Testing Instructions

- Confirm that Twenty Twenty Three allows color randomization as before.
- Confirm that the button does not appear in EmptyTheme without a color palette.