### PR TITLE
Fix flaky 'Keep styles on block transforms' e2e test

### DIFF
--- a/test/e2e/specs/editor/various/keep-styles-on-block-transforms.spec.js
+++ b/test/e2e/specs/editor/various/keep-styles-on-block-transforms.spec.js
@@ -12,9 +12,9 @@ test.describe( 'Keep styles on block transforms', () => {
 		page,
 		editor,
 	} ) => {
+		await editor.openDocumentSettingsSidebar();
 		await editor.canvas.click( 'role=button[name="Add default block"i]' );
 		await page.keyboard.type( '## Heading' );
-		await editor.openDocumentSettingsSidebar();
 		await page.click( 'role=button[name="Color Text styles"i]' );
 		await page.click( 'role=button[name="Color: Luminous vivid orange"i]' );
 
@@ -44,7 +44,7 @@ test.describe( 'Keep styles on block transforms', () => {
 				title: 'test',
 			} );
 		} );
-		// Create a paragraph block with some content.
+		await editor.openDocumentSettingsSidebar();
 		await editor.canvas.click( 'role=button[name="Add default block"i]' );
 		await page.keyboard.type( 'Line 1 to be made large' );
 		await page.keyboard.press( 'Enter' );
@@ -77,7 +77,7 @@ test.describe( 'Keep styles on block transforms', () => {
 		page,
 		editor,
 	} ) => {
-		// Create a paragraph block with some content.
+		await editor.openDocumentSettingsSidebar();
 		await editor.canvas.click( 'role=button[name="Add default block"i]' );
 		await page.keyboard.type( 'Line 1 to be made large' );
 		await page.click( 'role=radio[name="Large"i]' );


### PR DESCRIPTION
## What?
Fixes #47689.

PR ensures that the document settings sidebar is open before tests try to locate any element there.

## Testing Instructions
```
npm run test:e2e:playwright -- test/e2e/specs/editor/various/keep-styles-on-block-transforms.spec.js
```

## Screenshots from failure artifacts
![test-failed-1](https://github.com/WordPress/gutenberg/assets/240569/c57a06fa-4847-43e1-b314-f3f119bf33f2)
