### PR TITLE
Pattern: Add getBlockRootClientId call

### DIFF
--- a/packages/block-library/src/pattern/edit.js
+++ b/packages/block-library/src/pattern/edit.js
@@ -14,7 +14,7 @@ import {
  */
 import { unlock } from '../lock-unlock';
 
-const PatternEdit = ( { attributes, clientId, rootClientId } ) => {
+const PatternEdit = ( { attributes, clientId } ) => {
 	const selectedPattern = useSelect(
 		( select ) =>
 			select( blockEditorStore ).__experimentalGetParsedPattern(
@@ -26,7 +26,9 @@ const PatternEdit = ( { attributes, clientId, rootClientId } ) => {
 	const { replaceBlocks, __unstableMarkNextChangeAsNotPersistent } =
 		useDispatch( blockEditorStore );
 	const { setBlockEditingMode } = unlock( useDispatch( blockEditorStore ) );
-	const { getBlockEditingMode } = unlock( useSelect( blockEditorStore ) );
+	const { getBlockRootClientId, getBlockEditingMode } = unlock(
+		useSelect( blockEditorStore )
+	);
 
 	// Run this effect when the component loads.
 	// This adds the Pattern's contents to the post.
@@ -40,6 +42,7 @@ const PatternEdit = ( { attributes, clientId, rootClientId } ) => {
 			// because nested pattern blocks cannot be inserted if the parent block supports
 			// inner blocks but doesn't have blockSettings in the state.
 			window.queueMicrotask( () => {
+				const rootClientId = getBlockRootClientId( clientId );
 				// Clone blocks from the pattern before insertion to ensure they receive
 				// distinct client ids. See https://github.com/WordPress/gutenberg/issues/50628.
 				const clonedBlocks = selectedPattern.blocks.map( ( block ) =>
@@ -58,13 +61,13 @@ const PatternEdit = ( { attributes, clientId, rootClientId } ) => {
 			} );
 		}
 	}, [
-		rootClientId,
 		clientId,
 		selectedPattern?.blocks,
 		__unstableMarkNextChangeAsNotPersistent,
 		replaceBlocks,
 		getBlockEditingMode,
 		setBlockEditingMode,
+		getBlockRootClientId,
 	] );
 
 	const props = useBlockProps();


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Follow up to #53169 — move `rootClientId` to being retrieved via `getBlockRootClientId()`

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

As mentioned in https://github.com/WordPress/gutenberg/pull/53169#discussion_r1280084688 by @Mamaduka, `rootClientId` will always be `undefined` as it is not passed in by `BlockEdit`. Thank you spotting that, George! 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Remove `rootClientId` from destructuring, and use `getBlockRootClientId()` in the microtask instead.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Following testing instructions in #53169 and make sure this doesn't introduce any regressions.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
