### PR TITLE
Update fixed block toolbar

### DIFF
--- a/packages/block-editor/src/components/block-tools/block-contextual-toolbar.js
+++ b/packages/block-editor/src/components/block-tools/block-contextual-toolbar.js
@@ -15,7 +15,7 @@ import {
 	ToolbarButton,
 	ToolbarGroup,
 } from '@wordpress/components';
-import { levelUp } from '@wordpress/icons';
+import { next, previous } from '@wordpress/icons';
 import { useViewportMatch } from '@wordpress/compose';
 
 /**
@@ -24,7 +24,6 @@ import { useViewportMatch } from '@wordpress/compose';
 import NavigableToolbar from '../navigable-toolbar';
 import BlockToolbar from '../block-toolbar';
 import { store as blockEditorStore } from '../../store';
-import BlockIcon from '../block-icon';
 import { unlock } from '../../lock-unlock';
 
 function BlockContextualToolbar( { focusOnMount, isFixed, ...props } ) {
@@ -94,6 +93,7 @@ function BlockContextualToolbar( { focusOnMount, isFixed, ...props } ) {
 			aria-label={ __( 'Block tools' ) }
 			{ ...props }
 		>
+			{ ! isCollapsed && <BlockToolbar hideDragHandle={ isFixed } /> }
 			{ isFixed && isLargeViewport && blockType && (
 				<ToolbarGroup
 					className={
@@ -105,13 +105,7 @@ function BlockContextualToolbar( { focusOnMount, isFixed, ...props } ) {
 					<ToolbarItem
 						as={ ToolbarButton }
 						ref={ toolbarButtonRef }
-						icon={
-							isCollapsed ? (
-								<BlockIcon icon={ blockType.icon } />
-							) : (
-								levelUp
-							)
-						}
+						icon={ isCollapsed ? next : previous }
 						onClick={ () => {
 							setIsCollapsed( ( collapsed ) => ! collapsed );
 							toolbarButtonRef.current.focus();
@@ -124,7 +118,6 @@ function BlockContextualToolbar( { focusOnMount, isFixed, ...props } ) {
 					/>
 				</ToolbarGroup>
 			) }
-			{ ! isCollapsed && <BlockToolbar hideDragHandle={ isFixed } /> }
 		</NavigableToolbar>
 	);
 }

--- a/packages/block-editor/src/components/block-tools/block-contextual-toolbar.js
+++ b/packages/block-editor/src/components/block-tools/block-contextual-toolbar.js
@@ -113,7 +113,7 @@ function BlockContextualToolbar( { focusOnMount, isFixed, ...props } ) {
 						label={
 							isCollapsed
 								? __( 'Show block tools' )
-								: __( 'Show document tools' )
+								: __( 'Hide block tools' )
 						}
 					/>
 				</ToolbarGroup>

--- a/packages/block-editor/src/components/block-tools/style.scss
+++ b/packages/block-editor/src/components/block-tools/style.scss
@@ -131,8 +131,8 @@
 	@include break-medium() {
 		&.is-fixed {
 
-			// leave room for block inserter
-			margin-left: $grid-unit-80;
+			// leave room for block inserter, undo and redo
+			margin-left: $grid-unit-80 * 3;
 			// position on top of interface header
 			position: fixed;
 			top: $admin-bar-height + $grid-unit;
@@ -145,22 +145,37 @@
 
 			&.is-collapsed {
 				width: initial;
-				margin-left: $grid-unit-80 * 3 + $grid-unit-30;
+				// leave room for block inserter, undo and redo
+				margin-left: $grid-unit-80 * 3;
 			}
 
 			.is-fullscreen-mode & {
-				// leave room for block inserter
-				margin-left: $grid-unit-80 + $grid-unit-70;
+				// leave room for block inserter, undo and redo
+				margin-left: $grid-unit-80 * 4;
 				top: $grid-unit;
 				&.is-collapsed {
 					width: initial;
-					margin-left: $grid-unit-80 * 4 + $grid-unit-30;
+					// leave room for block inserter, undo and redo
+					margin-left: $grid-unit-80 * 4;
 				}
 			}
 
 			& > .block-editor-block-toolbar.is-showing-movers {
 				flex-grow: initial;
 				width: initial;
+
+				// Add a border as separator in the block toolbar.
+				&::before {
+					content: "";
+					width: $border-width;
+					height: 26px;
+					margin-top: $grid-unit + $grid-unit-05;
+					margin-right: 0;
+					background-color: $gray-300;
+					position: relative;
+					left: -$grid-unit-05;
+					top: -1px;
+				}
 			}
 
 			& > .block-editor-block-toolbar__group-collapse-fixed-toolbar {
@@ -239,12 +254,14 @@
 		}
 
 		&.is-fixed .block-editor-block-parent-selector {
+
 			.block-editor-block-parent-selector__button {
 				position: relative;
 				top: -1px;
 				border: 0;
 				padding-right: 6px;
 				padding-left: 6px;
+
 				&::after {
 					content: "\00B7";
 					font-size: 16px;

--- a/packages/block-editor/src/components/block-tools/style.scss
+++ b/packages/block-editor/src/components/block-tools/style.scss
@@ -131,11 +131,11 @@
 	@include break-medium() {
 		&.is-fixed {
 
-			// leave room for block inserter, undo and redo
-			margin-left: $grid-unit-80 * 3;
+			// leave room for block inserter, undo and redo, list view
+			margin-left: $grid-unit-80 * 3 - 2 * $grid-unit + $grid-unit-05;
 			// position on top of interface header
 			position: fixed;
-			top: $admin-bar-height + $grid-unit;
+			top: $admin-bar-height + $grid-unit - $border-width;
 			// Don't fill up when empty
 			min-height: initial;
 			// remove the border
@@ -145,18 +145,15 @@
 
 			&.is-collapsed {
 				width: initial;
-				// leave room for block inserter, undo and redo
-				margin-left: $grid-unit-80 * 3;
 			}
 
 			.is-fullscreen-mode & {
-				// leave room for block inserter, undo and redo
-				margin-left: $grid-unit-80 * 4;
-				top: $grid-unit;
+				// leave room for block inserter, undo and redo, list view
+				// and some margin left
+				margin-left: $grid-unit-80 * 4 - 2 * $grid-unit + $grid-unit-05;
+				top: $grid-unit - $border-width;
 				&.is-collapsed {
 					width: initial;
-					// leave room for block inserter, undo and redo
-					margin-left: $grid-unit-80 * 4;
 				}
 			}
 
@@ -168,7 +165,7 @@
 				&::before {
 					content: "";
 					width: $border-width;
-					height: 26px;
+					height: 3 * $grid-unit;
 					margin-top: $grid-unit + $grid-unit-05;
 					margin-right: 0;
 					background-color: $gray-300;
@@ -181,11 +178,25 @@
 			& > .block-editor-block-toolbar__group-collapse-fixed-toolbar {
 				border: none;
 
+				.show-icon-labels & {
+					.components-button.has-icon {
+						// Hide the button icons when labels are set to display...
+						svg {
+							display: none;
+						}
+						// ... and display labels.
+						&::after {
+							content: attr(aria-label);
+							font-size: $helptext-font-size;
+						}
+					}
+				}
+
 				// Add a border as separator in the block toolbar.
 				&::before {
 					content: "";
 					width: $border-width;
-					height: 26px;
+					height: 3 * $grid-unit;
 					margin-top: $grid-unit + $grid-unit-05;
 					margin-right: $grid-unit-10;
 					background-color: $gray-300;
@@ -198,6 +209,20 @@
 			& > .block-editor-block-toolbar__group-expand-fixed-toolbar {
 				border: none;
 
+				.show-icon-labels & {
+					.components-button.has-icon {
+						// Hide the button icons when labels are set to display...
+						svg {
+							display: none;
+						}
+						// ... and display labels.
+						&::after {
+							content: attr(aria-label);
+							font-size: $helptext-font-size;
+						}
+					}
+				}
+
 				// Add a border as separator in the block toolbar.
 				&::before {
 					content: "";
@@ -206,26 +231,19 @@
 					margin-bottom: $grid-unit + $grid-unit-05;
 					background-color: $gray-300;
 					position: relative;
-					left: -10px; //the padding of buttons
-					height: 26px;
+					left: -10px;
+					height: 3 * $grid-unit;
+					top: -1px;
 				}
 			}
 
 			.show-icon-labels & {
 
-				margin-left: $grid-unit-80;
-
-				&.is-collapsed {
-					margin-left: $grid-unit-80 * 6;
-				}
+				margin-left: $grid-unit-80 + 2 * $grid-unit; // inserter and margin ;
 
 				.is-fullscreen-mode & {
-					margin-left: $grid-unit-80 + $grid-unit-80;
-					&.is-collapsed {
-						margin-left: $grid-unit-80 * 7;
-					}
+					margin-left: $grid-unit * 18; // site hub, inserter and margin
 				}
-
 
 				.block-editor-block-parent-selector .block-editor-block-parent-selector__button::after {
 					left: 0;

--- a/packages/block-editor/src/components/block-tools/style.scss
+++ b/packages/block-editor/src/components/block-tools/style.scss
@@ -143,10 +143,6 @@
 			// has to be flex for collapse button to fit
 			display: flex;
 
-			//hide overflow and scroll
-			overflow: hidden;
-			overflow-x: scroll;
-
 			&.is-collapsed {
 				width: initial;
 			}

--- a/packages/block-editor/src/components/block-tools/style.scss
+++ b/packages/block-editor/src/components/block-tools/style.scss
@@ -158,19 +158,24 @@
 				}
 			}
 
+			& > .block-editor-block-toolbar.is-showing-movers {
+				flex-grow: initial;
+				width: initial;
+			}
+
 			& > .block-editor-block-toolbar__group-collapse-fixed-toolbar {
 				border: none;
 
 				// Add a border as separator in the block toolbar.
-				&::after {
+				&::before {
 					content: "";
 					width: $border-width;
-					height: 24px;
+					height: 26px;
 					margin-top: $grid-unit + $grid-unit-05;
-					margin-bottom: $grid-unit + $grid-unit-05;
+					margin-right: $grid-unit-10;
 					background-color: $gray-300;
-					position: absolute;
-					left: 44px;
+					position: relative;
+					left: 0;
 					top: -1px;
 				}
 			}
@@ -186,8 +191,8 @@
 					margin-bottom: $grid-unit + $grid-unit-05;
 					background-color: $gray-300;
 					position: relative;
-					left: -12px; //the padding of buttons
-					height: 24px;
+					left: -10px; //the padding of buttons
+					height: 26px;
 				}
 			}
 

--- a/packages/block-editor/src/components/block-tools/style.scss
+++ b/packages/block-editor/src/components/block-tools/style.scss
@@ -143,6 +143,10 @@
 			// has to be flex for collapse button to fit
 			display: flex;
 
+			//hide overflow and scroll
+			overflow: hidden;
+			overflow-x: scroll;
+
 			&.is-collapsed {
 				width: initial;
 			}
@@ -150,7 +154,7 @@
 			.is-fullscreen-mode & {
 				// leave room for block inserter, undo and redo, list view
 				// and some margin left
-				margin-left: $grid-unit-80 * 4 - 2 * $grid-unit + $grid-unit-05;
+				margin-left: $grid-unit-80 * 4 - 2 * $grid-unit;
 				top: $grid-unit - $border-width;
 				&.is-collapsed {
 					width: initial;
@@ -170,7 +174,7 @@
 					margin-right: 0;
 					background-color: $gray-300;
 					position: relative;
-					left: -$grid-unit-05;
+					left: math.div(-$grid-unit-05, 2);
 					top: -1px;
 				}
 			}
@@ -210,6 +214,7 @@
 				border: none;
 
 				.show-icon-labels & {
+					width: $grid-unit-80 * 4;
 					.components-button.has-icon {
 						// Hide the button icons when labels are set to display...
 						svg {
@@ -231,7 +236,7 @@
 					margin-bottom: $grid-unit + $grid-unit-05;
 					background-color: $gray-300;
 					position: relative;
-					left: -10px;
+					left: -8px;
 					height: 3 * $grid-unit;
 					top: -1px;
 				}
@@ -321,7 +326,9 @@
 	// for the block inserter the publish button
 	@include break-large() {
 		&.is-fixed {
-			width: initial;
+			// the combined with of the tools at the right of the header and the margin left
+			// of the toolbar which includes four buttons
+			width: calc(100% - 240px - #{4 * $grid-unit-80});
 		}
 	}
 

--- a/packages/edit-post/src/components/header/header-toolbar/index.js
+++ b/packages/edit-post/src/components/header/header-toolbar/index.js
@@ -19,6 +19,7 @@ import { Button, ToolbarItem } from '@wordpress/components';
 import { listView, plus } from '@wordpress/icons';
 import { useRef, useCallback } from '@wordpress/element';
 import { store as keyboardShortcutsStore } from '@wordpress/keyboard-shortcuts';
+import { store as preferencesStore } from '@wordpress/preferences';
 
 /**
  * Internal dependencies
@@ -36,6 +37,8 @@ function HeaderToolbar() {
 	const inserterButton = useRef();
 	const { setIsInserterOpened, setIsListViewOpened } =
 		useDispatch( editPostStore );
+	const { get: getPreference } = useSelect( preferencesStore );
+	const hasFixedToolbar = getPreference( 'core/edit-post', 'fixedToolbar' );
 	const {
 		isInserterEnabled,
 		isInserterOpened,
@@ -147,7 +150,7 @@ function HeaderToolbar() {
 				/>
 				{ ( isWideViewport || ! showIconLabels ) && (
 					<>
-						{ isLargeViewport && (
+						{ isLargeViewport && ! hasFixedToolbar && (
 							<ToolbarItem
 								as={ ToolSelector }
 								showTooltip={ ! showIconLabels }

--- a/packages/edit-site/src/components/header-edit-mode/document-actions/style.scss
+++ b/packages/edit-site/src/components/header-edit-mode/document-actions/style.scss
@@ -16,6 +16,14 @@
 		color: currentColor;
 		background: $gray-200;
 	}
+
+	@include break-medium() {
+		width: 50%;
+	}
+
+	@include break-large() {
+		width: min(100%, 450px);
+	}
 }
 
 .edit-site-document-actions__command {

--- a/packages/edit-site/src/components/header-edit-mode/index.js
+++ b/packages/edit-site/src/components/header-edit-mode/index.js
@@ -108,6 +108,9 @@ export default function HeaderEditMode() {
 		};
 	}, [] );
 
+	const { get: getPreference } = useSelect( preferencesStore );
+	const hasFixedToolbar = getPreference( editSiteStore.name, 'fixedToolbar' );
+
 	const {
 		__experimentalSetPreviewDeviceType: setPreviewDeviceType,
 		setIsInserterOpened,
@@ -213,14 +216,18 @@ export default function HeaderEditMode() {
 						) }
 						{ isLargeViewport && (
 							<>
-								<ToolbarItem
-									as={ ToolSelector }
-									showTooltip={ ! showIconLabels }
-									variant={
-										showIconLabels ? 'tertiary' : undefined
-									}
-									disabled={ ! isVisualMode }
-								/>
+								{ ! hasFixedToolbar && (
+									<ToolbarItem
+										as={ ToolSelector }
+										showTooltip={ ! showIconLabels }
+										variant={
+											showIconLabels
+												? 'tertiary'
+												: undefined
+										}
+										disabled={ ! isVisualMode }
+									/>
+								) }
 								<ToolbarItem
 									as={ UndoButton }
 									showTooltip={ ! showIconLabels }

--- a/packages/edit-site/src/components/header-edit-mode/index.js
+++ b/packages/edit-site/src/components/header-edit-mode/index.js
@@ -264,7 +264,8 @@ export default function HeaderEditMode() {
 									/>
 								) }
 								{ isZoomedOutViewExperimentEnabled &&
-									! isDistractionFree && (
+									! isDistractionFree &&
+									! hasFixedToolbar && (
 										<ToolbarItem
 											as={ Button }
 											className="edit-site-header-edit-mode__zoom-out-view-toggle"

--- a/packages/edit-site/src/components/layout/style.scss
+++ b/packages/edit-site/src/components/layout/style.scss
@@ -4,18 +4,6 @@
 	color: $gray-400;
 	display: flex;
 	flex-direction: column;
-
-	// Expand the fixed block toolbar to cover the document title control.
-	.block-editor-block-contextual-toolbar {
-		@include break-medium() {
-			&.is-fixed {
-				// the combined with of the tools at the right of the header and the margin left
-				// of the toolbar which includes four buttons
-				width: calc(100% - 240px - #{4 * $grid-unit-80});
-			}
-		}
-	}
-
 }
 
 .edit-site-layout__hub {

--- a/packages/edit-site/src/components/layout/style.scss
+++ b/packages/edit-site/src/components/layout/style.scss
@@ -10,7 +10,8 @@
 		@include break-medium() {
 			&.is-fixed {
 				// the combined with of the tools at the right of the header and the margin left
-				width: calc(100% - 240px - #{$grid-unit-80} - #{$grid-unit-70});
+				// of the toolbar which includes four buttons
+				width: calc(100% - 240px - #{4 * $grid-unit-80});
 			}
 		}
 	}

--- a/test/e2e/specs/editor/various/shortcut-focus-toolbar.spec.js
+++ b/test/e2e/specs/editor/various/shortcut-focus-toolbar.spec.js
@@ -254,7 +254,7 @@ class ToolbarUtils {
 			exact: true,
 		} );
 		this.blockToolbarShowDocumentButton = this.page.getByRole( 'button', {
-			name: 'Show document tools',
+			name: 'Hide block tools',
 			exact: true,
 		} );
 	}

--- a/test/e2e/specs/editor/various/shortcut-focus-toolbar.spec.js
+++ b/test/e2e/specs/editor/various/shortcut-focus-toolbar.spec.js
@@ -100,11 +100,8 @@ test.describe( 'Focus toolbar shortcut (alt + F10)', () => {
 			await editor.insertBlock( { name: 'core/paragraph' } );
 			await toolbarUtils.moveToToolbarShortcut();
 			await expect(
-				toolbarUtils.blockToolbarShowDocumentButton
+				toolbarUtils.blockToolbarParagraphButton
 			).toBeFocused();
-			await expect(
-				toolbarUtils.documentToolbarTooltip
-			).not.toBeVisible();
 
 			// Test: Focus the block toolbar from paragraph block with content
 			await editor.insertBlock( { name: 'core/paragraph' } );
@@ -113,11 +110,8 @@ test.describe( 'Focus toolbar shortcut (alt + F10)', () => {
 			);
 			await toolbarUtils.moveToToolbarShortcut();
 			await expect(
-				toolbarUtils.blockToolbarShowDocumentButton
+				toolbarUtils.blockToolbarParagraphButton
 			).toBeFocused();
-			await expect(
-				toolbarUtils.documentToolbarTooltip
-			).not.toBeVisible();
 		} );
 
 		test( 'Focuses the correct toolbar in select mode', async ( {
@@ -135,11 +129,8 @@ test.describe( 'Focus toolbar shortcut (alt + F10)', () => {
 			await toolbarUtils.useSelectMode();
 			await toolbarUtils.moveToToolbarShortcut();
 			await expect(
-				toolbarUtils.blockToolbarShowDocumentButton
+				toolbarUtils.blockToolbarParagraphButton
 			).toBeFocused();
-			await expect(
-				toolbarUtils.documentToolbarTooltip
-			).not.toBeVisible();
 
 			// Test: Focus the block toolbar from paragraph in select mode
 			await editor.insertBlock( { name: 'core/paragraph' } );
@@ -149,11 +140,8 @@ test.describe( 'Focus toolbar shortcut (alt + F10)', () => {
 			await toolbarUtils.useSelectMode();
 			await toolbarUtils.moveToToolbarShortcut();
 			await expect(
-				toolbarUtils.blockToolbarShowDocumentButton
+				toolbarUtils.blockToolbarParagraphButton
 			).toBeFocused();
-			await expect(
-				toolbarUtils.documentToolbarTooltip
-			).not.toBeVisible();
 		} );
 	} );
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Closes #51711

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

To improve the UX of using fixed block toolbar by:

- making the icons more clearly convey the result of collapse and expand action on the fixed toolbar
- allowing undo and redo to always be available
- saving some space

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

- [x] Update the icons for the expand and collapse buttons
- [x] Hide the Tools item in document tools when top toolbar preference is on
- [x] Move the position of the top toolbar to uncover undo and redo

## Testing Instructions

- In the site editor
- Toggle the top toolbar preference to on from the dot menu in the top right corner
- Select a block
- The block toolbar should have the new double horizontal chevron collapse and expand icons
- The block toolbar should not cover the undo and redo items in the document tools
- The Tools item in the document tools should be hidden

## Screenshots or screencast <!-- if applicable -->


https://github.com/WordPress/gutenberg/assets/107534/e2ec1e7f-045a-47ac-bfe6-e3dd85338aec

