### PR TITLE
Migrate PostTypeSupportCheck usages from withSelect to hooks

### DIFF
--- a/packages/editor/src/components/page-attributes/order.js
+++ b/packages/editor/src/components/page-attributes/order.js
@@ -7,8 +7,7 @@ import {
 	FlexBlock,
 	__experimentalNumberControl as NumberControl,
 } from '@wordpress/components';
-import { withSelect, withDispatch } from '@wordpress/data';
-import { compose } from '@wordpress/compose';
+import { useSelect, useDispatch } from '@wordpress/data';
 import { useState } from '@wordpress/element';
 
 /**
@@ -17,17 +16,25 @@ import { useState } from '@wordpress/element';
 import PostTypeSupportCheck from '../post-type-support-check';
 import { store as editorStore } from '../../store';
 
-export const PageAttributesOrder = ( { onUpdateOrder, order = 0 } ) => {
+function PageAttributesOrder() {
+	const order = useSelect(
+		( select ) =>
+			select( editorStore ).getEditedPostAttribute( 'menu_order' ) ?? 0,
+		[]
+	);
+	const { editPost } = useDispatch( editorStore );
 	const [ orderInput, setOrderInput ] = useState( null );
 
 	const setUpdatedOrder = ( value ) => {
 		setOrderInput( value );
 		const newOrder = Number( value );
 		if ( Number.isInteger( newOrder ) && value.trim?.() !== '' ) {
-			onUpdateOrder( Number( value ) );
+			editPost( { menu_order: newOrder } );
 		}
 	};
-	const value = orderInput === null ? order : orderInput;
+
+	const value = orderInput ?? order;
+
 	return (
 		<Flex>
 			<FlexBlock>
@@ -43,27 +50,12 @@ export const PageAttributesOrder = ( { onUpdateOrder, order = 0 } ) => {
 			</FlexBlock>
 		</Flex>
 	);
-};
+}
 
-function PageAttributesOrderWithChecks( props ) {
+export default function PageAttributesOrderWithChecks() {
 	return (
 		<PostTypeSupportCheck supportKeys="page-attributes">
-			<PageAttributesOrder { ...props } />
+			<PageAttributesOrder />
 		</PostTypeSupportCheck>
 	);
 }
-
-export default compose( [
-	withSelect( ( select ) => {
-		return {
-			order: select( editorStore ).getEditedPostAttribute( 'menu_order' ),
-		};
-	} ),
-	withDispatch( ( dispatch ) => ( {
-		onUpdateOrder( order ) {
-			dispatch( editorStore ).editPost( {
-				menu_order: order,
-			} );
-		},
-	} ) ),
-] )( PageAttributesOrderWithChecks );

--- a/packages/editor/src/components/post-excerpt/check.js
+++ b/packages/editor/src/components/post-excerpt/check.js
@@ -3,8 +3,12 @@
  */
 import PostTypeSupportCheck from '../post-type-support-check';
 
