### PR TITLE
Global Styles: Fix push-to-global-styles clearing of attributes, border fallbacks, link hover colors, and behaviors

### DIFF
--- a/packages/edit-site/src/hooks/push-changes-to-global-styles/index.js
+++ b/packages/edit-site/src/hooks/push-changes-to-global-styles/index.js
@@ -12,7 +12,7 @@ import {
 import { BaseControl, Button } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import {
-	__EXPERIMENTAL_STYLE_PROPERTY as STYLE_PROPERTY,
+	__EXPERIMENTAL_STYLE_PROPERTY,
 	getBlockType,
 	hasBlockSupport,
 } from '@wordpress/blocks';
@@ -32,6 +32,14 @@ const {
 	__experimentalUseGlobalBehaviors: useGlobalBehaviors,
 	__experimentalUseHasBehaviorsPanel: useHasBehaviorsPanel,
 } = unlock( blockEditorPrivateApis );
+
+// Block Gap is a special case and isn't defined within the blocks
+// style properties config. We'll add it here to allow it to be pushed
+// to global styles as well.
+const STYLE_PROPERTY = {
+	...__EXPERIMENTAL_STYLE_PROPERTY,
+	blockGap: { value: [ 'spacing', 'blockGap' ] },
+};
 
 // TODO: Temporary duplication of constant in @wordpress/block-editor. Can be
 // removed by moving PushChangesToGlobalStylesControl to
@@ -79,7 +87,7 @@ const STYLE_PATH_TO_CSS_VAR_INFIX = {
 	'elements.h6.typography.fontFamily': 'font-family',
 	'elements.h6.color.gradient': 'gradient',
 	'color.gradient': 'gradient',
-	'spacing.blockGap': 'spacing',
+	blockGap: 'spacing',
 	'typography.fontSize': 'font-size',
 	'typography.fontFamily': 'font-family',
 };

--- a/packages/edit-site/src/hooks/push-changes-to-global-styles/index.js
+++ b/packages/edit-site/src/hooks/push-changes-to-global-styles/index.js
@@ -78,6 +78,7 @@ const STYLE_PATH_TO_CSS_VAR_INFIX = {
 	'elements.h6.typography.fontFamily': 'font-family',
 	'elements.h6.color.gradient': 'gradient',
 	'color.gradient': 'gradient',
+	'spacing.blockGap': 'spacing',
 	'typography.fontSize': 'font-size',
 	'typography.fontFamily': 'font-family',
 };
@@ -128,7 +129,7 @@ function useChangesToPush( name, attributes ) {
 		// default border style if a border color or width is present.
 		const { color, style, width } = attributes.style?.border || {};
 
-		if ( ( color || width ) && ! style ) {
+		if ( ( attributes.borderColor || color || width ) && ! style ) {
 			changes.push( { path: [ 'border', 'style' ], value: 'solid' } );
 		}
 

--- a/packages/edit-site/src/hooks/push-changes-to-global-styles/index.js
+++ b/packages/edit-site/src/hooks/push-changes-to-global-styles/index.js
@@ -36,6 +36,7 @@ const {
 // removed by moving PushChangesToGlobalStylesControl to
 // @wordpress/block-editor.
 const STYLE_PATH_TO_CSS_VAR_INFIX = {
+	'border.color': 'color',
 	'color.background': 'color',
 	'color.text': 'color',
 	'elements.link.color.text': 'color',
@@ -85,6 +86,7 @@ const STYLE_PATH_TO_CSS_VAR_INFIX = {
 // removed by moving PushChangesToGlobalStylesControl to
 // @wordpress/block-editor.
 const STYLE_PATH_TO_PRESET_BLOCK_ATTRIBUTE = {
+	'border.color': 'borderColor',
 	'color.background': 'backgroundColor',
 	'color.text': 'textColor',
 	'color.gradient': 'gradient',
@@ -219,12 +221,22 @@ function PushChangesToGlobalStylesControl( {
 				);
 			}
 
+			const newBlockAttributes = {
+				borderColor: undefined,
+				backgroundColor: undefined,
+				textColor: undefined,
+				gradient: undefined,
+				fontSize: undefined,
+				fontFamily: undefined,
+				style: newBlockStyles,
+			};
+
 			// @wordpress/core-data doesn't support editing multiple entity types in
 			// a single undo level. So for now, we disable @wordpress/core-data undo
 			// tracking and implement our own Undo button in the snackbar
 			// notification.
 			__unstableMarkNextChangeAsNotPersistent();
-			setAttributes( { style: newBlockStyles } );
+			setAttributes( newBlockAttributes );
 			setUserConfig( () => newUserConfig, { undoIgnore: true } );
 			createSuccessNotice(
 				sprintf(
@@ -239,7 +251,7 @@ function PushChangesToGlobalStylesControl( {
 							label: __( 'Undo' ),
 							onClick() {
 								__unstableMarkNextChangeAsNotPersistent();
-								setAttributes( { style: blockStyles } );
+								setAttributes( attributes );
 								setUserConfig( () => userConfig, {
 									undoIgnore: true,
 								} );


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/48048

## What?

- Adds fallback default border style when applying block styles globally so a visual border is maintained
- Fixes pushing of border styles to global styles
- Fixes resetting of block attributes for presets when applying globally
- Cleans updated block style attribute to remove empty objects that were left behind
- Fixes pushing link hover colors
- Fixes clearing of behavior attributes
- Updates hook dependencies to satisfy linter (needs extra testing to ensure no regressions)

## Why?

Currently, the pushing of block instance styles to global styles doesn't work for borders creating unexpected UX.

## How?

- When determining the changes that need to be pushed to the user's global styles, we apply the required global styles logic to border styles (e.g. global styles needs longhand config).
- Border style fallbacks are only added if the side doesn't already have one in global styles to maintain prior selections
- Updates the config arrays so that border color preset values are added to the changes correctly
- Clears preset block attribute values from the updated block attributes
- Handle case where single support key for `linkColor` needs to check two style properties for changes
- Fix snackbar undo actions to also undo clearing of attributes

## Testing Instructions

1. Replicate the original issue before checking out this PR. See https://github.com/WordPress/gutenberg/issues/48048 for further info.
2. In the site editor, select an individual block that has border support e.g. Featured Image or Group
3. Apply a border width or color only to that block, note that the editor shows a visual border
4. Switch to the settings tab and expand the Advanced panel revealing the `Apply globally` button
5. Click "Apply globally" and confirm that the border remains visible as before in the editor, including color application now being fixed
6. Switch back to the styles tab and ensure that the border controls there are now reset
7. Navigate to Global Styles > Blocks > and then to the block type you styled
8. Confirm that block type's border controls now show the color or width you selected, along with the default border style
9. Repeat the process however this time set a dashed or dotted border style and confirm that border style is retained throughout
10. Test the application of block styles global setting all available color and font preset values e.g. text, background, gradient, border color, font size, font family etc. Confirm that now when you apply those styles globally, the block's attribute has been reset.
11. Test setting global styles first, then updating a block instance style before applying the block styles globally e.g. https://github.com/WordPress/gutenberg/pull/51621#issuecomment-1596572371
12. Test with varied border configs per side ensuring they are applied as expected globally.
13. Make sure that block instance styles are correctly applied globally when the block has per-side config, the global styles are using shorthand, and vice versa.
14. Confirm that when configuring per-side borders on a block instance the border style attributes are properly cleaned from the block attributes.
15. Test that after applying block styles globally, the undo link in the snackbar notice works correctly. In particular, ensure that preset attribute values are reinstated.
16. Test that block gap styles trigger the activation of the "Apply Globally" button and that they are successfully pushed to global styles and cleared from the block instance when the button is clicked.
17. Confirm link hover color is successfully pushed and cleared from block instance
18. Confirm pushed behaviours are also cleared


## Screenshots or screencast <!-- if applicable -->


https://github.com/WordPress/gutenberg/assets/60436221/999bae6a-3d50-4083-9e9c-790009086448


