### PR TITLE
Enforce PR labels: use `pull_request_target` trigger to work with PRs coming from forks

### DIFF
--- a/.github/workflows/enforce-pr-labels.yml
+++ b/.github/workflows/enforce-pr-labels.yml
@@ -1,13 +1,12 @@
 name: Enforce labels on Pull Request
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, labeled, unlabeled, synchronize]
 jobs:
   type-related-labels:
     runs-on: ubuntu-latest
     permissions:
-      issues: read
-      pull-requests: read
+      pull-requests: write
     steps:
       - uses: mheap/github-action-required-labels@v5
         with:
@@ -16,5 +15,4 @@ jobs:
           labels: "[Type] Accessibility (a11y), [Type] Automated Testing, [Type] Breaking Change, [Type] Bug, [Type] Build Tooling, [Type] Code Quality, [Type] Copy, [Type] Developer Documentation, [Type] Enhancement, [Type] Experimental, [Type] Feature, [Type] New API, [Type] Task, [Type] Performance, [Type] Project Management, [Type] Security, [Type] WP Core Ticket"
           add_comment: true
           message: "## ⚠️ Type of PR label error\n To merge this PR, it requires {{ errorString }} {{ count }} label indicating the type of PR. Other labels are optional and not being checked here. \n- **Type-related labels to choose from**: {{ provided }}.\n- **Labels found**: {{ applied }}."
-          token: ${{ secrets.GITHUB_TOKEN }}
           exit_type: success


### PR DESCRIPTION
Follow-up to #52980 and #52980
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
The action that enforces PR labels set in #52980 doesn't work properly with PRs coming from forks. This PR changes the action trigger to fix this issue and work with all PRs.

## Why?
When using the `pull_request`event, `${{ secrets.GITHUB_TOKEN }}` is not given `write` permissions.

## How?
By using the [`pull_request_target`](https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/#improvements-for-public-repository-forks) event instead:
> In order to solve this, we’ve added a new pull_request_target event, which behaves in an almost identical way to the pull_request event with the same set of filters and payload. However, instead of running against the workflow and code from the merge commit, the event runs against the workflow and code from the base of the pull request. This means the workflow is running from a trusted source and is given access to a read/write token as well as secrets enabling the maintainer to safely comment on or label a pull request.

## Testing Instructions
Once merged, change a label or update a PR that is coming from a fork and check the `Enforce PR labels` action is passing.