### PR TITLE
List: merge consecutive lists

### DIFF
--- a/packages/block-library/src/list/test/edit.native.js
+++ b/packages/block-library/src/list/test/edit.native.js
@@ -422,11 +422,9 @@ describe( 'List block', () => {
 
 		<!-- wp:list-item -->
 		<li>Two</li>
-		<!-- /wp:list-item --></ul>
-		<!-- /wp:list -->
+		<!-- /wp:list-item -->
 
-		<!-- wp:list -->
-		<ul><!-- wp:list-item -->
+		<!-- wp:list-item -->
 		<li>Three</li>
 		<!-- /wp:list-item --></ul>
 		<!-- /wp:list -->"

--- a/test/e2e/specs/editor/blocks/list.spec.js
+++ b/test/e2e/specs/editor/blocks/list.spec.js
@@ -481,11 +481,9 @@ test.describe( 'List (@firefox)', () => {
 
 <!-- wp:list-item -->
 <li></li>
-<!-- /wp:list-item --></ul>
-<!-- /wp:list -->
+<!-- /wp:list-item -->
 
-<!-- wp:list -->
-<ul><!-- wp:list-item -->
+<!-- wp:list-item -->
 <li>two</li>
 <!-- /wp:list-item --></ul>
 <!-- /wp:list -->`


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes #46039. When merging a paragraph that sits in between two lists of the same type, these two lists end up being side by side looking as one list, but are actually two separate lists.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

It's confusing that the lists don't merge, and it's not easy to know that they don't.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Checking the next block and merge nested items if the type and attributes match.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

See https://github.com/WordPress/gutenberg/issues/46039#issuecomment-1652157981.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
