### PR TITLE
Update e2e tests that use code editor

### DIFF
--- a/test/e2e/specs/editor/blocks/list.spec.js
+++ b/test/e2e/specs/editor/blocks/list.spec.js
@@ -1241,17 +1241,19 @@ test.describe( 'List (@firefox)', () => {
 
 	test( 'can be created by pasting an empty list (-firefox)', async ( {
 		editor,
+		page,
 		pageUtils,
 	} ) => {
 		// Open code editor
 		await pageUtils.pressKeys( 'secondary+M' ); // Emulates CTRL+Shift+Alt + M => toggle code editor
 
-		// Paste empty list block
-		pageUtils.setClipboardData( {
-			plainText:
-				'<!-- wp:list -->\n<ul><li></li></ul>\n<!-- /wp:list -->',
-		} );
-		await pageUtils.pressKeys( 'primary+v' );
+		// Add empty list block
+		await page.getByPlaceholder( 'Start writing with text or HTML' )
+			.fill( `<!-- wp:list -->
+<ul><!-- wp:list-item -->
+<li></li>
+<!-- /wp:list-item --></ul>
+<!-- /wp:list -->` );
 
 		// Go back to normal editor
 		await pageUtils.pressKeys( 'secondary+M' ); // Emulates CTRL+Shift+Alt + M => toggle code editor

--- a/test/e2e/specs/editor/various/content-only-lock.spec.js
+++ b/test/e2e/specs/editor/various/content-only-lock.spec.js
@@ -15,13 +15,14 @@ test.describe( 'Content-only lock', () => {
 	} ) => {
 		// Add content only locked block in the code editor
 		await pageUtils.pressKeys( 'secondary+M' ); // Emulates CTRL+Shift+Alt + M => toggle code editor
-		await page.click( '.editor-post-text-editor' );
-		await page.keyboard
-			.type( `<!-- wp:group {"templateLock":"contentOnly","layout":{"type":"constrained"}} -->
-        <div class="wp-block-group"><!-- wp:paragraph -->
-        <p>Hello</p>
-        <!-- /wp:paragraph --></div>
-        <!-- /wp:group -->` );
+
+		await page.getByPlaceholder( 'Start writing with text or HTML' )
+			.fill( `<!-- wp:group {"templateLock":"contentOnly","layout":{"type":"constrained"}} -->
+<div class="wp-block-group"><!-- wp:paragraph -->
+<p>Hello</p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:group -->` );
+
 		await pageUtils.pressKeys( 'secondary+M' );
 		await page.waitForSelector( 'iframe[name="editor-canvas"]' );
 		await editor.canvas.click( 'role=document[name="Paragraph block"i]' );


### PR DESCRIPTION
## What?
PR makes the following changes in the `list` and `content-only-block` specs:

* Use `getByPlaceholder` for the code editor locator.
* Use `Locator.fill` to emulate paste. The `fill` focus element and then fill the content. This is all we need here.

To be honest, I'm not sure how the list test passed before. When you run it in UI mode, you'll see that focus is on the post title during the paste action, but the content actually gets pasted in the code editor 🤷‍♂️

## Why?
I'm suspicious that due to failed keyboard shortcut, code editor mode was leaking into other tests like - https://github.com/WordPress/gutenberg/issues/51607#issuecomment-1595654822.

It's a known issue that switching to a code editor can cause focus loss and prevent editor shortcuts from working - #42145. These changes ensure there's a focus after the initial switch.

## Testing Instructions
CI checks should be green for these tests.
