### PR TITLE
Add init modules to details and post-time-to-read blocks

### DIFF
--- a/packages/block-library/src/details/init.js
+++ b/packages/block-library/src/details/init.js
@@ -1,0 +1,6 @@
+/**
+ * Internal dependencies
+ */
+import { init } from './';
+
+export default init();

--- a/packages/block-library/src/post-time-to-read/init.js
+++ b/packages/block-library/src/post-time-to-read/init.js
@@ -1,0 +1,6 @@
+/**
+ * Internal dependencies
+ */
+import { init } from './';
+
+export default init();


### PR DESCRIPTION
After #42258 it should be possible to register and retrieve an individual block by importing from a specialized `/init` module:
```js
import detailsBlock from '@wordpress/block-library/build-module/details/init';
```
But two blocks that were added only recently, `details` and `post-time-to-read`, don't have the `init` module. This PR is adding them.