### PR TITLE
Add GH action to enforce PR labels

### DIFF
--- a/.github/workflows/enforce-pr-labels.yml
+++ b/.github/workflows/enforce-pr-labels.yml
@@ -13,6 +13,6 @@ jobs:
         with:
           mode: exactly
           count: 1
-          labels: "[Type] Accessibility, [Type] Automated Testing, [Type] Bug, [Type] Build Tooling, [Type] Code Quality, [Type] Copy, [Type] Developer Documentation, [Type] Enhancement, [Type] Experimental, [Type] New API, [Type] Other, [Type] Performance, [Type] Project Management, [Type] WP Core Ticket"
+          labels: "[Type] Accessibility (a11y), [Type] Automated Testing, [Type] Bug, [Type] Build Tooling, [Type] Code Quality, [Type] Copy, [Type] Developer Documentation, [Type] Enhancement, [Type] Experimental, [Type] New API, [Type] Other, [Type] Performance, [Type] Project Management, [Type] WP Core Ticket"
           add_comment: true
           message: "## ⚠️ Type of PR label error\n To merge this PR, it requires {{ errorString }} {{ count }} label indicating the type of PR. Other labels are optional and not being checked here. \n- **Type-related labels to choose from**: {{ provided }}.\n- **Labels found**: {{ applied }}."

--- a/.github/workflows/enforce-pr-labels.yml
+++ b/.github/workflows/enforce-pr-labels.yml
@@ -1,0 +1,18 @@
+name: Enforce labels on Pull Request
+on:
+  pull_request:
+    types: [opened, labeled, unlabeled, synchronize]
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: mheap/github-action-required-labels@v5
+        with:
+          mode: exactly
+          count: 1
+          labels: "[Type] Accessibility, [Type] Automated Testing, [Type] Bug, [Type] Build Tooling, [Type] Code Quality, [Type] Copy, [Type] Developer Documentation, [Type] Enhancement, [Type] Experimental, [Type] New API, [Type] Other, [Type] Performance, [Type] Project Management, [Type] WP Core Ticket"
+          add_comment: true
+          message: "## ⚠️ Type of PR label error\n To merge this PR, it requires {{ errorString }} {{ count }} label indicating the type of PR. Other labels are optional and not being checked here. \n- **Type-related labels to choose from**: {{ provided }}.\n- **Labels found**: {{ applied }}."

--- a/.github/workflows/enforce-pr-labels.yml
+++ b/.github/workflows/enforce-pr-labels.yml
@@ -13,6 +13,6 @@ jobs:
         with:
           mode: exactly
           count: 1
-          labels: "[Type] Accessibility (a11y), [Type] Automated Testing, [Type] Bug, [Type] Build Tooling, [Type] Code Quality, [Type] Copy, [Type] Developer Documentation, [Type] Enhancement, [Type] Experimental, [Type] New API, [Type] Other, [Type] Performance, [Type] Project Management, [Type] WP Core Ticket"
+          labels: "[Type] Accessibility (a11y), [Type] Automated Testing, [Type] Breaking Change, [Type] Bug, [Type] Build Tooling, [Type] Code Quality, [Type] Copy, [Type] Developer Documentation, [Type] Enhancement, [Type] Experimental, [Type] Feature, [Type] New API, [Type] Task, [Type] Performance, [Type] Project Management, [Type] Security, [Type] WP Core Ticket"
           add_comment: true
           message: "## ⚠️ Type of PR label error\n To merge this PR, it requires {{ errorString }} {{ count }} label indicating the type of PR. Other labels are optional and not being checked here. \n- **Type-related labels to choose from**: {{ provided }}.\n- **Labels found**: {{ applied }}."

--- a/.github/workflows/enforce-pr-labels.yml
+++ b/.github/workflows/enforce-pr-labels.yml
@@ -3,7 +3,7 @@ on:
   pull_request:
     types: [opened, labeled, unlabeled, synchronize]
 jobs:
-  label:
+  type-related-labels:
     runs-on: ubuntu-latest
     permissions:
       issues: write


### PR DESCRIPTION
## What?
This PR introduces a new GitHub action that enforces that all PRs have exactly one label indicating the type of PR; other labels are not considered in this check.

When a PR has less or more than 1 type-related PR, the bot leaves a comment, and pre-merge checks fail. When the labels are updated, the bot updates/removes the comment and pre-merge checks accordingly.

## Why?
Working on the Gutenberg changelog with mislabeled PRs is challenging. Some examples include:
- PRs with no label indicating their nature.
- PRs with conflicting labels; bugfixes and enhancements refer to the product and not the codebase, like, for example:
  - A PR fixing a documentation issue test should be a documentation PR, not a bugfix.
  - A PR improving an e2e test is an automated testing PR, not an enhancement.
- PRs with unclear labels, like Task (at a high level, all PRs are tasks 😅) or that don't apply to PRs, only to issues (like `Overview`, `Tracking issue`)

## How?
By adding an automation that checks labels and enforces using exactly one of a small set of them, as follows (_to be updated with the final labels used_):
- [Type] Accessibility (a11y)
- [Type] Automated Testing
- [Type] Breaking Change
- [Type] Bug
- [Type] Build Tooling
- [Type] Code Quality
- [Type] Copy
- [Type] Developer Documentation
- [Type] Enhancement
- [Type] Experimental
- [Type] Feature
- [Type] New API
- [Type] Task
- [Type] Performance
- [Type] Project Management
- [Type] Security
- [Type] WP Core Ticket

Note that while there are more type-related labels, many of them don't apply to PRs (e.g., Overview, Discussion don't apply, or PRs that fix Flaky Test issues can be consolidated as `[Type] Automated Testing` PRs).

## Testing Instructions
Check my test repo with the automation enabled [here](https://github.com/priethor/automation-playground/pull/1).

## Screenshots or screencast <!-- if applicable -->
The screenshot below shows what the automation would look like, but please note the example labels are not the same ones as in the Gutenberg repository. See the `How` above to see which labels would be enforced in this repository.
![image](https://github.com/WordPress/gutenberg/assets/27339341/99a50dc8-8f08-410b-8d1d-edb9b6e02951)
