### PR TITLE
Fix phpunit failures

### DIFF
--- a/phpunit/block-template-utils-test.php
+++ b/phpunit/block-template-utils-test.php
@@ -9,9 +9,6 @@ class Tests_Block_Template_Utils extends WP_UnitTestCase {
 	public function set_up() {
 		parent::set_up();
 		switch_theme( 'emptytheme' );
-	}
-
-	public static function wpSetUpBeforeClass() {
 		register_post_type(
 			'custom_book',
 			array(
@@ -22,9 +19,10 @@ class Tests_Block_Template_Utils extends WP_UnitTestCase {
 		register_taxonomy( 'book_type', 'custom_book' );
 	}
 
-	public static function wpTearDownAfterClass() {
+	public function tear_down() {
 		unregister_post_type( 'custom_book' );
 		unregister_taxonomy( 'book_type' );
+		parent::tear_down();
 	}
 
 	public function test_get_template_hierarchy() {

--- a/phpunit/bootstrap.php
+++ b/phpunit/bootstrap.php
@@ -21,6 +21,9 @@ if ( ! defined( 'LOCAL_SCRIPT_DEBUG' ) ) {
 if ( ! defined( 'LOCAL_WP_ENVIRONMENT_TYPE' ) ) {
 	define( 'LOCAL_WP_ENVIRONMENT_TYPE', 'local' );
 }
+if ( ! defined( 'WP_RUN_CORE_TESTS' ) ) {
+	define( 'WP_RUN_CORE_TESTS', true );
+}
 
 // Require composer dependencies.
 require_once dirname( __DIR__ ) . '/vendor/autoload.php';

--- a/phpunit/bootstrap.php
+++ b/phpunit/bootstrap.php
@@ -22,10 +22,8 @@ if ( ! defined( 'LOCAL_WP_ENVIRONMENT_TYPE' ) ) {
 	define( 'LOCAL_WP_ENVIRONMENT_TYPE', 'local' );
 }
 
-// Needed while Gutenberg contains tests that use the global styles and settings
-// implementation that exists in Core.
-// See https://github.com/WordPress/gutenberg/pull/51950.
-// See https://core.trac.wordpress.org/ticket/57487.
+// Pretend that these are Core unit tests. This is needed so that
+// wp_theme_has_theme_json() does not cache its return value between each test.
 if ( ! defined( 'WP_RUN_CORE_TESTS' ) ) {
 	define( 'WP_RUN_CORE_TESTS', true );
 }

--- a/phpunit/bootstrap.php
+++ b/phpunit/bootstrap.php
@@ -21,6 +21,11 @@ if ( ! defined( 'LOCAL_SCRIPT_DEBUG' ) ) {
 if ( ! defined( 'LOCAL_WP_ENVIRONMENT_TYPE' ) ) {
 	define( 'LOCAL_WP_ENVIRONMENT_TYPE', 'local' );
 }
+
+// Needed while Gutenberg contains tests that use the global styles and settings
+// implementation that exists in Core.
+// See https://github.com/WordPress/gutenberg/pull/51950.
+// See https://core.trac.wordpress.org/ticket/57487.
 if ( ! defined( 'WP_RUN_CORE_TESTS' ) ) {
 	define( 'WP_RUN_CORE_TESTS', true );
 }


### PR DESCRIPTION
Fix the phpunit failures in `trunk`.

~All but one of the failures were from Gutenberg phpunit tests that one way or the other call into Core's global styles and settings functionality e.g. `wp_get_global_settings`. These functions will cache their results unless `WP_DEVELOPMENT_MODE`  is set to `'theme'` or if Core detects that the Core unit tests are running via the `WP_RUN_CORE_TESTS` flag. Since Gutenberg is testing Core functionality here, it is de facto performing the role of Core unit tests, and so the fix is to set `WP_RUN_CORE_TESTS`. See https://github.com/WordPress/wordpress-develop/commit/4a16702090984caef24af5a07d598cc5afff2fdc#r119747488.~

**edit:** Nope! All but one of the failures are to do with `wp_theme_has_theme_json` caching its return value unless `WP_RUN_CORE_TESTS` is set. See https://github.com/WordPress/gutenberg/pull/51950#issuecomment-1608768939.

One failure (`test_get_template_hierarchy`) is due to an issue where a test taxonomy is registered in `wpSetUpBeforeClass` and not `set_up`. This causes issues because the `switch_theme` in `set_up` will clobber the taxonomies. I note that when these tests were ported to Core this was addressed and we're not using `wpSetUpBeforeClass` there.

A lot of these tests, I think, don't belong in Gutenberg anymore. They should have been removed when the functionality that they test were moved from Gutenberg to Core. It doesn't make sense to have tests in Gutenberg that test Core functionality. Alternatively, the changes that were made to the PHP test code before being merged to Core should have been brought back to the plugin. For example note how different `Tests_Block_Template_Utils` looks in Core versus in Gutenberg.