### PR TITLE
Webkit e2e: attempt to fix shift+click test

### DIFF
--- a/test/e2e/specs/editor/various/multi-block-selection.spec.js
+++ b/test/e2e/specs/editor/various/multi-block-selection.spec.js
@@ -1209,13 +1209,15 @@ test.describe( 'Multi-block selection', () => {
 			.getByRole( 'region', { name: 'Editor content' } )
 			.getByText( '1', { exact: true } );
 		const strongBox = await strongText.boundingBox();
-		await strongText.click( {
-			// Ensure clicking on the right half of the element.
-			position: { x: strongBox.width, y: strongBox.height / 2 },
-			modifiers: [ 'Shift' ],
-			// "<p>" intercepts pointer events in WebKit.
-			force: true,
-		} );
+		// Focus and move the caret to the end.
+		await editor.canvas
+			.getByRole( 'document', { name: 'Paragraph block' } )
+			.filter( { hasText: '1[' } )
+			.click( {
+				// Ensure clicking on the right half of the element.
+				position: { x: strongBox.width - 1, y: strongBox.height / 2 },
+				modifiers: [ 'Shift' ],
+			} );
 		await page.keyboard.press( 'Backspace' );
 
 		// Ensure selection is in the correct place.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Tries to fix #53524.

Let's see if removing the force option work, and making sure the coordinates are within the bold tag.

I'll re-run the jobs a couple of times.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
