### PR TITLE
Compute presets from `theme.json`: skip those without classes or variables

### DIFF
--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -1569,6 +1569,10 @@ class WP_Theme_JSON_Gutenberg {
 
 		$stylesheet = '';
 		foreach ( static::PRESETS_METADATA as $preset_metadata ) {
+			if ( empty( $preset_metadata['classes'] ) ) {
+				continue;
+			}
+
 			$slugs = static::get_settings_slugs( $settings, $preset_metadata, $origins );
 			foreach ( $preset_metadata['classes'] as $class => $property ) {
 				foreach ( $slugs as $slug ) {

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -1772,7 +1772,7 @@ class WP_Theme_JSON_Gutenberg {
 	protected static function compute_preset_vars( $settings, $origins ) {
 		$declarations = array();
 		foreach ( static::PRESETS_METADATA as $preset_metadata ) {
-			if ( ! isset( $preset_metadata['css_vars'] ) ) {
+			if ( empty( $preset_metadata['css_vars'] ) ) {
 				continue;
 			}
 

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -1772,6 +1772,10 @@ class WP_Theme_JSON_Gutenberg {
 	protected static function compute_preset_vars( $settings, $origins ) {
 		$declarations = array();
 		foreach ( static::PRESETS_METADATA as $preset_metadata ) {
+			if ( ! isset( $preset_metadata['css_vars'] ) ) {
+				continue;
+			}
+
 			$values_by_slug = static::get_settings_values_by_slug( $settings, $preset_metadata, $origins );
 			foreach ( $values_by_slug as $slug => $value ) {
 				$declarations[] = array(


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/45171
Extracted from https://github.com/WordPress/gutenberg/pull/53351

## What?

When processing presets to generate its classes or CSS Custom Properties, skip those who don't declare any classes or variables in [their metadata](https://github.com/WordPress/gutenberg/blob/trunk/lib/class-wp-theme-json-gutenberg.php#L124).

## Why?

To reduce unnecessary computations.

## How?

Checking whether the preset has a class before processing it within `compute_preset_classes` and checking whether the preset has a variable before processing it within `compute_preset_vars`.

## Testing Instructions

Verify tests pass.
