### PR TITLE
Fix md5 class messed up with new block key

### DIFF
--- a/lib/experimental/interactivity-api/class-wp-directive-processor.php
+++ b/lib/experimental/interactivity-api/class-wp-directive-processor.php
@@ -17,6 +17,37 @@
  * to improve this code.
  */
 class WP_Directive_Processor extends WP_HTML_Tag_Processor {
+
+	/**
+	 * An array of root blocks.
+	 *
+	 * @var array
+	 */
+	static $root_blocks = array();
+
+	/**
+	 * Add a root block to the list.
+	 *
+	 * @param array $block The block to add.
+	 *
+	 * @return void
+	 */
+	public static function add_root_block( $block ) {
+			self::$root_blocks[] = md5( serialize( $block ) );
+	}
+
+	/**
+	 * Check if block is a root block.
+	 *
+	 * @param array $block The block to check.
+	 *
+	 * @return bool True if block is a root block, false otherwise.
+	 */
+	public static function is_root_block( $block ) {
+			return in_array( md5( serialize( $block ) ), self::$root_blocks, true );
+	}
+
+
 	/**
 	 * Find the matching closing tag for an opening tag.
 	 *

--- a/lib/experimental/interactivity-api/directive-processing.php
+++ b/lib/experimental/interactivity-api/directive-processing.php
@@ -17,7 +17,7 @@
  */
 function gutenberg_interactivity_process_directives_in_root_blocks( $block_content, $block ) {
 	// Don't process inner blocks or root blocks that don't contain directives.
-	if ( isset( $block['is_inner_block'] ) || strpos( $block_content, 'data-wp-' ) === false ) {
+	if ( ! WP_Directive_Processor::is_root_block( $block ) || strpos( $block_content, 'data-wp-' ) === false ) {
 		return $block_content;
 	}
 
@@ -47,8 +47,8 @@ add_filter( 'render_block', 'gutenberg_interactivity_process_directives_in_root_
  * @return array The parsed block.
  */
 function gutenberg_interactivity_mark_inner_blocks( $parsed_block, $source_block, $parent_block ) {
-	if ( isset( $parent_block ) ) {
-		$parsed_block['is_inner_block'] = true;
+	if ( ! isset( $parent_block ) ) {
+		WP_Directive_Processor::add_root_block( $parsed_block );
 	}
 	return $parsed_block;
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

<!-- In a few words, what is the PR actually doing? -->

Fix a mismatch between the class added to some blocks and the styles added to the page.

Fixes https://github.com/WordPress/gutenberg/issues/52195.

## Why?

<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Because the styles engine is using an md5 of the block array, and adding keys to the array (like `$block['is_inner_block]`) changes the md5.

## How?

<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Instead of adding a new key to `$block`, I used the same md5 technique to keep an array of root blocks.

## Testing Instructions

<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

Check that the md5-generated class works again:

- Add this markup to a post:
  ```html
  <!-- wp:query {"queryId":1,"query":{"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","sticky":"","perPage":10}} -->
  <div class="wp-block-query">
    <!-- wp:post-template {"layout":{"type":"default"}} -->
    <!-- wp:post-title {"isLink":true,"style":{"elements":{"link":{"color":{"text":"var:preset|color|vivid-red"}}}}} /-->
    <!-- wp:post-excerpt /-->
    <!-- /wp:post-template -->
  </div>
  <!-- /wp:query -->
  ```
- Save the post
- Open the post in the frontend
- Check that color of the post title is red

Check that the Interactivity API server-side rendering still works fine:

- Open a post
- Add an HTML block
- Paste this code
  ```html
  <div data-wp-context='{ "hide": false, "color": "red" }'>
    <div
      class="another"
      style="text-decoration: underline"
      data-wp-bind--hidden="context.hide"
      data-wp-class--show="!context.hide"
      data-wp-style--color="context.color"
      data-wp-text="context.color"
    >
      default value
    </div>
  </div>
  ```
- Take a look at the frontend, there should be a red underlined text saying "red" with the class "show"
- Change the "color" to "blue".
- Now there should be a blue underlined text saying "blue"
- Change "hide" to true.
- The text now should have a `hidden` attribute and the "show" class should not be there anymore
