### PR TITLE
Top toolbar: Refine the icons on the right.

### DIFF
--- a/packages/block-editor/src/components/preview-options/index.js
+++ b/packages/block-editor/src/components/preview-options/index.js
@@ -18,6 +18,7 @@ export default function PreviewOptions( {
 	isEnabled = true,
 	deviceType,
 	setDeviceType,
+	label,
 } ) {
 	const isMobile = useViewportMatch( 'small', '<' );
 	if ( isMobile ) return null;
@@ -30,7 +31,6 @@ export default function PreviewOptions( {
 		placement: 'bottom-end',
 	};
 	const toggleProps = {
-		variant: 'tertiary',
 		className: 'block-editor-post-preview__button-toggle',
 		disabled: ! isEnabled,
 		children: viewLabel,
@@ -52,6 +52,7 @@ export default function PreviewOptions( {
 			toggleProps={ toggleProps }
 			menuProps={ menuProps }
 			icon={ deviceIcons[ deviceType.toLowerCase() ] }
+			label={ label || __( 'Preview' ) }
 		>
 			{ () => (
 				<>

--- a/packages/edit-post/src/components/device-preview/index.js
+++ b/packages/edit-post/src/components/device-preview/index.js
@@ -44,8 +44,7 @@ export default function DevicePreview() {
 			className="edit-post-post-preview-dropdown"
 			deviceType={ deviceType }
 			setDeviceType={ setPreviewDeviceType }
-			/* translators: button label text should, if possible, be under 16 characters. */
-			viewLabel={ __( 'Preview' ) }
+			label={ __( 'Preview' ) }
 		>
 			{ isViewable && (
 				<MenuGroup>

--- a/packages/edit-post/src/components/header/index.js
+++ b/packages/edit-post/src/components/header/index.js
@@ -86,12 +86,12 @@ function Header( { setEntitiesSavedStatesCallback } ) {
 						showIconLabels={ showIconLabels }
 					/>
 				) }
-				<ViewLink />
 				<DevicePreview />
 				<PostPreviewButton
 					forceIsAutosaveable={ hasActiveMetaboxes }
 					forcePreviewLink={ isSaving ? null : undefined }
 				/>
+				<ViewLink />
 				<PostPublishButtonOrToggle
 					forceIsDirty={ hasActiveMetaboxes }
 					forceIsSaving={ isSaving }

--- a/packages/edit-site/src/components/header-edit-mode/index.js
+++ b/packages/edit-site/src/components/header-edit-mode/index.js
@@ -269,8 +269,7 @@ export default function HeaderEditMode() {
 							<PreviewOptions
 								deviceType={ deviceType }
 								setDeviceType={ setPreviewDeviceType }
-								/* translators: button label text should, if possible, be under 16 characters. */
-								viewLabel={ __( 'View' ) }
+								label={ __( 'View' ) }
 							>
 								<MenuGroup>
 									<MenuItem


### PR DESCRIPTION
## What?
<!-- In a few words, what is the PR actually doing? -->
Refine the icons on the right of the top toolbar for the post and site editor context. Changing the preview dropdown to use the icon with the label, and changing the style to match the others (removing `is-tertiary`).

Fixes https://github.com/WordPress/gutenberg/issues/51006

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

As reported in https://github.com/WordPress/gutenberg/issues/51006 we're looking to refine the icons, unifying styles and re-arranging order.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

**Post/page editor context.**

1. Go to the new post/page screen.
2. Confirm that the styles and arrangement of the buttons/icons are in line with what was described in https://github.com/WordPress/gutenberg/issues/51006 (Note: Check [this comment](https://github.com/WordPress/gutenberg/issues/51006#issuecomment-1598623687) to understand why is that we're keeping the trunk behavior for the "view" button in draft mode)

**Site editor context**

1. Go to the site editor.
2. Enter edit mode, and Confirm that the styles and arrangement of the buttons/icons are in line with what was described in https://github.com/WordPress/gutenberg/issues/51006

## Screenshots or screencast <!-- if applicable -->

**Post/page editor context**

https://github.com/WordPress/gutenberg/assets/252415/1c34af8f-d828-45b5-834f-eb8bac396983

**Site editor context**

https://github.com/WordPress/gutenberg/assets/252415/f21254a0-7f93-4f66-8dd0-517a104360ca





