### PR TITLE
Dependencies: Update @testing-library/react to v14

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -108,7 +108,7 @@
 				"@storybook/source-loader": "7.2.2",
 				"@storybook/theming": "7.2.2",
 				"@testing-library/jest-dom": "5.16.5",
-				"@testing-library/react": "13.4.0",
+				"@testing-library/react": "14.0.0",
 				"@testing-library/react-native": "12.1.2",
 				"@testing-library/user-event": "14.4.3",
 				"@types/eslint": "7.28.0",
@@ -13737,17 +13737,17 @@
 			}
 		},
 		"node_modules/@testing-library/react": {
-			"version": "13.4.0",
-			"resolved": "https://registry.npmjs.org/@testing-library/react/-/react-13.4.0.tgz",
-			"integrity": "sha512-sXOGON+WNTh3MLE9rve97ftaZukN3oNf2KjDy7YTx6hcTO2uuLHuCGynMDhFwGw/jYf4OJ2Qk0i4i79qMNNkyw==",
+			"version": "14.0.0",
+			"resolved": "https://registry.npmjs.org/@testing-library/react/-/react-14.0.0.tgz",
+			"integrity": "sha512-S04gSNJbYE30TlIMLTzv6QCTzt9AqIF5y6s6SzVFILNcNvbV/jU96GeiTPillGQo+Ny64M/5PV7klNYYgv5Dfg==",
 			"dev": true,
 			"dependencies": {
 				"@babel/runtime": "^7.12.5",
-				"@testing-library/dom": "^8.5.0",
+				"@testing-library/dom": "^9.0.0",
 				"@types/react-dom": "^18.0.0"
 			},
 			"engines": {
-				"node": ">=12"
+				"node": ">=14"
 			},
 			"peerDependencies": {
 				"react": "^18.0.0",
@@ -13773,6 +13773,107 @@
 					"optional": true
 				}
 			}
+		},
+		"node_modules/@testing-library/react/node_modules/@testing-library/dom": {
+			"version": "9.3.1",
+			"resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-9.3.1.tgz",
+			"integrity": "sha512-0DGPd9AR3+iDTjGoMpxIkAsUihHZ3Ai6CneU6bRRrffXMgzCdlNk43jTrD2/5LT6CBb3MWTP8v510JzYtahD2w==",
+			"dev": true,
+			"dependencies": {
+				"@babel/code-frame": "^7.10.4",
+				"@babel/runtime": "^7.12.5",
+				"@types/aria-query": "^5.0.1",
+				"aria-query": "5.1.3",
+				"chalk": "^4.1.0",
+				"dom-accessibility-api": "^0.5.9",
+				"lz-string": "^1.5.0",
+				"pretty-format": "^27.0.2"
+			},
+			"engines": {
+				"node": ">=14"
+			}
+		},
+		"node_modules/@testing-library/react/node_modules/@types/aria-query": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.1.tgz",
+			"integrity": "sha512-XTIieEY+gvJ39ChLcB4If5zHtPxt3Syj5rgZR+e1ctpmK8NjPf0zFqsz4JpLJT0xla9GFDKjy8Cpu331nrmE1Q==",
+			"dev": true
+		},
+		"node_modules/@testing-library/react/node_modules/ansi-styles": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/@testing-library/react/node_modules/aria-query": {
+			"version": "5.1.3",
+			"resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.1.3.tgz",
+			"integrity": "sha512-R5iJ5lkuHybztUfuOAznmboyjWq8O6sqNqtK7CLOqdydi54VNbORp49mb14KbWgG1QD3JFO9hJdZ+y4KutfdOQ==",
+			"dev": true,
+			"dependencies": {
+				"deep-equal": "^2.0.5"
+			}
+		},
+		"node_modules/@testing-library/react/node_modules/deep-equal": {
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.2.2.tgz",
+			"integrity": "sha512-xjVyBf0w5vH0I42jdAZzOKVldmPgSulmiyPRywoyq7HXC9qdgo17kxJE+rdnif5Tz6+pIrpJI8dCpMNLIGkUiA==",
+			"dev": true,
+			"dependencies": {
+				"array-buffer-byte-length": "^1.0.0",
+				"call-bind": "^1.0.2",
+				"es-get-iterator": "^1.1.3",
+				"get-intrinsic": "^1.2.1",
+				"is-arguments": "^1.1.1",
+				"is-array-buffer": "^3.0.2",
+				"is-date-object": "^1.0.5",
+				"is-regex": "^1.1.4",
+				"is-shared-array-buffer": "^1.0.2",
+				"isarray": "^2.0.5",
+				"object-is": "^1.1.5",
+				"object-keys": "^1.1.1",
+				"object.assign": "^4.1.4",
+				"regexp.prototype.flags": "^1.5.0",
+				"side-channel": "^1.0.4",
+				"which-boxed-primitive": "^1.0.2",
+				"which-collection": "^1.0.1",
+				"which-typed-array": "^1.1.9"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/@testing-library/react/node_modules/isarray": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+			"integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+			"dev": true
+		},
+		"node_modules/@testing-library/react/node_modules/pretty-format": {
+			"version": "27.5.1",
+			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+			"integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+			"dev": true,
+			"dependencies": {
+				"ansi-regex": "^5.0.1",
+				"ansi-styles": "^5.0.0",
+				"react-is": "^17.0.1"
+			},
+			"engines": {
+				"node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+			}
+		},
+		"node_modules/@testing-library/react/node_modules/react-is": {
+			"version": "17.0.2",
+			"resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+			"integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+			"dev": true
 		},
 		"node_modules/@testing-library/user-event": {
 			"version": "14.4.3",
@@ -28345,6 +28446,32 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/es-get-iterator": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.3.tgz",
+			"integrity": "sha512-sPZmqHBe6JIiTfN5q2pEi//TwxmAFHwj/XEuYjTuse78i8KxaqMTTzxPoFKuzRpDpTJ+0NAbpfenkmH2rePtuw==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.2",
+				"get-intrinsic": "^1.1.3",
+				"has-symbols": "^1.0.3",
+				"is-arguments": "^1.1.1",
+				"is-map": "^2.0.2",
+				"is-set": "^2.0.2",
+				"is-string": "^1.0.7",
+				"isarray": "^2.0.5",
+				"stop-iteration-iterator": "^1.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/es-get-iterator/node_modules/isarray": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+			"integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+			"dev": true
+		},
 		"node_modules/es-set-tostringtag": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.0.1.tgz",
@@ -33026,12 +33153,13 @@
 			}
 		},
 		"node_modules/is-arguments": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.0.tgz",
