### PR TITLE
Navigation block: Don't close submenu when it has focus

### DIFF
--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -127,7 +127,7 @@ if ( defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN ) {
 			if ( $w->next_tag(
 				array(
 					'tag_name'   => 'UL',
-					'class_name' => 'wp-block-navigation-submenu',
+					'class_name' => 'wp-block-navigation__submenu-container',
 				)
 			) ) {
 				$w->set_attribute( 'data-wp-on--focusin', 'actions.core.navigation.openMenuOnFocus' );

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -123,6 +123,17 @@ if ( defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN ) {
 				$w->set_attribute( 'data-wp-bind--aria-expanded', 'selectors.core.navigation.isMenuOpen' );
 			};
 
+			// Add directives to the submenu.
+			if ( $w->next_tag(
+				array(
+					'tag_name'   => 'UL',
+					'class_name' => 'wp-block-navigation-submenu',
+				)
+			) ) {
+				$w->set_attribute( 'data-wp-on--focusin', 'actions.core.navigation.openMenuOnFocus' );
+				$w->set_attribute( 'data-wp-on--focusout', 'actions.core.navigation.closeMenuOnFocus' );
+			}
+
 			// Iterate through subitems if exist.
 			block_core_navigation_add_directives_to_submenu( $w, $block_attributes );
 		}

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -131,7 +131,6 @@ if ( defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN ) {
 				)
 			) ) {
 				$w->set_attribute( 'data-wp-on--focusin', 'actions.core.navigation.openMenuOnFocus' );
-				$w->set_attribute( 'data-wp-on--focusout', 'actions.core.navigation.closeMenuOnFocus' );
 			}
 
 			// Iterate through subitems if exist.

