### PR TITLE
Post editor: Require confirmation before removing Footnotes

### DIFF
--- a/packages/block-editor/src/components/block-removal-warning-modal/index.js
+++ b/packages/block-editor/src/components/block-removal-warning-modal/index.js
@@ -50,6 +50,9 @@ export function BlockRemovalWarningModal( { rules } ) {
 		<Modal
 			title={ __( 'Are you sure?' ) }
 			onRequestClose={ clearBlockRemovalPrompt }
+			style={ {
+				maxWidth: '40rem',
+			} }
 		>
 			{ blockNamesForPrompt.length === 1 ? (
 				<p>{ rules[ blockNamesForPrompt[ 0 ] ] }</p>

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -71,7 +71,7 @@ const interfaceLabels = {
 
 const blockRemovalRules = {
 	'core/footnotes': __(
-		'The Footnotes block displays all footnotes found in the content.'
+		'The Footnotes block displays all footnotes found in the content. Note that any footnotes in the content will persist after removing this block.'
 	),
 };
 

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -16,7 +16,10 @@ import {
 	store as editorStore,
 } from '@wordpress/editor';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { BlockBreadcrumb } from '@wordpress/block-editor';
+import {
+	BlockBreadcrumb,
+	privateApis as blockEditorPrivateApis,
+} from '@wordpress/block-editor';
 import { Button, ScrollLock, Popover } from '@wordpress/components';
 import { useViewportMatch } from '@wordpress/compose';
 import { PluginArea } from '@wordpress/plugins';
@@ -49,6 +52,9 @@ import WelcomeGuide from '../welcome-guide';
 import ActionsPanel from './actions-panel';
 import StartPageOptions from '../start-page-options';
 import { store as editPostStore } from '../../store';
+import { unlock } from '../../lock-unlock';
+
+const { BlockRemovalWarningModal } = unlock( blockEditorPrivateApis );
 
 const interfaceLabels = {
 	/* translators: accessibility text for the editor top bar landmark region. */
@@ -61,6 +67,12 @@ const interfaceLabels = {
 	actions: __( 'Editor publish' ),
 	/* translators: accessibility text for the editor footer landmark region. */
 	footer: __( 'Editor footer' ),
+};
+
+const blockRemovalRules = {
+	'core/footnotes': __(
+		'The Footnotes block displays all footnotes found in the content.'
+	),
 };
 
 function Layout( { styles } ) {
@@ -202,6 +214,7 @@ function Layout( { styles } ) {
 			<LocalAutosaveMonitor />
 			<EditPostKeyboardShortcuts />
 			<EditorKeyboardShortcutsRegister />
+			<BlockRemovalWarningModal rules={ blockRemovalRules } />
 			<SettingsSidebar />
 			<InterfaceSkeleton
 				isDistractionFree={ isDistractionFree && isLargeViewport }

--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -70,6 +70,9 @@ const blockRemovalRules = {
 	'core/post-content': __(
 		'Post Content displays the content of a post or page.'
 	),
+	'core/footnotes': __(
+		'The Footnotes block displays all footnotes found in the content. Note that any footnotes in the content will persist after removing this block.'
+	),
 };
 
 export default function Editor( { isLoading } ) {


### PR DESCRIPTION
## What?

Context: #52176

This doesn't fix the parent issue but is a palliative.

Attempting to remove a Footnotes block triggers the `BlockRemovalWarningModal`, informing the user and requiring their confirmation before proceeding with the removal.

**note:** I myself am not sure this is the way to go, but the idea has been discussed, and this pull request should serve as the place to debate and experiment.

## Why?

* Accidental removal of the Footnotes block can lead to user frustration
* There are greater flows to fix or decisions to be made, like:
  - When the Footnotes block is removed, should the footnote anchors in the content be removed? How?
  - When the Footnotes block is removed, should the notes themselves (stored in post meta) be removed? If not, how should/can this be made clear for users?

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
In the Post Editor, add footnotes to some content, then try removing the Footnotes block.

## Screenshots or screencast

Latest:
<img width="798" alt="Screenshot 2023-07-04 at 12 04 51" src="https://github.com/WordPress/gutenberg/assets/150562/f01810fe-d57d-4b0a-bdf9-656556c1d2c9">

Previously:
<img width="662" alt="Screenshot 2023-07-04 at 11 41 25" src="https://github.com/WordPress/gutenberg/assets/150562/f4137aac-335f-4021-94ce-afe71d87f450">
