### PR TITLE
Site Editor: Fix canvas mode sync with URL

### DIFF
--- a/packages/edit-site/src/components/sync-state-with-url/use-sync-canvas-mode-with-url.js
+++ b/packages/edit-site/src/components/sync-state-with-url/use-sync-canvas-mode-with-url.js
@@ -58,10 +58,7 @@ export default function useSyncCanvasModeWithURL() {
 
 	useEffect( () => {
 		currentCanvasInUrl.current = canvasInUrl;
-		if (
-			( canvasInUrl === undefined || canvasInUrl === 'view' ) &&
-			currentCanvasMode.current !== 'view'
-		) {
+		if ( canvasInUrl !== 'edit' && currentCanvasMode.current !== 'view' ) {
 			setCanvasMode( 'view' );
 		} else if (
 			canvasInUrl === 'edit' &&

--- a/packages/edit-site/src/components/sync-state-with-url/use-sync-canvas-mode-with-url.js
+++ b/packages/edit-site/src/components/sync-state-with-url/use-sync-canvas-mode-with-url.js
@@ -59,7 +59,7 @@ export default function useSyncCanvasModeWithURL() {
 	useEffect( () => {
 		currentCanvasInUrl.current = canvasInUrl;
 		if (
-			canvasInUrl === undefined &&
+			( canvasInUrl === undefined || canvasInUrl === 'view' ) &&
 			currentCanvasMode.current !== 'view'
 		) {
 			setCanvasMode( 'view' );


### PR DESCRIPTION
## What?
PR fixes the URL synchronization side-effect in the `useSyncCanvasModeWithURL` hook, where canvas mode wasn't synced if it was set to `view` in query arguments.

## Why?
Without this sync, canvas stays in `init` mode and stops rendering the editor.

https://github.com/WordPress/gutenberg/blob/7eddee3be86dbeefc06990d817768e15de42d9fc/packages/edit-site/src/components/layout/index.js#L158-L163

## Testing Instructions
1. Using TT3.
2. Visiting the following URL should load the template part in view mode.

```
wp-admin/site-editor.php?postType=wp_template_part&postId=twentytwentythree%2F%2Ffooter&categoryId=footer&categoryType=wp_template_part&canvas=view
```

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/240569/93b4e379-7184-4b9d-9244-a3115bc66ebe
