### PR TITLE
Search block: Remove unnecessary useEffects

### DIFF
--- a/packages/block-library/src/search/edit.js
+++ b/packages/block-library/src/search/edit.js
@@ -143,25 +143,6 @@ export default function SearchEdit( {
 		defaultValues: { '%': PC_WIDTH_DEFAULT, px: PX_WIDTH_DEFAULT },
 	} );
 
-	useEffect( () => {
-		if ( hasOnlyButton && ! isSelected ) {
-			setAttributes( {
-				isSearchFieldHidden: true,
-			} );
-		}
-	}, [ hasOnlyButton, isSelected, setAttributes ] );
-
-	// Show the search field when width changes.
-	useEffect( () => {
-		if ( ! hasOnlyButton || ! isSelected ) {
-			return;
-		}
-
-		setAttributes( {
-			isSearchFieldHidden: false,
-		} );
-	}, [ hasOnlyButton, isSelected, setAttributes, width ] );
-
 	const getBlockClassNames = () => {
 		return classnames(
 			className,
@@ -264,6 +245,10 @@ export default function SearchEdit( {
 	};
 
 	const renderTextField = () => {
+		if ( hasOnlyButton && ! isSelected ) {
+			return;
+		}
+
 		// If the input is inside the wrapper, the wrapper gets the border color styles/classes, not the input control.
 		const textFieldClasses = classnames(
 			'wp-block-search__input',

--- a/packages/block-library/src/search/edit.js
+++ b/packages/block-library/src/search/edit.js
@@ -143,6 +143,10 @@ export default function SearchEdit( {
 		defaultValues: { '%': PC_WIDTH_DEFAULT, px: PX_WIDTH_DEFAULT },
 	} );
 
+	setAttributes( {
+		isSearchFieldHidden: hasOnlyButton && ! isSelected,
+	} );
+
 	const getBlockClassNames = () => {
 		return classnames(
 			className,
@@ -245,10 +249,6 @@ export default function SearchEdit( {
 	};
 
 	const renderTextField = () => {
-		if ( hasOnlyButton && ! isSelected ) {
-			return;
-		}
-
 		// If the input is inside the wrapper, the wrapper gets the border color styles/classes, not the input control.
 		const textFieldClasses = classnames(
 			'wp-block-search__input',

--- a/packages/block-library/src/search/edit.js
+++ b/packages/block-library/src/search/edit.js
@@ -19,7 +19,7 @@ import {
 	useSetting,
 } from '@wordpress/block-editor';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { useEffect, useRef } from '@wordpress/element';
+import { useEffect, useRef, useState } from '@wordpress/element';
 import {
 	ToolbarDropdownMenu,
 	ToolbarGroup,
@@ -80,10 +80,8 @@ export default function SearchEdit( {
 		buttonPosition,
 		buttonUseIcon,
 		buttonBehavior,
-		isSearchFieldHidden,
 		style,
 	} = attributes;
-
 	const insertedInNavigationBlock = useSelect(
 		( select ) => {
 			const { getBlockParentsByBlockName, wasBlockJustInserted } =
@@ -137,14 +135,13 @@ export default function SearchEdit( {
 	const hasOnlyButton = 'button-only' === buttonPosition;
 	const searchFieldRef = useRef();
 	const buttonRef = useRef();
+	const [ isSearchFieldHidden, setIsSearchFieldHidden ] = useState(
+		hasOnlyButton && ! isSelected
+	);
 
 	const units = useCustomUnits( {
 		availableUnits: [ '%', 'px' ],
 		defaultValues: { '%': PC_WIDTH_DEFAULT, px: PX_WIDTH_DEFAULT },
-	} );
-
-	setAttributes( {
-		isSearchFieldHidden: hasOnlyButton && ! isSelected,
 	} );
 
 	const getBlockClassNames = () => {
@@ -182,7 +179,6 @@ export default function SearchEdit( {
 			onClick: () => {
 				setAttributes( {
 					buttonPosition: 'button-outside',
-					isSearchFieldHidden: false,
 				} );
 			},
 		},
@@ -194,7 +190,6 @@ export default function SearchEdit( {
 			onClick: () => {
 				setAttributes( {
 					buttonPosition: 'button-inside',
-					isSearchFieldHidden: false,
 				} );
 			},
 		},
@@ -206,7 +201,6 @@ export default function SearchEdit( {
 			onClick: () => {
 				setAttributes( {
 					buttonPosition: 'no-button',
-					isSearchFieldHidden: false,
 				} );
 			},
 		},
@@ -218,7 +212,6 @@ export default function SearchEdit( {
 			onClick: () => {
 				setAttributes( {
 					buttonPosition: 'button-only',
-					isSearchFieldHidden: true,
 				} );
 			},
 		},
@@ -303,9 +296,7 @@ export default function SearchEdit( {
 		};
 		const handleButtonClick = () => {
 			if ( hasOnlyButton && BUTTON_BEHAVIOR_EXPAND === buttonBehavior ) {
-				setAttributes( {
-					isSearchFieldHidden: ! isSearchFieldHidden,
-				} );
+				setIsSearchFieldHidden( ! isSearchFieldHidden );
 			}
 		};
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
While looking into https://github.com/WordPress/gutenberg/pull/52342 I discovered that we can simplify the code of the search block quite a bit.

## Why?
useEffects run every time the component is rendered. We should avoid this for performance reasons if we can.

## How?
Rather than triggering this code on every render, I think we can just update the logic about when to show the text field. This is also less code.

## Testing Instructions
1. Add a search block
2. Set it to use the button only option
3. Click the button and confirm that the text field shows in the editor.
