### PR TITLE
Site Editor: Reset device preview type when exiting the editing mode

### DIFF
--- a/packages/edit-site/src/components/site-hub/index.js
+++ b/packages/edit-site/src/components/site-hub/index.js
@@ -51,7 +51,10 @@ const SiteHub = forwardRef( ( props, ref ) => {
 	const { open: openCommandCenter } = useDispatch( commandsStore );
 
 	const disableMotion = useReducedMotion();
-	const { setCanvasMode } = unlock( useDispatch( editSiteStore ) );
+	const {
+		setCanvasMode,
+		__experimentalSetPreviewDeviceType: setPreviewDeviceType,
+	} = unlock( useDispatch( editSiteStore ) );
 	const { clearSelectedBlock } = useDispatch( blockEditorStore );
 	const isBackToDashboardButton = canvasMode === 'view';
 	const siteIconButtonProps = isBackToDashboardButton
@@ -67,6 +70,7 @@ const SiteHub = forwardRef( ( props, ref ) => {
 					event.preventDefault();
 					if ( canvasMode === 'edit' ) {
 						clearSelectedBlock();
+						setPreviewDeviceType( 'desktop' );
 						setCanvasMode( 'view' );
 					}
 				},


### PR DESCRIPTION
## What?
Fixes #52464.

Reset the device preview type when exiting the Site editing mode. 

## Why?
The editor canvas preview mode conflicts with the resizing feature.

## Testing Instructions
1. Open the Site editor
2. Click on a template to enable the editing mode
3. Change the preview mode to something different from the desktop mode
4. Exit the editing mode by clicking "Open Navigation" in the top left corner
5. Confirm that the preview device type is set back to the desktop

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/240569/cb78e1c6-adaa-4f8a-9160-0efcd31b5f7f


