### PR TITLE
Site Editor: Remove unnecessary hook from 'PageTemplates'

### DIFF
--- a/packages/edit-site/src/components/page-templates/index.js
+++ b/packages/edit-site/src/components/page-templates/index.js
@@ -8,8 +8,7 @@ import {
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { useSelect } from '@wordpress/data';
-import { store as coreStore, useEntityRecords } from '@wordpress/core-data';
+import { useEntityRecords } from '@wordpress/core-data';
 import { decodeEntities } from '@wordpress/html-entities';
 
 /**
@@ -21,7 +20,6 @@ import Link from '../routes/link';
 import AddedBy from '../list/added-by';
 import TemplateActions from '../template-actions';
 import AddNewTemplate from '../add-new-template';
-import { store as editSiteStore } from '../../store';
 
 export default function PageTemplates() {
 	const { records: templates } = useEntityRecords(
@@ -31,15 +29,6 @@ export default function PageTemplates() {
 			per_page: -1,
 		}
 	);
-
-	const { canCreate } = useSelect( ( select ) => {
-		const { supportsTemplatePartsMode } =
-			select( editSiteStore ).getSettings();
-		return {
-			postType: select( coreStore ).getPostType( 'wp_template' ),
-			canCreate: ! supportsTemplatePartsMode,
-		};
-	} );
 
 	const columns = [
 		{
@@ -89,13 +78,11 @@ export default function PageTemplates() {
 		<Page
 			title={ __( 'Templates' ) }
 			actions={
-				canCreate && (
-					<AddNewTemplate
-						templateType={ 'wp_template' }
-						showIcon={ false }
-						toggleProps={ { variant: 'primary' } }
-					/>
-				)
+				<AddNewTemplate
+					templateType={ 'wp_template' }
+					showIcon={ false }
+					toggleProps={ { variant: 'primary' } }
+				/>
 			}
 		>
 			{ templates && <Table data={ templates } columns={ columns } /> }


### PR DESCRIPTION
## What?
PR removes the unnecessary `useSelect` hook from `PageTemplates`.

## Why?
The `supportsTemplatePartsMode` is only needed for the template parts list page, and the `postType` value wasn't used.

## Testing Instructions
1. Go to `wp-admin/site-editor.php?path=/wp_template/all`.
2. Confirm it loads as before and that the "Add New Template" button is still displayed.

## Screenshots or screencast <!-- if applicable -->

![CleanShot 2023-07-24 at 23 11 06](https://github.com/WordPress/gutenberg/assets/240569/b705b4cc-9b1d-4621-ade1-eef0eb81a924)
