### PR TITLE
Footnotes: register meta field for pages

### DIFF
--- a/packages/block-library/src/footnotes/index.php
+++ b/packages/block-library/src/footnotes/index.php
@@ -59,15 +59,17 @@ function render_block_core_footnotes( $attributes, $content, $block ) {
  * Registers the `core/footnotes` block on the server.
  */
 function register_block_core_footnotes() {
-	register_post_meta(
-		'post',
-		'footnotes',
-		array(
-			'show_in_rest' => true,
-			'single'       => true,
-			'type'         => 'string',
-		)
-	);
+	foreach ( array( 'post', 'page' ) as $post_type ) {
+		register_post_meta(
+			$post_type,
+			'footnotes',
+			array(
+				'show_in_rest' => true,
+				'single'       => true,
+				'type'         => 'string',
+			)
+		);
+	}
 	register_block_type_from_metadata(
 		__DIR__ . '/footnotes',
 		array(


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

In #51201, I forgot to register the meta field for pages.

This remind me that we should also:

* Find a way to not register the format when there's no meta field.
* Find a way to deregister the format when the block is deregistered.
* Ideally all these things should be connected: if one of these three (meta, block, or format) disappears, the others should also disappear.

Maybe best to look into that separately and merge this so footnotes don't look broken in pages.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
