### PR TITLE
Navigation: Remove one preloaded endpoint

### DIFF
--- a/lib/compat/wordpress-6.3/navigation-block-preloading.php
+++ b/lib/compat/wordpress-6.3/navigation-block-preloading.php
@@ -27,24 +27,6 @@ function gutenberg_preload_navigation_posts( $preload_paths, $context ) {
 	// Preload the OPTIONS request for all Navigation posts request.
 	$preload_paths[] = array( $navigation_rest_route, 'OPTIONS' );
 
-	// Preload the GET request for ALL 'published' or 'draft' Navigation posts.
-	$preload_paths[] = array(
-		add_query_arg(
-			array(
-				'context'   => 'edit',
-				'per_page'  => 100,
-				'order'     => 'desc',
-				'orderby'   => 'date',
-				'_locale'   => 'user',
-				// array indices are required to avoid query being encoded and not matching in cache.
-				'status[0]' => 'publish',
-				'status[1]' => 'draft',
-			),
-			$navigation_rest_route
-		),
-		'GET',
-	);
-
 	// Preload request for all menus in Browse Mode sidebar "Navigation" section.
 	$preload_paths[] = array(
 		add_query_arg(


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This removes one preloaded endpoint, since its not used anymore. Fixes #51803.

## Why?
This will improve loading speeds and performance generally.

## How?
Just remove the extra endpoint from the array.

## Testing Instructions
0. Open the console, and open the network tab. Filter by `navigation?context`
1. Open the Site Editor
2. Open the navigation section
3. Confirm that you don't see anything in the network tab
