### PR TITLE
Show warning on removal of Post Template block in the site editor.

### DIFF
--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -70,6 +70,9 @@ const blockRemovalRules = {
 	'core/post-content': __(
 		'Post Content displays the content of a post or page.'
 	),
+	'core/post-template': __(
+		'Post Template displays each post or page in a Query Loop.'
+	),
 };
 
 export default function Editor( { isLoading } ) {

--- a/test/e2e/specs/site-editor/block-removal.spec.js
+++ b/test/e2e/specs/site-editor/block-removal.spec.js
@@ -38,6 +38,30 @@ test.describe( 'Site editor block removal prompt', () => {
 		).toBeVisible();
 	} );
 
+	test( 'should appear when attempting to remove Post Template Block', async ( {
+		page,
+	} ) => {
+		// Open and focus List View
+		const topBar = page.getByRole( 'region', { name: 'Editor top bar' } );
+		await topBar.getByRole( 'button', { name: 'List View' } ).click();
+
+		// Select and open child blocks of Query Loop block
+		const listView = page.getByRole( 'region', { name: 'List View' } );
+		await listView.getByRole( 'link', { name: 'Query Loop' } ).click();
+		await page.keyboard.press( 'ArrowRight' );
+
+		// Select and try to remove Post Template block
+		await listView.getByRole( 'link', { name: 'Post Template' } ).click();
+		await page.keyboard.press( 'Backspace' );
+
+		// Expect the block removal prompt to have appeared
+		await expect(
+			page.getByText(
+				'Post Template displays each post or page in a Query Loop.'
+			)
+		).toBeVisible();
+	} );
+
 	test( 'should not appear when attempting to remove something else', async ( {
 		editor,
 		page,
@@ -53,14 +77,20 @@ test.describe( 'Site editor block removal prompt', () => {
 		// Reveal its inner blocks in the list view
 		await page.keyboard.press( 'ArrowRight' );
 
-		// Select and remove its Post Template inner block
+		// Select its Post Template inner block
 		await listView.getByRole( 'link', { name: 'Post Template' } ).click();
+
+		// Reveal its inner blocks in the list view
+		await page.keyboard.press( 'ArrowRight' );
+
+		// Select and remove its Title inner block
+		await listView.getByRole( 'link', { name: 'Title' } ).click();
 		await page.keyboard.press( 'Backspace' );
 
 		// Expect the block to have been removed with no prompt
 		await expect(
 			editor.canvas.getByRole( 'document', {
-				name: 'Block: Post Template',
+				name: 'Block: Title',
 			} )
 		).toBeHidden();
 	} );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes #52390.

Adds a warning when users try to delete the Post Template block in the site editor.


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. In the site editor, pick a homepage or other archive template that includes a Query block.
2. Try deleting the Post Template block from inside the Query: a warning modal should appear.
3. Try deleting the Query block: a warning should appear and mention both Query and Post Template blocks.
4. In the post editor, no warning should appear on deleting these blocks.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<img width="439" alt="Screenshot 2023-07-17 at 11 12 45 am" src="https://github.com/WordPress/gutenberg/assets/8096000/02f344a0-6635-4d70-82c5-0423bcb4c1b8">
 
<img width="460" alt="Screenshot 2023-07-17 at 11 12 29 am" src="https://github.com/WordPress/gutenberg/assets/8096000/6b3dab63-139b-48c5-840d-4d4d8e7e7023">

