### PR TITLE
Export the store for the core/edit-widgets pacakage

### DIFF
--- a/packages/edit-widgets/src/index.js
+++ b/packages/edit-widgets/src/index.js
@@ -124,3 +124,5 @@ const registerBlock = ( block ) => {
 	}
 	registerBlockType( name, settings );
 };
+
+export { store } from './store';


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Similar to https://github.com/WordPress/gutenberg/pull/51986 and https://github.com/WordPress/gutenberg/pull/52189 this PR exports store for the package to allow for usage with useSelect/useDispatch.

## Why?
Most of the examples import the [store directly from the package](https://developer.wordpress.org/block-editor/reference-guides/data/data-core-blocks/#getblocktype) and the expectation should be the same for this package.

