### PR TITLE
Fix flaky 'Push to Global Styles' e2e test

### DIFF
--- a/test/e2e/specs/site-editor/push-to-global-styles.spec.js
+++ b/test/e2e/specs/site-editor/push-to-global-styles.spec.js
@@ -5,11 +5,7 @@ const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 
 test.describe( 'Push to Global Styles button', () => {
 	test.beforeAll( async ( { requestUtils } ) => {
-		await Promise.all( [
-			requestUtils.activateTheme( 'emptytheme' ),
-			requestUtils.deleteAllTemplates( 'wp_template' ),
-			requestUtils.deleteAllTemplates( 'wp_template_part' ),
-		] );
+		await requestUtils.activateTheme( 'emptytheme' );
 	} );
 
 	test.afterAll( async ( { requestUtils } ) => {

--- a/test/e2e/specs/site-editor/push-to-global-styles.spec.js
+++ b/test/e2e/specs/site-editor/push-to-global-styles.spec.js
@@ -17,7 +17,10 @@ test.describe( 'Push to Global Styles button', () => {
 	} );
 
 	test.beforeEach( async ( { admin, editor } ) => {
-		await admin.visitSiteEditor();
+		await admin.visitSiteEditor( {
+			postId: 'emptytheme//index',
+			postType: 'wp_template',
+		} );
 		await editor.canvas.click( 'body' );
 	} );
 
@@ -29,8 +32,10 @@ test.describe( 'Push to Global Styles button', () => {
 		await editor.insertBlock( { name: 'core/heading' } );
 		await page.keyboard.type( 'A heading' );
 
+		const topBar = page.getByRole( 'region', { name: 'Editor top bar' } );
+
 		// Navigate to Styles -> Blocks -> Heading -> Typography
-		await page.getByRole( 'button', { name: 'Styles' } ).click();
+		await topBar.getByRole( 'button', { name: 'Styles' } ).click();
 		await page.getByRole( 'button', { name: 'Blocks styles' } ).click();
 		await page
 			.getByRole( 'button', { name: 'Heading block styles' } )
@@ -42,7 +47,7 @@ test.describe( 'Push to Global Styles button', () => {
 		).toHaveAttribute( 'aria-pressed', 'false' );
 
 		// Go to block settings and open the Advanced panel
-		await page.getByRole( 'button', { name: 'Settings' } ).click();
+		await topBar.getByRole( 'button', { name: 'Settings' } ).click();
 		await page.getByRole( 'button', { name: 'Advanced' } ).click();
 
 		// Push button should be disabled


### PR DESCRIPTION
## What?
Fixes #49942.

PR fixes flaky 'Push to Global Styles' e2e test by better scoping `Styles` and `Settings` button locators.

## Why?
The button with the label "Styles" is no longer unique in the Site Editor.

Error log
```
Error: locator.click: Error: strict mode violation: getByRole('button', { name: 'Styles' }) resolved to 2 elements:
    1) <button type="button" aria-label="Styles" aria-pressed="…>…</button> aka getByRole('region', { name: 'Editor top bar' }).getByRole('button', { name: 'Styles' })
    2) <button data-wp-c16t="true" id="/wp_global_styles" data-…>…</button> aka getByRole('region', { name: 'Navigation' }).getByRole('button', { name: 'Styles' })

=========================== logs ===========================
waiting for getByRole('button', { name: 'Styles' })
============================================================
    at /home/runner/work/gutenberg/gutenberg/test/e2e/specs/site-editor/push-to-global-styles.spec.js:33:56
```

## Testing Instructions
```
npm run test:e2e:playwright -- test/e2e/specs/site-editor/push-to-global-styles.spec.js
```