### PR TITLE
Patterns: Don't override the rootClientID  in create menu - only set if undefined

### DIFF
--- a/packages/reusable-blocks/src/components/reusable-blocks-menu-items/index.js
+++ b/packages/reusable-blocks/src/components/reusable-blocks-menu-items/index.js
@@ -11,8 +11,9 @@ import ReusableBlockConvertButton from './reusable-block-convert-button';
 import ReusableBlocksManageButton from './reusable-blocks-manage-button';
 
 export default function ReusableBlocksMenuItems( { rootClientId } ) {
-	const clientIds = useSelect( ( select ) =>
-		select( blockEditorStore ).getSelectedBlockClientIds()
+	const clientIds = useSelect(
+		( select ) => select( blockEditorStore ).getSelectedBlockClientIds(),
+		[]
 	);
 
 	return (

--- a/packages/reusable-blocks/src/components/reusable-blocks-menu-items/index.js
+++ b/packages/reusable-blocks/src/components/reusable-blocks-menu-items/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { withSelect } from '@wordpress/data';
+import { useSelect } from '@wordpress/data';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 
 /**
@@ -10,7 +10,11 @@ import { store as blockEditorStore } from '@wordpress/block-editor';
 import ReusableBlockConvertButton from './reusable-block-convert-button';
 import ReusableBlocksManageButton from './reusable-blocks-manage-button';
 
-function ReusableBlocksMenuItems( { clientIds, rootClientId } ) {
+export default function ReusableBlocksMenuItems( { rootClientId } ) {
+	const clientIds = useSelect( ( select ) =>
+		select( blockEditorStore ).getSelectedBlockClientIds()
+	);
+
 	return (
 		<>
 			<ReusableBlockConvertButton
@@ -23,16 +27,3 @@ function ReusableBlocksMenuItems( { clientIds, rootClientId } ) {
 		</>
 	);
 }
-
-export default withSelect( ( select ) => {
-	const { getSelectedBlockClientIds, getBlockRootClientId } =
-		select( blockEditorStore );
-	const clientIds = getSelectedBlockClientIds();
-	return {
-		clientIds,
-		rootClientId:
-			clientIds?.length > 0
-				? getBlockRootClientId( clientIds[ 0 ] )
-				: undefined,
-	};
-} )( ReusableBlocksMenuItems );

--- a/packages/reusable-blocks/src/components/reusable-blocks-menu-items/reusable-block-convert-button.js
+++ b/packages/reusable-blocks/src/components/reusable-blocks-menu-items/reusable-block-convert-button.js
@@ -51,8 +51,16 @@ export default function ReusableBlockConvertButton( {
 	const canConvert = useSelect(
 		( select ) => {
 			const { canUser } = select( coreStore );
-			const { getBlocksByClientId, canInsertBlockType } =
-				select( blockEditorStore );
+			const {
+				getBlocksByClientId,
+				canInsertBlockType,
+				getBlockRootClientId,
+			} = select( blockEditorStore );
+
+			const rootId =
+				rootClientId || clientIds.length > 0
+					? getBlockRootClientId( clientIds[ 0 ] )
+					: undefined;
 
 			const blocks = getBlocksByClientId( clientIds ) ?? [];
 
@@ -70,7 +78,7 @@ export default function ReusableBlockConvertButton( {
 				// Hide when this is already a reusable block.
 				! isReusable &&
 				// Hide when reusable blocks are disabled.
-				canInsertBlockType( 'core/block', rootClientId ) &&
+				canInsertBlockType( 'core/block', rootId ) &&
 				blocks.every(
 					( block ) =>
 						// Guard against the case where a regular block has *just* been converted.

--- a/packages/reusable-blocks/src/components/reusable-blocks-menu-items/reusable-block-convert-button.js
+++ b/packages/reusable-blocks/src/components/reusable-blocks-menu-items/reusable-block-convert-button.js
@@ -58,9 +58,10 @@ export default function ReusableBlockConvertButton( {
 			} = select( blockEditorStore );
 
 			const rootId =
-				rootClientId || clientIds.length > 0
+				rootClientId ||
+				( clientIds.length > 0
 					? getBlockRootClientId( clientIds[ 0 ] )
-					: undefined;
+					: undefined );
 
 			const blocks = getBlocksByClientId( clientIds ) ?? [];
 


### PR DESCRIPTION
## What?
Removes the withSelect override of rootClientId added in #52671. Also refactors withSelect to useSelect

## Why?
This rootClientId could be passed in by other components/plugins 

## How?
Only set the rootId in the menu component if the prop is not set.

## Testing Instructions
- In the site edit go into Pages and select a page to edit.
- Add a block in the page content and in the block overflow menu make sure the `Create pattern` menu appears and works as expected
- Also check that the `Create pattern` menu works as expected in the post editor still, and that create pattern menu does not appear in widget editor
- Double check that Create pattern menu does not appear if a synced pattern block is selected

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/3629020/6d8bc217-66e8-4e56-919d-fe58464b5ae5
