### PR TITLE
useInBetweenInserter: Remove unused selectors

### DIFF
--- a/packages/block-editor/src/components/block-list/use-in-between-inserter.js
+++ b/packages/block-editor/src/components/block-list/use-in-between-inserter.js
@@ -23,9 +23,7 @@ export function useInBetweenInserter() {
 	);
 	const {
 		getBlockListSettings,
-		getBlockRootClientId,
 		getBlockIndex,
-		isBlockInsertionPointVisible,
 		isMultiSelecting,
 		getSelectedBlockClientIds,
 		getTemplateLock,
@@ -172,9 +170,7 @@ export function useInBetweenInserter() {
 		[
 			openRef,
 			getBlockListSettings,
-			getBlockRootClientId,
 			getBlockIndex,
-			isBlockInsertionPointVisible,
 			isMultiSelecting,
 			showInsertionPoint,
 			hideInsertionPoint,


### PR DESCRIPTION
PR removes two unused selectors from the `useInBetweenInserter` hook. Noticed while working on #51673.

## Selectors

* `getBlockRootClientId` - hasn't been used since #30285.
* `isBlockInsertionPointVisible` - hasn't been used since #44702.

## Testing Instructions
* Confirm in-between inserter works as before.
* CI checks are green.
