### PR TITLE
Video: Fixing styles that vertical alignment of the video

### DIFF
--- a/packages/block-library/src/video/style.scss
+++ b/packages/block-library/src/video/style.scss
@@ -3,6 +3,7 @@
 	box-sizing: border-box;
 	video {
 		width: 100%;
+		vertical-align: middle;
 	}
 
 	@supports (position: sticky) {


### PR DESCRIPTION
Fixed #52944

Adding styles `vertical-align: middle;` to `.wp-block-video video`