### PR TITLE
Image block: fix image size at wide and full width

### DIFF
--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -566,9 +566,9 @@ export default function Image( {
 				className={ borderProps.className }
 				style={ {
 					width:
-						( width && height ) || aspectRatio ? '100%' : 'inherit',
+						( width && height ) || aspectRatio ? '100%' : undefined,
 					height:
-						( width && height ) || aspectRatio ? '100%' : 'inherit',
+						( width && height ) || aspectRatio ? '100%' : undefined,
 					objectFit: scale,
 					...borderProps.style,
 				} }


### PR DESCRIPTION
Fixes #53173

## What?
This PR fixes a problem with images not being properly widened when wide or full width is set in the image block.

## Why?

When the image block is wide or full width, width:100% should be applied to the `img` element as seen in this style.

https://github.com/WordPress/gutenberg/blob/16f95a82a15927626380576ca0455c85a2e3c574/packages/block-library/src/image/style.scss#L30-L34

However, if the image element has neither width, height, nor aspect ratio, the width and height properties of the `img` element will be `inherit`. As a result, I believe the width and height are implicitly `auto`, and the intended style is not applied.

![image-inherit](https://github.com/WordPress/gutenberg/assets/54422211/a4450768-1b60-4386-9280-0f1db657c10e)

## How?

Changed from `inherited` to `undefined`. This should apply the appropriate style depending on the context of the image size.

## Testing Instructions

- Add am image block.
- Set the image to wide or full width.
- The image should be widened to the appropriate width.
- However, the Aspect Ratio or cale controls should function properly even if they are wide or full width.

Note: I don't think it is intended that the width and height controls appear when wide or full width is used. I'm attempting to fix this issue in #53181.

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/54422211/a838b1ed-2c25-472c-a4a5-b270df299f06

