### PR TITLE
[RNMobile] Initialize E2E tests with initial HTML

### DIFF
--- a/packages/react-native-bridge/android/react-native-bridge/src/main/java/org/wordpress/mobile/WPAndroidGlue/GutenbergProps.kt
+++ b/packages/react-native-bridge/android/react-native-bridge/src/main/java/org/wordpress/mobile/WPAndroidGlue/GutenbergProps.kt
@@ -92,7 +92,6 @@ data class GutenbergProps @JvmOverloads constructor(
                     content?.let { putString(PROP_INITIAL_DATA, it) }
                 }
 
-        private const val PROP_INITIAL_DATA = "initialData"
         private const val PROP_INITIAL_TITLE = "initialTitle"
         private const val PROP_INITIAL_HTML_MODE_ENABLED = "initialHtmlModeEnabled"
         private const val PROP_POST_TYPE = "postType"
@@ -108,6 +107,7 @@ data class GutenbergProps @JvmOverloads constructor(
         private const val PROP_QUOTE_BLOCK_V2 = "quoteBlockV2"
         private const val PROP_LIST_BLOCK_V2 = "listBlockV2"
 
+        const val PROP_INITIAL_DATA = "initialData"
         const val PROP_LOCALE = "locale"
         const val PROP_CAPABILITIES = "capabilities"
         const val PROP_CAPABILITIES_CONTACT_INFO_BLOCK = "contactInfoBlock"

--- a/packages/react-native-editor/__device-tests__/gutenberg-editor-block-insertion-@canary.test.js
+++ b/packages/react-native-editor/__device-tests__/gutenberg-editor-block-insertion-@canary.test.js
@@ -7,6 +7,7 @@ import testData, { slashInserter, shortText } from './helpers/test-data';
 
 describe( 'Gutenberg Editor tests for Block insertion', () => {
 	it( 'should be able to insert multi-paragraph text, and text to another paragraph block in between', async () => {
+		await editorPage.initializeEditor();
 		await editorPage.addNewBlock( blockNames.paragraph );
 		let paragraphBlockElement = await editorPage.getTextBlockAtPosition(
 			blockNames.paragraph
@@ -38,19 +39,12 @@ describe( 'Gutenberg Editor tests for Block insertion', () => {
 		expect( html.toLowerCase() ).toBe(
 			testData.blockInsertionHtml.toLowerCase()
 		);
-
-		for ( let i = 4; i > 0; i-- ) {
-			paragraphBlockElement = await editorPage.getTextBlockAtPosition(
-				blockNames.paragraph
-			);
-			await paragraphBlockElement.click();
-			await editorPage.removeBlock();
-		}
 	} );
 
 	it( 'should be able to insert block at the beginning of post from the title', async () => {
+		await editorPage.initializeEditor();
 		await editorPage.addNewBlock( blockNames.paragraph );
-		let paragraphBlockElement = await editorPage.getTextBlockAtPosition(
+		const paragraphBlockElement = await editorPage.getTextBlockAtPosition(
 			blockNames.paragraph
 		);
 		if ( isAndroid() ) {
@@ -79,20 +73,12 @@ describe( 'Gutenberg Editor tests for Block insertion', () => {
 		expect( html.toLowerCase() ).toBe(
 			testData.blockInsertionHtmlFromTitle.toLowerCase()
 		);
-
-		// Remove blocks
-		for ( let i = 4; i > 0; i-- ) {
-			paragraphBlockElement = await editorPage.getTextBlockAtPosition(
-				blockNames.paragraph
-			);
-			await paragraphBlockElement.click();
-			await editorPage.removeBlock();
-		}
 	} );
 } );
 
 describe( 'Gutenberg Editor Slash Inserter tests', () => {
 	it( 'should show the menu after typing /', async () => {
+		await editorPage.initializeEditor();
 		await editorPage.addNewBlock( blockNames.paragraph );
 		const paragraphBlockElement = await editorPage.getTextBlockAtPosition(
 			blockNames.paragraph
@@ -104,10 +90,10 @@ describe( 'Gutenberg Editor Slash Inserter tests', () => {
 		);
 
 		expect( await editorPage.assertSlashInserterPresent() ).toBe( true );
-		await editorPage.removeBlock();
 	} );
 
 	it( 'should hide the menu after deleting the / character', async () => {
+		await editorPage.initializeEditor();
 		await editorPage.addNewBlock( blockNames.paragraph );
 		const paragraphBlockElement = await editorPage.getTextBlockAtPosition(
 			blockNames.paragraph
@@ -138,11 +124,10 @@ describe( 'Gutenberg Editor Slash Inserter tests', () => {
 
 		// Check if the slash inserter UI no longer exists.
 		expect( await editorPage.assertSlashInserterPresent() ).toBe( false );
-
-		await editorPage.removeBlock();
 	} );
 
 	it( 'should add an Image block after tying /image and tapping on the Image block button', async () => {
+		await editorPage.initializeEditor();
 		await editorPage.addNewBlock( blockNames.paragraph );
 		const paragraphBlockElement = await editorPage.getTextBlockAtPosition(
 			blockNames.paragraph
@@ -170,12 +155,10 @@ describe( 'Gutenberg Editor Slash Inserter tests', () => {
 
 		// Slash inserter UI should not be present after adding a block.
 		expect( await editorPage.assertSlashInserterPresent() ).toBe( false );
-
-		// Remove image block.
-		await editorPage.removeBlock();
 	} );
 
 	it( 'should insert an embed image block with "/img" + enter', async () => {
+		await editorPage.initializeEditor();
 		await editorPage.addNewBlock( blockNames.paragraph );
 		const paragraphBlockElement = await editorPage.getTextBlockAtPosition(
 			blockNames.paragraph
@@ -189,7 +172,5 @@ describe( 'Gutenberg Editor Slash Inserter tests', () => {
 		expect(
 			await editorPage.hasBlockAtPosition( 1, blockNames.embed )
 		).toBe( true );
-
-		await editorPage.removeBlock();
 	} );
 } );

--- a/packages/react-native-editor/__device-tests__/gutenberg-editor-device-actions.test.js
+++ b/packages/react-native-editor/__device-tests__/gutenberg-editor-device-actions.test.js
@@ -15,6 +15,7 @@ import testData from './helpers/test-data';
 
 describe( 'Gutenberg Editor Rotation tests', () => {
 	it( 'should be able to add blocks , rotate device and continue adding blocks', async () => {
+		await editorPage.initializeEditor();
 		await editorPage.addNewBlock( blockNames.paragraph );
 		let paragraphBlockElement = await editorPage.getTextBlockAtPosition(
 			blockNames.paragraph
@@ -70,6 +71,7 @@ describe( 'Gutenberg Editor Paste tests', () => {
 	} );
 
 	it.skip( 'copies plain text from one paragraph block and pastes in another', async () => {
+		await editorPage.initializeEditor();
 		await editorPage.addNewBlock( blockNames.paragraph );
 		const paragraphBlockElement = await editorPage.getTextBlockAtPosition(
 			blockNames.paragraph
@@ -107,14 +109,13 @@ describe( 'Gutenberg Editor Paste tests', () => {
 
 		const text = await editorPage.getTextForParagraphBlockAtPosition( 2 );
 		expect( text ).toBe( testData.pastePlainText );
-
-		await editorPage.removeBlock();
-		await editorPage.removeBlock();
 	} );
 
 	it.skip( 'copies styled text from one paragraph block and pastes in another', async () => {
 		// Create paragraph block with styled text by editing html.
-		await editorPage.setHtmlContent( testData.pasteHtmlText );
+		await editorPage.initializeEditor( {
+			initialData: testData.pasteHtmlText,
+		} );
 		const paragraphBlockElement = await editorPage.getTextBlockAtPosition(
 			blockNames.paragraph
 		);

--- a/packages/react-native-editor/__device-tests__/gutenberg-editor-drag-and-drop.test.js
+++ b/packages/react-native-editor/__device-tests__/gutenberg-editor-drag-and-drop.test.js
@@ -22,11 +22,12 @@ describe( 'Gutenberg Editor Drag & Drop blocks tests', () => {
 
 	it( 'should be able to drag & drop a block', async () => {
 		// Initialize the editor with a Spacer and Paragraph block
-		await editorPage.setHtmlContent(
-			[ testData.spacerBlock, testData.paragraphBlockShortText ].join(
-				'\n\n'
-			)
-		);
+		await editorPage.initializeEditor( {
+			initialData: [
+				testData.spacerBlock,
+				testData.paragraphBlockShortText,
+			].join( '\n\n' ),
+		} );
 
 		// Get elements for both blocks
 		const spacerBlock = await editorPage.getBlockAtPosition(
@@ -49,16 +50,12 @@ describe( 'Gutenberg Editor Drag & Drop blocks tests', () => {
 		const firstBlockText =
 			await editorPage.getTextForParagraphBlockAtPosition( 1 );
 		expect( firstBlockText ).toMatch( testData.shortText );
-
-		// Remove the blocks
-		await spacerBlock.click();
-		await editorPage.removeBlock();
-		await editorPage.removeBlock();
 	} );
 
 	onlyOnAndroid(
 		'should be able to long-press on a text-based block to paste a text in a focused textinput',
 		async () => {
+			await editorPage.initializeEditor();
 			// Add a Paragraph block
 			await editorPage.addNewBlock( blockNames.paragraph );
 			const paragraphBlockElement =
@@ -83,15 +80,13 @@ describe( 'Gutenberg Editor Drag & Drop blocks tests', () => {
 
 			// Expect to have the pasted text in the Paragraph block
 			expect( paragraphText ).toMatch( testData.shortText );
-
-			// Remove the block
-			await editorPage.removeBlock();
 		}
 	);
 
 	onlyOnAndroid(
 		'should be able to long-press on a text-based block using the PlainText component to paste a text in a focused textinput',
 		async () => {
+			await editorPage.initializeEditor();
 			// Add a Shortcode block
 			await editorPage.addNewBlock( blockNames.shortcode );
 			const shortcodeBlockElement =
@@ -125,12 +120,12 @@ describe( 'Gutenberg Editor Drag & Drop blocks tests', () => {
 
 	it( 'should be able to drag & drop a text-based block when another textinput is focused', async () => {
 		// Initialize the editor with two Paragraph blocks
-		await editorPage.setHtmlContent(
-			[
+		await editorPage.initializeEditor( {
+			initialData: [
 				testData.paragraphBlockShortText,
 				testData.paragraphBlockEmpty,
-			].join( '\n\n' )
-		);
+			].join( '\n\n' ),
+		} );
 
 		// Tap on the second block
 		const secondParagraphBlock = await editorPage.getBlockAtPosition(

--- a/packages/react-native-editor/__device-tests__/gutenberg-editor-heading-@canary.test.js
+++ b/packages/react-native-editor/__device-tests__/gutenberg-editor-heading-@canary.test.js
@@ -6,6 +6,7 @@ import testData from './helpers/test-data';
 
 describe( 'Gutenberg Editor tests', () => {
 	it( 'should be able to create a post with heading and paragraph blocks', async () => {
+		await editorPage.initializeEditor();
 		await editorPage.addNewBlock( blockNames.heading );
 		let headingBlockElement = await editorPage.getTextBlockAtPosition(
 			blockNames.heading

--- a/packages/react-native-editor/__device-tests__/gutenberg-editor-initial-html-@canary.test.js
+++ b/packages/react-native-editor/__device-tests__/gutenberg-editor-initial-html-@canary.test.js
@@ -5,7 +5,7 @@ import initialHtml from '../src/initial-html';
 
 describe( 'Gutenberg Editor Blocks test', () => {
 	it( 'should be able to create a post with all blocks and scroll to the last one', async () => {
-		await editorPage.setHtmlContent( initialHtml );
+		await editorPage.initializeEditor( { initialData: initialHtml } );
 
 		// Scroll to the last element
 		const addBlockPlaceholder =

--- a/packages/react-native-editor/__device-tests__/gutenberg-editor-media-blocks-@canary.test.js
+++ b/packages/react-native-editor/__device-tests__/gutenberg-editor-media-blocks-@canary.test.js
@@ -9,6 +9,7 @@ const onlyOniOS = ! isAndroid() ? describe : describe.skip;
 
 describe( 'Gutenberg Editor Audio Block tests', () => {
 	it( 'should be able to add an audio block and a file to it', async () => {
+		await editorPage.initializeEditor();
 		// add an audio block
 		await editorPage.addNewBlock( blockNames.audio );
 
@@ -17,17 +18,19 @@ describe( 'Gutenberg Editor Audio Block tests', () => {
 		await editorPage.closePicker();
 
 		// verify there's an audio block
-		let block = await editorPage.getFirstBlockVisible();
-		await expect( block ).toBeTruthy();
+		const block = await editorPage.getFirstBlockVisible();
+		expect( block ).toBeTruthy();
 
 		// tap on the audio block
-		block.click();
+		await block.click();
 
 		// wait for the media picker's Media Library option to come up
 		await waitForMediaLibrary( editorPage.driver );
 
 		// tap on Media Library option
 		await editorPage.chooseMediaLibrary();
+		// wait until the media is added
+		await editorPage.driver.sleep( 500 );
 
 		// get the html version of the content
 		const html = await editorPage.getHtmlContent();
@@ -36,15 +39,12 @@ describe( 'Gutenberg Editor Audio Block tests', () => {
 		expect( html.toLowerCase() ).toBe(
 			testData.audioBlockPlaceholder.toLowerCase()
 		);
-
-		block = await editorPage.getBlockAtPosition( blockNames.audio );
-		await block.click();
-		await editorPage.removeBlock();
 	} );
 } );
 
 describe( 'Gutenberg Editor File Block tests', () => {
 	it( 'should be able to add a file block and a file to it', async () => {
+		await editorPage.initializeEditor();
 		// add a file block
 		await editorPage.addNewBlock( blockNames.file );
 
@@ -53,17 +53,19 @@ describe( 'Gutenberg Editor File Block tests', () => {
 		await editorPage.closePicker();
 
 		// verify there's a file block
-		let block = await editorPage.getFirstBlockVisible();
-		await expect( block ).toBeTruthy();
+		const block = await editorPage.getFirstBlockVisible();
+		expect( block ).toBeTruthy();
 
 		// tap on the file block
-		block.click();
+		await block.click();
 
 		// wait for the media picker's Media Library option to come up
 		await waitForMediaLibrary( editorPage.driver );
 
 		// tap on Media Library option
 		await editorPage.chooseMediaLibrary();
+		// wait until the media is added
+		await editorPage.driver.sleep( 500 );
 
 		// get the html version of the content
 		const html = await editorPage.getHtmlContent();
@@ -72,20 +74,17 @@ describe( 'Gutenberg Editor File Block tests', () => {
 		expect( html.toLowerCase() ).toBe(
 			testData.fileBlockPlaceholder.toLowerCase()
 		);
-
-		block = await editorPage.getBlockAtPosition( blockNames.file );
-		await block.click();
-		await editorPage.removeBlock();
 	} );
 } );
 
 // iOS only test - It can only add images from the media library on iOS.
 onlyOniOS( 'Gutenberg Editor Image Block tests', () => {
 	it( 'should be able to add an image block', async () => {
+		await editorPage.initializeEditor();
 		await editorPage.addNewBlock( blockNames.image );
 		await editorPage.closePicker();
 
-		let imageBlock = await editorPage.getBlockAtPosition(
+		const imageBlock = await editorPage.getBlockAtPosition(
 			blockNames.image
 		);
 
@@ -106,10 +105,6 @@ onlyOniOS( 'Gutenberg Editor Image Block tests', () => {
 		expect( html.toLowerCase() ).toBe(
 			testData.imageShortHtml.toLowerCase()
 		);
-
-		imageBlock = await editorPage.getBlockAtPosition( blockNames.image );
-		await imageBlock.click();
-		await editorPage.removeBlock();
 	} );
 } );
 
@@ -117,7 +112,9 @@ onlyOniOS( 'Gutenberg Editor Cover Block test', () => {
 	it( 'should displayed properly and have properly converted height (ios only)', async () => {
 		// Temporarily this test is skipped on Android, due to the inconsistency of the results,
 		// which are related to getting values in raw pixels instead of density pixels on Android.
-		await editorPage.setHtmlContent( testData.coverHeightWithRemUnit );
+		await editorPage.initializeEditor( {
+			initialData: testData.coverHeightWithRemUnit,
+		} );
 
 		const coverBlock = await editorPage.getBlockAtPosition(
 			blockNames.cover
@@ -131,17 +128,15 @@ onlyOniOS( 'Gutenberg Editor Cover Block test', () => {
 
 		await coverBlock.click();
 		expect( coverBlock ).toBeTruthy();
-
-		// Navigate upwards to select parent block
-		await editorPage.moveBlockSelectionUp();
-		await editorPage.removeBlock();
 	} );
 
 	// Testing this for iOS on a device is valuable to ensure that it properly
 	// handles opening multiple modals, as only one can be open at a time.
 	// NOTE: It can only add images from the media library on iOS.
 	it( 'allows modifying media from within block settings', async () => {
-		await editorPage.setHtmlContent( testData.coverHeightWithRemUnit );
+		await editorPage.initializeEditor( {
+			initialData: testData.coverHeightWithRemUnit,
+		} );
 
 		const coverBlock = await editorPage.getBlockAtPosition(
 			blockNames.cover
@@ -165,6 +160,5 @@ onlyOniOS( 'Gutenberg Editor Cover Block test', () => {
 		await editorPage.chooseMediaLibrary();
 
 		expect( coverBlock ).toBeTruthy();
-		await editorPage.removeBlock();
 	} );
 } );

--- a/packages/react-native-editor/__device-tests__/gutenberg-editor-paragraph.test.js
+++ b/packages/react-native-editor/__device-tests__/gutenberg-editor-paragraph.test.js
@@ -6,12 +6,12 @@ import {
 	backspace,
 	clickMiddleOfElement,
 	clickBeginningOfElement,
-	isAndroid,
 } from './helpers/utils';
 import testData from './helpers/test-data';
 
 describe( 'Gutenberg Editor tests for Paragraph Block', () => {
 	it( 'should be able to split one paragraph block into two', async () => {
+		await editorPage.initializeEditor();
 		await editorPage.addNewBlock( blockNames.paragraph );
 		const paragraphBlockElement = await editorPage.getTextBlockAtPosition(
 			blockNames.paragraph
@@ -34,12 +34,10 @@ describe( 'Gutenberg Editor tests for Paragraph Block', () => {
 		expect( testData.shortText ).toMatch(
 			new RegExp( `${ text0 + text1 }|${ text0 } ${ text1 }` )
 		);
-
-		await editorPage.removeBlock();
-		await editorPage.removeBlock();
 	} );
 
 	it( 'should be able to merge 2 paragraph blocks into 1', async () => {
+		await editorPage.initializeEditor();
 		await editorPage.addNewBlock( blockNames.paragraph );
 		let paragraphBlockElement = await editorPage.getTextBlockAtPosition(
 			blockNames.paragraph
@@ -78,28 +76,22 @@ describe( 'Gutenberg Editor tests for Paragraph Block', () => {
 		);
 		await paragraphBlockElement.click();
 		expect( await editorPage.getNumberOfParagraphBlocks() ).toEqual( 1 );
-		await editorPage.removeBlock();
 	} );
 
 	it( 'should be able to create a post with multiple paragraph blocks', async () => {
+		await editorPage.initializeEditor();
 		await editorPage.addNewBlock( blockNames.paragraph );
 		await editorPage.sendTextToParagraphBlock( 1, testData.longText );
-
-		for ( let i = 3; i > 0; i-- ) {
-			const paragraphBlockElement =
-				await editorPage.getTextBlockAtPosition( blockNames.paragraph );
-			await paragraphBlockElement.click();
-			await editorPage.removeBlock();
-		}
+		expect( await editorPage.getNumberOfParagraphBlocks() ).toEqual( 3 );
 	} );
 
 	it( 'should be able to merge blocks with unknown html elements', async () => {
-		await editorPage.setHtmlContent(
-			[
+		await editorPage.initializeEditor( {
+			initialData: [
 				testData.unknownElementParagraphBlock,
 				testData.lettersInParagraphBlock,
-			].join( '\n\n' )
-		);
+			].join( '\n\n' ),
+		} );
 
 		// Merge paragraphs.
 		const paragraphBlockElement = await editorPage.getTextBlockAtPosition(
@@ -123,18 +115,16 @@ describe( 'Gutenberg Editor tests for Paragraph Block', () => {
 		const mergedBlockText =
 			await editorPage.getTextForParagraphBlockAtPosition( 1 );
 		expect( text0 + text1 ).toMatch( mergedBlockText );
-
-		await editorPage.removeBlock();
 	} );
 
 	// Based on https://github.com/wordpress-mobile/gutenberg-mobile/pull/1507
 	it( 'should handle multiline paragraphs from web', async () => {
-		await editorPage.setHtmlContent(
-			[
+		await editorPage.initializeEditor( {
+			initialData: [
 				testData.multiLinesParagraphBlock,
 				testData.paragraphBlockEmpty,
-			].join( '\n\n' )
-		);
+			].join( '\n\n' ),
+		} );
 
 		// Merge paragraphs.
 		const paragraphBlockElement = await editorPage.getTextBlockAtPosition(
@@ -149,10 +139,5 @@ describe( 'Gutenberg Editor tests for Paragraph Block', () => {
 		// Verify the editor has not crashed.
 		const text = await editorPage.getTextForParagraphBlockAtPosition( 1 );
 		expect( text.length ).not.toEqual( 0 );
-
-		if ( isAndroid() ) {
-			await paragraphBlockElement.click();
-		}
-		await editorPage.removeBlock();
 	} );
 } );

--- a/packages/react-native-editor/__device-tests__/gutenberg-editor-rendering-media-blocks.test.js
+++ b/packages/react-native-editor/__device-tests__/gutenberg-editor-rendering-media-blocks.test.js
@@ -5,7 +5,7 @@ import { mediaBlocks } from '../src/initial-html';
 
 describe( 'Gutenberg Editor Rendering Media Blocks test', () => {
 	it( 'should be able to render blocks correctly', async () => {
-		await editorPage.setHtmlContent( mediaBlocks );
+		await editorPage.initializeEditor( { initialData: mediaBlocks } );
 
 		// Give some time to media placeholders to render.
 		await editorPage.driver.sleep( 3000 );

--- a/packages/react-native-editor/__device-tests__/gutenberg-editor-rendering-other-blocks.test.js
+++ b/packages/react-native-editor/__device-tests__/gutenberg-editor-rendering-other-blocks.test.js
@@ -5,7 +5,7 @@ import { otherBlocks } from '../src/initial-html';
 
 describe( 'Gutenberg Editor Rendering Other Blocks test', () => {
 	it( 'should be able to render blocks correctly', async () => {
-		await editorPage.setHtmlContent( otherBlocks );
+		await editorPage.initializeEditor( { initialData: otherBlocks } );
 
 		// Scroll to the last element.
 		const addBlockPlaceholder =

--- a/packages/react-native-editor/__device-tests__/gutenberg-editor-rendering-text-blocks.test.js
+++ b/packages/react-native-editor/__device-tests__/gutenberg-editor-rendering-text-blocks.test.js
@@ -5,7 +5,7 @@ import { textBlocks } from '../src/initial-html';
 
 describe( 'Gutenberg Editor Rendering Text Blocks test', () => {
 	it( 'should be able to render blocks correctly', async () => {
-		await editorPage.setHtmlContent( textBlocks );
+		await editorPage.initializeEditor( { initialData: textBlocks } );
 
 		// Scroll to the last element
 		const addBlockPlaceholder =

--- a/packages/react-native-editor/__device-tests__/gutenberg-editor-search.test.js
+++ b/packages/react-native-editor/__device-tests__/gutenberg-editor-search.test.js
@@ -14,25 +14,30 @@ const testIds = {
 const searchBlockHtml = `<!-- wp:search {"label":"","buttonText":""} /-->`;
 
 describe( 'Gutenberg Editor Search Block tests.', () => {
+	it( 'Able to add the Search Block.', async () => {
+		await editorPage.initializeEditor();
+		await editorPage.addNewBlock( blockNames.search );
+		const searchBlock = await editorPage.getBlockAtPosition(
+			blockNames.search
+		);
+		expect( searchBlock ).toBeTruthy();
+	} );
+
 	describe( 'Editing Search Block elements.', () => {
-		beforeAll( async () => {
+		beforeEach( async () => {
 			// Add a search block with all child elements having no text.
 			// This is important to get around test flakiness where sometimes
 			// the existing default text isn't replaced properly when entering
 			// new text during testing.
-			await editorPage.setHtmlContent( searchBlockHtml );
-		} );
+			await editorPage.initializeEditor( {
+				initialData: searchBlockHtml,
+			} );
 
-		beforeEach( async () => {
 			// Tap search block to ensure selected.
 			const searchBlock = await editorPage.getBlockAtPosition(
 				blockNames.search
 			);
 			await searchBlock.click();
-		} );
-
-		afterAll( async () => {
-			await removeSearchBlock();
 		} );
 
 		it( 'Able to customize label text', async () => {
@@ -73,17 +78,10 @@ describe( 'Gutenberg Editor Search Block tests.', () => {
 	} );
 
 	describe( 'Changing search block settings.', () => {
-		afterAll( async () => {
-			await removeSearchBlock();
-		} );
-
-		it( 'Able to add the Search Block.', async () => {
-			await editorPage.addNewBlock( blockNames.search );
-			const searchBlock = await editorPage.getBlockAtPosition(
-				blockNames.search
-			);
-
-			expect( searchBlock ).toBeTruthy();
+		beforeEach( async () => {
+			await editorPage.initializeEditor( {
+				initialData: searchBlockHtml,
+			} );
 		} );
 
 		it( 'Able to hide search block label', async () => {
@@ -147,16 +145,6 @@ describe( 'Gutenberg Editor Search Block tests.', () => {
 		} );
 	} );
 } );
-
-const removeSearchBlock = async () => {
-	const searchBlock = await editorPage.getBlockAtPosition(
-		blockNames.search
-	);
-	await searchBlock.click();
-
-	// Remove search block.
-	await editorPage.removeBlock();
-};
 
 const verifySearchElementText = async ( testId, expected ) => {
 	let actual;

--- a/packages/react-native-editor/__device-tests__/helpers/caps.js
+++ b/packages/react-native-editor/__device-tests__/helpers/caps.js
@@ -9,6 +9,7 @@ const ios = {
 	processArguments: {
 		args: [ 'uitesting' ],
 	},
+	autoLaunch: false,
 };
 
 exports.iosLocal = ( { iPadDevice = false } ) => ( {
@@ -39,4 +40,5 @@ exports.android = {
 	appiumVersion: '1.22.1',
 	app: undefined,
 	disableWindowAnimation: true,
+	autoLaunch: false,
 };

--- a/packages/react-native-editor/__device-tests__/helpers/utils.js
+++ b/packages/react-native-editor/__device-tests__/helpers/utils.js
@@ -41,6 +41,9 @@ const backspace = '\u0008';
 // $block-edge-to-content value
 const blockEdgeToContent = 16;
 
+const IOS_BUNDLE_ID = 'org.wordpress.gutenberg.development';
+const ANDROID_COMPONENT_NAME = 'com.gutenberg/.MainActivity';
+
 const timer = ( ms ) => new Promise( ( res ) => setTimeout( res, ms ) );
 
 const isAndroid = () => {
@@ -750,6 +753,30 @@ const clearClipboard = async ( driver, contentType = 'plaintext' ) => {
 	await driver.setClipboard( '', contentType );
 };
 
+const launchApp = async ( driver, initialProps = {} ) => {
+	if ( isAndroid() ) {
+		await driver.execute( 'mobile: startActivity', {
+			component: ANDROID_COMPONENT_NAME,
+			stop: true,
+			extras: [
+				[
+					's',
+					'initialProps',
+					`'${ JSON.stringify( initialProps ) }'`,
+				],
+			],
+		} );
+	} else {
+		await driver.execute( 'mobile: terminateApp', {
+			bundleId: IOS_BUNDLE_ID,
+		} );
+		await driver.execute( 'mobile: launchApp', {
+			bundleId: IOS_BUNDLE_ID,
+			arguments: [ 'uitesting', JSON.stringify( initialProps ) ],
+		} );
+	}
+};
+
 module.exports = {
 	backspace,
 	clearClipboard,
@@ -763,10 +790,11 @@ module.exports = {
 	isEditorVisible,
 	isElementVisible,
 	isLocalEnvironment,
+	launchApp,
 	longPressMiddleOfElement,
+	selectTextFromElement,
 	setClipboard,
 	setupDriver,
-	selectTextFromElement,
 	stopDriver,
 	swipeDown,
 	swipeFromTo,

--- a/packages/react-native-editor/__device-tests__/pages/editor-page.js
+++ b/packages/react-native-editor/__device-tests__/pages/editor-page.js
@@ -22,27 +22,14 @@ const {
 	typeString,
 	waitForVisible,
 	clickIfClickable,
+	launchApp,
 } = require( '../helpers/utils' );
 
 const ADD_BLOCK_ID = isAndroid() ? 'Add block' : 'add-block-button';
 
-const initializeEditorPage = async () => {
+const setupEditor = async () => {
 	const driver = await setupDriver();
-	await isEditorVisible( driver );
-	const initialValues = await setupInitialValues( driver );
-	return new EditorPage( driver, initialValues );
-};
-
-// Stores initial values from the editor for different helpers.
-const setupInitialValues = async ( driver ) => {
-	const initialValues = {};
-	const addButton = await driver.elementsByAccessibilityId( ADD_BLOCK_ID );
-
-	if ( addButton.length !== 0 ) {
-		initialValues.addButtonLocation = await addButton[ 0 ].getLocation();
-	}
-
-	return initialValues;
+	return new EditorPage( driver );
 };
 
 class EditorPage {
@@ -53,16 +40,33 @@ class EditorPage {
 	verseBlockName = 'Verse';
 	orderedListButtonName = 'Ordered';
 
-	constructor( driver, initialValues ) {
+	constructor( driver ) {
 		this.driver = driver;
 		this.accessibilityIdKey = 'name';
 		this.accessibilityIdXPathAttrib = 'name';
-		this.initialValues = initialValues;
+		this.initialValues = {};
+		this.blockNames = blockNames;
 
 		if ( isAndroid() ) {
 			this.accessibilityIdXPathAttrib = 'content-desc';
 			this.accessibilityIdKey = 'contentDescription';
 		}
+	}
+
+	async initializeEditor( { initialData } = {} ) {
+		await launchApp( this.driver, { initialData } );
+
+		// Stores initial values from the editor for different helpers.
+		const addButton = await this.driver.elementsByAccessibilityId(
+			ADD_BLOCK_ID
+		);
+
+		if ( addButton.length !== 0 ) {
+			this.initialValues.addButtonLocation =
+				await addButton[ 0 ].getLocation();
+		}
+
+		await isEditorVisible( this.driver );
 	}
 
 	async getBlockList() {
@@ -1036,4 +1040,4 @@ const blockNames = {
 	unsupported: 'Unsupported',
 };
 
-module.exports = { initializeEditorPage, blockNames };
+module.exports = { setupEditor, blockNames };

--- a/packages/react-native-editor/__device-tests__/pages/editor-page.js
+++ b/packages/react-native-editor/__device-tests__/pages/editor-page.js
@@ -433,15 +433,7 @@ class EditorPage {
 		// Click on block of choice.
 		const blockButton = await this.findBlockButton( blockName );
 
-		if ( isAndroid() ) {
-			await blockButton.click();
-		} else {
-			await this.driver.execute( 'mobile: tap', {
-				element: blockButton,
-				x: 10,
-				y: 10,
-			} );
-		}
+		await blockButton.click();
 	}
 
 	static getInserterPageHeight( screenHeight ) {
@@ -530,6 +522,8 @@ class EditorPage {
 				toY: EditorPage.getInserterPageHeight( height ),
 				duration: 0.5,
 			} );
+			// Wait for dragging gesture
+			await this.driver.sleep( 2000 );
 		}
 
 		return blockButton;

--- a/packages/react-native-editor/android/app/src/main/java/com/gutenberg/MainActivity.java
+++ b/packages/react-native-editor/android/app/src/main/java/com/gutenberg/MainActivity.java
@@ -1,6 +1,7 @@
 package com.gutenberg;
 
 import android.os.Bundle;
+import android.util.Log;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
@@ -14,6 +15,8 @@ import com.facebook.react.ReactActivity;
 import com.facebook.react.ReactInstanceManager;
 import com.facebook.react.ReactRootView;
 
+import org.json.JSONException;
+import org.json.JSONObject;
 import org.wordpress.mobile.WPAndroidGlue.GutenbergProps;
 
 import java.util.Locale;
@@ -23,6 +26,8 @@ public class MainActivity extends ReactActivity {
 
     private ReactRootView mReactRootView;
     private Menu mMenu;
+
+    private static final String EXTRAS_INITIAL_PROPS = "initialProps";
 
     private void openReactNativeDebugMenu() {
         ReactInstanceManager devSettingsModule = getReactInstanceManager();
@@ -160,6 +165,21 @@ public class MainActivity extends ReactActivity {
     private Bundle getAppOptions() {
         Bundle bundle = new Bundle();
 
+        // Parse initial props from launch arguments
+        String initialData = null;
+        Bundle extrasBundle = getIntent().getExtras();
+        if(extrasBundle != null) {
+            String initialProps = extrasBundle.getString(EXTRAS_INITIAL_PROPS, "{}");
+            try {
+                JSONObject jsonObject = new JSONObject(initialProps);
+                if (jsonObject.has(GutenbergProps.PROP_INITIAL_DATA)) {
+                    initialData = jsonObject.getString(GutenbergProps.PROP_INITIAL_DATA);
+                }
+            } catch (final JSONException e) {
+                Log.e("MainActivity", "Json parsing error: " + e.getMessage());
+            }
+        }
+
         // Add locale
         String languageString = Locale.getDefault().toString();
         String localeSlug = languageString.replace("_", "-").toLowerCase(Locale.ENGLISH);
@@ -179,6 +199,11 @@ public class MainActivity extends ReactActivity {
         capabilities.putBoolean(GutenbergProps.PROP_CAPABILITIES_LOOM_EMBED_BLOCK, true);
         capabilities.putBoolean(GutenbergProps.PROP_CAPABILITIES_SMARTFRAME_EMBED_BLOCK, true);
         bundle.putBundle(GutenbergProps.PROP_CAPABILITIES, capabilities);
+
+        if(initialData != null) {
+            bundle.putString(GutenbergProps.PROP_INITIAL_DATA, initialData);
+        }
+
         return bundle;
     }
 }

--- a/packages/react-native-editor/ios/GutenbergDemo/GutenbergViewController.swift
+++ b/packages/react-native-editor/ios/GutenbergDemo/GutenbergViewController.swift
@@ -377,7 +377,10 @@ extension GutenbergViewController: GutenbergBridgeDataSource {
     }
 
     func gutenbergInitialContent() -> String? {
-        return nil
+        guard isUITesting(), let initialProps = getInitialPropsFromArgs() else {
+            return nil
+        }
+        return initialProps["initialData"]
     }
 
     func gutenbergInitialTitle() -> String? {
@@ -421,6 +424,29 @@ extension GutenbergViewController: GutenbergBridgeDataSource {
 
     func gutenbergMediaSources() -> [Gutenberg.MediaSource] {
         return [.filesApp, .otherApps]
+    }
+    
+    private func isUITesting() -> Bool {
+        guard ProcessInfo.processInfo.arguments.count >= 2 else {
+            return false
+        }
+        return ProcessInfo.processInfo.arguments[1] == "uitesting"
+    }
+    
+    private func getInitialPropsFromArgs() -> [String:String]? {
+        guard ProcessInfo.processInfo.arguments.count >= 3 else {
+            return nil
+        }
+        let initialProps = ProcessInfo.processInfo.arguments[2]
+        
+        if let data = initialProps.data(using: .utf8) {
+            do {
+                return try JSONSerialization.jsonObject(with: data, options: []) as? [String: String]
+            } catch {
+                print(error.localizedDescription)
+            }
+        }
+        return nil
     }
 }
 

--- a/packages/react-native-editor/jest_ui_test_environment.js
+++ b/packages/react-native-editor/jest_ui_test_environment.js
@@ -1,10 +1,7 @@
 /**
  * Internal dependencies
  */
-const {
-	initializeEditorPage,
-	blockNames,
-} = require( './__device-tests__/pages/editor-page' );
+const { setupEditor } = require( './__device-tests__/pages/editor-page' );
 const utils = require( './__device-tests__/helpers/utils' );
 const testData = require( './__device-tests__/helpers/test-data' );
 
@@ -18,8 +15,7 @@ class CustomEnvironment extends JSDOMEnvironment {
 	async setup() {
 		try {
 			await super.setup();
-			this.global.editorPage = await initializeEditorPage();
-			this.global.editorPage.blockNames = blockNames;
+			this.global.editorPage = await setupEditor();
 			this.global.e2eUtils = utils;
 			this.global.e2eTestData = testData;
 		} catch ( error ) {


### PR DESCRIPTION
**Related PRs:**
* https://github.com/wordpress-mobile/gutenberg-mobile/pull/6044

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Replaces the mechanism to set the initial HTML for E2E tests. Now, instead of switching to the HTML mode and pasting the content, we pass the initial HTML when starting the app.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

This change introduces the following improvements to the E2E test environment:
1. Reduce the time to run E2E tests, as it's faster to restart the app than go through the actions to paste HTML within the editor.
2. Improve the flakiness of E2E tests, as every test will start the editor from a clean state.
3. E2E tests no longer need to clean the editor content before finishing, this will simplify the test logic and reduce testing time.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
* The `editor-page` E2E util has been refactored to prevent starting the app when setting up tests. It now only set up the driver to communicate with Appium. The app is now initiated when calling `editorPage.initializeEditor` and accepts an argument to pass initial props to the editor like the post's content HTML.
* The demo app has been updated to fetch and process the arguments passed when launching the app. Although the argument is named `initialProps`, I only implemented the `initialData` property which is used to set the initial HTML in the editor. In the future, we could expand this and accept other initial props.
* All E2E tests have been updated to use the `initializeEditor` helper. Those that were using `setHtmlContent` are now initializing the editor passing the HTML. Additionally, the clean-up logic of the tests has been removed.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
* Observe that mobile E2E tests pass in this PR.
* Observe that mobile E2E tests pass in the [Gutenberg Mobile PR](https://github.com/wordpress-mobile/gutenberg-mobile/pull/6044).

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
N/A

## Screenshots or screencast <!-- if applicable -->
N/A