### PR TITLE
Image: Fix layout shift when lightbox is opened and closed

### DIFF
--- a/lib/block-supports/behaviors.php
+++ b/lib/block-supports/behaviors.php
@@ -233,7 +233,9 @@ function gutenberg_render_behaviors_support_lightbox( $block_content, $block ) {
             data-wp-bind--aria-modal="context.core.image.lightboxEnabled"
             data-wp-effect="effects.core.image.initLightbox"
             data-wp-on--keydown="actions.core.image.handleKeydown"
-			data-wp-on--touchmove="actions.core.image.handleTouchMove"
+			data-wp-on--touchstart="actions.core.image.handleTouchStart"
+            data-wp-on--touchmove="actions.core.image.handleTouchMove"
+            data-wp-on--touchend="actions.core.image.handleTouchEnd"
             data-wp-on--click="actions.core.image.hideLightbox"
             >
                 <button type="button" aria-label="$close_button_label" style="fill: $close_button_color" class="close-button" data-wp-on--click="actions.core.image.hideLightbox">

--- a/lib/block-supports/behaviors.php
+++ b/lib/block-supports/behaviors.php
@@ -233,7 +233,6 @@ function gutenberg_render_behaviors_support_lightbox( $block_content, $block ) {
             data-wp-bind--aria-modal="context.core.image.lightboxEnabled"
             data-wp-effect="effects.core.image.initLightbox"
             data-wp-on--keydown="actions.core.image.handleKeydown"
-            data-wp-on--mousewheel="actions.core.image.hideLightbox"
             data-wp-on--click="actions.core.image.hideLightbox"
             >
                 <button type="button" aria-label="$close_button_label" style="fill: $close_button_color" class="close-button" data-wp-on--click="actions.core.image.hideLightbox">

--- a/lib/block-supports/behaviors.php
+++ b/lib/block-supports/behaviors.php
@@ -233,6 +233,7 @@ function gutenberg_render_behaviors_support_lightbox( $block_content, $block ) {
             data-wp-bind--aria-modal="context.core.image.lightboxEnabled"
             data-wp-effect="effects.core.image.initLightbox"
             data-wp-on--keydown="actions.core.image.handleKeydown"
+			data-wp-on--touchmove="actions.core.image.handleTouchMove"
             data-wp-on--click="actions.core.image.hideLightbox"
             >
                 <button type="button" aria-label="$close_button_label" style="fill: $close_button_color" class="close-button" data-wp-on--click="actions.core.image.hideLightbox">

--- a/lib/block-supports/behaviors.php
+++ b/lib/block-supports/behaviors.php
@@ -233,7 +233,7 @@ function gutenberg_render_behaviors_support_lightbox( $block_content, $block ) {
             data-wp-bind--aria-modal="context.core.image.lightboxEnabled"
             data-wp-effect="effects.core.image.initLightbox"
             data-wp-on--keydown="actions.core.image.handleKeydown"
-			data-wp-on--touchstart="actions.core.image.handleTouchStart"
+            data-wp-on--touchstart="actions.core.image.handleTouchStart"
             data-wp-on--touchmove="actions.core.image.handleTouchMove"
             data-wp-on--touchend="actions.core.image.handleTouchEnd"
             data-wp-on--click="actions.core.image.hideLightbox"

--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -272,7 +272,7 @@ function block_core_image_render_lightbox( $block_content, $block ) {
             aria-modal="false"
             data-wp-effect="effects.core.image.initLightbox"
             data-wp-on--keydown="actions.core.image.handleKeydown"
-            data-wp-on--mousewheel="actions.core.image.hideLightbox"
+            data-wp-on--touchmove="actions.core.image.handleTouchMove"
             data-wp-on--click="actions.core.image.hideLightbox"
             >
                 <button type="button" aria-label="$close_button_label" style="fill: $close_button_color" class="close-button" data-wp-on--click="actions.core.image.hideLightbox">

--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -272,9 +272,9 @@ function block_core_image_render_lightbox( $block_content, $block ) {
             aria-modal="false"
             data-wp-effect="effects.core.image.initLightbox"
             data-wp-on--keydown="actions.core.image.handleKeydown"
-			data-wp-on--touchstart="actions.core.image.handleTouchStart"
+            data-wp-on--touchstart="actions.core.image.handleTouchStart"
             data-wp-on--touchmove="actions.core.image.handleTouchMove"
-			data-wp-on--touchend="actions.core.image.handleTouchEnd"
+            data-wp-on--touchend="actions.core.image.handleTouchEnd"
             data-wp-on--click="actions.core.image.hideLightbox"
             >
                 <button type="button" aria-label="$close_button_label" style="fill: $close_button_color" class="close-button" data-wp-on--click="actions.core.image.hideLightbox">

--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -272,7 +272,9 @@ function block_core_image_render_lightbox( $block_content, $block ) {
             aria-modal="false"
             data-wp-effect="effects.core.image.initLightbox"
             data-wp-on--keydown="actions.core.image.handleKeydown"
+			data-wp-on--touchstart="actions.core.image.handleTouchStart"
             data-wp-on--touchmove="actions.core.image.handleTouchMove"
+			data-wp-on--touchend="actions.core.image.handleTouchEnd"
             data-wp-on--click="actions.core.image.hideLightbox"
             >
                 <button type="button" aria-label="$close_button_label" style="fill: $close_button_color" class="close-button" data-wp-on--click="actions.core.image.hideLightbox">

--- a/packages/block-library/src/image/style.scss
+++ b/packages/block-library/src/image/style.scss
@@ -247,16 +247,16 @@
 	// or faster than the scrim to give a sense of depth.
 	&.active {
 		visibility: visible;
-		animation: both turn-on-visibility 0.25s;
+		animation: both turn-on-visibility-opaque 0.25s;
 		img {
-			animation: both turn-on-visibility 0.35s;
+			animation: both turn-on-visibility-opaque 0.35s;
 		}
 	}
 	&.hideanimationenabled {
 		&:not(.active) {
-			animation: both turn-off-visibility 0.35s;
+			animation: both turn-off-visibility-opaque 0.35s;
 			img {
-				animation: both turn-off-visibility 0.25s;
+				animation: both turn-off-visibility-opaque 0.25s;
 			}
 		}
 	}
@@ -275,7 +275,7 @@
 					}
 				}
 				.scrim {
-					animation: turn-on-visibility 0.4s forwards;
+					animation: turn-on-visibility-transparent 0.4s forwards;
 				}
 			}
 			&.hideanimationenabled {
@@ -289,7 +289,7 @@
 						}
 					}
 					.scrim {
-						animation: turn-off-visibility 0.4s forwards;
+						animation: turn-off-visibility-transparent 0.4s forwards;
 					}
 				}
 			}
@@ -297,7 +297,7 @@
 	}
 }
 
