### PR TITLE
Image block: Remove Lightbox markup if is set as disabled.

### DIFF
--- a/lib/block-supports/behaviors.php
+++ b/lib/block-supports/behaviors.php
@@ -59,6 +59,10 @@ function gutenberg_render_behaviors_support_lightbox( $block_content, $block ) {
 		}
 	}
 
+	if ( isset( $lightbox_settings['enabled'] ) && false === $lightbox_settings['enabled'] ) {
+		return $block_content;
+	}
+
 	if ( ! $lightbox_settings || 'none' !== $link_destination || empty( $experiments['gutenberg-interactivity-api-core-blocks'] ) ) {
 		return $block_content;
 	}

--- a/test/e2e/specs/editor/blocks/image.spec.js
+++ b/test/e2e/specs/editor/blocks/image.spec.js
@@ -997,6 +997,25 @@ test.describe( 'Image - interactivity', () => {
 			).not.toBeInViewport();
 		} );
 
+		test( 'lightbox markup should not appear if Lightbox is disabled', async ( {
+			editor,
+			page,
+		} ) => {
+			await page.getByRole( 'button', { name: 'Advanced' } ).click();
+			const behaviorSelect = page.getByRole( 'combobox', {
+				name: 'Behaviors',
+			} );
+			await behaviorSelect.selectOption( '' );
+
+			const postId = await editor.publishPost();
+			await page.goto( `/?p=${ postId }` );
+
+			// The lightbox markup should not appear in the DOM at all
+			await expect(
+				page.getByRole( 'button', { name: 'Enlarge image' } )
+			).not.toBeInViewport();
+		} );
+
 		test.describe( 'keyboard navigation', () => {
 			let openLightboxButton;
 			let lightbox;

--- a/test/e2e/specs/editor/blocks/image.spec.js
+++ b/test/e2e/specs/editor/blocks/image.spec.js
@@ -997,7 +997,7 @@ test.describe( 'Image - interactivity', () => {
 			).not.toBeInViewport();
 		} );
 
-		test( 'lightbox markup should not appear if Lightbox is disabled', async ( {
+		test( 'markup should not appear if Lightbox is disabled', async ( {
 			editor,
 			page,
 		} ) => {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Right now, even if you disable the Lightbox, the HTML code that makes this possible is still there. With this PR, if Lighbox is disabled, we don't add all that extra data.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
We were adding no needed bytes and, also we caused a misbehavior, showing a magnifying glass that indicates a behavior that is not happening. 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
1) Post or page with an image.
2) Enable/Disable the Lightbox behavior. You can also use theme.json and defaults.
3) Check that if disabled, Lightbox is not working, the mouse pointer is the default one, and nothing weird happens.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
Before PR:

https://github.com/WordPress/gutenberg/assets/37012961/520424a1-0b5e-4a0e-b7fe-dfbfc8b98b79



After PR:


https://github.com/WordPress/gutenberg/assets/37012961/c3eda8d9-2e06-4f08-921a-6661e40065da

