### PR TITLE
[Library] Add lock icon for theme patterns

### DIFF
--- a/packages/edit-site/src/components/page-patterns/grid-item.js
+++ b/packages/edit-site/src/components/page-patterns/grid-item.js
@@ -39,7 +39,7 @@ import { DELETE, BACKSPACE } from '@wordpress/keycodes';
 import { PATTERNS, USER_PATTERNS } from './utils';
 import { useLink } from '../routes/link';
 
-const THEME_PATTERN_TOOLTIP = __( 'Theme patterns cannot be edited here' );
+const THEME_PATTERN_TOOLTIP = __( 'Theme patterns cannot be edited.' );
 
 export default function GridItem( { categoryId, composite, icon, item } ) {
 	const descriptionId = useId();
@@ -166,7 +166,7 @@ export default function GridItem( { categoryId, composite, icon, item } ) {
 								<Tooltip
 									position="top center"
 									text={ __(
-										'Theme patterns cannot be edited here'
+										'Theme patterns cannot be edited.'
 									) }
 								>
 									<span className="edit-site-patterns__pattern-lock-icon">

--- a/packages/edit-site/src/components/page-patterns/grid-item.js
+++ b/packages/edit-site/src/components/page-patterns/grid-item.js
@@ -18,9 +18,8 @@ import {
 	Tooltip,
 	Flex,
 } from '@wordpress/components';
-import { useInstanceId } from '@wordpress/compose';
 import { useDispatch } from '@wordpress/data';
-import { useState } from '@wordpress/element';
+import { useState, useId } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import {
 	Icon,
@@ -40,9 +39,10 @@ import { DELETE, BACKSPACE } from '@wordpress/keycodes';
 import { PATTERNS, USER_PATTERNS } from './utils';
 import { useLink } from '../routes/link';
 
+const THEME_PATTERN_TOOLTIP = __( 'Theme patterns cannot be edited here' );
+
 export default function GridItem( { categoryId, composite, icon, item } ) {
-	const instanceId = useInstanceId( GridItem );
-	const descriptionId = `edit-site-patterns__pattern-description-${ instanceId }`;
+	const descriptionId = useId();
 	const [ isDeleteDialogOpen, setIsDeleteDialogOpen ] = useState( false );
 
 	const { __experimentalDeleteReusableBlock } =
@@ -87,14 +87,17 @@ export default function GridItem( { categoryId, composite, icon, item } ) {
 	};
 
 	const isUserPattern = item.type === USER_PATTERNS;
-	let ariaDescription;
+	const ariaDescriptions = [];
 	if ( isUserPattern ) {
 		// User patterns don't have descriptions, but can be edited and deleted, so include some help text.
-		ariaDescription = __(
-			'Press Enter to edit, or Delete to delete the pattern.'
+		ariaDescriptions.push(
+			__( 'Press Enter to edit, or Delete to delete the pattern.' )
 		);
 	} else if ( item.description ) {
-		ariaDescription = item.description;
+		ariaDescriptions.push( item.description );
+	}
+	if ( item.type === PATTERNS ) {
+		ariaDescriptions.push( THEME_PATTERN_TOOLTIP );
 	}
 
 	let itemIcon = icon;
@@ -118,21 +121,23 @@ export default function GridItem( { categoryId, composite, icon, item } ) {
 					onKeyDown={ isUserPattern ? onKeyDown : undefined }
 					aria-label={ item.title }
 					aria-describedby={
-						ariaDescription ? descriptionId : undefined
+						ariaDescriptions.length
+							? ariaDescriptions.join( ' ' )
+							: undefined
 					}
 				>
 					{ isEmpty && __( 'Empty pattern' ) }
 					{ ! isEmpty && <BlockPreview blocks={ item.blocks } /> }
 				</CompositeItem>
-				{ ariaDescription && (
+				{ ariaDescriptions.map( ( ariaDescription, index ) => (
 					<div
-						aria-hidden="true"
-						style={ { display: 'none' } }
-						id={ descriptionId }
+						key={ index }
+						hidden
+						id={ `${ descriptionId }-${ index }` }
 					>
 						{ ariaDescription }
 					</div>
-				) }
+				) ) }
 				<HStack
 					aria-hidden="true"
 					className="edit-site-patterns__footer"

--- a/packages/edit-site/src/components/page-patterns/grid-item.js
+++ b/packages/edit-site/src/components/page-patterns/grid-item.js
@@ -15,6 +15,8 @@ import {
 	__experimentalHeading as Heading,
 	__experimentalHStack as HStack,
 	__unstableCompositeItem as CompositeItem,
+	Tooltip,
+	Flex,
 } from '@wordpress/components';
 import { useInstanceId } from '@wordpress/compose';
 import { useDispatch } from '@wordpress/data';
@@ -26,6 +28,7 @@ import {
 	footer,
 	symbolFilled,
 	moreHorizontal,
+	lockSmall,
 } from '@wordpress/icons';
 import { store as noticesStore } from '@wordpress/notices';
 import { store as reusableBlocksStore } from '@wordpress/reusable-blocks';
@@ -141,8 +144,37 @@ export default function GridItem( { categoryId, composite, icon, item } ) {
 						spacing={ 3 }
 						className="edit-site-patterns__pattern-title"
 					>
-						{ icon && <Icon icon={ itemIcon } /> }
+						{ icon && (
+							<Icon
+								className="edit-site-library__pattern-icon"
+								icon={ itemIcon }
+							/>
+						) }
 						<Heading level={ 5 }>{ item.title }</Heading>
+						<Flex
+							as={ Heading }
+							level={ 5 }
+							gap={ 0 }
+							justify="left"
+						>
+							{ item.title }
+							{ item.type === PATTERNS && (
+								<Tooltip
+									position="top center"
+									text={ __(
+										'Theme patterns cannot be edited here'
+									) }
+								>
+									<span style={ { display: 'inline-flex' } }>
+										<Icon
+											style={ { fill: 'currentcolor' } }
+											icon={ lockSmall }
+											size={ 24 }
+										/>
+									</span>
+								</Tooltip>
+							) }
+						</Flex>
 					</HStack>
 					{ item.type === USER_PATTERNS && (
 						<DropdownMenu

--- a/packages/edit-site/src/components/page-patterns/grid-item.js
+++ b/packages/edit-site/src/components/page-patterns/grid-item.js
@@ -146,11 +146,10 @@ export default function GridItem( { categoryId, composite, icon, item } ) {
 					>
 						{ icon && (
 							<Icon
-								className="edit-site-library__pattern-icon"
+								className="edit-site-patterns__pattern-icon"
 								icon={ itemIcon }
 							/>
 						) }
-						<Heading level={ 5 }>{ item.title }</Heading>
 						<Flex
 							as={ Heading }
 							level={ 5 }
@@ -165,7 +164,7 @@ export default function GridItem( { categoryId, composite, icon, item } ) {
 										'Theme patterns cannot be edited here'
 									) }
 								>
-									<span style={ { display: 'inline-flex' } }>
+									<span className="edit-site-patterns__pattern-lock-icon">
 										<Icon
 											style={ { fill: 'currentcolor' } }
 											icon={ lockSmall }

--- a/packages/edit-site/src/components/page-patterns/style.scss
+++ b/packages/edit-site/src/components/page-patterns/style.scss
@@ -93,10 +93,14 @@
 .edit-site-patterns__pattern-title {
 	color: $gray-600;
 
-	.edit-site-library__pattern-icon {
+	.edit-site-patterns__pattern-icon {
 		border-radius: $grid-unit-05;
 		background: var(--wp-block-synced-color);
 		fill: $white;
+	}
+
+	.edit-site-patterns__pattern-lock-icon {
+		display: inline-flex;
 	}
 }
 

--- a/packages/edit-site/src/components/page-patterns/style.scss
+++ b/packages/edit-site/src/components/page-patterns/style.scss
@@ -93,7 +93,7 @@
 .edit-site-patterns__pattern-title {
 	color: $gray-600;
 
-	svg {
+	.edit-site-library__pattern-icon {
 		border-radius: $grid-unit-05;
 		background: var(--wp-block-synced-color);
 		fill: $white;

--- a/packages/edit-site/src/components/sidebar-navigation-screen-pattern/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-pattern/style.scss
@@ -23,3 +23,7 @@
 	height: 24px;
 	margin-right: $grid-unit-10;
 }
+
+.edit-site-sidebar-navigation-screen-pattern__lock-icon {
+	display: inline-flex;
+}

--- a/packages/edit-site/src/components/sidebar-navigation-screen-patterns/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-patterns/index.js
@@ -4,13 +4,16 @@
 import {
 	__experimentalItemGroup as ItemGroup,
 	__experimentalItem as Item,
+	Flex,
+	Icon,
+	Tooltip,
 } from '@wordpress/components';
 import { useViewportMatch } from '@wordpress/compose';
 import { useSelect } from '@wordpress/data';
 import { getTemplatePartIcon } from '@wordpress/editor';
 import { __ } from '@wordpress/i18n';
 import { getQueryArgs } from '@wordpress/url';
-import { file, starFilled } from '@wordpress/icons';
+import { file, starFilled, lockSmall } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -138,7 +141,38 @@ export default function SidebarNavigationScreenPatterns() {
 										<CategoryItem
 											key={ category.name }
 											count={ category.count }
-											label={ category.label }
+											label={
+												<Flex
+													justify="left"
+													align="center"
+													gap={ 0 }
+												>
+													{ category.label }
+													<Tooltip
+														position="top center"
+														text={ __(
+															'Theme patterns cannot be edited here'
+														) }
+													>
+														<span
+															style={ {
+																display:
+																	'inline-flex',
+															} }
+														>
+															<Icon
+																style={ {
+																	fill: 'currentcolor',
+																} }
+																icon={
+																	lockSmall
+																}
+																size={ 24 }
+															/>
+														</span>
+													</Tooltip>
+												</Flex>
+											}
 											icon={ file }
 											id={ category.name }
 											type="pattern"

--- a/packages/edit-site/src/components/sidebar-navigation-screen-patterns/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-patterns/index.js
@@ -154,12 +154,7 @@ export default function SidebarNavigationScreenPatterns() {
 															'Theme patterns cannot be edited here'
 														) }
 													>
-														<span
-															style={ {
-																display:
-																	'inline-flex',
-															} }
-														>
+														<span className="edit-site-sidebar-navigation-screen-pattern__lock-icon">
 															<Icon
 																style={ {
 																	fill: 'currentcolor',

--- a/packages/edit-site/src/components/sidebar-navigation-screen-patterns/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-patterns/index.js
@@ -151,7 +151,7 @@ export default function SidebarNavigationScreenPatterns() {
 													<Tooltip
 														position="top center"
 														text={ __(
-															'Theme patterns cannot be edited here'
+															'Theme patterns cannot be edited.'
 														) }
 													>
 														<span className="edit-site-sidebar-navigation-screen-pattern__lock-icon">


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What and why?
<!-- In a few words, what is the PR actually doing? -->
See https://github.com/WordPress/gutenberg/issues/51948#issuecomment-1609222337.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Just some flexbox thing and add the icon.

I noticed that some part of the library isn't accessible. It's not related to this PR though.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
1. Go to Site Editor -> Library
2. See that theme patterns now have lock icon
3. Click on either of the theme pattern categories, see that the pattern list also has lock icon
4. Hover over the lock icon will show the descriptive text

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
TBD

## Screenshots or screencast <!-- if applicable -->
![image](https://github.com/WordPress/gutenberg/assets/7753001/401fa238-2ab5-4c2b-b37d-ad3f2a72e8db)

![image](https://github.com/WordPress/gutenberg/assets/7753001/47f5e49c-3e9d-4bf1-828f-6565aee50778)
