### PR TITLE
Experimental: Fix TinyMCE removal for heartbeat requests

### DIFF
--- a/lib/experimental/disable-tinymce.php
+++ b/lib/experimental/disable-tinymce.php
@@ -61,14 +61,15 @@ function gutenberg_post_being_edited_requires_classic_block() {
 		return false;
 	}
 
-	// Handle the post editor.
-	if ( ! empty( $_GET['post'] ) && ! empty( $_GET['action'] ) && 'edit' === $_GET['action'] ) {
-		$current_post = get_post( intval( $_GET['post'] ) );
-		if ( ! $current_post || is_wp_error( $current_post ) ) {
-			return false;
-		}
+	// Continue only if we're in the post editor.
+	if ( empty( $_GET['post'] ) || empty( $_GET['action'] ) || 'edit' !== $_GET['action'] ) {
+		return false;
+	}
 
-		$content = $current_post->post_content;
+	// Bail if for some reason the post isn't found.
+	$current_post = get_post( intval( $_GET['post'] ) );
+	if ( ! $current_post || is_wp_error( $current_post ) ) {
+		return false;
 	}
 
 	// Check if block editor is disabled by "Classic Editor" or another plugin.
@@ -79,6 +80,7 @@ function gutenberg_post_being_edited_requires_classic_block() {
 		return true;
 	}
 
+	$content = $current_post->post_content;
 	if ( empty( $content ) ) {
 		return false;
 	}

--- a/lib/experimental/disable-tinymce.php
+++ b/lib/experimental/disable-tinymce.php
@@ -67,7 +67,7 @@ function gutenberg_post_being_edited_requires_classic_block() {
 	}
 
 	// Bail if for some reason the post isn't found.
-	$current_post = get_post( intval( $_GET['post'] ) );
+	$current_post = get_post( absint( $_GET['post'] ) );
 	if ( ! $current_post || is_wp_error( $current_post ) ) {
 		return false;
 	}

--- a/lib/experimental/disable-tinymce.php
+++ b/lib/experimental/disable-tinymce.php
@@ -68,7 +68,7 @@ function gutenberg_post_being_edited_requires_classic_block() {
 
 	// Bail if for some reason the post isn't found.
 	$current_post = get_post( absint( $_GET['post'] ) );
-	if ( ! $current_post || is_wp_error( $current_post ) ) {
+	if ( ! $current_post ) {
 		return false;
 	}
 


### PR DESCRIPTION
## What?

This PR fixes warnings that are thrown for heartbeat requests when the TinyMCE removal experiment is turned on.

The warnings are easy to see in your browser console if you have the Query Monitor plugin installed.

## Why?

We're just fixing some warnings:

![Screenshot 2023-07-25 at 15 13 21](https://github.com/WordPress/gutenberg/assets/8436925/d547e9c9-594e-4c2c-87c4-31fb4ac238cb)

Found while working on #52811.

## How?
We're moving the `$current_post` declaration outside the condition that declares it and moving the condition above. That way, the code that uses `$current_post` will actually be reached only when necessary.

## Testing Instructions
* Install the Query Monitor plugin.
* Open the post editor for an existing post.
* Wait for a minute to witness a heartbeat XHR request to run.
* Verify there are no longer warnings.
* Try the same as above but for a custom post type.
* Verify test instructions in #50387 still work well.

### Testing Instructions for Keyboard
None.

## Screenshots or screencast <!-- if applicable -->
None.