### PR TITLE
Footnotes: Add link, background and text color support

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -275,7 +275,7 @@ Add a link to a downloadable file. ([Source](https://github.com/WordPress/gutenb
 
 -	**Name:** core/footnotes
 -	**Category:** text
--	**Supports:** ~~html~~, ~~multiple~~, ~~reusable~~
+-	**Supports:** color (background, link, text), ~~html~~, ~~multiple~~, ~~reusable~~
 -	**Attributes:** 
 
 ## Classic

--- a/packages/block-library/src/footnotes/block.json
+++ b/packages/block-library/src/footnotes/block.json
@@ -9,6 +9,13 @@
 	"textdomain": "default",
 	"usesContext": [ "postId", "postType" ],
 	"supports": {
+		"color": {
+			"link": true,
+			"__experimentalDefaultControls": {
+				"background": true,
+				"text": true
+			}
+		},
 		"html": false,
 		"multiple": false,
 		"reusable": false


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
This adds link, background and text color support to the Footnotes block.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Closes https://github.com/WordPress/gutenberg/issues/51991.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Updates the Footnotes block.json file so that it includes `supports.color.link`, and also sets `__experimentalDefaultControls.background` and `__experimentalDefaultControls.text` to true.

I added the `__experimentalDefaultControls` settings so that the three color controls had the same configuration as the paragraph block, where `background` and `text` are shown by default, and the user needs to click into the Color Options menu to find the `link` controls:

<img width="280" alt="image" src="https://github.com/WordPress/gutenberg/assets/1645628/7be74e0e-7c6e-4d30-8206-365006104ed1">

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
1. Open the Post Editor
2. Add some text
3. Highlight some text, use the drop down menu in the block toolbar to add a footnote
4. Open block settings for the footnote and set a link color
5. The footnote arrow color should update to the correct color

## Screenshots or screencast <!-- if applicable -->
<img width="1433" alt="image" src="https://github.com/WordPress/gutenberg/assets/1645628/bc7f57b7-f641-44bc-9adc-ce12c346be4e">
