### PR TITLE
Improve writing flow for lists by capturing list item toolbars

### DIFF
--- a/packages/block-library/src/list/edit.js
+++ b/packages/block-library/src/list/edit.js
@@ -137,6 +137,7 @@ export default function Edit( { attributes, setAttributes, clientId, style } ) {
 			marginHorizontal: NATIVE_MARGIN_SPACING,
 			renderAppender: false,
 		} ),
+		__experimentalCaptureToolbars: true,
 	} );
 	useMigrateOnLoad( attributes, clientId );
 	const { ordered, type, reversed, start } = attributes;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Improve writing flow of list items by capturing the toolbar for each list item in the parent list block. 

## Why?
As-is, adding a new item blocks the previous one. It's also difficult to select other items in the list without first selecting the parent list block (have to click in the small space between the current list item and its toolbar. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a post or page.
2. Insert a list block.
3. Add a few items. 
4. Select between them. 

## Screenshots or screencast <!-- if applicable -->

### Before: 

https://github.com/WordPress/gutenberg/assets/1813435/c6b48820-d822-4668-8851-73172c738415

### After: 


https://github.com/WordPress/gutenberg/assets/1813435/97d6ff49-70b3-4f42-bd4e-5769ae51a6e3


