### PR TITLE
Library: Fix delete shortcut incorrectly bound to non-user patterns

### DIFF
--- a/packages/edit-site/src/components/page-library/grid-item.js
+++ b/packages/edit-site/src/components/page-library/grid-item.js
@@ -49,6 +49,12 @@ export default function GridItem( { categoryId, composite, icon, item } ) {
 		canvas: 'edit',
 	} );
 
+	const onKeyDown = ( event ) => {
+		if ( DELETE === event.keyCode || BACKSPACE === event.keyCode ) {
+			setIsDeleteDialogOpen( true );
+		}
+	};
+
 	const isEmpty = ! item.blocks?.length;
 	const patternClassNames = classnames( 'edit-site-library__pattern', {
 		'is-placeholder': isEmpty,
@@ -72,8 +78,9 @@ export default function GridItem( { categoryId, composite, icon, item } ) {
 		}
 	};
 
+	const isUserPattern = item.type === USER_PATTERNS;
 	let ariaDescription;
-	if ( item.type === USER_PATTERNS ) {
+	if ( isUserPattern ) {
 		// User patterns don't have descriptions, but can be edited and deleted, so include some help text.
 		ariaDescription = __(
 			'Press Enter to edit, or Delete to delete the pattern.'
@@ -90,19 +97,12 @@ export default function GridItem( { categoryId, composite, icon, item } ) {
 					role="option"
 					as="div"
 					{ ...composite }
-					onClick={ item.type !== PATTERNS ? onClick : undefined }
+					onClick={ isUserPattern ? onClick : undefined }
+					onKeyDown={ isUserPattern ? onKeyDown : undefined }
 					aria-label={ item.title }
 					aria-describedby={
 						ariaDescription ? descriptionId : undefined
 					}
-					onKeyDown={ ( event ) => {
-						if (
-							DELETE === event.keyCode ||
-							BACKSPACE === event.keyCode
-						) {
-							setIsDeleteDialogOpen( true );
-						}
-					} }
 				>
 					{ isEmpty && __( 'Empty pattern' ) }
 					{ ! isEmpty && <BlockPreview blocks={ item.blocks } /> }


### PR DESCRIPTION
## What?
A late addition to #51078 was the ability to use the delete key to remove a focused user created pattern.

This was accidentally applied not just to user created patterns, but also non-user created patterns that can't actually be deleted (nothing happens though).

## How?
Check if the pattern is user created before binding the onKeyDown event.

## Testing Instructions
1. Open the site editor, navigate to the library
2. Select a pattern category like 'Featured'
3. Tab to one of the patterns in the list
4. Press delete

In trunk: A confirmation dialog shows, trying to delete does nothing (it triggers a delete HTTP request, but it 404s)
In this branch: Pressing delete does nothing.