### PR TITLE
Template Part Block: Use `get_block_file_template` for rendering

### DIFF
--- a/packages/block-library/src/template-part/index.php
+++ b/packages/block-library/src/template-part/index.php
@@ -67,14 +67,11 @@ function render_block_core_template_part( $attributes ) {
 			// Else, if the template part was provided by the active theme,
 			// render the corresponding file content.
 			if ( 0 === validate_file( $attributes['slug'] ) ) {
-				$block_template_file = _get_block_template_file( 'wp_template_part', $attributes['slug'] );
-				if ( $block_template_file ) {
-					$template_part_file_path = $block_template_file['path'];
-					$content                 = (string) file_get_contents( $template_part_file_path );
-					$content                 = '' !== $content ? _inject_theme_attribute_in_block_template_content( $content ) : '';
-					if ( isset( $block_template_file['area'] ) ) {
-						$area = $block_template_file['area'];
-					}
+				$block_template = get_block_file_template( $template_part_id, 'wp_template_part' );
+
+				$content = $block_template->content;
+				if ( isset( $block_template->area ) ) {
+					$area = $block_template->area;
 				}
 			}
 


### PR DESCRIPTION
## What?
Change the Template Part block's render method (`render_block_core_template_part`) to use `get_block_file_template` rather than a number of lower-level functions.

## Why?
Higher-level functions such as [`get_block_file_template`](https://developer.wordpress.org/reference/functions/get_block_file_template/) apply filters (such as the eponymous [`get_block_file_template`](https://developer.wordpress.org/reference/hooks/get_block_file_template/)) that otherwise aren't invoked. (This is relevant e.g. for https://github.com/WordPress/gutenberg/pull/51449.)

Furthermore, it can be argued that if a high-level function is available to what otherwise requires calling a number of lower-level functions, it's preferable to use the high-level function (unless there are side effects and/or performance issues, of course) 😄 

## How?
By using `get_block_file_template` (which returns a `WP_Block_Template` object) in the code branch that loads a block template from a theme file, thus supplanting calls to the lower-level `_get_block_template_file` and `_inject_theme_attribute_in_block_template_content` functions.

Note that [`get_block_file_template` invokes both of them in its function body](https://github.com/WordPress/wordpress-develop/blob/20806d4d7fed387f26deb134085f59e91ee66364/src/wp-includes/block-template-utils.php#L1121-L1181). (`_inject_theme_attribute_in_block_template_content` [is called](https://github.com/WordPress/wordpress-develop/blob/20806d4d7fed387f26deb134085f59e91ee66364/src/wp-includes/block-template-utils.php#L560) via [`_build_block_template_result_from_file`](https://github.com/WordPress/wordpress-develop/blob/20806d4d7fed387f26deb134085f59e91ee66364/src/wp-includes/block-template-utils.php#L541-L585)).

## Testing Instructions
Verify that Template Parts still work as before:
- On the frontend, with an unmodified block theme;
- In the editor -- loading, modifying, and saving;
- On the frontend, with modifications to the template part.
