### PR TITLE
Block Supports: Change prefix in gutenberg_apply_colors_support to wp_ in dynamic blocks

### DIFF
--- a/packages/block-library/src/navigation-submenu/index.php
+++ b/packages/block-library/src/navigation-submenu/index.php
@@ -199,9 +199,9 @@ function render_block_core_navigation_submenu( $attributes, $content, $block ) {
 			$attributes['style']['color']['background'] = $block->context['customOverlayBackgroundColor'];
 		}
 
-		// This allows us to be able to get a response from gutenberg_apply_colors_support.
+		// This allows us to be able to get a response from wp_apply_colors_support.
 		$block->block_type->supports['color'] = true;
-		$colors_supports                      = gutenberg_apply_colors_support( $block->block_type, $attributes );
+		$colors_supports                      = wp_apply_colors_support( $block->block_type, $attributes );
 		$css_classes                          = 'wp-block-navigation__submenu-container';
 		if ( array_key_exists( 'class', $colors_supports ) ) {
 			$css_classes .= ' ' . $colors_supports['class'];

--- a/tools/webpack/blocks.js
+++ b/tools/webpack/blocks.js
@@ -29,6 +29,7 @@ const blockViewRegex = new RegExp(
  */
 const prefixFunctions = [
 	'build_query_vars_from_query_block',
+	'wp_apply_colors_support',
 	'wp_enqueue_block_support_styles',
 	'wp_get_typography_font_size_value',
 	'wp_style_engine_get_styles',


### PR DESCRIPTION
## What?
In the Navigation Submenu dynamic block, rename `gutenberg_apply_colors_support` to `wp_apply_colors_support`, and add the latter to the list of function calls that are rewritten during block build time.

## Why?
For the Core merge, see https://github.com/WordPress/wordpress-develop/pull/4722#issuecomment-1609877196.

## How?
Uses the existing mechanism in Webpack to rename functions during block build. See e.g. `wp_get_typography_font_size_value`/`gutenberg_get_typography_font_size_value` for precedent.

## Testing Instructions
Verify that "Color" block supports still works.