-@keyframes turn-on-visibility {
+@keyframes turn-on-visibility-opaque {
 	0% {
 		opacity: 0;
 	}
@@ -306,9 +306,33 @@
 	}
 }
 
-@keyframes turn-off-visibility {
+@keyframes turn-off-visibility-opaque {
 	0% {
 		opacity: 1;
+		visibility: visible;
+	}
+	99% {
+		opacity: 0;
+		visibility: visible;
+	}
+	100% {
+		opacity: 0;
+		visibility: hidden;
+	}
+}
+
+@keyframes turn-on-visibility-transparent {
+	0% {
+		opacity: 0;
+	}
+	100% {
+		opacity: 0.9;
+	}
+}
+
+@keyframes turn-off-visibility-transparent {
+	0% {
+		opacity: 0.9;
 		visibility: visible;
 	}
 	99% {

--- a/packages/block-library/src/image/style.scss
+++ b/packages/block-library/src/image/style.scss
@@ -186,8 +186,8 @@
 
 	.close-button {
 		position: absolute;
-		top: calc(env(safe-area-inset-top) + 12.5px);
-		right: calc(env(safe-area-inset-right) + 12.5px);
+		top: calc(env(safe-area-inset-top) + 20px);
+		right: calc(env(safe-area-inset-right) + 20px);
 		padding: 0;
 		cursor: pointer;
 		z-index: 5000000;

--- a/packages/block-library/src/image/style.scss
+++ b/packages/block-library/src/image/style.scss
@@ -297,10 +297,6 @@
 	}
 }
 
-html.wp-has-lightbox-open {
-	overflow: hidden;
-}
-
 @keyframes turn-on-visibility {
 	0% {
 		opacity: 0;

--- a/packages/block-library/src/image/style.scss
+++ b/packages/block-library/src/image/style.scss
@@ -247,16 +247,16 @@
 	// or faster than the scrim to give a sense of depth.
 	&.active {
 		visibility: visible;
-		animation: both turn-on-visibility-opaque 0.25s;
+		animation: both turn-on-visibility 0.25s;
 		img {
-			animation: both turn-on-visibility-opaque 0.35s;
+			animation: both turn-on-visibility 0.35s;
 		}
 	}
 	&.hideanimationenabled {
 		&:not(.active) {
-			animation: both turn-off-visibility-opaque 0.35s;
+			animation: both turn-off-visibility 0.35s;
 			img {
-				animation: both turn-off-visibility-opaque 0.25s;
+				animation: both turn-off-visibility 0.25s;
 			}
 		}
 	}
@@ -275,7 +275,7 @@
 					}
 				}
 				.scrim {
-					animation: turn-on-visibility-transparent 0.4s forwards;
+					animation: turn-on-visibility 0.4s forwards;
 				}
 			}
 			&.hideanimationenabled {
@@ -289,7 +289,7 @@
 						}
 					}
 					.scrim {
-						animation: turn-off-visibility-transparent 0.4s forwards;
+						animation: turn-off-visibility 0.4s forwards;
 					}
 				}
 			}
