### PR TITLE
Fix empty general template parts in Patterns

### DIFF
--- a/packages/edit-site/src/components/page-patterns/patterns-list.js
+++ b/packages/edit-site/src/components/page-patterns/patterns-list.js
@@ -63,9 +63,12 @@ export default function PatternsList( { categoryId, type } ) {
 
 	const deferredSyncedFilter = useDeferredValue( syncFilter );
 
+	const isUncategorizedThemePatterns =
+		type === PATTERNS && categoryId === 'uncategorized';
+
 	const { patterns, isResolving } = usePatterns(
 		type,
-		type !== PATTERNS || categoryId !== 'uncategorized' ? categoryId : '',
+		isUncategorizedThemePatterns ? '' : categoryId,
 		{
 			search: deferredFilterValue,
 			syncStatus:

--- a/packages/edit-site/src/components/page-patterns/patterns-list.js
+++ b/packages/edit-site/src/components/page-patterns/patterns-list.js
@@ -27,7 +27,7 @@ import usePatterns from './use-patterns';
 import SidebarButton from '../sidebar-button';
 import useDebouncedInput from '../../utils/use-debounced-input';
 import { unlock } from '../../lock-unlock';
-import { SYNC_TYPES, USER_PATTERN_CATEGORY } from './utils';
+import { SYNC_TYPES, USER_PATTERN_CATEGORY, PATTERNS } from './utils';
 import Pagination from './pagination';
 
 const { useLocation, useHistory } = unlock( routerPrivateApis );
@@ -65,7 +65,7 @@ export default function PatternsList( { categoryId, type } ) {
 
 	const { patterns, isResolving } = usePatterns(
 		type,
-		categoryId !== 'uncategorized' ? categoryId : '',
+		type !== PATTERNS || categoryId !== 'uncategorized' ? categoryId : '',
 		{
 			search: deferredFilterValue,
 			syncStatus:


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Fix incorrect empty general template parts in the Patterns screen.

Possibly introduced in #52633 ?

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The list has no general (uncategorized) template parts even though the sidebar says there are.

![image](https://github.com/WordPress/gutenberg/assets/7753001/eca0b324-7fc2-4ba1-9f5d-2bd93292ba74)

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Only pass the empty string as the `categoryId` if the type is theme patterns.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
1. Enable a theme that has general template parts, like twentytwentythree.
2. Go to Site Editor -> Patterns
3. Observe that the general template parts item in the sidebar has 2 template parts
4. Click on the item and expect that there are in fact two general template parts in the list.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
The same as for the testing instructions above.

## Screenshots or screencast <!-- if applicable -->
![image](https://github.com/WordPress/gutenberg/assets/7753001/b4e2313d-85ea-4c00-a33a-59a6853773b1)

