### PR TITLE
[RNMobile] Add outline around selected Social Link block

### DIFF
--- a/packages/block-editor/src/components/block-list/block-outline.native.js
+++ b/packages/block-editor/src/components/block-list/block-outline.native.js
@@ -13,7 +13,7 @@ import { usePreferredColorSchemeStyle } from '@wordpress/compose';
  */
 import styles from './block.scss';
 
-const TEXT_BLOCKS_WITH_OUTLINE = [ 'core/missing' ];
+const BLOCKS_WITH_OUTLINE = [ 'core/social-link', 'core/missing' ];
 
 function BlockOutline( {
 	blockCategory,
@@ -22,7 +22,7 @@ function BlockOutline( {
 	isSelected,
 	name,
 } ) {
-	const textBlockWithOutline = TEXT_BLOCKS_WITH_OUTLINE.includes( name );
+	const textBlockWithOutline = BLOCKS_WITH_OUTLINE.includes( name );
 	const hasBlockTextCategory =
 		blockCategory === 'text' && ! textBlockWithOutline;
 	const hasBlockMediaCategory =

--- a/packages/block-library/src/social-link/edit.native.js
+++ b/packages/block-library/src/social-link/edit.native.js
@@ -119,6 +119,7 @@ const SocialLinkEdit = ( {
 				toValue: 1,
 				duration: ANIMATION_DURATION,
 				easing: Easing.circle,
+				useNativeDriver: false,
 			} ),
 		] ).start( () => setHasUrl( true ) );
 	}

--- a/packages/block-library/src/social-link/edit.native.js
+++ b/packages/block-library/src/social-link/edit.native.js
@@ -157,7 +157,7 @@ const SocialLinkEdit = ( {
 		  );
 
 	return (
-		<View>
+		<View style={ styles.container }>
 			{ isSelected && (
 				<>
 					<BlockControls>

--- a/packages/block-library/src/social-link/editor.native.scss
+++ b/packages/block-library/src/social-link/editor.native.scss
@@ -1,5 +1,9 @@
 @import "./socials-with-bg.scss";
 
+.container {
+	margin: $block-selected-margin;
+}
+
 .linkSettingsPanel {
 	padding-left: 0;
 	padding-right: 0;

--- a/packages/block-library/src/social-links/edit.native.js
+++ b/packages/block-library/src/social-links/edit.native.js
@@ -57,7 +57,7 @@ function SocialLinksEdit( {
 	}, [ shouldRenderFooterAppender ] );
 
 	const renderFooterAppender = useRef( () => (
-		<View>
+		<View style={ styles.footerAppenderContainer }>
 			<InnerBlocks.ButtonBlockAppender isFloating={ true } />
 		</View>
 	) );

--- a/packages/block-library/src/social-links/editor.native.scss
+++ b/packages/block-library/src/social-links/editor.native.scss
@@ -19,3 +19,7 @@
 	flex-direction: row;
 	flex-wrap: wrap;
 }
+
+.footerAppenderContainer {
+	margin: $block-selected-margin 0;
+}

--- a/packages/react-native-editor/CHANGELOG.md
+++ b/packages/react-native-editor/CHANGELOG.md
@@ -11,6 +11,7 @@ For each user feature we should also add a importance categorization label  to i
 
 ## Unreleased
 -   [*] Display custom color value in mobile Cover Block color picker [#51414]
+-   [**] Display outline around selected Social Link block [#51414]
 
 ## 1.101.0
 -   [*] Remove visual gap in mobile toolbar when a Gallery block is selected [#52966]


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Adds outline around the selected Social Link icon on mobile.

* https://github.com/wordpress-mobile/gutenberg-mobile/pull/6043

## Why?
Block Outlines were updated in https://github.com/WordPress/gutenberg/pull/52702, with many outlines being removed. Design feedback indicated that a displaying an outline around the selected Social Link icon would help users to note which icon is selected. 

## How?
Updates the BlockOutline component to include the Social Link block as a block to be outlined.

## Testing Instructions

1. Add a post with a Social Link block
2. Tap between the individual Social Link icons and observe an outline is added

## Screenshots or screencast 

https://github.com/WordPress/gutenberg/assets/643285/a6e62c8f-6cf6-4ca3-861b-10df34c72979