-			"integrity": "sha512-1Ij4lOMPl/xB5kBDn7I+b2ttPMKa8szhEIrXDuXQD/oe3HJLTLhqhgGspwgyGd6MOywBUqVvYicF72lkgDnIHg==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
+			"integrity": "sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==",
 			"dev": true,
 			"dependencies": {
-				"call-bind": "^1.0.0"
+				"call-bind": "^1.0.2",
+				"has-tostringtag": "^1.0.0"
 			},
 			"engines": {
 				"node": ">= 0.4"
@@ -33364,6 +33492,15 @@
 			"integrity": "sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ==",
 			"dev": true
 		},
+		"node_modules/is-map": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.2.tgz",
+			"integrity": "sha512-cOZFQQozTha1f4MxLFzlgKYPTyj26picdZTx82hbc/Xf4K/tZOOXSCkMvU4pKioRXGDLJRn0GM7Upe7kR721yg==",
+			"dev": true,
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/is-nan": {
 			"version": "1.3.2",
 			"resolved": "https://registry.npmjs.org/is-nan/-/is-nan-1.3.2.tgz",
@@ -33539,6 +33676,15 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/is-set": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.2.tgz",
+			"integrity": "sha512-+2cnTEZeY5z/iXGbLhPrOAaK/Mau5k5eXq9j14CpRTftq0pAJu2MwVRSZhyZWBzx3o6X795Lz6Bpb6R0GKf37g==",
+			"dev": true,
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/is-shared-array-buffer": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.2.tgz",
@@ -33642,6 +33788,15 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/is-weakmap": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.1.tgz",
+			"integrity": "sha512-NSBR4kH5oVj1Uwvv970ruUkCV7O1mzgVFO4/rev2cLRda9Tm9HrL70ZPut4rOHgY0FNrUu9BCbXA2sdQ+x0chA==",
+			"dev": true,
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/is-weakref": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
@@ -33649,6 +33804,19 @@
 			"dev": true,
 			"dependencies": {
 				"call-bind": "^1.0.2"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-weakset": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.2.tgz",
+			"integrity": "sha512-t2yVvttHkQktwnNNmBQ98AhENLdPUTDTE21uPqAQ0ARwQfGeQKRVS0NNurH7bTf7RrvcVn1OOge45CnBeHCSmg==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.2",
+				"get-intrinsic": "^1.1.1"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
@@ -37876,9 +38044,9 @@
 			}
 		},
 		"node_modules/lz-string": {
-			"version": "1.4.4",
-			"resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.4.4.tgz",
-			"integrity": "sha512-0ckx7ZHRPqb0oUm8zNr+90mtf9DQB60H1wMCjBtfi62Kl3a7JbHob6gA2bC+xRvZoOL+1hzUK8jeuEIQE8svEQ==",
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+			"integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
 			"dev": true,
 			"bin": {
 				"lz-string": "bin/bin.js"
@@ -49404,6 +49572,18 @@
 				"node": ">= 0.6"
 			}
 		},
