### PR TITLE
Use next40pxDefaultSize on RangeControl components

### DIFF
--- a/packages/block-library/src/avatar/edit.js
+++ b/packages/block-library/src/avatar/edit.js
@@ -36,6 +36,7 @@ const AvatarInspectorControls = ( {
 		<PanelBody title={ __( 'Settings' ) }>
 			<RangeControl
 				__nextHasNoMarginBottom
+				__next40pxDefaultSize
 				label={ __( 'Image size' ) }
 				onChange={ ( newSize ) =>
 					setAttributes( {

--- a/packages/block-library/src/columns/edit.js
+++ b/packages/block-library/src/columns/edit.js
@@ -123,6 +123,7 @@ function ColumnsEditContainer( {
 						<>
 							<RangeControl
 								__nextHasNoMarginBottom
+								__next40pxDefaultSize
 								label={ __( 'Columns' ) }
 								value={ count }
 								onChange={ ( value ) =>

--- a/packages/block-library/src/comment-author-avatar/edit.js
+++ b/packages/block-library/src/comment-author-avatar/edit.js
@@ -51,6 +51,7 @@ export default function Edit( {
 			<PanelBody title={ __( 'Avatar Settings' ) }>
 				<RangeControl
 					__nextHasNoMarginBottom
+					__next40pxDefaultSize
 					label={ __( 'Image size' ) }
 					onChange={ ( newWidth ) =>
 						setAttributes( {

--- a/packages/block-library/src/file/inspector.js
+++ b/packages/block-library/src/file/inspector.js
@@ -58,6 +58,7 @@ export default function FileBlockInspector( {
 						{ displayPreview && (
 							<RangeControl
 								__nextHasNoMarginBottom
+								__next40pxDefaultSize
 								label={ __( 'Height in pixels' ) }
 								min={ MIN_PREVIEW_HEIGHT }
 								max={ Math.max(

--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -562,7 +562,7 @@ function GalleryEdit( props ) {
 							max={ Math.min( MAX_COLUMNS, images.length ) }
 							{ ...MOBILE_CONTROL_PROPS_RANGE_CONTROL }
 							required
-							size="__unstable-large"
+							__next40pxDefaultSize
 						/>
 					) }
 					<ToggleControl

--- a/packages/block-library/src/latest-comments/edit.js
+++ b/packages/block-library/src/latest-comments/edit.js
@@ -68,6 +68,7 @@ export default function LatestComments( { attributes, setAttributes } ) {
 					/>
 					<RangeControl
 						__nextHasNoMarginBottom
+						__next40pxDefaultSize
 						label={ __( 'Number of comments' ) }
 						value={ commentsToShow }
 						onChange={ ( value ) =>

--- a/packages/block-library/src/latest-posts/edit.js
+++ b/packages/block-library/src/latest-posts/edit.js
@@ -230,6 +230,7 @@ export default function LatestPostsEdit( { attributes, setAttributes } ) {
 					displayPostContentRadio === 'excerpt' && (
 						<RangeControl
 							__nextHasNoMarginBottom
+							__next40pxDefaultSize
 							label={ __( 'Max number of words' ) }
 							value={ excerptLength }
 							onChange={ ( value ) =>
@@ -359,6 +360,7 @@ export default function LatestPostsEdit( { attributes, setAttributes } ) {
 				{ postLayout === 'grid' && (
 					<RangeControl
 						__nextHasNoMarginBottom
+						__next40pxDefaultSize
 						label={ __( 'Columns' ) }
 						value={ columns }
 						onChange={ ( value ) =>

--- a/packages/block-library/src/rss/edit.js
+++ b/packages/block-library/src/rss/edit.js
@@ -116,6 +116,7 @@ export default function RSSEdit( { attributes, setAttributes } ) {
 				<PanelBody title={ __( 'Settings' ) }>
 					<RangeControl
 						__nextHasNoMarginBottom
+						__next40pxDefaultSize
 						label={ __( 'Number of items' ) }
 						value={ itemsToShow }
 						onChange={ ( value ) =>

--- a/packages/block-library/src/rss/edit.js
+++ b/packages/block-library/src/rss/edit.js
@@ -147,6 +147,7 @@ export default function RSSEdit( { attributes, setAttributes } ) {
 					{ displayExcerpt && (
 						<RangeControl
 							__nextHasNoMarginBottom
+							__next40pxDefaultSize
 							label={ __( 'Max number of words in excerpt' ) }
 							value={ excerptLength }
 							onChange={ ( value ) =>
@@ -160,6 +161,7 @@ export default function RSSEdit( { attributes, setAttributes } ) {
 					{ blockLayout === 'grid' && (
 						<RangeControl
 							__nextHasNoMarginBottom
+							__next40pxDefaultSize
 							label={ __( 'Columns' ) }
 							value={ columns }
 							onChange={ ( value ) =>

--- a/packages/block-library/src/site-logo/edit.js
+++ b/packages/block-library/src/site-logo/edit.js
@@ -293,6 +293,7 @@ const SiteLogo = ( {
 				<PanelBody title={ __( 'Settings' ) }>
 					<RangeControl
 						__nextHasNoMarginBottom
+						__next40pxDefaultSize
 						label={ __( 'Image width' ) }
 						onChange={ ( newWidth ) =>
 							setAttributes( { width: newWidth } )

--- a/packages/block-library/src/tag-cloud/edit.js
+++ b/packages/block-library/src/tag-cloud/edit.js
@@ -122,6 +122,7 @@ function TagCloudEdit( { attributes, setAttributes, taxonomies } ) {
 				/>
 				<RangeControl
 					__nextHasNoMarginBottom
+					__next40pxDefaultSize
 					label={ __( 'Number of tags' ) }
 					value={ numberOfTags }
 					onChange={ ( value ) =>

--- a/packages/block-library/src/text-columns/edit.js
+++ b/packages/block-library/src/text-columns/edit.js
@@ -35,6 +35,7 @@ export default function TextColumnsEdit( { attributes, setAttributes } ) {
 				<PanelBody>
 					<RangeControl
 						__nextHasNoMarginBottom
+						__next40pxDefaultSize
 						label={ __( 'Columns' ) }
 						value={ columns }
 						onChange={ ( value ) =>

--- a/packages/components/src/query-controls/index.native.js
+++ b/packages/components/src/query-controls/index.native.js
@@ -84,6 +84,7 @@ const QueryControls = memo(
 				) }
 				{ onNumberOfItemsChange && (
 					<RangeControl
+						__next40pxDefaultSize
 						label={ __( 'Number of items' ) }
 						value={ numberOfItems }
 						onChange={ onNumberOfItemsChange }

--- a/packages/components/src/query-controls/index.tsx
+++ b/packages/components/src/query-controls/index.tsx
@@ -177,6 +177,7 @@ export function QueryControls( {
 				onNumberOfItemsChange && (
 					<RangeControl
 						__nextHasNoMarginBottom
+						__next40pxDefaultSize
 						key="query-controls-range-control"
 						label={ __( 'Number of items' ) }
 						value={ numberOfItems }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Updating the RangeControl components in the block inspector components to use the 40px size for https://github.com/WordPress/gutenberg/issues/46734 — now that RangeControl supports it via https://github.com/WordPress/gutenberg/pull/49105. 

## Why?
Moving forward; consistency. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a Post or Page.
2. Insert the blocks listed below. 
3. Check the RangeControl components within the Inspector for each.

### Blocks
1. Gallery
2. Avatar
3. Columns
4. File
5. Comment Author Avatar
6. Latest Comments
7. RSS
8. Latest Posts
9. Site Logo
10. Text Columns
11. Tag Cloud

## Screenshots or screencast <!-- if applicable -->

| Before  | After |
| ------------- | ------------- |
|<img width="278" alt="CleanShot 2023-07-03 at 12 22 06" src="https://github.com/WordPress/gutenberg/assets/1813435/d868ee6e-cfd5-4b22-8009-cd7c4c0f1c3c"><img width="279" alt="CleanShot 2023-07-03 at 12 42 58" src="https://github.com/WordPress/gutenberg/assets/1813435/5977c617-2b8b-4299-8a3f-43e9677b7a19"><img width="280" alt="CleanShot 2023-07-03 at 12 44 50" src="https://github.com/WordPress/gutenberg/assets/1813435/68fec298-61cc-44e3-8379-990be95ab373"><img width="278" alt="CleanShot 2023-07-03 at 12 52 44" src="https://github.com/WordPress/gutenberg/assets/1813435/23315594-18c8-427f-8314-5d57c45253a6"><img width="280" alt="CleanShot 2023-07-03 at 12 53 04" src="https://github.com/WordPress/gutenberg/assets/1813435/8cbdb3b3-9785-4640-8ec3-32a9fe100b8e">|<img width="278" alt="CleanShot 2023-07-03 at 12 22 56" src="https://github.com/WordPress/gutenberg/assets/1813435/bbbb7f3a-2249-4cc0-ade0-7462e8bdb341"><img width="278" alt="CleanShot 2023-07-03 at 12 43 12" src="https://github.com/WordPress/gutenberg/assets/1813435/c140bf92-8580-4287-a9df-0a9dfea4c14f"><img width="280" alt="CleanShot 2023-07-03 at 12 45 11" src="https://github.com/WordPress/gutenberg/assets/1813435/adb11a45-5ee5-4f33-a214-ee673484fdd4"><img width="277" alt="CleanShot 2023-07-03 at 12 53 28" src="https://github.com/WordPress/gutenberg/assets/1813435/32bd3968-8e4b-45d5-9992-277f54a366b2"><img width="279" alt="CleanShot 2023-07-03 at 12 53 18" src="https://github.com/WordPress/gutenberg/assets/1813435/eb4e171f-9cbb-48b0-9a85-6f3eb1be67c5">|











