### PR TITLE
Site Editor Frame: Ignore Spotlight in view mode

### DIFF
--- a/packages/edit-site/src/components/block-editor/use-site-editor-settings.js
+++ b/packages/edit-site/src/components/block-editor/use-site-editor-settings.js
@@ -12,11 +12,13 @@ import { unlock } from '../../lock-unlock';
 import inserterMediaCategories from './inserter-media-categories';
 
 export default function useSiteEditorSettings( templateType ) {
-	const { storedSettings } = useSelect( ( select ) => {
-		const { getSettings } = unlock( select( editSiteStore ) );
-
+	const { storedSettings, canvasMode } = useSelect( ( select ) => {
+		const { getSettings, getCanvasMode } = unlock(
+			select( editSiteStore )
+		);
 		return {
 			storedSettings: getSettings(),
+			canvasMode: getCanvasMode(),
 		};
 	}, [] );
 
@@ -70,6 +72,7 @@ export default function useSiteEditorSettings( templateType ) {
 		const {
 			__experimentalAdditionalBlockPatterns,
 			__experimentalAdditionalBlockPatternCategories,
+			focusMode,
 			...restStoredSettings
 		} = storedSettings;
 
@@ -78,6 +81,7 @@ export default function useSiteEditorSettings( templateType ) {
 			inserterMediaCategories,
 			__experimentalBlockPatterns: blockPatterns,
 			__experimentalBlockPatternCategories: blockPatternCategories,
+			focusMode: canvasMode === 'view' && focusMode ? false : focusMode,
 		};
-	}, [ storedSettings, blockPatterns, blockPatternCategories ] );
+	}, [ storedSettings, blockPatterns, blockPatternCategories, canvasMode ] );
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Resolves: https://github.com/WordPress/gutenberg/issues/51415

>If you have the 'Spotlight mode' option enabled in the editor preferences, that manifests in the Site Editor frame too, which harms the effectiveness of the preview.

> Ideally the preview frame should ignore the Spotlight preference so that all blocks appear at full opacity.

## How

This approach overrides the edit site editor's `focusMode` setting conditionally. I'm not sure if there is a better approach though..
