### PR TITLE
Patterns: add a custom taxonomy for user created patterns

### DIFF
--- a/lib/compat/wordpress-6.4/block-patterns.php
+++ b/lib/compat/wordpress-6.4/block-patterns.php
@@ -28,6 +28,7 @@ function gutenberg_register_taxonomy_patterns() {
 		'show_admin_column' => true,
 		'query_var'         => true,
 		'show_in_rest'      => true,
+		'_builtin'          => true,
 		'rewrite'           => array( 'slug' => 'wp_pattern_category' ),
 	);
 	register_taxonomy( 'wp_pattern_category', array( 'wp_block' ), $args );

--- a/lib/compat/wordpress-6.4/block-patterns.php
+++ b/lib/compat/wordpress-6.4/block-patterns.php
@@ -15,7 +15,7 @@
  * @return void
  */
 function gutenberg_register_taxonomy_patterns() {
-	$args   = array(
+	$args = array(
 		array(
 			'public'            => false,
 			'hierarchical'      => false,
@@ -29,7 +29,7 @@ function gutenberg_register_taxonomy_patterns() {
 			'_builtin'          => true,
 			'show_in_nav_menus' => false,
 			'show_in_rest'      => true,
-		)
+		),
 	);
 	register_taxonomy( 'wp_pattern_category', array( 'wp_block' ), $args );
 }

--- a/lib/compat/wordpress-6.4/block-patterns.php
+++ b/lib/compat/wordpress-6.4/block-patterns.php
@@ -15,21 +15,21 @@
  * @return void
  */
 function gutenberg_register_taxonomy_patterns() {
-	$labels = array(
-		'name'          => _x( 'Pattern Categories', 'taxonomy general name' ),
-		'singular_name' => _x( 'Pattern Category', 'taxonomy singular name' ),
-	);
 	$args   = array(
-		'hierarchical'      => false,
-		'labels'            => $labels,
-		'show_ui'           => true,
-		'show_in_menu'      => false,
-		'show_in_nav_menus' => false,
-		'show_admin_column' => true,
-		'query_var'         => true,
-		'show_in_rest'      => true,
-		'_builtin'          => true,
-		'rewrite'           => array( 'slug' => 'wp_pattern_category' ),
+		array(
+			'public'            => false,
+			'hierarchical'      => false,
+			'labels'            => array(
+				'name'          => _x( 'Pattern Categories', 'taxonomy general name' ),
+				'singular_name' => _x( 'Pattern Category', 'taxonomy singular name' ),
+			),
+			'query_var'         => false,
+			'rewrite'           => false,
+			'show_ui'           => false,
+			'_builtin'          => true,
+			'show_in_nav_menus' => false,
+			'show_in_rest'      => true,
+		)
 	);
 	register_taxonomy( 'wp_pattern_category', array( 'wp_block' ), $args );
 }

--- a/lib/compat/wordpress-6.4/block-patterns.php
+++ b/lib/compat/wordpress-6.4/block-patterns.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Overrides Core's wp-includes/block-patterns.php to add new wp_patterns taxonomy for WP 6.4.
+ *
+ * @package gutenberg
+ */
+
+/**
+ * Adds a new taxonomy for organizing user created patterns.
+ *
+ * Note: This should be removed when the minimum required WP version is >= 6.4.
+ *
+ * @see https://github.com/WordPress/gutenberg/pull/51144
+ *
+ * @return void
+ */
+function gutenberg_register_taxonomy_patterns() {
+	$labels = array(
+		'name'          => _x( 'Pattern Categories', 'taxonomy general name' ),
+		'singular_name' => _x( 'Pattern Category', 'taxonomy singular name' ),
+	);
+	$args   = array(
+		'hierarchical'      => false,
+		'labels'            => $labels,
+		'show_ui'           => true,
+		'show_in_menu'      => false,
+		'show_in_nav_menus' => false,
+		'show_admin_column' => true,
+		'query_var'         => true,
+		'show_in_rest'      => true,
+		'rewrite'           => array( 'slug' => 'wp_pattern_custom_category' ),
+	);
+	register_taxonomy( 'wp_pattern_custom_category', array( 'wp_block' ), $args );
+}
+add_action( 'init', 'gutenberg_register_taxonomy_patterns' );

--- a/lib/compat/wordpress-6.4/block-patterns.php
+++ b/lib/compat/wordpress-6.4/block-patterns.php
@@ -28,8 +28,8 @@ function gutenberg_register_taxonomy_patterns() {
 		'show_admin_column' => true,
 		'query_var'         => true,
 		'show_in_rest'      => true,
-		'rewrite'           => array( 'slug' => 'wp_pattern_custom_category' ),
+		'rewrite'           => array( 'slug' => 'wp_pattern_category' ),
 	);
-	register_taxonomy( 'wp_pattern_custom_category', array( 'wp_block' ), $args );
+	register_taxonomy( 'wp_pattern_category', array( 'wp_block' ), $args );
 }
 add_action( 'init', 'gutenberg_register_taxonomy_patterns' );

--- a/lib/compat/wordpress-6.4/block-patterns.php
+++ b/lib/compat/wordpress-6.4/block-patterns.php
@@ -10,7 +10,7 @@
  *
  * Note: This should be removed when the minimum required WP version is >= 6.4.
  *
- * @see https://github.com/WordPress/gutenberg/pull/51144
+ * @see https://github.com/WordPress/gutenberg/pull/53163
  *
  * @return void
  */

--- a/lib/load.php
+++ b/lib/load.php
@@ -121,6 +121,7 @@ require_once __DIR__ . '/compat/wordpress-6.3/kses.php';
 
 // WordPress 6.4 compat.
 require __DIR__ . '/compat/wordpress-6.4/blocks.php';
+require __DIR__ . '/compat/wordpress-6.4/block-patterns.php';
 
 // Experimental features.
 require __DIR__ . '/experimental/block-editor-settings-mobile.php';


### PR DESCRIPTION
## What?
Adds a custom taxonomy to allow users to organize the synced and unsynced patterns that they create.

## Why?
Currently there is no way for users to classify their own patterns.
This would be step one to implement https://github.com/WordPress/gutenberg/issues/53164 - see further discussion there.

## How?
Adds a standard WP custom taxonomy called `wp_pattern_custom_category`.

Currently this just adds the base taxonomy. The post and site editor UI to make use of the UI will be added in follow-up PRs if this approach of using a custom taxonomy is accepted.

## Testing Instructions

- Go to `/wp-admin/edit.php?post_type=wp_block` and add a new pattern
- Make sure the Category option appears in the right settings panel and that you can add new categories

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/3629020/63895ddc-415a-4fea-ac7a-177813d138a4


