### PR TITLE
Site Editor: Don't allow creating template part on the Patterns page for non-block themes

### DIFF
--- a/packages/edit-site/src/components/add-new-pattern/index.js
+++ b/packages/edit-site/src/components/add-new-pattern/index.js
@@ -5,6 +5,7 @@ import { DropdownMenu } from '@wordpress/components';
 import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { plus, symbol, symbolFilled } from '@wordpress/icons';
+import { useSelect } from '@wordpress/data';
 import { privateApis as routerPrivateApis } from '@wordpress/router';
 
 /**
@@ -14,6 +15,7 @@ import CreatePatternModal from '../create-pattern-modal';
 import CreateTemplatePartModal from '../create-template-part-modal';
 import SidebarButton from '../sidebar-button';
 import { unlock } from '../../lock-unlock';
+import { store as editSiteStore } from '../../store';
 
 const { useHistory } = unlock( routerPrivateApis );
 
@@ -22,6 +24,10 @@ export default function AddNewPattern() {
 	const [ showPatternModal, setShowPatternModal ] = useState( false );
 	const [ showTemplatePartModal, setShowTemplatePartModal ] =
 		useState( false );
+	const isTemplatePartsMode = useSelect( ( select ) => {
+		const settings = select( editSiteStore ).getSettings();
+		return !! settings.supportsTemplatePartsMode;
+	}, [] );
 
 	function handleCreatePattern( { pattern, categoryId } ) {
 		setShowPatternModal( false );
@@ -55,7 +61,7 @@ export default function AddNewPattern() {
 		<>
 			<DropdownMenu
 				controls={ [
-					{
+					! isTemplatePartsMode && {
 						icon: symbolFilled,
 						onClick: () => setShowTemplatePartModal( true ),
 						title: __( 'Create template part' ),
@@ -65,7 +71,7 @@ export default function AddNewPattern() {
 						onClick: () => setShowPatternModal( true ),
 						title: __( 'Create pattern' ),
 					},
-				] }
+				].filter( Boolean ) }
 				toggleProps={ {
 					as: SidebarButton,
 				} }

--- a/test/e2e/specs/site-editor/hybrid-theme.spec.js
+++ b/test/e2e/specs/site-editor/hybrid-theme.spec.js
@@ -1,0 +1,41 @@
+/**
+ * WordPress dependencies
+ */
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+
+test.describe( 'Hybrid theme', () => {
+	test.beforeAll( async ( { requestUtils } ) => {
+		await requestUtils.activateTheme( 'gutenberg-test-themes/emptyhybrid' );
+	} );
+
+	test.afterAll( async ( { requestUtils } ) => {
+		await requestUtils.activateTheme( 'twentytwentyone' );
+	} );
+
+	test( 'should not show the Add Template Part button', async ( {
+		admin,
+		page,
+	} ) => {
+		await admin.visitAdminPage(
+			'/site-editor.php',
+			'postType=wp_template_part&path=/wp_template_part/all'
+		);
+
+		await expect(
+			page.locator( 'role=button[name="Add New Template Part"i]' )
+		).toBeHidden();
+
+		// Back to Patterns page.
+		await page.click(
+			'role=region[name="Navigation"i] >> role=button[name="Back"i]'
+		);
+
+		await page.click(
+			'role=region[name="Navigation"i] >> role=button[name="Create pattern"i]'
+		);
+
+		await expect(
+			page.locator( 'role=menuitem[name="Create template part"i]' )
+		).toBeHidden();
+	} );
+} );

--- a/test/e2e/specs/site-editor/hybrid-theme.spec.js
+++ b/test/e2e/specs/site-editor/hybrid-theme.spec.js
@@ -5,7 +5,7 @@ const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 
 test.describe( 'Hybrid theme', () => {
 	test.beforeAll( async ( { requestUtils } ) => {
-		await requestUtils.activateTheme( 'gutenberg-test-themes/emptyhybrid' );
+		await requestUtils.activateTheme( 'emptyhybrid' );
 	} );
 
 	test.afterAll( async ( { requestUtils } ) => {


### PR DESCRIPTION
Part of #52150

## What?

This PR fixes an issue where classic themes with `block-template-parts` support could unintentionally create a template part in the Patterns page of the Site Editor.

![create-patterns-modal](https://github.com/WordPress/gutenberg/assets/54422211/c4ad974e-290a-452f-ab19-f4eeb10f6ffd)

## Why?

Previously, classic themes that support block-template-parts could access the "All template parts" page in the site editor and edit only the template parts that the theme had. However, with the addition of the Patterns page, you can now return to the Patterns page when you press the Back button. As a result, there is a problem with being able to unintentionally create a template part from an action button.

To solve this problem, based on the discussion that took place in #52150, either of the following solutions would be possible:

1. When the back button is pressed on the All template parts page, the user is redirected to the WP-Admin page as before, not to the Patterns page.
2. Allow access to the Patterns page, but do not allow the creation of unintended template parts.

I have adopted the second approach in this PR because I thought that ideally the site editor pattern management functionality should be exposed to the classic theme as well.

However, classic themes that do not support `block-template-parts` do not have access to the Site Editor itself. In the future, I hope to add "Patterns" menu under the Apperance menu of all classic themes, so that users can create patterns and edit the template parts that the theme has on the Patterns page of the Site Editor.

## How?

I use `supportsTemplatePartsMode` and hide the Create Template Parts button on the Patterns page for classic themes that support `block-template-parts`. At the same time, I created a minimal e2e test for the hybrid theme that checks for the absence of the Create Template Part button.

## Testing Instructions

- Access to `localhost:8889/wp-admin/` ( not `localhost:8888/wp-admin/` ).
- Activate Emptyhybrid theme.
- Access to Appearance > Template Parts.
- Click the back button.
- If you click on the plus button on the Patterns page, there should not be a Create template part button in the dropdown menu.