### PR TITLE
Try forward slash keyboard shortcut for command palette

### DIFF
--- a/packages/commands/src/components/command-menu.js
+++ b/packages/commands/src/components/command-menu.js
@@ -222,9 +222,6 @@ export function CommandMenu() {
 			} else {
 				open();
 			}
-		},
-		{
-			bindGlobal: true,
 		}
 	);
 

--- a/packages/commands/src/components/command-menu.js
+++ b/packages/commands/src/components/command-menu.js
@@ -205,12 +205,7 @@ export function CommandMenu() {
 				modifier: 'primary',
 				character: '/',
 			},
-			aliases: [
-				{
-					modifier: 'primaryShift',
-					character: 'p',
-				},
-			],
+			aliases: [ { character: 'F1' } ],
 		} );
 	}, [ registerShortcut ] );
 

--- a/packages/commands/src/components/command-menu.js
+++ b/packages/commands/src/components/command-menu.js
@@ -203,8 +203,14 @@ export function CommandMenu() {
 			description: __( 'Open the command palette.' ),
 			keyCombination: {
 				modifier: 'primary',
-				character: 'k',
+				character: '/',
 			},
+			aliases: [
+				{
+					modifier: 'primaryShift',
+					character: 'p',
+				},
+			],
 		} );
 	}, [ registerShortcut ] );
 

--- a/packages/edit-site/src/components/site-hub/index.js
+++ b/packages/edit-site/src/components/site-hub/index.js
@@ -196,7 +196,7 @@ const SiteHub = memo( ( { isTransparent, className } ) => {
 						icon={ search }
 						onClick={ () => openCommandCenter() }
 						label={ __( 'Open command palette' ) }
-						shortcut={ displayShortcut.primary( 'k' ) }
+						shortcut={ displayShortcut.primary( '/' ) }
 					/>
 				) }
 			</HStack>

--- a/packages/editor/src/components/document-bar/index.js
+++ b/packages/editor/src/components/document-bar/index.js
@@ -184,7 +184,7 @@ function BaseDocumentActions( { postType, postId, onBack } ) {
 						</Text>
 					</HStack>
 					<span className="editor-document-bar__shortcut">
-						{ displayShortcut.primary( 'k' ) }
+						{ displayShortcut.primary( '/' ) }
 					</span>
 				</Button>
 			) }


### PR DESCRIPTION
## What?
Changes the keyboard shortcut for the command palette.

## Why?
The current shortcut is conflicted with the longstanding shortcut for adding a link to rich text and that breaks the intended global availability of the command palette shortcut.
To fix #51737

## How?
- Replaces the character “K” with another. For the moment, it's “/” and that required a little circumstantial update to allow the character to display in the keyboard shortcuts modal.
- Updates the hint in the Site Editor header.
- Adds an alias keyboard shortcut. Currently ”F1”.

## Testing Instructions
In either the Site or Post editors launch the command palette by pressing:
- macOS either: <kbd>⌘</kbd>+<kbd>/</kbd> or <kbd>F1</kbd>
- Windows (and others?) either: <kbd>Ctrl</kbd>+<kbd>/</kbd> or <kbd>F1</kbd>

Test it from a rich text area too and delight in the lack of conflict 🎊 .