### PR TITLE
Image block: Fix cursor style when lightbox is opened

### DIFF
--- a/packages/block-library/src/image/style.scss
+++ b/packages/block-library/src/image/style.scss
@@ -184,6 +184,7 @@
 	width: 100vw;
 	height: 100vh;
 	visibility: hidden;
+	cursor: zoom-out;
 
 	.close-button {
 		position: absolute;
@@ -268,7 +269,6 @@
 			transform-origin: top left;
 			width: var(--lightbox-image-max-width);
 			height: var(--lightbox-image-max-height);
-			cursor: zoom-out;
 		}
 
 		&.active {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
The cursor to zoom out was not showing on the scrim when the lightbox was opened. Also, it was not showing when using the `fade` animation at all. This fixes that style.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Users should be signaled when using a mouse that clicking on any part of the lightbox overlay will close it.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
It puts the cursor style on the whole lightbox overlay rather than on just the image.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
1. Make sure the Gutenberg Interactivity API experiment is enabled.
2. Add an image to a post.
3. Ensure the lightbox is enabled by going to Advanced > Behaviors > Lightbox.
4. Publish and view the post.
5. Hover over the image; see that the _zoom in_ cursor is visible.
6. Click on the image; see that the the _zoom out_ cursor is visible no matter where on the overlay your mouse is (except for the close button).
7. Test with both the `zoom` and `fade` animation.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
N/A