### PR TITLE
Footnotes: backport core changes to excerpt trim

### DIFF
--- a/lib/compat/wordpress-6.3/footnotes.php
+++ b/lib/compat/wordpress-6.3/footnotes.php
@@ -18,8 +18,15 @@ function gutenberg_trim_footnotes( $content ) {
 		return $content;
 	}
 
-	static $footnote_pattern = '_<sup data-fn="[^"]+" class="[^"]+">\s*<a href="[^"]+" id="[^"]+">\d+</a>\s*</sup>_';
-	return preg_replace( $footnote_pattern, '', $content );
+	if ( ! str_contains( $content, 'data-fn=' ) ) {
+		return $content;
+	}
+
+	return preg_replace(
+		'_<sup data-fn="[^"]+" class="[^"]+">\s*<a href="[^"]+" id="[^"]+">\d+</a>\s*</sup>_',
+		'',
+		$content
+	);
 }
 
 add_filter( 'the_content', 'gutenberg_trim_footnotes' );


### PR DESCRIPTION
## What?

A `preg_replace` to remove footnote anchors was introduced in:

- https://github.com/WordPress/gutenberg/pull/52518

The changes were backported to Core in https://github.com/WordPress/wordpress-develop/pull/4845 with some modifications.

This PR syncs those modifications in the plugin.

## Why?
Keep things up to date!


## Testing Instructions

There should be no regressions from https://github.com/WordPress/gutenberg/pull/52518

1. Create a post with some footnotes
2. In the site editor, check the template where your latest posts are displayed. Ensure the footnotes marker (the numbers, like `1`, `2`, do not appear in the excerpt).
3. Check the frontend as well.


