### PR TITLE
Fix Synced Patterns' color in quick inserter

### DIFF
--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1963,14 +1963,12 @@ const buildBlockTypeItem =
 export const getInserterItems = createSelector(
 	( state, rootClientId = null ) => {
 		const buildReusableBlockInserterItem = ( reusableBlock ) => {
-			const icon =
-				reusableBlock.wp_pattern_sync_status === 'synced' ||
-				! reusableBlock.wp_pattern_sync_status
-					? {
-							src: symbol,
-							foreground: 'var(--wp-block-synced-color)',
-					  }
-					: symbol;
+			const icon = ! reusableBlock.wp_pattern_sync_status
+				? {
+						src: symbol,
+						foreground: 'var(--wp-block-synced-color)',
+				  }
+				: symbol;
 			const id = `core/block/${ reusableBlock.id }`;
 			const { time, count = 0 } = getInsertUsage( state, id ) || {};
 			const frecency = calculateFrecency( time, count );

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1963,7 +1963,14 @@ const buildBlockTypeItem =
 export const getInserterItems = createSelector(
 	( state, rootClientId = null ) => {
 		const buildReusableBlockInserterItem = ( reusableBlock ) => {
-			const icon = symbol;
+			const icon =
+				reusableBlock.wp_pattern_sync_status === 'synced' ||
+				! reusableBlock.wp_pattern_sync_status
+					? {
+							src: symbol,
+							foreground: 'var(--wp-block-synced-color)',
+					  }
+					: symbol;
 			const id = `core/block/${ reusableBlock.id }`;
 			const { time, count = 0 } = getInsertUsage( state, id ) || {};
 			const frecency = calculateFrecency( time, count );

--- a/packages/block-editor/src/store/test/selectors.js
+++ b/packages/block-editor/src/store/test/selectors.js
@@ -3348,7 +3348,10 @@ describe( 'selectors', () => {
 				category: 'reusable',
 				content: '<!-- /wp:test-block-a -->',
 				frecency: 0,
-				icon: symbol,
+				icon: {
+					src: symbol,
+					foreground: 'var(--wp-block-synced-color)',
+				},
 				id: 'core/block/1',
 				initialAttributes: { ref: 1 },
 				isDisabled: false,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Fix https://github.com/WordPress/gutenberg/issues/53209. Fix the color for Synced Patterns in the quick inserter.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Consistency and clear separation.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Use the `{ src, foreground }` syntax for icons.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Create a synced pattern and an unsynced pattern and make their name include `pattern` and easy to distinguish between.
2. Open Post or Site editor.
3. Type `/pattern` and use the Arrow key to navigate through different patterns.
4. Expect the Synced one to have its icon filled with the purple color.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
Follow the same instructions above. Note that this fix changes the visual UI so it's not noticeable if you're only using screen readers.

## Screenshots or screencast <!-- if applicable -->
![image](https://github.com/WordPress/gutenberg/assets/7753001/0eac4e26-3b0a-420a-adf8-753d704950ce)
