### PR TITLE
Allow setting defaultBlock in navigation block

### DIFF
--- a/packages/block-library/src/navigation/block.json
+++ b/packages/block-library/src/navigation/block.json
@@ -71,6 +71,13 @@
 		"templateLock": {
 			"type": [ "string", "boolean" ],
 			"enum": [ "all", "insert", "contentOnly", false ]
+		},
+		"defaultBlock": {
+			"type": "object",
+			"default": {
+				"name": "core/navigation-link",
+				"attributes": {}
+			}
 		}
 	},
 	"providesContext": {

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -97,6 +97,7 @@ function Navigation( {
 		overlayMenu,
 		showSubmenuIcon,
 		templateLock,
+		defaultBlock,
 		layout: {
 			justifyContent,
 			orientation = 'horizontal',
@@ -858,6 +859,7 @@ function Navigation( {
 									}
 									templateLock={ templateLock }
 									orientation={ orientation }
+									defaultBlock={ defaultBlock }
 								/>
 							) }
 						</ResponsiveWrapper>

--- a/packages/block-library/src/navigation/edit/inner-blocks.js
+++ b/packages/block-library/src/navigation/edit/inner-blocks.js
@@ -25,6 +25,7 @@ export default function NavigationInnerBlocks( {
 	hasCustomPlaceholder,
 	orientation,
 	templateLock,
+	defaultBlock,
 } ) {
 	const {
 		isImmediateParentOfSelectedBlock,
@@ -88,6 +89,11 @@ export default function NavigationInnerBlocks( {
 	const showPlaceholder =
 		! hasCustomPlaceholder && ! hasMenuItems && ! isSelected;
 
+	// If the `defaultBlock` attribute is set and itself has an attributes object with values then use it
+	// otherwise fallback to the DEFAULT_BLOCK constant.
+	// This allows site owners to set the default `core/navigation-link` variation to use.
+	const navDefaultBlock = defaultBlock?.attributes && Object.keys(defaultBlock.attributes).length > 0 ? defaultBlock : DEFAULT_BLOCK;	
+
 	const innerBlocksProps = useInnerBlocksProps(
 		{
 			className: 'wp-block-navigation__container',
@@ -98,7 +104,7 @@ export default function NavigationInnerBlocks( {
 			onChange,
 			allowedBlocks: ALLOWED_BLOCKS,
 			prioritizedInserterBlocks: PRIORITIZED_INSERTER_BLOCKS,
-			defaultBlock: DEFAULT_BLOCK,
+			defaultBlock: navDefaultBlock,
 			directInsert: shouldDirectInsert,
 			orientation,
 			templateLock,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Create a defaultBlock attribute and sets innerblocks to reference that if attributes are present in it.

## Why?
Solves for #50982

## How?
This adds a new defaultBlock attribute and a check for it along with a quick sanity check if it fails it falls back to the DEFAULT_BLOCK constant.

## Testing Instructions

- Open a post or page
- Copy and paste this block markup into the editor:
```
<!-- wp:navigation {"defaultBlock":{"name":"core/navigation-link","attributes":{"type":"category","kind":"taxonomy"}}} /-->
```
- Click + inside the navigation block.
- Now category links should be the default when clicking + inside this navigation block.

