### PR TITLE
Sorting: assume standard sort is stable, try out the new toSorted method

### DIFF
--- a/packages/block-editor/src/utils/sorting.js
+++ b/packages/block-editor/src/utils/sorting.js
@@ -2,11 +2,10 @@
  * Recursive stable sorting comparator function.
  *
  * @param {string|Function} field Field to sort by.
- * @param {Array}           items Items to sort.
  * @param {string}          order Order, 'asc' or 'desc'.
  * @return {Function} Comparison function to be used in a `.sort()`.
  */
-const comparator = ( field, items, order ) => {
+const comparator = ( field, order ) => {
 	return ( a, b ) => {
 		let cmpA, cmpB;
 
@@ -18,23 +17,14 @@ const comparator = ( field, items, order ) => {
 			cmpB = b[ field ];
 		}
 
+		let result = 0;
 		if ( cmpA > cmpB ) {
-			return order === 'asc' ? 1 : -1;
+			result = 1;
 		} else if ( cmpB > cmpA ) {
-			return order === 'asc' ? -1 : 1;
+			result = -1;
 		}
 
-		const orderA = items.findIndex( ( item ) => item === a );
-		const orderB = items.findIndex( ( item ) => item === b );
-
-		// Stable sort: maintaining original array order
-		if ( orderA > orderB ) {
-			return 1;
-		} else if ( orderB > orderA ) {
-			return -1;
-		}
-
-		return 0;
+		return order === 'asc' ? result : -result;
 	};
 };
 
@@ -50,5 +40,5 @@ const comparator = ( field, items, order ) => {
  * @return {Array} Sorted items.
  */
 export function orderBy( items, field, order = 'asc' ) {
-	return items.concat().sort( comparator( field, items, order ) );
+	return items.concat().sort( comparator( field, order ) );
 }

--- a/packages/block-editor/src/utils/sorting.js
+++ b/packages/block-editor/src/utils/sorting.js
@@ -40,5 +40,5 @@ const comparator = ( field, order ) => {
  * @return {Array} Sorted items.
  */
 export function orderBy( items, field, order = 'asc' ) {
-	return items.concat().sort( comparator( field, order ) );
+	return items.toSorted( comparator( field, order ) );
 }

--- a/packages/block-library/src/navigation/menu-items-to-blocks.js
+++ b/packages/block-library/src/navigation/menu-items-to-blocks.js
@@ -36,7 +36,7 @@ function mapMenuItemsToBlocks( menuItems, level = 0 ) {
 	let mapping = {};
 
 	// The menuItem should be in menu_order sort order.
-	const sortedItems = [ ...menuItems ].sort(
+	const sortedItems = menuItems.toSorted(
 		( a, b ) => a.menu_order - b.menu_order
 	);
 

--- a/packages/blocks/src/api/factory.js
+++ b/packages/blocks/src/api/factory.js
@@ -6,7 +6,7 @@ import { v4 as uuid } from 'uuid';
 /**
  * WordPress dependencies
  */
-import { createHooks, applyFilters } from '@wordpress/hooks';
+import { applyFilters } from '@wordpress/hooks';
 
 /**
  * Internal dependencies
@@ -347,24 +347,11 @@ export function getPossibleBlockTransformations( blocks ) {
  * @return {?Object} Highest-priority transform candidate.
  */
 export function findTransform( transforms, predicate ) {
-	// The hooks library already has built-in mechanisms for managing priority
-	// queue, so leverage via locally-defined instance.
-	const hooks = createHooks();
-
-	for ( let i = 0; i < transforms.length; i++ ) {
-		const candidate = transforms[ i ];
-		if ( predicate( candidate ) ) {
-			hooks.addFilter(
-				'transform',
-				'transform/' + i.toString(),
-				( result ) => ( result ? result : candidate ),
-				candidate.priority
-			);
-		}
-	}
-
-	// Filter name is arbitrarily chosen but consistent with above aggregation.
-	return hooks.applyFilters( 'transform', null );
+	const priority = ( t ) => t.priority ?? 10;
+	const candidates = transforms
+		.filter( ( t ) => predicate( t ) )
+		.toSorted( ( t1, t2 ) => priority( t1 ) - priority( t2 ) );
+	return candidates.length > 0 ? candidates[ 0 ] : null;
 }
 
 /**


### PR DESCRIPTION
Array sort is specified as stable since 2019: https://stackoverflow.com/questions/3026281/what-is-the-stability-of-the-array-sort-method-in-different-browsers

This PR removes additional stabilizing code from `orderBy` -- all our supported browsers should be compliant by now. I'm not sure myself whether this change is really safe. Let's experiment and discuss.

Also I'm trying out the new `.toSorted()` method that doesn't mutate the original array. To use it, I had to upgrade `core-js`, `browserslist` and `caniuse-lite` to latest versions.