### PR TITLE
[RNMobile] Fix a crash related to Reanimated when closing the editor

### DIFF
--- a/packages/block-editor/src/components/block-draggable/index.native.js
+++ b/packages/block-editor/src/components/block-draggable/index.native.js
@@ -109,8 +109,12 @@ const BlockDraggableWrapper = ( { children, isRTL } ) => {
 		draggingScrollHandler( event );
 	};
 
-	const { onBlockDragOver, onBlockDragEnd, onBlockDrop, targetBlockIndex } =
-		useBlockDropZone();
+	const {
+		onBlockDragOverWorklet,
+		onBlockDragEnd,
+		onBlockDrop,
+		targetBlockIndex,
+	} = useBlockDropZone();
 
 	// Stop dragging blocks if the block draggable is unmounted.
 	useEffect( () => {
@@ -184,7 +188,7 @@ const BlockDraggableWrapper = ( { children, isRTL } ) => {
 		chip.y.value = dragPosition.y;
 		currentYPosition.value = dragPosition.y;
 
-		runOnJS( onBlockDragOver )( { x, y: y + scroll.offsetY.value } );
+		onBlockDragOverWorklet( { x, y: y + scroll.offsetY.value } );
 
 		// Update scrolling velocity
 		scrollOnDragOver( dragPosition.y );

--- a/packages/react-native-editor/CHANGELOG.md
+++ b/packages/react-native-editor/CHANGELOG.md
@@ -11,6 +11,7 @@ For each user feature we should also add a importance categorization label  to i
 
 ## Unreleased
 -   [*] Rename "Reusable blocks" to "Synced patterns", aligning with the web editor. [#51704]
+-   [**] Fix a crash related to Reanimated when closing the editor [#52320]
 
 ## 1.98.1
 -   [*] fix: Display heading level dropdown icons and labels [#52004]


### PR DESCRIPTION
**Related PR:** https://github.com/wordpress-mobile/gutenberg-mobile/pull/5938

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

When working on [the RN upgrade 0.71.11](https://github.com/WordPress/gutenberg/pull/51303), we spotted a very similar crash to [this one](https://github.com/wordpress-mobile/WordPress-iOS/issues/20499). Now that it has been fixed in the RN upgrade, we could also incorporate it into `trunk` in case it solves other crashes related to Reanimated before the upgrade lands.

⚠️ As we couldn't find a consistent way to reproduce the Reanimated crashes, it's not confirmed that this fix would actually solve the mentioned crashes.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

This PR aims to fix several crashes we identified in the app, but that we couldn't reproduce back then:
* https://github.com/wordpress-mobile/WordPress-iOS/issues/20499
* https://github.com/wordpress-mobile/gutenberg-mobile/issues/5862

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Seems there's some kind of incompatibility on calling a JS function from a Reanimated's worklet ([reference](https://github.com/WordPress/gutenberg/blob/b1579dd8d3bc745a1f25da2872f2df3cc16afc28/packages/block-editor/src/components/block-draggable/index.native.js#L180-L191)) invoked from a gesture handler ([reference](https://github.com/WordPress/gutenberg/blob/b1579dd8d3bc745a1f25da2872f2df3cc16afc28/packages/components/src/draggable/index.native.js#L109-L127)). For this reason, the logic to set the dropping insertion point has been updated. It now uses a Reanimated's shared value to keep the dragging over position and  `useDerivedValue` hook to listen for changes.

More info about the fix can be found [here](https://github.com/WordPress/gutenberg/pull/51303#issuecomment-1620474494).

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

As we couldn't find a consistent way to reproduce the Reanimated crashes, we won't be able to test that this PR fixes them. However, we can ensure that the drag & drop functionality works.

1. Open the app and create a new post/page.
2. Switch to HTML mode.
3. Copy and paste the [HTML example](https://github.com/wordpress-mobile/test-cases/blob/trunk/test-cases/gutenberg/drag-and-drop-blocks.md#html-example) into the HTML editor.
4. Switch to Visual Mode" mode.
5. Long press over a block.
6. Drag the block around the post/page (e.g. move it to the top or bottom of the content).
7. Observe that an insertion indicator is displayed when dragging the block.
<img src=https://github.com/wordpress-mobile/test-cases/raw/trunk/test-cases/resources/drag-and-drop-blocks-drag-to-bottom-content.gif width=200>
8. Observe that when dropping the block, it's added to the same position as indicated by the insertion indicator.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

N/A

## Screenshots or screencast <!-- if applicable -->

N/A