### PR TITLE
Have `createNewPost` wait for editor canvas contents

### DIFF
--- a/packages/e2e-test-utils-playwright/src/admin/create-new-post.js
+++ b/packages/e2e-test-utils-playwright/src/admin/create-new-post.js
@@ -29,7 +29,10 @@ export async function createNewPost( {
 	} ).slice( 1 );
 
 	await this.visitAdminPage( 'post-new.php', query );
-	await this.page.waitForSelector( '.edit-post-layout' );
+	await this.page
+		.frameLocator( '[name="editor-canvas"]' )
+		.locator( '.block-editor-iframe__body' )
+		.waitFor();
 
 	await this.page.evaluate( ( welcomeGuide ) => {
 		window.wp.data

--- a/packages/e2e-test-utils-playwright/src/admin/create-new-post.js
+++ b/packages/e2e-test-utils-playwright/src/admin/create-new-post.js
@@ -13,6 +13,7 @@ import { addQueryArgs } from '@wordpress/url';
  * @param {string}  [object.content]          Content of the new post.
  * @param {string}  [object.excerpt]          Excerpt of the new post.
  * @param {boolean} [object.showWelcomeGuide] Whether to show the welcome guide.
+ * @param {boolean} [object.legacyCanvas]     Whether the non-iframed editor canvas is awaited.
  */
 export async function createNewPost( {
 	postType,
@@ -20,6 +21,7 @@ export async function createNewPost( {
 	content,
 	excerpt,
 	showWelcomeGuide = false,
+	legacyCanvas = false,
 } = {} ) {
 	const query = addQueryArgs( '', {
 		post_type: postType,
@@ -29,10 +31,11 @@ export async function createNewPost( {
 	} ).slice( 1 );
 
 	await this.visitAdminPage( 'post-new.php', query );
-	await this.page
-		.frameLocator( '[name="editor-canvas"]' )
-		.locator( '.block-editor-iframe__body' )
-		.waitFor();
+	const canvasRoot = legacyCanvas
+		? this.page
+		: this.page.frameLocator( '[name=editor-canvas]' );
+
+	await canvasRoot.locator( '.editor-styles-wrapper' ).waitFor();
 
 	await this.page.evaluate( ( welcomeGuide ) => {
 		window.wp.data

--- a/packages/e2e-test-utils-playwright/src/admin/create-new-post.js
+++ b/packages/e2e-test-utils-playwright/src/admin/create-new-post.js
@@ -31,11 +31,15 @@ export async function createNewPost( {
 	} ).slice( 1 );
 
 	await this.visitAdminPage( 'post-new.php', query );
-	const canvasRoot = legacyCanvas
-		? this.page
-		: this.page.frameLocator( '[name=editor-canvas]' );
 
-	await canvasRoot.locator( '.editor-styles-wrapper' ).waitFor();
+	const canvasReadyLocator = legacyCanvas
+		? this.page.locator( '.edit-post-layout' )
+		: this.page
+				.frameLocator( '[name=editor-canvas]' )
+				.locator( 'body > *' )
+				.first();
+
+	await canvasReadyLocator.waitFor();
 
 	await this.page.evaluate( ( welcomeGuide ) => {
 		window.wp.data

--- a/packages/e2e-tests/plugins/block-api.php
+++ b/packages/e2e-tests/plugins/block-api.php
@@ -16,6 +16,8 @@ function enqueue_block_api_plugin_script() {
 		plugins_url( 'block-api/index.js', __FILE__ ),
 		array(
 			'wp-blocks',
+			'wp-block-editor',
+			'wp-element',
 			'wp-hooks',
 		),
 		filemtime( plugin_dir_path( __FILE__ ) . 'block-api/index.js' ),

--- a/packages/e2e-tests/plugins/block-api/index.js
+++ b/packages/e2e-tests/plugins/block-api/index.js
@@ -1,13 +1,16 @@
 ( function () {
 	const { registerBlockType } = wp.blocks;
+	const { useBlockProps } = wp.blockEditor;
+	const { createElement: el } = wp.element;
 	const { addFilter } = wp.hooks;
 
 	registerBlockType( 'e2e-tests/hello-world', {
+		apiVersion: 3,
 		title: 'Hello World',
 		description: 'Hello World test block.',
 		category: 'widgets',
-		edit() {
-			return 'Hello Editor!';
+		edit: function Edit() {
+			return el( 'p', useBlockProps(), 'Hello Editor!' );
 		},
 		save() {
 			return 'Hello Frontend!';

--- a/packages/e2e-tests/plugins/deprecated-node-matcher.php
+++ b/packages/e2e-tests/plugins/deprecated-node-matcher.php
@@ -15,7 +15,6 @@ function enqueue_deprecated_node_matcher_plugin_script() {
 		'gutenberg-test-deprecated-node-matcher',
 		plugins_url( 'deprecated-node-matcher/index.js', __FILE__ ),
 		array(
-			'lodash',
 			'wp-blocks',
 			'wp-element',
 			'wp-block-editor',

--- a/packages/e2e-tests/plugins/deprecated-node-matcher/index.js
+++ b/packages/e2e-tests/plugins/deprecated-node-matcher/index.js
@@ -1,9 +1,10 @@
 ( function () {
 	const registerBlockType = wp.blocks.registerBlockType;
-	const RichText = wp.blockEditor.RichText;
+	const { useBlockProps, RichText } = wp.blockEditor;
 	const el = wp.element.createElement;
 
 	registerBlockType( 'core/deprecated-children-matcher', {
+		apiVersion: 3,
 		title: 'Deprecated Children Matcher',
 		attributes: {
 			value: {
@@ -13,40 +14,35 @@
 			},
 		},
 		category: 'text',
-		edit( { attributes, setAttributes } ) {
+		edit: function EditChildrenMatcher( { attributes, setAttributes } ) {
 			return el( RichText, {
 				tagName: 'p',
 				value: attributes.value,
 				onChange( nextValue ) {
 					setAttributes( { value: nextValue } );
 				},
+				...useBlockProps(),
 			} );
 		},
 		save( { attributes } ) {
 			return el( RichText.Content, {
 				tagName: 'p',
 				value: attributes.value,
+				...useBlockProps.save(),
 			} );
 		},
 	} );
 
 	function toRichTextValue( value ) {
-		// eslint-disable-next-line no-undef
-		return _.map( value, function ( subValue ) {
-			return subValue.children;
-		} );
+		return value?.map( ( { children } ) => children ) ?? [];
 	}
 
 	function fromRichTextValue( value ) {
-		// eslint-disable-next-line no-undef
-		return _.map( value, function ( subValue ) {
-			return {
-				children: subValue,
-			};
-		} );
+		return value.map( ( subValue ) => ( { children: subValue } ) );
 	}
 
 	registerBlockType( 'core/deprecated-node-matcher', {
+		apiVersion: 3,
 		title: 'Deprecated Node Matcher',
 		attributes: {
 			value: {
@@ -61,10 +57,10 @@
 			},
 		},
 		category: 'text',
-		edit( { attributes, setAttributes } ) {
+		edit: function EditNodeMatcher( { attributes, setAttributes } ) {
 			return el(
 				'blockquote',
-				{},
+				useBlockProps(),
 				el( RichText, {
 					multiline: 'p',
 					value: toRichTextValue( attributes.value ),
@@ -74,12 +70,12 @@
 						} );
 					},
 				} )
-			);
+			)
 		},
 		save( { attributes } ) {
 			return el(
 				'blockquote',
-				{},
+				useBlockProps.save(),
 				el( RichText.Content, {
 					value: toRichTextValue( attributes.value ),
 				} )

--- a/packages/e2e-tests/plugins/inner-blocks-allowed-blocks/index.js
+++ b/packages/e2e-tests/plugins/inner-blocks-allowed-blocks/index.js
@@ -12,6 +12,7 @@
 	const allowedBlocksWhenMultipleChildren = [ 'core/gallery', 'core/video' ];
 
 	registerBlockType( 'test/allowed-blocks-dynamic', {
+		apiVersion: 3,
 		title: 'Allowed Blocks Dynamic',
 		icon: 'carrot',
 		category: 'text',

--- a/packages/e2e-tests/plugins/inner-blocks-templates/index.js
+++ b/packages/e2e-tests/plugins/inner-blocks-templates/index.js
@@ -2,7 +2,7 @@
 	const registerBlockType = wp.blocks.registerBlockType;
 	const createBlock = wp.blocks.createBlock;
 	const el = wp.element.createElement;
-	const InnerBlocks = wp.blockEditor.InnerBlocks;
+	const { InnerBlocks, useBlockProps } = wp.blockEditor;
 	const useState = window.wp.element.useState;
 
 	const TEMPLATE = [
@@ -47,6 +47,7 @@
 	};
 
 	registerBlockType( 'test/test-inner-blocks-no-locking', {
+		apiVersion: 3,
 		title: 'Test Inner Blocks no locking',
 		icon: 'cart',
 		category: 'text',
@@ -61,6 +62,7 @@
 	} );
 
 	registerBlockType( 'test/test-inner-blocks-locking-all', {
+		apiVersion: 3,
 		title: 'Test InnerBlocks locking all',
 		icon: 'cart',
 		category: 'text',
@@ -76,6 +78,7 @@
 	} );
 
 	registerBlockType( 'test/test-inner-blocks-update-locked-template', {
+		apiVersion: 3,
 		title: 'Test Inner Blocks update locked template',
 		icon: 'cart',
 		category: 'text',
@@ -112,6 +115,7 @@
 	} );
 
 	registerBlockType( 'test/test-inner-blocks-paragraph-placeholder', {
+		apiVersion: 3,
 		title: 'Test Inner Blocks Paragraph Placeholder',
 		icon: 'cart',
 		category: 'text',
@@ -127,6 +131,7 @@
 	} );
 
 	registerBlockType( 'test/test-inner-blocks-transformer-target', {
+		apiVersion: 3,
 		title: 'Test Inner Blocks transformer target',
 		icon: 'cart',
 		category: 'text',
@@ -182,14 +187,15 @@
 			setTemplate( TEMPLATE_TWO_PARAGRAPHS );
 		}, 1000 );
 
-		return el( InnerBlocks, {
+		return el('div', useBlockProps(), el( InnerBlocks, {
 			template,
-		} );
+		} ) );
 	}
 
 	registerBlockType(
 		'test/test-inner-blocks-async-template',
 		{
+			apiVersion: 3,
 			title: 'Test Inner Blocks Async Template',
 			icon: 'cart',
 			category: 'text',

--- a/packages/e2e-tests/plugins/inner-blocks-templates/index.js
+++ b/packages/e2e-tests/plugins/inner-blocks-templates/index.js
@@ -52,10 +52,10 @@
 		icon: 'cart',
 		category: 'text',
 
-		edit() {
-			return el( InnerBlocks, {
+		edit: function InnerBlocksNoLockingEdit() {
+			return el( 'div', useBlockProps(), el( InnerBlocks, {
 				template: TEMPLATE,
-			} );
+			} ) );
 		},
 
 		save,
@@ -67,11 +67,11 @@
 		icon: 'cart',
 		category: 'text',
 
-		edit() {
-			return el( InnerBlocks, {
+		edit: function InnerBlocksBlocksLockingAllEdit() {
+			return el( 'div', useBlockProps(), el( InnerBlocks, {
 				template: TEMPLATE,
 				templateLock: 'all',
-			} );
+			} ) );
 		},
 
 		save,
@@ -90,7 +90,7 @@
 			},
 		},
 
-		edit( props ) {
+		edit: function InnerBlocksUpdateLockedTemplateEdit( props ) {
 			const hasUpdatedTemplated = props.attributes.hasUpdatedTemplate;
 			return el( 'div', null, [
 				el(
@@ -102,12 +102,12 @@
 					},
 					'Update template'
 				),
-				el( InnerBlocks, {
+				el( 'div', useBlockProps(), el( InnerBlocks, {
 					template: hasUpdatedTemplated
 						? TEMPLATE_TWO_PARAGRAPHS
 						: TEMPLATE,
 					templateLock: 'all',
-				} ),
+				} ) ),
 			] );
 		},
 
@@ -120,11 +120,11 @@
 		icon: 'cart',
 		category: 'text',
 
-		edit() {
-			return el( InnerBlocks, {
+		edit: function InnerBlocksParagraphPlaceholderEdit() {
+			return el( 'div', useBlockProps(), el( InnerBlocks, {
 				template: TEMPLATE_PARAGRAPH_PLACEHOLDER,
 				templateInsertUpdatesSelection: true,
-			} );
+			} ) );
 		},
 
 		save,
@@ -170,27 +170,14 @@
 			],
 		},
 
-		edit() {
-			return el( InnerBlocks, {
+		edit: function InnerBlocksTransformerTargetEdit() {
+			return el( 'div', useBlockProps(), el( InnerBlocks, {
 				template: TEMPLATE,
-			} );
+			} ) );
 		},
 
 		save,
 	} );
-
-
-	function InnerBlocksAsyncTemplateEdit() {
-		const [ template, setTemplate ] = useState( [] );
-
-		setInterval( () => {
-			setTemplate( TEMPLATE_TWO_PARAGRAPHS );
-		}, 1000 );
-
-		return el('div', useBlockProps(), el( InnerBlocks, {
-			template,
-		} ) );
-	}
 
 	registerBlockType(
 		'test/test-inner-blocks-async-template',
@@ -200,7 +187,17 @@
 			icon: 'cart',
 			category: 'text',
 
-			edit: InnerBlocksAsyncTemplateEdit,
+			edit: function InnerBlocksAsyncTemplateEdit() {
+				const [ template, setTemplate ] = useState( [] );
+
+				setInterval( () => {
+					setTemplate( TEMPLATE_TWO_PARAGRAPHS );
+				}, 1000 );
+
+				return el('div', useBlockProps(), el( InnerBlocks, {
+					template,
+				} ) );
+			},
 
 			// Purposely do not save inner blocks so that it's possible to test template resolution.
 			save() {},

--- a/packages/e2e-tests/specs/editor/plugins/container-blocks.test.js
+++ b/packages/e2e-tests/specs/editor/plugins/container-blocks.test.js
@@ -9,6 +9,7 @@ import {
 	insertBlock,
 	switchEditorModeTo,
 	pressKeyWithModifier,
+	canvas,
 } from '@wordpress/e2e-test-utils';
 
 describe( 'InnerBlocks Template Sync', () => {
@@ -75,7 +76,7 @@ describe( 'InnerBlocks Template Sync', () => {
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 
 		// Trigger a template update and assert that a second block is now present.
-		const [ button ] = await page.$x(
+		const [ button ] = await canvas().$x(
 			`//button[contains(text(), 'Update template')]`
 		);
 		await button.click();

--- a/test/e2e/specs/editor/plugins/block-api.spec.js
+++ b/test/e2e/specs/editor/plugins/block-api.spec.js
@@ -15,13 +15,14 @@ test.describe( 'Using Block API', () => {
 	test( 'Inserts the filtered hello world block even when filter added after block registration', async ( {
 		admin,
 		editor,
-		page,
 	} ) => {
 		await admin.createNewPost();
 
 		await editor.insertBlock( { name: 'e2e-tests/hello-world' } );
 
-		const block = page.locator( '[data-type="e2e-tests/hello-world"]' );
+		const block = editor.canvas.locator(
+			'[data-type="e2e-tests/hello-world"]'
+		);
 		await expect( block ).toHaveText( 'Hello Editor!' );
 	} );
 } );

--- a/test/e2e/specs/editor/plugins/deprecated-node-matcher.spec.js
+++ b/test/e2e/specs/editor/plugins/deprecated-node-matcher.spec.js
@@ -27,7 +27,6 @@ test.describe( 'Deprecated Node Matcher', () => {
 		page,
 		editor,
 	} ) => {
-		// await insertBlock( 'Deprecated Node Matcher' );
 		await editor.insertBlock( { name: 'core/deprecated-node-matcher' } );
 		await page.keyboard.type( 'test' );
 		await page.keyboard.press( 'Enter' );
@@ -39,7 +38,6 @@ test.describe( 'Deprecated Node Matcher', () => {
 		editor,
 		pageUtils,
 	} ) => {
-		// await insertBlock( 'Deprecated Children Matcher' );
 		await editor.insertBlock( {
 			name: 'core/deprecated-children-matcher',
 		} );

--- a/test/e2e/specs/editor/plugins/wp-editor-meta-box.spec.js
+++ b/test/e2e/specs/editor/plugins/wp-editor-meta-box.spec.js
@@ -17,7 +17,7 @@ test.describe( 'WP Editor Meta Boxes', () => {
 	} );
 
 	test( 'Should save the changes', async ( { admin, editor, page } ) => {
-		await admin.createNewPost();
+		await admin.createNewPost( { legacyCanvas: true } );
 
 		// Add title to enable valid non-empty post save.
 		await editor.canvas.type(

--- a/test/e2e/specs/editor/various/inner-blocks-templates.spec.js
+++ b/test/e2e/specs/editor/various/inner-blocks-templates.spec.js
@@ -28,9 +28,11 @@ test.describe( 'Inner blocks templates', () => {
 			name: 'test/test-inner-blocks-async-template',
 		} );
 
-		const blockWithTemplateContent = editor.canvas.locator(
-			'role=document[name="Block: Test Inner Blocks Async Template"i] >> text=OneTwo'
-		);
+		const blockWithTemplateContent = page
+			.frameLocator( '[name=editor-canvas]' )
+			.locator(
+				'role=document[name="Block: Test Inner Blocks Async Template"i] >> text=OneTwo'
+			);
 
 		// The block template content appears asynchronously, so wait for it.
 		await expect( blockWithTemplateContent ).toBeVisible();


### PR DESCRIPTION
## What?
Improvements to e2e testing (Playwright utils) and some test/plugin updates.

Right now, this only updates `createNewPost` for Playwright and so I don't know if it completely resolves #51933, because I suppose the Puppeteer version may need the same sort of update.

## Why?
On my modest laptop, it’s almost the rule that tests using `createNewPost` get derailed by the late appearance of the editor canvas’s contents and waiting for them alleviates it. In CI, this doesn't seem to happen too often but better that it never does.

## How?
af06387 updates `createNewPost` to wait on an element that's inside the iframe instead of an element outside of it.
Doing so makes some other tests fail because they register blocks that trigger the non-iframed canvas.

bbe171a, d1f38a1, c9f7a12, 3e32458 update tests/plugins to register blocks with `apiVersion` `3` so they'll use the iframed editor canvas.

Then there was a final test failing that I couldn't find a way to have run with the iframed editor canvas. So I resorted to b937013 which allows a consumer to configure which canvas is awaited in `createNewPost` and 3fdf738 which uses that option in the test for meta box saving.

### Further details
b937013 means that the updates to blocks’ `apiVersion` aren’t necessary but the work was already done and it seems okay to run those with the iframed canvas. I'd be fine with reverting those if we'd rather reduce the changes.

## Testing Instructions
```shell
npm run test:e2e:playwright
```
