### PR TITLE
Editor: Remove a block select button from the multi-entity saving flow

### DIFF
--- a/packages/editor/src/components/entities-saved-states/entity-record-item.js
+++ b/packages/editor/src/components/entities-saved-states/entity-record-item.js
@@ -1,10 +1,9 @@
 /**
  * WordPress dependencies
  */
-import { CheckboxControl, Button, PanelRow } from '@wordpress/components';
+import { CheckboxControl, PanelRow } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { useSelect, useDispatch } from '@wordpress/data';
-import { store as blockEditorStore } from '@wordpress/block-editor';
+import { useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 import { decodeEntities } from '@wordpress/html-entities';
 
@@ -13,30 +12,8 @@ import { decodeEntities } from '@wordpress/html-entities';
  */
 import { store as editorStore } from '../../store';
 
-export default function EntityRecordItem( {
-	record,
-	checked,
-	onChange,
-	closePanel,
-} ) {
+export default function EntityRecordItem( { record, checked, onChange } ) {
 	const { name, kind, title, key } = record;
-	const parentBlockId = useSelect(
-		( select ) => {
-			// Get entity's blocks.
-			const { blocks = [] } = select( coreStore ).getEditedEntityRecord(
-				kind,
-				name,
-				key
-			);
-			// Get parents of the entity's first block.
-			const parents = select( blockEditorStore ).getBlockParents(
-				blocks[ 0 ]?.clientId
-			);
-			// Return closest parent block's clientId.
-			return parents[ parents.length - 1 ];
-		},
-		[ key, kind, name ]
-	);
 
 	// Handle templates that might use default descriptive titles.
 	const entityRecordTitle = useSelect(
@@ -57,17 +34,6 @@ export default function EntityRecordItem( {
 		[ name, kind, title, key ]
 	);
 
-	const isSelected = useSelect(
-		( select ) => {
-			const selectedBlockId =
-				select( blockEditorStore ).getSelectedBlockClientId();
-			return selectedBlockId === parentBlockId;
-		},
-		[ parentBlockId ]
-	);
-	const isSelectedText = isSelected ? __( 'Selected' ) : __( 'Select' );
-	const { selectBlock } = useDispatch( blockEditorStore );
-
 	return (
 		<PanelRow>
 			<CheckboxControl
@@ -81,27 +47,6 @@ export default function EntityRecordItem( {
 				checked={ checked }
 				onChange={ onChange }
 			/>
-			{ parentBlockId ? (
-				<>
-					<Button
-						className="entities-saved-states__find-entity"
-						disabled={ isSelected }
-						onClick={ () => selectBlock( parentBlockId ) }
-					>
-						{ isSelectedText }
-					</Button>
-					<Button
-						className="entities-saved-states__find-entity-small"
-						disabled={ isSelected }
-						onClick={ () => {
-							selectBlock( parentBlockId );
-							closePanel();
-						} }
-					>
-						{ isSelectedText }
-					</Button>
-				</>
-			) : null }
 		</PanelRow>
 	);
 }

--- a/packages/editor/src/components/entities-saved-states/entity-type-list.js
+++ b/packages/editor/src/components/entities-saved-states/entity-type-list.js
@@ -31,7 +31,6 @@ export default function EntityTypeList( {
 	list,
 	unselectedEntities,
 	setUnselectedEntities,
-	closePanel,
 } ) {
 	const count = list.length;
 	const firstRecord = list[ 0 ];
@@ -73,7 +72,6 @@ export default function EntityTypeList( {
 						onChange={ ( value ) =>
 							setUnselectedEntities( record, value )
 						}
-						closePanel={ closePanel }
 					/>
 				);
 			} ) }

--- a/packages/editor/src/components/entities-saved-states/index.js
+++ b/packages/editor/src/components/entities-saved-states/index.js
@@ -210,7 +210,6 @@ export function EntitiesSavedStatesExtensible( {
 					<EntityTypeList
 						key={ list[ 0 ].name }
 						list={ list }
-						closePanel={ dismissPanel }
 						unselectedEntities={ unselectedEntities }
 						setUnselectedEntities={ setUnselectedEntities }
 					/>

--- a/packages/editor/src/components/entities-saved-states/style.scss
+++ b/packages/editor/src/components/entities-saved-states/style.scss
@@ -1,18 +1,3 @@
-.entities-saved-states__find-entity {
-	display: none;
-
-	@include break-medium() {
-		display: block;
-	}
-}
-.entities-saved-states__find-entity-small {
-	display: block;
-
-	@include break-medium() {
-		display: none;
-	}
-}
-
 .entities-saved-states__panel-header {
 	box-sizing: border-box;
 	background: $white;


### PR DESCRIPTION
## What?
Closes #52324.
Closes #27898.

PR removes the parent block selection button from the multi-entity saving flow.

## Why?
Now that component is used in multiple places; the block selection feature doesn't always make sense. The UI can also be confusing, as described in #27898.

## Testing Instructions
1. Open a Post Editor.
2. Add synced pattern and warp it in a group block.
3. Make changes to a pattern.
4. Open multi-entity saving panel.
5. Confirm that the "Select" button isn't displayed.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2023-07-19 at 14 12 41](https://github.com/WordPress/gutenberg/assets/240569/9f068482-066b-4d71-99d6-1ca7109d0b79)
