### PR TITLE
Search Block: Write "Button Only" label in sentence capitalization

### DIFF
--- a/packages/block-library/src/search/edit.js
+++ b/packages/block-library/src/search/edit.js
@@ -226,7 +226,7 @@ export default function SearchEdit( {
 		},
 		{
 			role: 'menuitemradio',
-			title: __( 'Button Only' ),
+			title: __( 'Button only' ),
 			isActive: buttonPosition === 'button-only',
 			icon: buttonOnly,
 			onClick: () => {


### PR DESCRIPTION
Follow-up on: #50487

## What?
This PR rewrites "Button Only" label in sentence capitalization in the search block.

![search](https://github.com/WordPress/gutenberg/assets/54422211/860c8f4b-9a5d-446a-a6f1-ddfc85fa8c48)

## Why?
To be consistent with other blocks and other functional labels.
