### PR TITLE
Site Editor Patterns: Ensure sidebar does not shrink when long pattern titles are used

### DIFF
--- a/packages/edit-site/src/components/layout/style.scss
+++ b/packages/edit-site/src/components/layout/style.scss
@@ -61,6 +61,7 @@
 .edit-site-layout__sidebar {
 	z-index: z-index(".edit-site-layout__sidebar");
 	width: 100vw;
+	flex-shrink: 0;
 
 	@include break-medium {
 		width: $nav-sidebar-width;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Ensure the site editor browse mode sidebar does not shrink due to content in the right hand area of the layout filling up the area. An example of this is in the My Patterns view within the Patterns page, when a really long title is in use for a pattern/reusable block.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Because the overall layout uses `flex` and the main area (`.edit-site-layout__main`) is set to `flex-grow`, the sidebar appears to need a `flex-shrink: 0` rule to prevent it from shrinking if the content in the right hand side fills up.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* For the `.edit-site-layout__sidebar` class, give it a `flex-shrink: 0` rule to prevent it from shrinking. It should still otherwise be sized correctly (fixed to `360px` in larger viewports, and fill the viewport in narrower viewports).

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

* Prior to applying this PR create a pattern with a _really_ long name, so that it spans two lines in the My Patterns view.
* Notice that in the My Patterns view in the site editor browse mode, at some in between viewport widths (e.g. `1200px`), the left hand sidebar unexpectedly shrinks, with the search icon overflowing the sidebar.
* With this PR applied, the left hand sidebar should retain its `360px` width in this view.

## Screenshots or screencast <!-- if applicable -->

| Before | After |
| --- | --- |
| ![image](https://github.com/WordPress/gutenberg/assets/14988353/94745092-ea40-4a82-a741-92ddeefe6e82) | ![image](https://github.com/WordPress/gutenberg/assets/14988353/b3e5b297-00ba-4fca-ba55-9ba8b2d69f25) |