### PR TITLE
Navigation block: Do not toggle aria-expanded on hover when the overlay menu is opened

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7133,12 +7133,19 @@
 			"integrity": "sha512-M+M3ZOtd1dtV/uasyk4SZu1vbfEJ4NeENv0F7F12nijZYedB5wSgbtZcuACyssnTznhF4ctUyrR0dZHuHfyWKA=="
 		},
 		"@preact/signals-react": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/@preact/signals-react/-/signals-react-1.3.1.tgz",
-			"integrity": "sha512-YHWoGAT2Mmv2OGlGx7CCCbaLjAH/InV9ytGAR+esX8Y0HJmMAw51QlqGYOD5GPA5LwimV7Ht1x7KEIegDZIoxg==",
+			"version": "1.3.3",
+			"resolved": "https://registry.npmjs.org/@preact/signals-react/-/signals-react-1.3.3.tgz",
+			"integrity": "sha512-Tbv+oWPcrWowAJp1U1eWFiFUJihulOAnL8g/hJ3fUsP0IcsKsj8U0OcIDrwemIPQe7+J/3FuudkZzted0MD/bA==",
 			"requires": {
-				"@preact/signals-core": "^1.3.0",
+				"@preact/signals-core": "^1.3.1",
 				"use-sync-external-store": "^1.2.0"
+			},
+			"dependencies": {
+				"@preact/signals-core": {
+					"version": "1.3.1",
+					"resolved": "https://registry.npmjs.org/@preact/signals-core/-/signals-core-1.3.1.tgz",
+					"integrity": "sha512-DL+3kDssZ3UOMz9HufwSYE/gK0+TnT1jzegfF5rstgyPrnyfjz4BHAoxmzQA6Mkp4UlKe8qjsgl3v5a/obzNig=="
+				}
 			}
 		},
 		"@radix-ui/primitive": {
@@ -17303,7 +17310,6 @@
 			"version": "file:packages/block-library",
 			"requires": {
 				"@babel/runtime": "^7.16.0",
-				"@preact/signals": "^1.1.3",
 				"@wordpress/a11y": "file:packages/a11y",
 				"@wordpress/api-fetch": "file:packages/api-fetch",
 				"@wordpress/autop": "file:packages/autop",
@@ -17337,13 +17343,10 @@
 				"change-case": "^4.1.2",
 				"classnames": "^2.3.1",
 				"colord": "^2.7.0",
-				"deepsignal": "^1.3.0",
 				"escape-html": "^1.0.3",
 				"fast-average-color": "^9.1.1",
 				"fast-deep-equal": "^3.1.3",
 				"memize": "^2.1.0",
-				"micromodal": "^0.4.10",
-				"preact": "^10.13.2",
 				"remove-accents": "^0.4.2",
 				"uuid": "^8.3.0"
 			}
@@ -18131,7 +18134,7 @@
 			"version": "file:packages/interactivity",
 			"requires": {
 				"@preact/signals": "^1.1.3",
-				"deepsignal": "^1.3.0",
+				"deepsignal": "^1.3.3",
 				"preact": "^10.13.2"
 			}
 		},
@@ -31240,9 +31243,9 @@
 			"integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A=="
 		},
 		"deepsignal": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/deepsignal/-/deepsignal-1.3.0.tgz",
-			"integrity": "sha512-tMh3g3F7Ka6gKALqu7uOzi/3Xm00mGWgWR3hp1GUzGGnTz2J926ime5aOe1haz233v4encyjTkZESr5R6hr8oQ==",
+			"version": "1.3.3",
+			"resolved": "https://registry.npmjs.org/deepsignal/-/deepsignal-1.3.3.tgz",
+			"integrity": "sha512-4D5p2wp/4bRGfAPllwYCufPPAOxeD5milmfm/F4paKVoZOAjRVB5F+bs/wOJWWXsL8vsEcPf1vw8S/FT45k/wA==",
 			"requires": {
 				"@preact/signals": "^1.0.0",
 				"@preact/signals-core": "^1.0.0",
@@ -43553,11 +43556,6 @@
 				"picomatch": "^2.3.1"
 			}
 		},
-		"micromodal": {
-			"version": "0.4.10",
-			"resolved": "https://registry.npmjs.org/micromodal/-/micromodal-0.4.10.tgz",
-			"integrity": "sha512-BUrEnzMPFBwK8nOE4xUDYHLrlGlLULQVjpja99tpJQPSUEWgw3kTLp1n1qv0HmKU29AiHE7Y7sMLiRziDK4ghQ=="
-		},
 		"miller-rabin": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
