### PR TITLE
Block Editor: Ensure synced patterns are accounted for in 'getAllowedBlocks'

### DIFF
--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -2214,15 +2214,24 @@ export const getAllowedBlocks = createSelector(
 			return;
 		}
 
-		return getBlockTypes().filter( ( blockType ) =>
+		const blockTypes = getBlockTypes().filter( ( blockType ) =>
 			canIncludeBlockTypeInInserter( state, blockType, rootClientId )
 		);
+		const hasReusableBlock =
+			canInsertBlockTypeUnmemoized( state, 'core/block', rootClientId ) &&
+			getReusableBlocks( state ).length > 0;
+
+		return [
+			...blockTypes,
+			...( hasReusableBlock ? [ 'core/block' ] : [] ),
+		];
 	},
 	( state, rootClientId ) => [
 		state.blockListSettings[ rootClientId ],
 		state.blocks.byClientId,
 		state.settings.allowedBlockTypes,
 		state.settings.templateLock,
+		getReusableBlocks( state ),
 		getBlockTypes(),
 	]
 );


### PR DESCRIPTION
## What?
Fixes #52401.

PR updates the `getAllowedBlocks` selector and ensures the Synced Patterns (reusable blocks) are accounted for when checking allowed block types.

This fixes a bug with the inserter when a block has only two allowed blocks specified, and one of them is synced pattern.

## Why?
* The "smart appender" (#16708) will automatically add a block instead of displaying the quick inserter when only one block is allowed.
* The reusable blocks have an inserter disabled to avoid displaying itself without content in the category; instead, the list of reusable blocks is built separately for the inserter.
* The `getAllowedBlocks` hasn't accounted for this and incorrectly enabled "smart appender".

## How?
I added a separate check if the reusable block can be inserted and append the block name to the allowed block list. This matches the logic in `hasInserterItems` and `getInserterItems`.

## Testing Instructions
1. Open a Post or Page.
2. Insert example group block with `allowedBlocks` defined.
3. Confirm block inserter displays synced patterns.

### Example block
```
<!-- wp:group {"allowedBlocks":["core/paragraph","core/block"],"layout":{"type":"constrained"}} -->
<div class="wp-block-group"></div>
<!-- /wp:group -->
```

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/240569/e5bddbab-6824-4918-bb49-985e65faef12

