### PR TITLE
Button: Memoize link value passed to the LinkControl

### DIFF
--- a/packages/block-library/src/button/edit.js
+++ b/packages/block-library/src/button/edit.js
@@ -7,7 +7,7 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useEffect, useState, useRef } from '@wordpress/element';
+import { useEffect, useState, useRef, useMemo } from '@wordpress/element';
 import {
 	Button,
 	ButtonGroup,
@@ -149,6 +149,13 @@ function ButtonEdit( props ) {
 		}
 	}, [ isSelected ] );
 
+	// Memoize link value to avoid overriding the LinkControl's internal state.
+	// This is a temporary fix. See https://github.com/WordPress/gutenberg/issues/51256.
+	const linkValue = useMemo(
+		() => ( { url, opensInNewTab } ),
+		[ url, opensInNewTab ]
+	);
+
 	return (
 		<>
 			<div
@@ -235,7 +242,7 @@ function ButtonEdit( props ) {
 					shift
 				>
 					<LinkControl
-						value={ { url, opensInNewTab } }
+						value={ linkValue }
 						onChange={ ( {
 							url: newURL = '',
 							opensInNewTab: newOpensInNewTab,


### PR DESCRIPTION
## What?
This is similar to #51155
It is related to #51256.

Pass memoized link value to the `LinkControl` component to avoid losing user changes when the`ButtonEdit` component rerenders.

This is a temporary solution until we find a more permanent one for #51256.

## Why?

Referential stability of the `value` object prevents unnecessary value to state sync.

## Testing Instructions
1. Open a post or page.
2. Insert a Button block.
3. Add text and start adding a link to it.
4. Type or paste any URL in the LinkControl input field.
5. Hover/over the block toolbar or change the button width while the link control is open.
6. Confirm entered URL isn't cleared from the input.

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/240569/00b4d2c1-d66e-48cc-bf5e-996466f94859

