### PR TITLE
Distraction Free: Fix conflict with showListViewByDefault preference

### DIFF
--- a/packages/edit-post/src/index.js
+++ b/packages/edit-post/src/index.js
@@ -65,7 +65,11 @@ export function initializeEditor(
 	dispatch( blocksStore ).__experimentalReapplyBlockTypeFilters();
 
 	// Check if the block list view should be open by default.
-	if ( select( editPostStore ).isFeatureActive( 'showListViewByDefault' ) ) {
+	// If `distractionFree` mode is enabled, the block list view should not be open.
+	if (
+		select( editPostStore ).isFeatureActive( 'showListViewByDefault' ) &&
+		! select( editPostStore ).isFeatureActive( 'distractionFree' )
+	) {
 		dispatch( editPostStore ).setIsListViewOpened( true );
 	}
 

--- a/packages/edit-site/src/store/private-actions.js
+++ b/packages/edit-site/src/store/private-actions.js
@@ -18,11 +18,15 @@ export const setCanvasMode =
 			mode,
 		} );
 		// Check if the block list view should be open by default.
+		// If `distractionFree` mode is enabled, the block list view should not be open.
 		if (
 			mode === 'edit' &&
 			registry
 				.select( preferencesStore )
-				.get( 'core/edit-site', 'showListViewByDefault' )
+				.get( 'core/edit-site', 'showListViewByDefault' ) &&
+			! registry
+				.select( preferencesStore )
+				.get( 'core/edit-site', 'distractionFree' )
 		) {
 			dispatch.setIsListViewOpened( true );
 		}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Check if distraction free mode is set before opening the list view by default.

Note: I'm not sure if this bug fix can make it in time for RCs, happy to punt it if there isn't enough time. I mostly noticed it because I usually have my editor set to show the list view by default.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

While working on #52867 and #52868, I noticed that there is a conflict between the `showListViewByDefault` preference and the `distractionFree` mode. With Distraction Free mode, we expect that the list view will not be open, however the `showListViewByDefault` preference doesn't currently take this into account.

If you have `showListViewByDefault` set to `true` and then switch to Distraction Free mode while in the post or site editors, everything appears to work as expected. However, if you reload the page, the list view will be open. This PR fixes it so that when `distractionFree` is set, we skip opening the list view by default.

The approach in this PR preserves the `showListViewByDefault` preference so that a user that toggles Distraction Free mode will be restored back to showing the list view by default once they switch off Distraction Free mode.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* In the post and site editors check that distraction free mode is not enabled before opening the list view based on the `showListViewByDefault` preference.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Open the post editor and go to the editor's preferences (vertical ellipsis button at the top right, then Preferences) and switch "Always open list view" to true
2. Leave the preferences screen and click the "Distraction free" menu item (or use the `SHIFT+CMD+\` keyboard shortcut) to switch to distraction free mode.
3. Reload the editor and without this PR, note that the list view is unexpectedly open.
4. With this PR applied, the list view should not be unexpectedly open.
5. Toggle off Distraction free mode, and reload the editor — the list view should be open as expected.
6. Repeat the above steps using the site editor.

## Screenshots or screencast <!-- if applicable -->

In the following screengrabs the `showListViewByDefault` setting is set to `true` and then the user enables distraction free mode, and then reloads the editor. In the `Before` screengrab, the list view is unexpectedly open.

| Before | After |
| --- | --- |
| ![2023-07-25 14 30 28](https://github.com/WordPress/gutenberg/assets/14988353/c36577e7-fceb-4c48-ad66-9fd31c1dd9fb) | ![2023-07-25 14 29 18](https://github.com/WordPress/gutenberg/assets/14988353/cb59df8d-6d33-4ad8-b262-7707ebd569ee) |

Site editor after reloading with `showListViewByDefault` set to `true` as well as `distractionFree`:

| Before | After |
| --- | --- |
| ![image](https://github.com/WordPress/gutenberg/assets/14988353/5fa43e5c-24ff-4f07-8832-3cc7a1ce6499) | ![image](https://github.com/WordPress/gutenberg/assets/14988353/d05d4c71-85bf-41b6-a54b-b9dd0beac4d4) |