### PR TITLE
Page Content Focus: Switch to Page panel when deselecting a block

### DIFF
--- a/packages/edit-site/src/components/sidebar-edit-mode/index.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/index.js
@@ -56,11 +56,13 @@ export function SidebarComplementaryAreaFills() {
 	useEffect( () => {
 		// Don't automatically switch tab when the sidebar is closed or when we
 		// are focused on page content.
-		if ( ! isEditorSidebarOpened || hasPageContentFocus ) {
+		if ( ! isEditorSidebarOpened ) {
 			return;
 		}
 		if ( hasBlockSelection ) {
-			enableComplementaryArea( STORE_NAME, SIDEBAR_BLOCK );
+			if ( ! hasPageContentFocus ) {
+				enableComplementaryArea( STORE_NAME, SIDEBAR_BLOCK );
+			}
 		} else {
 			enableComplementaryArea( STORE_NAME, SIDEBAR_TEMPLATE );
 		}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes https://github.com/WordPress/gutenberg/issues/51302.

## Why?
When focusing on page content, it is confusing when a user tries to select a block that is a part of the template and the sidebar just says "No block selected."

Instead, when the block is deselected we should switch the sidebar to the Page panel. This matches what the other editors do.

We should continue to _not_ switch to the Block tab when selecting a block in page content focus mode as we want to emphasise content editing, not block design.

## Testing Instructions
1. Go to Appearance → Editor → Pages.
2. Select a page and press Edit.
3. Ensure the sidebar is opened.
4. Select a block that's within post content. The sidebar should remain on the Page tab.
5. Select the Block tab.
6. Deselect the block by e.g. clicking on something that's a part of the page's template. The sidebar should switch back to the Page tab.

1. Go to Appearance → Editor → Templates.
2. Select a template and press Edit.
3. Ensure the sidebar is opened.
4. Select a block that's within post content. The sidebar should switch to the Block tab.
6. Deselect the block by e.g. using the block breadcrumbs. The sidebar should switch back to the Template tab.

## Screenshots or screencast 

https://github.com/WordPress/gutenberg/assets/612155/89f22418-1461-40ac-aa96-41634439b32c