### PR TITLE
gutenberg_add_global_styles_for_blocks should add all global styles.

### DIFF
--- a/lib/global-styles-and-settings.php
+++ b/lib/global-styles-and-settings.php
@@ -210,8 +210,8 @@ function gutenberg_add_global_styles_for_blocks() {
 					$block_name        = str_replace( 'core/', '', $result[0] );
 					$stylesheet_handle = 'wp-block-' . $block_name;
 				}
-				wp_add_inline_style( $stylesheet_handle, $block_css );
 			}
+			wp_add_inline_style( $stylesheet_handle, $block_css );
 		}
 	}
 }


### PR DESCRIPTION
Closes #52276
Regression after #50310

## What?
Load all elements global styles for non 'core/' blocks.

## Why?
Any style with $metadata['path'] will be skipped if does not have element starting with 'core/'.  We should use 'wp_add_inline_style' for all global styles.

## How?
Call 'wp_add_inline_style'  for all  block global styles. 

## Testing Instructions

1. Install custom block (name in block.json not starting with "core/") with support any global style defined in styles.blocks.some/block.elements (eg. button, link, h[1-6]) of theme.json
2. Change some value for button, link, h[1-6] in styles.blocks.some/block.elements 
3. See change are effective