### PR TITLE
Edit Site: Use global background color while loading

### DIFF
--- a/packages/edit-site/src/components/canvas-spinner/index.js
+++ b/packages/edit-site/src/components/canvas-spinner/index.js
@@ -2,11 +2,21 @@
  * WordPress dependencies
  */
 import { Spinner } from '@wordpress/components';
+import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
 
-export default function CanvasSpinner( { spinnerStyle } ) {
+/**
+ * Internal dependencies
+ */
+import { unlock } from '../../lock-unlock';
+
+const { useGlobalStyle } = unlock( blockEditorPrivateApis );
+
+export default function CanvasSpinner() {
+	const [ textColor ] = useGlobalStyle( 'color.text' );
+
 	return (
 		<div className="edit-site-canvas-spinner">
-			<Spinner style={ spinnerStyle } />
+			<Spinner style={ { color: textColor } } />
 		</div>
 	);
 }

--- a/packages/edit-site/src/components/canvas-spinner/index.js
+++ b/packages/edit-site/src/components/canvas-spinner/index.js
@@ -3,10 +3,10 @@
  */
 import { Spinner } from '@wordpress/components';
 
-export default function CanvasSpinner() {
+export default function CanvasSpinner( { spinnerStyle } ) {
 	return (
 		<div className="edit-site-canvas-spinner">
-			<Spinner />
+			<Spinner style={ spinnerStyle } />
 		</div>
 	);
 }

--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -15,7 +15,6 @@ import {
 	BlockContextProvider,
 	BlockBreadcrumb,
 	store as blockEditorStore,
-	privateApis as blockEditorPrivateApis,
 } from '@wordpress/block-editor';
 import {
 	InterfaceSkeleton,
@@ -43,8 +42,6 @@ import CanvasSpinner from '../canvas-spinner';
 import { unlock } from '../../lock-unlock';
 import useEditedEntityRecord from '../use-edited-entity-record';
 import { SidebarFixedBottomSlot } from '../sidebar-edit-mode/sidebar-fixed-bottom';
-
-const { useGlobalStyle } = unlock( blockEditorPrivateApis );
 
 const interfaceLabels = {
 	/* translators: accessibility text for the editor content landmark region. */
@@ -163,13 +160,9 @@ export default function Editor( { isLoading } ) {
 	// action in <URlQueryController> from double-announcing.
 	useTitle( hasLoadedPost && title );
 
-	const [ textColor ] = useGlobalStyle( 'color.text' );
-
 	return (
 		<>
-			{ isLoading ? (
-				<CanvasSpinner spinnerStyle={ { color: textColor } } />
-			) : null }
+			{ isLoading ? <CanvasSpinner /> : null }
 			{ isEditMode && <WelcomeGuide /> }
 			<EntityProvider kind="root" type="site">
 				<EntityProvider

--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -15,6 +15,7 @@ import {
 	BlockContextProvider,
 	BlockBreadcrumb,
 	store as blockEditorStore,
+	privateApis as blockEditorPrivateApis,
 } from '@wordpress/block-editor';
 import {
 	InterfaceSkeleton,
@@ -42,6 +43,8 @@ import CanvasSpinner from '../canvas-spinner';
 import { unlock } from '../../lock-unlock';
 import useEditedEntityRecord from '../use-edited-entity-record';
 import { SidebarFixedBottomSlot } from '../sidebar-edit-mode/sidebar-fixed-bottom';
+
+const { useGlobalStyle } = unlock( blockEditorPrivateApis );
 
 const interfaceLabels = {
 	/* translators: accessibility text for the editor content landmark region. */
@@ -160,9 +163,13 @@ export default function Editor( { isLoading } ) {
 	// action in <URlQueryController> from double-announcing.
 	useTitle( hasLoadedPost && title );
 
+	const [ textColor ] = useGlobalStyle( 'color.text' );
+
 	return (
 		<>
-			{ isLoading ? <CanvasSpinner /> : null }
+			{ isLoading ? (
+				<CanvasSpinner spinnerStyle={ { color: textColor } } />
+			) : null }
 			{ isEditMode && <WelcomeGuide /> }
 			<EntityProvider kind="root" type="site">
 				<EntityProvider

--- a/packages/edit-site/src/components/layout/index.js
+++ b/packages/edit-site/src/components/layout/index.js
@@ -26,6 +26,7 @@ import {
 	privateApis as commandsPrivateApis,
 } from '@wordpress/commands';
 import { store as preferencesStore } from '@wordpress/preferences';
+import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
 import { privateApis as routerPrivateApis } from '@wordpress/router';
 import { privateApis as coreCommandsPrivateApis } from '@wordpress/core-commands';
 
@@ -53,6 +54,7 @@ import { useIsSiteEditorLoading } from './hooks';
 const { useCommands } = unlock( coreCommandsPrivateApis );
 const { useCommandContext } = unlock( commandsPrivateApis );
 const { useLocation } = unlock( routerPrivateApis );
+const { useGlobalStyle } = unlock( blockEditorPrivateApis );
 
 const ANIMATION_DURATION = 0.5;
 
@@ -112,6 +114,8 @@ export default function Layout() {
 			? 'site-editor-edit'
 			: 'site-editor';
 	useCommandContext( commandContext );
+
+	const [ backgroundColor ] = useGlobalStyle( 'color.background' );
 
 	// Synchronizing the URL with the store value of canvasMode happens in an effect
 	// This condition ensures the component is only rendered after the synchronization happens
@@ -250,6 +254,9 @@ export default function Layout() {
 													}
 													isFullWidth={ isEditing }
 													oversizedClassName="edit-site-layout__resizable-frame-oversized"
+													innerContentStyle={ {
+														backgroundColor,
+													} }
 												>
 													<Editor
 														isLoading={

--- a/packages/edit-site/src/components/layout/index.js
+++ b/packages/edit-site/src/components/layout/index.js
@@ -116,6 +116,7 @@ export default function Layout() {
 	useCommandContext( commandContext );
 
 	const [ backgroundColor ] = useGlobalStyle( 'color.background' );
+	const [ gradientValue ] = useGlobalStyle( 'color.gradient' );
 
 	// Synchronizing the URL with the store value of canvasMode happens in an effect
 	// This condition ensures the component is only rendered after the synchronization happens
@@ -255,7 +256,9 @@ export default function Layout() {
 													isFullWidth={ isEditing }
 													oversizedClassName="edit-site-layout__resizable-frame-oversized"
 													innerContentStyle={ {
-														backgroundColor,
+														background:
+															gradientValue ??
+															backgroundColor,
 													} }
 												>
 													<Editor

--- a/packages/edit-site/src/components/resizable-frame/index.js
+++ b/packages/edit-site/src/components/resizable-frame/index.js
@@ -76,6 +76,7 @@ function ResizableFrame( {
 	isReady,
 	children,
 	oversizedClassName,
+	innerContentStyle,
 } ) {
 	const [ frameSize, setFrameSize ] = useState( {
 		width: '100%',
@@ -253,6 +254,7 @@ function ResizableFrame( {
 					borderRadius: isFullWidth ? 0 : 8,
 				} }
 				transition={ FRAME_TRANSITION }
+				style={ innerContentStyle }
 			>
 				{ children }
 			</motion.div>


### PR DESCRIPTION
## What?
This PR suggests that the site editor loading experience uses the global styles background color while loading. 

Previously, the site editor loading canvas would always appear in the same color as the sidebar, and as a consequence, after loading finished, the canvas sometimes appeared too abruptly to the user.

## Why?
This makes it a more natural experience as the site loading finishes and the editor canvas is presented.

Originally suggested by @mtias in a recent chat. 

## How?
We're just using the global styles background color and passing it to the resizable frame as a background color.

## Testing Instructions
* Go to the site editor
* Verify the loading screen uses the global styles background

### Testing Instructions for Keyboard
None

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/8436925/726f17f8-63d8-4017-a5fd-2e63c0fbd9ee


