### PR TITLE
Buttons Block: add support for orientation-based block movers

### DIFF
--- a/packages/block-library/src/buttons/edit.js
+++ b/packages/block-library/src/buttons/edit.js
@@ -36,7 +36,7 @@ const DEFAULT_BLOCK = {
 };
 
 function ButtonsEdit( { attributes, className } ) {
-	const { fontSize, style } = attributes;
+	const { fontSize, layout, style } = attributes;
 	const blockProps = useBlockProps( {
 		className: classnames( className, {
 			'has-custom-font-size': fontSize || style?.typography?.fontSize,
@@ -59,8 +59,8 @@ function ButtonsEdit( { attributes, className } ) {
 				{ className: preferredStyle && `is-style-${ preferredStyle }` },
 			],
 		],
-
 		templateInsertUpdatesSelection: true,
+		orientation: layout?.orientation ?? 'horizontal',
 	} );
 
 	return <div { ...innerBlocksProps } />;


### PR DESCRIPTION
Similar to: #48452

## What?
This PR ensures that the mover of the inside button block takes the orientation into account.

## Why?
To match the direction of the mover to the direction in which the block is actually moved.

## How?
Added `orientation` property to `useInnerBlocksProps` with `layout.orientation` attribute indicating orientation as value.

## Testing Instructions
- Insert a buttons block and then insert some button blocks in it.
- When the button block is selected, the mover direction should be **horizontal**.
- Change the direction of the buttons block to **vertical**.
- When the button block is selected, the mover direction should be **vertical**.
- Returns the direction of the buttons block to **horizontal**.
- When the button block is selected, the mover direction should be **horizontal**.

## Screenshots or screencast <!-- if applicable -->


https://github.com/WordPress/gutenberg/assets/54422211/fbd0ceea-aaf7-4174-b1ff-5d54ce675f4c

