### PR TITLE
getInsertionPoint: Avoid returning a different object on every call

### DIFF
--- a/packages/customize-widgets/src/store/selectors.js
+++ b/packages/customize-widgets/src/store/selectors.js
@@ -1,3 +1,8 @@
+const EMPTY_INSERTION_POINT = {
+	rootClientId: undefined,
+	insertionIndex: undefined,
+};
+
 /**
  * Returns true if the inserter is opened.
  *
@@ -35,5 +40,9 @@ export function isInserterOpened( state ) {
  * @return {Object} The root client ID and index to insert at.
  */
 export function __experimentalGetInsertionPoint( state ) {
+	if ( typeof state === 'boolean' ) {
+		return EMPTY_INSERTION_POINT;
+	}
+
 	return state.blockInserterPanel;
 }

--- a/packages/customize-widgets/src/store/selectors.js
+++ b/packages/customize-widgets/src/store/selectors.js
@@ -35,6 +35,5 @@ export function isInserterOpened( state ) {
  * @return {Object} The root client ID and index to insert at.
  */
 export function __experimentalGetInsertionPoint( state ) {
-	const { rootClientId, insertionIndex } = state.blockInserterPanel;
-	return { rootClientId, insertionIndex };
+	return state.blockInserterPanel;
 }

--- a/packages/edit-post/src/store/selectors.js
+++ b/packages/edit-post/src/store/selectors.js
@@ -15,6 +15,11 @@ import deprecated from '@wordpress/deprecated';
 
 const EMPTY_ARRAY = [];
 const EMPTY_OBJECT = {};
+const EMPTY_INSERTION_POINT = {
+	rootClientId: undefined,
+	insertionIndex: undefined,
+	filterValue: undefined,
+};
 
 /**
  * Returns the current editing mode.
@@ -472,6 +477,10 @@ export function isInserterOpened( state ) {
  * @return {Object} The root client ID, index to insert at and starting filter value.
  */
 export function __experimentalGetInsertionPoint( state ) {
+	if ( typeof state === 'boolean' ) {
+		return EMPTY_INSERTION_POINT;
+	}
+
 	return state.blockInserterPanel;
 }
 

--- a/packages/edit-post/src/store/selectors.js
+++ b/packages/edit-post/src/store/selectors.js
@@ -472,9 +472,7 @@ export function isInserterOpened( state ) {
  * @return {Object} The root client ID, index to insert at and starting filter value.
  */
 export function __experimentalGetInsertionPoint( state ) {
-	const { rootClientId, insertionIndex, filterValue } =
-		state.blockInserterPanel;
-	return { rootClientId, insertionIndex, filterValue };
+	return state.blockInserterPanel;
 }
 
 /**

--- a/packages/edit-widgets/src/store/selectors.js
+++ b/packages/edit-widgets/src/store/selectors.js
@@ -254,8 +254,7 @@ export function isInserterOpened( state ) {
  * @return {Object} The root client ID and index to insert at.
  */
 export function __experimentalGetInsertionPoint( state ) {
-	const { rootClientId, insertionIndex } = state.blockInserterPanel;
-	return { rootClientId, insertionIndex };
+	return state.blockInserterPanel;
 }
 
 /**

--- a/packages/edit-widgets/src/store/selectors.js
+++ b/packages/edit-widgets/src/store/selectors.js
@@ -19,6 +19,11 @@ import {
 } from './utils';
 import { STORE_NAME as editWidgetsStoreName } from './constants';
 
+const EMPTY_INSERTION_POINT = {
+	rootClientId: undefined,
+	insertionIndex: undefined,
+};
+
 /**
  * Returns all API widgets.
  *
@@ -254,6 +259,10 @@ export function isInserterOpened( state ) {
  * @return {Object} The root client ID and index to insert at.
  */
 export function __experimentalGetInsertionPoint( state ) {
+	if ( typeof state === 'boolean' ) {
+		return EMPTY_INSERTION_POINT;
+	}
+
 	return state.blockInserterPanel;
 }
 


### PR DESCRIPTION
## What?
Avoid returning a different object when the `__experimentalGetInsertionPoint` selector is called with the same state multiple times.

There's one more definition of the same selector in the `edit-site` package. I'll handle it separately as it contains more logic.

## Why?
It prevents unnecessary rerenders. See #53666.

## How?
Return `state.blockInserterPanel` directly instead of destructuring and reconstructing the object.

## Testing Instructions

### Selector warning
1. Open a post or page.
2. Open the main block inserter.
3. The following errors shouldn't be logged - `The 'useSelect' hook returns different values when called with the same state and parameters. This can lead to unnecessary rerenders.`

### Selector behavior
1. Open a post or page.
2. Click on in-canvas quick inserter.
3. Search for a block.
4. Click the "Browse all" button.
5. The main block inserter should open and contain the search value.
6. Clicking on the block inserts it in the correct position.

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/240569/544dc6ec-2ff0-4b78-b8ec-b2d8c6690138