### PR TITLE
Global Styles: Add link to compare revisions

### DIFF
--- a/packages/edit-site/src/components/global-styles/screen-revisions/index.js
+++ b/packages/edit-site/src/components/global-styles/screen-revisions/index.js
@@ -8,6 +8,9 @@ import {
 	__experimentalConfirmDialog as ConfirmDialog,
 	Spinner,
 	__experimentalSpacer as Spacer,
+	MenuItem,
+	VisuallyHidden,
+	__experimentalVStack as VStack,
 } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useContext, useState, useEffect } from '@wordpress/element';
@@ -15,6 +18,7 @@ import {
 	privateApis as blockEditorPrivateApis,
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
+import { external } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -26,6 +30,7 @@ import SidebarFixedBottom from '../../sidebar-edit-mode/sidebar-fixed-bottom';
 import { store as editSiteStore } from '../../../store';
 import useGlobalStylesRevisions from './use-global-styles-revisions';
 import RevisionsButtons from './revisions-buttons';
+import { addQueryArgs } from '@wordpress/url';
 
 const { GlobalStylesContext, areGlobalStyleConfigsEqual } = unlock(
 	blockEditorPrivateApis
@@ -118,27 +123,51 @@ function ScreenRevisions() {
 						/>
 						{ isLoadButtonEnabled && (
 							<SidebarFixedBottom>
-								<Button
-									variant="primary"
-									className="edit-site-global-styles-screen-revisions__button"
-									disabled={
-										! globalStylesRevision?.id ||
-										globalStylesRevision?.id === 'unsaved'
-									}
-									onClick={ () => {
-										if ( hasUnsavedChanges ) {
-											setIsLoadingRevisionWithUnsavedChanges(
-												true
-											);
-										} else {
-											restoreRevision(
-												globalStylesRevision
-											);
+								<VStack>
+									<MenuItem
+										href={ addQueryArgs( 'revision.php', {
+											revision: globalStylesRevision?.id,
+											gutenberg: true,
+										} ) }
+										target="_blank"
+										icon={ external }
+										disabled={
+											! globalStylesRevision?.id ||
+											globalStylesRevision?.id ===
+												'unsaved'
 										}
-									} }
-								>
-									{ __( 'Apply' ) }
-								</Button>
+									>
+										{ __( 'View revision changes' ) }
+										<VisuallyHidden as="span">
+											{
+												/* translators: accessibility text */
+												__( '(opens in a new tab)' )
+											}
+										</VisuallyHidden>
+									</MenuItem>
+									<Button
+										variant="primary"
+										className="edit-site-global-styles-screen-revisions__button"
+										disabled={
+											! globalStylesRevision?.id ||
+											globalStylesRevision?.id ===
+												'unsaved'
+										}
+										onClick={ () => {
+											if ( hasUnsavedChanges ) {
+												setIsLoadingRevisionWithUnsavedChanges(
+													true
+												);
+											} else {
+												restoreRevision(
+													globalStylesRevision
+												);
+											}
+										} }
+									>
+										{ __( 'Apply' ) }
+									</Button>
+								</VStack>
 							</SidebarFixedBottom>
 						) }
 					</div>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Add a link to /wp-admin/revisions to compare Global Styles post revisions.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The current process of checking changes included in each global styles revision is done solely through the Site Editor. Users need to visually inspect the site preview on the left side to identify the modifications. However, since behaviors are only applied on the frontend, it becomes impossible to verify the differences between versions directly in the editor. Additionally, for larger websites, spotting the changes can be challenging.


## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

The quickest solution is to add a link to the existing interface of post revisions. We could in a future implement that view in the site editor canvas.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
Change styles, settings or behaviors to create revisions.
Go to revisions sidebar, click on one different, use the link.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
Link:
![Screenshot 2023-07-21 at 11 50 31](https://github.com/WordPress/gutenberg/assets/37012961/1dd30429-1e06-4204-a755-7d453585a843)

Destination:
![Screenshot 2023-07-21 at 11 50 25](https://github.com/WordPress/gutenberg/assets/37012961/fbaab34d-f48f-4ba7-a93d-e2f71b91a261)

Video:
https://github.com/WordPress/gutenberg/assets/37012961/72615a37-afa2-413d-9676-0050a29e540b

