### PR TITLE
Include namespace in layout classname for non-core blocks

### DIFF
--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -686,8 +686,9 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 	}
 
 	// Add combined layout and block classname for global styles to hook onto.
-	$block_name    = explode( '/', $block['blockName'] );
-	$class_names[] = 'wp-block-' . end( $block_name ) . '-' . $layout_classname;
+	$split_block_name = explode( '/', $block['blockName'] );
+	$full_block_name  = 'core' === $split_block_name[0] ? $split_block_name[1] : implode( '-', $split_block_name );
+	$class_names[]    = 'wp-block-' . $full_block_name . '-' . $layout_classname;
 
 	$content_with_outer_classnames = '';
 

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -687,7 +687,7 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 
 	// Add combined layout and block classname for global styles to hook onto.
 	$split_block_name = explode( '/', $block['blockName'] );
-	$full_block_name  = 'core' === $split_block_name[0] ? $split_block_name[1] : implode( '-', $split_block_name );
+	$full_block_name  = 'core' === $split_block_name[0] ? end( $split_block_name ) : implode( '-', $split_block_name );
 	$class_names[]    = 'wp-block-' . $full_block_name . '-' . $layout_classname;
 
 	$content_with_outer_classnames = '';

--- a/packages/block-editor/src/hooks/layout.js
+++ b/packages/block-editor/src/hooks/layout.js
@@ -72,7 +72,7 @@ export function useLayoutClasses( blockAttributes = {}, blockName = '' ) {
 		const splitBlockName = blockName.split( '/' );
 		const fullBlockName =
 			splitBlockName[ 0 ] === 'core'
-				? splitBlockName[ 1 ]
+				? splitBlockName.pop()
 				: splitBlockName.join( '-' );
 		const compoundClassName = `wp-block-${ fullBlockName }-${ baseClassName }`;
 		layoutClassnames.push( baseClassName, compoundClassName );

--- a/packages/block-editor/src/hooks/layout.js
+++ b/packages/block-editor/src/hooks/layout.js
@@ -69,9 +69,12 @@ export function useLayoutClasses( blockAttributes = {}, blockName = '' ) {
 	if ( LAYOUT_DEFINITIONS[ usedLayout?.type || 'default' ]?.className ) {
 		const baseClassName =
 			LAYOUT_DEFINITIONS[ usedLayout?.type || 'default' ]?.className;
-		const compoundClassName = `wp-block-${ blockName
-			.split( '/' )
-			.pop() }-${ baseClassName }`;
+		const splitBlockName = blockName.split( '/' );
+		const fullBlockName =
+			splitBlockName[ 0 ] === 'core'
+				? splitBlockName[ 1 ]
+				: splitBlockName.join( '-' );
+		const compoundClassName = `wp-block-${ fullBlockName }-${ baseClassName }`;
 		layoutClassnames.push( baseClassName, compoundClassName );
 	}
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes #53295.

The compound [block name]-[layout name] classname generated for layout blocks should take into account the block namespace if it's not a core block.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Install and activate a custom block with layout and block spacing support, or use [this test one](https://github.com/WordPress/gutenberg/files/12287041/layouty.zip).
2. Add the custom block to a post and check that the compound classname includes the block namespace in the editor and front end.
3. In global styles, set a global spacing value for the custom block.
4. Check that the spacing styles are attached to the correct compound classname in the editor and front end.


### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
