### PR TITLE
Library: Reinstate manage all template parts page

### DIFF
--- a/packages/edit-site/src/components/page-main/index.js
+++ b/packages/edit-site/src/components/page-main/index.js
@@ -6,8 +6,9 @@ import { privateApis as routerPrivateApis } from '@wordpress/router';
 /**
  * Internal dependencies
  */
-import PageTemplates from '../page-templates';
 import PageLibrary from '../page-library';
+import PageTemplateParts from '../page-template-parts';
+import PageTemplates from '../page-templates';
 import { unlock } from '../../lock-unlock';
 
 const { useLocation } = unlock( routerPrivateApis );
@@ -19,6 +20,8 @@ export default function PageMain() {
 
 	if ( path === '/wp_template/all' ) {
 		return <PageTemplates />;
+	} else if ( path === '/wp_template_part/all' ) {
+		return <PageTemplateParts />;
 	} else if ( path === '/library' ) {
 		return <PageLibrary />;
 	}

--- a/packages/edit-site/src/components/page-template-parts/index.js
+++ b/packages/edit-site/src/components/page-template-parts/index.js
@@ -1,0 +1,105 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	VisuallyHidden,
+	__experimentalHeading as Heading,
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { useSelect } from '@wordpress/data';
+import { store as coreStore, useEntityRecords } from '@wordpress/core-data';
+import { decodeEntities } from '@wordpress/html-entities';
+
+/**
+ * Internal dependencies
+ */
+import Page from '../page';
+import Table from '../table';
+import Link from '../routes/link';
+import AddedBy from '../list/added-by';
+import TemplateActions from '../template-actions';
+import AddNewTemplate from '../add-new-template';
+import { store as editSiteStore } from '../../store';
+
+export default function PageTemplateParts() {
+	const { records: templateParts } = useEntityRecords(
+		'postType',
+		'wp_template_part',
+		{
+			per_page: -1,
+		}
+	);
+
+	const { canCreate } = useSelect( ( select ) => {
+		const { supportsTemplatePartsMode } =
+			select( editSiteStore ).getSettings();
+		return {
+			postType: select( coreStore ).getPostType( 'wp_template_part' ),
+			canCreate: ! supportsTemplatePartsMode,
+		};
+	} );
+
+	const columns = [
+		{
+			header: __( 'Template Part' ),
+			cell: ( templatePart ) => (
+				<VStack>
+					<Heading level={ 5 }>
+						<Link
+							params={ {
+								postId: templatePart.id,
+								postType: templatePart.type,
+								canvas: 'edit',
+							} }
+							state={ { backPath: '/wp_template_part/all' } }
+						>
+							{ decodeEntities(
+								templatePart.title?.rendered ||
+									templatePart.slug
+							) }
+						</Link>
+					</Heading>
+				</VStack>
+			),
+			maxWidth: 400,
+		},
+		{
+			header: __( 'Added by' ),
+			cell: ( templatePart ) => (
+				<AddedBy
+					postType={ templatePart.type }
+					postId={ templatePart.id }
+				/>
+			),
+		},
+		{
+			header: <VisuallyHidden>{ __( 'Actions' ) }</VisuallyHidden>,
+			cell: ( templatePart ) => (
+				<TemplateActions
+					postType={ templatePart.type }
+					postId={ templatePart.id }
+				/>
+			),
+		},
+	];
+
+	return (
+		<Page
+			title={ __( 'Template Parts' ) }
+			actions={
+				canCreate && (
+					<AddNewTemplate
+						templateType={ 'wp_template_part' }
+						showIcon={ false }
+						toggleProps={ { variant: 'primary' } }
+					/>
+				)
+			}
+		>
+			{ templateParts && (
+				<Table data={ templateParts } columns={ columns } />
+			) }
+		</Page>
+	);
+}

--- a/packages/edit-site/src/components/page-template-parts/index.js
+++ b/packages/edit-site/src/components/page-template-parts/index.js
@@ -50,7 +50,7 @@ export default function PageTemplateParts() {
 							params={ {
 								postId: templatePart.id,
 								postType: templatePart.type,
-								canvas: 'edit',
+								canvas: 'view',
 							} }
 							state={ { backPath: '/wp_template_part/all' } }
 						>

--- a/packages/edit-site/src/components/sidebar-navigation-screen-library/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-library/index.js
@@ -48,6 +48,20 @@ export default function SidebarNavigationScreenLibrary() {
 	}, [] );
 
 	const templatePartsLink = useLink( { path: '/wp_template_part/all' } );
+	const footer = ! isMobileViewport ? (
+		<ItemGroup>
+			<SidebarNavigationItem withChevron { ...templatePartsLink }>
+				{ __( 'Manage all template parts' ) }
+			</SidebarNavigationItem>
+			<SidebarNavigationItem
+				as="a"
+				href="edit.php?post_type=wp_block"
+				withChevron
+			>
+				{ __( 'Manage all custom patterns' ) }
+			</SidebarNavigationItem>
+		</ItemGroup>
+	) : undefined;
 
 	return (
 		<SidebarNavigationScreen
@@ -57,27 +71,7 @@ export default function SidebarNavigationScreenLibrary() {
 				'Manage what patterns are available when editing your site.'
 			) }
 			actions={ <AddNewPattern /> }
-			footer={
-				<ItemGroup>
-					{ ! isMobileViewport && (
-						<>
-							<SidebarNavigationItem
-								withChevron
-								{ ...templatePartsLink }
-							>
-								{ __( 'Manage all template parts' ) }
-							</SidebarNavigationItem>
-							<SidebarNavigationItem
-								as="a"
-								href="edit.php?post_type=wp_block"
-								withChevron
-							>
-								{ __( 'Manage all custom patterns' ) }
-							</SidebarNavigationItem>
-						</>
-					) }
-				</ItemGroup>
-			}
+			footer={ footer }
 			content={
 				<>
 					{ isLoading && __( 'Loading library' ) }

--- a/packages/edit-site/src/components/sidebar-navigation-screen-library/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-library/index.js
@@ -21,6 +21,7 @@ import SidebarNavigationScreen from '../sidebar-navigation-screen';
 import CategoryItem from './category-item';
 import { DEFAULT_CATEGORY, DEFAULT_TYPE } from '../page-library/utils';
 import { store as editSiteStore } from '../../store';
+import { useLink } from '../routes/link';
 import usePatternCategories from './use-pattern-categories';
 import useTemplatePartAreas from './use-template-part-areas';
 
@@ -46,6 +47,8 @@ export default function SidebarNavigationScreenLibrary() {
 		return !! settings.supportsTemplatePartsMode;
 	}, [] );
 
+	const templatePartsLink = useLink( { path: '/wp_template_part/all' } );
+
 	return (
 		<SidebarNavigationScreen
 			isRoot={ isTemplatePartsMode }
@@ -57,13 +60,21 @@ export default function SidebarNavigationScreenLibrary() {
 			footer={
 				<ItemGroup>
 					{ ! isMobileViewport && (
-						<SidebarNavigationItem
-							as="a"
-							href="edit.php?post_type=wp_block"
-							withChevron
-						>
-							{ __( 'Manage all custom patterns' ) }
-						</SidebarNavigationItem>
+						<>
+							<SidebarNavigationItem
+								withChevron
+								{ ...templatePartsLink }
+							>
+								{ __( 'Manage all template parts' ) }
+							</SidebarNavigationItem>
+							<SidebarNavigationItem
+								as="a"
+								href="edit.php?post_type=wp_block"
+								withChevron
+							>
+								{ __( 'Manage all custom patterns' ) }
+							</SidebarNavigationItem>
+						</>
 					) }
 				</ItemGroup>
 			}

--- a/packages/edit-site/src/components/sidebar-navigation-screen-pattern/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-pattern/index.js
@@ -1,10 +1,11 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
-import { useDispatch } from '@wordpress/data';
-import { pencil } from '@wordpress/icons';
 import { __experimentalUseNavigator as useNavigator } from '@wordpress/components';
+import { useDispatch } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
+import { pencil } from '@wordpress/icons';
+import { getQueryArgs } from '@wordpress/url';
 
 /**
  * Internal dependencies
@@ -19,6 +20,7 @@ import { unlock } from '../../lock-unlock';
 
 export default function SidebarNavigationScreenPattern() {
 	const { params } = useNavigator();
+	const { categoryType } = getQueryArgs( window.location.href );
 	const { postType, postId } = params;
 	const { setCanvasMode } = unlock( useDispatch( editSiteStore ) );
 
@@ -26,6 +28,14 @@ export default function SidebarNavigationScreenPattern() {
 
 	const patternDetails = usePatternDetails( postType, postId );
 	const content = useNavigationMenuContent( postType, postId );
+
+	// The absence of a category type in the query params for template parts
+	// indicates the user has arrived at the template part via the "manage all"
+	// page and the back button should return them to that list page.
+	const backPath =
+		! categoryType && postType === 'wp_template_part'
+			? '/wp_template_part/all'
+			: '/library';
 
 	return (
 		<SidebarNavigationScreen
@@ -36,7 +46,7 @@ export default function SidebarNavigationScreenPattern() {
 					icon={ pencil }
 				/>
 			}
-			backPath={ '/library' }
+			backPath={ backPath }
 			content={ content }
 			{ ...patternDetails }
 		/>

--- a/packages/edit-site/src/components/sidebar-navigation-screen-templates-browse/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-templates-browse/index.js
@@ -21,6 +21,7 @@ const config = {
 		description: __(
 			'Create new template parts, or reset any customizations made to the template parts supplied by your theme.'
 		),
+		backPath: '/library',
 	},
 };
 
@@ -32,6 +33,7 @@ export default function SidebarNavigationScreenTemplatesBrowse() {
 		<SidebarNavigationScreen
 			title={ config[ postType ].title }
 			description={ config[ postType ].description }
+			backPath={ config[ postType ].backPath }
 		/>
 	);
 }

--- a/packages/edit-site/src/components/sidebar/index.js
+++ b/packages/edit-site/src/components/sidebar/index.js
@@ -59,11 +59,11 @@ function SidebarScreens() {
 			<NavigatorScreen path="/library">
 				<SidebarNavigationScreenLibrary />
 			</NavigatorScreen>
+			<NavigatorScreen path="/:postType(wp_template|wp_template_part)/all">
+				<SidebarNavigationScreenTemplatesBrowse />
+			</NavigatorScreen>
 			<NavigatorScreen path="/:postType(wp_template_part|wp_block)/:postId">
 				<SidebarNavigationScreenPattern />
-			</NavigatorScreen>
-			<NavigatorScreen path="/:postType(wp_template)/all">
-				<SidebarNavigationScreenTemplatesBrowse />
 			</NavigatorScreen>
 			<NavigatorScreen path="/:postType(wp_template)/:postId">
 				<SidebarNavigationScreenTemplate />

--- a/packages/edit-site/src/utils/get-is-list-page.js
+++ b/packages/edit-site/src/utils/get-is-list-page.js
@@ -15,6 +15,7 @@ export default function getIsListPage(
 ) {
 	return (
 		path === '/wp_template/all' ||
+		path === '/wp_template_part/all' ||
 		( path === '/library' &&
 			// Don't treat "/library" without categoryType and categoryId as a list page
 			// in mobile because the sidebar covers the whole page.


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/pull/51078#issuecomment-1607488515

## What?

Reinstates a "Manage all template parts" to the Site Editor's Library.

## Why?

Feedback received after the Library landing, revealed the removal of the "Manage all template parts" link and associated page was unexpected. The [primary library design](https://github.com/WordPress/gutenberg/issues/50028#issuecomment-1550777201), while omitting this link, has plenty of room to accommodate one alongside the other "manage all" link that was added after the fact.

## How?

- Reinstated the old version of `PageLibrary` as `PageTemplateParts` to display the table view of template parts
- Updates Site Editor sidebar navigation screens to accommodate the reinstated routes
- Updated the `get-is-list-page` util to cover the manage all template parts page
- Tweak back path's for template part related sidebar navigation screens so back buttons went to more expected locations

## Testing Instructions

1. Open Site Editor > Library
2. The "Manage all template parts" link should appear towards the bottom of the sidebar navigation screen
3. Confirm that clicking the "manage all" link takes you to the Template Parts table/list page
4. Check you can still edit a template part via this page
5. Test back navigation via both browser and sidebar navigation back buttons
6. Navigate back to the Library, select a category, and click on a template part
7. Check that the sidebar screen's back button takes you back to the library and the appropriate category still

## Screenshots or screencast <!-- if applicable -->


https://github.com/WordPress/gutenberg/assets/60436221/62f5ccc3-3dc1-4165-a69c-23180b1018fc


