### PR TITLE
Site Editor Patterns: Filter out patterns that are not available in the inserter

### DIFF
--- a/packages/edit-site/src/components/page-patterns/use-patterns.js
+++ b/packages/edit-site/src/components/page-patterns/use-patterns.js
@@ -86,6 +86,7 @@ const selectThemePatterns = ( select, { categoryId, search = '' } = {} ) => {
 			( pattern ) => ! CORE_PATTERN_SOURCES.includes( pattern.source )
 		)
 		.filter( filterOutDuplicatesByName )
+		.filter( ( pattern ) => pattern.inserter !== false )
 		.map( ( pattern ) => ( {
 			...pattern,
 			keywords: pattern.keywords || [],

--- a/packages/edit-site/src/components/sidebar-navigation-screen-patterns/use-theme-patterns.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-patterns/use-theme-patterns.js
@@ -36,7 +36,8 @@ export default function useThemePatterns() {
 					( pattern ) =>
 						! CORE_PATTERN_SOURCES.includes( pattern.source )
 				)
-				.filter( filterOutDuplicatesByName ),
+				.filter( filterOutDuplicatesByName )
+				.filter( ( pattern ) => pattern.inserter !== false ),
 		[ blockPatterns, restBlockPatterns ]
 	);
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Developers can register block patterns that are not available in the block inserter.
See https://developer.wordpress.org/reference/classes/wp_block_patterns_registry/register/#parameters
This PR filters out those patterns from the patterns list and pattern page.
Closes https://github.com/WordPress/gutenberg/issues/52629

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
They can not be inserted so they should not be presented as being available to the user.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Adds two new filters.

## Testing Instructions
In Twenty Twenty-Three, add `Inserter: no` to the file header of the post meta block pattern: twentytwentythree/patterns/post-meta.php.
```
<?php
/**
 * Title: Post Meta
 * Slug: twentytwentythree/post-meta
 * Categories: query
 * Keywords: post meta
 * Block Types: core/template-part/post-meta
 * Inserter: no
 */
?>
```
Save the file changes. 😄
Go to Appearance > Editor > Patterns and confirm that:
1. There is no longer a theme pattern category called "Posts" since this was the only pattern in this category.
2. The pattern is not displayed elsewhere.
4. All other patterns and pattern categories still display correctly.
