### PR TITLE
Docs: Fix sample code by adding JSX fragment

### DIFF
--- a/packages/components/src/popover/README.md
+++ b/packages/components/src/popover/README.md
@@ -45,17 +45,19 @@ const MyPopover = () => {
 	};
 
 	return (
-		<p ref={ setPopoverAnchor }>Popover s anchor</p>
-		<Button variant="secondary" onClick={ toggleVisible }>
-			Toggle Popover!
-		</Button>
-		{ isVisible && (
-			<Popover
-				anchor={ popoverAnchor }
-			>
-				Popover is toggled!
-			</Popover>
-		) }
+		<div>
+			<p ref={ setPopoverAnchor }>Popover s anchor</p>
+			<Button variant="secondary" onClick={ toggleVisible }>
+				Toggle Popover!
+			</Button>
+			{ isVisible && (
+				<Popover
+					anchor={ popoverAnchor }
+				>
+					Popover is toggled!
+				</Popover>
+			) }
+		<div/>
 	);
 };
 ```


### PR DESCRIPTION
## What?
sample code by adding JSX fragment

## Why?
Adjacent JSX elements must be wrapped in an enclosing tag.
