### PR TITLE
Fix Site editor page when JS support is disabled

### DIFF
--- a/packages/edit-post/src/style.scss
+++ b/packages/edit-post/src/style.scss
@@ -41,13 +41,7 @@
 	}
 }
 
-// In order to use mix-blend-mode, this element needs to have an explicitly set background-color
-// We scope it to .wp-toolbar to be wp-admin only, to prevent bleed into other implementations
-html.wp-toolbar {
-	background: $white;
-}
-
-body.block-editor-page {
+body.js.block-editor-page {
 	@include wp-admin-reset( ".block-editor" );
 }
 

--- a/packages/edit-site/src/style.scss
+++ b/packages/edit-site/src/style.scss
@@ -47,27 +47,20 @@
 @import "./components/resizable-frame/style.scss";
 @import "./hooks/push-changes-to-global-styles/style.scss";
 
-html #wpadminbar {
+body.js #wpadminbar {
 	display: none;
 }
 
-html #wpbody {
+body.js #wpbody {
 	padding-top: 0;
 }
 
-// In order to use mix-blend-mode, this element needs to have an explicitly set background-color.
-// We scope it to .wp-toolbar to be wp-admin only, to prevent bleed into other implementations.
-html.wp-toolbar {
-	background: $white;
-	padding-top: 0;
-}
-
-body.appearance_page_gutenberg-template-parts,
-body.site-editor-php {
+body.js.appearance_page_gutenberg-template-parts,
+body.js.site-editor-php {
 	@include wp-admin-reset(".edit-site");
 }
 
-body.site-editor-php {
+body.js.site-editor-php {
 	background: $gray-900;
 }
 
@@ -89,6 +82,11 @@ body.site-editor-php {
 		position: fixed;
 		right: 0;
 		top: 0;
+	}
+
+	.no-js & {
+		min-height: 0;
+		position: static;
 	}
 
 	.interface-interface-skeleton {

--- a/packages/edit-widgets/src/style.scss
+++ b/packages/edit-widgets/src/style.scss
@@ -11,14 +11,8 @@
 @import "./components/widget-areas-block-editor-content/style.scss";
 @import "./components/secondary-sidebar/style.scss";
 
-// In order to use mix-blend-mode, this element needs to have an explicitly set background-color
-// We scope it to .wp-toolbar to be wp-admin only, to prevent bleed into other implementations
-html.wp-toolbar {
-	background: $white;
-}
-
-body.appearance_page_gutenberg-widgets,
-body.widgets-php {
+body.js.appearance_page_gutenberg-widgets,
+body.js.widgets-php {
 	@include wp-admin-reset( ".blocks-widgets-container" );
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Splitting this out from https://github.com/WordPress/gutenberg/pull/42495

## What?
<!-- In a few words, what is the PR actually doing? -->
Currently, the Site editor page looks a bit wrong when JS support is off:

<img width="1792" alt="wp site editor no js" src="https://github.com/WordPress/gutenberg/assets/1682452/5a583586-8ee1-4062-9bb5-7724d36f96b6">

This page should look like the Post editor page with JS off. See some related recent changes in core:
https://core.trac.wordpress.org/ticket/56228
https://core.trac.wordpress.org/changeset/56025
https://github.com/WordPress/wordpress-develop/pull/4695

These change should have ben coordinated with the CSS change from https://github.com/WordPress/gutenberg/pull/42495

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The page layout is broken when JS is off.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Scopes the CSS admin reset to the `body.js` selector so that the reset is applied only when needed (when JS is on).
- Scopes a few more CSS rules to `body.js`.
- Removes the white background set on the `html` element. To my understanding, this background was introduced in https://github.com/WordPress/gutenberg/pull/6406 only to cover a Chrome bug with `mix-blend-mode`. However, `mix-blend-mode` is not used any longer since https://github.com/WordPress/gutenberg/pull/16835 so the white background on the `html` element is now pointless. The admin reset will apply a white background on the _body_ element anyways. Pinging @jasmussen  for kind confirmation this is no longer needed.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
- Test with latest WP trunk, with the latest patch from https://core.trac.wordpress.org/ticket/56228#comment:42 applied.
- Disable JS support in your browser.
- Go to the Site editor page, to the Post editor page, and to the Add new theme page `/wp-admin/theme-install.php`.
- Observe they look the same:
  - Visible heading at the top of the page.
  - An error notice below the heading.
  - Check the page footer is visible.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

Site editor page:

<img width="858" alt="Screenshot 2023-07-06 at 13 14 33" src="https://github.com/WordPress/gutenberg/assets/1682452/ca928604-3b91-4fac-bbbb-3be9290118f0">


Post editor page:

<img width="1031" alt="Screenshot 2023-07-06 at 13 14 36" src="https://github.com/WordPress/gutenberg/assets/1682452/6402c258-a314-4aa0-aa5a-687f317efd73">


Add theme page:

<img width="951" alt="Screenshot 2023-07-06 at 13 14 39" src="https://github.com/WordPress/gutenberg/assets/1682452/e4a3fc6a-778b-4655-a1b2-e90c32095e60">
