### PR TITLE
ProgressBar: Use the theme system accent for indicator color

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -12,6 +12,7 @@
 -   `MenuItemsChoice`, `MenuItem`: Support a `disabled` prop on a menu item ([#52737](https://github.com/WordPress/gutenberg/pull/52737)).
 -   `TabPanel`: Introduce a new version of `TabPanel` with updated internals and improved adherence to ARIA guidance on `tabpanel` focus behavior while maintaining the same functionality and API surface.([#52133](https://github.com/WordPress/gutenberg/pull/52133)).
 -   `Theme`: Expose via private APIs ([#53262](https://github.com/WordPress/gutenberg/pull/53262)).
+-   `ProgressBar`: Use the theme system accent for indicator color ([#53347](https://github.com/WordPress/gutenberg/pull/53347)).
 
 ### Bug Fix
 

--- a/packages/components/src/progress-bar/styles.ts
+++ b/packages/components/src/progress-bar/styles.ts
@@ -43,7 +43,7 @@ export const Indicator = styled.div< {
 	top: 0;
 	height: 100%;
 	border-radius: ${ CONFIG.radiusBlockUi };
-	background-color: ${ COLORS.ui.theme };
+	background-color: var( --wp-components-color-accent, ${ COLORS.ui.theme } );
 
 	${ ( { isIndeterminate, value } ) =>
 		isIndeterminate


### PR DESCRIPTION
## What?
This PR updates the `ProgressBar` indicator color to use the theme system accent color. Changes are only observable when the `ProgressBar` component is used in conjunction with the `Theme` component.

## Why?
Necessary to be able to properly and reliably style the progress bar for #53032 by using the [`@wordpress/components` Theme system](https://github.com/WordPress/gutenberg/blob/trunk/packages/components/src/theme/README.md#theme).

## How?
We're just changing the `ProgressBar` indicator color to use the theme system accent color with priority, and only optionally fall back to the `COLORS.ui.theme` color.

## Testing Instructions
* Run `npm run storybook:dev`
* Navigate to http://localhost:50240/?path=/docs/components-experimental-progressbar--default
* Verify the progress bar works and looks well. 
* Play with the Theme controls (the pencil icon) and verify the combinations work well.
* Test it with https://github.com/WordPress/gutenberg/pull/53032.

### Testing Instructions for Keyboard
None

## Screenshots or screencast <!-- if applicable -->
None - there are no observable visual changes. They're observed only with #53032.