### PR TITLE
test: Reduce test output noise

### DIFF
--- a/packages/block-editor/src/components/block-list/test/block-invalid-warning.native.js
+++ b/packages/block-editor/src/components/block-list/test/block-invalid-warning.native.js
@@ -11,6 +11,13 @@ import {
 
 setupCoreBlocks();
 
+beforeEach( () => {
+	// Intentionally suppress the expected console errors and warnings to reduce
+	// noise in the test output.
+	jest.spyOn( console, 'error' ).mockImplementation( () => {} );
+	jest.spyOn( console, 'warn' ).mockImplementation( () => {} );
+} );
+
 describe( 'Block invalid warning', () => {
 	it( 'shows invalid placeholder', async () => {
 		// Arrange

--- a/packages/block-library/src/embed/test/index.native.js
+++ b/packages/block-library/src/embed/test/index.native.js
@@ -200,6 +200,10 @@ beforeEach( () => {
 		MOCK_EMBED_PHOTO_SUCCESS_RESPONSE,
 		MOCK_BAD_EMBED_PROVIDER_RESPONSE,
 	] );
+
+	// Intentionally suppress the expected console logs to reduce noise in the
+	// test output.
+	jest.spyOn( console, 'log' ).mockImplementation( () => {} );
 } );
 
 afterAll( () => {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Reduce native test output noise.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The errors, warnings, and logs from these tests are expected for each
test case. However, their presence creates noise and reduces the
comprehensibility of the test output. Intentionally suppressing them
simplifies the test output, making it easier to identify new, unexpected
console output.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Intentionally suppress the console output for expected error, warnings, and
logs. This expected output is already monitored via assertions from
`@wordpress/jest-import`.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
Note modified tests no longer produce console errors, warnings, or logs.

<details><summary>Example suppressed Block Invalid Warning test output</summary>

```
    console.warn
      Encountered unexpected attribute `styless`.

      22 |              // of Webpack env substitution + UglifyJS dead code elimination.
      23 |              if ( process.env.NODE_ENV === 'test' ) {
    > 24 |                      log = ( ...args ) => logger( require( 'util' ).format( ...args ) );
         |                                           ^
      25 |              }
      26 |
      27 |              return log;

      at node_modules/jest-mock/build/index.js:709:23
      at logger (packages/blocks/src/api/validation/logger.js:24:25)
      at apply (packages/blocks/src/api/parser/index.js:283:53)
          at Array.forEach (<anonymous>)
      at forEach (packages/blocks/src/api/parser/index.js:283:20)
      at parseRawBlock (packages/blocks/src/api/parser/index.js:312:17)
          at Array.reduce (<anonymous>)
      at reduce (packages/blocks/src/api/parser/index.js:311:33)
      at Editor.render (packages/edit-post/src/editor.native.js:168:26)
      at finishClassComponent (node_modules/react-test-renderer/cjs/react-test-renderer.development.js:9624:31)
      at updateClassComponent (node_modules/react-test-renderer/cjs/react-test-renderer.development.js:9573:24)
      at beginWork (node_modules/react-test-renderer/cjs/react-test-renderer.development.js:11336:16)
      at performUnitOfWork (node_modules/react-test-renderer/cjs/react-test-renderer.development.js:15811:12)
      at workLoopSync (node_modules/react-test-renderer/cjs/react-test-renderer.development.js:15745:5)
      at renderRootSync (node_modules/react-test-renderer/cjs/react-test-renderer.development.js:15717:7)
      at performSyncWorkOnRoot (node_modules/react-test-renderer/cjs/react-test-renderer.development.js:15422:20)
      at flushSyncCallbacks (node_modules/react-test-renderer/cjs/react-test-renderer.development.js:2597:22)
      at flushActQueue (node_modules/react/cjs/react.development.js:2667:24)
      at Object.act (node_modules/react/cjs/react.development.js:2521:11)
      at act (node_modules/@testing-library/react-native/src/render-act.ts:13:16)
      at render (node_modules/@testing-library/react-native/src/render.tsx:48:33)
      at test/native/integration-test-helpers/initialize-editor.js:45:24
      at fn (test/native/integration-test-helpers/wait-for-store-resolvers.js:25:18)
      at asyncGeneratorStep (node_modules/@babel/runtime/helpers/asyncToGenerator.js:3:24)
      at _next (node_modules/@babel/runtime/helpers/asyncToGenerator.js:22:9)
      at node_modules/@babel/runtime/helpers/asyncToGenerator.js:27:7
      at node_modules/@babel/runtime/helpers/asyncToGenerator.js:19:12
      at fn (test/native/integration-test-helpers/with-fake-timers.js:37:23)
      at asyncGeneratorStep (node_modules/@babel/runtime/helpers/asyncToGenerator.js:3:24)
      at _next (node_modules/@babel/runtime/helpers/asyncToGenerator.js:22:9)
      at node_modules/@babel/runtime/helpers/asyncToGenerator.js:27:7
      at node_modules/@babel/runtime/helpers/asyncToGenerator.js:19:12
      at apply (test/native/integration-test-helpers/with-fake-timers.js:50:2)
      at apply (test/native/integration-test-helpers/with-fake-timers.js:8:37)
      at test/native/integration-test-helpers/wait-for-store-resolvers.js:24:23
      at asyncGeneratorStep (node_modules/@babel/runtime/helpers/asyncToGenerator.js:3:24)
      at _next (node_modules/@babel/runtime/helpers/asyncToGenerator.js:22:9)
      at node_modules/@babel/runtime/helpers/asyncToGenerator.js:27:7
      at node_modules/@babel/runtime/helpers/asyncToGenerator.js:19:12
      at apply (test/native/integration-test-helpers/wait-for-store-resolvers.js:39:2)
      at apply (test/native/integration-test-helpers/wait-for-store-resolvers.js:23:44)
      at test/native/integration-test-helpers/initialize-editor.js:35:30
      at asyncGeneratorStep (node_modules/@babel/runtime/helpers/asyncToGenerator.js:3:24)
      at _next (node_modules/@babel/runtime/helpers/asyncToGenerator.js:22:9)
      at node_modules/@babel/runtime/helpers/asyncToGenerator.js:27:7
      at node_modules/@babel/runtime/helpers/asyncToGenerator.js:19:12
      at apply (test/native/integration-test-helpers/initialize-editor.js:65:2)
      at apply (test/native/integration-test-helpers/initialize-editor.js:30:39)
      at Object.<anonymous> (packages/block-editor/src/components/block-list/test/block-invalid-warning.native.js:17:40)
      at asyncGeneratorStep (node_modules/@babel/runtime/helpers/asyncToGenerator.js:3:24)
      at _next (node_modules/@babel/runtime/helpers/asyncToGenerator.js:22:9)
      at node_modules/@babel/runtime/helpers/asyncToGenerator.js:27:7
      at Object.<anonymous> (node_modules/@babel/runtime/helpers/asyncToGenerator.js:19:12)

    console.error
      Block validation failed for `core/spacer` ({
        name: 'core/spacer',
        icon: {
          src: {
            '$$typeof': Symbol(react.element),
            type: <ref *1> [Function: SVG] {
              [length]: 1,
              [name]: 'SVG',
              [arguments]: null,
              [caller]: null,
              [prototype]: { [constructor]: [Circular *1] }
            },
            key: null,
            ref: null,
            props: {
              viewBox: '0 0 24 24',
              xmlns: 'http://www.w3.org/2000/svg',
              children: {
                '$$typeof': Symbol(react.element),
                type: [Function],
                key: null,
                ref: null,
                props: [Object],
                _owner: null,
                _store: [Object],
                [_self]: null,
                [_source]: null
              }
            },
            _owner: null,
            _store: { [validated]: false },
            [_self]: null,
            [_source]: null
          }
        },
        keywords: [ [length]: 0 ],
        attributes: {
          height: { type: 'string', default: '100px' },
          width: { type: 'string' },
          anchor: {
            type: 'string',
            source: 'attribute',
            attribute: 'id',
            selector: '*'
          },
          className: { type: 'string' },
          style: { type: 'object' }
        },
        providesContext: {},
        usesContext: [ 'orientation', [length]: 1 ],
        selectors: {},
        supports: {
          anchor: true,
          spacing: {
            margin: [ 'top', 'bottom', [length]: 2 ],
            __experimentalDefaultControls: { margin: true }
          }
        },
        styles: [ [length]: 0 ],
        variations: [ [length]: 0 ],
        save: <ref *2> [Function: save] {
          [length]: 1,
          [name]: 'save',
          [arguments]: null,
          [caller]: null,
          [prototype]: { [constructor]: [Circular *2] }
        },
        apiVersion: 3,
        title: 'Spacer',
        category: 'design',
        description: 'Add white space between blocks and customize its height.',
        edit: <ref *3> [Function (anonymous)] {
          [length]: 1,
          [name]: '',
          [arguments]: null,
          [caller]: null,
          [prototype]: { [constructor]: [Circular *3] },
          displayName: 'WithPreferredColorScheme(Spacer)'
        },
        deprecated: [
          {
            attributes: {
              height: { type: 'number', default: 100 },
              width: { type: 'number' },
              className: { type: 'string' }
            },
            migrate: <ref *4> [Function: migrate] {
              [length]: 1,
              [name]: 'migrate',
              [arguments]: null,
              [caller]: null,
              [prototype]: { [constructor]: [Circular *4] }
            },
            save: <ref *5> [Function: save] {
              [length]: 1,
              [name]: 'save',
              [arguments]: null,
              [caller]: null,
              [prototype]: { [constructor]: [Circular *5] }
            }
          },
          [length]: 1
        ],
        getEditWrapperProps: <ref *6> [Function (anonymous)] {
          [length]: 1,
          [name]: '',
          [arguments]: null,
          [caller]: null,
          [prototype]: { [constructor]: [Circular *6] }
        }
      }).

      Content generated by `save` function:

      <div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>

      Content retrieved from post body:

      <div styless="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
```

</details>

<details><summary>Example suppressed Embed test output</summary>

```
    console.log
      Processed HTML piece:

       <p>https://www.youtube.com/watch?v=lXMskKTw3Bc</p>

      at console.<anonymous> (node_modules/jest-mock/build/index.js:709:23)
          at Array.map (<anonymous>)

    console.log
      Processed HTML piece:

       <p>https://www.youtube.com/watch?v=lXMskKTw3Bc</p>

      at console.<anonymous> (node_modules/jest-mock/build/index.js:709:23)
          at Array.map (<anonymous>)
```

</details>

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
n/a

## Screenshots or screencast <!-- if applicable -->
n/a
