### PR TITLE
Block Editor: Unify texts for Create pattern modal

### DIFF
--- a/packages/reusable-blocks/src/components/reusable-blocks-menu-items/reusable-block-convert-button.js
+++ b/packages/reusable-blocks/src/components/reusable-blocks-menu-items/reusable-block-convert-button.js
@@ -156,6 +156,7 @@ export default function ReusableBlockConvertButton( {
 										label={ __( 'Name' ) }
 										value={ title }
 										onChange={ setTitle }
+										placeholder={ __( 'My pattern' ) }
 									/>
 
 									<ToggleControl
@@ -186,7 +187,7 @@ export default function ReusableBlockConvertButton( {
 										</Button>
 
 										<Button variant="primary" type="submit">
-											{ __( 'Save' ) }
+											{ __( 'Create' ) }
 										</Button>
 									</HStack>
 								</VStack>


### PR DESCRIPTION
## What?
This PR changes the following in the modal that appears when creating a pattern on the block editor

- Change Submit label from 'Save' to 'Create'
- Add a placeholder

| Before | After |
|--------|--------|
| ![before-block-editor](https://github.com/WordPress/gutenberg/assets/54422211/0eb3381b-70ad-4ca3-b0e0-46cbfa469e2f) | ![after-block-editor](https://github.com/WordPress/gutenberg/assets/54422211/9a963267-34b4-470c-80f7-3222f35584a8) | 

## Why?

This is to be consistent with the modal displayed when creating a pattern in the library menu.

![library-modal](https://github.com/WordPress/gutenberg/assets/54422211/ed874533-5c7c-4698-b00b-d97f9a613552)

## Testing Instructions

- Access the Post Editor or Site Editor.
- Select the block and click Create pattern from the toolbar menu.
- Confirm that the text displayed in the modal matches the screenshot of the latter pasted in this description.

