### PR TITLE
Footnotes: store in revisions

### DIFF
--- a/packages/block-library/src/footnotes/index.php
+++ b/packages/block-library/src/footnotes/index.php
@@ -59,7 +59,7 @@ function render_block_core_footnotes( $attributes, $content, $block ) {
  * Registers the `core/footnotes` block on the server.
  */
 function register_block_core_footnotes() {
-	foreach ( array( 'post', 'page', 'revision' ) as $post_type ) {
+	foreach ( array( 'post', 'page' ) as $post_type ) {
 		register_post_meta(
 			$post_type,
 			'footnotes',

--- a/packages/block-library/src/footnotes/index.php
+++ b/packages/block-library/src/footnotes/index.php
@@ -84,39 +84,62 @@ add_action( 'init', 'register_block_core_footnotes' );
 remove_action( 'post_updated', 'wp_save_post_revision', 10, 1 );
 add_action( 'wp_after_insert_post', 'wp_save_post_revision', 10, 1 );
 
+/**
+ * Saves the footnotes meta value to the revision.
+ *
+ * @param int $revision_id The revision ID.
+ */
 function gutenberg_save_footnotes_meta( $revision_id ) {
-    $post_id = wp_is_post_revision( $revision_id );
+	$post_id = wp_is_post_revision( $revision_id );
 
-    if ( $post_id ) {
-        $footnotes = get_post_meta( $post_id, 'footnotes', true );
+	if ( $post_id ) {
+		$footnotes = get_post_meta( $post_id, 'footnotes', true );
 
-        if ( $footnotes ) {
+		if ( $footnotes ) {
 			// Can't use update_post_meta() because it doesn't allow revisions.
-            update_metadata( 'post', $revision_id, 'footnotes', $footnotes );
-        }
-    }
+			update_metadata( 'post', $revision_id, 'footnotes', $footnotes );
+		}
+	}
 }
 add_action( 'wp_after_insert_post', 'gutenberg_save_footnotes_meta' );
 
+/**
+ * Restores the footnotes meta value from the revision.
+ *
+ * @param int $post_id      The post ID.
+ * @param int $revision_id  The revision ID.
+ */
 function gutenberg_restore_footnotes_meta( $post_id, $revision_id ) {
-    $footnotes = get_post_meta( $revision_id, 'footnotes', true );
+	$footnotes = get_post_meta( $revision_id, 'footnotes', true );
 
-    if ( $footnotes ) {
-        update_post_meta( $post_id, 'footnotes', $footnotes );
-    } else {
-        delete_post_meta( $post_id, 'footnotes' );
-    }
+	if ( $footnotes ) {
+		update_post_meta( $post_id, 'footnotes', $footnotes );
+	} else {
+		delete_post_meta( $post_id, 'footnotes' );
+	}
 }
 add_action( 'wp_restore_post_revision', 'gutenberg_restore_footnotes_meta', 10, 2 );
 
+/**
+ * Adds the footnotes field to the revision.
+ *
+ * @param array $fields The revision fields.
+ *
+ * @return array The revision fields.
+ */
 function gutenberg_revision_fields( $fields ) {
-    $fields['footnotes'] = __( 'Footnotes' );
-    return $fields;
+	$fields['footnotes'] = __( 'Footnotes' );
+	return $fields;
 }
 add_filter( '_wp_post_revision_fields', 'gutenberg_revision_fields' );
 
-function gutenberg_revision_field_footnotes( $value, $field ) {
-    global $revision;
-    return get_metadata( 'post', $revision->ID, $field, true );
+/**
+ * Gets the footnotes field from the revision.
+ *
+ * @return string The field value.
+ */
+function gutenberg_revision_field_footnotes() {
+	global $revision;
+	return get_metadata( 'post', $revision->ID, 'footnotes', true );
 }
-add_filter( 'wp_post_revision_field_footnotes', 'gutenberg_revision_field_footnotes', 10, 2 );
+add_filter( 'wp_post_revision_field_footnotes', 'gutenberg_revision_field_footnotes' );

--- a/packages/block-library/src/footnotes/index.php
+++ b/packages/block-library/src/footnotes/index.php
@@ -178,10 +178,14 @@ add_filter( '_wp_post_revision_fields', 'gutenberg_revision_fields' );
 /**
  * Gets the footnotes field from the revision.
  *
+ * @param string $revision_field The field value, but $revision->$field
+ *                               (footnotes) does not exist.
+ * @param string $field          The field name, in this case "footnotes".
+ * @param object $revision       The revision object to compare against.
+ *
  * @return string The field value.
  */
-function gutenberg_revision_field_footnotes() {
-	global $revision;
-	return get_metadata( 'post', $revision->ID, 'footnotes', true );
+function gutenberg_revision_field_footnotes( $revision_field, $field, $revision ) {
+	return get_metadata( 'post', $revision->ID, $field, true );
 }
 add_filter( 'wp_post_revision_field_footnotes', 'gutenberg_revision_field_footnotes' );

--- a/packages/block-library/src/footnotes/index.php
+++ b/packages/block-library/src/footnotes/index.php
@@ -79,113 +79,128 @@ function register_block_core_footnotes() {
 }
 add_action( 'init', 'register_block_core_footnotes' );
 
-/**
- * Saves the footnotes meta value to the revision.
- *
- * @param int $revision_id The revision ID.
- */
-function gutenberg_save_footnotes_meta( $revision_id ) {
-	$post_id = wp_is_post_revision( $revision_id );
+add_action(
+	'wp_after_insert_post',
+	/**
+	 * Saves the footnotes meta value to the revision.
+	 *
+	 * @param int $revision_id The revision ID.
+	 */
+	function( $revision_id ) {
+		$post_id = wp_is_post_revision( $revision_id );
 
-	if ( $post_id ) {
-		$footnotes = get_post_meta( $post_id, 'footnotes', true );
-
-		if ( $footnotes ) {
-			// Can't use update_post_meta() because it doesn't allow revisions.
-			update_metadata( 'post', $revision_id, 'footnotes', $footnotes );
-		}
-	}
-}
-add_action( 'wp_after_insert_post', 'gutenberg_save_footnotes_meta' );
-
-/**
- * Keeps track of the revision ID for "rest_after_insert_{$post_type}".
- *
- * @param int $revision_id The revision ID.
- */
-function gutenberg_wp_put_post_revision( $revision_id ) {
-	global $_gutenberg_revision_id;
-	$_gutenberg_revision_id = $revision_id;
-}
-
-add_action( '_wp_put_post_revision', 'gutenberg_wp_put_post_revision' );
-
-/**
- * This is a specific fix for the REST API. The REST API doesn't update the post
- * and post meta in one go (through `meta_input`). While it does fix the
- * `wp_after_insert_post` hook to be called correctly after updating meta, it
- * does NOT fix hooks such as post_updated and save_post, which are normally
- * also fired after post meta is updated in `wp_insert_post()`. Unfortunately,
- * `wp_save_post_revision` is added to the `post_updated` action, which means
- * the meta is not available at the time, so we have to add it afterwards
- * through the `"rest_after_insert_{$post_type}"` action.
- *
- * @param WP_Post $post The post object.
- */
-function gutenberg_save_footnotes_meta_rest_api( $post ) {
-	global $_gutenberg_revision_id;
-
-	if ( $_gutenberg_revision_id ) {
-		$revision = get_post( $_gutenberg_revision_id );
-		$post_id  = $revision->post_parent;
-
-		// Just making sure we're updating the right revision.
-		if ( $post->ID === $post_id ) {
+		if ( $post_id ) {
 			$footnotes = get_post_meta( $post_id, 'footnotes', true );
 
 			if ( $footnotes ) {
 				// Can't use update_post_meta() because it doesn't allow revisions.
-				update_metadata( 'post', $_gutenberg_revision_id, 'footnotes', $footnotes );
+				update_metadata( 'post', $revision_id, 'footnotes', $footnotes );
 			}
 		}
 	}
-}
+);
+
+add_action(
+	'_wp_put_post_revision',
+	/**
+	 * Keeps track of the revision ID for "rest_after_insert_{$post_type}".
+	 *
+	 * @param int $revision_id The revision ID.
+	 */
+	function( $revision_id ) {
+		global $_gutenberg_revision_id;
+		$_gutenberg_revision_id = $revision_id;
+	}
+);
 
 foreach ( array( 'post', 'page' ) as $post_type ) {
-	add_action( "rest_after_insert_{$post_type}", 'gutenberg_save_footnotes_meta_rest_api' );
+	add_action(
+		"rest_after_insert_{$post_type}",
+		/**
+		 * This is a specific fix for the REST API. The REST API doesn't update
+		 * the post and post meta in one go (through `meta_input`). While it
+		 * does fix the `wp_after_insert_post` hook to be called correctly after
+		 * updating meta, it does NOT fix hooks such as post_updated and
+		 * save_post, which are normally also fired after post meta is updated
+		 * in `wp_insert_post()`. Unfortunately, `wp_save_post_revision` is
+		 * added to the `post_updated` action, which means the meta is not
+		 * available at the time, so we have to add it afterwards through the
+		 * `"rest_after_insert_{$post_type}"` action.
+		 *
+		 * @param WP_Post $post The post object.
+		 */
+		function( $post ) {
+			global $_gutenberg_revision_id;
+
+			if ( $_gutenberg_revision_id ) {
+				$revision = get_post( $_gutenberg_revision_id );
+				$post_id  = $revision->post_parent;
+
+				// Just making sure we're updating the right revision.
+				if ( $post->ID === $post_id ) {
+					$footnotes = get_post_meta( $post_id, 'footnotes', true );
+
+					if ( $footnotes ) {
+						// Can't use update_post_meta() because it doesn't allow revisions.
+						update_metadata( 'post', $_gutenberg_revision_id, 'footnotes', $footnotes );
+					}
+				}
+			}
+		}
+	);
 }
 
-/**
- * Restores the footnotes meta value from the revision.
- *
- * @param int $post_id      The post ID.
- * @param int $revision_id  The revision ID.
- */
-function gutenberg_restore_footnotes_meta( $post_id, $revision_id ) {
-	$footnotes = get_post_meta( $revision_id, 'footnotes', true );
+add_action(
+	'wp_restore_post_revision', 
+	/**
+	 * Restores the footnotes meta value from the revision.
+	 *
+	 * @param int $post_id      The post ID.
+	 * @param int $revision_id  The revision ID.
+	 */
+	function( $post_id, $revision_id ) {
+		$footnotes = get_post_meta( $revision_id, 'footnotes', true );
 
-	if ( $footnotes ) {
-		update_post_meta( $post_id, 'footnotes', $footnotes );
-	} else {
-		delete_post_meta( $post_id, 'footnotes' );
+		if ( $footnotes ) {
+			update_post_meta( $post_id, 'footnotes', $footnotes );
+		} else {
+			delete_post_meta( $post_id, 'footnotes' );
+		}
+	},
+	10,
+	2
+);
+
+add_filter(
+	'_wp_post_revision_fields',
+	/**
+	 * Adds the footnotes field to the revision.
+	 *
+	 * @param array $fields The revision fields.
+	 *
+	 * @return array The revision fields.
+	 */
+	function( $fields ) {
+		$fields['footnotes'] = __( 'Footnotes' );
+		return $fields;
 	}
-}
-add_action( 'wp_restore_post_revision', 'gutenberg_restore_footnotes_meta', 10, 2 );
+);
 
-/**
- * Adds the footnotes field to the revision.
- *
- * @param array $fields The revision fields.
- *
- * @return array The revision fields.
- */
-function gutenberg_revision_fields( $fields ) {
-	$fields['footnotes'] = __( 'Footnotes' );
-	return $fields;
-}
-add_filter( '_wp_post_revision_fields', 'gutenberg_revision_fields' );
-
-/**
- * Gets the footnotes field from the revision.
- *
- * @param string $revision_field The field value, but $revision->$field
- *                               (footnotes) does not exist.
- * @param string $field          The field name, in this case "footnotes".
- * @param object $revision       The revision object to compare against.
- *
- * @return string The field value.
- */
-function gutenberg_revision_field_footnotes( $revision_field, $field, $revision ) {
-	return get_metadata( 'post', $revision->ID, $field, true );
-}
-add_filter( 'wp_post_revision_field_footnotes', 'gutenberg_revision_field_footnotes' );
+add_filter(
+	'wp_post_revision_field_footnotes',
+	/**
+	 * Gets the footnotes field from the revision.
+	 *
+	 * @param string $revision_field The field value, but $revision->$field
+	 *                               (footnotes) does not exist.
+	 * @param string $field          The field name, in this case "footnotes".
+	 * @param object $revision       The revision object to compare against.
+	 *
+	 * @return string The field value.
+	 */
+	function( $revision_field, $field, $revision ) {
+		return get_metadata( 'post', $revision->ID, $field, true );
+	},
+	10,
+	3
+);

--- a/packages/block-library/src/footnotes/index.php
+++ b/packages/block-library/src/footnotes/index.php
@@ -151,7 +151,7 @@ foreach ( array( 'post', 'page' ) as $post_type ) {
 }
 
 add_action(
-	'wp_restore_post_revision', 
+	'wp_restore_post_revision',
 	/**
 	 * Restores the footnotes meta value from the revision.
 	 *

--- a/packages/block-library/src/footnotes/index.php
+++ b/packages/block-library/src/footnotes/index.php
@@ -59,7 +59,7 @@ function render_block_core_footnotes( $attributes, $content, $block ) {
  * Registers the `core/footnotes` block on the server.
  */
 function register_block_core_footnotes() {
-	foreach ( array( 'post', 'page' ) as $post_type ) {
+	foreach ( array( 'post', 'page', 'revision' ) as $post_type ) {
 		register_post_meta(
 			$post_type,
 			'footnotes',
@@ -78,3 +78,45 @@ function register_block_core_footnotes() {
 	);
 }
 add_action( 'init', 'register_block_core_footnotes' );
+
+// Revisions must be created after post meta is updated, otherwise we don't have
+// access to the meta.
+remove_action( 'post_updated', 'wp_save_post_revision', 10, 1 );
+add_action( 'wp_after_insert_post', 'wp_save_post_revision', 10, 1 );
+
+function gutenberg_save_footnotes_meta( $revision_id ) {
+    $post_id = wp_is_post_revision( $revision_id );
+
+    if ( $post_id ) {
+        $footnotes = get_post_meta( $post_id, 'footnotes', true );
+
+        if ( $footnotes ) {
+			// Can't use update_post_meta() because it doesn't allow revisions.
+            update_metadata( 'post', $revision_id, 'footnotes', $footnotes );
+        }
+    }
+}
+add_action( 'wp_after_insert_post', 'gutenberg_save_footnotes_meta' );
+
+function gutenberg_restore_footnotes_meta( $post_id, $revision_id ) {
+    $footnotes = get_post_meta( $revision_id, 'footnotes', true );
+
+    if ( $footnotes ) {
+        update_post_meta( $post_id, 'footnotes', $footnotes );
+    } else {
+        delete_post_meta( $post_id, 'footnotes' );
+    }
+}
+add_action( 'wp_restore_post_revision', 'gutenberg_restore_footnotes_meta', 10, 2 );
+
+function gutenberg_revision_fields( $fields ) {
+    $fields['footnotes'] = __( 'Footnotes' );
+    return $fields;
+}
+add_filter( '_wp_post_revision_fields', 'gutenberg_revision_fields' );
+
+function gutenberg_revision_field_footnotes( $value, $field ) {
+    global $revision;
+    return get_metadata( 'post', $revision->ID, $field, true );
+}
+add_filter( 'wp_post_revision_field_footnotes', 'gutenberg_revision_field_footnotes', 10, 2 );

--- a/packages/block-library/src/footnotes/index.php
+++ b/packages/block-library/src/footnotes/index.php
@@ -98,8 +98,6 @@ function gutenberg_save_footnotes_meta( $revision_id ) {
 }
 add_action( 'wp_after_insert_post', 'gutenberg_save_footnotes_meta' );
 
-$_gutenberg_revision_id = null;
-
 /**
  * Keeps track of the revision ID for "rest_after_insert_{$post_type}".
  *
@@ -129,7 +127,7 @@ function gutenberg_save_footnotes_meta_rest_api( $post ) {
 
 	if ( $_gutenberg_revision_id ) {
 		$revision = get_post( $_gutenberg_revision_id );
-		$post_id = $revision->post_parent;
+		$post_id  = $revision->post_parent;
 
 		// Just making sure we're updating the right revision.
 		if ( $post->ID === $post_id ) {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Fixes #52541. Currently footnotes are not stored in revisions because it's post meta.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

We should store them, otherwise footnotes are lost and links become broken.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

When a revision is added, update the revision meta. When restoring a revision, also restore the meta.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

Create a post with footnotes. Then update the content and update a footnote or add/remove one. Now restore a previous revision.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

![fn-revision](https://github.com/WordPress/gutenberg/assets/4710635/c079bf7f-fcdf-4911-9a8e-b441851fce50)

