### PR TITLE
[Site Editor]: Fix `library` command path

### DIFF
--- a/packages/core-commands/src/site-editor-navigation-commands.js
+++ b/packages/core-commands/src/site-editor-navigation-commands.js
@@ -203,7 +203,7 @@ function useSiteEditorBasicNavigationCommands() {
 			icon: symbolFilled,
 			callback: ( { close } ) => {
 				const args = {
-					path: '/wp_template_part',
+					path: '/library',
 				};
 				const targetUrl = addQueryArgs( 'site-editor.php', args );
 				if ( isSiteEditor ) {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes the path when we select the command for `library`. 


## Testing Instructions
1. In site editor open the commands prompt and choose `library`
2. observe that now it opens the proper panel
