### PR TITLE
Block previews: memoize example blocks

### DIFF
--- a/packages/block-editor/src/components/inserter/preview-panel.js
+++ b/packages/block-editor/src/components/inserter/preview-panel.js
@@ -6,6 +6,7 @@ import {
 	createBlock,
 	getBlockFromExample,
 } from '@wordpress/blocks';
+import { useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -17,23 +18,26 @@ import BlockPreview from '../block-preview';
 function InserterPreviewPanel( { item } ) {
 	const { name, title, icon, description, initialAttributes, example } = item;
 	const isReusable = isReusableBlock( item );
+	const blocks = useMemo( () => {
+		if ( ! example ) {
+			return createBlock( name, initialAttributes );
+		}
+		return getBlockFromExample( name, {
+			attributes: {
+				...example.attributes,
+				...initialAttributes,
+			},
+			innerBlocks: example.innerBlocks,
+		} );
+	}, [ name, example, initialAttributes ] );
+
 	return (
 		<div className="block-editor-inserter__preview-container">
 			<div className="block-editor-inserter__preview">
 				{ isReusable || example ? (
 					<div className="block-editor-inserter__preview-content">
 						<BlockPreview
-							blocks={
-								example
-									? getBlockFromExample( name, {
-											attributes: {
-												...example.attributes,
-												...initialAttributes,
-											},
-											innerBlocks: example.innerBlocks,
-									  } )
-									: createBlock( name, initialAttributes )
-							}
+							blocks={ blocks }
 							viewportWidth={ example?.viewportWidth ?? 500 }
 							additionalStyles={ [
 								{ css: 'body { padding: 16px; }' },

--- a/packages/edit-site/src/components/global-styles/block-preview-panel.js
+++ b/packages/edit-site/src/components/global-styles/block-preview-panel.js
@@ -4,26 +4,37 @@
 import { BlockPreview } from '@wordpress/block-editor';
 import { getBlockType, getBlockFromExample } from '@wordpress/blocks';
 import { __experimentalSpacer as Spacer } from '@wordpress/components';
+import { useMemo } from '@wordpress/element';
 
 const BlockPreviewPanel = ( { name, variation = '' } ) => {
 	const blockExample = getBlockType( name )?.example;
-	const blockExampleWithVariation = {
-		...blockExample,
-		attributes: {
-			...blockExample?.attributes,
-			className: 'is-style-' + variation,
-		},
-	};
-	const blocks =
-		blockExample &&
-		getBlockFromExample(
-			name,
-			variation ? blockExampleWithVariation : blockExample
-		);
-	const viewportWidth = blockExample?.viewportWidth || null;
+	const blocks = useMemo( () => {
+		if ( ! blockExample ) {
+			return null;
+		}
+
+		let example = blockExample;
+		if ( variation ) {
+			example = {
+				...example,
+				attributes: {
+					...example.attributes,
+					className: 'is-style-' + variation,
+				},
+			};
+		}
+
+		return getBlockFromExample( name, example );
+	}, [ name, blockExample, variation ] );
+
+	const viewportWidth = blockExample?.viewportWidth ?? null;
 	const previewHeight = '150px';
 
-	return ! blockExample ? null : (
+	if ( ! blockExample ) {
+		return null;
+	}
+
+	return (
 		<Spacer marginX={ 4 } marginBottom={ 4 }>
 			<div
 				className="edit-site-global-styles__block-preview-panel"


### PR DESCRIPTION
Little optimization of the `InserterPreviewPanel` and `BlockPreviewPanel` components. They both show blocks created according to the `blockType.example` field, and until now have been creating the blocks from scratch on every render, and passing the value down as a `blocks` prop.

This PR memoizes the `getBlockFromExample` calls.

**How to test:**
Verify block previews when hovering in the block inserter (popover) and also when editing global styles for a given block:

<img width="288" alt="Screenshot 2023-08-14 at 15 51 50" src="https://github.com/WordPress/gutenberg/assets/664258/7a6e85e5-8084-4726-b11e-664f3be6ff88">
