### PR TITLE
Fix: Navigation block is broken when focus is applied to the ellipsis menu in the block sidebar

### DIFF
--- a/packages/block-library/src/navigation/edit/navigation-menu-selector.js
+++ b/packages/block-library/src/navigation/edit/navigation-menu-selector.js
@@ -102,7 +102,7 @@ function NavigationMenuSelector( {
 		selectorLabel = __( 'Choose or create a Navigation menu' );
 	} else {
 		// Current Menu's title.
-		selectorLabel = currentTitle;
+		selectorLabel = currentTitle?.rendered || currentTitle;
 	}
 
 	useEffect( () => {


### PR DESCRIPTION
Fixes: #52691

## What?

This PR fixes a problem in the sidebar of the navigation block where the block breaks when focus is placed on the topmost ellipsis menu.

https://github.com/WordPress/gutenberg/assets/54422211/4425133d-2af8-4ffc-a6cf-04c3a509c7b9

## Why?

The direct cause is that the object is passed to the text of the `ToolTip` component. The `currentTitle` that this PR is modifying is used in this text.

![tooltip](https://github.com/WordPress/gutenberg/assets/54422211/919a2bda-90b1-4d03-a2bd-314677a76627)

My guess is that when the default navigation embedded in the theme's template is rendered by the site editor, its title will be an object with the rendered property because it is processed server-side.

## How?
I have made the `rendered` property the preferred title.

## Testing Instructions

- You will probably need to initialize the site if you have customized the template or navigation.
- Open the Site editor.
- Select a Navigation block.
- Mouse over the Navigation button on the right side of the Menu page.
- trunk: the block is broken
- This PR: the block should not be broken and should shou the tooltip.
