### PR TITLE
Fix the flaky site editor list view tests

### DIFF
--- a/test/e2e/specs/site-editor/block-list-panel-preference.spec.js
+++ b/test/e2e/specs/site-editor/block-list-panel-preference.spec.js
@@ -38,5 +38,12 @@ test.describe( 'Block list view', () => {
 		await expect(
 			page.locator( 'role=region[name="List View"i]' )
 		).toBeVisible();
+
+		// The preferences cleanup.
+		await page.evaluate( () => {
+			window.wp.data
+				.dispatch( 'core/preferences' )
+				.set( 'core/edit-site', 'showListViewByDefault', false );
+		} );
 	} );
 } );


### PR DESCRIPTION
## What?
Fixes #51533.

The issue reported that the following assertion `await expect( openNavigationButton ).toBeFocused();` was failing on line 86 in the new site editor list view e2e tests - `test/e2e/specs/site-editor/list-view.spec.js`.

## Why?
The editor preferences persist across the tests, and the "Always open list view" setting was "leaking" from the block list panel preferences tests.

## How?
I added the cleanup code to the block list panel preferences test to turn off persisted list view after the tests are finished.

## Testing Instructions
It's hard to reproduce the exact scenario when the test fails on CI, but you can add this code snippet at the beginning of the "ensures List View global shortcut works properly" test to confirm my theory.

```js
await page.evaluate( () => {
	window.wp.data
		.dispatch( 'core/preferences' )
		.set( 'core/edit-site', 'showListViewByDefault', true );
} );

await page.reload();
```

Then run the tests.

```
npm run test:e2e:playwright -- test/e2e/specs/site-editor/list-view.spec.js
```
