### PR TITLE
ListView: Try showing blocks that are dragged (no longer hide them)

### DIFF
--- a/packages/block-editor/src/components/list-view/branch.js
+++ b/packages/block-editor/src/components/list-view/branch.js
@@ -207,7 +207,7 @@ function ListViewBranch( props ) {
 								listPosition={ nextPosition + 1 }
 								fixedListWindow={ fixedListWindow }
 								isBranchSelected={ isSelectedBranch }
-								isBranchDragged={ isDragged }
+								isBranchDragged={ isDragged || isBranchDragged }
 								selectedClientIds={ selectedClientIds }
 								isExpanded={ isExpanded }
 								isSyncedBranch={ syncedBranch }

--- a/packages/block-editor/src/components/list-view/branch.js
+++ b/packages/block-editor/src/components/list-view/branch.js
@@ -91,6 +91,7 @@ function ListViewBranch( props ) {
 		selectedClientIds,
 		level = 1,
 		path = '',
+		isBranchDragged = false,
 		isBranchSelected = false,
 		listPosition = 0,
 		fixedListWindow,
@@ -167,7 +168,8 @@ function ListViewBranch( props ) {
 				);
 				const isSelectedBranch =
 					isBranchSelected || ( isSelected && hasNestedBlocks );
-				const showBlock = isDragged || blockInView || isSelected;
+				const showBlock =
+					isDragged || blockInView || isSelected || isBranchDragged;
 				return (
 					<AsyncModeProvider key={ clientId } value={ ! isSelected }>
 						{ showBlock && (
@@ -176,7 +178,7 @@ function ListViewBranch( props ) {
 								selectBlock={ selectBlock }
 								isSelected={ isSelected }
 								isBranchSelected={ isSelectedBranch }
-								isDragged={ isDragged }
+								isDragged={ isDragged || isBranchDragged }
 								level={ level }
 								position={ position }
 								rowCount={ rowCount }
@@ -194,7 +196,7 @@ function ListViewBranch( props ) {
 								<td className="block-editor-list-view-placeholder" />
 							</tr>
 						) }
-						{ hasNestedBlocks && shouldExpand && ! isDragged && (
+						{ hasNestedBlocks && shouldExpand && (
 							<ListViewBranch
 								parentId={ clientId }
 								blocks={ innerBlocks }
@@ -205,6 +207,7 @@ function ListViewBranch( props ) {
 								listPosition={ nextPosition + 1 }
 								fixedListWindow={ fixedListWindow }
 								isBranchSelected={ isSelectedBranch }
+								isBranchDragged={ isDragged }
 								selectedClientIds={ selectedClientIds }
 								isExpanded={ isExpanded }
 								isSyncedBranch={ syncedBranch }

--- a/packages/block-editor/src/components/list-view/style.scss
+++ b/packages/block-editor/src/components/list-view/style.scss
@@ -80,10 +80,6 @@
 		box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) $white;
 	}
 
-	&.is-dragging {
-		opacity: 0.5;
-	}
-
 	// Border radius for corners of the selected item.
 	&.is-first-selected td:first-child {
 		border-top-left-radius: $radius-block-ui;

--- a/packages/block-editor/src/components/list-view/style.scss
+++ b/packages/block-editor/src/components/list-view/style.scss
@@ -25,7 +25,9 @@
 		&:hover {
 			color: var(--wp-admin-theme-color);
 		}
+	}
 
+	&:not(.is-selected) .block-editor-list-view-block-select-button {
 		// While components are being dragged, ensure that hover styles are not applied.
 		// This resolves a bug where while dragging, the hover styles would be applied to
 		// the wrong list item while scrolling long lists, particularly in Chrome.

--- a/packages/block-editor/src/components/list-view/style.scss
+++ b/packages/block-editor/src/components/list-view/style.scss
@@ -80,6 +80,10 @@
 		box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) $white;
 	}
 
+	&.is-dragging {
+		opacity: 0.5;
+	}
+
 	// Border radius for corners of the selected item.
 	&.is-first-selected td:first-child {
 		border-top-left-radius: $radius-block-ui;

--- a/packages/block-editor/src/components/list-view/style.scss
+++ b/packages/block-editor/src/components/list-view/style.scss
@@ -30,7 +30,9 @@
 		// This resolves a bug where while dragging, the hover styles would be applied to
 		// the wrong list item while scrolling long lists, particularly in Chrome.
 		.is-dragging-components-draggable & {
-			color: inherit;
+			&:hover {
+				color: inherit;
+			}
 		}
 	}
 

--- a/packages/block-editor/src/components/list-view/style.scss
+++ b/packages/block-editor/src/components/list-view/style.scss
@@ -25,6 +25,13 @@
 		&:hover {
 			color: var(--wp-admin-theme-color);
 		}
+
+		// While components are being dragged, ensure that hover styles are not applied.
+		// This resolves a bug where while dragging, the hover styles would be applied to
+		// the wrong list item while scrolling long lists, particularly in Chrome.
+		.is-dragging-components-draggable & {
+			color: inherit;
+		}
 	}
 
 	// The background has to be applied to the td, not tr, or border-radius won't work.
@@ -67,10 +74,6 @@
 	}
 	&.is-selected .block-editor-list-view-block__menu:focus {
 		box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) $white;
-	}
-
-	&.is-dragging {
-		opacity: 0.5;
 	}
 
 	// Border radius for corners of the selected item.

--- a/packages/block-editor/src/components/list-view/style.scss
+++ b/packages/block-editor/src/components/list-view/style.scss
@@ -51,13 +51,6 @@
 	&.is-selected .components-button.has-icon {
 		color: $white;
 	}
-	&.is-selected .block-editor-list-view-block-contents {
-		// Hide selection styles while a user is dragging blocks/files etc.
-		.is-dragging-components-draggable & {
-			background: none;
-			color: $gray-900;
-		}
-	}
 	&.is-selected .block-editor-list-view-block-contents:focus {
 		&::after {
 			box-shadow:
@@ -77,7 +70,7 @@
 	}
 
 	&.is-dragging {
-		display: none;
+		opacity: 0.5;
 	}
 
 	// Border radius for corners of the selected item.

--- a/packages/block-editor/src/components/list-view/use-list-view-drop-zone.js
+++ b/packages/block-editor/src/components/list-view/use-list-view-drop-zone.js
@@ -434,6 +434,8 @@ export default function useListViewDropZone( { dropZoneElement } ) {
 				const blocksData = blockElements.map( ( blockElement ) => {
 					const clientId = blockElement.dataset.block;
 					const isExpanded = blockElement.dataset.expanded === 'true';
+					const isDraggedBlock =
+						blockElement.classList.contains( 'is-dragging' );
 
 					// Get nesting level from `aria-level` attribute because Firefox does not support `element.ariaLevel`.
 					const nestingLevel = parseInt(
@@ -449,9 +451,7 @@ export default function useListViewDropZone( { dropZoneElement } ) {
 						blockIndex: getBlockIndex( clientId ),
 						element: blockElement,
 						nestingLevel: nestingLevel || undefined,
-						isDraggedBlock: isBlockDrag
-							? draggedBlockClientIds.includes( clientId )
-							: false,
+						isDraggedBlock: isBlockDrag ? isDraggedBlock : false,
 						innerBlockCount: getBlockCount( clientId ),
 						canInsertDraggedBlocksAsSibling: isBlockDrag
 							? canInsertBlocks(


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This PR explores an idea from @jameskoster in https://github.com/WordPress/gutenberg/issues/49563#issuecomment-1511090660 to try displaying blocks in the list view that are dragged.

❓ Note: this is an experimental PR exploring an idea — I'm not too sure what I think of it all up, so happy to either pursue it or close it, either way 😃

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

To see whether this results in less of a jump or friction while using the lift view drag and drop.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* Remove the `display: none` rule for dragged blocks in the list view
* Ensure that children of dragged blocks continue to render
* Override hover styles while dragging blocks so that hover styles don't erroneously appear while dragging / scrolling the list view

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

With some nested blocks in a post or template, try dragging around some expanded blocks. You should see that the block you're dragging is no longer hidden.

How does it feel? Especially when dragging a big selection — is it easier, or harder with the blocks displayed?

Note: if we like this approach, we might need to adjust some styling in other places the list view is used (e.g. in Navigation in browse mode, where currently the opacity rule doesn't change much)

## Screenshots or screencast <!-- if applicable -->

Here's a screengrab of a bit of drag and dropping to see how it might feel:

https://github.com/WordPress/gutenberg/assets/14988353/5dd0def8-c952-41ff-80b3-130261eec110