### PR TITLE
[a11y] Fix: aria-haspop and aria-expanded attributes on list view button.

### DIFF
--- a/packages/edit-post/src/components/header/header-toolbar/index.js
+++ b/packages/edit-post/src/components/header/header-toolbar/index.js
@@ -107,6 +107,7 @@ function HeaderToolbar() {
 				shortcut={ listViewShortcut }
 				showTooltip={ ! showIconLabels }
 				variant={ showIconLabels ? 'tertiary' : undefined }
+				aria-expanded={ isListViewOpen }
 			/>
 		</>
 	);

--- a/packages/edit-site/src/components/header-edit-mode/index.js
+++ b/packages/edit-site/src/components/header-edit-mode/index.js
@@ -265,6 +265,7 @@ export default function HeaderEditMode() {
 												? 'tertiary'
 												: undefined
 										}
+										aria-expanded={ isListViewOpen }
 									/>
 								) }
 								{ isZoomedOutViewExperimentEnabled &&


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/24796.
Currently, the list view button opens an additional UI (list view sidebar) but lacks aria-haspopup and aria-expanded tags. This PR addresses the issue.
Presently, the publish and sidebar buttons also trigger sidebars and already possess these attributes, ensuring this PR maintains uniformity across both elements.
A similar PR has been suggested for the inserter button at https://github.com/WordPress/gutenberg/pull/53692.

# Testing

- Opened the post editor and verified that the aria-haspopup and aria-expanded attributes of the list view button are functioning as expected.
- Repeated the process for the site editor.