### PR TITLE
Add xhuge breakpoint and update pattern grid

### DIFF
--- a/packages/base-styles/_breakpoints.scss
+++ b/packages/base-styles/_breakpoints.scss
@@ -3,6 +3,7 @@
  */
 
 // Most used breakpoints
+$break-xhuge: 1920px;
 $break-huge: 1440px;
 $break-wide: 1280px;
 $break-xlarge: 1080px;

--- a/packages/base-styles/_mixins.scss
+++ b/packages/base-styles/_mixins.scss
@@ -5,6 +5,12 @@
  * Breakpoint mixins
  */
 
+@mixin break-xhuge() {
+	@media (min-width: #{ ($break-xhuge) }) {
+		@content;
+	}
+}
+
 @mixin break-huge() {
 	@media (min-width: #{ ($break-huge) }) {
 		@content;

--- a/packages/edit-site/src/components/page-patterns/style.scss
+++ b/packages/edit-site/src/components/page-patterns/style.scss
@@ -134,6 +134,9 @@
 	@include break-huge {
 		grid-template-columns: 1fr 1fr 1fr;
 	}
+	@include break-xhuge {
+		grid-template-columns: 1fr 1fr 1fr 1fr;
+	}
 	.edit-site-patterns__pattern {
 		break-inside: avoid-column;
 		display: flex;


### PR DESCRIPTION
Follow-up to https://github.com/WordPress/gutenberg/pull/52927

## What?
Adds an `xhuge` breakpoint (1920px), and uses it to arrange the pattern grid into 4 columns at that size.

## Why?
The largest breakpoint is currently 1440px which will arguably not cover the use cases we'll need to handle as we tackle admin areas outside of the full screen editor. 

## How?
* Adds a `$break-xhuge` variable
* Adds `break-xhuge()` mixin
* Adjusts `.edit-site-patterns__grid`

### Before
<img width="1344" alt="Screenshot 2023-07-25 at 15 36 46" src="https://github.com/WordPress/gutenberg/assets/846565/cff509eb-3ef3-4197-b42e-df44164ae300">

### After
<img width="1344" alt="Screenshot 2023-07-25 at 15 36 23" src="https://github.com/WordPress/gutenberg/assets/846565/2505e664-92e6-47e2-84a2-8771785bdf04">


## Testing Instructions
1. Navigate to the pattern grid in the site editor
2. Resize the viewport to >1920px (you can use browser dev tools to accomplish this)
3. Observe the four column layout

### Note
This is only starting point to kick-off discussion. Perhaps there's an alternative to 1920px?

