### PR TITLE
[Mobile] - Fix crash when switching to the HTML Editor

### DIFF
--- a/packages/edit-post/src/test/editor.native.js
+++ b/packages/edit-post/src/test/editor.native.js
@@ -1,17 +1,24 @@
 /**
  * External dependencies
  */
-import { act, render } from 'test/helpers';
+import {
+	act,
+	addBlock,
+	fireEvent,
+	getBlock,
+	initializeEditor,
+	render,
+	setupCoreBlocks,
+} from 'test/helpers';
 
 /**
  * WordPress dependencies
  */
-import { registerCoreBlocks } from '@wordpress/block-library';
-import RNReactNativeGutenbergBridge from '@wordpress/react-native-bridge';
+import RNReactNativeGutenbergBridge, {
+	subscribeParentToggleHTMLMode,
+} from '@wordpress/react-native-bridge';
 // Force register 'core/editor' store.
 import { store } from '@wordpress/editor'; // eslint-disable-line no-unused-vars
-
-jest.mock( '../components/layout', () => () => 'Layout' );
 
 /**
  * Internal dependencies
@@ -34,11 +41,9 @@ afterAll( () => {
 	jest.useRealTimers();
 } );
 
-describe( 'Editor', () => {
-	beforeAll( () => {
-		registerCoreBlocks();
-	} );
+setupCoreBlocks();
 
+describe( 'Editor', () => {
 	it( 'detects unsupported block and sends hasUnsupportedBlocks true to native', () => {
 		RNReactNativeGutenbergBridge.editorDidMount = jest.fn();
 
@@ -55,6 +60,26 @@ describe( 'Editor', () => {
 		expect(
 			RNReactNativeGutenbergBridge.editorDidMount
 		).toHaveBeenCalledWith( [ 'core/notablock' ] );
+	} );
+
+	it( 'toggles the editor from Visual to HTML mode', async () => {
+		// Arrange
+		let toggleMode;
+		subscribeParentToggleHTMLMode.mockImplementation( ( callback ) => {
+			toggleMode = callback;
+		} );
+		const screen = await initializeEditor();
+		await addBlock( screen, 'Paragraph' );
+
+		// Act
+		const paragraphBlock = getBlock( screen, 'Paragraph' );
+		fireEvent.press( paragraphBlock );
+
+		toggleMode();
+
+		// Assert
+		const htmlEditor = await screen.findByLabelText( 'html-view-content' );
+		expect( htmlEditor ).toBeDefined();
 	} );
 } );
 

--- a/packages/edit-post/src/test/editor.native.js
+++ b/packages/edit-post/src/test/editor.native.js
@@ -79,7 +79,7 @@ describe( 'Editor', () => {
 
 		// Assert
 		const htmlEditor = await screen.findByLabelText( 'html-view-content' );
-		expect( htmlEditor ).toBeDefined();
+		expect( htmlEditor ).toBeVisible();
 	} );
 } );
 

--- a/packages/editor/src/components/provider/index.native.js
+++ b/packages/editor/src/components/provider/index.native.js
@@ -319,8 +319,6 @@ class NativeEditorProvider extends Component {
 		const { mode, switchMode } = this.props;
 		// Refresh html content first.
 		this.serializeToNativeAction();
-		// Make sure to blur the selected block and dismiss the keyboard.
-		this.props.clearSelectedBlock();
 		switchMode( mode === 'visual' ? 'text' : 'visual' );
 	}
 
@@ -387,12 +385,8 @@ const ComposedNativeProvider = compose( [
 	withDispatch( ( dispatch ) => {
 		const { editPost, resetEditorBlocks, updateEditorSettings } =
 			dispatch( editorStore );
-		const {
-			updateSettings,
-			clearSelectedBlock,
-			insertBlock,
-			replaceBlock,
-		} = dispatch( blockEditorStore );
+		const { updateSettings, insertBlock, replaceBlock } =
+			dispatch( blockEditorStore );
 		const { switchEditorMode } = dispatch( editPostStore );
 		const { addEntities, receiveEntityRecords } = dispatch( coreStore );
 		const { createSuccessNotice } = dispatch( noticesStore );
@@ -401,7 +395,6 @@ const ComposedNativeProvider = compose( [
 			updateBlockEditorSettings: updateSettings,
 			updateEditorSettings,
 			addEntities,
-			clearSelectedBlock,
 			insertBlock,
 			createSuccessNotice,
 			editTitle( title ) {


### PR DESCRIPTION
**Related PRS:**
- https://github.com/wordpress-mobile/gutenberg-mobile/pull/5879

## What?
This PR fixes a regression after https://github.com/WordPress/gutenberg/pull/51051 was merged.

## Why?
Within `toggleMode` we were calling `clearSelectedBlock` but this is already being called within [switchEditorMode](https://github.com/WordPress/gutenberg/blob/ce4dd6167517ed52de1a120ee4015942a7f73513/packages/edit-post/src/store/actions.js#L206).

It appears that now that we have stable references from https://github.com/WordPress/gutenberg/pull/51051 it surfaced this issue when it tries to clear a block when it was already cleared.

## How?
By removing the extra `clearSelectedBlock`. It also introduces an integration test to make sure we test the HTML editor opens.

## Testing Instructions
- Open the app
- Tap on the "Start writing" placeholder
- Switch to the HTML editor
- **Expect** the HTML editor to load correctly

CI checks should pass in this PR and in the Gutenberg mobile PR.

### Testing Instructions for Keyboard
N/A

## Screenshots or screencast <!-- if applicable -->
Before | After
-|-
<video src='https://github.com/WordPress/gutenberg/assets/4885740/a63ada94-2eca-4854-9dae-db875f1f9a1f' width=180/> | <video src='https://github.com/WordPress/gutenberg/assets/4885740/00ef251e-69ec-4afd-b245-365ec5da60ad' width=180/>