### PR TITLE
Column: exit on Enter

### DIFF
--- a/packages/block-library/src/column/block.json
+++ b/packages/block-library/src/column/block.json
@@ -23,6 +23,7 @@
 		}
 	},
 	"supports": {
+		"__experimentalOnEnter": true,
 		"anchor": true,
 		"reusable": false,
 		"html": false,

--- a/packages/block-library/src/paragraph/use-enter.js
+++ b/packages/block-library/src/paragraph/use-enter.js
@@ -85,6 +85,17 @@ export function useOnEnter( props ) {
 				return;
 			}
 
+			if (
+				! canInsertBlockType(
+					'core/paragraph',
+					getBlockRootClientId( wrapperClientId )
+				)
+			) {
+				return;
+			}
+
+			event.preventDefault();
+
 			// If it is in the middle, split the block in two.
 			const wrapperBlock = getBlock( wrapperClientId );
 			batch( () => {

--- a/packages/block-library/src/paragraph/use-enter.js
+++ b/packages/block-library/src/paragraph/use-enter.js
@@ -23,6 +23,7 @@ export function useOnEnter( props ) {
 		getBlockName,
 		getBlock,
 		getNextBlockClientId,
+		canInsertBlockType,
 	} = useSelect( blockEditorStore );
 	const propsRef = useRef( props );
 	propsRef.current = props;
@@ -63,11 +64,23 @@ export function useOnEnter( props ) {
 
 			// If it is the last block, exit.
 			if ( position === order.length - 1 ) {
+				let newWrapperClientId = wrapperClientId;
+
+				while (
+					! canInsertBlockType(
+						getBlockName( clientId ),
+						getBlockRootClientId( newWrapperClientId )
+					)
+				) {
+					newWrapperClientId =
+						getBlockRootClientId( newWrapperClientId );
+				}
+
 				moveBlocksToPosition(
 					[ clientId ],
 					wrapperClientId,
-					getBlockRootClientId( wrapperClientId ),
-					getBlockIndex( wrapperClientId ) + 1
+					getBlockRootClientId( newWrapperClientId ),
+					getBlockIndex( newWrapperClientId ) + 1
 				);
 				return;
 			}

--- a/packages/block-library/src/paragraph/use-enter.js
+++ b/packages/block-library/src/paragraph/use-enter.js
@@ -57,9 +57,6 @@ export function useOnEnter( props ) {
 			}
 
 			const order = getBlockOrder( wrapperClientId );
-
-			event.preventDefault();
-
 			const position = order.indexOf( clientId );
 
 			// If it is the last block, exit.
@@ -76,12 +73,15 @@ export function useOnEnter( props ) {
 						getBlockRootClientId( newWrapperClientId );
 				}
 
-				moveBlocksToPosition(
-					[ clientId ],
-					wrapperClientId,
-					getBlockRootClientId( newWrapperClientId ),
-					getBlockIndex( newWrapperClientId ) + 1
-				);
+				if ( typeof newWrapperClientId === 'string' ) {
+					event.preventDefault();
+					moveBlocksToPosition(
+						[ clientId ],
+						wrapperClientId,
+						getBlockRootClientId( newWrapperClientId ),
+						getBlockIndex( newWrapperClientId ) + 1
+					);
+				}
 				return;
 			}
 

--- a/packages/block-library/src/paragraph/use-enter.js
+++ b/packages/block-library/src/paragraph/use-enter.js
@@ -6,7 +6,11 @@ import { useRefEffect } from '@wordpress/compose';
 import { ENTER } from '@wordpress/keycodes';
 import { useSelect, useDispatch, useRegistry } from '@wordpress/data';
 import { store as blockEditorStore } from '@wordpress/block-editor';
-import { hasBlockSupport, createBlock } from '@wordpress/blocks';
+import {
+	hasBlockSupport,
+	createBlock,
+	getDefaultBlockName,
+} from '@wordpress/blocks';
 
 export function useOnEnter( props ) {
 	const { batch } = useRegistry();
@@ -85,9 +89,11 @@ export function useOnEnter( props ) {
 				return;
 			}
 
+			const defaultBlockName = getDefaultBlockName();
+
 			if (
 				! canInsertBlockType(
-					'core/paragraph',
+					defaultBlockName,
 					getBlockRootClientId( wrapperClientId )
 				)
 			) {
@@ -111,7 +117,7 @@ export function useOnEnter( props ) {
 					wrapperBlock.innerBlocks.slice( position + 1 )
 				);
 				insertBlock(
-					createBlock( 'core/paragraph' ),
+					createBlock( defaultBlockName ),
 					blockIndex + 1,
 					getBlockRootClientId( wrapperClientId ),
 					true

--- a/test/e2e/specs/editor/blocks/columns.spec.js
+++ b/test/e2e/specs/editor/blocks/columns.spec.js
@@ -122,4 +122,56 @@ test.describe( 'Columns', () => {
 			},
 		] );
 	} );
+
+	test( 'can exit on Enter', async ( { editor, page } ) => {
+		await editor.insertBlock( {
+			name: 'core/columns',
+			innerBlocks: [
+				{
+					name: 'core/column',
+					innerBlocks: [
+						{
+							name: 'core/paragraph',
+							attributes: { content: '1' },
+						},
+					],
+				},
+				{
+					name: 'core/column',
+				},
+			],
+		} );
+
+		await editor.selectBlocks(
+			editor.canvas.locator( 'role=document[name="Paragraph block"i]' )
+		);
+		await page.keyboard.press( 'ArrowRight' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( '2' );
+
+		await expect.poll( editor.getBlocks ).toMatchObject( [
+			{
+				name: 'core/columns',
+				innerBlocks: [
+					{
+						name: 'core/column',
+						innerBlocks: [
+							{
+								name: 'core/paragraph',
+								attributes: { content: '1' },
+							},
+						],
+					},
+					{
+						name: 'core/column',
+					},
+				],
+			},
+			{
+				name: 'core/paragraph',
+				attributes: { content: '2' },
+			},
+		] );
+	} );
 } );

--- a/test/e2e/specs/editor/blocks/columns.spec.js
+++ b/test/e2e/specs/editor/blocks/columns.spec.js
@@ -174,4 +174,70 @@ test.describe( 'Columns', () => {
 			},
 		] );
 	} );
