### PR TITLE
Try controlled navigator behavior

### DIFF
--- a/packages/components/src/navigator/navigator-provider/component.tsx
+++ b/packages/components/src/navigator/navigator-provider/component.tsx
@@ -105,6 +105,7 @@ function UnconnectedNavigatorProvider(
 			].path === destinationPath;
 
 		if ( isNavigatingToPreviousPath ) {
+			// Navigating back to previous location
 			setLocationHistory( ( prevLocationHistory ) => {
 				if ( prevLocationHistory.length <= 1 ) {
 					return prevLocationHistory;
@@ -120,48 +121,50 @@ function UnconnectedNavigatorProvider(
 					},
 				];
 			} );
-			return;
+		} else {
+			// Navigating to a new location
+			setLocationHistory( ( prevLocationHistory ) => {
+				const newLocation = {
+					...restOptions,
+					path: destinationPath,
+					isBack,
+					hasRestoredFocus: false,
+					skipFocus,
+				};
+
+				if ( prevLocationHistory.length === 0 ) {
+					return replace ? [] : [ newLocation ];
+				}
+
+				// Form the new location history array.
+				// Start by picking all previous history items, apart from the last one.
+				// A check is in place to make sure that the array doesn't grow
+				// beyond a max length.
+				const newLocationHistory = prevLocationHistory.slice(
+					prevLocationHistory.length > MAX_HISTORY_LENGTH - 1 ? 1 : 0,
+					-1
+				);
+
+				// If we're not replacing history, add the last location history item (the
+				// one what was just navigated from). We also assign it a
+				// `focusTargetSelector` for enhanced focus restoration when navigating
+				// back to it.
+				if ( ! replace ) {
+					newLocationHistory.push( {
+						...prevLocationHistory[
+							prevLocationHistory.length - 1
+						],
+						focusTargetSelector,
+					} );
+				}
+
+				// In any case, append the new location to the array (the one that
+				// was just navigated to)
+				newLocationHistory.push( newLocation );
+
+				return newLocationHistory;
+			} );
 		}
-
-		setLocationHistory( ( prevLocationHistory ) => {
-			const newLocation = {
-				...restOptions,
-				path: destinationPath,
-				isBack,
-				hasRestoredFocus: false,
-				skipFocus,
-			};
-
-			if ( prevLocationHistory.length === 0 ) {
-				return replace ? [] : [ newLocation ];
-			}
-
-			// Form the new location history array.
-			// Start by picking all previous history items, apart from the last one.
-			// A check is in place to make sure that the array doesn't grow
-			// beyond a max length.
-			const newLocationHistory = prevLocationHistory.slice(
-				prevLocationHistory.length > MAX_HISTORY_LENGTH - 1 ? 1 : 0,
-				-1
-			);
-
-			// If we're not replacing history, add the last location history item (the
-			// one what was just navigated from). We also assign it a
-			// `focusTargetSelector` for enhanced focus restoration when navigating
-			// back to it.
-			if ( ! replace ) {
-				newLocationHistory.push( {
-					...prevLocationHistory[ prevLocationHistory.length - 1 ],
-					focusTargetSelector,
-				} );
-			}
-
-			// In any case, append the new location to the array (the one that
-			// was just navigated to)
-			newLocationHistory.push( newLocation );
-
-			return newLocationHistory;
-		} );
 	}, [ location ] );
 
 	const currentMatch = useRef< MatchedPath >();

--- a/packages/components/src/navigator/navigator-provider/component.tsx
+++ b/packages/components/src/navigator/navigator-provider/component.tsx
@@ -65,7 +65,7 @@ function UnconnectedNavigatorProvider(
 		className,
 		...otherProps
 	} = useContextSystem( props, 'NavigatorProvider' );
