### PR TITLE
Fix typo and add tests for fonts install endpoint

### DIFF
--- a/lib/experimental/fonts-library/class-wp-rest-fonts-library-controller.php
+++ b/lib/experimental/fonts-library/class-wp-rest-fonts-library-controller.php
@@ -137,7 +137,7 @@ class WP_REST_Fonts_Library_Controller extends WP_REST_Controller {
 							);
 						}
 
-						if ( isset( $font_face['download_from_url'] ) && isset( $font_face['uplodaded_file'] ) ) {
+						if ( isset( $font_face['download_from_url'] ) && isset( $font_face['uploaded_file'] ) ) {
 							$error_messages[] = sprintf(
 								// translators: 1: font family index, 2: font face index.
 								__( 'Font family [%1$s] Font face [%2$s] should have only one of the download_from_url or uploaded_file properties defined and not both.', 'gutenberg' ),

--- a/lib/experimental/fonts-library/class-wp-rest-fonts-library-controller.php
+++ b/lib/experimental/fonts-library/class-wp-rest-fonts-library-controller.php
@@ -114,6 +114,7 @@ class WP_REST_Fonts_Library_Controller extends WP_REST_Controller {
 						__( 'Font family [%s] should have fontFace property defined as an array.', 'gutenberg' ),
 						$family_index
 					);
+					continue;
 				}
 
 				if ( count( $font_family['fontFace'] ) < 1 ) {

--- a/phpunit/fonts-library/class-wp-rest-fonts-library-controller-test.php
+++ b/phpunit/fonts-library/class-wp-rest-fonts-library-controller-test.php
@@ -340,4 +340,113 @@ class WP_REST_Fonts_Library_Controller_Test extends WP_UnitTestCase {
 			),
 		);
 	}
+
+	/**
+	 * Tests failure when fonfaces has improper inputs
+	 *
+	 * @covers ::install_fonts
+	 *
+	 * @dataProvider data_install_with_improper_inputs
+	 */
+	public function test_install_with_improper_inputs( $font_families, $files = array() ) {
+		wp_set_current_user( self::$admin_id );
+		$install_request    = new WP_REST_Request( 'POST', '/wp/v2/fonts' );
+		$font_families_json = json_encode( $font_families );
+		$install_request->set_param( 'fontFamilies', $font_families_json );
+		$response = rest_get_server()->dispatch( $install_request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 400, $response->get_status(), 'Response status is not 400 when font face has both donwload_from_url and uploaded_file properties.' );
+	}
+
+	/**
+	 * Data provider for test_install_with_improper_inputs
+	 */
+	public function data_install_with_improper_inputs() {
+		$temp_file_path1 = wp_tempnam( 'Piazzola1-' );
+		file_put_contents( $temp_file_path1, 'Mocking file content' );
+
+		return array(
+			'not a font families array'             => array(
+				'font_families' => 'This is not an array',
+			),
+
+			'empty array'                           => array(
+				'font_families' => array(),
+			),
+
+			'without slug'                          => array(
+				'font_families' => array(
+					array(
+						'fontFamily' => 'Piazzolla',
+						'name'       => 'Piazzolla',
+					),
+				),
+			),
+
+			'with improper font face propety'       => array(
+				'font_families' => array(
+					array(
+						'fontFamily' => 'Piazzolla',
+						'name'       => 'Piazzolla',
+						'slug'       => 'piazzolla',
+						'fontFace'   => 'This is not an array',
+					),
+				),
+			),
+
+			'with empty font face propety'          => array(
+				'font_families' => array(
+					array(
+						'fontFamily' => 'Piazzolla',
+						'name'       => 'Piazzolla',
+						'slug'       => 'piazzolla',
+						'fontFace'   => array(),
+					),
+				),
+			),
+
+			'fontface referencing uploaded file without uploaded files' => array(
+				'font_families' => array(
+					array(
+						'fontFamily' => 'Piazzolla',
+						'name'       => 'Piazzolla',
+						'slug'       => 'piazzolla',
+						'fontFace'   => array(
+							array(
+								'fontFamily'    => 'Piazzolla',
+								'fontStyle'     => 'normal',
+								'fontWeight'    => '400',
+								'uploaded_file' => 'files0',
+							),
+						),
+					),
+				),
+				'files'         => array(),
+			),
+
+			'fontface with incompatible properties' => array(
+				'font_families' => array(
+					array(
+						'fontFamily' => 'Piazzolla',
+						'slug'       => 'piazzolla',
+						'name'       => 'Piazzolla',
+						'fontFace'   => array(
+							array(
+								'fontFamily'        => 'Piazzolla',
+								'fontStyle'         => 'normal',
+								'fontWeight'        => '400',
+								'src'               => 'http://fonts.gstatic.com/s/piazzolla/v33/N0b72SlTPu5rIkWIZjVgI-TckS03oGpPETyEJ88Rbvi0_TzOzKcQhZqx3gX9BRy5m5M.ttf',
+								'download_from_url' => 'http://fonts.gstatic.com/s/piazzolla/v33/N0b72SlTPu5rIkWIZjVgI-TckS03oGpPETyEJ88Rbvi0_TzOzKcQhZqx3gX9BRy5m5M.ttf',
+								'uploaded_file'     => 'files0',
+							),
+						),
+					),
+				),
+			),
+
+		);
+	}
+
+
 }

