### PR TITLE
Fix missing snackbars in Library

### DIFF
--- a/packages/edit-site/src/components/page/index.js
+++ b/packages/edit-site/src/components/page/index.js
@@ -7,6 +7,7 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { NavigableRegion } from '@wordpress/interface';
+import { EditorSnackbars } from '@wordpress/editor';
 
 /**
  * Internal dependencies
@@ -32,7 +33,10 @@ export default function Page( {
 					actions={ actions }
 				/>
 			) }
-			<div className="edit-site-page-content">{ children }</div>
+			<div className="edit-site-page-content">
+				{ children }
+				<EditorSnackbars />
+			</div>
 		</NavigableRegion>
 	);
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
A quick fix to https://github.com/WordPress/gutenberg/issues/52003.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
See https://github.com/WordPress/gutenberg/issues/52003.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
It seems like the bug was indirectly introduced in #50766. When we change to `<Page>`, we are not using `<InterfaceLayout>` anymore, which is where we usually handle the snackbars. I'm not sure if we should bring it back though. It seems like it also handles something like region shortcuts which might be good to double-check. This PR is a quick fix to bring back the snackbars to the Library (and the list page).

Note that since the snackbars here and the snackbars in the editor are two different instances, so if we go back to the editor before the snackbar dismisses, it will show again and (maybe) restart the counter. This is an unfortunate side effect but I don't have any quick solution for that now.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
1. Go to Site Editor -> Library
2. Create a pattern in the sidebar if you don't have one.
3. Go to "Custom patterns"
4. Find the pattern you just created and delete it
5. You should see the snackbar pops up

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/7753001/a2c8166c-7b43-4a46-9ea8-3fc2fc9b589d

