### PR TITLE
Deprecate and make Fonts API non-functional.

### DIFF
--- a/lib/experimental/fonts/bc-layer/class-gutenberg-fonts-api-bc-layer.php
+++ b/lib/experimental/fonts/bc-layer/class-gutenberg-fonts-api-bc-layer.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Fonts API BC Layer helpers.
+ *
+ * BACKPORT NOTE: Do not backport this file to Core.
+ * This file is now part of the API's Backwards-Compatibility (BC) layer.
+ *
+ * @package    Gutenberg
+ * @subpackage Fonts API
+ * @since      15.7.0
+ */
+
+/**
+ * Class Gutenberg_Fonts_API_BC_Layer
+ *
+ * BACKPORT NOTE: Do not backport this file to Core.
+ *
+ * @since X.X.X
+ * @deprecated 16.3.0 Fonts API is not supported.
+ */
+class Gutenberg_Fonts_API_BC_Layer {
+
+	/**
+	 * Determines if the given fonts array is the deprecated array structure.
+	 *
+	 * @since X.X.X
+	 * @deprecated 16.3.0 Structure check is not functional.
+	 *
+	 * @return bool False.
+	 */
+	public static function is_deprecated_structure() {
+		_deprecated_function( __METHOD__, 'Gutenberg 16.3.0' );
+		return false;
+	}
+
+	/**
+	 * Migrates deprecated fonts structure into new API data structure,
+	 * i.e. variations grouped by their font-family.
+	 *
+	 * @since X.X.X
+	 * @deprecated 16.3.0 Migrate is not supported.
+	 *
+	 * @return array Empty array.
+	 */
+	public static function migrate_deprecated_structure() {
+		_deprecated_function( __METHOD__, 'Gutenberg 16.3.0' );
+		return array();
+	}
+}

--- a/lib/experimental/fonts/bc-layer/class-wp-fonts-provider-local.php
+++ b/lib/experimental/fonts/bc-layer/class-wp-fonts-provider-local.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Webfonts API: Provider for locally-hosted fonts.
+ *
+ * @package    WordPress
+ * @subpackage Fonts API
+ * @since      X.X.X
+ */
+
+if ( class_exists( 'WP_Fonts_Provider_Local' ) ) {
+	return;
+}
+
+/**
+ * A core bundled provider for generating `@font-face` styles
+ * from locally-hosted font files.
+ *
+ * @since X.X.X
+ * @deprecated 16.3.0 Providers are not supported.
+ *                    Local provider is in WP_Font_Face.
+ */
+class WP_Fonts_Provider_Local extends WP_Fonts_Provider {
+
+	/**
+	 * The provider's unique ID.
+	 *
+	 * @since X.X.X
+	 * @deprecated 16.3.0
+	 *
+	 * @var string
+	 */
+	protected $id = 'local';
+
+	/**
+	 * Gets the `@font-face` CSS styles for locally-hosted font files.
+	 *
+	 * @since X.X.X
+	 * @deprecated 16.3.0 Get styles is not supported.
+	 *
+	 * @return string Empty string.
+	 */
+	public function get_css() {
+		_deprecated_function( __FUNCTION__, 'Gutenberg 16.3' );
+		return '';
+	}
+}

--- a/lib/experimental/fonts/bc-layer/class-wp-fonts-provider.php
+++ b/lib/experimental/fonts/bc-layer/class-wp-fonts-provider.php
@@ -1,0 +1,98 @@
+<?php
+/**
+ * Fonts API: Provider abstract class.
+ *
+ * Individual fonts providers should extend this class and implement.
+ *
+ * @package    WordPress
+ * @subpackage Fonts API
+ * @since      X.X.X
+ */
+
+if ( class_exists( 'WP_Fonts_Provider' ) ) {
+	return;
+}
+
+/**
+ * Abstract class for Fonts API providers.
+ *
+ * @since X.X.X
+ * @deprecated 16.3.0 Custom providers are not supported.
+ */
+abstract class WP_Fonts_Provider {
+
+	/**
+	 * The provider's unique ID.
+	 *
+	 * @since X.X.X
+	 * @deprecated 16.3.0
+	 *
+	 * @var string
+	 */
+	protected $id = '';
+
+	/**
+	 * Fonts to be processed.
+	 *
+	 * @since X.X.X
+	 * @deprecated 16.3.0
+	 *
+	 * @var array[]
+	 */
+	protected $fonts = array();
+
+	/**
+	 * Array of Font-face style tag's attribute(s)
+	 * where the key is the attribute name and the
+	 * value is its value.
+	 *
+	 * @since X.X.X
+	 * @deprecated 16.3.0
+	 *
+	 * @var string[]
+	 */
+	protected $style_tag_atts = array();
+
+	/**
+	 * Sets this provider's fonts property.
+	 *
+	 * @since X.X.X
+	 * @deprecated 16.3.0 Set is not supported.
+	 */
+	public function set_fonts() {
+		_deprecated_function( __METHOD__, 'Gutenberg 16.3.0' );
+	}
+
+	/**
+	 * Prints the generated styles.
+	 *
+	 * @since X.X.X
+	 * @deprecated 16.3.0 Use wp_print_font_faces() instead.
+	 */
+	public function print_styles() {
+		_deprecated_function( __METHOD__, 'Gutenberg 16.3.0', 'wp_print_font_faces' );
+	}
+
+	/**
+	 * Gets the `@font-face` CSS for the provider's fonts.
+	 *
+	 * @since X.X.X
+	 * @deprecated 16.3.0
+	 *
+	 * @return string The `@font-face` CSS.
+	 */
+	abstract public function get_css();
+
+	/**
+	 * Gets the `<style>` element for wrapping the `@font-face` CSS.
+	 *
+	 * @since X.X.X
+	 * @deprecated 16.3.0 Get style element is not supported.
+	 *
+	 * @return string Empty string.
+	 */
+	protected function get_style_element() {
+		_deprecated_function( __METHOD__, 'Gutenberg 16.3.0' );
+		return '';
+	}
+}

