### PR TITLE
ResizableFrame: Make keyboard accessible

### DIFF
--- a/packages/edit-site/src/components/resizable-frame/index.js
+++ b/packages/edit-site/src/components/resizable-frame/index.js
@@ -36,7 +36,7 @@ const HANDLE_STYLES_OVERRIDE = {
 };
 
 // The minimum width of the frame (in px) while resizing.
-const FRAME_MIN_WIDTH = 340;
+const FRAME_MIN_WIDTH = 320;
 // The reference width of the frame (in px) used to calculate the aspect ratio.
 const FRAME_REFERENCE_WIDTH = 1300;
 // 9 : 19.5 is the target aspect ratio enforced (when possible) while resizing.

--- a/packages/edit-site/src/components/resizable-frame/index.js
+++ b/packages/edit-site/src/components/resizable-frame/index.js
@@ -299,7 +299,7 @@ function ResizableFrame( {
 						</Tooltip>
 						<div hidden id={ resizableHandleHelpId }>
 							{ __(
-								'Use left and right arrow keys to resize the canvas.'
+								'Use left and right arrow keys to resize the canvas. Hold shift to resize in larger increments.'
 							) }
 						</div>
 					</>

--- a/packages/edit-site/src/components/resizable-frame/index.js
+++ b/packages/edit-site/src/components/resizable-frame/index.js
@@ -269,10 +269,9 @@ function ResizableFrame( {
 						<Tooltip text={ __( 'Drag to resize' ) }>
 							{ /* Disable reason: role="separator" does in fact support aria-valuenow */ }
 							{ /* eslint-disable-next-line jsx-a11y/role-supports-aria-props */ }
-							<motion.div
+							<motion.button
 								key="handle"
 								role="separator"
-								tabIndex={ 0 }
 								aria-orientation="vertical"
 								className={ classnames(
 									'edit-site-resizable-frame__handle',

--- a/packages/edit-site/src/components/resizable-frame/index.js
+++ b/packages/edit-site/src/components/resizable-frame/index.js
@@ -176,9 +176,12 @@ function ResizableFrame( {
 
 		const step = 20 * ( event.shiftKey ? 5 : 1 );
 		const delta = step * ( event.key === 'ArrowLeft' ? 1 : -1 );
-		const newWidth = Math.max(
-			FRAME_MIN_WIDTH,
-			frameRef.current.resizable.offsetWidth + delta
+		const newWidth = Math.min(
+			Math.max(
+				FRAME_MIN_WIDTH,
+				frameRef.current.resizable.offsetWidth + delta
+			),
+			initialComputedWidthRef.current
 		);
 
 		setFrameSize( {
@@ -188,14 +191,6 @@ function ResizableFrame( {
 				initialAspectRatioRef.current
 			),
 		} );
-
-		// If oversized, immediately switch to edit mode
-		if ( newWidth > initialComputedWidthRef.current ) {
-			setFrameSize( INITIAL_FRAME_SIZE );
-			setCanvasMode( 'edit' );
-			// TODO: Confirm if this is the focus behavior we want
-			document.querySelector( 'iframe[name=editor-canvas]' ).focus();
-		}
 	};
 
 	const frameAnimationVariants = {

--- a/packages/edit-site/src/components/resizable-frame/index.js
+++ b/packages/edit-site/src/components/resizable-frame/index.js
@@ -13,7 +13,7 @@ import {
 	__unstableMotion as motion,
 } from '@wordpress/components';
 import { useInstanceId } from '@wordpress/compose';
-import { useDispatch } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -90,6 +90,10 @@ function ResizableFrame( {
 	const [ shouldShowHandle, setShouldShowHandle ] = useState( false );
 	const [ isOversized, setIsOversized ] = useState( false );
 	const [ resizeRatio, setResizeRatio ] = useState( 1 );
+	const canvasMode = useSelect(
+		( select ) => unlock( select( editSiteStore ) ).getCanvasMode(),
+		[]
+	);
 	const { setCanvasMode } = unlock( useDispatch( editSiteStore ) );
 	const initialAspectRatioRef = useRef( null );
 	// The width of the resizable frame on initial render.
@@ -265,7 +269,7 @@ function ResizableFrame( {
 			onMouseOver={ () => setShouldShowHandle( true ) }
 			onMouseOut={ () => setShouldShowHandle( false ) }
 			handleComponent={ {
-				left: (
+				left: canvasMode === 'view' && (
 					<>
 						<Tooltip text={ __( 'Drag to resize' ) }>
 							{ /* Disable reason: role="separator" does in fact support aria-valuenow */ }

--- a/packages/edit-site/src/components/resizable-frame/index.js
+++ b/packages/edit-site/src/components/resizable-frame/index.js
@@ -10,7 +10,6 @@ import { useState, useRef, useEffect } from '@wordpress/element';
 import {
 	ResizableBox,
 	Tooltip,
-	VisuallyHidden,
 	__unstableMotion as motion,
 } from '@wordpress/components';
 import { useInstanceId } from '@wordpress/compose';
@@ -296,11 +295,11 @@ function ResizableFrame( {
 								whileHover="active"
 							/>
 						</Tooltip>
-						<VisuallyHidden id={ resizableHandleHelpId }>
+						<div hidden id={ resizableHandleHelpId }>
 							{ __(
 								'Use left and right arrow keys to resize the canvas.'
 							) }
-						</VisuallyHidden>
+						</div>
 					</>
 				),
 			} }

--- a/packages/edit-site/src/components/resizable-frame/index.js
+++ b/packages/edit-site/src/components/resizable-frame/index.js
@@ -173,6 +173,8 @@ function ResizableFrame( {
 			return;
 		}
 
+		event.preventDefault();
+
 		const step = 20 * ( event.shiftKey ? 5 : 1 );
 		const delta = step * ( event.key === 'ArrowLeft' ? 1 : -1 );
 		const newWidth = Math.min(

--- a/packages/edit-site/src/components/resizable-frame/index.js
+++ b/packages/edit-site/src/components/resizable-frame/index.js
@@ -267,9 +267,13 @@ function ResizableFrame( {
 				left: (
 					<>
 						<Tooltip text={ __( 'Drag to resize' ) }>
-							<motion.button
+							{ /* Disable reason: role="separator" does in fact support aria-valuenow */ }
+							{ /* eslint-disable-next-line jsx-a11y/role-supports-aria-props */ }
+							<motion.div
 								key="handle"
-								type="button"
+								role="separator"
+								tabIndex={ 0 }
+								aria-orientation="vertical"
 								className={ classnames(
 									'edit-site-resizable-frame__handle',
 									{ 'is-resizing': isResizing }
@@ -278,6 +282,14 @@ function ResizableFrame( {
 								animate={ currentResizeHandleVariant }
 								aria-label={ __( 'Drag to resize' ) }
 								aria-describedby={ resizableHandleHelpId }
+								aria-valuenow={
+									frameRef.current?.resizable?.offsetWidth ||
+									undefined
+								}
+								aria-valuemin={ FRAME_MIN_WIDTH }
+								aria-valuemax={
+									initialComputedWidthRef.current
+								}
 								onKeyDown={ handleResizableHandleKeyDown }
 								initial="hidden"
 								exit="hidden"

--- a/packages/edit-site/src/components/resizable-frame/index.js
+++ b/packages/edit-site/src/components/resizable-frame/index.js
@@ -218,6 +218,12 @@ function ResizableFrame( {
 			scaleY: 1.3,
 		},
 	};
+	const currentResizeHandleVariant = ( () => {
+		if ( isResizing ) {
+			return 'active';
+		}
+		return shouldShowHandle ? 'visible' : 'hidden';
+	} )();
 
 	return (
 		<ResizableBox
@@ -266,7 +272,7 @@ function ResizableFrame( {
 								{ 'is-resizing': isResizing }
 							) }
 							variants={ resizeHandleVariants }
-							animate={ shouldShowHandle ? 'visible' : 'hidden' }
+							animate={ currentResizeHandleVariant }
 							aria-label={ __( 'Drag to resize' ) }
 							onKeyDown={ handleResizableHandleKeyDown }
 							initial="hidden"

--- a/packages/edit-site/src/components/resizable-frame/index.js
+++ b/packages/edit-site/src/components/resizable-frame/index.js
@@ -267,6 +267,7 @@ function ResizableFrame( {
 							) }
 							variants={ resizeHandleVariants }
 							animate={ shouldShowHandle ? 'visible' : 'hidden' }
+							aria-label={ __( 'Drag to resize' ) }
 							onKeyDown={ handleResizableHandleKeyDown }
 							initial="hidden"
 							exit="hidden"

--- a/packages/edit-site/src/components/resizable-frame/index.js
+++ b/packages/edit-site/src/components/resizable-frame/index.js
@@ -261,7 +261,10 @@ function ResizableFrame( {
 					<Tooltip text={ __( 'Drag to resize' ) }>
 						<motion.button
 							key="handle"
-							className="edit-site-resizable-frame__handle"
+							className={ classnames(
+								'edit-site-resizable-frame__handle',
+								{ 'is-resizing': isResizing }
+							) }
 							variants={ resizeHandleVariants }
 							animate={ shouldShowHandle ? 'visible' : 'hidden' }
 							onKeyDown={ handleResizableHandleKeyDown }

--- a/packages/edit-site/src/components/resizable-frame/index.js
+++ b/packages/edit-site/src/components/resizable-frame/index.js
@@ -10,8 +10,10 @@ import { useState, useRef, useEffect } from '@wordpress/element';
 import {
 	ResizableBox,
 	Tooltip,
+	VisuallyHidden,
 	__unstableMotion as motion,
 } from '@wordpress/components';
+import { useInstanceId } from '@wordpress/compose';
 import { useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 
@@ -95,6 +97,10 @@ function ResizableFrame( {
 	const initialComputedWidthRef = useRef( null );
 	const FRAME_TRANSITION = { type: 'tween', duration: isResizing ? 0 : 0.5 };
 	const frameRef = useRef( null );
+	const resizableHandleHelpId = useInstanceId(
+		ResizableFrame,
+		'edit-site-resizable-frame-handle-help'
+	);
 
 	// Remember frame dimensions on initial render.
 	useEffect( () => {
@@ -264,23 +270,32 @@ function ResizableFrame( {
 			onMouseOut={ () => setShouldShowHandle( false ) }
 			handleComponent={ {
 				left: (
-					<Tooltip text={ __( 'Drag to resize' ) }>
-						<motion.button
-							key="handle"
-							className={ classnames(
-								'edit-site-resizable-frame__handle',
-								{ 'is-resizing': isResizing }
+					<>
+						<Tooltip text={ __( 'Drag to resize' ) }>
+							<motion.button
+								key="handle"
+								type="button"
+								className={ classnames(
+									'edit-site-resizable-frame__handle',
+									{ 'is-resizing': isResizing }
+								) }
+								variants={ resizeHandleVariants }
+								animate={ currentResizeHandleVariant }
+								aria-label={ __( 'Drag to resize' ) }
+								aria-describedby={ resizableHandleHelpId }
+								onKeyDown={ handleResizableHandleKeyDown }
+								initial="hidden"
+								exit="hidden"
+								whileFocus="active"
+								whileHover="active"
+							/>
+						</Tooltip>
+						<VisuallyHidden id={ resizableHandleHelpId }>
+							{ __(
+								'Use left and right arrow keys to resize the canvas.'
 							) }
-							variants={ resizeHandleVariants }
-							animate={ currentResizeHandleVariant }
-							aria-label={ __( 'Drag to resize' ) }
-							onKeyDown={ handleResizableHandleKeyDown }
-							initial="hidden"
-							exit="hidden"
-							whileFocus="active"
-							whileHover="active"
-						/>
-					</Tooltip>
+						</VisuallyHidden>
+					</>
 				),
 			} }
 			onResizeStart={ handleResizeStart }

--- a/packages/edit-site/src/components/resizable-frame/style.scss
+++ b/packages/edit-site/src/components/resizable-frame/style.scss
@@ -30,11 +30,13 @@
 .edit-site-resizable-frame__handle {
 	align-items: center;
 	background-color: rgba($gray-700, 0.4);
+	border: 0;
 	border-radius: $grid-unit-05;
 	cursor: col-resize;
 	display: flex;
 	height: $grid-unit-80;
 	justify-content: flex-end;
+	padding: 0;
 	position: absolute;
 	top: calc(50% - #{$grid-unit-40});
 	width: $grid-unit-05;
@@ -57,15 +59,8 @@
 	}
 
 	&:hover,
+	&:focus,
 	.is-resizing & {
 		background-color: var(--wp-admin-theme-color);
-	}
-
-	.edit-site-resizable-frame__handle-label {
-		background: var(--wp-admin-theme-color);
-		border-radius: 2px;
-		color: #fff;
-		margin-right: $grid-unit-10;
-		padding: 4px 8px;
 	}
 }

--- a/packages/edit-site/src/components/resizable-frame/style.scss
+++ b/packages/edit-site/src/components/resizable-frame/style.scss
@@ -65,7 +65,7 @@
 
 	&:hover,
 	&:focus,
-	.is-resizing & {
+	&.is-resizing {
 		background-color: var(--wp-admin-theme-color);
 	}
 }

--- a/packages/edit-site/src/components/resizable-frame/style.scss
+++ b/packages/edit-site/src/components/resizable-frame/style.scss
@@ -58,6 +58,11 @@
 		width: $grid-unit-40;
 	}
 
+	&:focus-visible {
+		// Works with Windows high contrast mode while also hiding weird outline in Safari.
+		outline: 2px solid transparent;
+	}
+
 	&:hover,
 	&:focus,
 	.is-resizing & {


### PR DESCRIPTION
Fixes #51267 

## What?

Adds back keyboard operability to the Editor Canvas frame resizing handle.

In addition, the "Drag to resize" `title` attribute is now moved to a proper Tooltip and is translatable.

## Why?

The changes in #49910 introduced a major accessibility regression.

## How?

Make the resize handle focusable, and add keydown handlers for resizing.

## Testing Instructions

1. Open the [Site Editor](http://localhost:8888/wp-admin/site-editor.php).
2. Hit the Tab key until you focus on the resize handle.
3. Hit the Left/Right arrow keys to resize the frame. The Shift key works as a modifier.
4. Normal mouse drag resizing should also work as before.

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/555336/4bc9177f-6492-40e3-83a0-809386496875

