### PR TITLE
Lodash: Remove completely from `@wordpress/style-engine` package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18678,8 +18678,7 @@
 			"version": "file:packages/style-engine",
 			"requires": {
 				"@babel/runtime": "^7.16.0",
-				"change-case": "^4.1.2",
-				"lodash": "^4.17.21"
+				"change-case": "^4.1.2"
 			}
 		},
 		"@wordpress/stylelint-config": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -18678,6 +18678,7 @@
 			"version": "file:packages/style-engine",
 			"requires": {
 				"@babel/runtime": "^7.16.0",
+				"change-case": "^4.1.2",
 				"lodash": "^4.17.21"
 			}
 		},

--- a/packages/style-engine/package.json
+++ b/packages/style-engine/package.json
@@ -30,8 +30,7 @@
 	"sideEffects": false,
 	"dependencies": {
 		"@babel/runtime": "^7.16.0",
-		"change-case": "^4.1.2",
-		"lodash": "^4.17.21"
+		"change-case": "^4.1.2"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/style-engine/package.json
+++ b/packages/style-engine/package.json
@@ -30,6 +30,7 @@
 	"sideEffects": false,
 	"dependencies": {
 		"@babel/runtime": "^7.16.0",
+		"change-case": "^4.1.2",
 		"lodash": "^4.17.21"
 	},
 	"publishConfig": {

--- a/packages/style-engine/src/index.ts
+++ b/packages/style-engine/src/index.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { kebabCase } from 'lodash';
+import { paramCase as kebabCase } from 'change-case';
 
 /**
  * Internal dependencies

--- a/packages/style-engine/src/styles/utils.ts
+++ b/packages/style-engine/src/styles/utils.ts
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { paramCase as kebabCase } from 'change-case';
-import { get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -21,6 +20,25 @@ import {
 } from './constants';
 
 /**
+ * Helper util to return a value from a certain path of the object.
+ * Path is specified as an array of properties, like `[ 'x', 'y' ]`.
+ *
+ * @param object Input object.
+ * @param path   Path to the object property.
+ * @return Value of the object property at the specified path.
+ */
+export const getStyleValueByPath = (
+	object: Record< any, any >,
+	path: string[]
+) => {
+	let value: any = object;
+	path.forEach( ( fieldName: string ) => {
+		value = value?.[ fieldName ];
+	} );
+	return value;
+};
+
+/**
  * Returns a JSON representation of the generated CSS rules.
  *
  * @param style   Style object.
@@ -36,7 +54,7 @@ export function generateRule(
 	path: string[],
 	ruleKey: string
 ): GeneratedCSSRule[] {
-	const styleValue: string | undefined = get( style, path );
+	const styleValue: string | undefined = getStyleValueByPath( style, path );
 
 	return styleValue
 		? [
@@ -67,7 +85,10 @@ export function generateBoxRules(
 	ruleKeys: CssRulesKeys,
 	individualProperties: string[] = [ 'top', 'right', 'bottom', 'left' ]
 ): GeneratedCSSRule[] {
-	const boxStyle: Box | string | undefined = get( style, path );
+	const boxStyle: Box | string | undefined = getStyleValueByPath(
+		style,
+		path
+	);
 	if ( ! boxStyle ) {
 		return [];
 	}
@@ -83,7 +104,7 @@ export function generateBoxRules(
 		const sideRules = individualProperties.reduce(
 			( acc: GeneratedCSSRule[], side: string ) => {
 				const value: string | undefined = getCSSVarFromStyleValue(
-					get( boxStyle, [ side ] )
+					getStyleValueByPath( boxStyle, [ side ] )
 				);
 				if ( value ) {
 					acc.push( {

--- a/packages/style-engine/src/styles/utils.ts
+++ b/packages/style-engine/src/styles/utils.ts
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import { get, kebabCase } from 'lodash';
+import { paramCase as kebabCase } from 'change-case';
+import { get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -119,7 +120,16 @@ export function getCSSVarFromStyleValue( styleValue: string ): string {
 		const variable = styleValue
 			.slice( VARIABLE_REFERENCE_PREFIX.length )
 			.split( VARIABLE_PATH_SEPARATOR_TOKEN_ATTRIBUTE )
-			.map( ( presetVariable ) => kebabCase( presetVariable ) )
+			.map( ( presetVariable ) =>
+				kebabCase( presetVariable, {
+					splitRegexp: [
+						/([a-z0-9])([A-Z])/g, // fooBar => foo-bar, 3Bar => 3-bar
+						/([0-9])([a-z])/g, // 3bar => 3-bar
+						/([A-Za-z])([0-9])/g, // Foo3 => foo-3, foo3 => foo-3
+						/([A-Z])([A-Z][a-z])/g, // FOOBar => foo-bar
+					],
+				} )
+			)
 			.join( VARIABLE_PATH_SEPARATOR_TOKEN_STYLE );
 		return `var(--wp--${ variable })`;
 	}

--- a/packages/style-engine/src/test/utils.js
+++ b/packages/style-engine/src/test/utils.js
@@ -33,10 +33,30 @@ describe( 'utils', () => {
 			).toEqual( 'var(--wp--preset--font-size--h-1)' );
 		} );
 
+		it( 'should kebab case numbers as prefix', () => {
+			expect(
+				getCSSVarFromStyleValue( 'var:preset|font-size|1px' )
+			).toEqual( 'var(--wp--preset--font-size--1-px)' );
+		} );
+
+		it( 'should kebab case both sides of numbers', () => {
+			expect(
+				getCSSVarFromStyleValue( 'var:preset|color|orange11orange' )
+			).toEqual( 'var(--wp--preset--color--orange-11-orange)' );
+		} );
+
 		it( 'should kebab case camel case', () => {
 			expect(
 				getCSSVarFromStyleValue( 'var:preset|color|heavenlyBlue' )
 			).toEqual( 'var(--wp--preset--color--heavenly-blue)' );
+		} );
+
+		it( 'should kebab case underscores', () => {
+			expect(
+				getCSSVarFromStyleValue(
+					'var:preset|background|dark_Secrets_100'
+				)
+			).toEqual( 'var(--wp--preset--background--dark-secrets-100)' );
 		} );
 	} );
 } );


### PR DESCRIPTION
## What?
This PR refactors the `@wordpress/style-engine` package away from Lodash completely. There are just a few usages of `_.get()` and `_.kebabCase()`.

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?

* We're adding a straightforward custom inline utility to replace `_.get()`.
* We're using `paramCase` from `change-case` instead of `kebabCase`, which we've already been utilizing across the repository. 

## Testing Instructions

* Add a paragraph block, insert a link to it, add custom link styles for regular and hover states, and verify that the custom styles still work.
* Add some more custom styles - typography, dimensions, colors, etc and verify they still work as before.
* Verify all checks are green - some of the changes are covered by tests.