### PR TITLE
Edit Site: Make loading spinner colors consistent

### DIFF
--- a/packages/edit-site/src/components/canvas-spinner/index.js
+++ b/packages/edit-site/src/components/canvas-spinner/index.js
@@ -2,21 +2,11 @@
  * WordPress dependencies
  */
 import { Spinner } from '@wordpress/components';
-import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
-
-/**
- * Internal dependencies
- */
-import { unlock } from '../../lock-unlock';
-
-const { useGlobalStyle } = unlock( blockEditorPrivateApis );
 
 export default function CanvasSpinner() {
-	const [ textColor ] = useGlobalStyle( 'color.text' );
-
 	return (
 		<div className="edit-site-canvas-spinner">
-			<Spinner style={ { color: textColor } } />
+			<Spinner />
 		</div>
 	);
 }

--- a/packages/edit-site/src/components/canvas-spinner/style.scss
+++ b/packages/edit-site/src/components/canvas-spinner/style.scss
@@ -6,6 +6,6 @@
 	justify-content: center;
 
 	circle {
-		stroke: rgba($black, 0.5);
+		stroke: rgba($black, 0.3);
 	}
 }

--- a/packages/edit-site/src/components/canvas-spinner/style.scss
+++ b/packages/edit-site/src/components/canvas-spinner/style.scss
@@ -4,4 +4,8 @@
 	display: flex;
 	align-items: center;
 	justify-content: center;
+
+	circle {
+		stroke: rgba($black, 0.5);
+	}
 }


### PR DESCRIPTION
## What?
This PR improves the color of the site editor loading spinner to be consistent with the rest of the admin UI. 

Based on the feedback in #51800. Alternative to #51800.

Closes #51800.

## Why?
This updates the loading spinner to be consistent with the rest of the admin UI.

## How?

We're just changing the track indicator color to use the admin blue, and the track background color to be semi-transparent black, as suggested in #51800. 

## Testing Instructions
* Open the site editor.
* Observe the loading spinner and verify it works well.

### Testing Instructions for Keyboard
None.

## Screenshots or screencast <!-- if applicable -->

![Screenshot 2023-06-23 at 18 02 19](https://github.com/WordPress/gutenberg/assets/8436925/471840dd-3100-484a-bff8-5e170ff7a98a)
![Screenshot 2023-06-23 at 18 01 56](https://github.com/WordPress/gutenberg/assets/8436925/c3d4e68a-e50f-44cc-b57b-5e9a6b93cc6a)
