### PR TITLE
Browse Mode: Move CSS to more generic selector

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen-template-part/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-template-part/style.scss
@@ -1,3 +1,0 @@
-.edit-site-sidebar-navigation-screen-template-part-navigation-menu__title.components-heading {
-	margin-bottom: $grid-unit-10;
-}

--- a/packages/edit-site/src/components/sidebar-navigation-screen/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-screen/style.scss
@@ -14,12 +14,18 @@
 .edit-site-sidebar-navigation-screen__content {
 	color: $gray-400;
 	padding: 0 $grid-unit-20;
+
 	.components-item-group {
 		margin-left: -$grid-unit-20;
 		margin-right: -$grid-unit-20;
 	}
+
 	.components-text {
 		color: $gray-400;
+	}
+
+	.components-heading {
+		margin-bottom: $grid-unit-10;
 	}
 }
 
@@ -92,3 +98,4 @@
 	border-top: 1px solid $gray-800;
 	box-shadow: 0 #{-$grid-unit-10} $grid-unit-20 $gray-900;
 }
+

--- a/packages/edit-site/src/style.scss
+++ b/packages/edit-site/src/style.scss
@@ -33,7 +33,6 @@
 @import "./components/sidebar-navigation-screen-navigation-menu/style.scss";
 @import "./components/sidebar-navigation-screen-page/style.scss";
 @import "./components/sidebar-navigation-screen-template/style.scss";
-@import "./components/sidebar-navigation-screen-template-part/style.scss";
 @import "./components/sidebar-navigation-subtitle/style.scss";
 @import "./components/site-hub/style.scss";
 @import "./components/sidebar-navigation-screen-navigation-menus/style.scss";


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This makes the spacing around headers generic for all components in browse mode, rather than specific to the navigation section.

## Why?
We should have a consistency between each section of Browse Mode.

## How?
Move the CSS to the general browse mode sidebar SASS file.

## Testing Instructions
1. Open a template part in the site editor - select one that has a navigation block within it.
2. You should see a "Navigation" title on the left hand side
3. Check that the title has an 8px margin beneath it.

## Screenshots or screencast <!-- if applicable -->
<img width="359" alt="Screenshot 2023-06-15 at 17 12 34" src="https://github.com/WordPress/gutenberg/assets/275961/eb5598b1-690c-46bf-b563-460b1349edda">

