### PR TITLE
Template Parts: Add further details to template part panel

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen-details-panel/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-details-panel/style.scss
@@ -18,6 +18,7 @@
 .edit-site-sidebar-navigation-details-screen-panel__label.edit-site-sidebar-navigation-details-screen-panel__label {
 	color: $gray-600;
 	width: 100px;
+	flex-shrink: 0;
 }
 
 .edit-site-sidebar-navigation-details-screen-panel__value.edit-site-sidebar-navigation-details-screen-panel__value {

--- a/packages/edit-site/src/components/sidebar-navigation-screen-pattern/use-pattern-details.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-pattern/use-pattern-details.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __, sprintf, _x } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { store as coreStore } from '@wordpress/core-data';
 import { store as editorStore } from '@wordpress/editor';
 import { useSelect } from '@wordpress/data';
@@ -112,9 +112,7 @@ export default function usePatternDetails( postType, postId ) {
 			label: __( 'Customized' ),
 			value: (
 				<span className="edit-site-sidebar-navigation-screen-pattern__added-by-description-customized">
-					{ addedBy.isCustomized
-						? _x( 'Yes', 'pattern' )
-						: _x( 'No', 'pattern' ) }
+					{ addedBy.isCustomized ? __( 'Yes' ) : __( 'No' ) }
 				</span>
 			),
 		} );

--- a/packages/edit-site/src/components/sidebar-navigation-screen-pattern/use-pattern-details.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-pattern/use-pattern-details.js
@@ -4,7 +4,6 @@
 import { __, sprintf, _x } from '@wordpress/i18n';
 import { store as coreStore } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
-import { Icon } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -54,37 +53,7 @@ export default function usePatternDetails( postType, postId ) {
 		);
 	}
 
