### PR TITLE
Update mismatched package json files

### DIFF
--- a/bin/get-package-meta.js
+++ b/bin/get-package-meta.js
@@ -1,0 +1,59 @@
+/**
+ * External dependencies
+ */
+const { get } = require( 'https' );
+
+/**
+ * Gets basic npm package metadata given the npm package slug.
+ *
+ * @example (await getPackageMeta( 'react' ))[ 'dist-tags' ].latest // => '18.2.0'
+ *
+ * @param {string} packageSlug The package slug, like "npm" or "react" or "@wordpress/data"
+ * @return {Promise<Record<string, any>>} A promise which resolves to the npm package metadata. Rejects otherwise.
+ */
+function getPackageMeta( packageSlug ) {
+	return new Promise( ( resolve, reject ) => {
+		get(
+			`https://registry.npmjs.org/${ packageSlug }`,
+			{
+				headers: {
+					// By passing a specialized `Accept` header, the registry
+					// will return an abbreviated form of the package data which
+					// includes enough detail to determine the latest version.
+					//
+					// See: https://github.com/npm/registry/blob/HEAD/docs/responses/package-metadata.md
+					Accept: 'application/vnd.npm.install-v1+json',
+				},
+			},
+			async ( response ) => {
+				if ( response.statusCode !== 200 ) {
+					return reject(
+						new Error(
+							`Package data for ${ packageSlug } not found`
+						)
+					);
+				}
+
+				let body = '';
+				for await ( const chunk of response ) {
+					body += chunk.toString();
+				}
+
+				let data;
+				try {
+					data = JSON.parse( body );
+				} catch {
+					return reject(
+						new Error(
+							`Package data for ${ packageSlug } returned invalid response body`
+						)
+					);
+				}
+
+				resolve( data );
+			}
+		).on( 'error', reject );
+	} );
+}
+
+module.exports = getPackageMeta;

--- a/bin/packages/compare-local-package-versions-with-npm.js
+++ b/bin/packages/compare-local-package-versions-with-npm.js
@@ -54,7 +54,6 @@ async function compareLocalAndNpmPackageVersions() {
 		);
 
 	// Print info about mismatched packages.
