### PR TITLE
Move request utils reset to global setup

### DIFF
--- a/packages/e2e-test-utils-playwright/src/test.ts
+++ b/packages/e2e-test-utils-playwright/src/test.ts
@@ -136,18 +136,6 @@ const test = base.extend<
 				storageStatePath: STORAGE_STATE_PATH,
 			} );
 
-			await Promise.all( [
-				requestUtils.activateTheme( 'twentytwentyone' ),
-				// Disable this test plugin as it's conflicting with some of the tests.
-				// We already have reduced motion enabled and Playwright will wait for most of the animations anyway.
-				requestUtils.deactivatePlugin(
-					'gutenberg-test-plugin-disables-the-css-animations'
-				),
-				requestUtils.deleteAllPosts(),
-				requestUtils.deleteAllBlocks(),
-				requestUtils.resetPreferences(),
-			] );
-
 			await use( requestUtils );
 		},
 		{ scope: 'worker', auto: true },

--- a/test/e2e/config/global-setup.ts
+++ b/test/e2e/config/global-setup.ts
@@ -25,6 +25,19 @@ async function globalSetup( config: FullConfig ) {
 	// Authenticate and save the storageState to disk.
 	await requestUtils.setupRest();
 
+	// Reset the test environment before running the tests.
+	await Promise.all( [
+		requestUtils.activateTheme( 'twentytwentyone' ),
+		// Disable this test plugin as it's conflicting with some of the tests.
+		// We already have reduced motion enabled and Playwright will wait for most of the animations anyway.
+		requestUtils.deactivatePlugin(
+			'gutenberg-test-plugin-disables-the-css-animations'
+		),
+		requestUtils.deleteAllPosts(),
+		requestUtils.deleteAllBlocks(),
+		requestUtils.resetPreferences(),
+	] );
+
 	await requestContext.dispose();
 }
 

--- a/test/performance/config/global-setup.ts
+++ b/test/performance/config/global-setup.ts
@@ -25,6 +25,19 @@ async function globalSetup( config: FullConfig ) {
 	// Authenticate and save the storageState to disk.
 	await requestUtils.setupRest();
 
+	// Reset the test environment before running the tests.
+	await Promise.all( [
+		requestUtils.activateTheme( 'twentytwentyone' ),
+		// Disable this test plugin as it's conflicting with some of the tests.
+		// We already have reduced motion enabled and Playwright will wait for most of the animations anyway.
+		requestUtils.deactivatePlugin(
+			'gutenberg-test-plugin-disables-the-css-animations'
+		),
+		requestUtils.deleteAllPosts(),
+		requestUtils.deleteAllBlocks(),
+		requestUtils.resetPreferences(),
+	] );
+
 	await requestContext.dispose();
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Moves the "reset" logic from the request utils setup to global setup, wehre it belongs.

Fixes #50741
Fixes #52339

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Right now the request utils in `e2e-test-utils-playwright` contain a lot of Gutenberg-specific logic that does not apply to other setups.

That means everyone trying to use the utils gets errors about things like the `gutenberg-test-plugin-disables-the-css-animations` plugin or the `twentytwentyone` theme not existing.

This logic is an ideal candidate for [global setup](https://playwright.dev/docs/test-global-setup-teardown#configure-globalsetup-and-globalteardown) in Playwright.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

tests should pass

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
