### PR TITLE
wp-env: Fix errors which prevent it from working without internet

### DIFF
--- a/packages/env/CHANGELOG.md
+++ b/packages/env/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancement
+
+-   `wp-env` now works offline after the environment has been created. Note that many `wp-env` configuration changes involve internet connectivity and may not work in offline mode. [#53547](https://github.com/WordPress/gutenberg/pull/53547)
+
 ## 8.10.0 (2023-10-18)
 
 ### Bug Fix

--- a/packages/env/lib/cache.js
+++ b/packages/env/lib/cache.js
@@ -40,6 +40,9 @@ async function didCacheChange( key, value, options ) {
  * @param {WPEnvCacheOptions} options Parsing options
  */
 async function setCache( key, value, options ) {
+	// Make sure the cache directory exists.
+	await fs.mkdir( options.workDirectoryPath, { recursive: true } );
+
 	const existingCache = await getCacheFile( options );
 	existingCache[ key ] = value;
 

--- a/packages/env/lib/commands/start.js
+++ b/packages/env/lib/commands/start.js
@@ -28,6 +28,7 @@ const {
 	configureWordPress,
 	setupWordPressDirectories,
 	readWordPressVersion,
+	canAccessWPORG,
 } = require( '../wordpress' );
 const { didCacheChange, setCache } = require( '../cache' );
 const md5 = require( '../md5' );
@@ -77,15 +78,23 @@ module.exports = async function start( {
 	const configHash = md5( config );
 	const { workDirectoryPath, dockerComposeConfigPath } = config;
 	const shouldConfigureWp =
-		update ||
-		( await didCacheChange( CONFIG_CACHE_KEY, configHash, {
-			workDirectoryPath,
-		} ) );
+		( update ||
+			( await didCacheChange( CONFIG_CACHE_KEY, configHash, {
+				workDirectoryPath,
+			} ) ) ) &&
+		// Don't reconfigure everything when we can't connect to the internet because
+		// the majority of update tasks involve connecting to the internet. (Such
+		// as downloading sources and pulling docker images.)
+		( await canAccessWPORG() );
 
 	const dockerComposeConfig = {
 		config: dockerComposeConfigPath,
 		log: config.debug,
 	};
+
+	if ( ! ( await canAccessWPORG() ) ) {
+		spinner.info( 'wp-env is offline' );
+	}
 
 	/**
 	 * If the Docker image is already running and the `wp-env` files have been

--- a/packages/env/lib/config/parse-config.js
+++ b/packages/env/lib/config/parse-config.js
@@ -534,7 +534,7 @@ async function parseEnvironmentConfig(
 async function parseCoreSource( coreSource, options ) {
 	// An empty source means we should use the latest version of WordPress.
 	if ( ! coreSource ) {
-		const wpVersion = await getLatestWordPressVersion();
+		const wpVersion = await getLatestWordPressVersion( options );
 		if ( ! wpVersion ) {
 			throw new ValidationError(
 				'Could not find the latest WordPress version. There may be a network issue.'

--- a/packages/env/lib/config/test/config-integration.js
+++ b/packages/env/lib/config/test/config-integration.js
@@ -15,6 +15,8 @@ jest.mock( 'fs', () => ( {
 	promises: {
 		readFile: jest.fn(),
 		stat: jest.fn().mockResolvedValue( true ),
+		mkdir: jest.fn(),
+		writeFile: jest.fn(),
 	},
 } ) );
 

--- a/packages/env/lib/test/cache.js
+++ b/packages/env/lib/test/cache.js
@@ -18,6 +18,7 @@ jest.mock( 'fs', () => ( {
 	promises: {
 		readFile: jest.fn(),
 		writeFile: jest.fn(),
+		mkdir: jest.fn(),
 	},
 } ) );
 

--- a/packages/env/lib/wordpress.js
+++ b/packages/env/lib/wordpress.js
@@ -254,8 +254,14 @@ async function readWordPressVersion( coreSource, spinner, debug ) {
  *
  * @return {boolean} True if we can connect to WordPress.org, false otherwise.
  */
+let IS_OFFLINE;
 async function canAccessWPORG() {
-	return !! ( await dns.resolve( 'WordPress.org' ).catch( () => {} ) );
+	// Avoid situations where some parts of the code think we're offline and others don't.
+	if ( IS_OFFLINE !== undefined ) {
+		return IS_OFFLINE;
+	}
+	IS_OFFLINE = !! ( await dns.resolve( 'WordPress.org' ).catch( () => {} ) );
+	return IS_OFFLINE;
 }
 
 /**

--- a/packages/env/lib/wordpress.js
+++ b/packages/env/lib/wordpress.js
@@ -311,5 +311,6 @@ module.exports = {
 	resetDatabase,
 	setupWordPressDirectories,
 	readWordPressVersion,
+	canAccessWPORG,
 	getLatestWordPressVersion,
 };


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
## What?
Fixes #53433.
Fixes #52157.

Unfortunately, many `wp-env` commands don't work without internet due to a function which finds the latest WordPress version, which happens during config parsing. Beyond this function, `wp-env start` could fail in many cases when it tries to do updates (like downloading sources or pulling docker images).

## Why?
Offline mode always has its uses!

## How?
1. Create a function which uses `dns.resolve( 'WordPress.org' )` to check for internet access. This seems to be a reasonable practice based on my search for how to do this with NodeJS. It's also very fast, which isn't the case when we wait for timeouts in other functions.
2. Cache the latest WordPress version in our cache file, and use it when we have no internet. It's probably possible to code this without needing the cache (we could just reuse the existing docker-compose.yml file if it exists), but that would require more extensive changes with little benefit. (For example, if this function doesn't provide a WordPress version, the config doesn't have it either, meaning we can't cleanly map from a config to a docker-compose file.)
4. Avoid doing any of the `shouldConfigureWp` logic during `wp-env start`, since most of that involves internet connections (pulling docker images, downloading sources, etc.) I think it's easier to do this than to add extra checks all over the place when we do something with the network.

The side effect is that certain types of `wp-env.json` updates won't work if you're offline, but that seems like a reasonable compromise. For example, if you set the `phpVersion`, that involves downloading a different docker image. So a lot of the config options would be impacted anyways.

## Testing Instructions
1. Remove `core` from Gutenberg's `.wp-env.json` file to trigger the check for the latest core source.
2. make sure that you have a wp-env environment that works
3. turn off your internet
5. run a few wp-env commands:
    - `npx wp-env start`
    - `npx wp-env install-path`
    - `npx wp-env run cli bash`
    - `npx wp-env run cli phpunit --version`

All should work. 

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

You should see an offline message in the terminal as well:

<img width="469" alt="image" src="https://github.com/WordPress/gutenberg/assets/6265975/674dc628-f07f-44d8-9ece-a711f4af0bef">
