### PR TITLE
Image block: Disable flaky image tests related to Interactivity API

### DIFF
--- a/test/e2e/specs/editor/blocks/image.spec.js
+++ b/test/e2e/specs/editor/blocks/image.spec.js
@@ -727,489 +727,491 @@ test.describe( 'Image', () => {
 		expect( src ).toMatch( /\/wp-content\/uploads\// );
 	} );
 } );
-
-// test.describe( 'Image - interactivity', () => {
-// 	test.beforeAll( async ( { requestUtils } ) => {
-// 		await requestUtils.deleteAllMedia();
-// 	} );
-
-// 	test.afterAll( async ( { requestUtils } ) => {
-// 		await requestUtils.deleteAllMedia();
-// 	} );
-
-// 	test.beforeEach( async ( { admin, editor } ) => {
-// 		await admin.createNewPost();
-// 		await editor.insertBlock( { name: 'core/image' } );
-// 	} );
-
-// 	test.afterEach( async ( { requestUtils } ) => {
-// 		await requestUtils.deleteAllMedia();
-// 	} );
-
-// 	test.describe( 'tests using uploaded image', () => {
-// 		let filename = null;
-
-// 		test.beforeEach( async ( { editor, imageBlockUtils } ) => {
-// 			const imageBlock = editor.canvas.locator(
-// 				'role=document[name="Block: Image"i]'
-// 			);
-// 			await expect( imageBlock ).toBeVisible();
-
-// 			filename = await imageBlockUtils.upload(
-// 				imageBlock.locator( 'data-testid=form-file-upload-input' ),
-// 				'3200x2400_e2e_test_image_responsive_lightbox.jpeg'
-// 			);
-// 			const image = imageBlock.locator( 'role=img' );
-// 			await expect( image ).toBeVisible();
-// 			await expect( image ).toHaveAttribute(
-// 				'src',
-// 				new RegExp( filename )
-// 			);
-
-// 			await editor.openDocumentSettingsSidebar();
-// 		} );
-
-// 		test( 'should toggle "lightbox" in saved attributes', async ( {
-// 			editor,
-// 			page,
-// 		} ) => {
-// 			await page.getByRole( 'button', { name: 'Advanced' } ).click();
-// 			await page
-// 				.getByRole( 'combobox', { name: 'Behaviors' } )
-// 				.selectOption( 'lightbox' );
-
-// 			let blocks = await editor.getBlocks();
-// 			expect( blocks[ 0 ].attributes ).toMatchObject( {
-// 				behaviors: {
-// 					lightbox: {
-// 						animation: 'zoom',
-// 						enabled: true,
-// 					},
-// 				},
-// 				linkDestination: 'none',
-// 			} );
-// 			expect( blocks[ 0 ].attributes.url ).toContain( filename );
-
-// 			await page.getByLabel( 'Behaviors' ).selectOption( '' );
-// 			blocks = await editor.getBlocks();
-// 			expect( blocks[ 0 ].attributes ).toMatchObject( {
-// 				behaviors: {
-// 					lightbox: {
-// 						animation: '',
-// 						enabled: false,
-// 					},
-// 				},
-// 				linkDestination: 'none',
-// 			} );
-// 			expect( blocks[ 0 ].attributes.url ).toContain( filename );
-// 		} );
-
-// 		test.describe( 'should open and close the image in a lightbox when using a mouse and dynamically load src', () => {
-// 			test.beforeEach( async ( { page } ) => {
-// 				await page.getByRole( 'button', { name: 'Advanced' } ).click();
-// 				await page
-// 					.getByRole( 'combobox', { name: 'Behaviors' } )
-// 					.selectOption( 'lightbox' );
-// 			} );
-
-// 			test( 'zoom animation', async ( { editor, page } ) => {
-// 				await page
-// 					.getByRole( 'combobox', { name: 'Animation' } )
-// 					.selectOption( 'zoom' );
-
-// 				const postId = await editor.publishPost();
-// 				await page.goto( `/?p=${ postId }` );
-
-// 				// getByRole() doesn't work for the image here for
-// 				// some reason, so let's use locators instead
-// 				const contentFigure = page.locator( '.entry-content figure' );
-// 				const contentImage = page.locator(
-// 					'.entry-content figure img'
-// 				);
-
-// 				const wpContext = await contentFigure.getAttribute(
-// 					'data-wp-context'
-// 				);
-
-// 				const imageUploadedSrc =
-// 					JSON.parse( wpContext ).core.image.imageUploadedSrc;
-
-// 				const contentImageCurrentSrc = await contentImage.evaluate(
-// 					( img ) => img.currentSrc
-// 				);
-
-// 				const lightbox = page.locator( '.wp-lightbox-overlay' );
-// 				await expect( lightbox ).toBeHidden();
-// 				const responsiveImage = lightbox.locator(
-// 					'.responsive-image img'
-// 				);
-// 				const enlargedImage = lightbox.locator( '.enlarged-image img' );
-
-// 				await expect( responsiveImage ).toHaveAttribute(
-// 					'src',
-// 					contentImageCurrentSrc
-// 				);
-// 				await expect( enlargedImage ).toHaveAttribute( 'src', '' );
-
-// 				await page
-// 					.getByRole( 'button', { name: 'Enlarge image' } )
-// 					.click();
-
-// 				await expect( responsiveImage ).toHaveAttribute(
-// 					'src',
-// 					contentImageCurrentSrc
-// 				);
-// 				await expect( enlargedImage ).toHaveAttribute(
-// 					'src',
-// 					imageUploadedSrc
-// 				);
-
-// 				await expect( lightbox ).toBeVisible();
-
-// 				const document = page.getByRole( 'document' );
-// 				const lightboxStyleCheck = await document.evaluate( ( doc ) => {
-// 					// We don't have access to the getPropertyValue() method
-// 					// on the CSSStyleDeclaration returned form getComputedStyle()
-// 					// in the Playwright outer context, so we need to evaluate it here
-// 					// in the browser context here.
-// 					const documentStyles = window.getComputedStyle( doc );
-// 					const lightboxStyleVars = [
-// 						'--lightbox-scale-width',
-// 						'--lightbox-scale-height',
-// 						'--lightbox-image-max-width',
-// 						'--lightbox-image-max-height',
-// 						'--lightbox-initial-left-position',
-// 						'--lightbox-initial-top-position',
-// 					];
-// 					const lightboxStyleErrors = [];
-// 					lightboxStyleVars.forEach( ( styleVar ) => {
-// 						if ( ! documentStyles.getPropertyValue( styleVar ) ) {
-// 							lightboxStyleErrors.push( styleVar );
-// 						}
-// 					} );
-
-// 					return lightboxStyleErrors.length > 0
-// 						? lightboxStyleErrors
-// 						: true;
-// 				} );
-// 				expect( lightboxStyleCheck ).toBe( true );
-
-// 				const closeButton = lightbox.getByRole( 'button', {
-// 					name: 'Close',
-// 				} );
-// 				await closeButton.click();
-
-// 				await expect( responsiveImage ).toHaveAttribute( 'src', '' );
-// 				await expect( enlargedImage ).toHaveAttribute(
-// 					'src',
-// 					imageUploadedSrc
-// 				);
-
-// 				await expect( lightbox ).toBeHidden();
-// 			} );
-
-// 			test( 'fade animation', async ( { editor, page } ) => {
-// 				await page
-// 					.getByRole( 'combobox', { name: 'Animation' } )
-// 					.selectOption( 'fade' );
-
-// 				const postId = await editor.publishPost();
-// 				await page.goto( `/?p=${ postId }` );
-
-// 				// getByRole() doesn't work for the image here for
-// 				// some reason, so let's use locators instead
-// 				const contentFigure = page.locator( '.entry-content figure' );
-// 				const contentImage = page.locator(
-// 					'.entry-content figure img'
-// 				);
-
-// 				const wpContext = await contentFigure.getAttribute(
-// 					'data-wp-context'
-// 				);
-
-// 				const imageUploadedSrc =
-// 					JSON.parse( wpContext ).core.image.imageUploadedSrc;
-
-// 				const contentImageCurrentSrc = await contentImage.evaluate(
-// 					( img ) => img.currentSrc
-// 				);
-
-// 				const lightbox = page.locator( '.wp-lightbox-overlay' );
-// 				await expect( lightbox ).toBeHidden();
-// 				const responsiveImage = lightbox.locator(
-// 					'.responsive-image img'
-// 				);
-// 				const enlargedImage = lightbox.locator( '.enlarged-image img' );
-
-// 				await expect( responsiveImage ).toHaveAttribute(
-// 					'src',
-// 					contentImageCurrentSrc
-// 				);
-// 				await expect( enlargedImage ).toHaveAttribute( 'src', '' );
-
-// 				await page
-// 					.getByRole( 'button', { name: 'Enlarge image' } )
-// 					.click();
-
-// 				await expect( responsiveImage ).toHaveAttribute(
-// 					'src',
-// 					contentImageCurrentSrc
-// 				);
-// 				await expect( enlargedImage ).toHaveAttribute(
-// 					'src',
-// 					imageUploadedSrc
-// 				);
-
-// 				await expect( lightbox ).toBeVisible();
-
-// 				const closeButton = lightbox.getByRole( 'button', {
-// 					name: 'Close',
-// 				} );
-// 				await closeButton.click();
-
-// 				await expect( responsiveImage ).toHaveAttribute( 'src', '' );
-// 				await expect( enlargedImage ).toHaveAttribute(
-// 					'src',
-// 					imageUploadedSrc
-// 				);
-
-// 				await expect( lightbox ).toBeHidden();
-// 			} );
-// 		} );
-
-// 		test( 'lightbox should be overriden when link is configured for image', async ( {
-// 			editor,
-// 			page,
-// 		} ) => {
-// 			await page.getByRole( 'button', { name: 'Advanced' } ).click();
-// 			const behaviorSelect = page.getByRole( 'combobox', {
-// 				name: 'Behaviors',
-// 			} );
-// 			await behaviorSelect.selectOption( 'lightbox' );
-
-// 			await page
-// 				.getByLabel( 'Block tools' )
-// 				.getByLabel( 'Insert link' )
-// 				.click();
-
-// 			const form = page.locator(
-// 				'.block-editor-url-popover__link-editor'
-// 			);
-
-// 			const url = 'https://wordpress.org';
-
-// 			await form.getByLabel( 'URL' ).fill( url );
-
-// 			await form.getByRole( 'button', { name: 'Apply' } ).click();
-// 			await expect( behaviorSelect ).toBeDisabled();
-
-// 			const postId = await editor.publishPost();
-// 			await page.goto( `/?p=${ postId }` );
-
-// 			// The lightbox markup should not appear in the DOM at all
-// 			await expect(
-// 				page.getByRole( 'button', { name: 'Enlarge image' } )
-// 			).not.toBeInViewport();
-// 		} );
-
-// 		test( 'markup should not appear if Lightbox is disabled', async ( {
-// 			editor,
-// 			page,
-// 		} ) => {
-// 			await page.getByRole( 'button', { name: 'Advanced' } ).click();
-// 			const behaviorSelect = page.getByRole( 'combobox', {
-// 				name: 'Behaviors',
-// 			} );
-// 			await behaviorSelect.selectOption( '' );
-
-// 			const postId = await editor.publishPost();
-// 			await page.goto( `/?p=${ postId }` );
-
-// 			// The lightbox markup should not appear in the DOM at all
-// 			await expect(
-// 				page.getByRole( 'button', { name: 'Enlarge image' } )
-// 			).not.toBeInViewport();
-// 		} );
-
-// 		test.describe( 'Animation Select visibility', () => {
-// 			test( 'Animation selector should appear if Behavior is Lightbox', async ( {
-// 				page,
-// 			} ) => {
-// 				await page.getByRole( 'button', { name: 'Advanced' } ).click();
-// 				const behaviorSelect = page.getByRole( 'combobox', {
-// 					name: 'Behaviors',
-// 				} );
-// 				await behaviorSelect.selectOption( 'lightbox' );
-// 				await expect(
-// 					page.getByRole( 'combobox', {
-// 						name: 'Animation',
-// 					} )
-// 				).toBeVisible();
-// 			} );
-// 			test( 'Animation selector should NOT appear if Behavior is None', async ( {
-// 				page,
-// 			} ) => {
-// 				await page.getByRole( 'button', { name: 'Advanced' } ).click();
-// 				const behaviorSelect = page.getByRole( 'combobox', {
-// 					name: 'Behaviors',
-// 				} );
-// 				await behaviorSelect.selectOption( '' );
-// 				await expect(
-// 					page.getByRole( 'combobox', {
-// 						name: 'Animation',
-// 					} )
-// 				).not.toBeVisible();
-// 			} );
-// 			test( 'Animation selector should NOT appear if Behavior is Default', async ( {
-// 				page,
-// 			} ) => {
-// 				await page.getByRole( 'button', { name: 'Advanced' } ).click();
-// 				const behaviorSelect = page.getByRole( 'combobox', {
-// 					name: 'Behaviors',
-// 				} );
-// 				await behaviorSelect.selectOption( 'default' );
-// 				await expect(
-// 					page.getByRole( 'combobox', {
-// 						name: 'Animation',
-// 					} )
-// 				).not.toBeVisible();
-// 			} );
-// 		} );
-
-// 		test.describe( 'keyboard navigation', () => {
-// 			let openLightboxButton;
-// 			let lightbox;
-// 			let closeButton;
-
-// 			test.beforeEach( async ( { page, editor } ) => {
-// 				await page.getByRole( 'button', { name: 'Advanced' } ).click();
-// 				await page
-// 					.getByRole( 'combobox', { name: 'Behaviors' } )
-// 					.selectOption( 'lightbox' );
-
-// 				const postId = await editor.publishPost();
-// 				await page.goto( `/?p=${ postId }` );
-
-// 				openLightboxButton = page.getByRole( 'button', {
-// 					name: 'Enlarge image',
-// 				} );
-// 				lightbox = page.getByRole( 'dialog' );
-// 				closeButton = lightbox.getByRole( 'button', {
-// 					name: 'Close',
-// 				} );
-// 			} );
-
-// 			test( 'should open and focus appropriately using enter key', async ( {
-// 				page,
-// 			} ) => {
-// 				// Open and close lightbox using the close button
-// 				await openLightboxButton.focus();
-// 				await page.keyboard.press( 'Enter' );
-// 				await expect( lightbox ).toBeVisible();
-// 				await expect( closeButton ).toBeFocused();
-// 			} );
-
-// 			test( 'should close and focus appropriately using enter key on close button', async ( {
-// 				page,
-// 			} ) => {
-// 				// Open and close lightbox using the close button
-// 				await openLightboxButton.focus();
-// 				await page.keyboard.press( 'Enter' );
-// 				await expect( lightbox ).toBeVisible();
-// 				await expect( closeButton ).toBeFocused();
-// 				await page.keyboard.press( 'Enter' );
-// 				await expect( lightbox ).toBeHidden();
-// 				await expect( openLightboxButton ).toBeFocused();
-// 			} );
-
-// 			test( 'should close and focus appropriately using escape key', async ( {
-// 				page,
-// 			} ) => {
-// 				await openLightboxButton.focus();
-// 				await page.keyboard.press( 'Enter' );
-// 				await expect( lightbox ).toBeVisible();
-// 				await expect( closeButton ).toBeFocused();
-// 				await page.keyboard.press( 'Escape' );
-// 				await expect( lightbox ).toBeHidden();
-// 				await expect( openLightboxButton ).toBeFocused();
-// 			} );
-
-// 			// TO DO: Add these tests, which will involve adding a caption
-// 			// to uploaded test images
-// 			// test( 'should trap focus appropriately when using tab', async ( {
-// 			// 	page,
-// 			// } ) => {
-
-// 			// } );
-
-// 			// test( 'should trap focus appropriately using shift+tab', async ( {
-// 			// 	page,
-// 			// } ) => {
-
-// 			// } );
-// 		} );
-// 	} );
-
-// 	test( 'lightbox should work as expected when inserting image from URL', async ( {
-// 		editor,
-// 		page,
-// 	} ) => {
-// 		await editor.openDocumentSettingsSidebar();
-
-// 		const imageBlockFromUrl = editor.canvas.locator(
-// 			'role=document[name="Block: Image"i]'
-// 		);
-// 		await expect( imageBlockFromUrl ).toBeVisible();
-
-// 		await imageBlockFromUrl
-// 			.getByRole( 'button' )
-// 			.filter( { hasText: 'Insert from URL' } )
-// 			.click();
-
-// 		const form = page.locator(
-// 			'.block-editor-media-placeholder__url-input-form'
-// 		);
-
-// 		const imgUrl =
-// 			'https://wp20.wordpress.net/wp-content/themes/twentyseventeen-wp20/images/wp20-logo-white.svg';
-
-// 		await form.getByLabel( 'URL' ).fill( imgUrl );
-
-// 		await form.getByRole( 'button', { name: 'Apply' } ).click();
-
-// 		const image = imageBlockFromUrl.locator( 'role=img' );
-// 		await expect( image ).toBeVisible();
-// 		await expect( image ).toHaveAttribute( 'src', imgUrl );
-
-// 		await page.getByRole( 'button', { name: 'Advanced' } ).click();
-// 		await page
-// 			.getByRole( 'combobox', { name: 'Behaviors' } )
-// 			.selectOption( 'lightbox' );
-
-// 		const postId = await editor.publishPost();
-// 		await page.goto( `/?p=${ postId }` );
-
-// 		const lightbox = page.locator( '.wp-lightbox-overlay' );
-// 		const responsiveImage = lightbox.locator( '.responsive-image img' );
-// 		const enlargedImage = lightbox.locator( '.enlarged-image img' );
-
-// 		await expect( responsiveImage ).toHaveAttribute(
-// 			'src',
-// 			new RegExp( imgUrl )
-// 		);
-// 		await expect( enlargedImage ).toHaveAttribute( 'src', '' );
-
-// 		await page.getByRole( 'button', { name: 'Enlarge image' } ).click();
-
-// 		await expect( responsiveImage ).toHaveAttribute( 'src', imgUrl );
-// 		await expect( enlargedImage ).toHaveAttribute( 'src', imgUrl );
-
-// 		await page.getByRole( 'button', { name: 'Close' } ).click();
-
-// 		await expect( responsiveImage ).toHaveAttribute( 'src', '' );
-// 		await expect( enlargedImage ).toHaveAttribute( 'src', imgUrl );
-// 	} );
-// } );
+// These tests are disabled for now while we
+// work on a solution to make them more stable.
+// See https://github.com/WordPress/gutenberg/pull/52442
+test.skip( 'Image - interactivity', () => {
+	test.beforeAll( async ( { requestUtils } ) => {
+		await requestUtils.deleteAllMedia();
+	} );
+
+	test.afterAll( async ( { requestUtils } ) => {
+		await requestUtils.deleteAllMedia();
+	} );
+
+	test.beforeEach( async ( { admin, editor } ) => {
+		await admin.createNewPost();
+		await editor.insertBlock( { name: 'core/image' } );
+	} );
+
+	test.afterEach( async ( { requestUtils } ) => {
+		await requestUtils.deleteAllMedia();
+	} );
+
+	test.describe( 'tests using uploaded image', () => {
+		let filename = null;
+
+		test.beforeEach( async ( { editor, imageBlockUtils } ) => {
+			const imageBlock = editor.canvas.locator(
+				'role=document[name="Block: Image"i]'
+			);
+			await expect( imageBlock ).toBeVisible();
+
+			filename = await imageBlockUtils.upload(
+				imageBlock.locator( 'data-testid=form-file-upload-input' ),
+				'3200x2400_e2e_test_image_responsive_lightbox.jpeg'
+			);
+			const image = imageBlock.locator( 'role=img' );
+			await expect( image ).toBeVisible();
+			await expect( image ).toHaveAttribute(
+				'src',
+				new RegExp( filename )
+			);
+
+			await editor.openDocumentSettingsSidebar();
+		} );
+
+		test( 'should toggle "lightbox" in saved attributes', async ( {
+			editor,
+			page,
+		} ) => {
+			await page.getByRole( 'button', { name: 'Advanced' } ).click();
+			await page
+				.getByRole( 'combobox', { name: 'Behaviors' } )
+				.selectOption( 'lightbox' );
+
+			let blocks = await editor.getBlocks();
+			expect( blocks[ 0 ].attributes ).toMatchObject( {
+				behaviors: {
+					lightbox: {
+						animation: 'zoom',
+						enabled: true,
+					},
+				},
+				linkDestination: 'none',
+			} );
+			expect( blocks[ 0 ].attributes.url ).toContain( filename );
+
+			await page.getByLabel( 'Behaviors' ).selectOption( '' );
+			blocks = await editor.getBlocks();
+			expect( blocks[ 0 ].attributes ).toMatchObject( {
+				behaviors: {
+					lightbox: {
+						animation: '',
+						enabled: false,
+					},
+				},
+				linkDestination: 'none',
+			} );
+			expect( blocks[ 0 ].attributes.url ).toContain( filename );
+		} );
+
+		test.describe( 'should open and close the image in a lightbox when using a mouse and dynamically load src', () => {
+			test.beforeEach( async ( { page } ) => {
+				await page.getByRole( 'button', { name: 'Advanced' } ).click();
+				await page
+					.getByRole( 'combobox', { name: 'Behaviors' } )
+					.selectOption( 'lightbox' );
+			} );
+
+			test( 'zoom animation', async ( { editor, page } ) => {
+				await page
+					.getByRole( 'combobox', { name: 'Animation' } )
+					.selectOption( 'zoom' );
+
+				const postId = await editor.publishPost();
+				await page.goto( `/?p=${ postId }` );
+
+				// getByRole() doesn't work for the image here for
+				// some reason, so let's use locators instead
+				const contentFigure = page.locator( '.entry-content figure' );
+				const contentImage = page.locator(
+					'.entry-content figure img'
+				);
+
+				const wpContext = await contentFigure.getAttribute(
+					'data-wp-context'
+				);
+
+				const imageUploadedSrc =
+					JSON.parse( wpContext ).core.image.imageUploadedSrc;
+
+				const contentImageCurrentSrc = await contentImage.evaluate(
+					( img ) => img.currentSrc
+				);
+
+				const lightbox = page.locator( '.wp-lightbox-overlay' );
+				await expect( lightbox ).toBeHidden();
+				const responsiveImage = lightbox.locator(
+					'.responsive-image img'
+				);
+				const enlargedImage = lightbox.locator( '.enlarged-image img' );
+
+				await expect( responsiveImage ).toHaveAttribute(
+					'src',
+					contentImageCurrentSrc
+				);
+				await expect( enlargedImage ).toHaveAttribute( 'src', '' );
+
+				await page
+					.getByRole( 'button', { name: 'Enlarge image' } )
+					.click();
+
+				await expect( responsiveImage ).toHaveAttribute(
+					'src',
+					contentImageCurrentSrc
+				);
+				await expect( enlargedImage ).toHaveAttribute(
+					'src',
+					imageUploadedSrc
+				);
+
+				await expect( lightbox ).toBeVisible();
+
+				const document = page.getByRole( 'document' );
+				const lightboxStyleCheck = await document.evaluate( ( doc ) => {
+					// We don't have access to the getPropertyValue() method
+					// on the CSSStyleDeclaration returned form getComputedStyle()
+					// in the Playwright outer context, so we need to evaluate it here
+					// in the browser context here.
+					const documentStyles = window.getComputedStyle( doc );
+					const lightboxStyleVars = [
+						'--lightbox-scale-width',
+						'--lightbox-scale-height',
+						'--lightbox-image-max-width',
+						'--lightbox-image-max-height',
+						'--lightbox-initial-left-position',
+						'--lightbox-initial-top-position',
+					];
+					const lightboxStyleErrors = [];
+					lightboxStyleVars.forEach( ( styleVar ) => {
+						if ( ! documentStyles.getPropertyValue( styleVar ) ) {
+							lightboxStyleErrors.push( styleVar );
+						}
+					} );
+
+					return lightboxStyleErrors.length > 0
+						? lightboxStyleErrors
+						: true;
+				} );
+				expect( lightboxStyleCheck ).toBe( true );
+
+				const closeButton = lightbox.getByRole( 'button', {
+					name: 'Close',
+				} );
+				await closeButton.click();
+
+				await expect( responsiveImage ).toHaveAttribute( 'src', '' );
+				await expect( enlargedImage ).toHaveAttribute(
+					'src',
+					imageUploadedSrc
+				);
+
+				await expect( lightbox ).toBeHidden();
+			} );
+
+			test( 'fade animation', async ( { editor, page } ) => {
+				await page
+					.getByRole( 'combobox', { name: 'Animation' } )
+					.selectOption( 'fade' );
+
+				const postId = await editor.publishPost();
+				await page.goto( `/?p=${ postId }` );
+
+				// getByRole() doesn't work for the image here for
+				// some reason, so let's use locators instead
+				const contentFigure = page.locator( '.entry-content figure' );
+				const contentImage = page.locator(
+					'.entry-content figure img'
+				);
+
+				const wpContext = await contentFigure.getAttribute(
+					'data-wp-context'
+				);
+
+				const imageUploadedSrc =
+					JSON.parse( wpContext ).core.image.imageUploadedSrc;
+
+				const contentImageCurrentSrc = await contentImage.evaluate(
+					( img ) => img.currentSrc
+				);
+
+				const lightbox = page.locator( '.wp-lightbox-overlay' );
+				await expect( lightbox ).toBeHidden();
+				const responsiveImage = lightbox.locator(
+					'.responsive-image img'
+				);
+				const enlargedImage = lightbox.locator( '.enlarged-image img' );
+
+				await expect( responsiveImage ).toHaveAttribute(
+					'src',
+					contentImageCurrentSrc
+				);
+				await expect( enlargedImage ).toHaveAttribute( 'src', '' );
+
+				await page
+					.getByRole( 'button', { name: 'Enlarge image' } )
+					.click();
+
+				await expect( responsiveImage ).toHaveAttribute(
+					'src',
+					contentImageCurrentSrc
+				);
+				await expect( enlargedImage ).toHaveAttribute(
+					'src',
+					imageUploadedSrc
+				);
+
+				await expect( lightbox ).toBeVisible();
+
+				const closeButton = lightbox.getByRole( 'button', {
+					name: 'Close',
+				} );
+				await closeButton.click();
+
+				await expect( responsiveImage ).toHaveAttribute( 'src', '' );
+				await expect( enlargedImage ).toHaveAttribute(
+					'src',
+					imageUploadedSrc
+				);
+
+				await expect( lightbox ).toBeHidden();
+			} );
+		} );
+
+		test( 'lightbox should be overriden when link is configured for image', async ( {
+			editor,
+			page,
+		} ) => {
+			await page.getByRole( 'button', { name: 'Advanced' } ).click();
+			const behaviorSelect = page.getByRole( 'combobox', {
+				name: 'Behaviors',
+			} );
+			await behaviorSelect.selectOption( 'lightbox' );
+
+			await page
+				.getByLabel( 'Block tools' )
+				.getByLabel( 'Insert link' )
+				.click();
+
+			const form = page.locator(
+				'.block-editor-url-popover__link-editor'
+			);
+
+			const url = 'https://wordpress.org';
+
+			await form.getByLabel( 'URL' ).fill( url );
+
+			await form.getByRole( 'button', { name: 'Apply' } ).click();
+			await expect( behaviorSelect ).toBeDisabled();
+
+			const postId = await editor.publishPost();
+			await page.goto( `/?p=${ postId }` );
+
+			// The lightbox markup should not appear in the DOM at all
+			await expect(
+				page.getByRole( 'button', { name: 'Enlarge image' } )
+			).not.toBeInViewport();
+		} );
+
+		test( 'markup should not appear if Lightbox is disabled', async ( {
+			editor,
+			page,
+		} ) => {
+			await page.getByRole( 'button', { name: 'Advanced' } ).click();
+			const behaviorSelect = page.getByRole( 'combobox', {
+				name: 'Behaviors',
+			} );
+			await behaviorSelect.selectOption( '' );
+
+			const postId = await editor.publishPost();
+			await page.goto( `/?p=${ postId }` );
+
+			// The lightbox markup should not appear in the DOM at all
+			await expect(
+				page.getByRole( 'button', { name: 'Enlarge image' } )
+			).not.toBeInViewport();
+		} );
+
+		test.describe( 'Animation Select visibility', () => {
+			test( 'Animation selector should appear if Behavior is Lightbox', async ( {
+				page,
+			} ) => {
+				await page.getByRole( 'button', { name: 'Advanced' } ).click();
+				const behaviorSelect = page.getByRole( 'combobox', {
+					name: 'Behaviors',
+				} );
+				await behaviorSelect.selectOption( 'lightbox' );
+				await expect(
+					page.getByRole( 'combobox', {
+						name: 'Animation',
+					} )
+				).toBeVisible();
+			} );
+			test( 'Animation selector should NOT appear if Behavior is None', async ( {
+				page,
+			} ) => {
+				await page.getByRole( 'button', { name: 'Advanced' } ).click();
+				const behaviorSelect = page.getByRole( 'combobox', {
+					name: 'Behaviors',
+				} );
+				await behaviorSelect.selectOption( '' );
+				await expect(
+					page.getByRole( 'combobox', {
+						name: 'Animation',
+					} )
+				).not.toBeVisible();
+			} );
+			test( 'Animation selector should NOT appear if Behavior is Default', async ( {
+				page,
+			} ) => {
+				await page.getByRole( 'button', { name: 'Advanced' } ).click();
+				const behaviorSelect = page.getByRole( 'combobox', {
+					name: 'Behaviors',
+				} );
+				await behaviorSelect.selectOption( 'default' );
+				await expect(
+					page.getByRole( 'combobox', {
+						name: 'Animation',
+					} )
+				).not.toBeVisible();
+			} );
+		} );
+
+		test.describe( 'keyboard navigation', () => {
+			let openLightboxButton;
+			let lightbox;
+			let closeButton;
+
+			test.beforeEach( async ( { page, editor } ) => {
+				await page.getByRole( 'button', { name: 'Advanced' } ).click();
+				await page
+					.getByRole( 'combobox', { name: 'Behaviors' } )
+					.selectOption( 'lightbox' );
+
+				const postId = await editor.publishPost();
+				await page.goto( `/?p=${ postId }` );
+
+				openLightboxButton = page.getByRole( 'button', {
+					name: 'Enlarge image',
+				} );
+				lightbox = page.getByRole( 'dialog' );
+				closeButton = lightbox.getByRole( 'button', {
+					name: 'Close',
+				} );
+			} );
+
+			test( 'should open and focus appropriately using enter key', async ( {
+				page,
+			} ) => {
+				// Open and close lightbox using the close button
+				await openLightboxButton.focus();
+				await page.keyboard.press( 'Enter' );
+				await expect( lightbox ).toBeVisible();
+				await expect( closeButton ).toBeFocused();
+			} );
+
+			test( 'should close and focus appropriately using enter key on close button', async ( {
+				page,
+			} ) => {
+				// Open and close lightbox using the close button
+				await openLightboxButton.focus();
+				await page.keyboard.press( 'Enter' );
+				await expect( lightbox ).toBeVisible();
+				await expect( closeButton ).toBeFocused();
+				await page.keyboard.press( 'Enter' );
+				await expect( lightbox ).toBeHidden();
+				await expect( openLightboxButton ).toBeFocused();
+			} );
+
+			test( 'should close and focus appropriately using escape key', async ( {
+				page,
+			} ) => {
+				await openLightboxButton.focus();
+				await page.keyboard.press( 'Enter' );
+				await expect( lightbox ).toBeVisible();
+				await expect( closeButton ).toBeFocused();
+				await page.keyboard.press( 'Escape' );
+				await expect( lightbox ).toBeHidden();
+				await expect( openLightboxButton ).toBeFocused();
+			} );
+
+			// TO DO: Add these tests, which will involve adding a caption
+			// to uploaded test images
+			// test( 'should trap focus appropriately when using tab', async ( {
+			// 	page,
+			// } ) => {
+
+			// } );
+
+			// test( 'should trap focus appropriately using shift+tab', async ( {
+			// 	page,
+			// } ) => {
+
+			// } );
+		} );
+	} );
+
+	test( 'lightbox should work as expected when inserting image from URL', async ( {
+		editor,
+		page,
+	} ) => {
+		await editor.openDocumentSettingsSidebar();
+
+		const imageBlockFromUrl = editor.canvas.locator(
+			'role=document[name="Block: Image"i]'
+		);
+		await expect( imageBlockFromUrl ).toBeVisible();
+
+		await imageBlockFromUrl
+			.getByRole( 'button' )
+			.filter( { hasText: 'Insert from URL' } )
+			.click();
+
+		const form = page.locator(
+			'.block-editor-media-placeholder__url-input-form'
+		);
+
+		const imgUrl =
+			'https://wp20.wordpress.net/wp-content/themes/twentyseventeen-wp20/images/wp20-logo-white.svg';
+
+		await form.getByLabel( 'URL' ).fill( imgUrl );
+
+		await form.getByRole( 'button', { name: 'Apply' } ).click();
+
+		const image = imageBlockFromUrl.locator( 'role=img' );
+		await expect( image ).toBeVisible();
+		await expect( image ).toHaveAttribute( 'src', imgUrl );
+
+		await page.getByRole( 'button', { name: 'Advanced' } ).click();
+		await page
+			.getByRole( 'combobox', { name: 'Behaviors' } )
+			.selectOption( 'lightbox' );
+
+		const postId = await editor.publishPost();
+		await page.goto( `/?p=${ postId }` );
+
+		const lightbox = page.locator( '.wp-lightbox-overlay' );
+		const responsiveImage = lightbox.locator( '.responsive-image img' );
+		const enlargedImage = lightbox.locator( '.enlarged-image img' );
+
+		await expect( responsiveImage ).toHaveAttribute(
+			'src',
+			new RegExp( imgUrl )
+		);
+		await expect( enlargedImage ).toHaveAttribute( 'src', '' );
+
+		await page.getByRole( 'button', { name: 'Enlarge image' } ).click();
+
+		await expect( responsiveImage ).toHaveAttribute( 'src', imgUrl );
+		await expect( enlargedImage ).toHaveAttribute( 'src', imgUrl );
+
+		await page.getByRole( 'button', { name: 'Close' } ).click();
+
+		await expect( responsiveImage ).toHaveAttribute( 'src', '' );
+		await expect( enlargedImage ).toHaveAttribute( 'src', imgUrl );
+	} );
+} );
 
 class ImageBlockUtils {
 	constructor( { page } ) {

--- a/test/e2e/specs/editor/blocks/image.spec.js
+++ b/test/e2e/specs/editor/blocks/image.spec.js
@@ -728,488 +728,488 @@ test.describe( 'Image', () => {
 	} );
 } );
 
