### PR TITLE
Global font sizes: Ensure sizes are unique

### DIFF
--- a/packages/block-editor/src/components/global-styles/typography-panel.js
+++ b/packages/block-editor/src/components/global-styles/typography-panel.js
@@ -114,6 +114,21 @@ function useHasTextColumnsControl( settings ) {
 	return settings?.typography?.textColumns;
 }
 
+function getUniqueFontSizesBySlug( settings ) {
+	const fontSizesPerOrigin = settings?.typography?.fontSizes ?? {};
+	const fontSizes = []
+		.concat( fontSizesPerOrigin?.custom ?? [] )
+		.concat( fontSizesPerOrigin?.theme ?? [] )
+		.concat( fontSizesPerOrigin.default ?? [] );
+
+	return fontSizes.reduce( ( acc, currentSize ) => {
+		if ( ! acc.some( ( { slug } ) => slug === currentSize.slug ) ) {
+			acc.push( currentSize );
+		}
+		return acc;
+	}, [] );
+}
+
 function TypographyToolsPanel( {
 	resetAllFilter,
 	onChange,
@@ -189,11 +204,8 @@ export default function TypographyPanel( {
 	// Font Size
 	const hasFontSizeEnabled = useHasFontSizeControl( settings );
 	const disableCustomFontSizes = ! settings?.typography?.customFontSize;
-	const fontSizesPerOrigin = settings?.typography?.fontSizes ?? {};
-	const fontSizes = []
-		.concat( fontSizesPerOrigin?.custom ?? [] )
-		.concat( fontSizesPerOrigin?.theme ?? [] )
-		.concat( fontSizesPerOrigin.default ?? [] );
+	const fontSizes = getUniqueFontSizesBySlug( settings );
+
 	const fontSize = decodeValue( inheritedValue?.typography?.fontSize );
 	const setFontSize = ( newValue, metadata ) => {
 		const actualValue = !! metadata?.slug


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Make sure font sizes in global styles are unique.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
#51488 added font sizes from all origins in the global editor, but if a theme registeres a font size with the same slug as one of the default sizes an error is thrown.

<img width="1512" alt="image" src="https://github.com/WordPress/gutenberg/assets/1415747/6a61605b-60cc-42f7-8b6d-31f39c6b9c79">

In the Select control they are also listed as duplicates.
<img width="264" alt="image" src="https://github.com/WordPress/gutenberg/assets/1415747/380ac2a7-1e30-40fd-b003-0d7c16e75947">


## How?
Filter the font sizes and make sure all of them have a unique slug.

## Testing Instructions
Add some font sizes to your theme.json that already exists in Gutenberg (or use the TT3 theme). Ex:
```json
"typography": {
	"fontSizes": [
		{
			"name": "Small",
			"slug": "small",
			"size": "10px"
		},
		{
			"name": "Medium",
			"slug": "medium",
			"size": "14px"
		},
		{
			"name": "Large",
			"slug": "Large",
			"size": "28px"
		}
	]
}
```

Open the global styles editor and change the text font size of your site. The console should not show any errors.