### PR TITLE
Navigation fallback: use `found_posts` to get the count of navigation posts found

### DIFF
--- a/lib/compat/wordpress-6.3/class-gutenberg-navigation-fallback.php
+++ b/lib/compat/wordpress-6.3/class-gutenberg-navigation-fallback.php
@@ -66,7 +66,7 @@ class Gutenberg_Navigation_Fallback {
 
 		$navigation_post = new WP_Query( $parsed_args );
 
-		if ( count( $navigation_post->posts ) > 0 ) {
+		if ( $navigation_post->found_posts > 0 ) {
 			return $navigation_post->posts[0];
 		}
 

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -1049,7 +1049,7 @@ function block_core_navigation_get_most_recently_published_navigation() {
 	);
 
 	$navigation_post = new WP_Query( $parsed_args );
-	if ( count( $navigation_post->posts ) > 0 ) {
+	if ( $navigation_post->found_posts > 0 ) {
 		return $navigation_post->posts[0];
 	}
 


### PR DESCRIPTION


## What?
Following up on feedback from https://github.com/WordPress/wordpress-develop/pull/4713#pullrequestreview-1499992051

Let's use the `found_posts` [property](https://github.com/WordPress/wordpress-develop/blob/c226fa18f0877b86dc33947a92d304d67d0fc406/src/wp-includes/class-wp-query.php#L3571). 

## Why?
It does all the work for us (and can be filtered if required).

## How?
Swap `count()` for `$navigation_post->found_posts`

## Testing Instructions

Tests should pass and default navigation (if one has been created) should appear on the site editor sidebar under Navigation:

<img width="478" alt="Screenshot 2023-06-28 at 11 20 00 am" src="https://github.com/WordPress/gutenberg/assets/6458278/984050a4-c19b-4dcb-9aec-75edbe320dff">



