### PR TITLE
Template revisions API: move back to experimental

### DIFF
--- a/lib/compat/wordpress-6.3/class-gutenberg-rest-templates-controller-6-3.php
+++ b/lib/compat/wordpress-6.3/class-gutenberg-rest-templates-controller-6-3.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * REST API: Gutenberg_REST_Templates_Controller_6_2 class
+ * REST API: Gutenberg_REST_Templates_Controller_6_3 class
  *
  * @package    Gutenberg
  * @subpackage REST_API
@@ -64,68 +64,5 @@ class Gutenberg_REST_Templates_Controller_6_3 extends WP_REST_Templates_Controll
 		} while ( ! empty( $hierarchy ) && empty( $fallback_template->content ) );
 		$response = $this->prepare_item_for_response( $fallback_template, $request );
 		return rest_ensure_response( $response );
-	}
-
-	/**
-	 * Add revisions to the response.
-	 *
-	 * @since 6.3.0 Added prepare_revision_links() method to get revision links.
-	 *
-	 * @param WP_Block_Template $item    Template instance.
-	 * @param WP_REST_Request   $request Request object.
-	 * @return WP_REST_Response Response object.
-	 */
-	public function prepare_item_for_response( $item, $request ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
-		$template = $item;
-
-		$fields = $this->get_fields_for_response( $request );
-
-		$response = parent::prepare_item_for_response( $item, $request );
-
-		if ( rest_is_field_included( '_links', $fields ) || rest_is_field_included( '_embedded', $fields ) ) {
-			$links = $this->prepare_revision_links( $template );
-			$response->add_links( $links );
-			if ( ! empty( $links['self']['href'] ) ) {
-				$actions = $this->get_available_actions();
-				$self    = $links['self']['href'];
-				foreach ( $actions as $rel ) {
-					$response->add_link( $rel, $self );
-				}
-			}
-		}
-
-		return $response;
-	}
-
-	/**
-	 * Adds revisions to links.
-	 *
-	 * @since 6.3.0
-	 *
-	 * @param WP_Block_Template $template  Template instance.
-	 * @return array Links for the given post.
-	 */
-	protected function prepare_revision_links( $template ) {
-		$links = array();
-
-		if ( post_type_supports( $this->post_type, 'revisions' ) && (int) $template->wp_id ) {
-			$revisions       = wp_get_latest_revision_id_and_total_count( (int) $template->wp_id );
-			$revisions_count = ! is_wp_error( $revisions ) ? $revisions['count'] : 0;
-			$revisions_base  = sprintf( '/%s/%s/%s/revisions', $this->namespace, $this->rest_base, $template->id );
-
-			$links['version-history'] = array(
-				'href'  => rest_url( $revisions_base ),
-				'count' => $revisions_count,
-			);
-
-			if ( $revisions_count > 0 ) {
-				$links['predecessor-version'] = array(
-					'href' => rest_url( $revisions_base . '/' . $revisions['latest_id'] ),
-					'id'   => $revisions['latest_id'],
-				);
-			}
-		}
-
-		return $links;
 	}
 }

