### PR TITLE
Experimental: Backend handle freeform blocks with TinyMCE removal

### DIFF
--- a/lib/experimental/disable-tinymce.php
+++ b/lib/experimental/disable-tinymce.php
@@ -87,7 +87,8 @@ function gutenberg_post_being_edited_requires_classic_block() {
 
 	$parsed_blocks = parse_blocks( $content );
 	foreach ( $parsed_blocks as $block ) {
-		if ( empty( $block['blockName'] ) && strlen( trim( $block['innerHTML'] ) ) > 0 ) {
+		$is_freeform_block = empty( $block['blockName'] ) || 'core/freeform' === $block['blockName'];
+		if ( $is_freeform_block && strlen( trim( $block['innerHTML'] ) ) > 0 ) {
 			return true;
 		}
 	}


### PR DESCRIPTION
## What?
Handle `freeform` blocks properly as classic blocks and load the Classic block and TinyMCE properly.

Part of the fix for #52811.

## Why?
There are pre-existing posts that specifically have `freeform` blocks and we need to handle them properly when the TinyMCE experiment is enabled.

## How?
In addition to treating a raw block with content and no name as a Classic block, treat `core/freeform` blocks as such. 

## Testing Instructions
* Go to Experiments http://localhost:8888/wp-admin/admin.php?page=gutenberg-experiments.
* Enable the "Disable TinyMCE and Classic block" experiment and click "Save Changes".
* Create a post with this HTML:
```
<!-- wp:freeform -->
<p>test</p>
<!-- /wp:freeform -->
```
* Save the post.
* Refresh the page.
* Verify you can see the Classic block and it works correctly.

### Testing Instructions for Keyboard
None

## Screenshots or screencast <!-- if applicable -->
None