### PR TITLE
[RNMobile] Avoid navigation container dismissing the keyboard

### DIFF
--- a/packages/components/src/mobile/bottom-sheet/bottom-sheet-navigation/navigation-container.native.js
+++ b/packages/components/src/mobile/bottom-sheet/bottom-sheet-navigation/navigation-container.native.js
@@ -162,6 +162,7 @@ function BottomSheetNavigationContainer( {
 							<Stack.Navigator
 								screenOptions={ options }
 								detachInactiveScreens={ false }
+								keyboardHandlingEnabled={ false }
 							>
 								{ screens }
 							</Stack.Navigator>
@@ -170,6 +171,7 @@ function BottomSheetNavigationContainer( {
 						<Stack.Navigator
 							screenOptions={ options }
 							detachInactiveScreens={ false }
+							keyboardHandlingEnabled={ false }
 						>
 							{ screens }
 						</Stack.Navigator>

--- a/packages/components/src/mobile/bottom-sheet/bottom-sheet-navigation/navigation-container.native.js
+++ b/packages/components/src/mobile/bottom-sheet/bottom-sheet-navigation/navigation-container.native.js
@@ -59,6 +59,7 @@ const options = {
 	headerShown: false,
 	gestureEnabled: false,
 	cardStyleInterpolator: fadeConfig,
+	keyboardHandlingEnabled: false,
 };
 
 const HEIGHT_ANIMATION_DURATION = 300;
@@ -162,7 +163,6 @@ function BottomSheetNavigationContainer( {
 							<Stack.Navigator
 								screenOptions={ options }
 								detachInactiveScreens={ false }
-								keyboardHandlingEnabled={ false }
 							>
 								{ screens }
 							</Stack.Navigator>
@@ -171,7 +171,6 @@ function BottomSheetNavigationContainer( {
 						<Stack.Navigator
 							screenOptions={ options }
 							detachInactiveScreens={ false }
-							keyboardHandlingEnabled={ false }
 						>
 							{ screens }
 						</Stack.Navigator>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Disallowing navigation containers to control the keyboard and dismiss it when navigation occurs.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

This is a regression introduced when updating the React Navigation library via the [React Native upgrade 0.71.11](https://github.com/WordPress/gutenberg/pull/51303).

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Pass the prop [`keyboardHandlingEnabled`](https://reactnavigation.org/docs/stack-navigator/#keyboardhandlingenabled) to the navigation containers with value `false`. This should be enough to address the regression, based on the documentation:

> If false, the keyboard will NOT automatically dismiss when navigating to a new screen from this screen. Defaults to true.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Open a post/page.
2. Add a Paragraph block.
3. Select the Paragraph block and type some text.
4. Observe the text input is focused.
5. Tap on the ⚙️ button located in the bottom bar.
6. Observe the block settings sheet is displayed.
7. Tap on the backdrop area to dismiss the bottom sheet.
8. Observe the text input re-gains focus automatically.
9. Tap on the ⚙️ button located in the bottom bar.
10. Tap on the "Text" or "Background" options to navigate to an inner sheet.
11. Tap on the backdrop area to dismiss the bottom sheet. 
12. Observe the text input re-gains focus automatically.
13. Tap on the "Align text" button located in the bottom bar (next to ⚙️ button).
14. Tap on the backdrop area to dismiss the bottom sheet.
15. Observe the text input re-gains focus automatically.

⚠️ **NOTE:** On Android, the text input gains focus after dismissing the bottom sheet. However, as far as I tested (including the production version and before introducing the regression) the keyboard is not opened again.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
N/A

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/14905380/153409c4-ca16-45d1-9cd9-79b3373b63d6