### PR TITLE
perf: Reduce unnecessary LinkPicker re-renders

### DIFF
--- a/package.json
+++ b/package.json
@@ -315,7 +315,7 @@
 		"test:native:clean": "jest --clearCache --config test/native/jest.config.js; rm -rf $TMPDIR/jest_*",
 		"test:native:debug": "cross-env NODE_ENV=test node --inspect-brk node_modules/.bin/jest --runInBand --verbose --config test/native/jest.config.js",
 		"test:native:perf": "cross-env TEST_RUNNER_ARGS='--runInBand --config test/native/jest.config.js --testMatch \"**/performance/*.native.[jt]s?(x)\"' reassure",
-		"test:native:perf:baseline": "cross-env TEST_RUNNER_ARGS='--runInBand --config test/native/jest.config.js --testMatch \"**/performance/*.native.[jt]s?(x)\"' reassure --baseline --testMatch \"**/performance/*.native.[jt]s?(x)\"",
+		"test:native:perf:baseline": "cross-env TEST_RUNNER_ARGS='--runInBand --config test/native/jest.config.js --testMatch \"**/performance/*.native.[jt]s?(x)\"' reassure --baseline",
 		"test:native:update": "npm run test:native -- --updateSnapshot",
 		"test:performance": "wp-scripts test-e2e --config packages/e2e-tests/jest.performance.config.js",
 		"test:performance:debug": "wp-scripts --inspect-brk test-e2e --runInBand --no-cache --verbose --config packages/e2e-tests/jest.performance.config.js --puppeteer-devtools",

