### PR TITLE
Copy tweak for the reusable block rename hint

### DIFF
--- a/packages/block-editor/src/components/inserter/reusable-block-rename-hint.js
+++ b/packages/block-editor/src/components/inserter/reusable-block-rename-hint.js
@@ -29,7 +29,7 @@ export default function ReusableBlocksRenameHint() {
 		<div ref={ ref } className="reusable-blocks-menu-items__rename-hint">
 			<div className="reusable-blocks-menu-items__rename-hint-content">
 				{ __(
-					'Reusable blocks are now called patterns. A synced pattern will behave in exactly the same way as a reusable block.'
+					'Reusable blocks are now synced patterns. A synced pattern will behave in exactly the same way as a reusable block.'
 				) }
 			</div>
 			<Button


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Reusable blocks are _synced_ patterns, not just patterns. This clarification is important. 

## How?
Copy tweak.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a post or page.
2. Open the block inserter.
3. Select the synced pattern tab (requires a synced pattern). 
4. See the copy change.

## Screenshots or screencast <!-- if applicable -->

| Before  | After |
| ------------- | ------------- |
|<img width="350" alt="CleanShot 2023-07-12 at 14 00 19" src="https://github.com/WordPress/gutenberg/assets/1813435/85baeacd-1c6b-4d01-869d-34448b6b33f8">|<img width="349" alt="CleanShot 2023-07-12 at 14 00 02" src="https://github.com/WordPress/gutenberg/assets/1813435/295967de-8516-418c-84d1-07d3b66abe82">|

