### PR TITLE
Patterns: fix color and behavior of unsynced patterns in block inserter when searching for `reusable`

### DIFF
--- a/packages/block-editor/src/components/inserter-list-item/index.js
+++ b/packages/block-editor/src/components/inserter-list-item/index.js
@@ -49,7 +49,9 @@ function InserterListItem( {
 		];
 	}, [ item.name, item.initialAttributes, item.initialAttributes ] );
 
-	const isSynced = isReusableBlock( item ) || isTemplatePart( item );
+	const isSynced =
+		( isReusableBlock( item ) && item.syncStatus !== 'unsynced' ) ||
+		isTemplatePart( item );
 
 	return (
 		<InserterDraggableBlocks

--- a/packages/block-editor/src/components/inserter/hooks/use-block-types-state.js
+++ b/packages/block-editor/src/components/inserter/hooks/use-block-types-state.js
@@ -5,6 +5,7 @@ import {
 	createBlock,
 	createBlocksFromInnerBlocksTemplate,
 	store as blocksStore,
+	parse,
 } from '@wordpress/blocks';
 import { useSelect } from '@wordpress/data';
 import { useCallback } from '@wordpress/element';
@@ -37,12 +38,20 @@ const useBlockTypesState = ( rootClientId, onInsert ) => {
 	);
 
 	const onSelectItem = useCallback(
-		( { name, initialAttributes, innerBlocks }, shouldFocusBlock ) => {
-			const insertedBlock = createBlock(
-				name,
-				initialAttributes,
-				createBlocksFromInnerBlocksTemplate( innerBlocks )
-			);
+		(
+			{ name, initialAttributes, innerBlocks, syncStatus, content },
+			shouldFocusBlock
+		) => {
+			const insertedBlock =
+				syncStatus === 'unsynced'
+					? parse( content, {
+							__unstableSkipMigrationLogs: true,
+					  } )
+					: createBlock(
+							name,
+							initialAttributes,
+							createBlocksFromInnerBlocksTemplate( innerBlocks )
+					  );
 
 			onInsert( insertedBlock, undefined, shouldFocusBlock );
 		},


### PR DESCRIPTION
## What?
Makes sure unsynced patterns have an uncolored icon when displayed in inserter search results. Also make sure that they get inserted as an unsynced pattern when selected.

## Why?
Currently they show as purple which confuses them with synced patterns.

## How?
Checks the syncStatus of a pattern and don't assign color if `unsynced`. Also, if `unsynced` instert the parsed pattern content rather than the pattern block when selected.

## Testing Instructions

- Add both synced and unsynced patterns in the post editor
- In the inserter search for `reusable` and make sure the unsynced patterns display as black, and synced as purple
- Select both types and make sure synced are inserted as a pattern block and unsynced as standalone blocks 

## Screenshots or screencast <!-- if applicable -->
Before:

https://github.com/WordPress/gutenberg/assets/3629020/d90cf693-4616-494c-8e81-6ac8e7f4b058

After:

https://github.com/WordPress/gutenberg/assets/3629020/6c5d2944-4498-4ff1-93f1-75ed32fddfee


