### PR TITLE
Patterns: add option to set sync status when adding from wp-admin patterns list

### DIFF
--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -13,6 +13,7 @@ import {
 	EditorNotices,
 	EditorKeyboardShortcutsRegister,
 	EditorSnackbars,
+	PostSyncStatusModal,
 	store as editorStore,
 } from '@wordpress/editor';
 import { useSelect, useDispatch } from '@wordpress/data';
@@ -291,6 +292,7 @@ function Layout( { styles } ) {
 			<EditPostPreferencesModal />
 			<KeyboardShortcutHelpModal />
 			<WelcomeGuide />
+			<PostSyncStatusModal />
 			<StartPageOptions />
 			<Popover.Slot />
 			<PluginArea onError={ onPluginAreaError } />

--- a/packages/editor/src/components/index.js
+++ b/packages/editor/src/components/index.js
@@ -51,7 +51,10 @@ export { default as PostSlugCheck } from './post-slug/check';
 export { default as PostSticky } from './post-sticky';
 export { default as PostStickyCheck } from './post-sticky/check';
 export { default as PostSwitchToDraftButton } from './post-switch-to-draft-button';
-export { default as PostSyncStatus } from './post-sync-status';
+export {
+	default as PostSyncStatus,
+	PostSyncStatusModal,
+} from './post-sync-status';
 export { default as PostTaxonomies } from './post-taxonomies';
 export { FlatTermSelector as PostTaxonomiesFlatTermSelector } from './post-taxonomies/flat-term-selector';
 export { HierarchicalTermSelector as PostTaxonomiesHierarchicalTermSelector } from './post-taxonomies/hierarchical-term-selector';

--- a/packages/editor/src/components/post-sync-status/index.js
+++ b/packages/editor/src/components/post-sync-status/index.js
@@ -1,9 +1,19 @@
 /**
  * WordPress dependencies
  */
-import { useSelect } from '@wordpress/data';
+import { useSelect, useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
-import { PanelRow } from '@wordpress/components';
+import {
+	PanelRow,
+	Modal,
+	Button,
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+	ToggleControl,
+} from '@wordpress/components';
+import { useEffect, useState } from '@wordpress/element';
+import { ReusableBlocksRenameHint } from '@wordpress/block-editor';
+import { getQueryArgs } from '@wordpress/url';
 
 /**
  * Internal dependencies
@@ -11,24 +21,90 @@ import { PanelRow } from '@wordpress/components';
 import { store as editorStore } from '../../store';
 
 export default function PostSyncStatus() {
-	const { syncStatus, postType } = useSelect( ( select ) => {
-		const { getEditedPostAttribute } = select( editorStore );
+	const { editPost } = useDispatch( editorStore );
+	const [ isModalOpen, setIsModalOpen ] = useState( false );
+	const [ syncType, setSyncType ] = useState( 'fully' );
+
+	const { syncStatus, postType, isNewPost } = useSelect( ( select ) => {
+		const { getEditedPostAttribute, isCleanNewPost } =
+			select( editorStore );
 		return {
 			syncStatus: getEditedPostAttribute( 'wp_pattern_sync_status' ),
 			postType: getEditedPostAttribute( 'type' ),
+			isNewPost: isCleanNewPost(),
 		};
 	}, [] );
+
+	useEffect( () => {
+		if ( isNewPost ) {
+			setIsModalOpen( true );
+		}
+		// We only want the modal to open when the page is first loaded.
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [] );
+
+	const setSyncStatus = () => {
+		editPost( {
+			meta: {
+				wp_pattern_sync_status:
+					syncType === 'unsynced' ? 'unsynced' : null,
+			},
+		} );
+	};
+
 	if ( postType !== 'wp_block' ) {
 		return null;
 	}
-
-	const isFullySynced = ! syncStatus;
+	const { action } = getQueryArgs( window.location.href );
+	const currentSyncStatus = action === 'edit' ? syncStatus : syncType;
 
 	return (
 		<PanelRow className="edit-post-sync-status">
+			{ isModalOpen && (
+				<Modal
+					title={ __( 'Set pattern sync status' ) }
+					onRequestClose={ () => {
+						setIsModalOpen( false );
+					} }
+					overlayClassName="reusable-blocks-menu-items__convert-modal"
+				>
+					<form
+						onSubmit={ ( event ) => {
+							event.preventDefault();
+							setIsModalOpen( false );
+							setSyncStatus();
+						} }
+					>
+						<VStack spacing="5">
+							<ReusableBlocksRenameHint />
+							<ToggleControl
+								label={ __( 'Synced' ) }
+								help={ __(
+									'Editing the pattern will update it anywhere it is used.'
+								) }
+								checked={ syncType === 'fully' }
+								onChange={ () => {
+									setSyncType(
+										syncType === 'fully'
+											? 'unsynced'
+											: 'fully'
+									);
+								} }
+							/>
+							<HStack justify="right">
+								<Button variant="primary" type="submit">
+									{ __( 'Create' ) }
+								</Button>
+							</HStack>
+						</VStack>
+					</form>
+				</Modal>
+			) }
 			<span>{ __( 'Sync status' ) }</span>
 			<div>
-				{ isFullySynced ? __( 'Fully synced' ) : __( 'Not synced' ) }
+				{ currentSyncStatus === 'unsynced'
+					? __( 'Not synced' )
+					: __( 'Fully synced' ) }
 			</div>
 		</PanelRow>
 	);

--- a/packages/editor/src/components/post-sync-status/index.js
+++ b/packages/editor/src/components/post-sync-status/index.js
@@ -34,7 +34,7 @@ export default function PostSyncStatus() {
 	}
 	// When the post is first created, the top level wp_pattern_sync_status is not set so get meta value instead.
 	const currentSyncStatus =
-		meta.wp_pattern_sync_status === 'unsynced' ? 'unsynced' : syncStatus;
+		meta?.wp_pattern_sync_status === 'unsynced' ? 'unsynced' : syncStatus;
 
 	return (
 		<PanelRow className="edit-post-sync-status">

--- a/packages/editor/src/components/post-sync-status/index.js
+++ b/packages/editor/src/components/post-sync-status/index.js
@@ -51,7 +51,7 @@ export default function PostSyncStatus() {
 export function PostSyncStatusModal() {
 	const { editPost } = useDispatch( editorStore );
 	const [ isModalOpen, setIsModalOpen ] = useState( false );
-	const [ syncType, setSyncType ] = useState( 'fully' );
+	const [ syncType, setSyncType ] = useState( undefined );
 
 	const { postType, isNewPost } = useSelect( ( select ) => {
 		const { getEditedPostAttribute, isCleanNewPost } =
@@ -73,8 +73,7 @@ export function PostSyncStatusModal() {
 	const setSyncStatus = () => {
 		editPost( {
 			meta: {
-				wp_pattern_sync_status:
-					syncType === 'unsynced' ? 'unsynced' : undefined,
+				wp_pattern_sync_status: syncType,
 			},
 		} );
 	};
@@ -107,12 +106,10 @@ export function PostSyncStatusModal() {
 								help={ __(
 									'Editing the pattern will update it anywhere it is used.'
 								) }
-								checked={ syncType === 'fully' }
+								checked={ ! syncType }
 								onChange={ () => {
 									setSyncType(
-										syncType === 'fully'
-											? 'unsynced'
-											: 'fully'
+										! syncType ? 'unsynced' : undefined
 									);
 								} }
 							/>

--- a/packages/editor/src/components/post-sync-status/index.js
+++ b/packages/editor/src/components/post-sync-status/index.js
@@ -79,7 +79,7 @@ export function PostSyncStatusModal() {
 		} );
 	};
 
-	if ( postType !== 'wp_block' ) {
+	if ( postType !== 'wp_block' || ! isNewPost ) {
 		return null;
 	}
 


### PR DESCRIPTION
## What?
Adds option to set sync status when adding from wp-admin patterns list.

## Why?
Currently adding patterns from this page will always create synced patterns.
Fixes: #52329

## How?
Shows a modal to set sync status for new patterns.

## Testing Instructions

- Go to `/wp-admin/edit.php?post_type=wp_block` and click `Add new` button
- Create sync pattern and save and test that it works as a sync pattern when inserted from post editor inserter
- Create unsynced pattern and save and test that it works as a unsynced pattern when inserted from post editor inserter
- The modal should no display when creating new patterns from the site editor Patterns section, so go to the site editor and create new synced and unsynced patters using the '+' option at top of left navigation in Patterns section and make sure no second modal appears when editor loads


## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/3629020/7c09b919-4539-4d06-a89d-8cef2037866b



