### PR TITLE
Add examples for core/block-editor selectors and actions

### DIFF
--- a/docs/reference-guides/data/data-core-block-editor.md
+++ b/docs/reference-guides/data/data-core-block-editor.md
@@ -202,6 +202,28 @@ _Returns_
 
 Determines if the given block is allowed to be deleted.
 
+_Usage_
+
+```js
+import { store as blockEditorStore } from '@wordpress/block-editor';
+import { useSelect } from '@wordpress/data';
+const ExampleComponent = () => {
+	const { canRemoveBlock, getBlocks } = useSelect(
+		( select ) => select( blockEditorStore ),
+		[]
+	);
+
+	// Get all the blocks in the editor.
+	const availableBlocks = getBlocks();
+
+	return canRemoveBlock( availableBlocks[ 0 ]?.clientId ) ? (
+		<p>{ __( 'Blocks is removable.' ) }</p>
+	) : (
+		<p>{ __( 'Blocks is NOT removable.' ) }</p>
+	);
+};
+```
+
 _Parameters_
 
 -   _state_ `Object`: Editor state.
@@ -216,10 +238,36 @@ _Returns_
 
 Determines if the given blocks are allowed to be removed.
 
+_Usage_
+
+```js
+const ExampleComponent = () => {
+	const { canRemoveBlocks, getBlocks } = useSelect(
+		( select ) => select( blockEditorStore ),
+		[]
+	);
+
+	// Get all the blocks in the editor.
+	const availableBlocks = getBlocks();
+
+	// Define the list of blocks to check.
+	const blocksToCheck = [
+		availableBlocks[ 0 ]?.clientId,
+		availableBlocks[ 1 ]?.clientId,
+	];
+
+	return canRemoveBlocks( blocksToCheck ) ? (
+		<p>{ __( 'Blocks are removable.' ) }</p>
+	) : (
+		<p>{ __( 'Blocks are NOT removable.' ) }</p>
+	);
+};
+```
+
 _Parameters_
 
 -   _state_ `Object`: Editor state.
--   _clientIds_ `string`: The block client IDs to be removed.
+-   _clientIds_ `Array`: The block client IDs to be removed.
 -   _rootClientId_ `?string`: Optional root client ID of block list.
 
 _Returns_

