### PR TITLE
Global styles revisions: reduce visibility check from 2 to 1 revision

### DIFF
--- a/packages/edit-site/src/components/global-styles/ui.js
+++ b/packages/edit-site/src/components/global-styles/ui.js
@@ -139,7 +139,7 @@ function GlobalStylesRevisionsMenu() {
 		goTo( '/revisions' );
 		setEditorCanvasContainerView( 'global-styles-revisions' );
 	};
-	const hasRevisions = revisionsCount >= 1;
+	const hasRevisions = revisionsCount > 0;
 
 	return (
 		<GlobalStylesMenuFill>

--- a/packages/edit-site/src/components/sidebar-navigation-screen-global-styles/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-global-styles/index.js
@@ -222,7 +222,7 @@ export default function SidebarNavigationScreenGlobalStyles() {
 	}, [ openGlobalStyles, setEditorCanvasContainerView ] );
 
 	// If there are no revisions, do not render a footer.
-	const hasRevisions = revisionsCount >= 2;
+	const hasRevisions = revisionsCount > 0;
 	const modifiedDateTime = revisions?.[ 0 ]?.modified;
 	const shouldShowGlobalStylesFooter =
 		hasRevisions && ! isLoadingRevisions && modifiedDateTime;

--- a/test/e2e/specs/site-editor/user-global-styles-revisions.spec.js
+++ b/test/e2e/specs/site-editor/user-global-styles-revisions.spec.js
@@ -26,7 +26,7 @@ test.describe( 'Global styles revisions', () => {
 		await admin.visitSiteEditor();
 	} );
 
-	test( 'should display revisions UI when there is more than 1 revision', async ( {
+	test( 'should display revisions UI when there is 1 revision', async ( {
 		page,
 		editor,
 		userGlobalStylesRevisions,
@@ -39,19 +39,6 @@ test.describe( 'Global styles revisions', () => {
 		// Change a style and save it.
 		await page.getByRole( 'button', { name: 'Colors styles' } ).click();
 
-		await page
-			.getByRole( 'button', { name: 'Color Background styles' } )
-			.click();
-		await page
-			.getByRole( 'button', { name: 'Color: Black' } )
-			.click( { force: true } );
-
-		await editor.saveSiteEditorEntities();
-
-		/*
-		 * Change a style and save it again.
-		 * We need more than 2 revisions to show the UI.
-		 */
 		await page
 			.getByRole( 'button', { name: 'Color Background styles' } )
 			.click();
@@ -70,7 +57,7 @@ test.describe( 'Global styles revisions', () => {
 
 		// There should be 2 revisions not including the reset to theme defaults button.
 		await expect( revisionButtons ).toHaveCount(
-			currentRevisions.length + 2
+			currentRevisions.length + 1
 		);
 	} );
 


### PR DESCRIPTION
## What?
Reduces the revisions count condition with which we determine whether to open the styles revisions panel from `1` to `2`.

## Why?
Now that https://github.com/WordPress/gutenberg/pull/52965 has merged, we can show the revisions panel when there are more than `0` revisions since there is the default with which we can compare the single revision.

Previously, the panel was only available after 2 styles revisions were saved in the database.

This makes things consistent with the command center as well, which will allow opening the styles revisions panel after 1 revision.

## Testing Instructions
Start off with no style revisions. You shouldn't be able to open the styles revision panel from the site editor sidebar or the global styles panel.

<img width="281" alt="Screenshot 2023-08-03 at 1 57 13 pm" src="https://github.com/WordPress/gutenberg/assets/6458278/caf669d0-5a9b-4397-8da3-27fefc2c16f2">
<img width="359" alt="Screenshot 2023-08-03 at 1 55 37 pm" src="https://github.com/WordPress/gutenberg/assets/6458278/af0221a6-1022-44d4-b3ea-c1276a211d8b">

Now add a single revision, e.g., change the background color of the site and save.

The revisions panel should now be accessible from the site editor sidebar or the global styles panel.

<img width="366" alt="Screenshot 2023-08-03 at 2 01 30 pm" src="https://github.com/WordPress/gutenberg/assets/6458278/9bb0f668-5607-4092-b131-b5552c52fe23">


<img width="355" alt="Screenshot 2023-08-03 at 2 01 57 pm" src="https://github.com/WordPress/gutenberg/assets/6458278/fa1134b1-085f-4713-843c-e0ba70f25a77">

