### PR TITLE
i18n: Make the tab labels of `ColorGradientSettingsDropdown` component translatable

### DIFF
--- a/packages/block-editor/src/components/colors-gradients/control.js
+++ b/packages/block-editor/src/components/colors-gradients/control.js
@@ -6,6 +6,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
+import { __ } from '@wordpress/i18n';
 import {
 	BaseControl,
 	__experimentalVStack as VStack,
@@ -28,12 +29,12 @@ const colorsAndGradientKeys = [
 
 const TAB_COLOR = {
 	name: 'color',
-	title: 'Solid',
+	title: __( 'Solid' ),
 	value: 'color',
 };
 const TAB_GRADIENT = {
 	name: 'gradient',
-	title: 'Gradient',
+	title: __( 'Gradient' ),
 	value: 'gradient',
 };
 


### PR DESCRIPTION
## What?
This PR applies a translation function to the tab labels of the `ColorGradientSettingsDropdown` component.

| Before | After |
|--------|--------|
| ![before](https://github.com/WordPress/gutenberg/assets/54422211/17569775-e035-4640-9ce6-bf9e83935489) | ![after](https://github.com/WordPress/gutenberg/assets/54422211/3a165afa-1cec-4221-868d-2dec77a89607) |

## Why?

This problem does not occur with Text/Baclground popovers added with block support or global styles. This is because these tabs [already have translation functions applied](https://github.com/WordPress/gutenberg/blob/d1f763c36bb26c20ae719f19bb449a446fb64d00/packages/block-editor/src/components/global-styles/color-panel.js#L528-L542).

However, it can be reproduced with the Post Featured Image and the Cover block that import `ColorGradientSettingsDropdown` and have overlay colors available.

## Testing Instructions

- Change site language
- Insert a Post Featured Image block or a Cover Bock.
- Click "Overlay" panel.
- Confirm that the tab labels `Solid` and `Gradient` are translated.