### PR TITLE
Global styles revisions: add a reset to default revision

### DIFF
--- a/packages/edit-site/src/components/global-styles/screen-revisions/index.js
+++ b/packages/edit-site/src/components/global-styles/screen-revisions/index.js
@@ -137,7 +137,9 @@ function ScreenRevisions() {
 										}
 									} }
 								>
-									{ __( 'Apply' ) }
+									{ globalStylesRevision?.id === 'parent'
+										? __( 'Reset to defaults' )
+										: __( 'Apply' ) }
 								</Button>
 							</SidebarFixedBottom>
 						) }

--- a/packages/edit-site/src/components/global-styles/screen-revisions/index.js
+++ b/packages/edit-site/src/components/global-styles/screen-revisions/index.js
@@ -79,9 +79,9 @@ function ScreenRevisions() {
 
 	const selectRevision = ( revision ) => {
 		setGlobalStylesRevision( {
-			styles: revision?.styles,
-			settings: revision?.settings,
-			behaviors: revision?.behaviors,
+			styles: revision?.styles || {},
+			settings: revision?.settings || {},
+			behaviors: revision?.behaviors || {},
 			id: revision?.id,
 		} );
 		setSelectedRevisionId( revision?.id );

--- a/packages/edit-site/src/components/global-styles/screen-revisions/revisions-buttons.js
+++ b/packages/edit-site/src/components/global-styles/screen-revisions/revisions-buttons.js
@@ -72,6 +72,7 @@ function RevisionsButtons( { userRevisions, selectedRevisionId, onChange } ) {
 				const isSelected = selectedRevisionId
 					? selectedRevisionId === revision?.id
 					: index === 0;
+				const isReset = 'parent' === revision?.id;
 
 				return (
 					<li
@@ -91,29 +92,37 @@ function RevisionsButtons( { userRevisions, selectedRevisionId, onChange } ) {
 							} }
 							label={ getRevisionLabel( revision ) }
 						>
-							<span className="edit-site-global-styles-screen-revisions__description">
-								<time dateTime={ modified }>
-									{ humanTimeDiff( modified ) }
-								</time>
-								<span className="edit-site-global-styles-screen-revisions__meta">
-									{ isUnsaved
-										? sprintf(
-												/* translators: %s author display name */
-												__( 'Unsaved changes by %s' ),
-												authorDisplayName
-										  )
-										: sprintf(
-												/* translators: %s author display name */
-												__( 'Changes saved by %s' ),
-												authorDisplayName
-										  ) }
-
-									<img
-										alt={ author?.name }
-										src={ authorAvatar }
-									/>
+							{ isReset ? (
+								<span className="edit-site-global-styles-screen-revisions__description">
+									{ __( 'Theme default styles' ) }
 								</span>
-							</span>
+							) : (
+								<span className="edit-site-global-styles-screen-revisions__description">
+									<time dateTime={ modified }>
+										{ humanTimeDiff( modified ) }
+									</time>
+									<span className="edit-site-global-styles-screen-revisions__meta">
+										{ isUnsaved
+											? sprintf(
+													/* translators: %s author display name */
+													__(
+														'Unsaved changes by %s'
+													),
+													authorDisplayName
+											  )
+											: sprintf(
+													/* translators: %s author display name */
+													__( 'Changes saved by %s' ),
+													authorDisplayName
+											  ) }
+
+										<img
+											alt={ author?.name }
+											src={ authorAvatar }
+										/>
+									</span>
+								</span>
+							) }
 						</Button>
 					</li>
 				);

--- a/packages/edit-site/src/components/global-styles/screen-revisions/revisions-buttons.js
+++ b/packages/edit-site/src/components/global-styles/screen-revisions/revisions-buttons.js
@@ -9,6 +9,8 @@ import classnames from 'classnames';
 import { __, sprintf } from '@wordpress/i18n';
 import { Button } from '@wordpress/components';
 import { dateI18n, getDate, humanTimeDiff, getSettings } from '@wordpress/date';
+import { store as coreStore } from '@wordpress/core-data';
+import { useSelect } from '@wordpress/data';
 
 /**
  * Returns a button label for the revision.
@@ -19,6 +21,10 @@ import { dateI18n, getDate, humanTimeDiff, getSettings } from '@wordpress/date';
 function getRevisionLabel( revision ) {
 	const authorDisplayName = revision?.author?.name || __( 'User' );
 
+	if ( 'parent' === revision?.id ) {
+		return __( 'Reset the styles to the theme defaults' );
+	}
+
 	if ( 'unsaved' === revision?.id ) {
 		return sprintf(
 			/* translators: %s author display name */
@@ -26,6 +32,7 @@ function getRevisionLabel( revision ) {
 			authorDisplayName
 		);
 	}
+
 	const formattedDate = dateI18n(
 		getSettings().formats.datetimeAbbreviated,
 		getDate( revision?.modified )
@@ -58,6 +65,10 @@ function getRevisionLabel( revision ) {
  * @return {JSX.Element} The modal component.
  */
 function RevisionsButtons( { userRevisions, selectedRevisionId, onChange } ) {
+	const currentTheme = useSelect(
+		( select ) => select( coreStore ).getCurrentTheme(),
+		[]
+	);
 	return (
 		<ol
 			className="edit-site-global-styles-screen-revisions__revisions-list"
@@ -80,6 +91,7 @@ function RevisionsButtons( { userRevisions, selectedRevisionId, onChange } ) {
 							'edit-site-global-styles-screen-revisions__revision-item',
 							{
 								'is-selected': isSelected,
+								'is-reset': isReset,
 							}
 						) }
 						key={ id }
@@ -94,7 +106,11 @@ function RevisionsButtons( { userRevisions, selectedRevisionId, onChange } ) {
 						>
 							{ isReset ? (
 								<span className="edit-site-global-styles-screen-revisions__description">
-									{ __( 'Theme default styles' ) }
+									{ __( 'Default styles' ) }
+									<span className="edit-site-global-styles-screen-revisions__meta">
+										{ currentTheme?.name?.rendered ||
+											currentTheme?.stylesheet }
+									</span>
 								</span>
 							) : (
 								<span className="edit-site-global-styles-screen-revisions__description">

--- a/packages/edit-site/src/components/global-styles/screen-revisions/test/use-global-styles-revisions.js
+++ b/packages/edit-site/src/components/global-styles/screen-revisions/test/use-global-styles-revisions.js
@@ -71,6 +71,11 @@ describe( 'useGlobalStylesRevisions', () => {
 				settings: {},
 				styles: {},
 			},
+			{
+				id: 'parent',
+				settings: {},
+				styles: {},
+			},
 		] );
 	} );
 
@@ -103,6 +108,11 @@ describe( 'useGlobalStylesRevisions', () => {
 				},
 				id: 1,
 				isLatest: true,
+				settings: {},
+				styles: {},
+			},
+			{
+				id: 'parent',
 				settings: {},
 				styles: {},
 			},

--- a/packages/edit-site/src/components/global-styles/screen-revisions/use-global-styles-revisions.js
+++ b/packages/edit-site/src/components/global-styles/screen-revisions/use-global-styles-revisions.js
@@ -99,6 +99,12 @@ export default function useGlobalStylesRevisions() {
 
 				_modifiedRevisions.unshift( unsavedRevision );
 			}
+
+			_modifiedRevisions.push( {
+				id: 'parent',
+				styles: {},
+				settings: {},
+			} );
 		}
 
 		return {

--- a/packages/edit-site/src/components/global-styles/ui.js
+++ b/packages/edit-site/src/components/global-styles/ui.js
@@ -139,7 +139,7 @@ function GlobalStylesRevisionsMenu() {
 		goTo( '/revisions' );
 		setEditorCanvasContainerView( 'global-styles-revisions' );
 	};
-	const hasRevisions = revisionsCount >= 2;
+	const hasRevisions = revisionsCount >= 1;
 
 	return (
 		<GlobalStylesMenuFill>

--- a/test/e2e/specs/site-editor/user-global-styles-revisions.spec.js
+++ b/test/e2e/specs/site-editor/user-global-styles-revisions.spec.js
@@ -68,9 +68,9 @@ test.describe( 'Global styles revisions', () => {
 			name: /^Changes saved by /,
 		} );
 
-		// There should be 2 revisions plus the added reset to theme defaults button.
+		// There should be 2 revisions not including the reset to theme defaults button.
 		await expect( revisionButtons ).toHaveCount(
-			currentRevisions.length + 3
+			currentRevisions.length + 2
 		);
 	} );
 
@@ -102,7 +102,7 @@ test.describe( 'Global styles revisions', () => {
 			.last()
 			.click();
 
-		await page.getByRole( 'button', { name: 'Reset to defaults' } ).click();
+		await page.getByRole( 'button', { name: 'Apply' } ).click();
 
 		const confirm = page.getByRole( 'dialog' );
 		await expect( confirm ).toBeVisible();
@@ -116,6 +116,25 @@ test.describe( 'Global styles revisions', () => {
 			.getByRole( 'button', { name: 'Cancel' } )
 			.click();
 		await editor.saveSiteEditorEntities();
+	} );
+
+	test( 'should have a reset to defaults button', async ( {
+		page,
+		editor,
+		userGlobalStylesRevisions,
+	} ) => {
+		await editor.canvas.click( 'body' );
+		await userGlobalStylesRevisions.openStylesPanel();
+		await userGlobalStylesRevisions.openRevisions();
+		const lastRevisionButton = page
+			.getByLabel( 'Global styles revisions' )
+			.getByRole( 'button' )
+			.last();
+		await expect( lastRevisionButton ).toContainText( 'Default styles' );
+		await lastRevisionButton.click();
+		await expect(
+			page.getByRole( 'button', { name: 'Reset to defaults' } )
+		).toBeVisible();
 	} );
 } );
 

--- a/test/e2e/specs/site-editor/user-global-styles-revisions.spec.js
+++ b/test/e2e/specs/site-editor/user-global-styles-revisions.spec.js
@@ -68,8 +68,9 @@ test.describe( 'Global styles revisions', () => {
 			name: /^Changes saved by /,
 		} );
 
+		// There should be 2 revisions plus the added reset to theme defaults button.
 		await expect( revisionButtons ).toHaveCount(
-			currentRevisions.length + 2
+			currentRevisions.length + 3
 		);
 	} );
 
@@ -101,7 +102,7 @@ test.describe( 'Global styles revisions', () => {
 			.last()
 			.click();
 
-		await page.getByRole( 'button', { name: 'Apply' } ).click();
+		await page.getByRole( 'button', { name: 'Reset to defaults' } ).click();
 
 		const confirm = page.getByRole( 'dialog' );
 		await expect( confirm ).toBeVisible();


### PR DESCRIPTION
Resolves https://github.com/WordPress/gutenberg/issues/52951

## What?
Inserting a reset object as the first "revision" to reset to theme defaults.

Originally spoken about in https://github.com/WordPress/gutenberg/pull/50089#issuecomment-1532324313

## Why?
Testing out reducing any perceived confusion explained in https://github.com/WordPress/gutenberg/issues/52951

Basically we are trying to find a way to show the revisions panel after a the first change, instead of two changes.

Reason behind the two change rule here: https://github.com/WordPress/gutenberg/pull/50089#issuecomment-1532276020

## How?
Adding a 'fake' revision to the end of the revisions UI list.

## TODO

- [x] Fix tests, add an E2E test

## Testing Instructions

1.  Using a block theme, head to the site editor
2. Create a single global styles change and save
3. Open the revisions panel
4. You should be see 1 revision and the original theme "revision"
5. Check that selecting revisions works as per usual
6. Change themes to a new block theme and add a few revisions. Make sure the theme name is correctly rendered in the reset styles revision button at the bottom of the styles revisions list.

## Screenshots or screencast <!-- if applicable -->


https://github.com/WordPress/gutenberg/assets/6458278/dea3f22b-0b90-4102-869e-98255c1411c7




