### PR TITLE
ProgressBar: Use theme accent color variable

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -13,6 +13,7 @@
 -   `Modal:`: Nuance outside interactions ([#52994](https://github.com/WordPress/gutenberg/pull/52994)).
 -   `Button`: Remove default border from the destructive button ([#53607](https://github.com/WordPress/gutenberg/pull/53607)).
 -   Components: Move accent colors to theme context ([#53631](https://github.com/WordPress/gutenberg/pull/53631)).
+-   `ProgressBar`: Use the new theme system accent for indicator color ([#53632](https://github.com/WordPress/gutenberg/pull/53632)).
 
 ### Bug Fix
 

--- a/packages/components/src/progress-bar/styles.ts
+++ b/packages/components/src/progress-bar/styles.ts
@@ -43,10 +43,7 @@ export const Indicator = styled.div< {
 	top: 0;
 	height: 100%;
 	border-radius: ${ CONFIG.radiusBlockUi };
-	background-color: var(
-		--wp-components-color-accent,
-		${ COLORS.theme.accent }
-	);
+	background-color: ${ COLORS.theme.accent };
 
 	${ ( { isIndeterminate, value } ) =>
 		isIndeterminate


### PR DESCRIPTION
## What?
Following #53631, this PR updates the color of the progress bar indicator to avoid duplication and make the color definition clearer.

~Blocked by #53631 and needs to be rebased when it lands.~

## Why?
See https://github.com/WordPress/gutenberg/pull/53347#discussion_r1284774850 for motivation.

## How?
We're using the new `COLORS.theme.accent` color value.

## Testing Instructions
Verify there are no visual changes to the `ProgressBar` component and all checks are green.

### Testing Instructions for Keyboard
None.

## Screenshots or screencast <!-- if applicable -->
None.