### PR TITLE
Scripts: Remove deprecated `stable` deep dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -172,7 +172,7 @@
 				"core-js-builder": "3.31.0",
 				"cross-env": "3.2.4",
 				"css-loader": "6.2.0",
-				"cssnano": "5.0.7",
+				"cssnano": "6.0.1",
 				"deep-freeze": "0.0.1",
 				"equivalent-key-map": "0.2.2",
 				"escape-html": "1.0.3",
@@ -2028,12 +2028,12 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-react-constant-elements": {
-			"version": "7.16.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-constant-elements/-/plugin-transform-react-constant-elements-7.16.7.tgz",
-			"integrity": "sha512-lF+cfsyTgwWkcw715J88JhMYJ5GpysYNLhLP1PkvkhTRN7B3e74R/1KsDxFxhRpSn0UUD3IWM4GvdBR2PEbbQQ==",
+			"version": "7.22.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-constant-elements/-/plugin-transform-react-constant-elements-7.22.5.tgz",
+			"integrity": "sha512-BF5SXoO+nX3h5OhlN78XbbDrBOffv+AxPP2ENaJOVqjWCgBDeOY3WcaUcddutGSfoap+5NEQ/q/4I3WZIvgkXA==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.16.7"
+				"@babel/helper-plugin-utils": "^7.22.5"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -12965,12 +12965,12 @@
 			}
 		},
 		"node_modules/@svgr/babel-plugin-add-jsx-attribute": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/@svgr/babel-plugin-add-jsx-attribute/-/babel-plugin-add-jsx-attribute-6.0.0.tgz",
-			"integrity": "sha512-MdPdhdWLtQsjd29Wa4pABdhWbaRMACdM1h31BY+c6FghTZqNGT7pEYdBoaGeKtdTOBC/XNFQaKVj+r/Ei2ryWA==",
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@svgr/babel-plugin-add-jsx-attribute/-/babel-plugin-add-jsx-attribute-8.0.0.tgz",
+			"integrity": "sha512-b9MIk7yhdS1pMCZM8VeNfUlSKVRhsHZNMl5O9SfaX0l0t5wjdgu4IDzGB8bpnGBBOjGST3rRFVsaaEtI4W6f7g==",
 			"dev": true,
 			"engines": {
-				"node": ">=10"
+				"node": ">=14"
 			},
 			"funding": {
 				"type": "github",
@@ -12981,12 +12981,12 @@
 			}
 		},
 		"node_modules/@svgr/babel-plugin-remove-jsx-attribute": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/@svgr/babel-plugin-remove-jsx-attribute/-/babel-plugin-remove-jsx-attribute-6.0.0.tgz",
-			"integrity": "sha512-aVdtfx9jlaaxc3unA6l+M9YRnKIZjOhQPthLKqmTXC8UVkBLDRGwPKo+r8n3VZN8B34+yVajzPTZ+ptTSuZZCw==",
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@svgr/babel-plugin-remove-jsx-attribute/-/babel-plugin-remove-jsx-attribute-8.0.0.tgz",
+			"integrity": "sha512-BcCkm/STipKvbCl6b7QFrMh/vx00vIP63k2eM66MfHJzPr6O2U0jYEViXkHJWqXqQYjdeA9cuCl5KWmlwjDvbA==",
 			"dev": true,
 			"engines": {
-				"node": ">=10"
+				"node": ">=14"
 			},
 			"funding": {
 				"type": "github",
@@ -12997,12 +12997,12 @@
 			}
 		},
 		"node_modules/@svgr/babel-plugin-remove-jsx-empty-expression": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/@svgr/babel-plugin-remove-jsx-empty-expression/-/babel-plugin-remove-jsx-empty-expression-6.0.0.tgz",
-			"integrity": "sha512-Ccj42ApsePD451AZJJf1QzTD1B/BOU392URJTeXFxSK709i0KUsGtbwyiqsKu7vsYxpTM0IA5clAKDyf9RCZyA==",
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@svgr/babel-plugin-remove-jsx-empty-expression/-/babel-plugin-remove-jsx-empty-expression-8.0.0.tgz",
+			"integrity": "sha512-5BcGCBfBxB5+XSDSWnhTThfI9jcO5f0Ai2V24gZpG+wXF14BzwxxdDb4g6trdOux0rhibGs385BeFMSmxtS3uA==",
 			"dev": true,
 			"engines": {
-				"node": ">=10"
+				"node": ">=14"
 			},
 			"funding": {
 				"type": "github",
@@ -13013,12 +13013,12 @@
 			}
 		},
 		"node_modules/@svgr/babel-plugin-replace-jsx-attribute-value": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/@svgr/babel-plugin-replace-jsx-attribute-value/-/babel-plugin-replace-jsx-attribute-value-6.0.0.tgz",
-			"integrity": "sha512-88V26WGyt1Sfd1emBYmBJRWMmgarrExpKNVmI9vVozha4kqs6FzQJ/Kp5+EYli1apgX44518/0+t9+NU36lThQ==",
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@svgr/babel-plugin-replace-jsx-attribute-value/-/babel-plugin-replace-jsx-attribute-value-8.0.0.tgz",
+			"integrity": "sha512-KVQ+PtIjb1BuYT3ht8M5KbzWBhdAjjUPdlMtpuw/VjT8coTrItWX6Qafl9+ji831JaJcu6PJNKCV0bp01lBNzQ==",
 			"dev": true,
 			"engines": {
-				"node": ">=10"
+				"node": ">=14"
 			},
 			"funding": {
 				"type": "github",
@@ -13029,12 +13029,12 @@
 			}
 		},
 		"node_modules/@svgr/babel-plugin-svg-dynamic-title": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/@svgr/babel-plugin-svg-dynamic-title/-/babel-plugin-svg-dynamic-title-6.0.0.tgz",
-			"integrity": "sha512-F7YXNLfGze+xv0KMQxrl2vkNbI9kzT9oDK55/kUuymh1ACyXkMV+VZWX1zEhSTfEKh7VkHVZGmVtHg8eTZ6PRg==",
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@svgr/babel-plugin-svg-dynamic-title/-/babel-plugin-svg-dynamic-title-8.0.0.tgz",
+			"integrity": "sha512-omNiKqwjNmOQJ2v6ge4SErBbkooV2aAWwaPFs2vUY7p7GhVkzRkJ00kILXQvRhA6miHnNpXv7MRnnSjdRjK8og==",
 			"dev": true,
 			"engines": {
-				"node": ">=10"
+				"node": ">=14"
 			},
 			"funding": {
 				"type": "github",
@@ -13045,12 +13045,12 @@
 			}
 		},
 		"node_modules/@svgr/babel-plugin-svg-em-dimensions": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/@svgr/babel-plugin-svg-em-dimensions/-/babel-plugin-svg-em-dimensions-6.0.0.tgz",
-			"integrity": "sha512-+rghFXxdIqJNLQK08kwPBD3Z22/0b2tEZ9lKiL/yTfuyj1wW8HUXu4bo/XkogATIYuXSghVQOOCwURXzHGKyZA==",
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@svgr/babel-plugin-svg-em-dimensions/-/babel-plugin-svg-em-dimensions-8.0.0.tgz",
+			"integrity": "sha512-mURHYnu6Iw3UBTbhGwE/vsngtCIbHE43xCRK7kCw4t01xyGqb2Pd+WXekRRoFOBIY29ZoOhUCTEweDMdrjfi9g==",
 			"dev": true,
 			"engines": {
-				"node": ">=10"
+				"node": ">=14"
 			},
 			"funding": {
 				"type": "github",
@@ -13061,12 +13061,12 @@
 			}
 		},
 		"node_modules/@svgr/babel-plugin-transform-react-native-svg": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/@svgr/babel-plugin-transform-react-native-svg/-/babel-plugin-transform-react-native-svg-6.0.0.tgz",
-			"integrity": "sha512-VaphyHZ+xIKv5v0K0HCzyfAaLhPGJXSk2HkpYfXIOKb7DjLBv0soHDxNv6X0vr2titsxE7klb++u7iOf7TSrFQ==",
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@svgr/babel-plugin-transform-react-native-svg/-/babel-plugin-transform-react-native-svg-8.0.0.tgz",
+			"integrity": "sha512-UKrY3860AQICgH7g+6h2zkoxeVEPLYwX/uAjmqo4PIq2FIHppwhIqZstIyTz0ZtlwreKR41O3W3BzsBBiJV2Aw==",
 			"dev": true,
 			"engines": {
-				"node": ">=10"
+				"node": ">=14"
 			},
 			"funding": {
 				"type": "github",
@@ -13077,9 +13077,9 @@
 			}
 		},
 		"node_modules/@svgr/babel-plugin-transform-svg-component": {
-			"version": "6.2.0",
-			"resolved": "https://registry.npmjs.org/@svgr/babel-plugin-transform-svg-component/-/babel-plugin-transform-svg-component-6.2.0.tgz",
-			"integrity": "sha512-bhYIpsORb++wpsp91fymbFkf09Z/YEKR0DnFjxvN+8JHeCUD2unnh18jIMKnDJTWtvpTaGYPXELVe4OOzFI0xg==",
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@svgr/babel-plugin-transform-svg-component/-/babel-plugin-transform-svg-component-8.0.0.tgz",
+			"integrity": "sha512-DFx8xa3cZXTdb/k3kfPeaixecQLgKh5NVBMwD0AQxOzcZawK4oo1Jh9LbrcACUivsCA7TLG8eeWgrDXjTMhRmw==",
 			"dev": true,
 			"engines": {
 				"node": ">=12"
@@ -13093,22 +13093,22 @@
 			}
 		},
 		"node_modules/@svgr/babel-preset": {
-			"version": "6.2.0",
-			"resolved": "https://registry.npmjs.org/@svgr/babel-preset/-/babel-preset-6.2.0.tgz",
-			"integrity": "sha512-4WQNY0J71JIaL03DRn0vLiz87JXx0b9dYm2aA8XHlQJQoixMl4r/soYHm8dsaJZ3jWtkCiOYy48dp9izvXhDkQ==",
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@svgr/babel-preset/-/babel-preset-8.0.0.tgz",
+			"integrity": "sha512-KLcjiZychInVrhs86OvcYPLTFu9L5XV2vj0XAaE1HwE3J3jLmIzRY8ttdeAg/iFyp8nhavJpafpDZTt+1LIpkQ==",
 			"dev": true,
 			"dependencies": {
-				"@svgr/babel-plugin-add-jsx-attribute": "^6.0.0",
-				"@svgr/babel-plugin-remove-jsx-attribute": "^6.0.0",
-				"@svgr/babel-plugin-remove-jsx-empty-expression": "^6.0.0",
-				"@svgr/babel-plugin-replace-jsx-attribute-value": "^6.0.0",
-				"@svgr/babel-plugin-svg-dynamic-title": "^6.0.0",
-				"@svgr/babel-plugin-svg-em-dimensions": "^6.0.0",
-				"@svgr/babel-plugin-transform-react-native-svg": "^6.0.0",
-				"@svgr/babel-plugin-transform-svg-component": "^6.2.0"
+				"@svgr/babel-plugin-add-jsx-attribute": "8.0.0",
+				"@svgr/babel-plugin-remove-jsx-attribute": "8.0.0",
+				"@svgr/babel-plugin-remove-jsx-empty-expression": "8.0.0",
+				"@svgr/babel-plugin-replace-jsx-attribute-value": "8.0.0",
+				"@svgr/babel-plugin-svg-dynamic-title": "8.0.0",
+				"@svgr/babel-plugin-svg-em-dimensions": "8.0.0",
+				"@svgr/babel-plugin-transform-react-native-svg": "8.0.0",
+				"@svgr/babel-plugin-transform-svg-component": "8.0.0"
 			},
 			"engines": {
-				"node": ">=10"
+				"node": ">=14"
 			},
 			"funding": {
 				"type": "github",
@@ -13119,22 +13119,81 @@
 			}
 		},
 		"node_modules/@svgr/core": {
-			"version": "6.2.1",
-			"resolved": "https://registry.npmjs.org/@svgr/core/-/core-6.2.1.tgz",
-			"integrity": "sha512-NWufjGI2WUyrg46mKuySfviEJ6IxHUOm/8a3Ph38VCWSp+83HBraCQrpEM3F3dB6LBs5x8OElS8h3C0oOJaJAA==",
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@svgr/core/-/core-8.0.0.tgz",
+			"integrity": "sha512-aJKtc+Pie/rFYsVH/unSkDaZGvEeylNv/s2cP+ta9/rYWxRVvoV/S4Qw65Kmrtah4CBK5PM6ISH9qUH7IJQCng==",
 			"dev": true,
 			"dependencies": {
-				"@svgr/plugin-jsx": "^6.2.1",
+				"@babel/core": "^7.21.3",
+				"@svgr/babel-preset": "8.0.0",
 				"camelcase": "^6.2.0",
-				"cosmiconfig": "^7.0.1"
+				"cosmiconfig": "^8.1.3",
+				"snake-case": "^3.0.4"
 			},
 			"engines": {
-				"node": ">=10"
+				"node": ">=14"
 			},
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/gregberge"
 			}
