### PR TITLE
Fix invalid popover anchor calculation due to wrong format found

### DIFF
--- a/packages/rich-text/src/component/use-anchor.js
+++ b/packages/rich-text/src/component/use-anchor.js
@@ -31,6 +31,13 @@ function getFormatElement( range, editableContentElement, tagName, className ) {
 	if ( element === editableContentElement ) return;
 	if ( ! editableContentElement.contains( element ) ) return;
 
+	// Check if the candidate element is within the selected range.
+	// This avoids situations where two format elements can exist within the
+	// same parent element and the wrong element is mistakenly returned.
+	if ( ! range.isPointInRange( element, 0 ) ) {
+		return;
+	}
+
 	const selector = tagName + ( className ? '.' + className : '' );
 
 	// .closest( selector ), but with a boundary. Check if the element matches
@@ -39,6 +46,7 @@ function getFormatElement( range, editableContentElement, tagName, className ) {
 	// wrapper, which is what .closest( selector ) would do. When the element is
 	// the editable wrapper (which is most likely the case because most text is
 	// unformatted), this never runs.
+
 	while ( element !== editableContentElement ) {
 		if ( element.matches( selector ) ) {
 			return element;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Ensure Popover anchor points are correctly calculated when the rich text selection contains existing matching format types.

Fixes https://github.com/WordPress/gutenberg/issues/53641

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Because the found anchor should represent the text range _selection_ and not another matching format within the same rich text range.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Uses [`Range.isPointInRange()`](https://developer.mozilla.org/en-US/docs/Web/API/Range/isPointInRange) to check whether the candidate `element` is part of the selected range or not.

This avoids situations whereby you could have a `link` format _later_ in the range and even when making a selection _before_ that existing format, the existing format would be found because it indiscriminately matched on format type and didn't account for a matching range.

Initially tried simply `Range.toString()` but I realised that the existing format could have the same text content as the new range's text selection so that wouldn't work. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- New Post
- Add the following text:
> Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Nulla malesuada pellentesque elit eget. Vitae et leo duis ut diam quam nulla porttitor. Id nibh tortor id aliquet lectus proin nibh nisl. Sed augue lacus viverra vitae. Feugiat in ante metus dictum at tempor commodo ullamcorper. Vitae nunc sed velit dignissim sodales ut eu sem. Massa tempor nec feugiat nisl pretium fusce id velit ut. Eros in cursus turpis massa tincidunt. Lacinia at quis risus sed vulputate odio ut enim blandit.Placerat vestibulum lectus mauris ultrices eros in cursus turpis. Nascetur ridiculus mus mauris vitae ultricies leo integer. Et molestie ac feugiat sed lectus vestibulum mattis ullamcorper. Platea dictumst vestibulum rhoncus est pellentesque elit ullamcorper dignissim cras. Urna porttitor rhoncus dolor purus. Aliquet bibendum enim facilisis gravida neque convallis. Risus ultricies tristique nulla aliquet enim tortor at. Scelerisque fermentum dui faucibus in ornare quam viverra. Nisl vel pretium lectus quam id leo in vitae turpis. Vulputate enim nulla aliquet porttitor lacus luctus accumsan. Morbi tristique senectus et netus et malesuada.
- Highlight a word in the first line of text and starting create a link using the editor (no need to submit it).
- See link UI popover anchor correctly positioned on text selection range boundary.
- Dismiss/remove any link (in case you created one).
- Now create a link to `w.org` on any word in the _last_ sentence of the block of text.
- Now returning to the _first_ line of text try to create another [separate] link.
- Check that the Link UI is positioned correctly on the text selection (it should _not_ be placed on the link to `w.org`).

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/444434/3b4c8f02-1b8f-4a29-a332-2737714243c9

