### PR TITLE
Page Content Focus: Default insertion point to the Post Content block

### DIFF
--- a/packages/block-editor/src/components/inserter/library.js
+++ b/packages/block-editor/src/components/inserter/library.js
@@ -36,7 +36,8 @@ function InserterLibrary(
 			return {
 				destinationRootClientId: _rootClientId,
 				prioritizePatterns:
-					getSettings().__experimentalPreferPatternsOnRoot,
+					getSettings().__experimentalPreferPatternsOnRoot &&
+					! _rootClientId,
 			};
 		},
 		[ clientId, rootClientId ]

--- a/packages/edit-site/src/store/selectors.js
+++ b/packages/edit-site/src/store/selectors.js
@@ -12,6 +12,7 @@ import deprecated from '@wordpress/deprecated';
 import { uploadMedia } from '@wordpress/media-utils';
 import { Platform } from '@wordpress/element';
 import { store as preferencesStore } from '@wordpress/preferences';
+import { store as blockEditorStore } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
@@ -224,11 +225,35 @@ export function isInserterOpened( state ) {
  *
  * @return {Object} The root client ID, index to insert at and starting filter value.
  */
-export function __experimentalGetInsertionPoint( state ) {
-	const { rootClientId, insertionIndex, filterValue } =
-		state.blockInserterPanel;
-	return { rootClientId, insertionIndex, filterValue };
-}
+export const __experimentalGetInsertionPoint = createRegistrySelector(
+	( select ) => ( state ) => {
+		if ( typeof state.blockInserterPanel === 'object' ) {
+			const { rootClientId, insertionIndex, filterValue } =
+				state.blockInserterPanel;
+			return { rootClientId, insertionIndex, filterValue };
+		}
+
+		if ( hasPageContentFocus( state ) ) {
+			const [ postContentClientId ] =
+				select( blockEditorStore ).__experimentalGetGlobalBlocksByName(
+					'core/post-content'
+				);
+			if ( postContentClientId ) {
+				return {
+					rootClientId: postContentClientId,
+					insertionIndex: undefined,
+					filterValue: undefined,
+				};
+			}
+		}
+
+		return {
+			rootClientId: undefined,
+			insertionIndex: undefined,
+			filterValue: undefined,
+		};
+	}
+);
 
 /**
  * Returns the current opened/closed state of the list view panel.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Follows https://github.com/WordPress/gutenberg/pull/50857. 

Makes it so that when you are focused on editing a page's content in the site editor and no block is selected, the global inserter will insert blocks into the end of the Post Content block.

## Why?
This mimics the post editor and is what users would expect when editing page content.

## How?
Adds a special case to the existing `__experimentalGetInsertionPoint` selector in the `core/edit-site` store.

## Testing Instructions
1. Go to Appearance → Editor.
2. Select Pages.
3. Click on a page to edit or create one.
4. Select Edit.
5. Open the global inserter.
6. Select a block to insert.

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/612155/12679b24-72a8-43b1-a2b5-d14a689008b8