### PR TITLE
Update Dashboard button tooltips in the site editor

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen/index.js
@@ -78,7 +78,7 @@ export default function SidebarNavigationScreen( {
 							icon={ icon }
 							label={
 								! isPreviewingTheme()
-									? __( 'Go back to the Dashboard' )
+									? __( 'Go to the Dashboard' )
 									: __( 'Go back to the theme showcase' )
 							}
 							href={

--- a/packages/edit-site/src/components/site-hub/index.js
+++ b/packages/edit-site/src/components/site-hub/index.js
@@ -57,7 +57,7 @@ const SiteHub = forwardRef( ( props, ref ) => {
 	const siteIconButtonProps = isBackToDashboardButton
 		? {
 				href: dashboardLink,
-				label: __( 'Go back to the Dashboard' ),
+				label: __( 'Go to the Dashboard' ),
 		  }
 		: {
 				href: dashboardLink, // We need to keep the `href` here so the component doesn't remount as a `<button>` and break the animation.


### PR DESCRIPTION
## What?
Update the tooltip to say "Go to the Dashboard" rather than "Go **back** to the Dashboard".

## Why?
"Back" implies that you originally came from the Dashboard which may not be the case. You may have entered the editor via the admin bar on the frontend, or by clicking a direct link. 

## How?
Update text string.

## Testing Instructions
* Enter the Site Editor.
* Mouse over or focus the `<` button at the Design level of navigation.
* Observe the tooltip reads "Go to the Dashboard".
* Mouse over or focus the site icon button.
* Observe the tooltip reads "Go to the Dashboard".

## Screenshots or screencast <!-- if applicable -->

<img width="358" alt="Screenshot 2023-07-10 at 11 14 09" src="https://github.com/WordPress/gutenberg/assets/846565/04d3734a-0da8-47db-b49b-e77c544c6ad4">

