### PR TITLE
Check wp_theme_has_theme_json in addition to wp_is_block_theme in gutenberg_enqueue_global_styles_custom_css()

### DIFF
--- a/lib/script-loader.php
+++ b/lib/script-loader.php
@@ -63,7 +63,7 @@ add_action( 'wp_footer', 'gutenberg_enqueue_global_styles', 1 );
  * @since 6.2.0
  */
 function gutenberg_enqueue_global_styles_custom_css() {
-	if ( ! wp_is_block_theme() ) {
+	if ( ! wp_theme_has_theme_json() ) {
 		return;
 	}
 

--- a/lib/script-loader.php
+++ b/lib/script-loader.php
@@ -63,7 +63,7 @@ add_action( 'wp_footer', 'gutenberg_enqueue_global_styles', 1 );
  * @since 6.2.0
  */
 function gutenberg_enqueue_global_styles_custom_css() {
-	if ( ! wp_theme_has_theme_json() ) {
+	if ( ! wp_is_block_theme() && ! wp_theme_has_theme_json() )
 		return;
 	}
 

--- a/lib/script-loader.php
+++ b/lib/script-loader.php
@@ -63,7 +63,7 @@ add_action( 'wp_footer', 'gutenberg_enqueue_global_styles', 1 );
  * @since 6.2.0
  */
 function gutenberg_enqueue_global_styles_custom_css() {
-	if ( ! wp_is_block_theme() && ! wp_theme_has_theme_json() )
+	if ( ! wp_is_block_theme() && ! wp_theme_has_theme_json() ) {
 		return;
 	}
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Replace `wp_is_block_theme` with `wp_theme_has_theme_json` in `gutenberg_enqueue_global_styles_custom_css()` to make custom css from [theme.json](url) work on frontend **IN CLASSIC THEMES WITH A THEME.JSON FILE**, not only pure block themes.

Fixes #52644

I hope this can be fixed for WP6.3

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
