### PR TITLE
Spacing presets: fix bug with select control adding undefined preset values

### DIFF
--- a/packages/block-editor/src/components/spacing-sizes-control/test/utils.js
+++ b/packages/block-editor/src/components/spacing-sizes-control/test/utils.js
@@ -49,7 +49,15 @@ describe( 'getCustomValueFromPreset', () => {
 } );
 
 describe( 'getPresetValueFromCustomValue', () => {
-	const spacingSizes = [ { name: 'Small', slug: 20, size: '8px' } ];
+	const spacingSizes = [
+		{ name: 'Default', slug: 'default', size: undefined },
+		{ name: 'Small', slug: 20, size: '8px' },
+	];
+	it( 'should return undefined even if an undefined value exist in spacing sizes as occurs if spacingSizes has > 7 entries', () => {
+		expect( getPresetValueFromCustomValue( undefined, spacingSizes ) ).toBe(
+			undefined
+		);
+	} );
 	it( 'should return original value if a string in spacing presets var format', () => {
 		expect(
 			getPresetValueFromCustomValue(

--- a/packages/block-editor/src/components/spacing-sizes-control/utils.js
+++ b/packages/block-editor/src/components/spacing-sizes-control/utils.js
@@ -101,7 +101,7 @@ export function getCustomValueFromPreset( value, spacingSizes ) {
  * @return {string} The preset value if it can be found.
  */
 export function getPresetValueFromCustomValue( value, spacingSizes ) {
-	// Return value as-is if it undefined or is already a preset;
+	// Return value as-is if it is undefined or is already a preset, or '0';
 	if ( ! value || isValueSpacingPreset( value ) || value === '0' ) {
 		return value;
 	}

--- a/packages/block-editor/src/components/spacing-sizes-control/utils.js
+++ b/packages/block-editor/src/components/spacing-sizes-control/utils.js
@@ -101,11 +101,8 @@ export function getCustomValueFromPreset( value, spacingSizes ) {
  * @return {string} The preset value if it can be found.
  */
 export function getPresetValueFromCustomValue( value, spacingSizes ) {
-	if ( ! value ) {
-		return value;
-	}
-	// Return value as-is if it is already a preset;
-	if ( isValueSpacingPreset( value ) || value === '0' ) {
+	// Return value as-is if it undefined or is already a preset;
+	if ( ! value || isValueSpacingPreset( value ) || value === '0' ) {
 		return value;
 	}
 

--- a/packages/block-editor/src/components/spacing-sizes-control/utils.js
+++ b/packages/block-editor/src/components/spacing-sizes-control/utils.js
@@ -101,6 +101,9 @@ export function getCustomValueFromPreset( value, spacingSizes ) {
  * @return {string} The preset value if it can be found.
  */
 export function getPresetValueFromCustomValue( value, spacingSizes ) {
+	if ( ! value ) {
+		return value;
+	}
 	// Return value as-is if it is already a preset;
 	if ( isValueSpacingPreset( value ) || value === '0' ) {
 		return value;


### PR DESCRIPTION
## What?
Fixes a bug where the select list used if more than 7 preset values adds invalid preset value attributes.

## Why?
Fixes: #52976

## How?
Accounts for the undefined value set by spacing presets select list control in getPresetValueFromCustomValueControl.

## Testing Instructions
- In a theme.json increasing the number of `settings.spacing.spacingPresets` values to 8+
- Add a Group block in the editor and add a range of different padding settings, axial, and custom for each side, including setting back to the `Default` option in the select list
- Make sure that the padding attributes never get set to `var:preset|spacing|default`
-  Make sure that the gap spacing controls also behave as expected still
- Switch back to 7 or less spacing presets and make sure the slider controls for spacing settings all still work as expected

## Screenshots or screencast <!-- if applicable -->

Before:

https://github.com/WordPress/gutenberg/assets/3629020/761c18fe-3183-4188-9454-bd120127d81a

After:

https://github.com/WordPress/gutenberg/assets/3629020/140728e4-15dc-4b71-972c-ba3ea59c4d23

