### PR TITLE
Restore sidebar in focus mode on Pattern click through in Browse Mode `Library` 

### DIFF
--- a/packages/edit-site/src/components/page-library/grid-item.js
+++ b/packages/edit-site/src/components/page-library/grid-item.js
@@ -46,7 +46,7 @@ export default function GridItem( { categoryId, composite, icon, item } ) {
 		postId: item.type === USER_PATTERNS ? item.id : item.name,
 		categoryId,
 		categoryType: item.type,
-		canvas: 'edit',
+		canvas: 'view',
 	} );
 
 	const onKeyDown = ( event ) => {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Updates the link when clicking through from a Browse Mode Library item into focus mode to default to `view` mode rather than `edit`.

Fixes https://github.com/WordPress/gutenberg/issues/51839

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

As detailed in the associated Issue, not showing the sidebar means https://github.com/WordPress/gutenberg/pull/51492 is effectively hidden from the user. 

This PR restores it to be a feature users will actually encounter.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Sets route to `view` rather than `edit`.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

- Make sure your `Header` template part / pattern has a Navigation block with a menu in it.
- Go to `LIbrary` in Browse mode and click through to your `Header` pattern.
- See the sidebar is open and the url has `canvas=view` in it.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
