### PR TITLE
Edit Site: Update progress bar to determinate

### DIFF
--- a/packages/edit-site/src/components/canvas-loader/index.js
+++ b/packages/edit-site/src/components/canvas-loader/index.js
@@ -3,6 +3,8 @@
  */
 import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
 import { privateApis as componentsPrivateApis } from '@wordpress/components';
+import { store as coreStore } from '@wordpress/core-data';
+import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -19,11 +21,20 @@ export default function CanvasLoader( { id } ) {
 	const { highlightedColors } = useStylesPreviewColors();
 	const indicatorColor =
 		highlightedColors[ 0 ]?.color ?? fallbackIndicatorColor;
+	const { elapsed, total } = useSelect( ( select ) => {
+		const selectorsByStatus = select( coreStore ).countSelectorsByStatus();
+		const resolving = selectorsByStatus.resolving ?? 0;
+		const finished = selectorsByStatus.finished ?? 0;
+		return {
+			elapsed: finished,
+			total: finished + resolving,
+		};
+	}, [] );
 
 	return (
 		<div className="edit-site-canvas-loader">
 			<Theme accent={ indicatorColor } background={ backgroundColor }>
-				<ProgressBar id={ id } />
+				<ProgressBar id={ id } max={ total } value={ elapsed } />
 			</Theme>
 		</div>
 	);

--- a/packages/edit-site/src/components/canvas-loader/style.scss
+++ b/packages/edit-site/src/components/canvas-loader/style.scss
@@ -9,7 +9,7 @@
 	align-items: center;
 	justify-content: center;
 
-	animation: 0.5s ease 1s edit-site-canvas-loader__fade-in-animation;
+	animation: 0.5s ease 0.2s edit-site-canvas-loader__fade-in-animation;
 	animation-fill-mode: forwards;
 	@include reduce-motion("animation");
 


### PR DESCRIPTION
## What?
This PR builds on top of the work done in #53032 and makes the progress bar determinate.

Blocked by #53767 and needs to be rebased once it lands.

## Why?
To provide the end users with more accurate feedback on their site editor loading experience.

## How?
We believe that using a determinate progress bar instead will be a better loading experience for the user, because it provides better feedback on the loading progress.

This PR also contains a new redux metadata selector that we're separately introducing in #53767.

## Testing Instructions
* Open the site editor.
* Observe the loading progress bar and verify it works well.

### Testing Instructions for Keyboard
None

## Screenshots or screencast <!-- if applicable -->


https://github.com/WordPress/gutenberg/assets/8436925/7e086d2d-3be4-4193-9879-a9b8c2758941



