### PR TITLE
Perf: Rely on a single store listener only

### DIFF
--- a/packages/data/src/types.ts
+++ b/packages/data/src/types.ts
@@ -70,6 +70,12 @@ export type MapSelect = (
 
 export type SelectFunction = < S >( store: S ) => CurriedSelectorsOf< S >;
 
+/**
+ * Callback for store's `subscribe()` method that
+ * runs when the store data has changed.
+ */
+export type ListenerFunction = () => void;
+
 export type CurriedSelectorsOf< S > = S extends StoreDescriptor<
 	ReduxStoreConfig< any, any, infer Selectors >
 >


### PR DESCRIPTION
## Status

The first draft of this work apparently has a significant positive impact on the performance of a few different things we measure. I also noticed what felt like an improvement in local testing. It also isn't breaking any tests.

<s>_Right now_ I'm scaling back the scope and will re-run the perf tests. Getting 180 rounds of results took 40 hours, and I will do that again just to make sure we only have to run them once.</s>

Not yet have I looked into the memory overhead or garbage-collector runtime, but I would be interested to know if this has any measurable impact on that side of the equation.

## What?

Currently when a component calls `useSelect` or any of a number of other hooks, the store creates a new listener through Redux's `subscribe` method. In this patch we're storing a custom list of listeners before calling into Redux and relying on a single Redux listener to call all of the registered functions.

## Why?

We have major performance issues related to over-allocation and this patch is one of many avenues to try and find out the source of the issues and to resolve them.

## How?

At first it seemed like we might be creating actual event listeners for the Redux store, but after running some experiments that seems like it may not be the case, as Redux internally does what this patch does.

<del>Upon more inspection it could be that the important change is extracting the call to `getState()` out of the individual listener closures, or possibly in avoiding the creation of those closures at all.</del>

<del>Coming next will be an attempt to reduce the scope of the PR only to `getState` changes.</del>

<add>After more inspection, it doesn't seem clear to me how to extract the call to `getState` without also trapping all the listeners. This change thus is more atomic in nature. It may still be that the `getState` shuffling is where the performance improvement comes, but that isn't easily separable from the closure change.</add>

## Results

With `--rounds 180`, taking 40 hours

This seems like it's measuring a significant reduction in:
 - `type` ~ 4% (post) ~ 6% (site)
 - `focus` ~ 6%
 - `inserterSearch` ~ 9%
 - `inserterHover` ~ 9%

```
>> post-editor

┌──────────────────────┬─────────────────────────┬──────────────┐
│       (index)        │ perf/one-store-listener │    trunk     │
├──────────────────────┼─────────────────────────┼──────────────┤
│    serverResponse    │       '259.06 ms'       │ '259.31 ms'  │
│      firstPaint      │       '167.01 ms'       │ '164.82 ms'  │
│   domContentLoaded   │       '416.17 ms'       │ '415.73 ms'  │
│        loaded        │       '416.85 ms'       │ '416.43 ms'  │
│ firstContentfulPaint │       '937.19 ms'       │ '933.83 ms'  │
│      firstBlock      │      '9389.34 ms'       │ '9718.19 ms' │
│         type         │       '69.52 ms'        │  '72.1 ms'   │
│       minType        │       '65.57 ms'        │  '68.38 ms'  │
│       maxType        │       '80.28 ms'        │  '79.19 ms'  │
│    typeContainer     │       '15.69 ms'        │  '15.61 ms'  │
│   minTypeContainer   │       '11.71 ms'        │  '11.91 ms'  │
│   maxTypeContainer   │       '23.74 ms'        │  '23.61 ms'  │
│        focus         │        '43.4 ms'        │  '49.43 ms'  │
│       minFocus       │       '33.46 ms'        │  '39.68 ms'  │
│       maxFocus       │        '79.7 ms'        │  '82.54 ms'  │
│     inserterOpen     │       '31.32 ms'        │  '31.23 ms'  │
│   minInserterOpen    │       '19.26 ms'        │  '19.25 ms'  │
│   maxInserterOpen    │       '109.15 ms'       │ '109.43 ms'  │
│    inserterSearch    │        '9.32 ms'        │  '10.19 ms'  │
│  minInserterSearch   │        '3.71 ms'        │  '3.75 ms'   │
│  maxInserterSearch   │       '16.32 ms'        │  '17.75 ms'  │
│    inserterHover     │       '28.43 ms'        │  '31.19 ms'  │
│   minInserterHover   │         '25 ms'         │  '27.67 ms'  │
│   maxInserterHover   │       '33.88 ms'        │  '36.49 ms'  │
│     listViewOpen     │       '312.04 ms'       │ '316.63 ms'  │
│   minListViewOpen    │       '288.3 ms'        │ '293.25 ms'  │
│   maxListViewOpen    │       '409.43 ms'       │ '416.41 ms'  │
└──────────────────────┴─────────────────────────┴──────────────┘

>> site-editor

┌──────────────────────┬─────────────────────────┬───────────────┐
│       (index)        │ perf/one-store-listener │     trunk     │
├──────────────────────┼─────────────────────────┼───────────────┤
│    serverResponse    │       '115.58 ms'       │  '114.72 ms'  │
│      firstPaint      │       '260.35 ms'       │  '260.27 ms'  │
│   domContentLoaded   │       '440.35 ms'       │  '442.75 ms'  │
│        loaded        │       '440.73 ms'       │  '443.22 ms'  │
│ firstContentfulPaint │       '513.68 ms'       │  '517.07 ms'  │
│      firstBlock      │      '9430.32 ms'       │ '10007.55 ms' │
│         type         │       '47.92 ms'        │  '50.86 ms'   │
│       minType        │       '45.41 ms'        │  '48.14 ms'   │
│       maxType        │       '107.26 ms'       │  '112.03 ms'  │
└──────────────────────┴─────────────────────────┴───────────────┘

>> front-end-classic-theme

┌────────────────────────┬─────────────────────────┬────────────┐
│        (index)         │ perf/one-store-listener │   trunk    │
├────────────────────────┼─────────────────────────┼────────────┤
│    timeToFirstByte     │        '29.9 ms'        │ '29.9 ms'  │
│ largestContentfulPaint │        '62.8 ms'        │ '62.8 ms'  │
│      lcpMinusTtfb      │       '32.65 ms'        │ '32.65 ms' │
└────────────────────────┴─────────────────────────┴────────────┘

>> front-end-block-theme

┌────────────────────────┬─────────────────────────┬───────────┐
│        (index)         │ perf/one-store-listener │   trunk   │
├────────────────────────┼─────────────────────────┼───────────┤
│    timeToFirstByte     │        '55.2 ms'        │ '55.2 ms' │
│ largestContentfulPaint │       '81.92 ms'        │ '81.7 ms' │
│      lcpMinusTtfb      │        '26.3 ms'        │ '26.2 ms' │
└────────────────────────┴─────────────────────────┴───────────┘
```