--- a/packages/components/src/mobile/link-picker/index.native.js
+++ b/packages/components/src/mobile/link-picker/index.native.js
@@ -88,9 +88,7 @@ export const LinkPicker = ( {
 
 	useEffect( () => {
 		getURLFromClipboard()
-			.then( ( url ) => {
-				setClipboardUrl( url );
-			} )
+			.then( setClipboardUrl )
 			.catch( () => setClipboardUrl( '' ) );
 	}, [] );
 
@@ -113,9 +111,7 @@ export const LinkPicker = ( {
 					autoCapitalize="none"
 					autoCorrect={ false }
 					keyboardType="url"
-					onChangeValue={ ( newValue ) => {
-						setValue( newValue );
-					} }
+					onChangeValue={ setValue }
 					onSubmit={ onSubmit }
 					/* eslint-disable-next-line jsx-a11y/no-autofocus */
 					autoFocus

--- a/packages/components/src/mobile/link-picker/index.native.js
+++ b/packages/components/src/mobile/link-picker/index.native.js
@@ -57,10 +57,8 @@ export const LinkPicker = ( {
 	onLinkPicked,
 	onCancel: cancel,
 } ) => {
-	const [ { value, clipboardUrl }, setValue ] = useState( {
-		value: initialValue,
-		clipboardUrl: '',
-	} );
+	const [ value, setValue ] = useState( initialValue );
+	const [ clipboardUrl, setClipboardUrl ] = useState( '' );
 	const directEntry = createDirectEntry( value );
 
 	// The title of a direct entry is displayed as the raw input value, but if we
@@ -74,7 +72,8 @@ export const LinkPicker = ( {
 	};
 
 	const clear = () => {
-		setValue( { value: '', clipboardUrl } );
+		setValue( '' );
+		setClipboardUrl( '' );
 	};
 
 	const omniCellStyle = usePreferredColorSchemeStyle(
@@ -89,11 +88,10 @@ export const LinkPicker = ( {
 
 	useEffect( () => {
 		getURLFromClipboard()
-			.then( ( url ) => setValue( { value, clipboardUrl: url } ) )
-			.catch( () => setValue( { value, clipboardUrl: '' } ) );
-		// Disable reason: deferring this refactor to the native team.
-		// see https://github.com/WordPress/gutenberg/pull/41166
-		// eslint-disable-next-line react-hooks/exhaustive-deps
+			.then( ( url ) => {
+				setClipboardUrl( url );
+			} )
+			.catch( () => setClipboardUrl( '' ) );
 	}, [] );
 
 	// TODO: Localize the accessibility label.
@@ -116,7 +114,7 @@ export const LinkPicker = ( {
 					autoCorrect={ false }
 					keyboardType="url"
 					onChangeValue={ ( newValue ) => {
-						setValue( { value: newValue, clipboardUrl } );
+						setValue( newValue );
 					} }
 					onSubmit={ onSubmit }
 					/* eslint-disable-next-line jsx-a11y/no-autofocus */

--- a/packages/components/src/mobile/link-picker/test/performance/index.native.js
+++ b/packages/components/src/mobile/link-picker/test/performance/index.native.js
@@ -1,0 +1,35 @@
+/**
+ * External dependencies
+ */
+import { act, measurePerformance } from 'test/helpers';
+import Clipboard from '@react-native-clipboard/clipboard';
+
+/**
+ * Internal dependencies
+ */
+import { LinkPicker } from '../../index';
+
+describe( 'LinkPicker', () => {
+	const onLinkPicked = jest.fn();
+	const onCancel = jest.fn();
+	const clipboardResult = Promise.resolve( '' );
+	Clipboard.getString.mockReturnValue( clipboardResult );
+
+	it( 'performance is stable when clipboard results do not change', async () => {
+		const scenario = async () => {
+			// Given the clipboard result is an empty string, there are no
+			// user-facing changes to query. Thus, we must await the promise
+			// itself.
+			await act( () => clipboardResult );
+		};
+
+		await measurePerformance(
+			<LinkPicker
+				onLinkPicked={ onLinkPicked }
+				onCancel={ onCancel }
+				value=""
+			/>,
+			{ scenario }
+		);
+	} );
+} );

--- a/packages/components/src/mobile/link-settings/test/edit.native.js
+++ b/packages/components/src/mobile/link-settings/test/edit.native.js
@@ -138,7 +138,6 @@ describe.each( [
 					)
 				);
 				if ( type === 'core/image' ) {
-					// Wait for side effects produced by Clipboard and link suggestions
 					fireEvent.press( subject.getByLabelText( /Custom URL/ ) );
 				}
 				await subject.findByLabelText( 'Apply' );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Reduce unnecessary `LinkPicker` re-renders.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Re-renders include a performance cost, which can degrade the user experience.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Combining state with an object in a single `useState` meant a new object
was set to the state regardless of whether new values were present. This
resulted in unexpected `act` warnings caused by unnecessary re-renders.

Refactoring `LinkPicker` to separate the two state values into separate
`useState` calls resolves this issue by using primitives that can be
compared directly, which results in `useState` not triggering re-renders
when the values are the same.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
Automated tests should cover these changes fairly well. Here are a few manual test cases. 

**Add and edit links within rich text content**
1. Add a Paragraph. 
2. Type text. 
3. Select text. 
4. Tap the link button the block toolbar. 
5. Add a URL for the link.
6. Dismiss the bottom sheet. 
7. Verify the link is created. 
8. Repeat steps 1-7 without selection (step 3). 

**Add links for Buttons blocks**
1. Add a Buttons block. 
2. Add text to a button. 
3. Tap the link button in the block toolbar. 
4. Add URL for the link. 
5. Dismiss the bottom sheet. 
6. Verify the link is created. 

**Add links to Image blocks**
1. Add an Image block. 
2. Tap the block settings button in the block toolbar. 
3. Tap Link to. 
4. Select Custom URL. 
5. Set a URL for the link. 
6. Dismiss the bottom sheet. 
7. Verify the link is created. 

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
n/a

## Screenshots or screencast <!-- if applicable -->
The included performance test showcases the render count reducing from two to one, a 50% decrease. 

![link-picker-reduced-render-count](https://github.com/WordPress/gutenberg/assets/438664/720c8772-081d-4cd6-bf52-0d78d0e77c5d)
