### PR TITLE
Fix: Snack bar not fixed on certain pages in the Site Editor

### DIFF
--- a/packages/base-styles/_z-index.scss
+++ b/packages/base-styles/_z-index.scss
@@ -189,6 +189,7 @@ $z-layers: (
 	".edit-site-layout__hub": 3,
 	".edit-site-layout__header": 2,
 	".edit-site-page-header": 2,
+	".edit-site-page-content": 1,
 	".edit-site-patterns__header": 2,
 	".edit-site-patterns__grid-pagination": 2,
 	".edit-site-layout__canvas-container": 2,

--- a/packages/edit-site/src/components/page-patterns/style.scss
+++ b/packages/edit-site/src/components/page-patterns/style.scss
@@ -6,14 +6,6 @@
 	padding: 0;
 	overflow-x: auto;
 
-	.edit-site-page-content {
-		height: 100%;
-		position: relative;
-		padding: 0;
-		display: flex;
-		flex-flow: column;
-	}
-
 	.components-base-control {
 		width: 100%;
 		@include break-medium {

--- a/packages/edit-site/src/components/page/index.js
+++ b/packages/edit-site/src/components/page/index.js
@@ -26,17 +26,17 @@ export default function Page( {
 
 	return (
 		<NavigableRegion className={ classes } ariaLabel={ title }>
-			{ ! hideTitleFromUI && title && (
-				<Header
-					title={ title }
-					subTitle={ subTitle }
-					actions={ actions }
-				/>
-			) }
 			<div className="edit-site-page-content">
+				{ ! hideTitleFromUI && title && (
+					<Header
+						title={ title }
+						subTitle={ subTitle }
+						actions={ actions }
+					/>
+				) }
 				{ children }
-				<EditorSnackbars />
 			</div>
+			<EditorSnackbars />
 		</NavigableRegion>
 	);
 }

--- a/packages/edit-site/src/components/page/style.scss
+++ b/packages/edit-site/src/components/page/style.scss
@@ -2,7 +2,7 @@
 	color: $gray-800;
 	background: $white;
 	flex-grow: 1;
-	overflow: auto;
+	overflow: hidden;
 	margin: 0;
 	margin-top: $header-height;
 	@include break-medium() {
@@ -13,8 +13,7 @@
 
 .edit-site-page-header {
 	padding: 0 $grid-unit-40;
-	height: $header-height;
-	padding-left: $grid-unit-40;
+	min-height: $header-height;
 	border-bottom: 1px solid $gray-100;
 	background: $white;
 	position: sticky;
@@ -33,6 +32,10 @@
 }
 
 .edit-site-page-content {
-	padding: $grid-unit-40 $grid-unit-40;
-	overflow-x: auto;
+	height: 100%;
+	display: flex;
+	overflow: auto;
+	flex-flow: column;
+	position: relative;
+	z-index: z-index(".edit-site-page-content");
 }

--- a/packages/edit-site/src/components/table/style.scss
+++ b/packages/edit-site/src/components/table/style.scss
@@ -1,5 +1,6 @@
 .edit-site-table-wrapper {
 	width: 100%;
+	padding: $grid-unit-40;
 }
 
 .edit-site-table {


### PR DESCRIPTION
Fixes #53157

## What?

This PR fixes a problem in the following three pages where the snack bar is also affected by scrolling when the content is scrollable, and always fixes it to the lower left corner of the content.

- Patterns
- All templates
- All template parts

## Why?

As I understand it, the three pages above are rendered by [the Pages component](https://github.com/WordPress/gutenberg/blob/5efce0ecec77fec764c30ce53f6368554ce9eb1a/packages/edit-site/src/components/page/index.js).

In this component, the snack bar is rendered in the following positions:

```html
<div class="edit-site-page">
	<header class="edit-site-page-header"></header>
	<div class="edit-site-page-content">
		<!-- Children -->
		<div class="components-snackbar-list components-editor-notices__snackbar"></div>
	</div>
</div>
```

Because `overflow:auto` is applied to edit-site-page, if the content is higher than the height of the canvas, the content will be scrollable. At the same time, the snack bar is affected by this scrolling because it is a child of `.edit-site-page`.

## How?

I have changed the structure as follows: `.edit-site-page` is not scrollable, only `.edit-site-page-content` is scrollable. The snackbar is not among this scrollable element and is therefore not affected by scrolling.

```html
<div class="edit-site-page">
	<div class="edit-site-page-content">
		<header class="edit-site-page-header"></header>
		<!-- Children -->
	</div>
	<div class="components-snackbar-list components-editor-notices__snackbar"></div>
</div>
```

## Testing Instructions

On pages Patterns, All templates, and All template parts, check the following:

- The layout should be exactly the same.
- As before, if the content is larger than the height of the canvas, it should be scrollable.
- The snackbar displayed when renaming, etc., should not be affected by scrolling.

## Screenshots or screencast <!-- if applicable -->

### Desktop

https://github.com/WordPress/gutenberg/assets/54422211/0c12b94f-3fd3-46de-95e5-baf384cbb70a

### Mobile

Note: The mobile view is currently unable to display All templates and All template parts page. This issue is reported in #49769.

https://github.com/WordPress/gutenberg/assets/54422211/291b4f06-ce53-44af-b200-dbe1f56fb172