--- a/docs/reference-guides/data/data-core-block-editor.md
+++ b/docs/reference-guides/data/data-core-block-editor.md
@@ -19,8 +19,9 @@ import { store as blockEditorStore } from '@wordpress/block-editor';
 import { useSelect } from '@wordpress/data';
 
 const ExampleComponent = () => {
-	const { areInnerBlocksControlled, getBlocks } = useSelect( ( select ) =>
-		select( blockEditorStore )
+	const { areInnerBlocksControlled, getBlocks } = useSelect(
+		( select ) => select( blockEditorStore ),
+		[]
 	);
 
 	// Retrieve the clientId of the block to check.
@@ -54,8 +55,9 @@ import { store as blockEditorStore } from '@wordpress/block-editor';
 import { useSelect } from '@wordpress/data';
 
 const ExampleComponent = () => {
-	const { canEditBlock, getBlocks } = useSelect( ( select ) =>
-		select( blockEditorStore )
+	const { canEditBlock, getBlocks } = useSelect(
+		( select ) => select( blockEditorStore ),
+		[]
 	);
 
 	// Retrieve the clientId of the block to check.

--- a/docs/reference-guides/data/data-core-block-editor.md
+++ b/docs/reference-guides/data/data-core-block-editor.md
@@ -125,6 +125,29 @@ _Returns_
 
 Determines if the given block is allowed to be moved.
 
+_Usage_
+
+```js
+import { store as blockEditorStore } from '@wordpress/block-editor';
+import { useSelect } from '@wordpress/data';
+
+const ExampleComponent = () => {
+	const { canMoveBlock, getBlocks } = useSelect(
+		( select ) => select( blockEditorStore ),
+		[]
+	);
+
+	// Retrieve the clientId of the block to check.
+	const blockToCheck = getBlocks()[ 0 ]?.clientId;
+
+	return canMoveBlock( blockToCheck ) ? (
+		<p>{ __( 'Block is movable.' ) }</p>
+	) : (
+		<p>{ __( 'Block is NOT moveable.' ) }</p>
+	);
+};
+```
+
 _Parameters_
 
 -   _state_ `Object`: Editor state.
@@ -139,10 +162,36 @@ _Returns_
 
 Determines if the given blocks are allowed to be moved.
 
+_Usage_
+
+```js
+const ExampleComponent = () => {
+	const { canMoveBlocks, getBlocks } = useSelect(
+		( select ) => select( blockEditorStore ),
+		[]
+	);
+
+	// Get all the blocks in the editor.
+	const availableBlocks = getBlocks();
+
+	// Define the list of blocks to check.
+	const blocksToCheck = [
+		availableBlocks[ 0 ]?.clientId,
+		availableBlocks[ 1 ]?.clientId,
+	];
+
+	return canMoveBlocks( blocksToCheck ) ? (
+		<p>{ __( 'Blocks are movable.' ) }</p>
+	) : (
+		<p>{ __( 'Blocks are NOT moveable.' ) }</p>
+	);
+};
+```
+
 _Parameters_
 
 -   _state_ `Object`: Editor state.
--   _clientIds_ `string`: The block client IDs to be moved.
+-   _clientIds_ `Array`: The block client IDs to be moved.
 -   _rootClientId_ `?string`: Optional root client ID of block list.
 
 _Returns_

--- a/docs/reference-guides/data/data-core-block-editor.md
+++ b/docs/reference-guides/data/data-core-block-editor.md
@@ -10,6 +10,30 @@ Namespace: `core/block-editor`.
 
 Checks if a given block has controlled inner blocks.
 
+An example of an inner block controller is a template part block, which provides its own blocks from the template part entity data source.
+
+_Usage_
+
+```js
+import { store as blockEditorStore } from '@wordpress/block-editor';
+import { useSelect } from '@wordpress/data';
+
+const ExampleComponent = () => {
+	const { areInnerBlocksControlled, getBlocks } = useSelect( ( select ) =>
+		select( blockEditorStore )
+	);
+
+	// Retrieve the clientId of the block to check.
+	const blockToCheck = getBlocks()[ 0 ]?.clientId;
+
+	return areInnerBlocksControlled( blockToCheck ) ? (
+		<p>{ __( 'Inner blocks are controlled' ) }</p>
+	) : (
+		<p>{ __( 'Inner blocks are NOT controlled' ) }</p>
+	);
+};
+```
+
 _Parameters_
 
 -   _state_ `Object`: Global application state.

--- a/docs/reference-guides/data/data-core-block-editor.md
+++ b/docs/reference-guides/data/data-core-block-editor.md
@@ -47,6 +47,28 @@ _Returns_
 
 Determines if the given block is allowed to be edited.
 
+_Usage_
+
+```js
+import { store as blockEditorStore } from '@wordpress/block-editor';
+import { useSelect } from '@wordpress/data';
+
+const ExampleComponent = () => {
+	const { canEditBlock, getBlocks } = useSelect( ( select ) =>
+		select( blockEditorStore )
+	);
+
+	// Retrieve the clientId of the block to check.
+	const blockToCheck = getBlocks()[ 0 ]?.clientId;
+
+	return canEditBlock( blockToCheck?.clientId ) ? (
+		<p>{ __( 'Block is editable.' ) }</p>
+	) : (
+		<p>{ __( 'Block is NOT editable.' ) }</p>
+	);
+};
+```
+
 _Parameters_
 
 -   _state_ `Object`: Editor state.

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -2700,8 +2700,32 @@ export function isBlockHighlighted( state, clientId ) {
 /**
  * Checks if a given block has controlled inner blocks.
  *
+ * An example of an inner block controller is a template part block, which provides
+ * its own blocks from the template part entity data source.
+ *
  * @param {Object} state    Global application state.
  * @param {string} clientId The block to check.
+ *
+ * @example
+ * ```js
+ * import { store as blockEditorStore } from '@wordpress/block-editor';
+ * import { useSelect } from '@wordpress/data';
+ *
+ * const ExampleComponent = () => {
+ *     const { areInnerBlocksControlled, getBlocks } = useSelect( ( select ) =>
+ *         select( blockEditorStore )
+ *     );
+ *
+ *    // Retrieve the clientId of the block to check.
+ *    const blockToCheck = getBlocks()[ 0 ]?.clientId;
+ *
+ *    return areInnerBlocksControlled( blockToCheck ) ? (
+ *        <p>{ __( 'Inner blocks are controlled' ) }</p>
+ *    ) : (
+ *        <p>{ __( 'Inner blocks are NOT controlled' ) }</p>
+ *    );
+ * };
+ * ```
  *
  * @return {boolean} True if the block has controlled inner blocks.
  */

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1764,8 +1764,9 @@ export function canMoveBlocks( state, clientIds, rootClientId = null ) {
  * import { useSelect } from '@wordpress/data';
  *
  * const ExampleComponent = () => {
- *     const { canEditBlock, getBlocks } = useSelect( ( select ) =>
- *        select( blockEditorStore )
+ *     const { canEditBlock, getBlocks } = useSelect(
+ *         ( select ) => select( blockEditorStore ),
+ *         []
  *     );
  *
  *     // Retrieve the clientId of the block to check.
@@ -2733,8 +2734,9 @@ export function isBlockHighlighted( state, clientId ) {
  * import { useSelect } from '@wordpress/data';
  *
  * const ExampleComponent = () => {
- *     const { areInnerBlocksControlled, getBlocks } = useSelect( ( select ) =>
- *         select( blockEditorStore )
+ *     const { areInnerBlocksControlled, getBlocks } = useSelect(
+ *         ( select ) => select( blockEditorStore ),
+ *         []
  *     );
  *
  *    // Retrieve the clientId of the block to check.

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1681,6 +1681,27 @@ export function canInsertBlocks( state, clientIds, rootClientId = null ) {
  * @param {string}  clientId     The block client Id.
  * @param {?string} rootClientId Optional root client ID of block list.
  *
+ * @example
+ * ```js
+ * import { store as blockEditorStore } from '@wordpress/block-editor';
+ * import { useSelect } from '@wordpress/data';
+ * const ExampleComponent = () => {
+ *    const { canRemoveBlock, getBlocks } = useSelect(
+ *        ( select ) => select( blockEditorStore ),
+ *        []
+ *    );
+ *
+ *    // Get all the blocks in the editor.
+ *    const availableBlocks = getBlocks();
+ *
+ *    return canRemoveBlock( availableBlocks[ 0 ]?.clientId ) ? (
+ *        <p>{ __( 'Blocks is removable.' ) }</p>
+ *    ) : (
+ *        <p>{ __( 'Blocks is NOT removable.' ) }</p>
+ *    );
+ * };
+ * ```
+ *
  * @return {boolean} Whether the given block is allowed to be removed.
  */
 export function canRemoveBlock( state, clientId, rootClientId = null ) {
@@ -1702,8 +1723,33 @@ export function canRemoveBlock( state, clientId, rootClientId = null ) {
  * Determines if the given blocks are allowed to be removed.
  *
  * @param {Object}  state        Editor state.
- * @param {string}  clientIds    The block client IDs to be removed.
+ * @param {Array}   clientIds    The block client IDs to be removed.
  * @param {?string} rootClientId Optional root client ID of block list.
+ *
+ * @example
+ * ```js
+ * const ExampleComponent = () => {
+ *    const { canRemoveBlocks, getBlocks } = useSelect(
+ *        ( select ) => select( blockEditorStore ),
+ *        []
+ *    );
+ *
+ *    // Get all the blocks in the editor.
+ *    const availableBlocks = getBlocks();
+ *
+ *    // Define the list of blocks to check.
+ *    const blocksToCheck = [
+ *        availableBlocks[ 0 ]?.clientId,
+ *        availableBlocks[ 1 ]?.clientId,
+ *    ];
+ *
+ *    return canRemoveBlocks( blocksToCheck ) ? (
+ *        <p>{ __( 'Blocks are removable.' ) }</p>
+ *    ) : (
+ *        <p>{ __( 'Blocks are NOT removable.' ) }</p>
+ *    );
+ * };
+ * ```
  *
  * @return {boolean} Whether the given blocks are allowed to be removed.
  */

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1720,6 +1720,29 @@ export function canRemoveBlocks( state, clientIds, rootClientId = null ) {
  * @param {string}  clientId     The block client Id.
  * @param {?string} rootClientId Optional root client ID of block list.
  *
+ * @example
+ * ```js
+ * import { store as blockEditorStore } from '@wordpress/block-editor';
+ * import { useSelect } from '@wordpress/data';
+ *
+ * const ExampleComponent = () => {
+ *     const { canMoveBlock, getBlocks } = useSelect(
+ *        ( select ) => select( blockEditorStore ),
+ *        []
+ *     );
+ *
+ *     // Retrieve the clientId of the block to check.
+ *     const blockToCheck = getBlocks()[ 0 ]?.clientId;
+ *
+ *     return canMoveBlock( blockToCheck ) ? (
+ *         <p>{ __( 'Block is movable.' ) }</p>
+ *     ) : (
+ *         <p>{ __( 'Block is NOT moveable.' ) }</p>
+ *     );
+ * };
+ *
+ * ```
+ *
  * @return {boolean | undefined} Whether the given block is allowed to be moved.
  */
 export function canMoveBlock( state, clientId, rootClientId = null ) {
@@ -1741,8 +1764,33 @@ export function canMoveBlock( state, clientId, rootClientId = null ) {
  * Determines if the given blocks are allowed to be moved.
  *
  * @param {Object}  state        Editor state.
- * @param {string}  clientIds    The block client IDs to be moved.
+ * @param {Array}   clientIds    The block client IDs to be moved.
  * @param {?string} rootClientId Optional root client ID of block list.
+ *
+ * @example
+ * ```js
+ * const ExampleComponent = () => {
+ *    const { canMoveBlocks, getBlocks } = useSelect(
+ *        ( select ) => select( blockEditorStore ),
+ *        []
+ *    );
+ *
+ *    // Get all the blocks in the editor.
+ *    const availableBlocks = getBlocks();
+ *
+ *    // Define the list of blocks to check.
+ *    const blocksToCheck = [
+ *        availableBlocks[ 0 ]?.clientId,
+ *        availableBlocks[ 1 ]?.clientId,
+ *    ];
+ *
+ *    return canMoveBlocks( blocksToCheck ) ? (
+ *        <p>{ __( 'Blocks are movable.' ) }</p>
+ *    ) : (
+ *        <p>{ __( 'Blocks are NOT moveable.' ) }</p>
+ *    );
+ * };
+ * ```
  *
  * @return {boolean} Whether the given blocks are allowed to be moved.
  */

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1758,6 +1758,27 @@ export function canMoveBlocks( state, clientIds, rootClientId = null ) {
  * @param {Object} state    Editor state.
  * @param {string} clientId The block client Id.
  *
+ * @example
+ * ```js
+ * import { store as blockEditorStore } from '@wordpress/block-editor';
+ * import { useSelect } from '@wordpress/data';
+ *
+ * const ExampleComponent = () => {
+ *     const { canEditBlock, getBlocks } = useSelect( ( select ) =>
+ *        select( blockEditorStore )
+ *     );
+ *
+ *     // Retrieve the clientId of the block to check.
+ *     const blockToCheck = getBlocks()[ 0 ]?.clientId;
+ *
+ *     return canEditBlock( blockToCheck?.clientId ) ? (
+ *         <p>{ __( 'Block is editable.' ) }</p>
+ *     ) : (
+ *         <p>{ __( 'Block is NOT editable.' ) }</p>
+ *     );
+ * };
+ * ```
+ *
  * @return {boolean} Whether the given block is allowed to be edited.
  */
 export function canEditBlock( state, clientId ) {


### PR DESCRIPTION
## What?
This PR adds selectors and actions for the core/block-editor store as part of #42125