+
+	test( 'should not split in middle', async ( { editor, page } ) => {
+		await editor.insertBlock( {
+			name: 'core/columns',
+			innerBlocks: [
+				{
+					name: 'core/column',
+					innerBlocks: [
+						{
+							name: 'core/paragraph',
+							attributes: { content: '1' },
+						},
+						{
+							name: 'core/paragraph',
+							attributes: { content: '2' },
+						},
+					],
+				},
+				{
+					name: 'core/column',
+				},
+			],
+		} );
+
+		await editor.selectBlocks(
+			editor.canvas.locator(
+				'role=document[name="Paragraph block"i] >> text="1"'
+			)
+		);
+		await page.keyboard.press( 'ArrowRight' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( '3' );
+
+		await expect.poll( editor.getBlocks ).toMatchObject( [
+			{
+				name: 'core/columns',
+				innerBlocks: [
+					{
+						name: 'core/column',
+						innerBlocks: [
+							{
+								name: 'core/paragraph',
+								attributes: { content: '1' },
+							},
+							{
+								name: 'core/paragraph',
+								attributes: { content: '' },
+							},
+							{
+								name: 'core/paragraph',
+								attributes: { content: '3' },
+							},
+							{
+								name: 'core/paragraph',
+								attributes: { content: '2' },
+							},
+						],
+					},
+					{
+						name: 'core/column',
+					},
+				],
+			},
+		] );
+	} );
 } );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes #52774. 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Adds `__experimentalOnEnter` to the `column` block, so Enter in an empty paragraph at the end of the block moves the paragraph outside of the column. Had to modify it to search for the first parent block where a paragraph is insertable (with `canInsertBlockType`), because we can't simply move it to the columnS block, it needs to be moved up one more parent.

We also don't want to enable splitting the column block in the middle, so I disabled that by returning early with a `canInsertBlockType` check.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
