### PR TITLE
Remove 'withSpokenMessages' HoC from the Link format

### DIFF
--- a/packages/format-library/src/link/inline.js
+++ b/packages/format-library/src/link/inline.js
@@ -3,7 +3,8 @@
  */
 import { useState, useRef, createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
-import { withSpokenMessages, Popover } from '@wordpress/components';
+import { speak } from '@wordpress/a11y';
+import { Popover } from '@wordpress/components';
 import { prependHTTP } from '@wordpress/url';
 import {
 	create,
@@ -36,7 +37,6 @@ function InlineLinkUI( {
 	addingLink,
 	value,
 	onChange,
-	speak,
 	stopAddingLink,
 	contentRef,
 } ) {
@@ -299,4 +299,4 @@ function getRichTextValueFromSelection( value, isActive ) {
 	return slice( value, textStart, textEnd );
 }
 
-export default withSpokenMessages( InlineLinkUI );
+export default InlineLinkUI;


### PR DESCRIPTION
## What?
PR removes 'withSpokenMessages' HoC from the Link format popover and uses the `speak` method.

## Why?
There's no need to wrap components in HoC when we can call methods directly.

## Testing Instructions
CI checks are green.

The a11y announcements have [test coverage](https://github.com/WordPress/gutenberg/blob/8dbd88bdd34ff714a4a87b5801d4654e04458995/packages/e2e-tests/specs/editor/various/links.test.js#L474-L488).
