### PR TITLE
Enforce PR labels: Try using a different token

### DIFF
--- a/.github/workflows/enforce-pr-labels.yml
+++ b/.github/workflows/enforce-pr-labels.yml
@@ -15,5 +15,5 @@ jobs:
           labels: "[Type] Accessibility (a11y), [Type] Automated Testing, [Type] Breaking Change, [Type] Bug, [Type] Build Tooling, [Type] Code Quality, [Type] Copy, [Type] Developer Documentation, [Type] Enhancement, [Type] Experimental, [Type] Feature, [Type] New API, [Type] Task, [Type] Performance, [Type] Project Management, [Type] Security, [Type] WP Core Ticket"
           add_comment: true
           message: "## ⚠️ Type of PR label error\n To merge this PR, it requires {{ errorString }} {{ count }} label indicating the type of PR. Other labels are optional and not being checked here. \n- **Type-related labels to choose from**: {{ provided }}.\n- **Labels found**: {{ applied }}."
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GUTENBERG_TOKEN }}
           exit_type: success


### PR DESCRIPTION
Follow-up to #52975

## What?
Tries using a different token  for the automation that enforces PR labels.

## Why?
The GitHub automation that enforces PR labels fails in some cases due to insufficient permissions.

## How?
Using `GUTENBERG_TOKEN` instead of `GITHUB_TOKEN`