### PR TITLE
Page details: Fix displaying slugs with non-latin characters

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen-page/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-page/index.js
@@ -90,7 +90,9 @@ export default function SidebarNavigationScreenPage() {
 					className="edit-site-sidebar-navigation-screen__page-link"
 					href={ record.link }
 				>
-					{ record.link.replace( /^(https?:\/\/)?/, '' ) }
+					{ decodeURI(
+						record.link.replace( /^(https?:\/\/)?/, '' )
+					) }
 				</ExternalLink>
 			}
 			content={

--- a/packages/edit-site/src/components/sidebar-navigation-screen-page/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-page/index.js
@@ -14,6 +14,7 @@ import { decodeEntities } from '@wordpress/html-entities';
 import { pencil } from '@wordpress/icons';
 import { __unstableStripHTML as stripHTML } from '@wordpress/dom';
 import { escapeAttribute } from '@wordpress/escape-html';
+import { safeDecodeURIComponent, filterURLForDisplay } from '@wordpress/url';
 
 /**
  * Internal dependencies
@@ -90,8 +91,8 @@ export default function SidebarNavigationScreenPage() {
 					className="edit-site-sidebar-navigation-screen__page-link"
 					href={ record.link }
 				>
-					{ decodeURI(
-						record.link.replace( /^(https?:\/\/)?/, '' )
+					{ filterURLForDisplay(
+						safeDecodeURIComponent( record.link )
 					) }
 				</ExternalLink>
 			}

--- a/packages/edit-site/src/components/sidebar-navigation-screen-page/page-details.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-page/page-details.js
@@ -42,7 +42,11 @@ function getPageDetails( page ) {
 		},
 		{
 			label: __( 'Slug' ),
-			value: <Truncate numberOfLines={ 1 }>{ page.slug }</Truncate>,
+			value: (
+				<Truncate numberOfLines={ 1 }>
+					{ decodeURI( page.slug ) }
+				</Truncate>
+			),
 		},
 	];
 

--- a/packages/edit-site/src/components/sidebar-navigation-screen-page/page-details.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-page/page-details.js
@@ -7,6 +7,7 @@ import { count as wordCount } from '@wordpress/wordcount';
 import { useSelect } from '@wordpress/data';
 import { decodeEntities } from '@wordpress/html-entities';
 import { store as coreStore, useEntityRecord } from '@wordpress/core-data';
+import { safeDecodeURIComponent } from '@wordpress/url';
 
 /**
  * Internal dependencies
@@ -44,7 +45,7 @@ function getPageDetails( page ) {
 			label: __( 'Slug' ),
 			value: (
 				<Truncate numberOfLines={ 1 }>
-					{ decodeURI( page.slug ) }
+					{ safeDecodeURIComponent( page.slug ) }
 				</Truncate>
 			),
 		},


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

If a page has a title and slug with non-latin characters, the page details show them as encoded:
The Slug /επίπεδο-2/ shows as %ce%b5%cf%80%ce%af%cf%80%ce%b5%ce%b4%ce%bf-2.
This PR decodes the visual presentation of the slug in two places in the page details:
The page link at the top below the page title,  and the page slug item that is further down the list.

Closes https://github.com/WordPress/gutenberg/issues/51676

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The text was not displayed correctly.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Decodes the URI and slug.

## Testing Instructions
1. Activate a block theme
2. Import the [theme test data](https://github.com/WPTT/theme-test-data) that has some content in greek, or create a new page with this Russian title: `Привет, мир`
3. Navigate to Appearance > Editor > Pages.
4. Select the page you created, or for example the page with the title "Επίπεδο 2 -Second Greek level"
5. See that the slug shows the correct characters.
6.  Optionally confirm that clicking the link below the page title in the sidebar still works. It only displays incorrectly.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

1. Activate a block theme
2. Import the [theme test data](https://github.com/WPTT/theme-test-data) that has some content in greek, or create a new page with this Russian title: `Привет, мир`
3. Navigate from the WordPress admin to the Site Editor via the menu items Appearance, Editor.
4. In the navigation Sidebar, navigate past the links (go back to dashboard, view site etc) until you reach the navigation with buttons. Skip past the first two buttons, "Navigation" and "Styles", and activate the button with the label "Pages".
5. Skip past the back button and the "draft new page" button, and activate the button with the title of the page you want to test.
6. There are two items to test here:
1. A link that is immediately after the "Edit" button. Confirm that the slug with the non-latin characters is announced and not something like "0%/d".
2. A non-focusable text item inside a list. To test this, read the full content of the page and pay attention to "Slug" followed by the page slug. Confirm that it does not read out something like "0%/d".

## Screenshots or screencast <!-- if applicable -->
After:
<img width="389" alt="Page details view with decoded slugs" src="https://github.com/WordPress/gutenberg/assets/7422055/ff7d0cfb-ccbd-447e-9610-e2952009a7e5">
