### PR TITLE
Add confirmation step when deleting a Template

### DIFF
--- a/packages/edit-site/src/components/template-actions/index.js
+++ b/packages/edit-site/src/components/template-actions/index.js
@@ -3,8 +3,14 @@
  */
 import { useDispatch, useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
+import { useState } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
-import { DropdownMenu, MenuGroup, MenuItem } from '@wordpress/components';
+import {
+	DropdownMenu,
+	MenuGroup,
+	MenuItem,
+	__experimentalConfirmDialog as ConfirmDialog,
+} from '@wordpress/components';
 import { moreVertical } from '@wordpress/icons';
 import { store as noticesStore } from '@wordpress/notices';
 
@@ -84,17 +90,14 @@ export default function TemplateActions( {
 								template={ template }
 								onClose={ onClose }
 							/>
-							<MenuItem
-								isDestructive
-								isTertiary
-								onClick={ () => {
+							<DeleteMenuItem
+								onRemove={ () => {
 									removeTemplate( template );
 									onRemove?.();
 									onClose();
 								} }
-							>
-								{ __( 'Delete' ) }
-							</MenuItem>
+								isTemplate={ template.type === 'wp_template' }
+							/>
 						</>
 					) }
 					{ isRevertable && (
@@ -113,5 +116,32 @@ export default function TemplateActions( {
 				</MenuGroup>
 			) }
 		</DropdownMenu>
+	);
+}
+
+function DeleteMenuItem( { onRemove, isTemplate } ) {
+	const [ isModalOpen, setIsModalOpen ] = useState( false );
+	return (
+		<>
+			<MenuItem
+				isDestructive
+				isTertiary
+				onClick={ () => setIsModalOpen( true ) }
+			>
+				{ __( 'Delete' ) }
+			</MenuItem>
+			<ConfirmDialog
+				isOpen={ isModalOpen }
+				onConfirm={ onRemove }
+				onCancel={ () => setIsModalOpen( false ) }
+				confirmButtonText={ __( 'Delete' ) }
+			>
+				{ isTemplate
+					? __( 'Are you sure you want to delete this template?' )
+					: __(
+							'Are you sure you want to delete this template part?'
+					  ) }
+			</ConfirmDialog>
+		</>
 	);
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Resolves: https://github.com/WordPress/gutenberg/issues/47225

This PR adds a confirmation modal before deleting a template or template part. It uses the [same pattern](https://github.com/WordPress/gutenberg/issues/47225#issuecomment-1597161075) we have for deleting pages

## Testing Instructions
1. In site editor if you have templates or template parts that can be deleted, go to the respective list(template/template part) and click `delete`
2. Observe that the confirmation modal appears and works as expected.



## Screenshots or screencast <!-- if applicable -->
<img width="595" alt="Screenshot 2023-07-03 at 11 32 49 AM" src="https://github.com/WordPress/gutenberg/assets/16275880/ce735563-b5a6-4199-bac5-a8faecac2ef0">
