### PR TITLE
Remove `accordion` from details block keywords

### DIFF
--- a/packages/block-library/src/details/block.json
+++ b/packages/block-library/src/details/block.json
@@ -5,7 +5,7 @@
 	"title": "Details",
 	"category": "text",
 	"description": "Hide and show additional content.",
-	"keywords": [ "disclosure", "summary", "hide", "accordion" ],
+	"keywords": [ "disclosure", "summary", "hide" ],
 	"textdomain": "default",
 	"attributes": {
 		"showContent": {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This PR simply removes the keyword `accordion` from the Details block's block.json file, to stop the Details block from being suggested if someone searches for `accordion` in the Block Inserter.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
I know there has been lots of discussion around whether a details block is an accordion or not and the journey to bring the details block to fruition has been a long one. However, the details block does not serve as an accessible _accordion_ pattern since it's not navigable. It's not a good idea to encourage people to think of the Details block as an accordion alternative.

Some helpful articles and resources:

- https://adrianroselli.com/2019/04/details-summary-are-not-insert-control-here.html
- https://daverupert.com/2019/12/why-details-is-not-an-accordion/
