### PR TITLE
Image block: Fix stretched images constrained by max-width

### DIFF
--- a/packages/block-library/src/image/block.json
+++ b/packages/block-library/src/image/block.json
@@ -64,10 +64,10 @@
 			"__experimentalRole": "content"
 		},
 		"width": {
-			"type": "number"
+			"type": "string"
 		},
 		"height": {
-			"type": "number"
+			"type": "string"
 		},
 		"aspectRatio": {
 			"type": "string"

--- a/packages/block-library/src/image/deprecated.js
+++ b/packages/block-library/src/image/deprecated.js
@@ -745,7 +745,7 @@ const v6 = {
  * removing the width and height img element attributes which are not needed
  * as they get added by the TODO hook.
  *
- * @see https://github.com/WordPress/gutenberg/pull/TODO
+ * @see https://github.com/WordPress/gutenberg/pull/53274
  */
 const v7 = {
 	attributes: {

--- a/packages/block-library/src/image/deprecated.js
+++ b/packages/block-library/src/image/deprecated.js
@@ -740,4 +740,211 @@ const v6 = {
 	},
 };
 
-export default [ v6, v5, v4, v3, v2, v1 ];
+/**
+ * Deprecation for converting to string width and height block attributes and
+ * removing the width and height img element attributes which are not needed
+ * as they get added by the TODO hook.
+ *
+ * @see https://github.com/WordPress/gutenberg/pull/TODO
+ */
+const v7 = {
+	attributes: {
+		align: {
+			type: 'string',
+		},
+		url: {
+			type: 'string',
+			source: 'attribute',
+			selector: 'img',
+			attribute: 'src',
+			__experimentalRole: 'content',
+		},
+		alt: {
+			type: 'string',
+			source: 'attribute',
+			selector: 'img',
+			attribute: 'alt',
+			default: '',
+			__experimentalRole: 'content',
+		},
+		caption: {
+			type: 'string',
+			source: 'html',
+			selector: 'figcaption',
+			__experimentalRole: 'content',
+		},
+		title: {
+			type: 'string',
+			source: 'attribute',
+			selector: 'img',
+			attribute: 'title',
+			__experimentalRole: 'content',
+		},
+		href: {
+			type: 'string',
+			source: 'attribute',
+			selector: 'figure > a',
+			attribute: 'href',
+			__experimentalRole: 'content',
+		},
+		rel: {
+			type: 'string',
+			source: 'attribute',
+			selector: 'figure > a',
+			attribute: 'rel',
+		},
+		linkClass: {
+			type: 'string',
+			source: 'attribute',
+			selector: 'figure > a',
+			attribute: 'class',
+		},
+		id: {
+			type: 'number',
+			__experimentalRole: 'content',
+		},
+		width: {
+			type: 'number',
+		},
+		height: {
+			type: 'number',
+		},
+		aspectRatio: {
+			type: 'string',
+		},
+		scale: {
+			type: 'string',
+		},
+		sizeSlug: {
+			type: 'string',
+		},
+		linkDestination: {
+			type: 'string',
+		},
+		linkTarget: {
+			type: 'string',
+			source: 'attribute',
+			selector: 'figure > a',
+			attribute: 'target',
+		},
+	},
+	supports: {
+		anchor: true,
+		behaviors: {
+			lightbox: true,
+		},
+		color: {
+			text: false,
+			background: false,
+		},
+		filter: {
+			duotone: true,
+		},
+		__experimentalBorder: {
+			color: true,
+			radius: true,
+			width: true,
+			__experimentalSkipSerialization: true,
+			__experimentalDefaultControls: {
+				color: true,
+				radius: true,
+				width: true,
+			},
+		},
+	},
+	migrate( { width, height, ...attributes } ) {
+		return {
+			...attributes,
+			width: `${ width }px`,
+			height: `${ height }px`,
+		};
+	},
+	save( { attributes } ) {
+		const {
+			url,
+			alt,
+			caption,
+			align,
+			href,
+			rel,
+			linkClass,
+			width,
+			height,
+			aspectRatio,
+			scale,
+			id,
+			linkTarget,
+			sizeSlug,
+			title,
+		} = attributes;
+
+		const newRel = ! rel ? undefined : rel;
+		const borderProps = getBorderClassesAndStyles( attributes );
+
+		const classes = classnames( {
+			[ `align${ align }` ]: align,
+			[ `size-${ sizeSlug }` ]: sizeSlug,
+			'is-resized': width || height,
+			'has-custom-border':
+				!! borderProps.className ||
+				( borderProps.style &&
+					Object.keys( borderProps.style ).length > 0 ),
+		} );
+
+		const imageClasses = classnames( borderProps.className, {
+			[ `wp-image-${ id }` ]: !! id,
+		} );
+
+		const image = (
+			<img
+				src={ url }
+				alt={ alt }
+				className={ imageClasses || undefined }
+				style={ {
+					...borderProps.style,
+					aspectRatio,
+					objectFit: scale,
+					width,
+					height,
+				} }
+				width={ width }
+				height={ height }
+				title={ title }
+			/>
+		);
+
+		const figure = (
+			<>
+				{ href ? (
+					<a
+						className={ linkClass }
+						href={ href }
+						target={ linkTarget }
+						rel={ newRel }
+					>
+						{ image }
+					</a>
+				) : (
+					image
+				) }
+				{ ! RichText.isEmpty( caption ) && (
+					<RichText.Content
+						className={ __experimentalGetElementClassName(
+							'caption'
+						) }
+						tagName="figcaption"
+						value={ caption }
+					/>
+				) }
+			</>
+		);
+
+		return (
+			<figure { ...useBlockProps.save( { className: classes } ) }>
+				{ figure }
+			</figure>
+		);
+	},
+};
+
+export default [ v7, v6, v5, v4, v3, v2, v1 ];

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -252,11 +252,7 @@ export default function Image( {
 				loadedNaturalHeight ||
 				undefined,
 		};
-	}, [
-		loadedNaturalWidth,
-		loadedNaturalHeight,
-		imageRef.current?.complete,
-	] );
+	}, [ loadedNaturalWidth, loadedNaturalHeight, imageRef.current ] );
 
 	function onResizeStart() {
 		toggleSelection( false );
@@ -480,6 +476,26 @@ export default function Image( {
 					<DimensionsTool
 						value={ { width, height, scale, aspectRatio } }
 						onChange={ ( newValue ) => {
+							// If the width and height are set but the aspect ratio isn't
+							// then we need to calculate the aspect ratio from the width and height.
+							let newAspectRatio = newValue.aspectRatio;
+							const newNumericHeight = parseInt(
+								newValue.height,
+								10
+							);
+							const newNumericWidth = parseInt(
+								newValue.width,
+								10
+							);
+							if (
+								! newAspectRatio &&
+								height &&
+								newNumericWidth
+							) {
+								newAspectRatio =
+									newNumericWidth + '/' + newNumericHeight;
+							}
+
 							// Rebuilding the object forces setting `undefined`
 							// for values that are removed since setAttributes
 							// doesn't do anything with keys that aren't set.
@@ -487,7 +503,7 @@ export default function Image( {
 								width: newValue.width,
 								height: newValue.height,
 								scale: newValue.scale,
-								aspectRatio: newValue.aspectRatio,
+								aspectRatio: newAspectRatio,
 							} );
 						} }
 						defaultScale="cover"

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -252,7 +252,11 @@ export default function Image( {
 				loadedNaturalHeight ||
 				undefined,
 		};
-	}, [ loadedNaturalWidth, loadedNaturalHeight, imageRef.current ] );
+	}, [
+		loadedNaturalWidth,
+		loadedNaturalHeight,
+		imageRef.current?.complete,
+	] );
 
 	function onResizeStart() {
 		toggleSelection( false );
@@ -476,26 +480,6 @@ export default function Image( {
 					<DimensionsTool
 						value={ { width, height, scale, aspectRatio } }
 						onChange={ ( newValue ) => {
-							// If the width and height are set but the aspect ratio isn't
-							// then we need to calculate the aspect ratio from the width and height.
-							let newAspectRatio = newValue.aspectRatio;
-							const newNumericHeight = parseInt(
-								newValue.height,
-								10
-							);
-							const newNumericWidth = parseInt(
-								newValue.width,
-								10
-							);
-							if (
-								! newAspectRatio &&
-								height &&
-								newNumericWidth
-							) {
-								newAspectRatio =
-									newNumericWidth + '/' + newNumericHeight;
-							}
-
 							// Rebuilding the object forces setting `undefined`
 							// for values that are removed since setAttributes
 							// doesn't do anything with keys that aren't set.
@@ -503,7 +487,7 @@ export default function Image( {
 								width: newValue.width,
 								height: newValue.height,
 								scale: newValue.scale,
-								aspectRatio: newAspectRatio,
+								aspectRatio: newValue.aspectRatio,
 							} );
 						} }
 						defaultScale="cover"

--- a/packages/block-library/src/image/save.js
+++ b/packages/block-library/src/image/save.js
@@ -61,8 +61,6 @@ export default function save( { attributes } ) {
 				width,
 				height,
 			} }
-			width={ width }
-			height={ height }
 			title={ title }
 		/>
 	);

--- a/packages/block-library/src/image/save.js
+++ b/packages/block-library/src/image/save.js
@@ -59,7 +59,7 @@ export default function save( { attributes } ) {
 				aspectRatio,
 				objectFit: scale,
 				width,
-				maxHeight: height,
+				height,
 			} }
 			title={ title }
 		/>

