### PR TITLE
Fix flakiness of saving entities in the site editor

### DIFF
--- a/packages/e2e-test-utils-playwright/src/editor/site-editor.ts
+++ b/packages/e2e-test-utils-playwright/src/editor/site-editor.ts
@@ -24,10 +24,8 @@ export async function saveSiteEditorEntities( this: Editor ) {
 		.getByRole( 'button', { name: 'Save', exact: true } )
 		.click();
 
-	// A role selector cannot be used here because it needs to check that the `is-busy` class is not present.
 	await this.page
-		.locator( '[aria-label="Editor top bar"] [aria-label="Saved"].is-busy' )
-		.waitFor( {
-			state: 'hidden',
-		} );
+		.getByRole( 'button', { name: 'Dismiss this notice' } )
+		.getByText( 'Site updated.' )
+		.waitFor();
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Save flakiness of saving entities in the site editor e2e tests.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
I've been noticing some flakiness when running the `template-part` e2e tests in the site editor (especially `can detach blocks from a template part`).

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Instead of waiting for a CSS class, which is an implementation detail, we wait for a notice snackbar instead.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
CI should pass.