### PR TITLE
Footnotes: Add block-level caching when parsing content for footnotes

### DIFF
--- a/packages/core-data/src/entity-provider.js
+++ b/packages/core-data/src/entity-provider.js
@@ -9,19 +9,16 @@ import {
 } from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { parse, __unstableSerializeAndClean } from '@wordpress/blocks';
-import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
  */
 import { STORE_NAME } from './name';
-import { unlock } from './private-apis';
+import { updateFootnotesFromMeta } from './footnotes';
 
 /** @typedef {import('@wordpress/blocks').WPBlock} WPBlock */
 
 const EMPTY_ARRAY = [];
-
-let oldFootnotes = {};
 
 /**
  * Internal dependencies
@@ -182,136 +179,7 @@ export function useEntityBlockEditor( kind, name, { id: _id } = {} ) {
 	}, [ editedBlocks, content ] );
 
 	const updateFootnotes = useCallback(
-		( _blocks ) => {
-			const output = { blocks: _blocks };
-			if ( ! meta ) return output;
-			// If meta.footnotes is empty, it means the meta is not registered.
-			if ( meta.footnotes === undefined ) return output;
-
-			const { getRichTextValues } = unlock( blockEditorPrivateApis );
-			const _content = getRichTextValues( _blocks ).join( '' ) || '';
-			const newOrder = [];
-
-			// This can be avoided when
-			// https://github.com/WordPress/gutenberg/pull/43204 lands. We can then
-			// get the order directly from the rich text values.
-			if ( _content.indexOf( 'data-fn' ) !== -1 ) {
-				const regex = /data-fn="([^"]+)"/g;
-				let match;
-				while ( ( match = regex.exec( _content ) ) !== null ) {
-					newOrder.push( match[ 1 ] );
-				}
-			}
-
-			const footnotes = meta.footnotes
-				? JSON.parse( meta.footnotes )
-				: [];
-			const currentOrder = footnotes.map( ( fn ) => fn.id );
-
-			if ( currentOrder.join( '' ) === newOrder.join( '' ) )
-				return output;
-
-			const newFootnotes = newOrder.map(
-				( fnId ) =>
-					footnotes.find( ( fn ) => fn.id === fnId ) ||
-					oldFootnotes[ fnId ] || {
-						id: fnId,
-						content: '',
-					}
-			);
-
-			function updateAttributes( attributes ) {
-				// Only attempt to update attributes, if attributes is an object.
-				if (
-					! attributes ||
-					Array.isArray( attributes ) ||
-					typeof attributes !== 'object'
-				) {
-					return attributes;
-				}
-
-				attributes = { ...attributes };
-
-				for ( const key in attributes ) {
-					const value = attributes[ key ];
-
-					if ( Array.isArray( value ) ) {
-						attributes[ key ] = value.map( updateAttributes );
-						continue;
-					}
-
-					if ( typeof value !== 'string' ) {
-						continue;
-					}
-
-					if ( value.indexOf( 'data-fn' ) === -1 ) {
-						continue;
-					}
-
-					// When we store rich text values, this would no longer
-					// require a regex.
-					const regex =
-						/(<sup[^>]+data-fn="([^"]+)"[^>]*><a[^>]*>)[\d*]*<\/a><\/sup>/g;
-
-					attributes[ key ] = value.replace(
-						regex,
-						( match, opening, fnId ) => {
-							const index = newOrder.indexOf( fnId );
-							return `${ opening }${ index + 1 }</a></sup>`;
-						}
-					);
-
-					const compatRegex =
-						/<a[^>]+data-fn="([^"]+)"[^>]*>\*<\/a>/g;
-
-					attributes[ key ] = attributes[ key ].replace(
-						compatRegex,
-						( match, fnId ) => {
-							const index = newOrder.indexOf( fnId );
-							return `<sup data-fn="${ fnId }" class="fn"><a href="#${ fnId }" id="${ fnId }-link">${
-								index + 1
-							}</a></sup>`;
-						}
-					);
-				}
-
-				return attributes;
-			}
-
-			function updateBlocksAttributes( __blocks ) {
-				return __blocks.map( ( block ) => {
-					return {
-						...block,
-						attributes: updateAttributes( block.attributes ),
-						innerBlocks: updateBlocksAttributes(
-							block.innerBlocks
-						),
-					};
-				} );
-			}
-
-			// We need to go through all block attributes deeply and update the
-			// footnote anchor numbering (textContent) to match the new order.
-			const newBlocks = updateBlocksAttributes( _blocks );
-
-			oldFootnotes = {
-				...oldFootnotes,
-				...footnotes.reduce( ( acc, fn ) => {
-					if ( ! newOrder.includes( fn.id ) ) {
-						acc[ fn.id ] = fn;
-					}
-					return acc;
-				}, {} ),
-			};
-
-			return {
-				meta: {
-					...meta,
-					footnotes: JSON.stringify( newFootnotes ),
-				},
-				blocks: newBlocks,
-			};
-		},
+		( _blocks ) => updateFootnotesFromMeta( _blocks, meta ),
 		[ meta ]
 	);
 

--- a/packages/core-data/src/footnotes/get-footnotes-order.js
+++ b/packages/core-data/src/footnotes/get-footnotes-order.js
@@ -3,13 +3,10 @@
  */
 import getRichTextValuesCached from './get-rich-text-values-cached';
 
