### PR TITLE
Editor: Use hooks instead of HoCs in `PostPendingStatusCheck`

### DIFF
--- a/packages/editor/src/components/post-pending-status/check.js
+++ b/packages/editor/src/components/post-pending-status/check.js
@@ -1,19 +1,24 @@
 /**
  * WordPress dependencies
  */
-import { compose } from '@wordpress/compose';
-import { withSelect } from '@wordpress/data';
+import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
 import { store as editorStore } from '../../store';
 
-export function PostPendingStatusCheck( {
-	hasPublishAction,
-	isPublished,
-	children,
-} ) {
+export function PostPendingStatusCheck( { children } ) {
+	const { hasPublishAction, isPublished } = useSelect( ( select ) => {
+		const { isCurrentPostPublished, getCurrentPost } =
+			select( editorStore );
+		return {
+			hasPublishAction:
+				getCurrentPost()._links?.[ 'wp:action-publish' ] ?? false,
+			isPublished: isCurrentPostPublished(),
+		};
+	}, [] );
+
 	if ( isPublished || ! hasPublishAction ) {
 		return null;
 	}
@@ -21,15 +26,4 @@ export function PostPendingStatusCheck( {
 	return children;
 }
 
-export default compose(
-	withSelect( ( select ) => {
-		const { isCurrentPostPublished, getCurrentPostType, getCurrentPost } =
-			select( editorStore );
-		return {
-			hasPublishAction:
-				getCurrentPost()._links?.[ 'wp:action-publish' ] ?? false,
-			isPublished: isCurrentPostPublished(),
-			postType: getCurrentPostType(),
-		};
-	} )
-)( PostPendingStatusCheck );
+export default PostPendingStatusCheck;

--- a/packages/editor/src/components/post-pending-status/test/check.js
+++ b/packages/editor/src/components/post-pending-status/test/check.js
@@ -4,26 +4,48 @@
 import { render, screen } from '@testing-library/react';
 
 /**
+ * WordPress dependencies
+ */
+import { useSelect } from '@wordpress/data';
+
+/**
  * Internal dependencies
  */
 import { PostPendingStatusCheck } from '../check';
 
+jest.mock( '@wordpress/data/src/components/use-select', () => {
+	// This allows us to tweak the returned value on each test.
+	const mock = jest.fn();
+	return mock;
+} );
+
+function setupUseSelectMock( hasPublishAction ) {
+	useSelect.mockImplementation( ( cb ) => {
+		return cb( () => ( {
+			isCurrentPostPublished: () => false,
+			getCurrentPost: () => ( {
+				_links: {
+					'wp:action-publish': hasPublishAction,
+				},
+			} ),
+		} ) );
+	} );
+}
+
 describe( 'PostPendingStatusCheck', () => {
 	it( "should not render anything if the user doesn't have the right capabilities", () => {
-		render(
-			<PostPendingStatusCheck hasPublishAction={ false }>
-				status
-			</PostPendingStatusCheck>
-		);
+		setupUseSelectMock( false );
+
+		render( <PostPendingStatusCheck>status</PostPendingStatusCheck> );
+
 		expect( screen.queryByText( 'status' ) ).not.toBeInTheDocument();
 	} );
 
 	it( 'should render if the user has the correct capability', () => {
-		render(
-			<PostPendingStatusCheck hasPublishAction={ true }>
-				status
-			</PostPendingStatusCheck>
-		);
+		setupUseSelectMock( true );
+
+		render( <PostPendingStatusCheck>status</PostPendingStatusCheck> );
+
 		expect( screen.getByText( 'status' ) ).toBeVisible();
 	} );
 } );


### PR DESCRIPTION
## What?
This straightforward PR updates the `PostPendingStatusCheck` component to use the `@wordpress/data` hooks instead of the HoCs.

Related to #53387.

## Why?
A micro-optimization to makes the rendered component tree smaller.

## How?
We're using the `useSelect` hook instead of the `withSelect` HoC.

Because we're removing a `withSelect` and a `compose()` instance, this removes 2 levels of nesting.

## Testing Instructions
Creating a new post and editing an existing post, verifying the "Pending review" field in the post sidebar still works well. It should still not appear if a post is already published.

### Testing Instructions for Keyboard
None.

## Screenshots or screencast <!-- if applicable -->
The component tree before:
![Screenshot 2023-08-07 at 14 00 39](https://github.com/WordPress/gutenberg/assets/8436925/5800847c-2438-4ccc-875e-cec598d7bdad)


The component tree after:
![Screenshot 2023-08-07 at 13 59 57](https://github.com/WordPress/gutenberg/assets/8436925/d6ab4c35-209f-4f9a-a054-455da2babcf7)
