### PR TITLE
List View: Ensure onBlockDrop does not fire if there is no target

### DIFF
--- a/packages/block-editor/src/components/list-view/use-list-view-drop-zone.js
+++ b/packages/block-editor/src/components/list-view/use-list-view-drop-zone.js
@@ -489,7 +489,11 @@ export default function useListViewDropZone( { dropZoneElement } ) {
 
 	const ref = useDropZone( {
 		dropZoneElement,
-		onDrop: onBlockDrop,
+		onDrop( event ) {
+			if ( target ) {
+				onBlockDrop( event );
+			}
+		},
 		onDragLeave() {
 			throttled.cancel();
 			setTarget( null );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes: #52919

Fix issue with the List View's drag-and-drop where _sometimes_ blocks would suddenly be sent down to the bottom of the document when clicking around quickly.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

From some logging out of values, what appears to be happening on `trunk` is that if you click on a selected block very rapidly with a little bit of movement, sometimes an `onDragEnd` callback is fired (which sets `target` to `null`), before the `onDrop` callback is fired.

What's expected to happen is that dragging on a selected block will _effectively_ result in no moving of blocks occurring because the target is the same as what's being dragged over. However, the code that determines the desired target is throttled to `200ms`, so if you go to drag a block and within that `200ms` perform another drag, it's possible to fire that second drag after the first `dragEnd` event has cleared out the `target` and before the `onDragOver` gives us a new target.

I'm not 100% that this is exactly what's happening, but what I've observed is that if you're clicking around very quickly on a selected block, it seems that you can accidentally drag a block and rapidly start another drag in the same position, and due to this issue of `target` being set to `null` for a short time, the block winds up being sent all the way to the bottom.

To resolve this issue (which seems to be something of a race condition to me), we can check that the target is truthy before allowing a drop to occur.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Within the `onDrop` callback, check that the `target` is truthy before allowing `onBlockDrop` to be called. This should be pretty safe as the list view drag and drop behaviour expects that there is a target set for any kind of drop to occur.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Before applying this PR, check that you can reproduce the issue described in #52919
2. With this PR applied, try rapidly clicking on a block in the list view — it shouldn't flick the block to the bottom of the list
3. Ensure that dragging to different levels of the block hierarchy (in and out of Group blocks, and directly below nested Group blocks) works as on `trunk`
4. Ensure that dragging an image file from your computer's desktop into the List View results in an Image block being created with that image (this just checks that our truthy check for `target` doesn't interrupt drag events that are not about rearranging existing blocks)

## Screenshots or screencast <!-- if applicable -->

| Before | After |
| --- | --- |
| ![2023-07-26 14 55 26](https://github.com/WordPress/gutenberg/assets/14988353/b40f258b-438d-430e-ba27-6271ba4f052a) | ![2023-07-26 14 53 40](https://github.com/WordPress/gutenberg/assets/14988353/55766196-1268-41ec-bc47-e1fd171895ad) |