### PR TITLE
Backport from core: rename `gutenberg_get_remote_theme_patterns` to `gutenberg_get_theme_directory_pattern_slugs`

### DIFF
--- a/lib/compat/wordpress-6.3/block-patterns.php
+++ b/lib/compat/wordpress-6.3/block-patterns.php
@@ -139,7 +139,7 @@ function gutenberg_register_remote_theme_patterns() {
 		return;
 	}
 
-	$pattern_settings = gutenberg_get_remote_theme_patterns();
+	$pattern_settings = gutenberg_get_theme_directory_pattern_slugs();
 	if ( empty( $pattern_settings ) ) {
 		return;
 	}

--- a/lib/global-styles-and-settings.php
+++ b/lib/global-styles-and-settings.php
@@ -287,6 +287,6 @@ function gutenberg_get_global_styles( $path = array(), $context = array() ) {
  *
  * @return string[]
  */
-function gutenberg_get_remote_theme_patterns() {
+function gutenberg_get_theme_directory_pattern_slugs() {
 	return WP_Theme_JSON_Resolver_Gutenberg::get_theme_data( array(), array( 'with_supports' => false ) )->get_patterns();
 }


### PR DESCRIPTION
## What?

This PR backports to Gutenberg changes that were requested in WordPress core after porting to core the function `gutenberg_get_remote_theme_patterns`.

## Why?

Both codebases need to be in sync.

## How?

Rename all instances of that function.

## Testing Instructions

Make sure automated tests pass.
