### PR TITLE
Fix a bug that caused the display ratio of images to be corrupted starting from 6.3.( fix #53555 )

### DIFF
--- a/packages/block-library/src/image/deprecated.js
+++ b/packages/block-library/src/image/deprecated.js
@@ -310,6 +310,13 @@ const v4 = {
 	supports: {
 		anchor: true,
 	},
+	migrate( { width, height, ...attributes } ) {
+		return {
+			...attributes,
+			width: `${ width }px`,
+			height: `${ height }px`,
+		};
+	},
 	save( { attributes } ) {
 		const {
 			url,
@@ -479,6 +486,13 @@ const v5 = {
 				margin: '0 0 1em 0',
 			},
 		},
+	},
+	migrate( { width, height, ...attributes } ) {
+		return {
+			...attributes,
+			width: `${ width }px`,
+			height: `${ height }px`,
+		};
 	},
 	save( { attributes } ) {
 		const {
@@ -653,6 +667,13 @@ const v6 = {
 				width: true,
 			},
 		},
+	},
+	migrate( { width, height, ...attributes } ) {
+		return {
+			...attributes,
+			width: `${ width }px`,
+			height: `${ height }px`,
+		};
 	},
 	save( { attributes } ) {
 		const {

--- a/packages/block-library/src/image/save.js
+++ b/packages/block-library/src/image/save.js
@@ -49,6 +49,22 @@ export default function save( { attributes } ) {
 		[ `wp-image-${ id }` ]: !! id,
 	} );
 
+	const imgStyle = { aspectRatio, objectFit: scale };
+
+	// Branch by whether width and height both have size.
+	// If the image block is very old and has not been migrated to a string type, the size will be int.
+	// Note that only width may be "auto".
+	if ( ! aspectRatio && height && width && 'auto' !== width ) {
+		const w = parseInt( width );
+		const h = parseInt( height );
+		if ( ! isNaN( w ) && ! isNaN( h ) ) {
+			imgStyle.aspectRatio = `${ w }/${ h }`;
+		}
+	} else {
+		if ( 'string' === typeof width ) imgStyle.width = width;
+		if ( 'string' === typeof height ) imgStyle.height = height;
+	}
+
 	const image = (
 		<img
 			src={ url }
@@ -56,10 +72,7 @@ export default function save( { attributes } ) {
 			className={ imageClasses || undefined }
 			style={ {
 				...borderProps.style,
-				aspectRatio,
-				objectFit: scale,
-				width,
-				height,
+				...imgStyle,
 			} }
 			title={ title }
 		/>


### PR DESCRIPTION
## What?
Since 6.3, there is a bug that the display ratio is broken when the size is specified in the image block. (#53555)

This PR fixes the above problem.


## How?
If both `width` and `height` have size specifications, they are converted to `aspect-ratio` rather than being output as they are in the `style` attribute.

## Testing Instructions
- Check with v6.3
  1. Specify a size for the image block.
  2. Confirm with phone size, etc.
- Check blocks placed before v.6.2
  1. Place image block in v.6.2 and specify 75%, etc.
  2. Copy and paste that block and make sure it is converted to the new specifications.
  3. Confirm with phone size, etc.

As an example, I share one image block code I installed in 6.2.

```
<!-- wp:image {"width":600,"height":450,"sizeSlug":"large"} -->
<figure class="wp-block-image size-large is-resized"><img src="https://s.w.org/images/core/5.3/MtBlanc1.jpg" alt="" width="600" height="450"/></figure>
<!-- /wp:image -->
```

## Note

There was already a PR for 53274 that fixes another problem, which was already different from the 6.3 situation.

The 53274 changed the `width`, `height` to a `string` type, but blocks placed before 6.2 were not migrated correctly to a `string` type, so we are fixing those as well.

(In `deprecated.js`, `migrate` process　was also added to `v6`~`v4`)
