### PR TITLE
Change password input to type text so contents are visible.

### DIFF
--- a/packages/edit-site/src/components/sidebar-edit-mode/page-panels/page-status.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/page-panels/page-status.js
@@ -218,7 +218,7 @@ export default function PageStatus( {
 												placeholder={ __(
 													'Enter a secure password'
 												) }
-												type="password"
+												type="text"
 											/>
 										) }
 									</BaseControl>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes #52607. 

The password input field in the Page section of the site editor was a type `password`, which means its contents are obscured. It should instead be a type `text` as in the post editor.

<img width="346" alt="Screenshot 2023-07-14 at 11 28 20 am" src="https://github.com/WordPress/gutenberg/assets/8096000/adbb7d4b-9fef-4834-8b8d-b12e8c3be362">

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. In the site editor, navigate to Pages and select a page
2. Enter edit mode, and in the settings sidebar open the Status dropdown
3. Toggle "Hide this page behind a password" and check the password field displays text when typed in.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
