### PR TITLE
Don't allow access to Styles-related pages via the command palette in the hybrid theme

### DIFF
--- a/packages/core-commands/src/admin-navigation-commands.js
+++ b/packages/core-commands/src/admin-navigation-commands.js
@@ -10,14 +10,15 @@ import { privateApis as routerPrivateApis } from '@wordpress/router';
 /**
  * Internal dependencies
  */
-import { useIsSiteEditorAccessible } from './hooks';
+import { useIsTemplatesAccessible, useIsBlockBasedTheme } from './hooks';
 import { unlock } from './lock-unlock';
 
 const { useHistory } = unlock( routerPrivateApis );
 
 export function useAdminNavigationCommands() {
 	const history = useHistory();
-	const isSiteEditorAccessible = useIsSiteEditorAccessible();
+	const isTemplatesAccessible = useIsTemplatesAccessible();
+	const isBlockBasedTheme = useIsBlockBasedTheme();
 
 	const isSiteEditor = getPath( window.location.href )?.includes(
 		'site-editor.php'
@@ -43,9 +44,7 @@ export function useAdminNavigationCommands() {
 		name: 'core/manage-reusable-blocks',
 		label: __( 'Open patterns' ),
 		callback: ( { close } ) => {
-			if ( ! isSiteEditorAccessible ) {
-				document.location.href = 'edit.php?post_type=wp_block';
-			} else {
+			if ( isTemplatesAccessible && isBlockBasedTheme ) {
 				const args = {
 					path: '/patterns',
 				};
@@ -55,6 +54,8 @@ export function useAdminNavigationCommands() {
 					document.location = addQueryArgs( 'site-editor.php', args );
 				}
 				close();
+			} else {
+				document.location.href = 'edit.php?post_type=wp_block';
 			}
 		},
 		icon: isSiteEditor ? symbol : external,

--- a/packages/core-commands/src/hooks.js
+++ b/packages/core-commands/src/hooks.js
@@ -5,12 +5,18 @@ import { store as blockEditorStore } from '@wordpress/block-editor';
 import { store as coreStore } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
 
-export function useIsSiteEditorAccessible() {
+export function useIsTemplatesAccessible() {
+	return useSelect(
+		( select ) => select( coreStore ).canUser( 'read', 'templates' ),
+		[]
+	);
+}
+
+export function useIsBlockBasedTheme() {
 	return useSelect(
 		( select ) =>
 			select( blockEditorStore ).getSettings()
-				.__unstableIsBlockBasedTheme &&
-			select( coreStore ).canUser( 'read', 'templates' ),
+				.__unstableIsBlockBasedTheme,
 		[]
 	);
 }

--- a/packages/core-commands/src/hooks.js
+++ b/packages/core-commands/src/hooks.js
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { store as blockEditorStore } from '@wordpress/block-editor';
 import { store as coreStore } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
 
@@ -14,9 +13,7 @@ export function useIsTemplatesAccessible() {
 
 export function useIsBlockBasedTheme() {
 	return useSelect(
-		( select ) =>
-			select( blockEditorStore ).getSettings()
-				.__unstableIsBlockBasedTheme,
+		( select ) => select( coreStore ).getCurrentTheme()?.is_block_theme,
 		[]
 	);
 }

--- a/packages/core-commands/src/site-editor-navigation-commands.js
+++ b/packages/core-commands/src/site-editor-navigation-commands.js
@@ -20,7 +20,7 @@ import { getQueryArg, addQueryArgs, getPath } from '@wordpress/url';
 /**
  * Internal dependencies
  */
-import { useIsSiteEditorAccessible } from './hooks';
+import { useIsTemplatesAccessible, useIsBlockBasedTheme } from './hooks';
 import { unlock } from './lock-unlock';
 
 const { useHistory } = unlock( routerPrivateApis );
@@ -124,13 +124,15 @@ function useSiteEditorBasicNavigationCommands() {
 	const isSiteEditor = getPath( window.location.href )?.includes(
 		'site-editor.php'
 	);
-	const isSiteEditorAccessible = useIsSiteEditorAccessible();
+	const isTemplatesAccessible = useIsTemplatesAccessible();
+	const isBlockBasedTheme = useIsBlockBasedTheme();
 	const commands = useMemo( () => {
 		const result = [];
 
-		if ( ! isSiteEditorAccessible ) {
+		if ( ! isTemplatesAccessible || ! isBlockBasedTheme ) {
 			return result;
 		}
+
 		result.push( {
 			name: 'core/edit-site/open-navigation',
 			label: __( 'Open navigation' ),
@@ -204,7 +206,7 @@ function useSiteEditorBasicNavigationCommands() {
 		} );
 
 		return result;
-	}, [ history, isSiteEditor, isSiteEditorAccessible ] );
+	}, [ history, isSiteEditor, isTemplatesAccessible, isBlockBasedTheme ] );
 
 	return {
 		commands,

--- a/packages/edit-site/src/hooks/commands/use-common-commands.js
+++ b/packages/edit-site/src/hooks/commands/use-common-commands.js
@@ -6,10 +6,7 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { trash, backup, help, styles, external } from '@wordpress/icons';
 import { useCommandLoader, useCommand } from '@wordpress/commands';
-import {
-	privateApis as blockEditorPrivateApis,
-	store as blockEditorStore,
-} from '@wordpress/block-editor';
+import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
 import { privateApis as routerPrivateApis } from '@wordpress/router';
 import { store as preferencesStore } from '@wordpress/preferences';
 import { store as coreStore } from '@wordpress/core-data';
@@ -38,16 +35,15 @@ function useGlobalStylesOpenStylesCommands() {
 	const { createInfoNotice } = useDispatch( noticesStore );
 
 	const history = useHistory();
-	const { isDistractionFree, isBlockBasedTheme } = useSelect( ( select ) => {
-		return {
-			isDistractionFree: select( preferencesStore ).get(
-				editSiteStore.name,
-				'distractionFree'
-			),
-			isBlockBasedTheme:
-				select( blockEditorStore ).getSettings()
-					.__unstableIsBlockBasedTheme,
-		};
+	const isDistractionFree = useSelect( ( select ) => {
+		return select( preferencesStore ).get(
+			editSiteStore.name,
+			'distractionFree'
+		);
+	}, [] );
+
+	const isBlockBasedTheme = useSelect( ( select ) => {
+		return select( coreStore ).getCurrentTheme().is_block_theme;
 	}, [] );
 
 	const commands = useMemo( () => {
@@ -114,8 +110,7 @@ function useGlobalStylesToggleWelcomeGuideCommands() {
 
 	const history = useHistory();
 	const isBlockBasedTheme = useSelect( ( select ) => {
-		return select( blockEditorStore ).getSettings()
-			.__unstableIsBlockBasedTheme;
+		return select( coreStore ).getCurrentTheme().is_block_theme;
 	}, [] );
 
 	const commands = useMemo( () => {


### PR DESCRIPTION
Part of #52154

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This PR prevents two style-related pages from being accessible via the command palette in a classic theme that supports `block-template-parts`.

- Open styles
- Learn about styles

As a result, unintended page transitions and canvas rendering in the site editor will be fixed.

https://github.com/WordPress/gutenberg/assets/54422211/bca48479-8c00-493f-abb3-1f749e394451

## Why?
At least at this time, global styles are not available for non-block themes. However, my understanding is that [useCommonCommands](https://github.com/WordPress/gutenberg/blob/44fb9cd05c520494fe10a3652e9d5a5dae28ceb0/packages/edit-site/src/hooks/commands/use-common-commands.js#L172) is also executed when a non-block theme accesses the template parts page. This results in [two unintended commands being registered by useCommand](https://github.com/WordPress/gutenberg/blob/44fb9cd05c520494fe10a3652e9d5a5dae28ceb0/packages/edit-site/src/hooks/commands/use-common-commands.js#L197-L245).

## How?
I started by splitting the `useIsSiteEditorAccessible()` hook introduced in #52987 into the following two hooks:

- `useIsTemplatesAccessible()`
- `useIsBlockBasedTheme()`

And to conditionally execute the command, I used `useCommandLoader()` instead of `useCommand()`. In addition, use the newly added `useIsBlockBasedTheme()` hook and change these two commands to do nothing if it is not a block theme.

## Testing Instructions

In the classic theme (TT1), the hybrid theme (EmptyHybrid) and the block theme (TT3), confirm that all commands affected by this PR work as expected.

### Classic Theme

- Open patterns: Should go to the WP-Admin pattern page

### Hybrid Theme

- Open patterns: Should go to the WP-Admin pattern page
- Open navigation: Shouldn't show up.
- Open pages:  Shouldn't show up.
- Open style variations: Shouldn't show up.
- Open templates: Shouldn't show up.
- Open styles: **(new) Shouldn't show up.**
- Learn about styles: **(new) Shouldn't show up.**
- View site: Should show up.


### Block Theme

- Open patterns: should go to the Site Editor's pattern page.
- Open navigation: Should show up.
- Open pages:  Should show up.
- Open style variations: Should show up.
- Open templates: Should show up.
- Open styles: Should show up.
- Learn about styles: Should show up.
- View site: Should show up.

## Next Step

I have further confirmed that the page menu in the Site Editor is also unintentionally accessible. This will be addressed in a future PR.

![page](https://github.com/WordPress/gutenberg/assets/54422211/34b04361-1c84-4051-83e2-e7ff882677a7)
