### PR TITLE
Image block: Add aspect ratio support to lightbox

### DIFF
--- a/lib/block-supports/behaviors.php
+++ b/lib/block-supports/behaviors.php
@@ -148,7 +148,17 @@ function gutenberg_render_behaviors_support_lightbox( $block_content, $block ) {
 	$img = null;
 	preg_match( '/<img[^>]+>/', $body_content, $img );
 	$button       = '<div class="img-container">
-                             <button type="button" aria-haspopup="dialog" aria-label="' . esc_attr( $aria_label ) . '" data-wp-on--click="actions.core.image.showLightbox" data-wp-on--mouseenter="actions.core.image.preloadLightboxImage"></button>'
+                             <button
+							 	type="button"
+								aria-haspopup="dialog"
+								aria-label="' . esc_attr( $aria_label ) . '"
+								data-wp-on--click="actions.core.image.showLightbox"
+								data-wp-on--mouseenter="actions.core.image.preloadLightboxImage"
+								data-wp-effect="effects.core.image.initImageButton"
+								data-wp-style--width="context.core.image.imageButtonWidth"
+								data-wp-style--height="context.core.image.imageButtonHeight"
+							>
+							</button>'
 		. $img[0] .
 		'</div>';
 	$body_content = preg_replace( '/<img[^>]+>/', $button, $body_content );

--- a/lib/block-supports/behaviors.php
+++ b/lib/block-supports/behaviors.php
@@ -93,12 +93,10 @@ function gutenberg_render_behaviors_support_lightbox( $block_content, $block ) {
 		$img_metadata        = wp_get_attachment_metadata( $block['attrs']['id'] );
 		$img_width           = $img_metadata['width'];
 		$img_height          = $img_metadata['height'];
-		$img_uploaded_srcset = wp_get_attachment_image_srcset( $block['attrs']['id'] );
 	} else {
 		$img_uploaded_src    = $z->get_attribute( 'src' );
 		$img_width           = 'none';
 		$img_height          = 'none';
-		$img_uploaded_srcset = '';
 	}
 
 	$w = new WP_HTML_Tag_Processor( $content );
@@ -118,7 +116,6 @@ function gutenberg_render_behaviors_support_lightbox( $block_content, $block ) {
 						"lightboxAnimation": "%s",
 						"imageUploadedSrc": "%s",
 						"imageCurrentSrc": "",
-						"imageSrcSet": "%s",
 						"targetWidth": "%s",
 						"targetHeight": "%s"
 					}
@@ -126,7 +123,6 @@ function gutenberg_render_behaviors_support_lightbox( $block_content, $block ) {
 			}',
 			$lightbox_animation,
 			$img_uploaded_src,
-			$img_uploaded_srcset,
 			$img_width,
 			$img_height
 		)

