### PR TITLE
Patterns: stop endless snackbars appearing

### DIFF
--- a/packages/e2e-test-utils/src/create-reusable-block.js
+++ b/packages/e2e-test-utils/src/create-reusable-block.js
@@ -38,7 +38,7 @@ export const createReusableBlock = async ( content, title ) => {
 
 	// Wait for creation to finish
 	await page.waitForXPath(
-		'//*[contains(@class, "components-snackbar")]/*[text()="Synced Pattern created."]'
+		'//*[contains(@class, "components-snackbar")]/*[contains(text()="Pattern created:")]'
 	);
 
 	// Check that we have a reusable block on the page

--- a/packages/e2e-test-utils/src/create-reusable-block.js
+++ b/packages/e2e-test-utils/src/create-reusable-block.js
@@ -38,7 +38,7 @@ export const createReusableBlock = async ( content, title ) => {
 
 	// Wait for creation to finish
 	await page.waitForXPath(
-		'//*[contains(@class, "components-snackbar")]/*[contains(text()="Pattern created:")]'
+		'//*[contains(@class, "components-snackbar")]/*[contains(text(),"Pattern created:")]'
 	);
 
 	// Check that we have a reusable block on the page

--- a/packages/e2e-tests/specs/editor/various/reusable-blocks.test.js
+++ b/packages/e2e-tests/specs/editor/various/reusable-blocks.test.js
@@ -212,7 +212,7 @@ describe( 'Reusable blocks', () => {
 
 		// Wait for creation to finish.
 		await page.waitForXPath(
-			'//*[contains(@class, "components-snackbar")]/*[contains(text()="Pattern created:")]'
+			'//*[contains(@class, "components-snackbar")]/*[contains(text(),"Pattern created:")]'
 		);
 
 		await clearAllBlocks();

--- a/packages/e2e-tests/specs/editor/various/reusable-blocks.test.js
+++ b/packages/e2e-tests/specs/editor/various/reusable-blocks.test.js
@@ -212,7 +212,7 @@ describe( 'Reusable blocks', () => {
 
 		// Wait for creation to finish.
 		await page.waitForXPath(
-			'//*[contains(@class, "components-snackbar")]/*[text()="Synced Pattern created."]'
+			'//*[contains(@class, "components-snackbar")]/*[contains(text()="Pattern created:")]'
 		);
 
 		await clearAllBlocks();

--- a/packages/reusable-blocks/src/components/reusable-blocks-menu-items/reusable-block-convert-button.js
+++ b/packages/reusable-blocks/src/components/reusable-blocks-menu-items/reusable-block-convert-button.js
@@ -19,7 +19,7 @@ import {
 } from '@wordpress/components';
 import { symbol } from '@wordpress/icons';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { store as coreStore } from '@wordpress/core-data';
 
@@ -98,15 +98,25 @@ export default function ReusableBlockConvertButton( {
 				);
 				createSuccessNotice(
 					syncType === 'fully'
-						? __( 'Synced Pattern created.' )
-						: __( 'Unsynced Pattern created.' ),
+						? sprintf(
+								// translators: %s: the name the user has given to the pattern.
+								__( 'Synced Pattern created: %s' ),
+								reusableBlockTitle
+						  )
+						: sprintf(
+								// translators: %s: the name the user has given to the pattern.
+								__( 'Unsynced Pattern created: %s' ),
+								reusableBlockTitle
+						  ),
 					{
 						type: 'snackbar',
+						id: 'convert-to-reusable-block-success',
 					}
 				);
 			} catch ( error ) {
 				createErrorNotice( error.message, {
 					type: 'snackbar',
+					id: 'convert-to-reusable-block-error',
 				} );
 			}
 		},


### PR DESCRIPTION
## What?
Makes sure only one pattern creation success snackbar appears at time.

## Why?
Multiple snackbars currently pile up and obscure the interface

## How?
Sets a notice id.

## Testing Instructions
In the editor add multiple patterns one after the other and make sure only one snackbar appears at a time.

## Screenshots or screencast <!-- if applicable -->
Before:

https://github.com/WordPress/gutenberg/assets/3629020/40466827-0cbe-42ec-93bb-eca3cafce122

After:

https://github.com/WordPress/gutenberg/assets/3629020/0595eec2-c30b-4516-b199-ec8ee0f13c6b


