### PR TITLE
[Mobile] HeaderToolbar - Update inserterMethod meta data

### DIFF
--- a/packages/edit-post/src/components/header/header-toolbar/index.native.js
+++ b/packages/edit-post/src/components/header/header-toolbar/index.native.js
@@ -100,6 +100,7 @@ function HeaderToolbar( {
 		( blockType ) => () => {
 			insertBlock( createBlock( blockType ), undefined, undefined, true, {
 				source: 'inserter_menu',
+				inserterMethod: 'quick-inserter',
 			} );
 		},
 		[ insertBlock ]


### PR DESCRIPTION
**Related PRs:**
- https://github.com/wordpress-mobile/gutenberg-mobile/pull/5976

## What?
Adds the `inserterMethod` metadata when inserting blocks from the Header Toolbar.

## Why?
To be able to fetch this data on block insertion.

## How?
By adding `inserterMethod` in the metadata param for `insertBlock`.

## Testing Instructions
Check the Gutenberg Mobile PR description for testing instructions.

### Testing Instructions for Keyboard
N/A

## Screenshots or screencast <!-- if applicable -->
N/A