-function PostExcerptCheck( props ) {
-	return <PostTypeSupportCheck { ...props } supportKeys="excerpt" />;
+function PostExcerptCheck( { children } ) {
+	return (
+		<PostTypeSupportCheck supportKeys="excerpt">
+			{ children }
+		</PostTypeSupportCheck>
+	);
 }
 
 export default PostExcerptCheck;

--- a/packages/editor/src/components/post-featured-image/check.js
+++ b/packages/editor/src/components/post-featured-image/check.js
@@ -4,10 +4,12 @@
 import PostTypeSupportCheck from '../post-type-support-check';
 import ThemeSupportCheck from '../theme-support-check';
 
-function PostFeaturedImageCheck( props ) {
+function PostFeaturedImageCheck( { children } ) {
 	return (
 		<ThemeSupportCheck supportKeys="post-thumbnails">
-			<PostTypeSupportCheck { ...props } supportKeys="thumbnail" />
+			<PostTypeSupportCheck supportKeys="thumbnail">
+				{ children }
+			</PostTypeSupportCheck>
 		</ThemeSupportCheck>
 	);
 }

--- a/packages/editor/src/components/post-format/check.js
+++ b/packages/editor/src/components/post-format/check.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { withSelect } from '@wordpress/data';
+import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -9,17 +9,22 @@ import { withSelect } from '@wordpress/data';
 import PostTypeSupportCheck from '../post-type-support-check';
 import { store as editorStore } from '../../store';
 
-function PostFormatCheck( { disablePostFormats, ...props } ) {
+function PostFormatCheck( { children } ) {
+	const disablePostFormats = useSelect(
+		( select ) =>
+			select( editorStore ).getEditorSettings().disablePostFormats,
+		[]
+	);
+
+	if ( disablePostFormats ) {
+		return null;
+	}
+
 	return (
-		! disablePostFormats && (
-			<PostTypeSupportCheck { ...props } supportKeys="post-formats" />
-		)
+		<PostTypeSupportCheck supportKeys="post-formats">
+			{ children }
+		</PostTypeSupportCheck>
 	);
 }
 
-export default withSelect( ( select ) => {
-	const editorSettings = select( editorStore ).getEditorSettings();
-	return {
-		disablePostFormats: editorSettings.disablePostFormats,
-	};
-} )( PostFormatCheck );
+export default PostFormatCheck;

--- a/packages/editor/src/components/post-last-revision/check.js
+++ b/packages/editor/src/components/post-last-revision/check.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { withSelect } from '@wordpress/data';
+import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -9,11 +9,16 @@ import { withSelect } from '@wordpress/data';
 import PostTypeSupportCheck from '../post-type-support-check';
 import { store as editorStore } from '../../store';
 
-export function PostLastRevisionCheck( {
-	lastRevisionId,
-	revisionsCount,
-	children,
-} ) {
+function PostLastRevisionCheck( { children } ) {
+	const { lastRevisionId, revisionsCount } = useSelect( ( select ) => {
+		const { getCurrentPostLastRevisionId, getCurrentPostRevisionsCount } =
+			select( editorStore );
+		return {
+			lastRevisionId: getCurrentPostLastRevisionId(),
+			revisionsCount: getCurrentPostRevisionsCount(),
+		};
+	}, [] );
+
 	if ( ! lastRevisionId || revisionsCount < 2 ) {
 		return null;
 	}
@@ -25,11 +30,4 @@ export function PostLastRevisionCheck( {
 	);
 }
 
-export default withSelect( ( select ) => {
-	const { getCurrentPostLastRevisionId, getCurrentPostRevisionsCount } =
-		select( editorStore );
-	return {
-		lastRevisionId: getCurrentPostLastRevisionId(),
-		revisionsCount: getCurrentPostRevisionsCount(),
-	};
-} )( PostLastRevisionCheck );
+export default PostLastRevisionCheck;

--- a/packages/editor/src/components/post-last-revision/index.js
+++ b/packages/editor/src/components/post-last-revision/index.js
@@ -3,7 +3,7 @@
  */
 import { sprintf, _n } from '@wordpress/i18n';
 import { Button } from '@wordpress/components';
-import { withSelect } from '@wordpress/data';
+import { useSelect } from '@wordpress/data';
 import { backup } from '@wordpress/icons';
 import { addQueryArgs } from '@wordpress/url';
 
@@ -13,7 +13,16 @@ import { addQueryArgs } from '@wordpress/url';
 import PostLastRevisionCheck from './check';
 import { store as editorStore } from '../../store';
 
-function LastRevision( { lastRevisionId, revisionsCount } ) {
+function LastRevision() {
+	const { lastRevisionId, revisionsCount } = useSelect( ( select ) => {
+		const { getCurrentPostLastRevisionId, getCurrentPostRevisionsCount } =
+			select( editorStore );
+		return {
+			lastRevisionId: getCurrentPostLastRevisionId(),
+			revisionsCount: getCurrentPostRevisionsCount(),
+		};
+	}, [] );
+
 	return (
 		<PostLastRevisionCheck>
 			<Button
@@ -34,11 +43,4 @@ function LastRevision( { lastRevisionId, revisionsCount } ) {
 	);
 }
 
-export default withSelect( ( select ) => {
-	const { getCurrentPostLastRevisionId, getCurrentPostRevisionsCount } =
-		select( editorStore );
-	return {
-		lastRevisionId: getCurrentPostLastRevisionId(),
-		revisionsCount: getCurrentPostRevisionsCount(),
-	};
-} )( LastRevision );
+export default LastRevision;

--- a/packages/editor/src/components/post-last-revision/test/check.js
+++ b/packages/editor/src/components/post-last-revision/test/check.js
@@ -4,37 +4,49 @@
 import { render, screen } from '@testing-library/react';
 
 /**
+ * WordPress dependencies
+ */
+import { useSelect } from '@wordpress/data';
+
+/**
  * Internal dependencies
  */
-import { PostLastRevisionCheck } from '../check';
+import PostLastRevisionCheck from '../check';
+
+jest.mock( '@wordpress/data/src/components/use-select', () => jest.fn() );
+
+function setupDataMock( id, count ) {
+	useSelect.mockImplementation( ( mapSelect ) =>
+		mapSelect( () => ( {
+			getCurrentPostLastRevisionId: () => id,
+			getCurrentPostRevisionsCount: () => count,
+			getEditedPostAttribute: () => null,
+			getPostType: () => null,
+		} ) )
+	);
+}
 
 describe( 'PostLastRevisionCheck', () => {
 	it( 'should not render anything if the last revision ID is unknown', () => {
-		render(
-			<PostLastRevisionCheck revisionsCount={ 2 }>
-				Children
-			</PostLastRevisionCheck>
-		);
+		setupDataMock( null, 2 );
+
+		render( <PostLastRevisionCheck>Children</PostLastRevisionCheck> );
 
 		expect( screen.queryByText( 'Children' ) ).not.toBeInTheDocument();
 	} );
 
 	it( 'should not render anything if there is only one revision', () => {
-		render(
-			<PostLastRevisionCheck lastRevisionId={ 1 } revisionsCount={ 1 }>
-				Children
-			</PostLastRevisionCheck>
-		);
+		setupDataMock( 1, 1 );
+
+		render( <PostLastRevisionCheck>Children</PostLastRevisionCheck> );
 
 		expect( screen.queryByText( 'Children' ) ).not.toBeInTheDocument();
 	} );
 
 	it( 'should render if there are two revisions', () => {
-		render(
-			<PostLastRevisionCheck lastRevisionId={ 1 } revisionsCount={ 2 }>
-				Children
-			</PostLastRevisionCheck>
-		);
+		setupDataMock( 1, 2 );
+
+		render( <PostLastRevisionCheck>Children</PostLastRevisionCheck> );
 
 		expect( screen.getByText( 'Children' ) ).toBeVisible();
 	} );

--- a/packages/editor/src/components/post-type-support-check/index.js
+++ b/packages/editor/src/components/post-type-support-check/index.js
@@ -21,7 +21,7 @@ import { store as editorStore } from '../../store';
  *
  * @return {WPComponent} The component to be rendered.
  */
-export function PostTypeSupportCheck( { children, supportKeys } ) {
+function PostTypeSupportCheck( { children, supportKeys } ) {
 	const postType = useSelect( ( select ) => {
 		const { getEditedPostAttribute } = select( editorStore );
 		const { getPostType } = select( coreStore );

--- a/packages/editor/src/components/post-type-support-check/test/index.js
+++ b/packages/editor/src/components/post-type-support-check/test/index.js
@@ -11,7 +11,7 @@ import { useSelect } from '@wordpress/data';
 /**
  * Internal dependencies
  */
-import { PostTypeSupportCheck } from '../';
+import PostTypeSupportCheck from '../';
 
 jest.mock( '@wordpress/data/src/components/use-select', () => {
 	// This allows us to tweak the returned value on each test.


### PR DESCRIPTION
Inspired by @Mamaduka's #53235, this PR removes a few more usages of `withSelect` from components that use `PostTypeSupportCheck`.
- `withSelect` usages are converted to `useSelect` hooks, updating also some unit tests that now need `useSelect` mocking
- simplified module exports -- without a HoC, we no longer need to export two versions of a component, one wrapped and one unwrapped.
- some clarity is added to what props are passed through to `PostTypeSupportCheck`. It accepts only `children` (in addition to `supportKey`), so we always use `children` explicitly instead of generic `...props` passthroughs.