### PR TITLE
Site Editor: Disable Settings/Styles buttons when Distruction Free Mode is enabled

### DIFF
--- a/packages/edit-site/src/components/sidebar-edit-mode/default-sidebar.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/default-sidebar.js
@@ -23,10 +23,13 @@ export default function DefaultSidebar( {
 	headerClassName,
 	panelClassName,
 } ) {
-	const showIconLabels = useSelect(
-		( select ) => select( editSiteStore ).getSettings().showIconLabels,
-		[]
-	);
+	const { showIconLabels, isDistractionFree } = useSelect( ( select ) => {
+		const settings = select( editSiteStore ).getSettings();
+		return {
+			showIconLabels: settings.showIconLabels,
+			isDistractionFree: settings.isDistractionFree,
+		};
+	}, [] );
 
 	return (
 		<>
@@ -48,6 +51,7 @@ export default function DefaultSidebar( {
 				scope="core/edit-site"
 				identifier={ identifier }
 				icon={ icon }
+				disabled={ isDistractionFree }
 			>
 				{ title }
 			</ComplementaryAreaMoreMenuItem>


### PR DESCRIPTION
Fixes #52522

## What?
This PR deactivates the Settings and Styles buttons in the Options menu when Distruction Free Mode is enabled in the Site Editor.

## Why?
I think there are three approaches to solving the problem reported in #52522 of not being able to press the close button on the sidebar.

1. Push down the block sidebar by the height of the header bar that appears when hovering above the screen.
2. Disable Distruction Free Mode when the Settings or Styles button is pressed
3. Disable the Settings or Styles button itself

I think Distraction Free Mode should be explicitly toggled by the user. Also, in this mode, I think users should not inherently be expected to manipulate anything in the right sidebar.

For this reason, I chose the third approach.

## How?

Get the status of Distruction Free Mode from the edit-site store and disable these two buttons if it is enabled; it should not affect buttons added by `PluginSidebarMoreMenuItem`.

## Testing Instructions

Open the Site Editor and execute the following code in the browser console. This code will add a custom button to the Plugins category.

```javascript
wp.plugins.registerPlugin( 'test', { render: () => {
	return wp.element.createElement(
		wp.editSite.PluginSidebarMoreMenuItem,
		{
			target: 'my-sidebar',
		},
		'My Sidebar'
	);	
} } );
```

- Open the Options menu.
- Click on Distruction free to activate it.
- Settings and Styles should be disabled.
- The custom button should not be disabled.
- Click on Distruction free again to deactivate it.
- Settings and Styles buttons should be activated.

Note - Other editor instances do not require this processing, for the following reasons:

- Post Editor: Settings and Styles buttons themselves are missing.
- Widget Editor: There is no Distruction Free Mode itself.

## Screenshots or screencast <!-- if applicable -->
