### PR TITLE
Edit Site: Make admin background consistent with layout

### DIFF
--- a/packages/edit-site/src/style.scss
+++ b/packages/edit-site/src/style.scss
@@ -66,6 +66,10 @@ body.site-editor-php {
 	@include wp-admin-reset(".edit-site");
 }
 
+body.site-editor-php {
+	background: $gray-900;
+}
+
 .edit-site,
 // The modals are shown outside the .edit-site wrapper, they need these styles.
 .components-modal__frame {


### PR DESCRIPTION
## What?
This PR updates the wp-admin background on the site editor page consistent with the site editor layout background.

## Why?
Currently, there are a few milliseconds of white flickering going on while loading the site editor, and it makes the site editor loading experience a bit clunky. 

## How?
This issue gets resolved by using the same background color as the site editor layout.

## Testing Instructions
* Open the site editor.
* Refresh the page.
* Verify that the background before the site editor frame layout is the same color.

### Testing Instructions for Keyboard
None

## Screenshots or screencast <!-- if applicable -->

**Before:**

https://github.com/WordPress/gutenberg/assets/8436925/2db6cc70-d185-4187-9944-7aa1b4538f26



**After:**

https://github.com/WordPress/gutenberg/assets/8436925/7cf88b54-cc99-48cd-82d2-d4493707ee63



