### PR TITLE
Block Editor: Fix ESLint warning for the 'useBlockEditingMode' hook

### DIFF
--- a/packages/block-editor/src/components/block-editing-mode/index.js
+++ b/packages/block-editor/src/components/block-editing-mode/index.js
@@ -66,6 +66,6 @@ export function useBlockEditingMode( mode ) {
 				unsetBlockEditingMode( clientId );
 			}
 		};
-	}, [ clientId, mode ] );
+	}, [ clientId, mode, setBlockEditingMode, unsetBlockEditingMode ] );
 	return blockEditingMode;
 }


### PR DESCRIPTION
## What?
PR fixes the ESLint warning for the `useBlockEditingMode` hook.

```
React Hook useEffect has missing dependencies: 'setBlockEditingMode' and 'unsetBlockEditingMode'.
```

## Why?
The private actions/selectors return stable references and should be safe to provide as a `useEffect` dependency. See #51051.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
1. CI checks should be green.
2. Smoke test the page editing in the Site Editor. It should work as before.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2023-08-01 at 13 03 53](https://github.com/WordPress/gutenberg/assets/240569/ac300c9f-40a0-4a87-b07f-9f35d6a8eeff)
