### PR TITLE
Patterns: Add missing decoding entities processing in Patterns and Template/Parts pages

### DIFF
--- a/packages/edit-site/src/components/page-patterns/use-patterns.js
+++ b/packages/edit-site/src/components/page-patterns/use-patterns.js
@@ -4,6 +4,7 @@
 import { parse } from '@wordpress/blocks';
 import { useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
+import { decodeEntities } from '@wordpress/html-entities';
 
 /**
  * Internal dependencies
@@ -33,7 +34,7 @@ const templatePartToPattern = ( templatePart ) => ( {
 	keywords: templatePart.keywords || [],
 	id: createTemplatePartId( templatePart.theme, templatePart.slug ),
 	name: createTemplatePartId( templatePart.theme, templatePart.slug ),
-	title: templatePart.title.rendered,
+	title: decodeEntities( templatePart.title.rendered ),
 	type: templatePart.type,
 	templatePart,
 } );

--- a/packages/edit-site/src/components/template-actions/index.js
+++ b/packages/edit-site/src/components/template-actions/index.js
@@ -13,6 +13,7 @@ import {
 } from '@wordpress/components';
 import { moreVertical } from '@wordpress/icons';
 import { store as noticesStore } from '@wordpress/notices';
+import { decodeEntities } from '@wordpress/html-entities';
 
 /**
  * Internal dependencies
@@ -58,7 +59,7 @@ export default function TemplateActions( {
 				sprintf(
 					/* translators: The template/part's name. */
 					__( '"%s" reverted.' ),
-					template.title.rendered
+					decodeEntities( template.title.rendered )
 				),
 				{
 					type: 'snackbar',

--- a/packages/edit-site/src/components/template-actions/rename-menu-item.js
+++ b/packages/edit-site/src/components/template-actions/rename-menu-item.js
@@ -14,9 +14,13 @@ import {
 } from '@wordpress/components';
 import { store as coreStore } from '@wordpress/core-data';
 import { store as noticesStore } from '@wordpress/notices';
+import { decodeEntities } from '@wordpress/html-entities';
 
 export default function RenameMenuItem( { template, onClose } ) {
-	const [ title, setTitle ] = useState( () => template.title.rendered );
+	const [ title, setTitle ] = useState(
+		decodeEntities( template.title.rendered )
+	);
+
 	const [ isModalOpen, setIsModalOpen ] = useState( false );
 
 	const {
@@ -69,12 +73,7 @@ export default function RenameMenuItem( { template, onClose } ) {
 
 	return (
 		<>
-			<MenuItem
-				onClick={ () => {
-					setIsModalOpen( true );
-					setTitle( template.title.rendered );
-				} }
-			>
+			<MenuItem onClick={ () => setIsModalOpen( true ) }>
 				{ __( 'Rename' ) }
 			</MenuItem>
 			{ isModalOpen && (


### PR DESCRIPTION
Fixes #52419

## What?
This PR will fix the areas where HTML entities are not decoded on the Pattarns page and Template (Parts) page of the Site editor.

## Why?
The `title` property of the entity record has `raw` or `rendered` property; the HTML entity of the value of the `rendered` property is not decoded, so I think we need to add an explicit decoding process.

## How?
I have checked various actions, including the renaming modal reported in #52419, and added processing where decoding is needed.

## Testing Instructions

I have fixed the problem in a total of 9 places. In this PR, confirm that the HTML entities in the following locations are decoded correctly. Here is an example of the test text.

```
John & Mike' template
```

### Template rename modal

![modal_template_rename](https://github.com/WordPress/gutenberg/assets/54422211/13262bdf-d3d3-4e50-9295-3633c4ee9446)

### Template part rename modal

![modal_template_part_rename](https://github.com/WordPress/gutenberg/assets/54422211/7e5cb634-8944-482b-a6d8-7174c02d1c61)

### Template part delete modal

![modal_template_part_delete](https://github.com/WordPress/gutenberg/assets/54422211/30b683d3-0386-4cdf-96b3-9f44daa38063)

### Snackbar when duplicating a template part

![snackbar_template_part_duplicate](https://github.com/WordPress/gutenberg/assets/54422211/0a52e4db-bc8c-4d5a-99c1-996f0a09e5af)

### Title and aria-label on Patterns page

![a11y_template_part_preview_aria_label](https://github.com/WordPress/gutenberg/assets/54422211/f1d19569-875d-44d3-bdd9-f095cac8df06)

### Button description on Patterns page

![a11y_template_part_button_description](https://github.com/WordPress/gutenberg/assets/54422211/8795fed6-5eb5-4a1c-bd35-e186733820cc)

### Snack bar when template customization is cleared
### Snack bar when template-parts customization is cleared

To test this, activate EmptyTheme and modify theme.json as follows

<details><summary>theme.json</summary>

```json
{
	"$schema": "https://schemas.wp.org/trunk/theme.json",
	"version": 2,
	"settings": {
		"appearanceTools": true,
		"layout": {
			"contentSize": "840px",
			"wideSize": "1100px"
		}
	},
	"customTemplates": [
		{
			"name": "custom",
			"postTypes": [
				"page"
			],
			"title": "John & Mike's custom template"
		}
	],
	"templateParts": [
		{
			"area": "uncategorized",
			"name": "custom",
			"title": "John & Mike's custom template parts"
		}
	]
}
```

</details> 

Then make changes to the template (parts).

![snackbar_template_revert](https://github.com/WordPress/gutenberg/assets/54422211/4ced67c5-f367-4839-8d31-80ff5d745ad0)
![snackbar_template_part_revert](https://github.com/WordPress/gutenberg/assets/54422211/3e248390-5ad5-422c-a1b8-45f89b43e2d6)
