### PR TITLE
Stack the Switch to draft and Move to Trash buttons vertically.

### DIFF
--- a/packages/edit-post/src/components/sidebar/post-status/index.js
+++ b/packages/edit-post/src/components/sidebar/post-status/index.js
@@ -3,7 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import {
-	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
 	PanelBody,
 } from '@wordpress/components';
 import { withSelect, withDispatch } from '@wordpress/data';
@@ -53,7 +53,7 @@ function PostStatus( { isOpened, onTogglePanel } ) {
 						<PostAuthor />
 						<PostSyncStatus />
 						{ fills }
-						<HStack
+						<VStack
 							style={ {
 								marginTop: '16px',
 							} }
@@ -61,7 +61,7 @@ function PostStatus( { isOpened, onTogglePanel } ) {
 						>
 							<PostSwitchToDraftButton />
 							<PostTrash />
-						</HStack>
+						</VStack>
 					</>
 				) }
 			</PluginPostStatusInfo.Slot>

--- a/packages/edit-post/src/components/sidebar/post-trash/index.js
+++ b/packages/edit-post/src/components/sidebar/post-trash/index.js
@@ -2,14 +2,11 @@
  * WordPress dependencies
  */
 import { PostTrash as PostTrashLink, PostTrashCheck } from '@wordpress/editor';
-import { FlexItem } from '@wordpress/components';
 
 export default function PostTrash() {
 	return (
 		<PostTrashCheck>
-			<FlexItem isBlock>
-				<PostTrashLink />
-			</FlexItem>
+			<PostTrashLink />
 		</PostTrashCheck>
 	);
 }

--- a/packages/editor/src/components/post-switch-to-draft-button/index.js
+++ b/packages/editor/src/components/post-switch-to-draft-button/index.js
@@ -3,7 +3,6 @@
  */
 import {
 	Button,
-	FlexItem,
 	__experimentalConfirmDialog as ConfirmDialog,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
@@ -41,7 +40,7 @@ function PostSwitchToDraftButton( {
 	};
 
 	return (
-		<FlexItem isBlock>
+		<>
 			<Button
 				className="editor-post-switch-to-draft"
 				onClick={ () => {
@@ -60,7 +59,7 @@ function PostSwitchToDraftButton( {
 			>
 				{ alertMessage }
 			</ConfirmDialog>
-		</FlexItem>
+		</>
 	);
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Fixes https://github.com/WordPress/gutenberg/issues/51451

## What?
<!-- In a few words, what is the PR actually doing? -->
Any design needs to account for longer strings when translated in other languages. Typically, English has pretty short words compared to other languages. It is paramount to design taking into account other languags.

The new position of the 'Switch to Draft' and 'Move to Trash' buttons didn't take into account longer translations. Since the two buttons are now stacked horizontally. In most western languages the buttons text oferflows and in some cases it is even cut-off screen.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Test overflows or even cut-off screen in most languages other than English.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Stack the two buttons vertically instead.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

Before:
- Edit a publish post.
- Observe in the Settings panel on the right, the 'Switch to Draft' and 'Move to Trash' buttons are stacked horizontally.
- Switch the WordPress admin to other languages, for example:
  - Spanish 
  - German 
  - Italian 
  - Dutch 
  - Greek 
  - Polish 
  - Portuguese 
  - Russian 
- Refresh the post page.
- Observe the two buttons text overflows the button right edge and in some cases it's even cut-off screen.

Example in German:


<img width="326" alt="german before" src="https://github.com/WordPress/gutenberg/assets/1682452/d64f5174-92be-4a3a-92b2-5c31974f53fd">


- Switch to this branch and build.
- Repeat the steps above.
- Observe the two buttons are now stacked vertically.
- Test the mobile view as well.

Example in German after this change:

<img width="301" alt="german after" src="https://github.com/WordPress/gutenberg/assets/1682452/11215c37-bc0e-44be-8327-627c5fe7780e">


### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
