### PR TITLE
Image block and behaviors: Fix some warnings

### DIFF
--- a/lib/experimental/interactivity-api/blocks.php
+++ b/lib/experimental/interactivity-api/blocks.php
@@ -15,7 +15,9 @@
  */
 function gutenberg_block_update_interactive_view_script( $metadata ) {
 	if (
+		array_key_exists( 'name', $metadata ) &&
 		in_array( $metadata['name'], array( 'core/image' ), true ) &&
+		array_key_exists( 'file', $metadata ) &&
 		str_contains( $metadata['file'], 'build/block-library/blocks' )
 	) {
 		$metadata['viewScript'] = array( 'file:./view-interactivity.min.js' );

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -607,7 +607,8 @@ export default function Image( {
 		const ratio =
 			( aspectRatio && evalAspectRatio( aspectRatio ) ) ||
 			( width && height && width / height ) ||
-			naturalWidth / naturalHeight;
+			naturalWidth / naturalHeight ||
+			1;
 
 		const currentWidth = ! width && height ? height * ratio : width;
 		const currentHeight = ! height && width ? width / ratio : height;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
While working on another features I found a couple of warnings. This PR fixes them.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
A warning is not as dangerous as an error, but still is better not to have them.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
The first warning, by making sure if an array key exists before calling it in
The second one, setting a default number value for an expected number variable.

## Screenshots or screencast <!-- if applicable -->

First warning:
![Screenshot 2023-06-29 at 12 02 31](https://github.com/WordPress/gutenberg/assets/37012961/f1ab49f3-5847-4639-ab13-c3a92badf43c)

Second warning:
![Screenshot 2023-06-29 at 12 06 14](https://github.com/WordPress/gutenberg/assets/37012961/bb7f8901-7240-4461-82f3-558cc948cbc0)