+		"node_modules/stop-iteration-iterator": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.0.0.tgz",
+			"integrity": "sha512-iCGQj+0l0HOdZ2AEeBADlsRC+vsnDsZsbdSiH1yNSjcfKM7fdpCMfqAL/dwF5BLiw/XhRft/Wax6zQbhq2BcjQ==",
+			"dev": true,
+			"dependencies": {
+				"internal-slot": "^1.0.4"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
 		"node_modules/store2": {
 			"version": "2.14.2",
 			"resolved": "https://registry.npmjs.org/store2/-/store2-2.14.2.tgz",
@@ -53489,6 +53669,21 @@
 				"is-number-object": "^1.0.4",
 				"is-string": "^1.0.5",
 				"is-symbol": "^1.0.3"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/which-collection": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.1.tgz",
+			"integrity": "sha512-W8xeTUwaln8i3K/cY1nGXzdnVZlidBcagyNFtBdD5kxnb4TvGKR7FfSIS3mYpwWS1QUCutfKz8IY8RjftB0+1A==",
+			"dev": true,
+			"dependencies": {
+				"is-map": "^2.0.1",
+				"is-set": "^2.0.1",
+				"is-weakmap": "^2.0.1",
+				"is-weakset": "^2.0.1"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
@@ -65822,14 +66017,102 @@
 			}
 		},
 		"@testing-library/react": {
-			"version": "13.4.0",
-			"resolved": "https://registry.npmjs.org/@testing-library/react/-/react-13.4.0.tgz",
-			"integrity": "sha512-sXOGON+WNTh3MLE9rve97ftaZukN3oNf2KjDy7YTx6hcTO2uuLHuCGynMDhFwGw/jYf4OJ2Qk0i4i79qMNNkyw==",
+			"version": "14.0.0",
+			"resolved": "https://registry.npmjs.org/@testing-library/react/-/react-14.0.0.tgz",
+			"integrity": "sha512-S04gSNJbYE30TlIMLTzv6QCTzt9AqIF5y6s6SzVFILNcNvbV/jU96GeiTPillGQo+Ny64M/5PV7klNYYgv5Dfg==",
 			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.12.5",
-				"@testing-library/dom": "^8.5.0",
+				"@testing-library/dom": "^9.0.0",
 				"@types/react-dom": "^18.0.0"
+			},
+			"dependencies": {
+				"@testing-library/dom": {
+					"version": "9.3.1",
+					"resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-9.3.1.tgz",
+					"integrity": "sha512-0DGPd9AR3+iDTjGoMpxIkAsUihHZ3Ai6CneU6bRRrffXMgzCdlNk43jTrD2/5LT6CBb3MWTP8v510JzYtahD2w==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.10.4",
+						"@babel/runtime": "^7.12.5",
+						"@types/aria-query": "^5.0.1",
+						"aria-query": "5.1.3",
+						"chalk": "^4.1.0",
+						"dom-accessibility-api": "^0.5.9",
+						"lz-string": "^1.5.0",
+						"pretty-format": "^27.0.2"
+					}
+				},
+				"@types/aria-query": {
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.1.tgz",
+					"integrity": "sha512-XTIieEY+gvJ39ChLcB4If5zHtPxt3Syj5rgZR+e1ctpmK8NjPf0zFqsz4JpLJT0xla9GFDKjy8Cpu331nrmE1Q==",
+					"dev": true
+				},
+				"ansi-styles": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+					"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+					"dev": true
+				},
+				"aria-query": {
+					"version": "5.1.3",
+					"resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.1.3.tgz",
+					"integrity": "sha512-R5iJ5lkuHybztUfuOAznmboyjWq8O6sqNqtK7CLOqdydi54VNbORp49mb14KbWgG1QD3JFO9hJdZ+y4KutfdOQ==",
+					"dev": true,
+					"requires": {
+						"deep-equal": "^2.0.5"
+					}
+				},
+				"deep-equal": {
+					"version": "2.2.2",
+					"resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.2.2.tgz",
+					"integrity": "sha512-xjVyBf0w5vH0I42jdAZzOKVldmPgSulmiyPRywoyq7HXC9qdgo17kxJE+rdnif5Tz6+pIrpJI8dCpMNLIGkUiA==",
+					"dev": true,
+					"requires": {
+						"array-buffer-byte-length": "^1.0.0",
+						"call-bind": "^1.0.2",
+						"es-get-iterator": "^1.1.3",
+						"get-intrinsic": "^1.2.1",
+						"is-arguments": "^1.1.1",
+						"is-array-buffer": "^3.0.2",
+						"is-date-object": "^1.0.5",
+						"is-regex": "^1.1.4",
+						"is-shared-array-buffer": "^1.0.2",
+						"isarray": "^2.0.5",
+						"object-is": "^1.1.5",
+						"object-keys": "^1.1.1",
+						"object.assign": "^4.1.4",
+						"regexp.prototype.flags": "^1.5.0",
+						"side-channel": "^1.0.4",
+						"which-boxed-primitive": "^1.0.2",
+						"which-collection": "^1.0.1",
+						"which-typed-array": "^1.1.9"
+					}
+				},
+				"isarray": {
+					"version": "2.0.5",
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+					"integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+					"dev": true
+				},
+				"pretty-format": {
+					"version": "27.5.1",
+					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+					"integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^5.0.1",
+						"ansi-styles": "^5.0.0",
+						"react-is": "^17.0.1"
+					}
+				},
+				"react-is": {
+					"version": "17.0.2",
+					"resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+					"integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+					"dev": true
+				}
 			}
 		},
 		"@testing-library/react-native": {
@@ -79953,6 +80236,31 @@
 				"which-typed-array": "^1.1.10"
 			}
 		},
+		"es-get-iterator": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.3.tgz",
+			"integrity": "sha512-sPZmqHBe6JIiTfN5q2pEi//TwxmAFHwj/XEuYjTuse78i8KxaqMTTzxPoFKuzRpDpTJ+0NAbpfenkmH2rePtuw==",
+			"dev": true,
+			"requires": {
+				"call-bind": "^1.0.2",
+				"get-intrinsic": "^1.1.3",
+				"has-symbols": "^1.0.3",
+				"is-arguments": "^1.1.1",
+				"is-map": "^2.0.2",
+				"is-set": "^2.0.2",
+				"is-string": "^1.0.7",
+				"isarray": "^2.0.5",
+				"stop-iteration-iterator": "^1.0.0"
+			},
+			"dependencies": {
+				"isarray": {
+					"version": "2.0.5",
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+					"integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+					"dev": true
+				}
+			}
+		},
 		"es-set-tostringtag": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.0.1.tgz",
@@ -83537,12 +83845,13 @@
 			}
 		},
 		"is-arguments": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.0.tgz",
-			"integrity": "sha512-1Ij4lOMPl/xB5kBDn7I+b2ttPMKa8szhEIrXDuXQD/oe3HJLTLhqhgGspwgyGd6MOywBUqVvYicF72lkgDnIHg==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
+			"integrity": "sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==",
 			"dev": true,
 			"requires": {
-				"call-bind": "^1.0.0"
+				"call-bind": "^1.0.2",
+				"has-tostringtag": "^1.0.0"
 			}
 		},
 		"is-array-buffer": {
@@ -83781,6 +84090,12 @@
 			"integrity": "sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ==",
 			"dev": true
 		},
+		"is-map": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.2.tgz",
+			"integrity": "sha512-cOZFQQozTha1f4MxLFzlgKYPTyj26picdZTx82hbc/Xf4K/tZOOXSCkMvU4pKioRXGDLJRn0GM7Upe7kR721yg==",
+			"dev": true
+		},
 		"is-nan": {
 			"version": "1.3.2",
 			"resolved": "https://registry.npmjs.org/is-nan/-/is-nan-1.3.2.tgz",
@@ -83901,6 +84216,12 @@
 			"integrity": "sha512-7zjFAPO4/gwyQAAgRRmqeEeyIICSdmCqa3tsVHMdBzaXXRiqopZL4Cyghg/XulGWrtABTpbnYYzzIRffLkP4oA==",
 			"dev": true
 		},
