### PR TITLE
Try fixing block context e2e test failure

### DIFF
--- a/packages/e2e-tests/plugins/block-context.php
+++ b/packages/e2e-tests/plugins/block-context.php
@@ -8,10 +8,10 @@
  */
 
 /**
- * Enqueues a custom script for the plugin.
+ * Registers plugin test context blocks.
  */
-function gutenberg_test_enqueue_block_context_script() {
-	wp_enqueue_script(
+function gutenberg_test_register_context_blocks() {
+	wp_register_script(
 		'gutenberg-test-block-context',
 		plugins_url( 'block-context/index.js', __FILE__ ),
 		array(
@@ -22,37 +22,32 @@ function gutenberg_test_enqueue_block_context_script() {
 		filemtime( plugin_dir_path( __FILE__ ) . 'block-context/index.js' ),
 		true
 	);
-}
-add_action( 'init', 'gutenberg_test_enqueue_block_context_script' );
 
-/**
- * Registers plugin test context blocks.
- */
-function gutenberg_test_register_context_blocks() {
 	register_block_type(
 		'gutenberg/test-context-provider',
 		array(
-			'attributes'       => array(
+			'attributes'            => array(
 				'recordId' => array(
 					'type'    => 'number',
 					'default' => 0,
 				),
 			),
-			'provides_context' => array(
+			'provides_context'      => array(
 				'gutenberg/recordId' => 'recordId',
 			),
+			'editor_script_handles' => array( 'gutenberg-test-block-context' ),
 		)
 	);
 
 	register_block_type(
 		'gutenberg/test-context-consumer',
 		array(
-			'uses_context'    => array(
+			'uses_context'          => array(
 				'gutenberg/recordId',
 				'postId',
 				'postType',
 			),
-			'render_callback' => static function( $attributes, $content, $block ) {
+			'render_callback'       => static function( $attributes, $content, $block ) {
 				$ordered_context = array(
 					$block->context['gutenberg/recordId'],
 					$block->context['postId'],
@@ -61,6 +56,7 @@ function gutenberg_test_register_context_blocks() {
 
 				return implode( ',', $ordered_context );
 			},
+			'editor_script_handles' => array( 'gutenberg-test-block-context' ),
 		)
 	);
 }


### PR DESCRIPTION
## What?
Closes #48827.
Closes #48826.

PR tries to fix flaky "Block content" e2e tests.

## Why?
I noticed that this test was failing on the trunk due to a console warning.

Recent failures:
* https://github.com/WordPress/gutenberg/actions/runs/5520467670/jobs/10067132933#step:6:20
* https://github.com/WordPress/gutenberg/actions/runs/5520488014/jobs/10067181545#step:6:20

## How?
Use the `editor_script_handles` argument instead of enqueuing block script separately.

## Testing Instructions
CI should be green.

```
npm run test:e2e -- packages/e2e-tests/specs/editor/plugins/block-context.test.js
```
