### PR TITLE
Patterns: Add client side pagination to patterns list

### DIFF
--- a/packages/edit-site/src/components/page-patterns/grid.js
+++ b/packages/edit-site/src/components/page-patterns/grid.js
@@ -1,8 +1,8 @@
 /**
  * WordPress dependencies
  */
-import { __experimentalText as Text } from '@wordpress/components';
-import { useRef } from '@wordpress/element';
+import { __experimentalHStack as HStack } from '@wordpress/components';
+import { useRef, useState } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 
 /**
@@ -10,20 +10,87 @@ import { __, sprintf } from '@wordpress/i18n';
  */
 import GridItem from './grid-item';
 
-const PAGE_SIZE = 100;
+const PAGE_SIZE = 20;
+
+function Pagination( { currentPage, numPages, changePage, totalItems } ) {
+	return (
+		<HStack className="edit-site-patterns__grid-pagination">
+			<div className="edit-site-patterns__grid-pagination-label">
+				{
+					// translators: %s: Total number of patterns.
+					sprintf( __( '%s items' ), totalItems )
+				}
+			</div>
+
+			<button
+				onClick={ () => changePage( 1 ) }
+				disabled={ currentPage === 1 }
+			>
+				«
+			</button>
+			<button
+				onClick={ () => changePage( currentPage - 1 ) }
+				disabled={ currentPage === 1 }
+			>
+				‹
+			</button>
+			<div className="edit-site-patterns__grid-pagination-label">
+				{
+					// translators: %1$s: Current page number, %2$s: Total number of pages.
+					sprintf( __( '%1$s of %2$s' ), currentPage, numPages )
+				}
+			</div>
+			<button
+				onClick={ () => changePage( currentPage + 1 ) }
+				disabled={ currentPage === numPages }
+			>
+				›
+			</button>
+			<button
+				onClick={ () => changePage( numPages ) }
+				disabled={ currentPage === numPages }
+			>
+				»
+			</button>
+		</HStack>
+	);
+}
 
 export default function Grid( { categoryId, items, ...props } ) {
+	const [ currentPage, setCurrentPage ] = useState( 1 );
 	const gridRef = useRef();
 
 	if ( ! items?.length ) {
 		return null;
 	}
+	items.sort( ( a, b ) =>
+		a.title.localeCompare( b.title, undefined, {
+			numeric: true,
+			sensitivity: 'base',
+		} )
+	);
+	const numPages = Math.ceil( items.length / PAGE_SIZE );
+	const totalItems = items.length;
+	const pageIndex = currentPage - 1;
+	const list = items.slice(
+		pageIndex * PAGE_SIZE,
+		pageIndex * PAGE_SIZE + PAGE_SIZE
+	);
 
-	const list = items.slice( 0, PAGE_SIZE );
-	const restLength = items.length - PAGE_SIZE;
+	const changePage = ( page ) => {
+		const scrollContainer =
+			document.getElementsByClassName( 'edit-site-patterns' );
+
+		scrollContainer[ 0 ].scrollTo( 0, 0 );
+
+		setCurrentPage( page );
+	};
 
 	return (
 		<>
+			<Pagination
+				{ ...{ currentPage, numPages, changePage, totalItems } }
+			/>
 			<ul
 				role="listbox"
 				className="edit-site-patterns__grid"
@@ -38,15 +105,9 @@ export default function Grid( { categoryId, items, ...props } ) {
 					/>
 				) ) }
 			</ul>
-			{ restLength > 0 && (
-				<Text variant="muted" as="p" align="center">
-					{ sprintf(
-						/* translators: %d: number of patterns */
-						__( '+ %d more patterns discoverable by searching' ),
-						restLength
-					) }
-				</Text>
-			) }
+			<Pagination
+				{ ...{ currentPage, numPages, changePage, totalItems } }
+			/>
 		</>
 	);
 }

--- a/packages/edit-site/src/components/page-patterns/grid.js
+++ b/packages/edit-site/src/components/page-patterns/grid.js
@@ -14,7 +14,7 @@ import { __, sprintf } from '@wordpress/i18n';
  */
 import GridItem from './grid-item';
 
