### PR TITLE
Change pattern management title and text to avoid specifying pattern source incorrectly.

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen-patterns/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-patterns/index.js
@@ -61,6 +61,9 @@ function TemplatePartGroup( { areas, currentArea, currentType } ) {
 function ThemePatternsGroup( { categories, currentCategory, currentType } ) {
 	return (
 		<>
+			<div className="edit-site-sidebar-navigation-screen-patterns__group-header">
+				<Heading level={ 2 }>{ __( 'Additional patterns' ) }</Heading>
+			</div>
 			<ItemGroup className="edit-site-sidebar-navigation-screen-patterns__group">
 				{ categories.map( ( category ) => (
 					<CategoryItem
@@ -72,7 +75,7 @@ function ThemePatternsGroup( { categories, currentCategory, currentType } ) {
 								<Tooltip
 									position="top center"
 									text={ __(
-										'Theme patterns cannot be edited.'
+										'Included patterns cannot be edited.'
 									) }
 								>
 									<span className="edit-site-sidebar-navigation-screen-pattern__lock-icon">

--- a/packages/edit-site/src/components/sidebar-navigation-screen-patterns/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-patterns/index.js
@@ -61,9 +61,6 @@ function TemplatePartGroup( { areas, currentArea, currentType } ) {
 function ThemePatternsGroup( { categories, currentCategory, currentType } ) {
 	return (
 		<>
-			<div className="edit-site-sidebar-navigation-screen-patterns__group-header">
-				<Heading level={ 2 }>{ __( 'Additional patterns' ) }</Heading>
-			</div>
 			<ItemGroup className="edit-site-sidebar-navigation-screen-patterns__group">
 				{ categories.map( ( category ) => (
 					<CategoryItem
@@ -75,7 +72,7 @@ function ThemePatternsGroup( { categories, currentCategory, currentType } ) {
 								<Tooltip
 									position="top center"
 									text={ __(
-										'Included patterns cannot be edited.'
+										'Theme and plugin patterns cannot be edited.'
 									) }
 								>
 									<span className="edit-site-sidebar-navigation-screen-pattern__lock-icon">


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Re. https://github.com/WordPress/gutenberg/issues/52498

Change wording for patterns in the editor to avoid mislabeling plugin patterns as theme patterns.

## Screenshots or screencast <!-- if applicable -->
<img width="348" alt="image" src="https://github.com/WordPress/gutenberg/assets/1157901/a24be425-bc54-4135-a16b-fb9f815862cb">


