### PR TITLE
Export store from the edit-site package

### DIFF
--- a/packages/edit-site/src/index.js
+++ b/packages/edit-site/src/index.js
@@ -107,3 +107,4 @@ export { default as PluginSidebar } from './components/sidebar-edit-mode/plugin-
 export { default as PluginSidebarMoreMenuItem } from './components/header-edit-mode/plugin-sidebar-more-menu-item';
 export { default as PluginMoreMenuItem } from './components/header-edit-mode/plugin-more-menu-item';
 export { default as PluginTemplateSettingPanel } from './components/plugin-template-setting-panel';
+export { store } from './store';


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
While working on adding examples to the edit-site package as part of #42125, I discovered that the package does not export its `store` which does not allow for importing it for use with useSelect/useDispatch like other stores.

## Why?
Most of the examples import the [store directly from the package](https://developer.wordpress.org/block-editor/reference-guides/data/data-core-blocks/#getblocktype) and the expectation should be the same for this package.

## How?
Exporting the store from the main `index.js` file.

## Testing Instructions
Add the following code into a block and confirm that there is an console error:
 ```js
 import { store as editSiteStore } from '@wordpress/edit-site';
import { useSelect } from '@wordpress/data';

const ExampleComponent = () => {
	const { getCanUserCreateMedia } = useSelect(
		( select ) => select( editSiteStore ),
		[]
	);

	return getCanUserCreateMedia() ? (
		<p>{ __( 'Current user can create media.' ) }</p>
	) : (
		<p>{ __( 'Current user cannot create media.' ) }</p>
	);
};
```
Build this branch locally and confirm that the issue is fixed


