### PR TITLE
Try restoring the site editor animation

### DIFF
--- a/packages/edit-site/src/components/layout/index.js
+++ b/packages/edit-site/src/components/layout/index.js
@@ -247,21 +247,13 @@ export default function Layout() {
 
 				<div className="edit-site-layout__content">
 					<AnimatePresence initial={ false }>
-						{
+						{ showSidebar && (
 							<motion.div
+								layout
 								initial={ {
 									opacity: 0,
 								} }
-								animate={
-									showSidebar
-										? { opacity: 1, display: 'block' }
-										: {
-												opacity: 0,
-												transitionEnd: {
-													display: 'none',
-												},
-										  }
-								}
+								animate={ { opacity: 1 } }
 								exit={ {
 									opacity: 0,
 								} }
@@ -282,7 +274,7 @@ export default function Layout() {
 									<Sidebar />
 								</NavigableRegion>
 							</motion.div>
-						}
+						) }
 					</AnimatePresence>
 
 					<SavePanel />

--- a/packages/edit-site/src/components/layout/index.js
+++ b/packages/edit-site/src/components/layout/index.js
@@ -258,13 +258,9 @@ export default function Layout() {
 					<AnimatePresence initial={ false }>
 						{ showSidebar && (
 							<motion.div
-								initial={ {
-									opacity: 0,
-								} }
+								initial={ { opacity: 0 } }
 								animate={ { opacity: 1 } }
-								exit={ {
-									opacity: 0,
-								} }
+								exit={ { opacity: 0 } }
 								transition={ {
 									type: 'tween',
 									duration:

--- a/packages/edit-site/src/components/layout/index.js
+++ b/packages/edit-site/src/components/layout/index.js
@@ -257,31 +257,28 @@ export default function Layout() {
 				</motion.div>
 
 				<div className="edit-site-layout__content">
-					<AnimatePresence initial={ false }>
-						{ showSidebar && (
-							<motion.div
-								initial={ { opacity: 0 } }
-								animate={ { opacity: 1 } }
-								exit={ { opacity: 0 } }
-								transition={ {
-									type: 'tween',
-									duration:
-										// Disable transition in mobile to emulate a full page transition.
-										disableMotion || isMobileViewport
-											? 0
-											: ANIMATION_DURATION,
-									ease: 'easeOut',
-								} }
-								className="edit-site-layout__sidebar"
-							>
-								<NavigableRegion
-									ariaLabel={ __( 'Navigation' ) }
-								>
-									<Sidebar />
-								</NavigableRegion>
-							</motion.div>
-						) }
-					</AnimatePresence>
+					<motion.div
+						// The sidebar is needed for routing on mobile
+						// (https://github.com/WordPress/gutenberg/pull/51558/files#r1231763003),
+						// so we can't remove the element entirely. Using `inert` will make
+						// it inaccessible to screen readers and keyboard navigation.
+						inert={ showSidebar ? undefined : 'inert' }
+						animate={ { opacity: canvasMode === 'view' ? 1 : 0 } }
+						transition={ {
+							type: 'tween',
+							duration:
+								// Disable transition in mobile to emulate a full page transition.
+								disableMotion || isMobileViewport
+									? 0
+									: ANIMATION_DURATION,
+							ease: 'easeOut',
+						} }
+						className="edit-site-layout__sidebar"
+					>
+						<NavigableRegion ariaLabel={ __( 'Navigation' ) }>
+							<Sidebar />
+						</NavigableRegion>
+					</motion.div>
 
 					<SavePanel />
 

--- a/packages/edit-site/src/components/layout/index.js
+++ b/packages/edit-site/src/components/layout/index.js
@@ -242,7 +242,7 @@ export default function Layout() {
 								} }
 								initial={ {
 									opacity: isDistractionFree ? 1 : 0,
-									y: '-100%',
+									y: isDistractionFree ? 0 : '-100%',
 								} }
 								transition={ {
 									type: 'tween',

--- a/packages/edit-site/src/components/layout/index.js
+++ b/packages/edit-site/src/components/layout/index.js
@@ -263,7 +263,7 @@ export default function Layout() {
 						// so we can't remove the element entirely. Using `inert` will make
 						// it inaccessible to screen readers and keyboard navigation.
 						inert={ showSidebar ? undefined : 'inert' }
-						animate={ { opacity: canvasMode === 'view' ? 1 : 0 } }
+						animate={ { opacity: showSidebar ? 1 : 0 } }
 						transition={ {
 							type: 'tween',
 							duration:

--- a/packages/edit-site/src/components/layout/index.js
+++ b/packages/edit-site/src/components/layout/index.js
@@ -258,7 +258,6 @@ export default function Layout() {
 					<AnimatePresence initial={ false }>
 						{ showSidebar && (
 							<motion.div
-								layout
 								initial={ {
 									opacity: 0,
 								} }

--- a/packages/edit-site/src/components/layout/index.js
+++ b/packages/edit-site/src/components/layout/index.js
@@ -228,11 +228,20 @@ export default function Layout() {
 								ariaLabel={ __( 'Editor top bar' ) }
 								as={ motion.div }
 								variants={ {
-									isDistractionFree: { opacity: 0 },
-									isDistractionFreeHovering: { opacity: 1 },
-									view: { opacity: 1 },
-									edit: { opacity: 1 },
+									isDistractionFree: { opacity: 0, y: 0 },
+									isDistractionFreeHovering: {
+										opacity: 1,
+										y: 0,
+									},
+									view: { opacity: 1, y: '-100%' },
+									edit: { opacity: 1, y: 0 },
 								} }
+								exit="view"
+								initial={
+									isDistractionFree
+										? 'isDistractionFree'
+										: 'view'
+								}
 								transition={ {
 									type: 'tween',
 									duration: disableMotion ? 0 : 0.2,

--- a/packages/edit-site/src/components/layout/index.js
+++ b/packages/edit-site/src/components/layout/index.js
@@ -224,6 +224,7 @@ export default function Layout() {
 					<AnimatePresence initial={ false }>
 						{ isEditorPage && isEditing && (
 							<NavigableRegion
+								key="header"
 								className="edit-site-layout__header"
 								ariaLabel={ __( 'Editor top bar' ) }
 								as={ motion.div }
@@ -236,19 +237,20 @@ export default function Layout() {
 									view: { opacity: 1, y: '-100%' },
 									edit: { opacity: 1, y: 0 },
 								} }
-								exit="view"
-								initial={
-									isDistractionFree
-										? 'isDistractionFree'
-										: 'view'
-								}
+								exit={ {
+									y: '-100%',
+								} }
+								initial={ {
+									opacity: isDistractionFree ? 1 : 0,
+									y: '-100%',
+								} }
 								transition={ {
 									type: 'tween',
 									duration: disableMotion ? 0 : 0.2,
 									ease: 'easeOut',
 								} }
 							>
-								{ isEditing && <Header /> }
+								<Header />
 							</NavigableRegion>
 						) }
 					</AnimatePresence>


### PR DESCRIPTION
## What?
Attempts to fix https://github.com/WordPress/gutenberg/issues/51903

## How?
~~Restores how the code looked before (relying on `AnimatePresence` to handle entry and exit animations rather than the `display` property). Unfortunately bringing this back reintroduces routing issues on mobile that were solved by https://github.com/WordPress/gutenberg/pull/51558.~~

Since we're not sure how to fix the routing issues on mobile, we're leaving the sidebar present ini the DOM, but hiding it visually and marking it as `inert` to stop all user interactions on the sidebar.

Also resolves some issues with the editor header animation that seem to have been introduced by the addition of Distraction Free mode.

## Testing Instructions
1. Open the site editor
2. Switch between view and edit mode and back again.
3. There should be an animation of the viewport when switching back to view mode.
4. Switch to Distraction Free
5. Switch between view and edit mode and back again.
6. All animations should look nice :) 

## Screenshots or screencast <!-- if applicable -->
### Before
https://github.com/WordPress/gutenberg/assets/677833/57bedbc8-0b83-4984-80e7-a56ad5fd8886


### After
https://github.com/WordPress/gutenberg/assets/677833/e98cf5b2-3fa9-49e4-9896-76affc2a7406




