### PR TITLE
Site editor: Add a navigable region for content area of Library and Template views

### DIFF
--- a/packages/edit-site/src/components/page-library/index.js
+++ b/packages/edit-site/src/components/page-library/index.js
@@ -1,6 +1,7 @@
 /**
  * WordPress dependencies
  */
+import { __ } from '@wordpress/i18n';
 import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
 import { getQueryArgs } from '@wordpress/url';
 
@@ -26,7 +27,11 @@ export default function PageLibrary() {
 	// from the site editor store to the block editor store.
 	return (
 		<ExperimentalBlockEditorProvider settings={ settings }>
-			<Page className="edit-site-library">
+			<Page
+				className="edit-site-library"
+				title={ __( 'Library content' ) }
+				hideTitleFromUI
+			>
 				<PatternsList type={ type } categoryId={ category } />
 			</Page>
 		</ExperimentalBlockEditorProvider>

--- a/packages/edit-site/src/components/page/index.js
+++ b/packages/edit-site/src/components/page/index.js
@@ -4,6 +4,11 @@
 import classnames from 'classnames';
 
 /**
+ * WordPress dependencies
+ */
+import { NavigableRegion } from '@wordpress/interface';
+
+/**
  * Internal dependencies
  */
 import Header from './header';
@@ -14,12 +19,13 @@ export default function Page( {
 	actions,
 	children,
 	className,
+	hideTitleFromUI = false,
 } ) {
 	const classes = classnames( 'edit-site-page', className );
 
 	return (
-		<div className={ classes }>
-			{ title && (
+		<NavigableRegion className={ classes } ariaLabel={ title }>
+			{ ! hideTitleFromUI && title && (
 				<Header
 					title={ title }
 					subTitle={ subTitle }
@@ -27,6 +33,6 @@ export default function Page( {
 				/>
 			) }
 			<div className="edit-site-page-content">{ children }</div>
-		</div>
+		</NavigableRegion>
 	);
 }


### PR DESCRIPTION
## What?
Adds a navigable region to the Library content area and the Template content area (when you navigate to 'Manage all templates')

## Why?
It's a useful aid for keyboard/screenreader users to jump between parts of the screen

## How?
There seems to be a `Page` component that look perfect for this purpose. It already receives a `title`, so I've used that for the navigable region label.

## Testing Instructions for Keyboard
1. Open the site editor
2. Tab till you get to the Library option and select it
3. Use the navigate region shortcut to jump between the parts of the page (ctrl + backtick on a mac, ctrl + alt + n on windows)

Expected: There are two regions that are announced correctly, 'Navigation' and 'Library content'.

1. Open the site editor
2. Tab till you get to Templates and select it
3. Tab till you get to Manage all templates and select it
4. Use the navigate region shortcut to jump between the parts of the page (ctrl + backtick on a mac, ctrl + alt + n on windows)

Expected: There are two regions that are announced correctly, 'Navigation' and 'Templates'.

## Screenshots or screencast <!-- if applicable -->
There's no visible difference