### PR TITLE
Add runtime support for the `wp-style` directive

### DIFF
--- a/packages/e2e-tests/plugins/interactive-blocks/directive-style/block.json
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-style/block.json
@@ -1,0 +1,14 @@
+{
+	"apiVersion": 2,
+	"name": "test/directive-style",
+	"title": "E2E Interactivity tests - directive style",
+	"category": "text",
+	"icon": "heart",
+	"description": "",
+	"supports": {
+		"interactivity": true
+	},
+	"textdomain": "e2e-interactivity",
+	"viewScript": "directive-style-view",
+	"render": "file:./render.php"
+}

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-style/render.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-style/render.php
@@ -31,45 +31,57 @@
 	<div
 		style="color: red; background: green;"
 		data-wp-style--color="state.color"
-		data-testid="dont change style if callback returns same value"
-	>Don't change style if callback returns same value</div>
+		data-testid="dont change style if callback returns same value on hydration"
+	>Don't change style if callback returns same value on hydration</div>
 
 	<div
 		style="color: blue; background: green;"
 		data-wp-style--color="state.falseValue"
-		data-testid="remove style if callback returns falsy value"
-	>Remove style if callback returns falsy value</div>
+		data-testid="remove style if callback returns falsy value on hydration"
+	>Remove style if callback returns falsy value on hydration</div>
 
 	<div
 		style="color: blue; background: green;"
 		data-wp-style--color="state.color"
-		data-testid="change style if callback returns a new value"
-	>Change style if callback returns a new value</div>
+		data-testid="change style if callback returns a new value on hydration"
+	>Change style if callback returns a new value on hydration</div>
 
 	<div
 		style="color: blue; background: green; border: 1px solid black"
 		data-wp-style--color="state.falseValue"
 		data-wp-style--background="state.color"
 		data-wp-style--border="state.border"
-		data-testid="handles multiple styles"
-	>Handles multiple styles and callbacks</div>
+		data-testid="handles multiple styles and callbacks on hydration"
+	>Handles multiple styles and callbacks on hydration</div>
+
+	<div
+		data-wp-style--color="state.color"
+		data-testid="can add style when style attribute is missing on hydration"
+	>Can add style when style attribute is missing on hydration</div>
+
+	<div
+		style="color: red;"
+		data-wp-style--color="state.color"
+		data-testid="can toggle style"
+	>Can toggle style</div>
+
+	<div
+		style="color: red;"
+		data-wp-style--color="state.color"
+		data-testid="can remove style"
+	>Can remove style</div>
+
+	<div
+		style="color: blue; background: green; border: 1px solid black;"
+		data-wp-style--background="state.color"
+		data-testid="can toggle style in the middle"
+	>Can toggle style in the middle</div>
 
 	<div
 		style="background-color: green;"
 		data-wp-style--background-color="state.color"
 		data-testid="handles styles names with hyphens"
 	>Handles styles names with hyphens</div>
-
-	<div
-		style="color: blue; background: green; border: 1px solid black"
-		data-wp-style--background="state.color"
-		data-testid="can toggle style in the middle"
-	>Can toggle style in the middle</div>
-
-	<div
-		data-wp-style--color="state.color"
-		data-testid="can toggle style when style attribute is missing"
-	>Can toggle style when style attribute is missing</div>
 
 	<div data-wp-context='{ "color": "blue" }'>
 		<div
@@ -78,10 +90,10 @@
 			data-testid="can use context values"
 		></div>
 		<button
-			data-wp-on--click="actions.toggleContextValue"
-			data-testid="toggle context value"
+			data-wp-on--click="actions.toggleContext"
+			data-testid="toggle context"
 		>
-			Toggle context value
+			Toggle context
 		</button>
 	</div>
 </div>

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-style/render.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-style/render.php
@@ -21,13 +21,6 @@
 		Switch Color to False
 	</button>
 
