### PR TITLE
Fix Library routing on mobile

### DIFF
--- a/packages/edit-site/src/components/layout/index.js
+++ b/packages/edit-site/src/components/layout/index.js
@@ -65,7 +65,8 @@ export default function Layout() {
 
 	const hubRef = useRef();
 	const { params } = useLocation();
-	const isListPage = getIsListPage( params );
+	const isMobileViewport = useViewportMatch( 'medium', '<' );
+	const isListPage = getIsListPage( params, isMobileViewport );
 	const isEditorPage = ! isListPage;
 	const { hasFixedToolbar, canvasMode, previousShortcut, nextShortcut } =
 		useSelect( ( select ) => {
@@ -91,7 +92,6 @@ export default function Layout() {
 		next: nextShortcut,
 	} );
 	const disableMotion = useReducedMotion();
-	const isMobileViewport = useViewportMatch( 'medium', '<' );
 	const showSidebar =
 		( isMobileViewport && ! isListPage ) ||
 		( ! isMobileViewport && ( canvasMode === 'view' || ! isEditorPage ) );
@@ -171,20 +171,31 @@ export default function Layout() {
 
 				<div className="edit-site-layout__content">
 					<AnimatePresence initial={ false }>
-						{ showSidebar && (
+						{
 							<motion.div
 								initial={ {
 									opacity: 0,
 								} }
-								animate={ {
-									opacity: 1,
-								} }
+								animate={
+									showSidebar
+										? { opacity: 1, display: 'block' }
+										: {
+												opacity: 0,
+												transitionEnd: {
+													display: 'none',
+												},
+										  }
+								}
 								exit={ {
 									opacity: 0,
 								} }
 								transition={ {
 									type: 'tween',
-									duration: ANIMATION_DURATION,
+									duration:
+										// Disable transition in mobile to emulate a full page transition.
+										disableMotion || isMobileViewport
+											? 0
+											: ANIMATION_DURATION,
 									ease: 'easeOut',
 								} }
 								className="edit-site-layout__sidebar"
@@ -195,7 +206,7 @@ export default function Layout() {
 									<Sidebar />
 								</NavigableRegion>
 							</motion.div>
-						) }
+						}
 					</AnimatePresence>
 
 					<SavePanel />

--- a/packages/edit-site/src/components/page-library/style.scss
+++ b/packages/edit-site/src/components/page-library/style.scss
@@ -1,12 +1,16 @@
 .edit-site-library {
 	background: rgba(0, 0, 0, 0.05);
-	margin: 0;
+	margin: $header-height 0 0;
 	.components-text {
 		color: $gray-600;
 	}
 
 	.components-heading {
 		color: $white;
+	}
+
+	@include break-medium {
+		margin: 0;
 	}
 }
 

--- a/packages/edit-site/src/components/sidebar-navigation-screen-library/category-item.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-library/category-item.js
@@ -12,11 +12,19 @@ export default function CategoryItem( {
 	label,
 	type,
 } ) {
-	const linkInfo = useLink( {
-		path: '/library',
-		categoryType: type,
-		categoryId: id,
-	} );
+	const linkInfo = useLink(
+		{
+			path: '/library',
+			categoryType: type,
+			categoryId: id,
+		},
+		{
+			// Keep record for where we came from in a state so we can
+			// use browser's back button to go back to the library.
+			// See the implementation of the back button in patterns-list.
+			backPath: '/library',
+		}
+	);
 
 	if ( ! count ) {
 		return;

--- a/packages/edit-site/src/utils/get-is-list-page.js
+++ b/packages/edit-site/src/utils/get-is-list-page.js
@@ -1,11 +1,23 @@
 /**
  * Returns if the params match the list page route.
  *
- * @param {Object} params      The url params.
- * @param {string} params.path The current path.
+ * @param {Object}  params                The url params.
+ * @param {string}  params.path           The current path.
+ * @param {string}  [params.categoryType] The current category type.
+ * @param {string}  [params.categoryId]   The current category id.
+ * @param {boolean} isMobileViewport      Is mobile viewport.
  *
  * @return {boolean} Is list page or not.
  */
-export default function getIsListPage( { path } ) {
-	return path === '/wp_template/all' || path === '/library';
+export default function getIsListPage(
+	{ path, categoryType, categoryId },
+	isMobileViewport
+) {
+	return (
+		path === '/wp_template/all' ||
+		( path === '/library' &&
+			// Don't treat "/library" without categoryType and categoryId as a list page
+			// in mobile because the sidebar covers the whole page.
+			( ! isMobileViewport || ( !! categoryType && !! categoryId ) ) )
+	);
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What and why?
<!-- In a few words, what is the PR actually doing? -->
Based on #51078. Try to fix the routing and UX on mobile.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Some really tricky and hacky stuff 🙈 . There is definitely room for improvement.

Some of them are hard to explain. I'll try to add some inline code comments below for some confusing stuff 👇 .

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
1. Open the site editor on mobile
2. Open the Library
3. Try clicking different categories and the back button
4. Try clicking different patterns into the edit mode
5. Try browsers' native back/forward buttons 

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
TBD

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/7753001/5beecb1e-8876-41f9-b3f4-166c881d5326


