### PR TITLE
Code Data: Fix ESLint warning for 'useEntityProp' hook

### DIFF
--- a/packages/core-data/src/entity-provider.js
+++ b/packages/core-data/src/entity-provider.js
@@ -129,7 +129,7 @@ export function useEntityProp( kind, name, prop, _id ) {
 				[ prop ]: newValue,
 			} );
 		},
-		[ kind, name, id, prop ]
+		[ editEntityRecord, kind, name, id, prop ]
 	);
 
 	return [ value, setValue, fullValue ];


### PR DESCRIPTION
## What?
Fix the ESLint warning for the 'useEntityProp' hook.  The `editEntityRecord` action has a stable reference, and it's okay to list it as a dependency.

## Why?
Just a small code quality improvement.

## Testing Instructions
CI should be green.