### PR TITLE
Remove Taxonomy as an option in the add template flow

### DIFF
--- a/packages/edit-site/src/components/add-new-template/new-template.js
+++ b/packages/edit-site/src/components/add-new-template/new-template.js
@@ -52,7 +52,6 @@ const DEFAULT_TEMPLATE_SLUGS = [
 	'category',
 	'date',
 	'tag',
-	'taxonomy',
 	'search',
 	'404',
 ];


### PR DESCRIPTION
## What?
Remove Taxonomy as an option in the add template modal

## Why?
Some templates are technically complex and consequently excluded from the template creation UI, e.g. `singular`, `$mimetype-$subtype`, `$mimetype`, and `$subtype`.

I suspect that Taxonomy falls into this category, and we should consider removing it from the UI. To be clear: themes would still be able to create the template by adding the file, just as they can with `singular.html` etc.

As a reminder, the Taxonomy template will display an archive of posts in _any_ custom taxonomy when a more specific template cannot be found. Otherwise Archive, then Index, will be used. 

It's a template you would generally only create when a custom taxonomy already exists, which is not the case on a vanilla WP installation. When a custom taxonomy _does_ exist, and you want to create a template for it, the dedicated "Taxonomy Name" and "Taxonomy Name: Term" templates are much more intuitive. Just as it is more intuitive to use "Page" and "Single" templates instead of the ambiguous "Singular". Both of these options are already supported.

An added benefit of this change is that the add-template modal feels much less wordy by removing this one template.

| Before | After |
| --- | --- |
| <img width="830" alt="Screenshot 2023-06-16 at 14 45 04" src="https://github.com/WordPress/gutenberg/assets/846565/c93a547a-2a8b-4f7a-88a4-0e99711728ed"> | <img width="832" alt="Screenshot 2023-06-16 at 14 46 14" src="https://github.com/WordPress/gutenberg/assets/846565/2b7c46dd-3f09-42ef-a63f-0895f44f5445"> |


## How?
Remove `taxonomy` from array of support templates in` new-template.js`.

## Testing Instructions
1. Open the templates panel and click the [+] button to add a template.
2. Notice that Taxonomy does not appear as an option.
3. Ensure that if Taxonomy does exist (add taxonomy.html to your active theme) it still appears in the list as normal.