### PR TITLE
List View: Add keyboard shortcut for duplicating blocks

### DIFF
--- a/packages/block-editor/src/components/list-view/block-select-button.js
+++ b/packages/block-editor/src/components/list-view/block-select-button.js
@@ -86,11 +86,9 @@ function ListViewBlockSelectButton(
 		onDragStart?.( event );
 	};
 
-	// Determine which blocks to update using logic that if the current block
-	// is part of the block selection, then use the whole block selection for the
-	// update. Otherwise, only update the current block. This way, where the user is
-	// currently focused has a logical impact on what happens when they perform an action.
-	// This is used by actions to delete and duplicate blocks.
+	// Determine which blocks to update:
+	// If the current (focused) block is part of the block selection, use the whole selection.
+	// If the focused block is not part of the block selection, only update the focused block.
 	function getBlocksToUpdate() {
 		const selectedBlockClientIds = getSelectedBlockClientIds();
 		const isUpdatingSelectedBlocks =
@@ -175,14 +173,8 @@ function ListViewBlockSelectButton(
 			);
 
 			if ( canDuplicate ) {
-				const duplicatedBlocks = duplicateBlocks(
-					blocksToUpdate,
-					false
-				);
-
-				if ( duplicatedBlocks ) {
-					updateFocusAndSelection( duplicatedBlocks, true );
-				}
+				// Duplicate blocks, but do not update the selection.
+				duplicateBlocks( blocksToUpdate, false );
 			}
 		}
 	}

