### PR TITLE
Edit Post: Use hooks instead of HoCs in `DiscussionPanel`

### DIFF
--- a/packages/edit-post/src/components/sidebar/discussion-panel/index.js
+++ b/packages/edit-post/src/components/sidebar/discussion-panel/index.js
@@ -8,8 +8,7 @@ import {
 	PostPingbacks,
 	PostTypeSupportCheck,
 } from '@wordpress/editor';
-import { compose } from '@wordpress/compose';
-import { withSelect, withDispatch } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -21,7 +20,18 @@ import { store as editPostStore } from '../../../store';
  */
 const PANEL_NAME = 'discussion-panel';
 
-function DiscussionPanel( { isEnabled, isOpened, onTogglePanel } ) {
+function DiscussionPanel() {
+	const { isEnabled, isOpened } = useSelect( ( select ) => {
+		const { isEditorPanelEnabled, isEditorPanelOpened } =
+			select( editPostStore );
+		return {
+			isEnabled: isEditorPanelEnabled( PANEL_NAME ),
+			isOpened: isEditorPanelOpened( PANEL_NAME ),
+		};
+	}, [] );
+
+	const { toggleEditorPanelOpened } = useDispatch( editPostStore );
+
 	if ( ! isEnabled ) {
 		return null;
 	}
@@ -31,7 +41,7 @@ function DiscussionPanel( { isEnabled, isOpened, onTogglePanel } ) {
 			<PanelBody
 				title={ __( 'Discussion' ) }
 				opened={ isOpened }
-				onToggle={ onTogglePanel }
+				onToggle={ () => toggleEditorPanelOpened( PANEL_NAME ) }
 			>
 				<PostTypeSupportCheck supportKeys="comments">
 					<PanelRow>
@@ -49,19 +59,4 @@ function DiscussionPanel( { isEnabled, isOpened, onTogglePanel } ) {
 	);
 }
 
-export default compose( [
-	withSelect( ( select ) => {
-		return {
-			isEnabled:
-				select( editPostStore ).isEditorPanelEnabled( PANEL_NAME ),
-			isOpened: select( editPostStore ).isEditorPanelOpened( PANEL_NAME ),
-		};
-	} ),
-	withDispatch( ( dispatch ) => ( {
-		onTogglePanel() {
-			return dispatch( editPostStore ).toggleEditorPanelOpened(
-				PANEL_NAME
-			);
-		},
-	} ) ),
-] )( DiscussionPanel );
+export default DiscussionPanel;


### PR DESCRIPTION
## What?
This straightforward PR updates the `DiscussionPanel` component to use the `@wordpress/data` hooks instead of the HoCs.

## Why?
A micro-optimization to makes the rendered component tree smaller.

## How?
We're using the `useSelect` and `useDispatch` hooks instead of the `withSelect` and `withDispatch` hooks.

Because we're removing a `withSelect`, a `withDispatch` and a `compose()` instance, this removes 3 levels of nesting.

## Testing Instructions
Creating a new post and editing a new post, verifying the "Discussion" settings panel in the post sidebar still works well, and preserves its expanded/collapsed state.

### Testing Instructions for Keyboard
None.

## Screenshots or screencast <!-- if applicable -->
The component tree before:
![Screenshot 2023-08-01 at 16 04 30](https://github.com/WordPress/gutenberg/assets/8436925/10941ef7-b4a4-4c98-9c4f-fa9d4c0b0069)

The component tree after:
![Screenshot 2023-08-01 at 16 06 24](https://github.com/WordPress/gutenberg/assets/8436925/75bc7ff6-92b5-4549-a619-6fd7c5296afc)