--- a/packages/block-library/src/image/save.js
+++ b/packages/block-library/src/image/save.js
@@ -59,7 +59,7 @@ export default function save( { attributes } ) {
 				aspectRatio,
 				objectFit: scale,
 				width,
-				height,
+				maxHeight: height,
 			} }
 			title={ title }
 		/>

--- a/test/integration/fixtures/blocks/core__image__deprecated-v2-add-is-resized-class.serialized.html
+++ b/test/integration/fixtures/blocks/core__image__deprecated-v2-add-is-resized-class.serialized.html
@@ -1,3 +1,3 @@
 <!-- wp:image {"align":"left","width":100,"height":100} -->
-<figure class="wp-block-image alignleft is-resized"><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==" alt="" style="width:100px;height:100px" width="100" height="100"/></figure>
+<figure class="wp-block-image alignleft is-resized"><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==" alt="" style="width:100px;height:100px"/></figure>
 <!-- /wp:image -->

--- a/test/integration/fixtures/blocks/core__image__deprecated-v3-add-align-wrapper.serialized.html
+++ b/test/integration/fixtures/blocks/core__image__deprecated-v3-add-align-wrapper.serialized.html
@@ -1,3 +1,3 @@
 <!-- wp:image {"align":"left","width":100,"height":100} -->
