### PR TITLE
Tweak, and add, more consistent commands

### DIFF
--- a/packages/core-commands/src/site-editor-navigation-commands.js
+++ b/packages/core-commands/src/site-editor-navigation-commands.js
@@ -10,6 +10,7 @@ import {
 	post,
 	page,
 	layout,
+	symbol,
 	symbolFilled,
 	styles,
 	navigation,
@@ -135,7 +136,7 @@ function useSiteEditorBasicNavigationCommands() {
 
 		result.push( {
 			name: 'core/edit-site/open-navigation',
-			label: __( 'Open navigation' ),
+			label: __( 'Navigation' ),
 			icon: navigation,
 			callback: ( { close } ) => {
 				const args = {
@@ -152,26 +153,8 @@ function useSiteEditorBasicNavigationCommands() {
 		} );
 
 		result.push( {
-			name: 'core/edit-site/open-pages',
-			label: __( 'Open pages' ),
-			icon: page,
-			callback: ( { close } ) => {
-				const args = {
-					path: '/page',
-				};
-				const targetUrl = addQueryArgs( 'site-editor.php', args );
-				if ( isSiteEditor ) {
-					history.push( args );
-				} else {
-					document.location = targetUrl;
-				}
-				close();
-			},
-		} );
-
-		result.push( {
-			name: 'core/edit-site/open-style-variations',
-			label: __( 'Open style variations' ),
+			name: 'core/edit-site/open-styles',
+			label: __( 'Styles' ),
 			icon: styles,
 			callback: ( { close } ) => {
 				const args = {
@@ -188,12 +171,48 @@ function useSiteEditorBasicNavigationCommands() {
 		} );
 
 		result.push( {
+			name: 'core/edit-site/open-pages',
+			label: __( 'Pages' ),
+			icon: page,
+			callback: ( { close } ) => {
+				const args = {
+					path: '/page',
+				};
+				const targetUrl = addQueryArgs( 'site-editor.php', args );
+				if ( isSiteEditor ) {
+					history.push( args );
+				} else {
+					document.location = targetUrl;
+				}
+				close();
+			},
+		} );
+
+		result.push( {
 			name: 'core/edit-site/open-templates',
-			label: __( 'Open templates' ),
+			label: __( 'Templates' ),
 			icon: layout,
 			callback: ( { close } ) => {
 				const args = {
 					path: '/wp_template',
+				};
+				const targetUrl = addQueryArgs( 'site-editor.php', args );
+				if ( isSiteEditor ) {
+					history.push( args );
+				} else {
+					document.location = targetUrl;
+				}
+				close();
+			},
+		} );
+
+		result.push( {
+			name: 'core/edit-site/open-patterns',
+			label: __( 'Patterns' ),
+			icon: symbol,
+			callback: ( { close } ) => {
+				const args = {
+					path: '/patterns',
 				};
 				const targetUrl = addQueryArgs( 'site-editor.php', args );
 				if ( isSiteEditor ) {

--- a/packages/edit-post/src/components/keyboard-shortcuts/index.js
+++ b/packages/edit-post/src/components/keyboard-shortcuts/index.js
@@ -227,8 +227,8 @@ function KeyboardShortcuts() {
 		toggleFeature( 'distractionFree' );
 		createInfoNotice(
 			isFeatureActive( 'distractionFree' )
-				? __( 'Distraction free mode turned on.' )
-				: __( 'Distraction free mode turned off.' ),
+				? __( 'Distraction free on.' )
+				: __( 'Distraction free off.' ),
 			{
 				id: 'core/edit-post/distraction-free-mode/notice',
 				type: 'snackbar',

--- a/packages/edit-post/src/hooks/commands/use-common-commands.js
+++ b/packages/edit-post/src/hooks/commands/use-common-commands.js
@@ -151,7 +151,7 @@ export default function useCommonCommands() {
 
 	useCommand( {
 		name: 'core/open-preferences',
-		label: __( 'Open editor preferences' ),
+		label: __( 'Editor preferences' ),
 		icon: cog,
 		callback: () => {
 			openModal( PREFERENCES_MODAL_NAME );
@@ -160,7 +160,7 @@ export default function useCommonCommands() {
 
 	useCommand( {
 		name: 'core/open-shortcut-help',
-		label: __( 'Open keyboard shortcuts' ),
+		label: __( 'Keyboard shortcuts' ),
 		icon: keyboard,
 		callback: () => {
 			openModal( KEYBOARD_SHORTCUT_HELP_MODAL_NAME );
@@ -178,8 +178,8 @@ export default function useCommonCommands() {
 			close();
 			createInfoNotice(
 				showBlockBreadcrumbs
-					? __( 'Breadcrumbs off.' )
-					: __( 'Breadcrumbs on.' ),
+					? __( 'Breadcrumbs hidden.' )
+					: __( 'Breadcrumbs visible.' ),
 				{
 					id: 'core/edit-post/toggle-breadcrumbs/notice',
 					type: 'snackbar',

--- a/packages/edit-site/src/hooks/commands/use-common-commands.js
+++ b/packages/edit-site/src/hooks/commands/use-common-commands.js
@@ -4,7 +4,7 @@
 import { useMemo } from '@wordpress/element';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
-import { trash, backup, help, styles, external } from '@wordpress/icons';
+import { trash, backup, help, styles, external, brush } from '@wordpress/icons';
 import { useCommandLoader, useCommand } from '@wordpress/commands';
 import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
 import { privateApis as routerPrivateApis } from '@wordpress/router';
@@ -218,8 +218,8 @@ function useGlobalStylesOpenCssCommands() {
 		return [
 			{
 				name: 'core/edit-site/open-styles-css',
-				label: __( 'Open CSS' ),
-				icon: styles,
+				label: __( 'Customize CSS' ),
+				icon: brush,
 				callback: ( { close } ) => {
 					close();
 					if ( ! isEditorPage ) {
@@ -272,7 +272,7 @@ function useGlobalStylesOpenRevisionsCommands() {
 		return [
 			{
 				name: 'core/edit-site/open-global-styles-revisions',
-				label: __( 'Open styles revisions' ),
+				label: __( 'Style revisions' ),
 				icon: backup,
 				callback: ( { close } ) => {
 					close();

--- a/packages/edit-site/src/hooks/commands/use-edit-mode-commands.js
+++ b/packages/edit-site/src/hooks/commands/use-edit-mode-commands.js
@@ -83,6 +83,37 @@ function usePageContentFocusCommands() {
 	return { isLoading: false, commands };
 }
 
+function useEditorModeCommands() {
+	const { switchEditorMode } = useDispatch( editSiteStore );
+	const { canvasMode, editorMode } = useSelect(
+		( select ) => ( {
+			canvasMode: unlock( select( editSiteStore ) ).getCanvasMode(),
+			editorMode: select( editSiteStore ).getEditorMode(),
+		} ),
+		[]
+	);
+
+	if ( canvasMode !== 'edit' ) {
+		return { isLoading: false, commands: [] };
+	}
+
+	const commands = [];
+
+	if ( editorMode === 'text' ) {
+		commands.push( {
+			name: 'core/exit-code-editor',
+			label: __( 'Exit code editor' ),
+			icon: code,
+			callback: ( { close } ) => {
+				switchEditorMode( 'visual' );
+				close();
+			},
+		} );
+	}
+
+	return { isLoading: false, commands };
+}
+
 function useManipulateDocumentCommands() {
 	const { isLoaded, record: template } = useEditedEntityRecord();
 	const { removeTemplate, revertTemplate } = useDispatch( editSiteStore );
@@ -244,8 +275,8 @@ function useEditUICommands() {
 			toggle( 'core/edit-site', 'distractionFree' );
 			createInfoNotice(
 				getPreference( 'core/edit-site', 'distractionFree' )
-					? __( 'Distraction free mode turned on.' )
-					: __( 'Distraction free mode turned off.' ),
+					? __( 'Distraction free on.' )
+					: __( 'Distraction free off.' ),
 				{
 					id: 'core/edit-site/distraction-free-mode/notice',
 					type: 'snackbar',
@@ -265,19 +296,21 @@ function useEditUICommands() {
 		},
 	} );
 
-	commands.push( {
-		name: 'core/toggle-code-editor',
-		label: __( 'Toggle code editor' ),
-		icon: code,
-		callback: ( { close } ) => {
-			switchEditorMode( editorMode === 'visual' ? 'text' : 'visual' );
-			close();
-		},
-	} );
+	if ( editorMode === 'visual' ) {
+		commands.push( {
+			name: 'core/toggle-code-editor',
+			label: __( 'Open code editor' ),
+			icon: code,
+			callback: ( { close } ) => {
+				switchEditorMode( 'text' );
+				close();
+			},
+		} );
+	}
 
 	commands.push( {
 		name: 'core/open-preferences',
-		label: __( 'Open editor preferences' ),
+		label: __( 'Editor preferences' ),
 		icon: cog,
 		callback: () => {
 			openModal( PREFERENCES_MODAL_NAME );
@@ -286,7 +319,7 @@ function useEditUICommands() {
 
 	commands.push( {
 		name: 'core/open-shortcut-help',
-		label: __( 'Open keyboard shortcuts' ),
+		label: __( 'Keyboard shortcuts' ),
 		icon: keyboard,
 		callback: () => {
 			openModal( KEYBOARD_SHORTCUT_HELP_MODAL_NAME );
@@ -302,6 +335,15 @@ function useEditUICommands() {
 		callback: ( { close } ) => {
 			toggle( 'core/edit-site', 'showBlockBreadcrumbs' );
 			close();
+			createInfoNotice(
+				showBlockBreadcrumbs
+					? __( 'Breadcrumbs hidden.' )
+					: __( 'Breadcrumbs visible.' ),
+				{
+					id: 'core/edit-site/toggle-breadcrumbs/notice',
+					type: 'snackbar',
+				}
+			);
 		},
 	} );
 
@@ -312,6 +354,12 @@ function useEditUICommands() {
 }
 
 export function useEditModeCommands() {
+	useCommandLoader( {
+		name: 'core/exit-code-editor',
+		hook: useEditorModeCommands,
+		context: 'site-editor-edit',
+	} );
+
 	useCommandLoader( {
 		name: 'core/edit-site/page-content-focus',
 		hook: usePageContentFocusCommands,

--- a/packages/edit-site/src/hooks/commands/use-edit-mode-commands.js
+++ b/packages/edit-site/src/hooks/commands/use-edit-mode-commands.js
@@ -93,7 +93,7 @@ function useEditorModeCommands() {
 		[]
 	);
 
-	if ( canvasMode !== 'edit' ) {
+	if ( canvasMode !== 'edit' || editorMode !== 'text' ) {
 		return { isLoading: false, commands: [] };
 	}
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
- Further cleaning up of existing commands.
- Improves code/visual editor commands (adds suggestion to exit the code editor when in it). 
- Use "on/off" and  "visible/hidden" language for command snackbars. 
- Removes verbs from the beginning of most commands. I'm finding they are distracting and reduces scanning. 
- Add a couple missing commands. 

## Why?
Trying to establish consistency with command language, style, and actions. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a post or page.
2. Open the command palette. 
3. Run the Open code editor command. 
4. See "Exit code editor" suggested. 
5. See other command tweaks. 

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Visuals <!-- if applicable -->

### Before
<img width="417" alt="CleanShot 2023-08-09 at 17 00 23" src="https://github.com/WordPress/gutenberg/assets/1813435/54489505-23a0-4610-92b7-ab562622b64e">
<img width="416" alt="CleanShot 2023-08-09 at 17 01 08" src="https://github.com/WordPress/gutenberg/assets/1813435/ab09883f-d1a6-4297-af24-a6c224c99750">


### After 
<img width="417" alt="CleanShot 2023-08-09 at 16 45 46" src="https://github.com/WordPress/gutenberg/assets/1813435/d6d2d252-152e-464f-85d8-4cb86f515231">
<img width="417" alt="CleanShot 2023-08-09 at 16 46 48" src="https://github.com/WordPress/gutenberg/assets/1813435/53c08346-91bf-45fa-9e1a-88fdaf8d5730">
<img width="419" alt="CleanShot 2023-08-09 at 16 46 34" src="https://github.com/WordPress/gutenberg/assets/1813435/6c27b179-cdae-4d1c-b226-14b2f6a53bc0">
