### PR TITLE
Set fixedToolbar to false after each top toolbar test to ensure proper cleanup

### DIFF
--- a/test/e2e/specs/editor/various/shortcut-focus-toolbar.spec.js
+++ b/test/e2e/specs/editor/various/shortcut-focus-toolbar.spec.js
@@ -82,6 +82,11 @@ test.describe( 'Focus toolbar shortcut (alt + F10)', () => {
 			await editor.setIsFixedToolbar( true );
 		} );
 
+		test.afterEach( async ( { editor } ) => {
+			// Ensure the fixed toolbar option is off
+			await editor.setIsFixedToolbar( false );
+		} );
+
 		test( 'Focuses the correct toolbar in edit mode', async ( {
 			editor,
 			page,
@@ -159,11 +164,6 @@ test.describe( 'Focus toolbar shortcut (alt + F10)', () => {
 				width: 700,
 				height: 700,
 			},
-		} );
-
-		test.beforeEach( async ( { editor } ) => {
-			// Ensure the fixed toolbar option is off
-			await editor.setIsFixedToolbar( false );
 		} );
 
 		test( 'Focuses the correct toolbar in edit mode', async ( {


### PR DESCRIPTION


<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What? / Why? / How?
The cleanup for this test was handled in the test after it, rather than within the test itself. This moves the setTopToolbar( false ) into the Top Toolbar test.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
`npm run test:e2e:playwright shortcut-focus-toolbar.spec.js`
