### PR TITLE
Restore Unquote button

### DIFF
--- a/packages/block-editor/src/components/block-switcher/block-transformations-menu.js
+++ b/packages/block-editor/src/components/block-switcher/block-transformations-menu.js
@@ -5,6 +5,7 @@ import { __ } from '@wordpress/i18n';
 import { MenuGroup, MenuItem } from '@wordpress/components';
 import {
 	getBlockMenuDefaultClassName,
+	getBlockType,
 	switchToBlockType,
 } from '@wordpress/blocks';
 import { useState, useMemo } from '@wordpress/element';
@@ -15,6 +16,7 @@ import { useState, useMemo } from '@wordpress/element';
 import BlockIcon from '../block-icon';
 import PreviewBlockPopover from './preview-block-popover';
 import BlockVariationTransformations from './block-variation-transformations';
+import { useConvertToGroupButtonProps } from '../convert-to-group-buttons';
 
 /**
  * Helper hook to group transformations to display them in a specific order in the UI.
@@ -76,6 +78,8 @@ const BlockTransformationsMenu = ( {
 
 	const { priorityTextTransformations, restTransformations } =
 		useGroupedTransforms( possibleBlockTransformations );
+	const selectedClientIds = blocks.map( ( { clientId } ) => clientId );
+	const { onUngroup } = useConvertToGroupButtonProps( selectedClientIds );
 	// We have to check if both content transformations(priority and rest) are set
 	// in order to create a separate MenuGroup for them.
 	const hasBothContentTransformations =
@@ -87,8 +91,24 @@ const BlockTransformationsMenu = ( {
 			setHoveredTransformItemName={ setHoveredTransformItemName }
 		/>
 	);
+	const [ firstSelectedBlock ] = blocks;
+	const { name: firstSelectedBlockName } = firstSelectedBlock;
+	const { name, icon } = getBlockType( firstSelectedBlockName );
 	return (
 		<>
+			{ onUngroup && (
+				<MenuGroup className={ className }>
+					<MenuItem
+						className={ getBlockMenuDefaultClassName( name ) }
+						onClick={ () => {
+							onUngroup();
+						} }
+					>
+						<BlockIcon icon={ icon } showColors />
+						{ onUngroup.__experimentalLabel || __( 'Ungroup' ) }
+					</MenuItem>
+				</MenuGroup>
+			) }
 			<MenuGroup label={ __( 'Transform to' ) } className={ className }>
 				{ hoveredTransformItemName && (
 					<PreviewBlockPopover

--- a/packages/block-editor/src/components/block-switcher/block-transformations-menu.js
+++ b/packages/block-editor/src/components/block-switcher/block-transformations-menu.js
@@ -9,6 +9,7 @@ import {
 	switchToBlockType,
 } from '@wordpress/blocks';
 import { useState, useMemo } from '@wordpress/element';
+import { useDispatch } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -17,6 +18,7 @@ import BlockIcon from '../block-icon';
 import PreviewBlockPopover from './preview-block-popover';
 import BlockVariationTransformations from './block-variation-transformations';
 import { useConvertToGroupButtonProps } from '../convert-to-group-buttons';
+import { store as blockEditorStore } from '../../store';
 
 /**
  * Helper hook to group transformations to display them in a specific order in the UI.
@@ -73,6 +75,7 @@ const BlockTransformationsMenu = ( {
 	onSelectVariation,
 	blocks,
 } ) => {
+	const { replaceBlocks } = useDispatch( blockEditorStore );
 	const [ hoveredTransformItemName, setHoveredTransformItemName ] =
 		useState();
 
@@ -101,7 +104,13 @@ const BlockTransformationsMenu = ( {
 					<MenuItem
 						className={ getBlockMenuDefaultClassName( name ) }
 						onClick={ () => {
-							onUngroup();
+							replaceBlocks(
+								selectedClientIds,
+								onUngroup(
+									firstSelectedBlock.attributes,
+									firstSelectedBlock.innerBlocks
+								)
+							);
 						} }
 					>
 						<BlockIcon icon={ icon } showColors />

--- a/packages/block-library/src/quote/transforms.js
+++ b/packages/block-library/src/quote/transforms.js
@@ -2,6 +2,20 @@
  * WordPress dependencies
  */
 import { createBlock } from '@wordpress/blocks';
+import { __ } from '@wordpress/i18n';
+
+function ungroup( { citation }, innerBlocks ) {
+	return citation
+		? [
+				...innerBlocks,
+				createBlock( 'core/paragraph', {
+					content: citation,
+				} ),
+		  ]
+		: innerBlocks;
+}
+
+ungroup.__experimentalLabel = __( 'Unquote' );
 
 const transforms = {
 	from: [
@@ -127,15 +141,7 @@ const transforms = {
 				),
 		},
 	],
-	ungroup: ( { citation }, innerBlocks ) =>
-		citation
-			? [
-					...innerBlocks,
-					createBlock( 'core/paragraph', {
-						content: citation,
-					} ),
-			  ]
-			: innerBlocks,
+	ungroup,
 };
 
 export default transforms;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Restores the Unquote button (previously Unwrap), which was removed in #50385.

This is a quick and dirty PR, I'm open to suggestions.

## Why?

Users cannot find how to unquote.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Reuses the new ungroup API introduced in above PR.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

![image](https://github.com/WordPress/gutenberg/assets/4710635/9658a5da-d983-4249-ac9c-3a29bba6153f)

