### PR TITLE
Make Pattern title text clickable for 6.3 release

### DIFF
--- a/packages/edit-site/src/components/page-patterns/grid-item.js
+++ b/packages/edit-site/src/components/page-patterns/grid-item.js
@@ -16,6 +16,7 @@ import {
 	__unstableCompositeItem as CompositeItem,
 	Tooltip,
 	Flex,
+	Button,
 } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
 import { useState, useId } from '@wordpress/element';
@@ -160,7 +161,19 @@ export default function GridItem( { categoryId, composite, icon, item } ) {
 							/>
 						) }
 						<Flex as="span" gap={ 0 } justify="left">
-							{ item.title }
+							{ item.type === PATTERNS ? (
+								item.title
+							) : (
+								<Button
+									variant="link"
+									onClick={ onClick }
+									// Required for the grid's roving tab index system.
+									// See https://github.com/WordPress/gutenberg/pull/51898#discussion_r1243399243.
+									tabIndex="-1"
+								>
+									{ item.title }
+								</Button>
+							) }
 							{ item.type === PATTERNS && (
 								<Tooltip
 									position="top center"

--- a/packages/edit-site/src/components/page-patterns/style.scss
+++ b/packages/edit-site/src/components/page-patterns/style.scss
@@ -93,6 +93,16 @@
 .edit-site-patterns__pattern-title {
 	color: $gray-200;
 
+	.is-link {
+		text-decoration: none;
+		color: $gray-200;
+
+		&:hover,
+		&:focus {
+			color: $white;
+		}
+	}
+
 	.edit-site-patterns__pattern-icon {
 		border-radius: $grid-unit-05;
 		background: var(--wp-block-synced-color);


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Re-implements https://github.com/WordPress/gutenberg/pull/51898 as per https://github.com/WordPress/gutenberg/pull/51898#issuecomment-1632556673

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

- Check the title below each Pattern can be clicked to enter focus mode for that Pattern
- Make sure title's of Theme patterns cannot be clicked
- Make sure only title's of custom patterns can be clicked.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/444434/b0f6f732-f589-4079-b6eb-00a5a82f9296

