### PR TITLE
Image block: Disable behaviors dropdown if image has aspect ratio configured

### DIFF
--- a/lib/block-supports/behaviors.php
+++ b/lib/block-supports/behaviors.php
@@ -46,6 +46,7 @@ function gutenberg_register_behaviors_support( $block_type ) {
 function gutenberg_render_behaviors_support_lightbox( $block_content, $block ) {
 	$experiments      = get_option( 'gutenberg-experiments' );
 	$link_destination = isset( $block['attrs']['linkDestination'] ) ? $block['attrs']['linkDestination'] : 'none';
+	$aspect_ratio     = isset( $block['attrs']['aspectRatio'] ) ? $block['attrs']['aspectRatio'] : 'none';
 	// Get the lightbox setting from the block attributes.
 	if ( isset( $block['attrs']['behaviors']['lightbox'] ) ) {
 		$lightbox_settings = $block['attrs']['behaviors']['lightbox'];
@@ -63,7 +64,7 @@ function gutenberg_render_behaviors_support_lightbox( $block_content, $block ) {
 		return $block_content;
 	}
 
-	if ( ! $lightbox_settings || 'none' !== $link_destination || empty( $experiments['gutenberg-interactivity-api-core-blocks'] ) ) {
+	if ( ! $lightbox_settings || 'none' !== $link_destination || 'none' !== $aspect_ratio || empty( $experiments['gutenberg-interactivity-api-core-blocks'] ) ) {
 		return $block_content;
 	}
 

--- a/packages/block-editor/src/hooks/behaviors.js
+++ b/packages/block-editor/src/hooks/behaviors.js
@@ -20,7 +20,7 @@ function BehaviorsControl( {
 	blockBehaviors,
 	onChangeBehavior,
 	onChangeAnimation,
-	disabled = false,
+	override = [],
 } ) {
 	const { settings, themeBehaviors } = useSelect(
 		( select ) => {
@@ -89,9 +89,18 @@ function BehaviorsControl( {
 		return null;
 	}
 
-	const helpText = disabled
-		? __( 'The lightbox behavior is disabled for linked images.' )
-		: '';
+	let helpText =
+		override.length > 0
+			? 'The lightbox is disabled for images with the following configured options: '
+			: '';
+	override.forEach( ( element, index ) => {
+		helpText += element;
+		if ( override.length > 1 && index < override.length - 1 ) {
+			helpText += ', ';
+		} else {
+			helpText += '.';
+		}
+	} );
 
 	return (
 		<InspectorControls group="advanced">
@@ -105,7 +114,7 @@ function BehaviorsControl( {
 					hideCancelButton={ true }
 					help={ helpText }
 					size="__unstable-large"
-					disabled={ disabled }
+					disabled={ override.length > 0 ? true : false }
 				/>
 				{ behaviorsValue === 'lightbox' && (
 					<SelectControl
@@ -129,7 +138,7 @@ function BehaviorsControl( {
 						onChange={ onChangeAnimation }
 						hideCancelButton={ false }
 						size="__unstable-large"
-						disabled={ disabled }
+						disabled={ override.length > 0 ? true : false }
 					/>
 				) }
 			</div>
@@ -154,9 +163,17 @@ export const withBehaviors = createHigherOrderComponent( ( BlockEdit ) => {
 		if ( ! hasBlockSupport( props.name, 'behaviors' ) ) {
 			return blockEdit;
 		}
-		const blockHasLink =
+		const override = [];
+		if (
 			typeof props.attributes?.linkDestination !== 'undefined' &&
-			props.attributes?.linkDestination !== 'none';
+			props.attributes?.linkDestination !== 'none'
+		) {
+			override.push( 'link' );
+		}
+		if ( typeof props.attributes?.aspectRatio !== 'undefined' ) {
+			override.push( 'aspect ratio' );
+		}
+
 		return (
 			<>
 				{ blockEdit }
@@ -196,7 +213,7 @@ export const withBehaviors = createHigherOrderComponent( ( BlockEdit ) => {
 							},
 						} );
 					} }
-					disabled={ blockHasLink }
+					override={ override }
 				/>
 			</>
 		);

--- a/test/e2e/specs/editor/various/behaviors.spec.js
+++ b/test/e2e/specs/editor/various/behaviors.spec.js
@@ -178,6 +178,43 @@ test.describe( 'Testing behaviors functionality', () => {
 		await expect( select ).toBeDisabled();
 	} );
 
+	test( 'Lightbox behavior is disabled if the Image has a custom aspect ratio', async ( {
+		admin,
+		editor,
+		requestUtils,
+		page,
+		behaviorUtils,
+	} ) => {
+		// In this theme, the default value for settings.behaviors.blocks.core/image.lightbox is `true`.
+		await requestUtils.activateTheme( 'behaviors-enabled' );
+		await admin.createNewPost();
+		const media = await behaviorUtils.createMedia();
+
+		await editor.insertBlock( {
+			name: 'core/image',
+			attributes: {
+				alt: filename,
+				id: media.id,
+				url: media.source_url,
+				aspectRatio: '4/3',
+			},
+		} );
+
+		await editor.openDocumentSettingsSidebar();
+		const editorSettings = page.getByRole( 'region', {
+			name: 'Editor settings',
+		} );
+		await editorSettings
+			.getByRole( 'button', { name: 'Advanced' } )
+			.click();
+		const select = editorSettings.getByRole( 'combobox', {
+			name: 'Behavior',
+		} );
+
+		// The behaviors dropdown should be present but disabled.
+		await expect( select ).toBeDisabled();
+	} );
+
 	test( 'Lightbox behavior control has a default option that removes the markup', async ( {
 		admin,
 		editor,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
The image lightbox is currently incompatible with the aspect ratio configuration in image block settings.
This PR disables the lightbox when an aspect ratio is specified.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
We don't want to offer users broken experiences. Since the image lightbox is in early stages, we can plan to add to support for custom aspect ratios in a later version.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
It checks whether an aspect ratio is defined in the image block attributes, and if so, disables the dropdown. Since the lightbox is also disabled if a link is configured, the logic has also been revised to account for both scenarios.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
1. Ensure the Gutenberg Interactivity API experiments are enabled.
2. Add an image to a post.
3. Enable the lightbox in Advanced > Behaviors under the block settings.
4. Now try changing the aspect ratio under the image settings — see that the behaviors dropdown has been disabled, and that a message has appeared informing the user that the lightbox is incompatible aspect ratio configuration.
5. Now try adding a link to the image — see that the message for the behaviors dropdown has been updated to include incompatibility with links.
6. Remove the aspect ratio — see that the message updates appropriately.
7. Try saving the post and viewing it with an aspect ratio configured — the lightbox should be disabled.
8. Try saving the post with the aspect ratio set to `original` — the lightbox should work.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
N/A

## Screenshots or screencast <!-- if applicable -->
https://github.com/WordPress/gutenberg/assets/5360536/8839ead2-d4df-4a52-8adc-114553a42d71

