### PR TITLE
Add editor preference for default state of Link UI settings drawer

### DIFF
--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -12,7 +12,6 @@ import { useRef, useState, useEffect } from '@wordpress/element';
 import { focus } from '@wordpress/dom';
 import { ENTER } from '@wordpress/keycodes';
 import { isShallowEqualObjects } from '@wordpress/is-shallow-equal';
-import { store as preferencesStore } from '@wordpress/preferences';
 import { useSelect } from '@wordpress/data';
 
 /**
@@ -26,6 +25,7 @@ import useCreatePage from './use-create-page';
 import useInternalValue from './use-internal-value';
 import { ViewerFill } from './viewer-slot';
 import { DEFAULT_LINK_SETTINGS } from './constants';
+import { store as blockEditorStore } from '../../store';
 
 /**
  * Default properties associated with a link control value.
@@ -135,22 +135,12 @@ function LinkControl( {
 		withCreateSuggestion = true;
 	}
 
-	const { settingsDrawerStatePreference } = useSelect( ( select ) => {
-		const prefsStore = select( preferencesStore );
-
-		const postEditorEnabled =
-			prefsStore.get( 'core/edit-post', 'linkControlSettingsDrawer' ) ??
-			false;
-
-		const siteEditorEnabled =
-			prefsStore.get( 'core/edit-site', 'linkControlSettingsDrawer' ) ??
-			false;
-
-		return {
-			settingsDrawerStatePreference:
-				postEditorEnabled || siteEditorEnabled,
-		};
-	}, [] );
+	const settingsDrawerStatePreference = useSelect(
+		( select ) =>
+			select( blockEditorStore ).getSettings()
+				.linkControlAdvancedSettingsPreference,
+		[]
+	);
 
 	const isMounting = useRef( true );
 	const wrapperNode = useRef();

--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -135,6 +135,7 @@ function LinkControl( {
 		withCreateSuggestion = true;
 	}
 
+	// Preference is supplied by the relevant editor.
 	const settingsDrawerStatePreference = useSelect(
 		( select ) =>
 			select( blockEditorStore ).getSettings()

--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -12,6 +12,8 @@ import { useRef, useState, useEffect } from '@wordpress/element';
 import { focus } from '@wordpress/dom';
 import { ENTER } from '@wordpress/keycodes';
 import { isShallowEqualObjects } from '@wordpress/is-shallow-equal';
+import { store as preferencesStore } from '@wordpress/preferences';
+import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -133,6 +135,23 @@ function LinkControl( {
 		withCreateSuggestion = true;
 	}
 
+	const { settingsDrawerStatePreference } = useSelect( ( select ) => {
+		const prefsStore = select( preferencesStore );
+
+		const postEditorEnabled =
+			prefsStore.get( 'core/edit-post', 'linkControlSettingsDrawer' ) ??
+			false;
+
+		const siteEditorEnabled =
+			prefsStore.get( 'core/edit-site', 'linkControlSettingsDrawer' ) ??
+			false;
+
+		return {
+			settingsDrawerStatePreference:
+				postEditorEnabled || siteEditorEnabled,
+		};
+	}, [] );
+
 	const isMounting = useRef( true );
 	const wrapperNode = useRef();
 	const textInputRef = useRef();
@@ -140,7 +159,9 @@ function LinkControl( {
 
 	const settingsKeys = settings.map( ( { id } ) => id );
 
-	const [ settingsOpen, setSettingsOpen ] = useState( false );
+	const [ settingsOpen, setSettingsOpen ] = useState(
+		settingsDrawerStatePreference
+	);
 
 	const [
 		internalControlValue,

--- a/packages/edit-post/src/components/preferences-modal/index.js
+++ b/packages/edit-post/src/components/preferences-modal/index.js
@@ -5,7 +5,7 @@
 import { __ } from '@wordpress/i18n';
 import { useViewportMatch } from '@wordpress/compose';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { useMemo } from '@wordpress/element';
+import { useMemo, useCallback } from '@wordpress/element';
 import {
 	PostTaxonomies,
 	PostExcerptCheck,
@@ -69,12 +69,17 @@ export default function EditPostPreferencesModal() {
 
 	const { set: setPreference } = useDispatch( preferencesStore );
 
-	const toggleDistractionFree = () => {
+	const toggleDistractionFree = useCallback( () => {
 		setPreference( 'core/edit-post', 'fixedToolbar', false );
 		setIsInserterOpened( false );
 		setIsListViewOpened( false );
 		closeGeneralSidebar();
-	};
+	}, [
+		closeGeneralSidebar,
+		setIsInserterOpened,
+		setIsListViewOpened,
+		setPreference,
+	] );
 
 	const sections = useMemo(
 		() => [
@@ -152,6 +157,15 @@ export default function EditPostPreferencesModal() {
 									label={ __( 'Display block breadcrumbs' ) }
 								/>
 							) }
+							<EnableFeature
+								featureName="linkControlSettingsDrawer"
+								help={ __(
+									`Toggle's default open/closed state of the link creation interface's settings drawer.`
+								) }
+								label={ __(
+									'Always open Link UI Settings Drawer'
+								) }
+							/>
 						</PreferencesModalSection>
 					</>
 				),
@@ -252,7 +266,7 @@ export default function EditPostPreferencesModal() {
 				),
 			},
 		],
-		[ isLargeViewport, showBlockBreadcrumbsOption ]
+		[ isLargeViewport, showBlockBreadcrumbsOption, toggleDistractionFree ]
 	);
 
 	if ( ! isModalActive ) {

--- a/packages/edit-post/src/components/preferences-modal/index.js
+++ b/packages/edit-post/src/components/preferences-modal/index.js
@@ -160,7 +160,7 @@ export default function EditPostPreferencesModal() {
 							<EnableFeature
 								featureName="linkControlSettingsDrawer"
 								help={ __(
-									`Toggle's default open/closed state of the link creation interface's settings drawer.`
+									`Toggles advanced link creation settings.`
 								) }
 								label={ __(
 									'Always open advanced link settings'

--- a/packages/edit-post/src/components/preferences-modal/index.js
+++ b/packages/edit-post/src/components/preferences-modal/index.js
@@ -163,7 +163,7 @@ export default function EditPostPreferencesModal() {
 									`Toggle's default open/closed state of the link creation interface's settings drawer.`
 								) }
 								label={ __(
-									'Always open Link UI Settings Drawer'
+									'Always open advanced link settings'
 								) }
 							/>
 						</PreferencesModalSection>

--- a/packages/edit-post/src/editor.js
+++ b/packages/edit-post/src/editor.js
@@ -47,6 +47,7 @@ function Editor( { postId, postType, settings, initialEdits, ...props } ) {
 		keepCaretInsideBlock,
 		isTemplateMode,
 		template,
+		linkControlAdvancedSettingsPreference,
 	} = useSelect(
 		( select ) => {
 			const {
@@ -79,6 +80,8 @@ function Editor( { postId, postType, settings, initialEdits, ...props } ) {
 			const isViewable = getPostType( postType )?.viewable ?? false;
 			const canEditTemplate = canUser( 'create', 'templates' );
 
+			const prefsStore = select( preferencesStore );
+
 			return {
 				hasFixedToolbar:
 					isFeatureActive( 'fixedToolbar' ) ||
@@ -87,10 +90,15 @@ function Editor( { postId, postType, settings, initialEdits, ...props } ) {
 				isDistractionFree: isFeatureActive( 'distractionFree' ),
 				hasInlineToolbar: isFeatureActive( 'inlineToolbar' ),
 				hasThemeStyles: isFeatureActive( 'themeStyles' ),
-				preferredStyleVariations: select( preferencesStore ).get(
+				preferredStyleVariations: prefsStore.get(
 					'core/edit-post',
 					'preferredStyleVariations'
 				),
+				linkControlAdvancedSettingsPreference:
+					prefsStore.get(
+						'core/edit-post',
+						'linkControlSettingsDrawer'
+					) ?? false,
 				hiddenBlockTypes: getHiddenBlockTypes(),
 				blockTypes: getBlockTypes(),
 				keepCaretInsideBlock: isFeatureActive( 'keepCaretInsideBlock' ),
@@ -126,6 +134,7 @@ function Editor( { postId, postType, settings, initialEdits, ...props } ) {
 			// Keep a reference of the `allowedBlockTypes` from the server to handle use cases
 			// where we need to differentiate if a block is disabled by the user or some plugin.
 			defaultAllowedBlockTypes: settings.allowedBlockTypes,
+			linkControlAdvancedSettingsPreference,
 		};
 
 		// Omit hidden block types if exists and non-empty.
@@ -156,6 +165,7 @@ function Editor( { postId, postType, settings, initialEdits, ...props } ) {
 		setIsInserterOpened,
 		updatePreferredStyleVariations,
 		keepCaretInsideBlock,
+		linkControlAdvancedSettingsPreference,
 	] );
 
 	const styles = useMemo( () => {

--- a/packages/edit-site/src/components/block-editor/use-site-editor-settings.js
+++ b/packages/edit-site/src/components/block-editor/use-site-editor-settings.js
@@ -10,6 +10,7 @@ import { store as coreStore } from '@wordpress/core-data';
 import { store as editSiteStore } from '../../store';
 import { unlock } from '../../lock-unlock';
 import inserterMediaCategories from './inserter-media-categories';
+import { store as preferencesStore } from '@wordpress/preferences';
 
 export default function useSiteEditorSettings( templateType ) {
 	const { storedSettings, canvasMode } = useSelect( ( select ) => {
@@ -19,6 +20,18 @@ export default function useSiteEditorSettings( templateType ) {
 		return {
 			storedSettings: getSettings(),
 			canvasMode: getCanvasMode(),
+		};
+	}, [] );
+
+	const { linkControlAdvancedSettingsPreference } = useSelect( ( select ) => {
+		const prefsStore = select( preferencesStore );
+
+		return {
+			linkControlAdvancedSettingsPreference:
+				prefsStore.get(
+					'core/edit-site',
+					'linkControlSettingsDrawer'
+				) ?? false,
 		};
 	}, [] );
 
@@ -82,6 +95,13 @@ export default function useSiteEditorSettings( templateType ) {
 			__experimentalBlockPatterns: blockPatterns,
 			__experimentalBlockPatternCategories: blockPatternCategories,
 			focusMode: canvasMode === 'view' && focusMode ? false : focusMode,
+			linkControlAdvancedSettingsPreference,
 		};
-	}, [ storedSettings, blockPatterns, blockPatternCategories, canvasMode ] );
+	}, [
+		storedSettings,
+		blockPatterns,
+		blockPatternCategories,
+		canvasMode,
+		linkControlAdvancedSettingsPreference,
+	] );
 }

--- a/packages/edit-site/src/components/preferences-modal/index.js
+++ b/packages/edit-site/src/components/preferences-modal/index.js
@@ -7,7 +7,6 @@ import {
 	PreferencesModalSection,
 	store as interfaceStore,
 } from '@wordpress/interface';
-import { useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { useSelect, useDispatch, useRegistry } from '@wordpress/data';
 import { store as preferencesStore } from '@wordpress/preferences';
@@ -41,7 +40,7 @@ export default function EditSitePreferencesModal() {
 		} );
 	};
 
-	const sections = useMemo( () => [
+	const sections = [
 		{
 			name: 'general',
 			tabLabel: __( 'General' ),
@@ -86,6 +85,13 @@ export default function EditSitePreferencesModal() {
 						) }
 						label={ __( 'Display block breadcrumbs' ) }
 					/>
+					<EnableFeature
+						featureName="linkControlSettingsDrawer"
+						help={ __(
+							`Toggle's default open/closed state of the link creation interface's settings drawer.`
+						) }
+						label={ __( 'Always open Link UI Settings Drawer' ) }
+					/>
 				</PreferencesModalSection>
 			),
 		},
@@ -109,7 +115,8 @@ export default function EditSitePreferencesModal() {
 				</PreferencesModalSection>
 			),
 		},
-	] );
+	];
+
 	if ( ! isModalActive ) {
 		return null;
 	}

--- a/packages/editor/src/components/provider/use-block-editor-settings.js
+++ b/packages/editor/src/components/provider/use-block-editor-settings.js
@@ -77,6 +77,7 @@ const BLOCK_EDITOR_SETTINGS = [
 	'__unstableResolvedAssets',
 	'__unstableIsBlockBasedTheme',
 	'behaviors',
+	'linkControlAdvancedSettingsPreference',
 ];
 
 /**


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes regression where "optimising" the Link UI for 80% of users has made it worse for 20% who want to use "Open in new tab".

Sets an editor preference for the default open/closed state of the Link UI's settings drawer.

Closes https://github.com/WordPress/gutenberg/issues/52216

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Whilst we don't want to encourage usage of open in new tab it's still a use case for some. By adding a preference users can opt-in to always displaying the settings drawer which improves the UX for them.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Add preference and use as default state for link UI.

**Question**: is there a way to get the appropriate preference store depending on which editor I'm in? 


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

- New Post
- Add link
- Click link - see settings drawer is closed by default.
- Go to editor preferences modal.
- Set preference to persist setting drawer for Link UI.
- Return to editor.
- Click link again.
- See that now the settings drawer defaults to "open".
- Make sure you can still toggle the open/closed state of drawer manually using the UI.
- Repeat above steps in the Site Editor.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
<img width="787" alt="Screen Shot 2023-07-05 at 09 58 51" src="https://github.com/WordPress/gutenberg/assets/444434/90c8f322-1167-48fe-8bd2-37f9b4a4af5d">


