### PR TITLE
Site Editor: Fix browser console error in Library page

### DIFF
--- a/packages/edit-site/src/components/add-new-pattern/index.js
+++ b/packages/edit-site/src/components/add-new-pattern/index.js
@@ -66,13 +66,11 @@ export default function AddNewPattern() {
 						title: 'Create a pattern',
 					},
 				] }
-				icon={
-					<SidebarButton
-						icon={ plus }
-						label={ __( 'Create a pattern' ) }
-					/>
-				}
-				label="Create a pattern."
+				icon={ plus }
+				toggleProps={ {
+					as: SidebarButton,
+				} }
+				label={ __( 'Create a pattern.' ) }
 			/>
 			{ showPatternModal && (
 				<CreatePatternModal


### PR DESCRIPTION
## What?
This PR fixes a browser warning error that is output when the library page is opened in the site editor.

![error](https://github.com/WordPress/gutenberg/assets/54422211/5907a1ad-b8dd-4b32-bbdf-e40b11fc266c)

## Why?
This is because if the `SIdebarButton` component is passed to the icon prop of the `DropdownMenu` component, the button element will be nested.

## How?
Use `toggleProps` prop.

## Testing Instructions

Verify that the browser console does not output an error when the Library page is opened in the Site Editor.

> **Warning**
> This PR might conflict with #51743.