### PR TITLE
Use ellipsis to denote when menu items have modals (secondary steps) 

### DIFF
--- a/packages/block-editor/src/components/block-lock/menu-item.js
+++ b/packages/block-editor/src/components/block-lock/menu-item.js
@@ -24,7 +24,7 @@ export default function BlockLockMenuItem( { clientId } ) {
 		return null;
 	}
 
-	const label = isLocked ? __( 'Unlock' ) : __( 'Lock' );
+	const label = isLocked ? __( 'Unlock…' ) : __( 'Lock…' );
 
 	return (
 		<>

--- a/packages/block-editor/src/components/block-lock/toolbar.js
+++ b/packages/block-editor/src/components/block-lock/toolbar.js
@@ -60,7 +60,7 @@ export default function BlockLockToolbar( { clientId, wrapperRef } ) {
 			<ToolbarGroup className="block-editor-block-lock-toolbar">
 				<ToolbarButton
 					icon={ lock }
-					label={ __( 'Unlock' ) }
+					label={ __( 'Unlock…' ) }
 					onClick={ toggleModal }
 					ref={ lockButtonRef }
 				/>

--- a/packages/e2e-test-utils/src/create-reusable-block.js
+++ b/packages/e2e-test-utils/src/create-reusable-block.js
@@ -22,7 +22,7 @@ export const createReusableBlock = async ( content, title ) => {
 	await page.keyboard.type( content );
 
 	await clickBlockToolbarButton( 'Options' );
-	await clickMenuItem( 'Create pattern' );
+	await clickMenuItem( 'Create pattern…' );
 	const nameInput = await page.waitForSelector(
 		reusableBlockNameInputSelector
 	);

--- a/packages/e2e-tests/specs/editor/various/block-editor-keyboard-shortcuts.test.js
+++ b/packages/e2e-tests/specs/editor/various/block-editor-keyboard-shortcuts.test.js
@@ -90,7 +90,7 @@ describe( 'block editor keyboard shortcuts', () => {
 		} );
 		it( 'should prevent deleting multiple selected blocks from inputs', async () => {
 			await clickBlockToolbarButton( 'Options' );
-			await clickMenuItem( 'Create pattern' );
+			await clickMenuItem( 'Create pattern…' );
 			const reusableBlockNameInputSelector =
 				'.patterns-menu-items__convert-modal .components-text-control__input';
 			const nameInput = await page.waitForSelector(

--- a/packages/e2e-tests/specs/editor/various/reusable-blocks.test.js
+++ b/packages/e2e-tests/specs/editor/various/reusable-blocks.test.js
@@ -196,7 +196,7 @@ describe( 'Reusable blocks', () => {
 
 		// Convert block to a reusable block.
 		await clickBlockToolbarButton( 'Options' );
-		await clickMenuItem( 'Create pattern' );
+		await clickMenuItem( 'Create pattern…' );
 
 		// Set title.
 		const nameInput = await page.waitForSelector(
@@ -382,7 +382,7 @@ describe( 'Reusable blocks', () => {
 
 		// Convert to reusable.
 		await clickBlockToolbarButton( 'Options' );
-		await clickMenuItem( 'Create pattern' );
+		await clickMenuItem( 'Create pattern…' );
 		const nameInput = await page.waitForSelector(
 			reusableBlockNameInputSelector
 		);

--- a/packages/edit-site/src/components/template-part-converter/convert-to-template-part.js
+++ b/packages/edit-site/src/components/template-part-converter/convert-to-template-part.js
@@ -57,7 +57,7 @@ export default function ConvertToTemplatePart( { clientIds, blocks } ) {
 					setIsModalOpen( true );
 				} }
 			>
-				{ __( 'Create template part' ) }
+				{ __( 'Create template part…' ) }
 			</MenuItem>
 			{ isModalOpen && (
 				<CreateTemplatePartModal

--- a/packages/patterns/src/components/pattern-convert-button.js
+++ b/packages/patterns/src/components/pattern-convert-button.js
@@ -107,7 +107,7 @@ export default function PatternConvertButton( {
 	return (
 		<>
 			<MenuItem icon={ symbol } onClick={ () => setIsModalOpen( true ) }>
-				{ __( 'Create pattern' ) }
+				{ __( 'Create pattern…' ) }
 			</MenuItem>
 			{ isModalOpen && (
 				<CreatePatternModal

--- a/packages/reusable-blocks/src/components/reusable-blocks-menu-items/reusable-block-convert-button.js
+++ b/packages/reusable-blocks/src/components/reusable-blocks-menu-items/reusable-block-convert-button.js
@@ -152,8 +152,8 @@ export default function ReusableBlockConvertButton( {
 		<>
 			<MenuItem icon={ symbol } onClick={ () => setIsModalOpen( true ) }>
 				{ showRenameHint
-					? __( 'Create pattern/reusable block' )
-					: __( 'Create pattern' ) }
+					? __( 'Create pattern/reusable block…' )
+					: __( 'Create pattern…' ) }
 			</MenuItem>
 			{ isModalOpen && (
 				<Modal

--- a/test/e2e/specs/editor/blocks/columns.spec.js
+++ b/test/e2e/specs/editor/blocks/columns.spec.js
@@ -64,7 +64,7 @@ test.describe( 'Columns', () => {
 			)
 		);
 		await editor.clickBlockToolbarButton( 'Options' );
-		await page.click( 'role=menuitem[name="Lock"i]' );
+		await page.click( 'role=menuitem[name="Lock…"i]' );
 		await page.locator( 'role=checkbox[name="Prevent removal"i]' ).check();
 		await page.click( 'role=button[name="Apply"i]' );
 

--- a/test/e2e/specs/editor/various/block-locking.spec.js
+++ b/test/e2e/specs/editor/various/block-locking.spec.js
@@ -110,7 +110,7 @@ test.describe( 'Block Locking', () => {
 		} );
 		await paragraph.click();
 
-		await editor.clickBlockToolbarButton( 'Unlock' );
+		await editor.clickBlockToolbarButton( 'Unlock…' );
 		await page.click( 'role=checkbox[name="Lock all"]' );
 		await page.click( 'role=button[name="Apply"]' );
 

--- a/test/e2e/specs/editor/various/block-locking.spec.js
+++ b/test/e2e/specs/editor/various/block-locking.spec.js
@@ -12,7 +12,7 @@ test.describe( 'Block Locking', () => {
 		await editor.canvas.click( 'role=button[name="Add default block"i]' );
 		await page.keyboard.type( 'Some paragraph' );
 
-		await editor.clickBlockOptionsMenuItem( 'Lock' );
+		await editor.clickBlockOptionsMenuItem( 'Lock…' );
 
 		await page.click( 'role=checkbox[name="Prevent removal"]' );
 		await page.click( 'role=button[name="Apply"]' );
@@ -29,7 +29,7 @@ test.describe( 'Block Locking', () => {
 		await page.keyboard.type( 'Enter' );
 		await page.keyboard.type( 'Second paragraph' );
 
-		await editor.clickBlockOptionsMenuItem( 'Lock' );
+		await editor.clickBlockOptionsMenuItem( 'Lock…' );
 
 		await page.click( 'role=checkbox[name="Disable movement"]' );
 		await page.click( 'role=button[name="Apply"]' );
@@ -52,7 +52,7 @@ test.describe( 'Block Locking', () => {
 		await editor.canvas.click( 'role=button[name="Add default block"i]' );
 		await page.keyboard.type( 'Some paragraph' );
 
-		await editor.clickBlockOptionsMenuItem( 'Lock' );
+		await editor.clickBlockOptionsMenuItem( 'Lock…' );
 
 		await page.click( 'role=checkbox[name="Lock all"]' );
 		await page.click( 'role=button[name="Apply"]' );
@@ -67,12 +67,12 @@ test.describe( 'Block Locking', () => {
 		await editor.canvas.click( 'role=button[name="Add default block"i]' );
 		await page.keyboard.type( 'Some paragraph' );
 
-		await editor.clickBlockOptionsMenuItem( 'Lock' );
+		await editor.clickBlockOptionsMenuItem( 'Lock…' );
 
 		await page.click( 'role=checkbox[name="Lock all"]' );
 		await page.click( 'role=button[name="Apply"]' );
 
-		await editor.clickBlockToolbarButton( 'Unlock' );
+		await editor.clickBlockToolbarButton( 'Unlock…' );
 		await page.click( 'role=checkbox[name="Lock all"]' );
 		await page.click( 'role=button[name="Apply"]' );
 

--- a/test/e2e/specs/site-editor/site-editor-url-navigation.spec.js
+++ b/test/e2e/specs/site-editor/site-editor-url-navigation.spec.js
@@ -65,8 +65,8 @@ test.describe( 'Site editor url navigation', () => {
 			await page.click( 'role=button[name="Patterns"i]' );
 			await page.click( 'role=button[name="Create pattern"i]' );
 			await page
-				.getByRole( 'menu', { name: 'Create pattern' } )
-				.getByRole( 'menuitem', { name: 'Create template part' } )
+				.getByRole( 'menu', { name: 'Create pattern…' } )
+				.getByRole( 'menuitem', { name: 'Create template part…' } )
 				.click();
 			// Fill in a name in the dialog that pops up.
 			await page.type(

--- a/test/e2e/specs/site-editor/template-part.spec.js
+++ b/test/e2e/specs/site-editor/template-part.spec.js
@@ -147,7 +147,7 @@ test.describe( 'Template Part', () => {
 		await editor.selectBlocks( paragraphBlock1, paragraphBlock2 );
 
 		// Convert block to a template part.
-		await editor.clickBlockOptionsMenuItem( 'Create template part' );
+		await editor.clickBlockOptionsMenuItem( 'Create template part…' );
 		await page.type( 'role=dialog >> role=textbox[name="Name"i]', 'Test' );
 		await page.keyboard.press( 'Enter' );
 

--- a/test/e2e/specs/site-editor/template-part.spec.js
+++ b/test/e2e/specs/site-editor/template-part.spec.js
@@ -97,7 +97,7 @@ test.describe( 'Template Part', () => {
 		await editor.selectBlocks( paragraphBlock );
 
 		// Convert block to a template part.
-		await editor.clickBlockOptionsMenuItem( 'Create Template part' );
+		await editor.clickBlockOptionsMenuItem( 'Create template part…' );
 		await page.type( 'role=dialog >> role=textbox[name="Name"i]', 'Test' );
 		await page.keyboard.press( 'Enter' );
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Currently, you don't know if clicking a menu item within the block options toolbar will conduct an action, or open a modal instead. The expectation of requiring additional input is clearer, you don't have to know it requires additional input. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a post or page. 
2. Insert any block.
3. See "Create pattern…" and "Lock…" menu items (the same for "Create template part…" in the site editor. 

## Visual 

| Before  | After |
| ------------- | ------------- |
|<img width="249" alt="CleanShot 2023-08-15 at 14 18 29" src="https://github.com/WordPress/gutenberg/assets/1813435/fbf971e6-e06a-49db-a9e7-88d19febc1a2">|<img width="250" alt="CleanShot 2023-08-15 at 14 19 13" src="https://github.com/WordPress/gutenberg/assets/1813435/e502a1bc-f08e-4675-acfe-9567325d6792">|

## Recordings <!-- if applicable -->

### Before

https://github.com/WordPress/gutenberg/assets/1813435/8230e3f1-448b-4a15-89cd-84498d156b27

### After

https://github.com/WordPress/gutenberg/assets/1813435/38949263-1641-45be-b22e-91705ec42dbc



