### PR TITLE
Update navigation menu title size & weight in detail panels

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen-pattern/template-part-navigation-menu.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-pattern/template-part-navigation-menu.js
@@ -21,6 +21,7 @@ export default function TemplatePartNavigationMenu( { id } ) {
 				className="edit-site-sidebar-navigation-screen-template-part-navigation-menu__title"
 				size="11"
 				upperCase={ true }
+				weight={ 500 }
 			>
 				{ title?.rendered || title || __( 'Navigation' ) }
 			</Heading>

--- a/packages/edit-site/src/components/sidebar-navigation-screen-pattern/template-part-navigation-menu.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-pattern/template-part-navigation-menu.js
@@ -19,7 +19,7 @@ export default function TemplatePartNavigationMenu( { id } ) {
 		<>
 			<Heading
 				className="edit-site-sidebar-navigation-screen-template-part-navigation-menu__title"
-				size="12"
+				size="11"
 				upperCase={ true }
 			>
 				{ title?.rendered || title || __( 'Navigation' ) }

--- a/packages/edit-site/src/components/sidebar-navigation-screen-pattern/template-part-navigation-menus.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-pattern/template-part-navigation-menus.js
@@ -22,7 +22,7 @@ export default function TemplatePartNavigationMenus( { menus } ) {
 		<>
 			<Heading
 				className="edit-site-sidebar-navigation-screen-template-part-navigation-menu__title"
-				size="12"
+				size="11"
 				upperCase={ true }
 			>
 				{ __( 'Navigation' ) }

--- a/packages/edit-site/src/components/sidebar-navigation-screen-pattern/template-part-navigation-menus.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-pattern/template-part-navigation-menus.js
@@ -24,6 +24,7 @@ export default function TemplatePartNavigationMenus( { menus } ) {
 				className="edit-site-sidebar-navigation-screen-template-part-navigation-menu__title"
 				size="11"
 				upperCase={ true }
+				weight={ 500 }
 			>
 				{ __( 'Navigation' ) }
 			</Heading>


### PR DESCRIPTION
## What?
Update the menu title size & weight in template part detail panels. 

## Why?
Consistency. All other instances of the all-caps label are 11px/500, while this one is currently 12px/600.

## Testing Instructions
1. Add a navigation menu to a template part like a header
2. Open the details panel for that header
3. Observe the updated styling of the menu header

| Before | After |
| --- | --- |
| <img width="358" alt="Screenshot 2023-07-10 at 16 45 02" src="https://github.com/WordPress/gutenberg/assets/846565/cf469106-a558-48d5-879a-0b72f15f2ea9"> | <img width="358" alt="Screenshot 2023-07-10 at 21 22 42" src="https://github.com/WordPress/gutenberg/assets/846565/63236961-b1a8-49ff-b81b-e0aa1a0c1a1b"> |
