### PR TITLE
Interactivity API: Add support for underscores and leading dashes in the suffix part of the directive

### DIFF
--- a/packages/e2e-tests/plugins/interactive-blocks/directive-class/render.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-class/render.php
@@ -72,4 +72,15 @@
 			Toggle context falseValue
 		</button>
 	</div>
+
+	<div
+		data-wp-class--block__element--modifier="state.trueValue"
+		data-testid="can use BEM notation classes"
+	></div>
+
+	<div
+		data-wp-class--main-bg----color="state.trueValue"
+		data-testid="can use classes with several dashes"
+	></div>
+
 </div>

--- a/packages/interactivity/CHANGELOG.md
+++ b/packages/interactivity/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fix
+
+- Add support for underscores and leading dashes in the suffix part of the directive. ([#53337](https://github.com/WordPress/gutenberg/pull/53337))
+
 ### Breaking Change
 
 -   Remove the `wp-show` directive until we figure out its final implementation. ([#53240](https://github.com/WordPress/gutenberg/pull/53240))

--- a/packages/interactivity/src/vdom.js
+++ b/packages/interactivity/src/vdom.js
@@ -21,7 +21,7 @@ const directiveParser = new RegExp(
 		// (Optional) Match '--' followed by any alphanumeric charachters. It
 		// excludes underscore intentionally to prevent confusion, but it can
 		// contain multiple hyphens. E.g., "--custom-prefix--with-more-info".
-		'(?:--([a-z0-9][a-z0-9-]+))?$',
+		'(?:--([a-z0-9_-]+))?',
 	'i' // Case insensitive.
 );
 

--- a/packages/interactivity/src/vdom.js
+++ b/packages/interactivity/src/vdom.js
@@ -21,7 +21,7 @@ const directiveParser = new RegExp(
 		// (Optional) Match '--' followed by any alphanumeric charachters. It
 		// excludes underscore intentionally to prevent confusion, but it can
 		// contain multiple hyphens. E.g., "--custom-prefix--with-more-info".
-		'(?:--([a-z0-9_-]+))?',
+		'(?:--([a-z0-9_-]+))?$',
 	'i' // Case insensitive.
 );
 

--- a/test/e2e/specs/interactivity/directives-class.spec.ts
+++ b/test/e2e/specs/interactivity/directives-class.spec.ts
@@ -98,4 +98,14 @@ test.describe( 'data-wp-class', () => {
 		await page.getByTestId( 'toggle context false value' ).click();
 		await expect( el ).toHaveClass( '' );
 	} );
+
+	test( 'can use BEM notation classes', async ( { page } ) => {
+		const el = page.getByTestId( 'can use BEM notation classes' );
+		await expect( el ).toHaveClass( 'block__element--modifier' );
+	} );
+
+	test( 'can use classes with several dashes', async ( { page } ) => {
+		const el = page.getByTestId( 'can use classes with several dashes' );
+		await expect( el ).toHaveClass( 'main-bg----color' );
+	} );
 } );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Allow data-wp-class to contain classes with underscores, like BEM notation.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Cause WordPress is using this notation for their classes, and, trying to migrate Search block to the Interactivity API, I found that the directive was not processed for the class that hides the search input.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Changing REGEX 😭 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
I added a couple of tests, but still, feel free to test it by using `data-wp-class--underscores__for_the_win` in an interactive block and check that everything is working as expected.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
