### PR TITLE
Docs: Fix incorrect import of useEntityRecords in code example

### DIFF
--- a/packages/core-data/README.md
+++ b/packages/core-data/README.md
@@ -859,7 +859,7 @@ Resolves the specified entity records.
 _Usage_
 
 ```js
-import { useEntityRecord } from '@wordpress/core-data';
+import { useEntityRecords } from '@wordpress/core-data';
 
 function PageTitlesList() {
 	const { records, isResolving } = useEntityRecords( 'postType', 'page' );

--- a/packages/core-data/src/hooks/use-entity-records.ts
+++ b/packages/core-data/src/hooks/use-entity-records.ts
@@ -43,7 +43,7 @@ const EMPTY_ARRAY = [];
  * @param    options   Optional hook options.
  * @example
  * ```js
- * import { useEntityRecord } from '@wordpress/core-data';
+ * import { useEntityRecords } from '@wordpress/core-data';
  *
  * function PageTitlesList() {
  *   const { records, isResolving } = useEntityRecords( 'postType', 'page' );


### PR DESCRIPTION
This code example is for `useEntityRecords`, but it was importing `useEntityRecord`, so correct the import statement.

## Testing Instructions

No impact on the code.