### PR TITLE
Update: Developer documentation to refer to Node 16 instead of 14.

### DIFF
--- a/docs/getting-started/devenv/README.md
+++ b/docs/getting-started/devenv/README.md
@@ -21,10 +21,10 @@ curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash
 ```
 
 Quit and restart terminal
-Install Node.js v14.
+Install Node.js v16.
 
 ```
-nvm install 14
+nvm install 16
 ```
 
 **2. WordPress Development Site**
@@ -71,16 +71,16 @@ Note: On macOS, the required developer tools are not installed by default, if no
 
 <img src="https://developer.wordpress.org/files/2020/07/git-install-prompt.png" alt="Mac git command requires command line developer tools" width="400" height="195"/>
 
-After installing nvm, you need to use it to install Node.js, to install v14, run:
+After installing nvm, you need to use it to install Node.js, to install v16, run:
 
 ```sh
-nvm install 14
+nvm install 16
 ```
 
 If there is an error running the above command, for example a common error that occurs is:
 
 ```sh
-$ nvm install 14
+$ nvm install 16
 zsh: command not found: nvm
 ```
 
@@ -93,17 +93,17 @@ On macOS Catalina, the default shell is zsh, to create the profile file type `to
 After creating the profile file, re-run the install command:
 
 ```sh
-nvm install 14
+nvm install 16
 ```
 
 The important part after installing is being able to use them in your terminal. Open a terminal command-line and type `node -v` and `npm -v` to confirm they are installed.
 
 ```sh
 > node -v
-v14.19.0
+v16.20.1
 
 > npm -v
-6.14.16
+8.19.4
 ```
 
 Your versions may not match exactly, that is fine. The minimum version for Node.js is >= 12 and for npm >= 6.9, using v14 will be supported until upgrade is required.

--- a/packages/lazy-import/README.md
+++ b/packages/lazy-import/README.md
@@ -20,7 +20,7 @@ NPM 6.9.0 or newer is required, since it uses the [package aliases feature](http
 
 Usage is intended to mimic the behavior of the [dynamic `import` function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import#Dynamic_Imports), receiving the name (and optional version specifier) of an NPM package and returning a promise which resolves to the required module.
 
-_**Note:** Currently, this alignment to `import` is superficial, and the module resolution still uses [CommonJS `require`](https://nodejs.org/docs/latest-v12.x/api/modules.html#modules_require_id), rather than the newer [ES Modules support](https://nodejs.org/docs/latest-v14.x/api/esm.html). Future versions of this package will likely support ES Modules, once an LTS release of Node.js including unflagged ES Modules support becomes available._
+_**Note:** Currently, this alignment to `import` is superficial, and the module resolution still uses [CommonJS `require`](https://nodejs.org/docs/latest-v12.x/api/modules.html#modules_require_id), rather than the newer [ES Modules support](https://nodejs.org/docs/latest-v16.x/api/esm.html). Future versions of this package will likely support ES Modules, once an LTS release of Node.js including unflagged ES Modules support becomes available._
 
 The string passed to `lazyImport` can be formatted exactly as you would provide to `npm install`, including an optional version specifier (including [version ranges](https://docs.npmjs.com/misc/semver#ranges)). If the version specifier is omitted, it will be treated as equivalent to `*`, using the version of a locally installed package if available, otherwise installing the latest available version.
 


### PR DESCRIPTION
Updates some documents to refer node 16 the version we use currently instead of node 14.
