### PR TITLE
Fix #52598

### DIFF
--- a/packages/e2e-test-utils-playwright/src/config.ts
+++ b/packages/e2e-test-utils-playwright/src/config.ts
@@ -5,8 +5,8 @@ const {
 } = process.env;
 
 const WP_ADMIN_USER = {
-	username: WP_ADMIN_USER.username,
-	password: WP_ADMIN_USER.password,
+	username: WP_USERNAME,
+	password: WP_PASSWORD,
 } as const;
 
 export { WP_ADMIN_USER, WP_USERNAME, WP_PASSWORD, WP_BASE_URL };

--- a/packages/e2e-test-utils-playwright/src/config.ts
+++ b/packages/e2e-test-utils-playwright/src/config.ts
@@ -1,12 +1,12 @@
-const WP_ADMIN_USER = {
-	username: 'admin',
-	password: 'password',
-} as const;
-
 const {
-	WP_USERNAME = WP_ADMIN_USER.username,
-	WP_PASSWORD = WP_ADMIN_USER.password,
+	WP_USERNAME = 'admin',
+	WP_PASSWORD = 'password',
 	WP_BASE_URL = 'http://localhost:8889',
 } = process.env;
+
+const WP_ADMIN_USER = {
+	username: WP_ADMIN_USER.username,
+	password: WP_ADMIN_USER.password,
+} as const;
 
 export { WP_ADMIN_USER, WP_USERNAME, WP_PASSWORD, WP_BASE_URL };


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Re #52598 (UNTESTED) my first try in TypeScript to fix auth issue in e2e-test-utlis-playwright

## Why?
See issue #52598

## How?
Swapping the definition of WP_ADMIN_USER and the other constants. Now using WP_USERNAME and WP_PASSWORD as input for WP_ADMIN_USER in stead of the other way around.

## Testing Instructions
Sorry, untested.  But https://github.com/WordPress/gutenberg/pull/52625 is a test-use-case

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
