### PR TITLE
Social links: updating class and style attributes

### DIFF
--- a/packages/block-library/src/social-link/index.php
+++ b/packages/block-library/src/social-link/index.php
@@ -47,8 +47,8 @@ function render_block_core_social_link( $attributes, $content, $block ) {
 	$icon               = block_core_social_link_get_icon( $service );
 	$wrapper_attributes = get_block_wrapper_attributes(
 		array(
-			'class' => 'wp-social-link wp-social-link-' . $service . block_core_social_link_get_color_classes( $block->context ),
-			'style' => block_core_social_link_get_color_styles( $block->context ),
+			'class' => esc_attr( 'wp-social-link wp-social-link-' . $service . block_core_social_link_get_color_classes( $block->context ) ),
+			'style' => esc_attr( block_core_social_link_get_color_styles( $block->context ) ),
 		)
 	);
 


### PR DESCRIPTION

## What?
Escape social link class and style attributes.

## Why?
Escape social link class and style attributes.

## How?
Escape social link class and style attributes.

## Testing Instructions
Tests should pass
Social link block should render correctly on the frontend, with all classes/styles 

## Screenshots

### Editor


<img width="679" alt="Screenshot 2023-06-28 at 11 03 23 am" src="https://github.com/WordPress/gutenberg/assets/6458278/cdf67668-2867-42b4-ae33-399a36f1cf04">

### Frontend
<img width="649" alt="Screenshot 2023-06-28 at 11 03 17 am" src="https://github.com/WordPress/gutenberg/assets/6458278/defe877e-6689-4ca4-b16a-1d97175a1122">

