### PR TITLE
Lodash: Refactor away from `_.set()` in `PushChangesToGlobalStylesControl`

### DIFF
--- a/packages/core-data/src/utils/set-nested-value.js
+++ b/packages/core-data/src/utils/set-nested-value.js
@@ -10,6 +10,8 @@
  *
  * @see https://lodash.com/docs/4.17.15#set
  *
+ * @todo Needs to be deduplicated with its copy in `@wordpress/edit-site`.
+ *
  * @param {Object} object Object to modify
  * @param {Array}  path   Path of the property to set.
  * @param {*}      value  Value to set.

--- a/packages/edit-site/src/hooks/push-changes-to-global-styles/index.js
+++ b/packages/edit-site/src/hooks/push-changes-to-global-styles/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { get, set } from 'lodash';
+import { get } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -119,6 +119,46 @@ function useChangesToPush( name, attributes ) {
 	);
 }
 
+/**
+ * Sets the value at path of object.
+ * If a portion of path doesn’t exist, it’s created.
+ * Arrays are created for missing index properties while objects are created
+ * for all other missing properties.
+ *
+ * This function intentionally mutates the input object.
+ *
+ * Inspired by _.set().
+ *
+ * @see https://lodash.com/docs/4.17.15#set
+ *
+ * @todo Needs to be deduplicated with its copy in `@wordpress/core-data`.
+ *
+ * @param {Object} object Object to modify
+ * @param {Array}  path   Path of the property to set.
+ * @param {*}      value  Value to set.
+ */
+function setNestedValue( object, path, value ) {
+	if ( ! object || typeof object !== 'object' ) {
+		return object;
+	}
+
+	path.reduce( ( acc, key, idx ) => {
+		if ( acc[ key ] === undefined ) {
+			if ( Number.isInteger( path[ idx + 1 ] ) ) {
+				acc[ key ] = [];
+			} else {
+				acc[ key ] = {};
+			}
+		}
+		if ( idx === path.length - 1 ) {
+			acc[ key ] = value;
+		}
+		return acc[ key ];
+	}, object );
+
+	return object;
+}
+
 function cloneDeep( object ) {
 	return ! object ? {} : JSON.parse( JSON.stringify( object ) );
 }
@@ -148,8 +188,12 @@ function PushChangesToGlobalStylesControl( {
 		const newUserConfig = cloneDeep( userConfig );
 
 		for ( const { path, value } of changes ) {
-			set( newBlockStyles, path, undefined );
-			set( newUserConfig, [ 'styles', 'blocks', name, ...path ], value );
+			setNestedValue( newBlockStyles, path, undefined );
+			setNestedValue(
+				newUserConfig,
+				[ 'styles', 'blocks', name, ...path ],
+				value
+			);
 		}
 
 		// @wordpress/core-data doesn't support editing multiple entity types in


### PR DESCRIPTION
## What?
This PR removes Lodash's `_.set()` from the `PushChangesToGlobalStylesControl` component.

With #52278 and #52279, this removes the last occurrence of `_.set()`!

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?

We're replacing the usage with the existing `setNestedValue` utility function, which we're temporarily duplicating.

## Testing Instructions

* Open the site editor.
* Select a block, like "Paragraph" or "Heading".
* Make some style changes in the block inspector.
* Open the "Advanced" panel and click "Apply Globally".
The typography, spacing, dimensions, and color changes you made should now apply to all blocks of that type. You can verify this by navigating to Global Styles → Blocks → "Your Block".
* Verify all checks are green - there is an [existing e2e suite](https://github.com/WordPress/gutenberg/blob/783bb9c65360ec5167a412f7aed75e852133074c/test/e2e/specs/site-editor/push-to-global-styles.spec.js#L6) that specifically tests this functionality.