### PR TITLE
Fix missing MenuGroup segment in Site Editor header more menu

### DIFF
--- a/packages/edit-site/src/components/header-edit-mode/more-menu/index.js
+++ b/packages/edit-site/src/components/header-edit-mode/more-menu/index.js
@@ -116,14 +116,14 @@ export default function MoreMenu( { showIconLabels } ) {
 									'\\'
 								) }
 							/>
-							<ModeSwitcher />
-							<ActionItem.Slot
-								name="core/edit-site/plugin-more-menu"
-								label={ __( 'Plugins' ) }
-								as={ MenuGroup }
-								fillProps={ { onClick: onClose } }
-							/>
 						</MenuGroup>
+						<ModeSwitcher />
+						<ActionItem.Slot
+							name="core/edit-site/plugin-more-menu"
+							label={ __( 'Plugins' ) }
+							as={ MenuGroup }
+							fillProps={ { onClick: onClose } }
+						/>
 						<MenuGroup label={ __( 'Tools' ) }>
 							<SiteExport />
 							<MenuItem


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Noticed a tiny regression in the editor header more menu within the Site Editor, where the MenuGroup is not properly closed in the right spot, resulting in a missing border between the View and Plugins sections.

Closes #51859. 

## How?
Moves the closing </MenuGroup>. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open the Site Editor.
2. View the more menu at the top right.
3. See the "View" and "Editor" sections with a gray border between them. 

## Screenshots or screencast <!-- if applicable -->

| Before  | After |
| ------------- | ------------- |
|<img width="278" alt="CleanShot 2023-06-23 at 12 17 13" src="https://github.com/WordPress/gutenberg/assets/1813435/60fe6bbe-c730-4acb-96e0-44d5faf7c2b7">|<img width="280" alt="CleanShot 2023-06-23 at 12 17 33" src="https://github.com/WordPress/gutenberg/assets/1813435/fb428e65-6238-4187-88cf-4d1790b3fad8">|
