### PR TITLE
Bump plugin minimum supported PHP version to 7.0

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -97,7 +97,7 @@ jobs:
                 wordpress: [''] # Latest WordPress version.
                 include:
                     # Test with the previous WP version.
-                    - php: '5.6'
+                    - php: '7.0'
                       wordpress: ${{ needs.compute-previous-wordpress-version.outputs.previous-wordpress-version }}
                     - php: '7.4'
                       wordpress: ${{ needs.compute-previous-wordpress-version.outputs.previous-wordpress-version }}

--- a/gutenberg.php
+++ b/gutenberg.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://github.com/WordPress/gutenberg
  * Description: Printing since 1440. This is the development plugin for the block editor, site editor, and other future WordPress core functionality.
  * Requires at least: 6.1
- * Requires PHP: 5.6
+ * Requires PHP: 7.0
  * Version: 16.3.0
  * Author: Gutenberg Team
  * Text Domain: gutenberg

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -2,7 +2,8 @@
 <ruleset name="WordPress Coding Standards for Gutenberg Plugin">
 	<description>Sniffs for WordPress plugins, with minor modifications for Gutenberg</description>
 
-	<config name="testVersion" value="5.6-"/>
+	<!-- Check for cross-version support for PHP 7.0 and higher. -->
+	<config name="testVersion" value="7.0-"/>
 	<rule ref="PHPCompatibilityWP">
 		<include-pattern>*\.php$</include-pattern>
 	</rule>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

Closes #52344

## What?
<!-- In a few words, what is the PR actually doing? -->

* Bumps the plugin's minimum PHP version from 5.6 to 7.0.
* Bumps PHPCS `testVersion` from `5.6-` to `7.0-`.
* Bumps the PHPUnit test `Test with previous WP version` from `php: 5.6` to `php: 7.0`.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

WordPress Core parity.

[WordPress 6.3.0's minimum supported PHP version is/will be 7.0](https://make.wordpress.org/core/2023/07/05/dropping-support-for-php-5/).

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Modifies the plugin header's `Requires PHP:` from `5.6` to `7.0`.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Change your local test environment to PHP 5.6 and WordPress 6.2.2.
2. Install and activate the Gutenberg 6.3.x plugin from the wp . org repo.
3. Open the `gutenberg.php` file, and in the file's DocBlock change `Requires PHP:` back to `7.0`.
Expected: Stays activated, bulk actions disabled, and a notice appears:
>This plugin does not work with your version of PHP. [Learn more about updating PHP](https://wordpress.org/support/update-php/).
4. Deactivate the plugin.
Expected: Bulk edit is disabled; `Cannot Activate` is displayed but not clickable; notice appears:
>This plugin does not work with your version of PHP. [Learn more about updating PHP](https://wordpress.org/support/update-php/).

## Screenshots

![bumpgbphp](https://github.com/WordPress/gutenberg/assets/7284611/d0d3e91c-e2e8-4b1a-b549-d96db761c80a)

<img width="1436" alt="Deactivate only with notice" src="https://github.com/WordPress/gutenberg/assets/7284611/6b67d0d5-52ee-46a3-b19e-87ca56f5cf00">

<img width="1331" alt="Cannot Activate with notice" src="https://github.com/WordPress/gutenberg/assets/7284611/939e6e16-793a-43d7-853c-f0d56353a349">