### PR TITLE
Update stepper styling in Home template details panel

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-screen/style.scss
@@ -107,10 +107,10 @@
 .edit-site-sidebar-navigation-screen__input-control {
 	width: 100%;
 	.components-input-control__container {
-		background: $gray-800 !important;
+		background: $gray-800;
 
 		.components-button {
-			color: $gray-200 !important;
+			color: $gray-200;
 		}
 	}
 	.components-input-control__input {

--- a/packages/edit-site/src/components/sidebar-navigation-screen/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-screen/style.scss
@@ -107,7 +107,11 @@
 .edit-site-sidebar-navigation-screen__input-control {
 	width: 100%;
 	.components-input-control__container {
-		background: transparent;
+		background: $gray-800 !important;
+
+		.components-button {
+			color: $gray-200 !important;
+		}
 	}
 	.components-input-control__input {
 		color: $gray-200 !important;


### PR DESCRIPTION
## Why?
The current appearance is inconsistent with other instances of this component, and the +/- buttons do not have sufficient contrast.

## Testing Instructions
* Navigate to the Home template details in the Site Editor
* Observe the updated appearance of the "Posts per page" control

| Before | After |
| --- | --- |
| <img width="359" alt="Screenshot 2023-06-27 at 11 46 42" src="https://github.com/WordPress/gutenberg/assets/846565/7284ed27-83b5-4bc0-ae10-79493da7097b"> | <img width="350" alt="Screenshot 2023-06-27 at 11 44 04" src="https://github.com/WordPress/gutenberg/assets/846565/23490720-4dbf-4e6c-bec2-7183a2740521"> |


