### PR TITLE
useInsertionPoint: Add missing dependency for useCallback

### DIFF
--- a/packages/block-editor/src/components/inserter/hooks/use-insertion-point.js
+++ b/packages/block-editor/src/components/inserter/hooks/use-insertion-point.js
@@ -135,6 +135,7 @@ function useInsertionPoint( {
 			destinationIndex,
 			onSelect,
 			shouldFocusBlock,
+			selectBlockOnInsert,
 		]
 	);
 


### PR DESCRIPTION
## What?
_Noticed while working on #51673._

PR add `selectBlockOnInsert` to memoized callback dependency list in the `useInsertionPoint` hook. The `selectBlockOnInsert` is boolean, so this shouldn't have any unwanted side effects.

## Why?
Fixes ESLint warning and prevents stale closures.

## Testing Instructions
CI checks are green.
