### PR TITLE
Cover block: disable contrast checker

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -239,7 +239,7 @@ Add an image or video with a text overlay. ([Source](https://github.com/WordPres
 
 -	**Name:** core/cover
 -	**Category:** media
--	**Supports:** align, anchor, color (heading, text, ~~background~~), layout (~~allowJustification~~), spacing (blockGap, margin, padding), typography (fontSize, lineHeight), ~~html~~
+-	**Supports:** align, anchor, color (heading, text, ~~background~~, ~~enableContrastChecker~~), layout (~~allowJustification~~), spacing (blockGap, margin, padding), typography (fontSize, lineHeight), ~~html~~
 -	**Attributes:** allowedBlocks, alt, backgroundType, contentPosition, customGradient, customOverlayColor, dimRatio, focalPoint, gradient, hasParallax, id, isDark, isRepeated, minHeight, minHeightUnit, overlayColor, tagName, templateLock, url, useFeaturedImage
 
 ## Details

--- a/packages/block-library/src/cover/block.json
+++ b/packages/block-library/src/cover/block.json
@@ -111,7 +111,8 @@
 			"heading": true,
 			"text": true,
 			"background": false,
-			"__experimentalSkipSerialization": [ "gradients" ]
+			"__experimentalSkipSerialization": [ "gradients" ],
+			"enableContrastChecker": false
 		},
 		"typography": {
 			"fontSize": true,


### PR DESCRIPTION

## What?
Resolves https://github.com/WordPress/gutenberg/issues/50531

Let's deactivate the contrast checker on the cover block!

## Why?
Given the combination of text, image, alpha and overlay color, it's just too much for the contrast checking algorithm to cope. 

See discussion on [the current issue](https://github.com/WordPress/gutenberg/issues/50531) or a [past PR.](https://github.com/WordPress/gutenberg/pull/37731#issuecomment-1017090056) 

## How?
Whacking `"enableContrastChecker": false` in the Cover block's block.json.
Too easy.

## Testing Instructions

1. Insert a Cover block into a post
2. Set the same color for overlay and text
3. Witness that the contrast checker does not come to the party 

<details>

<summary>Example HTML (you'll have to replace the image)</summary>

```html
<!-- wp:cover {"url":"http://localhost:8888/wp-content/uploads/2023/07/Eq_it-na_pizza-margherita_sep2005_sml.jpg.webp","id":7,"dimRatio":50,"customOverlayColor":"#f2f0f0","isDark":false,"style":{"elements":{"link":{"color":{"text":"#f7f2f2"}}},"color":{"text":"#f7f2f2"}},"layout":{"type":"constrained"}} -->
<div class="wp-block-cover is-light has-text-color has-link-color" style="color:#f7f2f2"><span aria-hidden="true" class="wp-block-cover__background has-background-dim" style="background-color:#f2f0f0"></span><img class="wp-block-cover__image-background wp-image-7" alt="" src="http://localhost:8888/wp-content/uploads/2023/07/Eq_it-na_pizza-margherita_sep2005_sml.jpg.webp" data-object-fit="cover"/><div class="wp-block-cover__inner-container"><!-- wp:paragraph {"align":"center","placeholder":"Write title…","fontSize":"large"} -->
<p class="has-text-align-center has-large-font-size">A sweet cover block</p>
<!-- /wp:paragraph --></div></div>
<!-- /wp:cover -->

```

</details>

## Screenshots or screencast <!-- if applicable -->
| Before  | After |
| ------------- | ------------- |
| <img width="400" alt="Screenshot 2023-07-28 at 9 22 20 am" src="https://github.com/WordPress/gutenberg/assets/6458278/9fef42c6-491a-4d96-8168-1cdb9177e7f3"> | <img width="400" alt="Screenshot 2023-07-28 at 9 22 56 am" src="https://github.com/WordPress/gutenberg/assets/6458278/afb7e9d5-b8cf-49be-b231-9298d5ea792c"> |




