### PR TITLE
ZStack: fix component bounding box to match children

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -14,6 +14,7 @@
 -   `Button`: Remove unnecessary margin from dashicon ([#51395](https://github.com/WordPress/gutenberg/pull/51395)).
 -   `Autocomplete`: Announce how many results are available to screen readers when suggestions list first renders ([#51018](https://github.com/WordPress/gutenberg/pull/51018)).
 -   `ConfirmDialog`: Ensure onConfirm isn't called an extra time when submitting one of the buttons using the keyboard ([#51730](https://github.com/WordPress/gutenberg/pull/51730)).
+-   `ZStack`: ZStack: fix component bounding box to match children ([#51836](https://github.com/WordPress/gutenberg/pull/51836)).
 
 ### Internal
 

--- a/packages/components/src/z-stack/component.tsx
+++ b/packages/components/src/z-stack/component.tsx
@@ -43,7 +43,6 @@ function UnconnectedZStack(
 
 		return (
 			<ZStackChildView
-				isLayered={ isLayered }
 				offsetAmount={ offsetAmount }
 				zIndex={ zIndex }
 				key={ key }
@@ -57,6 +56,7 @@ function UnconnectedZStack(
 		<ZStackView
 			{ ...otherProps }
 			className={ className }
+			isLayered={ isLayered }
 			ref={ forwardedRef }
 		>
 			{ clonedChildren }

--- a/packages/components/src/z-stack/component.tsx
+++ b/packages/components/src/z-stack/component.tsx
@@ -35,7 +35,9 @@ function UnconnectedZStack(
 
 	const clonedChildren = validChildren.map( ( child, index ) => {
 		const zIndex = isReversed ? childrenLastIndex - index : index;
-		const offsetAmount = offset * index;
+		// Only when the component is layered, the offset needs to be multiplied
+		// the item's index, so that items can correctly stack at the right distance
+		const offsetAmount = isLayered ? offset * index : offset;
 
 		const key = isValidElement( child ) ? child.key : index;
 

--- a/packages/components/src/z-stack/component.tsx
+++ b/packages/components/src/z-stack/component.tsx
@@ -35,7 +35,7 @@ function UnconnectedZStack(
 
 	const clonedChildren = validChildren.map( ( child, index ) => {
 		const zIndex = isReversed ? childrenLastIndex - index : index;
-		// Only when the component is layered, the offset needs to be multiplied
+		// Only when the component is layered, the offset needs to be multiplied by
 		// the item's index, so that items can correctly stack at the right distance
 		const offsetAmount = isLayered ? offset * index : offset;
 

--- a/packages/components/src/z-stack/stories/index.tsx
+++ b/packages/components/src/z-stack/stories/index.tsx
@@ -8,7 +8,6 @@ import type { ComponentMeta, ComponentStory } from '@storybook/react';
  * Internal dependencies
  */
 import { Elevation } from '../../elevation';
-import { HStack } from '../../h-stack';
 import { View } from '../../view';
 import { ZStack } from '..';
 
@@ -55,18 +54,12 @@ const Avatar = ( {
 
 const Template: ComponentStory< typeof ZStack > = ( args ) => {
 	return (
-		<View>
-			<HStack>
-				<View>
-					<ZStack { ...args }>
-						<Avatar backgroundColor="#444" />
-						<Avatar backgroundColor="#777" />
-						<Avatar backgroundColor="#aaa" />
-						<Avatar backgroundColor="#fff" />
-					</ZStack>
-				</View>
-			</HStack>
-		</View>
+		<ZStack { ...args }>
+			<Avatar backgroundColor="#444" />
+			<Avatar backgroundColor="#777" />
+			<Avatar backgroundColor="#aaa" />
+			<Avatar backgroundColor="#fff" />
+		</ZStack>
 	);
 };
 

--- a/packages/components/src/z-stack/styles.ts
+++ b/packages/components/src/z-stack/styles.ts
@@ -27,6 +27,7 @@ export const ZStackView = styled.div< {
 
 	& > ${ ZStackChildView } {
 		position: relative;
+		justify-self: start;
 
 		${ ( { isLayered } ) =>
 			isLayered

--- a/packages/components/src/z-stack/styles.ts
+++ b/packages/components/src/z-stack/styles.ts
@@ -7,10 +7,10 @@ import styled from '@emotion/styled';
 /**
  * Internal dependencies
  */
-import { rtl } from '../utils';
 
 export const ZStackView = styled.div`
-	display: flex;
+	display: inline-grid;
+	grid-auto-flow: column;
 	position: relative;
 `;
 
@@ -19,21 +19,20 @@ export const ZStackChildView = styled.div< {
 	offsetAmount: number;
 	zIndex: number;
 } >`
-	${ ( { isLayered, offsetAmount } ) =>
-		isLayered
-			? css( rtl( { marginLeft: offsetAmount } )() )
-			: css( rtl( { right: offsetAmount * -1 } )() ) }
+	position: relative;
 
 	${ ( { isLayered } ) =>
-		isLayered ? positionAbsolute : positionRelative }
+		isLayered
+			? // When `isLayered` is true, all items overlap in the same grid cell
+			  css( { gridRowStart: 1, gridColumnStart: 1 } )
+			: undefined };
 
-	${ ( { zIndex } ) => css( { zIndex } ) }
-`;
+	&:not( :first-child ) {
+		${ ( { offsetAmount } ) =>
+			css( {
+				marginInlineStart: offsetAmount,
+			} ) };
+	}
 
-const positionAbsolute = css`
-	position: absolute;
-`;
-
-const positionRelative = css`
-	position: relative;
+	${ ( { zIndex } ) => css( { zIndex } ) };
 `;

--- a/packages/components/src/z-stack/styles.ts
+++ b/packages/components/src/z-stack/styles.ts
@@ -27,7 +27,7 @@ export const ZStackChildView = styled.div< {
 			  css( { gridRowStart: 1, gridColumnStart: 1 } )
 			: undefined };
 
-	&:not( :first-child ) {
+	&:not( :first-of-type ) {
 		${ ( { offsetAmount } ) =>
 			css( {
 				marginInlineStart: offsetAmount,

--- a/packages/components/src/z-stack/styles.ts
+++ b/packages/components/src/z-stack/styles.ts
@@ -4,29 +4,10 @@
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 
-/**
- * Internal dependencies
- */
-
-export const ZStackView = styled.div`
-	display: inline-grid;
-	grid-auto-flow: column;
-	position: relative;
-`;
-
 export const ZStackChildView = styled.div< {
-	isLayered: boolean;
 	offsetAmount: number;
 	zIndex: number;
 } >`
-	position: relative;
-
-	${ ( { isLayered } ) =>
-		isLayered
-			? // When `isLayered` is true, all items overlap in the same grid cell
-			  css( { gridRowStart: 1, gridColumnStart: 1 } )
-			: undefined };
-
 	&:not( :first-of-type ) {
 		${ ( { offsetAmount } ) =>
 			css( {
@@ -35,4 +16,22 @@ export const ZStackChildView = styled.div< {
 	}
 
 	${ ( { zIndex } ) => css( { zIndex } ) };
+`;
+
+export const ZStackView = styled.div< {
+	isLayered: boolean;
+} >`
+	display: inline-grid;
+	grid-auto-flow: column;
+	position: relative;
+
+	& > ${ ZStackChildView } {
+		position: relative;
+
+		${ ( { isLayered } ) =>
+			isLayered
+				? // When `isLayered` is true, all items overlap in the same grid cell
+				  css( { gridRowStart: 1, gridColumnStart: 1 } )
+				: undefined };
+	}
 `;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Rewrite the `ZStack` using CSS grid instead of a mix of position relative/absolute and negative margins.

Closes #51807

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The current implementation makes it hard to use the component correctly as part of more complex layouts, because the bounding box of `ZStack` doesn't always reflect the component's real footprint:

- when using `isLayered = true`, the wrapper's size is `0`, because of the absolute-positioned children
- when using `isLayered = false`, the wrapper's size is smaller than it should be, because of how the children components are spaced (via `right` prop)

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Rewrote the layout algorithm behind `ZStack` to use CSS Grid, which is much better at understanding the real size of the children components, and therefore allows the wrapper element's bounding box to be correct

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

In Storybook:
- visit the `ZStack` story, play around with the `isLayered`, `isReversed`, `offset` props. Make sure that the children elements are laid out exactly like on `trunk`, but also that the wrapper's bounding box is now accurately matching the real footprint of the component

In the block editor, make sure that the `ZStack` component renders as expected in the following places:

- Colors panel in block styles:
  - select a paragraph block
  - in the block settings sidebar, make sure that the color swatches for the "Text" and "Background" color in the "Colors" panel are rendering as expected
- Filters panel in block styles:
  - select an image block
  - in the block settings sidebar, select the "Styles" tab
  - In the styles tab panel, make sure that the color swatch for the "Duotone" item in the "Filters" panel is rendering as expected
- Palette screen in global styles:
  - open the global styles sidebar in the site editor
  - click the "Colors" button
  - in the new screen, make sure that all the color swatches (both in the "Palette" section, and for each individual color item) are rendering as expected

## Screenshots or screencast <!-- if applicable -->

**_(note: the red outline is only added for the purpose of highlighting the changes from this PR)_**

Trunk:

https://github.com/WordPress/gutenberg/assets/1083581/7147e48a-3c17-402f-bae2-337592a045db

This PR:

https://github.com/WordPress/gutenberg/assets/1083581/45112f31-e7ed-468e-b051-8ad074759553

