### PR TITLE
Image block: Fix aspect-ratio with max-width

### DIFF
--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -484,14 +484,18 @@ export default function Image( {
 							// for values that are removed since setAttributes
 							// doesn't do anything with keys that aren't set.
 							setAttributes( {
+								// width: attribute & style.
 								width:
 									newValue.width &&
 									parseInt( newValue.width, 10 ),
+								// height: attribute only, style is 'auto'.
 								height:
 									newValue.height &&
 									parseInt( newValue.height, 10 ),
 								scale: newValue.scale,
-								aspectRatio: newValue.aspectRatio,
+								aspectRatio:
+									newValue.aspectRatio ||
+									newValue.width / newValue.height,
 							} );
 						} }
 						defaultScale="cover"
@@ -688,9 +692,9 @@ export default function Image( {
 				onResizeStop={ ( event, direction, elt ) => {
 					onResizeStop();
 					setAttributes( {
-						width: elt.offsetWidth,
-						height: elt.offsetHeight,
-						aspectRatio: undefined,
+						width: elt.offsetWidth, // attribute & style.
+						height: elt.offsetHeight, // attribute only, style is 'auto'.
+						aspectRatio: elt.offsetWidth / elt.offsetHeight,
 					} );
 				} }
 				resizeRatio={ align === 'center' ? 2 : 1 }

--- a/packages/block-library/src/image/save.js
+++ b/packages/block-library/src/image/save.js
@@ -59,7 +59,7 @@ export default function save( { attributes } ) {
 				aspectRatio,
 				objectFit: scale,
 				width,
-				height,
+				height: !! height && 'auto', // Also defined in style.scss.
 			} }
 			width={ width }
 			height={ height }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## TODO

- [x] Force `height: 'auto'` in image block save.
- [x] Set `aspect-ratio` whenever both `width` and `height` are set.
- [ ] Fix block crash when dragging to resize after manually editing the height.
- [ ] Add block deprecation for the image block.
- [ ] What should happen when `height` is set and `width` is cleared? \*
- [ ] Should `object-fit` always be set in the case where the natural aspect ratio matches the calculated aspect ratio?

## What?
<!-- In a few words, what is the PR actually doing? -->

Always use `width` and `aspect-ratio` to define image block layout. \* See TODO

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Fixes #52739

The `max-width: 100%` had unintended side-effects when `height` and `width` were added to the inline style in #52286.

Users probably expect the ratio the configure their image to be to be maintained under the effects of `max-width: 100%`. 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

- Force `height: 'auto'` in image block save.
- Set `aspect-ratio` whenever both `width` and `height` are set.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

TODO

The properties to consider for layout in the existing image block are:

- CSS width
- CSS height
- CSS max-width
- inline style width
- inline style height
- inline style aspect-ratio
- attribute width
- attribute height

Various combinations of these properties that can be achieved in the editor should be considered.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
