### PR TITLE
Lodash: Remove from blocks package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17360,7 +17360,6 @@
 				"fast-deep-equal": "^3.1.3",
 				"hpq": "^1.3.0",
 				"is-plain-object": "^5.0.0",
-				"lodash": "^4.17.21",
 				"memize": "^2.1.0",
 				"rememo": "^4.0.2",
 				"remove-accents": "^0.4.2",

--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -49,7 +49,6 @@
 		"fast-deep-equal": "^3.1.3",
 		"hpq": "^1.3.0",
 		"is-plain-object": "^5.0.0",
-		"lodash": "^4.17.21",
 		"memize": "^2.1.0",
 		"rememo": "^4.0.2",
 		"remove-accents": "^0.4.2",

--- a/packages/blocks/src/store/private-selectors.js
+++ b/packages/blocks/src/store/private-selectors.js
@@ -2,12 +2,12 @@
  * External dependencies
  */
 import createSelector from 'rememo';
-import { get } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import { getBlockType } from './selectors';
+import { getValueFromObjectPath } from './utils';
 import { __EXPERIMENTAL_STYLE_PROPERTY as STYLE_PROPERTY } from '../api/constants';
 
 const ROOT_BLOCK_SUPPORTS = [
@@ -135,7 +135,7 @@ export const getSupportedStyles = createSelector(
 				if (
 					STYLE_PROPERTY[ styleName ].support[ 0 ] in
 						blockType.supports &&
-					get(
+					getValueFromObjectPath(
 						blockType.supports,
 						STYLE_PROPERTY[ styleName ].support
 					) !== false
@@ -146,7 +146,7 @@ export const getSupportedStyles = createSelector(
 			}
 
 			if (
-				get(
+				getValueFromObjectPath(
 					blockType.supports,
 					STYLE_PROPERTY[ styleName ].support,
 					false

--- a/packages/blocks/src/store/selectors.js
+++ b/packages/blocks/src/store/selectors.js
@@ -3,12 +3,16 @@
  */
 import createSelector from 'rememo';
 import removeAccents from 'remove-accents';
-import { get } from 'lodash';
 
 /**
  * WordPress dependencies
  */
 import { pipe } from '@wordpress/compose';
+
+/**
+ * Internal dependencies
+ */
+import { getValueFromObjectPath } from './utils';
 
 /** @typedef {import('../api/registration').WPBlockVariation} WPBlockVariation */
 /** @typedef {import('../api/registration').WPBlockVariationScope} WPBlockVariationScope */
@@ -607,7 +611,11 @@ export const getBlockSupport = (
 		return defaultSupports;
 	}
 
-	return get( blockType.supports, feature, defaultSupports );
+	return getValueFromObjectPath(
+		blockType.supports,
+		feature,
+		defaultSupports
+	);
 };
 
 /**

--- a/packages/blocks/src/store/utils.js
+++ b/packages/blocks/src/store/utils.js
@@ -1,0 +1,20 @@
+/**
+ * Helper util to return a value from a certain path of the object.
+ * Path is specified as either:
+ * - a string of properties, separated by dots, for example: "x.y".
+ * - an array of properties, for example `[ 'x', 'y' ]`.
+ * You can also specify a default value in case the result is nullish.
+ *
+ * @param {Object}       object       Input object.
+ * @param {string|Array} path         Path to the object property.
+ * @param {*}            defaultValue Default value if the value at the specified path is nullish.
+ * @return {*} Value of the object property at the specified path.
+ */
+export const getValueFromObjectPath = ( object, path, defaultValue ) => {
+	const normalizedPath = Array.isArray( path ) ? path : path.split( '.' );
+	let value = object;
+	normalizedPath.forEach( ( fieldName ) => {
+		value = value?.[ fieldName ];
+	} );
+	return value ?? defaultValue;
+};


### PR DESCRIPTION
## What?
This PR removes the last Lodash usage from the `@wordpress/blocks` package.

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?

We're creating a basic helper function to deal with retrieving values from object paths that are used in two locations to replace pre-existing `get()` usage. 

There might be an opportunity for deduplication in the future since this helper can be used in other places, but for now, our goal is to remove Lodash as a dependency. It's almost gone from the repo at this point.

## Testing Instructions

Verify all checks pass - the changes are covered by a bunch of tests.