### PR TITLE
Global styles: update PHP unit tests

### DIFF
--- a/lib/compat/wordpress-6.4/class-gutenberg-rest-global-styles-controller-6-4.php
+++ b/lib/compat/wordpress-6.4/class-gutenberg-rest-global-styles-controller-6-4.php
@@ -266,4 +266,26 @@ class Gutenberg_REST_Global_Styles_Controller_6_4 extends Gutenberg_REST_Global_
 		return $changes;
 	}
 
+	/**
+	 * Validate style.css as valid CSS.
+	 *
+	 * Currently just checks for invalid markup.
+	 *
+	 * @since 6.2.0
+	 * @since 6.4.0 Changed method visibility to protected.
+	 *
+	 * @param string $css CSS to validate.
+	 * @return true|WP_Error True if the input was validated, otherwise WP_Error.
+	 */
+	protected function validate_custom_css( $css ) {
+		if ( preg_match( '#</?\w+#', $css ) ) {
+			return new WP_Error(
+				'rest_custom_css_illegal_markup',
+				__( 'Markup is not allowed in CSS.', 'gutenberg' ),
+				array( 'status' => 400 )
+			);
+		}
+		return true;
+	}
+
 }

--- a/lib/compat/wordpress-6.4/class-gutenberg-rest-global-styles-revisions-controller-6-4.php
+++ b/lib/compat/wordpress-6.4/class-gutenberg-rest-global-styles-revisions-controller-6-4.php
@@ -19,6 +19,7 @@ class Gutenberg_REST_Global_Styles_Revisions_Controller_6_4 extends Gutenberg_RE
 	 * Prepares the revision for the REST response.
 	 *
 	 * @since 6.3.0
+	 * @since 6.4.0 Added `behaviors` field to the response.
 	 *
 	 * @param WP_Post         $post    Post revision object.
 	 * @param WP_REST_Request $request Request object.
@@ -87,6 +88,7 @@ class Gutenberg_REST_Global_Styles_Revisions_Controller_6_4 extends Gutenberg_RE
 	 * Retrieves the revision's schema, conforming to JSON Schema.
 	 *
 	 * @since 6.3.0
+	 * @since 6.4.0 Added `behaviors` field to the schema properties.
 	 *
 	 * @return array Item schema data.
 	 */

--- a/phpunit/class-gutenberg-rest-global-styles-revisions-controller-test.php
+++ b/phpunit/class-gutenberg-rest-global-styles-revisions-controller-test.php
@@ -1,4 +1,12 @@
 <?php
