### PR TITLE
Remove "post" from block titles

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -568,7 +568,7 @@ Displays the contents of a post or page. ([Source](https://github.com/WordPress/
 
 ## Date
 
-Add the date of this post. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/post-date))
+Display the publish date for an entry such as a post or page. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/post-date))
 
 -	**Name:** core/post-date
 -	**Category:** theme
@@ -612,7 +612,7 @@ Contains the block elements used to render a post, like the title, date, feature
 -	**Supports:** align (full, wide), color (background, gradients, link, text), layout, spacing (blockGap), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
 -	**Attributes:** 
 
-## Terms
+## Post Terms
 
 Post terms. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/post-terms))
 

--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -491,7 +491,7 @@ Show a block pattern. ([Source](https://github.com/WordPress/gutenberg/tree/trun
 -	**Supports:** ~~html~~, ~~inserter~~
 -	**Attributes:** slug
 
-## Post Author
+## Author
 
 Display post author details such as name, avatar, and bio. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/post-author))
 
@@ -500,7 +500,7 @@ Display post author details such as name, avatar, and bio. ([Source](https://git
 -	**Supports:** color (background, gradients, link, text), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
 -	**Attributes:** avatarSize, byline, isLink, linkTarget, showAvatar, showBio, textAlign
 
-## Post Author Biography
+## Author Biography
 
 The author biography. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/post-author-biography))
 
@@ -509,7 +509,7 @@ The author biography. ([Source](https://github.com/WordPress/gutenberg/tree/trun
 -	**Supports:** color (background, gradients, link, text), spacing (margin, padding), typography (fontSize, lineHeight)
 -	**Attributes:** textAlign
 
-## Post Author Name
+## Author Name
 
 The author name. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/post-author-name))
 
@@ -518,7 +518,7 @@ The author name. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/pac
 -	**Supports:** color (background, gradients, link, text), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
 -	**Attributes:** isLink, linkTarget, textAlign
 
-## Post Comment (deprecated)
+## Comment (deprecated)
 
 This block is deprecated. Please use the Comments block instead. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/post-comment))
 
@@ -528,7 +528,7 @@ This block is deprecated. Please use the Comments block instead. ([Source](https
 -	**Supports:** ~~html~~, ~~inserter~~
 -	**Attributes:** commentId
 
-## Post Comments Count
+## Comments Count
 
 Display a post's comments count. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/post-comments-count))
 
@@ -538,7 +538,7 @@ Display a post's comments count. ([Source](https://github.com/WordPress/gutenber
 -	**Supports:** color (background, gradients, text), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
 -	**Attributes:** textAlign
 
-## Post Comments Form
+## Comments Form
 
 Display a post's comments form. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/post-comments-form))
 
@@ -547,7 +547,7 @@ Display a post's comments form. ([Source](https://github.com/WordPress/gutenberg
 -	**Supports:** color (background, gradients, heading, link, text), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
 -	**Attributes:** textAlign
 
-## Post Comments Link
+## Comments Link
 
 Displays the link to the current post comments. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/post-comments-link))
 
@@ -557,7 +557,7 @@ Displays the link to the current post comments. ([Source](https://github.com/Wor
 -	**Supports:** color (background, link, ~~text~~), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
 -	**Attributes:** textAlign
 
-## Post Content
+## Content
 
 Displays the contents of a post or page. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/post-content))
 
@@ -566,7 +566,7 @@ Displays the contents of a post or page. ([Source](https://github.com/WordPress/
 -	**Supports:** align (full, wide), color (background, gradients, link, text), dimensions (minHeight), layout, typography (fontSize, lineHeight), ~~html~~
 -	**Attributes:** 
 
-## Post Date
+## Date
 
 Add the date of this post. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/post-date))
 
@@ -584,7 +584,7 @@ Display the excerpt. ([Source](https://github.com/WordPress/gutenberg/tree/trunk
 -	**Supports:** color (background, gradients, link, text), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
 -	**Attributes:** excerptLength, moreText, showMoreOnNewLine, textAlign
 
-## Post Featured Image
+## Featured Image
 
 Display a post's featured image. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/post-featured-image))
 
@@ -612,7 +612,7 @@ Contains the block elements used to render a post, like the title, date, feature
 -	**Supports:** align (full, wide), color (background, gradients, link, text), layout, spacing (blockGap), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
 -	**Attributes:** 
 
-## Post Terms
+## Terms
 
 Post terms. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/post-terms))
 

