### PR TITLE
Rich Text/Footnotes: fix getRichTextValues for useInnerBlocksProps.save

### DIFF
--- a/packages/block-editor/src/components/rich-text/get-rich-text-values.js
+++ b/packages/block-editor/src/components/rich-text/get-rich-text-values.js
@@ -78,22 +78,20 @@ function addValuesForElements( children, ...args ) {
 	}
 }
 
-function _getSaveElement( { name, attributes, innerBlocks } ) {
+function _getSaveElement( name, attributes, innerBlocks ) {
 	return getSaveElement(
 		name,
 		attributes,
-		innerBlocks.map( _getSaveElement )
+		innerBlocks.map( ( block ) =>
+			_getSaveElement( block.name, block.attributes, block.innerBlocks )
+		)
 	);
 }
 
 function addValuesForBlocks( values, blocks ) {
 	for ( let i = 0; i < blocks.length; i++ ) {
 		const { name, attributes, innerBlocks } = blocks[ i ];
-		const saveElement = _getSaveElement( {
-			name,
-			attributes,
-			innerBlocks,
-		} );
+		const saveElement = _getSaveElement( name, attributes, innerBlocks );
 		addValuesForElement( saveElement, values, innerBlocks );
 	}
 }

--- a/packages/block-editor/src/components/rich-text/get-rich-text-values.js
+++ b/packages/block-editor/src/components/rich-text/get-rich-text-values.js
@@ -78,10 +78,22 @@ function addValuesForElements( children, ...args ) {
 	}
 }
 
+function _getSaveElement( { name, attributes, innerBlocks } ) {
+	return getSaveElement(
+		name,
+		attributes,
+		innerBlocks.map( _getSaveElement )
+	);
+}
+
 function addValuesForBlocks( values, blocks ) {
 	for ( let i = 0; i < blocks.length; i++ ) {
 		const { name, attributes, innerBlocks } = blocks[ i ];
-		const saveElement = getSaveElement( name, attributes );
+		const saveElement = _getSaveElement( {
+			name,
+			attributes,
+			innerBlocks,
+		} );
 		addValuesForElement( saveElement, values, innerBlocks );
 	}
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

In #52628 I forgot to pass down the inner blocks' save elements to getSaveElement, in case they would be used by `useInnerBlocksProps.save`.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Fixes #52628, #52383.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Note the code that was deleted in #52241:

https://github.com/WordPress/gutenberg/pull/52241/files#diff-3f6f14a10be0a5da5f60b7fb8be5d5f8d5acf92599cb3218eec63394ac8125b6L70-L76

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
