### PR TITLE
Missing return for DEWP code examples

### DIFF
--- a/packages/dependency-extraction-webpack-plugin/README.md
+++ b/packages/dependency-extraction-webpack-plugin/README.md
@@ -172,6 +172,8 @@ function requestToExternal( request ) {
 		// Expect to find `my-module` as myModule in the global scope:
 		return 'myModule';
 	}
+
+	return request;
 }
 
 module.exports = {
@@ -204,6 +206,8 @@ function requestToHandle( request ) {
 		// `my-module` depends on the script with the 'my-module-script-handle' handle.
 		return 'my-module-script-handle';
 	}
+
+	return request;
 }
 
 module.exports = {


### PR DESCRIPTION
The examples for the Dependency Extraction Webpack Plugin for the functions `requestToExternal` and `requestToHandle` are missing to return `request`. If someone copy/paste the code as a starting point they'll loose all other dependencies.