### PR TITLE
Top toolbar: Fix issues with save button overlap, and plugin buttons

### DIFF
--- a/packages/block-editor/src/components/block-tools/style.scss
+++ b/packages/block-editor/src/components/block-tools/style.scss
@@ -328,7 +328,7 @@
 			// in full screen mode we need to account for
 			// the combined with of the tools at the right of the header and the margin left
 			// of the toolbar which includes four buttons
-			width: calc(100% - 240px - #{4 * $grid-unit-80});
+			width: calc(100% - 280px - #{4 * $grid-unit-80});
 		}
 	}
 }

--- a/packages/block-editor/src/components/block-tools/style.scss
+++ b/packages/block-editor/src/components/block-tools/style.scss
@@ -125,9 +125,18 @@
 		display: none;
 	}
 
+	// Add a scrim to the right of the collapsed button.
+	&.is-collapsed::after {
+		content: "";
+		position: absolute;
+		left: 100%;
+		width: $grid-unit-60;
+		height: 100%;
+		background: linear-gradient(to right, $white, transparent);
+	}
+
 	// on desktop and tablet viewports the toolbar is fixed
 	// on top of interface header
-
 	@include break-medium() {
 		&.is-fixed {
 
@@ -308,7 +317,7 @@
 		}
 	}
 
-	// on tablet vewports the toolbar is fixed
+	// on tablet viewports the toolbar is fixed
 	// on top of interface header and covers the whole header
 	// except for the inserter on the left
 	@include break-medium() {

--- a/packages/edit-post/src/components/header/header-toolbar/style.scss
+++ b/packages/edit-post/src/components/header/header-toolbar/style.scss
@@ -82,6 +82,10 @@
 	align-items: center;
 	padding-left: $grid-unit-10;
 
+	// Some plugins add buttons here despite best practices.
+	// Push them a bit rightwards to fit the top toolbar.
+	margin-right: $grid-unit-10;
+
 	@include break-small() {
 		padding-left: $grid-unit-30;
 	}

--- a/packages/edit-site/src/components/header-edit-mode/document-actions/style.scss
+++ b/packages/edit-site/src/components/header-edit-mode/document-actions/style.scss
@@ -13,6 +13,11 @@
 	border-radius: 4px;
 	width: min(100%, 450px);
 
+	// Make the document title shorter in top-toolbar mode, as it has to be covered.
+	.has-fixed-toolbar & {
+		width: min(100%, 380px);
+	}
+
 	.components-button {
 		&:hover {
 			color: var(--wp-block-synced-color);


### PR DESCRIPTION
## What?

This is a bugfix to handle cases of the top toolbar covering the save button, and not correctly covering plugin buttons.

## Why?

There are a couple of bugs with the top toolbar mode. It partially covers the "Save draft" and "Saved" state indicators in the post editor:

<img width="1392" alt="before, saved button cropped" src="https://github.com/WordPress/gutenberg/assets/1204802/c8725786-c202-4a72-92a2-dc53996c9708">

When a plugin adds buttons to the top toolbar area, it is incorrectly covered:

<img width="880" alt="before, plugin button peeking in" src="https://github.com/WordPress/gutenberg/assets/1204802/ee4ecd46-fa03-475f-bdad-31a6ad642edc">

This PR fixes both issues.

## How?

It is worth noting, that there is no official API for adding buttons to the top toolbar like some plugins do. It is for exactly this reason, the full behavior of the top toolbar and how it behaves responsively and in cases like these, is still being refined.

* By adding a left margin to the left document tools, to push in plugin buttons to have their left side correctly covered.
* By adding a scrim to the collapsed document tools button, to show that covering is intentional.
* By adjusting the width of the top toolbar when expanded, to not crop the save button.
* By reducing the width of the Document Tools panel, when top toolbar mode is enabled.

## Testing Instructions

* Install a plugin that adds a button to the top area, such as [Starter Templates](https://wordpress.org/plugins/astra-sites/).
* Test post and site editors with top toolbar mode enabled. 
* Test a variety of viewport widths.
* Test with block selected, and with the toolbar collapsed.

## Screenshots or screencast <!-- if applicable -->

After, block selected:

<img width="1211" alt="after, plugin button not peeking in" src="https://github.com/WordPress/gutenberg/assets/1204802/dbfe3126-bf1e-431d-ac52-a1e02c1ce9dd">

After, block selected and toolbar collapsed:
<img width="644" alt="after, plugin button collapsed" src="https://github.com/WordPress/gutenberg/assets/1204802/4272a5bc-ae7c-4101-a159-09b3eb4b22d9">

After, toolbar collapsed in site editor:
<img width="1277" alt="after, site editor, collapsed" src="https://github.com/WordPress/gutenberg/assets/1204802/08e3bdaa-5f9b-47e5-afad-09c09986c4c8">

After, toolbar expanded in site editor:

<img width="1277" alt="after, site editor not collapsed" src="https://github.com/WordPress/gutenberg/assets/1204802/08cf7dcd-f278-4598-a022-38e9cafd8e18">