-	<button
-		data-wp-on--click="actions.toggleBorder"
-		data-testid="toggle border"
-	>
-		Toggle Border
-	</button>
-
 	<div
 		style="color: red; background: green;"
 		data-wp-style--color="state.color"

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-style/render.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-style/render.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * HTML for testing the directive `data-wp-style`.
+ *
+ * @package gutenberg-test-interactive-blocks
+ */
+?>
+
+<div data-wp-interactive>
+	<button
+		data-wp-on--click="actions.toggleColor"
+		data-testid="toggle color"
+	>
+		Toggle Color
+	</button>
+
+	<button
+		data-wp-on--click="actions.switchColorToFalse"
+		data-testid="switch color to false"
+	>
+		Switch Color to False
+	</button>
+
+	<button
+		data-wp-on--click="actions.toggleBorder"
+		data-testid="toggle border"
+	>
+		Toggle Border
+	</button>
+
+	<div
+		style="color: red; background: green;"
+		data-wp-style--color="state.color"
+		data-testid="dont change style if callback returns same value"
+	>Don't change style if callback returns same value</div>
+
+	<div
+		style="color: blue; background: green;"
+		data-wp-style--color="state.falseValue"
+		data-testid="remove style if callback returns falsy value"
+	>Remove style if callback returns falsy value</div>
+
+	<div
+		style="color: blue; background: green;"
+		data-wp-style--color="state.color"
+		data-testid="change style if callback returns a new value"
+	>Change style if callback returns a new value</div>
+
+	<div
+		style="color: blue; background: green; border: 1px solid black"
+		data-wp-style--color="state.falseValue"
+		data-wp-style--background="state.color"
+		data-wp-style--border="state.border"
+		data-testid="handles multiple styles"
+	>Handles multiple styles and callbacks</div>
+
+	<div
+		style="background-color: green;"
+		data-wp-style--background-color="state.color"
+		data-testid="handles styles names with hyphens"
+	>Handles styles names with hyphens</div>
+
+	<div
+		style="color: blue; background: green; border: 1px solid black"
+		data-wp-style--background="state.color"
+		data-testid="can toggle style in the middle"
+	>Can toggle style in the middle</div>
+
+	<div
+		data-wp-style--color="state.color"
+		data-testid="can toggle style when style attribute is missing"
+	>Can toggle style when style attribute is missing</div>
+
+	<div data-wp-context='{ "color": "blue" }'>
+		<div
+			style="color: blue;"
+			data-wp-style--color="context.color"
+			data-testid="can use context values"
+		></div>
+		<button
+			data-wp-on--click="actions.toggleContextValue"
+			data-testid="toggle context value"
+		>
+			Toggle context value
+		</button>
+	</div>
+</div>

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-style/render.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-style/render.php
@@ -4,6 +4,7 @@
  *
  * @package gutenberg-test-interactive-blocks
  */
+
 ?>
 
 <div data-wp-interactive>

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-style/view.js
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-style/view.js
@@ -1,0 +1,25 @@
+( ( { wp } ) => {
+	const { store } = wp.interactivity;
+
+	store( {
+		state: {
+			falseValue: false,
+			color: "red",
+			border: "2px solid yellow"
+		},
+		actions: {
+			toggleColor: ( { state } ) => {
+				state.color = state.color === "red" ? "blue" : "red";
+			},
+			switchColorToFalse: ({ state }) => {
+				state.color = false;
+			},
+			toggleBorder: ( { state } ) => {
+				state.color = state.color === "2px solid yellow" ? "1px solid black" : "2px solid yellow";
+			},
+			toggleContextValue: ( { context } ) => {
+				context.color = context.color === "red" ? "blue" : "red";
+			},
+		},
+	} );
+} )( window );

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-style/view.js
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-style/view.js
@@ -14,9 +14,6 @@
 			switchColorToFalse: ({ state }) => {
 				state.color = false;
 			},
-			toggleBorder: ( { state } ) => {
-				state.color = state.color === "2px solid yellow" ? "1px solid black" : "2px solid yellow";
-			},
 			toggleContext: ( { context } ) => {
 				context.color = context.color === "red" ? "blue" : "red";
 			},

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-style/view.js
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-style/view.js
@@ -17,7 +17,7 @@
 			toggleBorder: ( { state } ) => {
 				state.color = state.color === "2px solid yellow" ? "1px solid black" : "2px solid yellow";
 			},
-			toggleContextValue: ( { context } ) => {
+			toggleContext: ( { context } ) => {
 				context.color = context.color === "red" ? "blue" : "red";
 			},
 		},

--- a/packages/interactivity/CHANGELOG.md
+++ b/packages/interactivity/CHANGELOG.md
@@ -4,4 +4,4 @@
 
 ### New Features
 