+		},
+		"node_modules/@svgr/core/node_modules/@babel/core": {
+			"version": "7.22.10",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.22.10.tgz",
+			"integrity": "sha512-fTmqbbUBAwCcre6zPzNngvsI0aNrPZe77AeqvDxWM9Nm+04RrJ3CAmGHA9f7lJQY6ZMhRztNemy4uslDxTX4Qw==",
+			"dev": true,
+			"dependencies": {
+				"@ampproject/remapping": "^2.2.0",
+				"@babel/code-frame": "^7.22.10",
+				"@babel/generator": "^7.22.10",
+				"@babel/helper-compilation-targets": "^7.22.10",
+				"@babel/helper-module-transforms": "^7.22.9",
+				"@babel/helpers": "^7.22.10",
+				"@babel/parser": "^7.22.10",
+				"@babel/template": "^7.22.5",
+				"@babel/traverse": "^7.22.10",
+				"@babel/types": "^7.22.10",
+				"convert-source-map": "^1.7.0",
+				"debug": "^4.1.0",
+				"gensync": "^1.0.0-beta.2",
+				"json5": "^2.2.2",
+				"semver": "^6.3.1"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/babel"
+			}
+		},
+		"node_modules/@svgr/core/node_modules/@babel/traverse": {
+			"version": "7.22.10",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.22.10.tgz",
+			"integrity": "sha512-Q/urqV4pRByiNNpb/f5OSv28ZlGJiFiiTh+GAHktbIrkPhPbl90+uW6SmpoLyZqutrg9AEaEf3Q/ZBRHBXgxig==",
+			"dev": true,
+			"dependencies": {
+				"@babel/code-frame": "^7.22.10",
+				"@babel/generator": "^7.22.10",
+				"@babel/helper-environment-visitor": "^7.22.5",
+				"@babel/helper-function-name": "^7.22.5",
+				"@babel/helper-hoist-variables": "^7.22.5",
+				"@babel/helper-split-export-declaration": "^7.22.6",
+				"@babel/parser": "^7.22.10",
+				"@babel/types": "^7.22.10",
+				"debug": "^4.1.0",
+				"globals": "^11.1.0"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@svgr/core/node_modules/argparse": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+			"dev": true
 		},
 		"node_modules/@svgr/core/node_modules/camelcase": {
 			"version": "6.3.0",
@@ -13148,17 +13207,74 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/@svgr/hast-util-to-babel-ast": {
-			"version": "6.2.1",
-			"resolved": "https://registry.npmjs.org/@svgr/hast-util-to-babel-ast/-/hast-util-to-babel-ast-6.2.1.tgz",
-			"integrity": "sha512-pt7MMkQFDlWJVy9ULJ1h+hZBDGFfSCwlBNW1HkLnVi7jUhyEXUaGYWi1x6bM2IXuAR9l265khBT4Av4lPmaNLQ==",
+		"node_modules/@svgr/core/node_modules/cosmiconfig": {
+			"version": "8.2.0",
+			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.2.0.tgz",
+			"integrity": "sha512-3rTMnFJA1tCOPwRxtgF4wd7Ab2qvDbL8jX+3smjIbS4HlZBagTlpERbdN7iAbWlrfxE3M8c27kTwTawQ7st+OQ==",
 			"dev": true,
 			"dependencies": {
-				"@babel/types": "^7.15.6",
-				"entities": "^3.0.1"
+				"import-fresh": "^3.2.1",
+				"js-yaml": "^4.1.0",
+				"parse-json": "^5.0.0",
+				"path-type": "^4.0.0"
 			},
 			"engines": {
-				"node": ">=10"
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/d-fischer"
+			}
+		},
+		"node_modules/@svgr/core/node_modules/globals": {
+			"version": "11.12.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+			"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+			"dev": true,
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/@svgr/core/node_modules/js-yaml": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+			"integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+			"dev": true,
+			"dependencies": {
+				"argparse": "^2.0.1"
+			},
+			"bin": {
+				"js-yaml": "bin/js-yaml.js"
+			}
+		},
+		"node_modules/@svgr/core/node_modules/path-type": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+			"integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@svgr/core/node_modules/semver": {
+			"version": "6.3.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+			"dev": true,
+			"bin": {
+				"semver": "bin/semver.js"
+			}
+		},
+		"node_modules/@svgr/hast-util-to-babel-ast": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@svgr/hast-util-to-babel-ast/-/hast-util-to-babel-ast-8.0.0.tgz",
+			"integrity": "sha512-EbDKwO9GpfWP4jN9sGdYwPBU0kdomaPIL2Eu4YwmgP+sJeXT+L7bMwJUBnhzfH8Q2qMBqZ4fJwpCyYsAN3mt2Q==",
+			"dev": true,
+			"dependencies": {
+				"@babel/types": "^7.21.3",
+				"entities": "^4.4.0"
+			},
+			"engines": {
+				"node": ">=14"
 			},
 			"funding": {
 				"type": "github",
@@ -13166,9 +13282,9 @@
 			}
 		},
 		"node_modules/@svgr/hast-util-to-babel-ast/node_modules/entities": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/entities/-/entities-3.0.1.tgz",
-			"integrity": "sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q==",
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+			"integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
 			"dev": true,
 			"engines": {
 				"node": ">=0.12"
@@ -13178,69 +13294,252 @@
 			}
 		},
 		"node_modules/@svgr/plugin-jsx": {
-			"version": "6.2.1",
-			"resolved": "https://registry.npmjs.org/@svgr/plugin-jsx/-/plugin-jsx-6.2.1.tgz",
-			"integrity": "sha512-u+MpjTsLaKo6r3pHeeSVsh9hmGRag2L7VzApWIaS8imNguqoUwDq/u6U/NDmYs/KAsrmtBjOEaAAPbwNGXXp1g==",
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@svgr/plugin-jsx/-/plugin-jsx-8.0.1.tgz",
+			"integrity": "sha512-bfCFb+4ZsM3UuKP2t7KmDwn6YV8qVn9HIQJmau6xeQb/iV65Rpi7NBNBWA2hcCd4GKoCqG8hpaaDk5FDR0eH+g==",
 			"dev": true,
 			"dependencies": {
-				"@babel/core": "^7.15.5",
-				"@svgr/babel-preset": "^6.2.0",
-				"@svgr/hast-util-to-babel-ast": "^6.2.1",
-				"svg-parser": "^2.0.2"
+				"@babel/core": "^7.21.3",
+				"@svgr/babel-preset": "8.0.0",
+				"@svgr/hast-util-to-babel-ast": "8.0.0",
+				"svg-parser": "^2.0.4"
 			},
 			"engines": {
-				"node": ">=10"
+				"node": ">=14"
 			},
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/gregberge"
 			},
 			"peerDependencies": {
-				"@svgr/core": "^6.0.0"
+				"@svgr/core": "*"
+			}
+		},
+		"node_modules/@svgr/plugin-jsx/node_modules/@babel/core": {
+			"version": "7.22.10",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.22.10.tgz",
+			"integrity": "sha512-fTmqbbUBAwCcre6zPzNngvsI0aNrPZe77AeqvDxWM9Nm+04RrJ3CAmGHA9f7lJQY6ZMhRztNemy4uslDxTX4Qw==",
+			"dev": true,
+			"dependencies": {
+				"@ampproject/remapping": "^2.2.0",
+				"@babel/code-frame": "^7.22.10",
+				"@babel/generator": "^7.22.10",
+				"@babel/helper-compilation-targets": "^7.22.10",
+				"@babel/helper-module-transforms": "^7.22.9",
+				"@babel/helpers": "^7.22.10",
+				"@babel/parser": "^7.22.10",
+				"@babel/template": "^7.22.5",
+				"@babel/traverse": "^7.22.10",
+				"@babel/types": "^7.22.10",
+				"convert-source-map": "^1.7.0",
+				"debug": "^4.1.0",
+				"gensync": "^1.0.0-beta.2",
+				"json5": "^2.2.2",
+				"semver": "^6.3.1"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/babel"
+			}
+		},
+		"node_modules/@svgr/plugin-jsx/node_modules/@babel/traverse": {
+			"version": "7.22.10",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.22.10.tgz",
+			"integrity": "sha512-Q/urqV4pRByiNNpb/f5OSv28ZlGJiFiiTh+GAHktbIrkPhPbl90+uW6SmpoLyZqutrg9AEaEf3Q/ZBRHBXgxig==",
+			"dev": true,
+			"dependencies": {
+				"@babel/code-frame": "^7.22.10",
+				"@babel/generator": "^7.22.10",
+				"@babel/helper-environment-visitor": "^7.22.5",
+				"@babel/helper-function-name": "^7.22.5",
+				"@babel/helper-hoist-variables": "^7.22.5",
+				"@babel/helper-split-export-declaration": "^7.22.6",
+				"@babel/parser": "^7.22.10",
+				"@babel/types": "^7.22.10",
+				"debug": "^4.1.0",
+				"globals": "^11.1.0"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@svgr/plugin-jsx/node_modules/globals": {
+			"version": "11.12.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+			"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+			"dev": true,
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/@svgr/plugin-jsx/node_modules/semver": {
+			"version": "6.3.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+			"dev": true,
+			"bin": {
+				"semver": "bin/semver.js"
 			}
 		},
 		"node_modules/@svgr/plugin-svgo": {
-			"version": "6.2.0",
-			"resolved": "https://registry.npmjs.org/@svgr/plugin-svgo/-/plugin-svgo-6.2.0.tgz",
-			"integrity": "sha512-oDdMQONKOJEbuKwuy4Np6VdV6qoaLLvoY86hjvQEgU82Vx1MSWRyYms6Sl0f+NtqxLI/rDVufATbP/ev996k3Q==",
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@svgr/plugin-svgo/-/plugin-svgo-8.0.1.tgz",
+			"integrity": "sha512-29OJ1QmJgnohQHDAgAuY2h21xWD6TZiXji+hnx+W635RiXTAlHTbjrZDktfqzkN0bOeQEtNe+xgq73/XeWFfSg==",
 			"dev": true,
 			"dependencies": {
-				"cosmiconfig": "^7.0.1",
-				"deepmerge": "^4.2.2",
-				"svgo": "^2.5.0"
+				"cosmiconfig": "^8.1.3",
+				"deepmerge": "^4.3.1",
+				"svgo": "^3.0.2"
 			},
 			"engines": {
-				"node": ">=10"
+				"node": ">=14"
 			},
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/gregberge"
 			},
 			"peerDependencies": {
-				"@svgr/core": "^6.0.0"
+				"@svgr/core": "*"
+			}
+		},
+		"node_modules/@svgr/plugin-svgo/node_modules/argparse": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+			"dev": true
+		},
+		"node_modules/@svgr/plugin-svgo/node_modules/cosmiconfig": {
+			"version": "8.2.0",
+			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.2.0.tgz",
+			"integrity": "sha512-3rTMnFJA1tCOPwRxtgF4wd7Ab2qvDbL8jX+3smjIbS4HlZBagTlpERbdN7iAbWlrfxE3M8c27kTwTawQ7st+OQ==",
+			"dev": true,
+			"dependencies": {
+				"import-fresh": "^3.2.1",
+				"js-yaml": "^4.1.0",
+				"parse-json": "^5.0.0",
+				"path-type": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/d-fischer"
+			}
+		},
+		"node_modules/@svgr/plugin-svgo/node_modules/js-yaml": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+			"integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+			"dev": true,
+			"dependencies": {
+				"argparse": "^2.0.1"
+			},
+			"bin": {
+				"js-yaml": "bin/js-yaml.js"
+			}
+		},
+		"node_modules/@svgr/plugin-svgo/node_modules/path-type": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+			"integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/@svgr/webpack": {
-			"version": "6.2.1",
-			"resolved": "https://registry.npmjs.org/@svgr/webpack/-/webpack-6.2.1.tgz",
-			"integrity": "sha512-h09ngMNd13hnePwgXa+Y5CgOjzlCvfWLHg+MBnydEedAnuLRzUHUJmGS3o2OsrhxTOOqEsPOFt5v/f6C5Qulcw==",
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@svgr/webpack/-/webpack-8.0.1.tgz",
+			"integrity": "sha512-zSoeKcbCmfMXjA11uDuCJb+1LWNb3vy6Qw/VHj0Nfcl3UuqwuoZWknHsBIhCWvi4wU9vPui3aq054qjVyZqY4A==",
 			"dev": true,
 			"dependencies": {
-				"@babel/core": "^7.15.5",
-				"@babel/plugin-transform-react-constant-elements": "^7.14.5",
-				"@babel/preset-env": "^7.15.6",
-				"@babel/preset-react": "^7.14.5",
-				"@babel/preset-typescript": "^7.15.0",
-				"@svgr/core": "^6.2.1",
-				"@svgr/plugin-jsx": "^6.2.1",
-				"@svgr/plugin-svgo": "^6.2.0"
+				"@babel/core": "^7.21.3",
+				"@babel/plugin-transform-react-constant-elements": "^7.21.3",
+				"@babel/preset-env": "^7.20.2",
+				"@babel/preset-react": "^7.18.6",
+				"@babel/preset-typescript": "^7.21.0",
+				"@svgr/core": "8.0.0",
+				"@svgr/plugin-jsx": "8.0.1",
+				"@svgr/plugin-svgo": "8.0.1"
 			},
 			"engines": {
-				"node": ">=10"
+				"node": ">=14"
 			},
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/gregberge"
+			}
+		},
+		"node_modules/@svgr/webpack/node_modules/@babel/core": {
+			"version": "7.22.10",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.22.10.tgz",
+			"integrity": "sha512-fTmqbbUBAwCcre6zPzNngvsI0aNrPZe77AeqvDxWM9Nm+04RrJ3CAmGHA9f7lJQY6ZMhRztNemy4uslDxTX4Qw==",
+			"dev": true,
+			"dependencies": {
+				"@ampproject/remapping": "^2.2.0",
+				"@babel/code-frame": "^7.22.10",
+				"@babel/generator": "^7.22.10",
+				"@babel/helper-compilation-targets": "^7.22.10",
+				"@babel/helper-module-transforms": "^7.22.9",
+				"@babel/helpers": "^7.22.10",
+				"@babel/parser": "^7.22.10",
+				"@babel/template": "^7.22.5",
+				"@babel/traverse": "^7.22.10",
+				"@babel/types": "^7.22.10",
+				"convert-source-map": "^1.7.0",
+				"debug": "^4.1.0",
+				"gensync": "^1.0.0-beta.2",
+				"json5": "^2.2.2",
+				"semver": "^6.3.1"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/babel"
+			}
+		},
+		"node_modules/@svgr/webpack/node_modules/@babel/traverse": {
+			"version": "7.22.10",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.22.10.tgz",
+			"integrity": "sha512-Q/urqV4pRByiNNpb/f5OSv28ZlGJiFiiTh+GAHktbIrkPhPbl90+uW6SmpoLyZqutrg9AEaEf3Q/ZBRHBXgxig==",
+			"dev": true,
+			"dependencies": {
+				"@babel/code-frame": "^7.22.10",
+				"@babel/generator": "^7.22.10",
+				"@babel/helper-environment-visitor": "^7.22.5",
+				"@babel/helper-function-name": "^7.22.5",
+				"@babel/helper-hoist-variables": "^7.22.5",
+				"@babel/helper-split-export-declaration": "^7.22.6",
+				"@babel/parser": "^7.22.10",
+				"@babel/types": "^7.22.10",
+				"debug": "^4.1.0",
+				"globals": "^11.1.0"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@svgr/webpack/node_modules/globals": {
+			"version": "11.12.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+			"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+			"dev": true,
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/@svgr/webpack/node_modules/semver": {
+			"version": "6.3.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+			"dev": true,
+			"bin": {
+				"semver": "bin/semver.js"
 			}
 		},
 		"node_modules/@swc/core": {
@@ -15666,12 +15965,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
 			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-			"dev": true
-		},
-		"node_modules/alphanum-sort": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz",
-			"integrity": "sha1-l6ERlkmyEa0zaR2fn0hqjsn74KM=",
 			"dev": true
 		},
 		"node_modules/anser": {
@@ -26400,25 +26693,13 @@
 				"node": ">=4"
 			}
 		},
-		"node_modules/css-color-names": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/css-color-names/-/css-color-names-1.0.1.tgz",
-			"integrity": "sha512-/loXYOch1qU1biStIFsHH8SxTmOseh1IJqFvy8IujXOm1h+QjUdDhkzOrR5HG8K8mlxREj0yfi8ewCHx0eMxzA==",
-			"dev": true,
-			"engines": {
-				"node": "*"
-			}
-		},
 		"node_modules/css-declaration-sorter": {
-			"version": "6.1.1",
-			"resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-6.1.1.tgz",
-			"integrity": "sha512-BZ1aOuif2Sb7tQYY1GeCjG7F++8ggnwUkH5Ictw0mrdpqpEd+zWmcPdstnH2TItlb74FqR0DrVEieon221T/1Q==",
+			"version": "6.4.1",
+			"resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-6.4.1.tgz",
+			"integrity": "sha512-rtdthzxKuyq6IzqX6jEcIzQF/YqccluefyCYheovBOLhFT/drQA9zj/UbRAa9J7C0o6EG6u3E6g+vKkay7/k3g==",
 			"dev": true,
-			"dependencies": {
-				"timsort": "^0.3.0"
-			},
 			"engines": {
-				"node": ">= 10"
+				"node": "^10 || ^12 || >=14"
 			},
 			"peerDependencies": {
 				"postcss": "^8.0.9"
@@ -26600,18 +26881,16 @@
 			}
 		},
 		"node_modules/cssnano": {
-			"version": "5.0.7",
-			"resolved": "https://registry.npmjs.org/cssnano/-/cssnano-5.0.7.tgz",
-			"integrity": "sha512-7C0tbb298hef3rq+TtBbMuezBQ9VrFtrQEsPNuBKNVgWny/67vdRsnq8EoNu7TRjAHURgYvWlRIpCUmcMZkRzw==",
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/cssnano/-/cssnano-6.0.1.tgz",
+			"integrity": "sha512-fVO1JdJ0LSdIGJq68eIxOqFpIJrZqXUsBt8fkrBcztCQqAjQD51OhZp7tc0ImcbwXD4k7ny84QTV90nZhmqbkg==",
 			"dev": true,
 			"dependencies": {
-				"cssnano-preset-default": "^5.1.3",
-				"is-resolvable": "^1.1.0",
-				"lilconfig": "^2.0.3",
-				"yaml": "^1.10.2"
+				"cssnano-preset-default": "^6.0.1",
+				"lilconfig": "^2.1.0"
 			},
 			"engines": {
-				"node": "^10 || ^12 || >=14.0"
+				"node": "^14 || ^16 || >=18.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -26622,70 +26901,100 @@
 			}
 		},
 		"node_modules/cssnano-preset-default": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/cssnano-preset-default/-/cssnano-preset-default-5.1.3.tgz",
-			"integrity": "sha512-qo9tX+t4yAAZ/yagVV3b+QBKeLklQbmgR3wI7mccrDcR+bEk9iHgZN1E7doX68y9ThznLya3RDmR+nc7l6/2WQ==",
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/cssnano-preset-default/-/cssnano-preset-default-6.0.1.tgz",
+			"integrity": "sha512-7VzyFZ5zEB1+l1nToKyrRkuaJIx0zi/1npjvZfbBwbtNTzhLtlvYraK/7/uqmX2Wb2aQtd983uuGw79jAjLSuQ==",
 			"dev": true,
 			"dependencies": {
-				"css-declaration-sorter": "^6.0.3",
-				"cssnano-utils": "^2.0.1",
-				"postcss-calc": "^8.0.0",
-				"postcss-colormin": "^5.2.0",
-				"postcss-convert-values": "^5.0.1",
-				"postcss-discard-comments": "^5.0.1",
-				"postcss-discard-duplicates": "^5.0.1",
-				"postcss-discard-empty": "^5.0.1",
-				"postcss-discard-overridden": "^5.0.1",
-				"postcss-merge-longhand": "^5.0.2",
-				"postcss-merge-rules": "^5.0.2",
-				"postcss-minify-font-values": "^5.0.1",
-				"postcss-minify-gradients": "^5.0.1",
-				"postcss-minify-params": "^5.0.1",
-				"postcss-minify-selectors": "^5.1.0",
-				"postcss-normalize-charset": "^5.0.1",
-				"postcss-normalize-display-values": "^5.0.1",
-				"postcss-normalize-positions": "^5.0.1",
-				"postcss-normalize-repeat-style": "^5.0.1",
-				"postcss-normalize-string": "^5.0.1",
-				"postcss-normalize-timing-functions": "^5.0.1",
-				"postcss-normalize-unicode": "^5.0.1",
-				"postcss-normalize-url": "^5.0.2",
-				"postcss-normalize-whitespace": "^5.0.1",
-				"postcss-ordered-values": "^5.0.2",
-				"postcss-reduce-initial": "^5.0.1",
-				"postcss-reduce-transforms": "^5.0.1",
-				"postcss-svgo": "^5.0.2",
-				"postcss-unique-selectors": "^5.0.1"
+				"css-declaration-sorter": "^6.3.1",
+				"cssnano-utils": "^4.0.0",
+				"postcss-calc": "^9.0.0",
+				"postcss-colormin": "^6.0.0",
+				"postcss-convert-values": "^6.0.0",
+				"postcss-discard-comments": "^6.0.0",
+				"postcss-discard-duplicates": "^6.0.0",
+				"postcss-discard-empty": "^6.0.0",
+				"postcss-discard-overridden": "^6.0.0",
+				"postcss-merge-longhand": "^6.0.0",
+				"postcss-merge-rules": "^6.0.1",
+				"postcss-minify-font-values": "^6.0.0",
+				"postcss-minify-gradients": "^6.0.0",
+				"postcss-minify-params": "^6.0.0",
+				"postcss-minify-selectors": "^6.0.0",
+				"postcss-normalize-charset": "^6.0.0",
+				"postcss-normalize-display-values": "^6.0.0",
+				"postcss-normalize-positions": "^6.0.0",
+				"postcss-normalize-repeat-style": "^6.0.0",
+				"postcss-normalize-string": "^6.0.0",
+				"postcss-normalize-timing-functions": "^6.0.0",
+				"postcss-normalize-unicode": "^6.0.0",
+				"postcss-normalize-url": "^6.0.0",
+				"postcss-normalize-whitespace": "^6.0.0",
+				"postcss-ordered-values": "^6.0.0",
+				"postcss-reduce-initial": "^6.0.0",
+				"postcss-reduce-transforms": "^6.0.0",
+				"postcss-svgo": "^6.0.0",
+				"postcss-unique-selectors": "^6.0.0"
 			},
 			"engines": {
-				"node": "^10 || ^12 || >=14.0"
+				"node": "^14 || ^16 || >=18.0"
 			},
 			"peerDependencies": {
 				"postcss": "^8.2.15"
 			}
 		},
 		"node_modules/cssnano-utils": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/cssnano-utils/-/cssnano-utils-2.0.1.tgz",
-			"integrity": "sha512-i8vLRZTnEH9ubIyfdZCAdIdgnHAUeQeByEeQ2I7oTilvP9oHO6RScpeq3GsFUVqeB8uZgOQ9pw8utofNn32hhQ==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/cssnano-utils/-/cssnano-utils-4.0.0.tgz",
+			"integrity": "sha512-Z39TLP+1E0KUcd7LGyF4qMfu8ZufI0rDzhdyAMsa/8UyNUU8wpS0fhdBxbQbv32r64ea00h4878gommRVg2BHw==",
 			"dev": true,
 			"engines": {
-				"node": "^10 || ^12 || >=14.0"
+				"node": "^14 || ^16 || >=18.0"
 			},
 			"peerDependencies": {
 				"postcss": "^8.2.15"
 			}
 		},
 		"node_modules/csso": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/csso/-/csso-4.2.0.tgz",
