### PR TITLE
Try/use focus outside iframe

### DIFF
--- a/packages/components/src/modal/stories/index.tsx
+++ b/packages/components/src/modal/stories/index.tsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { createPortal } from 'react-dom';
 import type { ComponentStory, ComponentMeta } from '@storybook/react';
 
 /**
@@ -42,29 +41,6 @@ const meta: ComponentMeta< typeof Modal > = {
 	},
 };
 export default meta;
-
-const IFrame: React.FC< {
-	title?: string;
-	width: number;
-	height: number;
-	children: React.ReactNode;
-} > = ( { children, ...props } ) => {
-	const [ contentRef, setContentRef ] = useState< HTMLIFrameElement | null >(
-		null
-	);
-	const mountNode = contentRef?.contentWindow?.document?.body;
-
-	return (
-		<iframe
-			title="test-iframe"
-			{ ...props }
-			ref={ setContentRef }
-			tabIndex={ -1 }
-		>
-			{ mountNode && createPortal( children, mountNode ) }
-		</iframe>
-	);
-};
 
 const Template: ComponentStory< typeof Modal > = ( {
 	onRequestClose,
@@ -110,10 +86,6 @@ const Template: ComponentStory< typeof Modal > = ( {
 						height="200"
 						src="https://www.openstreetmap.org/export/embed.html?bbox=-0.004017949104309083%2C51.47612752641776%2C0.00030577182769775396%2C51.478569861898606&layer=mapnik"
 					/>
-
-					<IFrame title="Example 2" width={ 300 } height={ 200 }>
-						<button>Button inside iframe</button>
-					</IFrame>
 
 					<Button variant="secondary" onClick={ closeModal }>
 						Close Modal

--- a/packages/components/src/modal/stories/index.tsx
+++ b/packages/components/src/modal/stories/index.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { createPortal } from 'react-dom';
 import type { ComponentStory, ComponentMeta } from '@storybook/react';
 
 /**
@@ -42,6 +43,29 @@ const meta: ComponentMeta< typeof Modal > = {
 };
 export default meta;
 
+const IFrame: React.FC< {
+	title?: string;
+	width: number;
+	height: number;
+	children: React.ReactNode;
+} > = ( { children, ...props } ) => {
+	const [ contentRef, setContentRef ] = useState< HTMLIFrameElement | null >(
+		null
+	);
+	const mountNode = contentRef?.contentWindow?.document?.body;
+
+	return (
+		<iframe
+			title="test-iframe"
+			{ ...props }
+			ref={ setContentRef }
+			tabIndex={ -1 }
+		>
+			{ mountNode && createPortal( children, mountNode ) }
+		</iframe>
+	);
+};
+
 const Template: ComponentStory< typeof Modal > = ( {
 	onRequestClose,
 	...args
@@ -77,6 +101,19 @@ const Template: ComponentStory< typeof Modal > = ( {
 					</p>
 
 					<InputControl style={ { marginBottom: '20px' } } />
+
+					<button>Button outside iframe</button>
+
+					<iframe
+						title="Example 1"
+						width="300"
+						height="200"
+						src="https://www.openstreetmap.org/export/embed.html?bbox=-0.004017949104309083%2C51.47612752641776%2C0.00030577182769775396%2C51.478569861898606&layer=mapnik"
+					/>
+
+					<IFrame title="Example 2" width={ 300 } height={ 200 }>
+						<button>Button inside iframe</button>
+					</IFrame>
 
 					<Button variant="secondary" onClick={ closeModal }>
 						Close Modal

--- a/packages/compose/src/hooks/use-focus-outside/index.ts
+++ b/packages/compose/src/hooks/use-focus-outside/index.ts
@@ -90,7 +90,7 @@ export default function useFocusOutside(
 	// Cancel blur checks on unmount.
 	useEffect( () => {
 		return () => cancelBlurCheck();
-	}, [] );
+	}, [ cancelBlurCheck ] );
 
 	// Cancel a blur check if the callback or ref is no longer provided.
 	useEffect( () => {

--- a/packages/compose/src/hooks/use-focus-outside/index.ts
+++ b/packages/compose/src/hooks/use-focus-outside/index.ts
@@ -1,17 +1,4 @@
 /**
- * External dependencies
- */
-import type {
-	FocusEventHandler,
-	EventHandler,
-	MouseEventHandler,
-	TouchEventHandler,
-	FocusEvent,
-	MouseEvent,
-	TouchEvent,
-} from 'react';
-
-/**
  * WordPress dependencies
  */
 import { useCallback, useEffect, useRef } from '@wordpress/element';
