### PR TITLE
Fix memory leaks in `<Iframe>`

### DIFF
--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -167,6 +167,7 @@ function Iframe( {
 		node.addEventListener( 'load', onLoad );
 
 		return () => {
+			delete node._load;
 			node.removeEventListener( 'load', onLoad );
 			iFrameDocument?.removeEventListener(
 				'dragover',


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Fix (some) memory leaks in the `<Iframe>` component. Though not completely fixed, I think we can still close https://github.com/WordPress/gutenberg/issues/53382 in this PR.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Memory leaks crash users' browsers with lower-end devices or limited available resources. The memory leaks this PR fixed leak the iframe `document` for each `<BlockPreview>`, which means the whole DOM tree and the whole document frame cannot be freed even when it's navigated away or unmounted.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
There are two separate fixes 1e4d8dc8aec1fc43cf301fefca62dd2ac50b37cf and e5e9e6fe7e32e337b12eed1a912f4c70a1d25c04. I'll share more details about them in the inline comments below.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
Follow the instructions in #53382.

Note that both commits need to be applied for the fix to work since they leak the same document. Try disabling any one of them and see that the document is still leaked.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
Same as above.

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/7753001/113ff258-82bd-42f6-b60c-911c6e1bb53c

You can see that there are still around 2KB of leaks, but the majority are fixed now.