### PR TITLE
Sidebar: Restore Back buton 'go to parent' functionality

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/leaf-more-menu.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/leaf-more-menu.js
@@ -23,10 +23,12 @@ import {
 	currentlyPreviewingTheme,
 } from '../../utils/is-previewing-theme';
 import { unlock } from '../../lock-unlock';
+import { getPathFromURL } from '../sync-state-with-url/use-sync-path-with-url';
 
-const { useHistory } = unlock( routerPrivateApis );
+const { useLocation, useHistory } = unlock( routerPrivateApis );
 
 export default function LeafMoreMenu( props ) {
+	const location = useLocation();
 	const history = useHistory();
 	const { block } = props;
 	const { clientId } = block;
@@ -63,22 +65,32 @@ export default function LeafMoreMenu( props ) {
 				attributes.type &&
 				history
 			) {
-				history.push( {
-					postType: attributes.type,
-					postId: attributes.id,
-					...( isPreviewingTheme() && {
-						wp_theme_preview: currentlyPreviewingTheme(),
-					} ),
-				} );
+				history.push(
+					{
+						postType: attributes.type,
+						postId: attributes.id,
+						...( isPreviewingTheme() && {
+							wp_theme_preview: currentlyPreviewingTheme(),
+						} ),
+					},
+					{
+						backPath: getPathFromURL( location.params ),
+					}
+				);
 			}
 			if ( name === 'core/page-list-item' && attributes.id && history ) {
-				history.push( {
-					postType: 'page',
-					postId: attributes.id,
-					...( isPreviewingTheme() && {
-						wp_theme_preview: currentlyPreviewingTheme(),
-					} ),
-				} );
+				history.push(
+					{
+						postType: 'page',
+						postId: attributes.id,
+						...( isPreviewingTheme() && {
+							wp_theme_preview: currentlyPreviewingTheme(),
+						} ),
+					},
+					{
+						backPath: getPathFromURL( location.params ),
+					}
+				);
 			}
 		},
 		[ history ]

--- a/packages/edit-site/src/components/sidebar-navigation-screen-pages/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-pages/index.js
@@ -28,10 +28,15 @@ import { unlock } from '../../lock-unlock';
 const { useHistory } = unlock( routerPrivateApis );
 
 const PageItem = ( { postType = 'page', postId, ...props } ) => {
-	const linkInfo = useLink( {
-		postType,
-		postId,
-	} );
+	const linkInfo = useLink(
+		{
+			postType,
+			postId,
+		},
+		{
+			backPath: '/page',
+		}
+	);
 	return <SidebarNavigationItem { ...linkInfo } { ...props } />;
 };
 

--- a/packages/edit-site/src/components/sidebar-navigation-screen/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen/index.js
@@ -11,6 +11,7 @@ import { isRTL, __, sprintf } from '@wordpress/i18n';
 import { chevronRight, chevronLeft } from '@wordpress/icons';
 import { store as coreStore } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
+import { privateApis as routerPrivateApis } from '@wordpress/router';
 
 /**
  * Internal dependencies
@@ -23,6 +24,8 @@ import {
 	currentlyPreviewingTheme,
 } from '../../utils/is-previewing-theme';
 
+const { useLocation } = unlock( routerPrivateApis );
+
 export default function SidebarNavigationScreen( {
 	isRoot,
 	title,
@@ -31,7 +34,7 @@ export default function SidebarNavigationScreen( {
 	content,
 	footer,
 	description,
-	backPath,
+	backPath: backPathProp,
 } ) {
 	const { dashboardLink } = useSelect( ( select ) => {
 		const { getSettings } = unlock( select( editSiteStore ) );
@@ -40,6 +43,7 @@ export default function SidebarNavigationScreen( {
 		};
 	}, [] );
 	const { getTheme } = useSelect( coreStore );
+	const location = useLocation();
 	const navigator = useNavigator();
 	const theme = getTheme( currentlyPreviewingTheme() );
 	const icon = isRTL() ? chevronRight : chevronLeft;
@@ -56,25 +60,19 @@ export default function SidebarNavigationScreen( {
 					alignment="flex-start"
 					className="edit-site-sidebar-navigation-screen__title-icon"
 				>
-					{ ! isRoot && ! backPath && (
+					{ ! isRoot && (
 						<SidebarButton
 							onClick={ () => {
-								if ( navigator.location.isInitial ) {
-									navigator.goToParent( { replace: true } );
+								const backPath =
+									backPathProp ?? location.state?.backPath;
+								if ( backPath ) {
+									navigator.goTo( backPath, {
+										isBack: true,
+									} );
 								} else {
-									navigator.goBack();
+									navigator.goToParent();
 								}
 							} }
-							icon={ icon }
-							label={ __( 'Back' ) }
-							showTooltip={ false }
-						/>
-					) }
-					{ ! isRoot && backPath && (
-						<SidebarButton
-							onClick={ () =>
-								navigator.goTo( backPath, { isBack: true } )
-							}
 							icon={ icon }
 							label={ __( 'Back' ) }
 							showTooltip={ false }


### PR DESCRIPTION
## What?
Fixes https://github.com/WordPress/gutenberg/issues/52665. Fixes https://github.com/WordPress/gutenberg/issues/52761.

Reverts the key change in https://github.com/WordPress/gutenberg/pull/52456 so that the back button will again "go to parent" instead of "go back".

## Why?
In https://github.com/WordPress/gutenberg/pull/52456 I attempted to fix https://github.com/WordPress/gutenberg/issues/50676 by making the back button consistently "go back" (to the previously viewed page) instead of "go to parent".

Unfortunately though this behaviour interacts poorly with the command centre. See https://github.com/WordPress/gutenberg/issues/52665 and https://github.com/WordPress/gutenberg/issues/52761.

## How?
This PR reverts the key change in https://github.com/WordPress/gutenberg/pull/52456 which is calling `navigator.goBack()` instead of `navigator.goToParent()` when the back button is clicked.

I did not revert any of the other changes in https://github.com/WordPress/gutenberg/pull/52456 which improve the stability of `useSyncPathWithURL` and make the `Navigator` API more consistent. I think they make sense to have regardless of what the back button does.

Additionally, this PR contains an alternative fix for the original issue https://github.com/WordPress/gutenberg/issues/50676. We store a `backPath` string in React History's `state` when calling `goTo`. This is an object that can hold arbitrary data associated with the new location. Then, when pressing back, we then navigate back to the stored `backPath` if it exists.

It's an approach we take elsewhere:

https://github.com/WordPress/gutenberg/blob/b2309e8207ee048b0e0e0be272a114501ba6c776/packages/edit-site/src/components/page-template-parts/index.js#L44

https://github.com/WordPress/gutenberg/blob/b2309e8207ee048b0e0e0be272a114501ba6c776/packages/edit-site/src/components/page-patterns/patterns-list.js#L128-L130

It's not the most elegant fix. I'd prefer to restructure our routes to be more hierarchical as @youknowriad suggests in https://github.com/WordPress/gutenberg/issues/52665#issuecomment-1637945110. For example, both `/templates/:templateId` and `/pages/:pageId/templates/:templateId` would load the `wp_template` with `id = templateId` but pressing back when viewing the latter would correctly go back to `/pages`. I think this is too great of a change to make while 6.3 is in its RC period, though, so I did not opt to do this.

## Testing Instructions
Test that you cannot reproduce https://github.com/WordPress/gutenberg/issues/50676, https://github.com/WordPress/gutenberg/issues/52665, or https://github.com/WordPress/gutenberg/issues/52761.