### PR TITLE
Edit Post: Use hooks instead of HoC in 'PluginDocumentSettingPanel'

### DIFF
--- a/packages/edit-post/README.md
+++ b/packages/edit-post/README.md
@@ -146,10 +146,11 @@ registerPlugin( 'document-setting-test', { render: MyDocumentSettingTest } );
 _Parameters_
 
 -   _props_ `Object`: Component properties.
--   _props.name_ `[string]`: The machine-friendly name for the panel.
+-   _props.name_ `string`: The machine-friendly name for the panel.
 -   _props.className_ `[string]`: An optional class name added to the row.
 -   _props.title_ `[string]`: The title of the panel
 -   _props.icon_ `[WPBlockTypeIconRender]`: The [Dashicon](https://developer.wordpress.org/resource/dashicons/) icon slug string, or an SVG WP element, to be rendered when the sidebar is pinned to toolbar.
+-   _props.children_ `WPElement`: Children to be rendered
 
 _Returns_
 

--- a/packages/edit-post/src/components/sidebar/plugin-document-setting-panel/index.js
+++ b/packages/edit-post/src/components/sidebar/plugin-document-setting-panel/index.js
@@ -6,9 +6,8 @@
  * WordPress dependencies
  */
 import { createSlotFill, PanelBody } from '@wordpress/components';
-import { compose } from '@wordpress/compose';
-import { withPluginContext } from '@wordpress/plugins';
-import { withDispatch, withSelect } from '@wordpress/data';
+import { usePluginContext } from '@wordpress/plugins';
+import { useDispatch, useSelect } from '@wordpress/data';
 import warning from '@wordpress/warning';
 
 /**
@@ -19,47 +18,15 @@ import { store as editPostStore } from '../../../store';
 
 const { Fill, Slot } = createSlotFill( 'PluginDocumentSettingPanel' );
 
-const PluginDocumentSettingFill = ( {
-	isEnabled,
-	panelName,
-	opened,
-	onToggle,
-	className,
-	title,
-	icon,
-	children,
-} ) => {
-	return (
-		<>
-			<EnablePluginDocumentSettingPanelOption
-				label={ title }
-				panelName={ panelName }
-			/>
-			<Fill>
-				{ isEnabled && (
-					<PanelBody
-						className={ className }
-						title={ title }
-						icon={ icon }
-						opened={ opened }
-						onToggle={ onToggle }
-					>
-						{ children }
-					</PanelBody>
-				) }
-			</Fill>
-		</>
-	);
-};
-
 /**
  * Renders items below the Status & Availability panel in the Document Sidebar.
  *
  * @param {Object}                props                                 Component properties.
- * @param {string}                [props.name]                          The machine-friendly name for the panel.
+ * @param {string}                props.name                            The machine-friendly name for the panel.
  * @param {string}                [props.className]                     An optional class name added to the row.
  * @param {string}                [props.title]                         The title of the panel
  * @param {WPBlockTypeIconRender} [props.icon=inherits from the plugin] The [Dashicon](https://developer.wordpress.org/resource/dashicons/) icon slug string, or an SVG WP element, to be rendered when the sidebar is pinned to toolbar.
+ * @param {WPElement}             props.children                        Children to be rendered
  *
  * @example
  * ```js
@@ -102,30 +69,55 @@ const PluginDocumentSettingFill = ( {
  *
  * @return {WPComponent} The component to be rendered.
  */
-const PluginDocumentSettingPanel = compose(
-	withPluginContext( ( context, ownProps ) => {
-		if ( undefined === ownProps.name ) {
-			warning( 'PluginDocumentSettingPanel requires a name property.' );
-		}
-		return {
-			panelName: `${ context.name }/${ ownProps.name }`,
-		};
-	} ),
-	withSelect( ( select, { panelName } ) => {
-		return {
-			opened: select( editPostStore ).isEditorPanelOpened( panelName ),
-			isEnabled:
-				select( editPostStore ).isEditorPanelEnabled( panelName ),
-		};
-	} ),
-	withDispatch( ( dispatch, { panelName } ) => ( {
-		onToggle() {
-			return dispatch( editPostStore ).toggleEditorPanelOpened(
-				panelName
-			);
+const PluginDocumentSettingPanel = ( {
+	name,
+	className,
+	title,
+	icon,
+	children,
+} ) => {
+	const { name: pluginName } = usePluginContext();
+	const panelName = `${ pluginName }/${ name }`;
+	const { opened, isEnabled } = useSelect(
+		( select ) => {
+			const { isEditorPanelOpened, isEditorPanelEnabled } =
+				select( editPostStore );
+
+			return {
+				opened: isEditorPanelOpened( panelName ),
+				isEnabled: isEditorPanelEnabled( panelName ),
+			};
 		},
-	} ) )
-)( PluginDocumentSettingFill );
+		[ panelName ]
+	);
+	const { toggleEditorPanelOpened } = useDispatch( editPostStore );
+
+	if ( undefined === name ) {
+		warning( 'PluginDocumentSettingPanel requires a name property.' );
+	}
+
+	return (
+		<>
+			<EnablePluginDocumentSettingPanelOption
+				label={ title }
+				panelName={ panelName }
+			/>
+			<Fill>
+				{ isEnabled && (
+					<PanelBody
+						className={ className }
+						title={ title }
+						icon={ icon }
+						opened={ opened }
+						onToggle={ () => toggleEditorPanelOpened( panelName ) }
+					>
+						{ children }
+					</PanelBody>
+				) }
+			</Fill>
+		</>
+	);
+};
 
 PluginDocumentSettingPanel.Slot = Slot;
 


### PR DESCRIPTION
## What?
PR refactors the `PluginDocumentSettingPanel` component to use data hooks instead of the HoC.

## Why?
Now all necessary logic is contained in the component. It also rendered the component tree slimmer.

## Testing Instructions
1. Open a post or page.
2. Add a new plugin that uses the component.
3. Confirm it works as before - renders the content and can open/close the panel.

### Example plugin

```js
const { createElement: el } = wp.element;
const registerPlugin = wp.plugins.registerPlugin;
const PluginDocumentSettingPanel = wp.editPost.PluginDocumentSettingPanel;

function ContextDocumentSettingPlugin() {
	return el(
		PluginDocumentSettingPanel,
		{
			className: 'test-context',
			title: 'Test Context',
			name: 'test-context'
		},
		el( 'p', {}, `Hello, context!` )
	);
}

registerPlugin( 'test-context', {
	render: ContextDocumentSettingPlugin,
} );
```

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2023-08-03 at 11 48 08](https://github.com/WordPress/gutenberg/assets/240569/0e00941f-0c2d-4030-8647-9e32fae7ab75)
