### PR TITLE
Design Tools: Add block instance elements color support for buttons and headings

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -302,7 +302,7 @@ Gather blocks in a layout container. ([Source](https://github.com/WordPress/gute
 
 -	**Name:** core/group
 -	**Category:** design
--	**Supports:** align (full, wide), anchor, ariaLabel, color (background, gradients, heading, link, text), dimensions (minHeight), layout (allowSizingOnChildren), position (sticky), spacing (blockGap, margin, padding), typography (fontSize, lineHeight), ~~html~~
+-	**Supports:** align (full, wide), anchor, ariaLabel, color (background, button, gradients, heading, link, text), dimensions (minHeight), layout (allowSizingOnChildren), position (sticky), spacing (blockGap, margin, padding), typography (fontSize, lineHeight), ~~html~~
 -	**Attributes:** allowedBlocks, tagName, templateLock
 
 ## Heading

--- a/lib/block-supports/colors.php
+++ b/lib/block-supports/colors.php
@@ -16,10 +16,12 @@ function gutenberg_register_colors_support( $block_type ) {
 	$has_background_colors_support = true === $color_support || ( is_array( $color_support ) && _wp_array_get( $color_support, array( 'background' ), true ) );
 	$has_gradients_support         = _wp_array_get( $color_support, array( 'gradients' ), false );
 	$has_link_colors_support       = _wp_array_get( $color_support, array( 'link' ), false );
+	$has_heading_colors_support    = _wp_array_get( $color_support, array( 'heading' ), false );
 	$has_color_support             = $has_text_colors_support ||
 		$has_background_colors_support ||
 		$has_gradients_support ||
-		$has_link_colors_support;
+		$has_link_colors_support ||
+		$has_heading_colors_support;
 
 	if ( ! $block_type->attributes ) {
 		$block_type->attributes = array();

--- a/lib/block-supports/colors.php
+++ b/lib/block-supports/colors.php
@@ -16,11 +16,13 @@ function gutenberg_register_colors_support( $block_type ) {
 	$has_background_colors_support = true === $color_support || ( is_array( $color_support ) && _wp_array_get( $color_support, array( 'background' ), true ) );
 	$has_gradients_support         = _wp_array_get( $color_support, array( 'gradients' ), false );
 	$has_link_colors_support       = _wp_array_get( $color_support, array( 'link' ), false );
+	$has_button_colors_support     = _wp_array_get( $color_support, array( 'button' ), false );
 	$has_heading_colors_support    = _wp_array_get( $color_support, array( 'heading' ), false );
 	$has_color_support             = $has_text_colors_support ||
 		$has_background_colors_support ||
 		$has_gradients_support ||
 		$has_link_colors_support ||
+		$has_button_colors_support ||
 		$has_heading_colors_support;
 
 	if ( ! $block_type->attributes ) {

--- a/lib/block-supports/elements.php
+++ b/lib/block-supports/elements.php
@@ -176,7 +176,7 @@ function gutenberg_render_elements_support_styles( $pre_render, $block ) {
 
 		foreach ( $heading_levels as $heading_level ) {
 			$heading_block_styles = isset( $element_block_styles[ $heading_level ] ) ? $element_block_styles[ $heading_level ] : null;
-			$heading_selector = 'heading' !== $heading_level
+			$heading_selector     = 'heading' !== $heading_level
 				? ".$class_name $heading_level"
 				: ".$class_name h1, .$class_name h2, .$class_name h3, .$class_name h4, .$class_name h5, .$class_name h6";
 

--- a/lib/block-supports/elements.php
+++ b/lib/block-supports/elements.php
@@ -47,7 +47,7 @@ function gutenberg_render_elements_support( $block_content, $block ) {
 	);
 
 	foreach ( $link_color_paths as $element_color_path ) {
-		$element_color = _wp_array_get( $block['attrs'], explode( '.', $element_color_path, ), null );
+		$element_color = _wp_array_get( $block['attrs'], explode( '.', $element_color_path ), null );
 
 		if ( null !== $element_color && ! $skip_link_color_serialization ) {
 			$element_colors_set++;
@@ -79,7 +79,7 @@ function gutenberg_render_elements_support( $block_content, $block ) {
 	);
 
 	foreach ( $heading_color_paths as $element_color_path ) {
-		$element_color = _wp_array_get( $block['attrs'], explode( '.', $element_color_path, ), null );
+		$element_color = _wp_array_get( $block['attrs'], explode( '.', $element_color_path ), null );
 
 		if ( null !== $element_color && ! $skip_heading_color_serialization ) {
 			$element_colors_set++;
@@ -93,7 +93,7 @@ function gutenberg_render_elements_support( $block_content, $block ) {
 	);
 
 	foreach ( $button_color_paths as $element_color_path ) {
-		$element_color = _wp_array_get( $block['attrs'], explode( '.', $element_color_path, ), null );
+		$element_color = _wp_array_get( $block['attrs'], explode( '.', $element_color_path ), null );
 
 		if ( null !== $element_color && ! $skip_button_color_serialization ) {
 			$element_colors_set++;
@@ -147,7 +147,7 @@ function gutenberg_render_elements_support_styles( $pre_render, $block ) {
 
 	$class_name = gutenberg_get_elements_class_name( $block );
 
-	// Link colors
+	// Link colors.
 	$link_block_styles = isset( $element_block_styles['link'] ) ? $element_block_styles['link'] : null;
 
 	if ( ! $skip_link_color_serialization && $link_block_styles ) {
@@ -170,7 +170,7 @@ function gutenberg_render_elements_support_styles( $pre_render, $block ) {
 		}
 	}
 
-	// Heading colors
+	// Heading colors.
 	if ( ! $skip_heading_color_serialization ) {
 		$heading_levels = array( 'heading', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6' );
 
@@ -192,7 +192,7 @@ function gutenberg_render_elements_support_styles( $pre_render, $block ) {
 		}
 	}
 
-	// Button colors
+	// Button colors.
 	$button_block_styles = isset( $element_block_styles['button'] ) ? $element_block_styles['button'] : null;
 
 	if ( ! $skip_button_color_serialization && $button_block_styles ) {

--- a/lib/block-supports/elements.php
+++ b/lib/block-supports/elements.php
@@ -27,76 +27,71 @@ function gutenberg_render_elements_support( $block_content, $block ) {
 		return $block_content;
 	}
 
-	$block_type                            = WP_Block_Type_Registry::get_instance()->get_registered( $block['blockName'] );
-	$skip_link_color_serialization         = wp_should_skip_block_supports_serialization( $block_type, 'color', 'link' );
-	$skip_heading_color_serialization      = wp_should_skip_block_supports_serialization( $block_type, 'color', 'heading' );
-	$skip_button_color_serialization       = wp_should_skip_block_supports_serialization( $block_type, 'color', 'button' );
-	$skips_all_element_color_serialization = $skip_link_color_serialization &&
-		$skip_heading_color_serialization &&
-		$skip_button_color_serialization;
+	$block_type = WP_Block_Type_Registry::get_instance()->get_registered( $block['blockName'] );
 
-	if ( $skips_all_element_color_serialization ) {
+	$element_color_properties = array(
+		'button'  => array(
+			'skip'  => wp_should_skip_block_supports_serialization( $block_type, 'color', 'button' ),
+			'paths' => array(
+				'style.elements.button.color.text',
+				'style.elements.button.color.background',
+				'style.elements.button.color.gradient',
+			),
+		),
+		'link'    => array(
+			'skip'  => wp_should_skip_block_supports_serialization( $block_type, 'color', 'link' ),
+			'paths' => array(
+				'style.elements.link.color.text',
+				'style.elements.link.:hover.color.text',
+			),
+		),
+		'heading' => array(
+			'skip'  => wp_should_skip_block_supports_serialization( $block_type, 'color', 'heading' ),
+			'paths' => array(
+				'style.elements.heading.color.text',
+				'style.elements.heading.color.background',
+				'style.elements.heading.color.gradient',
+				'style.elements.h1.color.text',
+				'style.elements.h1.color.background',
+				'style.elements.h1.color.gradient',
+				'style.elements.h2.color.text',
+				'style.elements.h2.color.background',
+				'style.elements.h2.color.gradient',
+				'style.elements.h3.color.text',
+				'style.elements.h3.color.background',
+				'style.elements.h3.color.gradient',
+				'style.elements.h4.color.text',
+				'style.elements.h4.color.background',
+				'style.elements.h4.color.gradient',
+				'style.elements.h5.color.text',
+				'style.elements.h5.color.background',
+				'style.elements.h5.color.gradient',
+				'style.elements.h6.color.text',
+				'style.elements.h6.color.background',
+				'style.elements.h6.color.gradient',
+			),
+		),
+	);
+
+	$skip_all_element_color_serialization = $element_color_properties['button']['skip'] &&
+		$element_color_properties['link']['skip'] &&
+		$element_color_properties['heading']['skip'];
+
+	if ( $skip_all_element_color_serialization ) {
 		return $block_content;
 	}
 
 	$element_colors_set = 0;
 
-	$link_color_paths = array(
-		'style.elements.link.color.text',
-		'style.elements.link.:hover.color.text',
-	);
-
-	foreach ( $link_color_paths as $element_color_path ) {
-		$element_color = _wp_array_get( $block['attrs'], explode( '.', $element_color_path ), null );
-
-		if ( null !== $element_color && ! $skip_link_color_serialization ) {
-			$element_colors_set++;
+	foreach ( $element_color_properties as $element_config ) {
+		if ( $element_config['skip'] ) {
+			continue;
 		}
-	}
 
-	$heading_color_paths = array(
-		'style.elements.heading.color.text',
-		'style.elements.heading.color.background',
-		'style.elements.heading.color.gradient',
-		'style.elements.h1.color.text',
-		'style.elements.h1.color.background',
-		'style.elements.h1.color.gradient',
-		'style.elements.h2.color.text',
-		'style.elements.h2.color.background',
-		'style.elements.h2.color.gradient',
-		'style.elements.h3.color.text',
-		'style.elements.h3.color.background',
-		'style.elements.h3.color.gradient',
-		'style.elements.h4.color.text',
-		'style.elements.h4.color.background',
-		'style.elements.h4.color.gradient',
-		'style.elements.h5.color.text',
-		'style.elements.h5.color.background',
-		'style.elements.h5.color.gradient',
-		'style.elements.h6.color.text',
-		'style.elements.h6.color.background',
-		'style.elements.h6.color.gradient',
-	);
-
-	foreach ( $heading_color_paths as $element_color_path ) {
-		$element_color = _wp_array_get( $block['attrs'], explode( '.', $element_color_path ), null );
-
-		if ( null !== $element_color && ! $skip_heading_color_serialization ) {
-			$element_colors_set++;
-		}
-	}
-
-	$button_color_paths = array(
-		'style.elements.button.color.text',
-		'style.elements.button.color.background',
-		'style.elements.button.color.gradient',
-	);
-
-	foreach ( $button_color_paths as $element_color_path ) {
-		$element_color = _wp_array_get( $block['attrs'], explode( '.', $element_color_path ), null );
-
-		if ( null !== $element_color && ! $skip_button_color_serialization ) {
-			$element_colors_set++;
+		foreach ( $element_config['paths'] as $path ) {
+			if ( null !== _wp_array_get( $block['attrs'], explode( '.', $path ), null ) ) {
+				$element_colors_set++;
+			}
 		}
 	}
 
@@ -147,62 +142,67 @@ function gutenberg_render_elements_support_styles( $pre_render, $block ) {
 
 	$class_name = gutenberg_get_elements_class_name( $block );
 
-	// Link colors.
-	$link_block_styles = isset( $element_block_styles['link'] ) ? $element_block_styles['link'] : null;
+	$element_types = array(
+		'button'  => array(
+			'selector' => ".$class_name .wp-element-button, .$class_name .wp-block-button__link",
+			'skip'     => $skip_button_color_serialization,
+		),
+		'link'    => array(
+			'selector'       => ".$class_name a",
+			'hover_selector' => ".$class_name a:hover",
+			'skip'           => $skip_link_color_serialization,
+		),
+		'heading' => array(
+			'selector' => ".$class_name h1, .$class_name h2, .$class_name h3, .$class_name h4, .$class_name h5, .$class_name h6",
+			'skip'     => $skip_heading_color_serialization,
+			'elements' => array( 'h1', 'h2', 'h3', 'h4', 'h5', 'h6' ),
+		),
+	);
 
-	if ( ! $skip_link_color_serialization && $link_block_styles ) {
-		gutenberg_style_engine_get_styles(
-			$link_block_styles,
-			array(
-				'selector' => ".$class_name a",
-				'context'  => 'block-supports',
-			)
-		);
+	foreach ( $element_types as $element_type => $element_config ) {
+		if ( $element_config['skip'] ) {
+			continue;
+		}
 
-		if ( isset( $link_block_styles[':hover'] ) ) {
+		$element_style_object = _wp_array_get( $element_block_styles, array( $element_type ), null );
+
+		// Process primary element type styles.
+		if ( $element_style_object ) {
 			gutenberg_style_engine_get_styles(
-				$link_block_styles[':hover'],
+				$element_style_object,
 				array(
-					'selector' => ".$class_name a:hover",
+					'selector' => $element_config['selector'],
 					'context'  => 'block-supports',
 				)
 			);
-		}
-	}
 
-	// Heading colors.
-	if ( ! $skip_heading_color_serialization ) {
-		$heading_levels = array( 'heading', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6' );
-
-		foreach ( $heading_levels as $heading_level ) {
-			$heading_block_styles = isset( $element_block_styles[ $heading_level ] ) ? $element_block_styles[ $heading_level ] : null;
-			$heading_selector     = 'heading' !== $heading_level
-				? ".$class_name $heading_level"
-				: ".$class_name h1, .$class_name h2, .$class_name h3, .$class_name h4, .$class_name h5, .$class_name h6";
-
-			if ( $heading_block_styles ) {
+			if ( isset( $element_style_object[':hover'] ) ) {
 				gutenberg_style_engine_get_styles(
-					$heading_block_styles,
+					$element_style_object[':hover'],
 					array(
-						'selector' => $heading_selector,
+						'selector' => $element_config['hover_selector'],
 						'context'  => 'block-supports',
 					)
 				);
 			}
 		}
-	}
 
-	// Button colors.
-	$button_block_styles = isset( $element_block_styles['button'] ) ? $element_block_styles['button'] : null;
+		// Process related elements e.g. h1-h6 for headings.
+		if ( isset( $element_config['elements'] ) ) {
+			foreach ( $element_config['elements'] as $element ) {
+				$element_style_object = _wp_array_get( $element_block_styles, array( $element ), null );
 
-	if ( ! $skip_button_color_serialization && $button_block_styles ) {
-		gutenberg_style_engine_get_styles(
-			$button_block_styles,
-			array(
-				'selector' => ".$class_name .wp-element-button, .$class_name .wp-block-button__link",
-				'context'  => 'block-supports',
-			)
-		);
+				if ( $element_style_object ) {
+					gutenberg_style_engine_get_styles(
+						$element_style_object,
+						array(
+							'selector' => ".$class_name $element",
+							'context'  => 'block-supports',
+						)
+					);
+				}
+			}
+		}
 	}
 
 	return null;

--- a/packages/block-editor/src/hooks/style.js
+++ b/packages/block-editor/src/hooks/style.js
@@ -34,6 +34,7 @@ import {
 } from './dimensions';
 import useDisplayBlockControls from '../components/use-display-block-controls';
 import { shouldSkipSerialization } from './utils';
+import { scopeSelector } from '../components/global-styles/utils';
 import { useBlockEditingMode } from '../components/block-editing-mode';
 
 const styleSupportKeys = [
@@ -382,11 +383,18 @@ const withElementsStyles = createHigherOrderComponent(
 		const blockElementsContainerIdentifier = `wp-elements-${ useInstanceId(
 			BlockListBlock
 		) }`;
+		const baseElementSelector = `.editor-styles-wrapper .${ blockElementsContainerIdentifier }`;
 
 		const skipLinkColorSerialization = shouldSkipSerialization(
 			props.name,
 			COLOR_SUPPORT_KEY,
 			'link'
+		);
+
+		const skipHeadingColorSerialization = shouldSkipSerialization(
+			props.name,
+			COLOR_SUPPORT_KEY,
+			'heading'
 		);
 
 		const styles = useMemo( () => {
@@ -398,14 +406,60 @@ const withElementsStyles = createHigherOrderComponent(
 					styles: ! skipLinkColorSerialization
 						? props.attributes.style?.elements?.link
 						: undefined,
-					selector: `.editor-styles-wrapper .${ blockElementsContainerIdentifier } ${ ELEMENTS.link }`,
+					selector: `${ baseElementSelector } ${ ELEMENTS.link }`,
 				},
 				{
 					styles: ! skipLinkColorSerialization
 						? props.attributes.style?.elements?.link?.[ ':hover' ]
 						: undefined,
-					selector: `.editor-styles-wrapper .${ blockElementsContainerIdentifier } ${ ELEMENTS.link }:hover`,
+					selector: `${ baseElementSelector } ${ ELEMENTS.link }:hover`,
 				},
+				{
+					styles: ! skipHeadingColorSerialization
+						? props.attributes.style?.elements?.heading
+						: undefined,
+					selector: scopeSelector(
+						baseElementSelector,
+						ELEMENTS.heading
+					),
+				},
+				{
+					styles: ! skipHeadingColorSerialization
+						? props.attributes.style?.elements?.h1
+						: undefined,
+					selector: scopeSelector( baseElementSelector, ELEMENTS.h1 ),
+				},
+				{
+					styles: ! skipHeadingColorSerialization
+						? props.attributes.style?.elements?.h2
+						: undefined,
+					selector: scopeSelector( baseElementSelector, ELEMENTS.h2 ),
+				},
+				{
+					styles: ! skipHeadingColorSerialization
+						? props.attributes.style?.elements?.h3
+						: undefined,
+					selector: scopeSelector( baseElementSelector, ELEMENTS.h3 ),
+				},
+				{
+					styles: ! skipHeadingColorSerialization
+						? props.attributes.style?.elements?.h4
+						: undefined,
+					selector: scopeSelector( baseElementSelector, ELEMENTS.h4 ),
+				},
+				{
+					styles: ! skipHeadingColorSerialization
+						? props.attributes.style?.elements?.h5
+						: undefined,
+					selector: scopeSelector( baseElementSelector, ELEMENTS.h5 ),
+				},
+				{
+					styles: ! skipHeadingColorSerialization
+						? props.attributes.style?.elements?.h6
+						: undefined,
+					selector: scopeSelector( baseElementSelector, ELEMENTS.h6 ),
+				},
+				//TODO: Refactor this to a helper that can more concisely flesh out the rest of the heading elements.
 			];
 			const elementCssRules = [];
 			for ( const { styles: elementStyles, selector } of elements ) {
@@ -421,7 +475,7 @@ const withElementsStyles = createHigherOrderComponent(
 				: undefined;
 		}, [
 			props.attributes.style?.elements,
-			blockElementsContainerIdentifier,
+			baseElementSelector,
 			skipLinkColorSerialization,
 		] );
 

--- a/packages/block-editor/src/hooks/style.js
+++ b/packages/block-editor/src/hooks/style.js
@@ -397,6 +397,12 @@ const withElementsStyles = createHigherOrderComponent(
 			'heading'
 		);
 
+		const skipButtonColorSerialization = shouldSkipSerialization(
+			props.name,
+			COLOR_SUPPORT_KEY,
+			'button'
+		);
+
 		const styles = useMemo( () => {
 			// The .editor-styles-wrapper selector is required on elements styles. As it is
 			// added to all other editor styles, not providing it causes reset and global
@@ -460,6 +466,15 @@ const withElementsStyles = createHigherOrderComponent(
 					selector: scopeSelector( baseElementSelector, ELEMENTS.h6 ),
 				},
 				//TODO: Refactor this to a helper that can more concisely flesh out the rest of the heading elements.
+				{
+					styles: ! skipButtonColorSerialization
+						? props.attributes.style?.elements?.button
+						: undefined,
+					selector: scopeSelector(
+						baseElementSelector,
+						ELEMENTS.button
+					),
+				},
 			];
 			const elementCssRules = [];
 			for ( const { styles: elementStyles, selector } of elements ) {

--- a/packages/block-editor/src/hooks/utils.js
+++ b/packages/block-editor/src/hooks/utils.js
@@ -167,6 +167,7 @@ export function useBlockSettings( name, parentLayout ) {
 	const isLinkEnabled = useSetting( 'color.link' );
 	const isTextEnabled = useSetting( 'color.text' );
 	const isHeadingEnabled = useSetting( 'color.heading' );
+	const isButtonEnabled = useSetting( 'color.button' );
 
 	const rawSettings = useMemo( () => {
 		return {
@@ -195,6 +196,7 @@ export function useBlockSettings( name, parentLayout ) {
 				background: isBackgroundEnabled,
 				link: isLinkEnabled,
 				heading: isHeadingEnabled,
+				button: isButtonEnabled,
 				text: isTextEnabled,
 			},
 			typography: {

--- a/packages/block-editor/src/hooks/utils.js
+++ b/packages/block-editor/src/hooks/utils.js
@@ -166,6 +166,7 @@ export function useBlockSettings( name, parentLayout ) {
 	const isBackgroundEnabled = useSetting( 'color.background' );
 	const isLinkEnabled = useSetting( 'color.link' );
 	const isTextEnabled = useSetting( 'color.text' );
+	const isHeadingEnabled = useSetting( 'color.heading' );
 
 	const rawSettings = useMemo( () => {
 		return {
@@ -193,6 +194,7 @@ export function useBlockSettings( name, parentLayout ) {
 				customDuotone,
 				background: isBackgroundEnabled,
 				link: isLinkEnabled,
+				heading: isHeadingEnabled,
 				text: isTextEnabled,
 			},
 			typography: {

--- a/packages/block-library/src/group/block.json
+++ b/packages/block-library/src/group/block.json
@@ -31,6 +31,7 @@
 		"color": {
 			"gradients": true,
 			"heading": true,
+			"button": true,
 			"link": true,
 			"__experimentalDefaultControls": {
 				"background": true,

--- a/packages/style-engine/class-wp-style-engine.php
+++ b/packages/style-engine/class-wp-style-engine.php
@@ -58,6 +58,9 @@ final class WP_Style_Engine {
 					'default' => 'background-color',
 				),
 				'path'          => array( 'color', 'background' ),
+				'css_vars'      => array(
+					'color' => '--wp--preset--color--$slug',
+				),
 				'classnames'    => array(
 					'has-background'             => true,
 					'has-$slug-background-color' => 'color',
@@ -66,6 +69,9 @@ final class WP_Style_Engine {
 			'gradient'   => array(
 				'property_keys' => array(
 					'default' => 'background',
+				),
+				'css_vars'      => array(
+					'gradient' => '--wp--preset--gradient--$slug',
 				),
 				'path'          => array( 'color', 'gradient' ),
 				'classnames'    => array(


### PR DESCRIPTION
Related:
- https://github.com/WordPress/gutenberg/issues/40318

## What?

Allows styling button and heading elements on individual block instances. 

_This PR only adds button & heading color support to the Group block, other container blocks can be updated in follow-ups._

## Why?

This is a small step towards allowing section specific styling based on container block instances. More background about the long term direction and goals can be found in https://github.com/WordPress/gutenberg/issues/40318 & https://github.com/WordPress/gutenberg/issues/48581.

## How?

- Updates the color block support to add style attribute object if button or heading color support is enabled
- Updates `elements.php` to inject block instance classname if any button or heading colors have been set
- Updates `elements.php` to generate CSS styles for button and heading element styles and add them to the block-supports context
- Updates `styles.js` hook to generate CSS styles for any button and heading element styles

_Note: The approach was refactored a little to use config arrays that might more easily be extended as we look to add further elements, e.g. caption, cite, or types of styles, e.g. typography._


## Testing Instructions

1. Add a group block to a post
2. Within that group block add a range of other blocks including at least, a paragraph with a link, some buttons, and several headings of different levels
3. Select the group block and apply element styles for links, buttons, and heading through the block inspector's color panel
4. Confirm these element styles are correctly displayed within the editor
5. Save the post and confirm matching application of styles of the fronend
6. Give link hover states a test along with gradient backgrounds
    - Note: Link hover element styles currently override button text color as buttons don't yet support `:hover`
    - Note: The generic "heading" element's gradient will override a simple background color set on a specific heading element e.g. `h1` - `h6`. This is an existing issue.


## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/60436221/5a704729-0438-44a8-8578-a2ad96eae1e7

