### PR TITLE
Enforce PR labels: change permissions to `read`

### DIFF
--- a/.github/workflows/enforce-pr-labels.yml
+++ b/.github/workflows/enforce-pr-labels.yml
@@ -6,7 +6,8 @@ jobs:
   type-related-labels:
     runs-on: ubuntu-latest
     permissions:
-      pull-requests: write
+      issues: read
+      pull-requests: read
     steps:
       - uses: mheap/github-action-required-labels@v5
         with:
@@ -15,5 +16,5 @@ jobs:
           labels: "[Type] Accessibility (a11y), [Type] Automated Testing, [Type] Breaking Change, [Type] Bug, [Type] Build Tooling, [Type] Code Quality, [Type] Copy, [Type] Developer Documentation, [Type] Enhancement, [Type] Experimental, [Type] Feature, [Type] New API, [Type] Task, [Type] Performance, [Type] Project Management, [Type] Security, [Type] WP Core Ticket"
           add_comment: true
           message: "## ⚠️ Type of PR label error\n To merge this PR, it requires {{ errorString }} {{ count }} label indicating the type of PR. Other labels are optional and not being checked here. \n- **Type-related labels to choose from**: {{ provided }}.\n- **Labels found**: {{ applied }}."
-          token: ${{ secrets.GUTENBERG_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           exit_type: success


### PR DESCRIPTION
Follow up to #52979

## What?
Changes permissions the GitHub action that enforces PR labels to `read`

## Why?
In some cases, the action is failing due to insufficient permissions.

## How?
By changing the permissions to `read` [as suggested by the action author](https://github.com/mheap/github-action-required-labels/issues/49#issuecomment-1492948272).
