### PR TITLE
FormTokenField: Fix token overflow when moving cursor left or right

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -12,6 +12,7 @@
 -   `Popover`: Pin `react-dropdown-menu` version to avoid breaking changes in dependency updates. ([#52356](https://github.com/WordPress/gutenberg/pull/52356)).
 -   `Item`: Unify focus style and add default font styles. ([#52495](https://github.com/WordPress/gutenberg/pull/52495)).
 -   `Toolbar`: Fix toolbar items not being tabbable on the first render. ([#52613](https://github.com/WordPress/gutenberg/pull/52613))
+-   `FormTokenField`: Fix token overflow when moving cursor left or right. ([#52662](https://github.com/WordPress/gutenberg/pull/52662))
 
 ## 25.3.0 (2023-07-05)
 

--- a/packages/components/src/form-token-field/styles.ts
+++ b/packages/components/src/form-token-field/styles.ts
@@ -9,6 +9,7 @@ import { css } from '@emotion/react';
  */
 import { Flex } from '../flex';
 import { space } from '../ui/utils/space';
+import { boxSizingReset } from '../utils';
 
 type TokensAndInputWrapperProps = {
 	__next40pxDefaultSize: boolean;
@@ -27,7 +28,7 @@ const deprecatedPaddings = ( {
 
 export const TokensAndInputWrapperFlex = styled( Flex )`
 	padding: 7px;
-	box-sizing: border-box;
+	${ boxSizingReset }
 
 	${ deprecatedPaddings }
 `;

--- a/packages/components/src/form-token-field/styles.ts
+++ b/packages/components/src/form-token-field/styles.ts
@@ -27,6 +27,7 @@ const deprecatedPaddings = ( {
 
 export const TokensAndInputWrapperFlex = styled( Flex )`
 	padding: 7px;
+	box-sizing: border-box;
 
 	${ deprecatedPaddings }
 `;


### PR DESCRIPTION
## What?
This PR fixes a problem in the `FormTokenField` component where tokens protrude from the input element when the cursor is moved between (or at the beginning of) tokens.

|Before|After|
|:-:|:-:|
|<video src="https://github.com/WordPress/gutenberg/assets/54422211/8937ddf0-1067-47a9-9b3e-b0baa2268213">|<video src="https://github.com/WordPress/gutenberg/assets/54422211/2f2ed866-4668-46b3-87c2-a61b35cd6233">|

## Why?
This is because this component does not have `box-sizing:border-box`. However, this problem does not occur in the sidebar of a post, for example, because the `box-sizing` is reset.

https://github.com/WordPress/gutenberg/blob/33bf984897683adfc4582a29adb079cf6ee0ab59/packages/edit-post/src/style.scss#L59-L65

https://github.com/WordPress/gutenberg/blob/33bf984897683adfc4582a29adb079cf6ee0ab59/packages/base-styles/_mixins.scss#L344-L352

## Testing Instructions

- Launch Storybook.
- Enter some tokens.
- Press the left and right cursor keys.
- Confirm that the tokens do not protrude from the input element.