### PR TITLE
Workflows: Fix issues with the npm publishing workflow when using locally

### DIFF
--- a/bin/plugin/commands/packages.js
+++ b/bin/plugin/commands/packages.js
@@ -424,6 +424,7 @@ async function publishPackagesToNpm( {
 			log(
 				'>> Trying to finish failed publishing of modified npm packages.'
 			);
+			await SimpleGit( gitWorkingDirectoryPath ).reset( 'hard' );
 			await command(
 				`npx lerna publish from-package --dist-tag ${ distTag } ${ yesFlag } ${ noVerifyAccessFlag }`,
 				{
@@ -457,6 +458,7 @@ async function publishPackagesToNpm( {
 			log(
 				'>> Trying to finish failed publishing of modified npm packages.'
 			);
+			await SimpleGit( gitWorkingDirectoryPath ).reset( 'hard' );
 			await command(
 				`npx lerna publish from-package ${ yesFlag } ${ noVerifyAccessFlag }`,
 				{

--- a/bin/plugin/commands/packages.js
+++ b/bin/plugin/commands/packages.js
@@ -25,6 +25,7 @@ const {
 	findPluginReleaseBranchName,
 } = require( './common' );
 const { join } = require( 'path' );
+const pluginConfig = require( '../config' );
 
 /**
  * Release type names.
@@ -99,7 +100,7 @@ async function checkoutNpmReleaseBranch( {
 	 * `trunk` commits from within the past week.
 	 */
 	await SimpleGit( gitWorkingDirectoryPath )
-		.fetch( npmReleaseBranch, [ '--depth=100' ] )
+		.fetch( 'origin', npmReleaseBranch, [ '--depth=100' ] )
 		.checkout( npmReleaseBranch );
 	log(
 		'>> The local npm release branch ' +
@@ -371,6 +372,16 @@ async function publishPackagesToNpm( {
 	minimumVersionBump,
 	releaseType,
 } ) {
+	const { stdout: nodeVersion } = await command( 'node -v', {
+		cwd: gitWorkingDirectoryPath,
+	} );
+	log( `>> Current node version: ${ nodeVersion }.` );
+
+	const { stdout: npmVersion } = await command( 'npm -v', {
+		cwd: gitWorkingDirectoryPath,
+	} );
+	log( `>> Current node version: ${ npmVersion }.` );
+
 	log( '>> Installing npm packages.' );
 	await command( 'npm ci', {
 		cwd: gitWorkingDirectoryPath,
@@ -411,13 +422,26 @@ async function publishPackagesToNpm( {
 		);
 	} else if ( [ 'bugfix', 'wp' ].includes( releaseType ) ) {
 		log( '>> Publishing modified packages to npm.' );
-		await command(
-			`npx lerna publish ${ minimumVersionBump } --dist-tag ${ distTag } --no-private ${ yesFlag } ${ noVerifyAccessFlag }`,
-			{
-				cwd: gitWorkingDirectoryPath,
-				stdio: 'inherit',
-			}
-		);
+		try {
+			await command(
+				`npx lerna publish ${ minimumVersionBump } --dist-tag ${ distTag } --no-private ${ yesFlag } ${ noVerifyAccessFlag }`,
+				{
+					cwd: gitWorkingDirectoryPath,
+					stdio: 'inherit',
+				}
+			);
+		} catch {
+			log(
+				'>> Trying to finish failed publishing of modified npm packages.'
+			);
+			await command(
+				`npx lerna publish from-package --dist-tag ${ distTag } ${ yesFlag } ${ noVerifyAccessFlag }`,
+				{
+					cwd: gitWorkingDirectoryPath,
+					stdio: 'inherit',
+				}
+			);
+		}
 	} else {
 		log(
 			'>> Bumping version of public packages changed since the last release.'
@@ -431,13 +455,26 @@ async function publishPackagesToNpm( {
 		);
 
 		log( '>> Publishing modified packages to npm.' );
-		await command(
-			`npx lerna publish from-package ${ yesFlag } ${ noVerifyAccessFlag }`,
-			{
-				cwd: gitWorkingDirectoryPath,
-				stdio: 'inherit',
-			}
-		);
+		try {
+			await command(
+				`npx lerna publish from-package ${ yesFlag } ${ noVerifyAccessFlag }`,
+				{
+					cwd: gitWorkingDirectoryPath,
+					stdio: 'inherit',
+				}
+			);
+		} catch {
+			log(
+				'>> Trying to finish failed publishing of modified npm packages.'
+			);
+			await command(
+				`npx lerna publish from-package ${ yesFlag } ${ noVerifyAccessFlag }`,
+				{
+					cwd: gitWorkingDirectoryPath,
+					stdio: 'inherit',
+				}
+			);
+		}
 	}
 
 	const afterCommitHash = await SimpleGit( gitWorkingDirectoryPath ).revparse(
@@ -530,7 +567,11 @@ async function runPackagesRelease( config, customMessages ) {
 			config.abortMessage,
 			async () => {
 				log( '>> Cloning the Git repository' );
-				await SimpleGit( gitPath ).clone( config.gitRepositoryURL );
+				await SimpleGit().clone(
+					pluginConfig.gitRepositoryURL,
+					gitPath,
+					[ '--depth=1', '--no-single-branch' ]
+				);
 				log( `   >> successfully clone into: ${ gitPath }` );
 			}
 		);

--- a/bin/plugin/commands/packages.js
+++ b/bin/plugin/commands/packages.js
@@ -372,16 +372,6 @@ async function publishPackagesToNpm( {
 	minimumVersionBump,
 	releaseType,
 } ) {
-	const { stdout: nodeVersion } = await command( 'node -v', {
-		cwd: gitWorkingDirectoryPath,
-	} );
-	log( `>> Current node version: ${ nodeVersion }.` );
-
-	const { stdout: npmVersion } = await command( 'npm -v', {
-		cwd: gitWorkingDirectoryPath,
-	} );
-	log( `>> Current node version: ${ npmVersion }.` );
-
 	log( '>> Installing npm packages.' );
 	await command( 'npm ci', {
 		cwd: gitWorkingDirectoryPath,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

WordPress publishing to npm failed last week after the Gutenberg plugin 16.4 RC1 last week. @luisherranz noticed that there are now updates available on npm, and after some investigation, I located the job that filed https://github.com/WordPress/gutenberg/actions/runs/5741376252/job/15561635704 with the following error:

<img width="1130" alt="Screenshot 2023-08-11 at 13 53 47" src="https://github.com/WordPress/gutenberg/assets/699132/3ff6bf0f-387a-4cce-a140-64ebae86eb5e">

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

It isn't the first time that we experienced network issues, but previously they happened only with npm. This time it was GitHub that had some connection issues. I had to run the process manually from my machine using the following command

```bash
./bin/plugin/cli.js npm-latest --semver minor
```

I saw the following issues introduced with the refactoring performed in #45255:

<img width="1187" alt="Screenshot 2023-08-10 at 13 30 47" src="https://github.com/WordPress/gutenberg/assets/699132/2ffed7b6-7a1c-4b31-b69e-2b21047f6da6">

<img width="1191" alt="Screenshot 2023-08-10 at 13 34 58" src="https://github.com/WordPress/gutenberg/assets/699132/9ab60498-39cd-4934-b83f-b70ee7aaac68">


## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

I updated git operations to work on my machine by trying different configurations. I don't know if it's optimal but I was able to move forward with that part.

 I also added a single re-try for npm publishing in case npm has network issues. We experienced it several times in the past, and @Mamaduka suggested we add some fallback for that. I used the command documented in https://github.com/WordPress/gutenberg/blob/trunk/docs/contributors/code/release.md#synchronizing-the-gutenberg-plugin that we use whenever that happens.

~There is additional logging included that print Node.js and npm version. `trunk` uses now Node 16/npm 8, while the release branch for 16.4 is on Node 14/npm 6. The issue I encountered was that `npm ci` exploded the script because the branch enforces npm 6 while the script is running now with npm 8. I will file a separate issue for that as we need to find a solution how to use GitHub UI to run backports for WordPress 6.3 and other older versions that will experience the same issue.~ Moved to https://github.com/WordPress/gutenberg/issues/53628.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

That part is tricky because it requires performing going through the full npm publishing process. There is nothing to publish at the moment with:

```bash
./bin/plugin/cli.js npm-latest --semver minor
```

I executed it yesterday, and everything went well. I can confirm that the changes resolve both issues listed.

However, it is possible to run the development version of publishing with the following:

```bash
./bin/plugin/cli.js npm-next
```

It requires access to WordPress organization on npm and being logged in to npm before executing the script. It also requires write access to the Gutenberg repository.