### PR TITLE
Image block: Fix responsive sizing in lightbox

### DIFF
--- a/lib/block-supports/behaviors.php
+++ b/lib/block-supports/behaviors.php
@@ -141,7 +141,7 @@ function gutenberg_render_behaviors_support_lightbox( $block_content, $block ) {
 	$img = null;
 	preg_match( '/<img[^>]+>/', $body_content, $img );
 	$button       = '<div class="img-container">
-                             <button type="button" aria-haspopup="dialog" aria-label="' . esc_attr( $aria_label ) . '" data-wp-on--click="actions.core.image.showLightbox" data-wp-on--mouseover="actions.core.image.preloadLightboxImage"></button>'
+                             <button type="button" aria-haspopup="dialog" aria-label="' . esc_attr( $aria_label ) . '" data-wp-on--click="actions.core.image.showLightbox" data-wp-effect="effects.core.image.preloadLightboxImage"></button>'
 		. $img[0] .
 		'</div>';
 	$body_content = preg_replace( '/<img[^>]+>/', $button, $body_content );

--- a/lib/block-supports/behaviors.php
+++ b/lib/block-supports/behaviors.php
@@ -141,7 +141,7 @@ function gutenberg_render_behaviors_support_lightbox( $block_content, $block ) {
 	$img = null;
 	preg_match( '/<img[^>]+>/', $body_content, $img );
 	$button       = '<div class="img-container">
-                             <button type="button" aria-haspopup="dialog" aria-label="' . esc_attr( $aria_label ) . '" data-wp-on--click="actions.core.image.showLightbox" data-wp-effect="effects.core.image.preloadLightboxImage"></button>'
+                             <button type="button" aria-haspopup="dialog" aria-label="' . esc_attr( $aria_label ) . '" data-wp-on--click="actions.core.image.showLightbox" data-wp-on--mouseover="actions.core.image.preloadLightboxImage"></button>'
 		. $img[0] .
 		'</div>';
 	$body_content = preg_replace( '/<img[^>]+>/', $button, $body_content );

--- a/packages/block-library/src/image/style.scss
+++ b/packages/block-library/src/image/style.scss
@@ -231,6 +231,18 @@
 	}
 
 	&.fade {
+		.wp-block-image {
+			padding: 40px 0;
+
+			@media screen and (min-width: 480px) {
+				padding: 40px;
+			}
+
+			@media screen and (min-width: 1920px) {
+				padding: 40px 80px;
+			}
+		}
+
 		&.active {
 			visibility: visible;
 			animation: both turn-on-visibility 0.25s;

--- a/packages/block-library/src/image/style.scss
+++ b/packages/block-library/src/image/style.scss
@@ -187,8 +187,8 @@
 
 	.close-button {
 		position: absolute;
-		top: 12.5px;
-		right: 12.5px;
+		top: calc(env(safe-area-inset-top) + 12.5px);
+		right: calc(env(safe-area-inset-right) + 12.5px);
 		padding: 0;
 		cursor: pointer;
 		z-index: 5000000;

--- a/packages/block-library/src/image/view-interactivity.js
+++ b/packages/block-library/src/image/view-interactivity.js
@@ -133,16 +133,6 @@ store( {
 						}
 					}
 				},
-				preloadLightboxImage: ( { context } ) => {
-					if ( ! context.core.image.preloadInitialized ) {
-						context.core.image.preloadInitialized = true;
-						const imgDom = document.createElement( 'img' );
-						imgDom.setAttribute(
-							'src',
-							context.core.image.imageUploadedSrc
-						);
-					}
-				},
 			},
 		},
 	},
@@ -180,6 +170,18 @@ store( {
 								this.currentSrc;
 						} );
 					}
