### PR TITLE
Require relocated class files for back-compat in WordPress releases.

### DIFF
--- a/packages/block-serialization-default-parser/class-wp-block-parser.php
+++ b/packages/block-serialization-default-parser/class-wp-block-parser.php
@@ -397,3 +397,17 @@ class WP_Block_Parser {
 		$this->output[] = (array) $stack_top->block;
 	}
 }
+
+/**
+ * WP_Block_Parser_Block class.
+ *
+ * Required for backward compatibility in WordPress Core.
+ */
+require_once __DIR__ . '/class-wp-block-parser-block.php';
+
+/**
+ * WP_Block_Parser_Frame class.
+ *
+ * Required for backward compatibility in WordPress Core.
+ */
+require_once __DIR__ . '/class-wp-block-parser-frame.php';


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This PR adds `require_once` calls for relocated classes in `packages/block-serialization-default-parser/class-wp-block-parser.php`.

This is required to maintain backward compatibly once the package is updated in WordPress-Develop and subsequently included in a WordPress Core release.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

In #48693 the block parser classes were split in to their own files per the WordPress Coding Standards.

In the package the three class files were renamed and back-compatibility maintained by retaining `parser.php` for developers requiring the files directory.

However, once the package is updated in WordPress-Develop, the copied file will be `packages/block-serialization-default-parser/class-wp-block-parser.php` to replace the file of the same name in WP-Dev's `wp-includes` folder, `packages/block-serialization-default-parser/parser.php` won't be included in a WordPress release.

To maintain backward compatibility for developers requiring the file directly in WordPress-Develop/releases, the relocated classes need to be required from their original location.

See [`src/wp-includes/class-wp-customize-control.php` in WordPress-Develop ](https://github.com/WordPress/wordpress-develop/blob/6d7430cfe1f8853b75787e03effe8f16f9242ad8/src/wp-includes/class-wp-customize-control.php#L704-L808) for an example of how back-compat has been historically maintained.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Requires classes within files as needed.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
