### PR TITLE
Fix: Sync status overlaps for some languages in Patterns post type page

### DIFF
--- a/packages/editor/src/components/post-sync-status/style.scss
+++ b/packages/editor/src/components/post-sync-status/style.scss
@@ -2,15 +2,18 @@
 	width: 100%;
 	position: relative;
 	justify-content: flex-start;
+	align-items: flex-start;
 
 	> span {
 		display: block;
 		width: 45%;
 		flex-shrink: 0;
+		padding: $grid-unit-15 * 0.5 0;
+		word-break: break-word;
 	}
 
 	> div {
 		// Match padding on tertiary buttons for alignment.
-		padding-left: $grid-unit-15;
+		padding: $grid-unit-15 * 0.5 0 $grid-unit-15 * 0.5 $grid-unit-15;
 	}
 }


### PR DESCRIPTION
Fixes: #52960

## What?
This PR prevents the problem of overlapping sync status label in the right sidebar of the Pattern post type page.

## Why?
This label has a width of 45%, but the text exceeds this width in some languages.

## How?

I have applied `word-break:break-word` to the label. As far as I have tested it in several languages, it appears to wrap properly without `break-all`.

In addition, I have applied 6px padding to the top and bottom as well as the other rows. This is because I applied `align-items:flex-start` to make it top-aligned, and without this padding the text would be too close to the top.

![no-padding](https://github.com/WordPress/gutenberg/assets/54422211/5bada02a-d73e-44d9-9738-2a683e4c8fee)

## Testing Instructions

- Change the site language to something other than the default English.
- Go to `http://localhost:8888/wp-admin/edit.php?post_type=wp_block` and create a pattern.
- Confirm that the Sync label in the right sidebar wraps properly.

## Screenshots or screencast <!-- if applicable -->

### English

![english](https://github.com/WordPress/gutenberg/assets/54422211/68fa065c-0734-43b0-a5a7-a7d31867ee1e)

### Japanese

![japanese](https://github.com/WordPress/gutenberg/assets/54422211/50ff7807-93e4-4a56-9832-231705f9ed65)

### Italiano

![italiano](https://github.com/WordPress/gutenberg/assets/54422211/bdf0d837-9e59-472d-91f4-2d612d544e3e)

### German

![german](https://github.com/WordPress/gutenberg/assets/54422211/a2c797ec-9b2d-4f22-82b1-53d323965cdb)

### Swedish

![swedish](https://github.com/WordPress/gutenberg/assets/54422211/e6c43ffe-a336-47c8-8151-1119701cf094)
