### PR TITLE
Aspect Ratio: Reset height when selecting the original aspect ratio

### DIFF
--- a/packages/block-editor/src/components/dimensions-tool/index.js
+++ b/packages/block-editor/src/components/dimensions-tool/index.js
@@ -124,12 +124,7 @@ function DimensionsTool( {
 					}
 
 					// Auto-update width and height.
-					if ( nextAspectRatio && width && height ) {
-						delete nextValue.height;
-					}
-
-					// Delete width and height when setting back to original.
-					if ( nextAspectRatio === null ) {
+					if ( aspectRatio !== nextAspectRatio && width && height ) {
 						delete nextValue.height;
 					}
 

--- a/packages/block-editor/src/components/dimensions-tool/index.js
+++ b/packages/block-editor/src/components/dimensions-tool/index.js
@@ -124,7 +124,7 @@ function DimensionsTool( {
 					}
 
 					// Auto-update width and height.
-					if ( aspectRatio !== nextAspectRatio && width && height ) {
+					if ( 'custom' !== nextAspectRatio && width && height ) {
 						delete nextValue.height;
 					}
 

--- a/packages/block-editor/src/components/dimensions-tool/index.js
+++ b/packages/block-editor/src/components/dimensions-tool/index.js
@@ -128,6 +128,11 @@ function DimensionsTool( {
 						delete nextValue.height;
 					}
 
+					// Delete width and height when setting back to original.
+					if ( nextAspectRatio === null ) {
+						delete nextValue.height;
+					}
+
 					onChange( nextValue );
 				} }
 			/>


### PR DESCRIPTION
## What?
Prevent images from stretching when resetting back to the original aspect ratio.

## Why?
On trunk, if an image has a custom aspect ratio, when you select the original aspect ratio the height and with are maintained, which makes the image stretched.

## How?
If the user selected the original aspect ratio we remove the height definition, allowing the image to rescale naturally.

## Testing Instructions
1. Add an image to a post
2. Select an aspect ratio
3. Resize the image using the drag handles
4. Now enter a custom height in the image dimension controls
5. Now select the original aspect ratio
6. The image should display with the same width but with a height that allows it to return to the natural aspect ratio for the image.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
<img width="1382" alt="Screenshot 2023-08-04 at 12 13 39" src="https://github.com/WordPress/gutenberg/assets/275961/f9441f30-e35a-43cd-896b-0ec49bee0e5a">
<img width="1401" alt="Screenshot 2023-08-04 at 12 13 47" src="https://github.com/WordPress/gutenberg/assets/275961/f4bf522e-4c01-4723-a598-5b0b9c1a4b8a">

