### PR TITLE
[RNMobile] Add optional chaining to `reusableBlock.title` 

### DIFF
--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1978,7 +1978,7 @@ export const getInserterItems = createSelector(
 				id,
 				name: 'core/block',
 				initialAttributes: { ref: reusableBlock.id },
-				title: reusableBlock.title.raw,
+				title: reusableBlock.title?.raw,
 				icon,
 				category: 'reusable',
 				keywords: [ 'reusable' ],


### PR DESCRIPTION
Potential fix for https://github.com/wordpress-mobile/gutenberg-mobile/issues/5496 and https://github.com/wordpress-mobile/WordPress-iOS/issues/21083

## What?

This PR adds optional chaining to `reusableBlock.title` within the `buildReusableBlockInserterItem` function:

https://github.com/WordPress/gutenberg/blob/abb51bab2b12c82d271ec206b93065edf45fd624/packages/block-editor/src/store/selectors.js#L1981

## Why?

We've received multiple reports of Gutenberg Mobile crashing with the following error:

```
RCTFatalException: Unhandled JS Exception: TypeError: undefined is not an object (evaluating 'n.title.raw') This error is lo...: Unhandled JS Exception: TypeError: undefined is not an object (evaluating 'n.title.raw')
```

The change in this PR is an attempt to fix that crash.

## How?

Even after digging deeply into user reports and available logs, attempts to reproduce the crash have been unsuccessful. The main clue we have to go on is that `n.title.raw` in the [app's generated bundle](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/bundle/ios/App.text.js) points to [the instance of reusable blocks](https://github.com/WordPress/gutenberg/blob/abb51bab2b12c82d271ec206b93065edf45fd624/packages/block-editor/src/store/selectors.js#L1977-L1990) returned by the inserter. 

From the [checks in place](https://github.com/WordPress/gutenberg/blob/abb51bab2b12c82d271ec206b93065edf45fd624/packages/block-editor/src/store/selectors.js#L2631-L2633) within `getReusableBlocks`, we can reasonably infer that `reusableBlocks` wouldn't be undefined. As such, this PR adds optional chaining to the `title` property within `reusableBlock`. 

(Note, the same pattern can be found [within the `__experimentalGetReusableBlockTitle` function](https://github.com/WordPress/gutenberg/blob/abb51bab2b12c82d271ec206b93065edf45fd624/packages/block-editor/src/store/selectors.js#L2579-L2591) in the same file.) 

By using optional chaining, the code now gracefully handles scenarios where `title` might be undefined, which should prevent the TypeError from being thrown.

## Testing Instructions

As the crash isn't easily reproducible, there isn't a straight forward way to ensure this PR fixes it. Instead, the logic of making these change should be verified. 

In both the app and on the web, we should also ensure that there are no regressions related to reusable blocks/synced patterns with no titles:

* Publish a new synced pattern with no title.
* Begin a new post and add the synced pattern to it.
* Verify that there is no issue related to there being no title.