### PR TITLE
Add taxonomy attributes to categories block #51388

### DIFF
--- a/packages/block-library/src/categories/block.json
+++ b/packages/block-library/src/categories/block.json
@@ -26,6 +26,10 @@
 		"showEmpty": {
 			"type": "boolean",
 			"default": false
+		},
+		"taxonomy": {
+			"type": "string",
+			"default": "category"
 		}
 	},
 	"supports": {

--- a/packages/block-library/src/categories/index.php
+++ b/packages/block-library/src/categories/index.php
@@ -23,6 +23,7 @@ function render_block_core_categories( $attributes ) {
 		'show_count'   => ! empty( $attributes['showPostCounts'] ),
 		'title_li'     => '',
 		'hide_empty'   => empty( $attributes['showEmpty'] ),
+		'taxonomy'     => $attributes['taxonomy'],
 	);
 	if ( ! empty( $attributes['showOnlyTopLevel'] ) && $attributes['showOnlyTopLevel'] ) {
 		$args['parent'] = 0;


### PR DESCRIPTION
Fix https://github.com/WordPress/gutenberg/issues/51388