### PR TITLE
Post Title: The changes should be reflected when previewing a post

### DIFF
--- a/packages/block-library/src/post-title/index.php
+++ b/packages/block-library/src/post-title/index.php
@@ -19,8 +19,11 @@ function render_block_core_post_title( $attributes, $content, $block ) {
 		return '';
 	}
 
-	$post  = get_post( $block->context['postId'] );
-	$title = get_the_title( $post );
+	/**
+	 * The `$post` argument is intentionally omitted so that changes are reflected when previewing a post.
+	 * See: https://github.com/WordPress/gutenberg/pull/37622#issuecomment-1000932816.
+	 */
+	$title = get_the_title();
 
 	if ( ! $title ) {
 		return '';
@@ -33,7 +36,7 @@ function render_block_core_post_title( $attributes, $content, $block ) {
 
 	if ( isset( $attributes['isLink'] ) && $attributes['isLink'] ) {
 		$rel   = ! empty( $attributes['rel'] ) ? 'rel="' . esc_attr( $attributes['rel'] ) . '"' : '';
-		$title = sprintf( '<a href="%1$s" target="%2$s" %3$s>%4$s</a>', get_the_permalink( $post ), esc_attr( $attributes['linkTarget'] ), $rel, $title );
+		$title = sprintf( '<a href="%1$s" target="%2$s" %3$s>%4$s</a>', get_the_permalink( $block->context['postId'] ), esc_attr( $attributes['linkTarget'] ), $rel, $title );
 	}
 
 	$classes = array();


### PR DESCRIPTION
## What?
PR fixes a regression when the post-title changes weren't reflected when previewing a published post with a block theme.

It was accidentally introduced in #48001.

## Why?
https://github.com/WordPress/gutenberg/pull/37622#issuecomment-1000932816

## How?
By omitting the `$post` argument from the `get_the_title`. I've also included an inline comment to avoid similar regressions in the future.

## Testing Instructions
1. Using a block theme - TT3
2. Open a published post.
3. Change the title.
4. Preview the post.
5. Confirm title changes are reflected in the preview.
