### PR TITLE
Modal: add `headerActions` prop to render buttons in the header

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -14,7 +14,7 @@
 -   `Theme`: Expose via private APIs ([#53262](https://github.com/WordPress/gutenberg/pull/53262)).
 -   `ProgressBar`: Use the theme system accent for indicator color ([#53347](https://github.com/WordPress/gutenberg/pull/53347)).
 -   `ProgressBar`: Use gray 300 for track color ([#53349](https://github.com/WordPress/gutenberg/pull/53349)).
--   `Modal`: add auxiliary actions prop to render buttons in the header. ([#53328](https://github.com/WordPress/gutenberg/pull/53328)).
+-   `Modal`: add `headerActions` prop to render buttons in the header. ([#53328](https://github.com/WordPress/gutenberg/pull/53328)).
 
 ### Bug Fix
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -4,9 +4,6 @@
 
 ### New Feature
 
--   Modal component: allow toggling fullscreen. ([#53328](https://github.com/WordPress/gutenberg/pull/53328)).
--   Add a new `ProgressBar` component. ([#53030](https://github.com/WordPress/gutenberg/pull/53030)).
-
 ### Enhancements
 
 -   `ColorPalette`, `BorderControl`: Don't hyphenate hex value in `aria-label` ([#52932](https://github.com/WordPress/gutenberg/pull/52932)).
@@ -15,6 +12,7 @@
 -   `Theme`: Expose via private APIs ([#53262](https://github.com/WordPress/gutenberg/pull/53262)).
 -   `ProgressBar`: Use the theme system accent for indicator color ([#53347](https://github.com/WordPress/gutenberg/pull/53347)).
 -   `ProgressBar`: Use gray 300 for track color ([#53349](https://github.com/WordPress/gutenberg/pull/53349)).
+-   `Modal`: add auxiliary actions prop to render buttons in the header. ([#53328](https://github.com/WordPress/gutenberg/pull/53328)).
 
 ### Bug Fix
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### New Feature
 
+-   Add a new `ProgressBar` component. ([#53030](https://github.com/WordPress/gutenberg/pull/53030)).
+
 ### Enhancements
 
 -   `ColorPalette`, `BorderControl`: Don't hyphenate hex value in `aria-label` ([#52932](https://github.com/WordPress/gutenberg/pull/52932)).

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New Feature
 
+-   Modal component: allow toggling fullscreen. ([#53328](https://github.com/WordPress/gutenberg/pull/53328)).
 -   Add a new `ProgressBar` component. ([#53030](https://github.com/WordPress/gutenberg/pull/53030)).
 
 ### Enhancements

--- a/packages/components/src/modal/README.md
+++ b/packages/components/src/modal/README.md
@@ -150,13 +150,6 @@ const MyModal = () => {
 The set of props accepted by the component will be specified below.
 Props not included in this set will be applied to the input elements.
 
-#### allowFullScreenToggle
-
-This property when set to `true` allows toggling between full screen.
-
--   Required: No
--   Default: `false`
-
 #### `aria.describedby`: `string`
 
 If this property is added, it will be added to the modal content `div` as `aria-describedby`.
@@ -172,6 +165,14 @@ Titles are required for accessibility reasons, see `contentLabel` and `title` fo
 
 -   Required: No
 -   Default: if the `title` prop is provided, this will default to the id of the element that renders `title`
+
+
+#### auxiliaryActions
+
+An optional React node intended to contain auxiliary actions of the modal, for example, buttons. Content is rendered in the top right corner of the modal and to the left of the close button, if visible.
+
+-   Required: No
+-   Default: `null`
 
 #### `bodyOpenClassName`: `string`
 

--- a/packages/components/src/modal/README.md
+++ b/packages/components/src/modal/README.md
@@ -166,14 +166,6 @@ Titles are required for accessibility reasons, see `contentLabel` and `title` fo
 -   Required: No
 -   Default: if the `title` prop is provided, this will default to the id of the element that renders `title`
 
-
-#### auxiliaryActions
-
-An optional React node intended to contain auxiliary actions of the modal, for example, buttons. Content is rendered in the top right corner of the modal and to the left of the close button, if visible.
-
--   Required: No
--   Default: `null`
-
 #### `bodyOpenClassName`: `string`
 
 Class name added to the body element when the modal is open.
@@ -201,6 +193,13 @@ If this property is true, it will focus the first tabbable element rendered in t
 
 -   Required: No
 -   Default: `true`
+
+#### headerActions
+
+An optional React node intended to contain additional actions or other elements related the modal, for example, buttons. Content is rendered in the top right corner of the modal and to the left of the close button, if visible.
+
+-   Required: No
+-   Default: `null`
 
 #### `isDismissible`: `boolean`
 

--- a/packages/components/src/modal/README.md
+++ b/packages/components/src/modal/README.md
@@ -196,7 +196,7 @@ If this property is true, it will focus the first tabbable element rendered in t
 
 #### headerActions
 
-An optional React node intended to contain additional actions or other elements related the modal, for example, buttons. Content is rendered in the top right corner of the modal and to the left of the close button, if visible.
+An optional React node intended to contain additional actions or other elements related to the modal, for example, buttons. Content is rendered in the top right corner of the modal and to the left of the close button, if visible.
 
 -   Required: No
 -   Default: `null`

--- a/packages/components/src/modal/README.md
+++ b/packages/components/src/modal/README.md
@@ -150,6 +150,13 @@ const MyModal = () => {
 The set of props accepted by the component will be specified below.
 Props not included in this set will be applied to the input elements.
 
+#### allowFullScreenToggle
+
+This property when set to `true` allows toggling between full screen.
+
+-   Required: No
+-   Default: `false`
+
 #### `aria.describedby`: `string`
 
 If this property is added, it will be added to the modal content `div` as `aria-describedby`.

--- a/packages/components/src/modal/index.tsx
+++ b/packages/components/src/modal/index.tsx
@@ -66,7 +66,7 @@ function UnforwardedModal(
 		contentLabel,
 		onKeyDown,
 		isFullScreen = false,
-		auxiliaryActions = null,
+		headerActions = null,
 		__experimentalHideHeader = false,
 	} = props;
 
@@ -258,7 +258,7 @@ function UnforwardedModal(
 										</h1>
 									) }
 								</div>
-								{ auxiliaryActions }
+								{ headerActions }
 								{ isDismissible && (
 									<Button
 										onClick={ onRequestClose }

--- a/packages/components/src/modal/index.tsx
+++ b/packages/components/src/modal/index.tsx
@@ -25,7 +25,7 @@ import {
 	useMergeRefs,
 } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
-import { close } from '@wordpress/icons';
+import { aspectRatio, close, fullscreen } from '@wordpress/icons';
 import { getScrollContainer } from '@wordpress/dom';
 
 /**
@@ -66,6 +66,7 @@ function UnforwardedModal(
 		contentLabel,
 		onKeyDown,
 		isFullScreen = false,
+		allowFullScreenToggle = false,
 		__experimentalHideHeader = false,
 	} = props;
 
@@ -83,6 +84,8 @@ function UnforwardedModal(
 
 	const [ hasScrolledContent, setHasScrolledContent ] = useState( false );
 	const [ hasScrollableContent, setHasScrollableContent ] = useState( false );
+	const [ isModalFullScreen, setIsModalFullScreen ] =
+		useState( isFullScreen );
 
 	// Determines whether the Modal content is scrollable and updates the state.
 	const isContentScrollable = useCallback( () => {
@@ -202,7 +205,7 @@ function UnforwardedModal(
 						'components-modal__frame',
 						className,
 						{
-							'is-full-screen': isFullScreen,
+							'is-full-screen': isModalFullScreen,
 						}
 					) }
 					style={ style }
@@ -257,6 +260,25 @@ function UnforwardedModal(
 										</h1>
 									) }
 								</div>
+								{ allowFullScreenToggle && (
+									<Button
+										onClick={ () =>
+											setIsModalFullScreen(
+												! isModalFullScreen
+											)
+										}
+										icon={
+											isModalFullScreen
+												? fullscreen
+												: aspectRatio
+										}
+										label={
+											isModalFullScreen
+												? __( 'Exit fullscreen' )
+												: __( 'Enter fullscreen' )
+										}
+									/>
+								) }
 								{ isDismissible && (
 									<Button
 										onClick={ onRequestClose }

--- a/packages/components/src/modal/index.tsx
+++ b/packages/components/src/modal/index.tsx
@@ -25,7 +25,7 @@ import {
 	useMergeRefs,
 } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
-import { aspectRatio, close, fullscreen } from '@wordpress/icons';
+import { close } from '@wordpress/icons';
 import { getScrollContainer } from '@wordpress/dom';
 
 /**
@@ -66,7 +66,7 @@ function UnforwardedModal(
 		contentLabel,
 		onKeyDown,
 		isFullScreen = false,
-		allowFullScreenToggle = false,
+		auxiliaryActions = null,
 		__experimentalHideHeader = false,
 	} = props;
 
@@ -84,8 +84,6 @@ function UnforwardedModal(
 
 	const [ hasScrolledContent, setHasScrolledContent ] = useState( false );
 	const [ hasScrollableContent, setHasScrollableContent ] = useState( false );
-	const [ isModalFullScreen, setIsModalFullScreen ] =
-		useState( isFullScreen );
 
 	// Determines whether the Modal content is scrollable and updates the state.
 	const isContentScrollable = useCallback( () => {
@@ -205,7 +203,7 @@ function UnforwardedModal(
 						'components-modal__frame',
 						className,
 						{
-							'is-full-screen': isModalFullScreen,
+							'is-full-screen': isFullScreen,
 						}
 					) }
 					style={ style }
@@ -260,25 +258,7 @@ function UnforwardedModal(
 										</h1>
 									) }
 								</div>
-								{ allowFullScreenToggle && (
-									<Button
-										onClick={ () =>
-											setIsModalFullScreen(
-												! isModalFullScreen
-											)
-										}
-										icon={
-											isModalFullScreen
-												? fullscreen
-												: aspectRatio
-										}
-										label={
-											isModalFullScreen
-												? __( 'Exit fullscreen' )
-												: __( 'Enter fullscreen' )
-										}
-									/>
-								) }
+								{ auxiliaryActions }
 								{ isDismissible && (
 									<Button
 										onClick={ onRequestClose }

--- a/packages/components/src/modal/stories/index.tsx
+++ b/packages/components/src/modal/stories/index.tsx
@@ -7,13 +7,12 @@ import type { ComponentStory, ComponentMeta } from '@storybook/react';
  * WordPress dependencies
  */
 import { useState } from '@wordpress/element';
-import { help, starEmpty, starFilled } from '@wordpress/icons';
+import { starEmpty, starFilled } from '@wordpress/icons';
 
 /**
  * Internal dependencies
  */
 import Button from '../../button';
-import Tooltip from '../../tooltip';
 import InputControl from '../../input-control';
 import Modal from '../';
 import type { ModalProps } from '../types';
@@ -36,6 +35,9 @@ const meta: ComponentMeta< typeof Modal > = {
 		},
 		onRequestClose: {
 			action: 'onRequestClose',
+		},
+		isDismissible: {
+			control: { type: 'boolean' },
 		},
 	},
 	parameters: {
@@ -89,56 +91,6 @@ const Template: ComponentStory< typeof Modal > = ( {
 	);
 };
 
-const TemplateWithHeaderActions: ComponentStory< typeof Modal > = ( {
-	onRequestClose,
-	...args
-} ) => {
-	const [ isLiked, setIsLiked ] = useState( false );
-	const [ isOpen, setOpen ] = useState( false );
-	const openModal = () => setOpen( true );
-	const closeModal: ModalProps[ 'onRequestClose' ] = ( event ) => {
-		setOpen( false );
-		onRequestClose( event );
-	};
-	const headerActions = (
-		<>
-			<Button
-				icon={ isLiked ? starFilled : starEmpty }
-				label="Like"
-				onClick={ () => setIsLiked( ! isLiked ) }
-			/>
-			<Tooltip text="We are here to help!">
-				<Button icon={ help } label="Help" />
-			</Tooltip>
-		</>
-	);
-
-	return (
-		<>
-			<Button variant="secondary" onClick={ openModal }>
-				Open Modal with Header Actions
-			</Button>
-			{ isOpen && (
-				<Modal
-					style={ { maxWidth: '600px' } }
-					isDismissible={ false }
-					onRequestClose={ closeModal }
-					headerActions={ headerActions }
-					{ ...args }
-				>
-					<p>
-						Lorem ipsum dolor sit amet, consectetur adipiscing elit,
-						sed do eiusmod tempor incididunt ut labore et magna
-						aliqua.
-					</p>
-					<Button variant="secondary" onClick={ closeModal }>
-						Close Modal
-					</Button>
-				</Modal>
-			) }
-		</>
-	);
-};
 export const Default: ComponentStory< typeof Modal > = Template.bind( {} );
 Default.args = {
 	title: 'Title',
@@ -151,15 +103,24 @@ Default.parameters = {
 	},
 };
 
-export const WithHeaderActions: ComponentStory< typeof Modal > =
-	TemplateWithHeaderActions.bind( {} );
+const LikeButton = () => {
+	const [ isLiked, setIsLiked ] = useState( false );
+	return (
+		<Button
+			icon={ isLiked ? starFilled : starEmpty }
+			label="Like"
+			onClick={ () => setIsLiked( ! isLiked ) }
+		/>
+	);
+};
+
+export const WithHeaderActions: ComponentStory< typeof Modal > = Template.bind(
+	{}
+);
 WithHeaderActions.args = {
 	...Default.args,
-};
-WithHeaderActions.argTypes = {
-	isDismissible: {
-		control: { type: 'boolean' },
-	},
+	headerActions: <LikeButton />,
+	isDismissible: false,
 };
 WithHeaderActions.parameters = {
 	...Default.parameters,

--- a/packages/components/src/modal/stories/index.tsx
+++ b/packages/components/src/modal/stories/index.tsx
@@ -89,7 +89,7 @@ const Template: ComponentStory< typeof Modal > = ( {
 	);
 };
 
-const TemplateWithAuxiliaryAction: ComponentStory< typeof Modal > = ( {
+const TemplateWithHeaderActions: ComponentStory< typeof Modal > = ( {
 	onRequestClose,
 	...args
 } ) => {
@@ -100,7 +100,7 @@ const TemplateWithAuxiliaryAction: ComponentStory< typeof Modal > = ( {
 		setOpen( false );
 		onRequestClose( event );
 	};
-	const auxiliaryActions = (
+	const headerActions = (
 		<>
 			<Button
 				icon={ isLiked ? starFilled : starEmpty }
@@ -116,14 +116,14 @@ const TemplateWithAuxiliaryAction: ComponentStory< typeof Modal > = ( {
 	return (
 		<>
 			<Button variant="secondary" onClick={ openModal }>
-				Open Modal with Auxiliary Actions
+				Open Modal with Header Actions
 			</Button>
 			{ isOpen && (
 				<Modal
 					style={ { maxWidth: '600px' } }
 					isDismissible={ false }
 					onRequestClose={ closeModal }
-					auxiliaryActions={ auxiliaryActions }
+					headerActions={ headerActions }
 					{ ...args }
 				>
 					<p>
@@ -151,16 +151,16 @@ Default.parameters = {
 	},
 };
 
-export const WithAuxiliaryActions: ComponentStory< typeof Modal > =
-	TemplateWithAuxiliaryAction.bind( {} );
-WithAuxiliaryActions.args = {
+export const WithHeaderActions: ComponentStory< typeof Modal > =
+	TemplateWithHeaderActions.bind( {} );
+WithHeaderActions.args = {
 	...Default.args,
 };
-WithAuxiliaryActions.argTypes = {
+WithHeaderActions.argTypes = {
 	isDismissible: {
 		control: { type: 'boolean' },
 	},
 };
-WithAuxiliaryActions.parameters = {
+WithHeaderActions.parameters = {
 	...Default.parameters,
 };

--- a/packages/components/src/modal/stories/index.tsx
+++ b/packages/components/src/modal/stories/index.tsx
@@ -7,11 +7,13 @@ import type { ComponentStory, ComponentMeta } from '@storybook/react';
  * WordPress dependencies
  */
 import { useState } from '@wordpress/element';
+import { help, starEmpty, starFilled } from '@wordpress/icons';
 
 /**
  * Internal dependencies
  */
 import Button from '../../button';
+import Tooltip from '../../tooltip';
 import InputControl from '../../input-control';
 import Modal from '../';
 import type { ModalProps } from '../types';
@@ -87,6 +89,56 @@ const Template: ComponentStory< typeof Modal > = ( {
 	);
 };
 
+const TemplateWithAuxiliaryAction: ComponentStory< typeof Modal > = ( {
+	onRequestClose,
+	...args
+} ) => {
+	const [ isLiked, setIsLiked ] = useState( false );
+	const [ isOpen, setOpen ] = useState( false );
+	const openModal = () => setOpen( true );
+	const closeModal: ModalProps[ 'onRequestClose' ] = ( event ) => {
+		setOpen( false );
+		onRequestClose( event );
+	};
+	const auxiliaryActions = (
+		<>
+			<Button
+				icon={ isLiked ? starFilled : starEmpty }
+				label="Like"
+				onClick={ () => setIsLiked( ! isLiked ) }
+			/>
+			<Tooltip text="We are here to help!">
+				<Button icon={ help } label="Help" />
+			</Tooltip>
+		</>
+	);
+
+	return (
+		<>
+			<Button variant="secondary" onClick={ openModal }>
+				Open Modal with Auxiliary Actions
+			</Button>
+			{ isOpen && (
+				<Modal
+					style={ { maxWidth: '600px' } }
+					isDismissible={ false }
+					onRequestClose={ closeModal }
+					auxiliaryActions={ auxiliaryActions }
+					{ ...args }
+				>
+					<p>
+						Lorem ipsum dolor sit amet, consectetur adipiscing elit,
+						sed do eiusmod tempor incididunt ut labore et magna
+						aliqua.
+					</p>
+					<Button variant="secondary" onClick={ closeModal }>
+						Close Modal
+					</Button>
+				</Modal>
+			) }
+		</>
+	);
+};
 export const Default: ComponentStory< typeof Modal > = Template.bind( {} );
 Default.args = {
 	title: 'Title',
@@ -97,4 +149,18 @@ Default.parameters = {
 			code: '',
 		},
 	},
+};
+
+export const WithAuxiliaryActions: ComponentStory< typeof Modal > =
+	TemplateWithAuxiliaryAction.bind( {} );
+WithAuxiliaryActions.args = {
+	...Default.args,
+};
+WithAuxiliaryActions.argTypes = {
+	isDismissible: {
+		control: { type: 'boolean' },
+	},
+};
+WithAuxiliaryActions.parameters = {
+	...Default.parameters,
 };

--- a/packages/components/src/modal/test/index.tsx
+++ b/packages/components/src/modal/test/index.tsx
@@ -115,4 +115,27 @@ describe( 'Modal', () => {
 		await user.click( modalFrame.parentElement! );
 		expect( opener ).toHaveFocus();
 	} );
+
+	it( 'should allow fullscreen toggle', async () => {
+		const user = userEvent.setup();
+		render(
+			<Modal allowFullScreenToggle={ true } onRequestClose={ noop }>
+				<p>Modal content</p>
+			</Modal>
+		);
+		const enterFullScreenToggleButton = screen.getByLabelText(
+			'Enter fullscreen',
+			{ selector: 'button' }
+		);
+		await user.click( enterFullScreenToggleButton );
+		expect( screen.getByRole( 'dialog' ) ).toHaveClass( 'is-full-screen' );
+		const exitFullScreenToggleButton = screen.getByLabelText(
+			'Exit fullscreen',
+			{ selector: 'button' }
+		);
+		await user.click( exitFullScreenToggleButton );
+		expect( screen.getByRole( 'dialog' ) ).not.toHaveClass(
+			'is-full-screen'
+		);
+	} );
 } );

--- a/packages/components/src/modal/test/index.tsx
+++ b/packages/components/src/modal/test/index.tsx
@@ -116,26 +116,17 @@ describe( 'Modal', () => {
 		expect( opener ).toHaveFocus();
 	} );
 
-	it( 'should allow fullscreen toggle', async () => {
-		const user = userEvent.setup();
+	it( 'should render `auxiliaryActions` React nodes', async () => {
 		render(
-			<Modal allowFullScreenToggle={ true } onRequestClose={ noop }>
+			<Modal
+				auxiliaryActions={ <button>A sweet button</button> }
+				onRequestClose={ noop }
+			>
 				<p>Modal content</p>
 			</Modal>
 		);
-		const enterFullScreenToggleButton = screen.getByLabelText(
-			'Enter fullscreen',
-			{ selector: 'button' }
-		);
-		await user.click( enterFullScreenToggleButton );
-		expect( screen.getByRole( 'dialog' ) ).toHaveClass( 'is-full-screen' );
-		const exitFullScreenToggleButton = screen.getByLabelText(
-			'Exit fullscreen',
-			{ selector: 'button' }
-		);
-		await user.click( exitFullScreenToggleButton );
-		expect( screen.getByRole( 'dialog' ) ).not.toHaveClass(
-			'is-full-screen'
-		);
+		expect(
+			screen.getByText( 'A sweet button', { selector: 'button' } )
+		).toBeInTheDocument();
 	} );
 } );

--- a/packages/components/src/modal/test/index.tsx
+++ b/packages/components/src/modal/test/index.tsx
@@ -116,10 +116,10 @@ describe( 'Modal', () => {
 		expect( opener ).toHaveFocus();
 	} );
 
-	it( 'should render `auxiliaryActions` React nodes', async () => {
+	it( 'should render `headerActions` React nodes', async () => {
 		render(
 			<Modal
-				auxiliaryActions={ <button>A sweet button</button> }
+				headerActions={ <button>A sweet button</button> }
 				onRequestClose={ noop }
 			>
 				<p>Modal content</p>

--- a/packages/components/src/modal/types.ts
+++ b/packages/components/src/modal/types.ts
@@ -34,13 +34,6 @@ export type ModalProps = {
 		labelledby?: string;
 	};
 	/**
-	 * Elements that are injected into the modal header to the left of the close button (if rendered).
-	 * Hidden if `__experimentalHideHeader` is `true`.
-	 *
-	 * @default null
-	 */
-	auxiliaryActions?: ReactNode;
-	/**
 	 * Class name added to the body element when the modal is open.
 	 *
 	 * @default 'modal-open'
@@ -76,6 +69,14 @@ export type ModalProps = {
 	 * @default true
 	 */
 	focusOnMount?: Parameters< typeof useFocusOnMount >[ 0 ];
+	/**
+	 * Elements that are injected into the modal header to the left of the close button (if rendered).
+	 * Hidden if `__experimentalHideHeader` is `true`.
+	 *
+	 * @default null
+	 */
+	headerActions?: ReactNode;
+
 	/**
 	 * If this property is added, an icon will be added before the title.
 	 */

--- a/packages/components/src/modal/types.ts
+++ b/packages/components/src/modal/types.ts
@@ -16,6 +16,12 @@ import type {
 import type { useFocusOnMount } from '@wordpress/compose';
 
 export type ModalProps = {
+	/**
+	 * This property when set to `true` allows toggling between full screen.
+	 *
+	 * @default false
+	 */
+	allowFullScreenToggle?: boolean;
 	aria?: {
 		/**
 		 * If this property is added, it will be added to the modal content

--- a/packages/components/src/modal/types.ts
+++ b/packages/components/src/modal/types.ts
@@ -16,12 +16,6 @@ import type {
 import type { useFocusOnMount } from '@wordpress/compose';
 
 export type ModalProps = {
-	/**
-	 * This property when set to `true` allows toggling between full screen.
-	 *
-	 * @default false
-	 */
-	allowFullScreenToggle?: boolean;
 	aria?: {
 		/**
 		 * If this property is added, it will be added to the modal content
@@ -39,6 +33,13 @@ export type ModalProps = {
 		 */
 		labelledby?: string;
 	};
+	/**
+	 * Elements that are injected into the modal header to the left of the close button (if rendered).
+	 * Hidden if `__experimentalHideHeader` is `true`.
+	 *
+	 * @default null
+	 */
+	auxiliaryActions?: ReactNode;
 	/**
 	 * Class name added to the body element when the modal is open.
 	 *


### PR DESCRIPTION
## What?
Not sure about this one yet. I would value some input 🙇🏻 

This is an experiment to add a new prop `headerActions: ReacNode` to the `<Modal />` component. 

The prop allows folks to inject buttons and other elements into the header.


## Why?
See: https://github.com/WordPress/gutenberg/issues/53258#issuecomment-1663326667

Some folks working in the classic block require things to be roomier, and it'd be nice to be able to toggle fullscreen mode in the modal. Why? There might be a lot of complex content in there, for which it would be helpful to have more real estate to work.

## How?
Adding a new prop.

## TODO
- [x] add stories

## Testing Instructions

A good place to test this is by applying the new prop to the Class block modal:

<details>

<summary>Example diff</summary>

```diff
diff --git a/packages/block-library/src/freeform/editor.scss b/packages/block-library/src/freeform/editor.scss
index a3be7ffc5e..c09cf9aace 100644
--- a/packages/block-library/src/freeform/editor.scss
+++ b/packages/block-library/src/freeform/editor.scss
@@ -376,14 +376,16 @@ div[data-type="core/freeform"] {
 }
 
 .block-editor-freeform-modal {
-	.components-modal__frame {
+	.block-editor-freeform-modal__content {
 		// On large screens, make the TinyMCE edit area grow to take all the
 		// available height so that the Cancel/Save buttons are always into the
 		// view. On smaller screens, the modal content is scrollable.
 		@include break-large() {
 			// On medium and large screens, the modal component sets a max-height.
 			// We want the modal to be as tall as possible also when the content is short.
-			height: 9999rem;
+			&:not(.is-full-screen) {
+				height: 9999rem;
+			}
 
 			.components-modal__header + div {
 				height: 100%;
diff --git a/packages/block-library/src/freeform/modal.js b/packages/block-library/src/freeform/modal.js
index 9f7b20460c..61a6b89415 100644
--- a/packages/block-library/src/freeform/modal.js
+++ b/packages/block-library/src/freeform/modal.js
@@ -13,6 +13,29 @@ import {
 import { useEffect, useState, RawHTML } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
+import { fullscreen } from '@wordpress/icons';
+import { useViewportMatch } from '@wordpress/compose';
+
+function ModalAuxiliaryActions( { onClick, isModalFullScreen } ) {
+	// 'small' to match the rules in editor.scss.
+	const isMobileViewport = useViewportMatch( 'small', '<' );
+	if ( isMobileViewport ) {
+		return null;
+	}
+
+	return (
+		<Button
+			onClick={ onClick }
+			icon={ fullscreen }
+			isPressed={ isModalFullScreen }
+			label={
+				isModalFullScreen
+					? __( 'Exit fullscreen' )
+					: __( 'Enter fullscreen' )
+			}
+		/>
+	);
+}
 
 function ClassicEdit( props ) {
 	const styles = useSelect(
@@ -58,6 +81,7 @@ export default function ModalEdit( props ) {
 		onReplace,
 	} = props;
 	const [ isOpen, setOpen ] = useState( false );
+	const [ isModalFullScreen, setIsModalFullScreen ] = useState( true );
 	const id = `editor-${ clientId }`;
 
 	const onClose = () => ( content ? setOpen( false ) : onReplace( [] ) );
@@ -78,6 +102,16 @@ export default function ModalEdit( props ) {
 					onRequestClose={ onClose }
 					shouldCloseOnClickOutside={ false }
 					overlayClassName="block-editor-freeform-modal"
+					isFullScreen={ isModalFullScreen }
+					className="block-editor-freeform-modal__content"
+					headerActions={
+						<ModalAuxiliaryActions
+							onClick={ () =>
+								setIsModalFullScreen( ! isModalFullScreen )
+							}
+							isModalFullScreen={ isModalFullScreen }
+						/>
+					}
 				>
 					<ClassicEdit id={ id } defaultValue={ content } />
 					<Flex

```


</details>

Also checkout the Story Book variation: `npm run storybook:dev`



## Screenshots or screencast <!-- if applicable -->



https://github.com/WordPress/gutenberg/assets/6458278/31076ec3-f07f-41ae-ace3-39586be7301e



https://github.com/WordPress/gutenberg/assets/6458278/f9422bda-f795-410f-acde-785bcb1463af


## ✍️  Dev note

Thanks to a new headerActions prop, consumers of Modal can inject buttons (and other elements) into the Modal's header, next to the close button.
