### PR TITLE
Inject theme stylesheet value as template part theme attribute

### DIFF
--- a/packages/block-library/src/pattern/edit.js
+++ b/packages/block-library/src/pattern/edit.js
@@ -31,6 +31,22 @@ const PatternEdit = ( { attributes, clientId } ) => {
 
 	function injectThemeAttributeInBlockTemplateContent( block ) {
 		if (
+			block.innerBlocks.find(
+				( innerBlock ) => innerBlock.name === 'core/template-part'
+			)
+		) {
+			block.innerBlocks = block.innerBlocks.map( ( innerBlock ) => {
+				if (
+					innerBlock.name === 'core/template-part' &&
+					innerBlock.attributes.theme === undefined
+				) {
+					innerBlock.attributes.theme = currentThemeStylesheet;
+				}
+				return innerBlock;
+			} );
+		}
+
+		if (
 			block.name === 'core/template-part' &&
 			block.attributes.theme === undefined
 		) {

--- a/packages/block-library/src/pattern/edit.js
+++ b/packages/block-library/src/pattern/edit.js
@@ -8,6 +8,7 @@ import {
 	store as blockEditorStore,
 	useBlockProps,
 } from '@wordpress/block-editor';
+import { store as coreStore } from '@wordpress/core-data';
 
 const PatternEdit = ( { attributes, clientId } ) => {
 	const selectedPattern = useSelect(
@@ -18,11 +19,25 @@ const PatternEdit = ( { attributes, clientId } ) => {
 		[ attributes.slug ]
 	);
 
+	const currentThemeStylesheet = useSelect(
+		( select ) => select( coreStore ).getCurrentTheme().stylesheet
+	);
+
 	const { replaceBlocks, __unstableMarkNextChangeAsNotPersistent } =
 		useDispatch( blockEditorStore );
 	const { setBlockEditingMode } = useDispatch( blockEditorStore );
 	const { getBlockRootClientId, getBlockEditingMode } =
 		useSelect( blockEditorStore );
+
+	function injectThemeAttributeInBlockTemplateContent( block ) {
+		if (
+			block.name === 'core/template-part' &&
+			block.attributes.theme === undefined
+		) {
+			block.attributes.theme = currentThemeStylesheet;
+		}
+		return block;
+	}
 
 	// Run this effect when the component loads.
 	// This adds the Pattern's contents to the post.
@@ -40,7 +55,9 @@ const PatternEdit = ( { attributes, clientId } ) => {
 				// Clone blocks from the pattern before insertion to ensure they receive
 				// distinct client ids. See https://github.com/WordPress/gutenberg/issues/50628.
 				const clonedBlocks = selectedPattern.blocks.map( ( block ) =>
-					cloneBlock( block )
+					cloneBlock(
+						injectThemeAttributeInBlockTemplateContent( block )
+					)
 				);
 				const rootEditingMode = getBlockEditingMode( rootClientId );
 				// Temporarily set the root block to default mode to allow replacing the pattern.

--- a/packages/block-library/src/pattern/index.php
+++ b/packages/block-library/src/pattern/index.php
@@ -41,7 +41,7 @@ function render_block_core_pattern( $attributes ) {
 	}
 
 	$pattern = $registry->get_registered( $slug );
-	$content = $pattern['content'];
+	$content = _inject_theme_attribute_in_block_template_content( $pattern['content'] );
 
 	$gutenberg_experiments = get_option( 'gutenberg-experiments' );
 	if ( $gutenberg_experiments && ! empty( $gutenberg_experiments['gutenberg-auto-inserting-blocks'] ) ) {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes #53194

When a Template Part is included in a Pattern the Template Part must have a `theme` attribute else the template part does not render.  This is different from including a template part in a template (or another template part) since, in those situations, the `theme` attribute is assumed to be "the current theme".

This change replicates that behavior in patterns so that Template Parts referenced from them is assumed to be "the current theme".

## Why?
In some design scenarios it's necessary to include content in a pattern (so that the content can be localized, or media references can be included) in such a way that things such as headers and footers contained in template parts need to be included.  This change allows that.


## How?
When templates are being rendered (both as a view and in the editor) if a template block is being rendered and it is missing the `theme` attribute the current theme's 'stylesheet' property is set as the value.

## Testing Instructions
Activate a theme with a TEMPLATE that references a PATTERN.
```<!-- wp:pattern {"slug":"blank/pattern-with-part"} /-->```

The PATTERN should reference a TEMPLATE PART.
```
<?php
/**
 * Title: A Test Pattern
 * Slug: blank/pattern-with-part
 */
?>

<!-- wp:paragraph -->
<p>This is a paragraph</p>
<!-- /wp:paragraph -->

<!-- wp:template-part {"slug":"just-a-part"} /-->
```

And the template part should have content:
```
<!-- wp:paragraph -->
<p>This is a simple template part</p>
<!-- /wp:paragraph -->
```

Before this patch is applied 'The template part cannot be found' is shown to the user in the editor and view.

After this patch is applied the template part is rendered as expected.
