### PR TITLE
EntityRecordItem: Fix ESLint warnings and remove unnecessary memoization

### DIFF
--- a/packages/editor/src/components/entities-saved-states/entity-record-item.js
+++ b/packages/editor/src/components/entities-saved-states/entity-record-item.js
@@ -4,7 +4,6 @@
 import { CheckboxControl, Button, PanelRow } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { useCallback } from '@wordpress/element';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 import { store as coreStore } from '@wordpress/core-data';
 import { decodeEntities } from '@wordpress/html-entities';
@@ -21,20 +20,23 @@ export default function EntityRecordItem( {
 	closePanel,
 } ) {
 	const { name, kind, title, key } = record;
-	const parentBlockId = useSelect( ( select ) => {
-		// Get entity's blocks.
-		const { blocks = [] } = select( coreStore ).getEditedEntityRecord(
-			kind,
-			name,
-			key
-		);
-		// Get parents of the entity's first block.
-		const parents = select( blockEditorStore ).getBlockParents(
-			blocks[ 0 ]?.clientId
-		);
-		// Return closest parent block's clientId.
-		return parents[ parents.length - 1 ];
-	}, [] );
+	const parentBlockId = useSelect(
+		( select ) => {
+			// Get entity's blocks.
+			const { blocks = [] } = select( coreStore ).getEditedEntityRecord(
+				kind,
+				name,
+				key
+			);
+			// Get parents of the entity's first block.
+			const parents = select( blockEditorStore ).getBlockParents(
+				blocks[ 0 ]?.clientId
+			);
+			// Return closest parent block's clientId.
+			return parents[ parents.length - 1 ];
+		},
+		[ key, kind, name ]
+	);
 
 	// Handle templates that might use default descriptive titles.
 	const entityRecordTitle = useSelect(
@@ -65,14 +67,6 @@ export default function EntityRecordItem( {
 	);
 	const isSelectedText = isSelected ? __( 'Selected' ) : __( 'Select' );
 	const { selectBlock } = useDispatch( blockEditorStore );
-	const selectParentBlock = useCallback(
-		() => selectBlock( parentBlockId ),
-		[ parentBlockId ]
-	);
-	const selectAndDismiss = useCallback( () => {
-		selectBlock( parentBlockId );
-		closePanel();
-	}, [ parentBlockId ] );
 
 	return (
 		<PanelRow>
@@ -90,16 +84,19 @@ export default function EntityRecordItem( {
 			{ parentBlockId ? (
 				<>
 					<Button
-						onClick={ selectParentBlock }
 						className="entities-saved-states__find-entity"
 						disabled={ isSelected }
+						onClick={ () => selectBlock( parentBlockId ) }
 					>
 						{ isSelectedText }
 					</Button>
 					<Button
-						onClick={ selectAndDismiss }
 						className="entities-saved-states__find-entity-small"
 						disabled={ isSelected }
+						onClick={ () => {
+							selectBlock( parentBlockId );
+							closePanel();
+						} }
 					>
 						{ isSelectedText }
 					</Button>


### PR DESCRIPTION
## What?
PR fixes the ESLint warning and removes unnecessary callback memoization in the `EntityRecordItem` component.

## Why?
The callbacks are not dependencies for any hooks, and the button components aren't memorized.

P.S. I was looking into a [different issue](https://github.com/WordPress/gutenberg/issues/52324) related to this component and decided to do a little cleanup first.

## Testing Instructions
1. Open the Site Editor.
2. Editor a template part.
3. Click on save.
4. Confirm entity record item for the template part is rendered correctly.
5. Clicking on "Select" selects the template part block.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2023-07-14 at 11 50 00](https://github.com/WordPress/gutenberg/assets/240569/5be02e5b-93fa-4a07-acc9-64b64ed67a8c)
