### PR TITLE
Image block: Fix aspect ratio sizing

### DIFF
--- a/packages/block-library/src/image/block.json
+++ b/packages/block-library/src/image/block.json
@@ -64,10 +64,10 @@
 			"__experimentalRole": "content"
 		},
 		"width": {
-			"type": "number"
+			"type": "string"
 		},
 		"height": {
-			"type": "number"
+			"type": "string"
 		},
 		"aspectRatio": {
 			"type": "string"

--- a/packages/block-library/src/image/deprecated.js
+++ b/packages/block-library/src/image/deprecated.js
@@ -6,7 +6,11 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { RichText, useBlockProps } from '@wordpress/block-editor';
+import {
+	RichText,
+	useBlockProps,
+	__experimentalGetBorderClassesAndStyles as getBorderClassesAndStyles,
+} from '@wordpress/block-editor';
 
 /**
  * Deprecation for adding the `wp-image-${id}` class to the image block for
@@ -539,4 +543,174 @@ const v5 = {
 	},
 };
 
-export default [ v5, v4, v3, v2, v1 ];
+/**
+ * Deprecation for using CSS strings for width and height attributes.
+ *
+ * @see TODO
+ */
+const v6 = {
+	attributes: {
+		align: {
+			type: 'string',
+		},
+		url: {
+			type: 'string',
+			source: 'attribute',
+			selector: 'img',
+			attribute: 'src',
+			__experimentalRole: 'content',
+		},
+		alt: {
+			type: 'string',
+			source: 'attribute',
+			selector: 'img',
+			attribute: 'alt',
+			default: '',
+			__experimentalRole: 'content',
+		},
+		caption: {
+			type: 'string',
+			source: 'html',
+			selector: 'figcaption',
+			__experimentalRole: 'content',
+		},
+		title: {
+			type: 'string',
+			source: 'attribute',
+			selector: 'img',
+			attribute: 'title',
+			__experimentalRole: 'content',
+		},
+		href: {
+			type: 'string',
+			source: 'attribute',
+			selector: 'figure > a',
+			attribute: 'href',
+			__experimentalRole: 'content',
+		},
+		rel: {
+			type: 'string',
+			source: 'attribute',
+			selector: 'figure > a',
+			attribute: 'rel',
+		},
+		linkClass: {
+			type: 'string',
+			source: 'attribute',
+			selector: 'figure > a',
+			attribute: 'class',
+		},
+		id: {
+			type: 'number',
+			__experimentalRole: 'content',
+		},
+		width: {
+			type: 'number',
+		},
+		height: {
+			type: 'number',
+		},
+		aspectRatio: {
+			type: 'string',
+		},
+		scale: {
+			type: 'string',
+		},
+		sizeSlug: {
+			type: 'string',
+		},
+		linkDestination: {
+			type: 'string',
+		},
+		linkTarget: {
+			type: 'string',
+			source: 'attribute',
+			selector: 'figure > a',
+			attribute: 'target',
+		},
+	},
+	save( { attributes } ) {
+		const {
+			url,
+			alt,
+			caption,
+			align,
+			href,
+			rel,
+			linkClass,
+			width,
+			height,
+			aspectRatio,
+			scale,
+			id,
+			linkTarget,
+			sizeSlug,
+			title,
+		} = attributes;
+
+		const newRel = ! rel ? undefined : rel;
+		const borderProps = getBorderClassesAndStyles( attributes );
+
+		const classes = classnames( {
+			[ `align${ align }` ]: align,
+			[ `size-${ sizeSlug }` ]: sizeSlug,
+			'is-resized': width || height,
+			'has-custom-border':
+				!! borderProps.className ||
+				( borderProps.style &&
+					Object.keys( borderProps.style ).length > 0 ),
+		} );
+
+		const imageClasses = classnames( borderProps.className, {
+			[ `wp-image-${ id }` ]: !! id,
+		} );
+
+		const image = (
+			<img
+				src={ url }
+				alt={ alt }
+				className={ imageClasses || undefined }
+				style={ {
+					...borderProps.style,
+					aspectRatio,
+					objectFit: scale,
+				} }
+				width={ width }
+				height={ height }
+				title={ title }
+			/>
+		);
+
+		const figure = (
+			<>
+				{ href ? (
+					<a
+						className={ linkClass }
+						href={ href }
+						target={ linkTarget }
+						rel={ newRel }
+					>
+						{ image }
+					</a>
+				) : (
+					image
+				) }
+				{ ! RichText.isEmpty( caption ) && (
+					<RichText.Content
+						className="wp-element-caption"
+						tagName="figcaption"
+						value={ caption }
+					/>
+				) }
+			</>
+		);
+
+		return (
+			<figure { ...useBlockProps.save( { className: classes } ) }>
+				{ figure }
+			</figure>
+		);
+	},
+};
+
+export default [ v6, v5, v4, v3, v2, v1 ];

--- a/packages/block-library/src/image/editor.scss
+++ b/packages/block-library/src/image/editor.scss
@@ -1,6 +1,9 @@
 // Provide special styling for the placeholder.
 // @todo: this particular minimal style of placeholder could be componentized further.
 .wp-block-image.wp-block-image {
+	// Using "display: flex" so the size of the drag handles do not affect the size of the block.
+	display: flex;
+
 	// Show Placeholder style on-select.
 	&.is-selected .components-placeholder {
 		// Block UI appearance.
@@ -66,10 +69,9 @@ figure.wp-block-image:not(.wp-block) {
 
 // This is necessary for the editor resize handles to accurately work on a non-floated, non-resized, small image.
 .wp-block-image .components-resizable-box__container {
-	// Using "display: table" because:
-	// - it visually hides empty white space in between elements
-	// - it allows the element to be as wide as its contents (instead of 100% width, as it would be with `display: block`)
-	display: table;
+	// Using "display: inline-flex" so the element is as wide as its contents and object-fit still works.
+	display: inline-flex;
+
 	img {
 		display: block;
 		width: inherit;

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -474,8 +474,8 @@ export default function Image( {
 					) }
 					<DimensionsTool
 						value={ {
-							width: width && `${ width }px`,
-							height: height && `${ height }px`,
+							width,
+							height,
 							scale,
 							aspectRatio,
 						} }
@@ -484,12 +484,8 @@ export default function Image( {
 							// for values that are removed since setAttributes
 							// doesn't do anything with keys that aren't set.
 							setAttributes( {
-								width:
-									newValue.width &&
-									parseInt( newValue.width, 10 ),
-								height:
-									newValue.height &&
-									parseInt( newValue.height, 10 ),
+								width: newValue.width,
+								height: newValue.height,
 								scale: newValue.scale,
 								aspectRatio: newValue.aspectRatio,
 							} );
@@ -583,8 +579,8 @@ export default function Image( {
 			<ImageEditor
 				id={ id }
 				url={ url }
-				width={ width }
-				height={ height }
+				width={ width && parseInt( width, 10 ) }
+				height={ height && parseInt( height, 10 ) }
 				clientWidth={ fallbackClientWidth }
 				naturalHeight={ naturalHeight }
 				naturalWidth={ naturalWidth }
@@ -600,14 +596,18 @@ export default function Image( {
 	} else if ( ! isResizable ) {
 		img = <div style={ { width, height, aspectRatio } }>{ img }</div>;
 	} else {
+		const pxWidth = width ? parseInt( width, 10 ) : undefined;
+		const pxHeight = height ? parseInt( height, 10 ) : undefined;
+
 		const ratio =
 			( aspectRatio && evalAspectRatio( aspectRatio ) ) ||
-			( width && height && width / height ) ||
+			( pxWidth && pxHeight && pxWidth / pxHeight ) ||
 			naturalWidth / naturalHeight ||
 			1;
 
-		const currentWidth = ! width && height ? height * ratio : width;
-		const currentHeight = ! height && width ? width / ratio : height;
+		const currentWidth = ! pxWidth && pxHeight ? pxHeight * ratio : pxWidth;
+		const currentHeight =
+			! pxHeight && pxWidth ? pxWidth / ratio : pxHeight;
 
 		const minWidth =
 			naturalWidth < naturalHeight ? MIN_SIZE : MIN_SIZE * ratio;
@@ -679,8 +679,8 @@ export default function Image( {
 				onResizeStop={ ( event, direction, elt ) => {
 					onResizeStop();
 					setAttributes( {
-						width: elt.offsetWidth,
-						height: elt.offsetHeight,
+						width: `${ elt.offsetWidth }px`,
+						height: `${ elt.offsetHeight }px`,
 						aspectRatio: undefined,
 					} );
 				} }

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -565,10 +565,6 @@ export default function Image( {
 				ref={ imageRef }
 				className={ borderProps.className }
 				style={ {
-					width:
-						( width && height ) || aspectRatio ? '100%' : 'inherit',
-					height:
-						( width && height ) || aspectRatio ? '100%' : 'inherit',
 					objectFit: scale,
 					...borderProps.style,
 				} }
@@ -661,12 +657,7 @@ export default function Image( {
 		img = (
 			<ResizableBox
 				style={ {
-					display: 'block',
-					objectFit: scale,
-					aspectRatio:
-						! width && ! height && aspectRatio
-							? aspectRatio
-							: undefined,
+					aspectRatio: ! width && ! height && aspectRatio,
 				} }
 				size={ {
 					width: currentWidth ?? 'auto',

--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -34,6 +34,35 @@ function render_block_core_image( $attributes, $content ) {
 }
 
 /**
+ * Prevent adding width and height attributes if they are already set in the styles.
+ *
+ * @param bool   $value   The filtered value, defaults to `true`.
+ * @param string $image   The HTML `img` tag where the attribute should be added.
+ * @param string $context Additional context about how the function was called or where the img tag is.
+ * @return bool Whether the width and height attributes should be set.
+ */
+function filter_width_height_core_image( $value, $image, $context ) {
+	$processor = new WP_HTML_Tag_Processor( $image );
+	$processor->next_tag( 'img' );
+
+	$style = $processor->get_attribute( 'style' );
+	echo '<pre>';
+	var_dump( $image, $context  );
+	echo '</pre>';
+
+	if ( $style === null ) {
+		return $value;
+	}
+
+	$match = preg_match( '/\b(width|height|aspect-ratio)\s*:\s*[^;]+/', $style, $matches );
+	echo '<pre>';
+	var_dump( $style, $match, $matches );
+	echo '</pre>';
+
+	return ! $match;
+}
+
+/**
  * Registers the `core/image` block on server.
  */
 function register_block_core_image() {
@@ -46,3 +75,4 @@ function register_block_core_image() {
 	);
 }
 add_action( 'init', 'register_block_core_image' );
+add_filter( 'wp_img_tag_add_width_and_height_attr', 'filter_width_height_core_image', 10, 3 );

--- a/packages/block-library/src/image/save.js
+++ b/packages/block-library/src/image/save.js
@@ -56,11 +56,13 @@ export default function save( { attributes } ) {
 			className={ imageClasses || undefined }
 			style={ {
 				...borderProps.style,
+				width: ! width && ! height ? undefined : width ?? 'auto',
+				height: ! width && ! height ? undefined : height ?? 'auto',
 				aspectRatio,
 				objectFit: scale,
 			} }
-			width={ width }
-			height={ height }
+			width={ width && parseInt( width, 10 ) }
+			height={ height && parseInt( height, 10 ) }
 			title={ title }
 		/>
 	);

--- a/packages/block-library/src/image/style.scss
+++ b/packages/block-library/src/image/style.scss
@@ -1,6 +1,5 @@
 .wp-block-image {
 	img {
-		height: auto;
 		max-width: 100%;
 		vertical-align: bottom;
 		box-sizing: border-box;
@@ -29,7 +28,6 @@
 
 	&.alignfull img,
 	&.alignwide img {
-		height: auto;
 		width: 100%;
 	}
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

**WORK IN PROGRESS**

Includes changes from https://github.com/WordPress/gutenberg/pull/52135 because if the `save` function needs to be updated here, the `edit` function has to be updated anyway—may as well just combine them into one PR.

## What?
<!-- In a few words, what is the PR actually doing? -->

This is attempting to do actually a few things for the image block with a single block deprecation.

1. Fix #51929 
2. Fix #52219
3. Pave the way for other units to be enabled for the image block eventually.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Fixes a few issues with the addition of `aspect-ratio` to the image block.

It seemed better to think the whole thing out thoroughly 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

1. Opens up the image block to be sized with units other than pixels by changing the number `width` and `height` attributes to strings. (It does not actually enable the other units)
2. Changes the conditions where `width` and `height` HTML attributes are saved in favor of CSS `width` and `height`.
3. Update CSS.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

Screenshots use https://github.com/WordPress/wordpress-develop/blob/62b286f9b2ebc7bb609827a09fcf5136cac5fa01/tests/phpunit/data/images/a2-small.jpg for testing.

This is content for every possible combination of width/height/scale/aspect-ratio for the image block. Be sure to use an image that is smaller than the width of the page and one that doesn't have a 3:4 portrait aspect ratio (as that's the ratio set in the example).

```html
<!-- wp:heading -->
<h2 class="wp-block-heading">Default Block</h2>
<!-- /wp:heading -->

<!-- wp:image {"id":443,"sizeSlug":"full","linkDestination":"none"} -->
<figure class="wp-block-image size-full"><img src="http://wp.local/wp-content/uploads/2023/06/a2-small.jpg" alt="" class="wp-image-443"/></figure>
<!-- /wp:image -->

<!-- wp:heading -->
<h2 class="wp-block-heading">Width</h2>
<!-- /wp:heading -->

<!-- wp:image {"id":443,"width":200,"sizeSlug":"full","linkDestination":"none"} -->
<figure class="wp-block-image size-full is-resized"><img src="http://wp.local/wp-content/uploads/2023/06/a2-small.jpg" alt="" class="wp-image-443" width="200"/></figure>
<!-- /wp:image -->

<!-- wp:heading -->
<h2 class="wp-block-heading">Height</h2>
<!-- /wp:heading -->

<!-- wp:image {"id":443,"height":150,"sizeSlug":"full","linkDestination":"none"} -->
<figure class="wp-block-image size-full is-resized"><img src="http://wp.local/wp-content/uploads/2023/06/a2-small.jpg" alt="" class="wp-image-443" height="150"/></figure>
<!-- /wp:image -->

<!-- wp:heading -->
<h2 class="wp-block-heading">Ratio Scale</h2>
<!-- /wp:heading -->

<!-- wp:image {"id":443,"aspectRatio":"3/4","scale":"cover","sizeSlug":"full","linkDestination":"none"} -->
<figure class="wp-block-image size-full"><img src="http://wp.local/wp-content/uploads/2023/06/a2-small.jpg" alt="" class="wp-image-443" style="aspect-ratio:3/4;object-fit:cover"/></figure>
<!-- /wp:image -->

<!-- wp:heading -->
<h2 class="wp-block-heading">Ratio Scale Width</h2>
<!-- /wp:heading -->

<!-- wp:image {"id":443,"width":200,"aspectRatio":"3/4","scale":"cover","sizeSlug":"full","linkDestination":"none"} -->
<figure class="wp-block-image size-full is-resized"><img src="http://wp.local/wp-content/uploads/2023/06/a2-small.jpg" alt="" class="wp-image-443" style="aspect-ratio:3/4;object-fit:cover" width="200"/></figure>
<!-- /wp:image -->

<!-- wp:heading -->
<h2 class="wp-block-heading">Ratio Scale Height</h2>
<!-- /wp:heading -->

<!-- wp:image {"id":443,"height":267,"aspectRatio":"3/4","scale":"cover","sizeSlug":"full","linkDestination":"none"} -->
<figure class="wp-block-image size-full is-resized"><img src="http://wp.local/wp-content/uploads/2023/06/a2-small.jpg" alt="" class="wp-image-443" style="aspect-ratio:3/4;object-fit:cover" height="267"/></figure>
<!-- /wp:image -->

<!-- wp:heading -->
<h2 class="wp-block-heading">Scale Width Height</h2>
<!-- /wp:heading -->

<!-- wp:image {"id":443,"width":200,"height":267,"scale":"cover","sizeSlug":"full","linkDestination":"none"} -->
<figure class="wp-block-image size-full is-resized"><img src="http://wp.local/wp-content/uploads/2023/06/a2-small.jpg" alt="" class="wp-image-443" style="object-fit:cover" width="200" height="267"/></figure>
<!-- /wp:image -->
```

Make sure that there are no layout shifts as images load (can be tested easily with the network throttling option in your browser dev tools).

The sizing for images should look like the "After" screenshot below for both the editor and the frontend.

<!-- ### Testing Instructions for Keyboard
How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

### Post Editor

![image-scale-fix](https://github.com/WordPress/gutenberg/assets/5129775/85c5634c-4b3d-4a0b-998d-002adccbecdc)

### Frontend

```
TODO
```