### PR TITLE
Adapt template part hint copy

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen-main/template-part-hint.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-main/template-part-hint.js
@@ -29,7 +29,7 @@ export default function TemplatePartHint() {
 			} }
 		>
 			{ __(
-				'Looking for template parts? You can now find them in the new "Patterns" page.'
+				'Looking for template parts? Find them in the new "Patterns" panel.'
 			) }
 		</Notice>
 	);

--- a/packages/edit-site/src/components/sidebar-navigation-screen-main/template-part-hint.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-main/template-part-hint.js
@@ -28,9 +28,7 @@ export default function TemplatePartHint() {
 				setPreference( 'core', PREFERENCE_NAME, false );
 			} }
 		>
-			{ __(
-				'Looking for template parts? Find them in the new "Patterns" panel.'
-			) }
+			{ __( 'Looking for template parts? Find them in "Patterns".' ) }
 		</Notice>
 	);
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
I don't think we've referred to any of these views as "pages" — that could be confusing. I have "panel" here, which is a bit better, but perhaps there's an alternative? Maybe `Looking for template parts? Find them in "Patterns"`.

## How?
Copy change.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open the site editor.
2. See copy change in the template notice. 

## Screenshots or screencast <!-- if applicable -->

| Before  | After |
| ------------- | ------------- |
|<img width="331" alt="CleanShot 2023-07-11 at 14 39 03" src="https://github.com/WordPress/gutenberg/assets/1813435/8358ab84-2865-4165-be06-584f15847de0">|<img width="333" alt="CleanShot 2023-07-11 at 14 39 17" src="https://github.com/WordPress/gutenberg/assets/1813435/66e49287-86aa-4183-8360-b4ea65185396">|


