### PR TITLE
Fix document title icon appearance

### DIFF
--- a/packages/edit-site/src/components/header-edit-mode/document-actions/style.scss
+++ b/packages/edit-site/src/components/header-edit-mode/document-actions/style.scss
@@ -40,6 +40,10 @@
 	overflow: hidden;
 	grid-column: 2 / 3;
 
+	.block-editor-block-icon {
+		min-width: $grid-unit-30;
+	}
+
 	h1 {
 		white-space: nowrap;
 		overflow: hidden;


### PR DESCRIPTION
## What?
Apply more specific min-width value to the icon in the document title.

## Why?
`min-width: 0` is currently applied via inherent `HStack` styles, which breaks the appearance in two ways:

1. The svg is too small.
2. There isn't enough width for the full icon to be visible.

<img width="571" alt="Screenshot 2023-07-07 at 14 30 06" src="https://github.com/WordPress/gutenberg/assets/846565/869cdeab-f45a-4e42-b09c-711f4071881a">

## How?
Set min-width on `.edit-site-document-actions__title .block-editor-block-icon`.

## Testing Instructions
1. Open a document in the Site Editor
2. Ensure the icon in the document title occupies a 24x24px footprint, like so:

<img width="484" alt="Screenshot 2023-07-07 at 14 33 27" src="https://github.com/WordPress/gutenberg/assets/846565/e2522121-3027-4ece-bfc4-dcf62b69f446">

