### PR TITLE
Add 'npm run test:e2e:playwright:ui'

### DIFF
--- a/package.json
+++ b/package.json
@@ -309,6 +309,7 @@
 		"test:e2e": "wp-scripts test-e2e --config packages/e2e-tests/jest.config.js",
 		"test:e2e:debug": "wp-scripts --inspect-brk test-e2e  --runInBand --no-cache --verbose --config packages/e2e-tests/jest.config.js --puppeteer-devtools",
 		"test:e2e:playwright": "playwright test --config test/e2e/playwright.config.ts",
+		"test:e2e:playwright:ui": "playwright test --ui --config test/e2e/playwright.config.ts",
 		"test:e2e:storybook": "playwright test --config test/storybook-playwright/playwright.config.ts",
 		"test:e2e:watch": "npm run test:e2e -- --watch",
 		"test:performance": "wp-scripts test-e2e --config packages/e2e-tests/jest.performance.config.js",


### PR DESCRIPTION
## What?
Adds a `npm run test:e2e:playwright:ui` command which invokes [UI Mode](https://playwright.dev/docs/test-ui-mode).

## Why?
UI Mode is really helpful, this might expose it to more contributors. 

## Testing Instructions
Ensure that `wp-env` is running and run `npm run test:e2e:playwright:ui`.