### PR TITLE
Patterns Browse Screen: Fix back button when switching between categories

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen-patterns/category-item.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-patterns/category-item.js
@@ -12,19 +12,11 @@ export default function CategoryItem( {
 	label,
 	type,
 } ) {
-	const linkInfo = useLink(
-		{
-			path: '/patterns',
-			categoryType: type,
-			categoryId: id,
-		},
-		{
-			// Keep a record of where we came from in state so we can
-			// use the browser's back button to go back to Patterns.
-			// See the implementation of the back button in patterns-list.
-			backPath: '/patterns',
-		}
-	);
+	const linkInfo = useLink( {
+		path: '/patterns',
+		categoryType: type,
+		categoryId: id,
+	} );
 
 	if ( ! count ) {
 		return;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Follows on from https://github.com/WordPress/gutenberg/pull/52910

In the Patterns screen within the site editor browse mode, if you click between patterns categories, the back button in the UI doesn't appear to work.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

I think this is because it's currently setting the `backPath` to `/patterns`, and #52910 changed the behaviour of the back button a little, so it seems that as of that PR, clicking the back button will result in being directed to the same page the user is currently on.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Remove the `backPath` param from the patterns category links. From a little testing, I _think_ the browser back button for Patterns is still working correctly without that param. I'm not 100% sure this is the right fix, though, so happy for feedback or to throw out this PR if there's a better approach!

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Before applying this PR, go to the site editor and choose the Patterns screen from browse mode.
2. Click between categories and then click the back button in the UI. Notice it doesn't do anything.
3. Apply this PR, and the issue should be resolved, with the UI back button going up the hierarchy back to the root screen.
4. Also, double check that if you click between patterns categories that the browser's back button behaviour otherwise behaves as on trunk.

## Screenshots or screencast <!-- if applicable -->

| Before | After |
| --- | --- |
| ![2023-07-26 16 36 14](https://github.com/WordPress/gutenberg/assets/14988353/8a5367bc-ac9d-4457-9f83-1ff671634ffc) | ![2023-07-26 16 33 16](https://github.com/WordPress/gutenberg/assets/14988353/f058b409-f688-4e09-9aca-6e346db1b90b) |