### PR TITLE
Add layout and block spacing to details block

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -248,7 +248,7 @@ Hide and show additional content. ([Source](https://github.com/WordPress/gutenbe
 
 -	**Name:** core/details
 -	**Category:** text
--	**Supports:** align (full, wide), color (background, gradients, link, text), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
+-	**Supports:** align (full, wide), color (background, gradients, link, text), layout (~~allowEditing~~), spacing (blockGap, margin, padding), typography (fontSize, lineHeight), ~~html~~
 -	**Attributes:** showContent, summary
 
 ## Embed

--- a/packages/block-library/src/details/block.json
+++ b/packages/block-library/src/details/block.json
@@ -35,6 +35,7 @@
 		"spacing": {
 			"margin": true,
 			"padding": true,
+			"blockGap": true,
 			"__experimentalDefaultControls": {
 				"margin": false,
 				"padding": false
@@ -52,6 +53,9 @@
 			"__experimentalDefaultControls": {
 				"fontSize": true
 			}
+		},
+		"layout": {
+			"allowEditing": false
 		}
 	},
 	"editorStyle": "wp-block-details-editor",

--- a/packages/block-library/src/details/style.scss
+++ b/packages/block-library/src/details/style.scss
@@ -6,14 +6,3 @@
 .wp-block-details summary {
 	cursor: pointer;
 }
-
-// Use block gap for block; falls back to browser default if not supported.
-.wp-block-details > *:not(summary) {
-	margin-block-start: var(--wp--style--block-gap);
-	margin-block-end: 0;
-}
-
-// Remove excess margin from the last block.
-.wp-block-details > *:last-child {
-	margin-bottom: 0;
-}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes #53252.

Adds flow layout and block spacing to the Details block

Quick draft to check all works as expected; some items in the issue such as hardcoded style removal haven't been addressed yet.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Add details block with content
2. Under dimensions, change block spacing
3. Check it works in editor and front end.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
