### PR TITLE
DimensionsPanel: Fix unexpected value decoding/encoding

### DIFF
--- a/packages/block-editor/src/components/global-styles/dimensions-panel.js
+++ b/packages/block-editor/src/components/global-styles/dimensions-panel.js
@@ -207,18 +207,24 @@ export default function DimensionsPanel( {
 	// in global styles but not in block inspector.
 	includeLayoutControls = false,
 } ) {
+	const { dimensions, spacing } = settings;
+
 	const decodeValue = ( rawValue ) => {
 		if ( rawValue && typeof rawValue === 'object' ) {
 			return Object.keys( rawValue ).reduce( ( acc, key ) => {
 				acc[ key ] = getValueFromVariable(
-					{ settings },
+					{ settings: { dimensions, spacing } },
 					'',
 					rawValue[ key ]
 				);
 				return acc;
 			}, {} );
 		}
-		return getValueFromVariable( { settings }, '', rawValue );
+		return getValueFromVariable(
+			{ settings: { dimensions, spacing } },
+			'',
+			rawValue
+		);
 	};
 
 	const showSpacingPresetsControl = useHasSpacingPresets( settings );

--- a/packages/block-editor/src/components/spacing-sizes-control/input-controls/axial.js
+++ b/packages/block-editor/src/components/spacing-sizes-control/input-controls/axial.js
@@ -2,7 +2,12 @@
  * Internal dependencies
  */
 import SpacingInputControl from './spacing-input-control';
-import { LABELS, ICONS, hasAxisSupport } from '../utils';
+import {
+	LABELS,
+	ICONS,
+	getPresetValueFromCustomValue,
+	hasAxisSupport,
+} from '../utils';
 
 const groupedSides = [ 'vertical', 'horizontal' ];
 
@@ -20,7 +25,17 @@ export default function AxialInputControls( {
 		if ( ! onChange ) {
 			return;
 		}
-		const nextValues = { ...values };
+
+		// Encode the existing value into the preset value if the passed in value matches the value of one of the spacingSizes.
+		const nextValues = {
+			...Object.keys( values ).reduce( ( acc, key ) => {
+				acc[ key ] = getPresetValueFromCustomValue(
+					values[ key ],
+					spacingSizes
+				);
+				return acc;
+			}, {} ),
+		};
 
 		if ( side === 'vertical' ) {
 			nextValues.top = next;

--- a/packages/block-editor/src/components/spacing-sizes-control/input-controls/separated.js
+++ b/packages/block-editor/src/components/spacing-sizes-control/input-controls/separated.js
@@ -2,7 +2,12 @@
  * Internal dependencies
  */
 import SpacingInputControl from './spacing-input-control';
-import { ALL_SIDES, LABELS, ICONS } from '../utils';
+import {
+	ALL_SIDES,
+	LABELS,
+	ICONS,
+	getPresetValueFromCustomValue,
+} from '../utils';
 
 export default function SeparatedInputControls( {
 	minimumCustomValue,
@@ -20,7 +25,17 @@ export default function SeparatedInputControls( {
 		: ALL_SIDES;
 
 	const createHandleOnChange = ( side ) => ( next ) => {
-		const nextValues = { ...values };
+		// Encode the existing value into the preset value if the passed in value matches the value of one of the spacingSizes.
+		const nextValues = {
+			...Object.keys( values ).reduce( ( acc, key ) => {
+				acc[ key ] = getPresetValueFromCustomValue(
+					values[ key ],
+					spacingSizes
+				);
+				return acc;
+			}, {} ),
+		};
+
 		nextValues[ side ] = next;
 
 		onChange( nextValues );

--- a/packages/block-editor/src/components/spacing-sizes-control/input-controls/single.js
+++ b/packages/block-editor/src/components/spacing-sizes-control/input-controls/single.js
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 import SpacingInputControl from './spacing-input-control';
-import { LABELS } from '../utils';
+import { LABELS, getPresetValueFromCustomValue } from '../utils';
 
 export default function SingleInputControl( {
 	minimumCustomValue,
@@ -16,7 +16,17 @@ export default function SingleInputControl( {
 	values,
 } ) {
 	const createHandleOnChange = ( currentSide ) => ( next ) => {
-		const nextValues = { ...values };
+		// Encode the existing value into the preset value if the passed in value matches the value of one of the spacingSizes.
+		const nextValues = {
+			...Object.keys( values ).reduce( ( acc, key ) => {
+				acc[ key ] = getPresetValueFromCustomValue(
+					values[ key ],
+					spacingSizes
+				);
+				return acc;
+			}, {} ),
+		};
+
 		nextValues[ currentSide ] = next;
 
 		onChange( nextValues );


### PR DESCRIPTION
Try to: Fixes: #51619

- Fixes: #51619
- Fixes: #51891

## What?

This PR attempts to fix #51619 and #51891, regressions caused by #50956.

## Why?

#50956 took the following search and approach to fix the issue reported in #50940 where the `SpacingSizesControl` value was reset when the global style was saved.

- The value that `DiemsionsPanel` is trying to decode (padding/margin) is an object with `top/bottom/left/right` properties
- However, `getValueFromVariable`, which `decodeValue` calls internally, [returns the object as is when it receives it](https://github.com/WordPress/gutenberg/blob/33bf984897683adfc4582a29adb079cf6ee0ab59/packages/block-editor/src/components/global-styles/utils.js#L322)
- Therefore, I made sure to decode each property value individually

However, this seems to have resulted in the following two regressions:

- [#51619](https://github.com/WordPress/gutenberg/issues/51619): unintentional switch to custom input when moving the slider.
- [#51891](https://github.com/WordPress/gutenberg/issues/51891): Actual values are output as values, not CSS variables (`var(--wp--preset--spacing--{slug})`)

I have done a lot of research and I suspect that #50956 caused the unintended decoding of the value.

## How?

After some trial and error, I found that if the decoding process is not performed when the value is in user preset format (`var: prefixed`), it works as expected. Or perhaps we should keep the decoding process and add a new encoding process. For example, in `BorderPanel`, [the color values are encoded](https://github.com/WordPress/gutenberg/blob/33bf984897683adfc4582a29adb079cf6ee0ab59/packages/block-editor/src/components/global-styles/border-panel.js#L89C8-L89C25).

## Testing Instructions

Enable EmptyTheme and update `theme.json` as follows:

<details><summary>theme.json</summary>

```
{
	"$schema": "https://schemas.wp.org/trunk/theme.json",
	"version": 2,
	"settings": {
		"appearanceTools": true,
		"layout": {
			"contentSize": "650px",
			"wideSize": "1200px"
		},
		"spacing": {
			"spacingSizes": [
				{
					"name": "Static Value",
					"size": "8px",
					"slug": "1"
				},
				{
					"name": "Clamp Value",
					"size": "clamp(1rem, 0.818rem + 0.91vw, 1.5rem);",
					"slug": "2"
				},
				{
					"name": "CSS Variable (Custom)",
					"size": "var(--wp--custom--font-size--20)",
					"slug": "3"
				},
				{
					"name": "CSS Variable (Font Size)",
					"size": "var(--wp--preset--font-size--24)",
					"slug": "4"
				}
			]
		},
		"typography": {
			"fontSizes": [
				{
					"name": "24px",
					"size": "24px",
					"slug": "24"
				}
			]
		},
		"custom": {
			"font-size": {
				"20": "20px"
			}
		}
  }
}
```
</details> 

This `theme.json` has many variations in the spacingSizes property.

### Test for #51619

- When the slider is moved, it does not switch to custom input.

<details><summary>Screencast</summary>

https://github.com/WordPress/gutenberg/assets/54422211/69f9c586-8548-4b88-b33d-db0cd6e3bedc

</details> 

### Test for #51891

- When moving the slider, the value is always updated as a CSS variable (`var(--wp--preset--spacing--{slug})`).
- When you enter an arbitrary value in a custom input, it will be updated with that value.
- If you enter a value (`8`) that exists in `spacingSizes` in the custom input, it will be reflected in the slider.

<details><summary>Screencast</summary>

https://github.com/WordPress/gutenberg/assets/54422211/ca0ffe39-e1d7-4fcf-bd4d-f6a5e08cb1ce

</details> 

### Test for #50940

- When spacing is updated in global style, the value of the control is not reset and the position of the slider is maintained.

<details><summary>Screencast</summary>

https://github.com/WordPress/gutenberg/assets/54422211/68595430-f52d-4609-8dad-c1314d604e19

</details> 
