### PR TITLE
Fix unintentional toggling on of distraction free

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen-global-styles/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-global-styles/index.js
@@ -16,6 +16,7 @@ import { BlockEditorProvider } from '@wordpress/block-editor';
 import { humanTimeDiff } from '@wordpress/date';
 import { useCallback } from '@wordpress/element';
 import { store as noticesStore } from '@wordpress/notices';
+import { store as preferencesStore } from '@wordpress/preferences';
 
 /**
  * Internal dependencies
@@ -32,9 +33,10 @@ import useGlobalStylesRevisions from '../global-styles/screen-revisions/use-glob
 const noop = () => {};
 
 export function SidebarNavigationItemGlobalStyles( props ) {
-	const { openGeneralSidebar, toggleFeature } = useDispatch( editSiteStore );
+	const { openGeneralSidebar } = useDispatch( editSiteStore );
 	const { setCanvasMode } = unlock( useDispatch( editSiteStore ) );
 	const { createNotice } = useDispatch( noticesStore );
+	const { set: setPreference } = useDispatch( preferencesStore );
 	const hasGlobalStyleVariations = useSelect(
 		( select ) =>
 			!! select(
@@ -56,7 +58,7 @@ export function SidebarNavigationItemGlobalStyles( props ) {
 			{ ...props }
 			onClick={ () => {
 				// Disable distraction free mode.
-				toggleFeature( 'distractionFree', false );
+				setPreference( editSiteStore.name, 'distractionFree', false );
 				createNotice(
 					'info',
 					__( 'Distraction free mode turned off' ),

--- a/packages/edit-site/src/components/sidebar-navigation-screen-global-styles/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-global-styles/index.js
@@ -37,11 +37,17 @@ export function SidebarNavigationItemGlobalStyles( props ) {
 	const { setCanvasMode } = unlock( useDispatch( editSiteStore ) );
 	const { createNotice } = useDispatch( noticesStore );
 	const { set: setPreference } = useDispatch( preferencesStore );
-	const hasGlobalStyleVariations = useSelect(
-		( select ) =>
-			!! select(
-				coreStore
-			).__experimentalGetCurrentThemeGlobalStylesVariations()?.length,
+	const { hasGlobalStyleVariations, isDistractionFree } = useSelect(
+		( select ) => ( {
+			hasGlobalStyleVariations:
+				!! select(
+					coreStore
+				).__experimentalGetCurrentThemeGlobalStylesVariations()?.length,
+			isDistractionFree: select( preferencesStore ).get(
+				editSiteStore.name,
+				'distractionFree'
+			),
+		} ),
 		[]
 	);
 	if ( hasGlobalStyleVariations ) {
@@ -58,15 +64,21 @@ export function SidebarNavigationItemGlobalStyles( props ) {
 			{ ...props }
 			onClick={ () => {
 				// Disable distraction free mode.
-				setPreference( editSiteStore.name, 'distractionFree', false );
-				createNotice(
-					'info',
-					__( 'Distraction free mode turned off' ),
-					{
-						isDismissible: true,
-						type: 'snackbar',
-					}
-				);
+				if ( isDistractionFree ) {
+					setPreference(
+						editSiteStore.name,
+						'distractionFree',
+						false
+					);
+					createNotice(
+						'info',
+						__( 'Distraction free mode turned off' ),
+						{
+							isDismissible: true,
+							type: 'snackbar',
+						}
+					);
+				}
 				// Switch to edit mode.
 				setCanvasMode( 'edit' );
 				// Open global styles sidebar.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

Co-authored-by: Nik Tsekouras <16275880+ntsekouras@users.noreply.github.com>

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes #52085

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Because I used the wrong function despite it being named like not what I wanted.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

See problem, feel kinda dumb, fix problem.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Enable a theme with no style variations (e.g. Stacks)
2. Open the site editor
3. Click styles
4. Click the site hub
5. Click styles
6. You should NOT be in distraction free mode
