### PR TITLE
Remove empty usages of BlockPreviewPanel

### DIFF
--- a/packages/edit-site/src/components/global-styles/screen-colors.js
+++ b/packages/edit-site/src/components/global-styles/screen-colors.js
@@ -10,7 +10,6 @@ import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
  */
 import ScreenHeader from './header';
 import Palette from './palette';
-import BlockPreviewPanel from './block-preview-panel';
 import { unlock } from '../../lock-unlock';
 
 const {
@@ -38,9 +37,6 @@ function ScreenColors() {
 					'Manage palettes and the default color of different global elements on the site.'
 				) }
 			/>
-
-			<BlockPreviewPanel />
-
 			<div className="edit-site-global-styles-screen-colors">
 				<VStack spacing={ 10 }>
 					<Palette />

--- a/packages/edit-site/src/components/global-styles/screen-layout.js
+++ b/packages/edit-site/src/components/global-styles/screen-layout.js
@@ -9,7 +9,6 @@ import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
  */
 import DimensionsPanel from './dimensions-panel';
 import ScreenHeader from './header';
-import BlockPreviewPanel from './block-preview-panel';
 import { unlock } from '../../lock-unlock';
 
 const { useHasDimensionsPanel, useGlobalSetting, useSettingsForBlockElement } =
@@ -22,7 +21,6 @@ function ScreenLayout() {
 	return (
 		<>
 			<ScreenHeader title={ __( 'Layout' ) } />
-			<BlockPreviewPanel />
 			{ hasDimensionsPanel && <DimensionsPanel /> }
 		</>
 	);

--- a/packages/edit-site/src/components/global-styles/screen-typography.js
+++ b/packages/edit-site/src/components/global-styles/screen-typography.js
@@ -16,7 +16,6 @@ import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
 import ScreenHeader from './header';
 import { NavigationButtonAsItem } from './navigation-button';
 import Subtitle from './subtitle';
-import BlockPreviewPanel from './block-preview-panel';
 import { unlock } from '../../lock-unlock';
 
 const { useGlobalStyle } = unlock( blockEditorPrivateApis );
@@ -83,9 +82,6 @@ function ScreenTypography() {
 					'Manage the typography settings for different elements.'
 				) }
 			/>
-
-			<BlockPreviewPanel />
-
 			<div className="edit-site-global-styles-screen-typography">
 				<VStack spacing={ 3 }>
 					<Subtitle level={ 3 }>{ __( 'Elements' ) }</Subtitle>


### PR DESCRIPTION
Followup to #49428. When working on #53640, I noticed that we're rendering `<BlockPreviewPanel>` instances with no `name` and `variation` props. There are going to be rendered as `null` -- there's no block to preview. They can be completely removed.