### PR TITLE
Do not navigate to the styles pages unless you're in a random listing page

### DIFF
--- a/packages/edit-site/src/hooks/commands/use-common-commands.js
+++ b/packages/edit-site/src/hooks/commands/use-common-commands.js
@@ -11,15 +11,17 @@ import { privateApis as routerPrivateApis } from '@wordpress/router';
 import { store as preferencesStore } from '@wordpress/preferences';
 import { store as coreStore } from '@wordpress/core-data';
 import { store as noticesStore } from '@wordpress/notices';
+import { useViewportMatch } from '@wordpress/compose';
 
 /**
  * Internal dependencies
  */
 import { unlock } from '../../lock-unlock';
 import { store as editSiteStore } from '../../store';
+import getIsListPage from '../../utils/get-is-list-page';
 
 const { useGlobalStylesReset } = unlock( blockEditorPrivateApis );
-const { useHistory } = unlock( routerPrivateApis );
+const { useHistory, useLocation } = unlock( routerPrivateApis );
 
 function useGlobalStylesResetCommands() {
 	const [ canReset, onReset ] = useGlobalStylesReset();
@@ -48,9 +50,12 @@ function useGlobalStylesResetCommands() {
 }
 
 function useGlobalStylesOpenCssCommands() {
-	const { openGeneralSidebar, setEditorCanvasContainerView } = unlock(
-		useDispatch( editSiteStore )
-	);
+	const { openGeneralSidebar, setEditorCanvasContainerView, setCanvasMode } =
+		unlock( useDispatch( editSiteStore ) );
+	const { params } = useLocation();
+	const isMobileViewport = useViewportMatch( 'medium', '<' );
+	const isListPage = getIsListPage( params, isMobileViewport );
+	const isEditorPage = ! isListPage;
 	const history = useHistory();
 	const { canEditCSS } = useSelect( ( select ) => {
 		const { getEntityRecord, __experimentalGetCurrentGlobalStylesId } =
@@ -66,6 +71,7 @@ function useGlobalStylesOpenCssCommands() {
 				!! globalStyles?._links?.[ 'wp:action-edit-css' ] ?? false,
 		};
 	}, [] );
+	const { getCanvasMode } = unlock( useSelect( editSiteStore ) );
 
 	const commands = useMemo( () => {
 		if ( ! canEditCSS ) {
@@ -79,10 +85,15 @@ function useGlobalStylesOpenCssCommands() {
 				icon: styles,
 				callback: ( { close } ) => {
 					close();
-					history.push( {
-						path: '/wp_global_styles',
-						canvas: 'edit',
-					} );
+					if ( ! isEditorPage ) {
+						history.push( {
+							path: '/wp_global_styles',
+							canvas: 'edit',
+						} );
+					}
+					if ( isEditorPage && getCanvasMode() !== 'edit' ) {
+						setCanvasMode( 'edit' );
+					}
 					openGeneralSidebar( 'edit-site/global-styles' );
 					setEditorCanvasContainerView( 'global-styles-css' );
 				},
@@ -93,6 +104,9 @@ function useGlobalStylesOpenCssCommands() {
 		openGeneralSidebar,
 		setEditorCanvasContainerView,
 		canEditCSS,
+		isEditorPage,
+		getCanvasMode,
+		setCanvasMode,
 	] );
 	return {
 		isLoading: false,
@@ -101,9 +115,13 @@ function useGlobalStylesOpenCssCommands() {
 }
 
 export function useCommonCommands() {
-	const { openGeneralSidebar, setEditorCanvasContainerView } = unlock(
-		useDispatch( editSiteStore )
-	);
+	const { openGeneralSidebar, setEditorCanvasContainerView, setCanvasMode } =
+		unlock( useDispatch( editSiteStore ) );
+	const { params } = useLocation();
+	const isMobileViewport = useViewportMatch( 'medium', '<' );
+	const isListPage = getIsListPage( params, isMobileViewport );
+	const isEditorPage = ! isListPage;
+	const { getCanvasMode } = unlock( useSelect( editSiteStore ) );
 	const { set } = useDispatch( preferencesStore );
 	const { createInfoNotice } = useDispatch( noticesStore );
 	const history = useHistory();
@@ -127,10 +145,15 @@ export function useCommonCommands() {
 		icon: backup,
 		callback: ( { close } ) => {
 			close();
-			history.push( {
-				path: '/wp_global_styles',
-				canvas: 'edit',
-			} );
+			if ( ! isEditorPage ) {
+				history.push( {
+					path: '/wp_global_styles',
+					canvas: 'edit',
+				} );
+			}
+			if ( isEditorPage && getCanvasMode() !== 'edit' ) {
+				setCanvasMode( 'edit' );
+			}
 			openGeneralSidebar( 'edit-site/global-styles' );
 			setEditorCanvasContainerView( 'global-styles-revisions' );
 		},
@@ -141,10 +164,15 @@ export function useCommonCommands() {
 		label: __( 'Open styles' ),
 		callback: ( { close } ) => {
 			close();
-			history.push( {
-				path: '/wp_global_styles',
-				canvas: 'edit',
-			} );
+			if ( ! isEditorPage ) {
+				history.push( {
+					path: '/wp_global_styles',
+					canvas: 'edit',
+				} );
+			}
+			if ( isEditorPage && getCanvasMode() !== 'edit' ) {
+				setCanvasMode( 'edit' );
+			}
 			if ( isDistractionFree ) {
 				set( editSiteStore.name, 'distractionFree', false );
 				createInfoNotice( __( 'Distraction free mode turned off.' ), {
@@ -161,10 +189,15 @@ export function useCommonCommands() {
 		label: __( 'Learn about styles' ),
 		callback: ( { close } ) => {
 			close();
-			history.push( {
-				path: '/wp_global_styles',
-				canvas: 'edit',
-			} );
+			if ( ! isEditorPage ) {
+				history.push( {
+					path: '/wp_global_styles',
+					canvas: 'edit',
+				} );
+			}
+			if ( isEditorPage && getCanvasMode() !== 'edit' ) {
+				setCanvasMode( 'edit' );
+			}
 			openGeneralSidebar( 'edit-site/global-styles' );
 			set( 'core/edit-site', 'welcomeGuideStyles', true );
 			// sometimes there's a focus loss that happens after some time


### PR DESCRIPTION
closes #52626 

## What?

The site editor offers some commands to navigate to the "styles" sidebar (custom css, learn styles, style revisions...). In trunk, before triggering any of these commands we first navigate to the "styles" page in the site editor. The current PR changes that behavior and instead keeps the current page if the current page is showing a "template" or "page" and is not a listing page.

## How?

Let's be clear, I don't like this PR personally, there's no other solution at the moment but if we can accept the behavior in trunk, I think it's better personally. The reason is that while writing a command, we shouldn't have to think about all the modes... and all the possibilities that we might be in, it should be straightforward and this PR adds complexity to the current commands.

Also, we don't have a clear way to check whether we're actually in an "editor"'s page (a page showing a template or page)

The last thing I wanted to mention is that some of these commands started having checks about "distraction mode" and switch back ... I understand the reasoning but I don't like the implementation. It suffers from the same issues as the current PR: adds complexity to the commands but ideally the commands shouldn't have to know that these things are only available in "non distraction free" mode. The solution here would be to update the "reducer" to disable distraction free mode automatically, when we open the styles panel for instance. cc @draganescu 

I also noticed that we have some bugs where sometimes trying to open the CSS panel from the revisions panel doesn't work... These bugs are independent of the current PR though, they're just made visible here. (I think for this one is another case where a "controlled Navigator component" would solve the issues) #51915 cc @ciampo 

## Testing Instructions

Test the "open styles revisions", "learn about styles", "open css"... commands.