-	const description = (
-		<>
-			{ descriptionText }
-
-			{ addedBy.text && ! isAddedByActiveTheme && (
-				<span className="edit-site-sidebar-navigation-screen-pattern__added-by-description">
-					<span className="edit-site-sidebar-navigation-screen-pattern__added-by-description-author">
-						<span className="edit-site-sidebar-navigation-screen-pattern__added-by-description-author-icon">
-							{ addedBy.imageUrl ? (
-								<img
-									src={ addedBy.imageUrl }
-									alt=""
-									width="24"
-									height="24"
-								/>
-							) : (
-								<Icon icon={ addedBy.icon } />
-							) }
-						</span>
-						{ addedBy.text }
-					</span>
-
-					{ addedBy.isCustomized && (
-						<span className="edit-site-sidebar-navigation-screen-pattern__added-by-description-customized">
-							{ _x( '(Customized)', 'pattern' ) }
-						</span>
-					) }
-				</span>
-			) }
-		</>
-	);
+	const description = <>{ descriptionText }</>;
 
 	const footer = !! record?.modified ? (
 		<SidebarNavigationScreenDetailsFooter
@@ -94,13 +63,67 @@ export default function usePatternDetails( postType, postId ) {
 
 	const details = [];
 
-	if ( postType === 'wp_block' ) {
+	if ( postType === 'wp_block' || 'wp_template_part' ) {
 		details.push( {
 			label: __( 'Syncing' ),
 			value:
 				record.wp_pattern_sync_status === 'unsynced'
 					? __( 'Not synced' )
 					: __( 'Fully synced' ),
+		} );
+	}
+
+	const templatePartAreaLabels = {
+		header: __( 'Header' ),
+		footer: __( 'Footer' ),
+		sidebar: __( 'Sidebar' ),
+		uncategorized: __( 'General' ),
+	};
+
+	if ( postType === 'wp_template_part' ) {
+		details.push( {
+			label: __( 'Area' ),
+			value: templatePartAreaLabels[ record.area ],
+		} );
+	}
+
+	if (
+		postType === 'wp_template_part' &&
+		addedBy.text &&
+		! isAddedByActiveTheme
+	) {
+		details.push( {
+			label: __( 'Added by' ),
+			value: (
+				<>
+					<span className="edit-site-sidebar-navigation-screen-pattern__added-by-description-author">
+						{ addedBy.text }
+					</span>
+				</>
+			),
+		} );
+	}
+
+	if (
+		postType === 'wp_template_part' &&
+		addedBy.text &&
+		( record.origin === 'plugin' || record.has_theme_file === true )
+	) {
+		details.push( {
+			label: __( 'Customized' ),
+			value: (
+				<>
+					{ addedBy.isCustomized ? (
+						<span className="edit-site-sidebar-navigation-screen-pattern__added-by-description-customized">
+							{ _x( 'Yes', 'pattern' ) }
+						</span>
+					) : (
+						<span className="edit-site-sidebar-navigation-screen-pattern__added-by-description-customized">
+							{ _x( 'No', 'pattern' ) }
+						</span>
+					) }
+				</>
+			),
 		} );
 	}
 

--- a/packages/edit-site/src/components/sidebar-navigation-screen-pattern/use-pattern-details.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-pattern/use-pattern-details.js
@@ -35,25 +35,23 @@ export default function usePatternDetails( postType, postId ) {
 	const isAddedByActiveTheme =
 		addedBy.type === 'theme' && record.theme === currentTheme?.stylesheet;
 	const title = getTitle();
-	let descriptionText = getDescription();
+	let description = getDescription();
 
-	if ( ! descriptionText && addedBy.text ) {
-		descriptionText = sprintf(
+	if ( ! description && addedBy.text ) {
+		description = sprintf(
 			// translators: %s: pattern title e.g: "Header".
 			__( 'This is the %s pattern.' ),
 			getTitle()
 		);
 	}
 
-	if ( ! descriptionText && postType === 'wp_block' && record?.title ) {
-		descriptionText = sprintf(
+	if ( ! description && postType === 'wp_block' && record?.title ) {
+		description = sprintf(
 			// translators: %s: user created pattern title e.g. "Footer".
 			__( 'This is the %s pattern.' ),
 			record.title
 		);
 	}
-
-	const description = <>{ descriptionText }</>;
 
 	const footer = !! record?.modified ? (
 		<SidebarNavigationScreenDetailsFooter
@@ -95,11 +93,9 @@ export default function usePatternDetails( postType, postId ) {
 		details.push( {
 			label: __( 'Added by' ),
 			value: (
-				<>
-					<span className="edit-site-sidebar-navigation-screen-pattern__added-by-description-author">
-						{ addedBy.text }
-					</span>
-				</>
+				<span className="edit-site-sidebar-navigation-screen-pattern__added-by-description-author">
+					{ addedBy.text }
+				</span>
 			),
 		} );
 	}
@@ -112,17 +108,11 @@ export default function usePatternDetails( postType, postId ) {
 		details.push( {
 			label: __( 'Customized' ),
 			value: (
-				<>
-					{ addedBy.isCustomized ? (
-						<span className="edit-site-sidebar-navigation-screen-pattern__added-by-description-customized">
-							{ _x( 'Yes', 'pattern' ) }
-						</span>
-					) : (
-						<span className="edit-site-sidebar-navigation-screen-pattern__added-by-description-customized">
-							{ _x( 'No', 'pattern' ) }
-						</span>
-					) }
-				</>
+				<span className="edit-site-sidebar-navigation-screen-pattern__added-by-description-customized">
+					{ addedBy.isCustomized
+						? _x( 'Yes', 'pattern' )
+						: _x( 'No', 'pattern' ) }
+				</span>
 			),
 		} );
 	}

--- a/packages/edit-site/src/components/sidebar-navigation-screen-pattern/use-pattern-details.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-pattern/use-pattern-details.js
@@ -3,6 +3,7 @@
  */
 import { __, sprintf, _x } from '@wordpress/i18n';
 import { store as coreStore } from '@wordpress/core-data';
+import { store as editorStore } from '@wordpress/editor';
 import { useSelect } from '@wordpress/data';
 
 /**
@@ -26,6 +27,11 @@ export default function usePatternDetails( postType, postId ) {
 	const { getDescription, getTitle, record } = useEditedEntityRecord(
 		postType,
 		postId
+	);
+	const templatePartAreas = useSelect(
+		( select ) =>
+			select( editorStore ).__experimentalGetDefaultTemplatePartAreas(),
+		[]
 	);
 	const currentTheme = useSelect(
 		( select ) => select( coreStore ).getCurrentTheme(),
@@ -71,17 +77,14 @@ export default function usePatternDetails( postType, postId ) {
 		} );
 	}
 
-	const templatePartAreaLabels = {
-		header: __( 'Header' ),
-		footer: __( 'Footer' ),
-		sidebar: __( 'Sidebar' ),
-		uncategorized: __( 'General' ),
-	};
-
 	if ( postType === 'wp_template_part' ) {
+		const templatePartArea = templatePartAreas.find(
+			( area ) => area.area === record.area
+		);
+
 		details.push( {
 			label: __( 'Area' ),
-			value: templatePartAreaLabels[ record.area ],
+			value: templatePartArea?.label,
 		} );
 	}
 

--- a/packages/edit-site/src/components/sidebar-navigation-screen-pattern/use-pattern-details.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-pattern/use-pattern-details.js
@@ -84,7 +84,7 @@ export default function usePatternDetails( postType, postId ) {
 
 		details.push( {
 			label: __( 'Area' ),
-			value: templatePartArea?.label,
+			value: templatePartArea?.label || record.area || __( 'None' ),
 		} );
 	}
 

--- a/packages/edit-site/src/components/sidebar-navigation-screen-pattern/use-pattern-details.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-pattern/use-pattern-details.js
@@ -134,6 +134,7 @@ export default function usePatternDetails( postType, postId ) {
 
 	const content = (
 		<>
+			{ useNavigationMenuContent( postType, postId ) }
 			{ !! details.length && (
 				<SidebarNavigationScreenDetailsPanel
 					spacing={ 5 }
@@ -151,7 +152,6 @@ export default function usePatternDetails( postType, postId ) {
 					) ) }
 				</SidebarNavigationScreenDetailsPanel>
 			) }
-			{ useNavigationMenuContent( postType, postId ) }
 		</>
 	);
 

--- a/packages/edit-site/src/components/sidebar-navigation-screen-pattern/use-pattern-details.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-pattern/use-pattern-details.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { sentenceCase } from 'change-case';
+
+/**
  * WordPress dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
@@ -82,10 +87,19 @@ export default function usePatternDetails( postType, postId ) {
 			( area ) => area.area === record.area
 		);
 
-		details.push( {
-			label: __( 'Area' ),
-			value: templatePartArea?.label || record.area || __( 'None' ),
-		} );
+		let areaDetailValue = templatePartArea?.label;
+
+		if ( ! areaDetailValue ) {
+			areaDetailValue = record.area
+				? sprintf(
+						// translators: %s: Sentenced cased template part area e.g: "My custom area".
+						__( '%s (removed)' ),
+						sentenceCase( record.area )
+				  )
+				: __( 'None' );
+		}
+
+		details.push( { label: __( 'Area' ), value: areaDetailValue } );
 	}
 
 	if (


### PR DESCRIPTION
Fixes #52377

## What?
Add more information to template part detail panels:

* The author for custom template parts.
* The source when template parts are added by a plugin.
* The sync status (template parts are always synced, but the user may not know this).
* Whether a template part that was added by a theme or plugin as been customised.
* The template part area.

## Why?
Template part detail panels can often be a little empty making them feel somewhat superfluous.

Displaying more information here gives the panel purpose, and helps the user better understand the template part they are viewing.

| Before | After |
| --- | --- |
| <img width="359" alt="Screenshot 2023-07-10 at 16 27 24" src="https://github.com/WordPress/gutenberg/assets/846565/c555dc0b-7aec-4d6e-8f94-efbe6fec6e65"> | <img width="360" alt="Screenshot 2023-07-10 at 16 32 06" src="https://github.com/WordPress/gutenberg/assets/846565/05bc33c0-2ddd-404b-8bed-b3faa4d92748"> |


## More examples
| Custom template part | Plugin template part |
| --- | --- |
| <img width="358" alt="Screenshot 2023-07-10 at 16 33 21" src="https://github.com/WordPress/gutenberg/assets/846565/aaec2d5d-a9df-4cb5-be74-bacc8f97a8f4"> | <img width="359" alt="Screenshot 2023-07-10 at 16 33 32" src="https://github.com/WordPress/gutenberg/assets/846565/9cab8e95-8e8c-4818-83a3-9a2c57076290"> |



## Testing Instructions
Browse to the detail panels for the following template parts and observe associated details:

### Custom template part
* Author.
* Area.
* Sync status.

### Theme template part
* Sync status.
* Area.
* Whether the template part has been customized or not.

### Plugin template part
* Sync status.
* Area.
* Source plugin.
* Whether the template part has been customized or not.
