### PR TITLE
Site Editor: Fix the template parts link on the list page

### DIFF
--- a/packages/edit-site/src/components/page-template-parts/index.js
+++ b/packages/edit-site/src/components/page-template-parts/index.js
@@ -39,7 +39,7 @@ export default function PageTemplateParts() {
 							params={ {
 								postId: templatePart.id,
 								postType: templatePart.type,
-								canvas: 'view',
+								canvas: 'edit',
 							} }
 							state={ { backPath: '/wp_template_part/all' } }
 						>


### PR DESCRIPTION
## What?
PR updates the template parts link on the list page to open the record in edit mode. This matches the behavior in the `PageTemplates` component.

## Why?
I was working on #52884 and noticed the regression.

## Testing Instructions
1. Open the Site Editor.
2. Go to the "Manage all template parts" screen.
3. Click on the template part link.
4. Confirm it opens in the edit mode.

