### PR TITLE
Update packages for WP 6.3

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,367 @@
 == Changelog ==
 
+= 16.1.0-rc.1 =
+
+## Changelog
+
+### Features
+
+#### Navigation Menu Sidebar
+- Add focus mode for Navigation Menus. ([39286](https://github.com/WordPress/gutenberg/pull/39286))
+- Allow renaming, duplication and deleting of Navigation menus from Browse Mode Sidebar. ([50880](https://github.com/WordPress/gutenberg/pull/50880))
+
+#### Block Library
+- Add Navigation Menus to Template Parts screen sidebar in Browse Mode. ([51492](https://github.com/WordPress/gutenberg/pull/51492))
+- Add Footnotes block to text blocks. ([51201](https://github.com/WordPress/gutenberg/pull/51201))
+
+#### Patterns
+- Allow for filtering of block patterns by source. ([51672](https://github.com/WordPress/gutenberg/pull/51672))
+- Reusable blocks: Rename to 'Patterns' and add option to also add a non-synced Pattern. ([51144](https://github.com/WordPress/gutenberg/pull/51144))
+- Site Editor: Add Library for Template Parts & Patterns Management. ([51078](https://github.com/WordPress/gutenberg/pull/51078))
+
+### Themes
+- Remove the experiment option for Block Theme Previews. ([50983](https://github.com/WordPress/gutenberg/pull/50983))
+
+### Enhancements
+
+#### Site Editor
+- Edit Site: Make admin background consistent with layout. ([51741](https://github.com/WordPress/gutenberg/pull/51741))
+- Edit Site: Remove first loading spinner. ([51736](https://github.com/WordPress/gutenberg/pull/51736))
+- Edit Site: Use global background color while loading. ([51709](https://github.com/WordPress/gutenberg/pull/51709))
+- Improve guidance to editing template when focused on editing a page. ([51366](https://github.com/WordPress/gutenberg/pull/51366))
+- Only show view site link in view mode. ([51279](https://github.com/WordPress/gutenberg/pull/51279))
+- Page Details View: Show featured image only if there is one. ([51649](https://github.com/WordPress/gutenberg/pull/51649))
+- Page Details View: Show parent only if there is one. ([51648](https://github.com/WordPress/gutenberg/pull/51648))
+- Site editor sidebar: Home template details. ([51223](https://github.com/WordPress/gutenberg/pull/51223))
+- Navigation on Browse Mode: Move the action to the leaf menu. ([50843](https://github.com/WordPress/gutenberg/pull/50843))
+- Remove Taxonomy as an option in the add template flow. ([51586](https://github.com/WordPress/gutenberg/pull/51586))
+- Remove shadows in Site Editor sidebar. ([51546](https://github.com/WordPress/gutenberg/pull/51546))
+- Show warning on critical block removal. ([51145](https://github.com/WordPress/gutenberg/pull/51145))
+- Site editor navigation: Use chevron left in RTL mode. ([51588](https://github.com/WordPress/gutenberg/pull/51588))
+- Add ability to set status, publish date and password in site editor. ([51408](https://github.com/WordPress/gutenberg/pull/51408))
+- Add table view to manage templates page. ([50766](https://github.com/WordPress/gutenberg/pull/50766))
+- Update Library panel footer. ([51652](https://github.com/WordPress/gutenberg/pull/51652))
+- Update page list footer. ([51438](https://github.com/WordPress/gutenberg/pull/51438))
+- List draft navigations in Browse mode Navigation section. ([51422](https://github.com/WordPress/gutenberg/pull/51422))
+- Show actions for empty menus in Navigation on Browse mode. ([51420](https://github.com/WordPress/gutenberg/pull/51420))
+- Unify welcome guides labels casing. ([51700](https://github.com/WordPress/gutenberg/pull/51700))
+- Site editor sidebar: Add footer to template part and ensure nested template areas display. ([51669](https://github.com/WordPress/gutenberg/pull/51669))
+
+#### Components
+- ItemGroup: Update button focus styles to be more consistent. ([51576](https://github.com/WordPress/gutenberg/pull/51576))
+- Toolbar: Use Ariakit instead of Reakit. ([51623](https://github.com/WordPress/gutenberg/pull/51623))
+- Update: Adjust modal radius to be between frame and buttons. ([51254](https://github.com/WordPress/gutenberg/pull/51254))
+- `UnitControl`: Revamp support for changing unit by typing. ([39303](https://github.com/WordPress/gutenberg/pull/39303))
+- Move HeadinglevelDropdown to its own component. ([46003](https://github.com/WordPress/gutenberg/pull/46003))
+
+#### Block Editor
+- List View: Try showing blocks that are dragged (no longer hide them). ([51724](https://github.com/WordPress/gutenberg/pull/51724))
+- Updated unstyled Button hover selector to change fill of svg and path element. ([50819](https://github.com/WordPress/gutenberg/pull/50819))
+- Writing Flow: Allow Escape key to deselect blocks and selection during multiselection. ([48904](https://github.com/WordPress/gutenberg/pull/48904))
+- Change "Copy block" to "Copy". ([51532](https://github.com/WordPress/gutenberg/pull/51532))
+- Limit Copy/Paste Styles menu item. ([51503](https://github.com/WordPress/gutenberg/pull/51503))
+- Force disable suggestions until URL field is dirty in Link Control. ([51354](https://github.com/WordPress/gutenberg/pull/51354))
+- Top toolbar: Refine the icons on the right. ([51735](https://github.com/WordPress/gutenberg/pull/51735))
+
+#### Block Library
+- List block: Add numbering type selection. ([51186](https://github.com/WordPress/gutenberg/pull/51186))
+- Patterns: Removes the pattern experiment. ([51719](https://github.com/WordPress/gutenberg/pull/51719))
+- Remove `accordion` from details block keywords. ([51597](https://github.com/WordPress/gutenberg/pull/51597))
+- Add init modules to details and post-time-to-read blocks. ([51606](https://github.com/WordPress/gutenberg/pull/51606))
+- Improve logic in `render_block_core_template_part`. ([50636](https://github.com/WordPress/gutenberg/pull/50636))
+- Indicate Draft status of menus in Nav block menu selector. ([51427](https://github.com/WordPress/gutenberg/pull/51427))
+- Mobile - Image block - Fix issue with set width and height images. ([51463](https://github.com/WordPress/gutenberg/pull/51463))
+- Navigation: Remove destructive colors from modal. ([51691](https://github.com/WordPress/gutenberg/pull/51691))
+- Pass the block to the onGoToPage function. ([51699](https://github.com/WordPress/gutenberg/pull/51699))
+- Post Author - don't show 0 in inspector controls. ([51345](https://github.com/WordPress/gutenberg/pull/51345))
+- Remove anchor support from dynamic blocks. ([51288](https://github.com/WordPress/gutenberg/pull/51288))
+- Site Tagline Block: Remove unnecessary square path from block icon SVG. ([51611](https://github.com/WordPress/gutenberg/pull/51611))
+
+#### Accessibility
+- Autocomplete: Announce results to screen readers when first becoming visible. ([51018](https://github.com/WordPress/gutenberg/pull/51018))
+- List View: A11Y focus enhancements for edit-site based on modifications to edit-post. ([51404](https://github.com/WordPress/gutenberg/pull/51404))
+- Add a description key to theme.json style variations. ([45242](https://github.com/WordPress/gutenberg/pull/45242))
+- Focus first focusable on Link UI. ([51105](https://github.com/WordPress/gutenberg/pull/51105))
+
+#### Interactivity API
+- Add missing tests for image block. ([51305](https://github.com/WordPress/gutenberg/pull/51305))
+- Image block: Add animation toggle to lightbox behavior. ([51357](https://github.com/WordPress/gutenberg/pull/51357))
+
+#### Global Styles
+- Accept transforms in gutenberg_get_global_styles context params. ([50484](https://github.com/WordPress/gutenberg/pull/50484))
+- Split styles menus in revisions and everything else. ([51318](https://github.com/WordPress/gutenberg/pull/51318))
+
+#### Icons
+- Tweak icons for improved HiDPI devices. ([51511](https://github.com/WordPress/gutenberg/pull/51511))
+
+#### Plugin
+- Remove Details block setting field from the experiments page. ([51372](https://github.com/WordPress/gutenberg/pull/51372))
+
+#### Templates API
+- Return post modified datetime in response. ([51362](https://github.com/WordPress/gutenberg/pull/51362))
+
+#### List View
+- Style Book: Close list view when opening the style book. ([50438](https://github.com/WordPress/gutenberg/pull/50438))
+
+#### Design Tools
+- List View: Add an indicator of when a position type is set for a block. ([49122](https://github.com/WordPress/gutenberg/pull/49122))
+- Sticky Position: Try re-enabling non-root sticky position. ([49321](https://github.com/WordPress/gutenberg/pull/49321))
+- Clarify error message if duotone color values is incorrect. ([51397](https://github.com/WordPress/gutenberg/pull/51397))
+- List all the font families and font sizes from all the theme.json origins in the font picker. ([51488](https://github.com/WordPress/gutenberg/pull/51488))
+
+#### Post Editor
+- Adjust the name of the custom field button labels. ([47407](https://github.com/WordPress/gutenberg/pull/47407))
+- Block manager: Display a 'Reset' button when blocks are hidden to quickly enable all. ([51200](https://github.com/WordPress/gutenberg/pull/51200))
+
+#### Media
+- Prepublish: Suggest uploading external images. ([46014](https://github.com/WordPress/gutenberg/pull/46014))
+
+#### Patterns
+- Block Options: Use consistent capitalization on template parts and patterns. ([51761](https://github.com/WordPress/gutenberg/pull/51761))
+
+#### CSS & Styling
+- Update editor UI modal width. ([51733](https://github.com/WordPress/gutenberg/pull/51733))
+
+#### Commands
+- Add commands to access template, template parts and styles. ([51501](https://github.com/WordPress/gutenberg/pull/51501))
+- Add global styles related commands. ([51637](https://github.com/WordPress/gutenberg/pull/51637))
+
+### Themes
+
+- Block Theme Previews: Change the URL query string for more safety. ([51312](https://github.com/WordPress/gutenberg/pull/51312))
+- Update the Save Button label when you're previewing a theme. ([51361](https://github.com/WordPress/gutenberg/pull/51361))
+
+### Bug Fixes
+
+#### Block Library
+
+- Fix navigation error in library. ([51589](https://github.com/WordPress/gutenberg/pull/51589))
+- Fix site editor rendering of Categories block. ([51329](https://github.com/WordPress/gutenberg/pull/51329))
+- Gallery block - Add default value for innerBlockImages. ([51443](https://github.com/WordPress/gutenberg/pull/51443))
+- Latest posts: Make more link consistent between frontend and editor. ([51190](https://github.com/WordPress/gutenberg/pull/51190))
+- Navigation: Don't interfere with pointer events. ([51378](https://github.com/WordPress/gutenberg/pull/51378))
+- Post editor: Make the Post Content block available as a child of the Query block. ([51405](https://github.com/WordPress/gutenberg/pull/51405))
+- Search Block: Fix problem with buttons not outputting primary status. ([51529](https://github.com/WordPress/gutenberg/pull/51529))
+- Try providing a non-zero value for client width in image editor. ([51285](https://github.com/WordPress/gutenberg/pull/51285))
+- Query Loop: Properly initialize and update `perPage` when we inherit from global query. ([51641](https://github.com/WordPress/gutenberg/pull/51641))
+- Avatar block: Fix not 1:1 between the editor and the front-end. ([49963](https://github.com/WordPress/gutenberg/pull/49963))
+- Spacer block: Fix invalid markup when set to fill. ([51317](https://github.com/WordPress/gutenberg/pull/51317))
+
+#### Commands
+- Show pages with any status in the command center. ([51324](https://github.com/WordPress/gutenberg/pull/51324))
+
+#### Core Data
+
+- Core Data: Fix ESLint warning for the 'useEntityRecord' hook. ([51562](https://github.com/WordPress/gutenberg/pull/51562))
+- useEntityRecord: Fix destructure error when `enabled` option is `false`. ([51534](https://github.com/WordPress/gutenberg/pull/51534))
+
+#### Block Editor
+- Fix blocks autocompleter 'rootClientId' selector. ([51673](https://github.com/WordPress/gutenberg/pull/51673))
+- Inserter: Fix arrows in RTL mode. ([51622](https://github.com/WordPress/gutenberg/pull/51622))
+- Link Format: Don't return focus on the selected text 'onFocusOutside'. ([51684](https://github.com/WordPress/gutenberg/pull/51684))
+- ListView: Update drop indicator line positioning to support rtl languages. ([51284](https://github.com/WordPress/gutenberg/pull/51284))
+- Page Content Focus: Default insertion point to the Post Content block. ([51773](https://github.com/WordPress/gutenberg/pull/51773))
+
+#### Site Editor
+- Add 'Edit template' and 'Back to page' commands. ([51364](https://github.com/WordPress/gutenberg/pull/51364))
+- Fix template display in page details with a custom template. ([51638](https://github.com/WordPress/gutenberg/pull/51638))
+- Page details: Fix displaying slugs with non-latin characters. ([51679](https://github.com/WordPress/gutenberg/pull/51679))
+- Prevent block overlay on blocks with a 'contentOnly' editing mode. ([51780](https://github.com/WordPress/gutenberg/pull/51780))
+- Fix gradient background color repeats. ([51374](https://github.com/WordPress/gutenberg/pull/51374))
+- Global styles: Fix back button tooltip. ([51725](https://github.com/WordPress/gutenberg/pull/51725))
+- Site editor header: Fix document title back and shortcut color contrast. ([51442](https://github.com/WordPress/gutenberg/pull/51442))
+- Site editor sidebar: Fix the heading hierarchy. ([51696](https://github.com/WordPress/gutenberg/pull/51696))
+
+#### Accessibility
+- Distraction Free: Avoid focus loss when enabling/disabling distraction free mode via the more menu. ([51627](https://github.com/WordPress/gutenberg/pull/51627))
+- Library: Add an explicit label to the search control. ([51781](https://github.com/WordPress/gutenberg/pull/51781))
+- Site editor: Add a navigable region for content area of Library and Template views. ([51782](https://github.com/WordPress/gutenberg/pull/51782))
+- Fix shift+tab behavior to move to toolbar when the preceding block has a form element. ([51548](https://github.com/WordPress/gutenberg/pull/51548))
+
+#### Global Styles
+- Color Panel: Fix rendering of tabs with no color. ([51498](https://github.com/WordPress/gutenberg/pull/51498))
+- Remove custom padding on style revisions button. ([51269](https://github.com/WordPress/gutenberg/pull/51269))
+
+#### Components
+- MediaPlaceholder: Fix position of URLPopover. ([51363](https://github.com/WordPress/gutenberg/pull/51363))
+- Popover: Allow legitimate 0 positions to update popover position. ([51320](https://github.com/WordPress/gutenberg/pull/51320))
+- Button: Remove unnecessary margin from dashicon. ([51395](https://github.com/WordPress/gutenberg/pull/51395))
+
+#### Patterns
+- Library: Reinstate sidebar navigation menu editing for template parts. ([51825](https://github.com/WordPress/gutenberg/pull/51825))
+
+#### Interactivity API
+- Image block: Remove Lightbox markup if is set as disabled. ([51692](https://github.com/WordPress/gutenberg/pull/51692))
+
+#### Block Locking
+- Fix regression in selectors. ([51541](https://github.com/WordPress/gutenberg/pull/51541))
+
+#### Typography
+- Fluid typography: Custom font-sizes should use max viewport width. ([51516](https://github.com/WordPress/gutenberg/pull/51516))
+
+#### Widgets Editor
+- Fix fixed toolbar in customize widgets. ([51092](https://github.com/WordPress/gutenberg/pull/51092))
+
+#### Navigation Menu Sidebar
+- Hide the hidden navigation block. ([50662](https://github.com/WordPress/gutenberg/pull/50662))
+
+#### Block Variations
+- [Block Library - Post Terms]: Custom taxonomies do not show icons when transforming from the toolbar. ([51476](https://github.com/WordPress/gutenberg/pull/51476))
+
+### Performance
+
+#### Site Editor
+- Edit Site: Add a loading timeout. ([51049](https://github.com/WordPress/gutenberg/pull/51049))
+- Improve DocumentActions performance. ([51432](https://github.com/WordPress/gutenberg/pull/51432))
+- Prevent BlockBreadcrumb from re-rendering unnecessarily when typing. ([51628](https://github.com/WordPress/gutenberg/pull/51628))
+- Reduce number of List View re-renders while typing. ([51518](https://github.com/WordPress/gutenberg/pull/51518))
+- Improve PagePanels performance. ([51319](https://github.com/WordPress/gutenberg/pull/51319))
+
+#### Block Editor
+- Improve getBlockEditingMode() and useAppender() performance. ([51675](https://github.com/WordPress/gutenberg/pull/51675))
+
+### Experiments
+
+#### Global Styles
+- Color Randomizer: Fix an error when the theme has no color palette. ([51539](https://github.com/WordPress/gutenberg/pull/51539))
+
+### Documentation
+
+- Docs: Fix incorrect import of useEntityRecords in code example. ([51630](https://github.com/WordPress/gutenberg/pull/51630))
+- Fix broken links in editor documentation. ([51321](https://github.com/WordPress/gutenberg/pull/51321))
+- Fix grammar in the Create a Block > WordPress Plugin page. ([51663](https://github.com/WordPress/gutenberg/pull/51663))
+- Fix grammar on the Create a Block tutorial page. ([51662](https://github.com/WordPress/gutenberg/pull/51662))
+- Fix grammar on the Getting Started page. ([51661](https://github.com/WordPress/gutenberg/pull/51661))
+- Update broken link. ([41758](https://github.com/WordPress/gutenberg/pull/41758))
+- Update components README.md. ([51557](https://github.com/WordPress/gutenberg/pull/51557))
+- Update wp-env changelog. ([51614](https://github.com/WordPress/gutenberg/pull/51614))
+- Updated getEntityRecord doc by using selector instead of dispatch. ([51298](https://github.com/WordPress/gutenberg/pull/51298))
+
+### Code Quality
+- Add tests for WP_Classic_To_Block_Menu_Converter class. ([51410](https://github.com/WordPress/gutenberg/pull/51410))
+- Adopt lock-unlock.js and private-apis.js convention. ([51322](https://github.com/WordPress/gutenberg/pull/51322))
+- Formats: Avoid rerendering language edit component when typing. ([51440](https://github.com/WordPress/gutenberg/pull/51440))
+- Keyboard Shortcut: Clean up shortcut names. ([51739](https://github.com/WordPress/gutenberg/pull/51739))
+- Lodash: Refactor away from `_.kebabCase()` in block editor. ([51687](https://github.com/WordPress/gutenberg/pull/51687))
+- Lodash: Refactor away from `_.mergeWith()`. ([51483](https://github.com/WordPress/gutenberg/pull/51483))
+- Lodash: Remove from blocks package. ([51703](https://github.com/WordPress/gutenberg/pull/51703))
+- Remove pattern directory categories endpoint. ([51340](https://github.com/WordPress/gutenberg/pull/51340))
+- Require relocated class files for back-compat in WordPress releases. ([51670](https://github.com/WordPress/gutenberg/pull/51670))
+
+#### Block Library
+- Details: Set 'clientId' as useSelect dependency. ([51634](https://github.com/WordPress/gutenberg/pull/51634))
+- Move Navigation fallback files to 6.3 directory. ([51572](https://github.com/WordPress/gutenberg/pull/51572))
+- Navigation: Fix ListView deprecation notice. ([51094](https://github.com/WordPress/gutenberg/pull/51094))
+- Navigation: Just a simple refactor. ([51382](https://github.com/WordPress/gutenberg/pull/51382))
+- Remove legacy isTopLevelLink attribute from Navigation block tests. ([51759](https://github.com/WordPress/gutenberg/pull/51759))
+- Search Block: Write "Button Only" label in sentence capitalization. ([51629](https://github.com/WordPress/gutenberg/pull/51629))
+
+#### Site Editor
+- Browse Mode: Move CSS to more generic selector. ([51547](https://github.com/WordPress/gutenberg/pull/51547))
+- DRY up ContentBlocksList and BlockInspectorLockedBlocks. ([51281](https://github.com/WordPress/gutenberg/pull/51281))
+- Edit Site: Refactor the NavigationMenuContent component and fix the deprecation notice. ([51469](https://github.com/WordPress/gutenberg/pull/51469))
+- PageContent: Fix unlock import. ([51360](https://github.com/WordPress/gutenberg/pull/51360))
+- Refactor Site Editor block editor code. ([51524](https://github.com/WordPress/gutenberg/pull/51524))
+
+#### Block Editor
+- Lodash: Replace `_.mergeWith()` with `deepmerge` in blocks. ([50637](https://github.com/WordPress/gutenberg/pull/50637))
+- useInsertionPoint: Add missing dependency for useCallback. ([51682](https://github.com/WordPress/gutenberg/pull/51682))
+- Block Editor: Improve data selector for BlockQuickNavigationItem. ([51429](https://github.com/WordPress/gutenberg/pull/51429))
+- Block Editor: Remove redundant memoization from 'ImageURLInputUI'. ([51658](https://github.com/WordPress/gutenberg/pull/51658))
+- Block Editor: Simplify filtering condition for `getBlockParentsByBlockName` selector. ([51439](https://github.com/WordPress/gutenberg/pull/51439))
+- Block Editor: Remove unused selectors. ([51674](https://github.com/WordPress/gutenberg/pull/51674))
+
+#### Navigation Menu Sidebar
+- Extract nav editor component in Nav in Browse mode. ([51436](https://github.com/WordPress/gutenberg/pull/51436))
+- Remove custom button and (conditionally) show single menu on Navigation route in Browse Mode. ([51565](https://github.com/WordPress/gutenberg/pull/51565))
+
+#### Design Tools
+- Fluid typography: Add missing changelog from #51516. ([51668](https://github.com/WordPress/gutenberg/pull/51668))
+
+#### Layout
+- Move layout definitions out of theme.json. ([50621](https://github.com/WordPress/gutenberg/pull/50621))
+- Try stabilising layout and its associated APIs. ([51434](https://github.com/WordPress/gutenberg/pull/51434))
+
+#### Global Styles
+- Global styles revisions: Move from experimental to 6.3. ([51474](https://github.com/WordPress/gutenberg/pull/51474))
+
+#### Post Editor
+- Fix refactor flat term selector to use data api for creating new terms. ([50952](https://github.com/WordPress/gutenberg/pull/50952))
+
+#### Data Layer
+- Private actions and selectors: Return stable references, expose to thunks. ([51051](https://github.com/WordPress/gutenberg/pull/51051))
+
+#### Themes
+- Block Theme Previews: Rename GET variable and prepare for core compat. ([51738](https://github.com/WordPress/gutenberg/pull/51738))
+
+#### Interactivity API
+- Remove the hydration console log of the Interactivity API. ([51571](https://github.com/WordPress/gutenberg/pull/51571))
+- Use interactivity API for Navigation and File blocks only in Gutenberg. ([51694](https://github.com/WordPress/gutenberg/pull/51694))
+- Behaviors: Move behaviors code to experimental folder. ([51654](https://github.com/WordPress/gutenberg/pull/51654))
+
+#### Components
+- Convert `ClipboardButton` to TypeScript. ([51334](https://github.com/WordPress/gutenberg/pull/51334))
+- Use internal context system to apply toolbar variant to toolbar dropdowns. ([51154](https://github.com/WordPress/gutenberg/pull/51154))
+
+#### Parser
+- Split each class in `parser.php` to a separate file. ([48693](https://github.com/WordPress/gutenberg/pull/48693))
+
+### Tools
+
+#### Testing
+- Add 'Mamaduka' as one of the code owners for Playwright tests. ([51470](https://github.com/WordPress/gutenberg/pull/51470))
+- Combine Site Editor list view tests into a single file. ([51635](https://github.com/WordPress/gutenberg/pull/51635))
+- Consolidate duplicate block tests. ([51352](https://github.com/WordPress/gutenberg/pull/51352))
+- Fix flaky 'Keep styles on block transforms' end-to-end test. ([51593](https://github.com/WordPress/gutenberg/pull/51593))
+- Fix flaky 'Push to Global Styles' end-to-end test. ([51636](https://github.com/WordPress/gutenberg/pull/51636))
+- Fix flaky 'Switch to Draft' action in preview end-to-end tests. ([51564](https://github.com/WordPress/gutenberg/pull/51564))
+- Fix flaky 'hooks API' end-to-end test. ([51592](https://github.com/WordPress/gutenberg/pull/51592))
+- Fix flaky Image block interactivity end-to-end test. ([51573](https://github.com/WordPress/gutenberg/pull/51573))
+- Fix the flaky site editor list view tests. ([51598](https://github.com/WordPress/gutenberg/pull/51598))
+- Migrate 'Allowed Blocks Setting on InnerBlocks' tests to Playwright. ([51677](https://github.com/WordPress/gutenberg/pull/51677))
+- Migrate block hierarchy navigation tests to Playwright. ([51517](https://github.com/WordPress/gutenberg/pull/51517))
+- Playwright Utils: Change preference update method in setIsFixedToolbar. ([51659](https://github.com/WordPress/gutenberg/pull/51659))
+- Playwright Utils: Simplify editor preference updates in createNewPost. ([51560](https://github.com/WordPress/gutenberg/pull/51560))
+- Styles Navigation Screen: Close style book using location. ([51365](https://github.com/WordPress/gutenberg/pull/51365))
+- Update BlockEditorProvider tests. ([51497](https://github.com/WordPress/gutenberg/pull/51497))
+- Update E2E test sharding on CI, make Playwright tests faster, Puppeteer tests slower. ([50362](https://github.com/WordPress/gutenberg/pull/50362))
+- Update the 'Iframe block' test and fix flakiness. ([51631](https://github.com/WordPress/gutenberg/pull/51631))
+- end-to-end tests: Try fixing 'networkidle' timeout errors. ([51826](https://github.com/WordPress/gutenberg/pull/51826))
+- test: Re-enable native integration tests. ([51706](https://github.com/WordPress/gutenberg/pull/51706))
+- Migrate Navigable toolbar test to Playwright. ([51514](https://github.com/WordPress/gutenberg/pull/51514))
+- Mobile unit tests: Remove custom waitFor implementation. ([46735](https://github.com/WordPress/gutenberg/pull/46735))
+- Set fixedToolbar to false after each top toolbar test to ensure proper cleanup. ([51600](https://github.com/WordPress/gutenberg/pull/51600))
+- Fix performance test failure on trunk. ([51407](https://github.com/WordPress/gutenberg/pull/51407))
+- Performance tests: Make theme versions consistent cross-env. ([50905](https://github.com/WordPress/gutenberg/pull/50905))
+- Performance tests: Update base point to compare. ([51381](https://github.com/WordPress/gutenberg/pull/51381))
+
+
+#### Build Tooling
+- Babel config: Enable useSpread option for JSX transform to reduce transpilation. ([51574](https://github.com/WordPress/gutenberg/pull/51574))
+- Lodash: Remove from lint staged type check. ([51698](https://github.com/WordPress/gutenberg/pull/51698))
+- Performance Tests: Update the base point to compare against. ([51689](https://github.com/WordPress/gutenberg/pull/51689))
+- wp-env: Try to fix failing PHP Github actions. ([51513](https://github.com/WordPress/gutenberg/pull/51513))
+- npm lockfile: Hoist reakit and date-fns packages to the top. ([51500](https://github.com/WordPress/gutenberg/pull/51500))
+
+#### Plugin
+- Add script to compile usage of experimental APIs. ([51341](https://github.com/WordPress/gutenberg/pull/51341))
+
+## First time contributors
+
+The following PRs were merged by first time contributors:
+
+- @bangank36: Update components README.md. ([51557](https://github.com/WordPress/gutenberg/pull/51557))
+- @samnajian: Accept transforms in gutenberg_get_global_styles context params. ([50484](https://github.com/WordPress/gutenberg/pull/50484))
+- @xerpa43: Avatar block: Fix not 1:1 between the editor and the front-end. ([49963](https://github.com/WordPress/gutenberg/pull/49963))
+
+
+## Contributors
+
+The following contributors merged PRs in this release:
+
+@aaronrobertshaw @afercia @alexstine @andrewserong @aristath @artemiomorales @aurooba @bangank36 @c4rl0sbr4v0 @carolinan @ciampo @dcalhoun @derekblank @diegohaz @draganescu @ellatrix @fabiankaegy @fluiddot @geriux @getdave @glendaviesnz @jameskoster @jasmussen @jeryj @jhnstn @jsnajdr @juanfra @kozer @luisherranz @MaggieCabrera @Mamaduka @matiasbenedetto @mcliwanow @mcsf @mikachan @n2erjo00 @noahtallen @noisysocks @ntsekouras @oandregal @okmttdhr @paulopmt1 @pbking @peterwilsoncc @pooja-muchandikar @ramonjd @richtabor @samnajian @SantosGuillamot @SavPhill @SaxonF @scruffian @shimotmk @Sidsector9 @SiobhyB @spacedmonkey @stokesman @sunyatasattva @t-hamano @talldan @tellthemachines @tyxla @walbo @WunderBart @xerpa43 @youknowriad
+
+
 = 16.0.0 =
 
 ## Changelog

--- a/gutenberg.php
+++ b/gutenberg.php
@@ -5,7 +5,7 @@
  * Description: Printing since 1440. This is the development plugin for the block editor, site editor, and other future WordPress core functionality.
  * Requires at least: 6.1
  * Requires PHP: 5.6
- * Version: 16.0.0
+ * Version: 16.1.0-rc.1
  * Author: Gutenberg Team
  * Text Domain: gutenberg
  *

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "gutenberg",
-	"version": "16.0.0",
+	"version": "16.1.0-rc.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -17717,7 +17717,7 @@
 				"@wordpress/core-data": "file:packages/core-data",
 				"@wordpress/data": "file:packages/data",
 				"@wordpress/deprecated": "file:packages/deprecated",
-				"@wordpress/dom": "^3.20.0",
+				"@wordpress/dom": "^3.35.1",
 				"@wordpress/editor": "file:packages/editor",
 				"@wordpress/element": "file:packages/element",
 				"@wordpress/hooks": "file:packages/hooks",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gutenberg",
-	"version": "16.0.0",
+	"version": "16.1.0-rc.1",
 	"private": true,
 	"description": "A new WordPress editor experience.",
 	"author": "The WordPress Contributors",

--- a/packages/a11y/package.json
+++ b/packages/a11y/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/a11y",
-	"version": "3.35.0",
+	"version": "3.35.1",
 	"description": "Accessibility (a11y) utilities for WordPress.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/annotations/package.json
+++ b/packages/annotations/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/annotations",
-	"version": "2.35.0",
+	"version": "2.35.1",
 	"description": "Annotate content in the Gutenberg editor.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/api-fetch/package.json
+++ b/packages/api-fetch/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/api-fetch",
-	"version": "6.32.0",
+	"version": "6.32.1",
 	"description": "Utility to make WordPress REST API requests.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/autop/package.json
+++ b/packages/autop/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/autop",
-	"version": "3.35.0",
+	"version": "3.35.1",
 	"description": "WordPress's automatic paragraph functions `autop` and `removep`.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/babel-plugin-import-jsx-pragma/package.json
+++ b/packages/babel-plugin-import-jsx-pragma/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/babel-plugin-import-jsx-pragma",
-	"version": "4.18.0",
+	"version": "4.18.1",
 	"description": "Babel transform plugin for automatically injecting an import to be used as the pragma for the React JSX Transform plugin.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/babel-plugin-makepot/package.json
+++ b/packages/babel-plugin-makepot/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/babel-plugin-makepot",
-	"version": "5.19.0",
+	"version": "5.19.1",
 	"description": "WordPress Babel internationalization (i18n) plugin.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/babel-preset-default/package.json
+++ b/packages/babel-preset-default/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/babel-preset-default",
-	"version": "7.19.0",
+	"version": "7.19.1",
 	"description": "Default Babel preset for WordPress development.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/base-styles/package.json
+++ b/packages/base-styles/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/base-styles",
-	"version": "4.26.0",
+	"version": "4.26.1",
 	"description": "Base SCSS utilities and variables for WordPress.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/blob/package.json
+++ b/packages/blob/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/blob",
-	"version": "3.35.0",
+	"version": "3.35.1",
 	"description": "Blob utilities for WordPress.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/block-directory/package.json
+++ b/packages/block-directory/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/block-directory",
-	"version": "4.12.0",
+	"version": "4.12.1",
 	"description": "Extend editor with block directory features to search, download and install blocks.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/block-editor/package.json
+++ b/packages/block-editor/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/block-editor",
-	"version": "12.3.0",
+	"version": "12.3.1",
 	"description": "Generic block editor.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/block-library/package.json
+++ b/packages/block-library/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/block-library",
-	"version": "8.12.0",
+	"version": "8.12.1",
 	"description": "Block library for the WordPress editor.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/block-serialization-default-parser/package.json
+++ b/packages/block-serialization-default-parser/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/block-serialization-default-parser",
-	"version": "4.35.0",
+	"version": "4.35.1",
 	"description": "Block serialization specification parser for WordPress posts.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/block-serialization-spec-parser/package.json
+++ b/packages/block-serialization-spec-parser/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/block-serialization-spec-parser",
-	"version": "4.35.0",
+	"version": "4.35.1",
 	"description": "Block serialization specification parser for WordPress posts.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/blocks",
-	"version": "12.12.0",
+	"version": "12.12.1",
 	"description": "Block API for WordPress.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/browserslist-config/package.json
+++ b/packages/browserslist-config/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/browserslist-config",
-	"version": "5.18.0",
+	"version": "5.18.1",
 	"description": "WordPress Browserslist shared configuration.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/commands/package.json
+++ b/packages/commands/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/commands",
-	"version": "0.6.0",
+	"version": "0.6.1",
 	"description": "Handles the commands menu.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/components",
-	"version": "25.1.0",
+	"version": "25.1.1",
 	"description": "UI components for WordPress.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/compose/package.json
+++ b/packages/compose/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/compose",
-	"version": "6.12.0",
+	"version": "6.12.1",
 	"description": "WordPress higher-order components (HOCs).",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/core-commands/package.json
+++ b/packages/core-commands/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/core-commands",
-	"version": "0.4.0",
+	"version": "0.4.1",
 	"description": "WordPress core reusable commands.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/core-data/package.json
+++ b/packages/core-data/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/core-data",
-	"version": "6.12.0",
+	"version": "6.12.1",
 	"description": "Access to and manipulation of core WordPress entities.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/create-block-tutorial-template/package.json
+++ b/packages/create-block-tutorial-template/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/create-block-tutorial-template",
-	"version": "2.23.0",
+	"version": "2.23.1",
 	"description": "Template for @wordpress/create-block used in the official WordPress tutorial.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/create-block/package.json
+++ b/packages/create-block/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/create-block",
-	"version": "4.19.0",
+	"version": "4.19.1",
 	"description": "Generates PHP, JS and CSS code for registering a block for a WordPress plugin.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/customize-widgets/package.json
+++ b/packages/customize-widgets/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/customize-widgets",
-	"version": "4.12.0",
+	"version": "4.12.1",
 	"description": "Widgets blocks in Customizer Module for WordPress.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/data-controls/package.json
+++ b/packages/data-controls/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/data-controls",
-	"version": "3.4.0",
+	"version": "3.4.1",
 	"description": "A set of common controls for the @wordpress/data api.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/data/package.json
+++ b/packages/data/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/data",
-	"version": "9.5.0",
+	"version": "9.5.1",
 	"description": "Data module for WordPress.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/date/package.json
+++ b/packages/date/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/date",
-	"version": "4.35.0",
+	"version": "4.35.1",
 	"description": "Date module for WordPress.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/dependency-extraction-webpack-plugin/package.json
+++ b/packages/dependency-extraction-webpack-plugin/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/dependency-extraction-webpack-plugin",
-	"version": "4.18.0",
+	"version": "4.18.1",
 	"description": "Extract WordPress script dependencies from webpack bundles.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/deprecated/package.json
+++ b/packages/deprecated/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/deprecated",
-	"version": "3.35.0",
+	"version": "3.35.1",
 	"description": "Deprecation utility for WordPress.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/docgen/package.json
+++ b/packages/docgen/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/docgen",
-	"version": "1.44.0",
+	"version": "1.44.1",
 	"description": "Autogenerate public API documentation from exports and JSDoc comments.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/dom-ready/package.json
+++ b/packages/dom-ready/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/dom-ready",
-	"version": "3.35.0",
+	"version": "3.35.1",
 	"description": "Execute callback after the DOM is loaded.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/dom/package.json
+++ b/packages/dom/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/dom",
-	"version": "3.35.0",
+	"version": "3.35.1",
 	"description": "DOM utilities module for WordPress.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/e2e-test-utils-playwright/package.json
+++ b/packages/e2e-test-utils-playwright/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/e2e-test-utils-playwright",
-	"version": "0.3.0",
+	"version": "0.3.1",
 	"description": "End-To-End (E2E) test utils for WordPress.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/e2e-test-utils/package.json
+++ b/packages/e2e-test-utils/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/e2e-test-utils",
-	"version": "10.6.0",
+	"version": "10.6.1",
 	"description": "End-To-End (E2E) test utils for WordPress.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/e2e-tests/package.json
+++ b/packages/e2e-tests/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/e2e-tests",
-	"version": "7.6.0",
+	"version": "7.6.1",
 	"description": "End-To-End (E2E) tests for WordPress.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/edit-post/package.json
+++ b/packages/edit-post/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/edit-post",
-	"version": "7.12.0",
+	"version": "7.12.1",
 	"description": "Edit Post module for WordPress.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",
@@ -39,7 +39,7 @@
 		"@wordpress/core-data": "file:../core-data",
 		"@wordpress/data": "file:../data",
 		"@wordpress/deprecated": "file:../deprecated",
-		"@wordpress/dom": "^3.20.0",
+		"@wordpress/dom": "^3.35.1",
 		"@wordpress/editor": "file:../editor",
 		"@wordpress/element": "file:../element",
 		"@wordpress/hooks": "file:../hooks",

--- a/packages/edit-site/package.json
+++ b/packages/edit-site/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/edit-site",
-	"version": "5.12.0",
+	"version": "5.12.1",
 	"description": "Edit Site Page module for WordPress.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/edit-widgets/package.json
+++ b/packages/edit-widgets/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/edit-widgets",
-	"version": "5.12.0",
+	"version": "5.12.1",
 	"description": "Widgets Page module for WordPress..",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/editor",
-	"version": "13.12.0",
+	"version": "13.12.1",
 	"description": "Enhanced block editor for WordPress posts.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/element/package.json
+++ b/packages/element/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/element",
-	"version": "5.12.0",
+	"version": "5.12.1",
 	"description": "Element React module for WordPress.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/env/package.json
+++ b/packages/env/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/env",
-	"version": "8.1.1",
+	"version": "8.1.2",
 	"description": "A zero-config, self contained local WordPress environment for development and testing.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/escape-html/package.json
+++ b/packages/escape-html/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/escape-html",
-	"version": "2.35.0",
+	"version": "2.35.1",
 	"description": "Escape HTML utils.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/eslint-plugin",
-	"version": "14.8.0",
+	"version": "14.8.1",
 	"description": "ESLint plugin for WordPress development.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/format-library/package.json
+++ b/packages/format-library/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/format-library",
-	"version": "4.12.0",
+	"version": "4.12.1",
 	"description": "Format library for the WordPress editor.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/hooks",
-	"version": "3.35.0",
+	"version": "3.35.1",
 	"description": "WordPress hooks library.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/html-entities/package.json
+++ b/packages/html-entities/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/html-entities",
-	"version": "3.35.0",
+	"version": "3.35.1",
 	"description": "HTML entity utilities for WordPress.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/i18n",
-	"version": "4.35.0",
+	"version": "4.35.1",
 	"description": "WordPress internationalization (i18n) library.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/icons",
-	"version": "9.26.0",
+	"version": "9.26.1",
 	"description": "WordPress Icons package, based on dashicon.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/interface/package.json
+++ b/packages/interface/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/interface",
-	"version": "5.12.0",
+	"version": "5.12.1",
 	"description": "Interface module for WordPress. The package contains shared functionality across the modern JavaScript-based WordPress screens.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/is-shallow-equal/package.json
+++ b/packages/is-shallow-equal/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/is-shallow-equal",
-	"version": "4.35.0",
+	"version": "4.35.1",
 	"description": "Test for shallow equality between two objects or arrays.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/jest-console/package.json
+++ b/packages/jest-console/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/jest-console",
-	"version": "7.6.0",
+	"version": "7.6.1",
 	"description": "Custom Jest matchers for the Console object.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/jest-preset-default/package.json
+++ b/packages/jest-preset-default/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/jest-preset-default",
-	"version": "11.6.0",
+	"version": "11.6.1",
 	"description": "Default Jest preset for WordPress development.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/jest-puppeteer-axe/package.json
+++ b/packages/jest-puppeteer-axe/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/jest-puppeteer-axe",
-	"version": "6.6.0",
+	"version": "6.6.1",
 	"description": "Axe API integration with Jest and Puppeteer.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/keyboard-shortcuts/package.json
+++ b/packages/keyboard-shortcuts/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/keyboard-shortcuts",
-	"version": "4.12.0",
+	"version": "4.12.1",
 	"description": "Handling keyboard shortcuts.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/keycodes/package.json
+++ b/packages/keycodes/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/keycodes",
-	"version": "3.35.0",
+	"version": "3.35.1",
 	"description": "Keycodes utilities for WordPress. Used to check for keyboard events across browsers/operating systems.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/lazy-import/package.json
+++ b/packages/lazy-import/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/lazy-import",
-	"version": "1.22.0",
+	"version": "1.22.1",
 	"description": "Lazily import a module, installing it automatically if missing.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/list-reusable-blocks/package.json
+++ b/packages/list-reusable-blocks/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/list-reusable-blocks",
-	"version": "4.12.0",
+	"version": "4.12.1",
 	"description": "Adding Export/Import support to the reusable blocks listing.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/media-utils/package.json
+++ b/packages/media-utils/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/media-utils",
-	"version": "4.26.0",
+	"version": "4.26.1",
 	"description": "WordPress Media Upload Utils.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/notices/package.json
+++ b/packages/notices/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/notices",
-	"version": "4.3.0",
+	"version": "4.3.1",
 	"description": "State management for notices.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/npm-package-json-lint-config/package.json
+++ b/packages/npm-package-json-lint-config/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/npm-package-json-lint-config",
-	"version": "4.20.0",
+	"version": "4.20.1",
 	"description": "WordPress npm-package-json-lint shareable configuration.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/plugins",
-	"version": "6.3.0",
+	"version": "6.3.1",
 	"description": "Plugins module for WordPress.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/postcss-plugins-preset/package.json
+++ b/packages/postcss-plugins-preset/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/postcss-plugins-preset",
-	"version": "4.19.0",
+	"version": "4.19.1",
 	"description": "PostCSS sharable plugins preset for WordPress development.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/postcss-themes/package.json
+++ b/packages/postcss-themes/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/postcss-themes",
-	"version": "5.18.0",
+	"version": "5.18.1",
 	"description": "PostCSS plugin to generate theme colors.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/preferences-persistence/package.json
+++ b/packages/preferences-persistence/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/preferences-persistence",
-	"version": "1.27.0",
+	"version": "1.27.1",
 	"description": "Persistence utilities for `wordpress/preferences`.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/preferences/package.json
+++ b/packages/preferences/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/preferences",
-	"version": "3.12.0",
+	"version": "3.12.1",
 	"description": "Utilities for managing WordPress preferences.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/prettier-config/package.json
+++ b/packages/prettier-config/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/prettier-config",
-	"version": "2.18.0",
+	"version": "2.18.1",
 	"description": "WordPress Prettier shared configuration.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/primitives/package.json
+++ b/packages/primitives/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/primitives",
-	"version": "3.33.0",
+	"version": "3.33.1",
 	"description": "WordPress cross-platform primitives.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/priority-queue/package.json
+++ b/packages/priority-queue/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/priority-queue",
-	"version": "2.35.0",
+	"version": "2.35.1",
 	"description": "Generic browser priority queue.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/private-apis/package.json
+++ b/packages/private-apis/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/private-apis",
-	"version": "0.17.0",
+	"version": "0.17.1",
 	"description": "Internal experimental APIs for WordPress core.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/project-management-automation/package.json
+++ b/packages/project-management-automation/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/project-management-automation",
-	"version": "1.34.0",
+	"version": "1.34.1",
 	"description": "GitHub Action that implements various automation to assist with managing the Gutenberg GitHub repository.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/react-i18n/package.json
+++ b/packages/react-i18n/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/react-i18n",
-	"version": "3.33.0",
+	"version": "3.33.1",
 	"description": "React bindings for @wordpress/i18n.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/readable-js-assets-webpack-plugin/package.json
+++ b/packages/readable-js-assets-webpack-plugin/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/readable-js-assets-webpack-plugin",
-	"version": "2.18.0",
+	"version": "2.18.1",
 	"description": "Generate a readable JS file for each JS asset.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/redux-routine/package.json
+++ b/packages/redux-routine/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/redux-routine",
-	"version": "4.35.0",
+	"version": "4.35.1",
 	"description": "Redux middleware for generator coroutines.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/reusable-blocks/package.json
+++ b/packages/reusable-blocks/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/reusable-blocks",
-	"version": "4.12.0",
+	"version": "4.12.1",
 	"description": "Reusable blocks utilities.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/rich-text/package.json
+++ b/packages/rich-text/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/rich-text",
-	"version": "6.12.0",
+	"version": "6.12.1",
 	"description": "Rich text value and manipulation API.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/router",
-	"version": "0.4.0",
+	"version": "0.4.1",
 	"description": "Router API for WordPress pages.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/scripts",
-	"version": "26.6.0",
+	"version": "26.6.1",
 	"description": "Collection of reusable scripts for WordPress development.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/server-side-render/package.json
+++ b/packages/server-side-render/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/server-side-render",
-	"version": "4.12.0",
+	"version": "4.12.1",
 	"description": "The component used with WordPress to server-side render a preview of dynamic blocks to display in the editor.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/shortcode/package.json
+++ b/packages/shortcode/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/shortcode",
-	"version": "3.35.0",
+	"version": "3.35.1",
 	"description": "Shortcode module for WordPress.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/style-engine/package.json
+++ b/packages/style-engine/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/style-engine",
-	"version": "1.18.0",
+	"version": "1.18.1",
 	"description": "A suite of parsers and compilers for WordPress styles.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/stylelint-config/package.json
+++ b/packages/stylelint-config/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/stylelint-config",
-	"version": "21.18.0",
+	"version": "21.18.1",
 	"description": "stylelint config for WordPress development.",
 	"author": "The WordPress Contributors",
 	"license": "MIT",

--- a/packages/token-list/package.json
+++ b/packages/token-list/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/token-list",
-	"version": "2.35.0",
+	"version": "2.35.1",
 	"description": "Constructable, plain JavaScript DOMTokenList implementation, supporting non-browser runtimes.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/url/package.json
+++ b/packages/url/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/url",
-	"version": "3.36.0",
+	"version": "3.36.1",
 	"description": "WordPress URL utilities.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/viewport/package.json
+++ b/packages/viewport/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/viewport",
-	"version": "5.12.0",
+	"version": "5.12.1",
 	"description": "Viewport module for WordPress.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/warning/package.json
+++ b/packages/warning/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/warning",
-	"version": "2.35.0",
+	"version": "2.35.1",
 	"description": "Warning utility for WordPress.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/widgets/package.json
+++ b/packages/widgets/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/widgets",
-	"version": "3.12.0",
+	"version": "3.12.1",
 	"description": "Functionality used by the widgets block editor in the Widgets screen and the Customizer.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/wordcount/package.json
+++ b/packages/wordcount/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/wordcount",
-	"version": "3.35.0",
+	"version": "3.35.1",
 	"description": "WordPress word count utility.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

I triggered the Publish [npm packages workflow](https://github.com/WordPress/gutenberg/actions/runs/5372942662) manually after 16.1 RC and chose the `wp` workflow, not realising it would publish patch versions for all the packages 😬 

Not sure if this ultimately makes much difference because this project has historically taken a somewhat relaxed approach to semver.

But given that the package versions were bumped in the WP branch, it's probably best to merge them back into trunk.
