### PR TITLE
Sidebar Navigation: Refactor delete modal with `ConfirmDialog` component

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/delete-modal.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/delete-modal.js
@@ -1,45 +1,24 @@
 /**
  * WordPress dependencies
  */
-import {
-	__experimentalHStack as HStack,
-	__experimentalVStack as VStack,
-	Button,
-	Modal,
-} from '@wordpress/components';
+import { __experimentalConfirmDialog as ConfirmDialog } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 export default function RenameModal( { onClose, onConfirm } ) {
 	return (
-		<Modal title={ __( 'Delete' ) } onRequestClose={ onClose }>
-			<form>
-				<VStack spacing="3">
-					<p>
-						{ __(
-							'Are you sure you want to delete this Navigation menu?'
-						) }
-					</p>
-					<HStack justify="right">
-						<Button variant="tertiary" onClick={ onClose }>
-							{ __( 'Cancel' ) }
-						</Button>
+		<ConfirmDialog
+			isOpen={ true }
+			onConfirm={ ( e ) => {
+				e.preventDefault();
+				onConfirm();
 
-						<Button
-							variant="primary"
-							type="submit"
-							onClick={ ( e ) => {
-								e.preventDefault();
-								onConfirm();
-
-								// Immediate close avoids ability to hit delete multiple times.
-								onClose();
-							} }
-						>
-							{ __( 'Delete' ) }
-						</Button>
-					</HStack>
-				</VStack>
-			</form>
-		</Modal>
+				// Immediate close avoids ability to hit delete multiple times.
+				onClose();
+			} }
+			onCancel={ onClose }
+			confirmButtonText={ __( 'Delete' ) }
+		>
+			{ __( 'Are you sure you want to delete this Navigation menu?' ) }
+		</ConfirmDialog>
 	);
 }


### PR DESCRIPTION
Related to: #50880

## What?

This PR refactors the modal for removing menus from the sidebar navigation menu with a ConfirmDialog component to improve UI consistency.

| Before | After |
|--------|--------|
| ![before](https://github.com/WordPress/gutenberg/assets/54422211/41f8683c-74e4-4efe-a727-bc977dd7b365) | ![after](https://github.com/WordPress/gutenberg/assets/54422211/57446147-c3da-43c4-8011-497aa44ac4c9) | 

## Why?

If only yes or no is required in the modal, I feel that the `ConfirmDialog` component is appropriate. The following are similar modals using the `ConfirmDialog` component.

### Delete pattern

![delete-pattern](https://github.com/WordPress/gutenberg/assets/54422211/5229f246-0c5d-4428-a03a-3ed5704f0124)

### Unpublish post

![change-post-draft](https://github.com/WordPress/gutenberg/assets/54422211/3442216c-c9db-470f-a86a-e0bfa1484ca6)

### Delete page

![delete-page](https://github.com/WordPress/gutenberg/assets/54422211/46279e19-877b-4afd-bc5e-c647eb155d84)

## How?

Simply refactored using existing logic and text. I was not sure which text to use, OK or Delete, but I used the same Delete label as before.

## Testing Instructions

Confirm that the navigation deletion works correctly as before.