### PR TITLE
Fix navigation error in library

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/style.scss
@@ -3,11 +3,6 @@
 }
 
 .edit-site-sidebar-navigation-screen-navigation-menus__content {
-	// Escapes the padding from the parent block, when showing the navigation items.
-	// Grid units aren't accurate enough to use here.
-	margin-left: -10px;
-	margin-right: -10px;
-
 	.offcanvas-editor-list-view-leaf {
 		max-width: calc(100% - #{ $grid-unit-05 });
 		border-radius: $radius-block-ui;

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/style.scss
@@ -3,6 +3,10 @@
 }
 
 .edit-site-sidebar-navigation-screen-navigation-menus__content {
+	// Escapes the padding from the parent block, when showing the navigation items.
+	margin-left: -$grid-unit-10;
+	margin-right: -$grid-unit-10;
+
 	.offcanvas-editor-list-view-leaf {
 		max-width: calc(100% - #{ $grid-unit-05 });
 		border-radius: $radius-block-ui;

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/style.scss
@@ -4,6 +4,7 @@
 
 .edit-site-sidebar-navigation-screen-navigation-menus__content {
 	// Escapes the padding from the parent block, when showing the navigation items.
+	// Grid units aren't accurate enough to use here.
 	margin-left: -10px;
 	margin-right: -10px;
 

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/style.scss
@@ -4,8 +4,8 @@
 
 .edit-site-sidebar-navigation-screen-navigation-menus__content {
 	// Escapes the padding from the parent block, when showing the navigation items.
-	margin-left: -$grid-unit-10;
-	margin-right: -$grid-unit-10;
+	margin-left: -10px;
+	margin-right: -10px;
 
 	.offcanvas-editor-list-view-leaf {
 		max-width: calc(100% - #{ $grid-unit-05 });

--- a/packages/edit-site/src/components/sidebar-navigation-screen-template-part/template-part-navigation-menu.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-template-part/template-part-navigation-menu.js
@@ -22,7 +22,7 @@ export default function TemplatePartNavigationMenu( { id } ) {
 				size="12"
 				upperCase={ true }
 			>
-				{ title || __( 'Navigation' ) }
+				{ title?.rendered || __( 'Navigation' ) }
 			</Heading>
 			<NavigationMenuEditor navigationMenuId={ id } />
 		</>

--- a/packages/edit-site/src/components/sidebar-navigation-screen-template-part/template-part-navigation-menu.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-template-part/template-part-navigation-menu.js
@@ -22,7 +22,7 @@ export default function TemplatePartNavigationMenu( { id } ) {
 				size="12"
 				upperCase={ true }
 			>
-				{ title?.rendered || __( 'Navigation' ) }
+				{ title || __( 'Navigation' ) }
 			</Heading>
 			<NavigationMenuEditor navigationMenuId={ id } />
 		</>


### PR DESCRIPTION
## What?
When a navigation has a title, when we try to show that navigation in a template part in the sidebar, the editor crashes. We should be accessing the rendered property of the title, not the whole object.

## Why?
To display the correct title, rather than a WSOD.

## How?
Access the correct property of the title object, if it exists.

## Testing Instructions
This only seems to happen on some themes, I'm not sure why.
1. Switch to the console theme
2. Open the site editor and navigate to the library section
3. Open your header
4. Notice that the editor doesn't crash!
This is the direct URL: /wp-admin/site-editor.php?postType=wp_template_part&postId=scruffian-themes%2Fconsole%2F%2Fheader

### Testing Instructions for Keyboard
As above

