### PR TITLE
Optimize `compute_style_properties` by reducing the number of iterations it performs

### DIFF
--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -1892,14 +1892,14 @@ class WP_Theme_JSON_Gutenberg {
 	 */
 	private static function get_paths_in_node( $node ) {
 		$paths = array();
-		foreach( $node as $key => $value ) {
+		foreach ( $node as $key => $value ) {
 			if ( is_array( $value ) ) {
 				$subpaths = static::get_paths_in_node( $value );
-				foreach( $subpaths as $subpath ) {
+				foreach ( $subpaths as $subpath ) {
 					if ( ! is_array( $subpath ) ) {
 						$subpath = array( $subpath );
 					}
-					$paths[] = array_merge( array( $key ) , $subpath );
+					$paths[] = array_merge( array( $key ), $subpath );
 				}
 			} else {
 				$paths[] = $key;
@@ -1957,8 +1957,8 @@ class WP_Theme_JSON_Gutenberg {
 		 */
 		$paths_in_node         = self::get_paths_in_node( $styles );
 		$properties_to_inspect = array();
-		foreach( $properties as $key => $value ) {
-			if ( in_array( $value, $paths_in_node ) ) {
+		foreach ( $properties as $key => $value ) {
+			if ( in_array( $value, $paths_in_node, true ) ) {
 				$properties_to_inspect[ $key ] = $value;
 			}
 		}


### PR DESCRIPTION
Related https://github.com/WordPress/gutenberg/issues/45171

## What?

This PR improves TTFB by improving how `WP_Theme_JSON_Gutenberg::compute_style_properties` operates.

## Why?

The faster, the better.

TTFB using a production environment locally ([data](https://docs.google.com/spreadsheets/d/1wk2-z-MvcxMsoQrwuoVGgoEecUru-B5d-OJBmWW8ibk/)):

![image](https://github.com/WordPress/gutenberg/assets/583546/4f0b8891-2a6d-4719-bb36-92b1691c2c95)

## How?

The `compute_style_properties` method is responsible for converting a "style node" coming from a `theme.json` structure into a list of CSS declarations.

Input:

```
array(
  'color' => array(
    'background' => 'background-value',
    'text'              => 'text-value',
  ),
)
```

Output:

```
array(
  array( 'name' => 'background-color', 'value' => 'background-value' ),
  array( 'name' => 'color', 'value' => 'text-value' ),
)
```

To do such conversion, it maintains a map of CSS properties to paths in a "style node" within a `theme.json` file: [PROPERTIES_METADATA](https://github.com/WordPress/gutenberg/blob/trunk/lib/class-wp-theme-json-gutenberg.php#L208). At the time of writing this, there's 54 of them.

The `compute_style_properties` method iterates over all of them for every input node. As a result, in a theme such as TwentyTwentyThree with 65 style nodes, some code paths are executed 65 * 54 = 3510 times.

This PR updates how `compute_style_properties` works to **iterate over the properties that exist in the input**, not over all of them. In a theme such as TwentyTwentyThree this can be less than 3 properties per style node, amounting to 65 * 3 ~= 195 times.

## Testing Instructions

Make sure the automated tests pass.

## How to reproduce the benchmarks locally:

- Build the plugin: `npm install && npm run build`.
- Create a `.wp-env.override.json` file with the following contents:

```json
{
        "config": {
                "WP_DEBUG": false,
                "SCRIPT_DEBUG": false
        }
}
```
- Run the docker environment: `npm run wp-env start`.
- Request the homepage of the theme 250 times: `eq 250 | xargs -Iz curl -o /dev/null -H 'Cache-Control: no-cache' -s -w "%{time_starttransfer}\n" http://localhost:8888/ | xclip -selection clipboard`.
- Paste the results into a spreadsheet.

Do the above for each one of the last default themes (TwentyTwenty, TwentyTwentyOne, TwentyTwentyTwo, TwentyTwentyThree) for this branch. Then, do the same using `trunk` at 72b7d89dbcda2ba63bc1ad99e8fc5f33309401d3.