### PR TITLE
Fix: Editor styles with imports.

### DIFF
--- a/packages/block-editor/src/utils/transform-styles/ast/parse.js
+++ b/packages/block-editor/src/utils/transform-styles/ast/parse.js
@@ -610,7 +610,17 @@ export default function ( css, options ) {
 	 * Parse import
 	 */
 
-	const atimport = _compileAtrule( 'import' );
+	const atimport = function () {
+		const re = new RegExp( '^@import\\s*(url\\(.*?\\)|[^;]+);' );
+		const pos = position();
+		const m = match( re );
+		if ( ! m ) {
+			return;
+		}
+		const ret = { type: 'import' };
+		ret.import = m[ 1 ].trim();
+		return pos( ret );
+	};
 
 	/**
 	 * Parse charset


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/53509

Addresses an issue with the CSS parser to make editor styles with imports work as expected.
Todo: Submit an upstream PR fixing https://github.com/reworkcss/css/issues/137.

## Testing
I verified the editor styles referred in https://github.com/WordPress/gutenberg/issues/53509 work as expected after this change.