### PR TITLE
`AlignmentMatrixControl`: replace `act()` with `userEvent`

### DIFF
--- a/packages/components/src/alignment-matrix-control/test/index.tsx
+++ b/packages/components/src/alignment-matrix-control/test/index.tsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import { act, render, screen, within } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 /**
  * Internal dependencies
@@ -27,6 +28,7 @@ describe( 'AlignmentMatrixControl', () => {
 
 	describe( 'Change value', () => {
 		const alignments = [ 'center left', 'center center', 'bottom center' ];
+		const user = userEvent.setup();
 
 		it.each( alignments )(
 			'should change value on %s cell click',
@@ -37,7 +39,9 @@ describe( 'AlignmentMatrixControl', () => {
 					<AlignmentMatrixControl value="center" onChange={ spy } />
 				);
 
-				await act( () => getCell( alignment ).focus() );
+				await user.click( getCell( alignment ) );
+
+				expect( getCell( alignment ) ).toHaveFocus();
 
 				expect( spy ).toHaveBeenCalledWith( alignment );
 			}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Update test to utilize `userEvent` and remove `act()`.

## Why?
While working on #48222, I came across this test which was failing due to `...wrapped into act(...)` errors. 

## How?

Removed `act()` and added `userEvent.click`. This moves the test closer to how a user would interact via `click` instead of setting the focus. I've added another assertion to check the element has focus after the click, instead. 

## Testing Instructions

Verify tests still pass: `packages/components/src/alignment-matrix-control/test/index.tsx`