### PR TITLE
PHP changes action forked repo permission test

### DIFF
--- a/.github/workflows/php-changes-detection.yml
+++ b/.github/workflows/php-changes-detection.yml
@@ -1,4 +1,4 @@
-name: OPTIONAL - Confirm if PHP changes require backporting to WordPress Core
+name: OPTIONAL - Confirm if PHP changes require porting to WordPress Core
 
 on:
     pull_request:

--- a/.github/workflows/php-changes-detection.yml
+++ b/.github/workflows/php-changes-detection.yml
@@ -49,7 +49,7 @@ jobs:
               uses: peter-evans/create-or-update-comment@v3
               with:
                   issue-number: ${{ github.event.pull_request.number }}
-                  repo-token: ${{ secrets.GITHUB_TOKEN }}
+                  github_token: ${{ secrets.GITHUB_TOKEN }}
                   body: |
                       <!-- pr-contains-php-changes -->
                       This pull request has changed or added PHP files. Please confirm whether these changes need to be synced to WordPress Core, and therefore featured in the next release of WordPress.
@@ -72,7 +72,7 @@ jobs:
                   comment-id: ${{ steps.find-comment.outputs.comment-id }}
                   issue-number: ${{ github.event.pull_request.number }}
                   edit-mode: replace
-                  repo-token: ${{ secrets.GITHUB_TOKEN }}
+                  github_token: ${{ secrets.GITHUB_TOKEN }}
                   body: |
                       <!-- pr-contains-php-changes -->
                       This pull request has changed or added PHP files. Please confirm whether these changes need to be synced to WordPress Core, and therefore featured in the next release of WordPress.
@@ -95,7 +95,7 @@ jobs:
                   comment-id: ${{ steps.find-comment.outputs.comment-id }}
                   issue-number: ${{ github.event.pull_request.number }}
                   edit-mode: replace
-                  repo-token: ${{ secrets.GITHUB_TOKEN }}
+                  github_token: ${{ secrets.GITHUB_TOKEN }}
                   body: |
                       <!-- pr-contains-php-changes -->
                       This pull request changed or added PHP files in previous commits, but none have been detected in the latest commit.

--- a/.github/workflows/php-changes-detection.yml
+++ b/.github/workflows/php-changes-detection.yml
@@ -49,7 +49,7 @@ jobs:
               uses: peter-evans/create-or-update-comment@v3
               with:
                   issue-number: ${{ github.event.pull_request.number }}
-                  github_token: ${{ secrets.GITHUB_TOKEN }}
+                  token: ${{ secrets.token }}
                   body: |
                       <!-- pr-contains-php-changes -->
                       This pull request has changed or added PHP files. Please confirm whether these changes need to be synced to WordPress Core, and therefore featured in the next release of WordPress.
@@ -72,7 +72,7 @@ jobs:
                   comment-id: ${{ steps.find-comment.outputs.comment-id }}
                   issue-number: ${{ github.event.pull_request.number }}
                   edit-mode: replace
-                  github_token: ${{ secrets.GITHUB_TOKEN }}
+                  token: ${{ secrets.token }}
                   body: |
                       <!-- pr-contains-php-changes -->
                       This pull request has changed or added PHP files. Please confirm whether these changes need to be synced to WordPress Core, and therefore featured in the next release of WordPress.
@@ -95,7 +95,7 @@ jobs:
                   comment-id: ${{ steps.find-comment.outputs.comment-id }}
                   issue-number: ${{ github.event.pull_request.number }}
                   edit-mode: replace
-                  github_token: ${{ secrets.GITHUB_TOKEN }}
+                  token: ${{ secrets.token }}
                   body: |
                       <!-- pr-contains-php-changes -->
                       This pull request changed or added PHP files in previous commits, but none have been detected in the latest commit.

--- a/.github/workflows/php-changes-detection.yml
+++ b/.github/workflows/php-changes-detection.yml
@@ -7,7 +7,7 @@ jobs:
     detect_php_changes:
         name: Detect PHP changes
         runs-on: ubuntu-latest
-        if: ${{ github.repository == 'WordPress/gutenberg' || github.event_name == 'pull_request' }}
+        if: ${{ github.repository == 'WordPress/gutenberg' && github.event_name == 'pull_request' }}
         steps:
             - name: Check out code
               uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
@@ -49,7 +49,6 @@ jobs:
               uses: peter-evans/create-or-update-comment@v3
               with:
                   issue-number: ${{ github.event.pull_request.number }}
-                  token: ${{ secrets.token }}
                   body: |
                       <!-- pr-contains-php-changes -->
                       This pull request has changed or added PHP files. Please confirm whether these changes need to be synced to WordPress Core, and therefore featured in the next release of WordPress.
@@ -72,7 +71,6 @@ jobs:
                   comment-id: ${{ steps.find-comment.outputs.comment-id }}
                   issue-number: ${{ github.event.pull_request.number }}
                   edit-mode: replace
-                  token: ${{ secrets.token }}
                   body: |
                       <!-- pr-contains-php-changes -->
                       This pull request has changed or added PHP files. Please confirm whether these changes need to be synced to WordPress Core, and therefore featured in the next release of WordPress.
@@ -95,7 +93,6 @@ jobs:
                   comment-id: ${{ steps.find-comment.outputs.comment-id }}
                   issue-number: ${{ github.event.pull_request.number }}
                   edit-mode: replace
-                  token: ${{ secrets.token }}
                   body: |
                       <!-- pr-contains-php-changes -->
                       This pull request changed or added PHP files in previous commits, but none have been detected in the latest commit.

--- a/.github/workflows/php-changes-detection.yml
+++ b/.github/workflows/php-changes-detection.yml
@@ -49,6 +49,7 @@ jobs:
               uses: peter-evans/create-or-update-comment@v3
               with:
                   issue-number: ${{ github.event.pull_request.number }}
+                  repo-token: ${{ secrets.GITHUB_TOKEN }}
                   body: |
                       <!-- pr-contains-php-changes -->
                       This pull request has changed or added PHP files. Please confirm whether these changes need to be synced to WordPress Core, and therefore featured in the next release of WordPress.
@@ -71,6 +72,7 @@ jobs:
                   comment-id: ${{ steps.find-comment.outputs.comment-id }}
                   issue-number: ${{ github.event.pull_request.number }}
                   edit-mode: replace
+                  repo-token: ${{ secrets.GITHUB_TOKEN }}
                   body: |
                       <!-- pr-contains-php-changes -->
                       This pull request has changed or added PHP files. Please confirm whether these changes need to be synced to WordPress Core, and therefore featured in the next release of WordPress.
@@ -93,6 +95,7 @@ jobs:
                   comment-id: ${{ steps.find-comment.outputs.comment-id }}
                   issue-number: ${{ github.event.pull_request.number }}
                   edit-mode: replace
+                  repo-token: ${{ secrets.GITHUB_TOKEN }}
                   body: |
                       <!-- pr-contains-php-changes -->
                       This pull request changed or added PHP files in previous commits, but none have been detected in the latest commit.

--- a/lib/load.php
+++ b/lib/load.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Load API functions, register scripts and actions, etc.
+ * Loads API functions, register scripts and actions, etc.
  *
  * @package gutenberg
  */


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Testing permission on the PHP changes github action.

Forked repos don't have permissions to write comments. 



## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
