### PR TITLE
Patterns: rename sync_status postmeta to pattern_post_sync_status

### DIFF
--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -372,3 +372,30 @@ function gutenberg_register_legacy_social_link_blocks() {
 }
 
 add_action( 'init', 'gutenberg_register_legacy_social_link_blocks' );
+
+/**
+ * Migrate the legacy `sync_status` meta key to the new `wp_pattern_sync_status` meta key.
+ *
+ * @since 16.1.1
+ *
+ * @param mixed  $value     The value to return, either a single metadata value or an array of values depending on the value of $single.
+ * @param int    $object_id ID of the object metadata is for.
+ * @param string $meta_key  Metadata key.
+ * @param bool   $single    Whether to return only the first value of the specified $meta_key.
+ *
+ * @see https://github.com/WordPress/gutenberg/pull/52232
+ */
+function gutenberg_legacy_wp_block_post_meta( $value, $object_id, $meta_key, $single ) {
+	if ( 'wp_pattern_sync_status' !== $meta_key ) {
+		return $value;
+	}
+
+	$sync_status = get_post_meta( $object_id, 'sync_status', $single );
+
+	if ( isset( $sync_status[0] ) && $sync_status[0] === 'unsynced' ) {
+		return $sync_status;
+	}
+
+	return $value;
+}
+add_filter( 'default_post_metadata', 'gutenberg_legacy_wp_block_post_meta', 10, 4 );

