### PR TITLE
Edit Post: Fix tab border conflicts in the Document Overview panel

### DIFF
--- a/packages/edit-post/src/components/secondary-sidebar/style.scss
+++ b/packages/edit-post/src/components/secondary-sidebar/style.scss
@@ -35,11 +35,12 @@
 
 		.edit-post-sidebar__panel-tab {
 			width: 50%;
+			margin-bottom: -$border-width;
 		}
 	}
 
 	.components-tab-panel__tab-content {
-		height: calc(100% - #{$grid-unit-60});
+		height: calc(100% - #{$grid-unit-60 - $border-width});
 	}
 }
 


### PR DESCRIPTION
Fixes #53651

## What?

This PR fixes a conflict between the active and gray borders of the tab panel in the document overview sidebar.

### Before

![before](https://github.com/WordPress/gutenberg/assets/54422211/e81c3ec0-4738-4d27-821e-8e888e68b8c2)

### After

![after](https://github.com/WordPress/gutenberg/assets/54422211/5080913c-004c-4521-a648-b4b9e9d4cb48)

## Why?
For consistency with other tab panels.

## How?
I have added a negative bottom margin below the tab button to overlap the active border and the gray border. You can find several examples of this approach by searching the code with `margin-top: -$border-width;` or `margin-bottom: -$border-width;`.

As a result, the tab content is moved up by 1px. To maintain the previous height, I have increased the height of the content by 1px.

## Testing Instructions
- Open the post editor.
- Click the Document Overview panel.
- The borders representing the active state of the panel and the gray border should overlap appropriately.