### PR TITLE
Lodash: Refactor away from `_.kebabCase()` in `getCleanTemplatePartSlug`

### DIFF
--- a/packages/edit-site/src/utils/template-part-create.js
+++ b/packages/edit-site/src/utils/template-part-create.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { kebabCase } from 'lodash';
+import { paramCase as kebabCase } from 'change-case';
 
 /**
  * WordPress dependencies


### PR DESCRIPTION
## What?
This PR removes Lodash's `_.kebabCase()` from the `getCleanTemplatePartSlug` helper function.

We have a few more usages of `kebabCase()` left in the codebase, but we might have to tread carefully, since some of them may have to deal with unicode characters, and I prefer testing those one by one.

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?

We're replacing the usage with `paramCase` from the `change-case` package, which we've already been utilizing for the general use cases. That's fine, since the utility function already claims to support only latin letters.

## Testing Instructions

* Go to `/wp-admin/site-editor.php?path=%2Flibrary`
* Click on the "+" button and click "Create template part"
* Input some title of the template part that includes non-alphanumeric characters, like `Custom % template part #$`, or try with some unicode characters, like Japanese for example
* Verify the slug of the template part is proper, in the above case, still `custom-template-part`.
* Verify tests pass - the function is covered by unit tests.