### PR TITLE
Update pattern library copy

### DIFF
--- a/packages/edit-site/src/components/page-patterns/patterns-list.js
+++ b/packages/edit-site/src/components/page-patterns/patterns-list.js
@@ -81,7 +81,7 @@ export default function PatternsList( { categoryId, type } ) {
 						</Heading>
 						<Text variant="muted" as="p">
 							{ __(
-								'Patterns that are kept in sync across your site'
+								'Patterns that are kept in sync across the site'
 							) }
 						</Text>
 					</VStack>
@@ -101,7 +101,7 @@ export default function PatternsList( { categoryId, type } ) {
 						</Heading>
 						<Text variant="muted" as="p">
 							{ __(
-								'Patterns that can be changed freely without affecting your site'
+								'Patterns that can be changed freely without affecting the site'
 							) }
 						</Text>
 					</VStack>

--- a/packages/edit-site/src/components/sidebar-navigation-screen-pattern/use-pattern-details.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-pattern/use-pattern-details.js
@@ -38,7 +38,7 @@ export default function usePatternDetails( postType, postId ) {
 	if ( ! descriptionText && addedBy.text ) {
 		descriptionText = sprintf(
 			// translators: %s: pattern title e.g: "Header".
-			__( 'This is your %s pattern.' ),
+			__( 'This is the %s pattern.' ),
 			getTitle()
 		);
 	}
@@ -46,7 +46,7 @@ export default function usePatternDetails( postType, postId ) {
 	if ( ! descriptionText && postType === 'wp_block' && record?.title ) {
 		descriptionText = sprintf(
 			// translators: %s: user created pattern title e.g. "Footer".
-			__( 'This is your %s pattern.' ),
+			__( 'This is the %s pattern.' ),
 			record.title
 		);
 	}

--- a/packages/edit-site/src/components/sidebar-navigation-screen-patterns/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-patterns/index.js
@@ -73,7 +73,7 @@ export default function SidebarNavigationScreenPatterns() {
 			isRoot={ isTemplatePartsMode }
 			title={ __( 'Patterns' ) }
 			description={ __(
-				'Manage what patterns are available when editing your site.'
+				'Manage what patterns are available when editing the site.'
 			) }
 			actions={ <AddNewPattern /> }
 			footer={ footer }


### PR DESCRIPTION
Follow-up to https://github.com/WordPress/gutenberg/pull/52282

## What?
Updates some of the copy in the pattern library.

## Why?
Possessive determiners (e.g. "**Your** site") do not work so well in a multi-user / enterprise environment. 

## How?
Update text strings.

## Testing Instructions
* Open the pattern library in the site editor
* Observe updated strings:

| Before | After |
| --- | --- |
| Manage what patterns are available when editing **your** site | Manage what patterns are available when editing **the** site |
| Patterns that are kept in sync across **your** site | Patterns that are kept in sync across **the** site |
| Patterns that can be changed freely without affecting **your** site | Patterns that can be changed freely without affecting **the** site |
| This is **your** %s pattern | This is **the** %s pattern |