### PR TITLE
Edit Post: Replace 'withPluginContext' in the 'PluginPrePublishPanel'

### DIFF
--- a/packages/edit-post/README.md
+++ b/packages/edit-post/README.md
@@ -355,6 +355,7 @@ _Parameters_
 -   _props.title_ `[string]`: Title displayed at the top of the panel.
 -   _props.initialOpen_ `[boolean]`: Whether to have the panel initially opened. When no title is provided it is always opened.
 -   _props.icon_ `[WPBlockTypeIconRender]`: The [Dashicon](https://developer.wordpress.org/resource/dashicons/) icon slug string, or an SVG WP element, to be rendered when the sidebar is pinned to toolbar.
+-   _props.children_ `WPElement`: Children to be rendered
 
 _Returns_
 

--- a/packages/edit-post/src/components/sidebar/plugin-pre-publish-panel/index.js
+++ b/packages/edit-post/src/components/sidebar/plugin-pre-publish-panel/index.js
@@ -73,7 +73,7 @@ const PluginPrePublishPanel = ( {
 				className={ className }
 				initialOpen={ initialOpen || ! title }
 				title={ title }
-				icon={ icon ?? context.icon }
+				icon={ icon ?? pluginIcon }
 			>
 				{ children }
 			</PanelBody>

--- a/packages/edit-post/src/components/sidebar/plugin-pre-publish-panel/index.js
+++ b/packages/edit-post/src/components/sidebar/plugin-pre-publish-panel/index.js
@@ -2,28 +2,9 @@
  * WordPress dependencies
  */
 import { createSlotFill, PanelBody } from '@wordpress/components';
-import { compose } from '@wordpress/compose';
-import { withPluginContext } from '@wordpress/plugins';
-const { Fill, Slot } = createSlotFill( 'PluginPrePublishPanel' );
+import { usePluginContext } from '@wordpress/plugins';
 
-const PluginPrePublishPanelFill = ( {
-	children,
-	className,
-	title,
-	initialOpen = false,
-	icon,
-} ) => (
-	<Fill>
-		<PanelBody
-			className={ className }
-			initialOpen={ initialOpen || ! title }
-			title={ title }
-			icon={ icon }
-		>
-			{ children }
-		</PanelBody>
-	</Fill>
-);
+const { Fill, Slot } = createSlotFill( 'PluginPrePublishPanel' );
 
 /**
  * Renders provided content to the pre-publish side panel in the publish flow
@@ -37,6 +18,7 @@ const PluginPrePublishPanelFill = ( {
  * @param {WPBlockTypeIconRender} [props.icon=inherits from the plugin] The [Dashicon](https://developer.wordpress.org/resource/dashicons/)
  *                                                                      icon slug string, or an SVG WP element, to be rendered when
  *                                                                      the sidebar is pinned to toolbar.
+ * @param {WPElement}             props.children                        Children to be rendered
  *
  * @example
  * ```js
@@ -76,13 +58,28 @@ const PluginPrePublishPanelFill = ( {
  *
  * @return {WPComponent} The component to be rendered.
  */
-const PluginPrePublishPanel = compose(
-	withPluginContext( ( context, ownProps ) => {
-		return {
-			icon: ownProps.icon || context.icon,
-		};
-	} )
-)( PluginPrePublishPanelFill );
+const PluginPrePublishPanel = ( {
+	children,
+	className,
+	title,
+	initialOpen = false,
+	icon,
+} ) => {
+	const context = usePluginContext();
+
+	return (
+		<Fill>
+			<PanelBody
+				className={ className }
+				initialOpen={ initialOpen || ! title }
+				title={ title }
+				icon={ icon ?? context.icon }
+			>
+				{ children }
+			</PanelBody>
+		</Fill>
+	);
+};
 
 PluginPrePublishPanel.Slot = Slot;
 

--- a/packages/edit-post/src/components/sidebar/plugin-pre-publish-panel/index.js
+++ b/packages/edit-post/src/components/sidebar/plugin-pre-publish-panel/index.js
@@ -65,7 +65,7 @@ const PluginPrePublishPanel = ( {
 	initialOpen = false,
 	icon,
 } ) => {
-	const context = usePluginContext();
+	const { icon: pluginIcon } = usePluginContext();
 
 	return (
 		<Fill>


### PR DESCRIPTION
## What?
This is similar to #53302.

PR replaces the use of `withPluginContext` in the `PluginPrePublishPanel` component with the new `usePluginContext` hook.

## Why?
The `useContext` hook or its wrappers is recommended way to consume context in modern React.

## Testing Instructions
1. Create a post.
2. Register a new pre-publish panel. See the code below.
3. Publish the post.
4. Confirm that the panel inherits the icon from the plugin.

### Code

```js
const {createElement: el} = wp.element;
const registerPlugin = wp.plugins.registerPlugin;
const PluginPrePublishPanel = wp.editPost.PluginPrePublishPanel;

function TestPrePublishPanel() {
    return el(PluginPrePublishPanel, {
        className: 'my-panel',
        title: 'My panel title',
        initialOpen: true
    }, el('p', {}, `Hello!`));
}

registerPlugin('test-pre-publish-panel', {
    icon: 'pets',
    render: TestPrePublishPanel,
});
```

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2023-08-03 at 18 53 29](https://github.com/WordPress/gutenberg/assets/240569/98c3413c-6508-450b-9c50-653467b842df)
