### PR TITLE
Footnotes: Attempt to iterate into nested blocks that use useInnerBlocksProps in the save function

### DIFF
--- a/packages/block-editor/src/components/rich-text/get-rich-text-values.js
+++ b/packages/block-editor/src/components/rich-text/get-rich-text-values.js
@@ -40,7 +40,9 @@ function addValuesForElement( element, ...args ) {
 		case Fragment:
 			return addValuesForElements( props.children, ...args );
 		case RawHTML:
-			return;
+			// `useInnerBlocksProps.save()` will return a `RawHTML` element,
+			// so use this as an indicator to recurse into the children.
+			return addValuesForBlocks( ...args );
 		case InnerBlocks.Content:
 			return addValuesForBlocks( ...args );
 		case Content:
@@ -81,7 +83,7 @@ function addValuesForElements( children, ...args ) {
 function addValuesForBlocks( values, blocks ) {
 	for ( let i = 0; i < blocks.length; i++ ) {
 		const { name, attributes, innerBlocks } = blocks[ i ];
-		const saveElement = getSaveElement( name, attributes );
+		const saveElement = getSaveElement( name, attributes, innerBlocks );
 		addValuesForElement( saveElement, values, innerBlocks );
 	}
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes https://github.com/WordPress/gutenberg/issues/52628 (hopefully!)

Over in https://github.com/WordPress/gutenberg/pull/52241 `getRichTextValues` was updated to work with `InnerBlocks.Content`, however as a result, it seems that nested blocks that don't use that component stopped being iterated over for extracting footnotes (e.g. the Group block, which uses `useInnerBlocksProps.save()` directly).

This PR attempts to recognise where in the block's output inner blocks are being rendered, by looking for `RawHTML` — if we match against that, then assume that we need to iterate into the block's inner blocks. The assumption in this PR is that we won't have blocks that use `useInnerBlocksProps.save()` _and_ `RawHTML` in their output intentionally. This is a bit of a hack, however it is preferable to an alternative:

In my first attempt at this PR, I thought I'd try adding a line to `addValuesToBlocks` so that it could recurse into itself around [here](https://github.com/WordPress/gutenberg/blob/7332ba6330b8d9b5a46b4b05fdfc341a741a098f/packages/block-editor/src/components/rich-text/get-rich-text-values.js#L87):  — basically, after working through all the elements for a block, iterate over its inner blocks. By doing that, we could then remove the explicit check for `InnerBlocks.Content`. The problem, though, is that this would mean that the iterating over children would always happen _after_ all the markup for the current block is processed. For the Quote block, this resulted in footnotes being in the wrong order, as in that block, `InnerBlocks.Content` appears before `RichtText.Content`. So, we need some way to ensure that the iteration always occurs at the correct place within the block's final markup.

Looking for `RawHTML` is imperfect, but for the moment appears to achieve better results than we have on trunk. I'm very happy to throw this PR away if folks have better ideas about how to achieve this!

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Prior to this PR, `getRichTextValues` only iterates over blocks that use `InnerBlocks.Content` (e.g. the Quote block, or List blocks). This means that blocks that are contained in Group blocks are never reached for extracting footnotes, as they do not use `InnerBlocks.Content`.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* Pass `innerBlocks` to `getSaveElement` so that inner blocks are rendered to a `RawHTML` component, so that we can use `RawHTML` as a flag for when to iterate over inner blocks.
* In `addValuesForElement`, use `RawHTML` in addition to `InnerBlocks.Content` as a flag to continue iterating into inner blocks.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. In a post, add headings, paragraphs, and list blocks, and quote blocks, and add footnotes to them. Ensure they work as expected.
2. Add a Group block or Cover block, and add new headings, paragraphs, list and quote blocks within these container blocks. Add more footnotes and ensure they work as expected.

## Screenshots or screencast <!-- if applicable -->

| Before (footnotes displayed as `0` or `*` | After (footnotes displayed correctly) |
| --- | --- |
| ![image](https://github.com/WordPress/gutenberg/assets/14988353/8a9bb67b-9789-4e08-aeec-8be85b239196) | ![image](https://github.com/WordPress/gutenberg/assets/14988353/7a20e086-d3b6-4897-bc2a-88a90ebc93b7) |
