### PR TITLE
Patterns: Prevent convert modal closing block options menu

### DIFF
--- a/packages/patterns/src/components/index.js
+++ b/packages/patterns/src/components/index.js
@@ -12,12 +12,11 @@ import PatternsManageButton from './patterns-manage-button';
 export default function PatternsMenuItems( { rootClientId } ) {
 	return (
 		<BlockSettingsMenuControls>
-			{ ( { onClose, selectedClientIds } ) => (
+			{ ( { selectedClientIds } ) => (
 				<>
 					<PatternConvertButton
 						clientIds={ selectedClientIds }
 						rootClientId={ rootClientId }
-						onClose={ onClose }
 					/>
 					{ selectedClientIds.length === 1 && (
 						<PatternsManageButton

--- a/packages/patterns/src/components/pattern-convert-button.js
+++ b/packages/patterns/src/components/pattern-convert-button.js
@@ -21,14 +21,9 @@ import CreatePatternModal from './create-pattern-modal';
  * @param {Object}   props              Component props.
  * @param {string[]} props.clientIds    Client ids of selected blocks.
  * @param {string}   props.rootClientId ID of the currently selected top-level block.
- * @param {()=>void} props.onClose      Callback to close the menu.
  * @return {import('@wordpress/element').WPComponent} The menu control or null.
  */
-export default function PatternConvertButton( {
-	clientIds,
-	rootClientId,
-	onClose,
-} ) {
+export default function PatternConvertButton( { clientIds, rootClientId } ) {
 	const { createSuccessNotice } = useDispatch( noticesStore );
 	const [ isModalOpen, setIsModalOpen ] = useState( false );
 	const canConvert = useSelect(
@@ -114,15 +109,12 @@ export default function PatternConvertButton( {
 					clientIds={ clientIds }
 					onSuccess={ ( pattern ) => {
 						handleSuccess( pattern );
-						onClose();
 					} }
 					onError={ () => {
 						setIsModalOpen( false );
-						onClose();
 					} }
 					onClose={ () => {
 						setIsModalOpen( false );
-						onClose();
 					} }
 				/>
 			) }


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/53694

## What?

Prevents the "create pattern" modal from closing the block options menu when it is closed.

## Why?

Provides consistency with the lock modal from the same block options menu.

## How?

Removes the call to the menu item's `onClose`

## Testing Instructions

1. Edit a post and add a block to it
2. Select the block and open the block options menu
3. Select the "Create pattern" option
4. Ensure that when you cancel or use the close icon at the top right that the modal closes but the block options menu remains open
5. Confirm this matches the Lock modal's behavior
6. Create an unsynced pattern and check the block options menu remains open
7. Create a synced pattern and note the block options menu is closed as the block itself is replaced with the synced pattern after its successfully converted

## Screenshots or screencast <!-- if applicable -->


https://github.com/WordPress/gutenberg/assets/60436221/f9cadfd3-69c3-472a-8468-fe23a226826f


