### PR TITLE
UnsavedChangesWarning: Don't return a function from 'mapSelect'

### DIFF
--- a/packages/editor/src/components/unsaved-changes-warning/index.js
+++ b/packages/editor/src/components/unsaved-changes-warning/index.js
@@ -13,13 +13,7 @@ import { store as coreStore } from '@wordpress/core-data';
  * @return {WPComponent} The component.
  */
 export default function UnsavedChangesWarning() {
-	const isDirty = useSelect( ( select ) => {
-		return () => {
-			const { __experimentalGetDirtyEntityRecords } = select( coreStore );
-			const dirtyEntityRecords = __experimentalGetDirtyEntityRecords();
-			return dirtyEntityRecords.length > 0;
-		};
-	}, [] );
+	const { __experimentalGetDirtyEntityRecords } = useSelect( coreStore );
 
 	/**
 	 * Warns the user if there are unsaved changes before leaving the editor.
@@ -33,7 +27,8 @@ export default function UnsavedChangesWarning() {
 		// conditions with `BrowserURL` where `componentDidUpdate` gets the
 		// new value of `isEditedPostDirty` before this component does,
 		// causing this component to incorrectly think a trashed post is still dirty.
-		if ( isDirty() ) {
+		const dirtyEntityRecords = __experimentalGetDirtyEntityRecords();
+		if ( dirtyEntityRecords.length > 0 ) {
 			event.returnValue = __(
 				'You have unsaved changes. If you proceed, they will be lost.'
 			);

--- a/packages/editor/src/components/unsaved-changes-warning/index.js
+++ b/packages/editor/src/components/unsaved-changes-warning/index.js
@@ -15,34 +15,34 @@ import { store as coreStore } from '@wordpress/core-data';
 export default function UnsavedChangesWarning() {
 	const { __experimentalGetDirtyEntityRecords } = useSelect( coreStore );
 
-	/**
-	 * Warns the user if there are unsaved changes before leaving the editor.
-	 *
-	 * @param {Event} event `beforeunload` event.
-	 *
-	 * @return {string | undefined} Warning prompt message, if unsaved changes exist.
-	 */
-	const warnIfUnsavedChanges = ( event ) => {
-		// We need to call the selector directly in the listener to avoid race
-		// conditions with `BrowserURL` where `componentDidUpdate` gets the
-		// new value of `isEditedPostDirty` before this component does,
-		// causing this component to incorrectly think a trashed post is still dirty.
-		const dirtyEntityRecords = __experimentalGetDirtyEntityRecords();
-		if ( dirtyEntityRecords.length > 0 ) {
-			event.returnValue = __(
-				'You have unsaved changes. If you proceed, they will be lost.'
-			);
-			return event.returnValue;
-		}
-	};
-
 	useEffect( () => {
+		/**
+		 * Warns the user if there are unsaved changes before leaving the editor.
+		 *
+		 * @param {Event} event `beforeunload` event.
+		 *
+		 * @return {string | undefined} Warning prompt message, if unsaved changes exist.
+		 */
+		const warnIfUnsavedChanges = ( event ) => {
+			// We need to call the selector directly in the listener to avoid race
+			// conditions with `BrowserURL` where `componentDidUpdate` gets the
+			// new value of `isEditedPostDirty` before this component does,
+			// causing this component to incorrectly think a trashed post is still dirty.
+			const dirtyEntityRecords = __experimentalGetDirtyEntityRecords();
+			if ( dirtyEntityRecords.length > 0 ) {
+				event.returnValue = __(
+					'You have unsaved changes. If you proceed, they will be lost.'
+				);
+				return event.returnValue;
+			}
+		};
+
 		window.addEventListener( 'beforeunload', warnIfUnsavedChanges );
 
 		return () => {
 			window.removeEventListener( 'beforeunload', warnIfUnsavedChanges );
 		};
-	}, [] );
+	}, [ __experimentalGetDirtyEntityRecords ] );
 
 	return null;
 }


### PR DESCRIPTION
## What?
Discovered while working on #53666.

PR refactors the `UnsavedChangesWarning` component to avoid returning a callback from `mapSelect`. Instead, use the `__experimentalGetDirtyEntityRecords` selector directly.

It also fixes ESLint warnings for the `useEffect` hook. The changes are in separate commit - 8ea99fb1b90f963bd7c67c18d26c425b31d974d9.

## Why?
The `mapSelect` returns a new callback value on every call and this can lead to unnecessary rerenders.

## Testing Instructions
 1. Open a post or page.
 2. Make changes to content.
 3. Try reloading the page.
 4. Warning about unsaved changes should be visible.

## Screenshots or screencast <!-- if applicable -->

![CleanShot 2023-08-15 at 14 13 22](https://github.com/WordPress/gutenberg/assets/240569/1bb37ce7-5e68-47ac-bc39-be08471b445d)

