### PR TITLE
Patterns: Update section heading levels

### DIFF
--- a/packages/edit-site/src/components/page-patterns/grid-item.js
+++ b/packages/edit-site/src/components/page-patterns/grid-item.js
@@ -12,7 +12,6 @@ import {
 	DropdownMenu,
 	MenuGroup,
 	MenuItem,
-	__experimentalHeading as Heading,
 	__experimentalHStack as HStack,
 	__unstableCompositeItem as CompositeItem,
 	Tooltip,
@@ -155,12 +154,7 @@ export default function GridItem( { categoryId, composite, icon, item } ) {
 								icon={ itemIcon }
 							/>
 						) }
-						<Flex
-							as={ Heading }
-							level={ 5 }
-							gap={ 0 }
-							justify="left"
-						>
+						<Flex as="span" gap={ 0 } justify="left">
 							{ item.title }
 							{ item.type === PATTERNS && (
 								<Tooltip

--- a/packages/edit-site/src/components/page-patterns/patterns-list.js
+++ b/packages/edit-site/src/components/page-patterns/patterns-list.js
@@ -76,7 +76,9 @@ export default function PatternsList( { categoryId, type } ) {
 			{ ! isResolving && !! syncedPatterns.length && (
 				<>
 					<VStack className="edit-site-patterns__section-header">
-						<Heading level={ 4 }>{ __( 'Synced' ) }</Heading>
+						<Heading as="h2" level={ 4 }>
+							{ __( 'Synced' ) }
+						</Heading>
 						<Text variant="muted" as="p">
 							{ __(
 								'Patterns that are kept in sync across your site'
@@ -94,7 +96,9 @@ export default function PatternsList( { categoryId, type } ) {
 			{ ! isResolving && !! unsyncedPatterns.length && (
 				<>
 					<VStack className="edit-site-patterns__section-header">
-						<Heading level={ 4 }>{ __( 'Standard' ) }</Heading>
+						<Heading as="h2" level={ 4 }>
+							{ __( 'Standard' ) }
+						</Heading>
 						<Text variant="muted" as="p">
 							{ __(
 								'Patterns that can be changed freely without affecting your site'

--- a/packages/edit-site/src/components/page-patterns/style.scss
+++ b/packages/edit-site/src/components/page-patterns/style.scss
@@ -91,7 +91,7 @@
 }
 
 .edit-site-patterns__pattern-title {
-	color: $gray-600;
+	color: $gray-200;
 
 	.edit-site-patterns__pattern-icon {
 		border-radius: $grid-unit-05;


### PR DESCRIPTION
Related:
- https://github.com/WordPress/gutenberg/issues/52253

## What?

- Corrects the level of the Patterns page's section headings (h4 > h2)
- Removes the use of a heading within a pattern title that isn't perceivable to assistive technologies 

## Why?

Addresses accessibility issue.

## How?

- Changes section heading levels
- Replaces pattern title's heading with span 
- Tweaks styles to maintain the same appearance as before

## Testing Instructions

1. Visit Site Editor > Patterns
2. Ensure the Synced and Unsynced section headings are now `h2` elements
3. Inspect a pattern's title and ensure it doesn't contain any heading elements
4. Compare the Patterns page to trunk and ensure that it looks the same.


## Screenshots or screencast <!-- if applicable -->

<img width="1048" alt="Screenshot 2023-07-04 at 5 36 49 pm" src="https://github.com/WordPress/gutenberg/assets/60436221/e58ec2d5-73a7-4730-9a27-7abae9c3d2d1">

<img width="1267" alt="Screenshot 2023-07-04 at 5 36 04 pm" src="https://github.com/WordPress/gutenberg/assets/60436221/b497dca4-ac5f-45d5-a670-95c085c20b27">

