### PR TITLE
Image Editor: Fix ESLint warnings and remove unnecessary dependencies

### DIFF
--- a/packages/block-editor/src/components/image-editor/use-save-image.js
+++ b/packages/block-editor/src/components/image-editor/use-save-image.js
@@ -13,9 +13,6 @@ import { __unstableStripHTML as stripHTML } from '@wordpress/dom';
 export default function useSaveImage( {
 	crop,
 	rotation,
-	height,
-	width,
-	aspect,
 	url,
 	id,
 	onSaveImage,
@@ -27,7 +24,7 @@ export default function useSaveImage( {
 	const cancel = useCallback( () => {
 		setIsInProgress( false );
 		onFinishEditing();
-	}, [ setIsInProgress, onFinishEditing ] );
+	}, [ onFinishEditing ] );
 
 	const apply = useCallback( () => {
 		setIsInProgress( true );
@@ -86,16 +83,12 @@ export default function useSaveImage( {
 				onFinishEditing();
 			} );
 	}, [
-		setIsInProgress,
 		crop,
 		rotation,
-		height,
-		width,
-		aspect,
+		id,
 		url,
 		onSaveImage,
 		createErrorNotice,
-		setIsInProgress,
 		onFinishEditing,
 	] );
 

--- a/packages/block-editor/src/components/image-editor/use-transform-image.js
+++ b/packages/block-editor/src/components/image-editor/use-transform-image.js
@@ -30,10 +30,10 @@ export default function useTransformImage( {
 			setEditedUrl();
 			setRotation( angle );
 			setAspect( defaultAspect );
-			setPosition( {
-				x: -( position.y * naturalAspectRatio ),
-				y: position.x * naturalAspectRatio,
-			} );
+			setPosition( ( prevPosition ) => ( {
+				x: -( prevPosition.y * naturalAspectRatio ),
+				y: prevPosition.x * naturalAspectRatio,
+			} ) );
 			return;
 		}
 
@@ -69,10 +69,10 @@ export default function useTransformImage( {
 				setEditedUrl( URL.createObjectURL( blob ) );
 				setRotation( angle );
 				setAspect( canvas.width / canvas.height );
-				setPosition( {
-					x: -( position.y * naturalAspectRatio ),
-					y: position.x * naturalAspectRatio,
-				} );
+				setPosition( ( prevPosition ) => ( {
+					x: -( prevPosition.y * naturalAspectRatio ),
+					y: prevPosition.x * naturalAspectRatio,
+				} ) );
 			} );
 		}
 
@@ -88,7 +88,7 @@ export default function useTransformImage( {
 		if ( typeof imgCrossOrigin === 'string' ) {
 			el.crossOrigin = imgCrossOrigin;
 		}
-	}, [ rotation, defaultAspect ] );
+	}, [ rotation, defaultAspect, url ] );
 
 	return useMemo(
 		() => ( {


### PR DESCRIPTION
## What?
PR fixes ESLint warnings for `useSaveImage` and `useTransformImage` hooks.

## Why?
Missing or incorrect dependencies can cause unexpected side effects or bugs.

## Testing Instructions
1. Open a post or page.
2. Insert an Image block and select an image.
3. Confirm image editing (cropping, rotation) works as before.
