### PR TITLE
Block Options: Use consistent capitalization on template parts and patterns

### DIFF
--- a/packages/e2e-test-utils/src/create-reusable-block.js
+++ b/packages/e2e-test-utils/src/create-reusable-block.js
@@ -24,7 +24,7 @@ export const createReusableBlock = async ( content, title ) => {
 	await page.keyboard.type( content );
 
 	await clickBlockToolbarButton( 'Options' );
-	await clickMenuItem( 'Create a Pattern' );
+	await clickMenuItem( 'Create pattern' );
 	const nameInput = await page.waitForSelector(
 		reusableBlockNameInputSelector
 	);

--- a/packages/e2e-tests/specs/editor/various/block-editor-keyboard-shortcuts.test.js
+++ b/packages/e2e-tests/specs/editor/various/block-editor-keyboard-shortcuts.test.js
@@ -90,7 +90,7 @@ describe( 'block editor keyboard shortcuts', () => {
 		} );
 		it( 'should prevent deleting multiple selected blocks from inputs', async () => {
 			await clickBlockToolbarButton( 'Options' );
-			await clickMenuItem( 'Create a Pattern' );
+			await clickMenuItem( 'Create pattern' );
 			const reusableBlockNameInputSelector =
 				'.reusable-blocks-menu-items__convert-modal .components-text-control__input';
 			const nameInput = await page.waitForSelector(

--- a/packages/e2e-tests/specs/editor/various/reusable-blocks.test.js
+++ b/packages/e2e-tests/specs/editor/various/reusable-blocks.test.js
@@ -197,7 +197,7 @@ describe( 'Reusable blocks', () => {
 
 		// Convert block to a reusable block.
 		await clickBlockToolbarButton( 'Options' );
-		await clickMenuItem( 'Create a Pattern' );
+		await clickMenuItem( 'Create pattern' );
 
 		// Set title.
 		const nameInput = await page.waitForSelector(
@@ -383,7 +383,7 @@ describe( 'Reusable blocks', () => {
 
 		// Convert to reusable.
 		await clickBlockToolbarButton( 'Options' );
-		await clickMenuItem( 'Create a Pattern' );
+		await clickMenuItem( 'Create pattern' );
 		const nameInput = await page.waitForSelector(
 			reusableBlockNameInputSelector
 		);

--- a/packages/edit-site/src/components/template-part-converter/convert-to-template-part.js
+++ b/packages/edit-site/src/components/template-part-converter/convert-to-template-part.js
@@ -57,7 +57,7 @@ export default function ConvertToTemplatePart( { clientIds, blocks } ) {
 					setIsModalOpen( true );
 				} }
 			>
-				{ __( 'Create Template part' ) }
+				{ __( 'Create template part' ) }
 			</MenuItem>
 			{ isModalOpen && (
 				<CreateTemplatePartModal

--- a/packages/reusable-blocks/src/components/reusable-blocks-menu-items/reusable-block-convert-button.js
+++ b/packages/reusable-blocks/src/components/reusable-blocks-menu-items/reusable-block-convert-button.js
@@ -130,11 +130,11 @@ export default function ReusableBlockConvertButton( {
 						icon={ symbol }
 						onClick={ () => setIsModalOpen( true ) }
 					>
-						{ __( 'Create a Pattern' ) }
+						{ __( 'Create pattern' ) }
 					</MenuItem>
 					{ isModalOpen && (
 						<Modal
-							title={ __( 'Create a Pattern' ) }
+							title={ __( 'Create pattern' ) }
 							onRequestClose={ () => {
 								setIsModalOpen( false );
 								setTitle( '' );

--- a/test/e2e/specs/site-editor/template-part.spec.js
+++ b/test/e2e/specs/site-editor/template-part.spec.js
@@ -147,7 +147,7 @@ test.describe( 'Template Part', () => {
 		await editor.selectBlocks( paragraphBlock1, paragraphBlock2 );
 
 		// Convert block to a template part.
-		await editor.clickBlockOptionsMenuItem( 'Create Template part' );
+		await editor.clickBlockOptionsMenuItem( 'Create template part' );
 		await page.type( 'role=dialog >> role=textbox[name="Name"i]', 'Test' );
 		await page.keyboard.press( 'Enter' );
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Minor copy change that adapts:
- "Create a Template part" to "Create template part"
- "Create a Pattern" to "Create pattern"

## Why?
https://github.com/WordPress/gutenberg/issues/51744

## How?
String changes.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
 1. Open a Post or Page.
2. Insert a Heading Block.
3. Open the block options.
4. See new strings. 

## Screenshots or screencast <!-- if applicable -->

| Before  | After |
| ------------- | ------------- |
|<img width="248" alt="CleanShot 2023-06-21 at 11 47 42" src="https://github.com/WordPress/gutenberg/assets/1813435/3e9af3d0-389a-4376-85e2-b83f9afdbf2f">|<img width="247" alt="CleanShot 2023-06-21 at 11 44 44" src="https://github.com/WordPress/gutenberg/assets/1813435/89b08a5b-b3ac-4d22-9edb-52614e465eac">|



