### PR TITLE
Site Editor: Fix incorrect 'useSelect' usage

### DIFF
--- a/packages/edit-site/src/components/save-panel/index.js
+++ b/packages/edit-site/src/components/save-panel/index.js
@@ -39,13 +39,19 @@ const EntitiesSavedStatesForPreview = ( { onClose } ) => {
 		activateSaveLabel = __( 'Activate' );
 	}
 
-	const { getTheme } = useSelect( coreStore );
-	const theme = getTheme( currentlyPreviewingTheme() );
+	const themeName = useSelect( ( select ) => {
+		const theme = select( coreStore ).getTheme(
+			currentlyPreviewingTheme()
+		);
+
+		return theme?.name?.rendered;
+	}, [] );
+
 	const additionalPrompt = (
 		<p>
 			{ sprintf(
-				'Saving your changes will change your active theme to  %1$s.',
-				theme?.name?.rendered
+				'Saving your changes will change your active theme to %s.',
+				themeName
 			) }
 		</p>
 	);


### PR DESCRIPTION
## What?
This is a follow-up to #50863.

PR fixes an incorrect `useSelect` usage in the `EntitiesSavedStatesForPreview` component.

## Why?
The render function shouldn't call the selectors directly to avoid stale values. While state values will rarely visible in this case, it promotes a bad practice in the core.

See: https://developer.wordpress.org/block-editor/reference-guides/packages/packages-data/#useselect

## Testing Instructions
1. Use the "Live Preview" feature on a block theme.
2. Make changes to a template.
3. Click on "Activate & Save".
4. Confirm it works as before and displays the correct theme name.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2023-07-17 at 15 43 23](https://github.com/WordPress/gutenberg/assets/240569/b4a80e13-48b2-4732-80e4-c26efa893717)
