### PR TITLE
Fix: enable link editing interface when removing Draft links

### DIFF
--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -590,6 +590,7 @@ export default function NavigationLinkEdit( {
 							link={ attributes }
 							onClose={ () => setIsLinkOpen( false ) }
 							anchor={ popoverAnchor }
+							isDraft={ isDraft }
 							onRemove={ removeLink }
 							onChange={ ( updatedValue ) => {
 								updateAttributes(

--- a/packages/block-library/src/navigation-link/link-ui.js
+++ b/packages/block-library/src/navigation-link/link-ui.js
@@ -193,7 +193,7 @@ export function LinkUI( props ) {
 				showInitialSuggestions={ true }
 				withCreateSuggestion={ userCanCreate }
 				createSuggestion={ handleCreate }
-				forceIsEditingLink={ ! props.isDraft }
+				forceIsEditingLink={ ! props.isDraft && ! url }
 				createSuggestionButtonText={ ( searchTerm ) => {
 					let format;
 

--- a/packages/block-library/src/navigation-link/link-ui.js
+++ b/packages/block-library/src/navigation-link/link-ui.js
@@ -193,6 +193,7 @@ export function LinkUI( props ) {
 				showInitialSuggestions={ true }
 				withCreateSuggestion={ userCanCreate }
 				createSuggestion={ handleCreate }
+				forceIsEditingLink={ ! props.isDraft }
 				createSuggestionButtonText={ ( searchTerm ) => {
 					let format;
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes: https://github.com/WordPress/gutenberg/issues/50180

Handling a special case in which links to Draft pages in the Navigation Block fail to complete the link removal flow, incorrectly displaying an empty Link Preview.

## How?
Uses `forceIsEditingLink` on the `LinkControl` to enable or disable the link editing UI depending on whether or not the page was a Draft. If the page is not a Draft, default behavior is unaffected.

## Testing Instructions
Within the navigation block.
1. Add a new link.
2. Create a draft page from the link editing UI.
3. Remove the link by clicking on the "Unlink" button; UI should go back to Link Editing.