### PR TITLE
Navigation: Remove destructive colors from modal

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/delete-modal.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/delete-modal.js
@@ -25,7 +25,6 @@ export default function RenameModal( { onClose, onConfirm } ) {
 						</Button>
 
 						<Button
-							isDestructive
 							variant="primary"
 							type="submit"
 							onClick={ ( e ) => {
@@ -36,7 +35,7 @@ export default function RenameModal( { onClose, onConfirm } ) {
 								onClose();
 							} }
 						>
-							{ __( 'Confirm' ) }
+							{ __( 'Delete' ) }
 						</Button>
 					</HStack>
 				</VStack>

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/more-menu.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/more-menu.js
@@ -56,9 +56,9 @@ export default function ScreenNavigationMoreMenu( props ) {
 							>
 								{ __( 'Duplicate' ) }
 							</MenuItem>
+						</MenuGroup>
+						<MenuGroup>
 							<MenuItem
-								isDestructive
-								isTertiary
 								onClick={ () => {
 									openDeleteModal();
 


### PR DESCRIPTION
## What?
Removes the destructive colors from the modal. Fixes https://github.com/WordPress/gutenberg/issues/51690. Also change the "Confirm" label to "Delete".

## Why?
 In general I think we should move away from "destructive colors" as they do not work well for color blindness and don't always culturally have the correct significance. In this case the confirm dialog itself is enough validation that you are sure. 

## How?
Remove the isDestructive props.

## Testing Instructions
1. Open the site editor
2. Go to the Navigation section
3. Open a single navigation
4. Open the ellipsis menu
5. Select the delete option
6. Confirm that the Button now says "Delete" and the button is blue not red.

## Screenshots or screencast <!-- if applicable -->
<img width="446" alt="Screenshot 2023-06-20 at 11 44 54" src="https://github.com/WordPress/gutenberg/assets/275961/ae7d4a63-72ae-4549-b6b7-1a02455a75eb">
<img width="539" alt="Screenshot 2023-06-20 at 11 44 49" src="https://github.com/WordPress/gutenberg/assets/275961/244f7986-1403-4105-ba65-a41b53e87880">


