### PR TITLE
Enforce Labels Workflow: Treat "Backports from WordPress Core" as allowable label

### DIFF
--- a/.github/workflows/enforce-pr-labels.yml
+++ b/.github/workflows/enforce-pr-labels.yml
@@ -12,7 +12,7 @@ jobs:
               with:
                   mode: exactly
                   count: 1
-                  labels: '[Type] Accessibility (a11y), [Type] Automated Testing, [Type] Breaking Change, [Type] Bug, [Type] Build Tooling, [Type] Code Quality, [Type] Copy, [Type] Developer Documentation, [Type] Enhancement, [Type] Experimental, [Type] Feature, [Type] New API, [Type] Task, [Type] Performance, [Type] Project Management, [Type] Regression, [Type] Security, [Type] WP Core Ticket'
+                  labels: '[Type] Accessibility (a11y), [Type] Automated Testing, [Type] Breaking Change, [Type] Bug, [Type] Build Tooling, [Type] Code Quality, [Type] Copy, [Type] Developer Documentation, [Type] Enhancement, [Type] Experimental, [Type] Feature, [Type] New API, [Type] Task, [Type] Performance, [Type] Project Management, [Type] Regression, [Type] Security, [Type] WP Core Ticket, Backport from WordPress Core'
                   add_comment: true
                   message: "## ⚠️ Type of PR label error\n To merge this PR, it requires {{ errorString }} {{ count }} label indicating the type of PR. Other labels are optional and not being checked here. \n- **Type-related labels to choose from**: {{ provided }}.\n- **Labels found**: {{ applied }}.\n\nYou can learn more about the Type labels in Gutenberg [here](https://github.com/WordPress/gutenberg/labels?q=type)"
                   exit_type: failure


### PR DESCRIPTION
## What?

None of the existing "[Type]" labels describe a backport, though one describes code that requires backporting into Core.

In this change the backport label satisfies the labeling requirement. Alternatively a new "[Type] Backport from WordPress Core" label could be created, but that would imply requiring two practically identical labels for each backport PR.

## Why?
The workflow is currently rejecting PRs for missing a required label, but I found no appropriate label to satisfy the workflow. We should not block work while providing no path to unblock that work.

## How?
Adds the existing backport label as an acceptable label.