### PR TITLE
Update stylelint config packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18718,8 +18718,8 @@
 			"version": "file:packages/stylelint-config",
 			"dev": true,
 			"requires": {
-				"stylelint-config-recommended": "^6.0.0",
-				"stylelint-config-recommended-scss": "^5.0.2"
+				"stylelint-config-recommended": "^13.0.0",
+				"stylelint-config-recommended-scss": "^12.0.0"
 			}
 		},
 		"@wordpress/token-list": {
@@ -47919,7 +47919,7 @@
 		"on-finished": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
-			"integrity": "sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==",
+			"integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
 			"requires": {
 				"ee-first": "1.1.1"
 			}

--- a/package-lock.json
+++ b/package-lock.json
@@ -18720,6 +18720,61 @@
 			"requires": {
 				"stylelint-config-recommended": "^13.0.0",
 				"stylelint-config-recommended-scss": "^12.0.0"
+			},
+			"dependencies": {
+				"postcss-selector-parser": {
+					"version": "6.0.13",
+					"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.13.tgz",
+					"integrity": "sha512-EaV1Gl4mUEV4ddhDnv/xtj7sxwrwxdetHdWUGnT4VJQf+4d05v6lHYZr8N573k5Z0BViss7BDhfWtKS3+sfAqQ==",
+					"dev": true,
+					"requires": {
+						"cssesc": "^3.0.0",
+						"util-deprecate": "^1.0.2"
+					}
+				},
+				"postcss-value-parser": {
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+					"integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+					"dev": true
+				},
+				"stylelint-config-recommended": {
+					"version": "13.0.0",
+					"resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-13.0.0.tgz",
+					"integrity": "sha512-EH+yRj6h3GAe/fRiyaoO2F9l9Tgg50AOFhaszyfov9v6ayXJ1IkSHwTxd7lB48FmOeSGDPLjatjO11fJpmarkQ==",
+					"dev": true
+				},
+				"stylelint-config-recommended-scss": {
+					"version": "12.0.0",
+					"resolved": "https://registry.npmjs.org/stylelint-config-recommended-scss/-/stylelint-config-recommended-scss-12.0.0.tgz",
+					"integrity": "sha512-5Bb2mlGy6WLa30oNeKpZvavv2lowJUsUJO25+OA68GFTemlwd1zbFsL7q0bReKipOSU3sG47hKneZ6Nd+ctrFA==",
+					"dev": true,
+					"requires": {
+						"postcss-scss": "^4.0.6",
+						"stylelint-config-recommended": "^12.0.0",
+						"stylelint-scss": "^5.0.0"
+					},
+					"dependencies": {
+						"stylelint-config-recommended": {
+							"version": "12.0.0",
+							"resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-12.0.0.tgz",
+							"integrity": "sha512-x6x8QNARrGO2sG6iURkzqL+Dp+4bJorPMMRNPScdvaUK8PsynriOcMW7AFDKqkWAS5wbue/u8fUT/4ynzcmqdQ==",
+							"dev": true
+						}
+					}
+				},
+				"stylelint-scss": {
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/stylelint-scss/-/stylelint-scss-5.0.1.tgz",
+					"integrity": "sha512-n87iCRZrr2J7//I/QFsDXxFLnHKw633U4qvWZ+mOW6KDAp/HLj06H+6+f9zOuTYy+MdGdTuCSDROCpQIhw5fvQ==",
+					"dev": true,
+					"requires": {
+						"postcss-media-query-parser": "^0.2.3",
+						"postcss-resolve-nested-selector": "^0.1.1",
+						"postcss-selector-parser": "^6.0.13",
+						"postcss-value-parser": "^4.2.0"
+					}
+				}
 			}
 		},
 		"@wordpress/token-list": {
@@ -49527,6 +49582,12 @@
 			"integrity": "sha512-FARHN8pwH+WiS2OPCxJI8FuRJpTVnn6ZNFiqAM2aeW2LwTHWWmWgIyKC6cUo0L8aeKiF/14MNvnpls6R2PBeMQ==",
 			"dev": true
 		},
