### PR TITLE
Site Editor: Prevent the sidebar navigation item focus from being cut off by the next item's background

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-item/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-item/style.scss
@@ -16,6 +16,11 @@
 		}
 	}
 
+	&:focus-visible {
+		// Avoid hiding the focus outline when the next navigation item is hovered
+		position: relative;
+	}
+
 	&[aria-current] {
 		background: var(--wp-admin-theme-color);
 		color: $white;


### PR DESCRIPTION
## What?

This issue may be an edge case, but this PR fixes a focus outline cutoff that occurs with the following operation:

- Open the Site Editor
- Focus on the sidebar navigation menu with the Tab key
- Mouse over the menu that is NOT in focus

| ![before](https://github.com/WordPress/gutenberg/assets/54422211/14be3033-cf09-4886-9441-2627804d37da) |

## Why?
I think it is because the HTML/CSS specification is such that the further back an element is, the higher it will be displayed.

## How?
Applied `position:relative` when the keyboard focus is on (`:focus-visible`) to make it appear more in the foreground.

## Screenshots or screencast <!-- if applicable -->

### Before

https://github.com/WordPress/gutenberg/assets/54422211/23163b17-b513-4c38-833d-acf21c2ad175

### After

https://github.com/WordPress/gutenberg/assets/54422211/b4cc7937-bd0e-4272-87fb-947944394e06
