### PR TITLE
[@wordpress/e2e-test-utils-playwright] Add `switchBlockInspectorTab` utility

### DIFF
--- a/packages/e2e-test-utils-playwright/src/editor/index.ts
+++ b/packages/e2e-test-utils-playwright/src/editor/index.ts
@@ -18,6 +18,7 @@ import { selectBlocks } from './select-blocks';
 import { setContent } from './set-content';
 import { showBlockToolbar } from './show-block-toolbar';
 import { saveSiteEditorEntities } from './site-editor';
+import { switchBlockInspectorTab } from './switch-block-inspector-tab';
 import { setIsFixedToolbar } from './set-is-fixed-toolbar';
 import { transformBlockTo } from './transform-block-to';
 
@@ -69,6 +70,9 @@ export class Editor {
 	setContent: typeof setContent = setContent.bind( this );
 	/** @borrows showBlockToolbar as this.showBlockToolbar */
 	showBlockToolbar: typeof showBlockToolbar = showBlockToolbar.bind( this );
+	/** @borrows switchBlockInspectorTab as this.switchBlockInspectorTab */
+	switchBlockInspectorTab: typeof switchBlockInspectorTab =
+		switchBlockInspectorTab.bind( this );
 	/** @borrows setIsFixedToolbar as this.setIsFixedToolbar */
 	setIsFixedToolbar: typeof setIsFixedToolbar =
 		setIsFixedToolbar.bind( this );

--- a/packages/e2e-test-utils-playwright/src/editor/switch-block-inspector-tab.ts
+++ b/packages/e2e-test-utils-playwright/src/editor/switch-block-inspector-tab.ts
@@ -15,13 +15,9 @@ export async function switchBlockInspectorTab(
 	this: Editor,
 	ariaLabel: string
 ) {
-	const tabButton = this.page.locator(
-		`.block-editor-block-inspector__tabs button[aria-label="${ ariaLabel }"]`
-	);
-	const id = await tabButton.getAttribute( 'id' );
-
-	await tabButton.click();
-	await this.page.waitForSelector(
-		`div[role="tabpanel"][aria-labelledby="${ id }"]`
-	);
+	const sidebar = this.page.getByRole( 'region', {
+		name: 'Editor settings',
+	} );
+	await sidebar.getByRole( 'tab', { name: ariaLabel } ).click();
+	await sidebar.getByRole( 'tabpanel', { name: ariaLabel } ).waitFor();
 }

--- a/packages/e2e-test-utils-playwright/src/editor/switch-block-inspector-tab.ts
+++ b/packages/e2e-test-utils-playwright/src/editor/switch-block-inspector-tab.ts
@@ -1,0 +1,27 @@
+/**
+ * Internal dependencies
+ */
+import type { Editor } from './index';
+
+/**
+ * Clicks on the block inspector tab button with the supplied label and waits
+ * for the tab switch.
+ *
+ * @param            this
+ * @param { string } ariaLabel Aria label to find tab button by.
+ */
+
+export async function switchBlockInspectorTab(
+	this: Editor,
+	ariaLabel: string
+) {
+	const tabButton = this.page.locator(
+		`.block-editor-block-inspector__tabs button[aria-label="${ ariaLabel }"]`
+	);
+	const id = await tabButton.getAttribute( 'id' );
+
+	await tabButton.click();
+	await this.page.waitForSelector(
+		`div[role="tabpanel"][aria-labelledby="${ id }"]`
+	);
+}


### PR DESCRIPTION

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This PR is migrating the Puppeteer utility  `switchBlockInspectorTab` to the new `@wordpress/e2e-test-utils-playwright` package

## Why?
This utility is needed by people migrating E2E tests to Playwright who use this utility from `@wordpress/e2e-test-utils`

## How?
The utility keeps the old logic of getting the button by label, clicking it and confirming the appropriate inspector tab is visible.

## Testing Instructions
Set up `wp-env`.

Add a new test file, `test/e2e/specs/editor/various/switch-block-inspector-tab.test.js` and add the following code:

```
/**
 * WordPress dependencies
 */
const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );

test.describe( 'switchBlockInspectorTab', () => {
	test( 'should open the page', async ( { admin, editor } ) => {
		await admin.createNewPost( {
			postType: 'post',
			title: 'My test post',
			content: '',
			excerpt: '',
		} );
		await editor.publishPost();

		await editor.insertBlock( { name: 'core/buttons' } );
		await editor.openDocumentSettingsSidebar();
		await editor.switchBlockInspectorTab( 'Styles' );
		// select Outline style for the Buttons block
		await admin.page.getByText( 'Outline' ).press( 'Enter' );
	} );
} );

```
Run `npm run test:e2e:playwright -- test/e2e/specs/editor/various/switch-block-inspector-tab.test.js` and ensure the test passes.


### Testing Instructions for Keyboard
N/A

## Screenshots or screencast <!-- if applicable -->
