### PR TITLE
List View: Return primitive value for 'hideInserter' in Appender component

### DIFF
--- a/packages/block-editor/src/components/list-view/appender.js
+++ b/packages/block-editor/src/components/list-view/appender.js
@@ -21,16 +21,15 @@ export const Appender = forwardRef(
 		const { insertedBlock, setInsertedBlock } = useListViewContext();
 
 		const instanceId = useInstanceId( Appender );
-		const { hideInserter } = useSelect(
+		const hideInserter = useSelect(
 			( select ) => {
 				const { getTemplateLock, __unstableGetEditorMode } =
 					select( blockEditorStore );
 
-				return {
-					hideInserter:
-						!! getTemplateLock( clientId ) ||
-						__unstableGetEditorMode() === 'zoom-out',
-				};
+				return (
+					!! getTemplateLock( clientId ) ||
+					__unstableGetEditorMode() === 'zoom-out'
+				);
 			},
 			[ clientId ]
 		);


### PR DESCRIPTION
## What?
PR updates the selector to return the `boolean` value directory.

## Why?
The "shallow equality" check will skip extra steps for primitive values.

P.S. I was experimenting if we can make a screen reader announcement without `useEffect` and decided to push this minor improvement.

## Testing Instructions
Confirm that the list view Appender is correctly rendered for the Navigation block.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2023-06-30 at 12 11 41](https://github.com/WordPress/gutenberg/assets/240569/f700ac62-0fcc-41a0-8c54-ebca07608b06)
