### PR TITLE
Update delete page button label

### DIFF
--- a/packages/edit-site/src/components/page-actions/delete-page-menu-item.js
+++ b/packages/edit-site/src/components/page-actions/delete-page-menu-item.js
@@ -63,6 +63,7 @@ export default function DeletePageMenuItem( { postId, onRemove } ) {
 				isOpen={ isModalOpen }
 				onConfirm={ removePage }
 				onCancel={ () => setIsModalOpen( false ) }
+				confirmButtonText={ __( 'Delete' ) }
 			>
 				{ __( 'Are you sure you want to delete this page?' ) }
 			</ConfirmDialog>


### PR DESCRIPTION
## What?
When you delete a page in the Site Editor a `ConfirmationDialog` opens to confirm the action. The primary button reads "OK". This PR updates that to read "Delete".

## Why?
"Delete" feels more confirmatory of the original action, while "OK" is a little ambiguous. 

## Testing Instructions
1. Delete a page in the site editor.
2. Notice the confirmation modal primary button reads "Delete".

## Before
<img width="420" alt="Screenshot 2023-06-22 at 17 00 34" src="https://github.com/WordPress/gutenberg/assets/846565/e97a812d-d919-4142-84b0-355236da7603">

## After
<img width="393" alt="Screenshot 2023-06-22 at 16 57 00" src="https://github.com/WordPress/gutenberg/assets/846565/dd39966a-400a-4f90-97ec-6653c8e6e2f0">
