### PR TITLE
Increase space between page meta and details section

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen-details-panel/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-details-panel/style.scss
@@ -1,5 +1,5 @@
 .edit-site-sidebar-navigation-details-screen-panel {
-	margin-bottom: $grid-unit-30;
+	margin: $grid-unit-30 0;
 
 	&:last-of-type {
 		margin-bottom: 0;


### PR DESCRIPTION
Follow-up to https://github.com/WordPress/gutenberg/issues/51508.

## What?
Increase the space between meta and details in the Page panel

## Why?
Since the featured image is now hidden when unset, the details section and page meta feel a little cramped.

| Before | After |
| --- | --- |
| <img width="359" alt="Screenshot 2023-06-23 at 16 12 45" src="https://github.com/WordPress/gutenberg/assets/846565/8bf1c6e0-1218-41e5-a5c8-f4234a5900fa"> | <img width="358" alt="Screenshot 2023-06-23 at 16 13 47" src="https://github.com/WordPress/gutenberg/assets/846565/b24d4bfb-5115-47b7-a480-626959e170bc"> |


