### PR TITLE
E2E tests: Try fixing 'networkidle' timeout errors

### DIFF
--- a/packages/e2e-tests/mu-plugins/nocache-headers.php
+++ b/packages/e2e-tests/mu-plugins/nocache-headers.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * Plugin Name: Gutenberg Test Plugin, No-cache Headers
+ * Plugin URI: https://github.com/WordPress/gutenberg
+ * Author: Gutenberg Team
+ *
+ * @package gutenberg-test-nocache-headers
+ */
+
+// Remove 'no-store' from the Cache-Control header set by WordPress when running
+// E2E tests. This is a workaround for an issue where E2E tests time out waiting
+// for 'networkidle'.
+add_filter(
+	'nocache_headers',
+	static function( $headers ) {
+		$cache_control_parts = explode( ', ', $headers['Cache-Control'] );
+		$cache_control_parts = array_diff( $cache_control_parts, array( 'no-store' ) );
+		$headers['Cache-Control'] = implode( ', ', $cache_control_parts );
+		return $headers;
+	}
+);

--- a/packages/e2e-tests/mu-plugins/nocache-headers.php
+++ b/packages/e2e-tests/mu-plugins/nocache-headers.php
@@ -13,8 +13,8 @@
 add_filter(
 	'nocache_headers',
 	static function( $headers ) {
-		$cache_control_parts = explode( ', ', $headers['Cache-Control'] );
-		$cache_control_parts = array_diff( $cache_control_parts, array( 'no-store' ) );
+		$cache_control_parts      = explode( ', ', $headers['Cache-Control'] );
+		$cache_control_parts      = array_diff( $cache_control_parts, array( 'no-store' ) );
 		$headers['Cache-Control'] = implode( ', ', $cache_control_parts );
 		return $headers;
 	}


### PR DESCRIPTION
A lot of tests are timing out when they call `page.waitForLoadState( 'networkidle' )`. @talldan ran `git bisect` and worked out that it's to do with [a recent Core commit](https://github.com/WordPress/wordpress-develop/commit/8d702842ce2c7dbb457624b8d66fe0536e1a8b48) that adjusted the `Cache-Control` headers set by WordPress. Removing `no-store` from the header seems to fix the issue.

I'm pretty stumped as to why this happens. (A Chrome bug?) This PR simply uses the `nocache_headers` filter to remove `no-store` from `Cache-Control` header in our E2E test environment. Hopefully this fixes the tests and unblocks committers from doing work while we investigate what's actually going on here.

Related Trac ticket: https://core.trac.wordpress.org/ticket/58592
Slack thread: https://wordpress.slack.com/archives/C02QB2JS7/p1687418950952019