### PR TITLE
Remove footnote from RichText toolbar if already present

### DIFF
--- a/packages/block-library/src/footnotes/format.js
+++ b/packages/block-library/src/footnotes/format.js
@@ -8,7 +8,7 @@ import { v4 as createId } from 'uuid';
  */
 import { __ } from '@wordpress/i18n';
 import { formatListNumbered as icon } from '@wordpress/icons';
-import { insertObject } from '@wordpress/rich-text';
+import { remove, insertObject } from '@wordpress/rich-text';
 import {
 	RichTextToolbarButton,
 	store as blockEditorStore,
@@ -40,7 +40,13 @@ export const format = {
 		} = useSelect( blockEditorStore );
 		const { selectionChange, insertBlock } =
 			useDispatch( blockEditorStore );
+
 		function onClick() {
+			if ( isObjectActive ) {
+				onChange( remove( value, value.start, value.end ) );
+				return;
+			}
+
 			registry.batch( () => {
 				const id = createId();
 				const newValue = insertObject(


### PR DESCRIPTION
## What?
Previously, clicking on the Footnote inline format in the RichText toolbar would always insert a new footnote, even if a footnote was already selected. With this pull request, footnotes behave like other formats, which means that the format button acts as a toggle:

**Before**

https://github.com/WordPress/gutenberg/assets/150562/0926b019-fcc6-4810-9164-f2b765428666

**After**

https://github.com/WordPress/gutenberg/assets/150562/dcaf4228-f0e1-4d72-955b-048cebf767ce

## How?

As I understand it, footnotes are a slightly different RichText format. They aren't just a simple inline [format](https://github.com/WordPress/gutenberg/blob/094b13720d2e7720dad9c358fc35b4f82b2e381c/packages/format-library/src/bold/index.js#L22-L25), but a [special object with a replacement](https://github.com/WordPress/gutenberg/blob/094b13720d2e7720dad9c358fc35b4f82b2e381c/packages/rich-text/src/insert-object.js#L24-L30). Notice how most formats are added with `applyFormat` / `toggleFormat`, while for footnotes we [resort to `insertObject`](https://github.com/WordPress/gutenberg/blob/094b13720d2e7720dad9c358fc35b4f82b2e381c/packages/block-library/src/footnotes/format.js#L52-L66). So my answer was to just remove the piece of RichText corresponding to the active object. I hope this is the right approach.

## Testing Instructions
1. Start a post, add some text, then add some footnotes.
1. Verify that there is no change in behaviour when inserting footnotes by accessing the formats toolbar.
2. Select an existing footnote by clicking on its superscript element.
4. Verify that clicking on the now highlighted _Footnote_ toolbar item removes the footnote from the document (and from the Footnotes block).