### PR TITLE
Fix admin_url() for preview link of block themes.

### DIFF
--- a/lib/compat/wordpress-6.3/theme-previews.php
+++ b/lib/compat/wordpress-6.3/theme-previews.php
@@ -88,7 +88,7 @@ function add_live_preview_button() {
 			livePreviewButton.setAttribute('class', 'button button-primary');
 			livePreviewButton.setAttribute(
 				'href',
-				`/wp-admin/site-editor.php?wp_theme_preview=${themePath}&return=themes.php`
+				`<?php echo esc_url( admin_url( '/site-editor.php' ) ); ?>?wp_theme_preview=${themePath}&return=themes.php`
 			);
 			livePreviewButton.innerHTML = '<?php echo esc_html_e( 'Live Preview' ); ?>';
 			themeInfo.querySelector('.theme-actions').appendChild(livePreviewButton);


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Ensures the admin URL generated for live previewing block themes is correct.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The current (in trunk) code presumes that WordPress is installed in the root directory of a domain. For sites running in a sub-directory (eg example.com/blog) or sites running [WordPress in it's own subdirectory](https://wordpress.org/documentation/article/giving-wordpress-its-own-directory/) this can result in a 404 error when clicking the link.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Replaces the hard coded `/wp-admin` with a call to `admin_url()`.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Install WordPress in a sub-directory
2. Visit Appearance > Themes
3. Click the preview link of a block theme
4. On trunk the link will 404, on this branch the link should work.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
