### PR TITLE
Navigation: Browse Mode: Fix misaligned ellipsis

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/style.scss
@@ -3,6 +3,10 @@
 }
 
 .edit-site-sidebar-navigation-screen-navigation-menus__content {
+	// Escapes the padding from the parent block, when showing the navigation items.
+	margin-left: -$grid-unit-10;
+	margin-right: -$grid-unit-10;
+
 	.offcanvas-editor-list-view-leaf {
 		max-width: calc(100% - #{ $grid-unit-05 });
 		border-radius: $radius-block-ui;

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/style.scss
@@ -4,6 +4,7 @@
 
 .edit-site-sidebar-navigation-screen-navigation-menus__content {
 	// Escapes the padding from the parent block, when showing the navigation items.
+	// Grid units aren't accurate enough to use here.
 	margin-left: -10px;
 	margin-right: -10px;
 

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/style.scss
@@ -4,8 +4,8 @@
 
 .edit-site-sidebar-navigation-screen-navigation-menus__content {
 	// Escapes the padding from the parent block, when showing the navigation items.
-	margin-left: -$grid-unit-10;
-	margin-right: -$grid-unit-10;
+	margin-left: -10px;
+	margin-right: -10px;
 
 	.offcanvas-editor-list-view-leaf {
 		max-width: calc(100% - #{ $grid-unit-05 });

--- a/packages/edit-site/src/components/sidebar-navigation-screen-template-part/template-part-navigation-menu.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-template-part/template-part-navigation-menu.js
@@ -22,7 +22,7 @@ export default function TemplatePartNavigationMenu( { id } ) {
 				size="12"
 				upperCase={ true }
 			>
-				{ title || __( 'Navigation' ) }
+				{ title?.rendered || __( 'Navigation' ) }
 			</Heading>
 			<NavigationMenuEditor navigationMenuId={ id } />
 		</>

--- a/packages/edit-site/src/components/sidebar-navigation-screen-template-part/template-part-navigation-menu.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-template-part/template-part-navigation-menu.js
@@ -22,7 +22,7 @@ export default function TemplatePartNavigationMenu( { id } ) {
 				size="12"
 				upperCase={ true }
 			>
-				{ title?.rendered || __( 'Navigation' ) }
+				{ title || __( 'Navigation' ) }
 			</Heading>
 			<NavigationMenuEditor navigationMenuId={ id } />
 		</>


### PR DESCRIPTION
## What?
Aligns the ellipsis menus in Browse mode.

## Why?
So it looks better.

## How?
Add some negative margins to the list view so it can use more of the screen canvas. Unfortunately using a grid value isn't possible as the value we need is between grid values.

## Testing Instructions
1. Open the Navigation section of Browse Mode in the Site Editor
2. Select a navigation
3. Check whether the ellipsis menu is aligned with the one in the header.

### Testing Instructions for Keyboard
N/A. This is a visual change

## Screenshots or screencast <!-- if applicable -->
<img width="361" alt="Screenshot 2023-06-16 at 14 43 51" src="https://github.com/WordPress/gutenberg/assets/275961/befb134c-7800-4488-bf0e-229914b85e3f">

