### PR TITLE
Fix auto-size patterns triggering scrollbar flickering on certain size

### DIFF
--- a/packages/block-editor/src/components/block-preview/auto.js
+++ b/packages/block-editor/src/components/block-preview/auto.js
@@ -58,12 +58,17 @@ function ScaledBlockPreview( {
 	MemoizedBlockList = MemoizedBlockList || pure( BlockList );
 
 	const scale = containerWidth / viewportWidth;
+	const aspectRatio = containerWidth / ( contentHeight * scale );
 	return (
 		<Disabled
 			className="block-editor-block-preview__content"
 			style={ {
 				transform: `scale(${ scale })`,
-				height: contentHeight * scale,
+				// Using width + aspect-ratio instead of height here triggers browsers' native
+				// handling of scrollbar's visibility. It prevents the flickering issue seen
+				// in https://github.com/WordPress/gutenberg/issues/52027.
+				width: '100%',
+				aspectRatio,
 				maxHeight:
 					contentHeight > MAX_HEIGHT ? MAX_HEIGHT * scale : undefined,
 				minHeight,

--- a/packages/block-editor/src/components/block-preview/auto.js
+++ b/packages/block-editor/src/components/block-preview/auto.js
@@ -67,7 +67,7 @@ function ScaledBlockPreview( {
 				// Using width + aspect-ratio instead of height here triggers browsers' native
 				// handling of scrollbar's visibility. It prevents the flickering issue seen
 				// in https://github.com/WordPress/gutenberg/issues/52027.
-				width: '100%',
+				// See https://github.com/WordPress/gutenberg/pull/52921 for more info.
 				aspectRatio,
 				maxHeight:
 					contentHeight > MAX_HEIGHT ? MAX_HEIGHT * scale : undefined,

--- a/packages/block-editor/src/components/block-preview/auto.js
+++ b/packages/block-editor/src/components/block-preview/auto.js
@@ -58,7 +58,9 @@ function ScaledBlockPreview( {
 	MemoizedBlockList = MemoizedBlockList || pure( BlockList );
 
 	const scale = containerWidth / viewportWidth;
-	const aspectRatio = containerWidth / ( contentHeight * scale );
+	const aspectRatio = contentHeight
+		? containerWidth / ( contentHeight * scale )
+		: 0;
 	return (
 		<Disabled
 			className="block-editor-block-preview__content"

--- a/packages/block-editor/src/components/block-preview/style.scss
+++ b/packages/block-editor/src/components/block-preview/style.scss
@@ -11,8 +11,9 @@
 	overflow: hidden;
 
 	.block-editor-block-preview__content {
-		// This element receives inline styles for width, height, and transform-scale.
+		// This element receives inline styles for transform-scale and aspect-ratio.
 		// Those inline styles are calculated to fit a perfect thumbnail.
+		width: 100%;
 
 		// Vertical alignment. It works with the transform: translate(-50%, -50%)`,
 		top: 0;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Fix https://github.com/WordPress/gutenberg/issues/52027. Prevents `BlockPreview`s from flickering on certain viewport sizes.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The issue happens when the scrollbar has a width and causes the viewport width to decrease when there's scrollable content.

1. The `<BlockPreview>` component uses dynamic `height` to auto-resize itself based on the preview content's height and container's width. The formula for calculating the height is `height = contentHeight * (containerWidth / viewportWidth)` where `viewportWidth` is often a constant integer and `contentHeight` also doesn't change for each pattern.
2. When there's scrollable content, the scrollbar appears and occupies some width (16px on macOS for example), causing the `containerWidth` to decrease a little bit.
3. Because `containerWidth` gets smaller, based on the formula in (1.), the height also gets smaller.
4. Because `<BlockPreview>` gets smaller in height, the scrollable content can now fit in the screen and doesn't require a scrollbar.
5. The scrollbar hides itself, then the viewport width grows a little bit (the scrollbar's width). The `containerWidth` now also grows bigger.
6. Because `containerWidth` is now bigger, based on the formula in (1.), the `height` also grows bigger. The grown amount causes the content to overflow, and the scrollbar appears again.
7. Back to (2.). It's now an infinite loop that causes the visual flickering.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

The solution might not be obvious, but excluding the scrollbar width right before the content overflows magically solves the issue. The key is that if the delta of height isn't enough to cause the transition of the width change, then it won't cause the flickering. I believe it can be proved with some math but I'd rather not go into that rabbit hole 😅.

Surprisingly, browsers natively handle this for us. The only gotcha is that we have to define `width` instead of `height` for some reason. Hence the solution in this PR is simply to use `width: 100%` and `aspect-ratio` to mimic the same behavior with dynamic height. It's also possibly more performant as we only change [compositor-only properties](https://web.dev/stick-to-compositor-only-properties-and-manage-layer-count/).

I've only tested this on macOS though, I'm not sure if other OSes behave differently. Could someone with access to Windows or Linux help test this?

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
1. If you're on macOS, enable "Always show scrollbar" in the system preferences.
2. Checkout to trunk.
3. Go to Site Editor -> Patterns.
4. Select a category that has enough content to cause overflow (but not too many).
5. Resize the window to a point that it causes the flickering.
6. Checkout to this branch and repeat the above. It should not cause flickering this time.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
Repeat the same above but use keyboard to resize the window (I don't know how to do that?).

## Screenshots or screencast <!-- if applicable -->

**Before**

https://github.com/WordPress/gutenberg/assets/7753001/ea801787-3a18-4cb7-8549-bb1ac9aaf89e

**After**

https://github.com/WordPress/gutenberg/assets/7753001/a1fb8666-baa9-41fa-bbdd-6afa26923b6a



