### PR TITLE
List View: Recalculate window list when expanded state changes (fix logic for long nested lists)

### DIFF
--- a/packages/block-editor/src/components/list-view/index.js
+++ b/packages/block-editor/src/components/list-view/index.js
@@ -159,19 +159,6 @@ function ListViewComponent(
 		isMounted.current = true;
 	}, [] );
 
-	// List View renders a fixed number of items and relies on each having a fixed item height of 36px.
-	// If this value changes, we should also change the itemHeight value set in useFixedWindowList.
-	// See: https://github.com/WordPress/gutenberg/pull/35230 for additional context.
-	const [ fixedListWindow ] = useFixedWindowList(
-		elementRef,
-		BLOCK_LIST_ITEM_HEIGHT,
-		visibleBlockCount,
-		{
-			useWindowing: true,
-			windowOverscan: 40,
-		}
-	);
-
 	const expand = useCallback(
 		( clientId ) => {
 			if ( ! clientId ) {
@@ -240,6 +227,25 @@ function ListViewComponent(
 			insertedBlock,
 			setInsertedBlock,
 		]
+	);
+
+	// List View renders a fixed number of items and relies on each having a fixed item height of 36px.
+	// If this value changes, we should also change the itemHeight value set in useFixedWindowList.
+	// See: https://github.com/WordPress/gutenberg/pull/35230 for additional context.
+	const [ fixedListWindow ] = useFixedWindowList(
+		elementRef,
+		BLOCK_LIST_ITEM_HEIGHT,
+		visibleBlockCount,
+		{
+			useWindowing: true,
+			// Ensure that the windowing logic is recalculated when the expanded state changes.
+			// This is necessary because expanding a collapsed block in a short list view can
+			// switch the list view to a tall list view with a scrollbar, and vice versa.
+			// When this happens, the windowing logic needs to be recalculated to ensure that
+			// the correct number of blocks are rendered, by rechecking for a scroll container.
+			watch: expandedState,
+			windowOverscan: 40,
+		}
 	);
 
 	// If there are no blocks to show and we're not showing the appender, do not render the list view.

--- a/packages/block-editor/src/components/list-view/index.js
+++ b/packages/block-editor/src/components/list-view/index.js
@@ -237,13 +237,13 @@ function ListViewComponent(
 		BLOCK_LIST_ITEM_HEIGHT,
 		visibleBlockCount,
 		{
-			useWindowing: true,
 			// Ensure that the windowing logic is recalculated when the expanded state changes.
 			// This is necessary because expanding a collapsed block in a short list view can
 			// switch the list view to a tall list view with a scrollbar, and vice versa.
 			// When this happens, the windowing logic needs to be recalculated to ensure that
 			// the correct number of blocks are rendered, by rechecking for a scroll container.
-			watch: expandedState,
+			expandedState,
+			useWindowing: true,
 			windowOverscan: 40,
 		}
 	);

--- a/packages/compose/src/hooks/use-fixed-window-list/index.js
+++ b/packages/compose/src/hooks/use-fixed-window-list/index.js
@@ -27,7 +27,7 @@ const DEFAULT_INIT_WINDOW_SIZE = 30;
  * @property {number}  [windowOverscan] Renders windowOverscan number of items before and after the calculated visible window.
  * @property {boolean} [useWindowing]   When false avoids calculating the window size
  * @property {number}  [initWindowSize] Initial window size to use on first render before we can calculate the window size.
- * @property {any}     [watch]          A variable to watch for changes to trigger a recalculation of the window size.
+ * @property {any}     [expandedState]  Used to recalculate the window size when the expanded state of a list changes.
  */
 
 /**
@@ -60,9 +60,7 @@ export default function useFixedWindowList(
 		if ( ! useWindowing ) {
 			return;
 		}
-
 		const scrollContainer = getScrollContainer( elementRef.current );
-
 		const measureWindow = (
 			/** @type {boolean | undefined} */ initRender
 		) => {
@@ -132,8 +130,8 @@ export default function useFixedWindowList(
 		itemHeight,
 		elementRef,
 		totalItems,
+		options?.expandedState,
 		options?.windowOverscan,
-		options?.watch,
 		useWindowing,
 	] );
 
@@ -184,7 +182,7 @@ export default function useFixedWindowList(
 		elementRef,
 		fixedListWindow.visibleItems,
 		useWindowing,
-		options?.watch,
+		options?.expandedState,
 	] );
 
 	return [ fixedListWindow, setFixedListWindow ];

--- a/packages/compose/src/hooks/use-fixed-window-list/index.js
+++ b/packages/compose/src/hooks/use-fixed-window-list/index.js
@@ -27,6 +27,7 @@ const DEFAULT_INIT_WINDOW_SIZE = 30;
  * @property {number}  [windowOverscan] Renders windowOverscan number of items before and after the calculated visible window.
  * @property {boolean} [useWindowing]   When false avoids calculating the window size
  * @property {number}  [initWindowSize] Initial window size to use on first render before we can calculate the window size.
