### PR TITLE
Verse: Enable the line breaks

### DIFF
--- a/packages/block-library/src/verse/edit.js
+++ b/packages/block-library/src/verse/edit.js
@@ -13,7 +13,6 @@ import {
 	AlignmentToolbar,
 	useBlockProps,
 } from '@wordpress/block-editor';
-import { createBlock, getDefaultBlockName } from '@wordpress/blocks';
 
 export default function VerseEdit( {
 	attributes,
@@ -21,7 +20,6 @@ export default function VerseEdit( {
 	mergeBlocks,
 	onRemove,
 	style,
-	insertBlocksAfter,
 } ) {
 	const { textAlign, content } = attributes;
 	const blockProps = useBlockProps( {
@@ -58,9 +56,6 @@ export default function VerseEdit( {
 				textAlign={ textAlign }
 				{ ...blockProps }
 				__unstablePastePlainText
-				__unstableOnSplitAtEnd={ () =>
-					insertBlocksAfter( createBlock( getDefaultBlockName() ) )
-				}
 			/>
 		</>
 	);

--- a/packages/block-library/src/verse/test/edit.native.js
+++ b/packages/block-library/src/verse/test/edit.native.js
@@ -64,15 +64,13 @@ describe( 'Verse block', () => {
 		const verseTextInput = await screen.findByPlaceholderText(
 			'Write verse…'
 		);
-		typeInRichText( verseTextInput, 'A great statement.Again', {
-			finalSelectionStart: 18,
-			finalSelectionEnd: 18,
-		} );
+		typeInRichText( verseTextInput, 'A great statement.' );
 		fireEvent( verseTextInput, 'onKeyDown', {
 			nativeEvent: {},
 			preventDefault() {},
 			keyCode: ENTER,
 		} );
+		typeInRichText( verseTextInput, 'Again' );
 
 		// Assert
 		expect( getEditorHtml() ).toMatchInlineSnapshot( `


### PR DESCRIPTION
## What?
Revert changes from #52783.

## Why?
TL;DR users expect <kbd>Enter</kbd> to create a line-break in multiline blocks like Verse, Preformatted, and Code.

See #52783 for the full discussion.

## How?
`git revert`

## Testing Instructions
1. Open a Post or Page.
2. Insert a Verse block and text.
3. Pressing Enter should always create a line break.
