### PR TITLE
Make the entire preview clickable in order to enter "edit" mode in focus mode.

### DIFF
--- a/packages/edit-site/src/components/block-editor/editor-canvas.js
+++ b/packages/edit-site/src/components/block-editor/editor-canvas.js
@@ -87,7 +87,9 @@ function EditorCanvas( { enableResizing, settings, children, ...props } ) {
 					// which isn't a requirement in auto resize mode.
 					enableResizing ? 'min-height:0!important;' : ''
 				}}body{position:relative; ${
-					canvasMode === 'view' ? 'cursor: pointer;' : ''
+					canvasMode === 'view'
+						? 'cursor: pointer; height: 100vh'
+						: ''
 				}}}`
 			}</style>
 			{ children }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Makes the entire preview clickable in order to enter "edit" mode in focus mode.

Fixes https://github.com/WordPress/gutenberg/issues/51794

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Currently, despite the preview being full height, there is a bug whereby only clicking the actual _blocks_ triggers edit mode. 

Instead the entire window should be clickable to trigger edit mode. This PR fixes that.

This is particularly important for patterns/navigations which only have a single block.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Sets the `body` in `view` mode to be `100vh` which resolves to "100% of the containing iframe". This ensures that the `body` expands to fill the full height.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

- Have a Navigation menu
- In Site Editor Browse Mode click on `Navigation` and choose a menu.
- Now click anywhere in the preview to active edit mode. You shouldn't need to click on the actual blocks.
- Now test this works for patterns and templates and all other content types.
- Check that "Zoom out mode" for previewing different style variations has not broken.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->



https://github.com/WordPress/gutenberg/assets/444434/6654e2d9-70c9-4f1a-b6da-396c39a26aa7