+				},
+				preloadLightboxImage: ( { context, ref } ) => {
+					ref.addEventListener( 'mouseover', () => {
+						if ( ! context.core.image.preloadInitialized ) {
+							context.core.image.preloadInitialized = true;
+							const imgDom = document.createElement( 'img' );
+							imgDom.setAttribute(
+								'src',
+								context.core.image.imageUploadedSrc
+							);
+						}
+					} );
 				},
 				initLightbox: async ( { context, ref } ) => {
 					context.core.image.figureRef =

--- a/packages/block-library/src/image/view-interactivity.js
+++ b/packages/block-library/src/image/view-interactivity.js
@@ -211,12 +211,12 @@ function setZoomStyles( imgDom, context, event ) {
 	// to calculate dimensions and positioning.
 
 	// As per the design, let's constrain the height with fixed padding
-	const containerOuterHeight = context.core.image.figureRef.clientHeight;
+	const containerOuterHeight = window.innerHeight;
 	const verticalPadding = 40;
 	const containerInnerHeight = containerOuterHeight - verticalPadding * 2;
 
 	// Let's set a variable horizontal padding based on the container width
-	const containerOuterWidth = context.core.image.figureRef.clientWidth;
+	const containerOuterWidth = window.innerWidth;
 	let horizontalPadding = 0;
 	if ( containerOuterWidth > 480 ) {
 		horizontalPadding = 40;

--- a/packages/block-library/src/image/view-interactivity.js
+++ b/packages/block-library/src/image/view-interactivity.js
@@ -206,48 +206,48 @@ function setZoomStyles( imgDom, context, event ) {
 	let targetWidth = context.core.image.targetWidth;
 	let targetHeight = context.core.image.targetHeight;
 
+	// Since the lightbox image has `position:absolute`, it
+	// ignores its parent's padding, so we need to set padding here
+	// to calculate dimensions and positioning.
+
+	// As per the design, let's constrain the height with fixed padding
+	const containerOuterHeight = context.core.image.figureRef.clientHeight;
 	const verticalPadding = 40;
+	const containerInnerHeight = containerOuterHeight - verticalPadding * 2;
 
-	// As per the design, let's allow the image to stretch
-	// to the full width of its containing figure, but for the height,
-	// constrain it with a fixed padding
-	const containerWidth = context.core.image.figureRef.clientWidth;
-
-	// The lightbox image has `positione:absolute` and
-	// ignores its parent's padding, so let's set the padding here,
-	// to be used when calculating the image width and positioning
+	// Let's set a variable horizontal padding based on the container width
+	const containerOuterWidth = context.core.image.figureRef.clientWidth;
 	let horizontalPadding = 0;
-	if ( containerWidth > 480 ) {
+	if ( containerOuterWidth > 480 ) {
 		horizontalPadding = 40;
-	} else if ( containerWidth > 1920 ) {
+	} else if ( containerOuterWidth > 1920 ) {
 		horizontalPadding = 80;
 	}
-
-	const containerHeight =
-		context.core.image.figureRef.clientHeight - verticalPadding * 2;
+	const containerInnerWidth = containerOuterWidth - horizontalPadding * 2;
 
 	// Check difference between the image and figure dimensions
 	const widthOverflow = Math.abs(
-		Math.min( containerWidth - targetWidth, 0 )
+		Math.min( containerInnerWidth - targetWidth, 0 )
 	);
 	const heightOverflow = Math.abs(
-		Math.min( containerHeight - targetHeight, 0 )
+		Math.min( containerInnerHeight - targetHeight, 0 )
 	);
 
-	// If image is larger than its container any dimension, resize along its largest axis.
-	// For vertically oriented devices, always maximize the width.
+	// If the image is larger than the container, let's resize
+	// it along the greater axis relative to the container
 	if ( widthOverflow > 0 || heightOverflow > 0 ) {
-		if (
-			widthOverflow >= heightOverflow ||
-			containerHeight >= containerWidth
-		) {
-			targetWidth = containerWidth - horizontalPadding * 2;
+		const containerInnerAspectRatio =
+			containerInnerWidth / containerInnerHeight;
+		const imageAspectRatio = targetWidth / targetHeight;
+
+		if ( imageAspectRatio > containerInnerAspectRatio ) {
+			targetWidth = containerInnerWidth;
 			targetHeight =
-				imgDom.naturalHeight * ( targetWidth / imgDom.naturalWidth );
+				( targetWidth * imgDom.naturalHeight ) / imgDom.naturalWidth;
 		} else {
-			targetHeight = containerHeight;
+			targetHeight = containerInnerHeight;
 			targetWidth =
-				imgDom.naturalWidth * ( targetHeight / imgDom.naturalHeight );
+				( targetHeight * imgDom.naturalWidth ) / imgDom.naturalHeight;
 		}
 	}
 
@@ -261,16 +261,16 @@ function setZoomStyles( imgDom, context, event ) {
 
 	// Get values used to center the image
 	let targetLeft = 0;
-	if ( targetWidth >= containerWidth ) {
+	if ( targetWidth >= containerInnerWidth ) {
 		targetLeft = horizontalPadding;
 	} else {
-		targetLeft = ( containerWidth - targetWidth ) / 2;
+		targetLeft = ( containerOuterWidth - targetWidth ) / 2;
 	}
 	let targetTop = 0;
-	if ( targetHeight >= containerHeight ) {
+	if ( targetHeight >= containerInnerHeight ) {
 		targetTop = verticalPadding;
 	} else {
-		targetTop = ( containerHeight - targetHeight ) / 2 + verticalPadding;
+		targetTop = ( containerOuterHeight - targetHeight ) / 2;
 	}
 
 	const root = document.documentElement;

--- a/packages/block-library/src/image/view-interactivity.js
+++ b/packages/block-library/src/image/view-interactivity.js
@@ -143,7 +143,8 @@ store( {
 					return context.core.image.lightboxEnabled ? 'dialog' : '';
 				},
 				responsiveImgSrc: ( { context } ) => {
-					return context.core.image.activateLargeImage
+					return context.core.image.activateLargeImage &&
+						context.core.image.hideAnimationEnabled
 						? ''
 						: context.core.image.imageCurrentSrc;
 				},

--- a/packages/block-library/src/image/view-interactivity.js
+++ b/packages/block-library/src/image/view-interactivity.js
@@ -133,6 +133,16 @@ store( {
 						}
 					}
 				},
+				preloadLightboxImage: ( { context } ) => {
+					if ( ! context.core.image.preloadInitialized ) {
+						context.core.image.preloadInitialized = true;
+						const imgDom = document.createElement( 'img' );
+						imgDom.setAttribute(
+							'src',
+							context.core.image.imageUploadedSrc
+						);
+					}
+				},
 			},
 		},
 	},
@@ -170,18 +180,6 @@ store( {
 								this.currentSrc;
 						} );
 					}
-				},
-				preloadLightboxImage: ( { context, ref } ) => {
-					ref.addEventListener( 'mouseover', () => {
-						if ( ! context.core.image.preloadInitialized ) {
-							context.core.image.preloadInitialized = true;
-							const imgDom = document.createElement( 'img' );
-							imgDom.setAttribute(
-								'src',
-								context.core.image.imageUploadedSrc
-							);
-						}
-					} );
 				},
 				initLightbox: async ( { context, ref } ) => {
 					context.core.image.figureRef =

--- a/test/e2e/specs/editor/blocks/image.spec.js
+++ b/test/e2e/specs/editor/blocks/image.spec.js
@@ -853,7 +853,10 @@ test.describe( 'Image - interactivity', () => {
 
 			await page.getByRole( 'button', { name: 'Enlarge image' } ).click();
 
-			await expect( responsiveImage ).toHaveAttribute( 'src', '' );
+			await expect( responsiveImage ).toHaveAttribute(
+				'src',
+				new RegExp( filename )
+			);
 			await expect( enlargedImage ).toHaveAttribute(
 				'src',
 				new RegExp( filename )
@@ -865,6 +868,12 @@ test.describe( 'Image - interactivity', () => {
 				name: 'Close',
 			} );
 			await closeButton.click();
+
+			await expect( responsiveImage ).toHaveAttribute( 'src', '' );
+			await expect( enlargedImage ).toHaveAttribute(
+				'src',
+				new RegExp( filename )
+			);
 
 			await expect( lightbox ).toBeHidden();
 		} );
@@ -1092,6 +1101,11 @@ test.describe( 'Image - interactivity', () => {
 		await expect( enlargedImage ).toHaveAttribute( 'src', '' );
 
 		await page.getByRole( 'button', { name: 'Enlarge image' } ).click();
+
+		await expect( responsiveImage ).toHaveAttribute( 'src', imgUrl );
+		await expect( enlargedImage ).toHaveAttribute( 'src', imgUrl );
+
+		await page.getByRole( 'button', { name: 'Close' } ).click();
 
 		await expect( responsiveImage ).toHaveAttribute( 'src', '' );
 		await expect( enlargedImage ).toHaveAttribute( 'src', imgUrl );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
This revises the logic for calculating image dimensions in the lightbox, as well as adds some styles, because the images were getting stretched in some cases.

This was most pronounced on mobile, but it was visible on desktop as well.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Addresses #51556 
The lightbox images should be scaled properly at all resolutions.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
It calculates the inner width of the parent container based on the padding, then compares the aspect ratio of the image to the inner container to determine on which axis to resize the image.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
1. Ensure Interactivity API experiments are enabled
2. Add an image block to a post
3. Make sure the lightbox zoom animation is enabled under Advanced > Behaviors
4. View the post and click on the image
5. Test at different responsive sizes
6. See that the image is scaled and centered appropriately

Please test a horizontal image, a vertical image, and a square image, at various resolutions, on mobile as well as desktop, and in different browsers.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
N/A

### Screenshots

#### Before

https://github.com/WordPress/gutenberg/assets/5360536/63e2623a-43cb-4c50-9d65-a64ad7583964

#### After

https://github.com/WordPress/gutenberg/assets/5360536/cab70934-b93e-44c7-a2f1-815f3e74ca5f