### PR TITLE
Command center: Add another batch of commands to the site editor

### DIFF
--- a/packages/commands/src/hooks/use-command.js
+++ b/packages/commands/src/hooks/use-command.js
@@ -28,7 +28,7 @@ export default function useCommand( command ) {
 			label: command.label,
 			searchLabel: command.searchLabel,
 			icon: command.icon,
-			callback: currentCallback.current,
+			callback: ( ...args ) => currentCallback.current( ...args ),
 		} );
 		return () => {
 			unregisterCommand( command.name );

--- a/packages/edit-site/src/hooks/commands/use-common-commands.js
+++ b/packages/edit-site/src/hooks/commands/use-common-commands.js
@@ -4,7 +4,7 @@
 import { useMemo } from '@wordpress/element';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
-import { trash, backup, help, styles } from '@wordpress/icons';
+import { trash, backup, help, styles, external } from '@wordpress/icons';
 import { useCommandLoader, useCommand } from '@wordpress/commands';
 import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
 import { privateApis as routerPrivateApis } from '@wordpress/router';
@@ -105,6 +105,15 @@ export function useCommonCommands() {
 	);
 	const { set } = useDispatch( preferencesStore );
 	const history = useHistory();
+	const { homeUrl } = useSelect( ( select ) => {
+		const {
+			getUnstableBase, // Site index.
+		} = select( coreStore );
+
+		return {
+			homeUrl: getUnstableBase()?.home,
+		};
+	}, [] );
 
 	useCommand( {
 		name: 'core/edit-site/open-global-styles-revisions',
@@ -153,6 +162,16 @@ export function useCommonCommands() {
 			}, 500 );
 		},
 		icon: help,
+	} );
+
+	useCommand( {
+		name: 'core/edit-site/view-site',
+		label: __( 'View site' ),
+		callback: ( { close } ) => {
+			close();
+			window.open( homeUrl, '_blank' );
+		},
+		icon: external,
 	} );
 
 	useCommandLoader( {

--- a/packages/edit-site/src/hooks/commands/use-edit-mode-commands.js
+++ b/packages/edit-site/src/hooks/commands/use-edit-mode-commands.js
@@ -132,7 +132,7 @@ function useEditUICommandLoader() {
 	const { toggle } = useDispatch( preferencesStore );
 
 	if ( canvasMode !== 'edit' ) {
-		return { isLoading: true, commands: [] };
+		return { isLoading: false, commands: [] };
 	}
 
 	const commands = [];

--- a/packages/edit-site/src/hooks/commands/use-edit-mode-commands.js
+++ b/packages/edit-site/src/hooks/commands/use-edit-mode-commands.js
@@ -17,6 +17,7 @@ import {
 import { useCommandLoader } from '@wordpress/commands';
 import { privateApis as routerPrivateApis } from '@wordpress/router';
 import { store as preferencesStore } from '@wordpress/preferences';
+import { store as interfaceStore } from '@wordpress/interface';
 
 /**
  * Internal dependencies
@@ -118,14 +119,17 @@ function useEditModeCommandLoader() {
 }
 
 function useEditUICommandLoader() {
-	const { openGeneralSidebar, switchEditorMode } =
+	const { openGeneralSidebar, closeGeneralSidebar, switchEditorMode } =
 		useDispatch( editSiteStore );
-	const { canvasMode, editorMode } = useSelect(
+	const { canvasMode, editorMode, activeSidebar } = useSelect(
 		( select ) => ( {
 			isPage: select( editSiteStore ).isPage(),
 			hasPageContentFocus: select( editSiteStore ).hasPageContentFocus(),
 			canvasMode: unlock( select( editSiteStore ) ).getCanvasMode(),
 			editorMode: select( editSiteStore ).getEditorMode(),
+			activeSidebar: select( interfaceStore ).getActiveComplementaryArea(
+				editSiteStore.name
+			),
 		} ),
 		[]
 	);
@@ -139,21 +143,29 @@ function useEditUICommandLoader() {
 
 	commands.push( {
 		name: 'core/open-settings-sidebar',
-		label: __( 'Open settings sidebar' ),
+		label: __( 'Toggle settings sidebar' ),
 		icon: isRTL() ? drawerLeft : drawerRight,
 		callback: ( { close } ) => {
-			openGeneralSidebar( 'edit-site/template' );
 			close();
+			if ( activeSidebar === 'edit-site/template' ) {
+				closeGeneralSidebar();
+			} else {
+				openGeneralSidebar( 'edit-site/template' );
+			}
 		},
 	} );
 
 	commands.push( {
 		name: 'core/open-block-inspector',
-		label: __( 'Open block inspector' ),
+		label: __( 'Toggle block inspector' ),
 		icon: blockDefault,
 		callback: ( { close } ) => {
-			openGeneralSidebar( 'edit-site/block-inspector' );
 			close();
+			if ( activeSidebar === 'edit-site/block-inspector' ) {
+				closeGeneralSidebar();
+			} else {
+				openGeneralSidebar( 'edit-site/block-inspector' );
+			}
 		},
 	} );
 


### PR DESCRIPTION
Related #51502 

## What?

This PR adds another batch of commands to the site editor:

 - View site
 - Open settings sidebar
 - Open block inspector
 - Toggle spotlight mode
 - Toggle top toolbar
 - Toggle code editor

## Testing Instructions

- Open the site editor
- Try the commands above (most of them are only available in edit mode)

