### PR TITLE
Backport tools: sort PRs to be cherry picked by merged/closed date

### DIFF
--- a/bin/cherry-pick.mjs
+++ b/bin/cherry-pick.mjs
@@ -114,12 +114,15 @@ async function fetchPRs() {
 	const { items } = await GitHubFetch(
 		`/search/issues?q=is:pr state:closed sort:updated label:"${ LABEL }" repo:WordPress/gutenberg`
 	);
-	const PRs = items.map( ( { id, number, title } ) => ( {
+	const PRs = items.map( ( { id, number, title, updated_at, closed_at } ) => ( {
 		id,
 		number,
 		title,
-	} ) );
-	console.log( 'Found the following PRs to cherry-pick: ' );
+		closed_at,
+	} ) )
+		.sort( ( a, b ) => new Date( a.closed_at ) - new Date( b.closed_at ) );
+
+	console.log( 'Found the following PRs to cherry-pick (sorted by closed date in ascending order): ' );
 	PRs.forEach( ( { number, title } ) =>
 		console.log( indent( `#${ number } – ${ title }` ) )
 	);

--- a/bin/cherry-pick.mjs
+++ b/bin/cherry-pick.mjs
@@ -114,13 +114,22 @@ async function fetchPRs() {
 	const { items } = await GitHubFetch(
 		`/search/issues?q=is:pr state:closed sort:updated label:"${ LABEL }" repo:WordPress/gutenberg`
 	);
-	const PRs = items.map( ( { id, number, title, updated_at, closed_at } ) => ( {
+	const PRs = items.map( ( { id, number, title, pull_request, closed_at } ) => ( {
 		id,
 		number,
 		title,
 		closed_at,
 	} ) )
-		.sort( ( a, b ) => new Date( a.closed_at ) - new Date( b.closed_at ) );
+		.sort( ( a, b ) => {
+			/*
+			 * `closed_at` and `pull_request.merged_at` are _usually_ the same,
+			 * but let's prefer the latter if it's available.
+			 */
+			if ( a?.pull_request?.merged_at && b?.pull_request?.merged_at ) {
+				return new Date(  a?.pull_request?.merged_at ) - new Date( b?.pull_request?.merged_at );
+			}
+			return new Date( a.closed_at ) - new Date( b.closed_at );
+		} );
 
 	console.log( 'Found the following PRs to cherry-pick (sorted by closed date in ascending order): ' );
 	PRs.forEach( ( { number, title } ) =>

--- a/bin/cherry-pick.mjs
+++ b/bin/cherry-pick.mjs
@@ -129,7 +129,7 @@ async function fetchPRs() {
 			return new Date(  a?.pull_request?.merged_at ) - new Date( b?.pull_request?.merged_at );
 		}
 		return new Date( a.closed_at ) - new Date( b.closed_at );
-	} )
+	} );
 
 
 	console.log( 'Found the following PRs to cherry-pick (sorted by closed date in ascending order): ' );

--- a/bin/cherry-pick.mjs
+++ b/bin/cherry-pick.mjs
@@ -119,17 +119,18 @@ async function fetchPRs() {
 		number,
 		title,
 		closed_at,
-	} ) )
-		.sort( ( a, b ) => {
-			/*
-			 * `closed_at` and `pull_request.merged_at` are _usually_ the same,
-			 * but let's prefer the latter if it's available.
-			 */
-			if ( a?.pull_request?.merged_at && b?.pull_request?.merged_at ) {
-				return new Date(  a?.pull_request?.merged_at ) - new Date( b?.pull_request?.merged_at );
-			}
-			return new Date( a.closed_at ) - new Date( b.closed_at );
-		} );
+		pull_request,
+	} ) ).sort( ( a, b ) => {
+		/*
+		 * `closed_at` and `pull_request.merged_at` are _usually_ the same,
+		 * but let's prefer the latter if it's available.
+		 */
+		if ( a?.pull_request?.merged_at && b?.pull_request?.merged_at ) {
+			return new Date(  a?.pull_request?.merged_at ) - new Date( b?.pull_request?.merged_at );
+		}
+		return new Date( a.closed_at ) - new Date( b.closed_at );
+	} )
+
 
 	console.log( 'Found the following PRs to cherry-pick (sorted by closed date in ascending order): ' );
 	PRs.forEach( ( { number, title } ) =>


### PR DESCRIPTION
## What?
Updates the `npm run other:cherry-pick` script.

When fetching PRs to be cherry picked, first sort them by `pull_request.merged_at` (and `closed_at` if not available) date in ascending order, that is, from the oldest merged/closed PRs to most recently merged/closed PRs.

<details>

<summary>Before (last_update updated descending)</summary>

```js
[
 // This item was the last updated, but not the first to be merged
  {
    id: 1803111783,
    number: 52603,
    title: "Do not autofocus page title field in the 'Draft a new page' modal dialog",
    last_update: 'Mon, 17 Jul 2023 01:28:15 GMT',
    merged: 'Fri, 14 Jul 2023 08:50:31 GMT'
  },
  {
    id: 1801055909,
    number: 52570,
    title: 'Remove "Theme patterns" heading in Pattern library',
    last_update: 'Fri, 14 Jul 2023 19:27:35 GMT',
    merged: 'Fri, 14 Jul 2023 19:27:07 GMT'
  },
  {
    id: 1803789256,
    number: 52617,
    title: 'Use lowercase p in in "Manage Patterns"',
    last_update: 'Fri, 14 Jul 2023 16:21:02 GMT',
    merged: 'Fri, 14 Jul 2023 16:20:37 GMT'
  },
  {
    id: 1803604703,
    number: 52613,
    title: 'Fix Shift+Tab to Block Toolbar',
    last_update: 'Fri, 14 Jul 2023 07:39:10 GMT',
    merged: 'Fri, 14 Jul 2023 04:10:08 GMT'
  },
  {
    id: 1804189935,
    number: 52627,
    title: 'Iframe: Silence style compat warnings when in a BlockPreview',
    last_update: 'Fri, 14 Jul 2023 06:46:41 GMT',
    merged: 'Fri, 14 Jul 2023 05:48:52 GMT'
  },
  {
    id: 1803983317,
    number: 52622,
    title: 'Change password input to type text so contents are visible.',
    last_update: 'Fri, 14 Jul 2023 05:11:01 GMT',
    merged: 'Fri, 14 Jul 2023 05:07:07 GMT'
  },
 // This item was the first to be merged
  {
    id: 1776105739,
    number: 51956,
    title: 'Try restoring the site editor animation',
    last_update: 'Fri, 14 Jul 2023 03:24:24 GMT',
    merged: 'Tue, 04 Jul 2023 09:49:33 GMT'
  }
]


```

</details>


<details>

<summary>After (sorted by merged ascending)</summary>

```js
[
 // This item was the first to be merged
  {
    id: 1776105739,
    number: 51956,
    title: 'Try restoring the site editor animation',
    last_update: 'Fri, 14 Jul 2023 03:24:24 GMT',
    merged: 'Tue, 04 Jul 2023 09:49:33 GMT'
  },
  {
    id: 1803604703,
    number: 52613,
    title: 'Fix Shift+Tab to Block Toolbar',
    last_update: 'Fri, 14 Jul 2023 07:39:10 GMT',
    merged: 'Fri, 14 Jul 2023 04:10:08 GMT'
  },
  {
    id: 1803983317,
    number: 52622,
    title: 'Change password input to type text so contents are visible.',
    last_update: 'Fri, 14 Jul 2023 05:11:01 GMT',
    merged: 'Fri, 14 Jul 2023 05:07:07 GMT'
  },
  {
    id: 1804189935,
    number: 52627,
    title: 'Iframe: Silence style compat warnings when in a BlockPreview',
    last_update: 'Fri, 14 Jul 2023 06:46:41 GMT',
    merged: 'Fri, 14 Jul 2023 05:48:52 GMT'
  },
  {
    id: 1803111783,
    number: 52603,
    title: "Do not autofocus page title field in the 'Draft a new page' modal dialog",
    last_update: 'Mon, 17 Jul 2023 01:28:15 GMT',
    merged: 'Fri, 14 Jul 2023 08:50:31 GMT'
  },
  {
    id: 1803789256,
    number: 52617,
    title: 'Use lowercase p in in "Manage Patterns"',
    last_update: 'Fri, 14 Jul 2023 16:21:02 GMT',
    merged: 'Fri, 14 Jul 2023 16:20:37 GMT'
  },
  {
    id: 1801055909,
    number: 52570,
    title: 'Remove "Theme patterns" heading in Pattern library',
    last_update: 'Fri, 14 Jul 2023 19:27:35 GMT',
    merged: 'Fri, 14 Jul 2023 19:27:07 GMT'
  }
]


```

</details>

## Why?
At the moment the script fetches PR according with an "updated" sort flag. These means that the PRs are ordered by the last updated date, with the most-recent item first.

When cherry-picking commits there's always a risk of merge conflicts - hopefully cherry-picking commits from oldest to most recent merge dates will reduce the likelihood of conflicts. 

The assumption is that applying newer commits to older ones will better reflect how the current state of the code should be as newer commits may have modified code in the older commits.

Conversely, applying an older commit to a newer commit could lead to merge conflicts where the older commit contains code that has been modified by the newer commit.

## How?
Sorting by dates available from the Github API response.

## Testing Instructions

You can test against any set of Gutenberg PR labels by running `npm run other:cherry-pick "LABEL_NAME"`

`npm run other:cherry-pick` alone will run against the "[Backport to WP Beta/RC](https://api.github.com/search/issues?q=is:pr%20state:closed%20sort:updated%20label:%22Backport%20to%20WP%20Beta/RC%22%20repo:WordPress/gutenberg)" label.

To test, I commented out most of the functionality and print out fetched PRs to check the order:

<details>

<summary>Diff</summary>

```diff
diff --git a/bin/cherry-pick.mjs b/bin/cherry-pick.mjs
index baf8d42962..f3c4d789dc 100644
--- a/bin/cherry-pick.mjs
+++ b/bin/cherry-pick.mjs
@@ -47,12 +47,14 @@ async function main() {
 	await promptDoYouWantToProceed();
 
 	console.log( `$ git pull origin ${ BRANCH } --rebase...` );
-	cli( 'git', [ 'pull', 'origin', BRANCH, '--rebase' ], true );
+	//cli( 'git', [ 'pull', 'origin', BRANCH, '--rebase' ], true );
 
 	console.log( `$ git fetch origin trunk...` );
-	cli( 'git', [ 'fetch', 'origin', 'trunk' ], true );
+	//cli( 'git', [ 'fetch', 'origin', 'trunk' ], true );
 
 	const PRs = await fetchPRs();
+	console.log( PRs );
+	return;
 	console.log( 'Trying to cherry-pick one by one...' );
 	const [ successes, failures ] = cherryPickAll( PRs );
 	console.log( 'Cherry-picking finished!' );
@@ -136,29 +138,29 @@ async function fetchPRs() {
 	PRs.forEach( ( { number, title } ) =>
 		console.log( indent( `#${ number } – ${ title }` ) )
 	);
