### PR TITLE
Footnotes: Fix recursion into updating attributes when attributes is not an object

### DIFF
--- a/packages/core-data/src/entity-provider.js
+++ b/packages/core-data/src/entity-provider.js
@@ -221,6 +221,15 @@ export function useEntityBlockEditor( kind, name, { id: _id } = {} ) {
 			);
 
 			function updateAttributes( attributes ) {
+				// Only attempt to update attributes, if attributes is an object.
+				if (
+					! attributes ||
+					Array.isArray( attributes ) ||
+					typeof attributes !== 'object'
+				) {
+					return attributes;
+				}
+
 				attributes = { ...attributes };
 
 				for ( const key in attributes ) {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes #53212 

Fix the footnotes logic from unintentionally converting an array of strings block attribute into an object keyed by numerical string index. Currently, custom blocks that use an array of strings will likely break when a user goes to add a footnote anywhere else on the same post or page as the custom block.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

When passed a string, the expansion of `attributes = { ...attributes }` results in an object keyed by string index. This happens due to the recursive call to `updateAttributes` for attributes that are an array. The problem is most noticeable with an attribute that is set to be an array of strings.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Within the footnotes' logic to update attributes (contained within `updateFootnotes`) check that `attributes` is an object before expanding it into an object.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

There could likely be a simpler way to test this (i.e. add an array of attributes to an existing block in the Gutenberg repo), but to be complete about it, I did the following to create a custom block for testing:

* Create a new custom block plugin via [`create-block`](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-create-block/) (`npx @wordpress/create-block my-test-block`)
* In `block.json` add the following to `attributes`:

```
	"attributes": {
		"items": {
			"type": "array",
			"items": {
				"type": "string"
			},
			"default": [ "apples", "oranges" ]
		}
	},
```

* Then, in the block's `edit.js` file, add the following to output the array of strings within the edit view:

```
export default function Edit( { attributes } ) {
	const { items } = attributes;
	console.log( items );
	return (
		<div { ...useBlockProps() }>
			{ items.map( ( item, index ) => {
				return <p key={ index }>{ item }</p>
			} ) }
		</div>
	);
}
```

This creates a custom block that renders out an array of strings within the edit view for the block. With the block plugin built and activated, go to add a Paragraph to the same post or page as the custom block. Within that Paragraph block go to add Footnotes. Without this PR, the block will error out.

In case it helps testing, I've pushed the above example custom block to a public repo over in https://github.com/andrewserong/andy-test-block

In addition to the above: check that adding Footnotes to nested blocks works as on `trunk` (e.g. paragraphs, quotes (especially the citation within the quote), and lists within multiple levels of nesting in Group blocks, etc)

## Screenshots or screencast <!-- if applicable -->

| Before | After |
| --- | --- |
| ![2023-08-02 15 32 15](https://github.com/WordPress/gutenberg/assets/14988353/00cd7b66-4ebf-4229-b937-bdc85207f79d) | ![2023-08-02 15 31 37](https://github.com/WordPress/gutenberg/assets/14988353/7e57d832-05d5-4a27-9004-9fe441bd05c6) |