### PR TITLE
PaletteEdit: Fix order numbers

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -12,6 +12,11 @@
 
 -   `Button`: Keep deprecated props in type definitions ([#59913](https://github.com/WordPress/gutenberg/pull/59913)).
 
+### Bug Fix
+-   `PaletteEdit`: Fix order numbers for color palette ([#52212](https://github.com/WordPress/gutenberg/pull/52212)).
+
+
+
 ## 27.1.0 (2024-03-06)
 
 ### Bug Fix

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -13,7 +13,7 @@
 -   `Button`: Keep deprecated props in type definitions ([#59913](https://github.com/WordPress/gutenberg/pull/59913)).
 
 ### Bug Fix
--   `PaletteEdit`: Fix order numbers for color palette ([#52212](https://github.com/WordPress/gutenberg/pull/52212)).
+-   `PaletteEdit`: Fix number incrementing of default names for new colors added in non-en-US locales ([#52212](https://github.com/WordPress/gutenberg/pull/52212)).
 
 
 

--- a/packages/components/src/palette-edit/index.tsx
+++ b/packages/components/src/palette-edit/index.tsx
@@ -108,7 +108,7 @@ export function getNameAndSlugForPosition(
 			__( 'Color %s' ),
 			position
 		),
-		slug: slugPrefix + 'color-' + position,
+		slug: `${ slugPrefix }color-${ position }`,
 	};
 }
 

--- a/packages/components/src/palette-edit/index.tsx
+++ b/packages/components/src/palette-edit/index.tsx
@@ -79,8 +79,8 @@ function NameInput( { value, onChange, label }: NameInputProps ) {
  * It expects slugs to be in the format: slugPrefix + color- + number.
  * It then sets the id component of the new name based on the incremented id of the highest existing slug id.
  *
- * @param  elements   An array of color palette items.
- * @param  slugPrefix The slug prefix used to match the element slug.
+ * @param elements   An array of color palette items.
+ * @param slugPrefix The slug prefix used to match the element slug.
  *
  * @return A name and slug for the new palette item.
  */

--- a/packages/components/src/palette-edit/index.tsx
+++ b/packages/components/src/palette-edit/index.tsx
@@ -82,7 +82,7 @@ function NameInput( { value, onChange, label }: NameInputProps ) {
  * @param  elements   An array of color palette items.
  * @param  slugPrefix The slug prefix used to match the element slug.
  *
- * @return {{name:string, slug:string}} A name and slug for the new palette item.
+ * @return A name and slug for the new palette item.
  */
 export function getNameAndSlugForPosition(
 	elements: PaletteElement[],

--- a/packages/components/src/palette-edit/index.tsx
+++ b/packages/components/src/palette-edit/index.tsx
@@ -74,17 +74,17 @@ function NameInput( { value, onChange, label }: NameInputProps ) {
 }
 
 /**
- * Returns a name for a palette item in the format "Color + id".
+ * Returns a name and slug for a palette item. The name takes the format "Color + id".
  * To ensure there are no duplicate ids, this function checks all slugs.
  * It expects slugs to be in the format: slugPrefix + color- + number.
  * It then sets the id component of the new name based on the incremented id of the highest existing slug id.
  *
- * @param elements   An array of color palette items.
- * @param slugPrefix The slug prefix used to match the element slug.
+ * @param  elements   An array of color palette items.
+ * @param  slugPrefix The slug prefix used to match the element slug.
  *
- * @return A unique name for a palette item.
+ * @return {{name:string, slug:string}} A name and slug for the new palette item.
  */
-export function getNameForPosition(
+export function getNameAndSlugForPosition(
 	elements: PaletteElement[],
 	slugPrefix: string
 ) {
@@ -102,11 +102,14 @@ export function getNameForPosition(
 		return previousValue;
 	}, 1 );
 
-	return sprintf(
-		/* translators: %s: is an id for a custom color */
-		__( 'Color %s' ),
-		position
-	);
+	return {
+		name: sprintf(
+			/* translators: %s: is an id for a custom color */
+			__( 'Color %s' ),
+			position
+		),
+		slug: slugPrefix + 'color-' + position,
+	};
 }
 
 function ColorPickerPopover< T extends Color | Gradient >( {
@@ -434,20 +437,19 @@ export function PaletteEdit( {
 									: __( 'Add color' )
 							}
 							onClick={ () => {
-								const optionName = getNameForPosition(
-									elements,
-									slugPrefix
-								);
+								const { name, slug } =
+									getNameAndSlugForPosition(
+										elements,
+										slugPrefix
+									);
 
 								if ( !! gradients ) {
 									onChange( [
 										...gradients,
 										{
 											gradient: DEFAULT_GRADIENT,
-											name: optionName,
-											slug:
-												slugPrefix +
-												kebabCase( optionName ),
+											name,
+											slug,
 										},
 									] );
 								} else {
@@ -455,10 +457,8 @@ export function PaletteEdit( {
 										...colors,
 										{
 											color: DEFAULT_COLOR,
-											name: optionName,
-											slug:
-												slugPrefix +
-												kebabCase( optionName ),
+											name,
+											slug,
 										},
 									] );
 								}

--- a/packages/components/src/palette-edit/test/index.tsx
+++ b/packages/components/src/palette-edit/test/index.tsx
@@ -7,7 +7,7 @@ import { click, type, press } from '@ariakit/test';
 /**
  * Internal dependencies
  */
-import PaletteEdit, { getNameForPosition } from '..';
+import PaletteEdit, { getNameAndSlugForPosition } from '..';
 import type { PaletteElement } from '../types';
 
 const noop = () => {};
@@ -21,12 +21,12 @@ async function clearInput( input: HTMLInputElement ) {
 	}
 }
 
-describe( 'getNameForPosition', () => {
+describe( 'getNameAndSlugForPosition', () => {
 	test( 'should return 1 by default', () => {
 		const slugPrefix = 'test-';
 		const elements: PaletteElement[] = [];
 
-		expect( getNameForPosition( elements, slugPrefix ) ).toEqual(
+		expect( getNameAndSlugForPosition( elements, slugPrefix ) ).toEqual(
 			'Color 1'
 		);
 	} );
@@ -41,7 +41,7 @@ describe( 'getNameForPosition', () => {
 			},
 		];
 
-		expect( getNameForPosition( elements, slugPrefix ) ).toEqual(
+		expect( getNameAndSlugForPosition( elements, slugPrefix ) ).toEqual(
 			'Color 2'
 		);
 	} );
@@ -56,7 +56,7 @@ describe( 'getNameForPosition', () => {
 			},
 		];
 
-		expect( getNameForPosition( elements, slugPrefix ) ).toEqual(
+		expect( getNameAndSlugForPosition( elements, slugPrefix ) ).toEqual(
 			'Color 1'
 		);
 	} );
@@ -86,7 +86,7 @@ describe( 'getNameForPosition', () => {
 			},
 		];
 
-		expect( getNameForPosition( elements, slugPrefix ) ).toEqual(
+		expect( getNameAndSlugForPosition( elements, slugPrefix ) ).toEqual(
 			'Color 151'
 		);
 	} );

--- a/packages/components/src/palette-edit/test/index.tsx
+++ b/packages/components/src/palette-edit/test/index.tsx
@@ -26,9 +26,10 @@ describe( 'getNameAndSlugForPosition', () => {
 		const slugPrefix = 'test-';
 		const elements: PaletteElement[] = [];
 
-		expect( getNameAndSlugForPosition( elements, slugPrefix ) ).toEqual(
-			'Color 1'
-		);
+		expect( getNameAndSlugForPosition( elements, slugPrefix ) ).toEqual( {
+			name: 'Color 1',
+			slug: 'test-color-1',
+		} );
 	} );
 
 	test( 'should return a new color name with an incremented slug id', () => {
@@ -41,9 +42,10 @@ describe( 'getNameAndSlugForPosition', () => {
 			},
 		];
 
-		expect( getNameAndSlugForPosition( elements, slugPrefix ) ).toEqual(
-			'Color 2'
-		);
+		expect( getNameAndSlugForPosition( elements, slugPrefix ) ).toEqual( {
+			name: 'Color 2',
+			slug: 'test-color-2',
+		} );
 	} );
 
 	test( 'should ignore user-defined color names', () => {
@@ -56,9 +58,10 @@ describe( 'getNameAndSlugForPosition', () => {
 			},
 		];
 
-		expect( getNameAndSlugForPosition( elements, slugPrefix ) ).toEqual(
-			'Color 1'
-		);
+		expect( getNameAndSlugForPosition( elements, slugPrefix ) ).toEqual( {
+			name: 'Color 1',
+			slug: 'test-color-1',
+		} );
 	} );
 
 	test( 'should return a new color name with an incremented slug id one higher than the current highest', () => {
@@ -86,9 +89,10 @@ describe( 'getNameAndSlugForPosition', () => {
 			},
 		];
 
-		expect( getNameAndSlugForPosition( elements, slugPrefix ) ).toEqual(
-			'Color 151'
-		);
+		expect( getNameAndSlugForPosition( elements, slugPrefix ) ).toEqual( {
+			name: 'Color 151',
+			slug: 'test-color-151',
+		} );
 	} );
 } );
 

--- a/packages/components/src/palette-edit/test/index.tsx
+++ b/packages/components/src/palette-edit/test/index.tsx
@@ -32,7 +32,7 @@ describe( 'getNameAndSlugForPosition', () => {
 		} );
 	} );
 
-	test( 'should return a new color name with an incremented slug id', () => {
+	test( 'should return a new color name and slug with an incremented slug id', () => {
 		const slugPrefix = 'test-';
 		const elements = [
 			{
@@ -48,7 +48,7 @@ describe( 'getNameAndSlugForPosition', () => {
 		} );
 	} );
 
-	test( 'should ignore user-defined color names', () => {
+	test( 'should ignore user-defined color name and slug', () => {
 		const slugPrefix = 'test-';
 		const elements = [
 			{
@@ -64,7 +64,7 @@ describe( 'getNameAndSlugForPosition', () => {
 		} );
 	} );
 
-	test( 'should return a new color name with an incremented slug id one higher than the current highest', () => {
+	test( 'should return a new color name and slug with an incremented slug id one higher than the current highest', () => {
 		const slugPrefix = 'test-';
 		const elements = [
 			{


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

For #51230



## Why?
copilot:summary

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

- Change Site Language Setting English to 日本語

<img width="623" alt="image" src="https://github.com/WordPress/gutenberg/assets/1205958/6576ef03-93e9-4fbb-a8d3-4c9cb84a52a1">

- Go to Style Color setting
- Push the Custom（カスタム） Plus icon

<img width="299" alt="image" src="https://github.com/WordPress/gutenberg/assets/1205958/fdee472e-5843-47d7-a718-eccf7c580218">

- You can find Custom Color (the name is 色 1)
- Add some custom colors
- You can watch Color name (incremental)

<img width="540" alt="image" src="https://github.com/WordPress/gutenberg/assets/1205958/d9293dbf-beab-4a94-8360-e546aa3dfa68">



## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