-			"integrity": "sha512-wvlcdIbf6pwKEk7vHj8/Bkc0B4ylXZruLvOgs9doS5eOsOpuodOV2zJChSpkp+pRpYQLQMeF04nr3Z68Sta9jA==",
+			"version": "5.0.5",
+			"resolved": "https://registry.npmjs.org/csso/-/csso-5.0.5.tgz",
+			"integrity": "sha512-0LrrStPOdJj+SPCCrGhzryycLjwcgUSHBtxNA8aIDxf0GLsRh1cKYhB00Gd1lDOS4yGH69+SNn13+TWbVHETFQ==",
 			"dev": true,
 			"dependencies": {
-				"css-tree": "^1.1.2"
+				"css-tree": "~2.2.0"
 			},
 			"engines": {
-				"node": ">=8.0.0"
+				"node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0",
+				"npm": ">=7.0.0"
+			}
+		},
+		"node_modules/csso/node_modules/css-tree": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.2.1.tgz",
+			"integrity": "sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA==",
+			"dev": true,
+			"dependencies": {
+				"mdn-data": "2.0.28",
+				"source-map-js": "^1.0.1"
+			},
+			"engines": {
+				"node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0",
+				"npm": ">=7.0.0"
+			}
+		},
+		"node_modules/csso/node_modules/mdn-data": {
+			"version": "2.0.28",
+			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.28.tgz",
+			"integrity": "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g==",
+			"dev": true
+		},
+		"node_modules/csso/node_modules/source-map-js": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
+			"integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/cssom": {
@@ -31872,12 +32181,6 @@
 				"node": ">= 8"
 			}
 		},
-		"node_modules/hex-color-regex": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/hex-color-regex/-/hex-color-regex-1.1.0.tgz",
-			"integrity": "sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ==",
-			"dev": true
-		},
 		"node_modules/highlight-words-core": {
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/highlight-words-core/-/highlight-words-core-1.2.2.tgz",
@@ -31968,18 +32271,6 @@
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/hpq/-/hpq-1.3.0.tgz",
 			"integrity": "sha512-fvYTvdCFOWQupGxqkahrkA+ERBuMdzkxwtUdKrxR6rmMd4Pfl+iZ1QiQYoaZ0B/v0y59MOMnz3XFUWbT50/NWA=="
-		},
-		"node_modules/hsl-regex": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/hsl-regex/-/hsl-regex-1.0.0.tgz",
-			"integrity": "sha1-1JMwx4ntgZ4nakwNJy3/owsY/m4=",
-			"dev": true
-		},
-		"node_modules/hsla-regex": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/hsla-regex/-/hsla-regex-1.0.0.tgz",
-			"integrity": "sha1-wc56MWjIxmFAM6S194d/OyJfnDg=",
-			"dev": true
 		},
 		"node_modules/html-encoding-sniffer": {
 			"version": "3.0.0",
@@ -33117,29 +33408,6 @@
 			"integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
 			"dev": true
 		},
-		"node_modules/is-color-stop": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/is-color-stop/-/is-color-stop-1.1.0.tgz",
-			"integrity": "sha1-z/9HGu5N1cnhWFmPvhKWe1za00U=",
-			"dev": true,
-			"dependencies": {
-				"css-color-names": "^0.0.4",
-				"hex-color-regex": "^1.1.0",
-				"hsl-regex": "^1.0.0",
-				"hsla-regex": "^1.0.0",
-				"rgb-regex": "^1.0.1",
-				"rgba-regex": "^1.0.0"
-			}
-		},
-		"node_modules/is-color-stop/node_modules/css-color-names": {
-			"version": "0.0.4",
-			"resolved": "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.4.tgz",
-			"integrity": "sha512-zj5D7X1U2h2zsXOAM8EyUREBnnts6H+Jm+d1M2DbiQQcUtnqgQsMrdo8JW9R80YFUmIdBZeMu5wvYM7hcgWP/Q==",
-			"dev": true,
-			"engines": {
-				"node": "*"
-			}
-		},
 		"node_modules/is-core-module": {
 			"version": "2.13.0",
 			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.0.tgz",
@@ -33526,12 +33794,6 @@
 			"engines": {
 				"node": ">=0.10.0"
 			}
-		},
-		"node_modules/is-resolvable": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
-			"integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==",
-			"dev": true
 		},
 		"node_modules/is-shared-array-buffer": {
 			"version": "1.0.2",
@@ -37012,9 +37274,9 @@
 			"dev": true
 		},
 		"node_modules/lilconfig": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.0.3.tgz",
-			"integrity": "sha512-EHKqr/+ZvdKCifpNrJCKxBTgk5XupZA3y/aCPY9mxfgBzmgh93Mt/WqjjQ38oMxXuvDokaKiM3lAgvSH2sjtHg==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.1.0.tgz",
+			"integrity": "sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==",
 			"dev": true,
 			"engines": {
 				"node": ">=10"
@@ -44364,13 +44626,16 @@
 			}
 		},
 		"node_modules/postcss-calc": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-8.0.0.tgz",
-			"integrity": "sha512-5NglwDrcbiy8XXfPM11F3HeC6hoT9W7GUH/Zi5U/p7u3Irv4rHhdDcIZwG0llHXV4ftsBjpfWMXAnXNl4lnt8g==",
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-9.0.1.tgz",
+			"integrity": "sha512-TipgjGyzP5QzEhsOZUaIkeO5mKeMFpebWzRogWG/ysonUlnHcq5aJe0jOjpfzUU8PeSaBQnrE8ehR0QA5vs8PQ==",
 			"dev": true,
 			"dependencies": {
-				"postcss-selector-parser": "^6.0.2",
-				"postcss-value-parser": "^4.0.2"
+				"postcss-selector-parser": "^6.0.11",
+				"postcss-value-parser": "^4.2.0"
+			},
+			"engines": {
+				"node": "^14 || ^16 || >=18.0"
 			},
 			"peerDependencies": {
 				"postcss": "^8.2.2"
@@ -44383,18 +44648,18 @@
 			"dev": true
 		},
 		"node_modules/postcss-colormin": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-5.2.0.tgz",
-			"integrity": "sha512-+HC6GfWU3upe5/mqmxuqYZ9B2Wl4lcoUUNkoaX59nEWV4EtADCMiBqui111Bu8R8IvaZTmqmxrqOAqjbHIwXPw==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-6.0.0.tgz",
+			"integrity": "sha512-EuO+bAUmutWoZYgHn2T1dG1pPqHU6L4TjzPlu4t1wZGXQ/fxV16xg2EJmYi0z+6r+MGV1yvpx1BHkUaRrPa2bw==",
 			"dev": true,
 			"dependencies": {
-				"browserslist": "^4.16.6",
+				"browserslist": "^4.21.4",
 				"caniuse-api": "^3.0.0",
-				"colord": "^2.0.1",
-				"postcss-value-parser": "^4.1.0"
+				"colord": "^2.9.1",
+				"postcss-value-parser": "^4.2.0"
 			},
 			"engines": {
-				"node": "^10 || ^12 || >=14.0"
+				"node": "^14 || ^16 || >=18.0"
 			},
 			"peerDependencies": {
 				"postcss": "^8.2.15"
@@ -44407,15 +44672,16 @@
 			"dev": true
 		},
 		"node_modules/postcss-convert-values": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-5.0.1.tgz",
-			"integrity": "sha512-C3zR1Do2BkKkCgC0g3sF8TS0koF2G+mN8xxayZx3f10cIRmTaAnpgpRQZjNekTZxM2ciSPoh2IWJm0VZx8NoQg==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-6.0.0.tgz",
+			"integrity": "sha512-U5D8QhVwqT++ecmy8rnTb+RL9n/B806UVaS3m60lqle4YDFcpbS3ae5bTQIh3wOGUSDHSEtMYLs/38dNG7EYFw==",
 			"dev": true,
 			"dependencies": {
-				"postcss-value-parser": "^4.1.0"
+				"browserslist": "^4.21.4",
+				"postcss-value-parser": "^4.2.0"
 			},
 			"engines": {
-				"node": "^10 || ^12 || >=14.0"
+				"node": "^14 || ^16 || >=18.0"
 			},
 			"peerDependencies": {
 				"postcss": "^8.2.15"
@@ -44428,48 +44694,48 @@
 			"dev": true
 		},
 		"node_modules/postcss-discard-comments": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-5.0.1.tgz",
-			"integrity": "sha512-lgZBPTDvWrbAYY1v5GYEv8fEO/WhKOu/hmZqmCYfrpD6eyDWWzAOsl2rF29lpvziKO02Gc5GJQtlpkTmakwOWg==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-6.0.0.tgz",
+			"integrity": "sha512-p2skSGqzPMZkEQvJsgnkBhCn8gI7NzRH2683EEjrIkoMiwRELx68yoUJ3q3DGSGuQ8Ug9Gsn+OuDr46yfO+eFw==",
 			"dev": true,
 			"engines": {
-				"node": "^10 || ^12 || >=14.0"
+				"node": "^14 || ^16 || >=18.0"
 			},
 			"peerDependencies": {
 				"postcss": "^8.2.15"
 			}
 		},
 		"node_modules/postcss-discard-duplicates": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-5.0.1.tgz",
-			"integrity": "sha512-svx747PWHKOGpAXXQkCc4k/DsWo+6bc5LsVrAsw+OU+Ibi7klFZCyX54gjYzX4TH+f2uzXjRviLARxkMurA2bA==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-6.0.0.tgz",
+			"integrity": "sha512-bU1SXIizMLtDW4oSsi5C/xHKbhLlhek/0/yCnoMQany9k3nPBq+Ctsv/9oMmyqbR96HYHxZcHyK2HR5P/mqoGA==",
 			"dev": true,
 			"engines": {
-				"node": "^10 || ^12 || >=14.0"
+				"node": "^14 || ^16 || >=18.0"
 			},
 			"peerDependencies": {
 				"postcss": "^8.2.15"
 			}
 		},
 		"node_modules/postcss-discard-empty": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-5.0.1.tgz",
-			"integrity": "sha512-vfU8CxAQ6YpMxV2SvMcMIyF2LX1ZzWpy0lqHDsOdaKKLQVQGVP1pzhrI9JlsO65s66uQTfkQBKBD/A5gp9STFw==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-6.0.0.tgz",
+			"integrity": "sha512-b+h1S1VT6dNhpcg+LpyiUrdnEZfICF0my7HAKgJixJLW7BnNmpRH34+uw/etf5AhOlIhIAuXApSzzDzMI9K/gQ==",
 			"dev": true,
 			"engines": {
-				"node": "^10 || ^12 || >=14.0"
+				"node": "^14 || ^16 || >=18.0"
 			},
 			"peerDependencies": {
 				"postcss": "^8.2.15"
 			}
 		},
 		"node_modules/postcss-discard-overridden": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-5.0.1.tgz",
-			"integrity": "sha512-Y28H7y93L2BpJhrdUR2SR2fnSsT+3TVx1NmVQLbcnZWwIUpJ7mfcTC6Za9M2PG6w8j7UQRfzxqn8jU2VwFxo3Q==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-6.0.0.tgz",
+			"integrity": "sha512-4VELwssYXDFigPYAZ8vL4yX4mUepF/oCBeeIT4OXsJPYOtvJumyz9WflmJWTfDwCUcpDR+z0zvCWBXgTx35SVw==",
 			"dev": true,
 			"engines": {
-				"node": "^10 || ^12 || >=14.0"
+				"node": "^14 || ^16 || >=18.0"
 			},
 			"peerDependencies": {
 				"postcss": "^8.2.15"
@@ -44504,17 +44770,16 @@
 			"dev": true
 		},
 		"node_modules/postcss-merge-longhand": {
-			"version": "5.0.2",
-			"resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-5.0.2.tgz",
-			"integrity": "sha512-BMlg9AXSI5G9TBT0Lo/H3PfUy63P84rVz3BjCFE9e9Y9RXQZD3+h3YO1kgTNsNJy7bBc1YQp8DmSnwLIW5VPcw==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-6.0.0.tgz",
+			"integrity": "sha512-4VSfd1lvGkLTLYcxFuISDtWUfFS4zXe0FpF149AyziftPFQIWxjvFSKhA4MIxMe4XM3yTDgQMbSNgzIVxChbIg==",
 			"dev": true,
 			"dependencies": {
-				"css-color-names": "^1.0.1",
-				"postcss-value-parser": "^4.1.0",
-				"stylehacks": "^5.0.1"
+				"postcss-value-parser": "^4.2.0",
+				"stylehacks": "^6.0.0"
 			},
 			"engines": {
-				"node": "^10 || ^12 || >=14.0"
+				"node": "^14 || ^16 || >=18.0"
 			},
 			"peerDependencies": {
 				"postcss": "^8.2.15"
@@ -44527,34 +44792,33 @@
 			"dev": true
 		},
 		"node_modules/postcss-merge-rules": {
-			"version": "5.0.2",
-			"resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-5.0.2.tgz",
-			"integrity": "sha512-5K+Md7S3GwBewfB4rjDeol6V/RZ8S+v4B66Zk2gChRqLTCC8yjnHQ601omj9TKftS19OPGqZ/XzoqpzNQQLwbg==",
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-6.0.1.tgz",
+			"integrity": "sha512-a4tlmJIQo9SCjcfiCcCMg/ZCEe0XTkl/xK0XHBs955GWg9xDX3NwP9pwZ78QUOWB8/0XCjZeJn98Dae0zg6AAw==",
 			"dev": true,
 			"dependencies": {
-				"browserslist": "^4.16.6",
+				"browserslist": "^4.21.4",
 				"caniuse-api": "^3.0.0",
-				"cssnano-utils": "^2.0.1",
-				"postcss-selector-parser": "^6.0.5",
-				"vendors": "^1.0.3"
+				"cssnano-utils": "^4.0.0",
+				"postcss-selector-parser": "^6.0.5"
 			},
 			"engines": {
-				"node": "^10 || ^12 || >=14.0"
+				"node": "^14 || ^16 || >=18.0"
 			},
 			"peerDependencies": {
 				"postcss": "^8.2.15"
 			}
 		},
 		"node_modules/postcss-minify-font-values": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-5.0.1.tgz",
-			"integrity": "sha512-7JS4qIsnqaxk+FXY1E8dHBDmraYFWmuL6cgt0T1SWGRO5bzJf8sUoelwa4P88LEWJZweHevAiDKxHlofuvtIoA==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-6.0.0.tgz",
+			"integrity": "sha512-zNRAVtyh5E8ndZEYXA4WS8ZYsAp798HiIQ1V2UF/C/munLp2r1UGHwf1+6JFu7hdEhJFN+W1WJQKBrtjhFgEnA==",
 			"dev": true,
 			"dependencies": {
-				"postcss-value-parser": "^4.1.0"
+				"postcss-value-parser": "^4.2.0"
 			},
 			"engines": {
-				"node": "^10 || ^12 || >=14.0"
+				"node": "^14 || ^16 || >=18.0"
 			},
 			"peerDependencies": {
 				"postcss": "^8.2.15"
@@ -44567,17 +44831,17 @@
 			"dev": true
 		},
 		"node_modules/postcss-minify-gradients": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-5.0.1.tgz",
-			"integrity": "sha512-odOwBFAIn2wIv+XYRpoN2hUV3pPQlgbJ10XeXPq8UY2N+9ZG42xu45lTn/g9zZ+d70NKSQD6EOi6UiCMu3FN7g==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-6.0.0.tgz",
+			"integrity": "sha512-wO0F6YfVAR+K1xVxF53ueZJza3L+R3E6cp0VwuXJQejnNUH0DjcAFe3JEBeTY1dLwGa0NlDWueCA1VlEfiKgAA==",
 			"dev": true,
 			"dependencies": {
-				"cssnano-utils": "^2.0.1",
-				"is-color-stop": "^1.1.0",
-				"postcss-value-parser": "^4.1.0"
+				"colord": "^2.9.1",
+				"cssnano-utils": "^4.0.0",
+				"postcss-value-parser": "^4.2.0"
 			},
 			"engines": {
-				"node": "^10 || ^12 || >=14.0"
+				"node": "^14 || ^16 || >=18.0"
 			},
 			"peerDependencies": {
 				"postcss": "^8.2.15"
@@ -44590,19 +44854,17 @@
 			"dev": true
 		},
 		"node_modules/postcss-minify-params": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-5.0.1.tgz",
-			"integrity": "sha512-4RUC4k2A/Q9mGco1Z8ODc7h+A0z7L7X2ypO1B6V8057eVK6mZ6xwz6QN64nHuHLbqbclkX1wyzRnIrdZehTEHw==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-6.0.0.tgz",
+			"integrity": "sha512-Fz/wMQDveiS0n5JPcvsMeyNXOIMrwF88n7196puSuQSWSa+/Ofc1gDOSY2xi8+A4PqB5dlYCKk/WfqKqsI+ReQ==",
 			"dev": true,
 			"dependencies": {
-				"alphanum-sort": "^1.0.2",
-				"browserslist": "^4.16.0",
-				"cssnano-utils": "^2.0.1",
-				"postcss-value-parser": "^4.1.0",
-				"uniqs": "^2.0.0"
+				"browserslist": "^4.21.4",
+				"cssnano-utils": "^4.0.0",
+				"postcss-value-parser": "^4.2.0"
 			},
 			"engines": {
-				"node": "^10 || ^12 || >=14.0"
+				"node": "^14 || ^16 || >=18.0"
 			},
 			"peerDependencies": {
 				"postcss": "^8.2.15"
@@ -44615,16 +44877,15 @@
 			"dev": true
 		},
 		"node_modules/postcss-minify-selectors": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-5.1.0.tgz",
-			"integrity": "sha512-NzGBXDa7aPsAcijXZeagnJBKBPMYLaJJzB8CQh6ncvyl2sIndLVWfbcDi0SBjRWk5VqEjXvf8tYwzoKf4Z07og==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-6.0.0.tgz",
+			"integrity": "sha512-ec/q9JNCOC2CRDNnypipGfOhbYPuUkewGwLnbv6omue/PSASbHSU7s6uSQ0tcFRVv731oMIx8k0SP4ZX6be/0g==",
 			"dev": true,
 			"dependencies": {
-				"alphanum-sort": "^1.0.2",
 				"postcss-selector-parser": "^6.0.5"
 			},
 			"engines": {
-				"node": "^10 || ^12 || >=14.0"
+				"node": "^14 || ^16 || >=18.0"
 			},
 			"peerDependencies": {
 				"postcss": "^8.2.15"
@@ -44696,28 +44957,27 @@
 			}
 		},
 		"node_modules/postcss-normalize-charset": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-5.0.1.tgz",
-			"integrity": "sha512-6J40l6LNYnBdPSk+BHZ8SF+HAkS4q2twe5jnocgd+xWpz/mx/5Sa32m3W1AA8uE8XaXN+eg8trIlfu8V9x61eg==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-6.0.0.tgz",
+			"integrity": "sha512-cqundwChbu8yO/gSWkuFDmKrCZ2vJzDAocheT2JTd0sFNA4HMGoKMfbk2B+J0OmO0t5GUkiAkSM5yF2rSLUjgQ==",
 			"dev": true,
 			"engines": {
-				"node": "^10 || ^12 || >=14.0"
+				"node": "^14 || ^16 || >=18.0"
 			},
 			"peerDependencies": {
 				"postcss": "^8.2.15"
 			}
 		},
 		"node_modules/postcss-normalize-display-values": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/postcss-normalize-display-values/-/postcss-normalize-display-values-5.0.1.tgz",
