### PR TITLE
Edit Site: Enforce loading state

### DIFF
--- a/packages/edit-site/src/components/canvas-spinner/index.js
+++ b/packages/edit-site/src/components/canvas-spinner/index.js
@@ -22,14 +22,16 @@ const { ProgressBar } = unlock( componentsPrivateApis );
 const { useGlobalStyle } = unlock( blockEditorPrivateApis );
 
 export default function CanvasSpinner() {
-	const [ textColor ] = useGlobalStyle( 'color.text' );
+	const [ fallbackTrackColor ] = useGlobalStyle( 'color.text' );
 	const { highlightedColors } = useStylesPreviewColors();
 
-	const trackColor = highlightedColors[ 0 ]?.color ?? textColor;
+	const trackColor = highlightedColors[ 1 ]?.color ?? fallbackTrackColor;
 	const trackColord = colord( trackColor );
-	const indicatorColor = trackColord.isDark()
+	const fallbackIndicatorColor = trackColord.isDark()
 		? trackColord.tints( 3 )[ 1 ].toHex()
 		: trackColord.shades( 3 )[ 1 ].toHex();
+	const indicatorColor =
+		highlightedColors[ 0 ]?.color ?? fallbackIndicatorColor;
 
 	return (
 		<div className="edit-site-canvas-spinner">

--- a/packages/edit-site/src/components/canvas-spinner/index.js
+++ b/packages/edit-site/src/components/canvas-spinner/index.js
@@ -1,12 +1,42 @@
 /**
+ * External dependencies
+ */
+import { colord, extend } from 'colord';
+import mixPlugin from 'colord/plugins/mix';
+
+extend( [ mixPlugin ] );
+
+/**
  * WordPress dependencies
  */
-import { Spinner } from '@wordpress/components';
+import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
+import { privateApis as componentsPrivateApis } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import { unlock } from '../../lock-unlock';
+import { useStylesPreviewColors } from '../global-styles/hooks';
+
+const { ProgressBar } = unlock( componentsPrivateApis );
+const { useGlobalStyle } = unlock( blockEditorPrivateApis );
 
 export default function CanvasSpinner() {
+	const [ textColor ] = useGlobalStyle( 'color.text' );
+	const { highlightedColors } = useStylesPreviewColors();
+
+	const trackColor = highlightedColors[ 0 ]?.color ?? textColor;
+	const trackColord = colord( trackColor );
+	const indicatorColor = trackColord.isDark()
+		? trackColord.tints( 3 )[ 1 ].toHex()
+		: trackColord.shades( 3 )[ 1 ].toHex();
+
 	return (
 		<div className="edit-site-canvas-spinner">
-			<Spinner />
+			<ProgressBar
+				indicatorColor={ indicatorColor }
+				trackColor={ trackColor }
+			/>
 		</div>
 	);
 }

--- a/packages/edit-site/src/components/canvas-spinner/index.js
+++ b/packages/edit-site/src/components/canvas-spinner/index.js
@@ -22,20 +22,20 @@ const { ProgressBar, Theme } = unlock( componentsPrivateApis );
 const { useGlobalStyle } = unlock( blockEditorPrivateApis );
 
 export default function CanvasSpinner() {
-	const [ fallbackTrackColor ] = useGlobalStyle( 'color.text' );
+	const [ fallbackIndicatorColor ] = useGlobalStyle( 'color.text' );
 	const { highlightedColors } = useStylesPreviewColors();
 
-	const trackColor = highlightedColors[ 1 ]?.color ?? fallbackTrackColor;
-	const trackColord = colord( trackColor );
-	const fallbackIndicatorColor = trackColord.isDark()
-		? trackColord.tints( 3 )[ 1 ].toHex()
-		: trackColord.shades( 3 )[ 1 ].toHex();
 	const indicatorColor =
 		highlightedColors[ 0 ]?.color ?? fallbackIndicatorColor;
+	const grayscaleIndicatorColor = colord( indicatorColor ).grayscale();
+	const trackColorBase = grayscaleIndicatorColor.isDark()
+		? grayscaleIndicatorColor.tints( 3 )[ 1 ]
+		: grayscaleIndicatorColor.shades( 3 )[ 1 ];
+	const trackColor = trackColorBase.alpha( 0.5 ).toHex();
 
 	return (
 		<div className="edit-site-canvas-spinner">
-			<Theme background={ trackColor } accent={ indicatorColor }>
+			<Theme accent={ indicatorColor } background={ trackColor }>
 				<ProgressBar />
 			</Theme>
 		</div>

--- a/packages/edit-site/src/components/canvas-spinner/index.js
+++ b/packages/edit-site/src/components/canvas-spinner/index.js
@@ -13,7 +13,7 @@ import { useStylesPreviewColors } from '../global-styles/hooks';
 const { ProgressBar, Theme } = unlock( componentsPrivateApis );
 const { useGlobalStyle } = unlock( blockEditorPrivateApis );
 
-export default function CanvasSpinner() {
+export default function CanvasSpinner( { id } ) {
 	const [ fallbackIndicatorColor ] = useGlobalStyle( 'color.text' );
 	const [ backgroundColor ] = useGlobalStyle( 'color.background' );
 	const { highlightedColors } = useStylesPreviewColors();
@@ -23,7 +23,7 @@ export default function CanvasSpinner() {
 	return (
 		<div className="edit-site-canvas-spinner">
 			<Theme accent={ indicatorColor } background={ backgroundColor }>
-				<ProgressBar />
+				<ProgressBar id={ id } />
 			</Theme>
 		</div>
 	);

--- a/packages/edit-site/src/components/canvas-spinner/index.js
+++ b/packages/edit-site/src/components/canvas-spinner/index.js
@@ -1,12 +1,4 @@
 /**
- * External dependencies
- */
-import { colord, extend } from 'colord';
-import mixPlugin from 'colord/plugins/mix';
-
-extend( [ mixPlugin ] );
-
-/**
  * WordPress dependencies
  */
 import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
@@ -23,19 +15,14 @@ const { useGlobalStyle } = unlock( blockEditorPrivateApis );
 
 export default function CanvasSpinner() {
 	const [ fallbackIndicatorColor ] = useGlobalStyle( 'color.text' );
+	const [ backgroundColor ] = useGlobalStyle( 'color.background' );
 	const { highlightedColors } = useStylesPreviewColors();
-
 	const indicatorColor =
 		highlightedColors[ 0 ]?.color ?? fallbackIndicatorColor;
-	const grayscaleIndicatorColor = colord( indicatorColor ).grayscale();
-	const trackColorBase = grayscaleIndicatorColor.isDark()
-		? grayscaleIndicatorColor.tints( 3 )[ 1 ]
-		: grayscaleIndicatorColor.shades( 3 )[ 1 ];
-	const trackColor = trackColorBase.alpha( 0.5 ).toHex();
 
 	return (
 		<div className="edit-site-canvas-spinner">
-			<Theme accent={ indicatorColor } background={ trackColor }>
+			<Theme accent={ indicatorColor } background={ backgroundColor }>
 				<ProgressBar />
 			</Theme>
 		</div>

--- a/packages/edit-site/src/components/canvas-spinner/index.js
+++ b/packages/edit-site/src/components/canvas-spinner/index.js
@@ -18,7 +18,7 @@ import { privateApis as componentsPrivateApis } from '@wordpress/components';
 import { unlock } from '../../lock-unlock';
 import { useStylesPreviewColors } from '../global-styles/hooks';
 
-const { ProgressBar } = unlock( componentsPrivateApis );
+const { ProgressBar, Theme } = unlock( componentsPrivateApis );
 const { useGlobalStyle } = unlock( blockEditorPrivateApis );
 
 export default function CanvasSpinner() {
@@ -35,10 +35,9 @@ export default function CanvasSpinner() {
 
 	return (
 		<div className="edit-site-canvas-spinner">
-			<ProgressBar
-				indicatorColor={ indicatorColor }
-				trackColor={ trackColor }
-			/>
+			<Theme background={ trackColor } accent={ indicatorColor }>
+				<ProgressBar />
+			</Theme>
 		</div>
 	);
 }

--- a/packages/edit-site/src/components/canvas-spinner/style.scss
+++ b/packages/edit-site/src/components/canvas-spinner/style.scss
@@ -10,8 +10,8 @@
 	animation-fill-mode: forwards;
 	@include reduce-motion("animation");
 
-	circle {
-		stroke: rgba($black, 0.3);
+	.components-progress-bar {
+		max-width: 200px;
 	}
 }
 

--- a/packages/edit-site/src/components/canvas-spinner/style.scss
+++ b/packages/edit-site/src/components/canvas-spinner/style.scss
@@ -10,8 +10,8 @@
 	animation-fill-mode: forwards;
 	@include reduce-motion("animation");
 
-	.components-progress-bar {
-		max-width: 200px;
+	& > div {
+		width: 160px;
 	}
 }
 

--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -78,6 +78,7 @@ const blockRemovalRules = {
 };
 
 export default function Editor( { isLoading } ) {
+	isLoading = true;
 	const {
 		record: editedPost,
 		getTitle,

--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -9,6 +9,7 @@ import classnames from 'classnames';
 import { useMemo } from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { Notice } from '@wordpress/components';
+import { useInstanceId } from '@wordpress/compose';
 import { EntityProvider } from '@wordpress/core-data';
 import { store as preferencesStore } from '@wordpress/preferences';
 import {
@@ -178,9 +179,14 @@ export default function Editor( { isLoading } ) {
 	// action in <URLQueryController> from double-announcing.
 	useTitle( hasLoadedPost && title );
 
+	const loadingProgressId = useInstanceId(
+		CanvasSpinner,
+		'edit-site-editor__loading-progress'
+	);
+
 	return (
 		<>
-			{ isLoading ? <CanvasSpinner /> : null }
+			{ isLoading ? <CanvasSpinner id={ loadingProgressId } /> : null }
 			{ isEditMode && <WelcomeGuide /> }
 			<EntityProvider kind="root" type="site">
 				<EntityProvider
@@ -232,6 +238,10 @@ export default function Editor( { isLoading } ) {
 									) }
 								</>
 							}
+							contentProps={ {
+								'aria-busy': 'true',
+								'aria-describedby': loadingProgressId,
+							} }
 							secondarySidebar={
 								isEditMode &&
 								( ( shouldShowInserter && (

--- a/packages/edit-site/src/components/global-styles/hooks.js
+++ b/packages/edit-site/src/components/global-styles/hooks.js
@@ -16,7 +16,7 @@ import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
 import { unlock } from '../../lock-unlock';
 import { useSelect } from '@wordpress/data';
 
-const { useGlobalSetting } = unlock( blockEditorPrivateApis );
+const { useGlobalSetting, useGlobalStyle } = unlock( blockEditorPrivateApis );
 
 // Enable colord's a11y plugin.
 extend( [ a11yPlugin ] );
@@ -50,6 +50,32 @@ export function useColorRandomizer( name ) {
 	return window.__experimentalEnableColorRandomizer
 		? [ randomizeColors ]
 		: [];
+}
+
+export function useStylesPreviewColors() {
+	const [ textColor = 'black' ] = useGlobalStyle( 'color.text' );
+	const [ backgroundColor = 'white' ] = useGlobalStyle( 'color.background' );
+	const [ headingColor = textColor ] = useGlobalStyle(
+		'elements.h1.color.text'
+	);
+	const [ coreColors ] = useGlobalSetting( 'color.palette.core' );
+	const [ themeColors ] = useGlobalSetting( 'color.palette.theme' );
+	const [ customColors ] = useGlobalSetting( 'color.palette.custom' );
+
+	const paletteColors = ( themeColors ?? [] )
+		.concat( customColors ?? [] )
+		.concat( coreColors ?? [] );
+	const highlightedColors = paletteColors
+		.filter(
+			// we exclude these two colors because they are already visible in the preview.
+			( { color } ) => color !== backgroundColor && color !== headingColor
+		)
+		.slice( 0, 2 );
+
+	return {
+		paletteColors,
+		highlightedColors,
+	};
 }
 
 export function useSupportedStyles( name, element ) {

--- a/packages/edit-site/src/components/global-styles/preview.js
+++ b/packages/edit-site/src/components/global-styles/preview.js
@@ -18,8 +18,9 @@ import { useState, useMemo } from '@wordpress/element';
  * Internal dependencies
  */
 import { unlock } from '../../lock-unlock';
+import { useStylesPreviewColors } from './hooks';
 
-const { useGlobalSetting, useGlobalStyle, useGlobalStylesOutput } = unlock(
+const { useGlobalStyle, useGlobalStylesOutput } = unlock(
 	blockEditorPrivateApis
 );
 
@@ -76,22 +77,11 @@ const StylesPreview = ( { label, isFocused, withHoverView } ) => {
 	const [ gradientValue ] = useGlobalStyle( 'color.gradient' );
 	const [ styles ] = useGlobalStylesOutput();
 	const disableMotion = useReducedMotion();
-	const [ coreColors ] = useGlobalSetting( 'color.palette.core' );
-	const [ themeColors ] = useGlobalSetting( 'color.palette.theme' );
-	const [ customColors ] = useGlobalSetting( 'color.palette.custom' );
 	const [ isHovered, setIsHovered ] = useState( false );
 	const [ containerResizeListener, { width } ] = useResizeObserver();
 	const ratio = width ? width / normalizedWidth : 1;
 
-	const paletteColors = ( themeColors ?? [] )
-		.concat( customColors ?? [] )
-		.concat( coreColors ?? [] );
-	const highlightedColors = paletteColors
-		.filter(
-			// we exclude these two colors because they are already visible in the preview.
-			( { color } ) => color !== backgroundColor && color !== headingColor
-		)
-		.slice( 0, 2 );
+	const { paletteColors, highlightedColors } = useStylesPreviewColors();
 
 	// Reset leaked styles from WP common.css and remove main content layout padding and border.
 	const editorStyles = useMemo( () => {

--- a/packages/interface/src/components/interface-skeleton/index.js
+++ b/packages/interface/src/components/interface-skeleton/index.js
@@ -52,6 +52,7 @@ function InterfaceSkeleton(
 		secondarySidebar,
 		notices,
 		content,
+		contentProps,
 		actions,
 		labels,
 		className,
@@ -150,6 +151,7 @@ function InterfaceSkeleton(
 					<NavigableRegion
 						className="interface-interface-skeleton__content"
 						ariaLabel={ mergedLabels.body }
+						{ ...contentProps }
 					>
 						{ content }
 					</NavigableRegion>


### PR DESCRIPTION
## What?
This PR enforces an infinite loading state of the site editor.

Should not be merged - used only for testing #53032.

DO NOT MERGE.

## Why?
Used for testing #53032.

## How?
We're setting the loading state to `true`, making the site editor loading infinite, thus making it easier to test.

## Testing Instructions
See #53032.

### Testing Instructions for Keyboard
None.

## Screenshots or screencast <!-- if applicable -->
None.