### PR TITLE
Fix react-dropdown-menu version to avoid breaking change from one of …

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17427,7 +17427,7 @@
 				"@emotion/styled": "^11.6.0",
 				"@emotion/utils": "^1.0.0",
 				"@floating-ui/react-dom": "1.0.0",
-				"@radix-ui/react-dropdown-menu": "^2.0.4",
+				"@radix-ui/react-dropdown-menu": "2.0.4",
 				"@use-gesture/react": "^10.2.24",
 				"@wordpress/a11y": "file:packages/a11y",
 				"@wordpress/compose": "file:packages/compose",
@@ -46493,7 +46493,7 @@
 		"optionator": {
 			"version": "0.8.2",
 			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
-			"integrity": "sha512-oCOQ8AIC2ciLy/sE2ehafRBleBgDLvzGhBRRev87sP7ovnbvQfqpc3XFI0DhHey2OfVoNV91W+GPC6B3540/5Q==",
+			"integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
 			"dev": true,
 			"requires": {
 				"deep-is": "~0.1.3",

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -20,6 +20,7 @@
 -   `DropdownMenu`: fix icon style when dashicon is used ([#43574](https://github.com/WordPress/gutenberg/pull/43574)).
 -   `UnitControl`: Fix crash when certain units are used ([#52211](https://github.com/WordPress/gutenberg/pull/52211)).
 -   `Guide`: Place focus on the guide's container instead of its first tabbable ([#52300](https://github.com/WordPress/gutenberg/pull/52300)).
+- `Popover`: Pin `react-dropdown-menu` version to avoid breaking changes in dependency updates. ([52356](https://github.com/WordPress/gutenberg/pull/52356)).
 
 ## 25.2.0 (2023-06-23)
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fix
+
+- `Popover`: Pin `react-dropdown-menu` version to avoid breaking changes in dependency updates. ([52356](https://github.com/WordPress/gutenberg/pull/52356)).
+
 ## 25.3.0 (2023-07-05)
 
 ### Enhancements
@@ -20,7 +24,6 @@
 -   `DropdownMenu`: fix icon style when dashicon is used ([#43574](https://github.com/WordPress/gutenberg/pull/43574)).
 -   `UnitControl`: Fix crash when certain units are used ([#52211](https://github.com/WordPress/gutenberg/pull/52211)).
 -   `Guide`: Place focus on the guide's container instead of its first tabbable ([#52300](https://github.com/WordPress/gutenberg/pull/52300)).
-- `Popover`: Pin `react-dropdown-menu` version to avoid breaking changes in dependency updates. ([52356](https://github.com/WordPress/gutenberg/pull/52356)).
 
 ## 25.2.0 (2023-06-23)
 

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -39,7 +39,7 @@
 		"@emotion/styled": "^11.6.0",
 		"@emotion/utils": "^1.0.0",
 		"@floating-ui/react-dom": "1.0.0",
-		"@radix-ui/react-dropdown-menu": "^2.0.4",
+		"@radix-ui/react-dropdown-menu": "2.0.4",
 		"@use-gesture/react": "^10.2.24",
 		"@wordpress/a11y": "file:../a11y",
 		"@wordpress/compose": "file:../compose",


### PR DESCRIPTION
…its dependencies.

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

`@radix-ui/react-dropdown-menu` depends on `@radix-ui/react-menu`, which depends on `@radix-ui/react-popper`, which in turn depends on `@floating-ui/react-dom`. The `@radix-ui/react-popper` update from version 1.1.1 to 1.1.2 includes an update of @floating-ui/react-dom from version 0.7.2 to 2.0.0. This is apparently causing our popovers to positions themselves incorrectly:

<img width="1425" alt="Screenshot 2023-07-06 at 1 44 42 pm" src="https://github.com/WordPress/gutenberg/assets/8096000/452f50e2-9071-455c-a2b8-590631b3e45c">

In order to avoid the `/react-popper` update, we need to pin our version of `react-dropdown-menu` to 2.0.4. 

See #48402 for related change to fix the same issue in WP 6.2. As in that case, we are days away from Beta 4 so fixing the underlying issue isn't doable right now 😅 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

Nothing should change with popover behaviour (or anything else) in Gutenberg. Once this change is imported into core, popovers should position themselves correctly over there.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
