### PR TITLE
Only request fallback navigation menu if necessary

### DIFF
--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -178,6 +178,7 @@ function Navigation( {
 	const [ overlayMenuPreview, setOverlayMenuPreview ] = useState( false );
 
 	const {
+		navigationMenus,
 		hasResolvedNavigationMenus,
 		isNavigationMenuResolved,
 		isNavigationMenuMissing,
@@ -226,16 +227,18 @@ function Navigation( {
 
 	const { getNavigationFallbackId } = unlock( useSelect( coreStore ) );
 
-	const navigationFallbackId = ! ( ref || hasUnsavedBlocks )
-		? getNavigationFallbackId()
-		: null;
-
 	useEffect( () => {
 		// If:
+		// - we haven't resolved the menus request and there isn't one missing, OR
 		// - there is an existing menu, OR
 		// - there are existing (uncontrolled) inner blocks
 		// ...then don't request a fallback menu.
-		if ( ref || hasUnsavedBlocks || ! navigationFallbackId ) {
+		if (
+			! navMenuResolvedButMissing ||
+			navigationMenus.length > 0 ||
+			ref ||
+			hasUnsavedBlocks
+		) {
 			return;
 		}
 
@@ -244,14 +247,15 @@ function Navigation( {
 		 *  The fallback should not request a save (entity dirty state)
 		 *  nor to be undoable, hence why it is marked as non persistent
 		 */
-
 		__unstableMarkNextChangeAsNotPersistent();
-		setRef( navigationFallbackId );
+		setRef( getNavigationFallbackId() );
 	}, [
 		ref,
 		setRef,
 		hasUnsavedBlocks,
-		navigationFallbackId,
+		navigationMenus,
+		navMenuResolvedButMissing,
+		getNavigationFallbackId,
 		__unstableMarkNextChangeAsNotPersistent,
 	] );
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

The navigation fallback menu is being requested unnecessarily. 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
To save network requests 🐎 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
If there are navigation menus available, we don't need a fallback (I think).

It may be better to add a `needsFallbackMenu` or something to `useNavigationMenu` that can handle this more easily across other places.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