-	const [ location, updatedLocation ] = useControlledValue( {
+	const [ location, updateLocation ] = useControlledValue( {
 		onChange,
 		value: locationProp,
 		defaultValue: { path: initialPath },
@@ -217,22 +217,22 @@ function UnconnectedNavigatorProvider(
 			return;
 		}
 
-		updatedLocation( {
+		updateLocation( {
 			isBack: true,
 			path: currentLocationHistory.current[
 				currentLocationHistory.current.length - 2
 			].path,
 		} );
-	}, [ updatedLocation ] );
+	}, [ updateLocation ] );
 
 	const goTo: NavigatorContextType[ 'goTo' ] = useCallback(
 		( destinationPath, options = {} ) => {
-			updatedLocation( {
+			updateLocation( {
 				...options,
 				path: destinationPath,
 			} );
 		},
-		[ updatedLocation ]
+		[ updateLocation ]
 	);
 
 	const goToParent: NavigatorContextType[ 'goToParent' ] = useCallback(

--- a/packages/components/src/navigator/stories/index.story.tsx
+++ b/packages/components/src/navigator/stories/index.story.tsx
@@ -4,6 +4,11 @@
 import type { Meta, StoryFn } from '@storybook/react';
 
 /**
+ * WordPress dependencies
+ */
+import { useState } from '@wordpress/element';
+
+/**
  * Internal dependencies
  */
 import Button from '../../button';
@@ -18,6 +23,7 @@ import {
 	NavigatorToParentButton,
 	useNavigator,
 } from '..';
+import type { NavigatorLocation } from '../types';
 
 const meta: Meta< typeof NavigatorProvider > = {
 	component: NavigatorProvider,
@@ -363,4 +369,72 @@ SkipFocus.args = {
 			</NavigatorButtonWithSkipFocus>
 		</>
 	),
+};
+
+export const ControlledNavigator: StoryFn< typeof NavigatorProvider > = (
+	props
+) => {
+	const [ location, setLocation ] = useState< NavigatorLocation >( {
+		path: props.initialPath ?? '/',
+	} );
+	return (
+		<NavigatorProvider
+			{ ...props }
+			location={ location }
+			onChange={ setLocation }
+			style={ { ...props.style, height: '100vh', maxHeight: '450px' } }
+		>
+			<NavigatorScreen path="/">
+				<Card>
+					<CardBody>
+						<NavigatorButton variant="secondary" path="/child1">
+							Go to first child.
+						</NavigatorButton>
+						<NavigatorButton variant="secondary" path="/child2">
+							Go to second child.
+						</NavigatorButton>
+					</CardBody>
+				</Card>
+			</NavigatorScreen>
+			<NavigatorScreen path="/child1">
+				<Card>
+					<CardBody>
+						This is the first child
+						<NavigatorToParentButton variant="secondary">
+							Go back to parent
+						</NavigatorToParentButton>
+					</CardBody>
+				</Card>
+			</NavigatorScreen>
+			<NavigatorScreen path="/child2">
+				<Card>
+					<CardBody>
+						This is the second child
+						<NavigatorToParentButton variant="secondary">
+							Go back to parent
+						</NavigatorToParentButton>
+						<NavigatorButton
+							variant="secondary"
+							path="/child2/grandchild"
+						>
+							Go to grand child.
+						</NavigatorButton>
+					</CardBody>
+				</Card>
+			</NavigatorScreen>
+			<NavigatorScreen path="/child2/grandchild">
+				<Card>
+					<CardBody>
+						This is the grand child
+						<NavigatorToParentButton variant="secondary">
+							Go back to parent
+						</NavigatorToParentButton>
+					</CardBody>
+				</Card>
+			</NavigatorScreen>
+		</NavigatorProvider>
+	);
+};
+ControlledNavigator.args = {
+	initialPath: '/child2/grandchild',
 };

--- a/packages/components/src/navigator/types.ts
+++ b/packages/components/src/navigator/types.ts
@@ -44,11 +44,24 @@ export type NavigatorProviderProps = {
 	/**
 	 * The initial active path.
 	 */
-	initialPath: string;
+	initialPath?: string;
+
 	/**
 	 * The children elements.
 	 */
 	children: ReactNode;
+
+	/**
+	 * The current path. When provided the navigator will be controlled.
+	 */
+	location?: NavigatorLocation;
+
+	/**
+	 * Navigates to a new path.
+	 *
+	 * @param path The path to navigate to.
+	 */
+	onChange?: ( location: NavigatorLocation ) => void;
 };
 
 export type NavigatorScreenProps = {


### PR DESCRIPTION
Related to discussion in #51760 

## What?

This PR tries to support a "controlled" mode for the navigator component. There are still some open questions about the history/focus management...

I've added a storybook story to be able to test this properly, I didn't update the site editor yet to use it.

**What we care about from the site editor's perspective**

 - Being able to control the path from the site editor
 - We do care about focus management (going down and going to parent should ideally restore the focus properly) but we do not care about "controlling" these properties, it's fine if we find a way to keep these flags and elements and all internal.
 - We don't really care about "history", we care about parent/children navigation more.

This PR is not ready entirely, right now it supports passing the whole "location" object as a prop and receives a location in the onChange. My personal ideal API would be to only pass "path" (string) to both, the rest of the flags should ideally remain internal.

Obviously this is not ready, some unit tests are failing but curious about your thoughts @ciampo  (especially around my requirements above and whether it's possible to implement that easily)