### PR TITLE
remove sidebar group descriptions

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen-patterns/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-patterns/index.js
@@ -35,7 +35,6 @@ function TemplatePartGroup( { areas, currentArea, currentType } ) {
 		<>
 			<div className="edit-site-sidebar-navigation-screen-patterns__group-header">
 				<Heading level={ 2 }>{ __( 'Template parts' ) }</Heading>
-				<p>{ __( 'Synced patterns for use in template building.' ) }</p>
 			</div>
 			<ItemGroup className="edit-site-sidebar-navigation-screen-patterns__group">
 				{ Object.entries( areas ).map(
@@ -64,11 +63,6 @@ function ThemePatternsGroup( { categories, currentCategory, currentType } ) {
 		<>
 			<div className="edit-site-sidebar-navigation-screen-patterns__group-header">
 				<Heading level={ 2 }>{ __( 'Theme patterns' ) }</Heading>
-				<p>
-					{ __(
-						'For insertion into documents where they can then be customized.'
-					) }
-				</p>
 			</div>
 			<ItemGroup className="edit-site-sidebar-navigation-screen-patterns__group">
 				{ categories.map( ( category ) => (

--- a/packages/edit-site/src/components/sidebar-navigation-screen-patterns/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-patterns/style.scss
@@ -1,8 +1,5 @@
 .edit-site-sidebar-navigation-screen-patterns__group {
 	margin-bottom: $grid-unit-40;
-	padding-bottom: $grid-unit-30;
-	border-bottom: 1px solid $gray-800;
-
 	&:last-of-type,
 	&:first-of-type {
 		border-bottom: 0;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Removes the new sidebar group descriptions on patterns page.

## Why?
The descriptions add visual noise to the sidebar which is making it a little harder to scan menu items. 

## Testing Instructions
1. Open site editor
2. Click patterns
3. Notice template part and theme pattern headings remain but the descriptions are gone
