### PR TITLE
Fix Cover block flicker (with improved heuristics for light/dark theme)

### DIFF
--- a/packages/block-library/src/cover/edit/index.js
+++ b/packages/block-library/src/cover/edit/index.js
@@ -9,7 +9,7 @@ import namesPlugin from 'colord/plugins/names';
  * WordPress dependencies
  */
 import { useEntityProp, store as coreStore } from '@wordpress/core-data';
-import { useEffect, useMemo, useRef } from '@wordpress/element';
+import { useMemo, useRef } from '@wordpress/element';
 import { Placeholder, Spinner } from '@wordpress/components';
 import { compose, useResizeObserver } from '@wordpress/compose';
 import {
@@ -124,8 +124,8 @@ function CoverEdit( {
 		? IMAGE_BACKGROUND_TYPE
 		: attributes.backgroundType;
 
-	const { __unstableMarkNextChangeAsNotPersistent } =
-		useDispatch( blockEditorStore );
+	useCoverIsDark( url, dimRatio, overlayColor.color, setAttributes );
+
 	const { createErrorNotice } = useDispatch( noticesStore );
 	const { gradientClass, gradientValue } = __experimentalUseGradient();
 	const onSelectMedia = attributesFromMedia( setAttributes, dimRatio );
@@ -134,14 +134,6 @@ function CoverEdit( {
 	const onUploadError = ( message ) => {
 		createErrorNotice( message, { type: 'snackbar' } );
 	};
-
-	const isCoverDark = useCoverIsDark( url, dimRatio, overlayColor.color );
-
-	useEffect( () => {
-		// This side-effect should not create an undo level.
-		__unstableMarkNextChangeAsNotPersistent();
-		setAttributes( { isDark: isCoverDark } );
-	}, [ isCoverDark ] );
 
 	const isImageBackground = IMAGE_BACKGROUND_TYPE === backgroundType;
 	const isVideoBackground = VIDEO_BACKGROUND_TYPE === backgroundType;

--- a/packages/block-library/src/cover/edit/use-cover-is-dark.js
+++ b/packages/block-library/src/cover/edit/use-cover-is-dark.js
@@ -73,8 +73,8 @@ export default function useCoverIsDark(
 					silent: process.env.NODE_ENV === 'production',
 					crossOrigin: imgCrossOrigin,
 				} )
-				.then( ( color ) => {
-					const media = colord( color.hex ).toRgb();
+				.then( ( { value: [ r, g, b, a ] } ) => {
+					const media = { r, g, b, a: a / 255 };
 					const composite = compositeOver( overlay, media );
 					setIsDark( colord( composite ).isDark() );
 				} );

--- a/packages/block-library/src/cover/edit/use-cover-is-dark.js
+++ b/packages/block-library/src/cover/edit/use-cover-is-dark.js
@@ -19,7 +19,7 @@ import { applyFilters } from '@wordpress/hooks';
  * @param {import('colord').RgbaColor} dest Destination color.
  * @return {import('colord').RgbaColor} Composite color.
  */
-function compositeOver( source, dest ) {
+function compositeSourceOver( source, dest ) {
 	return {
 		r: source.r * source.a + dest.r * dest.a * ( 1 - source.a ),
 		g: source.g * source.a + dest.g * dest.a * ( 1 - source.a ),
@@ -75,14 +75,14 @@ export default function useCoverIsDark(
 				} )
 				.then( ( { value: [ r, g, b, a ] } ) => {
 					const media = { r, g, b, a: a / 255 };
-					const composite = compositeOver( overlay, media );
+					const composite = compositeSourceOver( overlay, media );
 					setIsDark( colord( composite ).isDark() );
 				} );
 		} else {
 			// Assume a white background because it isn't easy to get the actual
 			// parent background color.
 			const background = { r: 255, g: 255, b: 255, a: 1 };
-			const composite = compositeOver( overlay, background );
+			const composite = compositeSourceOver( overlay, background );
 			setIsDark( colord( composite ).isDark() );
 		}
 	}, [ overlayColor, dimRatio, url, setIsDark ] );

--- a/packages/block-library/src/cover/edit/use-cover-is-dark.js
+++ b/packages/block-library/src/cover/edit/use-cover-is-dark.js
@@ -10,6 +10,15 @@ import { colord } from 'colord';
 import { useEffect, useState } from '@wordpress/element';
 import { applyFilters } from '@wordpress/hooks';
 
+/**
+ * Performs a Porter Duff composite source over operation on two rgba colors.
+ *
+ * @see https://www.w3.org/TR/compositing-1/#porterduffcompositingoperators_srcover
+ *
+ * @param {import('colord').RgbaColor} source Source color.
+ * @param {import('colord').RgbaColor} dest Destination color.
+ * @returns {import('colord').RgbaColor} Composite color.
+ */
 function compositeOver( source, dest ) {
 	return {
 		r: source.r * source.a + dest.r * dest.a * ( 1 - source.a ),

--- a/packages/block-library/src/cover/edit/use-cover-is-dark.js
+++ b/packages/block-library/src/cover/edit/use-cover-is-dark.js
@@ -31,10 +31,8 @@ function retrieveFastAverageColor() {
  */
 export default function useCoverIsDark( url, dimRatio = 50, overlayColor ) {
 	const [ isDark, setIsDark ] = useState( false );
-	const isDimmedEnough = dimRatio > 50;
-	const hasMedia = !! url;
 	useEffect( () => {
-		if ( isDimmedEnough || ! hasMedia || ! elementRef.current ) {
+		if ( dimRatio > 50 || ! url || ! elementRef.current ) {
 			// If opacity is greater than 50 the dominant color is the overlay
 			// color, so use the overlay color for the dark mode computation.
 			// Additionally, fall back to using the overlay color if a
@@ -63,12 +61,6 @@ export default function useCoverIsDark( url, dimRatio = 50, overlayColor ) {
 				} )
 				.then( ( color ) => setIsDark( color.isDark ) );
 		}
-	}, [
-		hasMedia,
-		isDimmedEnough,
-		overlayColor,
-		elementRef.current,
-		setIsDark,
-	] );
+	}, [ dimRatio > 50, ! url, overlayColor, elementRef.current, setIsDark ] );
 	return isDark;
 }

--- a/packages/block-library/src/cover/edit/use-cover-is-dark.js
+++ b/packages/block-library/src/cover/edit/use-cover-is-dark.js
@@ -74,6 +74,6 @@ export default function useCoverIsDark(
 		} else {
 			setIsDark( colord( overlayColor ).isDark() );
 		}
-	}, [ overlayColor, url, setIsDark ] );
+	}, [ overlayColor, dimRatio, url, setIsDark ] );
 	return isDark;
 }

--- a/packages/block-library/src/cover/edit/use-cover-is-dark.js
+++ b/packages/block-library/src/cover/edit/use-cover-is-dark.js
@@ -75,14 +75,15 @@ export default function useCoverIsDark(
 				} )
 				.then( ( color ) => {
 					const media = colord( color.hex ).toRgb();
-					const composite = colord( compositeOver( overlay, media ) );
-					setIsDark( composite.isDark() );
+					const composite = compositeOver( overlay, media );
+					setIsDark( colord( composite ).isDark() );
 				} );
 		} else {
-			// Assume a white background because it isn't easy to get the actual site background color.
+			// Assume a white background because it isn't easy to get the actual
+			// parent background color.
 			const background = { r: 255, g: 255, b: 255, a: 1 };
-			const composite = colord( compositeOver( overlay, background ) );
-			setIsDark( composite.isDark() );
+			const composite = compositeOver( overlay, background );
+			setIsDark( colord( composite ).isDark() );
 		}
 	}, [ overlayColor, dimRatio, url, setIsDark ] );
 	return isDark;

