### PR TITLE
Polish welcome guide copy for page / template editing

### DIFF
--- a/packages/edit-site/src/components/welcome-guide/page.js
+++ b/packages/edit-site/src/components/welcome-guide/page.js
@@ -31,7 +31,7 @@ export default function WelcomeGuidePage() {
 		return null;
 	}
 
-	const heading = __( 'Editing your page' );
+	const heading = __( 'Editing a page' );
 
 	return (
 		<Guide
@@ -63,7 +63,7 @@ export default function WelcomeGuidePage() {
 							</h1>
 							<p className="edit-site-welcome-guide__text">
 								{ __(
-									'We’ve recently introduced the ability to edit pages within the site editor. You can switch to editing your template using the settings sidebar.'
+									'It’s now possible to edit page content in the site editor. To customise other parts of the page like the header and footer switch to editing the template using the settings sidebar.'
 								) }
 							</p>
 						</>

--- a/packages/edit-site/src/components/welcome-guide/template.js
+++ b/packages/edit-site/src/components/welcome-guide/template.js
@@ -36,7 +36,7 @@ export default function WelcomeGuideTemplate() {
 		return null;
 	}
 
-	const heading = __( 'Editing your template' );
+	const heading = __( 'Editing a template' );
 
 	return (
 		<Guide
@@ -70,7 +70,7 @@ export default function WelcomeGuideTemplate() {
 							</h1>
 							<p className="edit-site-welcome-guide__text">
 								{ __(
-									'You’re now editing your page’s template. To switch back to editing your page you can click the back button in the toolbar.'
+									'Note that the same template can be used by multiple pages, so any changes made here may affect other pages on the site. To switch back to editing the page content click the ‘Back’ button in the toolbar.'
 								) }
 							</p>
 						</>


### PR DESCRIPTION
## What?
Updates the copy to be a little more educational, and remove possessive language.

## Why?
There's room to elaborate a little on the concepts presented in these welcome guides. 

Removing the possessive determiners/pronouns will work better in enterprise environments, and equally well otherwise.

## How?
Updated text strings.

## Testing Instructions
* In the Site Editor, navigate to a page and click the pencil icon to edit it
* In the resulting welcome guide observe the new copy
* Edit the template for that page and observe the new copy in the resulting welcome guide

### Editing a page before
> Editing your page
> We’ve recently introduced the ability to edit pages within the site editor. You can switch to editing your template using the settings sidebar.

### Editing a page after
> Editing a page
> It’s now possible to edit page content in the site editor. To customise other parts of the page like the header and footer switch to editing the template using the settings sidebar.

<img width="400" alt="Screenshot 2023-07-04 at 13 23 14" src="https://github.com/WordPress/gutenberg/assets/846565/01d8096f-1532-4351-b138-4cf5653957f0">


### Editing a page template before
> Editing your template
> You’re now editing your page’s template. To switch back to editing your page you can click the back button in the toolbar.

### Editing a page template after
> Editing a template
> Note that the same template can be used by multiple pages, so any changes made here may affect other pages on the site. To switch back to editing the page content click the ‘Back’ button in the toolbar.

<img width="371" alt="Screenshot 2023-07-04 at 13 26 19" src="https://github.com/WordPress/gutenberg/assets/846565/467dd6f3-79a7-4d12-95fe-5bde411fe979">