-<figure class="wp-block-image alignleft is-resized"><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==" alt="" style="width:100px;height:100px" width="100" height="100"/></figure>
+<figure class="wp-block-image alignleft is-resized"><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==" alt="" style="width:100px;height:100px"/></figure>
 <!-- /wp:image -->

--- a/test/integration/fixtures/blocks/core__image__deprecated-v4-remove-align-wrapper.serialized.html
+++ b/test/integration/fixtures/blocks/core__image__deprecated-v4-remove-align-wrapper.serialized.html
@@ -1,3 +1,3 @@
 <!-- wp:image {"align":"left","id":13,"width":358,"height":164,"sizeSlug":"large","linkDestination":"none"} -->
-<figure class="wp-block-image alignleft size-large is-resized"><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==" alt="" class="wp-image-13" style="width:358px;height:164px" width="358" height="164"/></figure>
+<figure class="wp-block-image alignleft size-large is-resized"><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==" alt="" class="wp-image-13" style="width:358px;height:164px"/></figure>
 <!-- /wp:image -->

--- a/test/integration/fixtures/blocks/core__image__deprecated-v6-add-style-width-height.serialized.html
+++ b/test/integration/fixtures/blocks/core__image__deprecated-v6-add-style-width-height.serialized.html
@@ -1,3 +1,3 @@
 <!-- wp:image {"align":"left","width":164,"height":164,"sizeSlug":"large","className":"is-style-rounded","style":{"border":{"radius":"100%"}}} -->
-<figure class="wp-block-image alignleft size-large is-resized has-custom-border is-style-rounded"><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==" alt="" style="border-radius:100%;width:164px;height:164px" width="164" height="164"/></figure>
+<figure class="wp-block-image alignleft size-large is-resized has-custom-border is-style-rounded"><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==" alt="" style="border-radius:100%;width:164px;height:164px"/></figure>
 <!-- /wp:image -->