--- a/lib/block-supports/behaviors.php
+++ b/lib/block-supports/behaviors.php
@@ -151,6 +151,8 @@ function gutenberg_render_behaviors_support_lightbox( $block_content, $block ) {
 	$m->next_tag( 'img' );
 	$m->set_attribute( 'src', '' );
 	$m->set_attribute( 'data-wp-bind--src', 'selectors.core.image.responsiveImgSrc' );
+	$m->set_attribute( 'data-wp-style--width', 'selectors.core.image.inheritSize' );
+	$m->set_attribute( 'data-wp-style--height', 'selectors.core.image.inheritSize' );
 	$initial_image_content = $m->get_updated_html();
 
 	$q = new WP_HTML_Tag_Processor( $content );
@@ -159,6 +161,8 @@ function gutenberg_render_behaviors_support_lightbox( $block_content, $block ) {
 	$q->next_tag( 'img' );
 	$q->set_attribute( 'src', '' );
 	$q->set_attribute( 'data-wp-bind--src', 'selectors.core.image.enlargedImgSrc' );
+	$q->set_attribute( 'data-wp-style--width', 'selectors.core.image.inheritSize' );
+	$q->set_attribute( 'data-wp-style--height', 'selectors.core.image.inheritSize' );
 	$enlarged_image_content = $q->get_updated_html();
 
 	$background_color = esc_attr( wp_get_global_styles( array( 'color', 'background' ) ) );

--- a/lib/block-supports/behaviors.php
+++ b/lib/block-supports/behaviors.php
@@ -173,7 +173,7 @@ function gutenberg_render_behaviors_support_lightbox( $block_content, $block ) {
 	$m->add_class( 'responsive-image' );
 	$m->next_tag( 'img' );
 	$m->set_attribute( 'src', '' );
-	$m->set_attribute( 'data-wp-bind--src', 'selectors.core.image.responsiveImgSrc' );
+	$m->set_attribute( 'data-wp-bind--src', 'context.core.image.imageCurrentSrc' );
 	$m->set_attribute( 'data-wp-style--object-fit', 'selectors.core.image.lightboxObjectFit' );
 	$initial_image_content = $m->get_updated_html();
 
@@ -181,8 +181,9 @@ function gutenberg_render_behaviors_support_lightbox( $block_content, $block ) {
 	$q->next_tag( 'figure' );
 	$q->add_class( 'enlarged-image' );
 	$q->next_tag( 'img' );
-	$q->set_attribute( 'src', '' );
-	$q->set_attribute( 'data-wp-bind--src', 'selectors.core.image.enlargedImgSrc' );
+	$q->set_attribute( 'loading', 'lazy' );
+	$q->set_attribute( 'data-wp-bind--hidden', '!context.core.image.initialized' );
+	$q->set_attribute( 'src', $img_uploaded_src );
 	$q->set_attribute( 'data-wp-style--object-fit', 'selectors.core.image.lightboxObjectFit' );
 	$enlarged_image_content = $q->get_updated_html();
 

--- a/lib/block-supports/behaviors.php
+++ b/lib/block-supports/behaviors.php
@@ -103,10 +103,17 @@ function gutenberg_render_behaviors_support_lightbox( $block_content, $block ) {
 		$img_height       = 'none';
 	}
 
+	if ( isset( $block['attrs']['scale'] ) ) {
+		$scale_attr = $block['attrs']['scale'];
+	} else {
+		$scale_attr = false;
+	}
+
 	$w = new WP_HTML_Tag_Processor( $content );
 	$w->next_tag( 'figure' );
 	$w->add_class( 'wp-lightbox-container' );
 	$w->set_attribute( 'data-wp-interactive', true );
+	
 	$w->set_attribute(
 		'data-wp-context',
 		sprintf(
@@ -121,14 +128,16 @@ function gutenberg_render_behaviors_support_lightbox( $block_content, $block ) {
 						"imageUploadedSrc": "%s",
 						"imageCurrentSrc": "",
 						"targetWidth": "%s",
-						"targetHeight": "%s"
+						"targetHeight": "%s",
+						"scaleAttr": "%s"
 					}
 				}
 			}',
 			$lightbox_animation,
 			$img_uploaded_src,
 			$img_width,
-			$img_height
+			$img_height,
+			$scale_attr
 		)
 	);
 	$w->next_tag( 'img' );

--- a/lib/block-supports/behaviors.php
+++ b/lib/block-supports/behaviors.php
@@ -165,9 +165,6 @@ function gutenberg_render_behaviors_support_lightbox( $block_content, $block ) {
 	$m->set_attribute( 'src', '' );
 	$m->set_attribute( 'data-wp-bind--src', 'selectors.core.image.responsiveImgSrc' );
 	$m->set_attribute( 'data-wp-style--object-fit', 'selectors.core.image.lightboxObjectFit' );
-	if ( 'fade' === $lightbox_animation ) {
-		$m->set_attribute( 'style', '' );
-	}
 	$initial_image_content = $m->get_updated_html();
 
 	$q = new WP_HTML_Tag_Processor( $content );
@@ -177,9 +174,6 @@ function gutenberg_render_behaviors_support_lightbox( $block_content, $block ) {
 	$q->set_attribute( 'src', '' );
 	$q->set_attribute( 'data-wp-bind--src', 'selectors.core.image.enlargedImgSrc' );
 	$q->set_attribute( 'data-wp-style--object-fit', 'selectors.core.image.lightboxObjectFit' );
-	if ( 'fade' === $lightbox_animation  ) {
-		$q->set_attribute( 'style', '' );
-	}
 	$enlarged_image_content = $q->get_updated_html();
 
 	$background_color = esc_attr( wp_get_global_styles( array( 'color', 'background' ) ) );

--- a/lib/block-supports/behaviors.php
+++ b/lib/block-supports/behaviors.php
@@ -164,6 +164,7 @@ function gutenberg_render_behaviors_support_lightbox( $block_content, $block ) {
 	$m->next_tag( 'img' );
 	$m->set_attribute( 'src', '' );
 	$m->set_attribute( 'data-wp-bind--src', 'selectors.core.image.responsiveImgSrc' );
+	$m->set_attribute( 'data-wp-style--object-fit', 'selectors.core.image.lightboxObjectFit' );
 	$m->set_attribute( 'width', $img_width );
 	$m->set_attribute( 'height', $img_height );
 	if ( 'fade' === $lightbox_animation ) {
@@ -177,6 +178,7 @@ function gutenberg_render_behaviors_support_lightbox( $block_content, $block ) {
 	$q->next_tag( 'img' );
 	$q->set_attribute( 'src', '' );
 	$q->set_attribute( 'data-wp-bind--src', 'selectors.core.image.enlargedImgSrc' );
+	$q->set_attribute( 'data-wp-style--object-fit', 'selectors.core.image.lightboxObjectFit' );
 	$q->set_attribute( 'width', $img_width );
 	$q->set_attribute( 'height', $img_height );
 	if ( 'fade' === $lightbox_animation  ) {

--- a/lib/block-supports/behaviors.php
+++ b/lib/block-supports/behaviors.php
@@ -165,8 +165,6 @@ function gutenberg_render_behaviors_support_lightbox( $block_content, $block ) {
 	$m->set_attribute( 'src', '' );
 	$m->set_attribute( 'data-wp-bind--src', 'selectors.core.image.responsiveImgSrc' );
 	$m->set_attribute( 'data-wp-style--object-fit', 'selectors.core.image.lightboxObjectFit' );
-	$m->set_attribute( 'width', $img_width );
-	$m->set_attribute( 'height', $img_height );
 	if ( 'fade' === $lightbox_animation ) {
 		$m->set_attribute( 'style', '' );
 	}
@@ -179,8 +177,6 @@ function gutenberg_render_behaviors_support_lightbox( $block_content, $block ) {
 	$q->set_attribute( 'src', '' );
 	$q->set_attribute( 'data-wp-bind--src', 'selectors.core.image.enlargedImgSrc' );
 	$q->set_attribute( 'data-wp-style--object-fit', 'selectors.core.image.lightboxObjectFit' );
-	$q->set_attribute( 'width', $img_width );
-	$q->set_attribute( 'height', $img_height );
 	if ( 'fade' === $lightbox_animation  ) {
 		$q->set_attribute( 'style', '' );
 	}

--- a/lib/block-supports/behaviors.php
+++ b/lib/block-supports/behaviors.php
@@ -182,9 +182,15 @@ function gutenberg_render_behaviors_support_lightbox( $block_content, $block ) {
 	$q->next_tag( 'figure' );
 	$q->add_class( 'enlarged-image' );
 	$q->next_tag( 'img' );
-	$q->set_attribute( 'loading', 'lazy' );
-	$q->set_attribute( 'data-wp-bind--hidden', '!context.core.image.initialized' );
-	$q->set_attribute( 'src', $img_uploaded_src );
+
+	// We set the 'src' attribute to an empty string to prevent the browser from loading the image
+	// on initial page load, then bind the attribute to a selector that returns the full-sized image src when
+	// the lightbox is opened. We could use 'loading=lazy' in combination with the 'hidden' attribute to
+	// accomplish the same behavior, but that appraoch breaks progressive loading of the image in Safari
+	// and Chrome (see LINK). Until that is resolved, manually setting the 'src' attribute
+	// in this way seems to be the best solution to load the large image only when needed.
+	$q->set_attribute( 'src', '' );
+	$q->set_attribute( 'data-wp-bind--src', 'selectors.core.image.enlargedImgSrc' );
 	$q->set_attribute( 'data-wp-style--object-fit', 'selectors.core.image.lightboxObjectFit' );
 	$enlarged_image_content = $q->get_updated_html();
 

--- a/lib/block-supports/behaviors.php
+++ b/lib/block-supports/behaviors.php
@@ -173,6 +173,13 @@ function gutenberg_render_behaviors_support_lightbox( $block_content, $block ) {
 	$m->next_tag( 'figure' );
 	$m->add_class( 'responsive-image' );
 	$m->next_tag( 'img' );
+	// We want to set the 'src' attribute to an empty string in the responsive image
+	// because otherwise, as of this writing, the wp_filter_content_tags() function in
+	// WordPress will automatically add a 'srcset' attribute to the image, which will at
+	// times cause the incorrectly sized image to be loaded in the lightbox on Firefox.
+	// Because of this, we bind the 'src' attribute explicitly the current src to reliably
+	// use the exact same image as in the content when the lightbox is first opened while
+	// we wait for the larger image to load.
 	$m->set_attribute( 'src', '' );
 	$m->set_attribute( 'data-wp-bind--src', 'context.core.image.imageCurrentSrc' );
 	$m->set_attribute( 'data-wp-style--object-fit', 'selectors.core.image.lightboxObjectFit' );

--- a/lib/block-supports/behaviors.php
+++ b/lib/block-supports/behaviors.php
@@ -70,7 +70,11 @@ function gutenberg_render_behaviors_support_lightbox( $block_content, $block ) {
 
 	$aria_label = __( 'Enlarge image', 'gutenberg' );
 
-	$alt_attribute = trim( $processor->get_attribute( 'alt' ) );
+	$alt_attribute = $processor->get_attribute( 'alt' );
+
+	if ( null !== $alt_attribute  ) {
+		$alt_attribute = trim( $alt_attribute );
+	}
 
 	if ( $alt_attribute ) {
 		/* translators: %s: Image alt text. */
@@ -151,8 +155,11 @@ function gutenberg_render_behaviors_support_lightbox( $block_content, $block ) {
 	$m->next_tag( 'img' );
 	$m->set_attribute( 'src', '' );
 	$m->set_attribute( 'data-wp-bind--src', 'selectors.core.image.responsiveImgSrc' );
-	$m->set_attribute( 'data-wp-style--width', 'selectors.core.image.inheritSize' );
-	$m->set_attribute( 'data-wp-style--height', 'selectors.core.image.inheritSize' );
+	$m->set_attribute( 'width', $img_width );
+	$m->set_attribute( 'height', $img_height );
+	if ( 'fade' === $lightbox_animation ) {
+		$m->set_attribute( 'style', '' );
+	}
 	$initial_image_content = $m->get_updated_html();
 
 	$q = new WP_HTML_Tag_Processor( $content );
@@ -161,8 +168,11 @@ function gutenberg_render_behaviors_support_lightbox( $block_content, $block ) {
 	$q->next_tag( 'img' );
 	$q->set_attribute( 'src', '' );
 	$q->set_attribute( 'data-wp-bind--src', 'selectors.core.image.enlargedImgSrc' );
-	$q->set_attribute( 'data-wp-style--width', 'selectors.core.image.inheritSize' );
-	$q->set_attribute( 'data-wp-style--height', 'selectors.core.image.inheritSize' );
+	$q->set_attribute( 'width', $img_width );
+	$q->set_attribute( 'height', $img_height );
+	if ( 'fade' === $lightbox_animation  ) {
+		$q->set_attribute( 'style', '' );
+	}
 	$enlarged_image_content = $q->get_updated_html();
 
 	$background_color = esc_attr( wp_get_global_styles( array( 'color', 'background' ) ) );

--- a/lib/block-supports/behaviors.php
+++ b/lib/block-supports/behaviors.php
@@ -157,6 +157,8 @@ function gutenberg_render_behaviors_support_lightbox( $block_content, $block ) {
 					data-wp-on--click="actions.core.image.showLightbox"
 					data-wp-style--width="context.core.image.imageButtonWidth"
 					data-wp-style--height="context.core.image.imageButtonHeight"
+					data-wp-style--left="context.core.image.imageButtonLeft"
+					data-wp-style--top="context.core.image.imageButtonTop"
 				>
 				</button>'
 				. $img[0];

--- a/lib/block-supports/behaviors.php
+++ b/lib/block-supports/behaviors.php
@@ -185,7 +185,7 @@ function gutenberg_render_behaviors_support_lightbox( $block_content, $block ) {
                 <button type="button" aria-label="$close_button_label" style="fill: $close_button_color" class="close-button" data-wp-on--click="actions.core.image.hideLightbox">
                     $close_button_icon
                 </button>
-                $initial_image_content
+                <!-- $initial_image_content -->
 				$enlarged_image_content
                 <div class="scrim" style="background-color: $background_color"></div>
         </div>

--- a/lib/block-supports/behaviors.php
+++ b/lib/block-supports/behaviors.php
@@ -186,9 +186,9 @@ function gutenberg_render_behaviors_support_lightbox( $block_content, $block ) {
 	// We set the 'src' attribute to an empty string to prevent the browser from loading the image
 	// on initial page load, then bind the attribute to a selector that returns the full-sized image src when
 	// the lightbox is opened. We could use 'loading=lazy' in combination with the 'hidden' attribute to
-	// accomplish the same behavior, but that appraoch breaks progressive loading of the image in Safari
-	// and Chrome (see LINK). Until that is resolved, manually setting the 'src' attribute
-	// in this way seems to be the best solution to load the large image only when needed.
+	// accomplish the same behavior, but that approach breaks progressive loading of the image in Safari
+	// and Chrome (see https://github.com/WordPress/gutenberg/pull/52765#issuecomment-1674008151). Until that
+	// is resolved, manually setting the 'src' seems to be the best solution to load the large image on demand.
 	$q->set_attribute( 'src', '' );
 	$q->set_attribute( 'data-wp-bind--src', 'selectors.core.image.enlargedImgSrc' );
 	$q->set_attribute( 'data-wp-style--object-fit', 'selectors.core.image.lightboxObjectFit' );

--- a/lib/block-supports/behaviors.php
+++ b/lib/block-supports/behaviors.php
@@ -199,8 +199,8 @@ function gutenberg_render_behaviors_support_lightbox( $block_content, $block ) {
                 <button type="button" aria-label="$close_button_label" style="fill: $close_button_color" class="close-button" data-wp-on--click="actions.core.image.hideLightbox">
                     $close_button_icon
                 </button>
-                $initial_image_content
-				$enlarged_image_content
+                <div class="lightbox-image-container">$initial_image_content</div>
+				<div class="lightbox-image-container">$enlarged_image_content</div>
                 <div class="scrim" style="background-color: $background_color"></div>
         </div>
 HTML;

--- a/lib/block-supports/behaviors.php
+++ b/lib/block-supports/behaviors.php
@@ -142,25 +142,24 @@ function gutenberg_render_behaviors_support_lightbox( $block_content, $block ) {
 	);
 	$w->next_tag( 'img' );
 	$w->set_attribute( 'data-wp-effect', 'effects.core.image.setCurrentSrc' );
-	$w->set_attribute( 'data-wp-init', 'effects.core.image.initButtonContainStyles' );
-	$w->set_attribute( 'data-wp-on--load', 'effects.core.image.initButtonContainStyles' );
+	$w->set_attribute( 'data-wp-init', 'effects.core.image.initButtonStyles' );
+	$w->set_attribute( 'data-wp-on--load', 'effects.core.image.initButtonStyles' );
 	$body_content = $w->get_updated_html();
 
 	// Wrap the image in the body content with a button.
 	$img = null;
 	preg_match( '/<img[^>]+>/', $body_content, $img );
-	$button       = '<div class="img-container">
-                             <button
-							 	type="button"
-								aria-haspopup="dialog"
-								aria-label="' . esc_attr( $aria_label ) . '"
-								data-wp-on--click="actions.core.image.showLightbox"
-								data-wp-style--width="context.core.image.imageButtonWidth"
-								data-wp-style--height="context.core.image.imageButtonHeight"
-							>
-							</button>'
-		. $img[0] .
-		'</div>';
+	$button       =
+				'<button
+					type="button"
+					aria-haspopup="dialog"
+					aria-label="' . esc_attr( $aria_label ) . '"
+					data-wp-on--click="actions.core.image.showLightbox"
+					data-wp-style--width="context.core.image.imageButtonWidth"
+					data-wp-style--height="context.core.image.imageButtonHeight"
+				>
+				</button>'
+				. $img[0];
 	$body_content = preg_replace( '/<img[^>]+>/', $button, $body_content );
 
 	// We need both a responsive image and an enlarged image to animate

--- a/lib/block-supports/behaviors.php
+++ b/lib/block-supports/behaviors.php
@@ -144,7 +144,11 @@ function gutenberg_render_behaviors_support_lightbox( $block_content, $block ) {
 		'</div>';
 	$body_content = preg_replace( '/<img[^>]+>/', $button, $body_content );
 
-	// Add src to the modal image.
+	// We need both a responsive image and an enlarged image to animate
+	// the zoom seamlessly on slow internet connections; the responsive
+	// image is a copy of the one in the body, which animates immediately
+	// as the lightbox is opened, while the enlarged one is a full-sized
+	// version that will likely still be loading as the animation begins.
 	$m = new WP_HTML_Tag_Processor( $content );
 	$m->next_tag( 'figure' );
 	$m->add_class( 'responsive-image' );
@@ -189,7 +193,7 @@ function gutenberg_render_behaviors_support_lightbox( $block_content, $block ) {
                 <button type="button" aria-label="$close_button_label" style="fill: $close_button_color" class="close-button" data-wp-on--click="actions.core.image.hideLightbox">
                     $close_button_icon
                 </button>
-                <!-- $initial_image_content -->
+                $initial_image_content
 				$enlarged_image_content
                 <div class="scrim" style="background-color: $background_color"></div>
         </div>

--- a/lib/block-supports/behaviors.php
+++ b/lib/block-supports/behaviors.php
@@ -141,9 +141,9 @@ function gutenberg_render_behaviors_support_lightbox( $block_content, $block ) {
 		)
 	);
 	$w->next_tag( 'img' );
-	$w->set_attribute( 'data-wp-effect', 'effects.core.image.setCurrentSrc' );
-	$w->set_attribute( 'data-wp-init', 'effects.core.image.initButtonStyles' );
-	$w->set_attribute( 'data-wp-on--load', 'effects.core.image.initButtonStyles' );
+	$w->set_attribute( 'data-wp-init', 'effects.core.image.setCurrentSrc' );
+	$w->set_attribute( 'data-wp-on--load', 'actions.core.image.handleLoad' );
+	$w->set_attribute( 'data-wp-effect', 'effects.core.image.setButtonStyles' );
 	$body_content = $w->get_updated_html();
 
 	// Wrap the image in the body content with a button.

--- a/lib/block-supports/behaviors.php
+++ b/lib/block-supports/behaviors.php
@@ -142,6 +142,8 @@ function gutenberg_render_behaviors_support_lightbox( $block_content, $block ) {
 	);
 	$w->next_tag( 'img' );
 	$w->set_attribute( 'data-wp-effect', 'effects.core.image.setCurrentSrc' );
+	$w->set_attribute( 'data-wp-init', 'effects.core.image.initButtonContainStyles' );
+	$w->set_attribute( 'data-wp-on--load', 'effects.core.image.initButtonContainStyles' );
 	$body_content = $w->get_updated_html();
 
 	// Wrap the image in the body content with a button.
@@ -153,8 +155,6 @@ function gutenberg_render_behaviors_support_lightbox( $block_content, $block ) {
 								aria-haspopup="dialog"
 								aria-label="' . esc_attr( $aria_label ) . '"
 								data-wp-on--click="actions.core.image.showLightbox"
-								data-wp-on--mouseenter="actions.core.image.preloadLightboxImage"
-								data-wp-effect="effects.core.image.initImageButton"
 								data-wp-style--width="context.core.image.imageButtonWidth"
 								data-wp-style--height="context.core.image.imageButtonHeight"
 							>

--- a/lib/block-supports/behaviors.php
+++ b/lib/block-supports/behaviors.php
@@ -89,14 +89,14 @@ function gutenberg_render_behaviors_support_lightbox( $block_content, $block ) {
 	$z->next_tag( 'img' );
 
 	if ( isset( $block['attrs']['id'] ) ) {
-		$img_uploaded_src    = wp_get_attachment_url( $block['attrs']['id'] );
-		$img_metadata        = wp_get_attachment_metadata( $block['attrs']['id'] );
-		$img_width           = $img_metadata['width'];
-		$img_height          = $img_metadata['height'];
+		$img_uploaded_src = wp_get_attachment_url( $block['attrs']['id'] );
+		$img_metadata     = wp_get_attachment_metadata( $block['attrs']['id'] );
+		$img_width        = $img_metadata['width'];
+		$img_height       = $img_metadata['height'];
 	} else {
-		$img_uploaded_src    = $z->get_attribute( 'src' );
-		$img_width           = 'none';
-		$img_height          = 'none';
+		$img_uploaded_src = $z->get_attribute( 'src' );
+		$img_width        = 'none';
+		$img_height       = 'none';
 	}
 
 	$w = new WP_HTML_Tag_Processor( $content );

--- a/lib/block-supports/behaviors.php
+++ b/lib/block-supports/behaviors.php
@@ -72,7 +72,7 @@ function gutenberg_render_behaviors_support_lightbox( $block_content, $block ) {
 
 	$alt_attribute = $processor->get_attribute( 'alt' );
 
-	if ( null !== $alt_attribute  ) {
+	if ( null !== $alt_attribute ) {
 		$alt_attribute = trim( $alt_attribute );
 	}
 
@@ -113,7 +113,7 @@ function gutenberg_render_behaviors_support_lightbox( $block_content, $block ) {
 	$w->next_tag( 'figure' );
 	$w->add_class( 'wp-lightbox-container' );
 	$w->set_attribute( 'data-wp-interactive', true );
-	
+
 	$w->set_attribute(
 		'data-wp-context',
 		sprintf(

--- a/packages/block-library/src/image/style.scss
+++ b/packages/block-library/src/image/style.scss
@@ -157,6 +157,9 @@
 		position: relative;
 		width: max-content;
 		max-width: 100%;
+		display: flex;
+		justify-content: center;
+		align-items: center;
 	}
 
 	button {
@@ -246,7 +249,6 @@
 		background-color: rgb(255, 255, 255);
 		opacity: 0.9;
 	}
-
 
 	// When fading, make the image come in slightly slower
 	// or faster than the scrim to give a sense of depth.

--- a/packages/block-library/src/image/style.scss
+++ b/packages/block-library/src/image/style.scss
@@ -225,7 +225,8 @@
 
 		img {
 			aspect-ratio: var(--lightbox-image-target-aspect-ratio);
-			object-fit: cover;
+			// Important is needed to overwrite the contain setting.
+			object-fit: cover !important;
 		}
 	}
 
@@ -261,6 +262,8 @@
 				.wp-block-image {
 					img {
 						// Important is needed to overwrite the custom sizes.
+						min-width: var(--lightbox-image-width);
+						min-height: var(--lightbox-image-height);
 						width: var(--lightbox-image-width) !important;
 						height: var(--lightbox-image-height) !important;
 					}
@@ -279,6 +282,8 @@
 					.wp-block-image {
 						img {
 							// Important is needed to overwrite the custom sizes.
+							min-width: var(--lightbox-image-width);
+							min-height: var(--lightbox-image-height);
 							width: var(--lightbox-image-width) !important;
 							height: var(--lightbox-image-height) !important;
 						}

--- a/packages/block-library/src/image/style.scss
+++ b/packages/block-library/src/image/style.scss
@@ -202,8 +202,8 @@
 		left: 50%;
 		transform-origin: top left;
 		transform: translate(-50%, -50%);
-		width: var(--lightbox-container-width);
-		height: var(--lightbox-container-height);
+		width: var(--wp--lightbox-container-width);
+		height: var(--wp--lightbox-container-height);
 		z-index: 9999999999;
 	}
 
@@ -224,7 +224,7 @@
 		}
 
 		img {
-			aspect-ratio: var(--lightbox-image-target-aspect-ratio);
+			aspect-ratio: var(--wp--lightbox-image-target-aspect-ratio);
 			// Important is needed to overwrite the contain setting.
 			object-fit: cover !important;
 		}
@@ -262,10 +262,10 @@
 				.wp-block-image {
 					img {
 						// Important is needed to overwrite the custom sizes.
-						min-width: var(--lightbox-image-width);
-						min-height: var(--lightbox-image-height);
-						width: var(--lightbox-image-width) !important;
-						height: var(--lightbox-image-height) !important;
+						min-width: var(--wp--lightbox-image-width);
+						min-height: var(--wp--lightbox-image-height);
+						width: var(--wp--lightbox-image-width) !important;
+						height: var(--wp--lightbox-image-height) !important;
 					}
 				}
 				.scrim {
@@ -282,10 +282,10 @@
 					.wp-block-image {
 						img {
 							// Important is needed to overwrite the custom sizes.
-							min-width: var(--lightbox-image-width);
-							min-height: var(--lightbox-image-height);
-							width: var(--lightbox-image-width) !important;
-							height: var(--lightbox-image-height) !important;
+							min-width: var(--wp--lightbox-image-width);
+							min-height: var(--wp--lightbox-image-height);
+							width: var(--wp--lightbox-image-width) !important;
+							height: var(--wp--lightbox-image-height) !important;
 						}
 					}
 					.scrim {
@@ -297,7 +297,7 @@
 	}
 }
 
-html.has-lightbox-open {
+html.wp-has-lightbox-open {
 	overflow: hidden;
 }
 
@@ -327,7 +327,7 @@ html.has-lightbox-open {
 
 @keyframes lightbox-zoom-in {
 	0% {
-		transform: translate(calc(-50vw + var(--lightbox-initial-left-position)), calc(-50vh + var(--lightbox-initial-top-position))) scale(var(--lightbox-scale));
+		transform: translate(calc(-50vw + var(--wp--lightbox-initial-left-position)), calc(-50vh + var(--wp--lightbox-initial-top-position))) scale(var(--wp--lightbox-scale));
 	}
 	100% {
 		transform: translate(-50%, -50%) scale(1, 1);
@@ -344,6 +344,6 @@ html.has-lightbox-open {
 	}
 	100% {
 		visibility: hidden;
-		transform: translate(calc(-50vw + var(--lightbox-initial-left-position)), calc(-50vh + var(--lightbox-initial-top-position))) scale(var(--lightbox-scale));
+		transform: translate(calc(-50vw + var(--wp--lightbox-initial-left-position)), calc(-50vh + var(--wp--lightbox-initial-top-position))) scale(var(--wp--lightbox-scale));
 	}
 }

--- a/packages/block-library/src/image/style.scss
+++ b/packages/block-library/src/image/style.scss
@@ -219,6 +219,13 @@
 		z-index: 3000000;
 		margin: 0;
 
+		img {
+			min-width: var(--wp--lightbox-image-width);
+			min-height: var(--wp--lightbox-image-height);
+			width: var(--wp--lightbox-image-width);
+			height: var(--wp--lightbox-image-height);
+		}
+
 		figcaption {
 			display: none;
 		}
@@ -252,15 +259,6 @@
 				.lightbox-image-container {
 					animation: lightbox-zoom-in 0.4s;
 				}
-
-				.wp-block-image {
-					img {
-						min-width: var(--wp--lightbox-image-width);
-						min-height: var(--wp--lightbox-image-height);
-						width: var(--wp--lightbox-image-width);
-						height: var(--wp--lightbox-image-height);
-					}
-				}
 				.scrim {
 					animation: turn-on-visibility 0.4s forwards;
 				}
@@ -270,15 +268,6 @@
 					animation: none;
 					.lightbox-image-container {
 						animation: lightbox-zoom-out 0.4s;
-					}
-
-					.wp-block-image {
-						img {
-							min-width: var(--wp--lightbox-image-width);
-							min-height: var(--wp--lightbox-image-height);
-							width: var(--wp--lightbox-image-width);
-							height: var(--wp--lightbox-image-height);
-						}
 					}
 					.scrim {
 						animation: turn-off-visibility 0.4s forwards;

--- a/packages/block-library/src/image/style.scss
+++ b/packages/block-library/src/image/style.scss
@@ -184,10 +184,6 @@
 	width: 100vw;
 	height: 100vh;
 	box-sizing: border-box;
-	display: flex;
-	justify-content: center;
-	align-items: center;
-	flex-direction: column;
 	visibility: hidden;
 	cursor: zoom-out;
 
@@ -202,22 +198,29 @@
 
 	.wp-block-image {
 		position: absolute;
-		transform-origin: top left;
-		width: var(--lightbox-image-max-width);
-		height: var(--lightbox-image-max-height);
-		z-index: 3000000;
+		width: 100%;
+		height: 100%;
 		display: flex;
 		justify-content: center;
 		align-items: center;
+		box-sizing: border-box;
+		z-index: 3000000;
+		padding: 40px 0;
 
+		@media screen and (min-width: 480px) {
+			padding: 40px;
+		}
+
+		@media screen and (min-width: 1920px) {
+			padding: 40px 80px;
+		}
 
 		figcaption {
 			display: none;
 		}
 
 		img {
-			width: var(--lightbox-image-max-width);
-			height: var(--lightbox-image-max-height);
+			width: auto;
 			max-width: 100%;
 			max-height: 100%;
 		}
@@ -237,68 +240,72 @@
 		opacity: 0.9;
 	}
 
-	&.fade {
-		.wp-block-image {
-			padding: 40px 0;
+	&.active {
+		visibility: visible;
+		animation: both turn-on-visibility 0.25s;
 
-			@media screen and (min-width: 480px) {
-				padding: 40px;
-			}
-
-			@media screen and (min-width: 1920px) {
-				padding: 40px 80px;
-			}
+		img {
+			animation: both turn-on-visibility 0.3s;
 		}
+	}
 
-		&.active {
-			visibility: visible;
-			animation: both turn-on-visibility 0.25s;
+	&.hideanimationenabled {
+		&:not(.active) {
+			animation: both turn-off-visibility 0.3s;
 
 			img {
-				animation: both turn-on-visibility 0.3s;
-			}
-		}
-		&.hideanimationenabled {
-			&:not(.active) {
-				animation: both turn-off-visibility 0.3s;
-
-				img {
-					animation: both turn-off-visibility 0.25s;
-				}
+				animation: both turn-off-visibility 0.25s;
 			}
 		}
 	}
 
-	&.zoom {
-		img {
-			object-fit: cover;
-		}
-
-		&.active {
-			opacity: 1;
-			visibility: visible;
+	@media (prefers-reduced-motion: no-preference) {
+		&.zoom {
 			.wp-block-image {
-				animation: lightbox-zoom-in 0.4s forwards;
+				width: var(--lightbox-origin-width);
+				height: var(--lightbox-origin-height);
+				left: var(--lightbox-origin-left-position);
+				top: var(--lightbox-origin-top-position);
+				transform-origin: center center;
+				padding: 0;
 
-				@media (prefers-reduced-motion) {
-					animation: both turn-on-visibility 0.4s;
+				img {
+					object-fit: cover;
+					width: 100%;
+					height: 100%;
 				}
 			}
-			.scrim {
-				animation: turn-on-visibility 0.4s forwards;
-			}
-		}
-		&.hideanimationenabled {
-			&:not(.active) {
-				.wp-block-image {
-					animation: lightbox-zoom-out 0.4s forwards;
 
-					@media (prefers-reduced-motion) {
-						animation: both turn-off-visibility 0.4s;
+			&.active {
+				opacity: 1;
+				visibility: visible;
+				animation: none;
+
+				.wp-block-image {
+					animation: lightbox-zoom-in 0.4s forwards;
+
+					img {
+						animation: none;
 					}
 				}
 				.scrim {
-					animation: turn-off-visibility 0.4s forwards;
+					animation: turn-on-visibility 0.4s forwards;
+				}
+			}
+			&.hideanimationenabled {
+				&:not(.active) {
+					animation: none;
+
+					.wp-block-image {
+						animation: lightbox-zoom-out 0.4s forwards;
+
+						img {
+							animation: none;
+						}
+					}
+					.scrim {
+						animation: turn-off-visibility 0.4s forwards;
+					}
 				}
 			}
 		}
@@ -335,30 +342,22 @@ html.has-lightbox-open {
 
 @keyframes lightbox-zoom-in {
 	0% {
-		left: var(--lightbox-initial-left-position);
-		top: var(--lightbox-initial-top-position);
-		transform: scale(var(--lightbox-scale-width), var(--lightbox-scale-height));
+		transform: translate(0, 0) scale(1, 1);
 	}
 	100% {
-		left: var(--lightbox-target-left-position);
-		top: var(--lightbox-target-top-position);
-		transform: scale(1, 1);
+		transform: translate(var(--lightbox-translate-left-position), var(--lightbox-translate-top-position)) scale(var(--lightbox-scale-width), var(--lightbox-scale-height));
 	}
 }
 
 @keyframes lightbox-zoom-out {
 	0% {
 		visibility: visible;
-		left: var(--lightbox-target-left-position);
-		top: var(--lightbox-target-top-position);
-		transform: scale(1, 1);
+		transform: translate(var(--lightbox-translate-left-position), var(--lightbox-translate-top-position)) scale(var(--lightbox-scale-width), var(--lightbox-scale-height));
 	}
 	99% {
 		visibility: visible;
 	}
 	100% {
-		left: var(--lightbox-initial-left-position);
-		top: var(--lightbox-initial-top-position);
-		transform: scale(var(--lightbox-scale-width), var(--lightbox-scale-height));
+		transform: translate(0, 0) scale(1, 1);
 	}
 }

--- a/packages/block-library/src/image/style.scss
+++ b/packages/block-library/src/image/style.scss
@@ -222,12 +222,6 @@
 		figcaption {
 			display: none;
 		}
-
-		img {
-			aspect-ratio: var(--wp--lightbox-image-target-aspect-ratio);
-			// Important is needed to overwrite the contain setting.
-			object-fit: cover !important;
-		}
 	}
 
 	button {
@@ -261,11 +255,10 @@
 
 				.wp-block-image {
 					img {
-						// Important is needed to overwrite the custom sizes.
 						min-width: var(--wp--lightbox-image-width);
 						min-height: var(--wp--lightbox-image-height);
-						width: var(--wp--lightbox-image-width) !important;
-						height: var(--wp--lightbox-image-height) !important;
+						width: var(--wp--lightbox-image-width);
+						height: var(--wp--lightbox-image-height);
 					}
 				}
 				.scrim {
@@ -281,11 +274,10 @@
 
 					.wp-block-image {
 						img {
-							// Important is needed to overwrite the custom sizes.
 							min-width: var(--wp--lightbox-image-width);
 							min-height: var(--wp--lightbox-image-height);
-							width: var(--wp--lightbox-image-width) !important;
-							height: var(--wp--lightbox-image-height) !important;
+							width: var(--wp--lightbox-image-width);
+							height: var(--wp--lightbox-image-height);
 						}
 					}
 					.scrim {

--- a/packages/block-library/src/image/style.scss
+++ b/packages/block-library/src/image/style.scss
@@ -262,17 +262,18 @@
 	@media (prefers-reduced-motion: no-preference) {
 		&.zoom {
 			.wp-block-image {
-				width: var(--lightbox-origin-width);
-				height: var(--lightbox-origin-height);
 				left: var(--lightbox-origin-left-position);
 				top: var(--lightbox-origin-top-position);
-				transform-origin: center center;
+				width: var(--lightbox-origin-width);
+				height: var(--lightbox-origin-height);
 				padding: 0;
+				overflow: var(--lightbox-outer-overflow);
 
 				img {
 					object-fit: cover;
-					width: 100%;
-					height: 100%;
+					width: var(--lightbox-inner-width);
+					height: var(--lightbox-inner-height);
+					transform-origin: center center;
 				}
 			}
 
@@ -282,10 +283,10 @@
 				animation: none;
 
 				.wp-block-image {
-					animation: lightbox-zoom-in 0.4s forwards;
+					animation: lightbox-outer-zoom-in 0.4s forwards;
 
 					img {
-						animation: none;
+						animation: lightbox-inner-zoom-in 0.4s forwards;
 					}
 				}
 				.scrim {
@@ -297,10 +298,10 @@
 					animation: none;
 
 					.wp-block-image {
-						animation: lightbox-zoom-out 0.4s forwards;
+						animation: lightbox-outer-zoom-out 0.4s forwards;
 
 						img {
-							animation: none;
+							animation: lightbox-inner-zoom-out 0.4s forwards;
 						}
 					}
 					.scrim {
@@ -340,24 +341,42 @@ html.has-lightbox-open {
 	}
 }
 
-@keyframes lightbox-zoom-in {
+@keyframes lightbox-outer-zoom-in {
 	0% {
 		transform: translate(0, 0) scale(1, 1);
 	}
 	100% {
-		transform: translate(var(--lightbox-translate-left-position), var(--lightbox-translate-top-position)) scale(var(--lightbox-scale-width), var(--lightbox-scale-height));
+		transform: translate(var(--lightbox-translate-left-position), var(--lightbox-translate-top-position)) scale(var(--lightbox-outer-scale-width), var(--lightbox-outer-scale-height));
 	}
 }
 
-@keyframes lightbox-zoom-out {
+@keyframes lightbox-outer-zoom-out {
 	0% {
 		visibility: visible;
-		transform: translate(var(--lightbox-translate-left-position), var(--lightbox-translate-top-position)) scale(var(--lightbox-scale-width), var(--lightbox-scale-height));
+		transform: translate(var(--lightbox-translate-left-position), var(--lightbox-translate-top-position)) scale(var(--lightbox-outer-scale-width), var(--lightbox-outer-scale-height));
 	}
 	99% {
 		visibility: visible;
 	}
 	100% {
 		transform: translate(0, 0) scale(1, 1);
+	}
+}
+
+@keyframes lightbox-inner-zoom-in {
+	0% {
+		transform: scale(var(--lightbox-inner-initial-scale-width), var(--lightbox-inner-initial-scale-height));
+	}
+	100% {
+		transform: scale(var(--lightbox-inner-target-scale-width), var(--lightbox-inner-target-scale-height));
+	}
+}
+
+@keyframes lightbox-inner-zoom-out {
+	0% {
+		transform: scale(var(--lightbox-inner-target-scale-width), var(--lightbox-inner-target-scale-height));
+	}
+	100% {
+		transform: scale(var(--lightbox-inner-initial-scale-width), var(--lightbox-inner-initial-scale-height));
 	}
 }

--- a/packages/block-library/src/image/style.scss
+++ b/packages/block-library/src/image/style.scss
@@ -183,6 +183,11 @@
 	overflow: hidden;
 	width: 100vw;
 	height: 100vh;
+	box-sizing: border-box;
+	display: flex;
+	justify-content: center;
+	align-items: center;
+	flex-direction: column;
 	visibility: hidden;
 	cursor: zoom-out;
 
@@ -196,24 +201,25 @@
 	}
 
 	.wp-block-image {
-		width: 100%;
-		height: 100%;
 		position: absolute;
+		transform-origin: top left;
+		width: var(--lightbox-image-max-width);
+		height: var(--lightbox-image-max-height);
 		z-index: 3000000;
-		box-sizing: border-box;
 		display: flex;
 		justify-content: center;
 		align-items: center;
-		flex-direction: column;
+
 
 		figcaption {
 			display: none;
 		}
 
 		img {
+			width: var(--lightbox-image-max-width);
+			height: var(--lightbox-image-max-height);
 			max-width: 100%;
 			max-height: 100%;
-			width: auto;
 		}
 	}
 
@@ -265,16 +271,14 @@
 
 	&.zoom {
 		img {
-			position: absolute;
-			transform-origin: top left;
-			width: var(--lightbox-image-max-width);
-			height: var(--lightbox-image-max-height);
+			width: inherit !important;
+			height: inherit !important;
 		}
 
 		&.active {
 			opacity: 1;
 			visibility: visible;
-			.wp-block-image img {
+			.wp-block-image {
 				animation: lightbox-zoom-in 0.4s forwards;
 
 				@media (prefers-reduced-motion) {
@@ -287,7 +291,7 @@
 		}
 		&.hideanimationenabled {
 			&:not(.active) {
-				.wp-block-image img {
+				.wp-block-image {
 					animation: lightbox-zoom-out 0.4s forwards;
 
 					@media (prefers-reduced-motion) {
@@ -337,18 +341,18 @@ html.has-lightbox-open {
 		transform: scale(var(--lightbox-scale-width), var(--lightbox-scale-height));
 	}
 	100% {
-		left: var(--lightbox-target-left-position);
-		top: var(--lightbox-target-top-position);
-		transform: scale(1, 1);
+		left: 50%;
+		top: 50%;
+		transform: translate(-50%, -50%) scale(1, 1);
 	}
 }
 
 @keyframes lightbox-zoom-out {
 	0% {
 		visibility: visible;
-		left: var(--lightbox-target-left-position);
-		top: var(--lightbox-target-top-position);
-		transform: scale(1, 1);
+		left: 50%;
+		top: 50%;
+		transform: translate(-50%, -50%) scale(1, 1);
 	}
 	99% {
 		visibility: visible;

--- a/packages/block-library/src/image/style.scss
+++ b/packages/block-library/src/image/style.scss
@@ -153,7 +153,6 @@
 }
 
 .wp-lightbox-container {
-
 	.img-container {
 		position: relative;
 	}
@@ -198,31 +197,25 @@
 
 	.wp-block-image {
 		position: absolute;
+		transform-origin: 0 0;
+		top: 0;
+		left: 0;
+		display: flex;
 		width: 100%;
 		height: 100%;
-		display: flex;
 		justify-content: center;
 		align-items: center;
 		box-sizing: border-box;
 		z-index: 3000000;
-		padding: 40px 0;
-
-		@media screen and (min-width: 480px) {
-			padding: 40px;
-		}
-
-		@media screen and (min-width: 1920px) {
-			padding: 40px 80px;
-		}
+		margin: 0;
 
 		figcaption {
 			display: none;
 		}
 
 		img {
-			width: auto;
-			max-width: 100%;
-			max-height: 100%;
+			aspect-ratio: var(--lightbox-image-target-aspect-ratio);
+			object-fit: cover;
 		}
 	}
 
@@ -243,51 +236,23 @@
 	&.active {
 		visibility: visible;
 		animation: both turn-on-visibility 0.25s;
-
-		img {
-			animation: both turn-on-visibility 0.3s;
-		}
-	}
-
-	&.hideanimationenabled {
-		&:not(.active) {
-			animation: both turn-off-visibility 0.3s;
-
-			img {
-				animation: both turn-off-visibility 0.25s;
-			}
-		}
 	}
 
 	@media (prefers-reduced-motion: no-preference) {
 		&.zoom {
-			.wp-block-image {
-				left: var(--lightbox-origin-left-position);
-				top: var(--lightbox-origin-top-position);
-				width: var(--lightbox-origin-width);
-				height: var(--lightbox-origin-height);
-				padding: 0;
-				overflow: var(--lightbox-outer-overflow);
-
-				img {
-					object-fit: cover;
-					width: var(--lightbox-inner-width);
-					height: var(--lightbox-inner-height);
-					transform-origin: center center;
-				}
-			}
-
 			&.active {
 				opacity: 1;
 				visibility: visible;
 				animation: none;
 
 				.wp-block-image {
-					animation: lightbox-outer-zoom-in 0.4s forwards;
-
 					img {
-						animation: lightbox-inner-zoom-in 0.4s forwards;
+						animation: lightbox-zoom-in 0.4s;
+						// Important is needed to overwrite the custom sizes.
+						width: var(--lightbox-image-width) !important;
+						height: var(--lightbox-image-height) !important;
 					}
+					// animation: lightbox-zoom-in 0.4s;
 				}
 				.scrim {
 					animation: turn-on-visibility 0.4s forwards;
@@ -298,11 +263,13 @@
 					animation: none;
 
 					.wp-block-image {
-						animation: lightbox-outer-zoom-out 0.4s forwards;
-
 						img {
-							animation: lightbox-inner-zoom-out 0.4s forwards;
+							animation: lightbox-zoom-out 0.4s;
+							// Important is needed to overwrite the custom sizes.
+							width: var(--lightbox-image-width) !important;
+							height: var(--lightbox-image-height) !important;
 						}
+						// animation: lightbox-zoom-out 0.4s;
 					}
 					.scrim {
 						animation: turn-off-visibility 0.4s forwards;
@@ -341,42 +308,25 @@ html.has-lightbox-open {
 	}
 }
 
-@keyframes lightbox-outer-zoom-in {
+@keyframes lightbox-zoom-in {
 	0% {
-		transform: translate(0, 0) scale(1, 1);
+		transform: translate(var(--lightbox-initial-left-position), var(--lightbox-initial-top-position)) scale(var(--lightbox-scale));
 	}
 	100% {
-		transform: translate(var(--lightbox-translate-left-position), var(--lightbox-translate-top-position)) scale(var(--lightbox-outer-scale-width), var(--lightbox-outer-scale-height));
+		transform: translate(0, 0) scale(1, 1);
 	}
 }
 
-@keyframes lightbox-outer-zoom-out {
+@keyframes lightbox-zoom-out {
 	0% {
 		visibility: visible;
-		transform: translate(var(--lightbox-translate-left-position), var(--lightbox-translate-top-position)) scale(var(--lightbox-outer-scale-width), var(--lightbox-outer-scale-height));
+		transform: translate(0, 0) scale(1, 1);
 	}
 	99% {
 		visibility: visible;
 	}
 	100% {
-		transform: translate(0, 0) scale(1, 1);
-	}
-}
-
-@keyframes lightbox-inner-zoom-in {
-	0% {
-		transform: scale(var(--lightbox-inner-initial-scale-width), var(--lightbox-inner-initial-scale-height));
-	}
-	100% {
-		transform: scale(var(--lightbox-inner-target-scale-width), var(--lightbox-inner-target-scale-height));
-	}
-}
-
-@keyframes lightbox-inner-zoom-out {
-	0% {
-		transform: scale(var(--lightbox-inner-target-scale-width), var(--lightbox-inner-target-scale-height));
-	}
-	100% {
-		transform: scale(var(--lightbox-inner-initial-scale-width), var(--lightbox-inner-initial-scale-height));
+		visibility: hidden;
+		transform: translate(var(--lightbox-initial-left-position), var(--lightbox-initial-top-position)) scale(var(--lightbox-scale));
 	}
 }

--- a/packages/block-library/src/image/style.scss
+++ b/packages/block-library/src/image/style.scss
@@ -195,11 +195,21 @@
 		z-index: 5000000;
 	}
 
-	.wp-block-image {
+	.lightbox-image-container {
 		position: absolute;
+		overflow: hidden;
+		top: 50%;
+		left: 50%;
+		transform-origin: top left;
+		transform: translate(-50%, -50%);
+		width: var(--lightbox-container-width);
+		height: var(--lightbox-container-height);
+		z-index: 9999999999;
+	}
+
+	.wp-block-image {
+		position: relative;
 		transform-origin: 0 0;
-		top: 0;
-		left: 0;
 		display: flex;
 		width: 100%;
 		height: 100%;
@@ -244,15 +254,16 @@
 				opacity: 1;
 				visibility: visible;
 				animation: none;
+				.lightbox-image-container {
+					animation: lightbox-zoom-in 0.4s;
+				}
 
 				.wp-block-image {
 					img {
-						animation: lightbox-zoom-in 0.4s;
 						// Important is needed to overwrite the custom sizes.
 						width: var(--lightbox-image-width) !important;
 						height: var(--lightbox-image-height) !important;
 					}
-					// animation: lightbox-zoom-in 0.4s;
 				}
 				.scrim {
 					animation: turn-on-visibility 0.4s forwards;
@@ -261,15 +272,16 @@
 			&.hideanimationenabled {
 				&:not(.active) {
 					animation: none;
+					.lightbox-image-container {
+						animation: lightbox-zoom-out 0.4s;
+					}
 
 					.wp-block-image {
 						img {
-							animation: lightbox-zoom-out 0.4s;
 							// Important is needed to overwrite the custom sizes.
 							width: var(--lightbox-image-width) !important;
 							height: var(--lightbox-image-height) !important;
 						}
-						// animation: lightbox-zoom-out 0.4s;
 					}
 					.scrim {
 						animation: turn-off-visibility 0.4s forwards;
@@ -310,23 +322,23 @@ html.has-lightbox-open {
 
 @keyframes lightbox-zoom-in {
 	0% {
-		transform: translate(var(--lightbox-initial-left-position), var(--lightbox-initial-top-position)) scale(var(--lightbox-scale));
+		transform: translate(calc(-50vw + var(--lightbox-initial-left-position)), calc(-50vh + var(--lightbox-initial-top-position))) scale(var(--lightbox-scale));
 	}
 	100% {
-		transform: translate(0, 0) scale(1, 1);
+		transform: translate(-50%, -50%) scale(1, 1);
 	}
 }
 
 @keyframes lightbox-zoom-out {
 	0% {
 		visibility: visible;
-		transform: translate(0, 0) scale(1, 1);
+		transform: translate(-50%, -50%) scale(1, 1);
 	}
 	99% {
 		visibility: visible;
 	}
 	100% {
 		visibility: hidden;
-		transform: translate(var(--lightbox-initial-left-position), var(--lightbox-initial-top-position)) scale(var(--lightbox-scale));
+		transform: translate(calc(-50vw + var(--lightbox-initial-left-position)), calc(-50vh + var(--lightbox-initial-top-position))) scale(var(--lightbox-scale));
 	}
 }

--- a/packages/block-library/src/image/style.scss
+++ b/packages/block-library/src/image/style.scss
@@ -340,18 +340,18 @@ html.has-lightbox-open {
 		transform: scale(var(--lightbox-scale-width), var(--lightbox-scale-height));
 	}
 	100% {
-		left: 50%;
-		top: 50%;
-		transform: translate(-50%, -50%) scale(1, 1);
+		left: var(--lightbox-target-left-position);
+		top: var(--lightbox-target-top-position);
+		transform: scale(1, 1);
 	}
 }
 
 @keyframes lightbox-zoom-out {
 	0% {
 		visibility: visible;
-		left: 50%;
-		top: 50%;
-		transform: translate(-50%, -50%) scale(1, 1);
+		left: var(--lightbox-target-left-position);
+		top: var(--lightbox-target-top-position);
+		transform: scale(1, 1);
 	}
 	99% {
 		visibility: visible;

--- a/packages/block-library/src/image/style.scss
+++ b/packages/block-library/src/image/style.scss
@@ -153,14 +153,10 @@
 }
 
 .wp-lightbox-container {
-	.img-container {
-		position: relative;
-		width: max-content;
-		max-width: 100%;
-		display: flex;
-		justify-content: center;
-		align-items: center;
-	}
+	position: relative;
+	display: flex;
+	justify-content: center;
+	align-items: center;
 
 	button {
 		border: none;

--- a/packages/block-library/src/image/style.scss
+++ b/packages/block-library/src/image/style.scss
@@ -247,9 +247,23 @@
 		opacity: 0.9;
 	}
 
+
+	// When fading, make the image come in slightly slower
+	// or faster than the scrim to give a sense of depth.
 	&.active {
 		visibility: visible;
 		animation: both turn-on-visibility 0.25s;
+		img {
+			animation: both turn-on-visibility 0.35s;
+		}
+	}
+	&.hideanimationenabled {
+		&:not(.active) {
+			animation: both turn-off-visibility 0.35s;
+			img {
+				animation: both turn-off-visibility 0.25s;
+			}
+		}
 	}
 
 	@media (prefers-reduced-motion: no-preference) {
@@ -260,6 +274,10 @@
 				animation: none;
 				.lightbox-image-container {
 					animation: lightbox-zoom-in 0.4s;
+					// Override fade animation for image
+					img {
+						animation: none;
+					}
 				}
 				.scrim {
 					animation: turn-on-visibility 0.4s forwards;
@@ -270,6 +288,10 @@
 					animation: none;
 					.lightbox-image-container {
 						animation: lightbox-zoom-out 0.4s;
+						// Override fade animation for image
+						img {
+							animation: none;
+						}
 					}
 					.scrim {
 						animation: turn-off-visibility 0.4s forwards;

--- a/packages/block-library/src/image/style.scss
+++ b/packages/block-library/src/image/style.scss
@@ -154,9 +154,6 @@
 
 .wp-lightbox-container {
 	position: relative;
-	display: flex;
-	justify-content: center;
-	align-items: center;
 
 	button {
 		border: none;

--- a/packages/block-library/src/image/style.scss
+++ b/packages/block-library/src/image/style.scss
@@ -155,6 +155,8 @@
 .wp-lightbox-container {
 	.img-container {
 		position: relative;
+		width: max-content;
+		max-width: 100%;
 	}
 
 	button {

--- a/packages/block-library/src/image/style.scss
+++ b/packages/block-library/src/image/style.scss
@@ -270,6 +270,10 @@
 	}
 
 	&.zoom {
+		img {
+			object-fit: cover;
+		}
+
 		&.active {
 			opacity: 1;
 			visibility: visible;

--- a/packages/block-library/src/image/style.scss
+++ b/packages/block-library/src/image/style.scss
@@ -270,11 +270,6 @@
 	}
 
 	&.zoom {
-		img {
-			width: inherit !important;
-			height: inherit !important;
-		}
-
 		&.active {
 			opacity: 1;
 			visibility: visible;

--- a/packages/block-library/src/image/view-interactivity.js
+++ b/packages/block-library/src/image/view-interactivity.js
@@ -95,7 +95,9 @@ store( {
 						);
 
 						context.core.image.lightboxEnabled = false;
-						context.core.image.lastFocusedElement.focus();
+						context.core.image.lastFocusedElement.focus( {
+							preventScroll: true,
+						} );
 					}
 				},
 				handleKeydown: ( { context, actions, event } ) => {

--- a/packages/block-library/src/image/view-interactivity.js
+++ b/packages/block-library/src/image/view-interactivity.js
@@ -197,6 +197,34 @@ store( {
 						ref.querySelector( '.close-button' ).focus();
 					}
 				},
+				initImageButton: ( { context, ref } ) => {
+					const originalImage =
+						ref.parentElement.querySelector( 'img' );
+					const {
+						naturalWidth,
+						naturalHeight,
+						offsetWidth: originalWidth,
+						offsetHeight: originalHeight,
+					} = originalImage;
+
+					// Natural ratio of the image.
+					const naturalRatio = naturalWidth / naturalHeight;
+					// Original ratio of the image.
+					const originalRatio = originalWidth / originalHeight;
+					if ( naturalRatio > originalRatio ) {
+						// If it reaches the width first, keep the width
+						// and recalculate the height.
+						context.core.image.imageButtonWidth = originalWidth;
+						context.core.image.imageButtonHeight =
+							originalWidth / naturalRatio;
+					} else {
+						// If it reaches the height first, keep the height
+						// and recalculate the width.
+						context.core.image.imageButtonHeight = originalHeight;
+						context.core.image.imageButtonWidth =
+							originalHeight * naturalRatio;
+					}
+				},
 			},
 		},
 	},

--- a/packages/block-library/src/image/view-interactivity.js
+++ b/packages/block-library/src/image/view-interactivity.js
@@ -174,6 +174,11 @@ store(
 							return 'cover';
 						}
 					},
+					enlargedImgSrc: ( { context } ) => {
+						return context.core.image.initialized
+							? context.core.image.imageUploadedSrc
+							: '';
+					},
 				},
 			},
 		},

--- a/packages/block-library/src/image/view-interactivity.js
+++ b/packages/block-library/src/image/view-interactivity.js
@@ -216,45 +216,45 @@ function setZoomStyles( context, event ) {
 	// dimensions have not been set (i.e. an external image with only one size),
 	// the image's dimensions in the lightbox are the same
 	// as those of the image in the content.
-	let targetWidth = parseFloat(
+	let imgMaxWidth = parseFloat(
 		context.core.image.targetWidth !== 'none'
 			? context.core.image.targetWidth
 			: naturalWidth
 	);
-	let targetHeight = parseFloat(
+	let imgMaxHeight = parseFloat(
 		context.core.image.targetHeight !== 'none'
 			? context.core.image.targetHeight
 			: naturalHeight
 	);
 
+	// Natural ratio of the image clicked to open the lightbox.
 	const naturalRatio = naturalWidth / naturalHeight;
-	let targetRatio = targetWidth / targetHeight;
+	// Original ratio of the image clicked to open the lightbox.
 	const originalRatio = originalWidth / originalHeight;
-
-	// If the ratio differs, recalculate the width and height.
-	let imgMaxWidth = targetWidth;
-	let imgMaxHeight = targetHeight;
-	let containerMaxWidth = targetWidth;
-	let containerMaxHeight = targetHeight;
+	// Ratio of the biggest image stored in the database.
+	let imgRatio = imgMaxWidth / imgMaxHeight;
+	let containerMaxWidth = imgMaxWidth;
+	let containerMaxHeight = imgMaxHeight;
+	let containerWidth = imgMaxWidth;
+	let containerHeight = imgMaxHeight;
 	// Check if the target image has a different ratio than the original one (thumbnail).
 	// Recalculate the width and height.
-	if ( naturalRatio.toFixed( 2 ) !== targetRatio.toFixed( 2 ) ) {
-		if ( naturalRatio > targetRatio ) {
+	if ( naturalRatio.toFixed( 2 ) !== imgRatio.toFixed( 2 ) ) {
+		if ( naturalRatio > imgRatio ) {
 			// If the width is reached before the height, we keep the targetWidth
 			// and recalculate the height.
-			// targetHeight = targetWidth / naturalRatio;
-			imgMaxHeight = targetWidth / naturalRatio;
+			imgMaxHeight = imgMaxWidth / naturalRatio;
 		} else {
 			// If the height is reached before the width, we keep the targetHeight
 			// and recalculate the width.
-			imgMaxWidth = targetHeight * naturalRatio;
+			imgMaxWidth = imgMaxHeight * naturalRatio;
 		}
-		targetWidth = imgMaxWidth;
-		targetHeight = imgMaxHeight;
-		targetRatio = targetWidth / targetHeight;
+		containerWidth = imgMaxWidth;
+		containerHeight = imgMaxHeight;
+		imgRatio = imgMaxWidth / imgMaxHeight;
 
 		// Calculate the max size of the container.
-		if ( originalRatio > targetRatio ) {
+		if ( originalRatio > imgRatio ) {
 			containerMaxWidth = imgMaxWidth;
 			containerMaxHeight = containerMaxWidth / originalRatio;
 		} else {
@@ -264,36 +264,33 @@ function setZoomStyles( context, event ) {
 	}
 
 	// If the image has been pixelated on purpose, keep that size.
-	if ( originalWidth > targetWidth || originalHeight > targetHeight ) {
-		targetWidth = originalWidth;
-		targetHeight = originalHeight;
+	if ( originalWidth > containerWidth || originalHeight > containerHeight ) {
+		containerWidth = originalWidth;
+		containerHeight = originalHeight;
 	}
 
 	// Calculate the final lightbox image size and the scale factor.
-
 	// MaxWidth is either the window container or the image resolution.
 	// TO DO: Add padding to the window container value.
-	const targetMaxWidth = Math.min( window.innerWidth, targetWidth );
-	const targetMaxHeight = Math.min( window.innerHeight, targetHeight );
+	const targetMaxWidth = Math.min( window.innerWidth, containerWidth );
+	const targetMaxHeight = Math.min( window.innerHeight, containerHeight );
 	const targetContainerRatio = targetMaxWidth / targetMaxHeight;
 
-	let imgContainerWidth;
-	let imgContainerHeight;
 	if ( originalRatio > targetContainerRatio ) {
 		// If targetMaxWidth is reached before targetMaxHeight
-		imgContainerWidth = targetMaxWidth;
-		imgContainerHeight = imgContainerWidth / originalRatio;
+		containerWidth = targetMaxWidth;
+		containerHeight = containerWidth / originalRatio;
 	} else {
 		// If targetMaxHeight is reached before targetMaxWidth
-		imgContainerHeight = targetMaxHeight;
-		imgContainerWidth = imgContainerHeight * originalRatio;
+		containerHeight = targetMaxHeight;
+		containerWidth = containerHeight * originalRatio;
 	}
 
-	const containerScale = originalWidth / imgContainerWidth;
+	const containerScale = originalWidth / containerWidth;
 	const lightboxImgWidth =
-		imgMaxWidth * ( imgContainerWidth / containerMaxWidth );
+		imgMaxWidth * ( containerWidth / containerMaxWidth );
 	const lightboxImgHeight =
-		imgMaxHeight * ( imgContainerHeight / containerMaxHeight );
+		imgMaxHeight * ( containerHeight / containerMaxHeight );
 
 	// Add the CSS variables needed.
 	const root = document.documentElement;
@@ -311,11 +308,11 @@ function setZoomStyles( context, event ) {
 	);
 	root.style.setProperty(
 		'--lightbox-container-width',
-		imgContainerWidth + 'px'
+		containerWidth + 'px'
 	);
 	root.style.setProperty(
 		'--lightbox-container-height',
-		imgContainerHeight + 'px'
+		containerHeight + 'px'
 	);
 	root.style.setProperty( '--lightbox-image-width', lightboxImgWidth + 'px' );
 	root.style.setProperty(

--- a/packages/block-library/src/image/view-interactivity.js
+++ b/packages/block-library/src/image/view-interactivity.js
@@ -226,7 +226,7 @@ function setZoomStyles( context, event ) {
 		targetHeight = offsetHeight;
 	}
 
-	// Change the targetRatio if it the original aspect ratio has been changed.
+	// Change the target dimensions if the original aspect ratio has been changed.
 	const targetRatio = targetWidth / targetHeight;
 	const offsetRatio =
 		event.target.nextElementSibling.offsetWidth /
@@ -241,7 +241,7 @@ function setZoomStyles( context, event ) {
 	// ignores its parent's padding, so we need to set padding here
 	// to calculate dimensions and positioning.
 
-	// As per the design, let's constrain the height with fixed padding
+	// As per the design, let's constrain the height with fixed padding.
 	const containerOuterHeight = window.innerHeight;
 	const verticalPadding = 40;
 	const containerInnerHeight = containerOuterHeight - verticalPadding * 2;
@@ -260,12 +260,18 @@ function setZoomStyles( context, event ) {
 	const heightOverflow = targetHeight - containerInnerHeight;
 
 	// If the image is larger than the container, let's resize
-	// it along the greater axis relative to the container
+	// it along the greater axis relative to the container.
 	if ( widthOverflow > 0 || heightOverflow > 0 ) {
 		const containerInnerAspectRatio =
 			containerInnerWidth / containerInnerHeight;
 		const imageAspectRatio = targetWidth / targetHeight;
 
+		// The larger the aspect ratio, the wider the image.
+		// If the image is wider than the container, then resize
+		// it along the width; if the image is narrower than the
+		// container, resize it along the height. Doing this, we
+		// can always be sure that the image will be placed within
+		// the bounds of the container.
 		if ( imageAspectRatio > containerInnerAspectRatio ) {
 			targetWidth = containerInnerWidth;
 			targetHeight = containerInnerWidth / offsetRatio;
@@ -313,6 +319,10 @@ function setZoomStyles( context, event ) {
 		'--lightbox-initial-top-position',
 		originTop + 'px'
 	);
+
+	// We need to center the image with manual values
+	// rather than using percentages because otherwise the
+	// animation does not function properly on iPhone and iPad.
 	root.style.setProperty(
 		'--lightbox-target-left-position',
 		targetLeft + 'px'

--- a/packages/block-library/src/image/view-interactivity.js
+++ b/packages/block-library/src/image/view-interactivity.js
@@ -241,13 +241,31 @@ function setZoomStyles( context, event ) {
 	// Recalculate the width and height.
 	if ( naturalRatio.toFixed( 2 ) !== imgRatio.toFixed( 2 ) ) {
 		if ( naturalRatio > imgRatio ) {
-			// If the width is reached before the height, we keep the targetWidth
+			// If the width is reached before the height, we keep the maxWidth
 			// and recalculate the height.
-			imgMaxHeight = imgMaxWidth / naturalRatio;
+			// Unless the difference between the maxHeight and the reducedHeight
+			// is higher than the maxWidth, where we keep the reducedHeight and
+			// recalculate the width.
+			const reducedHeight = imgMaxWidth / naturalRatio;
+			if ( imgMaxHeight - reducedHeight > imgMaxWidth ) {
+				imgMaxHeight = reducedHeight;
+				imgMaxWidth = reducedHeight * naturalRatio;
+			} else {
+				imgMaxHeight = imgMaxWidth / naturalRatio;
+			}
 		} else {
-			// If the height is reached before the width, we keep the targetHeight
+			// If the height is reached before the width, we keep the maxHeight
 			// and recalculate the width.
-			imgMaxWidth = imgMaxHeight * naturalRatio;
+			// Unless the difference between the maxWidth and the reducedWidth
+			// is higher than the maxHeight, where we keep the reducedWidth and
+			// recalculate the height.
+			const reducedWidth = imgMaxHeight * naturalRatio;
+			if ( imgMaxWidth - reducedWidth > imgMaxHeight ) {
+				imgMaxWidth = reducedWidth;
+				imgMaxHeight = reducedWidth / naturalRatio;
+			} else {
+				imgMaxWidth = imgMaxHeight * naturalRatio;
+			}
 		}
 		containerWidth = imgMaxWidth;
 		containerHeight = imgMaxHeight;

--- a/packages/block-library/src/image/view-interactivity.js
+++ b/packages/block-library/src/image/view-interactivity.js
@@ -45,19 +45,6 @@ store(
 						document.documentElement.classList.add(
 							'wp-has-lightbox-open'
 						);
-
-						// Since the img is hidden and its src not loaded until
-						// the lightbox is opened, let's create an img element on the fly
-						// so we can get the dimensions we need to calculate the styles
-						context.core.image.preloadInitialized = true;
-						const imgDom = document.createElement( 'img' );
-						imgDom.onload = function () {
-							context.core.image.activateLargeImage = true;
-						};
-						imgDom.setAttribute(
-							'src',
-							context.core.image.imageUploadedSrc
-						);
 					},
 					hideLightbox: async ( { context, event } ) => {
 						context.core.image.hideAnimationEnabled = true;
@@ -147,16 +134,6 @@ store(
 							context,
 							ref,
 						} );
-					},
-					preloadLightboxImage: ( { context } ) => {
-						if ( ! context.core.image.preloadInitialized ) {
-							context.core.image.preloadInitialized = true;
-							const imgDom = document.createElement( 'img' );
-							imgDom.setAttribute(
-								'src',
-								context.core.image.imageUploadedSrc
-							);
-						}
 					},
 				},
 			},

--- a/packages/block-library/src/image/view-interactivity.js
+++ b/packages/block-library/src/image/view-interactivity.js
@@ -162,6 +162,11 @@ store( {
 				inheritSize: ( { context } ) => {
 					return context.core.image.lightboxEnabled && 'inherit';
 				},
+				lightboxObjectFit: ( { context } ) => {
+					if ( context.core.image.initialized ) {
+						return 'cover';
+					}
+				},
 			},
 		},
 	},
@@ -339,7 +344,6 @@ function setZoomStyles( context, event ) {
 	}
 	styleTag.innerHTML = `
 		:root {
-			--wp--lightbox-image-target-aspect-ratio: ${ originalRatio };
 			--wp--lightbox-initial-top-position: ${ screenPosY }px;
 			--wp--lightbox-initial-left-position: ${ screenPosX }px;
 			--wp--lightbox-container-width: ${ containerWidth }px;

--- a/packages/block-library/src/image/view-interactivity.js
+++ b/packages/block-library/src/image/view-interactivity.js
@@ -232,6 +232,7 @@ function setZoomStyles( context, event ) {
 	// Change the target dimensions if the original aspect ratio has been changed.
 	const targetRatio = targetWidth / targetHeight;
 	const offsetRatio = offsetWidth / offsetHeight;
+	const naturalRatio = naturalWidth / naturalHeight;
 
 	if ( targetRatio.toFixed( 2 ) !== offsetRatio.toFixed( 2 ) ) {
 		if ( offsetRatio >= 1 ) targetWidth = targetHeight * offsetRatio;
@@ -283,8 +284,14 @@ function setZoomStyles( context, event ) {
 	// Set the origin values of the lightbox image
 	// from which we'll calculate our animation values.
 	const root = document.documentElement;
+	root.style.setProperty( '--lightbox-image-max-width', targetWidth + 'px' );
+	root.style.setProperty(
+		'--lightbox-image-max-height',
+		targetHeight + 'px'
+	);
 	root.style.setProperty( '--lightbox-origin-width', offsetWidth + 'px' );
 	root.style.setProperty( '--lightbox-origin-height', offsetHeight + 'px' );
+
 	root.style.setProperty(
 		'--lightbox-origin-left-position',
 		screenPosX + 'px'
@@ -296,10 +303,78 @@ function setZoomStyles( context, event ) {
 
 	// Create a scaling factor based on the target dimensions,
 	// which reflect our desired padding and container size.
+
 	const scaleWidth = targetWidth / offsetWidth;
 	const scaleHeight = targetHeight / offsetHeight;
-	root.style.setProperty( '--lightbox-scale-width', scaleWidth );
-	root.style.setProperty( '--lightbox-scale-height', scaleHeight );
+
+	if ( targetRatio.toFixed( 2 ) === naturalRatio.toFixed( 2 ) ) {
+		root.style.setProperty( '--lightbox-outer-overflow', 'visible' );
+		root.style.setProperty( '--lightbox-outer-scale-width', 1 );
+		root.style.setProperty( '--lightbox-outer-scale-height', 1 );
+		root.style.setProperty( '--lightbox-inner-width', '100%' );
+		root.style.setProperty( '--lightbox-inner-height', '100%' );
+		root.style.setProperty( '--lightbox-inner-initial-scale-width', 1 );
+		root.style.setProperty( '--lightbox-inner-initial-scale-height', 1 );
+		root.style.setProperty(
+			'--lightbox-inner-target-scale-width',
+			scaleWidth
+		);
+		root.style.setProperty(
+			'--lightbox-inner-target-scale-height',
+			scaleHeight
+		);
+	} else {
+		root.style.setProperty( '--lightbox-outer-overflow', 'hidden' );
+		root.style.setProperty( '--lightbox-outer-scale-width', scaleWidth );
+		root.style.setProperty( '--lightbox-outer-scale-height', scaleHeight );
+
+		let innerWidth;
+		let innerHeight;
+
+		let offsetScale = 0;
+		if ( offsetRatio >= 1 ) {
+			root.style.setProperty(
+				'--lightbox-inner-width',
+				offsetHeight + 'px'
+			);
+			root.style.setProperty(
+				'--lightbox-inner-height',
+				offsetHeight + 'px'
+			);
+			innerHeight = offsetWidth;
+			innerWidth = offsetRatio * offsetWidth;
+			offsetScale = innerHeight / offsetHeight;
+		} else {
+			root.style.setProperty(
+				'--lightbox-inner-width',
+				offsetWidth + 'px'
+			);
+			root.style.setProperty(
+				'--lightbox-inner-height',
+				offsetWidth + 'px'
+			);
+			innerWidth = offsetHeight;
+			innerHeight = offsetWidth / offsetRatio;
+			offsetScale = innerWidth / offsetWidth;
+		}
+
+		root.style.setProperty(
+			'--lightbox-inner-initial-scale-width',
+			offsetScale
+		);
+		root.style.setProperty(
+			'--lightbox-inner-initial-scale-height',
+			offsetScale
+		);
+		root.style.setProperty(
+			'--lightbox-inner-target-scale-width',
+			offsetScale
+		);
+		root.style.setProperty(
+			'--lightbox-inner-target-scale-height',
+			offsetScale
+		);
+	}
 
 	// Figure out the offset values of the image if
 	// it were placed in the center of the screen.

--- a/packages/block-library/src/image/view-interactivity.js
+++ b/packages/block-library/src/image/view-interactivity.js
@@ -331,31 +331,22 @@ function setZoomStyles( context, event ) {
 		imgMaxHeight * ( containerHeight / containerMaxHeight );
 
 	// Add the CSS variables needed.
-	const root = document.documentElement;
-	root.style.setProperty(
-		'--lightbox-image-target-aspect-ratio',
-		originalRatio
-	);
-	root.style.setProperty(
-		'--lightbox-initial-top-position',
-		screenPosY + 'px'
-	);
-	root.style.setProperty(
-		'--lightbox-initial-left-position',
-		screenPosX + 'px'
-	);
-	root.style.setProperty(
-		'--lightbox-container-width',
-		containerWidth + 'px'
-	);
-	root.style.setProperty(
-		'--lightbox-container-height',
-		containerHeight + 'px'
-	);
-	root.style.setProperty( '--lightbox-image-width', lightboxImgWidth + 'px' );
-	root.style.setProperty(
-		'--lightbox-image-height',
-		lightboxImgHeight + 'px'
-	);
-	root.style.setProperty( '--lightbox-scale', containerScale );
+	let styleTag = document.getElementById( 'wp-lightbox-styles' );
+	if ( ! styleTag ) {
+		styleTag = document.createElement( 'style' );
+		styleTag.id = 'wp-lightbox-styles';
+		document.head.appendChild( styleTag );
+	}
+	styleTag.innerHTML = `
+		:root {
+			--lightbox-image-target-aspect-ratio: ${ originalRatio };
+			--lightbox-initial-top-position: ${ screenPosY }px;
+			--lightbox-initial-left-position: ${ screenPosX }px;
+			--lightbox-container-width: ${ containerWidth }px;
+			--lightbox-container-height: ${ containerHeight }px;
+			--lightbox-image-width: ${ lightboxImgWidth }px;
+			--lightbox-image-height: ${ lightboxImgHeight }px;
+			--lightbox-scale: ${ containerScale };
+		}
+	`;
 }

--- a/packages/block-library/src/image/view-interactivity.js
+++ b/packages/block-library/src/image/view-interactivity.js
@@ -186,23 +186,23 @@ store( {
 						ref.querySelector( '.close-button' ).focus();
 					}
 				},
-				initButtonContainStyles: ( { context, ref } ) => {
-					// In the case of an image with object-fit: contain, the
-					// size of the img element can be larger than the image itself,
-					// so we need to calculate the size of the button to match.
-					if ( context.core.image.scaleAttr === 'contain' ) {
-						const {
-							naturalWidth,
-							naturalHeight,
-							offsetWidth,
-							offsetHeight,
-						} = ref;
+				initButtonStyles: ( { context, ref } ) => {
+					const {
+						naturalWidth,
+						naturalHeight,
+						offsetWidth,
+						offsetHeight,
+					} = ref;
 
-						// If the image isn't loaded yet, we can't
-						// calculate how big the button should be.
-						if ( naturalWidth === 0 || naturalHeight === 0 ) {
-							return;
-						}
+					// If the image isn't loaded yet, we can't
+					// calculate how big the button should be.
+					if ( naturalWidth === 0 || naturalHeight === 0 ) {
+						return;
+					}
+					if ( context.core.image.scaleAttr === 'contain' ) {
+						// In the case of an image with object-fit: contain, the
+						// size of the img element can be larger than the image itself,
+						// so we need to calculate the size of the button to match.
 
 						// Natural ratio of the image.
 						const naturalRatio = naturalWidth / naturalHeight;
@@ -222,6 +222,12 @@ store( {
 							context.core.image.imageButtonWidth =
 								offsetHeight * naturalRatio;
 						}
+					} else {
+						// In all other cases, we can trust that the size of
+						// the image is the right size for the button as well.
+
+						context.core.image.imageButtonWidth = offsetWidth;
+						context.core.image.imageButtonHeight = offsetHeight;
 					}
 				},
 			},
@@ -378,6 +384,7 @@ function setStyles( context, event ) {
 		styleTag.id = 'wp-lightbox-styles';
 		document.head.appendChild( styleTag );
 	}
+
 	styleTag.innerHTML = `
 		:root {
 			--wp--lightbox-initial-top-position: ${ screenPosY }px;

--- a/packages/block-library/src/image/view-interactivity.js
+++ b/packages/block-library/src/image/view-interactivity.js
@@ -210,17 +210,21 @@ store( {
 						const offsetRatio = offsetWidth / offsetHeight;
 
 						if ( naturalRatio > offsetRatio ) {
-							// If it reaches the width first, keep the width
-							// and recalculate the height.
+							// If it reaches the width first, keep
+							// the width and recalculate the height.
 							context.core.image.imageButtonWidth = offsetWidth;
-							context.core.image.imageButtonHeight =
-								offsetWidth / naturalRatio;
+							const buttonHeight = offsetWidth / naturalRatio;
+							context.core.image.imageButtonHeight = buttonHeight;
+							context.core.image.imageButtonTop =
+								( offsetHeight - buttonHeight ) / 2;
 						} else {
-							// If it reaches the height first, keep the height
-							// and recalculate the width.
+							// If it reaches the height first, keep
+							// the height and recalculate the width.
 							context.core.image.imageButtonHeight = offsetHeight;
-							context.core.image.imageButtonWidth =
-								offsetHeight * naturalRatio;
+							const buttonWidth = offsetHeight * naturalRatio;
+							context.core.image.imageButtonWidth = buttonWidth;
+							context.core.image.imageButtonLeft =
+								( offsetWidth - buttonWidth ) / 2;
 						}
 					} else {
 						// In all other cases, we can trust that the size of

--- a/packages/block-library/src/image/view-interactivity.js
+++ b/packages/block-library/src/image/view-interactivity.js
@@ -20,8 +20,12 @@ const focusableSelectors = [
 store(
 	{
 		state: {
-			windowWidth: window.innerWidth,
-			windowHeight: window.innerHeight,
+			core: {
+				image: {
+					windowWidth: window.innerWidth,
+					windowHeight: window.innerHeight,
+				},
+			},
 		},
 		actions: {
 			core: {
@@ -203,7 +207,8 @@ store(
 						// Subscribe to the window dimensions so we can
 						// recalculate the styles if the window is resized.
 						if (
-							( state.windowWidth || state.windowHeight ) &&
+							( state.core.image.windowWidth ||
+								state.core.image.windowHeight ) &&
 							context.core.image.scaleAttr === 'contain'
 						) {
 							// In the case of an image with object-fit: contain, the
@@ -253,8 +258,8 @@ store(
 			window.addEventListener(
 				'resize',
 				debounce( () => {
-					state.windowWidth = window.innerWidth;
-					state.windowHeight = window.innerHeight;
+					state.core.image.windowWidth = window.innerWidth;
+					state.core.image.windowHeight = window.innerHeight;
 				} )
 			);
 		},

--- a/packages/block-library/src/image/view-interactivity.js
+++ b/packages/block-library/src/image/view-interactivity.js
@@ -306,10 +306,12 @@ function setZoomStyles( context, event ) {
 	}
 
 	// Calculate the final lightbox image size and the scale factor.
-	// MaxWidth is either the window container or the image resolution.
-	// TO DO: Add padding to the window container value.
-	const targetMaxWidth = Math.min( window.innerWidth, containerWidth );
-	const targetMaxHeight = Math.min( window.innerHeight, containerHeight );
+	// MaxWidth is either the window container (plus padding) or the image resolution.
+	const targetMaxWidth = Math.min( window.innerWidth * 0.95, containerWidth );
+	const targetMaxHeight = Math.min(
+		window.innerHeight * 0.95,
+		containerHeight
+	);
 	const targetContainerRatio = targetMaxWidth / targetMaxHeight;
 
 	if ( originalRatio > targetContainerRatio ) {

--- a/packages/block-library/src/image/view-interactivity.js
+++ b/packages/block-library/src/image/view-interactivity.js
@@ -197,32 +197,42 @@ store( {
 						ref.querySelector( '.close-button' ).focus();
 					}
 				},
-				initImageButton: ( { context, ref } ) => {
-					const originalImage =
-						ref.parentElement.querySelector( 'img' );
-					const {
-						naturalWidth,
-						naturalHeight,
-						offsetWidth: originalWidth,
-						offsetHeight: originalHeight,
-					} = originalImage;
+				initButtonContainStyles: ( { context, ref } ) => {
+					// In the case of an image with object-fit: contain, the
+					// size of the img element can be larger than the image itself,
+					// so we need to calculate the size of the button to match.
+					if ( context.core.image.scaleAttr === 'contain' ) {
+						const {
+							naturalWidth,
+							naturalHeight,
+							offsetWidth,
+							offsetHeight,
+						} = ref;
 
-					// Natural ratio of the image.
-					const naturalRatio = naturalWidth / naturalHeight;
-					// Original ratio of the image.
-					const originalRatio = originalWidth / originalHeight;
-					if ( naturalRatio > originalRatio ) {
-						// If it reaches the width first, keep the width
-						// and recalculate the height.
-						context.core.image.imageButtonWidth = originalWidth;
-						context.core.image.imageButtonHeight =
-							originalWidth / naturalRatio;
-					} else {
-						// If it reaches the height first, keep the height
-						// and recalculate the width.
-						context.core.image.imageButtonHeight = originalHeight;
-						context.core.image.imageButtonWidth =
-							originalHeight * naturalRatio;
+						// If the image isn't loaded yet, we can't
+						// calculate how big the button should be.
+						if ( naturalWidth === 0 || naturalHeight === 0 ) {
+							return;
+						}
+
+						// Natural ratio of the image.
+						const naturalRatio = naturalWidth / naturalHeight;
+						// Offset ratio of the image.
+						const offsetRatio = offsetWidth / offsetHeight;
+
+						if ( naturalRatio > offsetRatio ) {
+							// If it reaches the width first, keep the width
+							// and recalculate the height.
+							context.core.image.imageButtonWidth = offsetWidth;
+							context.core.image.imageButtonHeight =
+								offsetWidth / naturalRatio;
+						} else {
+							// If it reaches the height first, keep the height
+							// and recalculate the width.
+							context.core.image.imageButtonHeight = offsetHeight;
+							context.core.image.imageButtonWidth =
+								offsetHeight * naturalRatio;
+						}
 					}
 				},
 			},

--- a/packages/block-library/src/image/view-interactivity.js
+++ b/packages/block-library/src/image/view-interactivity.js
@@ -385,12 +385,14 @@ function setStyles( context, event ) {
 		document.head.appendChild( styleTag );
 	}
 
+	// Add 1 pixel to the container width and height
+	// to avoid whitespace around the image on iOS.
 	styleTag.innerHTML = `
 		:root {
 			--wp--lightbox-initial-top-position: ${ screenPosY }px;
 			--wp--lightbox-initial-left-position: ${ screenPosX }px;
-			--wp--lightbox-container-width: ${ containerWidth }px;
-			--wp--lightbox-container-height: ${ containerHeight }px;
+			--wp--lightbox-container-width: ${ containerWidth + 1 }px;
+			--wp--lightbox-container-height: ${ containerHeight + 1 }px;
 			--wp--lightbox-image-width: ${ lightboxImgWidth }px;
 			--wp--lightbox-image-height: ${ lightboxImgHeight }px;
 			--wp--lightbox-scale: ${ containerScale };

--- a/packages/block-library/src/image/view-interactivity.js
+++ b/packages/block-library/src/image/view-interactivity.js
@@ -33,9 +33,7 @@ store( {
 					context.core.image.scrollDelta = 0;
 
 					context.core.image.lightboxEnabled = true;
-					if ( context.core.image.lightboxAnimation === 'zoom' ) {
-						setZoomStyles( context, event );
-					}
+					setStyles( context, event );
 					// Hide overflow only when the animation is in progress,
 					// otherwise the removal of the scrollbars will draw attention
 					// to itself and look like an error
@@ -205,7 +203,7 @@ store( {
 	},
 } );
 
-function setZoomStyles( context, event ) {
+function setStyles( context, event ) {
 	// The reference img element lies adjacent
 	// to the event target button in the DOM.
 	let {

--- a/packages/block-library/src/image/view-interactivity.js
+++ b/packages/block-library/src/image/view-interactivity.js
@@ -163,6 +163,9 @@ store( {
 						? context.core.image.imageUploadedSrc
 						: '';
 				},
+				inheritSize: ( { context } ) => {
+					return context.core.image.lightboxEnabled && 'inherit';
+				},
 			},
 		},
 	},

--- a/packages/block-library/src/image/view-interactivity.js
+++ b/packages/block-library/src/image/view-interactivity.js
@@ -157,9 +157,6 @@ store( {
 						? context.core.image.imageUploadedSrc
 						: '';
 				},
-				inheritSize: ( { context } ) => {
-					return context.core.image.lightboxEnabled && 'inherit';
-				},
 				lightboxObjectFit: ( { context } ) => {
 					if ( context.core.image.initialized ) {
 						return 'cover';

--- a/packages/block-library/src/image/view-interactivity.js
+++ b/packages/block-library/src/image/view-interactivity.js
@@ -34,11 +34,7 @@ store( {
 
 					context.core.image.lightboxEnabled = true;
 					if ( context.core.image.lightboxAnimation === 'zoom' ) {
-						setZoomStyles(
-							event.target.nextElementSibling,
-							context,
-							event
-						);
+						setZoomStyles( context, event );
 					}
 					// Hide overflow only when the animation is in progress,
 					// otherwise the removal of the scrollbars will draw attention
@@ -204,7 +200,7 @@ store( {
 	},
 } );
 
-function setZoomStyles( imgDom, context, event ) {
+function setZoomStyles( context, event ) {
 	// Typically, we use the image's full-sized dimensions. If those
 	// dimensions have not been set (i.e. an external image with only one size),
 	// the image's dimensions in the lightbox are the same
@@ -263,8 +259,14 @@ function setZoomStyles( imgDom, context, event ) {
 	const widthOverflow = targetWidth - containerInnerWidth;
 	const heightOverflow = targetHeight - containerInnerHeight;
 
+	// If the image is larger than the container, let's resize
+	// it along the greater axis relative to the container
 	if ( widthOverflow > 0 || heightOverflow > 0 ) {
-		if ( widthOverflow > heightOverflow ) {
+		const containerInnerAspectRatio =
+			containerInnerWidth / containerInnerHeight;
+		const imageAspectRatio = targetWidth / targetHeight;
+
+		if ( imageAspectRatio > containerInnerAspectRatio ) {
 			targetWidth = containerInnerWidth;
 			targetHeight = containerInnerWidth / offsetRatio;
 		} else {
@@ -272,32 +274,6 @@ function setZoomStyles( imgDom, context, event ) {
 			targetWidth = containerInnerHeight * offsetRatio;
 		}
 	}
-
-	// Check difference between the image and figure dimensions
-	// const widthOverflow = Math.abs(
-	// 	Math.min( containerInnerWidth - targetWidth, 0 )
-	// );
-	// const heightOverflow = Math.abs(
-	// 	Math.min( containerInnerHeight - targetHeight, 0 )
-	// );
-
-	// If the image is larger than the container, let's resize
-	// it along the greater axis relative to the container
-	// if ( widthOverflow > 0 || heightOverflow > 0 ) {
-	// 	const containerInnerAspectRatio =
-	// 		containerInnerWidth / containerInnerHeight;
-	// 	const imageAspectRatio = targetWidth / targetHeight;
-
-	// 	if ( imageAspectRatio > containerInnerAspectRatio ) {
-	// 		targetWidth = containerInnerWidth;
-	// 		targetHeight =
-	// 			( targetWidth * imgDom.naturalHeight ) / imgDom.naturalWidth;
-	// 	} else {
-	// 		targetHeight = containerInnerHeight;
-	// 		targetWidth =
-	// 			( targetHeight * imgDom.naturalWidth ) / imgDom.naturalHeight;
-	// 	}
-	// }
 
 	// The reference img element lies adjacent to the event target button in the DOM
 	const { x: originLeft, y: originTop } =

--- a/packages/block-library/src/image/view-interactivity.js
+++ b/packages/block-library/src/image/view-interactivity.js
@@ -203,14 +203,36 @@ store( {
 function setZoomStyles( context, event ) {
 	// The reference img element lies adjacent
 	// to the event target button in the DOM.
-	const {
+	let {
 		naturalWidth,
 		naturalHeight,
 		offsetWidth: originalWidth,
 		offsetHeight: originalHeight,
 	} = event.target.nextElementSibling;
-	const { x: screenPosX, y: screenPosY } =
+	let { x: screenPosX, y: screenPosY } =
 		event.target.nextElementSibling.getBoundingClientRect();
+
+	// Natural ratio of the image clicked to open the lightbox.
+	const naturalRatio = naturalWidth / naturalHeight;
+	// Original ratio of the image clicked to open the lightbox.
+	let originalRatio = originalWidth / originalHeight;
+
+	// If it has object-fit: contain, recalculate the original sizes
+	// and the screen position without the blank spaces.
+	if ( context.core.image.scaleAttr === 'contain' ) {
+		if ( naturalRatio > originalRatio ) {
+			const heightWithoutSpace = originalWidth / naturalRatio;
+			// Recalculate screen position without the top space.
+			screenPosY += ( originalHeight - heightWithoutSpace ) / 2;
+			originalHeight = heightWithoutSpace;
+		} else {
+			const widthWithoutSpace = originalHeight * naturalRatio;
+			// Recalculate screen position without the left space.
+			screenPosX += ( originalWidth - widthWithoutSpace ) / 2;
+			originalWidth = widthWithoutSpace;
+		}
+	}
+	originalRatio = originalWidth / originalHeight;
 
 	// Typically, we use the image's full-sized dimensions. If those
 	// dimensions have not been set (i.e. an external image with only one size),
@@ -227,10 +249,6 @@ function setZoomStyles( context, event ) {
 			: naturalHeight
 	);
 
-	// Natural ratio of the image clicked to open the lightbox.
-	const naturalRatio = naturalWidth / naturalHeight;
-	// Original ratio of the image clicked to open the lightbox.
-	const originalRatio = originalWidth / originalHeight;
 	// Ratio of the biggest image stored in the database.
 	let imgRatio = imgMaxWidth / imgMaxHeight;
 	let containerMaxWidth = imgMaxWidth;

--- a/packages/block-library/src/image/view-interactivity.js
+++ b/packages/block-library/src/image/view-interactivity.js
@@ -148,17 +148,6 @@ store( {
 				roleAttribute: ( { context } ) => {
 					return context.core.image.lightboxEnabled ? 'dialog' : '';
 				},
-				responsiveImgSrc: ( { context } ) => {
-					return context.core.image.activateLargeImage &&
-						context.core.image.hideAnimationEnabled
-						? ''
-						: context.core.image.imageCurrentSrc;
-				},
-				enlargedImgSrc: ( { context } ) => {
-					return context.core.image.initialized
-						? context.core.image.imageUploadedSrc
-						: '';
-				},
 				lightboxObjectFit: ( { context } ) => {
 					if ( context.core.image.initialized ) {
 						return 'cover';

--- a/packages/block-library/src/image/view-interactivity.js
+++ b/packages/block-library/src/image/view-interactivity.js
@@ -40,7 +40,7 @@ store( {
 					// otherwise the removal of the scrollbars will draw attention
 					// to itself and look like an error
 					document.documentElement.classList.add(
-						'has-lightbox-open'
+						'wp-has-lightbox-open'
 					);
 
 					// Since the img is hidden and its src not loaded until
@@ -93,7 +93,7 @@ store( {
 						}
 
 						document.documentElement.classList.remove(
-							'has-lightbox-open'
+							'wp-has-lightbox-open'
 						);
 
 						context.core.image.lightboxEnabled = false;
@@ -339,14 +339,14 @@ function setZoomStyles( context, event ) {
 	}
 	styleTag.innerHTML = `
 		:root {
-			--lightbox-image-target-aspect-ratio: ${ originalRatio };
-			--lightbox-initial-top-position: ${ screenPosY }px;
-			--lightbox-initial-left-position: ${ screenPosX }px;
-			--lightbox-container-width: ${ containerWidth }px;
-			--lightbox-container-height: ${ containerHeight }px;
-			--lightbox-image-width: ${ lightboxImgWidth }px;
-			--lightbox-image-height: ${ lightboxImgHeight }px;
-			--lightbox-scale: ${ containerScale };
+			--wp--lightbox-image-target-aspect-ratio: ${ originalRatio };
+			--wp--lightbox-initial-top-position: ${ screenPosY }px;
+			--wp--lightbox-initial-left-position: ${ screenPosX }px;
+			--wp--lightbox-container-width: ${ containerWidth }px;
+			--wp--lightbox-container-height: ${ containerHeight }px;
+			--wp--lightbox-image-width: ${ lightboxImgWidth }px;
+			--wp--lightbox-image-height: ${ lightboxImgHeight }px;
+			--wp--lightbox-scale: ${ containerScale };
 		}
 	`;
 }

--- a/packages/block-library/src/image/view-interactivity.js
+++ b/packages/block-library/src/image/view-interactivity.js
@@ -305,11 +305,23 @@ function setStyles( context, event ) {
 		containerHeight = originalHeight;
 	}
 
-	// Calculate the final lightbox image size and the scale factor.
-	// MaxWidth is either the window container (plus padding) or the image resolution.
-	const targetMaxWidth = Math.min( window.innerWidth * 0.95, containerWidth );
+	// Calculate the final lightbox image size and the
+	// scale factor. MaxWidth is either the window container
+	// (accounting for padding) or the image resolution.
+	let horizontalPadding = 0;
+	if ( window.innerWidth > 480 ) {
+		horizontalPadding = 80;
+	} else if ( window.innerWidth > 1920 ) {
+		horizontalPadding = 160;
+	}
+	const verticalPadding = 80;
+
+	const targetMaxWidth = Math.min(
+		window.innerWidth - horizontalPadding,
+		containerWidth
+	);
 	const targetMaxHeight = Math.min(
-		window.innerHeight * 0.95,
+		window.innerHeight - verticalPadding,
 		containerHeight
 	);
 	const targetContainerRatio = targetMaxWidth / targetMaxHeight;

--- a/packages/block-library/src/image/view-interactivity.js
+++ b/packages/block-library/src/image/view-interactivity.js
@@ -411,8 +411,11 @@ function setStyles( context, event ) {
 		document.head.appendChild( styleTag );
 	}
 
-	// Add 1 pixel to the container width and height
-	// to avoid whitespace around the image on iOS.
+	// As of this writing, using the calculations above will render the lightbox
+	// with a small, erroneous whitespace on the left side of the image in iOS Safari,
+	// perhaps due to an inconsistency in how browsers handle absolute positioning and CSS
+	// transformation. In any case, adding 1 pixel to the container width and height solves
+	// the problem, though this can be removed if the issue is fixed in the future.
 	styleTag.innerHTML = `
 		:root {
 			--wp--lightbox-initial-top-position: ${ screenPosY }px;

--- a/packages/interactivity/docs/2-api-reference.md
+++ b/packages/interactivity/docs/2-api-reference.md
@@ -550,32 +550,6 @@ store( {
 } );
 ```
 
-### Store options
-
-The `store` function accepts an object as a second argument with the following optional properties:
-
-#### `afterLoad`
-
-Callback to be executed after the Interactivity API has been set up and the store is ready. It receives the global store as argument.
-
-```js
-// view.js
-store(
-	{
-		state: {
-			cart: [],
-		},
-	},
-	{
-		afterLoad: async ( { state } ) => {
-			// Let's consider `clientId` is added
-			// during server-side rendering.
-			state.cart = await getCartData( state.clientId );
-		},
-	}
-);
-```
-
 ### Arguments passed to callbacks
 
 When a directive is evaluated, the reference callback receives an object with:

--- a/packages/interactivity/docs/2-api-reference.md
+++ b/packages/interactivity/docs/2-api-reference.md
@@ -550,6 +550,32 @@ store( {
 } );
 ```
 
+### Store options
+
+The `store` function accepts an object as a second argument with the following optional properties:
+
+#### `afterLoad`
+
+Callback to be executed after the Interactivity API has been set up and the store is ready. It receives the global store as argument.
+
+```js
+// view.js
+store(
+	{
+		state: {
+			cart: [],
+		},
+	},
+	{
+		afterLoad: async ( { state } ) => {
+			// Let's consider `clientId` is added
+			// during server-side rendering.
+			state.cart = await getCartData( state.clientId );
+		},
+	}
+);
+```
+
 ### Arguments passed to callbacks
 
 When a directive is evaluated, the reference callback receives an object with:

--- a/test/e2e/specs/editor/blocks/image.spec.js
+++ b/test/e2e/specs/editor/blocks/image.spec.js
@@ -916,7 +916,10 @@ test.describe( 'Image - interactivity', () => {
 				} );
 				await closeButton.click();
 
-				await expect( responsiveImage ).toHaveAttribute( 'src', '' );
+				await expect( responsiveImage ).toHaveAttribute(
+					'src',
+					contentImageCurrentSrc
+				);
 				await expect( enlargedImage ).toHaveAttribute(
 					'src',
 					imageUploadedSrc
@@ -1011,7 +1014,10 @@ test.describe( 'Image - interactivity', () => {
 				} );
 				await closeButton.click();
 
-				await expect( responsiveImage ).toHaveAttribute( 'src', '' );
+				await expect( responsiveImage ).toHaveAttribute(
+					'src',
+					contentImageCurrentSrc
+				);
 				await expect( enlargedImage ).toHaveAttribute(
 					'src',
 					imageUploadedSrc
@@ -1360,7 +1366,7 @@ test.describe( 'Image - interactivity', () => {
 
 		await page.getByRole( 'button', { name: 'Close' } ).click();
 
-		await expect( responsiveImage ).toHaveAttribute( 'src', '' );
+		await expect( responsiveImage ).toHaveAttribute( 'src', imgUrl );
 		await expect( enlargedImage ).toHaveAttribute( 'src', imgUrl );
 	} );
 } );

--- a/test/e2e/specs/editor/blocks/image.spec.js
+++ b/test/e2e/specs/editor/blocks/image.spec.js
@@ -885,33 +885,31 @@ test.describe( 'Image - interactivity', () => {
 
 				await expect( lightbox ).toBeVisible();
 
-				const document = page.getByRole( 'document' );
-				const lightboxStyleCheck = await document.evaluate( ( doc ) => {
-					// We don't have access to the getPropertyValue() method
-					// on the CSSStyleDeclaration returned form getComputedStyle()
-					// in the Playwright outer context, so we need to evaluate it here
-					// in the browser context here.
-					const documentStyles = window.getComputedStyle( doc );
-					const lightboxStyleVars = [
-						'--lightbox-scale-width',
-						'--lightbox-scale-height',
-						'--lightbox-image-max-width',
-						'--lightbox-image-max-height',
-						'--lightbox-initial-left-position',
-						'--lightbox-initial-top-position',
-					];
-					const lightboxStyleErrors = [];
-					lightboxStyleVars.forEach( ( styleVar ) => {
-						if ( ! documentStyles.getPropertyValue( styleVar ) ) {
-							lightboxStyleErrors.push( styleVar );
-						}
-					} );
-
-					return lightboxStyleErrors.length > 0
-						? lightboxStyleErrors
-						: true;
+				// Use page.evaluate to get the content of the style tag
+				const styleTagContent = await page.evaluate( () => {
+					const styleTag = document.querySelector(
+						'style#wp-lightbox-styles'
+					);
+					return styleTag ? styleTag.textContent : '';
 				} );
-				expect( lightboxStyleCheck ).toBe( true );
+
+				// Define the keys you want to check for
+				const keysToCheck = [
+					'--wp--lightbox-initial-top-position',
+					'--wp--lightbox-initial-left-position',
+					'--wp--lightbox-container-width',
+					'--wp--lightbox-container-height',
+					'--wp--lightbox-image-width',
+					'--wp--lightbox-image-height',
+					'--wp--lightbox-scale',
+				];
+
+				// Check if all the keys are present in the style tag's content
+				const keysPresent = keysToCheck.every( ( key ) =>
+					styleTagContent.includes( key )
+				);
+
+				expect( keysPresent ).toBe( true );
 
 				const closeButton = lightbox.getByRole( 'button', {
 					name: 'Close',


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
This PR makes it so the lightbox zoom animation functions as expected when configuring a custom aspect ratio on an image.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Addresses #52192
We want the lightbox to be compatible with all of the image block's features.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
It calculates the aspect ratio of the resized image and uses it to calculate the target zoom dimensions.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
1. Ensure interactivity API experiments are enabled
2. Add an image to a post
3. Customize the image's `aspect ratio` in block settings
4. Activate the lightbox under Advanced > Behaviors > Lightbox. Make sure the `zoom` animation is selected.
5. Publish, view the post, and click on the image — it should zoom in as expected.

*If possible, please also test on a mobile device.*

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
N/A

## Screenshots or screencast <!-- if applicable -->

### Before

https://github.com/WordPress/gutenberg/assets/5360536/08c395b4-afbb-4a16-a518-034d8935ea8c

### After

https://github.com/WordPress/gutenberg/assets/5360536/c66020b0-8e75-4187-aefe-8007c2ac5dcb


