### PR TITLE
Add missing `@emotion/react` dep to block-editor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17259,6 +17259,7 @@
 			"version": "file:packages/block-editor",
 			"requires": {
 				"@babel/runtime": "^7.16.0",
+				"@emotion/react": "^11.7.1",
 				"@emotion/styled": "^11.6.0",
 				"@react-spring/web": "^9.4.5",
 				"@wordpress/a11y": "file:packages/a11y",

--- a/packages/block-editor/package.json
+++ b/packages/block-editor/package.json
@@ -32,6 +32,7 @@
 	],
 	"dependencies": {
 		"@babel/runtime": "^7.16.0",
+		"@emotion/react": "^11.7.1",
 		"@emotion/styled": "^11.6.0",
 		"@react-spring/web": "^9.4.5",
 		"@wordpress/a11y": "file:../a11y",


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Add a missing dependency on `@emotion/react` from block-editor.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
PR #51545 added a dependency on `@emotion/styled`, which resulted in a transitive peer dependency on `@emotion/react`. We should satisfy that dependency ourself, just as we do in the components package.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Add the missing dep.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
Fixes #52474. See reproduction steps there.