### PR TITLE
Make "My patterns" category permanently visible

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen-patterns/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-patterns/index.js
@@ -107,7 +107,7 @@ export default function SidebarNavigationScreenPatterns() {
 	const { templatePartAreas, hasTemplateParts, isLoading } =
 		useTemplatePartAreas();
 	const { patternCategories, hasPatterns } = usePatternCategories();
-	const { myPatterns, hasPatterns: hasMyPatterns } = useMyPatterns();
+	const { myPatterns } = useMyPatterns();
 
 	const isTemplatePartsMode = useSelect( ( select ) => {
 		const settings = select( editSiteStore ).getSettings();
@@ -153,23 +153,25 @@ export default function SidebarNavigationScreenPatterns() {
 									</Item>
 								</ItemGroup>
 							) }
-							{ hasMyPatterns && (
-								<ItemGroup className="edit-site-sidebar-navigation-screen-patterns__group">
-									<CategoryItem
-										key={ myPatterns.name }
-										count={ myPatterns.count }
-										label={ myPatterns.label }
-										icon={ starFilled }
-										id={ myPatterns.name }
-										type="wp_block"
-										isActive={
-											currentCategory ===
-												`${ myPatterns.name }` &&
-											currentType === 'wp_block'
-										}
-									/>
-								</ItemGroup>
-							) }
+							<ItemGroup className="edit-site-sidebar-navigation-screen-patterns__group">
+								<CategoryItem
+									key={ myPatterns.name }
+									count={
+										! myPatterns.count
+											? '0'
+											: myPatterns.count
+									}
+									label={ myPatterns.label }
+									icon={ starFilled }
+									id={ myPatterns.name }
+									type="wp_block"
+									isActive={
+										currentCategory ===
+											`${ myPatterns.name }` &&
+										currentType === 'wp_block'
+									}
+								/>
+							</ItemGroup>
 							{ hasTemplateParts && (
 								<TemplatePartGroup
 									areas={ templatePartAreas }


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/52317

## What?
Make the "My patterns" category in the pattern library visible regardless of whether it contains any patterns.

## Why?
See https://github.com/WordPress/gutenberg/issues/52317. There it was suggested:

> Include the "My patterns" category, active, with 0 count. This would at least contextualise the "No patterns found" message.

## How?
Do not check `hasMyPatterns` before rendering the `CategoryItem`.

## Testing Instructions
* Open the Patterns section in the Site Editor.
* Ensure the "My Patterns" category is visible and works as expected:
  * When there are 0 patterns in the category.
  * When there are > 0 patterns in the category.

## Screenshots or screencast <!-- if applicable -->
<img width="1387" alt="Screenshot 2023-07-11 at 22 09 31" src="https://github.com/WordPress/gutenberg/assets/846565/49e78ca0-d915-4e2a-b3b0-9023ab8337b5">
