### PR TITLE
[WIP] Allow setting allowedBlocks on Navigation block via attribute

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -422,7 +422,7 @@ A collection of blocks that allow visitors to get around your site. ([Source](ht
 -	**Name:** core/navigation
 -	**Category:** theme
 -	**Supports:** align (full, wide), inserter, interactivity, layout (allowSizingOnChildren, default, ~~allowInheriting~~, ~~allowSwitching~~, ~~allowVerticalAlignment~~), spacing (blockGap, units), typography (fontSize, lineHeight), ~~html~~
--	**Attributes:** __unstableLocation, backgroundColor, customBackgroundColor, customOverlayBackgroundColor, customOverlayTextColor, customTextColor, hasIcon, icon, maxNestingLevel, openSubmenusOnClick, overlayBackgroundColor, overlayMenu, overlayTextColor, ref, rgbBackgroundColor, rgbTextColor, showSubmenuIcon, templateLock, textColor
+-	**Attributes:** __unstableLocation, allowedBlocks, backgroundColor, customBackgroundColor, customOverlayBackgroundColor, customOverlayTextColor, customTextColor, hasIcon, icon, maxNestingLevel, openSubmenusOnClick, overlayBackgroundColor, overlayMenu, overlayTextColor, ref, rgbBackgroundColor, rgbTextColor, showSubmenuIcon, templateLock, textColor
 
 ## Custom Link
 

--- a/packages/block-library/src/navigation/block.json
+++ b/packages/block-library/src/navigation/block.json
@@ -71,6 +71,9 @@
 		"templateLock": {
 			"type": [ "string", "boolean" ],
 			"enum": [ "all", "insert", "contentOnly", false ]
+		},
+		"allowedBlocks": {
+			"type": "array"
 		}
 	},
 	"providesContext": {

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -69,6 +69,8 @@ import ManageMenusButton from './manage-menus-button';
 import MenuInspectorControls from './menu-inspector-controls';
 import DeletedNavigationWarning from './deleted-navigation-warning';
 import { unlock } from '../../lock-unlock';
+import { ALLOWED_BLOCKS } from '../constants';
+
 const { useBlockEditingMode } = unlock( blockEditorPrivateApis );
 
 function Navigation( {
@@ -103,6 +105,7 @@ function Navigation( {
 		} = {},
 		hasIcon,
 		icon = 'handle',
+		allowedBlocks = ALLOWED_BLOCKS,
 	} = attributes;
 
 	const ref = attributes.ref;
@@ -675,6 +678,7 @@ function Navigation( {
 						createNavigationMenu={ createNavigationMenu }
 						blocks={ uncontrolledInnerBlocks }
 						hasSelection={ isSelected || isInnerBlockSelected }
+						allowedBlocks={ allowedBlocks }
 					/>
 				</ResponsiveWrapper>
 			</TagName>
@@ -830,6 +834,7 @@ function Navigation( {
 									}
 									templateLock={ templateLock }
 									orientation={ orientation }
+									allowedBlocks={ allowedBlocks }
 								/>
 							) }
 						</ResponsiveWrapper>

--- a/packages/block-library/src/navigation/edit/inner-blocks.js
+++ b/packages/block-library/src/navigation/edit/inner-blocks.js
@@ -14,17 +14,14 @@ import { useMemo } from '@wordpress/element';
  * Internal dependencies
  */
 import PlaceholderPreview from './placeholder/placeholder-preview';
-import {
-	DEFAULT_BLOCK,
-	ALLOWED_BLOCKS,
-	PRIORITIZED_INSERTER_BLOCKS,
-} from '../constants';
+import { DEFAULT_BLOCK, PRIORITIZED_INSERTER_BLOCKS } from '../constants';
 
 export default function NavigationInnerBlocks( {
 	clientId,
 	hasCustomPlaceholder,
 	orientation,
 	templateLock,
+	allowedBlocks,
 } ) {
 	const {
 		isImmediateParentOfSelectedBlock,
@@ -96,7 +93,7 @@ export default function NavigationInnerBlocks( {
 			value: blocks,
 			onInput,
 			onChange,
-			allowedBlocks: ALLOWED_BLOCKS,
+			allowedBlocks,
 			prioritizedInserterBlocks: PRIORITIZED_INSERTER_BLOCKS,
 			__experimentalDefaultBlock: DEFAULT_BLOCK,
 			__experimentalDirectInsert: shouldDirectInsert,

--- a/packages/block-library/src/navigation/edit/unsaved-inner-blocks.js
+++ b/packages/block-library/src/navigation/edit/unsaved-inner-blocks.js
@@ -11,11 +11,7 @@ import { useContext, useEffect, useRef, useMemo } from '@wordpress/element';
  * Internal dependencies
  */
 import { areBlocksDirty } from './are-blocks-dirty';
-import {
-	DEFAULT_BLOCK,
-	ALLOWED_BLOCKS,
-	SELECT_NAVIGATION_MENUS_ARGS,
-} from '../constants';
+import { DEFAULT_BLOCK, SELECT_NAVIGATION_MENUS_ARGS } from '../constants';
 
 const EMPTY_OBJECT = {};
 
@@ -23,6 +19,7 @@ export default function UnsavedInnerBlocks( {
 	blocks,
 	createNavigationMenu,
 	hasSelection,
+	allowedBlocks,
 } ) {
 	const originalBlocks = useRef();
 
@@ -67,7 +64,7 @@ export default function UnsavedInnerBlocks( {
 		},
 		{
 			renderAppender: hasSelection ? undefined : false,
-			allowedBlocks: ALLOWED_BLOCKS,
+			allowedBlocks,
 			__experimentalDefaultBlock: DEFAULT_BLOCK,
 			__experimentalDirectInsert: shouldDirectInsert,
 		}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

PoC for allowing setting a set of allowed blocks on the Nav block using an attribute `allowedBlocks.

Closes https://github.com/WordPress/gutenberg/issues/31387


## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Because people want to customise the Nav block. See https://github.com/WordPress/gutenberg/issues/31387.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Following existing examples such as https://github.com/WordPress/gutenberg/pull/49128.

## Problems

The current issue with this approach is that unlike many blocks,[ the Nav block _actively_ manages it's inner blocks on server side render](https://github.com/WordPress/gutenberg/blob/01b527dae85f2e19adcc23e102cf5b9b37f163b3/packages/block-library/src/navigation/index.php#L617).

So instead of just "render these inner blocks" the Nav block will loop over the inner blocks and actively manage their markup. I believe this is for accessibility reasons.

There's probably a good case for moving away from this approach but that would need to be a seperate PR.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

- New Post
- Open code view of editor
- Add the following:
```
<!-- wp:navigation {"allowedBlocks":["core/group","core/navigation-link","core/image"]} /-->
```
- Go back to visual mode.
- You can now add Group and Image blocks.
- Test on front of site to see how this breaks the markup as described in `Problems` above.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
