### PR TITLE
Exit template focus when opening the W menu

### DIFF
--- a/packages/edit-site/src/store/private-actions.js
+++ b/packages/edit-site/src/store/private-actions.js
@@ -11,7 +11,7 @@ import { store as preferencesStore } from '@wordpress/preferences';
  */
 export const setCanvasMode =
 	( mode ) =>
-	( { registry, dispatch } ) => {
+	( { registry, dispatch, select } ) => {
 		registry.dispatch( blockEditorStore ).__unstableSetEditorMode( 'edit' );
 		dispatch( {
 			type: 'SET_CANVAS_MODE',
@@ -25,6 +25,10 @@ export const setCanvasMode =
 				.get( 'core/edit-site', 'showListViewByDefault' )
 		) {
 			dispatch.setIsListViewOpened( true );
+		}
+		// Switch focus away from editing the template when switching to view mode.
+		if ( mode === 'view' && select.isPage() ) {
+			dispatch.setHasPageContentFocus( true );
 		}
 	};
 


### PR DESCRIPTION
## What?
Fixes https://github.com/WordPress/gutenberg/issues/51731.

## Why?


## How?
Updates `setCanvasMode` to call `setHasPageContentFocus` appropriately if a page is loaded into context.

## Testing Instructions
1. Go to Appearance → Editor → Pages and edit a page.
2. Press _Edit template_ in the sidebar to enter template focus.
3. Open the W menu.
4. You should automatically exit template focus.

## Screenshots or screencast

https://github.com/WordPress/gutenberg/assets/612155/ee6fe1e0-3c94-4ddc-a74b-532f853bbf79

