### PR TITLE
Navigation submenu: remove unused doc block

### DIFF
--- a/packages/block-library/src/navigation-submenu/index.php
+++ b/packages/block-library/src/navigation-submenu/index.php
@@ -6,16 +6,6 @@
  */
 
 /**
- * Build an array with CSS classes and inline styles defining the colors
- * which will be applied to the navigation markup in the front-end.
- *
- * @param  array $context     Navigation block context.
- * @param  array $attributes  Block attributes.
- * @param  bool  $is_sub_menu Whether the block is a sub-menu.
- * @return array Colors CSS classes and inline styles.
- */
-
-/**
  * Build an array with CSS classes and inline styles defining the font sizes
  * which will be applied to the navigation markup in the front-end.
  *


### PR DESCRIPTION
## What?
Removed unused doc block in navigation submenu

## Why?
`block_core_navigation_submenu_build_css_colors` was removed in https:/github.com/WordPress/gutenberg/pull/48936

The doc block wasn't.

## How?

The delete key.

## Testing Instructions

Check I'm not dreaming and that the doc block actually describes a deleted function.