### PR TITLE
Fix fetching Nav fallback ID flushing Navigation entity cache

### DIFF
--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -573,7 +573,7 @@ export const getBlockPatternCategories =
 
 export const getNavigationFallbackId =
 	() =>
-	async ( { dispatch } ) => {
+	async ( { dispatch, select } ) => {
 		const fallback = await apiFetch( {
 			path: addQueryArgs( '/wp-block-editor/v1/navigation-fallback', {
 				_embed: true,
@@ -585,7 +585,16 @@ export const getNavigationFallbackId =
 		dispatch.receiveNavigationFallbackId( fallback?.id );
 
 		if ( record ) {
-			const invalidateNavigationQueries = true;
+			// If the fallback is already in the store, don't invalidate navigation queries.
+			// Otherwise, invalidate the cache for the scenario where there were no Navigation
+			// posts in the state and the fallback created one.
+			const invalidateNavigationQueries = select.getEntityRecord(
+				'postType',
+				'wp_navigation',
+				fallback?.id
+			)
+				? false
+				: true;
 
 			dispatch.receiveEntityRecords(
 				'postType',

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -588,14 +588,12 @@ export const getNavigationFallbackId =
 			// If the fallback is already in the store, don't invalidate navigation queries.
 			// Otherwise, invalidate the cache for the scenario where there were no Navigation
 			// posts in the state and the fallback created one.
-			const invalidateNavigationQueries = select.getEntityRecord(
+			const existingFallbackEntityRecord = select.getEntityRecord(
 				'postType',
 				'wp_navigation',
 				fallback?.id
-			)
-				? false
-				: true;
-
+			);
+			const invalidateNavigationQueries = ! existingFallbackEntityRecord;
 			dispatch.receiveEntityRecords(
 				'postType',
 				'wp_navigation',


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Adds safety catch to `getNavigationFallbackId` resolver to avoid flushing Navigation entities cache if the retrieved fallback post ID is already in state.

Co-authored-by: Andrei Draganescu <107534+draganescu@users.noreply.github.com>
Co-authored-by: Ben Dwyer <275961+scruffian@users.noreply.github.com>

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Currently if a call to `getNavigationFallbackId` when there are already Navigation entities will still cause the entire cache for `getEntityRecords('postType','wp_navigation')` to be flushed. This triggers an unwanted additional network request to re-fetch the entities when it's not needed.

This PR fixes that.


## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

It fixes it by checking whether the post that's returned as the "fallback" already exists in Core Data. If it does, then it doesn't bother invalidating the cache as the record is already there.

If the record is not already in state, then it continues to flush the cache in order that the state is updated with the new sideloaded data.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->


- Have some Navigation Menus already created.
- Load Site Editor
- Open network tab and filter by `Navigation`.
- Open console and trigger call for fallback - `wp.data.select('core').getNavigationFallbackId()`
- Check that you do not see a network request to `wp/v2/navigation` to get "all" Navigations.
- Delete all your menus.
```
// Get IDs of all Navigation Menus
npm run wp-env run cli wp post list -- --post_type=wp_navigation --format=ids

// Then run this for each of the IDs
npm run wp-env run cli wp post delete {ID} -- --force
```
- Load Site Editor
- Open network tab and filter by `Navigation`.
- Open console and trigger call for fallback - `wp.data.select('core').getNavigationFallbackId()`
- Check that you do see a network request to `wp/v2/navigation` to get "all" Navigations.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
