### PR TITLE
Editor: Use hooks instead of HoCs in `PostComments`

### DIFF
--- a/packages/editor/src/components/post-comments/index.js
+++ b/packages/editor/src/components/post-comments/index.js
@@ -3,17 +3,23 @@
  */
 import { __ } from '@wordpress/i18n';
 import { CheckboxControl } from '@wordpress/components';
-import { compose } from '@wordpress/compose';
-import { withSelect, withDispatch } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
 import { store as editorStore } from '../../store';
 
-function PostComments( { commentStatus = 'open', ...props } ) {
+function PostComments() {
+	const commentStatus = useSelect(
+		( select ) =>
+			select( editorStore ).getEditedPostAttribute( 'comment_status' ) ??
+			'open',
+		[]
+	);
+	const { editPost } = useDispatch( editorStore );
 	const onToggleComments = () =>
-		props.editPost( {
+		editPost( {
 			comment_status: commentStatus === 'open' ? 'closed' : 'open',
 		} );
 
@@ -27,16 +33,4 @@ function PostComments( { commentStatus = 'open', ...props } ) {
 	);
 }
 
-export default compose( [
-	withSelect( ( select ) => {
-		return {
-			commentStatus:
-				select( editorStore ).getEditedPostAttribute(
-					'comment_status'
-				),
-		};
-	} ),
-	withDispatch( ( dispatch ) => ( {
-		editPost: dispatch( editorStore ).editPost,
-	} ) ),
-] )( PostComments );
+export default PostComments;


### PR DESCRIPTION
## What?
This straightforward PR updates the `PostComments` component to use the `@wordpress/data` hooks instead of the HoCs.

## Why?
A micro-optimization to makes the rendered component tree smaller.

## How?
We're using the `useSelect` and `useDispatch` hooks instead of the `withSelect` and `withDispatch` hooks.

Because we're removing a `withSelect`, a `withDispatch` and a `compose()` instance, this removes 3 levels of nesting.

## Testing Instructions
Creating a new post and editing a new post, verifying the "Allow comments" field under "Discussion" settings in the post sidebar still works well.

### Testing Instructions for Keyboard
None.

## Screenshots or screencast <!-- if applicable -->
The component tree before:
![Screenshot 2023-08-01 at 16 01 20](https://github.com/WordPress/gutenberg/assets/8436925/ff9c052d-d0bb-4060-acf4-cf0af90798b8)

The component tree after:
![Screenshot 2023-08-01 at 16 00 52](https://github.com/WordPress/gutenberg/assets/8436925/e56c6838-e161-4e09-9021-04c5cf9572ef)
