### PR TITLE
Footnotes: fix accidental  override

### DIFF
--- a/packages/block-library/src/footnotes/index.php
+++ b/packages/block-library/src/footnotes/index.php
@@ -160,8 +160,8 @@ function wp_add_footnotes_revisions_to_post_meta( $post ) {
 	}
 }
 
-add_action( "rest_after_insert_post", 'wp_add_footnotes_revisions_to_post_meta' );
-add_action( "rest_after_insert_page", 'wp_add_footnotes_revisions_to_post_meta' );
+add_action( 'rest_after_insert_post', 'wp_add_footnotes_revisions_to_post_meta' );
+add_action( 'rest_after_insert_page', 'wp_add_footnotes_revisions_to_post_meta' );
 
 /**
  * Restores the footnotes meta value from the revision.

--- a/packages/block-library/src/footnotes/index.php
+++ b/packages/block-library/src/footnotes/index.php
@@ -160,9 +160,8 @@ function wp_add_footnotes_revisions_to_post_meta( $post ) {
 	}
 }
 
-foreach ( array( 'post', 'page' ) as $post_type ) {
-	add_action( "rest_after_insert_{$post_type}", 'wp_add_footnotes_revisions_to_post_meta' );
-}
+add_action( "rest_after_insert_post", 'wp_add_footnotes_revisions_to_post_meta' );
+add_action( "rest_after_insert_page", 'wp_add_footnotes_revisions_to_post_meta' );
 
 /**
  * Restores the footnotes meta value from the revision.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

We're accidentally overriding the $post_type global 🤦‍♀️ 

Fixes https://core.trac.wordpress.org/ticket/59105.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Avoid the foreach loop setting the $post_type global

Alternatively, we could move this to `register_block_core_footnotes`, but I opted for moving as little code as possible.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
