### PR TITLE
Page List: Fix parent block selection when converting to link

### DIFF
--- a/packages/block-library/src/page-list/edit.js
+++ b/packages/block-library/src/page-list/edit.js
@@ -169,12 +169,6 @@ export default function PageListEdit( {
 		}, new Map() );
 	}, [ pages ] );
 
-	const convertToNavigationLinks = useConvertToNavigationLinks( {
-		clientId,
-		pages,
-		parentPageID,
-	} );
-
 	const blockProps = useBlockProps( {
 		className: classnames( 'wp-block-page-list', {
 			'has-text-color': !! context.textColor,
@@ -250,7 +244,7 @@ export default function PageListEdit( {
 	const {
 		isNested,
 		hasSelectedChild,
-		parentBlock,
+		parentClientId,
 		hasDraggedChild,
 		isChildOfNavigation,
 	} = useSelect(
@@ -258,7 +252,6 @@ export default function PageListEdit( {
 			const {
 				getBlockParentsByBlockName,
 				hasSelectedInnerBlock,
-				getBlockRootClientId,
 				hasDraggedInnerBlock,
 			} = select( blockEditorStore );
 			const blockParents = getBlockParentsByBlockName(
@@ -276,11 +269,18 @@ export default function PageListEdit( {
 				isChildOfNavigation: navigationBlockParents.length > 0,
 				hasSelectedChild: hasSelectedInnerBlock( clientId, true ),
 				hasDraggedChild: hasDraggedInnerBlock( clientId, true ),
-				parentBlock: getBlockRootClientId( clientId ),
+				parentClientId: navigationBlockParents[ 0 ],
 			};
 		},
 		[ clientId ]
 	);
+
+	const convertToNavigationLinks = useConvertToNavigationLinks( {
+		clientId,
+		pages,
+		parentClientId,
+		parentPageID,
+	} );
 
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {
 		allowedBlocks: [ 'core/page-list-item' ],
@@ -297,12 +297,12 @@ export default function PageListEdit( {
 	useEffect( () => {
 		if ( hasSelectedChild || hasDraggedChild ) {
 			openModal();
-			selectBlock( parentBlock );
+			selectBlock( parentClientId );
 		}
 	}, [
 		hasSelectedChild,
 		hasDraggedChild,
-		parentBlock,
+		parentClientId,
 		selectBlock,
 		openModal,
 	] );

--- a/packages/block-library/src/page-list/use-convert-to-navigation-links.js
+++ b/packages/block-library/src/page-list/use-convert-to-navigation-links.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { createBlock } from '@wordpress/blocks';
-import { useSelect, useDispatch } from '@wordpress/data';
+import { useDispatch } from '@wordpress/data';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 
 /**
@@ -116,27 +116,10 @@ export function convertToNavigationLinks( pages = [], parentPageID = null ) {
 export function useConvertToNavigationLinks( {
 	clientId,
 	pages,
+	parentClientId,
 	parentPageID,
 } ) {
 	const { replaceBlock, selectBlock } = useDispatch( blockEditorStore );
-
-	const { parentNavBlockClientId } = useSelect(
-		( select ) => {
-			const { getSelectedBlockClientId, getBlockParentsByBlockName } =
-				select( blockEditorStore );
-
-			const _selectedBlockClientId = getSelectedBlockClientId();
-
-			return {
-				parentNavBlockClientId: getBlockParentsByBlockName(
-					_selectedBlockClientId,
-					'core/navigation',
-					true
-				)[ 0 ],
-			};
-		},
-		[ clientId ]
-	);
 
 	return () => {
 		const navigationLinks = convertToNavigationLinks( pages, parentPageID );
@@ -145,6 +128,6 @@ export function useConvertToNavigationLinks( {
 		replaceBlock( clientId, navigationLinks );
 
 		// Select the Navigation block to reveal the changes.
-		selectBlock( parentNavBlockClientId );
+		selectBlock( parentClientId );
 	};
 }


### PR DESCRIPTION
## What?

Closes #50477

PR fixes the block selection loss when converting the Page List block to the links from the List View settings tab.

I also (by accident) fixed a bug when an incorrect block was selected if Page List was nested in a submenu.

## Why?
The side-effect that opens the modal also re-selects the parent navigation block. The action was causing the `parentNavBlockClientId` from the `useConvertToNavigationLinks` hook to be `undefined` since the Navigation block can't have itself as a parent.

## How?
For simplicity, use the parent client ID from `navigationBlockParents` and pass it to the `useConvertToNavigationLinks`.

## Testing Instructions
1. Open a Post or Page.
2. Insert a Navigation block that has inner Page List blocks.
3. Conver the block to links using the List View in the block settings sidebar.
4. Confirm block selection isn't lost and the Navigation block is still selected.

## Screenshots or screencast <!-- if applicable -->

**Before**

https://github.com/WordPress/gutenberg/assets/240569/26f38756-f744-40c2-a55c-fb750a3b8cee

**After**

https://github.com/WordPress/gutenberg/assets/240569/8d5a1ce7-f947-490d-9bbb-2510059a48dd


