### PR TITLE
[RNMobile] Use network images for Help and Support screens

### DIFF
--- a/packages/editor/src/components/editor-help/add-blocks.native.js
+++ b/packages/editor/src/components/editor-help/add-blocks.native.js
@@ -18,8 +18,8 @@ const AddBlocks = () => {
 	return (
 		<>
 			<HelpDetailImage
-				source={ require( './images/add-light.png' ) }
-				sourceDarkMode={ require( './images/add-dark.png' ) }
+				source={ 'add-light' }
+				sourceDarkMode={ 'add-dark' }
 			/>
 			<View style={ styles.helpDetailContainer }>
 				<HelpDetailBodyText

--- a/packages/editor/src/components/editor-help/customize-blocks.native.js
+++ b/packages/editor/src/components/editor-help/customize-blocks.native.js
@@ -18,8 +18,8 @@ const CustomizeBlocks = () => {
 	return (
 		<>
 			<HelpDetailImage
-				source={ require( './images/settings-light.png' ) }
-				sourceDarkMode={ require( './images/settings-dark.png' ) }
+				source={ 'settings-light' }
+				sourceDarkMode={ 'settings-light' }
 			/>
 			<View style={ styles.helpDetailContainer }>
 				<HelpDetailBodyText

--- a/packages/editor/src/components/editor-help/intro-to-blocks.native.js
+++ b/packages/editor/src/components/editor-help/intro-to-blocks.native.js
@@ -26,9 +26,7 @@ const IntroToBlocks = () => {
 	);
 	return (
 		<>
-			<HelpDetailImage
-				source={ require( './images/block-layout-collage.png' ) }
-			/>
+			<HelpDetailImage source={ 'block-layout-collage' } />
 			<View style={ styles.helpDetailContainer }>
 				<Text
 					accessibilityRole="header"
@@ -55,8 +53,8 @@ const IntroToBlocks = () => {
 					accessibilityLabel={ __(
 						'Text formatting controls are located within the toolbar positioned above the keyboard while editing a text block'
 					) }
-					source={ require( './images/rich-text-light.png' ) }
-					sourceDarkMode={ require( './images/rich-text-dark.png' ) }
+					source={ 'rich-text' }
+					sourceDarkMode={ 'rich-text-dark' }
 				/>
 				<HelpDetailSectionHeadingText text={ __( 'Embed media' ) } />
 				<HelpDetailBodyText
@@ -65,8 +63,8 @@ const IntroToBlocks = () => {
 					) }
 				/>
 				<HelpDetailImage
-					source={ require( './images/embed-media-light.png' ) }
-					sourceDarkMode={ require( './images/embed-media-dark.png' ) }
+					source={ 'embed-media-light' }
+					sourceDarkMode={ 'embed-media-dark' }
 				/>
 				<HelpDetailSectionHeadingText text={ __( 'Build layouts' ) } />
 				<HelpDetailBodyText
@@ -75,8 +73,8 @@ const IntroToBlocks = () => {
 					) }
 				/>
 				<HelpDetailImage
-					source={ require( './images/build-layouts-light.png' ) }
-					sourceDarkMode={ require( './images/build-layouts-dark.png' ) }
+					source={ 'build-layouts-light' }
+					sourceDarkMode={ 'build-layouts-dark' }
 				/>
 				<HelpDetailBodyText
 					text={ __(

--- a/packages/editor/src/components/editor-help/move-blocks.native.js
+++ b/packages/editor/src/components/editor-help/move-blocks.native.js
@@ -22,8 +22,8 @@ const MoveBlocks = () => {
 	return (
 		<>
 			<HelpDetailImage
-				source={ require( './images/drag-and-drop-light.png' ) }
-				sourceDarkMode={ require( './images/drag-and-drop-dark.png' ) }
+				source={ 'drag-and-drop-light' }
+				sourceDarkMode={ 'drag-and-drop-dark' }
 			/>
 			<View style={ styles.helpDetailContainer }>
 				<HelpDetailSectionHeadingText
@@ -37,8 +37,8 @@ const MoveBlocks = () => {
 				/>
 			</View>
 			<HelpDetailImage
-				source={ require( './images/move-light.png' ) }
-				sourceDarkMode={ require( './images/move-dark.png' ) }
+				source={ 'move-light' }
+				sourceDarkMode={ 'move-dark' }
 			/>
 			<View style={ styles.helpDetailContainer }>
 				<HelpDetailSectionHeadingText text={ __( 'Arrow buttons' ) } />

--- a/packages/editor/src/components/editor-help/remove-blocks.native.js
+++ b/packages/editor/src/components/editor-help/remove-blocks.native.js
@@ -18,8 +18,8 @@ const RemoveBlocks = () => {
 	return (
 		<>
 			<HelpDetailImage
-				source={ require( './images/options-light.png' ) }
-				sourceDarkMode={ require( './images/options-dark.png' ) }
+				source={ 'options-light' }
+				sourceDarkMode={ 'options-dark' }
 			/>
 			<View style={ styles.helpDetailContainer }>
 				<HelpDetailBodyText

--- a/packages/editor/src/components/editor-help/view-sections.native.js
+++ b/packages/editor/src/components/editor-help/view-sections.native.js
@@ -10,6 +10,7 @@ import {
 	usePreferredColorScheme,
 	usePreferredColorSchemeStyle,
 } from '@wordpress/compose';
+import { useEffect, useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -53,19 +54,41 @@ export const HelpDetailImage = ( {
 	source,
 	sourceDarkMode,
 } ) => {
-	const imageStyle = usePreferredColorSchemeStyle(
-		styles.helpDetailImage,
-		styles.helpDetailImageDark
-	);
+	const getUri = () => {
+		const sourceFromScheme =
+			darkModeEnabled && sourceDarkMode ? sourceDarkMode : source;
+
+		// TODO: Find an image CDN instead of GitHub
+		const sourcePrefix =
+			'https://raw.githubusercontent.com/WordPress/gutenberg/trunk/packages/editor/src/components/editor-help/images/';
+		const sourceSuffix = '.png';
+
+		return `${ sourcePrefix }${ sourceFromScheme }${ sourceSuffix }`;
+	};
+
+	const [ imageSize, setImageSize ] = useState( {
+		width: 0,
+		height: 0,
+	} );
+
+	useEffect( () => {
+		Image.getSize( getUri(), ( width, height ) => {
+			setImageSize( { width, height } );
+		} );
+	}, [ source, sourceDarkMode, getUri ] );
+
 	const darkModeEnabled = usePreferredColorScheme() === 'dark';
+
 	return (
 		<Image
 			accessible={ accessible }
 			accessibilityLabel={ accessibilityLabel }
-			source={
-				darkModeEnabled && sourceDarkMode ? sourceDarkMode : source
-			}
-			style={ imageStyle }
+			resizeMode="contain"
+			source={ {
+				uri: getUri(),
+			} }
+			// TODO: fix aspect ratio
+			style={ { width: imageSize.width, height: imageSize.height } }
 		/>
 	);
 };


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes images not being included in the mobile Help & Support screens.

* https://github.com/WordPress/gutenberg/issues/53591

⚠️ **Note**: this draft PR is a secondary option if the static images cannot be bundled with the Gutenberg XCFramework in https://github.com/wordpress-mobile/gutenberg-mobile/pull/6067.


## Why?
Presently,  static Help and Support images that are bundled with the app are not appearing, and are showing empty gray boxes. Moving these resources to network URI images allows them to be displayed within the application. 

## How?
Migrates the static Help & Support images to use network image URIs.

Todo:
- [ ] Choose an image CDN other than GitHub that can serve images
- [ ] Fix the aspect ratio in the image display
- [ ] Remove the static image resources from the app bundle

## Testing Instructions
1. Open a post
2. Use the three dots button in the top toolbar
3. Navigate to Help & Support 
4. Open Help & Support pages and note images
