### PR TITLE
Remove padding support from Post Featured Image

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -590,7 +590,7 @@ Display a post's featured image. ([Source](https://github.com/WordPress/gutenber
 
 -	**Name:** core/post-featured-image
 -	**Category:** theme
--	**Supports:** align (center, full, left, right, wide), color (~~background~~, ~~text~~), spacing (margin, padding), ~~html~~
+-	**Supports:** align (center, full, left, right, wide), color (~~background~~, ~~text~~), spacing (margin), ~~html~~
 -	**Attributes:** aspectRatio, customGradient, customOverlayColor, dimRatio, gradient, height, isLink, linkTarget, overlayColor, rel, scale, sizeSlug, width
 
 ## Post Navigation Link

--- a/packages/block-library/src/post-featured-image/block.json
+++ b/packages/block-library/src/post-featured-image/block.json
@@ -75,8 +75,7 @@
 		},
 		"html": false,
 		"spacing": {
-			"margin": true,
-			"padding": true
+			"margin": true
 		}
 	},
 	"editorStyle": "wp-block-post-featured-image-editor",

--- a/packages/block-library/src/post-featured-image/deprecated.js
+++ b/packages/block-library/src/post-featured-image/deprecated.js
@@ -1,0 +1,111 @@
+/**
+ * WordPress dependencies
+ */
+import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
+
+/**
+ * Internal dependencies
+ */
+import { unlock } from '../lock-unlock';
+
+const { cleanEmptyObject } = unlock( blockEditorPrivateApis );
+
+const v1 = {
+	attributes: {
+		isLink: {
+			type: 'boolean',
+			default: false,
+		},
+		aspectRatio: {
+			type: 'string',
+		},
+		width: {
+			type: 'string',
+		},
+		height: {
+			type: 'string',
+		},
+		scale: {
+			type: 'string',
+			default: 'cover',
+		},
+		sizeSlug: {
+			type: 'string',
+		},
+		rel: {
+			type: 'string',
+			attribute: 'rel',
+			default: '',
+		},
+		linkTarget: {
+			type: 'string',
+			default: '_self',
+		},
+		overlayColor: {
+			type: 'string',
+		},
+		customOverlayColor: {
+			type: 'string',
+		},
+		dimRatio: {
+			type: 'number',
+			default: 0,
+		},
+		gradient: {
+			type: 'string',
+		},
+		customGradient: {
+			type: 'string',
+		},
+	},
+	supports: {
+		align: [ 'left', 'right', 'center', 'wide', 'full' ],
+		color: {
+			__experimentalDuotone:
+				'img, .wp-block-post-featured-image__placeholder, .components-placeholder__illustration, .components-placeholder::before',
+			text: false,
+			background: false,
+		},
+		__experimentalBorder: {
+			color: true,
+			radius: true,
+			width: true,
+			__experimentalSelector:
+				'img, .block-editor-media-placeholder, .wp-block-post-featured-image__overlay',
+			__experimentalSkipSerialization: true,
+			__experimentalDefaultControls: {
+				color: true,
+				radius: true,
+				width: true,
+			},
+		},
+		html: false,
+		spacing: {
+			padding: true,
+			margin: true,
+		},
+	},
+	save() {
+		return null;
+	},
+	migrate: ( oldAttributes ) => {
+		if ( ! oldAttributes?.style?.spacing?.padding ) {
+			return oldAttributes;
+		}
+		return {
+			...oldAttributes,
+			style: cleanEmptyObject( {
+				...oldAttributes.style,
+				spacing: {
+					...oldAttributes.style.spacing,
+					padding: undefined,
+				},
+			} ),
+		};
+	},
+	isEligible( { style } ) {
+		return style?.spacing?.padding;
+	},
+};
+
+export default [ v1 ];

--- a/packages/block-library/src/post-featured-image/index.js
+++ b/packages/block-library/src/post-featured-image/index.js
@@ -9,6 +9,7 @@ import { postFeaturedImage as icon } from '@wordpress/icons';
 import initBlock from '../utils/init-block';
 import metadata from './block.json';
 import edit from './edit';
+import deprecated from './deprecated';
 
 const { name } = metadata;
 export { metadata, name };
@@ -16,6 +17,7 @@ export { metadata, name };
 export const settings = {
 	icon,
 	edit,
+	deprecated,
 };
 
 export const init = () => initBlock( { name, metadata, settings } );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Fixes: #52349

## What?
<!-- In a few words, what is the PR actually doing? -->
This PR reverts padding support for Post Featured Image blocks added by #35775.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
If you set padding like this issue, the border will be double marked up.
#52349
![post-featured-image](https://github.com/WordPress/gutenberg/assets/42362903/311b1062-89e3-485b-9d0e-9a55872eeb45)

Post Featured Image doesn't have content like Cover block, so I don't think it's necessary to set padding.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->

In the trunk branch
1. Open a Post or Page. 
2. Place a Post Featured Image block. If you haven't set an eye catch, set it.
3. Set the border.
4. Set overlay
5. Set Padding
6. You can see the overlayed border and two outer borders
7. Switch to this branch to see the padding control disappear.
8. Previously set spacing attributes are removed by the deprecated process.
For example, the padding is removed when pasting the following HTML.

```HTML
<!-- wp:post-featured-image {"overlayColor":"black","dimRatio":50,"style":{"spacing":{"padding":{"top":"clamp(1.875rem, 1.303rem + 1.83vw, 2.813rem)","bottom":"clamp(1.875rem, 1.303rem + 1.83vw, 2.813rem)","left":"var:preset|spacing|50","right":"var:preset|spacing|50"}},"border":{"width":"20px"}},"borderColor":"vivid-cyan-blue"} /-->
```

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
