### PR TITLE
Update the `ConfirmDialog` that appears when applying a style revision over unsaved changes

### DIFF
--- a/packages/edit-site/src/components/global-styles/screen-revisions/index.js
+++ b/packages/edit-site/src/components/global-styles/screen-revisions/index.js
@@ -144,13 +144,8 @@ function ScreenRevisions() {
 					</div>
 					{ isLoadingRevisionWithUnsavedChanges && (
 						<ConfirmDialog
-							title={ __(
-								'Loading this revision will discard all unsaved changes.'
-							) }
 							isOpen={ isLoadingRevisionWithUnsavedChanges }
-							confirmButtonText={ __(
-								' Discard unsaved changes'
-							) }
+							confirmButtonText={ __( 'Apply' ) }
 							onConfirm={ () =>
 								restoreRevision( globalStylesRevision )
 							}
@@ -158,18 +153,9 @@ function ScreenRevisions() {
 								setIsLoadingRevisionWithUnsavedChanges( false )
 							}
 						>
-							<>
-								<h2>
-									{ __(
-										'Loading this revision will discard all unsaved changes.'
-									) }
-								</h2>
-								<p>
-									{ __(
-										'Do you want to replace your unsaved changes in the editor?'
-									) }
-								</p>
-							</>
+							{ __(
+								'Any unsaved changes will be lost when you apply this revision.'
+							) }
 						</ConfirmDialog>
 					) }
 				</>

--- a/test/e2e/specs/site-editor/user-global-styles-revisions.spec.js
+++ b/test/e2e/specs/site-editor/user-global-styles-revisions.spec.js
@@ -106,7 +106,7 @@ test.describe( 'Global styles revisions', () => {
 		const confirm = page.getByRole( 'dialog' );
 		await expect( confirm ).toBeVisible();
 		await expect( confirm ).toHaveText(
-			/^Loading this revision will discard all unsaved changes/
+			/^Any unsaved changes will be lost when you apply this revision./
 		);
 
 		// This is to make sure there are no lingering unsaved changes.


### PR DESCRIPTION
## What?
Simplify ConfirmDialog application in style revisions, and align with similar instances.

## Why?
Consistency is good. A couple of principles are violated in this context:

1. Confirmation button repeats the initial action.
2. No heading.

## How?
1. Remove `title` prop – `ConfirmDialog` [doesn't support it](https://wordpress.github.io/gutenberg/?path=/docs/components-experimental-confirmdialog--default).
3. `confirmButtonText` now repeats original action.
4. Update body copy

## Testing Instructions
1. Open the site editor and create some style revisions.
2. Edit a style
3. Open style revisions and select a revision, click Apply
5. Observe the updated dialog

| Before | After |
| --- | --- |
| <img width="574" alt="Screenshot 2023-07-26 at 10 49 36" src="https://github.com/WordPress/gutenberg/assets/846565/936f73b5-59d4-459a-8c0a-e40615a25d06"> | <img width="514" alt="Screenshot 2023-07-26 at 10 58 24" src="https://github.com/WordPress/gutenberg/assets/846565/5eec2d30-4e42-4318-91d7-c2dc8257ba37"> |

## Alignment
Examples of similar confirmation modals in the site editor:

| Deleting a template | Deleting a pattern |
| --- | --- |
| <img width="426" alt="Screenshot 2023-07-26 at 11 03 12" src="https://github.com/WordPress/gutenberg/assets/846565/71f0b15e-65df-4718-8107-1754764de7a8"> | <img width="471" alt="Screenshot 2023-07-26 at 11 03 25" src="https://github.com/WordPress/gutenberg/assets/846565/e062f857-7a86-4fe6-8636-69e7b5dcb681"> |

We might consider the "Are you sure..." prefix an emerging principle, in which case the body copy might read:

> Are you sure you want to apply this style revision? Any unsaved changes will be lost.

cc @WordPress/gutenberg-design for thoughts on that.
