### PR TITLE
Add common commands (breadcrumbs, live preview, pre-publish checklist)

### DIFF
--- a/packages/edit-post/src/hooks/commands/use-common-commands.js
+++ b/packages/edit-post/src/hooks/commands/use-common-commands.js
@@ -12,10 +12,12 @@ import {
 	keyboardClose,
 	desktop,
 	listView,
+	external,
 } from '@wordpress/icons';
 import { useCommand } from '@wordpress/commands';
 import { store as preferencesStore } from '@wordpress/preferences';
 import { store as interfaceStore } from '@wordpress/interface';
+import { store as editorStore } from '@wordpress/editor';
 
 /**
  * Internal dependencies
@@ -32,19 +34,25 @@ export default function useCommonCommands() {
 		setIsListViewOpened,
 	} = useDispatch( editPostStore );
 	const { openModal } = useDispatch( interfaceStore );
-	const { editorMode, activeSidebar, isListViewOpen } = useSelect(
-		( select ) => {
-			const { getEditorMode, isListViewOpened } = select( editPostStore );
-			return {
-				activeSidebar: select(
-					interfaceStore
-				).getActiveComplementaryArea( editPostStore.name ),
-				editorMode: getEditorMode(),
-				isListViewOpen: isListViewOpened(),
-			};
-		},
-		[]
-	);
+	const {
+		editorMode,
+		activeSidebar,
+		isListViewOpen,
+		previewLink,
+		currentPostLink,
+	} = useSelect( ( select ) => {
+		const { getEditorMode, isListViewOpened } = select( editPostStore );
+		return {
+			activeSidebar: select( interfaceStore ).getActiveComplementaryArea(
+				editPostStore.name
+			),
+			editorMode: getEditorMode(),
+			isListViewOpen: isListViewOpened(),
+			previewLink: select( editorStore ).getEditedPostPreviewLink(),
+			currentPostLink:
+				select( editorStore ).getCurrentPostAttribute( 'link' ),
+		};
+	}, [] );
 	const { toggle } = useDispatch( preferencesStore );
 
 	useCommand( {
@@ -160,6 +168,16 @@ export default function useCommonCommands() {
 		callback: ( { close } ) => {
 			toggle( 'core/edit-post', 'showBlockBreadcrumbs' );
 			close();
+		},
+	} );
+
+	useCommand( {
+		name: 'core/preview-link',
+		label: __( 'Preview in a new tab' ),
+		icon: external,
+		callback: ( { close } ) => {
+			close();
+			window.open( previewLink || currentPostLink, '_blank' );
 		},
 	} );
 }

--- a/packages/edit-post/src/hooks/commands/use-common-commands.js
+++ b/packages/edit-post/src/hooks/commands/use-common-commands.js
@@ -45,8 +45,10 @@ export default function useCommonCommands() {
 		previewLink,
 		currentPostLink,
 		isPublishSidebarEnabled,
+		showBlockBreadcrumbs,
 	} = useSelect( ( select ) => {
-		const { getEditorMode, isListViewOpened } = select( editPostStore );
+		const { getEditorMode, isListViewOpened, isFeatureActive } =
+			select( editPostStore );
 		return {
 			activeSidebar: select( interfaceStore ).getActiveComplementaryArea(
 				editPostStore.name
@@ -58,10 +60,10 @@ export default function useCommonCommands() {
 			previewLink: select( editorStore ).getEditedPostPreviewLink(),
 			currentPostLink:
 				select( editorStore ).getCurrentPostAttribute( 'link' ),
+			showBlockBreadcrumbs: isFeatureActive( 'showBlockBreadcrumbs' ),
 		};
 	}, [] );
 	const { toggle } = useDispatch( preferencesStore );
-	const { get: getPreference } = useSelect( preferencesStore );
 	const { createInfoNotice } = useDispatch( noticesStore );
 
 	useCommand( {
@@ -172,15 +174,17 @@ export default function useCommonCommands() {
 
 	useCommand( {
 		name: 'core/toggle-breadcrumbs',
-		label: __( 'Show/hide block breadcrumbs' ),
+		label: showBlockBreadcrumbs
+			? __( 'Hide block breadcrumbs' )
+			: __( 'Show block breadcrumbs' ),
 		icon: cog,
 		callback: ( { close } ) => {
 			toggle( 'core/edit-post', 'showBlockBreadcrumbs' );
 			close();
 			createInfoNotice(
-				getPreference( 'core/edit-post', 'showBlockBreadcrumbs' )
-					? __( 'Breadcrumbs on.' )
-					: __( 'Breadcrumbs off.' ),
+				showBlockBreadcrumbs
+					? __( 'Breadcrumbs off.' )
+					: __( 'Breadcrumbs on.' ),
 				{
 					id: 'core/edit-post/toggle-breadcrumbs/notice',
 					type: 'snackbar',

--- a/packages/edit-post/src/hooks/commands/use-common-commands.js
+++ b/packages/edit-post/src/hooks/commands/use-common-commands.js
@@ -40,8 +40,6 @@ export default function useCommonCommands() {
 		editorMode,
 		activeSidebar,
 		isListViewOpen,
-		previewLink,
-		currentPostLink,
 		isPublishSidebarEnabled,
 		showBlockBreadcrumbs,
 	} = useSelect( ( select ) => {
@@ -55,14 +53,12 @@ export default function useCommonCommands() {
 			isListViewOpen: isListViewOpened(),
 			isPublishSidebarEnabled:
 				select( editorStore ).isPublishSidebarEnabled(),
-			previewLink: select( editorStore ).getEditedPostPreviewLink(),
-			currentPostLink:
-				select( editorStore ).getCurrentPostAttribute( 'link' ),
 			showBlockBreadcrumbs: isFeatureActive( 'showBlockBreadcrumbs' ),
 		};
 	}, [] );
 	const { toggle } = useDispatch( preferencesStore );
 	const { createInfoNotice } = useDispatch( noticesStore );
+	const { __unstableSaveForPreview } = useDispatch( editorStore );
 
 	useCommand( {
 		name: 'core/open-settings-sidebar',
@@ -216,9 +212,10 @@ export default function useCommonCommands() {
 		name: 'core/preview-link',
 		label: __( 'Preview in a new tab' ),
 		icon: external,
-		callback: ( { close } ) => {
+		callback: async ( { close } ) => {
 			close();
-			window.open( previewLink || currentPostLink, '_blank' );
+			const link = await __unstableSaveForPreview( {} );
+			window.open( link, '_blank' );
 		},
 	} );
 }

--- a/packages/edit-post/src/hooks/commands/use-common-commands.js
+++ b/packages/edit-post/src/hooks/commands/use-common-commands.js
@@ -35,8 +35,6 @@ export default function useCommonCommands() {
 		switchEditorMode,
 		setIsListViewOpened,
 	} = useDispatch( editPostStore );
-	const { enablePublishSidebar, disablePublishSidebar } =
-		useDispatch( editorStore );
 	const { openModal } = useDispatch( interfaceStore );
 	const {
 		editorMode,
@@ -201,11 +199,7 @@ export default function useCommonCommands() {
 		icon: formatListBullets,
 		callback: ( { close } ) => {
 			close();
-			if ( isPublishSidebarEnabled ) {
-				disablePublishSidebar();
-			} else {
-				enablePublishSidebar();
-			}
+			toggle( 'core/edit-post', 'isPublishSidebarEnabled' );
 			createInfoNotice(
 				isPublishSidebarEnabled
 					? __( 'Pre-publish checklist off.' )

--- a/packages/edit-post/src/hooks/commands/use-common-commands.js
+++ b/packages/edit-post/src/hooks/commands/use-common-commands.js
@@ -152,4 +152,14 @@ export default function useCommonCommands() {
 			openModal( KEYBOARD_SHORTCUT_HELP_MODAL_NAME );
 		},
 	} );
+
+	useCommand( {
+		name: 'core/toggle-breadcrumbs',
+		label: __( 'Show/hide block breadcrumbs' ),
+		icon: cog,
+		callback: ( { close } ) => {
+			toggle( 'core/edit-post', 'showBlockBreadcrumbs' );
+			close();
+		},
+	} );
 }

--- a/packages/edit-site/src/hooks/commands/use-edit-mode-commands.js
+++ b/packages/edit-site/src/hooks/commands/use-edit-mode-commands.js
@@ -145,16 +145,21 @@ function useEditUICommands() {
 		setIsListViewOpened,
 		switchEditorMode,
 	} = useDispatch( editSiteStore );
-	const { canvasMode, editorMode, activeSidebar } = useSelect(
-		( select ) => ( {
-			canvasMode: unlock( select( editSiteStore ) ).getCanvasMode(),
-			editorMode: select( editSiteStore ).getEditorMode(),
-			activeSidebar: select( interfaceStore ).getActiveComplementaryArea(
-				editSiteStore.name
-			),
-		} ),
-		[]
-	);
+	const { canvasMode, editorMode, activeSidebar, showBlockBreadcrumbs } =
+		useSelect(
+			( select ) => ( {
+				canvasMode: unlock( select( editSiteStore ) ).getCanvasMode(),
+				editorMode: select( editSiteStore ).getEditorMode(),
+				activeSidebar: select(
+					interfaceStore
+				).getActiveComplementaryArea( editSiteStore.name ),
+				showBlockBreadcrumbs: select( preferencesStore ).get(
+					'core/edit-site',
+					'showBlockBreadcrumbs'
+				),
+			} ),
+			[]
+		);
 	const { openModal } = useDispatch( interfaceStore );
 	const { get: getPreference } = useSelect( preferencesStore );
 	const { set: setPreference, toggle } = useDispatch( preferencesStore );
@@ -267,7 +272,9 @@ function useEditUICommands() {
 
 	commands.push( {
 		name: 'core/toggle-breadcrumbs',
-		label: __( 'Show/hide block breadcrumbs' ),
+		label: showBlockBreadcrumbs
+			? __( 'Hide block breadcrumbs' )
+			: __( 'Show block breadcrumbs' ),
 		icon: cog,
 		callback: ( { close } ) => {
 			toggle( 'core/edit-site', 'showBlockBreadcrumbs' );

--- a/packages/edit-site/src/hooks/commands/use-edit-mode-commands.js
+++ b/packages/edit-site/src/hooks/commands/use-edit-mode-commands.js
@@ -265,6 +265,16 @@ function useEditUICommands() {
 		},
 	} );
 
+	commands.push( {
+		name: 'core/toggle-breadcrumbs',
+		label: __( 'Show/hide block breadcrumbs' ),
+		icon: cog,
+		callback: ( { close } ) => {
+			toggle( 'core/edit-site', 'showBlockBreadcrumbs' );
+			close();
+		},
+	} );
+
 	return {
 		isLoading: false,
 		commands,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Add three commands to the command palette: 
- Show/hide block breadcrumbs 
- Enable pre-publish checklist / Disable pre-publish checklist
- Preview in a new tab

## Why?
We need these commands, but I'm also trying out a couple UX patterns (such as the "Show/hide" vs. "Toggle", and using snackbars more prominently. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a post or page.
2. Activate the command palette via CTRL+K or CMD+K.
3. Search for the commands above and test. 

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
<img width="478" alt="CleanShot 2023-07-27 at 14 52 14" src="https://github.com/WordPress/gutenberg/assets/1813435/cd227fa5-d68e-4b62-aaa7-8c2a19a37b85">
<img width="479" alt="CleanShot 2023-07-27 at 14 52 25" src="https://github.com/WordPress/gutenberg/assets/1813435/af5c1f99-0fbc-440d-88fe-35363a1bdb40">
<img width="478" alt="CleanShot 2023-07-27 at 14 52 41" src="https://github.com/WordPress/gutenberg/assets/1813435/0ac9b593-3910-4880-8ea4-7e225575deb0">
<img width="475" alt="CleanShot 2023-07-27 at 14 53 07" src="https://github.com/WordPress/gutenberg/assets/1813435/a56ddad7-eea3-43d8-90f5-a150b335bee0">
