### PR TITLE
Allow layout controls to be disabled per block from theme.json

### DIFF
--- a/docs/reference-guides/theme-json-reference/theme-json-living.md
+++ b/docs/reference-guides/theme-json-reference/theme-json-living.md
@@ -115,6 +115,7 @@ Settings related to layout.
 | ---       | ---    | ---    |---   |
 | contentSize | string |  |  |
 | wideSize | string |  |  |
+| allowEditing | boolean | true |  |
 
 ---
 

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -346,6 +346,7 @@ class WP_Theme_JSON_Gutenberg {
 	 * @since 6.2.0 Added `dimensions.minHeight`, 'shadow.presets', 'shadow.defaultPresets',
 	 *              `position.fixed` and `position.sticky`.
 	 * @since 6.3.0 Removed `layout.definitions`. Added `typography.writingMode`.
+	 * @since 6.4.0 Added `layout.allowEditing`.
 	 * @var array
 	 */
 	const VALID_SETTINGS = array(

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -415,6 +415,7 @@ class WP_Theme_JSON_Gutenberg {
 			'writingMode'    => null,
 		),
 		'behaviors'                     => null,
+		'layout'                        => null,
 	);
 
 	/**

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -379,8 +379,9 @@ class WP_Theme_JSON_Gutenberg {
 			'minHeight' => null,
 		),
 		'layout'                        => array(
-			'contentSize' => null,
-			'wideSize'    => null,
+			'contentSize'  => null,
+			'wideSize'     => null,
+			'allowEditing' => null,
 		),
 		'position'                      => array(
 			'fixed'  => null,
@@ -415,7 +416,6 @@ class WP_Theme_JSON_Gutenberg {
 			'writingMode'    => null,
 		),
 		'behaviors'                     => null,
-		'layout'                        => null,
 	);
 
 	/**

--- a/packages/block-editor/src/components/global-styles/hooks.js
+++ b/packages/block-editor/src/components/global-styles/hooks.js
@@ -307,11 +307,7 @@ export function useSettingsForBlockElement(
 		}
 
 		[ 'contentSize', 'wideSize' ].forEach( ( key ) => {
-			// If layout is set to false in theme.json it should be left that way.
-			if (
-				! supportedStyles.includes( key ) &&
-				updatedSettings.layout !== false
-			) {
+			if ( ! supportedStyles.includes( key ) ) {
 				updatedSettings.layout = {
 					...updatedSettings.layout,
 					[ key ]: false,

--- a/packages/block-editor/src/components/global-styles/hooks.js
+++ b/packages/block-editor/src/components/global-styles/hooks.js
@@ -307,7 +307,11 @@ export function useSettingsForBlockElement(
 		}
 
 		[ 'contentSize', 'wideSize' ].forEach( ( key ) => {
-			if ( ! supportedStyles.includes( key ) ) {
+			// If layout is set to false in theme.json it should be left that way.
+			if (
+				! supportedStyles.includes( key ) &&
+				updatedSettings.layout !== false
+			) {
 				updatedSettings.layout = {
 					...updatedSettings.layout,
 					[ key ]: false,

--- a/packages/block-editor/src/hooks/layout.js
+++ b/packages/block-editor/src/hooks/layout.js
@@ -31,6 +31,7 @@ import { getLayoutType, getLayoutTypes } from '../layouts';
 import { useBlockEditingMode } from '../components/block-editing-mode';
 import { LAYOUT_DEFINITIONS } from '../layouts/definitions';
 import { kebabCase } from '../utils/object';
+import { useBlockSettings } from './utils';
 
 const layoutBlockSupportKey = 'layout';
 
@@ -133,6 +134,9 @@ export function useLayoutStyles( blockAttributes = {}, blockName, selector ) {
 }
 
 function LayoutPanel( { setAttributes, attributes, name: blockName } ) {
+	const settings = useBlockSettings( blockName );
+	const { layout: layoutSetting } = settings;
+
 	const { layout } = attributes;
 	const defaultThemeLayout = useSetting( 'layout' );
 	const { themeSupportsLayout } = useSelect( ( select ) => {
@@ -155,7 +159,7 @@ function LayoutPanel( { setAttributes, attributes, name: blockName } ) {
 		default: defaultBlockLayout,
 	} = layoutBlockSupport;
 
-	if ( ! allowEditing ) {
+	if ( ! allowEditing || layoutSetting === false ) {
 		return null;
 	}
 

--- a/packages/block-editor/src/hooks/layout.js
+++ b/packages/block-editor/src/hooks/layout.js
@@ -135,7 +135,9 @@ export function useLayoutStyles( blockAttributes = {}, blockName, selector ) {
 
 function LayoutPanel( { setAttributes, attributes, name: blockName } ) {
 	const settings = useBlockSettings( blockName );
-	const { layout: layoutSetting } = settings;
+	const {
+		layout: { allowEditing: allowEditingSetting },
+	} = settings;
 
 	const { layout } = attributes;
 	const defaultThemeLayout = useSetting( 'layout' );
@@ -154,12 +156,12 @@ function LayoutPanel( { setAttributes, attributes, name: blockName } ) {
 	);
 	const {
 		allowSwitching,
-		allowEditing = true,
+		allowEditing = allowEditingSetting ?? true,
 		allowInheriting = true,
 		default: defaultBlockLayout,
 	} = layoutBlockSupport;
 
-	if ( ! allowEditing || layoutSetting === false ) {
+	if ( ! allowEditing ) {
 		return null;
 	}
 

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -291,6 +291,11 @@
 						"wideSize": {
 							"description": "Sets the max-width of wide (`.alignwide`) content. Also used as the maximum viewport when calculating fluid font sizes",
 							"type": "string"
+						},
+						"allowEditing": {
+							"description": "Disable the layout UI controls.",
+							"type": "boolean",
+							"default": true
 						}
 					},
 					"additionalProperties": false


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes #47807. 

Thinking better about this I'm not sure it should be possible to _enable_ the controls from theme.json as even if the block supports layout already (say Columns or Gallery, which support layout but have controls hidden) it might not work well with the layout controls.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. in theme.json, add e.g.:
```
"settings": {
    "blocks": {
        "core/buttons": {
            "layout": false
        {
    { 
{
```
2.Add a Buttons block in the editor and check that no layout controls display in the sidebar.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
