### PR TITLE
WP 6.3: remove IS_GUTENBERG_PLUGIN from PHP files

### DIFF
--- a/packages/block-library/src/file/index.php
+++ b/packages/block-library/src/file/index.php
@@ -5,23 +5,6 @@
  * @package WordPress
  */
 
-if ( defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN ) {
-	/**
-	 * Replaces view script for the File block with version using Interactivity API.
-	 *
-	 * @param array $metadata Block metadata as read in via block.json.
-	 *
-	 * @return array Filtered block type metadata.
-	 */
-	function gutenberg_block_core_file_update_interactive_view_script( $metadata ) {
-		if ( 'core/file' === $metadata['name'] ) {
-			$metadata['viewScript'] = array( 'file:./interactivity.min.js' );
-		}
-		return $metadata;
-	}
-	add_filter( 'block_type_metadata', 'gutenberg_block_core_file_update_interactive_view_script', 10, 1 );
-}
-
 /**
  * When the `core/file` block is rendering, check if we need to enqueue the `'wp-block-file-view` script.
  *
@@ -69,17 +52,6 @@ function render_block_core_file( $attributes, $content, $block ) {
 		},
 		$content
 	);
-
-	// If it uses the Interactivity API, add the directives.
-	if ( defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN && $should_load_view_script ) {
-		$processor = new WP_HTML_Tag_Processor( $content );
-		$processor->next_tag();
-		$processor->set_attribute( 'data-wp-interactive', '' );
-		$processor->next_tag( 'object' );
-		$processor->set_attribute( 'data-wp-bind--hidden', '!selectors.core.file.hasPdfPreview' );
-		$processor->set_attribute( 'hidden', true );
-		return $processor->get_updated_html();
-	}
 
 	return $content;
 }


### PR DESCRIPTION
Resolves https://github.com/WordPress/gutenberg/issues/52103

## What?
This PR removes `IS_GUTENBERG_PLUGIN` blocks from PHP files in the wp/6.3 branch only.

This is mostly the interactivity API.

## Why?
So that there is no plugin-specific code in Core.

## How?
Deleting stuff.

## Testing Instructions
Check that the file and navigation blocks still render correctly on the frontend. Make sure to verify all attributes/classes/styles please :) 
