### PR TITLE
Navigation: Load the raw property on the navigation fallback

### DIFF
--- a/lib/compat/wordpress-6.3/navigation-fallback.php
+++ b/lib/compat/wordpress-6.3/navigation-fallback.php
@@ -26,9 +26,16 @@ function gutenberg_add_fields_to_navigation_fallback_embeded_links( $schema ) {
 	$schema['properties']['content']['context'] = array_merge( $schema['properties']['content']['context'], array( 'embed' ) );
 
 	// Expose sub properties of content field.
+	// These aren't exposed by the posts controller by default, see:
+	// https://github.com/WordPress/wordpress-develop/blob/5c3c6258e468c67ba00bbd13db29994f1a57a52a/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php#L2425
 	$schema['properties']['content']['properties']['raw']['context']           = array_merge( $schema['properties']['content']['properties']['raw']['context'], array( 'embed' ) );
 	$schema['properties']['content']['properties']['rendered']['context']      = array_merge( $schema['properties']['content']['properties']['rendered']['context'], array( 'embed' ) );
 	$schema['properties']['content']['properties']['block_version']['context'] = array_merge( $schema['properties']['content']['properties']['block_version']['context'], array( 'embed' ) );
+
+	// Expose sub properties of title field.
+	// These aren't exposed by the posts controller by default, see:
+	// https://github.com/WordPress/wordpress-develop/blob/5c3c6258e468c67ba00bbd13db29994f1a57a52a/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php#L2401
+	//$schema['properties']['title']['properties']['raw']['context'] = array_merge( $schema['properties']['title']['properties']['raw']['context'], array( 'embed' ) );
 
 	return $schema;
 }

--- a/lib/compat/wordpress-6.3/navigation-fallback.php
+++ b/lib/compat/wordpress-6.3/navigation-fallback.php
@@ -34,8 +34,8 @@ function gutenberg_add_fields_to_navigation_fallback_embeded_links( $schema ) {
 
 	// Expose sub properties of title field.
 	// These aren't exposed by the posts controller by default, see:
-	// https://github.com/WordPress/wordpress-develop/blob/5c3c6258e468c67ba00bbd13db29994f1a57a52a/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php#L2401
-	//$schema['properties']['title']['properties']['raw']['context'] = array_merge( $schema['properties']['title']['properties']['raw']['context'], array( 'embed' ) );
+	// https://github.com/WordPress/wordpress-develop/blob/5c3c6258e468c67ba00bbd13db29994f1a57a52a/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php#L2401.
+	$schema['properties']['title']['properties']['raw']['context'] = array_merge( $schema['properties']['title']['properties']['raw']['context'], array( 'embed' ) );
 
 	return $schema;
 }

