### PR TITLE
Replace horizontal ellipsis icon with vertical ellipsis icon.

### DIFF
--- a/packages/block-editor/src/components/warning/index.js
+++ b/packages/block-editor/src/components/warning/index.js
@@ -9,7 +9,7 @@ import classnames from 'classnames';
 import { Children } from '@wordpress/element';
 import { DropdownMenu, MenuGroup, MenuItem } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { moreHorizontal } from '@wordpress/icons';
+import { moreVertical } from '@wordpress/icons';
 
 function Warning( { className, actions, children, secondaryActions } ) {
 	return (
@@ -34,7 +34,7 @@ function Warning( { className, actions, children, secondaryActions } ) {
 							{ secondaryActions && (
 								<DropdownMenu
 									className="block-editor-warning__secondary"
-									icon={ moreHorizontal }
+									icon={ moreVertical }
 									label={ __( 'More options' ) }
 									popoverProps={ {
 										position: 'bottom left',

--- a/packages/edit-site/src/components/page-patterns/grid-item.js
+++ b/packages/edit-site/src/components/page-patterns/grid-item.js
@@ -27,7 +27,7 @@ import {
 	footer,
 	symbolFilled as uncategorized,
 	symbol,
-	moreHorizontal,
+	moreVertical,
 	lockSmall,
 } from '@wordpress/icons';
 import { store as noticesStore } from '@wordpress/notices';
@@ -220,13 +220,12 @@ function GridItem( { categoryId, item, ...props } ) {
 					</Flex>
 				</HStack>
 				<DropdownMenu
-					icon={ moreHorizontal }
+					icon={ moreVertical }
 					label={ __( 'Actions' ) }
 					className="edit-site-patterns__dropdown"
 					popoverProps={ { placement: 'bottom-end' } }
 					toggleProps={ {
 						className: 'edit-site-patterns__button',
-						isSmall: true,
 						describedBy: sprintf(
 							/* translators: %s: pattern name */
 							__( 'Action menu for %s pattern' ),

--- a/packages/edit-site/src/components/page-patterns/style.scss
+++ b/packages/edit-site/src/components/page-patterns/style.scss
@@ -132,6 +132,10 @@
 			color: $gray-600;
 		}
 
+		.edit-site-patterns__dropdown {
+			flex-shrink: 0;
+		}
+
 		&.is-placeholder .edit-site-patterns__preview {
 			min-height: $grid-unit-80;
 			color: $gray-600;
@@ -148,7 +152,7 @@
 
 	.edit-site-patterns__preview {
 		flex: 0 1 auto;
-		margin-bottom: $grid-unit-20;
+		margin-bottom: $grid-unit-15;
 	}
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Fixes https://github.com/WordPress/gutenberg/issues/52408

## What?
<!-- In a few words, what is the PR actually doing? -->
All the ellipsis icon buttons in the editor use the vertical ellipsis icon, except two. 
Also, the ellipsis button in the Patterns list has a small target size of only 24 x 24 pixels, which seems to be there only for visual concerns. 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
It is best to always use the same icon. consistency and affordance considerations prevail on any otehr ad-hoc visual consideration.
Regarding the target size: Functionality come first than visuals and the target size should be the standard one for icon buttons 36 X 36 pixels.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Replaces the horizontal ellipsis icon with the vertical ellipsis one.
- Adjusts the CSS accordingly.
- Increases the target size of the ellipsis button in the Patterns list to 36 x 36 pixels.

Note: with this change, the `moreHorizontal` icon is now unused. As such, `packages/icons/src/library/more-horizontal.js` could be completely removed. Please do let me know what to do in this regard.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

- Edit a post.
- Alter a block markup in order to trigger the 'invalid block' warning.
- Observe the 'More options' button in the Warning now uses the vertical ellipsis icon.
- Go to the Site editor > Patterns
- Observe that in all the Patterns screens, the Actions button below each pattern now uses the vertical ellipsis icon.
- Observe the target size of the button is now 36 x 36 pixels.
- Observe there are no other relevant visual differences with trunk.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
