### PR TITLE
[Command Palette]: Remove suggestion for deleting templates/parts

### DIFF
--- a/packages/edit-site/src/hooks/commands/use-edit-mode-commands.js
+++ b/packages/edit-site/src/hooks/commands/use-edit-mode-commands.js
@@ -250,7 +250,6 @@ export function useEditModeCommands() {
 	useCommandLoader( {
 		name: 'core/edit-site/manipulate-document',
 		hook: useManipulateDocumentCommands,
-		context: 'site-editor-edit',
 	} );
 
 	useCommandLoader( {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Resolves: https://github.com/WordPress/gutenberg/issues/52143

From the issue:
>While there's not other suggested commands, let's remove the suggested commands for deleting/resetting templates and template parts. They should still be discoverable via searching for the command - but not suggested first thing.

