### PR TITLE
Refactor use-tab-nav shift+tab to use existing utils

### DIFF
--- a/packages/block-editor/src/components/writing-flow/use-tab-nav.js
+++ b/packages/block-editor/src/components/writing-flow/use-tab-nav.js
@@ -11,6 +11,7 @@ import { useRef } from '@wordpress/element';
  * Internal dependencies
  */
 import { store as blockEditorStore } from '../../store';
+import { isInSameBlock, isInsideRootBlock } from '../../utils/dom';
 
 export default function useTabNav() {
 	const container = useRef();
@@ -116,41 +117,23 @@ export default function useTabNav() {
 				return;
 			}
 
+			const nextTabbable = focus.tabbable[ direction ]( event.target );
+
 			// We want to constrain the tabbing to the block and its child blocks.
 			// If the preceding form element is within a different block,
 			// such as two sibling image blocks in the placeholder state,
 			// we want shift + tab from the first form element to move to the image
 			// block toolbar and not the previous image block's form element.
-			// TODO: Should this become a utility function?
-			/**
-			 * Determine whether an element is part of or is the selected block.
-			 *
-			 * @param {Object} selectedBlockElement
-			 * @param {Object} element
-			 * @return {boolean} Whether the element is part of or is the selected block.
-			 */
-			const isElementPartOfSelectedBlock = (
-				selectedBlockElement,
-				element
-			) => {
-				// Check if the element is or is within the selected block by finding the
-				// closest element with a data-block attribute and seeing if
-				// it matches our current selected block ID
-				const elementBlockId = element
-					.closest( '[data-block]' )
-					?.getAttribute( 'data-block' );
-				const isElementSameBlock =
-					elementBlockId === getSelectedBlockClientId();
+			const isElementPartOfSelectedBlock =
+				isInSameBlock(
+					event.target.closest( '[data-block]' ),
+					nextTabbable
+				) ||
+				isInsideRootBlock(
+					event.target.closest( '[data-block]' ),
+					nextTabbable
+				);
 
-				// Check if the element is a child of the selected block. This could be a
-				// child block in a group or column block, etc.
-				const isElementChildOfBlock =
-					selectedBlockElement.contains( element );
-
-				return isElementSameBlock || isElementChildOfBlock;
-			};
-
-			const nextTabbable = focus.tabbable[ direction ]( event.target );
 			// Allow tabbing from the block wrapper to a form element,
 			// and between form elements rendered in a block and its child blocks,
 			// such as inside a placeholder. Form elements are generally
@@ -159,10 +142,7 @@ export default function useTabNav() {
 			// future they can be rendered in an iframe or shadow DOM.
 			if (
 				isFormElement( nextTabbable ) &&
-				isElementPartOfSelectedBlock(
-					event.target.closest( '[data-block]' ),
-					nextTabbable
-				)
+				isElementPartOfSelectedBlock
 			) {
 				return;
 			}

--- a/packages/block-editor/src/components/writing-flow/use-tab-nav.js
+++ b/packages/block-editor/src/components/writing-flow/use-tab-nav.js
@@ -124,15 +124,12 @@ export default function useTabNav() {
 			// such as two sibling image blocks in the placeholder state,
 			// we want shift + tab from the first form element to move to the image
 			// block toolbar and not the previous image block's form element.
+			const currentBlock = event.target.closest( '[data-block]' );
 			const isElementPartOfSelectedBlock =
-				isInSameBlock(
-					event.target.closest( '[data-block]' ),
-					nextTabbable
-				) ||
-				isInsideRootBlock(
-					event.target.closest( '[data-block]' ),
-					nextTabbable
-				);
+				currentBlock &&
+				nextTabbable &&
+				( isInSameBlock( currentBlock, nextTabbable ) ||
+					isInsideRootBlock( currentBlock, nextTabbable ) );
 
 			// Allow tabbing from the block wrapper to a form element,
 			// and between form elements rendered in a block and its child blocks,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
@alexstine mentioned in the review on https://github.com/WordPress/gutenberg/pull/51548#pullrequestreview-1484248783, that we could simplify the code for determining if we were inside a selected block. This PR refactors to use that code. No behaviors should be changed.

### How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Check if the element in the natural tab order of `tab` or `shift+tab` is going to a tabbable element 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

#### Test blocks with form elements
- In a post, add an image block in the placeholder state
- add another image block in the placeholder state
- In the second image block, place focus on the wrapping block element (if focus is on one of the form elements within the block, use the up arrow to move to the wrapping block)
- shift + tab should move you to the block toolbar 

#### Test Column/Group Block Tabbing (should be same as on trunk)
Test to preserve behavior from https://github.com/WordPress/gutenberg/pull/39085
- In a post, add a Columns block.
- Check that pressing Tab moves focus to the first control in the placeholder.
- Select an option from the placeholder, e.g. "Two columns; equal split".
- Focus should now be on the first column.
- Check that pressing Tab moves focus to the block inserter inside the first column.
- Add a Group block.
- Check that pressing Tab moves focus to the block inserter inside the Group block.

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/967608/8aa2e34c-ee14-4b70-845a-97941f12cd58

