### PR TITLE
Lodash: Refactor away from `_.kebabCase()` in block editor

### DIFF
--- a/packages/block-editor/src/components/colors/utils.js
+++ b/packages/block-editor/src/components/colors/utils.js
@@ -1,10 +1,14 @@
 /**
  * External dependencies
  */
-import { kebabCase } from 'lodash';
 import { colord, extend } from 'colord';
 import namesPlugin from 'colord/plugins/names';
 import a11yPlugin from 'colord/plugins/a11y';
+
+/**
+ * Internal dependencies
+ */
+import { kebabCase } from '../../utils/object';
 
 extend( [ namesPlugin, a11yPlugin ] );
 

--- a/packages/block-editor/src/components/colors/with-colors.js
+++ b/packages/block-editor/src/components/colors/with-colors.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { kebabCase } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { useMemo, Component } from '@wordpress/element';
@@ -19,6 +14,7 @@ import {
 	getMostReadableColor,
 } from './utils';
 import useSetting from '../use-setting';
+import { kebabCase } from '../../utils/object';
 
 /**
  * Capitalizes the first letter in a string.

--- a/packages/block-editor/src/components/font-sizes/utils.js
+++ b/packages/block-editor/src/components/font-sizes/utils.js
@@ -1,7 +1,7 @@
 /**
- * External dependencies
+ * Internal dependencies
  */
-import { kebabCase } from 'lodash';
+import { kebabCase } from '../../utils/object';
 
 /**
  *  Returns the font size object based on an array of named font sizes and the namedFontSize and customFontSize values.

--- a/packages/block-editor/src/components/global-styles/use-global-styles-output.js
+++ b/packages/block-editor/src/components/global-styles/use-global-styles-output.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { get, kebabCase, set } from 'lodash';
+import { get, set } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -32,6 +32,7 @@ import { PresetDuotoneFilter } from '../duotone/components';
 import { getGapCSSValue } from '../../hooks/gap';
 import { store as blockEditorStore } from '../../store';
 import { LAYOUT_DEFINITIONS } from '../../layouts/definitions';
+import { kebabCase } from '../../utils/object';
 
 // List of block support features that can have their related styles
 // generated under their own feature level selector rather than the block's.

--- a/packages/block-editor/src/hooks/font-family.js
+++ b/packages/block-editor/src/hooks/font-family.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { kebabCase } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { addFilter } from '@wordpress/hooks';
@@ -15,6 +10,7 @@ import TokenList from '@wordpress/token-list';
  */
 import { shouldSkipSerialization } from './utils';
 import { TYPOGRAPHY_SUPPORT_KEY } from './typography';
+import { kebabCase } from '../utils/object';
 
 export const FONT_FAMILY_SUPPORT_KEY = 'typography.__experimentalFontFamily';
 

--- a/packages/block-editor/src/hooks/layout.js
+++ b/packages/block-editor/src/hooks/layout.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { kebabCase } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -31,6 +30,7 @@ import BlockList from '../components/block-list';
 import { getLayoutType, getLayoutTypes } from '../layouts';
 import { useBlockEditingMode } from '../components/block-editing-mode';
 import { LAYOUT_DEFINITIONS } from '../layouts/definitions';
+import { kebabCase } from '../utils/object';
 
 const layoutBlockSupportKey = 'layout';
 

