### PR TITLE
Pattern library: Switch to three column layout on `huge` screens

### DIFF
--- a/packages/edit-site/src/components/page-patterns/style.scss
+++ b/packages/edit-site/src/components/page-patterns/style.scss
@@ -131,6 +131,9 @@
 	@include break-large {
 		grid-template-columns: 1fr 1fr;
 	}
+	@include break-huge {
+		grid-template-columns: 1fr 1fr 1fr;
+	}
 	.edit-site-patterns__pattern {
 		break-inside: avoid-column;
 		display: flex;


### PR DESCRIPTION
## What?
Switch from two column to three column layout on viewports larger than 1440px.

## Why?
On wider screens the two column layout can result in extremely large preview thumbnails which feel outsized in comparison with the rest of the UI:

<img width="1706" alt="Screenshot 2023-07-25 at 10 30 12" src="https://github.com/WordPress/gutenberg/assets/846565/3a4269ed-4804-4266-91cc-05edebdfcce8">


## How?
Use `$break-huge` (1440px) to switch to three columns:

<img width="1707" alt="Screenshot 2023-07-25 at 10 30 40" src="https://github.com/WordPress/gutenberg/assets/846565/2017224b-7e5b-4134-ba12-7bee12129447">

**Note:** this is the largest breakpoint we have to work with. I think ideally a four column layout would be used at even larger sizes, but that's one to tackle separately as it will require the addition of a new variable.

## Testing Instructions
1. Open the pattern library
2. Resize the browser window and notice the layout adjust above the 1440px threshold. 
