### PR TITLE
Remove the hydration console log of the Interactivity API

### DIFF
--- a/packages/block-library/src/utils/interactivity/index.js
+++ b/packages/block-library/src/utils/interactivity/index.js
@@ -12,6 +12,4 @@ registerDirectives();
 
 document.addEventListener( 'DOMContentLoaded', async () => {
 	await init();
-	// eslint-disable-next-line no-console
-	console.log( 'Interactivity API started' );
 } );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Remove a `console.log` that happened on the Interactivity API hydration.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Because it was meant to be only for debugging.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Just remove the line.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

- Open a page that has a menu with either submenus or overlay.
- Check that the `Interactivity API started` log is gone.
