### PR TITLE
CommandPalette: Fixed to not execute commands in IME composition.

### DIFF
--- a/packages/commands/src/components/command-menu.js
+++ b/packages/commands/src/components/command-menu.js
@@ -201,6 +201,20 @@ export function CommandMenu() {
 	if ( ! isOpen ) {
 		return false;
 	}
+
+	const onKeyDown = ( event ) => {
+		if (
+			// Ignore keydowns from IMEs
+			event.nativeEvent.isComposing ||
+			// Workaround for Mac Safari where the final Enter/Backspace of an IME composition
+			// is `isComposing=false`, even though it's technically still part of the composition.
+			// These can only be detected by keyCode.
+			event.keyCode === 229
+		) {
+			event.preventDefault();
+		}
+	};
+
 	const isLoading = Object.values( loaders ).some( Boolean );
 
 	return (
@@ -211,7 +225,10 @@ export function CommandMenu() {
 			__experimentalHideHeader
 		>
 			<div className="commands-command-menu__container">
-				<Command label={ __( 'Command palette' ) }>
+				<Command
+					label={ __( 'Command palette' ) }
+					onKeyDown={ onKeyDown }
+				>
 					<div className="commands-command-menu__header">
 						<Command.Input
 							ref={ commandMenuInput }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Similar to 45607, if `isComposing` is `true` when Enter is pressed, the event was prevented.

Apply patch from @t-hamano 
https://github.com/WordPress/gutenberg/issues/52821#issuecomment-1645523477
 
## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
fix: #52821

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Use cmdk props.onKeydown to execute event.preventDefault() when Enter is pressed. cmdk will not execute anything on keyDown if event.defaultPrevented is true.

https://github.com/pacocoursey/cmdk/blob/ba2e20035ad86a2cb0fae0c2c296796e48a0181c/cmdk/src/index.tsx#L515

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Show command palette in Chrome / safari on Mac.
2. Type word using IME.
3. Press the Enter key to decide on the input.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
