### PR TITLE
Fix black pixel appearing when block toolbar is empty

### DIFF
--- a/packages/block-editor/src/components/block-toolbar/index.js
+++ b/packages/block-editor/src/components/block-toolbar/index.js
@@ -127,9 +127,9 @@ const BlockToolbar = ( { hideDragHandle } ) => {
 			{ ! isMultiToolbar &&
 				isLargeViewport &&
 				blockEditingMode === 'default' && <BlockParentSelector /> }
-			<div ref={ nodeRef } { ...showMoversGestures }>
-				{ ( shouldShowVisualToolbar || isMultiToolbar ) &&
-					blockEditingMode === 'default' && (
+			{ ( shouldShowVisualToolbar || isMultiToolbar ) &&
+				blockEditingMode === 'default' && (
+					<div ref={ nodeRef } { ...showMoversGestures }>
 						<ToolbarGroup className="block-editor-block-toolbar__block-controls">
 							<BlockSwitcher clientIds={ blockClientIds } />
 							{ ! isMultiToolbar && (
@@ -142,8 +142,8 @@ const BlockToolbar = ( { hideDragHandle } ) => {
 								hideDragHandle={ hideDragHandle }
 							/>
 						</ToolbarGroup>
-					) }
-			</div>
+					</div>
+				) }
 			{ shouldShowVisualToolbar && isMultiToolbar && (
 				<BlockGroupToolbar />
 			) }

--- a/packages/block-editor/src/components/block-tools/style.scss
+++ b/packages/block-editor/src/components/block-tools/style.scss
@@ -121,6 +121,10 @@
 		}
 	}
 
+	&:has(.block-editor-block-toolbar:empty) {
+		display: none;
+	}
+
 	// on desktop and tablet viewports the toolbar is fixed
 	// on top of interface header
 


### PR DESCRIPTION
## What?
Fixes an issue where when there are no tools in the block toolbar you see a single floating black pixel above the block. 

## Why?
This scenario is much more common now following https://github.com/WordPress/gutenberg/pull/50857. 

Closes https://github.com/WordPress/gutenberg/issues/51664.

## How?
This uses `:has()` to hide the contextual toolbar if the inner block toolbar is empty. The downside of this is that it doesn't work in Firefox which does not yet support `:has()`. But otherwise I think it's a nice approach and it looks like Firefox will soon support `:has()` so I am thinking... maybe this is good enough? Let me know if you disagree.

https://caniuse.com/?search=%3Ahas

## Testing Instructions
1. Go to Appearance → Editor.
2. Select Pages.
3. Select a page to edit.
4. Select the Post Title or Post Featured Image.

## Screenshots or screencast

| Before | After | 
| - | - | 
| <img width="1624" alt="Screenshot 2023-06-22 at 15 17 30" src="https://github.com/WordPress/gutenberg/assets/612155/13490aca-a168-4029-810f-6d0d88cb42d2"> | <img width="1624" alt="Screenshot 2023-06-22 at 15 17 10" src="https://github.com/WordPress/gutenberg/assets/612155/773f11c5-5244-4717-92c9-de0b9e286319"> |