### PR TITLE
Fix TS error

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -21,7 +21,7 @@
 		"noUnusedParameters": true,
 		"noImplicitReturns": true,
 		"noFallthroughCasesInSwitch": true,
-		"importsNotUsedAsValues": "error",
+		"verbatimModuleSyntax": true,
 
 		/* Module Resolution Options */
 		"moduleResolution": "node",


### PR DESCRIPTION
## What?

I keep getting this error locally:
```
Option 'importsNotUsedAsValues' is deprecated and will stop functioning in TypeScript 5.5. 
 * Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 * Use 'verbatimModuleSyntax' instead.
```

This PR fixes the error by migrating from `importsNotUsedAsValues` to `verbatimModuleSyntax`