### PR TITLE
Fix Webpack to watch the `interactivity` package files

### DIFF
--- a/tools/webpack/interactivity.js
+++ b/tools/webpack/interactivity.js
@@ -53,4 +53,8 @@ module.exports = {
 			},
 		],
 	},
+	watchOptions: {
+		ignored: [ '**/node_modules' ],
+		aggregateTimeout: 500,
+	},
 };


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

<!-- In a few words, what is the PR actually doing? -->

Fix Webpack to watch the `interactivity` package files

## Why?

<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Every time you make a change, you have to restart Webpack because its files were ignored.

## How?

<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Overwrite the default `watchOptions` settings to ignore only `node_modules`.

## Testing Instructions

<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

Previously:

- Checkout `trunk`
- Run `npm run dev`
- Make a change in a file that is inside the `interactivity` package
- Observe the console. Only this line should be output:
  ```
  [1] [0] -> update: /Users/luisherranz/Code/gutenberg/packages/interactivity/src/index.js
  ```

Now:

- Checkout this branch
- Run `npm run dev` again
- Make a change in a file that is inside the `interactivity` package
- Observe the console. Now, something like this should appear:
  ```
  [0]   asset ./build/interactivity/index.min.js 64.9 KiB [emitted] (name: index) 1 related asset
  [0]   cached modules 42.6 KiB [cached] 14 modules
  [0]   runtime modules 670 bytes 3 modules
  [0]   ./packages/interactivity/src/index.js 482 bytes [built] [code generated]
  [0]   interactivity (webpack 5.65.0) compiled successfully in 18 ms
  [1] [0] -> update: /Users/luisherranz/Code/gutenberg/packages/interactivity/src/index.js
  ```
