### PR TITLE
Add support for registering commands without icons

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -54720,6 +54720,7 @@
 				"@wordpress/icons": "file:../icons",
 				"@wordpress/keyboard-shortcuts": "file:../keyboard-shortcuts",
 				"@wordpress/private-apis": "file:../private-apis",
+				"classnames": "^2.3.1",
 				"cmdk": "^0.2.0",
 				"rememo": "^4.0.2"
 			},
@@ -67368,6 +67369,7 @@
 				"@wordpress/icons": "file:../icons",
 				"@wordpress/keyboard-shortcuts": "file:../keyboard-shortcuts",
 				"@wordpress/private-apis": "file:../private-apis",
+				"classnames": "^2.3.1",
 				"cmdk": "^0.2.0",
 				"rememo": "^4.0.2"
 			}

--- a/packages/commands/package.json
+++ b/packages/commands/package.json
@@ -34,6 +34,7 @@
 		"@wordpress/icons": "file:../icons",
 		"@wordpress/keyboard-shortcuts": "file:../keyboard-shortcuts",
 		"@wordpress/private-apis": "file:../private-apis",
+		"classnames": "^2.3.1",
 		"cmdk": "^0.2.0",
 		"rememo": "^4.0.2"
 	},

--- a/packages/commands/src/components/command-menu.js
+++ b/packages/commands/src/components/command-menu.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { Command, useCommandState } from 'cmdk';
+import classnames from 'classnames';
 
 /**
  * WordPress dependencies
@@ -53,9 +54,14 @@ function CommandMenuLoader( { name, search, hook, setLoader, close } ) {
 					>
 						<HStack
 							alignment="left"
-							className="commands-command-menu__item"
+							className={ classnames(
+								'commands-command-menu__item',
+								{
+									'with-no-icon': ! command.icon,
+								}
+							) }
 						>
-							<Icon icon={ command.icon } />
+							{ command.icon && <Icon icon={ command.icon } /> }
 							<span>
 								<TextHighlight
 									text={ command.label }
@@ -123,9 +129,11 @@ export function CommandMenuGroup( { isContextual, search, setLoader, close } ) {
 				>
 					<HStack
 						alignment="left"
-						className="commands-command-menu__item"
+						className={ classnames( 'commands-command-menu__item', {
+							'with-no-icon': ! command.icon,
+						} ) }
 					>
-						<Icon icon={ command.icon } />
+						{ command.icon && <Icon icon={ command.icon } /> }
 						<span>
 							<TextHighlight
 								text={ command.label }

--- a/packages/commands/src/components/command-menu.js
+++ b/packages/commands/src/components/command-menu.js
@@ -57,7 +57,7 @@ function CommandMenuLoader( { name, search, hook, setLoader, close } ) {
 							className={ classnames(
 								'commands-command-menu__item',
 								{
-									'with-no-icon': ! command.icon,
+									'has-icon': command.icon,
 								}
 							) }
 						>
@@ -130,7 +130,7 @@ export function CommandMenuGroup( { isContextual, search, setLoader, close } ) {
 					<HStack
 						alignment="left"
 						className={ classnames( 'commands-command-menu__item', {
-							'with-no-icon': ! command.icon,
+							'has-icon': command.icon,
 						} ) }
 					>
 						{ command.icon && <Icon icon={ command.icon } /> }

--- a/packages/commands/src/components/style.scss
+++ b/packages/commands/src/components/style.scss
@@ -69,6 +69,7 @@
 		padding: $grid-unit;
 		color: $gray-900;
 		font-size: $default-font-size;
+		min-height: $button-size-next-default-40px;
 
 		&[aria-selected="true"],
 		&:active {
@@ -87,6 +88,10 @@
 
 		svg {
 			fill: $gray-900;
+		}
+
+		> .with-no-icon {
+			padding-left: $grid-unit-40; // Align text, even without icons.
 		}
 	}
 

--- a/packages/commands/src/components/style.scss
+++ b/packages/commands/src/components/style.scss
@@ -66,7 +66,6 @@
 		cursor: pointer;
 		display: flex;
 		align-items: center;
-		padding: $grid-unit;
 		color: $gray-900;
 		font-size: $default-font-size;
 		min-height: $button-size-next-default-40px;
@@ -90,8 +89,13 @@
 			fill: $gray-900;
 		}
 
-		> .with-no-icon {
-			padding-left: $grid-unit-40; // Align text, even without icons.
+		> div {
+			padding: $grid-unit;
+			padding-left: $grid-unit-50; // Account for commands without icons.
+		}
+
+		> .has-icon {
+			padding-left: $grid-unit;
 		}
 	}
 

--- a/packages/edit-post/src/hooks/commands/use-common-commands.js
+++ b/packages/edit-post/src/hooks/commands/use-common-commands.js
@@ -5,7 +5,6 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import { __, isRTL } from '@wordpress/i18n';
 import {
 	code,
-	cog,
 	drawerLeft,
 	drawerRight,
 	blockDefault,
@@ -92,7 +91,6 @@ export default function useCommonCommands() {
 	useCommand( {
 		name: 'core/toggle-distraction-free',
 		label: __( 'Toggle distraction free' ),
-		icon: cog,
 		callback: ( { close } ) => {
 			toggle( 'core/edit-post', 'distractionFree' );
 			close();
@@ -102,7 +100,6 @@ export default function useCommonCommands() {
 	useCommand( {
 		name: 'core/toggle-spotlight-mode',
 		label: __( 'Toggle spotlight mode' ),
-		icon: cog,
 		callback: ( { close } ) => {
 			toggle( 'core/edit-post', 'focusMode' );
 			close();
@@ -132,7 +129,6 @@ export default function useCommonCommands() {
 	useCommand( {
 		name: 'core/toggle-top-toolbar',
 		label: __( 'Toggle top toolbar' ),
-		icon: cog,
 		callback: ( { close } ) => {
 			toggle( 'core/edit-post', 'fixedToolbar' );
 			close();
@@ -152,7 +148,6 @@ export default function useCommonCommands() {
 	useCommand( {
 		name: 'core/open-preferences',
 		label: __( 'Editor preferences' ),
-		icon: cog,
 		callback: () => {
 			openModal( PREFERENCES_MODAL_NAME );
 		},
@@ -172,7 +167,6 @@ export default function useCommonCommands() {
 		label: showBlockBreadcrumbs
 			? __( 'Hide block breadcrumbs' )
 			: __( 'Show block breadcrumbs' ),
-		icon: cog,
 		callback: ( { close } ) => {
 			toggle( 'core/edit-post', 'showBlockBreadcrumbs' );
 			close();

--- a/packages/edit-site/src/hooks/commands/use-edit-mode-commands.js
+++ b/packages/edit-site/src/hooks/commands/use-edit-mode-commands.js
@@ -12,7 +12,6 @@ import {
 	drawerLeft,
 	drawerRight,
 	blockDefault,
-	cog,
 	code,
 	keyboard,
 } from '@wordpress/icons';
@@ -256,7 +255,6 @@ function useEditUICommands() {
 	commands.push( {
 		name: 'core/toggle-spotlight-mode',
 		label: __( 'Toggle spotlight mode' ),
-		icon: cog,
 		callback: ( { close } ) => {
 			toggle( 'core/edit-site', 'focusMode' );
 			close();
@@ -266,7 +264,6 @@ function useEditUICommands() {
 	commands.push( {
 		name: 'core/toggle-distraction-free',
 		label: __( 'Toggle distraction free' ),
-		icon: cog,
 		callback: ( { close } ) => {
 			setPreference( 'core/edit-site', 'fixedToolbar', false );
 			setIsInserterOpened( false );
@@ -289,7 +286,6 @@ function useEditUICommands() {
 	commands.push( {
 		name: 'core/toggle-top-toolbar',
 		label: __( 'Toggle top toolbar' ),
-		icon: cog,
 		callback: ( { close } ) => {
 			toggle( 'core/edit-site', 'fixedToolbar' );
 			close();
@@ -311,7 +307,6 @@ function useEditUICommands() {
 	commands.push( {
 		name: 'core/open-preferences',
 		label: __( 'Editor preferences' ),
-		icon: cog,
 		callback: () => {
 			openModal( PREFERENCES_MODAL_NAME );
 		},
@@ -331,7 +326,6 @@ function useEditUICommands() {
 		label: showBlockBreadcrumbs
 			? __( 'Hide block breadcrumbs' )
 			: __( 'Show block breadcrumbs' ),
-		icon: cog,
 		callback: ( { close } ) => {
 			toggle( 'core/edit-site', 'showBlockBreadcrumbs' );
 			close();


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Closes https://github.com/WordPress/gutenberg/issues/53193 by removing the requirement for commands to register icons. If the icon does not support the command, it probably shouldn't be required as part of the registration. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a post or page.
2. Open command palette (CMD/CTRL K)
3. Search for "toggle" and no longer see the `cog` icons. 

## Screenshots or screencast <!-- if applicable -->

| Before  | After |
| ------------- | ------------- |
|<img width="418" alt="CleanShot 2023-08-14 at 14 47 30" src="https://github.com/WordPress/gutenberg/assets/1813435/abee563d-a6f6-4d57-846b-bec9ba48285e">|<img width="417" alt="CleanShot 2023-08-14 at 14 39 50" src="https://github.com/WordPress/gutenberg/assets/1813435/8e13e9bd-3f46-4e24-93e0-504e24a85393">|
