### PR TITLE
Update Library panel footer

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-item/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-item/style.scss
@@ -4,6 +4,7 @@
 	padding: $grid-unit-10 6px $grid-unit-10 $grid-unit-20;
 	border: none;
 	min-height: $grid-unit-50;
+	border-radius: $radius-block-ui;
 
 	&:hover,
 	&:focus,
@@ -22,6 +23,8 @@
 
 	&:is(a) {
 		text-decoration: none;
+		display: flex;
+		align-items: center;
 
 		&:focus {
 			box-shadow: none;

--- a/packages/edit-site/src/components/sidebar-navigation-screen-templates/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-templates/index.js
@@ -161,7 +161,6 @@ export default function SidebarNavigationScreenTemplates() {
 							<SidebarNavigationItem
 								as="a"
 								href="edit.php?post_type=wp_block"
-								withChevron
 							>
 								{ config[ postType ].labels.reusableBlocks }
 							</SidebarNavigationItem>

--- a/packages/edit-site/src/components/sidebar-navigation-screen-templates/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-templates/index.js
@@ -40,7 +40,7 @@ const config = {
 			title: __( 'Library' ),
 			loading: __( 'Loading library' ),
 			notFound: __( 'No patterns found' ),
-			manage: __( 'Manage template parts' ),
+			manage: __( 'Manage all template parts' ),
 			reusableBlocks: __( 'Manage reusable blocks' ),
 			description: __(
 				'Template Parts are small pieces of a layout that can be reused across multiple templates and always appear the same way. Common template parts include the site header, footer, or sidebar.'

--- a/packages/edit-site/src/components/sidebar-navigation-screen-templates/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-templates/index.js
@@ -40,7 +40,7 @@ const config = {
 			title: __( 'Library' ),
 			loading: __( 'Loading library' ),
 			notFound: __( 'No patterns found' ),
-			manage: __( 'Manage all template parts' ),
+			manage: __( 'Manage template parts' ),
 			reusableBlocks: __( 'Manage reusable blocks' ),
 			description: __(
 				'Template Parts are small pieces of a layout that can be reused across multiple templates and always appear the same way. Common template parts include the site header, footer, or sidebar.'


### PR DESCRIPTION
## What?
Updates a few details in the Library panel footer:

1. Removes chevron icon on the Reusable Blocks button.
2. Adds radius to footer buttons.
3. Removes 'all' in 'Manage all template parts'.

## Why?
1. The Reusable Blocks button is not a drilldown, so the chevron icon is misleading.
2. Consistency with other menu items in the sidebar.
3. Consistency with other 'manage' links in the sidebar.

## Testing Instructions
1. Open the Library panel in the site editor
2. Observe the changes noted above

| Before | After |
| --- | --- |
| <img width="359" alt="Screenshot 2023-06-19 at 13 53 24" src="https://github.com/WordPress/gutenberg/assets/846565/e3f25ef2-f5c0-4e16-b912-9b834373a87a"> |<img width="360" alt="Screenshot 2023-06-19 at 13 58 03" src="https://github.com/WordPress/gutenberg/assets/846565/04b1a621-1338-45ab-a443-ff04793e38b0"> |

