### PR TITLE
Implement accessible version of Navigation overlay preview toggle control

### DIFF
--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -43,6 +43,7 @@ import {
 import { __, sprintf } from '@wordpress/i18n';
 import { speak } from '@wordpress/a11y';
 import { close, Icon } from '@wordpress/icons';
+import { useInstanceId } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -500,6 +501,11 @@ function Navigation( {
 		isFirstRender.current = false;
 	}, [ submenuAccessibilityNotice ] );
 
+	const overlayMenuPreviewId = useInstanceId(
+		OverlayMenuPreview,
+		`overlay-menu-preview`
+	);
+
 	const colorGradientSettings = useMultipleOriginColorsAndGradients();
 	const stylingInspectorControls = (
 		<>
@@ -515,6 +521,11 @@ function Navigation( {
 											! overlayMenuPreview
 										);
 									} }
+									aria-label={ __(
+										'Toggle overlay menu controls'
+									) }
+									aria-controls={ overlayMenuPreviewId }
+									aria-expanded={ overlayMenuPreview }
 								>
 									{ hasIcon && (
 										<>
@@ -529,13 +540,17 @@ function Navigation( {
 										</>
 									) }
 								</Button>
-								{ overlayMenuPreview && (
-									<OverlayMenuPreview
-										setAttributes={ setAttributes }
-										hasIcon={ hasIcon }
-										icon={ icon }
-									/>
-								) }
+								<div id={ overlayMenuPreviewId }>
+									{ overlayMenuPreview && (
+										<OverlayMenuPreview
+											id={ overlayMenuPreviewId }
+											setAttributes={ setAttributes }
+											hasIcon={ hasIcon }
+											icon={ icon }
+											hidden={ ! overlayMenuPreview }
+										/>
+									) }
+								</div>
 							</>
 						) }
 						<h3>{ __( 'Overlay Menu' ) }</h3>

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -543,7 +543,6 @@ function Navigation( {
 								<div id={ overlayMenuPreviewId }>
 									{ overlayMenuPreview && (
 										<OverlayMenuPreview
-											id={ overlayMenuPreviewId }
 											setAttributes={ setAttributes }
 											hasIcon={ hasIcon }
 											icon={ icon }

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -522,7 +522,7 @@ function Navigation( {
 										);
 									} }
 									aria-label={ __(
-										'Toggle overlay menu controls'
+										'Overlay menu controls'
 									) }
 									aria-controls={ overlayMenuPreviewId }
 									aria-expanded={ overlayMenuPreview }

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -521,9 +521,7 @@ function Navigation( {
 											! overlayMenuPreview
 										);
 									} }
-									aria-label={ __(
-										'Overlay menu controls'
-									) }
+									aria-label={ __( 'Overlay menu controls' ) }
 									aria-controls={ overlayMenuPreviewId }
 									aria-expanded={ overlayMenuPreview }
 								>


### PR DESCRIPTION


<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Make the Navigaiton block's overlay controls toggle perceivable to assistive tech.

Fixes https://github.com/WordPress/gutenberg/issues/53461

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Because otherwise a whole set of users cannot properly configure the block.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

- Adds accessible title to toggle button
- Adds `aria-controls` to indicate which controls the button toggles
- Adds `aria-expanded` to button to indicate current state of control toggle

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

- Goto http://gutenberg.run/53462
- New Post
- Add Navigation block
- Move into block sidebar inspector controls
- Select the `Settings` tab.
- Expand the `Display` panel within that section.
- Tab until focused on button which has accessible title of `Toggle overlay menu controls`.
- Check `aria-expanded` is set to `false`.
- Check `aria-controls` attribute refers to an element with a valid DOM `id` attribute.
- Press the button.
- See `aria-expanded` update.
- See new controls revealed.
- Press button again to hide the controls and check that the `aria-` updates accordingly.

## Screenshots or screencast <!-- if applicable -->


https://github.com/WordPress/gutenberg/assets/444434/23e0e2cb-675d-4167-b396-c3c7187380bf
