### PR TITLE
shimAttributeSource: don't run outside the registerBlockType filter

### DIFF
--- a/packages/editor/src/hooks/custom-sources-backwards-compatibility.js
+++ b/packages/editor/src/hooks/custom-sources-backwards-compatibility.js
@@ -1,8 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { store as blocksStore } from '@wordpress/blocks';
-import { select as globalSelect, useSelect } from '@wordpress/data';
+import { useSelect } from '@wordpress/data';
 import { useEntityProp } from '@wordpress/core-data';
 import { useMemo } from '@wordpress/element';
 import { createHigherOrderComponent } from '@wordpress/compose';
@@ -124,26 +123,3 @@ addFilter(
 	'core/editor/custom-sources-backwards-compatibility/shim-attribute-source',
 	shimAttributeSource
 );
-
-// The above filter will only capture blocks registered after the filter was
-// added. There may already be blocks registered by this point, and those must
-// be updated to apply the shim.
-//
-// The following implementation achieves this, albeit with a couple caveats:
-// - Only blocks registered on the global store will be modified.
-// - The block settings are directly mutated, since there is currently no
-//   mechanism to update an existing block registration. This is the reason for
-//   `getBlockType` separate from `getBlockTypes`, since the latter returns a
-//   _copy_ of the block registration (i.e. the mutation would not affect the
-//   actual registered block settings).
-//
-// `getBlockTypes` or `getBlockType` implementation could change in the future
-// in regards to creating settings clones, but the corresponding end-to-end
-// tests for meta blocks should cover against any potential regressions.
-//
-// In the future, we could support updating block settings, at which point this
-// implementation could use that mechanism instead.
-globalSelect( blocksStore )
-	.getBlockTypes()
-	.map( ( { name } ) => globalSelect( blocksStore ).getBlockType( name ) )
-	.forEach( shimAttributeSource );


### PR DESCRIPTION
When adding back-compat support for `source: 'meta'`, the `shimAttributeSource` function is called in a `blocks.registerBlockType` filter, which is fine, but then it's also called statically, looping through all the blocks that were already registered. All this code was added in Feb 2020, in #20544, and it all made sense.

Then, year and a half later, in Oct 2021, in #34299, @gziolo added new `__experimentalReapplyBlockTypeFilters` action, dispatched during editor initialization, which removes the need for the static loop. It re-runs the `blocks.registerBlockType` filter, automatically catching all the early block registrations. This PR removes that static loop.

Found this when working on async block loading in #51778 -- the static loop goes through all registered blocks, which doesn't work well with async loading.

**How to test:**
There is a e2e suite that tests for this specifically. There is a `meta-attribute-block` plugin that registers two blocks, one early and one late, and tests that they both get the `source: 'meta`` behavior right.
