### PR TITLE
Remove unnecessary padding-right on the dismissible notice

### DIFF
--- a/packages/components/src/notice/style.scss
+++ b/packages/components/src/notice/style.scss
@@ -9,7 +9,6 @@
 	align-items: center;
 
 	&.is-dismissible {
-		padding-right: 36px;
 		position: relative;
 	}
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
In this PR I removed the `padding-right` from a Notice component when it's dismissable.

## Why?
When Notice was dismissable, an additional 36px `padding-right` was applied to the Notice container, pushing the content to the left, which makes little space for Notice content especially when used in Inspector Controls. It seems incorrect on the frontend (see screenshots below).

Worth to mention that the "X" button is coincidentally 36px wide, so the original idea might've been to apply the padding so the content makes space for an "X" button, but now it pushes both: "X" button and content.

## How?
It's fixed by removing the unnecessary padding-right from the `.components-notice.is-dismissable` selector.

## Testing Instructions
1. Edit some block Inspector Controls by including:
```
import { Notice } from '@wordpress/components';

...

<Notice>
    Some content of the Notice. Make sure it's wide enough to fill available space.
</Notice>
```
Notice component is dismissable by default, so there's no need to pass any additional props to it.
2. Display the Notice in the frontend
3. **Expected:** There's no unnecessary gap on the right side (check screenshots below).

## Screenshots or screencast <!-- if applicable -->

Before | After
-- | --
<img width="309" alt="image" src="https://github.com/WordPress/gutenberg/assets/20098064/4d7f6f11-463f-4a3f-9e20-d2c9c277cb22"> | <img width="315" alt="image" src="https://github.com/WordPress/gutenberg/assets/20098064/77fa3ef0-ccdd-4185-a058-4c66d35cfe09">

