### PR TITLE
Try: Change PR label enforcer automation not to work on draft PRs by default

### DIFF
--- a/.github/workflows/enforce-pr-labels.yml
+++ b/.github/workflows/enforce-pr-labels.yml
@@ -1,7 +1,7 @@
 name: Enforce labels on Pull Request
 on:
     pull_request_target:
-        types: [opened, labeled, unlabeled, synchronize]
+        types: [labeled, unlabeled, ready_for_review, review_requested]
 jobs:
     type-related-labels:
         runs-on: ubuntu-latest


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Changes the GitHub workflow that enforces PRs have proper labels not to work on draft PRs by default—original conversation found in [WordPress Slack](https://wordpress.slack.com/archives/C02QB2JS7/p1691480732921339).

## Why?
Some folks have suggested removing it. I would like to hear more drawbacks of having this check for draft PRs.

Some benefits I see of doing the label checks even on draft PRs:
- For folks that browse open PRs regularly, it can help to see labels even in draft PRs.
- By the time a PR is ready to review, it's more likely that the PR is labeled correctly and without the noise of the GitHub actions comment, helping with the review process

## How?
Removes the triggers `opened` and `synchronize`, and adds `ready_for_review` and `review_requested`. With these changes, the check would still apply to draft PRs in some scenarios, primarily when adding or removing labels, but also when asking folks to review: in my opinion,  if people are invited to check a PR, it should indeed have proper labels to help these people get the context of the PR.