### PR TITLE
Site editor: revert layout.js changes from Update frame resizing

### DIFF
--- a/packages/edit-site/src/components/layout/index.js
+++ b/packages/edit-site/src/components/layout/index.js
@@ -285,6 +285,11 @@ export default function Layout() {
 						{ showSidebar && (
 							<ResizableBox
 								as={ motion.div }
+								// The sidebar is needed for routing on mobile
+								// (https://github.com/WordPress/gutenberg/pull/51558/files#r1231763003),
+								// so we can't remove the element entirely. Using `inert` will make
+								// it inaccessible to screen readers and keyboard navigation.
+								inert={ showSidebar ? undefined : 'inert' }
 								initial={ {
 									opacity: 0,
 								} }
@@ -297,7 +302,10 @@ export default function Layout() {
 								transition={ {
 									type: 'tween',
 									duration:
-										disableMotion || isResizing
+										// Disable transition in mobile to emulate a full page transition.
+										disableMotion ||
+										isResizing ||
+										isMobileViewport
 											? 0
 											: ANIMATION_DURATION,
 									ease: 'easeOut',
@@ -421,6 +429,9 @@ export default function Layout() {
 													top: 0,
 													left: 0,
 													bottom: 0,
+													background:
+														gradientValue ??
+														backgroundColor,
 												} }
 												initial={ false }
 												animate={ {
@@ -437,12 +448,11 @@ export default function Layout() {
 												} }
 											>
 												<ErrorBoundary>
-													{ isEditorPage && (
-														<Editor />
-													) }
-													{ isListPage && (
-														<ListPage />
-													) }
+													<Editor
+														isLoading={
+															isEditorLoading
+														}
+													/>
 												</ErrorBoundary>
 											</motion.div>
 										</motion.div>

--- a/packages/edit-site/src/components/layout/style.scss
+++ b/packages/edit-site/src/components/layout/style.scss
@@ -93,6 +93,13 @@
 
 	.resizable-editor__drag-handle {
 		right: 0;
+		&.is-variation-separator {
+			height: 150px;
+			&::after {
+				width: 5px;
+				border-radius: 5px;
+			}
+		}
 	}
 }
 
@@ -127,16 +134,14 @@
 	left: 0;
 	bottom: 0;
 	width: 100%;
-
-
 	overflow: hidden;
-	//display: flex;
-	//justify-content: center;
-	//align-items: center;
-	//
-	//&:has(.edit-site-layout__resizable-frame-oversized) {
-	//	justify-content: flex-end;
-	//}
+	display: flex;
+	justify-content: center;
+	align-items: center;
+
+	&:has(.edit-site-layout__resizable-frame-oversized) {
+		justify-content: flex-end;
+	}
 
 	& > div {
 		color: $gray-900;

--- a/packages/edit-site/src/components/layout/style.scss
+++ b/packages/edit-site/src/components/layout/style.scss
@@ -127,13 +127,16 @@
 	left: 0;
 	bottom: 0;
 	width: 100%;
-	display: flex;
-	justify-content: center;
-	align-items: center;
 
-	&:has(.edit-site-layout__resizable-frame-oversized) {
-		justify-content: flex-end;
-	}
+
+	overflow: hidden;
+	//display: flex;
+	//justify-content: center;
+	//align-items: center;
+	//
+	//&:has(.edit-site-layout__resizable-frame-oversized) {
+	//	justify-content: flex-end;
+	//}
 
 	& > div {
 		color: $gray-900;


### PR DESCRIPTION
## What?
Maybe resolves https://github.com/WordPress/gutenberg/issues/51267

Rolls back the changes made to [packages/edit-site/src/components/layout/index.js](https://github.com/WordPress/gutenberg/pull/49910/files#diff-89e57bfd1de96b1cee155f91aa9754cb37715e9ffa9e4cc2f21463a770f7ec55) in https://github.com/WordPress/gutenberg/pull/49910.

## Why?
Frame resizing is not keyboard accessible

## How?
Manually reverted the changes from c689d9f by comparing with the previous version in d746e558

## Testing Instructions
Open the site editor in view mode.
Ensure the canvas is resizable with a keyboard and with a mouse.

## Screenshots or screencast <!-- if applicable -->

![2023-07-05 14 58 57](https://github.com/WordPress/gutenberg/assets/6458278/9e6f72d1-b27b-4a3d-8264-d1e2abe1dfa3)

