### PR TITLE
Social links: reverts updating class and style attributes

### DIFF
--- a/packages/block-library/src/social-link/index.php
+++ b/packages/block-library/src/social-link/index.php
@@ -47,8 +47,8 @@ function render_block_core_social_link( $attributes, $content, $block ) {
 	$icon               = block_core_social_link_get_icon( $service );
 	$wrapper_attributes = get_block_wrapper_attributes(
 		array(
-			'class' => esc_attr( 'wp-social-link wp-social-link-' . $service . block_core_social_link_get_color_classes( $block->context ) ),
-			'style' => esc_attr( block_core_social_link_get_color_styles( $block->context ) ),
+			'class' => 'wp-social-link wp-social-link-' . $service . block_core_social_link_get_color_classes( $block->context ),
+			'style' => block_core_social_link_get_color_styles( $block->context ),
 		)
 	);
 


### PR DESCRIPTION
## What
Reverts WordPress/gutenberg#51997

## Why

As reported in https://github.com/WordPress/gutenberg/pull/51997#issuecomment-1610895289, `get_block_wrapper_attributes` already uses `esc_attr` on values passed to it.

Props to @swissspidy for catching it. 

See: https://github.com/WordPress/wordpress-develop/blob/trunk/src/wp-includes/class-wp-block-supports.php#L175

## Testing instructions

Tests should pass
Social link block should render correctly on the frontend, with all classes/styles





