### PR TITLE
Footnotes/RichText: fix getRichTextValues for deeply nested blocks

### DIFF
--- a/packages/block-editor/src/components/rich-text/get-rich-text-values.js
+++ b/packages/block-editor/src/components/rich-text/get-rich-text-values.js
@@ -91,6 +91,9 @@ function _getSaveElement( name, attributes, innerBlocks ) {
 				block.attributes,
 				block.innerBlocks
 			);
+			if ( ! saveElement ) {
+				return null;
+			}
 			elementToInnerBlocksMap.set( saveElement, block );
 			return saveElement;
 		} )

--- a/packages/block-editor/src/components/rich-text/get-rich-text-values.js
+++ b/packages/block-editor/src/components/rich-text/get-rich-text-values.js
@@ -85,6 +85,11 @@ function _getSaveElement( name, attributes, innerBlocks ) {
 	return getSaveElement(
 		name,
 		attributes,
+		// We need to pass the inner blocks as save elements so that these
+		// elements can be used by `useInnerBlocksProps.save`
+		// (getInnerBlocksProps in the blocks package). The save element tree
+		// could in turn have inner blocks, which we may need when rendering
+		// `InnerBlocks.Content`.
 		innerBlocks.map( ( block ) => {
 			const saveElement = _getSaveElement(
 				block.name,

--- a/packages/block-editor/src/components/rich-text/get-rich-text-values.js
+++ b/packages/block-editor/src/components/rich-text/get-rich-text-values.js
@@ -13,8 +13,6 @@ import {
 import InnerBlocks from '../inner-blocks';
 import { Content } from './content';
 
-const elementToInnerBlocksMap = new WeakMap();
-
 /*
  * This function is similar to `@wordpress/element`'s `renderToString` function,
  * except that it does not render the elements to a string, but instead collects
@@ -33,10 +31,6 @@ function addValuesForElement( element, values, innerBlocks ) {
 		case 'string':
 		case 'number':
 			return;
-	}
-
-	if ( elementToInnerBlocksMap.has( element ) ) {
-		innerBlocks = elementToInnerBlocksMap.get( element ).innerBlocks;
 	}
 
 	const { type, props } = element;
@@ -81,34 +75,17 @@ function addValuesForElements( children, ...args ) {
 	}
 }
 
-function _getSaveElement( name, attributes, innerBlocks ) {
-	return getSaveElement(
-		name,
-		attributes,
-		// We need to pass the inner blocks as save elements so that these
-		// elements can be used by `useInnerBlocksProps.save`
-		// (getInnerBlocksProps in the blocks package). The save element tree
-		// could in turn have inner blocks, which we may need when rendering
-		// `InnerBlocks.Content`.
-		innerBlocks.map( ( block ) => {
-			const saveElement = _getSaveElement(
-				block.name,
-				block.attributes,
-				block.innerBlocks
-			);
-			if ( ! saveElement ) {
-				return null;
-			}
-			elementToInnerBlocksMap.set( saveElement, block );
-			return saveElement;
-		} )
-	);
-}
-
 function addValuesForBlocks( values, blocks ) {
 	for ( let i = 0; i < blocks.length; i++ ) {
 		const { name, attributes, innerBlocks } = blocks[ i ];
-		const saveElement = _getSaveElement( name, attributes, innerBlocks );
+		const saveElement = getSaveElement(
+			name,
+			attributes,
+			// Instead of letting save elements use `useInnerBlocksProps.save`,
+			// force them to use InnerBlocks.Content instead so we can intercept
+			// a single component.
+			<InnerBlocks.Content />
+		);
 		addValuesForElement( saveElement, values, innerBlocks );
 	}
 }

--- a/packages/block-editor/src/components/rich-text/get-rich-text-values.js
+++ b/packages/block-editor/src/components/rich-text/get-rich-text-values.js
@@ -13,18 +13,20 @@ import {
 import InnerBlocks from '../inner-blocks';
 import { Content } from './content';
 
+const elementToInnerBlocksMap = new WeakMap();
+
 /*
  * This function is similar to `@wordpress/element`'s `renderToString` function,
  * except that it does not render the elements to a string, but instead collects
  * the values of all rich text `Content` elements.
  */
-function addValuesForElement( element, ...args ) {
+function addValuesForElement( element, values, innerBlocks ) {
 	if ( null === element || undefined === element || false === element ) {
 		return;
 	}
 
 	if ( Array.isArray( element ) ) {
-		return addValuesForElements( element, ...args );
+		return addValuesForElements( element, values, innerBlocks );
 	}
 
 	switch ( typeof element ) {
@@ -33,18 +35,21 @@ function addValuesForElement( element, ...args ) {
 			return;
 	}
 
+	if ( elementToInnerBlocksMap.has( element ) ) {
+		innerBlocks = elementToInnerBlocksMap.get( element ).innerBlocks;
+	}
+
 	const { type, props } = element;
 
 	switch ( type ) {
 		case StrictMode:
 		case Fragment:
-			return addValuesForElements( props.children, ...args );
+			return addValuesForElements( props.children, values, innerBlocks );
 		case RawHTML:
 			return;
 		case InnerBlocks.Content:
-			return addValuesForBlocks( ...args );
+			return addValuesForBlocks( values, innerBlocks );
 		case Content:
-			const [ values ] = args;
 			values.push( props.value );
 			return;
 	}
@@ -52,21 +57,19 @@ function addValuesForElement( element, ...args ) {
 	switch ( typeof type ) {
 		case 'string':
 			if ( typeof props.children !== 'undefined' ) {
-				return addValuesForElements( props.children, ...args );
+				return addValuesForElements(
+					props.children,
+					values,
+					innerBlocks
+				);
 			}
 			return;
 		case 'function':
-			if (
-				type.prototype &&
-				typeof type.prototype.render === 'function'
-			) {
-				return addValuesForElement(
-					new type( props ).render(),
-					...args
-				);
-			}
-
-			return addValuesForElement( type( props ), ...args );
+			const el =
+				type.prototype && typeof type.prototype.render === 'function'
+					? new type( props ).render()
+					: type( props );
+			return addValuesForElement( el, values, innerBlocks );
 	}
 }
 
@@ -82,9 +85,15 @@ function _getSaveElement( name, attributes, innerBlocks ) {
 	return getSaveElement(
 		name,
 		attributes,
-		innerBlocks.map( ( block ) =>
-			_getSaveElement( block.name, block.attributes, block.innerBlocks )
-		)
+		innerBlocks.map( ( block ) => {
+			const saveElement = _getSaveElement(
+				block.name,
+				block.attributes,
+				block.innerBlocks
+			);
+			elementToInnerBlocksMap.set( saveElement, block );
+			return saveElement;
+		} )
 	);
 }
 

--- a/packages/blocks/src/api/serializer.js
+++ b/packages/blocks/src/api/serializer.js
@@ -98,6 +98,8 @@ export function getBlockProps( props = {} ) {
  */
 export function getInnerBlocksProps( props = {} ) {
 	const { innerBlocks } = innerBlocksPropsProvider;
+	// Allow a different component to be passed to getSaveElement to handle
+	// inner blocks, bypassing the default serialisation.
 	if ( ! Array.isArray( innerBlocks ) ) {
 		return { ...props, children: innerBlocks };
 	}

--- a/packages/blocks/src/api/serializer.js
+++ b/packages/blocks/src/api/serializer.js
@@ -98,12 +98,9 @@ export function getBlockProps( props = {} ) {
  */
 export function getInnerBlocksProps( props = {} ) {
 	const { innerBlocks } = innerBlocksPropsProvider;
-	const [ firstBlock ] = innerBlocks ?? [];
-	if ( ! firstBlock ) return props;
-	// If the innerBlocks passed to `getSaveElement` are not blocks but already
-	// components, return the props as is. This is the case for
-	// `getRichTextValues`.
-	if ( ! firstBlock.clientId ) return { ...props, children: innerBlocks };
+	if ( ! Array.isArray( innerBlocks ) ) {
+		return { ...props, children: innerBlocks };
+	}
 	// Value is an array of blocks, so defer to block serializer.
 	const html = serialize( innerBlocks, { isInnerBlocks: true } );
 	// Use special-cased raw HTML tag to avoid default escaping.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Fixes #53009. The problem is that when there's a quote nested in a group, when we encounter the group's `InnerBlocks.Content`, we are using the group's inner blocks instead of the quotes.

I changed things to enforce using `InnerBlock.Content` for all blocks, so inner block handling goes through a single code path.

I'd love to add some good tests to this come, either in this PR or a follow-up if we run out of time.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

We should link save elements to a block so we can change the innerBlocks when looping over the save elements.

## Testing Instructions

Add a quote in a group and add a footnote to the citation. There's shouldn't be a double entry in the footnotes block.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
