### PR TITLE
RichText: Remove 'Footnotes' when interactive formatting is disabled

### DIFF
--- a/packages/block-editor/src/components/rich-text/use-format-types.js
+++ b/packages/block-editor/src/components/rich-text/use-format-types.js
@@ -71,9 +71,11 @@ export function useFormatTypes( {
 				return false;
 			}
 
+			// The "Footnote" format requires special handling due to its nested interactive content tag.
 			if (
 				withoutInteractiveFormatting &&
-				interactiveContentTags.has( tagName )
+				( name === 'core/footnote' ||
+					interactiveContentTags.has( tagName ) )
 			) {
 				return false;
 			}

--- a/packages/block-editor/src/components/rich-text/use-format-types.js
+++ b/packages/block-editor/src/components/rich-text/use-format-types.js
@@ -66,16 +66,14 @@ export function useFormatTypes( {
 } ) {
 	const allFormatTypes = useSelect( formatTypesSelector, [] );
 	const formatTypes = useMemo( () => {
-		return allFormatTypes.filter( ( { name, tagName } ) => {
+		return allFormatTypes.filter( ( { name, interactive, tagName } ) => {
 			if ( allowedFormats && ! allowedFormats.includes( name ) ) {
 				return false;
 			}
 
-			// The "Footnote" format requires special handling due to its nested interactive content tag.
 			if (
 				withoutInteractiveFormatting &&
-				( name === 'core/footnote' ||
-					interactiveContentTags.has( tagName ) )
+				( interactive || interactiveContentTags.has( tagName ) )
 			) {
 				return false;
 			}

--- a/packages/block-editor/src/components/rich-text/use-format-types.js
+++ b/packages/block-editor/src/components/rich-text/use-format-types.js
@@ -82,7 +82,7 @@ export function useFormatTypes( {
 
 			return true;
 		} );
-	}, [ allFormatTypes, allowedFormats, interactiveContentTags ] );
+	}, [ allFormatTypes, allowedFormats, withoutInteractiveFormatting ] );
 	const keyedSelected = useSelect(
 		( select ) =>
 			formatTypes.reduce( ( accumulator, type ) => {

--- a/packages/block-library/src/footnotes/format.js
+++ b/packages/block-library/src/footnotes/format.js
@@ -37,6 +37,7 @@ export const format = {
 	attributes: {
 		'data-fn': 'data-fn',
 	},
+	interactive: true,
 	contentEditable: false,
 	[ usesContextKey ]: [ 'postType' ],
 	edit: function Edit( {

--- a/packages/rich-text/src/register-format-type.js
+++ b/packages/rich-text/src/register-format-type.js
@@ -13,6 +13,7 @@ import { store as richTextStore } from './store';
  *                                  unique across all registered formats.
  * @property {string}   tagName     The HTML tag this format will wrap the
  *                                  selection with.
+ * @property {boolean}  interactive Whether format makes content interactive or not.
  * @property {string}   [className] A class to match the format.
  * @property {string}   title       Name of the format.
  * @property {Function} edit        Should return a component for the user to


### PR DESCRIPTION
## What?
PR updates the `useFormatTypes` hook to exclude the 'Footnote' format when [`withoutInteractiveFormatting`](https://github.com/WordPress/gutenberg/blob/HEAD/packages/block-editor/src/components/rich-text/README.md#withoutinteractiveformatting-boolean) is set to true.

## Why?
The blocks using this flag with the `RichText` component already render interactive content tags. Inserting the 'Footnote' format could result in non-valid HTML markup. E.g., the Button block renders as a link (`a`), and adding a format marker means nesting link tags.

Blocks using `withoutInteractiveFormatting` flag: https://github.com/search?q=repo%3AWordPress%2Fgutenberg+withoutInteractiveFormatting+path%3A%2F%5Epackages%5C%2Fblock-library%5C%2Fsrc%5C%2F%2F&type=code

## How?
~~I added a special handler for the 'Footnote' format.~~

* PR introduces a new `interactive` setting which could indicate the format's interactivity aside from the tag name.
* Declares 'Footnote' format as interactive.

## Testing Instructions
1. Open a post or page.
2. Insert a Button or a File block.
3. Confirm footnote format isn't available for them.