### PR TITLE
Patterns: Check that core hasn't already moved sync status meta before moving and unsetting

### DIFF
--- a/lib/compat/wordpress-6.3/class-gutenberg-rest-blocks-controller.php
+++ b/lib/compat/wordpress-6.3/class-gutenberg-rest-blocks-controller.php
@@ -38,7 +38,11 @@ class Gutenberg_REST_Blocks_Controller extends WP_REST_Blocks_Controller {
 		 */
 		unset( $data['title']['rendered'] );
 		unset( $data['content']['rendered'] );
-
+		
+		// If `$data['wp_pattern_sync_status']` is already set core 6.3 + has already done the job of setting this so return early.
+		if ( isset( $data['wp_pattern_sync_status'] ) ) {
+			return $data;
+		}
 		// Add the core wp_pattern_sync_status meta as top level property to the response.
 		$data['wp_pattern_sync_status'] = isset( $data['meta']['wp_pattern_sync_status'] ) ? $data['meta']['wp_pattern_sync_status'] : '';
 		unset( $data['meta']['wp_pattern_sync_status'] );

--- a/lib/compat/wordpress-6.3/class-gutenberg-rest-blocks-controller.php
+++ b/lib/compat/wordpress-6.3/class-gutenberg-rest-blocks-controller.php
@@ -38,7 +38,7 @@ class Gutenberg_REST_Blocks_Controller extends WP_REST_Blocks_Controller {
 		 */
 		unset( $data['title']['rendered'] );
 		unset( $data['content']['rendered'] );
-		
+
 		// If `$data['wp_pattern_sync_status']` is already set core 6.3 + has already done the job of setting this so return early.
 		if ( isset( $data['wp_pattern_sync_status'] ) ) {
 			return $data;


### PR DESCRIPTION
## What?
Adds a check to the 6.3 compat REST controller to make sure that core 6.3+ hasn't already moved and unset the `wp_pattern_sync_status` meta before trying to move it

## Why?
Without this in place if running plugin on 6.3+ `wp_pattern_sync_status` always ends up empty so unsynced blocks appear as synced.

## How?
Check for existence of post `$data['wp_pattern_sync_status']` and if so assume in 6.3+ and return early.

## Testing Instructions
1. On 6.2.2 with plugin installed try adding synced and unsynced patterns via post editor and site editor and check that they appear as the correct sync status in the inserter
2. On 6.3 beta with plugin installed try adding synced and unsynced patterns via post editor and site editor and check that they appear as the correct sync status in the inserter

