### PR TITLE
[create-block] Refinements to the create-block-interactive-template package.

### DIFF
--- a/packages/create-block-interactive-template/CHANGELOG.md
+++ b/packages/create-block-interactive-template/CHANGELOG.md
@@ -1,1 +1,7 @@
 <!-- Learn how to maintain this file at https://github.com/WordPress/gutenberg/tree/HEAD/packages#maintaining-changelogs. -->
+
+## Unreleased
+
+### Enhancement
+
+-   Moves the `example` property into block.json by leveraging changes to create-block to now support `example`. [#52801](https://github.com/WordPress/gutenberg/pull/52801)

--- a/packages/create-block-interactive-template/block-templates/index.js.mustache
+++ b/packages/create-block-interactive-template/block-templates/index.js.mustache
@@ -29,14 +29,6 @@ import metadata from './block.json';
  */
 registerBlockType( metadata.name, {
 	/**
-	 * Used to construct a preview for the block to be shown in the block inserter.
-	 */
-	example: {
-		attributes: {
-			message: '{{title}}',
-		},
-	},
-	/**
 	 * @see ./edit.js
 	 */
 	edit: Edit,

--- a/packages/create-block-interactive-template/block-templates/render.php.mustache
+++ b/packages/create-block-interactive-template/block-templates/render.php.mustache
@@ -8,7 +8,7 @@ $unique_id = uniqid( 'p-' );
 ?>
 
 <div
-	<?php echo get_block_wrapper_attributes(); ?>
+	<?php echo wp_kses_data( get_block_wrapper_attributes() ); ?>
 	data-wp-interactive
 	data-wp-context='{ "{{namespace}}": { "isOpen": false } }'
 	data-wp-effect="effects.{{namespace}}.logIsOpen"
@@ -16,17 +16,17 @@ $unique_id = uniqid( 'p-' );
 	<button
 		data-wp-on--click="actions.{{namespace}}.toggle"
 		data-wp-bind--aria-expanded="context.{{namespace}}.isOpen"
-		aria-controls="p-<?php echo $unique_id; ?>"
+		aria-controls="p-<?php cho esc_attr( $unique_id ); ?>"
 	>
-		<?php _e( 'Toggle', '{{textdomain}}' ); ?>
+		<?php esc_html_e( 'Toggle', '{{textdomain}}' ); ?>
 	</button>
 
 	<p
-		id="p-<?php echo $unique_id; ?>"
+		id="p-<?php echo esc_attr( $unique_id ); ?>"
 		data-wp-bind--hidden="!context.{{namespace}}.isOpen"
 	>
 		<?php
-			_e( '{{title}} - hello from an interactive block!', '{{textdomain}}' );
+			esc_html_e( '{{title}} - hello from an interactive block!', '{{textdomain}}' );
 		?>
 	</p>
 </div>

--- a/packages/create-block-interactive-template/block-templates/render.php.mustache
+++ b/packages/create-block-interactive-template/block-templates/render.php.mustache
@@ -15,7 +15,7 @@ $unique_id = uniqid( 'p-' );
 ?>
 
 <div
-	<?php echo wp_kses_data( get_block_wrapper_attributes() ); ?>
+	<?php echo get_block_wrapper_attributes(); ?>
 	data-wp-interactive
 	data-wp-context='{ "{{namespace}}": { "isOpen": false } }'
 	data-wp-effect="effects.{{namespace}}.logIsOpen"

--- a/packages/create-block-interactive-template/block-templates/render.php.mustache
+++ b/packages/create-block-interactive-template/block-templates/render.php.mustache
@@ -1,6 +1,13 @@
 {{#isBasicVariant}}
 <?php
 /**
+ * PHP file to use when rendering the block type on the server to show on the front end.
+ *
+ * The following variables are exposed to the file:
+ *     $attributes (array): The block attributes.
+ *     $content (string): The block default content.
+ *     $block (WP_Block): The block instance.
+ *
  * @see https://github.com/WordPress/gutenberg/blob/trunk/docs/reference-guides/block-api/block-metadata.md#render
  */
 

--- a/packages/create-block-interactive-template/block-templates/render.php.mustache
+++ b/packages/create-block-interactive-template/block-templates/render.php.mustache
@@ -16,7 +16,7 @@ $unique_id = uniqid( 'p-' );
 	<button
 		data-wp-on--click="actions.{{namespace}}.toggle"
 		data-wp-bind--aria-expanded="context.{{namespace}}.isOpen"
-		aria-controls="p-<?php cho esc_attr( $unique_id ); ?>"
+		aria-controls="p-<?php echo esc_attr( $unique_id ); ?>"
 	>
 		<?php esc_html_e( 'Toggle', '{{textdomain}}' ); ?>
 	</button>

--- a/packages/create-block-interactive-template/index.js
+++ b/packages/create-block-interactive-template/index.js
@@ -16,11 +16,7 @@ module.exports = {
 		render: 'file:./render.php',
 		viewScript: 'file:./view.js',
 		customBlockJSON: {
-			example: {
-				attributes: {
-					message: 'Example Interactive',
-				},
-			},
+			example: {},
 		},
 	},
 	variants: {

--- a/packages/create-block-interactive-template/index.js
+++ b/packages/create-block-interactive-template/index.js
@@ -15,9 +15,7 @@ module.exports = {
 		},
 		render: 'file:./render.php',
 		viewScript: 'file:./view.js',
-		customBlockJSON: {
-			example: {},
-		},
+		example: {},
 	},
 	variants: {
 		basic: {},

--- a/packages/create-block-interactive-template/index.js
+++ b/packages/create-block-interactive-template/index.js
@@ -15,6 +15,13 @@ module.exports = {
 		},
 		render: 'file:./render.php',
 		viewScript: 'file:./view.js',
+		customBlockJSON: {
+			example: {
+				attributes: {
+					message: 'Example Interactive',
+				},
+			},
+		},
 	},
 	variants: {
 		basic: {},


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This PR introduces some refinements to the template files to have the `example` property defined in the `block.json` file instead of the `index.js` and to add some [late escaping](https://developer.wordpress.org/apis/security/escaping/#toc_3) to the render.php file.

## Why?
It is better to contain as much as possible in the block.json file, especially if there are translations involved as those strings are automatically translated. The escaping items trigger various WPCS rules and make for a better developer experience.

## Testing Instructions
1. Check out this branch
2. `cd` into the `packages/create-block-interactive-template
create-block-interactive-template`
3. Run `npx @wordpress/create-block@latest my-first-interactive-block --template ./`
4. cd into `my-first-interactive-block` and run `npx @wp-now/wp-now start `]
5. Install the Gutenberg plugin in the created environment.
6. Insert the block and confirm that everything works as expected.
