### PR TITLE
i18n: Add context to the word "Filters"

### DIFF
--- a/packages/block-editor/src/components/global-styles/filters-panel.js
+++ b/packages/block-editor/src/components/global-styles/filters-panel.js
@@ -22,7 +22,7 @@ import {
 	Flex,
 	FlexItem,
 } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import { useCallback, useMemo } from '@wordpress/element';
 
 /**
@@ -77,7 +77,7 @@ function FiltersToolsPanel( {
 
 	return (
 		<ToolsPanel
-			label={ __( 'Filters' ) }
+			label={ _x( 'Filters', 'Name for applying graphical effects' ) }
 			resetAll={ resetAll }
 			panelId={ panelId }
 		>


### PR DESCRIPTION
Related to:
- #49135
- #42255

## What?
This PR adds a translation context to the "Filters" label that appears in the sidebar of the image block.

![image](https://github.com/WordPress/gutenberg/assets/54422211/e57be63e-37dd-47f5-8857-db27d443cd48)

## Why?

On the Gutenberg plugin, this text is used in two places, each with a different meaning.

**Sidebar of the Image block**: Similar to the `filter` property in CSS and apply graphical effects like blur or color shift to an element.

![image](https://github.com/WordPress/gutenberg/assets/54422211/e3c7cdad-21cf-4989-a39a-c5dbb7a7c50b)

**Sidebar of the Query Loop block**: Narrow down multiple elements, such as a list, to only those that match the specified condition.

![query-loop](https://github.com/WordPress/gutenberg/assets/54422211/38320afa-de88-4ae8-8229-9d00a59205a8)

This text may be understood to be implicitly correct in English, depending on the context in which it is used. However, at least in Japanese, the two require the application of completely different translation texts depending on context.

## How?

Added context to "Filters" text for visual effects. I would appreciate your input on whether this context string is appropriate and whether this change would make sense in other languages.

## Testing Instructions

There should be no visual changes or impact on the code.