### PR TITLE
theme.json schema: Don't allow css property except at the root and block level

### DIFF
--- a/docs/reference-guides/theme-json-reference/theme-json-living.md
+++ b/docs/reference-guides/theme-json-reference/theme-json-living.md
@@ -317,13 +317,6 @@ Outline styles.
 | width | string, object |  |
 
 ---
-
-### css
-
-Sets custom CSS to apply styling not covered by other theme.json properties.
-
-
----
 ## customTemplates
 
 Additional metadata for custom templates defined in the templates folder.

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -1811,10 +1811,6 @@
 						}
 					},
 					"additionalProperties": false
-				},
-				"css": {
-					"description": "Sets custom CSS to apply styling not covered by other theme.json properties.",
-					"type": "string"
 				}
 			}
 		},
@@ -1833,8 +1829,7 @@
 						"typography": {},
 						"filter": {},
 						"shadow": {},
-						"outline": {},
-						"css": {}
+						"outline": {}
 					},
 					"additionalProperties": false
 				}
@@ -1858,7 +1853,6 @@
 								"outline": {},
 								"spacing": {},
 								"typography": {},
-								"css": {},
 								":hover": {
 									"$ref": "#/definitions/stylesPropertiesComplete"
 								},
@@ -2268,7 +2262,10 @@
 						"filter": {},
 						"shadow": {},
 						"outline": {},
-						"css": {},
+						"css": {
+							"description": "Sets custom CSS to apply styling not covered by other theme.json properties.",
+							"type": "string"
+						},
 						"elements": {
 							"$ref": "#/definitions/stylesElementsPropertiesComplete"
 						},
@@ -2357,7 +2354,10 @@
 						"filter": {},
 						"shadow": {},
 						"outline": {},
-						"css": {},
+						"css": {
+							"description": "Sets custom CSS to apply styling not covered by other theme.json properties.",
+							"type": "string"
+						},
 						"elements": {
 							"description": "Styles defined on a per-element basis using the element's selector.",
 							"$ref": "#/definitions/stylesElementsPropertiesComplete"


### PR DESCRIPTION
Fixes #52217

## What?

This PR changes the theme.json schema to not allow the insertion of CSS properties except at the root level of the `styles` property and directly under `styles.blocks`.

## Why?

For now, `css` property are only available in the site root and block and will not work if specified on variations or elements. It would make sense to display a warning according to the schema when a CSS property is defined that does not work.

## How?

Removed `css` property from `stylesProperties `. This is because if this property is present, it will appear as a candidate, even if the `css` property is not allowed.

![candidate](https://github.com/WordPress/gutenberg/assets/54422211/6da9fe7d-29f7-471b-aaec-648756f93935)

Removed `css` property from `stylesElementsPropertiesComplete `and `stylesPropertiesComplete`. This will trigger a warning when `css` properties are defined primarily at the element level.

Instead of removing `css` from `stylesProperties`, add `description` and `type` to `css` properties in `styles` and `stylesPropertiesAndElementsComplete`. This is to display a description when inserting a property and to insert a default empty string when the property is inserted.

![description](https://github.com/WordPress/gutenberg/assets/54422211/9b36682d-62b6-4650-8adf-f4c997d3d1bb)

## Testing Instructions

Create locally a theme.json with the schema directed to this PR:

<details><summary>theme.json sample</summary>

```json
{
	"$schema": "https://raw.githubusercontent.com/WordPress/gutenberg/schema/css-only-block-level/schemas/json/theme.json",
	"version": 2,
	"styles": {
		"css": "",
		"blocks": {
			"core/button": {
				"css": "",
				"elements": {
					"button": {
						"css": "",
						":hover": {
							"css": ""
						}
					},
					"link": {
						"css": "",
						":hover": {
							"css": ""
						}
					}
				},
				"variations": {
					"wide": {
						"css": ""
					}
				}
			},
			"my/custom": {
				"css": "",
				"elements": {
					"css": "",
					"button": {
						":hover": {
							"css": ""
						}
					}
				},
				"variations": {
					"wide": {
						"css": ""
					}
				}
			}
		},
		"elements": {
			"button": {
				"css": "",
				":hover": {
					"css": ""
				}
			},
			"link": {
				"css": "",
				":hover": {
					"css": ""
				}
			}
		}
	}
}
```

</details> 

Use this theme.json file to confirm the following:

- When typing `"css"` under `styles` and `styles.blocks.{blockname}`, a property with a description should appear in the candidate list. If you add a definition, you should not get a warning.
- If you type `"css"` anywhere else, it should not appear as a candidate. If you defined the property manually, you should get a warning.