### PR TITLE
Do not autofocus page title field in the 'Draft a new page' modal dialog

### DIFF
--- a/packages/edit-site/src/components/add-new-page/index.js
+++ b/packages/edit-site/src/components/add-new-page/index.js
@@ -72,9 +72,6 @@ export default function AddNewPageModal( { onSave, onClose } ) {
 			<form onSubmit={ createPage }>
 				<VStack spacing={ 3 }>
 					<TextControl
-						/* eslint-disable jsx-a11y/no-autofocus */
-						autoFocus
-						/* eslint-enable jsx-a11y/no-autofocus */
 						label={ __( 'Page title' ) }
 						onChange={ setTitle }
 						placeholder={ __( 'No title' ) }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Fixes https://github.com/WordPress/gutenberg/issues/52601

## What?
<!-- In a few words, what is the PR actually doing? -->
Fixes initial focus inconsistent behavior in the 'Draft a new page' modal dialog.

Please do not ever use the `autofocus` attribute.
Do not ever disable the `jsx-a11y/no-autofocus` rule, unless there are very very good reason to do so.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
- Autofocusing elements can cause usability issues for sighted and non-sighted users, as it dumps users within a form, potentially with no context.
- There are good reasons why the `jsx-a11y/no-autofocus` is in place and it should not be disabled.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Removes the autofocus attribute.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
- Go to the Site editor > Design > Pages > Draft a new page (the + icon button).
- The 'Draft a new page' modal dialog opens.
- Observe initial focus is now on the dialog container itself:
  - Press the Tab key
  - Observe focus goes to the X close button.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
See above.

## Screenshots or screencast <!-- if applicable -->
