### PR TITLE
Update SelectControl JSDoc

### DIFF
--- a/packages/components/src/select-control/index.tsx
+++ b/packages/components/src/select-control/index.tsx
@@ -151,7 +151,7 @@ function UnforwardedSelectControl(
  * `SelectControl` allows users to select from a single or multiple option menu.
  * It functions as a wrapper around the browser's native `<select>` element.
  *
- * @example
+ * ```jsx
  * import { SelectControl } from '@wordpress/components';
  * import { useState } from '@wordpress/element';
  *
@@ -171,6 +171,7 @@ function UnforwardedSelectControl(
  *     />
  *   );
  * };
+ * ```
  */
 export const SelectControl = forwardRef( UnforwardedSelectControl );
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
- Update [SelectControl](https://github.com/WordPress/gutenberg/tree/25215a997e23b8b4b05b122ccb1c2778dcd4cfa7/packages/components/src/select-control) JSDoc comment so it can be parsed properly in storybook

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
According to @wordpress/components [contributing handbook](https://github.com/WordPress/gutenberg/blob/trunk/packages/components/CONTRIBUTING.md#refactoring-a-component-to-typescript)

> On the component's main named export, add a JSDoc comment that includes the main description and the example code snippet from the README ([example](https://github.com/WordPress/gutenberg/blob/43d9c82922619c1d1ff6b454f86f75c3157d3de6/packages/components/src/date-time/date-time/index.tsx#L193-L217)). At the time of writing, the @example JSDoc keyword is not recognized by StoryBook's docgen, so please avoid using it.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Removing `@example` keyword and replace with `jsx` syntax

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Run `npm run storybook:dev`
- Navigator to `{host}/?path=/docs/components-selectcontrol--default`
- Confirm the JSDoc is parsed properly

|  Before |  Storybook |  VSCode |
|---|---|---|
|  <img width="1510" alt="image" src="https://github.com/WordPress/gutenberg/assets/10071857/64c36384-78e5-49de-bb42-72448bb9a123"> |  <img width="1464" alt="image" src="https://github.com/WordPress/gutenberg/assets/10071857/c739492d-91aa-4c07-a3f9-8a054b3ef5df"> | <img width="1800" alt="image" src="https://github.com/WordPress/gutenberg/assets/10071857/3a688ff2-4e9d-44b9-8d7a-458d693d3ab5">  |

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
