### PR TITLE
Site editor sidebar: add footer to template part and ensure nested template areas display

### DIFF
--- a/packages/edit-site/CHANGELOG.md
+++ b/packages/edit-site/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Enhancements
 -   Site editor sidebar: add home template details and controls [#51223](https://github.com/WordPress/gutenberg/pull/51223).
+-   Site editor sidebar: add footer to template part and ensure nested template areas display [#51669](https://github.com/WordPress/gutenberg/pull/51669).
 
 ## 5.12.0 (2023-06-07)
 

--- a/packages/edit-site/src/components/sidebar-navigation-screen-details-footer/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-details-footer/index.js
@@ -18,22 +18,28 @@ export default function SidebarNavigationScreenDetailsFooter( {
 	lastModifiedDateTime,
 } ) {
 	return (
-		<SidebarNavigationScreenDetailsPanelRow className="edit-site-sidebar-navigation-screen-details-footer">
-			<SidebarNavigationScreenDetailsPanelLabel>
-				{ __( 'Last modified' ) }
-			</SidebarNavigationScreenDetailsPanelLabel>
-			<SidebarNavigationScreenDetailsPanelValue>
-				{ createInterpolateElement(
-					sprintf(
-						/* translators: %s: is the relative time when the post was last modified. */
-						__( '<time>%s</time>' ),
-						humanTimeDiff( lastModifiedDateTime )
-					),
-					{
-						time: <time dateTime={ lastModifiedDateTime } />,
-					}
-				) }
-			</SidebarNavigationScreenDetailsPanelValue>
-		</SidebarNavigationScreenDetailsPanelRow>
+		<>
+			{ lastModifiedDateTime && (
+				<SidebarNavigationScreenDetailsPanelRow className="edit-site-sidebar-navigation-screen-details-footer">
+					<SidebarNavigationScreenDetailsPanelLabel>
+						{ __( 'Last modified' ) }
+					</SidebarNavigationScreenDetailsPanelLabel>
+					<SidebarNavigationScreenDetailsPanelValue>
+						{ createInterpolateElement(
+							sprintf(
+								/* translators: %s: is the relative time when the post was last modified. */
+								__( '<time>%s</time>' ),
+								humanTimeDiff( lastModifiedDateTime )
+							),
+							{
+								time: (
+									<time dateTime={ lastModifiedDateTime } />
+								),
+							}
+						) }
+					</SidebarNavigationScreenDetailsPanelValue>
+				</SidebarNavigationScreenDetailsPanelRow>
+			) }
+		</>
 	);
 }

--- a/packages/edit-site/src/components/sidebar-navigation-screen-page/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-page/index.js
@@ -121,11 +121,9 @@ export default function SidebarNavigationScreenPage() {
 				</>
 			}
 			footer={
-				!! record?.modified && (
-					<SidebarNavigationScreenDetailsFooter
-						lastModifiedDateTime={ record.modified }
-					/>
-				)
+				<SidebarNavigationScreenDetailsFooter
+					lastModifiedDateTime={ record?.modified }
+				/>
 			}
 		/>
 	) : null;

--- a/packages/edit-site/src/components/sidebar-navigation-screen-page/page-details.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-page/page-details.js
@@ -139,7 +139,10 @@ export default function PageDetails( { id } ) {
 		[ record?.parent ]
 	);
 	return (
-		<SidebarNavigationScreenDetailsPanel title={ __( 'Details' ) }>
+		<SidebarNavigationScreenDetailsPanel
+			spacing={ 5 }
+			title={ __( 'Details' ) }
+		>
 			{ getPageDetails( {
 				parentTitle,
 				templateTitle,

--- a/packages/edit-site/src/components/sidebar-navigation-screen-template-part/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-template-part/index.js
@@ -19,10 +19,10 @@ import { unlock } from '../../lock-unlock';
 import { store as editSiteStore } from '../../store';
 import SidebarButton from '../sidebar-button';
 import { useAddedBy } from '../list/added-by';
-
+import SidebarNavigationScreenDetailsFooter from '../sidebar-navigation-screen-details-footer';
 import TemplatePartNavigationMenus from './template-part-navigation-menus';
 
-function useTemplateTitleAndDescription( postType, postId ) {
+function useTemplateDetails( postType, postId ) {
 	const { getDescription, getTitle, record } = useEditedEntityRecord(
 		postType,
 		postId
@@ -78,7 +78,13 @@ function useTemplateTitleAndDescription( postType, postId ) {
 		</>
 	);
 
-	return { title, description };
+	const footer = !! record?.modified ? (
+		<SidebarNavigationScreenDetailsFooter
+			lastModifiedDateTime={ record.modified }
+		/>
+	) : null;
+
+	return { title, description, footer };
 }
 
 export default function SidebarNavigationScreenTemplatePart() {
@@ -88,7 +94,7 @@ export default function SidebarNavigationScreenTemplatePart() {
 
 	const { record } = useEditedEntityRecord( postType, postId );
 
-	const { title, description } = useTemplateTitleAndDescription(
+	const { title, description, footer } = useTemplateDetails(
 		postType,
 		postId
 	);
@@ -118,6 +124,7 @@ export default function SidebarNavigationScreenTemplatePart() {
 			content={
 				<TemplatePartNavigationMenus menus={ navigationMenuIds } />
 			}
+			footer={ footer }
 		/>
 	);
 }

--- a/packages/edit-site/src/components/sidebar-navigation-screen-template/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-template/index.js
@@ -43,19 +43,16 @@ function useTemplateDetails( postType, postId ) {
 		);
 	}
 
-	let content = null;
-	if ( record?.slug === 'home' || record?.slug === 'index' ) {
-		content = <HomeTemplateDetails />;
-	}
+	const content =
+		record?.slug === 'home' || record?.slug === 'index' ? (
+			<HomeTemplateDetails />
+		) : null;
 
-	let footer = null;
-	if ( !! record?.modified ) {
-		footer = (
-			<SidebarNavigationScreenDetailsFooter
-				lastModifiedDateTime={ record.modified }
-			/>
-		);
-	}
+	const footer = !! record?.modified ? (
+		<SidebarNavigationScreenDetailsFooter
+			lastModifiedDateTime={ record.modified }
+		/>
+	) : null;
 
 	const description = (
 		<>


### PR DESCRIPTION

## What?
This commit is a follow up to:

- https://github.com/WordPress/gutenberg/pull/51223

1. performs `lastModifiedDateTime` check in the generic footer
2. adds a last modified footer to template parts
3. ensures we know which default template part areas a template is using, even if those template areas are nested

Kudos to @andrewserong for raising most of the points that this PR addresses.

## Why?
1. `SidebarNavigationScreenDetailsFooter` is a generic component and therefore should handle internally whether is constituent parts are rendered 
2. To make things consistent with template and page views
3. Because we didn't identify template areas in the home page template view that where nested, e.g., in a container block



## Testing Instructions
1. Check that the last modified footer element appears correctly on modified templates, pages or template parts
2. Same as 1
3. On the home page template view in the edit side sidebar, ensure that we display all used default theme template parts, e.g., in 2023 we have footer, comment areas, post meta or header. Even if those template parts are nested in a Group block or other container block.

## Screenshots or screencast <!-- if applicable -->

### See last updated footer in templates and template parts

<img width="357" alt="Screenshot 2023-06-20 at 11 38 34 am" src="https://github.com/WordPress/gutenberg/assets/6458278/524b42cb-78e4-46a1-a700-06a850cd4e07">

### See the template's template areas
<img width="352" alt="Screenshot 2023-06-20 at 12 02 11 pm" src="https://github.com/WordPress/gutenberg/assets/6458278/6c940a96-9218-41c0-a537-15bb66829b04">