-			"integrity": "sha512-uupdvWk88kLDXi5HEyI9IaAJTE3/Djbcrqq8YgjvAVuzgVuqIk3SuJWUisT2gaJbZm1H9g5k2w1xXilM3x8DjQ==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-normalize-display-values/-/postcss-normalize-display-values-6.0.0.tgz",
+			"integrity": "sha512-Qyt5kMrvy7dJRO3OjF7zkotGfuYALETZE+4lk66sziWSPzlBEt7FrUshV6VLECkI4EN8Z863O6Nci4NXQGNzYw==",
 			"dev": true,
 			"dependencies": {
-				"cssnano-utils": "^2.0.1",
-				"postcss-value-parser": "^4.1.0"
+				"postcss-value-parser": "^4.2.0"
 			},
 			"engines": {
-				"node": "^10 || ^12 || >=14.0"
+				"node": "^14 || ^16 || >=18.0"
 			},
 			"peerDependencies": {
 				"postcss": "^8.2.15"
@@ -44730,15 +44990,15 @@
 			"dev": true
 		},
 		"node_modules/postcss-normalize-positions": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/postcss-normalize-positions/-/postcss-normalize-positions-5.0.1.tgz",
-			"integrity": "sha512-rvzWAJai5xej9yWqlCb1OWLd9JjW2Ex2BCPzUJrbaXmtKtgfL8dBMOOMTX6TnvQMtjk3ei1Lswcs78qKO1Skrg==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-normalize-positions/-/postcss-normalize-positions-6.0.0.tgz",
+			"integrity": "sha512-mPCzhSV8+30FZyWhxi6UoVRYd3ZBJgTRly4hOkaSifo0H+pjDYcii/aVT4YE6QpOil15a5uiv6ftnY3rm0igPg==",
 			"dev": true,
 			"dependencies": {
-				"postcss-value-parser": "^4.1.0"
+				"postcss-value-parser": "^4.2.0"
 			},
 			"engines": {
-				"node": "^10 || ^12 || >=14.0"
+				"node": "^14 || ^16 || >=18.0"
 			},
 			"peerDependencies": {
 				"postcss": "^8.2.15"
@@ -44751,16 +45011,15 @@
 			"dev": true
 		},
 		"node_modules/postcss-normalize-repeat-style": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/postcss-normalize-repeat-style/-/postcss-normalize-repeat-style-5.0.1.tgz",
-			"integrity": "sha512-syZ2itq0HTQjj4QtXZOeefomckiV5TaUO6ReIEabCh3wgDs4Mr01pkif0MeVwKyU/LHEkPJnpwFKRxqWA/7O3w==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-normalize-repeat-style/-/postcss-normalize-repeat-style-6.0.0.tgz",
+			"integrity": "sha512-50W5JWEBiOOAez2AKBh4kRFm2uhrT3O1Uwdxz7k24aKtbD83vqmcVG7zoIwo6xI2FZ/HDlbrCopXhLeTpQib1A==",
 			"dev": true,
 			"dependencies": {
-				"cssnano-utils": "^2.0.1",
-				"postcss-value-parser": "^4.1.0"
+				"postcss-value-parser": "^4.2.0"
 			},
 			"engines": {
-				"node": "^10 || ^12 || >=14.0"
+				"node": "^14 || ^16 || >=18.0"
 			},
 			"peerDependencies": {
 				"postcss": "^8.2.15"
@@ -44773,15 +45032,15 @@
 			"dev": true
 		},
 		"node_modules/postcss-normalize-string": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/postcss-normalize-string/-/postcss-normalize-string-5.0.1.tgz",
-			"integrity": "sha512-Ic8GaQ3jPMVl1OEn2U//2pm93AXUcF3wz+OriskdZ1AOuYV25OdgS7w9Xu2LO5cGyhHCgn8dMXh9bO7vi3i9pA==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-normalize-string/-/postcss-normalize-string-6.0.0.tgz",
+			"integrity": "sha512-KWkIB7TrPOiqb8ZZz6homet2KWKJwIlysF5ICPZrXAylGe2hzX/HSf4NTX2rRPJMAtlRsj/yfkrWGavFuB+c0w==",
 			"dev": true,
 			"dependencies": {
-				"postcss-value-parser": "^4.1.0"
+				"postcss-value-parser": "^4.2.0"
 			},
 			"engines": {
-				"node": "^10 || ^12 || >=14.0"
+				"node": "^14 || ^16 || >=18.0"
 			},
 			"peerDependencies": {
 				"postcss": "^8.2.15"
@@ -44794,16 +45053,15 @@
 			"dev": true
 		},
 		"node_modules/postcss-normalize-timing-functions": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/postcss-normalize-timing-functions/-/postcss-normalize-timing-functions-5.0.1.tgz",
-			"integrity": "sha512-cPcBdVN5OsWCNEo5hiXfLUnXfTGtSFiBU9SK8k7ii8UD7OLuznzgNRYkLZow11BkQiiqMcgPyh4ZqXEEUrtQ1Q==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-normalize-timing-functions/-/postcss-normalize-timing-functions-6.0.0.tgz",
+			"integrity": "sha512-tpIXWciXBp5CiFs8sem90IWlw76FV4oi6QEWfQwyeREVwUy39VSeSqjAT7X0Qw650yAimYW5gkl2Gd871N5SQg==",
 			"dev": true,
 			"dependencies": {
-				"cssnano-utils": "^2.0.1",
-				"postcss-value-parser": "^4.1.0"
+				"postcss-value-parser": "^4.2.0"
 			},
 			"engines": {
-				"node": "^10 || ^12 || >=14.0"
+				"node": "^14 || ^16 || >=18.0"
 			},
 			"peerDependencies": {
 				"postcss": "^8.2.15"
@@ -44816,16 +45074,16 @@
 			"dev": true
 		},
 		"node_modules/postcss-normalize-unicode": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/postcss-normalize-unicode/-/postcss-normalize-unicode-5.0.1.tgz",
-			"integrity": "sha512-kAtYD6V3pK0beqrU90gpCQB7g6AOfP/2KIPCVBKJM2EheVsBQmx/Iof+9zR9NFKLAx4Pr9mDhogB27pmn354nA==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-normalize-unicode/-/postcss-normalize-unicode-6.0.0.tgz",
+			"integrity": "sha512-ui5crYkb5ubEUDugDc786L/Me+DXp2dLg3fVJbqyAl0VPkAeALyAijF2zOsnZyaS1HyfPuMH0DwyY18VMFVNkg==",
 			"dev": true,
 			"dependencies": {
-				"browserslist": "^4.16.0",
-				"postcss-value-parser": "^4.1.0"
+				"browserslist": "^4.21.4",
+				"postcss-value-parser": "^4.2.0"
 			},
 			"engines": {
-				"node": "^10 || ^12 || >=14.0"
+				"node": "^14 || ^16 || >=18.0"
 			},
 			"peerDependencies": {
 				"postcss": "^8.2.15"
@@ -44838,17 +45096,15 @@
 			"dev": true
 		},
 		"node_modules/postcss-normalize-url": {
-			"version": "5.0.2",
-			"resolved": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-5.0.2.tgz",
-			"integrity": "sha512-k4jLTPUxREQ5bpajFQZpx8bCF2UrlqOTzP9kEqcEnOfwsRshWs2+oAFIHfDQB8GO2PaUaSE0NlTAYtbluZTlHQ==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-6.0.0.tgz",
+			"integrity": "sha512-98mvh2QzIPbb02YDIrYvAg4OUzGH7s1ZgHlD3fIdTHLgPLRpv1ZTKJDnSAKr4Rt21ZQFzwhGMXxpXlfrUBKFHw==",
 			"dev": true,
 			"dependencies": {
-				"is-absolute-url": "^3.0.3",
-				"normalize-url": "^6.0.1",
-				"postcss-value-parser": "^4.1.0"
+				"postcss-value-parser": "^4.2.0"
 			},
 			"engines": {
-				"node": "^10 || ^12 || >=14.0"
+				"node": "^14 || ^16 || >=18.0"
 			},
 			"peerDependencies": {
 				"postcss": "^8.2.15"
@@ -44861,15 +45117,15 @@
 			"dev": true
 		},
 		"node_modules/postcss-normalize-whitespace": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/postcss-normalize-whitespace/-/postcss-normalize-whitespace-5.0.1.tgz",
-			"integrity": "sha512-iPklmI5SBnRvwceb/XH568yyzK0qRVuAG+a1HFUsFRf11lEJTiQQa03a4RSCQvLKdcpX7XsI1Gen9LuLoqwiqA==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-normalize-whitespace/-/postcss-normalize-whitespace-6.0.0.tgz",
+			"integrity": "sha512-7cfE1AyLiK0+ZBG6FmLziJzqQCpTQY+8XjMhMAz8WSBSCsCNNUKujgIgjCAmDT3cJ+3zjTXFkoD15ZPsckArVw==",
 			"dev": true,
 			"dependencies": {
-				"postcss-value-parser": "^4.1.0"
+				"postcss-value-parser": "^4.2.0"
 			},
 			"engines": {
-				"node": "^10 || ^12 || >=14.0"
+				"node": "^14 || ^16 || >=18.0"
 			},
 			"peerDependencies": {
 				"postcss": "^8.2.15"
@@ -44882,16 +45138,16 @@
 			"dev": true
 		},
 		"node_modules/postcss-ordered-values": {
-			"version": "5.0.2",
-			"resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-5.0.2.tgz",
-			"integrity": "sha512-8AFYDSOYWebJYLyJi3fyjl6CqMEG/UVworjiyK1r573I56kb3e879sCJLGvR3merj+fAdPpVplXKQZv+ey6CgQ==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-6.0.0.tgz",
+			"integrity": "sha512-K36XzUDpvfG/nWkjs6d1hRBydeIxGpKS2+n+ywlKPzx1nMYDYpoGbcjhj5AwVYJK1qV2/SDoDEnHzlPD6s3nMg==",
 			"dev": true,
 			"dependencies": {
-				"cssnano-utils": "^2.0.1",
-				"postcss-value-parser": "^4.1.0"
+				"cssnano-utils": "^4.0.0",
+				"postcss-value-parser": "^4.2.0"
 			},
 			"engines": {
-				"node": "^10 || ^12 || >=14.0"
+				"node": "^14 || ^16 || >=18.0"
 			},
 			"peerDependencies": {
 				"postcss": "^8.2.15"
@@ -44904,32 +45160,31 @@
 			"dev": true
 		},
 		"node_modules/postcss-reduce-initial": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-5.0.1.tgz",
-			"integrity": "sha512-zlCZPKLLTMAqA3ZWH57HlbCjkD55LX9dsRyxlls+wfuRfqCi5mSlZVan0heX5cHr154Dq9AfbH70LyhrSAezJw==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-6.0.0.tgz",
+			"integrity": "sha512-s2UOnidpVuXu6JiiI5U+fV2jamAw5YNA9Fdi/GRK0zLDLCfXmSGqQtzpUPtfN66RtCbb9fFHoyZdQaxOB3WxVA==",
 			"dev": true,
 			"dependencies": {
-				"browserslist": "^4.16.0",
+				"browserslist": "^4.21.4",
 				"caniuse-api": "^3.0.0"
 			},
 			"engines": {
-				"node": "^10 || ^12 || >=14.0"
+				"node": "^14 || ^16 || >=18.0"
 			},
 			"peerDependencies": {
 				"postcss": "^8.2.15"
 			}
 		},
 		"node_modules/postcss-reduce-transforms": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-5.0.1.tgz",
-			"integrity": "sha512-a//FjoPeFkRuAguPscTVmRQUODP+f3ke2HqFNgGPwdYnpeC29RZdCBvGRGTsKpMURb/I3p6jdKoBQ2zI+9Q7kA==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-6.0.0.tgz",
+			"integrity": "sha512-FQ9f6xM1homnuy1wLe9lP1wujzxnwt1EwiigtWwuyf8FsqqXUDUp2Ulxf9A5yjlUOTdCJO6lonYjg1mgqIIi2w==",
 			"dev": true,
 			"dependencies": {
-				"cssnano-utils": "^2.0.1",
-				"postcss-value-parser": "^4.1.0"
+				"postcss-value-parser": "^4.2.0"
 			},
 			"engines": {
-				"node": "^10 || ^12 || >=14.0"
+				"node": "^14 || ^16 || >=18.0"
 			},
 			"peerDependencies": {
 				"postcss": "^8.2.15"
@@ -44977,16 +45232,16 @@
 			}
 		},
 		"node_modules/postcss-svgo": {
-			"version": "5.0.2",
-			"resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-5.0.2.tgz",
-			"integrity": "sha512-YzQuFLZu3U3aheizD+B1joQ94vzPfE6BNUcSYuceNxlVnKKsOtdo6hL9/zyC168Q8EwfLSgaDSalsUGa9f2C0A==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-6.0.0.tgz",
+			"integrity": "sha512-r9zvj/wGAoAIodn84dR/kFqwhINp5YsJkLoujybWG59grR/IHx+uQ2Zo+IcOwM0jskfYX3R0mo+1Kip1VSNcvw==",
 			"dev": true,
 			"dependencies": {
-				"postcss-value-parser": "^4.1.0",
-				"svgo": "^2.3.0"
+				"postcss-value-parser": "^4.2.0",
+				"svgo": "^3.0.2"
 			},
 			"engines": {
-				"node": "^10 || ^12 || >=14.0"
+				"node": "^14 || ^16 || >= 18"
 			},
 			"peerDependencies": {
 				"postcss": "^8.2.15"
@@ -44999,17 +45254,15 @@
 			"dev": true
 		},
 		"node_modules/postcss-unique-selectors": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-5.0.1.tgz",
-			"integrity": "sha512-gwi1NhHV4FMmPn+qwBNuot1sG1t2OmacLQ/AX29lzyggnjd+MnVD5uqQmpXO3J17KGL2WAxQruj1qTd3H0gG/w==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-6.0.0.tgz",
+			"integrity": "sha512-EPQzpZNxOxP7777t73RQpZE5e9TrnCrkvp7AH7a0l89JmZiPnS82y216JowHXwpBCQitfyxrof9TK3rYbi7/Yw==",
 			"dev": true,
 			"dependencies": {
-				"alphanum-sort": "^1.0.2",
-				"postcss-selector-parser": "^6.0.5",
-				"uniqs": "^2.0.0"
+				"postcss-selector-parser": "^6.0.5"
 			},
 			"engines": {
-				"node": "^10 || ^12 || >=14.0"
+				"node": "^14 || ^16 || >=18.0"
 			},
 			"peerDependencies": {
 				"postcss": "^8.2.15"
@@ -47840,18 +48093,6 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/rgb-regex": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/rgb-regex/-/rgb-regex-1.0.1.tgz",
-			"integrity": "sha1-wODWiC3w4jviVKR16O3UGRX+rrE=",
-			"dev": true
-		},
-		"node_modules/rgba-regex": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/rgba-regex/-/rgba-regex-1.0.0.tgz",
-			"integrity": "sha1-QzdOLiyglosO8VI0YLfXMP8i7rM=",
-			"dev": true
-		},
 		"node_modules/rimraf": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
@@ -49461,13 +49702,6 @@
 				"figgy-pudding": "^3.5.1"
 			}
 		},
-		"node_modules/stable": {
-			"version": "0.1.8",
-			"resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",
-			"integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==",
-			"deprecated": "Modern JS already guarantees Array#sort() is a stable sort, so this library is deprecated. See the compatibility table on MDN: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#browser_compatibility",
-			"dev": true
-		},
 		"node_modules/stack-utils": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.3.tgz",
@@ -49969,16 +50203,16 @@
 			"dev": true
 		},
 		"node_modules/stylehacks": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-5.0.1.tgz",
-			"integrity": "sha512-Es0rVnHIqbWzveU1b24kbw92HsebBepxfcqe5iix7t9j0PQqhs0IxXVXv0pY2Bxa08CgMkzD6OWql7kbGOuEdA==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-6.0.0.tgz",
+			"integrity": "sha512-+UT589qhHPwz6mTlCLSt/vMNTJx8dopeJlZAlBMJPWA3ORqu6wmQY7FBXf+qD+FsqoBJODyqNxOUP3jdntFRdw==",
 			"dev": true,
 			"dependencies": {
-				"browserslist": "^4.16.0",
+				"browserslist": "^4.21.4",
 				"postcss-selector-parser": "^6.0.4"
 			},
 			"engines": {
-				"node": "^10 || ^12 || >=14.0"
+				"node": "^14 || ^16 || >=18.0"
 			},
 			"peerDependencies": {
 				"postcss": "^8.2.15"
@@ -50405,24 +50639,27 @@
 			"dev": true
 		},
 		"node_modules/svgo": {
-			"version": "2.8.0",
-			"resolved": "https://registry.npmjs.org/svgo/-/svgo-2.8.0.tgz",
-			"integrity": "sha512-+N/Q9kV1+F+UeWYoSiULYo4xYSDQlTgb+ayMobAXPwMnLvop7oxKMo9OzIrX5x3eS4L4f2UHhc9axXwY8DpChg==",
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/svgo/-/svgo-3.0.2.tgz",
+			"integrity": "sha512-Z706C1U2pb1+JGP48fbazf3KxHrWOsLme6Rv7imFBn5EnuanDW1GPaA/P1/dvObE670JDePC3mnj0k0B7P0jjQ==",
 			"dev": true,
 			"dependencies": {
 				"@trysound/sax": "0.2.0",
 				"commander": "^7.2.0",
-				"css-select": "^4.1.3",
-				"css-tree": "^1.1.3",
-				"csso": "^4.2.0",
-				"picocolors": "^1.0.0",
-				"stable": "^0.1.8"
+				"css-select": "^5.1.0",
+				"css-tree": "^2.2.1",
+				"csso": "^5.0.5",
+				"picocolors": "^1.0.0"
 			},
 			"bin": {
 				"svgo": "bin/svgo"
 			},
 			"engines": {
-				"node": ">=10.13.0"
+				"node": ">=14.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/svgo"
 			}
 		},
 		"node_modules/svgo/node_modules/commander": {
@@ -50434,84 +50671,32 @@
 				"node": ">= 10"
 			}
 		},
