### PR TITLE
Interactivity API: Add JSDoc comments to the public API

### DIFF
--- a/packages/interactivity/CHANGELOG.md
+++ b/packages/interactivity/CHANGELOG.md
@@ -4,7 +4,11 @@
 
 ### Bug Fix
 
-- Add support for underscores and leading dashes in the suffix part of the directive. ([#53337](https://github.com/WordPress/gutenberg/pull/53337))
+-   Add support for underscores and leading dashes in the suffix part of the directive. ([#53337](https://github.com/WordPress/gutenberg/pull/53337))
+
+### Enhancements
+
+-   Add JSDoc comments to `store()` and `directive()` functions. ([#52469](https://github.com/WordPress/gutenberg/pull/52469))
 
 ### Breaking Change
 

--- a/packages/interactivity/src/hooks.js
+++ b/packages/interactivity/src/hooks.js
@@ -8,7 +8,7 @@ import { useRef, useCallback } from 'preact/hooks';
  */
 import { rawStore as store } from './store';
 
-/** @typedef {import('preact').VNode} Element */
+/** @typedef {import('preact').VNode} VNode */
 /** @typedef {typeof context} Context */
 /** @typedef {ReturnType<typeof getEvaluate>} Evaluate */
 
@@ -16,7 +16,7 @@ import { rawStore as store } from './store';
  * @typedef {Object} DirectiveCallbackParams Callback parameters.
  * @property {Object}   directives Object map with the defined directives of the element being evaluated.
  * @property {Object}   props      Props present in the current element.
- * @property {Element}  element    Virtual node representing the original element.
+ * @property {VNode}    element    Virtual node representing the original element.
  * @property {Context}  context    The inherited context.
  * @property {Evaluate} evaluate   Function that resolves a given path to a value either in the store or the context.
  */

--- a/packages/interactivity/src/hooks.js
+++ b/packages/interactivity/src/hooks.js
@@ -8,12 +8,69 @@ import { useRef, useCallback } from 'preact/hooks';
  */
 import { rawStore as store } from './store';
 
+/** @typedef {import('preact').VNode} Element */
+/** @typedef {typeof context} Context */
+/** @typedef {ReturnType<typeof getEvaluate>} Evaluate */
+
+/**
+ * @typedef {Object} DirectiveCallbackParams Callback parameters.
+ * @property {Object}   directives Object map with the defined directives of the element being evaluated.
+ * @property {Object}   props      Props present in the current element.
+ * @property {Element}  element    Virtual node representing the original element.
+ * @property {Context}  context    The inherited context.
+ * @property {Evaluate} evaluate   Function that resolves a given path to a value either in the store or the context.
+ */
+
+/**
+ * @callback DirectiveCallback Callback that runs the directive logic.
+ * @param {DirectiveCallbackParams} params Callback parameters.
+ */
+
+/**
+ * @typedef DirectiveOptions Options object.
+ * @property {number} [priority=10] Value that specifies the priority to
+ *                                  evaluate directives of this type. Lower
+ *                                  numbers correspond with earlier execution.
+ *                                  Default is `10`.
+ */
+
 // Main context.
 const context = createContext( {} );
 
 // WordPress Directives.
 const directiveCallbacks = {};
 const directivePriorities = {};
+
+/**
+ * Register a new directive type in the Interactivity API runtime.
+ *
+ * @example
+ * ```js
+ * directive(
+ *   'alert', // Name without the `data-wp-` prefix.
+ *   ( { directives: { alert }, element, evaluate }) => {
+ *     element.props.onClick = () => {
+ *       alert( evaluate( alert.default ) );
+ *     }
+ *   }
+ * )
+ * ```
+ *
+ * The previous code register a custom directive type for displaying an alert
+ * message whenever an element using it is clicked. The message text is obtained
+ * from the store using `evaluate`.
+ *
+ * When the HTML is processed by the Interactivity API, any element containing
+ * the `data-wp-alert` directive will have the `onClick` event handler, e.g.,
+ *
+ * ```html
+ * <button data-wp-alert="state.messages.alert">Click me!</button>
+ * ```
+ *
+ * @param {string}            name     Directive name, without the `data-wp-` prefix.
+ * @param {DirectiveCallback} callback Function that runs the directive logic.
+ * @param {DirectiveOptions=} options  Options object.
+ */
 export const directive = ( name, callback, { priority = 10 } = {} ) => {
 	directiveCallbacks[ name ] = callback;
 	directivePriorities[ name ] = priority;

--- a/packages/interactivity/src/hooks.js
+++ b/packages/interactivity/src/hooks.js
@@ -66,6 +66,41 @@ const directivePriorities = {};
  * ```html
  * <button data-wp-alert="state.messages.alert">Click me!</button>
  * ```
+ * Note that, in the previous example, you acces `alert.default` in order to
+ * retrieve the `state.messages.alert` value passed to the directive. You can
+ * also define custom names by appending `--` to the directive attribute,
+ * followed by a suffix, like in the following HTML snippet:
+ *
+ * ```html
+ * <button
+ *   data-wp-color--text="state.theme.text"
+ *   data-wp-color--background="state.theme.background"
+ * >Click me!</button>
+ * ```
+ *
+ * This could be an hypothetical implementation of the custom directive used in
+ * the snippet above.
+ *
+ * @example
+ * ```js
+ * directive(
+ *   'color', // Name without prefix and suffix.
+ *   ( { directives: { color }, ref, evaluate }) => {
+ *     if ( color.text ) {
+ * 	     ref.style.setProperty(
+ *         'color',
+ *         evaluate( color.text )
+ *       );
+ *     }
+ *     if ( color.background ) {
+ *       ref.style.setProperty(
+ *         'background-color',
+ *         evaluate( color.background )
+ *       );
+ *     }
+ *   }
+ * )
+ * ```
  *
  * @param {string}            name     Directive name, without the `data-wp-` prefix.
  * @param {DirectiveCallback} callback Function that runs the directive logic.

--- a/packages/interactivity/src/hooks.js
+++ b/packages/interactivity/src/hooks.js
@@ -56,7 +56,7 @@ const directivePriorities = {};
  * )
  * ```
  *
- * The previous code register a custom directive type for displaying an alert
+ * The previous code registers a custom directive type for displaying an alert
  * message whenever an element using it is clicked. The message text is obtained
  * from the store using `evaluate`.
  *
@@ -66,7 +66,7 @@ const directivePriorities = {};
  * ```html
  * <button data-wp-alert="state.messages.alert">Click me!</button>
  * ```
- * Note that, in the previous example, you acces `alert.default` in order to
+ * Note that, in the previous example, you access `alert.default` in order to
  * retrieve the `state.messages.alert` value passed to the directive. You can
  * also define custom names by appending `--` to the directive attribute,
  * followed by a suffix, like in the following HTML snippet:

--- a/packages/interactivity/src/hooks.js
+++ b/packages/interactivity/src/hooks.js
@@ -49,7 +49,7 @@ const directivePriorities = {};
  * directive(
  *   'alert', // Name without the `data-wp-` prefix.
  *   ( { directives: { alert }, element, evaluate }) => {
- *     element.props.onClick = () => {
+ *     element.props.onclick = () => {
  *       alert( evaluate( alert.default ) );
  *     }
  *   }

--- a/packages/interactivity/src/hooks.js
+++ b/packages/interactivity/src/hooks.js
@@ -61,7 +61,7 @@ const directivePriorities = {};
  * from the store using `evaluate`.
  *
  * When the HTML is processed by the Interactivity API, any element containing
- * the `data-wp-alert` directive will have the `onClick` event handler, e.g.,
+ * the `data-wp-alert` directive will have the `onclick` event handler, e.g.,
  *
  * ```html
  * <button data-wp-alert="state.messages.alert">Click me!</button>

--- a/packages/interactivity/src/store.js
+++ b/packages/interactivity/src/store.js
@@ -38,6 +38,35 @@ const getSerializedState = () => {
 const rawState = getSerializedState();
 export const rawStore = { state: deepSignal( rawState ) };
 
+/**
+ * Extends the global store with the passed properties. These props tipically
+ * consist of `state`, `actions` and `effects` used by interactive blocks, and
+ * any of them may be accessed by any directive present in the page.
+ *
+ * @example
+ * ```js
+ *  store({
+ *    state: {
+ *      favoriteMovies: [],
+ *    },
+ *    actions: {
+ *      addMovie: ({ state, context }) => {
+ *        // We assume that there is a `wp-context` directive
+ *        // on the block which provides the item ID.
+ *        state.favoriteMovies.push(context.item.id);
+ *      },
+ *      clearFavoriteMovies: ({ state }) => {
+ *        state.favoriteMovies = [];
+ *      },
+ *    },
+ *  });
+ * ```
+ *
+ * @param {Object} properties           Properties to be added to the global store.
+ * @param {Object} [properties.state]   State to be added to the global store.
+ * @param {Object} [properties.actions] Actions to be added to the global store.
+ * @param {Object} [properties.effects] Effects to be added to the global store.
+ */
 export const store = ( { state, ...block } ) => {
 	deepMerge( rawStore, block );
 	deepMerge( rawState, state );

--- a/packages/interactivity/src/store.js
+++ b/packages/interactivity/src/store.js
@@ -39,9 +39,10 @@ const rawState = getSerializedState();
 export const rawStore = { state: deepSignal( rawState ) };
 
 /**
- * Extends the global store with the passed properties. These props tipically
- * consist of `state`, `selectors` and `actions` used by interactive blocks, and
- * any of them may be accessed by any directive present in the page.
+ * Extends the Interactivity API global store with the passed properties.
+ *
+ * These props tipically consist of `state`, `selectors` and `actions` that can
+ * be used by any directive, making the HTML reactive and interactive.
  *
  * @example
  * ```js

--- a/packages/interactivity/src/store.js
+++ b/packages/interactivity/src/store.js
@@ -40,32 +40,43 @@ export const rawStore = { state: deepSignal( rawState ) };
 
 /**
  * Extends the global store with the passed properties. These props tipically
- * consist of `state`, `actions` and `effects` used by interactive blocks, and
+ * consist of `state`, `selectors` and `actions` used by interactive blocks, and
  * any of them may be accessed by any directive present in the page.
  *
  * @example
  * ```js
  *  store({
  *    state: {
- *      favoriteMovies: [],
+ *      counter: { value: 0 },
  *    },
  *    actions: {
- *      addMovie: ({ state, context }) => {
- *        // We assume that there is a `wp-context` directive
- *        // on the block which provides the item ID.
- *        state.favoriteMovies.push(context.item.id);
- *      },
- *      clearFavoriteMovies: ({ state }) => {
- *        state.favoriteMovies = [];
+ *      counter: {
+ *        increment: ({ state }) => {
+ *          state.counter.value += 1;
+ *        },
  *      },
  *    },
  *  });
  * ```
  *
- * @param {Object} properties           Properties to be added to the global store.
- * @param {Object} [properties.state]   State to be added to the global store.
- * @param {Object} [properties.actions] Actions to be added to the global store.
- * @param {Object} [properties.effects] Effects to be added to the global store.
+ * The code from the example above allows blocks to subscribe and interact with
+ * the store by using directives in the HTML, e.g.:
+ *
+ * ```html
+ * <div data-wp-interactive>
+ *   <button
+ *     data-wp-text="state.counter.value"
+ *     data-wp-on--click="actions.counter.increment"
+ *   >
+ *     0
+ *   </button>
+ * </div>
+ * ```
+ *
+ * @param {Object} properties             Properties to be added to the global store.
+ * @param {Object} [properties.state]     State to be added to the global store.
+ * @param {Object} [properties.selectors] Selectors to be added to the global store.
+ * @param {Object} [properties.actions]   Actions to be added to the global store.
  */
 export const store = ( { state, ...block } ) => {
 	deepMerge( rawStore, block );

--- a/packages/interactivity/src/store.js
+++ b/packages/interactivity/src/store.js
@@ -41,8 +41,10 @@ export const rawStore = { state: deepSignal( rawState ) };
 /**
  * Extends the Interactivity API global store with the passed properties.
  *
- * These props tipically consist of `state`, `selectors` and `actions` that can
- * be used by any directive, making the HTML reactive and interactive.
+ * These props typically consist of `state`, which is reactive, and other
+ * properties like `selectors`, `actions`, `effects`, etc. which can store
+ * callbacks and derived state. These props can then be referenced by any
+ * directive to make the HTML interactive.
  *
  * @example
  * ```js

--- a/packages/interactivity/src/store.js
+++ b/packages/interactivity/src/store.js
@@ -79,7 +79,6 @@ export const rawStore = { state: deepSignal( rawState ) };
  * @param {Object} properties         Properties to be added to the global store.
  * @param {Object} [properties.state] State to be added to the global store. All
  *                                    the properties included here become reactive.
- * @param {Object} [properties.block] Other properties to be added to the global store.
  */
 export const store = ( { state, ...block } ) => {
 	deepMerge( rawStore, block );

--- a/packages/interactivity/src/store.js
+++ b/packages/interactivity/src/store.js
@@ -76,8 +76,6 @@ export const rawStore = { state: deepSignal( rawState ) };
  *
  * @param {Object} properties             Properties to be added to the global store.
  * @param {Object} [properties.state]     State to be added to the global store.
- * @param {Object} [properties.selectors] Selectors to be added to the global store.
- * @param {Object} [properties.actions]   Actions to be added to the global store.
  */
 export const store = ( { state, ...block } ) => {
 	deepMerge( rawStore, block );

--- a/packages/interactivity/src/store.js
+++ b/packages/interactivity/src/store.js
@@ -76,8 +76,10 @@ export const rawStore = { state: deepSignal( rawState ) };
  * </div>
  * ```
  *
- * @param {Object} properties             Properties to be added to the global store.
- * @param {Object} [properties.state]     State to be added to the global store.
+ * @param {Object} properties         Properties to be added to the global store.
+ * @param {Object} [properties.state] State to be added to the global store. All
+ *                                    the properties included here become reactive.
+ * @param {Object} [properties.block] Other properties to be added to the global store.
  */
 export const store = ( { state, ...block } ) => {
 	deepMerge( rawStore, block );


### PR DESCRIPTION
## What?

Adds JSDoc comments to the `store` and `directive` functions, which are currently the public part of the Interactivity API.

## Why?

To start documenting the Interactivity API.

## How?

I followed the format used for other JSDoc comments in the repository. I added basic support for typing, but it is very preliminary and not meant to be fully compatible with TypeScript yet.