### PR TITLE
Site Editor: Fix site link accessibility issues

### DIFF
--- a/packages/edit-site/src/components/site-hub/index.js
+++ b/packages/edit-site/src/components/site-hub/index.js
@@ -174,7 +174,7 @@ const SiteHub = forwardRef( ( { isTransparent, ...restProps }, ref ) => {
 						<Button
 							href={ homeUrl }
 							target="_blank"
-							label={ __( 'View site' ) }
+							label={ __( 'View site (opens in a new tab)' ) }
 							aria-label={ __(
 								'View site (opens in a new tab)'
 							) }

--- a/packages/edit-site/src/components/site-hub/style.scss
+++ b/packages/edit-site/src/components/site-hub/style.scss
@@ -19,7 +19,7 @@
 
 	.edit-site-site-hub__site-view-link {
 		flex-grow: 0;
-		margin-right: 2px;
+		margin-right: var(--wp-admin-border-width-focus);
 		@include break-mobile() {
 			opacity: 0;
 			transition: opacity 0.2s ease-in-out;

--- a/packages/edit-site/src/components/site-hub/style.scss
+++ b/packages/edit-site/src/components/site-hub/style.scss
@@ -19,13 +19,12 @@
 
 	.edit-site-site-hub__site-view-link {
 		flex-grow: 0;
+		margin-right: 2px;
 		@include break-mobile() {
 			opacity: 0;
 			transition: opacity 0.2s ease-in-out;
 		}
 		&:focus {
-			outline: none;
-			box-shadow: none;
 			opacity: 1;
 		}
 		svg {


### PR DESCRIPTION
## What?
Fixes some accessibility issues with view site link in the site editor hub.

## Why?
These issues [were pointed out here](https://github.com/WordPress/gutenberg/pull/50420#issuecomment-1640710936).

## How?
Adds the focus border back and updates the button label text.

## Testing Instructions
In the site editor hub use the keyboard to tab to the View Site button and make sure tooltip says `View site (opens in a new tab)` and the blue focus border shows.

## Screenshots or screencast <!-- if applicable -->

Before:

https://github.com/WordPress/gutenberg/assets/3629020/1152231d-d9ef-44ec-bc8f-31a30ba6ca69

After:

https://github.com/WordPress/gutenberg/assets/3629020/37e78fc6-d10d-4475-b892-4e00a1eb0962



