### PR TITLE
Combine Document and Block Tools in the DOM

### DIFF
--- a/packages/block-editor/src/components/block-tools/empty-block-inserter.js
+++ b/packages/block-editor/src/components/block-tools/empty-block-inserter.js
@@ -6,21 +6,16 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { useRef, useEffect } from '@wordpress/element';
 import { isUnmodifiedDefaultBlock } from '@wordpress/blocks';
-import { useDispatch, useSelect } from '@wordpress/data';
-import { useShortcut } from '@wordpress/keyboard-shortcuts';
+import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
-import BlockSelectionButton from './block-selection-button';
-import BlockContextualToolbar from './block-contextual-toolbar';
 import { store as blockEditorStore } from '../../store';
 import BlockPopover from '../block-popover';
 import useBlockToolbarPopoverProps from './use-block-toolbar-popover-props';
 import Inserter from '../inserter';
-import { useShouldContextualToolbarShow } from '../../utils/use-should-contextual-toolbar-show';
 
 function selector( select ) {
 	const {
@@ -40,7 +35,7 @@ function selector( select ) {
 	};
 }
 
-function SelectedBlockPopover( {
+function EmptyBlockInserter( {
 	clientId,
 	rootClientId,
 	isEmptyDefaultBlock,
@@ -48,10 +43,7 @@ function SelectedBlockPopover( {
 	__unstablePopoverSlot,
 	__unstableContentRef,
 } ) {
-	const { editorMode, hasMultiSelection, isTyping, lastClientId } = useSelect(
-		selector,
-		[]
-	);
+	const { editorMode, isTyping, lastClientId } = useSelect( selector, [] );
 
 	const isInsertionPointVisible = useSelect(
 		( select ) => {
@@ -71,42 +63,9 @@ function SelectedBlockPopover( {
 		},
 		[ clientId ]
 	);
-	const isToolbarForced = useRef( false );
-	const { shouldShowContextualToolbar, canFocusHiddenToolbar } =
-		useShouldContextualToolbarShow();
-
-	const { stopTyping } = useDispatch( blockEditorStore );
 
 	const showEmptyBlockSideInserter =
 		! isTyping && editorMode === 'edit' && isEmptyDefaultBlock;
-	const shouldShowBreadcrumb =
-		! hasMultiSelection &&
-		( editorMode === 'navigation' || editorMode === 'zoom-out' );
-
-	useShortcut(
-		'core/block-editor/focus-toolbar',
-		() => {
-			isToolbarForced.current = true;
-			stopTyping( true );
-		},
-		{
-			isDisabled: ! canFocusHiddenToolbar,
-		}
-	);
-
-	useEffect( () => {
-		isToolbarForced.current = false;
-	} );
-
-	// Stores the active toolbar item index so the block toolbar can return focus
-	// to it when re-mounting.
-	const initialToolbarItemIndexRef = useRef();
-
-	useEffect( () => {
-		// Resets the index whenever the active block changes so this is not
-		// persisted. See https://github.com/WordPress/gutenberg/pull/25760#issuecomment-717906169
-		initialToolbarItemIndexRef.current = undefined;
-	}, [ clientId ] );
 
 	const popoverProps = useBlockToolbarPopoverProps( {
 		contentElement: __unstableContentRef?.current,
@@ -139,48 +98,6 @@ function SelectedBlockPopover( {
 						__experimentalIsQuick
 					/>
 				</div>
-			</BlockPopover>
-		);
-	}
-
-	if ( shouldShowBreadcrumb || shouldShowContextualToolbar ) {
-		return (
-			<BlockPopover
-				clientId={ capturingClientId || clientId }
-				bottomClientId={ lastClientId }
-				className={ classnames(
-					'block-editor-block-list__block-popover',
-					{
-						'is-insertion-point-visible': isInsertionPointVisible,
-					}
-				) }
-				__unstablePopoverSlot={ __unstablePopoverSlot }
-				__unstableContentRef={ __unstableContentRef }
-				resize={ false }
-				{ ...popoverProps }
-			>
-				{ shouldShowContextualToolbar && (
-					<BlockContextualToolbar
-						// If the toolbar is being shown because of being forced
-						// it should focus the toolbar right after the mount.
-						focusOnMount={ isToolbarForced.current }
-						__experimentalInitialIndex={
-							initialToolbarItemIndexRef.current
-						}
-						__experimentalOnIndexChange={ ( index ) => {
-							initialToolbarItemIndexRef.current = index;
-						} }
-						// Resets the index whenever the active block changes so
-						// this is not persisted. See https://github.com/WordPress/gutenberg/pull/25760#issuecomment-717906169
-						key={ clientId }
-					/>
-				) }
-				{ shouldShowBreadcrumb && (
-					<BlockSelectionButton
-						clientId={ clientId }
-						rootClientId={ rootClientId }
-					/>
-				) }
 			</BlockPopover>
 		);
 	}
@@ -230,7 +147,7 @@ function wrapperSelector( select ) {
 	};
 }
 
-export default function WrappedBlockPopover( {
+export default function WrappedEmptyBlockInserter( {
 	__unstablePopoverSlot,
 	__unstableContentRef,
 } ) {
@@ -253,7 +170,7 @@ export default function WrappedBlockPopover( {
 	}
 
 	return (
-		<SelectedBlockPopover
+		<EmptyBlockInserter
 			clientId={ clientId }
 			rootClientId={ rootClientId }
 			isEmptyDefaultBlock={ isEmptyDefaultBlock }

--- a/packages/block-editor/src/components/block-tools/index.js
+++ b/packages/block-editor/src/components/block-tools/index.js
@@ -2,7 +2,6 @@
  * WordPress dependencies
  */
 import { useSelect, useDispatch } from '@wordpress/data';
-import { useViewportMatch } from '@wordpress/compose';
 import { Popover } from '@wordpress/components';
 import { __unstableUseShortcutEventMatch as useShortcutEventMatch } from '@wordpress/keyboard-shortcuts';
 import { useRef } from '@wordpress/element';
@@ -14,9 +13,8 @@ import {
 	InsertionPointOpenRef,
 	default as InsertionPoint,
 } from './insertion-point';
-import SelectedBlockPopover from './selected-block-popover';
+import EmptyBlockInserter from './empty-block-inserter';
 import { store as blockEditorStore } from '../../store';
-import BlockContextualToolbar from './block-contextual-toolbar';
 import usePopoverScroll from '../block-popover/use-popover-scroll';
 import ZoomOutModeInserters from './zoom-out-mode-inserters';
 
@@ -45,11 +43,7 @@ export default function BlockTools( {
 	__unstableContentRef,
 	...props
 } ) {
-	const isLargeViewport = useViewportMatch( 'medium' );
-	const { hasFixedToolbar, isZoomOutMode, isTyping } = useSelect(
-		selector,
-		[]
-	);
+	const { isZoomOutMode, isTyping } = useSelect( selector, [] );
 	const isMatch = useShortcutEventMatch();
 	const { getSelectedBlockClientIds, getBlockRootClientId } =
 		useSelect( blockEditorStore );
@@ -138,13 +132,7 @@ export default function BlockTools( {
 						__unstableContentRef={ __unstableContentRef }
 					/>
 				) }
-				{ ! isZoomOutMode &&
-					( hasFixedToolbar || ! isLargeViewport ) && (
-						<BlockContextualToolbar isFixed />
-					) }
-				{ /* Even if the toolbar is fixed, the block popover is still
-					needed for navigation and zoom-out mode. */ }
-				<SelectedBlockPopover
+				<EmptyBlockInserter
 					__unstableContentRef={ __unstableContentRef }
 				/>
 				{ /* Used for the inline rich text toolbar. */ }

--- a/packages/block-editor/src/components/block-tools/selected-block-tools.js
+++ b/packages/block-editor/src/components/block-tools/selected-block-tools.js
@@ -1,0 +1,248 @@
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
+ * WordPress dependencies
+ */
+import { useRef, useEffect } from '@wordpress/element';
+import { isUnmodifiedDefaultBlock } from '@wordpress/blocks';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { useShortcut } from '@wordpress/keyboard-shortcuts';
+import { getScrollContainer } from '@wordpress/dom';
+
+/**
+ * Internal dependencies
+ */
+import BlockSelectionButton from './block-selection-button';
+import BlockContextualToolbar from './block-contextual-toolbar';
+import { store as blockEditorStore } from '../../store';
+import BlockPopover from '../block-popover';
+import useBlockToolbarPopoverProps from './use-block-toolbar-popover-props';
+import { useShouldContextualToolbarShow } from '../../utils/use-should-contextual-toolbar-show';
+
+function selector( select ) {
+	const {
+		__unstableGetEditorMode,
+		hasMultiSelection,
+		isTyping,
+		getLastMultiSelectedBlockClientId,
+	} = select( blockEditorStore );
+
+	return {
+		editorMode: __unstableGetEditorMode(),
+		hasMultiSelection: hasMultiSelection(),
+		isTyping: isTyping(),
+		lastClientId: hasMultiSelection()
+			? getLastMultiSelectedBlockClientId()
+			: null,
+	};
+}
+
+function SelectedBlockTools( {
+	clientId,
+	rootClientId,
+	isEmptyDefaultBlock,
+	isFixed,
+	capturingClientId,
+} ) {
+	const { editorMode, hasMultiSelection, isTyping, lastClientId } = useSelect(
+		selector,
+		[]
+	);
+
+	const isInsertionPointVisible = useSelect(
+		( select ) => {
+			const {
+				isBlockInsertionPointVisible,
+				getBlockInsertionPoint,
+				getBlockOrder,
+			} = select( blockEditorStore );
+
+			if ( ! isBlockInsertionPointVisible() ) {
+				return false;
+			}
+
+			const insertionPoint = getBlockInsertionPoint();
+			const order = getBlockOrder( insertionPoint.rootClientId );
+			return order[ insertionPoint.index ] === clientId;
+		},
+		[ clientId ]
+	);
+	const isToolbarForced = useRef( false );
+	const { shouldShowContextualToolbar, canFocusHiddenToolbar } =
+		useShouldContextualToolbarShow();
+
+	const { stopTyping } = useDispatch( blockEditorStore );
+
+	const showEmptyBlockSideInserter =
+		! isTyping && editorMode === 'edit' && isEmptyDefaultBlock;
+	const shouldShowBreadcrumb =
+		! hasMultiSelection &&
+		( editorMode === 'navigation' || editorMode === 'zoom-out' );
+
+	useShortcut(
+		'core/block-editor/focus-toolbar',
+		() => {
+			isToolbarForced.current = true;
+			stopTyping( true );
+		},
+		{
+			isDisabled: ! canFocusHiddenToolbar,
+		}
+	);
+
+	useEffect( () => {
+		isToolbarForced.current = false;
+	} );
+
+	// Stores the active toolbar item index so the block toolbar can return focus
+	// to it when re-mounting.
+	const initialToolbarItemIndexRef = useRef();
+
+	useEffect( () => {
+		// Resets the index whenever the active block changes so this is not
+		// persisted. See https://github.com/WordPress/gutenberg/pull/25760#issuecomment-717906169
+		initialToolbarItemIndexRef.current = undefined;
+	}, [ clientId ] );
+
+	const popoverProps = useBlockToolbarPopoverProps( {
+		contentElement: getScrollContainer(), // This is what useBlockToolbarPopoverProps does when the contentRef is undefined. This likely works by accident. It was being passed in via the BlockTools
+		clientId,
+	} );
+
+	if ( isFixed ) {
+		return (
+			<BlockContextualToolbar
+				__experimentalInitialIndex={
+					initialToolbarItemIndexRef.current
+				}
+				__experimentalOnIndexChange={ ( index ) => {
+					initialToolbarItemIndexRef.current = index;
+				} }
+				// Resets the index whenever the active block changes so
+				// this is not persisted. See https://github.com/WordPress/gutenberg/pull/25760#issuecomment-717906169
+				key={ clientId }
+			/>
+		);
+	}
+
+	if ( showEmptyBlockSideInserter ) {
+		return null;
+	}
+
+	if ( shouldShowBreadcrumb || shouldShowContextualToolbar ) {
+		return (
+			<BlockPopover
+				clientId={ capturingClientId || clientId }
+				bottomClientId={ lastClientId }
+				className={ classnames(
+					'block-editor-block-list__block-popover',
+					{
+						'is-insertion-point-visible': isInsertionPointVisible,
+					}
+				) }
+				resize={ false }
+				{ ...popoverProps }
+			>
+				{ shouldShowContextualToolbar && (
+					<BlockContextualToolbar
+						// If the toolbar is being shown because of being forced
+						// it should focus the toolbar right after the mount.
+						focusOnMount={ isToolbarForced.current }
+						__experimentalInitialIndex={
+							initialToolbarItemIndexRef.current
+						}
+						__experimentalOnIndexChange={ ( index ) => {
+							initialToolbarItemIndexRef.current = index;
+						} }
+						// Resets the index whenever the active block changes so
+						// this is not persisted. See https://github.com/WordPress/gutenberg/pull/25760#issuecomment-717906169
+						key={ clientId }
+					/>
+				) }
+				{ shouldShowBreadcrumb && (
+					<BlockSelectionButton
+						clientId={ clientId }
+						rootClientId={ rootClientId }
+					/>
+				) }
+			</BlockPopover>
+		);
+	}
+
+	return null;
+}
+
+function wrapperSelector( select ) {
+	const {
+		getSelectedBlockClientId,
+		getFirstMultiSelectedBlockClientId,
+		getBlockRootClientId,
+		getBlock,
+		getBlockParents,
+		__experimentalGetBlockListSettingsForBlocks,
+	} = select( blockEditorStore );
+
+	const clientId =
+		getSelectedBlockClientId() || getFirstMultiSelectedBlockClientId();
+
+	if ( ! clientId ) {
+		return;
+	}
+
+	const { name, attributes = {} } = getBlock( clientId ) || {};
+	const blockParentsClientIds = getBlockParents( clientId );
+
+	// Get Block List Settings for all ancestors of the current Block clientId.
+	const parentBlockListSettings = __experimentalGetBlockListSettingsForBlocks(
+		blockParentsClientIds
+	);
+
+	// Get the clientId of the topmost parent with the capture toolbars setting.
+	const capturingClientId = blockParentsClientIds.find(
+		( parentClientId ) =>
+			parentBlockListSettings[ parentClientId ]
+				?.__experimentalCaptureToolbars
+	);
+
+	return {
+		clientId,
+		rootClientId: getBlockRootClientId( clientId ),
+		name,
+		isEmptyDefaultBlock:
+			name && isUnmodifiedDefaultBlock( { name, attributes } ),
+		capturingClientId,
+	};
+}
+
+export default function WrappedSelectedBlockTools( { isFixed } ) {
+	const selected = useSelect( wrapperSelector, [] );
+
+	if ( ! selected ) {
+		return null;
+	}
+
+	const {
+		clientId,
+		rootClientId,
+		name,
+		isEmptyDefaultBlock,
+		capturingClientId,
+	} = selected;
+
+	if ( ! name ) {
+		return null;
+	}
+
+	return (
+		<SelectedBlockTools
+			clientId={ clientId }
+			rootClientId={ rootClientId }
+			isEmptyDefaultBlock={ isEmptyDefaultBlock }
+			isFixed={ isFixed }
+			capturingClientId={ capturingClientId }
+		/>
+	);
+}

--- a/packages/block-editor/src/components/block-tools/selected-block-tools.js
+++ b/packages/block-editor/src/components/block-tools/selected-block-tools.js
@@ -11,6 +11,7 @@ import { isUnmodifiedDefaultBlock } from '@wordpress/blocks';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useShortcut } from '@wordpress/keyboard-shortcuts';
 import { getScrollContainer } from '@wordpress/dom';
+import { useViewportMatch } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -70,6 +71,7 @@ function SelectedBlockTools( {
 		},
 		[ clientId ]
 	);
+	const isLargeViewport = useViewportMatch( 'medium' );
 	const isToolbarForced = useRef( false );
 	const { shouldShowContextualToolbar, canFocusHiddenToolbar } =
 		useShouldContextualToolbarShow();
@@ -112,10 +114,11 @@ function SelectedBlockTools( {
 		clientId,
 	} );
 
-	if ( isFixed ) {
+	// We need to show the toolbar as fixed when we're on the tablet breakpoint.
+	if ( isFixed || ! isLargeViewport ) {
 		return (
 			<BlockContextualToolbar
-				isFixed={ isFixed }
+				isFixed={ true }
 				__experimentalInitialIndex={
 					initialToolbarItemIndexRef.current
 				}

--- a/packages/block-editor/src/components/block-tools/selected-block-tools.js
+++ b/packages/block-editor/src/components/block-tools/selected-block-tools.js
@@ -115,6 +115,7 @@ function SelectedBlockTools( {
 	if ( isFixed ) {
 		return (
 			<BlockContextualToolbar
+				isFixed={ isFixed }
 				__experimentalInitialIndex={
 					initialToolbarItemIndexRef.current
 				}

--- a/packages/block-editor/src/components/block-tools/style.scss
+++ b/packages/block-editor/src/components/block-tools/style.scss
@@ -107,7 +107,6 @@
 	&.is-fixed {
 		position: fixed;
 		top: $admin-bar-height-big + $header-height;
-		z-index: z-index(".block-editor-block-popover");
 		width: 100%;
 		overflow: hidden;
 

--- a/packages/block-editor/src/components/block-tools/style.scss
+++ b/packages/block-editor/src/components/block-tools/style.scss
@@ -90,7 +90,7 @@
  */
 
 // Base left position for the toolbar when fixed.
-@include editor-left(".block-editor-block-contextual-toolbar.is-fixed");
+// @include editor-left(".block-editor-block-contextual-toolbar.is-fixed");
 
 .block-editor-block-contextual-toolbar {
 	// Block UI appearance.
@@ -105,10 +105,9 @@
 	}
 
 	&.is-fixed {
-		position: sticky;
-		top: 0;
+		position: fixed;
+		top: 107px; // Magic number. Needs updated. Should be whatever the toolbar + admin toolbar is?
 		z-index: z-index(".block-editor-block-popover");
-		display: block;
 		width: 100%;
 		overflow: hidden;
 
@@ -142,48 +141,19 @@
 	$toolbar-margin: $grid-unit-80 * 3 - 2 * $grid-unit + $grid-unit-05;
 	@include break-medium() {
 		&.is-fixed {
-			// leave room for block inserter, undo and redo, list view
-			margin-left: $toolbar-margin;
-			// position on top of interface header
-			position: fixed;
-			top: $admin-bar-height;
-			// Don't fill up when empty
-			min-height: initial;
+			position: relative;
+			top: 0;
+			display: inline-flex;
+			width: auto;
+
 			// remove the border
 			border-bottom: none;
-			// has to be flex for collapse button to fit
-			display: flex;
-
-			// Mimic the height of the parent, vertically align center, and provide a max-height.
-			height: $header-height;
-			align-items: center;
 
 			&.is-collapsed {
 				width: initial;
 			}
 
-			&:empty {
-				width: initial;
-			}
-
-			.is-fullscreen-mode & {
-				// leave room for block inserter, undo and redo, list view
-				// and some margin left
-				margin-left: $grid-unit-80 * 4 - 2 * $grid-unit;
-
-				top: 0;
-
-				&.is-collapsed {
-					width: initial;
-				}
-
-				&:empty {
-					width: initial;
-				}
-			}
-
 			& > .block-editor-block-toolbar {
-				flex-grow: initial;
 				width: initial;
 
 				// Add a border as separator in the block toolbar.
@@ -330,38 +300,6 @@
 				margin-left: -$border-width;
 				margin-bottom: -$border-width;
 			}
-		}
-	}
-
-	// on tablet viewports the toolbar is fixed
-	// on top of interface header and covers the whole header
-	// except for the inserter on the left
-	@include break-medium() {
-		&.is-fixed {
-			width: calc(100% - #{$toolbar-margin});
-
-			.show-icon-labels & {
-				width: calc(100% + 40px - #{$toolbar-margin}); //there are no undo, redo and list view buttons
-			}
-
-		}
-	}
-
-	// on desktop viewports the toolbar is fixed
-	// on top of interface header and leaves room
-	// for the block inserter the publish button
-	@include break-large() {
-		&.is-fixed {
-			width: auto;
-			.show-icon-labels & {
-				width: auto; //there are no undo, redo and list view buttons
-			}
-		}
-		.is-fullscreen-mode &.is-fixed {
-			// in full screen mode we need to account for
-			// the combined with of the tools at the right of the header and the margin left
-			// of the toolbar which includes four buttons
-			width: calc(100% - 280px - #{4 * $grid-unit-80});
 		}
 	}
 }

--- a/packages/block-editor/src/components/block-tools/style.scss
+++ b/packages/block-editor/src/components/block-tools/style.scss
@@ -106,7 +106,7 @@
 
 	&.is-fixed {
 		position: fixed;
-		top: 107px; // Magic number. Needs updated. Should be whatever the toolbar + admin toolbar is?
+		top: $admin-bar-height-big + $header-height;
 		z-index: z-index(".block-editor-block-popover");
 		width: 100%;
 		overflow: hidden;
@@ -118,6 +118,7 @@
 
 		border: none;
 		border-bottom: $border-width solid $gray-200;
+		border-top: $border-width solid $gray-200;
 		border-radius: 0;
 
 		.block-editor-block-toolbar .components-toolbar-group,
@@ -147,7 +148,7 @@
 			width: auto;
 
 			// remove the border
-			border-bottom: none;
+			border: none;
 
 			&.is-collapsed {
 				width: initial;

--- a/packages/block-editor/src/components/index.js
+++ b/packages/block-editor/src/components/index.js
@@ -126,6 +126,7 @@ export { default as BlockSettingsMenuControls } from './block-settings-menu-cont
 export { default as BlockTitle } from './block-title';
 export { default as BlockToolbar } from './block-toolbar';
 export { default as BlockTools } from './block-tools';
+export { default as _experimentalSelectedBlockTools } from './block-tools/selected-block-tools';
 export {
 	default as CopyHandler,
 	useClipboardHandler as __unstableUseClipboardHandler,

--- a/packages/edit-post/src/components/header/header-toolbar/index.js
+++ b/packages/edit-post/src/components/header/header-toolbar/index.js
@@ -7,6 +7,7 @@ import { __, _x } from '@wordpress/i18n';
 import {
 	NavigableToolbar,
 	ToolSelector,
+	_experimentalSelectedBlockTools,
 	store as blockEditorStore,
 	privateApis as blockEditorPrivateApis,
 } from '@wordpress/block-editor';
@@ -130,52 +131,59 @@ function HeaderToolbar() {
 	const shortLabel = ! isInserterOpened ? __( 'Add' ) : __( 'Close' );
 
 	return (
-		<NavigableToolbar
-			className="edit-post-header-toolbar"
-			aria-label={ toolbarAriaLabel }
-			shouldUseKeyboardFocusShortcut={ ! blockToolbarCanBeFocused }
-		>
-			<div className="edit-post-header-toolbar__left">
-				<ToolbarItem
-					ref={ inserterButton }
-					as={ Button }
-					className="edit-post-header-toolbar__inserter-toggle"
-					variant="primary"
-					isPressed={ isInserterOpened }
-					onMouseDown={ preventDefault }
-					onClick={ toggleInserter }
-					disabled={ ! isInserterEnabled }
-					icon={ plus }
-					label={ showIconLabels ? shortLabel : longLabel }
-					showTooltip={ ! showIconLabels }
-				/>
-				{ ( isWideViewport || ! showIconLabels ) && (
-					<>
-						{ isLargeViewport && ! hasFixedToolbar && (
+		<>
+			<NavigableToolbar
+				className="edit-post-header-toolbar"
+				aria-label={ toolbarAriaLabel }
+				shouldUseKeyboardFocusShortcut={ ! blockToolbarCanBeFocused }
+			>
+				<div className="edit-post-header-toolbar__left">
+					<ToolbarItem
+						ref={ inserterButton }
+						as={ Button }
+						className="edit-post-header-toolbar__inserter-toggle"
+						variant="primary"
+						isPressed={ isInserterOpened }
+						onMouseDown={ preventDefault }
+						onClick={ toggleInserter }
+						disabled={ ! isInserterEnabled }
+						icon={ plus }
+						label={ showIconLabels ? shortLabel : longLabel }
+						showTooltip={ ! showIconLabels }
+					/>
+					{ ( isWideViewport || ! showIconLabels ) && (
+						<>
+							{ isLargeViewport && ! hasFixedToolbar && (
+								<ToolbarItem
+									as={ ToolSelector }
+									showTooltip={ ! showIconLabels }
+									variant={
+										showIconLabels ? 'tertiary' : undefined
+									}
+									disabled={ isTextModeEnabled }
+								/>
+							) }
 							<ToolbarItem
-								as={ ToolSelector }
+								as={ EditorHistoryUndo }
 								showTooltip={ ! showIconLabels }
 								variant={
 									showIconLabels ? 'tertiary' : undefined
 								}
-								disabled={ isTextModeEnabled }
 							/>
-						) }
-						<ToolbarItem
-							as={ EditorHistoryUndo }
-							showTooltip={ ! showIconLabels }
-							variant={ showIconLabels ? 'tertiary' : undefined }
-						/>
-						<ToolbarItem
-							as={ EditorHistoryRedo }
-							showTooltip={ ! showIconLabels }
-							variant={ showIconLabels ? 'tertiary' : undefined }
-						/>
-						{ overflowItems }
-					</>
-				) }
-			</div>
-		</NavigableToolbar>
+							<ToolbarItem
+								as={ EditorHistoryRedo }
+								showTooltip={ ! showIconLabels }
+								variant={
+									showIconLabels ? 'tertiary' : undefined
+								}
+							/>
+							{ overflowItems }
+						</>
+					) }
+				</div>
+			</NavigableToolbar>
+			<_experimentalSelectedBlockTools isFixed={ hasFixedToolbar } />
+		</>
 	);
 }
 

--- a/packages/edit-post/src/components/header/style.scss
+++ b/packages/edit-post/src/components/header/style.scss
@@ -7,6 +7,14 @@
 	// The header should never be wider than the viewport, or buttons might be hidden. Especially relevant at high zoom levels. Related to https://core.trac.wordpress.org/ticket/47603#ticket.
 	max-width: 100vw;
 
+	.is-fixed-toolbar-visible & {
+		margin-bottom: 47px; // Magic number for the height of the toolbar. Address this is we merge this.
+
+		@include break-medium() {
+			margin-bottom: 0;
+		}
+	}
+
 	// Make toolbar sticky on larger breakpoints
 	@include break-zoomed-in {
 		flex-wrap: nowrap;

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -57,7 +57,9 @@ import StartPageOptions from '../start-page-options';
 import { store as editPostStore } from '../../store';
 import { unlock } from '../../lock-unlock';
 
-const { getLayoutStyles } = unlock( blockEditorPrivateApis );
+const { getLayoutStyles, useShouldContextualToolbarShow } = unlock(
+	blockEditorPrivateApis
+);
 
 const interfaceLabels = {
 	/* translators: accessibility text for the editor top bar landmark region. */
@@ -194,6 +196,10 @@ function Layout() {
 			hasBlockSelected ? 'edit-post/block' : 'edit-post/document'
 		);
 
+	// Using this to determine if the toolbar is present or not on smaller screens as
+	// the post editor content needs to be pushed down when the toolbar is visible.
+	const { fixedToolbarCanBeFocused } = useShouldContextualToolbarShow();
+
 	// Inserter and Sidebars are mutually exclusive
 	useEffect( () => {
 		if ( sidebarIsOpened && ! isHugeViewport ) {
@@ -222,6 +228,7 @@ function Layout() {
 
 	const className = classnames( 'edit-post-layout', 'is-mode-' + mode, {
 		'is-sidebar-opened': sidebarIsOpened,
+		'is-fixed-toolbar-visible': !! fixedToolbarCanBeFocused,
 		'has-fixed-toolbar': hasFixedToolbar,
 		'has-metaboxes': hasActiveMetaboxes,
 		'show-icon-labels': showIconLabels,

--- a/packages/edit-site/src/components/app/index.js
+++ b/packages/edit-site/src/components/app/index.js
@@ -5,7 +5,7 @@ import { SlotFillProvider, Popover } from '@wordpress/components';
 import { UnsavedChangesWarning } from '@wordpress/editor';
 import { ShortcutProvider } from '@wordpress/keyboard-shortcuts';
 import { store as noticesStore } from '@wordpress/notices';
-import { useDispatch } from '@wordpress/data';
+import { useSelect, useDispatch } from '@wordpress/data';
 import { __, sprintf } from '@wordpress/i18n';
 import { PluginArea } from '@wordpress/plugins';
 import { privateApis as routerPrivateApis } from '@wordpress/router';
@@ -15,6 +15,8 @@ import { privateApis as routerPrivateApis } from '@wordpress/router';
  */
 import Layout from '../layout';
 import { GlobalStylesProvider } from '../global-styles/global-styles-provider';
+import getBlockEditorProvider from '../block-editor/get-block-editor-provider';
+import { store as editSiteStore } from '../../store';
 import { unlock } from '../../lock-unlock';
 
 const { RouterProvider } = unlock( routerPrivateApis );
@@ -34,16 +36,27 @@ export default function App() {
 		);
 	}
 
+	const entityType = useSelect(
+		( select ) => select( editSiteStore ).getEditedPostType(),
+		[]
+	);
+
+	// Choose the provider based on the entity type currently
+	// being edited.
+	const BlockEditorProvider = getBlockEditorProvider( entityType );
+
 	return (
 		<ShortcutProvider style={ { height: '100%' } }>
 			<SlotFillProvider>
 				<GlobalStylesProvider>
-					<Popover.Slot />
-					<UnsavedChangesWarning />
-					<RouterProvider>
-						<Layout />
-						<PluginArea onError={ onPluginAreaError } />
-					</RouterProvider>
+					<BlockEditorProvider>
+						<Popover.Slot />
+						<UnsavedChangesWarning />
+						<RouterProvider>
+							<Layout />
+							<PluginArea onError={ onPluginAreaError } />
+						</RouterProvider>
+					</BlockEditorProvider>
 				</GlobalStylesProvider>
 			</SlotFillProvider>
 		</ShortcutProvider>

--- a/packages/edit-site/src/components/block-editor/index.js
+++ b/packages/edit-site/src/components/block-editor/index.js
@@ -3,7 +3,6 @@
  */
 import { BlockInspector } from '@wordpress/block-editor';
 import { privateApis as editPatternsPrivateApis } from '@wordpress/patterns';
-import { ReusableBlocksMenuItems } from '@wordpress/reusable-blocks';
 
 /**
  * Internal dependencies
@@ -25,7 +24,6 @@ export default function BlockEditor() {
 			<SiteEditorCanvas />
 
 			<PatternsMenuItems />
-			<ReusableBlocksMenuItems />
 		</>
 	);
 }

--- a/packages/edit-site/src/components/block-editor/index.js
+++ b/packages/edit-site/src/components/block-editor/index.js
@@ -1,33 +1,22 @@
 /**
  * WordPress dependencies
  */
-import { useSelect } from '@wordpress/data';
 import { BlockInspector } from '@wordpress/block-editor';
 import { privateApis as editPatternsPrivateApis } from '@wordpress/patterns';
+import { ReusableBlocksMenuItems } from '@wordpress/reusable-blocks';
 
 /**
  * Internal dependencies
  */
 import TemplatePartConverter from '../template-part-converter';
 import { SidebarInspectorFill } from '../sidebar-edit-mode';
-import { store as editSiteStore } from '../../store';
 import SiteEditorCanvas from './site-editor-canvas';
-import getBlockEditorProvider from './get-block-editor-provider';
 
 import { unlock } from '../../lock-unlock';
 const { PatternsMenuItems } = unlock( editPatternsPrivateApis );
 export default function BlockEditor() {
-	const entityType = useSelect(
-		( select ) => select( editSiteStore ).getEditedPostType(),
-		[]
-	);
-
-	// Choose the provider based on the entity type currently
-	// being edited.
-	const BlockEditorProvider = getBlockEditorProvider( entityType );
-
 	return (
-		<BlockEditorProvider>
+		<>
 			<TemplatePartConverter />
 			<SidebarInspectorFill>
 				<BlockInspector />
@@ -36,6 +25,7 @@ export default function BlockEditor() {
 			<SiteEditorCanvas />
 
 			<PatternsMenuItems />
-		</BlockEditorProvider>
+			<ReusableBlocksMenuItems />
+		</>
 	);
 }

--- a/packages/edit-site/src/components/layout/index.js
+++ b/packages/edit-site/src/components/layout/index.js
@@ -27,6 +27,7 @@ import {
 } from '@wordpress/commands';
 import { store as preferencesStore } from '@wordpress/preferences';
 import {
+	_experimentalSelectedBlockTools,
 	privateApis as blockEditorPrivateApis,
 	useBlockCommands,
 } from '@wordpress/block-editor';
@@ -229,35 +230,40 @@ export default function Layout() {
 
 					<AnimatePresence initial={ false }>
 						{ isEditorPage && isEditing && (
-							<NavigableRegion
-								key="header"
-								className="edit-site-layout__header"
-								ariaLabel={ __( 'Editor top bar' ) }
-								as={ motion.div }
-								variants={ {
-									isDistractionFree: { opacity: 0, y: 0 },
-									isDistractionFreeHovering: {
-										opacity: 1,
-										y: 0,
-									},
-									view: { opacity: 1, y: '-100%' },
-									edit: { opacity: 1, y: 0 },
-								} }
-								exit={ {
-									y: '-100%',
-								} }
-								initial={ {
-									opacity: isDistractionFree ? 1 : 0,
-									y: isDistractionFree ? 0 : '-100%',
-								} }
-								transition={ {
-									type: 'tween',
-									duration: disableMotion ? 0 : 0.2,
-									ease: 'easeOut',
-								} }
-							>
-								<Header />
-							</NavigableRegion>
+							<>
+								<NavigableRegion
+									key="header"
+									className="edit-site-layout__header"
+									ariaLabel={ __( 'Editor top bar' ) }
+									as={ motion.div }
+									variants={ {
+										isDistractionFree: { opacity: 0, y: 0 },
+										isDistractionFreeHovering: {
+											opacity: 1,
+											y: 0,
+										},
+										view: { opacity: 1, y: '-100%' },
+										edit: { opacity: 1, y: 0 },
+									} }
+									exit={ {
+										y: '-100%',
+									} }
+									initial={ {
+										opacity: isDistractionFree ? 1 : 0,
+										y: isDistractionFree ? 0 : '-100%',
+									} }
+									transition={ {
+										type: 'tween',
+										duration: disableMotion ? 0 : 0.2,
+										ease: 'easeOut',
+									} }
+								>
+									<Header />
+								</NavigableRegion>
+								<_experimentalSelectedBlockTools
+									isFixed={ hasFixedToolbar }
+								/>
+							</>
 						) }
 					</AnimatePresence>
 				</motion.div>


### PR DESCRIPTION
Large refactor/spike to test out how combining block tools in the DOM might be possible, as discussed in https://github.com/WordPress/gutenberg/issues/53013. All mouse + visual placements should be the same. 

This is a big commit with a large potential for bugs. Think of this as a spike or POC for now. There'll be a lot to address. Some general TODOs:
- [ ] Refactor shared code between empty-block-inserter and selected-block-tools
- [ ] More explicitly pass the popover slot and content ref into the SelectedBlockTools
- [ ] Shortcut/keystrokes for returning from the toolbar to where the cursor was before moving into the toolbar
- [ ] Inline Tools either move to the top toolbar or get inserted into the main block toolbar (think image caption formatting tools)
- [ ] Visual styles for the top toolbar

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Moving all Document and Block Tools together into the DOM.

## Why?
- Find a more accessible implementation of the toolbars that can be better communicated to AT
- Allow tab and shift + tab to work natively in the editor (i.e. a tab keypress should indent the text)

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Moves Block Tools into the editor header

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
