### PR TITLE
Patterns: Enable focus mode editing

### DIFF
--- a/packages/edit-site/src/components/block-editor/constants.js
+++ b/packages/edit-site/src/components/block-editor/constants.js
@@ -1,1 +1,5 @@
-export const FOCUSABLE_ENTITIES = [ 'wp_template_part', 'wp_navigation' ];
+export const FOCUSABLE_ENTITIES = [
+	'wp_template_part',
+	'wp_navigation',
+	'wp_block',
+];


### PR DESCRIPTION
## What?
Fixes #52422.

PR enabled focus mode editing for patterns.

## Testing Instructions
1. Open Site Editor
2. Go to Patterns
3. Edit a pattern.
4. Confirm that focus mode is enabled.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2023-07-07 at 18 03 59](https://github.com/WordPress/gutenberg/assets/240569/c3c7b337-c1bd-448e-b0e9-47f1905dc8df)