--- a/lib/compat/wordpress-6.3/navigation-fallback.php
+++ b/lib/compat/wordpress-6.3/navigation-fallback.php
@@ -27,7 +27,7 @@ function gutenberg_add_fields_to_navigation_fallback_embeded_links( $schema ) {
 
 	// Expose sub properties of content field.
 	// These aren't exposed by the posts controller by default, see:
-	// https://github.com/WordPress/wordpress-develop/blob/5c3c6258e468c67ba00bbd13db29994f1a57a52a/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php#L2425
+	// https://github.com/WordPress/wordpress-develop/blob/5c3c6258e468c67ba00bbd13db29994f1a57a52a/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php#L2425.
 	$schema['properties']['content']['properties']['raw']['context']           = array_merge( $schema['properties']['content']['properties']['raw']['context'], array( 'embed' ) );
 	$schema['properties']['content']['properties']['rendered']['context']      = array_merge( $schema['properties']['content']['properties']['rendered']['context'], array( 'embed' ) );
 	$schema['properties']['content']['properties']['block_version']['context'] = array_merge( $schema['properties']['content']['properties']['block_version']['context'], array( 'embed' ) );

--- a/phpunit/class-gutenberg-rest-navigation-fallback-controller-test.php
+++ b/phpunit/class-gutenberg-rest-navigation-fallback-controller-test.php
@@ -167,7 +167,7 @@ class Gutenberg_REST_Navigation_Fallback_Controller_Test extends WP_Test_REST_Co
 	 *
 	 * @covers wp_add_fields_to_navigation_fallback_embeded_links
 	 */
-	public function test_context_param() {
+	public function test_embedded_navigation_post_contains_required_fields() {
 		// First we'll use the navigation fallback to get a link to the navigation endpoint.
 		$request  = new WP_REST_Request( 'GET', '/wp-block-editor/v1/navigation-fallback' );
 		$response = rest_get_server()->dispatch( $request );

--- a/phpunit/class-gutenberg-rest-navigation-fallback-controller-test.php
+++ b/phpunit/class-gutenberg-rest-navigation-fallback-controller-test.php
@@ -175,7 +175,7 @@ class Gutenberg_REST_Navigation_Fallback_Controller_Test extends WP_Test_REST_Co
 
 		// Extract the navigation endpoint URL from the response.
 		$embedded_navigation_href = $links['self'][0]['href'];
-		preg_match('/\?rest_route=(.*)/', $embedded_navigation_href, $matches );
+		preg_match( '/\?rest_route=(.*)/', $embedded_navigation_href, $matches );
 		$navigation_endpoint = $matches[1];
 
 		// Fetch a navigation from the endpoint, with the context parameter set to embed.

--- a/phpunit/class-gutenberg-rest-navigation-fallback-controller-test.php
+++ b/phpunit/class-gutenberg-rest-navigation-fallback-controller-test.php
@@ -171,7 +171,7 @@ class Gutenberg_REST_Navigation_Fallback_Controller_Test extends WP_Test_REST_Co
 		// First we'll use the navigation fallback to get a link to the navigation endpoint.
 		$request  = new WP_REST_Request( 'GET', '/wp-block-editor/v1/navigation-fallback' );
 		$response = rest_get_server()->dispatch( $request );
-		$links = $response->get_links();
+		$links    = $response->get_links();
 
 		// Extract the navigation endpoint URL from the response.
 		$embedded_navigation_href = $links['self'][0]['href'];
@@ -179,7 +179,7 @@ class Gutenberg_REST_Navigation_Fallback_Controller_Test extends WP_Test_REST_Co
 		$navigation_endpoint = $matches[1];
 
 		// Fetch the "linked" navigation post from the endpoint, with the context parameter set to 'embed' to simulate fetching embedded links.
-		$request  = new WP_REST_Request( 'GET', $navigation_endpoint );
+		$request = new WP_REST_Request( 'GET', $navigation_endpoint );
 		$request->set_param( 'context', 'embed' );
 		$response = rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();

--- a/phpunit/class-gutenberg-rest-navigation-fallback-controller-test.php
+++ b/phpunit/class-gutenberg-rest-navigation-fallback-controller-test.php
@@ -162,7 +162,7 @@ class Gutenberg_REST_Navigation_Fallback_Controller_Test extends WP_Test_REST_Co
 	 *
 	 * By default, the REST response for the Posts Controller will not return all fields
 	 * when the context is set to 'embed'. Assert that correct additional fields are added
-	 * to the embedded Navigation Post, when the navigation fallback endpoint 
+	 * to the embedded Navigation Post, when the navigation fallback endpoint
 	 * is called with the `_embed` param.
 	 *
 	 * @covers wp_add_fields_to_navigation_fallback_embeded_links
@@ -184,12 +184,16 @@ class Gutenberg_REST_Navigation_Fallback_Controller_Test extends WP_Test_REST_Co
 		$response = rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();
 
-		// Verify that the additional fields are present.
+		// Verify that the additional status field is present.
 		$this->assertArrayHasKey( 'status', $data, 'Response title should contain a "status" field.' );
+
+		// Verify that the additional content fields are present.
 		$this->assertArrayHasKey( 'content', $data, 'Response should contain a "content" field.' );
 		$this->assertArrayHasKey( 'raw', $data['content'], 'Response content should contain a "raw" field.' );
 		$this->assertArrayHasKey( 'rendered', $data['content'], 'Response content should contain a "rendered" field.' );
 		$this->assertArrayHasKey( 'block_version', $data['content'], 'Response should contain a "block_version" field.' );
+
+		// Verify that the additional title.raw field is present.
 		$this->assertArrayHasKey( 'raw', $data['title'], 'Response title should contain a "raw" key.' );
 	}
 

--- a/phpunit/class-gutenberg-rest-navigation-fallback-controller-test.php
+++ b/phpunit/class-gutenberg-rest-navigation-fallback-controller-test.php
@@ -186,7 +186,7 @@ class Gutenberg_REST_Navigation_Fallback_Controller_Test extends WP_Test_REST_Co
 
 		// Verify that the additional fields are present.
 		$this->assertArrayHasKey( 'status', $data, 'Response title should contain a "status" field.' );
-		$this->assertArrayHasKey( 'content', $data, 'Response title should contain a "raw" key.' );
+		$this->assertArrayHasKey( 'content', $data, 'Response should contain a "content" field.' );
 		$this->assertArrayHasKey( 'raw', $data['content'], 'Response title should contain a "raw" key.' );
 		$this->assertArrayHasKey( 'rendered', $data['content'], 'Response title should contain a "raw" key.' );
 		$this->assertArrayHasKey( 'block_version', $data['content'], 'Response title should contain a "raw" key.' );

--- a/phpunit/class-gutenberg-rest-navigation-fallback-controller-test.php
+++ b/phpunit/class-gutenberg-rest-navigation-fallback-controller-test.php
@@ -189,7 +189,7 @@ class Gutenberg_REST_Navigation_Fallback_Controller_Test extends WP_Test_REST_Co
 		$this->assertArrayHasKey( 'content', $data, 'Response should contain a "content" field.' );
 		$this->assertArrayHasKey( 'raw', $data['content'], 'Response title should contain a "raw" key.' );
 		$this->assertArrayHasKey( 'rendered', $data['content'], 'Response title should contain a "raw" key.' );
-		$this->assertArrayHasKey( 'block_version', $data['content'], 'Response title should contain a "raw" key.' );
+		$this->assertArrayHasKey( 'block_version', $data['content'], 'Response should contain a "block_version" field.' );
 		$this->assertArrayHasKey( 'raw', $data['title'], 'Response title should contain a "raw" key.' );
 	}
 

--- a/phpunit/class-gutenberg-rest-navigation-fallback-controller-test.php
+++ b/phpunit/class-gutenberg-rest-navigation-fallback-controller-test.php
@@ -188,7 +188,7 @@ class Gutenberg_REST_Navigation_Fallback_Controller_Test extends WP_Test_REST_Co
 		$this->assertArrayHasKey( 'status', $data, 'Response title should contain a "status" field.' );
 		$this->assertArrayHasKey( 'content', $data, 'Response should contain a "content" field.' );
 		$this->assertArrayHasKey( 'raw', $data['content'], 'Response title should contain a "raw" key.' );
-		$this->assertArrayHasKey( 'rendered', $data['content'], 'Response title should contain a "raw" key.' );
+		$this->assertArrayHasKey( 'rendered', $data['content'], 'Response content should contain a "rendered" field.' );
 		$this->assertArrayHasKey( 'block_version', $data['content'], 'Response should contain a "block_version" field.' );
 		$this->assertArrayHasKey( 'raw', $data['title'], 'Response title should contain a "raw" key.' );
 	}

