### PR TITLE
Edit Site: Remove first loading spinner

### DIFF
--- a/packages/edit-site/src/components/global-styles/global-styles-provider.js
+++ b/packages/edit-site/src/components/global-styles/global-styles-provider.js
@@ -15,7 +15,6 @@ import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
 /**
  * Internal dependencies
  */
-import CanvasSpinner from '../canvas-spinner';
 import { unlock } from '../../lock-unlock';
 
 const { GlobalStylesContext, cleanEmptyObject } = unlock(
@@ -152,7 +151,7 @@ function useGlobalStylesContext() {
 export function GlobalStylesProvider( { children } ) {
 	const context = useGlobalStylesContext();
 	if ( ! context.isReady ) {
-		return <CanvasSpinner />;
+		return null;
 	}
 
 	return (


### PR DESCRIPTION
## What?
This PR suggests removing the first loading spinner as discussed in https://github.com/WordPress/gutenberg/pull/51709#discussion_r1236791615

## Why?
In #51709 we're polishing the current loading experience by altering it to resemble the canvas color scheme. However, the initial loading spinner conflicts with that, so I think it's better if we just remove it.

## How?
We're no longer displaying the additional spinner.

## Testing Instructions
* Open the site editor
* Verify that there's no full-page spinner.
* Verify that the canvas spinner still appears.

### Testing Instructions for Keyboard
None

## Screenshots or screencast <!-- if applicable -->

Before (with an additional loading spinner in the beginning):

https://github.com/WordPress/gutenberg/assets/8436925/ca6df065-09d1-4ece-888c-ac1e15f06297

After (with no additional loading spinner in the beginning)

https://github.com/WordPress/gutenberg/assets/8436925/0f446ecc-97f3-488b-8da1-b3a84685410d
