### PR TITLE
Promisify action creator return type for WP data dispatch

### DIFF
--- a/packages/data/CHANGELOG.md
+++ b/packages/data/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### Bug Fix
 
--   The return type for a dispatched action has been changed to a Promise, which matches how actions work.
+-   Update the type definitions for dispatched actions by accounting for Promisified return values and thunks. Previously, a dispatched action's return type was the same as the return type of the original action creator, which did not account for how dispatch works internally. (Plain actions get wrapped in a Promise, and thunk actions ultimately resolve to the innermost function's return type).
+-   Update the type definition for dispatch() to handle string store descriptors correctly.
 
 ## 9.8.0 (2023-07-20)
 

--- a/packages/data/CHANGELOG.md
+++ b/packages/data/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fix
+
+-   The return type for a dispatched action has been changed to a Promise, which matches how actions work.
+
 ## 9.8.0 (2023-07-20)
 
 ## 9.7.0 (2023-07-05)
@@ -62,7 +66,7 @@
 
 ### Breaking Changes
 
-–   Add TypeScript types to the built package (via "types": "build-types" in the package.json)
+– Add TypeScript types to the built package (via "types": "build-types" in the package.json)
 
 ### Bug Fix
 
@@ -100,9 +104,9 @@
 
 ### New Features
 
