### PR TITLE
Patterns: Rename edit label to Edit Block Pattern to resolve edge case in Chrome

### DIFF
--- a/lib/compat/wordpress-6.3/blocks.php
+++ b/lib/compat/wordpress-6.3/blocks.php
@@ -45,7 +45,7 @@ function gutenberg_rename_reusable_block_cpt_to_pattern( $args, $post_type ) {
 		$args['labels']['singular_name']            = _x( 'Pattern', 'post type singular name' );
 		$args['labels']['add_new_item']             = __( 'Add new Pattern' );
 		$args['labels']['new_item']                 = __( 'New Pattern' );
-		$args['labels']['edit_item']                = __( 'Edit Pattern' );
+		$args['labels']['edit_item']                = __( 'Edit Block Pattern' );
 		$args['labels']['view_item']                = __( 'View Pattern' );
 		$args['labels']['view_items']               = __( 'View Patterns' );
 		$args['labels']['all_items']                = __( 'All Patterns' );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Backport from core: https://github.com/WordPress/wordpress-develop/pull/4826 — rename the Pattern post type's `edit_item` label to be `Edit Block Pattern`.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

This resolves an issue in Chrome where the browser thinks that the page is in German and displays a translation popup. As mentioned in the linked PR, the reason Chrome does this isn't quite clear, but it's possibly related to there not being very much English text in the server-rendered view of the page (Chrome ignores the document's `lang` attribute and does what it wants). In manual testing, adding another English word to the edit item label resolves it for now.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Update `Edit Pattern` to `Edit Block Pattern` for the Pattern post type.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Go to `/wp-admin/edit.php?post_type=wp_block` to view the list of patterns.
2. If you don't already have any patterns, add one, and then go back to that list.
3. Click to edit one of the patterns. Before this PR, Chrome will display a popup to translate from German to English.
4. With this PR applied, there should be no popup displayed.

When testing, go from the `wp-admin` page and click the edit link on the pattern to test whether or not the translation popup is displayed.

## Screenshots or screencast <!-- if applicable -->

| Before | After |
| --- | --- |
| ![image](https://github.com/WordPress/gutenberg/assets/14988353/ddfb8101-ac1b-4b6e-8506-bebd130072a4) | ![image](https://github.com/WordPress/gutenberg/assets/14988353/d5f2d320-c5f2-4ea9-a65b-107a55d06703) |