### PR TITLE
Mobile - KeyboardAwareFlatList - Avoid VirtualizedList console error

### DIFF
--- a/packages/components/src/mobile/keyboard-aware-flat-list/index.ios.js
+++ b/packages/components/src/mobile/keyboard-aware-flat-list/index.ios.js
@@ -154,7 +154,7 @@ export const KeyboardAwareFlatList = ( {
 			scrollEventThrottle={ 16 }
 			style={ style }
 		>
-			<FlatList { ...props } />
+			<FlatList { ...props } scrollEnabled={ false } />
 		</AnimatedScrollView>
 	);
 };


### PR DESCRIPTION
**Related PRs:**
- https://github.com/wordpress-mobile/gutenberg-mobile/pull/6015

## What?
This PR removes a console error related to nesting a VirtualizedList (FlatList) within a ScrollView in the KeyboardAwareFlatList component.

<kbd><img src="https://github.com/WordPress/gutenberg/assets/4885740/8d833877-b773-4958-ae9d-b9bcecad7e63" width="200" /></kbd>

## Why?
To avoid having to discard it constantly while developing.

## How?
In React Native `0.71` a [new check](https://github.com/facebook/react-native/commit/62f83a9fad027ef0ed808f7e34973bb01cdf10e9) was added for nested VirtualizedLists to avoid displaying the console error if it had `scrollEnabled` set to false. For this case, the ScrollView is the component that handles the scrolling so we can disable it for the FlatList.

## Testing Instructions
- Open the demo app
- Test scrolling and drag and drop blocks
- **Expect** the scrolling functionality to work correctly.

### Testing Instructions for Keyboard
N/A

## Screenshots or screencast <!-- if applicable -->

After
-|
<video src="https://github.com/WordPress/gutenberg/assets/4885740/8d712c02-321b-4a05-bf97-104bbb01583c" width="200" />|