### PR TITLE
Site editor navigation: Use chevron left in RTL mode

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-item/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-item/index.js
@@ -11,7 +11,8 @@ import {
 	__experimentalHStack as HStack,
 	FlexBlock,
 } from '@wordpress/components';
-import { chevronRightSmall, Icon } from '@wordpress/icons';
+import { isRTL } from '@wordpress/i18n';
+import { chevronRightSmall, chevronLeftSmall, Icon } from '@wordpress/icons';
 
 export default function SidebarNavigationItem( {
 	className,
@@ -39,7 +40,7 @@ export default function SidebarNavigationItem( {
 				<FlexBlock>{ children }</FlexBlock>
 				{ withChevron && (
 					<Icon
-						icon={ chevronRightSmall }
+						icon={ isRTL() ? chevronLeftSmall : chevronRightSmall }
 						className="edit-site-sidebar-navigation-item__drilldown-indicator"
 						size={ 24 }
 					/>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Use `chevronLeftSmall` instead of `chevronRightSmall` in RTL mode in the sidebar navigation item component.

## Why?
The screens change direction on RTL and the arrow should point the correct way.

## How?
Check if the WP is running in RTL mode and serve the correct icon based on it.

## Testing Instructions
1. Change your WP installation to a RTL languague.
2. Go to the "Site Editor"
3. Make sure the icons in the navigation looks correct.

## Screenshots or screencast <!-- if applicable -->
| Before | After |
|-----|-----|
| ![image](https://github.com/WordPress/gutenberg/assets/1415747/a5f0ed6e-cd9c-4690-9620-be926bff7d3b)  | ![image](https://github.com/WordPress/gutenberg/assets/1415747/f73e5039-b75f-49f9-be2d-5eeed59b7106)   |


