### PR TITLE
Patterns: Remove ability for user to toggle sync status after pattern creation in 16.1 release

### DIFF
--- a/packages/editor/src/components/post-sync-status/index.js
+++ b/packages/editor/src/components/post-sync-status/index.js
@@ -1,9 +1,9 @@
 /**
  * WordPress dependencies
  */
-import { useSelect, useDispatch } from '@wordpress/data';
+import { useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
-import { ToggleControl, PanelRow } from '@wordpress/components';
+import { PanelRow } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -11,7 +11,6 @@ import { ToggleControl, PanelRow } from '@wordpress/components';
 import { store as editorStore } from '../../store';
 
 export default function PostSyncStatus() {
-	const { editPost } = useDispatch( editorStore );
 	const { meta, postType } = useSelect( ( select ) => {
 		const { getEditedPostAttribute } = select( editorStore );
 		return {
@@ -22,31 +21,15 @@ export default function PostSyncStatus() {
 	if ( postType !== 'wp_block' ) {
 		return null;
 	}
-	const onUpdateSync = ( syncStatus ) =>
-		editPost( {
-			meta: {
-				...meta,
-				sync_status: syncStatus === 'unsynced' ? syncStatus : null,
-			},
-		} );
 	const syncStatus = meta?.sync_status;
 	const isFullySynced = ! syncStatus;
 
 	return (
 		<PanelRow className="edit-post-sync-status">
-			<span>{ __( 'Syncing' ) }</span>
-			<ToggleControl
-				__nextHasNoMarginBottom
-				label={
-					isFullySynced ? __( 'Fully synced' ) : __( 'Not synced' )
-				}
-				checked={ isFullySynced }
-				onChange={ () => {
-					onUpdateSync(
-						syncStatus === 'unsynced' ? 'fully' : 'unsynced'
-					);
-				} }
-			/>
+			<span>{ __( 'Sync status' ) }</span>
+			<div>
+				{ isFullySynced ? __( 'Fully synced' ) : __( 'Not synced' ) }
+			</div>
 		</PanelRow>
 	);
 }

--- a/packages/editor/src/components/post-sync-status/style.scss
+++ b/packages/editor/src/components/post-sync-status/style.scss
@@ -9,8 +9,8 @@
 		flex-shrink: 0;
 	}
 
-	.components-base-control {
+	> div {
 		// Match padding on tertiary buttons for alignment.
-		padding-left: $grid-unit-15 * 0.5;
+		padding-left: $grid-unit-15;
 	}
 }


### PR DESCRIPTION
## What?
Backports removing the ability for users to toggle the sync status of a pattern once it is added to 16.1.1

## Why?
Changing the sync status after the pattern has already been inserted into posts could have unexpected results. See [this comment](https://github.com/WordPress/gutenberg/issues/51920#issuecomment-1608783038) for more details.
Fixes: #51920

## How?
Removes the sync toggle from the `wp_block` CPT update page.


## Testing Instructions

- Add both a synced and an unsynced pattern
- Go to `/wp-admin/edit.php?post_type=wp_block` and edit both types
- Check that there is no toggle to change the sync status in right post details panel
- Check that correct sync status displays


## Screenshots or screencast <!-- if applicable -->

Before:
<img width="286" alt="Screenshot 2023-06-28 at 1 19 24 PM" src="https://github.com/WordPress/gutenberg/assets/3629020/a6db57ec-f9f9-4597-9f13-278fbe195792">

After:
<img width="153" alt="Screenshot 2023-06-28 at 1 18 23 PM" src="https://github.com/WordPress/gutenberg/assets/3629020/38b10826-7e53-4177-af5a-b46050c22666">
