### PR TITLE
Block Inserter: Fix browser warning error when opening custom pattern category

### DIFF
--- a/packages/block-editor/src/components/block-patterns-list/index.js
+++ b/packages/block-editor/src/components/block-patterns-list/index.js
@@ -133,11 +133,11 @@ function BlockPatternList( {
 			className="block-editor-block-patterns-list"
 			aria-label={ label }
 		>
-			{ blockPatterns.map( ( pattern, index ) => {
+			{ blockPatterns.map( ( pattern ) => {
 				const isShown = shownPatterns.includes( pattern );
 				return isShown ? (
 					<BlockPattern
-						key={ index }
+						key={ pattern.name }
 						pattern={ pattern }
 						onClick={ onClickPattern }
 						onHover={ onHover }
@@ -146,7 +146,7 @@ function BlockPatternList( {
 						showTooltip={ showTitlesAsTooltip }
 					/>
 				) : (
-					<BlockPatternPlaceholder key={ index } />
+					<BlockPatternPlaceholder key={ pattern.name } />
 				);
 			} ) }
 		</Composite>

--- a/packages/block-editor/src/components/block-patterns-list/index.js
+++ b/packages/block-editor/src/components/block-patterns-list/index.js
@@ -133,11 +133,11 @@ function BlockPatternList( {
 			className="block-editor-block-patterns-list"
 			aria-label={ label }
 		>
-			{ blockPatterns.map( ( pattern ) => {
+			{ blockPatterns.map( ( pattern, index ) => {
 				const isShown = shownPatterns.includes( pattern );
 				return isShown ? (
 					<BlockPattern
-						key={ pattern.name }
+						key={ index }
 						pattern={ pattern }
 						onClick={ onClickPattern }
 						onHover={ onHover }
@@ -146,7 +146,7 @@ function BlockPatternList( {
 						showTooltip={ showTitlesAsTooltip }
 					/>
 				) : (
-					<BlockPatternPlaceholder key={ pattern.name } />
+					<BlockPatternPlaceholder key={ index } />
 				);
 			} ) }
 		</Composite>

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -2018,7 +2018,7 @@ export const getInserterItems = createSelector(
 
 			return {
 				id,
-				name: 'core/block',
+				name: id,
 				initialAttributes: { ref: reusableBlock.id },
 				title: reusableBlock.title.raw,
 				icon,


### PR DESCRIPTION
## What?
This PR fixes a browser warning error that is output when opening a custom pattern category from the main block inserter.

![browser error](https://github.com/WordPress/gutenberg/assets/54422211/39a57a49-3806-45bb-a3fd-75327145fe89)

## Why?
This is because the `pattern.name` of the custom pattern is `core/block` and the `key` is duplicated in the `map` function.

## How?
Replaced with `index`.

## Testing Instructions

- Create multiple **non-synced** patterns.
- Open the main block inserter and open "Custom patterns" from the Patterns tab.
- Confirm that no errors are output to the browser console.