### PR TITLE
Footnotes: disable for synced patterns and prevent duplication for pages in site editor

### DIFF
--- a/packages/block-library/src/footnotes/format.js
+++ b/packages/block-library/src/footnotes/format.js
@@ -50,7 +50,6 @@ export const format = {
 			getSelectedBlockClientId,
 			getBlocks,
 			getBlockRootClientId,
-			getBlockName,
 			getBlockParentsByBlockName,
 		} = useSelect( blockEditorStore );
 		const footnotesBlockType = useSelect( ( select ) =>
@@ -149,11 +148,8 @@ export const format = {
 				if ( ! fnBlock ) {
 					let rootClientId = getBlockRootClientId( selectedClientId );
 
-					while (
-						rootClientId &&
-						getBlockName( rootClientId ) !== POST_CONTENT_BLOCK_NAME
-					) {
-						rootClientId = getBlockRootClientId( rootClientId );
+					if ( parentPostContent.length ) {
+						rootClientId = parentPostContent[ 0 ];
 					}
 
 					fnBlock = createBlock( name );

--- a/packages/block-library/src/footnotes/format.js
+++ b/packages/block-library/src/footnotes/format.js
@@ -50,6 +50,7 @@ export const format = {
 			getSelectedBlockClientId,
 			getBlocks,
 			getBlockRootClientId,
+			getBlockName,
 			getBlockParentsByBlockName,
 		} = useSelect( blockEditorStore );
 		const footnotesBlockType = useSelect( ( select ) =>
@@ -148,8 +149,11 @@ export const format = {
 				if ( ! fnBlock ) {
 					let rootClientId = getBlockRootClientId( selectedClientId );
 
-					if ( parentPostContent.length ) {
-						rootClientId = parentPostContent[ 0 ];
+					while (
+						rootClientId &&
+						getBlockName( rootClientId ) !== POST_CONTENT_BLOCK_NAME
+					) {
+						rootClientId = getBlockRootClientId( rootClientId );
 					}
 
 					fnBlock = createBlock( name );

--- a/packages/block-library/src/footnotes/format.js
+++ b/packages/block-library/src/footnotes/format.js
@@ -56,7 +56,11 @@ export const format = {
 		const footnotesBlockType = useSelect( ( select ) =>
 			select( blocksStore ).getBlockType( name )
 		);
-		const hasParentCoreBlocks = useSelect( ( select ) => {
+		/*
+		 * This useSelect exists because we need to use its return value
+		 * outside the event callback.
+		 */
+		const isBlockWithinPattern = useSelect( ( select ) => {
 			const {
 				getBlockParentsByBlockName: _getBlockParentsByBlockName,
 				getSelectedBlockClientId: _getSelectedBlockClientId,
@@ -80,7 +84,7 @@ export const format = {
 		}
 
 		// Checks if the selected block lives within a pattern.
-		if ( hasParentCoreBlocks ) {
+		if ( isBlockWithinPattern ) {
 			return null;
 		}
 


### PR DESCRIPTION

## What?
A follow up to:

- https://github.com/WordPress/gutenberg/pull/52934

This PR attempts to resolves [some issues](https://github.com/WordPress/gutenberg/pull/52934#pullrequestreview-1546659253) found while testing:

- Prevents footnote creation within `core/block` blocks
- Only insert a footnote if one isn't found in the entity block list

## Why?
See https://github.com/WordPress/gutenberg/pull/52934#pullrequestreview-1546659253

## How?

- Prevent footnote creation within core/block
- Only insert a footnote if one isn't found in the entity block list

## Testing Instructions

- Create a new synced pattern. You shouldn't be able to add footnotes when editing the pattern in the site and post editors.
- Double check this for unsynced patterns
- In the site editor, edit a page that already has footnotes, and try to add some more. Ensure that the footnote block is not duplicated



## Screenshots or screencast <!-- if applicable -->
