### PR TITLE
Fix: Pattern focus mode DocumentActions should use the pattern icon

### DIFF
--- a/packages/edit-site/src/components/header-edit-mode/document-actions/index.js
+++ b/packages/edit-site/src/components/header-edit-mode/document-actions/index.js
@@ -20,6 +20,7 @@ import {
 	chevronLeftSmall as chevronLeftSmallIcon,
 	page as pageIcon,
 	navigation as navigationIcon,
+	symbol,
 } from '@wordpress/icons';
 import { displayShortcut } from '@wordpress/keycodes';
 import { useState, useEffect, useRef } from '@wordpress/element';
@@ -118,10 +119,17 @@ function TemplateDocumentActions( { className, onBack } ) {
 
 	const entityLabel = getEntityLabel( record.type );
 
+	let typeIcon = icon;
+	if ( record.type === 'wp_navigation' ) {
+		typeIcon = navigationIcon;
+	} else if ( record.type === 'wp_block' ) {
+		typeIcon = symbol;
+	}
+
 	return (
 		<BaseDocumentActions
 			className={ className }
-			icon={ record.type === 'wp_navigation' ? navigationIcon : icon }
+			icon={ typeIcon }
 			onBack={ onBack }
 		>
 			<VisuallyHidden as="span">


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Adds a condition for displaying the symbol icon if a pattern is being edited in focus mode.
With focus mode I mean when you navigate from Appearance > Editor > Library > Custom Patterns and select a synced pattern to edit in isolation.

Closes https://github.com/WordPress/gutenberg/issues/51992.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
It was showing the template icon.

## Testing Instructions
Navigate from Appearance > Editor > Library > Custom Patterns and select a synced pattern to edit in isolation.
Confirm that the icon in the top center part of the screen  (the document actions) is the correct pattern icon.

## Screenshots or screencast <!-- if applicable -->
After:
<img width="522" alt="The document action area shows the pattern icon next to the pattern name.," src="https://github.com/WordPress/gutenberg/assets/7422055/7d9ebc7b-9b1c-4fbb-ab96-64b0e6b1b384">


