### PR TITLE
Search block: Enqueue view script through block.json

### DIFF
--- a/packages/block-library/src/search/block.json
+++ b/packages/block-library/src/search/block.json
@@ -90,6 +90,7 @@
 		},
 		"html": false
 	},
+	"viewScript": "file:./view.min.js",
 	"editorStyle": "wp-block-search-editor",
 	"style": "wp-block-search"
 }

--- a/packages/block-library/src/search/index.php
+++ b/packages/block-library/src/search/index.php
@@ -8,11 +8,13 @@
 /**
  * Dynamically renders the `core/search` block.
  *
- * @param array $attributes The block attributes.
+ * @param array    $attributes The block attributes.
+ * @param string   $content    The saved content.
+ * @param WP_Block $block      The parsed block.
  *
  * @return string The search block markup.
  */
-function render_block_core_search( $attributes ) {
+function render_block_core_search( $attributes, $content, $block ) {
 	// Older versions of the Search block defaulted the label and buttonText
 	// attributes to `__( 'Search' )` meaning that many posts contain `<!--
 	// wp:search /-->`. Support these by defaulting an undefined label and
@@ -70,10 +72,26 @@ function render_block_core_search( $attributes ) {
 		$input->set_attribute( 'id', $input_id );
 		$input->set_attribute( 'value', get_search_query() );
 		$input->set_attribute( 'placeholder', $attributes['placeholder'] );
-		if ( 'button-only' === $button_position && 'expand-searchfield' === $button_behavior ) {
+
+		$is_expandable_searchfield = 'button-only' === $button_position && 'expand-searchfield' === $button_behavior;
+		if ( $is_expandable_searchfield ) {
 			$input->set_attribute( 'aria-hidden', 'true' );
 			$input->set_attribute( 'tabindex', '-1' );
-			wp_enqueue_script( 'wp-block--search-view', plugins_url( 'search/view.min.js', __FILE__ ) );
+		}
+
+		// If the script already exists, there is no point in removing it from viewScript.
+		$view_js_file  = 'wp-block-search-view';
+		if ( ! wp_script_is( $view_js_file ) ) {
+			$script_handles = $block->block_type->view_script_handles;
+
+			// If the script is not needed, and it is still in the `view_script_handles`, remove it.
+			if ( ! $is_expandable_searchfield && in_array( $view_js_file, $script_handles, true ) ) {
+				$block->block_type->view_script_handles = array_diff( $script_handles, array( $view_js_file ) );
+			}
+			// If the script is needed, but it was previously removed, add it again.
+			if ( $is_expandable_searchfield && ! in_array( $view_js_file, $script_handles, true ) ) {
+				$block->block_type->view_script_handles = array_merge( $script_handles, array( $view_js_file ) );
+			}
 		}
 	}
 

--- a/packages/block-library/src/search/index.php
+++ b/packages/block-library/src/search/index.php
@@ -80,7 +80,7 @@ function render_block_core_search( $attributes, $content, $block ) {
 		}
 
 		// If the script already exists, there is no point in removing it from viewScript.
-		$view_js_file  = 'wp-block-search-view';
+		$view_js_file = 'wp-block-search-view';
 		if ( ! wp_script_is( $view_js_file ) ) {
 			$script_handles = $block->block_type->view_script_handles;
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Update how the Search block registeres and enqueues the view script.

## Why?
While testing the beta version of WordPress I notices that the Search block isn't loading the script from the correct location (`/wp-content/plugins/var/www/src/wp-includes/blocks/search/view.min.js?ver=6.3-beta4-56216-src`).

The block can't use `plugins_url( 'search/view.min.js', __FILE__ )` when it is in core.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Use `viewScript` to register the script and update `view_script_handles` inside the block to only include it when it's needed.

## Testing Instructions
1. Insert a Search block.
2. Check frontend that the view script isn't loaded.
3. Update the Search block to use `Button only`.
4. Check frontend that the view script is loaded and works as expected.
