### PR TITLE
Lodash: Remove dependency from block library package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17340,7 +17340,6 @@
 				"escape-html": "^1.0.3",
 				"fast-average-color": "^9.1.1",
 				"fast-deep-equal": "^3.1.3",
-				"lodash": "^4.17.21",
 				"memize": "^2.1.0",
 				"micromodal": "^0.4.10",
 				"preact": "^10.13.2",

--- a/packages/block-library/package.json
+++ b/packages/block-library/package.json
@@ -69,7 +69,6 @@
 		"escape-html": "^1.0.3",
 		"fast-average-color": "^9.1.1",
 		"fast-deep-equal": "^3.1.3",
-		"lodash": "^4.17.21",
 		"memize": "^2.1.0",
 		"micromodal": "^0.4.10",
 		"preact": "^10.13.2",


### PR DESCRIPTION
## What?
#51916 removed the last Lodash usage in the block library package. This PR removes the dependency from the package altogether - another one bites the dust!

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?

We're just removing the dependency.

## Testing Instructions

* Verify Lodash is not in use in the block library package.
* Verify all checks are green.