### PR TITLE
Patterns: fix error with react list key with new custom patterns list in inserter

### DIFF
--- a/packages/block-editor/src/components/block-patterns-list/index.js
+++ b/packages/block-editor/src/components/block-patterns-list/index.js
@@ -137,7 +137,11 @@ function BlockPatternList( {
 				const isShown = shownPatterns.includes( pattern );
 				return isShown ? (
 					<BlockPattern
-						key={ pattern.name }
+						key={
+							pattern.name === 'core/block'
+								? pattern.id
+								: pattern.name
+						}
 						pattern={ pattern }
 						onClick={ onClickPattern }
 						onHover={ onHover }

--- a/packages/block-editor/src/components/block-patterns-list/index.js
+++ b/packages/block-editor/src/components/block-patterns-list/index.js
@@ -150,7 +150,13 @@ function BlockPatternList( {
 						showTooltip={ showTitlesAsTooltip }
 					/>
 				) : (
-					<BlockPatternPlaceholder key={ pattern.name } />
+					<BlockPatternPlaceholder
+						key={
+							pattern.name === 'core/block'
+								? pattern.id
+								: pattern.name
+						}
+					/>
 				);
 			} ) }
 		</Composite>

--- a/packages/block-editor/src/components/block-patterns-list/index.js
+++ b/packages/block-editor/src/components/block-patterns-list/index.js
@@ -135,14 +135,12 @@ function BlockPatternList( {
 		>
 			{ blockPatterns.map( ( pattern ) => {
 				const isShown = shownPatterns.includes( pattern );
+				// User added unsynced patterns do not have a unique name so we use the id instead.
+				const key =
+					pattern.name === 'core/block' ? pattern.id : pattern.name;
 				return isShown ? (
 					<BlockPattern
-						key={
-							// User added unsynced patterns do not have a unique name so we use the id instead.
-							pattern.name === 'core/block'
-								? pattern.id
-								: pattern.name
-						}
+						key={ key }
 						pattern={ pattern }
 						onClick={ onClickPattern }
 						onHover={ onHover }
@@ -151,13 +149,7 @@ function BlockPatternList( {
 						showTooltip={ showTitlesAsTooltip }
 					/>
 				) : (
-					<BlockPatternPlaceholder
-						key={
-							pattern.name === 'core/block'
-								? pattern.id
-								: pattern.name
-						}
-					/>
+					<BlockPatternPlaceholder key={ key } />
 				);
 			} ) }
 		</Composite>

--- a/packages/block-editor/src/components/block-patterns-list/index.js
+++ b/packages/block-editor/src/components/block-patterns-list/index.js
@@ -138,6 +138,7 @@ function BlockPatternList( {
 				return isShown ? (
 					<BlockPattern
 						key={
+							// User added unsynced patterns do not have a unique name so we use the id instead.
 							pattern.name === 'core/block'
 								? pattern.id
 								: pattern.name

--- a/packages/block-editor/src/components/inserter/block-patterns-explorer/patterns-list.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-explorer/patterns-list.js
@@ -14,6 +14,7 @@ import BlockPatternsList from '../../block-patterns-list';
 import InserterNoResults from '../no-results';
 import useInsertionPoint from '../hooks/use-insertion-point';
 import usePatternsState from '../hooks/use-patterns-state';
+import useUnsyncedPatterns from '../hooks/use-unsynced-patterns';
 import InserterListbox from '../../inserter-listbox';
 import { searchItems } from '../search-items';
 
@@ -52,6 +53,13 @@ function PatternList( { filterValue, selectedCategory, patternCategories } ) {
 		onInsertBlocks,
 		destinationRootClientId
 	);
+
+	const filteredUnsyncedPatterns = useUnsyncedPatterns(
+		destinationRootClientId,
+		onInsertBlocks,
+		true
+	);
+
 	const registeredPatternCategories = useMemo(
 		() =>
 			patternCategories.map(
@@ -91,11 +99,18 @@ function PatternList( { filterValue, selectedCategory, patternCategories } ) {
 		debouncedSpeak( resultsFoundMessage );
 	}, [ filterValue, debouncedSpeak ] );
 
-	const currentShownPatterns = useAsyncList( filteredBlockPatterns, {
+	const blockPatterns = useAsyncList( filteredBlockPatterns, {
 		step: INITIAL_INSERTER_RESULTS,
 	} );
 
-	const hasItems = !! filteredBlockPatterns?.length;
+	const blockPatternsUnsynced = useAsyncList( filteredUnsyncedPatterns, {
+		step: INITIAL_INSERTER_RESULTS,
+	} );
+
+	const currentShownPatterns =
+		selectedCategory === 'reusable' ? blockPatternsUnsynced : blockPatterns;
+
+	const hasItems = !! currentShownPatterns?.length;
 	return (
 		<div className="block-editor-block-patterns-explorer__list">
 			{ hasItems && (
@@ -109,7 +124,7 @@ function PatternList( { filterValue, selectedCategory, patternCategories } ) {
 				{ hasItems && (
 					<BlockPatternsList
 						shownPatterns={ currentShownPatterns }
-						blockPatterns={ filteredBlockPatterns }
+						blockPatterns={ currentShownPatterns }
 						onClickPattern={ onSelectBlockPattern }
 						isDraggable={ false }
 					/>

--- a/packages/block-editor/src/components/inserter/hooks/use-unsynced-patterns.js
+++ b/packages/block-editor/src/components/inserter/hooks/use-unsynced-patterns.js
@@ -1,0 +1,38 @@
+/**
+ * WordPress dependencies
+ */
+import { useMemo } from '@wordpress/element';
+import { parse } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import useBlockTypesState from '../hooks/use-block-types-state';
+
+export default function useUnsyncedPatterns(
+	rootClientId,
+	onInsert,
+	withBlocks
+) {
+	const [ unsyncedPatterns ] = useBlockTypesState(
+		rootClientId,
+		onInsert,
+		'unsynced'
+	);
+	const filteredUnsyncedPatterns = useMemo( () => {
+		return unsyncedPatterns
+			.filter(
+				( { category: unsyncedPatternCategory } ) =>
+					unsyncedPatternCategory === 'reusable'
+			)
+			.map( ( syncedPattern ) => ( {
+				...syncedPattern,
+				blocks: withBlocks
+					? parse( syncedPattern.content, {
+							__unstableSkipMigrationLogs: true,
+					  } )
+					: undefined,
+			} ) );
+	}, [ unsyncedPatterns, withBlocks ] );
+	return filteredUnsyncedPatterns;
+}


### PR DESCRIPTION
## What?
Fixes console error when browsing `Custom patterns` in the inserter patterns panel

## Why?
Fixes: #51873 and #51872

## How?
If the pattern is a `core/block` sets the React list key to `id` instead of `name`

## Testing Instructions
For #51873
- Create a non-synced pattern.
- Open the main block inserter and open "Custom patterns" from the Patterns tab.
- Confirm that no errors are output to the browser console.

For #51872 
- Register two patterns with Synced turned off from the Library menu in the Site Editor.
- Open the main block inserter.
- Click Patterns tab.
- Click Custom patterns category.
- Two patterns should appear correctly.
- Switch to other categories.
- Make sure the custom patterns do not appear in other categories.
- Return to Custom patterns category.
- Make sure the number of custom patterns has not increased to three.
- Repeat to switch categories.
- Each iteration check the number of custom patterns has not increased.

## Screenshots or screencast <!-- if applicable -->
Before:

https://github.com/WordPress/gutenberg/assets/54422211/47e7b566-5fe5-4205-8e5e-bfe1bec039e6

https://github.com/WordPress/gutenberg/assets/54422211/2d14f46b-fc0a-4f41-bf04-b486cd17f75e

After:

https://github.com/WordPress/gutenberg/assets/3629020/04a9de17-26c9-4006-9ad6-e7483be6f89c

https://github.com/WordPress/gutenberg/assets/3629020/a2282831-4bdb-4280-927e-baf773c14919

