### PR TITLE
Hide pattern previews on hover in inserter

### DIFF
--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -260,6 +260,7 @@ function InserterMenu(
 							filterValue={ delayedFilterValue }
 							onSelect={ onSelect }
 							onHover={ onHover }
+							onHoverPattern={ onHoverPattern }
 							rootClientId={ rootClientId }
 							clientId={ clientId }
 							isAppender={ isAppender }

--- a/packages/block-editor/src/components/inserter/search-results.js
+++ b/packages/block-editor/src/components/inserter/search-results.js
@@ -38,6 +38,7 @@ function InserterSearchResults( {
 	filterValue,
 	onSelect,
 	onHover,
+	onHoverPattern,
 	rootClientId,
 	clientId,
 	isAppender,
@@ -189,7 +190,7 @@ function InserterSearchResults( {
 					shownPatterns={ currentShownPatterns }
 					blockPatterns={ filteredBlockPatterns }
 					onClickPattern={ onSelectBlockPattern }
-					onHover={ onHover }
+					onHover={ onHoverPattern }
 					isDraggable={ isDraggable }
 				/>
 			</div>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Fix https://github.com/WordPress/gutenberg/issues/50495. Hide the pattern previews on hover in the inserter.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
There are already previews in the inserter sidebar, so we don't need to show the popover preview again.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Use `onHoverPattern` for pattern items.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
Follow the instructions in https://github.com/WordPress/gutenberg/issues/50495. Or follow the instructions in the below screencast.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
Same as above. The preview is visual only so this PR has no impact for screen reader users. The preview also only shows when the user is using a mouse to hover over the item, it doesn't show when the item is focused via the keyboard.

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/7753001/99b88a7b-835d-4f40-a458-f172d6865d12

