### PR TITLE
Site Editor: Fix BlockPreview in Template panel when editing a page

### DIFF
--- a/packages/edit-site/src/components/sidebar-edit-mode/page-panels/edit-template.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/page-panels/edit-template.js
@@ -8,6 +8,7 @@ import { BlockContextProvider, BlockPreview } from '@wordpress/block-editor';
 import { Button, __experimentalVStack as VStack } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { store as coreStore } from '@wordpress/core-data';
+import { parse } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -15,7 +16,7 @@ import { store as coreStore } from '@wordpress/core-data';
 import { store as editSiteStore } from '../../../store';
 
 export default function EditTemplate() {
-	const { context, hasResolved, title, blocks } = useSelect( ( select ) => {
+	const { context, hasResolved, title, content } = useSelect( ( select ) => {
 		const { getEditedPostContext, getEditedPostType, getEditedPostId } =
 			select( editSiteStore );
 		const { getEditedEntityRecord, hasFinishedResolution } =
@@ -34,7 +35,7 @@ export default function EditTemplate() {
 				queryArgs
 			),
 			title: template?.title,
-			blocks: template?.blocks,
+			content: template?.content,
 		};
 	}, [] );
 
@@ -43,6 +44,12 @@ export default function EditTemplate() {
 	const blockContext = useMemo(
 		() => ( { ...context, postType: null, postId: null } ),
 		[ context ]
+	);
+
+	const blocks = useMemo(
+		() =>
+			content && typeof content !== 'function' ? parse( content ) : [],
+		[ content ]
 	);
 
 	if ( ! hasResolved ) {

--- a/test/e2e/specs/site-editor/pages.spec.js
+++ b/test/e2e/specs/site-editor/pages.spec.js
@@ -79,6 +79,11 @@ test.describe( 'Pages', () => {
 
 		// Switch to template editing focus.
 		await editor.openDocumentSettingsSidebar();
+		await expect(
+			page.locator(
+				'.edit-site-page-panels__edit-template-preview iframe'
+			)
+		).toBeVisible();
 		await page
 			.getByRole( 'region', { name: 'Editor settings' } )
 			.getByRole( 'button', { name: 'Edit template' } )


### PR DESCRIPTION
## What?
Fixes the `BlockPreview` that appears in the sidebar's _Template_ panel when editing a page in the site editor.

## Why?
It went missing as a result of https://github.com/WordPress/gutenberg/pull/52417 removing the `blocks` attribute from the object retuned by `getEditedEntityRecord`. 

## How?
The fix is identical to https://github.com/WordPress/gutenberg/pull/52899. We simply `parse()` `content` ourselves.

## Testing Instructions
I added a regression assertion to this feature's E2E spec.

To test manually:

1. Go to Appearance → Editor → Pages and select a page to edit.
2. Open the settings sidebar (right sidebar). A preview of the template should appear in the _Template_ panel.

## Screenshots or screencast 

| Before | After |
|--------|--------|
| <img width="301" alt="Screenshot 2023-08-11 at 11 18 59" src="https://github.com/WordPress/gutenberg/assets/612155/9de0f42d-97e1-4979-af9c-22142c87195a"> | <img width="299" alt="Screenshot 2023-08-11 at 11 19 09" src="https://github.com/WordPress/gutenberg/assets/612155/2de181f4-7ab2-4e09-8cb9-0485c49baf75"> | 