### PR TITLE
Modify documentation to include the scripts --no-watch option

### DIFF
--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -51,6 +51,7 @@
 
 -   The `WP_DEVTOOL` environment variable can now be used to set the Webpack devtool option for sourcemaps in production builds ([#46812](https://github.com/WordPress/gutenberg/pull/46812)). Previously, this only worked for development builds.
 -   Update default webpack config and lint-style script to allow PostCSS (`.pcss` extension) file usage ([#45352](https://github.com/WordPress/gutenberg/pull/45352)).
+-   The `--no-watch` option can now be used to start the build for development without starting the watcher ([#44237](https://github.com/WordPress/gutenberg/pull/44237)).
 
 ## 25.3.0 (2023-02-01)
 

--- a/packages/scripts/README.md
+++ b/packages/scripts/README.md
@@ -387,6 +387,7 @@ This script automatically use the optimized config but sometimes you may want to
 -   `--webpack-devtool` – controls how source maps are generated. See options at https://webpack.js.org/configuration/devtool/#devtool.
 -   `--webpack-no-externals` – disables scripts' assets generation, and omits the list of default externals.
 -   `--webpack-src-dir` – Allows customization of the source code directory. Default is `src`.
+-	`--no-watch` – Starts the build for development without starting the watcher.
 
 #### Advanced information
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Updating packages/scripts/README.md and packages/scripts/CHANGELOG.md to include information on the `--no-watch` option merged on February 2, 2023 and released in version 25.4.0 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Adds missing documentation on the `--no-watch` option merged on February 2, 2023 and released in version 25.4.0. See [#44237](https://github.com/WordPress/gutenberg/pull/44237) and [#51695](https://github.com/WordPress/gutenberg/issues/51695).

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Minor changes to documentation

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
-    Go to [the scripts documentation](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-scripts).
-    Scroll until you get to the `start` section.