--- a/packages/block-editor/src/components/list-view/block-select-button.js
+++ b/packages/block-editor/src/components/list-view/block-select-button.js
@@ -114,7 +114,7 @@ function ListViewBlockSelectButton(
 	/**
 	 * @param {KeyboardEvent} event
 	 */
-	function onKeyDownHandler( event ) {
+	async function onKeyDownHandler( event ) {
 		if ( event.keyCode === ENTER || event.keyCode === SPACE ) {
 			onClick( event );
 		} else if (
@@ -173,8 +173,15 @@ function ListViewBlockSelectButton(
 			);
 
 			if ( canDuplicate ) {
-				// Duplicate blocks, but do not update the selection.
-				duplicateBlocks( blocksToUpdate, false );
+				const updatedBlocks = await duplicateBlocks(
+					blocksToUpdate,
+					false
+				);
+
+				if ( updatedBlocks?.length ) {
+					// If blocks have been duplicated, focus the first duplicated block.
+					updateFocusAndSelection( updatedBlocks[ 0 ], false );
+				}
 			}
 		}
 	}

--- a/test/e2e/specs/editor/various/list-view.spec.js
+++ b/test/e2e/specs/editor/various/list-view.spec.js
@@ -431,7 +431,7 @@ test.describe( 'List View', () => {
 		).toBeFocused();
 	} );
 
-	test( 'should delete blocks using keyboard', async ( {
+	test( 'should duplicate and delete blocks using keyboard', async ( {
 		editor,
 		page,
 		pageUtils,
@@ -474,6 +474,20 @@ test.describe( 'List View', () => {
 				{ name: 'core/file', selected: true, focused: true },
 			] );
 
+		await page.keyboard.press( 'Meta+Shift+d' );
+
+		await expect
+			.poll(
+				listViewUtils.getBlocksWithA11yAttributes,
+				'Duplicating a block should retain focus and selection on existing block.'
+			)
+			.toMatchObject( [
+				{ name: 'core/group' },
+				{ name: 'core/columns' },
+				{ name: 'core/file', selected: true, focused: true },
+				{ name: 'core/file' },
+			] );
+
 		await page.keyboard.press( 'Delete' );
 		await expect
 			.poll(
@@ -483,6 +497,7 @@ test.describe( 'List View', () => {
 			.toMatchObject( [
 				{ name: 'core/group' },
 				{ name: 'core/columns', selected: true, focused: true },
+				{ name: 'core/file' },
 			] );
 
 		// Expand the current column.
@@ -504,6 +519,7 @@ test.describe( 'List View', () => {
 						{ name: 'core/column', focused: true },
 					],
 				},
+				{ name: 'core/file' },
 			] );
 
 		await page.keyboard.press( 'Delete' );
@@ -525,6 +541,7 @@ test.describe( 'List View', () => {
 						},
 					],
 				},
+				{ name: 'core/file' },
 			] );
 
 		// Expand the current column.
@@ -555,6 +572,7 @@ test.describe( 'List View', () => {
 						},
 					],
 				},
+				{ name: 'core/file' },
 			] );
 
 		// Move focus and select the first block.
@@ -573,14 +591,17 @@ test.describe( 'List View', () => {
 					selected: true,
 					focused: true,
 				},
+				{ name: 'core/file' },
 			] );
 
+		// Delete remaining blocks.
 		// Keyboard shortcut should also work.
+		await pageUtils.pressKeys( 'access+z' );
 		await pageUtils.pressKeys( 'access+z' );
 		await expect
 			.poll(
 				listViewUtils.getBlocksWithA11yAttributes,
-				'Deleting the only block left will create a default block and focus/select it'
+				'Deleting the only blocks left will create a default block and focus/select it'
 			)
 			.toMatchObject( [
 				{

--- a/test/e2e/specs/editor/various/list-view.spec.js
+++ b/test/e2e/specs/editor/various/list-view.spec.js
@@ -474,7 +474,7 @@ test.describe( 'List View', () => {
 				{ name: 'core/file', selected: true, focused: true },
 			] );
 
-		await page.keyboard.press( 'Meta+Shift+d' );
+		await pageUtils.pressKeys( 'primaryShift+d' );
 
 		await expect
 			.poll(

--- a/test/e2e/specs/editor/various/list-view.spec.js
+++ b/test/e2e/specs/editor/various/list-view.spec.js
@@ -479,15 +479,17 @@ test.describe( 'List View', () => {
 		await expect
 			.poll(
 				listViewUtils.getBlocksWithA11yAttributes,
-				'Duplicating a block should retain focus and selection on existing block.'
+				'Duplicating a block should retain selection on existing block, move focus to duplicated block.'
 			)
 			.toMatchObject( [
 				{ name: 'core/group' },
 				{ name: 'core/columns' },
-				{ name: 'core/file', selected: true, focused: true },
-				{ name: 'core/file' },
+				{ name: 'core/file', selected: true },
+				{ name: 'core/file', focused: true },
 			] );
 
+		// Move focus to the first file block, and then delete it.
+		await page.keyboard.press( 'ArrowUp' );
 		await page.keyboard.press( 'Delete' );
 		await expect
 			.poll(


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Part of: https://github.com/WordPress/gutenberg/issues/49563

Within the List View, enable handling for the keyboard shortcut to duplicate blocks.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

So that while navigating around the list view via keyboard, you can quickly duplicate the selected (or focused) blocks without needing to change focus to another area (i.e. the block settings menu or the editor canvas).

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* Use similar logic as in the block settings menu to enable the keyboard shortcut for duplicating blocks, but within the list view
* Combine some of the shared logic for determining which blocks to update (the bits that are the same about deleting or duplicating blocks within the list view)
* Update the existing e2e test for deleting blocks in the list view so that it also covers duplicating blocks. While this adds some extra complexity to that test, I remember @kevin940726 mentioning that for e2es it's sometimes better to combine logic in the one test rather than have multiple slower tests. Very happy for feedback on the change there.

<!--
## To-do

* [x] Fix selection after duplication. What do we expect to have happen here? ~I _think_ I'd expect the duplicated blocks to all be selected and focused within the list view.~ Update: for consistency with the block settings menu behaviour, I've switched it so that blocks are duplicated but no selection change occurs.
* [x] Currently, it looks like no blocks are selected, so shift-clicking blocks does not immediately work to start a selection. Once the above has been fixed, double check that shift-clicking still works as expected. Edit: with the above change in place, the selection remains so shift-clicking works as normal.
-->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

* Add some blocks to a post or template
* Open the list view and click a block twice in the list view so that the block is selected and focus is retained within the list view
* Press `CMD+Shift+d` to duplicate the block. This should work!
* Try selecting multiple blocks within the list view and use the same keyboard shortcut to duplicate blocks. This should also work, and focus should remain on the existing blocks and not be shifted to the newly created blocks (this matches the existing behaviour when using the block settings menu)
* Add a footnote to a paragraph block within a post or page
* Try selecting multiple blocks that includes the Footnotes block (e.g. a Paragraph and a Footnotes block at the same time). Then, press `CMD+Shift+d` — nothing should happen as only one Footnotes block is allowed on a post or page.

## Screenshots or screencast <!-- if applicable -->

In the below screengrab, Paragraph blocks are duplicated via the keyboard shortcut. Then, a selection that includes a Footnotes block is made, and the keyboard shortcut is attempted again, and nothing happens (which is expected).

https://github.com/WordPress/gutenberg/assets/14988353/aa66a9d2-ebde-4e68-b693-22a42cb9cb76