@@ -63,12 +50,12 @@ function isFocusNormalizedButton(
 }
 
 type UseFocusOutsideReturn = {
-	onFocus: FocusEventHandler;
-	onMouseDown: MouseEventHandler;
-	onMouseUp: MouseEventHandler;
-	onTouchStart: TouchEventHandler;
-	onTouchEnd: TouchEventHandler;
-	onBlur: FocusEventHandler;
+	onFocus: React.FocusEventHandler;
+	onMouseDown: React.MouseEventHandler;
+	onMouseUp: React.MouseEventHandler;
+	onTouchStart: React.TouchEventHandler;
+	onTouchEnd: React.TouchEventHandler;
+	onBlur: React.FocusEventHandler;
 };
 
 /**
@@ -82,7 +69,7 @@ type UseFocusOutsideReturn = {
  * wrapping element element to capture when focus moves outside that element.
  */
 export default function useFocusOutside(
-	onFocusOutside: ( event: FocusEvent ) => void
+	onFocusOutside: ( event: React.FocusEvent ) => void
 ): UseFocusOutsideReturn {
 	const currentOnFocusOutside = useRef( onFocusOutside );
 	useEffect( () => {
@@ -122,17 +109,18 @@ export default function useFocusOutside(
 	 * @param event
 	 * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#Clicking_and_focus
 	 */
-	const normalizeButtonFocus: EventHandler< MouseEvent | TouchEvent > =
-		useCallback( ( event ) => {
-			const { type, target } = event;
-			const isInteractionEnd = [ 'mouseup', 'touchend' ].includes( type );
+	const normalizeButtonFocus: React.EventHandler<
+		React.MouseEvent | React.TouchEvent
+	> = useCallback( ( event ) => {
+		const { type, target } = event;
+		const isInteractionEnd = [ 'mouseup', 'touchend' ].includes( type );
 
-			if ( isInteractionEnd ) {
-				preventBlurCheck.current = false;
-			} else if ( isFocusNormalizedButton( target ) ) {
-				preventBlurCheck.current = true;
-			}
-		}, [] );
+		if ( isInteractionEnd ) {
+			preventBlurCheck.current = false;
+		} else if ( isFocusNormalizedButton( target ) ) {
+			preventBlurCheck.current = true;
+		}
+	}, [] );
 
 	/**
 	 * A callback triggered when a blur event occurs on the element the handler
@@ -141,7 +129,7 @@ export default function useFocusOutside(
 	 * Calls the `onFocusOutside` callback in an immediate timeout if focus has
 	 * move outside the bound element and is still within the document.
 	 */
-	const queueBlurCheck: FocusEventHandler = useCallback( ( event ) => {
+	const queueBlurCheck: React.FocusEventHandler = useCallback( ( event ) => {
 		// React does not allow using an event reference asynchronously
 		// due to recycling behavior, except when explicitly persisted.
 		event.persist();

--- a/packages/compose/src/hooks/use-focus-outside/index.ts
+++ b/packages/compose/src/hooks/use-focus-outside/index.ts
@@ -90,11 +90,6 @@ export default function useFocusOutside(
 	} | null >( null );
 	const pollingIntervalId = useRef< number | undefined >();
 
-	// Thoughts:
-	// - it needs to always stop when component unmounted
-	// - it needs to work when resuming focus from another doc and clicking
-	//   immediately on the backdrop
-
 	// Sometimes the blur event is not reliable, for example when focus moves
 	// to an iframe inside the wrapper. In these scenarios, we resort to polling,
 	// and we explicitly check if focus has indeed moved outside the wrapper.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Supersedes #45349
Fixes #40912

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The `useFocusOutside` hook doesn't currently behave as expected when focus moves to an `iframe` element inside the container element setting the boundaries for the hook (see related issue for an example)

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

By adding a check, in the blur event, to see if the active element is a child of the wrapper element that we're trying to detect focus outside of.

But when the `iframe` is in focus, the blur event would not fire as expected. That's why, un case the active element is an `iframe`, I added extra code to activate a temporary polling function, which checks every 50ms if focus has effectively left the wrapper element.

I will highlight a few more details of my changes with inline comments.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

On Storybook:
- Visit the Modal storybook example, interact with the component, make sure that it behaves as expected— ie.:
  - Clicking inside the iframe doesn't close the component
  - Clicking on the iframe, and then clicking another component inside the modal shouldn't close the modal
  - Keybaord focusing the iframe (or elements inside the iframe) shouldn't close the modal
  - Blurring the whole document window shouldn't close the modal. Resuming focus on the page shouldn't close the modal either.
  - Focusing the iframe, then blurring the modal, then focusing document again and clicking the overlay should close the modal
  - .... any other weird edge case that comes to mind which could trick the Modal component to close unexpectedly, or not to close when expected.
- Make sure that the `ConfirmDialog` example works as expected
- Make sure that the `PaletteEdit` behaves as expected:
  - Click on the "Add color" button (shown with a plus icon)
  - Edit the new color item
  - Make sure that the item exists "editing mode" as soon as focus leaves the item
- ComboboxControl:
  - focus the text input, make sure that the dropdown with the suggestions show
  - move focus outside of the input. Make sure that the suggestions dropdown doesn't get rendered to screen
- Popover:
  - make sure that the `onFocusOutside` prop is called as expected (see the `Modal` component testing instructions above)

In the editor:
- make sure that all the components listed above generally work as expected in the editor
- in particular, make sure that Modals interact as expected with each other
- post title

In the native editor (cc @geriux @dcalhoun @fluiddot )
- Make sure that [this callback](https://github.com/WordPress/gutenberg/blob/95035db15bc59846922e54710d25ffbecda278eb/packages/editor/src/components/post-title/index.native.js#L56-L58) fires as expected when blurring the post title

### Known bug

while testing on my machine, I noticed that on MacOS Safari focus is simply not trapped inside the modal. That seems to also happen on `trunk`, so we should probably open a separate issue and treat this separately.

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/1083581/683d14b1-350a-48f2-9725-f7b60b5e1e41

