### PR TITLE
Remove shadows in Site Editor sidebar

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-screen/style.scss
@@ -51,7 +51,6 @@
 	top: 0;
 	background: $gray-900;
 	padding-top: $grid-unit-60 + $header-height;
-	box-shadow: 0 $grid-unit-10 $grid-unit-20 $gray-900;
 	margin-bottom: $grid-unit-10;
 	padding-bottom: $grid-unit-10;
 	z-index: z-index(".edit-site-sidebar-navigation-screen__title-icon");
@@ -90,5 +89,4 @@
 	padding: $grid-unit-20 0;
 	margin: $grid-unit-20 0 0;
 	border-top: 1px solid $gray-800;
-	box-shadow: 0 #{-$grid-unit-10} $grid-unit-20 $gray-900;
 }


### PR DESCRIPTION
## What?
Try removing the shadows applied to the header / footer sections in the Site Editor sidebar.

## Why?
1. Fixes an issue on trunk where the shadow beneath the panel header is slightly visible even if you haven't scrolled.
2. The shadows may not be necessary.

## Testing Instructions
1. Open a panel in the Site Editor that will scroll, likely Pages or Templates
2. Scroll up and down
3. Notice there are no shadow effects.

| Before | After |
| --- | --- |
| <img src="https://github.com/WordPress/gutenberg/assets/846565/db64d505-e105-43cc-890a-bbe0bb9ba4a6" width="300"> | <img src="https://github.com/WordPress/gutenberg/assets/846565/d558cb00-9df6-425e-91ba-d452b8e1d65b" width="300"> |
