### PR TITLE
Refactor latest content selectors in 'CopyContentMenuItem' components

### DIFF
--- a/packages/edit-post/src/plugins/copy-content-menu-item/index.js
+++ b/packages/edit-post/src/plugins/copy-content-menu-item/index.js
@@ -10,11 +10,11 @@ import { store as editorStore } from '@wordpress/editor';
 
 export default function CopyContentMenuItem() {
 	const { createNotice } = useDispatch( noticesStore );
-	const getText = useSelect(
-		( select ) => () =>
-			select( editorStore ).getEditedPostAttribute( 'content' ),
-		[]
-	);
+	const { getEditedPostAttribute } = useSelect( editorStore );
+
+	function getText() {
+		return getEditedPostAttribute( 'content' );
+	}
 
 	function onSuccess() {
 		createNotice( 'info', __( 'All content copied.' ), {

--- a/packages/edit-site/src/components/header-edit-mode/more-menu/copy-content-menu-item.js
+++ b/packages/edit-site/src/components/header-edit-mode/more-menu/copy-content-menu-item.js
@@ -16,28 +16,27 @@ import { store as editSiteStore } from '../../../store';
 
 export default function CopyContentMenuItem() {
 	const { createNotice } = useDispatch( noticesStore );
-	const getText = useSelect( ( select ) => {
-		return () => {
-			const { getEditedPostId, getEditedPostType } =
-				select( editSiteStore );
-			const { getEditedEntityRecord } = select( coreStore );
-			const record = getEditedEntityRecord(
-				'postType',
-				getEditedPostType(),
-				getEditedPostId()
-			);
-			if ( record ) {
-				if ( typeof record.content === 'function' ) {
-					return record.content( record );
-				} else if ( record.blocks ) {
-					return __unstableSerializeAndClean( record.blocks );
-				} else if ( record.content ) {
-					return record.content;
-				}
-			}
+	const { getEditedPostId, getEditedPostType } = useSelect( editSiteStore );
+	const { getEditedEntityRecord } = useSelect( coreStore );
+
+	function getText() {
+		const record = getEditedEntityRecord(
+			'postType',
+			getEditedPostType(),
+			getEditedPostId()
+		);
+		if ( ! record ) {
 			return '';
-		};
-	}, [] );
+		}
+
+		if ( typeof record.content === 'function' ) {
+			return record.content( record );
+		} else if ( record.blocks ) {
+			return __unstableSerializeAndClean( record.blocks );
+		} else if ( record.content ) {
+			return record.content;
+		}
+	}
 
 	function onSuccess() {
 		createNotice( 'info', __( 'All content copied.' ), {


### PR DESCRIPTION
## What?
Discovered while working on #53666.
This is similar to #53672.

PR refactors the latest content selectors in the 'CopyContentMenuItem' components to avoid returning a callback from the `useSelect` hook.

## Why?
The `mapSelect` returns a new callback value on every call, and this can lead to unnecessary rerenders.

## Testing Instructions
Confirm "Copy all blocks" feature works as before in post and site editors.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2023-08-15 at 14 54 58](https://github.com/WordPress/gutenberg/assets/240569/4d250208-0ef0-4058-bf97-38e5b51dc9da)
