### PR TITLE
Skip migration logs in the Patterns screen

### DIFF
--- a/packages/edit-site/src/components/page-patterns/use-patterns.js
+++ b/packages/edit-site/src/components/page-patterns/use-patterns.js
@@ -28,7 +28,9 @@ const createTemplatePartId = ( theme, slug ) =>
 	theme && slug ? theme + '//' + slug : null;
 
 const templatePartToPattern = ( templatePart ) => ( {
-	blocks: parse( templatePart.content.raw ),
+	blocks: parse( templatePart.content.raw, {
+		__unstableSkipMigrationLogs: true,
+	} ),
 	categories: [ templatePart.area ],
 	description: templatePart.description || '',
 	isCustom: templatePart.source === 'custom',
@@ -107,7 +109,9 @@ const selectThemePatterns = ( select, { categoryId, search = '' } = {} ) => {
 			...pattern,
 			keywords: pattern.keywords || [],
 			type: 'pattern',
-			blocks: parse( pattern.content ),
+			blocks: parse( pattern.content, {
+				__unstableSkipMigrationLogs: true,
+			} ),
 		} ) );
 
 	if ( categoryId ) {
@@ -126,7 +130,9 @@ const selectThemePatterns = ( select, { categoryId, search = '' } = {} ) => {
 };
 
 const reusableBlockToPattern = ( reusableBlock ) => ( {
-	blocks: parse( reusableBlock.content.raw ),
+	blocks: parse( reusableBlock.content.raw, {
+		__unstableSkipMigrationLogs: true,
+	} ),
 	categories: reusableBlock.wp_pattern,
 	id: reusableBlock.id,
 	name: reusableBlock.slug,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
A small fix to skip migration logs in the Patterns screen.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
It's annoying to developers when we're parsing all the available patterns and showing migration logs for each of them.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Use the unstable `__unstableSkipMigrationLogs` argument in the `parse` function. It's also used in where we load patterns in the inserter.

https://github.com/WordPress/gutenberg/blob/26cf1f8e4063a4db2498d3e9af96767a8562ce47/packages/block-editor/src/store/selectors.js#L2326

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Open browser's devtools
2. Enable a theme with legacy blocks like twentytwentytwo
3. Go to Site Editor -> Patterns, and switch between different categories in the sidebar.
4. Notice that the devtools console isn't displaying migration logs.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
Same as above.

## Screenshots or screencast <!-- if applicable -->
N/A