### PR TITLE
Style engine: update docs for css_var

### DIFF
--- a/packages/style-engine/class-wp-style-engine.php
+++ b/packages/style-engine/class-wp-style-engine.php
@@ -31,7 +31,7 @@ final class WP_Style_Engine {
 	 *                    to match the incoming value, e.g., "color" to match var:preset|color|somePresetSlug.
 	 *  - css_vars      => (array) an array of key value pairs used to generate CSS var values.
 	 *                     The key should be the CSS property name that matches the second element of the preset string value,
-	 *                     i.e., "color" in var:preset|color|somePresetSlug. The value is a CSS var pattern,
+	 *                     i.e., "color" in var:preset|color|somePresetSlug. The value is a CSS var pattern (e.g. `--wp--preset--color--$slug`),
 	 *                     whose `$slug` fragment will be replaced with the preset slug, which is the third element of the preset string value,
 	 *                     i.e., `somePresetSlug` in var:preset|color|somePresetSlug.
 	 *  - property_keys => (array) array of keys whose values represent a valid CSS property, e.g., "margin" or "border".

--- a/packages/style-engine/class-wp-style-engine.php
+++ b/packages/style-engine/class-wp-style-engine.php
@@ -24,14 +24,16 @@ if ( class_exists( 'WP_Style_Engine' ) ) {
  */
 final class WP_Style_Engine {
 	/**
-	 * Style definitions that contain the instructions to
-	 * parse/output valid Gutenberg styles from a block's attributes.
+	 * Style definitions that contain the instructions to parse/output valid Gutenberg styles from a block's attributes.
 	 * For every style definition, the follow properties are valid:
 	 *  - classnames    => (array) an array of classnames to be returned for block styles. The key is a classname or pattern.
 	 *                    A value of `true` means the classname should be applied always. Otherwise, a valid CSS property (string)
 	 *                    to match the incoming value, e.g., "color" to match var:preset|color|somePresetSlug.
-	 *  - css_vars      => (array) an array of key value pairs used to generate CSS var values. The key is a CSS var pattern, whose `$slug` fragment will be replaced with a preset slug.
-	 *                    The value should be a valid CSS property (string) to match the incoming value, e.g., "color" to match var:preset|color|somePresetSlug.
+	 *  - css_vars      => (array) an array of key value pairs used to generate CSS var values.
+	 *                     The key should be the CSS property name that matches the second element of the preset string value,
+	 *                     i.e., "color" in var:preset|color|somePresetSlug. The value is a CSS var pattern,
+	 *                     whose `$slug` fragment will be replaced with the preset slug, which is the third element of the preset string value,
+	 *                     i.e., `somePresetSlug` in var:preset|color|somePresetSlug.
 	 *  - property_keys => (array) array of keys whose values represent a valid CSS property, e.g., "margin" or "border".
 	 *  - path          => (array) a path that accesses the corresponding style value in the block style object.
 	 *  - value_func    => (string) the name of a function to generate a CSS definition array for a particular style object. The output of this function should be `array( "$property" => "$value", ... )`.


### PR DESCRIPTION


## What?
The doc comments for css_var were topsy turvy.

The `css_var` property used to be this way, e.g., '--wp--preset--color--$slug' => 'color' , but then we swapped it around.

## Why?
To avoid confusion


## Testing Instructions

Check the code or unit test: k/phpunit/style-engine/style-engine-test.php#L237

The doc should reflect the key/values
