### PR TITLE
POC: Try fixing Safari top toolbar issue.

### DIFF
--- a/packages/interface/src/components/interface-skeleton/style.scss
+++ b/packages/interface/src/components/interface-skeleton/style.scss
@@ -82,7 +82,7 @@ html.interface-interface-skeleton__html-container {
 	// On Mobile the header is fixed to keep HTML as scrollable.
 	// Beyond the medium breakpoint, we allow the sidebar.
 	// The sidebar should scroll independently, so enable scroll here also.
-	overflow: auto;
+	//overflow: auto;
 
 	// On Safari iOS on smaller viewports lack of a z-index causes the background
 	// to "bleed" through the header.


### PR DESCRIPTION
## What?
Proof of concept: **do not merge yet**.

Work in progress to fix #53495.

## Why?

In Safari, for whatever reason when the viewport gets reduced in height, `.interface-interface-skeleton__content` gets "Scroll" applied, which crops off the top toolbar which is pushed up to cover the main bar at the top:

![before](https://github.com/WordPress/gutenberg/assets/1204802/ae692217-6469-4869-b147-0316784be4bb)

This is more easily shown in this GIF of the inspector, showing the "Scroll" property appearing when resizing the window:

![the issue](https://github.com/WordPress/gutenberg/assets/1204802/98af4229-9164-4606-b086-0fe2e213afc5)

So far this PR "fixes" the issue by removing the overflow value. However there's a great deal of prior comments around why that overflow property was added in the first place, so this needs a bit further debugging.

## How?

It appears that the overflow as applied to the main viewport causes the cropping of the top toolbar.

Overflow of course makes the various containers scroll, this is valid enough, and a better fix might be to _move_ where the toolbar lives so that it does not get cropped by the container that has overflow applied. However the position in the DOM is also delicate territory, so any testing, especially of the mobile use case, would be valuable. If the following instructions are obsolete, this PR can in fact land:

```
	// On Mobile the header is fixed to keep HTML as scrollable.
	// Beyond the medium breakpoint, we allow the sidebar.
	// The sidebar should scroll independently, so enable scroll here also.
	//overflow: auto;
```


## Testing Instructions

* Use Safari
* Enable top toolbar
* Select a block
* Resize the viewport to be very short (height-wise)

Observe how in trunk, the toolbar disappears, in this PR it stays.