### PR TITLE
Add global styles related commands

### DIFF
--- a/packages/core-commands/src/site-editor-navigation-commands.js
+++ b/packages/core-commands/src/site-editor-navigation-commands.js
@@ -162,7 +162,7 @@ function useSiteEditorBasicNavigationCommands() {
 		} );
 
 		result.push( {
-			name: 'core/edit-site/open-styles',
+			name: 'core/edit-site/open-style-variations',
 			label: __( 'Open style variations' ),
 			icon: styles,
 			callback: ( { close } ) => {

--- a/packages/edit-site/src/components/global-styles/ui.js
+++ b/packages/edit-site/src/components/global-styles/ui.js
@@ -260,7 +260,10 @@ function GlobalStylesEditorCanvasContainerLink() {
 			// Switching to any container other than revisions should
 			// redirect from the revisions screen to the root global styles screen.
 			goTo( '/' );
+		} else if ( editorCanvasContainerView === 'global-styles-css' ) {
+			goTo( '/css' );
 		}
+
 		// location?.path is not a dependency because we don't want to track it.
 		// Doing so will cause an infinite loop. We could abstract logic to avoid
 		// having to disable the check later.

--- a/packages/edit-site/src/components/layout/index.js
+++ b/packages/edit-site/src/components/layout/index.js
@@ -46,6 +46,7 @@ import { unlock } from '../../lock-unlock';
 import SavePanel from '../save-panel';
 import KeyboardShortcutsRegister from '../keyboard-shortcuts/register';
 import KeyboardShortcutsGlobal from '../keyboard-shortcuts/global';
+import { useCommonCommands } from '../../hooks/commands/use-common-commands';
 import { useEditModeCommands } from '../../hooks/commands/use-edit-mode-commands';
 import PageMain from '../page-main';
 import { useIsSiteEditorLoading } from './hooks';
@@ -62,6 +63,7 @@ export default function Layout() {
 	useSyncCanvasModeWithURL();
 	useCommands();
 	useEditModeCommands();
+	useCommonCommands();
 
 	const hubRef = useRef();
 	const { params } = useLocation();

--- a/packages/edit-site/src/hooks/commands/use-common-commands.js
+++ b/packages/edit-site/src/hooks/commands/use-common-commands.js
@@ -1,0 +1,91 @@
+/**
+ * WordPress dependencies
+ */
+import { useMemo } from '@wordpress/element';
+import { useDispatch } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
+import { trash, backup, help } from '@wordpress/icons';
+import { useCommandLoader, useCommand } from '@wordpress/commands';
+import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
+import { privateApis as routerPrivateApis } from '@wordpress/router';
+import { store as preferencesStore } from '@wordpress/preferences';
+
+/**
+ * Internal dependencies
+ */
+import { unlock } from '../../lock-unlock';
+import { store as editSiteStore } from '../../store';
+
+const { useGlobalStylesReset } = unlock( blockEditorPrivateApis );
+const { useHistory } = unlock( routerPrivateApis );
+
+function useGlobalStylesResetCommands() {
+	const [ canReset, onReset ] = useGlobalStylesReset();
+	const commands = useMemo( () => {
+		if ( ! canReset ) {
+			return [];
+		}
+
+		return [
+			{
+				name: 'core/edit-site/reset-global-styles',
+				label: __( 'Reset styles to defaults' ),
+				icon: trash,
+				callback: () => {
+					onReset();
+				},
+			},
+		];
+	}, [ canReset, onReset ] );
+
+	return {
+		isLoading: false,
+		commands,
+	};
+}
+
+export function useCommonCommands() {
+	const { openGeneralSidebar, setEditorCanvasContainerView } = unlock(
+		useDispatch( editSiteStore )
+	);
+	const { set } = useDispatch( preferencesStore );
+	const history = useHistory();
+
+	useCommand( {
+		name: 'core/edit-site/open-global-styles-revisions',
+		label: __( 'Open styles revisions' ),
+		icon: backup,
+		callback: () => {
+			history.push( {
+				path: '/wp_global_styles',
+				canvas: 'edit',
+			} );
+			openGeneralSidebar( 'edit-site/global-styles' );
+			setEditorCanvasContainerView( 'global-styles-revisions' );
+		},
+	} );
+
+	useCommand( {
+		name: 'core/edit-site/toggle-styles-welcome-guide',
+		label: __( 'Learn about styles' ),
+		callback: () => {
+			history.push( {
+				path: '/wp_global_styles',
+				canvas: 'edit',
+			} );
+			openGeneralSidebar( 'edit-site/global-styles' );
+			set( 'core/edit-site', 'welcomeGuideStyles', true );
+			// sometimes there's a focus loss that happens after some time
+			// that closes the modal, we need to force reopening it.
+			setTimeout( () => {
+				set( 'core/edit-site', 'welcomeGuideStyles', true );
+			}, 500 );
+		},
+		icon: help,
+	} );
+
+	useCommandLoader( {
+		name: 'core/edit-site/reset-global-styles',
+		hook: useGlobalStylesResetCommands,
+	} );
+}

--- a/packages/edit-site/src/hooks/commands/use-common-commands.js
+++ b/packages/edit-site/src/hooks/commands/use-common-commands.js
@@ -4,7 +4,7 @@
 import { useMemo } from '@wordpress/element';
 import { useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
-import { trash, backup, help } from '@wordpress/icons';
+import { trash, backup, help, styles } from '@wordpress/icons';
 import { useCommandLoader, useCommand } from '@wordpress/commands';
 import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
 import { privateApis as routerPrivateApis } from '@wordpress/router';
@@ -63,6 +63,19 @@ export function useCommonCommands() {
 			openGeneralSidebar( 'edit-site/global-styles' );
 			setEditorCanvasContainerView( 'global-styles-revisions' );
 		},
+	} );
+
+	useCommand( {
+		name: 'core/edit-site/open-styles',
+		label: __( 'Open styles' ),
+		callback: () => {
+			history.push( {
+				path: '/wp_global_styles',
+				canvas: 'edit',
+			} );
+			openGeneralSidebar( 'edit-site/global-styles' );
+		},
+		icon: styles,
 	} );
 
 	useCommand( {

--- a/packages/edit-site/src/hooks/commands/use-common-commands.js
+++ b/packages/edit-site/src/hooks/commands/use-common-commands.js
@@ -31,7 +31,8 @@ function useGlobalStylesResetCommands() {
 				name: 'core/edit-site/reset-global-styles',
 				label: __( 'Reset styles to defaults' ),
 				icon: trash,
-				callback: () => {
+				callback: ( { close } ) => {
+					close();
 					onReset();
 				},
 			},
@@ -55,7 +56,8 @@ export function useCommonCommands() {
 		name: 'core/edit-site/open-global-styles-revisions',
 		label: __( 'Open styles revisions' ),
 		icon: backup,
-		callback: () => {
+		callback: ( { close } ) => {
+			close();
 			history.push( {
 				path: '/wp_global_styles',
 				canvas: 'edit',
@@ -68,7 +70,8 @@ export function useCommonCommands() {
 	useCommand( {
 		name: 'core/edit-site/open-styles',
 		label: __( 'Open styles' ),
-		callback: () => {
+		callback: ( { close } ) => {
+			close();
 			history.push( {
 				path: '/wp_global_styles',
 				canvas: 'edit',
@@ -81,7 +84,8 @@ export function useCommonCommands() {
 	useCommand( {
 		name: 'core/edit-site/toggle-styles-welcome-guide',
 		label: __( 'Learn about styles' ),
-		callback: () => {
+		callback: ( { close } ) => {
+			close();
 			history.push( {
 				path: '/wp_global_styles',
 				canvas: 'edit',


### PR DESCRIPTION
Related #51502 

## What?

This PR adds three "styles" related commands to the command center in the site editor based on the list from #51502 

 - Reset global styles to defaults
 - Open global styles revisions panel
 - Learn about styles
 - Open styles

All of these commands are only available in the site editor because the actions to trigger them are not tied to the URL and are edit-site specific. At the moment we can't implement these commands in a global way yet.

## Testing Instructions

1- Open the site editor
2- Try the three commands above.