-		"node_modules/svgo/node_modules/css-select": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/css-select/-/css-select-4.3.0.tgz",
-			"integrity": "sha512-wPpOYtnsVontu2mODhA19JrqWxNsfdatRKd64kmpRbQgh1KtItko5sTnEpPdpSaJszTOhEMlF/RPz28qj4HqhQ==",
+		"node_modules/svgo/node_modules/css-tree": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.3.1.tgz",
+			"integrity": "sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==",
 			"dev": true,
 			"dependencies": {
-				"boolbase": "^1.0.0",
-				"css-what": "^6.0.1",
-				"domhandler": "^4.3.1",
-				"domutils": "^2.8.0",
-				"nth-check": "^2.0.1"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/fb55"
-			}
-		},
-		"node_modules/svgo/node_modules/dom-serializer": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.4.1.tgz",
-			"integrity": "sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag==",
-			"dev": true,
-			"dependencies": {
-				"domelementtype": "^2.0.1",
-				"domhandler": "^4.2.0",
-				"entities": "^2.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
-			}
-		},
-		"node_modules/svgo/node_modules/domelementtype": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
-			"integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/fb55"
-				}
-			]
-		},
-		"node_modules/svgo/node_modules/domhandler": {
-			"version": "4.3.1",
-			"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.1.tgz",
-			"integrity": "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==",
-			"dev": true,
-			"dependencies": {
-				"domelementtype": "^2.2.0"
+				"mdn-data": "2.0.30",
+				"source-map-js": "^1.0.1"
 			},
 			"engines": {
-				"node": ">= 4"
-			},
-			"funding": {
-				"url": "https://github.com/fb55/domhandler?sponsor=1"
+				"node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
 			}
 		},
-		"node_modules/svgo/node_modules/domutils": {
-			"version": "2.8.0",
-			"resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
-			"integrity": "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==",
-			"dev": true,
-			"dependencies": {
-				"dom-serializer": "^1.0.1",
-				"domelementtype": "^2.2.0",
-				"domhandler": "^4.2.0"
-			},
-			"funding": {
-				"url": "https://github.com/fb55/domutils?sponsor=1"
-			}
+		"node_modules/svgo/node_modules/mdn-data": {
+			"version": "2.0.30",
+			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.30.tgz",
+			"integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==",
+			"dev": true
 		},
-		"node_modules/svgo/node_modules/entities": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
-			"integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
+		"node_modules/svgo/node_modules/source-map-js": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
+			"integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
 			"dev": true,
-			"funding": {
-				"url": "https://github.com/fb55/entities?sponsor=1"
+			"engines": {
+				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/swc-loader": {
@@ -51088,12 +51273,6 @@
 			"engines": {
 				"node": ">=0.6.0"
 			}
-		},
-		"node_modules/timsort": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/timsort/-/timsort-0.3.0.tgz",
-			"integrity": "sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q=",
-			"dev": true
 		},
 		"node_modules/tiny-emitter": {
 			"version": "2.1.0",
@@ -51720,12 +51899,6 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/uniqs": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz",
-			"integrity": "sha1-/+3ks2slKQaW5uFl1KWe25mOawI=",
-			"dev": true
-		},
 		"node_modules/unique-filename": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.1.tgz",
@@ -52341,16 +52514,6 @@
 			"integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
 			"engines": {
 				"node": ">= 0.8"
-			}
-		},
-		"node_modules/vendors": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/vendors/-/vendors-1.0.4.tgz",
-			"integrity": "sha512-/juG65kTL4Cy2su4P8HjtkTxk6VmJDiOPBufWniqQ6wknac6jNiXS9vU+hO3wgusiyqWlzTbVHi0dyJqRONg3w==",
-			"dev": true,
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/wooorm"
 			}
 		},
 		"node_modules/verror": {
@@ -56238,7 +56401,7 @@
 			"dependencies": {
 				"@babel/core": "^7.16.0",
 				"@pmmmwh/react-refresh-webpack-plugin": "^0.5.2",
-				"@svgr/webpack": "^6.2.1",
+				"@svgr/webpack": "^8.0.1",
 				"@wordpress/babel-preset-default": "file:../babel-preset-default",
 				"@wordpress/browserslist-config": "file:../browserslist-config",
 				"@wordpress/dependency-extraction-webpack-plugin": "file:../dependency-extraction-webpack-plugin",
@@ -56258,7 +56421,7 @@
 				"copy-webpack-plugin": "^10.2.0",
 				"cross-spawn": "^5.1.0",
 				"css-loader": "^6.2.0",
-				"cssnano": "^5.0.7",
+				"cssnano": "^6.0.1",
 				"cwd": "^0.10.0",
 				"dir-glob": "^3.0.1",
 				"eslint": "^8.3.0",
@@ -57685,12 +57848,12 @@
 			}
 		},
 		"@babel/plugin-transform-react-constant-elements": {
-			"version": "7.16.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-constant-elements/-/plugin-transform-react-constant-elements-7.16.7.tgz",
-			"integrity": "sha512-lF+cfsyTgwWkcw715J88JhMYJ5GpysYNLhLP1PkvkhTRN7B3e74R/1KsDxFxhRpSn0UUD3IWM4GvdBR2PEbbQQ==",
+			"version": "7.22.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-constant-elements/-/plugin-transform-react-constant-elements-7.22.5.tgz",
+			"integrity": "sha512-BF5SXoO+nX3h5OhlN78XbbDrBOffv+AxPP2ENaJOVqjWCgBDeOY3WcaUcddutGSfoap+5NEQ/q/4I3WZIvgkXA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.16.7"
+				"@babel/helper-plugin-utils": "^7.22.5"
 			}
 		},
 		"@babel/plugin-transform-react-display-name": {
@@ -65577,143 +65740,376 @@
 			}
 		},
 		"@svgr/babel-plugin-add-jsx-attribute": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/@svgr/babel-plugin-add-jsx-attribute/-/babel-plugin-add-jsx-attribute-6.0.0.tgz",
-			"integrity": "sha512-MdPdhdWLtQsjd29Wa4pABdhWbaRMACdM1h31BY+c6FghTZqNGT7pEYdBoaGeKtdTOBC/XNFQaKVj+r/Ei2ryWA==",
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@svgr/babel-plugin-add-jsx-attribute/-/babel-plugin-add-jsx-attribute-8.0.0.tgz",
+			"integrity": "sha512-b9MIk7yhdS1pMCZM8VeNfUlSKVRhsHZNMl5O9SfaX0l0t5wjdgu4IDzGB8bpnGBBOjGST3rRFVsaaEtI4W6f7g==",
 			"dev": true
 		},
 		"@svgr/babel-plugin-remove-jsx-attribute": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/@svgr/babel-plugin-remove-jsx-attribute/-/babel-plugin-remove-jsx-attribute-6.0.0.tgz",
-			"integrity": "sha512-aVdtfx9jlaaxc3unA6l+M9YRnKIZjOhQPthLKqmTXC8UVkBLDRGwPKo+r8n3VZN8B34+yVajzPTZ+ptTSuZZCw==",
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@svgr/babel-plugin-remove-jsx-attribute/-/babel-plugin-remove-jsx-attribute-8.0.0.tgz",
+			"integrity": "sha512-BcCkm/STipKvbCl6b7QFrMh/vx00vIP63k2eM66MfHJzPr6O2U0jYEViXkHJWqXqQYjdeA9cuCl5KWmlwjDvbA==",
 			"dev": true
 		},
 		"@svgr/babel-plugin-remove-jsx-empty-expression": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/@svgr/babel-plugin-remove-jsx-empty-expression/-/babel-plugin-remove-jsx-empty-expression-6.0.0.tgz",
-			"integrity": "sha512-Ccj42ApsePD451AZJJf1QzTD1B/BOU392URJTeXFxSK709i0KUsGtbwyiqsKu7vsYxpTM0IA5clAKDyf9RCZyA==",
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@svgr/babel-plugin-remove-jsx-empty-expression/-/babel-plugin-remove-jsx-empty-expression-8.0.0.tgz",
+			"integrity": "sha512-5BcGCBfBxB5+XSDSWnhTThfI9jcO5f0Ai2V24gZpG+wXF14BzwxxdDb4g6trdOux0rhibGs385BeFMSmxtS3uA==",
 			"dev": true
 		},
 		"@svgr/babel-plugin-replace-jsx-attribute-value": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/@svgr/babel-plugin-replace-jsx-attribute-value/-/babel-plugin-replace-jsx-attribute-value-6.0.0.tgz",
-			"integrity": "sha512-88V26WGyt1Sfd1emBYmBJRWMmgarrExpKNVmI9vVozha4kqs6FzQJ/Kp5+EYli1apgX44518/0+t9+NU36lThQ==",
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@svgr/babel-plugin-replace-jsx-attribute-value/-/babel-plugin-replace-jsx-attribute-value-8.0.0.tgz",
+			"integrity": "sha512-KVQ+PtIjb1BuYT3ht8M5KbzWBhdAjjUPdlMtpuw/VjT8coTrItWX6Qafl9+ji831JaJcu6PJNKCV0bp01lBNzQ==",
 			"dev": true
 		},
 		"@svgr/babel-plugin-svg-dynamic-title": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/@svgr/babel-plugin-svg-dynamic-title/-/babel-plugin-svg-dynamic-title-6.0.0.tgz",
-			"integrity": "sha512-F7YXNLfGze+xv0KMQxrl2vkNbI9kzT9oDK55/kUuymh1ACyXkMV+VZWX1zEhSTfEKh7VkHVZGmVtHg8eTZ6PRg==",
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@svgr/babel-plugin-svg-dynamic-title/-/babel-plugin-svg-dynamic-title-8.0.0.tgz",
+			"integrity": "sha512-omNiKqwjNmOQJ2v6ge4SErBbkooV2aAWwaPFs2vUY7p7GhVkzRkJ00kILXQvRhA6miHnNpXv7MRnnSjdRjK8og==",
 			"dev": true
 		},
 		"@svgr/babel-plugin-svg-em-dimensions": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/@svgr/babel-plugin-svg-em-dimensions/-/babel-plugin-svg-em-dimensions-6.0.0.tgz",
-			"integrity": "sha512-+rghFXxdIqJNLQK08kwPBD3Z22/0b2tEZ9lKiL/yTfuyj1wW8HUXu4bo/XkogATIYuXSghVQOOCwURXzHGKyZA==",
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@svgr/babel-plugin-svg-em-dimensions/-/babel-plugin-svg-em-dimensions-8.0.0.tgz",
+			"integrity": "sha512-mURHYnu6Iw3UBTbhGwE/vsngtCIbHE43xCRK7kCw4t01xyGqb2Pd+WXekRRoFOBIY29ZoOhUCTEweDMdrjfi9g==",
 			"dev": true
 		},
 		"@svgr/babel-plugin-transform-react-native-svg": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/@svgr/babel-plugin-transform-react-native-svg/-/babel-plugin-transform-react-native-svg-6.0.0.tgz",
