### PR TITLE
Update text color of site editor menu item hover/active states

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-item/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-item/style.scss
@@ -9,7 +9,7 @@
 	&:hover,
 	&:focus,
 	&[aria-current] {
-		color: $white;
+		color: $gray-200;
 		background: $gray-800;
 	}
 


### PR DESCRIPTION
## Why?
To bring production in line with the latest designs which stipulate the use of three text colors in the sidebar:

* $gray-200 for most visible (e.g. hovered menu items, headings, data values in page details)
* $gray-400 for regular prominence (e.g. sub-headings, panel description)
* $gray-600 for lowest prominence, meets 4.5:1 contrast requirement (e.g. help text on inputs, detail labels)

This change will hopefully help with component theming down the road, where colors that fit into a particular scale will likely be desirable vs pure black / white.

## Testing Instructions
* Open the site Editor and hover a menu item
* Notice the text color is #e0e0e0 rather than #fff.

| Before | After |
| --- | --- |
| <img width="360" alt="Screenshot 2023-06-23 at 13 39 04" src="https://github.com/WordPress/gutenberg/assets/846565/9f89b490-7dc2-4fc3-99fc-8f70d1592618"> | <img width="359" alt="Screenshot 2023-06-23 at 13 38 49" src="https://github.com/WordPress/gutenberg/assets/846565/ae1e968a-5869-46b1-9495-67e4d31e9ac6"> |
