### PR TITLE
Block Editor: Fix blocks autocompleter 'rootClientId' selector

### DIFF
--- a/packages/block-editor/src/autocompleters/block.js
+++ b/packages/block-editor/src/autocompleters/block.js
@@ -40,11 +40,13 @@ function createBlockCompleter() {
 					const {
 						getSelectedBlockClientId,
 						getBlockName,
-						getBlockInsertionPoint,
 						getBlockListSettings,
+						getBlockRootClientId,
 					} = select( blockEditorStore );
 					const selectedBlockClientId = getSelectedBlockClientId();
-					const _rootClientId = getBlockInsertionPoint().rootClientId;
+					const _rootClientId = getBlockRootClientId(
+						selectedBlockClientId
+					);
 					return {
 						selectedBlockName: selectedBlockClientId
 							? getBlockName( selectedBlockClientId )


### PR DESCRIPTION
## What?
Fixes #51615.

PR updates block autocompoleter to use `getBlockRootClientId` instead of `getBlockInsertionPoint` for getting the `rootClientId`. Fixes a bug with an incorrect blocks list when in-between inserter was displayed for a different block.

## Why?
Using `rootClientId` from `getBlockInsertionPoint` can result in a wrong value.

## Testing Instructions
1. Open a Post or Page.
2. Insert a Buttons block and add a few buttons.
3. Insert a Paragraph before or after the block.
4. Type slash (`/`) to open the autocompleter.
5. Hover between buttons to display in-between inserter.
6. Confirm that the autocompleter block list doesn't change.


### Example buttons
```
<!-- wp:buttons {"layout":{"type":"flex","justifyContent":"space-between","orientation":"horizontal"}} -->
<div class="wp-block-buttons"><!-- wp:button -->
<div class="wp-block-button"><a class="wp-block-button__link wp-element-button">First Button</a></div>
<!-- /wp:button -->

<!-- wp:button -->
<div class="wp-block-button"><a class="wp-block-button__link wp-element-button">Last Button</a></div>
<!-- /wp:button --></div>
<!-- /wp:buttons -->
```

## Screenshots or screencast <!-- if applicable -->

**Before**

https://github.com/WordPress/gutenberg/assets/240569/9aa47965-90e3-4133-8cc0-339cdac58402

**After**

https://github.com/WordPress/gutenberg/assets/240569/534afdc6-81a8-496a-8574-0c28e1401304