--- a/lib/experimental/fonts/bc-layer/class-wp-fonts-resolver.php
+++ b/lib/experimental/fonts/bc-layer/class-wp-fonts-resolver.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * WP_Fonts_Resolver class.
+ *
+ * @package    WordPress
+ * @subpackage Fonts API
+ * @since      X.X.X
+ */
+
+if ( class_exists( 'WP_Fonts_Resolver' ) ) {
+	return;
+}
+
+/**
+ * The Fonts API Resolver abstracts the processing of different data sources
+ * (such as theme.json and global styles) for font interactions with the API.
+ *
+ * This class is for internal core usage and is not supposed to be used by
+ * extenders (plugins and/or themes).
+ *
+ * @access private
+ *
+ * @since X.X.X
+ * @deprecated 16.3.0 Fonts API is not supported.
+ */
+class WP_Fonts_Resolver {
+
+	/**
+	 * Enqueues user-selected fonts via global styles.
+	 *
+	 * @since X.X.X
+	 * @deprecated 16.3.0 Enqueue is not supported.
+	 *
+	 * @return array Empty array.
+	 */
+	public static function enqueue_user_selected_fonts() {
+		_deprecated_function( __FUNCTION__, 'Gutenberg 16.3' );
+		return array();
+	}
+
+	/**
+	 * Register fonts defined in theme.json.
+	 *
+	 * @since X.X.X
+	 * @deprecated 16.3.0 Register is not supported.
+	 */
+	public static function register_fonts_from_theme_json() {
+		_deprecated_function( __FUNCTION__, 'Gutenberg 16.3' );
+	}
+
+	/**
+	 * Add missing fonts to the global styles.
+	 *
+	 * @since X.X.X
+	 * @deprecated 16.3.0 Adding fonts into theme.json theme data layer is not supported.
+	 *
+	 * @param WP_Theme_JSON_Gutenberg|WP_Theme_JSON $data The global styles.
+	 * @return WP_Theme_JSON_Gutenberg|WP_Theme_JSON Unchanged global styles.
+	 */
+	public static function add_missing_fonts_to_theme_json( $data ) {
+		_deprecated_function( __FUNCTION__, 'Gutenberg 16.3' );
+		return $data;
+	}
+}

--- a/lib/experimental/fonts/bc-layer/class-wp-fonts-utils.php
+++ b/lib/experimental/fonts/bc-layer/class-wp-fonts-utils.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * Font API's utility helpers.
+ *
+ * @package    WordPress
+ * @subpackage Fonts API
+ * @since      X.X.X
+ */
+
+if ( class_exists( 'WP_Fonts_Utils' ) ) {
+	return;
+}
+
+/**
+ * Utility helpers for the Fonts API.
+ *
+ * @since X.X.X
+ * @deprecated 16.3.0 Fonts API is not supported.
+ */
+class WP_Fonts_Utils {
+
+	/**
+	 * Converts the given font family into a handle.
+	 *
+	 * @since X.X.X
+	 * @deprecated 16.3.0 This method is not supported.
+	 *
+	 * @return null
+	 */
+	public static function convert_font_family_into_handle() {
+		_deprecated_function( __METHOD__, 'Gutenberg 16.3.0' );
+		return null;
+	}
+
+	/**
+	 * Converts the given variation and its font-family into a handle.
+	 *
+	 * @since X.X.X
+	 * @deprecated 16.3.0 This method is not supported.
+	 *
+	 * @return null
+	 */
+	public static function convert_variation_into_handle() {
+		_deprecated_function( __METHOD__, 'Gutenberg 16.3.0' );
+		return null;
+	}
+
+	/**
+	 * Gets the font family from the variation.
+	 *
+	 * @since X.X.X
+	 * @deprecated 16.3.0 This method is not supported.
+	 *
+	 * @return null Null.
+	 */
+	public static function get_font_family_from_variation() {
+		_deprecated_function( __METHOD__, 'Gutenberg 16.3.0' );
+		return null;
+	}
+
+	/**
+	 * Checks if the given input is defined, i.e. meaning is a non-empty string.
+	 *
+	 * @since X.X.X
+	 * @deprecated 16.3.0
+	 *
+	 * @param string $input The input to check.
+	 * @return bool True when non-empty string. Else false.
+	 */
+	public static function is_defined( $input ) {
+		_deprecated_function( __METHOD__, 'Gutenberg 16.3.0' );
+		return ( is_string( $input ) && ! empty( $input ) );
+	}
+}