--- a/packages/block-library/src/post-author-biography/block.json
+++ b/packages/block-library/src/post-author-biography/block.json
@@ -2,7 +2,7 @@
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 3,
 	"name": "core/post-author-biography",
-	"title": "Post Author Biography",
+	"title": "Author Biography",
 	"category": "theme",
 	"description": "The author biography.",
 	"textdomain": "default",

--- a/packages/block-library/src/post-author-name/block.json
+++ b/packages/block-library/src/post-author-name/block.json
@@ -2,7 +2,7 @@
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 3,
 	"name": "core/post-author-name",
-	"title": "Post Author Name",
+	"title": "Author Name",
 	"category": "theme",
 	"description": "The author name.",
 	"textdomain": "default",

--- a/packages/block-library/src/post-author/block.json
+++ b/packages/block-library/src/post-author/block.json
@@ -2,7 +2,7 @@
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 3,
 	"name": "core/post-author",
-	"title": "Post Author",
+	"title": "Author",
 	"category": "theme",
 	"description": "Display post author details such as name, avatar, and bio.",
 	"textdomain": "default",

--- a/packages/block-library/src/post-comment/block.json
+++ b/packages/block-library/src/post-comment/block.json
@@ -3,7 +3,7 @@
 	"apiVersion": 3,
 	"__experimental": "fse",
 	"name": "core/post-comment",
-	"title": "Post Comment (deprecated)",
+	"title": "Comment (deprecated)",
 	"category": "theme",
 	"description": "This block is deprecated. Please use the Comments block instead.",
 	"textdomain": "default",

--- a/packages/block-library/src/post-comments-count/block.json
+++ b/packages/block-library/src/post-comments-count/block.json
@@ -3,7 +3,7 @@
 	"apiVersion": 3,
 	"__experimental": "fse",
 	"name": "core/post-comments-count",
-	"title": "Post Comments Count",
+	"title": "Comments Count",
 	"category": "theme",
 	"description": "Display a post's comments count.",
 	"textdomain": "default",

--- a/packages/block-library/src/post-comments-form/block.json
+++ b/packages/block-library/src/post-comments-form/block.json
@@ -2,7 +2,7 @@
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 3,
 	"name": "core/post-comments-form",
-	"title": "Post Comments Form",
+	"title": "Comments Form",
 	"category": "theme",
 	"description": "Display a post's comments form.",
 	"textdomain": "default",

--- a/packages/block-library/src/post-comments-link/block.json
+++ b/packages/block-library/src/post-comments-link/block.json
@@ -3,7 +3,7 @@
 	"apiVersion": 3,
 	"__experimental": "fse",
 	"name": "core/post-comments-link",
-	"title": "Post Comments Link",
+	"title": "Comments Link",
 	"category": "theme",
 	"description": "Displays the link to the current post comments.",
 	"textdomain": "default",

--- a/packages/block-library/src/post-content/block.json
+++ b/packages/block-library/src/post-content/block.json
@@ -2,7 +2,7 @@
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 3,
 	"name": "core/post-content",
-	"title": "Post Content",
+	"title": "Content",
 	"category": "theme",
 	"description": "Displays the contents of a post or page.",
 	"textdomain": "default",

--- a/packages/block-library/src/post-date/block.json
+++ b/packages/block-library/src/post-date/block.json
@@ -4,7 +4,7 @@
 	"name": "core/post-date",
 	"title": "Date",
 	"category": "theme",
