### PR TITLE
Pass the block to the onGoToPage function

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/leaf-more-menu.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/leaf-more-menu.js
@@ -117,7 +117,7 @@ export default function LeafMoreMenu( props ) {
 						{ block.attributes?.id && (
 							<MenuItem
 								onClick={ () => {
-									onGoToPage();
+									onGoToPage( block );
 									onClose();
 								} }
 							>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Pass the block to the onGoToPage function.

## Why?
So that users can open the page in the preview.

## How?
Just pass the param.

## Testing Instructions
1. Open the Navigation sidebar in the Site View of Site Editor
2. Open a navigation
3. Click on the ellipsis menu next to a page
4. Click on the "Go to [page name]" option
5. Confirm that the page opens in the preview. 
