### PR TITLE
Defer to preceding handlers in command palette keyboard shortcut

### DIFF
--- a/packages/commands/src/components/command-menu.js
+++ b/packages/commands/src/components/command-menu.js
@@ -199,6 +199,9 @@ export function CommandMenu() {
 	useShortcut(
 		'core/commands',
 		( event ) => {
+			// Bails to avoid obscuring the effect of the preceding handler(s).
+			if ( event.isDefaultPrevented() ) return;
+
 			event.preventDefault();
 			if ( isOpen ) {
 				close();

--- a/packages/commands/src/components/command-menu.js
+++ b/packages/commands/src/components/command-menu.js
@@ -198,9 +198,10 @@ export function CommandMenu() {
 
 	useShortcut(
 		'core/commands',
+		/** @type {import('react').KeyboardEventHandler} */
 		( event ) => {
 			// Bails to avoid obscuring the effect of the preceding handler(s).
-			if ( event.isDefaultPrevented() ) return;
+			if ( event.defaultPrevented ) return;
 
 			event.preventDefault();
 			if ( isOpen ) {


### PR DESCRIPTION
## What?
Generally what the title says. More specifically this fixes a visual/UX regression that comes along with the command palette’s conflicted keyboard shortcut.

## Why?
It’s a visual regression introduced since 6.2. This fixes a symptom of #51737.

## How?
If the event has its default behavior prevented then the command palette is not launched.

## Testing Instructions
1. Open the Post or Site editor
2. Place the caret in rich text
3. Use the keyboard shortcut to create a link/open command palette
4. Observe no flicker of the command palette
5. Repeat steps 3-4 a few times for good measure
6. Confirm that the shortcut for the command palette is not otherwise affected and it works as well as before

## Screenshots or screencast

### Before with a flicker

https://github.com/WordPress/gutenberg/assets/9000376/80899d16-74dd-418c-84c4-ba702f851f20
