### PR TITLE
Lodash: Deprecate `_.set()`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -129,6 +129,7 @@ const restrictedImports = [
 			'reject',
 			'repeat',
 			'reverse',
+			'set',
 			'setWith',
 			'size',
 			'snakeCase',


### PR DESCRIPTION
## What?
This PR deprecates Lodash's `_.set()` function.

Was blocked by:
- [x] #52278
- [x] #52279
- [x] #52404

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?

We're adding `_.set()` to the list of deprecated Lodash functions in our ESLint configuration.

## Testing Instructions

Not needed.