### PR TITLE
Project management: automate adding package-related labels to PRs

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,185 @@
+# Package labeling rules
+
+"[Package] A11y":
+- packages/a11y/**
+#"[Package] ":
+#- packages/annotations/**
+"[Package] API fetch":
+- packages/api-fetch/**
+"[Package] Autop":
+- packages/autop/**
+"[Package] Babel plugin import JSX pragma":
+- packages/babel-plugin-import-jsx-pragma/**
+"[Package] Babel plugin makepot":
+- packages/babel-plugin-makepot/**
+"[Package] Babel preset":
+- packages/babel-preset-default/**
+"[Package] Base styles":
+- packages/base-styles/**
+"[Package] Blob":
+- packages/blob/**
+#"[Package] Block directory":
+#- packages/block directory/**
+"[Package] Block editor":
+- packages/block-editor/**
+"[Package] Block library":
+- packages/block-library/**
+#"":
+#- packages/block-serialization-default-parser/**
+#"":
+#- packages/block-serialization-spec-parser/**
+"[Package] Blocks":
+- packages/blocks/**
+"[Package] Browserslist config":
+- packages/browserslist-config/**
+"[Package] Commands":
+- packages/commands/**
+"[Package] Components":
+- packages/components/**
+"[Package] Compose":
+- packages/compose/**
+#"":
+#- packages/core-commands/**
+"[Package] Core data":
+- packages/core-data/**
+"[Package] Create Block":
+- packages/create-block-interactive-template/**
+- packages/create-block-tutorial-template/**
+- packages/create-block/**
+#"":
+#- packages/customize-widgets/**
+"[Package] Data Controls":
+- packages/data-controls/**
+"[Package] Data":
+- packages/data/**
+"[Package] Date":
+- packages/date/**
+"[Package] Dependency Extraction Webpack Plugin":
+- packages/dependency-extraction-webpack-plugin/**
+"[Package] Deprecated":
+- packages/deprecated/**
+"[Package] Docgen":
+- packages/docgen/**
+"[Package] DOM ready":
+- packages/dom-ready/**
+"[Package] DOM":
+- packages/dom/**
+"[Package] E2E Test Utils":
+- packages/e2e-tests-utils-playwright/**
+- packages/e2e-test-utils/**
+"[Package] E2E Tests":
+- packages/e2e-tests/**
+"[Package] Edit Post":
+- packages/edit-post/**
+"[Package] Edit Site":
+- packages/edit-site/**
+"[Package] Edit Widgets":
+- packages/edit-widgets/**
+"[Package] Editor":
+- packages/editor/**
+"[Package] Element":
+- packages/element/**
+"[Package] Env":
+- packages/env/**
+"[Package] Escape HTML":
+- packages/escape-html/**
+"[Package] ESLint plugin":
+- packages/eslint-plugin/**
+"[Package] Format library":
+- packages/format-library/**
+"[Package] Hooks":
+- packages/hooks/**
+"[Package] HTML entities":
+- packages/html-entities/**
+"[Package] i18n":
+- packages/i18n/**
+"[Package] Icons":
+- packages/icons/**
+#"":
+#- packages/interactivity/**
+"[Package] Interface":
+- packages/interface/**
+"[Package] is-shallow-equal":
+- packages/is-shallow-equal/**
+"[Package] Jest console":
+- packages/jest-console/**
+"[Package] Jest preset":
+- packages/jest-preset-default/**
+"[Package] Jest Puppeteer aXe":
+- packages/jest-puppeteer-axe/**
+"[Package] Keyboard Shortcuts":
+- packages/keyboard-shortcuts/**
+"[Package] Keycodes":
+- packages/keycodes/**
+"[Package] Lazy import":
+- packages/lazy-import/**
+#"":
+#- packages/list-reusable-blocks/**
+"[Package] Media Utils":
+- packages/media-utils/**
+"[Package] Notices":
+- packages/notices/**
+"[Package] npm-package-json-lint-config":
+- packages/npm-package-json-lint-config/**
+"[Package] Plugins":
+- packages/plugins/**
+"[Package] PostCSS Plugins Preset":
+- packages/postcss-plugins-preset/**
+#"":
+#- packages/postcss-themes/**
+#"":
+#- packages/preferences-persistence/**
+"[Package] Preferences":
+- packages/preferences/**
+"[Package] Prettier config":
+- packages/prettier-config/**
+"[Package] Primitives":
+- packages/primitives/**
+"[Package] Priority Queue":
+- packages/priority-queue/**
+"[Package] Private APIs":
+- packages/private-apis/**
+"[Package] Project management automation":
+- packages/project-management-automation/**
+"[Package] React i18n":
+- packages/react-i18n/**
+#"":
+#- packages/react-native-aztec/**
+#"":
+#- packages/react-native-bridge/**
+#"":
+#- packages/react-native-editor/**
+"[Package] Readable JS Assets Webpack Plugin":
+- packages/readable-js-assets-webpack-plugin/**
+"[Package] Redux Routine":
+- packages/redux-routine/**
+#"":
+#- packages/report-flaky-tests/**
+#"":
+#- packages/reusable-blocks/**
+"[Package] Rich text":
+- packages/rich-text/**
+#"":
+#- packages/router/**
+"[Package] Scripts":
+- packages/scripts/**
+"[Package] Server Side Render":
+- packages/server-side-render/**
+#"":
+#- packages/shortcode/**
+"[Package] Style Engine":
+- packages/style-engine/**
+"[Package] stylelint config":
+- packages/stylelint-config/**
+"[Package] Token List":
+- packages/token-list/**
+"[Package] Url":
+- packages/url/**
+"[Package] Viewport":
+- packages/viewport/**
+"[Package] Warning":
+- packages/warning/**
+#"":
+#- packages/widgets/**
+"[Package] Word count":
+- packages/wordcount/**

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -82,8 +82,6 @@
 
 '[Package] E2E Tests':
     - changed-files:
-          - any-glob-to-any-file: 'packages/e2e-tests/**'
-          - any-glob-to-any-file: 'packages/e2e-test-utils/**'
           - any-glob-to-any-file: 'packages/e2e-test-utils-playwright/**'
 
 '[Package] Edit Post':

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -132,7 +132,7 @@
     - changed-files:
           - any-glob-to-any-file: 'packages/icons/**'
 
-'[Packages] Interactivity':
+'[Package] Interactivity':
     - changed-files:
           - any-glob-to-any-file: 'packages/interactivity/**'
 
@@ -224,7 +224,7 @@
     - changed-files:
           - any-glob-to-any-file: 'packages/style-engine/**'
 
-'[Packages] Sync':
+'[Package] Sync':
     - changed-files:
           - any-glob-to-any-file: 'packages/sync/**'
 

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,185 +1,255 @@
-# Package labeling rules
+# Package labeling rules - only labels that exist on GitHub
 
-"[Package] A11y":
-- packages/a11y/**
-#"[Package] ":
-#- packages/annotations/**
-"[Package] API fetch":
-- packages/api-fetch/**
-"[Package] Autop":
-- packages/autop/**
-"[Package] Babel plugin import JSX pragma":
-- packages/babel-plugin-import-jsx-pragma/**
-"[Package] Babel plugin makepot":
-- packages/babel-plugin-makepot/**
-"[Package] Babel preset":
-- packages/babel-preset-default/**
-"[Package] Base styles":
-- packages/base-styles/**
-"[Package] Blob":
-- packages/blob/**
-#"[Package] Block directory":
-#- packages/block directory/**
-"[Package] Block editor":
-- packages/block-editor/**
-"[Package] Block library":
-- packages/block-library/**
-#"":
-#- packages/block-serialization-default-parser/**
-#"":
-#- packages/block-serialization-spec-parser/**
-"[Package] Blocks":
-- packages/blocks/**
-"[Package] Browserslist config":
-- packages/browserslist-config/**
-"[Package] Commands":
-- packages/commands/**
-"[Package] Components":
-- packages/components/**
-"[Package] Compose":
-- packages/compose/**
-#"":
-#- packages/core-commands/**
-"[Package] Core data":
-- packages/core-data/**
-"[Package] Create Block":
-- packages/create-block-interactive-template/**
-- packages/create-block-tutorial-template/**
-- packages/create-block/**
-#"":
-#- packages/customize-widgets/**
-"[Package] Data Controls":
-- packages/data-controls/**
-"[Package] Data":
-- packages/data/**
-"[Package] Date":
-- packages/date/**
-"[Package] Dependency Extraction Webpack Plugin":
-- packages/dependency-extraction-webpack-plugin/**
-"[Package] Deprecated":
-- packages/deprecated/**
-"[Package] Docgen":
-- packages/docgen/**
-"[Package] DOM ready":
-- packages/dom-ready/**
-"[Package] DOM":
-- packages/dom/**
-"[Package] E2E Test Utils":
-- packages/e2e-tests-utils-playwright/**
-- packages/e2e-test-utils/**
-"[Package] E2E Tests":
-- packages/e2e-tests/**
-"[Package] Edit Post":
-- packages/edit-post/**
-"[Package] Edit Site":
-- packages/edit-site/**
-"[Package] Edit Widgets":
-- packages/edit-widgets/**
-"[Package] Editor":
-- packages/editor/**
-"[Package] Element":
-- packages/element/**
-"[Package] Env":
-- packages/env/**
-"[Package] Escape HTML":
-- packages/escape-html/**
-"[Package] ESLint plugin":
-- packages/eslint-plugin/**
-"[Package] Format library":
-- packages/format-library/**
-"[Package] Hooks":
-- packages/hooks/**
-"[Package] HTML entities":
-- packages/html-entities/**
-"[Package] i18n":
-- packages/i18n/**
-"[Package] Icons":
-- packages/icons/**
-#"":
-#- packages/interactivity/**
-"[Package] Interface":
-- packages/interface/**
-"[Package] is-shallow-equal":
-- packages/is-shallow-equal/**
-"[Package] Jest console":
-- packages/jest-console/**
-"[Package] Jest preset":
-- packages/jest-preset-default/**
-"[Package] Jest Puppeteer aXe":
-- packages/jest-puppeteer-axe/**
-"[Package] Keyboard Shortcuts":
-- packages/keyboard-shortcuts/**
-"[Package] Keycodes":
-- packages/keycodes/**
-"[Package] Lazy import":
-- packages/lazy-import/**
-#"":
-#- packages/list-reusable-blocks/**
-"[Package] Media Utils":
-- packages/media-utils/**
-"[Package] Notices":
-- packages/notices/**
-"[Package] npm-package-json-lint-config":
-- packages/npm-package-json-lint-config/**
-"[Package] Plugins":
-- packages/plugins/**
-"[Package] PostCSS Plugins Preset":
-- packages/postcss-plugins-preset/**
-#"":
-#- packages/postcss-themes/**
-#"":
-#- packages/preferences-persistence/**
-"[Package] Preferences":
-- packages/preferences/**
-"[Package] Prettier config":
-- packages/prettier-config/**
-"[Package] Primitives":
-- packages/primitives/**
-"[Package] Priority Queue":
-- packages/priority-queue/**
-"[Package] Private APIs":
-- packages/private-apis/**
-"[Package] Project management automation":
-- packages/project-management-automation/**
-"[Package] React i18n":
-- packages/react-i18n/**
-#"":
-#- packages/react-native-aztec/**
-#"":
-#- packages/react-native-bridge/**
-#"":
-#- packages/react-native-editor/**
-"[Package] Readable JS Assets Webpack Plugin":
-- packages/readable-js-assets-webpack-plugin/**
-"[Package] Redux Routine":
-- packages/redux-routine/**
-#"":
-#- packages/report-flaky-tests/**
-#"":
-#- packages/reusable-blocks/**
-"[Package] Rich text":
-- packages/rich-text/**
-#"":
-#- packages/router/**
-"[Package] Scripts":
-- packages/scripts/**
-"[Package] Server Side Render":
-- packages/server-side-render/**
-#"":
-#- packages/shortcode/**
-"[Package] Style Engine":
-- packages/style-engine/**
-"[Package] stylelint config":
-- packages/stylelint-config/**
-"[Package] Token List":
-- packages/token-list/**
-"[Package] Url":
-- packages/url/**
-"[Package] Viewport":
-- packages/viewport/**
-"[Package] Warning":
-- packages/warning/**
-#"":
-#- packages/widgets/**
-"[Package] Word count":
-- packages/wordcount/**
+'[Package] A11y':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/a11y/**'
+
+'[Package] API fetch':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/api-fetch/**'
+
+'[Package] Autop':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/autop/**'
+
+'[Package] Base styles':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/base-styles/**'
+
+'[Package] Blob':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/blob/**'
+
+'[Package] Block editor':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/block-editor/**'
+
+'[Package] Block library':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/block-library/**'
+
+'[Package] Blocks':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/blocks/**'
+
+'[Package] Commands':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/commands/**'
+
+'[Package] Components':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/components/**'
+
+'[Package] Compose':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/compose/**'
+
+'[Package] Core commands':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/core-commands/**'
+
+'[Package] Core data':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/core-data/**'
+
+'[Package] Data Controls':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/data-controls/**'
+
+'[Package] Data':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/data/**'
+
+'[Package] DataViews':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/dataviews/**'
+
+'[Package] Date':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/date/**'
+
+'[Package] Deprecated':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/deprecated/**'
+
+'[Package] DOM ready':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/dom-ready/**'
+
+'[Package] DOM':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/dom/**'
+
+'[Package] E2E Tests':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/e2e-tests/**'
+          - any-glob-to-any-file: 'packages/e2e-test-utils/**'
+          - any-glob-to-any-file: 'packages/e2e-test-utils-playwright/**'
+
+'[Package] Edit Post':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/edit-post/**'
+
+'[Package] Edit Site':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/edit-site/**'
+
+'[Package] Edit Widgets':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/edit-widgets/**'
+
+'[Package] Editor':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/editor/**'
+
+'[Package] Element':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/element/**'
+
+'[Package] Escape HTML':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/escape-html/**'
+
+'[Package] Fields':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/fields/**'
+
+'[Package] Format library':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/format-library/**'
+
+'[Package] Hooks':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/hooks/**'
+
+'[Package] HTML entities':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/html-entities/**'
+
+'[Package] i18n':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/i18n/**'
+
+'[Package] Icons':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/icons/**'
+
+'[Packages] Interactivity':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/interactivity/**'
+
+'[Package] Interactivity Router':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/interactivity-router/**'
+
+'[Package] Interface':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/interface/**'
+
+'[Package] is-shallow-equal':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/is-shallow-equal/**'
+
+'[Package] Keyboard Shortcuts':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/keyboard-shortcuts/**'
+
+'[Package] Keycodes':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/keycodes/**'
+
+'[Package] Lazy import':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/lazy-import/**'
+
+'[Package] Media Utils':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/media-utils/**'
+
+'[Package] Notices':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/notices/**'
+
+'[Package] Patterns':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/patterns/**'
+
+'[Package] Plugins':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/plugins/**'
+
+'[Package] Preferences':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/preferences/**'
+
+'[Package] Primitives':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/primitives/**'
+
+'[Package] Priority Queue':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/priority-queue/**'
+
+'[Package] Private APIs':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/private-apis/**'
+
+'[Package] Project management automation':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/project-management-automation/**'
+
+'[Package] React i18n':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/react-i18n/**'
+
+'[Package] Redux Routine':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/redux-routine/**'
+
+'[Package] Rich text':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/rich-text/**'
+
+'[Package] Router':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/router/**'
+
+'[Package] Sanitize':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/sanitize/**'
+
+'[Package] Server Side Render':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/server-side-render/**'
+
+'[Package] Style Engine':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/style-engine/**'
+
+'[Packages] Sync':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/sync/**'
+
+'[Package] Theme':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/theme/**'
+
+'[Package] Token List':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/token-list/**'
+
+'[Package] Url':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/url/**'
+
+'[Package] Viewport':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/viewport/**'
+
+'[Package] Warning':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/warning/**'
+
+'[Package] Word count':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/wordcount/**'

--- a/.github/workflows/pr-labeling-automation.yml
+++ b/.github/workflows/pr-labeling-automation.yml
@@ -1,0 +1,18 @@
+name: "Pull Request Labeler"
+on:
+  workflow_dispatch:
+  pull_request_target:
+    types: [opened, closed, reopened, edited, ready_for_review, synchronized]
+
+jobs:
+  auto_label_pull_request:
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@v4
+      with:        
+        dot: true
+        sync-labels: true

--- a/.github/workflows/pr-labeling-automation.yml
+++ b/.github/workflows/pr-labeling-automation.yml
@@ -2,8 +2,7 @@ name: 'Pull Request Labeler'
 on:
     workflow_dispatch:
     pull_request_target:
-        types:
-            [opened, closed, reopened, edited, ready_for_review, synchronized]
+        types: [opened, closed, reopened, edited, ready_for_review, synchronize]
 
 jobs:
     auto_label_pull_request:

--- a/.github/workflows/pr-labeling-automation.yml
+++ b/.github/workflows/pr-labeling-automation.yml
@@ -3,6 +3,10 @@ on:
     pull_request_target:
         types: [opened, synchronize]
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
     auto_label_pull_request:
         permissions:

--- a/.github/workflows/pr-labeling-automation.yml
+++ b/.github/workflows/pr-labeling-automation.yml
@@ -1,6 +1,5 @@
 name: 'Pull Request Labeler'
 on:
-    workflow_dispatch:
     pull_request_target:
         types: [opened, synchronize]
 

--- a/.github/workflows/pr-labeling-automation.yml
+++ b/.github/workflows/pr-labeling-automation.yml
@@ -9,7 +9,6 @@ jobs:
         permissions:
             contents: read
             pull-requests: write
-            issues: write
         runs-on: ubuntu-24.04
         steps:
             - uses: actions/labeler@634933edcd8ababfe52f92936142cc22ac488b1b # v6.0.1

--- a/.github/workflows/pr-labeling-automation.yml
+++ b/.github/workflows/pr-labeling-automation.yml
@@ -10,9 +10,9 @@ jobs:
             contents: read
             pull-requests: write
             issues: write
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-24.04
         steps:
-            - uses: actions/labeler@v6
+            - uses: actions/labeler@634933edcd8ababfe52f92936142cc22ac488b1b # v6.0.1
               with:
                   dot: true
                   sync-labels: true

--- a/.github/workflows/pr-labeling-automation.yml
+++ b/.github/workflows/pr-labeling-automation.yml
@@ -1,18 +1,19 @@
-name: "Pull Request Labeler"
+name: 'Pull Request Labeler'
 on:
-  workflow_dispatch:
-  pull_request_target:
-    types: [opened, closed, reopened, edited, ready_for_review, synchronized]
+    workflow_dispatch:
+    pull_request_target:
+        types:
+            [opened, closed, reopened, edited, ready_for_review, synchronized]
 
 jobs:
-  auto_label_pull_request:
-    permissions:
-      contents: read
-      pull-requests: write
-      issues: write
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/labeler@v4
-      with:        
-        dot: true
-        sync-labels: true
+    auto_label_pull_request:
+        permissions:
+            contents: read
+            pull-requests: write
+            issues: write
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/labeler@v6
+              with:
+                  dot: true
+                  sync-labels: true

--- a/.github/workflows/pr-labeling-automation.yml
+++ b/.github/workflows/pr-labeling-automation.yml
@@ -2,7 +2,7 @@ name: 'Pull Request Labeler'
 on:
     workflow_dispatch:
     pull_request_target:
-        types: [opened, closed, reopened, edited, ready_for_review, synchronize]
+        types: [opened, synchronize]
 
 jobs:
     auto_label_pull_request:


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
This PR automates adding package-related labels to PRs when they affect one or more npm packages. Related discussions in #52583 and https://github.com/WordPress/gutenberg/discussions/52727#discussioncomment-6477067

## Why?
Labeling in detail is a burden, and often PRs get merged without many labels. Some labels can be automated, like package labels and many feature-related ones.

## How?
By adding a [labeler GitHub action](https://github.com/marketplace/actions/labeler) that checks the path of the files affected by the PRs.

## Testing Instructions
I've created a [PoC in a test repository](https://github.com/priethor/automation-playground), and it seems to work fine!
