### PR TITLE
Search Block: Fix unintended wrapping of button text in "Button only" style

### DIFF
--- a/packages/block-library/src/search/style.scss
+++ b/packages/block-library/src/search/style.scss
@@ -53,6 +53,10 @@ $button-spacing-y: math.div($grid-unit-15, 2); // 6px
 .wp-block-search.wp-block-search__button-only {
 	.wp-block-search__button {
 		margin-left: 0;
+		// Prevent unintended text wrapping.
+		flex-shrink: 0;
+		// Ensure minimum input field width in small viewports.
+		max-width: calc(100% - 100px);
 	}
 }
 


### PR DESCRIPTION
Fixes: #53297

## What?

This PR fixes an unintentional wrapping of button text when opening and closing input fields when the Search block is "Button only" style.

https://github.com/WordPress/gutenberg/assets/54422211/5063ae73-9027-4f0a-accc-77529decb987

## Why?

The input field and the button are both children of the Flex layout. And since the input field has `fiex-basis:100%` applied, the width of the button is squashed.

## How?

The fact that the input field extends as far as possible to the full width of the parent element is itself an expected behavior. However, to prevent unnecessary button text wrapping, I applied the following styles to the button:

- `flex-shrink: 0;` to prevent text wrapping
- In small viewports, apply `max-width: calc(100% - 100px);` to prevent button overflow and to ensure minimum width of input fields


<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions

- Insert a Search block.
- Change to the button-only style and include multiple words in the button text.
- Click the button.
- In large viewports, button text should not wrap.
- In smaller viewports, buttons should not overflow and should wrap properly.

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/54422211/5c4100c1-d747-45d5-9fec-c0978bbd141b