### PR TITLE
Patterns: Align height of save button and patterns pagination

### DIFF
--- a/packages/edit-site/src/components/save-button/index.js
+++ b/packages/edit-site/src/components/save-button/index.js
@@ -19,6 +19,7 @@ export default function SaveButton( {
 	showTooltip = true,
 	defaultLabel,
 	icon,
+	__next40pxDefaultSize = false,
 } ) {
 	const { isDirty, isSaving, isSaveViewOpen } = useSelect( ( select ) => {
 		const { __experimentalGetDirtyEntityRecords, isSavingEntityRecord } =
@@ -83,6 +84,7 @@ export default function SaveButton( {
 			 */
 			showTooltip={ showTooltip }
 			icon={ icon }
+			__next40pxDefaultSize={ __next40pxDefaultSize }
 		>
 			{ label }
 		</Button>

--- a/packages/edit-site/src/components/save-hub/index.js
+++ b/packages/edit-site/src/components/save-hub/index.js
@@ -148,6 +148,7 @@ export default function SaveHub() {
 					disabled={ isSaving }
 					aria-disabled={ isSaving }
 					className="edit-site-save-hub__button"
+					__next40pxDefaultSize
 				>
 					{ label }
 				</Button>
@@ -158,6 +159,7 @@ export default function SaveHub() {
 					showTooltip={ false }
 					icon={ disabled && ! isSaving ? check : null }
 					defaultLabel={ label }
+					__next40pxDefaultSize
 				/>
 			) }
 		</HStack>

--- a/packages/edit-site/src/components/save-hub/style.scss
+++ b/packages/edit-site/src/components/save-hub/style.scss
@@ -3,7 +3,7 @@
 	border-top: 1px solid $gray-800;
 	flex-shrink: 0;
 	margin: 0;
-	padding: $canvas-padding;
+	padding: $grid-unit-20 + $grid-unit-05 $canvas-padding;
 }
 
 .edit-site-save-hub__button {


### PR DESCRIPTION
Follow-up on #52663

## What?

This PR changes the height of the save button from 32px to 40px on the Patterns page of the Site Editor. At the same time, align the height of the save button area and the pagination area.

## Why?

Although not all buttons currently follow that rule, I think the height of the button should be 32px or 40px.

## How?

The first question is whether to align the height of the save button with 32px or 40px, but I chose 40px because I believe this button is an important button used throughout the Site Editor. Also in #46734, we are aiming to make the default size 40px size, and in #43741, there is `__next40pxDefaultSize`  property for that purpose. Additionally, the vertical padding was adjusted to align the height with the existing pagination area.

## Screenshots or screencast <!-- if applicable -->

### Has no unsaved entity

#### Before
![before_no_unsaved_entity](https://github.com/WordPress/gutenberg/assets/54422211/1a19d033-4c95-4fa7-b989-5d0bbe6a1774)

#### After

![after_no_unsaved_entity](https://github.com/WordPress/gutenberg/assets/54422211/82892c85-b7ea-439e-8e0d-31de2c5e7cdb)

### Has unsaved entity

#### Before

![before_has_unsaved_entity](https://github.com/WordPress/gutenberg/assets/54422211/2ae5b6a1-7b89-4a3c-afde-659d751a0182)

#### After

![after_has_unsaved_entity](https://github.com/WordPress/gutenberg/assets/54422211/20ac15e4-62f4-482d-947d-af95b6dafdb8)