### PR TITLE
Command palette: rename

### DIFF
--- a/packages/commands/README.md
+++ b/packages/commands/README.md
@@ -38,7 +38,7 @@ _Type_
 
 ### useCommand
 
-Attach a command to the Global command menu.
+Attach a command to the command palette.
 
 _Parameters_
 
@@ -46,7 +46,7 @@ _Parameters_
 
 ### useCommandLoader
 
-Attach a command loader to the Global command menu.
+Attach a command loader to the command palette.
 
 _Parameters_
 

--- a/packages/commands/src/components/command-menu.js
+++ b/packages/commands/src/components/command-menu.js
@@ -155,7 +155,7 @@ export function CommandMenu() {
 		registerShortcut( {
 			name: 'core/commands',
 			category: 'global',
-			description: __( 'Open the global command menu' ),
+			description: __( 'Open the command palette' ),
 			keyCombination: {
 				modifier: 'primary',
 				character: 'k',
@@ -192,7 +192,7 @@ export function CommandMenu() {
 	};
 
 	useEffect( () => {
-		// Focus the command menu input when mounting the modal.
+		// Focus the command palette input when mounting the modal.
 		if ( isOpen ) {
 			commandMenuInput.current.focus();
 		}
@@ -211,7 +211,7 @@ export function CommandMenu() {
 			__experimentalHideHeader
 		>
 			<div className="commands-command-menu__container">
-				<Command label={ __( 'Global Command Menu' ) }>
+				<Command label={ __( 'Command palette' ) }>
 					<div className="commands-command-menu__header">
 						<Command.Input
 							ref={ commandMenuInput }

--- a/packages/commands/src/hooks/use-command-context.js
+++ b/packages/commands/src/hooks/use-command-context.js
@@ -11,7 +11,7 @@ import { store as commandsStore } from '../store';
 import { unlock } from '../lock-unlock';
 
 /**
- * Sets the active context of the command center
+ * Sets the active context of the command palette
  *
  * @param {string} context Context to set.
  */

--- a/packages/commands/src/hooks/use-command-loader.js
+++ b/packages/commands/src/hooks/use-command-loader.js
@@ -10,7 +10,7 @@ import { useDispatch } from '@wordpress/data';
 import { store as commandsStore } from '../store';
 
 /**
- * Attach a command loader to the Global command menu.
+ * Attach a command loader to the command palette.
  *
  * @param {import('../store/actions').WPCommandLoaderConfig} loader command loader config.
  */

--- a/packages/commands/src/hooks/use-command.js
+++ b/packages/commands/src/hooks/use-command.js
@@ -10,7 +10,7 @@ import { useDispatch } from '@wordpress/data';
 import { store as commandsStore } from '../store';
 
 /**
- * Attach a command to the Global command menu.
+ * Attach a command to the command palette.
  *
  * @param {import('../store/actions').WPCommandConfig} command command config.
  */

--- a/packages/commands/src/store/actions.js
+++ b/packages/commands/src/store/actions.js
@@ -84,7 +84,7 @@ export function unregisterCommandLoader( name ) {
 }
 
 /**
- * Opens the command center.
+ * Opens the command palette.
  *
  * @return {Object} action.
  */
@@ -95,7 +95,7 @@ export function open() {
 }
 
 /**
- * Closes the command center.
+ * Closes the command palette.
  *
  * @return {Object} action.
  */

--- a/packages/commands/src/store/reducer.js
+++ b/packages/commands/src/store/reducer.js
@@ -63,7 +63,7 @@ function commandLoaders( state = {}, action ) {
 }
 
 /**
- * Reducer returning the command center open state.
+ * Reducer returning the command palette open state.
  *
  * @param {Object} state  Current state.
  * @param {Object} action Dispatched action.
@@ -82,7 +82,7 @@ function isOpen( state = false, action ) {
 }
 
 /**
- * Reducer returning the command center's active context.
+ * Reducer returning the command palette's active context.
  *
  * @param {Object} state  Current state.
  * @param {Object} action Dispatched action.

--- a/packages/edit-site/src/components/layout/index.js
+++ b/packages/edit-site/src/components/layout/index.js
@@ -143,7 +143,7 @@ export default function Layout() {
 		headerAnimationState = canvasMode; // edit, view, init
 	}
 
-	// Sets the right context for the command center
+	// Sets the right context for the command palette
 	const commandContext =
 		canvasMode === 'edit' && isEditorPage
 			? 'site-editor-edit'

--- a/packages/edit-site/src/components/site-hub/index.js
+++ b/packages/edit-site/src/components/site-hub/index.js
@@ -174,7 +174,7 @@ const SiteHub = forwardRef( ( props, ref ) => {
 						className="edit-site-site-hub_toggle-command-center"
 						icon={ search }
 						onClick={ () => openCommandCenter() }
-						label={ __( 'Open command center' ) }
+						label={ __( 'Open command palette' ) }
 					/>
 				) }
 			</HStack>

--- a/test/e2e/specs/site-editor/command-center.spec.js
+++ b/test/e2e/specs/site-editor/command-center.spec.js
@@ -3,7 +3,7 @@
  */
 const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 
-test.describe( 'Site editor command center', () => {
+test.describe( 'Site editor command palette', () => {
 	test.beforeAll( async ( { requestUtils } ) => {
 		await requestUtils.activateTheme( 'emptytheme' );
 	} );
@@ -17,11 +17,11 @@ test.describe( 'Site editor command center', () => {
 		await admin.visitSiteEditor();
 	} );
 
-	test( 'Open the command center and navigate to the page create page', async ( {
+	test( 'Open the command palette and navigate to the page create page', async ( {
 		page,
 	} ) => {
 		await page
-			.getByRole( 'button', { name: 'Open command center' } )
+			.getByRole( 'button', { name: 'Open command palette' } )
 			.focus();
 		await page.keyboard.press( 'Meta+k' );
 		await page.keyboard.type( 'new page' );
@@ -36,11 +36,11 @@ test.describe( 'Site editor command center', () => {
 		).toBeVisible();
 	} );
 
-	test( 'Open the command center and navigate to a template', async ( {
+	test( 'Open the command palette and navigate to a template', async ( {
 		page,
 	} ) => {
 		await page
-			.getByRole( 'button', { name: 'Open command center' } )
+			.getByRole( 'button', { name: 'Open command palette' } )
 			.click();
 		await page.keyboard.type( 'index' );
 		await page.getByRole( 'option', { name: 'index' } ).click();


### PR DESCRIPTION
## What?
Updates the name in the UI and where it's mentioned in the codebase (excepting the changelog).

## Why?
The action to resolve #50925 

## How?
Mostly by replacing “command center” with “command palette”. There were instances where it was referred to as “command menu” too and those are replaced as well.

## Testing Instructions
- In the site editor make sure the tooltip says “command palette”.
- automatted tests pass
- Scrutinize the diff

## Screenshots or screencast <!-- if applicable -->
<img width="399" alt="image" src="https://github.com/WordPress/gutenberg/assets/9000376/36603019-4b9b-44ca-8b2b-76989c1f46ee">

![As seen in keyboard shortcuts](https://github.com/WordPress/gutenberg/assets/9000376/41fff0eb-6979-49b8-a68b-de8c2db29bca)

