### PR TITLE
Fix crash by moving editor style logic into a hook with useMemo

### DIFF
--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -77,7 +77,8 @@ function useEditorStyles() {
 			hasThemeStyleSupport:
 				select( editPostStore ).isFeatureActive( 'themeStyles' ),
 			editorSettings: select( editorStore ).getEditorSettings(),
-		} )
+		} ),
+		[]
 	);
 
 	// Compute the default styles.

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -115,10 +115,7 @@ function useEditorStyles() {
 		} );
 	}
 
-	return useMemo(
-		() => ( hasThemeStyles ? editorSettings.styles : defaultEditorStyles ),
-		[ hasThemeStyles, editorSettings.styles, defaultEditorStyles ]
-	);
+	return hasThemeStyles ? editorSettings.styles : defaultEditorStyles;
 }
 
 function Layout() {

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -81,41 +81,44 @@ function useEditorStyles() {
 	);
 
 	// Compute the default styles.
-	const { defaultEditorStyles, presetStyles } = useMemo( () => {
-		const _presetStyles =
+	return useMemo( () => {
+		const presetStyles =
 			editorSettings.styles?.filter(
 				( style ) =>
 					style.__unstableType && style.__unstableType !== 'theme'
 			) ?? [];
-		return {
-			presetStyles: _presetStyles,
-			defaultEditorStyles: [
-				...editorSettings.defaultEditorStyles,
-				..._presetStyles,
-			],
-		};
-	}, [ editorSettings.defaultEditorStyles, editorSettings.styles ] );
 
-	// Has theme styles if the theme supports them and if some styles were not preset styles (in which case they're theme styles).
-	const hasThemeStyles =
-		hasThemeStyleSupport &&
-		presetStyles.length !== ( editorSettings.styles?.length ?? 0 );
+		const defaultEditorStyles = [
+			...editorSettings.defaultEditorStyles,
+			...presetStyles,
+		];
 
-	// If theme styles are not present or displayed, ensure that
-	// base layout styles are still present in the editor.
-	if ( ! editorSettings.disableLayoutStyles && ! hasThemeStyles ) {
-		defaultEditorStyles.push( {
-			css: getLayoutStyles( {
-				style: {},
-				selector: 'body',
-				hasBlockGapSupport: false,
-				hasFallbackGapSupport: true,
-				fallbackGapValue: '0.5em',
-			} ),
-		} );
-	}
+		// Has theme styles if the theme supports them and if some styles were not preset styles (in which case they're theme styles).
+		const hasThemeStyles =
+			hasThemeStyleSupport &&
+			presetStyles.length !== ( editorSettings.styles?.length ?? 0 );
 
-	return hasThemeStyles ? editorSettings.styles : defaultEditorStyles;
+		// If theme styles are not present or displayed, ensure that
+		// base layout styles are still present in the editor.
+		if ( ! editorSettings.disableLayoutStyles && ! hasThemeStyles ) {
+			defaultEditorStyles.push( {
+				css: getLayoutStyles( {
+					style: {},
+					selector: 'body',
+					hasBlockGapSupport: false,
+					hasFallbackGapSupport: true,
+					fallbackGapValue: '0.5em',
+				} ),
+			} );
+		}
+
+		return hasThemeStyles ? editorSettings.styles : defaultEditorStyles;
+	}, [
+		editorSettings.defaultEditorStyles,
+		editorSettings.disableLayoutStyles,
+		editorSettings.styles,
+		hasThemeStyleSupport,
+	] );
 }
 
 function Layout() {

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -32,7 +32,7 @@ import {
 	InterfaceSkeleton,
 	store as interfaceStore,
 } from '@wordpress/interface';
-import { useState, useEffect, useCallback } from '@wordpress/element';
+import { useState, useEffect, useCallback, useMemo } from '@wordpress/element';
 import { store as keyboardShortcutsStore } from '@wordpress/keyboard-shortcuts';
 import { store as noticesStore } from '@wordpress/notices';
 
@@ -71,6 +71,56 @@ const interfaceLabels = {
 	footer: __( 'Editor footer' ),
 };
 
+function useEditorStyles() {
+	const { hasThemeStyleSupport, editorSettings } = useSelect(
+		( select ) => ( {
+			hasThemeStyleSupport:
+				select( editPostStore ).isFeatureActive( 'themeStyles' ),
+			editorSettings: select( editorStore ).getEditorSettings(),
+		} )
+	);
+
+	// Compute the default styles.
+	const { defaultEditorStyles, presetStyles } = useMemo( () => {
+		const _presetStyles =
+			editorSettings.styles?.filter(
+				( style ) =>
+					style.__unstableType && style.__unstableType !== 'theme'
+			) ?? [];
+		return {
+			presetStyles: _presetStyles,
+			defaultEditorStyles: [
+				...editorSettings.defaultEditorStyles,
+				..._presetStyles,
+			],
+		};
+	}, [ editorSettings.defaultEditorStyles, editorSettings.styles ] );
+
+	// Has theme styles if the theme supports them and if some styles were not preset styles (in which case they're theme styles).
+	const hasThemeStyles =
+		hasThemeStyleSupport &&
+		presetStyles.length !== ( editorSettings.styles?.length ?? 0 );
+
+	// If theme styles are not present or displayed, ensure that
+	// base layout styles are still present in the editor.
+	if ( ! editorSettings.disableLayoutStyles && ! hasThemeStyles ) {
+		defaultEditorStyles.push( {
+			css: getLayoutStyles( {
+				style: {},
+				selector: 'body',
+				hasBlockGapSupport: false,
+				hasFallbackGapSupport: true,
+				fallbackGapValue: '0.5em',
+			} ),
+		} );
+	}
+
+	return useMemo(
+		() => ( hasThemeStyles ? editorSettings.styles : defaultEditorStyles ),
+		[ hasThemeStyles, editorSettings.styles, defaultEditorStyles ]
+	);
+}
+
 function Layout() {
 	const isMobileViewport = useViewportMatch( 'medium', '<' );
 	const isHugeViewport = useViewportMatch( 'huge', '>=' );
@@ -95,45 +145,10 @@ function Layout() {
 		showBlockBreadcrumbs,
 		isTemplateMode,
 		documentLabel,
-		styles,
 	} = useSelect( ( select ) => {
 		const { getEditorSettings, getPostTypeLabel } = select( editorStore );
-		const { isFeatureActive } = select( editPostStore );
 		const editorSettings = getEditorSettings();
 		const postTypeLabel = getPostTypeLabel();
-		const hasThemeStyles = isFeatureActive( 'themeStyles' );
-
-		const themeStyles = [];
-		const presetStyles = [];
-		editorSettings.styles?.forEach( ( style ) => {
-			if ( ! style.__unstableType || style.__unstableType === 'theme' ) {
-				themeStyles.push( style );
-			} else {
-				presetStyles.push( style );
-			}
-		} );
-
-		const defaultEditorStyles = [
-			...editorSettings.defaultEditorStyles,
-			...presetStyles,
-		];
-
-		// If theme styles are not present or displayed, ensure that
-		// base layout styles are still present in the editor.
-		if (
-			! editorSettings.disableLayoutStyles &&
-			! ( hasThemeStyles && themeStyles.length )
-		) {
-			defaultEditorStyles.push( {
-				css: getLayoutStyles( {
-					style: {},
-					selector: 'body',
-					hasBlockGapSupport: false,
-					hasFallbackGapSupport: true,
-					fallbackGapValue: '0.5em',
-				} ),
-			} );
-		}
 
 		return {
 			isTemplateMode: select( editPostStore ).isEditingTemplate(),
@@ -166,12 +181,10 @@ function Layout() {
 			),
 			// translators: Default label for the Document in the Block Breadcrumb.
 			documentLabel: postTypeLabel || _x( 'Document', 'noun' ),
-			styles:
-				hasThemeStyles && themeStyles.length
-					? editorSettings.styles
-					: defaultEditorStyles,
 		};
 	}, [] );
+
+	const styles = useEditorStyles();
 
 	const openSidebarPanel = () =>
 		openGeneralSidebar(


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Follow-up to #52767 which optimizes the editor style calculation with `useMemo` to prevent possible infinite render loops.

## Why?
After installing Gutenberg 16.4 on a large multisite instance (WordPress.com), we began noticing editor crashes, with React giving the "maximum update depth exceeded". After debugging and `git bisect`, I tracked this to #52767, and reverting that PR fixes the issue.

After some experimentation, I found that the issue is prevented when we avoid creating new styles arrays on every `useSelect` call. 

From what I can tell, this crash happens in two scenarios:
1. The theme does _not_ support theme styles
2. The theme does support theme styles, but every single styles in `editorSettings.styles` matches `style.__unstableType && style.__unstableType !== 'theme'`

In either of those cases, the array with an unstable reference is returned and the editor crashes.

@ellatrix, can you verify that this makes sense and I'm not breaking anything?

## How?
I moved the styles logic to its own hook and used `useMemo` to maintain array references. Some of the logic was adjusted to make that easier (such as using array filter for the `presetStyles` array, and basing `hasThemeStyles` on whether every style is a preset or not).

## Testing Instructions
I don't know how to reproduce this outside of our environment, but I have verified the fix there. So I think this will follow the same testing steps as #52767, which is that the e2e test passes. (Which it is!)

### Testing Instructions for Keyboard


## Screenshots or screencast <!-- if applicable -->
