### PR TITLE
Add missing aria roles for block locking toolbar and menu buttons

### DIFF
--- a/packages/block-editor/src/components/block-lock/menu-item.js
+++ b/packages/block-editor/src/components/block-lock/menu-item.js
@@ -31,6 +31,8 @@ export default function BlockLockMenuItem( { clientId } ) {
 			<MenuItem
 				icon={ isLocked ? unlock : lockOutline }
 				onClick={ toggleModal }
+				aria-expanded={ isModalOpen }
+				aria-haspopup="dialog"
 			>
 				{ label }
 			</MenuItem>

--- a/packages/block-editor/src/components/block-lock/toolbar.js
+++ b/packages/block-editor/src/components/block-lock/toolbar.js
@@ -59,10 +59,12 @@ export default function BlockLockToolbar( { clientId, wrapperRef } ) {
 		<>
 			<ToolbarGroup className="block-editor-block-lock-toolbar">
 				<ToolbarButton
+					ref={ lockButtonRef }
 					icon={ lock }
 					label={ __( 'Unlock' ) }
 					onClick={ toggleModal }
-					ref={ lockButtonRef }
+					aria-expanded={ isModalOpen }
+					aria-haspopup="dialog"
 				/>
 			</ToolbarGroup>
 			{ isModalOpen && (


### PR DESCRIPTION
## What?
Part of #24796.

PR adds the missing aria roles for block locking toolbar and menu buttons.

## Why?
Both components open a dialog but lack the `aria-expanded` and `aria-haspopup` attributes.

## How?
The `aria-expanded` attribute is managed by the dialog open state, and the `aria-haspopup` has "dialog" as its value.

## Testing Instructions
1. Open a post or page.
2. Insert a heading block.
3. Navigate to the "Options" button in the block toolbar.
4. Open the dropdown and navigate to the "Lock" menu item.
5. Confirm it has appropriate aria roles.
6. Open the block locking dialog and lock any of the properties.
7. Close the dialog and navigate back to the block toolbar.
8. The "Unlock" button should have appropriate aria roles.

### Testing Instructions for Keyboard
Same instructions

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2023-08-16 at 16 58 04](https://github.com/WordPress/gutenberg/assets/240569/1c4a8887-a39a-4270-8164-88392fcad056)
