### PR TITLE
Page Details View: Show parent only if there is one

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen-page/page-details.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-page/page-details.js
@@ -54,7 +54,7 @@ function getPageDetails( page ) {
 	if ( page?.parentTitle ) {
 		details.push( {
 			label: __( 'Parent' ),
-			value: decodeEntities( page?.parentTitle || __( '(no title)' ) ),
+			value: decodeEntities( page.parentTitle || __( '(no title)' ) ),
 		} );
 	}
 

--- a/packages/edit-site/src/components/sidebar-navigation-screen-page/page-details.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-page/page-details.js
@@ -51,14 +51,12 @@ function getPageDetails( page ) {
 		} );
 	}
 
-	details.push( {
-		label: __( 'Parent' ),
-		// `null` indicates no parent.
-		value:
-			null === page?.parentTitle
-				? __( 'Top level' )
-				: decodeEntities( page?.parentTitle || __( '(no title)' ) ),
-	} );
+	if ( page?.parentTitle ) {
+		details.push( {
+			label: __( 'Parent' ),
+			value: decodeEntities( page?.parentTitle || __( '(no title)' ) ),
+		} );
+	}
 
 	/*
 	 * translators: If your word count is based on single characters (e.g. East Asian characters),


### PR DESCRIPTION
## What?
<!-- In a few words, what is the PR actually doing? -->

Show the parent page in the page details view, only if there is one.

Fixes https://github.com/WordPress/gutenberg/issues/51509

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
As reported in https://github.com/WordPress/gutenberg/issues/51509, having the parent details (set to top-level) when the page doesn't have a parent can be confusing.

## Testing Instructions

1. Create two pages, one without a parent and one with one.
2. Go to Appearance > Editor > Pages
3. Click on the page that has a parent, and confirm that the information is being displayed.
4. Go back, click on the page without a parent, and confirm that the "Parent" information is no longer there.

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/252415/11a79682-6fc4-4449-9904-7a1e805941b5



