### PR TITLE
Bugfixes for 6.3 RC2

### DIFF
--- a/lib/compat/wordpress-6.3/navigation-fallback.php
+++ b/lib/compat/wordpress-6.3/navigation-fallback.php
@@ -26,9 +26,16 @@ function gutenberg_add_fields_to_navigation_fallback_embeded_links( $schema ) {
 	$schema['properties']['content']['context'] = array_merge( $schema['properties']['content']['context'], array( 'embed' ) );
 
 	// Expose sub properties of content field.
+	// These aren't exposed by the posts controller by default, see:
+	// https://github.com/WordPress/wordpress-develop/blob/5c3c6258e468c67ba00bbd13db29994f1a57a52a/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php#L2425.
 	$schema['properties']['content']['properties']['raw']['context']           = array_merge( $schema['properties']['content']['properties']['raw']['context'], array( 'embed' ) );
 	$schema['properties']['content']['properties']['rendered']['context']      = array_merge( $schema['properties']['content']['properties']['rendered']['context'], array( 'embed' ) );
 	$schema['properties']['content']['properties']['block_version']['context'] = array_merge( $schema['properties']['content']['properties']['block_version']['context'], array( 'embed' ) );
+
+	// Expose sub properties of title field.
+	// These aren't exposed by the posts controller by default, see:
+	// https://github.com/WordPress/wordpress-develop/blob/5c3c6258e468c67ba00bbd13db29994f1a57a52a/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php#L2401.
+	$schema['properties']['title']['properties']['raw']['context'] = array_merge( $schema['properties']['title']['properties']['raw']['context'], array( 'embed' ) );
 
 	return $schema;
 }

--- a/packages/block-editor/src/components/block-tools/style.scss
+++ b/packages/block-editor/src/components/block-tools/style.scss
@@ -322,12 +322,15 @@
 	// for the block inserter the publish button
 	@include break-large() {
 		&.is-fixed {
+			width: auto;
+		}
+		.is-fullscreen-mode &.is-fixed {
+			// in full screen mode we need to account for
 			// the combined with of the tools at the right of the header and the margin left
 			// of the toolbar which includes four buttons
 			width: calc(100% - 240px - #{4 * $grid-unit-80});
 		}
 	}
-
 }
 
 /**

--- a/packages/block-editor/src/components/inserter/hooks/use-patterns-state.js
+++ b/packages/block-editor/src/components/inserter/hooks/use-patterns-state.js
@@ -61,6 +61,7 @@ const usePatternsState = ( onInsert, rootClientId ) => {
 				),
 				{
 					type: 'snackbar',
+					id: 'block-pattern-inserted-notice',
 				}
 			);
 		},

--- a/packages/block-editor/src/store/test/selectors.js
+++ b/packages/block-editor/src/store/test/selectors.js
@@ -121,7 +121,7 @@ describe( 'selectors', () => {
 			parent: [ 'core/test-block-b' ],
 		} );
 
-		registerBlockType( 'core/test-freeform', {
+		registerBlockType( 'core/freeform', {
 			save: ( props ) => <RawHTML>{ props.attributes.content }</RawHTML>,
 			category: 'text',
 			title: 'Test Freeform Content Handler',
@@ -177,7 +177,7 @@ describe( 'selectors', () => {
 			ancestor: [ 'core/test-block-ancestor' ],
 		} );
 
-		setFreeformContentHandlerName( 'core/test-freeform' );
+		setFreeformContentHandlerName( 'core/freeform' );
 
 		cachedSelectors.forEach( ( { clear } ) => clear() );
 	} );
@@ -187,7 +187,7 @@ describe( 'selectors', () => {
 		unregisterBlockType( 'core/test-block-a' );
 		unregisterBlockType( 'core/test-block-b' );
 		unregisterBlockType( 'core/test-block-c' );
-		unregisterBlockType( 'core/test-freeform' );
+		unregisterBlockType( 'core/freeform' );
 		unregisterBlockType( 'core/post-content-child' );
 		unregisterBlockType( 'core/test-block-ancestor' );
 		unregisterBlockType( 'core/test-block-parent' );
@@ -3450,7 +3450,7 @@ describe( 'selectors', () => {
 			expect( firstBlockFirstCall.map( ( item ) => item.id ) ).toEqual( [
 				'core/test-block-a',
 				'core/test-block-b',
-				'core/test-freeform',
+				'core/freeform',
 				'core/test-block-ancestor',
 				'core/test-block-parent',
 				'core/block/1',
@@ -3466,7 +3466,7 @@ describe( 'selectors', () => {
 			expect( secondBlockFirstCall.map( ( item ) => item.id ) ).toEqual( [
 				'core/test-block-a',
 				'core/test-block-b',
-				'core/test-freeform',
+				'core/freeform',
 				'core/test-block-ancestor',
 				'core/test-block-parent',
 				'core/block/1',

--- a/packages/block-library/src/comment-template/index.php
+++ b/packages/block-library/src/comment-template/index.php
@@ -8,6 +8,8 @@
 /**
  * Function that recursively renders a list of nested comments.
  *
+ * @since 6.3.0 Changed render_block_context priority to `1`.
+ *
  * @global int $comment_depth
  *
  * @param WP_Comment[] $comments        The array of comments.

--- a/packages/block-library/src/footnotes/index.php
+++ b/packages/block-library/src/footnotes/index.php
@@ -78,3 +78,129 @@ function register_block_core_footnotes() {
 	);
 }
 add_action( 'init', 'register_block_core_footnotes' );
+
+add_action(
+	'wp_after_insert_post',
+	/**
+	 * Saves the footnotes meta value to the revision.
+	 *
+	 * @param int $revision_id The revision ID.
+	 */
+	function( $revision_id ) {
+		$post_id = wp_is_post_revision( $revision_id );
+
+		if ( $post_id ) {
+			$footnotes = get_post_meta( $post_id, 'footnotes', true );
+
+			if ( $footnotes ) {
+				// Can't use update_post_meta() because it doesn't allow revisions.
+				update_metadata( 'post', $revision_id, 'footnotes', $footnotes );
+			}
+		}
+	}
+);
+
+add_action(
+	'_wp_put_post_revision',
+	/**
+	 * Keeps track of the revision ID for "rest_after_insert_{$post_type}".
+	 *
+	 * @param int $revision_id The revision ID.
+	 */
+	function( $revision_id ) {
+		global $_gutenberg_revision_id;
+		$_gutenberg_revision_id = $revision_id;
+	}
+);
+
+foreach ( array( 'post', 'page' ) as $post_type ) {
+	add_action(
+		"rest_after_insert_{$post_type}",
+		/**
+		 * This is a specific fix for the REST API. The REST API doesn't update
+		 * the post and post meta in one go (through `meta_input`). While it
+		 * does fix the `wp_after_insert_post` hook to be called correctly after
+		 * updating meta, it does NOT fix hooks such as post_updated and
+		 * save_post, which are normally also fired after post meta is updated
+		 * in `wp_insert_post()`. Unfortunately, `wp_save_post_revision` is
+		 * added to the `post_updated` action, which means the meta is not
+		 * available at the time, so we have to add it afterwards through the
+		 * `"rest_after_insert_{$post_type}"` action.
+		 *
+		 * @param WP_Post $post The post object.
+		 */
+		function( $post ) {
+			global $_gutenberg_revision_id;
+
+			if ( $_gutenberg_revision_id ) {
+				$revision = get_post( $_gutenberg_revision_id );
+				$post_id  = $revision->post_parent;
+
+				// Just making sure we're updating the right revision.
+				if ( $post->ID === $post_id ) {
+					$footnotes = get_post_meta( $post_id, 'footnotes', true );
+
+					if ( $footnotes ) {
+						// Can't use update_post_meta() because it doesn't allow revisions.
+						update_metadata( 'post', $_gutenberg_revision_id, 'footnotes', $footnotes );
+					}
+				}
+			}
+		}
+	);
+}
+
+add_action(
+	'wp_restore_post_revision',
+	/**
+	 * Restores the footnotes meta value from the revision.
+	 *
+	 * @param int $post_id      The post ID.
+	 * @param int $revision_id  The revision ID.
+	 */
+	function( $post_id, $revision_id ) {
+		$footnotes = get_post_meta( $revision_id, 'footnotes', true );
+
+		if ( $footnotes ) {
+			update_post_meta( $post_id, 'footnotes', $footnotes );
+		} else {
+			delete_post_meta( $post_id, 'footnotes' );
+		}
+	},
+	10,
+	2
+);
+
+add_filter(
+	'_wp_post_revision_fields',
+	/**
+	 * Adds the footnotes field to the revision.
+	 *
+	 * @param array $fields The revision fields.
+	 *
+	 * @return array The revision fields.
+	 */
+	function( $fields ) {
+		$fields['footnotes'] = __( 'Footnotes' );
+		return $fields;
+	}
+);
+
+add_filter(
+	'wp_post_revision_field_footnotes',
+	/**
+	 * Gets the footnotes field from the revision.
+	 *
+	 * @param string $revision_field The field value, but $revision->$field
+	 *                               (footnotes) does not exist.
+	 * @param string $field          The field name, in this case "footnotes".
+	 * @param object $revision       The revision object to compare against.
+	 *
+	 * @return string The field value.
+	 */
+	function( $revision_field, $field, $revision ) {
+		return get_metadata( 'post', $revision->ID, $field, true );
+	},
+	10,
+	3
+);

