### PR TITLE
Button: add `:disabled` selector to reset hover color for disabled buttons

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -18,7 +18,7 @@
 ### Bug Fix
 
 -   `Modal`: Fix loss of focus when clicking outside ([#52653](https://github.com/WordPress/gutenberg/pull/52653)).
--   `MenuItemsChoice`: add `aria-disabled` when disabled is `true` ([#53411](https://github.com/WordPress/gutenberg/pull/53411)).
+-   `Button`: add `:disabled` selector to reset hover color for disabled buttons ([#53411](https://github.com/WordPress/gutenberg/pull/53411)).
 
 ### Internal
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -18,6 +18,7 @@
 ### Bug Fix
 
 -   `Modal`: Fix loss of focus when clicking outside ([#52653](https://github.com/WordPress/gutenberg/pull/52653)).
+-   `MenuItemsChoice`: add `aria-disabled` when disabled is `true` ([#53411](https://github.com/WordPress/gutenberg/pull/53411)).
 
 ### Internal
 

--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -28,6 +28,7 @@
 	}
 
 	// Unset some hovers, instead of adding :not specificity.
+	&:disabled:hover,
 	&[aria-disabled="true"]:hover {
 		color: initial;
 	}

--- a/packages/components/src/menu-items-choice/index.tsx
+++ b/packages/components/src/menu-items-choice/index.tsx
@@ -59,7 +59,6 @@ function MenuItemsChoice( {
 						key={ item.value }
 						role="menuitemradio"
 						disabled={ item.disabled }
-						aria-disabled={ item.disabled }
 						icon={ isSelected && check }
 						info={ item.info }
 						isSelected={ isSelected }

--- a/packages/components/src/menu-items-choice/index.tsx
+++ b/packages/components/src/menu-items-choice/index.tsx
@@ -59,6 +59,7 @@ function MenuItemsChoice( {
 						key={ item.value }
 						role="menuitemradio"
 						disabled={ item.disabled }
+						aria-disabled={ item.disabled }
 						icon={ isSelected && check }
 						info={ item.info }
 						isSelected={ isSelected }


### PR DESCRIPTION
Probably resolves https://github.com/WordPress/gutenberg/issues/53177


## What?
Adds a `:disabled:hover` selector to reset hover colors for disabled Buttons.

```css
	// Unset some hovers, instead of adding :not specificity.
	&:disabled:hover,
	&[aria-disabled="true"]:hover {
		color: initial;
	}
```

## Why?

The`<Button />` text color does not inherit `:hover` state colors if it has an `aria-disabled` attribute. 

But it does not cater for the `"disabled"` attribute, which many buttons use without the additional `aria-disabled` attribute.

[This rule](https://github.com/WordPress/gutenberg/blob/fc6000ac74b3fb6dd93b142e447eb5cc189fdc35/packages/components/src/button/style.scss#L30-L30)

```css
	// Unset some hovers, instead of adding :not specificity.
	&[aria-disabled="true"]:hover {
		color: initial;
	}
```

## Testing Instructions

Here are a few screen recordings

The new selector will affect all buttons that have disabled states.

For example, the preview icon in the post editor. Add a new post but don't add any content.

Also the Reset revisions button in the site editor (it's disabled once pressed).

https://github.com/WordPress/gutenberg/assets/6458278/55f33925-7712-484f-ae29-5ec4f3b1e1de

https://github.com/WordPress/gutenberg/assets/6458278/561fc477-1c78-4a6f-9d26-b910785d0cef

To test that this PR fixes https://github.com/WordPress/gutenberg/issues/53177:

Disable code editing. The quick way is to toggle the default editor settings:

```diff
diff --git a/packages/editor/src/store/defaults.js b/packages/editor/src/store/defaults.js
index 38b79ad9a8..315484289e 100644
--- a/packages/editor/src/store/defaults.js
+++ b/packages/editor/src/store/defaults.js
@@ -25,6 +25,6 @@ export const EDITOR_SETTINGS_DEFAULTS = {
 	...SETTINGS_DEFAULTS,
 
 	richEditingEnabled: true,
-	codeEditingEnabled: true,
+	codeEditingEnabled: false,
 	enableCustomFields: undefined,
 };
```

Head over to the post editor and open the settings menu at the top right of the page using the ellipsis menu.

See that the color does not change on the disabled button.

## Screenshots or screencast <!-- if applicable -->

### Before

https://github.com/WordPress/gutenberg/assets/6458278/9049f865-05e8-4f2e-ad16-17687dd0649b

### After


https://github.com/WordPress/gutenberg/assets/6458278/8a9d6788-90b3-485c-beae-394b432ecd84



