### PR TITLE
Fix font printing regression when metabox exists

### DIFF
--- a/lib/experimental/fonts-api/fonts-api.php
+++ b/lib/experimental/fonts-api/fonts-api.php
@@ -26,14 +26,7 @@ if ( ! function_exists( 'wp_fonts' ) ) {
 			// Initialize.
 			$wp_fonts->register_provider( 'local', 'WP_Fonts_Provider_Local' );
 			add_action( 'wp_head', 'wp_print_fonts', 50 );
-
-			/*
-			 * For themes without a theme.json, admin printing is initiated by the 'admin_print_styles' hook.
-			 * For themes with theme.json, admin printing is initiated by _wp_get_iframed_editor_assets().
-			 */
-			if ( ! wp_theme_has_theme_json() ) {
-				add_action( 'admin_print_styles', 'wp_print_fonts', 50 );
-			}
+			add_action( 'admin_print_styles', 'wp_print_fonts', 50 );
 		}
 
 		return $wp_fonts;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

Fixes https://github.com/WordPress/gutenberg/issues/51209

## What?

Fixes the font printing regression in the post editor when a metabox exists. 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The change that introduced the regression in Gutenberg:
- PR #50259
- Commit https://github.com/WordPress/gutenberg/commit/af8d651a484fc2ff5d82fdb620177054db91f71b.

>This was done for performance to avoid printing the `@font-face` styles more than once, i.e. in the main doc and in the iframe. But consideration was not given to when metabox is present, causing the editor no longer be in an iframe.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Removes the `if` not a block theme guard around the `'admin_print_styles'` ` hook. This means, `@font-face` styles will be printed in each admin's main doc `<head>` and in each iframed editor.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Install and activate the Yoast SEO plugin, which will add a metabox to each post.
2. Change the Heading blocks to use IBM Plex Mono:
    a. Go to the Site Editor > Styles > Typography > Headings.
    b. In "Font", select "IBM Plex Mono".
    c. In "Appearance", select "Bold Italic.
    d. Click/select the "Save" button twice.

![Site Editor > Styles > Typography > Headings UI](https://github.com/WordPress/gutenberg/assets/7284611/96020d27-19b0-453e-8a34-752426a86077)
    
3. Create a new post and add the following the content:
    a. Title: "Mindblowing: a blog about philosophy."
    b. Paragraph block: whatever content you want.
4. In your favorite editor:
    a. Open its dev tools to the Network tab.
    b. Select "Fonts".
    c. Disable the cache, if available.
    d. Refresh the page.

Expectations:
* The `IBMMono-Italic.woff2` file should be present in the Network tab.
![headings look correct and font files are requested by the browser](https://github.com/WordPress/gutenberg/assets/7284611/931f8583-e31d-47d7-8b3f-8529ef7a8c18)
* The heading block should visually look like the [IBM Plex Mono font from the Google Fonts UI page](https://fonts.google.com/specimen/IBM+Plex+Mono?preview.text=Mindblowing:%20a%20blog%20about%20philosophy.&preview.text_type=custom&query=ibm)

![IBM Plex Mono font looks like this on the Google Fonts UI page](https://github.com/WordPress/gutenberg/assets/7284611/dd75fbce-e489-4ed6-8dc1-ecbbd39feb17)