### PR TITLE
Edit Post: Update 'PluginDocumentSettingPanel' documentation

### DIFF
--- a/packages/edit-post/README.md
+++ b/packages/edit-post/README.md
@@ -148,7 +148,7 @@ registerPlugin( 'document-setting-test', { render: MyDocumentSettingTest } );
 _Parameters_
 
 -   _props_ `Object`: Component properties.
--   _props.name_ `string`: The machine-friendly name for the panel.
+-   _props.name_ `string`: Required. A machine-friendly name for the panel.
 -   _props.className_ `[string]`: An optional class name added to the row.
 -   _props.title_ `[string]`: The title of the panel
 -   _props.icon_ `[WPBlockTypeIconRender]`: The [Dashicon](https://developer.wordpress.org/resource/dashicons/) icon slug string, or an SVG WP element, to be rendered when the sidebar is pinned to toolbar.

--- a/packages/edit-post/README.md
+++ b/packages/edit-post/README.md
@@ -116,6 +116,7 @@ function MyDocumentSettingPlugin() {
 		{
 			className: 'my-document-setting-plugin',
 			title: 'My Panel',
+			name: 'my-panel',
 		},
 		__( 'My Document Setting Panel' )
 	);
@@ -135,6 +136,7 @@ const MyDocumentSettingTest = () => (
 	<PluginDocumentSettingPanel
 		className="my-document-setting-plugin"
 		title="My Panel"
+		name="my-panel"
 	>
 		<p>My Document Setting Panel</p>
 	</PluginDocumentSettingPanel>

--- a/packages/edit-post/src/components/sidebar/plugin-document-setting-panel/index.js
+++ b/packages/edit-post/src/components/sidebar/plugin-document-setting-panel/index.js
@@ -8,7 +8,6 @@
 import { createSlotFill, PanelBody } from '@wordpress/components';
 import { usePluginContext } from '@wordpress/plugins';
 import { useDispatch, useSelect } from '@wordpress/data';
-import warning from '@wordpress/warning';
 
 /**
  * Internal dependencies
@@ -42,6 +41,7 @@ const { Fill, Slot } = createSlotFill( 'PluginDocumentSettingPanel' );
  * 		{
  * 			className: 'my-document-setting-plugin',
  * 			title: 'My Panel',
+ * 			name: 'my-panel',
  * 		},
  * 		__( 'My Document Setting Panel' )
  * 	);
@@ -59,7 +59,7 @@ const { Fill, Slot } = createSlotFill( 'PluginDocumentSettingPanel' );
  * import { PluginDocumentSettingPanel } from '@wordpress/edit-post';
  *
  * const MyDocumentSettingTest = () => (
- * 		<PluginDocumentSettingPanel className="my-document-setting-plugin" title="My Panel">
+ * 		<PluginDocumentSettingPanel className="my-document-setting-plugin" title="My Panel" name="my-panel">
  *			<p>My Document Setting Panel</p>
  *		</PluginDocumentSettingPanel>
  *	);
@@ -92,8 +92,11 @@ const PluginDocumentSettingPanel = ( {
 	);
 	const { toggleEditorPanelOpened } = useDispatch( editPostStore );
 
-	if ( undefined === name ) {
-		warning( 'PluginDocumentSettingPanel requires a name property.' );
+	if ( ! name ) {
+		// eslint-disable-next-line no-console
+		console.warn(
+			`PluginDocumentSettingPanel requires a 'name' property.`
+		);
 	}
 
 	return (

--- a/packages/edit-post/src/components/sidebar/plugin-document-setting-panel/index.js
+++ b/packages/edit-post/src/components/sidebar/plugin-document-setting-panel/index.js
@@ -1,8 +1,4 @@
 /**
- * Defines as extensibility slot for the Settings sidebar
- */
-
-/**
  * WordPress dependencies
  */
 import { createSlotFill, PanelBody } from '@wordpress/components';

--- a/packages/edit-post/src/components/sidebar/plugin-document-setting-panel/index.js
+++ b/packages/edit-post/src/components/sidebar/plugin-document-setting-panel/index.js
@@ -4,6 +4,7 @@
 import { createSlotFill, PanelBody } from '@wordpress/components';
 import { usePluginContext } from '@wordpress/plugins';
 import { useDispatch, useSelect } from '@wordpress/data';
+import warning from '@wordpress/warning';
 
 /**
  * Internal dependencies
@@ -17,7 +18,7 @@ const { Fill, Slot } = createSlotFill( 'PluginDocumentSettingPanel' );
  * Renders items below the Status & Availability panel in the Document Sidebar.
  *
  * @param {Object}                props                                 Component properties.
- * @param {string}                props.name                            The machine-friendly name for the panel.
+ * @param {string}                props.name                            Required. A machine-friendly name for the panel.
  * @param {string}                [props.className]                     An optional class name added to the row.
  * @param {string}                [props.title]                         The title of the panel
  * @param {WPBlockTypeIconRender} [props.icon=inherits from the plugin] The [Dashicon](https://developer.wordpress.org/resource/dashicons/) icon slug string, or an SVG WP element, to be rendered when the sidebar is pinned to toolbar.
@@ -88,11 +89,8 @@ const PluginDocumentSettingPanel = ( {
 	);
 	const { toggleEditorPanelOpened } = useDispatch( editPostStore );
 
-	if ( ! name ) {
-		// eslint-disable-next-line no-console
-		console.warn(
-			`PluginDocumentSettingPanel requires a 'name' property.`
-		);
+	if ( undefined === name ) {
+		warning( 'PluginDocumentSettingPanel requires a name property.' );
 	}
 
 	return (


### PR DESCRIPTION
## What?
~~PR replaces the `warning` method call with `console.warn` so that the missing `name` prop warning is logged in outside of the dev environments.~~

I've updated the documentation and examples to highlight that the `name` prop is required.

## Why?
The `pluginName/panelName` string combo is used to keep track of open panels. When the panel name isn't provided, it can cause unexpected side effects (see the screencast), which are hard to track down without warning or knowing the internals of the component.

Since the component is meant for third-party consumers, I think it's important that we highlight the missing required prop.

## Testing Instructions
None; it's just a docs update.

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/240569/5600632f-6527-4f93-ac62-f3ac8ea1d0ac
