### PR TITLE
Command palette: Fix metrics for resting and no results view

### DIFF
--- a/packages/commands/src/components/style.scss
+++ b/packages/commands/src/components/style.scss
@@ -94,7 +94,7 @@
 		max-height: 368px; // Specific to not have commands overflow oddly.
 		overflow: auto;
 
-		& > [cmdk-list-sizer]:not(:empty) {
+		& [cmdk-list-sizer] > [cmdk-group] > [cmdk-group-items]:not(:empty) {
 			padding: 0 $grid-unit $grid-unit;
 		}
 	}
@@ -103,9 +103,9 @@
 		display: flex;
 		align-items: center;
 		justify-content: center;
-		height: $grid-unit-80;
 		white-space: pre-wrap;
 		color: $gray-900;
+		padding: $grid-unit-10 0 $grid-unit-40;
 	}
 
 	[cmdk-loading] {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Small style tweaks to improve metrics. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open the command palette.
2. See proper metrics in the resting state.
3. Search for something random. 
4. See proper metrics for no results. 

## Screenshots or screencast <!-- if applicable -->

| Before  | After |
| ------------- | ------------- |
|<img width="439" alt="CleanShot 2023-08-09 at 17 12 15" src="https://github.com/WordPress/gutenberg/assets/1813435/ab4ffdd9-1192-4d8e-a0fa-aaa305f632bb"><img width="441" alt="CleanShot 2023-08-09 at 17 12 20" src="https://github.com/WordPress/gutenberg/assets/1813435/0db92281-7ea4-4a7f-b58c-bfa137aafc4d"> |<img width="458" alt="CleanShot 2023-08-09 at 17 09 45" src="https://github.com/WordPress/gutenberg/assets/1813435/3166a3a2-d818-4fd9-9cfe-87be0cac26de"><img width="445" alt="CleanShot 2023-08-09 at 17 09 55" src="https://github.com/WordPress/gutenberg/assets/1813435/08b896bd-cfa2-44fe-b702-2cc4acffd348">|




