### PR TITLE
Keyboard Shortcut: End the command palette description with a period

### DIFF
--- a/packages/commands/src/components/command-menu.js
+++ b/packages/commands/src/components/command-menu.js
@@ -189,7 +189,7 @@ export function CommandMenu() {
 		registerShortcut( {
 			name: 'core/commands',
 			category: 'global',
-			description: __( 'Open the command palette' ),
+			description: __( 'Open the command palette.' ),
 			keyCombination: {
 				modifier: 'primary',
 				character: 'k',


### PR DESCRIPTION
## What?
This PR adds a period to the end of the text about the command palette in the keyboard shortcut modal.

![period](https://github.com/WordPress/gutenberg/assets/54422211/24539f08-1b96-4553-82a7-31bf42165524)

## Why?
To be consistent with other text rules.

## Testing Instructions
No impact on code.

