### PR TITLE
test: Expand mobile editor tests

### DIFF
--- a/packages/block-library/src/list/test/edit.native.js
+++ b/packages/block-library/src/list/test/edit.native.js
@@ -19,7 +19,7 @@ import {
  */
 import { getBlockTypes, unregisterBlockType } from '@wordpress/blocks';
 import { registerCoreBlocks } from '@wordpress/block-library';
-import { BACKSPACE } from '@wordpress/keycodes';
+import { BACKSPACE, ENTER } from '@wordpress/keycodes';
 
 describe( 'List block', () => {
 	beforeAll( () => {
@@ -338,34 +338,125 @@ describe( 'List block', () => {
 		expect( getEditorHtml() ).toMatchSnapshot();
 	} );
 
-	it( 'merges with other lists', async () => {
+	it( 'splits empty list items into paragraphs', async () => {
+		// Arrange
 		const initialHtml = `<!-- wp:list -->
 		<ul><!-- wp:list-item -->
-		<li>One</li><!-- /wp:list-item --></ul>
-		<!-- /wp:list --><!-- wp:list -->
-		<ul><!-- wp:list-item -->
+		<li>One</li><!-- /wp:list-item -->
+		<!-- wp:list-item -->
 		<li>Two</li><!-- /wp:list-item --></ul>
 		<!-- /wp:list -->`;
+		const screen = await initializeEditor( { initialHtml } );
 
-		const screen = await initializeEditor( {
-			initialHtml,
-		} );
-
-		// Select List block
-		const [ listBlock ] = screen.getAllByLabelText( /List Block\. Row 2/ );
+		// Act
+		const listBlock = screen.getByLabelText( /List Block\. Row 1/ );
 		fireEvent.press( listBlock );
 		await triggerBlockListLayout( listBlock );
+		const listItemField = screen.getByLabelText( /Text input. .*One.*/ );
+		selectRangeInRichText( listItemField, 3, 3 );
+		fireEvent( listItemField, 'onKeyDown', {
+			nativeEvent: {},
+			preventDefault() {},
+			keyCode: ENTER,
+		} );
+		const listItemField2 = screen.getByLabelText( /Text input. Empty/ );
+		fireEvent( listItemField2, 'onKeyDown', {
+			nativeEvent: {},
+			preventDefault() {},
+			keyCode: ENTER,
+		} );
 
-		// Select List Item block
-		const [ listItemBlock ] = within( listBlock ).getAllByLabelText(
-			/List item Block\. Row 1/
-		);
-		fireEvent.press( listItemBlock );
+		// Assert
+		expect( getEditorHtml() ).toMatchInlineSnapshot( `
+		"<!-- wp:list -->
+		<ul><!-- wp:list-item -->
+		<li>One</li>
+		<!-- /wp:list-item --></ul>
+		<!-- /wp:list -->
 
-		// With cursor positioned at the beginning of the first List Item, press
-		// backward delete
-		const listItemField =
-			within( listItemBlock ).getByLabelText( /Text input. .*Two.*/ );
+		<!-- wp:paragraph -->
+		<p></p>
+		<!-- /wp:paragraph -->
+
+		<!-- wp:list -->
+		<ul><!-- wp:list-item -->
+		<li>Two</li>
+		<!-- /wp:list-item --></ul>
+		<!-- /wp:list -->"
+	` );
+	} );
+
+	it( 'merges paragraphs into list items', async () => {
+		const initialHtml = `<!-- wp:list -->
+		<ul><!-- wp:list-item -->
+		<li>One</li>
+		<!-- /wp:list-item --></ul>
+		<!-- /wp:list -->
+
+		<!-- wp:paragraph -->
+		<p>Two</p>
+		<!-- /wp:paragraph -->
+
+		<!-- wp:list -->
+		<ul><!-- wp:list-item -->
+		<li>Three</li>
+		<!-- /wp:list-item --></ul>
+		<!-- /wp:list -->`;
+		const screen = await initializeEditor( { initialHtml } );
+
+		// Act
+		const paragraphField = screen.getByLabelText( /Text input. .*Two.*/ );
+		selectRangeInRichText( paragraphField, 0 );
+		fireEvent( paragraphField, 'onKeyDown', {
+			nativeEvent: {},
+			preventDefault() {},
+			keyCode: BACKSPACE,
+		} );
+
+		// Assert
+		expect( getEditorHtml() ).toMatchInlineSnapshot( `
+		"<!-- wp:list -->
+		<ul><!-- wp:list-item -->
+		<li>One</li>
+		<!-- /wp:list-item -->
+
+		<!-- wp:list-item -->
+		<li>Two</li>
+		<!-- /wp:list-item --></ul>
+		<!-- /wp:list -->
+
+		<!-- wp:list -->
+		<ul><!-- wp:list-item -->
+		<li>Three</li>
+		<!-- /wp:list-item --></ul>
+		<!-- /wp:list -->"
+	` );
+	} );
+
+	it( 'merges lists into lists', async () => {
+		// Arrange
+		const initialHtml = `<!-- wp:list -->
+		<ul><!-- wp:list-item -->
+		<li>One</li>
+		<!-- /wp:list-item -->
+
+		<!-- wp:list-item -->
+		<li>Two</li>
+		<!-- /wp:list-item --></ul>
+		<!-- /wp:list -->
+
+		<!-- wp:list -->
+		<ul><!-- wp:list-item -->
+		<li>Three</li>
+		<!-- /wp:list-item --></ul>
+		<!-- /wp:list -->`;
+		const screen = await initializeEditor( { initialHtml } );
+
+		// Act
+		const listBlock = screen.getByLabelText( /List Block\. Row 2/ );
+		fireEvent.press( listBlock );
+		await triggerBlockListLayout( listBlock );
+		const listItemField = screen.getByLabelText( /Text input\..*Three/ );
 		selectRangeInRichText( listItemField, 0 );
 		fireEvent( listItemField, 'onKeyDown', {
 			nativeEvent: {},
@@ -373,17 +464,22 @@ describe( 'List block', () => {
 			keyCode: BACKSPACE,
 		} );
 
+		// Assert
 		expect( getEditorHtml() ).toMatchInlineSnapshot( `
-			"<!-- wp:list -->
-			<ul><!-- wp:list-item -->
-			<li>One</li>
-			<!-- /wp:list-item -->
+		"<!-- wp:list -->
+		<ul><!-- wp:list-item -->
+		<li>One</li>
+		<!-- /wp:list-item -->
 
-			<!-- wp:list-item -->
-			<li>Two</li>
-			<!-- /wp:list-item --></ul>
-			<!-- /wp:list -->"
-		` );
+		<!-- wp:list-item -->
+		<li>Two</li>
+		<!-- /wp:list-item -->
+
+		<!-- wp:list-item -->
+		<li>Three</li>
+		<!-- /wp:list-item --></ul>
+		<!-- /wp:list -->"
+	` );
 	} );
 
 	it( 'unwraps first item when attempting to merge with non-list block', async () => {
@@ -486,16 +582,16 @@ describe( 'List block', () => {
 		"<!-- wp:paragraph -->
 		<p>A quick brown fox.</p>
 		<!-- /wp:paragraph -->
-		
+
 		<!-- wp:paragraph -->
 		<p>One</p>
 		<!-- /wp:paragraph -->
-		
+
 		<!-- wp:list -->
 		<ul><!-- wp:list-item -->
 		<li>Two</li>
 		<!-- /wp:list-item -->
-		
+
 		<!-- wp:list-item -->
 		<li>Three</li>
 		<!-- /wp:list-item --></ul>

--- a/packages/block-library/src/list/test/edit.native.js
+++ b/packages/block-library/src/list/test/edit.native.js
@@ -353,7 +353,7 @@ describe( 'List block', () => {
 		fireEvent.press( listBlock );
 		await triggerBlockListLayout( listBlock );
 		const listItemField = screen.getByLabelText( /Text input. .*One.*/ );
-		selectRangeInRichText( listItemField, 3, 3 );
+		selectRangeInRichText( listItemField, 3 );
 		fireEvent( listItemField, 'onKeyDown', {
 			nativeEvent: {},
 			preventDefault() {},

--- a/packages/block-library/src/paragraph/test/edit.native.js
+++ b/packages/block-library/src/paragraph/test/edit.native.js
@@ -639,4 +639,30 @@ describe( 'Paragraph block', () => {
 		);
 		expect( contrastCheckElement ).toBeDefined();
 	} );
+
+	it( 'should highlight text with selection', async () => {
+		// Arrange
+		const screen = await initializeEditor( { withGlobalStyles: true } );
+		await addBlock( screen, 'Paragraph' );
+
+		// Act
+		const paragraphBlock = getBlock( screen, 'Paragraph' );
+		fireEvent.press( paragraphBlock );
+		const paragraphTextInput =
+			within( paragraphBlock ).getByPlaceholderText( 'Start writing…' );
+		typeInRichText(
+			paragraphTextInput,
+			'A quick brown fox jumps over the lazy dog.',
+			{ finalSelectionStart: 2, finalSelectionEnd: 7 }
+		);
+		fireEvent.press( screen.getByLabelText( 'Text color' ) );
+		fireEvent.press( await screen.findByLabelText( 'Tertiary' ) );
+
+		// Assert
+		expect( getEditorHtml() ).toMatchInlineSnapshot( `
+		"<!-- wp:paragraph -->
+		<p>A <mark style="background-color:rgba(0, 0, 0, 0);color:#2411a4" class="has-inline-color has-tertiary-color">quick</mark> brown fox jumps over the lazy dog.</p>
+		<!-- /wp:paragraph -->"
+	` );
+	} );
 } );

--- a/test/native/integration/editor-history.native.js
+++ b/test/native/integration/editor-history.native.js
@@ -123,7 +123,7 @@ describe( 'Editor History', () => {
 	` );
 
 		// Act
-		fireEvent.press( screen.getByLabelText( 'Undo' ) );
+		toggleUndo();
 
 		// Assert
 		expect( getEditorHtml() ).toMatchInlineSnapshot( `
@@ -143,7 +143,7 @@ describe( 'Editor History', () => {
 	` );
 
 		// Act
-		fireEvent.press( screen.getByLabelText( 'Redo' ) );
+		toggleRedo();
 
 		// Assert
 		expect( getEditorHtml() ).toMatchInlineSnapshot( `

--- a/test/native/integration/editor-history.native.js
+++ b/test/native/integration/editor-history.native.js
@@ -100,12 +100,10 @@ describe( 'Editor History', () => {
 		fireEvent.press( paragraphBlock );
 		const paragraphTextInput =
 			within( paragraphBlock ).getByPlaceholderText( 'Start writing…' );
-		typeInRichText(
-			paragraphTextInput,
-			'A quick brown fox jumps over the lazy dog.'
-		);
-
-		// TODO: Determine a way to type multiple times within a given block.
+		typeInRichText( paragraphTextInput, 'A quick brown fox' );
+		// Artifical delay to create two history entries for typing
+		await new Promise( ( resolve ) => setTimeout( resolve, 1000 ) );
+		typeInRichText( paragraphTextInput, ' jumps over the lazy dog.' );
 
 		// Assert
 		expect( getEditorHtml() ).toMatchInlineSnapshot( `
@@ -120,12 +118,32 @@ describe( 'Editor History', () => {
 		// Assert
 		expect( getEditorHtml() ).toMatchInlineSnapshot( `
 		"<!-- wp:paragraph -->
+		<p>A quick brown fox</p>
+		<!-- /wp:paragraph -->"
+	` );
+
+		// Act
+		fireEvent.press( screen.getByLabelText( 'Undo' ) );
+
+		// Assert
+		expect( getEditorHtml() ).toMatchInlineSnapshot( `
+		"<!-- wp:paragraph -->
 		<p></p>
 		<!-- /wp:paragraph -->"
 	` );
 
 		// Act
 		toggleRedo();
+
+		// Assert
+		expect( getEditorHtml() ).toMatchInlineSnapshot( `
+		"<!-- wp:paragraph -->
+		<p>A quick brown fox</p>
+		<!-- /wp:paragraph -->"
+	` );
+
+		// Act
+		fireEvent.press( screen.getByLabelText( 'Redo' ) );
 
 		// Assert
 		expect( getEditorHtml() ).toMatchInlineSnapshot( `

--- a/test/native/integration/editor-history.native.js
+++ b/test/native/integration/editor-history.native.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import {
+	act,
 	addBlock,
 	dismissModal,
 	getBlock,
@@ -30,10 +31,18 @@ describe( 'Editor History', () => {
 
 	beforeAll( () => {
 		subscribeOnUndoPressed.mockImplementation( ( callback ) => {
-			toggleUndo = callback;
+			toggleUndo = () => {
+				act( () => {
+					callback();
+				} );
+			};
 		} );
 		subscribeOnRedoPressed.mockImplementation( ( callback ) => {
-			toggleRedo = callback;
+			toggleRedo = () => {
+				act( () => {
+					callback();
+				} );
+			};
 		} );
 	} );
 

--- a/test/native/integration/editor-history.native.js
+++ b/test/native/integration/editor-history.native.js
@@ -168,12 +168,10 @@ describe( 'Editor History', () => {
 			'A quick brown fox jumps over the lazy dog.',
 			{ finalSelectionStart: 2, finalSelectionEnd: 7 }
 		);
-		// Artifical delay to create two history entries for typing and bolding.
+		// Artifical delay to create two history entries for typing and formatting.
 		await new Promise( ( resolve ) => setTimeout( resolve, 1000 ) );
 		fireEvent.press( screen.getByLabelText( 'Bold' ) );
 		fireEvent.press( screen.getByLabelText( 'Italic' ) );
-
-		// TODO: Determine a way to type multiple times within a given block.
 
 		// Assert
 		expect( getEditorHtml() ).toMatchInlineSnapshot( `


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Expand test coverage for the mobile editor.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Reduce the likelihood of regressions.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
**test: Test multiple text entry editor history**
Expand editor history tests to cover entering text over multiple history
entries.

**test: List split and merge**
Expand tests to cover splitting lists and merging with paragraphs.

**test: Highlight text with selection**
Expand tests to cover highlighting text with selection.

**test: Update inline comments**
The to-do note is not possible for formatted strings that result in
inner HTML tags within the text input. This is because the
`typeInRichText` helper does not support parsing inner HTML tags, only
outer tags. This results in inaccurate cursor placement as the tags
occupy indexes within the string, so the target index is off given it is
based upon the visual position, i.e. the position in the rendered
version of the parsed HTML, rather than the literal position in the
string, i.e. taking into account what positions are occupied by HTML
tags.

If we want to test typing after applying formats, we should likely use
e2e tests.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
n/a

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
n/a

## Screenshots or screencast <!-- if applicable -->
n/a
