### PR TITLE
Patterns: correctly color code unsynced patterns titles in site editor

### DIFF
--- a/packages/edit-site/src/components/header-edit-mode/document-actions/index.js
+++ b/packages/edit-site/src/components/header-edit-mode/document-actions/index.js
@@ -128,11 +128,10 @@ function TemplateDocumentActions( { className, onBack } ) {
 
 	return (
 		<BaseDocumentActions
-			className={
-				record.wp_pattern_sync_status !== 'unsynced'
-					? classnames( 'is-synced-entity', className )
-					: className
-			}
+			className={ classnames( className, {
+				'is-synced-entity':
+					record.wp_pattern_sync_status !== 'unsynced',
+			} ) }
 			icon={ typeIcon }
 			onBack={ onBack }
 		>

--- a/packages/edit-site/src/components/header-edit-mode/document-actions/index.js
+++ b/packages/edit-site/src/components/header-edit-mode/document-actions/index.js
@@ -128,7 +128,11 @@ function TemplateDocumentActions( { className, onBack } ) {
 
 	return (
 		<BaseDocumentActions
-			className={ className }
+			className={
+				record.wp_pattern_sync_status !== 'unsynced'
+					? classnames( 'is-synced-entity', className )
+					: className
+			}
 			icon={ typeIcon }
 			onBack={ onBack }
 		>

--- a/packages/edit-site/src/components/header-edit-mode/document-actions/style.scss
+++ b/packages/edit-site/src/components/header-edit-mode/document-actions/style.scss
@@ -24,6 +24,15 @@
 	@include break-large() {
 		width: min(100%, 450px);
 	}
+
+	&.is-synced-entity {
+		.edit-site-document-actions__title {
+			color: var(--wp-block-synced-color);
+			h1 {
+				color: var(--wp-block-synced-color);
+			}
+		}
+	}
 }
 
 .edit-site-document-actions__command {
@@ -36,7 +45,6 @@
 
 .edit-site-document-actions__title {
 	flex-grow: 1;
-	color: var(--wp-block-synced-color);
 	overflow: hidden;
 	grid-column: 2 / 3;
 
@@ -48,7 +56,6 @@
 		white-space: nowrap;
 		overflow: hidden;
 		text-overflow: ellipsis;
-		color: var(--wp-block-synced-color);
 	}
 
 	.edit-site-document-actions.is-page & {


### PR DESCRIPTION
## What?
Makes sure the unsynced patterns do not have the purple title color in the site editor header bar.

## Why?
Fixes: #52923

## How?
Add an is-synced-entity class to document actions so synced entities can be properly identified and color coded.

## Testing Instructions
In the site editor patterns section load a range of different patterns and template parts in the editor and check the color of the title and icon in the editor title bar are purple for synced patterns and black for unsynced patterns

## Screenshots or screencast <!-- if applicable -->

Before:
<img width="1116" alt="Screenshot 2023-07-26 at 1 47 12 PM" src="https://github.com/WordPress/gutenberg/assets/3629020/2c6ebda8-76eb-44f1-9f0d-30c7021b535a">

After:
<img width="1130" alt="Screenshot 2023-07-26 at 1 47 27 PM" src="https://github.com/WordPress/gutenberg/assets/3629020/f481038d-474d-46db-8f2a-679d03a53c11">

