### PR TITLE
Update descriptions in Pattern library

### DIFF
--- a/packages/edit-site/src/components/page-patterns/patterns-list.js
+++ b/packages/edit-site/src/components/page-patterns/patterns-list.js
@@ -40,10 +40,10 @@ const SYNC_FILTERS = {
 const SYNC_DESCRIPTIONS = {
 	all: '',
 	[ SYNC_TYPES.full ]: __(
-		'Patterns that are kept in sync across your site.'
+		'Patterns that are kept in sync across the site.'
 	),
 	[ SYNC_TYPES.unsynced ]: __(
-		'Patterns that can be changed freely without affecting your site.'
+		'Patterns that can be changed freely without affecting the site.'
 	),
 };
 


### PR DESCRIPTION
## What?
It looks like a couple of the changes in https://github.com/WordPress/gutenberg/pull/52340 were reverted during https://github.com/WordPress/gutenberg/pull/52303. This PR re-instates them.

## Why?
See https://github.com/WordPress/gutenberg/pull/52340.

## Testing Instructions
In the Pattern library observe the updated descriptions:

| Before | After |
| --- | --- |
| Patterns that are kept in sync across **your** site | Patterns that are kept in sync across **the** site |
| Patterns that can be changed freely without affecting **your** site | Patterns that can be changed freely without affecting **the** site |

