### PR TITLE
E2E Storybook: Fix for Storybook v7

### DIFF
--- a/test/storybook-playwright/storybook/main.js
+++ b/test/storybook-playwright/storybook/main.js
@@ -6,8 +6,9 @@ const baseConfig = require( '../../../storybook/main' );
 const config = {
 	...baseConfig,
 	addons: [ '@storybook/addon-toolbars' ],
+	docs: undefined,
 	stories: [
-		'../../../packages/components/src/**/stories/e2e/*.@(js|tsx|mdx)',
+		'../../../packages/components/src/**/stories/e2e/*.story.@(js|tsx|mdx)',
 	],
 };
 

--- a/test/storybook-playwright/storybook/webpack.config.js
+++ b/test/storybook-playwright/storybook/webpack.config.js
@@ -1,6 +1,0 @@
-/**
- * Internal dependencies
- */
-const baseConfig = require( '../../../storybook/webpack.config' );
-
-module.exports = baseConfig;


### PR DESCRIPTION
## What?

Fixes the setup for the components e2e test Storybook to work with our recent upgrade to Storybook v7 (#53520).

## How?

- Update test file naming scheme.
- Remove separate webpack config file.
- Remove the `docs` setting because it's erroring and we don't need it here.

## Testing Instructions

`npm run storybook:e2e:dev` should spin up the E2E Storybook in the browser without errors.