-	console.log( 'Fetching commit IDs...' );
-
-	const PRsWithMergeCommit = [];
-	for ( const PR of PRs ) {
-		const { merge_commit_sha: mergeCommitHash } = await GitHubFetch(
-			'/repos/WordPress/Gutenberg/pulls/' + PR.number
-		);
-		PRsWithMergeCommit.push( {
-			...PR,
-			mergeCommitHash,
-		} );
-		if ( ! mergeCommitHash ) {
-			throw new Error(
-				`Cannot fetch the merge commit sha for ${ prToString( PR ) }`
-			);
-		}
-	}
-
-	console.log( 'Done!' );
-	PRsWithMergeCommit.forEach( ( msg ) =>
-		console.log( indent( `${ prToString( msg ) }` ) )
-	);
-	return PRsWithMergeCommit;
+	// console.log( 'Fetching commit IDs...' );
+	//
+	// const PRsWithMergeCommit = [];
+	// for ( const PR of PRs ) {
+	// 	const { merge_commit_sha: mergeCommitHash } = await GitHubFetch(
+	// 		'/repos/WordPress/Gutenberg/pulls/' + PR.number
+	// 	);
+	// 	PRsWithMergeCommit.push( {
+	// 		...PR,
+	// 		mergeCommitHash,
+	// 	} );
+	// 	if ( ! mergeCommitHash ) {
+	// 		throw new Error(
+	// 			`Cannot fetch the merge commit sha for ${ prToString( PR ) }`
+	// 		);
+	// 	}
+	// }
+	//
+	// console.log( 'Done!' );
+	// PRsWithMergeCommit.forEach( ( msg ) =>
+	// 	console.log( indent( `${ prToString( msg ) }` ) )
+	// );
+	return PRs;
 }
 
 /**
```

</details>

