### PR TITLE
RichText/Footnotes: make getRichTextValues work with InnerBlocks.Content

### DIFF
--- a/packages/block-editor/src/components/rich-text/content.js
+++ b/packages/block-editor/src/components/rich-text/content.js
@@ -1,19 +1,14 @@
 /**
  * WordPress dependencies
  */
-import { RawHTML, StrictMode, Fragment } from '@wordpress/element';
-import {
-	children as childrenSource,
-	getSaveElement,
-	__unstableGetBlockProps as getBlockProps,
-} from '@wordpress/blocks';
+import { RawHTML } from '@wordpress/element';
+import { children as childrenSource } from '@wordpress/blocks';
 import deprecated from '@wordpress/deprecated';
 
 /**
  * Internal dependencies
  */
 import { getMultilineTag } from './utils';
-import InnerBlocks from '../inner-blocks';
 
 export const Content = ( { value, tagName: Tag, multiline, ...props } ) => {
 	// Handle deprecated `children` and `node` sources.
@@ -43,79 +38,3 @@ export const Content = ( { value, tagName: Tag, multiline, ...props } ) => {
 
 	return content;
 };
-
-function addValuesForElements( children, ...args ) {
-	children = Array.isArray( children ) ? children : [ children ];
-
-	for ( let i = 0; i < children.length; i++ ) {
-		addValuesForElement( children[ i ], ...args );
-	}
-}
-
-function addValuesForElement( element, ...args ) {
-	if ( null === element || undefined === element || false === element ) {
-		return;
-	}
-
-	if ( Array.isArray( element ) ) {
-		return addValuesForElements( element, ...args );
-	}
-
-	switch ( typeof element ) {
-		case 'string':
-		case 'number':
-			return;
-	}
-
-	const { type, props } = element;
-
-	switch ( type ) {
-		case StrictMode:
-		case Fragment:
-			return addValuesForElements( props.children, ...args );
-		case RawHTML:
-			return;
-		case InnerBlocks.Content:
-			return addValuesForBlocks( ...args );
-		case Content:
-			const [ values ] = args;
-			values.push( props.value );
-			return;
-	}
-
-	switch ( typeof type ) {
-		case 'string':
-			if ( typeof props.children !== 'undefined' ) {
-				return addValuesForElements( props.children, ...args );
-			}
-			return;
-		case 'function':
-			if (
-				type.prototype &&
-				typeof type.prototype.render === 'function'
-			) {
-				return addValuesForElement(
-					new type( props ).render(),
-					...args
-				);
-			}
-
-			return addValuesForElement( type( props ), ...args );
-	}
-}
-
-function addValuesForBlocks( values, blocks ) {
-	for ( let i = 0; i < blocks.length; i++ ) {
-		const { name, attributes, innerBlocks } = blocks[ i ];
-		const saveElement = getSaveElement( name, attributes );
-		addValuesForElement( saveElement, values, innerBlocks );
-	}
-}
-
-export function getRichTextValues( blocks = [] ) {
-	getBlockProps.skipFilters = true;
-	const values = [];
-	addValuesForBlocks( values, blocks );
-	getBlockProps.skipFilters = false;
-	return values;
-}

--- a/packages/block-editor/src/components/rich-text/get-rich-text-values.js
+++ b/packages/block-editor/src/components/rich-text/get-rich-text-values.js
@@ -1,0 +1,95 @@
+/**
+ * WordPress dependencies
+ */
+import { RawHTML, StrictMode, Fragment } from '@wordpress/element';
+import {
+	getSaveElement,
+	__unstableGetBlockProps as getBlockProps,
+} from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import InnerBlocks from '../inner-blocks';
+import { Content } from './content';
+
+/*
+ * This function is similar to `@wordpress/element`'s `renderToString` function,
+ * except that it does not render the elements to a string, but instead collects
+ * the values of all rich text `Content` elements.
+ */
+function addValuesForElement( element, ...args ) {
+	if ( null === element || undefined === element || false === element ) {
+		return;
+	}
+
+	if ( Array.isArray( element ) ) {
+		return addValuesForElements( element, ...args );
+	}
+
+	switch ( typeof element ) {
+		case 'string':
+		case 'number':
+			return;
+	}
+
+	const { type, props } = element;
+
+	switch ( type ) {
+		case StrictMode:
+		case Fragment:
+			return addValuesForElements( props.children, ...args );
+		case RawHTML:
+			return;
+		case InnerBlocks.Content:
+			return addValuesForBlocks( ...args );
+		case Content:
+			const [ values ] = args;
+			values.push( props.value );
+			return;
+	}
+
+	switch ( typeof type ) {
+		case 'string':
+			if ( typeof props.children !== 'undefined' ) {
+				return addValuesForElements( props.children, ...args );
+			}
+			return;
+		case 'function':
+			if (
+				type.prototype &&
+				typeof type.prototype.render === 'function'
+			) {
+				return addValuesForElement(
+					new type( props ).render(),
+					...args
+				);
+			}
+
+			return addValuesForElement( type( props ), ...args );
+	}
+}
+
+function addValuesForElements( children, ...args ) {
+	children = Array.isArray( children ) ? children : [ children ];
+
+	for ( let i = 0; i < children.length; i++ ) {
+		addValuesForElement( children[ i ], ...args );
+	}
+}
+
+function addValuesForBlocks( values, blocks ) {
+	for ( let i = 0; i < blocks.length; i++ ) {
+		const { name, attributes, innerBlocks } = blocks[ i ];
+		const saveElement = getSaveElement( name, attributes );
+		addValuesForElement( saveElement, values, innerBlocks );
+	}
+}
+
+export function getRichTextValues( blocks = [] ) {
+	getBlockProps.skipFilters = true;
+	const values = [];
+	addValuesForBlocks( values, blocks );
+	getBlockProps.skipFilters = false;
+	return values;
+}

--- a/packages/block-editor/src/private-apis.js
+++ b/packages/block-editor/src/private-apis.js
@@ -4,7 +4,7 @@
 import * as globalStyles from './components/global-styles';
 import { ExperimentalBlockEditorProvider } from './components/provider';
 import { lock } from './lock-unlock';
-import { getRichTextValues } from './components/rich-text/content';
+import { getRichTextValues } from './components/rich-text/get-rich-text-values';
 import { kebabCase } from './utils/object';
 import ResizableBoxPopover from './components/resizable-box-popover';
 import { ComposedPrivateInserter as PrivateInserter } from './components/inserter';

--- a/test/e2e/specs/editor/various/footnotes.spec.js
+++ b/test/e2e/specs/editor/various/footnotes.spec.js
@@ -182,4 +182,101 @@ test.describe( 'Footnotes', () => {
 
 		expect( await getFootnotes( page ) ).toMatchObject( [] );
 	} );
+
+	test( 'can be inserted in a list', async ( { editor, page } ) => {
+		await editor.canvas.click( 'role=button[name="Add default block"i]' );
+		await page.keyboard.type( '* 1' );
+		await editor.showBlockToolbar();
+		await editor.clickBlockToolbarButton( 'More' );
+		await page.locator( 'button:text("Footnote")' ).click();
+
+		await page.keyboard.type( 'a' );
+
+		const id1 = await editor.canvas.evaluate( () => {
+			return document.activeElement.id;
+		} );
+
+		expect( await editor.getBlocks() ).toMatchObject( [
+			{
+				name: 'core/list',
+				innerBlocks: [
+					{
+						name: 'core/list-item',
+						attributes: {
+							content: `1<a data-rich-text-format-boundary="true" href="#${ id1 }" id="${ id1 }-link" data-fn="${ id1 }" class="fn">*</a>`,
+						},
+					},
+				],
+			},
+			{
+				name: 'core/footnotes',
+			},
+		] );
+
+		expect( await getFootnotes( page ) ).toMatchObject( [
+			{
+				content: 'a',
+				id: id1,
+			},
+		] );
+	} );
+
+	test( 'can be inserted in a table', async ( { editor, page } ) => {
+		await editor.insertBlock( { name: 'core/table' } );
+		await editor.canvas.click( 'role=button[name="Create Table"i]' );
+		await page.keyboard.type( '1' );
+		await editor.showBlockToolbar();
+		await editor.clickBlockToolbarButton( 'More' );
+		await page.locator( 'button:text("Footnote")' ).click();
+
+		await page.keyboard.type( 'a' );
+
+		const id1 = await editor.canvas.evaluate( () => {
+			return document.activeElement.id;
+		} );
+
+		expect( await editor.getBlocks() ).toMatchObject( [
+			{
+				name: 'core/table',
+				attributes: {
+					body: [
+						{
+							cells: [
+								{
+									content: `1<a data-rich-text-format-boundary="true" href="#${ id1 }" id="${ id1 }-link" data-fn="${ id1 }" class="fn">*</a>`,
+									tag: 'td',
+								},
+								{
+									content: '',
+									tag: 'td',
+								},
+							],
+						},
+						{
+							cells: [
+								{
+									content: '',
+									tag: 'td',
+								},
+								{
+									content: '',
+									tag: 'td',
+								},
+							],
+						},
+					],
+				},
+			},
+			{
+				name: 'core/footnotes',
+			},
+		] );
+
+		expect( await getFootnotes( page ) ).toMatchObject( [
+			{
+				content: 'a',
+				id: id1,
+			},
+		] );
+	} );
 } );

