### PR TITLE
Library: Add an explicit label to the search control

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -18,6 +18,10 @@
 -   `ClipboardButton`: Convert to TypeScript ([#51334](https://github.com/WordPress/gutenberg/pull/51334)).
 -   `Toolbar`: Replace `reakit` dependency with `@ariakit/react` ([#51623](https://github.com/WordPress/gutenberg/pull/51623)).
 
+### Documentation
+
+-   `SearchControl`: Improve documentation around usage of `label` prop ([#51781](https://github.com/WordPress/gutenberg/pull/51781)).
+
 ## 25.1.0 (2023-06-07)
 
 ### Enhancements

--- a/packages/components/src/search-control/README.md
+++ b/packages/components/src/search-control/README.md
@@ -15,6 +15,7 @@ SearchControl components let users display a search control.
 Render a user interface to input the name of an additional css class.
 
 ```jsx
+import { __ } from '@wordpress/i18n';
 import { SearchControl } from '@wordpress/components';
 import { useState } from '@wordpress/element';
 
@@ -23,6 +24,7 @@ function MySearchControl( { className, setState } ) {
 
     return (
         <SearchControl
+			label={ __( 'Search posts' ) }
             value={ searchInput }
             onChange={ setSearchInput }
         />
@@ -38,6 +40,9 @@ Props not included in this set will be applied to the input element.
 #### label
 
 If this property is added, a label will be generated using label property as the content.
+
+A label should always be provided as an accessibility best practice, even when a placeholder is defined
+and `hideLabelFromVision` is `true`.
 
 -   Type: `String`
 -   Required: Yes
@@ -77,9 +82,10 @@ If this property is added, a help text will be generated using help property as 
 
 -   Type: `String|WPElement`
 -   Required: No
+
 ### hideLabelFromVision
 
-If true, the label will only be visible to screen readers.
+If true, the label will not be visible, but will be read by screen readers. Defaults to `true`.
 
 -   Type: `Boolean`
 -   Required: No

--- a/packages/components/src/search-control/README.md
+++ b/packages/components/src/search-control/README.md
@@ -24,7 +24,7 @@ function MySearchControl( { className, setState } ) {
 
     return (
         <SearchControl
-			label={ __( 'Search posts' ) }
+            label={ __( 'Search posts' ) }
             value={ searchInput }
             onChange={ setSearchInput }
         />

--- a/packages/edit-site/src/components/page-library/patterns-list.js
+++ b/packages/edit-site/src/components/page-library/patterns-list.js
@@ -66,6 +66,7 @@ export default function PatternsList( { categoryId, type } ) {
 						className="edit-site-library__search"
 						onChange={ ( value ) => setFilterValue( value ) }
 						placeholder={ __( 'Search patterns' ) }
+						label={ __( 'Search patterns' ) }
 						value={ filterValue }
 						__nextHasNoMarginBottom
 					/>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Small single line change to add a label prop to the `SearchControl` component in the site editor's library.

## Why?
Inputs should be labelled and not just rely on placeholder.

While screenreaders (though I'm not sure if all screenreaders) will announce a placeholder, the label is more prominently and consistently announced when the input has text entered.

## How?
Specify the label prop. This doesn't change anything visually, but is a good practice to follow for accessibility.

## Testing Instructions for Keyboard
1. Open the site editor
2. Tab to the Library option and select it
3. Tab till you get to the 'Search patterns' input

Expected: The label 'Search patterns' should be read

## Screenshots or screencast <!-- if applicable -->
It looks the same.