### PR TITLE
Fix top toolbar in the post editor with custom fields in Safari 

### DIFF
--- a/packages/interface/src/components/interface-skeleton/style.scss
+++ b/packages/interface/src/components/interface-skeleton/style.scss
@@ -88,6 +88,12 @@ html.interface-interface-skeleton__html-container {
 	// to "bleed" through the header.
 	// See https://github.com/WordPress/gutenberg/issues/32631
 	z-index: z-index(".interface-interface-skeleton__content");
+
+	// On Safari the z-index is not respected when the element is fixed.
+	// Setting it to auto fixes the problem
+	@include break-medium() {
+		z-index: auto;
+	}
 }
 
 .interface-interface-skeleton__secondary-sidebar,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes #53495

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

On Safari when custom fields were enabled or the viewport got vertically small enough the fixed block toolbar become insible, while still interactive. It is unclear why specifying the z-index triggered this behavior and what exactly does auto do better in Safari.

The ordering was correct in terms of 3D layering things, as even Safari's 3D layers panel showed.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->


Updated the z-index of the `.interface-interface-skeleton__content` container to `auto`.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->


- Edit a post with enough content that scroll is visible
- Set top toolbar on
- From preferences enable custom fields
- Reload
- Select blocks
- The top toolbar should show

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

N/A
