### PR TITLE
Docs/Interactivity API - Revamp of README to include API Reference among other indications

### DIFF
--- a/packages/interactivity/docs/README.md
+++ b/packages/interactivity/docs/README.md
@@ -2,21 +2,32 @@
 
 👋 Hi! Welcome to the Interactivity API documentation.
 
+
+> Interactivity API is a current [proposal](https://make.wordpress.org/core/2023/03/30/proposal-the-interactivity-api-a-better-developer-experience-in-building-interactive-blocks/) that **is only available in Gutenberg** at the moment and not in WordPress Core as it is still very experimental, and very likely to change.
+
+> As part of an [Open Source project](https://developer.wordpress.org/block-editor/explanations/faq/#the-gutenberg-project) we encourage participation in helping shape this API and its Docs. The [discussions](https://github.com/WordPress/gutenberg/discussions/categories/interactivity-api) and [issues](https://github.com/WordPress/gutenberg/labels/%5BFeature%5D%20Interactivity%20API) in GitHub are the best place to engage.
+
+
 ## Quick start
 
 The best place to start with the Interactivity API is this [**Getting started guide**](1-getting-started.md). There you'll will find a very quick start guide and the current requirements of the Interactivity API.
 
-
 ## Take a deep dive
 
-<!-- Links to get the details (API, architecture, resources...) -->
+At the [**API Reference**](1-getting-started.md) page you'll find detailed technical descriptions for the *Directives* and *Store* which are the main elements of the Interactivity API.
+
+You can also check [Getting Started - and other learning resources](https://github.com/WordPress/gutenberg/discussions/52894) among other [discussions in GitHub](https://github.com/WordPress/gutenberg/discussions/categories/interactivity-api) to learn more on this proposal.
 
 ## Get Involved
 
-<!-- Links to get involved -->
+Feel free to open pull requests to improve any part of these docs, or to add other sections or files to the docs.
+
+If you are willing to help with the documentation, please add a comment to [#51928](https://github.com/WordPress/gutenberg/discussions/51928), and we'll coordinate everyone's efforts.
+
+There's a Tracking Issue opened to ease the coordination of the work related to the Interactivity API Docs: **[Documentation for the Interactivity API - Tracking Issue #53296](https://github.com/WordPress/gutenberg/issues/53296)**
 
 ## License
 
-<!-- License? -->
+Interactivity API proposal, as part of Gutenberg and the WordPress project is free software, and is released under the terms of the GNU General Public License version 2 or (at your option) any later version. See [LICENSE.md](https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md) for complete license.
 
 <br/><br/><p align="center"><img src="https://s.w.org/style/images/codeispoetry.png?1" alt="Code is Poetry." /></p>

--- a/packages/interactivity/docs/README.md
+++ b/packages/interactivity/docs/README.md
@@ -14,7 +14,7 @@ The best place to start with the Interactivity API is this [**Getting started gu
 
 ## Take a deep dive
 
-At the [**API Reference**](1-getting-started.md) page you'll find detailed technical descriptions for the *Directives* and *Store* which are the main elements of the Interactivity API.
+At the [**API Reference**](2-api-reference.md) page you'll find detailed technical descriptions for the *Directives* and *Store* which are the main elements of the Interactivity API.
 
 You can also check [Getting Started - and other learning resources](https://github.com/WordPress/gutenberg/discussions/52894) among other [discussions in GitHub](https://github.com/WordPress/gutenberg/discussions/categories/interactivity-api) to learn more on this proposal.
 


### PR DESCRIPTION
Updates main README of Interactivity API Docs to provide a reference to API Reference.
It also provides a smoother introduction to resources and how to contribute. 
Solves https://github.com/WordPress/gutenberg/issues/53384