### PR TITLE
Footnotes: recover malformed meta

### DIFF
--- a/packages/block-library/src/footnotes/index.php
+++ b/packages/block-library/src/footnotes/index.php
@@ -34,28 +34,12 @@ function render_block_core_footnotes( $attributes, $content, $block ) {
 
 	$footnotes = json_decode( $raw_footnotes, true );
 
-	// The post meta contains malformed JSON. See
-	// https://core.trac.wordpress.org/ticket/59103.
-	if ( ! is_array( $footnotes ) ) {
-		// This will slash everything, including the key and value boundaries.
-		// Don't use wp_slash because it will also slash single quotes.
-		$footnotes = str_replace( '"', '\\"', $raw_footnotes );
-		// So we need to unslash the boundaries, which are limited to "content"
-		// and "id", and the order is fixed. We're alse dealing with a single
-		// line of JSON.
-		$footnotes = str_replace( '{\\"content\\":\\"', '{"content":"', $footnotes );
-		$footnotes = str_replace( '\\",\\"id\\":\\"', '","id":"', $footnotes );
-		$footnotes = str_replace( '\\"}', '"}', $footnotes );
-		$footnotes = json_decode( $footnotes, true );
-	}
-
 	if ( ! is_array( $footnotes ) || count( $footnotes ) === 0 ) {
 		return '';
 	}
 
 	$wrapper_attributes = get_block_wrapper_attributes();
-
-	$block_content = '';
+	$block_content      = '';
 
 	foreach ( $footnotes as $footnote ) {
 		$block_content .= sprintf(
@@ -347,8 +331,10 @@ function block_core_footnotes_get_post_metadata( $value, $object_id, $meta_key, 
 			$footnotes = str_replace( '{\\"content\\":\\"', '{"content":"', $footnotes );
 			$footnotes = str_replace( '\\",\\"id\\":\\"', '","id":"', $footnotes );
 			$footnotes = str_replace( '\\"}', '"}', $footnotes );
-			// Test if the transformation worked.
+
+			// Tests if the transformation worked.
 			$footnotes_json = json_decode( $footnotes, true );
+
 			if ( ! is_array( $footnotes_json ) || count( $footnotes_json ) === 0 ) {
 				return '';
 			}

--- a/packages/block-library/src/footnotes/index.php
+++ b/packages/block-library/src/footnotes/index.php
@@ -37,10 +37,12 @@ function render_block_core_footnotes( $attributes, $content, $block ) {
 	// The post meta contains malformed JSON. See
 	// https://core.trac.wordpress.org/ticket/59103.
 	if ( ! is_array( $footnotes ) ) {
-		// This will slash everything, including the keys value boundaries.
-		$footnotes = wp_slash( $raw_footnotes );
-		// So we need to unslash the keys, which are limited to "content" and
-		// "id".
+		// This will slash everything, including the key and value boundaries.
+		// Don't use wp_slash because it will also slash single quotes.
+		$footnotes = str_replace( '"', '\\"', $raw_footnotes );
+		// So we need to unslash the boundaries, which are limited to "content"
+		// and "id", and the order is fixed. We're alse dealing with a single
+		// line of JSON.
 		$footnotes = str_replace( '{\\"content\\":\\"', '{"content":"', $footnotes );
 		$footnotes = str_replace( '\\",\\"id\\":\\"', '","id":"', $footnotes );
 		$footnotes = str_replace( '\\"}', '"}', $footnotes );

--- a/packages/block-library/src/footnotes/index.php
+++ b/packages/block-library/src/footnotes/index.php
@@ -311,8 +311,6 @@ function block_core_footnotes_get_post_metadata( $value, $object_id, $meta_key, 
 		$footnotes     = json_decode( $raw_footnotes, true );
 
 		/*
-		 * This is the same transformation as render_block_core_footnotes()
-		 * above. Duplicating here to avoid creating a new function.
 		 * The post meta contains malformed JSON. See
 		 * https://core.trac.wordpress.org/ticket/59103.
 		 */

--- a/packages/block-library/src/footnotes/index.php
+++ b/packages/block-library/src/footnotes/index.php
@@ -311,7 +311,7 @@ add_filter( 'rest_pre_insert_post', '_wp_rest_api_force_autosave_difference', 10
  * @param string $meta_type Type of object metadata is for. Accepts 'post', 'comment', 'term', 'user',
  *                          or any other object type with an associated meta table.
  */
-function _wp_footnotes_get_post_metadata( $value, $object_id, $meta_key, $single, $meta_type ) {
+function block_core_footnotes_get_post_metadata( $value, $object_id, $meta_key, $single, $meta_type ) {
 	if ( 'footnotes' !== $meta_key ) {
 		return $value;
 	}
@@ -358,5 +358,5 @@ function _wp_footnotes_get_post_metadata( $value, $object_id, $meta_key, $single
 	return $value;
 }
 
-add_filter( 'get_post_metadata', '_wp_footnotes_get_post_metadata', 10, 5 );
+add_filter( 'get_post_metadata', 'block_core_footnotes_get_post_metadata', 10, 5 );
 

--- a/phpunit/blocks/render-block-footnotes-test.php
+++ b/phpunit/blocks/render-block-footnotes-test.php
@@ -64,10 +64,10 @@ class Blocks_RenderFootnotes_Test extends WP_UnitTestCase {
 	/**
 	 * @covers ::block_core_footnotes_get_post_metadata
 	 */
-	public function test_rendering_footnotes_block_with_quotations() {
+	public function test_rendering_footnotes_block_with_double_quotations() {
 		$post_args = array(
-			'ID'             => self::$post->ID,
-			'meta_input'     => array(
+			'ID'         => self::$post->ID,
+			'meta_input' => array(
 				'footnotes' => '[{\"content\":\"Because I said "so"!!!\",\"id\":\"b100\"}]',
 			),
 		);
@@ -85,6 +85,31 @@ class Blocks_RenderFootnotes_Test extends WP_UnitTestCase {
 		 */
 		$rendered = gutenberg_render_block_core_footnotes( array(), '', $block );
 		$expected = '<ol class="wp-block-footnotes"><li id="b100">Because I said "so"!!! <a href="#b100-link">↩︎</a></li></ol>';
+
+		$this->assertSame(
+			$expected,
+			$rendered
+		);
+	}
+
+	/**
+	 * @covers ::block_core_footnotes_get_post_metadata
+	 */
+	public function test_rendering_footnotes_block_with_single_quotations() {
+		$post_args = array(
+			'ID'         => self::$post->ID,
+			'meta_input' => array(
+				'footnotes' => "[{\"content\":\"And the bee said: \"I didn't know\"\",\"id\":\"b200\"}]",
+			),
+		);
+
+		wp_update_post( $post_args, true, false );
+
+		$updated_post             = get_post( self::$post->ID );
+		$block                    = new WP_Block( parse_blocks( $updated_post->post_content )[1] );
+		$block->context['postId'] = self::$post->ID;
+		$rendered                 = gutenberg_render_block_core_footnotes( array(), '', $block );
+		$expected                 = '<ol class="wp-block-footnotes"><li id="b200">And the bee said: "I didn\'t know" <a href="#b200-link">↩︎</a></li></ol>';
 
 		$this->assertSame(
 			$expected,

--- a/phpunit/blocks/render-block-footnotes-test.php
+++ b/phpunit/blocks/render-block-footnotes-test.php
@@ -1,0 +1,94 @@
+<?php
+/**
+ * Tests for the Footnotes block rendering.
+ *
+ * @package Gutenberg
+ * @subpackage Blocks
+ * @since 6.4.0
+ *
+ * @group blocks
+ */
+class Blocks_RenderFootnotes_Test extends WP_UnitTestCase {
+	/**
+	 * Test post.
+	 *
+	 * @var WP_Post
+	 */
+	private static $post;
+
+	/**
+	 * Setup method.
+	 */
+	public static function wpSetUpBeforeClass() {
+		self::$post = self::factory()->post->create_and_get(
+			array(
+				'post_type'    => 'post',
+				'post_status'  => 'publish',
+				'post_name'    => 'butterfly',
+				'post_title'   => 'Butterfly',
+				'post_content' => '<!-- wp:paragraph --><p>Butterflies are pretty cool<sup data-fn="b100" class="fn"><a href="#b100" id="b100-link">1</a></sup></p><!-- /wp:paragraph --><!-- wp:footnotes /-->',
+				'meta_input'   => array(
+					'footnotes' => '[{\"content\":\"Because I said so\",\"id\":\"b100\"}]',
+				),
+			)
+		);
+
+		/*
+		 * Needed for the tests to pass.
+		 * render_block_core_footnotes() calls get_block_wrapper_attributes(),
+		 * which calls WP_Block_Supports::get_instance()->apply_block_supports().
+		 * The latter ends up looking for `self::$block_to_render['blockName']`.
+		 */
+
+		WP_Block_Supports::init();
+		WP_Block_Supports::$block_to_render = array(
+			'blockName' => 'core/footnotes',
+		);
+	}
+
+	/**
+	 * @covers ::gutenberg_render_block_core_footnotes
+	 */
+	public function test_rendering_footnotes_block() {
+		$block                    = new WP_Block( parse_blocks( self::$post->post_content )[1] );
+		$block->context['postId'] = self::$post->ID;
+		$rendered                 = gutenberg_render_block_core_footnotes( array(), '', $block );
+		$expected                 = '<ol class="wp-block-footnotes"><li id="b100">Because I said so <a href="#b100-link">↩︎</a></li></ol>';
+
+		$this->assertSame(
+			$expected,
+			$rendered
+		);
+	}
+
+	/**
+	 * @covers ::block_core_footnotes_get_post_metadata
+	 */
+	public function test_rendering_footnotes_block_with_quotations() {
+		$post_args = array(
+			'ID'             => self::$post->ID,
+			'meta_input'     => array(
+				'footnotes' => '[{\"content\":\"Because I said "so"!!!\",\"id\":\"b100\"}]',
+			),
+		);
+
+		wp_update_post( $post_args, true, false );
+
+		$updated_post             = get_post( self::$post->ID );
+		$block                    = new WP_Block( parse_blocks( $updated_post->post_content )[1] );
+		$block->context['postId'] = self::$post->ID;
+
+		/*
+		 * gutenberg_render_block_core_footnotes calls get_post_meta()
+		 * The filter block_core_footnotes_get_post_metadata() transforms
+		 * malformed JSON into valid JSON where there are quotations.
+		 */
+		$rendered = gutenberg_render_block_core_footnotes( array(), '', $block );
+		$expected = '<ol class="wp-block-footnotes"><li id="b100">Because I said "so"!!! <a href="#b100-link">↩︎</a></li></ol>';
+
+		$this->assertSame(
+			$expected,
+			$rendered
+		);
+	}
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Alternative to #53708, without regexes.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Tries to recover malformed JSON stored in footnotes meta.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

1) We know that it concerns minified JSON, an array of objects with only "content" and "id", in that order. These are the same assumptions as the regex in #53708.
2) We can slash the string entirely, which would slash the values, but also the key/value boundaries.
3) We can undo the slashing of the boundaries with a simple string replace, since we are certain of the positions.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
