### PR TITLE
Fix flaky 'hooks API' e2e test

### DIFF
--- a/test/e2e/specs/editor/plugins/hooks-api.spec.js
+++ b/test/e2e/specs/editor/plugins/hooks-api.spec.js
@@ -21,6 +21,7 @@ test.describe( 'Using Hooks API', () => {
 		page,
 		editor,
 	} ) => {
+		await editor.openDocumentSettingsSidebar();
 		await editor.canvas.click( 'role=button[name="Add default block"i]' );
 		await page.keyboard.type( 'First paragraph' );
 		await page.click(
@@ -35,6 +36,7 @@ test.describe( 'Using Hooks API', () => {
 		editor,
 		page,
 	} ) => {
+		await editor.openDocumentSettingsSidebar();
 		await editor.canvas.click( 'role=button[name="Add default block"i]' );
 		await page.keyboard.type( 'First paragraph' );
 


### PR DESCRIPTION
## What?
Fixes #51583.

PR ensures that the document settings sidebar is open before tests try to locate any element there.

## Testing Instructions
```
npm run test:e2e:playwright -- test/e2e/specs/editor/plugins/hooks-api.spec.js
```

## Screenshots from failure artifacts
![test-failed-1](https://github.com/WordPress/gutenberg/assets/240569/e12eaf15-0032-4b56-9819-a1c1004a4f15)
