### PR TITLE
Add context to the "Reset template" "Delete template" and "Edit template" commands

### DIFF
--- a/packages/edit-site/src/hooks/commands/use-edit-mode-commands.js
+++ b/packages/edit-site/src/hooks/commands/use-edit-mode-commands.js
@@ -2,10 +2,10 @@
  * WordPress dependencies
  */
 import { useSelect, useDispatch } from '@wordpress/data';
-import { __, isRTL } from '@wordpress/i18n';
+import { __, sprintf, isRTL } from '@wordpress/i18n';
 import {
 	trash,
-	backup,
+	rotateLeft,
 	layout,
 	page,
 	drawerLeft,
@@ -16,6 +16,7 @@ import {
 	keyboardClose,
 } from '@wordpress/icons';
 import { useCommandLoader } from '@wordpress/commands';
+import { decodeEntities } from '@wordpress/html-entities';
 import { privateApis as routerPrivateApis } from '@wordpress/router';
 import { store as preferencesStore } from '@wordpress/preferences';
 import { store as interfaceStore } from '@wordpress/interface';
@@ -35,6 +36,7 @@ import { unlock } from '../../lock-unlock';
 const { useHistory } = unlock( routerPrivateApis );
 
 function usePageContentFocusCommands() {
+	const { record: template } = useEditedEntityRecord();
 	const { isPage, canvasMode, hasPageContentFocus } = useSelect(
 		( select ) => ( {
 			isPage: select( editSiteStore ).isPage(),
@@ -54,7 +56,11 @@ function usePageContentFocusCommands() {
 	if ( hasPageContentFocus ) {
 		commands.push( {
 			name: 'core/switch-to-template-focus',
-			label: __( 'Edit template' ),
+			/* translators: %1$s: template title */
+			label: sprintf(
+				'Edit template: %s',
+				decodeEntities( template.title )
+			),
 			icon: layout,
 			callback: ( { close } ) => {
 				setHasPageContentFocus( false );
@@ -94,12 +100,20 @@ function useManipulateDocumentCommands() {
 	if ( isTemplateRevertable( template ) && ! hasPageContentFocus ) {
 		const label =
 			template.type === 'wp_template'
-				? __( 'Reset template' )
-				: __( 'Reset template part' );
+				? /* translators: %1$s: template title */
+				  sprintf(
+						'Reset template: %s',
+						decodeEntities( template.title )
+				  )
+				: /* translators: %1$s: template part title */
+				  sprintf(
+						'Reset template part: %s',
+						decodeEntities( template.title )
+				  );
 		commands.push( {
 			name: 'core/reset-template',
 			label,
-			icon: backup,
+			icon: rotateLeft,
 			callback: ( { close } ) => {
 				revertTemplate( template );
 				close();

--- a/packages/edit-site/src/hooks/commands/use-edit-mode-commands.js
+++ b/packages/edit-site/src/hooks/commands/use-edit-mode-commands.js
@@ -58,7 +58,7 @@ function usePageContentFocusCommands() {
 			name: 'core/switch-to-template-focus',
 			/* translators: %1$s: template title */
 			label: sprintf(
-				'Edit template: %s',
+				'Edit template — %s',
 				decodeEntities( template.title )
 			),
 			icon: layout,
@@ -102,12 +102,12 @@ function useManipulateDocumentCommands() {
 			template.type === 'wp_template'
 				? /* translators: %1$s: template title */
 				  sprintf(
-						'Reset template: %s',
+						'Reset template — %s',
 						decodeEntities( template.title )
 				  )
 				: /* translators: %1$s: template part title */
 				  sprintf(
-						'Reset template part: %s',
+						'Reset template part — %s',
 						decodeEntities( template.title )
 				  );
 		commands.push( {
@@ -124,8 +124,16 @@ function useManipulateDocumentCommands() {
 	if ( isTemplateRemovable( template ) && ! hasPageContentFocus ) {
 		const label =
 			template.type === 'wp_template'
-				? __( 'Delete template' )
-				: __( 'Delete template part' );
+				? /* translators: %1$s: template title */
+				  sprintf(
+						'Delete template — %s',
+						decodeEntities( template.title )
+				  )
+				: /* translators: %1$s: template part title */
+				  sprintf(
+						'Delete template part — %s',
+						decodeEntities( template.title )
+				  );
 		const path =
 			template.type === 'wp_template'
 				? '/wp_template'

--- a/packages/edit-site/src/hooks/commands/use-edit-mode-commands.js
+++ b/packages/edit-site/src/hooks/commands/use-edit-mode-commands.js
@@ -6,6 +6,7 @@ import { __, sprintf, isRTL } from '@wordpress/i18n';
 import {
 	trash,
 	rotateLeft,
+	rotateRight,
 	layout,
 	page,
 	drawerLeft,
@@ -58,7 +59,7 @@ function usePageContentFocusCommands() {
 			name: 'core/switch-to-template-focus',
 			/* translators: %1$s: template title */
 			label: sprintf(
-				'Edit template — %s',
+				'Edit template: %s',
 				decodeEntities( template.title )
 			),
 			icon: layout,
@@ -102,18 +103,18 @@ function useManipulateDocumentCommands() {
 			template.type === 'wp_template'
 				? /* translators: %1$s: template title */
 				  sprintf(
-						'Reset template — %s',
+						'Reset template: %s',
 						decodeEntities( template.title )
 				  )
 				: /* translators: %1$s: template part title */
 				  sprintf(
-						'Reset template part — %s',
+						'Reset template part: %s',
 						decodeEntities( template.title )
 				  );
 		commands.push( {
 			name: 'core/reset-template',
 			label,
-			icon: rotateLeft,
+			icon: isRTL() ? rotateRight : rotateLeft,
 			callback: ( { close } ) => {
 				revertTemplate( template );
 				close();
@@ -126,12 +127,12 @@ function useManipulateDocumentCommands() {
 			template.type === 'wp_template'
 				? /* translators: %1$s: template title */
 				  sprintf(
-						'Delete template — %s',
+						'Delete template: %s',
 						decodeEntities( template.title )
 				  )
 				: /* translators: %1$s: template part title */
 				  sprintf(
-						'Delete template part — %s',
+						'Delete template part: %s',
 						decodeEntities( template.title )
 				  );
 		const path =


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Resolves: https://github.com/WordPress/gutenberg/issues/51693

This PR adds more context to the "Reset template", "Delete template" and "Edit template" commands, by adding the template title in the form of `Delete template: ${name}`. Additionally the `reset template` command icon was updated to `rotateLeft`. 
<!-- In a few words, what is the PR actually doing? -->

## Testing Instructions
Test these three commands and observe that the template title is also part of the label.
