### PR TITLE
Edit Site: Improve loading spinner colors 

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -7,6 +7,7 @@
 -   `UnitControl`: Revamp support for changing unit by typing ([#39303](https://github.com/WordPress/gutenberg/pull/39303)).
 -   `Modal`: Update corner radius to be between buttons and the site view frame, in a 2-4-8 system. ([#51254](https://github.com/WordPress/gutenberg/pull/51254)).
 -   `ItemGroup`: Update button focus state styles to be inline with other button focus states in the editor. ([#51576](https://github.com/WordPress/gutenberg/pull/51576)).
+-   `Spinner`: Introduce `trackStyles` prop. ([#51800](https://github.com/WordPress/gutenberg/pull/51800)).
 
 ### Bug Fix
 

--- a/packages/components/src/spinner/index.tsx
+++ b/packages/components/src/spinner/index.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import classNames from 'classnames';
-import type { ForwardedRef } from 'react';
+import type { CSSProperties, ForwardedRef } from 'react';
 
 /**
  * Internal dependencies
@@ -16,7 +16,11 @@ import type { WordPressComponentProps } from '../ui/context';
 import { forwardRef } from '@wordpress/element';
 
 export function UnforwardedSpinner(
-	{ className, ...props }: WordPressComponentProps< {}, 'svg', false >,
+	{
+		className,
+		trackStyles,
+		...props
+	}: WordPressComponentProps< { trackStyles?: CSSProperties }, 'svg', false >,
 	forwardedRef: ForwardedRef< any >
 ) {
 	return (
@@ -37,6 +41,7 @@ export function UnforwardedSpinner(
 				cy="50"
 				r="50"
 				vectorEffect="non-scaling-stroke"
+				style={ trackStyles }
 			/>
 
 			{ /* Theme-colored arc */ }

--- a/packages/edit-site/src/components/canvas-spinner/index.js
+++ b/packages/edit-site/src/components/canvas-spinner/index.js
@@ -1,4 +1,12 @@
 /**
+ * External dependencies
+ */
+import { colord, extend } from 'colord';
+import mixPlugin from 'colord/plugins/mix';
+
+extend( [ mixPlugin ] );
+
+/**
  * WordPress dependencies
  */
 import { Spinner } from '@wordpress/components';
@@ -8,15 +16,26 @@ import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
  * Internal dependencies
  */
 import { unlock } from '../../lock-unlock';
+import { useStylesPreviewColors } from '../global-styles/hooks';
 
 const { useGlobalStyle } = unlock( blockEditorPrivateApis );
 
 export default function CanvasSpinner() {
 	const [ textColor ] = useGlobalStyle( 'color.text' );
+	const { highlightedColors } = useStylesPreviewColors();
+
+	const trackColor = highlightedColors[ 0 ]?.color ?? textColor;
+	const trackColord = colord( trackColor );
+	const indicatorColor = trackColord.isDark()
+		? trackColord.tints( 3 )[ 1 ].toHex()
+		: trackColord.shades( 3 )[ 1 ].toHex();
 
 	return (
 		<div className="edit-site-canvas-spinner">
-			<Spinner style={ { color: textColor } } />
+			<Spinner
+				style={ { color: trackColor } }
+				trackStyles={ { stroke: indicatorColor } }
+			/>
 		</div>
 	);
 }

--- a/packages/edit-site/src/components/global-styles/hooks.js
+++ b/packages/edit-site/src/components/global-styles/hooks.js
@@ -16,7 +16,7 @@ import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
 import { unlock } from '../../lock-unlock';
 import { useSelect } from '@wordpress/data';
 
-const { useGlobalSetting } = unlock( blockEditorPrivateApis );
+const { useGlobalSetting, useGlobalStyle } = unlock( blockEditorPrivateApis );
 
 // Enable colord's a11y plugin.
 extend( [ a11yPlugin ] );
@@ -50,6 +50,32 @@ export function useColorRandomizer( name ) {
 	return window.__experimentalEnableColorRandomizer
 		? [ randomizeColors ]
 		: [];
+}
+
+export function useStylesPreviewColors() {
+	const [ textColor = 'black' ] = useGlobalStyle( 'color.text' );
+	const [ backgroundColor = 'white' ] = useGlobalStyle( 'color.background' );
+	const [ headingColor = textColor ] = useGlobalStyle(
+		'elements.h1.color.text'
+	);
+	const [ coreColors ] = useGlobalSetting( 'color.palette.core' );
+	const [ themeColors ] = useGlobalSetting( 'color.palette.theme' );
+	const [ customColors ] = useGlobalSetting( 'color.palette.custom' );
+
+	const paletteColors = ( themeColors ?? [] )
+		.concat( customColors ?? [] )
+		.concat( coreColors ?? [] );
+	const highlightedColors = paletteColors
+		.filter(
+			// we exclude these two colors because they are already visible in the preview.
+			( { color } ) => color !== backgroundColor && color !== headingColor
+		)
+		.slice( 0, 2 );
+
+	return {
+		paletteColors,
+		highlightedColors,
+	};
 }
 
 export function useSupportedStyles( name, element ) {

--- a/packages/edit-site/src/components/global-styles/preview.js
+++ b/packages/edit-site/src/components/global-styles/preview.js
@@ -18,8 +18,9 @@ import { useState, useMemo } from '@wordpress/element';
  * Internal dependencies
  */
 import { unlock } from '../../lock-unlock';
+import { useStylesPreviewColors } from './hooks';
 
-const { useGlobalSetting, useGlobalStyle, useGlobalStylesOutput } = unlock(
+const { useGlobalStyle, useGlobalStylesOutput } = unlock(
 	blockEditorPrivateApis
 );
 
@@ -76,22 +77,10 @@ const StylesPreview = ( { label, isFocused, withHoverView } ) => {
 	const [ gradientValue ] = useGlobalStyle( 'color.gradient' );
 	const [ styles ] = useGlobalStylesOutput();
 	const disableMotion = useReducedMotion();
-	const [ coreColors ] = useGlobalSetting( 'color.palette.core' );
-	const [ themeColors ] = useGlobalSetting( 'color.palette.theme' );
-	const [ customColors ] = useGlobalSetting( 'color.palette.custom' );
 	const [ isHovered, setIsHovered ] = useState( false );
 	const [ containerResizeListener, { width } ] = useResizeObserver();
 	const ratio = width ? width / normalizedWidth : 1;
-
-	const paletteColors = ( themeColors ?? [] )
-		.concat( customColors ?? [] )
-		.concat( coreColors ?? [] );
-	const highlightedColors = paletteColors
-		.filter(
-			// we exclude these two colors because they are already visible in the preview.
-			( { color } ) => color !== backgroundColor && color !== headingColor
-		)
-		.slice( 0, 2 );
+	const { paletteColors, highlightedColors } = useStylesPreviewColors();
 
 	// Reset leaked styles from WP common.css and remove main content layout padding and border.
 	const editorStyles = useMemo( () => {


### PR DESCRIPTION
## What?
This PR improves how we handle the colors of the site editor loading spinner. In #51709 we already improved the loading background to work with the current background (gradients supported too), and to make things more natural, we started using the text color for the spinner indicator color, Here, we're improving the spinner colors, both of the indicator and the track. 

## Why?
This makes it a more natural experience as the site loading finishes and the editor canvas is presented.

## How?
Previously, we were using the text color for the spinner indicator color, but now, we're getting more clever and using:

* Indicator color: The first highlighted color that's not the background or heading color. That matches the first color from the styles preview of that style. 
* Track color: A tint/shade version of the indicator color, which should work well enough in most contexts.

We're updating the Spinner component to support an additional prop for track styles.

We're also extracting the logic for the highlighted style preview colors to a hook so we can reuse it.

## Testing Instructions
* Open the site editor.
* Observe the loading spinner and verify it works well in your theme's context.
* Try the above steps with various style variations. 

### Testing Instructions for Keyboard
None.

## Screenshots or screencast <!-- if applicable -->
Here are spinner previews with all default style variations of the `twentytwentythree` theme:

https://github.com/WordPress/gutenberg/assets/8436925/f2a5dbf9-3e7a-43dc-be36-1a475d2af2b9


https://github.com/WordPress/gutenberg/assets/8436925/2ffa8406-2151-41ca-aedb-ea297f079393


https://github.com/WordPress/gutenberg/assets/8436925/449e2450-6408-4b70-ad2c-e6565776d753


https://github.com/WordPress/gutenberg/assets/8436925/73820d3b-5b1c-4f83-a013-6e972f58f8ca


https://github.com/WordPress/gutenberg/assets/8436925/7dbc4d69-14b6-4ddb-aa4f-97507f31b99a


https://github.com/WordPress/gutenberg/assets/8436925/5a283130-a102-4083-8a69-a93d30d3c026


https://github.com/WordPress/gutenberg/assets/8436925/03447738-0ac1-4ed6-8b96-b524f25d3500


https://github.com/WordPress/gutenberg/assets/8436925/0bb552e4-b05f-44df-9c5f-6743cb7c6fce


https://github.com/WordPress/gutenberg/assets/8436925/6e708b94-0c2d-4a4c-94a8-0287bf1af38d


https://github.com/WordPress/gutenberg/assets/8436925/c8625abb-3bc3-48ea-b4e5-2312daa373f8


https://github.com/WordPress/gutenberg/assets/8436925/e9fde5ed-df31-458b-b7ec-2ae5151417aa


https://github.com/WordPress/gutenberg/assets/8436925/9d4f8161-93ef-4c36-a28a-d6bd83ce6621

