### PR TITLE
Fix disable DFM when opening styles command

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen-global-styles/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-global-styles/index.js
@@ -72,11 +72,8 @@ export function SidebarNavigationItemGlobalStyles( props ) {
 					);
 					createNotice(
 						'info',
-						__( 'Distraction free mode turned off' ),
-						{
-							isDismissible: true,
-							type: 'snackbar',
-						}
+						__( 'Distraction free mode turned off.' ),
+						{ type: 'snackbar' }
 					);
 				}
 				// Switch to edit mode.

--- a/packages/edit-site/src/hooks/commands/use-common-commands.js
+++ b/packages/edit-site/src/hooks/commands/use-common-commands.js
@@ -10,6 +10,7 @@ import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
 import { privateApis as routerPrivateApis } from '@wordpress/router';
 import { store as preferencesStore } from '@wordpress/preferences';
 import { store as coreStore } from '@wordpress/core-data';
+import { store as noticesStore } from '@wordpress/notices';
 
 /**
  * Internal dependencies
@@ -104,14 +105,19 @@ export function useCommonCommands() {
 		useDispatch( editSiteStore )
 	);
 	const { set } = useDispatch( preferencesStore );
+	const { createInfoNotice } = useDispatch( noticesStore );
 	const history = useHistory();
-	const { homeUrl } = useSelect( ( select ) => {
+	const { homeUrl, isDistractionFree } = useSelect( ( select ) => {
 		const {
 			getUnstableBase, // Site index.
 		} = select( coreStore );
 
 		return {
 			homeUrl: getUnstableBase()?.home,
+			isDistractionFree: select( preferencesStore ).get(
+				editSiteStore.name,
+				'distractionFree'
+			),
 		};
 	}, [] );
 
@@ -139,6 +145,12 @@ export function useCommonCommands() {
 				path: '/wp_global_styles',
 				canvas: 'edit',
 			} );
+			if ( isDistractionFree ) {
+				set( editSiteStore.name, 'distractionFree', false );
+				createInfoNotice( __( 'Distraction free mode turned off.' ), {
+					type: 'snackbar',
+				} );
+			}
 			openGeneralSidebar( 'edit-site/global-styles' );
 		},
 		icon: styles,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Similar to: https://github.com/WordPress/gutenberg/pull/52090

When we have distraction free mode enabled and we select the `open styles` commands, we should check about it and disable it.

## Testing instructions
1. In site editor enable DFM
2. Open command center and select `open styles`
3. DFM mode should be turned off.
