### PR TITLE
Fix incorrect aria-describedby attributes for theme patterns

### DIFF
--- a/packages/edit-site/src/components/page-patterns/grid-item.js
+++ b/packages/edit-site/src/components/page-patterns/grid-item.js
@@ -122,7 +122,12 @@ export default function GridItem( { categoryId, composite, icon, item } ) {
 					aria-label={ item.title }
 					aria-describedby={
 						ariaDescriptions.length
-							? ariaDescriptions.join( ' ' )
+							? ariaDescriptions
+									.map(
+										( _, index ) =>
+											`${ descriptionId }-${ index }`
+									)
+									.join( ' ' )
 							: undefined
 					}
 				>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What and why?
<!-- In a few words, what is the PR actually doing? -->
An error introduced in #51990. Fix incorrect `aria-describedby` usage for theme patterns in the patterns page. Part of https://github.com/WordPress/gutenberg/issues/52253.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Pass in `id`s rather than the descriptions.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
1. Go to Site Editor > Design > Patterns
2. Go to a theme pattern in the sidebar (with a lock icon)
3. Open the devtools and see that the options should have the `Theme patterns cannot be edited.` descriptions.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
This is a screen-reader-only feature. Follow the same steps above and expect the descriptions to be read out from the options.

## Screenshots or screencast <!-- if applicable -->
![image](https://github.com/WordPress/gutenberg/assets/7753001/8411e6b5-119d-4b2f-b245-b745bbdd15bd)

