### PR TITLE
Featured Image: Use the first image in the post

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -582,7 +582,7 @@ Display a post's featured image. ([Source](https://github.com/WordPress/gutenber
 -	**Name:** core/post-featured-image
 -	**Category:** theme
 -	**Supports:** align (center, full, left, right, wide), color (~~background~~, ~~text~~), spacing (margin, padding), ~~html~~
--	**Attributes:** aspectRatio, customGradient, customOverlayColor, dimRatio, gradient, height, isLink, linkTarget, overlayColor, rel, scale, sizeSlug, width
+-	**Attributes:** aspectRatio, customGradient, customOverlayColor, dimRatio, gradient, height, isLink, linkTarget, overlayColor, rel, scale, sizeSlug, usePostFirstImage, width
 
 ## Post Navigation Link
 

--- a/packages/block-library/src/post-featured-image/block.json
+++ b/packages/block-library/src/post-featured-image/block.json
@@ -51,6 +51,10 @@
 		},
 		"customGradient": {
 			"type": "string"
+		},
+		"usePostFirstImage": {
+			"type": "boolean",
+			"default": false
 		}
 	},
 	"usesContext": [ "postId", "postType", "queryId" ],

--- a/packages/block-library/src/post-featured-image/edit.js
+++ b/packages/block-library/src/post-featured-image/edit.js
@@ -59,6 +59,7 @@ export default function PostFeaturedImageEdit( {
 		sizeSlug,
 		rel,
 		linkTarget,
+		usePostFirstImage,
 	} = attributes;
 	const [ featuredImage, setFeaturedImage ] = useEntityProp(
 		'postType',
@@ -177,6 +178,18 @@ export default function PostFeaturedImageEdit( {
 							/>
 						</>
 					) }
+					<ToggleControl
+						__nextHasNoMarginBottom
+						label={ __(
+							'Use first image from post if no featured image set'
+						) }
+						onChange={ () =>
+							setAttributes( {
+								usePostFirstImage: ! usePostFirstImage,
+							} )
+						}
+						checked={ usePostFirstImage }
+					/>
 				</PanelBody>
 			</InspectorControls>
 		</>

--- a/packages/block-library/src/post-featured-image/index.php
+++ b/packages/block-library/src/post-featured-image/index.php
@@ -13,6 +13,20 @@
  * @param WP_Block $block      Block instance.
  * @return string Returns the featured image for the current post.
  */
+
+function gutenberg_featured_image_post_thumbnail_id( $thumbnail_id, $post ) {
+	if ( ! $thumbnail_id ) {
+		$blocks = parse_blocks( $post->post_content );
+		foreach( $blocks as $block ) {
+			if ( $block['blockName'] === 'core/image' ) {
+				$thumbnail_id = $block['attrs']['id'];
+				break;
+			}
+		}
+	}
+	return $thumbnail_id;
+}
+
 function render_block_core_post_featured_image( $attributes, $content, $block ) {
 	if ( ! isset( $block->context['postId'] ) ) {
 		return '';
@@ -60,9 +74,17 @@ function render_block_core_post_featured_image( $attributes, $content, $block ) 
 	}
 
 	$featured_image = get_the_post_thumbnail( $post_ID, $size_slug, $attr );
+	if ( ! $featured_image && $attributes['usePostFirstImage'] ) {
+		// Add filter to get the first image from the post content.
+		add_filter( 'post_thumbnail_id', 'gutenberg_featured_image_post_thumbnail_id', 10, 2 );
+		// Get the post thumbnail again.
+		$featured_image = get_the_post_thumbnail( $post_ID, $size_slug, $attr );
+	}
+
 	if ( ! $featured_image ) {
 		return '';
 	}
+
 	if ( $is_link ) {
 		$link_target    = $attributes['linkTarget'];
 		$rel            = ! empty( $attributes['rel'] ) ? 'rel="' . esc_attr( $attributes['rel'] ) . '"' : '';


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This adds a toggle to the featured image block to allow the featured image block to fallback to the first image in the post. 
<img width="283" alt="Screenshot 2023-06-16 at 20 36 58" src="https://github.com/WordPress/gutenberg/assets/275961/e816800f-fd28-4a06-8551-bab468ecddc8">

## Why?
This is particularly useful for people replacing classic themes with block themes. Many old posts don't have featured images, and it's a lot of work to go back to them and add them all. This allows theme builders to use the post featured image block in a query block and have more confidence that an image will show.

## How?
We use parse blocks to grab the ID of the first image block and then apply a filter to the post featured image to return that id.

## Testing Instructions
1. Add some images to a post, but no featured image
2. Add a featured image block
3. Set the featured image block to `Use first image from post if no featured image set`
4. Check that the featured image block shows the first image in the post

### Testing Instructions for Keyboard
As above

## Screenshots or screencast <!-- if applicable -->
TBD

## Todo:
This works fine in the frontend but not in the editor.