### PR TITLE
Trim footnote anchors from excerpts

### DIFF
--- a/lib/compat/wordpress-6.3/footnotes.php
+++ b/lib/compat/wordpress-6.3/footnotes.php
@@ -1,11 +1,24 @@
 <?php
+/**
+ * Compatiblity filters for improved footnotes support.
+ *
+ * In core, this could be fixed directly in key functions.
+ *
+ * @package gutenberg
+ */
 
+/**
+ * Trims footnote anchors from content.
+ *
+ * @param string $content HTML content.
+ * @return string Filtered content.
+ */
 function gutenberg_trim_footnotes( $content ) {
 	if ( ! doing_filter( 'get_the_excerpt' ) ) {
 		return $content;
 	}
 
-	static $footnote_pattern =  '_<sup data-fn="[^"]+" class="[^"]+">\s*<a href="[^"]+" id="[^"]+">\d+</a>\s*</sup>_';
+	static $footnote_pattern = '_<sup data-fn="[^"]+" class="[^"]+">\s*<a href="[^"]+" id="[^"]+">\d+</a>\s*</sup>_';
 	return preg_replace( $footnote_pattern, '', $content );
 }
 

--- a/lib/compat/wordpress-6.3/footnotes.php
+++ b/lib/compat/wordpress-6.3/footnotes.php
@@ -1,0 +1,12 @@
+<?php
+
+function gutenberg_trim_footnotes( $content ) {
+	if ( ! doing_filter( 'get_the_excerpt' ) ) {
+		return $content;
+	}
+
+	static $footnote_pattern =  '_<sup data-fn="[^"]+" class="[^"]+">\s*<a href="[^"]+" id="[^"]+">\d+</a>\s*</sup>_';
+	return preg_replace( $footnote_pattern, '', $content );
+}
+
+add_filter( 'the_content', 'gutenberg_trim_footnotes' );

--- a/lib/load.php
+++ b/lib/load.php
@@ -57,6 +57,7 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 	require_once __DIR__ . '/compat/wordpress-6.3/link-template.php';
 	require_once __DIR__ . '/compat/wordpress-6.3/block-patterns.php';
 	require_once __DIR__ . '/compat/wordpress-6.3/class-gutenberg-rest-blocks-controller.php';
+	require_once __DIR__ . '/compat/wordpress-6.3/footnotes.php';
 
 	// Experimental.
 	if ( ! class_exists( 'WP_Rest_Customizer_Nonces' ) ) {


### PR DESCRIPTION
## What?

Fixes #52035

Strips footnote anchors from post content whenever excerpts are being computed by WordPress. That is, this removes the `<sup><a...></sup>` marks, so that a piece of content like "Hello<sup><a href="#">1</a></sup>, world<sup><a href="#">2</a></sup>" becomes "Hello, world".

## Why?
See parent issue.

## How?
Hook into the `the_content` filter, but only when this is part of a wider `get_the_excerpt` filter.

**Question: Is this the best approach to fix the issue?**

## Testing Instructions
1. Start a post, add some text and anchors.
2. Find a way to grab its excerpt, e.g. by rendering it in a template which uses the Post Excerpt block.

## Screenshots or screencast <!-- if applicable -->

On the left: a post with footnotes. On the right: the index page with post excerpts stripped of footnote anchors.

<img width="1512" alt="single-and-home-with-footnotes" src="https://github.com/WordPress/gutenberg/assets/150562/8ec76b09-c78b-4065-b783-53ec37996963">

