### PR TITLE
Add `Open styles revisions` command conditionally

### DIFF
--- a/packages/edit-site/src/hooks/commands/use-common-commands.js
+++ b/packages/edit-site/src/hooks/commands/use-common-commands.js
@@ -122,13 +122,13 @@ function useGlobalStylesOpenRevisionsCommands() {
 	const isMobileViewport = useViewportMatch( 'medium', '<' );
 	const isEditorPage = ! getIsListPage( params, isMobileViewport );
 	const history = useHistory();
-	const revisions = useSelect(
+	const hasRevisions = useSelect(
 		( select ) =>
-			select( coreStore ).getCurrentThemeGlobalStylesRevisions(),
+			select( coreStore ).getCurrentThemeGlobalStylesRevisions()?.length,
 		[]
 	);
 	const commands = useMemo( () => {
-		if ( ! revisions?.length ) {
+		if ( ! hasRevisions ) {
 			return [];
 		}
 
@@ -154,7 +154,7 @@ function useGlobalStylesOpenRevisionsCommands() {
 			},
 		];
 	}, [
-		revisions,
+		hasRevisions,
 		history,
 		openGeneralSidebar,
 		setEditorCanvasContainerView,

--- a/packages/edit-site/src/hooks/commands/use-common-commands.js
+++ b/packages/edit-site/src/hooks/commands/use-common-commands.js
@@ -19,7 +19,6 @@ import { useViewportMatch } from '@wordpress/compose';
 import { unlock } from '../../lock-unlock';
 import { store as editSiteStore } from '../../store';
 import getIsListPage from '../../utils/get-is-list-page';
-import useGlobalStylesRevisions from '../../components/global-styles/screen-revisions/use-global-styles-revisions';
 
 const { useGlobalStylesReset } = unlock( blockEditorPrivateApis );
 const { useHistory, useLocation } = unlock( routerPrivateApis );
@@ -123,7 +122,11 @@ function useGlobalStylesOpenRevisionsCommands() {
 	const isMobileViewport = useViewportMatch( 'medium', '<' );
 	const isEditorPage = ! getIsListPage( params, isMobileViewport );
 	const history = useHistory();
-	const { revisions } = useGlobalStylesRevisions();
+	const revisions = useSelect(
+		( select ) =>
+			select( coreStore ).getCurrentThemeGlobalStylesRevisions(),
+		[]
+	);
 	const commands = useMemo( () => {
 		if ( ! revisions?.length ) {
 			return [];

--- a/test/e2e/specs/site-editor/user-global-styles-revisions.spec.js
+++ b/test/e2e/specs/site-editor/user-global-styles-revisions.spec.js
@@ -26,22 +26,6 @@ test.describe( 'Global styles revisions', () => {
 		await admin.visitSiteEditor();
 	} );
 
-	test( 'should display no revisions message if landing via command center', async ( {
-		page,
-	} ) => {
-		await page
-			.getByRole( 'button', { name: 'Open command palette' } )
-			.focus();
-		await page.keyboard.press( 'Meta+k' );
-		await page.keyboard.type( 'styles revisions' );
-		await page
-			.getByRole( 'option', { name: 'Open styles revisions' } )
-			.click();
-		await expect(
-			page.getByTestId( 'global-styles-no-revisions' )
-		).toHaveText( 'No results found.' );
-	} );
-
 	test( 'should display revisions UI when there is more than 1 revision', async ( {
 		page,
 		editor,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Follow up of: https://github.com/WordPress/gutenberg/pull/52865#issuecomment-1649508889

This PR adds the `Open styles revisions` command conditionally, only if there are any revisions.

## Testing Instructions
1. In a block theme without styles revisions open the command center
2. Search for `Open styles revisions` command and observe it's **not** available
3. Make changes to styles and save them(that will create a revision
4. Search for `Open styles revisions` command and observe it **is** available 

