### PR TITLE
Updating the BlockEditorProvider settings prop should reset the store's settings entirely

### DIFF
--- a/packages/block-editor/src/components/provider/index.js
+++ b/packages/block-editor/src/components/provider/index.js
@@ -28,9 +28,14 @@ export const ExperimentalBlockEditorProvider = withRegistryProvider(
 					...settings,
 					__internalIsInitialized: true,
 				},
-				stripExperimentalSettings
+				stripExperimentalSettings,
+				true
 			);
-		}, [ settings ] );
+		}, [
+			settings,
+			stripExperimentalSettings,
+			__experimentalUpdateSettings,
+		] );
 
 		// Syncs the entity provider with changes in the block-editor store.
 		useBlockSync( props );

--- a/packages/block-editor/src/components/provider/index.js
+++ b/packages/block-editor/src/components/provider/index.js
@@ -28,8 +28,10 @@ export const ExperimentalBlockEditorProvider = withRegistryProvider(
 					...settings,
 					__internalIsInitialized: true,
 				},
-				stripExperimentalSettings,
-				true
+				{
+					stripExperimentalSettings,
+					reset: true,
+				}
 			);
 		}, [
 			settings,

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -1390,7 +1390,9 @@ export function updateBlockListSettings( clientId, settings ) {
  * @return {Object} Action object
  */
 export function updateSettings( settings ) {
-	return __experimentalUpdateSettings( settings, true );
+	return __experimentalUpdateSettings( settings, {
+		stripExperimentalSettings: true,
+	} );
 }
 
 /**

--- a/packages/block-editor/src/store/private-actions.js
+++ b/packages/block-editor/src/store/private-actions.js
@@ -36,7 +36,7 @@ const privateSettings = [
  */
 export function __experimentalUpdateSettings(
 	settings,
-	{ stripExperimentalSettings = false, reset = false }
+	{ stripExperimentalSettings = false, reset = false } = {}
 ) {
 	let cleanSettings = settings;
 	// There are no plugins in the mobile apps, so there is no

--- a/packages/block-editor/src/store/private-actions.js
+++ b/packages/block-editor/src/store/private-actions.js
@@ -30,11 +30,13 @@ const privateSettings = [
  *
  * @param {Object}  settings                  Updated settings
  * @param {boolean} stripExperimentalSettings Whether to strip experimental settings.
+ * @param {boolean} reset                     Whether to reset the settings.
  * @return {Object} Action object
  */
 export function __experimentalUpdateSettings(
 	settings,
-	stripExperimentalSettings = false
+	stripExperimentalSettings = false,
+	reset = false
 ) {
 	let cleanSettings = settings;
 	// There are no plugins in the mobile apps, so there is no
@@ -50,6 +52,7 @@ export function __experimentalUpdateSettings(
 	return {
 		type: 'UPDATE_SETTINGS',
 		settings: cleanSettings,
+		reset,
 	};
 }
 

--- a/packages/block-editor/src/store/private-actions.js
+++ b/packages/block-editor/src/store/private-actions.js
@@ -28,15 +28,15 @@ const privateSettings = [
  * Action that updates the block editor settings and
  * conditionally preserves the experimental ones.
  *
- * @param {Object}  settings                  Updated settings
- * @param {boolean} stripExperimentalSettings Whether to strip experimental settings.
- * @param {boolean} reset                     Whether to reset the settings.
+ * @param {Object}  settings                          Updated settings
+ * @param {Object}  options                           Options object.
+ * @param {boolean} options.stripExperimentalSettings Whether to strip experimental settings.
+ * @param {boolean} options.reset                     Whether to reset the settings.
  * @return {Object} Action object
  */
 export function __experimentalUpdateSettings(
 	settings,
-	stripExperimentalSettings = false,
-	reset = false
+	{ stripExperimentalSettings = false, reset = false }
 ) {
 	let cleanSettings = settings;
 	// There are no plugins in the mobile apps, so there is no

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -1623,6 +1623,12 @@ export function template( state = { isValid: true }, action ) {
 export function settings( state = SETTINGS_DEFAULTS, action ) {
 	switch ( action.type ) {
 		case 'UPDATE_SETTINGS':
+			if ( action.reset ) {
+				return {
+					...SETTINGS_DEFAULTS,
+					...action.settings,
+				};
+			}
 			return {
 				...state,
 				...action.settings,

--- a/packages/block-editor/src/store/test/private-actions.js
+++ b/packages/block-editor/src/store/test/private-actions.js
@@ -6,6 +6,7 @@ import {
 	showBlockInterface,
 	setBlockEditingMode,
 	unsetBlockEditingMode,
+	__experimentalUpdateSettings,
 } from '../private-actions';
 
 describe( 'private actions', () => {
@@ -47,6 +48,54 @@ describe( 'private actions', () => {
 			).toEqual( {
 				type: 'UNSET_BLOCK_EDITING_MODE',
 				clientId: '14501cc2-90a6-4f52-aa36-ab6e896135d1',
+			} );
+		} );
+	} );
+
+	describe( '__experimentalUpdateSettings', () => {
+		const experimentalSettings = {
+			inserterMediaCategories: 'foo',
+			blockInspectorAnimation: 'bar',
+		};
+
+		const stableSettings = {
+			foo: 'foo',
+			bar: 'bar',
+			baz: 'baz',
+		};
+
+		const settings = {
+			...experimentalSettings,
+			...stableSettings,
+		};
+
+		it( 'should dispatch provided settings by default', () => {
+			expect( __experimentalUpdateSettings( settings ) ).toEqual( {
+				type: 'UPDATE_SETTINGS',
+				settings,
+				reset: false,
+			} );
+		} );
+
+		it( 'should dispatch provided settings with reset flag when `reset` argument is truthy', () => {
+			expect(
+				__experimentalUpdateSettings( settings, false, true )
+			).toEqual( {
+				type: 'UPDATE_SETTINGS',
+				settings,
+				reset: true,
+			} );
+		} );
+
+		it( 'should strip experimental settings from a given settings object when `stripExperimentalSettings` argument is truthy', () => {
+			expect( __experimentalUpdateSettings( settings, true ) ).toEqual( {
+				type: 'UPDATE_SETTINGS',
+				settings: {
+					foo: 'foo',
+					bar: 'bar',
+					baz: 'baz',
+				},
+				reset: false,
 			} );
 		} );
 	} );

--- a/packages/block-editor/src/store/test/private-actions.js
+++ b/packages/block-editor/src/store/test/private-actions.js
@@ -79,7 +79,10 @@ describe( 'private actions', () => {
 
 		it( 'should dispatch provided settings with reset flag when `reset` argument is truthy', () => {
 			expect(
-				__experimentalUpdateSettings( settings, false, true )
+				__experimentalUpdateSettings( settings, {
+					stripExperimentalSettings: false,
+					reset: true,
+				} )
 			).toEqual( {
 				type: 'UPDATE_SETTINGS',
 				settings,
@@ -88,7 +91,11 @@ describe( 'private actions', () => {
 		} );
 
 		it( 'should strip experimental settings from a given settings object when `stripExperimentalSettings` argument is truthy', () => {
-			expect( __experimentalUpdateSettings( settings, true ) ).toEqual( {
+			expect(
+				__experimentalUpdateSettings( settings, {
+					stripExperimentalSettings: true,
+				} )
+			).toEqual( {
 				type: 'UPDATE_SETTINGS',
 				settings: {
 					foo: 'foo',

--- a/packages/edit-site/src/components/block-editor/use-site-editor-settings.js
+++ b/packages/edit-site/src/components/block-editor/use-site-editor-settings.js
@@ -78,14 +78,6 @@ export default function useSiteEditorSettings( templateType ) {
 			inserterMediaCategories,
 			__experimentalBlockPatterns: blockPatterns,
 			__experimentalBlockPatternCategories: blockPatternCategories,
-			// Temporary fix for bug in Block Editor Provider:
-			// see: https://github.com/WordPress/gutenberg/issues/51489.
-			// Some Site Editor entities (e.g. `wp_navigation`) may utilise
-			// template locking in their settings. Therefore this must be
-			// explicitly "unset" to avoid the template locking UI remaining
-			// active for all entities.
-			templateLock: false,
-			template: false,
 		};
 	}, [ storedSettings, blockPatterns, blockPatternCategories ] );
 }


### PR DESCRIPTION
closes #51489

## What?

If you render a block editor provider with a special setting (like template) and then you update your prop and omit that particular setting, you expect that setting to restore to the default value (undefined) instead of retaining the previous prop value. This PR ensures that any change to the `settings` prop of `BlockEditorProvider` actually resets the settings entirely.

This bug was discovered in https://github.com/WordPress/gutenberg/pull/39286#discussion_r1229247173

## Testing Instructions

Switch between "Navigation" and other entities in the site editor (templates). Template locking should remain active when doing so. You should be able to edit top level blocks in the template.