### PR TITLE
Fix regression with Edit site Navigate regions

### DIFF
--- a/packages/edit-site/src/components/layout/index.js
+++ b/packages/edit-site/src/components/layout/index.js
@@ -264,7 +264,10 @@ export default function Layout() {
 						The NavigableRegion must always be rendered and not use
 						`inert` otherwise `useNavigateRegions` will fail.
 					*/ }
-					<NavigableRegion ariaLabel={ __( 'Navigation' ) }>
+					<NavigableRegion
+						ariaLabel={ __( 'Navigation' ) }
+						className="edit-site-layout__sidebar-region"
+					>
 						<motion.div
 							// The sidebar is needed for routing on mobile
 							// (https://github.com/WordPress/gutenberg/pull/51558/files#r1231763003),

--- a/packages/edit-site/src/components/layout/index.js
+++ b/packages/edit-site/src/components/layout/index.js
@@ -260,28 +260,32 @@ export default function Layout() {
 				</motion.div>
 
 				<div className="edit-site-layout__content">
-					<motion.div
-						// The sidebar is needed for routing on mobile
-						// (https://github.com/WordPress/gutenberg/pull/51558/files#r1231763003),
-						// so we can't remove the element entirely. Using `inert` will make
-						// it inaccessible to screen readers and keyboard navigation.
-						inert={ showSidebar ? undefined : 'inert' }
-						animate={ { opacity: showSidebar ? 1 : 0 } }
-						transition={ {
-							type: 'tween',
-							duration:
-								// Disable transition in mobile to emulate a full page transition.
-								disableMotion || isMobileViewport
-									? 0
-									: ANIMATION_DURATION,
-							ease: 'easeOut',
-						} }
-						className="edit-site-layout__sidebar"
-					>
-						<NavigableRegion ariaLabel={ __( 'Navigation' ) }>
+					{ /*
+						The NavigableRegion must always be rendered and not use
+						`inert` otherwise `useNavigateRegions` will fail.
+					*/ }
+					<NavigableRegion ariaLabel={ __( 'Navigation' ) }>
+						<motion.div
+							// The sidebar is needed for routing on mobile
+							// (https://github.com/WordPress/gutenberg/pull/51558/files#r1231763003),
+							// so we can't remove the element entirely. Using `inert` will make
+							// it inaccessible to screen readers and keyboard navigation.
+							inert={ showSidebar ? undefined : 'inert' }
+							animate={ { opacity: showSidebar ? 1 : 0 } }
+							transition={ {
+								type: 'tween',
+								duration:
+									// Disable transition in mobile to emulate a full page transition.
+									disableMotion || isMobileViewport
+										? 0
+										: ANIMATION_DURATION,
+								ease: 'easeOut',
+							} }
+							className="edit-site-layout__sidebar"
+						>
 							<Sidebar />
-						</NavigableRegion>
-					</motion.div>
+						</motion.div>
+					</NavigableRegion>
 
 					<SavePanel />
 

--- a/packages/edit-site/src/components/layout/style.scss
+++ b/packages/edit-site/src/components/layout/style.scss
@@ -58,7 +58,7 @@
 	display: flex;
 }
 
-.edit-site-layout__sidebar {
+.edit-site-layout__sidebar-region {
 	z-index: z-index(".edit-site-layout__sidebar");
 	width: 100vw;
 	flex-shrink: 0;
@@ -75,7 +75,7 @@
 		top: 0;
 	}
 
-	> div {
+	.edit-site-layout__sidebar {
 		display: flex;
 		flex-direction: column;
 		height: 100%;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Fixes https://github.com/WordPress/gutenberg/issues/52920

## What?
<!-- In a few words, what is the PR actually doing? -->
Fixes a regression with the ravigate regions feature (`useNavigateRegions`) after #51956.
Please. note this is a regression compared to WP 6.2 and should be fixed for the WP 6.3 release. Cc @annezasu and @youknowriad for some kind help with triaging and reviewing.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Users can't navigate the main regions of the editor via keyboard shortcuts any longer, At some point jumping through the regions gets stuck on the navigation panel because it now uses `inert` after #51956.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
All `NavigableRegion` must always be rendered in the DOM and keyboard interaction on them must not be prevented via keyboard.
As such, I changed the order of the wrapping elements. Now, the NavigableRegion wraps the animated sidebar that uses `inert`. This way, `useNavigateRegions` still works as expected. The animation _should_ still work as expected.

**This PR contains the minimum amount of changes to fix the regression.**
Still to do in follow-ups:
- Add a visually hidden button that gets revealed only on focus at the top of the navigation panel, similarly to the Settings panel and to the Save panel.
- Add E2E tests. Currently, the navigate regions feature is tested only in the Post editor. It appears it needs to tested also in the Site editor to avoid more potential regressions in teh future..

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

Use thes keyboard shortcut for testing:

Navigate to the next part of the editor: Control + backtick or alternatively Control + Option + N
Navigate to the previous part of the editor: Shift + Control + backtick or alternatively Control + Option + P

- Go to the Site editor.
- On first load, the Editor is in View mode.
- Use the keyboard shortcuts and observe focus move from the navigation panel to the preview iframe and so on.
- Switch the editor to Edit mode.
- Check the animation works as expected.
- Try the keyboard shortcut to move to the Next region.
- Observe that at each key combination press, focus moves the next editor region.
- Observe a blue focus outline appears around the currently focused region.
- Observe you can navigate through all the regions and you never get stuck.
- Try also the keyboard shortcut to move to the Previous region.
- Switch the editor back to View mode.
- Check the animation works as expected.

Important note: the animation when switching the editor from View mode to Edit mode should be tested in all browsers (**especially Safari)**. The switching behavior should be tested also in the small screens view. I'd greatly appreciate some eyes to check the animation from someone who;s more familiar with this. Cc @jasmussen 


### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
