### PR TITLE
Adds site editor mobile block settings and styles

### DIFF
--- a/packages/edit-site/src/components/header-edit-mode/document-actions/style.scss
+++ b/packages/edit-site/src/components/header-edit-mode/document-actions/style.scss
@@ -55,7 +55,9 @@
 	overflow: hidden;
 
 	// Offset the layout based on the width of the ⌘K label. This ensures the title is centrally aligned.
-	padding-left: $grid-unit-40;
+	@include break-small() {
+		padding-left: $grid-unit-40;
+	}
 
 	&:hover {
 		color: var(--wp-block-synced-color);
@@ -95,6 +97,10 @@
 .edit-site-document-actions__shortcut {
 	color: $gray-800;
 	min-width: $grid-unit-40;
+	display: none;
+	@include break-small() {
+		display: initial;
+	}
 }
 
 .edit-site-document-actions__back.components-button.has-icon.has-text {

--- a/packages/edit-site/src/components/header-edit-mode/style.scss
+++ b/packages/edit-site/src/components/header-edit-mode/style.scss
@@ -88,15 +88,6 @@ $header-toolbar-min-width: 335px;
 	@include break-small() {
 		gap: $grid-unit-10;
 	}
-
-	// Pinned items.
-	.interface-pinned-items {
-		display: none;
-
-		@include break-medium() {
-			display: inline-flex;
-		}
-	}
 }
 
 .edit-site-header-edit-mode__preview-options {

--- a/packages/edit-site/src/components/sidebar-edit-mode/default-sidebar.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/default-sidebar.js
@@ -35,6 +35,7 @@ export default function DefaultSidebar( {
 				scope="core/edit-site"
 				identifier={ identifier }
 				title={ title }
+				smallScreenTitle={ title }
 				icon={ icon }
 				closeLabel={ closeLabel }
 				header={ header }

--- a/packages/interface/src/components/pinned-items/style.scss
+++ b/packages/interface/src/components/pinned-items/style.scss
@@ -3,8 +3,19 @@
 
 	// We intentionally hide pinned items (plugins) on mobile, and unhide them at desktop breakpoints.
 	// Otherwise the list can wreak havoc on the layout.
-	.components-button:not(:first-child) {
+	.components-button {
 		display: none;
+		margin: 0;
+
+		&:nth-last-child(1),
+		&:nth-last-child(2) {
+			display: flex;
+		}
+
+		svg {
+			max-width: $icon-size;
+			max-height: $icon-size;
+		}
 
 		@include break-small() {
 			display: flex;
@@ -16,13 +27,4 @@
 
 	// Account for larger grid from parent container gap.
 	margin-right: -$grid-unit-05;
-
-	.components-button {
-		margin: 0;
-
-		svg {
-			max-width: $icon-size;
-			max-height: $icon-size;
-		}
-	}
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Brings back (or over?) the buttons for block settings (inspector) and the syles inspector when viewing the site editor on a small viewport.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

SInce we removed the "show more settings" item from the block toolbar's more menu, the icon in the header is the only way to access block settings. Thus without the icon in the header if a block is broken there is no way to fix it on a small viewport.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

1. Makes the document title button smaller by removing the cmdk help text, some padding too
2. Makes the pinned items visible in the site editor on small viewports
3. Makes the _last two_ children of the pinned items visible in the site editor on small viewports

The fact that there was no small screen title passed to the complementary area in the composition of the site editor layout makes me think we never had these sidebars on small viewports in the site editor.

Also, fixing this I noticed there _was a style to make visible the 1st child of the pinned items_. Either the order in which the slots are filled changed or I am missing something, but I removed that style as for me plugins are placed _before_ the settings and styles buttons.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Visit the site editor on a small viewport
4. Edit a template
5. In the header there should be two icons on the right side one for block settings and one for styles
6. They should work as expected

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

N/A

## Screenshots or screencast <!-- if applicable -->

### Before

<img width="434" alt="Screenshot 2023-08-08 at 11 05 17" src="https://github.com/WordPress/gutenberg/assets/107534/b46b4645-db5e-40f6-bb7f-704130553d46">

### After


https://github.com/WordPress/gutenberg/assets/107534/47c476e8-6882-4c63-9b37-c22caa7cb2d5


