### PR TITLE
BlockRemovalWarningModal: Fix incorrect '_n' usage

### DIFF
--- a/packages/block-editor/src/components/block-removal-warning-modal/index.js
+++ b/packages/block-editor/src/components/block-removal-warning-modal/index.js
@@ -8,7 +8,7 @@ import {
 	Button,
 	__experimentalHStack as HStack,
 } from '@wordpress/components';
-import { __, _n } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -75,11 +75,9 @@ export function BlockRemovalWarningModal() {
 				</ul>
 			) }
 			<p>
-				{ _n(
-					'Removing this block is not advised.',
-					'Removing these blocks is not advised.',
-					blockNamesForPrompt.length
-				) }
+				{ blockNamesForPrompt.length > 1
+					? __( 'Removing these blocks is not advised.' )
+					: __( 'Removing this block is not advised.' ) }
 			</p>
 			<HStack justify="right">
 				<Button variant="tertiary" onClick={ clearRemovalPrompt }>


### PR DESCRIPTION
## What?
PR fixes an incorrect `_n` method's usage in the `BlockRemovalWarningModal` component.

## Why?
The _n translation function shouldn't be used for "one item" or "more than one items" cases. Details - https://developer.wordpress.org/reference/functions/_n/#comment-2397

## How?
Use ternary to render different messages for one or more blocks.

## Testing Instructions
1. Switch to TT3 or any theme that has a Query Loop block in the main template.
2. Open the Site Editor.
3. Try deleting the Query Loop block.
4. Confim correct message is displayed in the modal.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2023-06-30 at 12 45 02](https://github.com/WordPress/gutenberg/assets/240569/e62916d2-5711-4e30-9eb5-365067205fa1)

