### PR TITLE
Rename block theme activation nonce variable.

### DIFF
--- a/lib/compat/wordpress-6.3/theme-previews.php
+++ b/lib/compat/wordpress-6.3/theme-previews.php
@@ -107,7 +107,7 @@ function block_theme_activate_nonce() {
 	$nonce_handle = 'switch-theme_' . gutenberg_get_theme_preview_path();
 	?>
 <script type="text/javascript">
-	window.BLOCK_THEME_ACTIVATE_NONCE = '<?php echo wp_create_nonce( $nonce_handle ); ?>';
+	window.WP_BLOCK_THEME_ACTIVATE_NONCE = '<?php echo wp_create_nonce( $nonce_handle ); ?>';
 </script>
 	<?php
 }

--- a/packages/edit-site/src/utils/use-activate-theme.js
+++ b/packages/edit-site/src/utils/use-activate-theme.js
@@ -29,7 +29,7 @@ export function useActivateTheme() {
 				'themes.php?action=activate&stylesheet=' +
 				currentlyPreviewingTheme() +
 				'&_wpnonce=' +
-				window.BLOCK_THEME_ACTIVATE_NONCE;
+				window.WP_BLOCK_THEME_ACTIVATE_NONCE;
 			await window.fetch( activationURL );
 			const { wp_theme_preview: themePreview, ...params } =
 				location.params;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Renames the javascript variable `BLOCK_THEME_ACTIVATE_NONCE` to `WP_BLOCK_THEME_ACTIVATE_NONCE`.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

To reduce the chance of naming collisions.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Adds a `WP_` prefix to the variable.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->

1. Open the Appearance > Themes page in the WP Dashboard
2. Click preview on an inactive block theme
3. Activate the theme via the site editor
4. Ensure the theme changes

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

N/A

## Screenshots or screencast <!-- if applicable -->
