### PR TITLE
[RNMobile] Use Reanimated in bottom sheet height animation

### DIFF
--- a/packages/components/src/mobile/bottom-sheet/bottom-sheet-navigation/bottom-sheet-navigation-context.native.js
+++ b/packages/components/src/mobile/bottom-sheet/bottom-sheet-navigation/bottom-sheet-navigation-context.native.js
@@ -6,7 +6,7 @@ import { createContext } from '@wordpress/element';
 // Navigation context in BottomSheet is necessary for controlling the
 // height of navigation container.
 export const BottomSheetNavigationContext = createContext( {
-	currentHeight: 1,
+	currentHeight: { value: 0 },
 	setHeight: () => {},
 } );
 

--- a/packages/components/src/mobile/bottom-sheet/bottom-sheet-navigation/navigation-container.native.js
+++ b/packages/components/src/mobile/bottom-sheet/bottom-sheet-navigation/navigation-container.native.js
@@ -1,15 +1,19 @@
 /**
  * External dependencies
  */
-import { View, Easing } from 'react-native';
 import { NavigationContainer, DefaultTheme } from '@react-navigation/native';
 import { createStackNavigator } from '@react-navigation/stack';
+import Animated, {
+	Easing,
+	useAnimatedStyle,
+	useSharedValue,
+	withTiming,
+} from 'react-native-reanimated';
 
 /**
  * WordPress dependencies
  */
 import {
-	useState,
 	useContext,
 	useMemo,
 	useCallback,
@@ -23,11 +27,11 @@ import { usePreferredColorSchemeStyle } from '@wordpress/compose';
 /**
  * Internal dependencies
  */
-import { performLayoutAnimation } from '../../layout-animation';
 import {
 	BottomSheetNavigationContext,
 	BottomSheetNavigationProvider,
 } from './bottom-sheet-navigation-context';
+import { BottomSheetContext } from '../bottom-sheet-context';
 
 import styles from './styles.scss';
 
@@ -57,7 +61,8 @@ const options = {
 	cardStyleInterpolator: fadeConfig,
 };
 
-const ANIMATION_DURATION = 190;
+const HEIGHT_ANIMATION_DURATION = 300;
+const DEFAULT_HEIGHT = 1;
 
 function BottomSheetNavigationContainer( {
 	children,
@@ -67,9 +72,11 @@ function BottomSheetNavigationContainer( {
 	style,
 } ) {
 	const Stack = useRef( createStackNavigator() ).current;
-	const context = useContext( BottomSheetNavigationContext );
-	const [ currentHeight, setCurrentHeight ] = useState(
-		context.currentHeight || 1
+	const navigationContext = useContext( BottomSheetNavigationContext );
+	const { maxHeight: sheetMaxHeight, isMaxHeightSet: isSheetMaxHeightSet } =
+		useContext( BottomSheetContext );
+	const currentHeight = useSharedValue(
+		navigationContext.currentHeight?.value || DEFAULT_HEIGHT
 	);
 
 	const backgroundStyle = usePreferredColorSchemeStyle(
@@ -87,36 +94,34 @@ function BottomSheetNavigationContainer( {
 
 	const setHeight = useCallback(
 		( height ) => {
-			// The screen is fullHeight.
 			if (
-				typeof height === 'string' &&
-				typeof height !== typeof currentHeight
+				height > DEFAULT_HEIGHT &&
+				Math.round( height ) !== Math.round( currentHeight.value )
 			) {
-				performLayoutAnimation( ANIMATION_DURATION );
-				setCurrentHeight( height );
+				// If max height is set in the bottom sheet, we clamp
+				// the new height using that value.
+				const newHeight = isSheetMaxHeightSet
+					? Math.min( sheetMaxHeight, height )
+					: height;
+				const shouldAnimate =
+					animate && currentHeight.value !== DEFAULT_HEIGHT;
 
-				return;
-			}
-
-			if (
-				height > 1 &&
-				Math.round( height ) !== Math.round( currentHeight )
-			) {
-				if ( currentHeight === 1 ) {
-					setCurrentHeight( height );
-				} else if ( animate ) {
-					performLayoutAnimation( ANIMATION_DURATION );
-					setCurrentHeight( height );
+				if ( shouldAnimate ) {
+					currentHeight.value = withTiming( newHeight, {
+						duration: HEIGHT_ANIMATION_DURATION,
+						easing: Easing.out( Easing.cubic ),
+					} );
 				} else {
-					setCurrentHeight( height );
+					currentHeight.value = newHeight;
 				}
 			}
 		},
-		// Disable reason: deferring this refactor to the native team.
-		// see https://github.com/WordPress/gutenberg/pull/41166
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-		[ currentHeight ]
+		[ animate, currentHeight, isSheetMaxHeightSet, sheetMaxHeight ]
 	);
+
+	const animatedStyles = useAnimatedStyle( () => ( {
+		height: currentHeight.value,
+	} ) );
 
 	const screens = useMemo( () => {
 		return Children.map( children, ( child ) => {
@@ -143,12 +148,9 @@ function BottomSheetNavigationContainer( {
 
 	return useMemo( () => {
 		return (
-			<View style={ [ style, { height: currentHeight } ] }>
+			<Animated.View style={ [ style, animatedStyles ] }>
 				<BottomSheetNavigationProvider
-					value={ {
-						setHeight,
-						currentHeight,
-					} }
+					value={ { setHeight, currentHeight } }
 				>
 					{ main ? (
 						<NavigationContainer theme={ _theme }>
@@ -168,12 +170,12 @@ function BottomSheetNavigationContainer( {
 						</Stack.Navigator>
 					) }
 				</BottomSheetNavigationProvider>
-			</View>
+			</Animated.View>
 		);
 		// Disable reason: deferring this refactor to the native team.
 		// see https://github.com/WordPress/gutenberg/pull/41166
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [ currentHeight, _theme ] );
+	}, [ _theme ] );
 }
 
 export default BottomSheetNavigationContainer;

--- a/packages/components/src/mobile/bottom-sheet/bottom-sheet-navigation/navigation-container.native.js
+++ b/packages/components/src/mobile/bottom-sheet/bottom-sheet-navigation/navigation-container.native.js
@@ -70,6 +70,7 @@ function BottomSheetNavigationContainer( {
 	main,
 	theme,
 	style,
+	testID,
 } ) {
 	const Stack = useRef( createStackNavigator() ).current;
 	const navigationContext = useContext( BottomSheetNavigationContext );
@@ -149,7 +150,10 @@ function BottomSheetNavigationContainer( {
 
 	return useMemo( () => {
 		return (
-			<Animated.View style={ [ style, animatedStyles ] }>
+			<Animated.View
+				style={ [ style, animatedStyles ] }
+				testID={ testID }
+			>
 				<BottomSheetNavigationProvider
 					value={ { setHeight, currentHeight } }
 				>
@@ -181,6 +185,7 @@ function BottomSheetNavigationContainer( {
 		screens,
 		setHeight,
 		style,
+		testID,
 	] );
 }
 

--- a/packages/components/src/mobile/bottom-sheet/bottom-sheet-navigation/navigation-container.native.js
+++ b/packages/components/src/mobile/bottom-sheet/bottom-sheet-navigation/navigation-container.native.js
@@ -84,13 +84,17 @@ function BottomSheetNavigationContainer( {
 		styles.backgroundDark
 	);
 
-	const _theme = theme || {
-		...DefaultTheme,
-		colors: {
-			...DefaultTheme.colors,
-			background: backgroundStyle.backgroundColor,
-		},
-	};
+	const defaultTheme = useMemo(
+		() => ( {
+			...DefaultTheme,
+			colors: {
+				...DefaultTheme.colors,
+				background: backgroundStyle.backgroundColor,
+			},
+		} ),
+		[ backgroundStyle.backgroundColor ]
+	);
+	const _theme = theme || defaultTheme;
 
 	const setHeight = useCallback(
 		( height ) => {
@@ -141,10 +145,7 @@ function BottomSheetNavigationContainer( {
 				/>
 			);
 		} );
-		// Disable reason: deferring this refactor to the native team.
-		// see https://github.com/WordPress/gutenberg/pull/41166
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [ children ] );
+	}, [ children, main ] );
 
 	return useMemo( () => {
 		return (
@@ -172,10 +173,15 @@ function BottomSheetNavigationContainer( {
 				</BottomSheetNavigationProvider>
 			</Animated.View>
 		);
-		// Disable reason: deferring this refactor to the native team.
-		// see https://github.com/WordPress/gutenberg/pull/41166
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [ _theme ] );
+	}, [
+		_theme,
+		animatedStyles,
+		currentHeight,
+		main,
+		screens,
+		setHeight,
+		style,
+	] );
 }
 
 export default BottomSheetNavigationContainer;

--- a/packages/components/src/mobile/bottom-sheet/bottom-sheet-navigation/navigation-screen.native.js
+++ b/packages/components/src/mobile/bottom-sheet/bottom-sheet-navigation/navigation-screen.native.js
@@ -6,7 +6,12 @@ import {
 	useNavigation,
 	useFocusEffect,
 } from '@react-navigation/native';
-import { View, ScrollView, TouchableHighlight } from 'react-native';
+import {
+	ScrollView,
+	TouchableHighlight,
+	useWindowDimensions,
+	View,
+} from 'react-native';
 
 /**
  * WordPress dependencies
@@ -38,6 +43,7 @@ const BottomSheetNavigationScreen = ( {
 		listProps,
 		safeAreaBottomInset,
 	} = useContext( BottomSheetContext );
+	const { height: windowHeight } = useWindowDimensions();
 
 	const { setHeight } = useContext( BottomSheetNavigationContext );
 
@@ -81,7 +87,7 @@ const BottomSheetNavigationScreen = ( {
 	useFocusEffect(
 		useCallback( () => {
 			if ( fullScreen ) {
-				setHeight( '100%' );
+				setHeight( windowHeight );
 				setIsFullScreen( true );
 			} else if ( heightRef.current.maxHeight !== 0 ) {
 				setIsFullScreen( false );

--- a/packages/components/src/mobile/bottom-sheet/bottom-sheet-navigation/navigation-screen.native.js
+++ b/packages/components/src/mobile/bottom-sheet/bottom-sheet-navigation/navigation-screen.native.js
@@ -17,7 +17,6 @@ import {
  * WordPress dependencies
  */
 import { BottomSheetContext } from '@wordpress/components';
-import { debounce } from '@wordpress/compose';
 import { useRef, useCallback, useContext, useMemo } from '@wordpress/element';
 
 /**
@@ -46,13 +45,6 @@ const BottomSheetNavigationScreen = ( {
 	const { height: windowHeight } = useWindowDimensions();
 
 	const { setHeight } = useContext( BottomSheetNavigationContext );
-
-	// Disable reason: deferring this refactor to the native team.
-	// see https://github.com/WordPress/gutenberg/pull/41166
-	// eslint-disable-next-line react-hooks/exhaustive-deps
-	const setHeightDebounce = useCallback( debounce( setHeight, 10 ), [
-		setHeight,
-	] );
 
 	useFocusEffect(
 		useCallback( () => {
@@ -104,7 +96,7 @@ const BottomSheetNavigationScreen = ( {
 		const { height } = nativeEvent.layout;
 		if ( maxHeight.current !== height && isFocused ) {
 			maxHeight.current = height;
-			setHeightDebounce( height );
+			setHeight( height );
 		}
 	};
 

--- a/packages/components/src/mobile/bottom-sheet/bottom-sheet-navigation/navigation-screen.native.js
+++ b/packages/components/src/mobile/bottom-sheet/bottom-sheet-navigation/navigation-screen.native.js
@@ -34,7 +34,7 @@ const BottomSheetNavigationScreen = ( {
 	name,
 } ) => {
 	const navigation = useNavigation();
-	const heightRef = useRef( { maxHeight: 0 } );
+	const maxHeight = useRef( 0 );
 	const isFocused = useIsFocused();
 	const {
 		onHandleHardwareButtonPress,
@@ -89,15 +89,12 @@ const BottomSheetNavigationScreen = ( {
 			if ( fullScreen ) {
 				setHeight( windowHeight );
 				setIsFullScreen( true );
-			} else if ( heightRef.current.maxHeight !== 0 ) {
+			} else if ( maxHeight.current !== 0 ) {
 				setIsFullScreen( false );
-				setHeight( heightRef.current.maxHeight );
+				setHeight( maxHeight.current );
 			}
 			return () => {};
-			// Disable reason: deferring this refactor to the native team.
-			// see https://github.com/WordPress/gutenberg/pull/41166
-			// eslint-disable-next-line react-hooks/exhaustive-deps
-		}, [ setHeight ] )
+		}, [ fullScreen, setHeight, setIsFullScreen, windowHeight ] )
 	);
 
 	const onLayout = ( { nativeEvent } ) => {
@@ -105,9 +102,8 @@ const BottomSheetNavigationScreen = ( {
 			return;
 		}
 		const { height } = nativeEvent.layout;
-
-		if ( heightRef.current.maxHeight !== height && isFocused ) {
-			heightRef.current.maxHeight = height;
+		if ( maxHeight.current !== height && isFocused ) {
+			maxHeight.current = height;
 			setHeightDebounce( height );
 		}
 	};

--- a/packages/components/src/mobile/bottom-sheet/bottom-sheet-navigation/test/navigation-container.native.js
+++ b/packages/components/src/mobile/bottom-sheet/bottom-sheet-navigation/test/navigation-container.native.js
@@ -2,7 +2,12 @@
  * External dependencies
  */
 import { Text } from 'react-native';
-import { render, fireEvent, act } from 'test/helpers';
+import {
+	render,
+	fireEvent,
+	withReanimatedTimer,
+	advanceAnimationByTime,
+} from 'test/helpers';
 import { useNavigation } from '@react-navigation/native';
 
 /**
@@ -10,11 +15,8 @@ import { useNavigation } from '@react-navigation/native';
  */
 import NavigationContainer from '../navigation-container';
 import NavigationScreen from '../navigation-screen';
-import { performLayoutAnimation } from '../../../layout-animation';
 
-jest.mock( '../../../layout-animation', () => ( {
-	performLayoutAnimation: jest.fn(),
-} ) );
+const WINDOW_HEIGHT = 1000;
 
 const TestScreen = ( { fullScreen, name, navigateTo } ) => {
 	const navigation = useNavigation();
@@ -27,130 +29,174 @@ const TestScreen = ( { fullScreen, name, navigateTo } ) => {
 	);
 };
 
+const fireLayoutEvent = ( element, layout ) =>
+	fireEvent( element, 'layout', {
+		nativeEvent: { layout },
+	} );
+
 beforeAll( () => {
-	jest.useFakeTimers( { legacyFakeTimers: true } );
+	jest.spyOn(
+		require( 'react-native' ),
+		'useWindowDimensions'
+	).mockReturnValue( { width: 900, height: WINDOW_HEIGHT } );
 } );
 
-afterAll( () => {
-	jest.runOnlyPendingTimers();
-	jest.useRealTimers();
-} );
+it( 'animates height transitioning from non-full-screen to non-full-screen', async () =>
+	withReanimatedTimer( async () => {
+		const screen = render(
+			<NavigationContainer testID="navigation-container" main animate>
+				<TestScreen name="test-screen-1" navigateTo="test-screen-2" />
+				<TestScreen name="test-screen-2" navigateTo="test-screen-1" />
+			</NavigationContainer>
+		);
 
-it( 'animates height transitioning from non-full-screen to full-screen', async () => {
-	const screen = render(
-		<NavigationContainer main animate>
-			<TestScreen name="test-screen-1" navigateTo="test-screen-2" />
-			<TestScreen
-				name="test-screen-2"
-				navigateTo="test-screen-1"
-				fullScreen
-			/>
-		</NavigationContainer>
-	);
+		const navigationContainer = await screen.findByTestId(
+			'navigation-container'
+		);
 
-	// Await navigation screen to allow async state updates to complete
-	const navigationScreen = await screen.findByTestId(
-		'navigation-screen-test-screen-1'
-	);
-	// Trigger non-full-screen layout event
-	act( () => {
-		fireEvent( navigationScreen, 'layout', {
-			nativeEvent: {
-				layout: {
-					height: 123,
-				},
-			},
+		expect( navigationContainer ).toHaveAnimatedStyle( { height: 1 } );
+
+		// First height value should be set without animation, but we need
+		// to wait for a frame to let animated styles be updated.
+		const screen1Layout = { height: 100 };
+		fireLayoutEvent(
+			screen.getByTestId( 'navigation-screen-test-screen-1' ),
+			screen1Layout
+		);
+		advanceAnimationByTime( 1 );
+		expect( navigationContainer ).toHaveAnimatedStyle( screen1Layout );
+
+		// Navigate to screen 2
+		fireEvent.press( screen.getByText( /test-screen-1/ ) );
+		const screen2Layout = { height: 200 };
+		fireLayoutEvent(
+			screen.getByTestId( 'navigation-screen-test-screen-2' ),
+			screen2Layout
+		);
+		// The animation takes 300 ms, so we wait that time plus 1 ms
+		// to the completion.
+		advanceAnimationByTime( 301 );
+		expect( navigationContainer ).toHaveAnimatedStyle( screen2Layout );
+	} ) );
+
+it( 'animates height transitioning from non-full-screen to full-screen', async () =>
+	withReanimatedTimer( async () => {
+		const screen = render(
+			<NavigationContainer testID="navigation-container" main animate>
+				<TestScreen name="test-screen-1" navigateTo="test-screen-2" />
+				<TestScreen
+					name="test-screen-2"
+					navigateTo="test-screen-1"
+					fullScreen
+				/>
+			</NavigationContainer>
+		);
+
+		const navigationContainer = await screen.findByTestId(
+			'navigation-container'
+		);
+
+		expect( navigationContainer ).toHaveAnimatedStyle( { height: 1 } );
+
+		// First height value should be set without animation, but we need
+		// to wait for a frame to let animated styles be updated.
+		const screen1Layout = { height: 100 };
+		fireLayoutEvent(
+			screen.getByTestId( 'navigation-screen-test-screen-1' ),
+			screen1Layout
+		);
+		advanceAnimationByTime( 1 );
+		expect( navigationContainer ).toHaveAnimatedStyle( screen1Layout );
+
+		// Navigate to screen 2
+		fireEvent.press( screen.getByText( /test-screen-1/ ) );
+		// The animation takes 300 ms, so we wait that time plus 1 ms
+		// to the completion.
+		advanceAnimationByTime( 301 );
+		expect( navigationContainer ).toHaveAnimatedStyle( {
+			height: WINDOW_HEIGHT,
 		} );
-		// Trigger debounced setting of height after layout event
-		jest.advanceTimersByTime( 10 );
-	} );
-	// Navigate to screen 2
-	fireEvent.press( await screen.findByText( /test-screen-1/ ) );
-	// Await navigation screen to allow async state updates to complete
-	await screen.findByText( /test-screen-2/ );
+	} ) );
 
-	expect( performLayoutAnimation ).toHaveBeenCalledTimes( 1 );
-} );
+it( 'animates height transitioning from full-screen to non-full-screen', async () =>
+	withReanimatedTimer( async () => {
+		const screen = render(
+			<NavigationContainer testID="navigation-container" main animate>
+				<TestScreen name="test-screen-1" navigateTo="test-screen-2" />
+				<TestScreen
+					name="test-screen-2"
+					navigateTo="test-screen-1"
+					fullScreen
+				/>
+			</NavigationContainer>
+		);
 
-it( 'animates height transitioning from full-screen to non-full-screen', async () => {
-	const screen = render(
-		<NavigationContainer main animate>
-			<TestScreen name="test-screen-1" navigateTo="test-screen-2" />
-			<TestScreen
-				name="test-screen-2"
-				navigateTo="test-screen-1"
-				fullScreen
-			/>
-		</NavigationContainer>
-	);
+		const navigationContainer = await screen.findByTestId(
+			'navigation-container'
+		);
 
-	// Await navigation screen to allow async state updates to complete
-	const navigationScreen = await screen.findByTestId(
-		'navigation-screen-test-screen-1'
-	);
-	// Trigger non-full-screen layout event
-	act( () => {
-		fireEvent( navigationScreen, 'layout', {
-			nativeEvent: {
-				layout: {
-					height: 123,
-				},
-			},
+		expect( navigationContainer ).toHaveAnimatedStyle( { height: 1 } );
+
+		// First height value should be set without animation, but we need
+		// to wait for a frame to let animated styles be updated.
+		const screen1Layout = { height: 100 };
+		fireLayoutEvent(
+			screen.getByTestId( 'navigation-screen-test-screen-1' ),
+			screen1Layout
+		);
+		advanceAnimationByTime( 1 );
+		expect( navigationContainer ).toHaveAnimatedStyle( screen1Layout );
+
+		// Navigate to screen 2
+		fireEvent.press( screen.getByText( /test-screen-1/ ) );
+		// The animation takes 300 ms, so we wait that time plus 1 ms
+		// to the completion.
+		advanceAnimationByTime( 301 );
+		expect( navigationContainer ).toHaveAnimatedStyle( {
+			height: WINDOW_HEIGHT,
 		} );
-		// Trigger debounced setting of height after layout event
-		jest.advanceTimersByTime( 10 );
-	} );
-	// Navigate to screen 2
-	fireEvent.press( await screen.findByText( /test-screen-1/ ) );
-	// Navigate to screen 1
-	fireEvent.press( await screen.findByText( /test-screen-2/ ) );
-	// Await navigation screen to allow async state updates to complete
-	await screen.findByText( /test-screen-1/ );
 
-	expect( performLayoutAnimation ).toHaveBeenCalledTimes( 2 );
-} );
+		// Navigate to screen 1
+		fireEvent.press( await screen.findByText( /test-screen-2/ ) );
+		// The animation takes 300 ms, so we wait that time plus 1 ms
+		// to the completion.
+		advanceAnimationByTime( 301 );
+		expect( navigationContainer ).toHaveAnimatedStyle( screen1Layout );
+	} ) );
 
-it( 'does not animate height transitioning from full-screen to full-screen', async () => {
-	const screen = render(
-		<NavigationContainer main animate>
-			<TestScreen name="test-screen-1" navigateTo="test-screen-2" />
-			<TestScreen
-				name="test-screen-2"
-				navigateTo="test-screen-3"
-				fullScreen
-			/>
-			<TestScreen
-				name="test-screen-3"
-				navigateTo="test-screen-2"
-				fullScreen
-			/>
-		</NavigationContainer>
-	);
+it( 'does not animate height transitioning from full-screen to full-screen', async () =>
+	withReanimatedTimer( async () => {
+		const screen = render(
+			<NavigationContainer testID="navigation-container" main animate>
+				<TestScreen
+					name="test-screen-1"
+					navigateTo="test-screen-2"
+					fullScreen
+				/>
+				<TestScreen
+					name="test-screen-2"
+					navigateTo="test-screen-1"
+					fullScreen
+				/>
+			</NavigationContainer>
+		);
 
-	// Await navigation screen to allow async state updates to complete
-	const navigationScreen = await screen.findByTestId(
-		'navigation-screen-test-screen-1'
-	);
-	// Trigger non-full-screen layout event
-	act( () => {
-		fireEvent( navigationScreen, 'layout', {
-			nativeEvent: {
-				layout: {
-					height: 123,
-				},
-			},
+		const navigationContainer = await screen.findByTestId(
+			'navigation-container'
+		);
+
+		// First height value should be set without animation, but we need
+		// to wait for a frame to let animated styles be updated.
+		advanceAnimationByTime( 1 );
+		expect( navigationContainer ).toHaveAnimatedStyle( {
+			height: WINDOW_HEIGHT,
 		} );
-		// Trigger debounced setting of height after layout event
-		jest.advanceTimersByTime( 10 );
-	} );
-	// Navigate to screen 2
-	fireEvent.press( await screen.findByText( /test-screen-1/ ) );
-	// Navigate to screen 3
-	fireEvent.press( await screen.findByText( /test-screen-2/ ) );
-	// Navigate to screen 2
-	fireEvent.press( await screen.findByText( /test-screen-3/ ) );
-	// Await navigation screen to allow async state updates to complete
-	await screen.findByText( /test-screen-2/ );
 
-	expect( performLayoutAnimation ).toHaveBeenCalledTimes( 1 );
-} );
+		// Navigate to screen 2
+		fireEvent.press( screen.getByText( /test-screen-1/ ) );
+		// We wait some milliseconds to check if height has changed.
+		advanceAnimationByTime( 10 );
+		expect( navigationContainer ).toHaveAnimatedStyle( {
+			height: WINDOW_HEIGHT,
+		} );
+	} ) );

--- a/packages/components/src/mobile/bottom-sheet/index.native.js
+++ b/packages/components/src/mobile/bottom-sheet/index.native.js
@@ -575,6 +575,8 @@ class BottomSheet extends Component {
 								listProps,
 								setIsFullScreen: this.setIsFullScreen,
 								safeAreaBottomInset,
+								maxHeight,
+								isMaxHeightSet,
 							} }
 						>
 							{ hasNavigation ? (

--- a/packages/format-library/src/link/test/__snapshots__/modal.native.js.snap
+++ b/packages/format-library/src/link/test/__snapshots__/modal.native.js.snap
@@ -44,13 +44,18 @@ exports[`LinksUI LinksUI renders 1`] = `
       }
     >
       <View
-        style={
-          [
-            undefined,
-            {
+        animatedStyle={
+          {
+            "value": {
               "height": 1,
             },
-          ]
+          }
+        }
+        collapsable={false}
+        style={
+          {
+            "height": 1,
+          }
         }
       >
         <RNGestureHandlerRootView

--- a/test/native/integration-test-helpers/with-reanimated-timer.js
+++ b/test/native/integration-test-helpers/with-reanimated-timer.js
@@ -24,10 +24,18 @@ export async function withReanimatedTimer( fn ) {
 		global.requestAnimationFrame = ( callback ) =>
 			setTimeout( callback, FRAME_TIME );
 
+		// Reanimated uses a custom `now` function to advance animations. In order to be able to use
+		// Jest timer functions to advance animations we need to set the fake timers' internal clock.
+		// Reference: https://t.ly/0S__f
+		const reanimatedNowMockCopy = global.ReanimatedDataMock.now;
+		global.ReanimatedDataMock.now = jest.now;
+
 		const result = await fn();
 
 		// As part of the clean up, we run all pending timers that might have been derived from animations.
 		act( () => jest.runOnlyPendingTimers() );
+
+		global.ReanimatedDataMock.now = reanimatedNowMockCopy;
 
 		return result;
 	} );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

The main goal of this PR is to update the animation framework used to animate the bottom sheet's height. Currently, we use layout animations ([reference](https://github.com/WordPress/gutenberg/blob/e448fa70163ce936eae9aec454ca99f5a6287f15/packages/components/src/mobile/bottom-sheet/bottom-sheet-navigation/navigation-container.native.js#L108)) that will be replaced with Reanimated.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

On Android, using layout animations can lead to inconsistent visual states when used in combination with React navigation. Specifically in the Image block, the content of the bottom sheet gets transparent after setting a custom URL.

Additionally, layout animations are experimental on Android, so it would be great to avoid them.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

The height was being animated using the function `setHeight`, which keeps the height value in the component's state and updates the styles, and then invoking `performLayoutAnimation` to execute the layout animation. This logic has been replaced using [Reanimated's shared value](https://docs.swmansion.com/react-native-reanimated/docs/2.x/fundamentals/shared-values) to keep the height value, and [`withTiming`](https://docs.swmansion.com/react-native-reanimated/docs/2.x/api/animations/withTiming) in combination with [`useAnimatedStyle`](https://docs.swmansion.com/react-native-reanimated/docs/2.x/api/hooks/useAnimatedStyle) to animate the value. This implementation can be seen in https://github.com/WordPress/gutenberg/pull/52563/commits/634b2fd42d398c73656038e85ad9d4924d2edf95.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

### Inconsistent visual state in "Link to" setting
1. Open a post/page in the app.
2. Add an Image block.
3. Set an image.
4. Open the block settings by tapping on the ⚙️ button.
5. Tap on "Link to" option.
6. Tap on "Custom URL" option.
7. Type a URL.
8. Tap on the ✔️ /Submit key in the keyboard.
9. Observe that it navigates back to the block settings sheet.
10. Observe that the "Link to" option displays the value "Custom URL".

### Bottom sheet's height animation
**NOTE:** This covers a wide range of test cases, so we can't provide a specific case. 

1. Add different blocks.
2. Open the block settings of each block.
3. Navigate through different block settings.
4. Observe that the bottom sheet's height is animated accordingly.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
N/A

## Screenshots or screencast <!-- if applicable -->

| Android | iOS |
|--------|--------|
| <video src=https://github.com/WordPress/gutenberg/assets/14905380/80cdb7b4-d60a-4fbc-8f28-8b647504795c> | <video src=https://github.com/WordPress/gutenberg/assets/14905380/ec1fe1c2-8510-444b-a6b2-a3af9d3c8e2f> | 