### PR TITLE
(latest-posts) Make latest-posts ssr categories handling more defensive

### DIFF
--- a/packages/block-library/src/latest-posts/index.php
+++ b/packages/block-library/src/latest-posts/index.php
@@ -56,7 +56,7 @@ function render_block_core_latest_posts( $attributes ) {
 
 	add_filter( 'excerpt_more', $filter_latest_posts_excerpt_more );
 
-	if ( isset( $attributes['categories'] ) ) {
+	if ( ! empty( $attributes['categories'] ) ) {
 		$args['category__in'] = array_column( $attributes['categories'], 'id' );
 	}
 	if ( isset( $attributes['selectedAuthor'] ) ) {


### PR DESCRIPTION
## What?

This is an attempt to fix https://github.com/WordPress/gutenberg/issues/53648.

## Why?

In some multisite instances (i.g Wordpress.com) data corruption somewhere else (we couldn't troubleshoot the origin yet, unfortunately) can cause the `categories` attribute passed over to `render_block_core_latest_posts` to be blank (`''`), this ends up causing a PHP warning:

`array_column() expects parameter 1 to be array, string given`

And worst of all, **ends up printing the warning in the HTML instead of the actual latest-posts block!**

## How?

By making the condition more defensive by making sure the assignment doesn't happen if `$attributes['categories`] is `empty`. For some reason, `categories` is added with an `empty` string, while under normal circumstances, it should not be part of the `$attributes` array at all if it's not set.

## Testing Instructions

Unfortunately, it's not a scenario that's trivial to reproduce. The only way is to force it by passing an `$attributes` array arg with an empty `categories` (set to `''`) at the beginning of this method: https://github.com/WordPress/gutenberg/blame/trunk/packages/block-library/src/latest-posts/index.php#L36. I also didn't find unit tests for this block so this was the only way I could test it. 
