### PR TITLE
[WIP] Patterns: Add custom taxonomy for user patterns

### DIFF
--- a/lib/compat/wordpress-6.4/block-patterns.php
+++ b/lib/compat/wordpress-6.4/block-patterns.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Overrides Core's wp-includes/block-patterns.php to add new wp_patterns taxonomy for WP 6.3.
+ *
+ * @package gutenberg
+ */
+
+/**
+ * Adds a new taxonomy for organizing patterns.
+ *
+ * Note: This should be removed when the minimum required WP version is >= 6.3.
+ *
+ * @see https://github.com/WordPress/gutenberg/pull/51144
+ *
+ * @return void
+ */
+function gutenberg_register_taxonomy_patterns() {
+	$labels = array(
+		'name'          => _x( 'Pattern Categories', 'taxonomy general name' ),
+		'singular_name' => _x( 'Pattern Category', 'taxonomy singular name' ),
+	);
+	$args   = array(
+		'hierarchical'      => false,
+		'labels'            => $labels,
+		'show_ui'           => true,
+		'show_in_menu'      => false,
+		'show_in_nav_menus' => false,
+		'show_admin_column' => true,
+		'query_var'         => true,
+		'show_in_rest'      => true,
+		'rewrite'           => array( 'slug' => 'wp_pattern' ),
+	);
+	register_taxonomy( 'wp_user_pattern_categories', array( 'wp_block' ), $args );
+}
+add_action( 'init', 'gutenberg_register_taxonomy_patterns' );

--- a/lib/compat/wordpress-6.4/block-patterns.php
+++ b/lib/compat/wordpress-6.4/block-patterns.php
@@ -28,8 +28,8 @@ function gutenberg_register_taxonomy_patterns() {
 		'show_admin_column' => true,
 		'query_var'         => true,
 		'show_in_rest'      => true,
-		'rewrite'           => array( 'slug' => 'wp_pattern' ),
+		'rewrite'           => array( 'slug' => 'wp_pattern_custom_category' ),
 	);
-	register_taxonomy( 'wp_user_pattern_categories', array( 'wp_block' ), $args );
+	register_taxonomy( 'wp_pattern_custom_category', array( 'wp_block' ), $args );
 }
 add_action( 'init', 'gutenberg_register_taxonomy_patterns' );

--- a/lib/load.php
+++ b/lib/load.php
@@ -109,6 +109,9 @@ require __DIR__ . '/compat/wordpress-6.3/navigation-fallback.php';
 require __DIR__ . '/compat/wordpress-6.3/block-editor-settings.php';
 require_once __DIR__ . '/compat/wordpress-6.3/kses.php';
 
+// WordPress 6.4 compat.
+require __DIR__ . '/compat/wordpress-6.4/block-patterns.php';
+
 // Experimental features.
 require __DIR__ . '/experimental/block-editor-settings-mobile.php';
 require __DIR__ . '/experimental/blocks.php';

--- a/packages/edit-site/src/store/selectors.js
+++ b/packages/edit-site/src/store/selectors.js
@@ -94,6 +94,28 @@ export const getReusableBlocks = createRegistrySelector( ( select ) => () => {
 } );
 
 /**
+ * Returns any available custom pattern categories.
+ *
+ * @param {Object} state Global application state.
+ *
+ * @return {Array} The available custom pattern categories.
+ */
+export const getCustomPatternCategories = createRegistrySelector(
+	( select ) => () => {
+		const isWeb = Platform.OS === 'web';
+		return isWeb
+			? select( coreDataStore ).getEntityRecords(
+					'taxonomy',
+					'wp_pattern_custom_categories',
+					{
+						per_page: -1,
+					}
+			  )
+			: [];
+	}
+);
+
+/**
  * Returns the settings, taking into account active features and permissions.
  *
  * @param {Object}   state             Global application state.

--- a/packages/reusable-blocks/package.json
+++ b/packages/reusable-blocks/package.json
@@ -28,7 +28,6 @@
 		"{src,build,build-module}/{index.js,store/index.js}"
 	],
 	"dependencies": {
-		"@wordpress/api-fetch": "file:../api-fetch",
 		"@wordpress/block-editor": "file:../block-editor",
 		"@wordpress/blocks": "file:../blocks",
 		"@wordpress/components": "file:../components",

--- a/packages/reusable-blocks/package.json
+++ b/packages/reusable-blocks/package.json
@@ -28,17 +28,20 @@
 		"{src,build,build-module}/{index.js,store/index.js}"
 	],
 	"dependencies": {
+		"@wordpress/api-fetch": "file:../api-fetch",
 		"@wordpress/block-editor": "file:../block-editor",
 		"@wordpress/blocks": "file:../blocks",
 		"@wordpress/components": "file:../components",
 		"@wordpress/core-data": "file:../core-data",
 		"@wordpress/data": "file:../data",
 		"@wordpress/element": "file:../element",
+		"@wordpress/html-entities": "file:../html-entities",
 		"@wordpress/i18n": "file:../i18n",
 		"@wordpress/icons": "file:../icons",
 		"@wordpress/notices": "file:../notices",
 		"@wordpress/private-apis": "file:../private-apis",
-		"@wordpress/url": "file:../url"
+		"@wordpress/url": "file:../url",
+		"escape-html": "^1.0.3"
 	},
 	"peerDependencies": {
 		"react": "^18.0.0",

--- a/packages/reusable-blocks/src/store/actions.js
+++ b/packages/reusable-blocks/src/store/actions.js
@@ -42,12 +42,13 @@ export const __experimentalConvertBlockToStatic =
 /**
  * Returns a generator converting one or more static blocks into a pattern.
  *
- * @param {string[]}             clientIds The client IDs of the block to detach.
- * @param {string}               title     Pattern title.
- * @param {undefined|'unsynced'} syncType  They way block is synced, current undefined (synced) and 'unsynced'.
+ * @param {string[]}             clientIds  The client IDs of the block to detach.
+ * @param {string}               title      Pattern title.
+ * @param {undefined|'unsynced'} syncType   They way block is synced, current undefined (synced) and 'unsynced'.
+ * @param {string}               categoryId The category of pattern being created.
  */
 export const __experimentalConvertBlocksToReusable =
-	( clientIds, title, syncType ) =>
+	( clientIds, title, syncType, categoryId ) =>
 	async ( { registry, dispatch } ) => {
 		const meta =
 			syncType === 'unsynced'
@@ -56,6 +57,7 @@ export const __experimentalConvertBlocksToReusable =
 				  }
 				: undefined;
 
+		const categories = categoryId ? [ categoryId ] : undefined;
 		const reusableBlock = {
 			title: title || __( 'Untitled Pattern block' ),
 			content: serialize(
@@ -65,6 +67,7 @@ export const __experimentalConvertBlocksToReusable =
 			),
 			status: 'publish',
 			meta,
+			wp_user_pattern_categories: categories,
 		};
 
 		const updatedRecord = await registry

--- a/packages/reusable-blocks/src/store/actions.js
+++ b/packages/reusable-blocks/src/store/actions.js
@@ -67,7 +67,7 @@ export const __experimentalConvertBlocksToReusable =
 			),
 			status: 'publish',
 			meta,
-			wp_user_pattern_categories: categories,
+			wp_pattern_custom_category: categories,
 		};
 
 		const updatedRecord = await registry


### PR DESCRIPTION
## What?
Adds a custom taxonomy for user created patterns

## Why?
So users can classify their own patterns

## How?
Uses a standard WP taxonomy for the `wp_block` CPT

## Testing Instructions
Still a work in progress, not ready for testing yet

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
