### PR TITLE
Fix image stretching with only height

### DIFF
--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -485,15 +485,27 @@ export default function Image( {
 					{ isResizable && (
 						<DimensionsTool
 							value={ { width, height, scale, aspectRatio } }
-							onChange={ ( newValue ) => {
+							onChange={ ( {
+								width: newWidth,
+								height: newHeight,
+								scale: newScale,
+								aspectRatio: newAspectRatio,
+							} ) => {
 								// Rebuilding the object forces setting `undefined`
 								// for values that are removed since setAttributes
 								// doesn't do anything with keys that aren't set.
 								setAttributes( {
-									width: newValue.width,
-									height: newValue.height,
-									scale: newValue.scale,
-									aspectRatio: newValue.aspectRatio,
+									// CSS includes `height: auto`, but we need
+									// `width: auto` to fix the aspect ratio when
+									// only height is set due to the width and
+									// height attributes set via the server.
+									width:
+										! newWidth && newHeight
+											? 'auto'
+											: newWidth,
+									height: newHeight,
+									scale: newScale,
+									aspectRatio: newAspectRatio,
 								} );
 							} }
 							defaultScale="cover"

--- a/packages/block-library/src/image/style.scss
+++ b/packages/block-library/src/image/style.scss
@@ -1,7 +1,6 @@
 .wp-block-image {
 	img {
 		height: auto;
-		width: auto;
 		max-width: 100%;
 		vertical-align: bottom;
 		box-sizing: border-box;

--- a/packages/block-library/src/image/style.scss
+++ b/packages/block-library/src/image/style.scss
@@ -1,6 +1,7 @@
 .wp-block-image {
 	img {
 		height: auto;
+		width: auto;
 		max-width: 100%;
 		vertical-align: bottom;
 		box-sizing: border-box;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fix image scaling with only height set.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Images with only a height set can become stretched because the server adds width and height attributes to all images.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Add `width: auto` to the image so it scales correctly.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

![demo image](https://github.com/WordPress/gutenberg/assets/5129775/282e31f8-3e5d-4640-ba49-69fb0c4c5e3a)

```html
<!-- wp:image {"id":443,"height":"150px","sizeSlug":"full","linkDestination":"none","className":"is-resized"} -->
<figure class="wp-block-image size-full is-resized"><img src="http://wp.local/wp-content/uploads/2023/06/a2-small.jpg" alt="" class="wp-image-443" style="height:150px"/></figure>
<!-- /wp:image -->
```

1. Insert the image linked above.
2. Set height to 150px.
3. View preview.
4. See that the image is not stretched.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

### Before

![Screen Shot 2023-08-08 at 13 45 00](https://github.com/WordPress/gutenberg/assets/5129775/3c92071a-f83d-4eea-af70-354a585b5cce)

### After

![Screen Shot 2023-08-08 at 13 45 08](https://github.com/WordPress/gutenberg/assets/5129775/8ae7a60a-fa77-4ee6-9255-4b9224861116)
