### PR TITLE
Make use of accessing private APIs from thunks directly

### DIFF
--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -28,7 +28,6 @@ import {
 } from '../utils/selection';
 import {
 	__experimentalUpdateSettings,
-	ensureDefaultBlock,
 	privateRemoveBlocks,
 } from './private-actions';
 
@@ -403,7 +402,7 @@ export const replaceBlocks =
 			initialPosition,
 			meta,
 		} );
-		dispatch( ensureDefaultBlock() );
+		dispatch.ensureDefaultBlock();
 	};
 
 /**

--- a/packages/block-editor/src/store/test/actions.js
+++ b/packages/block-editor/src/store/test/actions.js
@@ -216,6 +216,7 @@ describe( 'actions', () => {
 				getBlockCount: () => 1,
 			};
 			const dispatch = jest.fn();
+			dispatch.ensureDefaultBlock = jest.fn();
 
 			replaceBlock( 'chicken', block )( { select, dispatch } );
 
@@ -281,6 +282,7 @@ describe( 'actions', () => {
 				getBlockCount: () => 1,
 			};
 			const dispatch = jest.fn();
+			dispatch.ensureDefaultBlock = jest.fn();
 
 			replaceBlocks( [ 'chicken' ], blocks )( { select, dispatch } );
 
@@ -314,6 +316,7 @@ describe( 'actions', () => {
 				getBlockCount: () => 1,
 			};
 			const dispatch = jest.fn();
+			dispatch.ensureDefaultBlock = jest.fn();
 
 			replaceBlocks(
 				[ 'chicken' ],

--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -18,7 +18,6 @@ import { receiveItems, removeItems, receiveQueriedItems } from './queried-data';
 import { getOrLoadEntitiesConfig, DEFAULT_ENTITY_KEY } from './entities';
 import { createBatch } from './batch';
 import { STORE_NAME } from './name';
-import { getUndoEdits, getRedoEdits } from './private-selectors';
 
 /**
  * Returns an action object used in signalling that authors have been received.
@@ -407,8 +406,7 @@ export const editEntityRecord =
 export const undo =
 	() =>
 	( { select, dispatch } ) => {
-		// Todo: we shouldn't have to pass "root" here.
-		const undoEdit = select( ( state ) => getUndoEdits( state.root ) );
+		const undoEdit = select.getUndoEdits();
 		if ( ! undoEdit ) {
 			return;
 		}
@@ -425,8 +423,7 @@ export const undo =
 export const redo =
 	() =>
 	( { select, dispatch } ) => {
-		// Todo: we shouldn't have to pass "root" here.
-		const redoEdit = select( ( state ) => getRedoEdits( state.root ) );
+		const redoEdit = select.getRedoEdits();
 		if ( ! redoEdit ) {
 			return;
 		}

--- a/packages/core-data/src/index.js
+++ b/packages/core-data/src/index.js
@@ -8,13 +8,13 @@ import { createReduxStore, register } from '@wordpress/data';
  */
 import reducer from './reducer';
 import * as selectors from './selectors';
+import * as privateSelectors from './private-selectors';
 import * as actions from './actions';
 import * as resolvers from './resolvers';
 import createLocksActions from './locks/actions';
 import { rootEntitiesConfig, getMethodName } from './entities';
 import { STORE_NAME } from './name';
 import { unlock } from './private-apis';
-import { getNavigationFallbackId } from './private-selectors';
 
 // The entity selectors/resolvers and actions are shortcuts to their generic equivalents
 // (getEntityRecord, getEntityRecords, updateEntityRecord, updateEntityRecords)
@@ -64,9 +64,7 @@ const storeConfig = () => ( {
  * @see https://github.com/WordPress/gutenberg/blob/HEAD/packages/data/README.md#createReduxStore
  */
 export const store = createReduxStore( STORE_NAME, storeConfig() );
-unlock( store ).registerPrivateSelectors( {
-	getNavigationFallbackId,
-} );
+unlock( store ).registerPrivateSelectors( privateSelectors );
 register( store ); // Register store after unlocking private selectors to allow resolvers to use them.
 
 export { default as EntityProvider } from './entity-provider';


### PR DESCRIPTION
Since #51051, private selectors and actions are exposed to thunks directly, already unlocked. There are several opportunities in the Gutenberg codebase to use this new feature. This PR does that: `ensureDefaultBlock`, and accessing `undoEdits` and `redoEdits`.