### PR TITLE
Block Editor: Simplify check in 'withBlockControls' styles hook

### DIFF
--- a/packages/block-editor/src/hooks/style.js
+++ b/packages/block-editor/src/hooks/style.js
@@ -11,7 +11,6 @@ import { addFilter } from '@wordpress/hooks';
 import {
 	getBlockSupport,
 	hasBlockSupport,
-	getBlockType,
 	__EXPERIMENTAL_ELEMENTS as ELEMENTS,
 } from '@wordpress/blocks';
 import { createHigherOrderComponent, useInstanceId } from '@wordpress/compose';
@@ -45,8 +44,8 @@ const styleSupportKeys = [
 	SPACING_SUPPORT_KEY,
 ];
 
-const hasStyleSupport = ( blockType ) =>
-	styleSupportKeys.some( ( key ) => hasBlockSupport( blockType, key ) );
+const hasStyleSupport = ( nameOrType ) =>
+	styleSupportKeys.some( ( key ) => hasBlockSupport( nameOrType, key ) );
 
 /**
  * Returns the inline styles to add depending on the style object
@@ -348,8 +347,7 @@ export function addEditProps( settings ) {
  */
 export const withBlockControls = createHigherOrderComponent(
 	( BlockEdit ) => ( props ) => {
-		const blockType = getBlockType( props.name );
-		if ( ! hasStyleSupport( blockType ) ) {
+		if ( ! hasStyleSupport( props.name ) ) {
 			return <BlockEdit { ...props } />;
 		}
 

--- a/packages/block-editor/src/hooks/style.js
+++ b/packages/block-editor/src/hooks/style.js
@@ -348,7 +348,7 @@ export function addEditProps( settings ) {
 export const withBlockControls = createHigherOrderComponent(
 	( BlockEdit ) => ( props ) => {
 		if ( ! hasStyleSupport( props.name ) ) {
-			return <BlockEdit { ...props } />;
+			return <BlockEdit key="edit" { ...props } />;
 		}
 
 		const shouldDisplayControls = useDisplayBlockControls();
@@ -364,7 +364,7 @@ export const withBlockControls = createHigherOrderComponent(
 						<DimensionsPanel { ...props } />
 					</>
 				) }
-				<BlockEdit { ...props } />
+				<BlockEdit key="edit" { ...props } />
 			</>
 		);
 	},


### PR DESCRIPTION
## What?
A minor follow-up to #53092.

* PR removes the `getBlockType` method call. The `hasBlockSupport` accepts name string or block type object, so will the `hasStyleSupport` wrapper.
* Adds `key` prop to the returned `BlockEdit` component to avoid accidental remounts. This is a common pattern in similar hooks. See #50292.

## Testing Instructions
Confirm fix from #53092 works as before.
