### PR TITLE
Plugins: Introduce the 'usePluginContext' hook

### DIFF
--- a/packages/plugins/README.md
+++ b/packages/plugins/README.md
@@ -182,6 +182,14 @@ _Returns_
 
 -   `WPPlugin | undefined`: The previous plugin settings object, if it has been successfully unregistered; otherwise `undefined`.
 
+#### usePluginContext
+
+A hook that returns the plugin context.
+
+_Returns_
+
+-   `PluginContext`: Plugin context
+
 #### withPluginContext
 
 A Higher Order Component used to inject Plugin context to the wrapped component.

--- a/packages/plugins/src/components/index.js
+++ b/packages/plugins/src/components/index.js
@@ -1,2 +1,2 @@
 export { default as PluginArea } from './plugin-area';
-export { withPluginContext } from './plugin-context';
+export { usePluginContext, withPluginContext } from './plugin-context';

--- a/packages/plugins/src/components/plugin-context/index.tsx
+++ b/packages/plugins/src/components/plugin-context/index.tsx
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { createContext } from '@wordpress/element';
+import { createContext, useContext } from '@wordpress/element';
 import { createHigherOrderComponent } from '@wordpress/compose';
 
 /**
@@ -14,12 +14,21 @@ export interface PluginContext {
 	icon: null | WPPlugin[ 'icon' ];
 }
 
-const { Consumer, Provider } = createContext< PluginContext >( {
+const Context = createContext< PluginContext >( {
 	name: null,
 	icon: null,
 } );
 
-export { Provider as PluginContextProvider };
+export const PluginContextProvider = Context.Provider;
+
+/**
+ * A hook that returns the plugin context.
+ *
+ * @return {PluginContext} Plugin context
+ */
+export function usePluginContext() {
+	return useContext( Context );
+}
 
 /**
  * A Higher Order Component used to inject Plugin context to the
@@ -39,13 +48,13 @@ export const withPluginContext = (
 ) =>
 	createHigherOrderComponent( ( OriginalComponent ) => {
 		return ( props ) => (
-			<Consumer>
+			<Context.Consumer>
 				{ ( context ) => (
 					<OriginalComponent
 						{ ...props }
 						{ ...mapContextToProps( context, props ) }
 					/>
 				) }
-			</Consumer>
+			</Context.Consumer>
 		);
 	}, 'withPluginContext' );


### PR DESCRIPTION
## What?
PR introduced a new `usePluginContext` hook to allow consuming the plugin context in components without `withPluginContext` HoC.

## Why?
It will allow us to easily remove HoC usage from components. See #53290.

## How?
The new hook is just a wrapper around `useContext`.

## Testing Instructions
1. Open a post or page.
2. Confim components using plugin context work as before.

### Example

```js
const { createElement: el } = wp.element;
const registerPlugin = wp.plugins.registerPlugin;
const PluginDocumentSettingPanel = wp.editPost.PluginDocumentSettingPanel;

function ContextDocumentSettingPlugin() {
	return el(
		PluginDocumentSettingPanel,
		{
			className: 'test-context',
			title: 'Test Context',
			name: 'test-context'
		},
		el( 'p', {}, `Hello, context!` )
	);
}

registerPlugin( 'test-context', {
	render: ContextDocumentSettingPlugin,
} );
```

### Screenshot

![CleanShot 2023-08-03 at 12 24 07](https://github.com/WordPress/gutenberg/assets/240569/251b06d3-06db-45db-a738-39e70dd2a018)

