### PR TITLE
Temporarily skip widget import e2e test

### DIFF
--- a/test/e2e/specs/site-editor/template-part.spec.js
+++ b/test/e2e/specs/site-editor/template-part.spec.js
@@ -293,7 +293,8 @@ test.describe( 'Template Part', () => {
 		await expect( paragraph ).toBeVisible();
 	} );
 
-	test( 'can import a widget area into an empty template part', async ( {
+	// Reason: https://github.com/WordPress/gutenberg/issues/47003.
+	test.skip( 'can import a widget area into an empty template part', async ( {
 		admin,
 		editor,
 		page,


### PR DESCRIPTION
## What?
PR skip flaky `can import a widget area into an empty template part` e2e test.

## Why?
This e2e test started failing more often lately. I think the failure is related to #47003, but I couldn't find a way to reproduce it consistently for debugging.

I'll try to look into this again in the near future, but let's skip the test for now.

Recent failure: https://github.com/WordPress/gutenberg/actions/runs/5724804540/job/15512039179?pr=53218#step:7:44.

## Testing Instructions
CI should be green.
