### PR TITLE
Page List: Fix ESLint warnings

### DIFF
--- a/packages/block-library/src/page-list/edit.js
+++ b/packages/block-library/src/page-list/edit.js
@@ -183,63 +183,66 @@ export default function PageListEdit( {
 		style: { ...context.style?.color },
 	} );
 
-	const getBlockList = ( parentId = parentPageID ) => {
-		const childPages = pagesByParentId.get( parentId );
+	const pagesTree = useMemo(
+		function makePagesTree( parentId = 0, level = 0 ) {
+			const childPages = pagesByParentId.get( parentId );
 
-		if ( ! childPages?.length ) {
-			return [];
-		}
-
-		return childPages.reduce( ( template, page ) => {
-			const hasChildren = pagesByParentId.has( page.id );
-			const pageProps = {
-				id: page.id,
-				label:
-					// translators: displayed when a page has an empty title.
-					page.title?.rendered?.trim() !== ''
-						? page.title?.rendered
-						: __( '(no title)' ),
-				title: page.title?.rendered,
-				link: page.url,
-				hasChildren,
-			};
-			let item = null;
-			const children = getBlockList( page.id );
-			item = createBlock( 'core/page-list-item', pageProps, children );
-			template.push( item );
-
-			return template;
-		}, [] );
-	};
-
-	const makePagesTree = ( parentId = 0, level = 0 ) => {
-		const childPages = pagesByParentId.get( parentId );
-
-		if ( ! childPages?.length ) {
-			return [];
-		}
-
-		return childPages.reduce( ( tree, page ) => {
-			const hasChildren = pagesByParentId.has( page.id );
-			const item = {
-				value: page.id,
-				label: '— '.repeat( level ) + page.title.rendered,
-				rawName: page.title.rendered,
-			};
-			tree.push( item );
-			if ( hasChildren ) {
-				tree.push( ...makePagesTree( page.id, level + 1 ) );
+			if ( ! childPages?.length ) {
+				return [];
 			}
-			return tree;
-		}, [] );
-	};
 
-	const pagesTree = useMemo( makePagesTree, [ pagesByParentId ] );
+			return childPages.reduce( ( tree, page ) => {
+				const hasChildren = pagesByParentId.has( page.id );
+				const item = {
+					value: page.id,
+					label: '— '.repeat( level ) + page.title.rendered,
+					rawName: page.title.rendered,
+				};
+				tree.push( item );
+				if ( hasChildren ) {
+					tree.push( ...makePagesTree( page.id, level + 1 ) );
+				}
+				return tree;
+			}, [] );
+		},
+		[ pagesByParentId ]
+	);
 
-	const blockList = useMemo( getBlockList, [
-		pagesByParentId,
-		parentPageID,
-	] );
+	const blockList = useMemo(
+		function getBlockList( parentId = parentPageID ) {
+			const childPages = pagesByParentId.get( parentId );
+
+			if ( ! childPages?.length ) {
+				return [];
+			}
+
+			return childPages.reduce( ( template, page ) => {
+				const hasChildren = pagesByParentId.has( page.id );
+				const pageProps = {
+					id: page.id,
+					label:
+						// translators: displayed when a page has an empty title.
+						page.title?.rendered?.trim() !== ''
+							? page.title?.rendered
+							: __( '(no title)' ),
+					title: page.title?.rendered,
+					link: page.url,
+					hasChildren,
+				};
+				let item = null;
+				const children = getBlockList( page.id );
+				item = createBlock(
+					'core/page-list-item',
+					pageProps,
+					children
+				);
+				template.push( item );
+
+				return template;
+			}, [] );
+		},
+		[ pagesByParentId, parentPageID ]
+	);
 
 	const {
 		isNested,


### PR DESCRIPTION
## What?
PR fixes the ESLint warning inside the Page List block's edit component.

## How?
I moved the function definition inside the `useMemo` hook.

## Testing Instructions
Confirm page list is rendered as before.

```
npm run lint:js -- packages/block-library/src/page-list/edit.js
```
