### PR TITLE
[WIP] Site Editor: Allow display of pattern blocks for Pages

### DIFF
--- a/packages/edit-site/src/components/page-content-focus-manager/disable-non-page-content-blocks.js
+++ b/packages/edit-site/src/components/page-content-focus-manager/disable-non-page-content-blocks.js
@@ -32,7 +32,6 @@ export default function DisableNonPageContentBlocks() {
  * Disables non-content blocks using the `useBlockEditingMode` hook.
  */
 export function useDisableNonPageContentBlocks() {
-	useBlockEditingMode( 'disabled' );
 	useEffect( () => {
 		addFilter(
 			'editor.BlockEdit',
@@ -53,7 +52,8 @@ const withDisableNonPageContentBlocks = createHigherOrderComponent(
 		const isPageContent =
 			PAGE_CONTENT_BLOCK_TYPES.includes( props.name ) &&
 			! isDescendentOfQueryLoop;
-		const mode = isPageContent ? 'contentOnly' : undefined;
+		const mode = isPageContent ? 'contentOnly' : 'disabled';
+
 		useBlockEditingMode( mode );
 		return <BlockEdit { ...props } />;
 	},


### PR DESCRIPTION
Related:
- https://github.com/WordPress/gutenberg/issues/52983

**NOTE: This isn't really a full solution but more a starting point for further debugging.**

_With this PR's tweak applied `wp:pattern` blocks in templates will display for Pages in the Site Editor. Unfortunately, template parts that reference `wp:pattern` blocks provided via themes still appear to not render_

## What?

Allow display of `wp:pattern` block when displaying a Page in the Site Editor.

## Why?

Without this, any Page using a Template containing a theme or core pattern will not render the pattern when visited via the Site Editor.

## How?

Relocate the disabling of block editing to the HoC for the `editor.BlockEdit` filter.

## Testing Instructions

- Using TwentyTwentyThree theme.
- Create custom template. in themes/twentytwentythree/templates/my-template.html
```
<!-- wp:pattern {"slug":"twentytwentythree/cta"} /-->
```
- Apply My Template to any page.
- Open Site Editor > Pages.
- Open the page to which you have applied My Template.
- Confirm the call to action pattern has been rendered


## Screenshots or screencast <!-- if applicable -->
