### PR TITLE
Fix e2e test for block API / filtered blocks

### DIFF
--- a/test/e2e/specs/editor/plugins/block-api.spec.js
+++ b/test/e2e/specs/editor/plugins/block-api.spec.js
@@ -17,12 +17,12 @@ test.describe( 'Using Block API', () => {
 		editor,
 	} ) => {
 		await admin.createNewPost();
-
 		await editor.insertBlock( { name: 'e2e-tests/hello-world' } );
 
-		const block = editor.canvas.locator(
-			'[data-type="e2e-tests/hello-world"]'
-		);
-		await expect( block ).toHaveText( 'Hello Editor!' );
+		await expect(
+			editor.canvas.getByRole( 'document', {
+				name: 'Block: Filtered Hello World',
+			} )
+		).toBeVisible();
 	} );
 } );


### PR DESCRIPTION
## What?
An attempt to fix a test that may not be doing what it's supposed to be. Noticed during work on #51824.

## Why?
It's worth a look because the test might not guard against regressions.

Currently the test asserts that the filtered block is inserted and has a certain text content. I suspect that’s wrong because the filter doesn't change the text content so there’s nothing testing the filter had an effect. 

Conversely, if the original issue was that a block would fail to be inserted if it had a filter added after its block type was registered, then this test is fine and this PR can be closed. However, that didn't seem to be the case from my reading of it.

## How?
Creates an assertion for the effect of the filter.

## Testing Instructions
```shell
npm run test:e2e:playwright -- block-api
```
