### PR TITLE
Command Palette: Remove double border on results pages.

### DIFF
--- a/packages/commands/src/components/style.scss
+++ b/packages/commands/src/components/style.scss
@@ -115,6 +115,10 @@
 	[cmdk-list-sizer] {
 		position: relative;
 	}
+
+	[cmdk-group]:has([cmdk-group-items]:not(:empty)):not([hidden]) + [cmdk-group]:has([cmdk-group-items]:not(:empty)) {
+		border-top: 1px solid $gray-200;
+	}
 }
 
 .commands-command-menu__item mark {

--- a/packages/commands/src/components/style.scss
+++ b/packages/commands/src/components/style.scss
@@ -115,10 +115,6 @@
 	[cmdk-list-sizer] {
 		position: relative;
 	}
-
-	[cmdk-group]:has([cmdk-group-items]:not(:empty)) + [cmdk-group]:has([cmdk-group-items]:not(:empty)) {
-		border-top: 1px solid $gray-200;
-	}
 }
 
 .commands-command-menu__item mark {

--- a/packages/commands/src/components/style.scss
+++ b/packages/commands/src/components/style.scss
@@ -117,7 +117,7 @@
 	}
 
 	[cmdk-group]:has([cmdk-group-items]:not(:empty)):not([hidden]) + [cmdk-group]:has([cmdk-group-items]:not(:empty)) {
-		border-top: 1px solid $gray-200;
+		border-top: $border-width solid $gray-200;
 	}
 }
 


### PR DESCRIPTION
## What?

When you search the command palette, there's a double border between input and results:

<img width="668" alt="double border before" src="https://github.com/WordPress/gutenberg/assets/1204802/b2fe5ca0-50d0-4955-a4ed-ac9940ef925e">

This PR fixes so the border is consistently a single pixel border:

<img width="705" alt="double border after" src="https://github.com/WordPress/gutenberg/assets/1204802/2cdd8d09-a863-4568-a39c-1fa4398b4b71">

## Testing Instructions

Open the command bar and observe the same separating border between the initially suggested actions, and the input and search results.