### PR TITLE
Navigation: Fix sidebar title

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen-pattern/template-part-navigation-menu.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-pattern/template-part-navigation-menu.js
@@ -22,7 +22,7 @@ export default function TemplatePartNavigationMenu( { id } ) {
 				size="12"
 				upperCase={ true }
 			>
-				{ title?.rendered || __( 'Navigation' ) }
+				{ title || __( 'Navigation' ) }
 			</Heading>
 			<NavigationMenuEditor navigationMenuId={ id } />
 		</>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This updates the title in the Navigation section of Patterns to use the name of the navigation itself.

## Why?
We should show the actual name of the navigation.

## How?
Just reference the title prop directly.

## Testing Instructions
1. Open the Site Editor
2. Open the Library
3. Open a header template that contains a navigation
4. Confirm that the navigation shows in the sidebar with the correct title
