### PR TITLE
Unify welcome guides labels casing

### DIFF
--- a/packages/edit-site/src/components/welcome-guide/editor.js
+++ b/packages/edit-site/src/components/welcome-guide/editor.js
@@ -32,7 +32,7 @@ export default function WelcomeGuideEditor() {
 		<Guide
 			className="edit-site-welcome-guide"
 			contentLabel={ __( 'Welcome to the site editor' ) }
-			finishButtonText={ __( 'Get Started' ) }
+			finishButtonText={ __( 'Get started' ) }
 			onFinish={ () => toggle( 'core/edit-site', 'welcomeGuide' ) }
 			pages={ [
 				{

--- a/packages/edit-site/src/components/welcome-guide/styles.js
+++ b/packages/edit-site/src/components/welcome-guide/styles.js
@@ -34,11 +34,13 @@ export default function WelcomeGuideStyles() {
 		return null;
 	}
 
+	const welcomeLabel = __( 'Welcome to Styles' );
+
 	return (
 		<Guide
 			className="edit-site-welcome-guide"
-			contentLabel={ __( 'Welcome to styles' ) }
-			finishButtonText={ __( 'Get Started' ) }
+			contentLabel={ welcomeLabel }
+			finishButtonText={ __( 'Get started' ) }
 			onFinish={ () => toggle( 'core/edit-site', 'welcomeGuideStyles' ) }
 			pages={ [
 				{
@@ -51,7 +53,7 @@ export default function WelcomeGuideStyles() {
 					content: (
 						<>
 							<h1 className="edit-site-welcome-guide__heading">
-								{ __( 'Welcome to Styles' ) }
+								{ welcomeLabel }
 							</h1>
 							<p className="edit-site-welcome-guide__text">
 								{ __(


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
There are five welcome guides currently in use: two in the post editor, two in the site editor, and one the widgets editor.

In these welcome guides, the 'Get started' button text uses inconsistent casing:

<img width="1645" alt="welcome guides" src="https://github.com/WordPress/gutenberg/assets/1682452/7fe623af-88a6-4f30-9164-0badcece65df">

- We should avoid unnecessary title casing.
- Also, two identical strings that only differ by casing actually produce two different strings to translate, which forces translators to some unnecessary effort. Wherever possible, we should use consistent casing.
- This also applies to the strings `Welcome to Styles` vs. `Welcome to styles` where the letter s of styles uses inconsistent casing. While one of these strings is not visible (because it is used for an aria-label attribute), it still produces two different strings to translate on translate.wordpress.org 

The two 'Get started' strings on translate.wordpress.org:

<img width="1331" alt="Screenshot 2023-06-20 at 13 04 30" src="https://github.com/WordPress/gutenberg/assets/1682452/feac4d2d-3de5-43b0-9f1d-d981ea2e5ebc">

The two 'Welcome to styles' strings on translate.wordpress.org:

<img width="1337" alt="Screenshot 2023-06-20 at 12 59 07" src="https://github.com/WordPress/gutenberg/assets/1682452/0b155049-31fb-4a90-acd4-14691528dc2e">


## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Test should use consistent casing. Avoid title case where appropriate.
We should make translators life as comfortable as possible.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
- Not sure there's a real need to test.
- Anyways: to open the welcome guides:
  - either manually edit the `wp_persisted_preferences` user meta and change all the values of the welcome guides to `b:1;`
  - or open the welcome guides from the three editors Options menu (note that this is buggy for the Styles welcome guide, will create a separate issue)
- If the welcome guide has multiple steps, go to the last one.
- Observe the 'Get started' button uses sentence case.


### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
