### PR TITLE
Navigation block: fix padding on mobile overlay when global padding is 0

### DIFF
--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -506,10 +506,10 @@ button.wp-block-navigation-item__content {
 		@include reduce-motion("animation");
 
 		// Try to inherit any root paddings set, so the X can align to a top-right aligned menu.
-		padding-top: max(var(--wp--style--root--padding-top, 2rem), 2rem);
-		padding-right: max(var(--wp--style--root--padding-right, 2rem), 2rem);
-		padding-bottom: max(var(--wp--style--root--padding-bottom, 2rem), 2rem);
-		padding-left: max(var(--wp--style--root--padding-left, 2rem), 2rem);
+		padding-top: clamp(1rem, var(--wp--style--root--padding-top), 20rem);
+		padding-right: clamp(1rem, var(--wp--style--root--padding-right), 20rem);
+		padding-bottom: clamp(1rem, var(--wp--style--root--padding-bottom), 20rem);
+		padding-left: clamp(1rem, var(--wp--style--root--padding-left), 20em);
 
 		// Allow modal to scroll.
 		overflow: auto;

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -506,10 +506,10 @@ button.wp-block-navigation-item__content {
 		@include reduce-motion("animation");
 
 		// Try to inherit any root paddings set, so the X can align to a top-right aligned menu.
-		padding-top: max(var(--wp--style--root--padding-top), 2rem);
-		padding-right: max(var(--wp--style--root--padding-right), 2rem);
-		padding-bottom: max(var(--wp--style--root--padding-bottom), 2rem);
-		padding-left: max(var(--wp--style--root--padding-left), 2rem);
+		padding-top: max(var(--wp--style--root--padding-top, 2rem), 2rem);
+		padding-right: max(var(--wp--style--root--padding-right, 2rem), 2rem);
+		padding-bottom: max(var(--wp--style--root--padding-bottom, 2rem), 2rem);
+		padding-left: max(var(--wp--style--root--padding-left, 2rem), 2rem);
 
 		// Allow modal to scroll.
 		overflow: auto;

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -506,10 +506,10 @@ button.wp-block-navigation-item__content {
 		@include reduce-motion("animation");
 
 		// Try to inherit any root paddings set, so the X can align to a top-right aligned menu.
-		padding-top: var(--wp--style--root--padding-top, 2rem);
-		padding-right: var(--wp--style--root--padding-right, 2rem);
-		padding-bottom: var(--wp--style--root--padding-bottom, 2rem);
-		padding-left: var(--wp--style--root--padding-left, 2rem);
+		padding-top: max(var(--wp--style--root--padding-top), 2rem);
+		padding-right: max(var(--wp--style--root--padding-right), 2rem);
+		padding-bottom: max(var(--wp--style--root--padding-bottom), 2rem);
+		padding-left: max(var(--wp--style--root--padding-left), 2rem);
 
 		// Allow modal to scroll.
 		overflow: auto;

--- a/test/e2e/specs/editor/blocks/navigation-colors.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation-colors.spec.js
@@ -413,6 +413,10 @@ class ColorControl {
 			.getByRole( 'button', { name: 'Open menu' } )
 			.click();
 
+		// Move the mouse to avoid accidentally triggering hover
+		// state on the links once the overlay opens.
+		await this.page.mouse.move( 1000, 1000 );
+
 		const overlay = this.editor.canvas
 			.locator( '.wp-block-navigation__responsive-container' )
 			.filter( { hasText: 'Submenu Link' } );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This PR expands on the fix made by https://github.com/WordPress/gutenberg/pull/43576 to cover the cases when themes don't declare a global top padding for their site (or they declare it as 0px). This makes sure that the padding value is not 0.

Fixes https://github.com/WordPress/gutenberg/issues/52233

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The original fix was adding a 2rem fallback if the global padding is not set by the theme. That fallback is probably only working for classic themes, since when block themes don't declare a global padding, the value of the CSS variable resolves to 0px, causing this issue on the overlay menu:

![Screen Capture on 2023-08-16 at 11-21-11](https://github.com/WordPress/gutenberg/assets/3593343/4850abd4-e9da-4057-ba18-501f7f78d057)

There is a use case for themes with no global padding-top when the theme wants to have a different color on the header than the body, where the theme uses group padding instead to separate the menu from the top of the viewport.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Using `max()`, we make sure that the highest value of the pair is always selected, so if the global padding is 0, it will default to 2rem instead.

There are two caveats to this implementation:

1. If the theme defines a non 0 global padding that is lower than 2rem, the 2rem value will prevail. This causes a slight visual jump when opening the overlay
2. This solution doesn't work if theme defines the global padding as a unitless 0. `max(`) needs the values to have units, else they won't work.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

In your theme.json file, define the global padding as either 

```
{
    "styles": {
               "spacing": {
			"padding": {
				"right": "var(--wp--preset--spacing--60)",
				"left": "var(--wp--preset--spacing--60)"
			}
		},
    }
}
```

or

```
{
    "styles": {
               "spacing": {
			"padding": {
                                "top": "0px",
				"right": "var(--wp--preset--spacing--60)",
				"left": "var(--wp--preset--spacing--60)",
                                "bottom": "0px",
			}
		},
    }
}
```

Check the frontend both on a logged in and logged out state, and notice that the burger icon is separated 2rem from the top of the viewport.

Also, check that if the value for the global padding is bigger than 2rem, that's the value that's been applied for the overlay too


