### PR TITLE
Incorrect function example in README

### DIFF
--- a/packages/dependency-extraction-webpack-plugin/README.md
+++ b/packages/dependency-extraction-webpack-plugin/README.md
@@ -207,7 +207,7 @@ function requestToHandle( request ) {
 }
 
 module.exports = {
-	plugins: [ new DependencyExtractionWebpackPlugin( { requestToExternal } ) ],
+	plugins: [ new DependencyExtractionWebpackPlugin( { requestToHandle } ) ],
 };
 ```
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fix incorrect function example in the Dependency Extraction Plugin for `requestToHandle`.

## Why?
Reduce cognitive effort to understand the code example

## How?
Changing the function name in the example

## Testing Instructions
Not relevant

### Testing Instructions for Keyboard
Not relevant 

## Screenshots or screencast <!-- if applicable -->
Not Relevant
