### PR TITLE
Add @example tags to the customize-widgets package

### DIFF
--- a/docs/reference-guides/data/data-core-customize-widgets.md
+++ b/docs/reference-guides/data/data-core-customize-widgets.md
@@ -10,6 +10,24 @@ Namespace: `core/customize-widgets`.
 
 Returns true if the inserter is opened.
 
+_Usage_
+
+```js
+import { __ } from '@wordpress/i18n';
+import { useSelect } from '@wordpress/data';
+
+const ExampleComponent = () => {
+	const { isInserterOpened } = useSelect(
+		( select ) => select( 'core/customize-widgets' ),
+		[]
+	);
+
+	return isInserterOpened()
+		? __( 'Inserter is open' )
+		: __( 'Inserter is closed.' );
+};
+```
+
 _Parameters_
 
 -   _state_ `Object`: Global application state.

--- a/docs/reference-guides/data/data-core-customize-widgets.md
+++ b/docs/reference-guides/data/data-core-customize-widgets.md
@@ -13,12 +13,13 @@ Returns true if the inserter is opened.
 _Usage_
 
 ```js
+import { store as customizeWidgetsStore } from '@wordpress/customize-widgets';
 import { __ } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
 
 const ExampleComponent = () => {
 	const { isInserterOpened } = useSelect(
-		( select ) => select( 'core/customize-widgets' ),
+		( select ) => select( customizeWidgetsStore ),
 		[]
 	);
 
@@ -49,13 +50,14 @@ Returns an action object used to open/close the inserter.
 _Usage_
 
 ```js
+import { store as customizeWidgetsStore } from '@wordpress/customize-widgets';
 import { __ } from '@wordpress/i18n';
 import { useDispatch } from '@wordpress/data';
 import { Button } from '@wordpress/components';
 import { useState } from '@wordpress/element';
 
 const ExampleComponent = () => {
-	const { setIsInserterOpened } = useDispatch( 'core/customize-widgets' );
+	const { setIsInserterOpened } = useDispatch( customizeWidgetsStore );
 	const [ isOpen, setIsOpen ] = useState( false );
 
 	return (

--- a/docs/reference-guides/data/data-core-customize-widgets.md
+++ b/docs/reference-guides/data/data-core-customize-widgets.md
@@ -28,6 +28,31 @@ _Returns_
 
 Returns an action object used to open/close the inserter.
 
+_Usage_
+
+```js
+import { __ } from '@wordpress/i18n';
+import { useDispatch } from '@wordpress/data';
+import { Button } from '@wordpress/components';
+import { useState } from '@wordpress/element';
+
+const ExampleComponent = () => {
+	const { setIsInserterOpened } = useDispatch( 'core/customize-widgets' );
+	const [ isOpen, setIsOpen ] = useState( false );
+
+	return (
+		<Button
+			onClick={ () => {
+				setIsInserterOpened( ! isOpen );
+				setIsOpen( ! isOpen );
+			} }
+		>
+			{ __( 'Open/close inserter' ) }
+		</Button>
+	);
+};
+```
+
 _Parameters_
 
 -   _value_ `boolean|Object`: Whether the inserter should be opened (true) or closed (false). To specify an insertion point, use an object.

--- a/packages/customize-widgets/src/store/actions.js
+++ b/packages/customize-widgets/src/store/actions.js
@@ -10,13 +10,14 @@
  *
  * @example
  * ```js
+ * import { store as customizeWidgetsStore } from '@wordpress/customize-widgets';
  * import { __ } from '@wordpress/i18n';
  * import { useDispatch } from '@wordpress/data';
  * import { Button } from '@wordpress/components';
  * import { useState } from '@wordpress/element';
  *
  * const ExampleComponent = () => {
- *   const { setIsInserterOpened } = useDispatch( 'core/customize-widgets' );
+ *   const { setIsInserterOpened } = useDispatch( customizeWidgetsStore );
  *   const [ isOpen, setIsOpen ] = useState( false );
  *
  *    return (

--- a/packages/customize-widgets/src/store/actions.js
+++ b/packages/customize-widgets/src/store/actions.js
@@ -8,6 +8,30 @@
  * @param {string}         value.rootClientId   The root client ID to insert at.
  * @param {number}         value.insertionIndex The index to insert at.
  *
+ * @example
+ * ```js
+ * import { __ } from '@wordpress/i18n';
+ * import { useDispatch } from '@wordpress/data';
+ * import { Button } from '@wordpress/components';
+ * import { useState } from '@wordpress/element';
+ *
+ * const ExampleComponent = () => {
+ *   const { setIsInserterOpened } = useDispatch( 'core/customize-widgets' );
+ *   const [ isOpen, setIsOpen ] = useState( false );
+ *
+ *    return (
+ *        <Button
+ *            onClick={ () => {
+ *                setIsInserterOpened( ! isOpen );
+ *                setIsOpen( ! isOpen );
+ *            } }
+ *        >
+ *            { __( 'Open/close inserter' ) }
+ *        </Button>
+ *    );
+ * };
+ * ```
+ *
  * @return {Object} Action object.
  */
 export function setIsInserterOpened( value ) {

--- a/packages/customize-widgets/src/store/selectors.js
+++ b/packages/customize-widgets/src/store/selectors.js
@@ -3,6 +3,23 @@
  *
  * @param {Object} state Global application state.
  *
+ * @example
+ * ```js
+ * import { __ } from '@wordpress/i18n';
+ * import { useSelect } from '@wordpress/data';
+ *
+ * const ExampleComponent = () => {
+ *    const { isInserterOpened } = useSelect(
+ *        ( select ) => select( 'core/customize-widgets' ),
+ *        []
+ *    );
+ *
+ *    return isInserterOpened()
+ *        ? __( 'Inserter is open' )
+ *        : __( 'Inserter is closed.' );
+ *    };
+ * ```
+ *
  * @return {boolean} Whether the inserter is opened.
  */
 export function isInserterOpened( state ) {

--- a/packages/customize-widgets/src/store/selectors.js
+++ b/packages/customize-widgets/src/store/selectors.js
@@ -5,19 +5,20 @@
  *
  * @example
  * ```js
+ * import { store as customizeWidgetsStore } from '@wordpress/customize-widgets';
  * import { __ } from '@wordpress/i18n';
  * import { useSelect } from '@wordpress/data';
  *
  * const ExampleComponent = () => {
  *    const { isInserterOpened } = useSelect(
- *        ( select ) => select( 'core/customize-widgets' ),
+ *        ( select ) => select( customizeWidgetsStore ),
  *        []
  *    );
  *
  *    return isInserterOpened()
  *        ? __( 'Inserter is open' )
  *        : __( 'Inserter is closed.' );
- *    };
+ * };
  * ```
  *
  * @return {boolean} Whether the inserter is opened.


### PR DESCRIPTION
## What?
Adds working examples to the package as part of https://github.com/WordPress/gutenberg/issues/42125.