### PR TITLE
Edit Site: Add delay and fade-in animation to loading spinner

### DIFF
--- a/packages/edit-site/src/components/canvas-spinner/style.scss
+++ b/packages/edit-site/src/components/canvas-spinner/style.scss
@@ -2,10 +2,24 @@
 	width: 100%;
 	height: 100%;
 	display: flex;
+	opacity: 0;
 	align-items: center;
 	justify-content: center;
 
+	animation: 0.5s ease 0.2s edit-site-canvas-spinner__fade-in-animation;
+	animation-fill-mode: forwards;
+	@include reduce-motion("animation");
+
 	circle {
 		stroke: rgba($black, 0.3);
+	}
+}
+
+@keyframes edit-site-canvas-spinner__fade-in-animation {
+	from {
+		opacity: 0;
+	}
+	to {
+		opacity: 1;
 	}
 }

--- a/packages/edit-site/src/components/canvas-spinner/style.scss
+++ b/packages/edit-site/src/components/canvas-spinner/style.scss
@@ -6,7 +6,7 @@
 	align-items: center;
 	justify-content: center;
 
-	animation: 0.5s ease 0.4s edit-site-canvas-spinner__fade-in-animation;
+	animation: 0.5s ease 1s edit-site-canvas-spinner__fade-in-animation;
 	animation-fill-mode: forwards;
 	@include reduce-motion("animation");
 

--- a/packages/edit-site/src/components/canvas-spinner/style.scss
+++ b/packages/edit-site/src/components/canvas-spinner/style.scss
@@ -6,7 +6,7 @@
 	align-items: center;
 	justify-content: center;
 
-	animation: 0.5s ease 0.2s edit-site-canvas-spinner__fade-in-animation;
+	animation: 0.5s ease 0.4s edit-site-canvas-spinner__fade-in-animation;
 	animation-fill-mode: forwards;
 	@include reduce-motion("animation");
 


### PR DESCRIPTION
## What?

This PR adds some minor delay and a fade-in animation to the site editor loading spinner, as suggested by @jasmussen in https://github.com/WordPress/gutenberg/pull/51857#pullrequestreview-1497821335.

This PR is a follow-up to #51857.

## Why?
As @jasmussen, phrased it:

> put some "optimism" into the spinner component. That is, to only ever show it when things take a while to load, and not just to show it. The precise implementation probably needs a little thought, but just as an example, if the spinner only ever faded in after 0.2 seconds passed, that would be an example of optimism: "it might finish before that?"

## How?
We're delaying the appearance by ~0.2~ ~0.4~ 1 second~s~ and fading in the spinner for half a second.

## Testing Instructions
* Open the site editor.
* Observe the loading spinner and verify it works well.
* Particularly observe the initial appearance of the loading spinner.

### Testing Instructions for Keyboard
None

## Screenshots or screencast <!-- if applicable -->
Before:

https://github.com/WordPress/gutenberg/assets/8436925/d4b766a6-cc89-46fe-9652-b648deaf40eb



After:

https://github.com/WordPress/gutenberg/assets/8436925/f79d5712-a1da-4af3-baeb-4f34887351a0