--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -376,6 +376,8 @@ add_action( 'init', 'gutenberg_register_legacy_social_link_blocks' );
 /**
  * Migrate the legacy `sync_status` meta key to the new `wp_pattern_sync_status` meta key.
  *
+ * This filter is INTENTIONALLY left out of core as the meta key was fist introduced to core in 6.3 as `wp_pattern_sync_status`.
+ * 
  * @since 16.1.1
  *
  * @param mixed  $value     The value to return, either a single metadata value or an array of values depending on the value of $single.

--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -377,6 +377,7 @@ add_action( 'init', 'gutenberg_register_legacy_social_link_blocks' );
  * Migrate the legacy `sync_status` meta key to the new `wp_pattern_sync_status` meta key.
  *
  * This filter is INTENTIONALLY left out of core as the meta key was fist introduced to core in 6.3 as `wp_pattern_sync_status`.
+ *
  * @since 16.1.1
  * @see https://github.com/WordPress/gutenberg/pull/52232
  *

--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -392,7 +392,7 @@ function gutenberg_legacy_wp_block_post_meta( $value, $object_id, $meta_key, $si
 
 	$sync_status = get_post_meta( $object_id, 'sync_status', $single );
 
-	if ( isset( $sync_status[0] ) && $sync_status[0] === 'unsynced' ) {
+	if ( isset( $sync_status[0] ) && 'unsynced' === $sync_status[0] ) {
 		return $sync_status;
 	}
 

--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -377,15 +377,14 @@ add_action( 'init', 'gutenberg_register_legacy_social_link_blocks' );
  * Migrate the legacy `sync_status` meta key to the new `wp_pattern_sync_status` meta key.
  *
  * This filter is INTENTIONALLY left out of core as the meta key was fist introduced to core in 6.3 as `wp_pattern_sync_status`.
- * 
  * @since 16.1.1
+ * @see https://github.com/WordPress/gutenberg/pull/52232
  *
  * @param mixed  $value     The value to return, either a single metadata value or an array of values depending on the value of $single.
  * @param int    $object_id ID of the object metadata is for.
  * @param string $meta_key  Metadata key.
  * @param bool   $single    Whether to return only the first value of the specified $meta_key.
  *
- * @see https://github.com/WordPress/gutenberg/pull/52232
  */
 function gutenberg_legacy_wp_block_post_meta( $value, $object_id, $meta_key, $single ) {
 	if ( 'wp_pattern_sync_status' !== $meta_key ) {
@@ -394,7 +393,9 @@ function gutenberg_legacy_wp_block_post_meta( $value, $object_id, $meta_key, $si
 
 	$sync_status = get_post_meta( $object_id, 'sync_status', $single );
 
-	if ( isset( $sync_status[0] ) && 'unsynced' === $sync_status[0] ) {
+	if ( $single && 'unsynced' === $sync_status ) {
+		return $sync_status;
+	} elseif ( isset( $sync_status[0] ) && 'unsynced' === $sync_status[0] ) {
 		return $sync_status;
 	}
 

--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -374,18 +374,15 @@ function gutenberg_register_legacy_social_link_blocks() {
 add_action( 'init', 'gutenberg_register_legacy_social_link_blocks' );
 
 /**
- * Migrate the legacy `sync_status` meta key to the new `wp_pattern_sync_status` meta key.
+ * Migrate the legacy `sync_status` meta key (added 16.1) to the new `wp_pattern_sync_status` meta key (16.1.1).
  *
  * This filter is INTENTIONALLY left out of core as the meta key was fist introduced to core in 6.3 as `wp_pattern_sync_status`.
- *
- * @since 16.1.1
- * @see https://github.com/WordPress/gutenberg/pull/52232
+ * see https://github.com/WordPress/gutenberg/pull/52232
  *
  * @param mixed  $value     The value to return, either a single metadata value or an array of values depending on the value of $single.
  * @param int    $object_id ID of the object metadata is for.
  * @param string $meta_key  Metadata key.
  * @param bool   $single    Whether to return only the first value of the specified $meta_key.
- *
  */
 function gutenberg_legacy_wp_block_post_meta( $value, $object_id, $meta_key, $single ) {
 	if ( 'wp_pattern_sync_status' !== $meta_key ) {

--- a/lib/compat/wordpress-6.3/blocks.php
+++ b/lib/compat/wordpress-6.3/blocks.php
@@ -89,7 +89,7 @@ function gutenberg_add_custom_fields_to_wp_block( $args, $post_type ) {
 add_filter( 'register_post_type_args', 'gutenberg_add_custom_fields_to_wp_block', 10, 2 );
 
 /**
- * Adds sync_status meta fields to the wp_block post type so an unsynced option can be added.
+ * Adds wp_pattern_sync_status meta fields to the wp_block post type so an unsynced option can be added.
  *
  * Note: This should be removed when the minimum required WP version is >= 6.3.
  *
@@ -101,7 +101,7 @@ function gutenberg_wp_block_register_post_meta() {
 	$post_type = 'wp_block';
 	register_post_meta(
 		$post_type,
-		'sync_status',
+		'wp_pattern_sync_status',
 		array(
 			'auth_callback'     => function() {
 				return current_user_can( 'edit_posts' );
@@ -113,7 +113,7 @@ function gutenberg_wp_block_register_post_meta() {
 				'schema' => array(
 					'type'       => 'string',
 					'properties' => array(
-						'sync_status' => array(
+						'wp_pattern_sync_status' => array(
 							'type' => 'string',
 						),
 					),
@@ -123,7 +123,7 @@ function gutenberg_wp_block_register_post_meta() {
 	);
 }
 /**
- * Sanitizes the array of wp_block post meta sync_status string.
+ * Sanitizes the array of wp_block post meta wp_pattern_sync_status string.
  *
  * Note: This should be removed when the minimum required WP version is >= 6.3.
  *

--- a/lib/compat/wordpress-6.3/blocks.php
+++ b/lib/compat/wordpress-6.3/blocks.php
@@ -137,31 +137,3 @@ function gutenberg_wp_block_sanitize_post_meta( $meta_value ) {
 	return sanitize_text_field( $meta_value );
 }
 add_action( 'init', 'gutenberg_wp_block_register_post_meta' );
-
-/**
- * Migrate the legacy `sync_status` meta key to the new `wp_pattern_sync_status` meta key.
- *
- * Note: This should be removed when the minimum required WP version is >= 6.3.
- *
- * @param mixed  $value     The value to return, either a single metadata value or an array of values depending on the value of $single.
- * @param int    $object_id ID of the object metadata is for.
- * @param string $meta_key  Metadata key.
- * @param bool   $single    Whether to return only the first value of the specified $meta_key.
- *
- * @see https://github.com/WordPress/gutenberg/pull/52232
- */
-function gutenberg_wp_block_migrate_post_meta( $value, $object_id, $meta_key, $single ) {
-	if ( 'wp_pattern_sync_status' !== $meta_key || null !== $value ) {
-		return $value;
-	}
-
-	$sync_status = get_post_meta( $object_id, $meta_key, $single );
-
-	if ( $sync_status ) {
-		return $value;
-	}
-
-	// Return legacy meta key.
-	return get_post_meta( $object_id, 'sync_status', $single );
-}
-add_filter( 'get_post_metadata', 'gutenberg_wp_block_migrate_post_meta', 10, 4 );

--- a/lib/compat/wordpress-6.3/blocks.php
+++ b/lib/compat/wordpress-6.3/blocks.php
@@ -137,3 +137,31 @@ function gutenberg_wp_block_sanitize_post_meta( $meta_value ) {
 	return sanitize_text_field( $meta_value );
 }
 add_action( 'init', 'gutenberg_wp_block_register_post_meta' );
+
+/**
+ * Migrate the legacy `sync_status` meta key to the new `wp_pattern_sync_status` meta key.
+ *
+ * Note: This should be removed when the minimum required WP version is >= 6.3.
+ *
+ * @param mixed  $value     The value to return, either a single metadata value or an array of values depending on the value of $single.
+ * @param int    $object_id ID of the object metadata is for.
+ * @param string $meta_key  Metadata key.
+ * @param bool   $single    Whether to return only the first value of the specified $meta_key.
+ *
+ * @see https://github.com/WordPress/gutenberg/pull/52232
+ */
+function gutenberg_wp_block_migrate_post_meta( $value, $object_id, $meta_key, $single ) {
+	if ( 'wp_pattern_sync_status' !== $meta_key || null !== $value ) {
+		return $value;
+	}
+
+	$sync_status = get_post_meta( $object_id, $meta_key, $single );
+
+	if ( $sync_status ) {
+		return $value;
+	}
+
+	// Return legacy meta key.
+	return get_post_meta( $object_id, 'sync_status', $single );
+}
+add_filter( 'get_post_metadata', 'gutenberg_wp_block_migrate_post_meta', 10, 4 );

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -2045,11 +2045,13 @@ export const getInserterItems = createSelector(
 			? getReusableBlocks( state )
 					.filter(
 						( reusableBlock ) =>
-							syncStatus === reusableBlock.meta?.sync_status ||
+							syncStatus ===
+								reusableBlock.meta?.wp_pattern_sync_status ||
 							( ! syncStatus &&
-								( reusableBlock.meta?.sync_status === '' ||
-									reusableBlock.meta?.sync_status ===
-										'fully' ) ) // Only reusable blocks added via site editor in release 16.1 will have sync_status of 'fully'.
+								( reusableBlock.meta?.wp_pattern_sync_status ===
+									'' ||
+									reusableBlock.meta
+										?.wp_pattern_sync_status === 'fully' ) ) // Only reusable blocks added via site editor in release 16.1 will have wp_pattern_sync_status of 'fully'.
 					)
 					.map( buildReusableBlockInserterItem )
 			: [];

--- a/packages/edit-site/src/components/create-pattern-modal/index.js
+++ b/packages/edit-site/src/components/create-pattern-modal/index.js
@@ -56,7 +56,7 @@ export default function CreatePatternModal( {
 					status: 'publish',
 					meta:
 						syncType === SYNC_TYPES.unsynced
-							? { sync_status: syncType }
+							? { wp_pattern_sync_status: syncType }
 							: undefined,
 				},
 				{ throwOnError: true }

--- a/packages/edit-site/src/components/page-library/use-patterns.js
+++ b/packages/edit-site/src/components/page-library/use-patterns.js
@@ -145,7 +145,7 @@ const reusableBlockToPattern = ( reusableBlock ) => ( {
 	categories: reusableBlock.wp_pattern,
 	id: reusableBlock.id,
 	name: reusableBlock.slug,
-	syncStatus: reusableBlock.meta?.sync_status || SYNC_TYPES.full,
+	syncStatus: reusableBlock.meta?.wp_pattern_sync_status || SYNC_TYPES.full,
 	title: reusableBlock.title.raw,
 	type: reusableBlock.type,
 	reusableBlock,

--- a/packages/editor/src/components/post-sync-status/index.js
+++ b/packages/editor/src/components/post-sync-status/index.js
@@ -21,7 +21,7 @@ export default function PostSyncStatus() {
 	if ( postType !== 'wp_block' ) {
 		return null;
 	}
-	const syncStatus = meta?.sync_status;
+	const syncStatus = meta?.wp_pattern_sync_status;
 	const isFullySynced = ! syncStatus;
 
 	return (

--- a/packages/reusable-blocks/src/store/actions.js
+++ b/packages/reusable-blocks/src/store/actions.js
@@ -52,7 +52,7 @@ export const __experimentalConvertBlocksToReusable =
 		const meta =
 			syncType === 'unsynced'
 				? {
-						sync_status: syncType,
+						wp_pattern_sync_status: syncType,
 				  }
 				: undefined;
 


### PR DESCRIPTION
## What?
Renames the new Patterns sync status postmeta field to `wp_patterns_sync_status`

## Why?
`sync_status` is very generic and could inadvertently be used by other plugins. 

## How?
Renamed the field in all the places it is used.

## Testing Instructions
- Before switching to this branch, in trunk or 16.1 branch add some synced and unsynced patterns
- Switch to this branch and check that these Patterns still display correctly as synced or unsynced in post editor inserter, site editor library and the manage all patterns page edit screens
- In the post editor add some new synced and unsynced patterns - make sure the synced ones appear in the Sync Patterns inserter tab and that the unsynced ones appear in Patterns tab under Custom patterns
- Follow the Manage All Patterns link in the Editors top right settings menu
- Edit each pattern and make sure sync status displays correctly in right post info panel
- When editing an unsycned pattern check rest endpoint (/wp/v2/blocks?) return to see that post meta field is set to `wp_pattern_status`
- In the Site editor library check that the patterns appear in the correct Synced and unsynced sections
- In the Site editor add new synced and unsynced patterns and make sure the appear in the correct sections

## Screenshots or screencast <!-- if applicable -->
Before:

<img width="305" alt="Screenshot 2023-07-03 at 5 13 32 PM" src="https://github.com/WordPress/gutenberg/assets/3629020/6fb15ebe-7933-4eba-94b0-0ef4bfeb00d4">

After:

<img width="317" alt="Screenshot 2023-07-03 at 5 04 44 PM" src="https://github.com/WordPress/gutenberg/assets/3629020/c888499b-4d12-4094-acaf-61b22f88f061">

