### PR TITLE
ESLint Plugin: Bring JSDoc plugin to the latest version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3312,17 +3312,17 @@
 			"integrity": "sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA=="
 		},
 		"node_modules/@es-joy/jsdoccomment": {
-			"version": "0.36.1",
-			"resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.36.1.tgz",
-			"integrity": "sha512-922xqFsTpHs6D0BUiG4toiyPOMc8/jafnWKxz1KWgS4XzKPy2qXf1Pe6UFuNSCQqt6tOuhAWXBNuuyUhJmw9Vg==",
+			"version": "0.40.1",
+			"resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.40.1.tgz",
+			"integrity": "sha512-YORCdZSusAlBrFpZ77pJjc5r1bQs5caPWtAu+WWmiSo+8XaUzseapVrfAtiRFbQWnrBxxLLEwF6f6ZG/UgCQCg==",
 			"dev": true,
 			"dependencies": {
-				"comment-parser": "1.3.1",
-				"esquery": "^1.4.0",
-				"jsdoc-type-pratt-parser": "~3.1.0"
+				"comment-parser": "1.4.0",
+				"esquery": "^1.5.0",
+				"jsdoc-type-pratt-parser": "~4.0.0"
 			},
 			"engines": {
-				"node": "^14 || ^16 || ^17 || ^18 || ^19"
+				"node": ">=16"
 			}
 		},
 		"node_modules/@esbuild/android-arm": {
@@ -22316,6 +22316,15 @@
 				"node": ">= 6"
 			}
 		},
+		"node_modules/are-docs-informative": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/are-docs-informative/-/are-docs-informative-0.0.2.tgz",
+			"integrity": "sha512-ixiS0nLNNG5jNQzgZJNoUpBKdo9yTYZMGJ+QgT2jmjR7G7+QHRCc4v6LQ3NgE7EBJq+o0ams3waJwkrlBom8Ig==",
+			"dev": true,
+			"engines": {
+				"node": ">=14"
+			}
+		},
 		"node_modules/are-we-there-yet": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-3.0.1.tgz",
@@ -23873,6 +23882,18 @@
 			"integrity": "sha512-571s0T7nZWK6vB67HI5dyUF7wXiNcfaPPPTl6zYCNApANjIvYJTg7hlud/+cJpdAhS7dVzqMLmfhfHR3rAcOjQ==",
 			"dev": true
 		},
+		"node_modules/builtin-modules": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.3.0.tgz",
+			"integrity": "sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==",
+			"dev": true,
+			"engines": {
+				"node": ">=6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/builtin-status-codes": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
@@ -24993,9 +25014,9 @@
 			}
 		},
 		"node_modules/comment-parser": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.3.1.tgz",
-			"integrity": "sha512-B52sN2VNghyq5ofvUsqZjmk6YkihBX5vMSChmSK9v4ShjKf3Vk5Xcmgpw4o+iIgtrnM/u5FiMpz9VKb8lpBveA==",
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.4.0.tgz",
+			"integrity": "sha512-QLyTNiZ2KDOibvFPlZ6ZngVsZ/0gYnE6uTXi5aoDg8ed3AkJAz4sEje3Y8a29hQ1s6A99MZXe47fLAXQ1rTqaw==",
 			"dev": true,
 			"engines": {
 				"node": ">= 12.0.0"
@@ -28663,21 +28684,23 @@
 			}
 		},
 		"node_modules/eslint-plugin-jsdoc": {
-			"version": "39.6.9",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-39.6.9.tgz",
-			"integrity": "sha512-GrESRfjT1jOaK1LC2DldMuh+Ajmex9OnRIVSKMXJ1t7lNDB+J2MA11afLPXfkTKWJpplxZohjo8prT8s5LOPgQ==",
+			"version": "46.4.6",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-46.4.6.tgz",
+			"integrity": "sha512-z4SWYnJfOqftZI+b3RM9AtWL1vF/sLWE/LlO9yOKDof9yN2+n3zOdOJTGX/pRE/xnPsooOLG2Rq6e4d+XW3lNw==",
 			"dev": true,
 			"dependencies": {
-				"@es-joy/jsdoccomment": "~0.36.1",
-				"comment-parser": "1.3.1",
+				"@es-joy/jsdoccomment": "~0.40.1",
+				"are-docs-informative": "^0.0.2",
+				"comment-parser": "1.4.0",
 				"debug": "^4.3.4",
 				"escape-string-regexp": "^4.0.0",
-				"esquery": "^1.4.0",
-				"semver": "^7.3.8",
+				"esquery": "^1.5.0",
+				"is-builtin-module": "^3.2.1",
+				"semver": "^7.5.4",
 				"spdx-expression-parse": "^3.0.1"
 			},
 			"engines": {
-				"node": "^14 || ^16 || ^17 || ^18 || ^19"
+				"node": ">=16"
 			},
 			"peerDependencies": {
 				"eslint": "^7.0.0 || ^8.0.0"
@@ -29255,9 +29278,9 @@
 			}
 		},
 		"node_modules/esquery": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz",
