### PR TITLE
Footnotes: checking type before using count()

### DIFF
--- a/packages/block-library/src/footnotes/index.php
+++ b/packages/block-library/src/footnotes/index.php
@@ -34,7 +34,7 @@ function render_block_core_footnotes( $attributes, $content, $block ) {
 
 	$footnotes = json_decode( $footnotes, true );
 
-	if ( count( $footnotes ) === 0 ) {
+	if ( ! is_array( $footnotes ) || count( $footnotes ) === 0 ) {
 		return '';
 	}
 


### PR DESCRIPTION

## What?

The PR attempts to guard against uncountable values in the footnotes block. 

Reported in https://core.trac.wordpress.org/ticket/59103

## Why?
I couldn't reproduce the error in PHP 7.4 or PHP 8.0, but decided it wouldn't hurt to first check if `$footnotes` was an array before we attempt to pass it through `count()`. 

I tested on WordPress 6.4-alpha and WordPress 6.3.

## How?
Adding an `is_array()` check before using `count()` in case `$footnotes` is not countable.

## Testing Instructions
If you're using `wp-env`, in order to test in PHP 8.0 add the following to `.wp-env.json`.

```json
{
	"core": "WordPress/WordPress",
	"phpVersion": "8.0",
...
}
```

And run `npm run wp-env start --update`

Ensure that still footnotes work in posts/pages and in the site editor.

As you work, check the logs for warnings using `npm run wp-env logs --watch`.

