### PR TITLE
Add children back to toolbar item render for rendered components

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -93,6 +93,7 @@
 ### Bug Fix
 
 -   `Modal`: Fix loss of focus when clicking outside ([#52653](https://github.com/WordPress/gutenberg/pull/52653)).
+-   `ToolbarItem`: Fix children not showing in rendered components ([#53314](https://github.com/WordPress/gutenberg/pull/53314)).
 
 ## 25.4.0 (2023-07-20)
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 -   `Tooltip`: dynamically render in the DOM only when visible ([#54312](https://github.com/WordPress/gutenberg/pull/54312)).
 -   `PaletteEdit`: Fix padding in RTL languages ([#54034](https://github.com/WordPress/gutenberg/pull/54034)).
+-   `ToolbarItem`: Fix children not showing in rendered components ([#53314](https://github.com/WordPress/gutenberg/pull/53314)).
 -   `CircularOptionPicker`: make focus styles resilient to button size changes ([#54196](https://github.com/WordPress/gutenberg/pull/54196)).
 
 ### Internal
@@ -93,7 +94,6 @@
 ### Bug Fix
 
 -   `Modal`: Fix loss of focus when clicking outside ([#52653](https://github.com/WordPress/gutenberg/pull/52653)).
--   `ToolbarItem`: Fix children not showing in rendered components ([#53314](https://github.com/WordPress/gutenberg/pull/53314)).
 
 ## 25.4.0 (2023-07-20)
 

--- a/packages/components/src/toolbar/toolbar-item/index.tsx
+++ b/packages/components/src/toolbar/toolbar-item/index.tsx
@@ -50,7 +50,9 @@ function ToolbarItem(
 			{ ...allProps }
 			store={ accessibleToolbarStore }
 			render={ render }
-		/>
+		>
+			{ children }
+		</BaseToolbarItem>
 	);
 }
 

--- a/packages/components/src/toolbar/toolbar-item/index.tsx
+++ b/packages/components/src/toolbar/toolbar-item/index.tsx
@@ -43,16 +43,14 @@ function ToolbarItem(
 		return children( allProps );
 	}
 
-	const render = isRenderProp ? children : Component && <Component />;
+	const render = isRenderProp ? children : Component && <Component>{children}</Component>;
 
 	return (
 		<BaseToolbarItem
 			{ ...allProps }
 			store={ accessibleToolbarStore }
 			render={ render }
-		>
-			{ children }
-		</BaseToolbarItem>
+		/>
 	);
 }
 

--- a/packages/components/src/toolbar/toolbar-item/index.tsx
+++ b/packages/components/src/toolbar/toolbar-item/index.tsx
@@ -43,7 +43,9 @@ function ToolbarItem(
 		return children( allProps );
 	}
 
-	const render = isRenderProp ? children : Component && <Component>{children}</Component>;
+	const render = isRenderProp
+		? children
+		: Component && <Component>{ children }</Component>;
 
 	return (
 		<BaseToolbarItem


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes #53313 
Allows usage of `children` for toolbar item components that make use of the `as` prop.

## Why?
This was removed in https://github.com/WordPress/gutenberg/pull/51623.  I believe this was unintentional and missed as a test case since many of the `ToolbarItems` take advantage of `icon` or `label` props, but pinging @diegohaz to confirm that there are no other issues with doing this with the newer Ariakit implementation.

## How?
This PR simply reverts to passing `children` to `BaseToolbarItem` so they can be used by the passed component in `render`. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Add a component that uses both the `as` property and `children`:
```js
<ToolbarItem
	as={ Button }
	variant="primary"
	onClick={ doSomething }
>
	This text should show
</ToolbarItem>
```
2. Verify that the text is shown in the toolbar button
3. Check other toolbar items around the site to make sure no regressions have occurred

Optionally, to see a real-world use case where this was broken:

1. Install WooCommerce 8.0 RC-1 - https://github.com/woocommerce/woocommerce/releases/tag/8.0.0-rc.1
2. Use the latest GB and/or WP 6.3.
1. Enable the new product editing experience under WooCommerce -> Settings -> Advanced -> Features.
3. Navigate to the Add Product page.
4. Click on "Add description"
5. Note that the "Cancel" and "Done" buttons and text are visible in the modal toolbar.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

### Before
<img width="199" alt="Screen Shot 2023-08-03 at 1 47 39 PM" src="https://github.com/WordPress/gutenberg/assets/10561050/25608e48-2fc9-4449-831a-30b94009a9ff">


### After
<img width="284" alt="Screen Shot 2023-08-03 at 1 50 01 PM" src="https://github.com/WordPress/gutenberg/assets/10561050/edbe8559-fff1-4a72-a865-ae03b1e18efe">