-			"integrity": "sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==",
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.5.0.tgz",
+			"integrity": "sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==",
 			"dev": true,
 			"dependencies": {
 				"estraverse": "^5.1.0"
@@ -33087,6 +33110,21 @@
 			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
 			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
 		},
+		"node_modules/is-builtin-module": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-3.2.1.tgz",
+			"integrity": "sha512-BSLE3HnV2syZ0FK0iMA/yUGplUeMmNz4AW5fnTunbCIqZi4vG3WjJT9FHMy5D69xmAYBHXQhJdALdpwVxV501A==",
+			"dev": true,
+			"dependencies": {
+				"builtin-modules": "^3.3.0"
+			},
+			"engines": {
+				"node": ">=6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/is-callable": {
 			"version": "1.2.7",
 			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
@@ -35251,9 +35289,9 @@
 			}
 		},
 		"node_modules/jsdoc-type-pratt-parser": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-3.1.0.tgz",
-			"integrity": "sha512-MgtD0ZiCDk9B+eI73BextfRrVQl0oyzRG8B2BjORts6jbunj4ScKPcyXGTbB6eXL4y9TzxCm6hyeLq/2ASzNdw==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-4.0.0.tgz",
+			"integrity": "sha512-YtOli5Cmzy3q4dP26GraSOeAhqecewG04hoO8DY56CH4KJ9Fvv5qKWUCCo3HZob7esJQHCv6/+bnTy72xZZaVQ==",
 			"dev": true,
 			"engines": {
 				"node": ">=12.0.0"
@@ -55521,7 +55559,7 @@
 				"eslint-config-prettier": "^8.3.0",
 				"eslint-plugin-import": "^2.25.2",
 				"eslint-plugin-jest": "^27.2.1",
-				"eslint-plugin-jsdoc": "^39.6.9",
+				"eslint-plugin-jsdoc": "^46.4.6",
 				"eslint-plugin-jsx-a11y": "^6.5.1",
 				"eslint-plugin-prettier": "^3.3.0",
 				"eslint-plugin-react": "^7.27.0",
@@ -58648,14 +58686,14 @@
 			"integrity": "sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA=="
 		},
 		"@es-joy/jsdoccomment": {
-			"version": "0.36.1",
-			"resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.36.1.tgz",
-			"integrity": "sha512-922xqFsTpHs6D0BUiG4toiyPOMc8/jafnWKxz1KWgS4XzKPy2qXf1Pe6UFuNSCQqt6tOuhAWXBNuuyUhJmw9Vg==",
+			"version": "0.40.1",
+			"resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.40.1.tgz",
+			"integrity": "sha512-YORCdZSusAlBrFpZ77pJjc5r1bQs5caPWtAu+WWmiSo+8XaUzseapVrfAtiRFbQWnrBxxLLEwF6f6ZG/UgCQCg==",
 			"dev": true,
 			"requires": {
-				"comment-parser": "1.3.1",
-				"esquery": "^1.4.0",
-				"jsdoc-type-pratt-parser": "~3.1.0"
+				"comment-parser": "1.4.0",
+				"esquery": "^1.5.0",
+				"jsdoc-type-pratt-parser": "~4.0.0"
 			}
 		},
 		"@esbuild/android-arm": {
@@ -67951,7 +67989,7 @@
 				"eslint-config-prettier": "^8.3.0",
 				"eslint-plugin-import": "^2.25.2",
 				"eslint-plugin-jest": "^27.2.1",
-				"eslint-plugin-jsdoc": "^39.6.9",
+				"eslint-plugin-jsdoc": "^46.4.6",
 				"eslint-plugin-jsx-a11y": "^6.5.1",
 				"eslint-plugin-prettier": "^3.3.0",
 				"eslint-plugin-react": "^7.27.0",
@@ -75462,6 +75500,12 @@
 				}
 			}
 		},
