### PR TITLE
[a11y] Fix: aria-haspop, aria-expanded attributes on the link format button.

### DIFF
--- a/packages/format-library/src/link/index.js
+++ b/packages/format-library/src/link/index.js
@@ -89,6 +89,8 @@ function Edit( {
 					isActive={ isActive }
 					shortcutType="primaryShift"
 					shortcutCharacter="k"
+					aria-haspopup="true"
+					aria-expanded={ addingLink || isActive }
 				/>
 			) }
 			{ ! isActive && (
@@ -100,6 +102,8 @@ function Edit( {
 					isActive={ isActive }
 					shortcutType="primary"
 					shortcutCharacter="k"
+					aria-haspopup="true"
+					aria-expanded={ addingLink || isActive }
 				/>
 			) }
 			{ ( addingLink || isActive ) && (


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/24796.
Currently, the link format button opens an additional UI but lacks aria-haspopup and aria-expanded tags. This PR resolves the issue.
Currently, the image link button already possesses these attributes, making this PR bring consistency to both elements.

# Testing

- Added a paragraph and selected some text on it.
- Verified that the link format button has the aria-haspopup and aria-expanded tags functioning as expected.