### PR TITLE
Paste: only link selection if URL protocol is http(s)

### DIFF
--- a/packages/block-editor/src/components/rich-text/use-paste-handler.js
+++ b/packages/block-editor/src/components/rich-text/use-paste-handler.js
@@ -139,10 +139,14 @@ export function usePasteHandler( props ) {
 
 			let mode = onReplace && onSplit ? 'AUTO' : 'INLINE';
 
+			const trimmedPlainText = plainText.trim();
+
 			if (
 				__unstableEmbedURLOnPaste &&
 				isEmpty( value ) &&
-				isURL( plainText.trim() )
+				isURL( trimmedPlainText ) &&
+				// For the link pasting feature, allow only http(s) protocols.
+				/^https?:/.test( trimmedPlainText )
 			) {
 				mode = 'BLOCKS';
 			}

--- a/packages/format-library/src/link/index.js
+++ b/packages/format-library/src/link/index.js
@@ -144,7 +144,8 @@ export const link = {
 			.trim();
 
 		// A URL was pasted, turn the selection into a link.
-		if ( ! isURL( pastedText ) ) {
+		// For the link pasting feature, allow only http(s) protocols.
+		if ( ! isURL( pastedText ) || ! /^https?:/.test( pastedText ) ) {
 			return value;
 		}
 

--- a/test/e2e/specs/editor/various/copy-cut-paste.spec.js
+++ b/test/e2e/specs/editor/various/copy-cut-paste.spec.js
@@ -496,4 +496,53 @@ test.describe( 'Copy/cut/paste', () => {
 		await page.keyboard.type( 'y' );
 		expect( await editor.getEditedPostContent() ).toMatchSnapshot();
 	} );
+
+	test( 'should link selection', async ( { pageUtils, editor } ) => {
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: {
+				content: 'a',
+			},
+		} );
+		await pageUtils.pressKeys( 'primary+a' );
+		pageUtils.setClipboardData( {
+			plainText: 'https://wordpress.org/gutenberg',
+			html: '<a href="https://wordpress.org/gutenberg">https://wordpress.org/gutenberg</a>',
+		} );
+		await pageUtils.pressKeys( 'primary+v' );
+		expect( await editor.getBlocks() ).toMatchObject( [
+			{
+				name: 'core/paragraph',
+				attributes: {
+					content: '<a href="https://wordpress.org/gutenberg">a</a>',
+				},
+			},
+		] );
+	} );
+
+	test( 'should not link selection for non http(s) protocol', async ( {
+		pageUtils,
+		editor,
+	} ) => {
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: {
+				content: 'a',
+			},
+		} );
+		await pageUtils.pressKeys( 'primary+a' );
+		pageUtils.setClipboardData( {
+			plainText: 'movie: b',
+			html: 'movie: b',
+		} );
+		await pageUtils.pressKeys( 'primary+v' );
+		expect( await editor.getBlocks() ).toMatchObject( [
+			{
+				name: 'core/paragraph',
+				attributes: {
+					content: 'movie: b',
+				},
+			},
+		] );
+	} );
 } );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Fixes #24895. `isURL` returns true for any sort of protocol, which results in false positives such as `movie: something`, where `movie` would be assumed as the protocol. To leave the flexibility of `isURL` and avoid changing this API, we can just add an additional check if the protocol is http(s) for just the link pasting feature. In this case, it's only really meant for these two protocols.

If there's more demand, we could add an argument to `isURL` in the future to check for whitelisted protocols.

OR we could return the URL instance so you can check as follows: 
```js
new Set( 'http', 'https' ).has( isURL( text )?.protocol ) )
```

OR we just use `new URL( text )` directly. What do you think?

Anyway, this needs to be fixed, we can thing about the best approach later.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Pasting anything with a colon over a selection results in a link.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Described above.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

Copy anything with a colon and paste over a selection. An e2e test has been added.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
