### PR TITLE
Patterns: update the title of Pattern block in the block inspector card 

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -38,7 +38,7 @@ Add a user’s avatar. ([Source](https://github.com/WordPress/gutenberg/tree/tru
 
 ## Pattern
 
-Create and save content to reuse across your site. Update the block, and the changes apply everywhere it’s used. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/block))
+Create and save content to reuse across your site. Update the pattern, and the changes apply everywhere it’s used. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/block))
 
 -	**Name:** core/block
 -	**Category:** reusable

--- a/packages/block-editor/src/components/block-card/index.js
+++ b/packages/block-editor/src/components/block-card/index.js
@@ -43,7 +43,8 @@ function BlockCard( { title, icon, description, blockType, className } ) {
 	}, [] );
 
 	const { selectBlock } = useDispatch( blockEditorStore );
-	// Only synced patterns are selectable in the editor so change the title to show the sync status.
+	// As with Navigation block it's not ideal having Pattern block specific code here, but only synced patterns are selectable in the editor
+	// currently and finding the sync status higher up involves a call to the core-data store which isn't allowed in the block editor.
 	const blockTitle =
 		title === __( 'Pattern' ) ? __( 'Synced Pattern' ) : title;
 	return (

--- a/packages/block-editor/src/components/block-card/index.js
+++ b/packages/block-editor/src/components/block-card/index.js
@@ -43,7 +43,9 @@ function BlockCard( { title, icon, description, blockType, className } ) {
 	}, [] );
 
 	const { selectBlock } = useDispatch( blockEditorStore );
