### PR TITLE
Playwright Utils: Change preference update method in setIsFixedToolbar

### DIFF
--- a/packages/e2e-test-utils-playwright/src/editor/set-is-fixed-toolbar.ts
+++ b/packages/e2e-test-utils-playwright/src/editor/set-is-fixed-toolbar.ts
@@ -11,11 +11,8 @@ import type { Editor } from './index';
  */
 export async function setIsFixedToolbar( this: Editor, isFixed: boolean ) {
 	await this.page.evaluate( ( _isFixed ) => {
-		const { select, dispatch } = window.wp.data;
-		const isCurrentlyFixed =
-			select( 'core/edit-post' ).isFeatureActive( 'fixedToolbar' );
-		if ( isCurrentlyFixed !== _isFixed ) {
-			dispatch( 'core/edit-post' ).toggleFeature( 'fixedToolbar' );
-		}
+		window.wp.data
+			.dispatch( 'core/preferences' )
+			.set( 'core/edit-post', 'fixedToolbar', _isFixed );
 	}, isFixed );
 }


### PR DESCRIPTION
## What?
This is similar to #51560.

I noticed that the #49733 test still needs to be fixed. PR updates the `setIsFixedToolbar` utility method to directly use the core/preferences store to set editor preferences.

## Why?
Removes extra checks and sets preference value needed for tests. Also, I'm out of ideas why preferences might be leaking.

## Testing Instructions
CI checks should pass.