+		"is-set": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.2.tgz",
+			"integrity": "sha512-+2cnTEZeY5z/iXGbLhPrOAaK/Mau5k5eXq9j14CpRTftq0pAJu2MwVRSZhyZWBzx3o6X795Lz6Bpb6R0GKf37g==",
+			"dev": true
+		},
 		"is-shared-array-buffer": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.2.tgz",
@@ -83971,6 +84292,12 @@
 			"resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
 			"integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw=="
 		},
+		"is-weakmap": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.1.tgz",
+			"integrity": "sha512-NSBR4kH5oVj1Uwvv970ruUkCV7O1mzgVFO4/rev2cLRda9Tm9HrL70ZPut4rOHgY0FNrUu9BCbXA2sdQ+x0chA==",
+			"dev": true
+		},
 		"is-weakref": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
@@ -83978,6 +84305,16 @@
 			"dev": true,
 			"requires": {
 				"call-bind": "^1.0.2"
+			}
+		},
+		"is-weakset": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.2.tgz",
+			"integrity": "sha512-t2yVvttHkQktwnNNmBQ98AhENLdPUTDTE21uPqAQ0ARwQfGeQKRVS0NNurH7bTf7RrvcVn1OOge45CnBeHCSmg==",
+			"dev": true,
+			"requires": {
+				"call-bind": "^1.0.2",
+				"get-intrinsic": "^1.1.1"
 			}
 		},
 		"is-whitespace-character": {
@@ -87206,9 +87543,9 @@
 			}
 		},
 		"lz-string": {
-			"version": "1.4.4",
-			"resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.4.4.tgz",
-			"integrity": "sha512-0ckx7ZHRPqb0oUm8zNr+90mtf9DQB60H1wMCjBtfi62Kl3a7JbHob6gA2bC+xRvZoOL+1hzUK8jeuEIQE8svEQ==",
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+			"integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
 			"dev": true
 		},
 		"macos-release": {
@@ -96096,6 +96433,15 @@
 			"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
 			"integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA=="
 		},
+		"stop-iteration-iterator": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.0.0.tgz",
+			"integrity": "sha512-iCGQj+0l0HOdZ2AEeBADlsRC+vsnDsZsbdSiH1yNSjcfKM7fdpCMfqAL/dwF5BLiw/XhRft/Wax6zQbhq2BcjQ==",
+			"dev": true,
+			"requires": {
+				"internal-slot": "^1.0.4"
+			}
+		},
 		"store2": {
 			"version": "2.14.2",
 			"resolved": "https://registry.npmjs.org/store2/-/store2-2.14.2.tgz",
@@ -99180,6 +99526,18 @@
 				"is-number-object": "^1.0.4",
 				"is-string": "^1.0.5",
 				"is-symbol": "^1.0.3"
+			}
+		},
+		"which-collection": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.1.tgz",
+			"integrity": "sha512-W8xeTUwaln8i3K/cY1nGXzdnVZlidBcagyNFtBdD5kxnb4TvGKR7FfSIS3mYpwWS1QUCutfKz8IY8RjftB0+1A==",
+			"dev": true,
+			"requires": {
+				"is-map": "^2.0.1",
+				"is-set": "^2.0.1",
+				"is-weakmap": "^2.0.1",
+				"is-weakset": "^2.0.1"
 			}
 		},
 		"which-module": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -181,7 +181,7 @@
 				"eslint-plugin-eslint-comments": "3.1.2",
 				"eslint-plugin-import": "2.25.2",
 				"eslint-plugin-jest": "27.2.1",
-				"eslint-plugin-jest-dom": "4.0.2",
+				"eslint-plugin-jest-dom": "5.0.2",
 				"eslint-plugin-playwright": "0.8.0",
 				"eslint-plugin-ssr-friendly": "1.0.6",
 				"eslint-plugin-storybook": "0.6.13",
@@ -28783,13 +28783,12 @@
 			}
 		},
 		"node_modules/eslint-plugin-jest-dom": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-jest-dom/-/eslint-plugin-jest-dom-4.0.2.tgz",
-			"integrity": "sha512-Jo51Atwyo2TdcUncjmU+UQeSTKh3sc2LF/M5i/R3nTU0Djw9V65KGJisdm/RtuKhy2KH/r7eQ1n6kwYFPNdHlA==",
+			"version": "5.0.2",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-jest-dom/-/eslint-plugin-jest-dom-5.0.2.tgz",
+			"integrity": "sha512-zfNOwQOrOOGcxb3tcOgB2fEiqmgEbXKcPrNC+NlNSWCi3wg/m+DWVqrrshp4gOjhpP1R/1X7kkHumnf8PLUFhw==",
 			"dev": true,
 			"dependencies": {
 				"@babel/runtime": "^7.16.3",
-				"@testing-library/dom": "^8.11.1",
 				"requireindex": "^1.2.0"
 			},
 			"engines": {
@@ -28798,6 +28797,7 @@
 				"yarn": ">=1"
 			},
 			"peerDependencies": {
+				"@testing-library/dom": "^8.0.0 || ^9.0.0",
 				"eslint": "^6.8.0 || ^7.0.0 || ^8.0.0"
 			}
 		},
@@ -65989,7 +65989,7 @@
 			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.12.5",
-				"@testing-library/dom": "^9.3.1",
+				"@testing-library/dom": "^9.0.0",
 				"@types/react-dom": "^18.0.0"
 			}
 		},
@@ -80611,13 +80611,12 @@
 			}
 		},
 		"eslint-plugin-jest-dom": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-jest-dom/-/eslint-plugin-jest-dom-4.0.2.tgz",
