### PR TITLE
Fix visually cut off link search results in LinkControl

### DIFF
--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -125,7 +125,7 @@ $block-editor-link-control-number-of-actions: 1;
 .block-editor-link-control__search-results {
 	margin-top: -$grid-unit-20;
 	padding: $grid-unit-10;
-	max-height: 200px;
+	max-height: $grid-unit * 24;
 	overflow-y: auto; // allow results list to scroll
 
 	&.is-loading {

--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -40,7 +40,7 @@ $block-editor-link-control-number-of-actions: 1;
 // Provides positioning context for reset button. Without this then when an
 // error notice is displayed the input's reset button is incorrectly positioned.
 .block-editor-link-control__search-input-wrapper {
-	margin-bottom: $grid-unit-10;
+	margin-bottom: $grid-unit-05;
 	position: relative;
 }
 

--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -138,6 +138,7 @@ $block-editor-link-control-number-of-actions: 1;
 	&.components-button.components-menu-item__button {
 		height: auto;
 		text-align: left;
+		max-height: $grid-unit * 11; // resolves to 44px
 	}
 
 	.components-menu-item__item {

--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -125,7 +125,7 @@ $block-editor-link-control-number-of-actions: 1;
 .block-editor-link-control__search-results {
 	margin-top: -$grid-unit-20;
 	padding: $grid-unit-10;
-	max-height: $grid-unit * 24;
+	max-height: $grid-unit * 24; // resolves to 194px
 	overflow-y: auto; // allow results list to scroll
 
 	&.is-loading {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixing a visual bug where link results were cut off visually due to the fixed height of the search results container. 

## How?
Adapts the height of the container so that the links display properly.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a Post or Page.
2. Insert a Heading Block. 
3. Add a link.
4. Search http to return a lot of links.
5. See no more cut off links.

## Screenshots or screencast <!-- if applicable -->

| Before  | After |
| ------------- | ------------- |
|<img width="433" alt="CleanShot 2023-07-13 at 17 35 07" src="https://github.com/WordPress/gutenberg/assets/1813435/7750d27a-b45e-4cc7-ae50-dc78bda91aef">|<img width="422" alt="CleanShot 2023-07-13 at 17 34 02" src="https://github.com/WordPress/gutenberg/assets/1813435/e6da90f7-be0d-4558-82d1-95a7fab4aae9">|


