### PR TITLE
Add keyboardReturn submit button back to LinkControl

### DIFF
--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -14,6 +14,7 @@ import { ENTER } from '@wordpress/keycodes';
 import { isShallowEqualObjects } from '@wordpress/is-shallow-equal';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { store as preferencesStore } from '@wordpress/preferences';
+import { keyboardReturn } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -388,6 +389,15 @@ function LinkControl( {
 							}
 							hideLabelFromVision={ ! showTextControl }
 						/>
+						<div className="block-editor-link-control__search-enter">
+							<Button
+								onClick={ isDisabled ? noop : handleSubmit }
+								label={ __( 'Submit' ) }
+								icon={ keyboardReturn }
+								className="block-editor-link-control__search-submit"
+								aria-disabled={ isDisabled }
+							/>
+						</div>
 					</div>
 					{ errorMessage && (
 						<Notice

--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -356,6 +356,7 @@ function LinkControl( {
 						className={ classnames( {
 							'block-editor-link-control__search-input-wrapper': true,
 							'has-text-control': showTextControl,
+							'has-actions': showActions,
 						} ) }
 					>
 						{ showTextControl && (
@@ -389,15 +390,17 @@ function LinkControl( {
 							}
 							hideLabelFromVision={ ! showTextControl }
 						/>
-						<div className="block-editor-link-control__search-enter">
-							<Button
-								onClick={ isDisabled ? noop : handleSubmit }
-								label={ __( 'Submit' ) }
-								icon={ keyboardReturn }
-								className="block-editor-link-control__search-submit"
-								aria-disabled={ isDisabled }
-							/>
-						</div>
+						{ ! showActions && (
+							<div className="block-editor-link-control__search-enter">
+								<Button
+									onClick={ isDisabled ? noop : handleSubmit }
+									label={ __( 'Submit' ) }
+									icon={ keyboardReturn }
+									className="block-editor-link-control__search-submit"
+									aria-disabled={ isDisabled }
+								/>
+							</div>
+						) }
 					</div>
 					{ errorMessage && (
 						<Notice

--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -46,7 +46,8 @@ $preview-image-height: 140px;
 }
 
 // Provides positioning context for search actions
-.block-editor-link-control__search-input-container {
+.block-editor-link-control__search-input-container,
+.block-editor-link-control__search-input-wrapper {
 	position: relative;
 }
 
@@ -465,6 +466,11 @@ $preview-image-height: 140px;
 		top: calc(50% - #{$spinner-size} / 2);
 		right: $grid-unit-50;
 	}
+}
+
+.block-editor-link-control .block-editor-link-control__search-input-wrapper.has-actions .components-spinner {
+	top: calc(50% + #{$spinner-size} / 4); // Add top spacing because this input has a visual label.
+	right: $grid-unit-15;
 }
 
 .block-editor-link-control__search-item-action {

--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -79,6 +79,17 @@ $preview-image-height: 140px;
 	margin: -$grid-unit-20 * 0.5 $grid-unit-20 $grid-unit-20; // negative margin to bring the error a bit closer to the button
 }
 
+.block-editor-link-control__search-enter {
+	position: absolute;
+	right: 19px; // specific to place the button properly.
+	top: 3px;
+
+	svg {
+		position: relative;
+		top: -2px; // the icon itself is not centered within the bounds; this centers it.
+	}
+}
+
 .block-editor-link-control__search-actions {
 	display: flex;
 	flex-direction: row-reverse; // put "Cancel" on the left but retain DOM order.
@@ -452,7 +463,7 @@ $preview-image-height: 140px;
 		left: auto;
 		bottom: auto;
 		top: calc(50% - #{$spinner-size} / 2);
-		right: $grid-unit-20;
+		right: $grid-unit-50;
 	}
 }
 

--- a/packages/block-editor/src/components/link-control/test/index.js
+++ b/packages/block-editor/src/components/link-control/test/index.js
@@ -959,6 +959,12 @@ describe( 'Link submission', () => {
 		expect( submitButton ).toBeVisible();
 		expect( submitButton ).toHaveAttribute( 'aria-disabled', 'true' );
 
+		// Click the button and check it's not possible to prematurely submit the link.
+		await user.click( submitButton );
+
+		expect( searchInput ).toBeVisible();
+		expect( submitButton ).toBeVisible();
+
 		await user.type( searchInput, 'https://wordpress.org' );
 
 		expect( submitButton ).toHaveAttribute( 'aria-disabled', 'false' );
@@ -989,6 +995,7 @@ describe( 'Link submission', () => {
 			name: 'Submit',
 		} );
 
+		// Check the submit button for "creation" of links is not displayed.
 		expect( createSubmitButton ).not.toBeInTheDocument();
 
 		const editSubmitButton = screen.getByRole( 'button', {
@@ -997,6 +1004,12 @@ describe( 'Link submission', () => {
 
 		expect( editSubmitButton ).toBeVisible();
 		expect( editSubmitButton ).toHaveAttribute( 'aria-disabled', 'true' );
+
+		// Click the button and check it's not possible to prematurely submit the link.
+		await user.click( editSubmitButton );
+
+		expect( searchInput ).toBeVisible();
+		expect( editSubmitButton ).toBeVisible();
 
 		await user.type( searchInput, '#appendtolinktext' );
 

--- a/packages/block-editor/src/components/link-control/test/index.js
+++ b/packages/block-editor/src/components/link-control/test/index.js
@@ -934,6 +934,33 @@ describe( 'Manual link entry', () => {
 			}
 		);
 	} );
+
+	it( 'should show a submit button when creating a link', async () => {
+		const user = userEvent.setup();
+
+		const LinkControlConsumer = () => {
+			const [ link, setLink ] = useState( {} );
+
+			return <LinkControl value={ link } onChange={ setLink } />;
+		};
+
+		render( <LinkControlConsumer /> );
+
+		const searchInput = screen.getByRole( 'combobox', {
+			name: 'Link',
+		} );
+
+		const submitButton = screen.getByRole( 'button', {
+			name: 'Submit',
+		} );
+
+		expect( submitButton ).toBeVisible();
+		expect( submitButton ).toHaveAttribute( 'aria-disabled', 'true' );
+
+		await user.type( searchInput, 'https://wordpress.org' );
+
+		expect( submitButton ).toHaveAttribute( 'aria-disabled', 'false' );
+	} );
 } );
 
 describe( 'Default search suggestions', () => {

--- a/packages/block-editor/src/components/link-control/test/index.js
+++ b/packages/block-editor/src/components/link-control/test/index.js
@@ -934,7 +934,9 @@ describe( 'Manual link entry', () => {
 			}
 		);
 	} );
+} );
 
+describe( 'Link submission', () => {
 	it( 'should show a submit button when creating a link', async () => {
 		const user = userEvent.setup();
 
@@ -960,6 +962,45 @@ describe( 'Manual link entry', () => {
 		await user.type( searchInput, 'https://wordpress.org' );
 
 		expect( submitButton ).toHaveAttribute( 'aria-disabled', 'false' );
+	} );
+
+	it( 'should show a submit button when editing a link', async () => {
+		const user = userEvent.setup();
+
+		const LinkControlConsumer = () => {
+			const [ link, setLink ] = useState( fauxEntitySuggestions[ 0 ] );
+
+			return (
+				<LinkControl
+					forceIsEditingLink
+					value={ link }
+					onChange={ setLink }
+				/>
+			);
+		};
+
+		render( <LinkControlConsumer /> );
+
+		const searchInput = screen.getByRole( 'combobox', {
+			name: 'Link',
+		} );
+
+		const createSubmitButton = screen.queryByRole( 'button', {
+			name: 'Submit',
+		} );
+
+		expect( createSubmitButton ).not.toBeInTheDocument();
+
+		const editSubmitButton = screen.getByRole( 'button', {
+			name: 'Save',
+		} );
+
+		expect( editSubmitButton ).toBeVisible();
+		expect( editSubmitButton ).toHaveAttribute( 'aria-disabled', 'true' );
+
+		await user.type( searchInput, '#appendtolinktext' );
+
+		expect( editSubmitButton ).toHaveAttribute( 'aria-disabled', 'false' );
 	} );
 } );
 

--- a/packages/block-editor/src/components/link-control/test/index.js
+++ b/packages/block-editor/src/components/link-control/test/index.js
@@ -766,9 +766,6 @@ describe( 'Manual link entry', () => {
 					name: 'Save',
 				} );
 
-				// debug the UI state
-				// screen.debug();
-
 				// Verify the submission UI is disabled.
 				expect( submitButton ).toBeVisible();
 				expect( submitButton ).toHaveAttribute(

--- a/packages/block-editor/src/components/link-control/test/index.js
+++ b/packages/block-editor/src/components/link-control/test/index.js
@@ -1013,6 +1013,11 @@ describe( 'Link submission', () => {
 
 		await user.type( searchInput, '#appendtolinktext' );
 
+		// As typing triggers the search handler, we need to wait for the
+		// search results to be returned. We can use the presence of the
+		// search results listbox as a proxy for this.
+		expect( await screen.findByRole( 'listbox' ) ).toBeVisible();
+
 		expect( editSubmitButton ).toHaveAttribute( 'aria-disabled', 'false' );
 	} );
 } );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
I couldn't find context why this was removed (if it was intentional), so here's a go at putting it back. 

If we don't need the button itself, an alternate would be to employ the icon itself (which is what the block inserter search input does). 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a Post or Page.
2. Insert a Heading block.
3. Make a link.
4. See the keyboardReturn submit button, indicating you can submit. 

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

### Before: 

https://github.com/WordPress/gutenberg/assets/1813435/1a502a31-a5ee-4036-bec9-9ba8c897a195

### After: 

https://github.com/WordPress/gutenberg/assets/1813435/d20ea15f-c47b-425e-aac5-5c9deceb8729

