### PR TITLE
test: Split block from citation

### DIFF
--- a/packages/block-library/src/pullquote/test/edit.native.js
+++ b/packages/block-library/src/pullquote/test/edit.native.js
@@ -5,6 +5,7 @@ import {
 	addBlock,
 	getBlock,
 	initializeEditor,
+	selectRangeInRichText,
 	setupCoreBlocks,
 	getEditorHtml,
 	fireEvent,
@@ -45,10 +46,13 @@ describe( 'Pullquote', () => {
 
 		const citationTextInput =
 			within( citationBlock ).getByPlaceholderText( 'Add citation' );
-		typeInRichText( citationTextInput, 'A person', {
-			finalSelectionStart: 2,
-			finalSelectionEnd: 2,
+		typeInRichText( citationTextInput, 'A person' );
+		fireEvent( citationTextInput, 'onKeyDown', {
+			nativeEvent: {},
+			preventDefault() {},
+			keyCode: ENTER,
 		} );
+		selectRangeInRichText( citationTextInput, 2, 2 );
 		fireEvent( citationTextInput, 'onKeyDown', {
 			nativeEvent: {},
 			preventDefault() {},
@@ -59,7 +63,11 @@ describe( 'Pullquote', () => {
 		expect( getEditorHtml() ).toMatchInlineSnapshot( `
 		"<!-- wp:pullquote -->
 		<figure class="wp-block-pullquote"><blockquote><p>A great statement.<br>Again</p><cite>A <br>person</cite></blockquote></figure>
-		<!-- /wp:pullquote -->"
+		<!-- /wp:pullquote -->
+
+		<!-- wp:paragraph -->
+		<p></p>
+		<!-- /wp:paragraph -->"
 	` );
 	} );
 } );

--- a/packages/block-library/src/quote/test/edit.native.js
+++ b/packages/block-library/src/quote/test/edit.native.js
@@ -5,6 +5,7 @@ import {
 	addBlock,
 	getBlock,
 	initializeEditor,
+	selectRangeInRichText,
 	setupCoreBlocks,
 	getEditorHtml,
 	fireEvent,
@@ -62,10 +63,13 @@ describe( 'Quote', () => {
 		typeInRichText( quoteTextInput, 'Again.' );
 		const citationTextInput =
 			within( citationBlock ).getByPlaceholderText( 'Add citation' );
-		typeInRichText( citationTextInput, 'A person', {
-			finalSelectionStart: 2,
-			finalSelectionEnd: 2,
+		typeInRichText( citationTextInput, 'A person' );
+		fireEvent( citationTextInput, 'onKeyDown', {
+			nativeEvent: {},
+			preventDefault() {},
+			keyCode: ENTER,
 		} );
+		selectRangeInRichText( citationTextInput, 2, 2 );
 		fireEvent( citationTextInput, 'onKeyDown', {
 			nativeEvent: {},
 			preventDefault() {},
@@ -82,7 +86,11 @@ describe( 'Quote', () => {
 		<!-- wp:paragraph -->
 		<p>Again.</p>
 		<!-- /wp:paragraph --><cite>A <br>person</cite></blockquote>
-		<!-- /wp:quote -->"
+		<!-- /wp:quote -->
+
+		<!-- wp:paragraph -->
+		<p></p>
+		<!-- /wp:paragraph -->"
 	` );
 	} );
 } );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Automate testing splitting of Quote and Pullquote blocks from the citation
field.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Improve product stability.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Update existing tests to include pressing <kbd>Return</kbd> with the cursor
positioned at the end of the citation field.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
n/a

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
n/a

## Screenshots or screencast <!-- if applicable -->
n/a
