### PR TITLE
Cover Block: improve cover is dark hook

### DIFF
--- a/packages/block-library/src/cover/edit/index.js
+++ b/packages/block-library/src/cover/edit/index.js
@@ -9,7 +9,7 @@ import namesPlugin from 'colord/plugins/names';
  * WordPress dependencies
  */
 import { useEntityProp, store as coreStore } from '@wordpress/core-data';
-import { useEffect, useMemo, useRef } from '@wordpress/element';
+import { useMemo, useRef } from '@wordpress/element';
 import { Placeholder, Spinner } from '@wordpress/components';
 import { compose, useResizeObserver } from '@wordpress/compose';
 import {

--- a/packages/block-library/src/cover/edit/index.js
+++ b/packages/block-library/src/cover/edit/index.js
@@ -124,8 +124,6 @@ function CoverEdit( {
 		? IMAGE_BACKGROUND_TYPE
 		: attributes.backgroundType;
 
-	const { __unstableMarkNextChangeAsNotPersistent } =
-		useDispatch( blockEditorStore );
 	const { createErrorNotice } = useDispatch( noticesStore );
 	const { gradientClass, gradientValue } = __experimentalUseGradient();
 	const onSelectMedia = attributesFromMedia( setAttributes, dimRatio );
@@ -135,13 +133,7 @@ function CoverEdit( {
 		createErrorNotice( message, { type: 'snackbar' } );
 	};
 
-	const isCoverDark = useCoverIsDark( url, dimRatio, overlayColor.color );
-
-	useEffect( () => {
-		// This side-effect should not create an undo level.
-		__unstableMarkNextChangeAsNotPersistent();
-		setAttributes( { isDark: isCoverDark } );
-	}, [ isCoverDark ] );
+	useCoverIsDark( url, dimRatio, overlayColor.color, setAttributes );
 
 	const isImageBackground = IMAGE_BACKGROUND_TYPE === backgroundType;
 	const isVideoBackground = VIDEO_BACKGROUND_TYPE === backgroundType;

--- a/packages/block-library/src/cover/edit/use-cover-is-dark.js
+++ b/packages/block-library/src/cover/edit/use-cover-is-dark.js
@@ -51,6 +51,7 @@ function useCoverIsDark( url, dimRatio = 50, overlayColor, setAttributes ) {
 		isDark = false;
 	}
 
+	// Determines darkness of media’s averaged color when the url changes.
 	useEffect( () => {
 		if ( url ) {
 			const imgCrossOrigin = applyFilters(

--- a/packages/block-library/src/cover/edit/use-cover-is-dark.js
+++ b/packages/block-library/src/cover/edit/use-cover-is-dark.js
@@ -41,7 +41,7 @@ function useCoverIsDark( url, dimRatio = 50, overlayColor, setAttributes ) {
 		isDark = !! mediaIsDark;
 	}
 	// When opacity is greater than 50 uses the overlay color’s darkness.
-	else if ( dimRatio > 50 || ! url ) {
+	else if ( dimRatio > 50 ) {
 		// If no overlay color exists the overlay color is black (isDark)
 		isDark = ! overlayColor || colord( overlayColor ).isDark();
 	}

--- a/packages/block-library/src/cover/test/edit.js
+++ b/packages/block-library/src/cover/test/edit.js
@@ -285,14 +285,11 @@ describe( 'Cover block', () => {
 					} )
 				);
 
-				fireEvent.change(
-					screen.getByRole( 'spinbutton', {
-						name: 'Overlay opacity',
-					} ),
-					{
-						target: { value: '40' },
-					}
-				);
+				const input = screen.getByRole( 'spinbutton', {
+					name: 'Overlay opacity',
+				} );
+				await userEvent.click( input );
+				await userEvent.keyboard( '[ArrowDown>6/]' );
 
 				expect( overlay[ 0 ] ).toHaveClass( 'has-background-dim-40' );
 			} );
@@ -315,12 +312,16 @@ describe( 'Cover block', () => {
 					} )
 				);
 
-				fireEvent.change(
-					screen.getByRole( 'slider', {
-						name: 'Overlay opacity',
-					} ),
-					{ target: { value: 30 } }
-				);
+				// Disable reason: Something about `useCoverIsDark` triggers warnings otherwise.
+				// eslint-disable-next-line testing-library/no-unnecessary-act
+				await act( async () => {
+					fireEvent.change(
+						screen.getByRole( 'slider', {
+							name: 'Overlay opacity',
+						} ),
+						{ target: { value: 30 } }
+					);
+				} );
 
 				expect( overlay[ 0 ] ).toHaveClass( 'has-background-dim-30' );
 			} );
@@ -404,12 +405,15 @@ describe( 'Cover block', () => {
 			await userEvent.click( popupColorPicker );
 			expect( coverBlock ).not.toHaveClass( 'is-light' );
 		} );
-		test( 'should apply is-light class if overlay color is removed', async () => {
+		test( 'should remove is-light class if overlay color is removed', async () => {
 			await setup();
-			await createAndSelectBlock();
+			const colorPicker = screen.getByRole( 'button', {
+				name: 'Color: White',
+			} );
+			await userEvent.click( colorPicker );
 			const coverBlock = screen.getByLabelText( 'Block: Cover' );
-			expect( coverBlock ).not.toHaveClass( 'is-light' );
-
+			expect( coverBlock ).toHaveClass( 'is-light' );
+			await selectBlock( 'Block: Cover' );
 			await userEvent.click(
 				screen.getByRole( 'tab', {
 					name: 'Styles',
@@ -419,10 +423,10 @@ describe( 'Cover block', () => {
 			// The default color is black, so clicking the black color option will remove the background color,
 			// which should remove the isDark setting and assign the is-light class.
 			const popupColorPicker = screen.getByRole( 'button', {
-				name: 'Color: Black',
+				name: 'Color: White',
 			} );
 			await userEvent.click( popupColorPicker );
-			expect( coverBlock ).toHaveClass( 'is-light' );
+			expect( coverBlock ).not.toHaveClass( 'is-light' );
 		} );
 	} );
 } );

--- a/packages/e2e-tests/specs/editor/various/__snapshots__/inserting-blocks.test.js.snap
+++ b/packages/e2e-tests/specs/editor/various/__snapshots__/inserting-blocks.test.js.snap
@@ -88,8 +88,8 @@ exports[`Inserting blocks inserts a block in proper place after having clicked \
 <p>First paragraph</p>
 <!-- /wp:paragraph -->
 
-<!-- wp:cover {"isDark":false,"layout":{"type":"constrained"}} -->
-<div class="wp-block-cover is-light"><span aria-hidden="true" class="wp-block-cover__background has-background-dim-100 has-background-dim"></span><div class="wp-block-cover__inner-container"></div></div>
+<!-- wp:cover {"layout":{"type":"constrained"}} -->
+<div class="wp-block-cover"><span aria-hidden="true" class="wp-block-cover__background has-background-dim-100 has-background-dim"></span><div class="wp-block-cover__inner-container"></div></div>
 <!-- /wp:cover -->
 
 <!-- wp:heading -->


### PR DESCRIPTION
## What?
Revamp `useCoverIsDark` for less effect hook reliance

## Why?
forthcoming…

## How?
forthcoming…

## Testing Instructions
See testing instructions in #53253

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
