### PR TITLE
Patterns: Include template parts for custom areas in Uncategorized category

### DIFF
--- a/packages/edit-site/src/components/page-patterns/use-patterns.js
+++ b/packages/edit-site/src/components/page-patterns/use-patterns.js
@@ -38,6 +38,15 @@ const templatePartToPattern = ( templatePart ) => ( {
 	templatePart,
 } );
 
+const templatePartCategories = [ 'header', 'footer', 'sidebar' ];
+const templatePartHasCategory = ( item, category ) => {
+	if ( category === 'uncategorized' ) {
+		return ! templatePartCategories.includes( item.templatePart.area );
+	}
+
+	return item.templatePart.area === category;
+};
+
 const useTemplatePartsAsPatterns = (
 	categoryId,
 	postType = TEMPLATE_PARTS,
@@ -83,7 +92,7 @@ const useTemplatePartsAsPatterns = (
 
 		return searchItems( templateParts, filterValue, {
 			categoryId,
-			hasCategory: ( item, area ) => item.templatePart.area === area,
+			hasCategory: templatePartHasCategory,
 		} );
 	}, [ templateParts, filterValue, categoryId ] );
 


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/52101

## What?

Includes template parts assigned to custom template part areas in the Uncategorized section of the Patterns library. Previously, the Patterns sidebar nav included these parts in the category count but failed to render them on the page itself.

## Why?

The user should be able to access all their Template Parts through the Patterns section. 

## How?

Adjusts the category check to include a template part in a page's results.

## Testing Instructions

1. Register a custom template part area in your theme (See snippet below)
2. Navigate to Site Editor > Patterns
3. Create a new template part via the sidebar navigation screen's plus menu
4. Give the template part a name, assign it to the custom area, and then save it
5. Navigate back to the Patterns page and the uncategorized category
6. Confirm that your new pattern is shown.

```php
function my_default_wp_template_part_areas( $default_area_definitions ) {
	return array_merge(
		$default_area_definitions,
		array(
			array(
				'area'        => 'my-area',
				'label'       => 'My Area',
				'icon'        => 'layout',
				'description' => '',
			),
		)
	);
}
add_filter( 'default_wp_template_part_areas', 'my_default_wp_template_part_areas' );
```

## Screenshots or screencast <!-- if applicable -->


https://github.com/WordPress/gutenberg/assets/60436221/a0009f1f-b96b-404c-8169-c4da458b1bee


