### PR TITLE
[RNMobile] Fix crash related to removing a block under certain conditions

### DIFF
--- a/packages/block-editor/src/components/block-toolbar/block-toolbar-menu.native.js
+++ b/packages/block-editor/src/components/block-toolbar/block-toolbar-menu.native.js
@@ -100,9 +100,11 @@ const BlockActionsMenu = ( {
 	} = getMoversSetup( isStackedHorizontally, moversOptions );
 
 	// Check if selected block is Groupable and/or Ungroupable.
-	const convertToGroupButtonProps = useConvertToGroupButtonProps( [
-		selectedBlockClientId,
-	] );
+	const convertToGroupButtonProps = useConvertToGroupButtonProps(
+		// `selectedBlockClientId` can be undefined in some cases where this
+		// component gets re-rendered right after the block is removed.
+		selectedBlockClientId ? [ selectedBlockClientId ] : []
+	);
 	const { isGroupable, isUngroupable } = convertToGroupButtonProps;
 	const showConvertToGroupButton =
 		( isGroupable || isUngroupable ) && canRemove;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes a crash produced when removing a block under certain conditions. The crash was originally identified when removing a File block in a post/page with only that block. However, it has also been able to reproduce when detaching a synced pattern in a post with other blocks.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Fixes the crash https://github.com/wordpress-mobile/gutenberg-mobile/issues/5925.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

When determining if the block is groupable/ungroupable, we now avoid passing an `undefined` value which leads to a crash. We now check if `selectedBlockClientId` is defined, and based on that it passes an empty array when calling `useConvertToGroupButtonProps`.

I was curious about why this only happens in specific blocks and noticed the following:
* When removing a block, `BlockActionsMenu` component can be re-rendered after the block is removed but before the default Paragraph block is inserted.

**Removing File block:**
<img width="911" alt="Screenshot 2023-07-13 at 13 15 49" src="https://github.com/WordPress/gutenberg/assets/14905380/f44481f1-ab36-4046-b8c2-8283b8156782">

* This only seems to happen on specific blocks because in most of them, `BlockActionsMenu` component is only re-rendered after the default block is inserted.

**Removing Image block:**
<img width="763" alt="Screenshot 2023-07-13 at 13 18 35" src="https://github.com/WordPress/gutenberg/assets/14905380/c417086b-1fcd-439f-9d40-89e94970028c">

For some reason, on specific blocks, the Redux state updates after removing the block are causing a re-render in `BlockActionsMenu` component. I checked the parameters of both Redux actions `REMOVE_BLOCKS` and `EDIT_ENTITY_RECORD` (this one is triggered by the block removal), but there's no specific value that differs from removing other blocks 🤔.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Create a post/page in the app.
2. Add a File block.
3. Add a file (it can be from the WP library or device).
4. Tap the ... button.
5. Tap on "Remove block".
6. Observe the editor doesn't crash.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

N/A

## Screenshots or screencast <!-- if applicable -->

| Without the fix | With the fix |
|--------|--------|
| <video src=https://github.com/WordPress/gutenberg/assets/14905380/6c3526c4-91be-453b-a830-2b6dfe121cc9> | <video src=https://github.com/WordPress/gutenberg/assets/14905380/1f6baba0-a59e-4c01-be71-d0a36295da5c> | 