### PR TITLE
Reusable blocks: update package to use relative path

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18572,7 +18572,7 @@
 				"@wordpress/i18n": "file:packages/i18n",
 				"@wordpress/icons": "file:packages/icons",
 				"@wordpress/notices": "file:packages/notices",
-				"@wordpress/private-apis": "^0.19.0",
+				"@wordpress/private-apis": "file:packages/private-apis",
 				"@wordpress/url": "file:packages/url"
 			}
 		},

--- a/packages/reusable-blocks/package.json
+++ b/packages/reusable-blocks/package.json
@@ -37,7 +37,7 @@
 		"@wordpress/i18n": "file:../i18n",
 		"@wordpress/icons": "file:../icons",
 		"@wordpress/notices": "file:../notices",
-		"@wordpress/private-apis": "^0.19.0",
+		"@wordpress/private-apis": "file:../private-apis",
 		"@wordpress/url": "file:../url"
 	},
 	"peerDependencies": {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Use relative path internally to include packages in dependencies

## Why?
So we're using the latest packages, and not those in NPM

## How?
Copy, paste. A bit of typing.

## Testing
The test steps in https://github.com/WordPress/gutenberg/pull/52664 should still work as expected, no regressions.