-export default function getFootnotesOrder( blocks ) {
-	const values = blocks.map( getRichTextValuesCached );
-	const content = values.join( '' );
-
+function getBlockFootnotesOrder( block ) {
+	const content = getRichTextValuesCached( block ).join( '' );
 	const newOrder = [];
 
-	// This can be avoided when
 	// https://github.com/WordPress/gutenberg/pull/43204 lands. We can then
 	// get the order directly from the rich text values.
 	if ( content.indexOf( 'data-fn' ) !== -1 ) {
@@ -21,4 +18,8 @@ export default function getFootnotesOrder( blocks ) {
 	}
 
 	return newOrder;
+}
+
+export default function getFootnotesOrder( blocks ) {
+	return blocks.flatMap( getBlockFootnotesOrder );
 }

--- a/packages/core-data/src/footnotes/get-footnotes-order.js
+++ b/packages/core-data/src/footnotes/get-footnotes-order.js
@@ -3,21 +3,26 @@
  */
 import getRichTextValuesCached from './get-rich-text-values-cached';
 
-function getBlockFootnotesOrder( block ) {
-	const content = getRichTextValuesCached( block ).join( '' );
-	const newOrder = [];
+const cache = new WeakMap();
 
-	// https://github.com/WordPress/gutenberg/pull/43204 lands. We can then
-	// get the order directly from the rich text values.
-	if ( content.indexOf( 'data-fn' ) !== -1 ) {
-		const regex = /data-fn="([^"]+)"/g;
-		let match;
-		while ( ( match = regex.exec( content ) ) !== null ) {
-			newOrder.push( match[ 1 ] );
+function getBlockFootnotesOrder( block ) {
+	if ( ! cache.has( block ) ) {
+		const content = getRichTextValuesCached( block ).join( '' );
+		const newOrder = [];
+
+		// https://github.com/WordPress/gutenberg/pull/43204 lands. We can then
+		// get the order directly from the rich text values.
+		if ( content.indexOf( 'data-fn' ) !== -1 ) {
+			const regex = /data-fn="([^"]+)"/g;
+			let match;
+			while ( ( match = regex.exec( content ) ) !== null ) {
+				newOrder.push( match[ 1 ] );
+			}
 		}
+		cache.set( block, newOrder );
 	}
 
-	return newOrder;
+	return cache.get( block );
 }
 
 export default function getFootnotesOrder( blocks ) {

--- a/packages/core-data/src/footnotes/get-footnotes-order.js
+++ b/packages/core-data/src/footnotes/get-footnotes-order.js
@@ -1,0 +1,24 @@
+/**
+ * Internal dependencies
+ */
+import getRichTextValuesCached from './get-rich-text-values-cached';
+
+export default function getFootnotesOrder( blocks ) {
+	const values = blocks.map( getRichTextValuesCached );
+	const content = values.join( '' );
+
+	const newOrder = [];
+
+	// This can be avoided when
+	// https://github.com/WordPress/gutenberg/pull/43204 lands. We can then
+	// get the order directly from the rich text values.
+	if ( content.indexOf( 'data-fn' ) !== -1 ) {
+		const regex = /data-fn="([^"]+)"/g;
+		let match;
+		while ( ( match = regex.exec( content ) ) !== null ) {
+			newOrder.push( match[ 1 ] );
+		}
+	}
+
+	return newOrder;
+}

