### PR TITLE
Try updated command palette styling

### DIFF
--- a/packages/commands/src/components/command-menu.js
+++ b/packages/commands/src/components/command-menu.js
@@ -24,7 +24,7 @@ import {
 	store as keyboardShortcutsStore,
 	useShortcut,
 } from '@wordpress/keyboard-shortcuts';
-import { Icon } from '@wordpress/icons';
+import { Icon, search as inputIcon } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -168,8 +168,9 @@ function CommandInput( { isOpen, search, setSearch } ) {
 			ref={ commandMenuInput }
 			value={ search }
 			onValueChange={ setSearch }
-			placeholder={ __( 'Type a command or search' ) }
+			placeholder={ __( 'Search for commands' ) }
 			aria-activedescendant={ selectedItemId }
+			icon={ search }
 		/>
 	);
 }
@@ -256,6 +257,7 @@ export function CommandMenu() {
 					onKeyDown={ onKeyDown }
 				>
 					<div className="commands-command-menu__header">
+						<Icon icon={ inputIcon } />
 						<CommandInput
 							search={ search }
 							setSearch={ setSearch }

--- a/packages/commands/src/components/style.scss
+++ b/packages/commands/src/components/style.scss
@@ -124,3 +124,8 @@
 	text-overflow: ellipsis;
 	white-space: nowrap;
 }
+
+.commands-command-menu__item mark {
+	color: inherit;
+	background: unset;
+}

--- a/packages/commands/src/components/style.scss
+++ b/packages/commands/src/components/style.scss
@@ -1,7 +1,7 @@
 // dirty hack to clean up modal
 .commands-command-menu {
 	width: 100%;
-	max-width: 480px;
+	max-width: 420px;
 	position: relative;
 	top: 15%;
 
@@ -19,6 +19,7 @@
 .commands-command-menu__header {
 	display: flex;
 	align-items: center;
+	padding-left: $grid-unit-20;
 
 	.components-button {
 		height: $grid-unit-70;
@@ -42,23 +43,21 @@
 	[cmdk-input] {
 		border: none;
 		width: 100%;
-		padding: $grid-unit-20;
+		padding: $grid-unit-20 $grid-unit-20 $grid-unit-20 $grid-unit-10;
 		outline: none;
 		color: $gray-900;
 		margin: 0;
-		font-size: 20px;
+		font-size: 16px;
 		line-height: 28px;
-		border-bottom: 1px solid $gray-200;
 		border-radius: 0;
 
 		&::placeholder {
-			color: $gray-600;
+			color: $gray-700;
 		}
 
 		&:focus {
 			box-shadow: none;
 			outline: none;
-			border-bottom: 1px solid $gray-200;
 		}
 	}
 
@@ -69,6 +68,7 @@
 		align-items: center;
 		padding: $grid-unit;
 		color: $gray-900;
+		font-size: $default-font-size;
 
 		&[aria-selected="true"],
 		&:active {
@@ -86,16 +86,16 @@
 		}
 
 		svg {
-			fill: $gray-600;
+			fill: $gray-900;
 		}
 	}
 
 	[cmdk-root] > [cmdk-list] {
-		max-height: 400px;
+		max-height: 368px; // Specific to not have commands overflow oddly.
 		overflow: auto;
 
 		& > [cmdk-list-sizer] :has([cmdk-group-items]:not(:empty)) {
-			padding: $grid-unit;
+			padding: 0 $grid-unit $grid-unit;
 		}
 	}
 
@@ -105,7 +105,7 @@
 		justify-content: center;
 		height: $grid-unit-80;
 		white-space: pre-wrap;
-		color: $gray-800;
+		color: $gray-900;
 	}
 
 	[cmdk-loading] {
@@ -115,14 +115,12 @@
 	[cmdk-list-sizer] {
 		position: relative;
 	}
-
-	[cmdk-group]:has([cmdk-group-items]:not(:empty)):not([hidden]) + [cmdk-group]:has([cmdk-group-items]:not(:empty)) {
-		border-top: $border-width solid $gray-200;
-	}
 }
 
-.commands-command-menu__item mark {
-	color: inherit;
-	background: unset;
-	font-weight: 600;
+.commands-command-menu__item span {
+	// Ensure commands do not run off the edge (great for post titles).
+	display: inline-block;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
 }

--- a/packages/commands/src/components/style.scss
+++ b/packages/commands/src/components/style.scss
@@ -94,7 +94,7 @@
 		max-height: 368px; // Specific to not have commands overflow oddly.
 		overflow: auto;
 
-		& > [cmdk-list-sizer] :has([cmdk-group-items]:not(:empty)) {
+		& > [cmdk-list-sizer]:not(:empty) {
 			padding: 0 $grid-unit $grid-unit;
 		}
 	}

--- a/packages/commands/src/components/style.scss
+++ b/packages/commands/src/components/style.scss
@@ -62,7 +62,7 @@
 	}
 
 	[cmdk-item] {
-		border-radius: $grid-unit-05;
+		border-radius: $radius-block-ui;
 		cursor: pointer;
 		display: flex;
 		align-items: center;

--- a/packages/commands/src/components/style.scss
+++ b/packages/commands/src/components/style.scss
@@ -128,4 +128,5 @@
 .commands-command-menu__item mark {
 	color: inherit;
 	background: unset;
+	font-weight: 600;
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
An initial attempt to revise the command palette UI. 

A couple highlights: 
- Introduces a search icon, aligned to the right.
- Set icon color to $gray-900.
- Simpler input placeholder
- Remove mark bolding (it's more distracting than necessary).
- Add ellipsis text-overflow for extra long commands.
- Removes distinction between the initial suggested contextual commands. If commands are suggested, they should just show up initially — otherwise not. 
- Reduce width to a bit more manageable size.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a post or page.
2. Use CMD+K or CTRL+K to open the command palette.

## Screenshots or screencast <!-- if applicable -->

### Before

<img width="600" alt="default-old" src="https://github.com/WordPress/gutenberg/assets/1813435/c7e77119-389e-43eb-9361-553065fe746a">

<img width="600" alt="with-commands-old" src="https://github.com/WordPress/gutenberg/assets/1813435/9b1cf64c-66e0-4fc3-bcd1-073bc9e1c7cf">

### After

<img width="600" alt="default" src="https://github.com/WordPress/gutenberg/assets/1813435/f88a84f8-d39b-4c9c-bc93-4b49504a04f4">
<img width="600" alt="with-commands" src="https://github.com/WordPress/gutenberg/assets/1813435/bf061ce2-c244-430e-9546-eeca84e3b98f">

