### PR TITLE
Improve command palette rendering on smaller viewports

### DIFF
--- a/packages/commands/src/components/style.scss
+++ b/packages/commands/src/components/style.scss
@@ -1,6 +1,6 @@
 // dirty hack to clean up modal
 .commands-command-menu {
-	border-radius: $radius-block-ui;
+	border-radius: $grid-unit-05;
 	width: 100%;
 	margin: auto;
 	max-width: 420px;

--- a/packages/commands/src/components/style.scss
+++ b/packages/commands/src/components/style.scss
@@ -1,6 +1,8 @@
 // dirty hack to clean up modal
 .commands-command-menu {
+	border-radius: $radius-block-ui;
 	width: 100%;
+	margin: auto;
 	max-width: 420px;
 	position: relative;
 	top: 15%;

--- a/packages/commands/src/components/style.scss
+++ b/packages/commands/src/components/style.scss
@@ -5,7 +5,11 @@
 	margin: auto;
 	max-width: 420px;
 	position: relative;
-	top: 15%;
+	top: calc(15% + #{$header-height});
+
+	@include break-small() {
+		top: 15%;
+	}
 
 	.components-modal__content {
 		margin: 0;

--- a/packages/commands/src/components/style.scss
+++ b/packages/commands/src/components/style.scss
@@ -1,7 +1,7 @@
 // dirty hack to clean up modal
 .commands-command-menu {
 	border-radius: $grid-unit-05;
-	width: 100%;
+	width: calc(100% - #{$grid-unit-40});
 	margin: auto;
 	max-width: 420px;
 	position: relative;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Minor adjustment to `.commands-command-menu` to improve how it displays on mobile.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a post or page within a smaller viewport.
2. Open the command palette with CMD K or CTRL K.

## Screenshots or screencast <!-- if applicable -->

### Before


https://github.com/WordPress/gutenberg/assets/1813435/0df66c2a-d214-4868-9629-1ae4935932c1


### After

https://github.com/WordPress/gutenberg/assets/1813435/60840ca2-c9de-48e3-9a74-ea8c5363bd7d