-	console.log( mismatchedPackages );
 	if ( mismatchedPackages.length ) {
 		console.log(
 			`\n${ mismatchedPackages.length } packages have local versions which don't match npm:`

--- a/bin/packages/compare-local-package-versions-with-npm.js
+++ b/bin/packages/compare-local-package-versions-with-npm.js
@@ -1,0 +1,117 @@
+#!/usr/bin/env node
+/**
+ * External dependencies
+ */
+const fs = require( 'fs' );
+const path = require( 'path' );
+
+/**
+ * Internal dependencies
+ */
+const getPackages = require( './get-packages' );
+const getPackageMeta = require( '../get-package-meta.js' );
+
+/**
+ * This script verifies that the local npm package.json files match the versions
+ * published to npm. Rarely, the two can get out of sync, making it necessary
+ * to manually update the local package.json files.
+ */
+async function compareLocalAndNpmPackageVersions() {
+	const pkgWithVersions = await Promise.allSettled(
+		getPackages().map( async ( pkgPath ) => {
+			const slug = '@wordpress/' + path.basename( pkgPath );
+			return {
+				pkgPath,
+				slug,
+				pkgJsonPath: path.resolve( pkgPath, 'package.json' ),
+				latestVersion: await getNpmVersion( slug ),
+				localVersion: getPackageJson(
+					path.resolve( pkgPath, 'package.json' )
+				)?.version,
+			};
+		} )
+	);
+
+	// Print info about any packages which errored, but we likely don't care.
+	const rejectedIssues = pkgWithVersions.filter(
+		( { status } ) => status === 'rejected'
+	);
+	if ( rejectedIssues.length ) {
+		console.log(
+			"Some errors occurred. This probably just means the package isn't published:"
+		);
+		rejectedIssues.forEach( ( { reason } ) => console.log( reason ) );
+	}
+
+	// Find the packages which have versions that don't match npm.
+	const mismatchedPackages = pkgWithVersions
+		.filter( ( { status } ) => status === 'fulfilled' )
+		.map( ( { value } ) => value )
+		.filter(
+			( { latestVersion, localVersion } ) =>
+				localVersion !== latestVersion
+		);
+
+	// Print info about mismatched packages.
+	console.log( mismatchedPackages );
+	if ( mismatchedPackages.length ) {
+		console.log(
+			`\n${ mismatchedPackages.length } packages have local versions which don't match npm:`
+		);
+		mismatchedPackages.forEach(
+			( { pkgJsonPath, latestVersion, localVersion, slug } ) =>
+				console.log(
+					`Local: ${ localVersion }\tNpm: ${ latestVersion }\tName: ${ slug }. Path: ${ pkgJsonPath }`
+				)
+		);
+	} else {
+		console.log( 'No mismatching packages found.' );
+		process.exit( 0 );
+	}
+
+	// If we want to fix them, we can easily update the package.json files with the new versions!
+	if ( process.argv.includes( '--fix' ) ) {
+		console.log( 'Fixing local package.json files...' );
+		await Promise.all( mismatchedPackages.map( fixPackageJson ) );
+		console.log( 'Fixed the files!' );
+	}
+}
+
+compareLocalAndNpmPackageVersions();
+
+async function fixPackageJson( { pkgJsonPath, latestVersion, slug } ) {
+	const pkg = getPackageJson( pkgJsonPath );
+	if ( ! pkg ) {
+		console.log( `Couldn't read package.json for ${ slug }` );
+		return;
+	}
+	pkg.version = latestVersion;
+	await fs.promises.writeFile(
+		pkgJsonPath,
+		JSON.stringify( pkg, null, '\t' ) + '\n'
+	);
+}
+
+async function getNpmVersion( pkg ) {
+	const packageMeta = await getPackageMeta( pkg );
+	const latestVersion = packageMeta[ 'dist-tags' ].latest;
+	if ( ! latestVersion ) {
+		throw new Error( `Could not find version for ${ pkg }` );
+	}
+	return latestVersion;
+}
+
+function getPackageJson( pkgJsonPath ) {
+	let pkg;
+	try {
+		pkg = require( path.resolve( pkgJsonPath ) );
+	} catch ( e ) {
+		console.error( e );
+		// If, for whatever reason, the package's `package.json` cannot be read,
+		// consider it as an invalid candidate. In most cases, this can happen
+		// when lingering directories are left in the working path when changing
+		// to an older branch where a package did not yet exist.
+		return null;
+	}
+	return pkg;
+}

--- a/bin/packages/compare-local-package-versions-with-npm.js
+++ b/bin/packages/compare-local-package-versions-with-npm.js
@@ -14,7 +14,8 @@ const getPackageMeta = require( '../get-package-meta.js' );
 /**
  * This script verifies that the local npm package.json files match the versions
  * published to npm. Rarely, the two can get out of sync, making it necessary
- * to manually update the local package.json files.
+ * to update the local package.json files. Updating the package.json versions
+ * to the latest version can be done with the '--fix' flag.
  */
 async function compareLocalAndNpmPackageVersions() {
 	const pkgWithVersions = await Promise.allSettled(

--- a/bin/tsconfig.json
+++ b/bin/tsconfig.json
@@ -18,6 +18,7 @@
 	"files": [
 		"./api-docs/update-api-docs.js",
 		"./check-latest-npm.js",
+		"./get-package-meta.js",
 		"./plugin/config.js",
 		"./plugin/commands/changelog.js",
 		"./plugin/commands/performance.js",

--- a/packages/a11y/package.json
+++ b/packages/a11y/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/a11y",
-	"version": "3.35.0",
+	"version": "3.36.0",
 	"description": "Accessibility (a11y) utilities for WordPress.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/api-fetch/package.json
+++ b/packages/api-fetch/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/api-fetch",
-	"version": "6.32.0",
+	"version": "6.33.0",
 	"description": "Utility to make WordPress REST API requests.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/autop/package.json
+++ b/packages/autop/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/autop",
-	"version": "3.35.0",
+	"version": "3.36.0",
 	"description": "WordPress's automatic paragraph functions `autop` and `removep`.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/blob/package.json
+++ b/packages/blob/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/blob",
-	"version": "3.35.0",
+	"version": "3.36.0",
 	"description": "Blob utilities for WordPress.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/block-serialization-default-parser/package.json
+++ b/packages/block-serialization-default-parser/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/block-serialization-default-parser",
-	"version": "4.35.0",
+	"version": "4.36.0",
 	"description": "Block serialization specification parser for WordPress posts.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/date/package.json
+++ b/packages/date/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/date",
-	"version": "4.35.0",
+	"version": "4.36.0",
 	"description": "Date module for WordPress.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/deprecated/package.json
+++ b/packages/deprecated/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/deprecated",
-	"version": "3.35.0",
+	"version": "3.36.0",
 	"description": "Deprecation utility for WordPress.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/dom-ready/package.json
+++ b/packages/dom-ready/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/dom-ready",
-	"version": "3.35.0",
+	"version": "3.36.0",
 	"description": "Execute callback after the DOM is loaded.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/dom/package.json
+++ b/packages/dom/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/dom",
-	"version": "3.35.0",
+	"version": "3.36.0",
 	"description": "DOM utilities module for WordPress.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/element/package.json
+++ b/packages/element/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/element",
-	"version": "5.12.0",
+	"version": "5.13.0",
 	"description": "Element React module for WordPress.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/escape-html/package.json
+++ b/packages/escape-html/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/escape-html",
-	"version": "2.35.0",
+	"version": "2.36.0",
 	"description": "Escape HTML utils.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/hooks",
-	"version": "3.35.0",
+	"version": "3.36.0",
 	"description": "WordPress hooks library.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/html-entities/package.json
+++ b/packages/html-entities/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/html-entities",
-	"version": "3.35.0",
+	"version": "3.36.0",
 	"description": "HTML entity utilities for WordPress.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/i18n",
-	"version": "4.35.0",
+	"version": "4.36.0",
 	"description": "WordPress internationalization (i18n) library.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/is-shallow-equal/package.json
+++ b/packages/is-shallow-equal/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/is-shallow-equal",
-	"version": "4.35.0",
+	"version": "4.36.0",
 	"description": "Test for shallow equality between two objects or arrays.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/jest-console/package.json
+++ b/packages/jest-console/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/jest-console",
-	"version": "7.6.0",
+	"version": "7.7.0",
 	"description": "Custom Jest matchers for the Console object.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/jest-puppeteer-axe/package.json
+++ b/packages/jest-puppeteer-axe/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/jest-puppeteer-axe",
-	"version": "6.6.0",
+	"version": "6.7.0",
 	"description": "Axe API integration with Jest and Puppeteer.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/keycodes/package.json
+++ b/packages/keycodes/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/keycodes",
-	"version": "3.35.0",
+	"version": "3.36.0",
 	"description": "Keycodes utilities for WordPress. Used to check for keyboard events across browsers/operating systems.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/primitives/package.json
+++ b/packages/primitives/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/primitives",
-	"version": "3.33.0",
+	"version": "3.34.0",
 	"description": "WordPress cross-platform primitives.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/priority-queue/package.json
+++ b/packages/priority-queue/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/priority-queue",
-	"version": "2.35.0",
+	"version": "2.36.0",
 	"description": "Generic browser priority queue.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/private-apis/package.json
+++ b/packages/private-apis/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/private-apis",
-	"version": "0.17.0",
+	"version": "0.18.0",
 	"description": "Internal experimental APIs for WordPress core.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/redux-routine/package.json
+++ b/packages/redux-routine/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/redux-routine",
-	"version": "4.35.0",
+	"version": "4.36.0",
 	"description": "Redux middleware for generator coroutines.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/router",
-	"version": "0.4.0",
+	"version": "0.5.0",
 	"description": "Router API for WordPress pages.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/shortcode/package.json
+++ b/packages/shortcode/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/shortcode",
-	"version": "3.35.0",
+	"version": "3.36.0",
 	"description": "Shortcode module for WordPress.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/style-engine/package.json
+++ b/packages/style-engine/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/style-engine",
-	"version": "1.18.0",
+	"version": "1.19.0",
 	"description": "A suite of parsers and compilers for WordPress styles.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/token-list/package.json
+++ b/packages/token-list/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/token-list",
-	"version": "2.35.0",
+	"version": "2.36.0",
 	"description": "Constructable, plain JavaScript DOMTokenList implementation, supporting non-browser runtimes.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/url/package.json
+++ b/packages/url/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/url",
-	"version": "3.36.0",
+	"version": "3.37.0",
 	"description": "WordPress URL utilities.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/warning/package.json
+++ b/packages/warning/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/warning",
-	"version": "2.35.0",
+	"version": "2.36.0",
 	"description": "Warning utility for WordPress.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/wordcount/package.json
+++ b/packages/wordcount/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/wordcount",
-	"version": "3.35.0",
+	"version": "3.36.0",
 	"description": "WordPress word count utility.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Some folks noticed that our npm package versions don't match the local package.json files. (For example, `@wordpress/hooks` is at version 3.36.0 on npm, but 3.35.0 in the package.json file. This fixes those!

Question: Is it critical to also update the changelogs, or will the next release get those automatically? 

## Why?

I _think_ this happened whenever folks were releasing hotfixes for the WordPress release? I saw some Slack messages about needing something released quickly outside of the normal process. Because normally, these are all updated automatically by the package update process, so I'm guessing something in the process might have been accidentally skipped. 

## How?
I wrote a script which can find and fix these issues, because why not :P This script is just run ad-hoc, so I think the potential impact is low. In part of this, I split out a function from a different script so that we can re-use it more easily.

I then used that script to fix all these issues.

## Testing Instructions
code review. You can also execute the node scripts if you like (`node bin/packages/compare-local-package-versions-with-npm.js`) and (`node bin/packages/compare-local-package-versions-with-npm.js --fix`).

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
