### PR TITLE
Try: reduce number of `WP_Theme_JSON` instances

### DIFF
--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -612,17 +612,20 @@ class WP_Theme_JSON_Gutenberg {
 			$origin = 'theme';
 		}
 
-		$this->theme_json    = WP_Theme_JSON_Schema::migrate( $theme_json );
-		$registry            = WP_Block_Type_Registry::get_instance();
-		$valid_block_names   = array_keys( $registry->get_all_registered() );
+		$this->theme_json = WP_Theme_JSON_Schema::migrate( $theme_json );
+
+		// TODO: this needs to be validated at a later stage.
 		$valid_element_names = array_keys( static::ELEMENTS );
-		$valid_variations    = array();
-		foreach ( self::get_blocks_metadata() as $block_name => $block_meta ) {
-			if ( ! isset( $block_meta['styleVariations'] ) ) {
-				continue;
-			}
-			$valid_variations[ $block_name ] = array_keys( $block_meta['styleVariations'] );
+		$valid_block_names   = array();
+		if ( isset( $theme_json['styles']['blocks'] ) ) {
+			$valid_block_names = array_keys( $theme_json['styles']['blocks'] );
 		}
+		if ( isset( $theme_json['settings']['blocks'] ) ) {
+			$valid_block_names = array_unique( array_merge( $valid_block_names, array_keys( $theme_json['settings']['blocks'] ) ) );
+		}
+		$valid_variations = array();
+		// END OF TODO
+
 		$theme_json       = static::sanitize( $this->theme_json, $valid_block_names, $valid_element_names, $valid_variations );
 		$this->theme_json = static::maybe_opt_in_into_settings( $theme_json );
 
@@ -2849,15 +2852,17 @@ class WP_Theme_JSON_Gutenberg {
 
 		$theme_json = WP_Theme_JSON_Schema::migrate( $theme_json );
 
-		$valid_block_names   = array_keys( static::get_blocks_metadata() );
+		// TODO: this needs to be validated at a later stage.
 		$valid_element_names = array_keys( static::ELEMENTS );
-		$valid_variations    = array();
-		foreach ( self::get_blocks_metadata() as $block_name => $block_meta ) {
-			if ( ! isset( $block_meta['styleVariations'] ) ) {
-				continue;
-			}
-			$valid_variations[ $block_name ] = array_keys( $block_meta['styleVariations'] );
+		$valid_block_names   = array();
+		if ( isset( $theme_json['styles']['blocks'] ) ) {
+			$valid_block_names = array_keys( $theme_json['styles']['blocks'] );
 		}
+		if ( isset( $theme_json['settings']['blocks'] ) ) {
+			$valid_block_names = array_unique( array_merge( $valid_block_names, array_keys( $theme_json['settings']['blocks'] ) ) );
+		}
+		$valid_variations = array();
+		// END OF TODO
 
 		$theme_json = static::sanitize( $theme_json, $valid_block_names, $valid_element_names, $valid_variations );
 

--- a/lib/class-wp-theme-json-resolver-gutenberg.php
+++ b/lib/class-wp-theme-json-resolver-gutenberg.php
@@ -24,19 +24,6 @@ if ( class_exists( 'WP_Theme_JSON_Resolver_Gutenberg' ) ) {
 class WP_Theme_JSON_Resolver_Gutenberg {
 
 	/**
-	 * Container for keep track of registered blocks.
-	 *
-	 * @since 6.1.0
-	 * @var array
-	 */
-	protected static $blocks_cache = array(
-		'core'   => array(),
-		'blocks' => array(),
-		'theme'  => array(),
-		'user'   => array(),
-	);
-
-	/**
 	 * Container for data coming from core.
 	 *
 	 * @since 5.8.0
@@ -161,7 +148,7 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 	 * @return WP_Theme_JSON Entity that holds core data.
 	 */
 	public static function get_core_data() {
-		if ( null !== static::$core && static::has_same_registered_blocks( 'core' ) ) {
+		if ( null !== static::$core ) {
 			return static::$core;
 		}
 
@@ -180,37 +167,6 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 		static::$core = new WP_Theme_JSON_Gutenberg( $config, 'default' );
 
 		return static::$core;
-	}
-
-	/**
-	 * Checks whether the registered blocks were already processed for this origin.
-	 *
-	 * @since 6.1.0
-	 *
-	 * @param string $origin Data source for which to cache the blocks.
-	 *                       Valid values are 'core', 'blocks', 'theme', and 'user'.
-	 * @return bool True on success, false otherwise.
-	 */
-	protected static function has_same_registered_blocks( $origin ) {
-		// Bail out if the origin is invalid.
-		if ( ! isset( static::$blocks_cache[ $origin ] ) ) {
-			return false;
-		}
-
-		$registry = WP_Block_Type_Registry::get_instance();
-		$blocks   = $registry->get_all_registered();
-
-		// Is there metadata for all currently registered blocks?
-		$block_diff = array_diff_key( $blocks, static::$blocks_cache[ $origin ] );
-		if ( empty( $block_diff ) ) {
-			return true;
-		}
-
-		foreach ( $blocks as $block_name => $block_type ) {
-			static::$blocks_cache[ $origin ][ $block_name ] = true;
-		}
-
-		return false;
 	}
 
 	/**
@@ -240,7 +196,7 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 
 		$options = wp_parse_args( $options, array( 'with_supports' => true ) );
 
-		if ( null === static::$theme || ! static::has_same_registered_blocks( 'theme' ) ) {
+		if ( null === static::$theme ) {
 			$theme_json_file = static::get_file_path_from_theme( 'theme.json' );
 			$wp_theme        = wp_get_theme();
 			if ( '' !== $theme_json_file ) {
@@ -371,7 +327,7 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 		$registry = WP_Block_Type_Registry::get_instance();
 		$blocks   = $registry->get_all_registered();
 
-		if ( null !== static::$blocks && static::has_same_registered_blocks( 'blocks' ) ) {
+		if ( null !== static::$blocks ) {
 			return static::$blocks;
 		}
 
@@ -512,7 +468,7 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 	 * @return WP_Theme_JSON Entity that holds styles for user data.
 	 */
 	public static function get_user_data() {
-		if ( null !== static::$user && static::has_same_registered_blocks( 'user' ) ) {
+		if ( null !== static::$user ) {
 			return static::$user;
 		}
 
@@ -688,12 +644,6 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 	public static function clean_cached_data() {
 		static::$core                     = null;
 		static::$blocks                   = null;
-		static::$blocks_cache             = array(
-			'core'   => array(),
-			'blocks' => array(),
-			'theme'  => array(),
-			'user'   => array(),
-		);
 		static::$theme                    = null;
 		static::$user                     = null;
 		static::$user_custom_post_type_id = null;


### PR DESCRIPTION
**DRAFT PR TO SEE THE IMPACT ON PERFORMANCE TESTS. NOT TO MERGE.**

Related https://github.com/WordPress/gutenberg/issues/45171

## What?

Reduce the number of `WP_Theme_JSON` instances.

## Why?

Faster is better.

## How?

This PR tries to avoid cache invalidation for some of the existing `theme.json` caches. By doing so, the number of instances of `WP_Theme_JSON` go from 30 to 18, reducing the number of processes and the time they take.

## Testing Instructions

See the impact of the performance tests. TBD.
