### PR TITLE
Check if object exists before accessing its properties.

### DIFF
--- a/packages/block-library/src/footnotes/index.php
+++ b/packages/block-library/src/footnotes/index.php
@@ -109,13 +109,15 @@ add_action( 'wp_after_insert_post', 'wp_save_footnotes_meta' );
  *
  * @since 6.3.0
  *
+ * @global int $wp_temporary_footnote_revision_id The footnote revision ID.
+ *
  * @param int $revision_id The revision ID.
  */
-function wp_keep_revision_id( $revision_id ) {
+function wp_keep_footnotes_revision_id( $revision_id ) {
 	global $wp_temporary_footnote_revision_id;
 	$wp_temporary_footnote_revision_id = $revision_id;
 }
-add_action( '_wp_put_post_revision', 'wp_keep_revision_id' );
+add_action( '_wp_put_post_revision', 'wp_keep_footnotes_revision_id' );
 
 /**
  * This is a specific fix for the REST API. The REST API doesn't update
@@ -134,7 +136,7 @@ add_action( '_wp_put_post_revision', 'wp_keep_revision_id' );
  *
  * @param WP_Post $post The post object.
  */
-function wp_add_revisions_to_post_meta( $post ) {
+function wp_add_footnotes_revisions_to_post_meta( $post ) {
 	global $wp_temporary_footnote_revision_id;
 
 	if ( $wp_temporary_footnote_revision_id ) {
@@ -159,7 +161,7 @@ function wp_add_revisions_to_post_meta( $post ) {
 }
 
 foreach ( array( 'post', 'page' ) as $post_type ) {
-	add_action( "rest_after_insert_{$post_type}", 'wp_add_revisions_to_post_meta' );
+	add_action( "rest_after_insert_{$post_type}", 'wp_add_footnotes_revisions_to_post_meta' );
 }
 
 /**

--- a/packages/block-library/src/footnotes/index.php
+++ b/packages/block-library/src/footnotes/index.php
@@ -83,141 +83,130 @@ function register_block_core_footnotes() {
 }
 add_action( 'init', 'register_block_core_footnotes' );
 
-add_action(
-	'wp_after_insert_post',
-	/**
-	 * Saves the footnotes meta value to the revision.
-	 *
-	 * @since 6.3.0
-	 *
-	 * @param int $revision_id The revision ID.
-	 */
-	static function( $revision_id ) {
-		$post_id = wp_is_post_revision( $revision_id );
+/**
+ * Saves the footnotes meta value to the revision.
+ *
+ * @since 6.3.0
+ *
+ * @param int $revision_id The revision ID.
+ */
+function wp_save_footnotes_meta( $revision_id ) {
+	$post_id = wp_is_post_revision( $revision_id );
 
-		if ( $post_id ) {
+	if ( $post_id ) {
+		$footnotes = get_post_meta( $post_id, 'footnotes', true );
+
+		if ( $footnotes ) {
+			// Can't use update_post_meta() because it doesn't allow revisions.
+			update_metadata( 'post', $revision_id, 'footnotes', $footnotes );
+		}
+	}
+}
+add_action( 'wp_after_insert_post', 'wp_save_footnotes_meta' );
+
+/**
+ * Keeps track of the revision ID for "rest_after_insert_{$post_type}".
+ *
+ * @since 6.3.0
+ *
+ * @param int $revision_id The revision ID.
+ */
+function wp_keep_revision_id( $revision_id ) {
+	global $wp_temporary_footnote_revision_id;
+	$wp_temporary_footnote_revision_id = $revision_id;
+}
+add_action( '_wp_put_post_revision', 'wp_keep_revision_id' );
+
+/**
+ * This is a specific fix for the REST API. The REST API doesn't update
+ * the post and post meta in one go (through `meta_input`). While it
+ * does fix the `wp_after_insert_post` hook to be called correctly after
+ * updating meta, it does NOT fix hooks such as post_updated and
+ * save_post, which are normally also fired after post meta is updated
+ * in `wp_insert_post()`. Unfortunately, `wp_save_post_revision` is
+ * added to the `post_updated` action, which means the meta is not
+ * available at the time, so we have to add it afterwards through the
+ * `"rest_after_insert_{$post_type}"` action.
+ *
+ * @since 6.3.0
+ *
+ * @global int $wp_temporary_footnote_revision_id The footnote revision ID.
+ *
+ * @param WP_Post $post The post object.
+ */
+function wp_add_revisions_to_post_meta( $post ) {
+	global $wp_temporary_footnote_revision_id;
+
+	if ( $wp_temporary_footnote_revision_id ) {
+		$revision = get_post( $wp_temporary_footnote_revision_id );
+
+		if ( ! $revision ) {
+			return;
+		}
+
+		$post_id = $revision->post_parent;
+
+		// Just making sure we're updating the right revision.
+		if ( $post->ID === $post_id ) {
 			$footnotes = get_post_meta( $post_id, 'footnotes', true );
 
 			if ( $footnotes ) {
 				// Can't use update_post_meta() because it doesn't allow revisions.
-				update_metadata( 'post', $revision_id, 'footnotes', $footnotes );
+				update_metadata( 'post', $wp_temporary_footnote_revision_id, 'footnotes', $footnotes );
 			}
 		}
 	}
-);
-
-add_action(
-	'_wp_put_post_revision',
-	/**
-	 * Keeps track of the revision ID for "rest_after_insert_{$post_type}".
-	 *
-	 * @param int $revision_id The revision ID.
-	 */
-	static function( $revision_id ) {
-		global $_gutenberg_revision_id;
-		$_gutenberg_revision_id = $revision_id;
-	}
-);
-
-foreach ( array( 'post', 'page' ) as $post_type ) {
-	add_action(
-		"rest_after_insert_{$post_type}",
-		/**
-		 * This is a specific fix for the REST API. The REST API doesn't update
-		 * the post and post meta in one go (through `meta_input`). While it
-		 * does fix the `wp_after_insert_post` hook to be called correctly after
-		 * updating meta, it does NOT fix hooks such as post_updated and
-		 * save_post, which are normally also fired after post meta is updated
-		 * in `wp_insert_post()`. Unfortunately, `wp_save_post_revision` is
-		 * added to the `post_updated` action, which means the meta is not
-		 * available at the time, so we have to add it afterwards through the
-		 * `"rest_after_insert_{$post_type}"` action.
-		 *
-		 * @since 6.3.0
-		 *
-		 * @param WP_Post $post The post object.
-		 */
-		static function( $post ) {
-			global $_gutenberg_revision_id;
-
-			if ( $_gutenberg_revision_id ) {
-				$revision = get_post( $_gutenberg_revision_id );
-
-				if ( ! $revision ) {
-					return;
-				}
-
-				$post_id = $revision->post_parent;
-
-				// Just making sure we're updating the right revision.
-				if ( $post->ID === $post_id ) {
-					$footnotes = get_post_meta( $post_id, 'footnotes', true );
-
-					if ( $footnotes ) {
-						// Can't use update_post_meta() because it doesn't allow revisions.
-						update_metadata( 'post', $_gutenberg_revision_id, 'footnotes', $footnotes );
-					}
-				}
-			}
-		}
-	);
 }
 
-add_action(
-	'wp_restore_post_revision',
-	/**
-	 * Restores the footnotes meta value from the revision.
-	 *
-	 * @since 6.3.0
-	 *
-	 * @param int $post_id      The post ID.
-	 * @param int $revision_id  The revision ID.
-	 */
-	static function( $post_id, $revision_id ) {
-		$footnotes = get_post_meta( $revision_id, 'footnotes', true );
+foreach ( array( 'post', 'page' ) as $post_type ) {
+	add_action( "rest_after_insert_{$post_type}", 'wp_add_revisions_to_post_meta' );
+}
 
-		if ( $footnotes ) {
-			update_post_meta( $post_id, 'footnotes', $footnotes );
-		} else {
-			delete_post_meta( $post_id, 'footnotes' );
-		}
-	},
-	10,
-	2
-);
+/**
+ * Restores the footnotes meta value from the revision.
+ *
+ * @since 6.3.0
+ *
+ * @param int $post_id     The post ID.
+ * @param int $revision_id The revision ID.
+ */
+function wp_restore_footnotes_from_revision( $post_id, $revision_id ) {
+	$footnotes = get_post_meta( $revision_id, 'footnotes', true );
 
-add_filter(
-	'_wp_post_revision_fields',
-	/**
-	 * Adds the footnotes field to the revision.
-	 *
-	 * @since 6.3.0
-	 *
-	 * @param array $fields The revision fields.
-	 * @return array The revision fields.
-	 */
-	static function( $fields ) {
-		$fields['footnotes'] = __( 'Footnotes' );
-		return $fields;
+	if ( $footnotes ) {
+		update_post_meta( $post_id, 'footnotes', $footnotes );
+	} else {
+		delete_post_meta( $post_id, 'footnotes' );
 	}
-);
+}
+add_action( 'wp_restore_post_revision', 'wp_restore_footnotes_from_revision', 10, 2 );
 
-add_filter(
-	'wp_post_revision_field_footnotes',
-	/**
-	 * Gets the footnotes field from the revision.
-	 *
-	 * @since 6.3.0
-	 *
-	 * @param string $revision_field The field value, but $revision->$field
-	 *                               (footnotes) does not exist.
-	 * @param string $field          The field name, in this case "footnotes".
-	 * @param object $revision       The revision object to compare against.
-	 * @return string The field value.
-	 */
-	static function( $revision_field, $field, $revision ) {
-		return get_metadata( 'post', $revision->ID, $field, true );
-	},
-	10,
-	3
-);
+/**
+ * Adds the footnotes field to the revision.
+ *
+ * @since 6.3.0
+ *
+ * @param array $fields The revision fields.
+ * @return array The revision fields.
+ */
+function wp_add_footnotes_to_revision( $fields ) {
+	$fields['footnotes'] = __( 'Footnotes' );
+	return $fields;
+}
+add_filter( '_wp_post_revision_fields', 'wp_add_footnotes_to_revision' );
+
+/**
+ * Gets the footnotes field from the revision.
+ *
+ * @since 6.3.0
+ *
+ * @param string $revision_field The field value, but $revision->$field
+ *                               (footnotes) does not exist.
+ * @param string $field          The field name, in this case "footnotes".
+ * @param object $revision       The revision object to compare against.
+ * @return string The field value.
+ */
+function wp_get_footnotes_from_revision( $revision_field, $field, $revision ) {
+	return get_metadata( 'post', $revision->ID, $field, true );
+}
+add_filter( 'wp_post_revision_field_footnotes', 'wp_get_footnotes_from_revision', 10, 3 );

--- a/packages/block-library/src/footnotes/index.php
+++ b/packages/block-library/src/footnotes/index.php
@@ -142,7 +142,12 @@ foreach ( array( 'post', 'page' ) as $post_type ) {
 
 			if ( $_gutenberg_revision_id ) {
 				$revision = get_post( $_gutenberg_revision_id );
-				$post_id  = $revision->post_parent;
+
+				if ( ! $revision ) {
+					return;
+				}
+
+				$post_id = $revision->post_parent;
 
 				// Just making sure we're updating the right revision.
 				if ( $post->ID === $post_id ) {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes [PHP test error](https://github.com/WordPress/wordpress-develop/actions/runs/5640501045/job/15277190255?pr=4892) encountered while [updating core](https://github.com/WordPress/wordpress-develop/pull/4892).

Also, based on feedback from the [core patch](https://github.com/WordPress/wordpress-develop/pull/4892) I've changed the anonymous functions to named ones without gutenberg prefixes.

## Testing Instructions

Check revisions still work for footnotes.
