### PR TITLE
Font Face: to generate and print font-face styles for theme.json fonts

### DIFF
--- a/lib/class-wp-theme-json-resolver-gutenberg.php
+++ b/lib/class-wp-theme-json-resolver-gutenberg.php
@@ -275,7 +275,9 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 			}
 
 			// BEGIN OF EXPERIMENTAL CODE. Not to backport to core.
-			static::$theme = WP_Fonts_Resolver::add_missing_fonts_to_theme_json( static::$theme );
+			if ( ! class_exists( 'WP_Font_Face' ) && class_exists( 'WP_Fonts_Resolver' ) ) {
+				static::$theme = WP_Fonts_Resolver::add_missing_fonts_to_theme_json( static::$theme );
+			}
 			// END OF EXPERIMENTAL CODE.
 
 		}

--- a/lib/compat/wordpress-6.3/script-loader.php
+++ b/lib/compat/wordpress-6.3/script-loader.php
@@ -81,7 +81,6 @@ function _gutenberg_get_iframed_editor_assets() {
 
 	ob_start();
 	wp_print_styles();
-	wp_print_fonts( true );
 	$styles = ob_get_clean();
 
 	ob_start();

--- a/lib/experimental/fonts-api/fonts-api.php
+++ b/lib/experimental/fonts-api/fonts-api.php
@@ -243,3 +243,17 @@ add_filter(
  * during the build. See: tools/webpack/blocks.js.
  */
 add_action( 'init', 'WP_Fonts_Resolver::register_fonts_from_theme_json', 21 );
+
+add_filter(
+	'block_editor_settings_all',
+	static function( $settings ) {
+		ob_start();
+		wp_print_fonts( true );
+		$styles = ob_get_clean();
+
+		// Add the font-face styles to iframed editor assets.
+		$settings['__unstableResolvedAssets']['styles'] .= $styles;
+		return $settings;
+	},
+	11
+);

--- a/lib/experimental/fonts-api/fonts-api.php
+++ b/lib/experimental/fonts-api/fonts-api.php
@@ -251,20 +251,8 @@ add_filter(
 		wp_print_fonts( true );
 		$styles = ob_get_clean();
 
-		// The fonts are wrapped in the STYLE tag, which has to be removed.
-		$styles = strip_tags( $styles );
-
-		// Add the font-face styles to the editor assets.
-		if ( empty( $settings['styles'] ) ) {
-			$settings['styles'] = array();
-		}
-
-		$settings['styles'][] = array(
-			'css'            => $styles,
-			'__unstableType' => 'theme',
-			'isGlobalStyles' => true,
-		);
-
+		// Add the font-face styles to iframed editor assets.
+		$settings['__unstableResolvedAssets']['styles'] .= $styles;
 		return $settings;
 	},
 	11

--- a/lib/experimental/fonts-api/fonts-api.php
+++ b/lib/experimental/fonts-api/fonts-api.php
@@ -251,8 +251,20 @@ add_filter(
 		wp_print_fonts( true );
 		$styles = ob_get_clean();
 
-		// Add the font-face styles to iframed editor assets.
-		$settings['__unstableResolvedAssets']['styles'] .= $styles;
+		// The fonts are wrapped in the STYLE tag, which has to be removed.
+		$styles = strip_tags( $styles );
+
+		// Add the font-face styles to the editor assets.
+		if ( empty( $settings['styles'] ) ) {
+			$settings['styles'] = array();
+		}
+
+		$settings['styles'][] = array(
+			'css'            => $styles,
+			'__unstableType' => 'theme',
+			'isGlobalStyles' => true,
+		);
+
 		return $settings;
 	},
 	11

--- a/lib/experimental/fonts/class-wp-font-face-resolver.php
+++ b/lib/experimental/fonts/class-wp-font-face-resolver.php
@@ -1,0 +1,158 @@
+<?php
+/**
+ * WP_Font_Face_Resolver class.
+ *
+ * @package    WordPress
+ * @subpackage Fonts
+ * @since      X.X.X
+ */
+
+if ( class_exists( 'WP_Font_Face_Resolver' ) ) {
+	return;
+}
+
+/**
+ * The Font Face Resolver abstracts the processing of different data sources
+ * (such as theme.json) for processing within the Font Face.
+ *
+ * This class is for internal core usage and is not supposed to be used by
+ * extenders (plugins and/or themes).
+ *
+ * @access private
+ */
+class WP_Font_Face_Resolver {
+
+	/**
+	 * Gets fonts defined in theme.json.
+	 *
+	 * @since X.X.X
+	 *
+	 * @return array Returns the font-families, each with their font-face variations.
+	 */
+	public static function get_fonts_from_theme_json() {
+		$settings = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data()->get_settings();
+
+		// Bail out early if there are no font settings.
+		if ( empty( $settings['typography'] ) || empty( $settings['typography']['fontFamilies'] ) ) {
+			return;
+		}
+
+		return static::parse_settings( $settings );
+	}
+
+	/**
+	 * Parse theme.json settings to extract font definitions with variations grouped by font-family.
+	 *
+	 * @since X.X.X
+	 *
+	 * @param array $settings Font settings to parse.
+	 * @return array Returns an array of fonts, grouped by font-family.
+	 */
+	private static function parse_settings( array $settings ) {
+		$fonts = array();
+
+		foreach ( $settings['typography']['fontFamilies'] as $font_families ) {
+			foreach ( $font_families as $definition ) {
+
+				// Skip if font-family "name" is not defined.
+				if ( empty( $definition['name'] ) ) {
+					continue;
+				}
+
+				// Skip if "fontFace" is not defined, meaning there are no variations.
+				if ( empty( $definition['fontFace'] ) ) {
+					continue;
+				}
+
+				$font_family = $definition['name'];
+
+				// Prepare the fonts array structure for this font-family.
+				if ( ! array_key_exists( $font_family, $fonts ) ) {
+					$fonts[ $font_family ] = array();
+				}
+
+				$fonts[ $font_family ] = static::convert_font_face_properties( $definition['fontFace'], $font_family );
+			}
+		}
+
+		return $fonts;
+	}
+
+	/**
+	 * Converts font-face properties from theme.json format.
+	 *
+	 * @since X.X.X
+	 *
+	 * @param array  $font_face_definition The font-face definitions to convert.
+	 * @param string $font_family_property The value to store in the font-face font-family property.
+	 * @return array Converted font-face properties.
+	 */
+	private static function convert_font_face_properties( array $font_face_definition, $font_family_property ) {
+		$converted_font_faces = array();
+
+		foreach ( $font_face_definition as $font_face ) {
+			// Add the font-family property to the font-face.
+			$font_face['font-family'] = $font_family_property;
+
+			// Converts the "file:./" src placeholder into a theme font file URI.
+			if ( ! empty( $font_face['src'] ) ) {
+				$font_face['src'] = static::to_theme_file_uri( (array) $font_face['src'] );
+			}
+
+			// Convert camelCase properties into kebab-case.
+			$font_face = static::to_kebab_case( $font_face );
+
+			$converted_font_faces[] = $font_face;
+		}
+
+		return $converted_font_faces;
+	}
+
+	/**
+	 * Converts each 'file:./' placeholder into a URI to the font file in the theme.
+	 *
+	 * The 'file:./' is specified in the theme's `theme.json` as a placeholder to be
+	 * replaced with the URI to the font file's location in the theme. When a "src"
+	 * beings with this placeholder, it is replaced, converting the src into a URI.
+	 *
+	 * @since X.X.X
+	 *
+	 * @param array $src An array of font file sources to process.
+	 * @return array An array of font file src URI(s).
+	 */
+	private static function to_theme_file_uri( array $src ) {
+		$placeholder = 'file:./';
+
+		foreach ( $src as $src_key => $src_url ) {
+			// Skip if the src doesn't start with the placeholder, as there's nothing to replace.
+			if ( ! str_starts_with( $src_url, $placeholder ) ) {
+				continue;
+			}
+
+			$src_file        = str_replace( $placeholder, '', $src_url );
+			$src[ $src_key ] = get_theme_file_uri( $src_file );
+		}
+
+		return $src;
+	}
+
+	/**
+	 * Converts all first dimension keys into kebab-case.
+	 *
+	 * @since X.X.X
+	 *
+	 * @param array $data The array to process.
+	 * @return array Data with first dimension keys converted into kebab-case.
+	 */
+	private static function to_kebab_case( array $data ) {
+		foreach ( $data as $key => $value ) {
+			$kebab_case          = _wp_to_kebab_case( $key );
+			$data[ $kebab_case ] = $value;
+			if ( $kebab_case !== $key ) {
+				unset( $data[ $key ] );
+			}
+		}
+
+		return $data;
+	}
+}

--- a/lib/experimental/fonts/class-wp-font-face-resolver.php
+++ b/lib/experimental/fonts/class-wp-font-face-resolver.php
@@ -34,7 +34,7 @@ class WP_Font_Face_Resolver {
 
 		// Bail out early if there are no font settings.
 		if ( empty( $settings['typography'] ) || empty( $settings['typography']['fontFamilies'] ) ) {
-			return;
+			return array();
 		}
 
 		return static::parse_settings( $settings );

--- a/lib/experimental/fonts/class-wp-font-face.php
+++ b/lib/experimental/fonts/class-wp-font-face.php
@@ -264,7 +264,7 @@ class WP_Font_Face {
 				$css .= '@font-face{' . $this->build_font_face_css( $font_face ) . '}' . "\n";
 		}
 
-		return $css;
+		return rtrim( $css, "\n" );
 	}
 
 	/**

--- a/lib/experimental/fonts/class-wp-font-face.php
+++ b/lib/experimental/fonts/class-wp-font-face.php
@@ -264,6 +264,7 @@ class WP_Font_Face {
 				$css .= '@font-face{' . $this->build_font_face_css( $font_face ) . '}' . "\n";
 		}
 
+		// Don't print the last newline character.
 		return rtrim( $css, "\n" );
 	}
 

--- a/lib/experimental/fonts/class-wp-font-face.php
+++ b/lib/experimental/fonts/class-wp-font-face.php
@@ -1,0 +1,421 @@
+<?php
+/**
+ * WP_Font_Face class.
+ *
+ * @package    WordPress
+ * @subpackage Fonts
+ * @since      X.X.X
+ */
+
+if ( class_exists( 'WP_Font_Face' ) ) {
+	return;
+}
+
+/**
+ * Font Face generates and prints `@font-face` styles for given fonts.
+ *
+ * @since X.X.X
+ */
+class WP_Font_Face {
+
+	/**
+	 * The font-face property defaults.
+	 *
+	 * @since X.X.X
+	 *
+	 * @var string[]
+	 */
+	private $font_face_property_defaults = array(
+		'font-family'  => '',
+		'font-style'   => 'normal',
+		'font-weight'  => '400',
+		'font-display' => 'fallback',
+	);
+
+	/**
+	 * Valid font-face property names.
+	 *
+	 * @since X.X.X
+	 *
+	 * @var string[]
+	 */
+	private $valid_font_face_properties = array(
+		'ascent-override',
+		'descent-override',
+		'font-display',
+		'font-family',
+		'font-stretch',
+		'font-style',
+		'font-weight',
+		'font-variant',
+		'font-feature-settings',
+		'font-variation-settings',
+		'line-gap-override',
+		'size-adjust',
+		'src',
+		'unicode-range',
+	);
+
+	/**
+	 * Valid font-display values.
+	 *
+	 * @since X.X.X
+	 *
+	 * @var string[]
+	 */
+	private $valid_font_display = array( 'auto', 'block', 'fallback', 'swap', 'optional' );
+
+	/**
+	 * Fonts to be processed.
+	 *
+	 * @since X.X.X
+	 *
+	 * @var array[]
+	 */
+	private $fonts = array();
+
+	/**
+	 * Array of font-face style tag's attribute(s)
+	 * where the key is the attribute name and the
+	 * value is its value.
+	 *
+	 * @since X.X.X
+	 *
+	 * @var string[]
+	 */
+	private $style_tag_atts = array();
+
+	/**
+	 * Creates and initializes an instance of WP_Font_Face.
+	 *
+	 * @since X.X.X
+	 */
+	public function __construct() {
+		/**
+		 * Filters the font-face property defaults.
+		 *
+		 * @since X.X.X
+		 *
+		 * @param array $defaults {
+		 *     An array of required font-face properties and defaults.
+		 *
+		 *     @type string $provider     The provider ID. Default 'local'.
+		 *     @type string $font-family  The font-family property. Default empty string.
+		 *     @type string $font-style   The font-style property. Default 'normal'.
+		 *     @type string $font-weight  The font-weight property. Default '400'.
+		 *     @type string $font-display The font-display property. Default 'fallback'.
+		 * }
+		 */
+		$this->font_face_property_defaults = apply_filters( 'wp_font_face_property_defaults', $this->font_face_property_defaults );
+
+		if (
+			function_exists( 'is_admin' ) && ! is_admin()
+			&&
+			function_exists( 'current_theme_supports' ) && ! current_theme_supports( 'html5', 'style' )
+		) {
+			$this->style_tag_atts = array( 'type' => 'text/css' );
+		}
+	}
+
+	/**
+	 * Generates and prints the `@font-face` styles for the given fonts.
+	 *
+	 * @since X.X.X
+	 *
+	 * @param array $fonts The fonts to generate and print @font-face styles.
+	 */
+	public function generate_and_print( array $fonts ) {
+		$fonts = $this->validate_fonts( $fonts );
+
+		printf(
+			$this->get_style_element(),
+			$this->get_css( $fonts )
+		);
+	}
+
+	/**
+	 * Validates each of the font-face properties.
+	 *
+	 * @since X.X.X
+	 *
+	 * @param array $fonts The fonts to valid.
+	 * @return array Prepared font-faces organized by provider and font-family.
+	 */
+	private function validate_fonts( array $fonts ) {
+		$validated_fonts = array();
+
+		foreach ( $fonts as $font_faces ) {
+			foreach ( $font_faces as $font_face ) {
+				$font_face = $this->validate_font_face_properties( $font_face );
+				// Skip if failed validation.
+				if ( false === $font_face ) {
+					continue;
+				}
+
+				$validated_fonts[] = $font_face;
+			}
+		}
+
+		return $validated_fonts;
+	}
+
+	/**
+	 * Validates each font-face property.
+	 *
+	 * @since X.X.X
+	 *
+	 * @param array $font_face Font face properties to validate.
+	 * @return false|array Validated font-face on success. Else, false.
+	 */
+	private function validate_font_face_properties( array $font_face ) {
+		$font_face = wp_parse_args( $font_face, $this->font_face_property_default );
+
+		// Check the font-family.
+		if ( empty( $font_face['font-family'] ) || ! is_string( $font_face['font-family'] ) ) {
+			trigger_error( 'Font font-family must be a non-empty string.' );
+			return false;
+		}
+
+		// Make sure that local fonts have 'src' defined.
+		if ( empty( $font_face['src'] ) || ( ! is_string( $font_face['src'] ) && ! is_array( $font_face['src'] ) ) ) {
+			trigger_error( 'Font src must be a non-empty string or an array of strings.' );
+			return false;
+		}
+
+		// Validate the 'src' property.
+		if ( ! empty( $font_face['src'] ) ) {
+			foreach ( (array) $font_face['src'] as $src ) {
+				if ( empty( $src ) || ! is_string( $src ) ) {
+					trigger_error( 'Each font src must be a non-empty string.' );
+					return false;
+				}
+			}
+		}
+
+		// Check the font-weight.
+		if ( ! is_string( $font_face['font-weight'] ) && ! is_int( $font_face['font-weight'] ) ) {
+			trigger_error( 'Font font-weight must be a properly formatted string or integer.' );
+			return false;
+		}
+
+		// Check the font-display.
+		if ( ! in_array( $font_face['font-display'], $this->valid_font_display, true ) ) {
+			$font_face['font-display'] = $this->font_face_property_defaults['font-display'];
+		}
+
+		// Remove invalid properties.
+		foreach ( $font_face as $prop => $value ) {
+			if ( ! in_array( $prop, $this->valid_font_face_properties, true ) ) {
+				unset( $font_face[ $prop ] );
+			}
+		}
+
+		return $font_face;
+	}
+
+	/**
+	 * Gets the `<style>` element for wrapping the `@font-face` CSS.
+	 *
+	 * @since X.X.X
+	 *
+	 * @return string The style element.
+	 */
+	private function get_style_element() {
+		$attributes = $this->generate_style_element_attributes();
+
+		return "<style id='wp-fonts-local'{$attributes}>\n%s\n</style>\n";
+	}
+
+	/**
+	 * Gets the defined <style> element's attributes.
+	 *
+	 * @since X.X.X
+	 *
+	 * @return string A string of attribute=value when defined, else, empty string.
+	 */
+	private function generate_style_element_attributes() {
+		$attributes = '';
+		foreach ( $this->style_tag_atts as $name => $value ) {
+			$attributes .= " {$name}='{$value}'";
+		}
+		return $attributes;
+	}
+
+	/**
+	 * Gets the `@font-face` CSS styles for locally-hosted font files.
+	 *
+	 * This method does the following processing tasks:
+	 *    1. Orchestrates an optimized `src` (with format) for browser support.
+	 *    2. Generates the `@font-face` for all its fonts.
+	 *
+	 * @since X.X.X
+	 *
+	 * @param array $font_faces The font-faces to generate @font-face CSS styles.
+	 * @return string The `@font-face` CSS styles.
+	 */
+	private function get_css( $font_faces ) {
+		$css = '';
+
+		foreach ( $font_faces as $font_face ) {
+				// Order the font's `src` items to optimize for browser support.
+				$font_face = $this->order_src( $font_face );
+
+				// Build the @font-face CSS for this font.
+				$css .= '@font-face{' . $this->build_font_face_css( $font_face ) . '}' . "\n";
+		}
+
+		return $css;
+	}
+
+	/**
+	 * Orders `src` items to optimize for browser support.
+	 *
+	 * @since X.X.X
+	 *
+	 * @param array $font_face Font face to process.
+	 * @return array Font-face with ordered src items.
+	 */
+	private function order_src( array $font_face ) {
+		if ( ! is_array( $font_face['src'] ) ) {
+			$font_face['src'] = (array) $font_face['src'];
+		}
+
+		$src         = array();
+		$src_ordered = array();
+
+		foreach ( $font_face['src'] as $url ) {
+			// Add data URIs first.
+			if ( str_starts_with( trim( $url ), 'data:' ) ) {
+				$src_ordered[] = array(
+					'url'    => $url,
+					'format' => 'data',
+				);
+				continue;
+			}
+			$format         = pathinfo( $url, PATHINFO_EXTENSION );
+			$src[ $format ] = $url;
+		}
+
+		// Add woff2.
+		if ( ! empty( $src['woff2'] ) ) {
+			$src_ordered[] = array(
+				'url'    => $src['woff2'],
+				'format' => 'woff2',
+			);
+		}
+
+		// Add woff.
+		if ( ! empty( $src['woff'] ) ) {
+			$src_ordered[] = array(
+				'url'    => $src['woff'],
+				'format' => 'woff',
+			);
+		}
+
+		// Add ttf.
+		if ( ! empty( $src['ttf'] ) ) {
+			$src_ordered[] = array(
+				'url'    => $src['ttf'],
+				'format' => 'truetype',
+			);
+		}
+
+		// Add eot.
+		if ( ! empty( $src['eot'] ) ) {
+			$src_ordered[] = array(
+				'url'    => $src['eot'],
+				'format' => 'embedded-opentype',
+			);
+		}
+
+		// Add otf.
+		if ( ! empty( $src['otf'] ) ) {
+			$src_ordered[] = array(
+				'url'    => $src['otf'],
+				'format' => 'opentype',
+			);
+		}
+		$font_face['src'] = $src_ordered;
+
+		return $font_face;
+	}
+
+	/**
+	 * Builds the font-family's CSS.
+	 *
+	 * @since X.X.X
+	 *
+	 * @param array $font_face Font face to process.
+	 * @return string This font-family's CSS.
+	 */
+	private function build_font_face_css( array $font_face ) {
+		$css = '';
+
+		// Wrap font-family in quotes if it contains spaces
+		// and is not already wrapped in quotes.
+		if (
+			str_contains( $font_face['font-family'], ' ' ) &&
+			! str_contains( $font_face['font-family'], '"' ) &&
+			! str_contains( $font_face['font-family'], "'" )
+		) {
+			$font_face['font-family'] = '"' . $font_face['font-family'] . '"';
+		}
+
+		foreach ( $font_face as $key => $value ) {
+			// Compile the "src" parameter.
+			if ( 'src' === $key ) {
+				$value = $this->compile_src( $value );
+			}
+
+			// If font-variation-settings is an array, convert it to a string.
+			if ( 'font-variation-settings' === $key && is_array( $value ) ) {
+				$value = $this->compile_variations( $value );
+			}
+
+			if ( ! empty( $value ) ) {
+				$css .= "$key:$value;";
+			}
+		}
+
+		return $css;
+	}
+
+	/**
+	 * Compiles the `src` into valid CSS.
+	 *
+	 * @since X.X.X
+	 *
+	 * @param array $value Value to process.
+	 * @return string The CSS.
+	 */
+	private function compile_src( array $value ) {
+		$src = '';
+
+		foreach ( $value as $item ) {
+			$src .= ( 'data' === $item['format'] )
+				? ", url({$item['url']})"
+				: ", url('{$item['url']}') format('{$item['format']}')";
+		}
+
+		$src = ltrim( $src, ', ' );
+		return $src;
+	}
+
+	/**
+	 * Compiles the font variation settings.
+	 *
+	 * @since X.X.X
+	 *
+	 * @param array $font_variation_settings Array of font variation settings.
+	 * @return string The CSS.
+	 */
+	private function compile_variations( array $font_variation_settings ) {
+		$variations = '';
+
+		foreach ( $font_variation_settings as $key => $value ) {
+			$variations .= "$key $value";
+		}
+
+		return $variations;
+	}
+}

--- a/lib/experimental/fonts/class-wp-font-face.php
+++ b/lib/experimental/fonts/class-wp-font-face.php
@@ -168,7 +168,7 @@ class WP_Font_Face {
 	 * @return false|array Validated font-face on success. Else, false.
 	 */
 	private function validate_font_face_properties( array $font_face ) {
-		$font_face = wp_parse_args( $font_face, $this->font_face_property_default );
+		$font_face = wp_parse_args( $font_face, $this->font_face_property_defaults );
 
 		// Check the font-family.
 		if ( empty( $font_face['font-family'] ) || ! is_string( $font_face['font-family'] ) ) {

--- a/lib/experimental/fonts/class-wp-font-face.php
+++ b/lib/experimental/fonts/class-wp-font-face.php
@@ -66,15 +66,6 @@ class WP_Font_Face {
 	private $valid_font_display = array( 'auto', 'block', 'fallback', 'swap', 'optional' );
 
 	/**
-	 * Fonts to be processed.
-	 *
-	 * @since X.X.X
-	 *
-	 * @var array[]
-	 */
-	private $fonts = array();
-
-	/**
 	 * Array of font-face style tag's attribute(s)
 	 * where the key is the attribute name and the
 	 * value is its value.
@@ -83,7 +74,7 @@ class WP_Font_Face {
 	 *
 	 * @var string[]
 	 */
-	private $style_tag_atts = array();
+	private $style_tag_attrs = array();
 
 	/**
 	 * Creates and initializes an instance of WP_Font_Face.
@@ -113,7 +104,7 @@ class WP_Font_Face {
 			&&
 			function_exists( 'current_theme_supports' ) && ! current_theme_supports( 'html5', 'style' )
 		) {
-			$this->style_tag_atts = array( 'type' => 'text/css' );
+			$this->style_tag_attrs = array( 'type' => 'text/css' );
 		}
 	}
 
@@ -235,7 +226,7 @@ class WP_Font_Face {
 	 */
 	private function generate_style_element_attributes() {
 		$attributes = '';
-		foreach ( $this->style_tag_atts as $name => $value ) {
+		foreach ( $this->style_tag_attrs as $name => $value ) {
 			$attributes .= " {$name}='{$value}'";
 		}
 		return $attributes;

--- a/lib/experimental/fonts/class-wp-font-face.php
+++ b/lib/experimental/fonts/class-wp-font-face.php
@@ -118,6 +118,11 @@ class WP_Font_Face {
 	public function generate_and_print( array $fonts ) {
 		$fonts = $this->validate_fonts( $fonts );
 
+		// Bail out if there are no fonts are given to process.
+		if ( empty( $fonts ) ) {
+			return;
+		}
+
 		printf(
 			$this->get_style_element(),
 			$this->get_css( $fonts )

--- a/lib/experimental/fonts/fonts.php
+++ b/lib/experimental/fonts/fonts.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Fonts functions.
+ *
+ * @package    WordPress
+ * @subpackage Fonts
+ * @since      X.X.X
+ */
+
+add_action( 'wp_head', 'wp_print_font_faces', 50 );
+add_action( 'admin_print_styles', 'wp_print_font_faces', 50 );
+
+if ( ! function_exists( 'wp_print_font_faces' ) ) {
+	/**
+	 * Generates and prints font-face styles for given fonts or theme.json fonts.
+	 *
+	 * @since X.X.X
+	 *
+	 * @param array $fonts Optional. The fonts to generate and print @font-face styles.
+	 *                     Default empty array.
+	 */
+	function wp_print_font_faces( array $fonts = array() ) {
+		static $wp_font_face = null;
+
+		if ( empty( $fonts ) ) {
+			$fonts = WP_Font_Face_Resolver::get_fonts_from_theme_json();
+		}
+
+		if ( empty( $fonts ) ) {
+			return;
+		}
+
+		if (
+			null !== $wp_font_face &&
+
+			/*
+			 * Ignore static cache when `WP_DEBUG` is enabled. Why? To avoid interfering with
+			 * the theme developer's workflow.
+			 *
+			 * @todo Replace `WP_DEBUG` once an "in development mode" check is available in Core.
+			 */
+			! WP_DEBUG &&
+
+			/*
+			 * Ignore cache when automated test suites are running. Why? To ensure
+			 * the static cache is reset between each test.
+			 */
+			! ( defined( 'WP_RUN_CORE_TESTS' ) && WP_RUN_CORE_TESTS )
+		) {
+			return $wp_font_face;
+		}
+
+		$wp_font_face = new WP_Font_Face();
+
+		wp_font_face()->generate_and_print( $fonts );
+	}
+}

--- a/lib/experimental/fonts/fonts.php
+++ b/lib/experimental/fonts/fonts.php
@@ -19,7 +19,7 @@ if ( ! function_exists( 'wp_print_font_faces' ) ) {
 	 * @param array $fonts Optional. The fonts to generate and print @font-face styles.
 	 *                     Default empty array.
 	 */
-	function wp_print_font_faces( array $fonts = array() ) {
+	function wp_print_font_faces( $fonts = array() ) {
 		static $wp_font_face = null;
 
 		if ( empty( $fonts ) ) {
@@ -31,28 +31,15 @@ if ( ! function_exists( 'wp_print_font_faces' ) ) {
 		}
 
 		if (
-			null !== $wp_font_face &&
+			null === $wp_font_face ||
 
-			/*
-			 * Ignore static cache when `WP_DEBUG` is enabled. Why? To avoid interfering with
-			 * the theme developer's workflow.
-			 *
-			 * @todo Replace `WP_DEBUG` once an "in development mode" check is available in Core.
-			 */
-			! WP_DEBUG &&
-
-			/*
-			 * Ignore cache when automated test suites are running. Why? To ensure
-			 * the static cache is reset between each test.
-			 */
-			! ( defined( 'WP_RUN_CORE_TESTS' ) && WP_RUN_CORE_TESTS )
+			// Ignore cache when automated test suites are running.
+			( defined( 'WP_RUN_CORE_TESTS' ) && WP_RUN_CORE_TESTS )
 		) {
-			return $wp_font_face;
+			$wp_font_face = new WP_Font_Face();
 		}
 
-		$wp_font_face = new WP_Font_Face();
-
-		wp_font_face()->generate_and_print( $fonts );
+		$wp_font_face->generate_and_print( $fonts );
 	}
 }
 

--- a/lib/experimental/fonts/fonts.php
+++ b/lib/experimental/fonts/fonts.php
@@ -55,3 +55,17 @@ if ( ! function_exists( 'wp_print_font_faces' ) ) {
 		wp_font_face()->generate_and_print( $fonts );
 	}
 }
+
+add_filter(
+	'block_editor_settings_all',
+	static function( $settings ) {
+		ob_start();
+		wp_print_font_faces();
+		$styles = ob_get_clean();
+
+		// Add the font-face styles to iframed editor assets.
+		$settings['__unstableResolvedAssets']['styles'] .= $styles;
+		return $settings;
+	},
+	11
+);

--- a/lib/load.php
+++ b/lib/load.php
@@ -102,7 +102,6 @@ require __DIR__ . '/compat/wordpress-6.3/block-editor-settings.php';
 require_once __DIR__ . '/compat/wordpress-6.3/kses.php';
 
 // Experimental features.
-remove_action( 'plugins_loaded', '_wp_theme_json_webfonts_handler' ); // Turns off WP 6.0's stopgap handler for Webfonts API.
 require __DIR__ . '/experimental/behaviors.php';
 require __DIR__ . '/experimental/block-editor-settings-mobile.php';
 require __DIR__ . '/experimental/blocks.php';
@@ -129,8 +128,22 @@ require __DIR__ . '/experimental/interactivity-api/directives/wp-class.php';
 require __DIR__ . '/experimental/interactivity-api/directives/wp-style.php';
 require __DIR__ . '/experimental/interactivity-api/directives/wp-text.php';
 
-// Fonts API.
-if ( ! class_exists( 'WP_Fonts' ) ) {
+// Fonts API / Font Face.
+remove_action( 'plugins_loaded', '_wp_theme_json_webfonts_handler' ); // Turns off WordPress 6.0's stopgap handler.
+
+/*
+ * If the Fonts Library is available, load the Font Face files, else load the Fonts API.
+ * This strategy is temporary until the Fonts Library is merged. It's used here to allow
+ * the Font Face (redesigned Fonts API) to be merged before the Fonts Library while
+ * keeping Fonts API available for sites that are using it.
+ */
+if ( class_exists( 'WP_Fonts_Library' ) || class_exists( 'WP_Fonts_Library_Controller' ) ) {
+	if ( ! class_exists( 'WP_Font_Face' ) ) {
+		require __DIR__ . '/experimental/fonts/class-wp-font-face.php';
+		require __DIR__ . '/experimental/fonts/class-wp-font-face-resolver.php';
+		require __DIR__ . '/experimental/fonts/fonts.php';
+	}
+} elseif ( ! class_exists( 'WP_Fonts' ) ) {
 	// Fonts API files.
 	require __DIR__ . '/experimental/fonts-api/class-wp-fonts-provider.php';
 	require __DIR__ . '/experimental/fonts-api/class-wp-fonts-utils.php';

--- a/phpunit/fonts/wp-font-face-testcase.php
+++ b/phpunit/fonts/wp-font-face-testcase.php
@@ -1,0 +1,187 @@
+<?php
+/**
+ * Test case for the Fonts tests.
+ *
+ * @package    WordPress
+ * @subpackage Fonts
+ */
+
+require_once __DIR__ . '/wp-font-face-tests-dataset.php';
+/**
+ * Abstracts the common tasks for the Font Face tests.
+ */
+abstract class WP_Font_Face_TestCase extends WP_UnitTestCase {
+	use WP_Font_Face_Tests_Datasets;
+
+	/**
+	 * Current error reporting level (before a test changes it).
+	 *
+	 * @var null|int
+	 */
+	protected $error_reporting_level = null;
+
+	/**
+	 * Reflection data store for non-public property access.
+	 *
+	 * @var ReflectionProperty[]
+	 */
+	protected $property = array();
+
+	/**
+	 * Indicates the test class uses `switch_theme()` and requires
+	 * set_up and tear_down fixtures to set and reset hooks and memory.
+	 *
+	 * If a test class switches themes, set this property to `true`.
+	 *
+	 * @var bool
+	 */
+	protected static $requires_switch_theme_fixtures = false;
+
+	/**
+	 * Theme root directory.
+	 *
+	 * @var string
+	 */
+	protected static $theme_root;
+
+	/**
+	 * Original theme directory.
+	 *
+	 * @var string
+	 */
+	protected $orig_theme_dir;
+
+	/**
+	 * Administrator ID.
+	 *
+	 * @var int
+	 */
+	protected static $administrator_id = 0;
+
+	public static function set_up_before_class() {
+		parent::set_up_before_class();
+
+		if ( self::$requires_switch_theme_fixtures ) {
+			self::$theme_root = realpath( __DIR__ . '/../data/themedir1' );
+		}
+	}
+
+	public static function tear_down_after_class() {
+		// Reset static flags.
+		self::$requires_switch_theme_fixtures = false;
+
+		parent::tear_down_after_class();
+	}
+
+	public function set_up() {
+		parent::set_up();
+
+		if ( self::$requires_switch_theme_fixtures ) {
+			$this->orig_theme_dir = $GLOBALS['wp_theme_directories'];
+
+			// /themes is necessary as theme.php functions assume /themes is the root if there is only one root.
+			$GLOBALS['wp_theme_directories'] = array( WP_CONTENT_DIR . '/themes', self::$theme_root );
+
+			// Set up the new root.
+			add_filter( 'theme_root', array( $this, 'filter_set_theme_root' ) );
+			add_filter( 'stylesheet_root', array( $this, 'filter_set_theme_root' ) );
+			add_filter( 'template_root', array( $this, 'filter_set_theme_root' ) );
+
+			// Clear caches.
+			wp_clean_themes_cache();
+			unset( $GLOBALS['wp_themes'] );
+		}
+	}
+
+	public function tear_down() {
+		$this->property = array();
+
+		// Reset the error reporting when modified within a test.
+		if ( is_int( $this->error_reporting_level ) ) {
+			error_reporting( $this->error_reporting_level );
+			$this->error_reporting_level = null;
+		}
+
+		if ( self::$requires_switch_theme_fixtures ) {
+			// Clean up the filters to modify the theme root.
+			remove_filter( 'theme_root', array( $this, 'filter_set_theme_root' ) );
+			remove_filter( 'stylesheet_root', array( $this, 'filter_set_theme_root' ) );
+			remove_filter( 'template_root', array( $this, 'filter_set_theme_root' ) );
+
+			WP_Theme_JSON_Resolver::clean_cached_data();
+			if ( class_exists( 'WP_Theme_JSON_Resolver_Gutenberg' ) ) {
+				WP_Theme_JSON_Resolver_Gutenberg::clean_cached_data();
+			}
+		}
+
+		parent::tear_down();
+	}
+
+	public function clean_up_global_scope() {
+		parent::clean_up_global_scope();
+
+		if ( self::$requires_switch_theme_fixtures ) {
+			$GLOBALS['wp_theme_directories'] = $this->orig_theme_dir;
+			wp_clean_themes_cache();
+
+			if ( function_exists( 'wp_clean_theme_json_cache' ) ) {
+				wp_clean_theme_json_cache();
+			}
+
+			if ( function_exists( '_gutenberg_clean_theme_json_caches' ) ) {
+				_gutenberg_clean_theme_json_caches();
+			}
+
+			unset( $GLOBALS['wp_themes'] );
+		}
+	}
+
+	public function filter_set_theme_root() {
+		return self::$theme_root;
+	}
+
+	protected function get_reflection_property( $property_name, $class = 'WP_Fonts' ) {
+		$property = new ReflectionProperty( $class, $property_name );
+		$property->setAccessible( true );
+
+		return $property;
+	}
+
+	protected function get_property_value( $property_name, $class, $wp_fonts = null ) {
+		$property = $this->get_reflection_property( $property_name, $class );
+
+		if ( ! $wp_fonts ) {
+			$wp_fonts = wp_fonts();
+		}
+
+		return $property->getValue( $wp_fonts );
+	}
+
+	protected function setup_property( $class, $property_name ) {
+		$key = $this->get_property_key( $class, $property_name );
+
+		if ( ! isset( $this->property[ $key ] ) ) {
+			$this->property[ $key ] = new ReflectionProperty( $class, 'providers' );
+			$this->property[ $key ]->setAccessible( true );
+		}
+
+		return $this->property[ $key ];
+	}
+
+	protected function get_property_key( $class, $property_name ) {
+		return $class . '::$' . $property_name;
+	}
+
+	/**
+	 * Opens the accessibility to access the given private or protected method.
+	 *
+	 * @param string $method_name Name of the method to open.
+	 * @return ReflectionMethod Instance of the method, ie to invoke it in the test.
+	 */
+	protected function get_reflection_method( $method_name ) {
+		$method = new ReflectionMethod( WP_Fonts::class, $method_name );
+		$method->setAccessible( true );
+
+		return $method;
+	}
+}

--- a/phpunit/fonts/wp-font-face-tests-dataset.php
+++ b/phpunit/fonts/wp-font-face-tests-dataset.php
@@ -198,4 +198,77 @@ CSS
 			),
 		);
 	}
+
+	public function get_expected_fonts_for_fonts_block_theme( $key = '' ) {
+		static $data = null;
+
+		if ( null === $data ) {
+			$uri  = get_stylesheet_directory_uri() . '/assets/fonts/';
+			$data = array(
+				'fonts'            => array(
+					'DM Sans'          => array(
+						array(
+							'src'          => array( $uri . 'dm-sans/DMSans-Regular.woff2' ),
+							'font-family'  => 'DM Sans',
+							'font-stretch' => 'normal',
+							'font-style'   => 'normal',
+							'font-weight'  => '400',
+						),
+						array(
+							'src'          => array( $uri . 'dm-sans/DMSans-Regular-Italic.woff2' ),
+							'font-family'  => 'DM Sans',
+							'font-stretch' => 'normal',
+							'font-style'   => 'italic',
+							'font-weight'  => '400',
+						),
+						array(
+							'src'          => array( $uri . 'dm-sans/DMSans-Bold.woff2' ),
+							'font-family'  => 'DM Sans',
+							'font-stretch' => 'normal',
+							'font-style'   => 'normal',
+							'font-weight'  => '700',
+						),
+						array(
+							'src'          => array( $uri . 'dm-sans/DMSans-Bold-Italic.woff2' ),
+							'font-family'  => 'DM Sans',
+							'font-stretch' => 'normal',
+							'font-style'   => 'italic',
+							'font-weight'  => '700',
+						),
+					),
+					'Source Serif Pro' => array(
+						array(
+							'src'          => array( $uri . 'source-serif-pro/SourceSerif4Variable-Roman.ttf.woff2' ),
+							'font-family'  => 'Source Serif Pro',
+							'font-stretch' => 'normal',
+							'font-style'   => 'normal',
+							'font-weight'  => '200 900',
+						),
+						array(
+							'src'          => array( $uri . 'source-serif-pro/SourceSerif4Variable-Italic.ttf.woff2' ),
+							'font-family'  => 'Source Serif Pro',
+							'font-stretch' => 'normal',
+							'font-style'   => 'italic',
+							'font-weight'  => '200 900',
+						),
+					),
+				),
+				'font_face_styles' => <<<CSS
+@font-face{font-family:"DM Sans";font-style:normal;font-weight:400;font-display:fallback;src:url('{$uri}dm-sans/DMSans-Regular.woff2') format('woff2');font-stretch:normal;}
+@font-face{font-family:"DM Sans";font-style:italic;font-weight:400;font-display:fallback;src:url('{$uri}dm-sans/DMSans-Regular-Italic.woff2') format('woff2');font-stretch:normal;}
+@font-face{font-family:"DM Sans";font-style:normal;font-weight:700;font-display:fallback;src:url('{$uri}dm-sans/DMSans-Bold.woff2') format('woff2');font-stretch:normal;}
+@font-face{font-family:"DM Sans";font-style:italic;font-weight:700;font-display:fallback;src:url('{$uri}dm-sans/DMSans-Bold-Italic.woff2') format('woff2');font-stretch:normal;}
+@font-face{font-family:"Source Serif Pro";font-style:normal;font-weight:200 900;font-display:fallback;src:url('{$uri}source-serif-pro/SourceSerif4Variable-Roman.ttf.woff2') format('woff2');font-stretch:normal;}
+@font-face{font-family:"Source Serif Pro";font-style:italic;font-weight:200 900;font-display:fallback;src:url('{$uri}source-serif-pro/SourceSerif4Variable-Italic.ttf.woff2') format('woff2');font-stretch:normal;}
+CSS
+				,
+			);
+		}
+
+		if ( isset( $data[ $key ] ) ) {
+			return $data[ $key ];
+		}
+
+		return $data;
+	}
 }

--- a/phpunit/fonts/wp-font-face-tests-dataset.php
+++ b/phpunit/fonts/wp-font-face-tests-dataset.php
@@ -1,0 +1,201 @@
+<?php
+/**
+ * Datasets for unit and integration tests.
+ *
+ * @package    WordPress
+ * @subpackage Fonts
+ */
+
+/**
+ * Trait for reusing datasets within the Fonts tests.
+ */
+trait WP_Font_Face_Tests_Datasets {
+	/**
+	 * Data provider.
+	 *
+	 * @return array
+	 */
+	public function data_should_print_given_fonts() {
+		return array(
+			'single truetype format font'    => array(
+				'fonts'    => array(
+					'Inter' =>
+						array(
+							array(
+								'src'          =>
+									array(
+										'https://example.org/assets/fonts/inter/Inter-VariableFont_slnt,wght.ttf',
+									),
+								'font-family'  => 'Inter',
+								'font-stretch' => 'normal',
+								'font-style'   => 'normal',
+								'font-weight'  => '200',
+							),
+						),
+				),
+				'expected' => <<<CSS
+@font-face{font-family:Inter;font-style:normal;font-weight:200;font-display:fallback;src:url('https://example.org/assets/fonts/inter/Inter-VariableFont_slnt,wght.ttf') format('truetype');font-stretch:normal;}
+CSS
+			,
+			),
+			'multiple truetype format fonts' => array(
+				'fonts'    => array(
+					'Inter' =>
+						array(
+							array(
+								'src'          =>
+									array(
+										'https://example.org/assets/fonts/inter/Inter-VariableFont_slnt,wght.ttf',
+									),
+								'font-family'  => 'Inter',
+								'font-stretch' => 'normal',
+								'font-style'   => 'normal',
+								'font-weight'  => '200',
+							),
+							array(
+								'src'          =>
+									array(
+										'https://example.org/assets/fonts/inter/Inter-VariableFont_slnt-Italic,wght.ttf',
+									),
+								'font-family'  => 'Inter',
+								'font-stretch' => 'normal',
+								'font-style'   => 'italic',
+								'font-weight'  => '900',
+							),
+						),
+				),
+				'expected' => <<<CSS
+@font-face{font-family:Inter;font-style:normal;font-weight:200;font-display:fallback;src:url('https://example.org/assets/fonts/inter/Inter-VariableFont_slnt,wght.ttf') format('truetype');font-stretch:normal;}
+@font-face{font-family:Inter;font-style:italic;font-weight:900;font-display:fallback;src:url('https://example.org/assets/fonts/inter/Inter-VariableFont_slnt-Italic,wght.ttf') format('truetype');font-stretch:normal;}
+CSS
+			,
+			),
+			'single woff2 format font'       => array(
+				'fonts'    => array(
+					'DM Sans' =>
+						array(
+							array(
+								'src'          =>
+									array(
+										'https://example.org/assets/fonts/dm-sans/DMSans-Regular.woff2',
+									),
+								'font-family'  => 'DM Sans',
+								'font-stretch' => 'normal',
+								'font-style'   => 'normal',
+								'font-weight'  => '400',
+							),
+						),
+				),
+				'expected' => <<<CSS
+@font-face{font-family:"DM Sans";font-style:normal;font-weight:400;font-display:fallback;src:url('https://example.org/assets/fonts/dm-sans/DMSans-Regular.woff2') format('woff2');font-stretch:normal;}
+CSS
+			,
+			),
+			'multiple woff2 format fonts'    => array(
+				'fonts'    => array(
+					'DM Sans'       =>
+						array(
+							array(
+								'src'          =>
+									array(
+										'https://example.org/assets/fonts/dm-sans/DMSans-Regular.woff2',
+									),
+								'font-family'  => 'DM Sans',
+								'font-stretch' => 'normal',
+								'font-style'   => 'normal',
+								'font-weight'  => '400',
+							),
+							array(
+								'src'          =>
+									array(
+										'https://example.org/assets/fonts/dm-sans/DMSans-Regular-Italic.woff2',
+									),
+								'font-family'  => 'DM Sans',
+								'font-stretch' => 'normal',
+								'font-style'   => 'italic',
+								'font-weight'  => '400',
+							),
+							array(
+								'src'          =>
+									array(
+										'https://example.org/assets/fonts/dm-sans/DMSans-Bold.woff2',
+									),
+								'font-family'  => 'DM Sans',
+								'font-stretch' => 'normal',
+								'font-style'   => 'normal',
+								'font-weight'  => '700',
+							),
+							array(
+								'src'          =>
+									array(
+										'https://example.org/assets/fonts/dm-sans/DMSans-Bold-Italic.woff2',
+									),
+								'font-family'  => 'DM Sans',
+								'font-stretch' => 'normal',
+								'font-style'   => 'italic',
+								'font-weight'  => '700',
+							),
+						),
+					'IBM Plex Mono' =>
+						array(
+							array(
+								'src'          =>
+									array(
+										'https://example.org/assets/fonts/ibm-plex-mono/IBMPlexMono-Light.woff2',
+									),
+								'font-family'  => 'IBM Plex Mono',
+								'font-display' => 'block',
+								'font-stretch' => 'normal',
+								'font-style'   => 'normal',
+								'font-weight'  => '300',
+							),
+							array(
+								'src'          =>
+									array(
+										'https://example.org/assets/fonts/ibm-plex-mono/IBMPlexMono-Regular.woff2',
+									),
+								'font-family'  => 'IBM Plex Mono',
+								'font-display' => 'block',
+								'font-stretch' => 'normal',
+								'font-style'   => 'normal',
+								'font-weight'  => '400',
+							),
+							array(
+								'src'          =>
+									array(
+										'https://example.org/assets/fonts/ibm-plex-mono/IBMPlexMono-Italic.woff2',
+									),
+								'font-family'  => 'IBM Plex Mono',
+								'font-display' => 'block',
+								'font-stretch' => 'normal',
+								'font-style'   => 'italic',
+								'font-weight'  => '400',
+							),
+							array(
+								'src'          =>
+									array(
+										'https://example.org/assets/fonts/ibm-plex-mono/IBMPlexMono-Bold.woff2',
+									),
+								'font-family'  => 'IBM Plex Mono',
+								'font-display' => 'block',
+								'font-stretch' => 'normal',
+								'font-style'   => 'normal',
+								'font-weight'  => '700',
+							),
+						),
+				),
+				'expected' => <<<CSS
+@font-face{font-family:"DM Sans";font-style:normal;font-weight:400;font-display:fallback;src:url('https://example.org/assets/fonts/dm-sans/DMSans-Regular.woff2') format('woff2');font-stretch:normal;}
+@font-face{font-family:"DM Sans";font-style:italic;font-weight:400;font-display:fallback;src:url('https://example.org/assets/fonts/dm-sans/DMSans-Regular-Italic.woff2') format('woff2');font-stretch:normal;}
+@font-face{font-family:"DM Sans";font-style:normal;font-weight:700;font-display:fallback;src:url('https://example.org/assets/fonts/dm-sans/DMSans-Bold.woff2') format('woff2');font-stretch:normal;}
+@font-face{font-family:"DM Sans";font-style:italic;font-weight:700;font-display:fallback;src:url('https://example.org/assets/fonts/dm-sans/DMSans-Bold-Italic.woff2') format('woff2');font-stretch:normal;}
+@font-face{font-family:"IBM Plex Mono";font-style:normal;font-weight:300;font-display:block;src:url('https://example.org/assets/fonts/ibm-plex-mono/IBMPlexMono-Light.woff2') format('woff2');font-stretch:normal;}
+@font-face{font-family:"IBM Plex Mono";font-style:normal;font-weight:400;font-display:block;src:url('https://example.org/assets/fonts/ibm-plex-mono/IBMPlexMono-Regular.woff2') format('woff2');font-stretch:normal;}
+@font-face{font-family:"IBM Plex Mono";font-style:italic;font-weight:400;font-display:block;src:url('https://example.org/assets/fonts/ibm-plex-mono/IBMPlexMono-Italic.woff2') format('woff2');font-stretch:normal;}
+@font-face{font-family:"IBM Plex Mono";font-style:normal;font-weight:700;font-display:block;src:url('https://example.org/assets/fonts/ibm-plex-mono/IBMPlexMono-Bold.woff2') format('woff2');font-stretch:normal;}
+CSS
+			,
+			),
+		);
+	}
+}

--- a/phpunit/fonts/wpFontFace/generateAndPrint-test.php
+++ b/phpunit/fonts/wpFontFace/generateAndPrint-test.php
@@ -12,7 +12,7 @@ require_once __DIR__ . '/../wp-fonts-testcase.php';
  * @group fonts
  * @covers WP_Font_Face::generate_and_print
  */
-class Tests_Fonts_WPFontFace_GenerateAndPrint extends WP_Fonts_TestCase {
+class Tests_Fonts_WPFontFace_GenerateAndPrint extends WP_UnitTestCase {
 
 	/**
 	 * @dataProvider data_test_generate_and_print

--- a/phpunit/fonts/wpFontFace/generateAndPrint-test.php
+++ b/phpunit/fonts/wpFontFace/generateAndPrint-test.php
@@ -1,0 +1,84 @@
+<?php
+
+require_once __DIR__ . '/../wp-fonts-testcase.php';
+
+/**
+ * Test WP_Font_Face::generate_and_print().
+ *
+ * @package WordPress
+ * @subpackage Fonts API
+ *
+ * @since X.X.X
+ * @group fonts
+ * @covers WP_Font_Face::generate_and_print
+ */
+class Tests_Fonts_WPFontFace_GenerateAndPrint extends WP_Fonts_TestCase {
+
+	/**
+	 * @dataProvider data_test_generate_and_print
+	 *
+	 * @param array  $fonts Prepared fonts (to store in WP_Fonts_Provider_Local::$fonts property).
+	 * @param string $expected Expected CSS.
+	 */
+	public function test_generate_and_print( array $fonts, $expected ) {
+		$expected_output = sprintf( $expected['style-element'], $expected['font-face-css'] );
+		$this->expectOutputString( $expected_output );
+		$this->provider->print_styles();
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array
+	 */
+	public function data_test_generate_and_print() {
+		return array(
+			'truetype format' => array(
+				'fonts'    => array(
+					'open-sans-bold-italic-local' => array(
+						'provider'    => 'local',
+						'font-family' => 'Open Sans',
+						'font-style'  => 'italic',
+						'font-weight' => 'bold',
+						'src'         => 'http://example.org/assets/fonts/OpenSans-Italic-VariableFont_wdth,wght.ttf',
+					),
+				),
+				'expected' => array(
+					'style-element' => "<style id='wp-fonts-local' type='text/css'>\n%s\n</style>\n",
+					'font-face-css' => <<<CSS
+@font-face{font-family:"Open Sans";font-style:italic;font-weight:bold;src:url('http://example.org/assets/fonts/OpenSans-Italic-VariableFont_wdth,wght.ttf') format('truetype');}
+CSS
+				,
+				),
+			),
+			'woff2 format'    => array(
+				'fonts'    => array(
+					'source-serif-pro-200-900-normal-local' => array(
+						'provider'     => 'local',
+						'font-family'  => 'Source Serif Pro',
+						'font-style'   => 'normal',
+						'font-weight'  => '200 900',
+						'font-stretch' => 'normal',
+						'src'          => 'http://example.org/assets/fonts/source-serif-pro/SourceSerif4Variable-Roman.ttf.woff2',
+					),
+					'source-serif-pro-400-900-italic-local' => array(
+						'provider'     => 'local',
+						'font-family'  => 'Source Serif Pro',
+						'font-style'   => 'italic',
+						'font-weight'  => '200 900',
+						'font-stretch' => 'normal',
+						'src'          => 'http://example.org/assets/fonts/source-serif-pro/SourceSerif4Variable-Italic.ttf.woff2',
+					),
+				),
+				'expected' => array(
+					'style-element' => "<style id='wp-fonts-local' type='text/css'>\n%s\n</style>\n",
+					'font-face-css' => <<<CSS
+@font-face{font-family:"Source Serif Pro";font-style:normal;font-weight:200 900;font-stretch:normal;src:url('http://example.org/assets/fonts/source-serif-pro/SourceSerif4Variable-Roman.ttf.woff2') format('woff2');}@font-face{font-family:"Source Serif Pro";font-style:italic;font-weight:200 900;font-stretch:normal;src:url('http://example.org/assets/fonts/source-serif-pro/SourceSerif4Variable-Italic.ttf.woff2') format('woff2');}
+CSS
+
+				,
+				),
+			),
+		);
+	}
+}

--- a/phpunit/fonts/wpFontFace/generateAndPrint-test.php
+++ b/phpunit/fonts/wpFontFace/generateAndPrint-test.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Test case for the Fonts tests.
+ * Test case for WP_Font_Face::generate_and_print().
  *
  * @package    WordPress
  * @subpackage Fonts

--- a/phpunit/fonts/wpFontFace/generateAndPrint-test.php
+++ b/phpunit/fonts/wpFontFace/generateAndPrint-test.php
@@ -41,49 +41,200 @@ class Tests_Fonts_WPFontFace_GenerateAndPrint extends WP_UnitTestCase {
 	 */
 	public function data_test_generate_and_print() {
 		return array(
-			'truetype format' => array(
+			'single truetype format font' => array(
 				'fonts'    => array(
-					'open-sans-bold-italic-local' => array(
-						'provider'    => 'local',
-						'font-family' => 'Open Sans',
-						'font-style'  => 'italic',
-						'font-weight' => 'bold',
-						'src'         => 'http://example.org/assets/fonts/OpenSans-Italic-VariableFont_wdth,wght.ttf',
-					),
+					'Inter' =>
+						array (
+							array (
+								'src' =>
+									array (
+										'https://example.org/assets/fonts/inter/Inter-VariableFont_slnt,wght.ttf',
+									),
+								'font-family' => 'Inter',
+								'font-stretch' => 'normal',
+								'font-style' => 'normal',
+								'font-weight' => '200',
+							),
+						),
 				),
-				'expected' => array(
+                'expected' => array(
 					'style-element' => "<style id='wp-fonts-local' type='text/css'>\n%s\n</style>\n",
 					'font-face-css' => <<<CSS
-@font-face{font-family:"Open Sans";font-style:italic;font-weight:bold;src:url('http://example.org/assets/fonts/OpenSans-Italic-VariableFont_wdth,wght.ttf') format('truetype');}
+@font-face{font-family:Inter;font-style:normal;font-weight:200;font-display:fallback;src:url('https://example.org/assets/fonts/inter/Inter-VariableFont_slnt,wght.ttf') format('truetype');font-stretch:normal;}
 CSS
 				,
 				),
 			),
-			'woff2 format'    => array(
+			'multiple truetype format fonts' => array(
 				'fonts'    => array(
-					'source-serif-pro-200-900-normal-local' => array(
-						'provider'     => 'local',
-						'font-family'  => 'Source Serif Pro',
-						'font-style'   => 'normal',
-						'font-weight'  => '200 900',
-						'font-stretch' => 'normal',
-						'src'          => 'http://example.org/assets/fonts/source-serif-pro/SourceSerif4Variable-Roman.ttf.woff2',
-					),
-					'source-serif-pro-400-900-italic-local' => array(
-						'provider'     => 'local',
-						'font-family'  => 'Source Serif Pro',
-						'font-style'   => 'italic',
-						'font-weight'  => '200 900',
-						'font-stretch' => 'normal',
-						'src'          => 'http://example.org/assets/fonts/source-serif-pro/SourceSerif4Variable-Italic.ttf.woff2',
-					),
+					'Inter' =>
+						array (
+							array (
+								'src' =>
+									array (
+										'https://example.org/assets/fonts/inter/Inter-VariableFont_slnt,wght.ttf',
+									),
+								'font-family' => 'Inter',
+								'font-stretch' => 'normal',
+								'font-style' => 'normal',
+								'font-weight' => '200',
+							),
+							array (
+								'src' =>
+									array (
+										'https://example.org/assets/fonts/inter/Inter-VariableFont_slnt,wght.ttf',
+									),
+								'font-family' => 'Inter',
+								'font-stretch' => 'normal',
+								'font-style' => 'italic',
+								'font-weight' => '900',
+							),
+						),
 				),
 				'expected' => array(
 					'style-element' => "<style id='wp-fonts-local' type='text/css'>\n%s\n</style>\n",
 					'font-face-css' => <<<CSS
-@font-face{font-family:"Source Serif Pro";font-style:normal;font-weight:200 900;font-stretch:normal;src:url('http://example.org/assets/fonts/source-serif-pro/SourceSerif4Variable-Roman.ttf.woff2') format('woff2');}@font-face{font-family:"Source Serif Pro";font-style:italic;font-weight:200 900;font-stretch:normal;src:url('http://example.org/assets/fonts/source-serif-pro/SourceSerif4Variable-Italic.ttf.woff2') format('woff2');}
+@font-face{font-family:Inter;font-style:normal;font-weight:200 900;font-display:fallback;src:url('https://example.org/assets/fonts/inter/Inter-VariableFont_slnt,wght.ttf') format('truetype');font-stretch:normal;}
 CSS
-
+				,
+				),
+			),
+			'single woff2 format font'    => array(
+				'fonts'    => array(
+					'DM Sans' =>
+						array (
+							array (
+								'src' =>
+									array (
+										'https://example.org/assets/fonts/dm-sans/DMSans-Regular.woff2',
+									),
+								'font-family' => 'DM Sans',
+								'font-stretch' => 'normal',
+								'font-style' => 'normal',
+								'font-weight' => '400',
+							),
+						),
+				),
+				'expected' => array(
+					'style-element' => "<style id='wp-fonts-local' type='text/css'>\n%s\n</style>\n",
+					'font-face-css' => <<<CSS
+@font-face{font-family:"DM Sans";font-style:normal;font-weight:400;font-display:fallback;src:url('https://example.org/assets/fonts/dm-sans/DMSans-Regular.woff2') format('woff2');font-stretch:normal;}
+@font-face{font-family:"DM Sans";font-style:italic;font-weight:400;font-display:fallback;src:url('https://example.org/assets/fonts/dm-sans/DMSans-Regular-Italic.woff2') format('woff2');font-stretch:normal;}
+@font-face{font-family:"DM Sans";font-style:normal;font-weight:700;font-display:fallback;src:url('https://example.org/assets/fonts/dm-sans/DMSans-Bold.woff2') format('woff2');font-stretch:normal;}
+@font-face{font-family:"DM Sans";font-style:italic;font-weight:700;font-display:fallback;src:url('https://example.org/assets/fonts/dm-sans/DMSans-Bold-Italic.woff2') format('woff2');font-stretch:normal;}
+@font-face{font-family:"IBM Plex Mono";font-style:normal;font-weight:300;font-display:block;src:url('https://example.org/assets/fonts/ibm-plex-mono/IBMPlexMono-Light.woff2') format('woff2');font-stretch:normal;}
+@font-face{font-family:"IBM Plex Mono";font-style:normal;font-weight:400;font-display:block;src:url('https://example.org/assets/fonts/ibm-plex-mono/IBMPlexMono-Regular.woff2') format('woff2');font-stretch:normal;}
+@font-face{font-family:"IBM Plex Mono";font-style:italic;font-weight:400;font-display:block;src:url('https://example.org/assets/fonts/ibm-plex-mono/IBMPlexMono-Italic.woff2') format('woff2');font-stretch:normal;}
+@font-face{font-family:"IBM Plex Mono";font-style:normal;font-weight:700;font-display:block;src:url('https://example.org/assets/fonts/ibm-plex-mono/IBMPlexMono-Bold.woff2') format('woff2');font-stretch:normal;}
+CSS
+				,
+				),
+			),
+			'multiple woff2 format fonts'    => array(
+				'fonts'    => array(
+					'DM Sans' =>
+						array (
+							array (
+								'src' =>
+									array (
+										'https://example.org/assets/fonts/dm-sans/DMSans-Regular.woff2',
+									),
+								'font-family' => 'DM Sans',
+								'font-stretch' => 'normal',
+								'font-style' => 'normal',
+								'font-weight' => '400',
+							),
+							array (
+								'src' =>
+									array (
+										'https://example.org/assets/fonts/dm-sans/DMSans-Regular-Italic.woff2',
+									),
+								'font-family' => 'DM Sans',
+								'font-stretch' => 'normal',
+								'font-style' => 'italic',
+								'font-weight' => '400',
+							),
+							array (
+								'src' =>
+									array (
+										'https://example.org/assets/fonts/dm-sans/DMSans-Bold.woff2',
+									),
+								'font-family' => 'DM Sans',
+								'font-stretch' => 'normal',
+								'font-style' => 'normal',
+								'font-weight' => '700',
+							),
+							array (
+								'src' =>
+									array (
+										'https://example.org/assets/fonts/dm-sans/DMSans-Bold-Italic.woff2',
+									),
+								'font-family' => 'DM Sans',
+								'font-stretch' => 'normal',
+								'font-style' => 'italic',
+								'font-weight' => '700',
+							),
+						),
+					'IBM Plex Mono' =>
+						array (
+							array (
+								'src' =>
+									array (
+										'https://example.org/assets/fonts/ibm-plex-mono/IBMPlexMono-Light.woff2',
+									),
+								'font-family' => 'IBM Plex Mono',
+								'font-display' => 'block',
+								'font-stretch' => 'normal',
+								'font-style' => 'normal',
+								'font-weight' => '300',
+							),
+							array (
+								'src' =>
+									array (
+										'https://example.org/assets/fonts/ibm-plex-mono/IBMPlexMono-Regular.woff2',
+									),
+								'font-family' => 'IBM Plex Mono',
+								'font-display' => 'block',
+								'font-stretch' => 'normal',
+								'font-style' => 'normal',
+								'font-weight' => '400',
+							),
+							array (
+								'src' =>
+									array (
+										'https://example.org/assets/fonts/ibm-plex-mono/IBMPlexMono-Italic.woff2',
+									),
+								'font-family' => 'IBM Plex Mono',
+								'font-display' => 'block',
+								'font-stretch' => 'normal',
+								'font-style' => 'italic',
+								'font-weight' => '400',
+							),
+							array (
+								'src' =>
+									array (
+										'https://example.org/assets/fonts/ibm-plex-mono/IBMPlexMono-Bold.woff2',
+									),
+								'font-family' => 'IBM Plex Mono',
+								'font-display' => 'block',
+								'font-stretch' => 'normal',
+								'font-style' => 'normal',
+								'font-weight' => '700',
+							),
+						),
+				),
+				'expected' => array(
+					'style-element' => "<style id='wp-fonts-local' type='text/css'>\n%s\n</style>\n",
+					'font-face-css' => <<<CSS
+@font-face{font-family:"DM Sans";font-style:normal;font-weight:400;font-display:fallback;src:url('https://example.org/assets/fonts/dm-sans/DMSans-Regular.woff2') format('woff2');font-stretch:normal;}
+@font-face{font-family:"DM Sans";font-style:italic;font-weight:400;font-display:fallback;src:url('https://example.org/assets/fonts/dm-sans/DMSans-Regular-Italic.woff2') format('woff2');font-stretch:normal;}
+@font-face{font-family:"DM Sans";font-style:normal;font-weight:700;font-display:fallback;src:url('https://example.org/assets/fonts/dm-sans/DMSans-Bold.woff2') format('woff2');font-stretch:normal;}
+@font-face{font-family:"DM Sans";font-style:italic;font-weight:700;font-display:fallback;src:url('https://example.org/assets/fonts/dm-sans/DMSans-Bold-Italic.woff2') format('woff2');font-stretch:normal;}
+@font-face{font-family:"IBM Plex Mono";font-style:normal;font-weight:300;font-display:block;src:url('https://example.org/assets/fonts/ibm-plex-mono/IBMPlexMono-Light.woff2') format('woff2');font-stretch:normal;}
+@font-face{font-family:"IBM Plex Mono";font-style:normal;font-weight:400;font-display:block;src:url('https://example.org/assets/fonts/ibm-plex-mono/IBMPlexMono-Regular.woff2') format('woff2');font-stretch:normal;}
+@font-face{font-family:"IBM Plex Mono";font-style:italic;font-weight:400;font-display:block;src:url('https://example.org/assets/fonts/ibm-plex-mono/IBMPlexMono-Italic.woff2') format('woff2');font-stretch:normal;}
+@font-face{font-family:"IBM Plex Mono";font-style:normal;font-weight:700;font-display:block;src:url('https://example.org/assets/fonts/ibm-plex-mono/IBMPlexMono-Bold.woff2') format('woff2');font-stretch:normal;}
+CSS
 				,
 				),
 			),

--- a/phpunit/fonts/wpFontFace/generateAndPrint-test.php
+++ b/phpunit/fonts/wpFontFace/generateAndPrint-test.php
@@ -1,5 +1,13 @@
 <?php
 
+// These code is only needed if the Font API is enabled.
+// It should be removed after Font Manager is merged into Gutenberg.
+if ( ! class_exists( 'WP_Font_Face' ) ) {
+	require_once __DIR__ . '/../../../lib/experimental/fonts/class-wp-font-face.php';
+	require_once __DIR__ . '/../../../lib/experimental/fonts/class-wp-font-face-resolver.php';
+	require_once __DIR__ . '/../../../lib/experimental/fonts/fonts.php';
+}
+
 /**
  * Test WP_Font_Face::generate_and_print().
  *
@@ -29,7 +37,8 @@ class Tests_Fonts_WPFontFace_GenerateAndPrint extends WP_UnitTestCase {
 	 * @param string $expected Expected CSS.
 	 */
 	public function test_generate_and_print( array $fonts, $expected ) {
-		$expected_output = sprintf( $expected['style-element'], $expected['font-face-css'] );
+		$style_element   = "<style id='wp-fonts-local' type='text/css'>\n%s\n</style>\n";
+		$expected_output = sprintf( $style_element, $expected );
 		$this->expectOutputString( $expected_output );
 		$this->font_face->generate_and_print( $fonts );
 	}
@@ -41,185 +50,173 @@ class Tests_Fonts_WPFontFace_GenerateAndPrint extends WP_UnitTestCase {
 	 */
 	public function data_test_generate_and_print() {
 		return array(
-			'single truetype format font' => array(
+			'single truetype format font'    => array(
 				'fonts'    => array(
 					'Inter' =>
-						array (
-							array (
-								'src' =>
-									array (
+						array(
+							array(
+								'src'          =>
+									array(
 										'https://example.org/assets/fonts/inter/Inter-VariableFont_slnt,wght.ttf',
 									),
-								'font-family' => 'Inter',
+								'font-family'  => 'Inter',
 								'font-stretch' => 'normal',
-								'font-style' => 'normal',
-								'font-weight' => '200',
+								'font-style'   => 'normal',
+								'font-weight'  => '200',
 							),
 						),
 				),
-                'expected' => array(
-					'style-element' => "<style id='wp-fonts-local' type='text/css'>\n%s\n</style>\n",
-					'font-face-css' => <<<CSS
+				'expected' => <<<CSS
 @font-face{font-family:Inter;font-style:normal;font-weight:200;font-display:fallback;src:url('https://example.org/assets/fonts/inter/Inter-VariableFont_slnt,wght.ttf') format('truetype');font-stretch:normal;}
 CSS
-				,
-				),
+			,
 			),
 			'multiple truetype format fonts' => array(
 				'fonts'    => array(
 					'Inter' =>
-						array (
-							array (
-								'src' =>
-									array (
+						array(
+							array(
+								'src'          =>
+									array(
 										'https://example.org/assets/fonts/inter/Inter-VariableFont_slnt,wght.ttf',
 									),
-								'font-family' => 'Inter',
+								'font-family'  => 'Inter',
 								'font-stretch' => 'normal',
-								'font-style' => 'normal',
-								'font-weight' => '200',
+								'font-style'   => 'normal',
+								'font-weight'  => '200',
 							),
-							array (
-								'src' =>
-									array (
+							array(
+								'src'          =>
+									array(
 										'https://example.org/assets/fonts/inter/Inter-VariableFont_slnt-Italic,wght.ttf',
 									),
-								'font-family' => 'Inter',
+								'font-family'  => 'Inter',
 								'font-stretch' => 'normal',
-								'font-style' => 'italic',
-								'font-weight' => '900',
+								'font-style'   => 'italic',
+								'font-weight'  => '900',
 							),
 						),
 				),
-				'expected' => array(
-					'style-element' => "<style id='wp-fonts-local' type='text/css'>\n%s\n</style>\n",
-					'font-face-css' => <<<CSS
+				'expected' => <<<CSS
 @font-face{font-family:Inter;font-style:normal;font-weight:200;font-display:fallback;src:url('https://example.org/assets/fonts/inter/Inter-VariableFont_slnt,wght.ttf') format('truetype');font-stretch:normal;}
 @font-face{font-family:Inter;font-style:italic;font-weight:900;font-display:fallback;src:url('https://example.org/assets/fonts/inter/Inter-VariableFont_slnt-Italic,wght.ttf') format('truetype');font-stretch:normal;}
 CSS
-				,
-				),
+			,
 			),
-			'single woff2 format font'    => array(
+			'single woff2 format font'       => array(
 				'fonts'    => array(
 					'DM Sans' =>
-						array (
-							array (
-								'src' =>
-									array (
+						array(
+							array(
+								'src'          =>
+									array(
 										'https://example.org/assets/fonts/dm-sans/DMSans-Regular.woff2',
 									),
-								'font-family' => 'DM Sans',
+								'font-family'  => 'DM Sans',
 								'font-stretch' => 'normal',
-								'font-style' => 'normal',
-								'font-weight' => '400',
+								'font-style'   => 'normal',
+								'font-weight'  => '400',
 							),
 						),
 				),
-				'expected' => array(
-					'style-element' => "<style id='wp-fonts-local' type='text/css'>\n%s\n</style>\n",
-					'font-face-css' => <<<CSS
+				'expected' => <<<CSS
 @font-face{font-family:"DM Sans";font-style:normal;font-weight:400;font-display:fallback;src:url('https://example.org/assets/fonts/dm-sans/DMSans-Regular.woff2') format('woff2');font-stretch:normal;}
-CSS
-				,
-				),
+CSS,
 			),
 			'multiple woff2 format fonts'    => array(
 				'fonts'    => array(
-					'DM Sans' =>
-						array (
-							array (
-								'src' =>
-									array (
+					'DM Sans'       =>
+						array(
+							array(
+								'src'          =>
+									array(
 										'https://example.org/assets/fonts/dm-sans/DMSans-Regular.woff2',
 									),
-								'font-family' => 'DM Sans',
+								'font-family'  => 'DM Sans',
 								'font-stretch' => 'normal',
-								'font-style' => 'normal',
-								'font-weight' => '400',
+								'font-style'   => 'normal',
+								'font-weight'  => '400',
 							),
-							array (
-								'src' =>
-									array (
+							array(
+								'src'          =>
+									array(
 										'https://example.org/assets/fonts/dm-sans/DMSans-Regular-Italic.woff2',
 									),
-								'font-family' => 'DM Sans',
+								'font-family'  => 'DM Sans',
 								'font-stretch' => 'normal',
-								'font-style' => 'italic',
-								'font-weight' => '400',
+								'font-style'   => 'italic',
+								'font-weight'  => '400',
 							),
-							array (
-								'src' =>
-									array (
+							array(
+								'src'          =>
+									array(
 										'https://example.org/assets/fonts/dm-sans/DMSans-Bold.woff2',
 									),
-								'font-family' => 'DM Sans',
+								'font-family'  => 'DM Sans',
 								'font-stretch' => 'normal',
-								'font-style' => 'normal',
-								'font-weight' => '700',
+								'font-style'   => 'normal',
+								'font-weight'  => '700',
 							),
-							array (
-								'src' =>
-									array (
+							array(
+								'src'          =>
+									array(
 										'https://example.org/assets/fonts/dm-sans/DMSans-Bold-Italic.woff2',
 									),
-								'font-family' => 'DM Sans',
+								'font-family'  => 'DM Sans',
 								'font-stretch' => 'normal',
-								'font-style' => 'italic',
-								'font-weight' => '700',
+								'font-style'   => 'italic',
+								'font-weight'  => '700',
 							),
 						),
 					'IBM Plex Mono' =>
-						array (
-							array (
-								'src' =>
-									array (
+						array(
+							array(
+								'src'          =>
+									array(
 										'https://example.org/assets/fonts/ibm-plex-mono/IBMPlexMono-Light.woff2',
 									),
-								'font-family' => 'IBM Plex Mono',
+								'font-family'  => 'IBM Plex Mono',
 								'font-display' => 'block',
 								'font-stretch' => 'normal',
-								'font-style' => 'normal',
-								'font-weight' => '300',
+								'font-style'   => 'normal',
+								'font-weight'  => '300',
 							),
-							array (
-								'src' =>
-									array (
+							array(
+								'src'          =>
+									array(
 										'https://example.org/assets/fonts/ibm-plex-mono/IBMPlexMono-Regular.woff2',
 									),
-								'font-family' => 'IBM Plex Mono',
+								'font-family'  => 'IBM Plex Mono',
 								'font-display' => 'block',
 								'font-stretch' => 'normal',
-								'font-style' => 'normal',
-								'font-weight' => '400',
+								'font-style'   => 'normal',
+								'font-weight'  => '400',
 							),
-							array (
-								'src' =>
-									array (
+							array(
+								'src'          =>
+									array(
 										'https://example.org/assets/fonts/ibm-plex-mono/IBMPlexMono-Italic.woff2',
 									),
-								'font-family' => 'IBM Plex Mono',
+								'font-family'  => 'IBM Plex Mono',
 								'font-display' => 'block',
 								'font-stretch' => 'normal',
-								'font-style' => 'italic',
-								'font-weight' => '400',
+								'font-style'   => 'italic',
+								'font-weight'  => '400',
 							),
-							array (
-								'src' =>
-									array (
+							array(
+								'src'          =>
+									array(
 										'https://example.org/assets/fonts/ibm-plex-mono/IBMPlexMono-Bold.woff2',
 									),
-								'font-family' => 'IBM Plex Mono',
+								'font-family'  => 'IBM Plex Mono',
 								'font-display' => 'block',
 								'font-stretch' => 'normal',
-								'font-style' => 'normal',
-								'font-weight' => '700',
+								'font-style'   => 'normal',
+								'font-weight'  => '700',
 							),
 						),
 				),
-				'expected' => array(
-					'style-element' => "<style id='wp-fonts-local' type='text/css'>\n%s\n</style>\n",
-					'font-face-css' => <<<CSS
+				'expected' => <<<CSS
 @font-face{font-family:"DM Sans";font-style:normal;font-weight:400;font-display:fallback;src:url('https://example.org/assets/fonts/dm-sans/DMSans-Regular.woff2') format('woff2');font-stretch:normal;}
 @font-face{font-family:"DM Sans";font-style:italic;font-weight:400;font-display:fallback;src:url('https://example.org/assets/fonts/dm-sans/DMSans-Regular-Italic.woff2') format('woff2');font-stretch:normal;}
 @font-face{font-family:"DM Sans";font-style:normal;font-weight:700;font-display:fallback;src:url('https://example.org/assets/fonts/dm-sans/DMSans-Bold.woff2') format('woff2');font-stretch:normal;}
@@ -229,8 +226,7 @@ CSS
 @font-face{font-family:"IBM Plex Mono";font-style:italic;font-weight:400;font-display:block;src:url('https://example.org/assets/fonts/ibm-plex-mono/IBMPlexMono-Italic.woff2') format('woff2');font-stretch:normal;}
 @font-face{font-family:"IBM Plex Mono";font-style:normal;font-weight:700;font-display:block;src:url('https://example.org/assets/fonts/ibm-plex-mono/IBMPlexMono-Bold.woff2') format('woff2');font-stretch:normal;}
 CSS
-				,
-				),
+			,
 			),
 		);
 	}

--- a/phpunit/fonts/wpFontFace/generateAndPrint-test.php
+++ b/phpunit/fonts/wpFontFace/generateAndPrint-test.php
@@ -1,7 +1,5 @@
 <?php
 
-require_once __DIR__ . '/../wp-fonts-testcase.php';
-
 /**
  * Test WP_Font_Face::generate_and_print().
  *

--- a/phpunit/fonts/wpFontFace/generateAndPrint-test.php
+++ b/phpunit/fonts/wpFontFace/generateAndPrint-test.php
@@ -13,6 +13,16 @@ require_once __DIR__ . '/../wp-fonts-testcase.php';
  * @covers WP_Font_Face::generate_and_print
  */
 class Tests_Fonts_WPFontFace_GenerateAndPrint extends WP_UnitTestCase {
+	/**
+	 * @var WP_Font_Face
+	 */
+	private $font_face;
+
+	public function set_up() {
+		parent::set_up();
+
+		$this->font_face = new WP_Font_Face();
+	}
 
 	/**
 	 * @dataProvider data_test_generate_and_print
@@ -23,7 +33,7 @@ class Tests_Fonts_WPFontFace_GenerateAndPrint extends WP_UnitTestCase {
 	public function test_generate_and_print( array $fonts, $expected ) {
 		$expected_output = sprintf( $expected['style-element'], $expected['font-face-css'] );
 		$this->expectOutputString( $expected_output );
-		$this->provider->print_styles();
+		$this->font_face->generate_and_print( $fonts );
 	}
 
 	/**

--- a/phpunit/fonts/wpFontFace/generateAndPrint-test.php
+++ b/phpunit/fonts/wpFontFace/generateAndPrint-test.php
@@ -12,7 +12,7 @@ if ( ! class_exists( 'WP_Font_Face' ) ) {
  * Test WP_Font_Face::generate_and_print().
  *
  * @package WordPress
- * @subpackage Fonts API
+ * @subpackage Fonts
  *
  * @since X.X.X
  * @group fonts

--- a/phpunit/fonts/wpFontFace/generateAndPrint-test.php
+++ b/phpunit/fonts/wpFontFace/generateAndPrint-test.php
@@ -3,11 +3,11 @@
  * Test case for the Fonts API tests.
  *
  * @package    WordPress
- * @subpackage Fonts API
+ * @subpackage Fonts
  */
 
 /**
- * These code is only needed if the Font API is enabled.
+ * This code is only needed if the Font API is enabled.
  * It should be removed after Font Manager is merged into Gutenberg.
  */
 if ( ! class_exists( 'WP_Font_Face' ) ) {

--- a/phpunit/fonts/wpFontFace/generateAndPrint-test.php
+++ b/phpunit/fonts/wpFontFace/generateAndPrint-test.php
@@ -41,10 +41,10 @@ class Tests_Fonts_WPFontFace_GenerateAndPrint extends WP_UnitTestCase {
 	/**
 	 * @dataProvider data_test_generate_and_print
 	 *
-	 * @param array  $fonts Prepared fonts (to store in WP_Fonts_Provider_Local::$fonts property).
+	 * @param array  $fonts Prepared fonts.
 	 * @param string $expected Expected CSS.
 	 */
-	public function test_generate_and_print( array $fonts, $expected ) {
+	public function test_should_generate_and_print_passed_fonts( array $fonts, $expected ) {
 		$style_element   = "<style id='wp-fonts-local' type='text/css'>\n%s\n</style>\n";
 		$expected_output = sprintf( $style_element, $expected );
 		$this->expectOutputString( $expected_output );

--- a/phpunit/fonts/wpFontFace/generateAndPrint-test.php
+++ b/phpunit/fonts/wpFontFace/generateAndPrint-test.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Test case for the Fonts API tests.
+ * Test case for the Fonts tests.
  *
  * @package    WordPress
  * @subpackage Fonts

--- a/phpunit/fonts/wpFontFace/generateAndPrint-test.php
+++ b/phpunit/fonts/wpFontFace/generateAndPrint-test.php
@@ -1,7 +1,15 @@
 <?php
+/**
+ * Test case for the Fonts API tests.
+ *
+ * @package    WordPress
+ * @subpackage Fonts API
+ */
 
-// These code is only needed if the Font API is enabled.
-// It should be removed after Font Manager is merged into Gutenberg.
+/**
+ * These code is only needed if the Font API is enabled.
+ * It should be removed after Font Manager is merged into Gutenberg.
+ */
 if ( ! class_exists( 'WP_Font_Face' ) ) {
 	require_once __DIR__ . '/../../../lib/experimental/fonts/class-wp-font-face.php';
 	require_once __DIR__ . '/../../../lib/experimental/fonts/class-wp-font-face-resolver.php';
@@ -121,7 +129,8 @@ CSS
 				),
 				'expected' => <<<CSS
 @font-face{font-family:"DM Sans";font-style:normal;font-weight:400;font-display:fallback;src:url('https://example.org/assets/fonts/dm-sans/DMSans-Regular.woff2') format('woff2');font-stretch:normal;}
-CSS,
+CSS
+				,
 			),
 			'multiple woff2 format fonts'    => array(
 				'fonts'    => array(

--- a/phpunit/fonts/wpFontFace/generateAndPrint-test.php
+++ b/phpunit/fonts/wpFontFace/generateAndPrint-test.php
@@ -82,7 +82,7 @@ CSS
 							array (
 								'src' =>
 									array (
-										'https://example.org/assets/fonts/inter/Inter-VariableFont_slnt,wght.ttf',
+										'https://example.org/assets/fonts/inter/Inter-VariableFont_slnt-Italic,wght.ttf',
 									),
 								'font-family' => 'Inter',
 								'font-stretch' => 'normal',
@@ -94,7 +94,8 @@ CSS
 				'expected' => array(
 					'style-element' => "<style id='wp-fonts-local' type='text/css'>\n%s\n</style>\n",
 					'font-face-css' => <<<CSS
-@font-face{font-family:Inter;font-style:normal;font-weight:200 900;font-display:fallback;src:url('https://example.org/assets/fonts/inter/Inter-VariableFont_slnt,wght.ttf') format('truetype');font-stretch:normal;}
+@font-face{font-family:Inter;font-style:normal;font-weight:200;font-display:fallback;src:url('https://example.org/assets/fonts/inter/Inter-VariableFont_slnt,wght.ttf') format('truetype');font-stretch:normal;}
+@font-face{font-family:Inter;font-style:italic;font-weight:900;font-display:fallback;src:url('https://example.org/assets/fonts/inter/Inter-VariableFont_slnt-Italic,wght.ttf') format('truetype');font-stretch:normal;}
 CSS
 				,
 				),
@@ -119,13 +120,6 @@ CSS
 					'style-element' => "<style id='wp-fonts-local' type='text/css'>\n%s\n</style>\n",
 					'font-face-css' => <<<CSS
 @font-face{font-family:"DM Sans";font-style:normal;font-weight:400;font-display:fallback;src:url('https://example.org/assets/fonts/dm-sans/DMSans-Regular.woff2') format('woff2');font-stretch:normal;}
-@font-face{font-family:"DM Sans";font-style:italic;font-weight:400;font-display:fallback;src:url('https://example.org/assets/fonts/dm-sans/DMSans-Regular-Italic.woff2') format('woff2');font-stretch:normal;}
-@font-face{font-family:"DM Sans";font-style:normal;font-weight:700;font-display:fallback;src:url('https://example.org/assets/fonts/dm-sans/DMSans-Bold.woff2') format('woff2');font-stretch:normal;}
-@font-face{font-family:"DM Sans";font-style:italic;font-weight:700;font-display:fallback;src:url('https://example.org/assets/fonts/dm-sans/DMSans-Bold-Italic.woff2') format('woff2');font-stretch:normal;}
-@font-face{font-family:"IBM Plex Mono";font-style:normal;font-weight:300;font-display:block;src:url('https://example.org/assets/fonts/ibm-plex-mono/IBMPlexMono-Light.woff2') format('woff2');font-stretch:normal;}
-@font-face{font-family:"IBM Plex Mono";font-style:normal;font-weight:400;font-display:block;src:url('https://example.org/assets/fonts/ibm-plex-mono/IBMPlexMono-Regular.woff2') format('woff2');font-stretch:normal;}
-@font-face{font-family:"IBM Plex Mono";font-style:italic;font-weight:400;font-display:block;src:url('https://example.org/assets/fonts/ibm-plex-mono/IBMPlexMono-Italic.woff2') format('woff2');font-stretch:normal;}
-@font-face{font-family:"IBM Plex Mono";font-style:normal;font-weight:700;font-display:block;src:url('https://example.org/assets/fonts/ibm-plex-mono/IBMPlexMono-Bold.woff2') format('woff2');font-stretch:normal;}
 CSS
 				,
 				),

--- a/phpunit/fonts/wpFontFace/generateAndPrint-test.php
+++ b/phpunit/fonts/wpFontFace/generateAndPrint-test.php
@@ -6,9 +6,11 @@
  * @subpackage Fonts
  */
 
-/**
+require_once __DIR__ . '/../wp-font-face-tests-dataset.php';
+
+/*
  * This code is only needed if the Font API is enabled.
- * It should be removed after Font Manager is merged into Gutenberg.
+ * @todo remove this code when Font Library is merged into Gutenberg.
  */
 if ( ! class_exists( 'WP_Font_Face' ) ) {
 	require_once __DIR__ . '/../../../lib/experimental/fonts/class-wp-font-face.php';
@@ -24,219 +26,24 @@ if ( ! class_exists( 'WP_Font_Face' ) ) {
  *
  * @since X.X.X
  * @group fonts
+ * @group fontface
  * @covers WP_Font_Face::generate_and_print
  */
 class Tests_Fonts_WPFontFace_GenerateAndPrint extends WP_UnitTestCase {
-	/**
-	 * @var WP_Font_Face
-	 */
-	private $font_face;
-
-	public function set_up() {
-		parent::set_up();
-
-		$this->font_face = new WP_Font_Face();
-	}
+	use WP_Font_Face_Tests_Datasets;
 
 	/**
-	 * @dataProvider data_test_generate_and_print
+	 * @dataProvider data_should_print_given_fonts
 	 *
 	 * @param array  $fonts Prepared fonts.
 	 * @param string $expected Expected CSS.
 	 */
-	public function test_should_generate_and_print_passed_fonts( array $fonts, $expected ) {
+	public function test_should_generate_and_print_given_fonts( array $fonts, $expected ) {
+		$font_face       = new WP_Font_Face();
 		$style_element   = "<style id='wp-fonts-local' type='text/css'>\n%s\n</style>\n";
 		$expected_output = sprintf( $style_element, $expected );
-		$this->expectOutputString( $expected_output );
-		$this->font_face->generate_and_print( $fonts );
-	}
 
-	/**
-	 * Data provider.
-	 *
-	 * @return array
-	 */
-	public function data_test_generate_and_print() {
-		return array(
-			'single truetype format font'    => array(
-				'fonts'    => array(
-					'Inter' =>
-						array(
-							array(
-								'src'          =>
-									array(
-										'https://example.org/assets/fonts/inter/Inter-VariableFont_slnt,wght.ttf',
-									),
-								'font-family'  => 'Inter',
-								'font-stretch' => 'normal',
-								'font-style'   => 'normal',
-								'font-weight'  => '200',
-							),
-						),
-				),
-				'expected' => <<<CSS
-@font-face{font-family:Inter;font-style:normal;font-weight:200;font-display:fallback;src:url('https://example.org/assets/fonts/inter/Inter-VariableFont_slnt,wght.ttf') format('truetype');font-stretch:normal;}
-CSS
-			,
-			),
-			'multiple truetype format fonts' => array(
-				'fonts'    => array(
-					'Inter' =>
-						array(
-							array(
-								'src'          =>
-									array(
-										'https://example.org/assets/fonts/inter/Inter-VariableFont_slnt,wght.ttf',
-									),
-								'font-family'  => 'Inter',
-								'font-stretch' => 'normal',
-								'font-style'   => 'normal',
-								'font-weight'  => '200',
-							),
-							array(
-								'src'          =>
-									array(
-										'https://example.org/assets/fonts/inter/Inter-VariableFont_slnt-Italic,wght.ttf',
-									),
-								'font-family'  => 'Inter',
-								'font-stretch' => 'normal',
-								'font-style'   => 'italic',
-								'font-weight'  => '900',
-							),
-						),
-				),
-				'expected' => <<<CSS
-@font-face{font-family:Inter;font-style:normal;font-weight:200;font-display:fallback;src:url('https://example.org/assets/fonts/inter/Inter-VariableFont_slnt,wght.ttf') format('truetype');font-stretch:normal;}
-@font-face{font-family:Inter;font-style:italic;font-weight:900;font-display:fallback;src:url('https://example.org/assets/fonts/inter/Inter-VariableFont_slnt-Italic,wght.ttf') format('truetype');font-stretch:normal;}
-CSS
-			,
-			),
-			'single woff2 format font'       => array(
-				'fonts'    => array(
-					'DM Sans' =>
-						array(
-							array(
-								'src'          =>
-									array(
-										'https://example.org/assets/fonts/dm-sans/DMSans-Regular.woff2',
-									),
-								'font-family'  => 'DM Sans',
-								'font-stretch' => 'normal',
-								'font-style'   => 'normal',
-								'font-weight'  => '400',
-							),
-						),
-				),
-				'expected' => <<<CSS
-@font-face{font-family:"DM Sans";font-style:normal;font-weight:400;font-display:fallback;src:url('https://example.org/assets/fonts/dm-sans/DMSans-Regular.woff2') format('woff2');font-stretch:normal;}
-CSS
-				,
-			),
-			'multiple woff2 format fonts'    => array(
-				'fonts'    => array(
-					'DM Sans'       =>
-						array(
-							array(
-								'src'          =>
-									array(
-										'https://example.org/assets/fonts/dm-sans/DMSans-Regular.woff2',
-									),
-								'font-family'  => 'DM Sans',
-								'font-stretch' => 'normal',
-								'font-style'   => 'normal',
-								'font-weight'  => '400',
-							),
-							array(
-								'src'          =>
-									array(
-										'https://example.org/assets/fonts/dm-sans/DMSans-Regular-Italic.woff2',
-									),
-								'font-family'  => 'DM Sans',
-								'font-stretch' => 'normal',
-								'font-style'   => 'italic',
-								'font-weight'  => '400',
-							),
-							array(
-								'src'          =>
-									array(
-										'https://example.org/assets/fonts/dm-sans/DMSans-Bold.woff2',
-									),
-								'font-family'  => 'DM Sans',
-								'font-stretch' => 'normal',
-								'font-style'   => 'normal',
-								'font-weight'  => '700',
-							),
-							array(
-								'src'          =>
-									array(
-										'https://example.org/assets/fonts/dm-sans/DMSans-Bold-Italic.woff2',
-									),
-								'font-family'  => 'DM Sans',
-								'font-stretch' => 'normal',
-								'font-style'   => 'italic',
-								'font-weight'  => '700',
-							),
-						),
-					'IBM Plex Mono' =>
-						array(
-							array(
-								'src'          =>
-									array(
-										'https://example.org/assets/fonts/ibm-plex-mono/IBMPlexMono-Light.woff2',
-									),
-								'font-family'  => 'IBM Plex Mono',
-								'font-display' => 'block',
-								'font-stretch' => 'normal',
-								'font-style'   => 'normal',
-								'font-weight'  => '300',
-							),
-							array(
-								'src'          =>
-									array(
-										'https://example.org/assets/fonts/ibm-plex-mono/IBMPlexMono-Regular.woff2',
-									),
-								'font-family'  => 'IBM Plex Mono',
-								'font-display' => 'block',
-								'font-stretch' => 'normal',
-								'font-style'   => 'normal',
-								'font-weight'  => '400',
-							),
-							array(
-								'src'          =>
-									array(
-										'https://example.org/assets/fonts/ibm-plex-mono/IBMPlexMono-Italic.woff2',
-									),
-								'font-family'  => 'IBM Plex Mono',
-								'font-display' => 'block',
-								'font-stretch' => 'normal',
-								'font-style'   => 'italic',
-								'font-weight'  => '400',
-							),
-							array(
-								'src'          =>
-									array(
-										'https://example.org/assets/fonts/ibm-plex-mono/IBMPlexMono-Bold.woff2',
-									),
-								'font-family'  => 'IBM Plex Mono',
-								'font-display' => 'block',
-								'font-stretch' => 'normal',
-								'font-style'   => 'normal',
-								'font-weight'  => '700',
-							),
-						),
-				),
-				'expected' => <<<CSS
-@font-face{font-family:"DM Sans";font-style:normal;font-weight:400;font-display:fallback;src:url('https://example.org/assets/fonts/dm-sans/DMSans-Regular.woff2') format('woff2');font-stretch:normal;}
-@font-face{font-family:"DM Sans";font-style:italic;font-weight:400;font-display:fallback;src:url('https://example.org/assets/fonts/dm-sans/DMSans-Regular-Italic.woff2') format('woff2');font-stretch:normal;}
-@font-face{font-family:"DM Sans";font-style:normal;font-weight:700;font-display:fallback;src:url('https://example.org/assets/fonts/dm-sans/DMSans-Bold.woff2') format('woff2');font-stretch:normal;}
-@font-face{font-family:"DM Sans";font-style:italic;font-weight:700;font-display:fallback;src:url('https://example.org/assets/fonts/dm-sans/DMSans-Bold-Italic.woff2') format('woff2');font-stretch:normal;}
-@font-face{font-family:"IBM Plex Mono";font-style:normal;font-weight:300;font-display:block;src:url('https://example.org/assets/fonts/ibm-plex-mono/IBMPlexMono-Light.woff2') format('woff2');font-stretch:normal;}
-@font-face{font-family:"IBM Plex Mono";font-style:normal;font-weight:400;font-display:block;src:url('https://example.org/assets/fonts/ibm-plex-mono/IBMPlexMono-Regular.woff2') format('woff2');font-stretch:normal;}
-@font-face{font-family:"IBM Plex Mono";font-style:italic;font-weight:400;font-display:block;src:url('https://example.org/assets/fonts/ibm-plex-mono/IBMPlexMono-Italic.woff2') format('woff2');font-stretch:normal;}
-@font-face{font-family:"IBM Plex Mono";font-style:normal;font-weight:700;font-display:block;src:url('https://example.org/assets/fonts/ibm-plex-mono/IBMPlexMono-Bold.woff2') format('woff2');font-stretch:normal;}
-CSS
-			,
-			),
-		);
+		$this->expectOutputString( $expected_output );
+		$font_face->generate_and_print( $fonts );
 	}
 }

--- a/phpunit/fonts/wpFontFace/generateAndPrint-test.php
+++ b/phpunit/fonts/wpFontFace/generateAndPrint-test.php
@@ -32,6 +32,14 @@ if ( ! class_exists( 'WP_Font_Face' ) ) {
 class Tests_Fonts_WPFontFace_GenerateAndPrint extends WP_UnitTestCase {
 	use WP_Font_Face_Tests_Datasets;
 
+	public function test_should_not_generate_and_print_when_no_fonts() {
+		$font_face = new WP_Font_Face();
+		$fonts     = array();
+
+		$this->expectOutputString( '' );
+		$font_face->generate_and_print( $fonts );
+	}
+
 	/**
 	 * @dataProvider data_should_print_given_fonts
 	 *

--- a/phpunit/fonts/wpFontFaceResolver/getFontsFromThemeJson-test.php
+++ b/phpunit/fonts/wpFontFaceResolver/getFontsFromThemeJson-test.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Test case for the Fonts tests.
+ * Test case for WP_Font_Face_Resolver::get_fonts_from_theme_json().
  *
  * @package    WordPress
  * @subpackage Fonts
@@ -25,7 +25,7 @@ if ( ! class_exists( 'WP_Font_Face' ) ) {
  * @group fonts
  * @covers WP_Font_Face_Resolver::get_fonts_from_theme_json
  */
-class Tests_Fonts_WpFontFaceResolver_GetFontsFromThemeJson extends WP_Fonts_TestCase {
+class Tests_Fonts_WPFontFaceResolver_GetFontsFromThemeJson extends WP_Fonts_TestCase {
 	const FONTS_THEME   = 'fonts-block-theme';
 	const FONT_FAMILIES = array(
 		'fonts-block-theme' => array(

--- a/phpunit/fonts/wpFontFaceResolver/getFontsFromThemeJson-test.php
+++ b/phpunit/fonts/wpFontFaceResolver/getFontsFromThemeJson-test.php
@@ -20,10 +20,10 @@ class Tests_Fonts_WpFontFaceResolver_GetFontsFromThemeJson extends WP_Fonts_Test
 	const FONT_FAMILIES = array(
 		'fonts-block-theme' => array(
 			// From theme.json.
-			'dm-sans',
-			'source-serif-pro',
+			'DM Sans',
+			'Source Serif Pro',
 			// From style variation.
-			'open-sans',
+			'Open Sans',
 		),
 	);
 
@@ -45,8 +45,7 @@ class Tests_Fonts_WpFontFaceResolver_GetFontsFromThemeJson extends WP_Fonts_Test
 
 		$fonts = WP_Font_Face_Resolver::get_fonts_from_theme_json();
 
-		$this->assertArrayHasKey( 'DM Sans', $fonts );
-		$this->assertArrayHasKey( 'Source Serif Pro', $fonts );
+		$this->assertArrayHasKey( 'Open Sans', $fonts );
 	}
 
 	/**

--- a/phpunit/fonts/wpFontFaceResolver/getFontsFromThemeJson-test.php
+++ b/phpunit/fonts/wpFontFaceResolver/getFontsFromThemeJson-test.php
@@ -51,7 +51,7 @@ class Tests_Fonts_WPFontFaceResolver_GetFontsFromThemeJson extends WP_Fonts_Test
 		switch_theme( 'block-theme' );
 
 		$fonts = WP_Font_Face_Resolver::get_fonts_from_theme_json();
-		$this->assertSame( array() );
+		$this->assertSame( array(), $fonts );
 	}
 
 	/**

--- a/phpunit/fonts/wpFontFaceResolver/getFontsFromThemeJson-test.php
+++ b/phpunit/fonts/wpFontFaceResolver/getFontsFromThemeJson-test.php
@@ -7,7 +7,564 @@
  */
 
 class Tests_Fonts_WpFontFaceResolver_EnqueueUserSelectedFonts extends WP_UnitTestCase {
+	/**
+	 * Administrator ID.
+	 *
+	 * @var int
+	 */
+	protected static $administrator_id;
+
+	/**
+	 * WP_Theme_JSON_Resolver::$blocks_cache property.
+	 *
+	 * @var ReflectionProperty
+	 */
+	private static $property_blocks_cache;
+
+	/**
+	 * Original value of the WP_Theme_JSON_Resolver::$blocks_cache property.
+	 *
+	 * @var array
+	 */
+	private static $property_blocks_cache_orig_value;
+
+	/**
+	 * WP_Theme_JSON_Resolver::$core property.
+	 *
+	 * @var ReflectionProperty
+	 */
+	private static $property_core;
+
+	/**
+	 * Original value of the WP_Theme_JSON_Resolver::$core property.
+	 *
+	 * @var WP_Theme_JSON
+	 */
+	private static $property_core_orig_value;
+
+	/**
+	 * @var string|null
+	 */
+	private $theme_root;
+
+	/**
+	 * @var array|null
+	 */
+	private $orig_theme_dir;
+
+	/**
+	 * @var array|null
+	 */
+	private $queries;
+
+	public static function set_up_before_class() {
+		parent::set_up_before_class();
+
+		self::$administrator_id = self::factory()->user->create(
+			array(
+				'role'       => 'administrator',
+				'user_email' => 'administrator@example.com',
+			)
+		);
+
+		static::$property_blocks_cache = new ReflectionProperty( WP_Theme_JSON_Resolver_Gutenberg::class, 'blocks_cache' );
+		static::$property_blocks_cache->setAccessible( true );
+		static::$property_blocks_cache_orig_value = static::$property_blocks_cache->getValue();
+
+		static::$property_core = new ReflectionProperty( WP_Theme_JSON_Resolver_Gutenberg::class, 'core' );
+		static::$property_core->setAccessible( true );
+		static::$property_core_orig_value = static::$property_core->getValue();
+	}
+
+	public function set_up() {
+		parent::set_up();
+		$this->theme_root = realpath( __DIR__ . '/data/themedir1' );
+
+		$this->orig_theme_dir = $GLOBALS['wp_theme_directories'];
+
+		// /themes is necessary as theme.php functions assume /themes is the root if there is only one root.
+		$GLOBALS['wp_theme_directories'] = array( WP_CONTENT_DIR . '/themes', $this->theme_root );
+
+		add_filter( 'theme_root', array( $this, 'filter_set_theme_root' ) );
+		add_filter( 'stylesheet_root', array( $this, 'filter_set_theme_root' ) );
+		add_filter( 'template_root', array( $this, 'filter_set_theme_root' ) );
+		$this->queries = array();
+		// Clear caches.
+		wp_clean_themes_cache();
+		unset( $GLOBALS['wp_themes'] );
+	}
+
+	public function tear_down() {
+		$GLOBALS['wp_theme_directories'] = $this->orig_theme_dir;
+		wp_clean_themes_cache();
+		unset( $GLOBALS['wp_themes'] );
+		parent::tear_down();
+	}
+
+	public function filter_set_theme_root() {
+		return $this->theme_root;
+	}
+
+	public function filter_set_locale_to_polish() {
+		return 'pl_PL';
+	}
+
+	public function filter_db_query( $query ) {
+		if ( preg_match( '#post_type = \'wp_global_styles\'#', $query ) ) {
+			$this->queries[] = $query;
+		}
+		return $query;
+	}
+
+	public function test_translations_are_applied() {
+		add_filter( 'locale', array( $this, 'filter_set_locale_to_polish' ) );
+		load_textdomain( 'block-theme', realpath( __DIR__ . '/data/languages/themes/block-theme-pl_PL.mo' ) );
+
+		switch_theme( 'block-theme' );
+		$actual = WP_Theme_JSON_Resolver_Gutenberg::get_theme_data();
+
+		unload_textdomain( 'block-theme' );
+		remove_filter( 'locale', array( $this, 'filter_set_locale_to_polish' ) );
+
+		$this->assertSame( wp_get_theme()->get( 'TextDomain' ), 'block-theme' );
+		$this->assertSame(
+			array(
+				'color'      => array(
+					'custom'         => false,
+					'customGradient' => true,
+					'palette'        => array(
+						'theme' => array(
+							array(
+								'slug'  => 'light',
+								'name'  => 'Jasny',
+								'color' => '#f5f7f9',
+							),
+							array(
+								'slug'  => 'dark',
+								'name'  => 'Ciemny',
+								'color' => '#000',
+							),
+						),
+					),
+				),
+				'typography' => array(
+					'customFontSize' => true,
+					'lineHeight'     => false,
+				),
+				'spacing'    => array(
+					'units'   => false,
+					'padding' => false,
+				),
+				'blocks'     => array(
+					'core/paragraph' => array(
+						'color' => array(
+							'palette' => array(
+								'theme' => array(
+									array(
+										'slug'  => 'light',
+										'name'  => 'Jasny',
+										'color' => '#f5f7f9',
+									),
+								),
+							),
+						),
+					),
+				),
+			),
+			$actual->get_settings()
+		);
+		$this->assertSame(
+			$actual->get_custom_templates(),
+			array(
+				'page-home' => array(
+					'title'     => 'Szablon strony głównej',
+					'postTypes' => array( 'page' ),
+				),
+			)
+		);
+		$this->assertSame(
+			$actual->get_template_parts(),
+			array(
+				'small-header' => array(
+					'title' => 'Mały nagłówek',
+					'area'  => 'header',
+				),
+			)
+		);
+	}
+
+	public function test_add_theme_supports_are_loaded_for_themes_without_theme_json() {
+		switch_theme( 'default' );
+		$color_palette = array(
+			array(
+				'name'  => 'Primary',
+				'slug'  => 'primary',
+				'color' => '#F00',
+			),
+			array(
+				'name'  => 'Secondary',
+				'slug'  => 'secondary',
+				'color' => '#0F0',
+			),
+			array(
+				'name'  => 'Tertiary',
+				'slug'  => 'tertiary',
+				'color' => '#00F',
+			),
+		);
+		add_theme_support( 'editor-color-palette', $color_palette );
+		add_theme_support( 'custom-line-height' );
+
+		$settings = WP_Theme_JSON_Resolver_Gutenberg::get_theme_data()->get_settings();
+
+		remove_theme_support( 'custom-line-height' );
+		remove_theme_support( 'editor-color-palette' );
+
+		$this->assertFalse( wp_theme_has_theme_json() );
+		$this->assertTrue( $settings['typography']['lineHeight'] );
+		$this->assertSame( $color_palette, $settings['color']['palette']['theme'] );
+	}
+
+	/**
+	 * Recursively applies ksort to an array.
+	 */
+	private static function recursive_ksort( &$array ) {
+		foreach ( $array as &$value ) {
+			if ( is_array( $value ) ) {
+				self::recursive_ksort( $value );
+			}
+		}
+		ksort( $array );
+	}
+
+	public function test_merges_child_theme_json_into_parent_theme_json() {
+		switch_theme( 'block-theme-child' );
+
+		$actual_settings   = WP_Theme_JSON_Resolver_Gutenberg::get_theme_data()->get_settings();
+		$expected_settings = array(
+			'color'      => array(
+				'custom'         => false,
+				'customGradient' => true,
+				'palette'        => array(
+					'theme' => array(
+						array(
+							'slug'  => 'light',
+							'name'  => 'Light',
+							'color' => '#f3f4f6',
+						),
+						array(
+							'slug'  => 'primary',
+							'name'  => 'Primary',
+							'color' => '#3858e9',
+						),
+						array(
+							'slug'  => 'dark',
+							'name'  => 'Dark',
+							'color' => '#111827',
+						),
+					),
+				),
+				'link'           => true,
+			),
+			'typography' => array(
+				'customFontSize' => true,
+				'lineHeight'     => false,
+			),
+			'spacing'    => array(
+				'units'   => false,
+				'padding' => false,
+			),
+			'blocks'     => array(
+				'core/paragraph'  => array(
+					'color' => array(
+						'palette' => array(
+							'theme' => array(
+								array(
+									'slug'  => 'light',
+									'name'  => 'Light',
+									'color' => '#f5f7f9',
+								),
+							),
+						),
+					),
+				),
+				'core/post-title' => array(
+					'color' => array(
+						'palette' => array(
+							'theme' => array(
+								array(
+									'slug'  => 'light',
+									'name'  => 'Light',
+									'color' => '#f3f4f6',
+								),
+							),
+						),
+					),
+				),
+			),
+		);
+		self::recursive_ksort( $actual_settings );
+		self::recursive_ksort( $expected_settings );
+
+		// Should merge settings.
+		$this->assertSame(
+			$expected_settings,
+			$actual_settings
+		);
+
+		$this->assertSame(
+			WP_Theme_JSON_Resolver_Gutenberg::get_theme_data()->get_custom_templates(),
+			array(
+				'page-home' => array(
+					'title'     => 'Homepage',
+					'postTypes' => array( 'page' ),
+				),
+			)
+		);
+	}
+
+	public function test_get_user_data_from_wp_global_styles_does_not_use_uncached_queries() {
+		// Switch to a theme that does have support.
+		switch_theme( 'block-theme' );
+		wp_set_current_user( self::$administrator_id );
+		$theme = wp_get_theme();
+		WP_Theme_JSON_Resolver_Gutenberg::get_user_data_from_wp_global_styles( $theme );
+		add_filter( 'query', array( $this, 'filter_db_query' ) );
+		$query_count = count( $this->queries );
+		for ( $i = 0; $i < 3; $i++ ) {
+			WP_Theme_JSON_Resolver_Gutenberg::get_user_data_from_wp_global_styles( $theme );
+			WP_Theme_JSON_Resolver_Gutenberg::clean_cached_data();
+		}
+		$query_count = count( $this->queries ) - $query_count;
+		$this->assertSame( 0, $query_count, 'Unexpected SQL queries detected for the wp_global_style post type prior to creation.' );
+
+		$user_cpt = WP_Theme_JSON_Resolver_Gutenberg::get_user_data_from_wp_global_styles( $theme );
+		$this->assertEmpty( $user_cpt, 'User CPT is expected to be empty.' );
+
+		$user_cpt = WP_Theme_JSON_Resolver_Gutenberg::get_user_data_from_wp_global_styles( $theme, true );
+		$this->assertNotEmpty( $user_cpt, 'User CPT is expected not to be empty.' );
+
+		$query_count = count( $this->queries );
+		for ( $i = 0; $i < 3; $i ++ ) {
+			$new_user_cpt = WP_Theme_JSON_Resolver_Gutenberg::get_user_data_from_wp_global_styles( $theme );
+			WP_Theme_JSON_Resolver_Gutenberg::clean_cached_data();
+			$this->assertSameSets( $user_cpt, $new_user_cpt, "User CPTs do not match on run {$i}." );
+		}
+		$query_count = count( $this->queries ) - $query_count;
+		$this->assertSame( 1, $query_count, 'Unexpected SQL queries detected for the wp_global_style post type after creation.' );
+	}
+
+	/**
+	 * @covers WP_Theme_JSON_Resolver::get_user_data_from_wp_global_styles
+	 */
+	public function test_get_user_data_from_wp_global_styles_does_not_use_uncached_queries_for_logged_out_users() {
+		$theme = wp_get_theme();
+		WP_Theme_JSON_Resolver_Gutenberg::get_user_data_from_wp_global_styles( $theme );
+		add_filter( 'query', array( $this, 'filter_db_query' ) );
+		$query_count = count( $this->queries );
+		for ( $i = 0; $i < 3; $i++ ) {
+			WP_Theme_JSON_Resolver_Gutenberg::get_user_data_from_wp_global_styles( $theme );
+			WP_Theme_JSON_Resolver_Gutenberg::clean_cached_data();
+		}
+		$query_count = count( $this->queries ) - $query_count;
+		$this->assertSame( 0, $query_count, 'Unexpected SQL queries detected for the wp_global_style post type prior to creation.' );
+
+		$user_cpt = WP_Theme_JSON_Resolver_Gutenberg::get_user_data_from_wp_global_styles( $theme );
+		$this->assertEmpty( $user_cpt, 'User CPT is expected to be empty.' );
+	}
+
+	/**
+	 * Test that get_merged_data returns the data merged up to the proper origin.
+	 *
+	 * @covers WP_Theme_JSON_Resolver::get_merged_data
+	 *
+	 * @dataProvider data_get_merged_data_returns_origin
+	 *
+	 * @param string $origin            What origin to get data from.
+	 * @param bool   $core_palette      Whether the core palette is present.
+	 * @param string $core_palette_text Message.
+	 * @param string $block_styles      Whether the block styles are present.
+	 * @param string $block_styles_text Message.
+	 * @param bool   $theme_palette      Whether the theme palette is present.
+	 * @param string $theme_palette_text Message.
+	 * @param bool   $user_palette      Whether the user palette is present.
+	 * @param string $user_palette_text Message.
+	 */
+	public function test_get_merged_data_returns_origin( $origin, $core_palette, $core_palette_text, $block_styles, $block_styles_text, $theme_palette, $theme_palette_text, $user_palette, $user_palette_text ) {
+		// Make sure there is data from the blocks origin.
+		register_block_type(
+			'my/block-with-styles',
+			array(
+				'api_version' => 3,
+				'attributes'  => array(
+					'borderColor' => array(
+						'type' => 'string',
+					),
+					'style'       => array(
+						'type' => 'object',
+					),
+				),
+				'supports'    => array(
+					'__experimentalStyle' => array(
+						'typography' => array(
+							'fontSize' => '42rem',
+						),
+					),
+				),
+			)
+		);
+
+		// Make sure there is data from the theme origin.
+		switch_theme( 'block-theme' );
+
+		// Make sure there is data from the user origin.
+		wp_set_current_user( self::$administrator_id );
+		$user_cpt = WP_Theme_JSON_Resolver_Gutenberg::get_user_data_from_wp_global_styles( wp_get_theme(), true );
+		$config   = json_decode( $user_cpt['post_content'], true );
+		$config['settings']['color']['palette']['custom'] = array(
+			array(
+				'color' => 'hotpink',
+				'name'  => 'My color',
+				'slug'  => 'my-color',
+			),
+		);
+		$user_cpt['post_content']                         = wp_json_encode( $config );
+		wp_update_post( $user_cpt, true, false );
+
+		$theme_json = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data( $origin );
+		$settings   = $theme_json->get_settings();
+		$styles     = $theme_json->get_styles_block_nodes();
+		$this->assertSame( $core_palette, isset( $settings['color']['palette']['default'] ), $core_palette_text );
+		$styles = array_filter(
+			$styles,
+			static function( $element ) {
+				return isset( $element['name'] ) && 'my/block-with-styles' === $element['name'];
+			}
+		);
+		$this->assertSame( $block_styles, count( $styles ) === 1, $block_styles_text );
+		$this->assertSame( $theme_palette, isset( $settings['color']['palette']['theme'] ), $theme_palette_text );
+		$this->assertSame( $user_palette, isset( $settings['color']['palette']['custom'] ), $user_palette_text );
+
+		unregister_block_type( 'my/block-with-styles' );
+	}
+
+	/**
+	 * Data provider for test_get_merged_data_returns_origin
+	 *
+	 * @return array
+	 */
+	public function data_get_merged_data_returns_origin() {
+		return array(
+			'origin_default' => array(
+				'origin'             => 'default',
+				'core_palette'       => true,
+				'core_palette_text'  => 'Core palette must be present',
+				'block_styles'       => false,
+				'block_styles_text'  => 'Block styles should not be present',
+				'theme_palette'      => false,
+				'theme_palette_text' => 'Theme palette should not be present',
+				'user_palette'       => false,
+				'user_palette_text'  => 'User palette should not be present',
+			),
+			'origin_blocks'  => array(
+				'origin'             => 'blocks',
+				'core_palette'       => true,
+				'core_palette_text'  => 'Core palette must be present',
+				'block_styles'       => true,
+				'block_styles_text'  => 'Block styles must be present',
+				'theme_palette'      => false,
+				'theme_palette_text' => 'Theme palette should not be present',
+				'user_palette'       => false,
+				'user_palette_text'  => 'User palette should not be present',
+			),
+			'origin_theme'   => array(
+				'origin'             => 'theme',
+				'core_palette'       => true,
+				'core_palette_text'  => 'Core palette must be present',
+				'block_styles'       => true,
+				'block_styles_text'  => 'Block styles must be present',
+				'theme_palette'      => true,
+				'theme_palette_text' => 'Theme palette must be present',
+				'user_palette'       => false,
+				'user_palette_text'  => 'User palette should not be present',
+			),
+			'origin_custom'  => array(
+				'origin'             => 'custom',
+				'core_palette'       => true,
+				'core_palette_text'  => 'Core palette must be present',
+				'block_styles'       => true,
+				'block_styles_text'  => 'Block styles must be present',
+				'theme_palette'      => true,
+				'theme_palette_text' => 'Theme palette must be present',
+				'user_palette'       => true,
+				'user_palette_text'  => 'User palette must be present',
+			),
+		);
+	}
 
 
+	/**
+	 * Test that get_style_variations returns all variations, including parent theme variations if the theme is a child,
+	 * and that the child variation overwrites the parent variation of the same name.
+	 *
+	 * @covers WP_Theme_JSON_Resolver::get_style_variations
+	 **/
+	public function test_get_style_variations_returns_all_variations() {
+		// Switch to a child theme.
+		switch_theme( 'block-theme-child' );
+		wp_set_current_user( self::$administrator_id );
 
+		$actual_settings   = WP_Theme_JSON_Resolver_Gutenberg::get_style_variations();
+		$expected_settings = array(
+			array(
+				'version'  => 2,
+				'title'    => 'variation-a',
+				'settings' => array(
+					'blocks' => array(
+						'core/paragraph' => array(
+							'color' => array(
+								'palette' => array(
+									'theme' => array(
+										array(
+											'slug'  => 'dark',
+											'name'  => 'Dark',
+											'color' => '#010101',
+										),
+									),
+								),
+							),
+						),
+					),
+				),
+			),
+			array(
+				'version'  => 2,
+				'title'    => 'variation-b',
+				'settings' => array(
+					'blocks' => array(
+						'core/post-title' => array(
+							'color' => array(
+								'palette' => array(
+									'theme' => array(
+										array(
+											'slug'  => 'light',
+											'name'  => 'Light',
+											'color' => '#f1f1f1',
+										),
+									),
+								),
+							),
+						),
+					),
+				),
+			),
+		);
+		self::recursive_ksort( $actual_settings );
+		self::recursive_ksort( $expected_settings );
+
+		$this->assertSame(
+			$expected_settings,
+			$actual_settings
+		);
+	}
 }

--- a/phpunit/fonts/wpFontFaceResolver/getFontsFromThemeJson-test.php
+++ b/phpunit/fonts/wpFontFaceResolver/getFontsFromThemeJson-test.php
@@ -76,8 +76,8 @@ class Tests_Fonts_WpFontFaceResolver_GetFontsFromThemeJson extends WP_Fonts_Test
 		$fonts = WP_Font_Face_Resolver::get_fonts_from_theme_json();
 
 		$style_variations_fonts = static::STYLE_VARIATIONS_FONTS[ static::FONTS_THEME ];
-		foreach ($style_variations_fonts as $style_variations_font ) {
-			$this->assertArrayNotHasKey($style_variations_font, $fonts);
+		foreach ( $style_variations_fonts as $style_variations_font ) {
+			$this->assertArrayNotHasKey( $style_variations_font, $fonts );
 		}
 	}
 
@@ -93,8 +93,8 @@ class Tests_Fonts_WpFontFaceResolver_GetFontsFromThemeJson extends WP_Fonts_Test
 
 		$fonts = WP_Font_Face_Resolver::get_fonts_from_theme_json();
 
-		$actual    = $fonts[ $font_name ][ $font_index ]['src'][0];
-		$expected  = get_stylesheet_directory_uri() . $expected;
+		$actual   = $fonts[ $font_name ][ $font_index ]['src'][0];
+		$expected = get_stylesheet_directory_uri() . $expected;
 
 		$this->assertStringNotContainsString( 'file:./', $actual, 'Font src should not contain the "file:./" placeholder' );
 		$this->assertSame( $expected, $actual, 'Font src should be an URL to its file' );
@@ -108,35 +108,35 @@ class Tests_Fonts_WpFontFaceResolver_GetFontsFromThemeJson extends WP_Fonts_Test
 	public function data_should_replace_src_file_placeholder() {
 		return array(
 			// Theme's theme.json.
-			'DM Sans: 400 normal'                          => array(
-				'font_name' =>   'DM Sans',
-				'font_index'   => 0,
-				'expected' => '/assets/fonts/dm-sans/DMSans-Regular.woff2',
+			'DM Sans: 400 normal'              => array(
+				'font_name'  => 'DM Sans',
+				'font_index' => 0,
+				'expected'   => '/assets/fonts/dm-sans/DMSans-Regular.woff2',
 			),
-			'DM Sans: 400 italic'                          => array(
-				'font_name' =>   'DM Sans',
-				'font_index'   => 1,
-				'expected' => '/assets/fonts/dm-sans/DMSans-Regular-Italic.woff2',
+			'DM Sans: 400 italic'              => array(
+				'font_name'  => 'DM Sans',
+				'font_index' => 1,
+				'expected'   => '/assets/fonts/dm-sans/DMSans-Regular-Italic.woff2',
 			),
-			'DM Sans: 700 normal'                          => array(
-				'font_name' =>   'DM Sans',
-				'font_index'   => 2,
-				'expected' => '/assets/fonts/dm-sans/DMSans-Bold.woff2',
+			'DM Sans: 700 normal'              => array(
+				'font_name'  => 'DM Sans',
+				'font_index' => 2,
+				'expected'   => '/assets/fonts/dm-sans/DMSans-Bold.woff2',
 			),
-			'DM Sans: 700 italic'                          => array(
-				'font_name' =>   'DM Sans',
-				'font_index'   => 3,
-				'expected' => '/assets/fonts/dm-sans/DMSans-Bold-Italic.woff2',
+			'DM Sans: 700 italic'              => array(
+				'font_name'  => 'DM Sans',
+				'font_index' => 3,
+				'expected'   => '/assets/fonts/dm-sans/DMSans-Bold-Italic.woff2',
 			),
-			'Source Serif Pro: 200-900 normal'             => array(
-				'font_name' =>   'Source Serif Pro',
-				'font_index'   => 0,
-				'expected' => '/assets/fonts/source-serif-pro/SourceSerif4Variable-Roman.ttf.woff2',
+			'Source Serif Pro: 200-900 normal' => array(
+				'font_name'  => 'Source Serif Pro',
+				'font_index' => 0,
+				'expected'   => '/assets/fonts/source-serif-pro/SourceSerif4Variable-Roman.ttf.woff2',
 			),
-			'Source Serif Pro: 200-900 italic'             => array(
-				'font_name' =>   'Source Serif Pro',
-				'font_index'   => 1,
-				'expected' => '/assets/fonts/source-serif-pro/SourceSerif4Variable-Italic.ttf.woff2',
+			'Source Serif Pro: 200-900 italic' => array(
+				'font_name'  => 'Source Serif Pro',
+				'font_index' => 1,
+				'expected'   => '/assets/fonts/source-serif-pro/SourceSerif4Variable-Italic.ttf.woff2',
 			),
 		);
 	}

--- a/phpunit/fonts/wpFontFaceResolver/getFontsFromThemeJson-test.php
+++ b/phpunit/fonts/wpFontFaceResolver/getFontsFromThemeJson-test.php
@@ -70,4 +70,64 @@ class Tests_Fonts_WpFontFaceResolver_GetFontsFromThemeJson extends WP_Fonts_Test
 			$this->assertArrayNotHasKey($style_variations_font, $fonts);
 		}
 	}
+
+	/**
+	 * @dataProvider data_should_replace_src_file_placeholder
+	 *
+	 * @param string $font_name Font's name.
+	 * @param string $font_index Font's index in the $fonts array.
+	 * @param string $expected  Expected src.
+	 */
+	public function test_should_replace_src_file_placeholder( $font_name, $font_index, $expected ) {
+		switch_theme( static::FONTS_THEME );
+
+		$fonts = WP_Font_Face_Resolver::get_fonts_from_theme_json();
+
+		$actual    = $fonts[ $font_name ][ $font_index ]['src'][0];
+		$expected  = get_stylesheet_directory_uri() . $expected;
+
+		$this->assertStringNotContainsString( 'file:./', $actual, 'Font src should not contain the "file:./" placeholder' );
+		$this->assertSame( $expected, $actual, 'Font src should be an URL to its file' );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array
+	 */
+	public function data_should_replace_src_file_placeholder() {
+		return array(
+			// Theme's theme.json.
+			'DM Sans: 400 normal'                          => array(
+				'font_name' =>   'DM Sans',
+				'font_index'   => 0,
+				'expected' => '/assets/fonts/dm-sans/DMSans-Regular.woff2',
+			),
+			'DM Sans: 400 italic'                          => array(
+				'font_name' =>   'DM Sans',
+				'font_index'   => 1,
+				'expected' => '/assets/fonts/dm-sans/DMSans-Regular-Italic.woff2',
+			),
+			'DM Sans: 700 normal'                          => array(
+				'font_name' =>   'DM Sans',
+				'font_index'   => 2,
+				'expected' => '/assets/fonts/dm-sans/DMSans-Bold.woff2',
+			),
+			'DM Sans: 700 italic'                          => array(
+				'font_name' =>   'DM Sans',
+				'font_index'   => 3,
+				'expected' => '/assets/fonts/dm-sans/DMSans-Bold-Italic.woff2',
+			),
+			'Source Serif Pro: 200-900 normal'             => array(
+				'font_name' =>   'Source Serif Pro',
+				'font_index'   => 0,
+				'expected' => '/assets/fonts/source-serif-pro/SourceSerif4Variable-Roman.ttf.woff2',
+			),
+			'Source Serif Pro: 200-900 italic'             => array(
+				'font_name' =>   'Source Serif Pro',
+				'font_index'   => 1,
+				'expected' => '/assets/fonts/source-serif-pro/SourceSerif4Variable-Italic.ttf.woff2',
+			),
+		);
+	}
 }

--- a/phpunit/fonts/wpFontFaceResolver/getFontsFromThemeJson-test.php
+++ b/phpunit/fonts/wpFontFaceResolver/getFontsFromThemeJson-test.php
@@ -1,0 +1,13 @@
+<?php
+
+/**
+ * Test WP_Theme_JSON_Resolver_Gutenberg class.
+ *
+ * @package Gutenberg
+ */
+
+class Tests_Fonts_WpFontFaceResolver_EnqueueUserSelectedFonts extends WP_UnitTestCase {
+
+
+
+}

--- a/phpunit/fonts/wpFontFaceResolver/getFontsFromThemeJson-test.php
+++ b/phpunit/fonts/wpFontFaceResolver/getFontsFromThemeJson-test.php
@@ -51,7 +51,7 @@ class Tests_Fonts_WPFontFaceResolver_GetFontsFromThemeJson extends WP_Fonts_Test
 		switch_theme( 'block-theme' );
 
 		$fonts = WP_Font_Face_Resolver::get_fonts_from_theme_json();
-		$this->assertEmpty( $fonts );
+		$this->assertSame( array() );
 	}
 
 	/**

--- a/phpunit/fonts/wpFontFaceResolver/getFontsFromThemeJson-test.php
+++ b/phpunit/fonts/wpFontFaceResolver/getFontsFromThemeJson-test.php
@@ -1,4 +1,10 @@
 <?php
+/**
+ * Test case for the Fonts tests.
+ *
+ * @package    WordPress
+ * @subpackage Fonts
+ */
 
 require_once __DIR__ . '/../../fonts-api/wp-fonts-testcase.php';
 // This code is only needed if the Font API is enabled.
@@ -10,11 +16,15 @@ if ( ! class_exists( 'WP_Font_Face' ) ) {
 }
 
 /**
- * Test WP_Theme_JSON_Resolver_Gutenberg class.
+ * Tests WP_Font_Face_Resolver::get_fonts_from_theme_json().
  *
- * @package Gutenberg
+ * @package WordPress
+ * @subpackage Fonts
+ *
+ * @since X.X.X
+ * @group fonts
+ * @covers WP_Font_Face_Resolver::get_fonts_from_theme_json
  */
-
 class Tests_Fonts_WpFontFaceResolver_GetFontsFromThemeJson extends WP_Fonts_TestCase {
 	const FONTS_THEME   = 'fonts-block-theme';
 	const FONT_FAMILIES = array(

--- a/phpunit/fonts/wpFontFaceResolver/getFontsFromThemeJson-test.php
+++ b/phpunit/fonts/wpFontFaceResolver/getFontsFromThemeJson-test.php
@@ -22,7 +22,11 @@ class Tests_Fonts_WpFontFaceResolver_GetFontsFromThemeJson extends WP_Fonts_Test
 			// From theme.json.
 			'DM Sans',
 			'Source Serif Pro',
-			// From style variation.
+		),
+	);
+
+	const STYLE_VARIATIONS_FONTS = array(
+		'fonts-block-theme' => array(
 			'Open Sans',
 		),
 	);
@@ -40,17 +44,9 @@ class Tests_Fonts_WpFontFaceResolver_GetFontsFromThemeJson extends WP_Fonts_Test
 		$this->assertEmpty( $fonts );
 	}
 
-	public function test_should_return_style_variation_fonts() {
-		switch_theme( static::FONTS_THEME );
-
-		$fonts = WP_Font_Face_Resolver::get_fonts_from_theme_json();
-
-		$this->assertArrayHasKey( 'Open Sans', $fonts );
-	}
-
 	/**
 	 * Tests all font families are registered and enqueued. "All" means all font families from
-	 * the theme's theme.json and within the style variations.
+	 * the theme's theme.json.
 	 */
 	public function test_should_return_all_defined_font_families() {
 		switch_theme( static::FONTS_THEME );
@@ -58,236 +54,20 @@ class Tests_Fonts_WpFontFaceResolver_GetFontsFromThemeJson extends WP_Fonts_Test
 		$fonts = WP_Font_Face_Resolver::get_fonts_from_theme_json();
 
 		$expected = static::FONT_FAMILIES[ static::FONTS_THEME ];
-		$this->assertSameSetsWithIndex( $expected, $fonts );
+		$this->assertSameSetsWithIndex( $expected, array_keys( $fonts ) );
 	}
 
 	/**
-	 * Test ensures duplicate fonts and variations in the style variations
-	 * are not re-registered.
-	 *
-	 * The Dm Sans fonts are duplicated in the theme's /styles/variations-duplicate-fonts.json.
+	 * Test ensures that the style variations are not returned.
 	 */
-	public function test_should_not_reregister_duplicate_fonts_from_style_variations() {
+	public function test_should_not_return_fonts_from_style_variations() {
 		switch_theme( static::FONTS_THEME );
 
-		WP_Fonts_Resolver::register_fonts_from_theme_json();
-		$wp_fonts = wp_fonts();
+		$fonts = WP_Font_Face_Resolver::get_fonts_from_theme_json();
 
-		// Font families are not duplicated.
-		$this->assertSameSetsWithIndex(
-			static::FONT_FAMILIES[ static::FONTS_THEME ],
-			$wp_fonts->get_registered_font_families(),
-			'Font families should not be duplicated'
-		);
-
-		// Font variations are not duplicated.
-		$this->assertSameSets(
-			array(
-				// From theme.json.
-				'dm-sans',
-				'dm-sans-400-normal',
-				'dm-sans-400-italic',
-				'dm-sans-700-normal',
-				'dm-sans-700-italic',
-				'source-serif-pro',
-				'source-serif-pro-200-900-normal',
-				'source-serif-pro-200-900-italic',
-				// From style variation.
-				'open-sans',
-				'open-sans-400-normal',
-				'open-sans-400-italic',
-				'dm-sans-500-normal',
-				'dm-sans-500-italic',
-			),
-			$wp_fonts->get_registered(),
-			'Font families and their variations should not be duplicated'
-		);
-	}
-
-	/**
-	 * @dataProvider data_should_replace_src_file_placeholder
-	 *
-	 * @param string $handle   Variation's handle.
-	 * @param string $expected Expected src.
-	 */
-	public function test_should_replace_src_file_placeholder( $handle, $expected ) {
-		switch_theme( static::FONTS_THEME );
-
-		WP_Fonts_Resolver::register_fonts_from_theme_json();
-
-		$variation = wp_fonts()->registered[ $handle ];
-		$actual    = array_pop( $variation->src );
-		$expected  = get_stylesheet_directory_uri() . $expected;
-
-		$this->assertStringNotContainsString( 'file:./', $actual, 'Font src should not contain the "file:./" placeholder' );
-		$this->assertSame( $expected, $actual, 'Font src should be an URL to its file' );
-	}
-
-	/**
-	 * Data provider.
-	 *
-	 * @return array
-	 */
-	public function data_should_replace_src_file_placeholder() {
-		return array(
-			// Theme's theme.json.
-			'DM Sans: 400 normal'                          => array(
-				'handle'   => 'dm-sans-400-normal',
-				'expected' => '/assets/fonts/dm-sans/DMSans-Regular.woff2',
-			),
-			'DM Sans: 400 italic'                          => array(
-				'handle'   => 'dm-sans-400-italic',
-				'expected' => '/assets/fonts/dm-sans/DMSans-Regular-Italic.woff2',
-			),
-			'DM Sans: 700 normal'                          => array(
-				'handle'   => 'dm-sans-700-normal',
-				'expected' => '/assets/fonts/dm-sans/DMSans-Bold.woff2',
-			),
-			'DM Sans: 700 italic'                          => array(
-				'handle'   => 'dm-sans-700-italic',
-				'expected' => '/assets/fonts/dm-sans/DMSans-Bold-Italic.woff2',
-			),
-			'Source Serif Pro: 200-900 normal'             => array(
-				'handle'   => 'source-serif-pro-200-900-normal',
-				'expected' => '/assets/fonts/source-serif-pro/SourceSerif4Variable-Roman.ttf.woff2',
-			),
-			'Source Serif Pro: 200-900 italic'             => array(
-				'handle'   => 'source-serif-pro-200-900-italic',
-				'expected' => '/assets/fonts/source-serif-pro/SourceSerif4Variable-Italic.ttf.woff2',
-			),
-
-			// Style Variation: variation-with-new-font-family.json.
-			'Style Variation: new font-family'             => array(
-				'handle'   => 'open-sans-400-normal',
-				'expected' => '/assets/fonts/open-sans/OpenSans-VariableFont_wdth,wght.tff',
-			),
-			'Style Variation: new font-family italic variation' => array(
-				'handle'   => 'open-sans-400-italic',
-				'expected' => '/assets/fonts/open-sans/OpenSans-Italic-VariableFont_wdth,wght.tff',
-			),
-
-			// Style Variation: variation-with-new-variation.json.
-			'Style Variation: new medium variation'        => array(
-				'handle'   => 'dm-sans-500-normal',
-				'expected' => '/assets/fonts/dm-sans/DMSans-Medium.woff2',
-			),
-			'Style Variation: new medium italic variation' => array(
-				'handle'   => 'dm-sans-500-italic',
-				'expected' => '/assets/fonts/dm-sans/DMSans-Medium-Italic.woff2',
-			),
-		);
-	}
-
-	public function test_should_convert_font_face_properties_into_kebab_case() {
-		switch_theme( static::FONTS_THEME );
-
-		WP_Fonts_Resolver::register_fonts_from_theme_json();
-
-		// Testing only one variation since this theme's fonts use the same properties.
-		$variation         = wp_fonts()->registered['dm-sans-400-normal'];
-		$actual_properties = $variation->extra['font-properties'];
-
-		$this->assertArrayHasKey( 'font-family', $actual_properties, 'fontFamily should have been converted into font-family' );
-		$this->assertArrayNotHasKey( 'fontFamily', $actual_properties, 'fontFamily should not exist.' );
-		$this->assertArrayHasKey( 'font-stretch', $actual_properties, 'fontStretch should have been converted into font-stretch' );
-		$this->assertArrayNotHasKey( 'fontStretch', $actual_properties, 'fontStretch should not exist' );
-		$this->assertArrayHasKey( 'font-style', $actual_properties, 'fontStyle should have been converted into font-style' );
-		$this->assertArrayNotHasKey( 'fontStyle', $actual_properties, 'fontStyle should not exist.' );
-		$this->assertArrayHasKey( 'font-weight', $actual_properties, 'fontWeight should have been converted into font-weight' );
-		$this->assertArrayNotHasKey( 'fontWeight', $actual_properties, 'fontWeight should not exist' );
-	}
-
-	/**
-	 * Tests that WP_Fonts_Resolver::register_fonts_from_theme_json() skips fonts that are already registered
-	 * in the Fonts API. How does it do that? Using the 'origin' property when checking each variation.
-	 * This property is added when WP_Theme_JSON_Resolver_Gutenberg::get_merged_data() runs.
-	 *
-	 * To simulate this scenario, a font is registered first, but not enqueued. Then after running,
-	 * it checks if the WP_Fonts_Resolver::register_fonts_from_theme_json() enqueued the font. If no, then
-	 * it was skipped as expected.
-	 */
-	public function test_should_skip_registered_fonts() {
-		switch_theme( static::FONTS_THEME );
-
-		// Register Lato font.
-		wp_register_fonts(
-			array(
-				'Lato' => array(
-					array(
-						'font-family' => 'Lato',
-						'font-style'  => 'normal',
-						'font-weight' => '400',
-						'src'         => 'https://example.com/tests/assets/fonts/lato/Lato-Regular.woff2',
-					),
-					array(
-						'font-family' => 'Lato',
-						'font-style'  => 'italic',
-						'font-weight' => '400',
-						'src'         => 'https://example.com/tests/assets/fonts/lato/Lato-Regular-Italic.woff2',
-					),
-				),
-			)
-		);
-
-		// Pre-check to ensure no fonts are enqueued.
-		$this->assertEmpty( wp_fonts()->get_enqueued(), 'No fonts should be enqueued before running WP_Fonts_Resolver::register_fonts_from_theme_json()' );
-
-		/*
-		 * When this function runs, it invokes WP_Theme_JSON_Resolver_Gutenberg::get_merged_data(),
-		 * which will include the Lato fonts with a 'origin' property set in each variation.
-		 */
-		WP_Fonts_Resolver::register_fonts_from_theme_json();
-
-		$actual_enqueued_fonts = wp_fonts()->get_enqueued();
-
-		$this->assertNotContains( 'lato', $actual_enqueued_fonts, 'Lato font-family should not be enqueued' );
-		$this->assertSameSets( static::FONT_FAMILIES[ static::FONTS_THEME ], $actual_enqueued_fonts, 'Only the theme font families should be enqueued' );
-	}
-
-	public function test_should_skip_when_font_face_not_defined() {
-		switch_theme( static::FONTS_THEME );
-		$expected_font_family = 'source-serif-pro';
-
-		/**
-		 * Callback that removes the 'fontFace' of the expected font family from the theme's theme.json data.
-		 * This callback is invoked at the start of WP_Fonts_Resolver::register_fonts_from_theme_json() before processing
-		 * within that function. How? It's in the call stack of WP_Theme_JSON_Resolver_Gutenberg::get_merged_data().
-		 *
-		 * @param WP_Theme_JSON_Data_Gutenberg| WP_Theme_JSON_Data $theme_json_data Instance of the Data object.
-		 * @return WP_Theme_JSON_Data_Gutenberg| WP_Theme_JSON_Data Modified instance.
-		 * @throws ReflectionException
-		 */
-		$remove_expected_font_family = static function( $theme_json_data ) use ( $expected_font_family ) {
-			// Need to get the underlying data array which is in WP_Theme_JSON_Gutenberg | WP_Theme_JSON object.
-			$property = new ReflectionProperty( $theme_json_data, 'theme_json' );
-			$property->setAccessible( true );
-			$theme_json_object = $property->getValue( $theme_json_data );
-
-			$property = new ReflectionProperty( $theme_json_object, 'theme_json' );
-			$property->setAccessible( true );
-			$data = $property->getValue( $theme_json_object );
-
-			// Loop through the fonts to find the expected font-family to modify.
-			foreach ( $data['settings']['typography']['fontFamilies']['theme'] as $index => $definitions ) {
-				if ( $expected_font_family !== $definitions['slug'] ) {
-					continue;
-				}
-
-				// Remove the 'fontFace' element, which removes the font's variations.
-				unset( $data['settings']['typography']['fontFamilies']['theme'][ $index ]['fontFace'] );
-				break;
-			}
-
-			$theme_json_data->update_with( $data );
-
-			return $theme_json_data;
-		};
-		add_filter( 'wp_theme_json_data_theme', $remove_expected_font_family );
-
-		WP_Fonts_Resolver::register_fonts_from_theme_json();
-
-		remove_filter( 'wp_theme_json_data_theme', $remove_expected_font_family );
-
-		$this->assertNotContains( $expected_font_family, wp_fonts()->get_registered_font_families() );
+		$style_variations_fonts = static::STYLE_VARIATIONS_FONTS[ static::FONTS_THEME ];
+		foreach ($style_variations_fonts as $style_variations_font ) {
+			$this->assertArrayNotHasKey($style_variations_font, $fonts);
+		}
 	}
 }

--- a/phpunit/fonts/wpFontFaceResolver/getFontsFromThemeJson-test.php
+++ b/phpunit/fonts/wpFontFaceResolver/getFontsFromThemeJson-test.php
@@ -6,9 +6,12 @@
  * @subpackage Fonts
  */
 
-require_once __DIR__ . '/../../fonts-api/wp-fonts-testcase.php';
-// This code is only needed if the Font API is enabled.
-// It should be removed after Font Manager is merged into Gutenberg.
+require_once __DIR__ . '/../wp-font-face-testcase.php';
+
+/*
+ * This code is only needed if the Font API is enabled.
+ * @todo remove this code when Font Library is merged into Gutenberg.
+ */
 if ( ! class_exists( 'WP_Font_Face' ) ) {
 	require_once __DIR__ . '/../../../lib/experimental/fonts/class-wp-font-face.php';
 	require_once __DIR__ . '/../../../lib/experimental/fonts/class-wp-font-face-resolver.php';
@@ -23,23 +26,11 @@ if ( ! class_exists( 'WP_Font_Face' ) ) {
  *
  * @since X.X.X
  * @group fonts
+ * @group fontface
  * @covers WP_Font_Face_Resolver::get_fonts_from_theme_json
  */
 class Tests_Fonts_WPFontFaceResolver_GetFontsFromThemeJson extends WP_Fonts_TestCase {
-	const FONTS_THEME   = 'fonts-block-theme';
-	const FONT_FAMILIES = array(
-		'fonts-block-theme' => array(
-			// From theme.json.
-			'DM Sans',
-			'Source Serif Pro',
-		),
-	);
-
-	const STYLE_VARIATIONS_FONTS = array(
-		'fonts-block-theme' => array(
-			'Open Sans',
-		),
-	);
+	const FONTS_THEME = 'fonts-block-theme';
 
 	public static function set_up_before_class() {
 		self::$requires_switch_theme_fixtures = true;
@@ -47,11 +38,12 @@ class Tests_Fonts_WPFontFaceResolver_GetFontsFromThemeJson extends WP_Fonts_Test
 		parent::set_up_before_class();
 	}
 
-	public function test_should_return_no_fonts_when_no_fonts_defined() {
+	public function test_should_return_empty_array_when_no_fonts_defined() {
 		switch_theme( 'block-theme' );
 
 		$fonts = WP_Font_Face_Resolver::get_fonts_from_theme_json();
-		$this->assertSame( array(), $fonts );
+		$this->assertIsArray( $fonts, 'Should return an array data type' );
+		$this->assertEmpty( $fonts, 'Should return an empty array' );
 	}
 
 	/**
@@ -63,30 +55,18 @@ class Tests_Fonts_WPFontFaceResolver_GetFontsFromThemeJson extends WP_Fonts_Test
 
 		$fonts = WP_Font_Face_Resolver::get_fonts_from_theme_json();
 
-		$expected = static::FONT_FAMILIES[ static::FONTS_THEME ];
-		$this->assertSameSetsWithIndex( $expected, array_keys( $fonts ) );
-	}
-
-	/**
-	 * Test ensures that the style variations are not returned.
-	 */
-	public function test_should_not_return_fonts_from_style_variations() {
-		switch_theme( static::FONTS_THEME );
-
-		$fonts = WP_Font_Face_Resolver::get_fonts_from_theme_json();
-
-		$style_variations_fonts = static::STYLE_VARIATIONS_FONTS[ static::FONTS_THEME ];
-		foreach ( $style_variations_fonts as $style_variations_font ) {
-			$this->assertArrayNotHasKey( $style_variations_font, $fonts );
-		}
+		$this->assertSameSetsWithIndex(
+			array( 'DM Sans', 'Source Serif Pro' ),
+			array_keys( $fonts )
+		);
 	}
 
 	/**
 	 * @dataProvider data_should_replace_src_file_placeholder
 	 *
-	 * @param string $font_name Font's name.
+	 * @param string $font_name  Font's name.
 	 * @param string $font_index Font's index in the $fonts array.
-	 * @param string $expected  Expected src.
+	 * @param string $expected   Expected src.
 	 */
 	public function test_should_replace_src_file_placeholder( $font_name, $font_index, $expected ) {
 		switch_theme( static::FONTS_THEME );

--- a/phpunit/fonts/wpFontFaceResolver/getFontsFromThemeJson-test.php
+++ b/phpunit/fonts/wpFontFaceResolver/getFontsFromThemeJson-test.php
@@ -29,7 +29,7 @@ if ( ! class_exists( 'WP_Font_Face' ) ) {
  * @group fontface
  * @covers WP_Font_Face_Resolver::get_fonts_from_theme_json
  */
-class Tests_Fonts_WPFontFaceResolver_GetFontsFromThemeJson extends WP_Fonts_TestCase {
+class Tests_Fonts_WPFontFaceResolver_GetFontsFromThemeJson extends WP_Font_Face_TestCase {
 	const FONTS_THEME = 'fonts-block-theme';
 
 	public static function set_up_before_class() {
@@ -38,7 +38,7 @@ class Tests_Fonts_WPFontFaceResolver_GetFontsFromThemeJson extends WP_Fonts_Test
 		parent::set_up_before_class();
 	}
 
-	public function test_should_return_empty_array_when_no_fonts_defined() {
+	public function test_should_return_empty_array_when_no_fonts_defined_in_theme() {
 		switch_theme( 'block-theme' );
 
 		$fonts = WP_Font_Face_Resolver::get_fonts_from_theme_json();
@@ -46,19 +46,12 @@ class Tests_Fonts_WPFontFaceResolver_GetFontsFromThemeJson extends WP_Fonts_Test
 		$this->assertEmpty( $fonts, 'Should return an empty array' );
 	}
 
-	/**
-	 * Tests all font families are registered and enqueued. "All" means all font families from
-	 * the theme's theme.json.
-	 */
-	public function test_should_return_all_defined_font_families() {
+	public function test_should_return_all_fonts_from_theme() {
 		switch_theme( static::FONTS_THEME );
 
-		$fonts = WP_Font_Face_Resolver::get_fonts_from_theme_json();
-
-		$this->assertSameSetsWithIndex(
-			array( 'DM Sans', 'Source Serif Pro' ),
-			array_keys( $fonts )
-		);
+		$actual   = WP_Font_Face_Resolver::get_fonts_from_theme_json();
+		$expected = $this->get_expected_fonts_for_fonts_block_theme( 'fonts' );
+		$this->assertSame( $expected, $actual );
 	}
 
 	/**

--- a/phpunit/fonts/wpPrintFontFaces-test.php
+++ b/phpunit/fonts/wpPrintFontFaces-test.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Test case for wp_print_font_faces().
+ *
+ * @package    WordPress
+ * @subpackage Fonts
+ */
+
+/**
+ * This code is only needed if the Font API is enabled.
+ * It should be removed after Font Manager is merged into Gutenberg.
+ */
+if ( ! class_exists( 'WP_Font_Face' ) ) {
+	require_once __DIR__ . '/../../../lib/experimental/fonts/class-wp-font-face.php';
+	require_once __DIR__ . '/../../../lib/experimental/fonts/class-wp-font-face-resolver.php';
+	require_once __DIR__ . '/../../../lib/experimental/fonts/fonts.php';
+}
+
+/**
+ * Test wp_print_font_faces().
+ *
+ * @package WordPress
+ * @subpackage Fonts
+ *
+ * @since X.X.X
+ * @group fonts
+ * @covers wp_print_font_faces
+ */
+class Tests_Fonts_WPPrintFontFaces extends WP_UnitTestCase {
+
+}

--- a/phpunit/fonts/wpPrintFontFaces-test.php
+++ b/phpunit/fonts/wpPrintFontFaces-test.php
@@ -28,4 +28,205 @@ if ( ! class_exists( 'WP_Font_Face' ) ) {
  */
 class Tests_Fonts_WPPrintFontFaces extends WP_UnitTestCase {
 
+	/**
+	 * @dataProvider data_test_wp_print_font_faces
+	 *
+	 * @param array  $fonts Prepared fonts (to store in WP_Fonts_Provider_Local::$fonts property).
+	 * @param string $expected Expected CSS.
+	 */
+	public function test_should_print_passed_fonts( array $fonts, $expected ) {
+		$style_element   = "<style id='wp-fonts-local' type='text/css'>\n%s\n</style>\n";
+		$expected_output = sprintf( $style_element, $expected );
+		$this->expectOutputString( $expected_output );
+		wp_print_font_faces( $fonts );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array
+	 */
+	public function data_test_wp_print_font_faces() {
+		return array(
+			'single truetype format font'    => array(
+				'fonts'    => array(
+					'Inter' =>
+						array(
+							array(
+								'src'          =>
+									array(
+										'https://example.org/assets/fonts/inter/Inter-VariableFont_slnt,wght.ttf',
+									),
+								'font-family'  => 'Inter',
+								'font-stretch' => 'normal',
+								'font-style'   => 'normal',
+								'font-weight'  => '200',
+							),
+						),
+				),
+				'expected' => <<<CSS
+@font-face{font-family:Inter;font-style:normal;font-weight:200;font-display:fallback;src:url('https://example.org/assets/fonts/inter/Inter-VariableFont_slnt,wght.ttf') format('truetype');font-stretch:normal;}
+CSS
+			,
+			),
+			'multiple truetype format fonts' => array(
+				'fonts'    => array(
+					'Inter' =>
+						array(
+							array(
+								'src'          =>
+									array(
+										'https://example.org/assets/fonts/inter/Inter-VariableFont_slnt,wght.ttf',
+									),
+								'font-family'  => 'Inter',
+								'font-stretch' => 'normal',
+								'font-style'   => 'normal',
+								'font-weight'  => '200',
+							),
+							array(
+								'src'          =>
+									array(
+										'https://example.org/assets/fonts/inter/Inter-VariableFont_slnt-Italic,wght.ttf',
+									),
+								'font-family'  => 'Inter',
+								'font-stretch' => 'normal',
+								'font-style'   => 'italic',
+								'font-weight'  => '900',
+							),
+						),
+				),
+				'expected' => <<<CSS
+@font-face{font-family:Inter;font-style:normal;font-weight:200;font-display:fallback;src:url('https://example.org/assets/fonts/inter/Inter-VariableFont_slnt,wght.ttf') format('truetype');font-stretch:normal;}
+@font-face{font-family:Inter;font-style:italic;font-weight:900;font-display:fallback;src:url('https://example.org/assets/fonts/inter/Inter-VariableFont_slnt-Italic,wght.ttf') format('truetype');font-stretch:normal;}
+CSS
+			,
+			),
+			'single woff2 format font'       => array(
+				'fonts'    => array(
+					'DM Sans' =>
+						array(
+							array(
+								'src'          =>
+									array(
+										'https://example.org/assets/fonts/dm-sans/DMSans-Regular.woff2',
+									),
+								'font-family'  => 'DM Sans',
+								'font-stretch' => 'normal',
+								'font-style'   => 'normal',
+								'font-weight'  => '400',
+							),
+						),
+				),
+				'expected' => <<<CSS
+@font-face{font-family:"DM Sans";font-style:normal;font-weight:400;font-display:fallback;src:url('https://example.org/assets/fonts/dm-sans/DMSans-Regular.woff2') format('woff2');font-stretch:normal;}
+CSS
+			,
+			),
+			'multiple woff2 format fonts'    => array(
+				'fonts'    => array(
+					'DM Sans'       =>
+						array(
+							array(
+								'src'          =>
+									array(
+										'https://example.org/assets/fonts/dm-sans/DMSans-Regular.woff2',
+									),
+								'font-family'  => 'DM Sans',
+								'font-stretch' => 'normal',
+								'font-style'   => 'normal',
+								'font-weight'  => '400',
+							),
+							array(
+								'src'          =>
+									array(
+										'https://example.org/assets/fonts/dm-sans/DMSans-Regular-Italic.woff2',
+									),
+								'font-family'  => 'DM Sans',
+								'font-stretch' => 'normal',
+								'font-style'   => 'italic',
+								'font-weight'  => '400',
+							),
+							array(
+								'src'          =>
+									array(
+										'https://example.org/assets/fonts/dm-sans/DMSans-Bold.woff2',
+									),
+								'font-family'  => 'DM Sans',
+								'font-stretch' => 'normal',
+								'font-style'   => 'normal',
+								'font-weight'  => '700',
+							),
+							array(
+								'src'          =>
+									array(
+										'https://example.org/assets/fonts/dm-sans/DMSans-Bold-Italic.woff2',
+									),
+								'font-family'  => 'DM Sans',
+								'font-stretch' => 'normal',
+								'font-style'   => 'italic',
+								'font-weight'  => '700',
+							),
+						),
+					'IBM Plex Mono' =>
+						array(
+							array(
+								'src'          =>
+									array(
+										'https://example.org/assets/fonts/ibm-plex-mono/IBMPlexMono-Light.woff2',
+									),
+								'font-family'  => 'IBM Plex Mono',
+								'font-display' => 'block',
+								'font-stretch' => 'normal',
+								'font-style'   => 'normal',
+								'font-weight'  => '300',
+							),
+							array(
+								'src'          =>
+									array(
+										'https://example.org/assets/fonts/ibm-plex-mono/IBMPlexMono-Regular.woff2',
+									),
+								'font-family'  => 'IBM Plex Mono',
+								'font-display' => 'block',
+								'font-stretch' => 'normal',
+								'font-style'   => 'normal',
+								'font-weight'  => '400',
+							),
+							array(
+								'src'          =>
+									array(
+										'https://example.org/assets/fonts/ibm-plex-mono/IBMPlexMono-Italic.woff2',
+									),
+								'font-family'  => 'IBM Plex Mono',
+								'font-display' => 'block',
+								'font-stretch' => 'normal',
+								'font-style'   => 'italic',
+								'font-weight'  => '400',
+							),
+							array(
+								'src'          =>
+									array(
+										'https://example.org/assets/fonts/ibm-plex-mono/IBMPlexMono-Bold.woff2',
+									),
+								'font-family'  => 'IBM Plex Mono',
+								'font-display' => 'block',
+								'font-stretch' => 'normal',
+								'font-style'   => 'normal',
+								'font-weight'  => '700',
+							),
+						),
+				),
+				'expected' => <<<CSS
+@font-face{font-family:"DM Sans";font-style:normal;font-weight:400;font-display:fallback;src:url('https://example.org/assets/fonts/dm-sans/DMSans-Regular.woff2') format('woff2');font-stretch:normal;}
+@font-face{font-family:"DM Sans";font-style:italic;font-weight:400;font-display:fallback;src:url('https://example.org/assets/fonts/dm-sans/DMSans-Regular-Italic.woff2') format('woff2');font-stretch:normal;}
+@font-face{font-family:"DM Sans";font-style:normal;font-weight:700;font-display:fallback;src:url('https://example.org/assets/fonts/dm-sans/DMSans-Bold.woff2') format('woff2');font-stretch:normal;}
+@font-face{font-family:"DM Sans";font-style:italic;font-weight:700;font-display:fallback;src:url('https://example.org/assets/fonts/dm-sans/DMSans-Bold-Italic.woff2') format('woff2');font-stretch:normal;}
+@font-face{font-family:"IBM Plex Mono";font-style:normal;font-weight:300;font-display:block;src:url('https://example.org/assets/fonts/ibm-plex-mono/IBMPlexMono-Light.woff2') format('woff2');font-stretch:normal;}
+@font-face{font-family:"IBM Plex Mono";font-style:normal;font-weight:400;font-display:block;src:url('https://example.org/assets/fonts/ibm-plex-mono/IBMPlexMono-Regular.woff2') format('woff2');font-stretch:normal;}
+@font-face{font-family:"IBM Plex Mono";font-style:italic;font-weight:400;font-display:block;src:url('https://example.org/assets/fonts/ibm-plex-mono/IBMPlexMono-Italic.woff2') format('woff2');font-stretch:normal;}
+@font-face{font-family:"IBM Plex Mono";font-style:normal;font-weight:700;font-display:block;src:url('https://example.org/assets/fonts/ibm-plex-mono/IBMPlexMono-Bold.woff2') format('woff2');font-stretch:normal;}
+CSS
+			,
+			),
+		);
+	}
 }

--- a/phpunit/fonts/wpPrintFontFaces-test.php
+++ b/phpunit/fonts/wpPrintFontFaces-test.php
@@ -6,7 +6,7 @@
  * @subpackage Fonts
  */
 
-require_once __DIR__ . '/wp-font-face-tests-dataset.php';
+require_once __DIR__ . '/wp-font-face-testcase.php';
 
 /*
  * This code is only needed if the Font API is enabled.
@@ -29,8 +29,14 @@ if ( ! class_exists( 'WP_Font_Face' ) ) {
  * @group fontface
  * @covers wp_print_font_faces
  */
-class Tests_Fonts_WPPrintFontFaces extends WP_UnitTestCase {
-	use WP_Font_Face_Tests_Datasets;
+class Tests_Fonts_WPPrintFontFaces extends WP_Font_Face_TestCase {
+	const FONTS_THEME = 'fonts-block-theme';
+
+	public static function set_up_before_class() {
+		self::$requires_switch_theme_fixtures = true;
+
+		parent::set_up_before_class();
+	}
 
 	/**
 	 * @dataProvider data_should_print_given_fonts
@@ -39,10 +45,24 @@ class Tests_Fonts_WPPrintFontFaces extends WP_UnitTestCase {
 	 * @param string $expected Expected CSS.
 	 */
 	public function test_should_print_given_fonts( array $fonts, $expected ) {
-		$style_element   = "<style id='wp-fonts-local' type='text/css'>\n%s\n</style>\n";
-		$expected_output = sprintf( $style_element, $expected );
+		$expected_output = $this->get_expected_styles_output( $expected );
 
 		$this->expectOutputString( $expected_output );
 		wp_print_font_faces( $fonts );
+	}
+
+	public function test_should_print_fonts_in_merged_data() {
+		switch_theme( static::FONTS_THEME );
+
+		$expected        = $this->get_expected_fonts_for_fonts_block_theme( 'font_face_styles' );
+		$expected_output = $this->get_expected_styles_output( $expected );
+
+		$this->expectOutputString( $expected_output );
+		wp_print_font_faces();
+	}
+
+	private function get_expected_styles_output( $styles ) {
+		$style_element = "<style id='wp-fonts-local' type='text/css'>\n%s\n</style>\n";
+		return sprintf( $style_element, $styles );
 	}
 }

--- a/phpunit/fonts/wpPrintFontFaces-test.php
+++ b/phpunit/fonts/wpPrintFontFaces-test.php
@@ -38,6 +38,13 @@ class Tests_Fonts_WPPrintFontFaces extends WP_Font_Face_TestCase {
 		parent::set_up_before_class();
 	}
 
+	public function test_should_not_print_when_no_fonts() {
+		switch_theme( 'block-theme' );
+
+		$this->expectOutputString( '' );
+		wp_print_font_faces();
+	}
+
 	/**
 	 * @dataProvider data_should_print_given_fonts
 	 *

--- a/phpunit/fonts/wpPrintFontFaces-test.php
+++ b/phpunit/fonts/wpPrintFontFaces-test.php
@@ -6,9 +6,11 @@
  * @subpackage Fonts
  */
 
-/**
+require_once __DIR__ . '/wp-font-face-tests-dataset.php';
+
+/*
  * This code is only needed if the Font API is enabled.
- * It should be removed after Font Manager is merged into Gutenberg.
+ * @todo remove this code when Font Library is merged into Gutenberg.
  */
 if ( ! class_exists( 'WP_Font_Face' ) ) {
 	require_once __DIR__ . '/../../../lib/experimental/fonts/class-wp-font-face.php';
@@ -24,209 +26,23 @@ if ( ! class_exists( 'WP_Font_Face' ) ) {
  *
  * @since X.X.X
  * @group fonts
+ * @group fontface
  * @covers wp_print_font_faces
  */
 class Tests_Fonts_WPPrintFontFaces extends WP_UnitTestCase {
+	use WP_Font_Face_Tests_Datasets;
 
 	/**
-	 * @dataProvider data_test_wp_print_font_faces
+	 * @dataProvider data_should_print_given_fonts
 	 *
-	 * @param array  $fonts Prepared fonts (to store in WP_Fonts_Provider_Local::$fonts property).
+	 * @param array  $fonts    Fonts to process.
 	 * @param string $expected Expected CSS.
 	 */
-	public function test_should_print_passed_fonts( array $fonts, $expected ) {
+	public function test_should_print_given_fonts( array $fonts, $expected ) {
 		$style_element   = "<style id='wp-fonts-local' type='text/css'>\n%s\n</style>\n";
 		$expected_output = sprintf( $style_element, $expected );
+
 		$this->expectOutputString( $expected_output );
 		wp_print_font_faces( $fonts );
-	}
-
-	/**
-	 * Data provider.
-	 *
-	 * @return array
-	 */
-	public function data_test_wp_print_font_faces() {
-		return array(
-			'single truetype format font'    => array(
-				'fonts'    => array(
-					'Inter' =>
-						array(
-							array(
-								'src'          =>
-									array(
-										'https://example.org/assets/fonts/inter/Inter-VariableFont_slnt,wght.ttf',
-									),
-								'font-family'  => 'Inter',
-								'font-stretch' => 'normal',
-								'font-style'   => 'normal',
-								'font-weight'  => '200',
-							),
-						),
-				),
-				'expected' => <<<CSS
-@font-face{font-family:Inter;font-style:normal;font-weight:200;font-display:fallback;src:url('https://example.org/assets/fonts/inter/Inter-VariableFont_slnt,wght.ttf') format('truetype');font-stretch:normal;}
-CSS
-			,
-			),
-			'multiple truetype format fonts' => array(
-				'fonts'    => array(
-					'Inter' =>
-						array(
-							array(
-								'src'          =>
-									array(
-										'https://example.org/assets/fonts/inter/Inter-VariableFont_slnt,wght.ttf',
-									),
-								'font-family'  => 'Inter',
-								'font-stretch' => 'normal',
-								'font-style'   => 'normal',
-								'font-weight'  => '200',
-							),
-							array(
-								'src'          =>
-									array(
-										'https://example.org/assets/fonts/inter/Inter-VariableFont_slnt-Italic,wght.ttf',
-									),
-								'font-family'  => 'Inter',
-								'font-stretch' => 'normal',
-								'font-style'   => 'italic',
-								'font-weight'  => '900',
-							),
-						),
-				),
-				'expected' => <<<CSS
-@font-face{font-family:Inter;font-style:normal;font-weight:200;font-display:fallback;src:url('https://example.org/assets/fonts/inter/Inter-VariableFont_slnt,wght.ttf') format('truetype');font-stretch:normal;}
-@font-face{font-family:Inter;font-style:italic;font-weight:900;font-display:fallback;src:url('https://example.org/assets/fonts/inter/Inter-VariableFont_slnt-Italic,wght.ttf') format('truetype');font-stretch:normal;}
-CSS
-			,
-			),
-			'single woff2 format font'       => array(
-				'fonts'    => array(
-					'DM Sans' =>
-						array(
-							array(
-								'src'          =>
-									array(
-										'https://example.org/assets/fonts/dm-sans/DMSans-Regular.woff2',
-									),
-								'font-family'  => 'DM Sans',
-								'font-stretch' => 'normal',
-								'font-style'   => 'normal',
-								'font-weight'  => '400',
-							),
-						),
-				),
-				'expected' => <<<CSS
-@font-face{font-family:"DM Sans";font-style:normal;font-weight:400;font-display:fallback;src:url('https://example.org/assets/fonts/dm-sans/DMSans-Regular.woff2') format('woff2');font-stretch:normal;}
-CSS
-			,
-			),
-			'multiple woff2 format fonts'    => array(
-				'fonts'    => array(
-					'DM Sans'       =>
-						array(
-							array(
-								'src'          =>
-									array(
-										'https://example.org/assets/fonts/dm-sans/DMSans-Regular.woff2',
-									),
-								'font-family'  => 'DM Sans',
-								'font-stretch' => 'normal',
-								'font-style'   => 'normal',
-								'font-weight'  => '400',
-							),
-							array(
-								'src'          =>
-									array(
-										'https://example.org/assets/fonts/dm-sans/DMSans-Regular-Italic.woff2',
-									),
-								'font-family'  => 'DM Sans',
-								'font-stretch' => 'normal',
-								'font-style'   => 'italic',
-								'font-weight'  => '400',
-							),
-							array(
-								'src'          =>
-									array(
-										'https://example.org/assets/fonts/dm-sans/DMSans-Bold.woff2',
-									),
-								'font-family'  => 'DM Sans',
-								'font-stretch' => 'normal',
-								'font-style'   => 'normal',
-								'font-weight'  => '700',
-							),
-							array(
-								'src'          =>
-									array(
-										'https://example.org/assets/fonts/dm-sans/DMSans-Bold-Italic.woff2',
-									),
-								'font-family'  => 'DM Sans',
-								'font-stretch' => 'normal',
-								'font-style'   => 'italic',
-								'font-weight'  => '700',
-							),
-						),
-					'IBM Plex Mono' =>
-						array(
-							array(
-								'src'          =>
-									array(
-										'https://example.org/assets/fonts/ibm-plex-mono/IBMPlexMono-Light.woff2',
-									),
-								'font-family'  => 'IBM Plex Mono',
-								'font-display' => 'block',
-								'font-stretch' => 'normal',
-								'font-style'   => 'normal',
-								'font-weight'  => '300',
-							),
-							array(
-								'src'          =>
-									array(
-										'https://example.org/assets/fonts/ibm-plex-mono/IBMPlexMono-Regular.woff2',
-									),
-								'font-family'  => 'IBM Plex Mono',
-								'font-display' => 'block',
-								'font-stretch' => 'normal',
-								'font-style'   => 'normal',
-								'font-weight'  => '400',
-							),
-							array(
-								'src'          =>
-									array(
-										'https://example.org/assets/fonts/ibm-plex-mono/IBMPlexMono-Italic.woff2',
-									),
-								'font-family'  => 'IBM Plex Mono',
-								'font-display' => 'block',
-								'font-stretch' => 'normal',
-								'font-style'   => 'italic',
-								'font-weight'  => '400',
-							),
-							array(
-								'src'          =>
-									array(
-										'https://example.org/assets/fonts/ibm-plex-mono/IBMPlexMono-Bold.woff2',
-									),
-								'font-family'  => 'IBM Plex Mono',
-								'font-display' => 'block',
-								'font-stretch' => 'normal',
-								'font-style'   => 'normal',
-								'font-weight'  => '700',
-							),
-						),
-				),
-				'expected' => <<<CSS
-@font-face{font-family:"DM Sans";font-style:normal;font-weight:400;font-display:fallback;src:url('https://example.org/assets/fonts/dm-sans/DMSans-Regular.woff2') format('woff2');font-stretch:normal;}
-@font-face{font-family:"DM Sans";font-style:italic;font-weight:400;font-display:fallback;src:url('https://example.org/assets/fonts/dm-sans/DMSans-Regular-Italic.woff2') format('woff2');font-stretch:normal;}
-@font-face{font-family:"DM Sans";font-style:normal;font-weight:700;font-display:fallback;src:url('https://example.org/assets/fonts/dm-sans/DMSans-Bold.woff2') format('woff2');font-stretch:normal;}
-@font-face{font-family:"DM Sans";font-style:italic;font-weight:700;font-display:fallback;src:url('https://example.org/assets/fonts/dm-sans/DMSans-Bold-Italic.woff2') format('woff2');font-stretch:normal;}
-@font-face{font-family:"IBM Plex Mono";font-style:normal;font-weight:300;font-display:block;src:url('https://example.org/assets/fonts/ibm-plex-mono/IBMPlexMono-Light.woff2') format('woff2');font-stretch:normal;}
-@font-face{font-family:"IBM Plex Mono";font-style:normal;font-weight:400;font-display:block;src:url('https://example.org/assets/fonts/ibm-plex-mono/IBMPlexMono-Regular.woff2') format('woff2');font-stretch:normal;}
-@font-face{font-family:"IBM Plex Mono";font-style:italic;font-weight:400;font-display:block;src:url('https://example.org/assets/fonts/ibm-plex-mono/IBMPlexMono-Italic.woff2') format('woff2');font-stretch:normal;}
-@font-face{font-family:"IBM Plex Mono";font-style:normal;font-weight:700;font-display:block;src:url('https://example.org/assets/fonts/ibm-plex-mono/IBMPlexMono-Bold.woff2') format('woff2');font-stretch:normal;}
-CSS
-			,
-			),
-		);
 	}
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Introduce Font Face processing to generate and print `@font-face` styles for fonts in theme.json merged data.

It's minimalistic in what it publicly exposes to avoid BC concerns.

There's no register, deregister, or enqueue of fonts or providers.

The fonts to be processed come directly from theme.json merged data which contains the theme's defined fonts and user "activated" fonts (from the Font Library).

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

See #51769.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

It adds 2 new classes `WP_Font_Face` and `WP_Font_Face_Resolver` which currently live in `/lib/experimental/fonts/` folder. That folder could also house the new Fonts Library.

Jobs:
* The Resolver's job is to handle getting and formatting the font data from theme.json.
* The `WP_Font_Face`'s job is to generate and print the `@font-face` styles.
* The local provider functionality is integrated into `WP_Font_Face`. 

If in the future support for custom providers is needed, the local provider can be removed from the`WP_Font_Face` and reintroduced as a separate class without breaking BC (backwards-compatibility).

When it's time to print, `wp_print_font_faces()` handles a call to the `WP_Font_Face_Resolver::get_fonts_from_theme_json()` and passes the fonts to `WP_Font_Face::print()`.

This also means other sources could pass fonts to `WP_Font_Face::print()`, such as plugins on a classic site.

### Prepared to be merged _before_ Fonts Library

The new files will not be loaded into memory unless the Fonts Library exists. In this way, this PR can be merged into `trunk` before the Fonts Library without breaking websites that are using the Fonts API.

## TODO

- [X] Add `WP_Font_Face_Resolver`.
- [X] Add `WP_Font_Face`.
- [X] Integrate local provider into `WP_Font_Face`.
- [X] Only expose `print()` to hide the internal workings (eliminate future BC concerns).
- [X] Conditional load only when the Fonts Library exists.
- [x] Add PHPUnit tests.

## Testing Instructions

1. Enable the loading of this PR's files by:
    a. Open `lib/load.php`.
    b. Scroll down to where the Font Face files are loaded.
    c. Add `true || ` in the `if`:
```php
if ( true || class_exists( 'WP_Fonts_Library' ) || class_exists( 'WP_Fonts_Library_Controller' ) ) {
```
2. With TT3:
  a. In Site Editor using Dev Tools, check that the `<script id="wp-fonts-local">` and `@font-face` styles are present in `<head>` and the iframed editor.
  b. In a post or page, check that the `<script id="wp-fonts-local">` and `@font-face` styles are present in `<head>` and the iframed editor.
  c. On the front-end, check that the `<script id="wp-fonts-local">` and `@font-face` styles are present.

```html
<style id="wp-fonts-local">
@font-face{font-family:"DM Sans";font-style:normal;font-weight:400;font-display:fallback;src:url('http://localhost:8889/wp-content/themes/twentytwentythree/assets/fonts/dm-sans/DMSans-Regular.woff2') format('woff2');font-stretch:normal;}
@font-face{font-family:"DM Sans";font-style:italic;font-weight:400;font-display:fallback;src:url('http://localhost:8889/wp-content/themes/twentytwentythree/assets/fonts/dm-sans/DMSans-Regular-Italic.woff2') format('woff2');font-stretch:normal;}
@font-face{font-family:"DM Sans";font-style:normal;font-weight:700;font-display:fallback;src:url('http://localhost:8889/wp-content/themes/twentytwentythree/assets/fonts/dm-sans/DMSans-Bold.woff2') format('woff2');font-stretch:normal;}
@font-face{font-family:"DM Sans";font-style:italic;font-weight:700;font-display:fallback;src:url('http://localhost:8889/wp-content/themes/twentytwentythree/assets/fonts/dm-sans/DMSans-Bold-Italic.woff2') format('woff2');font-stretch:normal;}
@font-face{font-family:"IBM Plex Mono";font-style:normal;font-weight:300;font-display:block;src:url('http://localhost:8889/wp-content/themes/twentytwentythree/assets/fonts/ibm-plex-mono/IBMPlexMono-Light.woff2') format('woff2');font-stretch:normal;}
@font-face{font-family:"IBM Plex Mono";font-style:normal;font-weight:400;font-display:block;src:url('http://localhost:8889/wp-content/themes/twentytwentythree/assets/fonts/ibm-plex-mono/IBMPlexMono-Regular.woff2') format('woff2');font-stretch:normal;}
@font-face{font-family:"IBM Plex Mono";font-style:italic;font-weight:400;font-display:block;src:url('http://localhost:8889/wp-content/themes/twentytwentythree/assets/fonts/ibm-plex-mono/IBMPlexMono-Italic.woff2') format('woff2');font-stretch:normal;}
@font-face{font-family:"IBM Plex Mono";font-style:normal;font-weight:700;font-display:block;src:url('http://localhost:8889/wp-content/themes/twentytwentythree/assets/fonts/ibm-plex-mono/IBMPlexMono-Bold.woff2') format('woff2');font-stretch:normal;}
@font-face{font-family:Inter;font-style:normal;font-weight:200 900;font-display:fallback;src:url('http://localhost:8889/wp-content/themes/twentytwentythree/assets/fonts/inter/Inter-VariableFont_slnt,wght.ttf') format('truetype');font-stretch:normal;}
@font-face{font-family:"Source Serif Pro";font-style:normal;font-weight:200 900;font-display:fallback;src:url('http://localhost:8889/wp-content/themes/twentytwentythree/assets/fonts/source-serif-pro/SourceSerif4Variable-Roman.ttf.woff2') format('woff2');font-stretch:normal;}
@font-face{font-family:"Source Serif Pro";font-style:italic;font-weight:200 900;font-display:fallback;src:url('http://localhost:8889/wp-content/themes/twentytwentythree/assets/fonts/source-serif-pro/SourceSerif4Variable-Italic.ttf.woff2') format('woff2');font-stretch:normal;}

</style>
```
2. With TT1:
    * In the `functions.php`, add the following code:
```php
add_action( 'wp_head', 'tt1_test_print_font_faces', 50 );
add_action( 'admin_print_styles', 'tt1_test_print_font_faces', 50 );
function tt1_test_print_font_faces() {
	$fonts = array(
			'Source Serif Pro' => array(
					array(
							'font-family' => 'Source Serif Pro',
							'font-style'   => 'normal',
							'font-weight'  => '200 900',
							'src'          => get_theme_file_uri( 'assets/fonts/source-serif-pro/SourceSerif4Variable-Roman.ttf.woff2' ),
					),
					array(
							'font-family' => 'Source Serif Pro',
							'font-style'   => 'italic',
							'font-weight'  => '200 900',
							'src'          => get_theme_file_uri( 'assets/fonts/source-serif-pro/SourceSerif4Variable-Italic.ttf.woff2' ),
					),
			),
	);
	wp_print_font_faces( $fonts );
}
```
   * Using Dev Tools, check in the front-end and admin area that the `<script id="wp-fonts-local">` and `@font-face` styles are present.

```html
<style id="wp-fonts-local">
@font-face{font-family:"Source Serif Pro";font-style:normal;font-weight:200 900;font-display:fallback;src:url('http://localhost:8889/wp-content/themes/twentytwentyone/assets/fonts/source-serif-pro/SourceSerif4Variable-Roman.ttf.woff2') format('woff2');}
@font-face{font-family:"Source Serif Pro";font-style:italic;font-weight:200 900;font-display:fallback;src:url('http://localhost:8889/wp-content/themes/twentytwentyone/assets/fonts/source-serif-pro/SourceSerif4Variable-Italic.ttf.woff2') format('woff2');}

</style>
```