### PR TITLE
Update save modal appearance in the Site Editor

### DIFF
--- a/packages/base-styles/_z-index.scss
+++ b/packages/base-styles/_z-index.scss
@@ -194,6 +194,7 @@ $z-layers: (
 
 	// Ensure modal footer actions appear above modal contents
 	".edit-site-start-template-options__modal__actions": 1,
+	".edit-site-save-panel__modal .entities-saved-states__panel-header": 1,
 );
 
 @function z-index( $key ) {

--- a/packages/edit-site/src/components/save-panel/index.js
+++ b/packages/edit-site/src/components/save-panel/index.js
@@ -98,7 +98,7 @@ export default function SavePanel() {
 			<Modal
 				className="edit-site-save-panel__modal"
 				onRequestClose={ onClose }
-				__experimentalHideHeader
+				title={ __( 'Save changes' ) }
 				contentLabel={ __(
 					'Save site, content, and template changes'
 				) }

--- a/packages/edit-site/src/components/save-panel/style.scss
+++ b/packages/edit-site/src/components/save-panel/style.scss
@@ -15,6 +15,17 @@
 			border: 1px solid $gray-200;
 			border-radius: $radius-block-ui;
 			margin-bottom: $grid-unit-20;
+
+			&.is-opened {
+				.components-panel__body-title,
+				.components-panel__body-title:hover {
+					border-bottom: 1px solid $gray-100;
+				}
+			}
+
+			.components-panel__body-title + .components-panel__row {
+				margin-top: $grid-unit-15;
+			}
 		}
 	}
 

--- a/packages/edit-site/src/components/save-panel/style.scss
+++ b/packages/edit-site/src/components/save-panel/style.scss
@@ -22,12 +22,22 @@
 		order: 1;
 		height: auto;
 		border: 0;
-		border-top: 1px solid $gray-200;
 		justify-content: end;
 		position: sticky;
 		bottom: 0;
-		padding: $grid-unit-20 0 $grid-unit-40;
+		padding: $grid-unit-30 0 $grid-unit-40;
 		z-index: z-index(".edit-site-save-panel__modal .entities-saved-states__panel-header");
+
+		&::before {
+			content: "";
+			display: block;
+			height: 1px;
+			background: $gray-200;
+			position: absolute;
+			top: 0;
+			left: - $grid-unit-40;
+			right: - $grid-unit-40;
+		}
 
 		.components-button {
 			flex: initial;

--- a/packages/edit-site/src/components/save-panel/style.scss
+++ b/packages/edit-site/src/components/save-panel/style.scss
@@ -2,4 +2,51 @@
 	@include break-small() {
 		width: 600px;
 	}
+
+	.components-modal__content {
+		padding-bottom: 0;
+	}
+
+	.entities-saved-states__panel {
+		display: flex;
+		flex-direction: column;
+
+		.components-panel__body {
+			border: 1px solid $gray-200;
+			border-radius: $radius-block-ui;
+			margin-bottom: $grid-unit-20;
+		}
+	}
+
+	.entities-saved-states__panel-header {
+		order: 1;
+		height: auto;
+		border: 0;
+		border-top: 1px solid $gray-200;
+		justify-content: end;
+		position: sticky;
+		bottom: 0;
+		padding: $grid-unit-20 0 $grid-unit-40;
+		z-index: z-index(".edit-site-save-panel__modal .entities-saved-states__panel-header");
+
+		.components-button {
+			flex: initial;
+
+			&.is-primary {
+				order: 1;
+			}
+		}
+	}
+
+	.entities-saved-states__text-prompt {
+		padding: 0;
+
+		p {
+			margin-top: 0;
+		}
+
+		strong {
+			display: none;
+		}
+	}
 }


### PR DESCRIPTION
## What?
Updates the appearance of the save modal in the Site Editor.

## Why?
The current modal is a makeshift repurposing of the save _panel_, and looks a bit clunky.

In lieu of a more holistic update to the saving experience I investigated whether we can style this modal to more closely resemble others. The functionality remains unchanged, but with the addition of a title, a bit of content re-arrangement using `order`, and some styling it's possible to get quite close.

## How?
* Add a `title` to save `Modal`.
* Re-orders elements via `order`.
* Make the actions container sticky.
* Adjust some styles to better suit the environment. 

## Testing Instructions
* Open the Site Editor
* Make changes to things like styles, content, templates
* Click "Review x changes" in site view
* Observe the updated modal appearance

### Before

<img width="676" alt="Screenshot 2023-07-04 at 16 14 30" src="https://github.com/WordPress/gutenberg/assets/846565/fd468a9c-5a34-4905-b1b0-65f33a5fd01d">


### After

https://github.com/WordPress/gutenberg/assets/846565/63e7a3e0-fc96-4b88-b584-852caf64ddcb

This is just a first take, we can refine from here.