### PR TITLE
Return focus more from focus return hook

### DIFF
--- a/packages/compose/README.md
+++ b/packages/compose/README.md
@@ -323,7 +323,7 @@ _Returns_
 
 ### useFocusReturn
 
-When opening modals/sidebars/dialogs, the focus must move to the opened area and return to the previously focused element when closed. The current hook implements the returning behavior.
+Adds the unmount behavior of returning focus to the element which had it previously as is expected for roles like menus or dialogs.
 
 _Usage_
 

--- a/packages/compose/src/hooks/use-focus-return/index.js
+++ b/packages/compose/src/hooks/use-focus-return/index.js
@@ -3,11 +3,12 @@
  */
 import { useRef, useEffect, useCallback } from '@wordpress/element';
 
+/** @type {Element|null} */
+let origin = null;
+
 /**
- * When opening modals/sidebars/dialogs, the focus
- * must move to the opened area and return to the
- * previously focused element when closed.
- * The current hook implements the returning behavior.
+ * Adds the unmount behavior of returning focus to the element which had it
+ * previously as is expected for roles like menus or dialogs.
  *
  * @param {() => void} [onFocusReturn] Overrides the default return behavior.
  * @return {import('react').RefCallback<HTMLElement>} Element Ref.
@@ -54,6 +55,7 @@ function useFocusReturn( onFocusReturn ) {
 			);
 
 			if ( ref.current?.isConnected && ! isFocused ) {
+				origin ??= focusedBeforeMount.current;
 				return;
 			}
 
@@ -64,10 +66,13 @@ function useFocusReturn( onFocusReturn ) {
 			if ( onFocusReturnRef.current ) {
 				onFocusReturnRef.current();
 			} else {
-				/** @type {null | HTMLElement} */ (
-					focusedBeforeMount.current
+				/** @type {null|HTMLElement} */ (
+					! focusedBeforeMount.current.isConnected
+						? origin
+						: focusedBeforeMount.current
 				)?.focus();
 			}
+			origin = null;
 		}
 	}, [] );
 }


### PR DESCRIPTION
## What?
Supports sequential dialogs sharing the element to which focus should return once the last dialog is dismissed.

## Why?
With the introduction of the command palette and its commands that launch other dialogs there is now greater potential for exposure to focus loss from successive dialogs. This addresses part of #52301.

## How?
Updates the compose package’s focus return hook to track the first focus origin and fallback to returning focus there as appropriate.

## Testing Instructions for Keyboard
1. Open the Post/Site Editor
2. Use the keyboard shortcut to launch the command palette and use it to open the Editor Preferences.
3. Press <kbd>esc</kbd> to close the Editor Preferences
4. Verify that focus wasn’t lost by using the keyboard shortcut to launch the command palette again.

## Screenshots or screencast <!-- if applicable -->
### Before

https://github.com/WordPress/gutenberg/assets/9000376/77e574ba-95da-4fb9-9af3-b7e85a28825e

### After

https://github.com/WordPress/gutenberg/assets/9000376/3631b704-5b48-4a8a-b87a-51ebf4ee2ff2


