### PR TITLE
Added Color Selection Option for FootNote Block

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -275,7 +275,7 @@ Add a link to a downloadable file. ([Source](https://github.com/WordPress/gutenb
 
 -	**Name:** core/footnotes
 -	**Category:** text
--	**Supports:** ~~html~~, ~~multiple~~, ~~reusable~~
+-	**Supports:** color (background, gradients, text), ~~html~~, ~~multiple~~, ~~reusable~~
 -	**Attributes:** 
 
 ## Classic

--- a/packages/block-library/src/footnotes/block.json
+++ b/packages/block-library/src/footnotes/block.json
@@ -9,6 +9,12 @@
 	"textdomain": "default",
 	"usesContext": [ "postId", "postType" ],
 	"supports": {
+		"color": {
+			"gradients": true,
+			"__experimentalDefaultControls": {
+				"text": true
+			}
+		},
 		"html": false,
 		"multiple": false,
 		"reusable": false


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Added Color Selection Option for FootNote Block

## Why?
https://github.com/WordPress/gutenberg/issues/51991

## How?
Allow Color Selection for block

<img width="648" alt="image" src="https://github.com/WordPress/gutenberg/assets/49809429/c8920093-2442-4cbe-be35-9b6d27a7cf80">


