### PR TITLE
Route to published post instead of homepage on navigation e2e tests

### DIFF
--- a/test/e2e/specs/editor/blocks/navigation.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation.spec.js
@@ -5,16 +5,18 @@ const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 
 test.describe( 'Navigation block', () => {
 	test.beforeEach( async ( { requestUtils } ) => {
-		await Promise.all( [ requestUtils.deleteAllMenus() ] );
+		await requestUtils.deleteAllMenus();
 	} );
 
 	test.afterAll( async ( { requestUtils } ) => {
-		await Promise.all( [ requestUtils.deleteAllMenus() ] );
+		await requestUtils.deleteAllMenus();
 	} );
 
 	test.afterEach( async ( { requestUtils } ) => {
-		await requestUtils.deleteAllPosts();
-		await requestUtils.deleteAllMenus();
+		await Promise.all( [
+			requestUtils.deleteAllPosts(),
+			requestUtils.deleteAllMenus(),
+		] );
 	} );
 
 	test.describe( 'As a user I want the navigation block to fallback to the best possible default', () => {

--- a/test/e2e/specs/editor/blocks/navigation.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation.spec.js
@@ -4,20 +4,12 @@
 const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 
 test.describe( 'Navigation block', () => {
-	test.beforeAll( async ( { requestUtils } ) => {
-		//TT3 is preferable to emptytheme because it already has the navigation block on its templates.
-		await requestUtils.activateTheme( 'twentytwentythree' );
-	} );
-
 	test.beforeEach( async ( { requestUtils } ) => {
 		await Promise.all( [ requestUtils.deleteAllMenus() ] );
 	} );
 
 	test.afterAll( async ( { requestUtils } ) => {
-		await Promise.all( [
-			requestUtils.deleteAllMenus(),
-			requestUtils.activateTheme( 'twentytwentyone' ),
-		] );
+		await Promise.all( [ requestUtils.deleteAllMenus() ] );
 	} );
 
 	test.afterEach( async ( { requestUtils } ) => {
@@ -74,8 +66,9 @@ test.describe( 'Navigation block', () => {
 				)
 			).toBeVisible();
 
-			// Check the markup of the block is correct.
 			const postId = await editor.publishPost();
+
+			// Check the markup of the block is correct.
 			await expect.poll( editor.getBlocks ).toMatchObject( [
 				{
 					name: 'core/navigation',
@@ -91,8 +84,6 @@ test.describe( 'Navigation block', () => {
 					`role=navigation >> role=link[name="WordPress"i]`
 				)
 			).toBeVisible();
-
-			expect( true ).toBe( false );
 		} );
 
 		test( 'default to the only existing classic menu if there are no block menus', async ( {
@@ -120,16 +111,15 @@ test.describe( 'Navigation block', () => {
 				)
 			).toBeVisible( { timeout: 10000 } ); // allow time for network request.
 
+			const postId = await editor.publishPost();
 			// Check the block in the frontend.
-			await page.goto( `/` );
+			await page.goto( `/?p=${ postId }` );
 
 			await expect(
 				page.locator(
 					`role=navigation >> role=link[name="Custom link"i]`
 				)
 			).toBeVisible();
-
-			expect( true ).toBe( false );
 		} );
 
 		test( 'default to my most recently created menu', async ( {
@@ -181,8 +171,6 @@ test.describe( 'Navigation block', () => {
 					`role=navigation >> role=link[name="Menu 2 Link"i]`
 				)
 			).toBeVisible();
-
-			expect( true ).toBe( false );
 		} );
 	} );
 
@@ -214,16 +202,14 @@ test.describe( 'Navigation block', () => {
 			} );
 			await addSubmenuButton.click();
 
-			await editor.publishPost();
-			await page.goto( `/` );
+			const postId = await editor.publishPost();
+			await page.goto( `/?p=${ postId }` );
 
 			await expect(
 				page.locator(
 					`role=navigation >> role=button[name="example.com submenu "i]`
 				)
 			).toBeVisible();
-
-			expect( true ).toBe( false );
 		} );
 
 		test( 'submenu converts to link automatically', async ( {

--- a/test/e2e/specs/editor/blocks/navigation.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation.spec.js
@@ -75,7 +75,7 @@ test.describe( 'Navigation block', () => {
 			).toBeVisible();
 
 			// Check the markup of the block is correct.
-			await editor.publishPost();
+			const postId = await editor.publishPost();
 			await expect.poll( editor.getBlocks ).toMatchObject( [
 				{
 					name: 'core/navigation',
@@ -84,13 +84,15 @@ test.describe( 'Navigation block', () => {
 			] );
 
 			// Check the block in the frontend.
-			await page.goto( `/` );
+			await page.goto( `/?p=${ postId }` );
 
 			await expect(
 				page.locator(
 					`role=navigation >> role=link[name="WordPress"i]`
 				)
 			).toBeVisible();
+
+			expect( true ).toBe( false );
 		} );
 
 		test( 'default to the only existing classic menu if there are no block menus', async ( {
@@ -126,6 +128,8 @@ test.describe( 'Navigation block', () => {
 					`role=navigation >> role=link[name="Custom link"i]`
 				)
 			).toBeVisible();
+
+			expect( true ).toBe( false );
 		} );
 
 		test( 'default to my most recently created menu', async ( {
@@ -154,7 +158,7 @@ test.describe( 'Navigation block', () => {
 			await editor.insertBlock( { name: 'core/navigation' } );
 
 			// Check the markup of the block is correct.
-			await editor.publishPost();
+			const postId = await editor.publishPost();
 			await expect.poll( editor.getBlocks ).toMatchObject( [
 				{
 					name: 'core/navigation',
@@ -170,13 +174,15 @@ test.describe( 'Navigation block', () => {
 			).toBeVisible();
 
 			// Check the block in the frontend.
-			await page.goto( `/` );
+			await page.goto( `/?p=${ postId }` );
 
 			await expect(
 				page.locator(
 					`role=navigation >> role=link[name="Menu 2 Link"i]`
 				)
 			).toBeVisible();
+
+			expect( true ).toBe( false );
 		} );
 	} );
 
@@ -216,6 +222,8 @@ test.describe( 'Navigation block', () => {
 					`role=navigation >> role=button[name="example.com submenu "i]`
 				)
 			).toBeVisible();
+
+			expect( true ).toBe( false );
 		} );
 
 		test( 'submenu converts to link automatically', async ( {


### PR DESCRIPTION
Some of the navigation tests rely on routing to `/` to test a menu created in the post editor. This works because if there are no menus, the header navigation template in TT3 _should_ grab the only available menu (the one just created) and put it in the header, like this:

![Routed to / with a menu in the header](https://github.com/WordPress/gutenberg/assets/967608/3bb148d5-61ca-40eb-8b13-8e5400b050b1)

Locally, when I run these tests which deletes the menu, I end up with no menu in the header. I even deleted TT3 from my testing environment and reinstalled it.

<img width="1274" alt="" src="https://github.com/WordPress/gutenberg/assets/967608/520893b9-df45-4131-ba55-076483e2cd4c">


In the header template state that has the "Navigation menu has been deleted or unavailable message".
<img width="1266" alt="" src="https://github.com/WordPress/gutenberg/assets/967608/f263dd63-e8a9-46b0-a2ce-ea23ecdfd885">

I've tried enough strategies to get my test environment and the github e2e test environment inline without any success. This makes me want to redo the method since it seems flaky (or at least is annoying enough to me).

Also, since this test is relying on a side-effect of the TT3 theme that _should_ have a header template and _should_ populate the header navigation with the most recently created one, the test works due to a side-effect that we could remove.

I think a better test set-up is to route to the published post, but on the github e2e tests, it ends up having two identical menus and the locator isn't specific enough.

![](https://github.com/WordPress/gutenberg/assets/967608/dc172d0e-24d7-4849-ac6e-894b9fea1163)


### The Fix
Instead of relying on the header template to hopefully use the only created navigation, use a theme without a default header navigation (TT1, which is already active), and route directly to the published post to check the markup.

### Testing Instructions
`npm run test:e2e:playwright /navigation.spec.js`

