### PR TITLE
Update: Improve titles of author templates in query title block.

### DIFF
--- a/packages/edit-site/src/components/block-editor/use-site-editor-settings.js
+++ b/packages/edit-site/src/components/block-editor/use-site-editor-settings.js
@@ -17,6 +17,8 @@ function useArchiveLabel( templateSlug ) {
 	);
 	let taxonomy;
 	let term;
+	let isAuthor = false;
+	let authorSlug;
 	if ( taxonomyMatches ) {
 		// If is for a all taxonomies of a type
 		if ( taxonomyMatches[ 1 ] ) {
@@ -35,10 +37,19 @@ function useArchiveLabel( templateSlug ) {
 
 		//getTaxonomy( 'category' );
 		//wp.data.select('core').getEntityRecords( 'taxonomy', 'category', {slug: 'newcat'} );
+	} else {
+		const authorMatches = templateSlug?.match( /^(author)$|^author-(.+)$/ );
+		if ( authorMatches ) {
+			isAuthor = true;
+			if ( authorMatches[ 2 ] ) {
+				authorSlug = authorMatches[ 2 ];
+			}
+		}
 	}
 	return useSelect(
 		( select ) => {
-			const { getEntityRecords, getTaxonomy } = select( coreStore );
+			const { getEntityRecords, getTaxonomy, getAuthors } =
+				select( coreStore );
 			let archiveTypeLabel;
 			let archiveNameLabel;
 			if ( taxonomy ) {
@@ -54,12 +65,21 @@ function useArchiveLabel( templateSlug ) {
 					archiveNameLabel = records[ 0 ].name;
 				}
 			}
+			if ( isAuthor ) {
+				archiveTypeLabel = 'Author';
+				if ( authorSlug ) {
+					const authorRecords = getAuthors( { slug: authorSlug } );
+					if ( authorRecords && authorRecords[ 0 ] ) {
+						archiveNameLabel = authorRecords[ 0 ].name;
+					}
+				}
+			}
 			return {
 				archiveTypeLabel,
 				archiveNameLabel,
 			};
 		},
-		[ taxonomy, term ]
+		[ authorSlug, isAuthor, taxonomy, term ]
 	);
 }
 


### PR DESCRIPTION
Follow up to https://github.com/WordPress/gutenberg/pull/52521.
Improves the titles of the author templates on the query title block.

<img width="1055" alt="Screenshot 2023-07-18 at 16 20 26" src="https://github.com/WordPress/gutenberg/assets/11271197/6dd4ef2f-d6af-4f39-a89c-0c55d1889757">
<img width="1066" alt="Screenshot 2023-07-18 at 16 20 50" src="https://github.com/WordPress/gutenberg/assets/11271197/247c7322-b5d7-40d5-acba-4fad85724159">

cc: @jameskoster 

## Testing
- I created a template for all authors,  and for a specific author.
- I opened the two templates referred above and verified the titles make sense and reference the type of archive. I toggled off "Show archive type in title" in the title of all archive templates and verified the titles still make sense.
