### PR TITLE
Add README for `BlockCaption` component

### DIFF
--- a/packages/block-editor/src/components/block-caption/README.md
+++ b/packages/block-editor/src/components/block-caption/README.md
@@ -106,4 +106,4 @@ Function to handle how blocks are inserted after pressing enter at the end of th
 
 ## Related components
 
-`BlockCaption` passes props directly to the [`Caption`](https://github.com/WordPress/gutenberg/blob/HEAD/packages/block-editor/src/components/caption) component.
+`BlockCaption` passes props directly to the [`Caption`](https://github.com/WordPress/gutenberg/blob/HEAD/packages/block-editor/src/components/caption) component. In turn, the `Caption` component uses the [`RichText`](https://github.com/WordPress/gutenberg/blob/HEAD/packages/block-editor/src/components/rich-text/) component. It is recommended to refer to each of those components' documentation for more information on their props and usage.

--- a/packages/block-editor/src/components/block-caption/README.md
+++ b/packages/block-editor/src/components/block-caption/README.md
@@ -1,0 +1,6 @@
+## Block Caption
+
+The `BlockCaption` component renders block-level UI for adding and editing captions. It wraps logic around the more generic `Caption` component to provide an editable caption field that is designed specifically for block-level use.
+
+`BlockCaption` is used in several native blocks, including `Video`, `Image`, `Audio`, etc.
+

--- a/packages/block-editor/src/components/block-caption/README.md
+++ b/packages/block-editor/src/components/block-caption/README.md
@@ -48,9 +48,11 @@ const MyBlockCaption = (
 
 ### Props
 
-The `clientId` prop is the only required prop, but the others are recommended.
+The `clientId` prop is the only required prop.
 
-The `onBlur`, `onFocus`, `isSelected`, and `insertBlocksAfter` props are all passed directly to the `Caption` component, which then passes them to the inner `RichText` component. ([See detailed info about the RichText component's props](https://github.com/WordPress/gutenberg/blob/HEAD/packages/block-editor/src/components/rich-text/README.md)).
+The `onBlur`, `onFocus`, `isSelected`, and `insertBlocksAfter` props are all passed directly to the `Caption` component, which then passes them to the inner `RichText` component. ([See detailed info about the RichText component's props](https://github.com/WordPress/gutenberg/blob/HEAD/packages/block-editor/src/components/rich-text/README.md)). These props are not strictly required, but necessary for many implementations of the component to function as expected.
+
+The `accessible` prop is `false` by default and must be set to `true` in order to set an accessibility label via the `accessibilityLabelCreator` prop.
 
 ### `clientId`
 

--- a/packages/block-editor/src/components/block-caption/README.md
+++ b/packages/block-editor/src/components/block-caption/README.md
@@ -64,8 +64,8 @@ The client ID of the block that the caption is associated with. This is prop is 
 ### `accessible`
 
 -   **Type:** `Boolean`
--   **Required:** `No`
 -   **Default:** `false`
+-   **Required:** `No`
 
 Boolean to indicate whether component is an accessibility element. When set to true, the component and all of its children will be treated as a single accessible element. Refer to [the relevant React Native documentation](https://reactnative.dev/docs/accessibility#accessible) for the most up-to-date information on this prop.
 

--- a/packages/block-editor/src/components/block-caption/README.md
+++ b/packages/block-editor/src/components/block-caption/README.md
@@ -4,6 +4,11 @@ The `BlockCaption` component renders block-level UI for adding and editing capti
 
 `BlockCaption` is used in several native blocks, including `Video`, `Image`, `Audio`, etc.
 
+## Table of contents
+
+1. [Development guidelines](#development-guidelines)
+2. [Related components](#related-components)
+
 ## Development guidelines
 
 ### Usage

--- a/packages/block-editor/src/components/block-caption/README.md
+++ b/packages/block-editor/src/components/block-caption/README.md
@@ -61,8 +61,6 @@ The client ID of the block that the caption is associated with. This is prop is 
 
 ### `accessible`
 
-## Begin again from here.
-
 -   **Type:** `Boolean`
 -   **Required:** `No`
 -   **Default:** `false`

--- a/packages/block-editor/src/components/block-caption/README.md
+++ b/packages/block-editor/src/components/block-caption/README.md
@@ -4,3 +4,40 @@ The `BlockCaption` component renders block-level UI for adding and editing capti
 
 `BlockCaption` is used in several native blocks, including `Video`, `Image`, `Audio`, etc.
 
+## Development guidelines
+
+### Usage
+
+Renders an editable caption field designed specifically for block-level use.
+
+```jsx
+import { BlockCaption } from '@wordpress/block-editor';
+
+const MyBlockCaption = (
+	clientId,
+	isCaptionSelected,
+	onFocusCaption,
+	onBlur,
+	insertBlocksAfter
+) => (
+	<BlockCaption
+		clientId={ clientId }
+		accessible={ true }
+		accessibilityLabelCreator={ ( caption ) =>
+			! caption
+				? /* translators: accessibility text. Empty caption. */
+				  'Caption. Empty'
+				: sprintf(
+						/* translators: accessibility text. %s: caption. */
+						__( 'Caption. %s' ),
+						caption
+				  )
+		}
+		isSelected={ isCaptionSelected }
+		onFocus={ onFocusCaption }
+		onBlur={ onBlur }
+		insertBlocksAfter={ insertBlocksAfter }
+	/>
+);
+```
+

--- a/packages/block-editor/src/components/block-caption/README.md
+++ b/packages/block-editor/src/components/block-caption/README.md
@@ -41,3 +41,6 @@ const MyBlockCaption = (
 );
 ```
 
+## Related components
+
+`BlockCaption` passes props directly to the [`Caption`](https://github.com/WordPress/gutenberg/blob/HEAD/packages/block-editor/src/components/caption) component.

--- a/packages/block-editor/src/components/block-caption/README.md
+++ b/packages/block-editor/src/components/block-caption/README.md
@@ -41,6 +41,64 @@ const MyBlockCaption = (
 );
 ```
 
+### Props
+
+The `clientId` prop is the only required prop, but the others are recommended.
+
+The `onBlur`, `onFocus`, `isSelected`, and `insertBlocksAfter` props are all passed directly to the `Caption` component, which then passes them to the inner `RichText` component. ([See detailed info about the RichText component's props](https://github.com/WordPress/gutenberg/blob/HEAD/packages/block-editor/src/components/rich-text/README.md)).
+
+### `clientId`
+
+-   **Type:** `String`
+-   **Required:** `Yes`
+
+The client ID of the block that the caption is associated with. This is prop is required in order for the component to perform key functionality, including retrieving the current caption from the block attributes.
+
+### `accessible`
+
+## Begin again from here.
+
+-   **Type:** `Boolean`
+-   **Required:** `No`
+-   **Default:** `false`
+
+Boolean to indicate whether component is an accessibility element. When set to true, the component and all of its children will be treated as a single accessible element. Refer to [the relevant React Native documentation](https://reactnative.dev/docs/accessibility#accessible) for the most up-to-date information on this prop.
+
+### `accessibilityLabelCreator`
+
+-   **Type:** `Function`
+-   **Required:** `No`
+
+Function that returns an accessibility label, which screen readers will use for the component. The `accessible` prop must be set to `true` in order for this prop to have any effect.
+
+### `onBlur`
+
+-   **Type:** `Function`
+-   **Required:** `No`
+
+Handler for `onBlur` events, called when the component loses focus. Although not required, it's highly recommended to pass down the component's `onBlur` function to ensure that loss of focus is always handled correctly.
+
+### `onFocus`
+
+-   **Type:** `Function`
+-   **Required:** `No`
+
+Handler for `onFocus` events, called when the component is brought into focus. Similar to `onBlur`, it's not required but recommended. Passing down this prop helps to ensure focus is always handled as expected on the native side.
+
+### `isSelected`
+
+-   **Type:** `Boolean`
+-   **Required:** `No`
+
+Boolean that indicates whether the caption is currently selected. This is used by the child `RichText` component to determine whether to display formatting controls.
+
+### `insertBlocksAfter`
+
+-   **Type:** `Function`
+-   **Required:** `No`
+
+Function to handle how blocks are inserted after pressing enter at the end of the component.
+
 ## Related components
 
 `BlockCaption` passes props directly to the [`Caption`](https://github.com/WordPress/gutenberg/blob/HEAD/packages/block-editor/src/components/caption) component.


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/52047

## What?

A README has been added for the `BlockCaption` component.

## Why?

As requested in https://github.com/WordPress/gutenberg/issues/52047, the README will serve as a guide for developers who may wish to contribute to Gutenberg.

## How?

The README was created using [the README.md for the AlignmentControl component ](https://github.com/WordPress/gutenberg/blob/trunk/packages/block-editor/src/components/alignment-control/README.md) as a guide.

## Testing Instructions

Read through the latest version of the README here and share with any suggestions for improvements: https://github.com/WordPress/gutenberg/blob/3ff123444e4fe50b15af2491e9461fbe84dd5808/packages/block-editor/src/components/block-caption/README.md