### PR TITLE
add sync tooltip

### DIFF
--- a/packages/edit-site/src/components/page-patterns/grid-item.js
+++ b/packages/edit-site/src/components/page-patterns/grid-item.js
@@ -173,10 +173,19 @@ function GridItem( { categoryId, item, ...props } ) {
 					className="edit-site-patterns__pattern-title"
 				>
 					{ itemIcon && (
-						<Icon
-							className="edit-site-patterns__pattern-icon"
-							icon={ itemIcon }
-						/>
+						<Tooltip
+							position="top center"
+							text={ __(
+								'Editing this pattern will also update anywhere it is used'
+							) }
+						>
+							<span>
+								<Icon
+									className="edit-site-patterns__pattern-icon"
+									icon={ itemIcon }
+								/>
+							</span>
+						</Tooltip>
 					) }
 					<Flex as="span" gap={ 0 } justify="left">
 						{ item.title }


### PR DESCRIPTION

<img width="509" alt="image" src="https://github.com/WordPress/gutenberg/assets/1072756/05321363-f6a4-42a3-a618-9746e122250c">


## What?
Adds a tooltip to the sync icon for patterns.

## Why?
Add slightly more context around what the icon means.

## How?
Wraps icon in Tooltip component

## Testing Instructions
1. Open site editor
2. Open patterns
3. Go to my patterns or template parts category
4. Hover over sync icon and notice tooltip
