### PR TITLE
Patterns: Add id to pattern inserted notice to stop multiple notices stacking

### DIFF
--- a/packages/block-editor/src/components/inserter/hooks/use-patterns-state.js
+++ b/packages/block-editor/src/components/inserter/hooks/use-patterns-state.js
@@ -61,6 +61,7 @@ const usePatternsState = ( onInsert, rootClientId ) => {
 				),
 				{
 					type: 'snackbar',
+					id: 'block-pattern-inserted-notice',
 				}
 			);
 		},


### PR DESCRIPTION
## What?
Fixes issue with multiple pattern inserted notices stacking up and cluttering the UI

## Why?
Multiple notices end up obscuring the UI

## How?
Adds a unique id to the notices

## Testing Instructions

- In the post editor inserter click on multiple patterns to insert them in the post
- Check that only one notice appears at a time

## Screenshots or screencast <!-- if applicable -->

Before:

https://github.com/WordPress/gutenberg/assets/3629020/3ed11ee4-ce08-4ba3-bd86-0fd3ceb3160e

After:

https://github.com/WordPress/gutenberg/assets/3629020/444c53df-fa44-438a-8267-647e649007b1




