### PR TITLE
Patterns: fix editor crashing on certain search filter combinations

### DIFF
--- a/packages/block-editor/src/components/editor-styles/index.js
+++ b/packages/block-editor/src/components/editor-styles/index.js
@@ -43,13 +43,13 @@ function useDarkThemeBodyClassName( styles ) {
 				body.appendChild( tempCanvas );
 
 				backgroundColor = defaultView
-					.getComputedStyle( tempCanvas, null )
+					?.getComputedStyle( tempCanvas, null )
 					.getPropertyValue( 'background-color' );
 
 				body.removeChild( tempCanvas );
 			} else {
 				backgroundColor = defaultView
-					.getComputedStyle( canvas, null )
+					?.getComputedStyle( canvas, null )
 					.getPropertyValue( 'background-color' );
 			}
 			const colordBackgroundColor = colord( backgroundColor );

--- a/packages/rich-text/src/component/use-selection-change-compat.js
+++ b/packages/rich-text/src/component/use-selection-change-compat.js
@@ -21,7 +21,7 @@ export function useSelectionChangeCompat() {
 	return useRefEffect( ( element ) => {
 		const { ownerDocument } = element;
 		const { defaultView } = ownerDocument;
-		const selection = defaultView.getSelection();
+		const selection = defaultView?.getSelection();
 
 		let range;
 


### PR DESCRIPTION
## What?
Fixes a bug where the editor crashes and gives a BSOD when a certain combination of search terms and filters are applied in the Patterns page

## Why?
It is annoying to end up with nothing but a black screen to stare at.

## How?
Check for the existence of `defaultView` before attempting to get computed styles or current selection.

The issue seems to be one of timing between some hooks running and the editor preview windows being pulled out of the DOM as the filters are applied. I couldn't see any way of fixing this other than checking that `defaultView` is defined before using it, and this seems to resolve the crashing.

## Testing Instructions

- Make sure you have a range of synced and unsynced patterns in your site
- Go to the Patterns page in the site editor
- Click the synced filter
- Enter a search term that matches one of your pattern names exactly
- Make sure the Patterns page does not crash
- Try a range of different combinations of filters and search terms and switching between them, clearing search, etc. and make sure no crashes occur

## Screenshots or screencast <!-- if applicable -->

Before:

https://github.com/WordPress/gutenberg/assets/3629020/b11c0fe9-f52a-430e-8779-81524ed576ef

After:

https://github.com/WordPress/gutenberg/assets/3629020/9567437f-624b-440a-a573-69cf910965ac