--- a/packages/core-data/src/footnotes/get-rich-text-values-cached.js
+++ b/packages/core-data/src/footnotes/get-rich-text-values-cached.js
@@ -8,13 +8,19 @@ import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
  */
 import { unlock } from '../private-apis';
 
-const { getRichTextValues } = unlock( blockEditorPrivateApis );
+// Avoid calling `unlock` at the module level, deferring the call until needed
+// in `getRichTextValuesCached`.
+let unlockedApis;
 
 const cache = new WeakMap();
 
 export default function getRichTextValuesCached( block ) {
+	if ( ! unlockedApis ) {
+		unlockedApis = unlock( blockEditorPrivateApis );
+	}
+
 	if ( ! cache.has( block ) ) {
-		const values = getRichTextValues( [ block ] );
+		const values = unlockedApis.getRichTextValues( [ block ] );
 		cache.set( block, values );
 	}
 	return cache.get( block );

--- a/packages/core-data/src/footnotes/get-rich-text-values-cached.js
+++ b/packages/core-data/src/footnotes/get-rich-text-values-cached.js
@@ -1,0 +1,21 @@
+/**
+ * WordPress dependencies
+ */
+import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
+
+/**
+ * Internal dependencies
+ */
+import { unlock } from '../private-apis';
+
+const { getRichTextValues } = unlock( blockEditorPrivateApis );
+
+const cache = new WeakMap();
+
+export default function getRichTextValuesCached( block ) {
+	if ( ! cache.has( block ) ) {
+		const values = getRichTextValues( [ block ] );
+		cache.set( block, values );
+	}
+	return cache.get( block );
+}

--- a/packages/core-data/src/footnotes/get-rich-text-values-cached.js
+++ b/packages/core-data/src/footnotes/get-rich-text-values-cached.js
@@ -8,8 +8,16 @@ import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
  */
 import { unlock } from '../private-apis';
 
-// Avoid calling `unlock` at the module level, deferring the call until needed
-// in `getRichTextValuesCached`.
+// TODO: The following line should have been:
+//
+//   const unlockedApis = unlock( blockEditorPrivateApis );
+//
+// But there are hidden circular dependencies in RNMobile code, specifically in
+// certain native components in the `components` package that depend on
+// `block-editor`. What follows is a workaround that defers the `unlock` call
+// to prevent native code from failing.
+//
+// Fix once https://github.com/WordPress/gutenberg/issues/52692 is closed.
 let unlockedApis;
 
 const cache = new WeakMap();

--- a/packages/core-data/src/footnotes/index.js
+++ b/packages/core-data/src/footnotes/index.js
@@ -12,13 +12,25 @@ const { getRichTextValues } = unlock( blockEditorPrivateApis );
 
 let oldFootnotes = {};
 
+const cache = new WeakMap();
+
+function getRichTextValuesCached( block ) {
+	if ( ! cache.has( block ) ) {
+		const values = getRichTextValues( [ block ] );
+		cache.set( block, values );
+	}
+	return cache.get( block );
+}
+
 export function updateFootnotesFromMeta( blocks, meta ) {
 	const output = { blocks };
 	if ( ! meta ) return output;
+
 	// If meta.footnotes is empty, it means the meta is not registered.
 	if ( meta.footnotes === undefined ) return output;
 
-	const _content = getRichTextValues( blocks ).join( '' ) || '';
+	const _content = blocks.map( getRichTextValuesCached ).join( '' );
+
 	const newOrder = [];
 
 	// This can be avoided when

--- a/packages/core-data/src/footnotes/index.js
+++ b/packages/core-data/src/footnotes/index.js
@@ -1,26 +1,9 @@
 /**
- * WordPress dependencies
- */
-import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
-
-/**
  * Internal dependencies
  */
-import { unlock } from '../private-apis';
-
-const { getRichTextValues } = unlock( blockEditorPrivateApis );
+import getRichTextValuesCached from './get-rich-text-values-cached';
 
 let oldFootnotes = {};
-
-const cache = new WeakMap();
-
-function getRichTextValuesCached( block ) {
-	if ( ! cache.has( block ) ) {
-		const values = getRichTextValues( [ block ] );
-		cache.set( block, values );
-	}
-	return cache.get( block );
-}
 
 export function updateFootnotesFromMeta( blocks, meta ) {
 	const output = { blocks };

--- a/packages/core-data/src/footnotes/index.js
+++ b/packages/core-data/src/footnotes/index.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import getRichTextValuesCached from './get-rich-text-values-cached';
+import getFootnotesOrder from './get-footnotes-order';
 
 let oldFootnotes = {};
 
@@ -12,20 +12,7 @@ export function updateFootnotesFromMeta( blocks, meta ) {
 	// If meta.footnotes is empty, it means the meta is not registered.
 	if ( meta.footnotes === undefined ) return output;
 
-	const _content = blocks.map( getRichTextValuesCached ).join( '' );
-
-	const newOrder = [];
-
-	// This can be avoided when
-	// https://github.com/WordPress/gutenberg/pull/43204 lands. We can then
-	// get the order directly from the rich text values.
-	if ( _content.indexOf( 'data-fn' ) !== -1 ) {
-		const regex = /data-fn="([^"]+)"/g;
-		let match;
-		while ( ( match = regex.exec( _content ) ) !== null ) {
-			newOrder.push( match[ 1 ] );
-		}
-	}
+	const newOrder = getFootnotesOrder( blocks );
 
 	const footnotes = meta.footnotes ? JSON.parse( meta.footnotes ) : [];
 	const currentOrder = footnotes.map( ( fn ) => fn.id );

--- a/packages/core-data/src/footnotes/index.js
+++ b/packages/core-data/src/footnotes/index.js
@@ -1,0 +1,137 @@
+/**
+ * WordPress dependencies
+ */
+import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
+
+/**
+ * Internal dependencies
+ */
+import { unlock } from '../private-apis';
+
+const { getRichTextValues } = unlock( blockEditorPrivateApis );
+
+let oldFootnotes = {};
+
+export function updateFootnotesFromMeta( blocks, meta ) {
+	const output = { blocks };
+	if ( ! meta ) return output;
+	// If meta.footnotes is empty, it means the meta is not registered.
+	if ( meta.footnotes === undefined ) return output;
+
+	const _content = getRichTextValues( blocks ).join( '' ) || '';
+	const newOrder = [];
+
+	// This can be avoided when
+	// https://github.com/WordPress/gutenberg/pull/43204 lands. We can then
+	// get the order directly from the rich text values.
+	if ( _content.indexOf( 'data-fn' ) !== -1 ) {
+		const regex = /data-fn="([^"]+)"/g;
+		let match;
+		while ( ( match = regex.exec( _content ) ) !== null ) {
+			newOrder.push( match[ 1 ] );
+		}
+	}
+
+	const footnotes = meta.footnotes ? JSON.parse( meta.footnotes ) : [];
+	const currentOrder = footnotes.map( ( fn ) => fn.id );
+
+	if ( currentOrder.join( '' ) === newOrder.join( '' ) ) return output;
+
+	const newFootnotes = newOrder.map(
+		( fnId ) =>
+			footnotes.find( ( fn ) => fn.id === fnId ) ||
+			oldFootnotes[ fnId ] || {
+				id: fnId,
+				content: '',
+			}
+	);
+
+	function updateAttributes( attributes ) {
+		// Only attempt to update attributes, if attributes is an object.
+		if (
+			! attributes ||
+			Array.isArray( attributes ) ||
+			typeof attributes !== 'object'
+		) {
+			return attributes;
+		}
+
+		attributes = { ...attributes };
+
+		for ( const key in attributes ) {
+			const value = attributes[ key ];
+
+			if ( Array.isArray( value ) ) {
+				attributes[ key ] = value.map( updateAttributes );
+				continue;
+			}
+
+			if ( typeof value !== 'string' ) {
+				continue;
+			}
+
+			if ( value.indexOf( 'data-fn' ) === -1 ) {
+				continue;
+			}
+
+			// When we store rich text values, this would no longer
+			// require a regex.
+			const regex =
+				/(<sup[^>]+data-fn="([^"]+)"[^>]*><a[^>]*>)[\d*]*<\/a><\/sup>/g;
+
+			attributes[ key ] = value.replace(
+				regex,
+				( match, opening, fnId ) => {
+					const index = newOrder.indexOf( fnId );
+					return `${ opening }${ index + 1 }</a></sup>`;
+				}
+			);
+
+			const compatRegex = /<a[^>]+data-fn="([^"]+)"[^>]*>\*<\/a>/g;
+
+			attributes[ key ] = attributes[ key ].replace(
+				compatRegex,
+				( match, fnId ) => {
+					const index = newOrder.indexOf( fnId );
+					return `<sup data-fn="${ fnId }" class="fn"><a href="#${ fnId }" id="${ fnId }-link">${
+						index + 1
+					}</a></sup>`;
+				}
+			);
+		}
+
+		return attributes;
+	}
+
+	function updateBlocksAttributes( __blocks ) {
+		return __blocks.map( ( block ) => {
+			return {
+				...block,
+				attributes: updateAttributes( block.attributes ),
+				innerBlocks: updateBlocksAttributes( block.innerBlocks ),
+			};
+		} );
+	}
+
+	// We need to go through all block attributes deeply and update the
+	// footnote anchor numbering (textContent) to match the new order.
+	const newBlocks = updateBlocksAttributes( blocks );
+
+	oldFootnotes = {
+		...oldFootnotes,
+		...footnotes.reduce( ( acc, fn ) => {
+			if ( ! newOrder.includes( fn.id ) ) {
+				acc[ fn.id ] = fn;
+			}
+			return acc;
+		}, {} ),
+	};
+
+	return {
+		meta: {
+			...meta,
+			footnotes: JSON.stringify( newFootnotes ),
+		},
+		blocks: newBlocks,
+	};
+}


