### PR TITLE
`Modal`: Nuance outside interactions

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -10,6 +10,7 @@
 -   `Modal`: add `headerActions` prop to render buttons in the header. ([#53328](https://github.com/WordPress/gutenberg/pull/53328)).
 -   `Snackbar`: Snackbar design and motion improvements ([#53248](https://github.com/WordPress/gutenberg/pull/53248))
 -   `NumberControl`: Add `spinFactor` prop for adjusting the amount by which the spin controls change the value ([#52902](https://github.com/WordPress/gutenberg/pull/52902)).
+-   `Modal:`: Nuance outside interactions ([#52994](https://github.com/WordPress/gutenberg/pull/52994)).
 
 ### Bug Fix
 

--- a/packages/components/src/modal/index.tsx
+++ b/packages/components/src/modal/index.tsx
@@ -186,8 +186,12 @@ function UnforwardedModal(
 				event.preventDefault();
 			}
 		},
-		// Requests closing only for primary pointer/button and if the
-		// target was the same as the one that was pressed.
+		// Closes the modal with two exceptions. 1. Opening the context menu on
+		// the overlay. 2. Pressing on the overlay then dragging the pointer
+		// over the modal and releasing. Due to the modal being a child of the
+		// overlay, such a gesture is a `click` on the overlay and cannot be
+		// excepted by a `click` handler. Thus the tactic of handling
+		// `pointerup` and comparing its target to that of the `pointerdown`.
 		onPointerUp: ( { target, isPrimary, button } ) => {
 			const isSameTarget = target === pressTarget;
 			pressTarget = null;

--- a/packages/components/src/modal/index.tsx
+++ b/packages/components/src/modal/index.tsx
@@ -192,10 +192,10 @@ function UnforwardedModal(
 		// overlay, such a gesture is a `click` on the overlay and cannot be
 		// excepted by a `click` handler. Thus the tactic of handling
 		// `pointerup` and comparing its target to that of the `pointerdown`.
-		onPointerUp: ( { target, isPrimary, button } ) => {
+		onPointerUp: ( { target, button } ) => {
 			const isSameTarget = target === pressTarget;
 			pressTarget = null;
-			if ( isPrimary && button === 0 && isSameTarget ) onRequestClose();
+			if ( button === 0 && isSameTarget ) onRequestClose();
 		},
 	};
 


### PR DESCRIPTION
## What?
Changes interactions on the overlay:
- To not dismiss until clicked, thereby allowing to cancel dismissal by dragging back over the modal before releasing.
- To permit opening the context menu without dismissal

## Why?
Some portion of the audience will appreciate these nuances and they don't otherwise negatively affect any UX.

## How?
Uses pointer event handlers and:
- at `pointerdown` if the overlay was pressed with the primary pointer then it’s tracked.
- at `pointerup` determines if the modal should be dismissed based on whether the overlay was the release target and whether the pointer (and button for mice) was primary.

## Testing Instructions
1. Open a modal.
2. Confirm ability to open the context menu with an alt click on the overlay without dismissing the modal.
3. Confirm ability to press the overlay without dismissing the modal.
4. Confirm ability to cancel dismissal by dragging back over the modal before releasing the press.

### Testing Instructions for Keyboard
The changes in question aren’t keyboard applicable.

## Screenshots or screencast <!-- if applicable -->
