### PR TITLE
Fix the `exsisting` -> `existing` typo

### DIFF
--- a/lib/experimental/interactivity-api/class-wp-interactivity-store.php
+++ b/lib/experimental/interactivity-api/class-wp-interactivity-store.php
@@ -37,7 +37,7 @@ class WP_Interactivity_Store {
 	/**
 	 * Merge data.
 	 *
-	 * @param array $data The data that will be merged with the exsisting store.
+	 * @param array $data The data that will be merged with the existing store.
 	 */
 	static function merge_data( $data ) {
 		self::$store = array_replace_recursive( self::$store, $data );

--- a/lib/experimental/interactivity-api/store.php
+++ b/lib/experimental/interactivity-api/store.php
@@ -7,9 +7,9 @@
  */
 
 /**
- * Merge data with the exsisting store.
+ * Merge data with the existing store.
  *
- * @param array $data Data that will be merged with the exsisting store.
+ * @param array $data Data that will be merged with the existing store.
  *
  * @return $data The current store data.
  */


### PR DESCRIPTION
Merely fixing the typo in the code comments.