### PR TITLE
Project automation: don't run e2e tests on documentation-only PRs

### DIFF
--- a/.github/workflows/end2end-test.yml
+++ b/.github/workflows/end2end-test.yml
@@ -2,7 +2,11 @@ name: End-to-End Tests
 
 on:
     pull_request:
+        paths-ignore:
+          - '**.md'
     push:
+        paths-ignore:
+          - '**.md'
         branches:
             - trunk
             - 'release/**'


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Don't run e2e tests on documentation-only PRs

## Why?
The benefits of not running e2e tests when PRs only contain documentation changes are twofold:
- It improves the contributor experience by avoiding unnecessary waiting times and other issues that might arise with flaky tests.
- It alleviates the usage of GitHub runners.

## How?
By adding a `paths-ignore` [filter](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-excluding-paths) to the e2e tests action that checks for markdown-only changes.  

## Testing Instructions
@ockham, is there a way to test this without actually pushing the PR? In a repo fork? 😅 