### PR TITLE
Block library: add PHP since annotations

### DIFF
--- a/packages/block-library/src/comment-template/index.php
+++ b/packages/block-library/src/comment-template/index.php
@@ -8,6 +8,8 @@
 /**
  * Function that recursively renders a list of nested comments.
  *
+ * @since 6.3.0 Changed render_block_context priority to `1`.
+ *
  * @global int $comment_depth
  *
  * @param WP_Comment[] $comments        The array of comments.

--- a/packages/block-library/src/footnotes/index.php
+++ b/packages/block-library/src/footnotes/index.php
@@ -8,6 +8,8 @@
 /**
  * Renders the `core/footnotes` block on the server.
  *
+ * @since 6.3.0
+ *
  * @param array    $attributes Block attributes.
  * @param string   $content    Block default content.
  * @param WP_Block $block      Block instance.
@@ -57,6 +59,8 @@ function render_block_core_footnotes( $attributes, $content, $block ) {
 
 /**
  * Registers the `core/footnotes` block on the server.
+ *
+ * @since 6.3.0
  */
 function register_block_core_footnotes() {
 	foreach ( array( 'post', 'page' ) as $post_type ) {
@@ -83,6 +87,8 @@ add_action(
 	'wp_after_insert_post',
 	/**
 	 * Saves the footnotes meta value to the revision.
+	 *
+	 * @since 6.3.0
 	 *
 	 * @param int $revision_id The revision ID.
 	 */
@@ -127,6 +133,8 @@ foreach ( array( 'post', 'page' ) as $post_type ) {
 		 * available at the time, so we have to add it afterwards through the
 		 * `"rest_after_insert_{$post_type}"` action.
 		 *
+		 * @since 6.3.0
+		 *
 		 * @param WP_Post $post The post object.
 		 */
 		static function( $post ) {
@@ -155,6 +163,8 @@ add_action(
 	/**
 	 * Restores the footnotes meta value from the revision.
 	 *
+	 * @since 6.3.0
+	 *
 	 * @param int $post_id      The post ID.
 	 * @param int $revision_id  The revision ID.
 	 */
@@ -176,8 +186,9 @@ add_filter(
 	/**
 	 * Adds the footnotes field to the revision.
 	 *
-	 * @param array $fields The revision fields.
+	 * @since 6.3.0
 	 *
+	 * @param array $fields The revision fields.
 	 * @return array The revision fields.
 	 */
 	static function( $fields ) {
@@ -191,11 +202,12 @@ add_filter(
 	/**
 	 * Gets the footnotes field from the revision.
 	 *
+	 * @since 6.3.0
+	 *
 	 * @param string $revision_field The field value, but $revision->$field
 	 *                               (footnotes) does not exist.
 	 * @param string $field          The field name, in this case "footnotes".
 	 * @param object $revision       The revision object to compare against.
-	 *
 	 * @return string The field value.
 	 */
 	static function( $revision_field, $field, $revision ) {

--- a/packages/block-library/src/pattern/index.php
+++ b/packages/block-library/src/pattern/index.php
@@ -22,6 +22,8 @@ function register_block_core_pattern() {
 /**
  * Renders the `core/pattern` block on the server.
  *
+ * @since 6.3.0 Backwards compatibility: blocks with no `syncStatus` attribute do not receive block wrapper.
+ *
  * @param array $attributes Block attributes.
  *
  * @return string Returns the output of the pattern.

--- a/packages/block-library/src/post-template/index.php
+++ b/packages/block-library/src/post-template/index.php
@@ -34,6 +34,8 @@ function block_core_post_template_uses_featured_image( $inner_blocks ) {
 /**
  * Renders the `core/post-template` block on the server.
  *
+ * @since 6.3.0 Changed render_block_context priority to `1`.
+ *
  * @param array    $attributes Block attributes.
  * @param string   $content    Block default content.
  * @param WP_Block $block      Block instance.

--- a/packages/block-library/src/post-title/index.php
+++ b/packages/block-library/src/post-title/index.php
@@ -8,6 +8,8 @@
 /**
  * Renders the `core/post-title` block on the server.
  *
+ * @since 6.3.0 Omitting the $post argument from the `get_the_title`.
+ *
  * @param array    $attributes Block attributes.
  * @param string   $content    Block default content.
  * @param WP_Block $block      Block instance.

--- a/packages/block-library/src/search/index.php
+++ b/packages/block-library/src/search/index.php
@@ -8,6 +8,8 @@
 /**
  * Dynamically renders the `core/search` block.
  *
+ * @since 6.3.0 Using block.json `viewScript` to register script, and update `view_script_handles()` only when needed.
+ *
  * @param array    $attributes The block attributes.
  * @param string   $content    The saved content.
  * @param WP_Block $block      The parsed block.


### PR DESCRIPTION
Pursuant to https://github.com/WordPress/gutenberg/issues/52720

## What?
Adding `@since` annotation for relevant 6.3 changes in block library PHP files.

This change is not exhaustive and doesn't perform the archeological work required to find the initial WordPress version for existing functions: it's only a perfunctory sweep of recent 6.3 changes.

## Why?
> The block library PHP files are automatically synced to core with the package updates, so they should be made core-ready in Gutenberg.

## How?
Looking at the commit history and verify meaningful changes that went into 6.3.

## Testing Instructions
- typos
- verbosity
- relevancy
