### PR TITLE
Github Workflow: Update update plugin version to also update nested version in package-lock.json

### DIFF
--- a/.github/workflows/build-plugin-zip.yml
+++ b/.github/workflows/build-plugin-zip.yml
@@ -122,7 +122,7 @@ jobs:
                   VERSION: ${{ steps.get_version.outputs.new_version }}
               run: |
                   cat <<< $(jq --tab --arg version "${VERSION}" '.version = $version' package.json) > package.json
-                  cat <<< $(jq --tab --arg version "${VERSION}" '.version = $version' package-lock.json) > package-lock.json
+                  cat <<< $(jq --tab --arg version "${VERSION}" '.version = $version | .packages[""].version = $version' package-lock.json) > package-lock.json
                   sed -i "s/${{ steps.get_version.outputs.old_version }}/${VERSION}/g" gutenberg.php
 
             - name: Commit the version bump to the release branch


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Follow-up to #53499 

Update the "update plugin version" workflow step so that it also updates the nested package version for Gutenberg.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

In https://github.com/WordPress/gutenberg/pull/53426, the Node and NPM versions were updated, which affects the structure of the `package-lock.json` file. As a result, there is now a `.packages[''].version` key that also needs to be bumped when version numbers are bumped.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Update the `jq` logic so that it updates the `.packages[""].version` attribute in addition to the root `.version` attribute.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

I'm not sure how to test this in an automatic way by running the step, however we can manually test the updated line by running it in a local environment.

1. Make sure you have `jq` installed locally. On a Mac, you can install it by running `brew install jq`.
2. Run the following line, which sets the `VERSION` variable before then running the code change proposed in this PR:

In this example we're updating to the string `apples` to make it clear, but in real world usage, the variable would be set to a real version number.

```
VERSION="apples" && cat <<< $(jq --tab --arg version "${VERSION}" '.version = $version | .packages[""].version = $version' package-lock.json) > package-lock.json
```

If you then run `git diff`, you should see that both the root `.version` attribute, and `.packages[""].version` have been updated:

<img width="380" alt="image" src="https://github.com/WordPress/gutenberg/assets/14988353/ab3f8b31-f790-4615-85e3-b173a336ae0d">