### PR TITLE
Site Tagline Block: Remove unnecessary square path from block icon SVG

### DIFF
--- a/packages/block-library/src/site-tagline/icon.js
+++ b/packages/block-library/src/site-tagline/icon.js
@@ -5,7 +5,6 @@ import { SVG, Path } from '@wordpress/components';
 
 export default (
 	<SVG xmlns="http://www.w3.org/2000/svg" width="24" height="24">
-		<Path fill="none" d="M0 0h24v24H0z" />
 		<Path d="M4 9h16v2H4V9zm0 4h10v2H4v-2z" />
 	</SVG>
 );


### PR DESCRIPTION
## What?
This PR removes an unnecessary square path from the icon svg in the Site Tagline block.

This fixes a problem with the resulting square path when this icon is rendered within a particular component (`ItemGroup`).

![tagline](https://github.com/WordPress/gutenberg/assets/54422211/d5f0ea16-3b06-437b-8086-dcad46e96838)

## Why?
This icon had a square path that filled a 24-size view box. Because of `fill=none` defined on this path element, this path would not have surfaced even if the following style had been defined.

```css
svg {
  fill: red;
}
```

However, in #50819, [`fill:currentColor` is now also applied to the path element](https://github.com/WordPress/gutenberg/pull/50819/files#diff-0a25db32f741444b3f28d877c613b7b3df90bd10c728a9c5349f91c17b1e94d6R18-R20) in svg icons in the `ItemGroup` component.
As a result, `fill=none` was overridden and a square path surfaced.

## How?
I have removed this path itself as I think it is unnecessary.

## Testing Instructions
- Access Global Styles > Blocks.
- Confirm that the Site Tagline block icon is displayed correctly.