### PR TITLE
Add view patterns plural label.

### DIFF
--- a/lib/compat/wordpress-6.3/blocks.php
+++ b/lib/compat/wordpress-6.3/blocks.php
@@ -47,6 +47,7 @@ function gutenberg_rename_reusable_block_cpt_to_pattern( $args, $post_type ) {
 		$args['labels']['new_item']                 = __( 'New Pattern' );
 		$args['labels']['edit_item']                = __( 'Edit Pattern' );
 		$args['labels']['view_item']                = __( 'View Pattern' );
+		$args['labels']['view_items']               = __( 'View Patterns' );
 		$args['labels']['all_items']                = __( 'All Patterns' );
 		$args['labels']['search_items']             = __( 'Search Patterns' );
 		$args['labels']['not_found']                = __( 'No Patterns found.' );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
https://github.com/WordPress/gutenberg/pull/51144 renamed Reusable blocks to Patterns. Amongst other things, it uses a filter to rename the `wp_block` post type labels. I assume this renaming should be then implemented directly in core.
Anyways, it missed to add the `view_items` (plural) label.
This label is used when editing a pattern in the editor: the site icon on the top left has an aria-label (and tooltip) that uses the view_items label

Cc @glendaviesnz 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The current label / tooltip say: `View Reusable blocks` instead of `View patterns`.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Adds the missing label.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

Before thie PR:
- Create a Pattern.
- In the Post Editor, click Options > Manage patterns
- You are now in the Patterns admin page at `/wp-admin/edit.php?post_type=wp_block`
- Edit your pattern.
- In the Editor, hover the site icon on the top left.
- Observe a tooltip appears with text `View Reusable blocks'.

<img width="1148" alt="Screenshot 2023-06-23 at 14 39 44" src="https://github.com/WordPress/gutenberg/assets/1682452/35aa2eb9-e690-45f7-bf96-08700f7cc8e6">

- Click the site icon.
- Observe you're now in a page named 'Patterns'.

<img width="945" alt="Screenshot 2023-06-23 at 14 39 50" src="https://github.com/WordPress/gutenberg/assets/1682452/1c99d0eb-57cf-4142-ae7c-83f3f944a5f5">

- Switch to this branch and build.
- Repeat the steps above.
- Observe the site icon tooltip is now 'View Patterns'.


### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
