### PR TITLE
Edit Site: Fix site editor canvas edit mode button

### DIFF
--- a/packages/edit-site/src/components/canvas-spinner/style.scss
+++ b/packages/edit-site/src/components/canvas-spinner/style.scss
@@ -2,6 +2,9 @@
 	width: 100%;
 	height: 100%;
 	display: flex;
+	position: absolute;
+	top: 0;
+	left: 0;
 	opacity: 0;
 	align-items: center;
 	justify-content: center;


### PR DESCRIPTION
## What?
This PR fixes the site editor canvas edit mode button to occupy the entire frame canvas.

See #47676 for where this button was initially introduced.

I believe this was broken in #50222.

## Why?
Right now, it's broken during the loading phase - the button appears below the canvas.

## How?
We're just making the loading spinner absolute so the site editor canvas edit mode button will take the entire canvas space.

## Testing Instructions
* Open the site editor.
* While the canvas is still loading, verify clicking anywhere on the canvas enters edit mode.
* After loading has finished, verify clicking anywhere on the canvas still enters edit mode.

### Testing Instructions for Keyboard
None

## Screenshots or screencast <!-- if applicable -->
None