### PR TITLE
Prevent block overlay on blocks with a 'contentOnly' editing mode

### DIFF
--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -2837,10 +2837,11 @@ export function __unstableGetTemporarilyEditingAsBlocks( state ) {
 }
 
 export function __unstableHasActiveBlockOverlayActive( state, clientId ) {
-	// Prevent overlay on disabled blocks. It's redundant since disabled blocks
-	// can't be selected, and prevents non-disabled nested blocks from being
-	// selected.
-	if ( getBlockEditingMode( state, clientId ) === 'disabled' ) {
+	// Prevent overlay on blocks with a non-default editing mode. If the mdoe is
+	// 'disabled' then the overlay is redundant since the block can't be
+	// selected. If the mode is 'contentOnly' then the overlay is redundant
+	// since there will be no controls to interact with once selected.
+	if ( getBlockEditingMode( state, clientId ) !== 'default' ) {
 		return false;
 	}
 


### PR DESCRIPTION
## What?
Fixes https://github.com/WordPress/gutenberg/issues/51259.

Prevents the block overlay from appearing on blocks with an [editing mode](https://github.com/WordPress/gutenberg/pull/50643) of `'contentOnly'`. For example the Post Content block when the user is [focused on editing page content](https://github.com/WordPress/gutenberg/pull/50857).

## Why?
The block overlay is redundant on blocks with an editing mode of `'contentOnly'`. There will be no block controls (toolbar items, etc.) once you select the block, so why push users towards selecting the block instead of its children?

## How?
Changes the logic in `__unstableHasActiveBlockOverlayActive`.

## Testing Instructions
1. Go to Appearance → Editor.
1. Select Pages.
1. Select a page to edit.
1. Click on a block that's in the page content e.g. a paragraph.
2. The block (e.g. paragraph) should be selected, not the Post Content block.