### PR TITLE
Fix template display in page details with a custom template

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen-page/page-details.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-page/page-details.js
@@ -11,11 +11,7 @@ import {
 import { count as wordCount } from '@wordpress/wordcount';
 import { useSelect } from '@wordpress/data';
 import { decodeEntities } from '@wordpress/html-entities';
-import {
-	store as coreStore,
-	useEntityRecord,
-	useEntityRecords,
-} from '@wordpress/core-data';
+import { store as coreStore, useEntityRecord } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
@@ -99,16 +95,15 @@ function getPageDetails( page ) {
 
 export default function PageDetails( { id } ) {
 	const { record } = useEntityRecord( 'postType', 'page', id );
-	const { records: templates } = useEntityRecords(
-		'postType',
-		'wp_template',
-		{ per_page: -1 }
-	);
 	const { parentTitle, templateTitle } = useSelect(
 		( select ) => {
 			const { getEditedPostContext } = unlock( select( editSiteStore ) );
 			const postContext = getEditedPostContext();
-
+			const templates = select( coreStore ).getEntityRecords(
+				'postType',
+				'wp_template',
+				{ per_page: -1 }
+			);
 			// Template title.
 			const templateSlug =
 				// Checks that the post type matches the current theme's post type, otherwise
@@ -118,7 +113,7 @@ export default function PageDetails( { id } ) {
 					: null;
 			const _templateTitle =
 				templates && templateSlug
-					? templates?.find(
+					? templates.find(
 							( template ) => template.slug === templateSlug
 					  )?.title?.rendered
 					: null;
@@ -140,7 +135,7 @@ export default function PageDetails( { id } ) {
 				templateTitle: _templateTitle,
 			};
 		},
-		[ record, templates ]
+		[ record?.parent ]
 	);
 	return (
 		<VStack spacing={ 5 }>

--- a/packages/edit-site/src/components/sidebar-navigation-screen-page/page-details.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-page/page-details.js
@@ -11,7 +11,11 @@ import {
 import { count as wordCount } from '@wordpress/wordcount';
 import { useSelect } from '@wordpress/data';
 import { decodeEntities } from '@wordpress/html-entities';
-import { store as coreStore, useEntityRecord } from '@wordpress/core-data';
+import {
+	store as coreStore,
+	useEntityRecord,
+	useEntityRecords,
+} from '@wordpress/core-data';
 
 /**
  * Internal dependencies
@@ -95,13 +99,14 @@ function getPageDetails( page ) {
 
 export default function PageDetails( { id } ) {
 	const { record } = useEntityRecord( 'postType', 'page', id );
-
+	const { records: templates } = useEntityRecords(
+		'postType',
+		'wp_template',
+		{ per_page: -1 }
+	);
 	const { parentTitle, templateTitle } = useSelect(
 		( select ) => {
-			const { getEditedPostContext, getSettings } = unlock(
-				select( editSiteStore )
-			);
-			const defaultTemplateTypes = getSettings()?.defaultTemplateTypes;
+			const { getEditedPostContext } = unlock( select( editSiteStore ) );
 			const postContext = getEditedPostContext();
 
 			// Template title.
@@ -112,10 +117,10 @@ export default function PageDetails( { id } ) {
 					? postContext?.templateSlug
 					: null;
 			const _templateTitle =
-				defaultTemplateTypes && templateSlug
-					? defaultTemplateTypes.find(
+				templates && templateSlug
+					? templates?.find(
 							( template ) => template.slug === templateSlug
-					  )?.title
+					  )?.title?.rendered
 					: null;
 
 			// Parent page title.
@@ -135,7 +140,7 @@ export default function PageDetails( { id } ) {
 				templateTitle: _templateTitle,
 			};
 		},
-		[ record ]
+		[ record, templates ]
 	);
 	return (
 		<VStack spacing={ 5 }>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This PR fixes the template display in page details with a custom template. Currently if a page has a custom template assigned, its title is not shown in page details panel in site editor. This was because we were searching the default templates only and not all the available ones.

This was mentioned in a different PR by @jameskoster [here](https://github.com/WordPress/gutenberg/pull/51477#issuecomment-1594665976).



## Testing Instructions
1. assign a custom template to a page
2. in site editor navigate to the page(`pages->some page`) and observe that now the `template row` is displayed in the page details panel.


## Screenshots or screencast <!-- if applicable -->
<img width="322" alt="Screenshot 2023-06-19 at 11 10 53 AM" src="https://github.com/WordPress/gutenberg/assets/16275880/aae2c56a-1291-4f02-84d2-0915783d06c3">
