### PR TITLE
Block Editor: Add README for FontFamilyControl component

### DIFF
--- a/packages/block-editor/src/components/font-family/README.md
+++ b/packages/block-editor/src/components/font-family/README.md
@@ -4,8 +4,9 @@ FontFamilyControl is a React component that renders a UI that allows users to se
 The component renders a user interface that allows the user to select from a set of predefined font families as defined by the `typography.fontFamilies` presets.
 Optionally, you can provide a `fontFamilies` prop that overrides the predefined font families.
 
-## Usage
+![FontFamilyControl component preview](https://i.imgur.com/blS5iA3.png)
 
+## Usage
 
 ```jsx
 import { FontFamilyControl } from '@wordpress/block-editor';

--- a/packages/block-editor/src/components/font-family/README.md
+++ b/packages/block-editor/src/components/font-family/README.md
@@ -1,0 +1,70 @@
+# FontFamilyControl
+
+FontFamilyControl is a React component that renders a UI that allows users to select a font family.
+The component renders a user interface that allows the user to select from a set of predefined font families as defined by the `typography.fontFamilies` presets.
+Optionally, you can provide a `fontFamilies` prop that overrides the predefined font families.
+
+## Usage
+
+
+```jsx
+import { FontFamilyControl } from '@wordpress/block-editor';
+import { useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+// ...
+
+const MyFontFamilyControl = () => {
+	const [ fontFamily, setFontFamily ] = useState( '' );
+
+	return (
+		<FontFamilyControl
+			value={ fontFamily }
+			onChange={ ( newFontFamily ) => {
+				setFontFamily( newFontFamily );
+			} }
+		/>
+	);
+};
+
+/// ...
+
+<MyFontFamilyControl />
+```
+
+## Props
+
+The component accepts the following props:
+
+### onChange
+
+A function that receives the new font family value.
+If onChange is called without any parameter, it should reset the value, attending to what reset means in that context, e.g., set the font family to undefined or set the font family a starting value.
+
+- Type: `function`
+- Required: Yes
+
+### fontFamilies
+
+A user-provided set of font families.
+Optional, used in case we want to override the predefined ones coming from presets.
+
+- Type: `Array`
+- Required: No
+
+The font families are provided as an array of objects with the following schema:
+
+| Property   | Description                               | Type   |
+| ---------- | ----------------------------------------- | ------ |
+| fontFamily | Font family, as used in CSS.              | string |
+| name       | Optional display name of the font family. | string |
+
+### value
+
+The current font family value.
+
+- Type: `String`
+- Required: No
+- Default: ''
+
+The rest of the props are passed down to the underlying `<SelectControl />` instance.


### PR DESCRIPTION
## What?
This PR adds a README for the `FontFamilyControl` component.

Fixes #52052.

## Why?
Part of #22891 where we aim to document all block editor components.

## How?
Just adding a README.

## Testing Instructions
Not needed.

### Testing Instructions for Keyboard
None.

## Screenshots or screencast <!-- if applicable -->
None.