### PR TITLE
Verse: Disable line breaks

### DIFF
--- a/packages/block-library/src/verse/edit.js
+++ b/packages/block-library/src/verse/edit.js
@@ -13,6 +13,7 @@ import {
 	AlignmentToolbar,
 	useBlockProps,
 } from '@wordpress/block-editor';
+import { createBlock, getDefaultBlockName } from '@wordpress/blocks';
 
 export default function VerseEdit( {
 	attributes,
@@ -20,6 +21,7 @@ export default function VerseEdit( {
 	mergeBlocks,
 	onRemove,
 	style,
+	insertBlocksAfter,
 } ) {
 	const { textAlign, content } = attributes;
 	const blockProps = useBlockProps( {
@@ -56,6 +58,9 @@ export default function VerseEdit( {
 				textAlign={ textAlign }
 				{ ...blockProps }
 				__unstablePastePlainText
+				__unstableOnSplitAtEnd={ () =>
+					insertBlocksAfter( createBlock( getDefaultBlockName() ) )
+				}
 			/>
 		</>
 	);

--- a/packages/block-library/src/verse/test/edit.native.js
+++ b/packages/block-library/src/verse/test/edit.native.js
@@ -64,13 +64,15 @@ describe( 'Verse block', () => {
 		const verseTextInput = await screen.findByPlaceholderText(
 			'Write verse…'
 		);
-		typeInRichText( verseTextInput, 'A great statement.' );
+		typeInRichText( verseTextInput, 'A great statement.Again', {
+			finalSelectionStart: 18,
+			finalSelectionEnd: 18,
+		} );
 		fireEvent( verseTextInput, 'onKeyDown', {
 			nativeEvent: {},
 			preventDefault() {},
 			keyCode: ENTER,
 		} );
-		typeInRichText( verseTextInput, 'Again' );
 
 		// Assert
 		expect( getEditorHtml() ).toMatchInlineSnapshot( `


### PR DESCRIPTION
## What?
Fixes #52773.

PR disables line breaks in the Verse block, so when a user presses <kbd>Enter</kbd> at the end of the text, it will create a new default block.

Users still be able to create line breaks using <kbd>Shift</kbd> + <kbd>Enter</kbd>.

## How?
Add the `__unstableOnSplitAtEnd` handle to the RichText component.

## Testing Instructions
1. Open a Post or Page.
2. Insert a Verse block and text.
3. Place the cursor at the end text and press <kbd>Enter</kbd>. Confirm new block is created.
4. Place the cursor somewhere inside the text and press <kbd>Enter</kbd>. Confirm line break is created.

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/240569/7ece888f-5484-4b7b-b828-d26c024dbec2

