### PR TITLE
Edit Post: Replace 'withPluginContext' in the 'PluginPostPublishPanel'

### DIFF
--- a/packages/edit-post/README.md
+++ b/packages/edit-post/README.md
@@ -259,6 +259,7 @@ _Parameters_
 -   _props.title_ `[string]`: Title displayed at the top of the panel.
 -   _props.initialOpen_ `[boolean]`: Whether to have the panel initially opened. When no title is provided it is always opened.
 -   _props.icon_ `[WPBlockTypeIconRender]`: The [Dashicon](https://developer.wordpress.org/resource/dashicons/) icon slug string, or an SVG WP element, to be rendered when the sidebar is pinned to toolbar.
+-   _props.children_ `WPElement`: Children to be rendered
 
 _Returns_
 

--- a/packages/edit-post/src/components/sidebar/plugin-post-publish-panel/index.js
+++ b/packages/edit-post/src/components/sidebar/plugin-post-publish-panel/index.js
@@ -62,7 +62,7 @@ const PluginPostPublishPanel = ( {
 	initialOpen = false,
 	icon,
 } ) => {
-	const context = usePluginContext();
+	const { icon: pluginIcon } = usePluginContext();
 
 	return (
 		<Fill>

--- a/packages/edit-post/src/components/sidebar/plugin-post-publish-panel/index.js
+++ b/packages/edit-post/src/components/sidebar/plugin-post-publish-panel/index.js
@@ -1,30 +1,11 @@
 /**
  * WordPress dependencies
  */
-import { compose } from '@wordpress/compose';
-import { withPluginContext } from '@wordpress/plugins';
+import { usePluginContext } from '@wordpress/plugins';
 import { createSlotFill, PanelBody } from '@wordpress/components';
 
 const { Fill, Slot } = createSlotFill( 'PluginPostPublishPanel' );
 
-const PluginPostPublishPanelFill = ( {
-	children,
-	className,
-	title,
-	initialOpen = false,
-	icon,
-} ) => (
-	<Fill>
-		<PanelBody
-			className={ className }
-			initialOpen={ initialOpen || ! title }
-			title={ title }
-			icon={ icon }
-		>
-			{ children }
-		</PanelBody>
-	</Fill>
-);
 /**
  * Renders provided content to the post-publish panel in the publish flow
  * (side panel that opens after a user publishes the post).
@@ -34,6 +15,7 @@ const PluginPostPublishPanelFill = ( {
  * @param {string}                [props.title]                         Title displayed at the top of the panel.
  * @param {boolean}               [props.initialOpen=false]             Whether to have the panel initially opened. When no title is provided it is always opened.
  * @param {WPBlockTypeIconRender} [props.icon=inherits from the plugin] The [Dashicon](https://developer.wordpress.org/resource/dashicons/) icon slug string, or an SVG WP element, to be rendered when the sidebar is pinned to toolbar.
+ * @param {WPElement}             props.children                        Children to be rendered
  *
  * @example
  * ```js
@@ -73,14 +55,28 @@ const PluginPostPublishPanelFill = ( {
  *
  * @return {WPComponent} The component to be rendered.
  */
+const PluginPostPublishPanel = ( {
+	children,
+	className,
+	title,
+	initialOpen = false,
+	icon,
+} ) => {
+	const context = usePluginContext();
 
-const PluginPostPublishPanel = compose(
-	withPluginContext( ( context, ownProps ) => {
-		return {
-			icon: ownProps.icon || context.icon,
-		};
-	} )
-)( PluginPostPublishPanelFill );
+	return (
+		<Fill>
+			<PanelBody
+				className={ className }
+				initialOpen={ initialOpen || ! title }
+				title={ title }
+				icon={ icon ?? context.icon }
+			>
+				{ children }
+			</PanelBody>
+		</Fill>
+	);
+};
 
 PluginPostPublishPanel.Slot = Slot;
 

--- a/packages/edit-post/src/components/sidebar/plugin-post-publish-panel/index.js
+++ b/packages/edit-post/src/components/sidebar/plugin-post-publish-panel/index.js
@@ -70,7 +70,7 @@ const PluginPostPublishPanel = ( {
 				className={ className }
 				initialOpen={ initialOpen || ! title }
 				title={ title }
-				icon={ icon ?? context.icon }
+				icon={ icon ?? pluginIcon }
 			>
 				{ children }
 			</PanelBody>


### PR DESCRIPTION
## What?
PR replaces the use of `withPluginContext` in the `PluginPostPublishPanel` component with the new `usePluginContext` hook.

## Why?
The `useContext` hook or its wrappers is recommended way to consume context in modern React.

## Testing Instructions
1. Create a post.
2. Register a new post-publish panel. See the code below.
3. Publish the post.
4. Confirm that the panel inherits the icon from the plugin.

### Code

```js
const { createElement: el } = wp.element;
const registerPlugin = wp.plugins.registerPlugin;
const PluginPostPublishPanel = wp.editPost.PluginPostPublishPanel;

function TestPostPublishPanel() {
	return el(
		PluginPostPublishPanel,
		{
			className: 'my-panel',
			title: 'My panel title',
			initialOpen: true
		},
		el( 'p', {}, `Hello, context!` )
	);
}

registerPlugin( 'test-post-publish-panel', {
    icon: 'pets',
	render: TestPostPublishPanel,
} );
```

## Screenshots or screencast <!-- if applicable -->

![CleanShot 2023-08-03 at 17 34 17](https://github.com/WordPress/gutenberg/assets/240569/3bad054f-cdae-42f2-a556-6a4ff0854633)

