### PR TITLE
Export store for the core/customize-widgets package.

### DIFF
--- a/packages/customize-widgets/src/index.js
+++ b/packages/customize-widgets/src/index.js
@@ -100,3 +100,4 @@ export function initialize( editorName, blockEditorSettings ) {
 		);
 	} );
 }
+export { store } from './store';


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Similar to https://github.com/WordPress/gutenberg/pull/51986, this PR exports `store` for the package to allow for usage with useSelect/useDispatch.

## Why?
Most of the examples import the [store directly from the package](https://developer.wordpress.org/block-editor/reference-guides/data/data-core-blocks/#getblocktype) and the expectation should be the same for this package.

