### PR TITLE
Add keyboard icon and use in relative commands

### DIFF
--- a/packages/edit-post/src/hooks/commands/use-common-commands.js
+++ b/packages/edit-post/src/hooks/commands/use-common-commands.js
@@ -9,7 +9,7 @@ import {
 	drawerLeft,
 	drawerRight,
 	blockDefault,
-	keyboardClose,
+	keyboard,
 	desktop,
 	listView,
 } from '@wordpress/icons';
@@ -147,7 +147,7 @@ export default function useCommonCommands() {
 	useCommand( {
 		name: 'core/open-shortcut-help',
 		label: __( 'Open keyboard shortcuts' ),
-		icon: keyboardClose,
+		icon: keyboard,
 		callback: () => {
 			openModal( KEYBOARD_SHORTCUT_HELP_MODAL_NAME );
 		},

--- a/packages/edit-site/src/hooks/commands/use-edit-mode-commands.js
+++ b/packages/edit-site/src/hooks/commands/use-edit-mode-commands.js
@@ -13,7 +13,7 @@ import {
 	blockDefault,
 	cog,
 	code,
-	keyboardClose,
+	keyboard,
 } from '@wordpress/icons';
 import { useCommandLoader } from '@wordpress/commands';
 import { privateApis as routerPrivateApis } from '@wordpress/router';
@@ -259,7 +259,7 @@ function useEditUICommands() {
 	commands.push( {
 		name: 'core/open-shortcut-help',
 		label: __( 'Open keyboard shortcuts' ),
-		icon: keyboardClose,
+		icon: keyboard,
 		callback: () => {
 			openModal( KEYBOARD_SHORTCUT_HELP_MODAL_NAME );
 		},

--- a/packages/icons/src/index.js
+++ b/packages/icons/src/index.js
@@ -123,6 +123,7 @@ export { default as justifyRight } from './library/justify-right';
 export { default as justifySpaceBetween } from './library/justify-space-between';
 export { default as justifyStretch } from './library/justify-stretch';
 export { default as key } from './library/key';
+export { default as keyboard } from './library/keyboard';
 export { default as keyboardClose } from './library/keyboard-close';
 export { default as keyboardReturn } from './library/keyboard-return';
 export { default as language } from './library/language';

--- a/packages/icons/src/library/keyboard.js
+++ b/packages/icons/src/library/keyboard.js
@@ -1,0 +1,13 @@
+/**
+ * WordPress dependencies
+ */
+import { SVG, Path } from '@wordpress/primitives';
+
+const keyboard = (
+	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+		<Path d="m16 15.5h-8v-1.5h8zm-7.5-2.5h-2v-2h2zm3 0h-2v-2h2zm3 0h-2v-2h2zm3 0h-2v-2h2zm-9-3h-2v-2h2zm3 0h-2v-2h2zm3 0h-2v-2h2zm3 0h-2v-2h2z" />
+		<Path d="m18.5 6.5h-13a.5.5 0 0 0 -.5.5v9.5a.5.5 0 0 0 .5.5h13a.5.5 0 0 0 .5-.5v-9.5a.5.5 0 0 0 -.5-.5zm-13-1.5h13a2 2 0 0 1 2 2v9.5a2 2 0 0 1 -2 2h-13a2 2 0 0 1 -2-2v-9.5a2 2 0 0 1 2-2z" />
+	</SVG>
+);
+
+export default keyboard;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Add a `keyboard` icon and use it in the commands, instead of the keyboardClose icon (which also needs cleaning up; though that is a separate issue). 

## How?
- Adds an icon to the library. 
- Uses said icon in the "Open keyboard shortcuts" command. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a Post or Page. 
2. Open the command palette with CMD + K or CTRL + K. 
3. Search "keyboard shortcut".
4. See the icon within the command. 

## Screenshots or screencast <!-- if applicable -->

| Before  | After |
| ------------- | ------------- |
|<img width="215" alt="CleanShot 2023-07-27 at 20 41 59" src="https://github.com/WordPress/gutenberg/assets/1813435/09bbff64-4179-43a0-9e11-22563170427d">|<img width="198" alt="CleanShot 2023-07-27 at 20 40 12" src="https://github.com/WordPress/gutenberg/assets/1813435/08bae8c7-d764-41d6-a257-2d774b982b5b">|




