### PR TITLE
Data: Warn if the 'useSelect' hook returns different values when called with the same state and parameters

### DIFF
--- a/packages/data/src/components/use-select/index.js
+++ b/packages/data/src/components/use-select/index.js
@@ -43,6 +43,7 @@ function Store( registry, suspense ) {
 	let lastMapResultValid = false;
 	let lastIsAsync;
 	let subscriber;
+	let didWarnUnstableReference;
 
 	const createSubscriber = ( stores ) => {
 		// The set of stores the `subscribe` function is supposed to subscribe to. Here it is
@@ -133,6 +134,24 @@ function Store( registry, suspense ) {
 				() => mapSelect( select, registry ),
 				listeningStores
 			);
+
+			if ( process.env.NODE_ENV === 'development' ) {
+				if ( ! didWarnUnstableReference ) {
+					const secondMapResult =
+						registry.__unstableMarkListeningStores(
+							() => mapSelect( select, registry ),
+							listeningStores
+						);
+
+					if ( ! isShallowEqual( mapResult, secondMapResult ) ) {
+						// eslint-disable-next-line no-console
+						console.warn(
+							`The values returned by the 'useSelect' hook aren't referentially stable. This can lead to unnecessary rerenders.`
+						);
+						didWarnUnstableReference = true;
+					}
+				}
+			}
 
 			if ( ! subscriber ) {
 				subscriber = createSubscriber( listeningStores.current );

--- a/packages/data/src/components/use-select/index.js
+++ b/packages/data/src/components/use-select/index.js
@@ -137,16 +137,11 @@ function Store( registry, suspense ) {
 
 			if ( process.env.NODE_ENV === 'development' ) {
 				if ( ! didWarnUnstableReference ) {
-					const secondMapResult =
-						registry.__unstableMarkListeningStores(
-							() => mapSelect( select, registry ),
-							listeningStores
-						);
-
+					const secondMapResult = mapSelect( select, registry );
 					if ( ! isShallowEqual( mapResult, secondMapResult ) ) {
 						// eslint-disable-next-line no-console
 						console.warn(
-							`The values returned by the 'useSelect' hook aren't referentially stable. This can lead to unnecessary rerenders.`
+							`The 'useSelect' hook returns different values when called with the same state and parameters. This can lead to unnecessary rerenders.`
 						);
 						didWarnUnstableReference = true;
 					}


### PR DESCRIPTION
## What?
See https://github.com/WordPress/gutenberg/pull/53596#issuecomment-1675729265.

PR adds a warning for `useSelect` hooks that return a new object/array reference on each `mapSelecet` call. The warning will only be displayed in dev mode.

## Why?
This will help us to catch possible bugs like #53596 early in development.

## How?
Call the `mapSelect` function again and compare the returned results with the previous call.

## Testing Instructions
1. Open a post or page.
2. Add an example plugin via DevTools.
3. Confirm the notice message.

<details><summary>Example plugin</summary>
<p>

```js
const { createElement: el, useState } = wp.element;
const { useSelect } = wp.data;
const registerPlugin = wp.plugins.registerPlugin;
const PluginDocumentSettingPanel = wp.editPost.PluginDocumentSettingPanel;

function PluginBlocksOnPage() {
    const { names, total } = useSelect( ( select ) => {
        const blocks = select('core/block-editor').getBlocks();

        return {
            names: blocks.map( ( { name } ) => name ),
            total: blocks.length,
        };
    }, [] );

	return el(
		PluginDocumentSettingPanel,
		{
			className: 'test-blocks-on-page',
			title: `Blocks on Page: ${ total }`,
			name: 'test-blocks-on-page'
		},
		el( 'p', {}, 'Placeholder' )
	);
}

registerPlugin( 'test-blocks-on-page', {
	render: PluginBlocksOnPage,
} );
```

</p>
</details> 

## Screenshots or screencast <!-- if applicable -->

![CleanShot 2023-08-15 at 17 03 56](https://github.com/WordPress/gutenberg/assets/240569/0aaf2e93-6547-4257-a56b-714108166e79)

