### PR TITLE
Block Editor: Add README for `RecursionProvider`

### DIFF
--- a/packages/block-editor/src/components/recursion-provider/README.md
+++ b/packages/block-editor/src/components/recursion-provider/README.md
@@ -1,0 +1,101 @@
+# RecursionProvider
+
+According to Gutenberg's block rendering architecture, any block type capable of recursion should be responsible for handling its own infinite loops. 
+
+To help with detecting infinite loops on the client, the `RecursionProvider` component and the `useHasRecursion()` hook are used to identify if a block has already been rendered. 
+
+## Usage
+
+```jsx
+/**
+ * WordPress dependencies
+ */
+import {
+	__experimentalRecursionProvider as RecursionProvider,
+	__experimentalUseHasRecursion as useHasRecursion,
+	useBlockProps,
+	Warning,
+} from '@wordpress/block-editor';
+import { __ } from '@wordpress/i18n';
+
+export default function MyRecursiveBlockEdit( { attributes: { ref } } ) {
+	const hasAlreadyRendered = useHasRecursion( ref );
+	const blockProps = useBlockProps( {
+		className: 'my-block__custom-class',
+	} );
+
+	if ( hasAlreadyRendered ) {
+		return (
+			<div { ...blockProps }>
+				<Warning>
+					{ __( 'Block cannot be rendered inside itself.' ) }
+				</Warning>
+			</div>
+		);
+	}
+
+	return (
+		<RecursionProvider uniqueId={ ref }>
+			Block editing code here....
+		</RecursionProvider>
+	);
+}
+
+/// ...
+
+<MyRecursiveBlockEdit />;
+```
+
+## Props
+
+The component accepts the following props:
+
+### uniqueId
+
+Any value that acts as a unique identifier for a block instance.
+
+- Type: `any`
+- Required: Yes
+
+### children
+
+Components to be rendered as content.
+
+- Type: `Element`
+- Required: Yes.
+
+### blockName
+
+Optional block name.
+
+- Type: `String`
+- Required: No
+- Default: ''
+
+# `useHasRecursion()`
+
+Used in conjunction with `RecursionProvider`, this hook us used to identify if a block has already been rendered.
+
+## Usage
+
+For example usage, refer to the example above.
+
+## Props
+
+The component accepts the following props:
+
+### uniqueId
+
+Any value that acts as a unique identifier for a block instance.
+
+- Type: `any`
+- Required: Yes
+
+### blockName
+
+Optional block name.
+
+- Type: `String`
+- Required: No
+- Default: ''
+

--- a/packages/block-editor/src/components/recursion-provider/README.md
+++ b/packages/block-editor/src/components/recursion-provider/README.md
@@ -74,7 +74,7 @@ Optional block name.
 
 # `useHasRecursion()`
 
-Used in conjunction with `RecursionProvider`, this hook us used to identify if a block has already been rendered.
+Used in conjunction with `RecursionProvider`, this hook is used to identify if a block has already been rendered.
 
 ## Usage
 


### PR DESCRIPTION
## What?
This PR adds a README for the `RecursionProvider` component and `useHasRecursion` hook.

Fixes #52065.

## Why?
Part of #22891 where we aim to document all block editor components.

## How?
Just adding a README.

Noting that this intentionally lacks a screenshot because the component's function isn't presentational.

## Testing Instructions
Not needed.

### Testing Instructions for Keyboard
None.

## Screenshots or screencast <!-- if applicable -->
None.