### PR TITLE
Improve the efficiency of the useDebouncedInput hook

### DIFF
--- a/packages/block-editor/src/components/inserter/hooks/use-debounced-input.js
+++ b/packages/block-editor/src/components/inserter/hooks/use-debounced-input.js
@@ -6,12 +6,13 @@ import { useDebounce } from '@wordpress/compose';
 
 export default function useDebouncedInput( defaultValue = '' ) {
 	const [ input, setInput ] = useState( defaultValue );
-	const [ debounced, setter ] = useState( defaultValue );
-	const setDebounced = useDebounce( setter, 250 );
+	const [ debouncedInput, setDebouncedState ] = useState( defaultValue );
+
+	const setDebouncedInput = useDebounce( setDebouncedState, 250 );
+
 	useEffect( () => {
-		if ( debounced !== input ) {
-			setDebounced( input );
-		}
-	}, [ debounced, input ] );
-	return [ input, setInput, debounced ];
+		setDebouncedInput( input );
+	}, [ input ] );
+
+	return [ input, setInput, debouncedInput ];
 }

--- a/packages/edit-site/src/utils/use-debounced-input.js
+++ b/packages/edit-site/src/utils/use-debounced-input.js
@@ -6,12 +6,13 @@ import { useDebounce } from '@wordpress/compose';
 
 export default function useDebouncedInput( defaultValue = '' ) {
 	const [ input, setInput ] = useState( defaultValue );
-	const [ debounced, setter ] = useState( defaultValue );
-	const setDebounced = useDebounce( setter, 250 );
+	const [ debouncedInput, setDebouncedState ] = useState( defaultValue );
+
+	const setDebouncedInput = useDebounce( setDebouncedState, 250 );
+
 	useEffect( () => {
-		if ( debounced !== input ) {
-			setDebounced( input );
-		}
-	}, [ debounced, input ] );
-	return [ input, setInput, debounced ];
+		setDebouncedInput( input );
+	}, [ input ] );
+
+	return [ input, setInput, debouncedInput ];
 }


### PR DESCRIPTION
## What?

Improve the efficiency of the `useDebouncedInput` hook by eliminating a redundant conditional check along with its dependency within the `useEffect` function. React internally should handle it and avoid re-rendering if the value doesn't change. 

This is a slight improvement, so it might not be well reflected in the performance comparison tests as the metric value fluctuation is relatively high.


## Testing Instructions

- Make sure the Inserter search works as expected,
- Make sure the Site Editor patterns search works as expected.