### PR TITLE
Theme previews: Escape theme activation nonce for output.

### DIFF
--- a/lib/compat/wordpress-6.3/theme-previews.php
+++ b/lib/compat/wordpress-6.3/theme-previews.php
@@ -107,7 +107,7 @@ function block_theme_activate_nonce() {
 	$nonce_handle = 'switch-theme_' . gutenberg_get_theme_preview_path();
 	?>
 <script type="text/javascript">
-	window.WP_BLOCK_THEME_ACTIVATE_NONCE = '<?php echo wp_create_nonce( $nonce_handle ); ?>';
+	window.WP_BLOCK_THEME_ACTIVATE_NONCE = <?php echo wp_json_encode( wp_create_nonce( $nonce_handle ) ); ?>;
 </script>
 	<?php
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Adds escaping to the nonce output used for activation of themes.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

As the WordPress nonce functions are pluggable, plugins can introduce custom implementations. While the core implementation only uses alphanumeric characters, a custom version may use any number of special characters.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Wraps output in `wp_json_encode()` -- note the removal of the quotes is intentional as the function adds them automatically.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Add an mu-plugin that replaces the nonce create function `function wp_create_nonce() { return "';"; }`
2. Visit the theme preview page (be aware this won't load entirely correctly due to the incomplete nonce implimentation)
3. In the console ensure the constant is set correctly
   ```
   >> WP_BLOCK_THEME_ACTIVATE_NONCE
   "';" 
   ```
4. Delete the mu-plugin so you don't end up wondering why everything is broken.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
N/A -- no UI change.

## Screenshots or screencast <!-- if applicable -->
