### PR TITLE
Navigation: Simplify the useSelect for useNavigationMenus

### DIFF
--- a/packages/block-library/src/navigation/constants.js
+++ b/packages/block-library/src/navigation/constants.js
@@ -20,13 +20,15 @@ export const PRIORITIZED_INSERTER_BLOCKS = [
 	'core/navigation-link',
 ];
 
+export const PRELOADED_NAVIGATION_MENUS_QUERY = {
+	per_page: 100,
+	status: [ 'publish', 'draft' ],
+	order: 'desc',
+	orderby: 'date',
+};
+
 export const SELECT_NAVIGATION_MENUS_ARGS = [
 	'postType',
 	'wp_navigation',
-	{
-		per_page: 100,
-		status: [ 'publish', 'draft' ],
-		order: 'desc',
-		orderby: 'date',
-	},
+	PRELOADED_NAVIGATION_MENUS_QUERY,
 ];

--- a/packages/block-library/src/navigation/constants.js
+++ b/packages/block-library/src/navigation/constants.js
@@ -20,6 +20,10 @@ export const PRIORITIZED_INSERTER_BLOCKS = [
 	'core/navigation-link',
 ];
 
+// These parameters must be kept aligned with those in
+// lib/compat/wordpress-6.3/navigation-block-preloading.php
+// and
+// edit-site/src/components/sidebar-navigation-screen-navigation-menus/constants.js
 export const PRELOADED_NAVIGATION_MENUS_QUERY = {
 	per_page: 100,
 	status: [ 'publish', 'draft' ],

--- a/packages/block-library/src/navigation/use-navigation-menu.js
+++ b/packages/block-library/src/navigation/use-navigation-menu.js
@@ -19,14 +19,6 @@ export default function useNavigationMenu( ref ) {
 	const useSelectResult = useSelect(
 		( select ) => {
 			const {
-				canCreate,
-				canUpdate,
-				canDelete,
-				isResolving,
-				hasResolved,
-			} = permissions;
-
-			const {
 				navigationMenu,
 				isNavigationMenuResolved,
 				isNavigationMenuMissing,
@@ -36,37 +28,27 @@ export default function useNavigationMenu( ref ) {
 				navigationMenu,
 				isNavigationMenuResolved,
 				isNavigationMenuMissing,
-
-				canUserCreateNavigationMenu: canCreate,
-				isResolvingCanUserCreateNavigationMenu: isResolving,
-				hasResolvedCanUserCreateNavigationMenu: hasResolved,
-
-				canUserUpdateNavigationMenu: canUpdate,
-				hasResolvedCanUserUpdateNavigationMenu: ref
-					? hasResolved
-					: undefined,
-
-				canUserDeleteNavigationMenu: canDelete,
-				hasResolvedCanUserDeleteNavigationMenu: ref
-					? hasResolved
-					: undefined,
 			};
 		},
-		[ ref, permissions ]
+		[ ref ]
 	);
+
+	const { canCreate, canUpdate, canDelete, isResolving, hasResolved } =
+		permissions;
 
 	const {
 		records: navigationMenus,
 		isResolving: isResolvingNavigationMenus,
 		hasResolved: hasResolvedNavigationMenus,
-		canSwitchNavigationMenu = ref
-			? navigationMenus?.length > 1
-			: navigationMenus?.length > 0,
 	} = useEntityRecords(
 		'postType',
 		`wp_navigation`,
 		PRELOADED_NAVIGATION_MENUS_QUERY
 	);
+
+	const canSwitchNavigationMenu = ref
+		? navigationMenus?.length > 1
+		: navigationMenus?.length > 0;
 
 	return {
 		...useSelectResult,
@@ -74,6 +56,13 @@ export default function useNavigationMenu( ref ) {
 		isResolvingNavigationMenus,
 		hasResolvedNavigationMenus,
 		canSwitchNavigationMenu,
+		canUserCreateNavigationMenu: canCreate,
+		isResolvingCanUserCreateNavigationMenu: isResolving,
+		hasResolvedCanUserCreateNavigationMenu: hasResolved,
+		canUserUpdateNavigationMenu: canUpdate,
+		hasResolvedCanUserUpdateNavigationMenu: ref ? hasResolved : undefined,
+		canUserDeleteNavigationMenu: canDelete,
+		hasResolvedCanUserDeleteNavigationMenu: ref ? hasResolved : undefined,
 	};
 }
 

--- a/packages/block-library/src/navigation/use-navigation-menu.js
+++ b/packages/block-library/src/navigation/use-navigation-menu.js
@@ -16,19 +16,13 @@ import { PRELOADED_NAVIGATION_MENUS_QUERY } from './constants';
 export default function useNavigationMenu( ref ) {
 	const permissions = useResourcePermissions( 'navigation', ref );
 
-	const useSelectResult = useSelect(
+	const {
+		navigationMenu,
+		isNavigationMenuResolved,
+		isNavigationMenuMissing,
+	} = useSelect(
 		( select ) => {
-			const {
-				navigationMenu,
-				isNavigationMenuResolved,
-				isNavigationMenuMissing,
-			} = selectExistingMenu( select, ref );
-
-			return {
-				navigationMenu,
-				isNavigationMenuResolved,
-				isNavigationMenuMissing,
-			};
+			return selectExistingMenu( select, ref );
 		},
 		[ ref ]
 	);
@@ -51,7 +45,9 @@ export default function useNavigationMenu( ref ) {
 		: navigationMenus?.length > 0;
 
 	return {
-		...useSelectResult,
+		navigationMenu,
+		isNavigationMenuResolved,
+		isNavigationMenuMissing,
 		navigationMenus,
 		isResolvingNavigationMenus,
 		hasResolvedNavigationMenus,

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/constants.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/constants.js
@@ -3,6 +3,8 @@
 // on apiFetch this query is limited to 100.
 // These parameters must be kept aligned with those in
 // lib/compat/wordpress-6.3/navigation-block-preloading.php
+// and
+// block-library/src/navigation/constants.js
 export const PRELOADED_NAVIGATION_MENUS_QUERY = {
 	per_page: 100,
 	status: [ 'publish', 'draft' ],


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
The useSelect for useNavigationMenus is unnecessarily complex - this simplifies it.

## Why?
Makes the code easier to read and change.

## How?
Refactoring.

## Testing Instructions
Check that the navigation block continues to behave as before
Check the tests pass