### PR TITLE
Borders: Prevent console error when clearing custom border color

### DIFF
--- a/packages/block-editor/src/hooks/border.js
+++ b/packages/block-editor/src/hooks/border.js
@@ -377,13 +377,14 @@ export const withBorderColorPaletteStyles = createHigherOrderComponent(
 			borderBottomColor: borderBottomColor || borderColorValue,
 			borderLeftColor: borderLeftColor || borderColorValue,
 		};
+		const cleanedExtraStyles = cleanEmptyObject( extraStyles ) || {};
 
 		let wrapperProps = props.wrapperProps;
 		wrapperProps = {
 			...props.wrapperProps,
 			style: {
 				...props.wrapperProps?.style,
-				...extraStyles,
+				...cleanedExtraStyles,
 			},
 		};
 


### PR DESCRIPTION
Related:
- https://github.com/WordPress/gutenberg/pull/51621#issuecomment-1643420666

## What?

Prevents console error when resetting custom shorthand border colors

## Why?

Unexpected errors aren't ideal.

## How?

The `extraStyles` set by the border block support's HoC are intended to fill the gap when a theme fails to load their palettes in the editor. 

If a custom border color is removed, there are still conflicting longhand styles added via this HoC that cause the error in the console. As these extra styles are added at runtime and not persisted in the block markup we can just omit them if they are `undefined`. 

## Testing Instructions

1. Before checking out this PR, add a group block to a post and select it
2. Add a custom border color that applies to all sides (shorthand or flat border color)
3. Reset the border control via the panel's menu
4. Note that there is a console error
5. Check out this PR
6. Repeat the process however this time there should be no console error
7. Bonus points for activating a theme that fails to load its palette in the editor and confirming preset colors are still applied correctly

## Screenshots or screencast <!-- if applicable -->

| Before | After |
|---|---|
| <video src="https://github.com/WordPress/gutenberg/assets/60436221/aef42a70-28f8-44b7-a393-fbbc9c6ca591" /> | <video src="https://github.com/WordPress/gutenberg/assets/60436221/0b4a0552-7510-4e8f-9e2d-6285d20b0f07" /> |