+/**
+ * Unit tests covering Gutenberg_REST_Global_Styles_Revisions_Controller_6_4 functionality.
+ *
+ * Note: the bulk of the tests covering this class and its methods have been ported to Core as of 6.3.
+ *
+ * @package WordPress
+ * @subpackage REST API
+ */
 
 class Gutenberg_REST_Global_Styles_Revisions_Controller_Test extends WP_Test_REST_Controller_Testcase {
 	/**
@@ -118,6 +126,9 @@ class Gutenberg_REST_Global_Styles_Revisions_Controller_Test extends WP_Test_RES
 							),
 						),
 					),
+					'behaviors'                   => array(
+						'default' => true,
+					),
 				)
 			),
 		);
@@ -148,6 +159,9 @@ class Gutenberg_REST_Global_Styles_Revisions_Controller_Test extends WP_Test_RES
 							),
 						),
 					),
+					'behaviors'                   => array(
+						'lightbox' => true,
+					),
 				)
 			),
 		);
@@ -177,6 +191,9 @@ class Gutenberg_REST_Global_Styles_Revisions_Controller_Test extends WP_Test_RES
 								),
 							),
 						),
+					),
+					'behaviors'                   => array(
+						'default' => true,
 					),
 				)
 			),
@@ -212,6 +229,14 @@ class Gutenberg_REST_Global_Styles_Revisions_Controller_Test extends WP_Test_RES
 
 		$this->revision_3    = array_pop( $revisions );
 		$this->revision_3_id = $this->revision_3->ID;
+
+		/*
+		 * For some reason the `rest_api_init` doesn't run early enough to ensure an overwritten `get_item_schema()`
+		 * is used. So we manually call it here.
+		 * See: https://github.com/WordPress/gutenberg/pull/52370#issuecomment-1643331655.
+		 */
+		$global_styles_revisions_controller = new Gutenberg_REST_Global_Styles_Revisions_Controller_6_4();
+		$global_styles_revisions_controller->register_routes();
 	}
 
 	/**
@@ -229,18 +254,6 @@ class Gutenberg_REST_Global_Styles_Revisions_Controller_Test extends WP_Test_RES
 	}
 
 	/**
-	 * @ticket 58524
-	 *
-	 * @covers WP_REST_Global_Styles_Controller::get_items
-	 */
-	public function test_get_items_missing_parent() {
-		wp_set_current_user( self::$admin_id );
-		$request  = new WP_REST_Request( 'GET', '/wp/v2/global-styles/' . REST_TESTS_IMPOSSIBLY_HIGH_NUMBER . '/revisions' );
-		$response = rest_get_server()->dispatch( $request );
-		$this->assertErrorResponse( 'rest_post_invalid_parent', $response, 404 );
-	}
-
-	/**
 	 * Utility function to check the items in WP_REST_Global_Styles_Controller::get_items
 	 * against the expected values.
 	 *
@@ -255,7 +268,7 @@ class Gutenberg_REST_Global_Styles_Revisions_Controller_Test extends WP_Test_RES
 		$this->assertSame( $revision_expected_item->post_parent, $response_revision_item['parent'], 'Check that an id for the parent exists.' );
 
 		// Global styles.
-		$config = ( new WP_Theme_JSON( json_decode( $revision_expected_item->post_content, true ), 'custom' ) )->get_raw_data();
+		$config = ( new WP_Theme_JSON_Gutenberg( json_decode( $revision_expected_item->post_content, true ), 'custom' ) )->get_raw_data();
 		$this->assertEquals(
 			$config['settings'],
 			$response_revision_item['settings'],
@@ -266,12 +279,17 @@ class Gutenberg_REST_Global_Styles_Revisions_Controller_Test extends WP_Test_RES
 			$response_revision_item['styles'],
 			'Check that the revision styles match the updated styles.'
 		);
+		$this->assertEquals(
+			$config['behaviors'],
+			$response_revision_item['behaviors'],
+			'Check that the revision behaviors match the updated behaviors.'
+		);
 	}
 
 	/**
 	 * @ticket 58524
 	 *
-	 * @covers WP_REST_Global_Styles_Controller::get_items
+	 * @covers Gutenberg_REST_Global_Styles_Revisions_Controller_6_4::get_items
 	 */
 	public function test_get_items() {
 		wp_set_current_user( self::$admin_id );
@@ -297,64 +315,9 @@ class Gutenberg_REST_Global_Styles_Revisions_Controller_Test extends WP_Test_RES
 	/**
 	 * @ticket 58524
 	 *
-	 * @covers WP_REST_Global_Styles_Controller::get_items
-	 */
-	public function test_get_items_eligible_roles() {
-		wp_set_current_user( self::$second_admin_id );
-		$config              = array(
-			'version'                     => WP_Theme_JSON::LATEST_SCHEMA,
-			'isGlobalStylesUserThemeJSON' => true,
-			'styles'                      => array(
-				'color' => array(
-					'background' => 'whitesmoke',
-				),
-			),
-			'settings'                    => array(),
-		);
-		$updated_styles_post = array(
-			'ID'           => self::$global_styles_id,
-			'post_content' => wp_json_encode( $config ),
-		);
-
-		wp_update_post( $updated_styles_post, true, false );
-
-		$request  = new WP_REST_Request( 'GET', '/wp/v2/global-styles/' . self::$global_styles_id . '/revisions' );
-		$response = rest_get_server()->dispatch( $request );
-		$data     = $response->get_data();
-
-		$this->assertCount( $this->total_revisions + 1, $data, 'Check that extra revision exist' );
-		$this->assertEquals( self::$second_admin_id, $data[0]['author'], 'Check that second author id returns expected value.' );
-	}
-
-	/**
-	 * @ticket 58524
-	 *
-	 * @covers WP_REST_Global_Styles_Controller::get_items with context arg.
-	 */
-	public function test_get_item_embed_context() {
-		wp_set_current_user( self::$admin_id );
-
-		$request = new WP_REST_Request( 'GET', '/wp/v2/global-styles/' . self::$global_styles_id . '/revisions' );
-		$request->set_param( 'context', 'embed' );
-		$response = rest_get_server()->dispatch( $request );
-		$fields   = array(
-			'author',
-			'date',
-			'id',
-			'parent',
-		);
-		$data     = $response->get_data();
-		$this->assertSameSets( $fields, array_keys( $data[0] ) );
-	}
-
-	/**
-	 * @ticket 58524
-	 *
-	 * @covers WP_REST_Global_Styles_Controller::get_item_schema
+	 * @covers Gutenberg_REST_Global_Styles_Revisions_Controller_6_4::get_item_schema
 	 */
 	public function test_get_item_schema() {
-		// See: https://github.com/WordPress/gutenberg/pull/52370#issuecomment-1643331655.
-		$this->markTestSkipped( 'Test already backported to Core' );
 		$request    = new WP_REST_Request( 'OPTIONS', '/wp/v2/global-styles/' . self::$global_styles_id . '/revisions' );
 		$response   = rest_get_server()->dispatch( $request );
 		$data       = $response->get_data();
@@ -372,414 +335,6 @@ class Gutenberg_REST_Global_Styles_Revisions_Controller_Test extends WP_Test_RES
 		$this->assertArrayHasKey( 'modified', $properties, 'Schema properties array has "modified" key.' );
 		$this->assertArrayHasKey( 'modified_gmt', $properties, 'Schema properties array has "modified_gmt" key.' );
 	}
-
-	/**
-	 * @ticket 58524
-	 *
-	 * @covers WP_REST_Global_Styles_Controller::get_item_permissions_check
-	 */
-	public function test_get_item_permissions_check() {
-		wp_set_current_user( self::$author_id );
-		$request  = new WP_REST_Request( 'GET', '/wp/v2/global-styles/' . self::$global_styles_id . '/revisions' );
-		$response = rest_get_server()->dispatch( $request );
-
-		$this->assertErrorResponse( 'rest_cannot_view', $response, 403 );
-	}
-
-	/**
-	 * Tests the pagination header of the first page.
-	 *
-	 * Duplicate of WP_Test_REST_Revisions_Controller::test_get_items_pagination_header_of_the_first_page
-	 *
-	 * @ticket 58524
-	 *
-	 * @covers WP_REST_Global_Styles_Controller::get_items
-	 */
-	public function test_get_items_pagination_header_of_the_first_page() {
-		wp_set_current_user( self::$admin_id );
-
-		$rest_route  = '/wp/v2/global-styles/' . self::$global_styles_id . '/revisions';
-		$per_page    = 2;
-		$total_pages = (int) ceil( $this->total_revisions / $per_page );
-		$page        = 1;  // First page.
-
-		$request = new WP_REST_Request( 'GET', $rest_route );
-		$request->set_query_params(
-			array(
-				'per_page' => $per_page,
-				'page'     => $page,
-			)
-		);
-		$response = rest_get_server()->dispatch( $request );
-		$headers  = $response->get_headers();
-		$this->assertSame( $this->total_revisions, $headers['X-WP-Total'] );
-		$this->assertSame( $total_pages, $headers['X-WP-TotalPages'] );
-		$next_link = add_query_arg(
-			array(
-				'per_page' => $per_page,
-				'page'     => $page + 1,
-			),
-			rest_url( $rest_route )
-		);
-		$this->assertStringNotContainsString( 'rel="prev"', $headers['Link'] );
-		$this->assertStringContainsString( '<' . $next_link . '>; rel="next"', $headers['Link'] );
-	}
-
-	/**
-	 * Tests the pagination header of the last page.
-	 *
-	 * Duplicate of WP_Test_REST_Revisions_Controller::test_get_items_pagination_header_of_the_last_page
-	 *
-	 * @ticket 58524
-	 *
-	 * @covers WP_REST_Global_Styles_Controller::get_items
-	 */
-	public function test_get_items_pagination_header_of_the_last_page() {
-		wp_set_current_user( self::$admin_id );
-
-		$rest_route  = '/wp/v2/global-styles/' . self::$global_styles_id . '/revisions';
-		$per_page    = 2;
-		$total_pages = (int) ceil( $this->total_revisions / $per_page );
-		$page        = 2;  // Last page.
-
-		$request = new WP_REST_Request( 'GET', $rest_route );
-		$request->set_query_params(
-			array(
-				'per_page' => $per_page,
-				'page'     => $page,
-			)
-		);
-		$response = rest_get_server()->dispatch( $request );
-		$headers  = $response->get_headers();
-		$this->assertSame( $this->total_revisions, $headers['X-WP-Total'] );
-		$this->assertSame( $total_pages, $headers['X-WP-TotalPages'] );
-		$prev_link = add_query_arg(
-			array(
-				'per_page' => $per_page,
-				'page'     => $page - 1,
-			),
-			rest_url( $rest_route )
-		);
-		$this->assertStringContainsString( '<' . $prev_link . '>; rel="prev"', $headers['Link'] );
-	}
-
-	/**
-	 * Tests that invalid 'per_page' query should error.
-	 *
-	 * Duplicate of WP_Test_REST_Revisions_Controller::test_get_items_invalid_per_page_should_error
-	 *
-	 * @ticket 58524
-	 *
-	 * @covers WP_REST_Global_Styles_Controller::get_items
-	 */
-	public function test_get_items_invalid_per_page_should_error() {
-		wp_set_current_user( self::$admin_id );
-
-		$per_page        = -1; // Invalid number.
-		$expected_error  = 'rest_invalid_param';
-		$expected_status = 400;
-
-		$request = new WP_REST_Request( 'GET', '/wp/v2/global-styles/' . self::$global_styles_id . '/revisions' );
-		$request->set_param( 'per_page', $per_page );
-		$response = rest_get_server()->dispatch( $request );
-		$this->assertErrorResponse( $expected_error, $response, $expected_status );
-	}
-
-	/**
-	 * Tests that out of bounds 'page' query should error.
-	 *
-	 * Duplicate of WP_Test_REST_Revisions_Controller::test_get_items_out_of_bounds_page_should_error
-	 *
-	 * @ticket 58524
-	 *
-	 * @covers WP_REST_Global_Styles_Controller::get_items
-	 */
-	public function test_get_items_out_of_bounds_page_should_error() {
-		wp_set_current_user( self::$admin_id );
-
-		$per_page        = 2;
-		$total_pages     = (int) ceil( $this->total_revisions / $per_page );
-		$page            = $total_pages + 1; // Out of bound page.
-		$expected_error  = 'rest_revision_invalid_page_number';
-		$expected_status = 400;
-
-		$request = new WP_REST_Request( 'GET', '/wp/v2/global-styles/' . self::$global_styles_id . '/revisions' );
-		$request->set_query_params(
-			array(
-				'per_page' => $per_page,
-				'page'     => $page,
-			)
-		);
-		$response = rest_get_server()->dispatch( $request );
-		$this->assertErrorResponse( $expected_error, $response, $expected_status );
-	}
-
-	/**
-	 * Tests that impossibly high 'page' query should error.
-	 *
-	 * Duplicate of WP_Test_REST_Revisions_Controller::test_get_items_invalid_max_pages_should_error
-	 *
-	 * @ticket 58524
-	 *
-	 * @covers WP_REST_Global_Styles_Controller::get_items
-	 */
-	public function test_get_items_invalid_max_pages_should_error() {
-		wp_set_current_user( self::$admin_id );
-
-		$per_page        = 2;
-		$page            = REST_TESTS_IMPOSSIBLY_HIGH_NUMBER; // Invalid number.
-		$expected_error  = 'rest_revision_invalid_page_number';
-		$expected_status = 400;
-
-		$request = new WP_REST_Request( 'GET', '/wp/v2/global-styles/' . self::$global_styles_id . '/revisions' );
-		$request->set_query_params(
-			array(
-				'per_page' => $per_page,
-				'page'     => $page,
-			)
-		);
-		$response = rest_get_server()->dispatch( $request );
-		$this->assertErrorResponse( $expected_error, $response, $expected_status );
-	}
-
-	/**
-	 * Tests that the default query should fetch all revisions.
-	 *
-	 * Duplicate of WP_Test_REST_Revisions_Controller::test_get_items_default_query_should_fetch_all_revisons
-	 *
-	 * @ticket 58524
-	 *
-	 * @covers WP_REST_Global_Styles_Controller::get_items
-	 */
-	public function test_get_items_default_query_should_fetch_all_revisons() {
-		wp_set_current_user( self::$admin_id );
-
-		$expected_count = $this->total_revisions;
-
-		$request  = new WP_REST_Request( 'GET', '/wp/v2/global-styles/' . self::$global_styles_id . '/revisions' );
-		$response = rest_get_server()->dispatch( $request );
-		$this->assertCount( $expected_count, $response->get_data() );
-	}
-
-	/**
-	 * Tests that 'offset' query shouldn't work without 'per_page' (fallback -1).
-	 *
-	 * Duplicate of WP_Test_REST_Revisions_Controller::test_get_items_offset_should_not_work_without_per_page
-	 *
-	 * @ticket 58524
-	 *
-	 * @covers WP_REST_Global_Styles_Controller::get_items
-	 */
-	public function test_get_items_offset_should_not_work_without_per_page() {
-		wp_set_current_user( self::$admin_id );
-
-		$offset         = 1;
-		$expected_count = $this->total_revisions;
-
-		$request = new WP_REST_Request( 'GET', '/wp/v2/global-styles/' . self::$global_styles_id . '/revisions' );
-		$request->set_param( 'offset', $offset );
-		$response = rest_get_server()->dispatch( $request );
-		$this->assertCount( $expected_count, $response->get_data() );
-	}
-
-	/**
-	 * Tests that 'offset' query should work with 'per_page'.
-	 *
-	 * Duplicate of WP_Test_REST_Revisions_Controller::test_get_items_offset_should_work_with_per_page
-	 *
-	 * @ticket 58524
-	 *
-	 * @covers WP_REST_Global_Styles_Controller::get_items
-	 */
-	public function test_get_items_offset_should_work_with_per_page() {
-		wp_set_current_user( self::$admin_id );
-
-		$per_page       = 2;
-		$offset         = 1;
-		$expected_count = 2;
-
-		$request = new WP_REST_Request( 'GET', '/wp/v2/global-styles/' . self::$global_styles_id . '/revisions' );
-		$request->set_query_params(
-			array(
-				'offset'   => $offset,
-				'per_page' => $per_page,
-			)
-		);
-		$response = rest_get_server()->dispatch( $request );
-		$this->assertCount( $expected_count, $response->get_data() );
-	}
-
-	/**
-	 * Tests that 'offset' query should take priority over 'page'.
-	 *
-	 * Duplicate of WP_Test_REST_Revisions_Controller::test_get_items_offset_should_take_priority_over_page
-	 *
-	 * @ticket 58524
-	 *
-	 * @covers WP_REST_Global_Styles_Controller::get_items
-	 */
-	public function test_get_items_offset_should_take_priority_over_page() {
-		wp_set_current_user( self::$admin_id );
-
-		$per_page       = 2;
-		$offset         = 1;
-		$page           = 1;
-		$expected_count = 2;
-
-		$request = new WP_REST_Request( 'GET', '/wp/v2/global-styles/' . self::$global_styles_id . '/revisions' );
-		$request->set_query_params(
-			array(
-				'offset'   => $offset,
-				'per_page' => $per_page,
-				'page'     => $page,
-			)
-		);
-		$response = rest_get_server()->dispatch( $request );
-		$this->assertCount( $expected_count, $response->get_data() );
-	}
-
-	/**
-	 * Tests that 'offset' query, as the total revisions count, should return empty data.
-	 *
-	 * Duplicate of WP_Test_REST_Revisions_Controller::test_get_items_total_revisions_offset_should_return_empty_data
-	 *
-	 * @ticket 58524
-	 *
-	 * @covers WP_REST_Global_Styles_Controller::get_items
-	 */
-	public function test_get_items_total_revisions_offset_should_return_empty_data() {
-		wp_set_current_user( self::$admin_id );
-
-		$per_page        = 2;
-		$offset          = $this->total_revisions;
-		$expected_error  = 'rest_revision_invalid_offset_number';
-		$expected_status = 400;
-
-		$request = new WP_REST_Request( 'GET', '/wp/v2/global-styles/' . self::$global_styles_id . '/revisions' );
-		$request->set_query_params(
-			array(
-				'offset'   => $offset,
-				'per_page' => $per_page,
-			)
-		);
-		$response = rest_get_server()->dispatch( $request );
-		$this->assertErrorResponse( $expected_error, $response, $expected_status );
-	}
-
-	/**
-	 * Tests that out of bound 'offset' query should error.
-	 *
-	 * Duplicate of WP_Test_REST_Revisions_Controller::test_get_items_out_of_bound_offset_should_error
-	 *
-	 * @ticket 58524
-	 *
-	 * @covers WP_REST_Global_Styles_Controller::get_items
-	 */
-	public function test_get_items_out_of_bound_offset_should_error() {
-		wp_set_current_user( self::$admin_id );
-
-		$per_page        = 2;
-		$offset          = $this->total_revisions + 1;
-		$expected_error  = 'rest_revision_invalid_offset_number';
-		$expected_status = 400;
-
-		$request = new WP_REST_Request( 'GET', '/wp/v2/global-styles/' . self::$global_styles_id . '/revisions' );
-		$request->set_query_params(
-			array(
-				'offset'   => $offset,
-				'per_page' => $per_page,
-			)
-		);
-		$response = rest_get_server()->dispatch( $request );
-		$this->assertErrorResponse( $expected_error, $response, $expected_status );
-	}
-
-	/**
-	 * Tests that impossible high number for 'offset' query should error.
-	 *
-	 * Duplicate of WP_Test_REST_Revisions_Controller::test_get_items_impossible_high_number_offset_should_error
-	 *
-	 * @ticket 58524
-	 *
-	 * @covers WP_REST_Global_Styles_Controller::get_items
-	 */
-	public function test_get_items_impossible_high_number_offset_should_error() {
-		wp_set_current_user( self::$admin_id );
-
-		$per_page        = 2;
-		$offset          = REST_TESTS_IMPOSSIBLY_HIGH_NUMBER;
-		$expected_error  = 'rest_revision_invalid_offset_number';
-		$expected_status = 400;
-
-		$request = new WP_REST_Request( 'GET', '/wp/v2/global-styles/' . self::$global_styles_id . '/revisions' );
-		$request->set_query_params(
-			array(
-				'offset'   => $offset,
-				'per_page' => $per_page,
-			)
-		);
-		$response = rest_get_server()->dispatch( $request );
-		$this->assertErrorResponse( $expected_error, $response, $expected_status );
-	}
-
-	/**
-	 * Tests that invalid 'offset' query should error.
-	 *
-	 * Duplicate of WP_Test_REST_Revisions_Controller::test_get_items_invalid_offset_should_error
-	 *
-	 * @ticket 58524
-	 *
-	 * @covers WP_REST_Global_Styles_Controller::get_items
-	 */
-	public function test_get_items_invalid_offset_should_error() {
-		wp_set_current_user( self::$admin_id );
-
-		$per_page        = 2;
-		$offset          = 'moreplease';
-		$expected_error  = 'rest_invalid_param';
-		$expected_status = 400;
-
-		$request = new WP_REST_Request( 'GET', '/wp/v2/global-styles/' . self::$global_styles_id . '/revisions' );
-		$request->set_query_params(
-			array(
-				'offset'   => $offset,
-				'per_page' => $per_page,
-			)
-		);
-		$response = rest_get_server()->dispatch( $request );
-		$this->assertErrorResponse( $expected_error, $response, $expected_status );
-	}
-
-	/**
-	 * Tests that out of bounds 'page' query should not error when offset is provided,
-	 * because it takes precedence.
-	 *
-	 * Duplicate of WP_Test_REST_Revisions_Controller::test_get_items_out_of_bounds_page_should_not_error_if_offset
-	 *
-	 * @ticket 58524
-	 *
-	 * @covers WP_REST_Global_Styles_Controller::get_items
-	 */
-	public function test_get_items_out_of_bounds_page_should_not_error_if_offset() {
-		wp_set_current_user( self::$admin_id );
-
-		$per_page       = 2;
-		$total_pages    = (int) ceil( $this->total_revisions / $per_page );
-		$page           = $total_pages + 1; // Out of bound page.
-		$expected_count = 2;
-
-		$request = new WP_REST_Request( 'GET', '/wp/v2/global-styles/' . self::$global_styles_id . '/revisions' );
-		$request->set_query_params(
-			array(
-				'offset'   => 1,
-				'per_page' => $per_page,
-				'page'     => $page,
-			)
-		);
-		$response = rest_get_server()->dispatch( $request );
-		$this->assertCount( $expected_count, $response->get_data() );
-	}
-
 	/**
 	 * @doesNotPerformAssertions
 	 */


### PR DESCRIPTION
## What?
Hello!

This PR: 

1. removes tests that have been ported to Core already as part of WP 6.3
2. adds tests for https://github.com/WordPress/gutenberg/pull/52370
3. changes a private method to protected so it can be used in inherited classes

## Why?

1. The tests are in Core, no need to duplicate 6.3 functionality test coverage
2. Adding tests for new functionality ("behaviors" in https://github.com/WordPress/gutenberg/pull/52370)
3. Make life easier when inheriting class for new functionality

## Testing Instructions

Tests should pass:

`npm run test:unit:php`