--- a/lib/experimental/fonts/bc-layer/class-wp-fonts.php
+++ b/lib/experimental/fonts/bc-layer/class-wp-fonts.php
@@ -1,0 +1,199 @@
+<?php
+/**
+ * WP Fonts API class.
+ *
+ * @package    WordPress
+ * @subpackage Fonts API
+ * @since      X.X.X
+ */
+
+if ( class_exists( 'WP_Fonts' ) ) {
+	return;
+}
+
+/**
+ * Class WP_Fonts
+ *
+ * @since X.X.X
+ * @deprecated 16.3.0 Fonts API is not supported.
+ */
+class WP_Fonts extends WP_Dependencies {
+
+	/**
+	 * Registered "origin", indicating the font is registered in the API.
+	 *
+	 * @since X.X.X
+	 * @deprecated 16.3.0
+	 *
+	 * @var string
+	 */
+	const REGISTERED_ORIGIN = 'gutenberg_wp_fonts_api';
+
+	/**
+	 * Constructor.
+	 *
+	 * @since X.X.X
+	 * @deprecated 16.3.0
+	 */
+	public function __construct() {
+		_deprecated_function( __METHOD__, 'Gutenberg 16.3.0' );
+	}
+
+	/**
+	 * Get the list of registered providers.
+	 *
+	 * @since X.X.X
+	 * @deprecated 16.3.0 Providers are not supported.
+	 */
+	public function get_providers() {
+		_deprecated_function( __METHOD__, 'Gutenberg 16.3.0' );
+	}
+
+	/**
+	 * Register a provider.
+	 *
+	 * @since X.X.X
+	 * @deprecated 16.3.0 Providers are not supported.
+	 *
+	 * @return bool False.
+	 */
+	public function register_provider() {
+		_deprecated_function( __METHOD__, 'Gutenberg 16.3.0' );
+		return false;
+	}
+
+	/**
+	 * Get the list of all registered font family handles.
+	 *
+	 * @since X.X.X
+	 * @deprecated 16.3.0 Register is not supported.
+	 *
+	 * @return array Empty array.
+	 */
+	public function get_registered_font_families() {
+		_deprecated_function( __METHOD__, 'Gutenberg 16.3.0' );
+		return array();
+	}
+
+	/**
+	 * Get the list of all registered font families and their variations.
+	 *
+	 * @since X.X.X
+	 * @deprecated 16.3.0 Register is not supported.
+	 *
+	 * @return array Empty array.
+	 */
+	public function get_registered() {
+		_deprecated_function( __METHOD__, 'Gutenberg 16.3.0' );
+		return array();
+	}
+
+	/**
+	 * Get the list of enqueued font families and their variations.
+	 *
+	 * @since X.X.X
+	 * @deprecated 16.3.0 Enqueue is not supported.
+	 *
+	 * @return array Empty array.
+	 */
+	public function get_enqueued() {
+		_deprecated_function( __METHOD__, 'Gutenberg 16.3.0' );
+		return array();
+	}
+
+	/**
+	 * Registers a font family.
+	 *
+	 * @since X.X.X
+	 * @deprecated 16.3.0 Add is not supported.
+	 *
+	 * @return null Null.
+	 */
+	public function add_font_family() {
+		_deprecated_function( __METHOD__, 'Gutenberg 16.3.0' );
+		return null;
+	}
+
+	/**
+	 * Removes a font family and all registered variations.
+	 *
+	 * @since X.X.X
+	 * @deprecated 16.3.0 Remove is not supported.
+	 */
+	public function remove_font_family() {
+		_deprecated_function( __METHOD__, 'Gutenberg 16.3.0' );
+	}
+
+	/**
+	 * Add a variation to an existing family or register family if none exists.
+	 *
+	 * @since X.X.X
+	 * @deprecated 16.3.0 Add is not supported.
+	 *
+	 * @return null Null.
+	 */
+	public function add_variation() {
+		_deprecated_function( __METHOD__, 'Gutenberg 16.3.0' );
+		return null;
+	}
+
+	/**
+	 * Removes a variation.
+	 *
+	 * @since X.X.X
+	 * @deprecated 16.3.0 Remove is not supported.
+	 */
+	public function remove_variation() {
+		_deprecated_function( __METHOD__, 'Gutenberg 16.3.0' );
+	}
+
+	/**
+	 * Processes the items and dependencies.
+	 *
+	 * Processes the items passed to it or the queue, and their dependencies.
+	 *
+	 * @since X.X.X
+	 * @deprecated 16.3.0 Processing items and dependencies is not supported.
+	 *
+	 * @param string|string[]|bool $handles Optional. Items to be processed: queue (false),
+	 *                                      single item (string), or multiple items (array of strings).
+	 *                                      Default false.
+	 * @param int|false            $group   Optional. Group level: level (int), no group (false).
+	 *
+	 * @return array Empty array.
+	 */
+	public function do_items( $handles = false, $group = false ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		_deprecated_function( __METHOD__, 'Gutenberg 16.3.0' );
+		return array();
+	}
+
+	/**
+	 * Invokes each provider to process and print its styles.
+	 *
+	 * @since X.X.X
+	 * @deprecated 16.3.0 Process and print provider styles is not supported.
+	 *
+	 * @see WP_Dependencies::do_item()
+	 *
+	 * @param string    $provider_id The provider to process.
+	 * @param int|false $group       Not used.
+	 * @return bool False.
+	 */
+	public function do_item( $provider_id, $group = false ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		_deprecated_function( __METHOD__, 'Gutenberg 16.3.0' );
+		return false;
+	}
+
+	/**
+	 * Converts the font family and its variations into theme.json structural format.
+	 *
+	 * @since X.X.X
+	 * @deprecated 16.3.0 Convert is not supported.
+	 *
+	 * @return array Empty array.
+	 */
+	public function to_theme_json() {
+		_deprecated_function( __METHOD__, 'Gutenberg 16.3.0' );
+		return array();
+	}
+}