--- a/test/integration/fixtures/blocks/core__image__deprecated-v7-string-width-height-attributes.html
+++ b/test/integration/fixtures/blocks/core__image__deprecated-v7-string-width-height-attributes.html
@@ -1,0 +1,3 @@
+<!-- wp:image {"width":164,"height":164,"sizeSlug":"large"} -->
+<figure class="wp-block-image size-large is-resized"><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==" alt="" style="width:164px;height:164px;" width="164" height="164"/></figure>
+<!-- /wp:image -->

--- a/test/integration/fixtures/blocks/core__image__deprecated-v7-string-width-height-attributes.json
+++ b/test/integration/fixtures/blocks/core__image__deprecated-v7-string-width-height-attributes.json
@@ -1,0 +1,15 @@
+[
+	{
+		"name": "core/image",
+		"isValid": true,
+		"attributes": {
+			"url": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==",
+			"alt": "",
+			"caption": "",
+			"sizeSlug": "large",
+			"width": "164px",
+			"height": "164px"
+		},
+		"innerBlocks": []
+	}
+]

--- a/test/integration/fixtures/blocks/core__image__deprecated-v7-string-width-height-attributes.parsed.json
+++ b/test/integration/fixtures/blocks/core__image__deprecated-v7-string-width-height-attributes.parsed.json
@@ -1,0 +1,15 @@
+[
+	{
+		"blockName": "core/image",
+		"attrs": {
+			"width": 164,
+			"height": 164,
+			"sizeSlug": "large"
+		},
+		"innerBlocks": [],
+		"innerHTML": "\n<figure class=\"wp-block-image size-large is-resized\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==\" alt=\"\" style=\"width:164px;height:164px;\" width=\"164\" height=\"164\"/></figure>\n",
+		"innerContent": [
+			"\n<figure class=\"wp-block-image size-large is-resized\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==\" alt=\"\" style=\"width:164px;height:164px;\" width=\"164\" height=\"164\"/></figure>\n"
+		]
+	}
+]

--- a/test/integration/fixtures/blocks/core__image__deprecated-v7-string-width-height-attributes.serialized.html
+++ b/test/integration/fixtures/blocks/core__image__deprecated-v7-string-width-height-attributes.serialized.html
@@ -1,0 +1,3 @@
+<!-- wp:image {"width":"164px","height":"164px","sizeSlug":"large"} -->
+<figure class="wp-block-image size-large is-resized"><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==" alt="" style="width:164px;height:164px"/></figure>
+<!-- /wp:image -->


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

- When dragging to resize an image, set `width` to the width in pixels, `height` to auto, and `aspect-ratio` to the computed image aspect ratio. This should match the user's expectations that the aspect ratio of the block is fixed even when constrained by `max-width`.
- Remove the `<img>` element `width` and `height` attributes from `save` as they are already added via [a hook](https://github.com/WordPress/wordpress-develop/blob/3a3bd8ea834e764de11fde21cf614fd87f66ac8c/src/wp-includes/media.php#L1810) to all images on a page.
- Add block deprecation and migration for `width` and `height` block attributes to be strings.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Fixes #52739

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Previously, dragging to resize would set the width and height of an image. However this caused problems in contexts where the block's max-width would constrain the image.

This approach solves the problem by saving the image's computed aspect ratio and sizing the block based on the width of the image when it is dragged to be resized.

Not every image is constrained by `max-width`, however. For example, image blocks grouped in a horizontal row block are not affected by `max-width`. In those scenarios, you may want to fix the height and allow for auto width.

Horizontal layouts are less common and there isn't a good way to know the context that the block will be rendered in from the perspective of the image block, so I can't really add a heuristic for dragging to resize the image in those scenarios. The sidebar will have to be used to set the height while leaving the width to be auto if you want a layout like that.

Rather than adding a new attribute for CSS `width` and `height`, the existing ones have been migrated to represent CSS strings instead of numbers representing `px` values.

The `<img>` element `width` and `height` attributes were removed from the `save` function as they are automatically added via a hook to prevent layout shifts as image load. This decouples the block attributes from the element attributes and allows for styling to be more flexible and matches the intention of setting the width and height of an image in the editor.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

See #52739 for details.

1. Insert an image into a post.
2. Resize the image to a smaller size, but do not select a scaling option.
3. View the site using responsive tools and observe the image scale down as expected when you reach widths smaller than `max-width` for your theme.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
