### PR TITLE
Use `_get_block_template_file` function and set $area variable.

### DIFF
--- a/packages/block-library/src/template-part/index.php
+++ b/packages/block-library/src/template-part/index.php
@@ -18,12 +18,11 @@ function render_block_core_template_part( $attributes ) {
 	$template_part_id = null;
 	$content          = null;
 	$area             = WP_TEMPLATE_PART_AREA_UNCATEGORIZED;
-	$stylesheet       = get_stylesheet();
 
 	if (
 		isset( $attributes['slug'] ) &&
 		isset( $attributes['theme'] ) &&
-		$stylesheet === $attributes['theme']
+		get_stylesheet() === $attributes['theme']
 	) {
 		$template_part_id    = $attributes['theme'] . '//' . $attributes['slug'];
 		$template_part_query = new WP_Query(
@@ -64,23 +63,16 @@ function render_block_core_template_part( $attributes ) {
 			 */
 			do_action( 'render_block_core_template_part_post', $template_part_id, $attributes, $template_part_post, $content );
 		} else {
+			$template_part_file_path = '';
 			// Else, if the template part was provided by the active theme,
 			// render the corresponding file content.
 			if ( 0 === validate_file( $attributes['slug'] ) ) {
-				$themes   = array( $stylesheet );
-				$template = get_template();
-				if ( $stylesheet !== $template ) {
-					$themes[] = $template;
-				}
-
-				foreach ( $themes as $theme ) {
-					$theme_folders           = get_block_theme_folders( $theme );
-					$template_part_file_path = get_theme_file_path( '/' . $theme_folders['wp_template_part'] . '/' . $attributes['slug'] . '.html' );
-					if ( file_exists( $template_part_file_path ) ) {
-						$content = (string) file_get_contents( $template_part_file_path );
-						$content = '' !== $content ? _inject_theme_attribute_in_block_template_content( $content ) : '';
-						break;
-					}
+				$block_template_file = _get_block_template_file( 'wp_template_part', $attributes['slug'] );
+				if ( $block_template_file ) {
+					$template_part_file_path = $block_template_file['path'];
+					$content                 = (string) file_get_contents( $template_part_file_path );
+					$content                 = '' !== $content ? _inject_theme_attribute_in_block_template_content( $content ) : '';
+					$area                    = isset( $block_template_file['area'] ) ? $block_template_file['area'] : WP_TEMPLATE_PART_AREA_UNCATEGORIZED;
 				}
 			}
 

--- a/packages/block-library/src/template-part/index.php
+++ b/packages/block-library/src/template-part/index.php
@@ -72,7 +72,9 @@ function render_block_core_template_part( $attributes ) {
 					$template_part_file_path = $block_template_file['path'];
 					$content                 = (string) file_get_contents( $template_part_file_path );
 					$content                 = '' !== $content ? _inject_theme_attribute_in_block_template_content( $content ) : '';
-					$area                    = isset( $block_template_file['area'] ) ? $block_template_file['area'] : WP_TEMPLATE_PART_AREA_UNCATEGORIZED;
+					if ( isset( $block_template_file['area'] ) ) {
+						$area = $block_template_file['area'];
+					}
 				}
 			}
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fix for [#58770](https://core.trac.wordpress.org/ticket/58770). 

Use `_get_block_template_file`, the util function to get path of block template file. This function returns an array of data that includes the area. A valid area is needed for the following line. 

```
$content = wp_filter_content_tags( $content, "template_part_{$area}" );
```

With a valid error type, this results in lazy loading attribute being added to header images. 

For extra context 
https://github.com/WordPress/wordpress-develop/blob/2e64ff87b847284a8235c190731266e620466206/src/wp-includes/media.php#L5682-L5687

https://github.com/WordPress/wordpress-develop/commit/87c575a9fcfd9b266365834545da5fcfa5f788e2

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions

Taken from https://core.trac.wordpress.org/ticket/58770:

> Images in block themes are not applying the image attributes correctly. While testing the following behaviours were noticed.
> 
> - Site logos in header of page, having loading="lazy".
> - Image in header, not having fetch priority = high. Also not no lazy loading image.
> - Image block hardcode into patterns not either loading and fetch priority attributes.
> 
> Steps to replicate:
> 
> Activate TT2 theme.
> 

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
