### PR TITLE
Fix support of sticky position in non-iframed post editor

### DIFF
--- a/packages/edit-post/src/components/visual-editor/index.js
+++ b/packages/edit-post/src/components/visual-editor/index.js
@@ -346,7 +346,7 @@ export default function VisualEditor( { styles } ) {
 			__unstableContentRef={ ref }
 			className={ classnames( 'edit-post-visual-editor', {
 				'is-template-mode': isTemplateMode,
-				'is-isolated': isToBeIframed,
+				'has-inline-canvas': ! isToBeIframed,
 			} ) }
 		>
 			<motion.div

--- a/packages/edit-post/src/components/visual-editor/index.js
+++ b/packages/edit-post/src/components/visual-editor/index.js
@@ -334,11 +334,19 @@ export default function VisualEditor( { styles } ) {
 		.is-root-container.alignfull { max-width: none; margin-left: auto; margin-right: auto;}
 		.is-root-container.alignfull:where(.is-layout-flow) > :not(.alignleft):not(.alignright) { max-width: none;}`;
 
+	const isToBeIframed =
+		( ( hasV3BlocksOnly || ( isGutenbergPlugin && isBlockBasedTheme ) ) &&
+			! hasMetaBoxes ) ||
+		isTemplateMode ||
+		deviceType === 'Tablet' ||
+		deviceType === 'Mobile';
+
 	return (
 		<BlockTools
 			__unstableContentRef={ ref }
 			className={ classnames( 'edit-post-visual-editor', {
 				'is-template-mode': isTemplateMode,
+				'is-isolated': isToBeIframed,
 			} ) }
 		>
 			<motion.div
@@ -354,14 +362,7 @@ export default function VisualEditor( { styles } ) {
 					className={ previewMode }
 				>
 					<MaybeIframe
-						shouldIframe={
-							( ( hasV3BlocksOnly ||
-								( isGutenbergPlugin && isBlockBasedTheme ) ) &&
-								! hasMetaBoxes ) ||
-							isTemplateMode ||
-							deviceType === 'Tablet' ||
-							deviceType === 'Mobile'
-						}
+						shouldIframe={ isToBeIframed }
 						contentRef={ contentRef }
 						styles={ styles }
 					>

--- a/packages/edit-post/src/components/visual-editor/style.scss
+++ b/packages/edit-post/src/components/visual-editor/style.scss
@@ -2,7 +2,9 @@
 	position: relative;
 	display: flex;
 	flex-flow: column;
-	overflow: hidden;
+	&.is-isolated {
+		overflow: hidden;
+	}
 
 	// Gray preview overlay (desktop/tablet/mobile) is intentionally not set on an element with scrolling content like
 	// interface-interface-skeleton__content. This causes graphical glitches (flashes of the background color)

--- a/packages/edit-post/src/components/visual-editor/style.scss
+++ b/packages/edit-post/src/components/visual-editor/style.scss
@@ -2,7 +2,9 @@
 	position: relative;
 	display: flex;
 	flex-flow: column;
-	&.is-isolated {
+	// In the iframed canvas this keeps extra scrollbars from appearing (when block toolbars overflow). In the
+	// legacy (non-iframed) canvas, overflow must not be hidden in order to maintain support for sticky positioning.
+	&:not(.has-inline-canvas) {
 		overflow: hidden;
 	}
 


### PR DESCRIPTION
## What?
This is a rework of #49978 to fix up the effect it had of breaking sticky positioning in the legacy (non-iframed) post editor.

## Why?
Sticky positioning in the non-iframed post editor is not working as before. To fix #53477

## How?
Adds a class to allow the fix made in #49978 to target just the iframed editor thus avoid its breakage in the non-iframed editor.

At first I tried to avoid adding a class but didn't find any existing markup to hang this on and didn't want to use `:has` for lack of complete support. There's `.has-metaboxes` that works in some cases but doesn't when it’s a block of `apiVersion < 3` causing the lack of iframe. Alternative ideas are welcome.

## Testing Instructions
1. Open a post
2. Turn on the Custom fields (Options > Preferences > Panels > Custom fields)
3. Once the editor reloads add a sticky positioned element and enough content to test scrolling.
4. Scroll and verify that the sticky positioning works as expected.

### Sample markup to test sticky positioning
```html
<!-- wp:group {"style":{"position":{"type":"sticky","top":"0px"}},"layout":{"type":"constrained"}} -->
<div class="wp-block-group"><!-- wp:heading -->
<h2 class="wp-block-heading">Stick me?</h2>
<!-- /wp:heading --></div>
<!-- /wp:group -->

<!-- wp:spacer {"height":"3000px"} -->
<div style="height:3000px" aria-hidden="true" class="wp-block-spacer"></div>
<!-- /wp:spacer -->
```

## Screenshots or screencast <!-- if applicable -->
