### PR TITLE
Ignore IDE and Editor specific files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,7 @@ test/storybook-playwright/specs/__snapshots__
 test/storybook-playwright/specs/*-snapshots/**
 test/gutenberg-test-themes/twentytwentyone
 test/gutenberg-test-themes/twentytwentythree
+
+# IDE & Editors
+.idea
+.vscode/settings.json


### PR DESCRIPTION
Someone might use Phpstorm or customize the VSCode installation, those files shouldn't be committed.

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Exclude IDE & Editor specific files and directories

## Why?
For local development it would require less maintainance

## How?
Adding some lines to `.gitignore`

## Testing Instructions
Not relevant

### Testing Instructions for Keyboard
Not relevant

## Screenshots or screencast <!-- if applicable -->
Not relevant