### PR TITLE
Fix console warning by improving error handling in Nav block classic menu conversion

### DIFF
--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -197,7 +197,7 @@ function Navigation( {
 		convert: convertClassicMenu,
 		status: classicMenuConversionStatus,
 		error: classicMenuConversionError,
-	} = useConvertClassicToBlockMenu( createNavigationMenu );
+	} = useConvertClassicToBlockMenu( clientId, createNavigationMenu );
 
 	const isConvertingClassicMenu =
 		classicMenuConversionStatus === CLASSIC_MENU_CONVERSION_PENDING;

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -197,7 +197,7 @@ function Navigation( {
 		convert: convertClassicMenu,
 		status: classicMenuConversionStatus,
 		error: classicMenuConversionError,
-	} = useConvertClassicToBlockMenu( clientId, createNavigationMenu );
+	} = useConvertClassicToBlockMenu( createNavigationMenu );
 
 	const isConvertingClassicMenu =
 		classicMenuConversionStatus === CLASSIC_MENU_CONVERSION_PENDING;

--- a/packages/block-library/src/navigation/edit/use-convert-classic-menu-to-block-menu.js
+++ b/packages/block-library/src/navigation/edit/use-convert-classic-menu-to-block-menu.js
@@ -20,7 +20,7 @@ export const CLASSIC_MENU_CONVERSION_IDLE = 'idle';
 // do not import the same classic menu twice.
 let classicMenuBeingConvertedId = null;
 
-function useConvertClassicToBlockMenu( createNavigationMenu ) {
+function useConvertClassicToBlockMenu( clientId, createNavigationMenu ) {
 	const registry = useRegistry();
 	const { editEntityRecord } = useDispatch( coreStore );
 

--- a/packages/block-library/src/navigation/edit/use-convert-classic-menu-to-block-menu.js
+++ b/packages/block-library/src/navigation/edit/use-convert-classic-menu-to-block-menu.js
@@ -20,7 +20,7 @@ export const CLASSIC_MENU_CONVERSION_IDLE = 'idle';
 // do not import the same classic menu twice.
 let classicMenuBeingConvertedId = null;
 
-function useConvertClassicToBlockMenu( clientId, createNavigationMenu ) {
+function useConvertClassicToBlockMenu( createNavigationMenu ) {
 	const registry = useRegistry();
 	const { editEntityRecord } = useDispatch( coreStore );
 

--- a/packages/block-library/src/navigation/edit/use-convert-classic-menu-to-block-menu.js
+++ b/packages/block-library/src/navigation/edit/use-convert-classic-menu-to-block-menu.js
@@ -20,7 +20,10 @@ export const CLASSIC_MENU_CONVERSION_IDLE = 'idle';
 // do not import the same classic menu twice.
 let classicMenuBeingConvertedId = null;
 
-function useConvertClassicToBlockMenu( createNavigationMenu ) {
+function useConvertClassicToBlockMenu(
+	createNavigationMenu,
+	{ throwOnError = false } = {}
+) {
 	const registry = useRegistry();
 	const { editEntityRecord } = useDispatch( coreStore );
 
@@ -149,19 +152,21 @@ function useConvertClassicToBlockMenu( createNavigationMenu ) {
 					classicMenuBeingConvertedId = null;
 
 					// Rethrow error for debugging.
-					throw new Error(
-						sprintf(
-							// translators: %s: the name of a menu (e.g. Header navigation).
-							__( `Unable to create Navigation Menu "%s".` ),
-							menuName
-						),
-						{
-							cause: err,
-						}
-					);
+					if ( throwOnError ) {
+						throw new Error(
+							sprintf(
+								// translators: %s: the name of a menu (e.g. Header navigation).
+								__( `Unable to create Navigation Menu "%s".` ),
+								menuName
+							),
+							{
+								cause: err,
+							}
+						);
+					}
 				} );
 		},
-		[ convertClassicMenuToBlockMenu ]
+		[ convertClassicMenuToBlockMenu, throwOnError ]
 	);
 
 	return {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes console warning if classic menu import fails.

Discovered in https://github.com/WordPress/gutenberg/pull/52573

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

By default the callback returned by the `useConvertClassicToBlockMenu` will throw an error if the import failed. This logs in console in the form

> use-convert-classic-menu-to-block-menu.js:164 Uncaught (in promise) Error: Unable to create Navigation Menu "Classic Menu Two".

_If_ we want to handle errors manually at call time then this is useful. However, the point of the hook is that it exposes the errors via status information and so in this case we wouldn't expect to _need_ to handle the failure on the promise.

The code currently doesn't handle the promise and so we see a warning. We should fix that.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Follows pattern established in Core Data whereby an options object allows consumers to switch returning of errors on/off.

Defaults to `false` meaning that the hook can be called without having to worry about the errors. But if you _need_ the errors if can be switched on via the flag and then you can `try/catch` as required.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

This is tricky...

I added the following error [here](https://github.com/WordPress/gutenberg/blob/7d84f622a644cbcfb9111a288fa7efd0b83bad57/packages/block-library/src/navigation/edit/use-convert-classic-menu-to-block-menu.js#L43):

```js
throw new Error(
	'I broke things'
);
```

Then I tested the code we have now to validate that there are no `console` warnings when the import fails.

Then I updated this line to pass the `throwOnError` option as `true`:

https://github.com/WordPress/gutenberg/blob/7d84f622a644cbcfb9111a288fa7efd0b83bad57/packages/block-library/src/navigation/edit/index.js#L200

Then I re-tested and checked I could see the console warning about the uncaught promise.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
