### PR TITLE
Move view site button next to site title

### DIFF
--- a/packages/edit-site/src/components/site-hub/index.js
+++ b/packages/edit-site/src/components/site-hub/index.js
@@ -154,20 +154,20 @@ const SiteHub = forwardRef( ( props, ref ) => {
 							} }
 						>
 							{ decodeEntities( siteTitle ) }
+							{ canvasMode === 'view' && (
+								<Button
+									href={ homeUrl }
+									target="_blank"
+									label={ __( 'View site' ) }
+									aria-label={ __(
+										'View site (opens in a new tab)'
+									) }
+									icon={ external }
+									className="edit-site-site-hub__site-view-link"
+								/>
+							) }
 						</motion.div>
 					</AnimatePresence>
-					{ canvasMode === 'view' && (
-						<Button
-							href={ homeUrl }
-							target="_blank"
-							label={ __( 'View site' ) }
-							aria-label={ __(
-								'View site (opens in a new tab)'
-							) }
-							icon={ external }
-							className="edit-site-site-hub__site-view-link"
-						/>
-					) }
 				</HStack>
 				{ canvasMode === 'view' && (
 					<Button

--- a/packages/edit-site/src/components/site-hub/style.scss
+++ b/packages/edit-site/src/components/site-hub/style.scss
@@ -7,27 +7,6 @@
 	.edit-site-site-hub__container {
 		gap: 0;
 	}
-
-	.edit-site-site-hub__site-view-link {
-		flex-grow: 0;
-		@include break-mobile() {
-			opacity: 0;
-			transition: opacity 0.2s ease-in-out;
-		}
-		&:focus {
-			outline: none;
-			box-shadow: none;
-			opacity: 1;
-		}
-		svg {
-			fill: $white;
-		}
-	}
-	&:hover {
-		.edit-site-site-hub__site-view-link {
-			opacity: 1;
-		}
-	}
 }
 
 .edit-site-site-hub__post-type {
@@ -53,8 +32,35 @@
 }
 
 .edit-site-site-hub__site-title {
+	display: flex;
+	align-items: center;
 	margin-left: $grid-unit-05;
+	gap: $grid-unit-05;
 	flex-grow: 1;
+
+	&:hover {
+		.edit-site-site-hub__site-view-link {
+			opacity: 1;
+		}
+	}
+}
+
+.edit-site-site-hub__site-view-link {
+	flex-grow: 0;
+	@include break-mobile() {
+		opacity: 0;
+		transition: opacity 0.1s ease-in-out;
+	}
+
+	&:focus {
+		outline: none;
+		box-shadow: none;
+		opacity: 1;
+	}
+
+	svg {
+		fill: $white;
+	}
 }
 
 .edit-site-site-hub_toggle-command-center {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
An alternative at the placement of the external link within the site hub. 

Other follow-ups could be to make the site title a link itself, and perhaps reduce the externalLink icon to only show up when hovering the site title itself. 


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open the Site Editor.
2. Hover over the site hub area. 
3. See changes. 

## Screenshots or screencast <!-- if applicable -->

### Before: 
https://github.com/WordPress/gutenberg/assets/1813435/7718141e-8a02-4651-92fd-6e70e40df888

### After: 
https://github.com/WordPress/gutenberg/assets/1813435/91796453-a5ab-401e-9b28-d0dfff4650c8