-			"integrity": "sha512-Jo51Atwyo2TdcUncjmU+UQeSTKh3sc2LF/M5i/R3nTU0Djw9V65KGJisdm/RtuKhy2KH/r7eQ1n6kwYFPNdHlA==",
+			"version": "5.0.2",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-jest-dom/-/eslint-plugin-jest-dom-5.0.2.tgz",
+			"integrity": "sha512-zfNOwQOrOOGcxb3tcOgB2fEiqmgEbXKcPrNC+NlNSWCi3wg/m+DWVqrrshp4gOjhpP1R/1X7kkHumnf8PLUFhw==",
 			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.16.3",
-				"@testing-library/dom": "^9.3.1",
 				"requireindex": "^1.2.0"
 			}
 		},

--- a/package-lock.json
+++ b/package-lock.json
@@ -13612,22 +13612,22 @@
 			"integrity": "sha512-oocsqY7g0cR+Gur5jRQLSrX2OtpMLMse1I10JQBm8CdGMrDkh1Mg2gjsiquMHRtBs4Qwu5wgEp5GgIYHk4SNPw=="
 		},
 		"node_modules/@testing-library/dom": {
-			"version": "8.13.0",
-			"resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-8.13.0.tgz",
-			"integrity": "sha512-9VHgfIatKNXQNaZTtLnalIy0jNZzY35a4S3oi08YAt9Hv1VsfZ/DfA45lM8D/UhtHBGJ4/lGwp0PZkVndRkoOQ==",
+			"version": "9.3.1",
+			"resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-9.3.1.tgz",
+			"integrity": "sha512-0DGPd9AR3+iDTjGoMpxIkAsUihHZ3Ai6CneU6bRRrffXMgzCdlNk43jTrD2/5LT6CBb3MWTP8v510JzYtahD2w==",
 			"dev": true,
 			"dependencies": {
 				"@babel/code-frame": "^7.10.4",
 				"@babel/runtime": "^7.12.5",
-				"@types/aria-query": "^4.2.0",
-				"aria-query": "^5.0.0",
+				"@types/aria-query": "^5.0.1",
+				"aria-query": "5.1.3",
 				"chalk": "^4.1.0",
 				"dom-accessibility-api": "^0.5.9",
-				"lz-string": "^1.4.4",
+				"lz-string": "^1.5.0",
 				"pretty-format": "^27.0.2"
 			},
 			"engines": {
-				"node": ">=12"
+				"node": ">=14"
 			}
 		},
 		"node_modules/@testing-library/dom/node_modules/ansi-styles": {
@@ -13643,13 +13643,48 @@
 			}
 		},
 		"node_modules/@testing-library/dom/node_modules/aria-query": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
-			"integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+			"version": "5.1.3",
+			"resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.1.3.tgz",
+			"integrity": "sha512-R5iJ5lkuHybztUfuOAznmboyjWq8O6sqNqtK7CLOqdydi54VNbORp49mb14KbWgG1QD3JFO9hJdZ+y4KutfdOQ==",
 			"dev": true,
 			"dependencies": {
-				"dequal": "^2.0.3"
+				"deep-equal": "^2.0.5"
 			}
+		},
+		"node_modules/@testing-library/dom/node_modules/deep-equal": {
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.2.2.tgz",
+			"integrity": "sha512-xjVyBf0w5vH0I42jdAZzOKVldmPgSulmiyPRywoyq7HXC9qdgo17kxJE+rdnif5Tz6+pIrpJI8dCpMNLIGkUiA==",
+			"dev": true,
+			"dependencies": {
+				"array-buffer-byte-length": "^1.0.0",
+				"call-bind": "^1.0.2",
+				"es-get-iterator": "^1.1.3",
+				"get-intrinsic": "^1.2.1",
+				"is-arguments": "^1.1.1",
+				"is-array-buffer": "^3.0.2",
+				"is-date-object": "^1.0.5",
+				"is-regex": "^1.1.4",
+				"is-shared-array-buffer": "^1.0.2",
+				"isarray": "^2.0.5",
+				"object-is": "^1.1.5",
+				"object-keys": "^1.1.1",
+				"object.assign": "^4.1.4",
+				"regexp.prototype.flags": "^1.5.0",
+				"side-channel": "^1.0.4",
+				"which-boxed-primitive": "^1.0.2",
+				"which-collection": "^1.0.1",
+				"which-typed-array": "^1.1.9"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/@testing-library/dom/node_modules/isarray": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+			"integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+			"dev": true
 		},
 		"node_modules/@testing-library/dom/node_modules/pretty-format": {
 			"version": "27.5.1",
@@ -13774,107 +13809,6 @@
 				}
 			}
 		},
