### PR TITLE
Commands: Use the same Preview target tab

### DIFF
--- a/packages/edit-post/src/hooks/commands/use-common-commands.js
+++ b/packages/edit-post/src/hooks/commands/use-common-commands.js
@@ -59,6 +59,7 @@ export default function useCommonCommands() {
 	const { toggle } = useDispatch( preferencesStore );
 	const { createInfoNotice } = useDispatch( noticesStore );
 	const { __unstableSaveForPreview } = useDispatch( editorStore );
+	const { getCurrentPostId } = useSelect( editorStore );
 
 	useCommand( {
 		name: 'core/open-settings-sidebar',
@@ -214,8 +215,9 @@ export default function useCommonCommands() {
 		icon: external,
 		callback: async ( { close } ) => {
 			close();
-			const link = await __unstableSaveForPreview( {} );
-			window.open( link, '_blank' );
+			const postId = getCurrentPostId();
+			const link = await __unstableSaveForPreview();
+			window.open( link, `wp-preview-${ postId }` );
 		},
 	} );
 }


### PR DESCRIPTION
## What?
Update the `Preview in a new tab` command to try and reuse the preview target tab when available.

## Why?
This will match the Preview button behavior.

## Testing Instructions
1. Open a post or page.
2. Activate the command palette via CTRL+K or CMD+K.
3. Search for a `Preview in a new tab` command.
4. Preview the post.
5. Go back to the editor browser tab and trigger command again.
6. Confirm that it updates the same preview tab instead of opening a new one.