### PR TITLE
Use template.blocks in BlockPreview if it exists

### DIFF
--- a/packages/edit-site/src/components/sidebar-edit-mode/page-panels/edit-template.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/page-panels/edit-template.js
@@ -16,7 +16,7 @@ import { parse } from '@wordpress/blocks';
 import { store as editSiteStore } from '../../../store';
 
 export default function EditTemplate() {
-	const { context, hasResolved, title, content } = useSelect( ( select ) => {
+	const { context, hasResolved, template } = useSelect( ( select ) => {
 		const { getEditedPostContext, getEditedPostType, getEditedPostId } =
 			select( editSiteStore );
 		const { getEditedEntityRecord, hasFinishedResolution } =
@@ -27,15 +27,13 @@ export default function EditTemplate() {
 			getEditedPostType(),
 			getEditedPostId(),
 		];
-		const template = getEditedEntityRecord( ...queryArgs );
 		return {
 			context: _context,
 			hasResolved: hasFinishedResolution(
 				'getEditedEntityRecord',
 				queryArgs
 			),
-			title: template?.title,
-			content: template?.content,
+			template: getEditedEntityRecord( ...queryArgs ),
 		};
 	}, [] );
 
@@ -48,8 +46,11 @@ export default function EditTemplate() {
 
 	const blocks = useMemo(
 		() =>
-			content && typeof content !== 'function' ? parse( content ) : [],
-		[ content ]
+			template.blocks ??
+			( template.content && typeof template.content !== 'function'
+				? parse( template.content )
+				: [] ),
+		[ template.blocks, template.content ]
 	);
 
 	if ( ! hasResolved ) {
@@ -58,7 +59,7 @@ export default function EditTemplate() {
 
 	return (
 		<VStack>
-			<div>{ decodeEntities( title ) }</div>
+			<div>{ decodeEntities( template.title ) }</div>
 			<div className="edit-site-page-panels__edit-template-preview">
 				<BlockContextProvider value={ blockContext }>
 					<BlockPreview viewportWidth={ 1024 } blocks={ blocks } />


### PR DESCRIPTION
Follows https://github.com/WordPress/gutenberg/pull/53550. Does what @youknowriad suggests in this comment https://github.com/WordPress/gutenberg/pull/53550#discussion_r1291059686.

To test manually:

1. Go to Appearance → Editor → Pages and select a page to edit.
2. Open the settings sidebar (right sidebar). A preview of the template should appear in the _Template_ panel.