+		"are-docs-informative": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/are-docs-informative/-/are-docs-informative-0.0.2.tgz",
+			"integrity": "sha512-ixiS0nLNNG5jNQzgZJNoUpBKdo9yTYZMGJ+QgT2jmjR7G7+QHRCc4v6LQ3NgE7EBJq+o0ams3waJwkrlBom8Ig==",
+			"dev": true
+		},
 		"are-we-there-yet": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-3.0.1.tgz",
@@ -76698,6 +76742,12 @@
 			"integrity": "sha512-571s0T7nZWK6vB67HI5dyUF7wXiNcfaPPPTl6zYCNApANjIvYJTg7hlud/+cJpdAhS7dVzqMLmfhfHR3rAcOjQ==",
 			"dev": true
 		},
+		"builtin-modules": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.3.0.tgz",
+			"integrity": "sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==",
+			"dev": true
+		},
 		"builtin-status-codes": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
@@ -77578,9 +77628,9 @@
 			"dev": true
 		},
 		"comment-parser": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.3.1.tgz",
-			"integrity": "sha512-B52sN2VNghyq5ofvUsqZjmk6YkihBX5vMSChmSK9v4ShjKf3Vk5Xcmgpw4o+iIgtrnM/u5FiMpz9VKb8lpBveA==",
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.4.0.tgz",
+			"integrity": "sha512-QLyTNiZ2KDOibvFPlZ6ZngVsZ/0gYnE6uTXi5aoDg8ed3AkJAz4sEje3Y8a29hQ1s6A99MZXe47fLAXQ1rTqaw==",
 			"dev": true
 		},
 		"common-path-prefix": {
@@ -80591,17 +80641,19 @@
 			}
 		},
 		"eslint-plugin-jsdoc": {
-			"version": "39.6.9",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-39.6.9.tgz",
-			"integrity": "sha512-GrESRfjT1jOaK1LC2DldMuh+Ajmex9OnRIVSKMXJ1t7lNDB+J2MA11afLPXfkTKWJpplxZohjo8prT8s5LOPgQ==",
+			"version": "46.4.6",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-46.4.6.tgz",
+			"integrity": "sha512-z4SWYnJfOqftZI+b3RM9AtWL1vF/sLWE/LlO9yOKDof9yN2+n3zOdOJTGX/pRE/xnPsooOLG2Rq6e4d+XW3lNw==",
 			"dev": true,
 			"requires": {
-				"@es-joy/jsdoccomment": "~0.36.1",
-				"comment-parser": "1.3.1",
+				"@es-joy/jsdoccomment": "~0.40.1",
+				"are-docs-informative": "^0.0.2",
+				"comment-parser": "1.4.0",
 				"debug": "^4.3.4",
 				"escape-string-regexp": "^4.0.0",
-				"esquery": "^1.4.0",
-				"semver": "^7.3.8",
+				"esquery": "^1.5.0",
+				"is-builtin-module": "^3.2.1",
+				"semver": "^7.5.4",
 				"spdx-expression-parse": "^3.0.1"
 			},
 			"dependencies": {
@@ -80830,9 +80882,9 @@
 			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
 		},
 		"esquery": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz",
-			"integrity": "sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==",
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.5.0.tgz",
+			"integrity": "sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==",
 			"dev": true,
 			"requires": {
 				"estraverse": "^5.1.0"
@@ -83797,6 +83849,15 @@
 			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
 			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
 		},
+		"is-builtin-module": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-3.2.1.tgz",
+			"integrity": "sha512-BSLE3HnV2syZ0FK0iMA/yUGplUeMmNz4AW5fnTunbCIqZi4vG3WjJT9FHMy5D69xmAYBHXQhJdALdpwVxV501A==",
+			"dev": true,
+			"requires": {
+				"builtin-modules": "^3.3.0"
+			}
+		},
 		"is-callable": {
 			"version": "1.2.7",
 			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
@@ -85408,9 +85469,9 @@
 			}
 		},
 		"jsdoc-type-pratt-parser": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-3.1.0.tgz",
