### PR TITLE
Add caching to schema of REST API.

### DIFF
--- a/lib/compat/wordpress-6.2/class-gutenberg-rest-block-pattern-categories-controller.php
+++ b/lib/compat/wordpress-6.2/class-gutenberg-rest-block-pattern-categories-controller.php
@@ -47,6 +47,10 @@ class Gutenberg_REST_Block_Pattern_Categories_Controller extends WP_REST_Block_P
 	 * @return array Item schema data.
 	 */
 	public function get_item_schema() {
+		if ( $this->schema ) {
+			return $this->add_additional_fields_schema( $this->schema );
+		}
+
 		$schema = array(
 			'$schema'    => 'http://json-schema.org/draft-04/schema#',
 			'title'      => 'block-pattern-category',
@@ -73,6 +77,8 @@ class Gutenberg_REST_Block_Pattern_Categories_Controller extends WP_REST_Block_P
 			),
 		);
 
-		return $this->add_additional_fields_schema( $schema );
+		$this->schema = $schema;
+
+		return $this->add_additional_fields_schema( $this->schema );
 	}
 }

--- a/lib/compat/wordpress-6.2/class-gutenberg-rest-block-patterns-controller-6-2.php
+++ b/lib/compat/wordpress-6.2/class-gutenberg-rest-block-patterns-controller-6-2.php
@@ -79,6 +79,10 @@ class Gutenberg_REST_Block_Patterns_Controller_6_2 extends WP_REST_Block_Pattern
 	 * @return array Item schema data.
 	 */
 	public function get_item_schema() {
+		if ( $this->schema ) {
+			return $this->add_additional_fields_schema( $this->schema );
+		}
+
 		$schema = array(
 			'$schema'    => 'http://json-schema.org/draft-04/schema#',
 			'title'      => 'block-pattern',
@@ -153,7 +157,9 @@ class Gutenberg_REST_Block_Patterns_Controller_6_2 extends WP_REST_Block_Pattern
 			),
 		);
 
-		return $this->add_additional_fields_schema( $schema );
+		$this->schema = $schema;
+
+		return $this->add_additional_fields_schema( $this->schema );
 	}
 
 	/**

--- a/lib/compat/wordpress-6.3/class-gutenberg-rest-block-patterns-controller-6-3.php
+++ b/lib/compat/wordpress-6.3/class-gutenberg-rest-block-patterns-controller-6-3.php
@@ -62,6 +62,10 @@ class Gutenberg_REST_Block_Patterns_Controller_6_3 extends Gutenberg_REST_Block_
 	 * @return array Item schema data.
 	 */
 	public function get_item_schema() {
+		if ( $this->schema ) {
+			return $this->add_additional_fields_schema( $this->schema );
+		}
+
 		$schema = array(
 			'$schema'    => 'http://json-schema.org/draft-04/schema#',
 			'title'      => 'block-pattern',
@@ -150,6 +154,8 @@ class Gutenberg_REST_Block_Patterns_Controller_6_3 extends Gutenberg_REST_Block_
 			),
 		);
 
-		return $this->add_additional_fields_schema( $schema );
+		$this->schema = $schema;
+
+		return $this->add_additional_fields_schema( $this->schema );
 	}
 }

--- a/lib/experimental/class-wp-rest-block-editor-settings-controller.php
+++ b/lib/experimental/class-wp-rest-block-editor-settings-controller.php
@@ -109,7 +109,7 @@ class WP_REST_Block_Editor_Settings_Controller extends WP_REST_Controller {
 			return $this->add_additional_fields_schema( $this->schema );
 		}
 
-		$this->schema = array(
+		$schema = array(
 			'$schema'    => 'http://json-schema.org/draft-04/schema#',
 			'title'      => 'block-editor-settings-item',
 			'type'       => 'object',
@@ -310,6 +310,8 @@ class WP_REST_Block_Editor_Settings_Controller extends WP_REST_Controller {
 				),
 			),
 		);
+
+		$this->schema = $schema;
 
 		return $this->add_additional_fields_schema( $this->schema );
 	}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Improve performance of the REST API call by caching schema data. See ticket for more details - https://core.trac.wordpress.org/ticket/58657#ticket

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
