### PR TITLE
Documentation: Add the Commands Data page to Handbook

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -1968,6 +1968,12 @@
 		"parent": "data"
 	},
 	{
+		"title": "The Commands Data",
+		"slug": "data-core-commands",
+		"markdown_source": "../docs/reference-guides/data/data-core-commands.md",
+		"parent": "data"
+	},
+	{
 		"title": "Customize Widgets",
 		"slug": "data-core-customize-widgets",
 		"markdown_source": "../docs/reference-guides/data/data-core-customize-widgets.md",

--- a/docs/toc.json
+++ b/docs/toc.json
@@ -268,6 +268,9 @@
 					},
 					{ "docs/reference-guides/data/data-core-blocks.md": [] },
 					{
+						"docs/reference-guides/data/data-core-commands.md": []
+					},
+					{
 						"docs/reference-guides/data/data-core-customize-widgets.md": []
 					},
 					{ "docs/reference-guides/data/data-core-edit-post.md": [] },


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
#52562 added Commands Data document to GitHub, but it was not included in the Handbook, and the link "core/commands: Command Palette" in the TOC page causes error: https://developer.wordpress.org/block-editor/reference-guides/data/

This PR fixes the issue by following the steps described in the following page:
https://developer.wordpress.org/block-editor/contributors/documentation/#create-a-new-document

## What?
<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
