### PR TITLE
SiteHub: Combine site data selector hooks

### DIFF
--- a/packages/edit-site/src/components/site-hub/index.js
+++ b/packages/edit-site/src/components/site-hub/index.js
@@ -32,22 +32,27 @@ import { unlock } from '../../lock-unlock';
 const HUB_ANIMATION_DURATION = 0.3;
 
 const SiteHub = forwardRef( ( props, ref ) => {
-	const { canvasMode, dashboardLink, homeUrl } = useSelect( ( select ) => {
-		const { getCanvasMode, getSettings } = unlock(
-			select( editSiteStore )
-		);
+	const { canvasMode, dashboardLink, homeUrl, siteTitle } = useSelect(
+		( select ) => {
+			const { getCanvasMode, getSettings } = unlock(
+				select( editSiteStore )
+			);
 
-		const {
-			getUnstableBase, // Site index.
-		} = select( coreStore );
+			const {
+				getSite,
+				getUnstableBase, // Site index.
+			} = select( coreStore );
 
-		return {
-			canvasMode: getCanvasMode(),
-			dashboardLink:
-				getSettings().__experimentalDashboardLink || 'index.php',
-			homeUrl: getUnstableBase()?.home,
-		};
-	}, [] );
+			return {
+				canvasMode: getCanvasMode(),
+				dashboardLink:
+					getSettings().__experimentalDashboardLink || 'index.php',
+				homeUrl: getUnstableBase()?.home,
+				siteTitle: getSite()?.title,
+			};
+		},
+		[]
+	);
 	const { open: openCommandCenter } = useDispatch( commandsStore );
 
 	const disableMotion = useReducedMotion();
@@ -71,12 +76,6 @@ const SiteHub = forwardRef( ( props, ref ) => {
 					}
 				},
 		  };
-
-	const siteTitle = useSelect(
-		( select ) =>
-			select( coreStore ).getEntityRecord( 'root', 'site' )?.title,
-		[]
-	);
 
 	return (
 		<motion.div


### PR DESCRIPTION
## What?
A small cleanup for the `SiteHub` component. Combines two `useSelect` hooks into one.

## Why?
The first hook was already subscribed to the `core` store, so I don't see a reason to keep two hooks.

P.S. I also couldn't find anything in the original PR #47777.

## Testing Instructions
1. Open the Site Editor.
2. Confirm site title is rendered as before.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2023-07-12 at 17 26 43](https://github.com/WordPress/gutenberg/assets/240569/0815d9ef-a521-457b-bf93-4c812d83276b)
