### PR TITLE
Fix: Block toolbar obscuring document tools when Top Toolbar is enabled

### DIFF
--- a/packages/block-editor/src/components/block-tools/style.scss
+++ b/packages/block-editor/src/components/block-tools/style.scss
@@ -333,16 +333,6 @@
 	}
 }
 
-body.site-editor-php {
-	.block-editor-block-contextual-toolbar {
-		@include break-large() {
-			&.is-fixed {
-				width: calc(100% - 240px - #{4 * $grid-unit-80});
-			}
-		}
-	}
-}
-
 /**
  * Block Label for Navigation/Selection Mode
  */

--- a/packages/block-editor/src/components/block-tools/style.scss
+++ b/packages/block-editor/src/components/block-tools/style.scss
@@ -325,7 +325,16 @@
 			width: auto;
 		}
 	}
+}
 
+body.site-editor-php {
+	.block-editor-block-contextual-toolbar {
+		@include break-large() {
+			&.is-fixed {
+				width: calc(100% - 240px - #{4 * $grid-unit-80});
+			}
+		}
+	}
 }
 
 /**

--- a/packages/block-editor/src/components/block-tools/style.scss
+++ b/packages/block-editor/src/components/block-tools/style.scss
@@ -324,6 +324,12 @@
 		&.is-fixed {
 			width: auto;
 		}
+		.is-fullscreen-mode &.is-fixed {
+			// in full screen mode we need to account for
+			// the combined with of the tools at the right of the header and the margin left
+			// of the toolbar which includes four buttons
+			width: calc(100% - 240px - #{4 * $grid-unit-80});
+		}
 	}
 }
 

--- a/packages/block-editor/src/components/block-tools/style.scss
+++ b/packages/block-editor/src/components/block-tools/style.scss
@@ -322,9 +322,7 @@
 	// for the block inserter the publish button
 	@include break-large() {
 		&.is-fixed {
-			// the combined with of the tools at the right of the header and the margin left
-			// of the toolbar which includes four buttons
-			width: calc(100% - 240px - #{4 * $grid-unit-80});
+			width: auto;
 		}
 	}
 


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/52688.

## What?
Adjust the width applied to `.block-editor-block-contextual-toolbar.is-fixed` on large screens.

## Why?
The current implementation results in document tools being obscured:


https://github.com/WordPress/gutenberg/assets/846565/df80b57b-2827-4ed9-a7d4-54c66ce185f7



## How?
Use `width: auto` instead of an absolute value. 

The Block toolbar will still obscure document tools on smaller screens, but they can be revealed by clicking the `<<` button, so I don't think it's an issue.

## Testing Instructions
* Open a page/post in the Post Editor.
* Disable full-screen editing.
* Enable top toolbar.
* Select a block.
* Ensure that document tools (save etc) are accessible, either inherently, or by clicking the `<<` on the block toolbar if necessary.


https://github.com/WordPress/gutenberg/assets/846565/20c8143a-bfcd-41ec-92c0-4e3ef7ef988a


