### PR TITLE
Allow editing existing footnote from RichText formats toolbar

### DIFF
--- a/packages/block-library/src/footnotes/format.js
+++ b/packages/block-library/src/footnotes/format.js
@@ -40,24 +40,30 @@ export const format = {
 		} = useSelect( blockEditorStore );
 		const { selectionChange, insertBlock } =
 			useDispatch( blockEditorStore );
+
 		function onClick() {
 			registry.batch( () => {
-				const id = createId();
-				const newValue = insertObject(
-					value,
-					{
-						type: formatName,
-						attributes: {
-							'data-fn': id,
+				let id;
+				if ( isObjectActive ) {
+					const object = value.replacements[ value.start ];
+					id = object?.attributes?.[ 'data-fn' ];
+				} else {
+					id = createId();
+					const newValue = insertObject(
+						value,
+						{
+							type: formatName,
+							attributes: {
+								'data-fn': id,
+							},
+							innerHTML: `<a href="#${ id }" id="${ id }-link">*</a>`,
 						},
-						innerHTML: `<a href="#${ id }" id="${ id }-link">*</a>`,
-					},
-					value.end,
-					value.end
-				);
-				newValue.start = newValue.end - 1;
-
-				onChange( newValue );
+						value.end,
+						value.end
+					);
+					newValue.start = newValue.end - 1;
+					onChange( newValue );
+				}
 
 				// BFS search to find the first footnote block.
 				let fnBlock = null;


### PR DESCRIPTION
Alternative to #52504
Fixes #52176

## What?

Previously, clicking on the Footnote inline format in the RichText toolbar would always insert a new footnote, even if a footnote was already selected. With this pull request, clicking on the _Footnote_ item when a footnote is already selected (in RichText parlance: when the footnote object is active) focuses the corresponding entry in the Footnotes block.

**If no Footnotes block is present, one will be automatically added.** This is the existing behaviour when inserting a new footnote.

## Why?

I am leaning more towards this pull request than #52504. In particularly, I think it provides an adequate solution to #52176.

## How?

This pull request is best read with [whitespace changes hidden](https://github.com/WordPress/gutenberg/pull/52506/files?diff=unified&w=1).

If the footnote object is active, extract the ID of its corresponding entry in the footnotes block. Otherwise, proceed with creating a new object. The logic then proceeds as normally: insert a Footnotes block if none was found, then select its target entry.

## Testing Instructions
1. Start a post, add some text, then add some footnotes.
1. Verify that there is no change in behaviour when inserting footnotes by accessing the formats toolbar.
1. Select an existing footnote by clicking on its superscript element.
1. Verify that clicking on the now highlighted Footnote toolbar item moves focus to the Footnotes block at the appropriate entry.
1. Now delete the Footnotes **block**.
2. Once again, select an existing footnote by clicking on its superscript element.
3. Verify that clicking on the now highlighted Footnote toolbar items causes a fresh Footnotes block to be inserted, after which the corresponding entry receives focus.

## Screenshots or screencast <!-- if applicable -->

**Before**

https://github.com/WordPress/gutenberg/assets/150562/0926b019-fcc6-4810-9164-f2b765428666

**After**

https://github.com/WordPress/gutenberg/assets/150562/f40d2c7e-627b-438a-9e83-5011def1635b