### PR TITLE
Don't show 'Back to page' notification when navigating away from page

### DIFF
--- a/packages/edit-site/src/components/page-content-focus-manager/back-to-page-notification.js
+++ b/packages/edit-site/src/components/page-content-focus-manager/back-to-page-notification.js
@@ -25,8 +25,11 @@ export default function BackToPageNotification() {
  * switches from focusing on editing page content to editing a template.
  */
 export function useBackToPageNotification() {
-	const hasPageContentFocus = useSelect(
-		( select ) => select( editSiteStore ).hasPageContentFocus(),
+	const { isPage, hasPageContentFocus } = useSelect(
+		( select ) => ( {
+			isPage: select( editSiteStore ).isPage(),
+			hasPageContentFocus: select( editSiteStore ).hasPageContentFocus(),
+		} ),
 		[]
 	);
 
@@ -39,6 +42,7 @@ export function useBackToPageNotification() {
 	useEffect( () => {
 		if (
 			! alreadySeen.current &&
+			isPage &&
 			prevHasPageContentFocus.current &&
 			! hasPageContentFocus
 		) {
@@ -57,6 +61,7 @@ export function useBackToPageNotification() {
 		prevHasPageContentFocus.current = hasPageContentFocus;
 	}, [
 		alreadySeen,
+		isPage,
 		prevHasPageContentFocus,
 		hasPageContentFocus,
 		createInfoNotice,


### PR DESCRIPTION
## What?
Fixes https://github.com/WordPress/gutenberg/issues/51261.

## How?
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e4093ba</samp>

* Restrict the back to page notification to page templates only by checking the `isPage` value ([link](https://github.com/WordPress/gutenberg/pull/51880/files?diff=unified&w=0#diff-4eea7a4400318c28f3752552c34d5856f2f692584732ca3548c980910893fb99R45), [link](https://github.com/WordPress/gutenberg/pull/51880/files?diff=unified&w=0#diff-4eea7a4400318c28f3752552c34d5856f2f692584732ca3548c980910893fb99R64))

## Testing Instructions
1. Go to Appearance → Editor → Pages.
2. Select a page and press Edit.
3. Press the W icon.
4. Press back.

A toast notification saying "You are editing at template" should not appear.

1. Go to Appearance → Editor → Pages.
2. Select a page and press Edit.
3. Press Edit template in the sidebar.

A toast notification saying "You are editing at template" should appear.

