### PR TITLE
Dependencies: Bump `remove-accents` to 0.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51113,9 +51113,9 @@
 			"integrity": "sha512-NVfSP9NstE3QPNs/TnegQY0vnJnstKQSpcrsI2kBTB3dB2PkdfKdTa+abbjMIDqpc63fE5LfjLgfMst0ULMFxQ=="
 		},
 		"node_modules/remove-accents": {
-			"version": "0.4.2",
-			"resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.4.2.tgz",
-			"integrity": "sha512-7pXIJqJOq5tFgG1A2Zxti3Ht8jJF337m4sowbuHsW30ZnkQFnDzy9qBNhgzX8ZLW4+UBcXiiR7SwR6pokHsxiA=="
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.5.0.tgz",
+			"integrity": "sha512-8g3/Otx1eJaVD12e31UbJj1YzdtVvzH85HV7t+9MJYk/u3XmkOUJ5Ys9wQrf9PCPK8+xn4ymzqYCiZl6QWKn+A=="
 		},
 		"node_modules/remove-trailing-separator": {
 			"version": "1.1.0",
@@ -58893,7 +58893,7 @@
 				"react-autosize-textarea": "^7.1.0",
 				"react-easy-crop": "^4.5.1",
 				"rememo": "^4.0.2",
-				"remove-accents": "^0.4.2",
+				"remove-accents": "^0.5.0",
 				"traverse": "^0.6.6"
 			},
 			"engines": {
@@ -58948,7 +58948,7 @@
 				"fast-deep-equal": "^3.1.3",
 				"memize": "^2.1.0",
 				"micromodal": "^0.4.10",
-				"remove-accents": "^0.4.2",
+				"remove-accents": "^0.5.0",
 				"uuid": "^8.3.0"
 			},
 			"engines": {
@@ -59010,7 +59010,7 @@
 				"is-plain-object": "^5.0.0",
 				"memize": "^2.1.0",
 				"rememo": "^4.0.2",
-				"remove-accents": "^0.4.2",
+				"remove-accents": "^0.5.0",
 				"showdown": "^1.9.1",
 				"simple-html-tokenizer": "^0.5.7",
 				"uuid": "^8.3.0"
@@ -59105,7 +59105,7 @@
 				"re-resizable": "^6.4.0",
 				"react-colorful": "^5.3.1",
 				"reakit": "^1.3.11",
-				"remove-accents": "^0.4.2",
+				"remove-accents": "^0.5.0",
 				"use-lilius": "^2.0.1",
 				"uuid": "^8.3.0",
 				"valtio": "1.7.0"
@@ -59589,7 +59589,7 @@
 				"memize": "^2.1.0",
 				"react-autosize-textarea": "^7.1.0",
 				"rememo": "^4.0.2",
-				"remove-accents": "^0.4.2"
+				"remove-accents": "^0.5.0"
 			},
 			"engines": {
 				"node": ">=12"
@@ -59679,7 +59679,7 @@
 				"memize": "^2.1.0",
 				"react-autosize-textarea": "^7.1.0",
 				"rememo": "^4.0.2",
-				"remove-accents": "^0.4.2"
+				"remove-accents": "^0.5.0"
 			},
 			"engines": {
 				"node": ">=12"
@@ -60726,7 +60726,7 @@
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
-				"remove-accents": "^0.4.2"
+				"remove-accents": "^0.5.0"
 			},
 			"engines": {
 				"node": ">=12"

--- a/package-lock.json
+++ b/package-lock.json
@@ -72701,7 +72701,7 @@
 				"react-autosize-textarea": "^7.1.0",
 				"react-easy-crop": "^4.5.1",
 				"rememo": "^4.0.2",
-				"remove-accents": "^0.4.2",
+				"remove-accents": "^0.5.0",
 				"traverse": "^0.6.6"
 			}
 		},
@@ -72747,7 +72747,7 @@
 				"fast-deep-equal": "^3.1.3",
 				"memize": "^2.1.0",
 				"micromodal": "^0.4.10",
-				"remove-accents": "^0.4.2",
+				"remove-accents": "^0.5.0",
 				"uuid": "^8.3.0"
 			}
 		},
@@ -72790,7 +72790,7 @@
 				"is-plain-object": "^5.0.0",
 				"memize": "^2.1.0",
 				"rememo": "^4.0.2",
-				"remove-accents": "^0.4.2",
+				"remove-accents": "^0.5.0",
 				"showdown": "^1.9.1",
 				"simple-html-tokenizer": "^0.5.7",
 				"uuid": "^8.3.0"
@@ -72862,7 +72862,7 @@
 				"re-resizable": "^6.4.0",
 				"react-colorful": "^5.3.1",
 				"reakit": "^1.3.11",
-				"remove-accents": "^0.4.2",
+				"remove-accents": "^0.5.0",
 				"use-lilius": "^2.0.1",
 				"uuid": "^8.3.0",
 				"valtio": "1.7.0"
@@ -73198,7 +73198,7 @@
 				"memize": "^2.1.0",
 				"react-autosize-textarea": "^7.1.0",
 				"rememo": "^4.0.2",
