### PR TITLE
Custom Fields: Add custom fields experimental setting.

### DIFF
--- a/lib/experimental/editor-settings.php
+++ b/lib/experimental/editor-settings.php
@@ -87,6 +87,10 @@ function gutenberg_enable_experiments() {
 		wp_add_inline_script( 'wp-block-editor', 'window.__experimentalEnableGroupGridVariation = true', 'before' );
 	}
 
+	if ( $gutenberg_experiments && array_key_exists( 'gutenberg-custom-fields', $gutenberg_experiments ) ) {
+		wp_add_inline_script( 'wp-block-editor', 'window.__experimentalCustomFields = true', 'before' );
+	}
+
 	if ( gutenberg_is_experiment_enabled( 'gutenberg-no-tinymce' ) ) {
 		wp_add_inline_script( 'wp-block-library', 'window.__experimentalDisableTinymce = true', 'before' );
 	}

--- a/lib/experiments-page.php
+++ b/lib/experiments-page.php
@@ -103,6 +103,18 @@ function gutenberg_initialize_experiments_settings() {
 		)
 	);
 
+	add_settings_field(
+		'gutenberg-custom-fields',
+		__( 'Custom Fields', 'gutenberg' ),
+		'gutenberg_display_experiment_field',
+		'gutenberg-experiments',
+		'gutenberg_experiments_section',
+		array(
+			'label' => __( 'Test Custom Fields', 'gutenberg' ),
+			'id'    => 'gutenberg-custom-fields',
+		)
+	);
+
 	register_setting(
 		'gutenberg-experiments',
 		'gutenberg-experiments'


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Do not merge until 16.4 is released.
Adds an experimental setting for future Custom Fields proofs of concepts.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
To start with experiments without interfere the Gutenberg experience until we have more stable things.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
Now is only the visual interface. Enabling this option won't cause anything yet.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
![Screenshot 2023-08-01 at 11 24 40](https://github.com/WordPress/gutenberg/assets/37012961/1edf9b2e-ce2b-4ad1-aa77-79078b90c575)
![Screenshot 2023-08-01 at 11 24 28](https://github.com/WordPress/gutenberg/assets/37012961/57fed2c5-523d-49ad-81d3-db50ab841402)
![Screenshot 2023-08-01 at 11 24 12](https://github.com/WordPress/gutenberg/assets/37012961/ed9e13e6-817c-47ee-bf61-ea3e2caf21ed)
