### PR TITLE
Patterns: Display all custom template part areas in sidebar nav

### DIFF
--- a/packages/edit-site/src/components/page-patterns/use-patterns.js
+++ b/packages/edit-site/src/components/page-patterns/use-patterns.js
@@ -38,14 +38,8 @@ const templatePartToPattern = ( templatePart ) => ( {
 	templatePart,
 } );
 
-const templatePartCategories = [ 'header', 'footer', 'sidebar' ];
-const templatePartHasCategory = ( item, category ) => {
-	if ( category === 'uncategorized' ) {
-		return ! templatePartCategories.includes( item.templatePart.area );
-	}
-
-	return item.templatePart.area === category;
-};
+const templatePartHasCategory = ( item, category ) =>
+	item.templatePart.area === category;
 
 const useTemplatePartsAsPatterns = (
 	categoryId,

--- a/packages/edit-site/src/components/sidebar-navigation-screen-patterns/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-patterns/index.js
@@ -30,6 +30,80 @@ import usePatternCategories from './use-pattern-categories';
 import useMyPatterns from './use-my-patterns';
 import useTemplatePartAreas from './use-template-part-areas';
 
+function TemplatePartGroup( { areas, currentArea, currentType } ) {
+	return (
+		<>
+			<div className="edit-site-sidebar-navigation-screen-patterns__group-header">
+				<Heading level={ 2 }>{ __( 'Template parts' ) }</Heading>
+				<p>{ __( 'Synced patterns for use in template building.' ) }</p>
+			</div>
+			<ItemGroup className="edit-site-sidebar-navigation-screen-patterns__group">
+				{ Object.entries( areas ).map(
+					( [ area, { label, templateParts } ] ) => (
+						<CategoryItem
+							key={ area }
+							count={ templateParts?.length }
+							icon={ getTemplatePartIcon( area ) }
+							label={ label }
+							id={ area }
+							type="wp_template_part"
+							isActive={
+								currentArea === area &&
+								currentType === 'wp_template_part'
+							}
+						/>
+					)
+				) }
+			</ItemGroup>
+		</>
+	);
+}
+
+function ThemePatternsGroup( { categories, currentCategory, currentType } ) {
+	return (
+		<>
+			<div className="edit-site-sidebar-navigation-screen-patterns__group-header">
+				<Heading level={ 2 }>{ __( 'Theme patterns' ) }</Heading>
+				<p>
+					{ __(
+						'For insertion into documents where they can then be customized.'
+					) }
+				</p>
+			</div>
+			<ItemGroup className="edit-site-sidebar-navigation-screen-patterns__group">
+				{ categories.map( ( category ) => (
+					<CategoryItem
+						key={ category.name }
+						count={ category.count }
+						label={
+							<Flex justify="left" align="center" gap={ 0 }>
+								{ category.label }
+								<Tooltip
+									position="top center"
+									text={ __(
+										'Theme patterns cannot be edited.'
+									) }
+								>
+									<span className="edit-site-sidebar-navigation-screen-pattern__lock-icon">
+										<Icon icon={ lockSmall } size={ 24 } />
+									</span>
+								</Tooltip>
+							</Flex>
+						}
+						icon={ file }
+						id={ category.name }
+						type="pattern"
+						isActive={
+							currentCategory === `${ category.name }` &&
+							currentType === 'pattern'
+						}
+					/>
+				) ) }
+			</ItemGroup>
+		</>
+	);
+}
+
 export default function SidebarNavigationScreenPatterns() {
 	const isMobileViewport = useViewportMatch( 'medium', '<' );
 	const { categoryType, categoryId } = getQueryArgs( window.location.href );
@@ -103,101 +177,18 @@ export default function SidebarNavigationScreenPatterns() {
 								</ItemGroup>
 							) }
 							{ hasTemplateParts && (
-								<>
-									<div className="edit-site-sidebar-navigation-screen-patterns__group-header">
-										<Heading level={ 2 }>
-											{ __( 'Template parts' ) }
-										</Heading>
-										<p>
-											{ __(
-												'Synced patterns for use in template building.'
-											) }
-										</p>
-									</div>
-									<ItemGroup className="edit-site-sidebar-navigation-screen-patterns__group">
-										{ Object.entries(
-											templatePartAreas
-										).map( ( [ area, { label, templateParts } ] ) => (
-											<CategoryItem
-												key={ area }
-												count={ templateParts?.length }
-												icon={ getTemplatePartIcon(
-													area
-												) }
-												label={ label }
-												id={ area }
-												type="wp_template_part"
-												isActive={
-													currentCategory === area &&
-													currentType ===
-														'wp_template_part'
-												}
-											/>
-										) ) }
-									</ItemGroup>
-								</>
+								<TemplatePartGroup
+									areas={ templatePartAreas }
+									currentArea={ currentCategory }
+									currentType={ currentType }
+								/>
 							) }
 							{ hasPatterns && (
-								<>
-									<div className="edit-site-sidebar-navigation-screen-patterns__group-header">
-										<Heading level={ 2 }>
-											{ __( 'Theme patterns' ) }
-										</Heading>
-										<p>
-											{ __(
-												'For insertion into documents where they can then be customized.'
-											) }
-										</p>
-									</div>
-									<ItemGroup className="edit-site-sidebar-navigation-screen-patterns__group">
-										{ patternCategories.map(
-											( category ) => (
-												<CategoryItem
-													key={ category.name }
-													count={ category.count }
-													label={
-														<Flex
-															justify="left"
-															align="center"
-															gap={ 0 }
-														>
-															{ category.label }
-															<Tooltip
-																position="top center"
-																text={ __(
-																	'Theme patterns cannot be edited.'
-																) }
-															>
-																<span className="edit-site-sidebar-navigation-screen-pattern__lock-icon">
-																	<Icon
-																		style={ {
-																			fill: 'currentcolor',
-																		} }
-																		icon={
-																			lockSmall
-																		}
-																		size={
-																			24
-																		}
-																	/>
-																</span>
-															</Tooltip>
-														</Flex>
-													}
-													icon={ file }
-													id={ category.name }
-													type="pattern"
-													isActive={
-														currentCategory ===
-															`${ category.name }` &&
-														currentType ===
-															'pattern'
-													}
-												/>
-											)
-										) }
-									</ItemGroup>
-								</>
+								<ThemePatternsGroup
+									categories={ patternCategories }
+									currentCategory={ currentCategory }
+									currentType={ currentType }
+								/>
 							) }
 						</>
 					) }

