### PR TITLE
Site editor: Make sure only one Site updated notice displays at a time

### DIFF
--- a/packages/edit-site/src/components/save-hub/index.js
+++ b/packages/edit-site/src/components/save-hub/index.js
@@ -27,12 +27,13 @@ const PUBLISH_ON_SAVE_ENTITIES = [
 ];
 
 export default function SaveHub() {
+	const saveNoticeId = 'site-edit-save-notice';
 	const { params } = useLocation();
 
 	const { __unstableMarkLastChangeAsPersistent } =
 		useDispatch( blockEditorStore );
 
-	const { createSuccessNotice, createErrorNotice } =
+	const { createSuccessNotice, createErrorNotice, removeNotice } =
 		useDispatch( noticesStore );
 
 	const { dirtyCurrentEntity, countUnsavedChanges, isDirty, isSaving } =
@@ -107,6 +108,7 @@ export default function SaveHub() {
 	const saveCurrentEntity = async () => {
 		if ( ! dirtyCurrentEntity ) return;
 
+		removeNotice( saveNoticeId );
 		const { kind, name, key, property } = dirtyCurrentEntity;
 
 		try {
@@ -132,6 +134,7 @@ export default function SaveHub() {
 
 			createSuccessNotice( __( 'Site updated.' ), {
 				type: 'snackbar',
+				id: saveNoticeId,
 			} );
 		} catch ( error ) {
 			createErrorNotice( `${ __( 'Saving failed.' ) } ${ error }` );


### PR DESCRIPTION
## What?
Die snackbars die!

## Why?
Because @jordesign  is not the only one that finds ever multiplying stacks of snacks that tell you the same thing annoying 😄 
Fixes: #53016

## How?
Adds an id to the snackbar, so it can be dismissed before consecutive saves so that only one appears at a time.

## Testing Instructions

- In the Site editor find a simple task that requires multiple saves of the site settings, eg. change the style variant and save after each change
- Observe that any existing snackbar is dismissed at start of save, so only one snackbar at a time appears

## Screenshots or screencast <!-- if applicable -->

Before:

https://github.com/WordPress/gutenberg/assets/3629020/280008ff-f494-46df-998a-eb8b90c2b178

After:

https://github.com/WordPress/gutenberg/assets/3629020/a840ced0-b84e-495f-9952-67b6ef36cbbb


