### PR TITLE
Fix the heading hierarchy in the site editor

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen-details-panel/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-details-panel/index.js
@@ -22,7 +22,7 @@ function SidebarNavigationScreenDetailsPanel( { title, children, spacing } ) {
 			{ title && (
 				<Heading
 					className="edit-site-sidebar-navigation-details-screen-panel__heading"
-					level={ 3 }
+					level={ 2 }
 				>
 					{ title }
 				</Heading>

--- a/packages/edit-site/src/components/sidebar-navigation-screen/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen/index.js
@@ -77,7 +77,7 @@ export default function SidebarNavigationScreen( {
 					<Heading
 						className="edit-site-sidebar-navigation-screen__title"
 						color={ 'white' }
-						level={ 2 }
+						level={ 1 }
 						size={ 20 }
 					>
 						{ ! isPreviewingTheme()

--- a/test/e2e/specs/site-editor/command-center.spec.js
+++ b/test/e2e/specs/site-editor/command-center.spec.js
@@ -44,7 +44,7 @@ test.describe( 'Site editor command center', () => {
 			.click();
 		await page.keyboard.type( 'index' );
 		await page.getByRole( 'option', { name: 'index' } ).click();
-		await expect( page.getByRole( 'heading', { level: 2 } ) ).toHaveText(
+		await expect( page.getByRole( 'heading', { level: 1 } ) ).toHaveText(
 			'Index'
 		);
 	} );


### PR DESCRIPTION
closes #42373 

## What?

The heading hierarchy was incorrect in the site editor, we were missing an h1 in view mode.

## Testing Instructions

Install the "HeadingMap" chrome extension to see the heading hierarchy live.

1- Open the site editor
2- Check that there's an h1 as you navigate the editor.
3- Check that the hierarchy is correct.
