### PR TITLE
Components: Expose `Theme` via private APIs

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -11,6 +11,7 @@
 -   `ColorPalette`, `BorderControl`: Don't hyphenate hex value in `aria-label` ([#52932](https://github.com/WordPress/gutenberg/pull/52932)).
 -   `MenuItemsChoice`, `MenuItem`: Support a `disabled` prop on a menu item ([#52737](https://github.com/WordPress/gutenberg/pull/52737)).
 -   `TabPanel`: Introduce a new version of `TabPanel` with updated internals and improved adherence to ARIA guidance on `tabpanel` focus behavior while maintaining the same functionality and API surface.([#52133](https://github.com/WordPress/gutenberg/pull/52133)).
+-   `Theme`: Expose via private APIs ([#53262](https://github.com/WordPress/gutenberg/pull/53262)).
 
 ### Bug Fix
 

--- a/packages/components/src/private-apis.ts
+++ b/packages/components/src/private-apis.ts
@@ -23,6 +23,7 @@ import {
 	DropdownSubMenuTrigger as DropdownSubMenuTriggerV2,
 } from './dropdown-menu-v2';
 import { ComponentsContext } from './ui/context/context-system-provider';
+import Theme from './theme';
 
 export const { lock, unlock } =
 	__dangerousOptInToUnstableAPIsOnlyForCoreModules(
@@ -47,4 +48,5 @@ lock( privateApis, {
 	DropdownSubMenuV2,
 	DropdownSubMenuTriggerV2,
 	ProgressBar,
+	Theme,
 } );

--- a/packages/components/src/theme/README.md
+++ b/packages/components/src/theme/README.md
@@ -8,23 +8,6 @@ This feature is still experimental. “Experimental” means this is an early im
 
 Multiple `Theme` components can be nested in order to override specific theme variables.
 
-## Usage
-
-```jsx
-import { __experimentalTheme as Theme } from '@wordpress/components';
-
-const Example = () => {
-	return (
-		<Theme accent="red">
-			<Button variant="primary">I'm red</Button>
-			<Theme accent="blue" background="black">
-				<Button variant="primary">I'm blue</Button>
-			</Theme>
-		</Theme>
-	);
-};
-```
-
 ## Props
 
 ### `accent`: `string`

--- a/packages/components/src/theme/index.tsx
+++ b/packages/components/src/theme/index.tsx
@@ -20,7 +20,15 @@ import { useCx } from '../utils';
  *
  * @example
  * ```jsx
- * import { __experimentalTheme as Theme } from '@wordpress/components';
+ * import { privateApis as componentsPrivateApis } from '@wordpress/components';
+ * import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/private-apis';
+ *
+ * const { lock, unlock } = __dangerousOptInToUnstableAPIsOnlyForCoreModules(
+ *   'I know using unstable features means my plugin or theme will inevitably break on the next WordPress release.',
+ *   '@wordpress/components'
+ * );
+ *
+ * const { Theme } = unlock( componentsPrivateApis );
  *
  * const Example = () => {
  *   return (

--- a/packages/components/src/theme/index.tsx
+++ b/packages/components/src/theme/index.tsx
@@ -20,16 +20,6 @@ import { useCx } from '../utils';
  *
  * @example
  * ```jsx
- * import { privateApis as componentsPrivateApis } from '@wordpress/components';
- * import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/private-apis';
- *
- * const { lock, unlock } = __dangerousOptInToUnstableAPIsOnlyForCoreModules(
- *   'I know using unstable features means my plugin or theme will inevitably break on the next WordPress release.',
- *   '@wordpress/components'
- * );
- *
- * const { Theme } = unlock( componentsPrivateApis );
- *
  * const Example = () => {
  *   return (
  *     <Theme accent="red">


### PR DESCRIPTION
## What?
This exposes the existing `Theme` component via the `@wordpress/component` private APIs.

## Why?
It's necessary for #53032, for usage outside of the `@wordpress/components` package.

Any prior usages of that component were within the package, so it could be directly imported.

Usage of `Theme` was suggested by @mirka here: https://github.com/WordPress/gutenberg/pull/53030#discussion_r1276950940

## How?
* We're adding `Theme` to the list of `@wordpress/components` private APIs, 
* We're removing the original README example since it was incorrect (it was assuming `__experimentalTheme` exposition, which isn't the case), 
* We're improving the inline example. 

## Testing Instructions
* Verify that `Theme` still works well in storybook.
* Verify all checks are green.

### Testing Instructions for Keyboard
None

## Screenshots or screencast <!-- if applicable -->
None