--- a/lib/experimental/fonts/bc-layer/class-wp-web-fonts.php
+++ b/lib/experimental/fonts/bc-layer/class-wp-web-fonts.php
@@ -1,0 +1,190 @@
+<?php
+/**
+ * Web Fonts API class.
+ *
+ * @package    WordPress
+ * @subpackage Fonts API
+ * @since      X.X.X
+ */
+
+if ( class_exists( 'WP_Web_Fonts' ) ) {
+	return;
+}
+
+/**
+ * Class WP_Web_Fonts
+ *
+ * @since 14.9.1
+ * @deprecated 15.1 Use WP_Fonts instead.
+ * @deprecated 16.3.0 Fonts API is not supported.
+ */
+class WP_Web_Fonts extends WP_Webfonts {
+
+	/**
+	 * Constructor.
+	 *
+	 * @since X.X.X
+	 * @deprecated 16.3.0
+	 */
+	public function __construct() {
+		_deprecated_function( __METHOD__, 'Gutenberg 16.3.0' );
+	}
+
+	/**
+	 * Get the list of registered providers.
+	 *
+	 * @since X.X.X
+	 * @deprecated 16.3.0 Providers are not supported.
+	 */
+	public function get_providers() {
+		_deprecated_function( __METHOD__, 'Gutenberg 16.3.0' );
+	}
+
+	/**
+	 * Register a provider.
+	 *
+	 * @since X.X.X
+	 * @deprecated 16.3.0 Providers are not supported.
+	 *
+	 * @return bool False.
+	 */
+	public function register_provider() {
+		_deprecated_function( __METHOD__, 'Gutenberg 16.3.0' );
+		return false;
+	}
+
+	/**
+	 * Get the list of all registered font family handles.
+	 *
+	 * @since X.X.X
+	 * @deprecated 16.3.0 Register is not supported.
+	 *
+	 * @return array Empty array.
+	 */
+	public function get_registered_font_families() {
+		_deprecated_function( __METHOD__, 'Gutenberg 16.3.0' );
+		return array();
+	}
+
+	/**
+	 * Get the list of all registered font families and their variations.
+	 *
+	 * @since X.X.X
+	 * @deprecated 16.3.0 Register is not supported.
+	 *
+	 * @return array Empty array.
+	 */
+	public function get_registered() {
+		_deprecated_function( __METHOD__, 'Gutenberg 16.3.0' );
+		return array();
+	}
+
+	/**
+	 * Get the list of enqueued font families and their variations.
+	 *
+	 * @since X.X.X
+	 * @deprecated 16.3.0 Enqueue is not supported.
+	 *
+	 * @return array Empty array.
+	 */
+	public function get_enqueued() {
+		_deprecated_function( __METHOD__, 'Gutenberg 16.3.0' );
+		return array();
+	}
+
+	/**
+	 * Registers a font family.
+	 *
+	 * @since X.X.X
+	 * @deprecated 16.3.0 Add is not supported.
+	 *
+	 * @return null Null.
+	 */
+	public function add_font_family() {
+		_deprecated_function( __METHOD__, 'Gutenberg 16.3.0' );
+		return null;
+	}
+
+	/**
+	 * Removes a font family and all registered variations.
+	 *
+	 * @since X.X.X
+	 * @deprecated 16.3.0 Remove is not supported.
+	 */
+	public function remove_font_family() {
+		_deprecated_function( __METHOD__, 'Gutenberg 16.3.0' );
+	}
+
+	/**
+	 * Add a variation to an existing family or register family if none exists.
+	 *
+	 * @since X.X.X
+	 * @deprecated 16.3.0 Add is not supported.
+	 *
+	 * @return null Null.
+	 */
+	public function add_variation() {
+		_deprecated_function( __METHOD__, 'Gutenberg 16.3.0' );
+		return null;
+	}
+
+	/**
+	 * Removes a variation.
+	 *
+	 * @since X.X.X
+	 * @deprecated 16.3.0 Remove is not supported.
+	 */
+	public function remove_variation() {
+		_deprecated_function( __METHOD__, 'Gutenberg 16.3.0' );
+	}
+
+	/**
+	 * Processes the items and dependencies.
+	 *
+	 * Processes the items passed to it or the queue, and their dependencies.
+	 *
+	 * @since X.X.X
+	 * @deprecated 16.3.0 Processing items and dependencies is not supported.
+	 *
+	 * @param string|string[]|bool $handles Optional. Items to be processed: queue (false),
+	 *                                      single item (string), or multiple items (array of strings).
+	 *                                      Default false.
+	 * @param int|false            $group   Optional. Group level: level (int), no group (false).
+	 *
+	 * @return array Empty array.
+	 */
+	public function do_items( $handles = false, $group = false ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		_deprecated_function( __METHOD__, 'Gutenberg 16.3.0' );
+		return array();
+	}
+
+	/**
+	 * Invokes each provider to process and print its styles.
+	 *
+	 * @since X.X.X
+	 * @deprecated 16.3.0 Process and print provider styles is not supported.
+	 *
+	 * @see WP_Dependencies::do_item()
+	 *
+	 * @param string    $provider_id The provider to process.
+	 * @param int|false $group       Not used.
+	 * @return bool False.
+	 */
+	public function do_item( $provider_id, $group = false ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		_deprecated_function( __METHOD__, 'Gutenberg 16.3.0' );
+		return false;
+	}
+
+	/**
+	 * Converts the font family and its variations into theme.json structural format.
+	 *
+	 * @since X.X.X
+	 * @deprecated 16.3.0 Convert is not supported.
+	 *
+	 * @return array Empty array.
+	 */
+	public function to_theme_json() {
+		_deprecated_function( __METHOD__, 'Gutenberg 16.3.0' );
+		return array();
+	}
+}

--- a/lib/experimental/fonts/bc-layer/class-wp-webfonts-provider-local.php
+++ b/lib/experimental/fonts/bc-layer/class-wp-webfonts-provider-local.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * Fonts API: Provider for locally-hosted fonts.
+ *
+ * Part of the backwards-compatibility (BC) layer for all
+ * deprecated publicly exposed methods and functionality.
+ *
+ * This class/file will NOT be backported to Core. Rather for sites
+ * using the previous API, it exists to prevent breakages, giving
+ * developers time to upgrade their code.
+ *
+ * @package    WordPress
+ * @subpackage Fonts
+ * @since      X.X.X
+ */
+
+if ( class_exists( 'WP_Webfonts_Provider_Local' ) ) {
+	return;
+}
+
+/**
+ * A deprecated core bundled provider for generating `@font-face` styles
+ * from locally-hosted font files.
+ *
+ * BACKPORT NOTE: Do not backport this file to Core.
+ *
+ * @since X.X.X
+ * @deprecated 15.1 Use `WP_Fonts_Provider_Local` instead.
+ * @deprecated 16.3.0 Providers are not supported.
+ *                    Local provider is in WP_Font_Face.
+ */
+class WP_Webfonts_Provider_Local extends WP_Webfonts_Provider {
+
+	/**
+	 * The provider's unique ID.
+	 *
+	 * @since 6.0.0
+	 * @deprecated 16.3.0
+	 *
+	 * @var string
+	 */
+	protected $id = 'local';
+
+	/**
+	 * Constructor.
+	 *
+	 * @since 6.1.0
+	 */
+	public function __construct() {
+		_deprecated_function( __METHOD__, 'Gutenberg 15.1' );
+	}
+
+	/**
+	 * Gets the `@font-face` CSS styles for locally-hosted font files.
+	 *
+	 * @since X.X.X
+	 * @deprecated 16.3.0 Get styles is not supported.
+	 *
+	 * @return string Empty string.
+	 */
+	public function get_css() {
+		_deprecated_function( __FUNCTION__, 'Gutenberg 16.3' );
+		return '';
+	}
+}

