### PR TITLE
Enforce PR labels: Make PR label checks non-blocking to merge while trying a different GH token setting

### DIFF
--- a/.github/workflows/enforce-pr-labels.yml
+++ b/.github/workflows/enforce-pr-labels.yml
@@ -6,7 +6,6 @@ jobs:
   type-related-labels:
     runs-on: ubuntu-latest
     permissions:
-      issues: write
       pull-requests: write
     steps:
       - uses: mheap/github-action-required-labels@v5
@@ -16,3 +15,5 @@ jobs:
           labels: "[Type] Accessibility (a11y), [Type] Automated Testing, [Type] Breaking Change, [Type] Bug, [Type] Build Tooling, [Type] Code Quality, [Type] Copy, [Type] Developer Documentation, [Type] Enhancement, [Type] Experimental, [Type] Feature, [Type] New API, [Type] Task, [Type] Performance, [Type] Project Management, [Type] Security, [Type] WP Core Ticket"
           add_comment: true
           message: "## ⚠️ Type of PR label error\n To merge this PR, it requires {{ errorString }} {{ count }} label indicating the type of PR. Other labels are optional and not being checked here. \n- **Type-related labels to choose from**: {{ provided }}.\n- **Labels found**: {{ applied }}."
+          token: ${{ secrets.GITHUB_TOKEN }}
+          exit_type: success


### PR DESCRIPTION
Follow-up to #52760

## What?
The action checking the PR labels is not working properly due to permission issues. This change tries using `${{ secrets.GITHUB_TOKEN }}` instead of the default `${{ github.token }}` as an alternative while making the label checks non-blocking to merge PRs. 

## Why?
As the action is currently failing, it will block PRs from being merged until fixed.

## How?
By adding the `exit_type: success` property to the action settings.