### PR TITLE
Revert phpcs testVersion back to PHP 5.6

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -2,7 +2,7 @@
 <ruleset name="WordPress Coding Standards for Gutenberg Plugin">
 	<description>Sniffs for WordPress plugins, with minor modifications for Gutenberg</description>
 
-	<config name="testVersion" value="7.0-"/>
+	<config name="testVersion" value="5.6-"/>
 	<rule ref="PHPCompatibilityWP">
 		<include-pattern>*\.php$</include-pattern>
 	</rule>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

Part of https://github.com/WordPress/gutenberg/issues/52344

## What?
<!-- In a few words, what is the PR actually doing? -->

Reverts the PHP version back to 5.6 for WPCS CI job.

I've changed my mind and now believe WPCS should continue checking PHP compatibility at 5.6.

See:
- PR https://github.com/WordPress/gutenberg/pull/52345 
- Commit https://github.com/WordPress/gutenberg/commit/d9022ff7e4a3558cc764a8b2debe89ff1377a517.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Gutenberg needs to continue supporting PHP 5.6. Reverting the WPCS CI, i.e. the `Unit Tests / PHP coding standards (pull_request)` job, is part of the tooling that helps check PHP compatibility for all code changes.

Why does Gutenberg need to supporting PHP 5.6? Because it supports the latest 2 WordPress major versions, which as of today is WP 6.1 and 6.2. Both of these WP versions support PHP 5.6. Thus, so must Gutenberg. 

For example, let's say a contributor [declares a function return type](https://www.php.net/manual/en/migration70.new-features.php). Function return type declarations are valid in PHP 7.0, but not compatible with PHP 5.6.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

This PR reverts the phpcs `testValue` change back to `5.6-`.

## Testing Instructions

The CI `Unit Tests / PHP coding standards (pull_request)` job in this PR should pass ✅ 

Testing it locally involves several steps. The following sections provide set up and testing instructions.

### Step 1: Set up

#### Sample code change

Change a function to declare a return type. For example, change `wp_fonts()` to 
```php
function wp_fonts(): WP_Fonts {
```

#### Run PHPCS

You'll use the following command to run phpcs in your favorite command line tool:
```
composer run lint -- ./lib/experimental/fonts-api/fonts-api.php
```
#### Run Gutenberg on PHP 5.6

With `wp-env` running on Docker, you can add a `.wp-env.override.json` file locally and define the `phpVersion` as `"5.6".

### Step 2: Before applying the change in this PR:

1. Run the `lint` above. Notice WPCS passes.

```
> phpcs --standard=phpcs.xml.dist './lib/experimental/fonts-api/fonts-api.php'
. 1 / 1 (100%)

Time: 123ms; Memory: 14MB
```

2. Now run Gutenberg on PHP 5.6. A fatal error should happen.

```
Parse error: syntax error, unexpected ':', expecting '{' in /var/www/html/wp-content/plugins/gutenberg/lib/experimental/fonts-api/fonts-api.php on line 20
```

### Step 3: Apply this PR's change and then: 

1. Run the `lint` above. WPCS should now fail.

```
> phpcs --standard=phpcs.xml.dist './lib/experimental/fonts-api/fonts-api.php'
E 1 / 1 (100%)

FILE: /Volumes/DevSSD/Dev/wordpress-develop/src/wp-content/plugins/gutenberg/lib/experimental/fonts-api/fonts-api.php
-----------------------------------------------------------------------------------------------------------------------------------------------------------
FOUND 1 ERROR AFFECTING 1 LINE
-----------------------------------------------------------------------------------------------------------------------------------------------------------
 20 | ERROR | Class name return type is not present in PHP version 5.6 or earlier
    |       | (PHPCompatibility.FunctionDeclarations.NewReturnTypeDeclarations.class_nameFound)
-----------------------------------------------------------------------------------------------------------------------------------------------------------

Time: 125ms; Memory: 16MB
```

2. Run Gutenberg on PHP 5.6. No fatal error should happen.