### PR TITLE
[RNMobile] [iOS] Run timers sooner in `addBlock` integration test helper to ensure block insertion is done properly

### DIFF
--- a/test/native/integration-test-helpers/add-block.js
+++ b/test/native/integration-test-helpers/add-block.js
@@ -47,6 +47,14 @@ export const addBlock = async (
 	// microtasks are executed.
 	await withFakeTimers( async () => {
 		fireEvent.press( blockButton );
+
+		// On iOS the action for inserting a block is delayed (https://bit.ly/3AVALqH).
+		// Hence, we need to wait for the different steps until the the block is inserted.
+		if ( Platform.isIOS ) {
+			await AccessibilityInfo.isScreenReaderEnabled();
+			act( () => jest.runOnlyPendingTimers() );
+		}
+
 		// Run all timers, in case any performs a state updates.
 		// Column block example: https://t.ly/NjTs
 		act( () => jest.runOnlyPendingTimers() );
@@ -54,13 +62,4 @@ export const addBlock = async (
 		// Inner blocks example: https://t.ly/b95nA
 		await act( async () => {} );
 	} );
-
-	// On iOS the action for inserting a block is delayed (https://bit.ly/3AVALqH).
-	// Hence, we need to wait for the different steps until the the block is inserted.
-	if ( Platform.isIOS ) {
-		await withFakeTimers( async () => {
-			await AccessibilityInfo.isScreenReaderEnabled();
-			act( () => jest.runOnlyPendingTimers() );
-		} );
-	}
 };


### PR DESCRIPTION
**Related PRs:**
* https://github.com/wordpress-mobile/gutenberg-mobile/pull/6049

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes an issue related to the integration test helper `addBlock`.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

We are already running the pending timers for potential state updates. However, the timer of the block insertion delay that is triggered on iOS needs to be run before to ensure the block is inserted. Otherwise, tests would fail for blocks that have inner blocks included upon insertion.

https://github.com/WordPress/gutenberg/blob/5ff4e28995d792de85e539a19284d1fefa840cff/packages/block-editor/src/components/inserter/menu.native.js#L138-L156

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Run the timer scheduled when inserting a block on iOS before running other timers related to potential state updates (e.g. microtasks triggered in inner blocks).

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
* Observe that all mobile unit tests pass.

**UPDATE:** This PR doesn't aim to fix a problem in current test suites. It can only be reproduced via the following specific case, which is related to [this PR](https://github.com/wordpress-mobile/gutenberg-mobile/pull/6049):
- Have a block with inner blocks.
- The inner blocks are added upon block insertion.
- Insert the block in an integration test.
- **UPDATE:** Run the integration test on the iOS platform (i.e. using the env var `TEST_RN_PLATFORM=ios`).

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
N/A

## Screenshots or screencast <!-- if applicable -->
N/A