### PR TITLE
Drop-indicator: remove white border.

### DIFF
--- a/packages/block-editor/src/components/list-view/style.scss
+++ b/packages/block-editor/src/components/list-view/style.scss
@@ -408,8 +408,7 @@ $block-navigation-max-indent: 8;
 
 	.block-editor-list-view-drop-indicator__line {
 		background: var(--wp-admin-theme-color);
-		height: 6px;
-		border: 1px solid $white;
+		height: 4px;
 		border-radius: 4px;
 	}
 }


### PR DESCRIPTION
## What?

The drop indicator when dragging/dropping menu items in the site editor has a white halo:

<img width="566" alt="before" src="https://github.com/WordPress/gutenberg/assets/1204802/c836a862-e6a8-4500-9249-618a1433f462">

This PR removes it:

<img width="356" alt="after" src="https://github.com/WordPress/gutenberg/assets/1204802/add582d9-1143-4d12-be3e-edaa4c128edb">

## Why?

Removing the halo makes the drop indicator the same as it is in the list view:

<img width="243" alt="Screenshot 2023-06-29 at 14 31 18" src="https://github.com/WordPress/gutenberg/assets/1204802/040acbc4-59e2-4f1e-8ea2-372117242e85">

## Testing Instructions

Create a navigation menu, edit it in the site editor site view. Click and drag an item to sort it, and observe only a blue line drop indicator.