### PR TITLE
`ColorPalette`: refine test query

### DIFF
--- a/packages/components/src/color-palette/test/index.tsx
+++ b/packages/components/src/color-palette/test/index.tsx
@@ -222,10 +222,6 @@ describe( 'ColorPalette', () => {
 
 	it( 'should display the selected color name and value', async () => {
 		const user = userEvent.setup();
-		// selector for Truncate component to make test queries more explicit
-		const truncateComponent = {
-			selector: 'span[data-wp-component="Truncate"]',
-		};
 
 		render( <ControlledColorPalette /> );
 
@@ -243,10 +239,14 @@ describe( 'ColorPalette', () => {
 
 		// Confirm the correct color name, color value, and button label are used
 		expect(
-			screen.getByText( colorName, truncateComponent )
+			screen.getByText( colorName, {
+				selector: '.components-color-palette__custom-color-name',
+			} )
 		).toBeVisible();
 		expect(
-			screen.getByText( colorCode, truncateComponent )
+			screen.getByText( colorCode, {
+				selector: '.components-color-palette__custom-color-value',
+			} )
 		).toBeVisible();
 		expect(
 			screen.getByRole( 'button', {
@@ -258,13 +258,8 @@ describe( 'ColorPalette', () => {
 		// Clear the color, confirm that the relative values are cleared/updated.
 		await user.click( screen.getByRole( 'button', { name: 'Clear' } ) );
 		expect( screen.getByText( 'No color selected' ) ).toBeVisible();
-
-		expect(
-			screen.queryByText( colorName, truncateComponent )
-		).not.toBeInTheDocument();
-		expect(
-			screen.queryByText( colorCode, truncateComponent )
-		).not.toBeInTheDocument();
+		expect( screen.queryByText( colorName ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( colorCode ) ).not.toBeInTheDocument();
 		expect(
 			screen.getByRole( 'button', {
 				name: /^Custom color picker.$/,

--- a/packages/components/src/color-palette/test/index.tsx
+++ b/packages/components/src/color-palette/test/index.tsx
@@ -222,11 +222,14 @@ describe( 'ColorPalette', () => {
 
 	it( 'should display the selected color name and value', async () => {
 		const user = userEvent.setup();
+		// selector for Truncate component to make test queries more explicit
+		const truncateComponent = {
+			selector: 'span[data-wp-component="Truncate"]',
+		};
 
 		render( <ControlledColorPalette /> );
 
-		const colorName = EXAMPLE_COLORS[ 0 ].name;
-		const colorCode = EXAMPLE_COLORS[ 0 ].color;
+		const { name: colorName, color: colorCode } = EXAMPLE_COLORS[ 0 ];
 
 		expect( screen.getByText( 'No color selected' ) ).toBeVisible();
 
@@ -240,12 +243,14 @@ describe( 'ColorPalette', () => {
 
 		// Confirm the correct color name, color value, and button label are used
 		expect(
-			screen.getByText( colorName, { selector: 'span' } )
+			screen.getByText( colorName, truncateComponent )
 		).toBeVisible();
-		expect( screen.getByText( colorCode ) ).toBeVisible();
+		expect(
+			screen.getByText( colorCode, truncateComponent )
+		).toBeVisible();
 		expect(
 			screen.getByRole( 'button', {
-				name: `Custom color picker. The currently selected color is called "${ colorName }" and has a value of "${ EXAMPLE_COLORS[ 0 ].color }".`,
+				name: `Custom color picker. The currently selected color is called "${ colorName }" and has a value of "${ colorCode }".`,
 				expanded: false,
 			} )
 		).toBeInTheDocument();
@@ -255,9 +260,11 @@ describe( 'ColorPalette', () => {
 		expect( screen.getByText( 'No color selected' ) ).toBeVisible();
 
 		expect(
-			screen.queryByText( colorName, { selector: 'span' } )
+			screen.queryByText( colorName, truncateComponent )
 		).not.toBeInTheDocument();
-		expect( screen.queryByText( colorCode ) ).not.toBeInTheDocument();
+		expect(
+			screen.queryByText( colorCode, truncateComponent )
+		).not.toBeInTheDocument();
 		expect(
 			screen.getByRole( 'button', {
 				name: /^Custom color picker.$/,

--- a/packages/components/src/color-palette/test/index.tsx
+++ b/packages/components/src/color-palette/test/index.tsx
@@ -225,6 +225,9 @@ describe( 'ColorPalette', () => {
 
 		render( <ControlledColorPalette /> );
 
+		const colorName = EXAMPLE_COLORS[ 0 ].name;
+		const colorCode = EXAMPLE_COLORS[ 0 ].color;
+
 		expect( screen.getByText( 'No color selected' ) ).toBeVisible();
 
 		// Click the first unpressed button
@@ -236,11 +239,13 @@ describe( 'ColorPalette', () => {
 		);
 
 		// Confirm the correct color name, color value, and button label are used
-		expect( screen.getByText( EXAMPLE_COLORS[ 0 ].name ) ).toBeVisible();
-		expect( screen.getByText( EXAMPLE_COLORS[ 0 ].color ) ).toBeVisible();
+		expect(
+			screen.getByText( colorName, { selector: 'span' } )
+		).toBeVisible();
+		expect( screen.getByText( colorCode ) ).toBeVisible();
 		expect(
 			screen.getByRole( 'button', {
-				name: `Custom color picker. The currently selected color is called "${ EXAMPLE_COLORS[ 0 ].name }" and has a value of "${ EXAMPLE_COLORS[ 0 ].color }".`,
+				name: `Custom color picker. The currently selected color is called "${ colorName }" and has a value of "${ EXAMPLE_COLORS[ 0 ].color }".`,
 				expanded: false,
 			} )
 		).toBeInTheDocument();
@@ -248,12 +253,11 @@ describe( 'ColorPalette', () => {
 		// Clear the color, confirm that the relative values are cleared/updated.
 		await user.click( screen.getByRole( 'button', { name: 'Clear' } ) );
 		expect( screen.getByText( 'No color selected' ) ).toBeVisible();
+
 		expect(
-			screen.queryByText( EXAMPLE_COLORS[ 0 ].name )
+			screen.queryByText( colorName, { selector: 'span' } )
 		).not.toBeInTheDocument();
-		expect(
-			screen.queryByText( EXAMPLE_COLORS[ 0 ].color )
-		).not.toBeInTheDocument();
+		expect( screen.queryByText( colorCode ) ).not.toBeInTheDocument();
 		expect(
 			screen.getByRole( 'button', {
 				name: /^Custom color picker.$/,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Updates the query for testing the color display name in  `ColorPalette`'s test. 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

This test fails due to the upcoming changes to tooltip (#48222). In the new version, tooltip can be found in the dom even while hidden. Therefore, the `getByText` query is returning multiple elements, including tooltip. If we change the query to `screen.getByRole( 'button', { name: /red/i } )`, it matches more than one button.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Until the changes are merged from https://github.com/WordPress/gutenberg/pull/52255 (@andrewhayward), I could not find a better way to avoid the above issues other than to specify the `span` [selector](https://testing-library.com/docs/queries/bytext#selector). This will fail in the aforementioned PR, but that will be a good reminder to update to `getByRole( 'option' )` instead 😄 (or we can add it as a to-do item). 

## Testing Instructions

Verify tests still pass `npm run test:unit packages/components/src/color-palette/test/index.tsx`
