### PR TITLE
Site Editor Sidebar: improvements to buttons

### DIFF
--- a/packages/edit-site/src/components/add-new-pattern/index.js
+++ b/packages/edit-site/src/components/add-new-pattern/index.js
@@ -12,6 +12,7 @@ import { privateApis as routerPrivateApis } from '@wordpress/router';
  */
 import CreatePatternModal from '../create-pattern-modal';
 import CreateTemplatePartModal from '../create-template-part-modal';
+import SidebarButton from '../sidebar-button';
 import { unlock } from '../../lock-unlock';
 
 const { useHistory } = unlock( routerPrivateApis );
@@ -66,7 +67,7 @@ export default function AddNewPattern() {
 					},
 				] }
 				toggleProps={ {
-					className: 'edit-site-sidebar-button',
+					as: SidebarButton,
 				} }
 				icon={ plus }
 				label={ __( 'Create pattern' ) }

--- a/packages/edit-site/src/components/add-new-pattern/index.js
+++ b/packages/edit-site/src/components/add-new-pattern/index.js
@@ -13,7 +13,6 @@ import { privateApis as routerPrivateApis } from '@wordpress/router';
 import CreatePatternModal from '../create-pattern-modal';
 import CreateTemplatePartModal from '../create-template-part-modal';
 import { unlock } from '../../lock-unlock';
-import SidebarButton from '../sidebar-button';
 
 const { useHistory } = unlock( routerPrivateApis );
 
@@ -66,13 +65,11 @@ export default function AddNewPattern() {
 						title: __( 'Create pattern' ),
 					},
 				] }
-				icon={
-					<SidebarButton
-						icon={ plus }
-						label={ __( 'Create pattern' ) }
-					/>
-				}
-				label={ __( 'Create pattern.' ) }
+				toggleProps={ {
+					className: 'edit-site-sidebar-button',
+				} }
+				icon={ plus }
+				label={ __( 'Create pattern' ) }
 			/>
 			{ showPatternModal && (
 				<CreatePatternModal

--- a/packages/edit-site/src/components/sidebar-navigation-screen/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen/index.js
@@ -67,7 +67,6 @@ export default function SidebarNavigationScreen( {
 					) }
 					{ ! isRoot && backPath && (
 						<SidebarButton
-							as={ SidebarButton }
 							onClick={ () => goTo( backPath, { isBack: true } ) }
 							icon={ icon }
 							label={ __( 'Back' ) }

--- a/packages/edit-site/src/components/sidebar-navigation-screen/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen/index.js
@@ -61,14 +61,17 @@ export default function SidebarNavigationScreen( {
 						<NavigatorToParentButton
 							as={ SidebarButton }
 							icon={ isRTL() ? chevronRight : chevronLeft }
-							aria-label={ __( 'Back' ) }
+							label={ __( 'Back' ) }
+							showTooltip={ false }
 						/>
 					) }
 					{ ! isRoot && backPath && (
 						<SidebarButton
+							as={ SidebarButton }
 							onClick={ () => goTo( backPath, { isBack: true } ) }
 							icon={ icon }
 							label={ __( 'Back' ) }
+							showTooltip={ false }
 						/>
 					) }
 					{ isRoot && (


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

While taking a look at #51078 and #51725 I noticed a couple of small issues, and opened this PR to fix those.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Code quality and UI polish

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

This PR achieves three goals:

- better way to disable the tooltip on the sidebar back button via the `showTooltip` prop
- the tooltip is disabled also for the root screen's back button
- the patterns screen was rendering a `button` nested inside a `button` for opening a dropdown menu, this PR fixes that

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

- Browse the sidebar in the site editor
- As you navigate across screens, make sure that the back button never displays a tooltip (including the one in the root sidebar screen)
- in the patterns screen, make sure that the dropdown menu trigger (displaying a "+" icon) doesn't render two `button`s nested inside each other 