### PR TITLE
Disambiguate "Import" button string.

### DIFF
--- a/packages/block-library/src/template-part/edit/import-controls.js
+++ b/packages/block-library/src/template-part/edit/import-controls.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __, sprintf } from '@wordpress/i18n';
+import { __, _x, sprintf } from '@wordpress/i18n';
 import { useMemo, useState } from '@wordpress/element';
 import { useDispatch, useSelect, useRegistry } from '@wordpress/data';
 import {

--- a/packages/block-library/src/template-part/edit/import-controls.js
+++ b/packages/block-library/src/template-part/edit/import-controls.js
@@ -163,7 +163,7 @@ export function TemplatePartImportControls( { area, setAttributes } ) {
 						isBusy={ isBusy }
 						aria-disabled={ isBusy || ! selectedSidebar }
 					>
-						{ __( 'Import' ) }
+						{ _x( 'Import', 'button label' ) }
 					</Button>
 				</FlexItem>
 			</HStack>


### PR DESCRIPTION
## What?
This helps disambiguate the string used for the "Import" button (it is already used for another string in Core, but we need a different translation in some Locales) and also brings consistency with [this other Gutenberg string](https://github.com/WordPress/gutenberg/blob/b2309e8207ee048b0e0e0be272a114501ba6c776/packages/list-reusable-blocks/src/components/import-form/index.js#L93).

This fixes this Core Trac ticket: https://core.trac.wordpress.org/ticket/58864