### PR TITLE
Turn off DFM for style book and style editing

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen-global-styles/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-global-styles/index.js
@@ -37,17 +37,27 @@ export function SidebarNavigationItemGlobalStyles( props ) {
 	const { setCanvasMode } = unlock( useDispatch( editSiteStore ) );
 	const { createNotice } = useDispatch( noticesStore );
 	const { set: setPreference } = useDispatch( preferencesStore );
-	const { hasGlobalStyleVariations, isDistractionFree } = useSelect(
-		( select ) => ( {
-			hasGlobalStyleVariations:
-				!! select(
-					coreStore
-				).__experimentalGetCurrentThemeGlobalStylesVariations()?.length,
-			isDistractionFree: select( preferencesStore ).get(
-				editSiteStore.name,
-				'distractionFree'
-			),
-		} ),
+	const { get: getPrefference } = useSelect( preferencesStore );
+
+	const turnOffDistractionFreeMode = useCallback( () => {
+		const isDistractionFree = getPrefference(
+			editSiteStore.name,
+			'distractionFree'
+		);
+		if ( ! isDistractionFree ) {
+			return;
+		}
+		setPreference( editSiteStore.name, 'distractionFree', false );
+		createNotice( 'info', __( 'Distraction free mode turned off' ), {
+			isDismissible: true,
+			type: 'snackbar',
+		} );
+	}, [ createNotice, setPreference, getPrefference ] );
+	const hasGlobalStyleVariations = useSelect(
+		( select ) =>
+			!! select(
+				coreStore
+			).__experimentalGetCurrentThemeGlobalStylesVariations()?.length,
 		[]
 	);
 	if ( hasGlobalStyleVariations ) {
@@ -63,19 +73,7 @@ export function SidebarNavigationItemGlobalStyles( props ) {
 		<SidebarNavigationItem
 			{ ...props }
 			onClick={ () => {
-				// Disable distraction free mode.
-				if ( isDistractionFree ) {
-					setPreference(
-						editSiteStore.name,
-						'distractionFree',
-						false
-					);
-					createNotice(
-						'info',
-						__( 'Distraction free mode turned off.' ),
-						{ type: 'snackbar' }
-					);
-				}
+				turnOffDistractionFreeMode();
 				// Switch to edit mode.
 				setCanvasMode( 'edit' );
 				// Open global styles sidebar.
@@ -170,6 +168,9 @@ export default function SidebarNavigationScreenGlobalStyles() {
 	const { setCanvasMode, setEditorCanvasContainerView } = unlock(
 		useDispatch( editSiteStore )
 	);
+	const { createNotice } = useDispatch( noticesStore );
+	const { set: setPreference } = useDispatch( preferencesStore );
+	const { get: getPrefference } = useSelect( preferencesStore );
 
 	const isStyleBookOpened = useSelect(
 		( select ) =>
@@ -178,13 +179,29 @@ export default function SidebarNavigationScreenGlobalStyles() {
 		[]
 	);
 
+	const turnOffDistractionFreeMode = useCallback( () => {
+		const isDistractionFree = getPrefference(
+			editSiteStore.name,
+			'distractionFree'
+		);
+		if ( ! isDistractionFree ) {
+			return;
+		}
+		setPreference( editSiteStore.name, 'distractionFree', false );
+		createNotice( 'info', __( 'Distraction free mode turned off' ), {
+			isDismissible: true,
+			type: 'snackbar',
+		} );
+	}, [ createNotice, setPreference, getPrefference ] );
+
 	const openGlobalStyles = useCallback(
 		async () =>
 			Promise.all( [
 				setCanvasMode( 'edit' ),
 				openGeneralSidebar( 'edit-site/global-styles' ),
+				turnOffDistractionFreeMode(),
 			] ),
-		[ setCanvasMode, openGeneralSidebar ]
+		[ setCanvasMode, openGeneralSidebar, turnOffDistractionFreeMode ]
 	);
 
 	const openStyleBook = useCallback( async () => {

--- a/packages/edit-site/src/components/sidebar-navigation-screen-global-styles/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-global-styles/index.js
@@ -194,15 +194,13 @@ export default function SidebarNavigationScreenGlobalStyles() {
 		} );
 	}, [ createNotice, setPreference, getPrefference ] );
 
-	const openGlobalStyles = useCallback(
-		async () =>
-			Promise.all( [
-				setCanvasMode( 'edit' ),
-				openGeneralSidebar( 'edit-site/global-styles' ),
-				turnOffDistractionFreeMode(),
-			] ),
-		[ setCanvasMode, openGeneralSidebar, turnOffDistractionFreeMode ]
-	);
+	const openGlobalStyles = useCallback( async () => {
+		turnOffDistractionFreeMode();
+		return Promise.all( [
+			setCanvasMode( 'edit' ),
+			openGeneralSidebar( 'edit-site/global-styles' ),
+		] );
+	}, [ setCanvasMode, openGeneralSidebar, turnOffDistractionFreeMode ] );
 
 	const openStyleBook = useCallback( async () => {
 		await openGlobalStyles();


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Continues #52090

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

There are two other entry paths to style editor and style book in the site editor sidebar that need to automatically turn off distraction free mode.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Refactor the code a bit.
Introduce a clear function that turns off DFM and creates a notice.
Get the preference with the dedicated getter.
Repeat the code in two components.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Using TwentyTwentyThree theme 
2. Visit the styles link in the site editor's sidebar
3. You see the list of theme styles
4. In the top right corner of the sidebar there are two buttons: an eye and a pencil
5. When these buttons are clicked DFM is turned off

## Screenshots or screencast <!-- if applicable -->


https://github.com/WordPress/gutenberg/assets/107534/fc95f8cb-c078-48ef-b141-c4820e554799