--- a/test/e2e/specs/editor/various/footnotes.spec.js
+++ b/test/e2e/specs/editor/various/footnotes.spec.js
@@ -203,7 +203,7 @@ test.describe( 'Footnotes', () => {
 					{
 						name: 'core/list-item',
 						attributes: {
-							content: `1<a data-rich-text-format-boundary="true" href="#${ id1 }" id="${ id1 }-link" data-fn="${ id1 }" class="fn">*</a>`,
+							content: `1<a href="#${ id1 }" id="${ id1 }-link" data-fn="${ id1 }" class="fn">*</a>`,
 						},
 					},
 				],
@@ -243,7 +243,7 @@ test.describe( 'Footnotes', () => {
 						{
 							cells: [
 								{
-									content: `1<a data-rich-text-format-boundary="true" href="#${ id1 }" id="${ id1 }-link" data-fn="${ id1 }" class="fn">*</a>`,
+									content: `1<a href="#${ id1 }" id="${ id1 }-link" data-fn="${ id1 }" class="fn">*</a>`,
 									tag: 'td',
 								},
 								{

--- a/test/e2e/specs/editor/various/footnotes.spec.js
+++ b/test/e2e/specs/editor/various/footnotes.spec.js
@@ -186,7 +186,6 @@ test.describe( 'Footnotes', () => {
 	test( 'can be inserted in a list', async ( { editor, page } ) => {
 		await editor.canvas.click( 'role=button[name="Add default block"i]' );
 		await page.keyboard.type( '* 1' );
-		await editor.showBlockToolbar();
 		await editor.clickBlockToolbarButton( 'More' );
 		await page.locator( 'button:text("Footnote")' ).click();
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes #52084.

`getRichTextValues` currently does not work with `InnerBlocks.Content` because this wraps `useInnerBlocksProps.save` in a function that is not called when the tree is constructed. This PR will now "render" all the components in the save function, meaning it will just call all the functions to get the nested element trees and check for rich text props in there. It's similar to `renderToString` in the `@wordpress/element` package, but without creating a string. We just need to find rich text values and can skip all the rest.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Footnotes is broken for blocks using `InnerBlocks.Content`;

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

See above.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

Create a list blocks and add a footnote. It should add an entry in the footnotes block.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
