### PR TITLE
Site Editor: Fix the typo in the title label map

### DIFF
--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -58,7 +58,7 @@ const interfaceLabels = {
 };
 
 const typeLabels = {
-	wp_template: __( 'Template Part' ),
+	wp_template: __( 'Template' ),
 	wp_template_part: __( 'Template Part' ),
 	wp_block: __( 'Pattern' ),
 };
@@ -165,12 +165,11 @@ export default function Editor( { isLoading } ) {
 
 	let title;
 	if ( hasLoadedPost ) {
-		const type = typeLabels[ editedPostType ] ?? __( 'Template' );
 		title = sprintf(
 			// translators: A breadcrumb trail in browser tab. %1$s: title of template being edited, %2$s: type of template (Template or Template Part).
 			__( '%1$s ‹ %2$s ‹ Editor' ),
 			getTitle(),
-			type
+			typeLabels[ editedPostType ] ?? typeLabels.wp_template
 		);
 	}
 


### PR DESCRIPTION
## What?
PR fixes the title label for templates in the Site Editor.

## Why?
It was incorrect.

## Testing Instructions
1. Open the Site Editor.
2. Confirm page title is rendered correctly.

## Screenshots or screencast <!-- if applicable -->
| Before | After |
|--------|--------|
| ![CleanShot 2023-07-27 at 22 28 22](https://github.com/WordPress/gutenberg/assets/240569/96be751c-6f7e-4529-99dd-aeee65ab2fd3) | ![CleanShot 2023-07-27 at 22 27 54](https://github.com/WordPress/gutenberg/assets/240569/4806c130-b309-4ec4-b633-3e5d910e492e) |