-			"integrity": "sha512-VaphyHZ+xIKv5v0K0HCzyfAaLhPGJXSk2HkpYfXIOKb7DjLBv0soHDxNv6X0vr2titsxE7klb++u7iOf7TSrFQ==",
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@svgr/babel-plugin-transform-react-native-svg/-/babel-plugin-transform-react-native-svg-8.0.0.tgz",
+			"integrity": "sha512-UKrY3860AQICgH7g+6h2zkoxeVEPLYwX/uAjmqo4PIq2FIHppwhIqZstIyTz0ZtlwreKR41O3W3BzsBBiJV2Aw==",
 			"dev": true
 		},
 		"@svgr/babel-plugin-transform-svg-component": {
-			"version": "6.2.0",
-			"resolved": "https://registry.npmjs.org/@svgr/babel-plugin-transform-svg-component/-/babel-plugin-transform-svg-component-6.2.0.tgz",
-			"integrity": "sha512-bhYIpsORb++wpsp91fymbFkf09Z/YEKR0DnFjxvN+8JHeCUD2unnh18jIMKnDJTWtvpTaGYPXELVe4OOzFI0xg==",
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@svgr/babel-plugin-transform-svg-component/-/babel-plugin-transform-svg-component-8.0.0.tgz",
+			"integrity": "sha512-DFx8xa3cZXTdb/k3kfPeaixecQLgKh5NVBMwD0AQxOzcZawK4oo1Jh9LbrcACUivsCA7TLG8eeWgrDXjTMhRmw==",
 			"dev": true
 		},
 		"@svgr/babel-preset": {
-			"version": "6.2.0",
-			"resolved": "https://registry.npmjs.org/@svgr/babel-preset/-/babel-preset-6.2.0.tgz",
-			"integrity": "sha512-4WQNY0J71JIaL03DRn0vLiz87JXx0b9dYm2aA8XHlQJQoixMl4r/soYHm8dsaJZ3jWtkCiOYy48dp9izvXhDkQ==",
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@svgr/babel-preset/-/babel-preset-8.0.0.tgz",
+			"integrity": "sha512-KLcjiZychInVrhs86OvcYPLTFu9L5XV2vj0XAaE1HwE3J3jLmIzRY8ttdeAg/iFyp8nhavJpafpDZTt+1LIpkQ==",
 			"dev": true,
 			"requires": {
-				"@svgr/babel-plugin-add-jsx-attribute": "^6.0.0",
-				"@svgr/babel-plugin-remove-jsx-attribute": "^6.0.0",
-				"@svgr/babel-plugin-remove-jsx-empty-expression": "^6.0.0",
-				"@svgr/babel-plugin-replace-jsx-attribute-value": "^6.0.0",
-				"@svgr/babel-plugin-svg-dynamic-title": "^6.0.0",
-				"@svgr/babel-plugin-svg-em-dimensions": "^6.0.0",
-				"@svgr/babel-plugin-transform-react-native-svg": "^6.0.0",
-				"@svgr/babel-plugin-transform-svg-component": "^6.2.0"
+				"@svgr/babel-plugin-add-jsx-attribute": "8.0.0",
+				"@svgr/babel-plugin-remove-jsx-attribute": "8.0.0",
+				"@svgr/babel-plugin-remove-jsx-empty-expression": "8.0.0",
+				"@svgr/babel-plugin-replace-jsx-attribute-value": "8.0.0",
+				"@svgr/babel-plugin-svg-dynamic-title": "8.0.0",
+				"@svgr/babel-plugin-svg-em-dimensions": "8.0.0",
+				"@svgr/babel-plugin-transform-react-native-svg": "8.0.0",
+				"@svgr/babel-plugin-transform-svg-component": "8.0.0"
 			}
 		},
 		"@svgr/core": {
-			"version": "6.2.1",
-			"resolved": "https://registry.npmjs.org/@svgr/core/-/core-6.2.1.tgz",
-			"integrity": "sha512-NWufjGI2WUyrg46mKuySfviEJ6IxHUOm/8a3Ph38VCWSp+83HBraCQrpEM3F3dB6LBs5x8OElS8h3C0oOJaJAA==",
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@svgr/core/-/core-8.0.0.tgz",
+			"integrity": "sha512-aJKtc+Pie/rFYsVH/unSkDaZGvEeylNv/s2cP+ta9/rYWxRVvoV/S4Qw65Kmrtah4CBK5PM6ISH9qUH7IJQCng==",
 			"dev": true,
 			"requires": {
-				"@svgr/plugin-jsx": "^6.2.1",
+				"@babel/core": "^7.21.3",
+				"@svgr/babel-preset": "8.0.0",
 				"camelcase": "^6.2.0",
-				"cosmiconfig": "^7.0.1"
+				"cosmiconfig": "^8.1.3",
+				"snake-case": "^3.0.4"
 			},
 			"dependencies": {
+				"@babel/core": {
+					"version": "7.22.10",
+					"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.22.10.tgz",
+					"integrity": "sha512-fTmqbbUBAwCcre6zPzNngvsI0aNrPZe77AeqvDxWM9Nm+04RrJ3CAmGHA9f7lJQY6ZMhRztNemy4uslDxTX4Qw==",
+					"dev": true,
+					"requires": {
+						"@ampproject/remapping": "^2.2.0",
+						"@babel/code-frame": "^7.22.10",
+						"@babel/generator": "^7.22.10",
+						"@babel/helper-compilation-targets": "^7.22.10",
+						"@babel/helper-module-transforms": "^7.22.9",
+						"@babel/helpers": "^7.22.10",
+						"@babel/parser": "^7.22.10",
+						"@babel/template": "^7.22.5",
+						"@babel/traverse": "^7.22.10",
+						"@babel/types": "^7.22.10",
+						"convert-source-map": "^1.7.0",
+						"debug": "^4.1.0",
+						"gensync": "^1.0.0-beta.2",
+						"json5": "^2.2.2",
+						"semver": "^6.3.1"
+					}
+				},
+				"@babel/traverse": {
+					"version": "7.22.10",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.22.10.tgz",
+					"integrity": "sha512-Q/urqV4pRByiNNpb/f5OSv28ZlGJiFiiTh+GAHktbIrkPhPbl90+uW6SmpoLyZqutrg9AEaEf3Q/ZBRHBXgxig==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.22.10",
+						"@babel/generator": "^7.22.10",
+						"@babel/helper-environment-visitor": "^7.22.5",
+						"@babel/helper-function-name": "^7.22.5",
+						"@babel/helper-hoist-variables": "^7.22.5",
+						"@babel/helper-split-export-declaration": "^7.22.6",
+						"@babel/parser": "^7.22.10",
+						"@babel/types": "^7.22.10",
+						"debug": "^4.1.0",
+						"globals": "^11.1.0"
+					}
+				},
+				"argparse": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+					"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+					"dev": true
+				},
 				"camelcase": {
 					"version": "6.3.0",
 					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
 					"integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
 					"dev": true
+				},
+				"cosmiconfig": {
+					"version": "8.2.0",
+					"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.2.0.tgz",
+					"integrity": "sha512-3rTMnFJA1tCOPwRxtgF4wd7Ab2qvDbL8jX+3smjIbS4HlZBagTlpERbdN7iAbWlrfxE3M8c27kTwTawQ7st+OQ==",
+					"dev": true,
+					"requires": {
+						"import-fresh": "^3.2.1",
+						"js-yaml": "^4.1.0",
+						"parse-json": "^5.0.0",
+						"path-type": "^4.0.0"
+					}
+				},
+				"globals": {
+					"version": "11.12.0",
+					"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+					"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+					"dev": true
+				},
+				"js-yaml": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+					"integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+					"dev": true,
+					"requires": {
+						"argparse": "^2.0.1"
+					}
+				},
+				"path-type": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+					"integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+					"dev": true
+				},
+				"semver": {
+					"version": "6.3.1",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+					"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+					"dev": true
 				}
 			}
 		},
 		"@svgr/hast-util-to-babel-ast": {
-			"version": "6.2.1",
-			"resolved": "https://registry.npmjs.org/@svgr/hast-util-to-babel-ast/-/hast-util-to-babel-ast-6.2.1.tgz",
-			"integrity": "sha512-pt7MMkQFDlWJVy9ULJ1h+hZBDGFfSCwlBNW1HkLnVi7jUhyEXUaGYWi1x6bM2IXuAR9l265khBT4Av4lPmaNLQ==",
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@svgr/hast-util-to-babel-ast/-/hast-util-to-babel-ast-8.0.0.tgz",
+			"integrity": "sha512-EbDKwO9GpfWP4jN9sGdYwPBU0kdomaPIL2Eu4YwmgP+sJeXT+L7bMwJUBnhzfH8Q2qMBqZ4fJwpCyYsAN3mt2Q==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.15.6",
-				"entities": "^3.0.1"
+				"@babel/types": "^7.21.3",
+				"entities": "^4.4.0"
 			},
 			"dependencies": {
 				"entities": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/entities/-/entities-3.0.1.tgz",
-					"integrity": "sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q==",
+					"version": "4.5.0",
+					"resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+					"integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
 					"dev": true
 				}
 			}
 		},
 		"@svgr/plugin-jsx": {
-			"version": "6.2.1",
-			"resolved": "https://registry.npmjs.org/@svgr/plugin-jsx/-/plugin-jsx-6.2.1.tgz",
-			"integrity": "sha512-u+MpjTsLaKo6r3pHeeSVsh9hmGRag2L7VzApWIaS8imNguqoUwDq/u6U/NDmYs/KAsrmtBjOEaAAPbwNGXXp1g==",
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@svgr/plugin-jsx/-/plugin-jsx-8.0.1.tgz",
+			"integrity": "sha512-bfCFb+4ZsM3UuKP2t7KmDwn6YV8qVn9HIQJmau6xeQb/iV65Rpi7NBNBWA2hcCd4GKoCqG8hpaaDk5FDR0eH+g==",
 			"dev": true,
 			"requires": {
-				"@babel/core": "^7.15.5",
-				"@svgr/babel-preset": "^6.2.0",
-				"@svgr/hast-util-to-babel-ast": "^6.2.1",
-				"svg-parser": "^2.0.2"
+				"@babel/core": "^7.21.3",
+				"@svgr/babel-preset": "8.0.0",
+				"@svgr/hast-util-to-babel-ast": "8.0.0",
+				"svg-parser": "^2.0.4"
+			},
+			"dependencies": {
+				"@babel/core": {
+					"version": "7.22.10",
+					"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.22.10.tgz",
+					"integrity": "sha512-fTmqbbUBAwCcre6zPzNngvsI0aNrPZe77AeqvDxWM9Nm+04RrJ3CAmGHA9f7lJQY6ZMhRztNemy4uslDxTX4Qw==",
+					"dev": true,
+					"requires": {
+						"@ampproject/remapping": "^2.2.0",
+						"@babel/code-frame": "^7.22.10",
+						"@babel/generator": "^7.22.10",
+						"@babel/helper-compilation-targets": "^7.22.10",
+						"@babel/helper-module-transforms": "^7.22.9",
+						"@babel/helpers": "^7.22.10",
+						"@babel/parser": "^7.22.10",
+						"@babel/template": "^7.22.5",
+						"@babel/traverse": "^7.22.10",
+						"@babel/types": "^7.22.10",
+						"convert-source-map": "^1.7.0",
+						"debug": "^4.1.0",
+						"gensync": "^1.0.0-beta.2",
+						"json5": "^2.2.2",
+						"semver": "^6.3.1"
+					}
+				},
+				"@babel/traverse": {
+					"version": "7.22.10",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.22.10.tgz",
+					"integrity": "sha512-Q/urqV4pRByiNNpb/f5OSv28ZlGJiFiiTh+GAHktbIrkPhPbl90+uW6SmpoLyZqutrg9AEaEf3Q/ZBRHBXgxig==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.22.10",
+						"@babel/generator": "^7.22.10",
+						"@babel/helper-environment-visitor": "^7.22.5",
+						"@babel/helper-function-name": "^7.22.5",
+						"@babel/helper-hoist-variables": "^7.22.5",
+						"@babel/helper-split-export-declaration": "^7.22.6",
+						"@babel/parser": "^7.22.10",
+						"@babel/types": "^7.22.10",
+						"debug": "^4.1.0",
+						"globals": "^11.1.0"
+					}
+				},
+				"globals": {
+					"version": "11.12.0",
+					"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+					"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+					"dev": true
+				},
+				"semver": {
+					"version": "6.3.1",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+					"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+					"dev": true
+				}
 			}
 		},
 		"@svgr/plugin-svgo": {
-			"version": "6.2.0",
-			"resolved": "https://registry.npmjs.org/@svgr/plugin-svgo/-/plugin-svgo-6.2.0.tgz",
-			"integrity": "sha512-oDdMQONKOJEbuKwuy4Np6VdV6qoaLLvoY86hjvQEgU82Vx1MSWRyYms6Sl0f+NtqxLI/rDVufATbP/ev996k3Q==",
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@svgr/plugin-svgo/-/plugin-svgo-8.0.1.tgz",
+			"integrity": "sha512-29OJ1QmJgnohQHDAgAuY2h21xWD6TZiXji+hnx+W635RiXTAlHTbjrZDktfqzkN0bOeQEtNe+xgq73/XeWFfSg==",
 			"dev": true,
 			"requires": {
-				"cosmiconfig": "^7.0.1",
-				"deepmerge": "^4.2.2",
-				"svgo": "^2.5.0"
+				"cosmiconfig": "^8.1.3",
+				"deepmerge": "^4.3.1",
+				"svgo": "^3.0.2"
+			},
+			"dependencies": {
+				"argparse": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+					"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+					"dev": true
+				},
+				"cosmiconfig": {
+					"version": "8.2.0",
+					"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.2.0.tgz",
+					"integrity": "sha512-3rTMnFJA1tCOPwRxtgF4wd7Ab2qvDbL8jX+3smjIbS4HlZBagTlpERbdN7iAbWlrfxE3M8c27kTwTawQ7st+OQ==",
+					"dev": true,
+					"requires": {
+						"import-fresh": "^3.2.1",
+						"js-yaml": "^4.1.0",
+						"parse-json": "^5.0.0",
+						"path-type": "^4.0.0"
+					}
+				},
+				"js-yaml": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+					"integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+					"dev": true,
+					"requires": {
+						"argparse": "^2.0.1"
+					}
+				},
+				"path-type": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+					"integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+					"dev": true
+				}
 			}
 		},
 		"@svgr/webpack": {
-			"version": "6.2.1",
-			"resolved": "https://registry.npmjs.org/@svgr/webpack/-/webpack-6.2.1.tgz",
-			"integrity": "sha512-h09ngMNd13hnePwgXa+Y5CgOjzlCvfWLHg+MBnydEedAnuLRzUHUJmGS3o2OsrhxTOOqEsPOFt5v/f6C5Qulcw==",
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@svgr/webpack/-/webpack-8.0.1.tgz",
+			"integrity": "sha512-zSoeKcbCmfMXjA11uDuCJb+1LWNb3vy6Qw/VHj0Nfcl3UuqwuoZWknHsBIhCWvi4wU9vPui3aq054qjVyZqY4A==",
 			"dev": true,
 			"requires": {
-				"@babel/core": "^7.15.5",
-				"@babel/plugin-transform-react-constant-elements": "^7.14.5",
-				"@babel/preset-env": "^7.15.6",
-				"@babel/preset-react": "^7.14.5",
-				"@babel/preset-typescript": "^7.15.0",
-				"@svgr/core": "^6.2.1",
-				"@svgr/plugin-jsx": "^6.2.1",
-				"@svgr/plugin-svgo": "^6.2.0"
+				"@babel/core": "^7.21.3",
+				"@babel/plugin-transform-react-constant-elements": "^7.21.3",
+				"@babel/preset-env": "^7.20.2",
+				"@babel/preset-react": "^7.18.6",
+				"@babel/preset-typescript": "^7.21.0",
+				"@svgr/core": "8.0.0",
+				"@svgr/plugin-jsx": "8.0.1",
+				"@svgr/plugin-svgo": "8.0.1"
+			},
+			"dependencies": {
+				"@babel/core": {
+					"version": "7.22.10",
+					"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.22.10.tgz",
+					"integrity": "sha512-fTmqbbUBAwCcre6zPzNngvsI0aNrPZe77AeqvDxWM9Nm+04RrJ3CAmGHA9f7lJQY6ZMhRztNemy4uslDxTX4Qw==",
+					"dev": true,
+					"requires": {
+						"@ampproject/remapping": "^2.2.0",
+						"@babel/code-frame": "^7.22.10",
+						"@babel/generator": "^7.22.10",
+						"@babel/helper-compilation-targets": "^7.22.10",
+						"@babel/helper-module-transforms": "^7.22.9",
+						"@babel/helpers": "^7.22.10",
+						"@babel/parser": "^7.22.10",
+						"@babel/template": "^7.22.5",
+						"@babel/traverse": "^7.22.10",
+						"@babel/types": "^7.22.10",
+						"convert-source-map": "^1.7.0",
+						"debug": "^4.1.0",
+						"gensync": "^1.0.0-beta.2",
+						"json5": "^2.2.2",
+						"semver": "^6.3.1"
+					}
+				},
+				"@babel/traverse": {
+					"version": "7.22.10",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.22.10.tgz",
+					"integrity": "sha512-Q/urqV4pRByiNNpb/f5OSv28ZlGJiFiiTh+GAHktbIrkPhPbl90+uW6SmpoLyZqutrg9AEaEf3Q/ZBRHBXgxig==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.22.10",
+						"@babel/generator": "^7.22.10",
+						"@babel/helper-environment-visitor": "^7.22.5",
+						"@babel/helper-function-name": "^7.22.5",
+						"@babel/helper-hoist-variables": "^7.22.5",
+						"@babel/helper-split-export-declaration": "^7.22.6",
+						"@babel/parser": "^7.22.10",
+						"@babel/types": "^7.22.10",
+						"debug": "^4.1.0",
+						"globals": "^11.1.0"
+					}
+				},
+				"globals": {
+					"version": "11.12.0",
+					"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+					"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+					"dev": true
+				},
+				"semver": {
+					"version": "6.3.1",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+					"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+					"dev": true
+				}
 			}
 		},
 		"@swc/core": {
@@ -68365,7 +68761,7 @@
 			"requires": {
 				"@babel/core": "^7.16.0",
 				"@pmmmwh/react-refresh-webpack-plugin": "^0.5.2",
-				"@svgr/webpack": "^6.2.1",
+				"@svgr/webpack": "^8.0.1",
 				"@wordpress/babel-preset-default": "file:../babel-preset-default",
 				"@wordpress/browserslist-config": "file:../browserslist-config",
 				"@wordpress/dependency-extraction-webpack-plugin": "file:../dependency-extraction-webpack-plugin",
@@ -68385,7 +68781,7 @@
 				"copy-webpack-plugin": "^10.2.0",
 				"cross-spawn": "^5.1.0",
 				"css-loader": "^6.2.0",
-				"cssnano": "^5.0.7",
+				"cssnano": "^6.0.1",
 				"cwd": "^0.10.0",
 				"dir-glob": "^3.0.1",
 				"eslint": "^8.3.0",
@@ -68779,12 +69175,6 @@
 			"version": "3.5.2",
 			"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
 			"integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-			"dev": true
-		},
-		"alphanum-sort": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz",
-			"integrity": "sha1-l6ERlkmyEa0zaR2fn0hqjsn74KM=",
 			"dev": true
 		},
 		"anser": {
@@ -78672,20 +79062,11 @@
 			"resolved": "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz",
 			"integrity": "sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg=="
 		},
-		"css-color-names": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/css-color-names/-/css-color-names-1.0.1.tgz",
-			"integrity": "sha512-/loXYOch1qU1biStIFsHH8SxTmOseh1IJqFvy8IujXOm1h+QjUdDhkzOrR5HG8K8mlxREj0yfi8ewCHx0eMxzA==",
-			"dev": true
-		},
 		"css-declaration-sorter": {
-			"version": "6.1.1",
-			"resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-6.1.1.tgz",
-			"integrity": "sha512-BZ1aOuif2Sb7tQYY1GeCjG7F++8ggnwUkH5Ictw0mrdpqpEd+zWmcPdstnH2TItlb74FqR0DrVEieon221T/1Q==",
-			"dev": true,
-			"requires": {
-				"timsort": "^0.3.0"
-			}
+			"version": "6.4.1",
+			"resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-6.4.1.tgz",
+			"integrity": "sha512-rtdthzxKuyq6IzqX6jEcIzQF/YqccluefyCYheovBOLhFT/drQA9zj/UbRAa9J7C0o6EG6u3E6g+vKkay7/k3g==",
+			"dev": true
 		},
 		"css-loader": {
 			"version": "6.2.0",
@@ -78815,67 +79196,89 @@
 			"dev": true
 		},
 		"cssnano": {
-			"version": "5.0.7",
-			"resolved": "https://registry.npmjs.org/cssnano/-/cssnano-5.0.7.tgz",
-			"integrity": "sha512-7C0tbb298hef3rq+TtBbMuezBQ9VrFtrQEsPNuBKNVgWny/67vdRsnq8EoNu7TRjAHURgYvWlRIpCUmcMZkRzw==",
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/cssnano/-/cssnano-6.0.1.tgz",
+			"integrity": "sha512-fVO1JdJ0LSdIGJq68eIxOqFpIJrZqXUsBt8fkrBcztCQqAjQD51OhZp7tc0ImcbwXD4k7ny84QTV90nZhmqbkg==",
 			"dev": true,
 			"requires": {
-				"cssnano-preset-default": "^5.1.3",
-				"is-resolvable": "^1.1.0",
-				"lilconfig": "^2.0.3",
-				"yaml": "^1.10.2"
+				"cssnano-preset-default": "^6.0.1",
+				"lilconfig": "^2.1.0"
 			}
 		},
 		"cssnano-preset-default": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/cssnano-preset-default/-/cssnano-preset-default-5.1.3.tgz",
-			"integrity": "sha512-qo9tX+t4yAAZ/yagVV3b+QBKeLklQbmgR3wI7mccrDcR+bEk9iHgZN1E7doX68y9ThznLya3RDmR+nc7l6/2WQ==",
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/cssnano-preset-default/-/cssnano-preset-default-6.0.1.tgz",
+			"integrity": "sha512-7VzyFZ5zEB1+l1nToKyrRkuaJIx0zi/1npjvZfbBwbtNTzhLtlvYraK/7/uqmX2Wb2aQtd983uuGw79jAjLSuQ==",
 			"dev": true,
 			"requires": {
-				"css-declaration-sorter": "^6.0.3",
-				"cssnano-utils": "^2.0.1",
-				"postcss-calc": "^8.0.0",
-				"postcss-colormin": "^5.2.0",
-				"postcss-convert-values": "^5.0.1",
-				"postcss-discard-comments": "^5.0.1",
-				"postcss-discard-duplicates": "^5.0.1",
-				"postcss-discard-empty": "^5.0.1",
-				"postcss-discard-overridden": "^5.0.1",
-				"postcss-merge-longhand": "^5.0.2",
-				"postcss-merge-rules": "^5.0.2",
-				"postcss-minify-font-values": "^5.0.1",
-				"postcss-minify-gradients": "^5.0.1",
-				"postcss-minify-params": "^5.0.1",
-				"postcss-minify-selectors": "^5.1.0",
-				"postcss-normalize-charset": "^5.0.1",
-				"postcss-normalize-display-values": "^5.0.1",
-				"postcss-normalize-positions": "^5.0.1",
-				"postcss-normalize-repeat-style": "^5.0.1",
-				"postcss-normalize-string": "^5.0.1",
-				"postcss-normalize-timing-functions": "^5.0.1",
-				"postcss-normalize-unicode": "^5.0.1",
-				"postcss-normalize-url": "^5.0.2",
-				"postcss-normalize-whitespace": "^5.0.1",
-				"postcss-ordered-values": "^5.0.2",
-				"postcss-reduce-initial": "^5.0.1",
-				"postcss-reduce-transforms": "^5.0.1",
-				"postcss-svgo": "^5.0.2",
-				"postcss-unique-selectors": "^5.0.1"
+				"css-declaration-sorter": "^6.3.1",
+				"cssnano-utils": "^4.0.0",
+				"postcss-calc": "^9.0.0",
+				"postcss-colormin": "^6.0.0",
+				"postcss-convert-values": "^6.0.0",
+				"postcss-discard-comments": "^6.0.0",
+				"postcss-discard-duplicates": "^6.0.0",
+				"postcss-discard-empty": "^6.0.0",
+				"postcss-discard-overridden": "^6.0.0",
+				"postcss-merge-longhand": "^6.0.0",
+				"postcss-merge-rules": "^6.0.1",
+				"postcss-minify-font-values": "^6.0.0",
+				"postcss-minify-gradients": "^6.0.0",
+				"postcss-minify-params": "^6.0.0",
+				"postcss-minify-selectors": "^6.0.0",
+				"postcss-normalize-charset": "^6.0.0",
+				"postcss-normalize-display-values": "^6.0.0",
+				"postcss-normalize-positions": "^6.0.0",
+				"postcss-normalize-repeat-style": "^6.0.0",
+				"postcss-normalize-string": "^6.0.0",
+				"postcss-normalize-timing-functions": "^6.0.0",
+				"postcss-normalize-unicode": "^6.0.0",
+				"postcss-normalize-url": "^6.0.0",
+				"postcss-normalize-whitespace": "^6.0.0",
+				"postcss-ordered-values": "^6.0.0",
+				"postcss-reduce-initial": "^6.0.0",
+				"postcss-reduce-transforms": "^6.0.0",
+				"postcss-svgo": "^6.0.0",
+				"postcss-unique-selectors": "^6.0.0"
 			}
 		},
 		"cssnano-utils": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/cssnano-utils/-/cssnano-utils-2.0.1.tgz",
-			"integrity": "sha512-i8vLRZTnEH9ubIyfdZCAdIdgnHAUeQeByEeQ2I7oTilvP9oHO6RScpeq3GsFUVqeB8uZgOQ9pw8utofNn32hhQ==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/cssnano-utils/-/cssnano-utils-4.0.0.tgz",
+			"integrity": "sha512-Z39TLP+1E0KUcd7LGyF4qMfu8ZufI0rDzhdyAMsa/8UyNUU8wpS0fhdBxbQbv32r64ea00h4878gommRVg2BHw==",
 			"dev": true
 		},
 		"csso": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/csso/-/csso-4.2.0.tgz",
