### PR TITLE
Post Editor: top-align Publish row in the post panel

### DIFF
--- a/packages/edit-post/src/components/sidebar/post-schedule/style.scss
+++ b/packages/edit-post/src/components/sidebar/post-schedule/style.scss
@@ -2,6 +2,7 @@
 	width: 100%;
 	position: relative;
 	justify-content: flex-start;
+	align-items: flex-start;
 
 	span {
 		display: block;
@@ -15,6 +16,7 @@
 .components-button.edit-post-post-schedule__toggle {
 	text-align: left;
 	white-space: normal;
+	height: auto;
 
 	// This span is added by the Popover in Tooltip when no anchor is
 	// provided. We set its width to 0 so that it does not cause the button text


### PR DESCRIPTION
This PR is based on [this comment](https://github.com/WordPress/gutenberg/pull/53243#issuecomment-1662156040)

## What?

This PR top-aligns the Publish row in the post sidebar.

| Before | After |
|--------|--------|
| ![before](https://github.com/WordPress/gutenberg/assets/54422211/e33d3fe6-3386-489a-9112-a3e9d0460ce4) | ![after](https://github.com/WordPress/gutenberg/assets/54422211/82c5f2b9-6354-44e6-adec-9d630f85d94d) |


## Why?

In #53243, the row showing the sync state of the block pattern is now top-aligned. This PR may not be ideal, but I think that for rows that may wrap, the post date row should be aligned on top as well as the URL row and the sync row.

## How?

Apply `align-items: start` to the row. At the same time, the height of the toggle button to change the post date has been changed to `auto`. There is a 6px padding above and below this button, but if the height is fixed at 36px, the text will intervene in the padding area and not be aligned at the correct height.

![padding](https://github.com/WordPress/gutenberg/assets/54422211/266f27b3-4680-4bd3-8f8c-9a2a551ccd7a)

This would make this button slightly taller than before. However, I find this acceptable, since the same is true for [the URL button with `height:auto` specified](https://github.com/WordPress/gutenberg/blob/7050a7b9b6453296502fe3742832c77d2d74da56/packages/edit-post/src/components/sidebar/post-url/style.scss#L18).


## Testing Instructions

- Open the post editor.
- Click the Post Tab.
- Make sure that the publish rows are aligned exactly on top.
- Misalignment should not occur even if the site language is not English.