### PR TITLE
POC: Saving title into undo stack after five characters typed

### DIFF
--- a/packages/editor/src/components/post-title/index.js
+++ b/packages/editor/src/components/post-title/index.js
@@ -63,6 +63,11 @@ function PostTitle( _, forwardedRef ) {
 		[]
 	);
 
+	const timeout = useRef();
+	if ( timeout.current === undefined ) {
+		timeout.current = 0;
+	}
+
 	useImperativeHandle( forwardedRef, () => ( {
 		focus: () => {
 			ref?.current?.focus();
@@ -99,6 +104,17 @@ function PostTitle( _, forwardedRef ) {
 
 	function onUpdate( newTitle ) {
 		editPost( { title: newTitle } );
+	}
+
+	function onUpdate( newTitle ) {
+		/**
+		 * As a POC, we're saving after 5 characters typed
+		 */
+		if ( timeout.current++ % 5 === 0 ) {
+			editPost( { title: newTitle } );
+		} else {
+			editPost( { title: newTitle }, { isCached: true } );
+		}
 	}
 
 	const [ selection, setSelection ] = useState( {} );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This is a POC to understand the next steps of solving this issue: https://github.com/WordPress/gutenberg/issues/37171

## How?
We're currently using [the cache concept implemented here](https://github.com/WordPress/gutenberg/pull/51644) and trying the idea of saving the title after a specific condition is met.

## Question

While editing the post, [we rely on useMarkPersistent](https://github.com/WordPress/gutenberg/blob/trunk/packages/block-editor/src/components/rich-text/use-mark-persistent.js#L30-L32) which calls [__unstableMarkLastChangeAsPersistent action](https://github.com/WordPress/gutenberg/blob/trunk/packages/block-editor/src/store/actions.js#L1420) and that will persist the past command into the undo stack after one-second window without typing.

Should we try something similar to [useMarkPersistent](https://github.com/WordPress/gutenberg/blob/trunk/packages/block-editor/src/components/rich-text/use-mark-persistent.js#L12) for the title?

This is the current behavior:

https://github.com/WordPress/gutenberg/assets/1044309/8ca033a9-f385-44a5-b3f4-4bc45a262cad