### PR TITLE
Image block: Use built-in directive for mouseover event in lightbox

### DIFF
--- a/lib/block-supports/behaviors.php
+++ b/lib/block-supports/behaviors.php
@@ -141,7 +141,7 @@ function gutenberg_render_behaviors_support_lightbox( $block_content, $block ) {
 	$img = null;
 	preg_match( '/<img[^>]+>/', $body_content, $img );
 	$button       = '<div class="img-container">
-                             <button type="button" aria-haspopup="dialog" aria-label="' . esc_attr( $aria_label ) . '" data-wp-on--click="actions.core.image.showLightbox" data-wp-on--mouseover="actions.core.image.preloadLightboxImage"></button>'
+                             <button type="button" aria-haspopup="dialog" aria-label="' . esc_attr( $aria_label ) . '" data-wp-on--click="actions.core.image.showLightbox" data-wp-on--mouseenter="actions.core.image.preloadLightboxImage"></button>'
 		. $img[0] .
 		'</div>';
 	$body_content = preg_replace( '/<img[^>]+>/', $button, $body_content );

--- a/lib/block-supports/behaviors.php
+++ b/lib/block-supports/behaviors.php
@@ -141,7 +141,7 @@ function gutenberg_render_behaviors_support_lightbox( $block_content, $block ) {
 	$img = null;
 	preg_match( '/<img[^>]+>/', $body_content, $img );
 	$button       = '<div class="img-container">
-                             <button type="button" aria-haspopup="dialog" aria-label="' . esc_attr( $aria_label ) . '" data-wp-on--click="actions.core.image.showLightbox" data-wp-effect="effects.core.image.preloadLightboxImage"></button>'
+                             <button type="button" aria-haspopup="dialog" aria-label="' . esc_attr( $aria_label ) . '" data-wp-on--click="actions.core.image.showLightbox" data-wp-on--mouseover="actions.core.image.preloadLightboxImage"></button>'
 		. $img[0] .
 		'</div>';
 	$body_content = preg_replace( '/<img[^>]+>/', $button, $body_content );

--- a/packages/block-library/src/image/view-interactivity.js
+++ b/packages/block-library/src/image/view-interactivity.js
@@ -133,6 +133,16 @@ store( {
 						}
 					}
 				},
+				preloadLightboxImage: ( { context } ) => {
+					if ( ! context.core.image.preloadInitialized ) {
+						context.core.image.preloadInitialized = true;
+						const imgDom = document.createElement( 'img' );
+						imgDom.setAttribute(
+							'src',
+							context.core.image.imageUploadedSrc
+						);
+					}
+				},
 			},
 		},
 	},
@@ -169,18 +179,6 @@ store( {
 								this.currentSrc;
 						} );
 					}
-				},
-				preloadLightboxImage: ( { context, ref } ) => {
-					ref.addEventListener( 'mouseover', () => {
-						if ( ! context.core.image.preloadInitialized ) {
-							context.core.image.preloadInitialized = true;
-							const imgDom = document.createElement( 'img' );
-							imgDom.setAttribute(
-								'src',
-								context.core.image.imageUploadedSrc
-							);
-						}
-					} );
 				},
 				initLightbox: async ( { context, ref } ) => {
 					context.core.image.figureRef =


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
This changes the implementation of the preload image logic by moving it from a `data-wp-effect` directive to the built-in `data-wp-on--mouseover` directive.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Brought up in the [following code review](https://github.com/WordPress/gutenberg/pull/51721#discussion_r1243263953).
In order to simplify code, we should be using built-in directives wherever possible.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
It replaces the directive and moves the preload function definition to `actions`.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
1. Make sure the Interactivity API is enabled under Gutenberg Experiments settings.
2. Add an image to a new post.
3. Ensure the lightbox is enabled under Advanced > Behaviors > Lightbox in the block settings.
4. Open your browser developer tools and go to the Network > Img tab or similar. In Chrome, it looks like this:
![Screenshot 2023-06-28 at 9 45 19 AM](https://github.com/WordPress/gutenberg/assets/5360536/563f2252-a57c-4776-8786-a1eb6154a87d)
6. Publish and view the post.
7. See the responsive image already loaded in the Network tab.
8. Now however over the image — see the full-size image get loaded.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
N/A