### PR TITLE
List block: Fix selected numbering style option

### DIFF
--- a/packages/block-library/src/list/edit.js
+++ b/packages/block-library/src/list/edit.js
@@ -177,10 +177,12 @@ export default function Edit( { attributes, setAttributes, clientId, style } ) {
 			{ controls }
 			{ ordered && (
 				<OrderedListSettings
-					setAttributes={ setAttributes }
-					ordered={ ordered }
-					reversed={ reversed }
-					start={ start }
+					{ ...{
+						setAttributes,
+						reversed,
+						start,
+						type,
+					} }
 				/>
 			) }
 		</>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
The editor doesn't show the selected numbering type when the editor is selected.

Follow-up on #51186.

## Why?
The selected numbering type should be shown when opening the settings panel.

## How?
Add the missing `type` attribute to the `OrderedListSettings` view.

## Testing Instructions
1. Insert a list block and add some bullet points.
2. Make the list a numbering list
3. Select a different numbering.
4. Save the post and refresh the editor.
5. Select the list block and check that the numbering style is the one you selected.

## Screenshots or screencast <!-- if applicable -->
| Before | After |
|-----|-----|
|![list-trunk](https://github.com/WordPress/gutenberg/assets/1415747/9dd61f4b-9b94-4d3f-a7ab-b657a1275e3b)|![list-fixed](https://github.com/WordPress/gutenberg/assets/1415747/c6c5d3fa-cac1-483f-bf50-a60da66f9bba)|
