### PR TITLE
Navigation: Use getTitle to get the navigation title

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen-pattern/template-part-navigation-menu-list-item.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-pattern/template-part-navigation-menu-list-item.js
@@ -1,17 +1,32 @@
 /**
  * WordPress dependencies
  */
+import { useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
+import { store as coreStore } from '@wordpress/core-data';
+import { store as editorStore } from '@wordpress/editor';
 
 /**
  * Internal dependencies
  */
 import SidebarNavigationItem from '../sidebar-navigation-item';
 import { useLink } from '../routes/link';
-import useEditedEntityRecord from '../use-edited-entity-record';
 
 export default function TemplatePartNavigationMenuListItem( { id } ) {
-	const { getTitle } = useEditedEntityRecord( 'wp_navigation', id );
+	const title = useSelect( ( select ) => {
+		const { getEditedEntityRecord } = select( coreStore );
+		const { __experimentalGetTemplateInfo: getTemplateInfo } =
+			select( editorStore );
+
+		const _record = getEditedEntityRecord(
+			'postType',
+			'wp_navigation',
+			id
+		);
+
+		const templateInfo = getTemplateInfo( _record );
+		return templateInfo?.title || __( '(no title)' );
+	} );
 
 	const linkInfo = useLink( {
 		postId: id,
@@ -22,7 +37,7 @@ export default function TemplatePartNavigationMenuListItem( { id } ) {
 
 	return (
 		<SidebarNavigationItem withChevron { ...linkInfo }>
-			{ getTitle() || __( '(no title)' ) }
+			{ title }
 		</SidebarNavigationItem>
 	);
 }

--- a/packages/edit-site/src/components/sidebar-navigation-screen-pattern/template-part-navigation-menu-list-item.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-pattern/template-part-navigation-menu-list-item.js
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { useEntityProp } from '@wordpress/core-data';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -9,9 +8,10 @@ import { __ } from '@wordpress/i18n';
  */
 import SidebarNavigationItem from '../sidebar-navigation-item';
 import { useLink } from '../routes/link';
+import useEditedEntityRecord from '../use-edited-entity-record';
 
 export default function TemplatePartNavigationMenuListItem( { id } ) {
-	const [ title ] = useEntityProp( 'postType', 'wp_navigation', 'title', id );
+	const { getTitle } = useEditedEntityRecord( 'wp_navigation', id );
 
 	const linkInfo = useLink( {
 		postId: id,
@@ -22,7 +22,7 @@ export default function TemplatePartNavigationMenuListItem( { id } ) {
 
 	return (
 		<SidebarNavigationItem withChevron { ...linkInfo }>
-			{ title || __( '(no title)' ) }
+			{ getTitle() || __( '(no title)' ) }
 		</SidebarNavigationItem>
 	);
 }

--- a/packages/edit-site/src/components/sidebar-navigation-screen-pattern/template-part-navigation-menu-list.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-pattern/template-part-navigation-menu-list.js
@@ -10,9 +10,9 @@ import TemplatePartNavigationMenuListItem from './template-part-navigation-menu-
 export default function TemplatePartNavigationMenuList( { menus } ) {
 	return (
 		<ItemGroup className="edit-site-sidebar-navigation-screen-template-part-navigation-menu-list">
-			{ menus.map( ( menuId ) => (
+			{ [ ...new Set( menus ) ].map( ( menuId, index ) => (
 				<TemplatePartNavigationMenuListItem
-					key={ menuId }
+					key={ index }
 					id={ menuId }
 				/>
 			) ) }

--- a/packages/edit-site/src/components/sidebar-navigation-screen-pattern/template-part-navigation-menu-list.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-pattern/template-part-navigation-menu-list.js
@@ -10,7 +10,7 @@ import TemplatePartNavigationMenuListItem from './template-part-navigation-menu-
 export default function TemplatePartNavigationMenuList( { menus } ) {
 	return (
 		<ItemGroup className="edit-site-sidebar-navigation-screen-template-part-navigation-menu-list">
-			{ [ ...new Set( menus ) ].map( ( menuId, index ) => (
+			{ [ ...new Set( menus ) ].map( ( menuId ) => (
 				<TemplatePartNavigationMenuListItem
 					key={ menuId }
 					id={ menuId }

--- a/packages/edit-site/src/components/sidebar-navigation-screen-pattern/template-part-navigation-menu-list.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-pattern/template-part-navigation-menu-list.js
@@ -12,7 +12,7 @@ export default function TemplatePartNavigationMenuList( { menus } ) {
 		<ItemGroup className="edit-site-sidebar-navigation-screen-template-part-navigation-menu-list">
 			{ [ ...new Set( menus ) ].map( ( menuId, index ) => (
 				<TemplatePartNavigationMenuListItem
-					key={ index }
+					key={ menuId }
 					id={ menuId }
 				/>
 			) ) }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Gets the entity title in a more predictable format. An alternative to https://github.com/WordPress/gutenberg/pull/52167.

## Why?
Sometimes it seems like `useEntityProp` returns an object and sometimes a string, so sometimes this throws an error.

## How?
This changes the approach to use  `getTitle` which is more predictable.

## Testing Instructions
1. Open the site editor
2. Open Library
3. Find a template part that contains a navigation block
4. Open the template part and check that you see the navigation in the left sidebar with the title of the Navigation