### PR TITLE
Spacing Sizes: Fix zero size typo and to be output directly

### DIFF
--- a/packages/block-editor/src/components/spacing-sizes-control/hooks/use-spacing-sizes.js
+++ b/packages/block-editor/src/components/spacing-sizes-control/hooks/use-spacing-sizes.js
@@ -10,7 +10,7 @@ import useSetting from '../../use-setting';
 
 export default function useSpacingSizes() {
 	const spacingSizes = [
-		{ name: 0, slug: '0', side: 0 },
+		{ name: 0, slug: '0', size: 0 },
 		...( useSetting( 'spacing.spacingSizes' ) || [] ),
 	];
 

--- a/packages/block-editor/src/components/spacing-sizes-control/utils.js
+++ b/packages/block-editor/src/components/spacing-sizes-control/utils.js
@@ -102,7 +102,7 @@ export function getCustomValueFromPreset( value, spacingSizes ) {
  */
 export function getPresetValueFromCustomValue( value, spacingSizes ) {
 	// Return value as-is if it is already a preset;
-	if ( isValueSpacingPreset( value ) ) {
+	if ( isValueSpacingPreset( value ) || value === '0' ) {
 		return value;
 	}
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fix typo in the spacing sizes' `0` size — the key should be `size`, not `side`.

Then, in `getPresetValueFromCustomValue` return `value` if it is `0`.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The expected behaviour for the spacing size's `0` size is for it to be output directly as `0` and not use a CSS variable. 

This currently happens on `trunk` due to an accident where the `0` size has a key of `side` (typo), so `getPresetValueFromCustomValue` never finds a match to the preset if the value is `0`, and the value gets returned. However, over in https://github.com/WordPress/gutenberg/pull/52661 it's possible that `getPresetValueFromCustomValue` will be called with `undefined`, which _does_ accidentally match against the erroneous size with key `side` as that preset's `size` value evaluates to `undefined`, creating a match between `undefined` and `undefined`.

With this PR, the `size` for the `0` preset is correctly set to `0`, and `getPresetValueFromCustomValue` is updated to explicitly return `value` when `0` is the value, as that was the expected behaviour on `trunk`. That is — for spacing sizes, someone setting to the `0` preset should result in e.g. `padding-left: 0` being applied directly.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* Update the spacing size's `0` preset to use `size: 0` (fix the typo)
* In `getPresetValueFromCustomValue` treat `0` as a direct value (skip looking up the presets) — this is because we don't output the `0` preset on the site frontend, rather it's expected that the value will be used directly.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. In a post or template add a Group block.
2. Set the Group block's padding (or any other spacing) to the `0` position via the spacing controls slider.
3. Switch to the code view, and you should see that the `0` CSS rules are output as on `trunk`.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

The expected markup of setting padding top/bottom to the `0` position:

![image](https://github.com/WordPress/gutenberg/assets/14988353/43c12c0f-1bca-4dd0-a228-8ef7ceb5ed46)


