### PR TITLE
Site Editor: Fix navigation menu sidebar actions order and label

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/more-menu.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/more-menu.js
@@ -33,6 +33,7 @@ export default function ScreenNavigationMoreMenu( props ) {
 		<>
 			<DropdownMenu
 				className="sidebar-navigation__more-menu"
+				label={ __( 'Actions' ) }
 				icon={ moreVertical }
 				popoverProps={ POPOVER_PROPS }
 			>

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/single-navigation-menu.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/single-navigation-menu.js
@@ -24,13 +24,13 @@ export default function SingleNavigationMenu( {
 		<SidebarNavigationScreenWrapper
 			actions={
 				<>
-					<EditButton postId={ navigationMenu?.id } />
 					<ScreenNavigationMoreMenu
 						menuTitle={ decodeEntities( menuTitle ) }
 						onDelete={ handleDelete }
 						onSave={ handleSave }
 						onDuplicate={ handleDuplicate }
 					/>
+					<EditButton postId={ navigationMenu?.id } />
 				</>
 			}
 			title={ buildNavigationLabel(


### PR DESCRIPTION
## What?
Fixes #52590.

PR updates action elements order for the navigation menu sidebar page and adds the missing label to the "Actions" dropdown.

## Why?
See #52590

## Testing Instructions
1. Open the Site Editor.
2. Go to the navigation menu from the sidebar.
3. Confirm the actions dropdown button has a label.
4. The action component's order matches other screens.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2023-07-13 at 13 46 18](https://github.com/WordPress/gutenberg/assets/240569/d0c3205a-3505-47ff-abce-e0c7920d3d48)

