### PR TITLE
Add taxonomy attributes to categories block #51388

### DIFF
--- a/packages/block-library/src/categories/block.json
+++ b/packages/block-library/src/categories/block.json
@@ -26,6 +26,10 @@
 		"showEmpty": {
 			"type": "boolean",
 			"default": false
+		},
+		"taxonomy": {
+			"type": "string",
+			"default": "category"
 		}
 	},
 	"supports": {

--- a/packages/block-library/src/categories/index.php
+++ b/packages/block-library/src/categories/index.php
@@ -19,6 +19,7 @@ function render_block_core_categories( $attributes ) {
 	$args = array(
 		'echo'         => false,
 		'hierarchical' => ! empty( $attributes['showHierarchy'] ),
+		'taxonomy'     => $attributes['taxonomy'],
 		'orderby'      => 'name',
 		'show_count'   => ! empty( $attributes['showPostCounts'] ),
 		'title_li'     => '',


### PR DESCRIPTION
## What?
Fix https://github.com/WordPress/gutenberg/issues/51388

## Why?
Make it possible to create taxonomy variations.

## How?
Simply add a taxonmy attribute