### PR TITLE
ItemGroup: Update button focus styles to be more consistent

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Enhancements
 
 -   `Modal`: Update corner radius to be between buttons and the site view frame, in a 2-4-8 system. ([#51254](https://github.com/WordPress/gutenberg/pull/51254)).
--   `ItemGroup`: Update focus state styles to be inline with other editor button focus states. ([#51576](https://github.com/WordPress/gutenberg/pull/51576)).
+-   `ItemGroup`: Update button focus state styles to be inline with other button focus states in the editor. ([#51576](https://github.com/WordPress/gutenberg/pull/51576)).
 
 ### Bug Fix
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Enhancements
 
 -   `Modal`: Update corner radius to be between buttons and the site view frame, in a 2-4-8 system. ([#51254](https://github.com/WordPress/gutenberg/pull/51254)).
+-   `ItemGroup`: Update focus state styles to be inline with other editor button focus states. ([#51576](https://github.com/WordPress/gutenberg/pull/51576)).
 
 ### Bug Fix
 

--- a/packages/components/src/item-group/styles.ts
+++ b/packages/components/src/item-group/styles.ts
@@ -23,6 +23,16 @@ export const unstyledButton = css`
 	&:hover {
 		color: ${ COLORS.ui.theme };
 	}
+
+	&:focus {
+		box-shadow: 0 0 0 var( --wp-admin-border-width-focus )
+			var(
+				--wp-components-color-accent,
+				var( --wp-admin-theme-color, ${ COLORS.ui.theme } )
+			);
+		// Windows high contrast mode.
+		outline: 2px solid transparent;
+	}
 `;
 
 export const itemWrapper = css`

--- a/packages/edit-post/src/components/preferences-modal/test/__snapshots__/index.js.snap
+++ b/packages/edit-post/src/components/preferences-modal/test/__snapshots__/index.js.snap
@@ -616,6 +616,14 @@ exports[`EditPostPreferencesModal should match snapshot when the modal is active
   color: var(--wp-components-color-accent, var(--wp-admin-theme-color, #3858e9));
 }
 
+.emotion-13:focus {
+  box-shadow: 0 0 0 var( --wp-admin-border-width-focus ) var(
+  				--wp-components-color-accent,
+  				var( --wp-admin-theme-color, var(--wp-components-color-accent, var(--wp-admin-theme-color, #3858e9)) )
+  			);
+  outline: 2px solid transparent;
+}
+
 .emotion-15 {
   display: -webkit-box;
   display: -webkit-flex;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Small update to make the focus styles of `ItemGroup` component consistent with other button focus styles in the editor.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Resolves this comment: https://github.com/WordPress/gutenberg/issues/50757#issuecomment-1589314311

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Copies the button focus styles used in the block settings panel.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
Compare the focus states of the buttons in the Pattern Inserter and the Global Styles panel. The focus states should include a styled border.

## Screenshots or screencast <!-- if applicable -->

| Before | After |
| ------- | ----- |
| <img width="348" alt="image" src="https://github.com/WordPress/gutenberg/assets/1645628/efe318e0-67cf-4e89-9d9d-5f06b707dafc">| <img width="348" alt="image" src="https://github.com/WordPress/gutenberg/assets/1645628/225d2eda-74c5-4121-bc4d-1dbb907bb3a0"> |

| Before | After |
| ------ | ----- |
| <img width="294" alt="image" src="https://github.com/WordPress/gutenberg/assets/1645628/b886c1df-f64e-4026-a0ce-468f7791c66b"> | <img width="294" alt="image" src="https://github.com/WordPress/gutenberg/assets/1645628/1ddd2b02-d303-4662-8a6d-c0ac716a1cdf"> |
