### PR TITLE
Fix history back after entering edit mode from Patterns

### DIFF
--- a/packages/edit-site/src/components/page-library/grid-item.js
+++ b/packages/edit-site/src/components/page-library/grid-item.js
@@ -52,7 +52,6 @@ export default function GridItem( { categoryId, composite, icon, item } ) {
 		postId: item.type === USER_PATTERNS ? item.id : item.name,
 		categoryId,
 		categoryType: item.type,
-		canvas: 'view',
 	} );
 
 	const onKeyDown = ( event ) => {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What and why?
<!-- In a few words, what is the PR actually doing? -->
Fix hitting browser's back button doesn't return to the view mode in Patterns.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Remove the `canvas: view` query parameter. I'm not sure why this is the fix, maybe it has something to do with the syncing logic in `use-sync-canvas-mode-with-url`?

This param was introduced in #51897 by @getdave. I'm not sure if this change has any unwanted side-effect, so would be appreciated if you could help double-check it? 🙇 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
1. Go to Site Editor -> Library (might be renamed to Patterns)
2. Click on a pattern and enter the edit mode
3. Click browser's back button
4. Expect the sidebar to open

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
TBD

## Screenshots or screencast <!-- if applicable -->
Before:

https://github.com/WordPress/gutenberg/assets/7753001/5e951ee4-6819-4d48-969c-f3c13596c978

After:

https://github.com/WordPress/gutenberg/assets/7753001/469e0b7f-b0f0-49f4-9a60-eb20c7cc670b


