### PR TITLE
Babel config: enable useSpread option for JSX transform to reduce transpilation

### DIFF
--- a/packages/babel-preset-default/index.js
+++ b/packages/babel-preset-default/index.js
@@ -89,6 +89,7 @@ module.exports = ( api ) => {
 				{
 					pragma: 'createElement',
 					pragmaFrag: 'Fragment',
+					useSpread: true,
 				},
 			],
 			maybeGetPluginTransformRuntime(),


### PR DESCRIPTION
While looking at output of `build:analyze-bundles` I noticed that we use and ship the Babel `extend` helper in many packages. It's used to transpile JSX spreads:
```js
<Foo bar={bar} {...rest} />
```
into
```js
createElement(Foo, extend({ bar }, rest))
```
This is legacy behavior, [Babel 8 will disable it by default](https://github.com/babel/babel/issues/9652), and there is the `useSpread: true` option that will transpile it to:
```js
createElement(Foo, { bar, ...rest })
```
It's then up to the further transforms to transpile the object spread if the browser doesn't support it.

After #50994, this is another little step to remove unnecessary Babel transforms. Generally, after dropping support for IE there remains very little to transpile nowadays.

**How to test:**
Look at output of `npm run build:analyze-bundles` and verify that the `extends` Babel helper package is no longer bundled in any Gutenberg package.