### PR TITLE
[Edit Post]: Add toggle fullscreen mode and list view commands

### DIFF
--- a/packages/edit-post/src/hooks/commands/use-common-commands.js
+++ b/packages/edit-post/src/hooks/commands/use-common-commands.js
@@ -10,6 +10,8 @@ import {
 	drawerRight,
 	blockDefault,
 	keyboardClose,
+	desktop,
+	listView,
 } from '@wordpress/icons';
 import { useCommand } from '@wordpress/commands';
 import { store as preferencesStore } from '@wordpress/preferences';
@@ -23,16 +25,24 @@ import { PREFERENCES_MODAL_NAME } from '../../components/preferences-modal';
 import { store as editPostStore } from '../../store';
 
 export default function useCommonCommands() {
-	const { openGeneralSidebar, closeGeneralSidebar, switchEditorMode } =
-		useDispatch( editPostStore );
+	const {
+		openGeneralSidebar,
+		closeGeneralSidebar,
+		switchEditorMode,
+		setIsListViewOpened,
+	} = useDispatch( editPostStore );
 	const { openModal } = useDispatch( interfaceStore );
-	const { editorMode, activeSidebar } = useSelect(
-		( select ) => ( {
-			activeSidebar: select( interfaceStore ).getActiveComplementaryArea(
-				editPostStore.name
-			),
-			editorMode: select( editPostStore ).getEditorMode(),
-		} ),
+	const { editorMode, activeSidebar, isListViewOpen } = useSelect(
+		( select ) => {
+			const { getEditorMode, isListViewOpened } = select( editPostStore );
+			return {
+				activeSidebar: select(
+					interfaceStore
+				).getActiveComplementaryArea( editPostStore.name ),
+				editorMode: getEditorMode(),
+				isListViewOpen: isListViewOpened(),
+			};
+		},
 		[]
 	);
 	const { toggle } = useDispatch( preferencesStore );
@@ -81,6 +91,26 @@ export default function useCommonCommands() {
 		icon: cog,
 		callback: ( { close } ) => {
 			toggle( 'core/edit-post', 'focusMode' );
+			close();
+		},
+	} );
+
+	useCommand( {
+		name: 'core/toggle-fullscreen-mode',
+		label: __( 'Toggle fullscreen mode' ),
+		icon: desktop,
+		callback: ( { close } ) => {
+			toggle( 'core/edit-post', 'fullscreenMode' );
+			close();
+		},
+	} );
+
+	useCommand( {
+		name: 'core/toggle-list-view',
+		label: __( 'Toggle list view' ),
+		icon: listView,
+		callback: ( { close } ) => {
+			setIsListViewOpened( ! isListViewOpen );
 			close();
 		},
 	} );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Resolves: https://github.com/WordPress/gutenberg/issues/51502

This PR adds the last two commands of the issue for post editor:
1. Toggle fullscreen mode
2. View outline / Opens the List view > Outline sidebar

excluding the comments commands, that can be tracked in a different issue.



## Testing Instructions
Test the commands in post editor.
