### PR TITLE
Change "Home" template name to "Blog home"

### DIFF
--- a/lib/compat/wordpress-6.3/block-template-utils.php
+++ b/lib/compat/wordpress-6.3/block-template-utils.php
@@ -29,7 +29,7 @@ function gutenberg_get_default_block_template_types( $default_template_types ) {
 	}
 	if ( isset( $default_template_types['home'] ) ) {
 		$default_template_types['home'] = array(
-			'title'       => _x( 'Home', 'Template name', 'gutenberg' ),
+			'title'       => _x( 'Blog Home', 'Template name', 'gutenberg' ),
 			'description' => __(
 				'Displays the latest posts as either the site homepage or as the "Posts page" as defined under reading settings. If it exists, the Front Page template overrides this template when posts are shown on the homepage.',
 				'gutenberg'


### PR DESCRIPTION
Follow-up to https://github.com/WordPress/gutenberg/pull/51428. Fixes https://github.com/WordPress/gutenberg/issues/44524.

## What?
Rename "Home" to "Blog Home"

## Why?
"Home" is easily conflated with the actual homepage, which this template does not always display. 

## How?
Change a text string.

## Testing Instructions
Observe that anywhere you encounter the Home template (e.g. the template details panel, the add template modal, etc.), it is now labeled "Blog Home".

## Screenshots or screencast <!-- if applicable -->
<img width="359" alt="Screenshot 2023-06-28 at 15 26 13" src="https://github.com/WordPress/gutenberg/assets/846565/91d5a1d1-6cf5-48a7-b39b-f564521f7720">
