### PR TITLE
Editor: Use hooks instead of HoCs for `PostPingbacks`

### DIFF
--- a/packages/editor/src/components/post-pingbacks/index.js
+++ b/packages/editor/src/components/post-pingbacks/index.js
@@ -11,12 +11,12 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { store as editorStore } from '../../store';
 
 function PostPingbacks() {
-	const pingStatus =
-		useSelect(
-			( select ) =>
-				select( editorStore ).getEditedPostAttribute( 'ping_status' ),
-			[]
-		) ?? 'open';
+	const pingStatus = useSelect(
+		( select ) =>
+			select( editorStore ).getEditedPostAttribute( 'ping_status' ) ??
+			'open',
+		[]
+	);
 	const { editPost } = useDispatch( editorStore );
 	const onTogglePingback = () =>
 		editPost( {

--- a/packages/editor/src/components/post-pingbacks/index.js
+++ b/packages/editor/src/components/post-pingbacks/index.js
@@ -3,17 +3,23 @@
  */
 import { __ } from '@wordpress/i18n';
 import { CheckboxControl } from '@wordpress/components';
-import { withSelect, withDispatch } from '@wordpress/data';
-import { compose } from '@wordpress/compose';
+import { useDispatch, useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
 import { store as editorStore } from '../../store';
 
-function PostPingbacks( { pingStatus = 'open', ...props } ) {
+function PostPingbacks() {
+	const pingStatus =
+		useSelect(
+			( select ) =>
+				select( editorStore ).getEditedPostAttribute( 'ping_status' ),
+			[]
+		) ?? 'open';
+	const { editPost } = useDispatch( editorStore );
 	const onTogglePingback = () =>
-		props.editPost( {
+		editPost( {
 			ping_status: pingStatus === 'open' ? 'closed' : 'open',
 		} );
 
@@ -27,14 +33,4 @@ function PostPingbacks( { pingStatus = 'open', ...props } ) {
 	);
 }
 
-export default compose( [
-	withSelect( ( select ) => {
-		return {
-			pingStatus:
-				select( editorStore ).getEditedPostAttribute( 'ping_status' ),
-		};
-	} ),
-	withDispatch( ( dispatch ) => ( {
-		editPost: dispatch( editorStore ).editPost,
-	} ) ),
-] )( PostPingbacks );
+export default PostPingbacks;


### PR DESCRIPTION
## What?
This straightforward PR updates the `PostPingbacks` component to use the `@wordpress/data` hooks instead of the HoCs.

## Why?
A micro-optimization to makes the rendered component tree smaller.

## How?
We're using the `useSelect` and `useDispatch` hooks instead of the `withSelect` and `withDispatch` hooks.

Because we're removing a `withSelect`, a `withDispatch` and a `compose()` instance, this removes 3 levels of nesting.

## Testing Instructions
Creating a new post and editing a new post, verifying the "Allow pingbacks & trackbacks" field under "Discussion" settings in the post sidebar still works well.

### Testing Instructions for Keyboard
None.

## Screenshots or screencast <!-- if applicable -->
The component tree before:
![Screenshot 2023-08-01 at 14 26 00](https://github.com/WordPress/gutenberg/assets/8436925/51359980-90be-4a76-b69e-7d113dfb42c8)

The component tree after:
![Screenshot 2023-08-01 at 14 26 29](https://github.com/WordPress/gutenberg/assets/8436925/d41eea6e-8dba-4876-8934-8ae36fdbe3d4)