### PR TITLE
Patterns: fix issue in 16.1 with wrong sync status set in Site Editor

### DIFF
--- a/bin/plugin/commands/performance.js
+++ b/bin/plugin/commands/performance.js
@@ -330,6 +330,10 @@ async function runPerformanceTests( branches, options ) {
 			path.join( environmentDirectory, '.wp-env.json' ),
 			JSON.stringify(
 				{
+					config: {
+						WP_DEBUG: false,
+						SCRIPT_DEBUG: false,
+					},
 					core: 'WordPress/WordPress',
 					plugins: [ path.join( environmentDirectory, 'plugin' ) ],
 					themes: [

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -2047,7 +2047,9 @@ export const getInserterItems = createSelector(
 						( reusableBlock ) =>
 							syncStatus === reusableBlock.meta?.sync_status ||
 							( ! syncStatus &&
-								reusableBlock.meta?.sync_status === '' )
+								( reusableBlock.meta?.sync_status === '' ||
+									reusableBlock.meta?.sync_status ===
+										'fully' ) ) // Only reusable blocks added via site editor in release 16.1 will have sync_status of 'fully'.
 					)
 					.map( buildReusableBlockInserterItem )
 			: [];

--- a/packages/edit-site/src/components/create-pattern-modal/index.js
+++ b/packages/edit-site/src/components/create-pattern-modal/index.js
@@ -54,7 +54,10 @@ export default function CreatePatternModal( {
 					title: name || __( 'Untitled Pattern' ),
 					content: '',
 					status: 'publish',
-					meta: { sync_status: syncType },
+					meta:
+						syncType === SYNC_TYPES.unsynced
+							? { sync_status: syncType }
+							: undefined,
 				},
 				{ throwOnError: true }
 			);

--- a/packages/edit-site/src/components/page-library/use-patterns.js
+++ b/packages/edit-site/src/components/page-library/use-patterns.js
@@ -145,7 +145,7 @@ const reusableBlockToPattern = ( reusableBlock ) => ( {
 	categories: reusableBlock.wp_pattern,
 	id: reusableBlock.id,
 	name: reusableBlock.slug,
-	syncStatus: reusableBlock.meta?.sync_status,
+	syncStatus: reusableBlock.meta?.sync_status || SYNC_TYPES.full,
 	title: reusableBlock.title.raw,
 	type: reusableBlock.type,
 	reusableBlock,

--- a/packages/editor/src/components/post-sync-status/index.js
+++ b/packages/editor/src/components/post-sync-status/index.js
@@ -26,13 +26,10 @@ export default function PostSyncStatus() {
 		editPost( {
 			meta: {
 				...meta,
-				wp_block:
-					syncStatus === 'unsynced'
-						? { sync_status: syncStatus }
-						: null,
+				sync_status: syncStatus === 'unsynced' ? syncStatus : null,
 			},
 		} );
-	const syncStatus = meta?.wp_block?.sync_status;
+	const syncStatus = meta?.sync_status;
 	const isFullySynced = ! syncStatus;
 
 	return (

--- a/phpunit/block-template-utils-test.php
+++ b/phpunit/block-template-utils-test.php
@@ -9,9 +9,6 @@ class Tests_Block_Template_Utils extends WP_UnitTestCase {
 	public function set_up() {
 		parent::set_up();
 		switch_theme( 'emptytheme' );
-	}
-
-	public static function wpSetUpBeforeClass() {
 		register_post_type(
 			'custom_book',
 			array(
@@ -22,9 +19,10 @@ class Tests_Block_Template_Utils extends WP_UnitTestCase {
 		register_taxonomy( 'book_type', 'custom_book' );
 	}
 
-	public static function wpTearDownAfterClass() {
+	public function tear_down() {
 		unregister_post_type( 'custom_book' );
 		unregister_taxonomy( 'book_type' );
+		parent::tear_down();
 	}
 
 	public function test_get_template_hierarchy() {

--- a/phpunit/bootstrap.php
+++ b/phpunit/bootstrap.php
@@ -22,6 +22,12 @@ if ( ! defined( 'LOCAL_WP_ENVIRONMENT_TYPE' ) ) {
 	define( 'LOCAL_WP_ENVIRONMENT_TYPE', 'local' );
 }
 
+// Pretend that these are Core unit tests. This is needed so that
+// wp_theme_has_theme_json() does not cache its return value between each test.
+if ( ! defined( 'WP_RUN_CORE_TESTS' ) ) {
+	define( 'WP_RUN_CORE_TESTS', true );
+}
+
 // Require composer dependencies.
 require_once dirname( __DIR__ ) . '/vendor/autoload.php';
 


### PR DESCRIPTION
## What?
There was a bug with synced patterns added in the Site Editor having a deprecated sync status added, which causes them not to display in the post editor inserter.

## Why?
The bug was [fixed here](https://github.com/WordPress/gutenberg/commit/866727e9f31bd98bde01df61a92676f6adb02744), but this fix did not make it into the 16.1 release.

## How?
Cherry picked the relevant commit and also added a check for the incorrect sync status to the reusable block selector.

This also includes the following php unit test fixes from trunk:

- https://github.com/WordPress/gutenberg/pull/51950
- https://github.com/WordPress/gutenberg/pull/52016

## Testing Instructions

1. Create both synced and unsynced patterns via the Library's create pattern modal
2. Ensure the new patterns (and any existing ones you have) are shown in the correct groups e.g. synced vs standard
6. Go to the post editor and make sure the sync patterns display in the synced patterns tab, and the unsynced ones display in Patterns tab under Custom patterns
7. Create further unsynced and synced patterns via the block editor
8. Make sure these new patterns and the existing ones are all still in the correct locations within the block editor's inserter and the Site Editor's library

## Screenshots or screencast <!-- if applicable -->
Before:

https://github.com/WordPress/gutenberg/assets/3629020/b6eee194-3e63-40d9-a690-b6cd30007036

After:

https://github.com/WordPress/gutenberg/assets/3629020/1b614ef5-99e9-4882-a143-9ab3a62fb721