--- a/phpunit/class-gutenberg-rest-navigation-fallback-controller-test.php
+++ b/phpunit/class-gutenberg-rest-navigation-fallback-controller-test.php
@@ -160,10 +160,10 @@ class Gutenberg_REST_Navigation_Fallback_Controller_Test extends WP_Test_REST_Co
 	/**
 	 * Tests that the correct filters are applied to the context parameter.
 	 *
-	 * The REST response for the Posts Controller doesn't return all fields,
-	 * when the context is set to embed. We need to add additional fields
-	 * for the navigation fallback, so that when it embeds a navigation,
-	 * the required fields are present.
+	 * By default, the REST response for the Posts Controller will not return all fields
+	 * when the context is set to 'embed'. Assert that correct additional fields are added
+	 * to the embedded Navigation Post, when the navigation fallback endpoint 
+	 * is called with the `_embed` param.
 	 *
 	 * @covers wp_add_fields_to_navigation_fallback_embeded_links
 	 */

--- a/phpunit/class-gutenberg-rest-navigation-fallback-controller-test.php
+++ b/phpunit/class-gutenberg-rest-navigation-fallback-controller-test.php
@@ -178,7 +178,7 @@ class Gutenberg_REST_Navigation_Fallback_Controller_Test extends WP_Test_REST_Co
 		preg_match( '/\?rest_route=(.*)/', $embedded_navigation_href, $matches );
 		$navigation_endpoint = $matches[1];
 
