### PR TITLE
Fix Shift+Tab to Block Toolbar

### DIFF
--- a/packages/block-editor/src/components/block-popover/index.js
+++ b/packages/block-editor/src/components/block-popover/index.js
@@ -44,6 +44,8 @@ function BlockPopover(
 		usePopoverScroll( __unstableContentRef ),
 	] );
 
+	console.log( mergedRefs );
+
 	const [
 		popoverDimensionsRecomputeCounter,
 		forceRecomputePopoverDimensions,

--- a/packages/block-editor/src/components/block-popover/index.js
+++ b/packages/block-editor/src/components/block-popover/index.js
@@ -44,8 +44,6 @@ function BlockPopover(
 		usePopoverScroll( __unstableContentRef ),
 	] );
 
-	console.log( mergedRefs );
-
 	const [
 		popoverDimensionsRecomputeCounter,
 		forceRecomputePopoverDimensions,

--- a/packages/block-editor/src/components/block-tools/block-contextual-toolbar.js
+++ b/packages/block-editor/src/components/block-tools/block-contextual-toolbar.js
@@ -27,7 +27,7 @@ import { store as blockEditorStore } from '../../store';
 import BlockIcon from '../block-icon';
 import { unlock } from '../../lock-unlock';
 
-function BlockContextualToolbar( { focusOnMount, isFixed, ...props } ) {
+function BlockContextualToolbar( { isFixed, ...props } ) {
 	// When the toolbar is fixed it can be collapsed
 	const [ isCollapsed, setIsCollapsed ] = useState( false );
 	const toolbarButtonRef = useRef();
@@ -87,7 +87,6 @@ function BlockContextualToolbar( { focusOnMount, isFixed, ...props } ) {
 
 	return (
 		<NavigableToolbar
-			focusOnMount={ focusOnMount }
 			className={ classes }
 			/* translators: accessibility text for the block toolbar */
 			aria-label={ __( 'Block tools' ) }

--- a/packages/block-editor/src/components/block-tools/selected-block-popover.js
+++ b/packages/block-editor/src/components/block-tools/selected-block-popover.js
@@ -83,25 +83,18 @@ function SelectedBlockPopover( {
 		! hasMultiSelection &&
 		( editorMode === 'navigation' || editorMode === 'zoom-out' );
 
-	const toolbarRef = useRef();
-
-	function focusFirstTabbableIn( container ) {
-		console.log( container );
-		// const [ firstTabbable ] = focus.tabbable.find( container );
-		// if ( firstTabbable ) {
-		// 	firstTabbable.focus();
-		// }
-	}
-
 	useShortcut(
 		'core/block-editor/focus-toolbar',
 		() => {
-			console.log( 'using shortcut', toolbarRef.current );
-			// isToolbarForced.current = true;
-			focusFirstTabbableIn( toolbarRef.current );
+			console.log( 'inside shortcut', shouldShowContextualToolbar );
 			stopTyping( true );
+		},
+		{
+			isDisabled: ! canFocusHiddenToolbar,
 		}
 	);
+
+	console.log( 'outside shortcut', shouldShowContextualToolbar );
 
 	const popoverProps = useBlockToolbarPopoverProps( {
 		contentElement: __unstableContentRef?.current,
@@ -116,7 +109,6 @@ function SelectedBlockPopover( {
 
 		return (
 			<BlockPopover
-				ref={ toolbarRef }
 				clientId={ capturingClientId || clientId }
 				bottomClientId={ lastClientId }
 				className={ classnames(
@@ -146,7 +138,9 @@ function SelectedBlockPopover( {
 
 				<BlockContextualToolbar
 					style={ {
-						visibility: shouldShowContextualToolbar ? 'visible' : 'hidden',
+						position: ! shouldShowContextualToolbar ? 'absolute' : undefined,
+						left: ! shouldShowContextualToolbar ? '-9999999999px' : undefined,
+						opacity: ! shouldShowContextualToolbar ? 0 : undefined,
 					} }
 					// Resets the index whenever the active block changes so
 					// this is not persisted. See https://github.com/WordPress/gutenberg/pull/25760#issuecomment-717906169

--- a/packages/block-editor/src/components/navigable-toolbar/index.js
+++ b/packages/block-editor/src/components/navigable-toolbar/index.js
@@ -18,14 +18,6 @@ function hasOnlyToolbarItem( elements ) {
 	return ! elements.some( ( element ) => ! ( dataProp in element.dataset ) );
 }
 
-function getAllToolbarItemsIn( container ) {
-	return Array.from( container.querySelectorAll( '[data-toolbar-item]' ) );
-}
-
-function hasFocusWithin( container ) {
-	return container.contains( container.ownerDocument.activeElement );
-}
-
 function focusFirstTabbableIn( container ) {
 	const [ firstTabbable ] = focus.tabbable.find( container );
 	if ( firstTabbable ) {
@@ -88,91 +80,23 @@ function useIsAccessibleToolbar( ref ) {
 	return isAccessibleToolbar;
 }
 
-function useToolbarFocus(
-	ref,
-	focusOnMount,
-	isAccessibleToolbar,
-	defaultIndex,
-	onIndexChange,
-	shouldUseKeyboardFocusShortcut
-) {
-	// Make sure we don't use modified versions of this prop.
-	const [ initialFocusOnMount ] = useState( focusOnMount );
-	const [ initialIndex ] = useState( defaultIndex );
-
-	const focusToolbar = useCallback( () => {
-		console.log( ref.current );
-		focusFirstTabbableIn( ref.current );
-	}, [] );
-
-	const focusToolbarViaShortcut = () => {
-		if ( shouldUseKeyboardFocusShortcut ) {
-			console.log( 'focusToolbarViaShortcut')
-			// focusToolbar();
-		}
-	};
-
-	// Focus on toolbar when pressing alt+F10 when the toolbar is visible.
-	useShortcut( 'core/block-editor/focus-toolbar', focusToolbarViaShortcut );
-
-	useEffect( () => {
-		if ( initialFocusOnMount ) {
-			focusToolbar();
-		}
-	}, [ isAccessibleToolbar, initialFocusOnMount, focusToolbar ] );
-
-	useEffect( () => {
-		// Store ref so we have access on useEffect cleanup: https://legacy.reactjs.org/blog/2020/08/10/react-v17-rc.html#effect-cleanup-timing
-		const navigableToolbarRef = ref.current;
-		// If initialIndex is passed, we focus on that toolbar item when the
-		// toolbar gets mounted and initial focus is not forced.
-		// We have to wait for the next browser paint because block controls aren't
-		// rendered right away when the toolbar gets mounted.
-		let raf = 0;
-		if ( ! initialFocusOnMount ) {
-			raf = window.requestAnimationFrame( () => {
-				const items = getAllToolbarItemsIn( navigableToolbarRef );
-				const index = initialIndex || 0;
-				if ( items[ index ] && hasFocusWithin( navigableToolbarRef ) ) {
-					items[ index ].focus( {
-						// When focusing newly mounted toolbars,
-						// the position of the popover is often not right on the first render
-						// This prevents the layout shifts when focusing the dialogs.
-						preventScroll: true,
-					} );
-				}
-			} );
-		}
-		return () => {
-			window.cancelAnimationFrame( raf );
-			if ( ! onIndexChange || ! navigableToolbarRef ) return;
-			// When the toolbar element is unmounted and onIndexChange is passed, we
-			// pass the focused toolbar item index so it can be hydrated later.
-			const items = getAllToolbarItemsIn( navigableToolbarRef );
-			const index = items.findIndex( ( item ) => item.tabIndex === 0 );
-			onIndexChange( index );
-		};
-	}, [ initialIndex, initialFocusOnMount ] );
-}
 
 function NavigableToolbar( {
 	children,
-	focusOnMount,
 	shouldUseKeyboardFocusShortcut = true,
-	__experimentalInitialIndex: initialIndex,
-	__experimentalOnIndexChange: onIndexChange,
 	...props
 } ) {
 	const ref = useRef();
 	const isAccessibleToolbar = useIsAccessibleToolbar( ref );
 
-	useToolbarFocus(
-		ref,
-		focusOnMount,
-		isAccessibleToolbar,
-		initialIndex,
-		onIndexChange,
-		shouldUseKeyboardFocusShortcut
+	// Focus on toolbar when pressing alt+F10 when the toolbar is visible.
+	useShortcut( 'core/block-editor/focus-toolbar', () => {
+
+		if ( shouldUseKeyboardFocusShortcut ) {
+			console.log( 'howdy')
+			focusFirstTabbableIn( ref.current );
+		} } 
+		
 	);
 
 	if ( isAccessibleToolbar ) {

--- a/packages/block-editor/src/components/navigable-toolbar/index.js
+++ b/packages/block-editor/src/components/navigable-toolbar/index.js
@@ -101,12 +101,14 @@ function useToolbarFocus(
 	const [ initialIndex ] = useState( defaultIndex );
 
 	const focusToolbar = useCallback( () => {
+		console.log( ref.current );
 		focusFirstTabbableIn( ref.current );
 	}, [] );
 
 	const focusToolbarViaShortcut = () => {
 		if ( shouldUseKeyboardFocusShortcut ) {
-			focusToolbar();
+			console.log( 'focusToolbarViaShortcut')
+			// focusToolbar();
 		}
 	};
 


### PR DESCRIPTION
An attempt at fixing https://github.com/WordPress/gutenberg/issues/51876. Very much in draft state! I don't even know if this is a good idea, but it was feeling like a good approach since it removed and simplified a lot of the code while also being more performant. I expect to find a lot of bugs with this along the way though :) 

Notes:
- I'll be out until July 6th, so anyone is free to take this over! 
-There would need to be some kind of deprecation/preserving the old NavigableToolbar initialIndex, onIndexChange, and focusOnMount behavior from before. Or, we could just leave it as is but not use it.

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Shift+tab to focus the toolbar stopped working with the upgrade to ariakit. Something changed about the render order where it is rendered too late to receive the focus from shift+tab.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Instead of trying to get it to render sooner in the process, it seems better to leave it in the DOM and hide/show it via an old-school CSS move-it-way-off-frame method. Doing it this way gives us several advantages:
- Fewer mounts/unmounts of the component
- Simplifies the logic of preserving the index of moving focus into the toolbar. We don't need to rely on tracking and resetting the index between mounts since it never gets unmounted.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
