### PR TITLE
Enhanced color palette group identification with unique slugs

### DIFF
--- a/packages/block-editor/src/components/colors-gradients/use-multiple-origin-colors-and-gradients.js
+++ b/packages/block-editor/src/components/colors-gradients/use-multiple-origin-colors-and-gradients.js
@@ -36,6 +36,7 @@ export default function useMultipleOriginColorsAndGradients() {
 					'Indicates this palette comes from the theme.'
 				),
 				colors: themeColors,
+				slug: 'theme',
 			} );
 		}
 		if (
@@ -49,6 +50,7 @@ export default function useMultipleOriginColorsAndGradients() {
 					'Indicates this palette comes from WordPress.'
 				),
 				colors: defaultColors,
+				slug: 'default',
 			} );
 		}
 		if ( customColors && customColors.length ) {
@@ -58,6 +60,7 @@ export default function useMultipleOriginColorsAndGradients() {
 					'Indicates this palette comes from the theme.'
 				),
 				colors: customColors,
+				slug: 'custom',
 			} );
 		}
 		return result;
@@ -83,6 +86,7 @@ export default function useMultipleOriginColorsAndGradients() {
 					'Indicates this palette comes from the theme.'
 				),
 				gradients: themeGradients,
+				slug: 'theme',
 			} );
 		}
 		if (
@@ -96,6 +100,7 @@ export default function useMultipleOriginColorsAndGradients() {
 					'Indicates this palette comes from WordPress.'
 				),
 				gradients: defaultGradients,
+				slug: 'default',
 			} );
 		}
 		if ( customGradients && customGradients.length ) {
@@ -105,6 +110,7 @@ export default function useMultipleOriginColorsAndGradients() {
 					'Indicates this palette is created by the user.'
 				),
 				gradients: customGradients,
+				slug: 'custom',
 			} );
 		}
 		return result;

--- a/packages/block-editor/src/components/global-styles/hooks.js
+++ b/packages/block-editor/src/components/global-styles/hooks.js
@@ -381,6 +381,7 @@ export function useColorsPerOrigin( settings ) {
 					'Indicates this palette comes from the theme.'
 				),
 				colors: themeColors,
+				slug: 'theme',
 			} );
 		}
 		if (
@@ -394,6 +395,7 @@ export function useColorsPerOrigin( settings ) {
 					'Indicates this palette comes from WordPress.'
 				),
 				colors: defaultColors,
+				slug: 'default',
 			} );
 		}
 		if ( customColors && customColors.length ) {
@@ -403,6 +405,7 @@ export function useColorsPerOrigin( settings ) {
 					'Indicates this palette is created by the user.'
 				),
 				colors: customColors,
+				slug: 'custom',
 			} );
 		}
 		return result;
@@ -429,6 +432,7 @@ export function useGradientsPerOrigin( settings ) {
 					'Indicates this palette comes from the theme.'
 				),
 				gradients: themeGradients,
+				slug: 'theme',
 			} );
 		}
 		if (
@@ -442,6 +446,7 @@ export function useGradientsPerOrigin( settings ) {
 					'Indicates this palette comes from WordPress.'
 				),
 				gradients: defaultGradients,
+				slug: 'default',
 			} );
 		}
 		if ( customGradients && customGradients.length ) {
@@ -451,6 +456,7 @@ export function useGradientsPerOrigin( settings ) {
 					'Indicates this palette is created by the user.'
 				),
 				gradients: customGradients,
+				slug: 'custom',
 			} );
 		}
 		return result;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
This PR adds a `slug` property to the color palette groups returned by:

- `useMultipleOriginColorsAndGradients`
- `useColorsPerOrigin`

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
When using the hooks `useMultipleOriginColorsAndGradients` and `useColorsPerOrigin` to get the palettes, a number of external factors determine what color palettes are returned (theme settings, SE settings, etc).

Since the hooks give us an array of available color palettes with just the names and colors, there is no sure way of determining whether the palette is a **theme**, **default** or a **custom** palette. Currently, the available information is only the name, which is translatable, which makes it an unreliable way to identify the color palette.

This enhancement is helpful for devs who want to use the hooks and identify the palettes - useful for filtering them, etc

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
This PR adds a `slug` property to each color palette object with the value `theme`, `default` or `custom`

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
Editor site:
1. Open a post or page
2. Insert a heading block
3. Change the text/background color of the block, try solid and gradient colors, you should be able to add it normally.

Hooks side:
The color palette objects in the array returned by the hooks `useMultipleOriginColorsAndGradients` and `useColorsPerOrigin` should now include a `slug` property.