-const PAGE_SIZE = 30;
+const PAGE_SIZE = 20;
 
 function Pagination( { currentPage, numPages, changePage, totalItems } ) {
 	return (

--- a/packages/edit-site/src/components/page-patterns/grid.js
+++ b/packages/edit-site/src/components/page-patterns/grid.js
@@ -1,7 +1,11 @@
 /**
  * WordPress dependencies
  */
-import { __experimentalHStack as HStack } from '@wordpress/components';
+import {
+	__experimentalHStack as HStack,
+	__experimentalText as Text,
+	Button,
+} from '@wordpress/components';
 import { useRef, useState } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 
@@ -10,48 +14,59 @@ import { __, sprintf } from '@wordpress/i18n';
  */
 import GridItem from './grid-item';
 
-const PAGE_SIZE = 20;
+const PAGE_SIZE = 30;
 
 function Pagination( { currentPage, numPages, changePage, totalItems } ) {
 	return (
-		<HStack className="edit-site-patterns__grid-pagination">
-			<div className="edit-site-patterns__grid-pagination-label">
+		<HStack
+			expanded={ false }
+			spacing={ 3 }
+			className="edit-site-patterns__grid-pagination"
+		>
+			<Text variant="muted">
 				{
 					// translators: %s: Total number of patterns.
 					sprintf( __( '%s items' ), totalItems )
 				}
-			</div>
-
-			<button
-				onClick={ () => changePage( 1 ) }
-				disabled={ currentPage === 1 }
-			>
-				«
-			</button>
-			<button
-				onClick={ () => changePage( currentPage - 1 ) }
-				disabled={ currentPage === 1 }
-			>
-				‹
-			</button>
-			<div className="edit-site-patterns__grid-pagination-label">
+			</Text>
+			<HStack expanded={ false } spacing={ 1 }>
+				<Button
+					variant="tertiary"
+					onClick={ () => changePage( 1 ) }
+					disabled={ currentPage === 1 }
+				>
+					«
+				</Button>
+				<Button
+					variant="tertiary"
+					onClick={ () => changePage( currentPage - 1 ) }
+					disabled={ currentPage === 1 }
+				>
+					‹
+				</Button>
+			</HStack>
+			<Text variant="muted">
 				{
 					// translators: %1$s: Current page number, %2$s: Total number of pages.
 					sprintf( __( '%1$s of %2$s' ), currentPage, numPages )
 				}
-			</div>
-			<button
-				onClick={ () => changePage( currentPage + 1 ) }
-				disabled={ currentPage === numPages }
-			>
-				›
-			</button>
-			<button
-				onClick={ () => changePage( numPages ) }
-				disabled={ currentPage === numPages }
-			>
-				»
-			</button>
+			</Text>
+			<HStack expanded={ false } spacing={ 1 }>
+				<Button
+					variant="tertiary"
+					onClick={ () => changePage( currentPage + 1 ) }
+					disabled={ currentPage === numPages }
+				>
+					›
+				</Button>
+				<Button
+					variant="tertiary"
+					onClick={ () => changePage( numPages ) }
+					disabled={ currentPage === numPages }
+				>
+					»
+				</Button>
+			</HStack>
 		</HStack>
 	);
 }
@@ -63,12 +78,6 @@ export default function Grid( { categoryId, items, ...props } ) {
 	if ( ! items?.length ) {
 		return null;
 	}
-	items.sort( ( a, b ) =>
-		a.title.localeCompare( b.title, undefined, {
-			numeric: true,
-			sensitivity: 'base',
-		} )
-	);
 	const numPages = Math.ceil( items.length / PAGE_SIZE );
 	const totalItems = items.length;
 	const pageIndex = currentPage - 1;
@@ -88,11 +97,6 @@ export default function Grid( { categoryId, items, ...props } ) {
 
 	return (
 		<>
-			{ numPages > 1 && (
-				<Pagination
-					{ ...{ currentPage, numPages, changePage, totalItems } }
-				/>
-			) }
 			<ul
 				role="listbox"
 				className="edit-site-patterns__grid"

--- a/packages/edit-site/src/components/page-patterns/grid.js
+++ b/packages/edit-site/src/components/page-patterns/grid.js
@@ -105,10 +105,8 @@ export default function Grid( { categoryId, items, ...props } ) {
 
 	const numPages = Math.ceil( items.length / PAGE_SIZE );
 	const changePage = ( page ) => {
-		const scrollContainer =
-			document.getElementsByClassName( 'edit-site-patterns' );
-
-		scrollContainer[ 0 ]?.scrollTo( 0, 0 );
+		const scrollContainer = document.querySelector( '.edit-site-patterns' );
+		scrollContainer?.scrollTo( 0, 0 );
 
 		setCurrentPage( page );
 	};

--- a/packages/edit-site/src/components/page-patterns/grid.js
+++ b/packages/edit-site/src/components/page-patterns/grid.js
@@ -7,7 +7,7 @@ import {
 	Button,
 } from '@wordpress/components';
 import { useRef, useState, useMemo } from '@wordpress/element';
-import { __, _x, sprintf } from '@wordpress/i18n';
+import { __, _x, _n, sprintf } from '@wordpress/i18n';
 import { useAsyncList } from '@wordpress/compose';
 
 /**
@@ -27,7 +27,7 @@ function Pagination( { currentPage, numPages, changePage, totalItems } ) {
 			<Text variant="muted">
 				{
 					// translators: %s: Total number of patterns.
-					sprintf( __( '%s items' ), totalItems )
+					sprintf( _n( '%s items' ), totalItems )
 				}
 			</Text>
 			<HStack expanded={ false } spacing={ 1 }>

--- a/packages/edit-site/src/components/page-patterns/grid.js
+++ b/packages/edit-site/src/components/page-patterns/grid.js
@@ -6,8 +6,9 @@ import {
 	__experimentalText as Text,
 	Button,
 } from '@wordpress/components';
-import { useRef, useState } from '@wordpress/element';
+import { useRef, useState, useMemo } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
+import { useAsyncList } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -74,18 +75,25 @@ function Pagination( { currentPage, numPages, changePage, totalItems } ) {
 export default function Grid( { categoryId, items, ...props } ) {
 	const [ currentPage, setCurrentPage ] = useState( 1 );
 	const gridRef = useRef();
-
-	if ( ! items?.length ) {
-		return null;
-	}
-	const numPages = Math.ceil( items.length / PAGE_SIZE );
 	const totalItems = items.length;
 	const pageIndex = currentPage - 1;
-	const list = items.slice(
-		pageIndex * PAGE_SIZE,
-		pageIndex * PAGE_SIZE + PAGE_SIZE
+
+	const list = useMemo(
+		() =>
+			items.slice(
+				pageIndex * PAGE_SIZE,
+				pageIndex * PAGE_SIZE + PAGE_SIZE
+			),
+		[ pageIndex, items ]
 	);
 
+	const asyncList = useAsyncList( list, { step: 10 } );
+
+	if ( ! list?.length ) {
+		return null;
+	}
+
+	const numPages = Math.ceil( items.length / PAGE_SIZE );
 	const changePage = ( page ) => {
 		const scrollContainer =
 			document.getElementsByClassName( 'edit-site-patterns' );
@@ -103,7 +111,7 @@ export default function Grid( { categoryId, items, ...props } ) {
 				{ ...props }
 				ref={ gridRef }
 			>
-				{ list.map( ( item ) => (
+				{ asyncList.map( ( item ) => (
 					<GridItem
 						key={ item.name }
 						item={ item }

--- a/packages/edit-site/src/components/page-patterns/grid.js
+++ b/packages/edit-site/src/components/page-patterns/grid.js
@@ -108,7 +108,7 @@ export default function Grid( { categoryId, items, ...props } ) {
 		const scrollContainer =
 			document.getElementsByClassName( 'edit-site-patterns' );
 
-		scrollContainer[ 0 ].scrollTo( 0, 0 );
+		scrollContainer[ 0 ]?.scrollTo( 0, 0 );
 
 		setCurrentPage( page );
 	};

--- a/packages/edit-site/src/components/page-patterns/grid.js
+++ b/packages/edit-site/src/components/page-patterns/grid.js
@@ -88,9 +88,11 @@ export default function Grid( { categoryId, items, ...props } ) {
 
 	return (
 		<>
-			<Pagination
-				{ ...{ currentPage, numPages, changePage, totalItems } }
-			/>
+			{ numPages > 1 && (
+				<Pagination
+					{ ...{ currentPage, numPages, changePage, totalItems } }
+				/>
+			) }
 			<ul
 				role="listbox"
 				className="edit-site-patterns__grid"
@@ -105,9 +107,11 @@ export default function Grid( { categoryId, items, ...props } ) {
 					/>
 				) ) }
 			</ul>
-			<Pagination
-				{ ...{ currentPage, numPages, changePage, totalItems } }
-			/>
+			{ numPages > 1 && (
+				<Pagination
+					{ ...{ currentPage, numPages, changePage, totalItems } }
+				/>
+			) }
 		</>
 	);
 }

--- a/packages/edit-site/src/components/page-patterns/grid.js
+++ b/packages/edit-site/src/components/page-patterns/grid.js
@@ -27,7 +27,11 @@ function Pagination( { currentPage, numPages, changePage, totalItems } ) {
 			<Text variant="muted">
 				{
 					// translators: %s: Total number of patterns.
-					sprintf( _n( '%s items' ), totalItems )
+					sprintf(
+						// translators: %s: Total number of patterns.
+						_n( '%s item', '%s items', totalItems ),
+						totalItems
+					)
 				}
 			</Text>
 			<HStack expanded={ false } spacing={ 1 }>

--- a/packages/edit-site/src/components/page-patterns/grid.js
+++ b/packages/edit-site/src/components/page-patterns/grid.js
@@ -35,6 +35,7 @@ function Pagination( { currentPage, numPages, changePage, totalItems } ) {
 					variant="tertiary"
 					onClick={ () => changePage( 1 ) }
 					disabled={ currentPage === 1 }
+					aria-label={ __( 'First page' ) }
 				>
 					«
 				</Button>
@@ -42,6 +43,7 @@ function Pagination( { currentPage, numPages, changePage, totalItems } ) {
 					variant="tertiary"
 					onClick={ () => changePage( currentPage - 1 ) }
 					disabled={ currentPage === 1 }
+					aria-label={ __( 'Previous page' ) }
 				>
 					‹
 				</Button>
@@ -57,6 +59,7 @@ function Pagination( { currentPage, numPages, changePage, totalItems } ) {
 					variant="tertiary"
 					onClick={ () => changePage( currentPage + 1 ) }
 					disabled={ currentPage === numPages }
+					aria-label={ __( 'Next page' ) }
 				>
 					›
 				</Button>
@@ -64,6 +67,7 @@ function Pagination( { currentPage, numPages, changePage, totalItems } ) {
 					variant="tertiary"
 					onClick={ () => changePage( numPages ) }
 					disabled={ currentPage === numPages }
+					aria-label={ __( 'Last page' ) }
 				>
 					»
 				</Button>

--- a/packages/edit-site/src/components/page-patterns/grid.js
+++ b/packages/edit-site/src/components/page-patterns/grid.js
@@ -7,7 +7,7 @@ import {
 	Button,
 } from '@wordpress/components';
 import { useRef, useState, useMemo } from '@wordpress/element';
-import { __, sprintf } from '@wordpress/i18n';
+import { __, _x, sprintf } from '@wordpress/i18n';
 import { useAsyncList } from '@wordpress/compose';
 
 /**
@@ -49,10 +49,12 @@ function Pagination( { currentPage, numPages, changePage, totalItems } ) {
 				</Button>
 			</HStack>
 			<Text variant="muted">
-				{
+				{ sprintf(
 					// translators: %1$s: Current page number, %2$s: Total number of pages.
-					sprintf( __( '%1$s of %2$s' ), currentPage, numPages )
-				}
+					_x( '%1$s of %2$s', 'paging' ),
+					currentPage,
+					numPages
+				) }
 			</Text>
 			<HStack expanded={ false } spacing={ 1 }>
 				<Button

--- a/packages/edit-site/src/components/page-patterns/patterns-list.js
+++ b/packages/edit-site/src/components/page-patterns/patterns-list.js
@@ -15,7 +15,7 @@ import {
 import { __, isRTL } from '@wordpress/i18n';
 import { chevronLeft, chevronRight } from '@wordpress/icons';
 import { privateApis as routerPrivateApis } from '@wordpress/router';
-import { useViewportMatch, useAsyncList } from '@wordpress/compose';
+import { useViewportMatch } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -70,7 +70,6 @@ export default function PatternsList( { categoryId, type } ) {
 	const hasPatterns = patterns.length;
 	const title = SYNC_FILTERS[ syncFilter ];
 	const description = SYNC_DESCRIPTIONS[ syncFilter ];
-	const shownPatterns = useAsyncList( patterns );
 
 	return (
 		<VStack spacing={ 6 }>
@@ -145,7 +144,7 @@ export default function PatternsList( { categoryId, type } ) {
 			{ hasPatterns && (
 				<Grid
 					categoryId={ categoryId }
-					items={ shownPatterns }
+					items={ patterns }
 					aria-labelledby={ titleId }
 					aria-describedby={ descriptionId }
 				/>

--- a/packages/edit-site/src/components/page-patterns/patterns-list.js
+++ b/packages/edit-site/src/components/page-patterns/patterns-list.js
@@ -131,7 +131,7 @@ export default function PatternsList( { categoryId, type } ) {
 			</Flex>
 			{ syncFilter !== 'all' && (
 				<VStack className="edit-site-patterns__section-header">
-					<Heading as="h3" level={ 4 } id={ titleId }>
+					<Heading as="h3" level={ 5 } id={ titleId }>
 						{ title }
 					</Heading>
 					{ description ? (

--- a/packages/edit-site/src/components/page-patterns/style.scss
+++ b/packages/edit-site/src/components/page-patterns/style.scss
@@ -1,6 +1,8 @@
 .edit-site-patterns {
-	background: rgba(0, 0, 0, 0.15);
+	border: 1px solid $gray-800;
+	background: none;
 	margin: $header-height 0 0;
+	border-radius: 0;
 	.components-base-control {
 		width: 100%;
 		@include break-medium {
@@ -62,9 +64,18 @@
 
 	.edit-site-patterns__grid-pagination {
 		width: fit-content;
-
-		.edit-site-patterns__grid-pagination-label {
-			color: $white;
+		.components-button.is-tertiary {
+			width: $button-size-compact;
+			height: $button-size-compact;
+			color: $gray-100;
+			background-color: $gray-800;
+			&:disabled {
+				color: $gray-600;
+				background: none;
+			}
+			&:hover:not(:disabled) {
+				background-color: $gray-700;
+			}
 		}
 	}
 }
@@ -82,6 +93,7 @@
 	// Small top padding required to avoid cutting off the visible outline
 	// when hovering items.
 	padding-top: $border-width-focus-fallback;
+	margin-top: 0;
 	margin-bottom: $grid-unit-40;
 	@include break-large {
 		grid-template-columns: 1fr 1fr;

--- a/packages/edit-site/src/components/page-patterns/style.scss
+++ b/packages/edit-site/src/components/page-patterns/style.scss
@@ -59,6 +59,14 @@
 		background: $gray-700;
 		color: $gray-100;
 	}
+
+	.edit-site-patterns__grid-pagination {
+		width: fit-content;
+
+		.edit-site-patterns__grid-pagination-label {
+			color: $white;
+		}
+	}
 }
 
 .edit-site-patterns__section-header {


### PR DESCRIPTION
## What?
Adds client side pagination to the Patterns list iin site editor

## Why?
Currently the list displays 100 patterns by default with no ability to page through rest of patterns without searching

## How?
Adds a simple pagination bar at  bottom of list

## Testing Instructions
In a site with more than 20 patterns open up the patterns list and make sure pagination controls at the bottom of the page work correctly and provide access to all patterns

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/3629020/0796ade8-6f0b-4cae-a987-0615a7ed1446