-				"remove-accents": "^0.4.2"
+				"remove-accents": "^0.5.0"
 			}
 		},
 		"@wordpress/edit-widgets": {
@@ -73270,7 +73270,7 @@
 				"memize": "^2.1.0",
 				"react-autosize-textarea": "^7.1.0",
 				"rememo": "^4.0.2",
-				"remove-accents": "^0.4.2"
+				"remove-accents": "^0.5.0"
 			}
 		},
 		"@wordpress/element": {
@@ -73921,7 +73921,7 @@
 			"version": "file:packages/url",
 			"requires": {
 				"@babel/runtime": "^7.16.0",
-				"remove-accents": "^0.4.2"
+				"remove-accents": "^0.5.0"
 			}
 		},
 		"@wordpress/viewport": {
@@ -102059,9 +102059,9 @@
 			"integrity": "sha512-NVfSP9NstE3QPNs/TnegQY0vnJnstKQSpcrsI2kBTB3dB2PkdfKdTa+abbjMIDqpc63fE5LfjLgfMst0ULMFxQ=="
 		},
 		"remove-accents": {
-			"version": "0.4.2",
-			"resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.4.2.tgz",
-			"integrity": "sha512-7pXIJqJOq5tFgG1A2Zxti3Ht8jJF337m4sowbuHsW30ZnkQFnDzy9qBNhgzX8ZLW4+UBcXiiR7SwR6pokHsxiA=="
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.5.0.tgz",
+			"integrity": "sha512-8g3/Otx1eJaVD12e31UbJj1YzdtVvzH85HV7t+9MJYk/u3XmkOUJ5Ys9wQrf9PCPK8+xn4ymzqYCiZl6QWKn+A=="
 		},
 		"remove-trailing-separator": {
 			"version": "1.1.0",

--- a/packages/block-editor/package.json
+++ b/packages/block-editor/package.json
@@ -75,7 +75,7 @@
 		"react-autosize-textarea": "^7.1.0",
 		"react-easy-crop": "^4.5.1",
 		"rememo": "^4.0.2",
-		"remove-accents": "^0.4.2",
+		"remove-accents": "^0.5.0",
 		"traverse": "^0.6.6"
 	},
 	"peerDependencies": {

--- a/packages/block-editor/src/components/inserter/test/search-items.js
+++ b/packages/block-editor/src/components/inserter/test/search-items.js
@@ -50,7 +50,10 @@ describe( 'getNormalizedSearchTerms', () => {
 		).toEqual( [ '师父领进门', '修行在个人' ] );
 		expect(
 			getNormalizedSearchTerms( 'Бързата работа – срам за майстора.' )
-		).toEqual( [ 'бързата', 'работа', 'срам', 'за', 'майстора' ] );
+		).toEqual( [ 'бързата', 'работа', 'срам', 'за', 'маистора' ] );
+		expect(
+			getNormalizedSearchTerms( 'Cảm ơn sự giúp đỡ của bạn.' )
+		).toEqual( [ 'cam', 'on', 'su', 'giup', 'do', 'cua', 'ban' ] );
 	} );
 } );
 

--- a/packages/block-library/package.json
+++ b/packages/block-library/package.json
@@ -69,7 +69,7 @@
 		"fast-deep-equal": "^3.1.3",
 		"memize": "^2.1.0",
 		"micromodal": "^0.4.10",
-		"remove-accents": "^0.4.2",
+		"remove-accents": "^0.5.0",
 		"uuid": "^8.3.0"
 	},
 	"peerDependencies": {

--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -51,7 +51,7 @@
 		"is-plain-object": "^5.0.0",
 		"memize": "^2.1.0",
 		"rememo": "^4.0.2",
-		"remove-accents": "^0.4.2",
+		"remove-accents": "^0.5.0",
 		"showdown": "^1.9.1",
 		"simple-html-tokenizer": "^0.5.7",
 		"uuid": "^8.3.0"

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -75,7 +75,7 @@
 		"re-resizable": "^6.4.0",
 		"react-colorful": "^5.3.1",
 		"reakit": "^1.3.11",
-		"remove-accents": "^0.4.2",
+		"remove-accents": "^0.5.0",
 		"use-lilius": "^2.0.1",
 		"uuid": "^8.3.0",
 		"valtio": "1.7.0"

--- a/packages/edit-site/package.json
+++ b/packages/edit-site/package.json
@@ -74,7 +74,7 @@
 		"memize": "^2.1.0",
 		"react-autosize-textarea": "^7.1.0",
 		"rememo": "^4.0.2",
-		"remove-accents": "^0.4.2"
+		"remove-accents": "^0.5.0"
 	},
 	"peerDependencies": {
 		"react": "^18.0.0",

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -64,7 +64,7 @@
 		"memize": "^2.1.0",
 		"react-autosize-textarea": "^7.1.0",
 		"rememo": "^4.0.2",
-		"remove-accents": "^0.4.2"
+		"remove-accents": "^0.5.0"
 	},
 	"peerDependencies": {
 		"react": "^18.0.0",

--- a/packages/url/package.json
+++ b/packages/url/package.json
@@ -28,7 +28,7 @@
 	"sideEffects": false,
 	"dependencies": {
 		"@babel/runtime": "^7.16.0",
-		"remove-accents": "^0.4.2"
+		"remove-accents": "^0.5.0"
 	},
 	"publishConfig": {
 		"access": "public"


### PR DESCRIPTION
## What?
This PR bumps `remove-accents` to v0.5.0.

Fixes #12907, which from what I understand is open because of the lack of proper Vietnamese support.

## Why?
Because it's the latest version, it resolves a few issues, namely some discrepancies with Vietnamese and Cyrillic.

## How?
I'm bumping the package version and adding a unit test that confirms the changes work as expected.

## Testing Instructions
Verify Gutenberg builds and runs well, tests pass and all checks are green (I'm intentionally not adding a components package CHANGELOG entry).

### Testing Instructions for Keyboard
None

## Screenshots or screencast <!-- if applicable -->
None