### PR TITLE
refactor: Reduce server log verbosity

### DIFF
--- a/packages/react-native-aztec/src/AztecView.js
+++ b/packages/react-native-aztec/src/AztecView.js
@@ -256,9 +256,6 @@ class AztecView extends Component {
 
 		if ( style.hasOwnProperty( 'lineHeight' ) ) {
 			delete style.lineHeight;
-			window.console.warn(
-				"Removing lineHeight style as it's not supported by native AztecView"
-			);
 			// Prevents passing line-height within styles to avoid a crash due to values without units
 			// We now support this but passing line-height as a prop instead.
 		}

--- a/packages/react-native-editor/src/setup.js
+++ b/packages/react-native-editor/src/setup.js
@@ -22,14 +22,6 @@ import setupApiFetch from './api-fetch-setup';
 const reactNativeSetup = () => {
 	LogBox.ignoreLogs( [
 		'Require cycle:', // TODO: Refactor to remove require cycles
-		/**
-		 * TODO: Migrate to @gorhom/bottom-sheet or replace usage of
-		 * LayoutAnimation to Animated. KeyboardAvoidingView's usage of
-		 * LayoutAnimation collides with both BottomSheet and NavigationContainer
-		 * usage of LayoutAnimation simultaneously https://github.com/facebook/react-native/issues/12663,
-		 * https://github.com/facebook/react-native/issues/10606
-		 */
-		'Overriding previous layout animation',
 	] );
 
 	// "@react-navigation" package uses the old API of gesture handler,

--- a/packages/react-native-editor/src/setup.js
+++ b/packages/react-native-editor/src/setup.js
@@ -49,10 +49,6 @@ const gutenbergSetup = () => {
 
 	setupApiFetch();
 
-	const isHermes = () => global.HermesInternal !== null;
-	// eslint-disable-next-line no-console
-	console.log( 'Hermes is: ' + isHermes() );
-
 	setupInitHooks();
 };
 

--- a/packages/react-native-editor/src/setup.js
+++ b/packages/react-native-editor/src/setup.js
@@ -22,7 +22,6 @@ import setupApiFetch from './api-fetch-setup';
 const reactNativeSetup = () => {
 	LogBox.ignoreLogs( [
 		'Require cycle:', // TODO: Refactor to remove require cycles
-		'lineHeight', // TODO: Remove lineHeight warning from Aztec
 		/**
 		 * TODO: Migrate to @gorhom/bottom-sheet or replace usage of
 		 * LayoutAnimation to Animated. KeyboardAvoidingView's usage of

--- a/packages/react-native-editor/src/setup.js
+++ b/packages/react-native-editor/src/setup.js
@@ -24,12 +24,6 @@ const reactNativeSetup = () => {
 		'Require cycle:', // TODO: Refactor to remove require cycles
 	] );
 
-	// "@react-navigation" package uses the old API of gesture handler,
-	// so the warning will be silenced until it gets updated.
-	LogBox.ignoreLogs( [
-		"[react-native-gesture-handler] Seems like you're using an old API with gesture components, check out new Gestures system!",
-	] );
-
 	I18nManager.forceRTL( false ); // Change to `true` to debug RTL layout easily.
 };
 

--- a/packages/react-native-editor/src/test/index.test.js
+++ b/packages/react-native-editor/src/test/index.test.js
@@ -197,7 +197,6 @@ describe( 'Register Gutenberg', () => {
 			registerCoreBlocksCallOrder
 		);
 		expect( callbackCallOrder ).toBeLessThan( onRenderEditorCallOrder );
-		expect( console ).toHaveLoggedWith( 'Hermes is: true' );
 
 		initializeEditorMock.mockRestore();
 	} );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Reduce the number of un-filterable server logs and warnings.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Un-filterable logs and warnings create ever-present noise that increases the
likelihood a new warning is overlooked and inhibits the ability to use the
server log for ad-hoc debugging.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
**refactor: Remove outdated LogBox configuration for gesture handler**
This warning appears to no longer occur. The configuration was
originally added in: a1b11c512ce5fa8f5eb59dcd4a27b3b52b224ec1

**refactor: Remove outdated LogBox configuration for LayoutAnimation**
This warning appears to no longer occur, presumably thanks to:
https://github.com/WordPress/gutenberg/pull/52563

**refactor: Remove Hermes engine status log**
While informative, this un-filterable log increases the amount of noise
in the server log, which can make it difficult to debug errors,
warnings, or intentionally logged values. 

**refactor: Remove unsupported line height Aztec warning**
While arguably educational, this warning increases the amount of noise
within the server log, which can make it difficult to debug errors,
warnings, or intentionally logged values.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
Launch the Demo editor and verify no unexpected logs and warnings are shown in
the server log.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
n/a

## Screenshots or screencast <!-- if applicable -->
n/a
