### PR TITLE
Fix ability to click through to Template Parts in Library

### DIFF
--- a/packages/edit-site/src/components/page-library/grid-item.js
+++ b/packages/edit-site/src/components/page-library/grid-item.js
@@ -97,7 +97,7 @@ export default function GridItem( { categoryId, composite, icon, item } ) {
 					role="option"
 					as="div"
 					{ ...composite }
-					onClick={ isUserPattern ? onClick : undefined }
+					onClick={ item.type !== PATTERNS ? onClick : undefined }
 					onKeyDown={ isUserPattern ? onKeyDown : undefined }
 					aria-label={ item.title }
 					aria-describedby={


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Restores ability to click through to a given template part in focus mode.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Users need to be able to click through on a pattern to enter focus mode.

@talldan said he may have broken it in https://github.com/WordPress/gutenberg/pull/51830.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Restore `onClick` handler.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

- Open Site Editor
- Click `Library` in browse mode sidebar
- Click on a Template Part
- You should click through to focus mode

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
