### PR TITLE
[a11y] Fix: aria-haspop and aria-expanded attributes on the inserter button.

### DIFF
--- a/packages/edit-post/src/components/header/header-toolbar/index.js
+++ b/packages/edit-post/src/components/header/header-toolbar/index.js
@@ -148,6 +148,7 @@ function HeaderToolbar() {
 					icon={ plus }
 					label={ showIconLabels ? shortLabel : longLabel }
 					showTooltip={ ! showIconLabels }
+					aria-expanded={ isInserterOpened }
 				/>
 				{ ( isWideViewport || ! showIconLabels ) && (
 					<>

--- a/packages/edit-site/src/components/header-edit-mode/index.js
+++ b/packages/edit-site/src/components/header-edit-mode/index.js
@@ -216,6 +216,7 @@ export default function HeaderEditMode() {
 									showIconLabels ? shortLabel : longLabel
 								}
 								showTooltip={ ! showIconLabels }
+								aria-expanded={ isInserterOpen }
 							/>
 						) }
 						{ isLargeViewport && (


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/24796.
Currently, the inserter button opens an additional UI (inserter sidebar) but lacks aria-haspopup and aria-expanded tags. This PR resolves the issue.
Currently, the publish and sidebar button also open sidebars and already possesses these attributes, making this PR bring consistency to both elements.

# Testing

- Opened the post editor and verified the aria-haspop and aria-expanded attributes of the inserter button are working as expected.
- Repeated the process for the site editor.