### PR TITLE
Patterns: Add handling of sync status to the wp-admin patterns list page

### DIFF
--- a/packages/list-reusable-blocks/src/components/import-form/index.js
+++ b/packages/list-reusable-blocks/src/components/import-form/index.js
@@ -49,8 +49,8 @@ function ImportForm( { instanceId, onUpload } ) {
 					case 'Invalid JSON file':
 						uiMessage = __( 'Invalid JSON file' );
 						break;
-					case 'Invalid Reusable block JSON file':
-						uiMessage = __( 'Invalid Reusable block JSON file' );
+					case 'Invalid Pattern JSON file':
+						uiMessage = __( 'Invalid Pattern JSON file' );
 						break;
 					default:
 						uiMessage = __( 'Unknown error' );

--- a/packages/list-reusable-blocks/src/index.js
+++ b/packages/list-reusable-blocks/src/index.js
@@ -31,9 +31,7 @@ document.addEventListener( 'DOMContentLoaded', () => {
 	const showNotice = () => {
 		const notice = document.createElement( 'div' );
 		notice.className = 'notice notice-success is-dismissible';
-		notice.innerHTML = `<p>${ __(
-			'Reusable block imported successfully!'
-		) }</p>`;
+		notice.innerHTML = `<p>${ __( 'Pattern imported successfully!' ) }</p>`;
 
 		const headerEnd = document.querySelector( '.wp-header-end' );
 		if ( ! headerEnd ) {

--- a/packages/list-reusable-blocks/src/utils/export.js
+++ b/packages/list-reusable-blocks/src/utils/export.js
@@ -25,11 +25,13 @@ async function exportReusableBlock( id ) {
 	} );
 	const title = post.title.raw;
 	const content = post.content.raw;
+	const syncStatus = post.wp_pattern_sync_status;
 	const fileContent = JSON.stringify(
 		{
 			__file: 'wp_block',
 			title,
 			content,
+			syncStatus,
 		},
 		null,
 		2

--- a/packages/list-reusable-blocks/src/utils/import.js
+++ b/packages/list-reusable-blocks/src/utils/import.js
@@ -27,7 +27,9 @@ async function importReusableBlock( file ) {
 		! parsedContent.title ||
 		! parsedContent.content ||
 		typeof parsedContent.title !== 'string' ||
-		typeof parsedContent.content !== 'string'
+		typeof parsedContent.content !== 'string' ||
+		( parsedContent.syncStatus &&
+			typeof parsedContent.syncStatus !== 'string' )
 	) {
 		throw new Error( 'Invalid Reusable block JSON file' );
 	}
@@ -38,6 +40,10 @@ async function importReusableBlock( file ) {
 			title: parsedContent.title,
 			content: parsedContent.content,
 			status: 'publish',
+			meta:
+				parsedContent.syncStatus === 'unsynced'
+					? { wp_pattern_sync_status: parsedContent.syncStatus }
+					: undefined,
 		},
 		method: 'POST',
 	} );

--- a/packages/list-reusable-blocks/src/utils/import.js
+++ b/packages/list-reusable-blocks/src/utils/import.js
@@ -31,7 +31,7 @@ async function importReusableBlock( file ) {
 		( parsedContent.syncStatus &&
 			typeof parsedContent.syncStatus !== 'string' )
 	) {
-		throw new Error( 'Invalid Reusable block JSON file' );
+		throw new Error( 'Invalid Pattern JSON file' );
 	}
 	const postType = await apiFetch( { path: `/wp/v2/types/wp_block` } );
 	const reusableBlock = await apiFetch( {

--- a/test/e2e/specs/editor/various/manage-reusable-blocks.spec.js
+++ b/test/e2e/specs/editor/various/manage-reusable-blocks.spec.js
@@ -35,7 +35,7 @@ test.describe( 'Managing reusable blocks', () => {
 
 		// Wait for the success notice.
 		await expect(
-			page.locator( 'text=Reusable block imported successfully!' )
+			page.locator( 'text=Pattern imported successfully!' )
 		).toBeVisible();
 
 		// Refresh the page.


### PR DESCRIPTION
## What?
Adds handling of sync status to wp-admin patterns list page

## Why?
Currently patterns imported and exported via the patterns list page all end up with sync status of fully synced.
Fixes: #52331
Fixes: #52333

## How?
Adds `syncStatus` to the exported json and handles this on import.

## Testing Instructions

- Add some synced and unsynced patterns
- Go to `/wp-admin/edit.php?post_type=wp_block` and export both synced and unsynced patterns
- Import synced and unsynced patterns and make sure import success message is correct and that the sync status has been correctly set

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/3629020/d87c7441-717f-4918-9c21-04d645b294c1