### PR DESCRIPTION
**Experimental:** This works, but the experiment needs to be validated with performance benchmarks.

This pull request explores the idea that I originally explained at https://github.com/WordPress/gutenberg/pull/52241#pullrequestreview-1521621603.

## What?

The current situation with footnotes is that, [if a post has any footnotes in meta](https://github.com/WordPress/gutenberg/blob/7e505dc5cd2037eb9fc6730bbd1e0e3846eabef8/packages/core-data/src/entity-provider.js#L195-L197), then a subroutine called `updateFootnotes` will [parse](https://github.com/WordPress/gutenberg/blob/7e505dc5cd2037eb9fc6730bbd1e0e3846eabef8/packages/core-data/src/entity-provider.js#L199-L212) the current document for any footnotes **on every change**.

(The reason for this is that footnotes need to be kept in order in the [Footnotes block](https://github.com/WordPress/gutenberg/blob/7e505dc5cd2037eb9fc6730bbd1e0e3846eabef8/packages/block-library/src/footnotes/edit.js) (as well as in the indices in the document itself), and any change to the document can affect that order: moving blocks around, deleting RichText containing a footnote anchor, inserting a footnote via the Formats menu.)

In practice, though, most changes to a document only affect one block at a time (e.g. typing, setting attributes) or a small number thereof (e.g. moving a selection of blocks). So a straightforward performance improvement to the footnote parsing process is to cache the parsing at the block level. That way, whenever a user is typing inside a block, the entire parsing looks like this:

```
in updateFootnotes( blocks ):
    in getFootnotesOrder( blocks ):
        for block in blocks:
            if block not in order cache: compute order and add to cache
            get cached value
        join values into one array
```

Note that caching was added in two components: `getFootnotesOrder` (higher level) and `getRichTextValuesCached` (lower level). I am not sure this is necessary.

whereas before the process looked like:

```
in updateFootnotes( blocks ):
    for block in blocks:
        values <- getRichTextValues( block )
    content <- concatenate all block values
    compute order over concatenated content
```

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
To help with the review, I took care to separate _refactoring commits_ from _functional commits_ in the commit history. The most important commits are probably:
* c81de297b028c5a9c54d5f698114d3819b0cf4a7
* 1b49eb65e522178fe623a46a294beedc1c30a3b1
* e2e589147e5f3b25199186927cf31e2ee0fe3727

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
