### PR TITLE
Edit site: Add missing label to post status password protected input field

### DIFF
--- a/packages/edit-site/src/components/sidebar-edit-mode/page-panels/page-status.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/page-panels/page-status.js
@@ -11,6 +11,7 @@ import {
 	__experimentalVStack as VStack,
 	TextControl,
 	RadioControl,
+	VisuallyHidden,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useDispatch } from '@wordpress/data';
@@ -18,6 +19,8 @@ import { useState, useMemo } from '@wordpress/element';
 import { store as coreStore } from '@wordpress/core-data';
 import { store as noticesStore } from '@wordpress/notices';
 import { __experimentalInspectorPopoverHeader as InspectorPopoverHeader } from '@wordpress/block-editor';
+import { useInstanceId } from '@wordpress/compose';
+
 /**
  * Internal dependencies
  */
@@ -85,6 +88,7 @@ export default function PageStatus( {
 	date,
 } ) {
 	const [ showPassword, setShowPassword ] = useState( !! password );
+	const instanceId = useInstanceId( PageStatus );
 
 	const { editEntityRecord } = useDispatch( coreStore );
 	const { createErrorNotice } = useDispatch( noticesStore );
@@ -205,18 +209,27 @@ export default function PageStatus( {
 											onChange={ handleTogglePassword }
 										/>
 										{ showPassword && (
-											<TextControl
-												onChange={ ( value ) =>
-													saveStatus( {
-														password: value,
-													} )
-												}
-												value={ password }
-												placeholder={ __(
-													'Use a secure password'
-												) }
-												type="text"
-											/>
+											<div className="edit-site-change-status__password-input">
+												<VisuallyHidden
+													as="label"
+													htmlFor={ `edit-site-change-status__password-input-${ instanceId }` }
+												>
+													{ __( 'Create password' ) }
+												</VisuallyHidden>
+												<TextControl
+													onChange={ ( value ) =>
+														saveStatus( {
+															password: value,
+														} )
+													}
+													value={ password }
+													placeholder={ __(
+														'Use a secure password'
+													) }
+													type="text"
+													id={ `edit-site-change-status__password-input-${ instanceId }` }
+												/>
+											</div>
 										) }
 									</BaseControl>
 								) }

--- a/packages/edit-site/src/components/sidebar-edit-mode/page-panels/page-status.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/page-panels/page-status.js
@@ -3,7 +3,6 @@
  */
 import {
 	Button,
-	BaseControl,
 	ToggleControl,
 	Dropdown,
 	__experimentalText as Text,
@@ -197,10 +196,17 @@ export default function PageStatus( {
 									selected={ status }
 								/>
 								{ status !== 'private' && (
-									<BaseControl
-										id={ `edit-site-change-status__password` }
-										label={ __( 'Password' ) }
-									>
+									<fieldset className="edit-site-change-status__password-fieldset">
+										<Text
+											as="legend"
+											className="edit-site-change-status__password-legend"
+											size="11"
+											lineHeight={ 1.4 }
+											weight={ 500 }
+											upperCase={ true }
+										>
+											{ __( 'Password' ) }
+										</Text>
 										<ToggleControl
 											label={ __(
 												'Hide this page behind a password'
@@ -231,7 +237,7 @@ export default function PageStatus( {
 												/>
 											</div>
 										) }
-									</BaseControl>
+									</fieldset>
 								) }
 							</VStack>
 						</form>

--- a/packages/edit-site/src/components/sidebar-edit-mode/page-panels/style.scss
+++ b/packages/edit-site/src/components/sidebar-edit-mode/page-panels/style.scss
@@ -14,10 +14,12 @@
 		min-width: 320px;
 		padding: $grid-unit-20;
 	}
+
 	.edit-site-change-status__options {
 		.components-base-control__field > .components-v-stack {
 			gap: $grid-unit-10;
 		}
+
 		label {
 			.components-text {
 				display: block;
@@ -25,15 +27,22 @@
 			}
 		}
 	}
+
+	.edit-site-change-status__password-legend {
+		padding: 0;
+		margin-bottom: $grid-unit-10;
+	}
 }
 
 .edit-site-summary-field {
 	.components-dropdown {
 		flex-grow: 1;
 	}
+
 	.edit-site-summary-field__trigger {
 		width: 100%;
 	}
+
 	.edit-site-summary-field__label {
 		width: 30%;
 	}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Follow-up to https://github.com/WordPress/gutenberg/pull/52634

In #52634 I missed that the password protected input field missies a properly associated label. 
Additionally, the visible all caps text `PASSWORD` is actually a stray label element that is not associated with any input. That's invalid HTML and also an a11y issue.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The actual labeling of this field is currently given only by its placeholder text, which is the last fallback in the accessible name computation. That's not great. Also, for consistency with the very similar input field in the post editor, labeling and semantics should be consistent.
Regarding the visible all caps text `PASSWORD`, that should not be a label element. It can be a fieldset legend so that the toggle and the input are grouped in a named group.


## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Adds a missing label for the password protected input field.
Removes a wrong usage of the `BaseControl` component that was rendering a stray label element Replaced with a fieldset and legend elements.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
- On current trunk:
- Go to the Site editor > Pages > Any page
- In the Settings panel, click Status to open the status popover.
- Observe the visible all caps text `PASSWORD` is a stray label element:
  - It is not associated with any input.
  - It is clickable like all label elements but clicking it doesn't do anything.
- Reveal the password protected input field by clicking the related toggle.
- Observe the password protected input field doesn't have any associated label element.
- Switch to this branch and re-inspect the elements above.
- Observe the visible all caps text `PASSWORD` is now a legend element within a fieldset element.
- Observe there are no relevant visual differences with the previous stray label.
- Observe the password protected input field has now a visually hidden associated label element.



### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<img width="376" alt="Screenshot 2023-07-24 at 12 11 13" src="https://github.com/WordPress/gutenberg/assets/1682452/266824f9-1c6c-4476-8c21-75f279bfdc27">

