### PR TITLE
Add accordion and toggle keywords to details block

### DIFF
--- a/packages/block-library/src/details/block.json
+++ b/packages/block-library/src/details/block.json
@@ -5,7 +5,7 @@
 	"title": "Details",
 	"category": "text",
 	"description": "Hide and show additional content.",
-	"keywords": [ "accordion", "summary", "toggle" ],
+	"keywords": [ "accordion", "summary", "toggle", "disclosure" ],
 	"textdomain": "default",
 	"attributes": {
 		"showContent": {

--- a/packages/block-library/src/details/block.json
+++ b/packages/block-library/src/details/block.json
@@ -5,7 +5,7 @@
 	"title": "Details",
 	"category": "text",
 	"description": "Hide and show additional content.",
-	"keywords": [ "disclosure", "summary", "hide" ],
+	"keywords": [ "accordion", "summary", "toggle" ],
 	"textdomain": "default",
 	"attributes": {
 		"showContent": {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Following up on the discussion around details block discovery https://github.com/WordPress/gutenberg/pull/45055#issuecomment-1299960936 and [this Twitter/X thread](https://twitter.com/matias_ventura/status/1689356828893646850), adding the `accordion` and `toggle` keywords. 

## Why?
As-is, you have to understand what a `<details>` element is, to find it. Adding common terms of `accordion` and `toggle` do not indicate this is a proper accordion, but do help with discoverability. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open list view.
2. Search for `accordion` and `toggle`. 
3. See the details block as a search result. 
