### PR TITLE
[WIP] Global styles: add text alignment section

### DIFF
--- a/packages/edit-site/src/components/global-styles/root-menu.js
+++ b/packages/edit-site/src/components/global-styles/root-menu.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __experimentalItemGroup as ItemGroup } from '@wordpress/components';
-import { typography, color, layout } from '@wordpress/icons';
+import { typography, color, layout, alignLeft } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
 import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
 
@@ -38,6 +38,15 @@ function RootMenu() {
 						aria-label={ __( 'Typography styles' ) }
 					>
 						{ __( 'Typography' ) }
+					</NavigationButtonAsItem>
+				) }
+				{ hasTypographyPanel && (
+					<NavigationButtonAsItem
+						icon={ alignLeft }
+						path="/text-alignment"
+						aria-label={ __( 'Text alignment' ) }
+					>
+						{ __( 'Text alignment' ) }
 					</NavigationButtonAsItem>
 				) }
 				{ hasColorPanel && (

--- a/packages/edit-site/src/components/global-styles/screen-text-alignment.js
+++ b/packages/edit-site/src/components/global-styles/screen-text-alignment.js
@@ -1,0 +1,79 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { __experimentalVStack as VStack, Button } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import ScreenHeader from './header';
+import Subtitle from './subtitle';
+import BlockPreviewPanel from './block-preview-panel';
+import {
+	alignCenter,
+	alignJustify,
+	alignLeft,
+	alignRight,
+} from '@wordpress/icons';
+
+const DEFAULT_ALIGNMENT_CONTROLS = [
+	{
+		icon: alignLeft,
+		title: __( 'Align text left' ),
+		align: 'left',
+	},
+	{
+		icon: alignCenter,
+		title: __( 'Align text center' ),
+		align: 'center',
+	},
+	{
+		icon: alignRight,
+		title: __( 'Align text right' ),
+		align: 'right',
+	},
+	{
+		icon: alignJustify,
+		title: __( 'Align justify' ),
+		align: 'justify',
+	},
+];
+
+function ScreenTextAlignment() {
+	return (
+		<>
+			<ScreenHeader
+				title={ __( 'Global Text Alignment' ) }
+				description={ __(
+					'Manage the global text alignment for pages and posts content.'
+				) }
+			/>
+
+			<BlockPreviewPanel />
+
+			<div className="edit-site-global-styles-screen-typography">
+				<VStack spacing={ 3 }>
+					<Subtitle level={ 3 }>{ __( 'Alignment' ) }</Subtitle>
+					{ DEFAULT_ALIGNMENT_CONTROLS.map(
+						( { icon, title, align } ) => (
+							<Button
+								icon={ icon }
+								key={ title }
+								onClick={ () => {
+									// TODO: update the style with useGlobalStyle
+									// eslint-disable-next-line no-console
+									console.log( 'clicked', align );
+								} }
+							>
+								{ title }
+							</Button>
+						)
+					) }
+				</VStack>
+			</div>
+		</>
+	);
+}
+
+export default ScreenTextAlignment;

--- a/packages/edit-site/src/components/global-styles/screen-text-alignment.js
+++ b/packages/edit-site/src/components/global-styles/screen-text-alignment.js
@@ -86,12 +86,18 @@ function ScreenTextAlignment() {
 						} }
 						value="auto"
 					>
-						<ToggleGroupControlOption label="auto" value="auto" />
 						<ToggleGroupControlOption
-							label="manual"
+							label={ __( 'auto' ) }
+							value="auto"
+						/>
+						<ToggleGroupControlOption
+							label={ __( 'manual' ) }
 							value="manual"
 						/>
-						<ToggleGroupControlOption label="none" value="none" />
+						<ToggleGroupControlOption
+							label={ __( 'none' ) }
+							value="none"
+						/>
 					</ToggleGroupControl>
 				</VStack>
 			</div>

--- a/packages/edit-site/src/components/global-styles/screen-text-alignment.js
+++ b/packages/edit-site/src/components/global-styles/screen-text-alignment.js
@@ -79,10 +79,10 @@ function ScreenTextAlignment() {
 					<ToggleGroupControl
 						isBlock
 						label={ __( 'Hyphens' ) }
-						onClick={ ( event ) => {
+						onChange={ ( value ) => {
 							// TODO: update the style with useGlobalStyle
 							// eslint-disable-next-line no-console
-							console.log( 'changed', event.target.value );
+							console.log( 'changed', value );
 						} }
 						value="auto"
 					>

--- a/packages/edit-site/src/components/global-styles/screen-text-alignment.js
+++ b/packages/edit-site/src/components/global-styles/screen-text-alignment.js
@@ -2,7 +2,12 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { __experimentalVStack as VStack, Button } from '@wordpress/components';
+import {
+	__experimentalVStack as VStack,
+	__experimentalToggleGroupControl as ToggleGroupControl,
+	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
+	Button,
+} from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -70,6 +75,24 @@ function ScreenTextAlignment() {
 							</Button>
 						)
 					) }
+
+					<ToggleGroupControl
+						isBlock
+						label={ __( 'Hyphens' ) }
+						onClick={ ( event ) => {
+							// TODO: update the style with useGlobalStyle
+							// eslint-disable-next-line no-console
+							console.log( 'changed', event.target.value );
+						} }
+						value="auto"
+					>
+						<ToggleGroupControlOption label="auto" value="auto" />
+						<ToggleGroupControlOption
+							label="manual"
+							value="manual"
+						/>
+						<ToggleGroupControlOption label="none" value="none" />
+					</ToggleGroupControl>
 				</VStack>
 			</div>
 		</>

--- a/packages/edit-site/src/components/global-styles/screen-text-alignment.js
+++ b/packages/edit-site/src/components/global-styles/screen-text-alignment.js
@@ -49,7 +49,7 @@ function ScreenTextAlignment() {
 	return (
 		<>
 			<ScreenHeader
-				title={ __( 'Global Text Alignment' ) }
+				title={ __( 'Text Alignment' ) }
 				description={ __(
 					'Manage the global text alignment for pages and posts content.'
 				) }

--- a/packages/edit-site/src/components/global-styles/ui.js
+++ b/packages/edit-site/src/components/global-styles/ui.js
@@ -39,6 +39,7 @@ import {
 import ScreenBlock from './screen-block';
 import ScreenTypography from './screen-typography';
 import ScreenTypographyElement from './screen-typography-element';
+import ScreenTextAlignment from './screen-text-alignment';
 import ScreenColors from './screen-colors';
 import ScreenColorPalette from './screen-color-palette';
 import ScreenLayout from './screen-layout';
@@ -378,6 +379,10 @@ function GlobalStylesUI() {
 
 			<GlobalStylesNavigationScreen path="/typography/button">
 				<ScreenTypographyElement element="button" />
+			</GlobalStylesNavigationScreen>
+
+			<GlobalStylesNavigationScreen path="/text-alignment">
+				<ScreenTextAlignment />
 			</GlobalStylesNavigationScreen>
 
 			<GlobalStylesNavigationScreen path="/colors">


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

WORK IN PROGRESS. For now, it's just a dummy UI with no real interaction.

- Closes https://github.com/WordPress/gutenberg/issues/48202

## What?
<!-- In a few words, what is the PR actually doing? -->
It adds `text-alignment` option to global styles.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Before adding justified text alignment at the block level, we will add the text alignment as a global style.
In this PR I suggest adding a `text-alignment` section to edit the `text-alignment` itself and `hyphens` on the global style.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

We are adding a new section to `GlobalStylesUI`.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

* On `/wp-admin/ go to `Appearance` > `Editor`
* Click on `Styles`
* Click on the pencil icon to `edit styles`
* Observe the new section `Text alignment` is present below `Typography`
* Click on it `Text alignment`
* Observe the options `Alignment` and `Hyphens` are present. _For now these options do nothing. It's still work in progress._


### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
<img width="281" alt="Screenshot 2023-07-07 at 14 55 09" src="https://github.com/WordPress/gutenberg/assets/779993/78073282-155a-4f72-975c-e5b1bd95cb7b">
<img width="285" alt="Screenshot 2023-07-07 at 14 56 33" src="https://github.com/WordPress/gutenberg/assets/779993/ca668beb-e47a-4217-a4a2-b6b7cbe93a81">




## Screencast

https://github.com/WordPress/gutenberg/assets/779993/378c77aa-e0e9-42c3-81fd-ff060c13ff6f

## Playground PR LIve preview

https://playground.wordpress.net/?gutenberg-pr=52426&url=/wp-admin/site-editor.php

