### PR TITLE
Patterns: Fix sidebar tab label

### DIFF
--- a/packages/edit-site/src/components/sidebar-edit-mode/settings-header/index.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/settings-header/index.js
@@ -18,6 +18,12 @@ import { STORE_NAME } from '../../../store/constants';
 import { SIDEBAR_BLOCK, SIDEBAR_TEMPLATE } from '../constants';
 import { store as editSiteStore } from '../../../store';
 
+const entityLabels = {
+	wp_navigation: __( 'Navigation' ),
+	wp_block: __( 'Pattern' ),
+	wp_template: __( 'Template' ),
+};
+
 const SettingsHeader = ( { sidebarName } ) => {
 	const { hasPageContentFocus, entityType } = useSelect( ( select ) => {
 		const { getEditedPostType, hasPageContentFocus: _hasPageContentFocus } =
@@ -29,8 +35,7 @@ const SettingsHeader = ( { sidebarName } ) => {
 		};
 	} );
 
-	const entityLabel =
-		entityType === 'wp_navigation' ? __( 'Navigation' ) : __( 'Template' );
+	const entityLabel = entityLabels[ entityType ] || entityLabels.wp_template;
 
 	const { enableComplementaryArea } = useDispatch( interfaceStore );
 	const openTemplateSettings = () =>


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/51925

## What?

Corrects the sidebar tab label when editing a pattern.

## Why?

Prevents confusion due to inaccurate label.

## How?

Use map to determine correct label now we have multiple entity types being edited e.g. Navigation, Template, Template Parts, and Patterns.

## Testing Instructions

1. Navigate to the Site Editor > Library
2. Create a new pattern or edit and existing user created pattern
3. In the editor ensure the sidebar tab for patterns now reads "Pattern"
4. Double check that navigation and template/template part entities still display their respective label (Navigation, Template)

## Screenshots or screencast <!-- if applicable -->

| Before | After |
|---|---|
| <img width="279" alt="Screenshot 2023-06-27 at 12 53 02 pm" src="https://github.com/WordPress/gutenberg/assets/60436221/a7350cc3-9079-40ae-a519-3f95d3c7a5c0"> | <img width="279" alt="Screenshot 2023-06-27 at 12 52 31 pm" src="https://github.com/WordPress/gutenberg/assets/60436221/8db15dbb-90be-412b-b450-c26f65b669c4"> |



