### PR TITLE
Remove Firefox work-around to type Space in RichText components inside button/summary

### DIFF
--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -402,7 +402,7 @@ function RichTextWrapper(
 						disableLineBreaks,
 						onSplitAtEnd,
 					} ),
-					useFirefoxCompat( { value, onChange } ),
+					useFirefoxCompat(),
 					anchorRef,
 				] ) }
 				contentEditable={ true }

--- a/packages/block-editor/src/components/rich-text/use-firefox-compat.js
+++ b/packages/block-editor/src/components/rich-text/use-firefox-compat.js
@@ -1,21 +1,15 @@
 /**
  * WordPress dependencies
  */
-import { useRef } from '@wordpress/element';
 import { useRefEffect } from '@wordpress/compose';
 import { useSelect } from '@wordpress/data';
-import { SPACE } from '@wordpress/keycodes';
-import { insert } from '@wordpress/rich-text';
 
 /**
  * Internal dependencies
  */
 import { store as blockEditorStore } from '../../store';
 
-export function useFirefoxCompat( props ) {
-	const propsRef = useRef( props );
-	propsRef.current = props;
-
+export function useFirefoxCompat() {
 	const { isMultiSelecting } = useSelect( blockEditorStore );
 	return useRefEffect( ( element ) => {
 		function onFocus() {
@@ -37,29 +31,9 @@ export function useFirefoxCompat( props ) {
 			}
 		}
 
-		// If a contenteditable element is inside a button/summary element,
-		// it is not possible to type a space in Firefox. Therefore, cancel
-		// the default event and insert a space explicitly.
-		// See: https://bugzilla.mozilla.org/show_bug.cgi?id=1822860
-		function onKeyDown( event ) {
-			if ( event.keyCode !== SPACE ) {
-				return;
-			}
-
-			if ( element.closest( 'button, summary' ) === null ) {
-				return;
-			}
-
-			const { value, onChange } = propsRef.current;
-			onChange( insert( value, ' ' ) );
-			event.preventDefault();
-		}
-
 		element.addEventListener( 'focus', onFocus );
-		element.addEventListener( 'keydown', onKeyDown );
 		return () => {
 			element.removeEventListener( 'focus', onFocus );
-			element.removeEventListener( 'keydown', onKeyDown );
 		};
 	}, [] );
 }


### PR DESCRIPTION
This reverts commit ce1ef4247c7893a9aecbddf517675ecd46ef40d0 from https://github.com/WordPress/gutenberg/pull/50540.

## What and why?

In #50540, a work-around was introduced to fix typing <kbd>Space</kbd> when the `RichText` component is inside button/summary in Firefox. Since then, the [Firefox bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1822860) has been fixed and released in the [latest Firefox ESR version](https://whattrainisitnow.com/calendar/), Firefox 115. Because of that, it should be safe to remove the work-around from the Gutenberg codebase.

## Testing Instructions

1. Add **Details** block in Firefox browser 115 or later.
2. Go to the **Details Summary** field.
3. Try entering any text including spaces.
4. Verify spaces are rendered correctly.

## Screenshots or screencast
[Enregistrament de pantalla des de 2023-07-20 11-31-57.webm](https://github.com/WordPress/gutenberg/assets/3616980/ee3c7478-e4fd-43a8-860e-97cd5d5da5b3)