### PR TITLE
Page Details View: Show featured image only if there is one

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen-page/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-page/index.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import classnames from 'classnames';
-
-/**
  * WordPress dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
@@ -104,30 +99,20 @@ export default function SidebarNavigationScreenPage() {
 			}
 			content={
 				<>
-					<VStack
-						className="edit-site-sidebar-navigation-screen-page__featured-image-wrapper"
-						alignment="left"
-						spacing={ 2 }
-					>
-						<div
-							className={ classnames(
-								'edit-site-sidebar-navigation-screen-page__featured-image',
-								{
-									'has-image': !! featuredMediaSourceUrl,
-								}
-							) }
+					{ !! featuredMediaSourceUrl && (
+						<VStack
+							className="edit-site-sidebar-navigation-screen-page__featured-image-wrapper"
+							alignment="left"
+							spacing={ 2 }
 						>
-							{ !! featuredMediaSourceUrl && (
+							<div className="edit-site-sidebar-navigation-screen-page__featured-image has-image">
 								<img
 									alt={ featureImageAltText }
 									src={ featuredMediaSourceUrl }
 								/>
-							) }
-							{ ! record?.featured_media && (
-								<p>{ __( 'No featured image' ) }</p>
-							) }
-						</div>
-					</VStack>
+							</div>
+						</VStack>
+					) }
 					{ !! record?.excerpt?.rendered && (
 						<Truncate
 							className="edit-site-sidebar-navigation-screen-page__excerpt"


### PR DESCRIPTION
## What?
<!-- In a few words, what is the PR actually doing? -->

Show the feature image in the page details view, only if one is assigned to the page.

Fixes https://github.com/WordPress/gutenberg/issues/51508

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
As reported in https://github.com/WordPress/gutenberg/issues/51508, as the Page Details view is currently not editable, the proposal is to only render the featured image if one is present.


## Testing Instructions

1. Create two pages, one without a featured image and one with one.
2. Go to Appearance > Editor > Pages
3. Click on the page that has a featured image, and confirm that the image is displayed.
4. Go back, click on the page without a featured image, and confirm that the "no featured image" indicator is no longer there.

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/252415/2172b73c-a88c-4bb9-894f-8d8d5213c71e


