### PR TITLE
Patterns: rename sync_status and move to top level field on rest return instead of a meta field

### DIFF
--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -372,3 +372,31 @@ function gutenberg_register_legacy_social_link_blocks() {
 }
 
 add_action( 'init', 'gutenberg_register_legacy_social_link_blocks' );
+
+/**
+ * Migrate the legacy `sync_status` meta key (added 16.1) to the new `wp_pattern_sync_status` meta key (16.1.1).
+ *
+ * This filter is INTENTIONALLY left out of core as the meta key was fist introduced to core in 6.3 as `wp_pattern_sync_status`.
+ * see https://github.com/WordPress/gutenberg/pull/52232
+ *
+ * @param mixed  $value     The value to return, either a single metadata value or an array of values depending on the value of $single.
+ * @param int    $object_id ID of the object metadata is for.
+ * @param string $meta_key  Metadata key.
+ * @param bool   $single    Whether to return only the first value of the specified $meta_key.
+ */
+function gutenberg_legacy_wp_block_post_meta( $value, $object_id, $meta_key, $single ) {
+	if ( 'wp_pattern_sync_status' !== $meta_key ) {
+		return $value;
+	}
+
+	$sync_status = get_post_meta( $object_id, 'sync_status', $single );
+
+	if ( $single && 'unsynced' === $sync_status ) {
+		return $sync_status;
+	} elseif ( isset( $sync_status[0] ) && 'unsynced' === $sync_status[0] ) {
+		return $sync_status;
+	}
+
+	return $value;
+}
+add_filter( 'default_post_metadata', 'gutenberg_legacy_wp_block_post_meta', 10, 4 );

