### PR TITLE
Mobile - Fix iOS Focus loop for RichText components

### DIFF
--- a/packages/block-editor/src/components/block-list/index.native.js
+++ b/packages/block-editor/src/components/block-list/index.native.js
@@ -1,12 +1,12 @@
 /**
  * External dependencies
  */
-import { View, Platform, TouchableWithoutFeedback } from 'react-native';
+import { View, Platform, Pressable } from 'react-native';
 
 /**
  * WordPress dependencies
  */
-import { useRef, useState } from '@wordpress/element';
+import { useRef, useState, useCallback } from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { createBlock } from '@wordpress/blocks';
 import {
@@ -372,20 +372,20 @@ function Footer( {
 	renderFooterAppender,
 	withFooter,
 } ) {
+	const onAddParagraphBlock = useCallback( () => {
+		const paragraphBlock = createBlock( 'core/paragraph' );
+		addBlockToEndOfPost( paragraphBlock );
+	}, [ addBlockToEndOfPost ] );
+
 	if ( ! isReadOnly && withFooter ) {
 		return (
-			<>
-				<TouchableWithoutFeedback
-					accessibilityLabel={ __( 'Add paragraph block' ) }
-					testID={ __( 'Add paragraph block' ) }
-					onPress={ () => {
-						const paragraphBlock = createBlock( 'core/paragraph' );
-						addBlockToEndOfPost( paragraphBlock );
-					} }
-				>
-					<View style={ styles.blockListFooter } />
-				</TouchableWithoutFeedback>
-			</>
+			<Pressable
+				accessibilityLabel={ __( 'Add paragraph block' ) }
+				testID={ __( 'Add paragraph block' ) }
+				onPress={ onAddParagraphBlock }
+			>
+				<View style={ styles.blockListFooter } />
+			</Pressable>
 		);
 	} else if ( renderFooterAppender ) {
 		return <View>{ renderFooterAppender() }</View>;

--- a/packages/block-editor/src/components/default-block-appender/index.native.js
+++ b/packages/block-editor/src/components/default-block-appender/index.native.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { TouchableWithoutFeedback, View } from 'react-native';
+import { Pressable, View } from 'react-native';
 
 /**
  * WordPress dependencies
@@ -20,6 +20,9 @@ import BlockInsertionPoint from '../block-list/insertion-point';
 import styles from './style.scss';
 import { store as blockEditorStore } from '../../store';
 
+const hitSlop = { top: 22, bottom: 22, left: 22, right: 22 };
+const noop = () => {};
+
 export function DefaultBlockAppender( {
 	isLocked,
 	isVisible,
@@ -37,22 +40,21 @@ export function DefaultBlockAppender( {
 			? decodeEntities( placeholder )
 			: __( 'Start writing…' );
 
+	const appenderStyles = [
+		styles.blockHolder,
+		showSeparator && containerStyle,
+	];
+
 	return (
-		<TouchableWithoutFeedback onPress={ onAppend }>
-			<View
-				style={ [
-					styles.blockHolder,
-					showSeparator && containerStyle,
-				] }
-				pointerEvents="box-only"
-			>
+		<Pressable onPress={ onAppend } hitSlop={ hitSlop }>
+			<View style={ appenderStyles } pointerEvents="box-only">
 				{ showSeparator ? (
 					<BlockInsertionPoint />
 				) : (
-					<RichText placeholder={ value } onChange={ () => {} } />
+					<RichText placeholder={ value } onChange={ noop } />
 				) }
 			</View>
-		</TouchableWithoutFeedback>
+		</Pressable>
 	);
 }
 

--- a/packages/react-native-aztec/src/AztecInputState.js
+++ b/packages/react-native-aztec/src/AztecInputState.js
@@ -117,6 +117,15 @@ export const notifyInputChange = () => {
 };
 
 /**
+ * Sets the current focused element ref held within TextInputState.
+ *
+ * @param {RefObject} element Element to be set as the focused element.
+ */
+export const focusInput = ( element ) => {
+	TextInputState.focusInput( element );
+};
+
+/**
  * Focuses the specified element.
  *
  * @param {RefObject} element Element to be focused.

--- a/packages/react-native-aztec/src/AztecView.js
+++ b/packages/react-native-aztec/src/AztecView.js
@@ -263,16 +263,22 @@ class AztecView extends Component {
 			// - https://github.com/wordpress-mobile/WordPress-Android/issues/16167
 			Platform.OS === 'ios'
 		) {
-			// Programmatically swapping input focus creates an infinite loop if the
-			// user taps a different input in between the programmatic focus and
-			// the resulting update to the React Native TextInputState focused element
-			// ref. To mitigate this, the below updates the focused element ref, but
-			// does not call the native focus methods.
-			//
-			// See: https://github.com/wordpress-mobile/WordPress-iOS/issues/18783
 			this.updateCaretData( event );
+
 			if ( ! this.isFocused() ) {
+				// Programmatically swapping input focus creates an infinite loop if the
+				// user taps a different input in between the programmatic focus and
+				// the resulting update to the React Native TextInputState focused element
+				// ref. To mitigate this, the below updates the focused element ref, but
+				// does not call the native focus methods.
+				//
+				// See: https://github.com/wordpress-mobile/WordPress-iOS/issues/18783
 				AztecInputState.focusInput( this.aztecViewRef.current );
+
+				// Calling _onFocus is needed to trigger provided onFocus callbacks
+				// which are needed to prevent undesired results like having a focused
+				// TextInput when another element has the focus.
+				this._onFocus( event );
 			}
 		}
 	}

--- a/packages/react-native-aztec/src/AztecView.js
+++ b/packages/react-native-aztec/src/AztecView.js
@@ -237,14 +237,40 @@ class AztecView extends Component {
 	}
 
 	_onAztecFocus( event ) {
-		// IMPORTANT: the onFocus events from Aztec are thrown away on Android as these are handled by onPress() in the upper level.
-		// It's necessary to do this otherwise onFocus may be set by `{...otherProps}` and thus the onPress + onFocus
-		// combination generate an infinite loop as described in https://github.com/wordpress-mobile/gutenberg-mobile/issues/302
-		// For iOS, this is necessary to let the system know when Aztec was focused programatically.
-		if ( Platform.OS === 'ios' ) {
+		// IMPORTANT: This function serves two purposes:
+		//
+		// Android: This intentional no-op function prevents focus loops originating
+		// when the native Aztec module programmatically focuses the instance. The
+		// no-op is explicitly passed as an `onFocus` prop to avoid future prop
+		// spreading from inadvertently introducing focus loops. The user-facing
+		// focus of the element is handled by `onPress` instead.
+		//
+		// See: https://github.com/wordpress-mobile/gutenberg-mobile/issues/302
+		//
+		// iOS: Programmatic focus from the native Aztec module is required to
+		// ensure the React-based `TextStateInput` ref is properly set when focus
+		// is *returned* to an instance, e.g. dismissing a bottom sheet. If the ref
+		// is not updated, attempts to dismiss the keyboard via the `ToolbarButton`
+		// will fail.
+		//
+		// See: https://github.com/wordpress-mobile/gutenberg-mobile/issues/702
+		if (
+			// The Android keyboard is, likely erroneously, already dismissed in the
+			// contexts where programmatic focus may be required on iOS.
+			//
+			// - https://github.com/WordPress/gutenberg/issues/28748
+			// - https://github.com/WordPress/gutenberg/issues/29048
+			// - https://github.com/wordpress-mobile/WordPress-Android/issues/16167
+			Platform.OS === 'ios' &&
+			// Programmatic swaping focus from element to another often leads to focus
+			// loops, only delegate the programmatic focus if there are no elements
+			// focused.
+			//
+			// See: https://github.com/wordpress-mobile/WordPress-iOS/issues/18783
+			! AztecInputState.getCurrentFocusedElement()
+		) {
 			this.updateCaretData( event );
-
-			this._onPress( event );
+			this._onPress(); // Call to move the focus in RN way (TextInputState)
 		}
 	}
 
@@ -285,9 +311,7 @@ class AztecView extends Component {
 					onBackspace={ this.props.onKeyDown && this._onBackspace }
 					onKeyDown={ this.props.onKeyDown && this._onKeyDown }
 					deleteEnter={ this.props.deleteEnter }
-					// IMPORTANT: the onFocus events are thrown away as these are handled by onPress() in the upper level.
-					// It's necessary to do this otherwise onFocus may be set by `{...otherProps}` and thus the onPress + onFocus
-					// combination generate an infinite loop as described in https://github.com/wordpress-mobile/gutenberg-mobile/issues/302
+					// IMPORTANT: Do not remove the `onFocus` prop, see `_onAztecFocus`
 					onFocus={ this._onAztecFocus }
 					onBlur={ this._onBlur }
 					ref={ this.aztecViewRef }

--- a/packages/react-native-aztec/src/AztecView.js
+++ b/packages/react-native-aztec/src/AztecView.js
@@ -271,7 +271,9 @@ class AztecView extends Component {
 			//
 			// See: https://github.com/wordpress-mobile/WordPress-iOS/issues/18783
 			this.updateCaretData( event );
-			AztecInputState.focusInput( this.aztecViewRef.current );
+			if ( ! this.isFocused() ) {
+				AztecInputState.focusInput( this.aztecViewRef.current );
+			}
 		}
 	}
 

--- a/packages/react-native-aztec/src/AztecView.js
+++ b/packages/react-native-aztec/src/AztecView.js
@@ -261,16 +261,17 @@ class AztecView extends Component {
 			// - https://github.com/WordPress/gutenberg/issues/28748
 			// - https://github.com/WordPress/gutenberg/issues/29048
 			// - https://github.com/wordpress-mobile/WordPress-Android/issues/16167
-			Platform.OS === 'ios' &&
-			// Programmatic swaping focus from element to another often leads to focus
-			// loops, only delegate the programmatic focus if there are no elements
-			// focused.
+			Platform.OS === 'ios'
+		) {
+			// Programmatically swapping input focus creates an infinite loop if the
+			// user taps a different input in between the programmatic focus and
+			// the resulting update to the React Native TextInputState focused element
+			// ref. To mitigate this, the below updates the focused element ref, but
+			// does not call the native focus methods.
 			//
 			// See: https://github.com/wordpress-mobile/WordPress-iOS/issues/18783
-			! AztecInputState.getCurrentFocusedElement()
-		) {
 			this.updateCaretData( event );
-			this._onPress(); // Call to move the focus in RN way (TextInputState)
+			AztecInputState.focusInput( this.aztecViewRef.current );
 		}
 	}
 

--- a/packages/react-native-editor/CHANGELOG.md
+++ b/packages/react-native-editor/CHANGELOG.md
@@ -15,6 +15,7 @@ For each user feature we should also add a importance categorization label  to i
 -   [**] Upgrade React Native to 0.71.11 [#51303]
 -   [*] Upgrade Gradle to 8.2.1 & AGP to 8.1.0 [#52872]
 -   [*] Fix Gallery block selection when adding media [#53127]
+-   [**] Fix iOS Focus loop for RichText components [#53217]
 
 ## 1.100.1
 -   [**] Add WP hook for registering non-core blocks [#52791]


### PR DESCRIPTION
**Related PRs:**
- https://github.com/wordpress-mobile/gutenberg-mobile/pull/6009

Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/6002
Fixes https://github.com/wordpress-mobile/WordPress-iOS/issues/18783
Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/1696
Fixes https://github.com/WordPress/gutenberg/issues/30562
Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/953

## What?
This PR attempts to fix the current iOS focus loop with RichText components. It's co-authored with @dcalhoun's work to address these issues from https://github.com/WordPress/gutenberg/pull/44988.

## Why?
This known issue is now more easy to reproduce after the recent design updates, so this PR addresses this bug to avoid a bad experience on the mobile editor.

## How?
You can find more information in https://github.com/WordPress/gutenberg/pull/44988 but it updates how the `onFocus` callback is handled for iOS from Aztec, by avoiding calling the `this._onPress` callback and instead calling the newly added `AztecInputState.focusInput` which sets the current TextInput's reference without calling the native onFocus methods that were generating focus loops.

It also updates the DefaultBlockAppender component code and the Footer Appender to avoid inline arrow functions and other minor code-style improvements.

## Testing Instructions

**Precondition**: Use the following [testing build](https://github.com/wordpress-mobile/WordPress-iOS/pull/21209#issuecomment-1658561718) from the iOS host app. You could test the demo app but it's not as easy since you'd need to build the app on your device for better testing.

## Scenario 1

- Create a post
- Add several blocks with text input (paragraph, verse, preformatted, etc)
- Rapidly (very rapidly) shift the focus of the text inputs by tapping between the blocks. (It's not necessary to type any text.)
- **Expect** the app not to go into a focus loop

## Scenario 2

- Create a post
- Add empty paragraph blocks by quickly tapping on the return key of the keyboard while simultaneously tapping on different paragraph blocks
- **Expect** the app not to go into a focus loop

## Scenario 3

- Open a post with a lot of content e.g. initial HTML example content.
- Quickly scroll down to the very bottom and tap several times on the invisible appender in the footer of the list
- **Expect** the app not to go into a focus loop

### Testing Instructions for Keyboard
N/A

## Screenshots or screencast <!-- if applicable -->

Scenario 2 Before|Scenario 2 After
-|-
<video src="https://github.com/WordPress/gutenberg/assets/4885740/d54fcce7-9286-4442-8b38-4bf667024043" width=200 />|<video src="https://github.com/WordPress/gutenberg/assets/4885740/575cb2de-0467-40a6-b495-d42d8c71c658" width=200 />

Scenario 3 Before|Scenario 3 After
-|-
<video src="https://github.com/WordPress/gutenberg/assets/4885740/1260bd9f-a2f0-475d-994b-4614f9d97493" width=200 />|<video src="https://github.com/WordPress/gutenberg/assets/4885740/144e5044-9d40-4b9b-83bd-b07c8ee29c69" width=200 />