### PR TITLE
Improve error handling when converting classic to block menus

### DIFF
--- a/lib/compat/wordpress-6.3/class-gutenberg-classic-to-block-menu-converter.php
+++ b/lib/compat/wordpress-6.3/class-gutenberg-classic-to-block-menu-converter.php
@@ -17,7 +17,7 @@ class Gutenberg_Classic_To_Block_Menu_Converter {
 	 * Converts a Classic Menu to blocks.
 	 *
 	 * @param WP_Term $menu The Menu term object of the menu to convert.
-	 * @return string the serialized and normalized parsed blocks.
+	 * @return string|WP_Error The serialized and normalized parsed blocks or a WP_Error object.
 	 */
 	public static function convert( $menu ) {
 
@@ -31,7 +31,7 @@ class Gutenberg_Classic_To_Block_Menu_Converter {
 		$menu_items = wp_get_nav_menu_items( $menu->term_id, array( 'update_post_term_cache' => false ) );
 
 		if ( empty( $menu_items ) ) {
-			return array();
+			return '';
 		}
 
 		// Set up the $menu_item variables.

--- a/lib/compat/wordpress-6.3/class-gutenberg-navigation-fallback.php
+++ b/lib/compat/wordpress-6.3/class-gutenberg-navigation-fallback.php
@@ -98,6 +98,10 @@ class Gutenberg_Navigation_Fallback {
 		// If there is a classic menu then convert it to blocks.
 		$classic_nav_menu_blocks = Gutenberg_Classic_To_Block_Menu_Converter::convert( $classic_nav_menu );
 
+		if ( is_wp_error( $classic_nav_menu_blocks ) ) {
+			return $classic_nav_menu_blocks;
+		}
+
 		if ( empty( $classic_nav_menu_blocks ) ) {
 			return new WP_Error( 'cannot_convert_classic_menu', __( 'Unable to convert Classic Menu to blocks.', 'gutenberg' ) );
 		}


### PR DESCRIPTION
## What?

See #52481. Addresses some errors that can occur when `Gutenberg_Navigation_Fallback::create_classic_menu_fallback()` calls `Gutenberg_Classic_To_Block_Menu_Converter::convert()`.

## Why?

To avoid unexpected behavior or errors resulting from incorrect type handling.

## How?

Improving type-checking and returning types consistent with the documentation