### PR TITLE
Fix entering edit mode in site editor

### DIFF
--- a/packages/edit-site/src/components/block-editor/editor-canvas.js
+++ b/packages/edit-site/src/components/block-editor/editor-canvas.js
@@ -88,7 +88,7 @@ function EditorCanvas( { enableResizing, settings, children, ...props } ) {
 					enableResizing ? 'min-height:0!important;' : ''
 				}}body{position:relative; ${
 					canvasMode === 'view'
-						? 'cursor: pointer; height: 100vh'
+						? 'cursor: pointer; min-height: 100vh;'
 						: ''
 				}}}`
 			}</style>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes #52402
Alternative to #51973

Fixes the frame in the site editor not being clickable once scrolled. Bug introduced in #51973

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Sometimes the frame has contents which are smaller than the height of the viewport. In these situations the body of the frame is only as big as the contents, which has the effect that one cannot click anywhere in the frame to enter edit mode.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

This PR fixes this by getting the idea from #51973 - to make the body as tall as the viewport is, but only addresses the min height - so that when contents extend below the height of the viewport the body can go to 100%.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

0. Make sure to have multiple menus
1. In the site editor browse some templates
2. Make sure that wherever you click on the frame you enter edit mode
3. Scroll the frame and make sure that wherever you click on the frame you enter edit mode
4. Visit the navigation item in the sidebar
5. The Navigation menu should be displayed in the frame
6. Clicking in the whitespace below the menu should trigger edit mode

## Screenshots or screencast <!-- if applicable -->



https://github.com/WordPress/gutenberg/assets/107534/9e661c8c-387c-4ea6-ab33-ec6cd76496b0