@@ -297,7 +297,7 @@
 	}
 }
 
-@keyframes turn-on-visibility-opaque {
+@keyframes turn-on-visibility {
 	0% {
 		opacity: 0;
 	}
@@ -306,33 +306,9 @@
 	}
 }
 
-@keyframes turn-off-visibility-opaque {
+@keyframes turn-off-visibility {
 	0% {
 		opacity: 1;
-		visibility: visible;
-	}
-	99% {
-		opacity: 0;
-		visibility: visible;
-	}
-	100% {
-		opacity: 0;
-		visibility: hidden;
-	}
-}
-
-@keyframes turn-on-visibility-transparent {
-	0% {
-		opacity: 0;
-	}
-	100% {
-		opacity: 0.9;
-	}
-}
-
-@keyframes turn-off-visibility-transparent {
-	0% {
-		opacity: 0.9;
 		visibility: visible;
 	}
 	99% {

--- a/packages/block-library/src/image/view.js
+++ b/packages/block-library/src/image/view.js
@@ -37,7 +37,10 @@ let scrollCallback;
 // for now that provides the best visual experience.
 function handleScroll( event, context, actions ) {
 	event.preventDefault();
-	window.scrollTo( 0, context.core.image.lastScrollTop );
+	window.scrollTo(
+		context.core.image.lastScrollLeft,
+		context.core.image.lastScrollTop
+	);
 	actions.core.image.hideLightbox( { context, event } );
 }
 
@@ -71,6 +74,12 @@ store(
 						context.core.image.lastScrollTop =
 							window.pageYOffset ||
 							document.documentElement.scrollTop;
+
+						// In most cases, this value will be 0, but this is included
+						// in case a user has created a page with horizontal scrolling.
+						context.core.image.lastScrollLeft =
+							window.pageXOffset ||
+							document.documentElement.scrollLeft;
 
 						// We define and bind the scroll callback here so that
 						// we can pass the context and actions as arguments.

--- a/packages/block-library/src/image/view.js
+++ b/packages/block-library/src/image/view.js
@@ -17,29 +17,55 @@ const focusableSelectors = [
 	'[tabindex]:not([tabindex^="-"])',
 ];
 
-// I've defined the scroll handling outside of the store
-// to prevent confusion as to how this logic is called.
-// This logic is not referenced directly by the directives
-// in the markup because the scroll event we need to listen
-// to is triggered on the window; so we define it outside of
-// the store to signal that the behavior here is different.
-// If we find a compelling reason to move it to the store,
-// feel free to do so.
+/*
+ * Stores a context-bound scroll handler.
+ *
+ * This callback could be defined inline inside of the store
+ * object but it's created externally to avoid confusion about
+ * how its logic is called. This logic is not referenced directly
+ * by the directives in the markup because the scroll event we
+ * need to listen to is triggered on the window; so by defining it
+ * outside of the store, we signal that the behavior here is different.
+ * If we find a compelling reason to move it to the store, feel free.
+ *
+ * @type {Function}
+ */
 let scrollCallback;
 
-// We need to track whether a user is touching the screen so we
-// can handle the scroll override differently on mobile devices.
+/*
+ * Tracks whether user is touching screen; used to
+ * differentiate behavior for touch and mouse input.
+ *
+ * @type {boolean}
+ */
 let isTouching = false;
+
+/*
+ * Tracks the last time the screen was touched; used to
+ * differentiate behavior for touch and mouse input.
+ *
+ * @type {number}
+ */
 let lastTouchTime = 0;
 
-// Using overflow: hidden to prevent scrolling while the lightbox
-// is open causes the content to shift and prevents the zoom
-// animation from working in some cases because we're unable to
-// account for the layout shift when doing the animation calculations.
-// Instead, here we use JavaScript to prevent and reset the scrolling
-// behavior. In the future, we may be able to use CSS or overflow: hidden
-// instead to not rely on JavaScript, but this seems to be the best approach
-// for now that provides the best visual experience.
+/*
+ * Lightbox page-scroll handler: prevents scrolling.
+ *
+ * This handler is added to prevent scrolling behaviors that
+ * trigger content shift while the lightbox is open.
+ *
+ * It would be better to accomplish this through CSS alone, but
+ * using overflow: hidden is currently the only way to do so, and
+ * that causes the layout to shift and prevents the zoom animation
+ * from working in some cases because we're unable to account for
+ * the layout shift when doing the animation calculations. Instead,
+ * here we use JavaScript to prevent and reset the scrolling
+ * behavior. In the future, we may be able to use CSS or overflow: hidden
+ * instead to not rely on JavaScript, but this seems to be the best approach
+ * for now that provides the best visual experience.
+ *
+ * @param {Object} context Interactivity page context?
+ */
 function handleScroll( context ) {
 	// We can't override the scroll behavior on mobile devices
 	// because doing so breaks the pinch to zoom functionality, and we
@@ -319,6 +345,13 @@ store(
 	}
 );
 
+/*
+ * Computes styles for the lightbox and adds them to the document.
+ *
+ * @function
+ * @param {Object} context - An Interactivity API context
+ * @param {Object} event - A triggering event
+ */
 function setStyles( context, event ) {
 	// The reference img element lies adjacent
 	// to the event target button in the DOM.
@@ -475,18 +508,25 @@ function setStyles( context, event ) {
 	// transformation. In any case, adding 1 pixel to the container width and height solves
 	// the problem, though this can be removed if the issue is fixed in the future.
 	styleTag.innerHTML = `
-		:root {
-			--wp--lightbox-initial-top-position: ${ screenPosY }px;
-			--wp--lightbox-initial-left-position: ${ screenPosX }px;
-			--wp--lightbox-container-width: ${ containerWidth + 1 }px;
-			--wp--lightbox-container-height: ${ containerHeight + 1 }px;
-			--wp--lightbox-image-width: ${ lightboxImgWidth }px;
-			--wp--lightbox-image-height: ${ lightboxImgHeight }px;
-			--wp--lightbox-scale: ${ containerScale };
-		}
-	`;
+			:root {
+				--wp--lightbox-initial-top-position: ${ screenPosY }px;
+				--wp--lightbox-initial-left-position: ${ screenPosX }px;
+				--wp--lightbox-container-width: ${ containerWidth + 1 }px;
+				--wp--lightbox-container-height: ${ containerHeight + 1 }px;
+				--wp--lightbox-image-width: ${ lightboxImgWidth }px;
+				--wp--lightbox-image-height: ${ lightboxImgHeight }px;
+				--wp--lightbox-scale: ${ containerScale };
+			}
+		`;
 }
 
+/*
+ * Debounces a function call.
+ *
+ * @function
+ * @param {Function} func - A function to be called
+ * @param {number} wait - The time to wait before calling the function
+ */
 function debounce( func, wait = 50 ) {
 	let timeout;
 	return () => {

--- a/packages/block-library/src/image/view.js
+++ b/packages/block-library/src/image/view.js
@@ -48,8 +48,8 @@ function handleScroll( context ) {
 		// We are unable to use event.preventDefault() to prevent scrolling
 		// because the scroll event can't be canceled, so we reset the position instead.
 		window.scrollTo(
-			context.core.image.lastScrollLeft,
-			context.core.image.lastScrollTop
+			context.core.image.scrollLeftReset,
+			context.core.image.scrollTopReset
 		);
 	}
 }
@@ -81,13 +81,13 @@ store(
 						context.core.image.lightboxEnabled = true;
 						setStyles( context, event );
 
-						context.core.image.lastScrollTop =
+						context.core.image.scrollTopReset =
 							window.pageYOffset ||
 							document.documentElement.scrollTop;
 
 						// In most cases, this value will be 0, but this is included
 						// in case a user has created a page with horizontal scrolling.
-						context.core.image.lastScrollLeft =
+						context.core.image.scrollLeftReset =
 							window.pageXOffset ||
 							document.documentElement.scrollLeft;
 

--- a/packages/block-library/src/image/view.js
+++ b/packages/block-library/src/image/view.js
@@ -508,16 +508,16 @@ function setStyles( context, event ) {
 	// transformation. In any case, adding 1 pixel to the container width and height solves
 	// the problem, though this can be removed if the issue is fixed in the future.
 	styleTag.innerHTML = `
-			:root {
-				--wp--lightbox-initial-top-position: ${ screenPosY }px;
-				--wp--lightbox-initial-left-position: ${ screenPosX }px;
-				--wp--lightbox-container-width: ${ containerWidth + 1 }px;
-				--wp--lightbox-container-height: ${ containerHeight + 1 }px;
-				--wp--lightbox-image-width: ${ lightboxImgWidth }px;
-				--wp--lightbox-image-height: ${ lightboxImgHeight }px;
-				--wp--lightbox-scale: ${ containerScale };
-			}
-		`;
+		:root {
+			--wp--lightbox-initial-top-position: ${ screenPosY }px;
+			--wp--lightbox-initial-left-position: ${ screenPosX }px;
+			--wp--lightbox-container-width: ${ containerWidth + 1 }px;
+			--wp--lightbox-container-height: ${ containerHeight + 1 }px;
+			--wp--lightbox-image-width: ${ lightboxImgWidth }px;
+			--wp--lightbox-image-height: ${ lightboxImgHeight }px;
+			--wp--lightbox-scale: ${ containerScale };
+		}
+	`;
 }
 
 /*

--- a/packages/block-library/src/image/view.js
+++ b/packages/block-library/src/image/view.js
@@ -111,8 +111,7 @@ store(
 					hideLightbox: async ( { context } ) => {
 						context.core.image.hideAnimationEnabled = true;
 						if ( context.core.image.lightboxEnabled ) {
-							// The lightbox will close once it detects a scroll event,
-							// but we want to wait until the close animation is completed
+							// We want to wait until the close animation is completed
 							// before allowing a user to scroll again. The duration of this
 							// animation is defined in the styles.scss and depends on if the
 							// animation is 'zoom' or 'fade', but in any case we should wait

--- a/packages/block-library/src/image/view.js
+++ b/packages/block-library/src/image/view.js
@@ -35,7 +35,7 @@ let scrollCallback;
 // behavior. In the future, we may be able to use CSS or overflow: hidden
 // instead to not rely on JavaScript, but this seems to be the best approach
 // for now that provides the best visual experience.
-function handleScroll( event, context, actions ) {
+function handleScroll( context, actions, event ) {
 	event.preventDefault();
 	window.scrollTo(
 		context.core.image.lastScrollLeft,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Currently, opening and closing the lightbox causes the website layout to shift, which can cause the zoom animation to appear broken, particularly on mobile. It is also possible to scroll the webpage while the lightbox is open by directly manipulating the scrollbar or using a mobile device, which is not in line with web standards.

This PR improves the lightbox implementation by removing the layout shift and updating the scroll handling so that the lightbox behaves reliably whenever a scroll is performed.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
We want to offer a polished lightbox experience, and the current experience appears broken in some cases. 

## How?
This PR removes `overflow: hidden` from the styles and updates the callback for the scroll handling.

Note: Expected behavior is that scrolling will be disabled on both desktop and mobile.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Insert an image in a post and add enough content to ensure that the scrollbar will be visible.
2. Enable the lightbox using the block settings.
4. Publish and view the post on desktop.
5. Click on the image to open and close the lightbox — make sure that the scrollbar remains intact and that there is no layout shift.
6. Attempt scrolling while the lightbox is open using the mousewheel, `up` and `down` arrow keys, the `PageUp` and `PageDown` keys, and by directly clicking and dragging the scrollbar — verify that the lightbox stays open and doesn't scroll when performing any of those actions.
7. On mobile devices, test that scrolling is disabled and that the lightbox remains open when attempting to scroll using touch input. Test also that pinch to zoom while the lightbox is open works reasonably well.

## Screenshare

### Layout Shift Demonstration

#### Before the Fix

https://github.com/WordPress/gutenberg/assets/5360536/3789a30b-5df3-42d3-85aa-c4369f61bd77

#### After the Fix

https://github.com/WordPress/gutenberg/assets/5360536/3682b764-17a0-4964-9d9f-2f9cdc4f777f


