### PR TITLE
fix: Select Gallery block when adding media

### DIFF
--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -91,6 +91,7 @@ function GalleryEdit( props ) {
 		isSelected,
 		insertBlocksAfter,
 		isContentLocked,
+		onFocus,
 	} = props;
 
 	const { columns, imageCrop, linkTarget, linkTo, sizeSlug, caption } =
@@ -498,6 +499,7 @@ function GalleryEdit( props ) {
 			value: hasImageIds ? images : {},
 			autoOpenMediaUpload:
 				! hasImages && isSelected && wasBlockJustInserted,
+			onFocus,
 		},
 	} );
 	const mediaPlaceholder = (

--- a/packages/block-library/src/gallery/test/index.native.js
+++ b/packages/block-library/src/gallery/test/index.native.js
@@ -159,9 +159,7 @@ describe( 'Gallery block', () => {
 		/* eslint-enable jest/no-conditional-expect */
 	} );
 
-	// This case is disabled until the issue (https://github.com/WordPress/gutenberg/issues/38444)
-	// is addressed.
-	it.skip( 'block remains selected after dismissing the media options picker', async () => {
+	it( 'block remains selected after dismissing the media options picker', async () => {
 		// Initialize with an empty gallery
 		const { getByLabelText, getByText, getByTestId } =
 			await initializeEditor( {

--- a/packages/react-native-editor/CHANGELOG.md
+++ b/packages/react-native-editor/CHANGELOG.md
@@ -14,6 +14,7 @@ For each user feature we should also add a importance categorization label  to i
 -   [*] Remove Gallery caption button on mobile [#53010]
 -   [**] Upgrade React Native to 0.71.11 [#51303]
 -   [*] Upgrade Gradle to 8.2.1 & AGP to 8.1.0 [#52872]
+-   [*] Fix Gallery block selection when adding media [#53127]
 
 ## 1.100.1
 -   [**] Add WP hook for registering non-core blocks [#52791]


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Select the Gallery block whenever it is focused.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Update the Gallery block to mirror the behaviour of other blocks, e.g.
the Image block. As a specific example, tapping "Add media" within an
empty Gallery block now results in the Gallery block becoming the
actively selected block. Fixes #38444.

This would also result in zero skipped tests for the mobile editor. 🎉 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Pass the `onFocus` prop provided by `BlockListBlock` through the Gallery block
edit component onto the `MediaPlaceholder`.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Verify the mobile editor Gallery block receives selection on focus
1. Add a Gallery block. 
2. Dismiss the media picker. 
3. Add an Image block. 
4. Dismiss the media picker. 
5. Tap "Add media" in the Gallery block. 
6. Dismiss the media picker. 
7. Verify the Gallery block has selection. 

### Verify the web editor Gallery block has not regressed 
1. In the web editor, add a Gallery block. 
2. Explore, performing various tasks, e.g. adding media, re-ordering media, removing media. 
3. Verify no regressions are encountered. 

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
n/a

## Screenshots or screencast <!-- if applicable -->

| Before | After | 
| - | - | 
| <video src="https://github.com/WordPress/gutenberg/assets/438664/e35a9a56-8eed-45e1-8623-836be84b968c" /> | <video src="https://github.com/WordPress/gutenberg/assets/438664/bc47dd72-6d67-40c8-9d27-b4684deb5ae8" /> |