--- a/packages/block-library/src/cover/edit/use-cover-is-dark.js
+++ b/packages/block-library/src/cover/edit/use-cover-is-dark.js
@@ -74,6 +74,7 @@ export default function useCoverIsDark(
 					crossOrigin: imgCrossOrigin,
 				} )
 				.then( ( { value: [ r, g, b, a ] } ) => {
+					// FAC uses 0-255 for alpha, but colord expects 0-1.
 					const media = { r, g, b, a: a / 255 };
 					const composite = compositeSourceOver( overlay, media );
 					setIsDark( colord( composite ).isDark() );

--- a/packages/block-library/src/cover/edit/use-cover-is-dark.js
+++ b/packages/block-library/src/cover/edit/use-cover-is-dark.js
@@ -16,7 +16,7 @@ import { applyFilters } from '@wordpress/hooks';
  * @see https://www.w3.org/TR/compositing-1/#porterduffcompositingoperators_srcover
  *
  * @param {import('colord').RgbaColor} source Source color.
- * @param {import('colord').RgbaColor} dest Destination color.
+ * @param {import('colord').RgbaColor} dest   Destination color.
  * @return {import('colord').RgbaColor} Composite color.
  */
 function compositeSourceOver( source, dest ) {

--- a/packages/block-library/src/cover/edit/use-cover-is-dark.js
+++ b/packages/block-library/src/cover/edit/use-cover-is-dark.js
@@ -17,7 +17,7 @@ import { applyFilters } from '@wordpress/hooks';
  *
  * @param {import('colord').RgbaColor} source Source color.
  * @param {import('colord').RgbaColor} dest Destination color.
- * @returns {import('colord').RgbaColor} Composite color.
+ * @return {import('colord').RgbaColor} Composite color.
  */
 function compositeOver( source, dest ) {
 	return {

--- a/packages/block-library/src/cover/edit/use-cover-is-dark.js
+++ b/packages/block-library/src/cover/edit/use-cover-is-dark.js
@@ -65,11 +65,10 @@ export default function useCoverIsDark(
 						dimRatio / 100
 					);
 					const media = colord( color.hex );
-					const c = colord(
+					const composite = colord(
 						compositeOver( overlay.toRgb(), media.toRgb() )
 					);
-					console.log( c );
-					setIsDark( c.isDark() );
+					setIsDark( composite.isDark() );
 				} );
 		} else {
 			setIsDark( colord( overlayColor ).isDark() );

--- a/packages/block-library/src/cover/edit/use-cover-is-dark.js
+++ b/packages/block-library/src/cover/edit/use-cover-is-dark.js
@@ -11,11 +11,12 @@ import { useEffect, useState } from '@wordpress/element';
 import { applyFilters } from '@wordpress/hooks';
 
 function compositeOver( source, dest ) {
-	const a = source.a + dest.a * ( 1 - source.a );
-	const r = source.r * source.a + dest.r * dest.a * ( 1 - source.a );
-	const g = source.g * source.a + dest.g * dest.a * ( 1 - source.a );
-	const b = source.b * source.a + dest.b * dest.a * ( 1 - source.a );
-	return { r, g, b, a };
+	return {
+		r: source.r * source.a + dest.r * dest.a * ( 1 - source.a ),
+		g: source.g * source.a + dest.g * dest.a * ( 1 - source.a ),
+		b: source.b * source.a + dest.b * dest.a * ( 1 - source.a ),
+		a: source.a + dest.a * ( 1 - source.a ),
+	};
 }
 
 function retrieveFastAverageColor() {

--- a/packages/block-library/src/cover/edit/use-cover-is-dark.js
+++ b/packages/block-library/src/cover/edit/use-cover-is-dark.js
@@ -54,6 +54,9 @@ export default function useCoverIsDark(
 ) {
 	const [ isDark, setIsDark ] = useState( false );
 	useEffect( () => {
+		const overlay = colord( overlayColor )
+			.alpha( dimRatio / 100 )
+			.toRgb();
 		if ( url ) {
 			const imgCrossOrigin = applyFilters(
 				'media.crossOrigin',
@@ -71,17 +74,15 @@ export default function useCoverIsDark(
 					crossOrigin: imgCrossOrigin,
 				} )
 				.then( ( color ) => {
-					const overlay = colord( overlayColor ).alpha(
-						dimRatio / 100
-					);
-					const media = colord( color.hex );
-					const composite = colord(
-						compositeOver( overlay.toRgb(), media.toRgb() )
-					);
+					const media = colord( color.hex ).toRgb();
+					const composite = colord( compositeOver( overlay, media ) );
 					setIsDark( composite.isDark() );
 				} );
 		} else {
-			setIsDark( colord( overlayColor ).isDark() );
+			// Assume a white background because it isn't easy to get the actual site background color.
+			const background = { r: 255, g: 255, b: 255, a: 1 };
+			const composite = colord( compositeOver( overlay, background ) );
+			setIsDark( composite.isDark() );
 		}
 	}, [ overlayColor, dimRatio, url, setIsDark ] );
 	return isDark;

--- a/packages/block-library/src/cover/edit/use-cover-is-dark.js
+++ b/packages/block-library/src/cover/edit/use-cover-is-dark.js
@@ -54,6 +54,9 @@ export default function useCoverIsDark(
 ) {
 	const [ isDark, setIsDark ] = useState( false );
 	useEffect( () => {
+		const overlay = colord( overlayColor )
+			.alpha( dimRatio / 100 )
+			.toRgb();
 		if ( url ) {
 			const imgCrossOrigin = applyFilters(
 				'media.crossOrigin',
@@ -72,16 +75,16 @@ export default function useCoverIsDark(
 				} )
 				.then( ( { value: [ r, g, b, a ] } ) => {
 					// FAC uses 0-255 for alpha, but colord expects 0-1.
-					const overlay = colord( overlayColor )
-						.alpha( dimRatio / 100 )
-						.toRgb();
 					const media = { r, g, b, a: a / 255 };
 					const composite = compositeSourceOver( overlay, media );
 					setIsDark( colord( composite ).isDark() );
 				} );
 		} else {
-			// Use the color directly since it's hard to determine the background color.
-			setIsDark( colord( overlayColor ).isDark() );
+			// Assume a white background because it isn't easy to get the actual
+			// parent background color.
+			const background = { r: 255, g: 255, b: 255, a: 1 };
+			const composite = compositeSourceOver( overlay, background );
+			setIsDark( colord( composite ).isDark() );
 		}
 	}, [ overlayColor, dimRatio, url, setIsDark ] );
 	return isDark;

--- a/packages/block-library/src/cover/edit/use-cover-is-dark.js
+++ b/packages/block-library/src/cover/edit/use-cover-is-dark.js
@@ -54,9 +54,6 @@ export default function useCoverIsDark(
 ) {
 	const [ isDark, setIsDark ] = useState( false );
 	useEffect( () => {
-		const overlay = colord( overlayColor )
-			.alpha( dimRatio / 100 )
-			.toRgb();
 		if ( url ) {
 			const imgCrossOrigin = applyFilters(
 				'media.crossOrigin',
@@ -75,16 +72,16 @@ export default function useCoverIsDark(
 				} )
 				.then( ( { value: [ r, g, b, a ] } ) => {
 					// FAC uses 0-255 for alpha, but colord expects 0-1.
+					const overlay = colord( overlayColor )
+						.alpha( dimRatio / 100 )
+						.toRgb();
 					const media = { r, g, b, a: a / 255 };
 					const composite = compositeSourceOver( overlay, media );
 					setIsDark( colord( composite ).isDark() );
 				} );
 		} else {
-			// Assume a white background because it isn't easy to get the actual
-			// parent background color.
-			const background = { r: 255, g: 255, b: 255, a: 1 };
-			const composite = compositeSourceOver( overlay, background );
-			setIsDark( colord( composite ).isDark() );
+			// Use the color directly since it's hard to determine the background color.
+			setIsDark( colord( overlayColor ).isDark() );
 		}
 	}, [ overlayColor, dimRatio, url, setIsDark ] );
 	return isDark;

--- a/packages/block-library/src/cover/test/edit.js
+++ b/packages/block-library/src/cover/test/edit.js
@@ -422,7 +422,7 @@ describe( 'Cover block', () => {
 				name: 'Color: Black',
 			} );
 			await userEvent.click( popupColorPicker );
-			expect( coverBlock ).toHaveClass( 'is-dark' );
+			expect( coverBlock ).not.toHaveClass( 'is-light' );
 		} );
 	} );
 } );

--- a/packages/block-library/src/cover/test/edit.js
+++ b/packages/block-library/src/cover/test/edit.js
@@ -45,10 +45,10 @@ async function setup( attributes, useCoreBlocks, customSettings ) {
 	return initializeEditor( testBlock, useCoreBlocks, settings );
 }
 
-async function createAndSelectBlock() {
+async function createAndSelectBlock( { overlayColor = 'Black' } = {} ) {
 	await userEvent.click(
 		screen.getByRole( 'button', {
-			name: 'Color: Black',
+			name: `Color: ${ overlayColor }`,
 		} )
 	);
 	await userEvent.click(
@@ -383,16 +383,9 @@ describe( 'Cover block', () => {
 	describe( 'isDark settings', () => {
 		test( 'should toggle is-light class if background changed from light to dark', async () => {
 			await setup();
-			const colorPicker = screen.getByRole( 'button', {
-				name: 'Color: White',
-			} );
-			await userEvent.click( colorPicker );
-
+			await createAndSelectBlock( { overlayColor: 'White' } );
 			const coverBlock = screen.getByLabelText( 'Block: Cover' );
-
 			expect( coverBlock ).toHaveClass( 'is-light' );
-
-			await selectBlock( 'Block: Cover' );
 			await userEvent.click(
 				screen.getByRole( 'tab', {
 					name: 'Styles',
@@ -405,22 +398,21 @@ describe( 'Cover block', () => {
 			await userEvent.click( popupColorPicker );
 			expect( coverBlock ).not.toHaveClass( 'is-light' );
 		} );
-		test( 'should keep is-dark class if overlay color is removed as the CSS default is black', async () => {
+		test( 'should remove is-light class if overlay color is removed', async () => {
 			await setup();
-			await createAndSelectBlock();
+			await createAndSelectBlock( { overlayColor: 'White' } );
 			const coverBlock = screen.getByLabelText( 'Block: Cover' );
-			expect( coverBlock ).not.toHaveClass( 'is-light' );
-
+			expect( coverBlock ).toHaveClass( 'is-light' );
 			await userEvent.click(
 				screen.getByRole( 'tab', {
 					name: 'Styles',
 				} )
 			);
 			await userEvent.click( screen.getByText( 'Overlay' ) );
-			// The default color is black, so clicking the black color option will remove the background color.
-			// The fallback CSS is still black, so the is-dark class should remain.
+			// The color is white, so clicking the same color option will remove
+			// the background color and therefore remove the is-light class.
 			const popupColorPicker = screen.getByRole( 'button', {
-				name: 'Color: Black',
+				name: 'Color: White',
 			} );
 			await userEvent.click( popupColorPicker );
 			expect( coverBlock ).not.toHaveClass( 'is-light' );

--- a/packages/block-library/src/cover/test/edit.js
+++ b/packages/block-library/src/cover/test/edit.js
@@ -285,14 +285,11 @@ describe( 'Cover block', () => {
 					} )
 				);
 
-				fireEvent.change(
-					screen.getByRole( 'spinbutton', {
-						name: 'Overlay opacity',
-					} ),
-					{
-						target: { value: '40' },
-					}
-				);
+				const input = screen.getByRole( 'spinbutton', {
+					name: 'Overlay opacity',
+				} );
+				await userEvent.click( input );
+				await userEvent.keyboard( '[ArrowDown>6/]' );
 
 				expect( overlay[ 0 ] ).toHaveClass( 'has-background-dim-40' );
 			} );
@@ -315,12 +312,16 @@ describe( 'Cover block', () => {
 					} )
 				);
 
-				fireEvent.change(
-					screen.getByRole( 'slider', {
-						name: 'Overlay opacity',
-					} ),
-					{ target: { value: 30 } }
-				);
+				// Disable reason: `useCoverIsDark` triggers `act` warnings otherwise.
+				// eslint-disable-next-line testing-library/no-unnecessary-act
+				await act( async () => {
+					fireEvent.change(
+						screen.getByRole( 'slider', {
+							name: 'Overlay opacity',
+						} ),
+						{ target: { value: 30 } }
+					);
+				} );
 
 				expect( overlay[ 0 ] ).toHaveClass( 'has-background-dim-30' );
 			} );

--- a/packages/block-library/src/cover/test/edit.js
+++ b/packages/block-library/src/cover/test/edit.js
@@ -404,7 +404,7 @@ describe( 'Cover block', () => {
 			await userEvent.click( popupColorPicker );
 			expect( coverBlock ).not.toHaveClass( 'is-light' );
 		} );
-		test( 'should apply is-light class if overlay color is removed', async () => {
+		test( 'should keep is-dark class if overlay color is removed as the CSS default is black', async () => {
 			await setup();
 			await createAndSelectBlock();
 			const coverBlock = screen.getByLabelText( 'Block: Cover' );
@@ -416,13 +416,13 @@ describe( 'Cover block', () => {
 				} )
 			);
 			await userEvent.click( screen.getByText( 'Overlay' ) );
-			// The default color is black, so clicking the black color option will remove the background color,
-			// which should remove the isDark setting and assign the is-light class.
+			// The default color is black, so clicking the black color option will remove the background color.
+			// The fallback CSS is still black, so the is-dark class should remain.
 			const popupColorPicker = screen.getByRole( 'button', {
 				name: 'Color: Black',
 			} );
 			await userEvent.click( popupColorPicker );
-			expect( coverBlock ).toHaveClass( 'is-light' );
+			expect( coverBlock ).toHaveClass( 'is-dark' );
 		} );
 	} );
 } );

--- a/packages/e2e-tests/specs/editor/various/__snapshots__/inserting-blocks.test.js.snap
+++ b/packages/e2e-tests/specs/editor/various/__snapshots__/inserting-blocks.test.js.snap
@@ -88,8 +88,8 @@ exports[`Inserting blocks inserts a block in proper place after having clicked \
 <p>First paragraph</p>
 <!-- /wp:paragraph -->
 
-<!-- wp:cover {"isDark":false,"layout":{"type":"constrained"}} -->
-<div class="wp-block-cover is-light"><span aria-hidden="true" class="wp-block-cover__background has-background-dim-100 has-background-dim"></span><div class="wp-block-cover__inner-container"></div></div>
+<!-- wp:cover {"layout":{"type":"constrained"}} -->
+<div class="wp-block-cover"><span aria-hidden="true" class="wp-block-cover__background has-background-dim-100 has-background-dim"></span><div class="wp-block-cover__inner-container"></div></div>
 <!-- /wp:cover -->
 
 <!-- wp:heading -->


### PR DESCRIPTION
## What?
Fixes the potential for unending state/store update loops in the Cover blocks’s hook for determining light/dark theme.

For now this includes the changes from #45076 for easy testing.

## Why?
The flicker that can be experienced is awful. To fix #53211 

## How?
Removes the local state from the hook to directly use store state.

## Testing Instructions

1. Create a synced pattern that contains a Cover block with a lightish background image set
2. In a theme like TT3, add a new template (e.g. my-template.html in the `templates` directory).
3. Within `my-template.html`, add the synced block pattern. To get the markup to add to the template, you can add the synced pattern to a post or page, then view the code editor view and copy + paste to your `my-template.html` file
4. Create a page and set its template to `my-template.html`.
5. Open the site editor, and navigate to Pages > your newly created page. Click the preview of the page to switch to the edit mode, and check that the Cover block does not flicker.

Example markup from my `my-template.html` file:

```
<!-- wp:template-part {"slug":"header","tagName":"header"} /-->

<!-- wp:pattern {"slug":"core/query-standard-posts"} /-->

<!-- wp:post-content /-->

<!-- wp:post-featured-image /-->

<!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->

<!-- wp:block {"ref":65} /-->
```

