### PR TITLE
Fix toolbar when previewing devices in post editor

### DIFF
--- a/packages/edit-post/src/editor.js
+++ b/packages/edit-post/src/editor.js
@@ -51,7 +51,6 @@ function Editor( { postId, postType, settings, initialEdits, ...props } ) {
 		( select ) => {
 			const {
 				isFeatureActive,
-				__experimentalGetPreviewDeviceType,
 				isEditingTemplate,
 				getEditedPostTemplate,
 				getHiddenBlockTypes,
@@ -80,9 +79,7 @@ function Editor( { postId, postType, settings, initialEdits, ...props } ) {
 			const canEditTemplate = canUser( 'create', 'templates' );
 
 			return {
-				hasFixedToolbar:
-					isFeatureActive( 'fixedToolbar' ) ||
-					__experimentalGetPreviewDeviceType() !== 'Desktop',
+				hasFixedToolbar: isFeatureActive( 'fixedToolbar' ),
 				focusMode: isFeatureActive( 'focusMode' ),
 				isDistractionFree: isFeatureActive( 'distractionFree' ),
 				hasInlineToolbar: isFeatureActive( 'inlineToolbar' ),


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes part of #52688

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

There was a relic line of code (I hope) that magically turned on fixed toolbar when previewing devices in the post editor. This behavior was not consistent with what happened in the site editor.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Fixed by removing the check that set the post editor fixed toolbar preference to true if the currently active previewing device was not desktop.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->


1. Open the post editor and add some blocks
2. Make sure the top toolbar setting is off
3. Using the device preview menu in the top right corner
4. Select tablet
5. Click around the blocks
6. The block toolbar should show

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

### Before


https://github.com/WordPress/gutenberg/assets/107534/5c2ae33d-4049-44c9-b2c2-69c8f2c8913e



### After


https://github.com/WordPress/gutenberg/assets/107534/faad8afc-4d42-4990-b3bb-5cb87f6e376e