-			"integrity": "sha512-MgtD0ZiCDk9B+eI73BextfRrVQl0oyzRG8B2BjORts6jbunj4ScKPcyXGTbB6eXL4y9TzxCm6hyeLq/2ASzNdw==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-4.0.0.tgz",
+			"integrity": "sha512-YtOli5Cmzy3q4dP26GraSOeAhqecewG04hoO8DY56CH4KJ9Fvv5qKWUCCo3HZob7esJQHCv6/+bnTy72xZZaVQ==",
 			"dev": true
 		},
 		"jsdom": {

--- a/packages/block-editor/src/components/block-preview/index.js
+++ b/packages/block-editor/src/components/block-preview/index.js
@@ -106,7 +106,6 @@ export default memo( BlockPreview );
  * @param {Object}    options.props  Optional. Props to pass to the element. Must contain
  *                                   the ref if one is defined.
  * @param {Object}    options.layout Layout settings to be used in the preview.
- *
  */
 export function useBlockPreview( { blocks, props = {}, layout } ) {
 	const originalSettings = useSelect(

--- a/packages/block-editor/src/components/global-styles/use-global-styles-output.js
+++ b/packages/block-editor/src/components/global-styles/use-global-styles-output.js
@@ -198,7 +198,6 @@ function flattenTree( input = {}, prefix, token ) {
  *
  * @param {string} styleVariationSelector The style variation selector.
  * @return {string} Combined selector string.
- *
  */
 function concatFeatureVariationSelectorString(
 	featureSelector,

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -1819,7 +1819,6 @@ export function __unstableSetTemporarilyEditingAsBlocks(
  *                                                                                                   the report url for the media item. It accepts the `InserterMediaItem` as an argument.
  * @property {boolean}                                                [isExternalResource]           If the media category is an external resource, this should be set to true.
  *                                                                                                   This is used to avoid making a request to the external resource when the user
- *
  */
 export const registerInserterMediaCategory =
 	( category ) =>

--- a/packages/block-library/src/index.native.js
+++ b/packages/block-library/src/index.native.js
@@ -122,7 +122,6 @@ export const coreBlocks = [
  * Function to register a block variations e.g. social icons different types.
  *
  * @param {Object} block The block which variations will be registered.
- *
  */
 const registerBlockVariations = ( block ) => {
 	const { metadata, settings, name } = block;

--- a/packages/block-library/src/navigation-link/update-attributes.js
+++ b/packages/block-library/src/navigation-link/update-attributes.js
@@ -27,7 +27,6 @@ import { safeDecodeURI } from '@wordpress/url';
  * @param {Object}                          updatedValue    New block attributes to update.
  * @param {Function}                        setAttributes   Block attribute update function.
  * @param {WPNavigationLinkBlockAttributes} blockAttributes Current block attributes.
- *
  */
 
 export const updateAttributes = (

--- a/packages/compose/src/hooks/use-resize-observer/index.native.js
+++ b/packages/compose/src/hooks/use-resize-observer/index.native.js
@@ -24,7 +24,6 @@ import { useState, useCallback } from '@wordpress/element';
  * 	);
  * };
  * ```
- *
  */
 const useResizeObserver = () => {
 	const [ measurements, setMeasurements ] = useState( null );

--- a/packages/data/src/plugins/persistence/index.js
+++ b/packages/data/src/plugins/persistence/index.js
@@ -21,7 +21,6 @@ import { combineReducers } from '../../';
  *                                at least implement `getItem` and `setItem` of
  *                                the Web Storage API.
  * @property {string}  storageKey Key on which to set in persistent storage.
- *
  */
 
 /**

--- a/packages/e2e-test-utils/src/set-option.js
+++ b/packages/e2e-test-utils/src/set-option.js
@@ -13,7 +13,6 @@ import { pressKeyWithModifier } from './press-key-with-modifier';
  * @param {string} value   The value to set the option to.
  *
  * @return {string} The previous value of the option.
- *
  */
 export async function setOption( setting, value ) {
 	await switchUserToAdmin();

--- a/packages/edit-widgets/src/index.js
+++ b/packages/edit-widgets/src/index.js
@@ -112,7 +112,6 @@ export function reinitializeEditor() {
  * Function to register an individual block.
  *
  * @param {Object} block The block to be registered.
- *
  */
 const registerBlock = ( block ) => {
 	if ( ! block ) {

--- a/packages/eslint-plugin/CHANGELOG.md
+++ b/packages/eslint-plugin/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+-   The bundled `eslint-plugin-jsdoc` dependency has been updated from requiring ^39.6.9 to requiring ^46.4.6 ([#53629](https://github.com/WordPress/gutenberg/pull/53629)):
+    -   Removes `jsdoc/newline-after-description` rule in favor of `jsdoc/tag-lines` with option `startLines: 0` for "never" and `startLines: 1` for "always". Defaults now to `startLines: null`.
+    -   Removes `dropEndLines: true` from `jsdoc/tag-lines` in favor of option `endLines: 0`.
+    -   Drops `jsdoc/tag-lines` rule's `noEndLines: true` in favor of `applyToEndTag: false`.
+    -   Disables the newly introduced `jsdoc/no-defaults` rule.
+
 ### Enhancement
 
 -   Support Typescript 5 and 5.1 by updating both `@typescript-eslint/parser` and `@typescript-eslint/eslint-plugin` to version `^5.62.0`. ([#52621](https://github.com/WordPress/gutenberg/pull/52621)).

--- a/packages/eslint-plugin/configs/jsdoc.js
+++ b/packages/eslint-plugin/configs/jsdoc.js
@@ -83,6 +83,7 @@ module.exports = {
 		},
 	},
 	rules: {
+		'jsdoc/no-defaults': 'off',
 		'jsdoc/no-undefined-types': [
 			'error',
 			{
@@ -105,7 +106,15 @@ module.exports = {
 		'jsdoc/require-param-description': 'off',
 		'jsdoc/require-returns': 'off',
 		'jsdoc/require-yields': 'off',
-		'jsdoc/tag-lines': 'off',
+		'jsdoc/tag-lines': [
+			1,
+			'any',
+			{
+				startLines: null,
+				endLines: 0,
+				applyToEndTag: false,
+			},
+		],
 		'jsdoc/no-multi-asterisks': [
 			'error',
 			{ preventAtMiddleLines: false },
@@ -127,7 +136,6 @@ module.exports = {
 		'jsdoc/check-values': 'off',
 		'jsdoc/empty-tags': 'error',
 		'jsdoc/implements-on-classes': 'error',
-		'jsdoc/newline-after-description': 'error',
 		'jsdoc/require-param': 'error',
 		'jsdoc/require-param-name': 'error',
 		'jsdoc/require-param-type': 'error',

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -40,7 +40,7 @@
 		"eslint-config-prettier": "^8.3.0",
 		"eslint-plugin-import": "^2.25.2",
 		"eslint-plugin-jest": "^27.2.1",
-		"eslint-plugin-jsdoc": "^39.6.9",
+		"eslint-plugin-jsdoc": "^46.4.6",
 		"eslint-plugin-jsx-a11y": "^6.5.1",
 		"eslint-plugin-prettier": "^3.3.0",
 		"eslint-plugin-react": "^7.27.0",

--- a/packages/notices/src/store/actions.js
+++ b/packages/notices/src/store/actions.js
@@ -11,7 +11,6 @@ import { DEFAULT_CONTEXT, DEFAULT_STATUS } from './constants';
  *                               browser navigation.
  * @property {?Function} onClick Optional function to invoke when action is
  *                               triggered by user.
- *
  */
 
 let uniqueId = 0;

--- a/packages/notices/src/store/selectors.js
+++ b/packages/notices/src/store/selectors.js
@@ -39,7 +39,6 @@ const DEFAULT_NOTICES = [];
  *                                             announced to screen readers. Defaults to
  *                                             `true`.
  * @property {WPNoticeAction[]} actions        User actions to present with notice.
- *
  */
 
 /**

--- a/packages/url/src/add-query-args.js
+++ b/packages/url/src/add-query-args.js
@@ -9,9 +9,9 @@ import { buildQueryString } from './build-query-string';
  * includes query arguments, the arguments are merged with (and take precedent
  * over) the existing set.
  *
- * @param {string} [url=''] URL to which arguments should be appended. If omitted,
- *                          only the resulting querystring is returned.
- * @param {Object} [args]   Query arguments to apply to URL.
+ * @param {string} [url]  URL to which arguments should be appended. If omitted,
+ *                        only the resulting querystring is returned.
+ * @param {Object} [args] Query arguments to apply to URL.
  *
  * @example
  * ```js

--- a/packages/url/src/add-query-args.js
+++ b/packages/url/src/add-query-args.js
@@ -9,9 +9,9 @@ import { buildQueryString } from './build-query-string';
  * includes query arguments, the arguments are merged with (and take precedent
  * over) the existing set.
  *
- * @param {string} [url]  URL to which arguments should be appended. If omitted,
- *                        only the resulting querystring is returned.
- * @param {Object} [args] Query arguments to apply to URL.
+ * @param {string} [url=''] URL to which arguments should be appended. If omitted,
+ *                          only the resulting querystring is returned.
+ * @param {Object} [args]   Query arguments to apply to URL.
  *
  * @example
  * ```js

--- a/test/native/integration-test-helpers/rich-text-select-range.js
+++ b/test/native/integration-test-helpers/rich-text-select-range.js
@@ -9,7 +9,6 @@ import { typeInRichText } from './rich-text-type';
  * @param {import('react-test-renderer').ReactTestInstance} richText RichText test instance.
  * @param {number}                                          start    Selection start position.
  * @param {number}                                          end      Selection end position.
- *
  */
 export const selectRangeInRichText = ( richText, start, end = start ) => {
 	if ( typeof start !== 'number' ) {

--- a/test/native/integration-test-helpers/setup-api-fetch.js
+++ b/test/native/integration-test-helpers/setup-api-fetch.js
@@ -33,7 +33,6 @@ import apiFetch from '@wordpress/api-fetch';
  * expect( apiFetch ).toHaveBeenCalledWith( responses[1].request );
  *
  * @param {object[]} responses Array with the potential responses to return upon requests.
- *
  */
 export function setupApiFetch( responses ) {
 	apiFetch.mockImplementation( async ( options ) => {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Replaces and closes: #50590. Kudos to @sharma20 for most of the work on this PR.

Fixes https://github.com/WordPress/gutenberg/issues/50001.
Fixes https://github.com/WordPress/gutenberg/issues/50452.
Fixes https://github.com/WordPress/gutenberg/issues/53213.
Fixes https://github.com/WordPress/gutenberg/issues/53553.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

`@wordpress/scripts` through `@wordpress/eslint-plugin` has deprecated NPM modules and unsupported node v20. It's caused by dependencies from `eslint-plugin-jsdoc`.

In addition to that, the `jsdoc/newline-after-description` was removed by jsdoc but is used here producing an error:

> Definition for rule 'jsdoc/newline-after-description' was not found

See https://github.com/gajus/eslint-plugin-jsdoc/releases/tag/v42.0.0


## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

`eslint-plugin-jsdoc` gets updated to the latest version that doesn't list Node 20 as not supported.

There is a new default in `jsdoc/tag-lines` which does the same thing, which means removing this rule should be sufficient.


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Run `npm run lint:js`. Everything should work as before and there should be no errors or warnings from the JSDoc plugin.