### PR TITLE
Fix "Manage all patterns" link appearance

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-item/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-item/style.scss
@@ -35,6 +35,11 @@
 			box-shadow: none;
 			outline: none;
 		}
+
+		&:focus-visible {
+			box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
+			outline: 2px solid transparent;
+		}
 	}
 
 	&.with-suffix {

--- a/packages/edit-site/src/components/sidebar-navigation-item/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-item/style.scss
@@ -11,6 +11,10 @@
 	&[aria-current] {
 		color: $gray-200;
 		background: $gray-800;
+
+		.edit-site-sidebar-navigation-item__drilldown-indicator {
+			fill: $gray-200;
+		}
 	}
 
 	&[aria-current] {
@@ -19,7 +23,7 @@
 	}
 
 	.edit-site-sidebar-navigation-item__drilldown-indicator {
-		fill: $gray-700;
+		fill: $gray-600;
 	}
 
 	&:is(a) {


### PR DESCRIPTION
## What?
Update the "Manage all patterns" link appearance so that it matches other similar menu items, specifically the "Manage all template parts" link just above.

## Why?
Consistency. It looks a bit clumsy for these links to have different appearances and behaviors.

## How?
Style the drilldown indicator so that it has the correct color in resting, hover, and states.

## Testing Instructions
1. Open the Patterns library in the site editor
2. Ensure the "Manage all template parts" and "Manage all patterns" link appear the same way, in their resting, hover, and focus states. 

### Before

https://github.com/WordPress/gutenberg/assets/846565/8192590f-9825-4e8a-a34a-fcdf8e0f2310


### After

https://github.com/WordPress/gutenberg/assets/846565/6bf1ce73-6742-442b-8950-69fd22f197fc