--- a/lib/compat/wordpress-6.3/blocks.php
+++ b/lib/compat/wordpress-6.3/blocks.php
@@ -90,7 +90,7 @@ function gutenberg_add_custom_fields_to_wp_block( $args, $post_type ) {
 add_filter( 'register_post_type_args', 'gutenberg_add_custom_fields_to_wp_block', 10, 2 );
 
 /**
- * Adds sync_status meta fields to the wp_block post type so an unsynced option can be added.
+ * Adds wp_sync_status meta fields to the wp_block post type so an unsynced option can be added.
  *
  * Note: This should be removed when the minimum required WP version is >= 6.3.
  *
@@ -102,7 +102,7 @@ function gutenberg_wp_block_register_post_meta() {
 	$post_type = 'wp_block';
 	register_post_meta(
 		$post_type,
-		'sync_status',
+		'wp_sync_status',
 		array(
 			'auth_callback'     => function() {
 				return current_user_can( 'edit_posts' );
@@ -114,7 +114,7 @@ function gutenberg_wp_block_register_post_meta() {
 				'schema' => array(
 					'type'       => 'string',
 					'properties' => array(
-						'sync_status' => array(
+						'wp_sync_status' => array(
 							'type' => 'string',
 						),
 					),
@@ -124,7 +124,7 @@ function gutenberg_wp_block_register_post_meta() {
 	);
 }
 /**
- * Sanitizes the array of wp_block post meta sync_status string.
+ * Sanitizes the array of wp_block post meta wp_sync_status string.
  *
  * Note: This should be removed when the minimum required WP version is >= 6.3.
  *

--- a/lib/compat/wordpress-6.3/blocks.php
+++ b/lib/compat/wordpress-6.3/blocks.php
@@ -102,39 +102,21 @@ function gutenberg_wp_block_register_post_meta() {
 	$post_type = 'wp_block';
 	register_post_meta(
 		$post_type,
-		'wp_sync_status',
+		'wp_pattern_sync_status',
 		array(
 			'auth_callback'     => function() {
 				return current_user_can( 'edit_posts' );
 			},
-			'sanitize_callback' => 'gutenberg_wp_block_sanitize_post_meta',
+			'sanitize_callback' => 'sanitize_text_field',
 			'single'            => true,
 			'type'              => 'string',
 			'show_in_rest'      => array(
 				'schema' => array(
-					'type'       => 'string',
-					'properties' => array(
-						'wp_sync_status' => array(
-							'type' => 'string',
-						),
-					),
+					'type' => 'string',
+					'enum' => array( 'partial', 'unsynced' ),
 				),
 			),
 		)
 	);
-}
-/**
- * Sanitizes the array of wp_block post meta wp_sync_status string.
- *
- * Note: This should be removed when the minimum required WP version is >= 6.3.
- *
- * @see https://github.com/WordPress/gutenberg/pull/51144
- *
- * @param array $meta_value String to sanitize.
- *
- * @return array Sanitized string.
- */
-function gutenberg_wp_block_sanitize_post_meta( $meta_value ) {
-	return sanitize_text_field( $meta_value );
 }
 add_action( 'init', 'gutenberg_wp_block_register_post_meta' );

--- a/lib/compat/wordpress-6.3/blocks.php
+++ b/lib/compat/wordpress-6.3/blocks.php
@@ -90,7 +90,7 @@ function gutenberg_add_custom_fields_to_wp_block( $args, $post_type ) {
 add_filter( 'register_post_type_args', 'gutenberg_add_custom_fields_to_wp_block', 10, 2 );
 
 /**
- * Adds wp_sync_status meta fields to the wp_block post type so an unsynced option can be added.
+ * Adds wp_pattern_sync_status meta fields to the wp_block post type so an unsynced option can be added.
  *
  * Note: This should be removed when the minimum required WP version is >= 6.3.
  *

--- a/lib/compat/wordpress-6.3/blocks.php
+++ b/lib/compat/wordpress-6.3/blocks.php
@@ -60,6 +60,7 @@ function gutenberg_rename_reusable_block_cpt_to_pattern( $args, $post_type ) {
 		$args['labels']['item_reverted_to_draft']   = __( 'Pattern reverted to draft.' );
 		$args['labels']['item_scheduled']           = __( 'Pattern scheduled.' );
 		$args['labels']['item_updated']             = __( 'Pattern updated.' );
+		$args['rest_controller_class']              = 'Gutenberg_REST_Blocks_Controller';
 	}
 
 	return $args;

--- a/lib/compat/wordpress-6.3/class-gutenberg-rest-blocks-controller.php
+++ b/lib/compat/wordpress-6.3/class-gutenberg-rest-blocks-controller.php
@@ -40,7 +40,7 @@ class Gutenberg_REST_Blocks_Controller extends WP_REST_Blocks_Controller {
 		unset( $data['content']['rendered'] );
 
 		// Add the core wp_pattern_sync_status meta as top level property to the response.
-		$data['wp_pattern_sync_status'] = $data['meta']['wp_pattern_sync_status'];
+		$data['wp_pattern_sync_status'] = isset( $data['meta']['wp_pattern_sync_status'] ) ? $data['meta']['wp_pattern_sync_status'] : '';
 		unset( $data['meta']['wp_pattern_sync_status'] );
 		return $data;
 	}

--- a/lib/compat/wordpress-6.3/class-gutenberg-rest-blocks-controller.php
+++ b/lib/compat/wordpress-6.3/class-gutenberg-rest-blocks-controller.php
@@ -39,7 +39,7 @@ class Gutenberg_REST_Blocks_Controller extends WP_REST_Blocks_Controller {
 		unset( $data['title']['rendered'] );
 		unset( $data['content']['rendered'] );
 
-		// Add the core sync_status meta as top level property to the response.
+		// Add the core wp_pattern_sync_status meta as top level property to the response.
 		$data['wp_pattern_sync_status'] = $data['meta']['wp_pattern_sync_status'];
 		unset( $data['meta']['wp_pattern_sync_status'] );
 		return $data;

--- a/lib/compat/wordpress-6.3/class-gutenberg-rest-blocks-controller.php
+++ b/lib/compat/wordpress-6.3/class-gutenberg-rest-blocks-controller.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Reusable blocks REST API: WP_REST_Blocks_Controller class
+ *
+ * @package WordPress
+ * @subpackage REST_API
+ * @since 5.0.0
+ */
+
+/**
+ * Controller which provides a REST endpoint for the editor to read, create,
+ * edit and delete reusable blocks. Blocks are stored as posts with the wp_block
+ * post type.
+ *
+ * @since 5.0.0
+ *
+ * @see WP_REST_Posts_Controller
+ * @see WP_REST_Controller
+ */
+class Gutenberg_REST_Blocks_Controller extends WP_REST_Blocks_Controller  {
+	/**
+	 * Filters a response based on the context defined in the schema.
+	 *
+	 * @since 5.0.0
+	 * @since 6.3 Adds the `sync_status` property to the response.
+     *
+	 * @param array  $data    Response data to filter.
+	 * @param string $context Context defined in the schema.
+	 * @return array Filtered response.
+	 */
+	public function filter_response_by_context( $data, $context ) {
+		$data = parent::filter_response_by_context( $data, $context );
+
+		/*
+		 * Remove `title.rendered` and `content.rendered` from the response. It
+		 * doesn't make sense for a reusable block to have rendered content on its
+		 * own, since rendering a block requires it to be inside a post or a page.
+		 */
+		unset( $data['title']['rendered'] );
+		unset( $data['content']['rendered'] );
+		
+		$sync_status = $data['meta']['sync_status'];
+		$data['sync_status'] = $sync_status ;
+		unset( $data['meta']['sync_status'] );
+		return $data;
+	}
+}

--- a/lib/compat/wordpress-6.3/class-gutenberg-rest-blocks-controller.php
+++ b/lib/compat/wordpress-6.3/class-gutenberg-rest-blocks-controller.php
@@ -23,7 +23,7 @@ class Gutenberg_REST_Blocks_Controller extends WP_REST_Blocks_Controller  {
 	 *
 	 * @since 5.0.0
 	 * @since 6.3 Adds the `sync_status` property to the response.
-     *
+	 *
 	 * @param array  $data    Response data to filter.
 	 * @param string $context Context defined in the schema.
 	 * @return array Filtered response.
@@ -39,10 +39,10 @@ class Gutenberg_REST_Blocks_Controller extends WP_REST_Blocks_Controller  {
 		unset( $data['title']['rendered'] );
 		unset( $data['content']['rendered'] );
 		
-        // Add the core sync_status meta as top level property to the response.
-        $sync_status = $data['meta']['sync_status'];
-        $data['sync_status'] = $sync_status ;
-        unset( $data['meta']['sync_status'] );
-        return $data;
+		// Add the core sync_status meta as top level property to the response.
+		$sync_status = $data['meta']['sync_status'];
+		$data['sync_status'] = $sync_status ;
+		unset( $data['meta']['sync_status'] );
+		return $data;
 	}
 }

--- a/lib/compat/wordpress-6.3/class-gutenberg-rest-blocks-controller.php
+++ b/lib/compat/wordpress-6.3/class-gutenberg-rest-blocks-controller.php
@@ -22,7 +22,7 @@ class Gutenberg_REST_Blocks_Controller extends WP_REST_Blocks_Controller {
 	 * Filters a response based on the context defined in the schema.
 	 *
 	 * @since 5.0.0
-	 * @since 6.3 Adds the `sync_status` property to the response.
+	 * @since 6.3 Adds the `wp_sync_status` property to the response.
 	 *
 	 * @param array  $data    Response data to filter.
 	 * @param string $context Context defined in the schema.
@@ -40,9 +40,9 @@ class Gutenberg_REST_Blocks_Controller extends WP_REST_Blocks_Controller {
 		unset( $data['content']['rendered'] );
 
 		// Add the core sync_status meta as top level property to the response.
-		$sync_status         = $data['meta']['sync_status'];
-		$data['sync_status'] = $sync_status;
-		unset( $data['meta']['sync_status'] );
+		$wp_sync_status = $data['meta']['wp_sync_status'];
+		$data['wp_sync_status'] = $wp_sync_status;
+		unset( $data['meta']['wp_sync_status'] );
 		return $data;
 	}
 }

--- a/lib/compat/wordpress-6.3/class-gutenberg-rest-blocks-controller.php
+++ b/lib/compat/wordpress-6.3/class-gutenberg-rest-blocks-controller.php
@@ -40,7 +40,7 @@ class Gutenberg_REST_Blocks_Controller extends WP_REST_Blocks_Controller {
 		unset( $data['content']['rendered'] );
 
 		// Add the core sync_status meta as top level property to the response.
-		$wp_sync_status = $data['meta']['wp_sync_status'];
+		$wp_sync_status         = $data['meta']['wp_sync_status'];
 		$data['wp_sync_status'] = $wp_sync_status;
 		unset( $data['meta']['wp_sync_status'] );
 		return $data;

--- a/lib/compat/wordpress-6.3/class-gutenberg-rest-blocks-controller.php
+++ b/lib/compat/wordpress-6.3/class-gutenberg-rest-blocks-controller.php
@@ -40,9 +40,9 @@ class Gutenberg_REST_Blocks_Controller extends WP_REST_Blocks_Controller  {
 		unset( $data['content']['rendered'] );
 		
         // Add the core sync_status meta as top level property to the response.
-		$sync_status = $data['meta']['sync_status'];
-		$data['sync_status'] = $sync_status ;
-		unset( $data['meta']['sync_status'] );
-		return $data;
+        $sync_status = $data['meta']['sync_status'];
+        $data['sync_status'] = $sync_status ;
+        unset( $data['meta']['sync_status'] );
+        return $data;
 	}
 }

--- a/lib/compat/wordpress-6.3/class-gutenberg-rest-blocks-controller.php
+++ b/lib/compat/wordpress-6.3/class-gutenberg-rest-blocks-controller.php
@@ -22,7 +22,7 @@ class Gutenberg_REST_Blocks_Controller extends WP_REST_Blocks_Controller {
 	 * Filters a response based on the context defined in the schema.
 	 *
 	 * @since 5.0.0
-	 * @since 6.3 Adds the `wp_sync_status` property to the response.
+	 * @since 6.3 Adds the `wp_pattern_sync_status` property to the response.
 	 *
 	 * @param array  $data    Response data to filter.
 	 * @param string $context Context defined in the schema.
@@ -40,8 +40,8 @@ class Gutenberg_REST_Blocks_Controller extends WP_REST_Blocks_Controller {
 		unset( $data['content']['rendered'] );
 
 		// Add the core sync_status meta as top level property to the response.
-		$data['wp_sync_status'] = $data['meta']['wp_sync_status'];
-		unset( $data['meta']['wp_sync_status'] );
+		$data['wp_pattern_sync_status'] = $data['meta']['wp_pattern_sync_status'];
+		unset( $data['meta']['wp_pattern_sync_status'] );
 		return $data;
 	}
 }

--- a/lib/compat/wordpress-6.3/class-gutenberg-rest-blocks-controller.php
+++ b/lib/compat/wordpress-6.3/class-gutenberg-rest-blocks-controller.php
@@ -17,7 +17,7 @@
  * @see WP_REST_Posts_Controller
  * @see WP_REST_Controller
  */
-class Gutenberg_REST_Blocks_Controller extends WP_REST_Blocks_Controller  {
+class Gutenberg_REST_Blocks_Controller extends WP_REST_Blocks_Controller {
 	/**
 	 * Filters a response based on the context defined in the schema.
 	 *
@@ -38,10 +38,10 @@ class Gutenberg_REST_Blocks_Controller extends WP_REST_Blocks_Controller  {
 		 */
 		unset( $data['title']['rendered'] );
 		unset( $data['content']['rendered'] );
-		
+
 		// Add the core sync_status meta as top level property to the response.
-		$sync_status = $data['meta']['sync_status'];
-		$data['sync_status'] = $sync_status ;
+		$sync_status         = $data['meta']['sync_status'];
+		$data['sync_status'] = $sync_status;
 		unset( $data['meta']['sync_status'] );
 		return $data;
 	}

--- a/lib/compat/wordpress-6.3/class-gutenberg-rest-blocks-controller.php
+++ b/lib/compat/wordpress-6.3/class-gutenberg-rest-blocks-controller.php
@@ -40,8 +40,7 @@ class Gutenberg_REST_Blocks_Controller extends WP_REST_Blocks_Controller {
 		unset( $data['content']['rendered'] );
 
 		// Add the core sync_status meta as top level property to the response.
-		$wp_sync_status         = $data['meta']['wp_sync_status'];
-		$data['wp_sync_status'] = $wp_sync_status;
+		$data['wp_sync_status'] = $data['meta']['wp_sync_status'];
 		unset( $data['meta']['wp_sync_status'] );
 		return $data;
 	}

--- a/lib/compat/wordpress-6.3/class-gutenberg-rest-blocks-controller.php
+++ b/lib/compat/wordpress-6.3/class-gutenberg-rest-blocks-controller.php
@@ -39,6 +39,7 @@ class Gutenberg_REST_Blocks_Controller extends WP_REST_Blocks_Controller  {
 		unset( $data['title']['rendered'] );
 		unset( $data['content']['rendered'] );
 		
+        // Add the core sync_status meta as top level property to the response.
 		$sync_status = $data['meta']['sync_status'];
 		$data['sync_status'] = $sync_status ;
 		unset( $data['meta']['sync_status'] );

--- a/lib/load.php
+++ b/lib/load.php
@@ -56,6 +56,7 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 	require_once __DIR__ . '/compat/wordpress-6.3/navigation-block-preloading.php';
 	require_once __DIR__ . '/compat/wordpress-6.3/link-template.php';
 	require_once __DIR__ . '/compat/wordpress-6.3/block-patterns.php';
+	require_once __DIR__ . '/compat/wordpress-6.3/class-gutenberg-rest-blocks-controller.php';
 
 	// Experimental.
 	if ( ! class_exists( 'WP_Rest_Customizer_Nonces' ) ) {

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -2034,11 +2034,11 @@ export const getInserterItems = createSelector(
 			? getReusableBlocks( state )
 					.filter(
 						( reusableBlock ) =>
-							// Filter to either fully synced patterns (sync_status === 'fully'),
-							// or old school reusable blocks (sync_status === '').
-							reusableBlock.sync_status === 'fully' ||
-							reusableBlock.sync_status === '' ||
-							! reusableBlock.sync_status
+							// Filter to either fully synced patterns (wp_sync_status === 'fully'),
+							// or old school reusable blocks (wp_sync_status === '').
+							reusableBlock.wp_sync_status === 'fully' ||
+							reusableBlock.wp_sync_status === '' ||
+							! reusableBlock.wp_sync_status
 					)
 					.map( buildReusableBlockInserterItem )
 			: [];
@@ -2312,7 +2312,9 @@ function getUnsyncedPatterns( state ) {
 		state?.settings?.__experimentalReusableBlocks ?? EMPTY_ARRAY;
 
 	return reusableBlocks
-		.filter( ( reusableBlock ) => reusableBlock.sync_status === 'unsynced' )
+		.filter(
+			( reusableBlock ) => reusableBlock.wp_sync_status === 'unsynced'
+		)
 		.map( ( reusableBlock ) => {
 			return {
 				name: `core/block/${ reusableBlock.id }`,

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -2038,9 +2038,9 @@ export const getInserterItems = createSelector(
 							// for backwards compat between patterns and old reusable blocks, but
 							// some in release 16.1 may have had sync status inadvertantly set to
 							// 'fully' if created in the site editor.
-							reusableBlock.meta?.sync_status === 'fully' ||
-							reusableBlock.meta?.sync_status === '' ||
-							! reusableBlock.meta?.sync_status
+							reusableBlock.wp_pattern_sync_status === 'fully' ||
+							reusableBlock.wp_pattern_sync_status === '' ||
+							! reusableBlock.wp_pattern_sync_status
 					)
 					.map( buildReusableBlockInserterItem )
 			: [];

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -2034,9 +2034,6 @@ export const getInserterItems = createSelector(
 			? getReusableBlocks( state )
 					.filter(
 						( reusableBlock ) =>
-							// Filter to either fully synced patterns (wp_pattern_sync_status === 'fully'),
-							// or old school reusable blocks (wp_pattern_sync_status === '').
-							reusableBlock.wp_pattern_sync_status === 'fully' ||
 							reusableBlock.wp_pattern_sync_status === '' ||
 							! reusableBlock.wp_pattern_sync_status
 					)

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -2034,11 +2034,11 @@ export const getInserterItems = createSelector(
 			? getReusableBlocks( state )
 					.filter(
 						( reusableBlock ) =>
-							// Filter to either fully synced patterns (wp_sync_status === 'fully'),
-							// or old school reusable blocks (wp_sync_status === '').
-							reusableBlock.wp_sync_status === 'fully' ||
-							reusableBlock.wp_sync_status === '' ||
-							! reusableBlock.wp_sync_status
+							// Filter to either fully synced patterns (wp_pattern_sync_status === 'fully'),
+							// or old school reusable blocks (wp_pattern_sync_status === '').
+							reusableBlock.wp_pattern_sync_status === 'fully' ||
+							reusableBlock.wp_pattern_sync_status === '' ||
+							! reusableBlock.wp_pattern_sync_status
 					)
 					.map( buildReusableBlockInserterItem )
 			: [];
@@ -2313,7 +2313,8 @@ function getUnsyncedPatterns( state ) {
 
 	return reusableBlocks
 		.filter(
-			( reusableBlock ) => reusableBlock.wp_sync_status === 'unsynced'
+			( reusableBlock ) =>
+				reusableBlock.wp_pattern_sync_status === 'unsynced'
 		)
 		.map( ( reusableBlock ) => {
 			return {

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -2036,9 +2036,9 @@ export const getInserterItems = createSelector(
 						( reusableBlock ) =>
 							// Filter to either fully synced patterns (sync_status === 'fully'),
 							// or old school reusable blocks (sync_status === '').
-							reusableBlock.meta?.sync_status === 'fully' ||
-							reusableBlock.meta?.sync_status === '' ||
-							! reusableBlock.meta?.sync_status
+							reusableBlock.sync_status === 'fully' ||
+							reusableBlock.sync_status === '' ||
+							! reusableBlock.sync_status
 					)
 					.map( buildReusableBlockInserterItem )
 			: [];
@@ -2312,9 +2312,7 @@ function getUnsyncedPatterns( state ) {
 		state?.settings?.__experimentalReusableBlocks ?? EMPTY_ARRAY;
 
 	return reusableBlocks
-		.filter(
-			( reusableBlock ) => reusableBlock.meta?.sync_status === 'unsynced'
-		)
+		.filter( ( reusableBlock ) => reusableBlock.sync_status === 'unsynced' )
 		.map( ( reusableBlock ) => {
 			return {
 				name: `core/block/${ reusableBlock.id }`,

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -2034,8 +2034,13 @@ export const getInserterItems = createSelector(
 			? getReusableBlocks( state )
 					.filter(
 						( reusableBlock ) =>
-							reusableBlock.wp_pattern_sync_status === '' ||
-							! reusableBlock.wp_pattern_sync_status
+							// Reusable blocks that are fully synced should have no sync status set
+							// for backwards compat between patterns and old reusable blocks, but
+							// some in release 16.1 may have had sync status inadvertantly set to
+							// 'fully' if created in the site editor.
+							reusableBlock.meta?.sync_status === 'fully' ||
+							reusableBlock.meta?.sync_status === '' ||
+							! reusableBlock.meta?.sync_status
 					)
 					.map( buildReusableBlockInserterItem )
 			: [];

--- a/packages/edit-site/src/components/create-pattern-modal/index.js
+++ b/packages/edit-site/src/components/create-pattern-modal/index.js
@@ -56,7 +56,7 @@ export default function CreatePatternModal( {
 					status: 'publish',
 					meta:
 						syncType === SYNC_TYPES.unsynced
-							? { sync_status: syncType }
+							? { wp_sync_status: syncType }
 							: undefined,
 				},
 				{ throwOnError: true }

--- a/packages/edit-site/src/components/create-pattern-modal/index.js
+++ b/packages/edit-site/src/components/create-pattern-modal/index.js
@@ -56,7 +56,7 @@ export default function CreatePatternModal( {
 					status: 'publish',
 					meta:
 						syncType === SYNC_TYPES.unsynced
-							? { wp_sync_status: syncType }
+							? { wp_pattern_sync_status: syncType }
 							: undefined,
 				},
 				{ throwOnError: true }

--- a/packages/edit-site/src/components/page-patterns/use-patterns.js
+++ b/packages/edit-site/src/components/page-patterns/use-patterns.js
@@ -154,7 +154,7 @@ const reusableBlockToPattern = ( reusableBlock ) => ( {
 	categories: reusableBlock.wp_pattern,
 	id: reusableBlock.id,
 	name: reusableBlock.slug,
-	syncStatus: reusableBlock.sync_status || SYNC_TYPES.full,
+	syncStatus: reusableBlock.wp_sync_status || SYNC_TYPES.full,
 	title: reusableBlock.title.raw,
 	type: reusableBlock.type,
 	reusableBlock,

--- a/packages/edit-site/src/components/page-patterns/use-patterns.js
+++ b/packages/edit-site/src/components/page-patterns/use-patterns.js
@@ -154,7 +154,7 @@ const reusableBlockToPattern = ( reusableBlock ) => ( {
 	categories: reusableBlock.wp_pattern,
 	id: reusableBlock.id,
 	name: reusableBlock.slug,
-	syncStatus: reusableBlock.wp_sync_status || SYNC_TYPES.full,
+	syncStatus: reusableBlock.wp_pattern_sync_status || SYNC_TYPES.full,
 	title: reusableBlock.title.raw,
 	type: reusableBlock.type,
 	reusableBlock,

--- a/packages/edit-site/src/components/page-patterns/use-patterns.js
+++ b/packages/edit-site/src/components/page-patterns/use-patterns.js
@@ -154,7 +154,7 @@ const reusableBlockToPattern = ( reusableBlock ) => ( {
 	categories: reusableBlock.wp_pattern,
 	id: reusableBlock.id,
 	name: reusableBlock.slug,
-	syncStatus: reusableBlock.meta?.sync_status || SYNC_TYPES.full,
+	syncStatus: reusableBlock.sync_status || SYNC_TYPES.full,
 	title: reusableBlock.title.raw,
 	type: reusableBlock.type,
 	reusableBlock,

--- a/packages/edit-site/src/components/sidebar-navigation-screen-pattern/use-pattern-details.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-pattern/use-pattern-details.js
@@ -95,7 +95,7 @@ export default function usePatternDetails( postType, postId ) {
 		details.push( {
 			label: __( 'Syncing' ),
 			value:
-				record.meta?.sync_status === 'unsynced'
+				record.sync_status === 'unsynced'
 					? __( 'Not synced' )
 					: __( 'Fully synced' ),
 		} );

--- a/packages/edit-site/src/components/sidebar-navigation-screen-pattern/use-pattern-details.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-pattern/use-pattern-details.js
@@ -95,7 +95,7 @@ export default function usePatternDetails( postType, postId ) {
 		details.push( {
 			label: __( 'Syncing' ),
 			value:
-				record.wp_sync_status === 'unsynced'
+				record.wp_pattern_sync_status === 'unsynced'
 					? __( 'Not synced' )
 					: __( 'Fully synced' ),
 		} );

--- a/packages/edit-site/src/components/sidebar-navigation-screen-pattern/use-pattern-details.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-pattern/use-pattern-details.js
@@ -95,7 +95,7 @@ export default function usePatternDetails( postType, postId ) {
 		details.push( {
 			label: __( 'Syncing' ),
 			value:
-				record.sync_status === 'unsynced'
+				record.wp_sync_status === 'unsynced'
 					? __( 'Not synced' )
 					: __( 'Fully synced' ),
 		} );

--- a/packages/editor/src/components/post-sync-status/index.js
+++ b/packages/editor/src/components/post-sync-status/index.js
@@ -11,17 +11,17 @@ import { PanelRow } from '@wordpress/components';
 import { store as editorStore } from '../../store';
 
 export default function PostSyncStatus() {
-	const { meta, postType } = useSelect( ( select ) => {
+	const { syncStatus, postType } = useSelect( ( select ) => {
 		const { getEditedPostAttribute } = select( editorStore );
 		return {
-			meta: getEditedPostAttribute( 'meta' ),
+			syncStatus: getEditedPostAttribute( 'sync_status' ),
 			postType: getEditedPostAttribute( 'type' ),
 		};
 	}, [] );
 	if ( postType !== 'wp_block' ) {
 		return null;
 	}
-	const syncStatus = meta?.sync_status;
+
 	const isFullySynced = ! syncStatus;
 
 	return (

--- a/packages/editor/src/components/post-sync-status/index.js
+++ b/packages/editor/src/components/post-sync-status/index.js
@@ -14,7 +14,7 @@ export default function PostSyncStatus() {
 	const { syncStatus, postType } = useSelect( ( select ) => {
 		const { getEditedPostAttribute } = select( editorStore );
 		return {
-			syncStatus: getEditedPostAttribute( 'wp_sync_status' ),
+			syncStatus: getEditedPostAttribute( 'wp_pattern_sync_status' ),
 			postType: getEditedPostAttribute( 'type' ),
 		};
 	}, [] );

--- a/packages/editor/src/components/post-sync-status/index.js
+++ b/packages/editor/src/components/post-sync-status/index.js
@@ -14,7 +14,7 @@ export default function PostSyncStatus() {
 	const { syncStatus, postType } = useSelect( ( select ) => {
 		const { getEditedPostAttribute } = select( editorStore );
 		return {
-			syncStatus: getEditedPostAttribute( 'sync_status' ),
+			syncStatus: getEditedPostAttribute( 'wp_sync_status' ),
 			postType: getEditedPostAttribute( 'type' ),
 		};
 	}, [] );

--- a/packages/reusable-blocks/src/store/actions.js
+++ b/packages/reusable-blocks/src/store/actions.js
@@ -52,7 +52,7 @@ export const __experimentalConvertBlocksToReusable =
 		const meta =
 			syncType === 'unsynced'
 				? {
-						sync_status: syncType,
+						wp_sync_status: syncType,
 				  }
 				: undefined;
 

--- a/packages/reusable-blocks/src/store/actions.js
+++ b/packages/reusable-blocks/src/store/actions.js
@@ -52,7 +52,7 @@ export const __experimentalConvertBlocksToReusable =
 		const meta =
 			syncType === 'unsynced'
 				? {
-						wp_sync_status: syncType,
+						wp_pattern_sync_status: syncType,
 				  }
 				: undefined;
 


### PR DESCRIPTION
## What?
Renames `sync_status` to `wp_pattern_sync_status` and moves the field to a top-level post field in REST responses instead of a meta field.

## Why?
As was [suggested here](https://github.com/WordPress/wordpress-develop/pull/4646#issuecomment-1603668189), this is a more `core` like way to return a `core` field.

## How?
Modifies `WP_REST_Blocks_Controller` `filter_response_by_context` method.

## Testing Instructions

- Before switching to this branch, in trunk or 16.1 branch add some synced and unsynced patterns
- Switch to this branch and check that these Patterns still display correctly as synced or unsynced in post editor inserter, site editor library and the manage all patterns page edit screens
- In the post editor add some new synced and unsynced patterns - make sure the synced ones appear in the Sync Patterns inserter tab and that the unsynced ones appear in Patterns tab under Custom patterns
- Follow the Manage All Patterns link in the Editors top right settings menu
- Edit each pattern and make sure sync status displays correctly in right post info panel
- When editing an unsycned pattern check rest endpoint (/wp/v2/blocks?) return to see that post meta field is empty but  `wp_pattern_status` field is set
- In the Site editor library check that the patterns appear in the correct Synced and unsynced sections
- In the Site editor add new synced and unsynced patterns and make sure the appear in the correct sections

## Screenshots or screencast <!-- if applicable -->

Before:
<img width="305" alt="Screenshot 2023-07-03 at 5 13 32 PM" src="https://github.com/WordPress/gutenberg/assets/3629020/6fb15ebe-7933-4eba-94b0-0ef4bfeb00d4">

After:
<img width="332" alt="Screenshot 2023-07-04 at 2 02 30 PM" src="https://github.com/WordPress/gutenberg/assets/3629020/7a8b6f8a-b7a5-4d1f-9193-f8e933d7c2c6">



