### PR TITLE
Site Editor: Swap pattern creation options

### DIFF
--- a/packages/edit-site/src/components/add-new-pattern/index.js
+++ b/packages/edit-site/src/components/add-new-pattern/index.js
@@ -57,21 +57,26 @@ export default function AddNewPattern() {
 		setShowTemplatePartModal( false );
 	}
 
+	const controls = [
+		{
+			icon: symbol,
+			onClick: () => setShowPatternModal( true ),
+			title: __( 'Create pattern' ),
+		},
+	];
+
+	if ( ! isTemplatePartsMode ) {
+		controls.push( {
+			icon: symbolFilled,
+			onClick: () => setShowTemplatePartModal( true ),
+			title: __( 'Create template part' ),
+		} );
+	}
+
 	return (
 		<>
 			<DropdownMenu
-				controls={ [
-					! isTemplatePartsMode && {
-						icon: symbolFilled,
-						onClick: () => setShowTemplatePartModal( true ),
-						title: __( 'Create template part' ),
-					},
-					{
-						icon: symbol,
-						onClick: () => setShowPatternModal( true ),
-						title: __( 'Create pattern' ),
-					},
-				].filter( Boolean ) }
+				controls={ controls }
 				toggleProps={ {
 					as: SidebarButton,
 				} }


### PR DESCRIPTION
## What?
Closes #52705

PR swaps the order of pattern and template creation options.

## Why?
The  "Create pattern" and the view heavily lean towards the notion of patterns.

## Testing Instructions
1. Open the Site Editor.
2. Go to the patterns view.
3. Confirm new order of dropdown menu items.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2023-07-18 at 13 40 53](https://github.com/WordPress/gutenberg/assets/240569/ae2e257d-a07e-4029-a1dd-91ccb465dd5d)
