### PR TITLE
Site Editor: Use the correct icon for Patterns in sidebar card

### DIFF
--- a/packages/edit-site/src/components/sidebar-edit-mode/template-panel/index.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/template-panel/index.js
@@ -7,7 +7,7 @@ import { store as editorStore } from '@wordpress/editor';
 import { store as coreStore } from '@wordpress/core-data';
 import { decodeEntities } from '@wordpress/html-entities';
 import { __ } from '@wordpress/i18n';
-import { navigation as navigationIcon } from '@wordpress/icons';
+import { navigation, symbol } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -18,11 +18,13 @@ import TemplateAreas from './template-areas';
 import LastRevision from './last-revision';
 import SidebarCard from '../sidebar-card';
 
+const CARD_ICONS = {
+	wp_block: symbol,
+	wp_navigation: navigation,
+};
+
 export default function TemplatePanel() {
-	const {
-		info: { title, description, icon },
-		record,
-	} = useSelect( ( select ) => {
+	const { title, description, icon, record } = useSelect( ( select ) => {
 		const { getEditedPostType, getEditedPostId } = select( editSiteStore );
 		const { getEditedEntityRecord } = select( coreStore );
 		const { __experimentalGetTemplateInfo: getTemplateInfo } =
@@ -31,10 +33,14 @@ export default function TemplatePanel() {
 		const postType = getEditedPostType();
 		const postId = getEditedPostId();
 		const _record = getEditedEntityRecord( 'postType', postType, postId );
+		const info = getTemplateInfo( _record );
 
-		const info = _record ? getTemplateInfo( _record ) : {};
-
-		return { info, record: _record };
+		return {
+			title: info.title,
+			description: info.description,
+			icon: info.icon,
+			record: _record,
+		};
 	}, [] );
 
 	if ( ! title && ! description ) {
@@ -46,9 +52,7 @@ export default function TemplatePanel() {
 			<SidebarCard
 				className="edit-site-template-card"
 				title={ decodeEntities( title ) }
-				icon={
-					record?.type === 'wp_navigation' ? navigationIcon : icon
-				}
+				icon={ CARD_ICONS[ record?.type ] ?? icon }
 				description={ decodeEntities( description ) }
 				actions={ <TemplateActions template={ record } /> }
 			>


### PR DESCRIPTION
## What?
Fixes #52924.

PR fixes the icon for Patterns in the site editor's sidebar card.

## How?
Create a map for record types and icons that need special handling.

## Testing Instructions
1. Go to the Site Editor > Patterns.
2. Open a Pattern.
3. Confirm correct icon is displayed in the sidebar.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2023-07-25 at 15 07 21](https://github.com/WordPress/gutenberg/assets/240569/53af38f5-7510-449f-81ce-5d8f393b8d0b)