--- a/phpunit/fonts-library/class-wp-rest-fonts-library-controller-test.php
+++ b/phpunit/fonts-library/class-wp-rest-fonts-library-controller-test.php
@@ -347,6 +347,9 @@ class WP_REST_Fonts_Library_Controller_Test extends WP_UnitTestCase {
 	 * @covers ::install_fonts
 	 *
 	 * @dataProvider data_install_with_improper_inputs
+	 *
+	 * @param array $font_families     Font families to install in theme.json format.
+	 * @param array $files             Font files to install.
 	 */
 	public function test_install_with_improper_inputs( $font_families, $files = array() ) {
 		wp_set_current_user( self::$admin_id );
@@ -366,15 +369,15 @@ class WP_REST_Fonts_Library_Controller_Test extends WP_UnitTestCase {
 		file_put_contents( $temp_file_path1, 'Mocking file content' );
 
 		return array(
-			'not a font families array'             => array(
+			'not a font families array'       => array(
 				'font_families' => 'This is not an array',
 			),
 
-			'empty array'                           => array(
+			'empty array'                     => array(
 				'font_families' => array(),
 			),
 
-			'without slug'                          => array(
+			'without slug'                    => array(
 				'font_families' => array(
 					array(
 						'fontFamily' => 'Piazzolla',
@@ -383,7 +386,7 @@ class WP_REST_Fonts_Library_Controller_Test extends WP_UnitTestCase {
 				),
 			),
 
-			'with improper font face propety'       => array(
+			'with improper font face propety' => array(
 				'font_families' => array(
 					array(
 						'fontFamily' => 'Piazzolla',
@@ -394,7 +397,7 @@ class WP_REST_Fonts_Library_Controller_Test extends WP_UnitTestCase {
 				),
 			),
 
-			'with empty font face propety'          => array(
+			'with empty font face propety'    => array(
 				'font_families' => array(
 					array(
 						'fontFamily' => 'Piazzolla',

--- a/phpunit/fonts-library/class-wp-rest-fonts-library-controller-test.php
+++ b/phpunit/fonts-library/class-wp-rest-fonts-library-controller-test.php
@@ -354,8 +354,6 @@ class WP_REST_Fonts_Library_Controller_Test extends WP_UnitTestCase {
 		$font_families_json = json_encode( $font_families );
 		$install_request->set_param( 'fontFamilies', $font_families_json );
 		$response = rest_get_server()->dispatch( $install_request );
-		$data     = $response->get_data();
-
 		$this->assertEquals( 400, $response->get_status(), 'Response status is not 400 when font face has both donwload_from_url and uploaded_file properties.' );
 	}
 

--- a/phpunit/fonts-library/class-wp-rest-fonts-library-controller-test.php
+++ b/phpunit/fonts-library/class-wp-rest-fonts-library-controller-test.php
@@ -369,15 +369,18 @@ class WP_REST_Fonts_Library_Controller_Test extends WP_UnitTestCase {
 		file_put_contents( $temp_file_path1, 'Mocking file content' );
 
 		return array(
-			'not a font families array'       => array(
+			'not a font families array'       
+ => array(
 				'font_families' => 'This is not an array',
 			),
 
-			'empty array'                     => array(
+			'empty array'                     
+ => array(
 				'font_families' => array(),
 			),
 
-			'without slug'                    => array(
+			'without slug'                    
+ => array(
 				'font_families' => array(
 					array(
 						'fontFamily' => 'Piazzolla',
@@ -397,7 +400,7 @@ class WP_REST_Fonts_Library_Controller_Test extends WP_UnitTestCase {
 				),
 			),
 
-			'with empty font face propety'    => array(
+			'with empty font face property'    => array(
 				'font_families' => array(
 					array(
 						'fontFamily' => 'Piazzolla',

--- a/phpunit/fonts-library/class-wp-rest-fonts-library-controller-test.php
+++ b/phpunit/fonts-library/class-wp-rest-fonts-library-controller-test.php
@@ -353,12 +353,14 @@ class WP_REST_Fonts_Library_Controller_Test extends WP_UnitTestCase {
 	 */
 	public function test_install_with_improper_inputs( $font_families, $files = array() ) {
 		wp_set_current_user( self::$admin_id );
+
 		$install_request    = new WP_REST_Request( 'POST', '/wp/v2/fonts' );
 		$font_families_json = json_encode( $font_families );
 		$install_request->set_param( 'fontFamilies', $font_families_json );
 		$install_request->set_file_params( $files );
+
 		$response = rest_get_server()->dispatch( $install_request );
-		$this->assertSame( 400, $response->get_status(), 'Response status is not 400 when font face has both donwload_from_url and uploaded_file properties.' );
+		$this->assertSame( 400, $response->get_status() );
 	}
 
 	/**
@@ -369,18 +371,15 @@ class WP_REST_Fonts_Library_Controller_Test extends WP_UnitTestCase {
 		file_put_contents( $temp_file_path1, 'Mocking file content' );
 
 		return array(
-			'not a font families array'       
- => array(
+			'not a font families array'        => array(
 				'font_families' => 'This is not an array',
 			),
 
-			'empty array'                     
- => array(
+			'empty array'                      => array(
 				'font_families' => array(),
 			),
 
-			'without slug'                    
- => array(
+			'without slug'                     => array(
 				'font_families' => array(
 					array(
 						'fontFamily' => 'Piazzolla',
@@ -476,7 +475,6 @@ class WP_REST_Fonts_Library_Controller_Test extends WP_UnitTestCase {
 					),
 				),
 			),
-
 		);
 	}
 }

--- a/phpunit/fonts-library/class-wp-rest-fonts-library-controller-test.php
+++ b/phpunit/fonts-library/class-wp-rest-fonts-library-controller-test.php
@@ -348,8 +348,8 @@ class WP_REST_Fonts_Library_Controller_Test extends WP_UnitTestCase {
 	 *
 	 * @dataProvider data_install_with_improper_inputs
 	 *
-	 * @param array $font_families     Font families to install in theme.json format.
-	 * @param array $files             Font files to install.
+	 * @param array $font_families Font families to install in theme.json format.
+	 * @param array $files         Font files to install.
 	 */
 	public function test_install_with_improper_inputs( $font_families, $files = array() ) {
 		wp_set_current_user( self::$admin_id );
@@ -358,7 +358,7 @@ class WP_REST_Fonts_Library_Controller_Test extends WP_UnitTestCase {
 		$install_request->set_param( 'fontFamilies', $font_families_json );
 		$install_request->set_file_params( $files );
 		$response = rest_get_server()->dispatch( $install_request );
-		$this->assertEquals( 400, $response->get_status(), 'Response status is not 400 when font face has both donwload_from_url and uploaded_file properties.' );
+		$this->assertSame( 400, $response->get_status(), 'Response status is not 400 when font face has both donwload_from_url and uploaded_file properties.' );
 	}
 
 	/**
@@ -386,7 +386,7 @@ class WP_REST_Fonts_Library_Controller_Test extends WP_UnitTestCase {
 				),
 			),
 
-			'with improper font face propety' => array(
+			'with improper font face property' => array(
 				'font_families' => array(
 					array(
 						'fontFamily' => 'Piazzolla',
@@ -476,6 +476,4 @@ class WP_REST_Fonts_Library_Controller_Test extends WP_UnitTestCase {
 
 		);
 	}
-
-
 }

--- a/phpunit/fonts-library/class-wp-rest-fonts-library-controller-test.php
+++ b/phpunit/fonts-library/class-wp-rest-fonts-library-controller-test.php
@@ -353,6 +353,7 @@ class WP_REST_Fonts_Library_Controller_Test extends WP_UnitTestCase {
 		$install_request    = new WP_REST_Request( 'POST', '/wp/v2/fonts' );
 		$font_families_json = json_encode( $font_families );
 		$install_request->set_param( 'fontFamilies', $font_families_json );
+		$install_request->set_file_params( $files );
 		$response = rest_get_server()->dispatch( $install_request );
 		$this->assertEquals( 400, $response->get_status(), 'Response status is not 400 when font face has both donwload_from_url and uploaded_file properties.' );
 	}
@@ -423,7 +424,34 @@ class WP_REST_Fonts_Library_Controller_Test extends WP_UnitTestCase {
 				'files'         => array(),
 			),
 
-			'fontface with incompatible properties' => array(
+			'fontface referencing uploaded file without uploaded files' => array(
+				'font_families' => array(
+					array(
+						'fontFamily' => 'Piazzolla',
+						'name'       => 'Piazzolla',
+						'slug'       => 'piazzolla',
+						'fontFace'   => array(
+							array(
+								'fontFamily'    => 'Piazzolla',
+								'fontStyle'     => 'normal',
+								'fontWeight'    => '400',
+								'uploaded_file' => 'files666',
+							),
+						),
+					),
+				),
+				'files'         => array(
+					'files0' => array(
+						'name'     => 'piazzola1.ttf',
+						'type'     => 'font/ttf',
+						'tmp_name' => $temp_file_path1,
+						'error'    => 0,
+						'size'     => 123,
+					),
+				),
+			),
+
+			'fontface with incompatible properties (download_from_url and uploaded_file together)' => array(
 				'font_families' => array(
 					array(
 						'fontFamily' => 'Piazzolla',


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
- Fix a typo in code: See @anton-vlasenko comment here: https://github.com/WordPress/gutenberg/pull/52704#discussion_r1290722815
- Add tests to specify when the endpoint should fail with 400 (bad request) error.

## Testing Instructions
Run WP_REST_Fonts_Library_Controller_Test PHP unit tests
