### PR TITLE
Fix the typo when setting the preview device type to 'Desktop'

### DIFF
--- a/packages/edit-site/src/components/header-edit-mode/index.js
+++ b/packages/edit-site/src/components/header-edit-mode/index.js
@@ -279,7 +279,7 @@ export default function HeaderEditMode() {
 											label={ __( 'Zoom-out View' ) }
 											onClick={ () => {
 												setPreviewDeviceType(
-													'desktop'
+													'Desktop'
 												);
 												__unstableSetEditorMode(
 													isZoomedOutView

--- a/packages/edit-site/src/components/site-hub/index.js
+++ b/packages/edit-site/src/components/site-hub/index.js
@@ -76,7 +76,7 @@ const SiteHub = forwardRef( ( { isTransparent, ...restProps }, ref ) => {
 					event.preventDefault();
 					if ( canvasMode === 'edit' ) {
 						clearSelectedBlock();
-						setPreviewDeviceType( 'desktop' );
+						setPreviewDeviceType( 'Desktop' );
 						setCanvasMode( 'view' );
 					}
 				},


### PR DESCRIPTION
## What?
PR the typos when setting the preview device type to 'Desktop'.

Originally [reproted](https://wordpress.slack.com/archives/C02QB2JS7/p1691418675757039) in the `code-editor` slack channel. Props to Louis.

## Why?
The `PreviewOptions` component uses [capitalized values](https://github.com/WordPress/gutenberg/blob/trunk/packages/block-editor/src/components/preview-options/index.js#L62). The third-party consumers could be listening to these changes and value difference will cause falsy results.

## Testing Instructions
1. Open the Site editor
2. Click on a template to enable the editing mode
3. Change the preview mode to something different from the desktop mode
4. Exit the editing mode by clicking "Open Navigation" in the top left corner
5. Confirm that the preview device type is set back to the desktop
