### PR TITLE
test: Enable jest-watch-typeahead for UI tests

### DIFF
--- a/packages/react-native-editor/jest_ui.config.js
+++ b/packages/react-native-editor/jest_ui.config.js
@@ -22,4 +22,8 @@ module.exports = {
 	testMatch: [ '**/__device-tests__/**/*.test.[jt]s?(x)' ],
 	testRunner: 'jest-jasmine2',
 	reporters: [ 'default', 'jest-junit' ],
+	watchPlugins: [
+		'jest-watch-typeahead/filename',
+		'jest-watch-typeahead/testname',
+	],
 };


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Enable `jest-watch-typeahead` for e2e UI tests.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Relates to #51869. Mirrors configuration for integration tests.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Add Jest configuration mirroring the integrate test setup.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Enable Jest watch mode: `TEST_RN_PLATFORM=ios npm run native device-tests:local -- -- --watch`
2. Press <kbd>p</kbd> to enable test file name filtering. 
3. Type to begin filtering, select a test file. 
4. Verify only the selected file runs. 
5. Press <kbd>t</kbd> to enable test name filtering. 
6. Type to begin filtering, select a test. 
7. Verify only the selected test runs. 

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
n/a

## Screenshots or screencast <!-- if applicable -->
n/a