-			"integrity": "sha512-wvlcdIbf6pwKEk7vHj8/Bkc0B4ylXZruLvOgs9doS5eOsOpuodOV2zJChSpkp+pRpYQLQMeF04nr3Z68Sta9jA==",
+			"version": "5.0.5",
+			"resolved": "https://registry.npmjs.org/csso/-/csso-5.0.5.tgz",
+			"integrity": "sha512-0LrrStPOdJj+SPCCrGhzryycLjwcgUSHBtxNA8aIDxf0GLsRh1cKYhB00Gd1lDOS4yGH69+SNn13+TWbVHETFQ==",
 			"dev": true,
 			"requires": {
-				"css-tree": "^1.1.2"
+				"css-tree": "~2.2.0"
+			},
+			"dependencies": {
+				"css-tree": {
+					"version": "2.2.1",
+					"resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.2.1.tgz",
+					"integrity": "sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA==",
+					"dev": true,
+					"requires": {
+						"mdn-data": "2.0.28",
+						"source-map-js": "^1.0.1"
+					}
+				},
+				"mdn-data": {
+					"version": "2.0.28",
+					"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.28.tgz",
+					"integrity": "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g==",
+					"dev": true
+				},
+				"source-map-js": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
+					"integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
+					"dev": true
+				}
 			}
 		},
 		"cssom": {
@@ -82881,12 +83284,6 @@
 				}
 			}
 		},
-		"hex-color-regex": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/hex-color-regex/-/hex-color-regex-1.1.0.tgz",
-			"integrity": "sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ==",
-			"dev": true
-		},
 		"highlight-words-core": {
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/highlight-words-core/-/highlight-words-core-1.2.2.tgz",
@@ -82970,18 +83367,6 @@
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/hpq/-/hpq-1.3.0.tgz",
 			"integrity": "sha512-fvYTvdCFOWQupGxqkahrkA+ERBuMdzkxwtUdKrxR6rmMd4Pfl+iZ1QiQYoaZ0B/v0y59MOMnz3XFUWbT50/NWA=="
-		},
-		"hsl-regex": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/hsl-regex/-/hsl-regex-1.0.0.tgz",
-			"integrity": "sha1-1JMwx4ntgZ4nakwNJy3/owsY/m4=",
-			"dev": true
-		},
-		"hsla-regex": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/hsla-regex/-/hsla-regex-1.0.0.tgz",
-			"integrity": "sha1-wc56MWjIxmFAM6S194d/OyJfnDg=",
-			"dev": true
 		},
 		"html-encoding-sniffer": {
 			"version": "3.0.0",
@@ -83820,28 +84205,6 @@
 				}
 			}
 		},
-		"is-color-stop": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/is-color-stop/-/is-color-stop-1.1.0.tgz",
-			"integrity": "sha1-z/9HGu5N1cnhWFmPvhKWe1za00U=",
-			"dev": true,
-			"requires": {
-				"css-color-names": "^0.0.4",
-				"hex-color-regex": "^1.1.0",
-				"hsl-regex": "^1.0.0",
-				"hsla-regex": "^1.0.0",
-				"rgb-regex": "^1.0.1",
-				"rgba-regex": "^1.0.0"
-			},
-			"dependencies": {
-				"css-color-names": {
-					"version": "0.0.4",
-					"resolved": "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.4.tgz",
-					"integrity": "sha512-zj5D7X1U2h2zsXOAM8EyUREBnnts6H+Jm+d1M2DbiQQcUtnqgQsMrdo8JW9R80YFUmIdBZeMu5wvYM7hcgWP/Q==",
-					"dev": true
-				}
-			}
-		},
 		"is-core-module": {
 			"version": "2.13.0",
 			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.0.tgz",
@@ -84115,12 +84478,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
 			"integrity": "sha512-7zjFAPO4/gwyQAAgRRmqeEeyIICSdmCqa3tsVHMdBzaXXRiqopZL4Cyghg/XulGWrtABTpbnYYzzIRffLkP4oA==",
-			"dev": true
-		},
-		"is-resolvable": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
-			"integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==",
 			"dev": true
 		},
 		"is-shared-array-buffer": {
@@ -86750,9 +87107,9 @@
 			}
 		},
 		"lilconfig": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.0.3.tgz",
-			"integrity": "sha512-EHKqr/+ZvdKCifpNrJCKxBTgk5XupZA3y/aCPY9mxfgBzmgh93Mt/WqjjQ38oMxXuvDokaKiM3lAgvSH2sjtHg==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.1.0.tgz",
+			"integrity": "sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==",
 			"dev": true
 		},
 		"line-height": {
@@ -92456,13 +92813,13 @@
 			}
 		},
 		"postcss-calc": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-8.0.0.tgz",
-			"integrity": "sha512-5NglwDrcbiy8XXfPM11F3HeC6hoT9W7GUH/Zi5U/p7u3Irv4rHhdDcIZwG0llHXV4ftsBjpfWMXAnXNl4lnt8g==",
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-9.0.1.tgz",
+			"integrity": "sha512-TipgjGyzP5QzEhsOZUaIkeO5mKeMFpebWzRogWG/ysonUlnHcq5aJe0jOjpfzUU8PeSaBQnrE8ehR0QA5vs8PQ==",
 			"dev": true,
 			"requires": {
-				"postcss-selector-parser": "^6.0.2",
-				"postcss-value-parser": "^4.0.2"
+				"postcss-selector-parser": "^6.0.11",
+				"postcss-value-parser": "^4.2.0"
 			},
 			"dependencies": {
 				"postcss-value-parser": {
@@ -92474,15 +92831,15 @@
 			}
 		},
 		"postcss-colormin": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-5.2.0.tgz",
-			"integrity": "sha512-+HC6GfWU3upe5/mqmxuqYZ9B2Wl4lcoUUNkoaX59nEWV4EtADCMiBqui111Bu8R8IvaZTmqmxrqOAqjbHIwXPw==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-6.0.0.tgz",
+			"integrity": "sha512-EuO+bAUmutWoZYgHn2T1dG1pPqHU6L4TjzPlu4t1wZGXQ/fxV16xg2EJmYi0z+6r+MGV1yvpx1BHkUaRrPa2bw==",
 			"dev": true,
 			"requires": {
-				"browserslist": "^4.16.6",
+				"browserslist": "^4.21.4",
 				"caniuse-api": "^3.0.0",
-				"colord": "^2.0.1",
-				"postcss-value-parser": "^4.1.0"
+				"colord": "^2.9.1",
+				"postcss-value-parser": "^4.2.0"
 			},
 			"dependencies": {
 				"postcss-value-parser": {
@@ -92494,12 +92851,13 @@
 			}
 		},
 		"postcss-convert-values": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-5.0.1.tgz",
-			"integrity": "sha512-C3zR1Do2BkKkCgC0g3sF8TS0koF2G+mN8xxayZx3f10cIRmTaAnpgpRQZjNekTZxM2ciSPoh2IWJm0VZx8NoQg==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-6.0.0.tgz",
+			"integrity": "sha512-U5D8QhVwqT++ecmy8rnTb+RL9n/B806UVaS3m60lqle4YDFcpbS3ae5bTQIh3wOGUSDHSEtMYLs/38dNG7EYFw==",
 			"dev": true,
 			"requires": {
-				"postcss-value-parser": "^4.1.0"
+				"browserslist": "^4.21.4",
+				"postcss-value-parser": "^4.2.0"
 			},
 			"dependencies": {
 				"postcss-value-parser": {
@@ -92511,27 +92869,27 @@
 			}
 		},
 		"postcss-discard-comments": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-5.0.1.tgz",
-			"integrity": "sha512-lgZBPTDvWrbAYY1v5GYEv8fEO/WhKOu/hmZqmCYfrpD6eyDWWzAOsl2rF29lpvziKO02Gc5GJQtlpkTmakwOWg==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-6.0.0.tgz",
+			"integrity": "sha512-p2skSGqzPMZkEQvJsgnkBhCn8gI7NzRH2683EEjrIkoMiwRELx68yoUJ3q3DGSGuQ8Ug9Gsn+OuDr46yfO+eFw==",
 			"dev": true
 		},
 		"postcss-discard-duplicates": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-5.0.1.tgz",
-			"integrity": "sha512-svx747PWHKOGpAXXQkCc4k/DsWo+6bc5LsVrAsw+OU+Ibi7klFZCyX54gjYzX4TH+f2uzXjRviLARxkMurA2bA==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-6.0.0.tgz",
+			"integrity": "sha512-bU1SXIizMLtDW4oSsi5C/xHKbhLlhek/0/yCnoMQany9k3nPBq+Ctsv/9oMmyqbR96HYHxZcHyK2HR5P/mqoGA==",
 			"dev": true
 		},
 		"postcss-discard-empty": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-5.0.1.tgz",
-			"integrity": "sha512-vfU8CxAQ6YpMxV2SvMcMIyF2LX1ZzWpy0lqHDsOdaKKLQVQGVP1pzhrI9JlsO65s66uQTfkQBKBD/A5gp9STFw==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-6.0.0.tgz",
+			"integrity": "sha512-b+h1S1VT6dNhpcg+LpyiUrdnEZfICF0my7HAKgJixJLW7BnNmpRH34+uw/etf5AhOlIhIAuXApSzzDzMI9K/gQ==",
 			"dev": true
 		},
 		"postcss-discard-overridden": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-5.0.1.tgz",
-			"integrity": "sha512-Y28H7y93L2BpJhrdUR2SR2fnSsT+3TVx1NmVQLbcnZWwIUpJ7mfcTC6Za9M2PG6w8j7UQRfzxqn8jU2VwFxo3Q==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-6.0.0.tgz",
+			"integrity": "sha512-4VELwssYXDFigPYAZ8vL4yX4mUepF/oCBeeIT4OXsJPYOtvJumyz9WflmJWTfDwCUcpDR+z0zvCWBXgTx35SVw==",
 			"dev": true
 		},
 		"postcss-loader": {
@@ -92552,14 +92910,13 @@
 			"dev": true
 		},
 		"postcss-merge-longhand": {
-			"version": "5.0.2",
-			"resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-5.0.2.tgz",
-			"integrity": "sha512-BMlg9AXSI5G9TBT0Lo/H3PfUy63P84rVz3BjCFE9e9Y9RXQZD3+h3YO1kgTNsNJy7bBc1YQp8DmSnwLIW5VPcw==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-6.0.0.tgz",
+			"integrity": "sha512-4VSfd1lvGkLTLYcxFuISDtWUfFS4zXe0FpF149AyziftPFQIWxjvFSKhA4MIxMe4XM3yTDgQMbSNgzIVxChbIg==",
 			"dev": true,
 			"requires": {
-				"css-color-names": "^1.0.1",
-				"postcss-value-parser": "^4.1.0",
-				"stylehacks": "^5.0.1"
+				"postcss-value-parser": "^4.2.0",
+				"stylehacks": "^6.0.0"
 			},
 			"dependencies": {
 				"postcss-value-parser": {
@@ -92571,25 +92928,24 @@
 			}
 		},
 		"postcss-merge-rules": {
-			"version": "5.0.2",
-			"resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-5.0.2.tgz",
-			"integrity": "sha512-5K+Md7S3GwBewfB4rjDeol6V/RZ8S+v4B66Zk2gChRqLTCC8yjnHQ601omj9TKftS19OPGqZ/XzoqpzNQQLwbg==",
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-6.0.1.tgz",
+			"integrity": "sha512-a4tlmJIQo9SCjcfiCcCMg/ZCEe0XTkl/xK0XHBs955GWg9xDX3NwP9pwZ78QUOWB8/0XCjZeJn98Dae0zg6AAw==",
 			"dev": true,
 			"requires": {
-				"browserslist": "^4.16.6",
+				"browserslist": "^4.21.4",
 				"caniuse-api": "^3.0.0",
-				"cssnano-utils": "^2.0.1",
-				"postcss-selector-parser": "^6.0.5",
-				"vendors": "^1.0.3"
+				"cssnano-utils": "^4.0.0",
+				"postcss-selector-parser": "^6.0.5"
 			}
 		},
 		"postcss-minify-font-values": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-5.0.1.tgz",
-			"integrity": "sha512-7JS4qIsnqaxk+FXY1E8dHBDmraYFWmuL6cgt0T1SWGRO5bzJf8sUoelwa4P88LEWJZweHevAiDKxHlofuvtIoA==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-6.0.0.tgz",
+			"integrity": "sha512-zNRAVtyh5E8ndZEYXA4WS8ZYsAp798HiIQ1V2UF/C/munLp2r1UGHwf1+6JFu7hdEhJFN+W1WJQKBrtjhFgEnA==",
 			"dev": true,
 			"requires": {
-				"postcss-value-parser": "^4.1.0"
+				"postcss-value-parser": "^4.2.0"
 			},
 			"dependencies": {
 				"postcss-value-parser": {
@@ -92601,14 +92957,14 @@
 			}
 		},
 		"postcss-minify-gradients": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-5.0.1.tgz",
-			"integrity": "sha512-odOwBFAIn2wIv+XYRpoN2hUV3pPQlgbJ10XeXPq8UY2N+9ZG42xu45lTn/g9zZ+d70NKSQD6EOi6UiCMu3FN7g==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-6.0.0.tgz",
+			"integrity": "sha512-wO0F6YfVAR+K1xVxF53ueZJza3L+R3E6cp0VwuXJQejnNUH0DjcAFe3JEBeTY1dLwGa0NlDWueCA1VlEfiKgAA==",
 			"dev": true,
 			"requires": {
-				"cssnano-utils": "^2.0.1",
-				"is-color-stop": "^1.1.0",
-				"postcss-value-parser": "^4.1.0"
+				"colord": "^2.9.1",
+				"cssnano-utils": "^4.0.0",
+				"postcss-value-parser": "^4.2.0"
 			},
 			"dependencies": {
 				"postcss-value-parser": {
@@ -92620,16 +92976,14 @@
 			}
 		},
 		"postcss-minify-params": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-5.0.1.tgz",
-			"integrity": "sha512-4RUC4k2A/Q9mGco1Z8ODc7h+A0z7L7X2ypO1B6V8057eVK6mZ6xwz6QN64nHuHLbqbclkX1wyzRnIrdZehTEHw==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-6.0.0.tgz",
+			"integrity": "sha512-Fz/wMQDveiS0n5JPcvsMeyNXOIMrwF88n7196puSuQSWSa+/Ofc1gDOSY2xi8+A4PqB5dlYCKk/WfqKqsI+ReQ==",
 			"dev": true,
 			"requires": {
-				"alphanum-sort": "^1.0.2",
-				"browserslist": "^4.16.0",
-				"cssnano-utils": "^2.0.1",
-				"postcss-value-parser": "^4.1.0",
-				"uniqs": "^2.0.0"
+				"browserslist": "^4.21.4",
+				"cssnano-utils": "^4.0.0",
+				"postcss-value-parser": "^4.2.0"
 			},
 			"dependencies": {
 				"postcss-value-parser": {
@@ -92641,12 +92995,11 @@
 			}
 		},
 		"postcss-minify-selectors": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-5.1.0.tgz",
-			"integrity": "sha512-NzGBXDa7aPsAcijXZeagnJBKBPMYLaJJzB8CQh6ncvyl2sIndLVWfbcDi0SBjRWk5VqEjXvf8tYwzoKf4Z07og==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-6.0.0.tgz",
+			"integrity": "sha512-ec/q9JNCOC2CRDNnypipGfOhbYPuUkewGwLnbv6omue/PSASbHSU7s6uSQ0tcFRVv731oMIx8k0SP4ZX6be/0g==",
 			"dev": true,
 			"requires": {
-				"alphanum-sort": "^1.0.2",
 				"postcss-selector-parser": "^6.0.5"
 			}
 		},
@@ -92694,19 +93047,18 @@
 			}
 		},
 		"postcss-normalize-charset": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-5.0.1.tgz",
-			"integrity": "sha512-6J40l6LNYnBdPSk+BHZ8SF+HAkS4q2twe5jnocgd+xWpz/mx/5Sa32m3W1AA8uE8XaXN+eg8trIlfu8V9x61eg==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-6.0.0.tgz",
+			"integrity": "sha512-cqundwChbu8yO/gSWkuFDmKrCZ2vJzDAocheT2JTd0sFNA4HMGoKMfbk2B+J0OmO0t5GUkiAkSM5yF2rSLUjgQ==",
 			"dev": true
 		},
 		"postcss-normalize-display-values": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/postcss-normalize-display-values/-/postcss-normalize-display-values-5.0.1.tgz",
-			"integrity": "sha512-uupdvWk88kLDXi5HEyI9IaAJTE3/Djbcrqq8YgjvAVuzgVuqIk3SuJWUisT2gaJbZm1H9g5k2w1xXilM3x8DjQ==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-normalize-display-values/-/postcss-normalize-display-values-6.0.0.tgz",
+			"integrity": "sha512-Qyt5kMrvy7dJRO3OjF7zkotGfuYALETZE+4lk66sziWSPzlBEt7FrUshV6VLECkI4EN8Z863O6Nci4NXQGNzYw==",
 			"dev": true,
 			"requires": {
-				"cssnano-utils": "^2.0.1",
-				"postcss-value-parser": "^4.1.0"
+				"postcss-value-parser": "^4.2.0"
 			},
 			"dependencies": {
 				"postcss-value-parser": {
@@ -92718,12 +93070,12 @@
 			}
 		},
 		"postcss-normalize-positions": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/postcss-normalize-positions/-/postcss-normalize-positions-5.0.1.tgz",
-			"integrity": "sha512-rvzWAJai5xej9yWqlCb1OWLd9JjW2Ex2BCPzUJrbaXmtKtgfL8dBMOOMTX6TnvQMtjk3ei1Lswcs78qKO1Skrg==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-normalize-positions/-/postcss-normalize-positions-6.0.0.tgz",
+			"integrity": "sha512-mPCzhSV8+30FZyWhxi6UoVRYd3ZBJgTRly4hOkaSifo0H+pjDYcii/aVT4YE6QpOil15a5uiv6ftnY3rm0igPg==",
 			"dev": true,
 			"requires": {
-				"postcss-value-parser": "^4.1.0"
+				"postcss-value-parser": "^4.2.0"
 			},
 			"dependencies": {
 				"postcss-value-parser": {
@@ -92735,13 +93087,12 @@
 			}
 		},
 		"postcss-normalize-repeat-style": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/postcss-normalize-repeat-style/-/postcss-normalize-repeat-style-5.0.1.tgz",