--- a/lib/experimental/fonts/bc-layer/class-wp-webfonts-provider.php
+++ b/lib/experimental/fonts/bc-layer/class-wp-webfonts-provider.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Fonts API: Provider abstract class.
+ *
+ * Part of the backwards-compatibility (BC) layer for all
+ * deprecated publicly exposed methods and functionality.
+ *
+ * This class/file will NOT be backported to Core. Rather for sites
+ * using the previous API, it exists to prevent breakages, giving
+ * developers time to upgrade their code.
+ *
+ * @package    WordPress
+ * @subpackage Fonts API
+ * @since      X.X.X
+ */
+
+if ( class_exists( 'WP_Webfonts_Provider' ) ) {
+	return;
+}
+
+/**
+ * Deprecated abstract class for Fonts API providers.
+ *
+ * BACKPORT NOTE: Do not backport this file to Core.
+ *
+ * @since X.X.X
+ * @deprecated 15.1 Use `WP_Fonts_Provider` instead.
+ * @deprecated 16.3.0 Custom providers are not supported.
+ */
+abstract class WP_Webfonts_Provider extends WP_Fonts_Provider {
+
+	/**
+	 * Fonts to be processed.
+	 *
+	 * @since X.X.X
+	 * @deprecated 15.1 Use WP_Fonts_Provider::$fonts property instead.
+	 * @deprecated 16.3.0
+	 *
+	 * @var array[]
+	 */
+	protected $webfonts = array();
+
+	/**
+	 * Sets this provider's fonts property.
+	 *
+	 * @since X.X.X
+	 * @deprecated GB 15.1 Use WP_Fonts_Provider::set_fonts() instead.
+	 * @deprecated 16.3.0 Set is not supported.
+	 */
+	public function set_webfonts() {
+		_deprecated_function( __METHOD__, 'Gutenberg 15.1' );
+	}
+}

--- a/lib/experimental/fonts/bc-layer/class-wp-webfonts-utils.php
+++ b/lib/experimental/fonts/bc-layer/class-wp-webfonts-utils.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * Webfont API's utility helpers.
+ *
+ * BACKPORT NOTE: Do not backport this file to Core.
+ * This file is now part of the API's Backwards-Compatibility (BC) layer.
+ *
+ * @package    WordPress
+ * @subpackage Fonts API
+ * @since      X.X.X
+ */
+
+if ( class_exists( 'WP_Webfonts_Utils' ) ) {
+	return;
+}
+
+/**
+ * Utility helpers for the Webfonts API.
+ *
+ * @since X.X.X
+ * @deprecated 15.1 Use WP_Fonts_Utils instead.
+ * @deprecated 16.3.0 Webfonts API is not supported.
+ */
+class WP_Webfonts_Utils {
+
+	/**
+	 * Converts the given font family into a handle.
+	 *
+	 * @since X.X.X
+	 * @deprecated 15.1 Use WP_Fonts_Utils::convert_font_family_into_handle() instead.
+	 * @deprecated 16.3.0 This method is not supported.
+	 *
+	 * @return null
+	 */
+	public static function convert_font_family_into_handle() {
+		_deprecated_function( __METHOD__, 'Gutenberg 15.1' );
+		return null;
+	}
+
+	/**
+	 * Converts the given variation and its font-family into a handle.
+	 *
+	 * @since X.X.X
+	 * @deprecated 15.1 Use WP_Fonts_Utils::convert_variation_into_handle() instead.
+	 * @deprecated 16.3.0 This method is not supported.
+	 *
+	 * @return null
+	 */
+	public static function convert_variation_into_handle() {
+		_deprecated_function( __METHOD__, 'Gutenberg 15.1' );
+		return null;
+	}
+
+	/**
+	 * Gets the font family from the variation.
+	 *
+	 * @since X.X.X
+	 * @deprecated 15.1 Use WP_Fonts_Utils::get_font_family_from_variation() instead.
+	 * @deprecated 16.3.0 This method is not supported.
+	 *
+	 * @return null
+	 */
+	public static function get_font_family_from_variation() {
+		_deprecated_function( __METHOD__, 'Gutenberg 15.1' );
+		return null;
+	}
+
+	/**
+	 * Checks if the given input is defined, i.e. meaning is a non-empty string.
+	 *
+	 * @since X.X.X
+	 * @deprecated 15.1 Use WP_Fonts_Utils::is_defined() instead.
+	 * @deprecated 16.3.0 This method is not supported.
+	 *
+	 * @param string $input The input to check.
+	 * @return bool True when non-empty string. Else false.
+	 */
+	public static function is_defined( $input ) {
+		_deprecated_function( __METHOD__, 'Gutenberg 15.1' );
+		return ( is_string( $input ) && ! empty( $input ) );
+	}
+}

