### PR TITLE
Check randomizer experiment is enabled before rendering button

### DIFF
--- a/packages/edit-site/src/components/global-styles/palette.js
+++ b/packages/edit-site/src/components/global-styles/palette.js
@@ -91,7 +91,7 @@ function Palette( { name } ) {
 					</HStack>
 				</NavigationButtonAsItem>
 			</ItemGroup>
-			{ themeColors?.length > 0 && (
+			{ randomizeThemeColors && themeColors?.length > 0 && (
 				<Button
 					variant="secondary"
 					icon={ shuffle }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes #52296.

The "Randomize colors" button in the colors section of global styles should only display if "Color randomizer" is enabled in Gutenberg experiments.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Go to Gutenberg > Experiments and enable color randomizer;
2. In the site editor go to Styles > Colors and check that "Randomize colors" button appears and works as expected.
3. Go back to experiments and disable randomizer;
4.  "Randomize colors" should not appear in Styles > Colors anymore.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
