### PR TITLE
Editor: updateEditorSettings: allow passing a callback

### DIFF
--- a/packages/e2e-tests/specs/editor/plugins/iframed-enqueue-block-editor-settings.test.js
+++ b/packages/e2e-tests/specs/editor/plugins/iframed-enqueue-block-editor-settings.test.js
@@ -43,19 +43,18 @@ describe( 'iframed block editor settings styles', () => {
 		);
 
 		await page.evaluate( () => {
-			const settings = window.wp.data
-				.select( 'core/editor' )
-				.getEditorSettings();
-			wp.data.dispatch( 'core/editor' ).updateEditorSettings( {
-				...settings,
-				styles: [
-					...settings.styles,
-					{
-						css: 'p { border-width: 2px; }',
-						__unstableType: 'plugin',
-					},
-				],
-			} );
+			wp.data
+				.dispatch( 'core/editor' )
+				.updateEditorSettings( ( settings ) => ( {
+					...settings,
+					styles: [
+						...settings.styles,
+						{
+							css: 'p { border-width: 2px; }',
+							__unstableType: 'plugin',
+						},
+					],
+				} ) );
 		} );
 
 		// Expect a 2px border (added in JS).
@@ -73,19 +72,18 @@ describe( 'iframed block editor settings styles', () => {
 			window.wp.data
 				.dispatch( 'core/edit-post' )
 				.toggleFeature( 'themeStyles' );
-			const settings = window.wp.data
-				.select( 'core/editor' )
-				.getEditorSettings();
-			wp.data.dispatch( 'core/editor' ).updateEditorSettings( {
-				...settings,
-				styles: [
-					...settings.styles,
-					{
-						css: 'p { border-width: 2px; }',
-						__unstableType: 'theme',
-					},
-				],
-			} );
+			wp.data
+				.dispatch( 'core/editor' )
+				.updateEditorSettings( ( settings ) => ( {
+					...settings,
+					styles: [
+						...settings.styles,
+						{
+							css: 'p { border-width: 2px; }',
+							__unstableType: 'theme',
+						},
+					],
+				} ) );
 		} );
 
 		// Expect a 1px border because theme styles are disabled.

--- a/packages/editor/src/store/reducer.js
+++ b/packages/editor/src/store/reducer.js
@@ -270,6 +270,12 @@ export function isReady( state = false, action ) {
 export function editorSettings( state = EDITOR_SETTINGS_DEFAULTS, action ) {
 	switch ( action.type ) {
 		case 'UPDATE_EDITOR_SETTINGS':
+			if ( typeof action.settings === 'function' ) {
+				return {
+					...state,
+					...action.settings( state ),
+				};
+			}
 			return {
 				...state,
 				...action.settings,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

`updateEditorSettings` has the potential to suffer from overriding existing settings, if you're not careful. This could happen if you get the existing settings and then call `updateEditorSettings ` at a later point async, for example in a `useEffect`.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Preventing race conditions.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

The solution is to allow passing a callback so settings can be merged synchronously, just like `useState` works.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
