### PR TITLE
Footnotes: fix published preview

### DIFF
--- a/packages/block-library/src/footnotes/index.php
+++ b/packages/block-library/src/footnotes/index.php
@@ -272,7 +272,7 @@ function wp_rest_api_force_autosave_difference( $prepared_post, $request ) {
 	}
 
 	// Only alter requests for the 'autosaves' route.
-	if (strpos($request->get_route(), '/autosaves') === false) {
+	if ( strpos( $request->get_route(), '/autosaves' ) === false ) {
 		return $prepared_post;
 	}
 

--- a/packages/block-library/src/footnotes/index.php
+++ b/packages/block-library/src/footnotes/index.php
@@ -222,7 +222,6 @@ function wp_rest_api_autosave_meta( $autosave ) {
 	// `wp_creating_autosave` passes the object,
 	// `_wp_put_post_revision` passes the ID.
 	$id = is_int( $autosave ) ? $autosave : $autosave['ID'];
-	var_dump( $id );
 
 	// Ensure it's a REST API request.
 	if ( ! defined( 'REST_REQUEST' ) || ! REST_REQUEST ) {

--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -551,9 +551,12 @@ export const saveEntityRecord =
 					data = Object.keys( data ).reduce(
 						( acc, key ) => {
 							if (
-								[ 'title', 'excerpt', 'content' ].includes(
-									key
-								)
+								[
+									'title',
+									'excerpt',
+									'content',
+									'meta',
+								].includes( key )
 							) {
 								acc[ key ] = data[ key ];
 							}

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -611,7 +611,7 @@ export const isEditedPostAutosaveable = createRegistrySelector(
 			return true;
 		}
 
-		// If the title or excerpt has changed, the post is autosaveable.
+		// If title, excerpt, or meta have changed, the post is autosaveable.
 		return [ 'title', 'excerpt', 'meta' ].some(
 			( field ) =>
 				getPostRawValue( autosave[ field ] ) !==

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -612,7 +612,7 @@ export const isEditedPostAutosaveable = createRegistrySelector(
 		}
 
 		// If the title or excerpt has changed, the post is autosaveable.
-		return [ 'title', 'excerpt' ].some(
+		return [ 'title', 'excerpt', 'meta' ].some(
 			( field ) =>
 				getPostRawValue( autosave[ field ] ) !==
 				getEditedPostAttribute( state, field )

--- a/test/e2e/specs/editor/various/footnotes.spec.js
+++ b/test/e2e/specs/editor/various/footnotes.spec.js
@@ -360,4 +360,44 @@ test.describe( 'Footnotes', () => {
 			},
 		] );
 	} );
+
+	test( 'can be previewed when published', async ( { editor, page } ) => {
+		await editor.canvas.click( 'role=button[name="Add default block"i]' );
+		await page.keyboard.type( 'a' );
+
+		await editor.showBlockToolbar();
+		await editor.clickBlockToolbarButton( 'More' );
+		await page.locator( 'button:text("Footnote")' ).click();
+
+		await page.keyboard.type( '1' );
+
+		// Publish post.
+		await editor.publishPost();
+
+		await editor.canvas.click( 'ol.wp-block-footnotes li span' );
+		await page.keyboard.press( 'End' );
+		await page.keyboard.type( '2' );
+
+		const editorPage = page;
+		const previewPage = await editor.openPreviewPage();
+
+		await expect(
+			previewPage.locator( 'ol.wp-block-footnotes li' )
+		).toHaveText( '12 ↩︎' );
+
+		await previewPage.close();
+		await editorPage.bringToFront();
+
+		// Test again, this time with an existing revision (different code
+		// path).
+		await editor.canvas.click( 'ol.wp-block-footnotes li span' );
+		await page.keyboard.press( 'End' );
+		await page.keyboard.type( '3' );
+
+		const previewPage2 = await editor.openPreviewPage();
+
+		await expect(
+			previewPage2.locator( 'ol.wp-block-footnotes li' )
+		).toHaveText( '123  ↩︎' );
+	} );
 } );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

We should think hard if we really want to fix this imo minor issue. The only thing that is broken is previews for **published** posts.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Adds filters to temporarily patch up the issues.

## Testing Instructions

Publish a post with footnotes. Now change some footnotes and preview. Footnote changes should be in the preview. Change it again and preview to test if updating the revision works. Also test just updating footnotes without any post content.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
