### PR TITLE
Footnotes: autosave is not slashing JSON

### DIFF
--- a/packages/block-library/src/footnotes/index.php
+++ b/packages/block-library/src/footnotes/index.php
@@ -243,7 +243,7 @@ function _wp_rest_api_autosave_meta( $autosave ) {
 		return;
 	}
 
-	update_post_meta( $id, 'footnotes', json_encode( $body['meta']['footnotes'] ) );
+	update_post_meta( $id, 'footnotes', wp_slash( $body['meta']['footnotes'] ) );
 }
 // See https://github.com/WordPress/wordpress-develop/blob/2103cb9966e57d452c94218bbc3171579b536a40/src/wp-includes/rest-api/endpoints/class-wp-rest-autosaves-controller.php#L391C1-L391C1.
 add_action( 'wp_creating_autosave', '_wp_rest_api_autosave_meta' );

--- a/packages/block-library/src/footnotes/index.php
+++ b/packages/block-library/src/footnotes/index.php
@@ -98,7 +98,7 @@ function wp_save_footnotes_meta( $revision_id ) {
 
 		if ( $footnotes ) {
 			// Can't use update_post_meta() because it doesn't allow revisions.
-			update_metadata( 'post', $revision_id, 'footnotes', $footnotes );
+			update_metadata( 'post', $revision_id, 'footnotes', wp_slash( $footnotes ) );
 		}
 	}
 }
@@ -154,7 +154,7 @@ function wp_add_footnotes_revisions_to_post_meta( $post ) {
 
 			if ( $footnotes ) {
 				// Can't use update_post_meta() because it doesn't allow revisions.
-				update_metadata( 'post', $wp_temporary_footnote_revision_id, 'footnotes', $footnotes );
+				update_metadata( 'post', $wp_temporary_footnote_revision_id, 'footnotes', wp_slash( $footnotes ) );
 			}
 		}
 	}
@@ -176,7 +176,7 @@ function wp_restore_footnotes_from_revision( $post_id, $revision_id ) {
 	$footnotes = get_post_meta( $revision_id, 'footnotes', true );
 
 	if ( $footnotes ) {
-		update_post_meta( $post_id, 'footnotes', $footnotes );
+		update_post_meta( $post_id, 'footnotes', wp_slash( $footnotes ) );
 	} else {
 		delete_post_meta( $post_id, 'footnotes' );
 	}

--- a/packages/block-library/src/footnotes/index.php
+++ b/packages/block-library/src/footnotes/index.php
@@ -243,7 +243,7 @@ function _wp_rest_api_autosave_meta( $autosave ) {
 		return;
 	}
 
-	update_post_meta( $id, 'footnotes', $body['meta']['footnotes'] );
+	update_post_meta( $id, 'footnotes', json_encode( $body['meta']['footnotes'] ) );
 }
 // See https://github.com/WordPress/wordpress-develop/blob/2103cb9966e57d452c94218bbc3171579b536a40/src/wp-includes/rest-api/endpoints/class-wp-rest-autosaves-controller.php#L391C1-L391C1.
 add_action( 'wp_creating_autosave', '_wp_rest_api_autosave_meta' );

--- a/test/e2e/specs/editor/various/footnotes.spec.js
+++ b/test/e2e/specs/editor/various/footnotes.spec.js
@@ -291,7 +291,8 @@ test.describe( 'Footnotes', () => {
 		await editor.clickBlockToolbarButton( 'More' );
 		await page.locator( 'button:text("Footnote")' ).click();
 
-		await page.keyboard.type( 'first footnote' );
+		// Check if content is correctly slashed on save and restore.
+		await page.keyboard.type( 'first footnote"' );
 
 		const id1 = await editor.canvas.evaluate( () => {
 			return document.activeElement.id;
@@ -316,7 +317,7 @@ test.describe( 'Footnotes', () => {
 				id: id2,
 			},
 			{
-				content: 'first footnote',
+				content: 'first footnote"',
 				id: id1,
 			},
 		] );
@@ -329,7 +330,7 @@ test.describe( 'Footnotes', () => {
 		// This also saves the post!
 		expect( await getFootnotes( page ) ).toMatchObject( [
 			{
-				content: 'first footnote',
+				content: 'first footnote"',
 				id: id1,
 			},
 			{
@@ -337,6 +338,16 @@ test.describe( 'Footnotes', () => {
 				id: id2,
 			},
 		] );
+
+		const editorPage = page;
+		const previewPage = await editor.openPreviewPage();
+
+		await expect(
+			previewPage.locator( 'ol.wp-block-footnotes' )
+		).toHaveText( 'first footnote” ↩︎second footnote ↩︎' );
+
+		await previewPage.close();
+		await editorPage.bringToFront();
 
 		// Open revisions.
 		await editor.openDocumentSettingsSidebar();
@@ -355,10 +366,19 @@ test.describe( 'Footnotes', () => {
 				id: id2,
 			},
 			{
-				content: 'first footnote',
+				content: 'first footnote"',
 				id: id1,
 			},
 		] );
+
+		const previewPage2 = await editor.openPreviewPage();
+
+		await expect(
+			previewPage2.locator( 'ol.wp-block-footnotes' )
+		).toHaveText( 'second footnote ↩︎first footnote” ↩︎' );
+
+		await previewPage2.close();
+		await editorPage.bringToFront();
 	} );
 
 	test( 'can be previewed when published', async ( { editor, page } ) => {

--- a/test/e2e/specs/editor/various/footnotes.spec.js
+++ b/test/e2e/specs/editor/various/footnotes.spec.js
@@ -392,12 +392,12 @@ test.describe( 'Footnotes', () => {
 		// path).
 		await editor.canvas.click( 'ol.wp-block-footnotes li span' );
 		await page.keyboard.press( 'End' );
-		await page.keyboard.type( '3' );
+		await page.keyboard.type( '3"' );
 
 		const previewPage2 = await editor.openPreviewPage();
 
 		await expect(
 			previewPage2.locator( 'ol.wp-block-footnotes li' )
-		).toHaveText( '123  ↩︎' );
+		).toHaveText( '123"  ↩︎' );
 	} );
 } );

--- a/test/e2e/specs/editor/various/footnotes.spec.js
+++ b/test/e2e/specs/editor/various/footnotes.spec.js
@@ -392,12 +392,14 @@ test.describe( 'Footnotes', () => {
 		// path).
 		await editor.canvas.click( 'ol.wp-block-footnotes li span' );
 		await page.keyboard.press( 'End' );
+		// Test slashing.
 		await page.keyboard.type( '3"' );
 
 		const previewPage2 = await editor.openPreviewPage();
 
+		// Note: quote will get curled by wptexturize.
 		await expect(
 			previewPage2.locator( 'ol.wp-block-footnotes li' )
-		).toHaveText( '123"  ↩︎' );
+		).toHaveText( '123″  ↩︎' );
 	} );
 } );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes #53660, https://core.trac.wordpress.org/ticket/59103

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

We're making this mistake:
https://developer.wordpress.org/reference/functions/update_post_meta/#character-escaping

This is what the REST API does:

https://github.com/WordPress/wordpress-develop/blob/trunk/src/wp-includes/rest-api/fields/class-wp-rest-meta-fields.php#L393

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
