### PR TITLE
feat: Rename Reusable blocks to Patterns

### DIFF
--- a/packages/block-editor/src/components/inserter/reusable-blocks-tab.native.js
+++ b/packages/block-editor/src/components/inserter/reusable-blocks-tab.native.js
@@ -28,11 +28,11 @@ function ReusableBlocksTab( { onSelect, rootClientId, listProps } ) {
 
 	return (
 		<BlockTypesList
-			name="ReusableBlocks"
+			name="SyncedPatterns"
 			sections={ sections }
 			onSelect={ onSelect }
 			listProps={ listProps }
-			label={ __( 'Reusable blocks' ) }
+			label={ __( 'Synced patterns' ) }
 		/>
 	);
 }

--- a/packages/block-editor/src/components/inserter/tabs.native.js
+++ b/packages/block-editor/src/components/inserter/tabs.native.js
@@ -142,7 +142,11 @@ InserterTabs.Control = TabsControl;
 
 InserterTabs.getTabs = () => [
 	{ name: 'blocks', title: __( 'Blocks' ), component: BlockTypesTab },
-	{ name: 'reusable', title: __( 'Reusable' ), component: ReusableBlocksTab },
+	{
+		name: 'reusable',
+		title: __( 'Synced patterns' ),
+		component: ReusableBlocksTab,
+	},
 ];
 
 export default InserterTabs;

--- a/packages/block-library/src/block/edit.native.js
+++ b/packages/block-library/src/block/edit.native.js
@@ -148,14 +148,14 @@ export default function ReusableBlockEdit( {
 				? sprintf(
 						/* translators: %s: name of the host app (e.g. WordPress) */
 						__(
-							'Editing reusable blocks is not yet supported on %s for Android'
+							'Editing synced patterns is not yet supported on %s for Android'
 						),
 						hostAppNamespace
 				  )
 				: sprintf(
 						/* translators: %s: name of the host app (e.g. WordPress) */
 						__(
-							'Editing reusable blocks is not yet supported on %s for iOS'
+							'Editing synced patterns is not yet supported on %s for iOS'
 						),
 						hostAppNamespace
 				  );

--- a/packages/block-library/src/block/test/edit.native.js
+++ b/packages/block-library/src/block/test/edit.native.js
@@ -56,8 +56,8 @@ afterAll( () => {
 	} );
 } );
 
-describe( 'Reusable block', () => {
-	it( 'inserts a reusable block', async () => {
+describe( 'Synced patterns', () => {
+	it( 'inserts a synced pattern', async () => {
 		// We have to use different ids because entities are cached in memory.
 		const reusableBlockMock1 = getMockedReusableBlock( 1 );
 		const reusableBlockMock2 = getMockedReusableBlock( 2 );
@@ -86,7 +86,7 @@ describe( 'Reusable block', () => {
 		fireEvent.press( await screen.findByLabelText( 'Add block' ) );
 
 		// Navigate to reusable tab.
-		const reusableSegment = await screen.findByText( 'Reusable' );
+		const reusableSegment = await screen.findByText( 'Synced patterns' );
 		// onLayout event is required by Segment component.
 		fireEvent( reusableSegment, 'layout', {
 			nativeEvent: {
@@ -98,7 +98,7 @@ describe( 'Reusable block', () => {
 		fireEvent.press( reusableSegment );
 
 		const reusableBlockList = screen.getByTestId(
-			'InserterUI-ReusableBlocks'
+			'InserterUI-SyncedPatterns'
 		);
 		// onScroll event used to force the FlatList to render all items.
 		fireEvent.scroll( reusableBlockList, {

--- a/packages/react-native-editor/CHANGELOG.md
+++ b/packages/react-native-editor/CHANGELOG.md
@@ -10,6 +10,7 @@ For each user feature we should also add a importance categorization label  to i
 -->
 
 ## Unreleased
+-   [*] Rename "Reusable blocks" to "Synced patterns", aligning with the web editor. [#51704]
 
 ## 1.98.0
 -   [*] Image block - Fix issue where in some cases the image doesn't display the right aspect ratio [#51463]


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## Related PRS

* https://github.com/wordpress-mobile/gutenberg-mobile/pull/5885

## What?
<!-- In a few words, what is the PR actually doing? -->
Rename "Reusable blocks" to "Synced patterns."

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Align with new web editor terminology: 487f230

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Update UI text strings and test IDs.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
1. Open a post containing Reusable blocks.
1. Verify the Reusable blocks:
    1. Display the new "Synced patterns" name instead.
    1. For unsupported hosts, display as unsupported.
    1. For supported hosts, display pattern contents, but are not editable
       without converting the pattern to regular blocks.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
n/a

## Screenshots or screencast <!-- if applicable -->

| Unsupported | Inserter Tab | Support Note |
| - | - | - |
| ![synced-patterns-unsupported](https://github.com/WordPress/gutenberg/assets/438664/ce486f0a-c78e-449c-ba9c-0d517b328e55) | ![synced-patterns-tab](https://github.com/WordPress/gutenberg/assets/438664/7cc5783e-1849-43bc-a929-f997bb5f8a70) | ![synced-patterns-note](https://github.com/WordPress/gutenberg/assets/438664/be032672-1511-48fb-a378-fce9e0d64cc8) |
