### PR TITLE
Update pattern creation modal in library

### DIFF
--- a/packages/edit-site/src/components/create-pattern-modal/index.js
+++ b/packages/edit-site/src/components/create-pattern-modal/index.js
@@ -26,7 +26,7 @@ export default function CreatePatternModal( {
 	onError,
 } ) {
 	const [ name, setName ] = useState( '' );
-	const [ syncType, setSyncType ] = useState( SYNC_TYPES.full );
+	const [ syncType, setSyncType ] = useState( SYNC_TYPES.unsynced );
 	const [ isSubmitting, setIsSubmitting ] = useState( false );
 
 	const onSyncChange = () => {
@@ -77,8 +77,6 @@ export default function CreatePatternModal( {
 			onRequestClose={ closeModal }
 			overlayClassName="edit-site-create-pattern-modal"
 		>
-			<p>{ __( 'Turn this block into a pattern to reuse later' ) }</p>
-
 			<form
 				onSubmit={ async ( event ) => {
 					event.preventDefault();
@@ -100,13 +98,11 @@ export default function CreatePatternModal( {
 						__nextHasNoMarginBottom
 					/>
 					<ToggleControl
-						label={ __( 'Synced' ) }
+						label={ __( 'Keep all pattern instances in sync' ) }
 						onChange={ onSyncChange }
-						help={
-							syncType === SYNC_TYPES.full
-								? __( 'Content is synced' )
-								: __( 'Content is not synced' )
-						}
+						help={ __(
+							'Editing the original pattern will also update anywhere the pattern is used.'
+						) }
 						checked={ syncType === SYNC_TYPES.full }
 					/>
 					<HStack justify="right">


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Updates the pattern creation modal in the library to be consistent with the one triggered from editor.

<img width="636" alt="image" src="https://github.com/WordPress/gutenberg/assets/1072756/4d2325a0-24d7-40d8-ae17-ba23e0c740c0">


## Why?
Fixes #51941


## Testing Instructions
1. open site editor
2. open library
3. click + and select "create pattern"
4. Notice modal changes which should be consistent with editor modal

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
