### PR TITLE
Ignore local test theme folders created by wp-env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,5 @@ phpunit-watcher.yml
 test/storybook-playwright/test-results
 test/storybook-playwright/specs/__snapshots__
 test/storybook-playwright/specs/*-snapshots/**
+test/gutenberg-test-themes/twentytwentyone
+test/gutenberg-test-themes/twentytwentythree


### PR DESCRIPTION
## What?
Add test themes folders created by wp-env to .gitignore so they're ignored by linter.

## Why?
Because wp-env creates these folders with very restrictive permissions and they have to be removed by a root user to make the commit linter pass.

![image](https://github.com/WordPress/gutenberg/assets/1451471/f68cc409-5002-4dd6-bad3-2691d25492b0)


## Testing Instructions
- Run `npx wp-env start --update` - you should see `twentytwentyone` and `twentytwentythree` be downloaded and installed as per [this config](https://github.com/WordPress/gutenberg/blob/a05b0159c4223e797c578e1fe42fd3a9d09fd578/.wp-env.json#L12-L13).
- Confirm that the above theme folders have been created inside `/test/gutenberg-test-themes/` folder (they should be empty).
- Make any change to any file and try to commit it - you should be able to do this without the aforementioned issue on this branch and not on `trunk`.