### PR TITLE
Update the icon used to reference the blog

### DIFF
--- a/packages/edit-site/src/components/add-new-template/new-template.js
+++ b/packages/edit-site/src/components/add-new-template/new-template.js
@@ -34,7 +34,7 @@ import {
 	page,
 	plus,
 	pin,
-	postList,
+	verse,
 	search,
 	tag,
 } from '@wordpress/icons';
@@ -78,7 +78,7 @@ const DEFAULT_TEMPLATE_SLUGS = [
 
 const TEMPLATE_ICONS = {
 	'front-page': home,
-	home: postList,
+	home: verse,
 	single: pin,
 	page,
 	archive,

--- a/packages/edit-site/src/components/sidebar-navigation-screen-pages/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-pages/index.js
@@ -12,7 +12,7 @@ import { __ } from '@wordpress/i18n';
 import { useEntityRecords, store as coreStore } from '@wordpress/core-data';
 import { decodeEntities } from '@wordpress/html-entities';
 import { privateApis as routerPrivateApis } from '@wordpress/router';
-import { layout, page, home, loop, plus } from '@wordpress/icons';
+import { layout, page, home, verse, plus } from '@wordpress/icons';
 import { useSelect } from '@wordpress/data';
 
 /**
@@ -159,7 +159,7 @@ export default function SidebarNavigationScreenPages() {
 											itemIcon = home;
 											break;
 										case postsPage:
-											itemIcon = loop;
+											itemIcon = verse;
 											break;
 										default:
 											itemIcon = page;


### PR DESCRIPTION
## What?
Replace `loop` icon with `verse`.

## Why?
`Loop` has some technical connection via the Query Loop block, but visually it's not a good representation of a blog. `Verse` is a bit better in that respect. 

## Testing Instructions
Observe the `verse` icon replaces the `loop` icon in the Site Editor when the blog, or blog template (Home) is referenced. Specifically:

* The "Posts Page" in the Site Editor's Pages panel.
* The Add Template modal

## Screenshots or screencast <!-- if applicable -->
<img width="348" alt="Screenshot 2023-06-28 at 16 23 55" src="https://github.com/WordPress/gutenberg/assets/846565/df353c7d-8b32-4b25-8196-7d61e54e723c">
<img width="885" alt="Screenshot 2023-06-28 at 16 24 11" src="https://github.com/WordPress/gutenberg/assets/846565/ae293666-efaa-4527-aeda-ed20f69710e6">
