### PR TITLE
Patterns: Open detail view when duplicating pattern

### DIFF
--- a/packages/edit-site/src/components/page-patterns/duplicate-menu-item.js
+++ b/packages/edit-site/src/components/page-patterns/duplicate-menu-item.js
@@ -78,8 +78,8 @@ export default function DuplicateMenuItem( {
 			createSuccessNotice(
 				sprintf(
 					// translators: %s: The new template part's title e.g. 'Call to action (copy)'.
-					__( '"%s" created.' ),
-					title
+					__( 'Duplicated "%s"' ),
+					item.title
 				),
 				{
 					type: 'snackbar',
@@ -137,8 +137,8 @@ export default function DuplicateMenuItem( {
 			createSuccessNotice(
 				sprintf(
 					// translators: %s: The new pattern's title e.g. 'Call to action (copy)'.
-					__( '"%s" added to my patterns.' ),
-					title
+					__( 'Duplicated "%s"' ),
+					item.title
 				),
 				{
 					type: 'snackbar',

--- a/packages/edit-site/src/components/page-patterns/duplicate-menu-item.js
+++ b/packages/edit-site/src/components/page-patterns/duplicate-menu-item.js
@@ -48,8 +48,7 @@ export default function DuplicateMenuItem( {
 	onClose,
 } ) {
 	const { saveEntityRecord } = useDispatch( coreStore );
-	const { createErrorNotice, createSuccessNotice } =
-		useDispatch( noticesStore );
+	const { createErrorNotice } = useDispatch( noticesStore );
 
 	const history = useHistory();
 	const existingTemplateParts = useExistingTemplateParts();
@@ -75,29 +74,12 @@ export default function DuplicateMenuItem( {
 				{ throwOnError: true }
 			);
 
-			createSuccessNotice(
-				sprintf(
-					// translators: %s: The new template part's title e.g. 'Call to action (copy)'.
-					__( '"%s" created.' ),
-					title
-				),
-				{
-					type: 'snackbar',
-					id: 'edit-site-patterns-success',
-					actions: [
-						{
-							label: __( 'Edit' ),
-							onClick: () =>
-								history.push( {
-									postType: TEMPLATE_PARTS,
-									postId: result?.id,
-									categoryType: TEMPLATE_PARTS,
-									categoryId,
-								} ),
-						},
-					],
-				}
-			);
+			history.push( {
+				postType: TEMPLATE_PARTS,
+				postId: result?.id,
+				categoryType: TEMPLATE_PARTS,
+				categoryId,
+			} );
 
 			onClose();
 		} catch ( error ) {
@@ -139,40 +121,12 @@ export default function DuplicateMenuItem( {
 				{ throwOnError: true }
 			);
 
-			const actionLabel = isThemePattern
-				? __( 'View my patterns' )
-				: __( 'Edit' );
-
-			const newLocation = isThemePattern
-				? {
-						categoryType: USER_PATTERNS,
-						categoryId: USER_PATTERN_CATEGORY,
-						path: '/patterns',
-				  }
-				: {
-						categoryType: USER_PATTERNS,
-						categoryId: USER_PATTERN_CATEGORY,
-						postType: USER_PATTERNS,
-						postId: result?.id,
-				  };
-
-			createSuccessNotice(
-				sprintf(
-					// translators: %s: The new pattern's title e.g. 'Call to action (copy)'.
-					__( '"%s" added to my patterns.' ),
-					title
-				),
-				{
-					type: 'snackbar',
-					id: 'edit-site-patterns-success',
-					actions: [
-						{
-							label: actionLabel,
-							onClick: () => history.push( newLocation ),
-						},
-					],
-				}
-			);
+			history.push( {
+				categoryType: USER_PATTERNS,
+				categoryId: USER_PATTERN_CATEGORY,
+				postType: USER_PATTERNS,
+				postId: result?.id,
+			} );
 
 			onClose();
 		} catch ( error ) {

--- a/packages/edit-site/src/components/page-patterns/duplicate-menu-item.js
+++ b/packages/edit-site/src/components/page-patterns/duplicate-menu-item.js
@@ -48,7 +48,8 @@ export default function DuplicateMenuItem( {
 	onClose,
 } ) {
 	const { saveEntityRecord } = useDispatch( coreStore );
-	const { createErrorNotice } = useDispatch( noticesStore );
+	const { createErrorNotice, createSuccessNotice } =
+		useDispatch( noticesStore );
 
 	const history = useHistory();
 	const existingTemplateParts = useExistingTemplateParts();
@@ -72,6 +73,18 @@ export default function DuplicateMenuItem( {
 				'wp_template_part',
 				{ slug, title, content, area },
 				{ throwOnError: true }
+			);
+
+			createSuccessNotice(
+				sprintf(
+					// translators: %s: The new template part's title e.g. 'Call to action (copy)'.
+					__( '"%s" created.' ),
+					title
+				),
+				{
+					type: 'snackbar',
+					id: 'edit-site-patterns-success',
+				}
 			);
 
 			history.push( {
@@ -119,6 +132,18 @@ export default function DuplicateMenuItem( {
 					title,
 				},
 				{ throwOnError: true }
+			);
+
+			createSuccessNotice(
+				sprintf(
+					// translators: %s: The new pattern's title e.g. 'Call to action (copy)'.
+					__( '"%s" added to my patterns.' ),
+					title
+				),
+				{
+					type: 'snackbar',
+					id: 'edit-site-patterns-success',
+				}
 			);
 
 			history.push( {

--- a/packages/edit-site/src/components/page-patterns/duplicate-menu-item.js
+++ b/packages/edit-site/src/components/page-patterns/duplicate-menu-item.js
@@ -78,7 +78,7 @@ export default function DuplicateMenuItem( {
 			createSuccessNotice(
 				sprintf(
 					// translators: %s: The new template part's title e.g. 'Call to action (copy)'.
-					__( 'Duplicated "%s"' ),
+					__( '"%s" duplicated.' ),
 					item.title
 				),
 				{
@@ -137,7 +137,7 @@ export default function DuplicateMenuItem( {
 			createSuccessNotice(
 				sprintf(
 					// translators: %s: The new pattern's title e.g. 'Call to action (copy)'.
-					__( 'Duplicated "%s"' ),
+					__( '"%s" duplicated.' ),
 					item.title
 				),
 				{


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/52649

## What?

Opens the pattern detail view after duplicating a pattern instead of displaying a success snackbar notice.

## Why?

This might be the more expected flow, see https://github.com/WordPress/gutenberg/issues/52649.

## How?

Replace the success snackbar notices with history push for the pattern's detail view.

## Testing Instructions

1. Open the Site Editor > Patterns page
2. Create a custom pattern
3. Duplicate the pattern and ensure you are taken to the pattern's detail view
4. Navigate back and you should be on the correct patterns category with the duplicated pattern in the grid (assuming no pagination)
5. Select a theme pattern category
6. Duplicate a theme pattern and confirm you are on that new pattern's detail view
7. Navigate back and you should also be on the My Patterns category
8. Select a Template Part category
9. Duplicate a template part and ensure that you are taken to the new template part's detail view
10. Navigate back and you should be on the appropriate template part category


## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/60436221/edead45b-a425-4d68-b7d1-d7b6ce411c06

