### PR TITLE
Distraction Free Keyboard Shortcut: Fix notices in site editor

### DIFF
--- a/packages/edit-site/src/components/keyboard-shortcuts/edit-mode.js
+++ b/packages/edit-site/src/components/keyboard-shortcuts/edit-mode.js
@@ -33,10 +33,8 @@ function KeyboardShortcutsEditMode() {
 	);
 	const { redo, undo } = useDispatch( coreStore );
 	const {
-		isFeatureActive,
 		setIsListViewOpened,
 		switchEditorMode,
-		toggleFeature,
 		setIsInserterOpened,
 		closeGeneralSidebar,
 	} = useDispatch( editSiteStore );
@@ -47,7 +45,8 @@ function KeyboardShortcutsEditMode() {
 	const { getBlockName, getSelectedBlockClientId, getBlockAttributes } =
 		useSelect( blockEditorStore );
 
-	const { set: setPreference } = useDispatch( preferencesStore );
+	const { get: getPreference } = useSelect( preferencesStore );
+	const { set: setPreference, toggle } = useDispatch( preferencesStore );
 	const { createInfoNotice } = useDispatch( noticesStore );
 
 	const toggleDistractionFree = () => {
@@ -135,9 +134,9 @@ function KeyboardShortcutsEditMode() {
 
 	useShortcut( 'core/edit-site/toggle-distraction-free', () => {
 		toggleDistractionFree();
-		toggleFeature( 'distractionFree' );
+		toggle( 'core/edit-site', 'distractionFree' );
 		createInfoNotice(
-			isFeatureActive( 'distractionFree' )
+			getPreference( 'core/edit-site', 'distractionFree' )
 				? __( 'Distraction free mode turned on.' )
 				: __( 'Distraction free mode turned off.' ),
 			{


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Distraction Free mode was added to the site editor in https://github.com/WordPress/gutenberg/pull/51173, so will be part of WP 6.3.

This PR fixes the display of notices when toggling Distraction Free mode via the keyboard shortcut. Currently they are not displayed in the site editor when toggling via keyboard, but they are within the post editor.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Prior to this PR, the notices weren't displaying due to `isFeatureActive` attempting to be accessed from `dispatch`, resulting in `TypeError: isFeatureActive is not a function`.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* Remove `isFeatureActive` and replace with `get` from the preferences store (we could access `isFeatureActive` from the edit-site store via `useSelect`, but the selector has been deprecated, so best to use `get` from the preferences store instead).
* Replace `toggleFeature` from the edit-site store with `toggle` from the preferences store (`toggleFeature` is deprecated so it was throwing a warning)

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Open up the site editor.
2. With focus somewhere in the editor canvas, use the keyboard shortcut for distraction free mode (`CMD+SHIFT+\` on a Mac)
3. Note that with this PR applied, you should see the snackbar notice when toggling distraction free mode via keyboard.

## Screenshots or screencast <!-- if applicable -->

The error and warning:

![image](https://github.com/WordPress/gutenberg/assets/14988353/b18f8e69-b0f3-476d-adee-2dd844721ea8)

| Before | After |
| --- | --- |
| ![2023-07-24 15 30 15](https://github.com/WordPress/gutenberg/assets/14988353/d5320711-d082-43dc-b25e-f9cc37470dda) | ![2023-07-24 15 35 05](https://github.com/WordPress/gutenberg/assets/14988353/451bc845-5aec-4a16-af8e-a0e487a98659) |