### PR TITLE
Remove effect dep in Link Control 

### DIFF
--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -205,12 +205,7 @@ function LinkControl( {
 			return;
 		}
 
-		setIsEditingLink( ( prevIsEditing ) => {
-			if ( prevIsEditing === forceIsEditingLink ) {
-				return prevIsEditing;
-			}
-			return forceIsEditingLink;
-		} );
+		setIsEditingLink( forceIsEditingLink );
 	}, [ forceIsEditingLink ] );
 
 	useEffect( () => {

--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -201,14 +201,16 @@ function LinkControl( {
 		useCreatePage( createSuggestion );
 
 	useEffect( () => {
-		if (
-			forceIsEditingLink !== undefined &&
-			forceIsEditingLink !== isEditingLink
-		) {
-			setIsEditingLink( forceIsEditingLink );
+		if ( forceIsEditingLink === undefined ) {
+			return;
 		}
-		// Todo: bug if the missing dep is introduced. Will need a fix.
-		// eslint-disable-next-line react-hooks/exhaustive-deps
+
+		setIsEditingLink( ( prevIsEditing ) => {
+			if ( prevIsEditing === forceIsEditingLink ) {
+				return prevIsEditing;
+			}
+			return forceIsEditingLink;
+		} );
 	}, [ forceIsEditingLink ] );
 
 	useEffect( () => {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes "Todo" in code by removing unneeded effect dependency for `isEditingLink` update.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Eslint was disabling the lint rule to add the dependency and there was a comment saying the dependency couldn't be added without causing bugs.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Uses functional form of "setState" to consume current value of `isEditingLink` state before `setIsEditingLink` is called based on value of `forceIsEditingLink`.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- Check component works as before
- All tests pass

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
