### PR TITLE
I18N: Add missing Gettext wrapper on strings in Edit Post overview sidebar

### DIFF
--- a/packages/edit-post/src/components/secondary-sidebar/list-view-sidebar.js
+++ b/packages/edit-post/src/components/secondary-sidebar/list-view-sidebar.js
@@ -11,7 +11,7 @@ import {
 import { useDispatch } from '@wordpress/data';
 import { focus } from '@wordpress/dom';
 import { useRef, useState } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import { closeSmall } from '@wordpress/icons';
 import { useShortcut } from '@wordpress/keyboard-shortcuts';
 import { ESCAPE } from '@wordpress/keycodes';
@@ -140,12 +140,12 @@ export default function ListViewSidebar() {
 				tabs={ [
 					{
 						name: 'list-view',
-						title: __( 'List View' ),
+						title: _x( 'List View', 'Post overview' ),
 						className: 'edit-post-sidebar__panel-tab',
 					},
 					{
 						name: 'outline',
-						title: __( 'Outline' ),
+						title: _x( 'Outline', 'Post overview' ),
 						className: 'edit-post-sidebar__panel-tab',
 					},
 				] }

--- a/packages/edit-post/src/components/secondary-sidebar/list-view-sidebar.js
+++ b/packages/edit-post/src/components/secondary-sidebar/list-view-sidebar.js
@@ -140,12 +140,12 @@ export default function ListViewSidebar() {
 				tabs={ [
 					{
 						name: 'list-view',
-						title: 'List View',
+						title: __( 'List View' ),
 						className: 'edit-post-sidebar__panel-tab',
 					},
 					{
 						name: 'outline',
-						title: 'Outline',
+						title: __( 'Outline' ),
 						className: 'edit-post-sidebar__panel-tab',
 					},
 				] }


### PR DESCRIPTION
## What?
Fix i18n on strings in Edit Post overview sidebar

## Why?
To be able to translate "List View" and "Outline" in Post editor overview sidebar tabs

## How?
Added `_x()` with context to avoid confusion with common "Outline" strings used everywhere else in border styling context.

## Testing Instructions
1. Build and update translation files to include the new "List View" and "Outline" strings with context.
2. Set a language on Settings > General other than English (US).
3. Add new post
4. Click on the overview icon on the top toolbar on the left
5. See both tabs titles translated.

Fixes #52970 
