### PR TITLE
Fix flaky 'Switch to Draft' action in preview e2e tests

### DIFF
--- a/test/e2e/specs/editor/various/preview.spec.js
+++ b/test/e2e/specs/editor/various/preview.spec.js
@@ -104,6 +104,8 @@ test.describe( 'Preview', () => {
 		page,
 		previewUtils,
 	} ) => {
+		await editor.openDocumentSettingsSidebar();
+
 		const editorPage = page;
 
 		// Type aaaaa in the title field.
@@ -180,7 +182,10 @@ test.describe( 'Preview', () => {
 
 		// Return to editor and switch to Draft.
 		await editorPage.bringToFront();
-		await page.click( 'role=button[name="Switch to draft"i]' );
+		await page
+			.getByRole( 'region', { name: 'Editor settings' } )
+			.getByRole( 'button', { name: 'Switch to draft' } )
+			.click();
 		// FIXME: The confirmation dialog is not named yet.
 		await page.click( 'role=dialog >> role=button[name="OK"i]' );
 


### PR DESCRIPTION
## What?
Fixes #37976.

PR fixes the flaky 'Switch to Draft' action in preview e2e tests.

## Why?
The button was recently moved to the document settings sidebar (#50217), requiring it to be open before performing an action.

P.S. If the locator had been scoped to the region, we would have caught this bug earlier. 

## How?
Ensure the document settings sidebar is open, and add scope to the locator.

## Testing Instructions
```
npm run test:e2e:playwright -- test/e2e/specs/editor/various/preview.spec.js
```
