### PR TITLE
Adds import statements for the stylesheet files

### DIFF
--- a/docs/how-to-guides/block-tutorial/applying-styles-with-stylesheets.md
+++ b/docs/how-to-guides/block-tutorial/applying-styles-with-stylesheets.md
@@ -113,6 +113,10 @@ For example the block name: `gutenberg-examples/example-02-stylesheets` would ge
 import { registerBlockType } from '@wordpress/blocks';
 import { useBlockProps } from '@wordpress/block-editor';
 
+// import the stylesheets
+import './style.css';
+import './editor.css';
+
 registerBlockType( 'gutenberg-examples/example-02-stylesheets', {
 	edit() {
 		const blockProps = useBlockProps();
@@ -168,6 +172,7 @@ In order to include the blockEditor as a dependency, make sure to run the build 
 {% JSX %}
 
 Build the scripts and update the asset file which is used to keep track of dependencies and the build version.
+
 ```bash
 npm run build
 ```
@@ -199,7 +204,7 @@ Use the `editorStyle` property to a CSS file you want to load in the editor view
 
 It is worth noting that, if the editor content is iframed, both of these will
 load in the iframe. `editorStyle` will also load outside the iframe, so it can
-be used for editor content as well as UI. 
+be used for editor content as well as UI.
 
 For example:
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Adds import statements for the stylesheet files in the JSX example for adding a block classname, in the "[Use styles and stylesheets](https://developer.wordpress.org/block-editor/how-to-guides/block-tutorial/applying-styles-with-stylesheets/)" page of the [Block tutorial](https://developer.wordpress.org/block-editor/how-to-guides/block-tutorial/).

## Why?
The example doesn't work without them.
