### PR TITLE
Block Locking: Fix regression in selectors

### DIFF
--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1667,16 +1667,14 @@ export function canRemoveBlock( state, clientId, rootClientId = null ) {
 	if ( attributes === null ) {
 		return true;
 	}
-	if ( attributes.lock?.remove ) {
-		return false;
+	if ( attributes.lock?.remove !== undefined ) {
+		return ! attributes.lock.remove;
 	}
 	if ( getTemplateLock( state, rootClientId ) ) {
 		return false;
 	}
-	if ( getBlockEditingMode( state, rootClientId ) === 'disabled' ) {
-		return false;
-	}
-	return true;
+
+	return getBlockEditingMode( state, rootClientId ) !== 'disabled';
 }
 
 /**
@@ -1706,18 +1704,16 @@ export function canRemoveBlocks( state, clientIds, rootClientId = null ) {
 export function canMoveBlock( state, clientId, rootClientId = null ) {
 	const attributes = getBlockAttributes( state, clientId );
 	if ( attributes === null ) {
-		return;
+		return true;
 	}
-	if ( attributes.lock?.move ) {
-		return false;
+	if ( attributes.lock?.move !== undefined ) {
+		return ! attributes.lock.move;
 	}
 	if ( getTemplateLock( state, rootClientId ) === 'all' ) {
 		return false;
 	}
-	if ( getBlockEditingMode( state, rootClientId ) === 'disabled' ) {
-		return false;
-	}
-	return true;
+
+	return getBlockEditingMode( state, rootClientId ) !== 'disabled';
 }
 
 /**

--- a/test/e2e/specs/editor/various/block-locking.spec.js
+++ b/test/e2e/specs/editor/various/block-locking.spec.js
@@ -8,79 +8,77 @@ test.describe( 'Block Locking', () => {
 		await admin.createNewPost();
 	} );
 
-	test.describe( 'General', () => {
-		test( 'can prevent removal', async ( { editor, page } ) => {
-			await editor.insertBlock( { name: 'core/paragraph' } );
-			await page.keyboard.type( 'Some paragraph' );
+	test( 'can prevent removal', async ( { editor, page } ) => {
+		await editor.canvas.click( 'role=button[name="Add default block"i]' );
+		await page.keyboard.type( 'Some paragraph' );
 
-			await editor.clickBlockOptionsMenuItem( 'Lock' );
+		await editor.clickBlockOptionsMenuItem( 'Lock' );
 
-			await page.click( 'role=checkbox[name="Prevent removal"]' );
-			await page.click( 'role=button[name="Apply"]' );
+		await page.click( 'role=checkbox[name="Prevent removal"]' );
+		await page.click( 'role=button[name="Apply"]' );
 
-			await expect(
-				page.locator( 'role=menuitem[name="Delete"]' )
-			).not.toBeVisible();
-		} );
+		await expect(
+			page.locator( 'role=menuitem[name="Delete"]' )
+		).not.toBeVisible();
+	} );
 
-		test( 'can disable movement', async ( { editor, page } ) => {
-			await editor.insertBlock( { name: 'core/paragraph' } );
-			await page.keyboard.type( 'First paragraph' );
+	test( 'can disable movement', async ( { editor, page } ) => {
+		await editor.canvas.click( 'role=button[name="Add default block"i]' );
+		await page.keyboard.type( 'First paragraph' );
 
-			await editor.insertBlock( { name: 'core/paragraph' } );
-			await page.keyboard.type( 'Second paragraph' );
+		await page.keyboard.type( 'Enter' );
+		await page.keyboard.type( 'Second paragraph' );
 
-			await editor.clickBlockOptionsMenuItem( 'Lock' );
+		await editor.clickBlockOptionsMenuItem( 'Lock' );
 
-			await page.click( 'role=checkbox[name="Disable movement"]' );
-			await page.click( 'role=button[name="Apply"]' );
+		await page.click( 'role=checkbox[name="Disable movement"]' );
+		await page.click( 'role=button[name="Apply"]' );
 
-			// Hide options.
-			await editor.clickBlockToolbarButton( 'Options' );
+		// Hide options.
+		await editor.clickBlockToolbarButton( 'Options' );
 
-			// Drag handle is hidden.
-			await expect(
-				page.locator( 'role=button[name="Drag"]' )
-			).not.toBeVisible();
+		// Drag handle is hidden.
+		await expect(
+			page.locator( 'role=button[name="Drag"]' )
+		).not.toBeVisible();
 
-			// Movers are hidden. No need to check for both.
-			await expect(
-				page.locator( 'role=button[name="Move up"]' )
-			).not.toBeVisible();
-		} );
+		// Movers are hidden. No need to check for both.
+		await expect(
+			page.locator( 'role=button[name="Move up"]' )
+		).not.toBeVisible();
+	} );
 
-		test( 'can lock everything', async ( { editor, page } ) => {
-			await editor.insertBlock( { name: 'core/paragraph' } );
-			await page.keyboard.type( 'Some paragraph' );
+	test( 'can lock everything', async ( { editor, page } ) => {
+		await editor.canvas.click( 'role=button[name="Add default block"i]' );
+		await page.keyboard.type( 'Some paragraph' );
 
-			await editor.clickBlockOptionsMenuItem( 'Lock' );
+		await editor.clickBlockOptionsMenuItem( 'Lock' );
 
-			await page.click( 'role=checkbox[name="Lock all"]' );
-			await page.click( 'role=button[name="Apply"]' );
+		await page.click( 'role=checkbox[name="Lock all"]' );
+		await page.click( 'role=button[name="Apply"]' );
 
-			expect( await editor.getEditedPostContent() )
-				.toBe( `<!-- wp:paragraph {"lock":{"move":true,"remove":true}} -->
+		expect( await editor.getEditedPostContent() )
+			.toBe( `<!-- wp:paragraph {"lock":{"move":true,"remove":true}} -->
 <p>Some paragraph</p>
 <!-- /wp:paragraph -->` );
-		} );
+	} );
 
-		test( 'can unlock from toolbar', async ( { editor, page } ) => {
-			await editor.insertBlock( { name: 'core/paragraph' } );
-			await page.keyboard.type( 'Some paragraph' );
+	test( 'can unlock from toolbar', async ( { editor, page } ) => {
+		await editor.canvas.click( 'role=button[name="Add default block"i]' );
+		await page.keyboard.type( 'Some paragraph' );
 
-			await editor.clickBlockOptionsMenuItem( 'Lock' );
+		await editor.clickBlockOptionsMenuItem( 'Lock' );
 
-			await page.click( 'role=checkbox[name="Lock all"]' );
-			await page.click( 'role=button[name="Apply"]' );
+		await page.click( 'role=checkbox[name="Lock all"]' );
+		await page.click( 'role=button[name="Apply"]' );
 
-			await editor.clickBlockToolbarButton( 'Unlock' );
-			await page.click( 'role=checkbox[name="Lock all"]' );
-			await page.click( 'role=button[name="Apply"]' );
+		await editor.clickBlockToolbarButton( 'Unlock' );
+		await page.click( 'role=checkbox[name="Lock all"]' );
+		await page.click( 'role=button[name="Apply"]' );
 
-			expect( await editor.getEditedPostContent() )
-				.toBe( `<!-- wp:paragraph {"lock":{"move":false,"remove":false}} -->
+		expect( await editor.getEditedPostContent() )
+			.toBe( `<!-- wp:paragraph {"lock":{"move":false,"remove":false}} -->
 <p>Some paragraph</p>
 <!-- /wp:paragraph -->` );
-		} );
 	} );
 } );


### PR DESCRIPTION
## What?
Regression was introduced in #51148.

PR fixes a regression when blocks were not able to override the `templateLock` via Block Locking API.

## Why?
Block locking should supersede template locking. See https://make.wordpress.org/core/2022/01/08/locking-blocks-in-wordpress-5-9/.

## How?
When the `attributes.lock` value isn't `undefined` return early.

## Testing Instructions
I added e2e test coverage to catch regressions early. See 8bad90cce6d276a62dda43eb146e3921f4f91ee5.

1. Open a Post or Page.
2. Paste the testing block snippet.
3. You should be able to unlock the Paragraph or Heading block.

## Snippet

```html
<!-- wp:group {"templateLock":"all","layout":{"type":"constrained"}} -->
<div class="wp-block-group"><!-- wp:heading -->
<h2 class="wp-block-heading">Hello, hello</h2>
<!-- /wp:heading -->

<!-- wp:paragraph -->
<p>Locked paragraph</p>
<!-- /wp:paragraph --></div>
<!-- /wp:group -->
```
