### PR TITLE
Patterns: Allow orphaned template parts to appear in general category

### DIFF
--- a/packages/block-library/src/template-part/index.php
+++ b/packages/block-library/src/template-part/index.php
@@ -247,7 +247,7 @@ function build_template_part_block_instance_variations() {
 				'area'  => $template_part->area,
 			),
 			'scope'       => array( 'inserter' ),
-			'icon'        => $icon_by_area[ $template_part->area ],
+			'icon'        => isset( $icon_by_area[ $template_part->area ] ) ? $icon_by_area[ $template_part->area ] : null,
 			'example'     => array(
 				'attributes' => array(
 					'slug'  => $template_part->slug,

--- a/packages/edit-site/src/components/page-patterns/use-patterns.js
+++ b/packages/edit-site/src/components/page-patterns/use-patterns.js
@@ -4,6 +4,7 @@
 import { parse } from '@wordpress/blocks';
 import { useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
+import { store as editorStore } from '@wordpress/editor';
 import { decodeEntities } from '@wordpress/html-entities';
 
 /**
@@ -39,14 +40,12 @@ const templatePartToPattern = ( templatePart ) => ( {
 	templatePart,
 } );
 
-const templatePartHasCategory = ( item, category ) =>
-	item.templatePart.area === category;
-
 const selectTemplatePartsAsPatterns = (
 	select,
 	{ categoryId, search = '' } = {}
 ) => {
 	const { getEntityRecords, getIsResolving } = select( coreStore );
+	const { __experimentalGetDefaultTemplatePartAreas } = select( editorStore );
 	const query = { per_page: -1 };
 	const rawTemplateParts =
 		getEntityRecords( 'postType', TEMPLATE_PARTS, query ) ??
@@ -54,6 +53,23 @@ const selectTemplatePartsAsPatterns = (
 	const templateParts = rawTemplateParts.map( ( templatePart ) =>
 		templatePartToPattern( templatePart )
 	);
+
+	// In the case where a custom template part area has been removed we need
+	// the current list of areas to cross check against so orphaned template
+	// parts can be treated as uncategorized.
+	const knownAreas = __experimentalGetDefaultTemplatePartAreas() || [];
+	const templatePartAreas = knownAreas.map( ( area ) => area.area );
+
+	const templatePartHasCategory = ( item, category ) => {
+		if ( category !== 'uncategorized' ) {
+			return item.templatePart.area === category;
+		}
+
+		return (
+			item.templatePart.area === category ||
+			! templatePartAreas.includes( item.templatePart.area )
+		);
+	};
 
 	const isResolving = getIsResolving( 'getEntityRecords', [
 		'postType',


### PR DESCRIPTION
## What?

Allows the display of a template part under the General category when it was assigned to a template part area that has since been removed.

## Why?

Currently, the General category in the Pattern's page sidebar shows a count including these "orphaned" template parts. It is confusing when the template parts then don't show up in the patterns list.

## How?

Updates the category filtering for the template parts. If the current category (template part area) is `uncategorized` a template part is considered in that category if it is explicitly assigned to `uncategorized` or is not assigned to a known template part area.

## Testing Instructions

1. Register a custom template part area
2. Create a new template part and assign it to your custom area
3. Remove the custom template part area registration
4. Navigate to the Patterns page in the site editor
5. Confirm that your template part that belong to the custom area now appears under the General category
6. Double check filtering within that category still works

**Note: Without a core patch there will likely be a PHP warning thrown due to an unsafe attempt to access an array key**

## Screenshots or screencast <!-- if applicable -->

| Before | After |
|---|---|
| <img width="1482" alt="Screenshot 2023-07-26 at 3 00 00 pm" src="https://github.com/WordPress/gutenberg/assets/60436221/f91193e6-7083-4a9b-b18c-701ff6da200b"> | <img width="1480" alt="Screenshot 2023-07-26 at 2 40 41 pm" src="https://github.com/WordPress/gutenberg/assets/60436221/47521c17-2a8a-4554-853a-06af023378ad"> |
