### PR TITLE
[Create Block] Add support for the example property and add template defaults.

### DIFF
--- a/packages/create-block/CHANGELOG.md
+++ b/packages/create-block/CHANGELOG.md
@@ -2,7 +2,15 @@
 
 ## Unreleased
 
+### Enhancement
+
+-   Add support for the `example` property add template defaults ([#52803](https://github.com/WordPress/gutenberg/pull/52803)).
+
 ## 4.22.0 (2023-07-20)
+
+### Enhancement
+
+-   Add support for the `viewScript` property ([#52612](https://github.com/WordPress/gutenberg/pull/52612)).
 
 ## 4.21.0 (2023-07-05)
 

--- a/packages/create-block/CHANGELOG.md
+++ b/packages/create-block/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Enhancement
 
--   Add support for the `example` property add template defaults ([#52803](https://github.com/WordPress/gutenberg/pull/52803)).
+-   Add support for the `example` property and add it to the default template ([#52803](https://github.com/WordPress/gutenberg/pull/52803)).
 
 ## 4.22.0 (2023-07-20)
 

--- a/packages/create-block/lib/init-block.js
+++ b/packages/create-block/lib/init-block.js
@@ -32,6 +32,7 @@ async function initBlockJSON( {
 	render,
 	viewScript,
 	customBlockJSON,
+	example,
 } ) {
 	info( '' );
 	info( 'Creating a "block.json" file.' );
@@ -53,6 +54,7 @@ async function initBlockJSON( {
 					category,
 					icon: dashicon,
 					description,
+					example,
 					attributes,
 					supports,
 					textdomain,

--- a/packages/create-block/lib/scaffold.js
+++ b/packages/create-block/lib/scaffold.js
@@ -48,6 +48,7 @@ module.exports = async (
 		variantVars,
 		customPackageJSON,
 		customBlockJSON,
+		example,
 	}
 ) => {
 	slug = slug.toLowerCase();
@@ -107,6 +108,7 @@ module.exports = async (
 		viewScript,
 		customPackageJSON,
 		customBlockJSON,
+		example,
 		...variantVars,
 	};
 

--- a/packages/create-block/lib/templates.js
+++ b/packages/create-block/lib/templates.js
@@ -34,6 +34,7 @@ const predefinedPluginTemplates = {
 			editorStyle: null,
 			style: null,
 			viewScript: 'file:./view.js',
+			example: {},
 		},
 		templatesPath: join( __dirname, 'templates', 'es5' ),
 		variants: {
@@ -55,6 +56,7 @@ const predefinedPluginTemplates = {
 				html: false,
 			},
 			viewScript: 'file:./view.js',
+			example: {},
 		},
 		variants: {
 			static: {},


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This PR adds support for the[ `example`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#example) property in block.json to the create-block tool and adds a basic `example: {}` to each template.

## Why?
The `example` property is used to trigger the block preview in the inserter as well as in the Style Book. This is a point of confusion for developers and by having it supported and in the default templates, it will bring awareness to the property and address issues around why custom block are not appearing in the Style Book

## Testing Instructions
1. Checkout this branch
2. `cd` into `pacakagpackages/create-block`
3. Run `node index.js` and follow prompts
4. Confirm that the created `block.json` contains `example: {}`
