### PR TITLE
Remove synced blocks from lastBlockInserted

### DIFF
--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -1855,7 +1855,6 @@ export function lastBlockInserted( state = {}, action ) {
 	switch ( action.type ) {
 		case 'INSERT_BLOCKS':
 		case 'REPLACE_BLOCKS':
-		case 'REPLACE_INNER_BLOCKS':
 			if ( ! action.blocks.length ) {
 				return state;
 			}

--- a/packages/block-editor/src/store/test/reducer.js
+++ b/packages/block-editor/src/store/test/reducer.js
@@ -3328,28 +3328,32 @@ describe( 'state', () => {
 			expect( state.clientIds ).toEqual( [ clientIdOne, clientIdTwo ] );
 		} );
 
-		it( 'should not return client ids of all blocks when inner blocks are replaced with REPLACE_INNER_BLOCKS', () => {
-			const clientIdOne = '62bfef6e-d5e9-43ba-b7f9-c77cf354141f';
-			const clientIdTwo = '9db792c6-a25a-495d-adbd-97d56a4c4189';
+		it( 'should return client ids of the original blocks when inner blocks are replaced with REPLACE_INNER_BLOCKS', () => {
+			const initialBlocks = deepFreeze( [
+				'62bfef6e-d5e9-43ba-b7f9-c77cf354141f',
+				'9db792c6-a25a-495d-adbd-97d56a4c4189',
+			] );
 
 			const action = {
 				blocks: [
 					{
-						clientId: clientIdOne,
+						clientId: 'afd1cb17-2c08-4e7a-91be-007ba7ddc3a1',
 					},
 					{
-						clientId: clientIdTwo,
+						clientId: '14501cc2-90a6-4f52-aa36-ab6e896135d1',
 					},
 				],
 				type: 'REPLACE_INNER_BLOCKS',
 			};
 
-			const state = lastBlockInserted( {}, action );
+			const state = lastBlockInserted(
+				{
+					clientIds: initialBlocks,
+				},
+				action
+			);
 
-			expect( state.clientIds ).not.toEqual( [
-				clientIdOne,
-				clientIdTwo,
-			] );
+			expect( state.clientIds ).toEqual( initialBlocks );
 		} );
 
 		it( 'should return empty state if last block inserted is called with action RESET_BLOCKS', () => {

--- a/packages/block-editor/src/store/test/reducer.js
+++ b/packages/block-editor/src/store/test/reducer.js
@@ -3328,7 +3328,7 @@ describe( 'state', () => {
 			expect( state.clientIds ).toEqual( [ clientIdOne, clientIdTwo ] );
 		} );
 
-		it( 'should return client ids of all blocks when inner blocks are replaced with REPLACE_INNER_BLOCKS', () => {
+		it( 'should not return client ids of all blocks when inner blocks are replaced with REPLACE_INNER_BLOCKS', () => {
 			const clientIdOne = '62bfef6e-d5e9-43ba-b7f9-c77cf354141f';
 			const clientIdTwo = '9db792c6-a25a-495d-adbd-97d56a4c4189';
 
@@ -3346,7 +3346,10 @@ describe( 'state', () => {
 
 			const state = lastBlockInserted( {}, action );
 
-			expect( state.clientIds ).toEqual( [ clientIdOne, clientIdTwo ] );
+			expect( state.clientIds ).not.toEqual( [
+				clientIdOne,
+				clientIdTwo,
+			] );
 		} );
 
 		it( 'should return empty state if last block inserted is called with action RESET_BLOCKS', () => {


### PR DESCRIPTION
## What?

Fixes https://github.com/WordPress/gutenberg/issues/51713.

## How?

Removes REPLACE_INNER_BLOCKS from the condition under which we determine that a block has been inserted into the canvas. 

`useBlockSync` calls `replaceInnerBlocks`, when it's trying to sync the controlled blocks state:

https://github.com/WordPress/gutenberg/blob/de715477d7d893da9ab3cc946edfa4b8fd896222/packages/block-editor/src/components/provider/use-block-sync.js#L127

Since https://github.com/WordPress/gutenberg/pull/46885, this ends up setting the state for the last inserted block in the reducer:

https://github.com/WordPress/gutenberg/blob/de715477d7d893da9ab3cc946edfa4b8fd896222/packages/block-editor/src/store/reducer.js#L1858

This means that when a controlled block is synced, the app considers all of these blocks to be "last inserted blocks". However the user would not consider these blocks to have been "last inserted".

This causes issues like https://github.com/WordPress/gutenberg/issues/51713, because we keep on thinking that the search block has been inserted again and resetting the attributes.

## Testing Instructions
1. Add a navigation block
2. Add a search block to your navigation block
3. Change the attributes of the search block and save it
4. Check that the search block keeps the attributes you selected.
