### PR TITLE
Fix flaky Image block interactivity e2e test

### DIFF
--- a/test/e2e/specs/editor/blocks/image.spec.js
+++ b/test/e2e/specs/editor/blocks/image.spec.js
@@ -1075,6 +1075,8 @@ test.describe( 'Image - interactivity', () => {
 		editor,
 		page,
 	} ) => {
+		await editor.openDocumentSettingsSidebar();
+
 		const imageBlockFromUrl = editor.canvas.locator(
 			'role=document[name="Block: Image"i]'
 		);


### PR DESCRIPTION
## What?
Fixes #51569.

Fixes flaky `lightbox should work as expected when inserting an image from URL` e2e test.

## Why?
The lightbox settings are located in the Advanced inspector controls panel, and in some cases Document settings sidebar might be closed, causing the failure.

The `tests using uploaded image` test group ensures the sidebar is open, but the action was missing from this test.

## Testing Instructions

```
npm run test:e2e:playwright -- test/e2e/specs/editor/blocks/image.spec.js
```


## Screenshots or screencast <!-- if applicable -->
![test-failed-1](https://github.com/WordPress/gutenberg/assets/240569/a8dcd6c3-1c89-413e-944b-d58635d77548)
