### PR TITLE
Patterns: Fix setting of sync status for fully synced patterns

### DIFF
--- a/packages/edit-site/src/components/create-pattern-modal/index.js
+++ b/packages/edit-site/src/components/create-pattern-modal/index.js
@@ -54,7 +54,10 @@ export default function CreatePatternModal( {
 					title: name || __( 'Untitled Pattern' ),
 					content: '',
 					status: 'publish',
-					meta: { sync_status: syncType },
+					meta:
+						syncType === SYNC_TYPES.unsynced
+							? { sync_status: syncType }
+							: undefined,
 				},
 				{ throwOnError: true }
 			);

--- a/packages/edit-site/src/components/page-library/use-patterns.js
+++ b/packages/edit-site/src/components/page-library/use-patterns.js
@@ -145,7 +145,7 @@ const reusableBlockToPattern = ( reusableBlock ) => ( {
 	categories: reusableBlock.wp_pattern,
 	id: reusableBlock.id,
 	name: reusableBlock.slug,
-	syncStatus: reusableBlock.meta?.sync_status,
+	syncStatus: reusableBlock.meta?.sync_status || SYNC_TYPES.full,
 	title: reusableBlock.title.raw,
 	type: reusableBlock.type,
 	reusableBlock,

--- a/packages/editor/src/components/post-sync-status/index.js
+++ b/packages/editor/src/components/post-sync-status/index.js
@@ -26,13 +26,10 @@ export default function PostSyncStatus() {
 		editPost( {
 			meta: {
 				...meta,
-				wp_block:
-					syncStatus === 'unsynced'
-						? { sync_status: syncStatus }
-						: null,
+				sync_status: syncStatus === 'unsynced' ? syncStatus : null,
 			},
 		} );
-	const syncStatus = meta?.wp_block?.sync_status;
+	const syncStatus = meta?.sync_status;
 	const isFullySynced = ! syncStatus;
 
 	return (


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/51923

## What?

Fully synced patterns were recently changed to keep their `meta.sync_status` value as `undefined` for backwards compatibility reasons. This change wasn't made in the Site Editor Library's create pattern modal. This PR fixes this and the post sync status when directly editing a pattern entity.


## Why?

Without these fixes we get inconsistent display and categorisation of patterns.

## How?

- Library's pattern creation modal now only saves sync status in the meta if the pattern is unsynced
- The library's pattern display page will treat `undefined` sync status as fully synced
- Fixes the retrieval and updating of the pattern entity's sync status via the `PostSyncStatus` component

## Testing Instructions

1. Create both synced and unsynced patterns via the Library's create pattern modal
2. Ensure the new patterns (and any existing ones you have) are shown in the correct groups e.g. synced vs standard
3. Visit the "Manage all custom patterns" page
4. Edit a pattern & toggle the sync status via the sidebar control
5. Double check this pattern is now displayed in the correct location in the library and block editor's inserter
6. Create further unsynced and synced patterns via the block editor
7. Make sure these new patterns and the existing ones are all still in the correct locations within the block editor's inserter and the Site Editor's library

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/60436221/7343c85d-d214-4f27-9a32-5de176ab86fd

