### PR TITLE
Project management: Remove automation that checks-in ANY issue without activity in 180 days

### DIFF
--- a/.github/workflows/stale-issue-gardening.yml
+++ b/.github/workflows/stale-issue-gardening.yml
@@ -33,12 +33,6 @@ jobs:
                       only-labels: '[Type] Flaky Test'
                       remove-stale-when-updated: true
                       stale-issue-label: '[Status] Stale'
-                    - name: 'Issues without recent updates that need confirmation'
-                      message: "Hi,\nThis issue has gone 180 days without any activity. This means it is time for a check-in to make sure it is still relevant. If you are still experiencing this issue with the latest versions, you can help the project by responding to confirm the problem and by providing any updated reproduction steps.\nThanks for helping out."
-                      days-before-stale: 180
-                      days-before-close: -1
-                      remove-stale-when-updated: false
-                      stale-issue-label: 'Needs check-in'
 
         steps:
             - name: Update issues


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Reverts part of #29321, which introduced a check-in to every issue after 180 days without activity, so that check-ins are only performed in issues with the `Needs more info" label.

## Why?
Many open issues need longer than 180 days to move forward. They might see less activity for longer periods of time just by the nature of the project and all the different priorities open in parallel. Checking in makes sense for issues labeled as `Needs more info`, but can become very noisy for issues that need to be open for longer periods of time, like overview issues.

#52173 tried using a different label than "Needs testing", which caused even more automation to trigger later, but it still seems too much.

## How?
By removing the GitHub workflow automation that performs the 180-day check-in to all issues.