### PR TITLE
Lodash: Refactor away from `_.kebabCase()` in generic template modal

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -100,6 +100,7 @@ const restrictedImports = [
 			'isPlainObject',
 			'isString',
 			'isUndefined',
+			'kebabCase',
 			'keyBy',
 			'keys',
 			'last',

--- a/packages/edit-site/src/components/add-new-template/add-custom-generic-template-modal-content.js
+++ b/packages/edit-site/src/components/add-new-template/add-custom-generic-template-modal-content.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { kebabCase } from 'lodash';
+import { paramCase as kebabCase } from 'change-case';
 
 /**
  * WordPress dependencies


### PR DESCRIPTION
## What?
This PR removes Lodash's `_.kebabCase()` from the generic template creation modal component.

Since this is the last usage of `_.kebabCase()`, we're also deprecating the function through ESLint.

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?

We're replacing the usage with `paramCase` from the `change-case` package, which we've already been utilizing for the general use cases. I think that's fine since a unique slug is being generated on the backend and used instead of the one generated on the client anyway:

https://github.com/WordPress/gutenberg/blob/1464f1841c369b1de5b9442a4465411ec4b07ec1/packages/edit-site/src/components/add-new-template/new-template.js#L191-L207

plus, slugs with Unicode characters tend to be less readable anyway, so I personally see this as an improvement. For example, using `初島しじ下法ウ共旅もレあし重名どて暮園` as the title would result in the template slug being `wp-custom-template-%25e5%2588%259d%25e5%25b3%25b6%25e3%2581%2597%25e3%2581%2598%25e4%25b8%258b%25e6%25b3%2595%25e3%2582%25a6%25e5%2585%25b1%25e6%2597%2585%25e3%2582%2582%25e3%2583%25ac%25e3%2581%2582%25e3%2581%2597%25e9%2587%258d%25e5%2590%258d%25e3%2581%25a9%25e3%2581%25a6%25e6%259a%25ae%25e5%259c%2592`, which is quite terrible IMHO.

## Testing Instructions

* Go to `/wp-admin/site-editor.php?path=%2Fwp_template`
* Click on the "+" icon to add a new template.
* In the modal, click on "Custom template".
* Input some title of the template part that includes non-alphanumeric characters, like Custom % template #$, or try with some Unicode characters, like Japanese for example.
* Click "Create" to create the template.
* Verify that you're redirected to edit the template, and after refreshing, it properly opens the page to edit that same template.
* Verify all checks are green.