### PR TITLE
Fix Shift+Tab to Block Toolbar

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -101,24 +101,24 @@
 			"dev": true
 		},
 		"@ariakit/core": {
-			"version": "0.2.6",
-			"resolved": "https://registry.npmjs.org/@ariakit/core/-/core-0.2.6.tgz",
-			"integrity": "sha512-83r2YmLvHLsV2NoclM5sfpLXfJ9S3R4lQIZK5Iad/KdfuFolvtVKPVrLW9OGoD1D4OuLxO1PgYKZEDPH0a1TjQ=="
+			"version": "0.2.7",
+			"resolved": "https://registry.npmjs.org/@ariakit/core/-/core-0.2.7.tgz",
+			"integrity": "sha512-Hs0N1EMYq88WW4v9xnSIHNR38TvbQuoUX6FYFmeLCZSTIXQBiET7lr1DQXwOOmdEtRtlxQ5HsxbTkxeOkPv+eg=="
 		},
 		"@ariakit/react": {
-			"version": "0.2.10",
-			"resolved": "https://registry.npmjs.org/@ariakit/react/-/react-0.2.10.tgz",
-			"integrity": "sha512-T0ftSgAuEXzA5MvurSWALfJBhTHzEgkXTDWEBTOkSzR5nxilPU/80UgA7dKHi4SGA3wUXIIMjRb42Djk3Qi9pQ==",
+			"version": "0.2.12",
+			"resolved": "https://registry.npmjs.org/@ariakit/react/-/react-0.2.12.tgz",
+			"integrity": "sha512-4rAgMyUURHW78EKgRCanhyRUtsiYCOxO65BBHF4mg3tZsDeOvu9kBG5IAXX8mUgakTcyr0EKXuOtGThaj7gobA==",
 			"requires": {
-				"@ariakit/react-core": "0.2.10"
+				"@ariakit/react-core": "0.2.12"
 			}
 		},
 		"@ariakit/react-core": {
-			"version": "0.2.10",
-			"resolved": "https://registry.npmjs.org/@ariakit/react-core/-/react-core-0.2.10.tgz",
-			"integrity": "sha512-/MBX9ToIBQUR//uaOs1XzLz+Zq7ECMQmr670mXiDg3L9bu0siQKP3vD2Fl8RDRWMEMOk6+0Utr3Fm49hYlg24g==",
+			"version": "0.2.12",
+			"resolved": "https://registry.npmjs.org/@ariakit/react-core/-/react-core-0.2.12.tgz",
+			"integrity": "sha512-3KSKlX10nnhCvjsbPW0CAnqG+6grryfwnMkeJJ/h34FSV7hEfUMexmIjKBVZyfBG08Xj8NjSK8kkx9c3ChkXeA==",
 			"requires": {
-				"@ariakit/core": "0.2.6",
+				"@ariakit/core": "0.2.7",
 				"@floating-ui/dom": "^1.0.0",
 				"use-sync-external-store": "^1.2.0"
 			}
@@ -17419,7 +17419,7 @@
 		"@wordpress/components": {
 			"version": "file:packages/components",
 			"requires": {
-				"@ariakit/react": "^0.2.10",
+				"@ariakit/react": "^0.2.12",
 				"@babel/runtime": "^7.16.0",
 				"@emotion/cache": "^11.7.1",
 				"@emotion/css": "^11.7.1",

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 -   `Popover`: Pin `react-dropdown-menu` version to avoid breaking changes in dependency updates. ([#52356](https://github.com/WordPress/gutenberg/pull/52356)).
 -   `Item`: Unify focus style and add default font styles. ([#52495](https://github.com/WordPress/gutenberg/pull/52495)).
+-   `Toolbar`: Fix toolbar items not being tabbable on the first render. ([#52613](https://github.com/WordPress/gutenberg/pull/52613))
 
 ## 25.3.0 (2023-07-05)
 

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -30,7 +30,7 @@
 	],
 	"types": "build-types",
 	"dependencies": {
-		"@ariakit/react": "^0.2.10",
+		"@ariakit/react": "^0.2.12",
 		"@babel/runtime": "^7.16.0",
 		"@emotion/cache": "^11.7.1",
 		"@emotion/css": "^11.7.1",

--- a/test/e2e/specs/editor/various/navigable-toolbar.spec.js
+++ b/test/e2e/specs/editor/various/navigable-toolbar.spec.js
@@ -45,4 +45,19 @@ test.describe( 'Block Toolbar', () => {
 			expect( scrollTopBefore ).toBe( scrollTopAfter );
 		} );
 	} );
+
+	test( 'should focus with Shift+Tab', async ( {
+		editor,
+		page,
+		pageUtils,
+	} ) => {
+		await editor.insertBlock( { name: 'core/paragraph' } );
+		await page.keyboard.type( 'a' );
+		await pageUtils.pressKeys( 'shift+Tab' );
+		await expect(
+			page
+				.getByRole( 'toolbar', { name: 'Block Tools' } )
+				.getByRole( 'button', { name: 'Paragraph' } )
+		).toBeFocused();
+	} );
 } );


### PR DESCRIPTION
Fixes #51876
Related to #52196 

After migrating the Toolbar component from Reakit to Ariakit on #51623, we encountered a regression in the <kbd>Shift</kbd>+<kbd>Tab</kbd> behavior for the Block Toolbar. Additional details can be found on #51876.

I'm still not sure why that's happening as I couldn't reproduce it outside of Gutenberg, but it seems that Ariakit v0.2.10 was setting `tabIndex={-1}` to all toolbar items before there was an active item with `tabIndex={0}`, resulting in a few frames with no tabbable elements in the block toolbar. So there wasn't anything to focus on in the block toolbar when pressing <kbd>Shift</kbd>+<kbd>Tab</kbd>. This could be fixed in Gutenberg by forcing the toolbar items to have `tabIndex={0}` on the initial render.

This PR upgrades Ariakit to v0.2.12, which updated this behavior on https://github.com/ariakit/ariakit/pull/2601. Although the change was initially intended to resolve another issue, it appears to fix this problem as well.

## Testing Instructions

1. In the Post Editor insert or focus a block and begin typing
2. Press <kbd>Shift</kbd>+<kbd>Tab</kbd>
3. Observe that focus moved to the block toolbar
