### PR TITLE
Enter focus mode when single Navigation is edited on "listing" Navigation browse mode route

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen-main/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-main/index.js
@@ -17,6 +17,7 @@ import { useEffect } from '@wordpress/element';
  */
 import SidebarNavigationScreen from '../sidebar-navigation-screen';
 import SidebarNavigationItem from '../sidebar-navigation-item';
+import SidebarNavigationScreenNavigationMenuButton from '../sidebar-navigation-screen-navigation-menus/navigator-button';
 import { SidebarNavigationItemGlobalStyles } from '../sidebar-navigation-screen-global-styles';
 import { unlock } from '../../lock-unlock';
 import { store as editSiteStore } from '../../store';
@@ -43,14 +44,13 @@ export default function SidebarNavigationScreenMain() {
 			) }
 			content={
 				<ItemGroup>
-					<NavigatorButton
+					<SidebarNavigationScreenNavigationMenuButton
 						as={ SidebarNavigationItem }
-						path="/navigation"
 						withChevron
 						icon={ navigation }
 					>
 						{ __( 'Navigation' ) }
-					</NavigatorButton>
+					</SidebarNavigationScreenNavigationMenuButton>
 					<SidebarNavigationItemGlobalStyles
 						withChevron
 						icon={ styles }

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/index.js
@@ -1,7 +1,12 @@
 /**
  * WordPress dependencies
  */
-import { useEntityRecord, store as coreStore } from '@wordpress/core-data';
+import {
+	useEntityRecord,
+	useEntityRecords,
+	store as coreStore,
+} from '@wordpress/core-data';
+
 import {
 	__experimentalUseNavigator as useNavigator,
 	Spinner,
@@ -13,6 +18,7 @@ import { decodeEntities } from '@wordpress/html-entities';
 /**
  * Internal dependencies
  */
+import { PRELOADED_NAVIGATION_MENUS_QUERY } from '../sidebar-navigation-screen-navigation-menus/constants';
 import { SidebarNavigationScreenWrapper } from '../sidebar-navigation-screen-navigation-menus';
 import ScreenNavigationMoreMenu from './more-menu';
 import SingleNavigationMenu from './single-navigation-menu';
@@ -29,6 +35,12 @@ export default function SidebarNavigationScreenNavigationMenu() {
 		'postType',
 		postType,
 		postId
+	);
+
+	const { records: navigationMenus } = useEntityRecords(
+		'postType',
+		`wp_navigation`,
+		PRELOADED_NAVIGATION_MENUS_QUERY
 	);
 
 	const { isSaving, isDeleting } = useSelect(
@@ -63,12 +75,18 @@ export default function SidebarNavigationScreenNavigationMenu() {
 	const _handleSave = ( edits ) => handleSave( navigationMenu, edits );
 	const _handleDuplicate = () => handleDuplicate( navigationMenu );
 
+	// If we have a single menu then the backpath should skip the
+	// navigation menus screen (as that would cause an infinite redirect)
+	// and instead go back to the root.
+	const backPath = navigationMenus?.length === 1 ? '/' : undefined;
+
 	if ( isLoading ) {
 		return (
 			<SidebarNavigationScreenWrapper
 				description={ __(
 					'Navigation menus are a curated collection of blocks that allow visitors to get around your site.'
 				) }
+				backPath={ backPath }
 			>
 				<Spinner className="edit-site-sidebar-navigation-screen-navigation-menus__loading" />
 			</SidebarNavigationScreenWrapper>
@@ -79,6 +97,7 @@ export default function SidebarNavigationScreenNavigationMenu() {
 		return (
 			<SidebarNavigationScreenWrapper
 				description={ __( 'Navigation Menu missing.' ) }
+				backPath={ backPath }
 			/>
 		);
 	}
@@ -96,6 +115,7 @@ export default function SidebarNavigationScreenNavigationMenu() {
 				}
 				title={ decodeEntities( menuTitle ) }
 				description={ __( 'This Navigation Menu is empty.' ) }
+				backPath={ backPath }
 			/>
 		);
 	}
@@ -106,6 +126,7 @@ export default function SidebarNavigationScreenNavigationMenu() {
 			handleDelete={ _handleDelete }
 			handleSave={ _handleSave }
 			handleDuplicate={ _handleDuplicate }
+			backPath={ backPath }
 		/>
 	);
 }

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/single-navigation-menu.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/single-navigation-menu.js
@@ -15,6 +15,7 @@ export default function SingleNavigationMenu( {
 	handleDelete,
 	handleDuplicate,
 	handleSave,
+	backPath,
 } ) {
 	const menuTitle = navigationMenu?.title?.rendered;
 
@@ -32,6 +33,7 @@ export default function SingleNavigationMenu( {
 			description={ __(
 				'Navigation menus are a curated collection of blocks that allow visitors to get around your site.'
 			) }
+			backPath={ backPath }
 		>
 			<NavigationMenuEditor navigationMenuId={ navigationMenu?.id } />
 		</SidebarNavigationScreenWrapper>

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/index.js
@@ -84,7 +84,7 @@ export default function SidebarNavigationScreenNavigationMenus() {
 	// more than one menu.
 	useEffect( () => {
 		if ( navigationMenus?.length === 1 ) {
-			history.push( {
+			history.replace( {
 				postId: navigationMenus[ 0 ].id,
 				postType: 'wp_navigation',
 			} );

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/navigator-button.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/navigator-button.js
@@ -1,0 +1,40 @@
+/**
+ * WordPress dependencies
+ */
+
+import { __experimentalNavigatorButton as NavigatorButton } from '@wordpress/components';
+import { useEntityRecords } from '@wordpress/core-data';
+
+/**
+ * Internal dependencies
+ */
+import { PRELOADED_NAVIGATION_MENUS_QUERY } from './constants';
+import SidebarNavigationItem from '../sidebar-navigation-item';
+import { useLink } from '../routes/link';
+
+export default function SidebarNavigationScreenNavigationMenuButton( props ) {
+	const { records: navigationMenus } = useEntityRecords(
+		'postType',
+		`wp_navigation`,
+		PRELOADED_NAVIGATION_MENUS_QUERY
+	);
+
+	const hasSingleNavigationMenu = navigationMenus?.length === 1;
+	const firstNavigationMenu = navigationMenus?.[ 0 ];
+
+	const linkInfo = useLink( {
+		postId: firstNavigationMenu?.id,
+		postType: 'wp_navigation',
+	} );
+
+	// If there is a single Navigation then link directly to it.
+	if ( hasSingleNavigationMenu ) {
+		return <SidebarNavigationItem { ...linkInfo } { ...props } />;
+	}
+
+	return (
+		<NavigatorButton { ...props } path="/navigation">
+			{ props.children }
+		</NavigatorButton>
+	);
+}


### PR DESCRIPTION
## What?
<!-- In a few words, what is the PR actually doing? -->

Ensures focus mode is entered for a Navigation menu if it's edited on the listing screen of Browse Mode. Fixes issue introduced by https://github.com/WordPress/gutenberg/pull/51565.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

In https://github.com/WordPress/gutenberg/pull/51565 we made it so that if you go to `Navigation` and there is only a single menu then it just renders that directly on that route. This works well, except that you no longer enter focus mode on that menu.

That's a bug because on the actual single route you always enter focus mode.

This is because the focus mode relies on the edited post being set in state. With multiple menus this is achieved when you browse to a single menu as the params in the URL are synced to state by a special component and `setNavigationMenu` is called with the post ID from the params.

However when there is a single menu the state update never happens as the menu's postID is not in the URL which remains as `/navigation`.

Therefore we must redirect to the route for a single menu.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

If there is a single Navigation Menu then:

- if you navigate directly to `/navigation` then we redirect to the route for the single menu.
- if you click on `Navigation` in the root of Browse Mode then you go directly to the route for the single menu.
- if you click "back" from a single menu route then you go back to the root (too many "roooooots" 😄 ).



## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

- Have a single Navigation menu
- Open Site Editor and click `Navigation`
- See that you are on a single menu page and the URL is the route for a single menu.
- See that you enter focus mode.
- Go back. Check you are on the root of Browse Mode (not attempt to go to Navigation _listing_!)
- Click `Navigation` and then duplicate your menu.
- Now check you can get to the listing screen.


### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