--- a/packages/block-editor/src/hooks/use-typography-props.js
+++ b/packages/block-editor/src/hooks/use-typography-props.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { kebabCase } from 'lodash';
 import classnames from 'classnames';
 
 /**
@@ -13,6 +12,7 @@ import {
 	getTypographyFontSizeValue,
 	getFluidTypographyOptionsFromSettings,
 } from '../components/global-styles/typography-utils';
+import { kebabCase } from '../utils/object';
 
 /*
  * This utility is intended to assist where the serialization of the typography

--- a/packages/block-editor/src/utils/object.js
+++ b/packages/block-editor/src/utils/object.js
@@ -34,7 +34,12 @@ function normalizePath( path ) {
  * @return {string} Kebab-cased string
  */
 export function kebabCase( str ) {
-	return paramCase( str, {
+	let input = str;
+	if ( typeof str !== 'string' ) {
+		input = str?.toString?.() ?? '';
+	}
+
+	return paramCase( input, {
 		splitRegexp: [
 			/([a-z0-9])([A-Z])/g, // fooBar => foo-bar, 3Bar => 3-bar
 			/([0-9])([a-z])/g, // 3bar => 3-bar

--- a/packages/block-editor/src/utils/object.js
+++ b/packages/block-editor/src/utils/object.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { paramCase } from 'change-case';
+
+/**
  * Converts a path to an array of its fragments.
  * Supports strings, numbers and arrays:
  *
@@ -17,6 +22,26 @@ function normalizePath( path ) {
 	}
 
 	return [ path ];
+}
+
+/**
+ * Converts any string to kebab case.
+ * Backwards compatible with Lodash's `_.kebabCase()`.
+ *
+ * @see https://lodash.com/docs/4.17.15#kebabCase
+ *
+ * @param {string} str String to convert.
+ * @return {string} Kebab-cased string
+ */
+export function kebabCase( str ) {
+	return paramCase( str, {
+		splitRegexp: [
+			/([a-z0-9])([A-Z])/g, // fooBar => foo-bar, 3Bar => 3-bar
+			/([0-9])([a-z])/g, // 3bar => 3-bar
+			/([A-Za-z])([0-9])/g, // Foo3 => foo-3, foo3 => foo-3
+			/([A-Z])([A-Z][a-z])/g, // FOOBar => foo-bar
+		],
+	} );
 }
 
 /**

--- a/packages/block-editor/src/utils/object.js
+++ b/packages/block-editor/src/utils/object.js
@@ -27,8 +27,10 @@ function normalizePath( path ) {
 /**
  * Converts any string to kebab case.
  * Backwards compatible with Lodash's `_.kebabCase()`.
+ * Backwards compatible with `_wp_to_kebab_case()`.
  *
  * @see https://lodash.com/docs/4.17.15#kebabCase
+ * @see https://developer.wordpress.org/reference/functions/_wp_to_kebab_case/`
  *
  * @param {string} str String to convert.
  * @return {string} Kebab-cased string
@@ -39,12 +41,15 @@ export function kebabCase( str ) {
 		input = str?.toString?.() ?? '';
 	}
 
+	// See https://github.com/lodash/lodash/blob/b185fcee26b2133bd071f4aaca14b455c2ed1008/lodash.js#L4970
+	input = input.replace( /['\u2019]/, '' );
+
 	return paramCase( input, {
 		splitRegexp: [
-			/([a-z0-9])([A-Z])/g, // fooBar => foo-bar, 3Bar => 3-bar
-			/([0-9])([a-z])/g, // 3bar => 3-bar
+			/(?!(?:1ST|2ND|3RD|[4-9]TH)(?![a-z]))([a-z0-9])([A-Z])/g, // fooBar => foo-bar, 3Bar => 3-bar
+			/(?!(?:1st|2nd|3rd|[4-9]th)(?![a-z]))([0-9])([a-z])/g, // 3bar => 3-bar
 			/([A-Za-z])([0-9])/g, // Foo3 => foo-3, foo3 => foo-3
-			/([A-Z])([A-Z][a-z])/g, // FOOBar => foo-bar
+			/([A-Z])([A-Z][a-z])/g, // FOOBar => foo-bar,
 		],
 	} );
 }

--- a/packages/block-editor/src/utils/object.js
+++ b/packages/block-editor/src/utils/object.js
@@ -30,7 +30,7 @@ function normalizePath( path ) {
  * Backwards compatible with `_wp_to_kebab_case()`.
  *
  * @see https://lodash.com/docs/4.17.15#kebabCase
- * @see https://developer.wordpress.org/reference/functions/_wp_to_kebab_case/`
+ * @see https://developer.wordpress.org/reference/functions/_wp_to_kebab_case/
  *
  * @param {string} str String to convert.
  * @return {string} Kebab-cased string
@@ -49,7 +49,7 @@ export function kebabCase( str ) {
 			/(?!(?:1ST|2ND|3RD|[4-9]TH)(?![a-z]))([a-z0-9])([A-Z])/g, // fooBar => foo-bar, 3Bar => 3-bar
 			/(?!(?:1st|2nd|3rd|[4-9]th)(?![a-z]))([0-9])([a-z])/g, // 3bar => 3-bar
 			/([A-Za-z])([0-9])/g, // Foo3 => foo-3, foo3 => foo-3
-			/([A-Z])([A-Z][a-z])/g, // FOOBar => foo-bar,
+			/([A-Z])([A-Z][a-z])/g, // FOOBar => foo-bar
 		],
 	} );
 }

--- a/packages/block-editor/src/utils/test/object.js
+++ b/packages/block-editor/src/utils/test/object.js
@@ -60,6 +60,42 @@ describe( 'kebabCase', () => {
 		expect( kebabCase( [] ) ).toEqual( '' );
 		expect( kebabCase( {} ) ).toEqual( 'object-object' );
 	} );
+
+	/**
+	 * Should cover all test cases of `_wp_to_kebab_case()`
+	 *
+	 * @see https://developer.wordpress.org/reference/functions/_wp_to_kebab_case/
+	 * @see https://github.com/WordPress/wordpress-develop/blob/76376fdbc3dc0b3261de377dffc350677345e7ba/tests/phpunit/tests/functions/wpToKebabCase.php#L35-L62
+	 */
+	it.each( [
+		[ 'white', 'white' ],
+		[ 'white+black', 'white-black' ],
+		[ 'white:black', 'white-black' ],
+		[ 'white*black', 'white-black' ],
+		[ 'white.black', 'white-black' ],
+		[ 'white black', 'white-black' ],
+		[ 'white	black', 'white-black' ],
+		[ 'white-to-black', 'white-to-black' ],
+		[ 'white2white', 'white-2-white' ],
+		[ 'white2nd', 'white-2nd' ],
+		[ 'white2ndcolor', 'white-2-ndcolor' ],
+		[ 'white2ndColor', 'white-2nd-color' ],
+		[ 'white2nd_color', 'white-2nd-color' ],
+		[ 'white23color', 'white-23-color' ],
+		[ 'white23', 'white-23' ],
+		[ '23color', '23-color' ],
+		[ 'white4th', 'white-4th' ],
+		[ 'font2xl', 'font-2-xl' ],
+		[ 'whiteToWhite', 'white-to-white' ],
+		[ 'whiteTOwhite', 'white-t-owhite' ],
+		[ 'WHITEtoWHITE', 'whit-eto-white' ],
+		[ 42, '42' ],
+		[ "i've done", 'ive-done' ],
+		[ '#ffffff', 'ffffff' ],
+		[ '$ffffff', 'ffffff' ],
+	] )( 'converts %s properly to %s', ( input, expected ) => {
+		expect( kebabCase( input ) ).toEqual( expected );
+	} );
 } );
 
 describe( 'setImmutably', () => {

--- a/packages/block-editor/src/utils/test/object.js
+++ b/packages/block-editor/src/utils/test/object.js
@@ -62,7 +62,7 @@ describe( 'kebabCase', () => {
 	} );
 
 	/**
-	 * Should cover all test cases of `_wp_to_kebab_case()`
+	 * Should cover all test cases of `_wp_to_kebab_case()`.
 	 *
 	 * @see https://developer.wordpress.org/reference/functions/_wp_to_kebab_case/
 	 * @see https://github.com/WordPress/wordpress-develop/blob/76376fdbc3dc0b3261de377dffc350677345e7ba/tests/phpunit/tests/functions/wpToKebabCase.php#L35-L62

--- a/packages/block-editor/src/utils/test/object.js
+++ b/packages/block-editor/src/utils/test/object.js
@@ -49,6 +49,17 @@ describe( 'kebabCase', () => {
 	it( 'returns an existing kebab case string unchanged', () => {
 		expect( kebabCase( 'foo-123-bar' ) ).toEqual( 'foo-123-bar' );
 	} );
+
+	it( 'returns an empty string if any nullish type is passed', () => {
+		expect( kebabCase( undefined ) ).toEqual( '' );
+		expect( kebabCase( null ) ).toEqual( '' );
+	} );
+
+	it( 'converts any unexpected non-nullish type to a string', () => {
+		expect( kebabCase( 12345 ) ).toEqual( '12345' );
+		expect( kebabCase( [] ) ).toEqual( '' );
+		expect( kebabCase( {} ) ).toEqual( 'object-object' );
+	} );
 } );
 
 describe( 'setImmutably', () => {

--- a/packages/block-editor/src/utils/test/object.js
+++ b/packages/block-editor/src/utils/test/object.js
@@ -1,7 +1,55 @@
 /**
  * Internal dependencies
  */
-import { setImmutably } from '../object';
+import { kebabCase, setImmutably } from '../object';
+
+describe( 'kebabCase', () => {
+	it( 'separates lowercase letters, followed by uppercase letters', () => {
+		expect( kebabCase( 'fooBar' ) ).toEqual( 'foo-bar' );
+	} );
+
+	it( 'separates numbers, followed by uppercase letters', () => {
+		expect( kebabCase( '123FOO' ) ).toEqual( '123-foo' );
+	} );
+
+	it( 'separates numbers, followed by lowercase characters', () => {
+		expect( kebabCase( '123bar' ) ).toEqual( '123-bar' );
+	} );
+
+	it( 'separates uppercase letters, followed by numbers', () => {
+		expect( kebabCase( 'FOO123' ) ).toEqual( 'foo-123' );
+	} );
+
+	it( 'separates lowercase letters, followed by numbers', () => {
+		expect( kebabCase( 'foo123' ) ).toEqual( 'foo-123' );
+	} );
+
+	it( 'separates uppercase groups from capitalized groups', () => {
+		expect( kebabCase( 'FOOBar' ) ).toEqual( 'foo-bar' );
+	} );
+
+	it( 'removes any non-dash special characters', () => {
+		expect(
+			kebabCase( 'foo±§!@#$%^&*()-_=+/?.>,<\\|{}[]`~\'";:bar' )
+		).toEqual( 'foo-bar' );
+	} );
+
+	it( 'removes any spacing characters', () => {
+		expect( kebabCase( ' foo \t \n \r \f \v bar ' ) ).toEqual( 'foo-bar' );
+	} );
+
+	it( 'groups multiple dashes into a single one', () => {
+		expect( kebabCase( 'foo---bar' ) ).toEqual( 'foo-bar' );
+	} );
+
+	it( 'returns an empty string unchanged', () => {
+		expect( kebabCase( '' ) ).toEqual( '' );
+	} );
+
+	it( 'returns an existing kebab case string unchanged', () => {
+		expect( kebabCase( 'foo-123-bar' ) ).toEqual( 'foo-123-bar' );
+	} );
+} );
 
 describe( 'setImmutably', () => {
 	describe( 'handling falsy values properly', () => {


### PR DESCRIPTION
## What?
This PR removes Lodash's `_.kebabCase()` from the block editor package. This basically gets rid of half of the remaining `kebabCase()` usages in the entire codebase.

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

We're pretty close with the migration away from Lodash, only 3 methods are used and we're close to reaping the benefits of not relying on it at all.

## How?

We're introducing a custom `kebabCase()` utility that basically customizes the existing `paramCase()` function from the `change-case` package that we've already been utilizing throughout Gutenberg.

The custom utility is necessary in order to keep backward compatibility with the Lodash function within the block editor context (it's mostly about properly handling class names the same way as Lodash's `kebabCase()` did).

We're adding unit tests to ensure we're covering all scenarios as Lodash did. 

We're finally replacing all usages within the block editor package with the new utility function. 

## Testing Instructions

* Smoke test various features in the block editor and verify they still work well:
  * Managing, changing, and setting colors and color palettes
  * Managing, changing, and setting font sizes and font families
  * Managing, changing, and setting layout settings for blocks that support it
  * Managing, changing, and setting various typography settings
* Verify all tests pass - most of the affected areas are well covered by unit tests.