### PR TITLE
Site Editor Pages: load the appropriate template if posts page set

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen-page/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-page/index.js
@@ -9,7 +9,7 @@ import {
 	ExternalLink,
 	__experimentalTruncate as Truncate,
 } from '@wordpress/components';
-import { store as coreStore, useEntityRecord } from '@wordpress/core-data';
+import { store as coreStore } from '@wordpress/core-data';
 import { decodeEntities } from '@wordpress/html-entities';
 import { pencil } from '@wordpress/icons';
 import { __unstableStripHTML as stripHTML } from '@wordpress/dom';
@@ -26,28 +26,36 @@ import SidebarButton from '../sidebar-button';
 import PageDetails from './page-details';
 import PageActions from '../page-actions';
 import SidebarNavigationScreenDetailsFooter from '../sidebar-navigation-screen-details-footer';
+import HomeTemplateDetails from '../sidebar-navigation-screen-template/home-template-details';
 
-export default function SidebarNavigationScreenPage() {
-	const navigator = useNavigator();
-	const { setCanvasMode } = unlock( useDispatch( editSiteStore ) );
+function usePageDetails( postId ) {
 	const {
-		params: { postId },
-	} = useNavigator();
-	const { record } = useEntityRecord( 'postType', 'page', postId );
-
-	const { featuredMediaAltText, featuredMediaSourceUrl } = useSelect(
+		isPostsPage,
+		record,
+		featuredMediaSourceUrl,
+		featuredMediaAltText,
+	} = useSelect(
 		( select ) => {
 			const { getEntityRecord } = select( coreStore );
+			const siteSettings = getEntityRecord( 'root', 'site' );
+			const pageRecord = select( coreStore ).getEntityRecord(
+				'postType',
+				'page',
+				postId
+			);
+
 			// Featured image.
-			const attachedMedia = record?.featured_media
+			const attachedMedia = pageRecord?.featured_media
 				? getEntityRecord(
 						'postType',
 						'attachment',
-						record?.featured_media
+						pageRecord?.featured_media
 				  )
 				: null;
-
 			return {
+				record: pageRecord,
+				isPostsPage:
+					parseInt( postId, 10 ) === siteSettings?.page_for_posts,
 				featuredMediaSourceUrl:
 					attachedMedia?.media_details.sizes?.medium?.source_url ||
 					attachedMedia?.source_url,
@@ -58,18 +66,81 @@ export default function SidebarNavigationScreenPage() {
 				),
 			};
 		},
-		[ record ]
+		[ postId ]
 	);
+
+	const title = decodeEntities(
+		record?.title?.rendered || __( '(no title)' )
+	);
+	const description = isPostsPage
+		? __( 'This page displays your latest posts' )
+		: '';
 
 	const featureImageAltText = featuredMediaAltText
 		? decodeEntities( featuredMediaAltText )
 		: decodeEntities( record?.title?.rendered || __( 'Featured image' ) );
 
-	return record ? (
-		<SidebarNavigationScreen
-			title={ decodeEntities(
-				record?.title?.rendered || __( '(no title)' )
+	const content = isPostsPage ? (
+		<HomeTemplateDetails />
+	) : (
+		<>
+			{ !! featuredMediaSourceUrl && ! isPostsPage && (
+				<VStack
+					className="edit-site-sidebar-navigation-screen-page__featured-image-wrapper"
+					alignment="left"
+					spacing={ 2 }
+				>
+					<div className="edit-site-sidebar-navigation-screen-page__featured-image has-image">
+						<img
+							alt={ featureImageAltText }
+							src={ featuredMediaSourceUrl }
+						/>
+					</div>
+				</VStack>
 			) }
+			{ !! record?.excerpt?.rendered && ! isPostsPage && (
+				<Truncate
+					className="edit-site-sidebar-navigation-screen-page__excerpt"
+					numberOfLines={ 3 }
+				>
+					{ stripHTML( record.excerpt.rendered ) }
+				</Truncate>
+			) }
+			<PageDetails id={ postId } />
+		</>
+	);
+
+	const meta = record?.link ? (
+		<ExternalLink
+			className="edit-site-sidebar-navigation-screen__page-link"
+			href={ record.link }
+		>
+			{ filterURLForDisplay( safeDecodeURIComponent( record.link ) ) }
+		</ExternalLink>
+	) : null;
+
+	const footer = !! record?.modified ? (
+		<SidebarNavigationScreenDetailsFooter
+			lastModifiedDateTime={ record.modified }
+		/>
+	) : null;
+
+	return { title, meta, description, content, footer };
+}
+
+export default function SidebarNavigationScreenPage() {
+	const navigator = useNavigator();
+	const { setCanvasMode } = unlock( useDispatch( editSiteStore ) );
+	const {
+		params: { postId },
+	} = useNavigator();
+	const { title, meta, content, description, footer } =
+		usePageDetails( postId );
+
+	return (
+		<SidebarNavigationScreen
+			title={ title }
+			description={ description }
 			actions={
 				<>
 					<PageActions
@@ -86,48 +157,9 @@ export default function SidebarNavigationScreenPage() {
 					/>
 				</>
 			}
-			meta={
-				<ExternalLink
-					className="edit-site-sidebar-navigation-screen__page-link"
-					href={ record.link }
-				>
-					{ filterURLForDisplay(
-						safeDecodeURIComponent( record.link )
-					) }
-				</ExternalLink>
-			}
-			content={
-				<>
-					{ !! featuredMediaSourceUrl && (
-						<VStack
-							className="edit-site-sidebar-navigation-screen-page__featured-image-wrapper"
-							alignment="left"
-							spacing={ 2 }
-						>
-							<div className="edit-site-sidebar-navigation-screen-page__featured-image has-image">
-								<img
-									alt={ featureImageAltText }
-									src={ featuredMediaSourceUrl }
-								/>
-							</div>
-						</VStack>
-					) }
-					{ !! record?.excerpt?.rendered && (
-						<Truncate
-							className="edit-site-sidebar-navigation-screen-page__excerpt"
-							numberOfLines={ 3 }
-						>
-							{ stripHTML( record.excerpt.rendered ) }
-						</Truncate>
-					) }
-					<PageDetails id={ postId } />
-				</>
-			}
-			footer={
-				<SidebarNavigationScreenDetailsFooter
-					lastModifiedDateTime={ record?.modified }
-				/>
-			}
+			meta={ meta }
+			content={ content }
+			footer={ footer }
 		/>
-	) : null;
+	);
 }

--- a/packages/edit-site/src/components/sidebar-navigation-screen-page/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-page/index.js
@@ -26,18 +26,11 @@ import SidebarButton from '../sidebar-button';
 import PageDetails from './page-details';
 import PageActions from '../page-actions';
 import SidebarNavigationScreenDetailsFooter from '../sidebar-navigation-screen-details-footer';
-import HomeTemplateDetails from '../sidebar-navigation-screen-template/home-template-details';
 
 function usePageDetails( postId ) {
-	const {
-		isPostsPage,
-		record,
-		featuredMediaSourceUrl,
-		featuredMediaAltText,
-	} = useSelect(
+	const { record, featuredMediaSourceUrl, featuredMediaAltText } = useSelect(
 		( select ) => {
 			const { getEntityRecord } = select( coreStore );
-			const siteSettings = getEntityRecord( 'root', 'site' );
 			const pageRecord = select( coreStore ).getEntityRecord(
 				'postType',
 				'page',
@@ -54,8 +47,6 @@ function usePageDetails( postId ) {
 				: null;
 			return {
 				record: pageRecord,
-				isPostsPage:
-					parseInt( postId, 10 ) === siteSettings?.page_for_posts,
 				featuredMediaSourceUrl:
 					attachedMedia?.media_details.sizes?.medium?.source_url ||
 					attachedMedia?.source_url,
@@ -72,19 +63,14 @@ function usePageDetails( postId ) {
 	const title = decodeEntities(
 		record?.title?.rendered || __( '(no title)' )
 	);
-	const description = isPostsPage
-		? __( 'This page displays your latest posts' )
-		: '';
 
 	const featureImageAltText = featuredMediaAltText
 		? decodeEntities( featuredMediaAltText )
 		: decodeEntities( record?.title?.rendered || __( 'Featured image' ) );
 
-	const content = isPostsPage ? (
-		<HomeTemplateDetails />
-	) : (
+	const content = (
 		<>
-			{ !! featuredMediaSourceUrl && ! isPostsPage && (
+			{ !! featuredMediaSourceUrl && (
 				<VStack
 					className="edit-site-sidebar-navigation-screen-page__featured-image-wrapper"
 					alignment="left"
@@ -98,7 +84,7 @@ function usePageDetails( postId ) {
 					</div>
 				</VStack>
 			) }
-			{ !! record?.excerpt?.rendered && ! isPostsPage && (
+			{ !! record?.excerpt?.rendered && (
 				<Truncate
 					className="edit-site-sidebar-navigation-screen-page__excerpt"
 					numberOfLines={ 3 }
@@ -125,7 +111,7 @@ function usePageDetails( postId ) {
 		/>
 	) : null;
 
-	return { title, meta, description, content, footer };
+	return { title, meta, content, footer };
 }
 
 export default function SidebarNavigationScreenPage() {
@@ -134,13 +120,11 @@ export default function SidebarNavigationScreenPage() {
 	const {
 		params: { postId },
 	} = useNavigator();
-	const { title, meta, content, description, footer } =
-		usePageDetails( postId );
+	const { title, meta, content, footer } = usePageDetails( postId );
 
 	return (
 		<SidebarNavigationScreen
 			title={ title }
-			description={ description }
 			actions={
 				<>
 					<PageActions

--- a/packages/edit-site/src/components/sidebar-navigation-screen-pages/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-pages/index.js
@@ -106,6 +106,26 @@ export default function SidebarNavigationScreenPages() {
 		setShowAddPage( false );
 	};
 
+	const getPageProps = ( id ) => {
+		let itemIcon = page;
+		const isPostsPage = postsPage && postsPage === id;
+
+		switch ( id ) {
+			case frontPage:
+				itemIcon = home;
+				break;
+			case postsPage:
+				itemIcon = verse;
+				break;
+		}
+
+		return {
+			icon: itemIcon,
+			postType: isPostsPage ? 'wp_template' : 'page',
+			postId: isPostsPage ? homeTemplate.id : id,
+		};
+	};
+
 	return (
 		<>
 			{ showAddPage && (
@@ -152,34 +172,20 @@ export default function SidebarNavigationScreenPages() {
 										</Truncate>
 									</PageItem>
 								) }
-								{ reorderedPages?.map( ( item ) => {
-									let itemIcon;
-									switch ( item.id ) {
-										case frontPage:
-											itemIcon = home;
-											break;
-										case postsPage:
-											itemIcon = verse;
-											break;
-										default:
-											itemIcon = page;
-									}
-									return (
-										<PageItem
-											postId={ item.id }
-											key={ item.id }
-											icon={ itemIcon }
-											withChevron
-										>
-											<Truncate numberOfLines={ 1 }>
-												{ decodeEntities(
-													item?.title?.rendered ||
-														__( '(no title)' )
-												) }
-											</Truncate>
-										</PageItem>
-									);
-								} ) }
+								{ reorderedPages?.map( ( { id, title } ) => (
+									<PageItem
+										{ ...getPageProps( id ) }
+										key={ id }
+										withChevron
+									>
+										<Truncate numberOfLines={ 1 }>
+											{ decodeEntities(
+												title?.rendered ||
+													__( '(no title)' )
+											) }
+										</Truncate>
+									</PageItem>
+								) ) }
 							</ItemGroup>
 						) }
 					</>

--- a/packages/edit-site/src/components/sidebar-navigation-screen-pages/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-pages/index.js
@@ -108,7 +108,8 @@ export default function SidebarNavigationScreenPages() {
 
 	const getPageProps = ( id ) => {
 		let itemIcon = page;
-		const isPostsPage = postsPage && postsPage === id;
+		const isPostsPage =
+			postsPage && postsPage === id && homeTemplate.slug !== 'front-page';
 
 		switch ( id ) {
 			case frontPage:

--- a/packages/edit-site/src/components/sidebar-navigation-screen-pages/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-pages/index.js
@@ -58,13 +58,16 @@ export default function SidebarNavigationScreenPages() {
 		templates?.find( ( template ) => template.slug === 'home' ) ||
 		templates?.find( ( template ) => template.slug === 'index' );
 
+	const getPostsPageTemplate = () =>
+		templates?.find( ( template ) => template.slug === 'home' ) ||
+		templates?.find( ( template ) => template.slug === 'index' );
+
 	const pagesAndTemplates = pages?.concat( dynamicPageTemplates, [
 		homeTemplate,
 	] );
 
 	const { frontPage, postsPage } = useSelect( ( select ) => {
 		const { getEntityRecord } = select( coreStore );
-
 		const siteSettings = getEntityRecord( 'root', 'site' );
 		return {
 			frontPage: siteSettings?.page_on_front,
@@ -108,8 +111,8 @@ export default function SidebarNavigationScreenPages() {
 
 	const getPageProps = ( id ) => {
 		let itemIcon = page;
-		const isPostsPage =
-			postsPage && postsPage === id && homeTemplate.slug !== 'front-page';
+		const postsPageTemplateId =
+			postsPage && postsPage === id ? getPostsPageTemplate()?.id : null;
 
 		switch ( id ) {
 			case frontPage:
@@ -122,8 +125,8 @@ export default function SidebarNavigationScreenPages() {
 
 		return {
 			icon: itemIcon,
-			postType: isPostsPage ? 'wp_template' : 'page',
-			postId: isPostsPage ? homeTemplate.id : id,
+			postType: postsPageTemplateId ? 'wp_template' : 'page',
+			postId: postsPageTemplateId || id,
 		};
 	};
 


### PR DESCRIPTION

## What?

Resolves: https://github.com/WordPress/gutenberg/issues/52114

This PR:
- links the posts page to the homepage template when a post page is set
- abstracts logic to get page item props


## How?
Checking if `posts_page` (from site settings) matches the current page id.

## Testing Instructions
Start off with a theme that has a home template, e.g., 2023

Set a posts/home page in the settings:
<img width="553" alt="Screenshot 2023-07-04 at 1 42 29 pm" src="https://github.com/WordPress/gutenberg/assets/6458278/0cc100eb-2660-45df-93ca-cd53dbf07705">

Head to the site editor, and navigate to the Pages pane in the sidebar.

Check that the posts page is in the list with the correct icon (verse) and that clicking it loads the current home template.

![2023-07-04 13 42 07](https://github.com/WordPress/gutenberg/assets/6458278/9c503daa-60ce-4d67-9562-97fa918a717a)

Create a `front-page` template and verify that the post page links to the front page template.

Switch to a theme that has an index template only, e.g., empty theme.

Verify that the post page links to the index template.

