### PR TITLE
My patterns page: Increase color contrast for the toggle group

### DIFF
--- a/packages/edit-site/src/components/page-patterns/style.scss
+++ b/packages/edit-site/src/components/page-patterns/style.scss
@@ -57,6 +57,9 @@
 			width: 300px;
 		}
 	}
+	.edit-site-patterns__sync-status-filter-option:not([aria-checked="true"]) {
+		color: $gray-400;
+	}
 	.edit-site-patterns__sync-status-filter-option:active {
 		background: $gray-700;
 		color: $gray-100;

--- a/packages/edit-site/src/components/page-patterns/style.scss
+++ b/packages/edit-site/src/components/page-patterns/style.scss
@@ -58,7 +58,7 @@
 		}
 	}
 	.edit-site-patterns__sync-status-filter-option:not([aria-checked="true"]) {
-		color: $gray-400;
+		color: $gray-600;
 	}
 	.edit-site-patterns__sync-status-filter-option:active {
 		background: $gray-700;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
In Appearance > Editor > Patterns > My patterns, the inactive options in the toggle group control for the synced status does not have a high enough color contrast to pass WCAG 2 AA:

Text: #757575
Background: #2F2F2F
Contrast Ratio: 2.9:1

Required: 3:1
Preferred: 4.5:1

This PR changes the text color to #949494 with the contrast ratio 4.41:1 against the background.

Closes https://github.com/WordPress/gutenberg/issues/52555

## Testing Instructions
Add at least one user-created pattern.
Go to Appearance > Editor > Patterns > My patterns.
Check that the button text for the options All, Synced and Standard are readable.

## Screenshots or screencast <!-- if applicable -->
After:
<img width="1163" alt="Toggle group buttons on the My patterns page" src="https://github.com/WordPress/gutenberg/assets/7422055/0d2834e1-45bc-496d-a0ba-ac6e15f0b49f">


