### PR TITLE
Fix back button tooltip

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen/index.js
@@ -60,8 +60,8 @@ export default function SidebarNavigationScreen( {
 					{ ! isRoot && ! backPath && (
 						<NavigatorToParentButton
 							as={ SidebarButton }
-							icon={ icon }
-							label={ __( 'Back' ) }
+							icon={ isRTL() ? chevronRight : chevronLeft }
+							aria-label={ __( 'Back' ) }
 						/>
 					) }
 					{ ! isRoot && backPath && (


### PR DESCRIPTION
## What?

Fix an issue where when navigating the site view, the a "Back" tooltip sits around the back button despite the mouse being nowhere near:

![before](https://github.com/WordPress/gutenberg/assets/1204802/949b582c-bdf9-44e8-8ff8-020d25343d41)

## Why?

To add consistency with Global Styles:

![back-button](https://github.com/WordPress/gutenberg/assets/1204802/b0c6c8ed-8019-4b5f-8b34-de8abada9f9a)

Here's after:

![after](https://github.com/WordPress/gutenberg/assets/1204802/7f6e7016-709f-4222-a47d-f0f27bc2c613)

## Testing Instructions

Test navigating the site view and observe that tooltips lingering.