### PR TITLE
Navigation: Try a slot for sidebar navigation

### DIFF
--- a/packages/block-library/src/navigation/edit/menu-inspector-controls.js
+++ b/packages/block-library/src/navigation/edit/menu-inspector-controls.js
@@ -11,6 +11,7 @@ import {
 	__experimentalHStack as HStack,
 	__experimentalHeading as Heading,
 	Spinner,
+	createSlotFill,
 } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { __, sprintf } from '@wordpress/i18n';
@@ -139,39 +140,46 @@ const MenuInspectorControls = ( props ) => {
 		isManageMenusButtonDisabled,
 		blockEditingMode,
 	} = props;
-
+	const { Fill } = createSlotFill( 'NavigationSidebar' );
 	return (
-		<InspectorControls group="list">
-			<PanelBody title={ null }>
-				<HStack className="wp-block-navigation-off-canvas-editor__header">
-					<Heading
-						className="wp-block-navigation-off-canvas-editor__title"
-						level={ 2 }
-					>
-						{ __( 'Menu' ) }
-					</Heading>
-					{ blockEditingMode === 'default' && (
-						<NavigationMenuSelector
-							currentMenuId={ currentMenuId }
-							onSelectClassicMenu={ onSelectClassicMenu }
-							onSelectNavigationMenu={ onSelectNavigationMenu }
-							onCreateNew={ onCreateNew }
-							createNavigationMenuIsSuccess={
-								createNavigationMenuIsSuccess
-							}
-							createNavigationMenuIsError={
-								createNavigationMenuIsError
-							}
-							actionLabel={ actionLabel }
-							isManageMenusButtonDisabled={
-								isManageMenusButtonDisabled
-							}
-						/>
-					) }
-				</HStack>
+		<>
+			<InspectorControls group="list">
+				<PanelBody title={ null }>
+					<HStack className="wp-block-navigation-off-canvas-editor__header">
+						<Heading
+							className="wp-block-navigation-off-canvas-editor__title"
+							level={ 2 }
+						>
+							{ __( 'Menu' ) }
+						</Heading>
+						{ blockEditingMode === 'default' && (
+							<NavigationMenuSelector
+								currentMenuId={ currentMenuId }
+								onSelectClassicMenu={ onSelectClassicMenu }
+								onSelectNavigationMenu={
+									onSelectNavigationMenu
+								}
+								onCreateNew={ onCreateNew }
+								createNavigationMenuIsSuccess={
+									createNavigationMenuIsSuccess
+								}
+								createNavigationMenuIsError={
+									createNavigationMenuIsError
+								}
+								actionLabel={ actionLabel }
+								isManageMenusButtonDisabled={
+									isManageMenusButtonDisabled
+								}
+							/>
+						) }
+					</HStack>
+					<MainContent { ...props } />
+				</PanelBody>
+			</InspectorControls>
+			<Fill>
 				<MainContent { ...props } />
-			</PanelBody>
-		</InspectorControls>
+			</Fill>
+		</>
 	);
 };
 

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/navigation-menu-content.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/navigation-menu-content.js
@@ -4,8 +4,6 @@
 import {
 	privateApis as blockEditorPrivateApis,
 	store as blockEditorStore,
-	BlockList,
-	BlockTools,
 } from '@wordpress/block-editor';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { createBlock } from '@wordpress/blocks';
@@ -105,11 +103,6 @@ export default function NavigationMenuContent( { rootClientId } ) {
 					showAppender={ false }
 				/>
 			) }
-			<div className="edit-site-sidebar-navigation-screen-navigation-menus__helper-block-editor">
-				<BlockTools>
-					<BlockList />
-				</BlockTools>
-			</div>
 		</>
 	);
 }

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/style.scss
@@ -99,7 +99,3 @@
 	margin-right: auto;
 	display: block;
 }
-
-.edit-site-sidebar-navigation-screen-navigation-menus__helper-block-editor {
-	display: none;
-}

--- a/packages/edit-site/src/components/sidebar-navigation-screen-pattern/use-pattern-details.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-pattern/use-pattern-details.js
@@ -4,14 +4,13 @@
 import { __, sprintf, _x } from '@wordpress/i18n';
 import { store as coreStore } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
-import { Icon } from '@wordpress/components';
+import { Icon, createSlotFill } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
 import { useAddedBy } from '../list/added-by';
 import useEditedEntityRecord from '../use-edited-entity-record';
-import useNavigationMenuContent from './use-navigation-menu-content';
 import SidebarNavigationScreenDetailsFooter from '../sidebar-navigation-screen-details-footer';
 import {
 	SidebarNavigationScreenDetailsPanel,
@@ -22,6 +21,7 @@ import {
 import normalizeRecordKey from '../../utils/normalize-record-key';
 
 export default function usePatternDetails( postType, postId ) {
+	const { Slot } = createSlotFill( 'NavigationSidebar' );
 	postId = normalizeRecordKey( postId );
 
 	const { getDescription, getTitle, record } = useEditedEntityRecord(
@@ -123,7 +123,7 @@ export default function usePatternDetails( postType, postId ) {
 					) ) }
 				</SidebarNavigationScreenDetailsPanel>
 			) }
-			{ useNavigationMenuContent( postType, postId ) }
+			<Slot />
 		</>
 	);
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Instead of loading a separate block in the Site View, we can add the Navigation List View to a new Slot in the Site View

## Why?
This removes the need to load a hidden block in the sidebar. It also means that when you select a block in the sidebar it is actually selected in the canvas.

## How?
Using slots and fills

## Testing Instructions
Open a template part that contains a navigation block and confirm that the list view shows in the site view.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
