### PR TITLE
[RNMobile] Wrap mobile block toolbar Block Settings Button with ToolbarGroup

### DIFF
--- a/packages/block-editor/src/components/block-settings/button.native.js
+++ b/packages/block-editor/src/components/block-settings/button.native.js
@@ -1,7 +1,11 @@
 /**
  * WordPress dependencies
  */
-import { createSlotFill, ToolbarButton } from '@wordpress/components';
+import {
+	createSlotFill,
+	ToolbarButton,
+	ToolbarGroup,
+} from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { withDispatch } from '@wordpress/data';
 import { cog } from '@wordpress/icons';
@@ -9,11 +13,13 @@ import { cog } from '@wordpress/icons';
 const { Fill, Slot } = createSlotFill( 'SettingsToolbarButton' );
 
 const SettingsButton = ( { openGeneralSidebar } ) => (
-	<ToolbarButton
-		title={ __( 'Open Settings' ) }
-		icon={ cog }
-		onClick={ openGeneralSidebar }
-	/>
+	<ToolbarGroup>
+		<ToolbarButton
+			title={ __( 'Open Settings' ) }
+			icon={ cog }
+			onClick={ openGeneralSidebar }
+		/>
+	</ToolbarGroup>
 );
 
 const SettingsButtonFill = ( props ) => (

--- a/packages/block-editor/src/components/block-toolbar/index.native.js
+++ b/packages/block-editor/src/components/block-toolbar/index.native.js
@@ -3,7 +3,6 @@
  */
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useCallback } from '@wordpress/element';
-import { ToolbarGroup } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -94,17 +93,15 @@ export default function BlockToolbar( { anchorNodeRef } ) {
 		<>
 			{ isValidAndVisual && (
 				<>
-					<ToolbarGroup>
-						<BlockSettingsButton.Slot>
-							{ /* Render only one settings icon even if we have more than one fill - need for hooks with controls. */ }
-							{ ( fills = [ null ] ) => {
-								if ( ! fills?.length > 0 ) {
-									return null;
-								}
-								return fills[ 0 ];
-							} }
-						</BlockSettingsButton.Slot>
-					</ToolbarGroup>
+					<BlockSettingsButton.Slot>
+						{ /* Render only one settings icon even if we have more than one fill - need for hooks with controls. */ }
+						{ ( fills = [ null ] ) => {
+							if ( ! fills?.length > 0 ) {
+								return null;
+							}
+							return fills[ 0 ];
+						} }
+					</BlockSettingsButton.Slot>
 					<BlockControls.Slot group="block" />
 					<BlockControls.Slot />
 					<BlockControls.Slot group="inline" />

--- a/packages/block-editor/src/components/block-toolbar/index.native.js
+++ b/packages/block-editor/src/components/block-toolbar/index.native.js
@@ -3,6 +3,7 @@
  */
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useCallback } from '@wordpress/element';
+import { ToolbarGroup } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -93,16 +94,17 @@ export default function BlockToolbar( { anchorNodeRef } ) {
 		<>
 			{ isValidAndVisual && (
 				<>
-					<BlockSettingsButton.Slot>
-						{ /* Render only one settings icon even if we have more than one fill - need for hooks with controls. */ }
-						{ ( fills = [ null ] ) => {
-							if ( ! fills?.length > 0 ) {
-								return null;
-							}
-							return fills[ 0 ];
-						} }
-					</BlockSettingsButton.Slot>
-
+					<ToolbarGroup>
+						<BlockSettingsButton.Slot>
+							{ /* Render only one settings icon even if we have more than one fill - need for hooks with controls. */ }
+							{ ( fills = [ null ] ) => {
+								if ( ! fills?.length > 0 ) {
+									return null;
+								}
+								return fills[ 0 ];
+							} }
+						</BlockSettingsButton.Slot>
+					</ToolbarGroup>
 					<BlockControls.Slot group="block" />
 					<BlockControls.Slot />
 					<BlockControls.Slot group="inline" />

--- a/packages/react-native-editor/CHANGELOG.md
+++ b/packages/react-native-editor/CHANGELOG.md
@@ -15,6 +15,7 @@ For each user feature we should also add a importance categorization label  to i
 -   [**] Move the undo/redo buttons to the navigation bar [#51766]
 -   [**] Update Editor block inserter button styles and default text input placeholder/selection styles [#52269]
 -   [**] Update Editor toolbar icons and colors [#52336]
+-   [*] Update Block Settings button border [#52715]
 
 ## 1.99.1
 - [**] Fix crash related to removing a block under certain conditions [#52595]


### PR DESCRIPTION
## What?
Wraps the mobile block toolbar Block Settings Button with ToolbarGroup.

* https://github.com/wordpress-mobile/gutenberg-mobile/pull/5972

## Why?
To match consistency with other design elements in the mobile block toolbar. ToolbarGroup provides consistent borders on the left and right of the Block Settings Button.

## How?
Updates the code of `block-toolbar/index.native.js` to include `ToolbarGroup` and wraps the `BlockSettingsButton.Slot` component.


## Testing Instructions
1. Open the editor
2. Tap or create a block that uses block settings, like Paragraph or Image
3. On the bottom toolbar above the keyboard, note the left border between the Block Settings Button and the Inserter button [+].

## Screenshots or screencast <!-- if applicable -->
Before | After
-|-
<img width="365" src="https://github.com/WordPress/gutenberg/assets/643285/04fd2fc5-ee89-4792-842b-0377bb42eaec"> | <img width="358" src="https://github.com/WordPress/gutenberg/assets/643285/c93fdbdf-f491-4a39-81b8-d9445e781c78">


