### PR TITLE
[WIP] List View: Initial attempt at resizable list view sidebar

### DIFF
--- a/packages/edit-post/src/components/secondary-sidebar/list-view-sidebar.js
+++ b/packages/edit-post/src/components/secondary-sidebar/list-view-sidebar.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __experimentalListView as ListView } from '@wordpress/block-editor';
-import { Button, TabPanel } from '@wordpress/components';
+import { Button, TabPanel, ResizableBox } from '@wordpress/components';
 import {
 	useFocusOnMount,
 	useFocusReturn,
@@ -119,46 +119,59 @@ export default function ListViewSidebar() {
 	}
 
 	return (
-		// eslint-disable-next-line jsx-a11y/no-static-element-interactions
-		<div
-			className="edit-post-editor__document-overview-panel"
-			onKeyDown={ closeOnEscape }
-			ref={ sidebarRef }
+		<ResizableBox
+			className="edit-post-editor__document-overview-panel__resizable-box"
+			enable={ {
+				top: false,
+				right: true, // TODO: update with an isRTL check.
+				bottom: false,
+				left: false, // TODO: update with a ! isRTL check.
+			} }
+			minWidth={ 350 }
+			maxWidth={ 700 }
+			showHandle={ true }
 		>
-			<Button
-				className="edit-post-editor__document-overview-panel__close-button"
-				ref={ headerFocusReturnRef }
-				icon={ closeSmall }
-				label={ __( 'Close' ) }
-				onClick={ () => setIsListViewOpened( false ) }
-			/>
-			<TabPanel
-				className="edit-post-editor__document-overview-panel__tab-panel"
-				ref={ tabPanelRef }
-				onSelect={ ( tabName ) => setTab( tabName ) }
-				selectOnMove={ false }
-				tabs={ [
-					{
-						name: 'list-view',
-						title: _x( 'List View', 'Post overview' ),
-						className: 'edit-post-sidebar__panel-tab',
-					},
-					{
-						name: 'outline',
-						title: _x( 'Outline', 'Post overview' ),
-						className: 'edit-post-sidebar__panel-tab',
-					},
-				] }
+			{ /* eslint-disable-next-line jsx-a11y/no-static-element-interactions */ }
+			<div
+				className="edit-post-editor__document-overview-panel"
+				onKeyDown={ closeOnEscape }
+				ref={ sidebarRef }
 			>
-				{ ( currentTab ) => (
-					<div
-						className="edit-post-editor__list-view-container"
-						ref={ listViewContainerRef }
-					>
-						{ renderTabContent( currentTab.name ) }
-					</div>
-				) }
-			</TabPanel>
-		</div>
+				<Button
+					className="edit-post-editor__document-overview-panel__close-button"
+					ref={ headerFocusReturnRef }
+					icon={ closeSmall }
+					label={ __( 'Close' ) }
+					onClick={ () => setIsListViewOpened( false ) }
+				/>
+				<TabPanel
+					className="edit-post-editor__document-overview-panel__tab-panel"
+					ref={ tabPanelRef }
+					onSelect={ ( tabName ) => setTab( tabName ) }
+					selectOnMove={ false }
+					tabs={ [
+						{
+							name: 'list-view',
+							title: _x( 'List View', 'Post overview' ),
+							className: 'edit-post-sidebar__panel-tab',
+						},
+						{
+							name: 'outline',
+							title: _x( 'Outline', 'Post overview' ),
+							className: 'edit-post-sidebar__panel-tab',
+						},
+					] }
+				>
+					{ ( currentTab ) => (
+						<div
+							className="edit-post-editor__list-view-container"
+							ref={ listViewContainerRef }
+						>
+							{ renderTabContent( currentTab.name ) }
+						</div>
+					) }
+				</TabPanel>
+			</div>
+		</ResizableBox>
 	);
 }

--- a/packages/edit-post/src/components/secondary-sidebar/style.scss
+++ b/packages/edit-post/src/components/secondary-sidebar/style.scss
@@ -10,12 +10,15 @@
 	flex-direction: column;
 }
 
-.edit-post-editor__document-overview-panel {
+.edit-post-editor__document-overview-panel__resizable-box {
 	@include break-medium() {
 		// Same width as the Inserter.
 		// @see packages/block-editor/src/components/inserter/style.scss
 		width: 350px;
 	}
+}
+
+.edit-post-editor__document-overview-panel {
 
 	.edit-post-editor__document-overview-panel__close-button {
 		position: absolute;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

🚧 🚧 🚧 🚧 This is an early exploration into https://github.com/WordPress/gutenberg/issues/53096 and is not ready for testing yet 🚧 🚧 🚧 🚧 🚧

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

For deeply nested list views, it could be useful for a user to be able to quickly drag the the list view to be wider or narrower, as desired.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

TBC, but mostly via wrapping the list view in a `ResizableBox`

## To-do

* [ ] Switch off on mobile view / narrower viewports
* [ ] Ensure it's the height of the whole list view area
* [ ] Make handle `isRTL` aware
* [ ] Save the value a user used when they close the list view, at least before the user navigates away
* [ ] Borrow logic from the site editor's `ResizableFrame` so that the handle only displays when hovering over it
* [ ] Also, borrow logic to ensure that the resizing is keyboard accessible
* [ ] Should we attempt the store the width in a preference so that it can persist past page reloads?
* [ ] Settle on good max / min values
* [ ] Implement in the site editor, too

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

TBC

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

An early exploration of how it might feel to use:

https://github.com/WordPress/gutenberg/assets/14988353/7894051b-c742-4ff2-b088-7dc41a2f8b11