### PR TITLE
Template Parts: Return a stable reference for the defined 'area'

### DIFF
--- a/packages/block-library/src/template-part/edit/advanced-controls.js
+++ b/packages/block-library/src/template-part/edit/advanced-controls.js
@@ -12,6 +12,27 @@ import { useSelect } from '@wordpress/data';
  */
 import { TemplatePartImportControls } from './import-controls';
 
+const htmlElementMessages = {
+	header: __(
+		'The <header> element should represent introductory content, typically a group of introductory or navigational aids.'
+	),
+	main: __(
+		'The <main> element should be used for the primary content of your document only.'
+	),
+	section: __(
+		"The <section> element should represent a standalone portion of the document that can't be better represented by another element."
+	),
+	article: __(
+		'The <article> element should represent a self-contained, syndicatable portion of the document.'
+	),
+	aside: __(
+		"The <aside> element should represent a portion of a document whose content is only indirectly related to the document's main content."
+	),
+	footer: __(
+		'The <footer> element should represent a footer for its nearest sectioning element (e.g.: <section>, <article>, <main> etc.).'
+	),
+};
+
 export function TemplatePartAdvancedControls( {
 	tagName,
 	setAttributes,
@@ -47,27 +68,6 @@ export function TemplatePartAdvancedControls( {
 		label,
 		value: _area,
 	} ) );
-
-	const htmlElementMessages = {
-		header: __(
-			'The <header> element should represent introductory content, typically a group of introductory or navigational aids.'
-		),
-		main: __(
-			'The <main> element should be used for the primary content of your document only. '
-		),
-		section: __(
-			"The <section> element should represent a standalone portion of the document that can't be better represented by another element."
-		),
-		article: __(
-			'The <article> element should represent a self-contained, syndicatable portion of the document.'
-		),
-		aside: __(
-			"The <aside> element should represent a portion of a document whose content is only indirectly related to the document's main content."
-		),
-		footer: __(
-			'The <footer> element should represent a footer for its nearest sectioning element (e.g.: <section>, <article>, <main> etc.).'
-		),
-	};
 
 	return (
 		<InspectorControls group="advanced">

--- a/packages/block-library/src/template-part/edit/advanced-controls.js
+++ b/packages/block-library/src/template-part/edit/advanced-controls.js
@@ -34,20 +34,19 @@ export function TemplatePartAdvancedControls( {
 		templatePartId
 	);
 
-	const { areaOptions } = useSelect( ( select ) => {
+	const definedAreas = useSelect( ( select ) => {
 		// FIXME: @wordpress/block-library should not depend on @wordpress/editor.
 		// Blocks can be loaded into a *non-post* block editor.
-		/* eslint-disable @wordpress/data-no-store-string-literals */
-		const definedAreas =
-			select( 'core/editor' ).__experimentalGetDefaultTemplatePartAreas();
-		/* eslint-enable @wordpress/data-no-store-string-literals */
-		return {
-			areaOptions: definedAreas.map( ( { label, area: _area } ) => ( {
-				label,
-				value: _area,
-			} ) ),
-		};
+		/* eslint-disable-next-line @wordpress/data-no-store-string-literals */
+		return select(
+			'core/editor'
+		).__experimentalGetDefaultTemplatePartAreas();
 	}, [] );
+
+	const areaOptions = definedAreas.map( ( { label, area: _area } ) => ( {
+		label,
+		value: _area,
+	} ) );
 
 	const htmlElementMessages = {
 		header: __(


### PR DESCRIPTION
## What?
Discovered while working on #53666.

PR updates the `TemplatePartAdvancedControls` component and avoids returning new array references from `mapSelect`.

Note: I've also moved `htmlElementMessages` definitions outside the component to avoid recreating a map object on each render.

## Why?
Array operations like `filter` and `map` will return a new array on each `mapSelect` call. This can cause unnecessary rerenders.

## Testing Instructions
1. Open the Site Editor.
2. Select a template part.
3. Confirm "Area" dropdown is rendered as before in Advanced controls.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2023-08-15 at 14 29 00](https://github.com/WordPress/gutenberg/assets/240569/07344858-fb6f-476e-94be-14c9fb996ecc)
