### PR TITLE
Capture toolbars in navigation block

### DIFF
--- a/packages/block-library/src/navigation/edit/inner-blocks.js
+++ b/packages/block-library/src/navigation/edit/inner-blocks.js
@@ -117,6 +117,7 @@ export default function NavigationInnerBlocks( {
 					? InnerBlocks.ButtonBlockAppender
 					: false,
 			placeholder: showPlaceholder ? placeholder : undefined,
+			__experimentalCaptureToolbars: true,
 		}
 	);
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Related to https://github.com/WordPress/gutenberg/pull/53306, trying out toolbar capture on the Navigation block. 

## Why?
Experimenting with improving nested block experiences. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a post or page.
2. Insert a navigation block.
3. Add navigation links, social, etc. 
4. Experience the nested block's toolbar captured in the parent navigation block. 

## Screenshots or screencast <!-- if applicable -->

### Before 

Notice how the toolbar moves with you:

https://github.com/WordPress/gutenberg/assets/1813435/34c3e0bc-e388-4198-b882-fe6bf1587080

### After 

Notice how the toolbar stays in place: 

https://github.com/WordPress/gutenberg/assets/1813435/e39a2c98-8643-486e-86f2-ec1f87d9f0d8



