### PR TITLE
Distraction Free: Avoid focus loss when enabling/disabling distraction free mode via the more menu

### DIFF
--- a/packages/edit-post/src/components/header/index.js
+++ b/packages/edit-post/src/components/header/index.js
@@ -27,7 +27,6 @@ function Header( { setEntitiesSavedStatesCallback } ) {
 		isPublishSidebarOpened,
 		isSaving,
 		showIconLabels,
-		isDistractionFreeMode,
 	} = useSelect(
 		( select ) => ( {
 			hasActiveMetaboxes: select( editPostStore ).hasMetaBoxes(),
@@ -36,21 +35,17 @@ function Header( { setEntitiesSavedStatesCallback } ) {
 			isSaving: select( editPostStore ).isSavingMetaBoxes(),
 			showIconLabels:
 				select( editPostStore ).isFeatureActive( 'showIconLabels' ),
-			isDistractionFreeMode:
-				select( editPostStore ).isFeatureActive( 'distractionFree' ),
 		} ),
 		[]
 	);
 
-	const isDistractionFree = isDistractionFreeMode && isLargeViewport;
-
 	const slideY = {
-		hidden: isDistractionFree ? { y: '-50' } : { y: 0 },
+		hidden: { y: '-50px' },
 		hover: { y: 0, transition: { type: 'tween', delay: 0.2 } },
 	};
 
 	const slideX = {
-		hidden: isDistractionFree ? { x: '-100%' } : { x: 0 },
+		hidden: { x: '-100%' },
 		hover: { x: 0, transition: { type: 'tween', delay: 0.2 } },
 	};
 

--- a/packages/edit-post/src/components/header/writing-menu/index.js
+++ b/packages/edit-post/src/components/header/writing-menu/index.js
@@ -25,16 +25,9 @@ function WritingMenu() {
 		[]
 	);
 
-	const blocks = useSelect(
-		( select ) => select( blockEditorStore ).getBlocks(),
-		[]
-	);
-
 	const { setIsInserterOpened, setIsListViewOpened, closeGeneralSidebar } =
 		useDispatch( postEditorStore );
 	const { set: setPreference } = useDispatch( preferencesStore );
-
-	const { selectBlock } = useDispatch( blockEditorStore );
 
 	const toggleDistractionFree = () => {
 		registry.batch( () => {
@@ -42,9 +35,6 @@ function WritingMenu() {
 			setIsInserterOpened( false );
 			setIsListViewOpened( false );
 			closeGeneralSidebar();
-			if ( ! isDistractionFree && !! blocks.length ) {
-				selectBlock( blocks[ 0 ].clientId );
-			}
 		} );
 	};
 

--- a/packages/interface/src/components/interface-skeleton/index.js
+++ b/packages/interface/src/components/interface-skeleton/index.js
@@ -75,11 +75,12 @@ function InterfaceSkeleton(
 	const mergedLabels = { ...defaultLabels, ...labels };
 
 	const headerVariants = {
-		hidden: isDistractionFree ? { opacity: 0 } : { opacity: 1 },
+		hidden: { opacity: 0 },
 		hover: {
 			opacity: 1,
 			transition: { type: 'tween', delay: 0.2, delayChildren: 0.2 },
 		},
+		distractionFreeInactive: { opacity: 1, transition: { delay: 0 } },
 	};
 
 	return (
@@ -97,23 +98,32 @@ function InterfaceSkeleton(
 			) }
 		>
 			<div className="interface-interface-skeleton__editor">
-				{ !! header && isDistractionFree && (
+				{ !! header && (
 					<NavigableRegion
 						as={ motion.div }
 						className="interface-interface-skeleton__header"
 						aria-label={ mergedLabels.header }
-						initial={ isDistractionFree ? 'hidden' : 'hover' }
-						whileHover="hover"
+						initial={
+							isDistractionFree
+								? 'hidden'
+								: 'distractionFreeInactive'
+						}
+						whileHover={
+							isDistractionFree
+								? 'hover'
+								: 'distractionFreeInactive'
+						}
+						animate={
+							isDistractionFree
+								? 'hidden'
+								: 'distractionFreeInactive'
+						}
 						variants={ headerVariants }
-						transition={ { type: 'tween', delay: 0.8 } }
-					>
-						{ header }
-					</NavigableRegion>
-				) }
-				{ !! header && ! isDistractionFree && (
-					<NavigableRegion
-						className="interface-interface-skeleton__header"
-						ariaLabel={ mergedLabels.header }
+						transition={
+							isDistractionFree
+								? { type: 'tween', delay: 0.8 }
+								: undefined
+						}
 					>
 						{ header }
 					</NavigableRegion>


### PR DESCRIPTION
## What?
Improves the issue mentioned here - https://github.com/WordPress/gutenberg/pull/41740#issuecomment-1582921123

There was a focus loss issue when entering distraction free mode via the editor options menu. This PR should resolve the issue in the majority of cases.

When testing I still noticed that very rarely a focus loss would occur, but I don't yet understand why, but I imagine there's a separate bug somewhere.

## Why?
The focus loss was happening due to an issue in the `InterfaceSkeleton` component. When toggling distraction free mode, the element being rendered switches from a `div` to a `motion.div`. When switching components like this it can cause React to unmount and remount the DOM element.

There was also some conditional rendering logic that might trip up the react reconciler.

## How?
I've switch to always rendering a `motion.div`. The advantage of this is that it's now possible to properly animate the entry and exit of distraction free mode.

I've also removed some of the conditional rendering in favour of just outputting a single `NavigableRegion`

## Testing Instructions for Keyboard
1. Tab to the Header Options menu and open it
2. Arrow key down to the 'Distraction Free' option
3. Toggle this option

Expected: The menu should stay open and the menu item should retain focus.

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/677833/076b44f6-4161-4422-93e6-13a633bc11d9

