### PR TITLE
E2E Test Utils: Improve test reliability in plugins/themes and login procedures

### DIFF
--- a/packages/e2e-test-utils/src/install-plugin.js
+++ b/packages/e2e-test-utils/src/install-plugin.js
@@ -20,6 +20,8 @@ export async function installPlugin( slug, searchTerm ) {
 			'&tab=search&type=term'
 	);
 	await page.click( `.install-now[data-slug="${ slug }"]` );
-	await page.waitForSelector( `.activate-now[data-slug="${ slug }"]` );
+	await page.waitForSelector( `.activate-now[data-slug="${ slug }"]`, {
+		timeout: 60000
+	} );
 	await switchUserToTest();
 }

--- a/packages/e2e-test-utils/src/install-plugin.js
+++ b/packages/e2e-test-utils/src/install-plugin.js
@@ -21,7 +21,7 @@ export async function installPlugin( slug, searchTerm ) {
 	);
 	await page.click( `.install-now[data-slug="${ slug }"]` );
 	await page.waitForSelector( `.activate-now[data-slug="${ slug }"]`, {
-		timeout: 60000
+		timeout: 60000,
 	} );
 	await switchUserToTest();
 }

--- a/packages/e2e-test-utils/src/install-theme.js
+++ b/packages/e2e-test-utils/src/install-theme.js
@@ -37,6 +37,8 @@ export async function installTheme( slug, { searchTerm } = {} ) {
 
 	await page.waitForSelector( `.theme-install[data-slug="${ slug }"]` );
 	await page.click( `.theme-install[data-slug="${ slug }"]` );
-	await page.waitForSelector( `.theme[data-slug="${ slug }"] .activate` );
+	await page.waitForSelector( `.theme[data-slug="${ slug }"] .activate`, {
+		timeout: 60000
+	} );
 	await switchUserToTest();
 }

--- a/packages/e2e-test-utils/src/install-theme.js
+++ b/packages/e2e-test-utils/src/install-theme.js
@@ -38,7 +38,7 @@ export async function installTheme( slug, { searchTerm } = {} ) {
 	await page.waitForSelector( `.theme-install[data-slug="${ slug }"]` );
 	await page.click( `.theme-install[data-slug="${ slug }"]` );
 	await page.waitForSelector( `.theme[data-slug="${ slug }"] .activate`, {
-		timeout: 60000
+		timeout: 60000,
 	} );
 	await switchUserToTest();
 }

--- a/packages/e2e-test-utils/src/login-user.js
+++ b/packages/e2e-test-utils/src/login-user.js
@@ -30,8 +30,5 @@ export async function loginUser(
 	await page.type( '#user_pass', password );
 
 	const waitForLoginNavigation = page.waitForNavigation();
-	await Promise.all( [
-		waitForLoginNavigation,
-		page.click( '#wp-submit' ),
-	] );
+	await Promise.all( [ waitForLoginNavigation, page.click( '#wp-submit' ) ] );
 }

--- a/packages/e2e-test-utils/src/login-user.js
+++ b/packages/e2e-test-utils/src/login-user.js
@@ -17,7 +17,9 @@ export async function loginUser(
 	password = WP_PASSWORD
 ) {
 	if ( ! isCurrentURL( 'wp-login.php' ) ) {
+		const waitForLoginPageNavigation = page.waitForNavigation();
 		await page.goto( createURL( 'wp-login.php' ) );
+		await waitForLoginPageNavigation;
 	}
 
 	await page.focus( '#user_login' );
@@ -27,8 +29,9 @@ export async function loginUser(
 	await pressKeyWithModifier( 'primary', 'a' );
 	await page.type( '#user_pass', password );
 
+	const waitForLoginNavigation = page.waitForNavigation();
 	await Promise.all( [
-		page.waitForNavigation(),
+		waitForLoginNavigation,
 		page.click( '#wp-submit' ),
 	] );
 }


### PR DESCRIPTION
## What?
This PR improves the E2E utility package by adding/improving the use of `waitForNavigation()` promises in the login flow, and also introduces context-specific heightened timeout values when installing plugins and themes.

## Why?
E2E tests in core rely on the `e2e-test-utils` package, but it has been sporadic of late. The cause was tracked down to what appears to be race conditions within the login procedure, and timeouts when waiting for plugin or themes to be installed when a system is overloaded, or bandwidth is in any way restricted.

## How?
One of the login navigation procedures had a combined promise event watcher (using a `promise.all()` wrapper), but it still had no guarantee of them firing in the correct order, while another did not have a navigation promise at this time. The missing navigation now has such a promise, while the wrapper is retained, the navigation promise is prepared before it, and then the result of that promise is instead the dependency.

The other change is to introduce longer timeouts when installing plugins and themes. As these rely on outside factors, such as dick read/write availability, download speeds from WordPress.org, the default timeout of 30 seconds would periodically be exceeded. By setting this to 60 seconds (the default value for most webserver requests), we've observed consistent test runs, so introducing this as well in the E2E improvements seems sensible.