-			"integrity": "sha512-syZ2itq0HTQjj4QtXZOeefomckiV5TaUO6ReIEabCh3wgDs4Mr01pkif0MeVwKyU/LHEkPJnpwFKRxqWA/7O3w==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-normalize-repeat-style/-/postcss-normalize-repeat-style-6.0.0.tgz",
+			"integrity": "sha512-50W5JWEBiOOAez2AKBh4kRFm2uhrT3O1Uwdxz7k24aKtbD83vqmcVG7zoIwo6xI2FZ/HDlbrCopXhLeTpQib1A==",
 			"dev": true,
 			"requires": {
-				"cssnano-utils": "^2.0.1",
-				"postcss-value-parser": "^4.1.0"
+				"postcss-value-parser": "^4.2.0"
 			},
 			"dependencies": {
 				"postcss-value-parser": {
@@ -92753,12 +93104,12 @@
 			}
 		},
 		"postcss-normalize-string": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/postcss-normalize-string/-/postcss-normalize-string-5.0.1.tgz",
-			"integrity": "sha512-Ic8GaQ3jPMVl1OEn2U//2pm93AXUcF3wz+OriskdZ1AOuYV25OdgS7w9Xu2LO5cGyhHCgn8dMXh9bO7vi3i9pA==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-normalize-string/-/postcss-normalize-string-6.0.0.tgz",
+			"integrity": "sha512-KWkIB7TrPOiqb8ZZz6homet2KWKJwIlysF5ICPZrXAylGe2hzX/HSf4NTX2rRPJMAtlRsj/yfkrWGavFuB+c0w==",
 			"dev": true,
 			"requires": {
-				"postcss-value-parser": "^4.1.0"
+				"postcss-value-parser": "^4.2.0"
 			},
 			"dependencies": {
 				"postcss-value-parser": {
@@ -92770,13 +93121,12 @@
 			}
 		},
 		"postcss-normalize-timing-functions": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/postcss-normalize-timing-functions/-/postcss-normalize-timing-functions-5.0.1.tgz",
-			"integrity": "sha512-cPcBdVN5OsWCNEo5hiXfLUnXfTGtSFiBU9SK8k7ii8UD7OLuznzgNRYkLZow11BkQiiqMcgPyh4ZqXEEUrtQ1Q==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-normalize-timing-functions/-/postcss-normalize-timing-functions-6.0.0.tgz",
+			"integrity": "sha512-tpIXWciXBp5CiFs8sem90IWlw76FV4oi6QEWfQwyeREVwUy39VSeSqjAT7X0Qw650yAimYW5gkl2Gd871N5SQg==",
 			"dev": true,
 			"requires": {
-				"cssnano-utils": "^2.0.1",
-				"postcss-value-parser": "^4.1.0"
+				"postcss-value-parser": "^4.2.0"
 			},
 			"dependencies": {
 				"postcss-value-parser": {
@@ -92788,13 +93138,13 @@
 			}
 		},
 		"postcss-normalize-unicode": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/postcss-normalize-unicode/-/postcss-normalize-unicode-5.0.1.tgz",
-			"integrity": "sha512-kAtYD6V3pK0beqrU90gpCQB7g6AOfP/2KIPCVBKJM2EheVsBQmx/Iof+9zR9NFKLAx4Pr9mDhogB27pmn354nA==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-normalize-unicode/-/postcss-normalize-unicode-6.0.0.tgz",
+			"integrity": "sha512-ui5crYkb5ubEUDugDc786L/Me+DXp2dLg3fVJbqyAl0VPkAeALyAijF2zOsnZyaS1HyfPuMH0DwyY18VMFVNkg==",
 			"dev": true,
 			"requires": {
-				"browserslist": "^4.16.0",
-				"postcss-value-parser": "^4.1.0"
+				"browserslist": "^4.21.4",
+				"postcss-value-parser": "^4.2.0"
 			},
 			"dependencies": {
 				"postcss-value-parser": {
@@ -92806,14 +93156,12 @@
 			}
 		},
 		"postcss-normalize-url": {
-			"version": "5.0.2",
-			"resolved": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-5.0.2.tgz",
-			"integrity": "sha512-k4jLTPUxREQ5bpajFQZpx8bCF2UrlqOTzP9kEqcEnOfwsRshWs2+oAFIHfDQB8GO2PaUaSE0NlTAYtbluZTlHQ==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-6.0.0.tgz",
+			"integrity": "sha512-98mvh2QzIPbb02YDIrYvAg4OUzGH7s1ZgHlD3fIdTHLgPLRpv1ZTKJDnSAKr4Rt21ZQFzwhGMXxpXlfrUBKFHw==",
 			"dev": true,
 			"requires": {
-				"is-absolute-url": "^3.0.3",
-				"normalize-url": "^6.0.1",
-				"postcss-value-parser": "^4.1.0"
+				"postcss-value-parser": "^4.2.0"
 			},
 			"dependencies": {
 				"postcss-value-parser": {
@@ -92825,12 +93173,12 @@
 			}
 		},
 		"postcss-normalize-whitespace": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/postcss-normalize-whitespace/-/postcss-normalize-whitespace-5.0.1.tgz",
-			"integrity": "sha512-iPklmI5SBnRvwceb/XH568yyzK0qRVuAG+a1HFUsFRf11lEJTiQQa03a4RSCQvLKdcpX7XsI1Gen9LuLoqwiqA==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-normalize-whitespace/-/postcss-normalize-whitespace-6.0.0.tgz",
+			"integrity": "sha512-7cfE1AyLiK0+ZBG6FmLziJzqQCpTQY+8XjMhMAz8WSBSCsCNNUKujgIgjCAmDT3cJ+3zjTXFkoD15ZPsckArVw==",
 			"dev": true,
 			"requires": {
-				"postcss-value-parser": "^4.1.0"
+				"postcss-value-parser": "^4.2.0"
 			},
 			"dependencies": {
 				"postcss-value-parser": {
@@ -92842,13 +93190,13 @@
 			}
 		},
 		"postcss-ordered-values": {
-			"version": "5.0.2",
-			"resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-5.0.2.tgz",
-			"integrity": "sha512-8AFYDSOYWebJYLyJi3fyjl6CqMEG/UVworjiyK1r573I56kb3e879sCJLGvR3merj+fAdPpVplXKQZv+ey6CgQ==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-6.0.0.tgz",
+			"integrity": "sha512-K36XzUDpvfG/nWkjs6d1hRBydeIxGpKS2+n+ywlKPzx1nMYDYpoGbcjhj5AwVYJK1qV2/SDoDEnHzlPD6s3nMg==",
 			"dev": true,
 			"requires": {
-				"cssnano-utils": "^2.0.1",
-				"postcss-value-parser": "^4.1.0"
+				"cssnano-utils": "^4.0.0",
+				"postcss-value-parser": "^4.2.0"
 			},
 			"dependencies": {
 				"postcss-value-parser": {
@@ -92860,23 +93208,22 @@
 			}
 		},
 		"postcss-reduce-initial": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-5.0.1.tgz",
-			"integrity": "sha512-zlCZPKLLTMAqA3ZWH57HlbCjkD55LX9dsRyxlls+wfuRfqCi5mSlZVan0heX5cHr154Dq9AfbH70LyhrSAezJw==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-6.0.0.tgz",
+			"integrity": "sha512-s2UOnidpVuXu6JiiI5U+fV2jamAw5YNA9Fdi/GRK0zLDLCfXmSGqQtzpUPtfN66RtCbb9fFHoyZdQaxOB3WxVA==",
 			"dev": true,
 			"requires": {
-				"browserslist": "^4.16.0",
+				"browserslist": "^4.21.4",
 				"caniuse-api": "^3.0.0"
 			}
 		},
 		"postcss-reduce-transforms": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-5.0.1.tgz",
-			"integrity": "sha512-a//FjoPeFkRuAguPscTVmRQUODP+f3ke2HqFNgGPwdYnpeC29RZdCBvGRGTsKpMURb/I3p6jdKoBQ2zI+9Q7kA==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-6.0.0.tgz",
+			"integrity": "sha512-FQ9f6xM1homnuy1wLe9lP1wujzxnwt1EwiigtWwuyf8FsqqXUDUp2Ulxf9A5yjlUOTdCJO6lonYjg1mgqIIi2w==",
 			"dev": true,
 			"requires": {
-				"cssnano-utils": "^2.0.1",
-				"postcss-value-parser": "^4.1.0"
+				"postcss-value-parser": "^4.2.0"
 			},
 			"dependencies": {
 				"postcss-value-parser": {
@@ -92910,13 +93257,13 @@
 			}
 		},
 		"postcss-svgo": {
-			"version": "5.0.2",
-			"resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-5.0.2.tgz",
-			"integrity": "sha512-YzQuFLZu3U3aheizD+B1joQ94vzPfE6BNUcSYuceNxlVnKKsOtdo6hL9/zyC168Q8EwfLSgaDSalsUGa9f2C0A==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-6.0.0.tgz",
+			"integrity": "sha512-r9zvj/wGAoAIodn84dR/kFqwhINp5YsJkLoujybWG59grR/IHx+uQ2Zo+IcOwM0jskfYX3R0mo+1Kip1VSNcvw==",
 			"dev": true,
 			"requires": {
-				"postcss-value-parser": "^4.1.0",
-				"svgo": "^2.3.0"
+				"postcss-value-parser": "^4.2.0",
+				"svgo": "^3.0.2"
 			},
 			"dependencies": {
 				"postcss-value-parser": {
@@ -92928,14 +93275,12 @@
 			}
 		},
 		"postcss-unique-selectors": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-5.0.1.tgz",
-			"integrity": "sha512-gwi1NhHV4FMmPn+qwBNuot1sG1t2OmacLQ/AX29lzyggnjd+MnVD5uqQmpXO3J17KGL2WAxQruj1qTd3H0gG/w==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-6.0.0.tgz",
+			"integrity": "sha512-EPQzpZNxOxP7777t73RQpZE5e9TrnCrkvp7AH7a0l89JmZiPnS82y216JowHXwpBCQitfyxrof9TK3rYbi7/Yw==",
 			"dev": true,
 			"requires": {
-				"alphanum-sort": "^1.0.2",
-				"postcss-selector-parser": "^6.0.5",
-				"uniqs": "^2.0.0"
+				"postcss-selector-parser": "^6.0.5"
 			}
 		},
 		"postcss-value-parser": {
@@ -95068,18 +95413,6 @@
 			"integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
 			"dev": true
 		},
-		"rgb-regex": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/rgb-regex/-/rgb-regex-1.0.1.tgz",
-			"integrity": "sha1-wODWiC3w4jviVKR16O3UGRX+rrE=",
-			"dev": true
-		},
-		"rgba-regex": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/rgba-regex/-/rgba-regex-1.0.0.tgz",
-			"integrity": "sha1-QzdOLiyglosO8VI0YLfXMP8i7rM=",
-			"dev": true
-		},
 		"rimraf": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
@@ -96359,12 +96692,6 @@
 				"figgy-pudding": "^3.5.1"
 			}
 		},
-		"stable": {
-			"version": "0.1.8",
-			"resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",
-			"integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==",
-			"dev": true
-		},
 		"stack-utils": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.3.tgz",
@@ -96740,12 +97067,12 @@
 			"dev": true
 		},
 		"stylehacks": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-5.0.1.tgz",
-			"integrity": "sha512-Es0rVnHIqbWzveU1b24kbw92HsebBepxfcqe5iix7t9j0PQqhs0IxXVXv0pY2Bxa08CgMkzD6OWql7kbGOuEdA==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-6.0.0.tgz",
+			"integrity": "sha512-+UT589qhHPwz6mTlCLSt/vMNTJx8dopeJlZAlBMJPWA3ORqu6wmQY7FBXf+qD+FsqoBJODyqNxOUP3jdntFRdw==",
 			"dev": true,
 			"requires": {
-				"browserslist": "^4.16.0",
+				"browserslist": "^4.21.4",
 				"postcss-selector-parser": "^6.0.4"
 			}
 		},
@@ -97071,18 +97398,17 @@
 			"dev": true
 		},
 		"svgo": {
-			"version": "2.8.0",
-			"resolved": "https://registry.npmjs.org/svgo/-/svgo-2.8.0.tgz",
-			"integrity": "sha512-+N/Q9kV1+F+UeWYoSiULYo4xYSDQlTgb+ayMobAXPwMnLvop7oxKMo9OzIrX5x3eS4L4f2UHhc9axXwY8DpChg==",
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/svgo/-/svgo-3.0.2.tgz",
+			"integrity": "sha512-Z706C1U2pb1+JGP48fbazf3KxHrWOsLme6Rv7imFBn5EnuanDW1GPaA/P1/dvObE670JDePC3mnj0k0B7P0jjQ==",
 			"dev": true,
 			"requires": {
 				"@trysound/sax": "0.2.0",
 				"commander": "^7.2.0",
-				"css-select": "^4.1.3",
-				"css-tree": "^1.1.3",
-				"csso": "^4.2.0",
-				"picocolors": "^1.0.0",
-				"stable": "^0.1.8"
+				"css-select": "^5.1.0",
+				"css-tree": "^2.2.1",
+				"csso": "^5.0.5",
+				"picocolors": "^1.0.0"
 			},
 			"dependencies": {
 				"commander": {
@@ -97091,60 +97417,26 @@
 					"integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
 					"dev": true
 				},
-				"css-select": {
-					"version": "4.3.0",
-					"resolved": "https://registry.npmjs.org/css-select/-/css-select-4.3.0.tgz",
-					"integrity": "sha512-wPpOYtnsVontu2mODhA19JrqWxNsfdatRKd64kmpRbQgh1KtItko5sTnEpPdpSaJszTOhEMlF/RPz28qj4HqhQ==",
+				"css-tree": {
+					"version": "2.3.1",
+					"resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.3.1.tgz",
+					"integrity": "sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==",
 					"dev": true,
 					"requires": {
-						"boolbase": "^1.0.0",
-						"css-what": "^6.0.1",
-						"domhandler": "^4.3.1",
-						"domutils": "^2.8.0",
-						"nth-check": "^2.0.1"
+						"mdn-data": "2.0.30",
+						"source-map-js": "^1.0.1"
 					}
 				},
-				"dom-serializer": {
-					"version": "1.4.1",
-					"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.4.1.tgz",
-					"integrity": "sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag==",
-					"dev": true,
-					"requires": {
-						"domelementtype": "^2.0.1",
-						"domhandler": "^4.2.0",
-						"entities": "^2.0.0"
-					}
-				},
-				"domelementtype": {
-					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
-					"integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+				"mdn-data": {
+					"version": "2.0.30",
+					"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.30.tgz",
+					"integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==",
 					"dev": true
 				},
-				"domhandler": {
-					"version": "4.3.1",
-					"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.1.tgz",
-					"integrity": "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==",
-					"dev": true,
-					"requires": {
-						"domelementtype": "^2.2.0"
-					}
-				},
-				"domutils": {
-					"version": "2.8.0",
-					"resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
-					"integrity": "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==",
-					"dev": true,
-					"requires": {
-						"dom-serializer": "^1.0.1",
-						"domelementtype": "^2.2.0",
-						"domhandler": "^4.2.0"
-					}
-				},
-				"entities": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
-					"integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
+				"source-map-js": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
+					"integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
 					"dev": true
 				}
 			}
@@ -97582,12 +97874,6 @@
 			"requires": {
 				"setimmediate": "^1.0.4"
 			}
-		},
-		"timsort": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/timsort/-/timsort-0.3.0.tgz",
-			"integrity": "sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q=",
-			"dev": true
 		},
 		"tiny-emitter": {
 			"version": "2.1.0",
@@ -98082,12 +98368,6 @@
 				"set-value": "^2.0.1"
 			}
 		},
-		"uniqs": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz",
-			"integrity": "sha1-/+3ks2slKQaW5uFl1KWe25mOawI=",
-			"dev": true
-		},
 		"unique-filename": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.1.tgz",
@@ -98523,12 +98803,6 @@
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
 			"integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="
-		},
-		"vendors": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/vendors/-/vendors-1.0.4.tgz",
-			"integrity": "sha512-/juG65kTL4Cy2su4P8HjtkTxk6VmJDiOPBufWniqQ6wknac6jNiXS9vU+hO3wgusiyqWlzTbVHi0dyJqRONg3w==",
-			"dev": true
 		},
 		"verror": {
 			"version": "1.10.0",

--- a/package.json
+++ b/package.json
@@ -184,7 +184,7 @@
 		"core-js-builder": "3.31.0",
 		"cross-env": "3.2.4",
 		"css-loader": "6.2.0",
-		"cssnano": "5.0.7",
+		"cssnano": "6.0.1",
 		"deep-freeze": "0.0.1",
 		"equivalent-key-map": "0.2.2",
 		"escape-html": "1.0.3",

--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Enhancements
+
+-   The bundled `@svgr/webpack` dependency has been updated from requiring ^6.2.1 to requiring ^8.0.1 ([#53630](https://github.com/WordPress/gutenberg/pull/53630)).
+-   The bundled `cssnano` dependency has been updated from requiring ^5.07 to requiring ^6.0.1 ([#53630](https://github.com/WordPress/gutenberg/pull/53630)).
+
 ### Bug Fix
 
 -   Fix prevent watch mode from aborting when encountering a `block.json` file that contains invalid JSON. ([#51971](https://github.com/WordPress/gutenberg/pull/51971))

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -34,7 +34,7 @@
 	"dependencies": {
 		"@babel/core": "^7.16.0",
 		"@pmmmwh/react-refresh-webpack-plugin": "^0.5.2",
-		"@svgr/webpack": "^6.2.1",
+		"@svgr/webpack": "^8.0.1",
 		"@wordpress/babel-preset-default": "file:../babel-preset-default",
 		"@wordpress/browserslist-config": "file:../browserslist-config",
 		"@wordpress/dependency-extraction-webpack-plugin": "file:../dependency-extraction-webpack-plugin",
@@ -54,7 +54,7 @@
 		"copy-webpack-plugin": "^10.2.0",
 		"cross-spawn": "^5.1.0",
 		"css-loader": "^6.2.0",
-		"cssnano": "^5.0.7",
+		"cssnano": "^6.0.1",
 		"cwd": "^0.10.0",
 		"dir-glob": "^3.0.1",
 		"eslint": "^8.3.0",


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes partially #53213.
Fixes partially #53553.

> When svgo@3.0.2 was installed separately, the "deprecated stable@0.1.8" warning did not appear.
> 
> In other words, maybe @wordpress/scripts should install @svgr/webpack@8.0.1 instead of @svgr/webpack@6.2.1.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

To remove the warning: "deprecated stable@0.1.8".

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

-   The bundled `@svgr/webpack` dependency has been updated from requiring ^6.2.1 to requiring ^8.0.1.
-   The bundled `cssnano` dependency has been updated from requiring ^5.07 to requiring ^6.0.1.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

I tested with

```bash
npx wp-create-block --template @wordpress/create-block-tutorial-template --no-wp-
scripts
cd gutenpride
../node_modules/.bin/wp-scripts build
```

I ensured that JS and CSS files are built correctly.