### PR TITLE
[Site editor]: Lower emphasis on style variations in navigation sidebar

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen-browse-global-styles/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-browse-global-styles/index.js
@@ -1,0 +1,48 @@
+/**
+ * WordPress dependencies
+ */
+import { useSelect } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
+import { BlockEditorProvider } from '@wordpress/block-editor';
+
+/**
+ * Internal dependencies
+ */
+import { unlock } from '../../lock-unlock';
+import { store as editSiteStore } from '../../store';
+import StyleVariationsContainer from '../global-styles/style-variations-container';
+import SidebarNavigationScreen from '../sidebar-navigation-screen';
+
+const noop = () => {};
+
+export default function SidebarNavigationScreenBrowseGlobalStyles() {
+	const { storedSettings } = useSelect( ( select ) => {
+		const { getSettings } = unlock( select( editSiteStore ) );
+
+		return {
+			storedSettings: getSettings( false ),
+		};
+	}, [] );
+	return (
+		<SidebarNavigationScreen
+			title={ __( 'Browse styles' ) }
+			description={ __(
+				'Choose a different style combination for the theme styles.'
+			) }
+			content={
+				// Wrap in a BlockEditorProvider to ensure that the Iframe's dependencies are
+				// loaded. This is necessary because the Iframe component waits until
+				// the block editor store's `__internalIsInitialized` is true before
+				// rendering the iframe. Without this, the iframe previews will not render
+				// in mobile viewport sizes, where the editor canvas is hidden.
+				<BlockEditorProvider
+					settings={ storedSettings }
+					onChange={ noop }
+					onInput={ noop }
+				>
+					<StyleVariationsContainer />
+				</BlockEditorProvider>
+			}
+		/>
+	);
+}

--- a/packages/edit-site/src/components/sidebar-navigation-screen-global-styles/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-global-styles/index.js
@@ -156,9 +156,9 @@ export default function SidebarNavigationScreenGlobalStyles() {
 						) }
 						<SidebarNavigationItem
 							icon={ styles }
-							onClick={ async () => await openGlobalStyles() }
+							onClick={ openGlobalStyles }
 						>
-							{ __( 'Open styles' ) }
+							{ __( 'Edit styles' ) }
 						</SidebarNavigationItem>
 					</ItemGroup>
 				}

--- a/packages/edit-site/src/components/sidebar-navigation-screen-main/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-main/index.js
@@ -17,7 +17,6 @@ import { useEffect } from '@wordpress/element';
  */
 import SidebarNavigationScreen from '../sidebar-navigation-screen';
 import SidebarNavigationItem from '../sidebar-navigation-item';
-import { SidebarNavigationItemGlobalStyles } from '../sidebar-navigation-screen-global-styles';
 import { unlock } from '../../lock-unlock';
 import { store as editSiteStore } from '../../store';
 
@@ -51,12 +50,14 @@ export default function SidebarNavigationScreenMain() {
 					>
 						{ __( 'Navigation' ) }
 					</NavigatorButton>
-					<SidebarNavigationItemGlobalStyles
+					<NavigatorButton
+						as={ SidebarNavigationItem }
+						path="/wp_global_styles"
 						withChevron
 						icon={ styles }
 					>
 						{ __( 'Styles' ) }
-					</SidebarNavigationItemGlobalStyles>
+					</NavigatorButton>
 					<NavigatorButton
 						as={ SidebarNavigationItem }
 						path="/page"

--- a/packages/edit-site/src/components/sidebar/index.js
+++ b/packages/edit-site/src/components/sidebar/index.js
@@ -23,6 +23,7 @@ import SidebarNavigationScreenNavigationMenus from '../sidebar-navigation-screen
 import SidebarNavigationScreenNavigationMenu from '../sidebar-navigation-screen-navigation-menu';
 import SidebarNavigationScreenGlobalStyles from '../sidebar-navigation-screen-global-styles';
 import SidebarNavigationScreenTemplatesBrowse from '../sidebar-navigation-screen-templates-browse';
+import SidebarNavigationScreenBrowseGlobalStyles from '../sidebar-navigation-screen-browse-global-styles';
 import SaveHub from '../save-hub';
 import { unlock } from '../../lock-unlock';
 import SidebarNavigationScreenPages from '../sidebar-navigation-screen-pages';
@@ -46,6 +47,9 @@ function SidebarScreens() {
 			</NavigatorScreen>
 			<NavigatorScreen path="/wp_global_styles">
 				<SidebarNavigationScreenGlobalStyles />
+			</NavigatorScreen>
+			<NavigatorScreen path="/wp_global_styles/browseStyles">
+				<SidebarNavigationScreenBrowseGlobalStyles />
 			</NavigatorScreen>
 			<NavigatorScreen path="/page">
 				<SidebarNavigationScreenPages />


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
First version of: https://github.com/WordPress/gutenberg/issues/50924

This PR implements the first iteration based on designs from [here](https://github.com/WordPress/gutenberg/issues/50924):
<img width="3432" alt="styles drilldown temporary" src="https://github.com/WordPress/gutenberg/assets/1204802/9f370168-bbab-433c-9274-dc01e9a883a4">
<!-- In a few words, what is the PR actually doing? -->

The side effect(not a bad one) is that now we also have a dedicated url path for the style variations.



## Testing Instructions
1. In site editor open the navigation sidebar and click `Styles`.
2. Also check with a theme that has no style variations(the button doesn't render)



## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/16275880/7e4dca7e-4973-483c-80bc-afc2e1073dd1