-		"node_modules/@testing-library/react/node_modules/@testing-library/dom": {
-			"version": "9.3.1",
-			"resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-9.3.1.tgz",
-			"integrity": "sha512-0DGPd9AR3+iDTjGoMpxIkAsUihHZ3Ai6CneU6bRRrffXMgzCdlNk43jTrD2/5LT6CBb3MWTP8v510JzYtahD2w==",
-			"dev": true,
-			"dependencies": {
-				"@babel/code-frame": "^7.10.4",
-				"@babel/runtime": "^7.12.5",
-				"@types/aria-query": "^5.0.1",
-				"aria-query": "5.1.3",
-				"chalk": "^4.1.0",
-				"dom-accessibility-api": "^0.5.9",
-				"lz-string": "^1.5.0",
-				"pretty-format": "^27.0.2"
-			},
-			"engines": {
-				"node": ">=14"
-			}
-		},
-		"node_modules/@testing-library/react/node_modules/@types/aria-query": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.1.tgz",
-			"integrity": "sha512-XTIieEY+gvJ39ChLcB4If5zHtPxt3Syj5rgZR+e1ctpmK8NjPf0zFqsz4JpLJT0xla9GFDKjy8Cpu331nrmE1Q==",
-			"dev": true
-		},
-		"node_modules/@testing-library/react/node_modules/ansi-styles": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-			"dev": true,
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
-			}
-		},
-		"node_modules/@testing-library/react/node_modules/aria-query": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.1.3.tgz",
-			"integrity": "sha512-R5iJ5lkuHybztUfuOAznmboyjWq8O6sqNqtK7CLOqdydi54VNbORp49mb14KbWgG1QD3JFO9hJdZ+y4KutfdOQ==",
-			"dev": true,
-			"dependencies": {
-				"deep-equal": "^2.0.5"
-			}
-		},
-		"node_modules/@testing-library/react/node_modules/deep-equal": {
-			"version": "2.2.2",
-			"resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.2.2.tgz",
-			"integrity": "sha512-xjVyBf0w5vH0I42jdAZzOKVldmPgSulmiyPRywoyq7HXC9qdgo17kxJE+rdnif5Tz6+pIrpJI8dCpMNLIGkUiA==",
-			"dev": true,
-			"dependencies": {
-				"array-buffer-byte-length": "^1.0.0",
-				"call-bind": "^1.0.2",
-				"es-get-iterator": "^1.1.3",
-				"get-intrinsic": "^1.2.1",
-				"is-arguments": "^1.1.1",
-				"is-array-buffer": "^3.0.2",
-				"is-date-object": "^1.0.5",
-				"is-regex": "^1.1.4",
-				"is-shared-array-buffer": "^1.0.2",
-				"isarray": "^2.0.5",
-				"object-is": "^1.1.5",
-				"object-keys": "^1.1.1",
-				"object.assign": "^4.1.4",
-				"regexp.prototype.flags": "^1.5.0",
-				"side-channel": "^1.0.4",
-				"which-boxed-primitive": "^1.0.2",
-				"which-collection": "^1.0.1",
-				"which-typed-array": "^1.1.9"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/@testing-library/react/node_modules/isarray": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-			"integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
-			"dev": true
-		},
-		"node_modules/@testing-library/react/node_modules/pretty-format": {
-			"version": "27.5.1",
-			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
-			"integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
-			"dev": true,
-			"dependencies": {
-				"ansi-regex": "^5.0.1",
-				"ansi-styles": "^5.0.0",
-				"react-is": "^17.0.1"
-			},
-			"engines": {
-				"node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-			}
-		},
-		"node_modules/@testing-library/react/node_modules/react-is": {
-			"version": "17.0.2",
-			"resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-			"integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-			"dev": true
-		},
 		"node_modules/@testing-library/user-event": {
 			"version": "14.4.3",
 			"resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.4.3.tgz",
@@ -13944,9 +13878,9 @@
 			}
 		},
 		"node_modules/@types/aria-query": {
-			"version": "4.2.2",
-			"resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-4.2.2.tgz",
-			"integrity": "sha512-HnYpAE1Y6kRyKM/XkEuiRQhTHvkzMBurTHnpFLYLBGPIylZNPs9jJcuOOYWxPLJCSEtmZT0Y8rHDokKN7rRTig==",
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.1.tgz",
+			"integrity": "sha512-XTIieEY+gvJ39ChLcB4If5zHtPxt3Syj5rgZR+e1ctpmK8NjPf0zFqsz4JpLJT0xla9GFDKjy8Cpu331nrmE1Q==",
 			"dev": true
 		},
 		"node_modules/@types/babel__core": {
@@ -65914,18 +65848,18 @@
 			"integrity": "sha512-oocsqY7g0cR+Gur5jRQLSrX2OtpMLMse1I10JQBm8CdGMrDkh1Mg2gjsiquMHRtBs4Qwu5wgEp5GgIYHk4SNPw=="
 		},
 		"@testing-library/dom": {
-			"version": "8.13.0",
-			"resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-8.13.0.tgz",
-			"integrity": "sha512-9VHgfIatKNXQNaZTtLnalIy0jNZzY35a4S3oi08YAt9Hv1VsfZ/DfA45lM8D/UhtHBGJ4/lGwp0PZkVndRkoOQ==",
+			"version": "9.3.1",
+			"resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-9.3.1.tgz",
+			"integrity": "sha512-0DGPd9AR3+iDTjGoMpxIkAsUihHZ3Ai6CneU6bRRrffXMgzCdlNk43jTrD2/5LT6CBb3MWTP8v510JzYtahD2w==",
 			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.10.4",
 				"@babel/runtime": "^7.12.5",
-				"@types/aria-query": "^4.2.0",
-				"aria-query": "^5.0.0",
+				"@types/aria-query": "^5.0.1",
+				"aria-query": "5.1.3",
 				"chalk": "^4.1.0",
 				"dom-accessibility-api": "^0.5.9",
-				"lz-string": "^1.4.4",
+				"lz-string": "^1.5.0",
 				"pretty-format": "^27.0.2"
 			},
 			"dependencies": {
@@ -65936,13 +65870,45 @@
 					"dev": true
 				},
 				"aria-query": {
-					"version": "5.3.0",
-					"resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
-					"integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+					"version": "5.1.3",
+					"resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.1.3.tgz",
+					"integrity": "sha512-R5iJ5lkuHybztUfuOAznmboyjWq8O6sqNqtK7CLOqdydi54VNbORp49mb14KbWgG1QD3JFO9hJdZ+y4KutfdOQ==",
 					"dev": true,
 					"requires": {
-						"dequal": "^2.0.3"
+						"deep-equal": "^2.0.5"
 					}
+				},
+				"deep-equal": {
+					"version": "2.2.2",
+					"resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.2.2.tgz",
+					"integrity": "sha512-xjVyBf0w5vH0I42jdAZzOKVldmPgSulmiyPRywoyq7HXC9qdgo17kxJE+rdnif5Tz6+pIrpJI8dCpMNLIGkUiA==",
+					"dev": true,
+					"requires": {
+						"array-buffer-byte-length": "^1.0.0",
+						"call-bind": "^1.0.2",
+						"es-get-iterator": "^1.1.3",
+						"get-intrinsic": "^1.2.1",
+						"is-arguments": "^1.1.1",
+						"is-array-buffer": "^3.0.2",
+						"is-date-object": "^1.0.5",
+						"is-regex": "^1.1.4",
+						"is-shared-array-buffer": "^1.0.2",
+						"isarray": "^2.0.5",
+						"object-is": "^1.1.5",
+						"object-keys": "^1.1.1",
+						"object.assign": "^4.1.4",
+						"regexp.prototype.flags": "^1.5.0",
+						"side-channel": "^1.0.4",
+						"which-boxed-primitive": "^1.0.2",
+						"which-collection": "^1.0.1",
+						"which-typed-array": "^1.1.9"
+					}
+				},
+				"isarray": {
+					"version": "2.0.5",
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+					"integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+					"dev": true
 				},
 				"pretty-format": {
 					"version": "27.5.1",
@@ -66023,96 +65989,8 @@
 			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.12.5",
-				"@testing-library/dom": "^9.0.0",
+				"@testing-library/dom": "^9.3.1",
 				"@types/react-dom": "^18.0.0"
-			},
-			"dependencies": {
-				"@testing-library/dom": {
-					"version": "9.3.1",
-					"resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-9.3.1.tgz",
-					"integrity": "sha512-0DGPd9AR3+iDTjGoMpxIkAsUihHZ3Ai6CneU6bRRrffXMgzCdlNk43jTrD2/5LT6CBb3MWTP8v510JzYtahD2w==",
-					"dev": true,
-					"requires": {
-						"@babel/code-frame": "^7.10.4",
-						"@babel/runtime": "^7.12.5",
-						"@types/aria-query": "^5.0.1",
-						"aria-query": "5.1.3",
-						"chalk": "^4.1.0",
-						"dom-accessibility-api": "^0.5.9",
-						"lz-string": "^1.5.0",
-						"pretty-format": "^27.0.2"
-					}
-				},
-				"@types/aria-query": {
-					"version": "5.0.1",
-					"resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.1.tgz",
-					"integrity": "sha512-XTIieEY+gvJ39ChLcB4If5zHtPxt3Syj5rgZR+e1ctpmK8NjPf0zFqsz4JpLJT0xla9GFDKjy8Cpu331nrmE1Q==",
-					"dev": true
-				},
-				"ansi-styles": {
-					"version": "5.2.0",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-					"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-					"dev": true
-				},
-				"aria-query": {
-					"version": "5.1.3",
-					"resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.1.3.tgz",
-					"integrity": "sha512-R5iJ5lkuHybztUfuOAznmboyjWq8O6sqNqtK7CLOqdydi54VNbORp49mb14KbWgG1QD3JFO9hJdZ+y4KutfdOQ==",
-					"dev": true,
-					"requires": {
-						"deep-equal": "^2.0.5"
-					}
-				},
-				"deep-equal": {
-					"version": "2.2.2",
-					"resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.2.2.tgz",
-					"integrity": "sha512-xjVyBf0w5vH0I42jdAZzOKVldmPgSulmiyPRywoyq7HXC9qdgo17kxJE+rdnif5Tz6+pIrpJI8dCpMNLIGkUiA==",
-					"dev": true,
-					"requires": {
-						"array-buffer-byte-length": "^1.0.0",
-						"call-bind": "^1.0.2",
-						"es-get-iterator": "^1.1.3",
-						"get-intrinsic": "^1.2.1",
-						"is-arguments": "^1.1.1",
-						"is-array-buffer": "^3.0.2",
-						"is-date-object": "^1.0.5",
-						"is-regex": "^1.1.4",
-						"is-shared-array-buffer": "^1.0.2",
-						"isarray": "^2.0.5",
-						"object-is": "^1.1.5",
-						"object-keys": "^1.1.1",
-						"object.assign": "^4.1.4",
-						"regexp.prototype.flags": "^1.5.0",
-						"side-channel": "^1.0.4",
-						"which-boxed-primitive": "^1.0.2",
-						"which-collection": "^1.0.1",
-						"which-typed-array": "^1.1.9"
-					}
-				},
-				"isarray": {
-					"version": "2.0.5",
-					"resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-					"integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
-					"dev": true
-				},
-				"pretty-format": {
-					"version": "27.5.1",
-					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
-					"integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
-					"dev": true,
-					"requires": {
-						"ansi-regex": "^5.0.1",
-						"ansi-styles": "^5.0.0",
-						"react-is": "^17.0.1"
-					}
-				},
-				"react-is": {
-					"version": "17.0.2",
-					"resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-					"integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-					"dev": true
-				}
 			}
 		},
 		"@testing-library/react-native": {
@@ -66173,9 +66051,9 @@
 			}
 		},
 		"@types/aria-query": {
-			"version": "4.2.2",
-			"resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-4.2.2.tgz",
-			"integrity": "sha512-HnYpAE1Y6kRyKM/XkEuiRQhTHvkzMBurTHnpFLYLBGPIylZNPs9jJcuOOYWxPLJCSEtmZT0Y8rHDokKN7rRTig==",
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.1.tgz",
+			"integrity": "sha512-XTIieEY+gvJ39ChLcB4If5zHtPxt3Syj5rgZR+e1ctpmK8NjPf0zFqsz4JpLJT0xla9GFDKjy8Cpu331nrmE1Q==",
 			"dev": true
 		},
 		"@types/babel__core": {
@@ -80739,7 +80617,7 @@
 			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.16.3",
-				"@testing-library/dom": "^8.11.1",
+				"@testing-library/dom": "^9.3.1",
 				"requireindex": "^1.2.0"
 			}
 		},

