### PR TITLE
LinkControl: prevent overflow when the title is a URL

### DIFF
--- a/packages/block-editor/src/components/link-control/link-preview.js
+++ b/packages/block-editor/src/components/link-control/link-preview.js
@@ -68,6 +68,7 @@ export default function LinkPreview( {
 				'is-fetching': !! isFetching,
 				'is-preview': true,
 				'is-error': isEmptyURL,
+				'is-url-title': displayTitle === displayURL,
 			} ) }
 		>
 			<div className="block-editor-link-control__search-item-top">

--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -193,6 +193,11 @@ $preview-image-height: 140px;
 		align-items: center;
 	}
 
+	&.is-url-title .block-editor-link-control__search-item-title {
+		// To prevent overflow when the title is a URL
+		word-break: break-all;
+	}
+
 	.block-editor-link-control__search-item-icon {
 		position: relative;
 		margin-right: $grid-unit-10;


### PR DESCRIPTION
Fixes #53352

## What?

This PR prevents overflow in the `LinkControl` component when the title is a URL.

| Before | After |
|--------|--------|
| ![before](https://github.com/WordPress/gutenberg/assets/54422211/044b6aad-7139-4253-bcc3-87d4103e1020) | ![after](https://github.com/WordPress/gutenberg/assets/54422211/247aad08-bcdd-4fa7-9d95-df993fdce9f3) | 

## Why?

It is the title that is causing the problem, but since [the `overflow-wrap: break-word;` is applied](https://github.com/WordPress/gutenberg/blob/284455b1c4830c45ea0df749b801aab718c535dd/packages/block-editor/src/components/link-control/style.scss#L170), it will wrap properly for text containing normal words. However, if the `hasRichPreviews` is `false`, as in the Button block [LinkControl](url), the title displayed is the URL itself.


## How?

Just as [`word-break: break-word;` is applied to the URL that appears below the title](https://github.com/WordPress/gutenberg/blob/284455b1c4830c45ea0df749b801aab718c535dd/packages/block-editor/src/components/link-control/style.scss#L183), I think I need to apply the same style only if the title is a URL. I have used the `is-url-title` class to make the decision and apply the `word-break: break-all;` if the title is a URL.

## Testing Instructions
- Add a Button block
- Add a URL (https://wordpress.org/news/2023/08/concerns-over-the-european-unions-cyber-resilience-act-cra/)
- trunk: The URL will not wrap properly and the content will overflow.
- This PR: The URL will wrap properly.