### PR TITLE
Block Styles: Fix misplaced preview popover on RTL site

### DIFF
--- a/packages/block-editor/src/components/block-styles/style.scss
+++ b/packages/block-editor/src/components/block-styles/style.scss
@@ -4,9 +4,6 @@
 
 .block-editor-block-styles__preview-panel {
 	display: none;
-	position: absolute;
-	right: $grid-unit-20;
-	left: auto;
 	// Same layer as the sidebar from which it's triggered.
 	z-index: z-index(".interface-interface-skeleton__sidebar {greater than small}");
 


### PR DESCRIPTION
Fixes: #49554

## What?

This PR fixes a problem with misaligned block style previews on RTL sites.

| Header | Header |
|--------|--------|
| ![before](https://github.com/WordPress/gutenberg/assets/54422211/82b250fd-1991-4baa-bd4a-2c2b7b8daac1) | ![after](https://github.com/WordPress/gutenberg/assets/54422211/25edcd26-67b9-4709-96c0-74355dc15ef2) | 

## Why?

The `placement` prop of the Popover component is set to `left-start`, which should render correctly in the opposite direction for the RTL language. And the Popover component has `position:absolute`. However, the `.block-editor-block-styles__preview-panel` in the Popover also has `position: abusolute`, `right`, `left` defined, which causes misplacement.

## How?

Remove unnecessary styles.

## Testing Instructions

- Change the site language to RTL.
- Insert the image block in the post editor.
- When you mouse over the block style button, confirm that the preview popover appears correctly to the right of the button.
- In LTR language, confirm that it still appears on the left side as before.