-test.describe( 'Image - interactivity', () => {
-	test.beforeAll( async ( { requestUtils } ) => {
-		await requestUtils.deleteAllMedia();
-	} );
-
-	test.afterAll( async ( { requestUtils } ) => {
-		await requestUtils.deleteAllMedia();
-	} );
-
-	test.beforeEach( async ( { admin, editor } ) => {
-		await admin.createNewPost();
-		await editor.insertBlock( { name: 'core/image' } );
-	} );
-
-	test.afterEach( async ( { requestUtils } ) => {
-		await requestUtils.deleteAllMedia();
-	} );
-
-	test.describe( 'tests using uploaded image', () => {
-		let filename = null;
-
-		test.beforeEach( async ( { editor, imageBlockUtils } ) => {
-			const imageBlock = editor.canvas.locator(
-				'role=document[name="Block: Image"i]'
-			);
-			await expect( imageBlock ).toBeVisible();
-
-			filename = await imageBlockUtils.upload(
-				imageBlock.locator( 'data-testid=form-file-upload-input' ),
-				'3200x2400_e2e_test_image_responsive_lightbox.jpeg'
-			);
-			const image = imageBlock.locator( 'role=img' );
-			await expect( image ).toBeVisible();
-			await expect( image ).toHaveAttribute(
-				'src',
-				new RegExp( filename )
-			);
-
-			await editor.openDocumentSettingsSidebar();
-		} );
-
-		test( 'should toggle "lightbox" in saved attributes', async ( {
-			editor,
-			page,
-		} ) => {
-			await page.getByRole( 'button', { name: 'Advanced' } ).click();
-			await page
-				.getByRole( 'combobox', { name: 'Behaviors' } )
-				.selectOption( 'lightbox' );
-
-			let blocks = await editor.getBlocks();
-			expect( blocks[ 0 ].attributes ).toMatchObject( {
-				behaviors: {
-					lightbox: {
-						animation: 'zoom',
-						enabled: true,
-					},
-				},
-				linkDestination: 'none',
-			} );
-			expect( blocks[ 0 ].attributes.url ).toContain( filename );
-
-			await page.getByLabel( 'Behaviors' ).selectOption( '' );
-			blocks = await editor.getBlocks();
-			expect( blocks[ 0 ].attributes ).toMatchObject( {
-				behaviors: {
-					lightbox: {
-						animation: '',
-						enabled: false,
-					},
-				},
-				linkDestination: 'none',
-			} );
-			expect( blocks[ 0 ].attributes.url ).toContain( filename );
-		} );
-
-		test.describe( 'should open and close the image in a lightbox when using a mouse and dynamically load src', () => {
-			test.beforeEach( async ( { page } ) => {
-				await page.getByRole( 'button', { name: 'Advanced' } ).click();
-				await page
-					.getByRole( 'combobox', { name: 'Behaviors' } )
-					.selectOption( 'lightbox' );
-			} );
-
-			test( 'zoom animation', async ( { editor, page } ) => {
-				await page
-					.getByRole( 'combobox', { name: 'Animation' } )
-					.selectOption( 'zoom' );
-
-				const postId = await editor.publishPost();
-				await page.goto( `/?p=${ postId }` );
-
-				// getByRole() doesn't work for the image here for
-				// some reason, so let's use locators instead
-				const contentFigure = page.locator( '.entry-content figure' );
-				const contentImage = page.locator(
-					'.entry-content figure img'
-				);
-
-				const wpContext = await contentFigure.getAttribute(
-					'data-wp-context'
-				);
-
-				const imageUploadedSrc =
-					JSON.parse( wpContext ).core.image.imageUploadedSrc;
-
-				const contentImageCurrentSrc = await contentImage.evaluate(
-					( img ) => img.currentSrc
-				);
-
-				const lightbox = page.locator( '.wp-lightbox-overlay' );
-				await expect( lightbox ).toBeHidden();
-				const responsiveImage = lightbox.locator(
-					'.responsive-image img'
-				);
-				const enlargedImage = lightbox.locator( '.enlarged-image img' );
-
-				await expect( responsiveImage ).toHaveAttribute(
-					'src',
-					contentImageCurrentSrc
-				);
-				await expect( enlargedImage ).toHaveAttribute( 'src', '' );
-
-				await page
-					.getByRole( 'button', { name: 'Enlarge image' } )
-					.click();
-
-				await expect( responsiveImage ).toHaveAttribute(
-					'src',
-					contentImageCurrentSrc
-				);
-				await expect( enlargedImage ).toHaveAttribute(
-					'src',
-					imageUploadedSrc
-				);
-
-				await expect( lightbox ).toBeVisible();
-
-				const document = page.getByRole( 'document' );
-				const lightboxStyleCheck = await document.evaluate( ( doc ) => {
-					// We don't have access to the getPropertyValue() method
-					// on the CSSStyleDeclaration returned form getComputedStyle()
-					// in the Playwright outer context, so we need to evaluate it here
-					// in the browser context here.
-					const documentStyles = window.getComputedStyle( doc );
-					const lightboxStyleVars = [
-						'--lightbox-scale-width',
-						'--lightbox-scale-height',
-						'--lightbox-image-max-width',
-						'--lightbox-image-max-height',
-						'--lightbox-initial-left-position',
-						'--lightbox-initial-top-position',
-					];
-					const lightboxStyleErrors = [];
-					lightboxStyleVars.forEach( ( styleVar ) => {
-						if ( ! documentStyles.getPropertyValue( styleVar ) ) {
-							lightboxStyleErrors.push( styleVar );
-						}
-					} );
-
-					return lightboxStyleErrors.length > 0
-						? lightboxStyleErrors
-						: true;
-				} );
-				expect( lightboxStyleCheck ).toBe( true );
-
-				const closeButton = lightbox.getByRole( 'button', {
-					name: 'Close',
-				} );
-				await closeButton.click();
-
-				await expect( responsiveImage ).toHaveAttribute( 'src', '' );
-				await expect( enlargedImage ).toHaveAttribute(
-					'src',
-					imageUploadedSrc
-				);
-
-				await expect( lightbox ).toBeHidden();
-			} );
-
-			test( 'fade animation', async ( { editor, page } ) => {
-				await page
-					.getByRole( 'combobox', { name: 'Animation' } )
-					.selectOption( 'fade' );
-
-				const postId = await editor.publishPost();
-				await page.goto( `/?p=${ postId }` );
-
-				// getByRole() doesn't work for the image here for
-				// some reason, so let's use locators instead
-				const contentFigure = page.locator( '.entry-content figure' );
-				const contentImage = page.locator(
-					'.entry-content figure img'
-				);
-
-				const wpContext = await contentFigure.getAttribute(
-					'data-wp-context'
-				);
-
-				const imageUploadedSrc =
-					JSON.parse( wpContext ).core.image.imageUploadedSrc;
-
-				const contentImageCurrentSrc = await contentImage.evaluate(
-					( img ) => img.currentSrc
-				);
-
-				const lightbox = page.locator( '.wp-lightbox-overlay' );
-				await expect( lightbox ).toBeHidden();
-				const responsiveImage = lightbox.locator(
-					'.responsive-image img'
-				);
-				const enlargedImage = lightbox.locator( '.enlarged-image img' );
-
-				await expect( responsiveImage ).toHaveAttribute(
-					'src',
-					contentImageCurrentSrc
-				);
-				await expect( enlargedImage ).toHaveAttribute( 'src', '' );
-
-				await page
-					.getByRole( 'button', { name: 'Enlarge image' } )
-					.click();
-
-				await expect( responsiveImage ).toHaveAttribute(
-					'src',
-					contentImageCurrentSrc
-				);
-				await expect( enlargedImage ).toHaveAttribute(
-					'src',
-					imageUploadedSrc
-				);
-
-				await expect( lightbox ).toBeVisible();
-
-				const closeButton = lightbox.getByRole( 'button', {
-					name: 'Close',
-				} );
-				await closeButton.click();
-
-				await expect( responsiveImage ).toHaveAttribute( 'src', '' );
-				await expect( enlargedImage ).toHaveAttribute(
-					'src',
-					imageUploadedSrc
-				);
-
-				await expect( lightbox ).toBeHidden();
-			} );
-		} );
-
-		test( 'lightbox should be overriden when link is configured for image', async ( {
-			editor,
-			page,
-		} ) => {
-			await page.getByRole( 'button', { name: 'Advanced' } ).click();
-			const behaviorSelect = page.getByRole( 'combobox', {
-				name: 'Behaviors',
-			} );
-			await behaviorSelect.selectOption( 'lightbox' );
-
-			await page
-				.getByLabel( 'Block tools' )
-				.getByLabel( 'Insert link' )
-				.click();
-
-			const form = page.locator(
-				'.block-editor-url-popover__link-editor'
-			);
-
-			const url = 'https://wordpress.org';
-
-			await form.getByLabel( 'URL' ).fill( url );
-
-			await form.getByRole( 'button', { name: 'Apply' } ).click();
-			await expect( behaviorSelect ).toBeDisabled();
-
-			const postId = await editor.publishPost();
-			await page.goto( `/?p=${ postId }` );
-
-			// The lightbox markup should not appear in the DOM at all
-			await expect(
-				page.getByRole( 'button', { name: 'Enlarge image' } )
-			).not.toBeInViewport();
-		} );
-
-		test( 'markup should not appear if Lightbox is disabled', async ( {
-			editor,
-			page,
-		} ) => {
-			await page.getByRole( 'button', { name: 'Advanced' } ).click();
-			const behaviorSelect = page.getByRole( 'combobox', {
-				name: 'Behaviors',
-			} );
-			await behaviorSelect.selectOption( '' );
-
-			const postId = await editor.publishPost();
-			await page.goto( `/?p=${ postId }` );
-
-			// The lightbox markup should not appear in the DOM at all
-			await expect(
-				page.getByRole( 'button', { name: 'Enlarge image' } )
-			).not.toBeInViewport();
-		} );
-
-		test.describe( 'Animation Select visibility', () => {
-			test( 'Animation selector should appear if Behavior is Lightbox', async ( {
-				page,
-			} ) => {
-				await page.getByRole( 'button', { name: 'Advanced' } ).click();
-				const behaviorSelect = page.getByRole( 'combobox', {
-					name: 'Behaviors',
-				} );
-				await behaviorSelect.selectOption( 'lightbox' );
-				await expect(
-					page.getByRole( 'combobox', {
-						name: 'Animation',
-					} )
-				).toBeVisible();
-			} );
-			test( 'Animation selector should NOT appear if Behavior is None', async ( {
-				page,
-			} ) => {
-				await page.getByRole( 'button', { name: 'Advanced' } ).click();
-				const behaviorSelect = page.getByRole( 'combobox', {
-					name: 'Behaviors',
-				} );
-				await behaviorSelect.selectOption( '' );
-				await expect(
-					page.getByRole( 'combobox', {
-						name: 'Animation',
-					} )
-				).not.toBeVisible();
-			} );
-			test( 'Animation selector should NOT appear if Behavior is Default', async ( {
-				page,
-			} ) => {
-				await page.getByRole( 'button', { name: 'Advanced' } ).click();
-				const behaviorSelect = page.getByRole( 'combobox', {
-					name: 'Behaviors',
-				} );
-				await behaviorSelect.selectOption( 'default' );
-				await expect(
-					page.getByRole( 'combobox', {
-						name: 'Animation',
-					} )
-				).not.toBeVisible();
-			} );
-		} );
-
-		test.describe( 'keyboard navigation', () => {
-			let openLightboxButton;
-			let lightbox;
-			let closeButton;
-
-			test.beforeEach( async ( { page, editor } ) => {
-				await page.getByRole( 'button', { name: 'Advanced' } ).click();
-				await page
-					.getByRole( 'combobox', { name: 'Behaviors' } )
-					.selectOption( 'lightbox' );
-
-				const postId = await editor.publishPost();
-				await page.goto( `/?p=${ postId }` );
-
-				openLightboxButton = page.getByRole( 'button', {
-					name: 'Enlarge image',
-				} );
-				lightbox = page.getByRole( 'dialog' );
-				closeButton = lightbox.getByRole( 'button', {
-					name: 'Close',
-				} );
-			} );
-
-			test( 'should open and focus appropriately using enter key', async ( {
-				page,
-			} ) => {
-				// Open and close lightbox using the close button
-				await openLightboxButton.focus();
-				await page.keyboard.press( 'Enter' );
-				await expect( lightbox ).toBeVisible();
-				await expect( closeButton ).toBeFocused();
-			} );
-
-			test( 'should close and focus appropriately using enter key on close button', async ( {
-				page,
-			} ) => {
-				// Open and close lightbox using the close button
-				await openLightboxButton.focus();
-				await page.keyboard.press( 'Enter' );
-				await expect( lightbox ).toBeVisible();
-				await expect( closeButton ).toBeFocused();
-				await page.keyboard.press( 'Enter' );
-				await expect( lightbox ).toBeHidden();
-				await expect( openLightboxButton ).toBeFocused();
-			} );
-
-			test( 'should close and focus appropriately using escape key', async ( {
-				page,
-			} ) => {
-				await openLightboxButton.focus();
-				await page.keyboard.press( 'Enter' );
-				await expect( lightbox ).toBeVisible();
-				await expect( closeButton ).toBeFocused();
-				await page.keyboard.press( 'Escape' );
-				await expect( lightbox ).toBeHidden();
-				await expect( openLightboxButton ).toBeFocused();
-			} );
-
-			// TO DO: Add these tests, which will involve adding a caption
-			// to uploaded test images
-			// test( 'should trap focus appropriately when using tab', async ( {
-			// 	page,
-			// } ) => {
-
-			// } );
-
-			// test( 'should trap focus appropriately using shift+tab', async ( {
-			// 	page,
-			// } ) => {
-
-			// } );
-		} );
-	} );
-
-	test( 'lightbox should work as expected when inserting image from URL', async ( {
-		editor,
-		page,
-	} ) => {
-		await editor.openDocumentSettingsSidebar();
-
-		const imageBlockFromUrl = editor.canvas.locator(
-			'role=document[name="Block: Image"i]'
-		);
-		await expect( imageBlockFromUrl ).toBeVisible();
-
-		await imageBlockFromUrl
-			.getByRole( 'button' )
-			.filter( { hasText: 'Insert from URL' } )
-			.click();
-
-		const form = page.locator(
-			'.block-editor-media-placeholder__url-input-form'
-		);
-
-		const imgUrl =
-			'https://wp20.wordpress.net/wp-content/themes/twentyseventeen-wp20/images/wp20-logo-white.svg';
-
-		await form.getByLabel( 'URL' ).fill( imgUrl );
-
-		await form.getByRole( 'button', { name: 'Apply' } ).click();
-
-		const image = imageBlockFromUrl.locator( 'role=img' );
-		await expect( image ).toBeVisible();
-		await expect( image ).toHaveAttribute( 'src', imgUrl );
-
-		await page.getByRole( 'button', { name: 'Advanced' } ).click();
-		await page
-			.getByRole( 'combobox', { name: 'Behaviors' } )
-			.selectOption( 'lightbox' );
-
-		const postId = await editor.publishPost();
-		await page.goto( `/?p=${ postId }` );
-
-		const lightbox = page.locator( '.wp-lightbox-overlay' );
-		const responsiveImage = lightbox.locator( '.responsive-image img' );
-		const enlargedImage = lightbox.locator( '.enlarged-image img' );
-
-		await expect( responsiveImage ).toHaveAttribute(
-			'src',
-			new RegExp( imgUrl )
-		);
-		await expect( enlargedImage ).toHaveAttribute( 'src', '' );
-
-		await page.getByRole( 'button', { name: 'Enlarge image' } ).click();
-
-		await expect( responsiveImage ).toHaveAttribute( 'src', imgUrl );
-		await expect( enlargedImage ).toHaveAttribute( 'src', imgUrl );
-
-		await page.getByRole( 'button', { name: 'Close' } ).click();
-
-		await expect( responsiveImage ).toHaveAttribute( 'src', '' );
-		await expect( enlargedImage ).toHaveAttribute( 'src', imgUrl );
-	} );
-} );
+// test.describe( 'Image - interactivity', () => {
+// 	test.beforeAll( async ( { requestUtils } ) => {
+// 		await requestUtils.deleteAllMedia();
+// 	} );
+
+// 	test.afterAll( async ( { requestUtils } ) => {
+// 		await requestUtils.deleteAllMedia();
+// 	} );
+
+// 	test.beforeEach( async ( { admin, editor } ) => {
+// 		await admin.createNewPost();
+// 		await editor.insertBlock( { name: 'core/image' } );
+// 	} );
+
+// 	test.afterEach( async ( { requestUtils } ) => {
+// 		await requestUtils.deleteAllMedia();
+// 	} );
+
+// 	test.describe( 'tests using uploaded image', () => {
+// 		let filename = null;
+
+// 		test.beforeEach( async ( { editor, imageBlockUtils } ) => {
+// 			const imageBlock = editor.canvas.locator(
+// 				'role=document[name="Block: Image"i]'
+// 			);
+// 			await expect( imageBlock ).toBeVisible();
+
+// 			filename = await imageBlockUtils.upload(
+// 				imageBlock.locator( 'data-testid=form-file-upload-input' ),
+// 				'3200x2400_e2e_test_image_responsive_lightbox.jpeg'
+// 			);
+// 			const image = imageBlock.locator( 'role=img' );
+// 			await expect( image ).toBeVisible();
+// 			await expect( image ).toHaveAttribute(
+// 				'src',
+// 				new RegExp( filename )
+// 			);
+
+// 			await editor.openDocumentSettingsSidebar();
+// 		} );
+
+// 		test( 'should toggle "lightbox" in saved attributes', async ( {
+// 			editor,
+// 			page,
+// 		} ) => {
+// 			await page.getByRole( 'button', { name: 'Advanced' } ).click();
+// 			await page
+// 				.getByRole( 'combobox', { name: 'Behaviors' } )
+// 				.selectOption( 'lightbox' );
+
+// 			let blocks = await editor.getBlocks();
+// 			expect( blocks[ 0 ].attributes ).toMatchObject( {
+// 				behaviors: {
+// 					lightbox: {
+// 						animation: 'zoom',
+// 						enabled: true,
+// 					},
+// 				},
+// 				linkDestination: 'none',
+// 			} );
+// 			expect( blocks[ 0 ].attributes.url ).toContain( filename );
+
+// 			await page.getByLabel( 'Behaviors' ).selectOption( '' );
+// 			blocks = await editor.getBlocks();
+// 			expect( blocks[ 0 ].attributes ).toMatchObject( {
+// 				behaviors: {
+// 					lightbox: {
+// 						animation: '',
+// 						enabled: false,
+// 					},
+// 				},
+// 				linkDestination: 'none',
+// 			} );
+// 			expect( blocks[ 0 ].attributes.url ).toContain( filename );
+// 		} );
+
+// 		test.describe( 'should open and close the image in a lightbox when using a mouse and dynamically load src', () => {
+// 			test.beforeEach( async ( { page } ) => {
+// 				await page.getByRole( 'button', { name: 'Advanced' } ).click();
+// 				await page
+// 					.getByRole( 'combobox', { name: 'Behaviors' } )
+// 					.selectOption( 'lightbox' );
+// 			} );
+
+// 			test( 'zoom animation', async ( { editor, page } ) => {
+// 				await page
+// 					.getByRole( 'combobox', { name: 'Animation' } )
+// 					.selectOption( 'zoom' );
+
+// 				const postId = await editor.publishPost();
+// 				await page.goto( `/?p=${ postId }` );
+
+// 				// getByRole() doesn't work for the image here for
+// 				// some reason, so let's use locators instead
+// 				const contentFigure = page.locator( '.entry-content figure' );
+// 				const contentImage = page.locator(
+// 					'.entry-content figure img'
+// 				);
+
+// 				const wpContext = await contentFigure.getAttribute(
+// 					'data-wp-context'
+// 				);
+
+// 				const imageUploadedSrc =
+// 					JSON.parse( wpContext ).core.image.imageUploadedSrc;
+
+// 				const contentImageCurrentSrc = await contentImage.evaluate(
+// 					( img ) => img.currentSrc
+// 				);
+
+// 				const lightbox = page.locator( '.wp-lightbox-overlay' );
+// 				await expect( lightbox ).toBeHidden();
+// 				const responsiveImage = lightbox.locator(
+// 					'.responsive-image img'
+// 				);
+// 				const enlargedImage = lightbox.locator( '.enlarged-image img' );
+
+// 				await expect( responsiveImage ).toHaveAttribute(
+// 					'src',
+// 					contentImageCurrentSrc
+// 				);
+// 				await expect( enlargedImage ).toHaveAttribute( 'src', '' );
+
+// 				await page
+// 					.getByRole( 'button', { name: 'Enlarge image' } )
+// 					.click();
+
+// 				await expect( responsiveImage ).toHaveAttribute(
+// 					'src',
+// 					contentImageCurrentSrc
+// 				);
+// 				await expect( enlargedImage ).toHaveAttribute(
+// 					'src',
+// 					imageUploadedSrc
+// 				);
+
+// 				await expect( lightbox ).toBeVisible();
+
+// 				const document = page.getByRole( 'document' );
+// 				const lightboxStyleCheck = await document.evaluate( ( doc ) => {
+// 					// We don't have access to the getPropertyValue() method
+// 					// on the CSSStyleDeclaration returned form getComputedStyle()
+// 					// in the Playwright outer context, so we need to evaluate it here
+// 					// in the browser context here.
+// 					const documentStyles = window.getComputedStyle( doc );
+// 					const lightboxStyleVars = [
+// 						'--lightbox-scale-width',
+// 						'--lightbox-scale-height',
+// 						'--lightbox-image-max-width',
+// 						'--lightbox-image-max-height',
+// 						'--lightbox-initial-left-position',
+// 						'--lightbox-initial-top-position',
+// 					];
+// 					const lightboxStyleErrors = [];
+// 					lightboxStyleVars.forEach( ( styleVar ) => {
+// 						if ( ! documentStyles.getPropertyValue( styleVar ) ) {
+// 							lightboxStyleErrors.push( styleVar );
+// 						}
+// 					} );
+
+// 					return lightboxStyleErrors.length > 0
+// 						? lightboxStyleErrors
+// 						: true;
+// 				} );
+// 				expect( lightboxStyleCheck ).toBe( true );
+
+// 				const closeButton = lightbox.getByRole( 'button', {
+// 					name: 'Close',
+// 				} );
+// 				await closeButton.click();
+
+// 				await expect( responsiveImage ).toHaveAttribute( 'src', '' );
+// 				await expect( enlargedImage ).toHaveAttribute(
+// 					'src',
+// 					imageUploadedSrc
+// 				);
+
+// 				await expect( lightbox ).toBeHidden();
+// 			} );
+
+// 			test( 'fade animation', async ( { editor, page } ) => {
+// 				await page
+// 					.getByRole( 'combobox', { name: 'Animation' } )
+// 					.selectOption( 'fade' );
+
+// 				const postId = await editor.publishPost();
+// 				await page.goto( `/?p=${ postId }` );
+
+// 				// getByRole() doesn't work for the image here for
+// 				// some reason, so let's use locators instead
+// 				const contentFigure = page.locator( '.entry-content figure' );
+// 				const contentImage = page.locator(
+// 					'.entry-content figure img'
+// 				);
+
+// 				const wpContext = await contentFigure.getAttribute(
+// 					'data-wp-context'
+// 				);
+
+// 				const imageUploadedSrc =
+// 					JSON.parse( wpContext ).core.image.imageUploadedSrc;
+
+// 				const contentImageCurrentSrc = await contentImage.evaluate(
+// 					( img ) => img.currentSrc
+// 				);
+
+// 				const lightbox = page.locator( '.wp-lightbox-overlay' );
+// 				await expect( lightbox ).toBeHidden();
+// 				const responsiveImage = lightbox.locator(
+// 					'.responsive-image img'
+// 				);
+// 				const enlargedImage = lightbox.locator( '.enlarged-image img' );
+
+// 				await expect( responsiveImage ).toHaveAttribute(
+// 					'src',
+// 					contentImageCurrentSrc
+// 				);
+// 				await expect( enlargedImage ).toHaveAttribute( 'src', '' );
+
+// 				await page
+// 					.getByRole( 'button', { name: 'Enlarge image' } )
+// 					.click();
+
+// 				await expect( responsiveImage ).toHaveAttribute(
+// 					'src',
+// 					contentImageCurrentSrc
+// 				);
+// 				await expect( enlargedImage ).toHaveAttribute(
+// 					'src',
+// 					imageUploadedSrc
+// 				);
+
+// 				await expect( lightbox ).toBeVisible();
+
+// 				const closeButton = lightbox.getByRole( 'button', {
+// 					name: 'Close',
+// 				} );
+// 				await closeButton.click();
+
+// 				await expect( responsiveImage ).toHaveAttribute( 'src', '' );
+// 				await expect( enlargedImage ).toHaveAttribute(
+// 					'src',
+// 					imageUploadedSrc
+// 				);
+
+// 				await expect( lightbox ).toBeHidden();
+// 			} );
+// 		} );
+
+// 		test( 'lightbox should be overriden when link is configured for image', async ( {
+// 			editor,
+// 			page,
+// 		} ) => {
+// 			await page.getByRole( 'button', { name: 'Advanced' } ).click();
+// 			const behaviorSelect = page.getByRole( 'combobox', {
+// 				name: 'Behaviors',
+// 			} );
+// 			await behaviorSelect.selectOption( 'lightbox' );
+
+// 			await page
+// 				.getByLabel( 'Block tools' )
+// 				.getByLabel( 'Insert link' )
+// 				.click();
+
+// 			const form = page.locator(
+// 				'.block-editor-url-popover__link-editor'
+// 			);
+
+// 			const url = 'https://wordpress.org';
+
+// 			await form.getByLabel( 'URL' ).fill( url );
+
+// 			await form.getByRole( 'button', { name: 'Apply' } ).click();
+// 			await expect( behaviorSelect ).toBeDisabled();
+
+// 			const postId = await editor.publishPost();
+// 			await page.goto( `/?p=${ postId }` );
+
+// 			// The lightbox markup should not appear in the DOM at all
+// 			await expect(
+// 				page.getByRole( 'button', { name: 'Enlarge image' } )
+// 			).not.toBeInViewport();
+// 		} );
+
+// 		test( 'markup should not appear if Lightbox is disabled', async ( {
+// 			editor,
+// 			page,
+// 		} ) => {
+// 			await page.getByRole( 'button', { name: 'Advanced' } ).click();
+// 			const behaviorSelect = page.getByRole( 'combobox', {
+// 				name: 'Behaviors',
+// 			} );
+// 			await behaviorSelect.selectOption( '' );
+
+// 			const postId = await editor.publishPost();
+// 			await page.goto( `/?p=${ postId }` );
+
+// 			// The lightbox markup should not appear in the DOM at all
+// 			await expect(
+// 				page.getByRole( 'button', { name: 'Enlarge image' } )
+// 			).not.toBeInViewport();
+// 		} );
+
+// 		test.describe( 'Animation Select visibility', () => {
+// 			test( 'Animation selector should appear if Behavior is Lightbox', async ( {
+// 				page,
+// 			} ) => {
+// 				await page.getByRole( 'button', { name: 'Advanced' } ).click();
+// 				const behaviorSelect = page.getByRole( 'combobox', {
+// 					name: 'Behaviors',
+// 				} );
+// 				await behaviorSelect.selectOption( 'lightbox' );
+// 				await expect(
+// 					page.getByRole( 'combobox', {
+// 						name: 'Animation',
+// 					} )
+// 				).toBeVisible();
+// 			} );
+// 			test( 'Animation selector should NOT appear if Behavior is None', async ( {
+// 				page,
+// 			} ) => {
+// 				await page.getByRole( 'button', { name: 'Advanced' } ).click();
+// 				const behaviorSelect = page.getByRole( 'combobox', {
+// 					name: 'Behaviors',
+// 				} );
+// 				await behaviorSelect.selectOption( '' );
+// 				await expect(
+// 					page.getByRole( 'combobox', {
+// 						name: 'Animation',
+// 					} )
+// 				).not.toBeVisible();
+// 			} );
+// 			test( 'Animation selector should NOT appear if Behavior is Default', async ( {
+// 				page,
+// 			} ) => {
+// 				await page.getByRole( 'button', { name: 'Advanced' } ).click();
+// 				const behaviorSelect = page.getByRole( 'combobox', {
+// 					name: 'Behaviors',
+// 				} );
+// 				await behaviorSelect.selectOption( 'default' );
+// 				await expect(
+// 					page.getByRole( 'combobox', {
+// 						name: 'Animation',
+// 					} )
+// 				).not.toBeVisible();
+// 			} );
+// 		} );
+
+// 		test.describe( 'keyboard navigation', () => {
+// 			let openLightboxButton;
+// 			let lightbox;
+// 			let closeButton;
+
+// 			test.beforeEach( async ( { page, editor } ) => {
+// 				await page.getByRole( 'button', { name: 'Advanced' } ).click();
+// 				await page
+// 					.getByRole( 'combobox', { name: 'Behaviors' } )
+// 					.selectOption( 'lightbox' );
+
+// 				const postId = await editor.publishPost();
+// 				await page.goto( `/?p=${ postId }` );
+
+// 				openLightboxButton = page.getByRole( 'button', {
+// 					name: 'Enlarge image',
+// 				} );
+// 				lightbox = page.getByRole( 'dialog' );
+// 				closeButton = lightbox.getByRole( 'button', {
+// 					name: 'Close',
+// 				} );
+// 			} );
+
+// 			test( 'should open and focus appropriately using enter key', async ( {
+// 				page,
+// 			} ) => {
+// 				// Open and close lightbox using the close button
+// 				await openLightboxButton.focus();
+// 				await page.keyboard.press( 'Enter' );
+// 				await expect( lightbox ).toBeVisible();
+// 				await expect( closeButton ).toBeFocused();
+// 			} );
+
+// 			test( 'should close and focus appropriately using enter key on close button', async ( {
+// 				page,
+// 			} ) => {
+// 				// Open and close lightbox using the close button
+// 				await openLightboxButton.focus();
+// 				await page.keyboard.press( 'Enter' );
+// 				await expect( lightbox ).toBeVisible();
+// 				await expect( closeButton ).toBeFocused();
+// 				await page.keyboard.press( 'Enter' );
+// 				await expect( lightbox ).toBeHidden();
+// 				await expect( openLightboxButton ).toBeFocused();
+// 			} );
+
+// 			test( 'should close and focus appropriately using escape key', async ( {
+// 				page,
+// 			} ) => {
+// 				await openLightboxButton.focus();
+// 				await page.keyboard.press( 'Enter' );
+// 				await expect( lightbox ).toBeVisible();
+// 				await expect( closeButton ).toBeFocused();
+// 				await page.keyboard.press( 'Escape' );
+// 				await expect( lightbox ).toBeHidden();
+// 				await expect( openLightboxButton ).toBeFocused();
+// 			} );
+
+// 			// TO DO: Add these tests, which will involve adding a caption
+// 			// to uploaded test images
+// 			// test( 'should trap focus appropriately when using tab', async ( {
+// 			// 	page,
+// 			// } ) => {
+
+// 			// } );
+
+// 			// test( 'should trap focus appropriately using shift+tab', async ( {
+// 			// 	page,
+// 			// } ) => {
+
+// 			// } );
+// 		} );
+// 	} );
+
+// 	test( 'lightbox should work as expected when inserting image from URL', async ( {
+// 		editor,
+// 		page,
+// 	} ) => {
+// 		await editor.openDocumentSettingsSidebar();
+
+// 		const imageBlockFromUrl = editor.canvas.locator(
+// 			'role=document[name="Block: Image"i]'
+// 		);
+// 		await expect( imageBlockFromUrl ).toBeVisible();
+
+// 		await imageBlockFromUrl
+// 			.getByRole( 'button' )
+// 			.filter( { hasText: 'Insert from URL' } )
+// 			.click();
+
+// 		const form = page.locator(
+// 			'.block-editor-media-placeholder__url-input-form'
+// 		);
+
+// 		const imgUrl =
+// 			'https://wp20.wordpress.net/wp-content/themes/twentyseventeen-wp20/images/wp20-logo-white.svg';
+
+// 		await form.getByLabel( 'URL' ).fill( imgUrl );
+
+// 		await form.getByRole( 'button', { name: 'Apply' } ).click();
+
+// 		const image = imageBlockFromUrl.locator( 'role=img' );
+// 		await expect( image ).toBeVisible();
+// 		await expect( image ).toHaveAttribute( 'src', imgUrl );
+
+// 		await page.getByRole( 'button', { name: 'Advanced' } ).click();
+// 		await page
+// 			.getByRole( 'combobox', { name: 'Behaviors' } )
+// 			.selectOption( 'lightbox' );
+
+// 		const postId = await editor.publishPost();
+// 		await page.goto( `/?p=${ postId }` );
+
+// 		const lightbox = page.locator( '.wp-lightbox-overlay' );
+// 		const responsiveImage = lightbox.locator( '.responsive-image img' );
+// 		const enlargedImage = lightbox.locator( '.enlarged-image img' );
+
+// 		await expect( responsiveImage ).toHaveAttribute(
+// 			'src',
+// 			new RegExp( imgUrl )
+// 		);
+// 		await expect( enlargedImage ).toHaveAttribute( 'src', '' );
+
+// 		await page.getByRole( 'button', { name: 'Enlarge image' } ).click();
+
+// 		await expect( responsiveImage ).toHaveAttribute( 'src', imgUrl );
+// 		await expect( enlargedImage ).toHaveAttribute( 'src', imgUrl );
+
+// 		await page.getByRole( 'button', { name: 'Close' } ).click();
+
+// 		await expect( responsiveImage ).toHaveAttribute( 'src', '' );
+// 		await expect( enlargedImage ).toHaveAttribute( 'src', imgUrl );
+// 	} );
+// } );
 
 class ImageBlockUtils {
 	constructor( { page } ) {

--- a/test/e2e/specs/editor/blocks/image.spec.js
+++ b/test/e2e/specs/editor/blocks/image.spec.js
@@ -730,7 +730,7 @@ test.describe( 'Image', () => {
 // These tests are disabled for now while we
 // work on a solution to make them more stable.
 // See https://github.com/WordPress/gutenberg/pull/52442
-test.skip( 'Image - interactivity', () => {
+test.describe.skip( 'Image - interactivity', () => {
 	test.beforeAll( async ( { requestUtils } ) => {
 		await requestUtils.deleteAllMedia();
 	} );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
This PR disables the flaky image tests that have recently become flaky for now while we work on solution (being discussed [here](https://github.com/WordPress/gutenberg/pull/52442)).

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
We want to avoid slowdowns in the deployment process.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
It comments out the image tests related to the Interactivity API.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
N/A

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
Run `npm run test:e2e:playwright` — see that the `Image - interactivity` tests do not run.