### PR TITLE
hasResolvingSelectors: exclude from result of resolveSelect

### DIFF
--- a/packages/data/src/redux-store/index.js
+++ b/packages/data/src/redux-store/index.js
@@ -402,6 +402,7 @@ function mapResolveSelectors( selectors, store ) {
 		getCachedResolvers,
 		getResolutionState,
 		getResolutionError,
+		hasResolvingSelectors,
 		...storeSelectors
 	} = selectors;
 

--- a/packages/data/src/redux-store/test/index.js
+++ b/packages/data/src/redux-store/test/index.js
@@ -281,7 +281,6 @@ describe( 'resolveSelect', () => {
 
 	it( 'returns only store native selectors and excludes all meta ones', () => {
 		expect( Object.keys( registry.resolveSelect( 'store' ) ) ).toEqual( [
-			'hasResolvingSelectors',
 			'getItems',
 			'getItemsNoResolver',
 		] );


### PR DESCRIPTION
Fixes a bug introduced in #50222 when adding the new `hasResolvingSelectors` meta-selector.

Meta-selectors are supposed to be excluded from the result of `resolveSelect`. The `mapResolveSelectors` function removes them by destructuring.

Noticed this when working on #52036.