### PR TITLE
LinkControl: Add width to ensure ellipsis truncating works

### DIFF
--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -139,6 +139,7 @@ $preview-image-height: 140px;
 		// Inline block required to preserve white space
 		// between `<mark>` elements and text nodes.
 		display: inline-block;
+		width: 100%;
 
 		mark {
 			font-weight: 600;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes the ellipsis truncating that is not applied. In trunk the link title is just cut off, if its too long.

## How?
Setting a width of 100% to the item.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Add a post with a long title
1. Open a post or page.
2. Insert a Paragraph block.
3. Click the link icon.
4. Search for the post with a long title.
5. See ellipsis applied. 

## Screenshots or screencast <!-- if applicable -->

| Before  | After |
| ------------- | ------------- |
|<img width="349" alt="CleanShot 2023-07-12 at 11 49 02" src="https://github.com/WordPress/gutenberg/assets/1813435/fee86528-a267-45a7-94e1-956533dd5925">|<img width="350" alt="CleanShot 2023-07-12 at 11 49 09" src="https://github.com/WordPress/gutenberg/assets/1813435/22604256-a976-4467-9e0f-ceb5f04303ad">|



