### PR TITLE
Add accessible description of current Navigation block state

### DIFF
--- a/packages/block-library/src/navigation/edit/accessible-description.js
+++ b/packages/block-library/src/navigation/edit/accessible-description.js
@@ -1,0 +1,10 @@
+export default function AccessibleDescription( { id, content } ) {
+	return (
+		<div
+			id={ id }
+			className="wp-block-navigation__description screen-reader-text"
+		>
+			{ content }
+		</div>
+	);
+}

--- a/packages/block-library/src/navigation/edit/accessible-description.js
+++ b/packages/block-library/src/navigation/edit/accessible-description.js
@@ -1,10 +1,14 @@
+/**
+ * WordPress dependencies
+ */
+import { VisuallyHidden } from '@wordpress/components';
+
 export default function AccessibleDescription( { id, children } ) {
 	return (
-		<div
-			id={ id }
-			className="wp-block-navigation__description screen-reader-text"
-		>
-			{ children }
-		</div>
+		<VisuallyHidden>
+			<div id={ id } className="wp-block-navigation__description">
+				{ children }
+			</div>
+		</VisuallyHidden>
 	);
 }

--- a/packages/block-library/src/navigation/edit/accessible-description.js
+++ b/packages/block-library/src/navigation/edit/accessible-description.js
@@ -1,10 +1,10 @@
-export default function AccessibleDescription( { id, content } ) {
+export default function AccessibleDescription( { id, children } ) {
 	return (
 		<div
 			id={ id }
 			className="wp-block-navigation__description screen-reader-text"
 		>
-			{ content }
+			{ children }
 		</div>
 	);
 }

--- a/packages/block-library/src/navigation/edit/accessible-menu-description.js
+++ b/packages/block-library/src/navigation/edit/accessible-menu-description.js
@@ -1,0 +1,18 @@
+/**
+ * WordPress dependencies
+ */
+import { useEntityProp } from '@wordpress/core-data';
+import { __, sprintf } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import AccessibleDescription from './accessible-description';
+
+export default function AccessibleMenuDescription( { id } ) {
+	const [ menuTitle ] = useEntityProp( 'postType', 'wp_navigation', 'title' );
+	/* translators: %s: Title of a Navigation Menu post. */
+	const description = sprintf( __( `Navigation menu: "%s"` ), menuTitle );
+
+	return <AccessibleDescription id={ id } content={ description } />;
+}

--- a/packages/block-library/src/navigation/edit/accessible-menu-description.js
+++ b/packages/block-library/src/navigation/edit/accessible-menu-description.js
@@ -14,5 +14,7 @@ export default function AccessibleMenuDescription( { id } ) {
 	/* translators: %s: Title of a Navigation Menu post. */
 	const description = sprintf( __( `Navigation menu: "%s"` ), menuTitle );
 
-	return <AccessibleDescription id={ id } content={ description } />;
+	return (
+		<AccessibleDescription id={ id }>{ description }</AccessibleDescription>
+	);
 }

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -75,20 +75,20 @@ import MenuInspectorControls from './menu-inspector-controls';
 import DeletedNavigationWarning from './deleted-navigation-warning';
 import { unlock } from '../../lock-unlock';
 
-function AccessibleDescription( { id } ) {
-	const [ menuTitle ] = useEntityProp( 'postType', 'wp_navigation', 'title' );
-
+function AccessibleDescription( { id, content } ) {
 	return (
-		<div
-			id={ `block-${ id }-desc` }
-			className="wp-block-navigation__desc screen-reader-text"
-		>
-			{
-				/* translators: %s: Title of a Navigation Menu post. */
-				sprintf( __( `Navigation menu: "%s"` ), menuTitle )
-			}
+		<div id={ id } className="wp-block-navigation__desc screen-reader-text">
+			{ content }
 		</div>
 	);
+}
+
+function AccessibleMenuDescription( { id } ) {
+	const [ menuTitle ] = useEntityProp( 'postType', 'wp_navigation', 'title' );
+	/* translators: %s: Title of a Navigation Menu post. */
+	const description = sprintf( __( `Navigation menu: "%s"` ), menuTitle );
+
+	return <AccessibleDescription id={ id } content={ description } />;
 }
 
 function Navigation( {
@@ -685,12 +685,23 @@ function Navigation( {
 		</>
 	);
 
+	const accessibleDescriptionId = `${ clientId }-desc`;
+
 	const isManageMenusButtonDisabled =
 		! hasManagePermissions || ! hasResolvedNavigationMenus;
 
 	if ( hasUnsavedBlocks && ! isCreatingNavigationMenu ) {
 		return (
-			<TagName { ...blockProps }>
+			<TagName
+				{ ...blockProps }
+				aria-describedby={
+					! isPlaceholder ? accessibleDescriptionId : undefined
+				}
+			>
+				<AccessibleDescription
+					id={ accessibleDescriptionId }
+					content={ __( 'Unsaved Navigation Menu.' ) }
+				/>
 				<MenuInspectorControls
 					clientId={ clientId }
 					createNavigationMenuIsSuccess={
@@ -860,11 +871,13 @@ function Navigation( {
 						{ ...blockProps }
 						aria-describedby={
 							! isPlaceholder
-								? `block-${ clientId }-desc`
+								? accessibleDescriptionId
 								: undefined
 						}
 					>
-						<AccessibleDescription id={ clientId } />
+						<AccessibleMenuDescription
+							id={ accessibleDescriptionId }
+						/>
 						<ResponsiveWrapper
 							id={ clientId }
 							onToggle={ setResponsiveMenuVisibility }

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -680,10 +680,10 @@ function Navigation( {
 					! isPlaceholder ? accessibleDescriptionId : undefined
 				}
 			>
-				<AccessibleDescription
-					id={ accessibleDescriptionId }
-					content={ __( 'Unsaved Navigation Menu.' ) }
-				/>
+				<AccessibleDescription id={ accessibleDescriptionId }>
+					{ __( 'Unsaved Navigation Menu.' ) }
+				</AccessibleDescription>
+
 				<MenuInspectorControls
 					clientId={ clientId }
 					createNavigationMenuIsSuccess={

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -28,7 +28,11 @@ import {
 	__experimentalUseMultipleOriginColorsAndGradients as useMultipleOriginColorsAndGradients,
 	useBlockEditingMode,
 } from '@wordpress/block-editor';
-import { EntityProvider, store as coreStore } from '@wordpress/core-data';
+import {
+	EntityProvider,
+	store as coreStore,
+	useEntityProp,
+} from '@wordpress/core-data';
 
 import { useDispatch, useSelect } from '@wordpress/data';
 import {
@@ -70,6 +74,22 @@ import ManageMenusButton from './manage-menus-button';
 import MenuInspectorControls from './menu-inspector-controls';
 import DeletedNavigationWarning from './deleted-navigation-warning';
 import { unlock } from '../../lock-unlock';
+
+function AccessibleDescription( { id } ) {
+	const [ menuTitle ] = useEntityProp( 'postType', 'wp_navigation', 'title' );
+
+	return (
+		<div
+			id={ `block-${ id }-desc` }
+			className="wp-block-navigation__desc screen-reader-text"
+		>
+			{
+				/* translators: %s: Title of a Navigation Menu post. */
+				sprintf( __( `Navigation menu: "%s"` ), menuTitle )
+			}
+		</div>
+	);
+}
 
 function Navigation( {
 	attributes,
@@ -836,7 +856,15 @@ function Navigation( {
 				) }
 
 				{ ! isLoading && (
-					<TagName { ...blockProps }>
+					<TagName
+						{ ...blockProps }
+						aria-describedby={
+							! isPlaceholder
+								? `block-${ clientId }-desc`
+								: undefined
+						}
+					>
+						<AccessibleDescription id={ clientId } />
 						<ResponsiveWrapper
 							id={ clientId }
 							onToggle={ setResponsiveMenuVisibility }

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -28,11 +28,7 @@ import {
 	__experimentalUseMultipleOriginColorsAndGradients as useMultipleOriginColorsAndGradients,
 	useBlockEditingMode,
 } from '@wordpress/block-editor';
-import {
-	EntityProvider,
-	store as coreStore,
-	useEntityProp,
-} from '@wordpress/core-data';
+import { EntityProvider, store as coreStore } from '@wordpress/core-data';
 
 import { useDispatch, useSelect } from '@wordpress/data';
 import {
@@ -73,23 +69,9 @@ import { detectColors } from './utils';
 import ManageMenusButton from './manage-menus-button';
 import MenuInspectorControls from './menu-inspector-controls';
 import DeletedNavigationWarning from './deleted-navigation-warning';
+import AccessibleDescription from './accessible-description';
+import AccessibleMenuDescription from './accessible-menu-description';
 import { unlock } from '../../lock-unlock';
-
-function AccessibleDescription( { id, content } ) {
-	return (
-		<div id={ id } className="wp-block-navigation__desc screen-reader-text">
-			{ content }
-		</div>
-	);
-}
-
-function AccessibleMenuDescription( { id } ) {
-	const [ menuTitle ] = useEntityProp( 'postType', 'wp_navigation', 'title' );
-	/* translators: %s: Title of a Navigation Menu post. */
-	const description = sprintf( __( `Navigation menu: "%s"` ), menuTitle );
-
-	return <AccessibleDescription id={ id } content={ description } />;
-}
 
 function Navigation( {
 	attributes,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Adds accessible description of current state of the Navigation block.

Closes https://github.com/WordPress/gutenberg/issues/47020

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Current accessible feedback is that the current state of the block is not easily perceivable.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Adds a description indicating which Navigation Menu is currently being used.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Saved Menu state

- New Post
- Add Nav block
- Select Navigation block 
- Use `Accessibility` panel in devtools to check description reads "Navigation Menu: %%MENU_NAME%%".

### Unsaved Block State (no menu)

- New Post
- Switch to code view and add the following code to create a Nav block with unsaved inner blocks
```
<!-- wp:navigation -->
<!-- wp:navigation-link {"className":" menu-item menu-item-type-post_type menu-item-object-page","description":"","id":"2","kind":"post-type","label":"Sample Page","opensInNewTab":false,"rel":null,"title":"","type":"page","url":"http://localhost:8888/sample-page/"} /-->
<!-- /wp:navigation -->
```
- Select Navigation block 
- Use `Accessibility` panel in devtools to check description reads "Unsaved Navigation Menu".

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
