### PR TITLE
Block Library: Set freeform handler only if Classic block exists

### DIFF
--- a/packages/block-library/src/index.js
+++ b/packages/block-library/src/index.js
@@ -282,7 +282,11 @@ export const registerCoreBlocks = (
 	blocks.forEach( ( { init } ) => init() );
 
 	setDefaultBlockName( paragraph.name );
-	if ( window.wp && window.wp.oldEditor && blocks.includes( classic ) ) {
+	if (
+		window.wp &&
+		window.wp.oldEditor &&
+		blocks.some( ( { name } ) => name === classic.name )
+	) {
 		setFreeformContentHandlerName( classic.name );
 	}
 	setUnregisteredTypeHandlerName( missing.name );

--- a/packages/block-library/src/index.js
+++ b/packages/block-library/src/index.js
@@ -282,7 +282,7 @@ export const registerCoreBlocks = (
 	blocks.forEach( ( { init } ) => init() );
 
 	setDefaultBlockName( paragraph.name );
-	if ( window.wp && window.wp.oldEditor ) {
+	if ( window.wp && window.wp.oldEditor && blocks.includes( classic ) ) {
 		setFreeformContentHandlerName( classic.name );
 	}
 	setUnregisteredTypeHandlerName( missing.name );


### PR DESCRIPTION
## What?
This PR updates the block library to set the freeform content handler to the classic block only if the classic block actually exists. 

This PR is part of the fix to address #52811.

## Why?
With this additional check, the freeform content handler will not be set if the TinyMCE removal experiment is turned on and the Classic block is intentionally not registered.

That way, the empty whitespaces won't be parsed to empty freeform blocks. 

## How?
We're just specifically setting the freeform content handler to the classic block only if the classic block actually exists. 

## Testing Instructions
* Follow the testing instructions of #52811.
* Verify that after refreshing the post page in the admin, you don't see these warnings: 

```
Your site doesn’t include support for the "core/freeform" block. You can leave this block intact or remove it entirely.
```

### Testing Instructions for Keyboard
None

## Screenshots or screencast <!-- if applicable -->
None