### PR TITLE
Update curating the editor to include starter patterns for templates

### DIFF
--- a/docs/how-to-guides/curating-the-editor-experience.md
+++ b/docs/how-to-guides/curating-the-editor-experience.md
@@ -413,6 +413,14 @@ To opt into this, include `core/post-content` in the Block Types for your patter
 
 Read more about this functionality in the [Page creation patterns in WordPress 6.0 dev note](https://make.wordpress.org/core/2022/05/03/page-creation-patterns-in-wordpress-6-0/) and [note that WordPress 6.1 brought this functionality to all post types](https://make.wordpress.org/core/2022/10/10/miscellaneous-editor-changes-for-wordpress-6-1/#start-content-patterns-for-all-post-types).  
 
+**Prioritize starter patterns for template creation**
+
+In the same way patterns can be prioritized for new posts or pages, the same experience can be added to the template creation process. When patterns declare support for the 'templateTypes' property, the patterns will appear anytime a template that matches the designation are created along with the options to start from a blank state or use the current fallback of the template. By default, WordPress does not include any of these patterns. 
+
+To opt into this, a pattern needs to specify a property called `templateTypes`, which is an array containing the templates where the patterns can be used as the full content. [Here's an example](https://gist.github.com/annezazu/99ce2f84fa033dae48eacc50a8287bae) of a pattern that would appear when creating a 404 template.
+
+Read more about this functionality in the [Patterns on the create a new template modal in the WordPress 6.3 dev note](https://make.wordpress.org/core/2023/07/18/miscellaneous-editor-changes-in-wordpress-6-3/#patterns-on-the-create-a-new-template-modal).
+
 **Lock patterns**
 
 As mentioned in the prior section on Locking APIs, aspects of patterns themselves can be locked so that the important aspects of the design can be preserved. [Here’s an example of a pattern](https://gist.github.com/annezazu/acee30f8b6e8995e1b1a52796e6ef805) with various blocks locked in different ways. You can build these patterns in the editor itself, including adding locking options, before [following the documentation to register them](/docs/reference-guides/block-api/block-patterns.md). 

--- a/docs/how-to-guides/curating-the-editor-experience.md
+++ b/docs/how-to-guides/curating-the-editor-experience.md
@@ -415,7 +415,7 @@ Read more about this functionality in the [Page creation patterns in WordPress 6
 
 **Prioritize starter patterns for template creation**
 
-In the same way patterns can be prioritized for new posts or pages, the same experience can be added to the template creation process. When patterns declare support for the 'templateTypes' property, the patterns will appear anytime a template that matches the designation are created along with the options to start from a blank state or use the current fallback of the template. By default, WordPress does not include any of these patterns. 
+In the same way patterns can be prioritized for new posts or pages, the same experience can be added to the template creation process. When patterns declare support for the 'templateTypes' property, the patterns will appear anytime a template that matches the designation is created, along with the options to start from a blank state or use the current fallback of the template. By default, WordPress does not include any of these patterns. 
 
 To opt into this, a pattern needs to specify a property called `templateTypes`, which is an array containing the templates where the patterns can be used as the full content. [Here's an example](https://gist.github.com/annezazu/99ce2f84fa033dae48eacc50a8287bae) of a pattern that would appear when creating a 404 template.
 

--- a/docs/how-to-guides/curating-the-editor-experience.md
+++ b/docs/how-to-guides/curating-the-editor-experience.md
@@ -417,7 +417,18 @@ Read more about this functionality in the [Page creation patterns in WordPress 6
 
 In the same way patterns can be prioritized for new posts or pages, the same experience can be added to the template creation process. When patterns declare support for the 'templateTypes' property, the patterns will appear anytime a template that matches the designation is created, along with the options to start from a blank state or use the current fallback of the template. By default, WordPress does not include any of these patterns. 
 
-To opt into this, a pattern needs to specify a property called `templateTypes`, which is an array containing the templates where the patterns can be used as the full content. [Here's an example](https://gist.github.com/annezazu/99ce2f84fa033dae48eacc50a8287bae) of a pattern that would appear when creating a 404 template.
+To opt into this, a pattern needs to specify a property called `templateTypes`, which is an array containing the templates where the patterns can be used as the full content. Here's an example of a pattern that would appear when creating a 404 template:
+
+```
+register_block_pattern(
+  'wp-my-theme/404-template-pattern',
+  array(
+     'title'      => __( '404 Only template pattern', 'wp-my-theme' ),
+     'templateTypes' => array( '404' ),
+     'content'    => '<!-- wp:paragraph {"align":"center","fontSize":"x-large"} --><p class="has-text-align-center has-x-large-font-size">404 pattern</p><!-- /wp:paragraph -->',
+  )
+);
+```
 
 Read more about this functionality in the [Patterns on the create a new template modal in the WordPress 6.3 dev note](https://make.wordpress.org/core/2023/07/18/miscellaneous-editor-changes-in-wordpress-6-3/#patterns-on-the-create-a-new-template-modal).
 


### PR DESCRIPTION
## What?

This updates the curating the editor doc to include the 6.3 update around starter patterns for templates ahead of the 6.3 release. 

## Why?

To keep the docs up to date :) 