--   Runtime support for the `data-wp-style` directive. ([#XX](XX))
+-   Runtime support for the `data-wp-style` directive. ([#52645](https://github.com/WordPress/gutenberg/pull/52645))

--- a/packages/interactivity/CHANGELOG.md
+++ b/packages/interactivity/CHANGELOG.md
@@ -1,0 +1,7 @@
+<!-- Learn how to maintain this file at https://github.com/WordPress/gutenberg/tree/HEAD/packages#maintaining-changelogs. -->
+
+## Unreleased
+
+### New Features
+
+-   Runtime support for the `data-wp-style` directive. ([#XX](XX))

--- a/packages/interactivity/src/directives.js
+++ b/packages/interactivity/src/directives.js
@@ -149,7 +149,7 @@ export default () => {
 	 * Convert a css style string into a object.
 	 *
 	 * Made by Cristian Bote (@cristianbote) for Goober.
-	 * https://github.com/cristianbote/goober/blob/a849b2d644146d96fa1dd1c560f6418ee1e1c469/src/core/astish.js
+	 * https://unpkg.com/browse/goober@2.1.13/src/core/astish.js
 	 *
 	 * @param {string} val CSS string.
 	 * @return {Object} CSS object.

--- a/packages/interactivity/src/directives.js
+++ b/packages/interactivity/src/directives.js
@@ -154,7 +154,7 @@ export default () => {
 	 * @param {string} val CSS string.
 	 * @return {Object} CSS object.
 	 */
-	const astish = ( val ) => {
+	const cssStringToObject = ( val ) => {
 		const tree = [ {} ];
 		let block, left;
 
@@ -188,7 +188,9 @@ export default () => {
 					} );
 					element.props.style = element.props.style || {};
 					if ( typeof element.props.style === 'string' )
-						element.props.style = astish( element.props.style );
+						element.props.style = cssStringToObject(
+							element.props.style
+						);
 					if ( ! result ) delete element.props.style[ key ];
 					else element.props.style[ key ] = result;
 

--- a/packages/interactivity/src/directives.js
+++ b/packages/interactivity/src/directives.js
@@ -139,6 +139,73 @@ export default () => {
 		}
 	);
 
+	const newRule =
+		/(?:([\u0080-\uFFFF\w-%@]+) *:? *([^{;]+?);|([^;}{]*?) *{)|(}\s*)/g;
+	const ruleClean = /\/\*[^]*?\*\/|  +/g;
+	const ruleNewline = /\n+/g;
+	const empty = ' ';
+
+	/**
+	 * Convert a css style string into a object.
+	 *
+	 * Made by Cristian Bote (@cristianbote) for Goober.
+	 * https://github.com/cristianbote/goober/blob/a849b2d644146d96fa1dd1c560f6418ee1e1c469/src/core/astish.js
+	 *
+	 * @param {string} val CSS string.
+	 * @return {Object} CSS object.
+	 */
+	const astish = ( val ) => {
+		const tree = [ {} ];
+		let block, left;
+
+		while ( ( block = newRule.exec( val.replace( ruleClean, '' ) ) ) ) {
+			if ( block[ 4 ] ) {
+				tree.shift();
+			} else if ( block[ 3 ] ) {
+				left = block[ 3 ].replace( ruleNewline, empty ).trim();
+				tree.unshift( ( tree[ 0 ][ left ] = tree[ 0 ][ left ] || {} ) );
+			} else {
+				tree[ 0 ][ block[ 1 ] ] = block[ 2 ]
+					.replace( ruleNewline, empty )
+					.trim();
+			}
+		}
+
+		return tree[ 0 ];
+	};
+
+	// data-wp-style--[style-key]
+	directive(
+		'style',
+		( { directives: { style }, element, evaluate, context } ) => {
+			const contextValue = useContext( context );
+			Object.keys( style )
+				.filter( ( n ) => n !== 'default' )
+				.forEach( ( key ) => {
+					const result = evaluate( style[ key ], {
+						key,
+						context: contextValue,
+					} );
+					element.props.style = element.props.style || {};
+					if ( typeof element.props.style === 'string' )
+						element.props.style = astish( element.props.style );
+					if ( ! result ) delete element.props.style[ key ];
+					else element.props.style[ key ] = result;
+
+					useEffect( () => {
+						// This seems necessary because Preact doesn't change the styles on
+						// the hydration, so we have to do it manually. It doesn't need deps
+						// because it only needs to do it the first time.
+						if ( ! result ) {
+							element.ref.current.style.removeProperty( key );
+						} else {
+							element.ref.current.style[ key ] = result;
+						}
+					}, [] );
+				} );
+		}
+	);
+
 	// data-wp-bind--[attribute]
 	directive(
 		'bind',

--- a/test/e2e/specs/interactivity/directives-style.spec.ts
+++ b/test/e2e/specs/interactivity/directives-style.spec.ts
@@ -1,0 +1,118 @@
+/**
+ * Internal dependencies
+ */
+import { test, expect } from './fixtures';
+
+test.describe( 'data-wp-style', () => {
+	test.beforeAll( async ( { interactivityUtils: utils } ) => {
+		await utils.activatePlugins();
+		await utils.addPostWithBlock( 'test/directive-style' );
+	} );
+
+	test.beforeEach( async ( { interactivityUtils: utils, page } ) => {
+		await page.goto( utils.getLink( 'test/directive-style' ) );
+	} );
+
+	test.afterAll( async ( { interactivityUtils: utils } ) => {
+		await utils.deactivatePlugins();
+		await utils.deleteAllPosts();
+	} );
+
+	test( 'dont change style if callback returns same value on hydration', async ( {
+		page,
+	} ) => {
+		const el = page.getByTestId(
+			'dont change style if callback returns same value on hydration'
+		);
+		await expect( el ).toHaveAttribute(
+			'style',
+			'color: red; background: green;'
+		);
+	} );
+
+	test( 'remove style if callback returns falsy value on hydration', async ( {
+		page,
+	} ) => {
+		const el = page.getByTestId(
+			'remove style if callback returns falsy value on hydration'
+		);
+		await expect( el ).toHaveAttribute( 'style', 'background: green;' );
+	} );
+
+	test( 'change style if callback returns a new value on hydration', async ( {
+		page,
+	} ) => {
+		const el = page.getByTestId(
+			'change style if callback returns a new value on hydration'
+		);
+		await expect( el ).toHaveAttribute(
+			'style',
+			'color: red; background: green;'
+		);
+	} );
+
+	test( 'handles multiple styles and callbacks on hydration', async ( {
+		page,
+	} ) => {
+		const el = page.getByTestId(
+			'handles multiple styles and callbacks on hydration'
+		);
+		await expect( el ).toHaveAttribute(
+			'style',
+			'background: red; border: 2px solid yellow;'
+		);
+	} );
+
+	test( 'can add style when style attribute is missing on hydration', async ( {
+		page,
+	} ) => {
+		const el = page.getByTestId(
+			'can add style when style attribute is missing on hydration'
+		);
+		await expect( el ).toHaveAttribute( 'style', 'color: red;' );
+	} );
+
+	test( 'can toggle style', async ( { page } ) => {
+		const el = page.getByTestId( 'can toggle style' );
+		await expect( el ).toHaveAttribute( 'style', 'color: red;' );
+		await page.getByTestId( 'toggle color' ).click();
+		await expect( el ).toHaveAttribute( 'style', 'color: blue;' );
+	} );
+
+	test( 'can remove style', async ( { page } ) => {
+		const el = page.getByTestId( 'can remove style' );
+		await expect( el ).toHaveAttribute( 'style', 'color: red;' );
+		await page.getByTestId( 'switch color to false' ).click();
+		await expect( el ).toHaveAttribute( 'style', '' );
+	} );
+
+	test( 'can toggle style in the middle', async ( { page } ) => {
+		const el = page.getByTestId( 'can toggle style in the middle' );
+		await expect( el ).toHaveAttribute(
+			'style',
+			'color: blue; background: red; border: 1px solid black;'
+		);
+		await page.getByTestId( 'toggle color' ).click();
+		await expect( el ).toHaveAttribute(
+			'style',
+			'color: blue; background: blue; border: 1px solid black;'
+		);
+	} );
+
+	test( 'handles styles names with hyphens', async ( { page } ) => {
+		const el = page.getByTestId( 'handles styles names with hyphens' );
+		await expect( el ).toHaveAttribute( 'style', 'background-color: red;' );
+		await page.getByTestId( 'toggle color' ).click();
+		await expect( el ).toHaveAttribute(
+			'style',
+			'background-color: blue;'
+		);
+	} );
+
+	test( 'can use context values', async ( { page } ) => {
+		const el = page.getByTestId( 'can use context values' );
+		await expect( el ).toHaveAttribute( 'style', 'color: blue;' );
+		await page.getByTestId( 'toggle context' ).click();
+		await expect( el ).toHaveAttribute( 'style', 'color: red;' );
+	} );
+} );

--- a/tools/webpack/interactivity.js
+++ b/tools/webpack/interactivity.js
@@ -53,4 +53,8 @@ module.exports = {
 			},
 		],
 	},
+	watchOptions: {
+		ignored: [ '**/node_modules' ],
+		aggregateTimeout: 500,
+	},
 };

--- a/tools/webpack/interactivity.js
+++ b/tools/webpack/interactivity.js
@@ -53,8 +53,4 @@ module.exports = {
 			},
 		],
 	},
-	watchOptions: {
-		ignored: [ '**/node_modules' ],
-		aggregateTimeout: 500,
-	},
 };


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

<!-- In a few words, what is the PR actually doing? -->

Add runtime support for the `wp-style` directive.

_Co-authored-by @c4rl0sbr4v0._

## Why?

<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Because it's one of the core directives and it was still missing.

## How?

<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

By adding it to the list of directives.

I used a magic function 🪄 from [Goober (🥜)](https://github.com/cristianbote/goober) made by @cristianbote 🧙‍♂️ to convert a CSS string into a style object.

## Testing Instructions

<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

- Add the `data-wp-style` directive to a block and reference some part of the state/context.
- Mutate that part of the state/context.
- Check that the `style` attribute changed accordingly.
