### PR TITLE
Capture toolbars in quote block

### DIFF
--- a/packages/block-library/src/quote/edit.js
+++ b/packages/block-library/src/quote/edit.js
@@ -93,6 +93,7 @@ export default function QuoteEdit( {
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {
 		template: TEMPLATE,
 		templateInsertUpdatesSelection: true,
+		__experimentalCaptureToolbars: true,
 	} );
 
 	return (


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Related to https://github.com/WordPress/gutenberg/pull/53306, trying out toolbar capture on the Quote block.

## Why?
Experimenting with improving nested block experiences.

## How?

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a post or page.
2. Insert a quote block.
3. Add content to the block. 
4. Select between the cite and paragraph content to experience the captured toolbar. 

## Screenshots or screencast <!-- if applicable -->

### Before 

Notice how the toolbar moves around: 

https://github.com/WordPress/gutenberg/assets/1813435/d7d4f73d-c986-4e40-b543-f1c7cf907963

### After

Notice how the toolbar stays in place:

https://github.com/WordPress/gutenberg/assets/1813435/8ad934d1-043c-4c04-bc13-9bb2256bde6a


