### PR TITLE
Fix missing Replace button in content-locked Image blocks

### DIFF
--- a/packages/block-editor/src/components/block-controls/use-has-block-controls.js
+++ b/packages/block-editor/src/components/block-controls/use-has-block-controls.js
@@ -1,0 +1,35 @@
+/**
+ * WordPress dependencies
+ */
+import { __experimentalUseSlotFills as useSlotFills } from '@wordpress/components';
+import warning from '@wordpress/warning';
+
+/**
+ * Internal dependencies
+ */
+import groups from './groups';
+
+export function useHasAnyBlockControls() {
+	let hasAnyBlockControls = false;
+	for ( const group in groups ) {
+		// It is safe to violate the rules of hooks here as the `groups` object
+		// is static and will not change length between renders. Do not return
+		// early as that will cause the hook to be called a different number of
+		// times between renders.
+		// eslint-disable-next-line react-hooks/rules-of-hooks
+		if ( useHasBlockControls( group ) ) {
+			hasAnyBlockControls = true;
+		}
+	}
+	return hasAnyBlockControls;
+}
+
+export function useHasBlockControls( group = 'default' ) {
+	const Slot = groups[ group ]?.Slot;
+	const fills = useSlotFills( Slot?.__unstableName );
+	if ( ! Slot ) {
+		warning( `Unknown BlockControls group "${ group }" provided.` );
+		return null;
+	}
+	return !! fills?.length;
+}

--- a/packages/block-editor/src/components/block-tools/block-contextual-toolbar.js
+++ b/packages/block-editor/src/components/block-tools/block-contextual-toolbar.js
@@ -25,6 +25,7 @@ import NavigableToolbar from '../navigable-toolbar';
 import BlockToolbar from '../block-toolbar';
 import { store as blockEditorStore } from '../../store';
 import { unlock } from '../../lock-unlock';
