### PR TITLE
Documentation - Fix outdated specification in the "Anatomy of a Block"

### DIFF
--- a/docs/getting-started/create-block/block-anatomy.md
+++ b/docs/getting-started/create-block/block-anatomy.md
@@ -33,7 +33,7 @@ The first parameter in the **registerBlockType** function is the block name, thi
 
 The second parameter to the function is the block object. See the [block registration documentation](/docs/reference-guides/block-api/block-registration.md) for full details.
 
-The last two block object properties are **edit** and **save**, these are the key parts of a block. Both properties are functions that are included via the import above.
+The two block object properties are **edit** and **save**, these are the key parts of a block. Both properties are functions that are included via the import above.
 
 The results of the edit function is what the editor will render to the editor page when the block is inserted.
 
@@ -65,7 +65,7 @@ The **title** is the title of the block shown in the Inserter and in other areas
 
 The **icon** is the icon shown in the Inserter. The icon property expects any Dashicon name as a string, see [list of available icons](https://developer.wordpress.org/resource/dashicons/). You can also provide an SVG object, but for now it's easiest to just pick a Dashicon name.
 
-The **category** specified is a string and must be one of: "common, formatting, layout, widgets, or embed". You can create your own custom category name, [see documentation for details](/docs/reference-guides/filters/block-filters.md#managing-block-categories).
+The **category** specified is a string and must be one of: "text, media, design, widgets, theme, or embed". You can create your own custom category name, [see documentation for details](/docs/reference-guides/filters/block-filters.md#managing-block-categories).
 
 ## Internationalization
 

--- a/docs/getting-started/create-block/block-anatomy.md
+++ b/docs/getting-started/create-block/block-anatomy.md
@@ -33,7 +33,7 @@ The first parameter in the **registerBlockType** function is the block name, thi
 
 The second parameter to the function is the block object. See the [block registration documentation](/docs/reference-guides/block-api/block-registration.md) for full details.
 
-The two block object properties are **edit** and **save**, these are the key parts of a block. Both properties are functions that are included via the import above.
+Two common object properties are **edit** and **save**, these are the key parts of a block. Both properties are functions that are included via the import above.
 
 The results of the edit function is what the editor will render to the editor page when the block is inserted.
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
"Anatomy of a Block" includes old categories such as "common, formatting, layout, widgets, or embed". It must be "text, media, design, widgets, theme, or embed".

I also fixed an edit omission when block.json was introduced (unnecessary 'last').

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