+ * @property {any}     [watch]          A variable to watch for changes to trigger a recalculation of the window size.
  */
 
 /**
@@ -59,9 +60,8 @@ export default function useFixedWindowList(
 		if ( ! useWindowing ) {
 			return;
 		}
-		const scrollContainer = elementRef.current?.closest(
-			'.edit-post-editor__list-view-panel-content'
-		);
+
+		const scrollContainer = getScrollContainer( elementRef.current );
 
 		const measureWindow = (
 			/** @type {boolean | undefined} */ initRender
@@ -128,7 +128,14 @@ export default function useFixedWindowList(
 				debounceMeasureList
 			);
 		};
-	}, [ itemHeight, elementRef, totalItems ] );
+	}, [
+		itemHeight,
+		elementRef,
+		totalItems,
+		options?.windowOverscan,
+		options?.watch,
+		useWindowing,
+	] );
 
 	useLayoutEffect( () => {
 		if ( ! useWindowing ) {
@@ -171,7 +178,14 @@ export default function useFixedWindowList(
 				handleKeyDown
 			);
 		};
-	}, [ totalItems, itemHeight, elementRef, fixedListWindow.visibleItems ] );
+	}, [
+		totalItems,
+		itemHeight,
+		elementRef,
+		fixedListWindow.visibleItems,
+		useWindowing,
+		options?.watch,
+	] );
 
 	return [ fixedListWindow, setFixedListWindow ];
 }

--- a/packages/compose/src/hooks/use-fixed-window-list/index.js
+++ b/packages/compose/src/hooks/use-fixed-window-list/index.js
@@ -59,7 +59,10 @@ export default function useFixedWindowList(
 		if ( ! useWindowing ) {
 			return;
 		}
-		const scrollContainer = getScrollContainer( elementRef.current );
+		const scrollContainer = elementRef.current?.closest(
+			'.edit-post-editor__list-view-panel-content'
+		);
+
 		const measureWindow = (
 			/** @type {boolean | undefined} */ initRender
 		) => {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes #41613, fixes #42031

Fix an issue with the windowing logic in the list view, where a short post containing a nested block with _heaps_ of inner blocks (e.g. a Gallery with > 40 images) results in the windowing logic getting stuck and not updating when a user scrolls up and down the list.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

When the list view is initially opened, if there are not many blocks at the root level, then no scrollbar will be present, so the fixed window list logic will not find the list view's scroll container in order to set up the windowing logic when a user scrolls up and down the list.

In normal circumstances (at the root level) this is fine — if you add or remove blocks, then `totalItems` within `useFixedWindowList` will change, causing the windowing logic to be recalculated. However, if you have a container block with heaps of children (i.e. 40 or more), then expanding and collapsing the container block does not cause the recalculation to happen. In these cases (short root list, but a container block with heaps of children), then prior to this PR, the windowing logic can fail to update.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

The fix is to ensure the fixed window list is recalculated whenever a block is expanded or collapsed. We can do this by passing the `expandedState` to `useFixedWindowList` and then place the `expandedState` in the hook's `useLayoutEffect` dependency arrays. This causes the windowing to be recalculated whenever the expanded state is changed, anywhere in the tree.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Create a post or page with only a few blocks at the root level.
2. Add a container block (e.g. Group or Gallery).
3. Within this container block, add lots of blocks (e.g. greater than 40-50 — I find it easier to test with a very large number like 100 or so).
4. Save your post or page and reload the editor.
5. Open the list view.
6. Expand the container block and scroll up and down the list view. Prior to this PR notice that the windowing logic is stuck and there'll be a big expanse of whitespace. With this PR applied, scrolling up and down the list view should update the list view.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

1. Reload the post or page created in the previous steps.
2. Navigate to the list view via keyboard (tab your way there).
3. With focus on the container block, press the Right arrow key to expand the item in the list.
4. Use Page Up / Page Down or Home and End keys to navigate up and down the list view. With this PR applied, the windowing logic should be correct, and behave in the same way as scrolling with the mouse.

## Screenshots or screencast <!-- if applicable -->

Note in the before screengrab below, when expanding the collapsed block and then scrolling down the list, that the window list is not updated, resulting in an expanse of white further down the list. In the After screengrab, the list is updated as the user scrolls up and down the list.

| Before | After |
| --- | --- |
| ![2023-08-18 15 14 02](https://github.com/WordPress/gutenberg/assets/14988353/ba4e3083-2c4f-48d4-bd7c-8aa743758b09) | ![2023-08-18 15 06 36](https://github.com/WordPress/gutenberg/assets/14988353/4e20ed7f-49f1-4a96-acc4-7b7b50b568b9) |