### PR TITLE
Revert "Update Changelog for 16.1.2"

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,12 +1,5 @@
 == Changelog ==
 
-= 16.1.2 =
-
-## Bugfixes
-
-* Footnotes: increase selector specificity for anchor (https://github.com/WordPress/gutenberg/pull/52179)
-
-
 = 16.2.0-rc.1 =
 
 


### PR DESCRIPTION
## What/Why?

We needed to push a stable point release for 16.1, and it uses this changeset https://github.com/WordPress/gutenberg/pull/49082#pullrequestreview-1467790447. The problem is that it wasn't part of the releases/16.1 branch, and it needs to, or the upload zip workflow will be the outdated one. That's what happened when I ran the workflow to release 16.1.2 the first time, so I'm reverting to do it again, but this time cherry-picking https://github.com/WordPress/gutenberg/pull/49082#pullrequestreview-1467790447  into releases/16.1 FIRST :)