### PR TITLE
Fluid typography: add missing changelog from #51516

### DIFF
--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fix
+
+-   Fluid typography: custom font-sizes should use max viewport width ([#51516](https://github.com/WordPress/gutenberg/pull/51516)).
+
 ## 12.3.0 (2023-06-07)
 
 ## 12.2.0 (2023-05-24)


### PR DESCRIPTION
## What?

Changelog entry for https://github.com/WordPress/gutenberg/pull/51516

## Why?
There was a recent bugfix for fluid typography:

- https://github.com/WordPress/gutenberg/pull/51516

I didn't update the changelog 😭 

## How?
I updated the changelog.
