### PR TITLE
Patterns: add a component to display empty pattern title

### DIFF
--- a/packages/block-editor/src/components/block-patterns-list/index.js
+++ b/packages/block-editor/src/components/block-patterns-list/index.js
@@ -14,6 +14,7 @@ import {
 	__unstableCompositeItem as CompositeItem,
 	Tooltip,
 	__experimentalHStack as HStack,
+	__experimentalTruncate as Truncate,
 } from '@wordpress/components';
 import { useInstanceId } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
@@ -33,6 +34,17 @@ const WithToolTip = ( { showTooltip, title, children } ) => {
 	return <>{ children }</>;
 };
 
+function BlockPatternItemPlaceholder( { title } ) {
+	return (
+		<div className="block-editor-block-patterns-list__empty-item">
+			<Truncate numberOfLines={ 2 }>{ title }</Truncate>
+			<span className="block-editor-block-patterns-list__empty-item-text">
+				{ __( '(Empty pattern)' ) }
+			</span>
+		</div>
+	);
+}
+
 function BlockPattern( {
 	isDraggable,
 	pattern,
@@ -45,6 +57,7 @@ function BlockPattern( {
 	const { blocks, viewportWidth } = pattern;
 	const instanceId = useInstanceId( BlockPattern );
 	const descriptionId = `block-editor-block-patterns-list__item-description-${ instanceId }`;
+	const isEmpty = ! blocks?.length;
 
 	return (
 		<InserterDraggableBlocks
@@ -101,10 +114,16 @@ function BlockPattern( {
 								pattern.description ? descriptionId : undefined
 							}
 						>
-							<BlockPreview
-								blocks={ blocks }
-								viewportWidth={ viewportWidth }
-							/>
+							{ ! isEmpty ? (
+								<BlockPreview
+									blocks={ blocks }
+									viewportWidth={ viewportWidth }
+								/>
+							) : (
+								<BlockPatternItemPlaceholder
+									title={ pattern.title }
+								/>
+							) }
 
 							<HStack className="block-editor-patterns__pattern-details">
 								{ pattern.id && ! pattern.syncStatus && (

--- a/packages/block-editor/src/components/block-patterns-list/style.scss
+++ b/packages/block-editor/src/components/block-patterns-list/style.scss
@@ -19,6 +19,24 @@
 .block-editor-block-patterns-list__item {
 	height: 100%;
 
+	.block-editor-block-patterns-list__empty-item {
+		min-height: 60px;
+		display: flex;
+		flex-flow: column;
+		align-items: center;
+		justify-content: center;
+		color: $gray-600;
+		border: 1px solid $gray-400;
+		padding: $grid-unit-10;
+		border-radius: 4px;
+	}
+
+	.block-editor-block-patterns-list__empty-item-text {
+		margin-top: $grid-unit-10;
+		font-size: 11px;
+		display: inline-block;
+	}
+
 	.block-editor-block-preview__container {
 		display: flex;
 		align-items: center;
@@ -31,10 +49,12 @@
 		flex-grow: 1;
 	}
 
+	&:hover .block-editor-block-patterns-list__empty-item,
 	&:hover .block-editor-block-preview__container {
 		box-shadow: 0 0 0 2px $gray-900;
 	}
 
+	&:focus .block-editor-block-patterns-list__empty-item,
 	&:focus .block-editor-block-preview__container {
 		@include button-style-outset__focus($gray-900);
 	}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Resolves https://github.com/WordPress/gutenberg/issues/52227

Adds a component that will display an empty pattern in the inserter.

The pattern's title is used in order to display something and to discern between other patterns.

## Why?
If an unsynced pattern is added via the site editor library, but has no content, it does not appear in the post editor inserter.

## Testing Instructions
1. Head over to Site editor library patterns view (/wp-admin/site-editor.php?path=%2Fpatterns)
2. Use the + in top of left nav to add a new unsynced pattern. Don't add any content in the editor (just click back)
3. Notice pattern appears in unsynced section of library listing as an Empty pattern
4. Go to post editor and open the patterns inserter panel. You should see the empty pattern item under "My patterns" 


<img width="1296" alt="Screenshot 2023-07-12 at 3 36 05 pm" src="https://github.com/WordPress/gutenberg/assets/6458278/10719761-d8c7-4668-ab83-b60b4b6a7e12">


https://github.com/WordPress/gutenberg/assets/6458278/2adaaa6d-f9d5-4178-9bb3-4869f89e631d


