### PR TITLE
Site Editor: Disable the revision button if there is no clickable menu

### DIFF
--- a/packages/edit-site/src/components/global-styles/ui.js
+++ b/packages/edit-site/src/components/global-styles/ui.js
@@ -11,6 +11,7 @@ import {
 	__experimentalNavigatorScreen as NavigatorScreen,
 	__experimentalUseNavigator as useNavigator,
 	createSlotFill,
+	Button,
 	DropdownMenu,
 	MenuGroup,
 	MenuItem,
@@ -142,33 +143,42 @@ function GlobalStylesRevisionsMenu() {
 
 	return (
 		<GlobalStylesMenuFill>
-			<DropdownMenu icon={ backup } label={ __( 'Revisions' ) }>
-				{ ( { onClose } ) => (
-					<MenuGroup>
-						{ hasRevisions && (
+			{ canReset || hasRevisions ? (
+				<DropdownMenu icon={ backup } label={ __( 'Revisions' ) }>
+					{ ( { onClose } ) => (
+						<MenuGroup>
+							{ hasRevisions && (
+								<MenuItem
+									onClick={ loadRevisions }
+									icon={
+										<RevisionsCountBadge>
+											{ revisionsCount }
+										</RevisionsCountBadge>
+									}
+								>
+									{ __( 'Revision history' ) }
+								</MenuItem>
+							) }
 							<MenuItem
-								onClick={ loadRevisions }
-								icon={
-									<RevisionsCountBadge>
-										{ revisionsCount }
-									</RevisionsCountBadge>
-								}
+								onClick={ () => {
+									onReset();
+									onClose();
+								} }
+								disabled={ ! canReset }
 							>
-								{ __( 'Revision history' ) }
+								{ __( 'Reset to defaults' ) }
 							</MenuItem>
-						) }
-						<MenuItem
-							onClick={ () => {
-								onReset();
-								onClose();
-							} }
-							disabled={ ! canReset }
-						>
-							{ __( 'Reset to defaults' ) }
-						</MenuItem>
-					</MenuGroup>
-				) }
-			</DropdownMenu>
+						</MenuGroup>
+					) }
+				</DropdownMenu>
+			) : (
+				<Button
+					label={ __( 'Revisions' ) }
+					icon={ backup }
+					disabled
+					__experimentalIsFocusable
+				/>
+			) }
 		</GlobalStylesMenuFill>
 	);
 }


### PR DESCRIPTION
Fixes: #51846

## What?
This PR disables the revision button if there is no clickable menu in Site Editor.

![disabled-button](https://github.com/WordPress/gutenberg/assets/54422211/9bb66bee-844f-48a2-90e7-3c726588c69f)

## Why?

If the global style has no revisions and is in its default state, only an inactive button "Reset to defaults" will be displayed. Since this element is not focusable, the popover cannot be closed by clicking outside the popover unless the popover is clicked once. Also, if there is no menu available, I don't think the dropdown menu should be displayed.

## How?

If the global style does not have a revision and is in its default state, the inactive `Button` component is displayed instead of the `DropdownMenu` component.

## Testing Instructions

- You may want to rebuild wp-env to reset the revisions. Alternatively, a plugin such as [Optimize Database after Deleting Revisions](https://wordpress.org/plugins/rvg-optimize-database/) can also delete revisions.
- Go to the Style panel in the Site Editor.
- The Revision button should be inactive.
- Make changes to the global style. (Do not save.)
- When you press the revision button, you will see that only the "Reset to defaults" menu is available.
- Make changes to the global style and save. Repeat a couple of times.
- Press the Revision button and confirm that the "Revision History" and "Reset to defaults" menus are available.
- Click on "Reset to defaults".
- After pressing the revision button, the "Reset to defaults" menu should be deactivated.

### Testing Instructions for Keyboard

Testing Instructions should be able to be performed using only the keyboard.

## Screenshots or screencast

https://github.com/WordPress/gutenberg/assets/54422211/c21e0ad8-ac23-441c-ae50-a787c8bd118e

## About E2e Test

I wanted to add an E2E test to test the revision button in its initial state. To do this, I need to delete all revisions once. However, currently the REST API does not seem to allow me to delete global style revisions.

![rest-api](https://github.com/WordPress/gutenberg/assets/54422211/c0bd839d-365f-4267-8e9f-784a9baab69a)
