### PR TITLE
Editor: Set default parameter for '__unstableSaveForPreview'

### DIFF
--- a/packages/editor/src/store/actions.js
+++ b/packages/editor/src/store/actions.js
@@ -302,7 +302,7 @@ export const autosave =
 	};
 
 export const __unstableSaveForPreview =
-	( { forceIsAutosaveable } ) =>
+	( { forceIsAutosaveable } = {} ) =>
 	async ( { select, dispatch } ) => {
 		if (
 			( forceIsAutosaveable || select.isEditedPostAutosaveable() ) &&


### PR DESCRIPTION
## What?
PR sets a default parameter for the `__unstableSaveForPreview` action.

## Why?
Allows dispatching action without arguments and prevents an error.

```
Uncaught TypeError: Cannot destructure property 'forceIsAutosaveable' of 'undefined' as it is undefined.
```

## Testing Instructions
1. Open a Post or Page.
2. Dispatching action via the DevTools console shouldn't trigger an error.

```js
wp.data.dispatch('core/editor').__unstableSaveForPreview()
```
