### PR TITLE
Fix: #52886 Make all the 'Loading' strings consistent

### DIFF
--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -610,7 +610,7 @@ function GalleryEdit( props ) {
 							</BaseControl.VisualLabel>
 							<View className={ 'gallery-image-sizes__loading' }>
 								<Spinner />
-								{ __( 'Loading…' ) }
+								{ __( 'Loading options…' ) }
 							</View>
 						</BaseControl>
 					) }

--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -610,7 +610,7 @@ function GalleryEdit( props ) {
 							</BaseControl.VisualLabel>
 							<View className={ 'gallery-image-sizes__loading' }>
 								<Spinner />
-								{ __( 'Loading options…' ) }
+								{ __( 'Loading…' ) }
 							</View>
 						</BaseControl>
 					) }

--- a/packages/block-library/src/navigation/edit/navigation-menu-selector.js
+++ b/packages/block-library/src/navigation/edit/navigation-menu-selector.js
@@ -96,7 +96,7 @@ function NavigationMenuSelector( {
 	let selectorLabel = '';
 
 	if ( isCreatingMenu || isResolvingNavigationMenus ) {
-		selectorLabel = __( 'Loading …' );
+		selectorLabel = __( 'Loading…' );
 	} else if ( noMenuSelected || noBlockMenus || menuUnavailable ) {
 		// Note: classic Menus may be available.
 		selectorLabel = __( 'Choose or create a Navigation menu' );

--- a/packages/block-library/src/navigation/edit/placeholder/index.js
+++ b/packages/block-library/src/navigation/edit/placeholder/index.js
@@ -32,7 +32,7 @@ export default function NavigationPlaceholder( {
 		}
 
 		if ( isResolvingMenus ) {
-			speak( __( 'Loading…' ) );
+			speak( __( 'Loading navigation block setup options…' ) );
 		}
 
 		if ( hasResolvedMenus ) {

--- a/packages/block-library/src/navigation/edit/placeholder/index.js
+++ b/packages/block-library/src/navigation/edit/placeholder/index.js
@@ -32,7 +32,7 @@ export default function NavigationPlaceholder( {
 		}
 
 		if ( isResolvingMenus ) {
-			speak( __( 'Loading Navigation block setup options.' ) );
+			speak( __( 'Loading…' ) );
 		}
 
 		if ( hasResolvedMenus ) {

--- a/packages/edit-site/src/components/sidebar-navigation-screen-pages/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-pages/index.js
@@ -152,7 +152,7 @@ export default function SidebarNavigationScreenPages() {
 					<>
 						{ ( isLoadingPages || isLoadingTemplates ) && (
 							<ItemGroup>
-								<Item>{ __( 'Loading pages' ) }</Item>
+								<Item>{ __( 'Loading…' ) }</Item>
 							</ItemGroup>
 						) }
 						{ ! ( isLoadingPages || isLoadingTemplates ) && (

--- a/packages/edit-site/src/components/sidebar-navigation-screen-pages/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-pages/index.js
@@ -152,7 +152,7 @@ export default function SidebarNavigationScreenPages() {
 					<>
 						{ ( isLoadingPages || isLoadingTemplates ) && (
 							<ItemGroup>
-								<Item>{ __( 'Loading…' ) }</Item>
+								<Item>{ __( 'Loading pages…' ) }</Item>
 							</ItemGroup>
 						) }
 						{ ! ( isLoadingPages || isLoadingTemplates ) && (

--- a/packages/edit-site/src/components/sidebar-navigation-screen-patterns/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-patterns/index.js
@@ -140,7 +140,7 @@ export default function SidebarNavigationScreenPatterns() {
 			footer={ footer }
 			content={
 				<>
-					{ isLoading && __( 'Loading patterns' ) }
+					{ isLoading && __( 'Loading…' ) }
 					{ ! isLoading && (
 						<>
 							{ ! hasTemplateParts && ! hasPatterns && (

--- a/packages/edit-site/src/components/sidebar-navigation-screen-patterns/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-patterns/index.js
@@ -140,7 +140,7 @@ export default function SidebarNavigationScreenPatterns() {
 			footer={ footer }
 			content={
 				<>
-					{ isLoading && __( 'Loading…' ) }
+					{ isLoading && __( 'Loading patterns…' ) }
 					{ ! isLoading && (
 						<>
 							{ ! hasTemplateParts && ! hasPatterns && (

--- a/packages/edit-site/src/components/sidebar-navigation-screen-templates/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-templates/index.js
@@ -71,7 +71,7 @@ export default function SidebarNavigationScreenTemplates() {
 			}
 			content={
 				<>
-					{ isLoading && __( 'Loading templates' ) }
+					{ isLoading && __( 'Loading…' ) }
 					{ ! isLoading && (
 						<ItemGroup>
 							{ ! templates?.length && (

--- a/packages/edit-site/src/components/sidebar-navigation-screen-templates/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-templates/index.js
@@ -71,7 +71,7 @@ export default function SidebarNavigationScreenTemplates() {
 			}
 			content={
 				<>
-					{ isLoading && __( 'Loading…' ) }
+					{ isLoading && __( 'Loading templates…' ) }
 					{ ! isLoading && (
 						<ItemGroup>
 							{ ! templates?.length && (


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Making all the 'Loading' strings consistent

## Why?
Making the Loading strings consistent adds to the UI. Here I am fixing #52886 issue which will improve the overall user experience.

## How?
I have changed the strings that were not consistent. I have added an ellipsis at the end of every 'Loading' string.

## Testing Instructions
1. Open any page where  loading pops up
2. Observe the 'Loading' strings

### Testing Instructions for Keyboard
N/A.

## Screenshots or screencast
N/A
