### PR TITLE
Edit Site: Rename `CanvasSpinner` to `CanvasLoader`

### DIFF
--- a/packages/e2e-test-utils-playwright/src/admin/visit-site-editor.ts
+++ b/packages/e2e-test-utils-playwright/src/admin/visit-site-editor.ts
@@ -63,7 +63,7 @@ export async function visitSiteEditor(
 		.first()
 		.waitFor();
 
-	// TODO: Ideally the content underneath the progress bar should be marked inert until it's ready.
+	// TODO: Ideally the content underneath the canvas loader should be marked inert until it's ready.
 	await this.page
 		.locator( '.edit-site-canvas-loader' )
 		// Bigger timeout is needed for larger entities, for example the large

--- a/packages/e2e-test-utils-playwright/src/admin/visit-site-editor.ts
+++ b/packages/e2e-test-utils-playwright/src/admin/visit-site-editor.ts
@@ -63,9 +63,9 @@ export async function visitSiteEditor(
 		.first()
 		.waitFor();
 
-	// TODO: Ideally the content underneath the spinner should be marked inert until it's ready.
+	// TODO: Ideally the content underneath the progress bar should be marked inert until it's ready.
 	await this.page
-		.locator( '.edit-site-canvas-spinner' )
+		.locator( '.edit-site-canvas-loader' )
 		// Bigger timeout is needed for larger entities, for example the large
 		// post html fixture that we load for performance tests, which often
 		// doesn't make it under the default 10 seconds.

--- a/packages/e2e-test-utils/src/site-editor.js
+++ b/packages/e2e-test-utils/src/site-editor.js
@@ -10,7 +10,7 @@ import { addQueryArgs } from '@wordpress/url';
 
 const SELECTORS = {
 	visualEditor: '.edit-site-visual-editor iframe',
-	loadingProgressBar: '.edit-site-canvas-loader',
+	canvasLoader: '.edit-site-canvas-loader',
 };
 
 /**
@@ -84,7 +84,7 @@ export async function visitSiteEditor( query, skipWelcomeGuide = true ) {
 
 	await visitAdminPage( 'site-editor.php', query );
 	await page.waitForSelector( SELECTORS.visualEditor );
-	await page.waitForSelector( SELECTORS.loadingProgressBar, {
+	await page.waitForSelector( SELECTORS.canvasLoader, {
 		hidden: true,
 	} );
 

--- a/packages/e2e-test-utils/src/site-editor.js
+++ b/packages/e2e-test-utils/src/site-editor.js
@@ -10,7 +10,7 @@ import { addQueryArgs } from '@wordpress/url';
 
 const SELECTORS = {
 	visualEditor: '.edit-site-visual-editor iframe',
-	loadingSpinner: '.edit-site-canvas-spinner',
+	loadingProgressBar: '.edit-site-canvas-loader',
 };
 
 /**
@@ -84,7 +84,9 @@ export async function visitSiteEditor( query, skipWelcomeGuide = true ) {
 
 	await visitAdminPage( 'site-editor.php', query );
 	await page.waitForSelector( SELECTORS.visualEditor );
-	await page.waitForSelector( SELECTORS.loadingSpinner, { hidden: true } );
+	await page.waitForSelector( SELECTORS.loadingProgressBar, {
+		hidden: true,
+	} );
 
 	if ( skipWelcomeGuide ) {
 		await disableSiteEditorWelcomeGuide();

--- a/packages/edit-site/src/components/canvas-loader/index.js
+++ b/packages/edit-site/src/components/canvas-loader/index.js
@@ -13,7 +13,7 @@ import { useStylesPreviewColors } from '../global-styles/hooks';
 const { ProgressBar, Theme } = unlock( componentsPrivateApis );
 const { useGlobalStyle } = unlock( blockEditorPrivateApis );
 
-export default function CanvasSpinner( { id } ) {
+export default function CanvasLoader( { id } ) {
 	const [ fallbackIndicatorColor ] = useGlobalStyle( 'color.text' );
 	const [ backgroundColor ] = useGlobalStyle( 'color.background' );
 	const { highlightedColors } = useStylesPreviewColors();
@@ -21,7 +21,7 @@ export default function CanvasSpinner( { id } ) {
 		highlightedColors[ 0 ]?.color ?? fallbackIndicatorColor;
 
 	return (
-		<div className="edit-site-canvas-spinner">
+		<div className="edit-site-canvas-loader">
 			<Theme accent={ indicatorColor } background={ backgroundColor }>
 				<ProgressBar id={ id } />
 			</Theme>

--- a/packages/edit-site/src/components/canvas-loader/style.scss
+++ b/packages/edit-site/src/components/canvas-loader/style.scss
@@ -1,4 +1,4 @@
-.edit-site-canvas-spinner {
+.edit-site-canvas-loader {
 	width: 100%;
 	height: 100%;
 	display: flex;
@@ -9,7 +9,7 @@
 	align-items: center;
 	justify-content: center;
 
-	animation: 0.5s ease 1s edit-site-canvas-spinner__fade-in-animation;
+	animation: 0.5s ease 1s edit-site-canvas-loader__fade-in-animation;
 	animation-fill-mode: forwards;
 	@include reduce-motion("animation");
 
@@ -18,7 +18,7 @@
 	}
 }
 
-@keyframes edit-site-canvas-spinner__fade-in-animation {
+@keyframes edit-site-canvas-loader__fade-in-animation {
 	from {
 		opacity: 0;
 	}

--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -40,7 +40,7 @@ import StartTemplateOptions from '../start-template-options';
 import { store as editSiteStore } from '../../store';
 import { GlobalStylesRenderer } from '../global-styles-renderer';
 import useTitle from '../routes/use-title';
-import CanvasSpinner from '../canvas-spinner';
+import CanvasLoader from '../canvas-loader';
 import { unlock } from '../../lock-unlock';
 import useEditedEntityRecord from '../use-edited-entity-record';
 import { SidebarFixedBottomSlot } from '../sidebar-edit-mode/sidebar-fixed-bottom';
@@ -180,7 +180,7 @@ export default function Editor( { isLoading } ) {
 	useTitle( hasLoadedPost && title );
 
 	const loadingProgressId = useInstanceId(
-		CanvasSpinner,
+		CanvasLoader,
 		'edit-site-editor__loading-progress'
 	);
 
@@ -193,7 +193,7 @@ export default function Editor( { isLoading } ) {
 
 	return (
 		<>
-			{ isLoading ? <CanvasSpinner id={ loadingProgressId } /> : null }
+			{ isLoading ? <CanvasLoader id={ loadingProgressId } /> : null }
 			{ isEditMode && <WelcomeGuide /> }
 			<EntityProvider kind="root" type="site">
 				<EntityProvider

--- a/packages/edit-site/src/style.scss
+++ b/packages/edit-site/src/style.scss
@@ -2,7 +2,7 @@
 
 @import "./components/add-new-template/style.scss";
 @import "./components/block-editor/style.scss";
-@import "./components/canvas-spinner/style.scss";
+@import "./components/canvas-loader/style.scss";
 @import "./components/code-editor/style.scss";
 @import "./components/global-styles/style.scss";
 @import "./components/global-styles/screen-revisions/style.scss";

--- a/test/performance/specs/site-editor.spec.js
+++ b/test/performance/specs/site-editor.spec.js
@@ -111,7 +111,7 @@ test.describe( 'Site Editor Performance', () => {
 
 			// Wait for the canvas to appear.
 			await testPage
-				.locator( '.edit-site-canvas-spinner' )
+				.locator( '.edit-site-canvas-loader' )
 				.waitFor( { state: 'hidden', timeout: 60_000 } );
 
 			// Wait for the first block.


### PR DESCRIPTION
## What?
This PR renames the `CanvasSpinner` component to `CanvasLoader` as recommended by @ntsekouras in https://github.com/WordPress/gutenberg/pull/53032#discussion_r1284590270. It also makes a lot of sense, given that the component no longer displays a spinner, but a progress bar.

## Why?
This PR is a simple rename of a component to match the new functionality and UI.

## How?
We're just renaming the directory and the component.

## Testing Instructions
Verify the site editor still loads correctly and all checks are green.

### Testing Instructions for Keyboard
None

## Screenshots or screencast <!-- if applicable -->
None