### PR TITLE
Fix renaming in Site View sidebar rename saves all edits for Template Parts and Navigation Menus

### DIFF
--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -790,9 +790,20 @@ export const __experimentalSaveSpecifiedEntityEdits =
 			}
 		}
 
-		// Provide recordKey to saveEntityRecord to avoid creating a new record
-		// and instead update the existing record.
-		editsToSave.id = recordId;
+		const configs = await dispatch( getOrLoadEntitiesConfig( kind ) );
+		const entityConfig = configs.find(
+			( config ) => config.kind === kind && config.name === name
+		);
+
+		const entityIdKey = entityConfig?.key || DEFAULT_ENTITY_KEY;
+
+		// If a record key is provided then update the existing record.
+		// This necessitates providing `recordKey` to saveEntityRecord as part of the
+		// `record` argument (here called `editsToSave`) to stop that action creating
+		// a new record and instead cause it to update the existing record.
+		if ( recordId ) {
+			editsToSave[ entityIdKey ] = recordId;
+		}
 
 		return await dispatch.saveEntityRecord(
 			kind,

--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -789,6 +789,11 @@ export const __experimentalSaveSpecifiedEntityEdits =
 				editsToSave[ edit ] = edits[ edit ];
 			}
 		}
+
+		// Provide recordKey to saveEntityRecord to avoid creating a new record
+		// and instead update the existing record.
+		editsToSave.id = recordId;
+
 		return await dispatch.saveEntityRecord(
 			kind,
 			name,

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/use-navigation-menu-handlers.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/use-navigation-menu-handlers.js
@@ -65,8 +65,10 @@ function useSaveNavigationMenu() {
 		};
 	}, [] );
 
-	const { editEntityRecord, saveEditedEntityRecord } =
-		useDispatch( coreStore );
+	const {
+		editEntityRecord,
+		__experimentalSaveSpecifiedEntityEdits: saveSpecifiedEntityEdits,
+	} = useDispatch( coreStore );
 
 	const { createSuccessNotice, createErrorNotice } =
 		useDispatch( noticesStore );
@@ -87,11 +89,19 @@ function useSaveNavigationMenu() {
 		// Apply the edits.
 		editEntityRecord( 'postType', postType, postId, edits );
 
+		const recordPropertiesToSave = Object.keys( edits );
+
 		// Attempt to persist.
 		try {
-			await saveEditedEntityRecord( 'postType', postType, postId, {
-				throwOnError: true,
-			} );
+			await saveSpecifiedEntityEdits(
+				'postType',
+				postType,
+				postId,
+				recordPropertiesToSave,
+				{
+					throwOnError: true,
+				}
+			);
 			createSuccessNotice( __( 'Renamed Navigation menu' ), {
 				type: 'snackbar',
 			} );

--- a/packages/edit-site/src/components/template-actions/rename-menu-item.js
+++ b/packages/edit-site/src/components/template-actions/rename-menu-item.js
@@ -19,8 +19,10 @@ export default function RenameMenuItem( { template, onClose } ) {
 	const [ title, setTitle ] = useState( () => template.title.rendered );
 	const [ isModalOpen, setIsModalOpen ] = useState( false );
 
-	const { editEntityRecord, saveEditedEntityRecord } =
-		useDispatch( coreStore );
+	const {
+		editEntityRecord,
+		__experimentalSaveSpecifiedEntityEdits: saveSpecifiedEntityEdits,
+	} = useDispatch( coreStore );
 	const { createSuccessNotice, createErrorNotice } =
 		useDispatch( noticesStore );
 
@@ -42,11 +44,14 @@ export default function RenameMenuItem( { template, onClose } ) {
 			onClose();
 
 			// Persist edited entity.
-			await saveEditedEntityRecord(
+			await saveSpecifiedEntityEdits(
 				'postType',
 				template.type,
 				template.id,
-				{ throwOnError: true }
+				[ 'title' ], // only save title to avoid persisting other edits.
+				{
+					throwOnError: true,
+				}
 			);
 
 			createSuccessNotice( __( 'Entity renamed.' ), {

--- a/packages/edit-site/src/components/template-actions/rename-menu-item.js
+++ b/packages/edit-site/src/components/template-actions/rename-menu-item.js
@@ -48,7 +48,7 @@ export default function RenameMenuItem( { template, onClose } ) {
 				'postType',
 				template.type,
 				template.id,
-				[ 'title' ], // only save title to avoid persisting other edits.
+				[ 'title' ], // Only save title to avoid persisting other edits.
 				{
 					throwOnError: true,
 				}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Only persists the title field of Template Parts and Navigation Menus being edited when they are renamed in the Site View sidebar.

Fixes https://github.com/WordPress/gutenberg/issues/52294

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Currently the entire record is saved being that if you make some edits to the entity and then rename, _all_ of your changes are saved despite you not confirming.

This PR changes this so that only the new title is changed and other edits are left for the user to confirm.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Only saves the `title` field of the entity. This necessitates using the `__experimentalSaveSpecifiedEntityEdits` action to allow us to pass a subset of fields to be saved.

Its also necessary to update the action to ensure the `recordKey` is _always_ passed. This is because `saveEntityRecord` will attempt to save a _new_ record rather than update the existing one unless the `recordKey` is passed as part of the 3rd `record` argument.

https://github.com/WordPress/gutenberg/blob/bc663f6418c2775b24b3e62a7c639f2d72eb1b51/packages/core-data/src/actions.js#L637-L641

This is because `saveEntityRecord` interrogates the passed `record` for an `id` property

https://github.com/WordPress/gutenberg/blob/bc663f6418c2775b24b3e62a7c639f2d72eb1b51/packages/core-data/src/actions.js#L481-L482

...and `__experimentalSaveSpecifiedEntityEdits` only passes a subset of the record:

https://github.com/WordPress/gutenberg/blob/bc663f6418c2775b24b3e62a7c639f2d72eb1b51/packages/core-data/src/actions.js#L786-L797

This PR updates `__experimentalSaveSpecifiedEntityEdits` to also pass the `recordKey`.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

- Create x2 Navigation Menus with some items in each. You should be easily able to identify the order of the menu items so name them `First` and `Second` ...etc.
- Click through to one of your Navigation Menus.
- Order the items in the menu so that `Second` is _before_ `First` but do _not_ save.
- Verify the "Save" button at the bottom of the sidebar is active.
- Now rename your Navigation Menu.
- You should still see the "Save" button at the bottom of the sidebar is active indicating the menu _item_ edits have not been saved.
- Refresh/reload the page.
- See that your menu has been renamed but that the menu edits were _not_ persisted and the _original_ menu item order is still in evidence.

----

- Do the same for Template Parts
- Create Custom Template Part
- Add content inside where you can tell the order of items such as two paragraphs with `first` and `second` as the content.
- Do NOT save.
- Go back to `Patterns` library and click on `Manage all Template Parts`
- Use options menu to `Rename`.
- Rename to whatever and confirm.
- Return to editing the Template Part
- See the entity save flow is still prompting you to Save.
- Reload - see that the edits you made to the Template Part are lost (i.e. were not persisted) but the renaming of the title is still present.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/444434/85217d8b-ff8e-42bb-9010-75f4d785b445

