### PR TITLE
Site Editor: Add navigation type to title labels map

### DIFF
--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -61,6 +61,7 @@ const typeLabels = {
 	wp_template: __( 'Template' ),
 	wp_template_part: __( 'Template Part' ),
 	wp_block: __( 'Pattern' ),
+	wp_navigation: __( 'Navigation Menu' ),
 };
 
 // Prevent accidental removal of certain blocks, asking the user for

--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -61,7 +61,7 @@ const typeLabels = {
 	wp_template: __( 'Template' ),
 	wp_template_part: __( 'Template Part' ),
 	wp_block: __( 'Pattern' ),
-	wp_navigation: __( 'Navigation Menu' ),
+	wp_navigation: __( 'Navigation' ),
 };
 
 // Prevent accidental removal of certain blocks, asking the user for


### PR DESCRIPTION
## What?
PR adds the `wp_navigation` label to the post-type label map for the Site Editor.

P.S. I've not included this fix in #53071, since we can't backport new string in RCs.

## Why?
It was incorrect.

## Testing Instructions
1. Open the Site Editor.
2. Open a navigation menu.
3. Confirm the title is rendered correctly.

## Screenshots or screencast <!-- if applicable -->
| Before | After |
|--------|--------|
| ![CleanShot 2023-07-27 at 22 54 29](https://github.com/WordPress/gutenberg/assets/240569/491c73fb-812e-4010-9f5b-da35d2e5deb7) | ![CleanShot 2023-07-27 at 22 54 06](https://github.com/WordPress/gutenberg/assets/240569/696cad42-72d7-4f70-a691-c70602d120d7) |