+		"postcss-scss": {
+			"version": "4.0.6",
+			"resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-4.0.6.tgz",
+			"integrity": "sha512-rLDPhJY4z/i4nVFZ27j9GqLxj1pwxE80eAzUNRMXtcpipFYIeowerzBgG3yJhMtObGEXidtIgbUpQ3eLDsf5OQ==",
+			"dev": true
+		},
 		"postcss-selector-parser": {
 			"version": "6.0.4",
 			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.4.tgz",
@@ -56363,62 +56424,6 @@
 					"version": "1.10.2",
 					"resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
 					"integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
-					"dev": true
-				}
-			}
-		},
-		"stylelint-config-recommended": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-6.0.0.tgz",
-			"integrity": "sha512-ZorSSdyMcxWpROYUvLEMm0vSZud2uB7tX1hzBZwvVY9SV/uly4AvvJPPhCcymZL3fcQhEQG5AELmrxWqtmzacw==",
-			"dev": true
-		},
-		"stylelint-config-recommended-scss": {
-			"version": "5.0.2",
-			"resolved": "https://registry.npmjs.org/stylelint-config-recommended-scss/-/stylelint-config-recommended-scss-5.0.2.tgz",
-			"integrity": "sha512-b14BSZjcwW0hqbzm9b0S/ScN2+3CO3O4vcMNOw2KGf8lfVSwJ4p5TbNEXKwKl1+0FMtgRXZj6DqVUe/7nGnuBg==",
-			"dev": true,
-			"requires": {
-				"postcss-scss": "^4.0.2",
-				"stylelint-config-recommended": "^6.0.0",
-				"stylelint-scss": "^4.0.0"
-			},
-			"dependencies": {
-				"postcss-scss": {
-					"version": "4.0.3",
-					"resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-4.0.3.tgz",
-					"integrity": "sha512-j4KxzWovfdHsyxwl1BxkUal/O4uirvHgdzMKS1aWJBAV0qh2qj5qAZqpeBfVUYGWv+4iK9Az7SPyZ4fyNju1uA==",
-					"dev": true
-				}
-			}
-		},
-		"stylelint-scss": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/stylelint-scss/-/stylelint-scss-4.1.0.tgz",
-			"integrity": "sha512-BNYTo7MMamhFOlcaAWp2dMpjg6hPyM/FFqfDIYzmYVLMmQJqc8lWRIiTqP4UX5bresj9Vo0dKC6odSh43VP2NA==",
-			"dev": true,
-			"requires": {
-				"lodash": "^4.17.21",
-				"postcss-media-query-parser": "^0.2.3",
-				"postcss-resolve-nested-selector": "^0.1.1",
-				"postcss-selector-parser": "^6.0.6",
-				"postcss-value-parser": "^4.1.0"
-			},
-			"dependencies": {
-				"postcss-selector-parser": {
-					"version": "6.0.8",
-					"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.8.tgz",
-					"integrity": "sha512-D5PG53d209Z1Uhcc0qAZ5U3t5HagH3cxu+WLZ22jt3gLUpXM4eXXfiO14jiDWST3NNooX/E8wISfOhZ9eIjGTQ==",
-					"dev": true,
-					"requires": {
-						"cssesc": "^3.0.0",
-						"util-deprecate": "^1.0.2"
-					}
-				},
-				"postcss-value-parser": {
-					"version": "4.2.0",
-					"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
-					"integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
 					"dev": true
 				}
 			}

--- a/package-lock.json
+++ b/package-lock.json
@@ -18675,7 +18675,7 @@
 				"sass": "^1.35.2",
 				"sass-loader": "^12.1.0",
 				"source-map-loader": "^3.0.0",
-				"stylelint": "^14.2.0",
+				"stylelint": "^14.16.1",
 				"terser-webpack-plugin": "^5.3.9",
 				"url-loader": "^4.1.1",
 				"webpack": "^5.47.1",

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -81,7 +81,7 @@
 		"sass": "^1.35.2",
 		"sass-loader": "^12.1.0",
 		"source-map-loader": "^3.0.0",
-		"stylelint": "^14.2.0",
+		"stylelint": "^14.16.1",
 		"terser-webpack-plugin": "^5.3.9",
 		"url-loader": "^4.1.1",
 		"webpack": "^5.47.1",

--- a/packages/stylelint-config/package.json
+++ b/packages/stylelint-config/package.json
@@ -31,8 +31,8 @@
 	],
 	"main": "index.js",
 	"dependencies": {
-		"stylelint-config-recommended": "^6.0.0",
-		"stylelint-config-recommended-scss": "^5.0.2"
+		"stylelint-config-recommended": "^13.0.0",
+		"stylelint-config-recommended-scss": "^12.0.0"
 	},
 	"peerDependencies": {
 		"stylelint": "^14.2"


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Updates the stylelint config packages (but _not_ stylelint itself, which is a much larger change!) looking at the changelogs for these config packages, though they're multiple major versions, they look very straightforward.

## Why?
I was working on #53275, and noticed a peer dependency warning about postcss. This is fixed by updating these packages. 

## How?
Simple package update!

## Testing Instructions
CI and `npm run lint:css`

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
