### PR TITLE
Command Palette: Update label and icon for Patterns

### DIFF
--- a/packages/core-commands/src/site-editor-navigation-commands.js
+++ b/packages/core-commands/src/site-editor-navigation-commands.js
@@ -13,6 +13,7 @@ import {
 	symbolFilled,
 	styles,
 	navigation,
+	symbol,
 } from '@wordpress/icons';
 import { privateApis as routerPrivateApis } from '@wordpress/router';
 import { getQueryArg, addQueryArgs, getPath } from '@wordpress/url';
@@ -199,8 +200,8 @@ function useSiteEditorBasicNavigationCommands() {
 
 		result.push( {
 			name: 'core/edit-site/open-template-parts',
-			label: __( 'Open library' ),
-			icon: symbolFilled,
+			label: __( 'Open patterns' ),
+			icon: symbol,
 			callback: ( { close } ) => {
 				const args = {
 					path: '/patterns',


### PR DESCRIPTION
## What?
Fixes #52741.

PR changes the label "Open Library" to "Open Patterns" and updates icon.

## Why?
Library was renamed to Patterns, and the Command Palette needs to be updated to that.

## Testing Instructions
1. Open the command palette.
2. Type "Open Patterns"
3. Confirm changes.

## Screenshots or screencast <!-- if applicable -->

![CleanShot 2023-07-19 at 00 19 35](https://github.com/WordPress/gutenberg/assets/240569/fc0858c4-ae65-4cd7-b807-b35d5a0c980e)

