### PR TITLE
Try: `get_style_nodes`: only return those that will be used

### DIFF
--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -1045,7 +1045,7 @@ class WP_Theme_JSON_Gutenberg {
 		}
 
 		$blocks_metadata = static::get_blocks_metadata();
-		$style_nodes     = static::get_style_nodes( $this->theme_json, $blocks_metadata );
+		$style_nodes     = static::get_style_nodes( $this->theme_json );
 		$setting_nodes   = static::get_setting_nodes( $this->theme_json, $blocks_metadata );
 
 		$root_style_key    = array_search( static::ROOT_BLOCK_SELECTOR, array_column( $style_nodes, 'selector' ), true );
@@ -2102,10 +2102,9 @@ class WP_Theme_JSON_Gutenberg {
 	 * @since 5.8.0
 	 *
 	 * @param array $theme_json The tree to extract style nodes from.
-	 * @param array $selectors  List of selectors per block.
 	 * @return array An array of style nodes metadata.
 	 */
-	protected static function get_style_nodes( $theme_json, $selectors = array() ) {
+	protected static function get_style_nodes( $theme_json ) {
 		$nodes = array();
 		if ( ! isset( $theme_json['styles'] ) ) {
 			return $nodes;
@@ -2144,26 +2143,7 @@ class WP_Theme_JSON_Gutenberg {
 			}
 		}
 
-		// Blocks.
-		if ( ! isset( $theme_json['styles']['blocks'] ) ) {
-			return $nodes;
-		}
-
-		$block_nodes = static::get_block_nodes( $theme_json, $selectors );
-		foreach ( $block_nodes as $block_node ) {
-			$nodes[] = $block_node;
-		}
-
-		/**
-		 * Filters the list of style nodes with metadata.
-		 *
-		 * This allows for things like loading block CSS independently.
-		 *
-		 * @since 6.1.0
-		 *
-		 * @param array $nodes Style nodes with metadata.
-		 */
-		return apply_filters( 'wp_theme_json_get_style_nodes', $nodes );
+		return $nodes;
 	}
 
 	/**
@@ -2863,8 +2843,10 @@ class WP_Theme_JSON_Gutenberg {
 
 		$theme_json = static::sanitize( $theme_json, $valid_block_names, $valid_element_names, $valid_variations );
 
-		$blocks_metadata = static::get_blocks_metadata();
-		$style_nodes     = static::get_style_nodes( $theme_json, $blocks_metadata );
+		$style_nodes = array_merge(
+			static::get_style_nodes( $theme_json ),
+			static::get_block_nodes( $theme_json ),
+		);
 
 		foreach ( $style_nodes as $metadata ) {
 			$input = _wp_array_get( $theme_json, $metadata['path'], array() );

--- a/lib/script-loader.php
+++ b/lib/script-loader.php
@@ -35,13 +35,6 @@ function gutenberg_enqueue_global_styles() {
 		return;
 	}
 
-	/*
-	 * If loading the CSS for each block separately, then load the theme.json CSS conditionally.
-	 * This removes the CSS from the global-styles stylesheet and adds it to the inline CSS for each block.
-	 * This filter must be registered before calling wp_get_global_stylesheet();
-	 */
-	add_filter( 'wp_theme_json_get_style_nodes', 'wp_filter_out_block_nodes' );
-
 	$stylesheet = gutenberg_get_global_stylesheet();
 	if ( empty( $stylesheet ) ) {
 		return;


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/45171
Extracted from https://github.com/WordPress/gutenberg/pull/53351

## What?

Do not compute block nodes in `get_style_nodes` as they will be discarded.

## Why?

The block nodes are discarded and are calculated via a different mechanism. By not doing unnecessary work, the code is faster.

## How to test

TBD.