### PR TITLE
`Modal`: fix closing when contained iframe is focused

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fix
+
+-   `Modal`: fix closing when contained iframe is focused ([#51602](https://github.com/WordPress/gutenberg/pull/51602)).
+
 ## 25.9.0 (2023-10-05)
 
 ### Enhancements
@@ -23,7 +27,6 @@
 -   `Button`: Remove `aria-selected` CSS selector from styling 'active' buttons ([#54931](https://github.com/WordPress/gutenberg/pull/54931)).
 -   `Popover`: Apply the CSS in JS styles properly for components used within popovers. ([#54912](https://github.com/WordPress/gutenberg/pull/54912))
 -   `Button`: Remove hover styles when `aria-disabled` is set to `true` for the secondary variant. ([#54978](https://github.com/WordPress/gutenberg/pull/54978))
--   `Modal`: fix closing when contained iframe is focused ([#51602](https://github.com/WordPress/gutenberg/pull/51602)).
 
 ### Internal
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -23,6 +23,7 @@
 -   `Button`: Remove `aria-selected` CSS selector from styling 'active' buttons ([#54931](https://github.com/WordPress/gutenberg/pull/54931)).
 -   `Popover`: Apply the CSS in JS styles properly for components used within popovers. ([#54912](https://github.com/WordPress/gutenberg/pull/54912))
 -   `Button`: Remove hover styles when `aria-disabled` is set to `true` for the secondary variant. ([#54978](https://github.com/WordPress/gutenberg/pull/54978))
+-   `Modal`: fix closing when contained iframe is focused ([#51602](https://github.com/WordPress/gutenberg/pull/51602)).
 
 ### Internal
 

--- a/packages/components/src/modal/index.tsx
+++ b/packages/components/src/modal/index.tsx
@@ -119,6 +119,12 @@ function UnforwardedModal(
 		}
 	}, [ contentRef ] );
 
+	const refOnRequestClose =
+		useRef< ModalProps[ 'onRequestClose' ] >( onRequestClose );
+	useEffect( () => {
+		refOnRequestClose.current = onRequestClose;
+	}, [ onRequestClose ] );
+
 	useEffect( () => {
 		ariaHelper.modalize( ref.current );
 		return () => ariaHelper.unmodalize();
@@ -141,7 +147,7 @@ function UnforwardedModal(
 				document.body.classList.remove( bodyOpenClassName );
 			}
 		};
-	}, [ bodyOpenClassName, onRequestClose ] );
+	}, [ bodyOpenClassName ] );
 
 	// Calls the isContentScrollable callback when the Modal children container resizes.
 	useLayoutEffect( () => {

--- a/packages/components/src/modal/index.tsx
+++ b/packages/components/src/modal/index.tsx
@@ -204,10 +204,7 @@ function UnforwardedModal(
 		onPointerDown: ( event ) => {
 			if ( event.isPrimary && event.target === event.currentTarget ) {
 				pressTarget = event.target;
-				// Avoids loss of focus yet also leaves `useFocusOutside`
-				// practically useless with its only potential trigger being
-				// programmatic focus movement. TODO opt for either removing
-				// the hook or enhancing it such that this isn't needed.
+				// Avoids focus changing so that focus return works as expected.
 				event.preventDefault();
 			}
 		},

--- a/packages/components/src/modal/index.tsx
+++ b/packages/components/src/modal/index.tsx
@@ -20,7 +20,6 @@ import {
 	useInstanceId,
 	useFocusReturn,
 	useFocusOnMount,
-	__experimentalUseFocusOutside as useFocusOutside,
 	useConstrainedTabbing,
 	useMergeRefs,
 } from '@wordpress/compose';
@@ -91,7 +90,6 @@ function UnforwardedModal(
 	);
 	const constrainedTabbingRef = useConstrainedTabbing();
 	const focusReturnRef = useFocusReturn();
-	const focusOutsideProps = useFocusOutside( onRequestClose );
 	const contentRef = useRef< HTMLDivElement >( null );
 	const childrenContainerRef = useRef< HTMLDivElement >( null );
 
@@ -253,9 +251,6 @@ function UnforwardedModal(
 					aria-labelledby={ contentLabel ? undefined : headingId }
 					aria-describedby={ aria.describedby }
 					tabIndex={ -1 }
-					{ ...( shouldCloseOnClickOutside
-						? focusOutsideProps
-						: {} ) }
 					onKeyDown={ onKeyDown }
 				>
 					<div

--- a/packages/components/src/modal/index.tsx
+++ b/packages/components/src/modal/index.tsx
@@ -35,8 +35,9 @@ import Button from '../button';
 import StyleProvider from '../style-provider';
 import type { ModalProps } from './types';
 
-// Used to count the number of open modals.
+// Used to track and dismiss the prior modal when another opens.
 let openModalCount = 0;
+let dismissOpenModal: ModalProps[ 'onRequestClose' ];
 
 function UnforwardedModal(
 	props: ModalProps,
@@ -128,7 +129,10 @@ function UnforwardedModal(
 
 		if ( openModalCount === 1 ) {
 			document.body.classList.add( bodyOpenClassName );
+		} else if ( openModalCount > 1 ) {
+			dismissOpenModal();
 		}
+		dismissOpenModal = onRequestClose;
 
 		return () => {
 			openModalCount--;
@@ -137,7 +141,7 @@ function UnforwardedModal(
 				document.body.classList.remove( bodyOpenClassName );
 			}
 		};
-	}, [ bodyOpenClassName ] );
+	}, [ bodyOpenClassName, onRequestClose ] );
 
 	// Calls the isContentScrollable callback when the Modal children container resizes.
 	useLayoutEffect( () => {

--- a/packages/components/src/modal/index.tsx
+++ b/packages/components/src/modal/index.tsx
@@ -46,7 +46,7 @@ import type { ModalProps } from './types';
 const level0Dismissers: MutableRefObject<
 	ModalProps[ 'onRequestClose' ] | undefined
 >[] = [];
-const context = createContext( level0Dismissers );
+const ModalContext = createContext( level0Dismissers );
 
 let isBodyOpenClassActive = false;
 
@@ -142,8 +142,10 @@ function UnforwardedModal(
 		refOnRequestClose.current = onRequestClose;
 	}, [ onRequestClose ] );
 
-	const dismissers = useContext( context );
-	const isLevel0 = dismissers === level0Dismissers;
+	// The list of `onRequestClose` callbacks of open (non-nested) Modals. Only
+	// one should remain open at a time and the list enables closing prior ones.
+	const dismissers = useContext( ModalContext );
+	// Used for the tracking and dismissing any nested modals.
 	const nestedDismissers = useRef< typeof level0Dismissers >( [] );
 
 	// Updates the stack tracking open modals at this level and calls
@@ -160,6 +162,7 @@ function UnforwardedModal(
 		};
 	}, [ dismissers ] );
 
+	const isLevel0 = dismissers === level0Dismissers;
 	// Adds/removes the value of bodyOpenClassName to body element.
 	useEffect( () => {
 		if ( ! isBodyOpenClassActive ) {
@@ -351,9 +354,9 @@ function UnforwardedModal(
 	);
 
 	return createPortal(
-		<context.Provider value={ nestedDismissers.current }>
+		<ModalContext.Provider value={ nestedDismissers.current }>
 			{ modal }
-		</context.Provider>,
+		</ModalContext.Provider>,
 		document.body
 	);
 }

--- a/packages/components/src/modal/index.tsx
+++ b/packages/components/src/modal/index.tsx
@@ -202,7 +202,7 @@ function UnforwardedModal(
 		onPointerUp: React.PointerEventHandler< HTMLDivElement >;
 	} = {
 		onPointerDown: ( event ) => {
-			if ( event.isPrimary && event.target === event.currentTarget ) {
+			if ( event.target === event.currentTarget ) {
 				pressTarget = event.target;
 				// Avoids focus changing so that focus return works as expected.
 				event.preventDefault();

--- a/packages/components/src/modal/stories/index.story.tsx
+++ b/packages/components/src/modal/stories/index.story.tsx
@@ -76,6 +76,13 @@ const Template: StoryFn< typeof Modal > = ( { onRequestClose, ...args } ) => {
 
 					<InputControl style={ { marginBottom: '20px' } } />
 
+					<iframe
+						title="Example"
+						width="300"
+						height="200"
+						src="https://www.openstreetmap.org/export/embed.html?bbox=-0.004017949104309083%2C51.47612752641776%2C0.00030577182769775396%2C51.478569861898606&layer=mapnik"
+					/>
+
 					<Button variant="secondary" onClick={ closeModal }>
 						Close Modal
 					</Button>

--- a/packages/components/src/modal/stories/index.story.tsx
+++ b/packages/components/src/modal/stories/index.story.tsx
@@ -76,13 +76,6 @@ const Template: StoryFn< typeof Modal > = ( { onRequestClose, ...args } ) => {
 
 					<InputControl style={ { marginBottom: '20px' } } />
 
-					<iframe
-						title="Example"
-						width="300"
-						height="200"
-						src="https://www.openstreetmap.org/export/embed.html?bbox=-0.004017949104309083%2C51.47612752641776%2C0.00030577182769775396%2C51.478569861898606&layer=mapnik"
-					/>
-
 					<Button variant="secondary" onClick={ closeModal }>
 						Close Modal
 					</Button>

--- a/packages/components/src/modal/test/index.tsx
+++ b/packages/components/src/modal/test/index.tsx
@@ -167,6 +167,35 @@ describe( 'Modal', () => {
 		expect( onRequestClose ).not.toHaveBeenCalled();
 	} );
 
+	it( 'should request closing of nested modal when outer modal unmounts', async () => {
+		const user = userEvent.setup();
+		const onRequestClose = jest.fn();
+
+		const RequestCloseOfNested = () => {
+			const [ isShown, setIsShown ] = useState( true );
+			return (
+				<>
+					{ isShown && (
+						<Modal
+							onKeyDown={ ( { key } ) => {
+								if ( key === 'o' ) setIsShown( false );
+							} }
+							onRequestClose={ noop }
+						>
+							<Modal onRequestClose={ onRequestClose }>
+								<p>Nested modal content</p>
+							</Modal>
+						</Modal>
+					) }
+				</>
+			);
+		};
+		render( <RequestCloseOfNested /> );
+
+		await user.keyboard( 'o' );
+		expect( onRequestClose ).toHaveBeenCalled();
+	} );
+
 	it( 'should accessibly hide and show siblings including outer modals', async () => {
 		const user = userEvent.setup();
 


### PR DESCRIPTION
## What?
Fix for a bug in `Modal` it closes when a contained iframe is focused.

## Why?
It seems like iframes in modals should be supported.
to fix: #40912

## How?
Uses an event handler on the Modal’s overlay element to trigger the closing instead of the `useFocusOutside` hook.

## Testing Instructions
1. Visit the Modal story in Storybook.
2. Open the modal.
3. Verify that clicking/focusing the contained iframe does not close the modal.
4. Verify that clicking outside the modal closes the modal.

