### PR TITLE
Library: Add sync status to pattern details screen

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen-pattern/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-pattern/index.js
@@ -14,7 +14,6 @@ import SidebarButton from '../sidebar-button';
 import SidebarNavigationScreen from '../sidebar-navigation-screen';
 import useInitEditedEntityFromURL from '../sync-state-with-url/use-init-edited-entity-from-url';
 import usePatternDetails from './use-pattern-details';
-import useNavigationMenuContent from './use-navigation-menu-content';
 import { store as editSiteStore } from '../../store';
 import { unlock } from '../../lock-unlock';
 
@@ -27,7 +26,6 @@ export default function SidebarNavigationScreenPattern() {
 	useInitEditedEntityFromURL();
 
 	const patternDetails = usePatternDetails( postType, postId );
-	const content = useNavigationMenuContent( postType, postId );
 
 	// The absence of a category type in the query params for template parts
 	// indicates the user has arrived at the template part via the "manage all"
@@ -47,7 +45,6 @@ export default function SidebarNavigationScreenPattern() {
 				/>
 			}
 			backPath={ backPath }
-			content={ content }
 			{ ...patternDetails }
 		/>
 	);

--- a/packages/edit-site/src/components/sidebar-navigation-screen-pattern/use-pattern-details.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-pattern/use-pattern-details.js
@@ -11,7 +11,14 @@ import { Icon } from '@wordpress/components';
  */
 import { useAddedBy } from '../list/added-by';
 import useEditedEntityRecord from '../use-edited-entity-record';
+import useNavigationMenuContent from './use-navigation-menu-content';
 import SidebarNavigationScreenDetailsFooter from '../sidebar-navigation-screen-details-footer';
+import {
+	SidebarNavigationScreenDetailsPanel,
+	SidebarNavigationScreenDetailsPanelRow,
+	SidebarNavigationScreenDetailsPanelLabel,
+	SidebarNavigationScreenDetailsPanelValue,
+} from '../sidebar-navigation-screen-details-panel';
 
 export default function usePatternDetails( postType, postId ) {
 	const { getDescription, getTitle, record } = useEditedEntityRecord(
@@ -82,5 +89,40 @@ export default function usePatternDetails( postType, postId ) {
 		/>
 	) : null;
 
-	return { title, description, footer };
+	const details = [];
+
+	if ( postType === 'wp_block' ) {
+		details.push( {
+			label: __( 'Syncing' ),
+			value:
+				record.meta?.sync_status === 'unsynced'
+					? __( 'Not synced' )
+					: __( 'Fully synced' ),
+		} );
+	}
+
+	const content = (
+		<>
+			{ !! details.length && (
+				<SidebarNavigationScreenDetailsPanel
+					spacing={ 5 }
+					title={ __( 'Details' ) }
+				>
+					{ details.map( ( { label, value } ) => (
+						<SidebarNavigationScreenDetailsPanelRow key={ label }>
+							<SidebarNavigationScreenDetailsPanelLabel>
+								{ label }
+							</SidebarNavigationScreenDetailsPanelLabel>
+							<SidebarNavigationScreenDetailsPanelValue>
+								{ value }
+							</SidebarNavigationScreenDetailsPanelValue>
+						</SidebarNavigationScreenDetailsPanelRow>
+					) ) }
+				</SidebarNavigationScreenDetailsPanel>
+			) }
+			{ useNavigationMenuContent( postType, postId ) }
+		</>
+	);
+
+	return { title, description, content, footer };
 }


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/51926

## What?

Adds a pattern's sync status to a details section within the pattern sidebar navigation screen.

## Why?

There's very limited information in that screen at present and it looks pretty sparse (see https://github.com/WordPress/gutenberg/issues/51926). The details introduced here can be expanded in future to potentially include things like places the pattern is in use etc.

## How?

- Small refactor to move the sidebar screen content generation into the hook with the rest of the page details
- If the current item is a pattern, add the sync status to dispalyed details.
    - The wording here follows the `PostSyncStatus` control

## Testing Instructions

**Note: This would be best tested alongside the fix in https://github.com/WordPress/gutenberg/issues/51923 which corrects the display of synced/unsynced patterns**

1. Navigate to Site Editor > Library
2. Choose "Custom Patterns" and select a pattern
3. Expand the sidebar navigation screen and confirm the correct sync status is displayed
4. Navigate to a template part and check that no sync status is displayed in the sidebar navigation screen
5. Create or select a pattern that also contains a navigation block
6. Ensure this pattern displays by the details block and the navigation editing


## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/60436221/050d0732-6922-4661-93e2-a4ffbccf1b5a

