### PR TITLE
[Mobile] Update mobile block editor settings endpoint

### DIFF
--- a/lib/experimental/block-editor-settings-mobile.php
+++ b/lib/experimental/block-editor-settings-mobile.php
@@ -23,7 +23,12 @@ function gutenberg_get_block_editor_settings_mobile( $settings ) {
 		'mobile' === $_GET['context']
 	) {
 		if ( wp_theme_has_theme_json() ) {
-			$settings['__experimentalStyles'] = gutenberg_get_global_styles();
+			$context = array(
+				'transforms' => array(
+					'resolve-variables',
+				),
+			);
+			$settings['__experimentalStyles'] = gutenberg_get_global_styles(array(), $context);
 		}
 
 		// To tell mobile that the site uses quote v2 (inner blocks).

--- a/packages/components/src/mobile/global-styles-context/utils.native.js
+++ b/packages/components/src/mobile/global-styles-context/utils.native.js
@@ -394,7 +394,16 @@ export function getColorsAndGradients(
 	};
 }
 
-export function getGlobalStyles( rawStyles, rawFeatures ) {
+/**
+ * @deprecated See getGlobalStyles implementation.
+ *
+ * Retrieves global styles data.
+ *
+ * @param {string|undefined} rawStyles   The raw styles to parse.
+ * @param {string|undefined} rawFeatures The raw features to parse.
+ * @return {Object} The global styles data.
+ */
+export function deprecatedGetGlobalStylesData( rawStyles, rawFeatures ) {
 	const features = rawFeatures ? JSON.parse( rawFeatures ) : {};
 	const mappedValues = getMappedValues( features, features?.color?.palette );
 	const colors = parseStylesVariables(
@@ -435,4 +444,59 @@ export function getGlobalStyles( rawStyles, rawFeatures ) {
 		},
 		__experimentalGlobalStylesBaseStyles: globalStyles,
 	};
+}
+
+/**
+ *
+ * Retrieves global styles data.
+ *
+ * @param {string|undefined} rawStyles   The raw styles to parse.
+ * @param {string|undefined} rawFeatures The raw features to parse.
+ * @return {Object} The global styles data.
+ */
+export function getGlobalStylesData( rawStyles, rawFeatures ) {
+	const features = rawFeatures ? JSON.parse( rawFeatures ) : {};
+	const globalStyles = rawStyles ? JSON.parse( rawStyles ) : {};
+	const fontSizes = normalizeFontSizes( features?.typography?.fontSizes );
+
+	return {
+		__experimentalFeatures: {
+			color: {
+				palette: features?.color?.palette,
+				gradients: features?.color?.gradients,
+				text: features?.color?.text ?? true,
+				background: features?.color?.background ?? true,
+				defaultPalette: features?.color?.defaultPalette ?? true,
+				defaultGradients: features?.color?.defaultGradients ?? true,
+			},
+			typography: {
+				fontSizes,
+				customLineHeight: features?.custom?.[ 'line-height' ],
+			},
+			spacing: features?.spacing,
+		},
+		__experimentalGlobalStylesBaseStyles: globalStyles,
+	};
+}
+
+/**
+ *
+ * Retrieves global styles theme configuration.
+ *
+ * @param {string|undefined} rawStyles   The raw styles to parse.
+ * @param {string|undefined} rawFeatures The raw features to parse.
+ * @return {Object} The global styles data.
+ */
+export function getGlobalStyles( rawStyles, rawFeatures ) {
+	const styles = rawStyles ? JSON.parse( rawStyles ) : {};
+
+	// Check if the current Global styles data is already parsed,
+	// e.g it doesn't have a variable name as background.
+	if ( ! styles?.color?.background?.includes( 'var(--' ) ) {
+		return getGlobalStylesData( rawStyles, rawFeatures );
+	}
+
+	// We need to keep the old approach parsing the theme json data for users who
+	// haven't updated their Gutenberg plugin version to >= 16.2
+	return deprecatedGetGlobalStylesData( rawStyles, rawFeatures );
 }


### PR DESCRIPTION
**In progress**

## What?
With the newly added features in https://github.com/WordPress/gutenberg/pull/50484 we can now pass the global styles data directly without manually parsing its values.

## Why?
To avoid adding extra load to the mobile editor by parsing the theme json configuration manually.

## How?
First, it adds a deprecation function to keep the existing behavior as we will have to keep the old support for a while until this change is shipped in a Gutenberg plugin version and probably up until a few months after WordPress 6.3 is released (mid August 2023). Since the changes in https://github.com/WordPress/gutenberg/pull/50484 will ship in that version.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
