### PR TITLE
LinkControl: Fix mark highlight to bold

### DIFF
--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -139,6 +139,12 @@ $preview-image-height: 140px;
 		// Inline block required to preserve white space
 		// between `<mark>` elements and text nodes.
 		display: inline-block;
+
+		mark {
+			font-weight: 600;
+			color: inherit;
+			background-color: transparent;
+		}
 	}
 
 	.components-menu-item__shortcut {
@@ -213,7 +219,7 @@ $preview-image-height: 140px;
 		position: relative;
 
 		mark {
-			font-weight: 700;
+			font-weight: 600;
 			color: inherit;
 			background-color: transparent;
 		}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
A regression where matched text is now highlighted, instead of bolded, in the LinkControl search results. 

## How?
CSS.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a Post or Page.
2. Insert a paragraph block.
3. Add a link. 
4. See highlighted text now bold, instead of highlighted.

## Screenshots or screencast <!-- if applicable -->

| Before  | After |
| ------------- | ------------- |
|<img width="741" alt="CleanShot 2023-07-11 at 11 52 10" src="https://github.com/WordPress/gutenberg/assets/1813435/9090642f-c4dd-4513-b474-92e9364f9748">|<img width="697" alt="CleanShot 2023-07-11 at 11 50 41" src="https://github.com/WordPress/gutenberg/assets/1813435/bf75479f-f0ac-4d07-a88f-51b5413bb9ee">|


