### PR TITLE
Update deepsignal version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5879,22 +5879,6 @@
 				"url": "https://opencollective.com/preact"
 			}
 		},
-		"node_modules/@preact/signals-react": {
-			"version": "1.3.3",
-			"resolved": "https://registry.npmjs.org/@preact/signals-react/-/signals-react-1.3.3.tgz",
-			"integrity": "sha512-Tbv+oWPcrWowAJp1U1eWFiFUJihulOAnL8g/hJ3fUsP0IcsKsj8U0OcIDrwemIPQe7+J/3FuudkZzted0MD/bA==",
-			"dependencies": {
-				"@preact/signals-core": "^1.3.1",
-				"use-sync-external-store": "^1.2.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/preact"
-			},
-			"peerDependencies": {
-				"react": "^16.14.0 || 17.x || 18.x"
-			}
-		},
 		"node_modules/@radix-ui/number": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/@radix-ui/number/-/number-1.0.1.tgz",
@@ -27001,16 +26985,28 @@
 			}
 		},
 		"node_modules/deepsignal": {
-			"version": "1.3.3",
-			"resolved": "https://registry.npmjs.org/deepsignal/-/deepsignal-1.3.3.tgz",
-			"integrity": "sha512-4D5p2wp/4bRGfAPllwYCufPPAOxeD5milmfm/F4paKVoZOAjRVB5F+bs/wOJWWXsL8vsEcPf1vw8S/FT45k/wA==",
-			"dependencies": {
-				"@preact/signals": "^1.0.0",
-				"@preact/signals-core": "^1.0.0",
-				"@preact/signals-react": "^1.0.0"
-			},
+			"version": "1.3.6",
+			"resolved": "https://registry.npmjs.org/deepsignal/-/deepsignal-1.3.6.tgz",
+			"integrity": "sha512-yjd+vtiznL6YaMptOsKnEKkPr60OEApa+LRe+Qe6Ile/RfCOrELKk/YM3qVpXFZiyOI3Ng67GDEyjAlqVc697g==",
 			"peerDependencies": {
-				"preact": "10.x"
+				"@preact/signals": "^1.1.4",
+				"@preact/signals-core": "^1.3.1",
+				"@preact/signals-react": "^1.3.3",
+				"preact": "^10.16.0"
+			},
+			"peerDependenciesMeta": {
+				"@preact/signals": {
+					"optional": true
+				},
+				"@preact/signals-core": {
+					"optional": true
+				},
+				"@preact/signals-react": {
+					"optional": true
+				},
+				"preact": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/default-browser-id": {
@@ -55638,7 +55634,7 @@
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@preact/signals": "^1.1.3",
-				"deepsignal": "^1.3.3",
+				"deepsignal": "^1.3.6",
 				"preact": "^10.13.2"
 			},
 			"engines": {
@@ -60477,15 +60473,6 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/@preact/signals-core/-/signals-core-1.4.0.tgz",
 			"integrity": "sha512-5iYoZBhELLIhUQceZI7sDTQWPb+xcVSn2qk8T/aNl/VMh+A4AiPX9YRSh4XO7fZ6pncrVxl1Iln82poVqYVbbw=="
-		},
-		"@preact/signals-react": {
-			"version": "1.3.3",
-			"resolved": "https://registry.npmjs.org/@preact/signals-react/-/signals-react-1.3.3.tgz",
-			"integrity": "sha512-Tbv+oWPcrWowAJp1U1eWFiFUJihulOAnL8g/hJ3fUsP0IcsKsj8U0OcIDrwemIPQe7+J/3FuudkZzted0MD/bA==",
-			"requires": {
-				"@preact/signals-core": "^1.3.1",
-				"use-sync-external-store": "^1.2.0"
-			}
 		},
 		"@radix-ui/number": {
 			"version": "1.0.1",
@@ -68025,7 +68012,7 @@
 			"version": "file:packages/interactivity",
 			"requires": {
 				"@preact/signals": "^1.1.3",
-				"deepsignal": "^1.3.3",
+				"deepsignal": "^1.3.6",
 				"preact": "^10.13.2"
 			}
 		},
@@ -79124,14 +79111,9 @@
 			"integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A=="
 		},
 		"deepsignal": {
-			"version": "1.3.3",
-			"resolved": "https://registry.npmjs.org/deepsignal/-/deepsignal-1.3.3.tgz",
-			"integrity": "sha512-4D5p2wp/4bRGfAPllwYCufPPAOxeD5milmfm/F4paKVoZOAjRVB5F+bs/wOJWWXsL8vsEcPf1vw8S/FT45k/wA==",
-			"requires": {
-				"@preact/signals": "^1.0.0",
-				"@preact/signals-core": "^1.0.0",
-				"@preact/signals-react": "^1.0.0"
-			}
+			"version": "1.3.6",
+			"resolved": "https://registry.npmjs.org/deepsignal/-/deepsignal-1.3.6.tgz",
+			"integrity": "sha512-yjd+vtiznL6YaMptOsKnEKkPr60OEApa+LRe+Qe6Ile/RfCOrELKk/YM3qVpXFZiyOI3Ng67GDEyjAlqVc697g=="
 		},
 		"default-browser-id": {
 			"version": "3.0.0",

--- a/packages/interactivity/package.json
+++ b/packages/interactivity/package.json
@@ -26,7 +26,7 @@
 	"react-native": "src/index",
 	"dependencies": {
 		"@preact/signals": "^1.1.3",
-		"deepsignal": "^1.3.3",
+		"deepsignal": "^1.3.6",
 		"preact": "^10.13.2"
 	},
 	"publishConfig": {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This updates the deepsignal version in Gutenberg, which fixes a peer dependency warning which happened in an older version of the package.

@luisherranz do we need to add any of the other peer dependencies to the interactivity package besides `@preact/signals` and `preact`?

## Why?
See https://github.com/luisherranz/deepsignal/issues/39