### PR TITLE
Site Editor: Make sidebar back button go *back* instead of *up* if possible

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Enhancements
 
 -   `TextControl`: Add `id` prop to allow for custom IDs in `TextControl`s ([#52028](https://github.com/WordPress/gutenberg/pull/52028)).
+-   `Navigator`: Add `replace` option to `navigator.goTo()` and `navigator.goToParent()` ([#52456](https://github.com/WordPress/gutenberg/pull/52456)).
 
 ### Bug Fix
 

--- a/packages/components/src/navigator/types.ts
+++ b/packages/components/src/navigator/types.ts
@@ -14,7 +14,10 @@ export type NavigateOptions = {
 	focusTargetSelector?: string;
 	isBack?: boolean;
 	skipFocus?: boolean;
+	replace?: boolean;
 };
+
+export type NavigateToParentOptions = Omit< NavigateOptions, 'isBack' >;
 
 export type NavigatorLocation = NavigateOptions & {
 	isInitial?: boolean;
@@ -28,7 +31,7 @@ export type Navigator = {
 	params: MatchParams;
 	goTo: ( path: string, options?: NavigateOptions ) => void;
 	goBack: () => void;
-	goToParent: () => void;
+	goToParent: ( options?: NavigateToParentOptions ) => void;
 };
 
 export type NavigatorContext = Navigator & {

--- a/packages/edit-site/src/components/sidebar-navigation-screen/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen/index.js
@@ -4,7 +4,6 @@
 import {
 	__experimentalHStack as HStack,
 	__experimentalHeading as Heading,
-	__experimentalNavigatorToParentButton as NavigatorToParentButton,
 	__experimentalUseNavigator as useNavigator,
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
@@ -41,7 +40,7 @@ export default function SidebarNavigationScreen( {
 		};
 	}, [] );
 	const { getTheme } = useSelect( coreStore );
-	const { goTo } = useNavigator();
+	const navigator = useNavigator();
 	const theme = getTheme( currentlyPreviewingTheme() );
 	const icon = isRTL() ? chevronRight : chevronLeft;
 
@@ -58,16 +57,24 @@ export default function SidebarNavigationScreen( {
 					className="edit-site-sidebar-navigation-screen__title-icon"
 				>
 					{ ! isRoot && ! backPath && (
-						<NavigatorToParentButton
-							as={ SidebarButton }
-							icon={ isRTL() ? chevronRight : chevronLeft }
+						<SidebarButton
+							onClick={ () => {
+								if ( navigator.location.isInitial ) {
+									navigator.goToParent( { replace: true } );
+								} else {
+									navigator.goBack();
+								}
+							} }
+							icon={ icon }
 							label={ __( 'Back' ) }
 							showTooltip={ false }
 						/>
 					) }
 					{ ! isRoot && backPath && (
 						<SidebarButton
-							onClick={ () => goTo( backPath, { isBack: true } ) }
+							onClick={ () =>
+								navigator.goTo( backPath, { isBack: true } )
+							}
 							icon={ icon }
 							label={ __( 'Back' ) }
 							showTooltip={ false }


### PR DESCRIPTION
## What?
Fixes https://github.com/WordPress/gutenberg/issues/50676.

Adjusts the back button in the site editor (left) sidebar to go _back_ to the previously seen screen if possible instead of _up_ to the parent page in the hierarchy.

## Why?
Going _up_ results in confusing flows for users. For example, if you select Pages → 404 and then press the back button you'll be taken to _Templates_ instead of _Pages_. See https://github.com/WordPress/gutenberg/issues/50676#issuecomment-1623368281 for a complete list of the currently confusing flows.

I strongly recommend reading the discussion in https://github.com/WordPress/gutenberg/issues/50676.

## How?
- Navigation screen changes:
  - Call `goBack()` if there is an item to go back to instead of `goToParent()`
  - Fix bug where `goTo()` is called twice: once when user clicks button, and then again when browser URL changes
- `Navigator` changes:
  - ~Add `hasBack` property which is true when `goBack()` will do something~
  - ~Reset navigation history when `goToParent()` is called or when `isBack` is passed to `goTo()`~
  - Allow `{ replace: true }` to be passed to `goTo()` or `goToParent()`. This results in a new history item not being created

## Testing Instructions
1. Go to Appearance → Editor.
2. Go to Pages → 404.
3. Press the back button.
4. You should return to Pages.
1. Repeat with all of the flows described in https://github.com/WordPress/gutenberg/issues/50676#issuecomment-1623368281. In each, clicking back should return you to the previous screen.
5. Simulate navigating directly to a page or template by e.g. clicking Templates → Page and then refreshing the browser.
6. Press the back button.
7. You should return to Templates as that is is the canonical parent.