### PR TITLE
Patterns: fix bug with Create Patterns menu not showing in site editor page editing

### DIFF
--- a/packages/reusable-blocks/src/components/reusable-blocks-menu-items/index.js
+++ b/packages/reusable-blocks/src/components/reusable-blocks-menu-items/index.js
@@ -25,8 +25,11 @@ function ReusableBlocksMenuItems( { clientIds, rootClientId } ) {
 }
 
 export default withSelect( ( select ) => {
-	const { getSelectedBlockClientIds } = select( blockEditorStore );
+	const { getSelectedBlockClientIds, getBlockRootClientId } =
+		select( blockEditorStore );
+	const clientIds = getSelectedBlockClientIds();
 	return {
-		clientIds: getSelectedBlockClientIds(),
+		clientIds,
+		rootClientId: getBlockRootClientId( clientIds[ 0 ] ),
 	};
 } )( ReusableBlocksMenuItems );

--- a/packages/reusable-blocks/src/components/reusable-blocks-menu-items/index.js
+++ b/packages/reusable-blocks/src/components/reusable-blocks-menu-items/index.js
@@ -30,8 +30,9 @@ export default withSelect( ( select ) => {
 	const clientIds = getSelectedBlockClientIds();
 	return {
 		clientIds,
-		rootClientId: clientIds?.length
-			? getBlockRootClientId( clientIds[ 0 ] )
-			: undefined,
+		rootClientId:
+			clientIds?.length > 0
+				? getBlockRootClientId( clientIds[ 0 ] )
+				: undefined,
 	};
 } )( ReusableBlocksMenuItems );

--- a/packages/reusable-blocks/src/components/reusable-blocks-menu-items/index.js
+++ b/packages/reusable-blocks/src/components/reusable-blocks-menu-items/index.js
@@ -30,6 +30,8 @@ export default withSelect( ( select ) => {
 	const clientIds = getSelectedBlockClientIds();
 	return {
 		clientIds,
-		rootClientId: getBlockRootClientId( clientIds[ 0 ] ),
+		rootClientId: clientIds?.length
+			? getBlockRootClientId( clientIds[ 0 ] )
+			: undefined,
 	};
 } )( ReusableBlocksMenuItems );


### PR DESCRIPTION
## What?
Fixes the bug with the `Create pattern` menu not appearing when editing a Page in the Site Editor

## Why?
Fixes: #51310

## How?
Passes the root client id of the selected blocks into the reusable blocks menu otherwise [getBlockEditingMode](https://github.com/WordPress/gutenberg/blob/trunk/packages/block-editor/src/store/private-selectors.js#L76C19-L76C36) returns disabled when in the site editor page edit.

## Testing Instructions

- In the site edit go into Pages and select a page to edit.
- Add a block in the page content and in the block overflow menu make sure the `Create pattern` menu appears and works as expected
- Also check that the `Create pattern` menu works as expected in the post editor still, and that create pattern menu does not appear in widget editor
- Double check that Create pattern menu does not appear if a synced pattern block is selected

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/3629020/6d8bc217-66e8-4e56-919d-fe58464b5ae5

