### PR TITLE
Interface: Fix ESLint warnings

### DIFF
--- a/packages/interface/src/components/complementary-area-toggle/index.js
+++ b/packages/interface/src/components/complementary-area-toggle/index.js
@@ -24,7 +24,7 @@ function ComplementaryAreaToggle( {
 		( select ) =>
 			select( interfaceStore ).getActiveComplementaryArea( scope ) ===
 			identifier,
-		[ identifier ]
+		[ identifier, scope ]
 	);
 	const { enableComplementaryArea, disableComplementaryArea } =
 		useDispatch( interfaceStore );

--- a/packages/interface/src/components/complementary-area/index.js
+++ b/packages/interface/src/components/complementary-area/index.js
@@ -79,7 +79,15 @@ function useAdjustComplementaryListener(
 		if ( isSmall !== previousIsSmall.current ) {
 			previousIsSmall.current = isSmall;
 		}
-	}, [ isActive, isSmall, scope, identifier, activeArea ] );
+	}, [
+		isActive,
+		isSmall,
+		scope,
+		identifier,
+		activeArea,
+		disableComplementaryArea,
+		enableComplementaryArea,
+	] );
 }
 
 function ComplementaryArea( {
@@ -145,7 +153,15 @@ function ComplementaryArea( {
 		} else if ( activeArea === undefined && isSmall ) {
 			disableComplementaryArea( scope, identifier );
 		}
-	}, [ activeArea, isActiveByDefault, scope, identifier, isSmall ] );
+	}, [
+		activeArea,
+		isActiveByDefault,
+		scope,
+		identifier,
+		isSmall,
+		enableComplementaryArea,
+		disableComplementaryArea,
+	] );
 
 	return (
 		<>

--- a/packages/interface/src/components/more-menu-feature-toggle/index.js
+++ b/packages/interface/src/components/more-menu-feature-toggle/index.js
@@ -24,7 +24,7 @@ export default function MoreMenuFeatureToggle( {
 	const isActive = useSelect(
 		( select ) =>
 			select( interfaceStore ).isFeatureActive( scope, feature ),
-		[ feature ]
+		[ feature, scope ]
 	);
 	const { toggleFeature } = useDispatch( interfaceStore );
 	const speakMessage = () => {


### PR DESCRIPTION
## What?
PR fixes ESlint warnings in the `interface` package.

## Why?
I'm working on a different PR to replace `withPluginContext` HoC usage in the package with the `usePluginContext` hook and decided to extract these code quality changes.

## Testing Instructions
CI checks should be green.

```
npm run lint:js -- packages/interface/src
```

