### PR TITLE
Adds documentation about selectors

### DIFF
--- a/packages/data/README.md
+++ b/packages/data/README.md
@@ -1045,7 +1045,7 @@ function Component() {
     (select) => {
 
       const query = { per_page: 20 };
-      const selectorArgs = ["postType", "page", query];
+      const selectorArgs = [ "postType", "page", query ];
 
       return {
         pages: select(coreDataStore).getEntityRecords(...selectorArgs),

--- a/packages/data/README.md
+++ b/packages/data/README.md
@@ -1035,46 +1035,53 @@ The following selectors are available on the object returned by `wp.data.select(
 _Example_
 
 ```js
-import { store as coreDataStore } from "@wordpress/core-data";
+import { store as coreDataStore } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
 
 function Component() {
+	const result = useSelect( ( select ) => {
+		const query = { per_page: 20 };
+		const selectorArgs = [ 'postType', 'page', query ];
 
-  const result = useSelect(
+		return {
+			pages: select( coreDataStore ).getEntityRecords( ...selectorArgs ),
+			hasStartedResolution: select( coreDataStore ).hasStartedResolution(
+				'getEntityRecords', // _selectorName_
+				selectorArgs
+			),
+			hasFinishedResolution: select(
+				coreDataStore
+			).hasFinishedResolution( 'getEntityRecords', selectorArgs ),
+			isResolving: select( coreDataStore ).isResolving(
+				'getEntityRecords',
+				selectorArgs
+			),
+		};
+	} );
 
-    ( select ) => {
+	if ( result.hasStartedResolution ) {
+		return <>Fetching data...</>;
+	}
 
-      const query = { per_page: 20 };
-      const selectorArgs = [ "postType", "page", query ];
+	if ( result.isResolving ) {
+		return (
+			<>
+				{
+					// show a spinner
+				 }
+			</>
+		);
+	}
 
-      return {
-        pages: select( coreDataStore ).getEntityRecords( ...selectorArgs ),
-        hasStartedResolution: select( coreDataStore ).hasStartedResolution(
-          "getEntityRecords", // _selectorName_
-          selectorArgs
-        ),
-        hasFinishedResolution: select( coreDataStore ).hasFinishedResolution(
-          "getEntityRecords",
-          selectorArgs
-        ),
-        isResolving: select( coreDataStore ).isResolving(
-          "getEntityRecords",
-          selectorArgs
-        )
-      };
-    }
-  );
-
-  console.log( result.hasStartedResolution );
-  console.log( result.hasFinishedResolutio n);
-  console.log( result.isResolving );
-
-  return (
-    <>
-      {
-        //use the result properties here
-      }
-    </>
+	if ( result.hasFinishedResolution ) {
+		return (
+			<>
+				{
+					// data is ready
+				 }
+			</>
+		);
+	}
 }
 ```
 

--- a/packages/data/README.md
+++ b/packages/data/README.md
@@ -1053,7 +1053,7 @@ function Component() {
           "getEntityRecords", // _selectorName_
           selectorArgs
         ),
-        hasFinishedResolution: select(coreDataStore).hasFinishedResolution(
+        hasFinishedResolution: select( coreDataStore ).hasFinishedResolution(
           "getEntityRecords",
           selectorArgs
         ),

--- a/packages/data/README.md
+++ b/packages/data/README.md
@@ -1030,7 +1030,49 @@ function Component() {
 
 ## Selectors
 
-The following selectors are available on the object returned by `wp.data.select( 'core' )`:
+The following selectors are available on the object returned by `wp.data.select( 'core' )`.
+
+_Example_
+
+```js
+import { store as coreDataStore } from "@wordpress/core-data";
+
+function Component() {
+
+  const result = useSelect(
+
+    (select) => {
+
+      const query = { per_page: 20 };
+      const selectorArgs = ["postType", "page", query];
+
+      return {
+        pages: select(coreDataStore).getEntityRecords(...selectorArgs),
+        hasStartedResolution: select(coreDataStore).hasStartedResolution(
+          "getEntityRecords", // _selectorName_
+          selectorArgs
+        ),
+        hasFinishedResolution: select(coreDataStore).hasFinishedResolution(
+          "getEntityRecords",
+          selectorArgs
+        ),
+        isResolving: select(coreDataStore).isResolving(
+          "getEntityRecords",
+          selectorArgs
+        )
+      };
+    };
+  );
+
+  console.log(result.hasStartedResolution);
+  console.log(result.hasFinishedResolution);
+  console.log(result.isResolving);
+
+  return (
+    // use the result properties here
+  )
+}
+```
 
 ### hasFinishedResolution
 

--- a/packages/data/README.md
+++ b/packages/data/README.md
@@ -1028,6 +1028,52 @@ function Component() {
 }
 ```
 
+## Selectors
+
+The following selectors are available on the object returned by `wp.data.select( 'core' )`:
+
+### hasFinishedResolution
+
+Returns true if resolution has completed for a given selector name, and arguments set.
+
+_Parameters_
+
+-   _state_ `State`: Data state.
+-   _selectorName_ `string`: Selector name.
+-   _args_ `unknown[]?`: Arguments passed to selector.
+
+_Returns_
+
+-   `boolean`: Whether resolution has completed.
+
+### hasStartedResolution
+
+Returns true if resolution has already been triggered for a given selector name, and arguments set.
+
+_Parameters_
+
+-   _state_ `State`: Data state.
+-   _selectorName_ `string`: Selector name.
+-   _args_ `unknown[]?`: Arguments passed to selector.
+
+_Returns_
+
+-   `boolean`: Whether resolution has been triggered.
+
+### isResolving
+
+Returns true if resolution has been triggered but has not yet completed for a given selector name, and arguments set.
+
+_Parameters_
+
+-   _state_ `State`: Data state.
+-   _selectorName_ `string`: Selector name.
+-   _args_ `unknown[]?`: Arguments passed to selector.
+
+_Returns_
+
+-   `boolean`: Whether resolution is in progress.
+
 ## Going further
 
 -   [What is WordPress Data?](https://unfoldingneurons.com/2020/what-is-wordpress-data/)

--- a/packages/data/README.md
+++ b/packages/data/README.md
@@ -1062,7 +1062,7 @@ function Component() {
           selectorArgs
         )
       };
-    };
+    }
   );
 
   console.log(result.hasStartedResolution);

--- a/packages/data/README.md
+++ b/packages/data/README.md
@@ -1048,7 +1048,7 @@ function Component() {
       const selectorArgs = [ "postType", "page", query ];
 
       return {
-        pages: select(coreDataStore).getEntityRecords(...selectorArgs),
+        pages: select( coreDataStore ).getEntityRecords( ...selectorArgs ),
         hasStartedResolution: select(coreDataStore).hasStartedResolution(
           "getEntityRecords", // _selectorName_
           selectorArgs

--- a/packages/data/README.md
+++ b/packages/data/README.md
@@ -1057,7 +1057,7 @@ function Component() {
           "getEntityRecords",
           selectorArgs
         ),
-        isResolving: select(coreDataStore).isResolving(
+        isResolving: select( coreDataStore ).isResolving(
           "getEntityRecords",
           selectorArgs
         )

--- a/packages/data/README.md
+++ b/packages/data/README.md
@@ -1049,7 +1049,7 @@ function Component() {
 
       return {
         pages: select( coreDataStore ).getEntityRecords( ...selectorArgs ),
-        hasStartedResolution: select(coreDataStore).hasStartedResolution(
+        hasStartedResolution: select( coreDataStore ).hasStartedResolution(
           "getEntityRecords", // _selectorName_
           selectorArgs
         ),

--- a/packages/data/README.md
+++ b/packages/data/README.md
@@ -1042,7 +1042,7 @@ function Component() {
 
   const result = useSelect(
 
-    (select) => {
+    ( select ) => {
 
       const query = { per_page: 20 };
       const selectorArgs = [ "postType", "page", query ];
@@ -1065,13 +1065,16 @@ function Component() {
     }
   );
 
-  console.log(result.hasStartedResolution);
-  console.log(result.hasFinishedResolution);
-  console.log(result.isResolving);
+  console.log( result.hasStartedResolution );
+  console.log( result.hasFinishedResolutio n);
+  console.log( result.isResolving );
 
   return (
-    // use the result properties here
-  )
+    <>
+      {
+        //use the result properties here
+      }
+    </>
 }
 ```
 

--- a/packages/data/README.md
+++ b/packages/data/README.md
@@ -1036,6 +1036,7 @@ _Example_
 
 ```js
 import { store as coreDataStore } from "@wordpress/core-data";
+import { useSelect } from '@wordpress/data';
 
 function Component() {
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Closes #17082
## What?
<!-- In a few words, what is the PR actually doing? -->
Adds documentation for the following selectors:

- hasFinishedResolution
- hasStartedResolution
- isResolving

to the README file for the `@wordpress/data` package.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
As per #17082 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Doc blocks copied from [selectors.js](https://github.com/WordPress/gutenberg/blob/trunk/packages/data/src/redux-store/metadata/selectors.js)

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
