### PR TITLE
Global styles revisions: display text if no revisions are found

### DIFF
--- a/docs/reference-guides/data/data-core.md
+++ b/docs/reference-guides/data/data-core.md
@@ -136,7 +136,7 @@ _Parameters_
 
 _Returns_
 
--   `Object | null`: The current global styles.
+-   `Array< object > | null`: The current global styles.
 
 ### getCurrentUser
 

--- a/packages/core-data/README.md
+++ b/packages/core-data/README.md
@@ -313,7 +313,7 @@ _Parameters_
 
 _Returns_
 
--   `Object | null`: The current global styles.
+-   `Array< object > | null`: The current global styles.
 
 ### getCurrentUser
 

--- a/packages/core-data/src/selectors.ts
+++ b/packages/core-data/src/selectors.ts
@@ -1266,7 +1266,7 @@ export function getBlockPatternCategories( state: State ): Array< any > {
  */
 export function getCurrentThemeGlobalStylesRevisions(
 	state: State
-): Object | null {
+): Array< object > | null {
 	const currentGlobalStylesId =
 		__experimentalGetCurrentGlobalStylesId( state );
 

--- a/packages/edit-site/src/components/global-styles/screen-revisions/index.js
+++ b/packages/edit-site/src/components/global-styles/screen-revisions/index.js
@@ -7,6 +7,7 @@ import {
 	__experimentalUseNavigator as useNavigator,
 	__experimentalConfirmDialog as ConfirmDialog,
 	Spinner,
+	__experimentalSpacer as Spacer,
 } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useContext, useState, useEffect } from '@wordpress/element';
@@ -89,6 +90,7 @@ function ScreenRevisions() {
 	const isLoadButtonEnabled =
 		!! globalStylesRevision?.id &&
 		! areGlobalStyleConfigsEqual( globalStylesRevision, userConfig );
+	const shouldShowRevisions = ! isLoading && revisions.length;
 
 	return (
 		<>
@@ -101,68 +103,80 @@ function ScreenRevisions() {
 			{ isLoading && (
 				<Spinner className="edit-site-global-styles-screen-revisions__loading" />
 			) }
-			{ ! isLoading && (
-				<Revisions
-					blocks={ blocks }
-					userConfig={ globalStylesRevision }
-					onClose={ onCloseRevisions }
-				/>
-			) }
-			<div className="edit-site-global-styles-screen-revisions">
-				<RevisionsButtons
-					onChange={ selectRevision }
-					selectedRevisionId={ selectedRevisionId }
-					userRevisions={ revisions }
-				/>
-				{ isLoadButtonEnabled && (
-					<SidebarFixedBottom>
-						<Button
-							variant="primary"
-							className="edit-site-global-styles-screen-revisions__button"
-							disabled={
-								! globalStylesRevision?.id ||
-								globalStylesRevision?.id === 'unsaved'
-							}
-							onClick={ () => {
-								if ( hasUnsavedChanges ) {
-									setIsLoadingRevisionWithUnsavedChanges(
-										true
-									);
-								} else {
-									restoreRevision( globalStylesRevision );
-								}
-							} }
-						>
-							{ __( 'Apply' ) }
-						</Button>
-					</SidebarFixedBottom>
-				) }
-			</div>
-			{ isLoadingRevisionWithUnsavedChanges && (
-				<ConfirmDialog
-					title={ __(
-						'Loading this revision will discard all unsaved changes.'
-					) }
-					isOpen={ isLoadingRevisionWithUnsavedChanges }
-					confirmButtonText={ __( ' Discard unsaved changes' ) }
-					onConfirm={ () => restoreRevision( globalStylesRevision ) }
-					onCancel={ () =>
-						setIsLoadingRevisionWithUnsavedChanges( false )
-					}
-				>
-					<>
-						<h2>
-							{ __(
+			{ shouldShowRevisions ? (
+				<>
+					<Revisions
+						blocks={ blocks }
+						userConfig={ globalStylesRevision }
+						onClose={ onCloseRevisions }
+					/>
+					<div className="edit-site-global-styles-screen-revisions">
+						<RevisionsButtons
+							onChange={ selectRevision }
+							selectedRevisionId={ selectedRevisionId }
+							userRevisions={ revisions }
+						/>
+						{ isLoadButtonEnabled && (
+							<SidebarFixedBottom>
+								<Button
+									variant="primary"
+									className="edit-site-global-styles-screen-revisions__button"
+									disabled={
+										! globalStylesRevision?.id ||
+										globalStylesRevision?.id === 'unsaved'
+									}
+									onClick={ () => {
+										if ( hasUnsavedChanges ) {
+											setIsLoadingRevisionWithUnsavedChanges(
+												true
+											);
+										} else {
+											restoreRevision(
+												globalStylesRevision
+											);
+										}
+									} }
+								>
+									{ __( 'Apply' ) }
+								</Button>
+							</SidebarFixedBottom>
+						) }
+					</div>
+					{ isLoadingRevisionWithUnsavedChanges && (
+						<ConfirmDialog
+							title={ __(
 								'Loading this revision will discard all unsaved changes.'
 							) }
-						</h2>
-						<p>
-							{ __(
-								'Do you want to replace your unsaved changes in the editor?'
+							isOpen={ isLoadingRevisionWithUnsavedChanges }
+							confirmButtonText={ __(
+								' Discard unsaved changes'
 							) }
-						</p>
-					</>
-				</ConfirmDialog>
+							onConfirm={ () =>
+								restoreRevision( globalStylesRevision )
+							}
+							onCancel={ () =>
+								setIsLoadingRevisionWithUnsavedChanges( false )
+							}
+						>
+							<>
+								<h2>
+									{ __(
+										'Loading this revision will discard all unsaved changes.'
+									) }
+								</h2>
+								<p>
+									{ __(
+										'Do you want to replace your unsaved changes in the editor?'
+									) }
+								</p>
+							</>
+						</ConfirmDialog>
+					) }
+				</>
+			) : (
+				<Spacer marginX={ 4 } data-testid="global-styles-no-revisions">
+					{ __( 'There are currently no style revisions.' ) }
+				</Spacer>
 			) }
 		</>
 	);

--- a/packages/edit-site/src/components/global-styles/screen-revisions/index.js
+++ b/packages/edit-site/src/components/global-styles/screen-revisions/index.js
@@ -175,7 +175,11 @@ function ScreenRevisions() {
 				</>
 			) : (
 				<Spacer marginX={ 4 } data-testid="global-styles-no-revisions">
-					{ __( 'There are currently no style revisions.' ) }
+					{
+						// Adding an existing translation here in case these changes are shipped to WordPress 6.3.
+						// Later we could update to something better, e.g., "There are currently no style revisions.".
+						__( 'No results found.' )
+					}
 				</Spacer>
 			) }
 		</>

--- a/packages/edit-site/src/components/global-styles/screen-revisions/test/use-global-styles-revisions.js
+++ b/packages/edit-site/src/components/global-styles/screen-revisions/test/use-global-styles-revisions.js
@@ -49,6 +49,7 @@ describe( 'useGlobalStylesRevisions', () => {
 				styles: {},
 			},
 		],
+		isLoadingGlobalStylesRevisions: false,
 	};
 
 	it( 'returns loaded revisions with no unsaved changes', () => {
@@ -117,9 +118,21 @@ describe( 'useGlobalStylesRevisions', () => {
 		const { result } = renderHook( () => useGlobalStylesRevisions() );
 		const { revisions, isLoading, hasUnsavedChanges } = result.current;
 
-		expect( isLoading ).toBe( true );
+		expect( isLoading ).toBe( false );
 		expect( hasUnsavedChanges ).toBe( false );
 		expect( revisions ).toEqual( [] );
+	} );
+
+	it( 'returns loading status when resolving global revisions', () => {
+		useSelect.mockImplementation( () => ( {
+			...selectValue,
+			isLoadingGlobalStylesRevisions: true,
+		} ) );
+
+		const { result } = renderHook( () => useGlobalStylesRevisions() );
+		const { isLoading } = result.current;
+
+		expect( isLoading ).toBe( true );
 	} );
 
 	it( 'returns empty revisions when authors are not yet available', () => {

--- a/test/e2e/specs/site-editor/user-global-styles-revisions.spec.js
+++ b/test/e2e/specs/site-editor/user-global-styles-revisions.spec.js
@@ -22,14 +22,16 @@ test.describe( 'Global styles revisions', () => {
 		await requestUtils.activateTheme( 'twentytwentyone' );
 	} );
 
-	test.beforeEach( async ( { admin, editor } ) => {
+	test.beforeEach( async ( { admin } ) => {
 		await admin.visitSiteEditor();
-		await editor.canvas.click( 'body' );
 	} );
 
 	test( 'should display no revisions message if landing via command center', async ( {
 		page,
 	} ) => {
+		await page
+			.getByRole( 'button', { name: 'Open command palette' } )
+			.focus();
 		await page.keyboard.press( 'Meta+k' );
 		await page.keyboard.type( 'styles revisions' );
 		await page
@@ -45,6 +47,7 @@ test.describe( 'Global styles revisions', () => {
 		editor,
 		userGlobalStylesRevisions,
 	} ) => {
+		await editor.canvas.click( 'body' );
 		const currentRevisions =
 			await userGlobalStylesRevisions.getGlobalStylesRevisions();
 		await userGlobalStylesRevisions.openStylesPanel();
@@ -91,6 +94,7 @@ test.describe( 'Global styles revisions', () => {
 		editor,
 		userGlobalStylesRevisions,
 	} ) => {
+		await editor.canvas.click( 'body' );
 		await userGlobalStylesRevisions.openStylesPanel();
 		await page.getByRole( 'button', { name: 'Colors styles' } ).click();
 		await page

--- a/test/e2e/specs/site-editor/user-global-styles-revisions.spec.js
+++ b/test/e2e/specs/site-editor/user-global-styles-revisions.spec.js
@@ -27,6 +27,19 @@ test.describe( 'Global styles revisions', () => {
 		await editor.canvas.click( 'body' );
 	} );
 
+	test( 'should display no revisions message if landing via command center', async ( {
+		page,
+	} ) => {
+		await page.keyboard.press( 'Meta+k' );
+		await page.keyboard.type( 'styles revisions' );
+		await page
+			.getByRole( 'option', { name: 'Open styles revisions' } )
+			.click();
+		await expect(
+			page.getByTestId( 'global-styles-no-revisions' )
+		).toHaveText( 'There are currently no style revisions.' );
+	} );
+
 	test( 'should display revisions UI when there is more than 1 revision', async ( {
 		page,
 		editor,

--- a/test/e2e/specs/site-editor/user-global-styles-revisions.spec.js
+++ b/test/e2e/specs/site-editor/user-global-styles-revisions.spec.js
@@ -37,7 +37,7 @@ test.describe( 'Global styles revisions', () => {
 			.click();
 		await expect(
 			page.getByTestId( 'global-styles-no-revisions' )
-		).toHaveText( 'There are currently no style revisions.' );
+		).toHaveText( 'No results found.' );
 	} );
 
 	test( 'should display revisions UI when there is more than 1 revision', async ( {


### PR DESCRIPTION
## What?

If somehow a user lands on the revisions panel when there are no revisions, show some helpful text rather than a loading spinner. 

Also, add an E2E test!

## Why?
When testing https://github.com/WordPress/gutenberg/pull/52728 I noticed that the global styles revisions panel will show the loading spinner where there are no revisions. 

This was previously hidden from the UI since one could not open the panel if there were no revisions.

## How?
Using a combination of `isResolving` and `revisions.length` to determine if:

a) A request has been dispatched
b) The response contains revisions

## Testing Instructions

1. Make sure you have no global styles revisions (change to a new block theme or reset your site)
2. Fire up this branch and head over to the site editor `/wp-admin/site-editor.php?canvas=edit`
3. Open the command center (`Cmd/Ctrl-K`) and type in "revisions"
4. Click on "Open styles revisions"
5. If no styles are found, the text "There are currently no style revisions." should display in the panel, instead of a loading spinner 
6. Change a style and save
7. Repeat steps 3-4
8. You should see one revision

## Screenshots

### Before




https://github.com/WordPress/gutenberg/assets/6458278/b753e67a-9e5f-42dd-87e5-2f94cb37c670


### After

https://github.com/WordPress/gutenberg/assets/6458278/5c18651c-e7f0-4c69-91a8-44ff33603983
