### PR TITLE
Lodash: Remove from lint staged typecheck

### DIFF
--- a/bin/packages/lint-staged-typecheck.js
+++ b/bin/packages/lint-staged-typecheck.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-const _ = require( 'lodash' );
 const path = require( 'path' );
 const fs = require( 'fs' );
 const execa = require( 'execa' );
@@ -18,12 +17,14 @@ const tscPath = path.join( repoRoot, 'node_modules', '.bin', 'tsc' );
 const changedFiles = process.argv.slice( 2 );
 
 // Transform changed files to package directories containing tsconfig.json.
-const changedPackages = _.uniq(
-	changedFiles.map( ( fullPath ) => {
-		const relativePath = path.relative( repoRoot, fullPath );
-		return path.join( ...relativePath.split( path.sep ).slice( 0, 2 ) );
-	} )
-).filter( ( packageRoot ) =>
+const changedPackages = [
+	...new Set(
+		changedFiles.map( ( fullPath ) => {
+			const relativePath = path.relative( repoRoot, fullPath );
+			return path.join( ...relativePath.split( path.sep ).slice( 0, 2 ) );
+		} )
+	),
+].filter( ( packageRoot ) =>
 	fs.existsSync( path.join( packageRoot, 'tsconfig.json' ) )
 );
 


### PR DESCRIPTION
## What?
This PR removes Lodash usage from the lint staged type check script.

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?

We're using the `[ ...new Set( array ) ]` approach to get an array with unique items.

## Testing Instructions
* Add some changes to JS files.
* `git add` them to stage them.
* Run `npx lint-staged` and verify it runs without errors.