### PR TITLE
Fix flaky Site Editor pages e2e test

### DIFF
--- a/test/e2e/specs/site-editor/pages.spec.js
+++ b/test/e2e/specs/site-editor/pages.spec.js
@@ -78,7 +78,7 @@ test.describe( 'Pages', () => {
 		).toBeVisible();
 
 		// Switch to template editing focus.
-		await page.getByRole( 'button', { name: 'Settings' } ).click();
+		await editor.openDocumentSettingsSidebar();
 		await page
 			.getByRole( 'region', { name: 'Editor settings' } )
 			.getByRole( 'button', { name: 'Edit template' } )
@@ -102,7 +102,10 @@ test.describe( 'Pages', () => {
 			.fill( 'New Site Title' );
 
 		// Go back to page editing focus.
-		await page.getByRole( 'button', { name: 'Back', exact: true } ).click();
+		await page
+			.getByRole( 'region', { name: 'Editor top bar' } )
+			.getByRole( 'button', { name: 'Back' } )
+			.click();
 
 		// Site Title and Page entities should have been modified.
 		await page.getByRole( 'button', { name: 'Save', exact: true } ).click();


### PR DESCRIPTION
## What?
I noticed this test failing on the trunk due to the broad scope locator - https://github.com/WordPress/gutenberg/actions/runs/5453941422/jobs/9923411345.

## Why?
It turns out we're always rendering the "Navigation" region in the site editor, and it also can have a "Back" button.

## How?
A better-scoped "Back" button locator.

## Testing Instructions

```
npm run test:e2e:playwright -- test/e2e/specs/site-editor/pages.spec.js
```
