### PR TITLE
Site Editor: Open template parts from the list page in canvas view mode

### DIFF
--- a/packages/edit-site/src/components/page-template-parts/index.js
+++ b/packages/edit-site/src/components/page-template-parts/index.js
@@ -39,7 +39,6 @@ export default function PageTemplateParts() {
 							params={ {
 								postId: templatePart.id,
 								postType: templatePart.type,
-								canvas: 'edit',
 							} }
 							state={ { backPath: '/wp_template_part/all' } }
 						>


### PR DESCRIPTION
## What?
This a follow-up to #52891.

Keep template parts from the list page in canvas view mode.

## Why?
See https://github.com/WordPress/gutenberg/pull/52891#issuecomment-1648790025.

## How?
Don't specify canvas mode. The `view` is the default.

## Testing Instructions

1. Open the Site Editor.
2. Go to the "Manage all template parts" screen.
3. Click on the template part link.
4. Confirm it opens in the view mode.