### PR TITLE
Navigation: backport Core changes for the navigation fallback

### DIFF
--- a/lib/compat/wordpress-6.3/navigation-fallback.php
+++ b/lib/compat/wordpress-6.3/navigation-fallback.php
@@ -13,28 +13,36 @@
  * Navigation Fallback REST endpoint.
  *
  * The endpoint may embed the full Navigation Menu object into the
- * response as the `self` link. By default the Posts Controller
- * will only exposes a limited subset of fields but the editor requires
- * additional fields to be available in order to utilise the menu.
+ * response as the `self` link. By default, the Posts Controller
+ * will only expose a limited subset of fields but the editor requires
+ * additional fields to be available in order to utilize the menu.
  *
  * @param array $schema the schema for the `wp_navigation` post.
  * @return array the modified schema.
  */
-function gutenberg_add_fields_to_navigation_fallback_embeded_links( $schema ) {
+function gutenberg_add_fields_to_navigation_fallback_embedded_links( $schema ) {
 	// Expose top level fields.
 	$schema['properties']['status']['context']  = array_merge( $schema['properties']['status']['context'], array( 'embed' ) );
 	$schema['properties']['content']['context'] = array_merge( $schema['properties']['content']['context'], array( 'embed' ) );
 
-	// Expose sub properties of content field.
-	// These aren't exposed by the posts controller by default, see:
-	// https://github.com/WordPress/wordpress-develop/blob/5c3c6258e468c67ba00bbd13db29994f1a57a52a/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php#L2425.
+	/*
+	 * Exposes sub properties of content field.
+	 * These sub properties aren't exposed by the posts controller by default,
+	 * for requests where context is `embed`.
+	 *
+	 * @see WP_REST_Posts_Controller::get_item_schema()
+	 */
 	$schema['properties']['content']['properties']['raw']['context']           = array_merge( $schema['properties']['content']['properties']['raw']['context'], array( 'embed' ) );
 	$schema['properties']['content']['properties']['rendered']['context']      = array_merge( $schema['properties']['content']['properties']['rendered']['context'], array( 'embed' ) );
 	$schema['properties']['content']['properties']['block_version']['context'] = array_merge( $schema['properties']['content']['properties']['block_version']['context'], array( 'embed' ) );
 
-	// Expose sub properties of title field.
-	// These aren't exposed by the posts controller by default, see:
-	// https://github.com/WordPress/wordpress-develop/blob/5c3c6258e468c67ba00bbd13db29994f1a57a52a/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php#L2401.
+	/*
+	 * Exposes sub properties of title field.
+	 * These sub properties aren't exposed by the posts controller by default,
+	 * for requests where context is `embed`.
+	 *
+	 * @see WP_REST_Posts_Controller::get_item_schema()
+	 */
 	$schema['properties']['title']['properties']['raw']['context'] = array_merge( $schema['properties']['title']['properties']['raw']['context'], array( 'embed' ) );
 
 	return $schema;
@@ -42,5 +50,5 @@ function gutenberg_add_fields_to_navigation_fallback_embeded_links( $schema ) {
 
 add_filter(
 	'rest_wp_navigation_item_schema',
-	'gutenberg_add_fields_to_navigation_fallback_embeded_links'
+	'gutenberg_add_fields_to_navigation_fallback_embedded_links'
 );

--- a/phpunit/class-gutenberg-rest-navigation-fallback-controller-test.php
+++ b/phpunit/class-gutenberg-rest-navigation-fallback-controller-test.php
@@ -165,7 +165,7 @@ class Gutenberg_REST_Navigation_Fallback_Controller_Test extends WP_Test_REST_Co
 	 * to the embedded Navigation Post, when the navigation fallback endpoint
 	 * is called with the `_embed` param.
 	 *
-	 * @covers wp_add_fields_to_navigation_fallback_embeded_links
+	 * @covers wp_add_fields_to_navigation_fallback_embedded_links
 	 */
 	public function test_embedded_navigation_post_contains_required_fields() {
 		// First we'll use the navigation fallback to get a link to the navigation endpoint.


### PR DESCRIPTION

## What?
Backports changes from:

- https://github.com/WordPress/wordpress-develop/pull/4891

## Why?
Keep things in sync

## How?
Copy paste.

## Testing Instructions
Tests should pass.
