### PR TITLE
Footnotes: Add typography, dimensions, and border block supports

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -275,7 +275,7 @@ Add a link to a downloadable file. ([Source](https://github.com/WordPress/gutenb
 
 -	**Name:** core/footnotes
 -	**Category:** text
--	**Supports:** color (background, link, text), ~~html~~, ~~multiple~~, ~~reusable~~
+-	**Supports:** color (background, link, text), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~, ~~multiple~~, ~~reusable~~
 -	**Attributes:** 
 
 ## Classic

--- a/packages/block-library/src/footnotes/block.json
+++ b/packages/block-library/src/footnotes/block.json
@@ -9,8 +9,22 @@
 	"textdomain": "default",
 	"usesContext": [ "postId", "postType" ],
 	"supports": {
+		"__experimentalBorder": {
+			"radius": true,
+			"color": true,
+			"width": true,
+			"style": true,
+			"__experimentalDefaultControls": {
+				"radius": false,
+				"color": false,
+				"width": false,
+				"style": false
+			}
+		},
 		"color": {
+			"background": true,
 			"link": true,
+			"text": true,
 			"__experimentalDefaultControls": {
 				"link": true,
 				"text": true
@@ -18,7 +32,29 @@
 		},
 		"html": false,
 		"multiple": false,
-		"reusable": false
+		"reusable": false,
+		"spacing": {
+			"margin": true,
+			"padding": true,
+			"__experimentalDefaultControls": {
+				"margin": false,
+				"padding": false
+			}
+		},
+		"typography": {
+			"fontSize": true,
+			"lineHeight": true,
+			"__experimentalFontFamily": true,
+			"__experimentalTextDecoration": true,
+			"__experimentalFontStyle": true,
+			"__experimentalFontWeight": true,
+			"__experimentalLetterSpacing": true,
+			"__experimentalTextTransform": true,
+			"__experimentalWritingMode": true,
+			"__experimentalDefaultControls": {
+				"fontSize": true
+			}
+		}
 	},
 	"style": "wp-block-footnotes"
 }

--- a/packages/block-library/src/footnotes/block.json
+++ b/packages/block-library/src/footnotes/block.json
@@ -12,7 +12,7 @@
 		"color": {
 			"link": true,
 			"__experimentalDefaultControls": {
-				"background": true,
+				"link": true,
 				"text": true
 			}
 		},


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
This updates the block supports for the Footnotes block to include typography, dimensions, and border controls. It also adjusts the color supports so that link and text are the defaults, rather than background and text.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
This gives the Footnotes block further design flexibility. Follow-on from https://github.com/WordPress/gutenberg/pull/52897, and addresses this comment: https://github.com/WordPress/gutenberg/pull/52897#issuecomment-1650218902.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Updates the Footnotes `block.json` file.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
1. Open the Post Editor
2. Add some text
3. Highlight some text, use the drop down menu in the block toolbar to add a footnote
4. Open block settings for the footnote and ensure that there are typography, dimensions and border controls
5. Please try applying controls from the available options; make sure the settings are applied in the editor and the front end

## Screenshots or screencast <!-- if applicable -->
Default settings for the Footnotes block with this PR:

![image](https://github.com/WordPress/gutenberg/assets/1645628/7b1eac9e-9265-4859-9a84-837db3166e8d)
