### PR TITLE
Remove "Theme patterns" heading in Pattern library

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen-patterns/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-patterns/index.js
@@ -61,9 +61,6 @@ function TemplatePartGroup( { areas, currentArea, currentType } ) {
 function ThemePatternsGroup( { categories, currentCategory, currentType } ) {
 	return (
 		<>
-			<div className="edit-site-sidebar-navigation-screen-patterns__group-header">
-				<Heading level={ 2 }>{ __( 'Theme patterns' ) }</Heading>
-			</div>
 			<ItemGroup className="edit-site-sidebar-navigation-screen-patterns__group">
 				{ categories.map( ( category ) => (
 					<CategoryItem
@@ -117,15 +114,15 @@ export default function SidebarNavigationScreenPatterns() {
 	const templatePartsLink = useLink( { path: '/wp_template_part/all' } );
 	const footer = ! isMobileViewport ? (
 		<ItemGroup>
-			<SidebarNavigationItem withChevron { ...templatePartsLink }>
-				{ __( 'Manage all template parts' ) }
-			</SidebarNavigationItem>
 			<SidebarNavigationItem
 				as="a"
 				href="edit.php?post_type=wp_block"
 				withChevron
 			>
 				{ __( 'Manage all of my patterns' ) }
+			</SidebarNavigationItem>
+			<SidebarNavigationItem withChevron { ...templatePartsLink }>
+				{ __( 'Manage all template parts' ) }
 			</SidebarNavigationItem>
 		</ItemGroup>
 	) : undefined;
@@ -172,17 +169,17 @@ export default function SidebarNavigationScreenPatterns() {
 									}
 								/>
 							</ItemGroup>
-							{ hasTemplateParts && (
-								<TemplatePartGroup
-									areas={ templatePartAreas }
-									currentArea={ currentCategory }
-									currentType={ currentType }
-								/>
-							) }
 							{ hasPatterns && (
 								<ThemePatternsGroup
 									categories={ patternCategories }
 									currentCategory={ currentCategory }
+									currentType={ currentType }
+								/>
+							) }
+							{ hasTemplateParts && (
+								<TemplatePartGroup
+									areas={ templatePartAreas }
+									currentArea={ currentCategory }
 									currentType={ currentType }
 								/>
 							) }

--- a/packages/edit-site/src/components/sidebar-navigation-screen-patterns/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-patterns/style.scss
@@ -1,18 +1,16 @@
 .edit-site-sidebar-navigation-screen-patterns__group {
-	margin-bottom: $grid-unit-40;
-	&:last-of-type,
-	&:first-of-type {
+	margin-bottom: $grid-unit-30;
+
+	&:last-of-type {
 		border-bottom: 0;
 		padding-bottom: 0;
 		margin-bottom: 0;
 	}
-
-	&:first-of-type {
-		margin-bottom: $grid-unit-40;
-	}
 }
 
 .edit-site-sidebar-navigation-screen-patterns__group-header {
+	margin-top: $grid-unit-20;
+
 	p {
 		color: $gray-600;
 	}


### PR DESCRIPTION
Alternative to https://github.com/WordPress/gutenberg/pull/52568.

## What?
1. Remove the "Theme patterns" heading.
2. Re-order pattern categories so that theme & plugin patterns appear above template parts.
3. Re-order the 'manage' links in the panel footer to match.

## Why?
Pattern categories beneath the "Theme patterns" heading can also be added by plugins, which makes the heading inaccurate. 

See https://github.com/WordPress/gutenberg/issues/52498 for more information.

## Testing Instructions
1. Open the pattern library
2. Notice that theme and plugin patterns appear above template parts
3. Notice that the 'Manage all patterns' link in the footer appears above 'Manage all template parts'.

| Before | After |
| --- | --- |
| <img width="356" alt="Screenshot 2023-07-12 at 14 47 29" src="https://github.com/WordPress/gutenberg/assets/846565/3d51e0da-0024-4dd7-a960-239e3db19186"> | <img width="363" alt="Screenshot 2023-07-12 at 14 47 39" src="https://github.com/WordPress/gutenberg/assets/846565/aed8312e-e62a-4e42-9711-26341e2e00ee"> |


