### PR TITLE
Perf logging: change date to ISO 8601

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -87,7 +87,7 @@ jobs:
               env:
                   CODEHEALTH_PROJECT_TOKEN: ${{ secrets.CODEHEALTH_PROJECT_TOKEN }}
               run: |
-                  COMMITTED_AT=$(git show -s $GITHUB_SHA --format="%ct")
+                  COMMITTED_AT=$(git show -s $GITHUB_SHA --format="%cI")
                   ./bin/log-performance-results.js $CODEHEALTH_PROJECT_TOKEN trunk $GITHUB_SHA 34af5829ac9edb31833167ff6a3b51bea982999c $COMMITTED_AT
 
             - name: Archive debug artifacts (screenshots, HTML snapshots)

--- a/bin/log-performance-results.js
+++ b/bin/log-performance-results.js
@@ -37,7 +37,7 @@ const data = new TextEncoder().encode(
 		branch,
 		hash,
 		baseHash,
-		timestamp: parseInt( timestamp, 10 ),
+		timestamp,
 		metrics: resultsFiles.reduce( ( result, { metricsPrefix }, index ) => {
 			return {
 				...result,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Currently we log a UNIX timestamp, which is in seconds. ISO 8601 is human readable and parsable by `new Date()`, e.g. `2023-06-22T21:00:30+03:00`.

## Why?

Date logging is broken on https://www.codevitals.run/project/gutenberg.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
