### PR TITLE
Hide word count and reading time meta data for the Posts Page details panel

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen-page/page-details.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-page/page-details.js
@@ -76,7 +76,7 @@ function getPageDetails( page ) {
 		: 0;
 	const readingTime = Math.round( wordsCounted / AVERAGE_READING_RATE );
 
-	if ( wordsCounted ) {
+	if ( wordsCounted && ! page?.postsPage ) {
 		details.push(
 			{
 				label: __( 'Words' ),
@@ -100,7 +100,7 @@ function getPageDetails( page ) {
 
 export default function PageDetails( { id } ) {
 	const { record } = useEntityRecord( 'postType', 'page', id );
-	const { parentTitle, templateTitle } = useSelect(
+	const { parentTitle, templateTitle, postsPage } = useSelect(
 		( select ) => {
 			const { getEditedPostContext } = unlock( select( editSiteStore ) );
 			const postContext = getEditedPostContext();
@@ -135,12 +135,16 @@ export default function PageDetails( { id } ) {
 				  )?.title?.rendered
 				: null;
 
+			const { getEntityRecord } = select( coreStore );
+			const siteSettings = getEntityRecord( 'root', 'site' );
+
 			return {
 				parentTitle: _parentTitle,
 				templateTitle: _templateTitle,
+				postsPage: record?.id === siteSettings?.page_for_posts,
 			};
 		},
-		[ record?.parent ]
+		[ record?.parent, record?.id ]
 	);
 	return (
 		<SidebarNavigationScreenDetailsPanel
@@ -150,6 +154,7 @@ export default function PageDetails( { id } ) {
 			{ getPageDetails( {
 				parentTitle,
 				templateTitle,
+				postsPage,
 				...record,
 			} ).map( ( { label, value } ) => (
 				<SidebarNavigationScreenDetailsPanelRow key={ label }>

--- a/packages/edit-site/src/components/sidebar-navigation-screen-page/page-details.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-page/page-details.js
@@ -76,7 +76,7 @@ function getPageDetails( page ) {
 		: 0;
 	const readingTime = Math.round( wordsCounted / AVERAGE_READING_RATE );
 
-	if ( wordsCounted && ! page?.postsPage ) {
+	if ( wordsCounted && ! page?.isPostsPage ) {
 		details.push(
 			{
 				label: __( 'Words' ),
@@ -100,7 +100,7 @@ function getPageDetails( page ) {
 
 export default function PageDetails( { id } ) {
 	const { record } = useEntityRecord( 'postType', 'page', id );
-	const { parentTitle, templateTitle, postsPage } = useSelect(
+	const { parentTitle, templateTitle, isPostsPage } = useSelect(
 		( select ) => {
 			const { getEditedPostContext } = unlock( select( editSiteStore ) );
 			const postContext = getEditedPostContext();
@@ -141,7 +141,7 @@ export default function PageDetails( { id } ) {
 			return {
 				parentTitle: _parentTitle,
 				templateTitle: _templateTitle,
-				postsPage: record?.id === siteSettings?.page_for_posts,
+				isPostsPage: record?.id === siteSettings?.page_for_posts,
 			};
 		},
 		[ record?.parent, record?.id ]
@@ -154,7 +154,7 @@ export default function PageDetails( { id } ) {
 			{ getPageDetails( {
 				parentTitle,
 				templateTitle,
-				postsPage,
+				isPostsPage,
 				...record,
 			} ).map( ( { label, value } ) => (
 				<SidebarNavigationScreenDetailsPanelRow key={ label }>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Hide word count and reading time metadata for the Posts Page details panel.

Fixes: https://github.com/WordPress/gutenberg/issues/51260

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Since the Posts Page (defined in reading settings) will always render a template rather than displaying a page, there is no reference for word count or reading time.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Create two pages. One titled "Blog" and the other one titled "Normal page"
2. Go to Settings > Reading and set the one titled "Blog" as the "posts page".
3. Go to Appearance > Editor. Then navigate to Pages.
4. Confirm that when you click on "Blog" it's not displaying the word count and reading time. Confirm that's displaying the word count and reading time for the "Normal page".

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/252415/f1de2636-e9d9-4bbe-914d-2867f5d8715a


