### PR TITLE
Add maxLength to LinkControl search item URLs

### DIFF
--- a/packages/block-editor/src/components/link-control/search-item.js
+++ b/packages/block-editor/src/components/link-control/search-item.js
@@ -54,7 +54,7 @@ export const LinkControlSearchItem = ( {
 } ) => {
 	const info = isURL
 		? __( 'Press ENTER to add this link' )
-		: filterURLForDisplay( safeDecodeURI( suggestion?.url ) );
+		: filterURLForDisplay( safeDecodeURI( suggestion?.url ), 24 );
 
 	return (
 		<MenuItem


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Part of the effort to refine [LinkControl](https://github.com/WordPress/gutenberg/issues/50891) (specifically https://github.com/WordPress/gutenberg/issues/50885) by ensuring URLs are properly truncated past 24 characters. 

A follow-up would be to potentially remove the domain name as well, if it's the home URL. For example, on my site richtabor.com, the About page would render `/about`, instead of `https://richtabor.com/about`. Along with this PR, this would help improve the information density and scan-ability, while also presenting the most relevant information.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a Post or Page.
2. Insert a paragraph block.
3. Create a link. 
4. Search for 'http' or something to bring up one of your attachments (as those have long URLs out of the box). 
5. See the URL truncated.

## Screenshots or screencast <!-- if applicable -->

| Before  | After |
| ------------- | ------------- |
|<img width="346" alt="CleanShot 2023-07-11 at 13 48 35" src="https://github.com/WordPress/gutenberg/assets/1813435/ed643422-0b96-487c-bbc7-8a0f3fca0024">|<img width="348" alt="CleanShot 2023-07-11 at 13 48 02" src="https://github.com/WordPress/gutenberg/assets/1813435/f26c0760-d58f-40f0-b3e0-8cdb675de274">|



