### PR TITLE
Navigation block: Add notice on reduced accessibility

### DIFF
--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -38,6 +38,7 @@ import {
 	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
 	Button,
 	Spinner,
+	Notice,
 } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { speak } from '@wordpress/a11y';
@@ -485,6 +486,25 @@ function Navigation( {
 		{ open: overlayMenuPreview }
 	);
 
+	const submenuAccessibilityNotice =
+		! showSubmenuIcon && ! openSubmenusOnClick
+			? __(
+					'The current menu options offer reduced accessibility for users and are not recommended. '
+			  ) +
+			  __(
+					'Enabling either "Open on Click" or "Show arrow" offers enhanced accessibility by allowing keyboard users to browse submenus selectively.'
+			  )
+			: '';
+
+	useEffect( () => {
+		if ( submenuAccessibilityNotice )
+			speak(
+				__(
+					'The current menu options offer reduced accessibility for users and are not recommended.'
+				)
+			);
+	}, [ submenuAccessibilityNotice ] );
+
 	const colorGradientSettings = useMultipleOriginColorsAndGradients();
 	const stylingInspectorControls = (
 		<>
@@ -578,6 +598,18 @@ function Navigation( {
 									disabled={ attributes.openSubmenusOnClick }
 									label={ __( 'Show arrow' ) }
 								/>
+
+								{ submenuAccessibilityNotice && (
+									<div>
+										<Notice
+											spokenMessage={ null }
+											status="warning"
+											isDismissible={ false }
+										>
+											{ submenuAccessibilityNotice }
+										</Notice>
+									</div>
+								) }
 							</>
 						) }
 					</PanelBody>

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -501,7 +501,8 @@ function Navigation( {
 			speak(
 				__(
 					'The current menu options offer reduced accessibility for users and are not recommended.'
-				)
+				),
+				'assertive'
 			);
 	}, [ submenuAccessibilityNotice ] );
 

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -496,14 +496,17 @@ function Navigation( {
 			  )
 			: '';
 
+	const isFirstRender = useRef( true );
 	useEffect( () => {
-		if ( submenuAccessibilityNotice )
+		if ( ! isFirstRender.current && submenuAccessibilityNotice ) {
 			speak(
 				__(
 					'The current menu options offer reduced accessibility for users and are not recommended.'
 				),
 				'assertive'
 			);
+		}
+		isFirstRender.current = false;
 	}, [ submenuAccessibilityNotice ] );
 
 	const colorGradientSettings = useMultipleOriginColorsAndGradients();

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -489,22 +489,14 @@ function Navigation( {
 	const submenuAccessibilityNotice =
 		! showSubmenuIcon && ! openSubmenusOnClick
 			? __(
-					'The current menu options offer reduced accessibility for users and are not recommended. '
-			  ) +
-			  __(
-					'Enabling either "Open on Click" or "Show arrow" offers enhanced accessibility by allowing keyboard users to browse submenus selectively.'
+					'The current menu options offer reduced accessibility for users and are not recommended. Enabling either "Open on Click" or "Show arrow" offers enhanced accessibility by allowing keyboard users to browse submenus selectively.'
 			  )
 			: '';
 
-	const isFirstRender = useRef( true );
+	const isFirstRender = useRef( true ); // Don't speak on first render.
 	useEffect( () => {
 		if ( ! isFirstRender.current && submenuAccessibilityNotice ) {
-			speak(
-				__(
-					'The current menu options offer reduced accessibility for users and are not recommended.'
-				),
-				'assertive'
-			);
+			speak( submenuAccessibilityNotice );
 		}
 		isFirstRender.current = false;
 	}, [ submenuAccessibilityNotice ] );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes https://github.com/WordPress/gutenberg/issues/51226.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Because when both the `showSubmenuIcons` ("Show arrows" in the UI) and `openOnClick` options are false, the accessibility is reduced, and after some discussion, the decision was to [add a warning when both of those options are false](https://github.com/WordPress/gutenberg/issues/51226#issuecomment-1594803160).

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Just use the component and approach as the one [used in the Color panel for the low contrast warning](https://github.com/WordPress/gutenberg/issues/51226#issuecomment-1594836083).

I have one question: should the screen reader notice be triggered each time there is a full refresh if those options are selected, or only after the user has changed them?

I'm following what I saw for other notices, but it feels a bit weird to hear that notice each time you refresh, so I wonder what's the usual behavior here.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

- Select a Navigation block.
- Add at least one submenu (if not, these options don't show up).
- Open the Navigation block settings.
- Toggle both Submenu options off.
- Check that the notice appears.
- Check that the screen reader reads the notice.
- Toggle one of them on.
- Check that the notice disappears.

## Screenshots or screencast <!-- if applicable -->

<img width="279" alt="Screenshot of the notice in the UI" src="https://github.com/WordPress/gutenberg/assets/3305402/eb4534f0-0e9f-494e-a297-96263688862a">