--- a/packages/edit-site/src/components/sidebar-navigation-screen-patterns/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-patterns/index.js
@@ -30,13 +30,6 @@ import usePatternCategories from './use-pattern-categories';
 import useMyPatterns from './use-my-patterns';
 import useTemplatePartAreas from './use-template-part-areas';
 
-const templatePartAreaLabels = {
-	header: __( 'Headers' ),
-	footer: __( 'Footers' ),
-	sidebar: __( 'Sidebar' ),
-	uncategorized: __( 'Uncategorized' ),
-};
-
 export default function SidebarNavigationScreenPatterns() {
 	const isMobileViewport = useViewportMatch( 'medium', '<' );
 	const { categoryType, categoryId } = getQueryArgs( window.location.href );
@@ -124,18 +117,14 @@ export default function SidebarNavigationScreenPatterns() {
 									<ItemGroup className="edit-site-sidebar-navigation-screen-patterns__group">
 										{ Object.entries(
 											templatePartAreas
-										).map( ( [ area, parts ] ) => (
+										).map( ( [ area, { label, templateParts } ] ) => (
 											<CategoryItem
 												key={ area }
-												count={ parts.length }
+												count={ templateParts?.length }
 												icon={ getTemplatePartIcon(
 													area
 												) }
-												label={
-													templatePartAreaLabels[
-														area
-													]
-												}
+												label={ label }
 												id={ area }
 												type="wp_template_part"
 												isActive={

--- a/packages/edit-site/src/components/sidebar-navigation-screen-patterns/use-template-part-areas.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-patterns/use-template-part-areas.js
@@ -2,18 +2,40 @@
  * WordPress dependencies
  */
 import { useEntityRecords } from '@wordpress/core-data';
+import { useSelect } from '@wordpress/data';
+import { store as editorStore } from '@wordpress/editor';
 
-const getTemplatePartAreas = ( items ) => {
+const useTemplatePartsGroupedByArea = ( items ) => {
 	const allItems = items || [];
 
-	const groupedByArea = allItems.reduce(
-		( accumulator, item ) => {
-			const key = accumulator[ item.area ] ? item.area : 'uncategorized';
-			accumulator[ key ].push( item );
-			return accumulator;
-		},
-		{ header: [], footer: [], sidebar: [], uncategorized: [] }
+	const templatePartAreas = useSelect(
+		( select ) =>
+			select( editorStore ).__experimentalGetDefaultTemplatePartAreas(),
+		[]
 	);
+
+	// Create map of template areas ensuring that default areas are displayed before
+	// any custom registered template part areas.
+	const knownAreas = {
+		header: {},
+		footer: {},
+		sidebar: {},
+		uncategorized: {},
+	};
+
+	templatePartAreas.forEach(
+		( templatePartArea ) =>
+			( knownAreas[ templatePartArea.area ] = {
+				...templatePartArea,
+				templateParts: [],
+			} )
+	);
+
+	const groupedByArea = allItems.reduce( ( accumulator, item ) => {
+		const key = accumulator[ item.area ] ? item.area : 'uncategorized';
+		accumulator[ key ].templateParts.push( item );
+		return accumulator;
+	}, knownAreas );
 
 	return groupedByArea;
 };
@@ -28,6 +50,6 @@ export default function useTemplatePartAreas() {
 	return {
 		hasTemplateParts: templateParts ? !! templateParts.length : false,
 		isLoading,
-		templatePartAreas: getTemplatePartAreas( templateParts ),
+		templatePartAreas: useTemplatePartsGroupedByArea( templateParts ),
 	};
 }


### PR DESCRIPTION
Related:
- https://github.com/WordPress/gutenberg/pull/52354

## What?

- Renames Uncategorized template part area in Patterns sidebar nav to General
- Displays all custom template part areas within the Patterns sidebar nav

**Note: We might opt for only a simple renaming of the existing Uncategorized category to General for 6.3 (https://github.com/WordPress/gutenberg/pull/52354) and explore this more fully in 6.4**

## Why?

This is a more accurate categorization of template parts and will then reflect the create template part modal 1:1.

## How?

- Updates the hook to retrieve the template part areas and their counts to handle custom registered areas
- Updates the hook used to display template parts in a category/area to match

## Testing Instructions

1. You'll need to register some custom template part areas, you can do this via the snippet below
2. Navigate to Site Editor > Patterns
3. Initially, you won't see the custom areas unless they have a template part already assigned to them. Create template parts for each of your custom areas
4. Confirm these custom areas now show in the sidebar navigation
5. Navigate to these custom areas and the General area to ensure the correct patterns are shown

```php
<?php

function my_default_wp_template_part_areas( $default_area_definitions ) {
	return array_merge(
		$default_area_definitions,
		array(
			array(
				'area'        => 'my-area',
				'label'       => 'My Area',
				'icon'        => 'layout',
				'description' => 'A custom template part area',
			),
			array(
				'area'        => 'custom-area',
				'label'       => 'Custom Area',
				'icon'        => 'layout',
				'description' => 'Another custom template part area',
			),
		)
	);
}
add_filter( 'default_wp_template_part_areas', 'my_default_wp_template_part_areas' );

```


## Screenshots or screencast <!-- if applicable -->
<img width="355" alt="Screenshot 2023-07-06 at 1 03 37 pm" src="https://github.com/WordPress/gutenberg/assets/60436221/7c4ff452-9852-4e25-bfc2-2cb92be1047d">
