### PR TITLE
Navigation: Add the draft status to the navigation title

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/index.js
@@ -17,6 +17,7 @@ import { SidebarNavigationScreenWrapper } from '../sidebar-navigation-screen-nav
 import ScreenNavigationMoreMenu from './more-menu';
 import SingleNavigationMenu from './single-navigation-menu';
 import useNavigationMenuHandlers from './use-navigation-menu-handlers';
+import { buildNavigationLabel } from '../sidebar-navigation-screen-navigation-menus/build-navigation-label';
 
 export const postType = `wp_navigation`;
 
@@ -94,7 +95,11 @@ export default function SidebarNavigationScreenNavigationMenu() {
 						onDuplicate={ _handleDuplicate }
 					/>
 				}
-				title={ decodeEntities( menuTitle ) }
+				title={ buildNavigationLabel(
+					navigationMenu?.title,
+					navigationMenu?.id,
+					navigationMenu?.status
+				) }
 				description={ __( 'This Navigation Menu is empty.' ) }
 			/>
 		);

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/index.js
@@ -17,7 +17,7 @@ import { SidebarNavigationScreenWrapper } from '../sidebar-navigation-screen-nav
 import ScreenNavigationMoreMenu from './more-menu';
 import SingleNavigationMenu from './single-navigation-menu';
 import useNavigationMenuHandlers from './use-navigation-menu-handlers';
-import { buildNavigationLabel } from '../sidebar-navigation-screen-navigation-menus/build-navigation-label';
+import buildNavigationLabel from '../sidebar-navigation-screen-navigation-menus/build-navigation-label';
 
 export const postType = `wp_navigation`;
 

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/single-navigation-menu.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/single-navigation-menu.js
@@ -9,7 +9,7 @@ import { decodeEntities } from '@wordpress/html-entities';
 import { SidebarNavigationScreenWrapper } from '../sidebar-navigation-screen-navigation-menus';
 import ScreenNavigationMoreMenu from './more-menu';
 import NavigationMenuEditor from './navigation-menu-editor';
-import { buildNavigationLabel } from '../sidebar-navigation-screen-navigation-menus/build-navigation-label';
+import buildNavigationLabel from '../sidebar-navigation-screen-navigation-menus/build-navigation-label';
 
 export default function SingleNavigationMenu( {
 	navigationMenu,

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/single-navigation-menu.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/single-navigation-menu.js
@@ -9,6 +9,7 @@ import { decodeEntities } from '@wordpress/html-entities';
 import { SidebarNavigationScreenWrapper } from '../sidebar-navigation-screen-navigation-menus';
 import ScreenNavigationMoreMenu from './more-menu';
 import NavigationMenuEditor from './navigation-menu-editor';
+import { buildNavigationLabel } from '../sidebar-navigation-screen-navigation-menus/build-navigation-label';
 
 export default function SingleNavigationMenu( {
 	navigationMenu,
@@ -28,7 +29,11 @@ export default function SingleNavigationMenu( {
 					onDuplicate={ handleDuplicate }
 				/>
 			}
-			title={ decodeEntities( menuTitle ) }
+			title={ buildNavigationLabel(
+				navigationMenu?.title,
+				navigationMenu?.id,
+				navigationMenu?.status
+			) }
 			description={ __(
 				'Navigation menus are a curated collection of blocks that allow visitors to get around your site.'
 			) }

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/build-navigation-label.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/build-navigation-label.js
@@ -1,0 +1,24 @@
+/**
+ * WordPress dependencies
+ */
+import { __, sprintf } from '@wordpress/i18n';
+import { decodeEntities } from '@wordpress/html-entities';
+
+// Copied from packages/block-library/src/navigation/edit/navigation-menu-selector.js.
+export function buildNavigationLabel( title, id, status ) {
+	if ( ! title?.rendered ) {
+		/* translators: %s is the index of the menu in the list of menus. */
+		return sprintf( __( '(no title %s)' ), id );
+	}
+
+	if ( status === 'publish' ) {
+		return decodeEntities( title?.rendered );
+	}
+
+	return sprintf(
+		// translators: %1s: title of the menu; %2s: status of the menu (draft, pending, etc.).
+		__( '%1$s (%2$s)' ),
+		decodeEntities( title?.rendered ),
+		status
+	);
+}

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/build-navigation-label.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/build-navigation-label.js
@@ -5,7 +5,7 @@ import { __, sprintf } from '@wordpress/i18n';
 import { decodeEntities } from '@wordpress/html-entities';
 
 // Copied from packages/block-library/src/navigation/edit/navigation-menu-selector.js.
-export function buildNavigationLabel( title, id, status ) {
+export default function buildNavigationLabel( title, id, status ) {
 	if ( ! title?.rendered ) {
 		/* translators: %s is the index of the menu in the list of menus. */
 		return sprintf( __( '(no title %s)' ), id );


### PR DESCRIPTION
## What?
Adds the `(draft)` status to the title of the Navigation area of the Site View sidebar. Fixes #51797.

## Why?
The status should be in both places.

## How?
Extract `buildNavigationLabel` to a new file so it can be shared across all the different places it is used.

## Testing Instructions
1. Open the site editor
2. Edit the navigation block, and create a new navigation menu
3. Do not save!
4. Now go back to the site view, and open the navigation section of the sidebar
5. The newly created navigation should have the `(draft)` status indicator next to it in both the list view and the single view.
6. Now delete all of the other navigations and check that the status is still next to the title.

## Screenshots or screencast <!-- if applicable -->
<img width="360" alt="Screenshot 2023-06-27 at 10 59 46" src="https://github.com/WordPress/gutenberg/assets/275961/8bf9d28b-b924-4fa5-8928-d10e5f636ec2">

<img width="360" alt="Screenshot 2023-06-27 at 10 59 57" src="https://github.com/WordPress/gutenberg/assets/275961/af7922e3-851b-44f1-ab53-b7a2e3ff7dd4">

