### PR TITLE
Allow soft return for native Verse block

### DIFF
--- a/packages/block-library/src/verse/edit.native.js
+++ b/packages/block-library/src/verse/edit.native.js
@@ -1,0 +1,70 @@
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import {
+	RichText,
+	BlockControls,
+	AlignmentToolbar,
+	useBlockProps,
+} from '@wordpress/block-editor';
+import { createBlock, getDefaultBlockName } from '@wordpress/blocks';
+
+export default function VerseEdit( {
+	attributes,
+	setAttributes,
+	mergeBlocks,
+	onRemove,
+	style,
+	insertBlocksAfter,
+} ) {
+	const { textAlign, content } = attributes;
+	const blockProps = useBlockProps( {
+		className: classnames( {
+			[ `has-text-align-${ textAlign }` ]: textAlign,
+		} ),
+		style,
+	} );
+
+	return (
+		<>
+			<BlockControls>
+				<AlignmentToolbar
+					value={ textAlign }
+					onChange={ ( nextAlign ) => {
+						setAttributes( { textAlign: nextAlign } );
+					} }
+				/>
+			</BlockControls>
+			<RichText
+				tagName="pre"
+				identifier="content"
+				preserveWhiteSpace
+				value={ content }
+				onChange={ ( nextContent ) => {
+					setAttributes( {
+						content: nextContent,
+					} );
+				} }
+				aria-label={ __( 'Verse text' ) }
+				placeholder={ __( 'Write verse…' ) }
+				onRemove={ onRemove }
+				multiline={ true }
+				blurOnSubmit={ true }
+				onMerge={ mergeBlocks }
+				textAlign={ textAlign }
+				textAlignVertical={ 'top' }
+				{ ...blockProps }
+				__unstablePastePlainText
+				__unstableOnSplitAtEnd={ () =>
+					insertBlocksAfter( createBlock( getDefaultBlockName() ) )
+				}
+			/>
+		</>
+	);
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Allows the native Verse block to create line breaks within the block.

## Why?
Currently, pressing return within the Verse block will create a new block instead of a new line within the block.

## How?
- Creates a new native Verse component
- Enables the `multiline={ true }` [prop](https://reactnative.dev/docs/textinput#multiline)

## Testing Instructions

1. Create a new post
2. Create a Verse block
3. Type some text
4. Experiment with creating new lines and new blocks

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
