### PR TITLE
Make `query` optional in `visitAdminPage`

### DIFF
--- a/packages/e2e-test-utils-playwright/src/admin/visit-admin-page.ts
+++ b/packages/e2e-test-utils-playwright/src/admin/visit-admin-page.ts
@@ -18,7 +18,7 @@ import type { Admin } from './';
 export async function visitAdminPage(
 	this: Admin,
 	adminPath: string,
-	query: string
+	query?: string
 ) {
 	await this.page.goto(
 		join( 'wp-admin', adminPath ) + ( query ? `?${ query }` : '' )


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Makes the `query` parameter optional in the `visitAdminPage` util.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Because the query param is really optional :-)

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
