### PR TITLE
Code Data: Fix ESLint warning for the 'useEntityRecord' hook

### DIFF
--- a/packages/core-data/src/hooks/use-entity-record.ts
+++ b/packages/core-data/src/hooks/use-entity-record.ts
@@ -160,7 +160,7 @@ export default function useEntityRecord< RecordType >(
 					...saveOptions,
 				} ),
 		} ),
-		[ recordId ]
+		[ editEntityRecord, kind, name, recordId, saveEditedEntityRecord ]
 	);
 
 	const { editedRecord, hasEdits } = useSelect(


### PR DESCRIPTION
## What?
PR fixes ESLint warning for the 'useEntityRecord' hook - `React Hook useMemo has missing dependencies`.

## Why?
The hook will return stale data mutation helpers if `kind` or `name` values change during re-render. All these dependencies have stable references and won't cause any side effects.

## Testing Instructions
CI checks should pass as before.
