### PR TITLE
Footnotes: disable based on post type

### DIFF
--- a/packages/block-editor/src/components/rich-text/format-edit.js
+++ b/packages/block-editor/src/components/rich-text/format-edit.js
@@ -11,8 +11,15 @@ import BlockContext from '../block-context';
 
 const DEFAULT_BLOCK_CONTEXT = {};
 
+// eslint-disable-next-line no-restricted-syntax
+export const usesContextKey = 'usesContext' + Math.random();
+
 function Edit( { onChange, onFocus, value, forwardedRef, settings } ) {
-	const { name, edit: EditFunction, usesContext } = settings;
+	const {
+		name,
+		edit: EditFunction,
+		[ usesContextKey ]: usesContext,
+	} = settings;
 
 	const blockContext = useContext( BlockContext );
 

--- a/packages/block-editor/src/components/rich-text/format-edit.js
+++ b/packages/block-editor/src/components/rich-text/format-edit.js
@@ -11,8 +11,7 @@ import BlockContext from '../block-context';
 
 const DEFAULT_BLOCK_CONTEXT = {};
 
-// eslint-disable-next-line no-restricted-syntax
-export const usesContextKey = 'usesContext' + Math.random();
+export const usesContextKey = Symbol( 'usesContext' );
 
 function Edit( { onChange, onFocus, value, forwardedRef, settings } ) {
 	const {

--- a/packages/block-editor/src/components/rich-text/format-edit.js
+++ b/packages/block-editor/src/components/rich-text/format-edit.js
@@ -2,7 +2,6 @@
  * WordPress dependencies
  */
 import { getActiveFormat, getActiveObject } from '@wordpress/rich-text';
-
 import { useContext, useMemo } from '@wordpress/element';
 
 /**

--- a/packages/block-editor/src/private-apis.js
+++ b/packages/block-editor/src/private-apis.js
@@ -23,6 +23,7 @@ import {
 	default as ReusableBlocksRenameHint,
 	useReusableBlocksRenameHint,
 } from './components/inserter/reusable-block-rename-hint';
+import { usesContextKey } from './components/rich-text/format-edit';
 
 /**
  * Private @wordpress/block-editor APIs.
@@ -49,4 +50,5 @@ lock( privateApis, {
 	ResolutionTool,
 	ReusableBlocksRenameHint,
 	useReusableBlocksRenameHint,
+	usesContextKey,
 } );

--- a/packages/block-library/src/footnotes/edit.js
+++ b/packages/block-library/src/footnotes/edit.js
@@ -17,6 +17,20 @@ export default function FootnotesEdit( { context: { postType, postId } } ) {
 	const footnotes = meta?.footnotes ? JSON.parse( meta.footnotes ) : [];
 	const blockProps = useBlockProps();
 
+	if ( postType !== 'post' && postType !== 'page' ) {
+		return (
+			<div { ...blockProps }>
+				<Placeholder
+					icon={ <BlockIcon icon={ icon } /> }
+					label={ __( 'Footnotes' ) }
+					instructions={ __(
+						'Footnotes are not supported here. Add this block to post or page content.'
+					) }
+				/>
+			</div>
+		);
+	}
+
 	if ( ! footnotes.length ) {
 		return (
 			<div { ...blockProps }>

--- a/packages/block-library/src/footnotes/edit.js
+++ b/packages/block-library/src/footnotes/edit.js
@@ -37,9 +37,7 @@ export default function FootnotesEdit( { context: { postType, postId } } ) {
 				<Placeholder
 					icon={ <BlockIcon icon={ icon } /> }
 					label={ __( 'Footnotes' ) }
-					instructions={ __(
-						'Footnotes found in blocks within this document will be displayed here.'
-					) }
+					// To do: add instructions. We can't add new string in RC.
 				/>
 			</div>
 		);

--- a/packages/block-library/src/footnotes/edit.js
+++ b/packages/block-library/src/footnotes/edit.js
@@ -23,9 +23,7 @@ export default function FootnotesEdit( { context: { postType, postId } } ) {
 				<Placeholder
 					icon={ <BlockIcon icon={ icon } /> }
 					label={ __( 'Footnotes' ) }
-					instructions={ __(
-						'Footnotes are not supported here. Add this block to post or page content.'
-					) }
+					// To do: add instructions. We can't add new string in RC.
 				/>
 			</div>
 		);
@@ -37,7 +35,9 @@ export default function FootnotesEdit( { context: { postType, postId } } ) {
 				<Placeholder
 					icon={ <BlockIcon icon={ icon } /> }
 					label={ __( 'Footnotes' ) }
-					// To do: add instructions. We can't add new string in RC.
+					instructions={ __(
+						'Footnotes found in blocks within this document will be displayed here.'
+					) }
 				/>
 			</div>
 		);

--- a/packages/block-library/src/footnotes/format.js
+++ b/packages/block-library/src/footnotes/format.js
@@ -14,7 +14,7 @@ import {
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import { useSelect, useDispatch, useRegistry } from '@wordpress/data';
-import { createBlock } from '@wordpress/blocks';
+import { createBlock, store as blocksStore } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -44,8 +44,15 @@ export const format = {
 			getBlockName,
 			getBlocks,
 		} = useSelect( blockEditorStore );
+		const footnotesBlockType = useSelect( ( select ) =>
+			select( blocksStore ).getBlockType( name )
+		);
 		const { selectionChange, insertBlock } =
 			useDispatch( blockEditorStore );
+
+		if ( ! footnotesBlockType ) {
+			return null;
+		}
 
 		if ( postType !== 'post' && postType !== 'page' ) {
 			return null;

--- a/packages/block-library/src/footnotes/format.js
+++ b/packages/block-library/src/footnotes/format.js
@@ -12,6 +12,7 @@ import { insertObject } from '@wordpress/rich-text';
 import {
 	RichTextToolbarButton,
 	store as blockEditorStore,
+	privateApis,
 } from '@wordpress/block-editor';
 import { useSelect, useDispatch, useRegistry } from '@wordpress/data';
 import { createBlock, store as blocksStore } from '@wordpress/blocks';
@@ -20,6 +21,9 @@ import { createBlock, store as blocksStore } from '@wordpress/blocks';
  * Internal dependencies
  */
 import { name } from './block.json';
+import { unlock } from '../lock-unlock';
+
+const { usesContextKey } = unlock( privateApis );
 
 export const formatName = 'core/footnote';
 export const format = {
@@ -30,7 +34,7 @@ export const format = {
 		'data-fn': 'data-fn',
 	},
 	contentEditable: false,
-	usesContext: [ 'postType' ],
+	[ usesContextKey ]: [ 'postType' ],
 	edit: function Edit( {
 		value,
 		onChange,

--- a/packages/block-library/src/footnotes/format.js
+++ b/packages/block-library/src/footnotes/format.js
@@ -30,7 +30,13 @@ export const format = {
 		'data-fn': 'data-fn',
 	},
 	contentEditable: false,
-	edit: function Edit( { value, onChange, isObjectActive } ) {
+	usesContext: [ 'postType' ],
+	edit: function Edit( {
+		value,
+		onChange,
+		isObjectActive,
+		context: { postType },
+	} ) {
 		const registry = useRegistry();
 		const {
 			getSelectedBlockClientId,
@@ -40,6 +46,10 @@ export const format = {
 		} = useSelect( blockEditorStore );
 		const { selectionChange, insertBlock } =
 			useDispatch( blockEditorStore );
+
+		if ( postType !== 'post' && postType !== 'page' ) {
+			return null;
+		}
 
 		function onClick() {
 			registry.batch( () => {

--- a/packages/block-library/src/footnotes/index.js
+++ b/packages/block-library/src/footnotes/index.js
@@ -21,7 +21,8 @@ export const settings = {
 	edit,
 };
 
+registerFormatType( formatName, format );
+
 export const init = () => {
 	initBlock( { name, metadata, settings } );
-	registerFormatType( formatName, format );
 };

--- a/packages/block-library/src/footnotes/index.js
+++ b/packages/block-library/src/footnotes/index.js
@@ -21,9 +21,7 @@ export const settings = {
 	edit,
 };
 
-// Would be good to remove the format and HoR if the block is unregistered.
-registerFormatType( formatName, format );
-
 export const init = () => {
 	initBlock( { name, metadata, settings } );
+	registerFormatType( formatName, format );
 };


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

For now, let's restrict the footnotes block and format to posts and pages.

* Always register the block type and format
* Disable the format and block based on the post type context.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

We don't want people to be adding footnote anchors outside of the post content. For now we also don't want custom post types to add footnotes, but we can enable that in a future release.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

We need a `usesContext` setting for format types as well. Not sure if we should immediately ship this as a stable API though. What do you think?

In the future it would be good to disable block _insertion_ as well, but this is not possible with the current block.json APIs. Maybe we should expand `parent`?

## Testing Instructions

In the site editor, try adding an anchor in a template. The button should not be there. The block is insertable, but it will have a message that is doesn't work.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
