### PR TITLE
Avatar: Fix global border styles generation

### DIFF
--- a/packages/block-library/src/avatar/block.json
+++ b/packages/block-library/src/avatar/block.json
@@ -48,6 +48,9 @@
 			"__experimentalDuotone": "img"
 		}
 	},
+	"selectors": {
+		"border": ".wp-block-avatar img"
+	},
 	"editorStyle": "wp-block-avatar-editor",
 	"style": "wp-block-avatar"
 }


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/48253

## What?

Updates the selector used for the Avatar block's global border styles so they target the same element as the block instance styles are applied to.

## Why?

Without this fix global border styles for the Avatar block target the wrapper instead of the inner image.

## How?

Define the correct selector for the border feature via the Selectors API.

## Testing Instructions

1. Edit a template or post and add a few Avatar blocks including one that links to the user profile
2. Switch to the Site Editor > Global Styles > Blocks > Avatar
3. Apply a global styles border
4. Switch back to the editor and ensure the global border styles target the Avatar block's `img` element
5. Save the post or template and confirm the correct styling on the frontend
6. Test that you can override the global border styles with block instance border styles still

## Screenshots or screencast <!-- if applicable -->

| Before | After |
|---|---|
| <img width="684" alt="Screenshot 2023-07-27 at 2 46 48 pm" src="https://github.com/WordPress/gutenberg/assets/60436221/95f821b6-6594-4f90-8b76-f4c243126500"> | <img width="685" alt="Screenshot 2023-07-27 at 2 47 02 pm" src="https://github.com/WordPress/gutenberg/assets/60436221/7ee5c21a-32e8-487a-8984-39077c3b06c4"> |


https://github.com/WordPress/gutenberg/assets/60436221/914391a6-aa9a-42cc-94f0-8478a899f3ef

