### PR TITLE
Post Content link color should not be applied to placeholder component links

### DIFF
--- a/packages/block-library/src/embed/editor.scss
+++ b/packages/block-library/src/embed/editor.scss
@@ -19,10 +19,6 @@
 
 	.components-placeholder__learn-more {
 		margin-top: 1em;
-		.components-external-link,
-		a {
-			color: var(--wp-admin-theme-color);
-		}
 	}
 }
 

--- a/packages/block-library/src/embed/editor.scss
+++ b/packages/block-library/src/embed/editor.scss
@@ -19,6 +19,10 @@
 
 	.components-placeholder__learn-more {
 		margin-top: 1em;
+		.components-external-link,
+		a {
+			color: var(--wp-admin-theme-color);
+		}
 	}
 }
 

--- a/packages/components/src/placeholder/style.scss
+++ b/packages/components/src/placeholder/style.scss
@@ -161,6 +161,11 @@
 			padding: 0 $grid-unit-10 2px;
 		}
 	}
+	.components-placeholder__learn-more {
+		.components-external-link {
+			color: var(--wp-admin-theme-color);
+		}
+	}
 }
 
 


### PR DESCRIPTION
Fixes #52258

 Post Content link color

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->



## Why?
Links within the UI should remain styled by the UI. The expectation here is that links have the --wp-admin-theme-color applied to them.

## How?
https://github.com/WordPress/gutenberg/issues/52258

## Testing Instructions
1. Add an Embed block.
2. See the link color of the theme (TwentyTwentyThree in my screenshot) applied to the links within the component.



## Screenshots or screencast <!-- if applicable -->
<img width="696" alt="image" src="https://github.com/WordPress/gutenberg/assets/49809429/217f24f3-1368-4f02-80bf-5846e8660ff5">
