### PR TITLE
Migrate site editor multi-entity save flow tests

### DIFF
--- a/packages/e2e-tests/specs/site-editor/multi-entity-saving.test.js
+++ b/packages/e2e-tests/specs/site-editor/multi-entity-saving.test.js
@@ -12,8 +12,6 @@ import {
 	activateTheme,
 	clickButton,
 	createReusableBlock,
-	visitSiteEditor,
-	enterEditMode,
 	deleteAllTemplates,
 	canvas,
 } from '@wordpress/e2e-test-utils';
@@ -237,106 +235,6 @@ describe( 'Multi-entity save flow', () => {
 			checkboxInputs = await page.$$( checkboxInputSelector );
 
 			expect( checkboxInputs ).toHaveLength( 1 );
-		} );
-	} );
-
-	describe( 'Site Editor', () => {
-		// Selectors - Site editor specific.
-		const saveSiteSelector = '.edit-site-save-button__button';
-		const activeSaveSiteSelector = `${ saveSiteSelector }[aria-disabled=false]`;
-		const disabledSaveSiteSelector = `${ saveSiteSelector }[aria-disabled=true]`;
-		const saveA11ySelector = '.edit-site-editor__toggle-save-panel-button';
-
-		const saveAllChanges = async () => {
-			// Clicking button should open panel with boxes checked.
-			await page.click( activeSaveSiteSelector );
-			await page.waitForSelector( savePanelSelector );
-			await assertAllBoxesChecked();
-
-			// Save a11y button should not be present with save panel open.
-			await assertExistence( saveA11ySelector, false );
-
-			// Saving should result in items being saved.
-			await page.click( entitiesSaveSelector );
-		};
-
-		it( 'Save flow should work as expected', async () => {
-			// Navigate to site editor.
-			await visitSiteEditor( {
-				postId: 'emptytheme//index',
-				postType: 'wp_template',
-			} );
-
-			await enterEditMode();
-
-			// Select the header template part via list view.
-			await page.click( '.edit-site-header-edit-mode__list-view-toggle' );
-			const headerTemplatePartListViewButton = await page.waitForXPath(
-				'//a[contains(@class, "block-editor-list-view-block-select-button")][contains(., "header")]'
-			);
-			headerTemplatePartListViewButton.click();
-			await page.click( 'button[aria-label="Close"]' );
-
-			// Insert something to dirty the editor.
-			await insertBlock( 'Paragraph' );
-
-			const enabledButton = await page.waitForSelector(
-				activeSaveSiteSelector
-			);
-
-			// Should be enabled after edits.
-			expect( enabledButton ).not.toBeNull();
-
-			// Save a11y button should be present.
-			await assertExistence( saveA11ySelector, true );
-
-			// Save all changes.
-			await saveAllChanges();
-
-			const disabledButton = await page.waitForSelector(
-				disabledSaveSiteSelector
-			);
-			expect( disabledButton ).not.toBeNull();
-		} );
-
-		it( 'Save flow should allow re-saving after changing the same block attribute', async () => {
-			// Navigate to site editor.
-			await visitSiteEditor( {
-				postId: 'emptytheme//index',
-				postType: 'wp_template',
-			} );
-
-			await enterEditMode();
-
-			// Insert a paragraph at the bottom.
-			await insertBlock( 'Paragraph' );
-
-			// Open the block settings.
-			await page.click( 'button[aria-label="Settings"]' );
-
-			// Wait for the font size picker controls.
-			await page.waitForSelector(
-				'.components-font-size-picker__controls'
-			);
-
-			// Change the font size.
-			await page.click(
-				'.components-font-size-picker__controls button[aria-label="Small"]'
-			);
-
-			// Save all changes.
-			await saveAllChanges();
-
-			// Change the font size.
-			await page.click(
-				'.components-font-size-picker__controls button[aria-label="Medium"]'
-			);
-
-			// Assert that the save button has been re-enabled.
-			const saveButton = await page.waitForSelector(
-				activeSaveSiteSelector
-			);
-			expect( saveButton ).not.toBeNull();
 		} );
 	} );
 } );

--- a/test/e2e/specs/site-editor/multi-entity-saving.spec.js
+++ b/test/e2e/specs/site-editor/multi-entity-saving.spec.js
@@ -5,11 +5,17 @@ const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 
 test.describe( 'Site Editor - Multi-entity save flow', () => {
 	test.beforeAll( async ( { requestUtils } ) => {
-		await requestUtils.activateTheme( 'emptytheme' );
+		await Promise.all( [
+			requestUtils.activateTheme( 'emptytheme' ),
+			requestUtils.deleteAllTemplates( 'wp_template' ),
+		] );
 	} );
 
 	test.afterAll( async ( { requestUtils } ) => {
-		await requestUtils.activateTheme( 'twentytwentyone' );
+		await Promise.all( [
+			requestUtils.activateTheme( 'twentytwentyone' ),
+			requestUtils.deleteAllTemplates( 'wp_template' ),
+		] );
 	} );
 
 	test.beforeEach( async ( { admin, editor } ) => {


### PR DESCRIPTION
## What?
Part of #38851.

PR migrates Site Editor parts of `specs/site-editor/multi-entity-saving.test.js` e2e test to Playwright.

## Why?
* The `specs/site-editor/multi-entity-saving.test.js` test has been failing a lot lately. The Puppeteer artifacts aren't helpful with debugging, and Playwright tests are more stable, in my experience.
* Since we keep `editor` and `site-editor` tests separately, I decided to split the test and migration efforts.

### Recent failures
* https://github.com/WordPress/gutenberg/actions/runs/5471018283/jobs/9961726948
* https://github.com/WordPress/gutenberg/actions/runs/5473425559/jobs/9966879957
* https://github.com/WordPress/gutenberg/actions/runs/5470592863/jobs/9960850336

## Testing Instructions
CI checks are green, and puppies are happy 🐶

```
npm run test:e2e:playwright -- test/e2e/specs/site-editor/multi-entity-saving.spec.js
```

## Puppeteer artifact
Based on this screenshot, a selected block is a paragraph but renders the Excerpt block controls. I am unsure how the tests ended in this block editor state.

![Save flow should allow re-saving after changing the same block attribute 2023-07-05T11-52-07](https://github.com/WordPress/gutenberg/assets/240569/992ef89f-59f4-407a-8520-d275044ef8ed)
