### PR TITLE
Update the `block.json` schema to include Behavior supports

### DIFF
--- a/schemas/json/block.json
+++ b/schemas/json/block.json
@@ -259,6 +259,7 @@
 					"default": false
 				},
 				"behaviors": {
+					"type": "object",
 					"description": "Behaviors are a way to add additional functionality to a block. They are defined as an object with a name and a set of properties. Curently, only one behavior is supported: lightbox.",
 					"additionalProperties": false,
 					"properties": {

--- a/schemas/json/block.json
+++ b/schemas/json/block.json
@@ -258,6 +258,17 @@
 					"description": "ARIA-labels let you define an accessible label for elements. This property allows enabling the definition of an aria-label for the block, without exposing a UI field.",
 					"default": false
 				},
+				"behaviors": {
+					"description": "Behaviors are a way to add additional functionality to a block. They are defined as an object with a name and a set of properties. Curently, only one behavior is supported: lightbox.",
+					"additionalProperties": false,
+					"properties": {
+						"lightbox": {
+							"type": "boolean",
+							"description": "This property adds a 'lightbox' behavior to the block. It allows to open the block's content in a lightbox when clicking on it.",
+							"default": false
+						}
+					}
+				},
 				"className": {
 					"type": "boolean",
 					"description": "By default, the class .wp-block-your-block-name is added to the root element of your saved markup. This helps having a consistent mechanism for styling blocks that themes and plugins can rely on. If, for whatever reason, a class is not desired on the markup, this functionality can be disabled.",


### PR DESCRIPTION
Updates the schema for `block.json` files to include `"supports": { "behaviors": "lightbox" }`

Follow-up to https://github.com/WordPress/gutenberg/pull/51156

https://github.com/WordPress/gutenberg/assets/5417266/e3eede48-028f-4ae4-8731-d253829e6ae7

