### PR TITLE
Fix entity cache misses for single posts due to string as recordKey

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/index.js
@@ -22,9 +22,10 @@ import buildNavigationLabel from '../sidebar-navigation-screen-navigation-menus/
 export const postType = `wp_navigation`;
 
 export default function SidebarNavigationScreenNavigationMenu() {
-	const {
-		params: { postId },
-	} = useNavigator();
+	const { params } = useNavigator();
+
+	// See https://github.com/WordPress/gutenberg/pull/52120.
+	const postId = Number( params?.postId );
 
 	const { record: navigationMenu, isResolving } = useEntityRecord(
 		'postType',

--- a/packages/edit-site/src/components/sidebar-navigation-screen-page/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-page/index.js
@@ -30,9 +30,9 @@ import SidebarNavigationScreenDetailsFooter from '../sidebar-navigation-screen-d
 export default function SidebarNavigationScreenPage() {
 	const navigator = useNavigator();
 	const { setCanvasMode } = unlock( useDispatch( editSiteStore ) );
-	const {
-		params: { postId },
-	} = useNavigator();
+	const { params } = useNavigator();
+
+	const postId = Number( params?.postId );
 	const { record } = useEntityRecord( 'postType', 'page', postId );
 
 	const { featuredMediaAltText, featuredMediaSourceUrl } = useSelect(

--- a/packages/edit-site/src/components/sidebar-navigation-screen-pattern/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-pattern/index.js
@@ -16,7 +16,7 @@ import useInitEditedEntityFromURL from '../sync-state-with-url/use-init-edited-e
 import usePatternDetails from './use-pattern-details';
 import { store as editSiteStore } from '../../store';
 import { unlock } from '../../lock-unlock';
-import normalizePostIdForPostType from '../../utils/normalize-post-id-for-post-type';
+import normalizeRecordKey from '../../utils/normalize-record-key';
 
 export default function SidebarNavigationScreenPattern() {
 	const { categoryType } = getQueryArgs( window.location.href );
@@ -24,7 +24,7 @@ export default function SidebarNavigationScreenPattern() {
 
 	const { params } = useNavigator();
 	const { postType } = params;
-	const postId = normalizePostIdForPostType( params?.postId, postType );
+	const postId = normalizeRecordKey( params?.postId );
 
 	useInitEditedEntityFromURL();
 

--- a/packages/edit-site/src/components/sidebar-navigation-screen-pattern/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-pattern/index.js
@@ -16,12 +16,15 @@ import useInitEditedEntityFromURL from '../sync-state-with-url/use-init-edited-e
 import usePatternDetails from './use-pattern-details';
 import { store as editSiteStore } from '../../store';
 import { unlock } from '../../lock-unlock';
+import normalizePostIdForPostType from '../../utils/normalize-post-id-for-post-type';
 
 export default function SidebarNavigationScreenPattern() {
-	const { params } = useNavigator();
 	const { categoryType } = getQueryArgs( window.location.href );
-	const { postType, postId } = params;
 	const { setCanvasMode } = unlock( useDispatch( editSiteStore ) );
+
+	const { params } = useNavigator();
+	const { postType } = params;
+	const postId = normalizePostIdForPostType( params?.postId, postType );
 
 	useInitEditedEntityFromURL();
 

--- a/packages/edit-site/src/components/sidebar-navigation-screen-pattern/use-pattern-details.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-pattern/use-pattern-details.js
@@ -19,16 +19,10 @@ import {
 	SidebarNavigationScreenDetailsPanelLabel,
 	SidebarNavigationScreenDetailsPanelValue,
 } from '../sidebar-navigation-screen-details-panel';
+import normalizePostIdForPostType from '../../utils/normalize-post-id-for-post-type';
 
 export default function usePatternDetails( postType, postId ) {
-	const postTypesThatUseStringBasedIds = [
-		'wp_template',
-		'wp_template_part',
-	];
-
-	postId = ! postTypesThatUseStringBasedIds?.includes( postType )
-		? Number( postId )
-		: postId;
+	postId = normalizePostIdForPostType( postId, postType );
 
 	const { getDescription, getTitle, record } = useEditedEntityRecord(
 		postType,

--- a/packages/edit-site/src/components/sidebar-navigation-screen-pattern/use-pattern-details.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-pattern/use-pattern-details.js
@@ -19,10 +19,10 @@ import {
 	SidebarNavigationScreenDetailsPanelLabel,
 	SidebarNavigationScreenDetailsPanelValue,
 } from '../sidebar-navigation-screen-details-panel';
-import normalizePostIdForPostType from '../../utils/normalize-post-id-for-post-type';
+import normalizeRecordKey from '../../utils/normalize-record-key';
 
 export default function usePatternDetails( postType, postId ) {
-	postId = normalizePostIdForPostType( postId, postType );
+	postId = normalizeRecordKey( postId );
 
 	const { getDescription, getTitle, record } = useEditedEntityRecord(
 		postType,

--- a/packages/edit-site/src/components/sidebar-navigation-screen-pattern/use-pattern-details.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-pattern/use-pattern-details.js
@@ -21,6 +21,15 @@ import {
 } from '../sidebar-navigation-screen-details-panel';
 
 export default function usePatternDetails( postType, postId ) {
+	const postTypesThatUseStringBasedIds = [
+		'wp_template',
+		'wp_template_part',
+	];
+
+	postId = ! postTypesThatUseStringBasedIds?.includes( postType )
+		? Number( postId )
+		: postId;
+
 	const { getDescription, getTitle, record } = useEditedEntityRecord(
 		postType,
 		postId

--- a/packages/edit-site/src/components/sync-state-with-url/use-init-edited-entity-from-url.js
+++ b/packages/edit-site/src/components/sync-state-with-url/use-init-edited-entity-from-url.js
@@ -15,7 +15,12 @@ import { unlock } from '../../lock-unlock';
 const { useLocation } = unlock( routerPrivateApis );
 
 export default function useInitEditedEntityFromURL() {
-	const { params: { postId, postType } = {} } = useLocation();
+	const { params } = useLocation();
+
+	const { postType } = params;
+
+	let postId = params?.postId;
+
 	const { isRequestingSite, homepageId, url } = useSelect( ( select ) => {
 		const { getSite, getUnstableBase } = select( coreDataStore );
 		const siteData = getSite();
@@ -39,6 +44,15 @@ export default function useInitEditedEntityFromURL() {
 		setNavigationMenu,
 	} = useDispatch( editSiteStore );
 
+	const postTypesThatUseStringBasedIds = [
+		'wp_template',
+		'wp_template_part',
+	];
+
+	postId = ! postTypesThatUseStringBasedIds?.includes( postType )
+		? Number( postId )
+		: postId;
+
 	useEffect( () => {
 		if ( postType && postId ) {
 			switch ( postType ) {
@@ -49,10 +63,10 @@ export default function useInitEditedEntityFromURL() {
 					setTemplatePart( postId );
 					break;
 				case 'wp_navigation':
-					setNavigationMenu( Number( postId ) );
+					setNavigationMenu( postId );
 					break;
 				case 'wp_block':
-					setEditedEntity( postType, Number( postId ) );
+					setEditedEntity( postType, postId );
 					break;
 				default:
 					setPage( {

--- a/packages/edit-site/src/components/sync-state-with-url/use-init-edited-entity-from-url.js
+++ b/packages/edit-site/src/components/sync-state-with-url/use-init-edited-entity-from-url.js
@@ -11,6 +11,7 @@ import { privateApis as routerPrivateApis } from '@wordpress/router';
  */
 import { store as editSiteStore } from '../../store';
 import { unlock } from '../../lock-unlock';
+import normalizePostIdForPostType from '../../utils/normalize-post-id-for-post-type';
 
 const { useLocation } = unlock( routerPrivateApis );
 
@@ -19,7 +20,7 @@ export default function useInitEditedEntityFromURL() {
 
 	const { postType } = params;
 
-	let postId = params?.postId;
+	const postId = normalizePostIdForPostType( params?.postId, postType );
 
 	const { isRequestingSite, homepageId, url } = useSelect( ( select ) => {
 		const { getSite, getUnstableBase } = select( coreDataStore );
@@ -43,15 +44,6 @@ export default function useInitEditedEntityFromURL() {
 		setPage,
 		setNavigationMenu,
 	} = useDispatch( editSiteStore );
-
-	const postTypesThatUseStringBasedIds = [
-		'wp_template',
-		'wp_template_part',
-	];
-
-	postId = ! postTypesThatUseStringBasedIds?.includes( postType )
-		? Number( postId )
-		: postId;
 
 	useEffect( () => {
 		if ( postType && postId ) {

--- a/packages/edit-site/src/components/sync-state-with-url/use-init-edited-entity-from-url.js
+++ b/packages/edit-site/src/components/sync-state-with-url/use-init-edited-entity-from-url.js
@@ -49,10 +49,10 @@ export default function useInitEditedEntityFromURL() {
 					setTemplatePart( postId );
 					break;
 				case 'wp_navigation':
-					setNavigationMenu( postId );
+					setNavigationMenu( Number( postId ) );
 					break;
 				case 'wp_block':
-					setEditedEntity( postType, postId );
+					setEditedEntity( postType, Number( postId ) );
 					break;
 				default:
 					setPage( {
@@ -66,7 +66,7 @@ export default function useInitEditedEntityFromURL() {
 		// In all other cases, we need to set the home page in the site editor view.
 		if ( homepageId ) {
 			setPage( {
-				context: { postType: 'page', postId: homepageId },
+				context: { postType: 'page', postId: Number( homepageId ) },
 			} );
 		} else if ( ! isRequestingSite ) {
 			setPage( {

--- a/packages/edit-site/src/components/sync-state-with-url/use-init-edited-entity-from-url.js
+++ b/packages/edit-site/src/components/sync-state-with-url/use-init-edited-entity-from-url.js
@@ -11,7 +11,7 @@ import { privateApis as routerPrivateApis } from '@wordpress/router';
  */
 import { store as editSiteStore } from '../../store';
 import { unlock } from '../../lock-unlock';
-import normalizePostIdForPostType from '../../utils/normalize-post-id-for-post-type';
+import normalizeRecordKey from '../../utils/normalize-record-key';
 
 const { useLocation } = unlock( routerPrivateApis );
 
@@ -20,7 +20,7 @@ export default function useInitEditedEntityFromURL() {
 
 	const { postType } = params;
 
-	const postId = normalizePostIdForPostType( params?.postId, postType );
+	const postId = normalizeRecordKey( params?.postId );
 
 	const { isRequestingSite, homepageId, url } = useSelect( ( select ) => {
 		const { getSite, getUnstableBase } = select( coreDataStore );

--- a/packages/edit-site/src/components/use-edited-entity-record/index.js
+++ b/packages/edit-site/src/components/use-edited-entity-record/index.js
@@ -21,7 +21,17 @@ export default function useEditedEntityRecord( postType, postId ) {
 			const { __experimentalGetTemplateInfo: getTemplateInfo } =
 				select( editorStore );
 			const usedPostType = postType ?? getEditedPostType();
-			const usedPostId = postId ?? getEditedPostId();
+			const postTypesThatUseStringBasedIds = [
+				'wp_template',
+				'wp_template_part',
+			];
+
+			let usedPostId = postId ?? getEditedPostId();
+
+			usedPostId = ! postTypesThatUseStringBasedIds?.includes( postType )
+				? Number( usedPostId )
+				: usedPostId;
+
 			const _record = getEditedEntityRecord(
 				'postType',
 				usedPostType,

--- a/packages/edit-site/src/components/use-edited-entity-record/index.js
+++ b/packages/edit-site/src/components/use-edited-entity-record/index.js
@@ -10,6 +10,7 @@ import { decodeEntities } from '@wordpress/html-entities';
  * Internal dependencies
  */
 import { store as editSiteStore } from '../../store';
+import normalizePostIdForPostType from '../../utils/normalize-post-id-for-post-type';
 
 export default function useEditedEntityRecord( postType, postId ) {
 	const { record, title, description, isLoaded, icon } = useSelect(
@@ -21,18 +22,10 @@ export default function useEditedEntityRecord( postType, postId ) {
 			const { __experimentalGetTemplateInfo: getTemplateInfo } =
 				select( editorStore );
 			const usedPostType = postType ?? getEditedPostType();
-			const postTypesThatUseStringBasedIds = [
-				'wp_template',
-				'wp_template_part',
-			];
 
 			let usedPostId = postId ?? getEditedPostId();
 
-			usedPostId = ! postTypesThatUseStringBasedIds?.includes(
-				usedPostType
-			)
-				? Number( usedPostId )
-				: usedPostId;
+			usedPostId = normalizePostIdForPostType( usedPostId, usedPostType );
 
 			const _record = getEditedEntityRecord(
 				'postType',

--- a/packages/edit-site/src/components/use-edited-entity-record/index.js
+++ b/packages/edit-site/src/components/use-edited-entity-record/index.js
@@ -10,7 +10,7 @@ import { decodeEntities } from '@wordpress/html-entities';
  * Internal dependencies
  */
 import { store as editSiteStore } from '../../store';
-import normalizePostIdForPostType from '../../utils/normalize-post-id-for-post-type';
+import normalizeRecordKey from '../../utils/normalize-record-key';
 
 export default function useEditedEntityRecord( postType, postId ) {
 	const { record, title, description, isLoaded, icon } = useSelect(
@@ -25,7 +25,7 @@ export default function useEditedEntityRecord( postType, postId ) {
 
 			let usedPostId = postId ?? getEditedPostId();
 
-			usedPostId = normalizePostIdForPostType( usedPostId, usedPostType );
+			usedPostId = normalizeRecordKey( usedPostId, usedPostType );
 
 			const _record = getEditedEntityRecord(
 				'postType',

--- a/packages/edit-site/src/components/use-edited-entity-record/index.js
+++ b/packages/edit-site/src/components/use-edited-entity-record/index.js
@@ -28,7 +28,9 @@ export default function useEditedEntityRecord( postType, postId ) {
 
 			let usedPostId = postId ?? getEditedPostId();
 
-			usedPostId = ! postTypesThatUseStringBasedIds?.includes( postType )
+			usedPostId = ! postTypesThatUseStringBasedIds?.includes(
+				usedPostType
+			)
 				? Number( usedPostId )
 				: usedPostId;
 

--- a/packages/edit-site/src/utils/normalize-post-id-for-post-type.js
+++ b/packages/edit-site/src/utils/normalize-post-id-for-post-type.js
@@ -1,9 +1,0 @@
-const POST_TYPES_THAT_USE_STRING_BASED_IDS = [
-	'wp_template',
-	'wp_template_part',
-];
-export default function normalizePostIdForPostType( postId, postType ) {
-	return ! POST_TYPES_THAT_USE_STRING_BASED_IDS?.includes( postType )
-		? Number( postId )
-		: postId;
-}

--- a/packages/edit-site/src/utils/normalize-post-id-for-post-type.js
+++ b/packages/edit-site/src/utils/normalize-post-id-for-post-type.js
@@ -1,0 +1,9 @@
+const POST_TYPES_THAT_USE_STRING_BASED_IDS = [
+	'wp_template',
+	'wp_template_part',
+];
+export default function normalizePostIdForPostType( postId, postType ) {
+	return ! POST_TYPES_THAT_USE_STRING_BASED_IDS?.includes( postType )
+		? Number( postId )
+		: postId;
+}

--- a/packages/edit-site/src/utils/normalize-record-key.js
+++ b/packages/edit-site/src/utils/normalize-record-key.js
@@ -1,0 +1,11 @@
+function isNumericID( str ) {
+	return /^\s*\d+\s*$/.test( str );
+}
+
+export default function normalizeRecordKey( postId ) {
+	if ( isNumericID( postId ) ) {
+		postId = Number( postId );
+	}
+
+	return postId;
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes instances where entity data for a single entity is re-requested from network even though it already exists in cache.

Related to https://github.com/WordPress/gutenberg/pull/52120.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Because if the data is already in state then we shouldn't fetch from network unless the query changes.

This fixes additional requests for:

- Pages
- Navigations
- Patterns (i.e. "Reusable Blocks" using the `wp_block` post type).

It also preserves existing functionality for entities which _do_ use strings for the `recordKey` which is `template_part` and `template`.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

When `recordKey` argument of `getEntityRecord` is intended to be a numeric post ID (e.g. `123`) ensure it as passed as a number and not a string.

Why? Because passing as a string will cause the resolve cache to "miss" (see fix in https://github.com/WordPress/gutenberg/pull/52120) and thus retrigger the network request for the entity.

The root fix for this is https://github.com/WordPress/gutenberg/pull/52120 but it helps to encourage use of the correct pattern in Core.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

- Open Site Editor
- Use Site View sidebar to browse to Patterns/Pages/Navigations listing screens.
- Check Core Data to ensure the given entities are loaded into state - `wp.data.select('core').getEntityRecords('postType', 'wp_navigation')` - alter query as needed per post type.
-  Now click to drill down to a single Pattern/Page/Navigation.
- See that no additional network request is sent.
- Need to be extremely careful to check that requests for single Templates and Template Parts are not broken. 

Note: that whilst https://github.com/WordPress/gutenberg/pull/52120 is not merged, you can try this on `trunk` to see that requests are dispatched without this PR.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
