### PR TITLE
Edit Site: Fix the pattern with the post types becomes the placeholder pattern when editing template part

### DIFF
--- a/packages/edit-site/src/components/block-editor/use-site-editor-settings.js
+++ b/packages/edit-site/src/components/block-editor/use-site-editor-settings.js
@@ -11,16 +11,17 @@ import { store as editSiteStore } from '../../store';
 import { unlock } from '../../lock-unlock';
 import inserterMediaCategories from './inserter-media-categories';
 
-export default function useSiteEditorSettings( templateType ) {
+export default function useSiteEditorSettings() {
 	const { setIsInserterOpened } = useDispatch( editSiteStore );
-	const { storedSettings, canvasMode } = useSelect(
+	const { storedSettings, canvasMode, templateType } = useSelect(
 		( select ) => {
-			const { getSettings, getCanvasMode } = unlock(
+			const { getSettings, getCanvasMode, getEditedPostType } = unlock(
 				select( editSiteStore )
 			);
 			return {
 				storedSettings: getSettings( setIsInserterOpened ),
 				canvasMode: getCanvasMode(),
+				templateType: getEditedPostType(),
 			};
 		},
 		[ setIsInserterOpened ]


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

The pattern with the post types becomes the placeholder pattern since the site editor only allows patterns with the specific post type. However, the allowed post type is always `undefined` because we never pass the value when calling the hook.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

This resolves https://github.com/Automattic/wp-calypso/issues/79145 that the pattern with `wp_template_part` post type becomes the placeholder pattern when you're editing the template part and you cannot do anything on the placeholder pattern.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

The `useSiteEditorSettings` hook supports `templateType` as an argument, just pass the value to it so it can filter the patterns out with the specific post type correctly.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Download TT3 from https://wordpress.org/themes/twentytwentythree/
2. Edit the `patterns/footer-default.php` pattern as followed
  ```diff
     /**
      * Title: Default Footer
      * Slug: twentytwentythree/footer-default
      * Categories: footer
      * Block Types: core/template-part/footer
      * Block Types: core/template-part
+   * Post Types: wp_template, wp_template_part, page
      */
  ```
3. Zip the modified TT3 theme and upload again
5. Go to the site editor to edit the footer template part
6. Before this patch, you will see the placeholder pattern and you cannot do anything on it
7. After this patch, the footer template part will be displayed correctly

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

| Before | After |
| - | - |
| ![image](https://github.com/WordPress/gutenberg/assets/13596067/163444f2-349f-40d5-a00b-853017898702) | ![image](https://github.com/WordPress/gutenberg/assets/13596067/9369e5ed-4721-4c99-8453-7eef1b5ff8ea) |
