### PR TITLE
Library: Fix misalignment of description in custom template parts

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen-pattern/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-pattern/style.scss
@@ -1,0 +1,25 @@
+.edit-site-sidebar-navigation-screen-pattern__added-by-description {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	margin-top: $grid-unit-30;
+}
+
+.edit-site-sidebar-navigation-screen-pattern__added-by-description-author {
+	display: inline-flex;
+	align-items: center;
+
+	img {
+		border-radius: $grid-unit-15;
+	}
+
+	svg {
+		fill: $gray-600;
+	}
+}
+
+.edit-site-sidebar-navigation-screen-pattern__added-by-description-author-icon {
+	width: 24px;
+	height: 24px;
+	margin-right: $grid-unit-10;
+}

--- a/packages/edit-site/src/components/sidebar-navigation-screen-template/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-template/style.scss
@@ -3,25 +3,25 @@
 	align-items: center;
 	justify-content: space-between;
 	margin-top: $grid-unit-30;
+}
 
-	&-author {
-		display: inline-flex;
-		align-items: center;
+.edit-site-sidebar-navigation-screen-template__added-by-description-author {
+	display: inline-flex;
+	align-items: center;
 
-		img {
-			border-radius: $grid-unit-15;
-		}
-
-		svg {
-			fill: $gray-600;
-		}
-
-		&-icon {
-			width: 24px;
-			height: 24px;
-			margin-right: $grid-unit-10;
-		}
+	img {
+		border-radius: $grid-unit-15;
 	}
+
+	svg {
+		fill: $gray-600;
+	}
+}
+
+.edit-site-sidebar-navigation-screen-template__added-by-description-author-icon {
+	width: 24px;
+	height: 24px;
+	margin-right: $grid-unit-10;
 }
 
 .edit-site-sidebar-navigation-screen-template__template-area-button {

--- a/packages/edit-site/src/style.scss
+++ b/packages/edit-site/src/style.scss
@@ -37,6 +37,7 @@
 @import "./components/sidebar-navigation-screen-navigation-menu/style.scss";
 @import "./components/sidebar-navigation-screen-page/style.scss";
 @import "components/sidebar-navigation-screen-details-panel/style.scss";
+@import "./components/sidebar-navigation-screen-pattern/style.scss";
 @import "./components/sidebar-navigation-screen-template/style.scss";
 @import "./components/site-hub/style.scss";
 @import "./components/sidebar-navigation-screen-navigation-menus/style.scss";


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This PR fixes the broken layout of the description in the sidebar of the custom template parts.

| Before | After |
|--------|--------|
| ![before](https://github.com/WordPress/gutenberg/assets/54422211/d8854a7e-bf90-4975-8a22-30ff2d8caaf5) | ![after](https://github.com/WordPress/gutenberg/assets/54422211/b72c5229-9075-4a77-9468-327122de1733) | 

## Why?
This part of the layout would be expected to be similar to the custom template.

![custom-template](https://github.com/WordPress/gutenberg/assets/54422211/1e267bec-519a-4313-92c3-79229457223f)

However, there is a lack of CSS to achieve this layout.

## How?
I have applied the required styles using [the styles applied to the custom template descriptions](https://github.com/WordPress/gutenberg/blob/302a4207a27239cddeedb1cac07912e078bbb3e3/packages/edit-site/src/components/sidebar-navigation-screen-template/style.scss) as a guide.

## Testing Instructions

- Access the Library menu in the Site Editor.
- Create a template part from the Plus button.
- Return to the view mode.
- You should see the description, avatar icon, and author name in the sidebar in the proper layout.