### PR TITLE
Experimental: Disable TinyMCE compat with classic editor

### DIFF
--- a/lib/experimental/disable-tinymce.php
+++ b/lib/experimental/disable-tinymce.php
@@ -71,6 +71,14 @@ function gutenberg_post_being_edited_requires_classic_block() {
 		$content = $current_post->post_content;
 	}
 
+	// Check if block editor is disabled by "Classic Editor" or another plugin.
+	if (
+		function_exists( 'use_block_editor_for_post_type' ) &&
+		! use_block_editor_for_post_type( $current_post->post_type )
+	) {
+		return true;
+	}
+
 	if ( empty( $content ) ) {
 		return false;
 	}


### PR DESCRIPTION
## What?
This PR makes the TinyMCE removal experiment compatible with the Classic Editor plugin and other plugins that disable the block editor. 

## Why?
In #50387 we introduced an experiment that allows us to remove TinyMCE from initial loading when we can. We're now polishing it in terms of plugin interoperability to make sure there are regressions and weird edge cases.

## How?
We augment the existing `gutenberg_post_being_edited_requires_classic_block()` checks to also handle if the `use_block_editor_for_post_type` filter was used to disable the block editor specifically for a post type. This is the same filter that the Classic Editor plugin is using.

## Testing Instructions
* Activate the "Disable TinyMCE" experiment if it's not active yet.
* Install and activate the "Classic Editor" plugin.
* Start writing a new post. 
* Verify the TinyMCE editor loads and works correctly and there are no errors in the console.
* Disable the "Classic Editor" plugin.
* Start writing a new post. 
* Verify you can see the block editor and there is still no "Classic" block available.

### Testing Instructions for Keyboard
None

## Screenshots or screencast <!-- if applicable -->
None
