### PR TITLE
Update locked pattern tooltips

### DIFF
--- a/packages/edit-site/src/components/page-patterns/grid-item.js
+++ b/packages/edit-site/src/components/page-patterns/grid-item.js
@@ -210,9 +210,7 @@ function GridItem( { categoryId, item, ...props } ) {
 						{ item.type === PATTERNS && (
 							<Tooltip
 								position="top center"
-								text={ __(
-									'Theme & plugin patterns cannot be edited.'
-								) }
+								text={ __( 'This pattern cannot be edited.' ) }
 							>
 								<span className="edit-site-patterns__pattern-lock-icon">
 									<Icon icon={ lockSmall } size={ 24 } />

--- a/packages/edit-site/src/components/page-patterns/grid-item.js
+++ b/packages/edit-site/src/components/page-patterns/grid-item.js
@@ -114,7 +114,9 @@ function GridItem( { categoryId, item, ...props } ) {
 	}
 
 	if ( isNonUserPattern ) {
-		ariaDescriptions.push( __( 'Theme patterns cannot be edited.' ) );
+		ariaDescriptions.push(
+			__( 'Theme & plugin patterns cannot be edited.' )
+		);
 	}
 
 	const itemIcon =
@@ -209,7 +211,7 @@ function GridItem( { categoryId, item, ...props } ) {
 							<Tooltip
 								position="top center"
 								text={ __(
-									'Theme patterns cannot be edited.'
+									'Theme & plugin patterns cannot be edited.'
 								) }
 							>
 								<span className="edit-site-patterns__pattern-lock-icon">

--- a/packages/edit-site/src/components/sidebar-navigation-screen-patterns/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-patterns/index.js
@@ -75,7 +75,7 @@ function ThemePatternsGroup( { categories, currentCategory, currentType } ) {
 								<Tooltip
 									position="top center"
 									text={ __(
-										'Theme patterns cannot be edited.'
+										'Theme & plugin patterns cannot be edited.'
 									) }
 								>
 									<span className="edit-site-sidebar-navigation-screen-pattern__lock-icon">

--- a/packages/edit-site/src/components/sidebar-navigation-screen-patterns/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-patterns/index.js
@@ -12,7 +12,7 @@ import {
 import { useViewportMatch } from '@wordpress/compose';
 import { useSelect } from '@wordpress/data';
 import { getTemplatePartIcon } from '@wordpress/editor';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { getQueryArgs } from '@wordpress/url';
 import { file, starFilled, lockSmall } from '@wordpress/icons';
 
@@ -74,8 +74,10 @@ function ThemePatternsGroup( { categories, currentCategory, currentType } ) {
 								{ category.label }
 								<Tooltip
 									position="top center"
-									text={ __(
-										'Theme & plugin patterns cannot be edited.'
+									text={ sprintf(
+										// translators: %s: The pattern category name.
+										'"%s" patterns cannot be edited.',
+										category.label
 									) }
 								>
 									<span className="edit-site-sidebar-navigation-screen-pattern__lock-icon">


### PR DESCRIPTION
## What?
Update locked pattern tooltips to include plugins.

## Why?
Currently, hovering the lock icon on patterns added by a _plugin_ reveals a tooltip stating:

> **Theme** patterns cannot be edited.

This PR updates that string to include plugins:

<img width="350" alt="Screenshot 2023-07-11 at 09 41 46" src="https://github.com/WordPress/gutenberg/assets/846565/6a204477-e936-432a-aa86-3bae53402539">


## How?
Update text string.

## Testing Instructions.
1. Have some theme and plugin patterns active on your site.
2. Open the pattern library.
3. Mouse over the lock icon on plugin / theme categories.
4. Observe the updated tooltip.

It might be nice to add some logic to make the tooltip contextual, but I'm not sure it's worth the effort. This feels like an easy change to cover the issue of mis-labelled plugin patterns.
