### PR TITLE
Editor: Use hooks instead of HoCs in `PostExcerpt`

### DIFF
--- a/packages/editor/src/components/post-excerpt/index.js
+++ b/packages/editor/src/components/post-excerpt/index.js
@@ -3,22 +3,27 @@
  */
 import { __ } from '@wordpress/i18n';
 import { ExternalLink, TextareaControl } from '@wordpress/components';
-import { withSelect, withDispatch } from '@wordpress/data';
-import { compose } from '@wordpress/compose';
+import { useDispatch, useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
 import { store as editorStore } from '../../store';
 
-function PostExcerpt( { excerpt, onUpdateExcerpt } ) {
+function PostExcerpt() {
+	const excerpt = useSelect(
+		( select ) => select( editorStore ).getEditedPostAttribute( 'excerpt' ),
+		[]
+	);
+	const { editPost } = useDispatch( editorStore );
+
 	return (
 		<div className="editor-post-excerpt">
 			<TextareaControl
 				__nextHasNoMarginBottom
 				label={ __( 'Write an excerpt (optional)' ) }
 				className="editor-post-excerpt__textarea"
-				onChange={ ( value ) => onUpdateExcerpt( value ) }
+				onChange={ ( value ) => editPost( { excerpt: value } ) }
 				value={ excerpt }
 			/>
 			<ExternalLink
@@ -32,15 +37,4 @@ function PostExcerpt( { excerpt, onUpdateExcerpt } ) {
 	);
 }
 
-export default compose( [
-	withSelect( ( select ) => {
-		return {
-			excerpt: select( editorStore ).getEditedPostAttribute( 'excerpt' ),
-		};
-	} ),
-	withDispatch( ( dispatch ) => ( {
-		onUpdateExcerpt( excerpt ) {
-			dispatch( editorStore ).editPost( { excerpt } );
-		},
-	} ) ),
-] )( PostExcerpt );
+export default PostExcerpt;


### PR DESCRIPTION
## What?
This straightforward PR updates the `PostExcerpt` component to use the `@wordpress/data` hooks instead of the HoCs.

## Why?
A micro-optimization to makes the rendered component tree smaller.

## How?
We're using the `useSelect` and `useDispatch` hooks instead of the `withSelect` and `withDispatch` hooks.

Because we're removing a `withSelect`, a `withDispatch` and a `compose()` instance, this removes 3 levels of nesting.

## Testing Instructions
Creating a new post and editing a new post, verifying the "Excerpt" field in the post sidebar still works well.

### Testing Instructions for Keyboard
None.

## Screenshots or screencast <!-- if applicable -->
The component tree before:
![Screenshot 2023-08-01 at 14 50 37](https://github.com/WordPress/gutenberg/assets/8436925/3c1c1af1-87b7-4de8-9edb-41a06d7830a9)

The component tree after:
![Screenshot 2023-08-01 at 14 50 08](https://github.com/WordPress/gutenberg/assets/8436925/3197cb91-b4aa-4718-aacf-9a29c6c008a9)
