### PR TITLE
Blog Home template details: Add link to manage posts

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen-details-footer/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-details-footer/style.scss
@@ -1,5 +1,4 @@
 .edit-site-sidebar-navigation-screen-details-footer {
-	padding-top: $grid-unit-10;
-	padding-bottom: $grid-unit-10;
+	min-height: $grid-unit-50;
 	padding-left: $grid-unit-20;
 }

--- a/packages/edit-site/src/components/sidebar-navigation-screen-template/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-template/index.js
@@ -21,6 +21,7 @@ import { useAddedBy } from '../list/added-by';
 import TemplateActions from '../template-actions';
 import HomeTemplateDetails from './home-template-details';
 import SidebarNavigationScreenDetailsFooter from '../sidebar-navigation-screen-details-footer';
+import SidebarNavigationItem from '../sidebar-navigation-item';
 
 function useTemplateDetails( postType, postId ) {
 	const { getDescription, getTitle, record } = useEditedEntityRecord(
@@ -48,11 +49,23 @@ function useTemplateDetails( postType, postId ) {
 			<HomeTemplateDetails />
 		) : null;
 
-	const footer = !! record?.modified ? (
+	const revisionsLink = !! record?.modified ? (
 		<SidebarNavigationScreenDetailsFooter
 			lastModifiedDateTime={ record.modified }
 		/>
 	) : null;
+
+	const manageLink =
+		record?.slug === 'home' || record?.slug === 'index' ? (
+			<SidebarNavigationItem
+				href="edit.php?post_type=post"
+				onClick={ () => {
+					document.location = 'edit.php?post_type=post';
+				} }
+			>
+				{ __( 'Manage all posts' ) }
+			</SidebarNavigationItem>
+		) : null;
 
 	const description = (
 		<>
@@ -86,7 +99,7 @@ function useTemplateDetails( postType, postId ) {
 		</>
 	);
 
-	return { title, description, content, footer };
+	return { title, description, content, revisionsLink, manageLink };
 }
 
 export default function SidebarNavigationScreenTemplate() {
@@ -95,10 +108,8 @@ export default function SidebarNavigationScreenTemplate() {
 		params: { postType, postId },
 	} = navigator;
 	const { setCanvasMode } = unlock( useDispatch( editSiteStore ) );
-	const { title, content, description, footer } = useTemplateDetails(
-		postType,
-		postId
-	);
+	const { title, content, description, revisionsLink, manageLink } =
+		useTemplateDetails( postType, postId );
 
 	return (
 		<SidebarNavigationScreen
@@ -122,7 +133,7 @@ export default function SidebarNavigationScreenTemplate() {
 			}
 			description={ description }
 			content={ content }
-			footer={ footer }
+			footer={ [ revisionsLink, manageLink ] }
 		/>
 	);
 }


### PR DESCRIPTION
## What?
Try adding "Manage all posts" link to the bottom of the Blog Home template details panel.

## Why?
Similar panels (Pages, Library, Templates) include links to manage the associated entries. Adding a link to manage posts from the Blog Home template detail panel is consistent with experiences users find elsewhere in the site editor and could be a handy shortcut.

## How?
Set up a `manageLink` const which is added to the `SidebarNavigationScreen` footer.

## Testing Instructions
* Open the Blog Home or Index template in the Site Editor.
* In the details panel, observe the "Manage all posts" link.
* Click the "Manage all posts" link to view the post management page in wp-admin.

## Screenshot
<img width="359" alt="Screenshot 2023-06-30 at 17 52 07" src="https://github.com/WordPress/gutenberg/assets/846565/a2831dfa-1f49-4b80-aefe-997cc6e06df0">