-		// Fetch a navigation from the endpoint, with the context parameter set to embed.
+		// Fetch the "linked" navigation post from the endpoint, with the context parameter set to 'embed' to simulate fetching embedded links.
 		$request  = new WP_REST_Request( 'GET', $navigation_endpoint );
 		$request->set_param( 'context', 'embed' );
 		$response = rest_get_server()->dispatch( $request );

--- a/phpunit/class-gutenberg-rest-navigation-fallback-controller-test.php
+++ b/phpunit/class-gutenberg-rest-navigation-fallback-controller-test.php
@@ -187,7 +187,7 @@ class Gutenberg_REST_Navigation_Fallback_Controller_Test extends WP_Test_REST_Co
 		// Verify that the additional fields are present.
 		$this->assertArrayHasKey( 'status', $data, 'Response title should contain a "status" field.' );
 		$this->assertArrayHasKey( 'content', $data, 'Response should contain a "content" field.' );
-		$this->assertArrayHasKey( 'raw', $data['content'], 'Response title should contain a "raw" key.' );
+		$this->assertArrayHasKey( 'raw', $data['content'], 'Response content should contain a "raw" field.' );
 		$this->assertArrayHasKey( 'rendered', $data['content'], 'Response content should contain a "rendered" field.' );
 		$this->assertArrayHasKey( 'block_version', $data['content'], 'Response should contain a "block_version" field.' );
 		$this->assertArrayHasKey( 'raw', $data['title'], 'Response title should contain a "raw" key.' );

--- a/phpunit/class-gutenberg-rest-navigation-fallback-controller-test.php
+++ b/phpunit/class-gutenberg-rest-navigation-fallback-controller-test.php
@@ -185,7 +185,7 @@ class Gutenberg_REST_Navigation_Fallback_Controller_Test extends WP_Test_REST_Co
 		$data     = $response->get_data();
 
 		// Verify that the additional fields are present.
-		$this->assertArrayHasKey( 'status', $data, 'Response title should contain a "raw" key.' );
+		$this->assertArrayHasKey( 'status', $data, 'Response title should contain a "status" field.' );
 		$this->assertArrayHasKey( 'content', $data, 'Response title should contain a "raw" key.' );
 		$this->assertArrayHasKey( 'raw', $data['content'], 'Response title should contain a "raw" key.' );
 		$this->assertArrayHasKey( 'rendered', $data['content'], 'Response title should contain a "raw" key.' );

--- a/phpunit/class-gutenberg-rest-navigation-fallback-controller-test.php
+++ b/phpunit/class-gutenberg-rest-navigation-fallback-controller-test.php
@@ -200,6 +200,13 @@ class Gutenberg_REST_Navigation_Fallback_Controller_Test extends WP_Test_REST_Co
 	/**
 	 * @doesNotPerformAssertions
 	 */
+	public function test_context_param() {
+		// Covered by the core test.
+	}
+
+	/**
+	 * @doesNotPerformAssertions
+	 */
 	public function test_get_items() {
 		// Covered by the core test.
 	}


### PR DESCRIPTION
## What?
When loading the navigation fallback with an embed context we need to add the raw property of the title so that we have the response in the format expected by the frontend.

## Why?
Without the raw property, the data resolver treats the data differently which causes errors like https://github.com/WordPress/gutenberg/issues/52680 and https://github.com/WordPress/gutenberg/issues/52691

## How?
Updates the schema to include the raw property.

## Testing Instructions
1. Open the site editor at the root level
2. Open the patterns section
3. Open the headers section
4. Click on a header
5. Add a navigation block to the header, making sure you have two navigation blocks in the template
6. Make sure that the two navigation blocks use different wp_navigation CPTs
7. In trunk you should see an error, on this branch you should not.

## Note
I tried adding an end to end test for this change, but it's not possible to navigate directly to the root of the site editor in the test environment - not sure why.