### PR TITLE
Update active item appearance in Library

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen-library/category-item.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-library/category-item.js
@@ -35,7 +35,7 @@ export default function CategoryItem( {
 			{ ...linkInfo }
 			icon={ icon }
 			suffix={ <span>{ count }</span> }
-			className={ isActive ? 'is-active-category' : undefined }
+			aria-current={ isActive ? 'true' : undefined }
 		>
 			{ label }
 		</SidebarNavigationItem>

--- a/packages/edit-site/src/components/sidebar-navigation-screen-library/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-library/style.scss
@@ -4,4 +4,5 @@
 
 .edit-site-sidebar-navigation-item.is-active-category {
 	background: $gray-800;
+	color: $gray-200;
 }

--- a/packages/edit-site/src/components/sidebar-navigation-screen-library/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-library/style.scss
@@ -1,8 +1,3 @@
 .edit-site-sidebar-navigation-screen-library__group {
 	margin-bottom: $grid-unit-30;
 }
-
-.edit-site-sidebar-navigation-item.is-active-category {
-	background: $gray-800;
-	color: $gray-200;
-}


### PR DESCRIPTION
## What?
This PR does two things:

1. Fixes an issue with the active state of the initially-selected in the Library, where the text is the wrong color.
2. Makes use of the `aria-current` styling provided by `SidebarNavigationItem` instead of custom css.

## Why?
1. The initial active state isn't consistent with the actual active state. You'll notice when you open the Library the Headers menu item in the sidebar has text color `#949494`, but if you click it then the text takes on the correct color.
2. Custom css is harder to maintain in the long run. It makes sense to use the affordances supplied by the component.
3. The active state should be different to the hover state

## Testing Instructions
* Open the Library
* Notice the Headers menu item has `aria-current` and the associated styling


| Before | After |
| --- | --- |
| <img width="359" alt="Screenshot 2023-06-23 at 13 53 25" src="https://github.com/WordPress/gutenberg/assets/846565/46e71a85-3ceb-4329-ad11-b3de94a3fbc6"> | <img width="357" alt="Screenshot 2023-06-23 at 13 52 56" src="https://github.com/WordPress/gutenberg/assets/846565/2ae983a3-28d4-4b33-be17-7ef248e87233"> |

## Note on styling

The styling (blue background) is already part of the `SidebarNavigationItem` component. As far as I know the active state isn't used in any other panel yet, so if we'd like to change the blue to something else it should be safe to do that here. 


