### PR TITLE
Fix toolbar overlap in site editor

### DIFF
--- a/packages/edit-site/src/components/layout/style.scss
+++ b/packages/edit-site/src/components/layout/style.scss
@@ -4,6 +4,16 @@
 	color: $white;
 	display: flex;
 	flex-direction: column;
+
+	// expand the fixed block toolbar to cover the document title control
+	.block-editor-block-contextual-toolbar {
+		@include break-medium() {
+			&.is-fixed {
+				// the combined with of the tools at the right of the header and the margin left
+				width: calc(100% - 240px - #{$grid-unit-80} - #{$grid-unit-70});
+			}
+		}
+	}
 }
 
 .edit-site-layout__hub {
@@ -241,20 +251,6 @@
 
 	@include break-medium {
 		border-left: $border-width solid $gray-300;
-	}
-}
-
-.edit-site-layout.has-fixed-toolbar {
-	// making the header be lower than the content
-	// so the fixed toolbar can be positioned on top of it
-	// but only on desktop
-	@include break-medium() {
-		.edit-site-site-hub {
-			z-index: 4;
-		}
-		.edit-site-layout__header:focus-within {
-			z-index: 3;
-		}
 	}
 }
 

--- a/packages/edit-site/src/components/layout/style.scss
+++ b/packages/edit-site/src/components/layout/style.scss
@@ -5,7 +5,7 @@
 	display: flex;
 	flex-direction: column;
 
-	// expand the fixed block toolbar to cover the document title control
+	// Expand the fixed block toolbar to cover the document title control.
 	.block-editor-block-contextual-toolbar {
 		@include break-medium() {
 			&.is-fixed {
@@ -14,6 +14,7 @@
 			}
 		}
 	}
+
 }
 
 .edit-site-layout__hub {
@@ -251,6 +252,20 @@
 
 	@include break-medium {
 		border-left: $border-width solid $gray-300;
+	}
+}
+
+.edit-site-layout.has-fixed-toolbar {
+	// making the header be lower than the content
+	// so the fixed toolbar can be positioned on top of it
+	// but only on desktop
+	@include break-medium() {
+		.edit-site-site-hub {
+			z-index: 4;
+		}
+		.edit-site-layout__header:focus-within {
+			z-index: 3;
+		}
 	}
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

The block toolbar in fixed move overlaps the document title control in the site editor.

<img width="1024" alt="Screenshot 2023-06-22 at 18 58 40" src="https://github.com/WordPress/gutenberg/assets/107534/d515608a-4f99-4153-9000-25e8190738b1">


## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Because it is implemented via absolute positioning.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

It expands the fixed block toolbar to completely cover the control.

## Testing Instructions

1. In the site editor
2. Activate from the dot menu in the top right corner the Top Toolbar option
3. Select blocks
4. Observe the document title control is no longer visible

## Screenshots or screencast <!-- if applicable -->


https://github.com/WordPress/gutenberg/assets/107534/d8b1af26-f290-4e78-82ad-127499cd1093


