### PR TITLE
Backport changes from WP 6.3

### DIFF
--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -297,7 +297,7 @@ function gutenberg_register_core_block_assets( $block_name ) {
 			$theme_style_handle = "wp-block-{$block_name}-theme";
 			if ( wp_style_is( $theme_style_handle, 'registered' ) ) {
 				wp_deregister_style( $theme_style_handle );
-				if ( file_exists( $stylesheet_path ) ) {
+				if ( file_exists( $theme_style_path ) ) {
 					// If there is a main stylesheet for this block, append the theme styles to main styles.
 					wp_register_style(
 						$theme_style_handle,

--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -249,24 +249,25 @@ function gutenberg_register_core_block_assets( $block_name ) {
 	// else (for development or test) default to use the current time.
 	$default_version = defined( 'GUTENBERG_VERSION' ) && ! SCRIPT_DEBUG ? GUTENBERG_VERSION : time();
 
-	$style_path      = "build/block-library/blocks/$block_name/";
-	$stylesheet_url  = gutenberg_url( $style_path . 'style.css' );
-	$stylesheet_path = gutenberg_dir_path() . $style_path . ( is_rtl() ? 'style-rtl.css' : 'style.css' );
+	$style_path         = "build/block-library/blocks/$block_name/";
+	$stylesheet_url     = gutenberg_url( $style_path . 'style.css' );
+	$stylesheet_path    = gutenberg_dir_path() . $style_path . ( is_rtl() ? 'style-rtl.css' : 'style.css' );
+	$block_style_handle = "wp-block-{$block_name}";
 
 	if ( file_exists( $stylesheet_path ) ) {
-		wp_deregister_style( "wp-block-{$block_name}" );
+		wp_deregister_style( $block_style_handle );
 		wp_register_style(
-			"wp-block-{$block_name}",
+			$block_style_handle,
 			$stylesheet_url,
 			array(),
 			$default_version
 		);
-		wp_style_add_data( "wp-block-{$block_name}", 'rtl', 'replace' );
+		wp_style_add_data( $block_style_handle, 'rtl', 'replace' );
 
 		// Add a reference to the stylesheet's path to allow calculations for inlining styles in `wp_head`.
-		wp_style_add_data( "wp-block-{$block_name}", 'path', $stylesheet_path );
+		wp_style_add_data( $block_style_handle, 'path', $stylesheet_path );
 	} else {
-		wp_register_style( "wp-block-{$block_name}", false, array() );
+		wp_register_style( $block_style_handle, false, array() );
 	}
 
 	// If the current theme supports wp-block-styles, dequeue the full stylesheet
@@ -293,22 +294,44 @@ function gutenberg_register_core_block_assets( $block_name ) {
 
 		// If the file exists, enqueue it.
 		if ( file_exists( gutenberg_dir_path() . $theme_style_path ) ) {
-
-			if ( file_exists( $stylesheet_path ) ) {
-				// If there is a main stylesheet for this block, append the theme styles to main styles.
-				wp_add_inline_style(
-					"wp-block-{$block_name}",
-					file_get_contents( gutenberg_dir_path() . $theme_style_path )
-				);
+			$theme_style_handle = "wp-block-{$block_name}-theme";
+			if ( wp_style_is( $theme_style_handle, 'registered' ) ) {
+				wp_deregister_style( $theme_style_handle );
+				if ( file_exists( $stylesheet_path ) ) {
+					// If there is a main stylesheet for this block, append the theme styles to main styles.
+					wp_register_style(
+						$theme_style_handle,
+						false,
+						array(),
+						$default_version
+					);
+				} else {
+					// If there is no main stylesheet for this block, register theme style.
+					wp_register_style(
+						$theme_style_handle,
+						gutenberg_url( $theme_style_path ),
+						array(),
+						$default_version
+					);
+					wp_style_add_data( $theme_style_handle, 'path', gutenberg_dir_path() . $theme_style_path );
+				}
 			} else {
-				// If there is no main stylesheet for this block, register theme style.
-				wp_register_style(
-					"wp-block-{$block_name}",
-					gutenberg_url( $theme_style_path ),
-					array(),
-					$default_version
-				);
-				wp_style_add_data( "wp-block-{$block_name}", 'path', gutenberg_dir_path() . $theme_style_path );
+				if ( file_exists( $stylesheet_path ) ) {
+					// If there is a main stylesheet for this block, append the theme styles to main styles.
+					wp_add_inline_style(
+						$block_style_handle,
+						file_get_contents( gutenberg_dir_path() . $theme_style_path )
+					);
+				} else {
+					// If there is no main stylesheet for this block, register theme style.
+					wp_register_style(
+						$block_style_handle,
+						gutenberg_url( $theme_style_path ),
+						array(),
+						$default_version
+					);
+					wp_style_add_data( $block_style_handle, 'path', gutenberg_dir_path() . $theme_style_path );
+				}
 			}
 		}
 	}

--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -254,85 +254,82 @@ function gutenberg_register_core_block_assets( $block_name ) {
 	$stylesheet_path    = gutenberg_dir_path() . $style_path . ( is_rtl() ? 'style-rtl.css' : 'style.css' );
 	$block_style_handle = "wp-block-{$block_name}";
 
-	if ( file_exists( $stylesheet_path ) ) {
-		wp_deregister_style( $block_style_handle );
-		wp_register_style(
-			$block_style_handle,
-			$stylesheet_url,
-			array(),
-			$default_version
-		);
-		wp_style_add_data( $block_style_handle, 'rtl', 'replace' );
+if ( file_exists( $stylesheet_path ) ) {
+	wp_deregister_style( $block_style_handle );
+	wp_register_style(
+		$block_style_handle,
+		$stylesheet_url,
+		array(),
+		$default_version
+	);
+	wp_style_add_data( $block_style_handle, 'rtl', 'replace' );
 
-		// Add a reference to the stylesheet's path to allow calculations for inlining styles in `wp_head`.
-		wp_style_add_data( $block_style_handle, 'path', $stylesheet_path );
-	} else {
-		wp_register_style( $block_style_handle, false, array() );
-	}
+	// Add a reference to the stylesheet's path to allow calculations for inlining styles in `wp_head`.
+	wp_style_add_data( $block_style_handle, 'path', $stylesheet_path );
+} else {
+	wp_register_style( $block_style_handle, false, array() );
+}
 
 	// If the current theme supports wp-block-styles, dequeue the full stylesheet
 	// and instead attach each block's theme-styles to their block styles stylesheet.
-	if ( current_theme_supports( 'wp-block-styles' ) ) {
+if ( current_theme_supports( 'wp-block-styles' ) ) {
 
-		// Dequeue the full stylesheet.
-		// Make sure this only runs once, it doesn't need to run for every block.
-		static $stylesheet_removed;
-		if ( ! $stylesheet_removed ) {
-			add_action(
-				'wp_enqueue_scripts',
-				static function () {
-					wp_dequeue_style( 'wp-block-library-theme' );
-				}
-			);
-			$stylesheet_removed = true;
-		}
-
-		// Get the path to the block's stylesheet.
-		$theme_style_path = is_rtl()
-			? "build/block-library/blocks/$block_name/theme-rtl.css"
-			: "build/block-library/blocks/$block_name/theme.css";
-
-		// If the file exists, enqueue it.
-		if ( file_exists( gutenberg_dir_path() . $theme_style_path ) ) {
-			$theme_style_handle = "wp-block-{$block_name}-theme";
-			if ( wp_style_is( $theme_style_handle, 'registered' ) ) {
-				wp_deregister_style( $theme_style_handle );
-				if ( file_exists( $theme_style_path ) ) {
-					// If there is a main stylesheet for this block, append the theme styles to main styles.
-					wp_register_style(
-						$theme_style_handle,
-						false,
-						array(),
-						$default_version
-					);
-				} else {
-					// If there is no main stylesheet for this block, register theme style.
-					wp_register_style(
-						$theme_style_handle,
-						gutenberg_url( $theme_style_path ),
-						array(),
-						$default_version
-					);
-					wp_style_add_data( $theme_style_handle, 'path', gutenberg_dir_path() . $theme_style_path );
-				}
-			} else {
-				if ( file_exists( $stylesheet_path ) ) {
-					// If there is a main stylesheet for this block, append the theme styles to main styles.
-					wp_add_inline_style(
-						$block_style_handle,
-						file_get_contents( gutenberg_dir_path() . $theme_style_path )
-					);
-				} else {
-					// If there is no main stylesheet for this block, register theme style.
-					wp_register_style(
-						$block_style_handle,
-						gutenberg_url( $theme_style_path ),
-						array(),
-						$default_version
-					);
-					wp_style_add_data( $block_style_handle, 'path', gutenberg_dir_path() . $theme_style_path );
-				}
+	// Dequeue the full stylesheet.
+	// Make sure this only runs once, it doesn't need to run for every block.
+	static $stylesheet_removed;
+	if ( ! $stylesheet_removed ) {
+		add_action(
+			'wp_enqueue_scripts',
+			static function() {
+				wp_dequeue_style( 'wp-block-library-theme' );
 			}
+		);
+		$stylesheet_removed = true;
+	}
+
+	// Get the path to the block's stylesheet.
+	$theme_style_path      = is_rtl()
+		? "build/block-library/blocks/$block_name/theme-rtl.css"
+		: "build/block-library/blocks/$block_name/theme.css";
+	$theme_style_file_path = gutenberg_dir_path() . $theme_style_path;
+	$theme_style_handle    = "wp-block-{$block_name}-theme";
+
+	if ( wp_style_is( $theme_style_handle, 'registered' ) ) {
+		wp_deregister_style( $theme_style_handle );
+		if ( file_exists( $theme_style_file_path ) ) {
+			// If there is a main stylesheet for this block, append the theme styles to main styles.
+			wp_register_style(
+				$theme_style_handle,
+				false,
+				array(),
+				$default_version
+			);
+		} else {
+			// If there is no main stylesheet for this block, register theme style.
+			wp_register_style(
+				$theme_style_handle,
+				gutenberg_url( $theme_style_path ),
+				array(),
+				$default_version
+			);
+			wp_style_add_data( $theme_style_handle, 'path', $theme_style_file_path );
+		}
+	} elseif ( file_exists( $theme_style_file_path ) ) {
+		if ( file_exists( $stylesheet_path ) ) {
+			// If there is a main stylesheet for this block, append the theme styles to main styles.
+			wp_add_inline_style(
+				$block_style_handle,
+				file_get_contents( $theme_style_file_path )
+			);
+		} else {
+			// If there is no main stylesheet for this block, register theme style.
+			wp_register_style(
+				$block_style_handle,
+				gutenberg_url( $theme_style_path ),
+				array(),
+				$default_version
+			);
+			wp_style_add_data( $block_style_handle, 'path', $theme_style_file_path );
 		}
 	}
 

--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -254,97 +254,98 @@ function gutenberg_register_core_block_assets( $block_name ) {
 	$stylesheet_path    = gutenberg_dir_path() . $style_path . ( is_rtl() ? 'style-rtl.css' : 'style.css' );
 	$block_style_handle = "wp-block-{$block_name}";
 
-if ( file_exists( $stylesheet_path ) ) {
-	wp_deregister_style( $block_style_handle );
-	wp_register_style(
-		$block_style_handle,
-		$stylesheet_url,
-		array(),
-		$default_version
-	);
-	wp_style_add_data( $block_style_handle, 'rtl', 'replace' );
-
-	// Add a reference to the stylesheet's path to allow calculations for inlining styles in `wp_head`.
-	wp_style_add_data( $block_style_handle, 'path', $stylesheet_path );
-} else {
-	wp_register_style( $block_style_handle, false, array() );
-}
-
-	// If the current theme supports wp-block-styles, dequeue the full stylesheet
-	// and instead attach each block's theme-styles to their block styles stylesheet.
-if ( current_theme_supports( 'wp-block-styles' ) ) {
-
-	// Dequeue the full stylesheet.
-	// Make sure this only runs once, it doesn't need to run for every block.
-	static $stylesheet_removed;
-	if ( ! $stylesheet_removed ) {
-		add_action(
-			'wp_enqueue_scripts',
-			static function() {
-				wp_dequeue_style( 'wp-block-library-theme' );
-			}
-		);
-		$stylesheet_removed = true;
-	}
-
-	// Get the path to the block's stylesheet.
-	$theme_style_path      = is_rtl()
-		? "build/block-library/blocks/$block_name/theme-rtl.css"
-		: "build/block-library/blocks/$block_name/theme.css";
-	$theme_style_file_path = gutenberg_dir_path() . $theme_style_path;
-	$theme_style_handle    = "wp-block-{$block_name}-theme";
-
-	if ( wp_style_is( $theme_style_handle, 'registered' ) ) {
-		wp_deregister_style( $theme_style_handle );
-		if ( file_exists( $theme_style_file_path ) ) {
-			// If there is a main stylesheet for this block, append the theme styles to main styles.
-			wp_register_style(
-				$theme_style_handle,
-				false,
-				array(),
-				$default_version
-			);
-		} else {
-			// If there is no main stylesheet for this block, register theme style.
-			wp_register_style(
-				$theme_style_handle,
-				gutenberg_url( $theme_style_path ),
-				array(),
-				$default_version
-			);
-			wp_style_add_data( $theme_style_handle, 'path', $theme_style_file_path );
-		}
-	} elseif ( file_exists( $theme_style_file_path ) ) {
-		if ( file_exists( $stylesheet_path ) ) {
-			// If there is a main stylesheet for this block, append the theme styles to main styles.
-			wp_add_inline_style(
-				$block_style_handle,
-				file_get_contents( $theme_style_file_path )
-			);
-		} else {
-			// If there is no main stylesheet for this block, register theme style.
-			wp_register_style(
-				$block_style_handle,
-				gutenberg_url( $theme_style_path ),
-				array(),
-				$default_version
-			);
-			wp_style_add_data( $block_style_handle, 'path', $theme_style_file_path );
-		}
-	}
-
-	$editor_style_path = "build/block-library/blocks/$block_name/style-editor.css";
-	if ( file_exists( gutenberg_dir_path() . $editor_style_path ) ) {
-		wp_deregister_style( "wp-block-{$block_name}-editor" );
+	if ( file_exists( $stylesheet_path ) ) {
+		wp_deregister_style( $block_style_handle );
 		wp_register_style(
-			"wp-block-{$block_name}-editor",
-			gutenberg_url( $editor_style_path ),
+			$block_style_handle,
+			$stylesheet_url,
 			array(),
 			$default_version
 		);
-		wp_style_add_data( "wp-block-{$block_name}-editor", 'rtl', 'replace' );
+		wp_style_add_data( $block_style_handle, 'rtl', 'replace' );
+
+		// Add a reference to the stylesheet's path to allow calculations for inlining styles in `wp_head`.
+		wp_style_add_data( $block_style_handle, 'path', $stylesheet_path );
 	} else {
-		wp_register_style( "wp-block-{$block_name}-editor", false );
+		wp_register_style( $block_style_handle, false, array() );
+	}
+
+	// If the current theme supports wp-block-styles, dequeue the full stylesheet
+	// and instead attach each block's theme-styles to their block styles stylesheet.
+	if ( current_theme_supports( 'wp-block-styles' ) ) {
+
+		// Dequeue the full stylesheet.
+		// Make sure this only runs once, it doesn't need to run for every block.
+		static $stylesheet_removed;
+		if ( ! $stylesheet_removed ) {
+			add_action(
+				'wp_enqueue_scripts',
+				static function () {
+					wp_dequeue_style( 'wp-block-library-theme' );
+				}
+			);
+			$stylesheet_removed = true;
+		}
+
+		// Get the path to the block's stylesheet.
+		$theme_style_path      = is_rtl()
+		? "build/block-library/blocks/$block_name/theme-rtl.css"
+		: "build/block-library/blocks/$block_name/theme.css";
+		$theme_style_file_path = gutenberg_dir_path() . $theme_style_path;
+		$theme_style_handle    = "wp-block-{$block_name}-theme";
+
+		if ( wp_style_is( $theme_style_handle, 'registered' ) ) {
+			wp_deregister_style( $theme_style_handle );
+			if ( file_exists( $theme_style_file_path ) ) {
+				// If there is a main stylesheet for this block, append the theme styles to main styles.
+				wp_register_style(
+					$theme_style_handle,
+					false,
+					array(),
+					$default_version
+				);
+			} else {
+				// If there is no main stylesheet for this block, register theme style.
+				wp_register_style(
+					$theme_style_handle,
+					gutenberg_url( $theme_style_path ),
+					array(),
+					$default_version
+				);
+				wp_style_add_data( $theme_style_handle, 'path', $theme_style_file_path );
+			}
+		} elseif ( file_exists( $theme_style_file_path ) ) {
+			if ( file_exists( $stylesheet_path ) ) {
+				// If there is a main stylesheet for this block, append the theme styles to main styles.
+				wp_add_inline_style(
+					$block_style_handle,
+					file_get_contents( $theme_style_file_path )
+				);
+			} else {
+				// If there is no main stylesheet for this block, register theme style.
+				wp_register_style(
+					$block_style_handle,
+					gutenberg_url( $theme_style_path ),
+					array(),
+					$default_version
+				);
+				wp_style_add_data( $block_style_handle, 'path', $theme_style_file_path );
+			}
+		}
+
+		$editor_style_path = "build/block-library/blocks/$block_name/style-editor.css";
+		if ( file_exists( gutenberg_dir_path() . $editor_style_path ) ) {
+			wp_deregister_style( "wp-block-{$block_name}-editor" );
+			wp_register_style(
+				"wp-block-{$block_name}-editor",
+				gutenberg_url( $editor_style_path ),
+				array(),
+				$default_version
+			);
+			wp_style_add_data( "wp-block-{$block_name}-editor", 'rtl', 'replace' );
+		} else {
+			wp_register_style( "wp-block-{$block_name}-editor", false );
+		}
 	}
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
After https://github.com/WordPress/wordpress-develop/commit/d8409a205a40a9c5a69d668a9aa2aa3123f4c3e5 was committed, this break the override functionality in this plugin. Make a backwards compatibility fix. 

More context - https://core.trac.wordpress.org/ticket/58528 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
