### PR TITLE
Editor initrial appender: Zero out margins in constrained layouts.

### DIFF
--- a/packages/block-editor/src/components/default-block-appender/content.scss
+++ b/packages/block-editor/src/components/default-block-appender/content.scss
@@ -26,6 +26,17 @@
 		opacity: 0.62;
 	}
 
+	// In "constrained" layout containers, the first and last paragraphs have their margins zeroed out.
+	// In the case of this appender, it needs to apply those same rules to avoid layout shifts.
+	// Such shifts happen when the bottom margin of the Title block has been set to less than the default 1em margin of paragraphs.
+	:where(body .is-layout-constrained) & {
+		> :first-child:first-child {
+			margin-block-start: 0;
+		}
+
+		// Since this particular appender will only ever appear on an entirely empty document, we don't account for last-child.
+	}
+
 	// Dropzone.
 	.components-drop-zone__content-icon {
 		display: none;


### PR DESCRIPTION
## What?

If in Global Styles → Blocks → Title you set the bottom margin to zero, then there will be a layout shift when you click the initial paragraph appender in the post list.

![before](https://github.com/WordPress/gutenberg/assets/1204802/a4ba3018-e558-4e3e-ac7e-405d1d6a0fab)

This layout shift happens because the zeroed out bottom margin on the post title reveals that the _default appender_ (a `button` that exists on a completely empty document before even an empty paragraph is inserted) has a `p`/paragraph inside which has a browser-default 1em top and bottom margin applied, but the actual empty paragraph has those same margins zeroed out.

That zeroed out paragraph margin comes from this ruleset:

```
.editor-styles-wrapper :where(body .is-layout-constrained) > :first-child:first-child {
    margin-block-start: 0;
}
```

Essentially that exists to eliminate the top margin of the first paragraph in a "constrained" container.

So what happens is that when the post/page title has a default margin that is larger than the browser-default 1em for a paragraph, you won't see a layout shift as the title holds it properly in place. But when that same margin is zeroed out, the layout shift _will_ appear.

This PR fixes that layout shift:

![after](https://github.com/WordPress/gutenberg/assets/1204802/9e76ee00-6379-4471-9701-6670d51f0177)

## How?

The layout shift is fixed by applying the same margin rule to the default appender as is applied to the first paragraph of the post.

## Testing Instructions

* In global styles, set the bottom margin of the Title block to zero.
* Go to the post or page editor and click "Add new"
* Click the "Type / to choose a block" prompt, and there should be no layout shift.
