### PR TITLE
Lodash: Refactor embed block away from `_.kebabCase()`

### DIFF
--- a/packages/block-editor/src/private-apis.js
+++ b/packages/block-editor/src/private-apis.js
@@ -5,6 +5,7 @@ import * as globalStyles from './components/global-styles';
 import { ExperimentalBlockEditorProvider } from './components/provider';
 import { lock } from './lock-unlock';
 import { getRichTextValues } from './components/rich-text/content';
+import { kebabCase } from './utils/object';
 import ResizableBoxPopover from './components/resizable-box-popover';
 import { ComposedPrivateInserter as PrivateInserter } from './components/inserter';
 import { PrivateListView } from './components/list-view';
@@ -27,6 +28,7 @@ lock( privateApis, {
 	...globalStyles,
 	ExperimentalBlockEditorProvider,
 	getRichTextValues,
+	kebabCase,
 	PrivateInserter,
 	PrivateListView,
 	ResizableBoxPopover,

--- a/packages/block-editor/src/private-apis.native.js
+++ b/packages/block-editor/src/private-apis.native.js
@@ -3,6 +3,7 @@
  */
 import * as globalStyles from './components/global-styles';
 import { ExperimentalBlockEditorProvider } from './components/provider';
+import { kebabCase } from './utils/object';
 import { lock } from './lock-unlock';
 
 /**
@@ -11,5 +12,6 @@ import { lock } from './lock-unlock';
 export const privateApis = {};
 lock( privateApis, {
 	...globalStyles,
+	kebabCase,
 	ExperimentalBlockEditorProvider,
 } );

--- a/packages/block-library/src/embed/util.js
+++ b/packages/block-library/src/embed/util.js
@@ -1,18 +1,13 @@
 /**
- * Internal dependencies
- */
-import { ASPECT_RATIOS, WP_EMBED_TYPE } from './constants';
-
-/**
  * External dependencies
  */
-import { kebabCase } from 'lodash';
 import classnames from 'classnames/dedupe';
 import memoize from 'memize';
 
 /**
  * WordPress dependencies
  */
+import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
 import { renderToString } from '@wordpress/element';
 import {
 	createBlock,
@@ -24,8 +19,11 @@ import {
  * Internal dependencies
  */
 import metadata from './block.json';
+import { ASPECT_RATIOS, WP_EMBED_TYPE } from './constants';
+import { unlock } from '../lock-unlock';
 
 const { name: DEFAULT_EMBED_BLOCK } = metadata;
+const { kebabCase } = unlock( blockEditorPrivateApis );
 
 /** @typedef {import('@wordpress/blocks').WPBlockVariation} WPBlockVariation */
 


### PR DESCRIPTION
## What?
This PR removes Lodash's `_.kebabCase()` from the embed block.

We have a few more usages of `kebabCase()` left in the codebase, but we might have to tread carefully, since some of them may have to deal with Unicode characters, and I prefer testing those one by one.

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?

We're replacing the `_.kebabCase()` usage with the `kebabCase()` utility from the block editor package, which is already being utilized for kebab-casing specifically when generating classnames:

https://github.com/WordPress/gutenberg/blob/2a5b997a73a4787e9148889748d804930abbaaaf/packages/block-editor/src/components/colors/utils.js#L73

We're adding that utility to the locked APIs and unlocking it for the purpose.

We're also reorganizing the imports a bit, since there were two `internal dependencies` blocks inside the `utils` module of the embeds block.

## Testing Instructions

* Start a new post.
* Insert an embed block.
* Test various embeds and verify they still work well, and are still properly recognized (e.g. youtube changes the icon of the block to youtube).
* Test with v2 of the embed block and verify classnames are properly specified in the preview `figure` of the block (e.g. `is-provider-youtube`).
* Verify all checks still pass.