### PR TITLE
MenuGroup: Add Storybook stories

### DIFF
--- a/packages/components/src/menu-group/stories/index.tsx
+++ b/packages/components/src/menu-group/stories/index.tsx
@@ -1,0 +1,83 @@
+/**
+ * WordPress dependencies
+ */
+import { useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import MenuGroup from '..';
+import MenuItem from '../../menu-item';
+import MenuItemsChoice from '../../menu-items-choice';
+
+/**
+ * External dependencies
+ */
+import type { ComponentMeta, ComponentStory } from '@storybook/react';
+
+const meta: ComponentMeta< typeof MenuGroup > = {
+	title: 'Components/MenuGroup',
+	component: MenuGroup,
+	argTypes: {
+		children: { control: { type: null } },
+	},
+	parameters: {
+		controls: { expanded: true },
+		docs: { source: { state: 'open' } },
+	},
+};
+export default meta;
+
+const Template: ComponentStory< typeof MenuGroup > = ( args ) => {
+	return (
+		<MenuGroup { ...args }>
+			<MenuItem>Menu Item 1</MenuItem>
+			<MenuItem>Menu Item 2</MenuItem>
+		</MenuGroup>
+	);
+};
+
+export const Default: ComponentStory< typeof MenuGroup > = Template.bind( {} );
+
+const MultiGroupsTemplate: ComponentStory< typeof MenuGroup > = ( args ) => {
+	const [ mode, setMode ] = useState( 'visual' );
+	const choices = [
+		{
+			value: 'visual',
+			label: 'Visual editor',
+		},
+		{
+			value: 'text',
+			label: 'Code editor',
+		},
+	];
+
+	return (
+		<>
+			<MenuGroup label={ 'View' }>
+				<MenuItem>Top Toolbar</MenuItem>
+				<MenuItem>Spotlight Mode</MenuItem>
+				<MenuItem>Distraction Free</MenuItem>
+			</MenuGroup>
+			<MenuGroup { ...args }>
+				<MenuItemsChoice
+					choices={ choices }
+					value={ mode }
+					onSelect={ ( newMode: string ) => setMode( newMode ) }
+					onHover={ () => {} }
+				/>
+			</MenuGroup>
+		</>
+	);
+};
+
+/**
+ * When other menu items exist above or below a MenuGroup, the group
+ * should have a divider line between it and the adjacent item.
+ */
+export const WithSeperator = MultiGroupsTemplate.bind( {} );
+WithSeperator.args = {
+	...Default.args,
+	hideSeparator: false,
+	label: 'Editor',
+};


### PR DESCRIPTION
## What?
Add missing story for[ MenuGroup Component](https://github.com/WordPress/gutenberg/tree/trunk/packages/components/src/menu-group)

## Why?
Missing stories for components has been discussed on https://github.com/WordPress/gutenberg/issues/36128#issuecomment-1650618499

## How?
Add new /stories folder on /menu-group

## Testing Instructions
1. `npm run storybook:dev`
2. See the stories for MenuGroup

### Testing Instructions for Keyboard

## Screenshots or screencast <!-- if applicable -->
<img width="1035" alt="image" src="https://github.com/WordPress/gutenberg/assets/10071857/ee98e6d2-b0fa-421e-a01d-df58de067ea7">

