### PR TITLE
E2E Utils: Allow overriding username/password

### DIFF
--- a/packages/e2e-test-utils-playwright/src/config.ts
+++ b/packages/e2e-test-utils-playwright/src/config.ts
@@ -1,12 +1,12 @@
-const WP_ADMIN_USER = {
-	username: 'admin',
-	password: 'password',
-} as const;
-
 const {
-	WP_USERNAME = WP_ADMIN_USER.username,
-	WP_PASSWORD = WP_ADMIN_USER.password,
+	WP_USERNAME = 'admin',
+	WP_PASSWORD = 'password',
 	WP_BASE_URL = 'http://localhost:8889',
 } = process.env;
+
+const WP_ADMIN_USER = {
+	username: WP_USERNAME,
+	password: WP_PASSWORD,
+} as const;
 
 export { WP_ADMIN_USER, WP_USERNAME, WP_PASSWORD, WP_BASE_URL };


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
`WP_ADMIN_USER` was hardcoded in [config.ts](https://github.com/WordPress/gutenberg/blob/trunk/packages/e2e-test-utils-playwright/src/config.ts#L2). Fixes #52598 

## Why?
Because of hardcoded values, the credential variables was not passing through `.env` file and was giving 400 error

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
Add `.env` file in your test directory and run the tests, don't forget to add `require( 'dotenv' ).config();` in your playwright.config.ts

