### PR TITLE
Popover: Fix iframe story and add test

### DIFF
--- a/packages/components/src/popover/stories/index.tsx
+++ b/packages/components/src/popover/stories/index.tsx
@@ -14,8 +14,8 @@ import { __unstableIframe as Iframe } from '@wordpress/block-editor';
  * Internal dependencies
  */
 import Button from '../../button';
-import { Provider as SlotFillProvider } from '../../slot-fill';
 import { Popover } from '..';
+import { PopoverInsideIframeRenderedInExternalSlot } from '../test/utils';
 import type { PopoverProps } from '../types';
 
 const AVAILABLE_PLACEMENTS: PopoverProps[ 'placement' ][] = [
@@ -249,51 +249,7 @@ DynamicHeight.args = {
 export const WithSlotOutsideIframe: ComponentStory< typeof Popover > = (
 	args
 ) => {
-	const anchorRef = useRef( null );
-	const slotName = 'popover-with-slot-outside-iframe';
-
-	return (
-		<SlotFillProvider>
-			<div>
-				{ /* @ts-expect-error Slot is not currently typed on Popover */ }
-				<Popover.Slot name={ slotName } />
-				<Iframe
-					style={ {
-						width: '100%',
-						height: '400px',
-						border: '0',
-						outline: '1px solid purple',
-					} }
-				>
-					<div
-						style={ {
-							height: '200vh',
-							paddingTop: '10vh',
-						} }
-					>
-						<p
-							style={ {
-								padding: '8px',
-								background: 'salmon',
-								maxWidth: '200px',
-								marginTop: '100px',
-								marginLeft: 'auto',
-								marginRight: 'auto',
-							} }
-							ref={ anchorRef }
-						>
-							Popover&apos;s anchor
-						</p>
-						<Popover
-							{ ...args }
-							__unstableSlotName={ slotName }
-							anchorRef={ anchorRef }
-						/>
-					</div>
-				</Iframe>
-			</div>
-		</SlotFillProvider>
-	);
+	return <PopoverInsideIframeRenderedInExternalSlot { ...args } />;
 };
 WithSlotOutsideIframe.args = {
 	...Default.args,

--- a/packages/components/src/popover/test/index.tsx
+++ b/packages/components/src/popover/test/index.tsx
@@ -19,6 +19,7 @@ import {
 } from '../utils';
 import Popover from '..';
 import type { PopoverProps } from '../types';
+import { PopoverInsideIframeRenderedInExternalSlot } from './utils';
 
 type PositionToPlacementTuple = [
 	NonNullable< PopoverProps[ 'position' ] >,
@@ -172,6 +173,19 @@ describe( 'Popover', () => {
 
 				expect( document.body ).toHaveFocus();
 			} );
+		} );
+	} );
+
+	describe( 'Slot outside iframe', () => {
+		it( 'should support cross-document rendering', async () => {
+			render(
+				<PopoverInsideIframeRenderedInExternalSlot>
+					<span>content</span>
+				</PopoverInsideIframeRenderedInExternalSlot>
+			);
+			await waitFor( async () =>
+				expect( screen.getByText( 'content' ) ).toBeVisible()
+			);
 		} );
 	} );
 

