### PR TITLE
Details: Set 'clientId' as useSelect dependency

### DIFF
--- a/packages/block-library/src/details/edit.js
+++ b/packages/block-library/src/details/edit.js
@@ -30,15 +30,18 @@ function DetailsEdit( { attributes, setAttributes, clientId } ) {
 	} );
 
 	// Check if either the block or the inner blocks are selected.
-	const hasSelection = useSelect( ( select ) => {
-		const { isBlockSelected, hasSelectedInnerBlock } =
-			select( blockEditorStore );
-		/* Sets deep to true to also find blocks inside the details content block. */
-		return (
-			hasSelectedInnerBlock( clientId, true ) ||
-			isBlockSelected( clientId )
-		);
-	}, [] );
+	const hasSelection = useSelect(
+		( select ) => {
+			const { isBlockSelected, hasSelectedInnerBlock } =
+				select( blockEditorStore );
+			/* Sets deep to true to also find blocks inside the details content block. */
+			return (
+				hasSelectedInnerBlock( clientId, true ) ||
+				isBlockSelected( clientId )
+			);
+		},
+		[ clientId ]
+	);
 
 	return (
 		<>


### PR DESCRIPTION
## What?
PR fixes `React Hook useSelect has a missing dependency: 'clientId'` ESLint warning in the Details block.

## Why?
Missing dependencies can have unexpected side effects.

## Testing Instructions
Confirm the Details block works as before.
