### PR TITLE
Patterns: Fix missing custom patterns in patterns explorer

### DIFF
--- a/packages/block-editor/src/components/block-patterns-list/index.js
+++ b/packages/block-editor/src/components/block-patterns-list/index.js
@@ -150,7 +150,13 @@ function BlockPatternList( {
 						showTooltip={ showTitlesAsTooltip }
 					/>
 				) : (
-					<BlockPatternPlaceholder key={ pattern.name } />
+					<BlockPatternPlaceholder
+						key={
+							pattern.name === 'core/block'
+								? pattern.id
+								: pattern.name
+						}
+					/>
 				);
 			} ) }
 		</Composite>

--- a/packages/block-editor/src/components/block-patterns-list/index.js
+++ b/packages/block-editor/src/components/block-patterns-list/index.js
@@ -137,11 +137,7 @@ function BlockPatternList( {
 				const isShown = shownPatterns.includes( pattern );
 				return isShown ? (
 					<BlockPattern
-						key={
-							pattern.name === 'core/block'
-								? pattern.id
-								: pattern.name
-						}
+						key={ pattern.name }
 						pattern={ pattern }
 						onClick={ onClickPattern }
 						onHover={ onHover }
@@ -150,13 +146,7 @@ function BlockPatternList( {
 						showTooltip={ showTitlesAsTooltip }
 					/>
 				) : (
-					<BlockPatternPlaceholder
-						key={
-							pattern.name === 'core/block'
-								? pattern.id
-								: pattern.name
-						}
-					/>
+					<BlockPatternPlaceholder key={ pattern.name } />
 				);
 			} ) }
 		</Composite>

--- a/packages/block-editor/src/components/block-patterns-list/index.js
+++ b/packages/block-editor/src/components/block-patterns-list/index.js
@@ -137,7 +137,12 @@ function BlockPatternList( {
 				const isShown = shownPatterns.includes( pattern );
 				return isShown ? (
 					<BlockPattern
-						key={ pattern.name }
+						key={
+							// User added unsynced patterns do not have a unique name so we use the id instead.
+							pattern.name === 'core/block'
+								? pattern.id
+								: pattern.name
+						}
 						pattern={ pattern }
 						onClick={ onClickPattern }
 						onHover={ onHover }
@@ -146,7 +151,13 @@ function BlockPatternList( {
 						showTooltip={ showTitlesAsTooltip }
 					/>
 				) : (
-					<BlockPatternPlaceholder key={ pattern.name } />
+					<BlockPatternPlaceholder
+						key={
+							pattern.name === 'core/block'
+								? pattern.id
+								: pattern.name
+						}
+					/>
 				);
 			} ) }
 		</Composite>

--- a/packages/block-editor/src/components/inserter/block-patterns-explorer/patterns-list.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-explorer/patterns-list.js
@@ -6,7 +6,6 @@ import { _n, sprintf } from '@wordpress/i18n';
 import { useDebounce, useAsyncList } from '@wordpress/compose';
 import { __experimentalHeading as Heading } from '@wordpress/components';
 import { speak } from '@wordpress/a11y';
-import { parse } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -15,7 +14,7 @@ import BlockPatternsList from '../../block-patterns-list';
 import InserterNoResults from '../no-results';
 import useInsertionPoint from '../hooks/use-insertion-point';
 import usePatternsState from '../hooks/use-patterns-state';
-import useBlockTypesState from '../hooks/use-block-types-state';
+import useUnsyncedPatterns from '../hooks/use-unsynced-patterns';
 import InserterListbox from '../../inserter-listbox';
 import { searchItems } from '../search-items';
 
@@ -54,24 +53,12 @@ function PatternList( { filterValue, selectedCategory, patternCategories } ) {
 		onInsertBlocks,
 		destinationRootClientId
 	);
-	const [ unsyncedPatterns ] = useBlockTypesState(
+
+	const filteredUnsyncedPatterns = useUnsyncedPatterns(
 		destinationRootClientId,
 		onInsertBlocks,
-		'unsynced'
+		true
 	);
-	const filteredUnsyncedPatterns = useMemo( () => {
-		return unsyncedPatterns
-			.filter(
-				( { category: unsyncedPatternCategory } ) =>
-					unsyncedPatternCategory === 'reusable'
-			)
-			.map( ( syncedPattern ) => ( {
-				...syncedPattern,
-				blocks: parse( syncedPattern.content, {
-					__unstableSkipMigrationLogs: true,
-				} ),
-			} ) );
-	}, [ unsyncedPatterns ] );
 
 	const registeredPatternCategories = useMemo(
 		() =>

--- a/packages/block-editor/src/components/inserter/block-patterns-explorer/patterns-list.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-explorer/patterns-list.js
@@ -112,16 +112,16 @@ function PatternList( { filterValue, selectedCategory, patternCategories } ) {
 		debouncedSpeak( resultsFoundMessage );
 	}, [ filterValue, debouncedSpeak ] );
 
-	const patterns =
-		selectedCategory === 'reusable'
-			? filteredUnsyncedPatterns
-			: filteredBlockPatterns;
-
-	const currentShownPatterns = useAsyncList( patterns, {
+	const blockPatterns = useAsyncList( filteredBlockPatterns, {
 		step: INITIAL_INSERTER_RESULTS,
 	} );
 
-	const hasItems = !! patterns?.length;
+	const currentShownPatterns =
+		selectedCategory === 'reusable'
+			? filteredUnsyncedPatterns
+			: blockPatterns;
+
+	const hasItems = !! currentShownPatterns?.length;
 	return (
 		<div className="block-editor-block-patterns-explorer__list">
 			{ hasItems && (
@@ -135,7 +135,7 @@ function PatternList( { filterValue, selectedCategory, patternCategories } ) {
 				{ hasItems && (
 					<BlockPatternsList
 						shownPatterns={ currentShownPatterns }
-						blockPatterns={ patterns }
+						blockPatterns={ currentShownPatterns }
 						onClickPattern={ onSelectBlockPattern }
 						isDraggable={ false }
 					/>

--- a/packages/block-editor/src/components/inserter/block-patterns-explorer/patterns-list.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-explorer/patterns-list.js
@@ -116,10 +116,12 @@ function PatternList( { filterValue, selectedCategory, patternCategories } ) {
 		step: INITIAL_INSERTER_RESULTS,
 	} );
 
+	const blockPatternsUnsynced = useAsyncList( filteredUnsyncedPatterns, {
+		step: INITIAL_INSERTER_RESULTS,
+	} );
+
 	const currentShownPatterns =
-		selectedCategory === 'reusable'
-			? filteredUnsyncedPatterns
-			: blockPatterns;
+		selectedCategory === 'reusable' ? blockPatternsUnsynced : blockPatterns;
 
 	const hasItems = !! currentShownPatterns?.length;
 	return (

--- a/packages/block-editor/src/components/inserter/block-patterns-tab.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-tab.js
@@ -214,7 +214,14 @@ export function BlockPatternsCategoryPanel( {
 		category.name === 'reusable'
 			? filteredUnsyncedPatterns
 			: currentCategoryPatterns;
-	const currentShownPatterns = useAsyncList( patterns );
+
+	const unsyncedPatternsList = useAsyncList( filteredUnsyncedPatterns );
+	const categoryPatternsList = useAsyncList( currentCategoryPatterns );
+
+	const currentShownPatterns =
+		category.name === 'reusable'
+			? unsyncedPatternsList
+			: categoryPatternsList;
 
 	// Hide block pattern preview on unmount.
 	useEffect( () => () => onHover( null ), [] );

--- a/packages/block-editor/src/components/inserter/block-patterns-tab.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-tab.js
@@ -18,7 +18,6 @@ import {
 	Button,
 } from '@wordpress/components';
 import { Icon, chevronRight, chevronLeft } from '@wordpress/icons';
-import { parse } from '@wordpress/blocks';
 import { focus } from '@wordpress/dom';
 
 /**
@@ -28,7 +27,7 @@ import usePatternsState from './hooks/use-patterns-state';
 import BlockPatternList from '../block-patterns-list';
 import PatternsExplorerModal from './block-patterns-explorer/explorer';
 import MobileTabNavigation from './mobile-tab-navigation';
-import useBlockTypesState from './hooks/use-block-types-state';
+import useUnsyncedPatterns from './hooks/use-unsynced-patterns';
 
 const noop = () => {};
 
@@ -51,18 +50,8 @@ function usePatternsCategories( rootClientId ) {
 		rootClientId
 	);
 
-	const [ unsyncedPatterns ] = useBlockTypesState(
-		rootClientId,
-		undefined,
-		'unsynced'
-	);
+	const filteredUnsyncedPatterns = useUnsyncedPatterns( rootClientId );
 
-	const filteredUnsyncedPatterns = useMemo( () => {
-		return unsyncedPatterns.filter(
-			( { category: unsyncedPatternCategory } ) =>
-				unsyncedPatternCategory === 'reusable'
-		);
-	}, [ unsyncedPatterns ] );
 	const hasRegisteredCategory = useCallback(
 		( pattern ) => {
 			if ( ! pattern.categories || ! pattern.categories.length ) {
@@ -169,24 +158,11 @@ export function BlockPatternsCategoryPanel( {
 		onInsert,
 		rootClientId
 	);
-	const [ unsyncedPatterns ] = useBlockTypesState(
+	const filteredUnsyncedPatterns = useUnsyncedPatterns(
 		rootClientId,
 		onInsert,
-		'unsynced'
+		true
 	);
-	const filteredUnsyncedPatterns = useMemo( () => {
-		return unsyncedPatterns
-			.filter(
-				( { category: unsyncedPatternCategory } ) =>
-					unsyncedPatternCategory === 'reusable'
-			)
-			.map( ( syncedPattern ) => ( {
-				...syncedPattern,
-				blocks: parse( syncedPattern.content, {
-					__unstableSkipMigrationLogs: true,
-				} ),
-			} ) );
-	}, [ unsyncedPatterns ] );
 
 	const availableCategories = usePatternsCategories( rootClientId );
 	const currentCategoryPatterns = useMemo(

--- a/packages/block-editor/src/components/inserter/hooks/use-unsynced-patterns.js
+++ b/packages/block-editor/src/components/inserter/hooks/use-unsynced-patterns.js
@@ -1,0 +1,38 @@
+/**
+ * WordPress dependencies
+ */
+import { useMemo } from '@wordpress/element';
+import { parse } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import useBlockTypesState from '../hooks/use-block-types-state';
+
+export default function useUnsyncedPatterns(
+	rootClientId,
+	onInsert,
+	withBlocks
+) {
+	const [ unsyncedPatterns ] = useBlockTypesState(
+		rootClientId,
+		onInsert,
+		'unsynced'
+	);
+	const filteredUnsyncedPatterns = useMemo( () => {
+		return unsyncedPatterns
+			.filter(
+				( { category: unsyncedPatternCategory } ) =>
+					unsyncedPatternCategory === 'reusable'
+			)
+			.map( ( syncedPattern ) => ( {
+				...syncedPattern,
+				blocks: withBlocks
+					? parse( syncedPattern.content, {
+							__unstableSkipMigrationLogs: true,
+					  } )
+					: undefined,
+			} ) );
+	}, [ unsyncedPatterns, withBlocks ] );
+	return filteredUnsyncedPatterns;
+}


### PR DESCRIPTION
## What?
Adds the new user created custom patterns into the inserter patterns explorer

## Why?
The are not there and they should be.
Fixes: #51844

## How?
Uses the same code as in the inserter to retrieve these patterns, but abstracts this to a hook so it can be shared.

## Testing Instructions
Add some `unsynced` patterns
Go to the tab inserter and select the Patterns tab, and then the `Explore all patterns` button at the bottom
Make sure your new patterns appear under `Custom patterns` and can be inserted

## Screenshots or screencast <!-- if applicable -->
Before:

https://github.com/WordPress/gutenberg/assets/3629020/4f624f58-2e49-46a4-a25f-90be8c71c4d9

After:

https://github.com/WordPress/gutenberg/assets/3629020/10475541-2ac9-48cb-b564-10a8088ef52b


