### PR TITLE
Try text label instead of icon for "Detach" ToolbarButton

### DIFF
--- a/packages/block-library/src/block/edit.js
+++ b/packages/block-library/src/block/edit.js
@@ -28,7 +28,6 @@ import {
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import { store as reusableBlocksStore } from '@wordpress/reusable-blocks';
-import { ungroup } from '@wordpress/icons';
 
 export default function ReusableBlockEdit( { attributes: { ref }, clientId } ) {
 	const hasAlreadyRendered = useHasRecursion( ref );
@@ -39,13 +38,11 @@ export default function ReusableBlockEdit( { attributes: { ref }, clientId } ) {
 	);
 	const isMissing = hasResolved && ! record;
 
-	const { canRemove, innerBlockCount } = useSelect(
+	const { canRemove } = useSelect(
 		( select ) => {
-			const { canRemoveBlock, getBlockCount } =
-				select( blockEditorStore );
+			const { canRemoveBlock } = select( blockEditorStore );
 			return {
 				canRemove: canRemoveBlock( clientId ),
-				innerBlockCount: getBlockCount( clientId ),
 			};
 		},
 		[ clientId ]
@@ -117,14 +114,11 @@ export default function ReusableBlockEdit( { attributes: { ref }, clientId } ) {
 					<ToolbarGroup>
 						<ToolbarButton
 							onClick={ () => convertBlockToStatic( clientId ) }
-							label={
-								innerBlockCount > 1
-									? __( 'Detach patterns' )
-									: __( 'Detach pattern' )
-							}
-							icon={ ungroup }
+							label={ __( 'Detach' ) }
 							showTooltip
-						/>
+						>
+							{ __( 'Detach' ) }
+						</ToolbarButton>
 					</ToolbarGroup>
 				</BlockControls>
 			) }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
The unGroup icon, which is used for "Detach" in a synced pattern's toolbar, doesnt quite convey the notion of detaching an instance of a synced pattern. I wanted to try using a text label instead; if this control is necessary in the first place (as we have "Detach pattern" in the block options popover. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a page.
2. Insert a synced pattern.
3. Select the synced pattern to see the toolbar control. 

## Screenshots or screencast <!-- if applicable -->

| Before  | After |
| ------------- | ------------- |
|<img width="258" alt="CleanShot 2023-07-26 at 16 55 29" src="https://github.com/WordPress/gutenberg/assets/1813435/e11fd6eb-eb7d-441f-be3a-02b5190bf3c4">|<img width="276" alt="CleanShot 2023-07-26 at 16 55 00" src="https://github.com/WordPress/gutenberg/assets/1813435/6c01ad0c-bd91-43f3-814b-1c6a3cacc6ba">|



