### PR TITLE
#52569 Create post-terms block variations for custom taxonomies in editor

### DIFF
--- a/packages/block-library/src/post-terms/hooks.js
+++ b/packages/block-library/src/post-terms/hooks.js
@@ -2,26 +2,55 @@
  * WordPress dependencies
  */
 import { postCategories, postTerms } from '@wordpress/icons';
+import { select, subscribe } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
+import { __, sprintf } from '@wordpress/i18n';
+import { registerBlockVariation } from '@wordpress/blocks';
 
 const variationIconMap = {
 	category: postCategories,
 	post_tag: postTerms,
 };
 
-// We add `icons` to categories and tags. The remaining ones use
-// the block's default icon.
-export default function enhanceVariations( settings, name ) {
-	if ( name !== 'core/post-terms' ) {
-		return settings;
-	}
-	const variations = settings.variations.map( ( variation ) => ( {
-		...variation,
-		...{
-			icon: variationIconMap[ variation.name ] ?? postCategories,
-		},
-	} ) );
-	return {
-		...settings,
-		variations,
-	};
+// Creates dynamic variations for all public queryable taxonomies
+// Do this in the editor, and not when registering block on server so all registered taxonomies can be fetched
+export default function createVariations() {
+	const unsubscribe = subscribe( () => {
+		const taxonomies = select( coreStore ).getTaxonomies( {
+			// TODO: Maybe fetch only taxonomies connected to current post type (see #52569)
+			// type: postType,
+			per_page: -1,
+			context: 'edit',
+		} );
+
+		if ( ! taxonomies ) {
+			return;
+		}
+		unsubscribe();
+
+		taxonomies.forEach( ( taxonomy ) => {
+			if ( ! taxonomy.visibility?.publicly_queryable ) {
+				return;
+			}
+			const variation = {
+				name: taxonomy.slug,
+				title: taxonomy.name,
+				// We add `icons` to categories and tags. The remaining ones use
+				// the block's default icon.
+				icon: variationIconMap[ taxonomy.slug ] ?? postCategories,
+				description: sprintf(
+					/* translators: %s: taxonomy's label */
+					__( 'Display the assigned taxonomy: %s' ),
+					taxonomy.name
+				),
+				attributes: {
+					term: taxonomy.slug,
+				},
+				isActive: [ 'term' ],
+				scope: [ 'inserter', 'transform' ],
+			};
+
+			registerBlockVariation( 'core/post-terms', variation );
+		} );
+	} );
 }

--- a/packages/block-library/src/post-terms/index.js
+++ b/packages/block-library/src/post-terms/index.js
@@ -2,7 +2,6 @@
  * WordPress dependencies
  */
 import { postCategories as icon } from '@wordpress/icons';
-import { addFilter } from '@wordpress/hooks';
 
 /**
  * Internal dependencies
@@ -10,7 +9,7 @@ import { addFilter } from '@wordpress/hooks';
 import initBlock from '../utils/init-block';
 import metadata from './block.json';
 import edit from './edit';
-import enhanceVariations from './hooks';
+import createVariations from './hooks';
 
 const { name } = metadata;
 export { metadata, name };
@@ -21,11 +20,7 @@ export const settings = {
 };
 
 export const init = () => {
-	addFilter(
-		'blocks.registerBlockType',
-		'core/template-part',
-		enhanceVariations
-	);
+	createVariations();
 
 	return initBlock( { name, metadata, settings } );
 };

--- a/packages/block-library/src/post-terms/index.php
+++ b/packages/block-library/src/post-terms/index.php
@@ -62,49 +62,10 @@ function render_block_core_post_terms( $attributes, $content, $block ) {
  * Registers the `core/post-terms` block on the server.
  */
 function register_block_core_post_terms() {
-	$taxonomies = get_taxonomies(
-		array(
-			'publicly_queryable' => true,
-			'show_in_rest'       => true,
-		),
-		'objects'
-	);
-
-	// Split the available taxonomies to `built_in` and custom ones,
-	// in order to prioritize the `built_in` taxonomies at the
-	// search results.
-	$built_ins         = array();
-	$custom_variations = array();
-
-	// Create and register the eligible taxonomies variations.
-	foreach ( $taxonomies as $taxonomy ) {
-		$variation = array(
-			'name'        => $taxonomy->name,
-			'title'       => $taxonomy->label,
-			/* translators: %s: taxonomy's label */
-			'description' => sprintf( __( 'Display the assigned taxonomy: %s' ), $taxonomy->label ),
-			'attributes'  => array(
-				'term' => $taxonomy->name,
-			),
-			'isActive'    => array( 'term' ),
-			'scope'       => array( 'inserter', 'transform' ),
-		);
-		// Set the category variation as the default one.
-		if ( 'category' === $taxonomy->name ) {
-			$variation['isDefault'] = true;
-		}
-		if ( $taxonomy->_builtin ) {
-			$built_ins[] = $variation;
-		} else {
-			$custom_variations[] = $variation;
-		}
-	}
-
 	register_block_type_from_metadata(
 		__DIR__ . '/post-terms',
 		array(
 			'render_callback' => 'render_block_core_post_terms',
-			'variations'      => array_merge( $built_ins, $custom_variations ),
 		)
 	);
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This is a first try at fixing #52569. 
I try to create the variations of the post-terms block for all custom taxonomies in the editor instead of on the server side.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
See #52569 - server side function runs too early to make sure it gets all custom taxonomies by plugins, themes etc.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
I have to get the taxonomies from the rest api - and the results of them may come in async - therefore I have to use subscribe and unsubscribe. That's the only way I know right now how to get this kind of data (post types, taxonomies) on the "start" of the editor outside of react. If anyone has a better approach, I'm very happy to change this.
Therefore I'm using `registerBlockVariation` as soon as the data is available and I can't use the `blocks.registerBlockType` filter as in the previous code.

Some caveats: 
- Because of the REST API call, this only gets taxonomies which have "show_in_rest" enabled. 
- Maybe we can preload all the taxonomies data (like the navigation block does), but that can be a lot of data on large sites.
- I don't know of the performance impacts of subscribe/unsubscribe but could imagine it's kind of large because
- The `_builtin` property of taxonomies is not output via REST API. But by default the builtin taxonomies are registered first and therefore output first (and therefore added as a variation first).

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
1. Register a custom taxonomy. (See explanation below)
2. Create a new page/post.
3. See that the blocks for builtin taxonomies "Tags", "Categories" are available
4. See that a block "Courses" is available
5. Check all three blocks are displayed with the correct name and can be switch with the variation switcher.

**How to create custom taxonomy:**
I've used the [example code from developer.wordpress.org](https://developer.wordpress.org/plugins/taxonomies/working-with-custom-taxonomies/#step-2-creating-a-new-plugin) and put it in a simple plugin which I have mapped to load into gutenberg. 

in `.wp-env.json` add: 
```json
	"mappings": {
		"wp-content/plugins/test-taxonomy": "../test-taxonomy"
	},
```
In this case i've added the sample plugin in a directory named "test-taxonomy" one level above the gutenberg directory.

### TODO:
- [ ] Maybe set one variation as the default so the "post terms" "naked" variation does not show
- [ ] Maybe only fetch taxonomies that are releated to the currently edited post type (eg on custom post types, tags & categories would not be shown).

## Screenshots or screencast <!-- if applicable -->
![grafik](https://github.com/WordPress/gutenberg/assets/5585580/3f23771a-8059-4192-9108-54d8b570e13d)