--- a/lib/experimental/fonts/bc-layer/class-wp-webfonts.php
+++ b/lib/experimental/fonts/bc-layer/class-wp-webfonts.php
@@ -1,0 +1,146 @@
+<?php
+/**
+ * Webfonts API class: backwards-compatibility (BC) layer for all
+ * deprecated publicly exposed methods and functionality.
+ *
+ * This class/file will NOT be backported to Core. Rather for sites
+ * using the previous API, it exists to prevent breakages, giving
+ * developers time to upgrade their code.
+ *
+ * @package    Gutenberg
+ * @subpackage Fonts API's BC Layer
+ * @since      X.X.X
+ */
+
+if ( class_exists( 'WP_Webfonts' ) ) {
+	return;
+}
+
+/**
+ * Class WP_Webfonts
+ *
+ * @since X.X.X
+ * @deprecated 15.1 Use WP_Fonts instead.
+ * @deprecated 16.3.0 Fonts API is not supported.
+ */
+class WP_Webfonts {
+
+	/**
+	 * Constructor.
+	 *
+	 * @since X.X.X
+	 * @deprecated 16.3.0
+	 */
+	public function __construct() {
+		_deprecated_function( __METHOD__, 'Gutenberg 16.3.0' );
+	}
+
+	/**
+	 * Gets the font slug.
+	 *
+	 * @since X.X.X
+	 * @deprecated Use WP_Fonts_Utils::convert_font_family_into_handle() or WP_Fonts_Utils::get_font_family_from_variation().
+	 * @deprecated 16.3.0 This method is not supported.
+	 *
+	 * @return false False.
+	 */
+	public static function get_font_slug() {
+		_deprecated_function( __METHOD__, 'Gutenberg 16.3.0' );
+		return false;
+	}
+
+	/**
+	 * Initializes the API.
+	 *
+	 * @since 6.0.0
+	 * @deprecated 14.9.1 Use wp_fonts().
+	 */
+	public static function init() {
+		_deprecated_function( __METHOD__, 'GB 14.9.1', 'wp_fonts()' );
+	}
+
+	/**
+	 * Get the list of all registered font family handles.
+	 *
+	 * @since X.X.X
+	 * @deprecated GB 15.8.0 Use wp_fonts()->get_registered_font_families().
+	 * @deprecated 16.3.0 Register is not supported.
+	 *
+	 * @return array Empty array.
+	 */
+	public function get_registered_font_families() {
+		_deprecated_function( __METHOD__, 'Gutenberg 15.8.0' );
+		return array();
+	}
+
+	/**
+	 * Gets the list of registered fonts.
+	 *
+	 * @since 6.0.0
+	 * @deprecated 14.9.1 Use wp_fonts()->get_registered().
+	 * @deprecated 16.3.0 Register is not supported.
+	 *
+	 * @return array Empty array.
+	 */
+	public function get_registered_webfonts() {
+		_deprecated_function( __METHOD__, 'Gutenberg 14.9.1' );
+
+		return array();
+	}
+
+	/**
+	 * Gets the list of enqueued fonts.
+	 *
+	 * @since 6.0.0
+	 * @deprecated 14.9.1 Use wp_fonts()->get_enqueued().
+	 * @deprecated 16.3.0 Enqueue is not supported.
+	 *
+	 * @return array Empty array.
+	 */
+	public function get_enqueued_webfonts() {
+		_deprecated_function( __METHOD__, 'Gutenberg 14.9.1' );
+		return array();
+	}
+
+	/**
+	 * Gets the list of all fonts.
+	 *
+	 * @since X.X.X
+	 * @deprecated GB 14.9.1 Use wp_fonts()->get_registered().
+	 * @deprecated 16.3.0 This method is not supported.
+	 *
+	 * @return array[]
+	 */
+	public function get_all_webfonts() {
+		_deprecated_function( __METHOD__, 'Gutenberg 14.9.1', 'wp_fonts()->get_registered()' );
+		return array();
+	}
+
+	/**
+	 * Registers a webfont.
+	 *
+	 * @since 6.0.0
+	 * @deprecated GB 14.9.1 Use wp_register_fonts().
+	 * @deprecated 16.3.0 Register is not supported.
+	 *
+	 * @return bool False.
+	 */
+	public function register_webfont() {
+		_deprecated_function( __METHOD__, 'GB 14.9.1', 'wp_register_fonts()' );
+		return false;
+	}
+
+	/**
+	 * Enqueue a font-family that has been already registered.
+	 *
+	 * @since XX.X
+	 * @deprecated 14.9.1 Use wp_enqueue_fonts().
+	 * @deprecated 16.3.0 Register is not supported.
+	 *
+	 * @return bool False.
+	 */
+	public function enqueue_webfont() {
+		_deprecated_function( __METHOD__, 'Gutenberg 14.9.1' );
+		return false;
+	}
+}

