### PR TITLE
Added a visible left bar on selected command center item to improve accessibility

### DIFF
--- a/packages/commands/src/components/style.scss
+++ b/packages/commands/src/components/style.scss
@@ -63,7 +63,7 @@
 	}
 
 	[cmdk-item] {
-		border-radius: $grid-unit-05;
+		border-radius: 0 $grid-unit-05 $grid-unit-05 0;
 		cursor: pointer;
 		display: flex;
 		align-items: center;
@@ -73,6 +73,7 @@
 		&[aria-selected="true"],
 		&:active {
 			background: rgba(var(--wp-admin-theme-color--rgb), 0.04);
+			box-shadow: inset 4px 0 0 0 currentColor;
 			color: var(--wp-admin-theme-color);
 
 			svg {

--- a/packages/commands/src/components/style.scss
+++ b/packages/commands/src/components/style.scss
@@ -73,11 +73,22 @@
 		&[aria-selected="true"],
 		&:active {
 			background: rgba(var(--wp-admin-theme-color--rgb), 0.04);
-			box-shadow: inset 4px 0 0 0 currentColor;
 			color: var(--wp-admin-theme-color);
 
 			svg {
-				fill: var(--wp-admin-theme-color);
+				fill: currentColor;
+			}
+
+			&::after {
+				border-color: currentColor;
+				border-style: solid;
+				border-width: 2px 2px 0 0;
+				content: "";
+				display: inline-block;
+				height: 10px;
+				margin-right: 0.75rem;
+				transform: rotate(45deg);
+				width: 10px;
 			}
 		}
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Goal is to improve accessibility of command center suggestions list by adding visible left bar on selected item (hover).

## Why?
Issue was brought up here #51582 

## How?
Checked how the WordPress main menu creates the left bar on current item / on hover and grabbed the CSS and pasted it here.

## Testing Instructions
1. Open Site editor
2. Open Command center
3. Hover on top of suggestions
4. Observe the effect on current item

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
<img width="522" alt="Screenshot 2023-06-18 at 18 29 38" src="https://github.com/WordPress/gutenberg/assets/62872075/257cf292-a370-4fc5-8918-a1f847326514">
