### PR TITLE
Lodash: Refactor away from `_.set()` in `getNodesWithSettings()`

### DIFF
--- a/packages/block-editor/src/components/global-styles/use-global-styles-output.js
+++ b/packages/block-editor/src/components/global-styles/use-global-styles-output.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { get, set } from 'lodash';
+import { get } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -32,7 +32,7 @@ import { PresetDuotoneFilter } from '../duotone/components';
 import { getGapCSSValue } from '../../hooks/gap';
 import { store as blockEditorStore } from '../../store';
 import { LAYOUT_DEFINITIONS } from '../../layouts/definitions';
-import { kebabCase } from '../../utils/object';
+import { kebabCase, setImmutably } from '../../utils/object';
 
 // List of block support features that can have their related styles
 // generated under their own feature level selector rather than the block's.
@@ -678,11 +678,11 @@ export const getNodesWithSettings = ( tree, blockSelectors ) => {
 	}
 
 	const pickPresets = ( treeToPickFrom ) => {
-		const presets = {};
+		let presets = {};
 		PRESET_METADATA.forEach( ( { path } ) => {
 			const value = get( treeToPickFrom, path, false );
 			if ( value !== false ) {
-				set( presets, path, value );
+				presets = setImmutably( presets, path, value );
 			}
 		} );
 		return presets;


### PR DESCRIPTION
## What?
This PR removes Lodash's `_.set()` from the `getNodesWithSettings()` global styles function.

We have a few more usages of `set()` left in the codebase, but we might have to tread carefully, since some of them may have to deal with Unicode characters, and I prefer testing them one by one.

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?

We're replacing the usage with the existing `setImmutably` utility function, which should do the job even better - there's no need to specifically mutate, as long as we preserve all the prior changes.

## Testing Instructions

* Smoke test global styles and verify still work well.
* Verify tests pass - the function is covered by unit tests.