### PR TITLE
Image: Clear aspect ratio when wide aligned

### DIFF
--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -326,7 +326,7 @@ export default function Image( {
 
 	function updateAlignment( nextAlign ) {
 		const extraUpdatedAttributes = [ 'wide', 'full' ].includes( nextAlign )
-			? { width: undefined, height: undefined }
+			? { width: undefined, height: undefined, aspectRatio: undefined }
 			: {};
 		setAttributes( {
 			...extraUpdatedAttributes,

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -326,7 +326,12 @@ export default function Image( {
 
 	function updateAlignment( nextAlign ) {
 		const extraUpdatedAttributes = [ 'wide', 'full' ].includes( nextAlign )
-			? { width: undefined, height: undefined, aspectRatio: undefined }
+			? {
+					width: undefined,
+					height: undefined,
+					aspectRatio: undefined,
+					scale: undefined,
+			  }
 			: {};
 		setAttributes( {
 			...extraUpdatedAttributes,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Clear aspect ratio when setting wide or full alignments.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

In #53181 we hid the dimensions controls for wide and full images since the interaction between them needs some work. We should also clear the aspect ratio when switching for consistency.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Clear aspect ratio when setting wide or full alignments.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Open image block.
2. Set aspect ratio.
3. Set wide or full align.
4. See that aspect ratio is cleared from the block attributes.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
