### PR TITLE
Button: Replace the 'isSmall' deprecated prop in the 'WidthPanel'

### DIFF
--- a/packages/block-library/src/button/edit.js
+++ b/packages/block-library/src/button/edit.js
@@ -52,7 +52,7 @@ function WidthPanel( { selectedWidth, setAttributes } ) {
 					return (
 						<Button
 							key={ widthValue }
-							isSmall
+							size="small"
 							variant={
 								widthValue === selectedWidth
 									? 'primary'


### PR DESCRIPTION
## What?
PR replaces the `isSmall` deprecated prop in the `WidthPanel` component with `size="small"`.

## Why?
The core should avoid using the deprecated method and props.

## Testing Instructions
1. Open a post or page.
2. Insert a Button block.
3. Confirm that width settings controls are rendered as before.

## Screenshots or screencast <!-- if applicable -->

![CleanShot 2023-08-09 at 18 07 02](https://github.com/WordPress/gutenberg/assets/240569/dffe7a01-6471-48d1-9d9c-c090341ccd9a)
