### PR TITLE
Set top toolbar size dynamically

### DIFF
--- a/packages/block-editor/src/components/block-toolbar/style.scss
+++ b/packages/block-editor/src/components/block-toolbar/style.scss
@@ -252,6 +252,16 @@
 		flex-shrink: 1;
 	}
 
+	@include break-medium() {
+		.block-editor-block-contextual-toolbar.is-fixed {
+			.components-toolbar,
+			.components-toolbar-group {
+				flex-shrink: 0;
+			}
+		}
+	}
+
+
 	.block-editor-rich-text__inline-format-toolbar-group {
 		.components-button + .components-button {
 			margin-left: 6px;

--- a/packages/block-editor/src/components/block-tools/index.js
+++ b/packages/block-editor/src/components/block-tools/index.js
@@ -5,7 +5,7 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import { useViewportMatch } from '@wordpress/compose';
 import { Popover } from '@wordpress/components';
 import { __unstableUseShortcutEventMatch as useShortcutEventMatch } from '@wordpress/keyboard-shortcuts';
-import { useRef } from '@wordpress/element';
+import { useLayoutEffect, useRef } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -63,6 +63,53 @@ export default function BlockTools( {
 		moveBlocksUp,
 		moveBlocksDown,
 	} = useDispatch( blockEditorStore );
+
+	useLayoutEffect( () => {
+		// don't do anything if not fixed toolbar
+		if ( ! hasFixedToolbar ) {
+			return;
+		}
+
+		const blockToolbar = document.querySelector(
+			'.block-editor-block-contextual-toolbar'
+		);
+
+		if ( ! blockToolbar ) {
+			return;
+		}
+
+		// get the width of the pinned items in the post editor
+		const pinnedItems = document.querySelector(
+			'.edit-post-header__settings'
+		);
+
+		// get the width of the left header in the site editor
+		const leftHeader = document.querySelector(
+			'.edit-site-header-edit-mode__end'
+		);
+
+		const computedToolbarStyle = window.getComputedStyle( blockToolbar );
+		const computedPinnedItemsStyle = pinnedItems
+			? window.getComputedStyle( pinnedItems )
+			: false;
+		const computedLeftHeaderStyle = leftHeader
+			? window.getComputedStyle( leftHeader )
+			: false;
+
+		const marginLeft = parseFloat( computedToolbarStyle.marginLeft );
+		const pinnedItemsWidth = computedPinnedItemsStyle
+			? parseFloat( computedPinnedItemsStyle.width ) + 10 // 10 is the pinned items padding
+			: 0;
+		const leftHeaderWidth = computedLeftHeaderStyle
+			? parseFloat( computedLeftHeaderStyle.width )
+			: 0;
+		// set the new witdth of the toolbar
+		document.querySelector(
+			'.block-editor-block-contextual-toolbar'
+		).style.width = `calc(100% - ${
+			leftHeaderWidth + pinnedItemsWidth + marginLeft
+		}px)`;
+	}, [ hasFixedToolbar ] );
 
 	function onKeyDown( event ) {
 		if ( event.defaultPrevented ) return;

--- a/packages/block-editor/src/components/block-tools/index.js
+++ b/packages/block-editor/src/components/block-tools/index.js
@@ -64,9 +64,11 @@ export default function BlockTools( {
 		moveBlocksDown,
 	} = useDispatch( blockEditorStore );
 
+	const isLargerThanTabletViewport = useViewportMatch( 'medium', '>' );
+
 	useLayoutEffect( () => {
 		// don't do anything if not fixed toolbar
-		if ( ! hasFixedToolbar ) {
+		if ( ! hasFixedToolbar || ! isLargerThanTabletViewport ) {
 			return;
 		}
 
@@ -109,7 +111,7 @@ export default function BlockTools( {
 		).style.width = `calc(100% - ${
 			leftHeaderWidth + pinnedItemsWidth + marginLeft
 		}px)`;
-	}, [ hasFixedToolbar ] );
+	}, [ hasFixedToolbar, isLargerThanTabletViewport ] );
 
 	function onKeyDown( event ) {
 		if ( event.defaultPrevented ) return;

--- a/packages/block-editor/src/components/block-tools/index.js
+++ b/packages/block-editor/src/components/block-tools/index.js
@@ -5,7 +5,7 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import { useViewportMatch } from '@wordpress/compose';
 import { Popover } from '@wordpress/components';
 import { __unstableUseShortcutEventMatch as useShortcutEventMatch } from '@wordpress/keyboard-shortcuts';
-import { useLayoutEffect, useRef } from '@wordpress/element';
+import { useRef } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -63,55 +63,6 @@ export default function BlockTools( {
 		moveBlocksUp,
 		moveBlocksDown,
 	} = useDispatch( blockEditorStore );
-
-	const isLargerThanTabletViewport = useViewportMatch( 'medium', '>' );
-
-	useLayoutEffect( () => {
-		// don't do anything if not fixed toolbar
-		if ( ! hasFixedToolbar || ! isLargerThanTabletViewport ) {
-			return;
-		}
-
-		const blockToolbar = document.querySelector(
-			'.block-editor-block-contextual-toolbar'
-		);
-
-		if ( ! blockToolbar ) {
-			return;
-		}
-
-		// get the width of the pinned items in the post editor
-		const pinnedItems = document.querySelector(
-			'.edit-post-header__settings'
-		);
-
-		// get the width of the left header in the site editor
-		const leftHeader = document.querySelector(
-			'.edit-site-header-edit-mode__end'
-		);
-
-		const computedToolbarStyle = window.getComputedStyle( blockToolbar );
-		const computedPinnedItemsStyle = pinnedItems
-			? window.getComputedStyle( pinnedItems )
-			: false;
-		const computedLeftHeaderStyle = leftHeader
-			? window.getComputedStyle( leftHeader )
-			: false;
-
-		const marginLeft = parseFloat( computedToolbarStyle.marginLeft );
-		const pinnedItemsWidth = computedPinnedItemsStyle
-			? parseFloat( computedPinnedItemsStyle.width ) + 10 // 10 is the pinned items padding
-			: 0;
-		const leftHeaderWidth = computedLeftHeaderStyle
-			? parseFloat( computedLeftHeaderStyle.width )
-			: 0;
-		// set the new witdth of the toolbar
-		document.querySelector(
-			'.block-editor-block-contextual-toolbar'
-		).style.width = `calc(100% - ${
-			leftHeaderWidth + pinnedItemsWidth + marginLeft
-		}px)`;
-	}, [ hasFixedToolbar, isLargerThanTabletViewport ] );
 
 	function onKeyDown( event ) {
 		if ( event.defaultPrevented ) return;

--- a/packages/block-editor/src/components/block-tools/style.scss
+++ b/packages/block-editor/src/components/block-tools/style.scss
@@ -113,9 +113,8 @@
 		overflow: hidden;
 
 		.block-editor-block-toolbar {
+			overflow: auto;
 			overflow-y: hidden;
-			overflow-x: scroll;
-			scrollbar-gutter: stable;
 		}
 
 		border: none;
@@ -140,11 +139,11 @@
 
 	// on desktop and tablet viewports the toolbar is fixed
 	// on top of interface header
+	$toolbar-margin: $grid-unit-80 * 3 - 2 * $grid-unit + $grid-unit-05;
 	@include break-medium() {
 		&.is-fixed {
-
 			// leave room for block inserter, undo and redo, list view
-			margin-left: $grid-unit-80 * 3 - 2 * $grid-unit + $grid-unit-05;
+			margin-left: $toolbar-margin;
 			// position on top of interface header
 			position: fixed;
 			top: $admin-bar-height + $grid-unit - $border-width;
@@ -163,7 +162,12 @@
 				// leave room for block inserter, undo and redo, list view
 				// and some margin left
 				margin-left: $grid-unit-80 * 4 - 2 * $grid-unit;
-				top: $grid-unit - $border-width;
+
+				// Mimic the height of the parent, vertically align center, and provide a max-height.
+				top: 0;
+				height: $header-height;
+				align-items: center;
+
 				&.is-collapsed {
 					width: initial;
 				}
@@ -325,7 +329,7 @@
 	// except for the inserter on the left
 	@include break-medium() {
 		&.is-fixed {
-			width: 100%;
+			width: calc(100% - #{$toolbar-margin});
 		}
 	}
 

--- a/packages/block-editor/src/components/block-tools/style.scss
+++ b/packages/block-editor/src/components/block-tools/style.scss
@@ -110,6 +110,13 @@
 		z-index: z-index(".block-editor-block-popover");
 		display: block;
 		width: 100%;
+		overflow: hidden;
+
+		.block-editor-block-toolbar {
+			overflow-y: hidden;
+			overflow-x: scroll;
+			scrollbar-gutter: stable;
+		}
 
 		border: none;
 		border-bottom: $border-width solid $gray-200;

--- a/packages/block-editor/src/components/block-tools/style.scss
+++ b/packages/block-editor/src/components/block-tools/style.scss
@@ -146,7 +146,7 @@
 			margin-left: $toolbar-margin;
 			// position on top of interface header
 			position: fixed;
-			top: $admin-bar-height + $grid-unit - $border-width;
+			top: $admin-bar-height;
 			// Don't fill up when empty
 			min-height: initial;
 			// remove the border
@@ -154,7 +154,15 @@
 			// has to be flex for collapse button to fit
 			display: flex;
 
+			// Mimic the height of the parent, vertically align center, and provide a max-height.
+			height: $header-height;
+			align-items: center;
+
 			&.is-collapsed {
+				width: initial;
+			}
+
+			&:empty {
 				width: initial;
 			}
 
@@ -163,12 +171,13 @@
 				// and some margin left
 				margin-left: $grid-unit-80 * 4 - 2 * $grid-unit;
 
-				// Mimic the height of the parent, vertically align center, and provide a max-height.
 				top: 0;
-				height: $header-height;
-				align-items: center;
 
 				&.is-collapsed {
+					width: initial;
+				}
+
+				&:empty {
 					width: initial;
 				}
 			}
@@ -256,7 +265,7 @@
 
 			.show-icon-labels & {
 
-				margin-left: $grid-unit-80 + 2 * $grid-unit; // inserter and margin ;
+				margin-left: $grid-unit-80 + 2 * $grid-unit; // inserter and margin
 
 				.is-fullscreen-mode & {
 					margin-left: $grid-unit * 18; // site hub, inserter and margin
@@ -330,6 +339,11 @@
 	@include break-medium() {
 		&.is-fixed {
 			width: calc(100% - #{$toolbar-margin});
+
+			.show-icon-labels & {
+				width: calc(100% + 40px - #{$toolbar-margin}); //there are no undo, redo and list view buttons
+			}
+
 		}
 	}
 
@@ -339,6 +353,9 @@
 	@include break-large() {
 		&.is-fixed {
 			width: auto;
+			.show-icon-labels & {
+				width: auto; //there are no undo, redo and list view buttons
+			}
 		}
 		.is-fullscreen-mode &.is-fixed {
 			// in full screen mode we need to account for


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Dinamycally adjusts the top toolbar to fit in the remaining visual space between the left hand tools and the right hand pinned items.


## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Because the current situation will overal various UI elements depending on the number of plugins installed.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Using a layout effect I measure what's on the right side in the post editor and the site editor and deduct it from total toolbar width. It's, again, a small patch for a big wound - but it's perfectly possible if it becomes a big problem.

## Testing Instructions

1. Install plugins that expand the right side pinned items area in the post editor or site editor
2. Notice the top toolbar does not overlap them

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

N/A


## Screenshots or screencast <!-- if applicable -->


https://github.com/WordPress/gutenberg/assets/107534/751a272a-ab2f-4734-9fa6-da18a5d81890


