### PR TITLE
Image: Use the correct method for caption class in recent deprecation

### DIFF
--- a/packages/block-library/src/image/deprecated.js
+++ b/packages/block-library/src/image/deprecated.js
@@ -9,6 +9,7 @@ import classnames from 'classnames';
 import {
 	RichText,
 	useBlockProps,
+	__experimentalGetElementClassName,
 	__experimentalGetBorderClassesAndStyles as getBorderClassesAndStyles,
 } from '@wordpress/block-editor';
 
@@ -721,7 +722,9 @@ const v6 = {
 				) }
 				{ ! RichText.isEmpty( caption ) && (
 					<RichText.Content
-						className={ getBorderClassesAndStyles( 'caption' ) }
+						className={ __experimentalGetElementClassName(
+							'caption'
+						) }
 						tagName="figcaption"
 						value={ caption }
 					/>


### PR DESCRIPTION
## What?
A small follow-up to #52822.

PR fixes a deprecation failure when the previous version of the image block contains a caption.

## Why?
Bugfixes.

## How?
Use the `__experimentalGetElementClassName` to get a caption class. This matches the original save method.

## Testing Instructions
The following image block shouldn't produce a deprecation error.

```
<!-- wp:image {"align":"left","width":164,"height":164,"sizeSlug":"large","style":{"border":{"radius":"100%"}},"className":"is-style-rounded"} -->
<figure class="wp-block-image alignleft size-large is-resized has-custom-border is-style-rounded"><img src="https://s.w.org/images/core/5.8/portrait.jpg" alt="" style="border-radius:100%" width="164" height="164"/><figcaption class="wp-element-caption">Caption</figcaption></figure>
<!-- /wp:image -->