+import { useHasAnyBlockControls } from '../block-controls/use-has-block-controls';
 
 function BlockContextualToolbar( { focusOnMount, isFixed, ...props } ) {
 	// When the toolbar is fixed it can be collapsed
@@ -32,48 +33,58 @@ function BlockContextualToolbar( { focusOnMount, isFixed, ...props } ) {
 	const toolbarButtonRef = useRef();
 
 	const isLargeViewport = useViewportMatch( 'medium' );
-	const { blockType, hasParents, showParentSelector, selectedBlockClientId } =
-		useSelect( ( select ) => {
-			const {
-				getBlockName,
-				getBlockParents,
-				getSelectedBlockClientIds,
-				getBlockEditingMode,
-			} = unlock( select( blockEditorStore ) );
-			const { getBlockType } = select( blocksStore );
-			const selectedBlockClientIds = getSelectedBlockClientIds();
-			const _selectedBlockClientId = selectedBlockClientIds[ 0 ];
-			const parents = getBlockParents( _selectedBlockClientId );
-			const firstParentClientId = parents[ parents.length - 1 ];
-			const parentBlockName = getBlockName( firstParentClientId );
-			const parentBlockType = getBlockType( parentBlockName );
+	const {
+		blockType,
+		blockEditingMode,
+		hasParents,
+		showParentSelector,
+		selectedBlockClientId,
+	} = useSelect( ( select ) => {
+		const {
+			getBlockName,
+			getBlockParents,
+			getSelectedBlockClientIds,
+			getBlockEditingMode,
+		} = unlock( select( blockEditorStore ) );
+		const { getBlockType } = select( blocksStore );
+		const selectedBlockClientIds = getSelectedBlockClientIds();
+		const _selectedBlockClientId = selectedBlockClientIds[ 0 ];
+		const parents = getBlockParents( _selectedBlockClientId );
+		const firstParentClientId = parents[ parents.length - 1 ];
+		const parentBlockName = getBlockName( firstParentClientId );
+		const parentBlockType = getBlockType( parentBlockName );
 
-			return {
-				selectedBlockClientId: _selectedBlockClientId,
-				blockType:
-					_selectedBlockClientId &&
-					getBlockType( getBlockName( _selectedBlockClientId ) ),
-				hasParents: parents.length,
-				showParentSelector:
-					parentBlockType &&
-					getBlockEditingMode( firstParentClientId ) === 'default' &&
-					hasBlockSupport(
-						parentBlockType,
-						'__experimentalParentSelector',
-						true
-					) &&
-					selectedBlockClientIds.length <= 1 &&
-					getBlockEditingMode( _selectedBlockClientId ) === 'default',
-			};
-		}, [] );
+		return {
+			selectedBlockClientId: _selectedBlockClientId,
+			blockType:
+				_selectedBlockClientId &&
+				getBlockType( getBlockName( _selectedBlockClientId ) ),
+			blockEditingMode: getBlockEditingMode( _selectedBlockClientId ),
+			hasParents: parents.length,
+			showParentSelector:
+				parentBlockType &&
+				getBlockEditingMode( firstParentClientId ) === 'default' &&
+				hasBlockSupport(
+					parentBlockType,
+					'__experimentalParentSelector',
+					true
+				) &&
+				selectedBlockClientIds.length <= 1 &&
+				getBlockEditingMode( _selectedBlockClientId ) === 'default',
+		};
+	}, [] );
 
 	useEffect( () => {
 		setIsCollapsed( false );
 	}, [ selectedBlockClientId ] );
 
+	const isToolbarEnabled =
+		! blockType ||
+		hasBlockSupport( blockType, '__experimentalToolbar', true );
+	const hasAnyBlockControls = useHasAnyBlockControls();
 	if (
-		blockType &&
-		! hasBlockSupport( blockType, '__experimentalToolbar', true )
+		! isToolbarEnabled ||
+		( blockEditingMode !== 'default' && ! hasAnyBlockControls )
 	) {
 		return null;
 	}

--- a/packages/block-editor/src/components/block-tools/block-contextual-toolbar.js
+++ b/packages/block-editor/src/components/block-tools/block-contextual-toolbar.js
@@ -32,56 +32,48 @@ function BlockContextualToolbar( { focusOnMount, isFixed, ...props } ) {
 	const toolbarButtonRef = useRef();
 
 	const isLargeViewport = useViewportMatch( 'medium' );
-	const {
-		blockType,
-		hasParents,
-		showParentSelector,
-		selectedBlockClientId,
-		isContentOnly,
-	} = useSelect( ( select ) => {
-		const {
-			getBlockName,
-			getBlockParents,
-			getSelectedBlockClientIds,
-			getBlockEditingMode,
-		} = unlock( select( blockEditorStore ) );
-		const { getBlockType } = select( blocksStore );
-		const selectedBlockClientIds = getSelectedBlockClientIds();
-		const _selectedBlockClientId = selectedBlockClientIds[ 0 ];
-		const parents = getBlockParents( _selectedBlockClientId );
-		const firstParentClientId = parents[ parents.length - 1 ];
-		const parentBlockName = getBlockName( firstParentClientId );
-		const parentBlockType = getBlockType( parentBlockName );
+	const { blockType, hasParents, showParentSelector, selectedBlockClientId } =
+		useSelect( ( select ) => {
+			const {
+				getBlockName,
+				getBlockParents,
+				getSelectedBlockClientIds,
+				getBlockEditingMode,
+			} = unlock( select( blockEditorStore ) );
+			const { getBlockType } = select( blocksStore );
+			const selectedBlockClientIds = getSelectedBlockClientIds();
+			const _selectedBlockClientId = selectedBlockClientIds[ 0 ];
+			const parents = getBlockParents( _selectedBlockClientId );
+			const firstParentClientId = parents[ parents.length - 1 ];
+			const parentBlockName = getBlockName( firstParentClientId );
+			const parentBlockType = getBlockType( parentBlockName );
 
-		return {
-			selectedBlockClientId: _selectedBlockClientId,
-			blockType:
-				_selectedBlockClientId &&
-				getBlockType( getBlockName( _selectedBlockClientId ) ),
-			hasParents: parents.length,
-			isContentOnly:
-				getBlockEditingMode( _selectedBlockClientId ) === 'contentOnly',
-			showParentSelector:
-				parentBlockType &&
-				getBlockEditingMode( firstParentClientId ) === 'default' &&
-				hasBlockSupport(
-					parentBlockType,
-					'__experimentalParentSelector',
-					true
-				) &&
-				selectedBlockClientIds.length <= 1 &&
-				getBlockEditingMode( _selectedBlockClientId ) === 'default',
-		};
-	}, [] );
+			return {
+				selectedBlockClientId: _selectedBlockClientId,
+				blockType:
+					_selectedBlockClientId &&
+					getBlockType( getBlockName( _selectedBlockClientId ) ),
+				hasParents: parents.length,
+				showParentSelector:
+					parentBlockType &&
+					getBlockEditingMode( firstParentClientId ) === 'default' &&
+					hasBlockSupport(
+						parentBlockType,
+						'__experimentalParentSelector',
+						true
+					) &&
+					selectedBlockClientIds.length <= 1 &&
+					getBlockEditingMode( _selectedBlockClientId ) === 'default',
+			};
+		}, [] );
 
 	useEffect( () => {
 		setIsCollapsed( false );
 	}, [ selectedBlockClientId ] );
 
 	if (
-		isContentOnly ||
-		( blockType &&
-			! hasBlockSupport( blockType, '__experimentalToolbar', true ) )
+		blockType &&
+		! hasBlockSupport( blockType, '__experimentalToolbar', true )
 	) {
 		return null;
 	}

--- a/packages/block-editor/src/components/block-tools/style.scss
+++ b/packages/block-editor/src/components/block-tools/style.scss
@@ -121,10 +121,6 @@
 		}
 	}
 
-	&:has(.block-editor-block-toolbar:empty) {
-		display: none;
-	}
-
 	// Add a scrim to the right of the collapsed button.
 	&.is-collapsed::after {
 		content: "";


### PR DESCRIPTION
## What?
Reverts https://github.com/WordPress/gutenberg/pull/53110, partially reverts https://github.com/WordPress/gutenberg/pull/51779, and implements an alternative to both PRs that uses `useSlotFills`.

## Why?
When a block has a block editing mode of `'contentOnly'`, the parent selector, movers, etc. do not appear in the block toolbar. If the block then also does not render any custom controls, the toolbar appears completely empty. This causes visual weirdness in two forms:

- When Top Toolbar is disabled, a black pixel appears above the selected block. See https://github.com/WordPress/gutenberg/issues/51664.
- When Top Toolbar is enabled, a lot of extra cruft appears in the toolbar. See https://github.com/WordPress/gutenberg/pull/53110.

https://github.com/WordPress/gutenberg/pull/51779 was a very simplistic fix for this that does not work in Firefox which does not support `:has()`. Also, upon testing it now, I note that it doesn't seem to work in Safari. (Possibly because of how `:empty` works?)

https://github.com/WordPress/gutenberg/pull/53110 was another fix for this issue but made the invalid assumption that no block with an editing mode of `'contentOnly'` can render any controls. Some blocks such as the Image and Post Featured Image blocks do render controls, though, i.e. the _Replace_ button. See https://github.com/WordPress/gutenberg/pull/53110#issuecomment-1668893255 for a more detailed explanation.

## How?
So, with those two PRs reverted, we need to think of a better fix.

In this PR I am using `useSlotFills` to determine whether or not there are any custom block controls. Then, if the editing mode is `'disabled'` or `'contentOnly'`, and there are no custom controls, we can safely hide `BlockContextualToolbar`.

## Testing Instructions
Pages in the site editor:

1. Go to Appearance → Editor → Pages and select or create a page.
2. Set a featured image if one is not already set.
3. Select the Post Featured Image block. You should see the _Replace_ button which lets you replace the image.

Images in content locked patterns:

1. Insert a content locked pattern containing an Image block. Here's one: https://gist.github.com/richtabor/ddeea41ced691721318649bea8ce9db8
2. Select an Image block within that pattern. You should see the _Replace_ button which lets you replace the image.

Check for regressions of https://github.com/WordPress/gutenberg/issues/51664:

1. Go to Appearance → Editor → Pages and select or create a page.
2. With Top Toolbar disabled, select the Post Title block.
3. A black pixel should not appear above the selected block.

Check for regressions of https://github.com/WordPress/gutenberg/pull/53110:

1. Go to the site editor
2. Select Navigation
3. Select one of the menus
4. Enter edit mode
5. Select the navigation block
6. Set top toolbar from the top right options menu
7. Notice that there is nothing shown in the header
8. Click on a navigation block item 
9. Notice the block toolbar appears in the header
