### PR TITLE
Paste: fix internal inline paste

### DIFF
--- a/packages/blocks/src/api/raw-handling/paste-handler.js
+++ b/packages/blocks/src/api/raw-handling/paste-handler.js
@@ -70,12 +70,25 @@ function filterInlineHTML( HTML, preserveWhiteSpace ) {
  * block, and the original plain text content does not have any line breaks,
  * then treat it as inline paste.
  *
- * @param {Object} options
- * @param {Array}  options.blocks
- * @param {string} options.plainText
- * @param {string} options.mode
+ * @param {Object}  options
+ * @param {Array}   options.blocks
+ * @param {string}  options.plainText
+ * @param {string}  options.mode
+ * @param {boolean} options.preserveWhiteSpace
  */
-function maybeConvertToInline( { blocks, plainText, mode } ) {
+function maybeConvertToInline( {
+	blocks,
+	plainText,
+	mode,
+	preserveWhiteSpace,
+} ) {
+	if ( mode === 'INLINE' ) {
+		// To do: this filter is a bit too agressive for internal paste, it
+		// will remove highlights for example. We should try to remove only
+		// block level elements.
+		return filterInlineHTML( plainText, preserveWhiteSpace );
+	}
+
 	if (
 		mode === 'AUTO' &&
 		blocks.length === 1 &&
@@ -161,6 +174,7 @@ export function pasteHandler( {
 			blocks: htmlToBlocks( normaliseBlocks( HTML ), pasteHandler ),
 			plainText,
 			mode,
+			preserveWhiteSpace,
 		} );
 	}
 

--- a/packages/blocks/src/api/raw-handling/paste-handler.js
+++ b/packages/blocks/src/api/raw-handling/paste-handler.js
@@ -70,25 +70,12 @@ function filterInlineHTML( HTML, preserveWhiteSpace ) {
  * block, and the original plain text content does not have any line breaks,
  * then treat it as inline paste.
  *
- * @param {Object}  options
- * @param {Array}   options.blocks
- * @param {string}  options.plainText
- * @param {string}  options.mode
- * @param {boolean} options.preserveWhiteSpace
+ * @param {Object} options
+ * @param {Array}  options.blocks
+ * @param {string} options.plainText
+ * @param {string} options.mode
  */
-function maybeConvertToInline( {
-	blocks,
-	plainText,
-	mode,
-	preserveWhiteSpace,
-} ) {
-	if ( mode === 'INLINE' ) {
-		// To do: this filter is a bit too agressive for internal paste, it
-		// will remove highlights for example. We should try to remove only
-		// block level elements.
-		return filterInlineHTML( plainText, preserveWhiteSpace );
-	}
-
+function maybeConvertToInline( { blocks, plainText, mode } ) {
 	if (
 		mode === 'AUTO' &&
 		blocks.length === 1 &&
@@ -169,12 +156,18 @@ export function pasteHandler( {
 		HTML = HTML.normalize();
 	}
 
+	if ( mode === 'INLINE' ) {
+		// To do: this filter is a bit too agressive for internal paste, it
+		// will remove highlights for example. We should try to remove only
+		// block level elements.
+		return filterInlineHTML( HTML, preserveWhiteSpace );
+	}
+
 	if ( disableFilters ) {
 		return maybeConvertToInline( {
 			blocks: htmlToBlocks( normaliseBlocks( HTML ), pasteHandler ),
 			plainText,
 			mode,
-			preserveWhiteSpace,
 		} );
 	}
 

--- a/test/e2e/specs/editor/various/copy-cut-paste.spec.js
+++ b/test/e2e/specs/editor/various/copy-cut-paste.spec.js
@@ -460,4 +460,32 @@ test.describe( 'Copy/cut/paste', () => {
 		await page.keyboard.type( 'y' );
 		expect( await editor.getEditedPostContent() ).toMatchSnapshot();
 	} );
+
+	test( 'should convert internal paste to inline', async ( {
+		page,
+		pageUtils,
+		editor,
+	} ) => {
+		await editor.canvas.click( 'role=button[name="Add default block"i]' );
+		await page.keyboard.type( 'ab' );
+		await pageUtils.pressKeys( 'shift+ArrowLeft' );
+		await pageUtils.pressKeys( 'primary+c' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( '> ' );
+		// Select cite.
+		await page.keyboard.press( 'ArrowDown' );
+		await pageUtils.pressKeys( 'primary+v' );
+		// Ensure the selection is correct.
+		await page.keyboard.type( '‸' );
+		expect( await editor.getBlocks() ).toMatchObject( [
+			{
+				name: 'core/paragraph',
+				attributes: { content: 'a' },
+			},
+			{
+				name: 'core/quote',
+				attributes: { citation: 'b‸' },
+			},
+		] );
+	} );
 } );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Fixes #53422. This is a regression caused by https://github.com/WordPress/gutenberg/pull/48254.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Restores the codepath for mode=INLINE

## Testing Instructions

copy a paragraph and paste it in a quote citation or image caption

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
