### PR TITLE
Image Aspect Ratio: Rely only on width to define image sizes when aspect ratio is set

### DIFF
--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -547,6 +547,21 @@ export default function Image( {
 	const borderProps = useBorderProps( attributes );
 	const isRounded = attributes.className?.includes( 'is-style-rounded' );
 
+	const imgStyle = {
+		aspectRatio: aspectRatio ? aspectRatio : undefined,
+		objectFit: scale,
+		...borderProps.style,
+	};
+	if ( aspectRatio ) {
+		imgStyle.height = 'auto';
+		imgStyle.width = '100%';
+	}
+	if ( width ) {
+		imgStyle.width = width;
+	}
+	if ( height ) {
+		imgStyle.height = height;
+	}
 	let img = (
 		// Disable reason: Image itself is not meant to be interactive, but
 		// should direct focus to block.
@@ -564,14 +579,7 @@ export default function Image( {
 				} }
 				ref={ imageRef }
 				className={ borderProps.className }
-				style={ {
-					width:
-						( width && height ) || aspectRatio ? '100%' : undefined,
-					height:
-						( width && height ) || aspectRatio ? '100%' : undefined,
-					objectFit: scale,
-					...borderProps.style,
-				} }
+				style={ imgStyle }
 			/>
 			{ temporaryURL && <Spinner /> }
 		</>
@@ -689,8 +697,8 @@ export default function Image( {
 					onResizeStop();
 					setAttributes( {
 						width: elt.offsetWidth,
-						height: elt.offsetHeight,
-						aspectRatio: undefined,
+						height: 'auto',
+						aspectRatio: aspectRatio ? aspectRatio : undefined,
 					} );
 				} }
 				resizeRatio={ align === 'center' ? 2 : 1 }

--- a/packages/block-library/src/image/save.js
+++ b/packages/block-library/src/image/save.js
@@ -49,20 +49,26 @@ export default function save( { attributes } ) {
 		[ `wp-image-${ id }` ]: !! id,
 	} );
 
+	const imgStyle = {
+		...borderProps.style,
+		aspectRatio,
+		objectFit: scale,
+	};
+	if ( width ) {
+		imgStyle.width = width;
+	}
+
+	if ( height && ! isNaN( height ) ) {
+		imgStyle.height = height;
+	}
 	const image = (
 		<img
 			src={ url }
 			alt={ alt }
 			className={ imageClasses || undefined }
-			style={ {
-				...borderProps.style,
-				aspectRatio,
-				objectFit: scale,
-				width,
-				height,
-			} }
+			style={ imgStyle }
 			width={ width }
-			height={ height }
+			height={ isNaN( height ) ? undefined : height }
 			title={ title }
 		/>
 	);


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
When setting aspect ratio for an image, we define both a width and a height. This is unnecessary, as the browser can infer the height based on a width and an aspect ratio. This PR removes the reliance on the height attribute for images that have aspect ratio defined, to allow the browser to calculate the height. Fixes https://github.com/WordPress/gutenberg/issues/52739

## Why?
When the browser is smaller than the width/height defined in the CSS, the image is stretched. See https://github.com/WordPress/gutenberg/issues/52739

## How?
When the user resizes the image and aspect ratio is defined, then don't update the height attribute, only the width.

## Testing Instructions
1. Add an image to your post
2. Select an aspect ratio
3. Resize using the handles
4. Save
5. Open in the front end
6. Resize your browser window
7. You should see the image at the correct aspect ratio, with no stretching.

## Screenshots or screencast <!-- if applicable -->
<img width="337" alt="Screenshot 2023-08-01 at 11 06 48" src="https://github.com/WordPress/gutenberg/assets/275961/cbc050de-fc1c-4428-8ded-3c98fb61ee22">


Co-authored-by: Maggie <3593343+MaggieCabrera@users.noreply.github.com>