### PR TITLE
Site Editor: Update text color of active menu items

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-item/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-item/style.scss
@@ -15,6 +15,7 @@
 
 	&[aria-current] {
 		background: var(--wp-admin-theme-color);
+		color: $white;
 	}
 
 	.edit-site-sidebar-navigation-item__drilldown-indicator {


### PR DESCRIPTION
## What?
Updates the text color of active menu items in the site editor.

## Why?
Grey on blue doesn't offer adequate contrast.

## Testing Instructions
* Open the Library in the Site Editor
* Notice the text and icon in the active menu item are white

| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/1813435/248932354-f00f0b20-d401-46ee-b759-59c9a4f98853.png"> | <img src="https://user-images.githubusercontent.com/1813435/248932351-ac2b6ef4-967a-4488-836c-970b7f555ddf.png"> | 
