### PR TITLE
Image block: Lightbox animation improvements

### DIFF
--- a/lib/block-supports/behaviors.php
+++ b/lib/block-supports/behaviors.php
@@ -88,6 +88,8 @@ function gutenberg_render_behaviors_support_lightbox( $block_content, $block ) {
 	$z = new WP_HTML_Tag_Processor( $content );
 	$z->next_tag( 'img' );
 
+	$img_srcset = '';
+
 	if ( isset( $block['attrs']['id'] ) ) {
 		$img_src      = wp_get_attachment_url( $block['attrs']['id'] );
 		$img_metadata = wp_get_attachment_metadata( $block['attrs']['id'] );
@@ -124,7 +126,7 @@ function gutenberg_render_behaviors_support_lightbox( $block_content, $block ) {
 			}',
 			$lightbox_animation,
 			$img_src,
-			$img_srcset ? $img_srcset : '',
+			$img_srcset,
 			$img_width,
 			$img_height
 		)

--- a/lib/block-supports/behaviors.php
+++ b/lib/block-supports/behaviors.php
@@ -89,16 +89,16 @@ function gutenberg_render_behaviors_support_lightbox( $block_content, $block ) {
 	$z->next_tag( 'img' );
 
 	if ( isset( $block['attrs']['id'] ) ) {
-		$img_src = wp_get_attachment_url( $block['attrs']['id'] );
+		$img_src      = wp_get_attachment_url( $block['attrs']['id'] );
 		$img_metadata = wp_get_attachment_metadata( $block['attrs']['id'] );
 		$img_width    = $img_metadata['width'];
 		$img_height   = $img_metadata['height'];
-		$img_srcset = wp_get_attachment_image_srcset( $block['attrs']['id'] );
+		$img_srcset   = wp_get_attachment_image_srcset( $block['attrs']['id'] );
 	} else {
-		$img_src = $z->get_attribute( 'src' );
+		$img_src        = $z->get_attribute( 'src' );
 		$img_dimensions = getimagesize( $img_src );
-		$img_width    	= $img_dimensions[0];
-		$img_height   	= $img_dimensions[1];
+		$img_width      = $img_dimensions[0];
+		$img_height     = $img_dimensions[1];
 	}
 
 	$w = new WP_HTML_Tag_Processor( $content );
@@ -124,7 +124,7 @@ function gutenberg_render_behaviors_support_lightbox( $block_content, $block ) {
 			}',
 			$lightbox_animation,
 			$img_src,
-			$img_srcset ?? '',
+			$img_srcset ? $img_srcset : '',
 			$img_width,
 			$img_height
 		)

--- a/lib/block-supports/behaviors.php
+++ b/lib/block-supports/behaviors.php
@@ -87,16 +87,19 @@ function gutenberg_render_behaviors_support_lightbox( $block_content, $block ) {
 	// We want to store the src in the context so we can set it dynamically when the lightbox is opened.
 	$z = new WP_HTML_Tag_Processor( $content );
 	$z->next_tag( 'img' );
-	$img_metadata = wp_get_attachment_metadata( $block['attrs']['id'] );
-	$img_width    = $img_metadata['width'];
-	$img_height   = $img_metadata['height'];
 
 	if ( isset( $block['attrs']['id'] ) ) {
 		$img_src = wp_get_attachment_url( $block['attrs']['id'] );
+		$img_metadata = wp_get_attachment_metadata( $block['attrs']['id'] );
+		$img_width    = $img_metadata['width'];
+		$img_height   = $img_metadata['height'];
+		$img_srcset = wp_get_attachment_image_srcset( $block['attrs']['id'] );
 	} else {
 		$img_src = $z->get_attribute( 'src' );
+		$img_dimensions = getimagesize( $img_src );
+		$img_width    	= $img_dimensions[0];
+		$img_height   	= $img_dimensions[1];
 	}
-	$img_srcset = wp_get_attachment_image_srcset( $block['attrs']['id'] );
 
 	$w = new WP_HTML_Tag_Processor( $content );
 	$w->next_tag( 'figure' );
@@ -121,7 +124,7 @@ function gutenberg_render_behaviors_support_lightbox( $block_content, $block ) {
 			}',
 			$lightbox_animation,
 			$img_src,
-			$img_srcset,
+			$img_srcset ?? '',
 			$img_width,
 			$img_height
 		)

--- a/lib/block-supports/behaviors.php
+++ b/lib/block-supports/behaviors.php
@@ -88,8 +88,6 @@ function gutenberg_render_behaviors_support_lightbox( $block_content, $block ) {
 	$z = new WP_HTML_Tag_Processor( $content );
 	$z->next_tag( 'img' );
 
-	$img_srcset = '';
-
 	if ( isset( $block['attrs']['id'] ) ) {
 		$img_src      = wp_get_attachment_url( $block['attrs']['id'] );
 		$img_metadata = wp_get_attachment_metadata( $block['attrs']['id'] );
@@ -101,6 +99,7 @@ function gutenberg_render_behaviors_support_lightbox( $block_content, $block ) {
 		$img_dimensions = getimagesize( $img_src );
 		$img_width      = $img_dimensions[0];
 		$img_height     = $img_dimensions[1];
+		$img_srcset     = '';
 	}
 
 	$w = new WP_HTML_Tag_Processor( $content );

--- a/lib/block-supports/behaviors.php
+++ b/lib/block-supports/behaviors.php
@@ -96,7 +96,7 @@ function gutenberg_render_behaviors_support_lightbox( $block_content, $block ) {
 		$img_srcset   = wp_get_attachment_image_srcset( $block['attrs']['id'] );
 	} else {
 		$img_src        = $z->get_attribute( 'src' );
-		$img_dimensions = getimagesize( $img_src );
+		$img_dimensions = wp_getimagesize( $img_src );
 		$img_width      = $img_dimensions[0];
 		$img_height     = $img_dimensions[1];
 		$img_srcset     = '';

--- a/lib/block-supports/behaviors.php
+++ b/lib/block-supports/behaviors.php
@@ -110,6 +110,7 @@ function gutenberg_render_behaviors_support_lightbox( $block_content, $block ) {
 					{ 	"initialized": false,
 						"lightboxEnabled": false,
 						"hideAnimationEnabled": false,
+						"preloadInitialized": false,
 						"lightboxAnimation": "%s",
 						"imageSrc": "%s",
 						"imageSrcSet": "%s",
@@ -131,7 +132,7 @@ function gutenberg_render_behaviors_support_lightbox( $block_content, $block ) {
 	$img = null;
 	preg_match( '/<img[^>]+>/', $content, $img );
 	$button       = '<div class="img-container">
-                             <button type="button" aria-haspopup="dialog" aria-label="' . esc_attr( $aria_label ) . '" data-wp-on--click="actions.core.image.showLightbox"></button>'
+                             <button type="button" aria-haspopup="dialog" aria-label="' . esc_attr( $aria_label ) . '" data-wp-on--click="actions.core.image.showLightbox" data-wp-effect="effects.core.image.preloadLightboxImage"></button>'
 		. $img[0] .
 		'</div>';
 	$body_content = preg_replace( '/<img[^>]+>/', $button, $body_content );

--- a/lib/block-supports/behaviors.php
+++ b/lib/block-supports/behaviors.php
@@ -145,6 +145,7 @@ function gutenberg_render_behaviors_support_lightbox( $block_content, $block ) {
 	$m->next_tag( 'figure' );
 	$m->add_class( 'responsive-image' );
 	$m->next_tag( 'img' );
+	$m->set_attribute( 'src', '' );
 	$m->set_attribute( 'data-wp-bind--src', 'selectors.core.image.responsiveImgSrc' );
 	$m->set_attribute( 'data-wp-bind--srcset', 'selectors.core.image.responsiveImgSrcSet' );
 	$initial_image_content = $m->get_updated_html();
@@ -153,6 +154,7 @@ function gutenberg_render_behaviors_support_lightbox( $block_content, $block ) {
 	$q->next_tag( 'figure' );
 	$q->add_class( 'enlarged-image' );
 	$q->next_tag( 'img' );
+	$q->set_attribute( 'src', '' );
 	$q->set_attribute( 'data-wp-bind--src', 'selectors.core.image.enlargedImgSrc' );
 	$enlarged_image_content = $q->get_updated_html();
 

--- a/packages/block-library/src/image/interactivity.js
+++ b/packages/block-library/src/image/interactivity.js
@@ -45,6 +45,7 @@ store( {
 					// Since the img is hidden and its src not loaded until
 					// the lightbox is opened, let's create an img element on the fly
 					// so we can get the dimensions we need to calculate the styles
+					context.core.image.preloadInitialized = true;
 					const imgDom = document.createElement( 'img' );
 					imgDom.onload = function () {
 						context.core.image.activateLargeImage = true;
@@ -154,6 +155,18 @@ store( {
 	effects: {
 		core: {
 			image: {
+				preloadLightboxImage: ( { context, ref } ) => {
+					ref.addEventListener( 'mouseover', () => {
+						if ( ! context.core.image.preloadInitialized ) {
+							context.core.image.preloadInitialized = true;
+							const imgDom = document.createElement( 'img' );
+							imgDom.setAttribute(
+								'src',
+								context.core.image.imageSrc
+							);
+						}
+					} );
+				},
 				initLightbox: async ( { context, ref } ) => {
 					context.core.image.figureRef =
 						ref.querySelector( 'figure' );

--- a/packages/block-library/src/image/interactivity.js
+++ b/packages/block-library/src/image/interactivity.js
@@ -27,25 +27,27 @@ store( {
 						window.document.activeElement;
 					context.core.image.scrollDelta = 0;
 
+					context.core.image.lightboxEnabled = true;
+					if ( context.core.image.lightboxAnimation === 'zoom' ) {
+						setZoomStyles(
+							event.target.nextElementSibling,
+							context,
+							event
+						);
+					}
+					// Hide overflow only when the animation is in progress,
+					// otherwise the removal of the scrollbars will draw attention
+					// to itself and look like an error
+					document.documentElement.classList.add(
+						'has-lightbox-open'
+					);
+
 					// Since the img is hidden and its src not loaded until
 					// the lightbox is opened, let's create an img element on the fly
 					// so we can get the dimensions we need to calculate the styles
 					const imgDom = document.createElement( 'img' );
-
 					imgDom.onload = function () {
-						// Enable the lightbox only after the image
-						// is loaded to prevent flashing of unstyled content
-						context.core.image.lightboxEnabled = true;
-						if ( context.core.image.lightboxAnimation === 'zoom' ) {
-							setZoomStyles( imgDom, context, event );
-						}
-
-						// Hide overflow only when the animation is in progress,
-						// otherwise the removal of the scrollbars will draw attention
-						// to itself and look like an error
-						document.documentElement.classList.add(
-							'has-lightbox-open'
-						);
+						context.core.image.activateLargeImage = true;
 					};
 					imgDom.setAttribute( 'src', context.core.image.imageSrc );
 				},
@@ -131,7 +133,17 @@ store( {
 				roleAttribute: ( { context } ) => {
 					return context.core.image.lightboxEnabled ? 'dialog' : '';
 				},
-				imageSrc: ( { context } ) => {
+				responsiveImgSrc: ( { context } ) => {
+					return context.core.image.activateLargeImage
+						? ''
+						: context.core.image.imageSrc;
+				},
+				responsiveImgSrcSet: ( { context } ) => {
+					return context.core.image.activateLargeImage
+						? ''
+						: context.core.image.imageSrcSet;
+				},
+				enlargedImgSrc: ( { context } ) => {
 					return context.core.image.initialized
 						? context.core.image.imageSrc
 						: '';
@@ -163,8 +175,8 @@ store( {
 } );
 
 function setZoomStyles( imgDom, context, event ) {
-	let targetWidth = imgDom.naturalWidth;
-	let targetHeight = imgDom.naturalHeight;
+	let targetWidth = context.core.image.targetWidth;
+	let targetHeight = context.core.image.targetHeight;
 
 	const verticalPadding = 40;
 

--- a/packages/block-library/src/image/interactivity.js
+++ b/packages/block-library/src/image/interactivity.js
@@ -135,14 +135,22 @@ store( {
 					return context.core.image.lightboxEnabled ? 'dialog' : '';
 				},
 				responsiveImgSrc: ( { context } ) => {
-					return context.core.image.activateLargeImage
-						? ''
-						: context.core.image.imageSrc;
+					if (
+						! context.core.image.initialized ||
+						context.core.image.activateLargeImage
+					) {
+						return '';
+					}
+					return context.core.image.imageSrc;
 				},
 				responsiveImgSrcSet: ( { context } ) => {
-					return context.core.image.activateLargeImage
-						? ''
-						: context.core.image.imageSrcSet;
+					if (
+						! context.core.image.initialized ||
+						context.core.image.activateLargeImage
+					) {
+						return '';
+					}
+					return context.core.image.imageSrcSet;
 				},
 				enlargedImgSrc: ( { context } ) => {
 					return context.core.image.initialized

--- a/test/e2e/specs/editor/blocks/image.spec.js
+++ b/test/e2e/specs/editor/blocks/image.spec.js
@@ -990,10 +990,7 @@ test.describe( 'Image - interactivity', () => {
 			const responsiveImage = lightbox.locator( '.responsive-image img' );
 			const enlargedImage = lightbox.locator( '.enlarged-image img' );
 
-			await expect( responsiveImage ).toHaveAttribute(
-				'src',
-				new RegExp( filename )
-			);
+			await expect( responsiveImage ).toHaveAttribute( 'src', '' );
 			await expect( enlargedImage ).toHaveAttribute( 'src', '' );
 
 			await page.getByRole( 'button', { name: 'Enlarge image' } ).click();
@@ -1185,7 +1182,7 @@ test.describe( 'Image - interactivity', () => {
 		const responsiveImage = lightbox.locator( '.responsive-image img' );
 		const enlargedImage = lightbox.locator( '.enlarged-image img' );
 
-		await expect( responsiveImage ).toHaveAttribute( 'src', imgUrl );
+		await expect( responsiveImage ).toHaveAttribute( 'src', '' );
 		await expect( enlargedImage ).toHaveAttribute( 'src', '' );
 
 		await page.getByRole( 'button', { name: 'Enlarge image' } ).click();

--- a/test/e2e/specs/editor/blocks/image.spec.js
+++ b/test/e2e/specs/editor/blocks/image.spec.js
@@ -990,7 +990,10 @@ test.describe( 'Image - interactivity', () => {
 			const responsiveImage = lightbox.locator( '.responsive-image img' );
 			const enlargedImage = lightbox.locator( '.enlarged-image img' );
 
-			await expect( responsiveImage ).toHaveAttribute( 'src', '' );
+			await expect( responsiveImage ).toHaveAttribute(
+				'src',
+				new RegExp( filename )
+			);
 			await expect( enlargedImage ).toHaveAttribute( 'src', '' );
 
 			await page.getByRole( 'button', { name: 'Enlarge image' } ).click();
@@ -1182,7 +1185,10 @@ test.describe( 'Image - interactivity', () => {
 		const responsiveImage = lightbox.locator( '.responsive-image img' );
 		const enlargedImage = lightbox.locator( '.enlarged-image img' );
 
-		await expect( responsiveImage ).toHaveAttribute( 'src', '' );
+		await expect( responsiveImage ).toHaveAttribute(
+			'src',
+			new RegExp( imgUrl )
+		);
 		await expect( enlargedImage ).toHaveAttribute( 'src', '' );
 
 		await page.getByRole( 'button', { name: 'Enlarge image' } ).click();

--- a/test/e2e/specs/editor/blocks/image.spec.js
+++ b/test/e2e/specs/editor/blocks/image.spec.js
@@ -987,13 +987,19 @@ test.describe( 'Image - interactivity', () => {
 
 			const lightbox = page.locator( '.wp-lightbox-overlay' );
 			await expect( lightbox ).toBeHidden();
-			const image = lightbox.locator( 'img' );
+			const responsiveImage = lightbox.locator( '.responsive-image img' );
+			const enlargedImage = lightbox.locator( '.enlarged-image img' );
 
-			await expect( image ).toHaveAttribute( 'src', '' );
+			await expect( responsiveImage ).toHaveAttribute(
+				'src',
+				new RegExp( filename )
+			);
+			await expect( enlargedImage ).toHaveAttribute( 'src', '' );
 
 			await page.getByRole( 'button', { name: 'Enlarge image' } ).click();
 
-			await expect( image ).toHaveAttribute(
+			await expect( responsiveImage ).toHaveAttribute( 'src', '' );
+			await expect( enlargedImage ).toHaveAttribute(
 				'src',
 				new RegExp( filename )
 			);
@@ -1176,12 +1182,16 @@ test.describe( 'Image - interactivity', () => {
 		await page.goto( `/?p=${ postId }` );
 
 		const lightbox = page.locator( '.wp-lightbox-overlay' );
-		const imageDom = lightbox.locator( 'img' );
-		await expect( imageDom ).toHaveAttribute( 'src', '' );
+		const responsiveImage = lightbox.locator( '.responsive-image img' );
+		const enlargedImage = lightbox.locator( '.enlarged-image img' );
+
+		await expect( responsiveImage ).toHaveAttribute( 'src', imgUrl );
+		await expect( enlargedImage ).toHaveAttribute( 'src', '' );
 
 		await page.getByRole( 'button', { name: 'Enlarge image' } ).click();
 
-		await expect( imageDom ).toHaveAttribute( 'src', imgUrl );
+		await expect( responsiveImage ).toHaveAttribute( 'src', '' );
+		await expect( enlargedImage ).toHaveAttribute( 'src', imgUrl );
 	} );
 } );
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
This PR will do the following in order to improve the UX around the lightbox animation:
1. On click, use the existing image if the full one hasn't loaded yet
2. Once the new one has loaded, replace it
3. Preload the full image on hover


## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Addresses #51555
Currently, there is a delay when the user clicks on an image to activate the lightbox. This will improve that experience.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
I've edited the code so that we now have two `img` elements inside of the lightbox. The lower resolution one is a copy of the image inside of the body content; there is also a larger resolution one whose `src` attribute is populated dynamically when when the lightbox is opened and the full-sized image finishes loading.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
*Must be tested on a live site (not a local environment)
1. Make sure the Interactivity API experiments are enabled
2. Add an image block to a post and activate the lightbox under Advanced > Behaviors in the block settings
3. Publish the post and click on the image
4. The lightbox should respond immediately
5. If you'd like, you can inspect the source to ensure the high resolution image is the one being displayed in the lightbox

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
N/A

## Screenshots or screencast <!-- if applicable -->

### Before

https://github.com/WordPress/gutenberg/assets/5360536/b030b40a-8dbc-477f-a064-8a778c829dd5

### After

https://github.com/WordPress/gutenberg/assets/5360536/812ada30-a008-4bb7-a6d8-16ed9020558e