### PR TITLE
Patterns: Reset current page when search filters change

### DIFF
--- a/packages/edit-site/src/components/page-patterns/patterns-list.js
+++ b/packages/edit-site/src/components/page-patterns/patterns-list.js
@@ -1,7 +1,13 @@
 /**
  * WordPress dependencies
  */
-import { useState, useDeferredValue, useId, useMemo } from '@wordpress/element';
+import {
+	useState,
+	useDeferredValue,
+	useEffect,
+	useId,
+	useMemo,
+} from '@wordpress/element';
 import {
 	SearchControl,
 	__experimentalVStack as VStack,
@@ -78,6 +84,13 @@ export default function PatternsList( { categoryId, type } ) {
 		}
 	);
 
+	// If the search term or sync filter is changing, we need to reset the
+	// current page back to zero so results are still within the set displayed.
+	useEffect(
+		() => setCurrentPage( 1 ),
+		[ deferredFilterValue, deferredSyncedFilter ]
+	);
+
 	const id = useId();
 	const titleId = `${ id }-title`;
 	const descriptionId = `${ id }-description`;
@@ -90,14 +103,12 @@ export default function PatternsList( { categoryId, type } ) {
 	const pageIndex = currentPage - 1;
 	const numPages = Math.ceil( patterns.length / PAGE_SIZE );
 
-	const list = useMemo(
-		() =>
-			patterns.slice(
-				pageIndex * PAGE_SIZE,
-				pageIndex * PAGE_SIZE + PAGE_SIZE
-			),
-		[ pageIndex, patterns ]
-	);
+	const list = useMemo( () => {
+		return patterns.slice(
+			pageIndex * PAGE_SIZE,
+			pageIndex * PAGE_SIZE + PAGE_SIZE
+		);
+	}, [ pageIndex, patterns ] );
 
 	const asyncList = useAsyncList( list, { step: 10 } );
 

--- a/packages/edit-site/src/components/page-patterns/patterns-list.js
+++ b/packages/edit-site/src/components/page-patterns/patterns-list.js
@@ -1,13 +1,7 @@
 /**
  * WordPress dependencies
  */
-import {
-	useState,
-	useDeferredValue,
-	useEffect,
-	useId,
-	useMemo,
-} from '@wordpress/element';
+import { useState, useDeferredValue, useId, useMemo } from '@wordpress/element';
 import {
 	SearchControl,
 	__experimentalVStack as VStack,
@@ -84,12 +78,15 @@ export default function PatternsList( { categoryId, type } ) {
 		}
 	);
 
-	// If the search term or sync filter is changing, we need to reset the
-	// current page back to zero so results are still within the set displayed.
-	useEffect(
-		() => setCurrentPage( 1 ),
-		[ deferredFilterValue, deferredSyncedFilter ]
-	);
+	const updateSearchFilter = ( value ) => {
+		setCurrentPage( 1 );
+		setFilterValue( value );
+	};
+
+	const updateSyncFilter = ( value ) => {
+		setCurrentPage( 1 );
+		setSyncFilter( value );
+	};
 
 	const id = useId();
 	const titleId = `${ id }-title`;
@@ -149,7 +146,9 @@ export default function PatternsList( { categoryId, type } ) {
 					<FlexBlock className="edit-site-patterns__search-block">
 						<SearchControl
 							className="edit-site-patterns__search"
-							onChange={ ( value ) => setFilterValue( value ) }
+							onChange={ ( value ) =>
+								updateSearchFilter( value )
+							}
 							placeholder={ __( 'Search patterns' ) }
 							label={ __( 'Search patterns' ) }
 							value={ filterValue }
@@ -163,7 +162,7 @@ export default function PatternsList( { categoryId, type } ) {
 							label={ __( 'Filter by sync status' ) }
 							value={ syncFilter }
 							isBlock
-							onChange={ ( value ) => setSyncFilter( value ) }
+							onChange={ ( value ) => updateSyncFilter( value ) }
 							__nextHasNoMarginBottom
 						>
 							{ Object.entries( SYNC_FILTERS ).map(


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/52926

## What?

Resets the current page of pattern results when search term or sync status filters are updated to ensure results are shown.

## Why?

Searching patterns isn't much use if it can only be done on the first page of results.

## How?

Resets the current page state when search term or filters change.

## Testing Instructions

1. Add enough patterns that you have at least two pages full (or activate a theme that has plenty of patterns)
2. Navigate to any page after the first
3. Enter a search term into the input at the top of the page
4. Confirm that expected pattern results are displayed


## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/60436221/30fc7ccc-e3c5-4498-8071-35f426973bac

