### PR TITLE
Fix spacing for LinkControl actions

### DIFF
--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -84,7 +84,7 @@ $preview-image-height: 140px;
 	flex-direction: row-reverse; // put "Cancel" on the left but retain DOM order.
 	justify-content: flex-start;
 	gap: $grid-unit-10;
-	padding: $grid-unit-10;
+	padding: $grid-unit-10 $grid-unit-20 $grid-unit-20;
 	order: 20;
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
A minor fix to the applied padding, ensuring proper spacing between the popover edge and the buttons within the actions.

## How?
CSS change.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a post or page.
2. Insert a paragraph.
3. Add a link. 
4. Edit the link.
5. See the "Cancel" and "Save" links spaced properly from the bottom and right edges of the popover.

## Screenshots or screencast <!-- if applicable -->

| Before  | After |
| ------------- | ------------- |
|<img width="350" alt="CleanShot 2023-07-27 at 11 45 31" src="https://github.com/WordPress/gutenberg/assets/1813435/04af9312-463c-4418-ae99-931a41855390">|<img width="349" alt="CleanShot 2023-07-27 at 11 45 37" src="https://github.com/WordPress/gutenberg/assets/1813435/375b6d85-f15d-491b-83ff-e66de7e42823">|


