### PR TITLE
Quality: remove unnecessary `as` prop from `SiteHub` component

### DIFF
--- a/packages/edit-site/src/components/layout/index.js
+++ b/packages/edit-site/src/components/layout/index.js
@@ -212,7 +212,6 @@ export default function Layout() {
 					animate={ headerAnimationState }
 				>
 					<SiteHub
-						as={ motion.div }
 						variants={ {
 							isDistractionFree: { x: '-100%' },
 							isDistractionFreeHovering: { x: 0 },


### PR DESCRIPTION
Fixes the problem mentioned in [this comment](https://github.com/WordPress/gutenberg/pull/51173#issuecomment-1617635238)

## What?

This PR removes unintended `as` attributes applied to the `SiteHub` component.

| Before | After |
|--------|--------|
| ![before](https://github.com/WordPress/gutenberg/assets/54422211/fae45a7d-2b89-43be-8671-0e13c8f482a9) | ![after](https://github.com/WordPress/gutenberg/assets/54422211/92b8eb6b-7295-4ec9-a5d6-ee75ca607d16) | 

## Why?

As I understand it, the `as` prop is used to control what element/component a certain component is to be rendered as. However, since the `SiteHub` component was originally rendered as `motion.div` and the `as` property is not used internally either, removing it should not be a problem.

## How?

Removed `as` prop.

## Testing Instructions

There should be no effect on the Site Editor, but confirm that animations still work as before when switching between view and edit modes, or in the distraction-free mode added in #51173.