### PR TITLE
Block Editor: Display variation icon in the 'BlockDraggable' component

### DIFF
--- a/packages/block-editor/src/components/block-draggable/index.js
+++ b/packages/block-editor/src/components/block-draggable/index.js
@@ -22,16 +22,25 @@ const BlockDraggable = ( {
 } ) => {
 	const { srcRootClientId, isDraggable, icon } = useSelect(
 		( select ) => {
-			const { canMoveBlocks, getBlockRootClientId, getBlockName } =
-				select( blockEditorStore );
-			const { getBlockType } = select( blocksStore );
+			const {
+				canMoveBlocks,
+				getBlockRootClientId,
+				getBlockName,
+				getBlockAttributes,
+			} = select( blockEditorStore );
+			const { getBlockType, getActiveBlockVariation } =
+				select( blocksStore );
 			const rootClientId = getBlockRootClientId( clientIds[ 0 ] );
 			const blockName = getBlockName( clientIds[ 0 ] );
+			const variation = getActiveBlockVariation(
+				blockName,
+				getBlockAttributes( clientIds[ 0 ] )
+			);
 
 			return {
 				srcRootClientId: rootClientId,
 				isDraggable: canMoveBlocks( clientIds, rootClientId ),
-				icon: getBlockType( blockName )?.icon,
+				icon: variation?.icon || getBlockType( blockName )?.icon,
 			};
 		},
 		[ clientIds ]


### PR DESCRIPTION
## What?
Fixes #52461.

PR fixes the icon displayed by the `BlockDraggable` component when dragging a block variation.

## How?
Use the icon from matched block variation and fallback to the default block type icon.

## Testing Instructions
1. Open Site Editor.
2. Try dragging the footer or header template part.
3. Confirm dragging chip displays the correct icon.

## Screenshots or screencast <!-- if applicable -->

![CleanShot 2023-07-11 at 14 15 32](https://github.com/WordPress/gutenberg/assets/240569/ca79fd93-6ae1-4b67-a120-489fea2ffb96)
