### PR TITLE
Lodash: Remove completely from site editor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17822,7 +17822,6 @@
 				"downloadjs": "^1.4.7",
 				"fast-deep-equal": "^3.1.3",
 				"is-plain-object": "^5.0.0",
-				"lodash": "^4.17.21",
 				"memize": "^2.1.0",
 				"react-autosize-textarea": "^7.1.0",
 				"rememo": "^4.0.2",

--- a/packages/edit-site/package.json
+++ b/packages/edit-site/package.json
@@ -71,7 +71,6 @@
 		"downloadjs": "^1.4.7",
 		"fast-deep-equal": "^3.1.3",
 		"is-plain-object": "^5.0.0",
-		"lodash": "^4.17.21",
 		"memize": "^2.1.0",
 		"react-autosize-textarea": "^7.1.0",
 		"rememo": "^4.0.2",

--- a/packages/edit-site/src/components/add-new-template/utils.js
+++ b/packages/edit-site/src/components/add-new-template/utils.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { get } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { useSelect } from '@wordpress/data';
@@ -20,6 +15,14 @@ import { blockMeta, post, archive } from '@wordpress/icons';
  * @property {string}        name The entity's name.
  */
 
+const getValueFromObjectPath = ( object, path ) => {
+	let value = object;
+	path.split( '.' ).forEach( ( fieldName ) => {
+		value = value?.[ fieldName ];
+	} );
+	return value;
+};
+
 /**
  * Helper util to map records to add a `name` prop from a
  * provided path, in order to handle all entities in the same
@@ -32,7 +35,7 @@ import { blockMeta, post, archive } from '@wordpress/icons';
 export const mapToIHasNameAndId = ( entities, path ) => {
 	return ( entities || [] ).map( ( entity ) => ( {
 		...entity,
-		name: decodeEntities( get( entity, path ) ),
+		name: decodeEntities( getValueFromObjectPath( entity, path ) ),
 	} ) );
 };
 

--- a/packages/edit-site/src/hooks/push-changes-to-global-styles/index.js
+++ b/packages/edit-site/src/hooks/push-changes-to-global-styles/index.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { get } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { addFilter } from '@wordpress/hooks';
@@ -96,6 +91,14 @@ const STYLE_PATH_TO_PRESET_BLOCK_ATTRIBUTE = {
 
 const SUPPORTED_STYLES = [ 'border', 'color', 'spacing', 'typography' ];
 
+const getValueFromObjectPath = ( object, path ) => {
+	let value = object;
+	path.forEach( ( fieldName ) => {
+		value = value?.[ fieldName ];
+	} );
+	return value;
+};
+
 function useChangesToPush( name, attributes ) {
 	const supports = useSupportedStyles( name );
 
@@ -115,7 +118,7 @@ function useChangesToPush( name, attributes ) {
 					];
 				const value = presetAttributeValue
 					? `var:preset|${ STYLE_PATH_TO_CSS_VAR_INFIX[ presetAttributeKey ] }|${ presetAttributeValue }`
-					: get( attributes.style, path );
+					: getValueFromObjectPath( attributes.style, path );
 				return value ? [ { path, value } ] : [];
 			} ),
 		[ supports, name, attributes ]


### PR DESCRIPTION
## What?
This PR removes Lodash's `_.get()` from the `@wordpress/edit-site` package and since those are the last Lodash usages there, it removes the Lodash dependency.

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?

We're using direct access with optional chaining as an alternative. It might feel like we're being repetitive adding the same function twice, but it's not the same actually: in one of the cases it works with an array path, and in the other case, it works with a string path. There are other usages and different implementations of `getValueFromObjectPath` throughout the codebase and I'm planning to follow up with unifying them in another PR. 

## Testing Instructions

* Follow the testing instructions of #41189, particularly searching in the post template creation modal.
* Follow the testing instructions of #52404.