### PR TITLE
Playwright Utils: Simplify editor preference updates in createNewPost

### DIFF
--- a/packages/e2e-test-utils-playwright/src/admin/create-new-post.js
+++ b/packages/e2e-test-utils-playwright/src/admin/create-new-post.js
@@ -29,38 +29,15 @@ export async function createNewPost( {
 	} ).slice( 1 );
 
 	await this.visitAdminPage( 'post-new.php', query );
-
 	await this.page.waitForSelector( '.edit-post-layout' );
 
-	const isWelcomeGuideActive = await this.page.evaluate( () =>
+	await this.page.evaluate( ( welcomeGuide ) => {
 		window.wp.data
-			.select( 'core/edit-post' )
-			.isFeatureActive( 'welcomeGuide' )
-	);
-	const isFullscreenMode = await this.page.evaluate( () =>
+			.dispatch( 'core/preferences' )
+			.set( 'core/edit-post', 'welcomeGuide', welcomeGuide );
+
 		window.wp.data
-			.select( 'core/edit-post' )
-			.isFeatureActive( 'fullscreenMode' )
-	);
-
-	if ( showWelcomeGuide !== isWelcomeGuideActive ) {
-		await this.page.evaluate( () =>
-			window.wp.data
-				.dispatch( 'core/edit-post' )
-				.toggleFeature( 'welcomeGuide' )
-		);
-
-		await this.page.reload();
-		await this.page.waitForSelector( '.edit-post-layout' );
-	}
-
-	if ( isFullscreenMode ) {
-		await this.page.evaluate( () =>
-			window.wp.data
-				.dispatch( 'core/edit-post' )
-				.toggleFeature( 'fullscreenMode' )
-		);
-
-		await this.page.waitForSelector( 'body:not(.is-fullscreen-mode)' );
-	}
+			.dispatch( 'core/preferences' )
+			.set( 'core/edit-post', 'fullscreenMode', false );
+	}, showWelcomeGuide );
 }


### PR DESCRIPTION
## What?
PR updates the `createNewPost` utility method to use the `core/preferences` store directly to set editor preference for the post editor. 

## Why?
Removing extra steps to query settings first prevents the Welcome Guide from flashing in tests. This also matches the logic in `visitSiteEditor`.

## Testing Instructions
CI checks should pass as before 🤞
