### PR TITLE
Post and Comment Template blocks: Change render_block_context priority to 1

### DIFF
--- a/packages/block-library/src/comment-template/index.php
+++ b/packages/block-library/src/comment-template/index.php
@@ -35,8 +35,11 @@ function block_core_comment_template_render_comments( $comments, $block ) {
 		 * We set commentId context through the `render_block_context` filter so
 		 * that dynamically inserted blocks (at `render_block` filter stage)
 		 * will also receive that context.
+		 *
+		 * Use an early priority to so that other 'render_block_context' filters
+		 * have access to the values.
 		 */
-		add_filter( 'render_block_context', $filter_block_context );
+		add_filter( 'render_block_context', $filter_block_context, 1 );
 
 		/*
 		 * We construct a new WP_Block instance from the parsed block so that
@@ -44,7 +47,7 @@ function block_core_comment_template_render_comments( $comments, $block ) {
 		 */
 		$block_content = ( new WP_Block( $block->parsed_block ) )->render( array( 'dynamic' => false ) );
 
-		remove_filter( 'render_block_context', $filter_block_context );
+		remove_filter( 'render_block_context', $filter_block_context, 1 );
 
 		$children = $comment->get_children();
 

--- a/packages/block-library/src/post-template/index.php
+++ b/packages/block-library/src/post-template/index.php
@@ -97,11 +97,13 @@ function render_block_core_post_template( $attributes, $content, $block ) {
 			$context['postId']   = $post_id;
 			return $context;
 		};
-		add_filter( 'render_block_context', $filter_block_context );
+
+		// Use an early priority to so that other 'render_block_context' filters have access to the values.
+		add_filter( 'render_block_context', $filter_block_context, 1 );
 		// Render the inner blocks of the Post Template block with `dynamic` set to `false` to prevent calling
 		// `render_callback` and ensure that no wrapper markup is included.
 		$block_content = ( new WP_Block( $block_instance ) )->render( array( 'dynamic' => false ) );
-		remove_filter( 'render_block_context', $filter_block_context );
+		remove_filter( 'render_block_context', $filter_block_context, 1 );
 
 		// Wrap the render inner blocks in a `li` element with the appropriate post classes.
 		$post_classes = implode( ' ', get_post_class( 'wp-block-post' ) );


### PR DESCRIPTION
## What?
Block context relevant for the Post Template and Comment Template blocks (i.e. post ID and type, and comment ID, respectively) is set via the `render_block_context` filter. This PR changes that filter's priority from the default 10 to 1 (i.e. as early as possible).

This PR is based on @dhl01's https://github.com/WordPress/wordpress-develop/pull/4780. 

## Why?
As explained in https://core.trac.wordpress.org/ticket/58699, block context for those blocks was previously directly passed as an argument to the `WP_Block` constructor. During the 6.3 cycle, we changed that to use the `render_block_context` filter instead (in https://github.com/WordPress/gutenberg/pull/50313 and https://github.com/WordPress/gutenberg/pull/50279, later amended by https://github.com/WordPress/gutenberg/pull/50883). Overall, the filter-based approach has some benefits that we'd rather keep; however, I missed at the time that any _other_ (3rd-party) `render_block_context` filter with priority of 10 or less would no longer receive that block context.

## How?
This PR remediates that problem by assigning the earliest possible priority to both filters.

## Testing Instructions
We have automated test coverage for this: https://github.com/WordPress/gutenberg/blob/e72a740e189be3d47024e803f3709cac06c4ff31/phpunit/blocks/render-comment-template-test.php#L80-L123

Other than that, make sure that the Post Template and Comment Template blocks still work as before on the frontend. (This should be fairly straight-forward to verify in a current Block Theme, e.g. TT3.)