### PR TITLE
Add 'Open CSS' command to the command centre

### DIFF
--- a/packages/edit-site/src/components/global-styles/ui.js
+++ b/packages/edit-site/src/components/global-styles/ui.js
@@ -260,7 +260,10 @@ function GlobalStylesEditorCanvasContainerLink() {
 			// Switching to any container other than revisions should
 			// redirect from the revisions screen to the root global styles screen.
 			goTo( '/' );
+		} else if ( editorCanvasContainerView === 'global-styles-css' ) {
+			goTo( '/css' );
 		}
+
 		// location?.path is not a dependency because we don't want to track it.
 		// Doing so will cause an infinite loop. We could abstract logic to avoid
 		// having to disable the check later.

--- a/packages/edit-site/src/hooks/commands/use-common-commands.js
+++ b/packages/edit-site/src/hooks/commands/use-common-commands.js
@@ -2,13 +2,14 @@
  * WordPress dependencies
  */
 import { useMemo } from '@wordpress/element';
-import { useDispatch } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { trash, backup, help, styles } from '@wordpress/icons';
 import { useCommandLoader, useCommand } from '@wordpress/commands';
 import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
 import { privateApis as routerPrivateApis } from '@wordpress/router';
 import { store as preferencesStore } from '@wordpress/preferences';
+import { store as coreStore } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
@@ -45,6 +46,59 @@ function useGlobalStylesResetCommands() {
 	};
 }
 
+function useGlobalStylesOpenCssCommands() {
+	const { openGeneralSidebar, setEditorCanvasContainerView } = unlock(
+		useDispatch( editSiteStore )
+	);
+	const history = useHistory();
+	const { canEditCSS } = useSelect( ( select ) => {
+		const { getEntityRecord, __experimentalGetCurrentGlobalStylesId } =
+			select( coreStore );
+
+		const globalStylesId = __experimentalGetCurrentGlobalStylesId();
+		const globalStyles = globalStylesId
+			? getEntityRecord( 'root', 'globalStyles', globalStylesId )
+			: undefined;
+
+		return {
+			canEditCSS:
+				!! globalStyles?._links?.[ 'wp:action-edit-css' ] ?? false,
+		};
+	}, [] );
+
+	const commands = useMemo( () => {
+		if ( ! canEditCSS ) {
+			return [];
+		}
+
+		return [
+			{
+				name: 'core/edit-site/open-styles-css',
+				label: __( 'Open CSS' ),
+				icon: styles,
+				callback: ( { close } ) => {
+					close();
+					history.push( {
+						path: '/wp_global_styles',
+						canvas: 'edit',
+					} );
+					openGeneralSidebar( 'edit-site/global-styles' );
+					setEditorCanvasContainerView( 'global-styles-css' );
+				},
+			},
+		];
+	}, [
+		history,
+		openGeneralSidebar,
+		setEditorCanvasContainerView,
+		canEditCSS,
+	] );
+	return {
+		isLoading: false,
+		commands,
+	};
+}
+
 export function useCommonCommands() {
 	const { openGeneralSidebar, setEditorCanvasContainerView } = unlock(
 		useDispatch( editSiteStore )
@@ -64,21 +118,6 @@ export function useCommonCommands() {
 			} );
 			openGeneralSidebar( 'edit-site/global-styles' );
 			setEditorCanvasContainerView( 'global-styles-revisions' );
-		},
-	} );
-
-	useCommand( {
-		name: 'core/edit-site/open-styles-css',
-		label: __( 'Open CSS' ),
-		icon: styles,
-		callback: ( { close } ) => {
-			close();
-			history.push( {
-				path: '/wp_global_styles',
-				canvas: 'edit',
-			} );
-			openGeneralSidebar( 'edit-site/global-styles' );
-			setEditorCanvasContainerView( 'global-styles-css' );
 		},
 	} );
 
@@ -119,5 +158,10 @@ export function useCommonCommands() {
 	useCommandLoader( {
 		name: 'core/edit-site/reset-global-styles',
 		hook: useGlobalStylesResetCommands,
+	} );
+
+	useCommandLoader( {
+		name: 'core/edit-site/open-styles-css',
+		hook: useGlobalStylesOpenCssCommands,
 	} );
 }

--- a/packages/edit-site/src/hooks/commands/use-common-commands.js
+++ b/packages/edit-site/src/hooks/commands/use-common-commands.js
@@ -68,6 +68,21 @@ export function useCommonCommands() {
 	} );
 
 	useCommand( {
+		name: 'core/edit-site/open-styles-css',
+		label: __( 'Open CSS' ),
+		icon: styles,
+		callback: ( { close } ) => {
+			close();
+			history.push( {
+				path: '/wp_global_styles',
+				canvas: 'edit',
+			} );
+			openGeneralSidebar( 'edit-site/global-styles' );
+			setEditorCanvasContainerView( 'global-styles-css' );
+		},
+	} );
+
+	useCommand( {
 		name: 'core/edit-site/open-styles',
 		label: __( 'Open styles' ),
 		callback: ( { close } ) => {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Add the 'Open CSS' command to the command centre when in the site-editor

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

One of the command centre ideas mentioned in https://github.com/WordPress/gutenberg/issues/51502

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

I've branched from @youknowriad's https://github.com/WordPress/gutenberg/pull/51637 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
 1. Open the site editor
 2. Open the command centre, e.g. with ⌘ + k
 3. Type 'CSS' 
 4. See the command appear in the list
 5. Choose the command
 6. Watch the 'Additional CSS' screen open.

### Post editor
Try it again in the post editor and see that it doesn't appear and you can't use it :)

### Without edit_css capabilities
Now try it again but as a user that does have access to the site editor, but doesn't have access to custom CSS.

Add a snippet like this:
```php
add_filter( 'map_meta_cap', 'no_css', 10, 2 );

function no_css( $caps, $cap ) {

	if ( 'edit_css' === $cap ) {
		$caps = array( 'do_not_allow' );
	}

	return $caps;
}
```

Now try try to run the steps again, you should notice that Open CSS doesn't show up in the command list, just as it doesn't show up in the GS sidebar & three-dot menu

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

As above

## Screenshots or screencast <!-- if applicable -->



https://github.com/WordPress/gutenberg/assets/93301/27cfef8d-4e20-4eb0-946f-addaf574055f

