### PR TITLE
Conditionally render Link UI settings drawer wrapper only when multiple settings are present

### DIFF
--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -335,7 +335,11 @@ function LinkControl( {
 
 	const isEditing = ( isEditingLink || ! value ) && ! isCreatingPage;
 	const isDisabled = ! valueHasChanges || currentInputIsEmpty;
-	const showSettings = !! settings?.length && isEditingLink && hasLinkValue;
+	const showSettings =
+		!! settings?.length &&
+		isEditingLink &&
+		hasLinkValue &&
+		! currentInputIsEmpty;
 
 	return (
 		<div
@@ -440,7 +444,7 @@ function LinkControl( {
 
 			{ showSettings && (
 				<div className="block-editor-link-control__tools">
-					{ ! currentInputIsEmpty && (
+					{ settings?.length > 1 ? (
 						<LinkControlSettingsDrawer
 							settingsOpen={ isSettingsOpen }
 							setSettingsOpen={ setSettingsOpenWithPreference }
@@ -453,6 +457,14 @@ function LinkControl( {
 								) }
 							/>
 						</LinkControlSettingsDrawer>
+					) : (
+						<LinkSettings
+							value={ internalControlValue }
+							settings={ settings }
+							onChange={ createSetInternalSettingValueHandler(
+								settingsKeys
+							) }
+						/>
 					) }
 				</div>
 			) }

--- a/packages/block-editor/src/components/link-control/test/index.js
+++ b/packages/block-editor/src/components/link-control/test/index.js
@@ -1733,245 +1733,282 @@ describe( 'Selecting links', () => {
 	} );
 } );
 
-describe( 'Addition Settings UI', () => {
-	it( 'should allow toggling the "Opens in new tab" setting control (only) on the link preview', async () => {
-		const user = userEvent.setup();
-		const selectedLink = fauxEntitySuggestions[ 0 ];
-		const mockOnChange = jest.fn();
+describe( 'Link Settings', () => {
+	describe( 'Previewing links', () => {
+		it( 'should allow toggling the "Opens in new tab" setting control (only) on the link preview', async () => {
+			const user = userEvent.setup();
+			const selectedLink = fauxEntitySuggestions[ 0 ];
+			const mockOnChange = jest.fn();
 
-		const customSettings = [
-			{
-				id: 'opensInNewTab',
-				title: 'Open in new tab',
-			},
-			{
-				id: 'noFollow',
-				title: 'No follow',
-			},
-		];
+			const customSettings = [
+				{
+					id: 'opensInNewTab',
+					title: 'Open in new tab',
+				},
+				{
+					id: 'noFollow',
+					title: 'No follow',
+				},
+			];
 
-		const LinkControlConsumer = () => {
-			const [ link, setLink ] = useState( selectedLink );
+			const LinkControlConsumer = () => {
+				const [ link, setLink ] = useState( selectedLink );
 
-			return (
-				<LinkControl
-					value={ link }
-					settings={ customSettings }
-					onChange={ ( newVal ) => {
-						mockOnChange( newVal );
-						setLink( newVal );
-					} }
-				/>
-			);
-		};
+				return (
+					<LinkControl
+						value={ link }
+						settings={ customSettings }
+						onChange={ ( newVal ) => {
+							mockOnChange( newVal );
+							setLink( newVal );
+						} }
+					/>
+				);
+			};
 
-		render( <LinkControlConsumer /> );
+			render( <LinkControlConsumer /> );
 
-		const opensInNewTabField = screen.queryByRole( 'checkbox', {
-			name: 'Open in new tab',
-			checked: false,
-		} );
+			const opensInNewTabField = screen.queryByRole( 'checkbox', {
+				name: 'Open in new tab',
+				checked: false,
+			} );
 
-		expect( opensInNewTabField ).toBeInTheDocument();
+			expect( opensInNewTabField ).toBeInTheDocument();
 
-		// No matter which settings are passed in only the `Opens in new tab`
-		// setting should be shown on the link preview (non-editing) state.
-		const noFollowField = screen.queryByRole( 'checkbox', {
-			name: 'No follow',
-		} );
-		expect( noFollowField ).not.toBeInTheDocument();
+			// No matter which settings are passed in only the `Opens in new tab`
+			// setting should be shown on the link preview (non-editing) state.
+			const noFollowField = screen.queryByRole( 'checkbox', {
+				name: 'No follow',
+			} );
+			expect( noFollowField ).not.toBeInTheDocument();
 
-		// Check that the link value is updated immediately upon checking
-		// the checkbox.
-		await user.click( opensInNewTabField );
+			// Check that the link value is updated immediately upon checking
+			// the checkbox.
+			await user.click( opensInNewTabField );
 
-		expect( opensInNewTabField ).toBeChecked();
+			expect( opensInNewTabField ).toBeChecked();
 
-		expect( mockOnChange ).toHaveBeenCalledTimes( 1 );
-		expect( mockOnChange ).toHaveBeenCalledWith( {
-			opensInNewTab: true,
-		} );
-	} );
-
-	it( 'should hide advanced link settings and toggle when not editing a link', async () => {
-		const selectedLink = fauxEntitySuggestions[ 0 ];
-
-		const LinkControlConsumer = () => {
-			const [ link ] = useState( selectedLink );
-
-			return <LinkControl value={ link } />;
-		};
-
-		render( <LinkControlConsumer /> );
-
-		const settingsToggle = getSettingsDrawerToggle();
-
-		expect( settingsToggle ).not.toBeInTheDocument();
-	} );
-
-	it( 'should provides a means to toggle the advanced link settings when editing a link', async () => {
-		const selectedLink = fauxEntitySuggestions[ 0 ];
-
-		const LinkControlConsumer = () => {
-			const [ link ] = useState( selectedLink );
-
-			return <LinkControl value={ link } forceIsEditingLink />;
-		};
-
-		render( <LinkControlConsumer /> );
-
-		const user = userEvent.setup();
-
-		const settingsToggle = getSettingsDrawerToggle();
-
-		expect( settingsToggle ).toHaveAttribute( 'aria-expanded', 'false' );
-
-		expect( settingsToggle ).toBeVisible();
-
-		await user.click( settingsToggle );
-
-		expect( settingsToggle ).toHaveAttribute( 'aria-expanded', 'true' );
-
-		const newTabSettingInput = screen.getByRole( 'checkbox', {
-			name: 'Open in new tab',
-		} );
-
-		expect( newTabSettingInput ).toBeVisible();
-
-		await user.click( settingsToggle );
-
-		expect( settingsToggle ).toHaveAttribute( 'aria-expanded', 'false' );
-		expect( newTabSettingInput ).not.toBeVisible();
-	} );
-
-	it( 'should display "New Tab" setting (in "off" mode) by default when a link is edited', async () => {
-		const selectedLink = fauxEntitySuggestions[ 0 ];
-		const expectedSettingText = 'Open in new tab';
-
-		const LinkControlConsumer = () => {
-			const [ link ] = useState( selectedLink );
-
-			return <LinkControl value={ link } forceIsEditingLink />;
-		};
-
-		render( <LinkControlConsumer /> );
-
-		const user = userEvent.setup();
-
-		await toggleSettingsDrawer( user );
-
-		const newTabSettingLabel = screen.getByText( expectedSettingText );
-		expect( newTabSettingLabel ).toBeVisible();
-
-		const newTabSettingInput = screen.getByRole( 'checkbox', {
-			name: expectedSettingText,
-			checked: false,
-		} );
-
-		expect( newTabSettingInput ).toBeVisible();
-	} );
-
-	it( 'should display a setting control with correct default state for each of the custom settings provided', async () => {
-		const selectedLink = fauxEntitySuggestions[ 0 ];
-
-		const customSettings = [
-			{
-				id: 'opensInNewTab',
-				title: 'Open in new tab',
-			},
-			{
-				id: 'noFollow',
-				title: 'No follow',
-			},
-		];
-
-		const LinkControlConsumer = () => {
-			const [ link ] = useState( selectedLink );
-
-			return (
-				<LinkControl
-					value={ { ...link, newTab: false, noFollow: true } }
-					settings={ customSettings }
-					forceIsEditingLink
-				/>
-			);
-		};
-
-		render( <LinkControlConsumer /> );
-
-		const user = userEvent.setup();
-
-		await toggleSettingsDrawer( user );
-
-		expect( screen.queryAllByRole( 'checkbox' ) ).toHaveLength( 2 );
-
-		expect(
-			screen.getByRole( 'checkbox', {
-				name: customSettings[ 0 ].title,
-			} )
-		).not.toBeChecked();
-		expect(
-			screen.getByRole( 'checkbox', {
-				name: customSettings[ 1 ].title,
-			} )
-		).toBeChecked();
-	} );
-
-	it( 'should require settings changes to be submitted/applied', async () => {
-		const user = userEvent.setup();
-
-		const mockOnChange = jest.fn();
-
-		const selectedLink = {
-			...fauxEntitySuggestions[ 0 ],
-			// Including a setting here helps to assert on a potential bug
-			// whereby settings on the suggestion override the current (internal)
-			// settings values set by the user in the UI.
-			opensInNewTab: false,
-		};
-
-		render(
-			<LinkControl
-				value={ selectedLink }
-				forceIsEditingLink
-				hasTextControl
-				onChange={ mockOnChange }
-			/>
-		);
-
-		// check that the "Apply" button is disabled by default.
-		const submitButton = screen.queryByRole( 'button', {
-			name: 'Save',
-		} );
-
-		expect( submitButton ).toHaveAttribute( 'aria-disabled', 'true' );
-
-		await toggleSettingsDrawer( user );
-
-		const opensInNewTabToggle = screen.queryByRole( 'checkbox', {
-			name: 'Open in new tab',
-		} );
-
-		// toggle the checkbox
-		await user.click( opensInNewTabToggle );
-
-		// Check settings are **not** directly submitted
-		// which would trigger the onChange handler.
-		expect( mockOnChange ).not.toHaveBeenCalled();
-
-		// Check Apply button is now enabled because changes
-		// have been detected.
-		expect( submitButton ).toBeEnabled();
-
-		// Submit the changed setting value using the Apply button
-		await user.click( submitButton );
-
-		// Assert the value is updated.
-		expect( mockOnChange ).toHaveBeenCalledWith(
-			expect.objectContaining( {
+			expect( mockOnChange ).toHaveBeenCalledTimes( 1 );
+			expect( mockOnChange ).toHaveBeenCalledWith( {
 				opensInNewTab: true,
-			} )
-		);
+			} );
+		} );
+
+		it( 'should hide advanced link settings and toggle when not editing a link', async () => {
+			const selectedLink = fauxEntitySuggestions[ 0 ];
+
+			const customSettings = [
+				{
+					id: 'opensInNewTab',
+					title: 'Open in new tab',
+				},
+				{
+					id: 'noFollow',
+					title: 'No follow',
+				},
+			];
+
+			const LinkControlConsumer = () => {
+				const [ link ] = useState( selectedLink );
+
+				return (
+					<LinkControl value={ link } settings={ customSettings } />
+				);
+			};
+
+			render( <LinkControlConsumer /> );
+
+			const settingsToggle = getSettingsDrawerToggle();
+
+			expect( settingsToggle ).not.toBeInTheDocument();
+		} );
+	} );
+
+	describe( 'Editing links', () => {
+		it( 'should not display "Advanced" toggle for settings when "Open in new tab" is the only setting', async () => {
+			const selectedLink = fauxEntitySuggestions[ 0 ];
+			const expectedSettingText = 'Open in new tab';
+
+			const LinkControlConsumer = () => {
+				const [ link ] = useState( selectedLink );
+
+				return (
+					<LinkControl
+						value={ link }
+						forceIsEditingLink
+						settings={ [
+							{
+								id: 'opensInNewTab',
+								title: 'Open in new tab',
+							},
+						] }
+					/>
+				);
+			};
+
+			render( <LinkControlConsumer /> );
+
+			const advancedSettingsToggle = screen.queryByRole( 'button', {
+				name: 'Advanced',
+			} );
+
+			expect( advancedSettingsToggle ).not.toBeInTheDocument();
+
+			const openInNewTabSettingLabel =
+				screen.getByLabelText( expectedSettingText );
+			expect( openInNewTabSettingLabel ).toBeVisible();
+
+			const openInNewTabSettingControl = screen.getByRole( 'checkbox', {
+				name: expectedSettingText,
+				checked: false,
+			} );
+
+			expect( openInNewTabSettingControl ).toBeVisible();
+		} );
+
+		it( 'should provide a means to toggle the advanced link settings when editing a link', async () => {
+			const selectedLink = fauxEntitySuggestions[ 0 ];
+
+			const LinkControlConsumer = () => {
+				const [ link ] = useState( selectedLink );
+
+				return <LinkControl value={ link } forceIsEditingLink />;
+			};
+
+			render( <LinkControlConsumer /> );
+
+			const user = userEvent.setup();
+
+			const settingsToggle = getSettingsDrawerToggle();
+
+			expect( settingsToggle ).toHaveAttribute(
+				'aria-expanded',
+				'false'
+			);
+
+			expect( settingsToggle ).toBeVisible();
+
+			await user.click( settingsToggle );
+
+			expect( settingsToggle ).toHaveAttribute( 'aria-expanded', 'true' );
+
+			const newTabSettingInput = screen.getByRole( 'checkbox', {
+				name: 'Open in new tab',
+			} );
+
+			expect( newTabSettingInput ).toBeVisible();
+
+			await user.click( settingsToggle );
+
+			expect( settingsToggle ).toHaveAttribute(
+				'aria-expanded',
+				'false'
+			);
+			expect( newTabSettingInput ).not.toBeVisible();
+		} );
+
+		it( 'should display a setting control with correct default state for each of the custom settings provided', async () => {
+			const selectedLink = fauxEntitySuggestions[ 0 ];
+
+			const customSettings = [
+				{
+					id: 'opensInNewTab',
+					title: 'Open in new tab',
+				},
+				{
+					id: 'noFollow',
+					title: 'No follow',
+				},
+			];
+
+			const LinkControlConsumer = () => {
+				const [ link ] = useState( selectedLink );
+
+				return (
+					<LinkControl
+						value={ { ...link, newTab: false, noFollow: true } }
+						settings={ customSettings }
+						forceIsEditingLink
+					/>
+				);
+			};
+
+			render( <LinkControlConsumer /> );
+
+			const user = userEvent.setup();
+
+			await toggleSettingsDrawer( user );
+
+			expect( screen.queryAllByRole( 'checkbox' ) ).toHaveLength( 2 );
+
+			expect(
+				screen.getByRole( 'checkbox', {
+					name: customSettings[ 0 ].title,
+				} )
+			).not.toBeChecked();
+			expect(
+				screen.getByRole( 'checkbox', {
+					name: customSettings[ 1 ].title,
+				} )
+			).toBeChecked();
+		} );
+
+		it( 'should require settings changes to be submitted/applied', async () => {
+			const user = userEvent.setup();
+
+			const mockOnChange = jest.fn();
+
+			const selectedLink = {
+				...fauxEntitySuggestions[ 0 ],
+				// Including a setting here helps to assert on a potential bug
+				// whereby settings on the suggestion override the current (internal)
+				// settings values set by the user in the UI.
+				opensInNewTab: false,
+			};
+
+			render(
+				<LinkControl
+					value={ selectedLink }
+					forceIsEditingLink
+					hasTextControl
+					onChange={ mockOnChange }
+				/>
+			);
+
+			// check that the "Apply" button is disabled by default.
+			const submitButton = screen.queryByRole( 'button', {
+				name: 'Save',
+			} );
+
+			expect( submitButton ).toHaveAttribute( 'aria-disabled', 'true' );
+
+			await toggleSettingsDrawer( user );
+
+			const opensInNewTabToggle = screen.queryByRole( 'checkbox', {
+				name: 'Open in new tab',
+			} );
+
+			// toggle the checkbox
+			await user.click( opensInNewTabToggle );
+
+			// Check settings are **not** directly submitted
+			// which would trigger the onChange handler.
+			expect( mockOnChange ).not.toHaveBeenCalled();
+
+			// Check Apply button is now enabled because changes
+			// have been detected.
+			expect( submitButton ).toBeEnabled();
+
+			// Submit the changed setting value using the Apply button
+			await user.click( submitButton );
+
+			// Assert the value is updated.
+			expect( mockOnChange ).toHaveBeenCalledWith(
+				expect.objectContaining( {
+					opensInNewTab: true,
+				} )
+			);
+		} );
 	} );
 } );
 

--- a/packages/block-editor/src/components/link-control/test/index.js
+++ b/packages/block-editor/src/components/link-control/test/index.js
@@ -1735,7 +1735,7 @@ describe( 'Selecting links', () => {
 
 describe( 'Link Settings', () => {
 	describe( 'Previewing links', () => {
-		it( 'should allow toggling the "Opens in new tab" setting control (only) on the link preview', async () => {
+		it( 'should allow toggling the "Opens in new tab" setting control (only)', async () => {
 			const user = userEvent.setup();
 			const selectedLink = fauxEntitySuggestions[ 0 ];
 			const mockOnChange = jest.fn();
@@ -1794,7 +1794,7 @@ describe( 'Link Settings', () => {
 			} );
 		} );
 
-		it( 'should hide advanced link settings and toggle when not editing a link', async () => {
+		it( 'should hide advanced link settings and toggle', async () => {
 			const selectedLink = fauxEntitySuggestions[ 0 ];
 
 			const customSettings = [
@@ -1825,16 +1825,18 @@ describe( 'Link Settings', () => {
 	} );
 
 	describe( 'Editing links', () => {
-		it( 'should not display "Advanced" toggle for settings when "Open in new tab" is the only setting', async () => {
+		it( 'should display "Open in new tab" setting outside of advanced settings area when it is the only setting', async () => {
+			const user = userEvent.setup();
 			const selectedLink = fauxEntitySuggestions[ 0 ];
 			const expectedSettingText = 'Open in new tab';
 
 			const LinkControlConsumer = () => {
-				const [ link ] = useState( selectedLink );
+				const [ link, setLink ] = useState( selectedLink );
 
 				return (
 					<LinkControl
 						value={ link }
+						onChange={ setLink }
 						forceIsEditingLink
 						settings={ [
 							{
@@ -1864,20 +1866,41 @@ describe( 'Link Settings', () => {
 			} );
 
 			expect( openInNewTabSettingControl ).toBeVisible();
+
+			await user.click( openInNewTabSettingControl );
+
+			expect( openInNewTabSettingControl ).toBeChecked();
 		} );
 
-		it( 'should provide a means to toggle the advanced link settings when editing a link', async () => {
+		it( 'should show an advanced link settings area when multiple settings are provided', async () => {
 			const selectedLink = fauxEntitySuggestions[ 0 ];
+			const user = userEvent.setup();
+
+			const customSettings = [
+				{
+					id: 'opensInNewTab',
+					title: 'Open in new tab',
+				},
+				{
+					id: 'noFollow',
+					title: 'No follow',
+				},
+			];
 
 			const LinkControlConsumer = () => {
-				const [ link ] = useState( selectedLink );
+				const [ link, setLink ] = useState( selectedLink );
 
-				return <LinkControl value={ link } forceIsEditingLink />;
+				return (
+					<LinkControl
+						value={ link }
+						onChange={ setLink }
+						forceIsEditingLink
+						settings={ customSettings }
+					/>
+				);
 			};
 
 			render( <LinkControlConsumer /> );
-
-			const user = userEvent.setup();
 
 			const settingsToggle = getSettingsDrawerToggle();
 
@@ -1897,6 +1920,19 @@ describe( 'Link Settings', () => {
 			} );
 
 			expect( newTabSettingInput ).toBeVisible();
+
+			const noFollowSettingInput = screen.getByRole( 'checkbox', {
+				name: 'No follow',
+			} );
+
+			expect( noFollowSettingInput ).toBeVisible();
+
+			// check both settings and check they are now checked
+			await user.click( newTabSettingInput );
+			await user.click( noFollowSettingInput );
+
+			expect( newTabSettingInput ).toBeChecked();
+			expect( noFollowSettingInput ).toBeChecked();
 
 			await user.click( settingsToggle );
 

--- a/test/e2e/specs/editor/blocks/links.spec.js
+++ b/test/e2e/specs/editor/blocks/links.spec.js
@@ -45,16 +45,6 @@ test.describe( 'Links', () => {
 		// Edit link.
 		await page.getByRole( 'button', { name: 'Edit' } ).click();
 
-		// Open settings.
-		await page
-			.getByRole( 'region', {
-				name: 'Editor content',
-			} )
-			.getByRole( 'button', {
-				name: 'Advanced',
-			} )
-			.click();
-
 		// Navigate to and toggle the "Open in new tab" checkbox.
 		const checkbox = page.getByLabel( 'Open in new tab' );
 		await checkbox.click();
@@ -63,7 +53,7 @@ test.describe( 'Links', () => {
 		await expect( checkbox ).toBeChecked();
 		await expect( checkbox ).toBeFocused();
 
-		// Tab back to the Submit and apply the link.
+		// Save the change.
 		await page
 			//TODO: change to a better selector when https://github.com/WordPress/gutenberg/issues/51060 is resolved.
 			.locator( '.block-editor-link-control' )
@@ -210,16 +200,6 @@ test.describe( 'Links', () => {
 		// and I can see the open in new tab checkbox. This verifies
 		// that the editor preference was persisted.
 		await expect( page.getByLabel( 'Open in new tab' ) ).toBeVisible();
-
-		// Toggle the Advanced settings back to being closed.
-		await page
-			.getByRole( 'region', {
-				name: 'Editor content',
-			} )
-			.getByRole( 'button', {
-				name: 'Advanced',
-			} )
-			.click();
 
 		// Move focus out of Link UI and into Paragraph block.
 		await pageUtils.pressKeys( 'Escape' );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Only renders the "Advanced" area when there is more than a single setting in the Link Control component.

Applies some feedback from https://github.com/WordPress/gutenberg/pull/52799/.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The toggle was added to help clean up the UI in anticipation of allowing the ability to add more settings in the future. However, currently most implementations (including Core) only have a single setting `Opens in new tab`. It seems a little redundant to have a drawer when there is only a single setting.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Conditionally only renders the `Advanced` settings toggle is there is more than a single setting. Otherwise just renders directly under the inputs.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- New Post
- Add link
- Edit link
- See `Opens in new tab` checkbox
- Don't see `Advanced` toggle
- Check changing the link and settings the `Opens in new tab` behaves as expected.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<img width="494" alt="Screen Shot 2023-08-10 at 15 05 46" src="https://github.com/WordPress/gutenberg/assets/444434/0a41d7f9-807b-4c0f-813a-fd609decb7bc">

