### PR TITLE
Check if spacing tool is defined before displaying controls.

### DIFF
--- a/packages/block-editor/src/components/global-styles/hooks.js
+++ b/packages/block-editor/src/components/global-styles/hooks.js
@@ -326,7 +326,11 @@ export function useSettingsForBlockElement(
 			const sides = Array.isArray( supports?.spacing?.[ key ] )
 				? supports?.spacing?.[ key ]
 				: supports?.spacing?.[ key ]?.sides;
-			if ( sides?.length ) {
+			// Check if spacing type actually exists before adding sides.
+			if (
+				sides?.length &&
+				typeof updatedSettings.spacing?.[ key ] !== 'undefined'
+			) {
 				updatedSettings.spacing = {
 					...updatedSettings.spacing,
 					[ key ]: {

--- a/packages/block-editor/src/components/global-styles/hooks.js
+++ b/packages/block-editor/src/components/global-styles/hooks.js
@@ -326,11 +326,8 @@ export function useSettingsForBlockElement(
 			const sides = Array.isArray( supports?.spacing?.[ key ] )
 				? supports?.spacing?.[ key ]
 				: supports?.spacing?.[ key ]?.sides;
-			// Check if spacing type actually exists before adding sides.
-			if (
-				sides?.length &&
-				typeof updatedSettings.spacing?.[ key ] !== 'undefined'
-			) {
+			// Check if spacing type is supported before adding sides.
+			if ( sides?.length && updatedSettings.spacing?.[ key ] ) {
 				updatedSettings.spacing = {
 					...updatedSettings.spacing,
 					[ key ]: {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

 Fixes #52909.

In classic themes, block spacing controls don't work so they shouldn't be displayed. 

This PR adds a check for whether the spacing tool is defined before outputting any sizes setting it may have. In classic themes, `spacing.blockGap` is undefined so this should prevent blockGap sizes from being added to settings.

I'm not sure this is the best fix, but it was the simplest I could think of for now 😅 

Arguably we _should_ support blockGap in classic themes, but that's beyond the scope of this bug fix.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Activate a classic theme such as Twenty Twenty.
2. In a post, add a Columns block.
3. Check that in the Styles section of the sidebar, under Dimensions, there are no block spacing controls displayed.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
