### PR TITLE
Dependabot settings: remove the  `Automated testing` label.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,5 +10,4 @@ updates:
       open-pull-requests-limit: 10
       labels:
           - 'GitHub Actions'
-          - 'Automated Testing'
           - '[Type] Build Tooling'


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Updates the dependabot settings to add less labels to PRs.

## Why?
Following up on #52760, PRs should only have one label of each type. Moreover, the `Automated testing` label has been updated to `[Type] Automated testing` and doesn't exist anymore.

## How?
By removing the `Automated testing` label from the dependabot settings.