### PR TITLE
Checking if it's an ajax call for the post excerpt

### DIFF
--- a/packages/block-library/src/post-excerpt/index.php
+++ b/packages/block-library/src/post-excerpt/index.php
@@ -84,12 +84,13 @@ add_action( 'init', 'register_block_core_post_excerpt' );
  * Returns 100 because 100 is the max length in the setting.
  */
 if ( is_admin() ||
-	defined( 'REST_REQUEST' ) && REST_REQUEST ) {
-	add_filter(
-		'excerpt_length',
-		static function() {
-			return 100;
-		},
-		PHP_INT_MAX
-	);
+     defined( 'REST_REQUEST' ) && REST_REQUEST ||
+     ( defined( 'DOING_AJAX' ) && DOING_AJAX ) ) {
+    add_filter(
+        'excerpt_length',
+        static function() {
+            return 100;
+        },
+        PHP_INT_MAX
+    );
 }

--- a/packages/block-library/src/post-excerpt/index.php
+++ b/packages/block-library/src/post-excerpt/index.php
@@ -84,13 +84,13 @@ add_action( 'init', 'register_block_core_post_excerpt' );
  * Returns 100 because 100 is the max length in the setting.
  */
 if ( is_admin() ||
-     defined( 'REST_REQUEST' ) && REST_REQUEST ||
-     ( defined( 'DOING_AJAX' ) && DOING_AJAX ) ) {
-    add_filter(
-        'excerpt_length',
-        static function() {
-            return 100;
-        },
-        PHP_INT_MAX
-    );
+	defined( 'REST_REQUEST' ) && REST_REQUEST ||
+	( defined( 'DOING_AJAX' ) && DOING_AJAX ) ) {
+	add_filter(
+		'excerpt_length',
+		static function() {
+			return 100;
+		},
+		PHP_INT_MAX
+	);
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
We are checking if it's an Ajax call for the post excerpt request.

## Why?
This is to ensure the correct length of the excerpt is returned.Fixes #53570

## How?
We are using the DOING_AJAX to check if it's an AJAX request.

## Testing Instructions
Please check the testing instructions here: https://github.com/WordPress/gutenberg/issues/53570

### Testing Instructions for Keyboard
N/A

## Screenshots or screencast <!-- if applicable -->
N/A
