### PR TITLE
Update versions in WP for 6.3

### DIFF
--- a/docs/contributors/versions-in-wordpress.md
+++ b/docs/contributors/versions-in-wordpress.md
@@ -6,6 +6,7 @@ If anything looks incorrect here, please bring it up in #core-editor in [WordPre
 
 | Gutenberg Versions | WordPress Version |
 | ------------------ | ----------------- |
+| 15.2-16.1          | 6.3               |
 | 14.2-15.1          | 6.2               |
 | 13.1-14.1          | 6.1.1             |
 | 13.1-14.1          | 6.1               |


### PR DESCRIPTION
## What?

With 6.3 beta 1 going out today, this updates the versions in WP to include the latest release.

