### PR TITLE
Pullquote Block: Font size control adding extra padding 

### DIFF
--- a/packages/block-library/src/pullquote/style.scss
+++ b/packages/block-library/src/pullquote/style.scss
@@ -1,5 +1,4 @@
 .wp-block-pullquote {
-	padding: 3em 0;
 	text-align: center; // Default text-alignment where the `textAlign` attribute value isn't specified.
 	overflow-wrap: break-word; // Break long strings of text without spaces so they don't overflow the block.
 	box-sizing: border-box;


### PR DESCRIPTION
**Description**
In the Typography Section of the Pullquote block the size attribute setting is not working as expected. It is giving the padding on top and bottom instead of only increasing/decreasing the font size.

**Step-by-step reproduction instructions**
Add Pullquote Block
2.Open Typography section from the Inspector Controls
3.Tried to change the Size

**Screenshots, screen recording, code snippet**
Video : https://www.loom.com/share/53b069c1cd564a54ad01ea0cef8a8c17?sid=3a6b243e-f66e-40f8-9baa-3804f9a9c54a