### PR TITLE
Avoid errors in Dimension visualizers when switching between iframed and non-iframed editors

### DIFF
--- a/packages/block-editor/src/hooks/margin.js
+++ b/packages/block-editor/src/hooks/margin.js
@@ -23,7 +23,10 @@ export function MarginVisualizer( { clientId, attributes, forceShow } ) {
 	const margin = attributes?.style?.spacing?.margin;
 
 	useEffect( () => {
-		if ( ! blockElement ) {
+		if (
+			! blockElement ||
+			null === blockElement.ownerDocument.defaultView
+		) {
 			return;
 		}
 

--- a/packages/block-editor/src/hooks/padding.js
+++ b/packages/block-editor/src/hooks/padding.js
@@ -23,7 +23,10 @@ export function PaddingVisualizer( { clientId, attributes, forceShow } ) {
 	const padding = attributes?.style?.spacing?.padding;
 
 	useEffect( () => {
-		if ( ! blockElement ) {
+		if (
+			! blockElement ||
+			null === blockElement.ownerDocument.defaultView
+		) {
 			return;
 		}
 


### PR DESCRIPTION
## What?
Fixes #52587.

PR updates effects in `MarginVisualizer` and `PaddingVisualizer ` components to avoid the `Cannot read properties of null (reading 'getComputedStyle')` error when switching between iframed and non-iframed editors.

## Why?

When `MaybeIframe` switches between iframed and non-iframed editors, it removes the browser context associated with the iframe.

According to HTML specs - https://html.spec.whatwg.org/multipage/document-sequences.html#concept-document-bc
> **Note**
>
> A Document does not necessarily have a non-null browsing context. In particular, data mining tools are likely to never instantiate browsing contexts. A Document created using an API such as createDocument() never has a non-null browsing context. **And the Document originally created for an iframe element, which has since been removed from the document, has no associated browsing context, since that browsing context was nulled out.**

A sandbox with minimum code to reproduce the issue: https://codesandbox.io/s/browsing-context-was-nulled-out-8gn4xq?file=/src/App.js

## How?
Update return early condition in effects and check if browser context isn't `null`. Originally, I planned to use optional chaining in `getComputedStyle`, but I think it makes more sense to skip style updates.

## Testing Instructions
1. Open a Post or Page.
2. Enable "Custom fields" from Preferences.
3. Add a paragraph and text.
4. Select text.
5. Switch to device preview 'Tablet' and back to 'Desktop'.
6. Confirm error isn't triggered.

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/42362903/45ca130b-5dda-4168-b2fd-6565c3d28c4e
