### PR TITLE
Fix PHP warnings coming from Classic block compat experiment

### DIFF
--- a/lib/experimental/disable-tinymce.php
+++ b/lib/experimental/disable-tinymce.php
@@ -61,14 +61,15 @@ function gutenberg_post_being_edited_requires_classic_block() {
 		return false;
 	}
 
+	$current_post = null;
+
 	// Handle the post editor.
 	if ( ! empty( $_GET['post'] ) && ! empty( $_GET['action'] ) && 'edit' === $_GET['action'] ) {
-		$current_post = get_post( intval( $_GET['post'] ) );
-		if ( ! $current_post || is_wp_error( $current_post ) ) {
-			return false;
-		}
+		$current_post = get_post( absint( $_GET['post'] ) );
+	}
 
-		$content = $current_post->post_content;
+	if ( ! $current_post ) {
+		return false;
 	}
 
 	// Check if block editor is disabled by "Classic Editor" or another plugin.
@@ -79,11 +80,11 @@ function gutenberg_post_being_edited_requires_classic_block() {
 		return true;
 	}
 
-	if ( empty( $content ) ) {
+	if ( empty( $current_post->content ) ) {
 		return false;
 	}
 
-	$parsed_blocks = parse_blocks( $content );
+	$parsed_blocks = parse_blocks( $current_post->content );
 	foreach ( $parsed_blocks as $block ) {
 		if ( empty( $block['blockName'] ) && strlen( trim( $block['innerHTML'] ) ) > 0 ) {
 			return true;


### PR DESCRIPTION
## What?
PR updates early bailout logic in `gutenberg_post_being_edited_requires_classic_block` to avoid PHP notices when visiting admin pages.

```
PHP Warning:  Undefined variable $current_post in ~/gutenberg/wp-content/plugins/gutenberg/lib/experimental/disable-tinymce.php on line 77
PHP Warning:  Attempt to read property "post_type" on null in ~/gutenberg/wp-content/plugins/gutenberg/lib/experimental/disable-tinymce.php on line 77
```

## Why?
The previous early return condition was never reached without `post` and `action` query args.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
1. Disable TinyMCE and Classic block from Gutenberg > Experiments.
2. Refresh the experiments page or go to the dashboard.
3. Confirm no PHP errors are logged.