### PR TITLE
Performance tests: configure as a production environment

### DIFF
--- a/bin/plugin/commands/performance.js
+++ b/bin/plugin/commands/performance.js
@@ -330,6 +330,10 @@ async function runPerformanceTests( branches, options ) {
 			path.join( environmentDirectory, '.wp-env.json' ),
 			JSON.stringify(
 				{
+					config: {
+						WP_DEBUG: false,
+						SCRIPT_DEBUG: false,
+					},
 					core: 'WordPress/WordPress',
 					plugins: [ path.join( environmentDirectory, 'plugin' ) ],
 					themes: [


### PR DESCRIPTION
## What?

Sets up the `WP_DEBUG` and `SCRIPTS_DEBUG` to `false`, so the WordPress instance resembles a production environment.

## Why?

Certain aspects of performance are different when running when debug enabled: some caches may be disabled, assets are minified, etc. We should aim to measure performance as close as possible to a production environment.

This is the difference in the performance CI job in [this branch](https://github.com/WordPress/gutenberg/actions/runs/5398164956/jobs/9803650901?pr=52016) vs [one of the last to succeed in `trunk`](https://github.com/WordPress/gutenberg/actions/runs/5398078509/jobs/9803461929) (can also be compared with current codevitals metrics):

| | This branch | Trunk |
| --- | --- | --- |
| Front-end | ![image](https://github.com/WordPress/gutenberg/assets/583546/82e170c2-5d77-4bc9-a965-022b4614b949) | ![image](https://github.com/WordPress/gutenberg/assets/583546/2c09d10a-8373-45af-acfe-ba7695043905) |
| Post editor | ![image](https://github.com/WordPress/gutenberg/assets/583546/f5426eba-bf94-44df-bc1f-213cf071be9d) | ![image](https://github.com/WordPress/gutenberg/assets/583546/a14a8259-7f0a-4686-94ab-1a2ba0d395bb) |
| Site editor | ![image](https://github.com/WordPress/gutenberg/assets/583546/1189c6eb-ff9c-48e1-b570-920f1bb0d464) | ![image](https://github.com/WordPress/gutenberg/assets/583546/c176a91f-6a6b-4095-9132-278e3ede9895) |

## How?

Sets the `WP_DEBUG` and `SCRIPTS_DEBUG` global variables to `false`.

## Testing Instructions

See the performance results.

