### PR TITLE
Selection: restore focus after dragging out of the block repeatedly

### DIFF
--- a/packages/block-editor/src/components/writing-flow/use-drag-selection.js
+++ b/packages/block-editor/src/components/writing-flow/use-drag-selection.js
@@ -96,7 +96,11 @@ export default function useDragSelection() {
 					return;
 				}
 
-				anchorElement = ownerDocument.activeElement;
+				// Do not rely on the active element because it may change after
+				// the mouse leaves for the first time. See
+				// https://github.com/WordPress/gutenberg/issues/48747.
+				anchorElement = target;
+
 				startMultiSelect();
 
 				// `onSelectionStart` is called after `mousedown` and

--- a/test/e2e/specs/editor/various/multi-block-selection.spec.js
+++ b/test/e2e/specs/editor/various/multi-block-selection.spec.js
@@ -608,6 +608,10 @@ test.describe( 'Multi-block selection', () => {
 		await page.mouse.click( coord1.x, coord1.y );
 		await page.mouse.down();
 		await page.mouse.move( coord2.x, coord2.y, { steps: 10 } );
+		// Simulate moving once in and out of the paragraph.
+		// Fixes https://github.com/WordPress/gutenberg/issues/48747.
+		await page.mouse.move( coord1.x, coord1.y, { steps: 10 } );
+		await page.mouse.move( coord2.x, coord2.y, { steps: 10 } );
 		await page.mouse.up();
 
 		// Wait for:


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes #48747, which is actually not just a problem with the table block. Even when you select inside a paragraph and move out of it multiple times, you end up not being able to type in the paragraph because selection is lost.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

It's a simple fix, we should be checking the event target instead of active element, which doesn't change even after moving out of the block multiple times.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Create a paragraph with "ab". Place the caret between these characters and drag forward and out of the paragraph **multiple** times, releasing the mouse after this with only "a" selected. Press Delete. It should work.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