--- a/package.json
+++ b/package.json
@@ -193,7 +193,7 @@
 		"eslint-plugin-eslint-comments": "3.1.2",
 		"eslint-plugin-import": "2.25.2",
 		"eslint-plugin-jest": "27.2.1",
-		"eslint-plugin-jest-dom": "4.0.2",
+		"eslint-plugin-jest-dom": "5.0.2",
 		"eslint-plugin-playwright": "0.8.0",
 		"eslint-plugin-ssr-friendly": "1.0.6",
 		"eslint-plugin-storybook": "0.6.13",
@@ -256,9 +256,6 @@
 		"webpack": "5.65.0",
 		"webpack-bundle-analyzer": "4.4.2",
 		"worker-farm": "1.7.0"
-	},
-	"overrides": {
-		"@testing-library/dom": "^9.3.1"
 	},
 	"scripts": {
 		"build": "npm run build:packages && wp-scripts build",

--- a/package.json
+++ b/package.json
@@ -257,6 +257,9 @@
 		"webpack-bundle-analyzer": "4.4.2",
 		"worker-farm": "1.7.0"
 	},
+	"overrides": {
+		"@testing-library/dom": "^9.3.1"
+	},
 	"scripts": {
 		"build": "npm run build:packages && wp-scripts build",
 		"build:analyze-bundles": "npm run build -- --webpack-bundle-analyzer",

--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
 		"@storybook/source-loader": "7.2.2",
 		"@storybook/theming": "7.2.2",
 		"@testing-library/jest-dom": "5.16.5",
-		"@testing-library/react": "13.4.0",
+		"@testing-library/react": "14.0.0",
 		"@testing-library/react-native": "12.1.2",
 		"@testing-library/user-event": "14.4.3",
 		"@types/eslint": "7.28.0",

--- a/packages/block-directory/src/components/downloadable-block-list-item/test/index.js
+++ b/packages/block-directory/src/components/downloadable-block-list-item/test/index.js
@@ -61,7 +61,7 @@ describe( 'DownloadableBlockListItem', () => {
 		);
 		const button = screen.getByRole( 'option' );
 		// Keeping it false to avoid focus loss and disable it using aria-disabled.
-		expect( button.disabled ).toBe( false );
+		expect( button ).toBeEnabled();
 		expect( button ).toHaveAttribute( 'aria-disabled', 'true' );
 	} );
 

