### PR TITLE
added README for the "caption" component

### DIFF
--- a/packages/block-editor/src/components/caption/README.md
+++ b/packages/block-editor/src/components/caption/README.md
@@ -1,25 +1,23 @@
 ## Caption
 
-The `Caption` component renders the [caption part](https://wordpress.org/documentation/article/gallery-block/#caption) of some blocks (image, gallery...)
+The `Caption` component renders the [caption part](https://wordpress.org/documentation/article/gallery-block/#caption) of some blocks (image, gallery...).
 
-This component encapsulates the "caption" behaviour and styles over a `<RichText>` so it can be used in other components such as the `BlockCaption` component 
-
+This component encapsulates the "caption" behaviour and styles over a `<RichText>` so it can be used in other components such as the `BlockCaption` component.
 
 ## Table of contents
 
 1. [Development guidelines](#development-guidelines)
+
 2. [Related components](#related-components)
 
 ## Development guidelines
 
 ### Usage
 
-Renders a Caption area 
+Renders a Caption area:
 
 ```jsx
-
 import { Caption } from '@wordpress/block-editor';
-
 const BlockCaption = ( {
 	onBlur,
 	onChange,
@@ -41,13 +39,12 @@ const BlockCaption = ( {
 		/>
 	</View>
 );
-
 ```
 
 ### Props
 
-The properties `isSelected`, `onBlur`, `onChange`, `onFocus`, `shouldDisplay`, `value`, `insertBlocksAfter` of this component are passed directly to their related props of its inner `<RichText>` component ([see detailed info about component's props](https://github.com/WordPress/gutenberg/blob/HEAD/packages/block-editor/src/components/rich-text/README.md))
+The properties `isSelected`, `onBlur`, `onChange`, `onFocus`, `shouldDisplay`, `value`, `insertBlocksAfter` of this component are passed directly to their related props of its inner `<RichText>` component ([see detailed info about the RichText component's props](https://github.com/WordPress/gutenberg/blob/HEAD/packages/block-editor/src/components/rich-text/README.md)).
 
 ## Related components
 
-Caption components is mostly used by the [`BlockCaption`](https://github.com/WordPress/gutenberg/blob/HEAD/packages/block-editor/src/components/block-caption) component 
+Caption components is mostly used by the [`BlockCaption`](https://github.com/WordPress/gutenberg/blob/HEAD/packages/block-editor/src/components/block-caption) component.

--- a/packages/block-editor/src/components/caption/README.md
+++ b/packages/block-editor/src/components/caption/README.md
@@ -1,0 +1,53 @@
+## Caption
+
+The `Caption` component renders the [caption part](https://wordpress.org/documentation/article/gallery-block/#caption) of some blocks (image, gallery...)
+
+This component encapsulates the "caption" behaviour and styles over a `<RichText>` so it can be used in other components such as the `BlockCaption` component 
+
+
+## Table of contents
+
+1. [Development guidelines](#development-guidelines)
+2. [Related components](#related-components)
+
+## Development guidelines
+
+### Usage
+
+Renders a Caption area 
+
+```jsx
+
+import { Caption } from '@wordpress/block-editor';
+
+const BlockCaption = ( {
+	onBlur,
+	onChange,
+	onFocus,
+	isSelected,
+	shouldDisplay,
+	text,
+	insertBlocksAfter,
+} ) => (
+	<View >
+		<Caption
+			isSelected={ isSelected }
+			onBlur={ onBlur }
+			onChange={ onChange }
+			onFocus={ onFocus }
+			shouldDisplay={ shouldDisplay }
+			value={ text }
+			insertBlocksAfter={ insertBlocksAfter }
+		/>
+	</View>
+);
+
+```
+
+### Props
+
+The properties `isSelected`, `onBlur`, `onChange`, `onFocus`, `shouldDisplay`, `value`, `insertBlocksAfter` of this component are passed directly to their related props of its inner `<RichText>` component ([see detailed info about component's props](https://github.com/WordPress/gutenberg/blob/HEAD/packages/block-editor/src/components/rich-text/README.md))
+
+## Related components
+
+Caption components is mostly used by the [`BlockCaption`](https://github.com/WordPress/gutenberg/blob/HEAD/packages/block-editor/src/components/block-caption) component 

--- a/packages/block-editor/src/components/caption/README.md
+++ b/packages/block-editor/src/components/caption/README.md
@@ -7,7 +7,6 @@ This component encapsulates the "caption" behaviour and styles over a `<RichText
 ## Table of contents
 
 1. [Development guidelines](#development-guidelines)
-
 2. [Related components](#related-components)
 
 ## Development guidelines


### PR DESCRIPTION
## What?
As part of https://github.com/WordPress/gutenberg/issues/22891 this PR adds a README.md for this component with some guidance to use.

## Why?
Because each component need to have a reference for WordPress developers 

## How?
By creating a README w/ at least some basic guidance about how to use it
