### PR TITLE
Editor: Use hooks instead of HoCs in `PostPendingStatus`

### DIFF
--- a/packages/editor/src/components/post-pending-status/index.js
+++ b/packages/editor/src/components/post-pending-status/index.js
@@ -3,8 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { CheckboxControl } from '@wordpress/components';
-import { withSelect, withDispatch } from '@wordpress/data';
-import { compose } from '@wordpress/compose';
+import { useDispatch, useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -12,10 +11,15 @@ import { compose } from '@wordpress/compose';
 import PostPendingStatusCheck from './check';
 import { store as editorStore } from '../../store';
 
-export function PostPendingStatus( { status, onUpdateStatus } ) {
+export function PostPendingStatus() {
+	const status = useSelect(
+		( select ) => select( editorStore ).getEditedPostAttribute( 'status' ),
+		[]
+	);
+	const { editPost } = useDispatch( editorStore );
 	const togglePendingStatus = () => {
 		const updatedStatus = status === 'pending' ? 'draft' : 'pending';
-		onUpdateStatus( updatedStatus );
+		editPost( { status: updatedStatus } );
 	};
 
 	return (
@@ -30,13 +34,4 @@ export function PostPendingStatus( { status, onUpdateStatus } ) {
 	);
 }
 
-export default compose(
-	withSelect( ( select ) => ( {
-		status: select( editorStore ).getEditedPostAttribute( 'status' ),
-	} ) ),
-	withDispatch( ( dispatch ) => ( {
-		onUpdateStatus( status ) {
-			dispatch( editorStore ).editPost( { status } );
-		},
-	} ) )
-)( PostPendingStatus );
+export default PostPendingStatus;


### PR DESCRIPTION
## What?
This straightforward PR updates the `PostPendingStatus` component to use the `@wordpress/data` hooks instead of the HoCs.

Related to #53389.

## Why?
A micro-optimization to makes the rendered component tree smaller.

## How?
We're using the `useSelect` and `useDispatch` hooks instead of the `withSelect` and `withDispatch` hooks.

Because we're removing a `withSelect`, a `withDispatch` and a `compose()` instance, this removes 3 levels of nesting.

## Testing Instructions
Creating a new post and editing a new post, verifying the "Pending review" field in the post sidebar still works well.

### Testing Instructions for Keyboard
None.

## Screenshots or screencast <!-- if applicable -->
The component tree before:
![Screenshot 2023-08-07 at 13 50 10](https://github.com/WordPress/gutenberg/assets/8436925/bcb08a6c-c541-4cbb-8d49-f1b6182a57d3)


The component tree after:
![Screenshot 2023-08-07 at 13 50 22](https://github.com/WordPress/gutenberg/assets/8436925/41deb7f1-475f-4d9e-a481-830b7e067da4)


