### PR TITLE
Try using maxHeight instead of height in the dimensions tool

### DIFF
--- a/packages/block-library/src/image/block.json
+++ b/packages/block-library/src/image/block.json
@@ -69,6 +69,12 @@
 		"height": {
 			"type": "string"
 		},
+		"maxWidth": {
+			"type": "string"
+		},
+		"maxHeight": {
+			"type": "string"
+		},
 		"aspectRatio": {
 			"type": "string"
 		},

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -109,6 +109,7 @@ export default function Image( {
 		title,
 		width,
 		height,
+		maxHeight,
 		aspectRatio,
 		scale,
 		linkTarget,
@@ -117,7 +118,7 @@ export default function Image( {
 
 	// The only supported unit is px, so we can parseInt to strip the px here.
 	const numericWidth = width ? parseInt( width, 10 ) : undefined;
-	const numericHeight = height ? parseInt( height, 10 ) : undefined;
+	const numericHeight = height ? parseInt( maxHeight, 10 ) : undefined;
 
 	const imageRef = useRef();
 	const prevCaption = usePrevious( caption );
@@ -326,7 +327,7 @@ export default function Image( {
 
 	function updateAlignment( nextAlign ) {
 		const extraUpdatedAttributes = [ 'wide', 'full' ].includes( nextAlign )
-			? { width: undefined, height: undefined }
+			? { width: undefined, maxHeight: undefined }
 			: {};
 		setAttributes( {
 			...extraUpdatedAttributes,
@@ -443,7 +444,7 @@ export default function Image( {
 					resetAll={ () =>
 						setAttributes( {
 							width: undefined,
-							height: undefined,
+							maxHeight: undefined,
 							scale: undefined,
 							aspectRatio: undefined,
 						} )
@@ -479,14 +480,19 @@ export default function Image( {
 					) }
 					{ isResizable && (
 						<DimensionsTool
-							value={ { width, height, scale, aspectRatio } }
+							value={ {
+								width,
+								height: maxHeight,
+								scale,
+								aspectRatio,
+							} }
 							onChange={ ( newValue ) => {
 								// Rebuilding the object forces setting `undefined`
 								// for values that are removed since setAttributes
 								// doesn't do anything with keys that aren't set.
 								setAttributes( {
 									width: newValue.width,
-									height: newValue.height,
+									maxHeight: newValue.height,
 									scale: newValue.scale,
 									aspectRatio: newValue.aspectRatio,
 								} );
@@ -564,9 +570,13 @@ export default function Image( {
 				className={ borderProps.className }
 				style={ {
 					width:
-						( width && height ) || aspectRatio ? '100%' : undefined,
-					height:
-						( width && height ) || aspectRatio ? '100%' : undefined,
+						( width && maxHeight ) || aspectRatio
+							? '100%'
+							: undefined,
+					maxHeight:
+						( width && maxHeight ) || aspectRatio
+							? '100%'
+							: undefined,
 					objectFit: scale,
 					...borderProps.style,
 				} }
@@ -600,7 +610,7 @@ export default function Image( {
 			/>
 		);
 	} else if ( ! isResizable ) {
-		img = <div style={ { width, height, aspectRatio } }>{ img }</div>;
+		img = <div style={ { width, maxHeight, aspectRatio } }>{ img }</div>;
 	} else {
 		const numericRatio = aspectRatio && evalAspectRatio( aspectRatio );
 		const customRatio = numericWidth / numericHeight;
@@ -666,7 +676,7 @@ export default function Image( {
 					display: 'block',
 					objectFit: scale,
 					aspectRatio:
-						! width && ! height && aspectRatio
+						! width && ! maxHeight && aspectRatio
 							? aspectRatio
 							: undefined,
 				} }
@@ -696,6 +706,7 @@ export default function Image( {
 					setAttributes( {
 						width: `${ elt.offsetWidth }px`,
 						height: 'auto',
+						maxHeight: undefined,
 						aspectRatio: `${ ratio }`,
 					} );
 				} }

--- a/packages/block-library/src/image/save.js
+++ b/packages/block-library/src/image/save.js
@@ -24,6 +24,8 @@ export default function save( { attributes } ) {
 		linkClass,
 		width,
 		height,
+		maxWidth,
+		maxHeight,
 		aspectRatio,
 		scale,
 		id,
@@ -60,6 +62,8 @@ export default function save( { attributes } ) {
 				objectFit: scale,
 				width,
 				height,
+				maxWidth,
+				maxHeight,
 			} }
 			title={ title }
 		/>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

# ⚠️ EXPERIMENT: DO NOT MERGE ⚠️ 

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes an issue that @scruffian found when testing https://github.com/WordPress/gutenberg/pull/53274.

> If I create an image that has fixed width and height attributes like this:
> <img width="823" alt="Screenshot 2023-08-03 at 12 24 00" src="https://github.com/WordPress/gutenberg/assets/275961/bf77b4e1-02ac-47bc-8a66-26496f604869">
(image dimensions 700 x 100)
>
> And then I resize the window, the height gets fixed at 100px but the width reduces, like this:
> <img width="260" alt="Screenshot 2023-08-03 at 12 24 07" src="https://github.com/WordPress/gutenberg/assets/275961/313304ce-3dba-46b1-9ef9-90da098b16d2">

Here we try to set `maxHeight` instead of `height` when changing the dimensions tool. In #53274, the `height` attribute was hard-coded to `'auto'` when using the drag controls.

I'm a bit unsure of this solution for image blocks in horizontal contexts such as the row block.

This doesn't really fix issues some images may be smaller than the height listed and won't be scaled up to match the size they were set to.

But, we're giving it a try to see how the idea pans out and if those issues can be resolved.

I think the heuristic for most users is that the aspect ratio is unchanging when both width and height are set or when the aspect ratio is set regardless of `max-width` being set in the block CSS.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
