### PR TITLE
Update colors in 'Site view'

### DIFF
--- a/packages/edit-site/src/components/layout/style.scss
+++ b/packages/edit-site/src/components/layout/style.scss
@@ -1,7 +1,7 @@
 .edit-site-layout {
 	height: 100%;
 	background: $gray-900;
-	color: $white;
+	color: $gray-400;
 	display: flex;
 	flex-direction: column;
 

--- a/packages/edit-site/src/components/page-library/style.scss
+++ b/packages/edit-site/src/components/page-library/style.scss
@@ -6,7 +6,7 @@
 	}
 
 	.components-heading {
-		color: $white;
+		color: $gray-200;
 	}
 
 	@include break-medium {
@@ -78,7 +78,7 @@
 .edit-site-library__search {
 	&#{&} input[type="search"] {
 		background: $gray-800;
-		color: $gray-100;
+		color: $gray-200;
 
 		&:focus {
 			background: $gray-800;

--- a/packages/edit-site/src/components/sidebar-button/style.scss
+++ b/packages/edit-site/src/components/sidebar-button/style.scss
@@ -19,6 +19,6 @@
 	&:focus,
 	&:not([aria-disabled="true"]):active,
 	&[aria-expanded="true"] {
-		color: $white;
+		color: $gray-100;
 	}
 }

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/style.scss
@@ -1,10 +1,10 @@
 .sidebar-navigation__more-menu {
 	.components-button {
-		color: $gray-600;
+		color: $gray-200;
 		&:hover,
 		&:focus,
 		&[aria-current] {
-			color: $white;
+			color: $gray-100;
 		}
 	}
 }

--- a/packages/edit-site/src/components/sidebar-navigation-screen/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen/index.js
@@ -90,7 +90,7 @@ export default function SidebarNavigationScreen( {
 					) }
 					<Heading
 						className="edit-site-sidebar-navigation-screen__title"
-						color={ 'white' }
+						color={ '#e0e0e0' /* $gray-200 */ }
 						level={ 1 }
 						size={ 20 }
 					>

--- a/packages/edit-site/src/components/sidebar-navigation-screen/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-screen/style.scss
@@ -12,7 +12,6 @@
 }
 
 .edit-site-sidebar-navigation-screen__content {
-	color: $gray-400;
 	padding: 0 $grid-unit-20;
 
 	.components-item-group {

--- a/packages/edit-site/src/components/site-hub/style.scss
+++ b/packages/edit-site/src/components/site-hub/style.scss
@@ -20,7 +20,7 @@
 			opacity: 1;
 		}
 		svg {
-			fill: $white;
+			fill: $gray-200;
 		}
 	}
 	&:hover {
@@ -55,12 +55,13 @@
 .edit-site-site-hub__site-title {
 	margin-left: $grid-unit-05;
 	flex-grow: 1;
+	color: $gray-200;
 }
 
 .edit-site-site-hub_toggle-command-center {
-	color: $white;
+	color: $gray-200;
 
 	&:hover {
-		color: $white;
+		color: $gray-100;
 	}
 }


### PR DESCRIPTION
This is a comprehensive follow-up to https://github.com/WordPress/gutenberg/pull/51847.

## What?
Update various color declarations in the Site Editor 'site view' (dark material). 

For the most part this means swapping out `$white` values for `$gray-200`, but there are a couple of other changes too:

* Default text color for the dark material (`.edit-site-layout`) is now `$gray-400` rather than `$white`.
* Search input text is now `$gray-200` instead of `$gray-100`.
* Ellipsis button in the Navigation panel is now `$gray-200` instead of `$gray-600`.

## Why?
1. `$gray-200` is preferred to pure white for much the same reasons that `$gray-900` is preferred to pure black in the full screen editor. 
2. Updating the default color for `.edit-site-layout` is important for when third parties begin to extend this area.
3. `$gray-100` for search input text in the Library is unnecessary proliferation. `$gray-200` works fine there.
4. The ellipsis button in the Navigation panel was inconsistent with all other panels, this appears to have been an oversight. 

## How?
Mostly CSS. 

## Testing Instructions
1. Open the Site Editor and browse around the drilldown panels
2. Text / Icons should only be one of three colors (`$gray-200`, `$gray-400`, `$gray-600`).

| Before | After |
| --- | --- |
| <img width="359" alt="Screenshot 2023-06-23 at 16 00 04" src="https://github.com/WordPress/gutenberg/assets/846565/8841e63e-943b-4f4b-85f6-ae4dae769bcf"> | <img width="359" alt="Screenshot 2023-06-23 at 15 59 26" src="https://github.com/WordPress/gutenberg/assets/846565/43c9777d-9651-4099-894e-db6b7dac6d13"> |

The differences are very subtle. This is mostly a matter of tidying up inconsistencies and reducing the number of colors used  overall.


