### PR TITLE
Patterns: distinguish between theme patterns and template parts in category list

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen-patterns/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-patterns/index.js
@@ -7,6 +7,7 @@ import {
 	Flex,
 	Icon,
 	Tooltip,
+	__experimentalHeading as Heading,
 } from '@wordpress/components';
 import { useViewportMatch } from '@wordpress/compose';
 import { useSelect } from '@wordpress/data';
@@ -109,9 +110,21 @@ export default function SidebarNavigationScreenPatterns() {
 								</ItemGroup>
 							) }
 							{ hasTemplateParts && (
-								<ItemGroup className="edit-site-sidebar-navigation-screen-patterns__group">
-									{ Object.entries( templatePartAreas ).map(
-										( [ area, parts ] ) => (
+								<>
+									<div className="edit-site-sidebar-navigation-screen-patterns__group-header">
+										<Heading level={ 2 }>
+											{ __( 'Template parts' ) }
+										</Heading>
+										<p>
+											{ __(
+												'Synced patterns for use in template building.'
+											) }
+										</p>
+									</div>
+									<ItemGroup className="edit-site-sidebar-navigation-screen-patterns__group">
+										{ Object.entries(
+											templatePartAreas
+										).map( ( [ area, parts ] ) => (
 											<CategoryItem
 												key={ area }
 												count={ parts.length }
@@ -131,54 +144,71 @@ export default function SidebarNavigationScreenPatterns() {
 														'wp_template_part'
 												}
 											/>
-										)
-									) }
-								</ItemGroup>
+										) ) }
+									</ItemGroup>
+								</>
 							) }
 							{ hasPatterns && (
-								<ItemGroup className="edit-site-sidebar-navigation-screen-patterns__group">
-									{ patternCategories.map( ( category ) => (
-										<CategoryItem
-											key={ category.name }
-											count={ category.count }
-											label={
-												<Flex
-													justify="left"
-													align="center"
-													gap={ 0 }
-												>
-													{ category.label }
-													<Tooltip
-														position="top center"
-														text={ __(
-															'Theme patterns cannot be edited.'
-														) }
-													>
-														<span className="edit-site-sidebar-navigation-screen-pattern__lock-icon">
-															<Icon
-																style={ {
-																	fill: 'currentcolor',
-																} }
-																icon={
-																	lockSmall
-																}
-																size={ 24 }
-															/>
-														</span>
-													</Tooltip>
-												</Flex>
-											}
-											icon={ file }
-											id={ category.name }
-											type="pattern"
-											isActive={
-												currentCategory ===
-													`${ category.name }` &&
-												currentType === 'pattern'
-											}
-										/>
-									) ) }
-								</ItemGroup>
+								<>
+									<div className="edit-site-sidebar-navigation-screen-patterns__group-header">
+										<Heading level={ 2 }>
+											{ __( 'Theme patterns' ) }
+										</Heading>
+										<p>
+											{ __(
+												'For insertion into documents where they can then be customized.'
+											) }
+										</p>
+									</div>
+									<ItemGroup className="edit-site-sidebar-navigation-screen-patterns__group">
+										{ patternCategories.map(
+											( category ) => (
+												<CategoryItem
+													key={ category.name }
+													count={ category.count }
+													label={
+														<Flex
+															justify="left"
+															align="center"
+															gap={ 0 }
+														>
+															{ category.label }
+															<Tooltip
+																position="top center"
+																text={ __(
+																	'Theme patterns cannot be edited.'
+																) }
+															>
+																<span className="edit-site-sidebar-navigation-screen-pattern__lock-icon">
+																	<Icon
+																		style={ {
+																			fill: 'currentcolor',
+																		} }
+																		icon={
+																			lockSmall
+																		}
+																		size={
+																			24
+																		}
+																	/>
+																</span>
+															</Tooltip>
+														</Flex>
+													}
+													icon={ file }
+													id={ category.name }
+													type="pattern"
+													isActive={
+														currentCategory ===
+															`${ category.name }` &&
+														currentType ===
+															'pattern'
+													}
+												/>
+											)
+										) }
+									</ItemGroup>
+								</>
 							) }
 						</>
 					) }

--- a/packages/edit-site/src/components/sidebar-navigation-screen-patterns/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-patterns/style.scss
@@ -1,3 +1,28 @@
 .edit-site-sidebar-navigation-screen-patterns__group {
-	margin-bottom: $grid-unit-30;
+	margin-bottom: $grid-unit-40;
+	padding-bottom: $grid-unit-30;
+	border-bottom: 1px solid $gray-800;
+
+	&:last-of-type,
+	&:first-of-type {
+		border-bottom: 0;
+		padding-bottom: 0;
+		margin-bottom: 0;
+	}
+
+	&:first-of-type {
+		margin-bottom: $grid-unit-40;
+	}
+}
+
+.edit-site-sidebar-navigation-screen-patterns__group-header {
+	p {
+		color: $gray-600;
+	}
+
+	h2 {
+		font-size: 11px;
+		font-weight: 500;
+		text-transform: uppercase;
+	}
 }


### PR DESCRIPTION
## What?
Add header sections to each pattern group in the Patterns sidebar.

## Why?
Here's the current Patterns sidebar:

<img width="358" alt="Screenshot 2023-07-06 at 15 47 57" src="https://github.com/WordPress/gutenberg/assets/846565/feb303d3-7d53-484a-b439-b90aa6a95266">

This PR attempts to address some related issues...

* There is no clear and obvious reason for the duplicate "Header" and "Footer" categories. The icon alone doesn't really communicate the difference.
* "Uncategorized" (or "General" — see https://github.com/WordPress/gutenberg/pull/52355) doesn't really capture what these template parts are about. A user could easily mistake them for content and mis-use.
* Template parts will always remain somewhat separate from regular patterns as they require additional privileges to create and edit. This arguably warrants some separation in the UI.
* There is no context for the "Create template part" menu item which can be confusing for those unfamiliar with this technical element. 

## How?
Adjusted `SidebarNavigationScreenPatterns` and its associated stylesheet.

## Testing Instructions
* Open the Patterns section in the Site Editor
* Observe that template parts and theme patterns now have headings/descriptions:

<img width="354" alt="Screenshot 2023-07-06 at 16 08 07" src="https://github.com/WordPress/gutenberg/assets/846565/bb0e8dd2-4c42-4e9c-bddc-52e5321c91ea">

