### PR TITLE
Patterns: add `delete_posts` to the wp_block (patterns) capabilities

### DIFF
--- a/lib/compat/wordpress-6.4/blocks.php
+++ b/lib/compat/wordpress-6.4/blocks.php
@@ -14,7 +14,7 @@
  */
 function gutenberg_add_custom_capabilities_to_wp_block( $args ) {
 	if ( is_array( $args ) ) {
-		if ( is_array( $args['capabilities'] ) || ! isset( $args['capabilities'] ) ) {
+		if ( ! isset( $args['capabilities'] ) || is_array( $args['capabilities'] ) ) {
 			$args['capabilities']['delete_posts'] = 'delete_posts';
 		}
 	}

--- a/lib/compat/wordpress-6.4/blocks.php
+++ b/lib/compat/wordpress-6.4/blocks.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Temporary compatibility shims for block APIs present in Gutenberg.
+ *
+ * @package gutenberg
+ */
+
+/**
+ * Adds delete_posts capabilities to the wp_block post type.
+ *
+ * @param array $args Register post type args.
+ *
+ * @return array Register post type args.
+ */
+function gutenberg_add_custom_capabilities_to_wp_block( $args ) {
+	$args['capabilities']['delete_posts'] = 'delete_posts';
+	return $args;
+}
+add_filter( 'register_wp_block_post_type_args', 'gutenberg_add_custom_capabilities_to_wp_block', 10, 1 );

--- a/lib/compat/wordpress-6.4/blocks.php
+++ b/lib/compat/wordpress-6.4/blocks.php
@@ -13,7 +13,11 @@
  * @return array Register post type args.
  */
 function gutenberg_add_custom_capabilities_to_wp_block( $args ) {
-	$args['capabilities']['delete_posts'] = 'delete_posts';
+	if ( is_array( $args ) ) {
+		if ( is_array( $args['capabilities'] ) || ! isset( $args['capabilities'] ) ) {
+			$args['capabilities']['delete_posts'] = 'delete_posts';
+		}
+	}
 	return $args;
 }
 add_filter( 'register_wp_block_post_type_args', 'gutenberg_add_custom_capabilities_to_wp_block', 10, 1 );

--- a/lib/load.php
+++ b/lib/load.php
@@ -118,6 +118,9 @@ require __DIR__ . '/compat/wordpress-6.3/navigation-fallback.php';
 require __DIR__ . '/compat/wordpress-6.3/block-editor-settings.php';
 require_once __DIR__ . '/compat/wordpress-6.3/kses.php';
 
+// WordPress 6.4 compat.
+require __DIR__ . '/compat/wordpress-6.4/blocks.php';
+
 // Experimental features.
 require __DIR__ . '/experimental/block-editor-settings-mobile.php';
 require __DIR__ . '/experimental/blocks.php';


### PR DESCRIPTION
Maybe resolves https://github.com/WordPress/gutenberg/issues/53367

## What?
Adds `delete_posts` to the wp_block (patterns) capabilities.

WordPress core backport PR:

- https://github.com/WordPress/wordpress-develop/pull/4987


## Why?
It's currently not possible to delete draft posts. The `wp_block` post type has `delete_published_posts` in the capabilities array only.

See: https://github.com/WordPress/wordpress-develop/blob/444bdf49bc38883f603a584bcc119aedf98257b8/src/wp-includes/post.php#L322

## How?
Using the [register_{$post_type}_post_type_args](https://developer.wordpress.org/reference/hooks/register_post_type_post_type_args/) hook.

## Testing Instructions

1. Add a pattern in the post editor (wp-admin/edit.php?post_type=wp_block)
2. Save it in draft status
3. Go back to the list table
4. Try to trash the pattern (the row action will not be there)



## Screenshots or screencast <!-- if applicable -->

### Before
https://github.com/WordPress/gutenberg/assets/6458278/ec585568-1362-4742-acd0-d3be30a28f9d

### After
https://github.com/WordPress/gutenberg/assets/6458278/2c9be9a7-c2bf-4de0-aed4-1341335cc75d





