### PR TITLE
Fix: Patterns & template parts: remove "apply globally" option from block settings

### DIFF
--- a/packages/edit-site/src/hooks/push-changes-to-global-styles/index.js
+++ b/packages/edit-site/src/hooks/push-changes-to-global-styles/index.js
@@ -94,6 +94,8 @@ const STYLE_PATH_TO_PRESET_BLOCK_ATTRIBUTE = {
 	'typography.fontFamily': 'fontFamily',
 };
 
+const SUPPORTED_STYLES = [ 'border', 'color', 'spacing', 'typography' ];
+
 function useChangesToPush( name, attributes ) {
 	const supports = useSupportedStyles( name );
 
@@ -213,9 +215,9 @@ function PushChangesToGlobalStylesControl( {
 const withPushChangesToGlobalStyles = createHigherOrderComponent(
 	( BlockEdit ) => ( props ) => {
 		const blockEditingMode = useBlockEditingMode();
-		const supportsStyles =
-			hasBlockSupport( props.name, 'color' ) ||
-			hasBlockSupport( props.name, 'typography' );
+		const supportsStyles = SUPPORTED_STYLES.some( ( feature ) =>
+			hasBlockSupport( props.name, feature )
+		);
 
 		return (
 			<>

--- a/packages/edit-site/src/hooks/push-changes-to-global-styles/index.js
+++ b/packages/edit-site/src/hooks/push-changes-to-global-styles/index.js
@@ -18,7 +18,9 @@ import { __, sprintf } from '@wordpress/i18n';
 import {
 	__EXPERIMENTAL_STYLE_PROPERTY as STYLE_PROPERTY,
 	getBlockType,
+	hasBlockSupport,
 } from '@wordpress/blocks';
+
 import { useContext, useMemo, useCallback } from '@wordpress/element';
 import { useDispatch } from '@wordpress/data';
 import { store as noticesStore } from '@wordpress/notices';
@@ -214,13 +216,13 @@ const withPushChangesToGlobalStyles = createHigherOrderComponent(
 		const blockEditingMode = useBlockEditingMode();
 
 		/**
-		 * Do not show the panel for pattern and template part blocks.
+		 * Do not show the panel if the block does not have style support.
 		 *
 		 * @see https://github.com/WordPress/gutenberg/issues/52139
 		 */
 		if (
-			'core/block' === props.name ||
-			'core/template-part' === props.name
+			! hasBlockSupport( props.name, 'color' ) ||
+			! hasBlockSupport( props.name, 'typography' )
 		) {
 			return <BlockEdit { ...props } />;
 		}

--- a/packages/edit-site/src/hooks/push-changes-to-global-styles/index.js
+++ b/packages/edit-site/src/hooks/push-changes-to-global-styles/index.js
@@ -212,6 +212,19 @@ function PushChangesToGlobalStylesControl( {
 const withPushChangesToGlobalStyles = createHigherOrderComponent(
 	( BlockEdit ) => ( props ) => {
 		const blockEditingMode = useBlockEditingMode();
+
+		/**
+		 * Do not show the panel for pattern and template part blocks.
+		 *
+		 * @see https://github.com/WordPress/gutenberg/issues/52139
+		 */
+		if (
+			'core/block' === props.name ||
+			'core/template-part' === props.name
+		) {
+			return <BlockEdit { ...props } />;
+		}
+
 		return (
 			<>
 				<BlockEdit { ...props } />

--- a/packages/edit-site/src/hooks/push-changes-to-global-styles/index.js
+++ b/packages/edit-site/src/hooks/push-changes-to-global-styles/index.js
@@ -20,7 +20,6 @@ import {
 	getBlockType,
 	hasBlockSupport,
 } from '@wordpress/blocks';
-
 import { useContext, useMemo, useCallback } from '@wordpress/element';
 import { useDispatch } from '@wordpress/data';
 import { store as noticesStore } from '@wordpress/notices';
@@ -214,23 +213,14 @@ function PushChangesToGlobalStylesControl( {
 const withPushChangesToGlobalStyles = createHigherOrderComponent(
 	( BlockEdit ) => ( props ) => {
 		const blockEditingMode = useBlockEditingMode();
-
-		/**
-		 * Do not show the panel if the block does not have style support.
-		 *
-		 * @see https://github.com/WordPress/gutenberg/issues/52139
-		 */
-		if (
-			! hasBlockSupport( props.name, 'color' ) ||
-			! hasBlockSupport( props.name, 'typography' )
-		) {
-			return <BlockEdit { ...props } />;
-		}
+		const supportsStyles =
+			hasBlockSupport( props.name, 'color' ) ||
+			hasBlockSupport( props.name, 'typography' );
 
 		return (
 			<>
 				<BlockEdit { ...props } />
-				{ blockEditingMode === 'default' && (
+				{ blockEditingMode === 'default' && supportsStyles && (
 					<InspectorAdvancedControls>
 						<PushChangesToGlobalStylesControl { ...props } />
 					</InspectorAdvancedControls>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Synced patterns and template parts have a Styles option in the Advanced panel of the block settings sidebar (inspector), for applying styles globally.

This PR removes this option by adding an early return to the "push changes to global styles" hook, if the block is a template part or pattern.

Closes https://github.com/WordPress/gutenberg/issues/52139

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
These blocks have no styling options, so the option to apply the styles is not needed.

## Testing Instructions
1. Activate a block theme
2. Open the site editor. 
3. Select or create a synced pattern and a template part.
4. Select them and open the Advanced panel in the inspector.
5. Confirm that there is no styles and "apply globally" option.
6. Select a different block that has style options. Open the advanced panel and confirm that the block still has the styles option. Optionally, make some style changes, use the option, and confirm that the option still works for the valid block types.

## Screenshots or screencast <!-- if applicable -->
Before:
<img width="286" alt="The block settings sidebar with the unused styles option." src="https://github.com/WordPress/gutenberg/assets/7422055/44da9fee-87d6-4085-bf28-6c09fe432548">

After:
<img width="293" alt="The block settings sidebar without the styles 'apply globally' option." src="https://github.com/WordPress/gutenberg/assets/7422055/cc7ad8f1-0179-44b8-ad96-f45df61bf864">
