### PR TITLE
Adjust the position of sticky headings in preferences modal

### DIFF
--- a/packages/edit-post/src/components/block-manager/style.scss
+++ b/packages/edit-post/src/components/block-manager/style.scss
@@ -36,7 +36,7 @@
 
 .edit-post-block-manager__category-title {
 	position: sticky;
-	top: 0;
+	top: - $grid-unit-05; // Offsets the top padding on the modal content container
 	padding: $grid-unit-20 0;
 	background-color: $white;
 	z-index: z-index(".edit-post-block-manager__category-title");


### PR DESCRIPTION
Fix a regression introduced in https://github.com/WordPress/gutenberg/pull/51829.

## What?
Offset sticky headings in the "Blocks" section of the preferences modal by 4px.

## Why?
In https://github.com/WordPress/gutenberg/pull/51829 a small amount of padding (4px) was added to the modal content container so that the focus ring was remain visible on descendants. 

However this change effectively pushed sticky headings in the "Blocks" section of the preferences modal down, meaning a sliver of content could be seen above them as you scroll:

<img src="https://user-images.githubusercontent.com/9000376/250482886-aff5563c-562b-47db-8c19-c4c23d1f5dc9.png">

## How?
Change `top` value from `0` to `-4px` on `.edit-post-block-manager__category-title`.

## Testing Instructions
1. In the post editor open the Preferences modal and click the Blocks tab.
2. As you scroll, notice that content does not appear above the headings as they stick:

<img width="816" alt="Screenshot 2023-07-03 at 14 29 29" src="https://github.com/WordPress/gutenberg/assets/846565/877fac2b-7d80-4484-8280-2c5915035a0d">