--- a/lib/compat/wordpress-6.3/rest-api.php
+++ b/lib/compat/wordpress-6.3/rest-api.php
@@ -23,15 +23,14 @@
  */
 function gutenberg_update_templates_template_parts_rest_controller( $args, $post_type ) {
 	if ( in_array( $post_type, array( 'wp_template', 'wp_template_part' ), true ) ) {
-		$template_edit_link            = 'site-editor.php?' . build_query(
+		$template_edit_link = 'site-editor.php?' . build_query(
 			array(
 				'postType' => $post_type,
 				'postId'   => '%s',
 				'canvas'   => 'edit',
 			)
 		);
-		$args['_edit_link']            = $template_edit_link;
-		$args['rest_controller_class'] = 'Gutenberg_REST_Templates_Controller_6_3';
+		$args['_edit_link'] = $template_edit_link;
 	}
 
 	if ( in_array( $post_type, array( 'wp_global_styles' ), true ) ) {

--- a/lib/experimental/class-gutenberg-rest-template-revision-count.php
+++ b/lib/experimental/class-gutenberg-rest-template-revision-count.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * REST API: Gutenberg_REST_Template_Revision_Count class
+ *
+ * @package    gutenberg
+ */
+
+/**
+ * Gutenberg_REST_Template_Revision_Count class
+ *
+ * Template revision changes are waiting on a core change to be merged.
+ * See: https://github.com/WordPress/gutenberg/pull/45215#issuecomment-1592704026
+ * When merging into core, prepare_revision_links() should be merged with
+ * WP_REST_Templates_Controller::prepare_links().
+ */
+class Gutenberg_REST_Template_Revision_Count extends Gutenberg_REST_Templates_Controller_6_3 {
+	/**
+	 * Add revisions to the response.
+	 *
+	 * @param WP_Block_Template $item    Template instance.
+	 * @param WP_REST_Request   $request Request object.
+	 * @return WP_REST_Response Response object.
+	 */
+	public function prepare_item_for_response( $item, $request ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		$template = $item;
+
+		$fields = $this->get_fields_for_response( $request );
+
+		$response = parent::prepare_item_for_response( $item, $request );
+
+		if ( rest_is_field_included( '_links', $fields ) || rest_is_field_included( '_embedded', $fields ) ) {
+			$links = $this->prepare_revision_links( $template );
+			$response->add_links( $links );
+			if ( ! empty( $links['self']['href'] ) ) {
+				$actions = $this->get_available_actions();
+				$self    = $links['self']['href'];
+				foreach ( $actions as $rel ) {
+					$response->add_link( $rel, $self );
+				}
+			}
+		}
+
+		return $response;
+	}
+
+	/**
+	 * Adds revisions to links.
+	 *
+	 * @param WP_Block_Template $template  Template instance.
+	 * @return array Links for the given post.
+	 */
+	protected function prepare_revision_links( $template ) {
+		$links = array();
+
+		if ( post_type_supports( $this->post_type, 'revisions' ) && (int) $template->wp_id ) {
+			$revisions       = wp_get_latest_revision_id_and_total_count( (int) $template->wp_id );
+			$revisions_count = ! is_wp_error( $revisions ) ? $revisions['count'] : 0;
+			$revisions_base  = sprintf( '/%s/%s/%s/revisions', $this->namespace, $this->rest_base, $template->id );
+
+			$links['version-history'] = array(
+				'href'  => rest_url( $revisions_base ),
+				'count' => $revisions_count,
+			);
+
+			if ( $revisions_count > 0 ) {
+				$links['predecessor-version'] = array(
+					'href' => rest_url( $revisions_base . '/' . $revisions['latest_id'] ),
+					'id'   => $revisions['latest_id'],
+				);
+			}
+		}
+
+		return $links;
+	}
+}

--- a/lib/experimental/rest-api.php
+++ b/lib/experimental/rest-api.php
@@ -111,3 +111,24 @@ function gutenberg_auto_draft_get_sample_permalink( $permalink, $id, $title, $na
 	return $permalink;
 }
 add_filter( 'get_sample_permalink', 'gutenberg_auto_draft_get_sample_permalink', 10, 5 );
+
+/**
+ * Hook in to the template and template part post types and decorate
+ * the rest endpoint with the revision count.
+ *
+ * When merging to core, this can be removed once Gutenberg_REST_Template_Revision_Count is
+ * merged with WP_REST_Template_Controller.
+ *
+ * @param array  $args Current registered post type args.
+ * @param string $post_type Name of post type.
+ *
+ * @return array
+ */
+function wp_api_template_revision_args( $args, $post_type ) {
+	if ( 'wp_template' === $post_type || 'wp_template_part' === $post_type ) {
+		$args['rest_controller_class'] = 'Gutenberg_REST_Template_Revision_Count';
+	}
+
+	return $args;
+}
+add_filter( 'register_post_type_args', 'wp_api_template_revision_args', 10, 2 );

--- a/lib/load.php
+++ b/lib/load.php
@@ -59,6 +59,7 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 	if ( ! class_exists( 'WP_Rest_Customizer_Nonces' ) ) {
 		require_once __DIR__ . '/experimental/class-wp-rest-customizer-nonces.php';
 	}
+	require_once __DIR__ . '/experimental/class-gutenberg-rest-template-revision-count.php';
 
 	require_once __DIR__ . '/experimental/rest-api.php';
 }


### PR DESCRIPTION
## What?
This PR moves the PHP changes from:

- https://github.com/WordPress/gutenberg/pull/45215 (code was originally in experimental)
- https://github.com/WordPress/gutenberg/pull/48078 (moved to 6.3)

from `compat/6.3` into `/experimental`

## Why?
Template revisions feature won't make it to 6.3 without a Core change

See discussion: https://github.com/WordPress/gutenberg/pull/45215#issuecomment-1592704026

## How?
Copy pasta

## Testing Instructions
Check that the feature still works on Gutenberg, and that you can see the template revisions button after you change a template or template part (more than twice).

<img width="354" alt="Screenshot 2023-06-22 at 12 39 25 pm" src="https://github.com/WordPress/gutenberg/assets/6458278/04485cd4-06d7-49d0-abf0-0c7f02100237">

More detailed test steps in https://github.com/WordPress/gutenberg/pull/45215




