### PR TITLE
Remove babel-plugin-inline-json-import in favor of native webpack JSON support

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -3,7 +3,7 @@ module.exports = ( api ) => {
 
 	return {
 		presets: [ '@wordpress/babel-preset-default' ],
-		plugins: [ '@emotion/babel-plugin', 'babel-plugin-inline-json-import' ],
+		plugins: [ '@emotion/babel-plugin' ],
 		overrides: [
 			{
 				test: 'packages/block-library/src/index.js',

--- a/bin/packages/build-worker.js
+++ b/bin/packages/build-worker.js
@@ -174,12 +174,22 @@ async function buildJS( file ) {
 	}
 }
 
+async function copyJSON( file ) {
+	const content = await readFile( file, 'utf8' );
+	for ( const buildDir of Object.values( JS_ENVIRONMENTS ) ) {
+		const destPath = getBuildPath( file, buildDir );
+		await makeDir( path.dirname( destPath ) );
+		await writeFile( destPath, content );
+	}
+}
+
 /**
  * Object of build tasks per file extension.
  *
  * @type {Object<string,Function>}
  */
 const BUILD_TASK_BY_EXTENSION = {
+	'.json': copyJSON,
 	'.scss': buildCSS,
 	'.js': buildJS,
 	'.ts': buildJS,

--- a/bin/packages/build.js
+++ b/bin/packages/build.js
@@ -148,46 +148,6 @@ function createStyleEntryTransform() {
 	} );
 }
 
-/**
- * Returns a stream transform which maps an individual block.json to the
- * index.js that imports it. Presently, babel resolves the import of json
- * files by inlining them as a JavaScript primitive in the importing file.
- * This transform ensures the importing file is rebuilt.
- *
- * @return {Transform} Stream transform instance.
- */
-function createBlockJsonEntryTransform() {
-	const blocks = new Set();
-
-	return new Transform( {
-		objectMode: true,
-		async transform( file, encoding, callback ) {
-			const matches =
-				/block-library[\/\\]src[\/\\](.*)[\/\\]block.json$/.exec(
-					file
-				);
-			const blockName = matches ? matches[ 1 ] : undefined;
-
-			// Only block.json files in the block-library folder are subject to this transform.
-			if ( ! blockName ) {
-				this.push( file );
-				callback();
-				return;
-			}
-
-			// Only operate once per block, assuming entries are common.
-			if ( blockName && blocks.has( blockName ) ) {
-				callback();
-				return;
-			}
-
-			blocks.add( blockName );
-			this.push( file.replace( 'block.json', 'index.js' ) );
-			callback();
-		},
-	} );
-}
-
 let onFileComplete = () => {};
 
 let stream;
@@ -199,9 +159,7 @@ if ( files.length ) {
 	} );
 
 	stream.push( null );
-	stream = stream
-		.pipe( createStyleEntryTransform() )
-		.pipe( createBlockJsonEntryTransform() );
+	stream = stream.pipe( createStyleEntryTransform() );
 } else {
 	const bar = new ProgressBar( 'Build Progress: [:bar] :percent', {
 		width: 30,
@@ -215,6 +173,7 @@ if ( files.length ) {
 		[
 			`${ PACKAGES_DIR }/*/src/**/*.{js,ts,tsx}`,
 			`${ PACKAGES_DIR }/*/src/*.scss`,
+			`${ PACKAGES_DIR }/*/src/**/*.json`,
 			`${ PACKAGES_DIR }/block-library/src/**/*.js`,
 			`${ PACKAGES_DIR }/block-library/src/*/style.scss`,
 			`${ PACKAGES_DIR }/block-library/src/*/theme.scss`,
@@ -224,7 +183,7 @@ if ( files.length ) {
 		{
 			ignore: [
 				`**/benchmark/**`,
-				`**/{__mocks__,__tests__,test}/**`,
+				`**/{__mocks__,__tests__,__fixtures__,test}/**`,
 				`**/{storybook,stories}/**`,
 				`**/e2e-test-utils-playwright/**`,
 			],

--- a/package-lock.json
+++ b/package-lock.json
@@ -158,7 +158,6 @@
 				"appium": "1.22.3",
 				"babel-jest": "29.5.0",
 				"babel-loader": "8.2.3",
-				"babel-plugin-inline-json-import": "0.3.2",
 				"babel-plugin-react-native-classname-to-style": "1.2.2",
 				"babel-plugin-react-native-platform-specific-extensions": "1.1.1",
 				"babel-plugin-transform-remove-console": "6.9.4",
@@ -23084,15 +23083,6 @@
 			"integrity": "sha512-LY3+Y0XVDYcShHHorshrDbt4KFWL4bSeniCtl4SYZbask+Syngk1uMPCeN9+nSiZo6zX5s0RTq/J9Pnaaf/KHw==",
 			"dev": true
 		},
-		"node_modules/babel-plugin-inline-json-import": {
-			"version": "0.3.2",
-			"resolved": "https://registry.npmjs.org/babel-plugin-inline-json-import/-/babel-plugin-inline-json-import-0.3.2.tgz",
-			"integrity": "sha512-QNNJx08KjmMT25Cw7rAPQ6dlREDPiZGDyApHL8KQ9vrQHbrr4PTi7W8g1tMMZPz0jEMd39nx/eH7xjnDNxq5sA==",
-			"dev": true,
-			"dependencies": {
-				"decache": "^4.5.1"
-			}
-		},
 		"node_modules/babel-plugin-istanbul": {
 			"version": "6.1.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-6.1.1.tgz",
@@ -24220,15 +24210,6 @@
 			},
 			"engines": {
 				"node": ">=4"
-			}
-		},
-		"node_modules/callsite": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
-			"integrity": "sha512-0vdNRFXn5q+dtOqjfFtmtlI9N2eVZ7LMyEV2iKC5mEEFvSg/69Ml6b/WU2qF8W1nLRa0wiSrDT3Y5jOHZCwKPQ==",
-			"dev": true,
-			"engines": {
-				"node": "*"
 			}
 		},
 		"node_modules/callsites": {
@@ -26973,15 +26954,6 @@
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
 			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-		},
-		"node_modules/decache": {
-			"version": "4.5.1",
-			"resolved": "https://registry.npmjs.org/decache/-/decache-4.5.1.tgz",
-			"integrity": "sha512-5J37nATc6FmOTLbcsr9qx7Nm28qQyg1SK4xyEHqM0IBkNhWFp0Sm+vKoWYHD8wq+OUEb9jLyaKFfzzd1A9hcoA==",
-			"dev": true,
-			"dependencies": {
-				"callsite": "^1.0.0"
-			}
 		},
 		"node_modules/decamelize": {
 			"version": "1.2.0",
@@ -75972,15 +75944,6 @@
 			"integrity": "sha512-LY3+Y0XVDYcShHHorshrDbt4KFWL4bSeniCtl4SYZbask+Syngk1uMPCeN9+nSiZo6zX5s0RTq/J9Pnaaf/KHw==",
 			"dev": true
 		},
-		"babel-plugin-inline-json-import": {
-			"version": "0.3.2",
-			"resolved": "https://registry.npmjs.org/babel-plugin-inline-json-import/-/babel-plugin-inline-json-import-0.3.2.tgz",
-			"integrity": "sha512-QNNJx08KjmMT25Cw7rAPQ6dlREDPiZGDyApHL8KQ9vrQHbrr4PTi7W8g1tMMZPz0jEMd39nx/eH7xjnDNxq5sA==",
-			"dev": true,
-			"requires": {
-				"decache": "^4.5.1"
-			}
-		},
 		"babel-plugin-istanbul": {
 			"version": "6.1.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-6.1.1.tgz",
@@ -76894,12 +76857,6 @@
 			"requires": {
 				"caller-callsite": "^2.0.0"
 			}
-		},
-		"callsite": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
-			"integrity": "sha512-0vdNRFXn5q+dtOqjfFtmtlI9N2eVZ7LMyEV2iKC5mEEFvSg/69Ml6b/WU2qF8W1nLRa0wiSrDT3Y5jOHZCwKPQ==",
-			"dev": true
 		},
 		"callsites": {
 			"version": "3.1.0",
@@ -79021,15 +78978,6 @@
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
 					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
 				}
-			}
-		},
-		"decache": {
-			"version": "4.5.1",
-			"resolved": "https://registry.npmjs.org/decache/-/decache-4.5.1.tgz",
-			"integrity": "sha512-5J37nATc6FmOTLbcsr9qx7Nm28qQyg1SK4xyEHqM0IBkNhWFp0Sm+vKoWYHD8wq+OUEb9jLyaKFfzzd1A9hcoA==",
-			"dev": true,
-			"requires": {
-				"callsite": "^1.0.0"
 			}
 		},
 		"decamelize": {

--- a/package.json
+++ b/package.json
@@ -170,7 +170,6 @@
 		"appium": "1.22.3",
 		"babel-jest": "29.5.0",
 		"babel-loader": "8.2.3",
-		"babel-plugin-inline-json-import": "0.3.2",
 		"babel-plugin-react-native-classname-to-style": "1.2.2",
 		"babel-plugin-react-native-platform-specific-extensions": "1.1.1",
 		"babel-plugin-transform-remove-console": "6.9.4",

--- a/packages/block-library/src/paragraph/transforms.js
+++ b/packages/block-library/src/paragraph/transforms.js
@@ -3,11 +3,6 @@
  */
 import { createBlock, getBlockAttributes } from '@wordpress/blocks';
 
-/**
- * Internal dependencies
- */
-import { name } from './block.json';
-
 const transforms = {
 	from: [
 		{
@@ -22,7 +17,10 @@ const transforms = {
 				},
 			} ),
 			transform( node ) {
-				const attributes = getBlockAttributes( name, node.outerHTML );
+				const attributes = getBlockAttributes(
+					'core/paragraph',
+					node.outerHTML
+				);
 				const { textAlign } = node.style || {};
 
 				if (
@@ -33,7 +31,7 @@ const transforms = {
 					attributes.align = textAlign;
 				}
 
-				return createBlock( name, attributes );
+				return createBlock( 'core/paragraph', attributes );
 			},
 		},
 	],


### PR DESCRIPTION
Fixes #49458. Removes the `babel-plugin-inline-json-import` in favor of native webpack 5 JSON imports.

Webpack can optimize these imports. In code like:
```js
import metadata from './block.json';
console.log( metadata.name );
```
it detects that only the `name` field is used and will inline a truncated version of the JSON:
```js
const metadata_namespaceObject = {"name":"core/list"};
console.log( metadata_namespaceObject.name );
```
Very similar to the previous inlining behavior, but optimized!

The patch had to solve several issues:
- because the `block.json` files are no longer inlined at Babel level, we need to copy the `block.json` files to the `build-module` directories of individual packages, so that webpack can find them there. Previously, `block.json` files were inlined by Babel, and webpack was not aware of them at all.
- webpack doesn't support named exports from JSON modules, like `import { name  } from './block.json'`. It supports only default exports. Therefore we need to rewrite the `import { name }` pattern to `import metadata` + `metadata.name`.

There was a tricky unit test failure I had to fix. When a block is being serialized, we don't serialize attribute values that are equal to their default values, per `block.json` schema. But the `===` comparison:

https://github.com/WordPress/gutenberg/blob/5fe62fdbf0a9f4fe946c49e5c620f99afb78e633/packages/blocks/src/api/serializer.js#L241

doesn't work reliably for values like `[]`. Apparently before this PR, the attribute schemas were inlined two times at two different places, so that `schema1.default !== schema2.default`. But now the schema is shared, so the two `[]` values are identical to each other.

A good fix would be to use `fast-deep-equal` for the default value comparison.