### PR TITLE
Fix multiple navigation blocks in pattern template

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen-pattern/use-navigation-menu-content.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-pattern/use-navigation-menu-content.js
@@ -59,13 +59,20 @@ export default function useNavigationMenuContent( postType, postId ) {
 		record?.blocks
 	);
 
+	if ( ! navigationBlocks.length ) {
+		return;
+	}
+
 	const navigationMenuIds = navigationBlocks?.map(
 		( block ) => block.attributes.ref
 	);
 
-	if ( ! navigationMenuIds?.length ) {
+	// Dedupe the Navigation blocks, as you can have multiple in the same template part.
+	const uniqueNavigationMenuIds = [ ...new Set( navigationMenuIds ) ];
+
+	if ( ! uniqueNavigationMenuIds?.length ) {
 		return;
 	}
 
-	return <TemplatePartNavigationMenus menus={ navigationMenuIds } />;
+	return <TemplatePartNavigationMenus menus={ uniqueNavigationMenuIds } />;
 }

--- a/packages/edit-site/src/components/sidebar-navigation-screen-pattern/use-navigation-menu-content.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-pattern/use-navigation-menu-content.js
@@ -67,8 +67,11 @@ export default function useNavigationMenuContent( postType, postId ) {
 		( block ) => block.attributes.ref
 	);
 
-	// Dedupe the Navigation blocks, as you can have multiple in the same template part.
-	const uniqueNavigationMenuIds = [ ...new Set( navigationMenuIds ) ];
+	// Dedupe the Navigation blocks, as you can have multiple navigation blocks in the template.
+	// Also, filter out undefined values, as blocks don't have an id when initially added.
+	const uniqueNavigationMenuIds = [ ...new Set( navigationMenuIds ) ].filter(
+		( menuId ) => menuId
+	);
 
 	if ( ! uniqueNavigationMenuIds?.length ) {
 		return;


### PR DESCRIPTION
If the same navigation block was present in a template, the editor would crash since it was trying to generate a sidebar navigation item for the same keyed item. This dedupes and removes invalid navigation menu ID values before passing it to `<TemplatePartNavigationMenus />`.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
1. In the Site Editor, go to Patterns > Template Parts > Header
2. Switch to the Code Editor
3. Copy/Paste the navigation menu block code so you have two navigation blocks on the template
4. Save
5. Reload. 
6. Check that the editor does not crash with duplicate menus
7. Open the sidebar of the site editor (click the top left W or Site logo)
8. The sidebar editor should only have one navigation menu
9. Add a new navigation block to the template via the block appender
10. The editor should not crash at any point.
