### PR TITLE
Update package-lock.json to match 16.4.0 version number

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "gutenberg",
-			"version": "16.4.0-rc.1",
+			"version": "16.4.0",
 			"hasInstallScript": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Update plugin version in `package-lock.json` to be 16.4.0.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

It looks like one line of the bump plugin version in #53489 might have been missed, as the static analysis Github action is currently failing with the following:

<img width="799" alt="image" src="https://github.com/WordPress/gutenberg/assets/14988353/9527299b-2fcb-4c1c-bb5b-eca7c8dfb718">

I'm wondering if this is related to the npm upgrade in https://github.com/WordPress/gutenberg/pull/53426? CC: @youknowriad 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Update the affected line.

Separately, in a follow-up we might need to update the `Update plugin version` step in Github workflows, too: https://github.com/WordPress/gutenberg/blob/eb6c362d580cecdbcd0116c7a6acbc7b5547be56/.github/workflows/build-plugin-zip.yml#L125

However, for now, let's see if updating this line allows the Github actions to pass again.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Check that Github actions pass, specifically the static analysis job.
