### PR TITLE
Add missing periods in pattern descriptions

### DIFF
--- a/packages/edit-site/src/components/page-patterns/patterns-list.js
+++ b/packages/edit-site/src/components/page-patterns/patterns-list.js
@@ -79,7 +79,7 @@ export default function PatternsList( { categoryId, type } ) {
 						<Heading level={ 4 }>{ __( 'Synced' ) }</Heading>
 						<Text variant="muted" as="p">
 							{ __(
-								'Patterns that are kept in sync across your site'
+								'Patterns that are kept in sync across your site.'
 							) }
 						</Text>
 					</VStack>
@@ -97,7 +97,7 @@ export default function PatternsList( { categoryId, type } ) {
 						<Heading level={ 4 }>{ __( 'Standard' ) }</Heading>
 						<Text variant="muted" as="p">
 							{ __(
-								'Patterns that can be changed freely without affecting your site'
+								'Patterns that can be changed freely without affecting your site.'
 							) }
 						</Text>
 					</VStack>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Super small addition of `.` at the end of the descriptive text under both the "Synced" and "Standard" pattern headings. 

## Why?
Consistency.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open the Site Editor.
2. View the Pattern library. 
3. See periods. 

## Screenshots or screencast <!-- if applicable -->

| Before  | After |
| ------------- | ------------- |
|<img width="339" alt="CleanShot 2023-07-03 at 14 15 07" src="https://github.com/WordPress/gutenberg/assets/1813435/9c7e8b23-6612-4b83-b540-e73b98ab3c9e">|<img width="340" alt="CleanShot 2023-07-03 at 14 15 18" src="https://github.com/WordPress/gutenberg/assets/1813435/5cb9ad5f-6de1-4f4a-b263-0345b79c5e5c">|

