### PR TITLE
Image block: Remove extra lookup for external image dimensions in lightbox

### DIFF
--- a/lib/block-supports/behaviors.php
+++ b/lib/block-supports/behaviors.php
@@ -97,9 +97,8 @@ function gutenberg_render_behaviors_support_lightbox( $block_content, $block ) {
 		$img_uploaded_srcset = wp_get_attachment_image_srcset( $block['attrs']['id'] );
 	} else {
 		$img_uploaded_src    = $z->get_attribute( 'src' );
-		$img_dimensions      = wp_getimagesize( $img_uploaded_src );
-		$img_width           = $img_dimensions[0];
-		$img_height          = $img_dimensions[1];
+		$img_width           = 'none';
+		$img_height          = 'none';
 		$img_uploaded_srcset = '';
 	}
 

--- a/packages/block-library/src/image/view-interactivity.js
+++ b/packages/block-library/src/image/view-interactivity.js
@@ -202,8 +202,18 @@ store( {
 } );
 
 function setZoomStyles( imgDom, context, event ) {
-	let targetWidth = context.core.image.targetWidth;
-	let targetHeight = context.core.image.targetHeight;
+	// Typically, we use the image's full-sized dimensions. If those
+	// dimensions have not been set (i.e. an external image with only one size),
+	// the image's dimensions in the lightbox are the same
+	// as those of the image in the content.
+	let targetWidth =
+		context.core.image.targetWidth !== 'none'
+			? context.core.image.targetWidth
+			: event.target.nextElementSibling.naturalWidth;
+	let targetHeight =
+		context.core.image.targetHeight !== 'none'
+			? context.core.image.targetHeight
+			: event.target.nextElementSibling.naturalHeight;
 
 	// Since the lightbox image has `position:absolute`, it
 	// ignores its parent's padding, so we need to set padding here


### PR DESCRIPTION
## What?
<!-- In a few words, what is the PR actually doing? -->
In the lightbox, when dealing with external images, were doing a call to `wp_getimagesize()` in order to get the dimensions needed to set the lightbox styles.

However, we actually don't need to make the call, because when it comes to external images, the zoomed lightbox image is the same as the image in the content — and has the same dimensions.

This PR removes the call to `wp_getimagesize()` and adds logic to handle this scenario.

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
We should avoid making unnecessary network requests, especially with image files.
Fixes https://github.com/WordPress/gutenberg/issues/52172

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
It sets the 'width' and 'height' values to 'none' in the Interactivity API context, then adds a conditional to get the lightbox enlarged dimensions from the image in the content if the width and height values are unavailable.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
1. Ensure the Gutenberg Interactivity API experiment is enabled in the admin
2. Add an image from an external URL
3. Enable the lightbox using Advanced > Behaviors > Lightbox in block settings
4. Publish the post and click on the image
5. See that the lightbox works as expected
6. Try adding another image, but this time using a broken external URL
7. View the post and make sure there are no PHP errors or other unexpected behavior (in this scenario, since there is no image, the lightbox should be unavailable)

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
N/A