### PR TITLE
Top Toolbar: Move the preferences selection into the main useSelect

### DIFF
--- a/packages/edit-post/src/components/header/header-toolbar/index.js
+++ b/packages/edit-post/src/components/header/header-toolbar/index.js
@@ -37,8 +37,6 @@ function HeaderToolbar() {
 	const inserterButton = useRef();
 	const { setIsInserterOpened, setIsListViewOpened } =
 		useDispatch( editPostStore );
-	const { get: getPreference } = useSelect( preferencesStore );
-	const hasFixedToolbar = getPreference( 'core/edit-post', 'fixedToolbar' );
 	const {
 		isInserterEnabled,
 		isInserterOpened,
@@ -46,6 +44,7 @@ function HeaderToolbar() {
 		showIconLabels,
 		isListViewOpen,
 		listViewShortcut,
+		hasFixedToolbar,
 	} = useSelect( ( select ) => {
 		const { hasInserterItems, getBlockRootClientId, getBlockSelectionEnd } =
 			select( blockEditorStore );
@@ -53,6 +52,7 @@ function HeaderToolbar() {
 		const { getEditorMode, isFeatureActive, isListViewOpened } =
 			select( editPostStore );
 		const { getShortcutRepresentation } = select( keyboardShortcutsStore );
+		const { get: getPreference } = select( preferencesStore );
 
 		return {
 			// This setting (richEditingEnabled) should not live in the block editor's setting.
@@ -69,6 +69,7 @@ function HeaderToolbar() {
 			listViewShortcut: getShortcutRepresentation(
 				'core/edit-post/toggle-list-view'
 			),
+			hasFixedToolbar: getPreference( 'core/edit-post', 'fixedToolbar' ),
 		};
 	}, [] );
 

--- a/packages/edit-site/src/components/header-edit-mode/index.js
+++ b/packages/edit-site/src/components/header-edit-mode/index.js
@@ -97,15 +97,15 @@ export default function HeaderEditMode() {
 			isVisualMode: getEditorMode() === 'visual',
 			blockEditorMode: __unstableGetEditorMode(),
 			homeUrl: getUnstableBase()?.home,
-			showIconLabels: select( preferencesStore ).get(
-				'core/edit-site',
+			showIconLabels: getPreference(
+				editSiteStore.name,
 				'showIconLabels'
 			),
 			editorCanvasView: unlock(
 				select( editSiteStore )
 			).getEditorCanvasContainerView(),
-			isDistractionFree: select( preferencesStore ).get(
-				'core/edit-site',
+			isDistractionFree: getPreference(
+				editSiteStore.name,
 				'distractionFree'
 			),
 			hasFixedToolbar: getPreference(

--- a/packages/edit-site/src/components/header-edit-mode/index.js
+++ b/packages/edit-site/src/components/header-edit-mode/index.js
@@ -66,6 +66,7 @@ export default function HeaderEditMode() {
 		homeUrl,
 		showIconLabels,
 		editorCanvasView,
+		hasFixedToolbar,
 	} = useSelect( ( select ) => {
 		const {
 			__experimentalGetPreviewDeviceType,
@@ -82,6 +83,8 @@ export default function HeaderEditMode() {
 		const {
 			getUnstableBase, // Site index.
 		} = select( coreStore );
+
+		const { get: getPreference } = select( preferencesStore );
 
 		return {
 			deviceType: __experimentalGetPreviewDeviceType(),
@@ -105,11 +108,12 @@ export default function HeaderEditMode() {
 				'core/edit-site',
 				'distractionFree'
 			),
+			hasFixedToolbar: getPreference(
+				editSiteStore.name,
+				'fixedToolbar'
+			),
 		};
 	}, [] );
-
-	const { get: getPreference } = useSelect( preferencesStore );
-	const hasFixedToolbar = getPreference( editSiteStore.name, 'fixedToolbar' );
 
 	const {
 		__experimentalSetPreviewDeviceType: setPreviewDeviceType,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This moves the hasFixedToolbar select inside the main useSelect, as raised in https://github.com/WordPress/gutenberg/pull/52123#discussion_r1252980401.

## Why?
So that when the fixedToolbar preference value changes, the component will rerender.

## How?
Refactoring.

## Testing Instructions
Check that changing the top toolbar setting still changes the display of the block toolbars.