### PR TITLE
Global Styles: Don't use named arguments for 'sprintf'

### DIFF
--- a/packages/edit-site/src/components/global-styles/screen-revisions/revisions-buttons.js
+++ b/packages/edit-site/src/components/global-styles/screen-revisions/revisions-buttons.js
@@ -21,11 +21,9 @@ function getRevisionLabel( revision ) {
 
 	if ( 'unsaved' === revision?.id ) {
 		return sprintf(
-			/* translators: %(name)s author display name */
-			__( 'Unsaved changes by %(name)s' ),
-			{
-				name: authorDisplayName,
-			}
+			/* translators: %s author display name */
+			__( 'Unsaved changes by %s' ),
+			authorDisplayName
 		);
 	}
 	const formattedDate = dateI18n(
@@ -35,20 +33,16 @@ function getRevisionLabel( revision ) {
 
 	return revision?.isLatest
 		? sprintf(
-				/* translators: %(name)s author display name, %(date)s: revision creation date */
-				__( 'Changes saved by %(name)s on %(date)s (current)' ),
-				{
-					name: authorDisplayName,
-					date: formattedDate,
-				}
+				/* translators: %1$s author display name, %2$s: revision creation date */
+				__( 'Changes saved by %1$s on %2$s (current)' ),
+				authorDisplayName,
+				formattedDate
 		  )
 		: sprintf(
-				/* translators: %(name)s author display name, %(date)s: revision creation date */
-				__( 'Changes saved by %(name)s on %(date)s' ),
-				{
-					name: authorDisplayName,
-					date: formattedDate,
-				}
+				/* translators: %1$s author display name, %2$s: revision creation date */
+				__( 'Changes saved by %1$s on %2$s' ),
+				authorDisplayName,
+				formattedDate
 		  );
 }
 
@@ -104,22 +98,14 @@ function RevisionsButtons( { userRevisions, selectedRevisionId, onChange } ) {
 								<span className="edit-site-global-styles-screen-revisions__meta">
 									{ isUnsaved
 										? sprintf(
-												/* translators: %(name)s author display name */
-												__(
-													'Unsaved changes by %(name)s'
-												),
-												{
-													name: authorDisplayName,
-												}
+												/* translators: %s author display name */
+												__( 'Unsaved changes by %s' ),
+												authorDisplayName
 										  )
 										: sprintf(
-												/* translators: %(name)s author display name */
-												__(
-													'Changes saved by %(name)s'
-												),
-												{
-													name: authorDisplayName,
-												}
+												/* translators: %s author display name */
+												__( 'Changes saved by %s' ),
+												authorDisplayName
 										  ) }
 
 									<img


### PR DESCRIPTION
## What?
PR replaces [named arguments](https://www.npmjs.com/package/sprintf-js#named-arguments) for the `sprintf` i18n helper with regular placeholders.

## Why?
The PHP counterpart doesn't support named arguments and the difference can be confusing for people working on translations.

See https://wordpress.slack.com/archives/C02RP50LK/p1689759989093929

## Testing Instructions
1. Open the Site Editor.
2. Smoke test the global styles revisions.
3. Confirm they work as before.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2023-07-20 at 11 16 22](https://github.com/WordPress/gutenberg/assets/240569/6e68f0dc-296b-41fa-8e07-5bfe766036ae)
