### PR TITLE
Move grid function kses patch into 6.3 compat folder.

### DIFF
--- a/lib/compat/wordpress-6.3/kses.php
+++ b/lib/compat/wordpress-6.3/kses.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Temporary compatibility shims for kses rules present in Gutenberg.
+ *
+ * The functions in this file should not be backported to core.
+ *
+ * @package gutenberg
+ */
+
+/**
+ * Mark CSS safe if it contains grid functions
+ *
+ * This function should not be backported to core.
+ *
+ * @param bool   $allow_css Whether the CSS is allowed.
+ * @param string $css_test_string The CSS to test.
+ */
+function allow_grid_functions_in_styles( $allow_css, $css_test_string ) {
+	if ( preg_match(
+		'/^grid-template-columns:\s*repeat\([0-9,a-z-\s\(\)]*\)$/',
+		$css_test_string
+	) ) {
+		return true;
+	}
+	return $allow_css;
+}
+add_filter( 'safecss_filter_attr_allow_css', 'allow_grid_functions_in_styles', 10, 2 );

--- a/lib/experimental/kses.php
+++ b/lib/experimental/kses.php
@@ -87,22 +87,3 @@ function allow_filter_in_styles( $allow_css, $css_test_string ) {
 }
 
 add_filter( 'safecss_filter_attr_allow_css', 'allow_filter_in_styles', 10, 2 );
-
-/**
- * Mark CSS safe if it contains grid functions
- *
- * This function should not be backported to core.
- *
- * @param bool   $allow_css Whether the CSS is allowed.
- * @param string $css_test_string The CSS to test.
- */
-function allow_grid_functions_in_styles( $allow_css, $css_test_string ) {
-	if ( preg_match(
-		'/^grid-template-columns:\s*repeat\([0-9,a-z-\s\(\)]*\)$/',
-		$css_test_string
-	) ) {
-		return true;
-	}
-	return $allow_css;
-}
-add_filter( 'safecss_filter_attr_allow_css', 'allow_grid_functions_in_styles', 10, 2 );

--- a/lib/load.php
+++ b/lib/load.php
@@ -56,6 +56,7 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 	require_once __DIR__ . '/compat/wordpress-6.3/navigation-block-preloading.php';
 	require_once __DIR__ . '/compat/wordpress-6.3/link-template.php';
 	require_once __DIR__ . '/compat/wordpress-6.3/block-patterns.php';
+	require_once __DIR__ . '/compat/wordpress-6.3/kses.php';
 
 	// Experimental.
 	if ( ! class_exists( 'WP_Rest_Customizer_Nonces' ) ) {

--- a/lib/load.php
+++ b/lib/load.php
@@ -56,7 +56,6 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 	require_once __DIR__ . '/compat/wordpress-6.3/navigation-block-preloading.php';
 	require_once __DIR__ . '/compat/wordpress-6.3/link-template.php';
 	require_once __DIR__ . '/compat/wordpress-6.3/block-patterns.php';
-	require_once __DIR__ . '/compat/wordpress-6.3/kses.php';
 
 	// Experimental.
 	if ( ! class_exists( 'WP_Rest_Customizer_Nonces' ) ) {
@@ -99,6 +98,7 @@ require __DIR__ . '/compat/wordpress-6.3/script-loader.php';
 require __DIR__ . '/compat/wordpress-6.3/blocks.php';
 require __DIR__ . '/compat/wordpress-6.3/navigation-fallback.php';
 require __DIR__ . '/compat/wordpress-6.3/block-editor-settings.php';
+require_once __DIR__ . '/compat/wordpress-6.3/kses.php';
 
 // Experimental features.
 remove_action( 'plugins_loaded', '_wp_theme_json_webfonts_handler' ); // Turns off WP 6.0's stopgap handler for Webfonts API.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Now that kses support for CSS grid functions[ is in core (WP 6.3)](https://core.trac.wordpress.org/ticket/58551), the Gutenberg patch for it can be moved into the 6.3 compat folder.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Enable the Grid experiment in the plugin experiments page. 
2. Add a Grid block to a page and check that it displays correctly in the front end. 
3. Choose "grid" layout type in the Post Template block.
4. Save and check that Post Template grid displays correctly in the front end. 

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
