### PR TITLE
Editor: Avoid remounting pre-publish sidebar contents during autosave

### DIFF
--- a/packages/editor/src/components/post-publish-panel/index.js
+++ b/packages/editor/src/components/post-publish-panel/index.js
@@ -141,6 +141,7 @@ export default compose( [
 			isCurrentPostScheduled,
 			isEditedPostBeingScheduled,
 			isEditedPostDirty,
+			isAutosavingPost,
 			isSavingPost,
 			isSavingNonPostEntityChanges,
 		} = select( editorStore );
@@ -155,7 +156,7 @@ export default compose( [
 			isDirty: isEditedPostDirty(),
 			isPublished: isCurrentPostPublished(),
 			isPublishSidebarEnabled: isPublishSidebarEnabled(),
-			isSaving: isSavingPost(),
+			isSaving: isSavingPost() && ! isAutosavingPost(),
 			isSavingNonPostEntityChanges: isSavingNonPostEntityChanges(),
 			isScheduled: isCurrentPostScheduled(),
 		};


### PR DESCRIPTION
## What?
Fixes #51024.

PR updates the `isSaving` condition for the component to avoid remounting sidebar contents during the autosave.

## Why?
The autosaving sets `isSavingPost` to true and unmounts pre-publish panel contents to display the spinner. The unmounting causes the internal state of the panels to reset, which is used by Tags and Category suggestions to prevent panels from being hidden while the user is editing.

We only want to display the spinner, when switching from the `pre-publish` to the `post-publish` panel. This only happens after the actual save action and not the autosaves.


## Testing Instructions
1. Create a new post and add a title.
2. Open the pre-publish panel.
3. Select a tag.
4. Manually trigger an autosave - `wp.data.dispatch('core/editor').autosave()`.
5. Confirm that the Tags suggestion panel doesn't disappear.

## Screenshots or screencast <!-- if applicable -->

**Before**

https://github.com/WordPress/gutenberg/assets/240569/7e090a60-9b63-4435-8b97-7411e45a4472

**After**

https://github.com/WordPress/gutenberg/assets/240569/47c6ea75-53a9-427c-a8e4-8737f5ec405f

