### PR TITLE
List View: Add media previews to list view for gallery and image blocks

### DIFF
--- a/packages/block-editor/src/components/list-view/block-select-button.js
+++ b/packages/block-editor/src/components/list-view/block-select-button.js
@@ -28,6 +28,7 @@ import useBlockDisplayTitle from '../block-title/use-block-display-title';
 import ListViewExpander from './expander';
 import { useBlockLock } from '../block-lock';
 import { store as blockEditorStore } from '../../store';
+import useListViewImages from './use-list-view-images';
 
 function ListViewBlockSelectButton(
 	{
@@ -63,6 +64,7 @@ function ListViewBlockSelectButton(
 	const { removeBlocks } = useDispatch( blockEditorStore );
 	const isMatch = useShortcutEventMatch();
 	const isSticky = blockInformation?.positionType === 'sticky';
+	const images = useListViewImages( { clientId, isExpanded } );
 
 	const positionLabel = blockInformation?.positionLabel
 		? sprintf(
@@ -184,6 +186,19 @@ function ListViewBlockSelectButton(
 							</span>
 						</Tooltip>
 					) }
+					{ images.length ? (
+						<span className="block-editor-list-view-block-select-button__images">
+							{ images.map( ( image, index ) => (
+								<img
+									key={ index }
+									src={ image.url }
+									alt={ image.alt }
+									width={ 24 }
+									height={ 24 }
+								/>
+							) ) }
+						</span>
+					) : null }
 					{ isLocked && (
 						<span className="block-editor-list-view-block-select-button__lock">
 							<Icon icon={ lock } />

--- a/packages/block-editor/src/components/list-view/block-select-button.js
+++ b/packages/block-editor/src/components/list-view/block-select-button.js
@@ -28,7 +28,7 @@ import useBlockDisplayTitle from '../block-title/use-block-display-title';
 import ListViewExpander from './expander';
 import { useBlockLock } from '../block-lock';
 import { store as blockEditorStore } from '../../store';
-import useListViewImages from './use-list-view-images';
+import useListViewImages, { MAX_IMAGES } from './use-list-view-images';
 
 function ListViewBlockSelectButton(
 	{
@@ -187,17 +187,31 @@ function ListViewBlockSelectButton(
 						</Tooltip>
 					) }
 					{ images.length ? (
-						<span className="block-editor-list-view-block-select-button__images">
-							{ images.map( ( image, index ) => (
-								<span
-									className="block-editor-list-view-block-select-button__image"
-									key={ index }
-									style={ {
-										backgroundImage: `url(${ image.url })`,
-										zIndex: images.length - index, // Ensure the first image is on top, and subsequent images are behind.
-									} }
-								/>
-							) ) }
+						<span
+							className="block-editor-list-view-block-select-button__images"
+							aria-hidden
+						>
+							{ images
+								.slice( 0, MAX_IMAGES )
+								.map( ( image, index ) => (
+									<span
+										className="block-editor-list-view-block-select-button__image"
+										key={ `img-${ image.url }` }
+										style={ {
+											backgroundImage: `url(${ image.url })`,
+											zIndex: images.length - index, // Ensure the first image is on top, and subsequent images are behind.
+										} }
+									/>
+								) ) }
+							{ images.length > MAX_IMAGES && (
+								<span className="block-editor-list-view-block-select-button__image-count">
+									{ sprintf(
+										/* translators: %d: Number of additional images within a block. */
+										__( '+%d' ),
+										images.length - MAX_IMAGES
+									) }
+								</span>
+							) }
 						</span>
 					) : null }
 					{ isLocked && (

--- a/packages/block-editor/src/components/list-view/block-select-button.js
+++ b/packages/block-editor/src/components/list-view/block-select-button.js
@@ -28,7 +28,7 @@ import useBlockDisplayTitle from '../block-title/use-block-display-title';
 import ListViewExpander from './expander';
 import { useBlockLock } from '../block-lock';
 import { store as blockEditorStore } from '../../store';
-import useListViewImages, { MAX_IMAGES } from './use-list-view-images';
+import useListViewImages from './use-list-view-images';
 
 function ListViewBlockSelectButton(
 	{
@@ -191,27 +191,16 @@ function ListViewBlockSelectButton(
 							className="block-editor-list-view-block-select-button__images"
 							aria-hidden
 						>
-							{ images
-								.slice( 0, MAX_IMAGES )
-								.map( ( image, index ) => (
-									<span
-										className="block-editor-list-view-block-select-button__image"
-										key={ `img-${ image.url }` }
-										style={ {
-											backgroundImage: `url(${ image.url })`,
-											zIndex: images.length - index, // Ensure the first image is on top, and subsequent images are behind.
-										} }
-									/>
-								) ) }
-							{ images.length > MAX_IMAGES && (
-								<span className="block-editor-list-view-block-select-button__image-count">
-									{ sprintf(
-										/* translators: %d: Number of additional images within a block. */
-										__( '+%d' ),
-										images.length - MAX_IMAGES
-									) }
-								</span>
-							) }
+							{ images.map( ( image, index ) => (
+								<span
+									className="block-editor-list-view-block-select-button__image"
+									key={ `img-${ image.url }` }
+									style={ {
+										backgroundImage: `url(${ image.url })`,
+										zIndex: images.length - index, // Ensure the first image is on top, and subsequent images are behind.
+									} }
+								/>
+							) ) }
 						</span>
 					) : null }
 					{ isLocked && (

--- a/packages/block-editor/src/components/list-view/block-select-button.js
+++ b/packages/block-editor/src/components/list-view/block-select-button.js
@@ -189,12 +189,13 @@ function ListViewBlockSelectButton(
 					{ images.length ? (
 						<span className="block-editor-list-view-block-select-button__images">
 							{ images.map( ( image, index ) => (
-								<img
+								<span
+									className="block-editor-list-view-block-select-button__image"
 									key={ index }
-									src={ image.url }
-									alt={ image.alt }
-									width={ 24 }
-									height={ 24 }
+									style={ {
+										backgroundImage: `url(${ image.url })`,
+										zIndex: images.length - index, // Ensure the first image is on top, and subsequent images are behind.
+									} }
 								/>
 							) ) }
 						</span>

--- a/packages/block-editor/src/components/list-view/style.scss
+++ b/packages/block-editor/src/components/list-view/style.scss
@@ -339,6 +339,28 @@
 	.block-editor-list-view-block-select-button__sticky {
 		line-height: 0;
 	}
+
+	.block-editor-list-view-block-select-button__images {
+		display: flex;
+		align-items: center;
+		flex-direction: row;
+	}
+
+	.block-editor-list-view-block-select-button__image {
+		background-size: cover;
+		width: $grid-unit-30;
+		height: $grid-unit-30;
+		border-radius: $radius-block-ui;
+		box-shadow: 0 0 0 $radius-block-ui $white;
+
+		&:not(:first-child) {
+			margin-left: -$grid-unit-10;
+		}
+	}
+
+	&.is-selected .block-editor-list-view-block-select-button__image {
+		box-shadow: 0 0 0 $radius-block-ui var(--wp-admin-theme-color);
+	}
 }
 
 .block-editor-list-view-block__contents-cell,

--- a/packages/block-editor/src/components/list-view/style.scss
+++ b/packages/block-editor/src/components/list-view/style.scss
@@ -342,19 +342,20 @@
 
 	.block-editor-list-view-block-select-button__images {
 		display: flex;
-		align-items: center;
-		flex-direction: row;
 	}
 
 	.block-editor-list-view-block-select-button__image {
 		background-size: cover;
-		width: $grid-unit-30;
-		height: $grid-unit-30;
+		width: 20px;
+		height: 20px;
 		border-radius: $radius-block-ui;
-		box-shadow: 0 0 0 $radius-block-ui $white;
+
+		&:not(:only-child) {
+			box-shadow: 0 0 0 $radius-block-ui $white;
+		}
 
 		&:not(:first-child) {
-			margin-left: -$grid-unit-10;
+			margin-left: -5px;
 		}
 	}
 

--- a/packages/block-editor/src/components/list-view/style.scss
+++ b/packages/block-editor/src/components/list-view/style.scss
@@ -359,6 +359,12 @@
 		}
 	}
 
+	.block-editor-list-view-block-select-button__image-count {
+		font-size: $helptext-font-size;
+		margin-left: $grid-unit-05;
+		opacity: 0.6;
+	}
+
 	&.is-selected .block-editor-list-view-block-select-button__image {
 		box-shadow: 0 0 0 $radius-block-ui var(--wp-admin-theme-color);
 	}

--- a/packages/block-editor/src/components/list-view/style.scss
+++ b/packages/block-editor/src/components/list-view/style.scss
@@ -359,14 +359,10 @@
 		}
 	}
 
-	.block-editor-list-view-block-select-button__image-count {
-		font-size: $helptext-font-size;
-		margin-left: $grid-unit-05;
-		opacity: 0.6;
-	}
-
 	&.is-selected .block-editor-list-view-block-select-button__image {
-		box-shadow: 0 0 0 $radius-block-ui var(--wp-admin-theme-color);
+		&:not(:only-child) {
+			box-shadow: 0 0 0 $radius-block-ui var(--wp-admin-theme-color);
+		}
 	}
 }
 

--- a/packages/block-editor/src/components/list-view/use-list-view-images.js
+++ b/packages/block-editor/src/components/list-view/use-list-view-images.js
@@ -9,12 +9,15 @@ import { useSelect } from '@wordpress/data';
  */
 import { store as blockEditorStore } from '../../store';
 
+// Maximum number of images to display in a list view row.
+const MAX_IMAGES = 5;
+
 function getImageUrl( block ) {
 	if ( block.name !== 'core/image' ) {
 		return;
 	}
 
-	if ( block.attributes.url ) {
+	if ( block.attributes?.url ) {
 		return { url: block.attributes.url, alt: block.attributes.alt };
 	}
 }
@@ -23,16 +26,20 @@ function getImagesFromGallery( block ) {
 	if ( block.name !== 'core/gallery' || ! block.innerBlocks ) {
 		return [];
 	}
-	return block.innerBlocks.reduce( ( images, innerBlock ) => {
-		if ( innerBlock.name !== 'core/image' ) {
-			return images;
-		}
+
+	const images = [];
+
+	for ( const innerBlock of block.innerBlocks ) {
 		const img = getImageUrl( innerBlock );
 		if ( img ) {
-			return [ ...images, img ];
+			images.push( img );
 		}
-		return images;
-	}, [] );
+		if ( images.length >= MAX_IMAGES ) {
+			return images;
+		}
+	}
+
+	return images;
 }
 
 function getImagesFromBlock( block, isExpanded ) {
@@ -43,6 +50,18 @@ function getImagesFromBlock( block, isExpanded ) {
 	return isExpanded ? [] : getImagesFromGallery( block );
 }
 
+/**
+ * Get a block's preview images for display within a list view row.
+ *
+ * TODO: Currently only supports images from the core/image and core/gallery
+ * blocks. This should be expanded to support other blocks that have images,
+ * potentially via an API that blocks can opt into / provide their own logic.
+ *
+ * @param {Object}  props            Hook properties.
+ * @param {string}  props.clientId   The block's clientId.
+ * @param {boolean} props.isExpanded Whether or not the block is expanded in the list view.
+ * @return {Array} Images.
+ */
 export default function useListViewImages( { clientId, isExpanded } ) {
 	const { block } = useSelect(
 		( select ) => {

--- a/packages/block-editor/src/components/list-view/use-list-view-images.js
+++ b/packages/block-editor/src/components/list-view/use-list-view-images.js
@@ -10,7 +10,7 @@ import { useSelect } from '@wordpress/data';
 import { store as blockEditorStore } from '../../store';
 
 // Maximum number of images to display in a list view row.
-const MAX_IMAGES = 5;
+export const MAX_IMAGES = 5;
 
 function getImageUrl( block ) {
 	if ( block.name !== 'core/image' ) {
@@ -33,9 +33,6 @@ function getImagesFromGallery( block ) {
 		const img = getImageUrl( innerBlock );
 		if ( img ) {
 			images.push( img );
-		}
-		if ( images.length >= MAX_IMAGES ) {
-			return images;
 		}
 	}
 

--- a/packages/block-editor/src/components/list-view/use-list-view-images.js
+++ b/packages/block-editor/src/components/list-view/use-list-view-images.js
@@ -10,7 +10,7 @@ import { useSelect } from '@wordpress/data';
 import { store as blockEditorStore } from '../../store';
 
 // Maximum number of images to display in a list view row.
-export const MAX_IMAGES = 5;
+const MAX_IMAGES = 3;
 
 function getImageUrl( block ) {
 	if ( block.name !== 'core/image' ) {
@@ -33,6 +33,9 @@ function getImagesFromGallery( block ) {
 		const img = getImageUrl( innerBlock );
 		if ( img ) {
 			images.push( img );
+		}
+		if ( images.length >= MAX_IMAGES ) {
+			return images;
 		}
 	}
 

--- a/packages/block-editor/src/components/list-view/use-list-view-images.js
+++ b/packages/block-editor/src/components/list-view/use-list-view-images.js
@@ -1,0 +1,60 @@
+/**
+ * WordPress dependencies
+ */
+import { useMemo } from '@wordpress/element';
+import { useSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { store as blockEditorStore } from '../../store';
+
+function getImageUrl( block ) {
+	if ( block.name !== 'core/image' ) {
+		return;
+	}
+
+	if ( block.attributes.url ) {
+		return { url: block.attributes.url, alt: block.attributes.alt };
+	}
+}
+
+function getImagesFromGallery( block ) {
+	if ( block.name !== 'core/gallery' || ! block.innerBlocks ) {
+		return [];
+	}
+	return block.innerBlocks.reduce( ( images, innerBlock ) => {
+		if ( innerBlock.name !== 'core/image' ) {
+			return images;
+		}
+		const img = getImageUrl( innerBlock );
+		if ( img ) {
+			return [ ...images, img ];
+		}
+		return images;
+	}, [] );
+}
+
+function getImagesFromBlock( block, isExpanded ) {
+	const img = getImageUrl( block );
+	if ( img ) {
+		return [ img ];
+	}
+	return isExpanded ? [] : getImagesFromGallery( block );
+}
+
+export default function useListViewImages( { clientId, isExpanded } ) {
+	const { block } = useSelect(
+		( select ) => {
+			const _block = select( blockEditorStore ).getBlock( clientId );
+			return { block: _block };
+		},
+		[ clientId ]
+	);
+
+	const images = useMemo( () => {
+		return getImagesFromBlock( block, isExpanded );
+	}, [ block, isExpanded ] );
+
+	return images;
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

An exploration into https://github.com/WordPress/gutenberg/issues/46015 — add media previews for gallery and image blocks in the list view.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

In large documents with many images or galleries, adding media thumbnails to the list view row should (hopefully) make it easier to identify which image or gallery is which, and improve navigating around documents within the list view.

In this PR:

* Displays images for the Gallery block, but only when it is collapsed
* Images overlap slightly, and max out at 3 in the row for now (we can adjust this if there's a better number to go with)
* Any Image block in the list view will display a single image in the row

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* Add a hook to the list view for grabbing images for the preview
* The image is displayed via a background image with background size to set to `cover`
* For now, hard-code the logic to look for images via the Image block, or children of the Gallery block. I've added a TODO item in the comments that eventually we could move to a consistent API for this. For now, by hard-coding, we can retain the same entrypoint for the list view (the `useListViewImages` hook), but in follow-ups we can refactor the internals to use a block API of some kind (i.e. either via something in `block.json`, or via a method like `__experimentalLabel` but for images)

## To-do

* [x] Style the images so that they always fill a square (e.g. cover the background)
* [x] For gallery block, layer the images over one-another, with a maximum number of images displayed

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Add a gallery block with a couple of images
2. Add another gallery block with > 3 images
3. Play around with expanding and collapsing the gallery block within the list view
4. Check that adding / removing / updating images in an existing block updates the list view item

## Screenshots or screencast <!-- if applicable -->

The following screenshot includes:

* Selected collapsed Gallery block (with and without lock status)
* Deselected collapsed Gallery block
* Expanded Gallery block with images
* Standalone Image block

<!--
<img width="966" alt="image" src="https://github.com/WordPress/gutenberg/assets/14988353/c349cd96-2e2d-4868-9ff7-a1725940419e">
-->

<img width="347" alt="image" src="https://github.com/WordPress/gutenberg/assets/14988353/485bb69a-199e-4ac0-8b64-9e07e8d17c0d">

