### PR TITLE
Patterns: Update manage pattern links to go to site editor if available

### DIFF
--- a/packages/edit-post/src/plugins/index.js
+++ b/packages/edit-post/src/plugins/index.js
@@ -19,29 +19,25 @@ import ToolsMoreMenuGroup from '../components/header/tools-more-menu-group';
 import WelcomeGuideMenuItem from './welcome-guide-menu-item';
 
 function ManagePatternsMenuItem() {
-	const { isBlockTheme, isVisible } = useSelect( ( select ) => {
+	const url = useSelect( ( select ) => {
 		const { canUser } = select( coreStore );
 		const { getEditorSettings } = select( editorStore );
 
-		return {
-			// The site editor and templates both check whether the user has
-			// edit_theme_options capabilities. We can leverage that here and not
-			// display the manage patterns link if the user can't access it.
-			isVisible: canUser( 'read', 'templates' ),
-			isBlockTheme: getEditorSettings().__unstableIsBlockBasedTheme,
-		};
+		const isBlockTheme = getEditorSettings().__unstableIsBlockBasedTheme;
+		const defaultUrl = addQueryArgs( 'edit.php', {
+			post_type: 'wp_block',
+		} );
+		const patternsUrl = addQueryArgs( 'site-editor.php', {
+			path: '/patterns',
+		} );
+
+		// The site editor and templates both check whether the user has
+		// edit_theme_options capabilities. We can leverage that here and not
+		// display the manage patterns link if the user can't access it.
+		return canUser( 'read', 'templates' ) && isBlockTheme
+			? patternsUrl
+			: defaultUrl;
 	}, [] );
-
-	if ( ! isVisible ) {
-		return null;
-	}
-
-	const defaultUrl = addQueryArgs( 'edit.php', { post_type: 'wp_block' } );
-	const patternsUrl = addQueryArgs( 'site-editor.php', {
-		path: '/patterns',
-	} );
-
-	const url = isBlockTheme ? patternsUrl : defaultUrl;
 
 	return (
 		<MenuItem role="menuitem" href={ url }>

--- a/packages/edit-post/src/plugins/index.js
+++ b/packages/edit-post/src/plugins/index.js
@@ -2,6 +2,9 @@
  * WordPress dependencies
  */
 import { MenuItem, VisuallyHidden } from '@wordpress/components';
+import { store as coreStore } from '@wordpress/core-data';
+import { store as editorStore } from '@wordpress/editor';
+import { useSelect } from '@wordpress/data';
 import { external } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
 import { registerPlugin } from '@wordpress/plugins';
@@ -15,6 +18,38 @@ import KeyboardShortcutsHelpMenuItem from './keyboard-shortcuts-help-menu-item';
 import ToolsMoreMenuGroup from '../components/header/tools-more-menu-group';
 import WelcomeGuideMenuItem from './welcome-guide-menu-item';
 
+function ManagePatternsMenuItem() {
+	const { isBlockTheme, isVisible } = useSelect( ( select ) => {
+		const { canUser } = select( coreStore );
+		const { getEditorSettings } = select( editorStore );
+
+		return {
+			// The site editor and templates both check whether the user has
+			// edit_theme_options capabilities. We can leverage that here and not
+			// display the manage patterns link if the user can't access it.
+			isVisible: canUser( 'read', 'templates' ),
+			isBlockTheme: getEditorSettings().__unstableIsBlockBasedTheme,
+		};
+	}, [] );
+
+	if ( ! isVisible ) {
+		return null;
+	}
+
+	const defaultUrl = addQueryArgs( 'edit.php', { post_type: 'wp_block' } );
+	const patternsUrl = addQueryArgs( 'site-editor.php', {
+		path: '/patterns',
+	} );
+
+	const url = isBlockTheme ? patternsUrl : defaultUrl;
+
+	return (
+		<MenuItem role="menuitem" href={ url }>
+			{ __( 'Manage Patterns' ) }
+		</MenuItem>
+	);
+}
+
 registerPlugin( 'edit-post', {
 	render() {
 		return (
@@ -22,14 +57,7 @@ registerPlugin( 'edit-post', {
 				<ToolsMoreMenuGroup>
 					{ ( { onClose } ) => (
 						<>
-							<MenuItem
-								role="menuitem"
-								href={ addQueryArgs( 'edit.php', {
-									post_type: 'wp_block',
-								} ) }
-							>
-								{ __( 'Manage Patterns' ) }
-							</MenuItem>
+							<ManagePatternsMenuItem />
 							<KeyboardShortcutsHelpMenuItem
 								onSelect={ onClose }
 							/>

--- a/packages/reusable-blocks/src/components/reusable-blocks-menu-items/reusable-blocks-manage-button.js
+++ b/packages/reusable-blocks/src/components/reusable-blocks-menu-items/reusable-blocks-manage-button.js
@@ -18,12 +18,19 @@ import { store as coreStore } from '@wordpress/core-data';
 import { store as reusableBlocksStore } from '../../store';
 
 function ReusableBlocksManageButton( { clientId } ) {
-	const { canRemove, isVisible, innerBlockCount } = useSelect(
+	const {
+		canRemove,
+		isVisible,
+		innerBlockCount,
+		canManagePatterns,
+		managePatternsUrl,
+	} = useSelect(
 		( select ) => {
-			const { getBlock, canRemoveBlock, getBlockCount } =
+			const { getBlock, canRemoveBlock, getBlockCount, getSettings } =
 				select( blockEditorStore );
 			const { canUser } = select( coreStore );
 			const reusableBlock = getBlock( clientId );
+			const isBlockTheme = getSettings().__unstableIsBlockBasedTheme;
 
 			return {
 				canRemove: canRemoveBlock( clientId ),
@@ -36,6 +43,17 @@ function ReusableBlocksManageButton( { clientId } ) {
 						reusableBlock.attributes.ref
 					),
 				innerBlockCount: getBlockCount( clientId ),
+				// The site editor and templates both check whether the user
+				// has edit_theme_options capabilities. We can leverage that here
+				// and omit the manage patterns link if the user can't access it.
+				canManagePatterns: canUser( 'read', 'templates' ),
+				managePatternsUrl: isBlockTheme
+					? addQueryArgs( 'site-editor.php', {
+							path: '/patterns',
+					  } )
+					: addQueryArgs( 'edit.php', {
+							post_type: 'wp_block',
+					  } ),
 			};
 		},
 		[ clientId ]
@@ -50,11 +68,11 @@ function ReusableBlocksManageButton( { clientId } ) {
 
 	return (
 		<BlockSettingsMenuControls>
-			<MenuItem
-				href={ addQueryArgs( 'edit.php', { post_type: 'wp_block' } ) }
-			>
-				{ __( 'Manage Patterns' ) }
-			</MenuItem>
+			{ canManagePatterns && (
+				<MenuItem href={ managePatternsUrl }>
+					{ __( 'Manage Patterns' ) }
+				</MenuItem>
+			) }
 			{ canRemove && (
 				<MenuItem onClick={ () => convertBlockToStatic( clientId ) }>
 					{ innerBlockCount > 1

--- a/packages/reusable-blocks/src/components/reusable-blocks-menu-items/reusable-blocks-manage-button.js
+++ b/packages/reusable-blocks/src/components/reusable-blocks-menu-items/reusable-blocks-manage-button.js
@@ -18,46 +18,41 @@ import { store as coreStore } from '@wordpress/core-data';
 import { store as reusableBlocksStore } from '../../store';
 
 function ReusableBlocksManageButton( { clientId } ) {
-	const {
-		canRemove,
-		isVisible,
-		innerBlockCount,
-		canManagePatterns,
-		managePatternsUrl,
-	} = useSelect(
-		( select ) => {
-			const { getBlock, canRemoveBlock, getBlockCount, getSettings } =
-				select( blockEditorStore );
-			const { canUser } = select( coreStore );
-			const reusableBlock = getBlock( clientId );
-			const isBlockTheme = getSettings().__unstableIsBlockBasedTheme;
+	const { canRemove, isVisible, innerBlockCount, managePatternsUrl } =
+		useSelect(
+			( select ) => {
+				const { getBlock, canRemoveBlock, getBlockCount, getSettings } =
+					select( blockEditorStore );
+				const { canUser } = select( coreStore );
+				const reusableBlock = getBlock( clientId );
+				const isBlockTheme = getSettings().__unstableIsBlockBasedTheme;
 
-			return {
-				canRemove: canRemoveBlock( clientId ),
-				isVisible:
-					!! reusableBlock &&
-					isReusableBlock( reusableBlock ) &&
-					!! canUser(
-						'update',
-						'blocks',
-						reusableBlock.attributes.ref
-					),
-				innerBlockCount: getBlockCount( clientId ),
-				// The site editor and templates both check whether the user
-				// has edit_theme_options capabilities. We can leverage that here
-				// and omit the manage patterns link if the user can't access it.
-				canManagePatterns: canUser( 'read', 'templates' ),
-				managePatternsUrl: isBlockTheme
-					? addQueryArgs( 'site-editor.php', {
-							path: '/patterns',
-					  } )
-					: addQueryArgs( 'edit.php', {
-							post_type: 'wp_block',
-					  } ),
-			};
-		},
-		[ clientId ]
-	);
+				return {
+					canRemove: canRemoveBlock( clientId ),
+					isVisible:
+						!! reusableBlock &&
+						isReusableBlock( reusableBlock ) &&
+						!! canUser(
+							'update',
+							'blocks',
+							reusableBlock.attributes.ref
+						),
+					innerBlockCount: getBlockCount( clientId ),
+					// The site editor and templates both check whether the user
+					// has edit_theme_options capabilities. We can leverage that here
+					// and omit the manage patterns link if the user can't access it.
+					managePatternsUrl:
+						isBlockTheme && canUser( 'read', 'templates' )
+							? addQueryArgs( 'site-editor.php', {
+									path: '/patterns',
+							  } )
+							: addQueryArgs( 'edit.php', {
+									post_type: 'wp_block',
+							  } ),
+				};
+			},
+			[ clientId ]
+		);
 
 	const { __experimentalConvertBlockToStatic: convertBlockToStatic } =
 		useDispatch( reusableBlocksStore );
@@ -68,11 +63,9 @@ function ReusableBlocksManageButton( { clientId } ) {
 
 	return (
 		<BlockSettingsMenuControls>
-			{ canManagePatterns && (
-				<MenuItem href={ managePatternsUrl }>
-					{ __( 'Manage Patterns' ) }
-				</MenuItem>
-			) }
+			<MenuItem href={ managePatternsUrl }>
+				{ __( 'Manage Patterns' ) }
+			</MenuItem>
 			{ canRemove && (
 				<MenuItem onClick={ () => convertBlockToStatic( clientId ) }>
 					{ innerBlockCount > 1


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/51944

Alternative to:
- https://github.com/WordPress/gutenberg/pull/51957

## What?

The "Manage Patterns" links in the editor are updated to direct the user to the site editor's new Patterns page, if the current user can access the site editor and is using a block theme. If not, the links will continue to send the user to the wp-admin page for the `wp_block` post type.

## Why?

With the introduction of the site editor's patterns library, it makes sense to direct users with access there to manage their patterns.

## How?

The site editor checks whether the current user has the  `edit_theme_options` permission. The `templates` REST endpoint also checks this same permission. This allows the "manage patterns" links to check for site editor access via `canUser( 'read', 'templates' )`.

Combining the above permissions check with whether or not the current theme is a block theme provides enough information to correctly send a user to either the site editor's patterns page or to wp-admin.

Kudos to @noisysocks for the approach and help 🙇 

## Testing Instructions
1. With an admin user, open the post editor, editing a post with a synced pattern (formerly reusable block) added to it.
2. Open the editor's options menu in the very top right and confirm the presence of the manage patterns menu item
3. Select Manage Patterns and confirm you are taken to the site editor's patterns page
4. Navigate back to the post editor and select the synced pattern
5. Confirm the presence of Manage Patterns within the block toolbar's more menu
6. Check this Manage Patterns link also takes you to the site editor's patterns page
7. Switch themes to a non-block theme
8. Repeat the above process except confirming you are taken to the wp-admin page
9. Log in with a non-admin user that only has the editor role, and switch to a block theme
10. Repeat the process confirming this time that the Manage Patterns links go to wp-admin

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/60436221/3cc22140-1e9a-4c8c-a640-862991558286

