### PR TITLE
Try capturing image toolbars in gallery

### DIFF
--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -532,6 +532,7 @@ function GalleryEdit( props ) {
 		allowedBlocks,
 		orientation: 'horizontal',
 		renderAppender: false,
+		__experimentalCaptureToolbars: true,
 		...nativeInnerBlockProps,
 	} );
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Related to https://github.com/WordPress/gutenberg/pull/53306, trying out toolbar capture on the Gallery block. 

🚨 I'm not as confident in this experience—as I am with the list, quote and navigation explorations—but I wanted to try it and share anyhow for feedback or other thoughts.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a post or page.
2. Insert a gallery block.
3. Add images. 
4. Select and control different images. 
5. Make the gallery block fullwidth. 
6. Try selecting different images again. 

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

### Before: 

https://github.com/WordPress/gutenberg/assets/1813435/cd9e7ab3-12ea-40c7-80bd-6a847cd46f0c

### After: 

https://github.com/WordPress/gutenberg/assets/1813435/f4c84c95-37d0-4199-b795-2178d230381e

