### PR TITLE
`get_root_layout_rules`: remove unnecessary call to `sanitize_title`

### DIFF
--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -1317,7 +1317,7 @@ class WP_Theme_JSON_Gutenberg {
 						continue;
 					}
 
-					$class_name    = sanitize_title( _wp_array_get( $layout_definition, array( 'className' ), false ) );
+					$class_name    = _wp_array_get( $layout_definition, array( 'className' ), false );
 					$spacing_rules = _wp_array_get( $layout_definition, array( 'spacingStyles' ), array() );
 
 					if (
@@ -1374,7 +1374,7 @@ class WP_Theme_JSON_Gutenberg {
 		) {
 			$valid_display_modes = array( 'block', 'flex', 'grid' );
 			foreach ( $layout_definitions as $layout_definition ) {
-				$class_name       = sanitize_title( _wp_array_get( $layout_definition, array( 'className' ), false ) );
+				$class_name       = _wp_array_get( $layout_definition, array( 'className' ), false );
 				$base_style_rules = _wp_array_get( $layout_definition, array( 'baseStyles' ), array() );
 
 				if (


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/45171
Extracted from https://github.com/WordPress/gutenberg/pull/53351/

## What

This removes an unnecessary call to `sanitize_title`.

## Why

When this was introduced at https://github.com/WordPress/gutenberg/pull/40875 layout definitions were taken from `theme.json` (user modifiable), so sanitization was required. Now, the layout definitions are static, so we no longer need this.

I took a profile from loading the "hello world" post in a site that uses TwentyTwentyThree. I don't expect this to have big performance wins, though it's a small and fast win. 

| Trunk | PR |
| --- | --- |
| Called 92 times | Called 84 times |
| <img width="716" alt="Captura de ecrã 2023-08-11, às 14 14 48" src="https://github.com/WordPress/gutenberg/assets/583546/86a36680-6144-4c12-8b2b-20e028f1dc77"> |  <img width="716" alt="Captura de ecrã 2023-08-11, às 14 14 54" src="https://github.com/WordPress/gutenberg/assets/583546/e15031ac-b04c-4df4-be41-af0c512d23cc"> |

## Testing Instructions

Verify tests pass.
