### PR TITLE
Block Library: Do not display empty classic blocks if Classic block is not registered

### DIFF
--- a/packages/block-library/src/missing/edit.js
+++ b/packages/block-library/src/missing/edit.js
@@ -38,6 +38,7 @@ function MissingBlockWarning( { attributes, convertToHTML, clientId } ) {
 	const actions = [];
 	let messageHTML;
 
+	const blockProps = useBlockProps( { className: 'has-warning' } );
 	const convertToHtmlButton = (
 		<Button key="convert" onClick={ convertToHTML } variant="primary">
 			{ __( 'Keep as HTML' ) }
@@ -64,6 +65,12 @@ function MissingBlockWarning( { attributes, convertToHTML, clientId } ) {
 			originalName
 		);
 		actions.push( convertToHtmlButton );
+	} else if (
+		! hasContent &&
+		! hasFreeformBlock &&
+		originalName === 'core/freeform'
+	) {
+		return null;
 	} else {
 		messageHTML = sprintf(
 			/* translators: %s: block name */
@@ -75,7 +82,7 @@ function MissingBlockWarning( { attributes, convertToHTML, clientId } ) {
 	}
 
 	return (
-		<div { ...useBlockProps( { className: 'has-warning' } ) }>
+		<div { ...blockProps }>
 			<Warning actions={ actions }>{ messageHTML }</Warning>
 			<RawHTML>{ safeHTML( originalUndelimitedContent ) }</RawHTML>
 		</div>


### PR DESCRIPTION
## What?
This PR updates the missing block to not render empty freeform blocks if the Classic block is not registered. 

This PR is part of the fix to address #52811.

## Why?
With this additional condition, if the TinyMCE removal experiment is turned on and the Classic block is intentionally not registered, we won't be displaying empty classic blocks.

## How?
We're moving a hook above to preserve the React [rule of hooks](https://legacy.reactjs.org/docs/hooks-rules.html), and adding an additional condition to render nothing if all conditions are true:

* the currently missing block has NO content
* the currently missing block is a `core/freeform` block
* the `core/freeform` block isn't registered - in the case when TinyMCE removal experiment is enabled

## Testing Instructions
* Follow the testing instructions of #52811.
* Insert a post with the following content:

```
<!-- wp:paragraph {"align":"center"} -->
<p class="has-text-align-center">Please be aware this is a test.</p>
<!-- /wp:paragraph -->

<!-- wp:freeform /-->

<!-- wp:paragraph {"align":"center"} -->
<p class="has-text-align-center">A second paragraph that has content inserted</p>
<!-- /wp:paragraph -->
```
* Verify that after refreshing the post page in the admin, you don't see this missing block warning: 

```
Your site doesn’t include support for the "core/freeform" block. You can leave this block intact or remove it entirely.
```

### Testing Instructions for Keyboard
None

## Screenshots or screencast <!-- if applicable -->
None