### PR TITLE
Patterns: Remove padding from root container to stop it affecting preview

### DIFF
--- a/packages/block-editor/src/components/block-preview/auto.js
+++ b/packages/block-editor/src/components/block-preview/auto.js
@@ -38,13 +38,13 @@ function ScaledBlockPreview( {
 		};
 	}, [] );
 
-	// Avoid scrollbars for pattern previews.
+	// Avoid scrollbars for pattern previews and also remove any padding on the root container.
 	const editorStyles = useMemo( () => {
 		if ( styles ) {
 			return [
 				...styles,
 				{
-					css: 'body{height:auto;overflow:hidden;border:none;padding:0;}',
+					css: 'body{height:auto;overflow:hidden;border:none;padding:0;}.is-root-container{padding:0!important} ',
 					__unstableType: 'presets',
 				},
 				...additionalStyles,


### PR DESCRIPTION
## What?
Overrides any root padding added by a theme in the pattern preview iframe

## Why?
Fixes: #52421

## How?
Sets padding to `0` for `.is-root-container`.

## Testing Instructions
In TT2 theme load the pattern preview panel in the inserter and check that there is no additional external padding on the previews - `Featured` is a good category to check.

## Screenshots or screencast <!-- if applicable -->

Before:

<img width="618" alt="Screenshot 2023-07-20 at 10 37 28 AM" src="https://github.com/WordPress/gutenberg/assets/3629020/5eb0a080-e411-4be4-8823-7cd0b2052f64">

After:

<img width="624" alt="Screenshot 2023-07-20 at 10 48 13 AM" src="https://github.com/WordPress/gutenberg/assets/3629020/abe5627b-c00b-4814-b2f1-cbb1eaf2021d">




