### PR TITLE
Navigation Sidebar: Add the fallback navigation to the template part

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen-pattern/use-navigation-menu-content.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-pattern/use-navigation-menu-content.js
@@ -78,10 +78,22 @@ export default function useNavigationMenuContent( postType, postId ) {
 	}
 
 	const { getNavigationFallbackId } = unlock( selectedCoreStore );
-	const navigationMenuIds = navigationBlocks?.map( ( block ) =>
-		// If the block doesn't have a ref, assume that it's the fallback navigation.
-		block.attributes.ref ? block.attributes.ref : getNavigationFallbackId()
-	);
+	const navigationMenuIds = navigationBlocks?.map( ( block ) => {
+		// There are three different states the block can be in:
+		// 1. The bloch is synced which means it had a ref attribute:
+		if ( block.attributes.ref ) {
+			return block.attributes.ref;
+		}
+
+		// 2. The block has defined inner blocks:
+		if ( block.innerBlocks.length > 0 ) {
+			return null;
+		}
+
+		// 3. The block has no inner blocks and no ref attribute, in which case
+		//	we use the fallback navigation menu id:
+		return getNavigationFallbackId();
+	} );
 
 	// Dedupe the Navigation blocks, as you can have multiple navigation blocks in the template.
 	// Also, filter out undefined values, as blocks don't have an id when initially added.

--- a/packages/edit-site/src/components/sidebar-navigation-screen-pattern/use-navigation-menu-content.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-pattern/use-navigation-menu-content.js
@@ -2,12 +2,15 @@
  * WordPress dependencies
  */
 import { parse } from '@wordpress/blocks';
+import { store as coreStore } from '@wordpress/core-data';
+import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
 import TemplatePartNavigationMenus from './template-part-navigation-menus';
 import useEditedEntityRecord from '../use-edited-entity-record';
+import { unlock } from '../../lock-unlock';
 
 /**
  * Retrieves a list of specific blocks from a given tree of blocks.
@@ -51,6 +54,7 @@ function getBlocksOfTypeFromBlocks( targetBlockType, blocks ) {
 
 export default function useNavigationMenuContent( postType, postId ) {
 	const { record } = useEditedEntityRecord( postType, postId );
+	const { getNavigationFallbackId } = unlock( useSelect( coreStore ) );
 
 	// Only managing navigation menus in template parts is supported
 	// to match previous behaviour. This could potentially be expanded
@@ -73,8 +77,9 @@ export default function useNavigationMenuContent( postType, postId ) {
 		return;
 	}
 
-	const navigationMenuIds = navigationBlocks?.map(
-		( block ) => block.attributes.ref
+	const navigationMenuIds = navigationBlocks?.map( ( block ) =>
+		// If the block doesn't have a ref, assume that it's the fallback navigation.
+		block.attributes.ref ? block.attributes.ref : getNavigationFallbackId()
 	);
 
 	// Dedupe the Navigation blocks, as you can have multiple navigation blocks in the template.

--- a/packages/edit-site/src/components/sidebar-navigation-screen-pattern/use-navigation-menu-content.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-pattern/use-navigation-menu-content.js
@@ -54,7 +54,7 @@ function getBlocksOfTypeFromBlocks( targetBlockType, blocks ) {
 
 export default function useNavigationMenuContent( postType, postId ) {
 	const { record } = useEditedEntityRecord( postType, postId );
-	const { getNavigationFallbackId } = unlock( useSelect( coreStore ) );
+	const selectedCoreStore = useSelect( coreStore );
 
 	// Only managing navigation menus in template parts is supported
 	// to match previous behaviour. This could potentially be expanded
@@ -77,6 +77,7 @@ export default function useNavigationMenuContent( postType, postId ) {
 		return;
 	}
 
+	const { getNavigationFallbackId } = unlock( selectedCoreStore );
 	const navigationMenuIds = navigationBlocks?.map( ( block ) =>
 		// If the block doesn't have a ref, assume that it's the fallback navigation.
 		block.attributes.ref ? block.attributes.ref : getNavigationFallbackId()


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Restores the navigation sidebar to template parts when the navigation block is in fallback mode.

## Why?
When the navigation block is displaying a fallback, it doesn't have a ref attribute, which means the template sidebar doesn't know which navigation to display. This PR assumes that navigation blocks without a ref must be using the fallback, and therefore loads the fallback in the sidebar.

## How?
Fetch the fallback and display it in the sidebar.

## Testing Instructions
1. Open the site editor
2. Open a template part that contains a navigation block without a set ref attribute (most themes do this in their header).
3. You should see the navigation in the sidebar
 
## Screenshots or screencast <!-- if applicable -->
<img width="1761" alt="Screenshot 2023-07-31 at 10 19 22" src="https://github.com/WordPress/gutenberg/assets/275961/c740774f-1b8d-424d-82da-9e6686a12be9">



## Note:
I had to commit with a no-verify flag because if I have a variable which is dependent on a hook, defining at the start of the function results in this linting error:

```
Variables should not be assigned until just prior its first reference. An early return statement may leave this variable unused 
```
But if I define it later in the file I get this error:

```
Warning: React has detected a change in the order of Hooks called by SidebarNavigationScreenPattern. This will lead to bugs and errors if not fixed. For more information, read the Rules of Hooks: https://reactjs.org/link/rules-of-hooks
```