### PR TITLE
test: Enable jest-console for native tests

### DIFF
--- a/packages/block-editor/src/components/block-draggable/test/index.native.js
+++ b/packages/block-editor/src/components/block-draggable/test/index.native.js
@@ -16,7 +16,6 @@ import TextInputState from 'react-native/Libraries/Components/TextInput/TextInpu
  */
 import { getBlockTypes, unregisterBlockType } from '@wordpress/blocks';
 import { registerCoreBlocks } from '@wordpress/block-library';
-import '@wordpress/jest-console';
 
 /**
  * Internal dependencies

--- a/packages/block-editor/src/components/block-list/test/block-invalid-warning.native.js
+++ b/packages/block-editor/src/components/block-list/test/block-invalid-warning.native.js
@@ -19,6 +19,10 @@ describe( 'Block invalid warning', () => {
             <div styless="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
             <!-- /wp:spacer -->`,
 		} );
+		expect( console ).toHaveErrored();
+		expect( console ).toHaveWarnedWith(
+			'Encountered unexpected attribute `styless`.'
+		);
 
 		// Assert
 		const warningElement = screen.getByText( /Problem displaying block./ );
@@ -32,7 +36,10 @@ describe( 'Block invalid warning', () => {
             <div styless="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
             <!-- /wp:spacer -->`,
 		} );
-
+		expect( console ).toHaveErrored();
+		expect( console ).toHaveWarnedWith(
+			'Encountered unexpected attribute `styless`.'
+		);
 		// Act
 		fireEvent.press( screen.getByText( /Problem displaying block./ ) );
 		const spacerBlock = getBlock( screen, 'Spacer' );

--- a/packages/block-library/src/buttons/test/edit.native.js
+++ b/packages/block-library/src/buttons/test/edit.native.js
@@ -324,6 +324,10 @@ describe( 'Buttons block', () => {
 
 			// Tap one color
 			fireEvent.press( screen.getByLabelText( 'Pale pink' ) );
+			// TODO(jest-console): Fix the warning and remove the expect below.
+			expect( console ).toHaveWarnedWith(
+				`Non-serializable values were found in the navigation state. Check:\n\nColor > params.onColorChange (Function)\n\nThis can break usage such as persisting and restoring state. This might happen if you passed non-serializable values such as function, class instances etc. in params. If you need to use components with callbacks in your options, you can use 'navigation.setOptions' instead. See https://reactnavigation.org/docs/troubleshooting#i-get-the-warning-non-serializable-values-were-found-in-the-navigation-state for more details.`
+			);
 
 			// Dismiss the Block Settings modal.
 			fireEvent( blockSettingsModal, 'backdropPress' );

--- a/packages/block-library/src/cover/test/edit.native.js
+++ b/packages/block-library/src/cover/test/edit.native.js
@@ -220,6 +220,10 @@ describe( 'when an image is attached', () => {
 			'52'
 		);
 		fireEvent.press( screen.getByLabelText( 'Apply' ) );
+		// TODO(jest-console): Fix the warning and remove the expect below.
+		expect( console ).toHaveWarnedWith(
+			`Non-serializable values were found in the navigation state. Check:\n\nFocalPoint > params.onFocalPointChange (Function)\n\nThis can break usage such as persisting and restoring state. This might happen if you passed non-serializable values such as function, class instances etc. in params. If you need to use components with callbacks in your options, you can use 'navigation.setOptions' instead. See https://reactnavigation.org/docs/troubleshooting#i-get-the-warning-non-serializable-values-were-found-in-the-navigation-state for more details.`
+		);
 
 		expect( setAttributes ).toHaveBeenCalledWith(
 			expect.objectContaining( {
@@ -377,6 +381,10 @@ describe( 'color settings', () => {
 		// Find the selected color.
 		const colorPaletteButton = await screen.findByTestId( COLOR_PINK );
 		expect( colorPaletteButton ).toBeDefined();
+		// TODO(jest-console): Fix the warning and remove the expect below.
+		expect( console ).toHaveWarnedWith(
+			`Non-serializable values were found in the navigation state. Check:\n\nColor > params.onColorChange (Function)\n\nThis can break usage such as persisting and restoring state. This might happen if you passed non-serializable values such as function, class instances etc. in params. If you need to use components with callbacks in your options, you can use 'navigation.setOptions' instead. See https://reactnavigation.org/docs/troubleshooting#i-get-the-warning-non-serializable-values-were-found-in-the-navigation-state for more details.`
+		);
 
 		// Select another color.
 		const newColorButton = await screen.findByTestId( COLOR_RED );

--- a/packages/block-library/src/embed/test/index.native.js
+++ b/packages/block-library/src/embed/test/index.native.js
@@ -898,6 +898,10 @@ describe( 'Embed block', () => {
 
 			// Select create embed option.
 			fireEvent.press( editor.getByText( 'Create embed' ) );
+			expect( console ).toHaveLoggedWith(
+				'Processed HTML piece:\n\n',
+				`<p>${ expectedURL }</p>`
+			);
 
 			// Get the created embed block.
 			const [ embedBlock ] = await editor.findAllByLabelText(
@@ -942,6 +946,10 @@ describe( 'Embed block', () => {
 
 			// Select create link option.
 			fireEvent.press( editor.getByText( 'Create link' ) );
+			expect( console ).toHaveLoggedWith(
+				'Processed HTML piece:\n\n',
+				`<p>${ expectedURL }</p>`
+			);
 
 			// Get the link text.
 			const linkText = await editor.findByDisplayValue(

--- a/packages/block-library/src/heading/test/index.native.js
+++ b/packages/block-library/src/heading/test/index.native.js
@@ -71,6 +71,10 @@ describe( 'Heading block', () => {
 
 		// Tap one color
 		fireEvent.press( screen.getByLabelText( 'Pale pink' ) );
+		// TODO(jest-console): Fix the warning and remove the expect below.
+		expect( console ).toHaveWarnedWith(
+			`Non-serializable values were found in the navigation state. Check:\n\nColor > params.onColorChange (Function)\n\nThis can break usage such as persisting and restoring state. This might happen if you passed non-serializable values such as function, class instances etc. in params. If you need to use components with callbacks in your options, you can use 'navigation.setOptions' instead. See https://reactnavigation.org/docs/troubleshooting#i-get-the-warning-non-serializable-values-were-found-in-the-navigation-state for more details.`
+		);
 
 		// Dismiss the Block Settings modal.
 		fireEvent( blockSettingsModal, 'backdropPress' );

--- a/packages/block-library/src/image/test/edit.native.js
+++ b/packages/block-library/src/image/test/edit.native.js
@@ -26,7 +26,6 @@ import { select, dispatch } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
 import { store as coreStore } from '@wordpress/core-data';
 import apiFetch from '@wordpress/api-fetch';
-import '@wordpress/jest-console';
 
 /**
  * Internal dependencies

--- a/packages/block-library/src/paragraph/test/edit.native.js
+++ b/packages/block-library/src/paragraph/test/edit.native.js
@@ -414,6 +414,10 @@ describe( 'Paragraph block', () => {
 
 		// Tap one color
 		fireEvent.press( screen.getByLabelText( 'Pale pink' ) );
+		// TODO(jest-console): Fix the warning and remove the expect below.
+		expect( console ).toHaveWarnedWith(
+			`Non-serializable values were found in the navigation state. Check:\n\nColor > params.onColorChange (Function)\n\nThis can break usage such as persisting and restoring state. This might happen if you passed non-serializable values such as function, class instances etc. in params. If you need to use components with callbacks in your options, you can use 'navigation.setOptions' instead. See https://reactnavigation.org/docs/troubleshooting#i-get-the-warning-non-serializable-values-were-found-in-the-navigation-state for more details.`
+		);
 
 		// Dismiss the Block Settings modal.
 		fireEvent( blockSettingsModal, 'backdropPress' );
@@ -669,6 +673,10 @@ describe( 'Paragraph block', () => {
 		);
 		fireEvent.press( screen.getByLabelText( 'Text color' ) );
 		fireEvent.press( await screen.findByLabelText( 'Tertiary' ) );
+		// TODO(jest-console): Fix the warning and remove the expect below.
+		expect( console ).toHaveWarnedWith(
+			`Non-serializable values were found in the navigation state. Check:\n\ntext-color > Palette > params.onColorChange (Function)\n\nThis can break usage such as persisting and restoring state. This might happen if you passed non-serializable values such as function, class instances etc. in params. If you need to use components with callbacks in your options, you can use 'navigation.setOptions' instead. See https://reactnavigation.org/docs/troubleshooting#i-get-the-warning-non-serializable-values-were-found-in-the-navigation-state for more details.`
+		);
 
 		// Assert
 		expect( getEditorHtml() ).toMatchInlineSnapshot( `

--- a/packages/components/src/draggable/test/index.native.js
+++ b/packages/components/src/draggable/test/index.native.js
@@ -110,6 +110,10 @@ describe( 'Draggable', () => {
 			},
 			{ state: State.END },
 		] );
+		// TODO(jest-console): Fix the warning and remove the expect below.
+		expect( console ).toHaveWarnedWith(
+			'[Reanimated] You can not use setGestureState in non-worklet function.'
+		);
 
 		expect( onDragStart ).toHaveBeenCalledTimes( 1 );
 		expect( onDragStart ).toHaveBeenCalledWith( {

--- a/packages/edit-post/src/test/editor.native.js
+++ b/packages/edit-post/src/test/editor.native.js
@@ -74,8 +74,9 @@ describe( 'Editor', () => {
 		// Act
 		const paragraphBlock = getBlock( screen, 'Paragraph' );
 		fireEvent.press( paragraphBlock );
-
-		toggleMode();
+		act( () => {
+			toggleMode();
+		} );
 
 		// Assert
 		const htmlEditor = await screen.findByLabelText( 'html-view-content' );

--- a/packages/edit-post/src/test/editor.native.js
+++ b/packages/edit-post/src/test/editor.native.js
@@ -79,7 +79,7 @@ describe( 'Editor', () => {
 		} );
 
 		// Assert
-		const htmlEditor = await screen.findByLabelText( 'html-view-content' );
+		const htmlEditor = screen.getByLabelText( 'html-view-content' );
 		expect( htmlEditor ).toBeVisible();
 	} );
 } );

--- a/packages/format-library/src/text-color/test/index.native.js
+++ b/packages/format-library/src/text-color/test/index.native.js
@@ -83,6 +83,10 @@ describe( 'Text color', () => {
 		const pinkColorButton = await screen.findByA11yHint( COLOR_PINK );
 		expect( pinkColorButton ).toBeDefined();
 		fireEvent.press( pinkColorButton );
+		// TODO(jest-console): Fix the warning and remove the expect below.
+		expect( console ).toHaveWarnedWith(
+			`Non-serializable values were found in the navigation state. Check:\n\ntext-color > Palette > params.onColorChange (Function)\n\nThis can break usage such as persisting and restoring state. This might happen if you passed non-serializable values such as function, class instances etc. in params. If you need to use components with callbacks in your options, you can use 'navigation.setOptions' instead. See https://reactnavigation.org/docs/troubleshooting#i-get-the-warning-non-serializable-values-were-found-in-the-navigation-state for more details.`
+		);
 
 		expect( getEditorHtml() ).toMatchSnapshot();
 	} );

--- a/packages/react-native-editor/src/setup-locale.js
+++ b/packages/react-native-editor/src/setup-locale.js
@@ -35,16 +35,6 @@ export default (
 			...extraTranslations,
 		};
 
-		if ( domain === 'default' ) {
-			// eslint-disable-next-line no-console
-			console.log( 'locale', locale, allTranslations );
-		} else {
-			// Extra translations are already logged along with the default domain, so
-			// for other domains we can limit the output to their translations.
-			// eslint-disable-next-line no-console
-			console.log( `${ domain } - locale`, locale, translations );
-		}
-
 		// Only change the locale if it's supported by gutenberg
 		if ( translations || extraTranslations ) {
 			setLocaleData( allTranslations, domain );

--- a/packages/react-native-editor/src/test/index.test.js
+++ b/packages/react-native-editor/src/test/index.test.js
@@ -11,7 +11,6 @@ import * as wpHooks from '@wordpress/hooks';
 import { registerCoreBlocks } from '@wordpress/block-library';
 // eslint-disable-next-line no-restricted-imports
 import * as wpEditPost from '@wordpress/edit-post';
-import '@wordpress/jest-console';
 
 /**
  * Internal dependencies

--- a/packages/react-native-editor/src/test/setup-locale.test.js
+++ b/packages/react-native-editor/src/test/setup-locale.test.js
@@ -28,6 +28,11 @@ const pluginTranslations = [
 describe( 'Setup locale', () => {
 	it( 'sets up default domain translations', () => {
 		setupLocale( 'test', extraTranslations, getDefaultTranslation );
+		// TODO(jest-console): Remove the log and remove the expect below.
+		expect( console ).toHaveLoggedWith( 'locale', 'test', {
+			...getDefaultTranslation(),
+			...extraTranslations,
+		} );
 
 		expect( __( 'default-string' ) ).toBe( 'default-string-translation' );
 		expect( __( 'extra-string' ) ).toBe( 'extra-string-translation' );
@@ -42,6 +47,11 @@ describe( 'Setup locale', () => {
 			getDefaultTranslation,
 			pluginTranslations
 		);
+		// TODO(jest-console): Remove the log and remove the expect below.
+		expect( console ).toHaveLoggedWith( 'locale', 'test', {
+			...getDefaultTranslation(),
+			...extraTranslations,
+		} );
 
 		/* eslint-disable @wordpress/i18n-text-domain */
 		expect( __( 'domain-1-string', domain ) ).toBe(

--- a/packages/react-native-editor/src/test/setup-locale.test.js
+++ b/packages/react-native-editor/src/test/setup-locale.test.js
@@ -28,11 +28,6 @@ const pluginTranslations = [
 describe( 'Setup locale', () => {
 	it( 'sets up default domain translations', () => {
 		setupLocale( 'test', extraTranslations, getDefaultTranslation );
-		// TODO(jest-console): Remove the log and remove the expect below.
-		expect( console ).toHaveLoggedWith( 'locale', 'test', {
-			...getDefaultTranslation(),
-			...extraTranslations,
-		} );
 
 		expect( __( 'default-string' ) ).toBe( 'default-string-translation' );
 		expect( __( 'extra-string' ) ).toBe( 'extra-string-translation' );
@@ -47,11 +42,6 @@ describe( 'Setup locale', () => {
 			getDefaultTranslation,
 			pluginTranslations
 		);
-		// TODO(jest-console): Remove the log and remove the expect below.
-		expect( console ).toHaveLoggedWith( 'locale', 'test', {
-			...getDefaultTranslation(),
-			...extraTranslations,
-		} );
 
 		/* eslint-disable @wordpress/i18n-text-domain */
 		expect( __( 'domain-1-string', domain ) ).toBe(

--- a/packages/rich-text/src/test/index.native.js
+++ b/packages/rich-text/src/test/index.native.js
@@ -15,7 +15,6 @@ import {
 	setDefaultBlockName,
 	unregisterBlockType,
 } from '@wordpress/blocks';
-import '@wordpress/jest-console';
 
 /**
  * Internal dependencies

--- a/test/native/setup-after-env.js
+++ b/test/native/setup-after-env.js
@@ -1,4 +1,9 @@
 /**
+ * WordPress dependencies
+ */
+import '@wordpress/jest-console';
+
+/**
  * Internal dependencies
  */
 import { toBeVisible } from './matchers/to-be-visible';


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Enable `@wordpress/jest-console` for the native editor automated tests.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Ensure accidental errors, warnings, and logs are not outputted during tests.
For example, an `act` warning will now cause a test failure.

Additionally, this will further align native editor tests with web editor tests. 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Enable the `@wordpress/jest-console` package within the native tests Jest
configuration, much like the web editor tests. Add assertions and to do comments
for all pre-existing logs that need to be addressed.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
n/a

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
n/a

## Screenshots or screencast <!-- if applicable -->
n/a
