### PR TITLE
Patterns: Update Uncategorized label to General

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen-patterns/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-patterns/index.js
@@ -33,7 +33,7 @@ const templatePartAreaLabels = {
 	header: __( 'Headers' ),
 	footer: __( 'Footers' ),
 	sidebar: __( 'Sidebar' ),
-	uncategorized: __( 'Uncategorized' ),
+	uncategorized: __( 'General' ),
 };
 
 export default function SidebarNavigationScreenPatterns() {


### PR DESCRIPTION
Related:
- https://github.com/WordPress/gutenberg/pull/52355

## What?

Renames the "Uncategorized" template part category in the Patterns sidebar nav screen to "General"

**Note: There is an alternative approach on offer which will display all custom template part areas in the sidebar rather than group them under General (https://github.com/WordPress/gutenberg/pull/52355)**

## Why?

This brings the category name more in line with the default `uncategorized` template part area which is labelled "General" in the create template part modal

## How?

Renames the label.

## Testing Instructions

1. Navigate to Site Editor > Patterns
2. Confirm the General category is below Header and Footer

## Screenshots or screencast <!-- if applicable -->
<img width="355" alt="Screenshot 2023-07-06 at 1 11 36 pm" src="https://github.com/WordPress/gutenberg/assets/60436221/42721218-de8d-40d6-a24e-82cf64907b18">

