### PR TITLE
Interactivity API: Move Store's data encoding to the `echo` call

### DIFF
--- a/lib/experimental/interactivity-api/class-wp-interactivity-store.php
+++ b/lib/experimental/interactivity-api/class-wp-interactivity-store.php
@@ -48,16 +48,6 @@ class WP_Interactivity_Store {
 	}
 
 	/**
-	 * Serialize store data to JSON.
-	 *
-	 * @return string|false Serialized JSON data.
-	 */
-	static function serialize() {
-		// TODO: Escape?
-		return wp_json_encode( self::$store );
-	}
-
-	/**
 	 * Reset the store data.
 	 */
 	static function reset() {
@@ -71,7 +61,9 @@ class WP_Interactivity_Store {
 		if ( empty( self::$store ) ) {
 			return;
 		}
-		$store = self::serialize();
-		echo "<script id=\"wp-interactivity-store-data\" type=\"application/json\">$store</script>";
+		echo sprintf(
+			'<script id="wp-interactivity-store-data" type="application/json">%s</script>',
+			wp_json_encode( self::$store )
+		);
 	}
 }

--- a/lib/experimental/interactivity-api/class-wp-interactivity-store.php
+++ b/lib/experimental/interactivity-api/class-wp-interactivity-store.php
@@ -63,7 +63,7 @@ class WP_Interactivity_Store {
 		}
 		echo sprintf(
 			'<script id="wp-interactivity-store-data" type="application/json">%s</script>',
-			wp_json_encode( self::$store )
+			wp_json_encode( self::$store, JSON_HEX_TAG | JSON_HEX_AMP )
 		);
 	}
 }

--- a/phpunit/experimental/interactivity-api/class-wp-interactivity-store-test.php
+++ b/phpunit/experimental/interactivity-api/class-wp-interactivity-store-test.php
@@ -171,15 +171,15 @@ class WP_Interactivity_Store_Test extends WP_UnitTestCase {
 			array(
 				'state' => array(
 					'amps' => 'http://site.test/?foo=1&baz=2&bar=3',
-					'tags' => 'Do not do this: <!-- <script>'
-				)
+					'tags' => 'Do not do this: <!-- <script>',
+				),
 			)
 		);
 		ob_start();
 		WP_Interactivity_Store::render();
 		$rendered = ob_get_clean();
 		$this->assertSame(
-			'<script id="wp-interactivity-store-data" type="application/json">{"state":{"amps":"http:\/\/site.test\/?foo=1\u0026baz=2\u0026bar=3","content":"Do not do this: \u003C!-- \u003Cscript\u003E"}}</script>',
+			'<script id="wp-interactivity-store-data" type="application/json">{"state":{"amps":"http:\/\/site.test\/?foo=1\u0026baz=2\u0026bar=3","tags":"Do not do this: \u003C!-- \u003Cscript\u003E"}}</script>',
 			$rendered
 		);
 	}

--- a/phpunit/experimental/interactivity-api/class-wp-interactivity-store-test.php
+++ b/phpunit/experimental/interactivity-api/class-wp-interactivity-store-test.php
@@ -165,4 +165,22 @@ class WP_Interactivity_Store_Test extends WP_UnitTestCase {
 			$rendered
 		);
 	}
+
+	public function test_store_should_also_escape_tags_and_amps() {
+		WP_Interactivity_Store::merge_data(
+			array(
+				'state' => array(
+					'amps' => 'http://site.test/?foo=1&baz=2&bar=3',
+					'tags' => 'Do not do this: <!-- <script>'
+				)
+			)
+		);
+		ob_start();
+		WP_Interactivity_Store::render();
+		$rendered = ob_get_clean();
+		$this->assertSame(
+			'<script id="wp-interactivity-store-data" type="application/json">{"state":{"amps":"http:\/\/site.test\/?foo=1\u0026baz=2\u0026bar=3","content":"Do not do this: \u003C!-- \u003Cscript\u003E"}}</script>',
+			$rendered
+		);
+	}
 }


### PR DESCRIPTION
## What?
Moves `wp_json_encode()` to the `WP_Interactivity_Store`'s `render` method (next to `echo`), thus escaping as late as possible.

Also, removes the unneeded `serialize` method.

Props to @danielwrobert. 😄 


## Why?

To conform with [WP security guiding principles](https://developer.wordpress.org/apis/security/#h-guiding-principles).


## Testing Instructions
PHP unit tests should pass.