--- a/packages/components/src/popover/test/utils.tsx
+++ b/packages/components/src/popover/test/utils.tsx
@@ -1,0 +1,83 @@
+/**
+ * WordPress dependencies
+ */
+import { createPortal, useEffect, useRef, useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import Popover from '..';
+import { Provider as SlotFillProvider } from '../../slot-fill';
+import type { WordPressComponentProps } from '../../ui/context';
+
+const GenericIframe = ( {
+	children,
+	...props
+}: WordPressComponentProps< { children: React.ReactNode }, 'iframe' > ) => {
+	const [ isMounted, setIsMounted ] = useState( false );
+	const iframeRef = useRef< HTMLIFrameElement >( null );
+
+	useEffect( () => {
+		setIsMounted( true );
+	}, [] );
+
+	return (
+		<iframe { ...props } title="My Iframe" ref={ iframeRef }>
+			{ isMounted &&
+				iframeRef.current?.contentWindow &&
+				createPortal(
+					children,
+					iframeRef.current.contentWindow.document.body
+				) }
+		</iframe>
+	);
+};
+
+export const PopoverInsideIframeRenderedInExternalSlot = (
+	props: React.ComponentProps< typeof Popover >
+) => {
+	const SLOT_NAME = 'my-slot';
+	const [ anchorRef, setAnchorRef ] =
+		useState< HTMLParagraphElement | null >();
+
+	return (
+		<SlotFillProvider>
+			{ /* @ts-expect-error Slot is not currently typed on Popover */ }
+			<Popover.Slot name={ SLOT_NAME } />
+			<GenericIframe
+				style={ {
+					width: '100%',
+					height: '400px',
+					border: '0',
+					outline: '1px solid purple',
+				} }
+			>
+				<div
+					style={ {
+						height: '200vh',
+						paddingTop: '10vh',
+					} }
+				>
+					<p
+						style={ {
+							padding: '8px',
+							background: 'salmon',
+							maxWidth: '200px',
+							marginTop: '100px',
+							marginLeft: 'auto',
+							marginRight: 'auto',
+						} }
+						ref={ setAnchorRef }
+					>
+						Popover&apos;s anchor
+					</p>
+					<Popover
+						{ ...props }
+						__unstableSlotName={ SLOT_NAME }
+						anchor={ anchorRef }
+					/>
+				</div>
+			</GenericIframe>
+		</SlotFillProvider>
+	);
+};

--- a/packages/components/src/popover/test/utils.tsx
+++ b/packages/components/src/popover/test/utils.tsx
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { createPortal, useEffect, useRef, useState } from '@wordpress/element';
+import { createPortal, useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -14,20 +14,16 @@ const GenericIframe = ( {
 	children,
 	...props
 }: WordPressComponentProps< { children: React.ReactNode }, 'iframe' > ) => {
-	const [ isMounted, setIsMounted ] = useState( false );
-	const iframeRef = useRef< HTMLIFrameElement >( null );
-
-	useEffect( () => {
-		setIsMounted( true );
-	}, [] );
+	const [ iframeRef, setIframeRef ] = useState< HTMLIFrameElement | null >(
+		null
+	);
 
 	return (
-		<iframe { ...props } title="My Iframe" ref={ iframeRef }>
-			{ isMounted &&
-				iframeRef.current?.contentWindow &&
+		<iframe { ...props } title="My Iframe" ref={ setIframeRef }>
+			{ iframeRef?.contentWindow &&
 				createPortal(
 					children,
-					iframeRef.current.contentWindow.document.body
+					iframeRef?.contentWindow.document.body
 				) }
 		</iframe>
 	);
@@ -37,8 +33,9 @@ export const PopoverInsideIframeRenderedInExternalSlot = (
 	props: React.ComponentProps< typeof Popover >
 ) => {
 	const SLOT_NAME = 'my-slot';
-	const [ anchorRef, setAnchorRef ] =
-		useState< HTMLParagraphElement | null >();
+	const [ anchorRef, setAnchorRef ] = useState< HTMLParagraphElement | null >(
+		null
+	);
 
 	return (
 		<SlotFillProvider>

--- a/packages/components/src/popover/test/utils/index.tsx
+++ b/packages/components/src/popover/test/utils/index.tsx
@@ -6,9 +6,9 @@ import { createPortal, useState } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import Popover from '..';
-import { Provider as SlotFillProvider } from '../../slot-fill';
-import type { WordPressComponentProps } from '../../ui/context';
+import Popover from '../..';
+import { Provider as SlotFillProvider } from '../../../slot-fill';
+import type { WordPressComponentProps } from '../../../ui/context';
 
 const GenericIframe = ( {
 	children,

--- a/packages/components/src/popover/test/utils/index.tsx
+++ b/packages/components/src/popover/test/utils/index.tsx
@@ -14,17 +14,23 @@ const GenericIframe = ( {
 	children,
 	...props
 }: WordPressComponentProps< { children: React.ReactNode }, 'iframe' > ) => {
-	const [ iframeRef, setIframeRef ] = useState< HTMLIFrameElement | null >(
-		null
-	);
+	const [ containerNode, setContainerNode ] = useState< HTMLElement >();
 
 	return (
-		<iframe { ...props } title="My Iframe" ref={ setIframeRef }>
-			{ iframeRef?.contentWindow &&
-				createPortal(
-					children,
-					iframeRef?.contentWindow.document.body
-				) }
+		<iframe
+			{ ...props }
+			title="My Iframe"
+			// Waiting for the load event ensures that this works in Firefox.
+			// See https://github.com/facebook/react/issues/22847#issuecomment-991394558
+			onLoad={ ( event ) => {
+				if ( event.currentTarget.contentDocument ) {
+					setContainerNode(
+						event.currentTarget.contentDocument.body
+					);
+				}
+			} }
+		>
+			{ containerNode && createPortal( children, containerNode ) }
 		</iframe>
 	);
 };

--- a/packages/components/src/popover/test/utils/index.tsx
+++ b/packages/components/src/popover/test/utils/index.tsx
@@ -20,6 +20,7 @@ const GenericIframe = ( {
 		<iframe
 			{ ...props }
 			title="My Iframe"
+			srcDoc="<!doctype html><html><body></body></html>"
 			// Waiting for the load event ensures that this works in Firefox.
 			// See https://github.com/facebook/react/issues/22847#issuecomment-991394558
 			onLoad={ ( event ) => {


### PR DESCRIPTION
## What?

Fixes the ["With Slot Outside Iframe" story](https://wordpress.github.io/gutenberg/?path=/story/components-popover--with-slot-outside-iframe) of the Popover component in Storybook.

I also added a unit test to ensure that the cross-document rendering is working as expected. This test is also a good first step in unblocking our version-pinned `floating-ui` dependency (#48402).

## Why?

This story was originally (#42903) written using the `Iframe` component in `@wordpress/block-editor`. In #46706, there was an implementation change in this `Iframe` component that introduced some [conditional rendering logic](https://github.com/WordPress/gutenberg/pull/46706/files?w=1#diff-ab17abd38e687edd56573694ae3017e105e96b319571c190e9d4705c1872bc9cR304-R317) that relied on the block editor store. This change broke the isolated example in Storybook, and made the `Iframe` component unsuitable for non-WP usage.

## How?

I replaced the `Iframe` component with a generic iframe component that is suitable for isolated testing.

## Testing Instructions

✅ Tests pass

1. `npm run storybook:dev`
2. Go to the [Popover "With Slot Outside Iframe"](http://localhost:50240/?path=/story/components-popover--with-slot-outside-iframe) story in Storybook and see that it works again.

## Screenshots or screencast <!-- if applicable -->

### Expected story

https://github.com/WordPress/gutenberg/assets/555336/3e0dc48d-f1e8-42d6-96e4-d12511cfa65e