--- a/packages/block-library/src/footnotes/index.php
+++ b/packages/block-library/src/footnotes/index.php
@@ -8,6 +8,8 @@
 /**
  * Renders the `core/footnotes` block on the server.
  *
+ * @since 6.3.0
+ *
  * @param array    $attributes Block attributes.
  * @param string   $content    Block default content.
  * @param WP_Block $block      Block instance.
@@ -57,6 +59,8 @@ function render_block_core_footnotes( $attributes, $content, $block ) {
 
 /**
  * Registers the `core/footnotes` block on the server.
+ *
+ * @since 6.3.0
  */
 function register_block_core_footnotes() {
 	foreach ( array( 'post', 'page' ) as $post_type ) {
@@ -83,6 +87,8 @@ add_action(
 	'wp_after_insert_post',
 	/**
 	 * Saves the footnotes meta value to the revision.
+	 *
+	 * @since 6.3.0
 	 *
 	 * @param int $revision_id The revision ID.
 	 */
@@ -127,6 +133,8 @@ foreach ( array( 'post', 'page' ) as $post_type ) {
 		 * available at the time, so we have to add it afterwards through the
 		 * `"rest_after_insert_{$post_type}"` action.
 		 *
+		 * @since 6.3.0
+		 *
 		 * @param WP_Post $post The post object.
 		 */
 		static function( $post ) {
@@ -155,6 +163,8 @@ add_action(
 	/**
 	 * Restores the footnotes meta value from the revision.
 	 *
+	 * @since 6.3.0
+	 *
 	 * @param int $post_id      The post ID.
 	 * @param int $revision_id  The revision ID.
 	 */
@@ -176,8 +186,9 @@ add_filter(
 	/**
 	 * Adds the footnotes field to the revision.
 	 *
-	 * @param array $fields The revision fields.
+	 * @since 6.3.0
 	 *
+	 * @param array $fields The revision fields.
 	 * @return array The revision fields.
 	 */
 	static function( $fields ) {
@@ -191,11 +202,12 @@ add_filter(
 	/**
 	 * Gets the footnotes field from the revision.
 	 *
+	 * @since 6.3.0
+	 *
 	 * @param string $revision_field The field value, but $revision->$field
 	 *                               (footnotes) does not exist.
 	 * @param string $field          The field name, in this case "footnotes".
 	 * @param object $revision       The revision object to compare against.
-	 *
 	 * @return string The field value.
 	 */
 	static function( $revision_field, $field, $revision ) {

--- a/packages/block-library/src/footnotes/index.php
+++ b/packages/block-library/src/footnotes/index.php
@@ -86,7 +86,7 @@ add_action(
 	 *
 	 * @param int $revision_id The revision ID.
 	 */
-	function( $revision_id ) {
+	static function( $revision_id ) {
 		$post_id = wp_is_post_revision( $revision_id );
 
 		if ( $post_id ) {
@@ -107,7 +107,7 @@ add_action(
 	 *
 	 * @param int $revision_id The revision ID.
 	 */
-	function( $revision_id ) {
+	static function( $revision_id ) {
 		global $_gutenberg_revision_id;
 		$_gutenberg_revision_id = $revision_id;
 	}
@@ -129,7 +129,7 @@ foreach ( array( 'post', 'page' ) as $post_type ) {
 		 *
 		 * @param WP_Post $post The post object.
 		 */
-		function( $post ) {
+		static function( $post ) {
 			global $_gutenberg_revision_id;
 
 			if ( $_gutenberg_revision_id ) {
@@ -158,7 +158,7 @@ add_action(
 	 * @param int $post_id      The post ID.
 	 * @param int $revision_id  The revision ID.
 	 */
-	function( $post_id, $revision_id ) {
+	static function( $post_id, $revision_id ) {
 		$footnotes = get_post_meta( $revision_id, 'footnotes', true );
 
 		if ( $footnotes ) {
@@ -180,7 +180,7 @@ add_filter(
 	 *
 	 * @return array The revision fields.
 	 */
-	function( $fields ) {
+	static function( $fields ) {
 		$fields['footnotes'] = __( 'Footnotes' );
 		return $fields;
 	}
@@ -198,7 +198,7 @@ add_filter(
 	 *
 	 * @return string The field value.
 	 */
-	function( $revision_field, $field, $revision ) {
+	static function( $revision_field, $field, $revision ) {
 		return get_metadata( 'post', $revision->ID, $field, true );
 	},
 	10,

--- a/packages/block-library/src/pattern/index.php
+++ b/packages/block-library/src/pattern/index.php
@@ -22,6 +22,8 @@ function register_block_core_pattern() {
 /**
  * Renders the `core/pattern` block on the server.
  *
+ * @since 6.3.0 Backwards compatibility: blocks with no `syncStatus` attribute do not receive block wrapper.
+ *
  * @param array $attributes Block attributes.
  *
  * @return string Returns the output of the pattern.

--- a/packages/block-library/src/post-template/index.php
+++ b/packages/block-library/src/post-template/index.php
@@ -34,6 +34,8 @@ function block_core_post_template_uses_featured_image( $inner_blocks ) {
 /**
  * Renders the `core/post-template` block on the server.
  *
+ * @since 6.3.0 Changed render_block_context priority to `1`.
+ *
  * @param array    $attributes Block attributes.
  * @param string   $content    Block default content.
  * @param WP_Block $block      Block instance.

--- a/packages/block-library/src/post-title/index.php
+++ b/packages/block-library/src/post-title/index.php
@@ -8,6 +8,8 @@
 /**
  * Renders the `core/post-title` block on the server.
  *
+ * @since 6.3.0 Omitting the $post argument from the `get_the_title`.
+ *
  * @param array    $attributes Block attributes.
  * @param string   $content    Block default content.
  * @param WP_Block $block      Block instance.

--- a/packages/block-library/src/search/index.php
+++ b/packages/block-library/src/search/index.php
@@ -8,6 +8,8 @@
 /**
  * Dynamically renders the `core/search` block.
  *
+ * @since 6.3.0 Using block.json `viewScript` to register script, and update `view_script_handles()` only when needed.
+ *
  * @param array    $attributes The block attributes.
  * @param string   $content    The saved content.
  * @param WP_Block $block      The parsed block.

--- a/packages/blocks/src/api/parser/index.js
+++ b/packages/blocks/src/api/parser/index.js
@@ -101,6 +101,7 @@ export function normalizeRawBlock( rawBlock, options ) {
 	// meaning there are no negative consequences to repeated autop calls.
 	if (
 		rawBlockName === fallbackBlockName &&
+		rawBlockName === 'core/freeform' &&
 		! options?.__unstableSkipAutop
 	) {
 		rawInnerHTML = autop( rawInnerHTML ).trim();

--- a/packages/blocks/src/api/parser/test/index.js
+++ b/packages/blocks/src/api/parser/test/index.js
@@ -90,19 +90,30 @@ describe( 'block parser', () => {
 		} );
 
 		it( 'should fall back to the freeform content handler if block type not specified', () => {
-			registerBlockType( 'core/freeform-block', unknownBlockSettings );
-			setFreeformContentHandlerName( 'core/freeform-block' );
+			registerBlockType( 'core/freeform', unknownBlockSettings );
+			setFreeformContentHandlerName( 'core/freeform' );
 
 			const block = parseRawBlock( {
 				innerHTML: 'content',
 			} );
-			expect( block.name ).toEqual( 'core/freeform-block' );
+			expect( block.name ).toEqual( 'core/freeform' );
 			expect( block.attributes ).toEqual( { content: '<p>content</p>' } );
 		} );
 
+		it( 'skips adding paragraph tags if freeform block is set to core/html', () => {
+			registerBlockType( 'core/html', unknownBlockSettings );
+			setFreeformContentHandlerName( 'core/html' );
+
+			const block = parseRawBlock( {
+				innerHTML: 'content',
+			} );
+			expect( block.name ).toEqual( 'core/html' );
+			expect( block.attributes ).toEqual( { content: 'content' } );
+		} );
+
 		it( 'skips adding paragraph tags if __unstableSkipAutop is passed as an option', () => {
-			registerBlockType( 'core/freeform-block', unknownBlockSettings );
-			setFreeformContentHandlerName( 'core/freeform-block' );
+			registerBlockType( 'core/freeform', unknownBlockSettings );
+			setFreeformContentHandlerName( 'core/freeform' );
 
 			const block = parseRawBlock(
 				{
@@ -112,7 +123,7 @@ describe( 'block parser', () => {
 					__unstableSkipAutop: true,
 				}
 			);
-			expect( block.name ).toEqual( 'core/freeform-block' );
+			expect( block.name ).toEqual( 'core/freeform' );
 			expect( block.attributes ).toEqual( { content: 'content' } );
 		} );
 

--- a/packages/blocks/src/api/serializer.js
+++ b/packages/blocks/src/api/serializer.js
@@ -390,7 +390,8 @@ export function __unstableSerializeAndClean( blocks ) {
 	// pre-block-editor removep'd content formatting.
 	if (
 		blocks.length === 1 &&
-		blocks[ 0 ].name === getFreeformContentHandlerName()
+		blocks[ 0 ].name === getFreeformContentHandlerName() &&
+		blocks[ 0 ].name === 'core/freeform'
 	) {
 		content = removep( content );
 	}

--- a/packages/blocks/src/api/test/serializer.js
+++ b/packages/blocks/src/api/test/serializer.js
@@ -244,7 +244,7 @@ describe( 'block serializer', () => {
 
 	describe( 'serializeBlock()', () => {
 		it( 'serializes the freeform content fallback block without comment delimiters', () => {
-			registerBlockType( 'core/freeform-block', {
+			registerBlockType( 'core/freeform', {
 				category: 'text',
 				title: 'freeform block',
 				attributes: {
@@ -254,8 +254,8 @@ describe( 'block serializer', () => {
 				},
 				save: ( { attributes } ) => attributes.fruit,
 			} );
-			setFreeformContentHandlerName( 'core/freeform-block' );
-			const block = createBlock( 'core/freeform-block', {
+			setFreeformContentHandlerName( 'core/freeform' );
+			const block = createBlock( 'core/freeform', {
 				fruit: 'Bananas',
 			} );
 
@@ -264,7 +264,7 @@ describe( 'block serializer', () => {
 			expect( content ).toBe( 'Bananas' );
 		} );
 		it( 'serializes the freeform content fallback block with comment delimiters in nested context', () => {
-			registerBlockType( 'core/freeform-block', {
+			registerBlockType( 'core/freeform', {
 				category: 'text',
 				title: 'freeform block',
 				attributes: {
@@ -274,17 +274,17 @@ describe( 'block serializer', () => {
 				},
 				save: ( { attributes } ) => attributes.fruit,
 			} );
-			setFreeformContentHandlerName( 'core/freeform-block' );
-			const block = createBlock( 'core/freeform-block', {
+			setFreeformContentHandlerName( 'core/freeform' );
+			const block = createBlock( 'core/freeform', {
 				fruit: 'Bananas',
 			} );
 
 			const content = serializeBlock( block, { isInnerBlocks: true } );
 
 			expect( content ).toBe(
-				'<!-- wp:freeform-block {"fruit":"Bananas"} -->\n' +
+				'<!-- wp:freeform {"fruit":"Bananas"} -->\n' +
 					'Bananas\n' +
-					'<!-- /wp:freeform-block -->'
+					'<!-- /wp:freeform -->'
 			);
 		} );
 		it( 'serializes the unregistered fallback block without comment delimiters', () => {

--- a/packages/e2e-tests/plugins/iframed-enqueue-block-editor-settings.php
+++ b/packages/e2e-tests/plugins/iframed-enqueue-block-editor-settings.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Plugin Name: Gutenberg Test Iframed enqueue block editor settings
+ * Plugin URI: https://github.com/WordPress/gutenberg
+ * Author: Gutenberg Team
+ *
+ * @package gutenberg-test-iframed-iframed-enqueue-block-editor-settings
+ */
+
+add_action(
+	'block_editor_settings_all',
+	function( $settings ) {
+		$settings['styles'][] = array(
+			'css'            => 'p { border: 1px solid red }',
+			'__unstableType' => 'plugin',
+		);
+		return $settings;
+	}
+);

--- a/packages/e2e-tests/specs/editor/plugins/iframed-enqueue-block-editor-settings.test.js
+++ b/packages/e2e-tests/specs/editor/plugins/iframed-enqueue-block-editor-settings.test.js
@@ -1,0 +1,108 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	activatePlugin,
+	createNewPost,
+	deactivatePlugin,
+	canvas,
+	activateTheme,
+} from '@wordpress/e2e-test-utils';
+
+async function getComputedStyle( context, selector, property ) {
+	return await context.evaluate(
+		( sel, prop ) =>
+			window.getComputedStyle( document.querySelector( sel ) )[ prop ],
+		selector,
+		property
+	);
+}
+
+describe( 'iframed block editor settings styles', () => {
+	beforeEach( async () => {
+		// Activate the empty theme (block based theme), which is iframed.
+		await activateTheme( 'emptytheme' );
+		await activatePlugin(
+			'gutenberg-test-iframed-enqueue-block-editor-settings'
+		);
+		await createNewPost();
+	} );
+
+	afterEach( async () => {
+		await deactivatePlugin(
+			'gutenberg-test-iframed-enqueue-block-editor-settings'
+		);
+		await activateTheme( 'twentytwentyone' );
+	} );
+
+	it( 'should load styles added through block editor settings', async () => {
+		await page.waitForSelector( 'iframe[name="editor-canvas"]' );
+		// Expect a red border (added in PHP).
+		expect( await getComputedStyle( canvas(), 'p', 'border-color' ) ).toBe(
+			'rgb(255, 0, 0)'
+		);
+
+		await page.evaluate( () => {
+			const settings = window.wp.data
+				.select( 'core/editor' )
+				.getEditorSettings();
+			wp.data.dispatch( 'core/editor' ).updateEditorSettings( {
+				...settings,
+				styles: [
+					...settings.styles,
+					{
+						css: 'p { border-width: 2px; }',
+						__unstableType: 'plugin',
+					},
+				],
+			} );
+		} );
+
+		// Expect a 2px border (added in JS).
+		expect( await getComputedStyle( canvas(), 'p', 'border-width' ) ).toBe(
+			'2px'
+		);
+	} );
+
+	it( 'should load theme styles added through block editor settings', async () => {
+		await page.waitForSelector( 'iframe[name="editor-canvas"]' );
+
+		await page.evaluate( () => {
+			// Make sure that theme styles are added even if the theme styles
+			// preference is off.
+			window.wp.data
+				.dispatch( 'core/edit-post' )
+				.toggleFeature( 'themeStyles' );
+			const settings = window.wp.data
+				.select( 'core/editor' )
+				.getEditorSettings();
+			wp.data.dispatch( 'core/editor' ).updateEditorSettings( {
+				...settings,
+				styles: [
+					...settings.styles,
+					{
+						css: 'p { border-width: 2px; }',
+						__unstableType: 'theme',
+					},
+				],
+			} );
+		} );
+
+		// Expect a 1px border because theme styles are disabled.
+		expect( await getComputedStyle( canvas(), 'p', 'border-width' ) ).toBe(
+			'1px'
+		);
+
+		await page.evaluate( () => {
+			// Now enable theme styles.
+			window.wp.data
+				.dispatch( 'core/edit-post' )
+				.toggleFeature( 'themeStyles' );
+		} );
+
+		// Expect a 2px border because theme styles are enabled.
+		expect( await getComputedStyle( canvas(), 'p', 'border-width' ) ).toBe(
+			'2px'
+		);
+	} );
+} );

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -17,7 +17,10 @@ import {
 	store as editorStore,
 } from '@wordpress/editor';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { BlockBreadcrumb } from '@wordpress/block-editor';
+import {
+	BlockBreadcrumb,
+	privateApis as blockEditorPrivateApis,
+} from '@wordpress/block-editor';
 import { Button, ScrollLock, Popover } from '@wordpress/components';
 import { useViewportMatch } from '@wordpress/compose';
 import { PluginArea } from '@wordpress/plugins';
@@ -50,6 +53,9 @@ import WelcomeGuide from '../welcome-guide';
 import ActionsPanel from './actions-panel';
 import StartPageOptions from '../start-page-options';
 import { store as editPostStore } from '../../store';
+import { unlock } from '../../lock-unlock';
+
+const { getLayoutStyles } = unlock( blockEditorPrivateApis );
 
 const interfaceLabels = {
 	/* translators: accessibility text for the editor top bar landmark region. */
@@ -64,7 +70,7 @@ const interfaceLabels = {
 	footer: __( 'Editor footer' ),
 };
 
-function Layout( { styles } ) {
+function Layout() {
 	const isMobileViewport = useViewportMatch( 'medium', '<' );
 	const isHugeViewport = useViewportMatch( 'huge', '>=' );
 	const isLargeViewport = useViewportMatch( 'large' );
@@ -88,10 +94,45 @@ function Layout( { styles } ) {
 		showBlockBreadcrumbs,
 		isTemplateMode,
 		documentLabel,
+		styles,
 	} = useSelect( ( select ) => {
 		const { getEditorSettings, getPostTypeLabel } = select( editorStore );
+		const { isFeatureActive } = select( editPostStore );
 		const editorSettings = getEditorSettings();
 		const postTypeLabel = getPostTypeLabel();
+		const hasThemeStyles = isFeatureActive( 'themeStyles' );
+
+		const themeStyles = [];
+		const presetStyles = [];
+		editorSettings.styles?.forEach( ( style ) => {
+			if ( ! style.__unstableType || style.__unstableType === 'theme' ) {
+				themeStyles.push( style );
+			} else {
+				presetStyles.push( style );
+			}
+		} );
+
+		const defaultEditorStyles = [
+			...editorSettings.defaultEditorStyles,
+			...presetStyles,
+		];
+
+		// If theme styles are not present or displayed, ensure that
+		// base layout styles are still present in the editor.
+		if (
+			! editorSettings.disableLayoutStyles &&
+			! ( hasThemeStyles && themeStyles.length )
+		) {
+			defaultEditorStyles.push( {
+				css: getLayoutStyles( {
+					style: {},
+					selector: 'body',
+					hasBlockGapSupport: false,
+					hasFallbackGapSupport: true,
+					fallbackGapValue: '0.5em',
+				} ),
+			} );
+		}
 
 		return {
 			isTemplateMode: select( editPostStore ).isEditingTemplate(),
@@ -124,6 +165,10 @@ function Layout( { styles } ) {
 			),
 			// translators: Default label for the Document in the Block Breadcrumb.
 			documentLabel: postTypeLabel || _x( 'Document', 'noun' ),
+			styles:
+				hasThemeStyles && themeStyles.length
+					? editorSettings.styles
+					: defaultEditorStyles,
 		};
 	}, [] );
 

--- a/packages/edit-post/src/editor.js
+++ b/packages/edit-post/src/editor.js
@@ -9,7 +9,6 @@ import {
 	store as editorStore,
 	privateApis as editorPrivateApis,
 } from '@wordpress/editor';
-import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
 import { useMemo } from '@wordpress/element';
 import { SlotFillProvider } from '@wordpress/components';
 import { store as coreStore } from '@wordpress/core-data';
@@ -28,7 +27,6 @@ import { unlock } from './lock-unlock';
 import useCommonCommands from './hooks/commands/use-common-commands';
 
 const { ExperimentalEditorProvider } = unlock( editorPrivateApis );
-const { getLayoutStyles } = unlock( blockEditorPrivateApis );
 const { useCommands } = unlock( coreCommandsPrivateApis );
 
 function Editor( { postId, postType, settings, initialEdits, ...props } ) {
@@ -39,7 +37,6 @@ function Editor( { postId, postType, settings, initialEdits, ...props } ) {
 		focusMode,
 		isDistractionFree,
 		hasInlineToolbar,
-		hasThemeStyles,
 		post,
 		preferredStyleVariations,
 		hiddenBlockTypes,
@@ -83,7 +80,6 @@ function Editor( { postId, postType, settings, initialEdits, ...props } ) {
 				focusMode: isFeatureActive( 'focusMode' ),
 				isDistractionFree: isFeatureActive( 'distractionFree' ),
 				hasInlineToolbar: isFeatureActive( 'inlineToolbar' ),
-				hasThemeStyles: isFeatureActive( 'themeStyles' ),
 				preferredStyleVariations: select( preferencesStore ).get(
 					'core/edit-post',
 					'preferredStyleVariations'
@@ -155,44 +151,6 @@ function Editor( { postId, postType, settings, initialEdits, ...props } ) {
 		keepCaretInsideBlock,
 	] );
 
-	const styles = useMemo( () => {
-		const themeStyles = [];
-		const presetStyles = [];
-		settings.styles?.forEach( ( style ) => {
-			if ( ! style.__unstableType || style.__unstableType === 'theme' ) {
-				themeStyles.push( style );
-			} else {
-				presetStyles.push( style );
-			}
-		} );
-
-		const defaultEditorStyles = [
-			...settings.defaultEditorStyles,
-			...presetStyles,
-		];
-
-		// If theme styles are not present or displayed, ensure that
-		// base layout styles are still present in the editor.
-		if (
-			! settings.disableLayoutStyles &&
-			! ( hasThemeStyles && themeStyles.length )
-		) {
-			defaultEditorStyles.push( {
-				css: getLayoutStyles( {
-					style: {},
-					selector: 'body',
-					hasBlockGapSupport: false,
-					hasFallbackGapSupport: true,
-					fallbackGapValue: '0.5em',
-				} ),
-			} );
-		}
-
-		return hasThemeStyles && themeStyles.length
-			? settings.styles
-			: defaultEditorStyles;
-	}, [ settings, hasThemeStyles ] );
-
 	if ( ! post ) {
 		return null;
 	}
@@ -211,7 +169,7 @@ function Editor( { postId, postType, settings, initialEdits, ...props } ) {
 					<ErrorBoundary>
 						<CommandMenu />
 						<EditorInitialization postId={ postId } />
-						<Layout styles={ styles } />
+						<Layout />
 					</ErrorBoundary>
 					<PostLockedModal />
 				</ExperimentalEditorProvider>

--- a/packages/edit-post/src/editor.js
+++ b/packages/edit-post/src/editor.js
@@ -51,7 +51,6 @@ function Editor( { postId, postType, settings, initialEdits, ...props } ) {
 		( select ) => {
 			const {
 				isFeatureActive,
-				__experimentalGetPreviewDeviceType,
 				isEditingTemplate,
 				getEditedPostTemplate,
 				getHiddenBlockTypes,
@@ -80,9 +79,7 @@ function Editor( { postId, postType, settings, initialEdits, ...props } ) {
 			const canEditTemplate = canUser( 'create', 'templates' );
 
 			return {
-				hasFixedToolbar:
-					isFeatureActive( 'fixedToolbar' ) ||
-					__experimentalGetPreviewDeviceType() !== 'Desktop',
+				hasFixedToolbar: isFeatureActive( 'fixedToolbar' ),
 				focusMode: isFeatureActive( 'focusMode' ),
 				isDistractionFree: isFeatureActive( 'distractionFree' ),
 				hasInlineToolbar: isFeatureActive( 'inlineToolbar' ),

--- a/packages/edit-site/src/components/global-styles/screen-revisions/revisions-buttons.js
+++ b/packages/edit-site/src/components/global-styles/screen-revisions/revisions-buttons.js
@@ -21,11 +21,9 @@ function getRevisionLabel( revision ) {
 
 	if ( 'unsaved' === revision?.id ) {
 		return sprintf(
-			/* translators: %(name)s author display name */
-			__( 'Unsaved changes by %(name)s' ),
-			{
-				name: authorDisplayName,
-			}
+			/* translators: %s author display name */
+			__( 'Unsaved changes by %s' ),
+			authorDisplayName
 		);
 	}
 	const formattedDate = dateI18n(
@@ -35,20 +33,16 @@ function getRevisionLabel( revision ) {
 
 	return revision?.isLatest
 		? sprintf(
-				/* translators: %(name)s author display name, %(date)s: revision creation date */
-				__( 'Changes saved by %(name)s on %(date)s (current)' ),
-				{
-					name: authorDisplayName,
-					date: formattedDate,
-				}
+				/* translators: %1$s author display name, %2$s: revision creation date */
+				__( 'Changes saved by %1$s on %2$s (current)' ),
+				authorDisplayName,
+				formattedDate
 		  )
 		: sprintf(
-				/* translators: %(name)s author display name, %(date)s: revision creation date */
-				__( 'Changes saved by %(name)s on %(date)s' ),
-				{
-					name: authorDisplayName,
-					date: formattedDate,
-				}
+				/* translators: %1$s author display name, %2$s: revision creation date */
+				__( 'Changes saved by %1$s on %2$s' ),
+				authorDisplayName,
+				formattedDate
 		  );
 }
 
@@ -104,22 +98,14 @@ function RevisionsButtons( { userRevisions, selectedRevisionId, onChange } ) {
 								<span className="edit-site-global-styles-screen-revisions__meta">
 									{ isUnsaved
 										? sprintf(
-												/* translators: %(name)s author display name */
-												__(
-													'Unsaved changes by %(name)s'
-												),
-												{
-													name: authorDisplayName,
-												}
+												/* translators: %s author display name */
+												__( 'Unsaved changes by %s' ),
+												authorDisplayName
 										  )
 										: sprintf(
-												/* translators: %(name)s author display name */
-												__(
-													'Changes saved by %(name)s'
-												),
-												{
-													name: authorDisplayName,
-												}
+												/* translators: %s author display name */
+												__( 'Changes saved by %s' ),
+												authorDisplayName
 										  ) }
 
 									<img

--- a/packages/edit-site/src/components/layout/index.js
+++ b/packages/edit-site/src/components/layout/index.js
@@ -121,6 +121,8 @@ export default function Layout() {
 	const [ fullResizer ] = useResizeObserver();
 	const [ isResizing ] = useState( false );
 	const isEditorLoading = useIsSiteEditorLoading();
+	const [ isResizableFrameOversized, setIsResizableFrameOversized ] =
+		useState( false );
 
 	// This determines which animation variant should apply to the header.
 	// There is also a `isDistractionFreeHovering` state that gets priority
@@ -218,6 +220,7 @@ export default function Layout() {
 							edit: { x: 0 },
 						} }
 						ref={ hubRef }
+						isTransparent={ isResizableFrameOversized }
 						className="edit-site-layout__hub"
 					/>
 
@@ -315,7 +318,13 @@ export default function Layout() {
 											}
 											initial={ false }
 											layout="position"
-											className="edit-site-layout__canvas"
+											className={ classnames(
+												'edit-site-layout__canvas',
+												{
+													'is-right-aligned':
+														isResizableFrameOversized,
+												}
+											) }
 											transition={ {
 												type: 'tween',
 												duration:
@@ -331,7 +340,12 @@ export default function Layout() {
 														! isEditorLoading
 													}
 													isFullWidth={ isEditing }
-													oversizedClassName="edit-site-layout__resizable-frame-oversized"
+													isOversized={
+														isResizableFrameOversized
+													}
+													setIsOversized={
+														setIsResizableFrameOversized
+													}
 													innerContentStyle={ {
 														background:
 															gradientValue ??

--- a/packages/edit-site/src/components/layout/style.scss
+++ b/packages/edit-site/src/components/layout/style.scss
@@ -121,7 +121,7 @@
 	justify-content: center;
 	align-items: center;
 
-	&:has(.edit-site-layout__resizable-frame-oversized) {
+	&.is-right-aligned {
 		justify-content: flex-end;
 	}
 

--- a/packages/edit-site/src/components/page-patterns/patterns-list.js
+++ b/packages/edit-site/src/components/page-patterns/patterns-list.js
@@ -27,7 +27,7 @@ import usePatterns from './use-patterns';
 import SidebarButton from '../sidebar-button';
 import useDebouncedInput from '../../utils/use-debounced-input';
 import { unlock } from '../../lock-unlock';
-import { SYNC_TYPES, USER_PATTERN_CATEGORY } from './utils';
+import { SYNC_TYPES, USER_PATTERN_CATEGORY, PATTERNS } from './utils';
 
 const { useLocation, useHistory } = unlock( routerPrivateApis );
 
@@ -58,9 +58,12 @@ export default function PatternsList( { categoryId, type } ) {
 	const [ syncFilter, setSyncFilter ] = useState( 'all' );
 	const deferredSyncedFilter = useDeferredValue( syncFilter );
 
+	const isUncategorizedThemePatterns =
+		type === PATTERNS && categoryId === 'uncategorized';
+
 	const { patterns, isResolving } = usePatterns(
 		type,
-		categoryId !== 'uncategorized' ? categoryId : '',
+		isUncategorizedThemePatterns ? '' : categoryId,
 		{
 			search: deferredFilterValue,
 			syncStatus:

--- a/packages/edit-site/src/components/page-patterns/use-patterns.js
+++ b/packages/edit-site/src/components/page-patterns/use-patterns.js
@@ -86,6 +86,7 @@ const selectThemePatterns = ( select, { categoryId, search = '' } = {} ) => {
 			( pattern ) => ! CORE_PATTERN_SOURCES.includes( pattern.source )
 		)
 		.filter( filterOutDuplicatesByName )
+		.filter( ( pattern ) => pattern.inserter !== false )
 		.map( ( pattern ) => ( {
 			...pattern,
 			keywords: pattern.keywords || [],

--- a/packages/edit-site/src/components/resizable-frame/index.js
+++ b/packages/edit-site/src/components/resizable-frame/index.js
@@ -78,9 +78,10 @@ function calculateNewHeight( width, initialAspectRatio ) {
 
 function ResizableFrame( {
 	isFullWidth,
+	isOversized,
+	setIsOversized,
 	isReady,
 	children,
-	oversizedClassName,
 	innerContentStyle,
 } ) {
 	const [ frameSize, setFrameSize ] = useState( INITIAL_FRAME_SIZE );
@@ -88,7 +89,6 @@ function ResizableFrame( {
 	const [ startingWidth, setStartingWidth ] = useState();
 	const [ isResizing, setIsResizing ] = useState( false );
 	const [ shouldShowHandle, setShouldShowHandle ] = useState( false );
-	const [ isOversized, setIsOversized ] = useState( false );
 	const [ resizeRatio, setResizeRatio ] = useState( 1 );
 	const canvasMode = useSelect(
 		( select ) => unlock( select( editSiteStore ) ).getCanvasMode(),
@@ -314,7 +314,6 @@ function ResizableFrame( {
 			onResizeStop={ handleResizeStop }
 			className={ classnames( 'edit-site-resizable-frame__inner', {
 				'is-resizing': isResizing,
-				[ oversizedClassName ]: isOversized,
 			} ) }
 		>
 			<motion.div

--- a/packages/edit-site/src/components/resizable-frame/style.scss
+++ b/packages/edit-site/src/components/resizable-frame/style.scss
@@ -1,23 +1,6 @@
 .edit-site-resizable-frame__inner {
 	position: relative;
 
-	&.edit-site-layout__resizable-frame-oversized {
-		@at-root {
-			body:has(&) {
-				.edit-site-site-hub {
-					.edit-site-site-hub__site-title,
-					.edit-site-site-hub_toggle-command-center {
-						opacity: 0 !important;
-					}
-
-					.edit-site-site-hub__view-mode-toggle-container {
-						background-color: transparent;
-					}
-				}
-			}
-		}
-	}
-
 	&.is-resizing {
 		@at-root {
 			body:has(&) {

--- a/packages/edit-site/src/components/sidebar-edit-mode/page-panels/page-status.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/page-panels/page-status.js
@@ -212,11 +212,8 @@ export default function PageStatus( {
 													} )
 												}
 												value={ password }
-												/* eslint-disable jsx-a11y/no-autofocus */
-												autoFocus={ ! password }
-												/* eslint-enable jsx-a11y/no-autofocus */
 												placeholder={ __(
-													'Enter a secure password'
+													'Use a secure password'
 												) }
 												type="text"
 											/>

--- a/packages/edit-site/src/components/sidebar-navigation-screen-patterns/use-theme-patterns.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-patterns/use-theme-patterns.js
@@ -36,7 +36,8 @@ export default function useThemePatterns() {
 					( pattern ) =>
 						! CORE_PATTERN_SOURCES.includes( pattern.source )
 				)
-				.filter( filterOutDuplicatesByName ),
+				.filter( filterOutDuplicatesByName )
+				.filter( ( pattern ) => pattern.inserter !== false ),
 		[ blockPatterns, restBlockPatterns ]
 	);
 

--- a/packages/edit-site/src/components/site-hub/index.js
+++ b/packages/edit-site/src/components/site-hub/index.js
@@ -31,7 +31,7 @@ import { unlock } from '../../lock-unlock';
 
 const HUB_ANIMATION_DURATION = 0.3;
 
-const SiteHub = forwardRef( ( props, ref ) => {
+const SiteHub = forwardRef( ( { isTransparent, ...restProps }, ref ) => {
 	const { canvasMode, dashboardLink, homeUrl } = useSelect( ( select ) => {
 		const { getCanvasMode, getSettings } = unlock(
 			select( editSiteStore )
@@ -85,8 +85,11 @@ const SiteHub = forwardRef( ( props, ref ) => {
 	return (
 		<motion.div
 			ref={ ref }
-			{ ...props }
-			className={ classnames( 'edit-site-site-hub', props.className ) }
+			{ ...restProps }
+			className={ classnames(
+				'edit-site-site-hub',
+				restProps.className
+			) }
 			initial={ false }
 			transition={ {
 				type: 'tween',
@@ -105,7 +108,12 @@ const SiteHub = forwardRef( ( props, ref ) => {
 					spacing="0"
 				>
 					<motion.div
-						className="edit-site-site-hub__view-mode-toggle-container"
+						className={ classnames(
+							'edit-site-site-hub__view-mode-toggle-container',
+							{
+								'has-transparent-background': isTransparent,
+							}
+						) }
 						layout
 						transition={ {
 							type: 'tween',
@@ -149,7 +157,10 @@ const SiteHub = forwardRef( ( props, ref ) => {
 							exit={ {
 								opacity: 0,
 							} }
-							className="edit-site-site-hub__site-title"
+							className={ classnames(
+								'edit-site-site-hub__site-title',
+								{ 'is-transparent': isTransparent }
+							) }
 							transition={ {
 								type: 'tween',
 								duration: disableMotion ? 0 : 0.2,
@@ -175,7 +186,10 @@ const SiteHub = forwardRef( ( props, ref ) => {
 				</HStack>
 				{ canvasMode === 'view' && (
 					<Button
-						className="edit-site-site-hub_toggle-command-center"
+						className={ classnames(
+							'edit-site-site-hub_toggle-command-center',
+							{ 'is-transparent': isTransparent }
+						) }
 						icon={ search }
 						onClick={ () => openCommandCenter() }
 						label={ __( 'Open command palette' ) }

--- a/packages/edit-site/src/components/site-hub/index.js
+++ b/packages/edit-site/src/components/site-hub/index.js
@@ -164,7 +164,7 @@ const SiteHub = forwardRef( ( props, ref ) => {
 						<Button
 							href={ homeUrl }
 							target="_blank"
-							label={ __( 'View site' ) }
+							label={ __( 'View site (opens in a new tab)' ) }
 							aria-label={ __(
 								'View site (opens in a new tab)'
 							) }

--- a/packages/edit-site/src/components/site-hub/style.scss
+++ b/packages/edit-site/src/components/site-hub/style.scss
@@ -15,13 +15,12 @@
 
 	.edit-site-site-hub__site-view-link {
 		flex-grow: 0;
+		margin-right: var(--wp-admin-border-width-focus);
 		@include break-mobile() {
 			opacity: 0;
 			transition: opacity 0.2s ease-in-out;
 		}
 		&:focus {
-			outline: none;
-			box-shadow: none;
 			opacity: 1;
 		}
 		svg {

--- a/packages/edit-site/src/components/site-hub/style.scss
+++ b/packages/edit-site/src/components/site-hub/style.scss
@@ -11,6 +11,10 @@
 	.edit-site-site-hub__site-title,
 	.edit-site-site-hub_toggle-command-center {
 		transition: opacity ease 0.1s;
+
+		&.is-transparent {
+			opacity: 0 !important;
+		}
 	}
 
 	.edit-site-site-hub__site-view-link {
@@ -43,6 +47,10 @@
 	width: $header-height;
 	flex-shrink: 0;
 	background: $gray-900;
+
+	&.has-transparent-background {
+		background: transparent;
+	}
 }
 
 .edit-site-site-hub__text-content {

--- a/packages/edit-site/src/hooks/commands/use-common-commands.js
+++ b/packages/edit-site/src/hooks/commands/use-common-commands.js
@@ -11,15 +11,17 @@ import { privateApis as routerPrivateApis } from '@wordpress/router';
 import { store as preferencesStore } from '@wordpress/preferences';
 import { store as coreStore } from '@wordpress/core-data';
 import { store as noticesStore } from '@wordpress/notices';
+import { useViewportMatch } from '@wordpress/compose';
 
 /**
  * Internal dependencies
  */
 import { unlock } from '../../lock-unlock';
 import { store as editSiteStore } from '../../store';
+import getIsListPage from '../../utils/get-is-list-page';
 
 const { useGlobalStylesReset } = unlock( blockEditorPrivateApis );
-const { useHistory } = unlock( routerPrivateApis );
+const { useHistory, useLocation } = unlock( routerPrivateApis );
 
 function useGlobalStylesResetCommands() {
 	const [ canReset, onReset ] = useGlobalStylesReset();
@@ -48,9 +50,12 @@ function useGlobalStylesResetCommands() {
 }
 
 function useGlobalStylesOpenCssCommands() {
-	const { openGeneralSidebar, setEditorCanvasContainerView } = unlock(
-		useDispatch( editSiteStore )
-	);
+	const { openGeneralSidebar, setEditorCanvasContainerView, setCanvasMode } =
+		unlock( useDispatch( editSiteStore ) );
+	const { params } = useLocation();
+	const isMobileViewport = useViewportMatch( 'medium', '<' );
+	const isListPage = getIsListPage( params, isMobileViewport );
+	const isEditorPage = ! isListPage;
 	const history = useHistory();
 	const { canEditCSS } = useSelect( ( select ) => {
 		const { getEntityRecord, __experimentalGetCurrentGlobalStylesId } =
@@ -66,6 +71,7 @@ function useGlobalStylesOpenCssCommands() {
 				!! globalStyles?._links?.[ 'wp:action-edit-css' ] ?? false,
 		};
 	}, [] );
+	const { getCanvasMode } = unlock( useSelect( editSiteStore ) );
 
 	const commands = useMemo( () => {
 		if ( ! canEditCSS ) {
@@ -79,10 +85,15 @@ function useGlobalStylesOpenCssCommands() {
 				icon: styles,
 				callback: ( { close } ) => {
 					close();
-					history.push( {
-						path: '/wp_global_styles',
-						canvas: 'edit',
-					} );
+					if ( ! isEditorPage ) {
+						history.push( {
+							path: '/wp_global_styles',
+							canvas: 'edit',
+						} );
+					}
+					if ( isEditorPage && getCanvasMode() !== 'edit' ) {
+						setCanvasMode( 'edit' );
+					}
 					openGeneralSidebar( 'edit-site/global-styles' );
 					setEditorCanvasContainerView( 'global-styles-css' );
 				},
@@ -93,6 +104,9 @@ function useGlobalStylesOpenCssCommands() {
 		openGeneralSidebar,
 		setEditorCanvasContainerView,
 		canEditCSS,
+		isEditorPage,
+		getCanvasMode,
+		setCanvasMode,
 	] );
 	return {
 		isLoading: false,
@@ -101,9 +115,13 @@ function useGlobalStylesOpenCssCommands() {
 }
 
 export function useCommonCommands() {
-	const { openGeneralSidebar, setEditorCanvasContainerView } = unlock(
-		useDispatch( editSiteStore )
-	);
+	const { openGeneralSidebar, setEditorCanvasContainerView, setCanvasMode } =
+		unlock( useDispatch( editSiteStore ) );
+	const { params } = useLocation();
+	const isMobileViewport = useViewportMatch( 'medium', '<' );
+	const isListPage = getIsListPage( params, isMobileViewport );
+	const isEditorPage = ! isListPage;
+	const { getCanvasMode } = unlock( useSelect( editSiteStore ) );
 	const { set } = useDispatch( preferencesStore );
 	const { createInfoNotice } = useDispatch( noticesStore );
 	const history = useHistory();
@@ -127,10 +145,15 @@ export function useCommonCommands() {
 		icon: backup,
 		callback: ( { close } ) => {
 			close();
-			history.push( {
-				path: '/wp_global_styles',
-				canvas: 'edit',
-			} );
+			if ( ! isEditorPage ) {
+				history.push( {
+					path: '/wp_global_styles',
+					canvas: 'edit',
+				} );
+			}
+			if ( isEditorPage && getCanvasMode() !== 'edit' ) {
+				setCanvasMode( 'edit' );
+			}
 			openGeneralSidebar( 'edit-site/global-styles' );
 			setEditorCanvasContainerView( 'global-styles-revisions' );
 		},
@@ -141,10 +164,15 @@ export function useCommonCommands() {
 		label: __( 'Open styles' ),
 		callback: ( { close } ) => {
 			close();
-			history.push( {
-				path: '/wp_global_styles',
-				canvas: 'edit',
-			} );
+			if ( ! isEditorPage ) {
+				history.push( {
+					path: '/wp_global_styles',
+					canvas: 'edit',
+				} );
+			}
+			if ( isEditorPage && getCanvasMode() !== 'edit' ) {
+				setCanvasMode( 'edit' );
+			}
 			if ( isDistractionFree ) {
 				set( editSiteStore.name, 'distractionFree', false );
 				createInfoNotice( __( 'Distraction free mode turned off.' ), {
@@ -161,10 +189,15 @@ export function useCommonCommands() {
 		label: __( 'Learn about styles' ),
 		callback: ( { close } ) => {
 			close();
-			history.push( {
-				path: '/wp_global_styles',
-				canvas: 'edit',
-			} );
+			if ( ! isEditorPage ) {
+				history.push( {
+					path: '/wp_global_styles',
+					canvas: 'edit',
+				} );
+			}
+			if ( isEditorPage && getCanvasMode() !== 'edit' ) {
+				setCanvasMode( 'edit' );
+			}
 			openGeneralSidebar( 'edit-site/global-styles' );
 			set( 'core/edit-site', 'welcomeGuideStyles', true );
 			// sometimes there's a focus loss that happens after some time

--- a/packages/editor/src/store/test/selectors.js
+++ b/packages/editor/src/store/test/selectors.js
@@ -264,7 +264,7 @@ describe( 'selectors', () => {
 			parent: [ 'core/test-block-b' ],
 		} );
 
-		registerBlockType( 'core/test-freeform', {
+		registerBlockType( 'core/freeform', {
 			save: ( props ) => <RawHTML>{ props.attributes.content }</RawHTML>,
 			category: 'text',
 			title: 'Test Freeform Content Handler',
@@ -291,7 +291,7 @@ describe( 'selectors', () => {
 			save: () => null,
 		} );
 
-		setFreeformContentHandlerName( 'core/test-freeform' );
+		setFreeformContentHandlerName( 'core/freeform' );
 		setDefaultBlockName( 'core/test-default' );
 
 		cachedSelectors.forEach( ( { clear } ) => clear() );
@@ -302,7 +302,7 @@ describe( 'selectors', () => {
 		unregisterBlockType( 'core/test-block-a' );
 		unregisterBlockType( 'core/test-block-b' );
 		unregisterBlockType( 'core/test-block-c' );
-		unregisterBlockType( 'core/test-freeform' );
+		unregisterBlockType( 'core/freeform' );
 		unregisterBlockType( 'core/test-default' );
 
 		setFreeformContentHandlerName( undefined );
@@ -1339,7 +1339,7 @@ describe( 'selectors', () => {
 							value: [
 								{
 									clientId: 123,
-									name: 'core/test-freeform',
+									name: 'core/freeform',
 									isValid: true,
 									attributes: {
 										content: '',
@@ -1366,7 +1366,7 @@ describe( 'selectors', () => {
 							value: [
 								{
 									clientId: 123,
-									name: 'core/test-freeform',
+									name: 'core/freeform',
 									isValid: true,
 									attributes: {
 										content: '',
@@ -1742,7 +1742,7 @@ describe( 'selectors', () => {
 							value: [
 								{
 									clientId: 123,
-									name: 'core/test-freeform',
+									name: 'core/freeform',
 									isValid: true,
 									attributes: {
 										content: '',
@@ -1768,7 +1768,7 @@ describe( 'selectors', () => {
 							value: [
 								{
 									clientId: 123,
-									name: 'core/test-freeform',
+									name: 'core/freeform',
 									isValid: true,
 									attributes: {
 										content: '',
@@ -1796,7 +1796,7 @@ describe( 'selectors', () => {
 							value: [
 								{
 									clientId: 123,
-									name: 'core/test-freeform',
+									name: 'core/freeform',
 									isValid: true,
 									attributes: {
 										content: 'Test Data',
@@ -1824,7 +1824,7 @@ describe( 'selectors', () => {
 							value: [
 								{
 									clientId: 123,
-									name: 'core/test-freeform',
+									name: 'core/freeform',
 									isValid: true,
 									attributes: {
 										content: '',
@@ -1832,7 +1832,7 @@ describe( 'selectors', () => {
 								},
 								{
 									clientId: 456,
-									name: 'core/test-freeform',
+									name: 'core/freeform',
 									isValid: true,
 									attributes: {
 										content: '',
@@ -2415,7 +2415,7 @@ describe( 'selectors', () => {
 		} );
 
 		it( "returns removep'd serialization of blocks for single unknown", () => {
-			const unknownBlock = createBlock( 'core/test-freeform', {
+			const unknownBlock = createBlock( 'core/freeform', {
 				content: '<p>foo</p>',
 			} );
 			const state = {
@@ -2437,10 +2437,10 @@ describe( 'selectors', () => {
 		} );
 
 		it( "returns non-removep'd serialization of blocks for multiple unknown", () => {
-			const firstUnknown = createBlock( 'core/test-freeform', {
+			const firstUnknown = createBlock( 'core/freeform', {
 				content: '<p>foo</p>',
 			} );
-			const secondUnknown = createBlock( 'core/test-freeform', {
+			const secondUnknown = createBlock( 'core/freeform', {
 				content: '<p>bar</p>',
 			} );
 			const state = {

--- a/packages/reusable-blocks/src/components/reusable-blocks-menu-items/index.js
+++ b/packages/reusable-blocks/src/components/reusable-blocks-menu-items/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { withSelect } from '@wordpress/data';
+import { useSelect } from '@wordpress/data';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 
 /**
@@ -10,7 +10,12 @@ import { store as blockEditorStore } from '@wordpress/block-editor';
 import ReusableBlockConvertButton from './reusable-block-convert-button';
 import ReusableBlocksManageButton from './reusable-blocks-manage-button';
 
-function ReusableBlocksMenuItems( { clientIds, rootClientId } ) {
+export default function ReusableBlocksMenuItems( { rootClientId } ) {
+	const clientIds = useSelect(
+		( select ) => select( blockEditorStore ).getSelectedBlockClientIds(),
+		[]
+	);
+
 	return (
 		<>
 			<ReusableBlockConvertButton
@@ -23,16 +28,3 @@ function ReusableBlocksMenuItems( { clientIds, rootClientId } ) {
 		</>
 	);
 }
-
-export default withSelect( ( select ) => {
-	const { getSelectedBlockClientIds, getBlockRootClientId } =
-		select( blockEditorStore );
-	const clientIds = getSelectedBlockClientIds();
-	return {
-		clientIds,
-		rootClientId:
-			clientIds?.length > 0
-				? getBlockRootClientId( clientIds[ 0 ] )
-				: undefined,
-	};
-} )( ReusableBlocksMenuItems );

--- a/packages/reusable-blocks/src/components/reusable-blocks-menu-items/reusable-block-convert-button.js
+++ b/packages/reusable-blocks/src/components/reusable-blocks-menu-items/reusable-block-convert-button.js
@@ -51,8 +51,17 @@ export default function ReusableBlockConvertButton( {
 	const canConvert = useSelect(
 		( select ) => {
 			const { canUser } = select( coreStore );
-			const { getBlocksByClientId, canInsertBlockType } =
-				select( blockEditorStore );
+			const {
+				getBlocksByClientId,
+				canInsertBlockType,
+				getBlockRootClientId,
+			} = select( blockEditorStore );
+
+			const rootId =
+				rootClientId ||
+				( clientIds.length > 0
+					? getBlockRootClientId( clientIds[ 0 ] )
+					: undefined );
 
 			const blocks = getBlocksByClientId( clientIds ) ?? [];
 
@@ -70,7 +79,7 @@ export default function ReusableBlockConvertButton( {
 				// Hide when this is already a reusable block.
 				! isReusable &&
 				// Hide when reusable blocks are disabled.
-				canInsertBlockType( 'core/block', rootClientId ) &&
+				canInsertBlockType( 'core/block', rootId ) &&
 				blocks.every(
 					( block ) =>
 						// Guard against the case where a regular block has *just* been converted.

--- a/phpunit/class-gutenberg-rest-navigation-fallback-controller-test.php
+++ b/phpunit/class-gutenberg-rest-navigation-fallback-controller-test.php
@@ -158,6 +158,46 @@ class Gutenberg_REST_Navigation_Fallback_Controller_Test extends WP_Test_REST_Co
 	}
 
 	/**
+	 * Tests that the correct filters are applied to the context parameter.
+	 *
+	 * By default, the REST response for the Posts Controller will not return all fields
+	 * when the context is set to 'embed'. Assert that correct additional fields are added
+	 * to the embedded Navigation Post, when the navigation fallback endpoint
+	 * is called with the `_embed` param.
+	 *
+	 * @covers wp_add_fields_to_navigation_fallback_embeded_links
+	 */
+	public function test_embedded_navigation_post_contains_required_fields() {
+		// First we'll use the navigation fallback to get a link to the navigation endpoint.
+		$request  = new WP_REST_Request( 'GET', '/wp-block-editor/v1/navigation-fallback' );
+		$response = rest_get_server()->dispatch( $request );
+		$links    = $response->get_links();
+
+		// Extract the navigation endpoint URL from the response.
+		$embedded_navigation_href = $links['self'][0]['href'];
+		preg_match( '/\?rest_route=(.*)/', $embedded_navigation_href, $matches );
+		$navigation_endpoint = $matches[1];
+
+		// Fetch the "linked" navigation post from the endpoint, with the context parameter set to 'embed' to simulate fetching embedded links.
+		$request = new WP_REST_Request( 'GET', $navigation_endpoint );
+		$request->set_param( 'context', 'embed' );
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		// Verify that the additional status field is present.
+		$this->assertArrayHasKey( 'status', $data, 'Response title should contain a "status" field.' );
+
+		// Verify that the additional content fields are present.
+		$this->assertArrayHasKey( 'content', $data, 'Response should contain a "content" field.' );
+		$this->assertArrayHasKey( 'raw', $data['content'], 'Response content should contain a "raw" field.' );
+		$this->assertArrayHasKey( 'rendered', $data['content'], 'Response content should contain a "rendered" field.' );
+		$this->assertArrayHasKey( 'block_version', $data['content'], 'Response should contain a "block_version" field.' );
+
+		// Verify that the additional title.raw field is present.
+		$this->assertArrayHasKey( 'raw', $data['title'], 'Response title should contain a "raw" key.' );
+	}
+
+	/**
 	 * @doesNotPerformAssertions
 	 */
 	public function test_context_param() {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Cherry-picks the following PRs into the release branch:

[Global Styles: Don't use named arguments for 'sprintf'](https://github.com/WordPress/gutenberg/pull/52782)  

[Footnotes: Use static closures when not using '$this'](https://github.com/WordPress/gutenberg/pull/52781)  

[Fix toolbar when previewing devices in post editor](https://github.com/WordPress/gutenberg/pull/52770)  

[Allow styles to be changed dynamically through editor settings](https://github.com/WordPress/gutenberg/pull/52767) 

[Navigation: Load the raw property on the navigation fallback](https://github.com/WordPress/gutenberg/pull/52758) (needs wp-develop PR) https://github.com/WordPress/wordpress-develop/pull/4891

[Fix empty general template parts in Patterns](https://github.com/WordPress/gutenberg/pull/52747) 

[Patterns: Add id to pattern inserted notice to stop multiple notices stacking](https://github.com/WordPress/gutenberg/pull/52746) 

[Site Editor: Fix site link accessibility issues](https://github.com/WordPress/gutenberg/pull/52744)  

[Do not navigate to the styles pages unless you're in a random listing page](https://github.com/WordPress/gutenberg/pull/52728) 

[Fix: Block toolbar obscuring document tools when Top Toolbar is enabled](https://github.com/WordPress/gutenberg/pull/52722) 

[Parser / Site Editor: Ensure autop is not run when freeform block is set to core/html](https://github.com/WordPress/gutenberg/pull/52716) 

[Patterns: Don't override the rootClientID in create menu - only set if undefined](https://github.com/WordPress/gutenberg/pull/52713) 

[ResizableFrame: Fix styling in Firefox](https://github.com/WordPress/gutenberg/pull/52700) 

[Footnotes: store in revisions](https://github.com/WordPress/gutenberg/pull/52686) 

[Site Editor Patterns: Filter out patterns that are not available in the inserter](https://github.com/WordPress/gutenberg/pull/52675)

[Password protected field: Remove autofocus and improve placeholder text consistency.](https://github.com/WordPress/gutenberg/pull/52634)
