### PR TITLE
Writing flow: avoid merging paragraph into Columns

### DIFF
--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -1042,9 +1042,7 @@ export const mergeBlocks =
 					clientIdA
 				);
 				dispatch.removeBlock( clientIdB );
-				dispatch.selectBlock(
-					blockWithSameType.innerBlocks[ 0 ].clientId
-				);
+				dispatch.selectBlock( firstInnerBlock.clientId );
 			} );
 			return;
 		}

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -1025,6 +1025,16 @@ export const mergeBlocks =
 				dispatch.selectBlock( blockA.clientId );
 				return;
 			}
+			const firstInnerBlock = blockWithSameType.innerBlocks[ 0 ];
+			// After switching to the block type, if the first inner block is
+			// not the same type, avoid merging because it's too complex. For
+			// example, a paragraph can be switched to columns block, but the
+			// paragraph is moved two levels deep. Merging resulting in an
+			// additional column would be strange.
+			if ( firstInnerBlock.name !== blockAType.name ) {
+				dispatch.selectBlock( blockA.clientId );
+				return;
+			}
 			registry.batch( () => {
 				dispatch.insertBlocks(
 					blockWithSameType.innerBlocks,

--- a/packages/block-library/src/group/block.json
+++ b/packages/block-library/src/group/block.json
@@ -22,6 +22,7 @@
 	},
 	"supports": {
 		"__experimentalOnEnter": true,
+		"__experimentalOnMerge": true,
 		"__experimentalSettings": true,
 		"align": [ "wide", "full" ],
 		"anchor": true,

--- a/packages/block-library/src/list/block.json
+++ b/packages/block-library/src/list/block.json
@@ -69,6 +69,7 @@
 		},
 		"__unstablePasteTextInline": true,
 		"__experimentalSelector": "ol,ul",
+		"__experimentalOnMerge": true,
 		"__experimentalSlashInserter": true
 	},
 	"editorStyle": "wp-block-list-editor",

--- a/packages/block-library/src/quote/block.json
+++ b/packages/block-library/src/quote/block.json
@@ -31,6 +31,7 @@
 		"anchor": true,
 		"html": false,
 		"__experimentalOnEnter": true,
+		"__experimentalOnMerge": true,
 		"typography": {
 			"fontSize": true,
 			"lineHeight": true,

--- a/test/e2e/specs/editor/blocks/columns.spec.js
+++ b/test/e2e/specs/editor/blocks/columns.spec.js
@@ -240,4 +240,75 @@ test.describe( 'Columns', () => {
 			},
 		] );
 	} );
+
+	test.describe( 'following paragraph', () => {
+		const columnsBlock = {
+			name: 'core/columns',
+			innerBlocks: [
+				{
+					name: 'core/column',
+					innerBlocks: [
+						{
+							name: 'core/paragraph',
+							attributes: { content: '1' },
+						},
+					],
+				},
+				{
+					name: 'core/column',
+					innerBlocks: [
+						{
+							name: 'core/paragraph',
+							attributes: { content: '2' },
+						},
+					],
+				},
+			],
+		};
+
+		test( 'should be deleted on Backspace when empty', async ( {
+			editor,
+			page,
+		} ) => {
+			await editor.insertBlock( columnsBlock );
+			await editor.insertBlock( { name: 'core/paragraph' } );
+
+			await page.keyboard.press( 'Backspace' );
+
+			expect( await editor.getBlocks() ).toMatchObject( [
+				columnsBlock,
+			] );
+
+			// Ensure focus is on the columns block.
+			await page.keyboard.press( 'Backspace' );
+
+			expect( await editor.getBlocks() ).toMatchObject( [] );
+		} );
+
+		test( 'should only select Columns on Backspace when non-empty', async ( {
+			editor,
+			page,
+		} ) => {
+			const paragraphBlock = {
+				name: 'core/paragraph',
+				attributes: { content: 'a' },
+			};
+			await editor.insertBlock( columnsBlock );
+			await editor.insertBlock( paragraphBlock );
+
+			await page.keyboard.press( 'Backspace' );
+
+			expect( await editor.getBlocks() ).toMatchObject( [
+				columnsBlock,
+				paragraphBlock,
+			] );
+
+			// Ensure focus is on the columns block.
+			await page.keyboard.press( 'Backspace' );
+
+			expect( await editor.getBlocks() ).toMatchObject( [
+				paragraphBlock,
+			] );
+		} );
+	} );
 } );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Fixes #45436. When attempting to merge a paragraph into a Columns block, abort merging. Currently a merge is attempted by transforming the paragraph to a Columns block and then merging the column blocks.

## Why?

This merging behaviour doesn't make sense, and on top of that it's broken because the width attributes are not merged correctly.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Only attempt merging if there's block support for it through `__experimentalOnMerge`. There's precedent with `__experimentalOnEnter`.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Create a column with two paragraphs. Create another after the column and press backspace.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
