### PR TITLE
Fix cleanup in `useRemoveBrowserShortcuts`

### DIFF
--- a/packages/block-editor/src/components/rich-text/use-remove-browser-shortcuts.js
+++ b/packages/block-editor/src/components/rich-text/use-remove-browser-shortcuts.js
@@ -23,7 +23,7 @@ export function useRemoveBrowserShortcuts() {
 		}
 		node.addEventListener( 'keydown', onKeydown );
 		return () => {
-			node.addEventListener( 'keydown', onKeydown );
+			node.removeEventListener( 'keydown', onKeydown );
 		};
 	}, [] );
 }


### PR DESCRIPTION
## What?
A correction to remove an event listener in a cleanup function.

## Why?
It fixes the intention of the code.

## How?
Removes an event listener (instead of adding another).

## Testing Instructions
I guess that automated tests pass.