### PR TITLE
Improve getBlockEditingMode() and useAppender() performance

### DIFF
--- a/packages/block-editor/src/components/block-list-appender/index.js
+++ b/packages/block-editor/src/components/block-list-appender/index.js
@@ -41,7 +41,7 @@ function DefaultAppender( { rootClientId } ) {
 }
 
 function useAppender( rootClientId, CustomAppender ) {
-	return useSelect(
+	const isVisible = useSelect(
 		( select ) => {
 			const {
 				getTemplateLock,
@@ -51,7 +51,7 @@ function useAppender( rootClientId, CustomAppender ) {
 			} = unlock( select( blockEditorStore ) );
 
 			if ( CustomAppender === false ) {
-				return null;
+				return false;
 			}
 
 			if ( ! CustomAppender ) {
@@ -60,7 +60,7 @@ function useAppender( rootClientId, CustomAppender ) {
 					rootClientId === selectedBlockClientId ||
 					( ! rootClientId && ! selectedBlockClientId );
 				if ( ! isParentSelected ) {
-					return null;
+					return false;
 				}
 			}
 
@@ -69,16 +69,22 @@ function useAppender( rootClientId, CustomAppender ) {
 				getBlockEditingMode( rootClientId ) === 'disabled' ||
 				__unstableGetEditorMode() === 'zoom-out'
 			) {
-				return null;
+				return false;
 			}
 
-			return CustomAppender ? (
-				<CustomAppender />
-			) : (
-				<DefaultAppender rootClientId={ rootClientId } />
-			);
+			return true;
 		},
 		[ rootClientId, CustomAppender ]
+	);
+
+	if ( ! isVisible ) {
+		return null;
+	}
+
+	return CustomAppender ? (
+		<CustomAppender />
+	) : (
+		<DefaultAppender rootClientId={ rootClientId } />
 	);
 }
 

--- a/packages/block-editor/src/components/block-list-appender/index.js
+++ b/packages/block-editor/src/components/block-list-appender/index.js
@@ -41,7 +41,7 @@ function DefaultAppender( { rootClientId } ) {
 }
 
 function useAppender( rootClientId, CustomAppender ) {
-	const { hideInserter, isParentSelected } = useSelect(
+	return useSelect(
 		( select ) => {
 			const {
 				getTemplateLock,
@@ -50,35 +50,36 @@ function useAppender( rootClientId, CustomAppender ) {
 				getBlockEditingMode,
 			} = unlock( select( blockEditorStore ) );
 
-			const selectedBlockClientId = getSelectedBlockClientId();
+			if ( CustomAppender === false ) {
+				return null;
+			}
 
-			return {
-				hideInserter:
-					!! getTemplateLock( rootClientId ) ||
-					getBlockEditingMode( rootClientId ) === 'disabled' ||
-					__unstableGetEditorMode() === 'zoom-out',
-				isParentSelected:
+			if ( ! CustomAppender ) {
+				const selectedBlockClientId = getSelectedBlockClientId();
+				const isParentSelected =
 					rootClientId === selectedBlockClientId ||
-					( ! rootClientId && ! selectedBlockClientId ),
-			};
+					( ! rootClientId && ! selectedBlockClientId );
+				if ( ! isParentSelected ) {
+					return null;
+				}
+			}
+
+			if (
+				getTemplateLock( rootClientId ) ||
+				getBlockEditingMode( rootClientId ) === 'disabled' ||
+				__unstableGetEditorMode() === 'zoom-out'
+			) {
+				return null;
+			}
+
+			return CustomAppender ? (
+				<CustomAppender />
+			) : (
+				<DefaultAppender rootClientId={ rootClientId } />
+			);
 		},
-		[ rootClientId ]
+		[ rootClientId, CustomAppender ]
 	);
-
-	if ( hideInserter || CustomAppender === false ) {
-		return null;
-	}
-
-	if ( CustomAppender ) {
-		// Prefer custom render prop if provided.
-		return <CustomAppender />;
-	}
-
-	if ( ! isParentSelected ) {
-		return null;
-	}
-
-	return <DefaultAppender rootClientId={ rootClientId } />;
 }
 
 function BlockListAppender( {

--- a/packages/block-editor/src/store/private-selectors.js
+++ b/packages/block-editor/src/store/private-selectors.js
@@ -73,41 +73,31 @@ export function getLastInsertedBlocksClientIds( state ) {
  * @return {BlockEditingMode} The block editing mode. One of `'disabled'`,
  *                            `'contentOnly'`, or `'default'`.
  */
-export const getBlockEditingMode = createSelector(
-	( state, clientId = '' ) => {
-		if ( state.blockEditingModes.has( clientId ) ) {
-			return state.blockEditingModes.get( clientId );
-		}
-		if ( ! clientId ) {
-			return 'default';
-		}
-		const rootClientId = getBlockRootClientId( state, clientId );
-		const templateLock = getTemplateLock( state, rootClientId );
-		if ( templateLock === 'contentOnly' ) {
-			const name = getBlockName( state, clientId );
-			// TODO: Terrible hack! We're calling the global select() function
-			// here instead of using createRegistrySelector(). The problem with
-			// using createRegistrySelector() is that then the public
-			// block-editor selectors (e.g. canInsertBlockTypeUnmemoized) can't
-			// call this private block-editor selector due to a bug in
-			// @wordpress/data. See
-			// https://github.com/WordPress/gutenberg/pull/50985.
-			const isContent =
-				select( blocksStore ).__experimentalHasContentRoleAttribute(
-					name
-				);
-			return isContent ? 'contentOnly' : 'disabled';
-		}
-		const parentMode = getBlockEditingMode( state, rootClientId );
-		return parentMode === 'contentOnly' ? 'default' : parentMode;
-	},
-	( state ) => [
-		state.blockEditingModes,
-		state.blocks.parents,
-		state.settings.templateLock,
-		state.blockListSettings,
-	]
-);
+export function getBlockEditingMode( state, clientId = '' ) {
+	if ( state.blockEditingModes.has( clientId ) ) {
+		return state.blockEditingModes.get( clientId );
+	}
+	if ( ! clientId ) {
+		return 'default';
+	}
+	const rootClientId = getBlockRootClientId( state, clientId );
+	const templateLock = getTemplateLock( state, rootClientId );
+	if ( templateLock === 'contentOnly' ) {
+		const name = getBlockName( state, clientId );
+		// TODO: Terrible hack! We're calling the global select() function
+		// here instead of using createRegistrySelector(). The problem with
+		// using createRegistrySelector() is that then the public
+		// block-editor selectors (e.g. canInsertBlockTypeUnmemoized) can't
+		// call this private block-editor selector due to a bug in
+		// @wordpress/data. See
+		// https://github.com/WordPress/gutenberg/pull/50985.
+		const isContent =
+			select( blocksStore ).__experimentalHasContentRoleAttribute( name );
+		return isContent ? 'contentOnly' : 'disabled';
+	}
+	const parentMode = getBlockEditingMode( state, rootClientId );
+	return parentMode === 'contentOnly' ? 'default' : parentMode;
+}
 
 /**
  * Returns true if the block with the given client ID and all of its descendants


### PR DESCRIPTION
## What?
Fixes a performance regression introduced in https://github.com/WordPress/gutenberg/pull/51148#issuecomment-1584852322.

## How?
There's two fixes / issues at play here:

- `useAppender()` will only show a default appender in a container block when the container block is selected or at the document level when there is no selection. But `getTemplateLock()`, `getBlockEditingMode()`, and `__unstableGetEditorMode()` are called regardless of whether the appender is shown or not. This is a little wasteful. We can fix this by swapping the order of the `isParentSelected` and `isInserterHidden` checks 

- `getBlockEditingMode()` is memoised using `createSelector()` from `rememo`. I did this because `getBlockEditingMode()` will recurse through the block's ancestors. This is problematic though because [`rememo` will iterate through every cached entry](https://github.com/aduth/rememo/blob/4c4a00e023c8e761d3b354dee56885eb8bf06fd1/rememo.js#L238-L264) when the selector is called which in this case is significant as there will be one cache entry per block. The fix is to not use `createSelector()`. In most cases the depth of the block tree (number of ancestors) will be less than the number of blocks.

## Testing Instructions
Nothing specific. Check that the block appender still appears when expected at the document level and in container blocks.

## Benchmark

`trunk`

```
Typing:
Average time to type character: 38.77ms
Slowest time to type character: 108.92ms
Fastest time to type character: 33.74ms
```

This branch

```
Typing:
Average time to type character: 29.92ms
Slowest time to type character: 77.7ms
Fastest time to type character: 25.65ms
```