### PR TITLE
Image block: fix aspect ratio sizing in the editor preview

### DIFF
--- a/packages/block-library/src/image/editor.scss
+++ b/packages/block-library/src/image/editor.scss
@@ -1,6 +1,9 @@
 // Provide special styling for the placeholder.
 // @todo: this particular minimal style of placeholder could be componentized further.
 .wp-block-image.wp-block-image {
+	// Using "display: flex" so the size of the drag handles do not affect the size of the block.
+	display: flex;
+
 	// Show Placeholder style on-select.
 	&.is-selected .components-placeholder {
 		// Block UI appearance.
@@ -66,10 +69,9 @@ figure.wp-block-image:not(.wp-block) {
 
 // This is necessary for the editor resize handles to accurately work on a non-floated, non-resized, small image.
 .wp-block-image .components-resizable-box__container {
-	// Using "display: table" because:
-	// - it visually hides empty white space in between elements
-	// - it allows the element to be as wide as its contents (instead of 100% width, as it would be with `display: block`)
-	display: table;
+	// Using "display: inline-flex" so the element is as wide as its contents and object-fit still works.
+	display: inline-flex;
+
 	img {
 		display: block;
 		width: inherit;

--- a/packages/block-library/src/image/editor.scss
+++ b/packages/block-library/src/image/editor.scss
@@ -74,8 +74,8 @@ figure.wp-block-image:not(.wp-block) {
 
 	img {
 		display: block;
-		width: inherit;
-		height: inherit;
+		width: 100%;
+		height: 100%;
 	}
 }
 

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -563,10 +563,6 @@ export default function Image( {
 				ref={ imageRef }
 				className={ borderProps.className }
 				style={ {
-					width:
-						( width && height ) || aspectRatio ? '100%' : undefined,
-					height:
-						( width && height ) || aspectRatio ? '100%' : undefined,
 					objectFit: scale,
 					...borderProps.style,
 				} }
@@ -663,12 +659,7 @@ export default function Image( {
 		img = (
 			<ResizableBox
 				style={ {
-					display: 'block',
-					objectFit: scale,
-					aspectRatio:
-						! width && ! height && aspectRatio
-							? aspectRatio
-							: undefined,
+					aspectRatio: ! width && ! height && aspectRatio,
 				} }
 				size={ {
 					width: currentWidth ?? 'auto',


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes an issue where images that were smaller than the width of the page and only had an aspect ratio set were being scaled up in the editor.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Bug fix

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Played around with the `display` properties of the image and resizable box container and removed 100% `width` and `height` in some cases.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

This is content for every possible combination of width/height/scale/aspect-ratio for the image block. Be sure to use an image that is smaller than the width of the page and one that doesn't have a 3:4 portrait aspect ratio (as that's the ratio set in the example).

```html
<!-- wp:heading -->
<h2 class="wp-block-heading">Default Block</h2>
<!-- /wp:heading -->

<!-- wp:image {"id":443,"sizeSlug":"full","linkDestination":"none"} -->
<figure class="wp-block-image size-full"><img src="http://wp.local/wp-content/uploads/2023/06/a2-small.jpg" alt="" class="wp-image-443"/></figure>
<!-- /wp:image -->

<!-- wp:heading -->
<h2 class="wp-block-heading">Width</h2>
<!-- /wp:heading -->

<!-- wp:image {"id":443,"width":200,"sizeSlug":"full","linkDestination":"none"} -->
<figure class="wp-block-image size-full is-resized"><img src="http://wp.local/wp-content/uploads/2023/06/a2-small.jpg" alt="" class="wp-image-443" width="200"/></figure>
<!-- /wp:image -->

<!-- wp:heading -->
<h2 class="wp-block-heading">Height</h2>
<!-- /wp:heading -->

<!-- wp:image {"id":443,"height":150,"sizeSlug":"full","linkDestination":"none"} -->
<figure class="wp-block-image size-full is-resized"><img src="http://wp.local/wp-content/uploads/2023/06/a2-small.jpg" alt="" class="wp-image-443" height="150"/></figure>
<!-- /wp:image -->

<!-- wp:heading -->
<h2 class="wp-block-heading">Ratio Scale</h2>
<!-- /wp:heading -->

<!-- wp:image {"id":443,"aspectRatio":"3/4","scale":"cover","sizeSlug":"full","linkDestination":"none"} -->
<figure class="wp-block-image size-full"><img src="http://wp.local/wp-content/uploads/2023/06/a2-small.jpg" alt="" class="wp-image-443" style="aspect-ratio:3/4;object-fit:cover"/></figure>
<!-- /wp:image -->

<!-- wp:heading -->
<h2 class="wp-block-heading">Ratio Scale Width</h2>
<!-- /wp:heading -->

<!-- wp:image {"id":443,"width":200,"aspectRatio":"3/4","scale":"cover","sizeSlug":"full","linkDestination":"none"} -->
<figure class="wp-block-image size-full is-resized"><img src="http://wp.local/wp-content/uploads/2023/06/a2-small.jpg" alt="" class="wp-image-443" style="aspect-ratio:3/4;object-fit:cover" width="200"/></figure>
<!-- /wp:image -->

<!-- wp:heading -->
<h2 class="wp-block-heading">Ratio Scale Height</h2>
<!-- /wp:heading -->

<!-- wp:image {"id":443,"height":267,"aspectRatio":"3/4","scale":"cover","sizeSlug":"full","linkDestination":"none"} -->
<figure class="wp-block-image size-full is-resized"><img src="http://wp.local/wp-content/uploads/2023/06/a2-small.jpg" alt="" class="wp-image-443" style="aspect-ratio:3/4;object-fit:cover" height="267"/></figure>
<!-- /wp:image -->

<!-- wp:heading -->
<h2 class="wp-block-heading">Scale Width Height</h2>
<!-- /wp:heading -->

<!-- wp:image {"id":443,"width":200,"height":267,"scale":"cover","sizeSlug":"full","linkDestination":"none"} -->
<figure class="wp-block-image size-full is-resized"><img src="http://wp.local/wp-content/uploads/2023/06/a2-small.jpg" alt="" class="wp-image-443" style="object-fit:cover" width="200" height="267"/></figure>
<!-- /wp:image -->
```

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

![image-scale-fix](https://github.com/WordPress/gutenberg/assets/5129775/85c5634c-4b3d-4a0b-998d-002adccbecdc)

