### PR TITLE
Site Editor: Don't register the Footnotes block

### DIFF
--- a/packages/block-library/src/cover/test/edit.js
+++ b/packages/block-library/src/cover/test/edit.js
@@ -39,7 +39,13 @@ const disabledColorSettings = {
 async function setup( attributes, useCoreBlocks, customSettings ) {
 	const testBlock = { name: 'core/cover', attributes };
 	const settings = customSettings || defaultSettings;
-	return initializeEditor( testBlock, useCoreBlocks, settings );
+	const skippedBlocks = [ 'core/footnotes' ];
+	return initializeEditor(
+		testBlock,
+		useCoreBlocks,
+		settings,
+		skippedBlocks
+	);
 }
 
 async function createAndSelectBlock() {

--- a/packages/block-library/src/cover/test/edit.js
+++ b/packages/block-library/src/cover/test/edit.js
@@ -39,13 +39,7 @@ const disabledColorSettings = {
 async function setup( attributes, useCoreBlocks, customSettings ) {
 	const testBlock = { name: 'core/cover', attributes };
 	const settings = customSettings || defaultSettings;
-	const skippedBlocks = [ 'core/footnotes' ];
-	return initializeEditor(
-		testBlock,
-		useCoreBlocks,
-		settings,
-		skippedBlocks
-	);
+	return initializeEditor( testBlock, useCoreBlocks, settings );
 }
 
 async function createAndSelectBlock() {

--- a/packages/block-library/src/footnotes/index.js
+++ b/packages/block-library/src/footnotes/index.js
@@ -21,9 +21,8 @@ export const settings = {
 	edit,
 };
 
-// Would be good to remove the format and HoR if the block is unregistered.
-registerFormatType( formatName, format );
-
 export const init = () => {
+	// Would be good to remove the format and HoR if the block is unregistered.
+	registerFormatType( formatName, format );
 	initBlock( { name, metadata, settings } );
 };

--- a/packages/block-library/src/footnotes/index.js
+++ b/packages/block-library/src/footnotes/index.js
@@ -22,7 +22,7 @@ export const settings = {
 };
 
 export const init = () => {
-	// Would be good to remove the format and HoR if the block is unregistered.
+	// Would be good to remove the format if the block is unregistered.
 	registerFormatType( formatName, format );
 	initBlock( { name, metadata, settings } );
 };

--- a/packages/edit-site/src/index.js
+++ b/packages/edit-site/src/index.js
@@ -29,6 +29,8 @@ import './hooks';
 import { store as editSiteStore } from './store';
 import App from './components/app';
 
+const DISALLOWED_BLOCKS = [ 'core/freeform', 'core/footnotes' ];
+
 /**
  * Initializes the site editor screen.
  *
@@ -45,7 +47,7 @@ export function initializeEditor( id, settings ) {
 
 	dispatch( blocksStore ).__experimentalReapplyBlockTypeFilters();
 	const coreBlocks = __experimentalGetCoreBlocks().filter(
-		( { name } ) => name !== 'core/freeform'
+		( { name } ) => ! DISALLOWED_BLOCKS.includes( name )
 	);
 	registerCoreBlocks( coreBlocks );
 	dispatch( blocksStore ).setFreeformFallbackBlockName( 'core/html' );

--- a/test/integration/helpers/integration-test-editor.js
+++ b/test/integration/helpers/integration-test-editor.js
@@ -18,7 +18,10 @@ import {
 	ObserveTyping,
 } from '@wordpress/block-editor';
 import { Popover, SlotFillProvider } from '@wordpress/components';
-import { registerCoreBlocks } from '@wordpress/block-library';
+import {
+	registerCoreBlocks,
+	__experimentalGetCoreBlocks,
+} from '@wordpress/block-library';
 import { ShortcutProvider } from '@wordpress/keyboard-shortcuts';
 import '@wordpress/format-library';
 import {
@@ -100,14 +103,19 @@ export function Editor( { testBlocks, settings = {} } ) {
  * @param {Object | Array} testBlocks    Block or array of block settings for blocks to be tested.
  * @param {boolean}        useCoreBlocks Defaults to true. If false, core blocks will not be registered.
  * @param {Object}         settings      Any additional editor settings to be passed to the editor.
+ * @param {Array}          skippedBlocks Blocks that should be skipped during registration.
  */
 export async function initializeEditor(
 	testBlocks,
 	useCoreBlocks = true,
-	settings
+	settings,
+	skippedBlocks = []
 ) {
 	if ( useCoreBlocks ) {
-		registerCoreBlocks();
+		const coreBlocks = __experimentalGetCoreBlocks().filter(
+			( { name } ) => ! skippedBlocks.includes( name )
+		);
+		registerCoreBlocks( coreBlocks );
 	}
 	const blocks = Array.isArray( testBlocks ) ? testBlocks : [ testBlocks ];
 	const newBlocks = blocks.map( ( testBlock ) =>


### PR DESCRIPTION
## What?
PR disabled the Footnotes block for the Site Editor.

## Why?
The footnotes don't work with templates.

## How?
Move the footnotes format registration into the block init method and let the core block registrar handle both.

## Testing Instructions
1. Open the Site Editor.
2. Edit a template.
3. Add a Heading or Paragraph block.
4. Confirm Footnotes format isn't available.
