### PR TITLE
Allow developers to opt out of auto-creation of Navigation fallback

### DIFF
--- a/lib/compat/wordpress-6.3/class-gutenberg-navigation-fallback.php
+++ b/lib/compat/wordpress-6.3/class-gutenberg-navigation-fallback.php
@@ -23,9 +23,18 @@ class Gutenberg_Navigation_Fallback {
 	 */
 	public static function get_fallback() {
 
+		/**
+		 * Filters whether or not a fallback should be created.
+		 *
+		 * @since 6.3.0
+		 *
+		 * @param bool Whether or not to create a fallback.
+		 */
+		$should_create_fallback = apply_filters( 'gutenberg_navigation_should_create_fallback', true );
+
 		$fallback = static::get_most_recently_published_navigation();
 
-		if ( $fallback ) {
+		if ( $fallback || ! $should_create_fallback ) {
 			return $fallback;
 		}
 

--- a/phpunit/class-gutenberg-navigation-fallback-gutenberg-test.php
+++ b/phpunit/class-gutenberg-navigation-fallback-gutenberg-test.php
@@ -32,7 +32,6 @@ class Gutenberg_Navigation_Fallback_Test extends WP_UnitTestCase {
 		$this->assertTrue( class_exists( 'Gutenberg_Navigation_Fallback' ), 'Gutenberg_Navigation_Fallback class should exist.' );
 	}
 
-
 	/**
 	 * @covers WP_REST_Navigation_Fallback_Controller::get_fallback
 	 */
@@ -52,6 +51,24 @@ class Gutenberg_Navigation_Fallback_Test extends WP_UnitTestCase {
 		$navs_in_db = $this->get_navigations_in_database();
 
 		$this->assertCount( 1, $navs_in_db, 'The fallback Navigation post should be the only one in the database.' );
+	}
+
+	/**
+	 * @covers WP_REST_Navigation_Fallback_Controller::get_fallback
+	 */
+	public function test_should_not_automatically_create_fallback_if_filter_is_falsey() {
+
+		add_filter( 'gutenberg_navigation_should_create_fallback', '__return_false' );
+
+		$data = Gutenberg_Navigation_Fallback::get_fallback();
+
+		$this->assertEmpty( $data );
+
+		$navs_in_db = $this->get_navigations_in_database();
+
+		$this->assertCount( 0, $navs_in_db, 'The fallback Navigation post should not have been created.' );
+
+		remove_filter( 'gutenberg_navigation_should_create_fallback', '__return_false' );
 	}
 
 	/**


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Allows developers to opt out of automatic Navigation Menu fallback creation. This allows developers to choose whether or not they would like a Navigation to be automatically created if one doesn't exist in the database. 

Note: if this lands then we'll need to backport and also update the names of the filter to `wp_`.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

If we add a feature like this we should provide a means to opt _out_ of the behaviour.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Adds a filter `gutenberg_navigation_should_create_fallback` which defaults to `true`. If this is filtered to `false` then:

- no classic menu to block menu conversion occurs.
- no fallback Navigation is created.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

Run tests

```
npm run test:unit:php -- --filter Gutenberg_Navigation_Fallback_Test --order-by=random
```

Also check that nothing breaks in the editor or on the front of the site when you load them with no Navigations in your DB.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
