### PR TITLE
Global Styles Revisions API: backport changes from Core

### DIFF
--- a/lib/compat/wordpress-6.3/class-gutenberg-rest-global-styles-controller-6-3.php
+++ b/lib/compat/wordpress-6.3/class-gutenberg-rest-global-styles-controller-6-3.php
@@ -31,7 +31,7 @@ class Gutenberg_REST_Global_Styles_Controller_6_3 extends Gutenberg_REST_Global_
 		if ( post_type_supports( $this->post_type, 'revisions' ) ) {
 			$revisions                = wp_get_latest_revision_id_and_total_count( $id );
 			$revisions_count          = ! is_wp_error( $revisions ) ? $revisions['count'] : 0;
-			$revisions_base           = sprintf( '/%s/%s/%d/revisions', $this->namespace, $this->rest_base, $id );
+			$revisions_base           = sprintf( '/%s/%d/revisions', $base, $id );
 			$links['version-history'] = array(
 				'href'  => rest_url( $revisions_base ),
 				'count' => $revisions_count,

--- a/phpunit/class-gutenberg-rest-global-styles-revisions-controller-test.php
+++ b/phpunit/class-gutenberg-rest-global-styles-revisions-controller-test.php
@@ -21,10 +21,40 @@ class Gutenberg_REST_Global_Styles_Revisions_Controller_Test extends WP_Test_RES
 	 */
 	protected static $global_styles_id;
 
-	public function set_up() {
-		parent::set_up();
-		switch_theme( 'emptytheme' );
-	}
+	/**
+	 * @var int
+	 */
+	private $total_revisions;
+
+	/**
+	 * @var array
+	 */
+	private $revision_1;
+
+	/**
+	 * @var int
+	 */
+	private $revision_1_id;
+
+	/**
+	 * @var array
+	 */
+	private $revision_2;
+
+	/**
+	 * @var int
+	 */
+	private $revision_2_id;
+
+	/**
+	 * @var array
+	 */
+	private $revision_3;
+
+	/**
+	 * @var int
+	 */
+	private $revision_3_id;
 
 	/**
 	 * Create fake data before our tests run.
@@ -47,19 +77,113 @@ class Gutenberg_REST_Global_Styles_Revisions_Controller_Test extends WP_Test_RES
 				'role' => 'author',
 			)
 		);
+
+		wp_set_current_user( self::$admin_id );
 		// This creates the global styles for the current theme.
 		self::$global_styles_id = $factory->post->create(
 			array(
-				'post_content' => '{"version": ' . WP_Theme_JSON_Gutenberg::LATEST_SCHEMA . ', "isGlobalStylesUserThemeJSON": true }',
+				'post_content' => '{"version": ' . WP_Theme_JSON::LATEST_SCHEMA . ', "isGlobalStylesUserThemeJSON": true }',
 				'post_status'  => 'publish',
 				'post_title'   => __( 'Custom Styles', 'default' ),
 				'post_type'    => 'wp_global_styles',
-				'post_name'    => 'wp-global-styles-emptytheme-revisions',
+				'post_name'    => 'wp-global-styles-tt1-blocks-revisions',
 				'tax_input'    => array(
-					'wp_theme' => 'emptytheme',
+					'wp_theme' => 'tt1-blocks',
 				),
 			)
 		);
+
+		// Update post to create a new revisions.
+		$new_styles_post = array(
+			'ID'           => self::$global_styles_id,
+			'post_content' => wp_json_encode(
+				array(
+					'version'                     => WP_Theme_JSON::LATEST_SCHEMA,
+					'isGlobalStylesUserThemeJSON' => true,
+					'styles'                      => array(
+						'color' => array(
+							'background' => 'hotpink',
+						),
+					),
+					'settings'                    => array(
+						'color' => array(
+							'palette' => array(
+								'custom' => array(
+									array(
+										'name'  => 'Ghost',
+										'slug'  => 'ghost',
+										'color' => 'ghost',
+									),
+								),
+							),
+						),
+					),
+				)
+			),
+		);
+
+		wp_update_post( $new_styles_post, true, false );
+
+		$new_styles_post = array(
+			'ID'           => self::$global_styles_id,
+			'post_content' => wp_json_encode(
+				array(
+					'version'                     => WP_Theme_JSON::LATEST_SCHEMA,
+					'isGlobalStylesUserThemeJSON' => true,
+					'styles'                      => array(
+						'color' => array(
+							'background' => 'lemonchiffon',
+						),
+					),
+					'settings'                    => array(
+						'color' => array(
+							'palette' => array(
+								'custom' => array(
+									array(
+										'name'  => 'Gwanda',
+										'slug'  => 'gwanda',
+										'color' => 'gwanda',
+									),
+								),
+							),
+						),
+					),
+				)
+			),
+		);
+
+		wp_update_post( $new_styles_post, true, false );
+
+		$new_styles_post = array(
+			'ID'           => self::$global_styles_id,
+			'post_content' => wp_json_encode(
+				array(
+					'version'                     => WP_Theme_JSON::LATEST_SCHEMA,
+					'isGlobalStylesUserThemeJSON' => true,
+					'styles'                      => array(
+						'color' => array(
+							'background' => 'chocolate',
+						),
+					),
+					'settings'                    => array(
+						'color' => array(
+							'palette' => array(
+								'custom' => array(
+									array(
+										'name'  => 'Stacy',
+										'slug'  => 'stacy',
+										'color' => 'stacy',
+									),
+								),
+							),
+						),
+					),
+				)
+			),
+		);
+
+		wp_update_post( $new_styles_post, true, false );
+		wp_set_current_user( 0 );
 	}
 
 	/**
@@ -72,114 +196,184 @@ class Gutenberg_REST_Global_Styles_Revisions_Controller_Test extends WP_Test_RES
 	}
 
 	/**
-	 * @covers Gutenberg_REST_Global_Styles_Revisions_Controller::register_routes
+	 * Sets up before tests.
+	 */
+	public function set_up() {
+		parent::set_up();
+		switch_theme( 'emptytheme' );
+		$revisions             = wp_get_post_revisions( self::$global_styles_id );
+		$this->total_revisions = count( $revisions );
+
+		$this->revision_1    = array_pop( $revisions );
+		$this->revision_1_id = $this->revision_1->ID;
+
+		$this->revision_2    = array_pop( $revisions );
+		$this->revision_2_id = $this->revision_2->ID;
+
+		$this->revision_3    = array_pop( $revisions );
+		$this->revision_3_id = $this->revision_3->ID;
+	}
+
+	/**
+	 * @ticket 58524
+	 *
+	 * @covers WP_REST_Global_Styles_Controller::register_routes
 	 */
 	public function test_register_routes() {
 		$routes = rest_get_server()->get_routes();
 		$this->assertArrayHasKey(
 			'/wp/v2/global-styles/(?P<parent>[\d]+)/revisions',
 			$routes,
-			'Global style revisions based on the given parentID route does not exist'
+			'Global style revisions based on the given parentID route does not exist.'
 		);
 	}
 
 	/**
-	 * @covers Gutenberg_REST_Global_Styles_Revisions_Controller::get_items
+	 * @ticket 58524
+	 *
+	 * @covers WP_REST_Global_Styles_Controller::get_items
 	 */
-	public function test_get_items() {
+	public function test_get_items_missing_parent() {
 		wp_set_current_user( self::$admin_id );
-		// Update post to create a new revision.
-		$config          = array(
-			'version'                     => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
-			'isGlobalStylesUserThemeJSON' => true,
-			'styles'                      => array(
-				'color' => array(
-					'background' => 'hotpink',
-				),
-			),
-		);
-		$new_styles_post = array(
-			'ID'           => self::$global_styles_id,
-			'post_content' => wp_json_encode( $config ),
-		);
-
-		wp_update_post( $new_styles_post, true, false );
-
-		$request  = new WP_REST_Request( 'GET', '/wp/v2/global-styles/' . self::$global_styles_id . '/revisions' );
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/global-styles/' . REST_TESTS_IMPOSSIBLY_HIGH_NUMBER . '/revisions' );
 		$response = rest_get_server()->dispatch( $request );
-		$data     = $response->get_data();
+		$this->assertErrorResponse( 'rest_post_invalid_parent', $response, 404 );
+	}
 
-		$this->assertCount( 1, $data, 'Check that only one revision exists' );
-		$this->assertArrayHasKey( 'id', $data[0], 'Check that an id key exists' );
-		$this->assertEquals( self::$global_styles_id, $data[0]['parent'], 'Check that an id for the parent exists' );
-
-		// Dates.
-		$this->assertArrayHasKey( 'date', $data[0], 'Check that an date key exists' );
-		$this->assertArrayHasKey( 'date_gmt', $data[0], 'Check that an date_gmt key exists' );
-		$this->assertArrayHasKey( 'modified', $data[0], 'Check that an modified key exists' );
-		$this->assertArrayHasKey( 'modified_gmt', $data[0], 'Check that an modified_gmt key exists' );
-		$this->assertArrayHasKey( 'modified_gmt', $data[0], 'Check that an modified_gmt key exists' );
-
-		// Author information.
-		$this->assertEquals( self::$admin_id, $data[0]['author'], 'Check that author id returns expected value' );
+	/**
+	 * Utility function to check the items in WP_REST_Global_Styles_Controller::get_items
+	 * against the expected values.
+	 *
+	 * @ticket 58524
+	 */
+	protected function check_get_revision_response( $response_revision_item, $revision_expected_item ) {
+		$this->assertSame( (int) $revision_expected_item->post_author, $response_revision_item['author'], 'Check that the revision item `author` exists.' );
+		$this->assertSame( mysql_to_rfc3339( $revision_expected_item->post_date ), $response_revision_item['date'], 'Check that the revision item `date` exists.' );
+		$this->assertSame( mysql_to_rfc3339( $revision_expected_item->post_date_gmt ), $response_revision_item['date_gmt'], 'Check that the revision item `date_gmt` exists.' );
+		$this->assertSame( mysql_to_rfc3339( $revision_expected_item->post_modified ), $response_revision_item['modified'], 'Check that the revision item `modified` exists.' );
+		$this->assertSame( mysql_to_rfc3339( $revision_expected_item->post_modified_gmt ), $response_revision_item['modified_gmt'], 'Check that the revision item `modified_gmt` exists.' );
+		$this->assertSame( $revision_expected_item->post_parent, $response_revision_item['parent'], 'Check that an id for the parent exists.' );
 
 		// Global styles.
+		$config = ( new WP_Theme_JSON( json_decode( $revision_expected_item->post_content, true ), 'custom' ) )->get_raw_data();
 		$this->assertEquals(
-			$data[0]['settings'],
-			new stdClass(),
+			$config['settings'],
+			$response_revision_item['settings'],
 			'Check that the revision settings exist in the response.'
 		);
 		$this->assertEquals(
-			$data[0]['styles'],
-			array(
-				'color' => array(
-					'background' => 'hotpink',
-				),
-			),
-			'Check that the revision styles match the last updated styles.'
+			$config['styles'],
+			$response_revision_item['styles'],
+			'Check that the revision styles match the updated styles.'
 		);
+	}
 
-		// Checks that the revisions are returned for all eligible users.
-		wp_set_current_user( self::$second_admin_id );
-		$config['styles']['color']['background'] = 'blue';
-		$new_styles_post                         = array(
-			'ID'           => self::$global_styles_id,
-			'post_content' => wp_json_encode( $config ),
-		);
-
-		wp_update_post( $new_styles_post, true, false );
+	/**
+	 * @ticket 58524
+	 *
+	 * @covers WP_REST_Global_Styles_Controller::get_items
+	 */
+	public function test_get_items() {
+		wp_set_current_user( self::$admin_id );
 
 		$request  = new WP_REST_Request( 'GET', '/wp/v2/global-styles/' . self::$global_styles_id . '/revisions' );
 		$response = rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();
 
-		$this->assertCount( 2, $data, 'Check that two revisions exists' );
-		$this->assertEquals( self::$second_admin_id, $data[0]['author'], 'Check that second author id returns expected value' );
-		$this->assertEquals( self::$admin_id, $data[1]['author'], 'Check that second author id returns expected value' );
+		$this->assertSame( 200, $response->get_status(), 'Response status is 200.' );
+		$this->assertCount( $this->total_revisions, $data, 'Check that correct number of revisions exists.' );
+
+		// Reverse chronology.
+		$this->assertSame( $this->revision_3_id, $data[0]['id'] );
+		$this->check_get_revision_response( $data[0], $this->revision_3 );
+
+		$this->assertSame( $this->revision_2_id, $data[1]['id'] );
+		$this->check_get_revision_response( $data[1], $this->revision_2 );
+
+		$this->assertSame( $this->revision_1_id, $data[2]['id'] );
+		$this->check_get_revision_response( $data[2], $this->revision_1 );
 	}
 
 	/**
-	 * @covers Gutenberg_REST_Global_Styles_Revisions_Controller::get_item_schema
+	 * @ticket 58524
+	 *
+	 * @covers WP_REST_Global_Styles_Controller::get_items
+	 */
+	public function test_get_items_eligible_roles() {
+		wp_set_current_user( self::$second_admin_id );
+		$config              = array(
+			'version'                     => WP_Theme_JSON::LATEST_SCHEMA,
+			'isGlobalStylesUserThemeJSON' => true,
+			'styles'                      => array(
+				'color' => array(
+					'background' => 'whitesmoke',
+				),
+			),
+			'settings'                    => array(),
+		);
+		$updated_styles_post = array(
+			'ID'           => self::$global_styles_id,
+			'post_content' => wp_json_encode( $config ),
+		);
+
+		wp_update_post( $updated_styles_post, true, false );
+
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/global-styles/' . self::$global_styles_id . '/revisions' );
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertCount( $this->total_revisions + 1, $data, 'Check that extra revision exist' );
+		$this->assertEquals( self::$second_admin_id, $data[0]['author'], 'Check that second author id returns expected value.' );
+	}
+
+	/**
+	 * @ticket 58524
+	 *
+	 * @covers WP_REST_Global_Styles_Controller::get_items with context arg.
+	 */
+	public function test_get_item_embed_context() {
+		wp_set_current_user( self::$admin_id );
+
+		$request = new WP_REST_Request( 'GET', '/wp/v2/global-styles/' . self::$global_styles_id . '/revisions' );
+		$request->set_param( 'context', 'embed' );
+		$response = rest_get_server()->dispatch( $request );
+		$fields   = array(
+			'author',
+			'date',
+			'id',
+			'parent',
+		);
+		$data     = $response->get_data();
+		$this->assertSameSets( $fields, array_keys( $data[0] ) );
+	}
+
+	/**
+	 * @ticket 58524
+	 *
+	 * @covers WP_REST_Global_Styles_Controller::get_item_schema
 	 */
 	public function test_get_item_schema() {
 		$request    = new WP_REST_Request( 'OPTIONS', '/wp/v2/global-styles/' . self::$global_styles_id . '/revisions' );
 		$response   = rest_get_server()->dispatch( $request );
 		$data       = $response->get_data();
 		$properties = $data['schema']['properties'];
-		$this->assertCount( 9, $properties, 'Schema properties array does not have exactly 9 elements' );
-		$this->assertArrayHasKey( 'id', $properties, 'Schema properties array does not have "id" key' );
-		$this->assertArrayHasKey( 'styles', $properties, 'Schema properties array does not have "styles" key' );
-		$this->assertArrayHasKey( 'settings', $properties, 'Schema properties array does not have "settings" key' );
-		$this->assertArrayHasKey( 'parent', $properties, 'Schema properties array does not have "parent" key' );
-		$this->assertArrayHasKey( 'author', $properties, 'Schema properties array does not have "author" key' );
-		$this->assertArrayHasKey( 'date', $properties, 'Schema properties array does not have "date" key' );
-		$this->assertArrayHasKey( 'date_gmt', $properties, 'Schema properties array does not have "date_gmt" key' );
-		$this->assertArrayHasKey( 'modified', $properties, 'Schema properties array does not have "modified" key' );
-		$this->assertArrayHasKey( 'modified_gmt', $properties, 'Schema properties array does not have "modified_gmt" key' );
+
+		$this->assertCount( 9, $properties, 'Schema properties array has exactly 9 elements.' );
+		$this->assertArrayHasKey( 'id', $properties, 'Schema properties array has "id" key.' );
+		$this->assertArrayHasKey( 'styles', $properties, 'Schema properties array has "styles" key.' );
+		$this->assertArrayHasKey( 'settings', $properties, 'Schema properties array has "settings" key.' );
+		$this->assertArrayHasKey( 'parent', $properties, 'Schema properties array has "parent" key.' );
+		$this->assertArrayHasKey( 'author', $properties, 'Schema properties array has "author" key.' );
+		$this->assertArrayHasKey( 'date', $properties, 'Schema properties array has "date" key.' );
+		$this->assertArrayHasKey( 'date_gmt', $properties, 'Schema properties array has "date_gmt" key.' );
+		$this->assertArrayHasKey( 'modified', $properties, 'Schema properties array has "modified" key.' );
+		$this->assertArrayHasKey( 'modified_gmt', $properties, 'Schema properties array has "modified_gmt" key.' );
 	}
 
 	/**
-	 * @covers Gutenberg_REST_Global_Styles_Revisions_Controller::get_item_permissions_check
+	 * @ticket 58524
+	 *
+	 * @covers WP_REST_Global_Styles_Controller::get_item_permissions_check
 	 */
 	public function test_get_item_permissions_check() {
 		wp_set_current_user( self::$author_id );
@@ -190,10 +384,404 @@ class Gutenberg_REST_Global_Styles_Revisions_Controller_Test extends WP_Test_RES
 	}
 
 	/**
+	 * Tests the pagination header of the first page.
+	 *
+	 * Duplicate of WP_Test_REST_Revisions_Controller::test_get_items_pagination_header_of_the_first_page
+	 *
+	 * @ticket 58524
+	 *
+	 * @covers WP_REST_Global_Styles_Controller::get_items
+	 */
+	public function test_get_items_pagination_header_of_the_first_page() {
+		wp_set_current_user( self::$admin_id );
+
+		$rest_route  = '/wp/v2/global-styles/' . self::$global_styles_id . '/revisions';
+		$per_page    = 2;
+		$total_pages = (int) ceil( $this->total_revisions / $per_page );
+		$page        = 1;  // First page.
+
+		$request = new WP_REST_Request( 'GET', $rest_route );
+		$request->set_query_params(
+			array(
+				'per_page' => $per_page,
+				'page'     => $page,
+			)
+		);
+		$response = rest_get_server()->dispatch( $request );
+		$headers  = $response->get_headers();
+		$this->assertSame( $this->total_revisions, $headers['X-WP-Total'] );
+		$this->assertSame( $total_pages, $headers['X-WP-TotalPages'] );
+		$next_link = add_query_arg(
+			array(
+				'per_page' => $per_page,
+				'page'     => $page + 1,
+			),
+			rest_url( $rest_route )
+		);
+		$this->assertStringNotContainsString( 'rel="prev"', $headers['Link'] );
+		$this->assertStringContainsString( '<' . $next_link . '>; rel="next"', $headers['Link'] );
+	}
+
+	/**
+	 * Tests the pagination header of the last page.
+	 *
+	 * Duplicate of WP_Test_REST_Revisions_Controller::test_get_items_pagination_header_of_the_last_page
+	 *
+	 * @ticket 58524
+	 *
+	 * @covers WP_REST_Global_Styles_Controller::get_items
+	 */
+	public function test_get_items_pagination_header_of_the_last_page() {
+		wp_set_current_user( self::$admin_id );
+
+		$rest_route  = '/wp/v2/global-styles/' . self::$global_styles_id . '/revisions';
+		$per_page    = 2;
+		$total_pages = (int) ceil( $this->total_revisions / $per_page );
+		$page        = 2;  // Last page.
+
+		$request = new WP_REST_Request( 'GET', $rest_route );
+		$request->set_query_params(
+			array(
+				'per_page' => $per_page,
+				'page'     => $page,
+			)
+		);
+		$response = rest_get_server()->dispatch( $request );
+		$headers  = $response->get_headers();
+		$this->assertSame( $this->total_revisions, $headers['X-WP-Total'] );
+		$this->assertSame( $total_pages, $headers['X-WP-TotalPages'] );
+		$prev_link = add_query_arg(
+			array(
+				'per_page' => $per_page,
+				'page'     => $page - 1,
+			),
+			rest_url( $rest_route )
+		);
+		$this->assertStringContainsString( '<' . $prev_link . '>; rel="prev"', $headers['Link'] );
+	}
+
+	/**
+	 * Tests that invalid 'per_page' query should error.
+	 *
+	 * Duplicate of WP_Test_REST_Revisions_Controller::test_get_items_invalid_per_page_should_error
+	 *
+	 * @ticket 58524
+	 *
+	 * @covers WP_REST_Global_Styles_Controller::get_items
+	 */
+	public function test_get_items_invalid_per_page_should_error() {
+		wp_set_current_user( self::$admin_id );
+
+		$per_page        = -1; // Invalid number.
+		$expected_error  = 'rest_invalid_param';
+		$expected_status = 400;
+
+		$request = new WP_REST_Request( 'GET', '/wp/v2/global-styles/' . self::$global_styles_id . '/revisions' );
+		$request->set_param( 'per_page', $per_page );
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertErrorResponse( $expected_error, $response, $expected_status );
+	}
+
+	/**
+	 * Tests that out of bounds 'page' query should error.
+	 *
+	 * Duplicate of WP_Test_REST_Revisions_Controller::test_get_items_out_of_bounds_page_should_error
+	 *
+	 * @ticket 58524
+	 *
+	 * @covers WP_REST_Global_Styles_Controller::get_items
+	 */
+	public function test_get_items_out_of_bounds_page_should_error() {
+		wp_set_current_user( self::$admin_id );
+
+		$per_page        = 2;
+		$total_pages     = (int) ceil( $this->total_revisions / $per_page );
+		$page            = $total_pages + 1; // Out of bound page.
+		$expected_error  = 'rest_revision_invalid_page_number';
+		$expected_status = 400;
+
+		$request = new WP_REST_Request( 'GET', '/wp/v2/global-styles/' . self::$global_styles_id . '/revisions' );
+		$request->set_query_params(
+			array(
+				'per_page' => $per_page,
+				'page'     => $page,
+			)
+		);
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertErrorResponse( $expected_error, $response, $expected_status );
+	}
+
+	/**
+	 * Tests that impossibly high 'page' query should error.
+	 *
+	 * Duplicate of WP_Test_REST_Revisions_Controller::test_get_items_invalid_max_pages_should_error
+	 *
+	 * @ticket 58524
+	 *
+	 * @covers WP_REST_Global_Styles_Controller::get_items
+	 */
+	public function test_get_items_invalid_max_pages_should_error() {
+		wp_set_current_user( self::$admin_id );
+
+		$per_page        = 2;
+		$page            = REST_TESTS_IMPOSSIBLY_HIGH_NUMBER; // Invalid number.
+		$expected_error  = 'rest_revision_invalid_page_number';
+		$expected_status = 400;
+
+		$request = new WP_REST_Request( 'GET', '/wp/v2/global-styles/' . self::$global_styles_id . '/revisions' );
+		$request->set_query_params(
+			array(
+				'per_page' => $per_page,
+				'page'     => $page,
+			)
+		);
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertErrorResponse( $expected_error, $response, $expected_status );
+	}
+
+	/**
+	 * Tests that the default query should fetch all revisions.
+	 *
+	 * Duplicate of WP_Test_REST_Revisions_Controller::test_get_items_default_query_should_fetch_all_revisons
+	 *
+	 * @ticket 58524
+	 *
+	 * @covers WP_REST_Global_Styles_Controller::get_items
+	 */
+	public function test_get_items_default_query_should_fetch_all_revisons() {
+		wp_set_current_user( self::$admin_id );
+
+		$expected_count = $this->total_revisions;
+
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/global-styles/' . self::$global_styles_id . '/revisions' );
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertCount( $expected_count, $response->get_data() );
+	}
+
+	/**
+	 * Tests that 'offset' query shouldn't work without 'per_page' (fallback -1).
+	 *
+	 * Duplicate of WP_Test_REST_Revisions_Controller::test_get_items_offset_should_not_work_without_per_page
+	 *
+	 * @ticket 58524
+	 *
+	 * @covers WP_REST_Global_Styles_Controller::get_items
+	 */
+	public function test_get_items_offset_should_not_work_without_per_page() {
+		wp_set_current_user( self::$admin_id );
+
+		$offset         = 1;
+		$expected_count = $this->total_revisions;
+
+		$request = new WP_REST_Request( 'GET', '/wp/v2/global-styles/' . self::$global_styles_id . '/revisions' );
+		$request->set_param( 'offset', $offset );
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertCount( $expected_count, $response->get_data() );
+	}
+
+	/**
+	 * Tests that 'offset' query should work with 'per_page'.
+	 *
+	 * Duplicate of WP_Test_REST_Revisions_Controller::test_get_items_offset_should_work_with_per_page
+	 *
+	 * @ticket 58524
+	 *
+	 * @covers WP_REST_Global_Styles_Controller::get_items
+	 */
+	public function test_get_items_offset_should_work_with_per_page() {
+		wp_set_current_user( self::$admin_id );
+
+		$per_page       = 2;
+		$offset         = 1;
+		$expected_count = 2;
+
+		$request = new WP_REST_Request( 'GET', '/wp/v2/global-styles/' . self::$global_styles_id . '/revisions' );
+		$request->set_query_params(
+			array(
+				'offset'   => $offset,
+				'per_page' => $per_page,
+			)
+		);
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertCount( $expected_count, $response->get_data() );
+	}
+
+	/**
+	 * Tests that 'offset' query should take priority over 'page'.
+	 *
+	 * Duplicate of WP_Test_REST_Revisions_Controller::test_get_items_offset_should_take_priority_over_page
+	 *
+	 * @ticket 58524
+	 *
+	 * @covers WP_REST_Global_Styles_Controller::get_items
+	 */
+	public function test_get_items_offset_should_take_priority_over_page() {
+		wp_set_current_user( self::$admin_id );
+
+		$per_page       = 2;
+		$offset         = 1;
+		$page           = 1;
+		$expected_count = 2;
+
+		$request = new WP_REST_Request( 'GET', '/wp/v2/global-styles/' . self::$global_styles_id . '/revisions' );
+		$request->set_query_params(
+			array(
+				'offset'   => $offset,
+				'per_page' => $per_page,
+				'page'     => $page,
+			)
+		);
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertCount( $expected_count, $response->get_data() );
+	}
+
+	/**
+	 * Tests that 'offset' query, as the total revisions count, should return empty data.
+	 *
+	 * Duplicate of WP_Test_REST_Revisions_Controller::test_get_items_total_revisions_offset_should_return_empty_data
+	 *
+	 * @ticket 58524
+	 *
+	 * @covers WP_REST_Global_Styles_Controller::get_items
+	 */
+	public function test_get_items_total_revisions_offset_should_return_empty_data() {
+		wp_set_current_user( self::$admin_id );
+
+		$per_page        = 2;
+		$offset          = $this->total_revisions;
+		$expected_error  = 'rest_revision_invalid_offset_number';
+		$expected_status = 400;
+
+		$request = new WP_REST_Request( 'GET', '/wp/v2/global-styles/' . self::$global_styles_id . '/revisions' );
+		$request->set_query_params(
+			array(
+				'offset'   => $offset,
+				'per_page' => $per_page,
+			)
+		);
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertErrorResponse( $expected_error, $response, $expected_status );
+	}
+
+	/**
+	 * Tests that out of bound 'offset' query should error.
+	 *
+	 * Duplicate of WP_Test_REST_Revisions_Controller::test_get_items_out_of_bound_offset_should_error
+	 *
+	 * @ticket 58524
+	 *
+	 * @covers WP_REST_Global_Styles_Controller::get_items
+	 */
+	public function test_get_items_out_of_bound_offset_should_error() {
+		wp_set_current_user( self::$admin_id );
+
+		$per_page        = 2;
+		$offset          = $this->total_revisions + 1;
+		$expected_error  = 'rest_revision_invalid_offset_number';
+		$expected_status = 400;
+
+		$request = new WP_REST_Request( 'GET', '/wp/v2/global-styles/' . self::$global_styles_id . '/revisions' );
+		$request->set_query_params(
+			array(
+				'offset'   => $offset,
+				'per_page' => $per_page,
+			)
+		);
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertErrorResponse( $expected_error, $response, $expected_status );
+	}
+
+	/**
+	 * Tests that impossible high number for 'offset' query should error.
+	 *
+	 * Duplicate of WP_Test_REST_Revisions_Controller::test_get_items_impossible_high_number_offset_should_error
+	 *
+	 * @ticket 58524
+	 *
+	 * @covers WP_REST_Global_Styles_Controller::get_items
+	 */
+	public function test_get_items_impossible_high_number_offset_should_error() {
+		wp_set_current_user( self::$admin_id );
+
+		$per_page        = 2;
+		$offset          = REST_TESTS_IMPOSSIBLY_HIGH_NUMBER;
+		$expected_error  = 'rest_revision_invalid_offset_number';
+		$expected_status = 400;
+
+		$request = new WP_REST_Request( 'GET', '/wp/v2/global-styles/' . self::$global_styles_id . '/revisions' );
+		$request->set_query_params(
+			array(
+				'offset'   => $offset,
+				'per_page' => $per_page,
+			)
+		);
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertErrorResponse( $expected_error, $response, $expected_status );
+	}
+
+	/**
+	 * Tests that invalid 'offset' query should error.
+	 *
+	 * Duplicate of WP_Test_REST_Revisions_Controller::test_get_items_invalid_offset_should_error
+	 *
+	 * @ticket 58524
+	 *
+	 * @covers WP_REST_Global_Styles_Controller::get_items
+	 */
+	public function test_get_items_invalid_offset_should_error() {
+		wp_set_current_user( self::$admin_id );
+
+		$per_page        = 2;
+		$offset          = 'moreplease';
+		$expected_error  = 'rest_invalid_param';
+		$expected_status = 400;
+
+		$request = new WP_REST_Request( 'GET', '/wp/v2/global-styles/' . self::$global_styles_id . '/revisions' );
+		$request->set_query_params(
+			array(
+				'offset'   => $offset,
+				'per_page' => $per_page,
+			)
+		);
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertErrorResponse( $expected_error, $response, $expected_status );
+	}
+
+	/**
+	 * Tests that out of bounds 'page' query should not error when offset is provided,
+	 * because it takes precedence.
+	 *
+	 * Duplicate of WP_Test_REST_Revisions_Controller::test_get_items_out_of_bounds_page_should_not_error_if_offset
+	 *
+	 * @ticket 58524
+	 *
+	 * @covers WP_REST_Global_Styles_Controller::get_items
+	 */
+	public function test_get_items_out_of_bounds_page_should_not_error_if_offset() {
+		wp_set_current_user( self::$admin_id );
+
+		$per_page       = 2;
+		$total_pages    = (int) ceil( $this->total_revisions / $per_page );
+		$page           = $total_pages + 1; // Out of bound page.
+		$expected_count = 2;
+
+		$request = new WP_REST_Request( 'GET', '/wp/v2/global-styles/' . self::$global_styles_id . '/revisions' );
+		$request->set_query_params(
+			array(
+				'offset'   => 1,
+				'per_page' => $per_page,
+				'page'     => $page,
+			)
+		);
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertCount( $expected_count, $response->get_data() );
+	}
+
+	/**
 	 * @doesNotPerformAssertions
 	 */
 	public function test_context_param() {
-		// Controller does not use get_context_param().
+		// Controller does not implement test_context_param().
 	}
 
 	/**


### PR DESCRIPTION
## What?
Backport changes to the Global styles revisions endpoint from Core to Gutenberg.

Changes include:
- pagination
- request headers `X-Wp-Total` and `X-Wp-Totalpages`
- new tests

See: https://github.com/WordPress/wordpress-develop/pull/4606


## Testing Instructions
Check that there are no regressions. Check out the test description over at https://github.com/WordPress/gutenberg/pull/50089

A quick way to test the endpoint in the site editor, fire up this branch and head over to the site editor.

In your browser's console, switch to the network tab and run the following :

```js
await wp.apiFetch( { url: `/index.php?rest_route=%2Fwp%2Fv2%2Fglobal-styles%2F${ wp.data.select('core').__experimentalGetCurrentGlobalStylesId() }%2Frevisions&_locale=user` } );
```

Run PHP unit tests:

```shell
npm run test:unit:php -- --filter Gutenberg_REST_Global_Styles_Revisions_Controller_Test
```

For the `/global-styles/<id>/revisions` endpoint, check that the response headers are set:

<img width="784" alt="Screenshot 2023-06-29 at 12 45 04 pm" src="https://github.com/WordPress/gutenberg/assets/6458278/9ad8688d-58b5-41d8-aefe-85cca3909db7">
