### PR TITLE
Fix: Title is not copied correctly when duplicating navigation

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/use-navigation-menu-handlers.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/use-navigation-menu-handlers.js
@@ -135,7 +135,8 @@ function useDuplicateNavigationMenu() {
 		useDispatch( noticesStore );
 
 	const handleDuplicate = async ( navigationMenu ) => {
-		const menuTitle = navigationMenu?.title || navigationMenu?.slug;
+		const menuTitle =
+			navigationMenu?.title?.rendered || navigationMenu?.slug;
 
 		try {
 			const savedRecord = await saveEntityRecord(


### PR DESCRIPTION
Follow-up on #52807

## What?

This PR fixes a problem with the title being converted to the unintended string `[object object]` when the navigation menu is duplicated.

![navigation_duplicate](https://github.com/WordPress/gutenberg/assets/54422211/a23558e4-c94f-45b5-9074-3abd51405f4f)

## Why?

The navigation object passed to the copy handler is obtained via `useEntityRecord()`.

https://github.com/WordPress/gutenberg/blob/4f4f8e5092a4d973eade78528d3fe1040a1de7c0/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/index.js#L29-L33

I don't fully understand, but the `title `property should be an object with `raw` and `rendered` properties, not a string.

## How?
Reverted to the previous implementation of checking the `rendered` property.

## Testing Instructions

- Copy navigation.
- The title of the copied navigation should be `{Navigation Name} (copy)`.