--- a/lib/experimental/fonts/bc-layer/webfonts-deprecations.php
+++ b/lib/experimental/fonts/bc-layer/webfonts-deprecations.php
@@ -1,0 +1,291 @@
+<?php
+/**
+ * Deprecated functions provided here to give extenders time to change
+ * their plugins/themes before this API is introduced into Core.
+ *
+ * BACKPORT NOTE: Do not backport these deprecated functions to Core.
+ *
+ * @package    WordPress
+ * @subpackage Fonts API
+ * @since      X.X.X
+ */
+
+if ( ! function_exists( 'wp_webfonts' ) ) {
+	/**
+	 * Initialize $wp_webfonts if it has not been set.
+	 *
+	 * @since X.X.X
+	 * @deprecated 15.1 Use wp_fonts() instead.
+	 * @deprecated 16.3.0 No longer functional. Do not use.
+	 *
+	 * @global WP_Webfonts $wp_webfonts
+	 *
+	 * @return WP_Webfonts WP_Webfonts instance.
+	 */
+	function wp_webfonts() {
+		_deprecated_function( __FUNCTION__, 'Gutenberg 15.1' );
+
+		global $wp_webfonts;
+
+		if ( ! ( $wp_webfonts instanceof WP_Webfonts ) ) {
+			$wp_webfonts = new WP_Webfonts( wp_fonts() );
+		}
+
+		return $wp_webfonts;
+	}
+}
+
+if ( ! function_exists( 'wp_register_webfonts' ) ) {
+	/**
+	 * Registers one or more font-families and each of their variations.
+	 *
+	 * @since X.X.X
+	 * @deprecated 15.1 Use wp_register_fonts() instead.
+	 * @deprecated 16.3.0 Register is not supported.
+	 *
+	 * @return array Empty array.
+	 */
+	function wp_register_webfonts() {
+		_deprecated_function( __FUNCTION__, 'Gutenberg 15.1' );
+		return array();
+	}
+}
+
+if ( ! function_exists( 'wp_register_webfont' ) ) {
+	/**
+	 * Registers a single webfont.
+	 *
+	 * @since X.X.X
+	 * @deprecated 14.9.1 Use wp_register_fonts().
+	 * @deprecated 16.3.0 Register is not supported.
+	 *
+	 * @return bool False.
+	 */
+	function wp_register_webfont() {
+		_deprecated_function( __FUNCTION__, 'Gutenberg 14.9.1' );
+		return false;
+	}
+}
+
+if ( ! function_exists( 'wp_enqueue_webfonts' ) ) {
+	/**
+	 * Enqueues one or more font family and all of its variations.
+	 *
+	 * @since X.X.X
+	 * @deprecated 15.1 Use wp_enqueue_fonts() instead.
+	 * @deprecated 16.3.0 Enqueue is not supported.
+	 */
+	function wp_enqueue_webfonts() {
+		_deprecated_function( __FUNCTION__, 'Gutenberg 15.1' );
+	}
+}
+
+if ( ! function_exists( 'wp_enqueue_webfont' ) ) {
+	/**
+	 * Enqueue a single font family that has been registered beforehand.
+	 *
+	 * @since X.X.X
+	 * @deprecated 14.9.1 Use wp_enqueue_fonts() instead.
+	 * @deprecated 16.3.0 Enqueue is not supported.
+	 *
+	 * @return bool False.
+	 */
+	function wp_enqueue_webfont() {
+		_deprecated_function( __FUNCTION__, 'Gutenberg 14.9.1' );
+		return false;
+	}
+}
+
+if ( ! function_exists( 'wp_enqueue_webfont_variations' ) ) {
+	/**
+	 * Enqueues a specific set of web font variations.
+	 *
+	 * @since X.X.X
+	 * @deprecated 15.1 Use wp_enqueue_font_variations() instead.
+	 * @deprecated 16.3.0 No longer functional. Do not use.
+	 */
+	function wp_enqueue_webfont_variations() {
+		_deprecated_function( __FUNCTION__, 'Gutenberg 15.1' );
+	}
+}
+
+if ( ! function_exists( 'wp_deregister_webfont_variation' ) ) {
+	/**
+	 * Deregisters a font variation.
+	 *
+	 * @since 14.9.1
+	 * @deprecated 15.1 Use wp_deregister_font_variation() instead.
+	 * @deprecated 16.3.0 Deregister is not supported.
+	 */
+	function wp_deregister_webfont_variation() {
+		_deprecated_function( __FUNCTION__, 'Gutenberg 15.1' );
+	}
+}
+
+if ( ! function_exists( 'wp_get_webfont_providers' ) ) {
+	/**
+	 * Gets all registered providers.
+	 *
+	 * @since X.X.X
+	 * @deprecated 14.9.1 Use wp_fonts()->get_providers().
+	 * @deprecated 16.3.0 Providers are not supported.
+	 *
+	 * @return array Empty array.
+	 */
+	function wp_get_webfont_providers() {
+		_deprecated_function( __FUNCTION__, '14.9.1' );
+
+		return array();
+	}
+}
+
+if ( ! function_exists( 'wp_register_webfont_provider' ) ) {
+	/**
+	 * Registers a custom font service provider.
+	 *
+	 * @since X.X.X
+	 * @deprecated 15.1 Use wp_register_font_provider() instead.
+	 * @deprecated 16.3.0 Providers are not supported.
+	 *
+	 * @return bool False.
+	 */
+	function wp_register_webfont_provider() {
+		_deprecated_function( __FUNCTION__, 'GB 15.1', 'wp_register_font_provider' );
+		return false;
+	}
+}
+
+if ( ! function_exists( 'wp_print_webfonts' ) ) {
+	/**
+	 * Invokes each provider to process and print its styles.
+	 *
+	 * @since 14.9.1
+	 * @deprecated 15.1 Use wp_print_fonts() instead.
+	 * @deprecated 16.3.0 Webfonts API is not supported.
+	 *
+	 * @return array Empty array.
+	 */
+	function wp_print_webfonts() {
+		_deprecated_function( __FUNCTION__, 'Gutenberg 15.1', 'wp_print_font_faces' );
+		return array();
+	}
+}
+
+if ( ! function_exists( 'wp_fonts' ) ) {
+	/**
+	 * Initialize $wp_fonts if it has not been set.
+	 *
+	 * @since X.X.X
+	 * @deprecated 16.3.0 Use Fonts Library and Font Face. Fonts API is not supported.
+	 *
+	 * @global WP_Fonts $wp_fonts
+	 *
+	 * @return WP_Fonts WP_Fonts instance.
+	 */
+	function wp_fonts() {
+		_deprecated_function( __FUNCTION__, 'Gutenberg 16.3' );
+
+		global $wp_fonts;
+
+		if ( ! ( $wp_fonts instanceof WP_Fonts ) ) {
+			$wp_fonts = new WP_Fonts();
+		}
+
+		return $wp_fonts;
+	}
+}
+
+if ( ! function_exists( 'wp_register_fonts' ) ) {
+	/**
+	 * Registers one or more font-families and each of their variations.
+	 *
+	 * @since X.X.X
+	 * @deprecated 16.3.0 Register is not supported.
+	 *
+	 * @return array Empty array.
+	 */
+	function wp_register_fonts() {
+		_deprecated_function( __FUNCTION__, 'Gutenberg 16.3' );
+		return array();
+	}
+}
+
+if ( ! function_exists( 'wp_enqueue_fonts' ) ) {
+	/**
+	 * Enqueues one or more font family and all of its variations.
+	 *
+	 * @since X.X.X
+	 * @deprecated 16.3.0 Enqueue is not supported.
+	 */
+	function wp_enqueue_fonts() {
+		_deprecated_function( __FUNCTION__, 'Gutenberg 16.3' );
+	}
+}
+
+if ( ! function_exists( 'wp_enqueue_font_variations' ) ) {
+	/**
+	 * Enqueues a specific set of font variations.
+	 *
+	 * @since X.X.X
+	 * @deprecated 16.3.0 Enqueue is not supported.
+	 */
+	function wp_enqueue_font_variations() {
+		_deprecated_function( __FUNCTION__, 'Gutenberg 16.3' );
+	}
+}
+
+if ( ! function_exists( 'wp_deregister_font_family' ) ) {
+	/**
+	 * Deregisters a font family and all of its registered variations.
+	 *
+	 * @since X.X.X
+	 * @deprecated 16.3.0 Deregister is not supported.
+	 */
+	function wp_deregister_font_family() {
+		_deprecated_function( __FUNCTION__, 'Gutenberg 16.3' );
+	}
+}
+
+if ( ! function_exists( 'wp_deregister_font_variation' ) ) {
+	/**
+	 * Deregisters a font variation.
+	 *
+	 * @since X.X.X
+	 * @deprecated 16.3.0 Deregister is not supported.
+	 */
+	function wp_deregister_font_variation() {
+		_deprecated_function( __FUNCTION__, 'Gutenberg 16.3' );
+	}
+}
+
+if ( ! function_exists( 'wp_register_font_provider' ) ) {
+	/**
+	 * Registers a custom font service provider.
+	 *
+	 * @since X.X.X
+	 * @deprecated 16.3.0 Providers are not supported.
+	 *
+	 * @return bool False.
+	 */
+	function wp_register_font_provider() {
+		_deprecated_function( __FUNCTION__, 'Gutenberg 16.3' );
+		return false;
+	}
+}
+
+if ( ! function_exists( 'wp_print_fonts' ) ) {
+	/**
+	 * Invokes each provider to process and print its styles.
+	 *
+	 * @since X.X.X
+	 * @deprecated 16.3.0 For classic themes, use wp_print_font_faces(). For all other sites,
+	 *                    Font Face will automatically print all fonts in theme.json merged data layer,
+	 *                    including in theme and user activated fonts from the Fonts Library.
+	 *
+	 * @return array Empty array.
+	 */
+	function wp_print_fonts() {
+		_deprecated_function( __FUNCTION__, 'Gutenberg 16.3', 'wp_print_font_faces' );
+		return array();
+	}
+}

