### PR TITLE
Site Editor: Fix document actions label helper method

### DIFF
--- a/packages/edit-site/src/components/header-edit-mode/document-actions/index.js
+++ b/packages/edit-site/src/components/header-edit-mode/document-actions/index.js
@@ -6,7 +6,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { sprintf, __, isRTL } from '@wordpress/i18n';
+import { __, isRTL } from '@wordpress/i18n';
 import { useSelect, useDispatch } from '@wordpress/data';
 import {
 	Button,
@@ -118,8 +118,6 @@ function TemplateDocumentActions( { className, onBack } ) {
 		);
 	}
 
-	const entityLabel = getEntityLabel( record.type );
-
 	let typeIcon = icon;
 	if ( record.type === 'wp_navigation' ) {
 		typeIcon = navigationIcon;
@@ -137,11 +135,7 @@ function TemplateDocumentActions( { className, onBack } ) {
 			onBack={ onBack }
 		>
 			<VisuallyHidden as="span">
-				{ sprintf(
-					/* translators: %s: the entity being edited, like "template"*/
-					__( 'Editing %s: ' ),
-					entityLabel
-				) }
+				{ getEntityLabel( record.type ) }
 			</VisuallyHidden>
 			{ getTitle() }
 		</BaseDocumentActions>
@@ -189,18 +183,12 @@ function BaseDocumentActions( { className, icon, children, onBack } ) {
 }
 
 function getEntityLabel( entityType ) {
-	let label = '';
-	switch ( entityType ) {
-		case 'wp_navigation':
-			label = 'navigation menu';
-			break;
-		case 'wp_template_part':
-			label = 'template part';
-			break;
-		default:
-			label = 'template';
-			break;
-	}
+	const labels = {
+		wp_block: __( 'Editing pattern:' ),
+		wp_navigation: __( 'Editing navigation menu:' ),
+		wp_template: __( 'Editing template:' ),
+		wp_template_part: __( 'Editing template part:' ),
+	};
 
-	return label;
+	return labels[ entityType ] ?? labels.wp_template;
 }

--- a/packages/edit-site/src/components/header-edit-mode/document-actions/index.js
+++ b/packages/edit-site/src/components/header-edit-mode/document-actions/index.js
@@ -34,7 +34,10 @@ import useEditedEntityRecord from '../../use-edited-entity-record';
 import { store as editSiteStore } from '../../../store';
 
 export default function DocumentActions() {
-	const isPage = useSelect( ( select ) => select( editSiteStore ).isPage() );
+	const isPage = useSelect(
+		( select ) => select( editSiteStore ).isPage(),
+		[]
+	);
 	return isPage ? <PageDocumentActions /> : <TemplateDocumentActions />;
 }
 

--- a/packages/edit-site/src/components/header-edit-mode/document-actions/index.js
+++ b/packages/edit-site/src/components/header-edit-mode/document-actions/index.js
@@ -33,6 +33,13 @@ import { store as coreStore } from '@wordpress/core-data';
 import useEditedEntityRecord from '../../use-edited-entity-record';
 import { store as editSiteStore } from '../../../store';
 
+const typeLabels = {
+	wp_block: __( 'Editing pattern:' ),
+	wp_navigation: __( 'Editing navigation menu:' ),
+	wp_template: __( 'Editing template:' ),
+	wp_template_part: __( 'Editing template part:' ),
+};
+
 export default function DocumentActions() {
 	const isPage = useSelect(
 		( select ) => select( editSiteStore ).isPage(),
@@ -138,7 +145,7 @@ function TemplateDocumentActions( { className, onBack } ) {
 			onBack={ onBack }
 		>
 			<VisuallyHidden as="span">
-				{ getEntityLabel( record.type ) }
+				{ typeLabels[ record.type ] ?? typeLabels.wp_template }
 			</VisuallyHidden>
 			{ getTitle() }
 		</BaseDocumentActions>
@@ -183,15 +190,4 @@ function BaseDocumentActions( { className, icon, children, onBack } ) {
 			</Button>
 		</div>
 	);
-}
-
-function getEntityLabel( entityType ) {
-	const labels = {
-		wp_block: __( 'Editing pattern:' ),
-		wp_navigation: __( 'Editing navigation menu:' ),
-		wp_template: __( 'Editing template:' ),
-		wp_template_part: __( 'Editing template part:' ),
-	};
-
-	return labels[ entityType ] ?? labels.wp_template;
 }

--- a/test/e2e/specs/site-editor/title.spec.js
+++ b/test/e2e/specs/site-editor/title.spec.js
@@ -26,7 +26,7 @@ test.describe( 'Site editor title', () => {
 			'role=region[name="Editor top bar"i] >> role=heading[level=1]'
 		);
 
-		await expect( title ).toHaveText( 'Editing template: Index' );
+		await expect( title ).toHaveText( 'Editing template:Index' );
 	} );
 
 	test( 'displays the selected template name in the title for the header template', async ( {
@@ -43,6 +43,6 @@ test.describe( 'Site editor title', () => {
 			'role=region[name="Editor top bar"i] >> role=heading[level=1]'
 		);
 
-		await expect( title ).toHaveText( 'Editing template part: header' );
+		await expect( title ).toHaveText( 'Editing template part:header' );
 	} );
 } );


### PR DESCRIPTION
## What?
PR updates the entity type label map for the document actions component to avoid missing translations. I've also added a missing label for patterns.

## Why?
The previous method for concatenating translation strings isn't ideal. The `sprintf` should be used when strings aren't static.

## How?
Create a label map and return an entire string for a record type, fallback to the template when there's no label available.

## Testing Instructions
1. Open the Site Editor.
2. Edit different types of entities - Navigation, Pattern, Templates.
3. Confirm document action label is correctly rendered in a11y tree.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2023-07-26 at 14 19 37](https://github.com/WordPress/gutenberg/assets/240569/2f2c894f-4441-42ed-a0e4-964e42329f07)
