### PR TITLE
fix: Dynamic bottom sheet height

### DIFF
--- a/packages/editor/src/components/editor-help/index.native.js
+++ b/packages/editor/src/components/editor-help/index.native.js
@@ -102,7 +102,7 @@ function EditorHelpTopics( { close, isVisible, onClose, showSupport } ) {
 			contentStyle={ styles.contentContainer }
 			testID="editor-help-modal"
 		>
-			<SafeAreaView>
+			<SafeAreaView style={ styles.safeAreaContainer }>
 				<BottomSheet.NavigationContainer
 					animate
 					main

--- a/packages/editor/src/components/editor-help/style.scss
+++ b/packages/editor/src/components/editor-help/style.scss
@@ -19,7 +19,12 @@
 	color: $dark-primary;
 }
 
+.safeAreaContainer {
+	flex: 1;
+}
+
 .navigationContainer {
+	flex: 1;
 	overflow: hidden;
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Fix the dynamic height when opening and closing navigation screens within the
bottom sheet.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Relates to #53591. The incorrect height obscured content.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Stretch the content containers by applying `flex: 1`. Stretching this content
with flex appears to be necessary after upgrading React Native or refactoring
the bottom sheet height animation.

Refactor: 0411df13e1e8b832d8011e4fafe34436cd8fc773

Upgrade: c2957aa08de7e574d030f167ed8c5731c89e37af

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Open the editor. 
1. Tap the three-dot button in the top-right corner.
1. Navigate to Help & Support.
1. Navigate to a help topic.
1. Navigate out of Help & Support, closing the bottom sheet. 
1. Repeat steps 2-4.
1. Verify the content is not obscured.
1. Navigate to other bottom sheets verifying content is not obscured, e.g. block
   settings.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
n/a

## Screenshots or screencast <!-- if applicable -->
n/a
