### PR TITLE
Allow connecting "url" and "title" attributes of the Image block to custom fields.

### DIFF
--- a/lib/experimental/blocks.php
+++ b/lib/experimental/blocks.php
@@ -157,7 +157,7 @@ if ( $gutenberg_experiments && array_key_exists( 'gutenberg-connections', $guten
 		// - Image: url.
 		$blocks_attributes_allowlist = array(
 			'core/paragraph' => array( 'content' ),
-			'core/image'     => array( 'url' ),
+			'core/image'     => array( 'url', 'title' ),
 		);
 
 		// Whitelist of the block types that support block connections.

--- a/lib/experimental/connection-sources/index.php
+++ b/lib/experimental/connection-sources/index.php
@@ -8,8 +8,10 @@
 return array(
 	'name'        => 'meta',
 	'meta_fields' => function ( $block_instance, $meta_field ) {
+		global $post;
+
 		// We should probably also check if the meta field exists but for now it's okay because
 		// if it doesn't, `get_post_meta()` will just return an empty string.
-		return get_post_meta( $block_instance->context['postId'], $meta_field, true );
+		return get_post_meta( $post->ID, $meta_field, true );
 	},
 );

--- a/packages/block-editor/src/hooks/custom-fields.js
+++ b/packages/block-editor/src/hooks/custom-fields.js
@@ -37,8 +37,8 @@ function addAttribute( settings ) {
 /**
  * Override the default edit UI to include a new block inspector control for
  * assigning a connection to blocks that has support for connections.
- * Currently, only the `core/paragraph` block is supported and there is only a relation
- * between paragraph content and a custom field.
+ * Currently, only the `core/paragraph` and `core/image` blocks are supported
+ * and only the `content` and `url` attributes of these blocks are supported respectively.
  *
  * @param {WPComponent} BlockEdit Original component.
  *

--- a/packages/block-editor/src/hooks/custom-fields.js
+++ b/packages/block-editor/src/hooks/custom-fields.js
@@ -89,7 +89,7 @@ const withInspectorControl = createHigherOrderComponent( ( BlockEdit ) => {
 										if ( nextValue === '' ) {
 											props.setAttributes( {
 												connections: undefined,
-												[ attributeName ]: undefined,
+												[ attributeName ]: '',
 												placeholder: undefined,
 											} );
 										} else {
@@ -105,7 +105,7 @@ const withInspectorControl = createHigherOrderComponent( ( BlockEdit ) => {
 														},
 													},
 												},
-												[ attributeName ]: undefined,
+												[ attributeName ]: '',
 												placeholder: sprintf(
 													'This content will be replaced on the frontend by the value of "%s" custom field.',
 													nextValue

--- a/packages/block-library/src/image/block.json
+++ b/packages/block-library/src/image/block.json
@@ -4,7 +4,7 @@
 	"name": "core/image",
 	"title": "Image",
 	"category": "media",
-	"usesContext": [ "allowResize", "imageCrop", "fixedHeight" ],
+	"usesContext": [ "allowResize", "imageCrop", "fixedHeight", "postId" ],
 	"description": "Insert an image to make a visual statement.",
 	"keywords": [ "img", "photo", "picture" ],
 	"textdomain": "default",
@@ -100,6 +100,7 @@
 		"filter": {
 			"duotone": true
 		},
+		"__experimentalConnections": true,
 		"__experimentalBorder": {
 			"color": true,
 			"radius": true,

--- a/packages/block-library/src/image/block.json
+++ b/packages/block-library/src/image/block.json
@@ -4,7 +4,7 @@
 	"name": "core/image",
 	"title": "Image",
 	"category": "media",
-	"usesContext": [ "allowResize", "imageCrop", "fixedHeight", "postId" ],
+	"usesContext": [ "allowResize", "imageCrop", "fixedHeight" ],
 	"description": "Insert an image to make a visual statement.",
 	"keywords": [ "img", "photo", "picture" ],
 	"textdomain": "default",

--- a/packages/block-library/src/paragraph/block.json
+++ b/packages/block-library/src/paragraph/block.json
@@ -7,7 +7,6 @@
 	"description": "Start with the basic building block of all narrative.",
 	"keywords": [ "text" ],
 	"textdomain": "default",
-	"usesContext": [ "postId" ],
 	"attributes": {
 		"align": {
 			"type": "string"


### PR DESCRIPTION
## What?
Enable connecting the `url` attribute of the Image to custom fields.

Related to https://github.com/WordPress/gutenberg/issues/51373
Follow-up to #53241 and #53247.

## Screencast

Very basic functionality can be demonstrated:


https://github.com/WordPress/gutenberg/assets/5417266/9e6290ba-7a3d-4688-a940-c89caf10480c