@@ -46495,7 +46493,7 @@
 		"optionator": {
 			"version": "0.8.2",
 			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
-			"integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+			"integrity": "sha512-oCOQ8AIC2ciLy/sE2ehafRBleBgDLvzGhBRRev87sP7ovnbvQfqpc3XFI0DhHey2OfVoNV91W+GPC6B3540/5Q==",
 			"dev": true,
 			"requires": {
 				"deep-is": "~0.1.3",

--- a/packages/block-library/package.json
+++ b/packages/block-library/package.json
@@ -31,7 +31,6 @@
 	],
 	"dependencies": {
 		"@babel/runtime": "^7.16.0",
-		"@preact/signals": "^1.1.3",
 		"@wordpress/a11y": "file:../a11y",
 		"@wordpress/api-fetch": "file:../api-fetch",
 		"@wordpress/autop": "file:../autop",
@@ -65,13 +64,10 @@
 		"change-case": "^4.1.2",
 		"classnames": "^2.3.1",
 		"colord": "^2.7.0",
-		"deepsignal": "^1.3.0",
 		"escape-html": "^1.0.3",
 		"fast-average-color": "^9.1.1",
 		"fast-deep-equal": "^3.1.3",
 		"memize": "^2.1.0",
-		"micromodal": "^0.4.10",
-		"preact": "^10.13.2",
 		"remove-accents": "^0.4.2",
 		"uuid": "^8.3.0"
 	},

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -103,7 +103,7 @@ if ( defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN ) {
 		) ) {
 			// Add directives to the parent `<li>`.
 			$w->set_attribute( 'data-wp-interactive', true );
-			$w->set_attribute( 'data-wp-context', '{ "core": { "navigation": { "submenuOpenBy": { "click": false, "hover": false }, "type": "submenu" } } }' );
+			$w->set_attribute( 'data-wp-context', '{ "core": { "navigation": { "submenuOpenBy": {}, "type": "submenu" } } }' );
 			$w->set_attribute( 'data-wp-effect', 'effects.core.navigation.initMenu' );
 			$w->set_attribute( 'data-wp-on--focusout', 'actions.core.navigation.handleMenuFocusout' );
 			$w->set_attribute( 'data-wp-on--keydown', 'actions.core.navigation.handleMenuKeydown' );
@@ -711,7 +711,7 @@ function render_block_core_navigation( $attributes, $content, $block ) {
 	if ( defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN && $should_load_view_script ) {
 		$nav_element_directives          = '
 			data-wp-interactive
-			data-wp-context=\'{ "core": { "navigation": { "overlayOpenBy": { "click": false, "hover": false }, "type": "overlay", "roleAttribute": "" } } }\'
+			data-wp-context=\'{ "core": { "navigation": { "overlayOpenBy": {}, "type": "overlay", "roleAttribute": "" } } }\'
 		';
 		$open_button_directives          = '
 			data-wp-on--click="actions.core.navigation.openMenuOnClick"

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -103,7 +103,7 @@ if ( defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN ) {
 		) ) {
 			// Add directives to the parent `<li>`.
 			$w->set_attribute( 'data-wp-interactive', true );
-			$w->set_attribute( 'data-wp-context', '{ "core": { "navigation": { "submenuOpenBy": {}, "type": "submenu" } } }' );
+			$w->set_attribute( 'data-wp-context', '{ "core": { "navigation": { "submenuOpenedBy": {}, "type": "submenu" } } }' );
 			$w->set_attribute( 'data-wp-effect', 'effects.core.navigation.initMenu' );
 			$w->set_attribute( 'data-wp-on--focusout', 'actions.core.navigation.handleMenuFocusout' );
 			$w->set_attribute( 'data-wp-on--keydown', 'actions.core.navigation.handleMenuKeydown' );
@@ -711,7 +711,7 @@ function render_block_core_navigation( $attributes, $content, $block ) {
 	if ( defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN && $should_load_view_script ) {
 		$nav_element_directives          = '
 			data-wp-interactive
-			data-wp-context=\'{ "core": { "navigation": { "overlayOpenBy": {}, "type": "overlay", "roleAttribute": "" } } }\'
+			data-wp-context=\'{ "core": { "navigation": { "overlayOpenedBy": {}, "type": "overlay", "roleAttribute": "" } } }\'
 		';
 		$open_button_directives          = '
 			data-wp-on--click="actions.core.navigation.openMenuOnClick"

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -103,7 +103,7 @@ if ( defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN ) {
 		) ) {
 			// Add directives to the parent `<li>`.
 			$w->set_attribute( 'data-wp-interactive', true );
-			$w->set_attribute( 'data-wp-context', '{ "core": { "navigation": { "isMenuOpen": { "click": false, "hover": false }, "overlay": false } } }' );
+			$w->set_attribute( 'data-wp-context', '{ "core": { "navigation": { "submenuOpenBy": { "click": false, "hover": false }, "type": "submenu" } } }' );
 			$w->set_attribute( 'data-wp-effect', 'effects.core.navigation.initMenu' );
 			$w->set_attribute( 'data-wp-on--focusout', 'actions.core.navigation.handleMenuFocusout' );
 			$w->set_attribute( 'data-wp-on--keydown', 'actions.core.navigation.handleMenuKeydown' );
@@ -711,7 +711,7 @@ function render_block_core_navigation( $attributes, $content, $block ) {
 	if ( defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN && $should_load_view_script ) {
 		$nav_element_directives          = '
 			data-wp-interactive
-			data-wp-context=\'{ "core": { "navigation": { "isMenuOpen": { "click": false, "hover": false }, "overlay": true, "roleAttribute": "" } } }\'
+			data-wp-context=\'{ "core": { "navigation": { "overlayOpenBy": { "click": false, "hover": false }, "type": "overlay", "roleAttribute": "" } } }\'
 		';
 		$open_button_directives          = '
 			data-wp-on--click="actions.core.navigation.openMenuOnClick"
@@ -736,11 +736,11 @@ function render_block_core_navigation( $attributes, $content, $block ) {
 	}
 
 	$responsive_container_markup = sprintf(
-		'<button aria-haspopup="true" %3$s class="%6$s" data-micromodal-trigger="%1$s" %11$s>%9$s</button>
+		'<button aria-haspopup="true" %3$s class="%6$s" %11$s>%9$s</button>
 			<div class="%5$s" style="%7$s" id="%1$s" %12$s>
-				<div class="wp-block-navigation__responsive-close" tabindex="-1" data-micromodal-close>
+				<div class="wp-block-navigation__responsive-close" tabindex="-1">
 					<div class="wp-block-navigation__responsive-dialog" aria-label="%8$s" %13$s>
-							<button %4$s data-micromodal-close class="wp-block-navigation__responsive-container-close" %14$s>%10$s</button>
+							<button %4$s class="wp-block-navigation__responsive-container-close" %14$s>%10$s</button>
 						<div class="wp-block-navigation__responsive-container-content" id="%1$s-content">
 							%2$s
 						</div>

--- a/packages/block-library/src/navigation/view.js
+++ b/packages/block-library/src/navigation/view.js
@@ -1,35 +1,33 @@
 /**
  * WordPress dependencies
  */
-import { store } from '@wordpress/interactivity';
+import { store as wpStore } from '@wordpress/interactivity';
 
 const focusableSelectors = [
 	'a[href]',
-	'area[href]',
 	'input:not([disabled]):not([type="hidden"]):not([aria-hidden])',
 	'select:not([disabled]):not([aria-hidden])',
 	'textarea:not([disabled]):not([aria-hidden])',
 	'button:not([disabled]):not([aria-hidden])',
-	'iframe',
-	'object',
-	'embed',
 	'[contenteditable]',
 	'[tabindex]:not([tabindex^="-"])',
 ];
 
-const openMenu = ( { context, ref }, menuOpenedOn ) => {
-	context.core.navigation.isMenuOpen[ menuOpenedOn ] = true;
+const openMenu = ( store, menuOpenedOn ) => {
+	const { context, ref, selectors } = store;
+	selectors.core.navigation.menuOpenBy( store )[ menuOpenedOn ] = true;
 	context.core.navigation.previousFocus = ref;
-	if ( context.core.navigation.overlay ) {
+	if ( context.core.navigation.type === 'overlay' ) {
 		// Add a `has-modal-open` class to the <html> root.
 		document.documentElement.classList.add( 'has-modal-open' );
 	}
 };
 
-const closeMenu = ( { context, selectors }, menuClosedOn ) => {
-	context.core.navigation.isMenuOpen[ menuClosedOn ] = false;
+const closeMenu = ( store, menuClosedOn ) => {
+	const { context, selectors } = store;
+	selectors.core.navigation.menuOpenBy( store )[ menuClosedOn ] = false;
 	// Check if the menu is still open or not.
-	if ( ! selectors.core.navigation.isMenuOpen( { context } ) ) {
+	if ( ! selectors.core.navigation.isMenuOpen( store ) ) {
 		if (
 			context.core.navigation.modal?.contains(
 				window.document.activeElement
@@ -39,18 +37,19 @@ const closeMenu = ( { context, selectors }, menuClosedOn ) => {
 		}
 		context.core.navigation.modal = null;
 		context.core.navigation.previousFocus = null;
-		if ( context.core.navigation.overlay ) {
+		if ( context.core.navigation.type === 'overlay' ) {
 			document.documentElement.classList.remove( 'has-modal-open' );
 		}
 	}
 };
 
-store( {
+wpStore( {
 	effects: {
 		core: {
 			navigation: {
-				initMenu: ( { context, selectors, ref } ) => {
-					if ( selectors.core.navigation.isMenuOpen( { context } ) ) {
+				initMenu: ( store ) => {
+					const { context, selectors, ref } = store;
+					if ( selectors.core.navigation.isMenuOpen( store ) ) {
 						const focusableElements =
 							ref.querySelectorAll( focusableSelectors );
 						context.core.navigation.modal = ref;
@@ -60,8 +59,9 @@ store( {
 							focusableElements[ focusableElements.length - 1 ];
 					}
 				},
-				focusFirstElement: ( { context, selectors, ref } ) => {
-					if ( selectors.core.navigation.isMenuOpen( { context } ) ) {
+				focusFirstElement: ( store ) => {
+					const { selectors, ref } = store;
+					if ( selectors.core.navigation.isMenuOpen( store ) ) {
 						ref.querySelector(
 							'.wp-block-navigation-item > *:first-child'
 						).focus();
@@ -73,60 +73,77 @@ store( {
 	selectors: {
 		core: {
 			navigation: {
-				roleAttribute: ( { context, selectors } ) =>
-					context.core.navigation.overlay &&
-					selectors.core.navigation.isMenuOpen( { context } )
+				roleAttribute: ( store ) => {
+					const { context, selectors } = store;
+					return context.core.navigation.type === 'overlay' &&
+						selectors.core.navigation.isMenuOpen( store )
 						? 'dialog'
-						: '',
+						: '';
+				},
 				isMenuOpen: ( { context } ) =>
-					// The menu is opened if either `click` or `hover` is true.
-					Object.values( context.core.navigation.isMenuOpen ).filter(
-						Boolean
-					).length > 0,
+					// The menu is opened if either `click`, `hover` or `focus` is true.
+					Object.values(
+						context.core.navigation[
+							context.core.navigation.type === 'overlay'
+								? 'overlayOpenBy'
+								: 'submenuOpenBy'
+						]
+					).filter( Boolean ).length > 0,
+				menuOpenBy: ( { context } ) =>
+					context.core.navigation[
+						context.core.navigation.type === 'overlay'
+							? 'overlayOpenBy'
+							: 'submenuOpenBy'
+					],
 			},
 		},
 	},
 	actions: {
 		core: {
 			navigation: {
-				openMenuOnHover( args ) {
-					openMenu( args, 'hover' );
+				openMenuOnHover( store ) {
+					const { navigation } = store.context.core;
+					if (
+						navigation.type === 'submenu' &&
+						// Only open on hover if the overlay is closed.
+						Object.values( navigation.overlayOpenBy || {} ).filter(
+							Boolean
+						).length === 0
+					)
+						openMenu( store, 'hover' );
 				},
-				closeMenuOnHover( args ) {
-					closeMenu( args, 'hover' );
+				closeMenuOnHover( store ) {
+					closeMenu( store, 'hover' );
 				},
-				openMenuOnClick( args ) {
-					openMenu( args, 'click' );
+				openMenuOnClick( store ) {
+					openMenu( store, 'click' );
 				},
-				closeMenuOnClick( args ) {
-					closeMenu( args, 'click' );
+				closeMenuOnClick( store ) {
+					closeMenu( store, 'click' );
 				},
-				toggleMenuOnClick: ( args ) => {
-					const { context } = args;
-					if ( context.core.navigation.isMenuOpen.click ) {
-						closeMenu( args, 'click' );
+				toggleMenuOnClick: ( store ) => {
+					const { selectors } = store;
+					if ( selectors.core.navigation.menuOpenBy( store ).click ) {
+						closeMenu( store, 'click' );
 					} else {
-						openMenu( args, 'click' );
+						openMenu( store, 'click' );
 					}
 				},
-				handleMenuKeydown: ( args ) => {
-					const { context, event } = args;
-					if ( context.core.navigation.isMenuOpen.click ) {
-						// If Escape close the menu
-						if (
-							event?.key === 'Escape' ||
-							event?.keyCode === 27
-						) {
-							closeMenu( args, 'click' );
+				handleMenuKeydown: ( store ) => {
+					const { context, selectors, event } = store;
+					if ( selectors.core.navigation.menuOpenBy( store ).click ) {
+						// If Escape close the menu.
+						if ( event?.key === 'Escape' ) {
+							closeMenu( store, 'click' );
 							return;
 						}
 
-						// Trap focus if it is an overlay (main menu)
+						// Trap focus if it is an overlay (main menu).
 						if (
-							context.core.navigation.overlay &&
-							( event.key === 'Tab' || event.keyCode === 9 )
+							context.core.navigation.type === 'overlay' &&
+							event.key === 'Tab'
 						) {
-							// If shift + tab it change the direction
+							// If shift + tab it change the direction.
 							if (
 								event.shiftKey &&
 								window.document.activeElement ===
@@ -146,21 +163,21 @@ store( {
 						}
 					}
 				},
-				handleMenuFocusout: ( args ) => {
-					const { context, event } = args;
+				handleMenuFocusout: ( store ) => {
+					const { context, selectors, event } = store;
 					// If focus is outside modal, and in the document, close menu
 					// event.target === The element losing focus
 					// event.relatedTarget === The element receiving focus (if any)
 					// When focusout is outsite the document,
-					// `window.document.activeElement` doesn't change
+					// `window.document.activeElement` doesn't change.
 					if (
-						context.core.navigation.isMenuOpen.click &&
+						selectors.core.navigation.menuOpenBy( store ).click &&
 						! context.core.navigation.modal?.contains(
 							event.relatedTarget
 						) &&
 						event.target !== window.document.activeElement
 					) {
-						closeMenu( args, 'click' );
+						closeMenu( store, 'click' );
 					}
 				},
 			},

--- a/packages/block-library/src/navigation/view.js
+++ b/packages/block-library/src/navigation/view.js
@@ -85,15 +85,15 @@ wpStore( {
 					Object.values(
 						context.core.navigation[
 							context.core.navigation.type === 'overlay'
-								? 'overlayOpenBy'
-								: 'submenuOpenBy'
+								? 'overlayOpenedBy'
+								: 'submenuOpenedBy'
 						]
 					).filter( Boolean ).length > 0,
 				menuOpenBy: ( { context } ) =>
 					context.core.navigation[
 						context.core.navigation.type === 'overlay'
-							? 'overlayOpenBy'
-							: 'submenuOpenBy'
+							? 'overlayOpenedBy'
+							: 'submenuOpenedBy'
 					],
 			},
 		},
@@ -106,9 +106,9 @@ wpStore( {
 					if (
 						navigation.type === 'submenu' &&
 						// Only open on hover if the overlay is closed.
-						Object.values( navigation.overlayOpenBy || {} ).filter(
-							Boolean
-						).length === 0
+						Object.values(
+							navigation.overlayOpenedBy || {}
+						).filter( Boolean ).length === 0
 					)
 						openMenu( store, 'hover' );
 				},

--- a/packages/interactivity/package.json
+++ b/packages/interactivity/package.json
@@ -26,7 +26,7 @@
 	"react-native": "src/index",
 	"dependencies": {
 		"@preact/signals": "^1.1.3",
-		"deepsignal": "^1.3.0",
+		"deepsignal": "^1.3.3",
 		"preact": "^10.13.2"
 	},
 	"publishConfig": {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Do not toggle `aria-expanded` on hover of the submenus when the overlay menu is opened.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Because the submenus are expanded by defualt when the overlay menu is opened.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

I divided `isMenuOpen` into two different properties (`overlayOpenedBy` and `submenuOpenedBy`) so it's possible to know if the parent overlay is opened or not in the children submenu. I also changed the `overlay` boolean to `type = "overlay"` or `type = "submenu"` to make it more explicit.

I also updated `deepsignal` and removed the leftovers in the `block-library`'s `package.json`.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Create a menu with submenus and overlay activated on mobile
2. Check that the `aria-expanded` attribute of the submenus turns `true` on hover
3. Open the overlay menu
4. Check that the `aria-expanded` attribute of the submenus doesn't turn `true` on hover

## Screenshots or screencast <!-- if applicable -->

**Before**


https://github.com/WordPress/gutenberg/assets/3305402/50fc0ab9-1753-491a-9968-476611383167

 

**After**


https://github.com/WordPress/gutenberg/assets/3305402/4f7a0f1d-f70a-4201-9cfb-1f57f5b5c73d


