### PR TITLE
LinkControl/LinkUI: Remove unused `className` prop

### DIFF
--- a/packages/block-library/src/button/edit.js
+++ b/packages/block-library/src/button/edit.js
@@ -235,7 +235,6 @@ function ButtonEdit( props ) {
 					shift
 				>
 					<LinkControl
-						className="wp-block-navigation-link__inline-link-input"
 						value={ { url, opensInNewTab } }
 						onChange={ ( {
 							url: newURL = '',

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -585,7 +585,6 @@ export default function NavigationLinkEdit( {
 					) }
 					{ isLinkOpen && (
 						<LinkUI
-							className="wp-block-navigation-link__inline-link-input"
 							clientId={ clientId }
 							link={ attributes }
 							onClose={ () => setIsLinkOpen( false ) }

--- a/packages/block-library/src/navigation-link/link-ui.js
+++ b/packages/block-library/src/navigation-link/link-ui.js
@@ -188,7 +188,6 @@ export function LinkUI( props ) {
 			<LinkControl
 				hasTextControl
 				hasRichPreviews
-				className={ props.className }
 				value={ link }
 				showInitialSuggestions={ true }
 				withCreateSuggestion={ userCanCreate }

--- a/packages/block-library/src/navigation-submenu/edit.js
+++ b/packages/block-library/src/navigation-submenu/edit.js
@@ -475,7 +475,6 @@ export default function NavigationSubmenuEdit( {
 					}
 					{ ! openSubmenusOnClick && isLinkOpen && (
 						<LinkUI
-							className="wp-block-navigation-link__inline-link-input"
 							clientId={ clientId }
 							link={ attributes }
 							onClose={ () => setIsLinkOpen( false ) }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This PR removes from the `LinkControl` and `LinkUI` components any className prop that is not used and not accepted by the component.

## Why?

- The `wp-block-navigation-link__inline-link-input` class does not appear to be used throughout the repository.
- The `LinkControl` component [does not accept the classname itself](https://github.com/WordPress/gutenberg/blob/16598fc7e3c5330b85fdee322f1f7155754a5e5e/packages/block-editor/src/components/link-control/index.js#L117-L135). Therefore, even the `LinkUI` component that wraps this component should not need to pass the classname to the internal `LinkControl`.

## How?
I have removed those props and classnames. If in the future we want to pass additional classnames to `LinkControl` or `LinkUI` components, I think we can implement them at that time.

## Testing Instructions

As before, the block editor should have no impact.
