### PR TITLE
Fix loading state flicker in Navigation in Site View when requesting fallback

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/index.js
@@ -4,6 +4,7 @@
 import { __, sprintf } from '@wordpress/i18n';
 import { useEntityRecords, store as coreStore } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
+import { useState, useEffect } from '@wordpress/element';
 
 import { decodeEntities } from '@wordpress/html-entities';
 import {
@@ -44,6 +45,21 @@ function buildMenuLabel( title, id, status ) {
 
 // Save a boolean to prevent us creating a fallback more than once per session.
 let hasCreatedFallback = false;
+
+function DelayedSpinner( { delay = 250, ...props } ) {
+	const [ show, setShow ] = useState( false );
+
+	useEffect( () => {
+		const timeout = setTimeout( () => {
+			setShow( true );
+		}, delay );
+		return () => {
+			clearTimeout( timeout );
+		};
+	}, [ delay ] );
+
+	return show && <Spinner { ...props } />;
+}
 
 export default function SidebarNavigationScreenNavigationMenus() {
 	const {
@@ -112,7 +128,7 @@ export default function SidebarNavigationScreenNavigationMenus() {
 	if ( isLoading ) {
 		return (
 			<SidebarNavigationScreenWrapper>
-				<Spinner className="edit-site-sidebar-navigation-screen-navigation-menus__loading" />
+				<DelayedSpinner className="edit-site-sidebar-navigation-screen-navigation-menus__loading" />
 			</SidebarNavigationScreenWrapper>
 		);
 	}

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/index.js
@@ -56,10 +56,35 @@ export default function SidebarNavigationScreenNavigationMenus() {
 		PRELOADED_NAVIGATION_MENUS_QUERY
 	);
 
-	const isLoading =
+	const {
+		getNavigationFallbackId,
+		hasResolvedNavigationFallbackId,
+		isResolvingNavigationFallbackId,
+	} = useSelect( ( select ) => {
+		const {
+			getNavigationFallbackId: getNavigationFallbackIdSelector,
+			hasFinishedResolution,
+			isResolving,
+		} = unlock( select( coreStore ) );
+
+		return {
+			getNavigationFallbackId: getNavigationFallbackIdSelector,
+			isResolvingNavigationFallbackId: isResolving(
+				'getNavigationFallbackId'
+			),
+			hasResolvedNavigationFallbackId: hasFinishedResolution(
+				'getNavigationFallbackId'
+			),
+		};
+	}, [] );
+
+	const isLoadingNavigationMenus =
 		isResolvingNavigationMenus && ! hasResolvedNavigationMenus;
 
-	const { getNavigationFallbackId } = unlock( useSelect( coreStore ) );
+	const isLoadingFallback =
+		isResolvingNavigationFallbackId && ! hasResolvedNavigationFallbackId;
+
+	const isLoading = isLoadingNavigationMenus || isLoadingFallback;
 
 	const firstNavigationMenu = navigationMenus?.[ 0 ];
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Avoids flicker in `Navigation` listing section of Site View during resolution of fallback Navigation:

Closes https://github.com/WordPress/gutenberg/issues/51802

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

There is a flicker between loading and non-loading states because:

- menus start loading which shows the loading state
- menus finish loading which shows the "empty no menus" state.
- the fallback is requested - no change to the UI
- the fallback resolves - no change to UI
- menus are requested from state - UI show loading state
- menus resolve - UI shows single menu

That's not nice UX.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

This PR fixes the situation by also making the "loading" state in the UI dependent on the resolution status of the fallback request if it's currently running.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

Check first that it fixes the bug outlined in https://github.com/WordPress/gutenberg/issues/51802.

Then...

- Have menus
- Make sure you can view Nav listing and there are no quirks such as infinite loading spinners etc.
- Delete all menus.
- Reload site editor and go to /navigation/ in Site View.
- See a single loading state until all the requests resolve.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
