### PR TITLE
Fix clicking browser's back button in edit mode from the Library

### DIFF
--- a/packages/edit-site/src/components/page-library/grid-item.js
+++ b/packages/edit-site/src/components/page-library/grid-item.js
@@ -66,7 +66,6 @@ const GridItem = ( { categoryId, composite, icon, item } ) => {
 	const descriptionId = `edit-site-library__pattern-description-${ instanceId }`;
 
 	const { onClick } = useLink( {
-		path: '/library',
 		postType: item.type,
 		postId: item.type === USER_PATTERNS ? item.id : item.name,
 		categoryId,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What and why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Based on #51078. Try to fix a bug where clicking on the browser's back button in the edit mode doesn't go back to the library page.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
1. Open site editor -> Library
2. Select a category and edit a pattern
3. Hit browser's back button
4. Should go back to the library page.

## Screenshots or screencast <!-- if applicable -->

Before:


https://github.com/WordPress/gutenberg/assets/7753001/bf670f3d-828b-4171-8ae4-e555fb5adca4


After:


https://github.com/WordPress/gutenberg/assets/7753001/00a42a49-5dbc-49df-bbc5-c82b424b8ce4

