### PR TITLE
Parser / Site Editor: Ensure autop is not run when freeform block is set to core/html

### DIFF
--- a/packages/block-editor/src/store/test/selectors.js
+++ b/packages/block-editor/src/store/test/selectors.js
@@ -121,7 +121,7 @@ describe( 'selectors', () => {
 			parent: [ 'core/test-block-b' ],
 		} );
 
-		registerBlockType( 'core/test-freeform', {
+		registerBlockType( 'core/freeform', {
 			save: ( props ) => <RawHTML>{ props.attributes.content }</RawHTML>,
 			category: 'text',
 			title: 'Test Freeform Content Handler',
@@ -177,7 +177,7 @@ describe( 'selectors', () => {
 			ancestor: [ 'core/test-block-ancestor' ],
 		} );
 
-		setFreeformContentHandlerName( 'core/test-freeform' );
+		setFreeformContentHandlerName( 'core/freeform' );
 
 		cachedSelectors.forEach( ( { clear } ) => clear() );
 	} );
@@ -187,7 +187,7 @@ describe( 'selectors', () => {
 		unregisterBlockType( 'core/test-block-a' );
 		unregisterBlockType( 'core/test-block-b' );
 		unregisterBlockType( 'core/test-block-c' );
-		unregisterBlockType( 'core/test-freeform' );
+		unregisterBlockType( 'core/freeform' );
 		unregisterBlockType( 'core/post-content-child' );
 		unregisterBlockType( 'core/test-block-ancestor' );
 		unregisterBlockType( 'core/test-block-parent' );
@@ -3450,7 +3450,7 @@ describe( 'selectors', () => {
 			expect( firstBlockFirstCall.map( ( item ) => item.id ) ).toEqual( [
 				'core/test-block-a',
 				'core/test-block-b',
-				'core/test-freeform',
+				'core/freeform',
 				'core/test-block-ancestor',
 				'core/test-block-parent',
 				'core/block/1',
@@ -3466,7 +3466,7 @@ describe( 'selectors', () => {
 			expect( secondBlockFirstCall.map( ( item ) => item.id ) ).toEqual( [
 				'core/test-block-a',
 				'core/test-block-b',
-				'core/test-freeform',
+				'core/freeform',
 				'core/test-block-ancestor',
 				'core/test-block-parent',
 				'core/block/1',

--- a/packages/blocks/src/api/parser/index.js
+++ b/packages/blocks/src/api/parser/index.js
@@ -101,6 +101,7 @@ export function normalizeRawBlock( rawBlock, options ) {
 	// meaning there are no negative consequences to repeated autop calls.
 	if (
 		rawBlockName === fallbackBlockName &&
+		rawBlockName !== 'core/html' &&
 		! options?.__unstableSkipAutop
 	) {
 		rawInnerHTML = autop( rawInnerHTML ).trim();

--- a/packages/blocks/src/api/parser/index.js
+++ b/packages/blocks/src/api/parser/index.js
@@ -101,7 +101,7 @@ export function normalizeRawBlock( rawBlock, options ) {
 	// meaning there are no negative consequences to repeated autop calls.
 	if (
 		rawBlockName === fallbackBlockName &&
-		rawBlockName !== 'core/html' &&
+		rawBlockName === 'core/freeform' &&
 		! options?.__unstableSkipAutop
 	) {
 		rawInnerHTML = autop( rawInnerHTML ).trim();

--- a/packages/blocks/src/api/parser/test/index.js
+++ b/packages/blocks/src/api/parser/test/index.js
@@ -100,6 +100,17 @@ describe( 'block parser', () => {
 			expect( block.attributes ).toEqual( { content: '<p>content</p>' } );
 		} );
 
+		it( 'skips adding paragraph tags if freeform block is set to core/html', () => {
+			registerBlockType( 'core/html', unknownBlockSettings );
+			setFreeformContentHandlerName( 'core/html' );
+
+			const block = parseRawBlock( {
+				innerHTML: 'content',
+			} );
+			expect( block.name ).toEqual( 'core/html' );
+			expect( block.attributes ).toEqual( { content: 'content' } );
+		} );
+
 		it( 'skips adding paragraph tags if __unstableSkipAutop is passed as an option', () => {
 			registerBlockType( 'core/freeform-block', unknownBlockSettings );
 			setFreeformContentHandlerName( 'core/freeform-block' );

--- a/packages/blocks/src/api/parser/test/index.js
+++ b/packages/blocks/src/api/parser/test/index.js
@@ -90,13 +90,13 @@ describe( 'block parser', () => {
 		} );
 
 		it( 'should fall back to the freeform content handler if block type not specified', () => {
-			registerBlockType( 'core/freeform-block', unknownBlockSettings );
-			setFreeformContentHandlerName( 'core/freeform-block' );
+			registerBlockType( 'core/freeform', unknownBlockSettings );
+			setFreeformContentHandlerName( 'core/freeform' );
 
 			const block = parseRawBlock( {
 				innerHTML: 'content',
 			} );
-			expect( block.name ).toEqual( 'core/freeform-block' );
+			expect( block.name ).toEqual( 'core/freeform' );
 			expect( block.attributes ).toEqual( { content: '<p>content</p>' } );
 		} );
 
@@ -112,8 +112,8 @@ describe( 'block parser', () => {
 		} );
 
 		it( 'skips adding paragraph tags if __unstableSkipAutop is passed as an option', () => {
-			registerBlockType( 'core/freeform-block', unknownBlockSettings );
-			setFreeformContentHandlerName( 'core/freeform-block' );
+			registerBlockType( 'core/freeform', unknownBlockSettings );
+			setFreeformContentHandlerName( 'core/freeform' );
 
 			const block = parseRawBlock(
 				{
@@ -123,7 +123,7 @@ describe( 'block parser', () => {
 					__unstableSkipAutop: true,
 				}
 			);
-			expect( block.name ).toEqual( 'core/freeform-block' );
+			expect( block.name ).toEqual( 'core/freeform' );
 			expect( block.attributes ).toEqual( { content: 'content' } );
 		} );
 

--- a/packages/blocks/src/api/serializer.js
+++ b/packages/blocks/src/api/serializer.js
@@ -390,7 +390,8 @@ export function __unstableSerializeAndClean( blocks ) {
 	// pre-block-editor removep'd content formatting.
 	if (
 		blocks.length === 1 &&
-		blocks[ 0 ].name === getFreeformContentHandlerName()
+		blocks[ 0 ].name === getFreeformContentHandlerName() &&
+		blocks[ 0 ].name === 'core/freeform'
 	) {
 		content = removep( content );
 	}

--- a/packages/blocks/src/api/test/serializer.js
+++ b/packages/blocks/src/api/test/serializer.js
@@ -244,7 +244,7 @@ describe( 'block serializer', () => {
 
 	describe( 'serializeBlock()', () => {
 		it( 'serializes the freeform content fallback block without comment delimiters', () => {
-			registerBlockType( 'core/freeform-block', {
+			registerBlockType( 'core/freeform', {
 				category: 'text',
 				title: 'freeform block',
 				attributes: {
@@ -254,8 +254,8 @@ describe( 'block serializer', () => {
 				},
 				save: ( { attributes } ) => attributes.fruit,
 			} );
-			setFreeformContentHandlerName( 'core/freeform-block' );
-			const block = createBlock( 'core/freeform-block', {
+			setFreeformContentHandlerName( 'core/freeform' );
+			const block = createBlock( 'core/freeform', {
 				fruit: 'Bananas',
 			} );
 
@@ -264,7 +264,7 @@ describe( 'block serializer', () => {
 			expect( content ).toBe( 'Bananas' );
 		} );
 		it( 'serializes the freeform content fallback block with comment delimiters in nested context', () => {
-			registerBlockType( 'core/freeform-block', {
+			registerBlockType( 'core/freeform', {
 				category: 'text',
 				title: 'freeform block',
 				attributes: {
@@ -274,17 +274,17 @@ describe( 'block serializer', () => {
 				},
 				save: ( { attributes } ) => attributes.fruit,
 			} );
-			setFreeformContentHandlerName( 'core/freeform-block' );
-			const block = createBlock( 'core/freeform-block', {
+			setFreeformContentHandlerName( 'core/freeform' );
+			const block = createBlock( 'core/freeform', {
 				fruit: 'Bananas',
 			} );
 
 			const content = serializeBlock( block, { isInnerBlocks: true } );
 
 			expect( content ).toBe(
-				'<!-- wp:freeform-block {"fruit":"Bananas"} -->\n' +
+				'<!-- wp:freeform {"fruit":"Bananas"} -->\n' +
 					'Bananas\n' +
-					'<!-- /wp:freeform-block -->'
+					'<!-- /wp:freeform -->'
 			);
 		} );
 		it( 'serializes the unregistered fallback block without comment delimiters', () => {

--- a/packages/editor/src/store/test/selectors.js
+++ b/packages/editor/src/store/test/selectors.js
@@ -260,7 +260,7 @@ describe( 'selectors', () => {
 			parent: [ 'core/test-block-b' ],
 		} );
 
-		registerBlockType( 'core/test-freeform', {
+		registerBlockType( 'core/freeform', {
 			save: ( props ) => <RawHTML>{ props.attributes.content }</RawHTML>,
 			category: 'text',
 			title: 'Test Freeform Content Handler',
@@ -287,7 +287,7 @@ describe( 'selectors', () => {
 			save: () => null,
 		} );
 
-		setFreeformContentHandlerName( 'core/test-freeform' );
+		setFreeformContentHandlerName( 'core/freeform' );
 		setDefaultBlockName( 'core/test-default' );
 
 		cachedSelectors.forEach( ( { clear } ) => clear() );
@@ -298,7 +298,7 @@ describe( 'selectors', () => {
 		unregisterBlockType( 'core/test-block-a' );
 		unregisterBlockType( 'core/test-block-b' );
 		unregisterBlockType( 'core/test-block-c' );
-		unregisterBlockType( 'core/test-freeform' );
+		unregisterBlockType( 'core/freeform' );
 		unregisterBlockType( 'core/test-default' );
 
 		setFreeformContentHandlerName( undefined );
@@ -1335,7 +1335,7 @@ describe( 'selectors', () => {
 							value: [
 								{
 									clientId: 123,
-									name: 'core/test-freeform',
+									name: 'core/freeform',
 									isValid: true,
 									attributes: {
 										content: '',
@@ -1362,7 +1362,7 @@ describe( 'selectors', () => {
 							value: [
 								{
 									clientId: 123,
-									name: 'core/test-freeform',
+									name: 'core/freeform',
 									isValid: true,
 									attributes: {
 										content: '',
@@ -1736,7 +1736,7 @@ describe( 'selectors', () => {
 							value: [
 								{
 									clientId: 123,
-									name: 'core/test-freeform',
+									name: 'core/freeform',
 									isValid: true,
 									attributes: {
 										content: '',
@@ -1762,7 +1762,7 @@ describe( 'selectors', () => {
 							value: [
 								{
 									clientId: 123,
-									name: 'core/test-freeform',
+									name: 'core/freeform',
 									isValid: true,
 									attributes: {
 										content: '',
@@ -1790,7 +1790,7 @@ describe( 'selectors', () => {
 							value: [
 								{
 									clientId: 123,
-									name: 'core/test-freeform',
+									name: 'core/freeform',
 									isValid: true,
 									attributes: {
 										content: 'Test Data',
@@ -1818,7 +1818,7 @@ describe( 'selectors', () => {
 							value: [
 								{
 									clientId: 123,
-									name: 'core/test-freeform',
+									name: 'core/freeform',
 									isValid: true,
 									attributes: {
 										content: '',
@@ -1826,7 +1826,7 @@ describe( 'selectors', () => {
 								},
 								{
 									clientId: 456,
-									name: 'core/test-freeform',
+									name: 'core/freeform',
 									isValid: true,
 									attributes: {
 										content: '',
@@ -2409,7 +2409,7 @@ describe( 'selectors', () => {
 		} );
 
 		it( "returns removep'd serialization of blocks for single unknown", () => {
-			const unknownBlock = createBlock( 'core/test-freeform', {
+			const unknownBlock = createBlock( 'core/freeform', {
 				content: '<p>foo</p>',
 			} );
 			const state = {
@@ -2431,10 +2431,10 @@ describe( 'selectors', () => {
 		} );
 
 		it( "returns non-removep'd serialization of blocks for multiple unknown", () => {
-			const firstUnknown = createBlock( 'core/test-freeform', {
+			const firstUnknown = createBlock( 'core/freeform', {
 				content: '<p>foo</p>',
 			} );
-			const secondUnknown = createBlock( 'core/test-freeform', {
+			const secondUnknown = createBlock( 'core/freeform', {
 				content: '<p>bar</p>',
 			} );
 			const state = {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Possible fix for https://github.com/WordPress/gutenberg/issues/49166

If the freeform block for the editor is set to `core/html`, skip running `autop` on raw parsed blocks. To achieve this, this PR now runs `autop` only when the freeform block is set to `core/freeform` (the Classic block).

This should hopefully resolve an issue where custom HTML added to a template would receive unexpected `<p>` and `<br>` tags.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Back in https://github.com/WordPress/gutenberg/pull/48129, the site editor was updated to set `setFreeformFallbackBlockName` to `core/html` so that freeform content would be treated as an HTML block. However, in `normalizeRawBlock` raw content matching the fallback block name gets run through `autop` to automatically add `p` and `br` tags. From context, I believe this is to ensure that Classic blocks in post content correctly receive paragraph and break tags and such. In the site editor / when editing templates, I believe this is not required or expected, especially now that freeform content is treated as HTML blocks.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

In the parser's `normalizeRawBlock` function, only apply `autop` when the freeform block is set to `core/freeform`, so that editors that use `core/html` do not unexpectedly include automatically inserted `p` and `br` tags.

Update tests that relate to the freeform block behaviour so that they use the string `core/freeform` for the block name for consistency (and to catch the expected default behaviour).

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Open up the site editor
2. Add a Custom HTML block to a template, ensuring that there's a bunch of extra line breaks and spacing within the custom HTML.
3. Save the template.
4. Reload the site editor. Before this PR, note that there are some extra `<p>` tags in your Custom HTML. With this PR applied, after saving and reloading the template, there should not be extra `<p>` tags added to the Custom HTML.

Example markup to use:

```html
<marquee>

   Hello there!!

</marquee>
```

## Screenshots or screencast <!-- if applicable -->

| Before | After |
| --- | --- |
| ![image](https://github.com/WordPress/gutenberg/assets/14988353/642a045e-d7da-4b1c-ae6f-af79a6deff9e) | ![image](https://github.com/WordPress/gutenberg/assets/14988353/1df903d6-450b-4370-b927-33ec32b342e5) |