### PR TITLE
Remove unneeded block.json name-only imports

### DIFF
--- a/packages/block-library/src/buttons/transforms.js
+++ b/packages/block-library/src/buttons/transforms.js
@@ -4,11 +4,6 @@
 import { createBlock } from '@wordpress/blocks';
 import { __unstableCreateElement as createElement } from '@wordpress/rich-text';
 
-/**
- * Internal dependencies
- */
-import { name } from './block.json';
-
 const transforms = {
 	from: [
 		{
@@ -18,7 +13,7 @@ const transforms = {
 			transform: ( buttons ) =>
 				// Creates the buttons block.
 				createBlock(
-					name,
+					'core/buttons',
 					{},
 					// Loop the selected buttons.
 					buttons.map( ( attributes ) =>
@@ -34,7 +29,7 @@ const transforms = {
 			transform: ( buttons ) =>
 				// Creates the buttons block.
 				createBlock(
-					name,
+					'core/buttons',
 					{},
 					// Loop the selected buttons.
 					buttons.map( ( attributes ) => {

--- a/packages/block-library/src/footnotes/format.js
+++ b/packages/block-library/src/footnotes/format.js
@@ -20,7 +20,6 @@ import { createBlock, store as blocksStore } from '@wordpress/blocks';
 /**
  * Internal dependencies
  */
-import { name } from './block.json';
 import { unlock } from '../lock-unlock';
 
 const { usesContextKey } = unlock( privateApis );
@@ -53,9 +52,11 @@ export const format = {
 			getBlockRootClientId,
 			getBlockName,
 			getBlockParentsByBlockName,
-		} = useSelect( blockEditorStore );
-		const footnotesBlockType = useSelect( ( select ) =>
-			select( blocksStore ).getBlockType( name )
+		} = registry.select( blockEditorStore );
+		const hasFootnotesBlockType = useSelect(
+			( select ) =>
+				!! select( blocksStore ).getBlockType( 'core/footnotes' ),
+			[]
 		);
 		/*
 		 * This useSelect exists because we need to use its return value
@@ -76,7 +77,7 @@ export const format = {
 		const { selectionChange, insertBlock } =
 			useDispatch( blockEditorStore );
 
-		if ( ! footnotesBlockType ) {
+		if ( ! hasFootnotesBlockType ) {
 			return null;
 		}
 
@@ -136,7 +137,7 @@ export const format = {
 					const queue = [ ...blocks ];
 					while ( queue.length ) {
 						const block = queue.shift();
-						if ( block.name === name ) {
+						if ( block.name === 'core/footnotes' ) {
 							fnBlock = block;
 							break;
 						}
@@ -157,7 +158,7 @@ export const format = {
 						rootClientId = getBlockRootClientId( rootClientId );
 					}
 
-					fnBlock = createBlock( name );
+					fnBlock = createBlock( 'core/footnotes' );
 
 					insertBlock( fnBlock, undefined, rootClientId );
 				}

--- a/packages/block-library/src/heading/transforms.js
+++ b/packages/block-library/src/heading/transforms.js
@@ -7,7 +7,6 @@ import { createBlock, getBlockAttributes } from '@wordpress/blocks';
  * Internal dependencies
  */
 import { getLevelFromHeadingNodeName } from './shared';
-import { name } from './block.json';
 
 const transforms = {
 	from: [
@@ -17,7 +16,7 @@ const transforms = {
 			blocks: [ 'core/paragraph' ],
 			transform: ( attributes ) =>
 				attributes.map( ( { content, anchor, align: textAlign } ) =>
-					createBlock( name, {
+					createBlock( 'core/heading', {
 						content,
 						anchor,
 						textAlign,
@@ -42,7 +41,10 @@ const transforms = {
 				};
 			},
 			transform( node ) {
-				const attributes = getBlockAttributes( name, node.outerHTML );
+				const attributes = getBlockAttributes(
+					'core/heading',
+					node.outerHTML
+				);
 				const { textAlign } = node.style || {};
 
 				attributes.level = getLevelFromHeadingNodeName( node.nodeName );
@@ -55,14 +57,14 @@ const transforms = {
 					attributes.align = textAlign;
 				}
 
-				return createBlock( name, attributes );
+				return createBlock( 'core/heading', attributes );
 			},
 		},
 		...[ 1, 2, 3, 4, 5, 6 ].map( ( level ) => ( {
 			type: 'prefix',
 			prefix: Array( level + 1 ).join( '#' ),
 			transform( content ) {
-				return createBlock( name, {
+				return createBlock( 'core/heading', {
 					level,
 					content,
 				} );
@@ -72,7 +74,7 @@ const transforms = {
 			type: 'enter',
 			regExp: new RegExp( `^/(h|H)${ level }$` ),
 			transform( content ) {
-				return createBlock( name, {
+				return createBlock( 'core/heading', {
 					level,
 					content,
 				} );

--- a/packages/block-library/src/list-item/hooks/use-merge.js
+++ b/packages/block-library/src/list-item/hooks/use-merge.js
@@ -9,8 +9,6 @@ import { store as blockEditorStore } from '@wordpress/block-editor';
  */
 import useOutdentListItem from './use-outdent-list-item';
 
-import { name as listItemName } from '../block.json';
-
 export default function useMerge( clientId, onMerge ) {
 	const registry = useRegistry();
 	const {
@@ -38,7 +36,7 @@ export default function useMerge( clientId, onMerge ) {
 		const listId = getBlockRootClientId( id );
 		const parentListItemId = getBlockRootClientId( listId );
 		if ( ! parentListItemId ) return;
-		if ( getBlockName( parentListItemId ) !== listItemName ) return;
+		if ( getBlockName( parentListItemId ) !== 'core/list-item' ) return;
 		return parentListItemId;
 	}
 

--- a/packages/block-library/src/list-item/hooks/use-outdent-list-item.js
+++ b/packages/block-library/src/list-item/hooks/use-outdent-list-item.js
@@ -6,11 +6,6 @@ import { useSelect, useDispatch, useRegistry } from '@wordpress/data';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 import { cloneBlock } from '@wordpress/blocks';
 
-/**
- * Internal dependencies
- */
-import { name as listItemName } from '../block.json';
-
 export default function useOutdentListItem( clientId ) {
 	const registry = useRegistry();
 	const { canOutdent } = useSelect(
@@ -21,7 +16,7 @@ export default function useOutdentListItem( clientId ) {
 				getBlockRootClientId( clientId )
 			);
 			const grandParentName = getBlockName( grandParentId );
-			const isListItem = grandParentName === listItemName;
+			const isListItem = grandParentName === 'core/list-item';
 
 			return {
 				canOutdent: isListItem,
@@ -49,7 +44,7 @@ export default function useOutdentListItem( clientId ) {
 		const listId = getBlockRootClientId( id );
 		const parentListItemId = getBlockRootClientId( listId );
 		if ( ! parentListItemId ) return;
-		if ( getBlockName( parentListItemId ) !== listItemName ) return;
+		if ( getBlockName( parentListItemId ) !== 'core/list-item' ) return;
 		return parentListItemId;
 	}
 
@@ -65,7 +60,7 @@ export default function useOutdentListItem( clientId ) {
 			const firstClientId = clientIds[ 0 ];
 
 			// Can't outdent if it's not a list item.
-			if ( getBlockName( firstClientId ) !== listItemName ) return;
+			if ( getBlockName( firstClientId ) !== 'core/list-item' ) return;
 
 			const parentListItemId = getParentListItemId( firstClientId );
 

--- a/packages/block-library/src/list-item/utils.js
+++ b/packages/block-library/src/list-item/utils.js
@@ -1,40 +1,27 @@
 /**
  * WordPress dependencies
  */
-import { createBlock, switchToBlockType } from '@wordpress/blocks';
-
-/**
- * Internal dependencies
- */
-import { name as listItemName } from './block.json';
-import { name as listName } from '../list/block.json';
-import { name as paragraphName } from '../paragraph/block.json';
-
-export function createListItem( listItemAttributes, listAttributes, children ) {
-	return createBlock(
-		listItemName,
-		listItemAttributes,
-		! children?.length
-			? []
-			: [ createBlock( listName, listAttributes, children ) ]
-	);
-}
+import { switchToBlockType } from '@wordpress/blocks';
 
 function convertBlockToList( block ) {
-	const list = switchToBlockType( block, listName );
-	if ( list ) return list;
-	const paragraph = switchToBlockType( block, paragraphName );
-	if ( paragraph ) return switchToBlockType( paragraph, listName );
-	return null;
+	const list = switchToBlockType( block, 'core/list' );
+	if ( list ) {
+		return list;
+	}
+	const paragraph = switchToBlockType( block, 'core/paragraph' );
+	if ( ! paragraph ) {
+		return null;
+	}
+	return switchToBlockType( paragraph, 'core/list' );
 }
 
 export function convertToListItems( blocks ) {
 	const listItems = [];
 
 	for ( let block of blocks ) {
-		if ( block.name === listItemName ) {
+		if ( block.name === 'core/list-item' ) {
 			listItems.push( block );
-		} else if ( block.name === listName ) {
+		} else if ( block.name === 'core/list' ) {
 			listItems.push( ...block.innerBlocks );
 		} else if ( ( block = convertBlockToList( block ) ) ) {
 			for ( const { innerBlocks } of block ) {

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -41,7 +41,6 @@ import { useMergeRefs } from '@wordpress/compose';
 /**
  * Internal dependencies
  */
-import { name } from './block.json';
 import { LinkUI } from './link-ui';
 import { updateAttributes } from './update-attributes';
 import { getColors } from '../navigation/edit/utils';
@@ -206,7 +205,7 @@ export default function NavigationLinkEdit( {
 				innerBlocks: getBlocks( clientId ),
 				isAtMaxNesting:
 					getBlockParentsByBlockName( clientId, [
-						name,
+						'core/navigation-link',
 						'core/navigation-submenu',
 					] ).length >= maxNestingLevel,
 				isTopLevelLink:

--- a/packages/block-library/src/navigation-submenu/edit.js
+++ b/packages/block-library/src/navigation-submenu/edit.js
@@ -39,7 +39,6 @@ import { useMergeRefs, usePrevious } from '@wordpress/compose';
  * Internal dependencies
  */
 import { ItemSubmenuIcon } from './icons';
-import { name } from './block.json';
 import { LinkUI } from '../navigation-link/link-ui';
 import { updateAttributes } from '../navigation-link/update-attributes';
 import {
@@ -155,8 +154,7 @@ export default function NavigationSubmenuEdit( {
 	const postsPermissions = useResourcePermissions( 'posts' );
 
 	const {
-		isAtMaxNesting,
-		isTopLevelItem,
+		parentCount,
 		isParentOfSelectedBlock,
 		isImmediateParentOfSelectedBlock,
 		hasChildren,
@@ -191,11 +189,10 @@ export default function NavigationSubmenuEdit( {
 			}
 
 			return {
-				isAtMaxNesting:
-					getBlockParentsByBlockName( clientId, name ).length >=
-					maxNestingLevel,
-				isTopLevelItem:
-					getBlockParentsByBlockName( clientId, name ).length === 0,
+				parentCount: getBlockParentsByBlockName(
+					clientId,
+					'core/navigation-submenu'
+				).length,
 				isParentOfSelectedBlock: hasSelectedInnerBlock(
 					clientId,
 					true
@@ -278,7 +275,7 @@ export default function NavigationSubmenuEdit( {
 		customTextColor,
 		backgroundColor,
 		customBackgroundColor,
-	} = getColors( context, ! isTopLevelItem );
+	} = getColors( context, parentCount > 0 );
 
 	function onKeyDown( event ) {
 		if ( isKeyboardEvent.primary( event, 'k' ) ) {
@@ -310,11 +307,12 @@ export default function NavigationSubmenuEdit( {
 	// Always use overlay colors for submenus.
 	const innerBlocksColors = getColors( context, true );
 
-	const allowedBlocks = isAtMaxNesting
-		? ALLOWED_BLOCKS.filter(
-				( blockName ) => blockName !== 'core/navigation-submenu'
-		  )
-		: ALLOWED_BLOCKS;
+	const allowedBlocks =
+		parentCount >= maxNestingLevel
+			? ALLOWED_BLOCKS.filter(
+					( blockName ) => blockName !== 'core/navigation-submenu'
+			  )
+			: ALLOWED_BLOCKS;
 
 	const navigationChildBlockProps =
 		getNavigationChildBlockProps( innerBlocksColors );

--- a/packages/block-library/src/query/utils.js
+++ b/packages/block-library/src/query/utils.js
@@ -8,11 +8,6 @@ import { store as blockEditorStore } from '@wordpress/block-editor';
 import { decodeEntities } from '@wordpress/html-entities';
 import { cloneBlock, store as blocksStore } from '@wordpress/blocks';
 
-/**
- * Internal dependencies
- */
-import { name as queryLoopName } from './block.json';
-
 /** @typedef {import('@wordpress/blocks').WPBlockVariation} WPBlockVariation */
 
 /**
@@ -175,7 +170,7 @@ export function useAllowedControls( attributes ) {
 	return useSelect(
 		( select ) =>
 			select( blocksStore ).getActiveBlockVariation(
-				queryLoopName,
+				'core/query',
 				attributes
 			)?.allowedControls,
 
@@ -249,25 +244,29 @@ export function useBlockNameForPatterns( clientId, attributes ) {
 	const activeVariationName = useSelect(
 		( select ) =>
 			select( blocksStore ).getActiveBlockVariation(
-				queryLoopName,
+				'core/query',
 				attributes
 			)?.name,
 		[ attributes ]
 	);
-	const blockName = `${ queryLoopName }/${ activeVariationName }`;
-	const activeVariationPatterns = useSelect(
+	const blockName = `core/query/${ activeVariationName }`;
+	const hasActiveVariationPatterns = useSelect(
 		( select ) => {
 			if ( ! activeVariationName ) {
-				return;
+				return false;
 			}
 			const { getBlockRootClientId, getPatternsByBlockTypes } =
 				select( blockEditorStore );
 			const rootClientId = getBlockRootClientId( clientId );
-			return getPatternsByBlockTypes( blockName, rootClientId );
+			const activePatterns = getPatternsByBlockTypes(
+				blockName,
+				rootClientId
+			);
+			return activePatterns.length > 0;
 		},
-		[ clientId, activeVariationName ]
+		[ clientId, activeVariationName, blockName ]
 	);
-	return activeVariationPatterns?.length ? blockName : queryLoopName;
+	return hasActiveVariationPatterns ? blockName : 'core/query';
 }
 
 /**
@@ -300,10 +299,10 @@ export function useScopedBlockVariations( attributes ) {
 				select( blocksStore );
 			return {
 				activeVariationName: getActiveBlockVariation(
-					queryLoopName,
+					'core/query',
 					attributes
 				)?.name,
-				blockVariations: getBlockVariations( queryLoopName, 'block' ),
+				blockVariations: getBlockVariations( 'core/query', 'block' ),
 			};
 		},
 		[ attributes ]


### PR DESCRIPTION
Incremental step towards adopting standard JSON module imports, see also #34176 and #53470. This PR removes imports from `block.json` files that only care about the block name (e.g., `core/heading`).

The code reads better (less indirection, better greppable) when the block names are hardcoded as strings. You will notice that virtually every modified file already references other block names as strings anyway.

Also, the JSON modules standard doesn't support named imports, only default ones. So, named import usages would need to be modified anyway, and here we solve the problem by removing them.

Because JSON imports are currently inlined by a Babel plugin, the `block-library` will get a bit smaller, now that full `block.json` files are no longer inlined just to read the `.name` field.

The only remaining places that import `block.json` files are the block registration scripts.