--- a/packages/components/src/date-time/date/test/index.tsx
+++ b/packages/components/src/date-time/date/test/index.tsx
@@ -112,6 +112,6 @@ describe( 'DatePicker', () => {
 		const button = screen.getByRole( 'button', {
 			name: 'May 20, 2022',
 		} ) as HTMLButtonElement;
-		expect( button.disabled ).toBe( true );
+		expect( button ).toBeDisabled();
 	} );
 } );

--- a/packages/components/src/tools-panel/test/index.tsx
+++ b/packages/components/src/tools-panel/test/index.tsx
@@ -286,8 +286,8 @@ describe( 'ToolsPanel', () => {
 			const menuItems = await screen.findAllByRole( 'menuitemcheckbox' );
 
 			expect( menuItems.length ).toEqual( 2 );
-			expect( menuItems[ 0 ] ).toHaveAttribute( 'aria-checked', 'true' );
-			expect( menuItems[ 1 ] ).toHaveAttribute( 'aria-checked', 'false' );
+			expect( menuItems[ 0 ] ).toBeChecked();
+			expect( menuItems[ 1 ] ).not.toBeChecked();
 		} );
 
 		it( 'should render panel label as header text', () => {

--- a/packages/components/src/ui/tooltip/test/index.js
+++ b/packages/components/src/ui/tooltip/test/index.js
@@ -21,7 +21,7 @@ describe( 'props', () => {
 
 	test( 'should render correctly', () => {
 		render( <VisibleTooltip /> );
-		const tooltip = screen.getByRole( /tooltip/i );
+		const tooltip = screen.getByRole( 'tooltip' );
 		expect( tooltip ).toMatchSnapshot();
 	} );
 
@@ -37,7 +37,7 @@ describe( 'props', () => {
 				<Text>{ invisibleTooltipTriggerContent }</Text>
 			</Tooltip>
 		);
-		const tooltip = screen.getByRole( /tooltip/i );
+		const tooltip = screen.getByRole( 'tooltip' );
 		const invisibleTooltipTrigger = screen.getByText(
 			invisibleTooltipTriggerContent
 		);
@@ -59,7 +59,7 @@ describe( 'props', () => {
 				visible
 			/>
 		);
-		const tooltips = screen.getAllByRole( /tooltip/i );
+		const tooltips = screen.getAllByRole( 'tooltip' );
 		const childlessTooltip = tooltips.find( byId( childlessTooltipId ) );
 		expect( childlessTooltip ).not.toBeUndefined();
 	} );
@@ -72,7 +72,7 @@ describe( 'props', () => {
 				<Text>WordPress.org</Text>
 			</Tooltip>
 		);
-		const tooltip = screen.getByRole( /tooltip/i );
+		const tooltip = screen.getByRole( 'tooltip' );
 		// Assert only the base tooltip rendered.
 		expect( tooltip ).toBeInTheDocument();
 		expect( tooltip.id ).toBe( baseTooltipId );


### PR DESCRIPTION
## What?
This PR updates `@testing-library/react` to v14.

## Why?
It's been a while since we migrated to React 18, and we're even using the latest `@testing-library/user-event`, but we have been using an obsolete `@testing-library/react` version for a while now.

## How?
We're bumping `@testing-library/react` to v14 and adding an override to use `@testing-library/dom@9` because, without it, we'll end up using `@testing-library/dom@8` because of its [peer dependencies](https://github.com/WordPress/gutenberg/blob/update/testing-library-14/package-lock.json#L13822), and that will cause hundreds of tests to fail (see [this for more info](https://github.com/testing-library/user-event/issues/1104#issuecomment-1461658418)). We're also fixing a test to use string instead of regex for querying by roles, because that's one of the [breaking changes](https://github.com/testing-library/dom-testing-library/releases/tag/v9.0.0) in v9 of `@testing-library/dom`.

## Testing Instructions
Verify all checks are green and tests pass.

### Testing Instructions for Keyboard
None.

## Screenshots or screencast <!-- if applicable -->
None.