--- a/lib/load.php
+++ b/lib/load.php
@@ -149,7 +149,6 @@ if ( class_exists( 'WP_Fonts_Library' ) || class_exists( 'WP_Fonts_Library_Contr
 		require __DIR__ . '/experimental/fonts/bc-layer/class-wp-fonts.php';
 		require __DIR__ . '/experimental/fonts/bc-layer/class-wp-fonts-provider-local.php';
 		require __DIR__ . '/experimental/fonts/bc-layer/class-wp-fonts-resolver.php';
-		require __DIR__ . '/experimental/fonts/bc-layer/fonts-api.php';
 		require __DIR__ . '/experimental/fonts/bc-layer/class-gutenberg-fonts-api-bc-layer.php';
 		require __DIR__ . '/experimental/fonts/bc-layer/webfonts-deprecations.php';
 		require __DIR__ . '/experimental/fonts/bc-layer/class-wp-webfonts-utils.php';

--- a/lib/load.php
+++ b/lib/load.php
@@ -142,6 +142,21 @@ if ( class_exists( 'WP_Fonts_Library' ) || class_exists( 'WP_Fonts_Library_Contr
 		require __DIR__ . '/experimental/fonts/class-wp-font-face.php';
 		require __DIR__ . '/experimental/fonts/class-wp-font-face-resolver.php';
 		require __DIR__ . '/experimental/fonts/fonts.php';
+
+		// Load the BC Layer. Do no backport to WP Core.
+		require __DIR__ . '/experimental/fonts/bc-layer/class-wp-fonts-provider.php';
+		require __DIR__ . '/experimental/fonts/bc-layer/class-wp-fonts-utils.php';
+		require __DIR__ . '/experimental/fonts/bc-layer/class-wp-fonts.php';
+		require __DIR__ . '/experimental/fonts/bc-layer/class-wp-fonts-provider-local.php';
+		require __DIR__ . '/experimental/fonts/bc-layer/class-wp-fonts-resolver.php';
+		require __DIR__ . '/experimental/fonts/bc-layer/fonts-api.php';
+		require __DIR__ . '/experimental/fonts/bc-layer/class-gutenberg-fonts-api-bc-layer.php';
+		require __DIR__ . '/experimental/fonts/bc-layer/webfonts-deprecations.php';
+		require __DIR__ . '/experimental/fonts/bc-layer/class-wp-webfonts-utils.php';
+		require __DIR__ . '/experimental/fonts/bc-layer/class-wp-webfonts-provider.php';
+		require __DIR__ . '/experimental/fonts/bc-layer/class-wp-webfonts-provider-local.php';
+		require __DIR__ . '/experimental/fonts/bc-layer/class-wp-webfonts.php';
+		require __DIR__ . '/experimental/fonts/bc-layer/class-wp-web-fonts.php';
 	}
 } elseif ( ! class_exists( 'WP_Fonts' ) ) {
 	// Fonts API files.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

Closes [51819](https://github.com/WordPress/gutenberg/issues/51819).

## What?
<!-- In a few words, what is the PR actually doing? -->

Creates a BC Layer in the new Font Face.

Deprecates all of the Fonts API's public-facing files, functions, classes, and methods.

Makes the Fonts API non-functional, i.e. as Font Face replaces it.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Font Face replaces Fonts API.

For sites using the Fonts API, this PR:

1. Avoids those sites experiencing a fatal parsing error.
2. Makes the Fonts API non-functional to avoid conflicts with the [new font management approach](https://github.com/WordPress/gutenberg/issues/45271).

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

1. Copies all of the Fonts API's files into a new `fonts/bc-layer` directory.
2. Removes all `private` methods.
3. Removes all functionality from remaining functions and methods.
4. Deprecates all of the files, classes, functions, and methods.
5. Loads the files into memory (to avoid fatal parsing errors on sites using it).

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

### Set up
1. Enable the loading of the Font Face files:
    a. Open `lib/load.php`.
    b. Scroll down to where the Font Face files are loaded.
    c. Add `true || ` in the `if`:

```php
if ( true || class_exists( 'WP_Fonts_Library' ) || class_exists( 'WP_Fonts_Library_Controller' ) ) {
```

2. Plugin using the Fonts API:
* Install and activate [this test plugin](https://github.com/ironprogrammer/webfonts-jetpack-test).
* Comment out these [3 lines of code](https://github.com/ironprogrammer/webfonts-jetpack-test/blob/master/webfonts.php#L75-L77) in the `webfonts.php` file:

```php
                 if ( ! function_exists( 'wp_register_font_provider' ) || ! function_exists( 'wp_register_fonts' ) ) {
                        return;
                }
```

#### Reproduce the fatal error

Before applying the changes from this PR (or comment out the BC Layer files loading in `lib/load.php`, refresh the admin page on your test site.

Expected: Fatal error such as:

```
Fatal error: Uncaught Error: Call to undefined function wp_register_font_provider() in ../wp-content/plugins/webfonts-jetpack-test/webfonts.php:79
```

the path to the `webfonts.php` will be different in your test site.

This fatal error happens because the tester plugin is using the Fonts API but it is not loaded into memory.

#### Test this PR

1. Apply the changes from this PR to your local testing site.
2. Refresh the admin page.
Expected: No fatal error. There will be deprecation notices as the tester plugin is using the Fonts API (which is now deprecated).
3. Check that none of the Google Fonts from the tester plugin are in the font pickers:
   a. Go to Site Editor > Styles > Typography > Headings.
   b. Select "FONT".
Expected: Google Fonts such as Arvo, Merriweather, Open Sans, etc. are not in the list. Rather, only the theme's fonts in the list.

Using TT3, the FONT picker should contain:
- Default
- DM Sans
- IBM Plex Mono
- Inter
- System Font
- Source Serif Pro
![Screen Shot 2023-07-11 at 3 48 19 PM](https://github.com/WordPress/gutenberg/assets/7284611/2e9d75f9-8da2-4009-a4de-328ba308a8d2)

Note: To see all of the Google Fonts the tester plugin registers, remove the `true` so that the Font Face libs are not loaded.