-
+	// Only synced patterns are selectable in the editor so change the title to show the sync status.
+	const blockTitle =
+		title === __( 'Pattern' ) ? __( 'Synced Pattern' ) : title;
 	return (
 		<div className={ classnames( 'block-editor-block-card', className ) }>
 			{ parentNavBlockClientId && ( // This is only used by the Navigation block for now. It's not ideal having Navigation block specific code here.
@@ -61,7 +63,9 @@ function BlockCard( { title, icon, description, blockType, className } ) {
 			) }
 			<BlockIcon icon={ icon } showColors />
 			<div className="block-editor-block-card__content">
-				<h2 className="block-editor-block-card__title">{ title }</h2>
+				<h2 className="block-editor-block-card__title">
+					{ blockTitle }
+				</h2>
 				<span className="block-editor-block-card__description">
 					{ description }
 				</span>

--- a/packages/block-editor/src/components/block-card/index.js
+++ b/packages/block-editor/src/components/block-card/index.js
@@ -43,10 +43,7 @@ function BlockCard( { title, icon, description, blockType, className } ) {
 	}, [] );
 
 	const { selectBlock } = useDispatch( blockEditorStore );
-	// As with Navigation block it's not ideal having Pattern block specific code here, but only synced patterns are selectable in the editor
-	// currently and finding the sync status higher up involves a call to the core-data store which isn't allowed in the block editor.
-	const blockTitle =
-		title === __( 'Pattern' ) ? __( 'Synced Pattern' ) : title;
+
 	return (
 		<div className={ classnames( 'block-editor-block-card', className ) }>
 			{ parentNavBlockClientId && ( // This is only used by the Navigation block for now. It's not ideal having Navigation block specific code here.
@@ -64,9 +61,7 @@ function BlockCard( { title, icon, description, blockType, className } ) {
 			) }
 			<BlockIcon icon={ icon } showColors />
 			<div className="block-editor-block-card__content">
-				<h2 className="block-editor-block-card__title">
-					{ blockTitle }
-				</h2>
+				<h2 className="block-editor-block-card__title">{ title }</h2>
 				<span className="block-editor-block-card__description">
 					{ description }
 				</span>

--- a/packages/block-editor/src/components/use-block-display-information/index.js
+++ b/packages/block-editor/src/components/use-block-display-information/index.js
@@ -67,8 +67,11 @@ export default function useBlockDisplayInformation( clientId ) {
 	return useSelect(
 		( select ) => {
 			if ( ! clientId ) return null;
-			const { getBlockName, getBlockAttributes } =
-				select( blockEditorStore );
+			const {
+				getBlockName,
+				getBlockAttributes,
+				__experimentalGetReusableBlockTitle,
+			} = select( blockEditorStore );
 			const { getBlockType, getActiveBlockVariation } =
 				select( blocksStore );
 			const blockName = getBlockName( clientId );
@@ -76,12 +79,14 @@ export default function useBlockDisplayInformation( clientId ) {
 			if ( ! blockType ) return null;
 			const attributes = getBlockAttributes( clientId );
 			const match = getActiveBlockVariation( blockName, attributes );
-			const isSynced =
-				isReusableBlock( blockType ) || isTemplatePart( blockType );
+			const isReusable = isReusableBlock( blockType );
+			const isSynced = isReusable || isTemplatePart( blockType );
 			const positionLabel = getPositionTypeLabel( attributes );
 			const blockTypeInfo = {
 				isSynced,
-				title: blockType.title,
+				title: isReusable
+					? __experimentalGetReusableBlockTitle( attributes.ref )
+					: blockType.title,
 				icon: blockType.icon,
 				description: blockType.description,
 				anchor: attributes?.anchor,

--- a/packages/block-editor/src/components/use-block-display-information/index.js
+++ b/packages/block-editor/src/components/use-block-display-information/index.js
@@ -77,15 +77,13 @@ export default function useBlockDisplayInformation( clientId ) {
 			const blockName = getBlockName( clientId );
 			const blockType = getBlockType( blockName );
 			if ( ! blockType ) return null;
-			let title = blockType.title;
 			const attributes = getBlockAttributes( clientId );
 			const match = getActiveBlockVariation( blockName, attributes );
 			const isReusable = isReusableBlock( blockType );
-			if ( isReusable ) {
-				title =
-					__experimentalGetReusableBlockTitle( attributes.ref ) ||
-					blockType.title;
-			}
+			const resusableTitle = isReusableBlock( blockType )
+				? __experimentalGetReusableBlockTitle( attributes.ref )
+				: undefined;
+			const title = resusableTitle || blockType.title;
 			const isSynced = isReusable || isTemplatePart( blockType );
 			const positionLabel = getPositionTypeLabel( attributes );
 			const blockTypeInfo = {

--- a/packages/block-editor/src/components/use-block-display-information/index.js
+++ b/packages/block-editor/src/components/use-block-display-information/index.js
@@ -80,7 +80,7 @@ export default function useBlockDisplayInformation( clientId ) {
 			const attributes = getBlockAttributes( clientId );
 			const match = getActiveBlockVariation( blockName, attributes );
 			const isReusable = isReusableBlock( blockType );
-			const resusableTitle = isReusableBlock( blockType )
+			const resusableTitle = isReusable
 				? __experimentalGetReusableBlockTitle( attributes.ref )
 				: undefined;
 			const title = resusableTitle || blockType.title;

--- a/packages/block-editor/src/components/use-block-display-information/index.js
+++ b/packages/block-editor/src/components/use-block-display-information/index.js
@@ -82,13 +82,15 @@ export default function useBlockDisplayInformation( clientId ) {
 			const match = getActiveBlockVariation( blockName, attributes );
 			const isReusable = isReusableBlock( blockType );
 			if ( isReusable ) {
-				title = __experimentalGetReusableBlockTitle( attributes.ref );
+				title =
+					__experimentalGetReusableBlockTitle( attributes.ref ) ||
+					blockType.title;
 			}
 			const isSynced = isReusable || isTemplatePart( blockType );
 			const positionLabel = getPositionTypeLabel( attributes );
 			const blockTypeInfo = {
 				isSynced,
-				title: title ? title : blockType.title,
+				title,
 				icon: blockType.icon,
 				description: blockType.description,
 				anchor: attributes?.anchor,

--- a/packages/block-editor/src/components/use-block-display-information/index.js
+++ b/packages/block-editor/src/components/use-block-display-information/index.js
@@ -77,16 +77,18 @@ export default function useBlockDisplayInformation( clientId ) {
 			const blockName = getBlockName( clientId );
 			const blockType = getBlockType( blockName );
 			if ( ! blockType ) return null;
+			let title = blockType.title;
 			const attributes = getBlockAttributes( clientId );
 			const match = getActiveBlockVariation( blockName, attributes );
 			const isReusable = isReusableBlock( blockType );
+			if ( isReusable ) {
+				title = __experimentalGetReusableBlockTitle( attributes.ref );
+			}
 			const isSynced = isReusable || isTemplatePart( blockType );
 			const positionLabel = getPositionTypeLabel( attributes );
 			const blockTypeInfo = {
 				isSynced,
-				title: isReusable
-					? __experimentalGetReusableBlockTitle( attributes.ref )
-					: blockType.title,
+				title: title ? title : blockType.title,
 				icon: blockType.icon,
 				description: blockType.description,
 				anchor: attributes?.anchor,

--- a/packages/block-library/src/block/block.json
+++ b/packages/block-library/src/block/block.json
@@ -4,7 +4,7 @@
 	"name": "core/block",
 	"title": "Pattern",
 	"category": "reusable",
-	"description": "Create and save content to reuse across your site. Update the block, and the changes apply everywhere it’s used.",
+	"description": "Create and save content to reuse across your site. Update the pattern, and the changes apply everywhere it’s used.",
 	"textdomain": "default",
 	"attributes": {
 		"ref": {

--- a/packages/e2e-tests/specs/editor/various/reusable-blocks.test.js
+++ b/packages/e2e-tests/specs/editor/various/reusable-blocks.test.js
@@ -352,7 +352,7 @@ describe( 'Reusable blocks', () => {
 		expect( reusableBlockWithParagraph ).toBeTruthy();
 
 		// Convert back to regular blocks.
-		await clickBlockToolbarButton( 'Select Pattern' );
+		await clickBlockToolbarButton( 'Select Edited block' );
 		await clickBlockToolbarButton( 'Detach pattern' );
 		await page.waitForXPath( selector, {
 			hidden: true,


### PR DESCRIPTION
## What?
Updates the title of Pattern block in the block inspector card to show the block title instead of generic `Patterns` title to match handling of template parts.

## Why?
Currently only synced patterns can be selected in the editor so indicates to the user the type of pattern they are currently viewing.
Fixes: #51922

## How?
Detects a block of type resuable and uses the entity title instead of title from block settings.

## Testing Instructions
- Add a synced pattern
- Insert the pattern in the editor and check that the title in the inspector block card is the title given to the block, and that other block types still display the standard block title from block settings.

## Screenshots or screencast <!-- if applicable -->
<img width="294" alt="Screenshot 2023-07-10 at 4 16 49 PM" src="https://github.com/WordPress/gutenberg/assets/3629020/fb91b92b-5300-432c-a0d1-8fe5fd800d13">

