### PR TITLE
Site Editor: Make string to add Template parts & Patterns consistent and translatable

### DIFF
--- a/packages/edit-site/src/components/add-new-pattern/index.js
+++ b/packages/edit-site/src/components/add-new-pattern/index.js
@@ -58,12 +58,12 @@ export default function AddNewPattern() {
 					{
 						icon: header,
 						onClick: () => setShowTemplatePartModal( true ),
-						title: 'Create a template part',
+						title: __( 'Create a template part' ),
 					},
 					{
 						icon: file,
 						onClick: () => setShowPatternModal( true ),
-						title: 'Create a pattern',
+						title: __( 'Create a pattern' ),
 					},
 				] }
 				icon={
@@ -72,7 +72,7 @@ export default function AddNewPattern() {
 						label={ __( 'Create a pattern' ) }
 					/>
 				}
-				label="Create a pattern."
+				label={ __( 'Create a pattern.' ) }
 			/>
 			{ showPatternModal && (
 				<CreatePatternModal

--- a/packages/edit-site/src/components/add-new-pattern/index.js
+++ b/packages/edit-site/src/components/add-new-pattern/index.js
@@ -58,21 +58,21 @@ export default function AddNewPattern() {
 					{
 						icon: header,
 						onClick: () => setShowTemplatePartModal( true ),
-						title: __( 'Create a template part' ),
+						title: __( 'Create template part' ),
 					},
 					{
 						icon: file,
 						onClick: () => setShowPatternModal( true ),
-						title: __( 'Create a pattern' ),
+						title: __( 'Create pattern' ),
 					},
 				] }
 				icon={
 					<SidebarButton
 						icon={ plus }
-						label={ __( 'Create a pattern' ) }
+						label={ __( 'Create pattern' ) }
 					/>
 				}
-				label={ __( 'Create a pattern.' ) }
+				label={ __( 'Create pattern.' ) }
 			/>
 			{ showPatternModal && (
 				<CreatePatternModal

--- a/packages/edit-site/src/components/create-pattern-modal/index.js
+++ b/packages/edit-site/src/components/create-pattern-modal/index.js
@@ -73,7 +73,7 @@ export default function CreatePatternModal( {
 
 	return (
 		<Modal
-			title={ __( 'Create a pattern' ) }
+			title={ __( 'Create pattern' ) }
 			onRequestClose={ closeModal }
 			overlayClassName="edit-site-create-pattern-modal"
 		>

--- a/packages/edit-site/src/components/create-template-part-modal/index.js
+++ b/packages/edit-site/src/components/create-template-part-modal/index.js
@@ -101,7 +101,7 @@ export default function CreateTemplatePartModal( {
 
 	return (
 		<Modal
-			title={ __( 'Create a template part' ) }
+			title={ __( 'Create template part' ) }
 			onRequestClose={ closeModal }
 			overlayClassName="edit-site-create-template-part-modal"
 		>

--- a/test/e2e/specs/site-editor/site-editor-url-navigation.spec.js
+++ b/test/e2e/specs/site-editor/site-editor-url-navigation.spec.js
@@ -63,10 +63,10 @@ test.describe( 'Site editor url navigation', () => {
 		} ) => {
 			await admin.visitSiteEditor();
 			await page.click( 'role=button[name="Library"i]' );
-			await page.click( 'role=button[name="Create a pattern"i]' );
+			await page.click( 'role=button[name="Create pattern"i]' );
 			await page
-				.getByRole( 'menu', { name: 'Create a pattern' } )
-				.getByRole( 'menuitem', { name: 'Create a template part' } )
+				.getByRole( 'menu', { name: 'Create pattern' } )
+				.getByRole( 'menuitem', { name: 'Create template part' } )
 				.click();
 			// Fill in a name in the dialog that pops up.
 			await page.type(


### PR DESCRIPTION
Related to #51078

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This PR makes Template Parts & Patterns Management dropdown string translatable in the site editor.

![capture](https://github.com/WordPress/gutenberg/assets/54422211/af3463dc-c18b-47e3-a9d0-b4eab6a5aa05)

_Update:_ At the same time, through code review, the following were additionally addressed.

- String changes for consistency: `Create a pattern` > `Create pattern`, `Create a template part` > `Create template part`
- Apply this consistency to the title of the template part/pattern modal

## Testing Instructions

No impact on code.