### PR TITLE
Docs: Update Appearance Tools

### DIFF
--- a/docs/how-to-guides/themes/theme-support.md
+++ b/docs/how-to-guides/themes/theme-support.md
@@ -472,6 +472,8 @@ Use this setting to enable the following Global Styles settings:
 - color: link
 - spacing: blockGap, margin, padding
 - typography: lineHeight
+- dimensions: minHeight
+- position: sticky
 
 ```php
 add_theme_support( 'appearance-tools' );


### PR DESCRIPTION
The [Documentation on Theme Support ](https://developer.wordpress.org/block-editor/how-to-guides/themes/theme-support/#appearance-tools)was missing two settings for Appearance Tools ([see issue](https://github.com/WordPress/gutenberg/issues/52784))


## What?

Adding support for appearance tools adds to more presets for Global Styles
- dimensions: minHeight
- position: sticky

## Why?
Schema change in #48057 in  WordPress 6.2
## How?
added two lines
- dimensions: minHeight
- position: sticky

## Testing Instructions
Docs only change

