### PR TITLE
Adjust size of image previews in list view

### DIFF
--- a/packages/block-editor/src/components/list-view/style.scss
+++ b/packages/block-editor/src/components/list-view/style.scss
@@ -346,8 +346,8 @@
 
 	.block-editor-list-view-block-select-button__image {
 		background-size: cover;
-		width: 20px;
-		height: 20px;
+		width: 18px;
+		height: 18px;
 		border-radius: $radius-block-ui;
 
 		&:not(:only-child) {
@@ -355,7 +355,7 @@
 		}
 
 		&:not(:first-child) {
-			margin-left: -5px;
+			margin-left: #{$grid-unit-15 * -0.5};
 		}
 	}
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Follow-up to https://github.com/WordPress/gutenberg/pull/53381. Minor adjustment to list view image previews, matching the image icon size. The negative margin is set to display two-thirds of each image now as well. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a post or page.
2. Insert an image block, with an image.
3. Insert a gallery block, with images.
4. Open list view.
5. See changes. 

## Screenshots or screencast <!-- if applicable -->
<img width="831" alt="CleanShot 2023-08-14 at 15 44 07" src="https://github.com/WordPress/gutenberg/assets/1813435/7749c949-cb7e-4742-b3af-2bb0d62b2776">
