### PR TITLE
Adding description of the --no-watch option

### DIFF
--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -57,7 +57,7 @@
 
 -   The `WP_DEVTOOL` environment variable can now be used to set the Webpack devtool option for sourcemaps in production builds ([#46812](https://github.com/WordPress/gutenberg/pull/46812)). Previously, this only worked for development builds.
 -   Update default webpack config and lint-style script to allow PostCSS (`.pcss` extension) file usage ([#45352](https://github.com/WordPress/gutenberg/pull/45352)).
--  the --no-watch – option allows creating the unminified/dev JS without starting the watcher ([#44237](https://github.com/WordPress/gutenberg/pull/44237)).
+-   Add `--no-watch` option to allow creating the unminified/dev JS without starting the watcher ([#44237](https://github.com/WordPress/gutenberg/pull/44237)).
 
 ## 25.3.0 (2023-02-01)
 

--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -57,6 +57,7 @@
 
 -   The `WP_DEVTOOL` environment variable can now be used to set the Webpack devtool option for sourcemaps in production builds ([#46812](https://github.com/WordPress/gutenberg/pull/46812)). Previously, this only worked for development builds.
 -   Update default webpack config and lint-style script to allow PostCSS (`.pcss` extension) file usage ([#45352](https://github.com/WordPress/gutenberg/pull/45352)).
+-  the --no-watch – option allows creating the unminified/dev JS without starting the watcher ([#44237](https://github.com/WordPress/gutenberg/pull/44237)).
 
 ## 25.3.0 (2023-02-01)
 

--- a/packages/scripts/README.md
+++ b/packages/scripts/README.md
@@ -382,7 +382,7 @@ This is how you execute the script with presented setup:
 This script automatically use the optimized config but sometimes you may want to specify some custom options:
 
 -   `--hot` – enables "Fast Refresh". The page will automatically reload if you make changes to the code. _For now, it requires that WordPress has the [`SCRIPT_DEBUG`](https://wordpress.org/documentation/article/debugging-in-wordpress/#script_debug) flag enabled and the [Gutenberg](https://wordpress.org/plugins/gutenberg/) plugin installed._
--   `--no-watch` – ensures that the watcher will not monitor for changes and won't trigger tasks or builds automatically in response to those changes.
+-   `--no-watch` – Starts the build for development without starting the watcher.
 -   `--webpack-bundle-analyzer` – enables visualization for the size of webpack output files with an interactive zoomable treemap.
 -   `--webpack-copy-php` – enables copying all PHP files from the source directory ( default is `src` ) and its subfolders to the output directory.
 -   `--webpack-devtool` – controls how source maps are generated. See options at https://webpack.js.org/configuration/devtool/#devtool.

--- a/packages/scripts/README.md
+++ b/packages/scripts/README.md
@@ -382,6 +382,7 @@ This is how you execute the script with presented setup:
 This script automatically use the optimized config but sometimes you may want to specify some custom options:
 
 -   `--hot` – enables "Fast Refresh". The page will automatically reload if you make changes to the code. _For now, it requires that WordPress has the [`SCRIPT_DEBUG`](https://wordpress.org/documentation/article/debugging-in-wordpress/#script_debug) flag enabled and the [Gutenberg](https://wordpress.org/plugins/gutenberg/) plugin installed._
+-   `--no-watch` – ensures that the watcher will not monitor for changes and won't trigger tasks or builds automatically in response to those changes.
 -   `--webpack-bundle-analyzer` – enables visualization for the size of webpack output files with an interactive zoomable treemap.
 -   `--webpack-copy-php` – enables copying all PHP files from the source directory ( default is `src` ) and its subfolders to the output directory.
 -   `--webpack-devtool` – controls how source maps are generated. See options at https://webpack.js.org/configuration/devtool/#devtool.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines: https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->


## What?
<!-- In a few words, what is the PR actually doing? -->

Adding description for the --no-watch option merged on February 2, 2023 and released in version 25.4.0 in packages/scripts/README.md and packages/scripts/CHANGELOG.md  



## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Adds missing documentation on the --no-watch option merged on February 2, 2023 and released in version 25.4.0. See https://github.com/WordPress/gutenberg/pull/44237 and https://github.com/WordPress/gutenberg/issues/51695.
## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Minor changes to documentation

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
Go to [the scripts documentation](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-scripts).


