### PR TITLE
Library: Update section headings in pattern grid to account for template parts

### DIFF
--- a/packages/edit-site/src/components/page-library/patterns-list.js
+++ b/packages/edit-site/src/components/page-library/patterns-list.js
@@ -42,6 +42,12 @@ export default function PatternsList( { categoryId, type } ) {
 
 	const { syncedPatterns, unsyncedPatterns } = patterns;
 	const hasPatterns = !! syncedPatterns.length || !! unsyncedPatterns.length;
+	const isHeaders = type === 'wp_template_part' && categoryId === 'header';
+	const isFooters = type === 'wp_template_part' && categoryId === 'footer';
+	const isTemplatePart =
+		type === 'wp_template_part' && categoryId === 'uncategorized';
+	const isCustomPattern =
+		type === 'pattern' && categoryId === 'custom-patterns';
 
 	return (
 		<VStack spacing={ 6 }>
@@ -75,18 +81,36 @@ export default function PatternsList( { categoryId, type } ) {
 			{ isResolving && __( 'Loading' ) }
 			{ ! isResolving && !! syncedPatterns.length && (
 				<>
-					<VStack className="edit-site-library__section-header">
-						<Heading level={ 4 }>{ __( 'Synced' ) }</Heading>
-						<Text variant="muted" as="p">
-							{ __(
-								'Patterns that are kept in sync across your site'
-							) }
-						</Text>
-					</VStack>
+					{ isCustomPattern && (
+						<VStack className="edit-site-library__section-header">
+							<Heading level={ 4 }>{ __( 'Synced' ) }</Heading>
+
+							<Text variant="muted" as="p">
+								{ __(
+									'Patterns that are kept in sync across your site'
+								) }
+							</Text>
+						</VStack>
+					) }
 					<Grid
 						icon={ symbol }
 						categoryId={ categoryId }
-						label={ __( 'Synced patterns' ) }
+						label={ ( () => {
+							switch ( true ) {
+								case isHeaders: {
+									return __( 'Headers' );
+								}
+								case isFooters: {
+									return __( 'Footers' );
+								}
+								case isTemplatePart: {
+									return __( 'Uncategorized' );
+								}
+								default: {
+									return __( 'Synced patterns' );
+								}
+							}
+						} )() }
 						items={ syncedPatterns }
 					/>
 				</>


### PR DESCRIPTION
## What?
When browsing template parts in the Library, do not display the "Synced" heading and description.

## Why?
The pattern grid splits synced and unsynced entries like so:

<img width="690" alt="Screenshot 2023-06-27 at 16 37 33" src="https://github.com/WordPress/gutenberg/assets/846565/f146fb87-0051-4d59-bfa8-cea61e8b2927">

This is useful in contexts where patterns can be synced or not, such as the "Custom patterns" section. 

However, template parts are _always_ synced, so the heading is somewhat irrelevant.

Additionally, the description refers to the entries as "patterns", and it is not 100% clear that is the correct label for template parts.

## Testing Instructions
* Open the Library
* Browse template parts and notice there is no "Synced" heading above them.
* Browse "Custom patterns" and notice the "Synced" and "Standard" headings remain.

## Before
<img width="1418" alt="Screenshot 2023-06-27 at 16 42 03" src="https://github.com/WordPress/gutenberg/assets/846565/c45c1ef2-784d-4e6a-a7fe-3f7ed5b6967c">

## After
<img width="1418" alt="Screenshot 2023-06-27 at 16 41 41" src="https://github.com/WordPress/gutenberg/assets/846565/ea33cccc-6ad0-458b-ae75-41cbf442c222">
