### PR TITLE
Fix not expanding pattern in page editor

### DIFF
--- a/packages/edit-site/src/components/page-content-focus-manager/disable-non-page-content-blocks.js
+++ b/packages/edit-site/src/components/page-content-focus-manager/disable-non-page-content-blocks.js
@@ -49,7 +49,7 @@ export function useDisableNonPageContentBlocks() {
 
 const withDisableNonPageContentBlocks = createHigherOrderComponent(
 	( BlockEdit ) => ( props ) => {
-		const isDescendentOfQueryLoop = !! props.context.queryId;
+		const isDescendentOfQueryLoop = props.context.queryId !== undefined;
 		const isPageContent =
 			PAGE_CONTENT_BLOCK_TYPES.includes( props.name ) &&
 			! isDescendentOfQueryLoop;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What and why?
<!-- In a few words, what is the PR actually doing? -->
See #52983.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
The page editor disables edits, which causes `replaceBlocks` in the pattern block to fail silently. This PR temporarily unsets the editing mode before performing the action and then restores it after it's done. I'm not sure if this is the best solution though. This is more like a debug PR than a fix. Feel free to push other solutions directly in this PR!

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
Follow the instructions in #52983.

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/7753001/6a09e310-0399-4573-a6c3-6a4d8b30e062

