### PR TITLE
Get the top toolbar preference from the correct scope

### DIFF
--- a/packages/edit-site/src/components/layout/index.js
+++ b/packages/edit-site/src/components/layout/index.js
@@ -86,8 +86,10 @@ export default function Layout() {
 				nextShortcut: getAllShortcutKeyCombinations(
 					'core/edit-site/next-region'
 				),
-				hasFixedToolbar:
-					select( preferencesStore ).get( 'fixedToolbar' ),
+				hasFixedToolbar: select( preferencesStore ).get(
+					'core/edit-site',
+					'fixedToolbar'
+				),
 			};
 		}, [] );
 	const isEditing = canvasMode === 'edit';


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Working on https://github.com/WordPress/gutenberg/pull/51173 I found that the site editor layout did not get the correct class name when top toolbar preference was on.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The preference is checked without a scope.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Fixed the prefference getter to search in the edit site scope.