-	"description": "Add the date of this post.",
+	"description": "Display the publish date for an entry such as a post or page.",
 	"textdomain": "default",
 	"attributes": {
 		"textAlign": {

--- a/packages/block-library/src/post-date/block.json
+++ b/packages/block-library/src/post-date/block.json
@@ -2,7 +2,7 @@
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 3,
 	"name": "core/post-date",
-	"title": "Post Date",
+	"title": "Date",
 	"category": "theme",
 	"description": "Add the date of this post.",
 	"textdomain": "default",

--- a/packages/block-library/src/post-date/variations.js
+++ b/packages/block-library/src/post-date/variations.js
@@ -7,7 +7,7 @@ import { postDate } from '@wordpress/icons';
 const variations = [
 	{
 		name: 'post-date-modified',
-		title: __( 'Post Modified Date' ),
+		title: __( 'Modified Date' ),
 		description: __( "Display a post's last updated date." ),
 		attributes: { displayType: 'modified' },
 		scope: [ 'block', 'inserter' ],

--- a/packages/block-library/src/post-featured-image/block.json
+++ b/packages/block-library/src/post-featured-image/block.json
@@ -2,7 +2,7 @@
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 3,
 	"name": "core/post-featured-image",
-	"title": "Post Featured Image",
+	"title": "Featured Image",
 	"category": "theme",
 	"description": "Display a post's featured image.",
 	"textdomain": "default",

--- a/packages/block-library/src/post-terms/block.json
+++ b/packages/block-library/src/post-terms/block.json
@@ -2,7 +2,7 @@
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 3,
 	"name": "core/post-terms",
-	"title": "Post Terms",
+	"title": "Terms",
 	"category": "theme",
 	"description": "Post terms.",
 	"textdomain": "default",

--- a/packages/block-library/src/post-terms/block.json
+++ b/packages/block-library/src/post-terms/block.json
@@ -2,7 +2,7 @@
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 3,
 	"name": "core/post-terms",
-	"title": "Terms",
+	"title": "Post Terms",
 	"category": "theme",
 	"description": "Post terms.",
 	"textdomain": "default",

--- a/packages/e2e-tests/specs/experiments/blocks/post-comments-form.test.js
+++ b/packages/e2e-tests/specs/experiments/blocks/post-comments-form.test.js
@@ -11,7 +11,7 @@ import {
 	canvas,
 } from '@wordpress/e2e-test-utils';
 
-describe( 'Post Comments Form', () => {
+describe( 'Comments Form', () => {
 	let previousCommentStatus;
 
 	beforeAll( async () => {
@@ -42,7 +42,7 @@ describe( 'Post Comments Form', () => {
 			await enterEditMode();
 
 			// Insert post comments form
-			await insertBlock( 'Post Comments Form' );
+			await insertBlock( 'Comments Form' );
 
 			// Ensure the placeholder is there
 			await expect( canvas() ).toMatchElement(

--- a/test/e2e/specs/site-editor/pages.spec.js
+++ b/test/e2e/specs/site-editor/pages.spec.js
@@ -54,7 +54,7 @@ test.describe( 'Pages', () => {
 		// Insert into Page Content using appender.
 		await page
 			.getByRole( 'region', { name: 'Editor footer' } )
-			.getByRole( 'button', { name: 'Post Content' } )
+			.getByRole( 'button', { name: 'Content' } )
 			.click();
 		await editor.canvas
 			.getByRole( 'button', { name: 'Add block' } )

--- a/test/e2e/specs/site-editor/pages.spec.js
+++ b/test/e2e/specs/site-editor/pages.spec.js
@@ -90,7 +90,7 @@ test.describe( 'Pages', () => {
 			.click();
 		await expect(
 			editor.canvas.getByRole( 'document', {
-				name: 'Block: Post Content',
+				name: 'Block: Content',
 			} )
 		).toContainText(
 			'This is the Post Content block, it will display all the blocks in any single post or page.'

--- a/test/performance/specs/site-editor.spec.js
+++ b/test/performance/specs/site-editor.spec.js
@@ -170,7 +170,7 @@ test.describe( 'Site Editor Performance', () => {
 
 		// Insert a new paragraph right under the first one.
 		await canvas
-			.getByRole( 'document', { name: 'Block: Post Content' } )
+			.getByRole( 'document', { name: 'Block: Content' } )
 			.click();
 		await firstParagraph.click();
 		await pageUtils.pressKeys( 'primary+a' );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Removes the "Post" prefix on block titles. 
Examples, changes "Post Featured Image" to "Featured Image". Closes https://github.com/WordPress/gutenberg/issues/53459. 

## Why?
- Was suggested a few times, notably in https://github.com/WordPress/gutenberg/issues/53459.
- The "Post" prefix is confusing if editing a page, or any other custom post type template.
- There are already a few blocks without the "Post" prefix. 

## Visual 


| Before  | After |
| ------------- | ------------- |
|<img width="346" alt="CleanShot 2023-08-09 at 16 17 49" src="https://github.com/WordPress/gutenberg/assets/1813435/20242507-150e-485b-8324-479e8f454304">|<img width="349" alt="CleanShot 2023-08-09 at 16 17 23" src="https://github.com/WordPress/gutenberg/assets/1813435/0d989fbe-e4b1-4944-bcae-a46012ec4613">|


