### PR TITLE
[RNMobile] Do not include MediaReplaceFlow component in native Gallery toolbar

### DIFF
--- a/packages/block-editor/src/components/media-replace-flow/index.native.js
+++ b/packages/block-editor/src/components/media-replace-flow/index.native.js
@@ -6,7 +6,7 @@ import { View } from 'react-native';
 // MediaReplaceFlow component is not yet implemented in the native version.
 // For testing purposes, we are using an empty View component with a testID prop.
 const MediaReplaceFlow = () => {
-	return <View testID={ 'media-replace-flow' } />;
+	return <View testID="media-replace-flow" />;
 };
 
 export default MediaReplaceFlow;

--- a/packages/block-editor/src/components/media-replace-flow/index.native.js
+++ b/packages/block-editor/src/components/media-replace-flow/index.native.js
@@ -1,3 +1,12 @@
-// MediaReplaceFlow component is not yet implemented in the native version,
-// so we return an empty component instead.
-export default () => null;
+/**
+ * External dependencies
+ */
+import { View } from 'react-native';
+
+// MediaReplaceFlow component is not yet implemented in the native version.
+// For testing purposes, we are using an empty View component with a testID prop.
+const MediaReplaceFlow = () => {
+	return <View testID={ 'media-replace-flow' } />;
+};
+
+export default MediaReplaceFlow;

--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -635,25 +635,27 @@ function GalleryEdit( props ) {
 					/>
 				) }
 			</BlockControls>
-			<BlockControls group="other">
-				<MediaReplaceFlow
-					allowedTypes={ ALLOWED_MEDIA_TYPES }
-					accept="image/*"
-					handleUpload={ false }
-					onSelect={ updateImages }
-					name={ __( 'Add' ) }
-					multiple={ true }
-					mediaIds={ images
-						.filter( ( image ) => image.id )
-						.map( ( image ) => image.id ) }
-					addToGallery={ hasImageIds }
-				/>
-			</BlockControls>
 			{ Platform.isWeb && (
-				<GapStyles
-					blockGap={ attributes.style?.spacing?.blockGap }
-					clientId={ clientId }
-				/>
+				<>
+					<BlockControls group="other">
+						<MediaReplaceFlow
+							allowedTypes={ ALLOWED_MEDIA_TYPES }
+							accept="image/*"
+							handleUpload={ false }
+							onSelect={ updateImages }
+							name={ __( 'Add' ) }
+							multiple={ true }
+							mediaIds={ images
+								.filter( ( image ) => image.id )
+								.map( ( image ) => image.id ) }
+							addToGallery={ hasImageIds }
+						/>
+					</BlockControls>
+					<GapStyles
+						blockGap={ attributes.style?.spacing?.blockGap }
+						clientId={ clientId }
+					/>
+				</>
 			) }
 			<Gallery
 				{ ...props }

--- a/packages/block-library/src/gallery/test/index.native.js
+++ b/packages/block-library/src/gallery/test/index.native.js
@@ -622,6 +622,20 @@ describe( 'Gallery block', () => {
 		expect( getEditorHtml() ).toMatchSnapshot();
 	} );
 
+	it( 'does not display MediaReplaceFlow component within the block toolbar', async () => {
+		const screen = await initializeWithGalleryBlock( {
+			numberOfItems: 3,
+			media,
+		} );
+		const { queryByTestId } = screen;
+
+		fireEvent.press( getBlock( screen, 'Gallery' ) );
+
+		// Expect the native MediaReplaceFlow component to not be present in the block toolbar
+		const mediaReplaceFlow = queryByTestId( 'media-replace-flow' );
+		expect( mediaReplaceFlow ).toBeNull();
+	} );
+
 	// Test cases related to TC013 - Settings - Columns
 	// Reference: https://github.com/wordpress-mobile/test-cases/blob/trunk/test-cases/gutenberg/gallery.md#tc013
 	describe( 'Columns setting', () => {

--- a/packages/react-native-editor/CHANGELOG.md
+++ b/packages/react-native-editor/CHANGELOG.md
@@ -10,6 +10,7 @@ For each user feature we should also add a importance categorization label  to i
 -->
 
 ## Unreleased
+-   [*] Remove visual gap in mobile toolbar when a Gallery block is selected [#52966]
 
 ## 1.100.1
 -   [**] Add WP hook for registering non-core blocks [#52791]


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Resolves an issue with removing an extra visual gap in the mobile toolbar.

Related:
* https://github.com/wordpress-mobile/gutenberg-mobile/issues/5998
* https://github.com/wordpress-mobile/gutenberg-mobile/pull/5999

## Why?
Under the new Editor UX changes (released in Gutenberg 1.100.1 / WordPress 22.9), the mobile block toolbar buttons were rearranged, with the [Block "More" and "Settings" buttons being moved](https://github.com/WordPress/gutenberg/pull/52289) from the block to the toolbar itself. In the native Gallery block, this change exposed an extra BlockControls component gap within the toolbar wrapping the MediaReplaceFlow component:

https://github.com/WordPress/gutenberg/blob/bdde553b1796c556b93d97da8ffb6a89e5d955ea/packages/block-library/src/gallery/edit.js#L638-L651

MediaReplaceFlow is not yet implemented on mobile, and the native component currently returns an [empty null component value](https://github.com/WordPress/gutenberg/blob/bdde553b1796c556b93d97da8ffb6a89e5d955ea/packages/block-editor/src/components/media-replace-flow/index.native.js#L1-L3
).  As the Gallery block shares the [edit.js](https://github.com/WordPress/gutenberg/blob/trunk/packages/block-library/src/gallery/edit.js) file between web and mobile, this extra BlockControls separator is wrapping an empty component. The addition of moving the More and Settings buttons after this within the toolbar adds a unnecessary double border from the BlockControls component.

## How?

1. In gallery/edit.js, the MediaReplaceFlow component is moved within an existing `Platform.isWeb` boolean block so it is not present in the mobile toolbar. 
2. The native MediaReplaceFlow is converted to an empty `<View />` with a testID so that it can be tested.
3. The native Gallery tests are updated to check that the MediaReplaceFlow component is not present in the toolbar.  This seemed like the most direct way to test that the visual gap would not be present within an integration test, but I am open to other ideas that may be more elegant. 

## Testing Instructions
1. Create a new post
2. Add a gallery block with some images
3. Tap the gallery block to focus the toolbar (not the individual child gallery items)
4. Observe that there is not an extra gap in the toolbar

## Screenshots or screencast <!-- if applicable -->
Before | After
-|-
<img src="https://github.com/WordPress/gutenberg/assets/643285/e56e458b-08fe-4b32-a19b-42bf155b23e4" /> | <img  src="https://github.com/WordPress/gutenberg/assets/643285/d37366ca-33c8-48ea-8940-13e2c33c0c95" />


