### PR TITLE
Copy: "Detach pattern" instead of "Covert to regular block"

### DIFF
--- a/packages/block-editor/src/components/block-mobile-toolbar/block-actions-menu.native.js
+++ b/packages/block-editor/src/components/block-mobile-toolbar/block-actions-menu.native.js
@@ -213,16 +213,12 @@ const BlockActionsMenu = ( {
 			id: 'convertToRegularBlocksOption',
 			label:
 				innerBlockCount > 1
-					? __( 'Convert to regular blocks' )
-					: __( 'Convert to regular block' ),
+					? __( 'Detach patterns' )
+					: __( 'Detach pattern' ),
 			value: 'convertToRegularBlocksOption',
 			onSelect: () => {
-				const successNotice =
-					innerBlockCount > 1
-						? /* translators: %s: name of the reusable block */
-						  __( '%s converted to regular blocks' )
-						: /* translators: %s: name of the reusable block */
-						  __( '%s converted to regular block' );
+				/* translators: %s: name of the synced block */
+				const successNotice = __( '%s detached' );
 				createSuccessNotice(
 					sprintf(
 						successNotice,

--- a/packages/block-library/src/block/edit.js
+++ b/packages/block-library/src/block/edit.js
@@ -119,8 +119,8 @@ export default function ReusableBlockEdit( { attributes: { ref }, clientId } ) {
 							onClick={ () => convertBlockToStatic( clientId ) }
 							label={
 								innerBlockCount > 1
-									? __( 'Convert to regular blocks' )
-									: __( 'Convert to regular block' )
+									? __( 'Detach patterns' )
+									: __( 'Detach pattern' )
 							}
 							icon={ ungroup }
 							showTooltip

--- a/packages/block-library/src/block/edit.native.js
+++ b/packages/block-library/src/block/edit.native.js
@@ -132,12 +132,8 @@ export default function ReusableBlockEdit( {
 	}
 
 	const onConvertToRegularBlocks = useCallback( () => {
-		const successNotice =
-			innerBlockCount > 1
-				? /* translators: %s: name of the reusable block */
-				  __( '%s converted to regular blocks' )
-				: /* translators: %s: name of the reusable block */
-				  __( '%s converted to regular block' );
+		/* translators: %s: name of the synced block */
+		const successNotice = __( '%s detached' );
 		createSuccessNotice( sprintf( successNotice, title ) );
 
 		clearSelectedBlock();
@@ -182,17 +178,17 @@ export default function ReusableBlockEdit( {
 					<Text style={ [ infoTextStyle, infoDescriptionStyle ] }>
 						{ innerBlockCount > 1
 							? __(
-									'Alternatively, you can detach and edit these blocks separately by tapping “Convert to regular blocks”.'
+									'Alternatively, you can detach and edit these blocks separately by tapping “Detach patterns”.'
 							  )
 							: __(
-									'Alternatively, you can detach and edit this block separately by tapping “Convert to regular block”.'
+									'Alternatively, you can detach and edit this block separately by tapping “Detach pattern”.'
 							  ) }
 					</Text>
 					<TextControl
 						label={
 							innerBlockCount > 1
-								? __( 'Convert to regular blocks' )
-								: __( 'Convert to regular block' )
+								? __( 'Detach patterns' )
+								: __( 'Detach pattern' )
 						}
 						separatorType="topFullWidth"
 						onPress={ onConvertToRegularBlocks }

--- a/packages/e2e-tests/specs/editor/various/reusable-blocks.test.js
+++ b/packages/e2e-tests/specs/editor/various/reusable-blocks.test.js
@@ -113,7 +113,7 @@ describe( 'Reusable blocks', () => {
 		await insertReusableBlock( 'Surprised greeting block' );
 
 		// Convert block to a regular block.
-		await clickBlockToolbarButton( 'Convert to regular block' );
+		await clickBlockToolbarButton( 'Detach pattern' );
 
 		// Check that we have a paragraph block on the page.
 		const paragraphBlock = await canvas().$(
@@ -221,7 +221,7 @@ describe( 'Reusable blocks', () => {
 		await insertReusableBlock( 'Multi-selection reusable block' );
 
 		// Convert block to a regular block.
-		await clickBlockToolbarButton( 'Convert to regular blocks' );
+		await clickBlockToolbarButton( 'Detach patterns' );
 
 		// Check that we have two paragraph blocks on the page.
 		expect( await getEditedPostContent() ).toMatchSnapshot();
@@ -353,7 +353,7 @@ describe( 'Reusable blocks', () => {
 
 		// Convert back to regular blocks.
 		await clickBlockToolbarButton( 'Select Pattern' );
-		await clickBlockToolbarButton( 'Convert to regular block' );
+		await clickBlockToolbarButton( 'Detach pattern' );
 		await page.waitForXPath( selector, {
 			hidden: true,
 		} );

--- a/packages/reusable-blocks/src/components/reusable-blocks-menu-items/reusable-blocks-manage-button.js
+++ b/packages/reusable-blocks/src/components/reusable-blocks-menu-items/reusable-blocks-manage-button.js
@@ -58,8 +58,8 @@ function ReusableBlocksManageButton( { clientId } ) {
 			{ canRemove && (
 				<MenuItem onClick={ () => convertBlockToStatic( clientId ) }>
 					{ innerBlockCount > 1
-						? __( 'Convert to regular blocks' )
-						: __( 'Convert to regular block' ) }
+						? __( 'Detach patterns' )
+						: __( 'Detach pattern' ) }
 				</MenuItem>
 			) }
 		</BlockSettingsMenuControls>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Closes https://github.com/WordPress/gutenberg/issues/51940, making the idea of synced/detached patterns a bit more clearer. Part of the effort to signal reusable blocks as synced patterns. 

## How?
- String changes for the most part. 
- Simplified the successNotice to `__( '%s detached' )`, regardless of innerBlockCount (although the notice doesn't fire — _not related to this change_). 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a post or page.
2. Insert a synced pattern. 
3. Select the pattern.
4. Open block toolbar options. 
5. See "Detach pattern".

## Screenshots or screencast <!-- if applicable -->

| Before  | After |
| ------------- | ------------- |
|<img width="248" alt="CleanShot 2023-06-27 at 17 54 32" src="https://github.com/WordPress/gutenberg/assets/1813435/2b14aafe-1e4f-490b-adf3-c0bcfbe9bb1e">|<img width="247" alt="CleanShot 2023-06-27 at 17 52 55" src="https://github.com/WordPress/gutenberg/assets/1813435/98bec82c-28f6-498d-bf3f-3f16c7bb72c1">|