-- Enabled thunks by default for all stores and removed the `__experimentalUseThunks` flag.
-- Store the resolution errors in store metadata and expose them using `hasResolutionFailed` the `getResolutionError` meta-selectors ([#38669](https://github.com/WordPress/gutenberg/pull/38669)).
-- Expose the resolution status (undefined, resolving, finished, error) via the `getResolutionState` meta-selector ([#38669](https://github.com/WordPress/gutenberg/pull/38669)).
+-   Enabled thunks by default for all stores and removed the `__experimentalUseThunks` flag.
+-   Store the resolution errors in store metadata and expose them using `hasResolutionFailed` the `getResolutionError` meta-selectors ([#38669](https://github.com/WordPress/gutenberg/pull/38669)).
+-   Expose the resolution status (undefined, resolving, finished, error) via the `getResolutionState` meta-selector ([#38669](https://github.com/WordPress/gutenberg/pull/38669)).
 
 ## 6.2.1 (2022-02-10)
 

--- a/packages/data/README.md
+++ b/packages/data/README.md
@@ -499,11 +499,11 @@ dispatch( myCustomStore ).setPrice( 'hammer', 9.75 );
 
 _Parameters_
 
--   _storeNameOrDescriptor_ `string | T`: The store descriptor. The legacy calling convention of passing the store name is also supported.
+-   _storeNameOrDescriptor_ `StoreNameOrDescriptor`: The store descriptor. The legacy calling convention of passing the store name is also supported.
 
 _Returns_
 
--   `ActionCreatorsOf< ConfigOf< T > >`: Object containing the action creators.
+-   `DispatchReturn< StoreNameOrDescriptor >`: Object containing the action creators.
 
 ### plugins
 

--- a/packages/data/src/dispatch.ts
+++ b/packages/data/src/dispatch.ts
@@ -1,12 +1,7 @@
 /**
  * Internal dependencies
  */
-import type {
-	ActionCreatorsOf,
-	AnyConfig,
-	ConfigOf,
-	StoreDescriptor,
-} from './types';
+import type { AnyConfig, StoreDescriptor, DispatchReturn } from './types';
 import defaultRegistry from './default-registry';
 
 /**
@@ -28,8 +23,10 @@ import defaultRegistry from './default-registry';
  * ```
  * @return Object containing the action creators.
  */
-export function dispatch< T extends StoreDescriptor< AnyConfig > >(
-	storeNameOrDescriptor: string | T
-): ActionCreatorsOf< ConfigOf< T > > {
+export function dispatch<
+	StoreNameOrDescriptor extends StoreDescriptor< AnyConfig > | string
+>(
+	storeNameOrDescriptor: StoreNameOrDescriptor
+): DispatchReturn< StoreNameOrDescriptor > {
 	return defaultRegistry.dispatch( storeNameOrDescriptor );
 }

--- a/packages/data/src/types.ts
+++ b/packages/data/src/types.ts
@@ -6,7 +6,7 @@ import type { combineReducers as reduxCombineReducers } from 'redux';
 
 type MapOf< T > = { [ name: string ]: T };
 
-export type ActionCreator = Function | Generator;
+export type ActionCreator = ( ...args: any[] ) => any | Generator;
 export type Resolver = Function | Generator;
 export type Selector = Function;
 
@@ -170,8 +170,16 @@ export type ConfigOf< S > = S extends StoreDescriptor< infer C > ? C : never;
 
 export type ActionCreatorsOf< Config extends AnyConfig > =
 	Config extends ReduxStoreConfig< any, infer ActionCreators, any >
-		? ActionCreators
+		? PromisifiedActionCreator< ActionCreators >
 		: never;
+
+// When dispatching an action creator, the return value is a promise.
+type PromisifiedActionCreator< ActionCreators extends MapOf< ActionCreator > > =
+	{
+		[ Action in keyof ActionCreators ]: (
+			...args: Parameters< ActionCreators[ Action ] >
+		) => Promise< void >;
+	};
 
 type SelectorsOf< Config extends AnyConfig > = Config extends ReduxStoreConfig<
 	any,

--- a/packages/data/src/types.ts
+++ b/packages/data/src/types.ts
@@ -190,13 +190,22 @@ export type PromisifiedActionCreators<
 };
 
 // Wraps action creator return types with a Promise -- also handles thunks by
-// extracting the return type of the inner function of the thunk's action creator.
+// extracting the return type of the inner function of the thunk's action creator,
+// and by accounting for thunks that return a Promise.
 export type PromisifyActionCreator< Action extends ActionCreator > = (
 	...args: Parameters< Action >
 ) => Promise<
 	ReturnType< Action > extends ( ..._args: any[] ) => any
-		? ReturnType< ReturnType< Action > > // Thunks need to be unwrapped twice.
+		? ThunkReturnType< Action >
 		: ReturnType< Action >
+>;
+
+// A thunk is an action creator which returns a function, which can optionally
+// return a Promise. The double ReturnType unwraps the innermost function's
+// return type, and Awaited gets the type the Promise resolves to. If the return
+// type is not a Promise, Awaited returns that original type.
+export type ThunkReturnType< Action extends ActionCreator > = Awaited<
+	ReturnType< ReturnType< Action > >
 >;
 
 type SelectorsOf< Config extends AnyConfig > = Config extends ReduxStoreConfig<

--- a/packages/data/src/types.ts
+++ b/packages/data/src/types.ts
@@ -43,6 +43,7 @@ export interface ReduxStoreConfig<
 	controls?: MapOf< Function >;
 }
 
+// Return type for the useSelect() hook.
 export type UseSelectReturn< F extends MapSelect | StoreDescriptor< any > > =
 	F extends MapSelect
 		? ReturnType< F >
@@ -50,6 +51,7 @@ export type UseSelectReturn< F extends MapSelect | StoreDescriptor< any > > =
 		? CurriedSelectorsOf< F >
 		: never;
 
+// Return type for the useDispatch() hook.
 export type UseDispatchReturn< StoreNameOrDescriptor > =
 	StoreNameOrDescriptor extends StoreDescriptor< any >
 		? ActionCreatorsOf< ConfigOf< StoreNameOrDescriptor > >
@@ -59,9 +61,12 @@ export type UseDispatchReturn< StoreNameOrDescriptor > =
 
 export type DispatchFunction = < StoreNameOrDescriptor >(
 	store: StoreNameOrDescriptor
-) => StoreNameOrDescriptor extends StoreDescriptor< any >
-	? ActionCreatorsOf< ConfigOf< StoreNameOrDescriptor > >
-	: any;
+) => DispatchReturn< StoreNameOrDescriptor >;
+
+export type DispatchReturn< StoreNameOrDescriptor > =
+	StoreNameOrDescriptor extends StoreDescriptor< any >
+		? ActionCreatorsOf< ConfigOf< StoreNameOrDescriptor > >
+		: unknown;
 
 export type MapSelect = (
 	select: SelectFunction,
@@ -185,7 +190,12 @@ export type PromisifiedActionCreators<
 // creator, so that consumers know that they are dealing with a Promise.
 export type PromisifyActionCreator< Action extends ActionCreator > = (
 	...args: Parameters< Action >
-) => Promise< ReturnType< Action > >;
+) => Promise<
+	ReturnType< Action > extends ( ..._args: any[] ) => any
+		? // Thunks return another function, so we unwrap the return type twice in that scenario.
+		  ReturnType< ReturnType< Action > >
+		: ReturnType< Action >
+>;
 
 type SelectorsOf< Config extends AnyConfig > = Config extends ReduxStoreConfig<
 	any,

--- a/packages/data/src/types.ts
+++ b/packages/data/src/types.ts
@@ -185,7 +185,7 @@ export type PromisifiedActionCreators<
 // creator, so that consumers know that they are dealing with a Promise.
 export type PromisifyActionCreator< Action extends ActionCreator > = (
 	...args: Parameters< Action >
-) => Promise< void >;
+) => Promise< ReturnType< Action > >;
 
 type SelectorsOf< Config extends AnyConfig > = Config extends ReduxStoreConfig<
 	any,

--- a/packages/data/src/types.ts
+++ b/packages/data/src/types.ts
@@ -170,16 +170,22 @@ export type ConfigOf< S > = S extends StoreDescriptor< infer C > ? C : never;
 
 export type ActionCreatorsOf< Config extends AnyConfig > =
 	Config extends ReduxStoreConfig< any, infer ActionCreators, any >
-		? PromisifiedActionCreator< ActionCreators >
+		? PromisifiedActionCreators< ActionCreators >
 		: never;
 
-// When dispatching an action creator, the return value is a promise.
-type PromisifiedActionCreator< ActionCreators extends MapOf< ActionCreator > > =
-	{
-		[ Action in keyof ActionCreators ]: (
-			...args: Parameters< ActionCreators[ Action ] >
-		) => Promise< void >;
-	};
+export type PromisifiedActionCreators<
+	ActionCreators extends MapOf< ActionCreator >
+> = {
+	[ Action in keyof ActionCreators ]: PromisifyActionCreator<
+		ActionCreators[ Action ]
+	>;
+};
+
+// A dispatched action returns a Promise. This helper extends the original action
+// creator, so that consumers know that they are dealing with a Promise.
+export type PromisifyActionCreator< Action extends ActionCreator > = (
+	...args: Parameters< Action >
+) => Promise< void >;
 
 type SelectorsOf< Config extends AnyConfig > = Config extends ReduxStoreConfig<
 	any,

--- a/packages/data/src/types.ts
+++ b/packages/data/src/types.ts
@@ -189,9 +189,7 @@ export type PromisifiedActionCreators<
 	>;
 };
 
-// Wraps action creator return types with a Promise -- also handles thunks by
-// extracting the return type of the inner function of the thunk's action creator,
-// and by accounting for thunks that return a Promise.
+// Wraps action creator return types with a Promise and handles thunks.
 export type PromisifyActionCreator< Action extends ActionCreator > = (
 	...args: Parameters< Action >
 ) => Promise<

--- a/packages/data/src/types.ts
+++ b/packages/data/src/types.ts
@@ -178,6 +178,9 @@ export type ActionCreatorsOf< Config extends AnyConfig > =
 		? PromisifiedActionCreators< ActionCreators >
 		: never;
 
+// Takes an object containing all action creators for a store and updates the
+// return type of each action creator to account for internal registry details --
+// for example, dispatched actions are wrapped with a Promise.
 export type PromisifiedActionCreators<
 	ActionCreators extends MapOf< ActionCreator >
 > = {
@@ -186,14 +189,13 @@ export type PromisifiedActionCreators<
 	>;
 };
 
-// A dispatched action returns a Promise. This helper extends the original action
-// creator, so that consumers know that they are dealing with a Promise.
+// Wraps action creator return types with a Promise -- also handles thunks by
+// extracting the return type of the inner function of the thunk's action creator.
 export type PromisifyActionCreator< Action extends ActionCreator > = (
 	...args: Parameters< Action >
 ) => Promise<
 	ReturnType< Action > extends ( ..._args: any[] ) => any
-		? // Thunks return another function, so we unwrap the return type twice in that scenario.
-		  ReturnType< ReturnType< Action > >
+		? ReturnType< ReturnType< Action > > // Thunks need to be unwrapped twice.
 		: ReturnType< Action >
 >;
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
I've been working on integrating a `@wordpress/data` update into a different repo. There is an existing code snippet like this:

```ts
const { doSomething } = useDispatch( storeDescriptor );
doSomething().then( doSomethingElse );
```

However, this fails because `.then` does not exist on `doSomething` (e.g. the action creator doesn't return a promise)

## Why?
According to the documentation, this is a valid use case. However, our types prevent this because `doSomething` retains its original return type and isn't wrapped with a promise.

This was also fixed in the DT types, but that fix never made it here (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/60693)

## How?
I'm attempting to add a wrapper to our `ActionCreatorsOf` type, which is used to generate return types for `dispatch`. This wrapper basically says that every action creator now returns a `Promise<void>`. 

Two things this doesn't handle:
- Generator action creators. (Should we handle this?)
- Is something other than `Promise<void>` ever returned, or is it always `void`?

## Testing Instructions
unsure

### Testing Instructions for Keyboard
n/a

## Screenshots or screencast <!-- if applicable -->
n/a