### PR TITLE
Use lowercase p in in "Manage Patterns"

### DIFF
--- a/packages/edit-post/src/plugins/index.js
+++ b/packages/edit-post/src/plugins/index.js
@@ -41,7 +41,7 @@ function ManagePatternsMenuItem() {
 
 	return (
 		<MenuItem role="menuitem" href={ url }>
-			{ __( 'Manage Patterns' ) }
+			{ __( 'Manage patterns' ) }
 		</MenuItem>
 	);
 }

--- a/packages/reusable-blocks/src/components/reusable-blocks-menu-items/reusable-blocks-manage-button.js
+++ b/packages/reusable-blocks/src/components/reusable-blocks-menu-items/reusable-blocks-manage-button.js
@@ -64,7 +64,7 @@ function ReusableBlocksManageButton( { clientId } ) {
 	return (
 		<BlockSettingsMenuControls>
 			<MenuItem href={ managePatternsUrl }>
-				{ __( 'Manage Patterns' ) }
+				{ __( 'Manage patterns' ) }
 			</MenuItem>
 			{ canRemove && (
 				<MenuItem onClick={ () => convertBlockToStatic( clientId ) }>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
"Patterns" should be lowercase. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open the Site Editor.
2. Insert a synced pattern.
3. Click on more menu within the block toolbar.
4. See "Manage patterns" instead of "Manage Patterns".

## Screenshots or screencast <!-- if applicable -->

| Before  | After |
| ------------- | ------------- |
|<img width="249" alt="CleanShot 2023-07-13 at 17 28 52" src="https://github.com/WordPress/gutenberg/assets/1813435/85215ad2-4d31-441e-8ef0-0764c42ac4c8">|<img width="249" alt="CleanShot 2023-07-13 at 17 29 18" src="https://github.com/WordPress/gutenberg/assets/1813435/ac29858a-afeb-4173-a5ef-ce3d58d57f08">|