### PR TITLE
Update Site Editor frame z-index

### DIFF
--- a/packages/base-styles/_z-index.scss
+++ b/packages/base-styles/_z-index.scss
@@ -186,7 +186,7 @@ $z-layers: (
 	".edit-site-layout__hub": 3,
 	".edit-site-layout__header": 2,
 	".edit-site-page-header": 2,
-	".edit-site-layout__canvas-container": 2,
+	".edit-site-layout__canvas-container": 4,
 	".edit-site-layout__sidebar": 1,
 	".edit-site-layout__canvas-container.is-resizing::after": 100,
 	// Title needs to appear above other UI the section content.

--- a/packages/base-styles/_z-index.scss
+++ b/packages/base-styles/_z-index.scss
@@ -186,7 +186,7 @@ $z-layers: (
 	".edit-site-layout__hub": 3,
 	".edit-site-layout__header": 2,
 	".edit-site-page-header": 2,
-	".edit-site-layout__canvas-container": 4,
+	".edit-site-layout__canvas-container": 2,
 	".edit-site-layout__sidebar": 1,
 	".edit-site-layout__canvas-container.is-resizing::after": 100,
 	// Title needs to appear above other UI the section content.

--- a/packages/edit-site/src/components/resizable-frame/style.scss
+++ b/packages/edit-site/src/components/resizable-frame/style.scss
@@ -1,6 +1,23 @@
 .edit-site-resizable-frame__inner {
 	position: relative;
 
+	&.edit-site-layout__resizable-frame-oversized {
+		@at-root {
+			body:has(&) {
+				.edit-site-site-hub {
+					.edit-site-site-hub__site-title,
+					.edit-site-site-hub_toggle-command-center {
+						opacity: 0 !important;
+					}
+
+					.edit-site-site-hub__view-mode-toggle-container {
+						background-color: transparent;
+					}
+				}
+			}
+		}
+	}
+
 	&.is-resizing {
 		@at-root {
 			body:has(&) {

--- a/packages/edit-site/src/components/site-hub/style.scss
+++ b/packages/edit-site/src/components/site-hub/style.scss
@@ -8,6 +8,11 @@
 		gap: 0;
 	}
 
+	.edit-site-site-hub__site-title,
+	.edit-site-site-hub_toggle-command-center {
+		transition: opacity ease 0.1s;
+	}
+
 	.edit-site-site-hub__site-view-link {
 		flex-grow: 0;
 		@include break-mobile() {


### PR DESCRIPTION
## What?
Increase the z-index applied to `.edit-site-layout__canvas-container`.

## Why?
To stop it underlapping the 'site hub'

## Testing Instructions
1. Enter the Site Editor
2. Hover the preview frame, grab the resize handle and increase the width
3. Observe that the frame overlaps the 'site hub'.

## Before
https://github.com/WordPress/gutenberg/assets/846565/51fedb4f-356f-4def-8959-e3ed8a73a39a

## After
https://github.com/WordPress/gutenberg/assets/846565/b93aa8a8-21d8-47cf-91b2-73c467bcd83a


## Trade-off
There's a small trade-off: when you click to edit the document, the frame overlaps the document toolbar. But that should be fixed when https://github.com/WordPress/gutenberg/issues/51903 is addressed. 