### PR TITLE
Global Styles: Fix push to global styles for borders and preset attributes

### DIFF
--- a/packages/edit-site/src/hooks/push-changes-to-global-styles/index.js
+++ b/packages/edit-site/src/hooks/push-changes-to-global-styles/index.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { get, set } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { addFilter } from '@wordpress/hooks';
@@ -18,6 +13,7 @@ import { __, sprintf } from '@wordpress/i18n';
 import {
 	__EXPERIMENTAL_STYLE_PROPERTY as STYLE_PROPERTY,
 	getBlockType,
+	hasBlockSupport,
 } from '@wordpress/blocks';
 import { useContext, useMemo, useCallback } from '@wordpress/element';
 import { useDispatch } from '@wordpress/data';
@@ -29,7 +25,7 @@ import { store as noticesStore } from '@wordpress/notices';
 import { useSupportedStyles } from '../../components/global-styles/hooks';
 import { unlock } from '../../lock-unlock';
 
-const { GlobalStylesContext, useBlockEditingMode } = unlock(
+const { GlobalStylesContext, cleanEmptyObject, useBlockEditingMode } = unlock(
 	blockEditorPrivateApis
 );
 
@@ -37,6 +33,7 @@ const { GlobalStylesContext, useBlockEditingMode } = unlock(
 // removed by moving PushChangesToGlobalStylesControl to
 // @wordpress/block-editor.
 const STYLE_PATH_TO_CSS_VAR_INFIX = {
+	'border.color': 'color',
 	'color.background': 'color',
 	'color.text': 'color',
 	'elements.link.color.text': 'color',
@@ -78,6 +75,7 @@ const STYLE_PATH_TO_CSS_VAR_INFIX = {
 	'elements.h6.typography.fontFamily': 'font-family',
 	'elements.h6.color.gradient': 'gradient',
 	'color.gradient': 'gradient',
+	'spacing.blockGap': 'spacing',
 	'typography.fontSize': 'font-size',
 	'typography.fontFamily': 'font-family',
 };
@@ -86,6 +84,7 @@ const STYLE_PATH_TO_CSS_VAR_INFIX = {
 // removed by moving PushChangesToGlobalStylesControl to
 // @wordpress/block-editor.
 const STYLE_PATH_TO_PRESET_BLOCK_ATTRIBUTE = {
+	'border.color': 'borderColor',
 	'color.background': 'backgroundColor',
 	'color.text': 'textColor',
 	'color.gradient': 'gradient',
@@ -93,30 +92,153 @@ const STYLE_PATH_TO_PRESET_BLOCK_ATTRIBUTE = {
 	'typography.fontFamily': 'fontFamily',
 };
 
-function useChangesToPush( name, attributes ) {
-	const supports = useSupportedStyles( name );
+const SUPPORTED_STYLES = [ 'border', 'color', 'spacing', 'typography' ];
 
-	return useMemo(
-		() =>
-			supports.flatMap( ( key ) => {
-				if ( ! STYLE_PROPERTY[ key ] ) {
-					return [];
-				}
-				const { value: path } = STYLE_PROPERTY[ key ];
-				const presetAttributeKey = path.join( '.' );
-				const presetAttributeValue =
-					attributes[
-						STYLE_PATH_TO_PRESET_BLOCK_ATTRIBUTE[
-							presetAttributeKey
-						]
-					];
-				const value = presetAttributeValue
-					? `var:preset|${ STYLE_PATH_TO_CSS_VAR_INFIX[ presetAttributeKey ] }|${ presetAttributeValue }`
-					: get( attributes.style, path );
-				return value ? [ { path, value } ] : [];
-			} ),
-		[ supports, name, attributes ]
-	);
+const getValueFromObjectPath = ( object, path ) => {
+	let value = object;
+	path.forEach( ( fieldName ) => {
+		value = value?.[ fieldName ];
+	} );
+	return value;
+};
+
+const flatBorderProperties = [ 'borderColor', 'borderWidth', 'borderStyle' ];
+const sides = [ 'top', 'right', 'bottom', 'left' ];
+
+function getBorderStyleChanges( border, presetColor, userStyle ) {
+	if ( ! border && ! presetColor ) {
+		return [];
+	}
+
+	const changes = [
+		...getFallbackBorderStyleChange( 'top', border, userStyle ),
+		...getFallbackBorderStyleChange( 'right', border, userStyle ),
+		...getFallbackBorderStyleChange( 'bottom', border, userStyle ),
+		...getFallbackBorderStyleChange( 'left', border, userStyle ),
+	];
+
+	// Handle a flat border i.e. all sides the same, CSS shorthand.
+	const { color: customColor, style, width } = border || {};
+	const hasColorOrWidth = presetColor || customColor || width;
+
+	if ( hasColorOrWidth && ! style ) {
+		// Global Styles need individual side configurations to overcome
+		// theme.json configurations which are per side as well.
+		sides.forEach( ( side ) => {
+			// Only add fallback border-style if global styles don't already
+			// have something set.
+			if ( ! userStyle?.[ side ]?.style ) {
+				changes.push( {
+					path: [ 'border', side, 'style' ],
+					value: 'solid',
+				} );
+			}
+		} );
+	}
+
+	return changes;
+}
+
+function getFallbackBorderStyleChange( side, border, globalBorderStyle ) {
+	if ( ! border?.[ side ] || globalBorderStyle?.[ side ]?.style ) {
+		return [];
+	}
+
+	const { color, style, width } = border[ side ];
+	const hasColorOrWidth = color || width;
+
+	if ( ! hasColorOrWidth || style ) {
+		return [];
+	}
+
+	return [ { path: [ 'border', side, 'style' ], value: 'solid' } ];
+}
+
+function useChangesToPush( name, attributes, userConfig ) {
+	const supports = useSupportedStyles( name );
+	const blockUserConfig = userConfig?.styles?.blocks?.[ name ];
+
+	return useMemo( () => {
+		const changes = supports.flatMap( ( key ) => {
+			if ( ! STYLE_PROPERTY[ key ] ) {
+				return [];
+			}
+			const { value: path } = STYLE_PROPERTY[ key ];
+			const presetAttributeKey = path.join( '.' );
+			const presetAttributeValue =
+				attributes[
+					STYLE_PATH_TO_PRESET_BLOCK_ATTRIBUTE[ presetAttributeKey ]
+				];
+			const value = presetAttributeValue
+				? `var:preset|${ STYLE_PATH_TO_CSS_VAR_INFIX[ presetAttributeKey ] }|${ presetAttributeValue }`
+				: getValueFromObjectPath( attributes.style, path );
+
+			// The shorthand border styles can't be mapped directly as global
+			// styles requires longhand config.
+			if ( flatBorderProperties.includes( key ) && value ) {
+				// The shorthand config path is included to clear the block attribute.
+				const borderChanges = [ { path, value } ];
+				sides.forEach( ( side ) => {
+					const currentPath = [ ...path ];
+					currentPath.splice( -1, 0, side );
+					borderChanges.push( { path: currentPath, value } );
+				} );
+				return borderChanges;
+			}
+
+			return value ? [ { path, value } ] : [];
+		} );
+
+		// To ensure display of a visible border, global styles require a
+		// default border style if a border color or width is present.
+		getBorderStyleChanges(
+			attributes.style?.border,
+			attributes.borderColor,
+			blockUserConfig?.border
+		).forEach( ( change ) => changes.push( change ) );
+
+		return changes;
+	}, [ supports, attributes, blockUserConfig ] );
+}
+
+/**
+ * Sets the value at path of object.
+ * If a portion of path doesn’t exist, it’s created.
+ * Arrays are created for missing index properties while objects are created
+ * for all other missing properties.
+ *
+ * This function intentionally mutates the input object.
+ *
+ * Inspired by _.set().
+ *
+ * @see https://lodash.com/docs/4.17.15#set
+ *
+ * @todo Needs to be deduplicated with its copy in `@wordpress/core-data`.
+ *
+ * @param {Object} object Object to modify
+ * @param {Array}  path   Path of the property to set.
+ * @param {*}      value  Value to set.
+ */
+function setNestedValue( object, path, value ) {
+	if ( ! object || typeof object !== 'object' ) {
+		return object;
+	}
+
+	path.reduce( ( acc, key, idx ) => {
+		if ( acc[ key ] === undefined ) {
+			if ( Number.isInteger( path[ idx + 1 ] ) ) {
+				acc[ key ] = [];
+			} else {
+				acc[ key ] = {};
+			}
+		}
+		if ( idx === path.length - 1 ) {
+			acc[ key ] = value;
+		}
+		return acc[ key ];
+	}, object );
+
+	return object;
 }
 
 function cloneDeep( object ) {
@@ -128,10 +250,10 @@ function PushChangesToGlobalStylesControl( {
 	attributes,
 	setAttributes,
 } ) {
-	const changes = useChangesToPush( name, attributes );
-
 	const { user: userConfig, setUserConfig } =
 		useContext( GlobalStylesContext );
+
+	const changes = useChangesToPush( name, attributes, userConfig );
 
 	const { __unstableMarkNextChangeAsNotPersistent } =
 		useDispatch( blockEditorStore );
@@ -148,16 +270,30 @@ function PushChangesToGlobalStylesControl( {
 		const newUserConfig = cloneDeep( userConfig );
 
 		for ( const { path, value } of changes ) {
-			set( newBlockStyles, path, undefined );
-			set( newUserConfig, [ 'styles', 'blocks', name, ...path ], value );
+			setNestedValue( newBlockStyles, path, undefined );
+			setNestedValue(
+				newUserConfig,
+				[ 'styles', 'blocks', name, ...path ],
+				value
+			);
 		}
+
+		const newBlockAttributes = {
+			borderColor: undefined,
+			backgroundColor: undefined,
+			textColor: undefined,
+			gradient: undefined,
+			fontSize: undefined,
+			fontFamily: undefined,
+			style: cleanEmptyObject( newBlockStyles ),
+		};
 
 		// @wordpress/core-data doesn't support editing multiple entity types in
 		// a single undo level. So for now, we disable @wordpress/core-data undo
 		// tracking and implement our own Undo button in the snackbar
 		// notification.
 		__unstableMarkNextChangeAsNotPersistent();
-		setAttributes( { style: newBlockStyles } );
+		setAttributes( newBlockAttributes );
 		setUserConfig( () => newUserConfig, { undoIgnore: true } );
 
 		createSuccessNotice(
@@ -173,7 +309,7 @@ function PushChangesToGlobalStylesControl( {
 						label: __( 'Undo' ),
 						onClick() {
 							__unstableMarkNextChangeAsNotPersistent();
-							setAttributes( { style: blockStyles } );
+							setAttributes( attributes );
 							setUserConfig( () => userConfig, {
 								undoIgnore: true,
 							} );
@@ -182,7 +318,16 @@ function PushChangesToGlobalStylesControl( {
 				],
 			}
 		);
-	}, [ changes, attributes, userConfig, name ] );
+	}, [
+		changes,
+		attributes,
+		userConfig,
+		name,
+		createSuccessNotice,
+		setAttributes,
+		setUserConfig,
+		__unstableMarkNextChangeAsNotPersistent,
+	] );
 
 	return (
 		<BaseControl
@@ -212,10 +357,14 @@ function PushChangesToGlobalStylesControl( {
 const withPushChangesToGlobalStyles = createHigherOrderComponent(
 	( BlockEdit ) => ( props ) => {
 		const blockEditingMode = useBlockEditingMode();
+		const supportsStyles = SUPPORTED_STYLES.some( ( feature ) =>
+			hasBlockSupport( props.name, feature )
+		);
+
 		return (
 			<>
 				<BlockEdit { ...props } />
-				{ blockEditingMode === 'default' && (
+				{ blockEditingMode === 'default' && supportsStyles && (
 					<InspectorAdvancedControls>
 						<PushChangesToGlobalStylesControl { ...props } />
 					</InspectorAdvancedControls>


### PR DESCRIPTION
Related:
- https://github.com/WordPress/gutenberg/pull/51621
- https://github.com/WordPress/gutenberg/pull/52480
- https://github.com/WordPress/gutenberg/pull/52160

## What?

Fixes the following without bringing in non-6.3 changes:
- pushing border styles so they include necessary fallbacks to maintain visual borders when a global style
- prevents empty style attribute obect properties
- clearing top-level block attributes used by preset values e.g. textColor, fontSize, fontFamily etc

Some changes from later Gutenberg releases have been included as well to minimise conflicts when backporting this to the 6.3 RC.

## Why?

Without these fixes the push to global styles feature is broken.

## How?

Changes included to make conflict resolution easier:
- Removal of lodash get/set functions
- Restricting the display of the apply globally button to when the block has styles support

Changes to fix pushing of global styles etc:
- Leverages `cleanEmptyObject` to prevent empty objects for properties within the block style attribute object
- Updates the config arrays so the missed block supports are picked up when detecting style changes eligible for pushing
- Appends changes to apply required border fallbacks to maintain visible borders
- Clears all the top-level preset value block attributes that are being pushed to global styles
- Makes the snackbar notice's undo action reinstate cleared preset attribute values
- Adds missing dependencies for hooks


## Testing Instructions

1. Replicate the original issue before checking out this PR. See https://github.com/WordPress/gutenberg/issues/48048 for further info.
2. In the site editor, select an individual block that has border support e.g. Featured Image or Group
3. Apply a border width or color only to that block, note that the editor shows a visual border
4. Switch to the settings tab and expand the Advanced panel revealing the Apply globally button
5. Click "Apply globally" and confirm that the border remains visible as before in the editor, including color application now being fixed
6. Switch back to the styles tab and ensure that the border controls there are now reset
7. Navigate to Global Styles > Blocks > and then to the block type you styled
8. Confirm that block type's border controls now show the color or width you selected, along with the default border style
9. Repeat the process however this time set a dashed or dotted border style and confirm that border style is retained throughout
10. Test the application of block styles global setting all available color and font preset values e.g. text, background, gradient, border color, font size, font family etc. Confirm that now when you apply those styles globally, the block's attribute has been reset.
11. Test setting global styles first, then updating a block instance style before applying the block styles globally e.g. https://github.com/WordPress/gutenberg/pull/51621#issuecomment-1596572371
12. Test with varied border configs per side ensuring they are applied as expected globally.
13. Make sure that block instance styles are correctly applied globally when the block has per-side config, the global styles are using shorthand, and vice versa.
14. Confirm that when configuring per-side borders on a block instance the border style attributes are properly cleaned from the block attributes.
15. Test that after applying block styles globally, the undo link in the snackbar notice works correctly. In particular, ensure that preset attribute values are reinstated.


## Screenshots or screencast <!-- if applicable -->


https://github.com/WordPress/gutenberg/assets/60436221/999bae6a-3d50-4083-9e9c-790009086448