### PR TITLE
Lodash: Refactor away from `_.kebabCase()` in add page modal

### DIFF
--- a/packages/edit-site/src/components/add-new-page/index.js
+++ b/packages/edit-site/src/components/add-new-page/index.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { kebabCase } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import {
@@ -41,7 +36,7 @@ export default function AddNewPageModal( { onSave, onClose } ) {
 				{
 					status: 'draft',
 					title,
-					slug: kebabCase( title || __( 'No title' ) ),
+					slug: title || __( 'No title' ),
 				},
 				{ throwOnError: true }
 			);


### PR DESCRIPTION
## What?
This PR removes Lodash's `_.kebabCase()` from the page creation modal.

We have a few more usages of `kebabCase()` left in the codebase, but we might have to tread carefully, since some of them may have to deal with unicode characters, and I prefer testing those one by one.

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?

We're removing the `kebabCase()` usage since even if we pass a non-slugfied slug to `wp_insert_post()`, it will slugify it and return it properly slugified to us. That means that there's no good reason to slugify on the client side.

## Testing Instructions

* Go to `/wp-admin/site-editor.php?path=%2Fpage`
* Click on the "+" button to start creating a new page.
* Input some title of the page that includes non-alphanumeric characters, like `Custom % page #$`, or try with some unicode characters, like Japanese for example and click the button to create the page
* Verify the slug of the page is proper, in the above case, still `custom-page`.
* Verify all checks pass.