### PR TITLE
Try core/image aspect ratio

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -331,7 +331,7 @@ Insert an image to make a visual statement. ([Source](https://github.com/WordPre
 -	**Name:** core/image
 -	**Category:** media
 -	**Supports:** anchor, behaviors (lightbox), color (~~background~~, ~~text~~), filter (duotone)
--	**Attributes:** align, alt, caption, height, href, id, linkClass, linkDestination, linkTarget, rel, sizeSlug, title, url, width
+-	**Attributes:** align, alt, aspectRatio, caption, height, href, id, linkClass, linkDestination, linkTarget, rel, scale, sizeSlug, title, url, width
 
 ## Latest Comments
 

--- a/packages/block-library/src/image/block.json
+++ b/packages/block-library/src/image/block.json
@@ -80,6 +80,13 @@
 			"source": "attribute",
 			"selector": "figure > a",
 			"attribute": "target"
+		},
+		"aspectRatio": {
+			"type": "string"
+		},
+		"scale": {
+			"type": "string",
+			"default": "cover"
 		}
 	},
 	"supports": {

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -329,9 +329,7 @@ export function ImageEdit( {
 		ref,
 		className: classes,
 		style: {
-			height: aspectRatio ? '100%' : height,
-			width: !! aspectRatio && '100%',
-			objectFit: !! ( height || aspectRatio ) && scale,
+			objectFit: aspectRatio ? scale : 'auto',
 			aspectRatio,
 		},
 	} );
@@ -351,8 +349,6 @@ export function ImageEdit( {
 					'Upload an image file, pick one from your media library, or add one with a URL.'
 				) }
 				style={ {
-					height: !! aspectRatio && '100%',
-					width: !! aspectRatio && '100%',
 					...borderProps.style,
 				} }
 			>

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -114,6 +114,8 @@ export function ImageEdit( {
 		width,
 		height,
 		sizeSlug,
+		aspectRatio,
+		scale,
 	} = attributes;
 	const [ temporaryURL, setTemporaryURL ] = useState();
 
@@ -326,6 +328,12 @@ export function ImageEdit( {
 	const blockProps = useBlockProps( {
 		ref,
 		className: classes,
+		style: {
+			height: aspectRatio ? '100%' : height,
+			width: !! aspectRatio && '100%',
+			objectFit: !! ( height || aspectRatio ) && scale,
+			aspectRatio,
+		},
 	} );
 
 	// Much of this description is duplicated from MediaPlaceholder.
@@ -342,7 +350,11 @@ export function ImageEdit( {
 				instructions={ __(
 					'Upload an image file, pick one from your media library, or add one with a URL.'
 				) }
-				style={ isSelected ? undefined : borderProps.style }
+				style={ {
+					height: !! aspectRatio && '100%',
+					width: !! aspectRatio && '100%',
+					...borderProps.style,
+				} }
 			>
 				{ content }
 			</Placeholder>

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -459,12 +459,12 @@ export default function Image( {
 						label={ __( 'Aspect ratio' ) }
 						options={ [
 							{ label: __( 'Original' ), value: 'auto' },
-							{ label: __( 'Square - 1:1' ), value: '1:1' },
-							{ label: __( 'Classic - 3:2' ), value: '3:2' },
-							{ label: __( 'Standard - 4:3' ), value: '4:3' },
-							{ label: __( 'Portrait - 3:4' ), value: '3:4' },
-							{ label: __( 'Wide - 16:9' ), value: '16:9' },
-							{ label: __( 'Tall - 9:16' ), value: '9:16' },
+							{ label: __( 'Square - 1:1' ), value: '1/1' },
+							{ label: __( 'Classic - 3:2' ), value: '3/2' },
+							{ label: __( 'Standard - 4:3' ), value: '4/3' },
+							{ label: __( 'Portrait - 3:4' ), value: '3/4' },
+							{ label: __( 'Wide - 16:9' ), value: '16/9' },
+							{ label: __( 'Tall - 9:16' ), value: '9/16' },
 							{ label: __( 'Custom' ), value: 'custom' },
 						] }
 						value={ aspectRatio }

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -11,8 +11,6 @@ import {
 	TextControl,
 	ToolbarButton,
 	SelectControl,
-	__experimentalToggleGroupControl as ToggleGroupControl,
-	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
 } from '@wordpress/components';
 import { useViewportMatch, usePrevious } from '@wordpress/compose';
 import { useSelect, useDispatch } from '@wordpress/data';
@@ -36,7 +34,7 @@ import {
 	useRef,
 	useCallback,
 } from '@wordpress/element';
-import { __, _x, sprintf, isRTL } from '@wordpress/i18n';
+import { __, sprintf, isRTL } from '@wordpress/i18n';
 import { getFilename } from '@wordpress/url';
 import {
 	createBlock,
@@ -326,33 +324,6 @@ export default function Image( {
 
 	const canEditImage = id && naturalWidth && naturalHeight && imageEditing;
 	const allowCrop = ! multiImageSelection && canEditImage && ! isEditingImage;
-	const showScaleControl =
-		height || ( aspectRatio && aspectRatio !== 'auto' );
-
-	const SCALE_OPTIONS = (
-		<>
-			<ToggleGroupControlOption
-				value="cover"
-				label={ _x( 'Cover', 'Scale option for aspect ratio control' ) }
-			/>
-			<ToggleGroupControlOption
-				value="contain"
-				label={ _x(
-					'Contain',
-					'Scale option for aspect ratio control'
-				) }
-			/>
-		</>
-	);
-
-	const scaleHelp = {
-		cover: __(
-			'Image is scaled and cropped to fill the entire space without being distorted.'
-		),
-		contain: __(
-			'Image is scaled to fill the space without clipping nor distorting.'
-		),
-	};
 
 	function switchToCover() {
 		replaceBlocks(
@@ -459,35 +430,18 @@ export default function Image( {
 						label={ __( 'Aspect ratio' ) }
 						options={ [
 							{ label: __( 'Original' ), value: 'auto' },
-							{ label: __( 'Square - 1:1' ), value: '1/1' },
-							{ label: __( 'Classic - 3:2' ), value: '3/2' },
-							{ label: __( 'Standard - 4:3' ), value: '4/3' },
-							{ label: __( 'Portrait - 3:4' ), value: '3/4' },
-							{ label: __( 'Wide - 16:9' ), value: '16/9' },
-							{ label: __( 'Tall - 9:16' ), value: '9/16' },
+							{ label: __( 'Square - 1:1' ), value: '1' },
+							{ label: __( 'Classic - 3:2' ), value: '1.5' },
+							{ label: __( 'Standard - 4:3' ), value: '1.33' },
+							{ label: __( 'Portrait - 3:4' ), value: '0.75' },
+							{ label: __( 'Wide - 16:9' ), value: '1.77' },
+							{ label: __( 'Tall - 9:16' ), value: '0.562' },
 							{ label: __( 'Custom' ), value: 'custom' },
 						] }
 						value={ aspectRatio }
 						onChange={ updateAspectRatio }
 						size="__unstable-large"
 					/>
-					{ showScaleControl && (
-						<ToggleGroupControl
-							__nextHasNoMarginBottom
-							label={ __( 'Scale' ) }
-							value={ scale }
-							help={ scaleHelp[ scale ] }
-							onChange={ ( value ) =>
-								setAttributes( {
-									scale: value,
-								} )
-							}
-							isBlock
-						>
-							{ SCALE_OPTIONS }
-						</ToggleGroupControl>
-					) }
-
 					<ImageSizeControl
 						onChangeImage={ updateImage }
 						onChange={ ( value ) => setAttributes( value ) }
@@ -547,6 +501,11 @@ export default function Image( {
 	const hasCustomBorder =
 		!! borderProps.className ||
 		( borderProps.style && Object.keys( borderProps.style ).length > 0 );
+	const imageStyles = {
+		...borderProps.style,
+		aspectRatio,
+		objectFit: !! ( height || aspectRatio ) && scale,
+	};
 
 	let img = (
 		// Disable reason: Image itself is not meant to be interactive, but
@@ -565,7 +524,7 @@ export default function Image( {
 				} }
 				ref={ imageRef }
 				className={ borderProps.className }
-				style={ borderProps.style }
+				style={ imageStyles }
 			/>
 			{ temporaryURL && <Spinner /> }
 		</>
@@ -662,7 +621,7 @@ export default function Image( {
 		img = (
 			<ResizableBox
 				size={ {
-					width: width ?? 'auto',
+					width: 'auto',
 					height: height && ! hasCustomBorder ? height : 'auto',
 				} }
 				showHandle={ isSelected }
@@ -686,6 +645,7 @@ export default function Image( {
 					} );
 				} }
 				resizeRatio={ align === 'center' ? 2 : 1 }
+				styles={ { aspectRatio } }
 			>
 				{ img }
 			</ResizableBox>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Proof of concept to try out #51138. 

cc @ajlende 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a Post or Page.
2. Insert an Image block.
3. Add an image to the block. 
4. See the new aspect ratio control in the block inspector.

## Screenshots or screencast <!-- if applicable -->
<img width="279" alt="CleanShot 2023-06-15 at 10 30 56" src="https://github.com/WordPress/gutenberg/assets/1813435/8427a6e4-c7eb-44bd-bf08-1e916502b858">

<img width="279" alt="CleanShot 2023-06-15 at 10 31 12" src="https://github.com/WordPress/gutenberg/assets/1813435/b0be68c6-87ed-421f-b592-ebd9a9e96f10">
