### PR TITLE
Patterns: Add missing full stop to string

### DIFF
--- a/packages/block-editor/src/components/inserter/hooks/use-patterns-state.js
+++ b/packages/block-editor/src/components/inserter/hooks/use-patterns-state.js
@@ -15,7 +15,7 @@ import { store as blockEditorStore } from '../../../store';
 const CUSTOM_CATEGORY = {
 	name: 'custom',
 	label: __( 'My patterns' ),
-	description: __( 'Custom patterns added by site users' ),
+	description: __( 'Custom patterns added by site users.' ),
 };
 
 /**


### PR DESCRIPTION
## What?
Adds missing full stop to string

## Why?
Little things matter

## How?
Opened the file, placed cursor at end of the offending string and pressed `.` on the keyboard, saved file, commited, pushed, done -  too easy 

## Testing Instructions
Get  @richtabor to look at the string and observe if he cringes or not 😄 


