### PR TITLE
Remove serverSideBlockDefinitions from a test

### DIFF
--- a/packages/blocks/src/api/registration.js
+++ b/packages/blocks/src/api/registration.js
@@ -129,7 +129,7 @@ import { store as blocksStore } from '../store';
  *                                              then no preview is shown.
  */
 
-export const serverSideBlockDefinitions = {};
+const serverSideBlockDefinitions = {};
 
 function isObject( object ) {
 	return object !== null && typeof object === 'object';

--- a/packages/blocks/src/api/test/registration.js
+++ b/packages/blocks/src/api/test/registration.js
@@ -28,7 +28,6 @@ import {
 	getBlockSupport,
 	hasBlockSupport,
 	isReusableBlock,
-	serverSideBlockDefinitions,
 	unstable__bootstrapServerSideBlockDefinitions, // eslint-disable-line camelcase
 } from '../registration';
 import { BLOCK_ICON_DEFAULT, DEPRECATED_ENTRY_KEYS } from '../constants';
@@ -822,7 +821,6 @@ describe( 'blocks', () => {
 										styles: [],
 										variations: [],
 										save: () => null,
-										...serverSideBlockDefinitions[ name ],
 										...blockSettingsWithDeprecations,
 									},
 									DEPRECATED_ENTRY_KEYS


### PR DESCRIPTION
Making the `serverSideBlockDefinitions` object a private variable in the module, stopping to export it. The only usage of the export was in a unit test. And that test doesn't need the value, because there are no server-bootstrapped block data present in a unit test.

This export was originally added in #16518. When implementing async block loading, I plan to turn the server bootstrap info into a part of Redux state.