### PR TITLE
Keyboard Shortcut: Clean up shortcut names

### DIFF
--- a/packages/customize-widgets/src/components/keyboard-shortcuts/index.js
+++ b/packages/customize-widgets/src/components/keyboard-shortcuts/index.js
@@ -127,7 +127,7 @@ function KeyboardShortcutsRegister() {
 		} );
 
 		registerShortcut( {
-			name: `core/customize-widgets/transform-heading-to-paragraph`,
+			name: 'core/customize-widgets/transform-heading-to-paragraph',
 			category: 'block-library',
 			description: __( 'Transform heading to paragraph.' ),
 			keyCombination: {

--- a/packages/edit-post/src/components/keyboard-shortcuts/index.js
+++ b/packages/edit-post/src/components/keyboard-shortcuts/index.js
@@ -184,7 +184,7 @@ function KeyboardShortcuts() {
 		} );
 
 		registerShortcut( {
-			name: `core/edit-post/transform-heading-to-paragraph`,
+			name: 'core/edit-post/transform-heading-to-paragraph',
 			category: 'block-library',
 			description: __( 'Transform heading to paragraph.' ),
 			keyCombination: {

--- a/packages/edit-site/src/components/keyboard-shortcuts/register.js
+++ b/packages/edit-site/src/components/keyboard-shortcuts/register.js
@@ -129,7 +129,7 @@ function KeyboardShortcutsRegister() {
 		} );
 
 		registerShortcut( {
-			name: `core/edit-site/transform-heading-to-paragraph`,
+			name: 'core/edit-site/transform-heading-to-paragraph',
 			category: 'block-library',
 			description: __( 'Transform heading to paragraph.' ),
 			keyCombination: {

--- a/packages/edit-widgets/src/components/keyboard-shortcuts/index.js
+++ b/packages/edit-widgets/src/components/keyboard-shortcuts/index.js
@@ -70,7 +70,7 @@ function KeyboardShortcuts() {
 	} );
 
 	useShortcut(
-		'core/edit-widgets//transform-heading-to-paragraph',
+		'core/edit-widgets/transform-heading-to-paragraph',
 		( event ) => handleTextLevelShortcut( event, 0 )
 	);
 
@@ -79,7 +79,7 @@ function KeyboardShortcuts() {
 		//the hook will execute the same way every time
 		//eslint-disable-next-line react-hooks/rules-of-hooks
 		useShortcut(
-			`core/edit-widgets//transform-paragraph-to-heading-${ level }`,
+			`core/edit-widgets/transform-paragraph-to-heading-${ level }`,
 			( event ) => handleTextLevelShortcut( event, level )
 		);
 	} );
@@ -180,7 +180,7 @@ function KeyboardShortcutsRegister() {
 		} );
 
 		registerShortcut( {
-			name: `core/edit-widgets//transform-heading-to-paragraph`,
+			name: 'core/edit-widgets/transform-heading-to-paragraph',
 			category: 'block-library',
 			description: __( 'Transform heading to paragraph.' ),
 			keyCombination: {
@@ -191,7 +191,7 @@ function KeyboardShortcutsRegister() {
 
 		[ 1, 2, 3, 4, 5, 6 ].forEach( ( level ) => {
 			registerShortcut( {
-				name: `core/edit-widgets//transform-paragraph-to-heading-${ level }`,
+				name: `core/edit-widgets/transform-paragraph-to-heading-${ level }`,
 				category: 'block-library',
 				description: __( 'Transform paragraph to heading.' ),
 				keyCombination: {


### PR DESCRIPTION
## What?
This PR makes the following two changes to shortcuts registered by `registerShortcut`.

- Change unnecessary backslash to single quote in the `name` property.
- Changed double slash to single slash in the `name` property

## Why?
For code quality improvement.

### Testing Instructions for Keyboard

There should be no impact on the code, but condfirm that the shortcut for switching between paragraph and heading works in all of the following editors.

- Post Editor
- Site Editor
- Widget Editor
- Customize widget editor