### PR TITLE
Page List: Change modal text

### DIFF
--- a/packages/block-library/src/page-list/convert-to-links-modal.js
+++ b/packages/block-library/src/page-list/convert-to-links-modal.js
@@ -5,7 +5,7 @@ import { Button, Modal } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 export const convertDescription = __(
-	'This page list is synced with the published pages on your site. Unsync the page list to add, delete, or reorder pages yourself.'
+	'This page list is synced with the published pages on your site. Detach the page list to add, delete, or reorder pages yourself.'
 );
 
 export function ConvertToLinksModal( { onClick, onClose, disabled } ) {

--- a/packages/block-library/src/page-list/convert-to-links-modal.js
+++ b/packages/block-library/src/page-list/convert-to-links-modal.js
@@ -5,14 +5,14 @@ import { Button, Modal } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 export const convertDescription = __(
-	'This menu is automatically kept in sync with pages on your site. You can manage the menu yourself by clicking "Edit" below.'
+	'This page list is synced with the published pages on your site. Unsync the page list to add, delete, or reorder pages yourself.'
 );
 
 export function ConvertToLinksModal( { onClick, onClose, disabled } ) {
 	return (
 		<Modal
 			onRequestClose={ onClose }
-			title={ __( 'Edit this menu' ) }
+			title={ __( 'Edit Page List' ) }
 			className={ 'wp-block-page-list-modal' }
 			aria={ {
 				describedby: 'wp-block-page-list-modal__description',
@@ -30,7 +30,7 @@ export function ConvertToLinksModal( { onClick, onClose, disabled } ) {
 					disabled={ disabled }
 					onClick={ onClick }
 				>
-					{ __( 'Edit' ) }
+					{ __( 'Unsync' ) }
 				</Button>
 			</div>
 		</Modal>

--- a/packages/block-library/src/page-list/convert-to-links-modal.js
+++ b/packages/block-library/src/page-list/convert-to-links-modal.js
@@ -30,7 +30,7 @@ export function ConvertToLinksModal( { onClick, onClose, disabled } ) {
 					disabled={ disabled }
 					onClick={ onClick }
 				>
-					{ __( 'Unsync' ) }
+					{ __( 'Detach' ) }
 				</Button>
 			</div>
 		</Modal>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Updates the modal text as per https://github.com/WordPress/gutenberg/issues/51789. Fixes https://github.com/WordPress/gutenberg/issues/51789.

## Why?
The current copy doesn't make sense when there are multiple page list blocks in a navigation. This copy makes it clearer to the user what is going on.

## How?
Just text changes.

## Testing Instructions
1. Add a page list block to your navigation
2. Drag the items around to reorder them
3. You should see the modal appear with the new copy:

Edit Page List
This page list is synced with the published pages on your site. Unsync the page list to add, delete, or reorder pages yourself.

Cancel / Unsync

## Screenshots or screencast <!-- if applicable -->
<img width="525" alt="Screenshot 2023-06-29 at 12 41 16" src="https://github.com/WordPress/gutenberg/assets/275961/f66e0443-f9f9-4ad4-bc2b-97c59932b0be">
