### PR TITLE
Password protected field: Remove autofocus and improve placeholder text consistency.

### DIFF
--- a/packages/edit-site/src/components/sidebar-edit-mode/page-panels/page-status.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/page-panels/page-status.js
@@ -212,11 +212,8 @@ export default function PageStatus( {
 													} )
 												}
 												value={ password }
-												/* eslint-disable jsx-a11y/no-autofocus */
-												autoFocus={ ! password }
-												/* eslint-enable jsx-a11y/no-autofocus */
 												placeholder={ __(
-													'Enter a secure password'
+													'Use a secure password'
 												) }
 												type="text"
 											/>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Fixes https://github.com/WordPress/gutenberg/issues/52605

See also https://github.com/WordPress/gutenberg/pull/52603

## What?
<!-- In a few words, what is the PR actually doing? -->

When editing a page in the _Site_ editor, the password protected input field is auto-focused as soon as it is revealed. This may not be the best experience for users. Also, it is inconsistent with the behavior in the _Post_ editor.
Please do not ever use the `autofocus` attribute.
Do not ever disable the `jsx-a11y/no-autofocus` rule, unless there are very very good reason to do so.


## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
- Autofocusing elements can cause usability issues for sighted and non-sighted users, as it dumps users within a form, potentially with no context.
- There are good reasons why the `jsx-a11y/no-autofocus` is in place and it should not be disabled.
- The autofocus behavior in the Site editor is inconsistent with the similar input field in the Post editor.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Removes the autofocus attribute.
Standardizes the placeholder text.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
- Go to the Site editor > Design > Pages > edit any page.
- In the Settings panel > Summary, edit the 'Status'.
- Click the 'Hide this page behind a password' toggle.
- Observe the password input field is not auto-focused.
- Observe the password input field placeholder text is `Use a secure password`.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

Before: on the right: clicking the password protected toggle in the Site editor auto-focused the input field

<img width="675" alt="password autofocus before" src="https://github.com/WordPress/gutenberg/assets/1682452/41fe89c3-931c-4e88-bf4c-81caa83d8589">


After:
- Both fields (in the Post editor and in the Site Editor) do not use autofocus.
- The placeholder text is now consistent.

<img width="678" alt="password autofocus after" src="https://github.com/WordPress/gutenberg/assets/1682452/9f7c7d4e-06eb-47b8-b6cd-3ab09159fc63">