### PR TITLE
Button: Introduce `size` prop

### DIFF
--- a/packages/base-styles/_variables.scss
+++ b/packages/base-styles/_variables.scss
@@ -48,6 +48,7 @@ $icon-size: 24px;
 $button-size: 36px;
 $button-size-next-default-40px: 40px; // transitionary variable for next default button size
 $button-size-small: 24px;
+$button-size-compact: 32px;
 $header-height: 60px;
 $panel-header-height: $grid-unit-60;
 $nav-sidebar-width: 360px;

--- a/packages/base-styles/_variables.scss
+++ b/packages/base-styles/_variables.scss
@@ -48,7 +48,6 @@ $icon-size: 24px;
 $button-size: 36px;
 $button-size-next-default-40px: 40px; // transitionary variable for next default button size
 $button-size-small: 24px;
-$button-size-small-next-default-32px: 32px; // transitionary variable for next small button size
 $header-height: 60px;
 $panel-header-height: $grid-unit-60;
 $nav-sidebar-width: 360px;

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 -   `UnitControl`: Revamp support for changing unit by typing ([#39303](https://github.com/WordPress/gutenberg/pull/39303)).
 -   `Modal`: Update corner radius to be between buttons and the site view frame, in a 2-4-8 system. ([#51254](https://github.com/WordPress/gutenberg/pull/51254)).
+-   `Button`: Introduce `size` prop with `default`, `compact`, and `small` variants ([#51842](https://github.com/WordPress/gutenberg/pull/51842)).
 -   `ItemGroup`: Update button focus state styles to be inline with other button focus states in the editor. ([#51576](https://github.com/WordPress/gutenberg/pull/51576)).
 
 ### Bug Fix

--- a/packages/components/src/button/README.md
+++ b/packages/components/src/button/README.md
@@ -198,6 +198,8 @@ Renders a pressed button style.
 
 Decreases the size of the button.
 
+Deprecated in favor of the `size` prop. If both props are defined, the `size` prop will take precedence.
+
 -   Required: No
 
 #### `label`: `string`
@@ -226,6 +228,7 @@ The size of the button.
 -   `'compact'`: For toggle buttons, icon buttons, and buttons when used in context of either.
 -   `'small'`: For icon buttons associated with more advanced or auxiliary features.
 
+If the deprecated `isSmall` prop is also defined, this prop will take precedence.
 
 -   Required: No
 -   Default: `'default'`

--- a/packages/components/src/button/README.md
+++ b/packages/components/src/button/README.md
@@ -228,6 +228,7 @@ The size of the button.
 
 
 -   Required: No
+-   Default: `'default'`
 
 #### `target`: `string`
 

--- a/packages/components/src/button/README.md
+++ b/packages/components/src/button/README.md
@@ -223,7 +223,7 @@ If provided, renders a [Tooltip](/packages/components/src/tooltip/README.md) com
 The size of the button.
 
 -   `'default'`: For normal text-label buttons, unless it is a toggle button.
--   `'compact'`: For toggle buttons and icon buttons.
+-   `'compact'`: For toggle buttons, icon buttons, and buttons when used in context of either.
 -   `'small'`: For icon buttons associated with more advanced or auxiliary features.
 
 

--- a/packages/components/src/button/README.md
+++ b/packages/components/src/button/README.md
@@ -218,6 +218,17 @@ If provided, renders a [Tooltip](/packages/components/src/tooltip/README.md) com
 
 -   Required: No
 
+#### `size`: `'default'` | `'compact'` | `'small'`
+
+The size of the button.
+
+-   `'default'`: For normal text-label buttons, unless it is a toggle button.
+-   `'compact'`: For toggle buttons and icon buttons.
+-   `'small'`: For icon buttons associated with more advanced or auxiliary features.
+
+
+-   Required: No
+
 #### `target`: `string`
 
 If provided with `href`, sets the `target` attribute to the `a`.

--- a/packages/components/src/button/index.tsx
+++ b/packages/components/src/button/index.tsx
@@ -42,7 +42,7 @@ function useDeprecatedProps( {
 	let computedVariant = variant;
 
 	if ( isSmall ) {
-		computedSize = 'small';
+		computedSize ??= 'small';
 	}
 
 	if ( isPrimary ) {

--- a/packages/components/src/button/index.tsx
+++ b/packages/components/src/button/index.tsx
@@ -76,7 +76,6 @@ export function UnforwardedButton(
 ) {
 	const {
 		__next40pxDefaultSize,
-		__next32pxSmallSize,
 		isSmall,
 		isPressed,
 		isBusy,
@@ -118,7 +117,6 @@ export function UnforwardedButton(
 
 	const classes = classnames( 'components-button', className, {
 		'is-next-40px-default-size': __next40pxDefaultSize,
-		'is-next-32px-small-size': __next32pxSmallSize,
 		'is-secondary': variant === 'secondary',
 		'is-primary': variant === 'primary',
 		'is-small': isSmall,

--- a/packages/components/src/button/index.tsx
+++ b/packages/components/src/button/index.tsx
@@ -33,10 +33,17 @@ function useDeprecatedProps( {
 	isSecondary,
 	isTertiary,
 	isLink,
+	isSmall,
+	size,
 	variant,
 	...otherProps
 }: ButtonProps & DeprecatedButtonProps ): ButtonProps {
+	let computedSize = size;
 	let computedVariant = variant;
+
+	if ( isSmall ) {
+		computedSize = 'small';
+	}
 
 	if ( isPrimary ) {
 		computedVariant ??= 'primary';
@@ -66,6 +73,7 @@ function useDeprecatedProps( {
 
 	return {
 		...otherProps,
+		size: computedSize,
 		variant: computedVariant,
 	};
 }
@@ -76,7 +84,6 @@ export function UnforwardedButton(
 ) {
 	const {
 		__next40pxDefaultSize,
-		isSmall,
 		isPressed,
 		isBusy,
 		isDestructive,
@@ -90,6 +97,7 @@ export function UnforwardedButton(
 		shortcut,
 		label,
 		children,
+		size = 'default',
 		text,
 		variant,
 		__experimentalIsFocusable: isFocusable,
@@ -119,7 +127,8 @@ export function UnforwardedButton(
 		'is-next-40px-default-size': __next40pxDefaultSize,
 		'is-secondary': variant === 'secondary',
 		'is-primary': variant === 'primary',
-		'is-small': isSmall,
+		'is-small': size === 'small',
+		'is-compact': size === 'compact',
 		'is-tertiary': variant === 'tertiary',
 		'is-pressed': isPressed,
 		'is-busy': isBusy,

--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -257,16 +257,26 @@
 		/* stylelint-enable */
 	}
 
+	&.is-compact {
+		height: $button-size-compact;
+
+		&.has-icon:not(.has-text) {
+			padding: 0;
+			width: $button-size-compact;
+			min-width: $button-size-compact;
+		}
+	}
+
 	&.is-small {
-		height: $icon-size;
+		height: $button-size-small;
 		line-height: 22px;
 		padding: 0 8px;
 		font-size: 11px;
 
 		&.has-icon:not(.has-text) {
 			padding: 0;
-			width: $icon-size;
-			min-width: $icon-size;
+			width: $button-size-small;
+			min-width: $button-size-small;
 		}
 	}
 

--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -258,24 +258,15 @@
 	}
 
 	&.is-small {
-		height: $button-size-small-next-default-32px;
+		height: $icon-size;
 		line-height: 22px;
 		padding: 0 8px;
 		font-size: 11px;
 
 		&.has-icon:not(.has-text) {
 			padding: 0;
-			width: $button-size-small-next-default-32px;
-			min-width: $button-size-small-next-default-32px;
-		}
-
-		&:not(.is-next-32px-small-size) {
-			height: $button-size-small;
-
-			&.has-icon:not(.has-text) {
-				width: $button-size-small;
-				min-width: $button-size-small;
-			}
+			width: $icon-size;
+			min-width: $icon-size;
 		}
 	}
 

--- a/packages/components/src/button/test/index.tsx
+++ b/packages/components/src/button/test/index.tsx
@@ -407,6 +407,14 @@ describe( 'Button', () => {
 			render( <Button isSmall /> );
 			expect( screen.getByRole( 'button' ) ).toHaveClass( 'is-small' );
 		} );
+
+		it( 'should prioritize the `size` prop over `isSmall`', () => {
+			render( <Button size="compact" isSmall /> );
+			expect( screen.getByRole( 'button' ) ).not.toHaveClass(
+				'is-small'
+			);
+			expect( screen.getByRole( 'button' ) ).toHaveClass( 'is-compact' );
+		} );
 	} );
 
 	describe( 'static typing', () => {

--- a/packages/components/src/button/test/index.tsx
+++ b/packages/components/src/button/test/index.tsx
@@ -402,6 +402,11 @@ describe( 'Button', () => {
 			);
 			expect( console ).toHaveWarned();
 		} );
+
+		it( 'should not break when the legacy isSmall prop is passed', () => {
+			render( <Button isSmall /> );
+			expect( screen.getByRole( 'button' ) ).toHaveClass( 'is-small' );
+		} );
 	} );
 
 	describe( 'static typing', () => {

--- a/packages/components/src/button/types.ts
+++ b/packages/components/src/button/types.ts
@@ -67,6 +67,10 @@ type BaseButtonProps = {
 	isPressed?: boolean;
 	/**
 	 * Decreases the size of the button.
+	 *
+	 * Deprecated in favor of the `size` prop.
+	 *
+	 * @deprecated Use the `'small'` value on the `size` prop instead.
 	 */
 	isSmall?: boolean;
 	/**
@@ -83,6 +87,16 @@ type BaseButtonProps = {
 	 * If provided, renders a Tooltip component for the button.
 	 */
 	showTooltip?: boolean;
+	/**
+	 * The size of the button.
+	 *
+	 * - `'default'`: For normal text-label buttons, unless it is a toggle button.
+	 * - `'compact'`: For toggle buttons and icon buttons.
+	 * - `'small'`: For icon buttons associated with more advanced or auxiliary features.
+	 *
+	 * @default 'default'
+	 */
+	size?: 'default' | 'compact' | 'small';
 	/**
 	 * If provided, displays the given text inside the button. If the button contains children elements, the text is displayed before them.
 	 */

--- a/packages/components/src/button/types.ts
+++ b/packages/components/src/button/types.ts
@@ -69,7 +69,7 @@ type BaseButtonProps = {
 	/**
 	 * Decreases the size of the button.
 	 *
-	 * Deprecated in favor of the `size` prop.
+	 * Deprecated in favor of the `size` prop. If both props are defined, the `size` prop will take precedence.
 	 *
 	 * @deprecated Use the `'small'` value on the `size` prop instead.
 	 */
@@ -94,6 +94,8 @@ type BaseButtonProps = {
 	 * - `'default'`: For normal text-label buttons, unless it is a toggle button.
 	 * - `'compact'`: For toggle buttons, icon buttons, and buttons when used in context of either.
 	 * - `'small'`: For icon buttons associated with more advanced or auxiliary features.
+	 *
+	 * If the deprecated `isSmall` prop is also defined, this prop will take precedence.
 	 *
 	 * @default 'default'
 	 */

--- a/packages/components/src/button/types.ts
+++ b/packages/components/src/button/types.ts
@@ -92,7 +92,7 @@ type BaseButtonProps = {
 	 * The size of the button.
 	 *
 	 * - `'default'`: For normal text-label buttons, unless it is a toggle button.
-	 * - `'compact'`: For toggle buttons and icon buttons.
+	 * - `'compact'`: For toggle buttons, icon buttons, and buttons when used in context of either.
 	 * - `'small'`: For icon buttons associated with more advanced or auxiliary features.
 	 *
 	 * @default 'default'

--- a/packages/components/src/button/types.ts
+++ b/packages/components/src/button/types.ts
@@ -26,15 +26,6 @@ type BaseButtonProps = {
 	 */
 	__next40pxDefaultSize?: boolean;
 	/**
-	 * Start opting into the larger `isSmall` button size that will become the
-	 * default small size in a future version.
-	 *
-	 * Only takes effect when the `isSmall` prop is `true`.
-	 *
-	 * @default false
-	 */
-	__next32pxSmallSize?: boolean;
-	/**
 	 * The button's children.
 	 */
 	children?: ReactNode;

--- a/packages/components/src/button/types.ts
+++ b/packages/components/src/button/types.ts
@@ -65,6 +65,7 @@ type BaseButtonProps = {
 	 * Renders a pressed button style.
 	 */
 	isPressed?: boolean;
+	// TODO: Deprecate officially (add console warning and move to DeprecatedButtonProps).
 	/**
 	 * Decreases the size of the button.
 	 *

--- a/packages/components/src/font-size-picker/index.tsx
+++ b/packages/components/src/font-size-picker/index.tsx
@@ -14,6 +14,7 @@ import { useState, useMemo, forwardRef } from '@wordpress/element';
 /**
  * Internal dependencies
  */
+import { Button } from '../button';
 import RangeControl from '../range-control';
 import { Flex, FlexItem } from '../flex';
 import {
@@ -31,7 +32,6 @@ import {
 	HeaderLabel,
 	HeaderToggle,
 	Controls,
-	ResetButton,
 } from './styles';
 import { Spacer } from '../spacer';
 import FontSizePickerSelect from './font-size-picker-select';
@@ -268,17 +268,21 @@ const UnforwardedFontSizePicker = (
 						) }
 						{ withReset && (
 							<FlexItem>
-								<ResetButton
+								<Button
 									disabled={ value === undefined }
 									onClick={ () => {
 										onChange?.( undefined );
 									} }
-									isSmall
 									variant="secondary"
-									size={ size }
+									__next40pxDefaultSize
+									size={
+										size !== '__unstable-large'
+											? 'small'
+											: 'default'
+									}
 								>
 									{ __( 'Reset' ) }
-								</ResetButton>
+								</Button>
 							</FlexItem>
 						) }
 					</Flex>

--- a/packages/components/src/font-size-picker/styles.ts
+++ b/packages/components/src/font-size-picker/styles.ts
@@ -11,7 +11,6 @@ import Button from '../button';
 import { HStack } from '../h-stack';
 import { space } from '../ui/utils/space';
 import { COLORS } from '../utils';
-import type { FontSizePickerProps } from './types';
 
 export const Container = styled.fieldset`
 	border: 0;
@@ -43,13 +42,4 @@ export const Controls = styled.div< {
 } >`
 	${ ( props ) =>
 		! props.__nextHasNoMarginBottom && `margin-bottom: ${ space( 6 ) };` }
-`;
-
-export const ResetButton = styled( Button )< {
-	size: FontSizePickerProps[ 'size' ];
-} >`
-	&&& {
-		height: ${ ( props ) =>
-			props.size === '__unstable-large' ? '40px' : '30px' };
-	}
 `;

--- a/packages/components/src/number-control/index.tsx
+++ b/packages/components/src/number-control/index.tsx
@@ -16,7 +16,7 @@ import deprecated from '@wordpress/deprecated';
 /**
  * Internal dependencies
  */
-import { Input, SpinButton } from './styles/number-control-styles';
+import { Input, SpinButton, styles } from './styles/number-control-styles';
 import * as inputControlActionTypes from '../input-control/reducer/actions';
 import { add, subtract, roundClamp } from '../utils/math';
 import { ensureNumber, isValueEmpty } from '../utils/values';
@@ -24,6 +24,7 @@ import type { WordPressComponentProps } from '../ui/context/wordpress-component'
 import type { NumberControlProps } from './types';
 import { HStack } from '../h-stack';
 import { Spacer } from '../spacer';
+import { useCx } from '../utils';
 
 const noop = () => {};
 
@@ -78,6 +79,8 @@ function UnforwardedNumberControl(
 
 	const autoComplete = typeProp === 'number' ? 'off' : undefined;
 	const classes = classNames( 'components-number-control', className );
+	const cx = useCx();
+	const spinButtonClasses = cx( size === 'small' && styles.smallSpinButtons );
 
 	const spinValue = (
 		value: string | number | undefined,
@@ -236,6 +239,7 @@ function UnforwardedNumberControl(
 						<Spacer marginBottom={ 0 } marginRight={ 2 }>
 							<HStack spacing={ 1 }>
 								<SpinButton
+									className={ spinButtonClasses }
 									icon={ plusIcon }
 									isSmall
 									aria-hidden="true"
@@ -244,9 +248,9 @@ function UnforwardedNumberControl(
 									onClick={ buildSpinButtonClickHandler(
 										'up'
 									) }
-									spinButtonSize={ size }
 								/>
 								<SpinButton
+									className={ spinButtonClasses }
 									icon={ resetIcon }
 									isSmall
 									aria-hidden="true"
@@ -255,7 +259,6 @@ function UnforwardedNumberControl(
 									onClick={ buildSpinButtonClickHandler(
 										'down'
 									) }
-									spinButtonSize={ size }
 								/>
 							</HStack>
 						</Spacer>

--- a/packages/components/src/number-control/index.tsx
+++ b/packages/components/src/number-control/index.tsx
@@ -244,7 +244,7 @@ function UnforwardedNumberControl(
 									onClick={ buildSpinButtonClickHandler(
 										'up'
 									) }
-									size={ size }
+									spinButtonSize={ size }
 								/>
 								<SpinButton
 									icon={ resetIcon }
@@ -255,7 +255,7 @@ function UnforwardedNumberControl(
 									onClick={ buildSpinButtonClickHandler(
 										'down'
 									) }
-									size={ size }
+									spinButtonSize={ size }
 								/>
 							</HStack>
 						</Spacer>

--- a/packages/components/src/number-control/styles/number-control-styles.ts
+++ b/packages/components/src/number-control/styles/number-control-styles.ts
@@ -11,7 +11,6 @@ import InputControl from '../../input-control';
 import { COLORS } from '../../utils';
 import Button from '../../button';
 import { space } from '../../ui/utils/space';
-import type { NumberControlProps } from '../types';
 
 const htmlArrowStyles = ( { hideHTMLArrows }: { hideHTMLArrows: boolean } ) => {
 	if ( ! hideHTMLArrows ) {
@@ -35,25 +34,16 @@ export const Input = styled( InputControl )`
 	${ htmlArrowStyles };
 `;
 
-const spinButtonSizeStyles = ( {
-	spinButtonSize,
-}: {
-	spinButtonSize: NumberControlProps[ 'size' ];
-} ) => {
-	if ( spinButtonSize !== 'small' ) {
-		return ``;
-	}
-
-	return css`
-		width: ${ space( 5 ) };
-		min-width: ${ space( 5 ) };
-		height: ${ space( 5 ) };
-	`;
-};
-
 export const SpinButton = styled( Button )`
 	&&&&& {
 		color: ${ COLORS.ui.theme };
-		${ spinButtonSizeStyles }
 	}
 `;
+
+const smallSpinButtons = css`
+	width: ${ space( 5 ) };
+	min-width: ${ space( 5 ) };
+	height: ${ space( 5 ) };
+`;
+
+export const styles = { smallSpinButtons };

--- a/packages/components/src/number-control/styles/number-control-styles.ts
+++ b/packages/components/src/number-control/styles/number-control-styles.ts
@@ -36,9 +36,11 @@ export const Input = styled( InputControl )`
 `;
 
 const spinButtonSizeStyles = ( {
-	size,
-}: Pick< NumberControlProps, 'size' > ) => {
-	if ( size !== 'small' ) {
+	spinButtonSize,
+}: {
+	spinButtonSize: NumberControlProps[ 'size' ];
+} ) => {
+	if ( spinButtonSize !== 'small' ) {
 		return ``;
 	}
 


### PR DESCRIPTION
Closes #51708
Part of #46741

## What?

Introduces a new `size` prop to the `Button` component where:

* `small` = 24px
* `compact` = 32px
* `default` = 40px when `__next40pxDefaultSize = true`, otherwise 36px

## Why?

After some investigation and discussion in #51708, it became clear that Button still needs three size variants, at least for the time being.

## How?

- Reverts the changes in #51012 (basically retracts the `__next32pxSmallSize` prop that I added there)
- NumberControl: Fixes a prop name conflict by renaming (no visual changes)
- FontSizePicker: Fixes a prop name conflict by simplifying the reset button

## Testing Instructions

1. `npm run storybook:dev`
2. Check the `size` variants in the `Button` story. The `__next40pxDefaultSize` prop should only affect the `size = 'default'` case. The `isSmall` prop should still work.

## Screenshots or screencast <!-- if applicable -->

### Default
<img src="https://github.com/WordPress/gutenberg/assets/555336/3846b35e-c84d-4399-9dd9-882e2b8a634a" alt="Buttons at default size" width="179">

### Default with `__next40pxDefaultSize`
<img src="https://github.com/WordPress/gutenberg/assets/555336/aee62a40-ff1b-4658-9e6d-5fffadfc5687" alt="Buttons at default size (40px)" width="179">

### Compact
<img src="https://github.com/WordPress/gutenberg/assets/555336/9e1b72d6-5c84-4cef-89ab-00b22630d44a" alt="Buttons at compact size" width="179">

### Small
<img src="https://github.com/WordPress/gutenberg/assets/555336/aac442cb-75c0-47be-9725-738a7f02bb36" alt="Buttons at small size" width="179">
