### PR TITLE
Add some missing internal peer dependencies

### DIFF
--- a/packages/annotations/package.json
+++ b/packages/annotations/package.json
@@ -33,6 +33,9 @@
 		"rememo": "^4.0.2",
 		"uuid": "^8.3.0"
 	},
+	"peerDependencies": {
+		"react": "^18.0.0"
+	},
 	"publishConfig": {
 		"access": "public"
 	}

--- a/packages/commands/package.json
+++ b/packages/commands/package.json
@@ -38,7 +38,8 @@
 		"rememo": "^4.0.2"
 	},
 	"peerDependencies": {
-		"react": "^18.0.0"
+		"react": "^18.0.0",
+		"react-dom": "^18.0.0"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/core-commands/package.json
+++ b/packages/core-commands/package.json
@@ -39,7 +39,8 @@
 		"@wordpress/url": "file:../url"
 	},
 	"peerDependencies": {
-		"react": "^18.0.0"
+		"react": "^18.0.0",
+		"react-dom": "^18.0.0"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/core-data/package.json
+++ b/packages/core-data/package.json
@@ -51,7 +51,8 @@
 		"uuid": "^8.3.0"
 	},
 	"peerDependencies": {
-		"react": "^18.0.0"
+		"react": "^18.0.0",
+		"react-dom": "^18.0.0"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/data-controls/package.json
+++ b/packages/data-controls/package.json
@@ -32,6 +32,9 @@
 		"@wordpress/data": "file:../data",
 		"@wordpress/deprecated": "file:../deprecated"
 	},
+	"peerDependencies": {
+		"react": "^18.0.0"
+	},
 	"publishConfig": {
 		"access": "public"
 	}

--- a/packages/notices/package.json
+++ b/packages/notices/package.json
@@ -30,6 +30,9 @@
 		"@wordpress/a11y": "file:../a11y",
 		"@wordpress/data": "file:../data"
 	},
+	"peerDependencies": {
+		"react": "^18.0.0"
+	},
 	"publishConfig": {
 		"access": "public"
 	}

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -36,7 +36,8 @@
 		"memize": "^2.0.1"
 	},
 	"peerDependencies": {
-		"react": "^18.0.0"
+		"react": "^18.0.0",
+		"react-dom": "^18.0.0"
 	},
 	"publishConfig": {
 		"access": "public"


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

If you install WordPress packages in another repo, you'll likely see these messages:

```sh
➤ YN0002: │ @wordpress/annotations doesn't provide react (p989a1), requested by @wordpress/data
➤ YN0002: │ @wordpress/annotations doesn't provide react (p7be6e), requested by @wordpress/rich-text
➤ YN0002: │ @wordpress/commands [62522] doesn't provide react-dom (p74998), requested by @wordpress/components
➤ YN0002: │ @wordpress/commands [62522] doesn't provide react-dom (p22ea4), requested by cmdk
➤ YN0002: │ @wordpress/core-commands [62522] doesn't provide react-dom (p9fc8f), requested by @wordpress/block-editor
➤ YN0002: │ @wordpress/core-data [62522] doesn't provide react-dom (pcd477), requested by @wordpress/block-editor
➤ YN0002: │ @wordpress/data-controls doesn't provide react (p1b32a), requested by @wordpress/data
➤ YN0002: │ @wordpress/e2e-tests [62522] doesn't provide puppeteer (pea0fd), requested by puppeteer-testing-library
➤ YN0002: │ @wordpress/notices doesn't provide react (p103c4), requested by @wordpress/data
➤ YN0002: │ @wordpress/plugins [62522] doesn't provide react-dom (p2c1a1), requested by @wordpress/components
```

The problem is that a few of our internal packages don't handle some peer dependency requests. For example, `@wordpress/data` includes `use-memo-one`, which requests React. As a result, `@wordpress/data` sets react as a peer dependency. Now, any internal package using `@wordpress/data` needs to either provide React or set it as a peer dependency.

While this is somewhat annoying, it's really important to have explicit dependencies. In these cases, we don't want to provide React ourselves, but we want a consumer to use their copy. So we have to add peer dependencies requests for react and react-dom in a lot of places.

The only other way to avoid this is to stop using packages which have peer dependency requests for React in our most commonly used packages. For example, removing `use-memo-one` would mean that `@wordpress/data` (and therefore a _ton_ of other internal packages) doesn't need a peer dep on react.
 
There are a few remaining peer dep issues, but those come from other repositories like deepsignal. Some other things we could do for follow-up:
1. Remove reakit if possible, which has been migrated to a different package (iirc) and doesn't support current React versions. (https://github.com/WordPress/gutenberg/pull/51623#issuecomment-1598920851)
2. Update `stylelint-config-recommended-scss` to get a peer dep fix on their end: https://github.com/WordPress/gutenberg/pull/53276
3. Remove puppeteer or update it to get a peer dep fix on their end.

## Why?
So that we stop showing warnings in other repos!

## How?
I have a little repo set up: https://github.com/noahtallen/test-yarn-gutenberg. This has some scripts which add dependencies on all `@wordpress` packages, detects peer issues, and autofixes them.

## Testing Instructions
Basically just verify these make sense! We've done this in many places already.
