### PR TITLE
Fix stepper styling in Home template sidebar

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-screen/style.scss
@@ -110,7 +110,7 @@
 		background: $gray-800;
 
 		.components-button {
-			color: $gray-200;
+			color: $gray-200 !important;
 		}
 	}
 	.components-input-control__input {


### PR DESCRIPTION
Follow up to https://github.com/WordPress/gutenberg/pull/51972. I remove the `!important` declarations before merging, but it looks like my build wasn't running and I didn't notice that it is required for these buttons.

## What?
Adds `!important` declaration to button color in the stepper variant of the number control.

## Why?
To fix contrast and general appearance.

## Testing Instructions
* Open Home (or Index if Home doesn't exist) template 
* Observe correctly colored +/- button

**Before**
<img width="315" alt="Screenshot 2023-06-28 at 10 31 31" src="https://github.com/WordPress/gutenberg/assets/846565/ca5c9a4a-338a-4405-9359-cc9dd8aa05bf">

**After**
<img width="347" alt="Screenshot 2023-06-28 at 10 32 47" src="https://github.com/WordPress/gutenberg/assets/846565/f59fd686-7512-4583-b6a5-f9cfba072c45">

