### PR TITLE
[Mobile] E2E tests - Update hiding of the keyboard for iPad 

### DIFF
--- a/packages/react-native-editor/__device-tests__/pages/editor-page.js
+++ b/packages/react-native-editor/__device-tests__/pages/editor-page.js
@@ -296,7 +296,7 @@ class EditorPage {
 					'Hide keyboard, Tap to hide the keyboard'
 			  )
 			: await this.waitForElementToBeDisplayedByXPath(
-					'//XCUIElementTypeButton[@name="Hide keyboard"]'
+					'(//XCUIElementTypeOther[@name="Hide keyboard"])[1]'
 			  );
 
 		await hideKeyboardButton.click();


### PR DESCRIPTION
**Related PRs:**
- https://github.com/wordpress-mobile/gutenberg-mobile/pull/5980

## What?
This PR updates the XPath used to hide the keyboard on iOS.

## Why?
To solve an issue with iPad E2E tests where the floating keyboard would be visible and would break the visual tests.

## How?
By selecting the first keyboard element (on iPad there are two), this shouldn't break the current behavior for the iPhone simulator.

## Testing Instructions
CI checks on Gutenberg mobile should pass.

### Testing Instructions for Keyboard
N/A

## Screenshots or screencast <!-- if applicable -->
N/A