--- a/packages/block-library/src/navigation/view.js
+++ b/packages/block-library/src/navigation/view.js
@@ -121,6 +121,12 @@ wpStore( {
 				closeMenuOnClick( store ) {
 					closeMenu( store, 'click' );
 				},
+				openMenuOnFocus( store ) {
+					openMenu( store, 'focus' );
+				},
+				closeMenuOnFocus( store ) {
+					closeMenu( store, 'focus' );
+				},
 				toggleMenuOnClick: ( store ) => {
 					const { selectors } = store;
 					if ( selectors.core.navigation.menuOpenBy( store ).click ) {

--- a/packages/block-library/src/navigation/view.js
+++ b/packages/block-library/src/navigation/view.js
@@ -120,6 +120,7 @@ wpStore( {
 				},
 				closeMenuOnClick( store ) {
 					closeMenu( store, 'click' );
+					closeMenu( store, 'focus' );
 				},
 				openMenuOnFocus( store ) {
 					openMenu( store, 'focus' );
@@ -128,6 +129,7 @@ wpStore( {
 					const { selectors } = store;
 					if ( selectors.core.navigation.menuOpenBy( store ).click ) {
 						closeMenu( store, 'click' );
+						closeMenu( store, 'focus' );
 					} else {
 						openMenu( store, 'click' );
 					}
@@ -138,6 +140,7 @@ wpStore( {
 						// If Escape close the menu.
 						if ( event?.key === 'Escape' ) {
 							closeMenu( store, 'click' );
+							closeMenu( store, 'focus' );
 							return;
 						}
 

--- a/packages/block-library/src/navigation/view.js
+++ b/packages/block-library/src/navigation/view.js
@@ -124,9 +124,6 @@ wpStore( {
 				openMenuOnFocus( store ) {
 					openMenu( store, 'focus' );
 				},
-				closeMenuOnFocus( store ) {
-					closeMenu( store, 'focus' );
-				},
 				toggleMenuOnClick: ( store ) => {
 					const { selectors } = store;
 					if ( selectors.core.navigation.menuOpenBy( store ).click ) {
@@ -170,20 +167,20 @@ wpStore( {
 					}
 				},
 				handleMenuFocusout: ( store ) => {
-					const { context, selectors, event } = store;
+					const { context, event } = store;
 					// If focus is outside modal, and in the document, close menu
 					// event.target === The element losing focus
 					// event.relatedTarget === The element receiving focus (if any)
 					// When focusout is outsite the document,
 					// `window.document.activeElement` doesn't change.
 					if (
-						selectors.core.navigation.menuOpenBy( store ).click &&
 						! context.core.navigation.modal?.contains(
 							event.relatedTarget
 						) &&
 						event.target !== window.document.activeElement
 					) {
 						closeMenu( store, 'click' );
+						closeMenu( store, 'focus' );
 					}
 				},
 			},

--- a/packages/block-library/src/navigation/view.js
+++ b/packages/block-library/src/navigation/view.js
@@ -127,7 +127,9 @@ wpStore( {
 				},
 				toggleMenuOnClick: ( store ) => {
 					const { selectors } = store;
-					if ( selectors.core.navigation.menuOpenBy( store ).click ) {
+					const menuOpenBy =
+						selectors.core.navigation.menuOpenBy( store );
+					if ( menuOpenBy.click || menuOpenBy.focus ) {
 						closeMenu( store, 'click' );
 						closeMenu( store, 'focus' );
 					} else {

--- a/packages/block-library/src/navigation/view.js
+++ b/packages/block-library/src/navigation/view.js
@@ -15,7 +15,7 @@ const focusableSelectors = [
 
 const openMenu = ( store, menuOpenedOn ) => {
 	const { context, ref, selectors } = store;
-	selectors.core.navigation.menuOpenBy( store )[ menuOpenedOn ] = true;
+	selectors.core.navigation.menuOpenedBy( store )[ menuOpenedOn ] = true;
 	context.core.navigation.previousFocus = ref;
 	if ( context.core.navigation.type === 'overlay' ) {
 		// Add a `has-modal-open` class to the <html> root.
@@ -25,7 +25,7 @@ const openMenu = ( store, menuOpenedOn ) => {
 
 const closeMenu = ( store, menuClosedOn ) => {
 	const { context, selectors } = store;
-	selectors.core.navigation.menuOpenBy( store )[ menuClosedOn ] = false;
+	selectors.core.navigation.menuOpenedBy( store )[ menuClosedOn ] = false;
 	// Check if the menu is still open or not.
 	if ( ! selectors.core.navigation.isMenuOpen( store ) ) {
 		if (
@@ -89,7 +89,7 @@ wpStore( {
 								: 'submenuOpenedBy'
 						]
 					).filter( Boolean ).length > 0,
-				menuOpenBy: ( { context } ) =>
+				menuOpenedBy: ( { context } ) =>
 					context.core.navigation[
 						context.core.navigation.type === 'overlay'
 							? 'overlayOpenedBy'
@@ -127,9 +127,9 @@ wpStore( {
 				},
 				toggleMenuOnClick: ( store ) => {
 					const { selectors } = store;
-					const menuOpenBy =
-						selectors.core.navigation.menuOpenBy( store );
-					if ( menuOpenBy.click || menuOpenBy.focus ) {
+					const menuOpenedBy =
+						selectors.core.navigation.menuOpenedBy( store );
+					if ( menuOpenedBy.click || menuOpenedBy.focus ) {
 						closeMenu( store, 'click' );
 						closeMenu( store, 'focus' );
 					} else {
@@ -138,7 +138,9 @@ wpStore( {
 				},
 				handleMenuKeydown: ( store ) => {
 					const { context, selectors, event } = store;
-					if ( selectors.core.navigation.menuOpenBy( store ).click ) {
+					if (
+						selectors.core.navigation.menuOpenedBy( store ).click
+					) {
 						// If Escape close the menu.
 						if ( event?.key === 'Escape' ) {
 							closeMenu( store, 'click' );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

_This PR builds on top of https://github.com/WordPress/gutenberg/pull/52170 because it includes changes that only work with the modified logic of that PR._

Don't close the submenu when it has been focused because the mouse was hovering.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

It's an edge case, but it shouldn't happen.

Spotted by @jeryj in [Slack](https://wordpress.slack.com/archives/C02RP4X03/p1685462188595509?thread_ts=1684403764.422519&cid=C02RP4X03).

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Adding a new `focusin` handler that adds a `"focus"` prop to the `"submenuOpenedBy"` object and prevents the menu from closing until `"focus"` is removed on the `focusout` handler.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. --> 
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

- Hover a parent (submenu opens)
- Move focus into the submenu with `tab` keypresses
- Hover off the menu
- Menu should remain open until the focus is gone

## Screenshots or screencast <!-- if applicable -->

**Before** 


https://github.com/WordPress/gutenberg/assets/3305402/c606fa59-3187-4e95-bdd5-826f2221839c



**After**


https://github.com/WordPress/gutenberg/assets/3305402/54d20ae6-9b27-49aa-bc56-1f0bf470e162



