### PR TITLE
Add `fitted` prop to TabPanel

### DIFF
--- a/packages/components/src/tab-panel/index.tsx
+++ b/packages/components/src/tab-panel/index.tsx
@@ -82,6 +82,7 @@ const UnforwardedTabPanel = (
 	{
 		className,
 		children,
+		fitted = false,
 		tabs,
 		selectOnMove = true,
 		initialTabName,
@@ -163,7 +164,11 @@ const UnforwardedTabPanel = (
 				onNavigate={
 					selectOnMove ? activateTabAutomatically : undefined
 				}
-				className="components-tab-panel__tabs"
+				//className="components-tab-panel__tabs"
+				className={ classnames(
+					'components-tab-panel__tabs',
+					fitted ? 'is-fitted' : null
+				) }
 			>
 				{ tabs.map( ( tab ) => (
 					<TabButton

--- a/packages/components/src/tab-panel/style.scss
+++ b/packages/components/src/tab-panel/style.scss
@@ -5,6 +5,12 @@
 	&[aria-orientation="vertical"] {
 		flex-direction: column;
 	}
+	&.is-fitted {
+		.components-tab-panel__tabs-item {
+			flex: 1;
+			justify-content: center;
+		}
+	}
 }
 
 // This tab style CSS is duplicated verbatim in

--- a/packages/components/src/tab-panel/types.ts
+++ b/packages/components/src/tab-panel/types.ts
@@ -87,4 +87,12 @@ export type TabPanelProps = {
 	 * @see https://www.w3.org/WAI/ARIA/apg/patterns/tabpanel/
 	 */
 	selectOnMove?: boolean;
+
+	/**
+	 * When `true` the tab panel will grow to fill its container.
+	 * .
+	 *
+	 * @default false
+	 */
+	fitted?: boolean;
 };


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/42320.

## What?
Adds a `fitted` prop to the `TabPanel` component. When `true`, tabs will grow to fill their container horizontally.

## Why?
Sometimes this layout is desirable, so it would be good to have a consistent way of achieving it. 

An example of something we might do:

<img width="294" alt="Screenshot 2023-07-21 at 16 59 21" src="https://github.com/WordPress/gutenberg/assets/846565/f6aeca72-41d5-4a8f-be47-30e1d3637c7b">

This addition would also facilitate the removal of the custom styling that currently implemented in order to achieve this layout in the block inspector:

<img width="281" alt="Screenshot 2023-07-21 at 16 52 02" src="https://github.com/WordPress/gutenberg/assets/846565/ebc103d5-33f2-43da-8204-fce78683df1e">

## How?
Add `fitted` prop to `UnforwardedTabPanel`. When `true`, child `.components-tab-panel__tabs-item` elements receive: 

```
flex: 1; 
justify-content: center
```

## Testing Instructions
1. Build storybook locally (`npm run storybook:dev`).
2. Open storybook.
3. Navigate to TabPanel (http://localhost:50240/?path=/story/components-tabpanel--default&args=fitted:true).
4. In the "Docs" tab find the "Fitted" prop and set it to `true`.
5. Observe the full-width tabs in the preview:

<img width="1029" alt="Screenshot 2023-07-21 at 17 03 11" src="https://github.com/WordPress/gutenberg/assets/846565/8c68259d-438b-4ebd-8f97-6b8f3c0576b5">