### PR TITLE
Footnotes: add missing _ in revision field filter

### DIFF
--- a/packages/block-library/src/footnotes/index.php
+++ b/packages/block-library/src/footnotes/index.php
@@ -211,7 +211,7 @@ add_filter( '_wp_post_revision_fields', '_wp_add_footnotes_to_revision' );
 function _wp_get_footnotes_from_revision( $revision_field, $field, $revision ) {
 	return get_metadata( 'post', $revision->ID, $field, true );
 }
-add_filter( 'wp_post_revision_field_footnotes', '_wp_get_footnotes_from_revision', 10, 3 );
+add_filter( '_wp_post_revision_field_footnotes', '_wp_get_footnotes_from_revision', 10, 3 );
 
 /**
  * The REST API autosave endpoint doesn't save meta, so we can use the

--- a/packages/block-library/src/footnotes/index.php
+++ b/packages/block-library/src/footnotes/index.php
@@ -90,7 +90,7 @@ add_action( 'init', 'register_block_core_footnotes' );
  *
  * @param int $revision_id The revision ID.
  */
-function wp_save_footnotes_meta( $revision_id ) {
+function _wp_save_footnotes_meta( $revision_id ) {
 	$post_id = wp_is_post_revision( $revision_id );
 
 	if ( $post_id ) {
@@ -102,7 +102,7 @@ function wp_save_footnotes_meta( $revision_id ) {
 		}
 	}
 }
-add_action( 'wp_after_insert_post', 'wp_save_footnotes_meta' );
+add_action( 'wp_after_insert_post', '_wp_save_footnotes_meta' );
 
 /**
  * Keeps track of the revision ID for "rest_after_insert_{$post_type}".
@@ -172,7 +172,7 @@ foreach ( array( 'post', 'page' ) as $post_type ) {
  * @param int $post_id     The post ID.
  * @param int $revision_id The revision ID.
  */
-function wp_restore_footnotes_from_revision( $post_id, $revision_id ) {
+function _wp_restore_footnotes_from_revision( $post_id, $revision_id ) {
 	$footnotes = get_post_meta( $revision_id, 'footnotes', true );
 
 	if ( $footnotes ) {
@@ -181,7 +181,7 @@ function wp_restore_footnotes_from_revision( $post_id, $revision_id ) {
 		delete_post_meta( $post_id, 'footnotes' );
 	}
 }
-add_action( 'wp_restore_post_revision', 'wp_restore_footnotes_from_revision', 10, 2 );
+add_action( 'wp_restore_post_revision', '_wp_restore_footnotes_from_revision', 10, 2 );
 
 /**
  * Adds the footnotes field to the revision.
@@ -191,11 +191,11 @@ add_action( 'wp_restore_post_revision', 'wp_restore_footnotes_from_revision', 10
  * @param array $fields The revision fields.
  * @return array The revision fields.
  */
-function wp_add_footnotes_to_revision( $fields ) {
+function _wp_add_footnotes_to_revision( $fields ) {
 	$fields['footnotes'] = __( 'Footnotes' );
 	return $fields;
 }
-add_filter( '_wp_post_revision_fields', 'wp_add_footnotes_to_revision' );
+add_filter( '_wp_post_revision_fields', '_wp_add_footnotes_to_revision' );
 
 /**
  * Gets the footnotes field from the revision.
@@ -208,10 +208,10 @@ add_filter( '_wp_post_revision_fields', 'wp_add_footnotes_to_revision' );
  * @param object $revision       The revision object to compare against.
  * @return string The field value.
  */
-function wp_get_footnotes_from_revision( $revision_field, $field, $revision ) {
+function _wp_get_footnotes_from_revision( $revision_field, $field, $revision ) {
 	return get_metadata( 'post', $revision->ID, $field, true );
 }
-add_filter( 'wp_post_revision_field_footnotes', 'wp_get_footnotes_from_revision', 10, 3 );
+add_filter( 'wp_post_revision_field_footnotes', '_wp_get_footnotes_from_revision', 10, 3 );
 
 /**
  * The REST API autosave endpoint doesn't save meta, so we can use the

--- a/packages/block-library/src/footnotes/index.php
+++ b/packages/block-library/src/footnotes/index.php
@@ -90,7 +90,7 @@ add_action( 'init', 'register_block_core_footnotes' );
  *
  * @param int $revision_id The revision ID.
  */
-function _wp_save_footnotes_meta( $revision_id ) {
+function wp_save_footnotes_meta( $revision_id ) {
 	$post_id = wp_is_post_revision( $revision_id );
 
 	if ( $post_id ) {
@@ -102,7 +102,7 @@ function _wp_save_footnotes_meta( $revision_id ) {
 		}
 	}
 }
-add_action( 'wp_after_insert_post', '_wp_save_footnotes_meta' );
+add_action( 'wp_after_insert_post', 'wp_save_footnotes_meta' );
 
 /**
  * Keeps track of the revision ID for "rest_after_insert_{$post_type}".
@@ -172,7 +172,7 @@ foreach ( array( 'post', 'page' ) as $post_type ) {
  * @param int $post_id     The post ID.
  * @param int $revision_id The revision ID.
  */
-function _wp_restore_footnotes_from_revision( $post_id, $revision_id ) {
+function wp_restore_footnotes_from_revision( $post_id, $revision_id ) {
 	$footnotes = get_post_meta( $revision_id, 'footnotes', true );
 
 	if ( $footnotes ) {
@@ -181,7 +181,7 @@ function _wp_restore_footnotes_from_revision( $post_id, $revision_id ) {
 		delete_post_meta( $post_id, 'footnotes' );
 	}
 }
-add_action( 'wp_restore_post_revision', '_wp_restore_footnotes_from_revision', 10, 2 );
+add_action( 'wp_restore_post_revision', 'wp_restore_footnotes_from_revision', 10, 2 );
 
 /**
  * Adds the footnotes field to the revision.
@@ -191,11 +191,11 @@ add_action( 'wp_restore_post_revision', '_wp_restore_footnotes_from_revision', 1
  * @param array $fields The revision fields.
  * @return array The revision fields.
  */
-function _wp_add_footnotes_to_revision( $fields ) {
+function wp_add_footnotes_to_revision( $fields ) {
 	$fields['footnotes'] = __( 'Footnotes' );
 	return $fields;
 }
-add_filter( '_wp_post_revision_fields', '_wp_add_footnotes_to_revision' );
+add_filter( '_wp_post_revision_fields', 'wp_add_footnotes_to_revision' );
 
 /**
  * Gets the footnotes field from the revision.
@@ -208,10 +208,10 @@ add_filter( '_wp_post_revision_fields', '_wp_add_footnotes_to_revision' );
  * @param object $revision       The revision object to compare against.
  * @return string The field value.
  */
-function _wp_get_footnotes_from_revision( $revision_field, $field, $revision ) {
+function wp_get_footnotes_from_revision( $revision_field, $field, $revision ) {
 	return get_metadata( 'post', $revision->ID, $field, true );
 }
-add_filter( '_wp_post_revision_field_footnotes', '_wp_get_footnotes_from_revision', 10, 3 );
+add_filter( '_wp_post_revision_field_footnotes', 'wp_get_footnotes_from_revision', 10, 3 );
 
 /**
  * The REST API autosave endpoint doesn't save meta, so we can use the


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Props @adamsilverstein for [bringing this to my attentions](https://github.com/WordPress/wordpress-develop/pull/4859#discussion_r1276844592). I forgot to prefix a filter with `_`.

But for some reason the filter is working fine without the `_`! I'm not sure why? I turned off both this filter and the one in core, and footnotes are rendering fine in the revision diff.

https://github.com/WordPress/wordpress-develop/blob/78e9478de7ee5dc67975a6694ffd1657cf1843aa/src/wp-admin/includes/revision.php#L70-L93

I've also prefixed the function that have been named in #52870.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions

Create a post with footnotes. Then update the content and update a footnote or add/remove one. Check the footnotes field on the revisions page.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
