### PR TITLE
Scan the /patterns directory recursively to find patterns in subfolders.

### DIFF
--- a/lib/compat/wordpress-6.2/block-patterns.php
+++ b/lib/compat/wordpress-6.2/block-patterns.php
@@ -200,7 +200,7 @@ function gutenberg_register_theme_block_patterns() {
 			continue;
 		}
 		if ( file_exists( $dirpath ) ) {
-			$files = glob( $dirpath . '*.php' );
+			$files = _get_block_pattern_paths( $dirpath);
 			if ( $files ) {
 				foreach ( $files as $file ) {
 					$pattern_data = get_file_data( $file, $default_headers );
@@ -330,4 +330,25 @@ function gutenberg_normalize_remote_pattern( $pattern ) {
 	}
 
 	return (array) $pattern;
+}
+
+/**
+ * Finds all nested pattern file paths in a theme's directory.
+ *
+ * @since ?
+ * @access private
+ *
+ * @param string $base_directory The theme's file path.
+ * @return string[] A list of paths to all pattern files.
+ */
+function _get_block_pattern_paths( $base_directory ) {
+	$path_list = array();
+	if ( file_exists( $base_directory ) ) {
+		$nested_files      = new RecursiveIteratorIterator( new RecursiveDirectoryIterator( $base_directory ) );
+		$nested_html_files = new RegexIterator( $nested_files, '/^.+\.php$/i', RecursiveRegexIterator::GET_MATCH );
+		foreach ( $nested_html_files as $path => $file ) {
+			$path_list[] = $path;
+		}
+	}
+	return $path_list;
 }


### PR DESCRIPTION
Related:
- https://github.com/WordPress/gutenberg/issues/50144

## What?
Right now patterns can't be organized in subfolders, like [template parts](https://github.com/WordPress/gutenberg/issues/20375).

I'm not sure if this needs to be added to: `gutenberg/lib/compat/wordpress-6.2/block-patterns.php` or somewhere else and what to set as `@since`?

Furthermore, there are at least two functions that are similar and can perhaps be combined into one function:

[json-resolver-gutenberg.php#L703-L715](https://github.com/WordPress/gutenberg/blob/0048b22657b01a0eadd04b59c63f1a6535401709/lib/class-wp-theme-json-resolver-gutenberg.php#L703-L715) (Gutenberg plugin)
[block-template-utils.php#L223-L242](https://github.com/WordPress/wordpress-develop/blob/f107073f39827c2ab2b3b3198e194f844f357213/src/wp-includes/block-template-utils.php#L223-L242) (Wordpress Core)


## Why?
Better organize pattern files.

## How?
Scan the /patterns directory recursively to find patterns in subfolders.

## Testing Instructions
1. Add pattern in /patterns/subfolder/my-pattern.php
2. Open a post or page.
3. Confirm that 'my-pattern' shows up

### Testing Instructions for Keyboard
--
## Screenshots or screencast
--
