### PR TITLE
Ensure that the unsaved title is not persisted when reopening the modal

### DIFF
--- a/packages/edit-site/src/components/template-actions/rename-menu-item.js
+++ b/packages/edit-site/src/components/template-actions/rename-menu-item.js
@@ -17,10 +17,8 @@ import { store as noticesStore } from '@wordpress/notices';
 import { decodeEntities } from '@wordpress/html-entities';
 
 export default function RenameMenuItem( { template, onClose } ) {
-	const [ title, setTitle ] = useState(
-		decodeEntities( template.title.rendered )
-	);
-
+	const title = decodeEntities( template.title.rendered );
+	const [ editedTitle, setEditedTitle ] = useState( title );
 	const [ isModalOpen, setIsModalOpen ] = useState( false );
 
 	const {
@@ -39,11 +37,11 @@ export default function RenameMenuItem( { template, onClose } ) {
 
 		try {
 			await editEntityRecord( 'postType', template.type, template.id, {
-				title,
+				title: editedTitle,
 			} );
 
 			// Update state before saving rerenders the list.
-			setTitle( '' );
+			setEditedTitle( '' );
 			setIsModalOpen( false );
 			onClose();
 
@@ -73,7 +71,12 @@ export default function RenameMenuItem( { template, onClose } ) {
 
 	return (
 		<>
-			<MenuItem onClick={ () => setIsModalOpen( true ) }>
+			<MenuItem
+				onClick={ () => {
+					setIsModalOpen( true );
+					setEditedTitle( title );
+				} }
+			>
 				{ __( 'Rename' ) }
 			</MenuItem>
 			{ isModalOpen && (
@@ -89,8 +92,8 @@ export default function RenameMenuItem( { template, onClose } ) {
 							<TextControl
 								__nextHasNoMarginBottom
 								label={ __( 'Name' ) }
-								value={ title }
-								onChange={ setTitle }
+								value={ editedTitle }
+								onChange={ setEditedTitle }
 								required
 							/>
 


### PR DESCRIPTION
Props to @tellthemachines for pointing this out in [this comment](https://github.com/WordPress/gutenberg/pull/52449#discussion_r1257758084).

## What?
This PR fixes the issue caused by #52449 where the unsaved title is persisted when reopening a renaming template/part modal.

## How?
As well as correcting the problem, I have made it easier to see if the title was edited or before it was edited.

- Hold the decoded `template.title.rendered` in the `title` variable
- Changed `title` to `editedTitle` for the title being edited.
- Changed `setTitle` to `setEditedTitle` for the dispatch action to change the title

This naming convention is similar to [the navigation renaming process](https://github.com/WordPress/gutenberg/blob/70215589cd2510a9881286d36aa48e41e19d06ac/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/rename-modal.js#L17).

## Testing Instructions

- Attempts to rename the template.
- Change the title in the rename modal and press the Cancel button.
- Click "Rename" in the dropdown that **is still open**.
- Trunk: The changed title should be retained
- This PR: It should show the title before it was changed

## Screenshots or screencast <!-- if applicable -->

### Before

https://github.com/WordPress/gutenberg/assets/54422211/196ca8e6-3e3e-4d3e-93d3-eb91ade33e28

### After

https://github.com/WordPress/gutenberg/assets/54422211/8e0146f9-77c4-4a54-8791-5fdd6c5a5762
