### PR TITLE
Remove @types/classnames deprecated package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -108,7 +108,6 @@
 				"@testing-library/react": "13.4.0",
 				"@testing-library/react-native": "12.1.2",
 				"@testing-library/user-event": "14.4.3",
-				"@types/classnames": "2.3.1",
 				"@types/eslint": "7.28.0",
 				"@types/estree": "0.0.50",
 				"@types/highlight-words-core": "1.2.1",
@@ -17572,16 +17571,6 @@
 				"@types/keyv": "^3.1.4",
 				"@types/node": "*",
 				"@types/responselike": "^1.0.0"
-			}
-		},
-		"node_modules/@types/classnames": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/@types/classnames/-/classnames-2.3.1.tgz",
-			"integrity": "sha512-zeOWb0JGBoVmlQoznvqXbE0tEC/HONsnoUNH19Hc96NFsTAwTXbTqb8FMYkru1F/iqp7a18Ws3nWJvtA1sHD1A==",
-			"deprecated": "This is a stub types definition. classnames provides its own type definitions, so you do not need this installed.",
-			"dev": true,
-			"dependencies": {
-				"classnames": "*"
 			}
 		},
 		"node_modules/@types/eslint": {
@@ -75241,15 +75230,6 @@
 				"@types/keyv": "^3.1.4",
 				"@types/node": "*",
 				"@types/responselike": "^1.0.0"
-			}
-		},
-		"@types/classnames": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/@types/classnames/-/classnames-2.3.1.tgz",
-			"integrity": "sha512-zeOWb0JGBoVmlQoznvqXbE0tEC/HONsnoUNH19Hc96NFsTAwTXbTqb8FMYkru1F/iqp7a18Ws3nWJvtA1sHD1A==",
-			"dev": true,
-			"requires": {
-				"classnames": "*"
 			}
 		},
 		"@types/eslint": {

--- a/package.json
+++ b/package.json
@@ -120,7 +120,6 @@
 		"@testing-library/react": "13.4.0",
 		"@testing-library/react-native": "12.1.2",
 		"@testing-library/user-event": "14.4.3",
-		"@types/classnames": "2.3.1",
 		"@types/eslint": "7.28.0",
 		"@types/estree": "0.0.50",
 		"@types/highlight-words-core": "1.2.1",


### PR DESCRIPTION
## What?

While doing the node/npm migration, I've noticed a few messages when installing packages. Among them, the fact that we're using a few deprecated packages. I'll try to clean these out a little bit.

In this first PR, I'm just removing a dependency that is useless right now `@types/classnames` as the `classnames` package ships with its own types nowadays. 

## Testing Instructions

1- Ensure typescripts types building still works (CI is green)
