### PR TITLE
Added missing left and right placement positions

### DIFF
--- a/packages/components/src/popover/utils.ts
+++ b/packages/components/src/popover/utils.ts
@@ -20,6 +20,8 @@ const POSITION_TO_PLACEMENT: Record<
 > = {
 	bottom: 'bottom',
 	top: 'top',
+	left: 'left',
+	right: 'right',
 	'middle left': 'left',
 	'middle right': 'right',
 	'bottom left': 'bottom-end',


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Added `left` and `right` position definitions.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
I noticed that when I used `tooltipPosition="right"` and `tooltipPosition="left"` in a Button component, it didn't work. However, "top" and "bottom" both work. To make right and left work, you'll need to add `middle` y axis value to it: "middle right" and "middle left".

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
It looked like it didn't work because the definition for "right" and "left" were not defined in the list of shorthand positions. Since "top" and "bottom" values worked, I think it should be that "right" and "left" values should be added in as well.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
Add a Button that uses "right" or "left" tooltipPositions:
```jsx
// This now works:
<Button label="Tooltip" tooltipPosition="right">Hover me</Button>
// The above is identical to:
<Button label="Tooltip" tooltipPosition="middle right">Hover me</Button>

// And this now works:
<Button label="Tooltip" tooltipPosition="left">Hover me</Button>
// Which is identical to:
<Button label="Tooltip" tooltipPosition="middle left">Hover me</Button>
```

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
