### PR TITLE
Block Widget: Fix content cutoff in the keyboard shortcut modal

### DIFF
--- a/packages/edit-widgets/src/components/keyboard-shortcut-help-modal/style.scss
+++ b/packages/edit-widgets/src/components/keyboard-shortcut-help-modal/style.scss
@@ -3,11 +3,6 @@
 		margin: 0 0 2rem 0;
 	}
 
-	&__main-shortcuts .edit-widgets-keyboard-shortcut-help-modal__shortcut-list {
-		// Push the shortcut to be flush with top modal header.
-		margin-top: -$grid-unit-30 -$border-width;
-	}
-
 	&__section-title {
 		font-size: 0.9rem;
 		font-weight: 600;


### PR DESCRIPTION
## What?
This PR fixes a problem in the Block Widget Editor where text in the keyboard shortcut modal is cut off.

### Before
![before](https://github.com/WordPress/gutenberg/assets/54422211/b8084c4b-5ad2-4d15-a99f-e3fcf337f37f)

### After

![after](https://github.com/WordPress/gutenberg/assets/54422211/860e439e-fc0d-4333-ae59-468b7dd665a3)

## Why?

This is because a negative margin was applied to the top of the main shortcut section. A similar style existed in the post editor and the site editor but was removed when the modal design was updated in #40781. Therefore, this style is also unnecessary in the widget editor.

## Testing Instructions

- Activate Twenty Twenty One Theme.
- Go to Appearance > Widgets > Options > Keyboard shortcuts.
- Ensure that the content is not cut off.
