### PR TITLE
Enforce PR labels: fully re-enabling the pre-merge check

### DIFF
--- a/.github/workflows/enforce-pr-labels.yml
+++ b/.github/workflows/enforce-pr-labels.yml
@@ -12,7 +12,7 @@ jobs:
         with:
           mode: exactly
           count: 1
-          labels: "[Type] Accessibility (a11y), [Type] Automated Testing, [Type] Breaking Change, [Type] Bug, [Type] Build Tooling, [Type] Code Quality, [Type] Copy, [Type] Developer Documentation, [Type] Enhancement, [Type] Experimental, [Type] Feature, [Type] New API, [Type] Task, [Type] Performance, [Type] Project Management, [Type] Security, [Type] WP Core Ticket"
+          labels: "[Type] Accessibility (a11y), [Type] Automated Testing, [Type] Breaking Change, [Type] Bug, [Type] Build Tooling, [Type] Code Quality, [Type] Copy, [Type] Developer Documentation, [Type] Enhancement, [Type] Experimental, [Type] Feature, [Type] New API, [Type] Task, [Type] Performance, [Type] Project Management, [Type] Regression, [Type] Security, [Type] WP Core Ticket"
           add_comment: true
           message: "## ⚠️ Type of PR label error\n To merge this PR, it requires {{ errorString }} {{ count }} label indicating the type of PR. Other labels are optional and not being checked here. \n- **Type-related labels to choose from**: {{ provided }}.\n- **Labels found**: {{ applied }}.\n\nYou can learn more about the Type labels in Gutenberg [here](https://github.com/WordPress/gutenberg/labels?q=type)"
           exit_type: failure

--- a/.github/workflows/enforce-pr-labels.yml
+++ b/.github/workflows/enforce-pr-labels.yml
@@ -14,5 +14,5 @@ jobs:
           count: 1
           labels: "[Type] Accessibility (a11y), [Type] Automated Testing, [Type] Breaking Change, [Type] Bug, [Type] Build Tooling, [Type] Code Quality, [Type] Copy, [Type] Developer Documentation, [Type] Enhancement, [Type] Experimental, [Type] Feature, [Type] New API, [Type] Task, [Type] Performance, [Type] Project Management, [Type] Security, [Type] WP Core Ticket"
           add_comment: true
-          message: "## ⚠️ Type of PR label error\n To merge this PR, it requires {{ errorString }} {{ count }} label indicating the type of PR. Other labels are optional and not being checked here. \n- **Type-related labels to choose from**: {{ provided }}.\n- **Labels found**: {{ applied }}."
-          exit_type: success
+          message: "## ⚠️ Type of PR label error\n To merge this PR, it requires {{ errorString }} {{ count }} label indicating the type of PR. Other labels are optional and not being checked here. \n- **Type-related labels to choose from**: {{ provided }}.\n- **Labels found**: {{ applied }}.\nYou can learn more about the Type labels in Gutenberg [here](https://github.com/WordPress/gutenberg/labels?q=type)"
+          exit_type: failure

--- a/.github/workflows/enforce-pr-labels.yml
+++ b/.github/workflows/enforce-pr-labels.yml
@@ -14,5 +14,5 @@ jobs:
           count: 1
           labels: "[Type] Accessibility (a11y), [Type] Automated Testing, [Type] Breaking Change, [Type] Bug, [Type] Build Tooling, [Type] Code Quality, [Type] Copy, [Type] Developer Documentation, [Type] Enhancement, [Type] Experimental, [Type] Feature, [Type] New API, [Type] Task, [Type] Performance, [Type] Project Management, [Type] Security, [Type] WP Core Ticket"
           add_comment: true
-          message: "## ⚠️ Type of PR label error\n To merge this PR, it requires {{ errorString }} {{ count }} label indicating the type of PR. Other labels are optional and not being checked here. \n- **Type-related labels to choose from**: {{ provided }}.\n- **Labels found**: {{ applied }}.\nYou can learn more about the Type labels in Gutenberg [here](https://github.com/WordPress/gutenberg/labels?q=type)"
+          message: "## ⚠️ Type of PR label error\n To merge this PR, it requires {{ errorString }} {{ count }} label indicating the type of PR. Other labels are optional and not being checked here. \n- **Type-related labels to choose from**: {{ provided }}.\n- **Labels found**: {{ applied }}.\n\nYou can learn more about the Type labels in Gutenberg [here](https://github.com/WordPress/gutenberg/labels?q=type)"
           exit_type: failure


### PR DESCRIPTION
Follow-up to https://github.com/WordPress/gutenberg/pull/52981

## What?
Fully enables the pre-check merge that enforces PR labels so that the check fails if the PR is not fully labeled.

Also improves the error message description linking to all [type-related labels in the repository](https://github.com/WordPress/gutenberg/labels?q=type) and adds the missing `[Type] Regression` label.

## Why?
After the initial setup of the GitHub action, there were some cases where it didn't work properly, so I made the check exit in a success state in all cases to avoid blocking PRs.

## How?
By removing the `exit_type: sucess` setting in the workflow configuration.

## Testing Instructions
After merging:
- Create a PR with no labels: the `Enforce PR labels` pre-merge check will fail. 
- Add one of the suggested labels, and the workflow will run again and will succeed.