### PR TITLE
Navigation: Fix e2e test failures caused by sidebar title change

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen-pattern/template-part-navigation-menu.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-pattern/template-part-navigation-menu.js
@@ -22,7 +22,7 @@ export default function TemplatePartNavigationMenu( { id } ) {
 				size="12"
 				upperCase={ true }
 			>
-				{ title?.rendered || __( 'Navigation' ) }
+				{ title?.rendered || title || __( 'Navigation' ) }
 			</Heading>
 			<NavigationMenuEditor navigationMenuId={ id } />
 		</>

--- a/packages/edit-site/src/components/sidebar-navigation-screen-pattern/template-part-navigation-menu.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-pattern/template-part-navigation-menu.js
@@ -22,7 +22,7 @@ export default function TemplatePartNavigationMenu( { id } ) {
 				size="12"
 				upperCase={ true }
 			>
-				{ title || __( 'Navigation' ) }
+				{ title?.rendered || __( 'Navigation' ) }
 			</Heading>
 			<NavigationMenuEditor navigationMenuId={ id } />
 		</>


### PR DESCRIPTION
## What?
This updates commit ea6b5a12aa7424c2cd9c10e4a4476d9dad10295d to add check for object as sometimes `title` is returned as object and sometimes as string.

## Why?
The original change caused e2e test failures due to the site editor crashing in instances where the title is an object.

## How?
Added check for object and string for `title`

## Testing Instructions

- Open the Site Editor
- Open the Library
- Open a header template that contains a navigation
- Confirm that the navigation shows in the sidebar with the correct title
- Check that `npm run test:e2e:playwright  -- --headed specs/editor/blocks/navigation.spec.js` completes

