### PR TITLE
Patterns: Update Manage Patterns to point to the Site Editor if available

### DIFF
--- a/packages/edit-post/src/plugins/index.js
+++ b/packages/edit-post/src/plugins/index.js
@@ -24,8 +24,8 @@ registerPlugin( 'edit-post', {
 						<>
 							<MenuItem
 								role="menuitem"
-								href={ addQueryArgs( 'edit.php', {
-									post_type: 'wp_block',
+								href={ addQueryArgs( 'site-editor.php', {
+									path: '/patterns',
 								} ) }
 							>
 								{ __( 'Manage Patterns' ) }

--- a/packages/edit-post/src/plugins/index.js
+++ b/packages/edit-post/src/plugins/index.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { MenuItem, VisuallyHidden } from '@wordpress/components';
+import { useEffect, useState } from '@wordpress/element';
 import { external } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
 import { registerPlugin } from '@wordpress/plugins';
@@ -15,6 +16,29 @@ import KeyboardShortcutsHelpMenuItem from './keyboard-shortcuts-help-menu-item';
 import ToolsMoreMenuGroup from '../components/header/tools-more-menu-group';
 import WelcomeGuideMenuItem from './welcome-guide-menu-item';
 
+function ManagePatternsMenuItem() {
+	const defaultUrl = addQueryArgs( 'edit.php', { postType: 'wp_block' } );
+	const patternsUrl = addQueryArgs( 'site-editor.php', {
+		path: '/patterns',
+	} );
+
+	const [ url, setUrl ] = useState( defaultUrl );
+
+	useEffect( () => {
+		window.fetch( patternsUrl ).then( ( response ) => {
+			if ( response?.status === 200 ) {
+				setUrl( patternsUrl );
+			}
+		} );
+	}, [] );
+
+	return (
+		<MenuItem role="menuitem" href={ url }>
+			{ __( 'Manage Patterns' ) }
+		</MenuItem>
+	);
+}
+
 registerPlugin( 'edit-post', {
 	render() {
 		return (
@@ -22,14 +46,7 @@ registerPlugin( 'edit-post', {
 				<ToolsMoreMenuGroup>
 					{ ( { onClose } ) => (
 						<>
-							<MenuItem
-								role="menuitem"
-								href={ addQueryArgs( 'site-editor.php', {
-									path: '/patterns',
-								} ) }
-							>
-								{ __( 'Manage Patterns' ) }
-							</MenuItem>
+							<ManagePatternsMenuItem />
 							<KeyboardShortcutsHelpMenuItem
 								onSelect={ onClose }
 							/>

--- a/packages/reusable-blocks/src/components/reusable-blocks-menu-items/reusable-blocks-manage-button.js
+++ b/packages/reusable-blocks/src/components/reusable-blocks-menu-items/reusable-blocks-manage-button.js
@@ -5,6 +5,7 @@ import { MenuItem } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { isReusableBlock } from '@wordpress/blocks';
 import { useSelect, useDispatch } from '@wordpress/data';
+import { useEffect, useState } from '@wordpress/element';
 import {
 	BlockSettingsMenuControls,
 	store as blockEditorStore,
@@ -16,6 +17,29 @@ import { store as coreStore } from '@wordpress/core-data';
  * Internal dependencies
  */
 import { store as reusableBlocksStore } from '../../store';
+
+function ManagePatternsMenuItem() {
+	const defaultUrl = addQueryArgs( 'edit.php', { postType: 'wp_block' } );
+	const patternsUrl = addQueryArgs( 'site-editor.php', {
+		path: '/patterns',
+	} );
+
+	const [ url, setUrl ] = useState( defaultUrl );
+
+	useEffect( () => {
+		window.fetch( patternsUrl ).then( ( response ) => {
+			if ( response?.status === 200 ) {
+				setUrl( patternsUrl );
+			}
+		} );
+	}, [] );
+
+	return (
+		<MenuItem role="menuitem" href={ url }>
+			{ __( 'Manage Patterns' ) }
+		</MenuItem>
+	);
+}
 
 function ReusableBlocksManageButton( { clientId } ) {
 	const { canRemove, isVisible, innerBlockCount } = useSelect(
@@ -50,13 +74,7 @@ function ReusableBlocksManageButton( { clientId } ) {
 
 	return (
 		<BlockSettingsMenuControls>
-			<MenuItem
-				href={ addQueryArgs( 'site-editor.php', {
-					path: '/patterns',
-				} ) }
-			>
-				{ __( 'Manage Patterns' ) }
-			</MenuItem>
+			<ManagePatternsMenuItem />
 			{ canRemove && (
 				<MenuItem onClick={ () => convertBlockToStatic( clientId ) }>
 					{ innerBlockCount > 1

--- a/packages/reusable-blocks/src/components/reusable-blocks-menu-items/reusable-blocks-manage-button.js
+++ b/packages/reusable-blocks/src/components/reusable-blocks-menu-items/reusable-blocks-manage-button.js
@@ -51,7 +51,9 @@ function ReusableBlocksManageButton( { clientId } ) {
 	return (
 		<BlockSettingsMenuControls>
 			<MenuItem
-				href={ addQueryArgs( 'edit.php', { post_type: 'wp_block' } ) }
+				href={ addQueryArgs( 'site-editor.php', {
+					path: '/patterns',
+				} ) }
 			>
 				{ __( 'Manage Patterns' ) }
 			</MenuItem>


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/51944

Related:
- https://github.com/WordPress/gutenberg/pull/51949

## What?

Updates "Manage Patterns" links to go to the library.

**Note: This could be updated to simply direct to the root `/library` path once it defaults to the `my-patterns` category and falls back to the header template parts category if there aren't any patterns**

## Why?

With the new Library, there is a better location to direct users for managing their patterns.

## How?

- Updates the `href` attributes for the Manage Patterns links
- This PR is dependent upon the renaming of the "Custom Patterns" category to "My Patterns"

## Testing Instructions

1. Edit a post in the block editor and insert a synced pattern (formerly reusable block)
2. Select the pattern
3. Within the block toolbar's more menu, select Manage Patterns and ensure you're directed to the Library
4. Switch back to the block editor and option the top "Options" more menu
5. Select Manage Patterns in this menu and confirm you end up in the Library again

