### PR TITLE
Link Format: Don't return focus on the selected text 'onFocusOutside'

### DIFF
--- a/packages/e2e-tests/specs/editor/various/links.test.js
+++ b/packages/e2e-tests/specs/editor/various/links.test.js
@@ -669,7 +669,9 @@ describe( 'Links', () => {
 			await page.waitForXPath( `//label[text()='Open in new tab']` );
 
 			// Move focus back to RichText for the underlying link.
-			await pressKeyTimes( 'Tab', 4 );
+			await pressKeyWithModifier( 'shift', 'Tab' );
+			await pressKeyWithModifier( 'shift', 'Tab' );
+			await pressKeyWithModifier( 'shift', 'Tab' );
 
 			// Make a selection within the RichText.
 			await pressKeyWithModifier( 'shift', 'ArrowRight' );

--- a/packages/format-library/src/link/index.js
+++ b/packages/format-library/src/link/index.js
@@ -60,9 +60,11 @@ function Edit( {
 		}
 	}
 
-	function stopAddingLink() {
+	function stopAddingLink( returnFocus = true ) {
 		setAddingLink( false );
-		onFocus();
+		if ( returnFocus ) {
+			onFocus();
+		}
 	}
 
 	function onRemoveFormat() {

--- a/packages/format-library/src/link/inline.js
+++ b/packages/format-library/src/link/inline.js
@@ -255,6 +255,7 @@ function InlineLinkUI( {
 			anchor={ popoverAnchor }
 			focusOnMount={ focusOnMount.current }
 			onClose={ stopAddingLink }
+			onFocusOutside={ () => stopAddingLink( false ) }
 			placement="bottom"
 			shift
 		>


### PR DESCRIPTION
## What?
Fixes #51646.

Do not return focus to the selected text when the Link format inline popover is closed by focusing outside. Fixes a bug with the main block inserter closing because of focus change.

## Why?
The `onFocusOutside` event can be interpreted as the user's intention to move focus to another element.

## How?
* Add param to `stopAddingLink` to manage focus returns.
* Set a separate `onFocusOutside` handler for the popover.

## Testing Instructions

1. Go to the post editor.
2. Select some text in a Paragraph block.
3. Press Cmd (or Control on Windows) + K, to open the Link popover.
4. Keep the Link popover open.
5. Click the + button in the top bar to open the main inserter.
6. Observe the inserter opens, and the Link popover closes.

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/240569/59d33159-08be-4c4a-99cc-2fe7064cbcd9

