### PR TITLE
`Modal`: Fix loss of focus when clicking outside

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 -   `ColorPalette`, `BorderControl`: Don't hyphenate hex value in `aria-label` ([#52932](https://github.com/WordPress/gutenberg/pull/52932)).
 
+### Bug Fix
+
+-   `Modal`: Fix loss of focus when clicking outside ([#52653](https://github.com/WordPress/gutenberg/pull/52653)).
+
 ## 25.4.0 (2023-07-20)
 
 ### Enhancements

--- a/packages/components/src/modal/index.tsx
+++ b/packages/components/src/modal/index.tsx
@@ -170,6 +170,15 @@ function UnforwardedModal(
 		[ hasScrolledContent ]
 	);
 
+	const onOverlayPress: React.PointerEventHandler< HTMLDivElement > = (
+		event
+	) => {
+		if ( event.target === event.currentTarget ) {
+			event.preventDefault();
+			onRequestClose( event );
+		}
+	};
+
 	return createPortal(
 		// eslint-disable-next-line jsx-a11y/no-static-element-interactions
 		<div
@@ -179,6 +188,9 @@ function UnforwardedModal(
 				overlayClassName
 			) }
 			onKeyDown={ handleEscapeKeyDown }
+			onPointerDown={
+				shouldCloseOnClickOutside ? onOverlayPress : undefined
+			}
 		>
 			<StyleProvider document={ document }>
 				<div

--- a/packages/components/src/modal/index.tsx
+++ b/packages/components/src/modal/index.tsx
@@ -188,6 +188,10 @@ function UnforwardedModal(
 				overlayClassName
 			) }
 			onKeyDown={ handleEscapeKeyDown }
+			// Avoids loss of focus from clicking the overlay and also obviates
+			// `useFocusOutside` aside from cases of focus programmatically
+			// moving outside. TODO ideally both the hook and this handler
+			// won't be needed and one can be removed.
 			onPointerDown={
 				shouldCloseOnClickOutside ? onOverlayPress : undefined
 			}

--- a/packages/components/src/modal/test/index.tsx
+++ b/packages/components/src/modal/test/index.tsx
@@ -5,6 +5,11 @@ import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 /**
+ * WordPress dependencies
+ */
+import { useState } from '@wordpress/element';
+
+/**
  * Internal dependencies
  */
 import Modal from '../';
@@ -81,5 +86,33 @@ describe( 'Modal', () => {
 		);
 		await user.keyboard( '[Escape]' );
 		expect( onRequestClose ).toHaveBeenCalled();
+	} );
+
+	it( 'should return focus when dismissed by clicking outside', async () => {
+		const user = userEvent.setup();
+		const ReturnDemo = () => {
+			const [ isShown, setIsShown ] = useState( false );
+			return (
+				<div>
+					<button onClick={ () => setIsShown( true ) }>📣</button>
+					{ isShown && (
+						<Modal onRequestClose={ () => setIsShown( false ) }>
+							<p>Modal content</p>
+						</Modal>
+					) }
+				</div>
+			);
+		};
+		render( <ReturnDemo /> );
+
+		const opener = screen.getByRole( 'button' );
+		await user.click( opener );
+		const modalFrame = screen.getByRole( 'dialog' );
+		expect( modalFrame ).toHaveFocus();
+
+		// Disable reason: No semantic query can reach the overlay.
+		// eslint-disable-next-line testing-library/no-node-access
+		await user.click( modalFrame.parentElement! );
+		expect( opener ).toHaveFocus();
 	} );
 } );


### PR DESCRIPTION
## What?
- Ensures that return of focus from the `Modal` component works when it’s dismissed by clicking outside.
- Adds a unit test to guard regressions.

## Why?
Focus loss is troublesome in various ways. This fixes #51722.

## How?
Uses a pointer event handler to preempt the `onFocusOutside` handling for dismissing the modal when clicking outside.

## Testing Instructions
1. Start in the Post Editor
2. Open the Options menu
3. Open the Preferences modal
4. Click outside the Preferences modal to dismiss it
5. Observe the Options menu is still open and focus returned to the “Preferences” button.

This can be generalized to any modal/confirmation dialog in any of the block editors.

### Testing Instructions for Keyboard
After step 4 of the above testing instructions you can try using editor keyboard shortcuts and observe they do work.

### Unit Test Testing Instructions
1. Check out the first commit on this branch `git checkout 1aaa194`
2. `npm run test:unit -- modal/test/index.tsx`
3. Observe the new test fails
4. `git switch -`
5. Repeat step 2.
6. Observe the new test passes
