### PR TITLE
Fix flaky tests in `navigation.spec.js` and other tests related to the Post Editor Template mode

### DIFF
--- a/test/e2e/specs/editor/blocks/navigation.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation.spec.js
@@ -971,7 +971,7 @@ test.describe( 'Navigation block - Frontend interactivity', () => {
 			await editor.saveSiteEditorEntities();
 		} );
 
-		test( 'Overlay menu interactions', async ( { page } ) => {
+		test( 'Overlay menu interactions', async ( { page, pageUtils } ) => {
 			await page.goto( '/' );
 			const overlayMenuFirstElement = page.getByRole( 'link', {
 				name: 'Item 1',
@@ -993,11 +993,9 @@ test.describe( 'Navigation block - Frontend interactivity', () => {
 			await expect( overlayMenuFirstElement ).toBeFocused();
 
 			// Test: overlay menu traps focus
-			await page.keyboard.press( 'Tab' );
-			await page.keyboard.press( 'Tab' );
+			await pageUtils.pressKeys( 'Tab', { times: 2, delay: 50 } );
 			await expect( closeMenuButton ).toBeFocused();
-			await page.keyboard.press( 'Shift+Tab' );
-			await page.keyboard.press( 'Shift+Tab' );
+			await pageUtils.pressKeys( 'Shift+Tab', { times: 2, delay: 50 } );
 			await expect( overlayMenuFirstElement ).toBeFocused();
 
 			// Test: overlay menu closes on click on close menu button
@@ -1007,7 +1005,7 @@ test.describe( 'Navigation block - Frontend interactivity', () => {
 			// Test: overlay menu closes on ESC key
 			await openMenuButton.click();
 			await expect( overlayMenuFirstElement ).toBeVisible();
-			await page.keyboard.press( 'Escape' );
+			await pageUtils.pressKeys( 'Escape' );
 			await expect( overlayMenuFirstElement ).toBeHidden();
 			await expect( openMenuButton ).toBeFocused();
 		} );
@@ -1044,7 +1042,7 @@ test.describe( 'Navigation block - Frontend interactivity', () => {
 			await editor.saveSiteEditorEntities();
 		} );
 
-		test( 'Submenu interactions', async ( { page } ) => {
+		test( 'Submenu interactions', async ( { page, pageUtils } ) => {
 			await page.goto( '/' );
 			const simpleSubmenuButton = page.getByRole( 'button', {
 				name: 'Simple Submenu',
@@ -1090,28 +1088,26 @@ test.describe( 'Navigation block - Frontend interactivity', () => {
 
 			// Test: submenu opens on Enter keypress
 			await simpleSubmenuButton.focus();
-			await page.keyboard.press( 'Enter' );
+			await pageUtils.pressKeys( 'Enter' );
 			await expect( innerElement ).toBeVisible();
 
 			// Test: submenu closes on ESC key and focuses parent link
-			await page.keyboard.press( 'Escape' );
+			await pageUtils.pressKeys( 'Escape' );
 			await expect( innerElement ).toBeHidden();
 			await expect( simpleSubmenuButton ).toBeFocused();
 
 			// Test: submenu closes on tab outside submenu
 			await simpleSubmenuButton.focus();
-			await page.keyboard.press( 'Enter' );
+			await pageUtils.pressKeys( 'Enter' );
 			await expect( innerElement ).toBeVisible();
-			// Tab to first element.
-			await page.keyboard.press( 'Tab' );
-			// Tab outside the submenu.
-			await page.keyboard.press( 'Tab' );
+			// Tab to first element, then tab outside the submenu.
+			await pageUtils.pressKeys( 'Tab', { times: 2, delay: 50 } );
 			await expect( innerElement ).toBeHidden();
 			await expect( complexSubmenuButton ).toBeFocused();
 
 			// Test: only nested submenu closes on tab outside
 			await complexSubmenuButton.focus();
-			await page.keyboard.press( 'Enter' );
+			await pageUtils.pressKeys( 'Enter' );
 			await expect( firstLevelElement ).toBeVisible();
 			await expect( secondLevelElement ).toBeHidden();
 
@@ -1119,10 +1115,9 @@ test.describe( 'Navigation block - Frontend interactivity', () => {
 			await expect( firstLevelElement ).toBeVisible();
 			await expect( secondLevelElement ).toBeVisible();
 
-			// Tab to nested submenu first element.
-			await page.keyboard.press( 'Tab' );
-			// Tab outside the nested submenu.
-			await page.keyboard.press( 'Tab' );
+			// Tab to nested submenu first element, then tab outside the nested
+			// submenu.
+			await pageUtils.pressKeys( 'Tab', { times: 2, delay: 50 } );
 			await expect( firstLevelElement ).toBeVisible();
 			await expect( secondLevelElement ).toBeHidden();
 			// Tab outside the complex submenu.
@@ -1217,7 +1212,10 @@ test.describe( 'Navigation block - Frontend interactivity', () => {
 			await editor.saveSiteEditorEntities();
 		} );
 
-		test( 'page-list submenu user interactions', async ( { page } ) => {
+		test( 'page-list submenu user interactions', async ( {
+			page,
+			pageUtils,
+		} ) => {
 			await page.goto( '/' );
 			const submenuButton = page.getByRole( 'button', {
 				name: 'Parent Page',
@@ -1237,20 +1235,18 @@ test.describe( 'Navigation block - Frontend interactivity', () => {
 
 			// page-list submenu opens on enter keypress
 			await submenuButton.focus();
-			await page.keyboard.press( 'Enter' );
+			await pageUtils.pressKeys( 'Enter' );
 			await expect( innerElement ).toBeVisible();
 
 			// page-list submenu closes on ESC key and focuses submenu button
-			await page.keyboard.press( 'Escape' );
+			await pageUtils.pressKeys( 'Escape' );
 			await expect( innerElement ).toBeHidden();
 			await expect( submenuButton ).toBeFocused();
 
 			// page-list submenu closes on tab outside submenu
-			await page.keyboard.press( 'Enter' );
-			// Tab to first element.
-			await page.keyboard.press( 'Tab' );
-			// Tab outside the submenu.
-			await page.keyboard.press( 'Tab' );
+			await pageUtils.pressKeys( 'Enter', { delay: 50 } );
+			// Tab to first element, then tab outside the submenu.
+			await pageUtils.pressKeys( 'Tab', { times: 2, delay: 50 } );
 			await expect( innerElement ).toBeHidden();
 		} );
 	} );

--- a/test/e2e/specs/editor/various/post-editor-template-mode.spec.js
+++ b/test/e2e/specs/editor/various/post-editor-template-mode.spec.js
@@ -156,6 +156,7 @@ class PostEditorTemplateMode {
 
 	async createPostAndSaveDraft() {
 		await this.admin.createNewPost();
+		await this.editor.canvas.waitForLoadState();
 		// Create a random post.
 		await this.page.keyboard.type( 'Just an FSE Post' );
 		await this.page.keyboard.press( 'Enter' );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes flaky tests in the `navigation.spec.js` file belonging to the 'Navigation block - Frontend interactivity' test group.

- https://github.com/WordPress/gutenberg/issues/51537
- https://github.com/WordPress/gutenberg/issues/51543
- https://github.com/WordPress/gutenberg/issues/51348

Other tests were failing, this time related to the `Post Editor Template mode` (see [post-editor-template-mode.spec.js](https://github.com/WordPress/gutenberg/blob/9ee7e63734892e20c76649e763bf25da525b01a6/test/e2e/specs/editor/various/post-editor-template-mode.spec.js)). I fixed them as well.

## Why?

The feature works fine, but tests are randomly failing because Playwright seems to fail with consecutive `Tab` keystrokes without a delay in between.

## How?

Replaced consecutive `page.keyboard.press` calls with `pageUtils.pressKeys`, passing a delay of 50 milliseconds.

## Testing Instructions

Automatic e2e tests should pass now.
