### PR TITLE
Filter to switch from the Interactivity API to the old implementation

### DIFF
--- a/packages/block-library/src/file/index.php
+++ b/packages/block-library/src/file/index.php
@@ -5,7 +5,7 @@
  * @package WordPress
  */
 
-if ( defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN ) {
+if ( apply_filters( 'gutenberg_block_core_file_use_interactivity_api', true ) ) {
 	/**
 	 * Replaces view script for the File block with version using Interactivity API.
 	 *
@@ -71,7 +71,7 @@ function render_block_core_file( $attributes, $content, $block ) {
 	);
 
 	// If it uses the Interactivity API, add the directives.
-	if ( defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN && $should_load_view_script ) {
+	if ( apply_filters( 'gutenberg_block_core_file_use_interactivity_api', true ) && $should_load_view_script ) {
 		$processor = new WP_HTML_Tag_Processor( $content );
 		$processor->next_tag();
 		$processor->set_attribute( 'data-wp-interactive', '' );

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -7,7 +7,7 @@
 
 // These functions are used for the __unstableLocation feature and only active
 // when the gutenberg plugin is active.
-if ( defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN ) {
+if ( apply_filters( 'gutenberg_block_core_navigation_use_interactivity_api', true ) ) {
 	/**
 	 * Returns the menu items for a WordPress menu location.
 	 *
@@ -471,7 +471,7 @@ function render_block_core_navigation( $attributes, $content, $block ) {
 	// - we don't have a relationship to a `wp_navigation` Post (via `ref`).
 	// ...then create inner blocks from the classic menu assigned to that location.
 	if (
-		defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN &&
+		apply_filters( 'gutenberg_block_core_navigation_use_interactivity_api', true ) &&
 		array_key_exists( '__unstableLocation', $attributes ) &&
 		! array_key_exists( 'ref', $attributes ) &&
 		! empty( block_core_navigation_get_menu_items_at_location( $attributes['__unstableLocation'] ) )
@@ -685,7 +685,7 @@ function render_block_core_navigation( $attributes, $content, $block ) {
 	}
 
 	// Add directives to the submenu if needed.
-	if ( defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN && $has_submenus && $should_load_view_script ) {
+	if ( apply_filters( 'gutenberg_block_core_navigation_use_interactivity_api', true ) && $has_submenus && $should_load_view_script ) {
 		$w                 = new WP_HTML_Tag_Processor( $inner_blocks_html );
 		$inner_blocks_html = block_core_navigation_add_directives_to_submenu( $w, $attributes );
 	}
@@ -733,7 +733,7 @@ function render_block_core_navigation( $attributes, $content, $block ) {
 	$responsive_container_directives = '';
 	$responsive_dialog_directives    = '';
 	$close_button_directives         = '';
-	if ( defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN && $should_load_view_script ) {
+	if ( apply_filters( 'gutenberg_block_core_navigation_use_interactivity_api', true ) && $should_load_view_script ) {
 		$nav_element_directives          = '
 			data-wp-interactive
 			data-wp-context=\'{ "core": { "navigation": { "overlayOpenedBy": {}, "type": "overlay", "roleAttribute": "" } } }\'


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

<!-- In a few words, what is the PR actually doing? -->

Add filters to switch from the Interactivity API to the old implementation of the Navigation and File blocks.

Follow up on https://github.com/WordPress/gutenberg/pull/52553.

## Why?

<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

To be able to keep improving those versions, which are still in WP Core ([more context](https://github.com/WordPress/gutenberg/pull/50906#issuecomment-1631555402)).

## How?

<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Just replace the `IS_GUTENBERG_PLUGIN` constant which was used to avoid merging the Interactivity API in Core with two filters, one for each block:

- `gutenberg_block_core_navigation_use_interactivity_api`
- `gutenberg_block_core_file_use_interactivity_api`

## Testing Instructions

<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

- Add a Navigation block
- Check that it works with the Interactivity API (check the network tab or accessibility improvements like `aria-expanded` switching to `true` on hover).
- Add this filter somewhere in your code:
  ```php
  add_filter( 'gutenberg_block_core_navigation_use_interactivity_api', '__return_false' );
  ```
- Check that the Navigation block now works with `micromodal` (check the network tab or accessibility issues like `aria-expanded` not switching to `true` on hover).
