### PR TITLE
Global styles revisions: update private methods to protected

### DIFF
--- a/lib/compat/wordpress-6.3/class-gutenberg-rest-global-styles-revisions-controller-6-3.php
+++ b/lib/compat/wordpress-6.3/class-gutenberg-rest-global-styles-revisions-controller-6-3.php
@@ -21,7 +21,7 @@ class Gutenberg_REST_Global_Styles_Revisions_Controller_6_3 extends WP_REST_Cont
 	 * @since 6.3.0
 	 * @var string
 	 */
-	private $parent_post_type;
+	protected $parent_post_type;
 
 	/**
 	 * The base of the parent controller's route.
@@ -29,7 +29,7 @@ class Gutenberg_REST_Global_Styles_Revisions_Controller_6_3 extends WP_REST_Cont
 	 * @since 6.3.0
 	 * @var string
 	 */
-	private $parent_base;
+	protected $parent_base;
 
 	/**
 	 * Constructor.
@@ -102,7 +102,7 @@ class Gutenberg_REST_Global_Styles_Revisions_Controller_6_3 extends WP_REST_Cont
 	 * @param string $raw_json Encoded JSON from global styles custom post content.
 	 * @return Array|WP_Error
 	 */
-	private function get_decoded_global_styles_json( $raw_json ) {
+	protected function get_decoded_global_styles_json( $raw_json ) {
 		$decoded_json = json_decode( $raw_json, true );
 
 		if ( is_array( $decoded_json ) && isset( $decoded_json['isGlobalStylesUserThemeJSON'] ) && true === $decoded_json['isGlobalStylesUserThemeJSON'] ) {


### PR DESCRIPTION
This PR should only be merged if the corresponding Core patch makes it into 6.3.

Otherwise I'll have to prep the changes for 6.4 :)

## What?
Updates the private vars and methods in the Global styles revisions rest API controller to be protected.

Core backport PR: https://github.com/WordPress/wordpress-develop/pull/4867


## Why?
So class entities that inherit from the base can use them, and we can iterate on 6.3 features without having to copy over private methods to new classes all the time.


## Testing Instructions
All tests should pass.
There is no functional change, only changes 2 vars and 1 method to protected.