### PR TITLE
Fix pattern creation button in list view dropdown menu

### DIFF
--- a/packages/e2e-test-utils/src/click-menu-item.js
+++ b/packages/e2e-test-utils/src/click-menu-item.js
@@ -4,8 +4,8 @@
  * @param {string} label The label to search the menu item for.
  */
 export async function clickMenuItem( label ) {
-	const menuItems = await page.$x(
+	const menuItem = await page.waitForXPath(
 		`//*[@role="menu"]//*[text()="${ label }"]`
 	);
-	await menuItems[ 0 ].click();
+	await menuItem.click();
 }

--- a/packages/patterns/src/components/index.js
+++ b/packages/patterns/src/components/index.js
@@ -1,8 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useSelect } from '@wordpress/data';
-import { store as blockEditorStore } from '@wordpress/block-editor';
+import { BlockSettingsMenuControls } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
@@ -11,20 +10,22 @@ import PatternConvertButton from './pattern-convert-button';
 import PatternsManageButton from './patterns-manage-button';
 
 export default function PatternsMenuItems( { rootClientId } ) {
-	const clientIds = useSelect(
-		( select ) => select( blockEditorStore ).getSelectedBlockClientIds(),
-		[]
-	);
-
 	return (
-		<>
-			<PatternConvertButton
-				clientIds={ clientIds }
-				rootClientId={ rootClientId }
-			/>
-			{ clientIds.length === 1 && (
-				<PatternsManageButton clientId={ clientIds[ 0 ] } />
+		<BlockSettingsMenuControls>
+			{ ( { onClose, selectedClientIds } ) => (
+				<>
+					<PatternConvertButton
+						clientIds={ selectedClientIds }
+						rootClientId={ rootClientId }
+						onClose={ onClose }
+					/>
+					{ selectedClientIds.length === 1 && (
+						<PatternsManageButton
+							clientId={ selectedClientIds[ 0 ] }
+						/>
+					) }
+				</>
 			) }
-		</>
+		</BlockSettingsMenuControls>
 	);
 }

--- a/packages/patterns/src/components/pattern-convert-button.js
+++ b/packages/patterns/src/components/pattern-convert-button.js
@@ -2,10 +2,7 @@
  * WordPress dependencies
  */
 import { hasBlockSupport, isReusableBlock } from '@wordpress/blocks';
-import {
-	BlockSettingsMenuControls,
-	store as blockEditorStore,
-} from '@wordpress/block-editor';
+import { store as blockEditorStore } from '@wordpress/block-editor';
 import { useState } from '@wordpress/element';
 import { MenuItem } from '@wordpress/components';
 import { symbol } from '@wordpress/icons';
@@ -24,9 +21,14 @@ import CreatePatternModal from './create-pattern-modal';
  * @param {Object}   props              Component props.
  * @param {string[]} props.clientIds    Client ids of selected blocks.
  * @param {string}   props.rootClientId ID of the currently selected top-level block.
+ * @param {()=>void} props.onClose      Callback to close the menu.
  * @return {import('@wordpress/element').WPComponent} The menu control or null.
  */
-export default function PatternConvertButton( { clientIds, rootClientId } ) {
+export default function PatternConvertButton( {
+	clientIds,
+	rootClientId,
+	onClose,
+} ) {
 	const { createSuccessNotice } = useDispatch( noticesStore );
 	const [ isModalOpen, setIsModalOpen ] = useState( false );
 	const canConvert = useSelect(
@@ -103,34 +105,27 @@ export default function PatternConvertButton( { clientIds, rootClientId } ) {
 		setIsModalOpen( false );
 	};
 	return (
-		<BlockSettingsMenuControls>
-			{ ( { onClose } ) => (
-				<>
-					<MenuItem
-						icon={ symbol }
-						onClick={ () => setIsModalOpen( true ) }
-					>
-						{ __( 'Create pattern' ) }
-					</MenuItem>
-					{ isModalOpen && (
-						<CreatePatternModal
-							clientIds={ clientIds }
-							onSuccess={ ( pattern ) => {
-								handleSuccess( pattern );
-								onClose();
-							} }
-							onError={ () => {
-								setIsModalOpen( false );
-								onClose();
-							} }
-							onClose={ () => {
-								setIsModalOpen( false );
-								onClose();
-							} }
-						/>
-					) }
-				</>
+		<>
+			<MenuItem icon={ symbol } onClick={ () => setIsModalOpen( true ) }>
+				{ __( 'Create pattern' ) }
+			</MenuItem>
+			{ isModalOpen && (
+				<CreatePatternModal
+					clientIds={ clientIds }
+					onSuccess={ ( pattern ) => {
+						handleSuccess( pattern );
+						onClose();
+					} }
+					onError={ () => {
+						setIsModalOpen( false );
+						onClose();
+					} }
+					onClose={ () => {
+						setIsModalOpen( false );
+						onClose();
+					} }
+				/>
 			) }
-		</BlockSettingsMenuControls>
+		</>
 	);
 }

--- a/packages/patterns/src/components/patterns-manage-button.js
+++ b/packages/patterns/src/components/patterns-manage-button.js
@@ -5,10 +5,7 @@ import { MenuItem } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { isReusableBlock } from '@wordpress/blocks';
 import { useSelect, useDispatch } from '@wordpress/data';
-import {
-	BlockSettingsMenuControls,
-	store as blockEditorStore,
-} from '@wordpress/block-editor';
+import { store as blockEditorStore } from '@wordpress/block-editor';
 import { addQueryArgs } from '@wordpress/url';
 import { store as coreStore } from '@wordpress/core-data';
 
@@ -62,7 +59,7 @@ function PatternsManageButton( { clientId } ) {
 	}
 
 	return (
-		<BlockSettingsMenuControls>
+		<>
 			<MenuItem href={ managePatternsUrl }>
 				{ __( 'Manage patterns' ) }
 			</MenuItem>
@@ -73,7 +70,7 @@ function PatternsManageButton( { clientId } ) {
 						: __( 'Detach pattern' ) }
 				</MenuItem>
 			) }
-		</BlockSettingsMenuControls>
+		</>
 	);
 }
 

--- a/packages/patterns/src/index.native.js
+++ b/packages/patterns/src/index.native.js
@@ -1,0 +1,11 @@
+/**
+ * Internal dependencies
+ */
+import './store';
+import { lock } from './lock-unlock';
+
+export const privateApis = {};
+lock( privateApis, {
+	CreatePatternModal: () => null,
+	PatternsMenuItems: () => null,
+} );

--- a/packages/reusable-blocks/src/components/reusable-blocks-menu-items/index.js
+++ b/packages/reusable-blocks/src/components/reusable-blocks-menu-items/index.js
@@ -1,8 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useSelect } from '@wordpress/data';
-import { store as blockEditorStore } from '@wordpress/block-editor';
+import { BlockSettingsMenuControls } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
@@ -11,20 +10,22 @@ import ReusableBlockConvertButton from './reusable-block-convert-button';
 import ReusableBlocksManageButton from './reusable-blocks-manage-button';
 
 export default function ReusableBlocksMenuItems( { rootClientId } ) {
-	const clientIds = useSelect(
-		( select ) => select( blockEditorStore ).getSelectedBlockClientIds(),
-		[]
-	);
-
 	return (
-		<>
-			<ReusableBlockConvertButton
-				clientIds={ clientIds }
-				rootClientId={ rootClientId }
-			/>
-			{ clientIds.length === 1 && (
-				<ReusableBlocksManageButton clientId={ clientIds[ 0 ] } />
+		<BlockSettingsMenuControls>
+			{ ( { onClose, selectedClientIds } ) => (
+				<>
+					<ReusableBlockConvertButton
+						clientIds={ selectedClientIds }
+						rootClientId={ rootClientId }
+						onClose={ onClose }
+					/>
+					{ selectedClientIds.length === 1 && (
+						<ReusableBlocksManageButton
+							clientId={ selectedClientIds[ 0 ] }
+						/>
+					) }
+				</>
 			) }
-		</>
+		</BlockSettingsMenuControls>
 	);
 }

--- a/packages/reusable-blocks/src/components/reusable-blocks-menu-items/reusable-block-convert-button.js
+++ b/packages/reusable-blocks/src/components/reusable-blocks-menu-items/reusable-block-convert-button.js
@@ -3,7 +3,6 @@
  */
 import { hasBlockSupport, isReusableBlock } from '@wordpress/blocks';
 import {
-	BlockSettingsMenuControls,
 	store as blockEditorStore,
 	privateApis as blockEditorPrivateApis,
 } from '@wordpress/block-editor';
@@ -35,11 +34,13 @@ import { unlock } from '../../lock-unlock';
  * @param {Object}   props              Component props.
  * @param {string[]} props.clientIds    Client ids of selected blocks.
  * @param {string}   props.rootClientId ID of the currently selected top-level block.
+ * @param {()=>void} props.onClose      Callback to close the menu.
  * @return {import('@wordpress/element').WPComponent} The menu control or null.
  */
 export default function ReusableBlockConvertButton( {
 	clientIds,
 	rootClientId,
+	onClose,
 } ) {
 	const { useReusableBlocksRenameHint, ReusableBlocksRenameHint } = unlock(
 		blockEditorPrivateApis
@@ -148,80 +149,71 @@ export default function ReusableBlockConvertButton( {
 	}
 
 	return (
-		<BlockSettingsMenuControls>
-			{ ( { onClose } ) => (
-				<>
-					<MenuItem
-						icon={ symbol }
-						onClick={ () => setIsModalOpen( true ) }
+		<>
+			<MenuItem icon={ symbol } onClick={ () => setIsModalOpen( true ) }>
+				{ showRenameHint
+					? __( 'Create pattern/reusable block' )
+					: __( 'Create pattern' ) }
+			</MenuItem>
+			{ isModalOpen && (
+				<Modal
+					title={ __( 'Create pattern' ) }
+					onRequestClose={ () => {
+						setIsModalOpen( false );
+						setTitle( '' );
+					} }
+					overlayClassName="reusable-blocks-menu-items__convert-modal"
+				>
+					<form
+						onSubmit={ ( event ) => {
+							event.preventDefault();
+							onConvert( title );
+							setIsModalOpen( false );
+							setTitle( '' );
+							onClose();
+						} }
 					>
-						{ showRenameHint
-							? __( 'Create pattern/reusable block' )
-							: __( 'Create pattern' ) }
-					</MenuItem>
-					{ isModalOpen && (
-						<Modal
-							title={ __( 'Create pattern' ) }
-							onRequestClose={ () => {
-								setIsModalOpen( false );
-								setTitle( '' );
-							} }
-							overlayClassName="reusable-blocks-menu-items__convert-modal"
-						>
-							<form
-								onSubmit={ ( event ) => {
-									event.preventDefault();
-									onConvert( title );
-									setIsModalOpen( false );
-									setTitle( '' );
-									onClose();
+						<VStack spacing="5">
+							<ReusableBlocksRenameHint />
+							<TextControl
+								__nextHasNoMarginBottom
+								label={ __( 'Name' ) }
+								value={ title }
+								onChange={ setTitle }
+								placeholder={ __( 'My pattern' ) }
+							/>
+
+							<ToggleControl
+								label={ __( 'Synced' ) }
+								help={ __(
+									'Editing the pattern will update it anywhere it is used.'
+								) }
+								checked={ ! syncType }
+								onChange={ () => {
+									setSyncType(
+										! syncType ? 'unsynced' : undefined
+									);
 								} }
-							>
-								<VStack spacing="5">
-									<ReusableBlocksRenameHint />
-									<TextControl
-										__nextHasNoMarginBottom
-										label={ __( 'Name' ) }
-										value={ title }
-										onChange={ setTitle }
-										placeholder={ __( 'My pattern' ) }
-									/>
+							/>
+							<HStack justify="right">
+								<Button
+									variant="tertiary"
+									onClick={ () => {
+										setIsModalOpen( false );
+										setTitle( '' );
+									} }
+								>
+									{ __( 'Cancel' ) }
+								</Button>
 
-									<ToggleControl
-										label={ __( 'Synced' ) }
-										help={ __(
-											'Editing the pattern will update it anywhere it is used.'
-										) }
-										checked={ ! syncType }
-										onChange={ () => {
-											setSyncType(
-												! syncType
-													? 'unsynced'
-													: undefined
-											);
-										} }
-									/>
-									<HStack justify="right">
-										<Button
-											variant="tertiary"
-											onClick={ () => {
-												setIsModalOpen( false );
-												setTitle( '' );
-											} }
-										>
-											{ __( 'Cancel' ) }
-										</Button>
-
-										<Button variant="primary" type="submit">
-											{ __( 'Create' ) }
-										</Button>
-									</HStack>
-								</VStack>
-							</form>
-						</Modal>
-					) }
-				</>
+								<Button variant="primary" type="submit">
+									{ __( 'Create' ) }
+								</Button>
+							</HStack>
+						</VStack>
+					</form>
+				</Modal>
 			) }
-		</BlockSettingsMenuControls>
+		</>
 	);
 }

--- a/packages/reusable-blocks/src/components/reusable-blocks-menu-items/reusable-blocks-manage-button.js
+++ b/packages/reusable-blocks/src/components/reusable-blocks-menu-items/reusable-blocks-manage-button.js
@@ -5,10 +5,7 @@ import { MenuItem } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { isReusableBlock } from '@wordpress/blocks';
 import { useSelect, useDispatch } from '@wordpress/data';
-import {
-	BlockSettingsMenuControls,
-	store as blockEditorStore,
-} from '@wordpress/block-editor';
+import { store as blockEditorStore } from '@wordpress/block-editor';
 import { addQueryArgs } from '@wordpress/url';
 import { store as coreStore } from '@wordpress/core-data';
 
@@ -62,7 +59,7 @@ function ReusableBlocksManageButton( { clientId } ) {
 	}
 
 	return (
-		<BlockSettingsMenuControls>
+		<>
 			<MenuItem href={ managePatternsUrl }>
 				{ __( 'Manage patterns' ) }
 			</MenuItem>
@@ -73,7 +70,7 @@ function ReusableBlocksManageButton( { clientId } ) {
 						: __( 'Detach pattern' ) }
 				</MenuItem>
 			) }
-		</BlockSettingsMenuControls>
+		</>
 	);
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
(Also closes #37366 and closes #49440)

Also accidentally fixes https://github.com/WordPress/gutenberg/issues/53319. There's a bug mentioned in the issue that sometimes the "Create patterns/reusable block" button shows on a pattern that is already a pattern. This PR fixes that and also fixes the OP's issue as well.

This is a minimal fix though, and whether or not one should be able to create nested patterns inside another pattern is still undecided. The default is to allow that, but if that doesn't make sense in some scenarios, we can add some additional logic to disallow that (possibly in another PR for easier reviews).

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Inconsistency and confusing to the users.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
By moving `BlockSettingsMenuControls` to the parent `ReusableBlocksMenuItems` component and passing the `selectedClientIds` in the render props to the underlying components. In list view context, the blocks that the user is interacting with aren't necessarily the selected blocks (`getSelectedBlockClientIds`). This is because one could select a block but open the dropdown menu of another irrelevant block.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
Follow the instructions in #53319 for the empty pattern bug.

The list view dropdown block can be reproduced as:
1. Open a post editor
2. Insert a pattern into the post
3. Open the list view sidebar
4. Select the pattern and click the dropdown menu icon. There should be no "Create pattern/reusable block" menu item in the dropdown.
5. Without changing the selected block in the list view, hover on another non-pattern block and click on its dropdown menu icon. There should be a "Create pattern/reusable block" menu button if it's allowed.

The original bug can be seen in this video below:

https://github.com/WordPress/gutenberg/assets/7753001/4108318f-db12-4e5a-b75e-ef67a9c6c92f


### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

In site editor when creating a nested pattern:

https://github.com/WordPress/gutenberg/assets/7753001/6960eda6-b7ae-4b69-ad44-8ecf34aaf781

In post editor when using list view to create a pattern:

https://github.com/WordPress/gutenberg/assets/7753001/8676774b-58c9-4061-bd9e-7654e918d5b1

