### PR TITLE
Custom fields: insert path and query args to form before submitting

### DIFF
--- a/packages/edit-post/src/components/preferences-modal/options/enable-custom-fields.js
+++ b/packages/edit-post/src/components/preferences-modal/options/enable-custom-fields.js
@@ -14,15 +14,12 @@ function submitCustomFieldsForm() {
 		'toggle-custom-fields-form'
 	);
 
-	if ( customFieldsForm ) {
-		customFieldsForm
-			.querySelector( '[name="_wp_http_referer"]' )
-			.setAttribute(
-				'value',
-				getPathAndQueryString( window.location.href )
-			);
-		customFieldsForm.submit();
-	}
+	// Ensure the referrer values is up to update with any
+	customFieldsForm
+		.querySelector( '[name="_wp_http_referer"]' )
+		.setAttribute( 'value', getPathAndQueryString( window.location.href ) );
+
+	customFieldsForm.submit();
 }
 
 export function CustomFieldsConfirmation( { willEnable } ) {

--- a/packages/edit-post/src/components/preferences-modal/options/enable-custom-fields.js
+++ b/packages/edit-post/src/components/preferences-modal/options/enable-custom-fields.js
@@ -7,10 +7,26 @@ import { Button } from '@wordpress/components';
 import { withSelect } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
 import { ___unstablePreferencesModalBaseOption as BaseOption } from '@wordpress/interface';
+import { getPathAndQueryString } from '@wordpress/url';
+
+function submitCustomFieldsForm() {
+	const customFieldsForm = document.getElementById(
+		'toggle-custom-fields-form'
+	);
+
+	if ( customFieldsForm ) {
+		customFieldsForm
+			.querySelector( '[name="_wp_http_referer"]' )
+			.setAttribute(
+				'value',
+				getPathAndQueryString( window.location.href )
+			);
+		customFieldsForm.submit();
+	}
+}
 
 export function CustomFieldsConfirmation( { willEnable } ) {
 	const [ isReloading, setIsReloading ] = useState( false );
-
 	return (
 		<>
 			<p className="edit-post-preferences-modal__custom-fields-confirmation-message">
@@ -25,9 +41,7 @@ export function CustomFieldsConfirmation( { willEnable } ) {
 				disabled={ isReloading }
 				onClick={ () => {
 					setIsReloading( true );
-					document
-						.getElementById( 'toggle-custom-fields-form' )
-						.submit();
+					submitCustomFieldsForm();
 				} }
 			>
 				{ willEnable

--- a/packages/edit-post/src/components/preferences-modal/options/test/enable-custom-fields.js
+++ b/packages/edit-post/src/components/preferences-modal/options/test/enable-custom-fields.js
@@ -58,18 +58,23 @@ describe( 'CustomFieldsConfirmation', () => {
 	it( 'submits the toggle-custom-fields-form', async () => {
 		const user = userEvent.setup();
 		const submit = jest.fn();
+		const setAttribute = jest.fn();
 		const getElementById = jest
 			.spyOn( document, 'getElementById' )
 			.mockImplementation( () => ( {
 				submit,
+				querySelector: () => ( { setAttribute } ),
 			} ) );
-
 		render( <CustomFieldsConfirmation /> );
 
 		await user.click( screen.getByRole( 'button' ) );
 
 		expect( getElementById ).toHaveBeenCalledWith(
 			'toggle-custom-fields-form'
+		);
+		expect( setAttribute ).toHaveBeenCalledWith(
+			'value',
+			'/' // This is the path returned by getPathAndQueryString.
 		);
 		expect( submit ).toHaveBeenCalled();
 


### PR DESCRIPTION


## What?
Resolves https://github.com/WordPress/gutenberg/issues/53323

Inserts the path and query args into the `#toggle-custom-fields-form [name="_wp_http_referer"]` input value before page refresh.


## Why?
When activating the custom fields preference on a new post or page with saved content, the window is refreshed on the page that is first loaded, that is, `/wp-admin/post.php` and not, for example, `?post=27&action=edit`.

This is because the toggle-custom-fields-form uses the first admin URL is finds when it is rendered to the page and is not updated after a post is saved.

## How?
See "what"

## Testing Instructions

1. Create a new post
2. Add some content and save the post
3. Open the Preferences panel > Panel tab
4. Toggle Custom fields and click the "Hide and Reload page" button
5. You should land on the same post 



## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/6458278/3aee6893-df14-420e-958a-a57a86fcad9e

