### PR TITLE
Command Palette: Proper handling of page/post links in all themes

### DIFF
--- a/packages/core-commands/src/site-editor-navigation-commands.js
+++ b/packages/core-commands/src/site-editor-navigation-commands.js
@@ -37,28 +37,22 @@ const icons = {
 const getNavigationCommandLoaderPerPostType = ( postType ) =>
 	function useNavigationCommandLoader( { search } ) {
 		const history = useHistory();
-		const supportsSearch = ! [ 'wp_template', 'wp_template_part' ].includes(
-			postType
-		);
+		const isBlockBasedTheme = useIsBlockBasedTheme();
 		const { records, isLoading } = useSelect(
 			( select ) => {
 				const { getEntityRecords } = select( coreStore );
-				const query = supportsSearch
-					? {
-							search: !! search ? search : undefined,
-							per_page: 10,
-							orderby: search ? 'relevance' : 'date',
-							status: [
-								'publish',
-								'future',
-								'draft',
-								'pending',
-								'private',
-							],
-					  }
-					: {
-							per_page: -1,
-					  };
+				const query = {
+					search: !! search ? search : undefined,
+					per_page: 10,
+					orderby: search ? 'relevance' : 'date',
+					status: [
+						'publish',
+						'future',
+						'draft',
+						'pending',
+						'private',
+					],
+				};
 				return {
 					records: getEntityRecords( 'postType', postType, query ),
 					isLoading: ! select( coreStore ).hasFinishedResolution(
@@ -67,30 +61,46 @@ const getNavigationCommandLoaderPerPostType = ( postType ) =>
 					),
 				};
 			},
-			[ supportsSearch, search ]
+			[ search ]
 		);
 
-		/*
-		 * wp_template and wp_template_part endpoints do not support per_page or orderby parameters.
-		 * We need to sort the results based on the search query to avoid removing relevant
-		 * records below using .slice().
-		 */
-		const orderedRecords = useMemo( () => {
-			if ( supportsSearch ) {
-				return records ?? [];
-			}
-
-			return orderEntityRecordsBySearch( records, search ).slice( 0, 10 );
-		}, [ supportsSearch, records, search ] );
-
 		const commands = useMemo( () => {
-			return orderedRecords.map( ( record ) => {
+			return ( records ?? [] ).map( ( record ) => {
+				if (
+					postType === 'post' ||
+					( postType === 'page' && ! isBlockBasedTheme )
+				) {
+					return {
+						name: postType + '-' + record.id,
+						searchLabel: record.title?.rendered + ' ' + record.id,
+						label: record.title?.rendered
+							? record.title?.rendered
+							: __( '(no title)' ),
+						icon: icons[ postType ],
+						callback: ( { close } ) => {
+							const args = {
+								post: record.id,
+								action: 'edit',
+							};
+							const targetUrl = addQueryArgs( 'post.php', args );
+							document.location = targetUrl;
+							close();
+						},
+					};
+				}
+
 				const isSiteEditor = getPath( window.location.href )?.includes(
 					'site-editor.php'
 				);
 				const extraArgs = isSiteEditor
-					? { canvas: getQueryArg( window.location.href, 'canvas' ) }
+					? {
+							canvas: getQueryArg(
+								window.location.href,
+								'canvas'
+							),
+					  }
 					: {};
+
 				return {
 					name: postType + '-' + record.id,
 					searchLabel: record.title?.rendered + ' ' + record.id,
@@ -117,7 +127,81 @@ const getNavigationCommandLoaderPerPostType = ( postType ) =>
 					},
 				};
 			} );
-		}, [ orderedRecords, history ] );
+		}, [ records, isBlockBasedTheme, history ] );
+
+		return {
+			commands,
+			isLoading,
+		};
+	};
+
+const getNavigationCommandLoaderPerTemplate = ( templateType ) =>
+	function useNavigationCommandLoader( { search } ) {
+		const history = useHistory();
+		const isBlockBasedTheme = useIsBlockBasedTheme();
+		const { records, isLoading } = useSelect( ( select ) => {
+			const { getEntityRecords } = select( coreStore );
+			const query = { per_page: -1 };
+			return {
+				records: getEntityRecords( 'postType', templateType, query ),
+				isLoading: ! select( coreStore ).hasFinishedResolution(
+					'getEntityRecords',
+					[ 'postType', templateType, query ]
+				),
+			};
+		}, [] );
+
+		/*
+		 * wp_template and wp_template_part endpoints do not support per_page or orderby parameters.
+		 * We need to sort the results based on the search query to avoid removing relevant
+		 * records below using .slice().
+		 */
+		const orderedRecords = useMemo( () => {
+			return orderEntityRecordsBySearch( records, search ).slice( 0, 10 );
+		}, [ records, search ] );
+
+		const commands = useMemo( () => {
+			if (
+				! isBlockBasedTheme &&
+				! templateType === 'wp_template_part'
+			) {
+				return [];
+			}
+			return orderedRecords.map( ( record ) => {
+				const isSiteEditor = getPath( window.location.href )?.includes(
+					'site-editor.php'
+				);
+				const extraArgs = isSiteEditor
+					? { canvas: getQueryArg( window.location.href, 'canvas' ) }
+					: {};
+
+				return {
+					name: templateType + '-' + record.id,
+					searchLabel: record.title?.rendered + ' ' + record.id,
+					label: record.title?.rendered
+						? record.title?.rendered
+						: __( '(no title)' ),
+					icon: icons[ templateType ],
+					callback: ( { close } ) => {
+						const args = {
+							postType: templateType,
+							postId: record.id,
+							...extraArgs,
+						};
+						const targetUrl = addQueryArgs(
+							'site-editor.php',
+							args
+						);
+						if ( isSiteEditor ) {
+							history.push( args );
+						} else {
+							document.location = targetUrl;
+						}
+						close();
+					},
+				};
+			} );
+		}, [ isBlockBasedTheme, orderedRecords, history ] );
 
 		return {
 			commands,
@@ -130,9 +214,9 @@ const usePageNavigationCommandLoader =
 const usePostNavigationCommandLoader =
 	getNavigationCommandLoaderPerPostType( 'post' );
 const useTemplateNavigationCommandLoader =
-	getNavigationCommandLoaderPerPostType( 'wp_template' );
+	getNavigationCommandLoaderPerTemplate( 'wp_template' );
 const useTemplatePartNavigationCommandLoader =
-	getNavigationCommandLoaderPerPostType( 'wp_template_part' );
+	getNavigationCommandLoaderPerTemplate( 'wp_template_part' );
 
 function useSiteEditorBasicNavigationCommands() {
 	const history = useHistory();

--- a/packages/core-commands/src/site-editor-navigation-commands.js
+++ b/packages/core-commands/src/site-editor-navigation-commands.js
@@ -66,17 +66,21 @@ const getNavigationCommandLoaderPerPostType = ( postType ) =>
 
 		const commands = useMemo( () => {
 			return ( records ?? [] ).map( ( record ) => {
+				const command = {
+					name: postType + '-' + record.id,
+					searchLabel: record.title?.rendered + ' ' + record.id,
+					label: record.title?.rendered
+						? record.title?.rendered
+						: __( '(no title)' ),
+					icon: icons[ postType ],
+				};
+
 				if (
 					postType === 'post' ||
 					( postType === 'page' && ! isBlockBasedTheme )
 				) {
 					return {
-						name: postType + '-' + record.id,
-						searchLabel: record.title?.rendered + ' ' + record.id,
-						label: record.title?.rendered
-							? record.title?.rendered
-							: __( '(no title)' ),
-						icon: icons[ postType ],
+						...command,
 						callback: ( { close } ) => {
 							const args = {
 								post: record.id,
@@ -102,12 +106,7 @@ const getNavigationCommandLoaderPerPostType = ( postType ) =>
 					: {};
 
 				return {
-					name: postType + '-' + record.id,
-					searchLabel: record.title?.rendered + ' ' + record.id,
-					label: record.title?.rendered
-						? record.title?.rendered
-						: __( '(no title)' ),
-					icon: icons[ postType ],
+					...command,
 					callback: ( { close } ) => {
 						const args = {
 							postType,


### PR DESCRIPTION
Should be able to close #52154, #52847
Related to #53123

## What?

This PR fixes the following two issues in the command palette:

In the classic theme and the hybrid theme, accessing a searched page would take you to the Site Editor which you do not have permission to access.

<details><summary>Screencast</summary>

https://github.com/WordPress/gutenberg/assets/54422211/bd2dc3a4-6708-46b2-af8f-a1d443dd8572

</details> 

In all themes, accessing a searched post takes you to a page where the Site Editor does not exist.

<details><summary>Screencast</summary>

https://github.com/WordPress/gutenberg/assets/54422211/bbc63613-0320-4856-9410-7a0db587f4b5

</details> 

## Why?
For pages, you should go to the Pages menu in the Site Editor for block themes and to the normal edit page for non-block themes.

For posts, you should go to the normal edit page regardless of the theme type, as it is not currently implemented in the Site Editor.

## How?

These commands are controlled by the `getNavigationCommandLoaderPerPostType()` function. This function handles all posts, pages, templates, and template parts, and therefore contains various conditions based on post type.

I have split it into two functions to simplify the process:

- `getNavigationCommandLoaderPerPostType()`: commands for posts and pages
- `getNavigationCommandLoaderPerTemplate()`: commands for templates and template parts

And in each of these functions, I added processing according to the theme type.

## Testing Instructions

Go to `localhost:8889/wp-admin`, open the Command Palette in each theme, and check the following:

### Block Theme (Twenty Twenty Three)

- `hello`:  should move to the edit post page
- `privacy`: should move to the edit page of the Site Editor
- `404`:  should move to the template page of the Site Editor
- `header`: should move to the template part page of the Site Editor

### Hybrid Theme (Emptyhybrid)

- `hello`:  should move to the edit post page
- `privacy`: should move to the edit post page
- `404`:  the command results should not be displayed
- `header`: should move to the template part of the Site Editor

### Classic Theme (Twenty Twenty One)

- `hello`:  should move to the edit post page
- `privacy`: should move to the edit post page
- `404`:  the command results should not be displayed
- `header`: the command results should not be displayed

