### PR TITLE
Force full height for editor in Navigation focus mode

### DIFF
--- a/packages/edit-site/src/components/block-editor/site-editor-canvas.js
+++ b/packages/edit-site/src/components/block-editor/site-editor-canvas.js
@@ -96,6 +96,8 @@ export default function SiteEditorCanvas() {
 			? false
 			: undefined;
 
+	const forceFullHeight = isNavigationFocusMode;
+
 	return (
 		<>
 			<EditorCanvasContainer.Slot>
@@ -123,7 +125,11 @@ export default function SiteEditorCanvas() {
 							<BackButton />
 							<ResizableEditor
 								enableResizing={ enableResizing }
-								height={ sizes.height ?? '100%' }
+								height={
+									sizes.height && ! forceFullHeight
+										? sizes.height
+										: '100%'
+								}
 							>
 								<EditorCanvas
 									enableResizing={ enableResizing }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Makes Navigation focus mode use full height editor

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

When editing Navigations with submenus the dropdowns would be clipped by the height of the focus mode which was previously set to be the height of the block itself.

We need to allow full editing and there is no real downside to allowing this.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Adds a condition to force full height for Navigation Focus mode.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

- Go to focus mode for Navigation menu containing submenus.
- Check it's full height.
- Check that constrained height still works for Template Parts.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
<img width="755" alt="Screen Shot 2023-06-22 at 12 58 15" src="https://github.com/WordPress/gutenberg/assets/444434/bc90d692-bf23-495c-8ba8-ec8b2ccde743">
