### PR TITLE
Fluid typography: add min and max viewport width configurable options

### DIFF
--- a/lib/block-supports/typography.php
+++ b/lib/block-supports/typography.php
@@ -459,8 +459,11 @@ function gutenberg_get_typography_font_size_value( $preset, $should_use_fluid_ty
 	$fluid_settings = isset( $typography_settings['fluid'] ) && is_array( $typography_settings['fluid'] ) ? $typography_settings['fluid'] : array();
 
 	// Defaults.
-	$default_maximum_viewport_width       = isset( $layout_settings['wideSize'] ) ? $layout_settings['wideSize'] : '1600px';
-	$default_minimum_viewport_width       = '320px';
+	$default_maximum_viewport_width = isset( $layout_settings['wideSize'] ) ? $layout_settings['wideSize'] : '1600px';
+	if ( isset( $typography_settings['maxViewportWidth'] ) ) {
+		$default_maximum_viewport_width = $typography_settings['maxViewportWidth'];
+	}
+	$default_minimum_viewport_width       = isset( $typography_settings['minViewportWidth'] ) ? $typography_settings['minViewportWidth'] : '320px';
 	$default_minimum_font_size_factor_max = 0.75;
 	$default_minimum_font_size_factor_min = 0.25;
 	$default_scale_factor                 = 1;

--- a/lib/block-supports/typography.php
+++ b/lib/block-supports/typography.php
@@ -460,10 +460,11 @@ function gutenberg_get_typography_font_size_value( $preset, $should_use_fluid_ty
 
 	// Defaults.
 	$default_maximum_viewport_width = isset( $layout_settings['wideSize'] ) ? $layout_settings['wideSize'] : '1600px';
-	if ( isset( $typography_settings['maxViewportWidth'] ) ) {
-		$default_maximum_viewport_width = $typography_settings['maxViewportWidth'];
+	if ( isset( $fluid_settings['maxViewportWidth'] ) ) {
+		$default_maximum_viewport_width = $fluid_settings['maxViewportWidth'];
 	}
-	$default_minimum_viewport_width       = isset( $typography_settings['minViewportWidth'] ) ? $typography_settings['minViewportWidth'] : '320px';
+
+	$default_minimum_viewport_width       = isset( $fluid_settings['minViewportWidth'] ) ? $fluid_settings['minViewportWidth'] : '320px';
 	$default_minimum_font_size_factor_max = 0.75;
 	$default_minimum_font_size_factor_min = 0.25;
 	$default_scale_factor                 = 1;

--- a/lib/block-supports/typography.php
+++ b/lib/block-supports/typography.php
@@ -459,17 +459,21 @@ function gutenberg_get_typography_font_size_value( $preset, $should_use_fluid_ty
 	$fluid_settings = isset( $typography_settings['fluid'] ) && is_array( $typography_settings['fluid'] ) ? $typography_settings['fluid'] : array();
 
 	// Defaults.
-	$default_maximum_viewport_width = isset( $layout_settings['wideSize'] ) ? $layout_settings['wideSize'] : '1600px';
-	if ( isset( $fluid_settings['maxViewportWidth'] ) ) {
-		$default_maximum_viewport_width = $fluid_settings['maxViewportWidth'];
-	}
-
-	$default_minimum_viewport_width       = isset( $fluid_settings['minViewportWidth'] ) ? $fluid_settings['minViewportWidth'] : '320px';
+	$default_maximum_viewport_width       = '1600px';
+	$default_minimum_viewport_width       = '320px';
 	$default_minimum_font_size_factor_max = 0.75;
 	$default_minimum_font_size_factor_min = 0.25;
 	$default_scale_factor                 = 1;
-	$has_min_font_size                    = isset( $fluid_settings['minFontSize'] ) && ! empty( gutenberg_get_typography_value_and_unit( $fluid_settings['minFontSize'] ) );
-	$default_minimum_font_size_limit      = $has_min_font_size ? $fluid_settings['minFontSize'] : '14px';
+	$default_minimum_font_size_limit      = '14px';
+
+	// Defaults overrides.
+	$minimum_viewport_width = isset( $fluid_settings['minViewportWidth'] ) ? $fluid_settings['minViewportWidth'] : $default_minimum_viewport_width;
+	$maximum_viewport_width = isset( $layout_settings['wideSize'] ) ? $layout_settings['wideSize'] : $default_maximum_viewport_width;
+	if ( isset( $fluid_settings['maxViewportWidth'] ) ) {
+		$maximum_viewport_width = $fluid_settings['maxViewportWidth'];
+	}
+	$has_min_font_size       = isset( $fluid_settings['minFontSize'] ) && ! empty( gutenberg_get_typography_value_and_unit( $fluid_settings['minFontSize'] ) );
+	$minimum_font_size_limit = $has_min_font_size ? $fluid_settings['minFontSize'] : $default_minimum_font_size_limit;
 
 	// Font sizes.
 	$fluid_font_size_settings = isset( $preset['fluid'] ) ? $preset['fluid'] : null;
@@ -493,7 +497,7 @@ function gutenberg_get_typography_font_size_value( $preset, $should_use_fluid_ty
 
 	// Parses the minimum font size limit, so we can perform checks using it.
 	$minimum_font_size_limit = gutenberg_get_typography_value_and_unit(
-		$default_minimum_font_size_limit,
+		$minimum_font_size_limit,
 		array(
 			'coerce_to' => $preferred_size['unit'],
 		)
@@ -542,8 +546,8 @@ function gutenberg_get_typography_font_size_value( $preset, $should_use_fluid_ty
 
 	$fluid_font_size_value = gutenberg_get_computed_fluid_typography_value(
 		array(
-			'minimum_viewport_width' => $default_minimum_viewport_width,
-			'maximum_viewport_width' => $default_maximum_viewport_width,
+			'minimum_viewport_width' => $minimum_viewport_width,
+			'maximum_viewport_width' => $maximum_viewport_width,
 			'minimum_font_size'      => $minimum_font_size_raw,
 			'maximum_font_size'      => $maximum_font_size_raw,
 			'scale_factor'           => $default_scale_factor,

--- a/packages/block-editor/src/components/global-styles/test/typography-utils.js
+++ b/packages/block-editor/src/components/global-styles/test/typography-utils.js
@@ -96,6 +96,36 @@ describe( 'typography utils', () => {
 			},
 
 			{
+				message:
+					'should override default max viewport width fluid typography settings',
+				preset: {
+					size: '1.75rem',
+				},
+				typographySettings: {
+					fluid: {
+						maxViewportWidth: '1200px',
+					},
+				},
+				expected:
+					'clamp(1.119rem, 1.119rem + ((1vw - 0.2rem) * 1.147), 1.75rem)',
+			},
+
+			{
+				message:
+					'should override default min viewport width fluid typography settings',
+				preset: {
+					size: '1.75rem',
+				},
+				typographySettings: {
+					fluid: {
+						minViewportWidth: '800px',
+					},
+				},
+				expected:
+					'clamp(1.119rem, 1.119rem + ((1vw - 0.5rem) * 1.262), 1.75rem)',
+			},
+
+			{
 				message: 'should return clamp value with em min and max units',
 				preset: {
 					size: '1.75em',
@@ -477,6 +507,21 @@ describe( 'typography utils', () => {
 				},
 				expected:
 					'clamp(100px, 6.25rem + ((1vw - 3.2px) * 7.813), 200px)',
+			},
+
+			{
+				message: 'should apply all custom fluid typography settings',
+				preset: {
+					size: '17px',
+				},
+				typographySettings: {
+					fluid: {
+						minFontSize: '16px',
+						maxViewportWidth: '1200px',
+						minViewportWidth: '640px',
+					},
+				},
+				expected: 'clamp(16px, 1rem + ((1vw - 6.4px) * 0.179), 17px)',
 			},
 		].forEach( ( { message, preset, typographySettings, expected } ) => {
 			it( `${ message }`, () => {

--- a/packages/block-editor/src/components/global-styles/typography-utils.js
+++ b/packages/block-editor/src/components/global-styles/typography-utils.js
@@ -68,6 +68,7 @@ export function getTypographyFontSizeValue( preset, typographyOptions ) {
 		fontSize: defaultSize,
 		minimumFontSizeLimit: fluidTypographySettings?.minFontSize,
 		maximumViewportWidth: fluidTypographySettings?.maxViewportWidth,
+		minimumViewportWidth: fluidTypographySettings?.minViewportWidth,
 	} );
 
 	if ( !! fluidFontSizeValue ) {

--- a/phpunit/block-supports/typography-test.php
+++ b/phpunit/block-supports/typography-test.php
@@ -679,7 +679,7 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 			'returns clamp value using custom fluid config' => array(
 				'font_size_value' => '17px',
 				'theme_slug'      => 'block-theme-child-with-fluid-typography-config',
-				'expected_output' => 'font-size:clamp(16px, 1rem + ((1vw - 3.2px) * 0.147), 17px);',
+				'expected_output' => 'font-size:clamp(16px, 1rem + ((1vw - 6.4px) * 0.179), 17px);',
 			),
 			'returns value when font size <= custom min font size bound' => array(
 				'font_size_value' => '15px',

--- a/phpunit/data/themedir1/block-theme-child-with-fluid-typography-config/theme.json
+++ b/phpunit/data/themedir1/block-theme-child-with-fluid-typography-config/theme.json
@@ -7,7 +7,9 @@
 		},
 		"typography": {
 			"fluid": {
-				"minFontSize": "16px"
+				"minFontSize": "16px",
+				"maxViewportWidth": "1200px",
+				"minViewportWidth": "640px"
 			}
 		}
 	}

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -451,6 +451,14 @@
 										"minFontSize": {
 											"description": "Allow users to set a global minimum font size boundary in px, rem or em. Custom font sizes below this value will not be clamped, and all calculated minimum font sizes will be, a at minimum, this value.",
 											"type": "string"
+										},
+										"maxViewPortWidth": {
+											"description": "Allow users to set custom a max viewport width in px, rem or em, used to set the maximum size boundary of a fluid font size.",
+											"type": "string"
+										},
+										"minViewPortWidth": {
+											"description": "Allow users to set a custom min viewport width in px, rem or em, used to set the minimum size boundary of a fluid font size.",
+											"type": "string"
 										}
 									},
 									"additionalProperties": false

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -449,7 +449,7 @@
 									"type": "object",
 									"properties": {
 										"minFontSize": {
-											"description": "Allow users to set a global minimum font size boundary in px, rem or em. Custom font sizes below this value will not be clamped, and all calculated minimum font sizes will be, a at minimum, this value.",
+											"description": "Allow users to set a global minimum font size boundary in px, rem or em. Custom font sizes below this value will not be clamped, and all calculated minimum font sizes will be, at a minimum, this value.",
 											"type": "string"
 										},
 										"maxViewportWidth": {

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -452,11 +452,11 @@
 											"description": "Allow users to set a global minimum font size boundary in px, rem or em. Custom font sizes below this value will not be clamped, and all calculated minimum font sizes will be, a at minimum, this value.",
 											"type": "string"
 										},
-										"maxViewPortWidth": {
+										"maxViewportWidth": {
 											"description": "Allow users to set custom a max viewport width in px, rem or em, used to set the maximum size boundary of a fluid font size.",
 											"type": "string"
 										},
-										"minViewPortWidth": {
+										"minViewportWidth": {
 											"description": "Allow users to set a custom min viewport width in px, rem or em, used to set the minimum size boundary of a fluid font size.",
 											"type": "string"
 										}


### PR DESCRIPTION
## What?
Welcome to this PR!

Please test its exciting features. Wow!

We're adding configurable min and max viewport width values to the `typography.fluid` theme.json schema, to allow theme developers to configure their own default min and max viewport widths for calculating fluid font sizes.

"What do the min and max viewport widths do?" you ask? Good question.

They define the boundaries, in terms of viewport widths, at which font size clamp values will stop being "fluid". For example, consider the following theme.json settings:

```json
		"typography": {
			"fluid": {
				"maxViewportWidth": "800px",
				"minViewportWidth": "600px"
			},
                  }
```

Between the browser widths of `600px` and `800px` a font size will be fluid. If the browser width is narrower or wider, the font size will no longer  shrink or grow.

See this fascinating screencast that demonstrates the above claim now! Witness how the computed `font-size` changes as the browser moves between `800px` and `600px`, but remains static higher or lower than those values. Unbelievable!

https://github.com/WordPress/gutenberg/assets/6458278/21d6f8e4-9f95-41ac-822f-b66a28d2ca81

## Why?

1. To provide extra configuration to theme authors so they can control how fluid typography works.
2. To also decouple max viewport width from the layout `wideSize` value (introduced in https://github.com/WordPress/gutenberg/pull/49815). Here is the background behind this motivation:
- https://github.com/WordPress/gutenberg/issues/44888#issuecomment-1653963566 cc @eric-michel

## TODO

- [x] Rename `maxViewPortWidth` to `maxViewportWidth` in the JS to be more consistent with the PHP property and also recognize that viewport is one word 😄  https://github.com/WordPress/gutenberg/pull/53082
- [x] Add unit tests
- [x] Backport PR: https://github.com/WordPress/wordpress-develop/pull/4989

## How?
By accepting `maxViewportWidth` and `minViewportWidth` values from theme.json settings in the editor and frontend.


## Testing Instructions
1. Fire up a block theme and enable fluid typography (see example theme.json below). Define a `maxViewportWidth` and `minViewportWidth`
2. Add some text content to a post/page or template and apply a custom font size to them. (see example HTML below).
3. Make sure your text has clamp values applied to them, and also verify that the font sizes are only fluid within the limits of the min and max viewport widths defined in theme.json. To do this you can open up Chrome dev tools and check the computed `font-size` values of the elements as you vary the width of the viewport. 
4. Ensure that `maxViewportWidth` takes precedence over any `settings.layout.wideSize` value

<details>

<summary>Example theme.json</summary>

```html
{
	"version": 2,
	"settings": {
		"appearanceTools": true,
		"layout": {
			"contentSize": "1000px",
			"wideSize": "1100px"
		},
		"typography": {
			"fluid": {
				"maxViewportWidth": "800px",
				"minViewportWidth": "600px"
			}
		}
	}
}


```
</details>

<details>

<summary>Example block HTML</summary>

```html

<!-- wp:paragraph {"style":{"typography":{"fontSize":"30px"}}} -->
<p style="font-size:30px">A paragraph 30px</p>
<!-- /wp:paragraph -->

<!-- wp:heading {"style":{"typography":{"fontSize":"6rem"}}} -->
<h2 class="wp-block-heading" style="font-size:6rem">A heading 6rem</h2>
<!-- /wp:heading -->

<!-- wp:cover {"customOverlayColor":"#a3e9a6","isDark":false,"layout":{"type":"constrained"}} -->
<div class="wp-block-cover is-light"><span aria-hidden="true" class="wp-block-cover__background has-background-dim-100 has-background-dim" style="background-color:#a3e9a6"></span><div class="wp-block-cover__inner-container"><!-- wp:paragraph {"align":"center","placeholder":"Write title…","style":{"typography":{"fontSize":"5em"}}} -->
<p class="has-text-align-center" style="font-size:5em">Cover block text 5em</p>
<!-- /wp:paragraph --></div></div>
<!-- /wp:cover -->
```

</details>

