### PR TITLE
Footnotes: Fix incorrect anchor position in Firefox

### DIFF
--- a/packages/block-library/src/footnotes/style.scss
+++ b/packages/block-library/src/footnotes/style.scss
@@ -7,7 +7,8 @@
 	vertical-align: super;
 	font-size: smaller;
 	counter-increment: footnotes;
-	display: inline-block;
+	display: inline-flex;
+	text-decoration: none;
 	text-indent: -9999999px;
 }
 


### PR DESCRIPTION
Fixes: #52239

## What?
This PR fixes incorrect anchor position in the Footnotes block in the Firefox browser.

| Before | After |
|--------|--------|
| ![before](https://github.com/WordPress/gutenberg/assets/54422211/39cb17c1-173f-4df3-8fbd-730bd3005c73) | ![after](https://github.com/WordPress/gutenberg/assets/54422211/ce3a5b54-273e-40e0-baca-a0e02680925e) | 

## Why?
I could not figure out the root cause, but one factor is that in Firefox the anchor element has a width of zero.

| Firefox | Chrome |
|--------|--------|
| ![firefox](https://github.com/WordPress/gutenberg/assets/54422211/02403281-f761-48f2-99b1-511d46071f8b) | ![chrome](https://github.com/WordPress/gutenberg/assets/54422211/4eab55dd-6eea-40ca-9e98-73a46321de8f) |


## How?
I could not find a source that technically back up this approach, but I was able to solve the problem by changing from `display: inline-block` to `inline-flex`. At the same time, Firefox had an unintended underline, so we added a style to reset it.

## Testing Instructions

Add a footnote and make sure that: 

- This issue should be fixes in Firefox
- Should still display correctly in other browsers (I tested with Chrome and Edge)
- The height of the paragraph block itself with the footnote inserted should be the same as before

### Testing Instructions for Keyboard

Make sure that the anchor is properly focused when the tab key is pressed.