### PR TITLE
Template Parts: Set attributes 'area' as useSelect dependency

### DIFF
--- a/packages/block-library/src/template-part/edit/index.js
+++ b/packages/block-library/src/template-part/edit/index.js
@@ -77,7 +77,7 @@ export default function TemplatePartEdit( {
 				area: _area,
 			};
 		},
-		[ templatePartId, clientId ]
+		[ templatePartId, attributes.area, clientId ]
 	);
 	const { templateParts } = useAlternativeTemplateParts(
 		area,


### PR DESCRIPTION
## What?
PR fixes ` React Hook useSelect has a missing dependency: 'attributes.area'.` ESLint warning in the Template Parts block.

## Why?
Missing dependencies can have unexpected side effects.

## Testing Instructions for Keyboard
Confirm template part loads as before.
