### PR TITLE
Update the add template modal design

### DIFF
--- a/packages/edit-site/src/components/add-new-template/new-template.js
+++ b/packages/edit-site/src/components/add-new-template/new-template.js
@@ -16,7 +16,7 @@ import {
 } from '@wordpress/components';
 import { decodeEntities } from '@wordpress/html-entities';
 import { useState } from '@wordpress/element';
-import { useDispatch } from '@wordpress/data';
+import { useSelect, useDispatch } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 import {
 	archive,
@@ -140,6 +140,26 @@ export default function NewTemplate( {
 	const { createErrorNotice, createSuccessNotice } =
 		useDispatch( noticesStore );
 	const { setTemplate } = unlock( useDispatch( editSiteStore ) );
+
+	const { homeUrl } = useSelect( ( select ) => {
+		const {
+			getUnstableBase, // Site index.
+		} = select( coreStore );
+
+		return {
+			homeUrl: getUnstableBase()?.home,
+		};
+	}, [] );
+
+	const TEMPLATE_SHORT_DESCRIPTIONS = {
+		'front-page': homeUrl,
+		date: sprintf(
+			// translators: %s: The homepage url.
+			__( 'E.g. %s/2023/' ),
+			homeUrl
+		),
+	};
+
 	async function createTemplate( template, isWPSuggestion = true ) {
 		if ( isCreatingTemplate ) {
 			return;
@@ -257,13 +277,14 @@ export default function NewTemplate( {
 							className="edit-site-add-new-template__template-list__contents"
 						>
 							{ missingTemplates.map( ( template ) => {
-								const { title, description, slug, onClick } =
-									template;
+								const { title, slug, onClick } = template;
 								return (
 									<TemplateListItem
 										key={ slug }
 										title={ title }
-										description={ description }
+										description={
+											TEMPLATE_SHORT_DESCRIPTIONS[ slug ]
+										}
 										icon={ TEMPLATE_ICONS[ slug ] || post }
 										onClick={ () =>
 											onClick

--- a/packages/edit-site/src/components/add-new-template/new-template.js
+++ b/packages/edit-site/src/components/add-new-template/new-template.js
@@ -17,7 +17,7 @@ import {
 } from '@wordpress/components';
 import { decodeEntities } from '@wordpress/html-entities';
 import { useState } from '@wordpress/element';
-import { useSelect, useDispatch } from '@wordpress/data';
+import { useDispatch } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 import {
 	archive,
@@ -162,25 +162,6 @@ export default function NewTemplate( {
 		useDispatch( noticesStore );
 	const { setTemplate } = unlock( useDispatch( editSiteStore ) );
 
-	const { homeUrl } = useSelect( ( select ) => {
-		const {
-			getUnstableBase, // Site index.
-		} = select( coreStore );
-
-		return {
-			homeUrl: getUnstableBase()?.home,
-		};
-	}, [] );
-
-	const TEMPLATE_SHORT_DESCRIPTIONS = {
-		'front-page': homeUrl,
-		date: sprintf(
-			// translators: %s: The homepage url.
-			__( 'E.g. %s' ),
-			homeUrl + '/' + new Date().getFullYear()
-		),
-	};
-
 	async function createTemplate( template, isWPSuggestion = true ) {
 		if ( isCreatingTemplate ) {
 			return;
@@ -310,9 +291,6 @@ export default function NewTemplate( {
 										title={ title }
 										direction="column"
 										className="edit-site-add-new-template__template-button"
-										description={
-											TEMPLATE_SHORT_DESCRIPTIONS[ slug ]
-										}
 										icon={
 											TEMPLATE_ICONS[ slug ] || layout
 										}

--- a/packages/edit-site/src/components/add-new-template/new-template.js
+++ b/packages/edit-site/src/components/add-new-template/new-template.js
@@ -98,17 +98,16 @@ function TemplateListItem( {
 	direction,
 	className,
 	description,
-	hideDescription = true,
 	icon,
 	onClick,
-	showTooltip = true,
+	children,
 } ) {
 	return (
 		<Button
 			className={ className }
 			onClick={ onClick }
 			label={ description }
-			showTooltip={ showTooltip }
+			showTooltip={ !! description }
 		>
 			<Flex
 				as="span"
@@ -132,13 +131,7 @@ function TemplateListItem( {
 					>
 						{ title }
 					</Text>
-					{ description && ! hideDescription && (
-						<Text
-							lineHeight={ 1.53846153846 } // 20px
-						>
-							{ description }
-						</Text>
-					) }
+					{ children }
 				</VStack>
 			</Flex>
 		</Button>
@@ -335,18 +328,21 @@ export default function NewTemplate( {
 								title={ __( 'Custom template' ) }
 								direction="row"
 								className="edit-site-add-new-template__custom-template-button"
-								description={ __(
-									'A custom template can be manually applied to any post or page.'
-								) }
-								hideDescription={ false }
-								showTooltip={ false }
 								icon={ edit }
 								onClick={ () =>
 									setModalContent(
 										modalContentMap.customGenericTemplate
 									)
 								}
-							/>
+							>
+								<Text
+									lineHeight={ 1.53846153846 } // 20px
+								>
+									{ __(
+										'A custom template can be manually applied to any post or page.'
+									) }
+								</Text>
+							</TemplateListItem>
 						</Grid>
 					) }
 					{ modalContent === modalContentMap.customTemplate && (

--- a/packages/edit-site/src/components/add-new-template/new-template.js
+++ b/packages/edit-site/src/components/add-new-template/new-template.js
@@ -101,19 +101,21 @@ function TemplateListItem( { title, className, description, icon, onClick } ) {
 				style={ { width: '100%' } }
 			>
 				<Icon icon={ icon } />
-				<Text
-					weight={ 500 }
-					lineHeight={ 1.53846153846 } // 20px
-				>
-					{ title }
-				</Text>
-				{ description && (
+				<VStack alignment="center" spacing={ 0 }>
 					<Text
+						weight={ 500 }
 						lineHeight={ 1.53846153846 } // 20px
 					>
-						{ description }
+						{ title }
 					</Text>
-				) }
+					{ description && (
+						<Text
+							lineHeight={ 1.53846153846 } // 20px
+						>
+							{ description }
+						</Text>
+					) }
+				</VStack>
 			</VStack>
 		</Button>
 	);

--- a/packages/edit-site/src/components/add-new-template/new-template.js
+++ b/packages/edit-site/src/components/add-new-template/new-template.js
@@ -100,7 +100,9 @@ function TemplateListItem( { title, className, description, icon, onClick } ) {
 				alignment="center"
 				style={ { width: '100%' } }
 			>
-				<Icon icon={ icon } />
+				<div className="edit-site-add-new-template__template-icon">
+					<Icon icon={ icon } />
+				</div>
 				<VStack alignment="center" spacing={ 0 }>
 					<Text
 						weight={ 500 }
@@ -286,6 +288,7 @@ export default function NewTemplate( {
 									<TemplateListItem
 										key={ slug }
 										title={ title }
+										className="edit-site-add-new-template__template-button"
 										description={
 											TEMPLATE_SHORT_DESCRIPTIONS[ slug ]
 										}

--- a/packages/edit-site/src/components/add-new-template/new-template.js
+++ b/packages/edit-site/src/components/add-new-template/new-template.js
@@ -176,8 +176,8 @@ export default function NewTemplate( {
 		'front-page': homeUrl,
 		date: sprintf(
 			// translators: %s: The homepage url.
-			__( 'E.g. %s/2023/' ),
-			homeUrl
+			__( 'E.g. %s' ),
+			homeUrl + '/' + new Date().getFullYear()
 		),
 	};
 

--- a/packages/edit-site/src/components/add-new-template/new-template.js
+++ b/packages/edit-site/src/components/add-new-template/new-template.js
@@ -22,7 +22,10 @@ import { store as coreStore } from '@wordpress/core-data';
 import {
 	archive,
 	blockMeta,
+	calendar,
 	category,
+	commentAuthorAvatar,
+	edit,
 	home,
 	layout,
 	list,
@@ -30,9 +33,7 @@ import {
 	notFound,
 	page,
 	plus,
-	post,
-	postAuthor,
-	postDate,
+	pin,
 	postList,
 	search,
 	tag,
@@ -78,16 +79,16 @@ const DEFAULT_TEMPLATE_SLUGS = [
 const TEMPLATE_ICONS = {
 	'front-page': home,
 	home: postList,
-	single: post,
+	single: pin,
 	page,
 	archive,
 	search,
 	404: notFound,
 	index: list,
 	category,
-	author: postAuthor,
+	author: commentAuthorAvatar,
 	taxonomy: blockMeta,
-	date: postDate,
+	date: calendar,
 	tag,
 	attachment: media,
 };
@@ -312,7 +313,9 @@ export default function NewTemplate( {
 										description={
 											TEMPLATE_SHORT_DESCRIPTIONS[ slug ]
 										}
-										icon={ TEMPLATE_ICONS[ slug ] || post }
+										icon={
+											TEMPLATE_ICONS[ slug ] || layout
+										}
 										onClick={ () =>
 											onClick
 												? onClick( template )
@@ -328,7 +331,7 @@ export default function NewTemplate( {
 								description={ __(
 									'A custom template can be manually applied to any post or page.'
 								) }
-								icon={ layout }
+								icon={ edit }
 								onClick={ () =>
 									setModalContent(
 										modalContentMap.customGenericTemplate

--- a/packages/edit-site/src/components/add-new-template/new-template.js
+++ b/packages/edit-site/src/components/add-new-template/new-template.js
@@ -12,12 +12,30 @@ import {
 	__experimentalGrid as Grid,
 	__experimentalText as Text,
 	__experimentalVStack as VStack,
+	Icon,
 } from '@wordpress/components';
 import { decodeEntities } from '@wordpress/html-entities';
 import { useState } from '@wordpress/element';
 import { useDispatch } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
-import { plus } from '@wordpress/icons';
+import {
+	archive,
+	blockMeta,
+	category,
+	home,
+	layout,
+	list,
+	media,
+	notFound,
+	page,
+	plus,
+	post,
+	postAuthor,
+	postDate,
+	postList,
+	search,
+	tag,
+} from '@wordpress/icons';
 import { __, sprintf } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { privateApis as routerPrivateApis } from '@wordpress/router';
@@ -56,7 +74,24 @@ const DEFAULT_TEMPLATE_SLUGS = [
 	'404',
 ];
 
-function TemplateListItem( { title, description, onClick } ) {
+const TEMPLATE_ICONS = {
+	'front-page': home,
+	home: postList,
+	single: post,
+	page,
+	archive,
+	search,
+	404: notFound,
+	index: list,
+	category,
+	author: postAuthor,
+	taxonomy: blockMeta,
+	date: postDate,
+	tag,
+	attachment: media,
+};
+
+function TemplateListItem( { title, description, icon, onClick } ) {
 	return (
 		<Button onClick={ onClick }>
 			<VStack
@@ -65,6 +100,7 @@ function TemplateListItem( { title, description, onClick } ) {
 				justify="flex-start"
 				style={ { width: '100%' } }
 			>
+				<Icon icon={ icon } />
 				<Text
 					weight={ 500 }
 					lineHeight={ 1.53846153846 } // 20px
@@ -228,6 +264,7 @@ export default function NewTemplate( {
 										key={ slug }
 										title={ title }
 										description={ description }
+										icon={ TEMPLATE_ICONS[ slug ] || post }
 										onClick={ () =>
 											onClick
 												? onClick( template )
@@ -241,6 +278,7 @@ export default function NewTemplate( {
 								description={ __(
 									'A custom template can be manually applied to any post or page.'
 								) }
+								icon={ layout }
 								onClick={ () =>
 									setModalContent(
 										modalContentMap.customGenericTemplate

--- a/packages/edit-site/src/components/add-new-template/new-template.js
+++ b/packages/edit-site/src/components/add-new-template/new-template.js
@@ -97,7 +97,7 @@ function TemplateListItem( { title, description, icon, onClick } ) {
 			<VStack
 				as="span"
 				spacing={ 2 }
-				justify="flex-start"
+				alignment="center"
 				style={ { width: '100%' } }
 			>
 				<Icon icon={ icon } />

--- a/packages/edit-site/src/components/add-new-template/new-template.js
+++ b/packages/edit-site/src/components/add-new-template/new-template.js
@@ -91,9 +91,9 @@ const TEMPLATE_ICONS = {
 	attachment: media,
 };
 
-function TemplateListItem( { title, description, icon, onClick } ) {
+function TemplateListItem( { title, className, description, icon, onClick } ) {
 	return (
-		<Button onClick={ onClick }>
+		<Button className={ className } onClick={ onClick }>
 			<VStack
 				as="span"
 				spacing={ 2 }
@@ -296,6 +296,7 @@ export default function NewTemplate( {
 							} ) }
 							<TemplateListItem
 								title={ __( 'Custom template' ) }
+								className="edit-site-add-new-template__custom-template-button"
 								description={ __(
 									'A custom template can be manually applied to any post or page.'
 								) }

--- a/packages/edit-site/src/components/add-new-template/new-template.js
+++ b/packages/edit-site/src/components/add-new-template/new-template.js
@@ -12,6 +12,7 @@ import {
 	__experimentalGrid as Grid,
 	__experimentalText as Text,
 	__experimentalVStack as VStack,
+	Flex,
 	Icon,
 } from '@wordpress/components';
 import { decodeEntities } from '@wordpress/html-entities';
@@ -91,19 +92,32 @@ const TEMPLATE_ICONS = {
 	attachment: media,
 };
 
-function TemplateListItem( { title, className, description, icon, onClick } ) {
+function TemplateListItem( {
+	title,
+	direction,
+	className,
+	description,
+	icon,
+	onClick,
+} ) {
 	return (
 		<Button className={ className } onClick={ onClick }>
-			<VStack
+			<Flex
 				as="span"
 				spacing={ 2 }
-				alignment="center"
+				align="center"
+				justify="center"
 				style={ { width: '100%' } }
+				direction={ direction }
 			>
 				<div className="edit-site-add-new-template__template-icon">
 					<Icon icon={ icon } />
 				</div>
-				<VStack alignment="center" spacing={ 0 }>
+				<VStack
+					className="edit-site-add-new-template__template-name"
+					alignment="center"
+					spacing={ 0 }
+				>
 					<Text
 						weight={ 500 }
 						lineHeight={ 1.53846153846 } // 20px
@@ -118,7 +132,7 @@ function TemplateListItem( { title, className, description, icon, onClick } ) {
 						</Text>
 					) }
 				</VStack>
-			</VStack>
+			</Flex>
 		</Button>
 	);
 }
@@ -288,6 +302,7 @@ export default function NewTemplate( {
 									<TemplateListItem
 										key={ slug }
 										title={ title }
+										direction="column"
 										className="edit-site-add-new-template__template-button"
 										description={
 											TEMPLATE_SHORT_DESCRIPTIONS[ slug ]
@@ -303,6 +318,7 @@ export default function NewTemplate( {
 							} ) }
 							<TemplateListItem
 								title={ __( 'Custom template' ) }
+								direction="row"
 								className="edit-site-add-new-template__custom-template-button"
 								description={ __(
 									'A custom template can be manually applied to any post or page.'

--- a/packages/edit-site/src/components/add-new-template/new-template.js
+++ b/packages/edit-site/src/components/add-new-template/new-template.js
@@ -17,7 +17,7 @@ import {
 } from '@wordpress/components';
 import { decodeEntities } from '@wordpress/html-entities';
 import { useState } from '@wordpress/element';
-import { useDispatch } from '@wordpress/data';
+import { useSelect, useDispatch } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 import {
 	archive,
@@ -162,6 +162,25 @@ export default function NewTemplate( {
 		useDispatch( noticesStore );
 	const { setTemplate } = unlock( useDispatch( editSiteStore ) );
 
+	const { homeUrl } = useSelect( ( select ) => {
+		const {
+			getUnstableBase, // Site index.
+		} = select( coreStore );
+
+		return {
+			homeUrl: getUnstableBase()?.home,
+		};
+	}, [] );
+
+	const TEMPLATE_SHORT_DESCRIPTIONS = {
+		'front-page': homeUrl,
+		date: sprintf(
+			// translators: %s: The homepage url.
+			__( 'E.g. %s' ),
+			homeUrl + '/' + new Date().getFullYear()
+		),
+	};
+
 	async function createTemplate( template, isWPSuggestion = true ) {
 		if ( isCreatingTemplate ) {
 			return;
@@ -291,6 +310,9 @@ export default function NewTemplate( {
 										title={ title }
 										direction="column"
 										className="edit-site-add-new-template__template-button"
+										description={
+											TEMPLATE_SHORT_DESCRIPTIONS[ slug ]
+										}
 										icon={
 											TEMPLATE_ICONS[ slug ] || layout
 										}

--- a/packages/edit-site/src/components/add-new-template/new-template.js
+++ b/packages/edit-site/src/components/add-new-template/new-template.js
@@ -98,11 +98,18 @@ function TemplateListItem( {
 	direction,
 	className,
 	description,
+	hideDescription = true,
 	icon,
 	onClick,
+	showTooltip = true,
 } ) {
 	return (
-		<Button className={ className } onClick={ onClick }>
+		<Button
+			className={ className }
+			onClick={ onClick }
+			label={ description }
+			showTooltip={ showTooltip }
+		>
 			<Flex
 				as="span"
 				spacing={ 2 }
@@ -125,7 +132,7 @@ function TemplateListItem( {
 					>
 						{ title }
 					</Text>
-					{ description && (
+					{ description && ! hideDescription && (
 						<Text
 							lineHeight={ 1.53846153846 } // 20px
 						>
@@ -331,6 +338,8 @@ export default function NewTemplate( {
 								description={ __(
 									'A custom template can be manually applied to any post or page.'
 								) }
+								hideDescription={ false }
+								showTooltip={ false }
 								icon={ edit }
 								onClick={ () =>
 									setModalContent(

--- a/packages/edit-site/src/components/add-new-template/new-template.js
+++ b/packages/edit-site/src/components/add-new-template/new-template.js
@@ -107,11 +107,13 @@ function TemplateListItem( { title, className, description, icon, onClick } ) {
 				>
 					{ title }
 				</Text>
-				<Text
-					lineHeight={ 1.53846153846 } // 20px
-				>
-					{ description }
-				</Text>
+				{ description && (
+					<Text
+						lineHeight={ 1.53846153846 } // 20px
+					>
+						{ description }
+					</Text>
+				) }
 			</VStack>
 		</Button>
 	);

--- a/packages/edit-site/src/components/add-new-template/new-template.js
+++ b/packages/edit-site/src/components/add-new-template/new-template.js
@@ -296,6 +296,11 @@ export default function NewTemplate( {
 							justify="center"
 							className="edit-site-add-new-template__template-list__contents"
 						>
+							<Flex className="edit-site-add-new-template__template-list__prompt">
+								{ __(
+									'Select what the new template should apply to:'
+								) }
+							</Flex>
 							{ missingTemplates.map( ( template ) => {
 								const { title, slug, onClick } = template;
 								return (

--- a/packages/edit-site/src/components/add-new-template/style.scss
+++ b/packages/edit-site/src/components/add-new-template/style.scss
@@ -138,6 +138,21 @@
 	@include break-large() {
 		width: calc(100% - #{$grid-unit-80 * 2});
 	}
+
+	.edit-site-add-new-template__template-button,
+	.edit-site-add-new-template__custom-template-button {
+		svg {
+			fill: var(--wp-admin-theme-color);
+		}
+	}
+
+	.edit-site-add-new-template__template-icon {
+		padding: $grid-unit-10;
+		background: rgba(var(--wp-admin-theme-color--rgb), 0.04);
+		border-radius: 100%;
+		max-height: $grid-unit-50;
+		max-width: $grid-unit-50;
+	}
 }
 
 .edit-site-custom-template-modal__contents,

--- a/packages/edit-site/src/components/add-new-template/style.scss
+++ b/packages/edit-site/src/components/add-new-template/style.scss
@@ -206,7 +206,8 @@
 		}
 	}
 
-	.edit-site-add-new-template__custom-template-button {
+	.edit-site-add-new-template__custom-template-button,
+	.edit-site-add-new-template__template-list__prompt {
 		grid-column-start: 1;
 		grid-column-end: 4;
 	}

--- a/packages/edit-site/src/components/add-new-template/style.scss
+++ b/packages/edit-site/src/components/add-new-template/style.scss
@@ -149,6 +149,7 @@
 		flex-direction: column;
 		border: $border-width solid $gray-300;
 		min-height: $grid-unit-80 * 3;
+		justify-content: center;
 
 		// Show the boundary of the button, in High Contrast Mode.
 		outline: 1px solid transparent;

--- a/packages/edit-site/src/components/add-new-template/style.scss
+++ b/packages/edit-site/src/components/add-new-template/style.scss
@@ -148,7 +148,6 @@
 		display: flex;
 		flex-direction: column;
 		border: $border-width solid $gray-300;
-		min-height: $grid-unit-80 * 3;
 		justify-content: center;
 
 		// Show the boundary of the button, in High Contrast Mode.

--- a/packages/edit-site/src/components/add-new-template/style.scss
+++ b/packages/edit-site/src/components/add-new-template/style.scss
@@ -146,6 +146,13 @@
 		}
 	}
 
+	.edit-site-add-new-template__custom-template-button {
+		.edit-site-add-new-template__template-name {
+			flex-grow: 1;
+			align-items: flex-start;
+		}
+	}
+
 	.edit-site-add-new-template__template-icon {
 		padding: $grid-unit-10;
 		background: rgba(var(--wp-admin-theme-color--rgb), 0.04);

--- a/packages/edit-site/src/components/add-new-template/style.scss
+++ b/packages/edit-site/src/components/add-new-template/style.scss
@@ -165,7 +165,7 @@
 .edit-site-custom-template-modal__contents,
 .edit-site-add-new-template__template-list__contents {
 	> .components-button {
-		padding: $grid-unit-30;
+		padding: $grid-unit-40;
 		border-radius: $radius-block-ui;
 		display: flex;
 		flex-direction: column;

--- a/packages/edit-site/src/components/add-new-template/style.scss
+++ b/packages/edit-site/src/components/add-new-template/style.scss
@@ -184,6 +184,11 @@
 			}
 		}
 	}
+
+	.edit-site-add-new-template__custom-template-button {
+		grid-column-start: 1;
+		grid-column-end: 4;
+	}
 }
 
 .edit-site-add-new-template__template-list__contents {


### PR DESCRIPTION
## What?
Updates the design for the add template modal.

## Why?
The current design is a little bland, and feels rather verbose given the long descriptions that some templates have.

Furthermore, custom templates deserve increased prominence given their unique application.

## How?
Mostly style changes, and some updates to `TemplateListItem`.

## Testing Instructions
1. In the Site Editor open the Templates panel
2. Click the + button
3. Observe the new modal design

## Before
<img width="906" alt="Screenshot 2023-06-22 at 13 49 06" src="https://github.com/WordPress/gutenberg/assets/846565/341f40b9-feba-4dcd-9c43-3809407f8ae3">


## After
<img width="906" alt="Screenshot 2023-06-22 at 13 48 37" src="https://github.com/WordPress/gutenberg/assets/846565/6ab9c20e-d991-4885-bca6-57b81d7ce1f8">

The general design is a first-pass and feedback is very welcome.

## Caveat
By removing the descriptions, some templates become a little ambiguous. I don't know if the changes here need to be _blocked_, but if merged alongside https://github.com/WordPress/gutenberg/pull/51428 the experience would generally be improved quite a bit. 

Some templates like Date include a hint which is displayed in a tooltip. The tooltip however isn't currently visible due to https://github.com/WordPress/gutenberg/issues/47614.

I'm sure there are better ways to handle some of the logic, hopefully @ntsekouras or another engineer can provide some guidance :) 
