### PR TITLE
Post Navigation Link: Remove unnecessary space between arrows and label

### DIFF
--- a/packages/block-library/src/post-navigation-link/index.php
+++ b/packages/block-library/src/post-navigation-link/index.php
@@ -88,9 +88,9 @@ function render_block_core_post_navigation_link( $attributes, $content ) {
 		$arrow = $arrow_map[ $attributes['arrow'] ][ $navigation_type ];
 
 		if ( 'next' === $navigation_type ) {
-			$format = '%link <span class="wp-block-post-navigation-link__arrow-next is-arrow-' . $attributes['arrow'] . '" aria-hidden="true">' . $arrow . '</span>';
+			$format = '%link<span class="wp-block-post-navigation-link__arrow-next is-arrow-' . $attributes['arrow'] . '" aria-hidden="true">' . $arrow . '</span>';
 		} else {
-			$format = '<span class="wp-block-post-navigation-link__arrow-previous is-arrow-' . $attributes['arrow'] . '" aria-hidden="true">' . $arrow . '</span> %link';
+			$format = '<span class="wp-block-post-navigation-link__arrow-previous is-arrow-' . $attributes['arrow'] . '" aria-hidden="true">' . $arrow . '</span>%link';
 		}
 	}
 


### PR DESCRIPTION
Fixes: #53340

## What?

This PR removes unnecessary space between arrow and label in the Post Navigation block.

| Before | After |
|--------|--------|
| ![before](https://github.com/WordPress/gutenberg/assets/54422211/ac67657b-ff6b-4e4a-80d0-3a71edec9c5f) | ![after](https://github.com/WordPress/gutenberg/assets/54422211/8ef3b3ae-fd48-4c09-84cb-496eda3a6496) | 

## Why?

When generating HTML in dynamic rendering, a space exists between the arrow and the link text. Since neither the arrow nor the link text is a block element, this space actually provides width.

However, this space is unintentional because there is a margin between the arrow and the link text that [has a value of 1ch](https://github.com/WordPress/gutenberg/blob/7050a7b9b6453296502fe3742832c77d2d74da56/packages/block-library/src/post-navigation-link/style.scss#L5).

## How?

This space has been removed.

## Testing Instructions

- Ensure your WordPress installation has enough posts to make the pagination work.
- Create a new post.

Use the following HTML to insert the block. This markup also includes Pagination blocks with Arrow or Chvron applied, and the font size is consistent across all blocks. This is to confirm the issue reported in #53340 where the space between the arrow and the text varies from block to block.

<details><summary>Details</summary>

```html
<!-- wp:post-navigation-link {"type":"previous","label":"","linkLabel":true,"arrow":"arrow","fontSize":"large"} /-->

<!-- wp:post-navigation-link {"arrow":"arrow","fontSize":"large"} /-->

<!-- wp:query {"queryId":7,"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false}} -->
<div class="wp-block-query"><!-- wp:query-pagination {"paginationArrow":"arrow"} -->
<!-- wp:query-pagination-previous {"fontSize":"large"} /-->

<!-- wp:query-pagination-next {"fontSize":"large"} /-->
<!-- /wp:query-pagination --></div>
<!-- /wp:query -->

<!-- wp:post-navigation-link {"type":"previous","arrow":"chevron","fontSize":"large"} /-->

<!-- wp:post-navigation-link {"arrow":"chevron","fontSize":"large"} /-->

<!-- wp:query {"queryId":7,"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false}} -->
<div class="wp-block-query"><!-- wp:query-pagination {"paginationArrow":"chevron"} -->
<!-- wp:query-pagination-previous {"fontSize":"large"} /-->

<!-- wp:query-pagination-next {"fontSize":"large"} /-->
<!-- /wp:query-pagination --></div>
<!-- /wp:query -->
```

</details> 

- Display that post on the front end.
- In the Post Navigation and Pagination blocks, the space between the arrow and the text should be the same.

![alignment](https://github.com/WordPress/gutenberg/assets/54422211/4103b0cb-b577-4081-9fa5-1c8fb48ccb17)
