### PR TITLE
Navigation Sidebar: Fetch the blocks from the content when trying to load navigations

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen-pattern/use-navigation-menu-content.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-pattern/use-navigation-menu-content.js
@@ -60,7 +60,7 @@ export default function useNavigationMenuContent( postType, postId ) {
 	}
 
 	const blocks =
-		record && record.content && typeof record.content !== 'function'
+		record?.content && typeof record.content !== 'function'
 			? parse( record.content )
 			: [];
 

--- a/packages/edit-site/src/components/sidebar-navigation-screen-pattern/use-navigation-menu-content.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-pattern/use-navigation-menu-content.js
@@ -52,17 +52,17 @@ function getBlocksOfTypeFromBlocks( targetBlockType, blocks ) {
 export default function useNavigationMenuContent( postType, postId ) {
 	const { record } = useEditedEntityRecord( postType, postId );
 
-	const blocks =
-		record && record.content && typeof record.content !== 'function'
-			? parse( record.content )
-			: [];
-
 	// Only managing navigation menus in template parts is supported
 	// to match previous behaviour. This could potentially be expanded
 	// to patterns as well.
 	if ( postType !== 'wp_template_part' ) {
 		return;
 	}
+
+	const blocks =
+		record && record.content && typeof record.content !== 'function'
+			? parse( record.content )
+			: [];
 
 	const navigationBlocks = getBlocksOfTypeFromBlocks(
 		'core/navigation',

--- a/packages/edit-site/src/components/sidebar-navigation-screen-pattern/use-navigation-menu-content.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-pattern/use-navigation-menu-content.js
@@ -1,4 +1,9 @@
 /**
+ * WordPress dependencies
+ */
+import { parse } from '@wordpress/blocks';
+
+/**
  * Internal dependencies
  */
 import TemplatePartNavigationMenus from './template-part-navigation-menus';
@@ -47,6 +52,11 @@ function getBlocksOfTypeFromBlocks( targetBlockType, blocks ) {
 export default function useNavigationMenuContent( postType, postId ) {
 	const { record } = useEditedEntityRecord( postType, postId );
 
+	const blocks =
+		record && record.content && typeof record.content !== 'function'
+			? parse( record.content )
+			: [];
+
 	// Only managing navigation menus in template parts is supported
 	// to match previous behaviour. This could potentially be expanded
 	// to patterns as well.
@@ -56,7 +66,7 @@ export default function useNavigationMenuContent( postType, postId ) {
 
 	const navigationBlocks = getBlocksOfTypeFromBlocks(
 		'core/navigation',
-		record?.blocks
+		blocks
 	);
 
 	if ( ! navigationBlocks.length ) {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Updates the way we load navigations from the entity, so that we create blocks which can be used to display the navigation in the sidebar.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
This worked, but was broken by https://github.com/WordPress/gutenberg/pull/52417. The problem seems to be that we were relying on the blocks property, which isn't always present.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Instead of relying on `block`, we can just generate them from content, using `parse`.

## Testing Instructions
1. Open the Site Editor
2. Open a template part that contains a navigation
3. Check that the navigation appears in the sidebar

## Screenshots or screencast <!-- if applicable -->
<img width="1512" alt="Screenshot 2023-07-25 at 00 26 26" src="https://github.com/WordPress/gutenberg/assets/275961/26d8c047-62d1-4f80-9d27-9dacc5f25f6b">
