### PR TITLE
Changelog automation: use the correct label to filter Mobile app PRs

### DIFF
--- a/bin/plugin/commands/changelog.js
+++ b/bin/plugin/commands/changelog.js
@@ -470,6 +470,21 @@ const createOmitByLabel = ( labels ) => ( text, issue ) =>
 		: text;
 
 /**
+ * Higher-order function which returns a normalization function to omit by issue
+ * label starting with any of the given prefixes
+ *
+ * @param {string[]} prefixes Label prefixes from which to determine if given entry
+ *                            should be omitted.
+ *
+ * @return {WPChangelogNormalization} Normalization function.
+ */
+const createOmitByLabelPrefix = ( prefixes ) => ( text, issue ) =>
+	issue.labels.some( ( label ) =>
+		prefixes.some( ( prefix ) => label.name.startsWith( prefix ) )
+	)
+		? undefined
+		: text;
+/**
  * Given an issue title and issue, returns the title with redundant grouping
  * type details removed. The prefix is redundant since it would already be clear
  * enough by group assignment that the prefix would be inferred.
@@ -513,7 +528,7 @@ function removeFeaturePrefix( text ) {
  * @type {Array<WPChangelogNormalization>}
  */
 const TITLE_NORMALIZATIONS = [
-	createOmitByLabel( [ 'Mobile App - i.e. Android or iOS' ] ),
+	createOmitByLabelPrefix( [ 'Mobile App' ] ),
 	createOmitByTitlePrefix( [ '[rnmobile]', '[mobile]', 'Mobile Release' ] ),
 	removeRedundantTypePrefix,
 	reword,
@@ -1040,6 +1055,7 @@ async function getReleaseChangelog( options ) {
 	capitalizeAfterColonSeparatedPrefix,
 	createOmitByTitlePrefix,
 	createOmitByLabel,
+	createOmitByLabelPrefix,
 	addTrailingPeriod,
 	getNormalizedTitle,
 	getReleaseChangelog,

--- a/bin/plugin/commands/changelog.js
+++ b/bin/plugin/commands/changelog.js
@@ -513,7 +513,7 @@ function removeFeaturePrefix( text ) {
  * @type {Array<WPChangelogNormalization>}
  */
 const TITLE_NORMALIZATIONS = [
-	createOmitByLabel( [ 'Mobile App Android/iOS' ] ),
+	createOmitByLabel( [ 'Mobile App - i.e. Android or iOS' ] ),
 	createOmitByTitlePrefix( [ '[rnmobile]', '[mobile]', 'Mobile Release' ] ),
 	removeRedundantTypePrefix,
 	reword,

--- a/bin/plugin/commands/test/__snapshots__/changelog.js.snap
+++ b/bin/plugin/commands/test/__snapshots__/changelog.js.snap
@@ -177,8 +177,6 @@ exports[`getChangelog verify that the changelog is properly formatted 1`] = `
 ### Various
 
 - Core Data: Deprecate \`getAuthors\` in favor of \`getUsers\`. ([33725](https://github.com/WordPress/gutenberg/pull/33725))
-- RNMobile: Add integration test guide. ([33833](https://github.com/WordPress/gutenberg/pull/33833))
-- RNMobile: Try unifying the unit test command on mobile. ([33657](https://github.com/WordPress/gutenberg/pull/33657))
 - Tune appender margin. ([33866](https://github.com/WordPress/gutenberg/pull/33866))
 
 #### Block Library
@@ -196,7 +194,6 @@ exports[`getChangelog verify that the changelog is properly formatted 1`] = `
 - Try to fix flaky customizer inspector test. ([33890](https://github.com/WordPress/gutenberg/pull/33890))
 
 #### Block Editor
-- Closing the block inserter decrements block type impressions. ([33906](https://github.com/WordPress/gutenberg/pull/33906))
 - Enable rich previews for internal links. ([33086](https://github.com/WordPress/gutenberg/pull/33086))
 
 #### Icons

--- a/bin/plugin/commands/test/changelog.js
+++ b/bin/plugin/commands/test/changelog.js
@@ -51,7 +51,7 @@ describe( 'getNormalizedTitle', () => {
 			undefined,
 			{
 				...DEFAULT_ISSUE,
-				labels: [ { name: 'Mobile App Android/iOS' } ],
+				labels: [ { name: 'Mobile App - i.e. Android or iOS' } ],
 			},
 		],
 		[


### PR DESCRIPTION
## What?
Adapts the changelog automation script and its test fixtures to use the right label to filter out PRs related to the mobile app.

## Why?
Mobile app-related PRs are not being filtered properly from the changelog.

## How?
Instead of looking for a specific label, by filtering PRs that contain labels starting with the`Mobile App` prefix. This not only filters PRs with the updated `Mobile App - i.e. Android or iOS` label but also less frequent labels like `Mobile App - Release` and `Mobile App - Automation`.

## Testing Instructions
Run `npm run test:unit bin/plugin/commands/test/changelog.js`. Three more PRs will be filtered out now.
