### PR TITLE
Rename Group blocks in the Editor via Modal

### DIFF
--- a/packages/base-styles/_z-index.scss
+++ b/packages/base-styles/_z-index.scss
@@ -125,6 +125,7 @@ $z-layers: (
 	".edit-site-create-template-part-modal": 1000001,
 	".block-editor-block-lock-modal": 1000001,
 	".block-editor-template-part__selection-modal": 1000001,
+	".block-editor-block-rename-modal": 1000001,
 
 	// Note: The ConfirmDialog component's z-index is being set to 1000001 in packages/components/src/confirm-dialog/styles.ts
 	// because it uses emotion and not sass. We need it to render on top its parent popover.

--- a/packages/block-editor/src/components/list-view/block.js
+++ b/packages/block-editor/src/components/list-view/block.js
@@ -73,6 +73,7 @@ function ListViewBlock( {
 
 	const blockInformation = useBlockDisplayInformation( clientId );
 	const blockTitle = blockInformation?.title || __( 'Untitled' );
+
 	const block = useSelect(
 		( select ) => select( blockEditorStore ).getBlock( clientId ),
 		[ clientId ]
@@ -106,14 +107,14 @@ function ListViewBlock( {
 		? sprintf(
 				// translators: %s: The title of the block. This string indicates a link to select the locked block.
 				__( '%s (locked)' ),
-				blockTitle
+				blockInformation?.name || blockTitle
 		  )
-		: blockTitle;
+		: blockInformation?.name || blockTitle;
 
 	const settingsAriaLabel = sprintf(
 		// translators: %s: The title of the block.
 		__( 'Options for %s' ),
-		blockTitle
+		blockInformation?.name || blockTitle
 	);
 
 	const {

--- a/packages/block-editor/src/components/list-view/block.js
+++ b/packages/block-editor/src/components/list-view/block.js
@@ -72,7 +72,8 @@ function ListViewBlock( {
 	const { toggleBlockHighlight } = useDispatch( blockEditorStore );
 
 	const blockInformation = useBlockDisplayInformation( clientId );
-	const blockTitle = blockInformation?.title || __( 'Untitled' );
+	const blockTitle =
+		blockInformation?.name || blockInformation?.title || __( 'Untitled' );
 
 	const block = useSelect(
 		( select ) => select( blockEditorStore ).getBlock( clientId ),
@@ -107,14 +108,14 @@ function ListViewBlock( {
 		? sprintf(
 				// translators: %s: The title of the block. This string indicates a link to select the locked block.
 				__( '%s (locked)' ),
-				blockInformation?.name || blockTitle
+				blockTitle
 		  )
-		: blockInformation?.name || blockTitle;
+		: blockTitle;
 
 	const settingsAriaLabel = sprintf(
 		// translators: %s: The title of the block.
 		__( 'Options for %s' ),
-		blockInformation?.name || blockTitle
+		blockTitle
 	);
 
 	const {

--- a/packages/block-editor/src/components/use-block-display-information/index.js
+++ b/packages/block-editor/src/components/use-block-display-information/index.js
@@ -26,6 +26,7 @@ import { store as blockEditorStore } from '../../store';
  * @property {WPIcon}  icon        Block type icon.
  * @property {string}  description A detailed block type description.
  * @property {string}  anchor      HTML anchor.
+ * @property {name}    name        A custom, human readable name for the block.
  */
 
 /**
@@ -94,6 +95,7 @@ export default function useBlockDisplayInformation( clientId ) {
 				anchor: attributes?.anchor,
 				positionLabel,
 				positionType: attributes?.style?.position?.type,
+				name: attributes?.metadata?.name,
 			};
 			if ( ! match ) return blockTypeInfo;
 
@@ -105,6 +107,7 @@ export default function useBlockDisplayInformation( clientId ) {
 				anchor: attributes?.anchor,
 				positionLabel,
 				positionType: attributes?.style?.position?.type,
+				name: attributes?.metadata?.name,
 			};
 		},
 		[ clientId ]

--- a/packages/block-editor/src/hooks/block-rename-ui.js
+++ b/packages/block-editor/src/hooks/block-rename-ui.js
@@ -56,6 +56,8 @@ function RenameModal( { blockName, originalBlockName, onClose, onSave } ) {
 					<TextControl
 						__nextHasNoMarginBottom
 						value={ editedBlockName }
+						label={ __( 'Block name' ) }
+						hideLabelFromVision={ true }
 						placeholder={ __( 'Block name' ) }
 						onChange={ setEditedBlockName }
 						onBlur={ () => {

--- a/packages/block-editor/src/hooks/block-rename-ui.js
+++ b/packages/block-editor/src/hooks/block-rename-ui.js
@@ -114,6 +114,8 @@ function BlockRenameControl( props ) {
 							onClick={ () => {
 								setRenamingBlock( true );
 							} }
+							aria-expanded={ renamingBlock }
+							aria-haspopup="dialog"
 						>
 							{ __( 'Rename' ) }
 						</MenuItem>

--- a/packages/block-editor/src/hooks/block-rename-ui.js
+++ b/packages/block-editor/src/hooks/block-rename-ui.js
@@ -37,7 +37,21 @@ function RenameModal( { blockName, onClose, onSave } ) {
 	return (
 		<Modal title={ __( 'Rename block' ) } onRequestClose={ onClose }>
 			<p>{ __( 'Choose a custom name for this block.' ) }</p>
-			<form className="sidebar-navigation__rename-modal-form">
+			<form
+				className="sidebar-navigation__rename-modal-form"
+				onSubmit={ ( e ) => {
+					e.preventDefault();
+
+					if ( ! isNameValid ) {
+						return;
+					}
+
+					onSave( editedBlockName );
+
+					// Immediate close avoids ability to hit save multiple times.
+					onClose();
+				} }
+			>
 				<VStack spacing="3">
 					<TextControl
 						__nextHasNoMarginBottom
@@ -54,17 +68,6 @@ function RenameModal( { blockName, onClose, onSave } ) {
 							aria-disabled={ ! isNameValid }
 							variant="primary"
 							type="submit"
-							onClick={ ( e ) => {
-								e.preventDefault();
-
-								if ( ! isNameValid ) {
-									return;
-								}
-								onSave( editedBlockName );
-
-								// Immediate close avoids ability to hit save multiple times.
-								onClose();
-							} }
 						>
 							{ __( 'Save' ) }
 						</Button>

--- a/packages/block-editor/src/hooks/block-rename-ui.js
+++ b/packages/block-editor/src/hooks/block-rename-ui.js
@@ -20,7 +20,10 @@ import { useDispatch } from '@wordpress/data';
  * Internal dependencies
  */
 import { store as blockEditorStore } from '../store';
-import { BlockSettingsMenuControls } from '../components';
+import {
+	BlockSettingsMenuControls,
+	useBlockDisplayInformation,
+} from '../components';
 
 const notEmptyString = ( testString ) => testString?.trim()?.length > 0;
 
@@ -39,7 +42,7 @@ function RenameModal( { blockName, onClose, onSave } ) {
 					<TextControl
 						__nextHasNoMarginBottom
 						value={ editedBlockName }
-						placeholder={ __( 'Navigation title' ) }
+						placeholder={ __( 'Block name' ) }
 						onChange={ setEditedBlockName }
 					/>
 					<HStack justify="right">
@@ -82,6 +85,8 @@ export const withBlockRenameControl = createHigherOrderComponent(
 			name: blockName,
 			attributes: blockAttributes,
 		} = props;
+
+		const blockInformation = useBlockDisplayInformation( clientId );
 
 		const metaDataSupport = getBlockSupport(
 			blockName,
@@ -132,7 +137,11 @@ export const withBlockRenameControl = createHigherOrderComponent(
 
 				{ renamingBlock && (
 					<RenameModal
-						blockName={ blockAttributes?.metadata?.name || '' }
+						blockName={
+							blockAttributes?.metadata?.name ||
+							blockInformation?.title ||
+							''
+						}
 						onClose={ () => setRenamingBlock( false ) }
 						onSave={ ( newName ) => {
 							updateBlockAttributes( clientId, {

--- a/packages/block-editor/src/hooks/block-rename-ui.js
+++ b/packages/block-editor/src/hooks/block-rename-ui.js
@@ -135,7 +135,7 @@ export const withBlockRenameControl = createHigherOrderComponent(
 					</BlockSettingsMenuControls>
 				) }
 
-				{ renamingBlock && (
+				{ renamingBlock && supportsBlockNaming && (
 					<RenameModal
 						blockName={
 							blockAttributes?.metadata?.name ||

--- a/packages/block-editor/src/hooks/block-rename-ui.js
+++ b/packages/block-editor/src/hooks/block-rename-ui.js
@@ -51,7 +51,7 @@ function RenameModal( { blockName, onClose, onSave } ) {
 						</Button>
 
 						<Button
-							disabled={ ! isNameValid }
+							aria-disabled={ ! isNameValid }
 							variant="primary"
 							type="submit"
 							onClick={ ( e ) => {

--- a/packages/block-editor/src/hooks/block-rename-ui.js
+++ b/packages/block-editor/src/hooks/block-rename-ui.js
@@ -103,16 +103,10 @@ function BlockRenameControl( props ) {
 						selectedClientIds.length === 1 &&
 						clientId === selectedClientIds[ 0 ];
 
-					// This check ensures
-					// - the `BlockSettingsMenuControls` fill
+					// This check ensures the `BlockSettingsMenuControls` fill
 					// doesn't render multiple times and also that it renders for
 					// the block from which the menu was triggered.
-					// - `Rename` only appears in the ListView options.
-					// - `Rename` only appears for blocks that support renaming.
-					if (
-						// __unstableDisplayLocation !== 'list-view' ||
-						! canRename
-					) {
+					if ( ! canRename ) {
 						return null;
 					}
 

--- a/packages/block-editor/src/hooks/block-rename-ui.js
+++ b/packages/block-editor/src/hooks/block-rename-ui.js
@@ -35,7 +35,11 @@ function RenameModal( { blockName, originalBlockName, onClose, onSave } ) {
 	const isNameValid = nameHasChanged && ! emptyString( editedBlockName );
 
 	return (
-		<Modal title={ __( 'Rename block' ) } onRequestClose={ onClose }>
+		<Modal
+			title={ __( 'Rename block' ) }
+			onRequestClose={ onClose }
+			overlayClassName="block-editor-block-rename-modal"
+		>
 			<p>{ __( 'Choose a custom name for this block.' ) }</p>
 			<form
 				className="sidebar-navigation__rename-modal-form"
@@ -112,7 +116,7 @@ export const withBlockRenameControl = createHigherOrderComponent(
 			<>
 				{ supportsBlockNaming && (
 					<BlockSettingsMenuControls>
-						{ ( { selectedClientIds, onClose } ) => {
+						{ ( { selectedClientIds } ) => {
 							// Only enabled for single selections.
 							const canRename =
 								selectedClientIds.length === 1 &&
@@ -135,7 +139,6 @@ export const withBlockRenameControl = createHigherOrderComponent(
 								<MenuItem
 									onClick={ () => {
 										setRenamingBlock( true );
-										onClose();
 									} }
 								>
 									{ __( 'Rename' ) }

--- a/packages/block-editor/src/hooks/block-rename-ui.js
+++ b/packages/block-editor/src/hooks/block-rename-ui.js
@@ -40,7 +40,6 @@ function RenameModal( { blockName, originalBlockName, onClose, onSave } ) {
 		>
 			<p>{ __( 'Choose a custom name for this block.' ) }</p>
 			<form
-				className="sidebar-navigation__rename-modal-form"
 				onSubmit={ ( e ) => {
 					e.preventDefault();
 

--- a/packages/block-editor/src/hooks/block-rename-ui.js
+++ b/packages/block-editor/src/hooks/block-rename-ui.js
@@ -14,12 +14,10 @@ import {
 	Modal,
 } from '@wordpress/components';
 import { useState } from '@wordpress/element';
-import { useDispatch } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
-import { store as blockEditorStore } from '../store';
 import {
 	BlockSettingsMenuControls,
 	useBlockDisplayInformation,
@@ -92,12 +90,12 @@ function RenameModal( { blockName, originalBlockName, onClose, onSave } ) {
 export const withBlockRenameControl = createHigherOrderComponent(
 	( BlockEdit ) => ( props ) => {
 		const [ renamingBlock, setRenamingBlock ] = useState( false );
-		const { updateBlockAttributes } = useDispatch( blockEditorStore );
 
 		const {
 			clientId,
 			name: blockName,
 			attributes: blockAttributes,
+			setAttributes,
 		} = props;
 
 		const blockInformation = useBlockDisplayInformation( clientId );
@@ -165,7 +163,7 @@ export const withBlockRenameControl = createHigherOrderComponent(
 								newName = undefined;
 							}
 
-							updateBlockAttributes( clientId, {
+							setAttributes( {
 								// Include existing metadata (if present) to avoid overwriting existing.
 								metadata: {
 									...( blockAttributes?.metadata &&

--- a/packages/block-editor/src/hooks/block-rename-ui.js
+++ b/packages/block-editor/src/hooks/block-rename-ui.js
@@ -1,0 +1,71 @@
+/**
+ * WordPress dependencies
+ */
+import { MenuItem } from '@wordpress/components';
+import { createHigherOrderComponent } from '@wordpress/compose';
+import { addFilter } from '@wordpress/hooks';
+import { __ } from '@wordpress/i18n';
+import { getBlockSupport } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import { BlockSettingsMenuControls } from '../components';
+
+export const withBlockRenameControl = createHigherOrderComponent(
+	( BlockEdit ) => ( props ) => {
+		const { clientId, name: blockName } = props;
+
+		const metaDataSupport = getBlockSupport(
+			blockName,
+			'__experimentalMetadata',
+			false
+		);
+
+		const supportsBlockNaming = !! (
+			true === metaDataSupport || metaDataSupport?.name
+		);
+
+		return (
+			<>
+				{ supportsBlockNaming && (
+					<BlockSettingsMenuControls>
+						{ ( { selectedClientIds } ) => {
+							// Only enabled for single selections.
+							const canRename =
+								selectedClientIds.length === 1 &&
+								clientId === selectedClientIds[ 0 ];
+
+							// This check ensures
+							// - the `BlockSettingsMenuControls` fill
+							// doesn't render multiple times and also that it renders for
+							// the block from which the menu was triggered.
+							// - `Rename` only appears in the ListView options.
+							// - `Rename` only appears for blocks that support renaming.
+							if (
+								// __unstableDisplayLocation !== 'list-view' ||
+								! canRename
+							) {
+								return null;
+							}
+
+							return (
+								<MenuItem onClick={ () => {} }>
+									{ __( 'Rename' ) }
+								</MenuItem>
+							);
+						} }
+					</BlockSettingsMenuControls>
+				) }
+				<BlockEdit key="edit" { ...props } />
+			</>
+		);
+	},
+	'withToolbarControls'
+);
+
+addFilter(
+	'editor.BlockEdit',
+	'core/block-rename-ui/with-block-rename-control',
+	withBlockRenameControl
+);

--- a/packages/block-editor/src/hooks/block-rename-ui.js
+++ b/packages/block-editor/src/hooks/block-rename-ui.js
@@ -3,7 +3,7 @@
  */
 import { createHigherOrderComponent, useInstanceId } from '@wordpress/compose';
 import { addFilter } from '@wordpress/hooks';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { getBlockSupport } from '@wordpress/blocks';
 import {
 	MenuItem,
@@ -14,6 +14,7 @@ import {
 	Modal,
 } from '@wordpress/components';
 import { useState } from '@wordpress/element';
+import { speak } from '@wordpress/a11y';
 
 /**
  * Internal dependencies
@@ -43,6 +44,24 @@ function RenameModal( { blockName, originalBlockName, onClose, onSave } ) {
 		`block-editor-rename-modal__description`
 	);
 
+	const handleSubmit = () => {
+		// Must be assertive to immediately announce change.
+		speak(
+			sprintf(
+				/* translators: %1$s: type of update (either reset of changed). %2$s: new name/label for the block */
+				__( 'Block name %1$s to: "%2$s".' ),
+				nameIsOriginal ? __( 'reset' ) : __( 'changed' ),
+				editedBlockName
+			),
+			'assertive'
+		);
+
+		onSave( editedBlockName );
+
+		// Immediate close avoids ability to hit save multiple times.
+		onClose();
+	};
+
 	return (
 		<Modal
 			title={ __( 'Rename block' ) }
@@ -63,10 +82,7 @@ function RenameModal( { blockName, originalBlockName, onClose, onSave } ) {
 						return;
 					}
 
-					onSave( editedBlockName );
-
-					// Immediate close avoids ability to hit save multiple times.
-					onClose();
+					handleSubmit();
 				} }
 			>
 				<VStack spacing="3">

--- a/packages/block-editor/src/hooks/block-rename-ui.js
+++ b/packages/block-editor/src/hooks/block-rename-ui.js
@@ -167,7 +167,7 @@ function BlockRenameControl( props ) {
 
 			{ renamingBlock && (
 				<RenameModal
-					blockName={ customName || blockInformation?.title || '' }
+					blockName={ customName || '' }
 					originalBlockName={ blockInformation?.title }
 					onClose={ () => setRenamingBlock( false ) }
 					onSave={ ( newName ) => {

--- a/packages/block-editor/src/hooks/block-rename-ui.js
+++ b/packages/block-editor/src/hooks/block-rename-ui.js
@@ -93,7 +93,7 @@ function RenameModal( { blockName, originalBlockName, onClose, onSave } ) {
 function BlockRenameControl( props ) {
 	const [ renamingBlock, setRenamingBlock ] = useState( false );
 
-	const { clientId, blockAttributes, onChange } = props;
+	const { clientId, customName, onChange } = props;
 
 	const blockInformation = useBlockDisplayInformation( clientId );
 
@@ -103,7 +103,7 @@ function BlockRenameControl( props ) {
 				<TextControl
 					__nextHasNoMarginBottom
 					label={ __( 'Custom block name' ) }
-					value={ blockAttributes?.metadata?.name || '' }
+					value={ customName || '' }
 					onChange={ onChange }
 				/>
 			</InspectorControls>
@@ -137,11 +137,7 @@ function BlockRenameControl( props ) {
 
 			{ renamingBlock && (
 				<RenameModal
-					blockName={
-						blockAttributes?.metadata?.name ||
-						blockInformation?.title ||
-						''
-					}
+					blockName={ customName || blockInformation?.title || '' }
 					originalBlockName={ blockInformation?.title }
 					onClose={ () => setRenamingBlock( false ) }
 					onSave={ ( newName ) => {
@@ -180,7 +176,7 @@ export const withBlockRenameControl = createHigherOrderComponent(
 					<>
 						<BlockRenameControl
 							clientId={ clientId }
-							blockAttributes={ attributes }
+							customName={ attributes?.metadata?.name }
 							onChange={ ( newName ) => {
 								setAttributes( {
 									metadata: {

--- a/packages/block-editor/src/hooks/block-rename-ui.js
+++ b/packages/block-editor/src/hooks/block-rename-ui.js
@@ -21,6 +21,7 @@ import { useState } from '@wordpress/element';
 import {
 	BlockSettingsMenuControls,
 	useBlockDisplayInformation,
+	InspectorControls,
 } from '../components';
 
 const emptyString = ( testString ) => testString?.trim()?.length === 0;
@@ -98,6 +99,23 @@ function BlockRenameControl( props ) {
 
 	return (
 		<>
+			<InspectorControls group="advanced">
+				<TextControl
+					__nextHasNoMarginBottom
+					label={ __( 'Custom block name' ) }
+					value={ blockAttributes?.metadata?.name || '' }
+					onChange={ ( newName ) => {
+						onChange( {
+							// Include existing metadata (if present) to avoid overwriting existing.
+							metadata: {
+								...( blockAttributes?.metadata &&
+									blockAttributes?.metadata ),
+								name: newName,
+							},
+						} );
+					} }
+				/>
+			</InspectorControls>
 			<BlockSettingsMenuControls>
 				{ ( { selectedClientIds } ) => {
 					// Only enabled for single selections.
@@ -175,11 +193,13 @@ export const withBlockRenameControl = createHigherOrderComponent(
 		return (
 			<>
 				{ supportsBlockNaming && (
-					<BlockRenameControl
-						clientId={ clientId }
-						blockAttributes={ attributes }
-						onChange={ setAttributes }
-					/>
+					<>
+						<BlockRenameControl
+							clientId={ clientId }
+							blockAttributes={ attributes }
+							onChange={ setAttributes }
+						/>
+					</>
 				) }
 
 				<BlockEdit key="edit" { ...props } />

--- a/packages/block-editor/src/hooks/block-rename-ui.js
+++ b/packages/block-editor/src/hooks/block-rename-ui.js
@@ -30,8 +30,11 @@ function RenameModal( { blockName, originalBlockName, onClose, onSave } ) {
 	const [ editedBlockName, setEditedBlockName ] = useState( blockName );
 
 	const nameHasChanged = editedBlockName !== blockName;
+	const nameIsOriginal = editedBlockName === originalBlockName;
 
-	const isNameValid = nameHasChanged && ! emptyString( editedBlockName );
+	const isNameValid =
+		( nameHasChanged || nameIsOriginal ) &&
+		! emptyString( editedBlockName );
 
 	const autoSelectInputText = ( event ) => event.target.select();
 
@@ -58,11 +61,12 @@ function RenameModal( { blockName, originalBlockName, onClose, onSave } ) {
 			>
 				<VStack spacing="3">
 					<TextControl
+						required
 						__nextHasNoMarginBottom
 						value={ editedBlockName }
 						label={ __( 'Block name' ) }
 						hideLabelFromVision={ true }
-						placeholder={ __( 'Block name' ) }
+						placeholder={ originalBlockName }
 						onChange={ setEditedBlockName }
 						onBlur={ () => {
 							if ( emptyString( editedBlockName ) ) {

--- a/packages/block-editor/src/hooks/block-rename-ui.js
+++ b/packages/block-editor/src/hooks/block-rename-ui.js
@@ -32,6 +32,8 @@ function RenameModal( { blockName, originalBlockName, onClose, onSave } ) {
 
 	const isNameValid = nameHasChanged && ! emptyString( editedBlockName );
 
+	const autoSelectInputText = ( event ) => event.target.select();
+
 	return (
 		<Modal
 			title={ __( 'Rename block' ) }
@@ -66,6 +68,7 @@ function RenameModal( { blockName, originalBlockName, onClose, onSave } ) {
 								setEditedBlockName( originalBlockName );
 							}
 						} }
+						onFocus={ autoSelectInputText }
 					/>
 					<HStack justify="right">
 						<Button variant="tertiary" onClick={ onClose }>

--- a/packages/block-editor/src/hooks/block-rename-ui.js
+++ b/packages/block-editor/src/hooks/block-rename-ui.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { createHigherOrderComponent } from '@wordpress/compose';
+import { createHigherOrderComponent, useInstanceId } from '@wordpress/compose';
 import { addFilter } from '@wordpress/hooks';
 import { __ } from '@wordpress/i18n';
 import { getBlockSupport } from '@wordpress/blocks';
@@ -38,13 +38,23 @@ function RenameModal( { blockName, originalBlockName, onClose, onSave } ) {
 
 	const autoSelectInputText = ( event ) => event.target.select();
 
+	const dialogDescription = useInstanceId(
+		RenameModal,
+		`block-editor-rename-modal__description`
+	);
+
 	return (
 		<Modal
 			title={ __( 'Rename block' ) }
 			onRequestClose={ onClose }
 			overlayClassName="block-editor-block-rename-modal"
+			aria={ {
+				describedby: dialogDescription,
+			} }
 		>
-			<p>{ __( 'Choose a custom name for this block.' ) }</p>
+			<p id={ dialogDescription }>
+				{ __( 'Choose a custom name for this block.' ) }
+			</p>
 			<form
 				onSubmit={ ( e ) => {
 					e.preventDefault();

--- a/packages/block-editor/src/hooks/block-rename-ui.js
+++ b/packages/block-editor/src/hooks/block-rename-ui.js
@@ -104,16 +104,7 @@ function BlockRenameControl( props ) {
 					__nextHasNoMarginBottom
 					label={ __( 'Custom block name' ) }
 					value={ blockAttributes?.metadata?.name || '' }
-					onChange={ ( newName ) => {
-						onChange( {
-							// Include existing metadata (if present) to avoid overwriting existing.
-							metadata: {
-								...( blockAttributes?.metadata &&
-									blockAttributes?.metadata ),
-								name: newName,
-							},
-						} );
-					} }
+					onChange={ onChange }
 				/>
 			</InspectorControls>
 			<BlockSettingsMenuControls>
@@ -161,14 +152,7 @@ function BlockRenameControl( props ) {
 							newName = undefined;
 						}
 
-						onChange( {
-							// Include existing metadata (if present) to avoid overwriting existing.
-							metadata: {
-								...( blockAttributes?.metadata &&
-									blockAttributes?.metadata ),
-								name: newName,
-							},
-						} );
+						onChange( newName );
 					} }
 				/>
 			) }
@@ -197,7 +181,15 @@ export const withBlockRenameControl = createHigherOrderComponent(
 						<BlockRenameControl
 							clientId={ clientId }
 							blockAttributes={ attributes }
-							onChange={ setAttributes }
+							onChange={ ( newName ) => {
+								setAttributes( {
+									metadata: {
+										...( attributes?.metadata &&
+											attributes?.metadata ),
+										name: newName,
+									},
+								} );
+							} }
 						/>
 					</>
 				) }

--- a/packages/block-editor/src/hooks/block-rename-ui.js
+++ b/packages/block-editor/src/hooks/block-rename-ui.js
@@ -130,7 +130,7 @@ function BlockRenameControl( props ) {
 			<InspectorControls group="advanced">
 				<TextControl
 					__nextHasNoMarginBottom
-					label={ __( 'Custom block name' ) }
+					label={ __( 'Block name' ) }
 					value={ customName || '' }
 					onChange={ onChange }
 				/>

--- a/packages/block-editor/src/hooks/block-rename-ui.js
+++ b/packages/block-editor/src/hooks/block-rename-ui.js
@@ -25,8 +25,6 @@ import {
 	InspectorControls,
 } from '../components';
 
-const emptyString = ( testString ) => testString?.trim()?.length === 0;
-
 function RenameModal( { blockName, originalBlockName, onClose, onSave } ) {
 	const [ editedBlockName, setEditedBlockName ] = useState( blockName );
 
@@ -85,18 +83,12 @@ function RenameModal( { blockName, originalBlockName, onClose, onSave } ) {
 			>
 				<VStack spacing="3">
 					<TextControl
-						required
 						__nextHasNoMarginBottom
 						value={ editedBlockName }
 						label={ __( 'Block name' ) }
 						hideLabelFromVision={ true }
 						placeholder={ originalBlockName }
 						onChange={ setEditedBlockName }
-						onBlur={ () => {
-							if ( emptyString( editedBlockName ) ) {
-								setEditedBlockName( originalBlockName );
-							}
-						} }
 						onFocus={ autoSelectInputText }
 					/>
 					<HStack justify="right">

--- a/packages/block-editor/src/hooks/block-rename-ui.js
+++ b/packages/block-editor/src/hooks/block-rename-ui.js
@@ -63,7 +63,7 @@ function RenameModal( { blockName, originalBlockName, onClose, onSave } ) {
 
 	return (
 		<Modal
-			title={ __( 'Rename block' ) }
+			title={ __( 'Rename' ) }
 			onRequestClose={ onClose }
 			overlayClassName="block-editor-block-rename-modal"
 			aria={ {

--- a/packages/block-editor/src/hooks/block-rename-ui.js
+++ b/packages/block-editor/src/hooks/block-rename-ui.js
@@ -33,9 +33,7 @@ function RenameModal( { blockName, originalBlockName, onClose, onSave } ) {
 	const nameHasChanged = editedBlockName !== blockName;
 	const nameIsOriginal = editedBlockName === originalBlockName;
 
-	const isNameValid =
-		( nameHasChanged || nameIsOriginal ) &&
-		! emptyString( editedBlockName );
+	const isNameValid = nameHasChanged || nameIsOriginal;
 
 	const autoSelectInputText = ( event ) => event.target.select();
 

--- a/packages/block-editor/src/hooks/block-rename-ui.js
+++ b/packages/block-editor/src/hooks/block-rename-ui.js
@@ -25,11 +25,14 @@ import {
 	InspectorControls,
 } from '../components';
 
+const emptyString = ( testString ) => testString?.trim()?.length === 0;
+
 function RenameModal( { blockName, originalBlockName, onClose, onSave } ) {
 	const [ editedBlockName, setEditedBlockName ] = useState( blockName );
 
 	const nameHasChanged = editedBlockName !== blockName;
 	const nameIsOriginal = editedBlockName === originalBlockName;
+	const nameIsEmpty = emptyString( editedBlockName );
 
 	const isNameValid = nameHasChanged || nameIsOriginal;
 
@@ -46,7 +49,7 @@ function RenameModal( { blockName, originalBlockName, onClose, onSave } ) {
 			sprintf(
 				/* translators: %1$s: type of update (either reset of changed). %2$s: new name/label for the block */
 				__( 'Block name %1$s to: "%2$s".' ),
-				nameIsOriginal ? __( 'reset' ) : __( 'changed' ),
+				nameIsOriginal || nameIsEmpty ? __( 'reset' ) : __( 'changed' ),
 				editedBlockName
 			),
 			'assertive'
@@ -162,9 +165,12 @@ function BlockRenameControl( props ) {
 					onClose={ () => setRenamingBlock( false ) }
 					onSave={ ( newName ) => {
 						// If the new value is the block's original name (e.g. `Group`)
-						// then assume the intent is to reset the value. Therefore reset
-						// the metadata.
-						if ( newName === blockInformation?.title ) {
+						// or it is an empty string then assume the intent is to reset
+						// the value. Therefore reset the metadata.
+						if (
+							newName === blockInformation?.title ||
+							emptyString( newName )
+						) {
 							newName = undefined;
 						}
 

--- a/packages/block-editor/src/hooks/block-rename-ui.scss
+++ b/packages/block-editor/src/hooks/block-rename-ui.scss
@@ -1,0 +1,3 @@
+.block-editor-block-rename-modal {
+	z-index: z-index(".block-editor-block-rename-modal");
+}

--- a/packages/block-editor/src/hooks/index.js
+++ b/packages/block-editor/src/hooks/index.js
@@ -23,6 +23,7 @@ import './metadata-name';
 import './behaviors';
 import './custom-fields';
 import './auto-inserting-blocks';
+import './block-rename-ui';
 
 export { useCustomSides } from './dimensions';
 export { useLayoutClasses, useLayoutStyles } from './layout';

--- a/packages/block-editor/src/style.scss
+++ b/packages/block-editor/src/style.scss
@@ -53,6 +53,7 @@
 @import "./hooks/padding.scss";
 @import "./hooks/position.scss";
 @import "./hooks/typography.scss";
+@import "./hooks/block-rename-ui.scss";
 
 @import "./components/block-toolbar/style.scss";
 @import "./components/inserter/style.scss";

--- a/packages/block-library/src/group/block.json
+++ b/packages/block-library/src/group/block.json
@@ -24,6 +24,7 @@
 		"__experimentalOnEnter": true,
 		"__experimentalOnMerge": true,
 		"__experimentalSettings": true,
+		"__experimentalMetadata": true,
 		"align": [ "wide", "full" ],
 		"anchor": true,
 		"ariaLabel": true,

--- a/test/e2e/specs/editor/various/block-renaming.spec.js
+++ b/test/e2e/specs/editor/various/block-renaming.spec.js
@@ -59,7 +59,7 @@ test.describe( 'Block Renaming', () => {
 
 		await saveButton.click();
 
-		await expect( renameModal ).not.toBeVisible();
+		await expect( renameModal ).toBeHidden();
 
 		// Check that focus is transferred back to original "Rename" menu item.
 		await expect(

--- a/test/e2e/specs/editor/various/block-renaming.spec.js
+++ b/test/e2e/specs/editor/various/block-renaming.spec.js
@@ -36,6 +36,9 @@ test.describe( 'Block Renaming', () => {
 			name: 'Rename block',
 		} );
 
+		// Check focus is transferred into modal.
+		await expect( renameModal ).toBeFocused();
+
 		// Check the Modal is perceivable.
 		await expect( renameModal ).toBeVisible();
 
@@ -57,6 +60,13 @@ test.describe( 'Block Renaming', () => {
 		await saveButton.click();
 
 		await expect( renameModal ).not.toBeVisible();
+
+		// Check that focus is transferred back to original "Rename" menu item.
+		await expect(
+			page.getByRole( 'menuitem', {
+				name: 'Rename',
+			} )
+		).toBeFocused();
 
 		await expect.poll( editor.getBlocks ).toMatchObject( [
 			{

--- a/test/e2e/specs/editor/various/block-renaming.spec.js
+++ b/test/e2e/specs/editor/various/block-renaming.spec.js
@@ -47,7 +47,7 @@ test.describe( 'Block Renaming', () => {
 			type: 'submit',
 		} );
 
-		await expect( saveButton ).toHaveAttribute( 'aria-disabled', 'true' );
+		await expect( saveButton ).toBeDisabled();
 
 		const nameInput = renameModal.getByLabel( 'Block name' );
 
@@ -55,7 +55,7 @@ test.describe( 'Block Renaming', () => {
 
 		await nameInput.fill( 'My new name' );
 
-		await expect( saveButton ).toHaveAttribute( 'aria-disabled', 'false' );
+		await expect( saveButton ).toBeEnabled();
 
 		await saveButton.click();
 
@@ -106,7 +106,7 @@ test.describe( 'Block Renaming', () => {
 			type: 'submit',
 		} );
 
-		await expect( saveButton ).toHaveAttribute( 'aria-disabled', 'true' );
+		await expect( saveButton ).toBeDisabled();
 
 		const nameInput = renameModal.getByLabel( 'Block name' );
 
@@ -123,7 +123,7 @@ test.describe( 'Block Renaming', () => {
 		// Expect value to automatically revert to original block name.
 		await expect( nameInput ).toHaveValue( 'Group' );
 
-		await expect( saveButton ).toHaveAttribute( 'aria-disabled', 'false' );
+		await expect( saveButton ).toBeEnabled();
 
 		await saveButton.click();
 

--- a/test/e2e/specs/editor/various/block-renaming.spec.js
+++ b/test/e2e/specs/editor/various/block-renaming.spec.js
@@ -32,6 +32,16 @@ test.describe( 'Block Renaming', () => {
 
 		await editor.clickBlockOptionsMenuItem( 'Rename' );
 
+		const renameMenuItem = page.getByRole( 'menuitem', {
+			name: 'Rename',
+			includeHidden: true, // the option is hidden behind modal but assertion is still valid.
+		} );
+
+		await expect( renameMenuItem ).toHaveAttribute(
+			'aria-expanded',
+			'true'
+		);
+
 		const renameModal = page.getByRole( 'dialog', {
 			name: 'Rename block',
 		} );
@@ -62,11 +72,12 @@ test.describe( 'Block Renaming', () => {
 		await expect( renameModal ).toBeHidden();
 
 		// Check that focus is transferred back to original "Rename" menu item.
-		await expect(
-			page.getByRole( 'menuitem', {
-				name: 'Rename',
-			} )
-		).toBeFocused();
+		await expect( renameMenuItem ).toBeFocused();
+
+		await expect( renameMenuItem ).toHaveAttribute(
+			'aria-expanded',
+			'false'
+		);
 
 		await expect.poll( editor.getBlocks ).toMatchObject( [
 			{

--- a/test/e2e/specs/editor/various/block-renaming.spec.js
+++ b/test/e2e/specs/editor/various/block-renaming.spec.js
@@ -1,0 +1,72 @@
+/**
+ * WordPress dependencies
+ */
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+
+test.describe( 'Block Renaming', () => {
+	test.beforeEach( async ( { admin } ) => {
+		await admin.createNewPost();
+	} );
+
+	test( 'allows renaming of blocks that support the feature', async ( {
+		editor,
+		page,
+		pageUtils,
+	} ) => {
+		// Create a two blocks on the page.
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: { content: 'First Paragraph' },
+		} );
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: { content: 'Second Paragraph' },
+		} );
+
+		// Multiselect via keyboard.
+		await pageUtils.pressKeys( 'primary+a' );
+		await pageUtils.pressKeys( 'primary+a' );
+
+		// Convert to a Group block which supports renaming.
+		await editor.clickBlockOptionsMenuItem( 'Group' );
+
+		await editor.clickBlockOptionsMenuItem( 'Rename' );
+
+		const renameModal = page.getByRole( 'dialog', {
+			name: 'Rename block',
+		} );
+
+		// Check the Modal is perceivable.
+		await expect( renameModal ).toBeVisible();
+
+		const saveButton = renameModal.getByRole( 'button', {
+			name: 'Save',
+			type: 'submit',
+		} );
+
+		await expect( saveButton ).toHaveAttribute( 'aria-disabled', 'true' );
+
+		const nameInput = renameModal.getByLabel( 'Block name' );
+
+		await expect( nameInput ).toHaveValue( 'Group' );
+
+		await nameInput.fill( 'My new name' );
+
+		await expect( saveButton ).toHaveAttribute( 'aria-disabled', 'false' );
+
+		await saveButton.click();
+
+		await expect( renameModal ).not.toBeVisible();
+
+		await expect.poll( editor.getBlocks ).toMatchObject( [
+			{
+				name: 'core/group',
+				attributes: {
+					metadata: {
+						name: 'My new name',
+					},
+				},
+			},
+		] );
+	} );
+} );

--- a/test/e2e/specs/editor/various/block-renaming.spec.js
+++ b/test/e2e/specs/editor/various/block-renaming.spec.js
@@ -8,145 +8,221 @@ test.describe( 'Block Renaming', () => {
 		await admin.createNewPost();
 	} );
 
-	test( 'allows renaming of blocks that support the feature', async ( {
-		editor,
-		page,
-		pageUtils,
-	} ) => {
-		// Create a two blocks on the page.
-		await editor.insertBlock( {
-			name: 'core/paragraph',
-			attributes: { content: 'First Paragraph' },
+	test.describe( 'Dialog renaming', () => {
+		test.only( 'allows renaming of blocks that support the feature via dialog-based UI', async ( {
+			editor,
+			page,
+			pageUtils,
+		} ) => {
+			// Create a two blocks on the page.
+			await editor.insertBlock( {
+				name: 'core/paragraph',
+				attributes: { content: 'First Paragraph' },
+			} );
+			await editor.insertBlock( {
+				name: 'core/paragraph',
+				attributes: { content: 'Second Paragraph' },
+			} );
+
+			// Multiselect via keyboard.
+			await pageUtils.pressKeys( 'primary+a' );
+			await pageUtils.pressKeys( 'primary+a' );
+
+			// Convert to a Group block which supports renaming.
+			await editor.clickBlockOptionsMenuItem( 'Group' );
+
+			await editor.clickBlockOptionsMenuItem( 'Rename' );
+
+			const renameMenuItem = page.getByRole( 'menuitem', {
+				name: 'Rename',
+				includeHidden: true, // the option is hidden behind modal but assertion is still valid.
+			} );
+
+			await expect( renameMenuItem ).toHaveAttribute(
+				'aria-expanded',
+				'true'
+			);
+
+			const renameModal = page.getByRole( 'dialog', {
+				name: 'Rename block',
+			} );
+
+			// Check focus is transferred into modal.
+			await expect( renameModal ).toBeFocused();
+
+			// Check the Modal is perceivable.
+			await expect( renameModal ).toBeVisible();
+
+			const saveButton = renameModal.getByRole( 'button', {
+				name: 'Save',
+				type: 'submit',
+			} );
+
+			await expect( saveButton ).toBeDisabled();
+
+			const nameInput = renameModal.getByLabel( 'Block name' );
+
+			await expect( nameInput ).toHaveValue( 'Group' );
+
+			await nameInput.fill( 'My new name' );
+
+			await expect( saveButton ).toBeEnabled();
+
+			await saveButton.click();
+
+			await expect( renameModal ).toBeHidden();
+
+			// Check that focus is transferred back to original "Rename" menu item.
+			await expect( renameMenuItem ).toBeFocused();
+
+			await expect( renameMenuItem ).toHaveAttribute(
+				'aria-expanded',
+				'false'
+			);
+
+			await expect.poll( editor.getBlocks ).toMatchObject( [
+				{
+					name: 'core/group',
+					attributes: {
+						metadata: {
+							name: 'My new name',
+						},
+					},
+				},
+			] );
 		} );
-		await editor.insertBlock( {
-			name: 'core/paragraph',
-			attributes: { content: 'Second Paragraph' },
-		} );
 
-		// Multiselect via keyboard.
-		await pageUtils.pressKeys( 'primary+a' );
-		await pageUtils.pressKeys( 'primary+a' );
-
-		// Convert to a Group block which supports renaming.
-		await editor.clickBlockOptionsMenuItem( 'Group' );
-
-		await editor.clickBlockOptionsMenuItem( 'Rename' );
-
-		const renameMenuItem = page.getByRole( 'menuitem', {
-			name: 'Rename',
-			includeHidden: true, // the option is hidden behind modal but assertion is still valid.
-		} );
-
-		await expect( renameMenuItem ).toHaveAttribute(
-			'aria-expanded',
-			'true'
-		);
-
-		const renameModal = page.getByRole( 'dialog', {
-			name: 'Rename block',
-		} );
-
-		// Check focus is transferred into modal.
-		await expect( renameModal ).toBeFocused();
-
-		// Check the Modal is perceivable.
-		await expect( renameModal ).toBeVisible();
-
-		const saveButton = renameModal.getByRole( 'button', {
-			name: 'Save',
-			type: 'submit',
-		} );
-
-		await expect( saveButton ).toBeDisabled();
-
-		const nameInput = renameModal.getByLabel( 'Block name' );
-
-		await expect( nameInput ).toHaveValue( 'Group' );
-
-		await nameInput.fill( 'My new name' );
-
-		await expect( saveButton ).toBeEnabled();
-
-		await saveButton.click();
-
-		await expect( renameModal ).toBeHidden();
-
-		// Check that focus is transferred back to original "Rename" menu item.
-		await expect( renameMenuItem ).toBeFocused();
-
-		await expect( renameMenuItem ).toHaveAttribute(
-			'aria-expanded',
-			'false'
-		);
-
-		await expect.poll( editor.getBlocks ).toMatchObject( [
-			{
+		test( 'allows custom name to be removed and reset to original block name', async ( {
+			editor,
+			page,
+			pageUtils,
+		} ) => {
+			// Prefill with block that already has a custom name.
+			await editor.insertBlock( {
 				name: 'core/group',
 				attributes: {
 					metadata: {
-						name: 'My new name',
+						name: 'My custom name',
 					},
 				},
-			},
-		] );
+			} );
+
+			await editor.clickBlockOptionsMenuItem( 'Rename' );
+
+			const renameModal = page.getByRole( 'dialog', {
+				name: 'Rename block',
+			} );
+
+			const saveButton = renameModal.getByRole( 'button', {
+				name: 'Save',
+				type: 'submit',
+			} );
+
+			await expect( saveButton ).toBeDisabled();
+
+			const nameInput = renameModal.getByLabel( 'Block name' );
+
+			await expect( nameInput ).toHaveValue( 'My custom name' );
+
+			// Clear the input of text content.
+			await nameInput.focus();
+			await pageUtils.pressKeys( 'primary+a' );
+			await page.keyboard.press( 'Delete' );
+
+			// Trigger blur event on input.
+			await saveButton.focus();
+
+			// Expect value to automatically revert to original block name.
+			await expect( nameInput ).toHaveValue( 'Group' );
+
+			await expect( saveButton ).toBeEnabled();
+
+			await saveButton.click();
+
+			await expect.poll( editor.getBlocks ).toMatchObject( [
+				{
+					name: 'core/group',
+					attributes: {
+						metadata: {
+							name: undefined,
+						},
+					},
+				},
+			] );
+		} );
 	} );
 
-	test( 'allows custom name to be removed and reset to original block name', async ( {
-		editor,
-		page,
-		pageUtils,
-	} ) => {
-		// Prefill with block that already has a custom name.
-		await editor.insertBlock( {
-			name: 'core/group',
-			attributes: {
-				metadata: {
-					name: 'My custom name',
-				},
-			},
-		} );
+	test.describe( 'Block inspector renaming', () => {
+		test( 'allows renaming of blocks that support the feature via "Advanced" section of block inspector tools', async ( {
+			editor,
+			page,
+			pageUtils,
+		} ) => {
+			// Create a two blocks on the page.
+			await editor.insertBlock( {
+				name: 'core/paragraph',
+				attributes: { content: 'First Paragraph' },
+			} );
+			await editor.insertBlock( {
+				name: 'core/paragraph',
+				attributes: { content: 'Second Paragraph' },
+			} );
 
-		await editor.clickBlockOptionsMenuItem( 'Rename' );
+			// Multiselect via keyboard.
+			await pageUtils.pressKeys( 'primary+a' );
+			await pageUtils.pressKeys( 'primary+a' );
 
-		const renameModal = page.getByRole( 'dialog', {
-			name: 'Rename block',
-		} );
+			// Convert to a Group block which supports renaming.
+			await editor.clickBlockOptionsMenuItem( 'Group' );
 
-		const saveButton = renameModal.getByRole( 'button', {
-			name: 'Save',
-			type: 'submit',
-		} );
+			await editor.openDocumentSettingsSidebar();
 
-		await expect( saveButton ).toBeDisabled();
+			const advancedPanelToggle = page
+				.getByRole( 'region', {
+					name: 'Editor settings',
+				} )
+				.getByRole( 'button', {
+					name: 'Advanced',
+					expanded: false,
+				} );
 
-		const nameInput = renameModal.getByLabel( 'Block name' );
+			await advancedPanelToggle.click();
 
-		await expect( nameInput ).toHaveValue( 'My custom name' );
+			const nameInput = page.getByRole( 'textbox', {
+				name: 'Custom block name',
+			} );
 
-		// Clear the input of text content.
-		await nameInput.focus();
-		await pageUtils.pressKeys( 'primary+a' );
-		await page.keyboard.press( 'Delete' );
+			await expect( nameInput ).toBeEmpty();
 
-		// Trigger blur event on input.
-		await saveButton.focus();
+			await nameInput.fill( 'My new name' );
 
-		// Expect value to automatically revert to original block name.
-		await expect( nameInput ).toHaveValue( 'Group' );
+			await expect( nameInput ).toHaveValue( 'My new name' );
 
-		await expect( saveButton ).toBeEnabled();
-
-		await saveButton.click();
-
-		await expect.poll( editor.getBlocks ).toMatchObject( [
-			{
-				name: 'core/group',
-				attributes: {
-					metadata: {
-						name: undefined,
+			await expect.poll( editor.getBlocks ).toMatchObject( [
+				{
+					name: 'core/group',
+					attributes: {
+						metadata: {
+							name: 'My new name',
+						},
 					},
 				},
-			},
-		] );
+			] );
+
+			await nameInput.focus();
+			await pageUtils.pressKeys( 'primary+a' );
+			await page.keyboard.press( 'Delete' );
+
+			await expect.poll( editor.getBlocks ).toMatchObject( [
+				{
+					name: 'core/group',
+					attributes: {
+						metadata: {
+							name: '',
+						},
+					},
+				},
+			] );
+		} );
 	} );
 } );

--- a/test/e2e/specs/editor/various/block-renaming.spec.js
+++ b/test/e2e/specs/editor/various/block-renaming.spec.js
@@ -9,7 +9,7 @@ test.describe( 'Block Renaming', () => {
 	} );
 
 	test.describe( 'Dialog renaming', () => {
-		test.only( 'allows renaming of blocks that support the feature via dialog-based UI', async ( {
+		test( 'allows renaming of blocks that support the feature via dialog-based UI', async ( {
 			editor,
 			page,
 			pageUtils,
@@ -62,7 +62,7 @@ test.describe( 'Block Renaming', () => {
 
 			const nameInput = renameModal.getByLabel( 'Block name' );
 
-			await expect( nameInput ).toHaveValue( 'Group' );
+			await expect( nameInput ).toHaveAttribute( 'placeholder', 'Group' );
 
 			await nameInput.fill( 'My new name' );
 

--- a/test/e2e/specs/editor/various/block-renaming.spec.js
+++ b/test/e2e/specs/editor/various/block-renaming.spec.js
@@ -14,6 +14,17 @@ test.describe( 'Block Renaming', () => {
 			page,
 			pageUtils,
 		} ) => {
+			// Turn on block list view by default.
+			await page.evaluate( () => {
+				window.wp.data
+					.dispatch( 'core/preferences' )
+					.set( 'core/edit-site', 'showListViewByDefault', true );
+			} );
+
+			const listView = page.getByRole( 'treegrid', {
+				name: 'Block navigation structure',
+			} );
+
 			// Create a two blocks on the page.
 			await editor.insertBlock( {
 				name: 'core/paragraph',
@@ -80,6 +91,11 @@ test.describe( 'Block Renaming', () => {
 				'false'
 			);
 
+			// Check custom name reflected in List View.
+			listView.getByRole( 'link', {
+				name: 'My new name',
+			} );
+
 			await expect.poll( editor.getBlocks ).toMatchObject( [
 				{
 					name: 'core/group',
@@ -109,6 +125,11 @@ test.describe( 'Block Renaming', () => {
 			await expect( saveButton ).toBeEnabled();
 
 			await saveButton.click();
+
+			// Check the original block name to reflected in List View.
+			listView.getByRole( 'link', {
+				name: 'Group',
+			} );
 
 			// Expect block to have no custom name (i.e. it should be reset to the original block name).
 			await expect.poll( editor.getBlocks ).toMatchObject( [

--- a/test/e2e/specs/editor/various/block-renaming.spec.js
+++ b/test/e2e/specs/editor/various/block-renaming.spec.js
@@ -161,7 +161,7 @@ test.describe( 'Block Renaming', () => {
 			await advancedPanelToggle.click();
 
 			const nameInput = page.getByRole( 'textbox', {
-				name: 'Custom block name',
+				name: 'Block name',
 			} );
 
 			await expect( nameInput ).toBeEmpty();

--- a/test/e2e/specs/editor/various/block-renaming.spec.js
+++ b/test/e2e/specs/editor/various/block-renaming.spec.js
@@ -55,7 +55,7 @@ test.describe( 'Block Renaming', () => {
 			);
 
 			const renameModal = page.getByRole( 'dialog', {
-				name: 'Rename block',
+				name: 'Rename',
 			} );
 
 			// Check focus is transferred into modal.

--- a/test/e2e/specs/editor/various/block-renaming.spec.js
+++ b/test/e2e/specs/editor/various/block-renaming.spec.js
@@ -90,55 +90,27 @@ test.describe( 'Block Renaming', () => {
 					},
 				},
 			] );
-		} );
 
-		test( 'allows custom name to be removed and reset to original block name', async ( {
-			editor,
-			page,
-			pageUtils,
-		} ) => {
-			// Prefill with block that already has a custom name.
-			await editor.insertBlock( {
-				name: 'core/group',
-				attributes: {
-					metadata: {
-						name: 'My custom name',
-					},
-				},
-			} );
+			// Re-trigger the rename dialog.
+			await renameMenuItem.click();
 
-			await editor.clickBlockOptionsMenuItem( 'Rename' );
-
-			const renameModal = page.getByRole( 'dialog', {
-				name: 'Rename block',
-			} );
-
-			const saveButton = renameModal.getByRole( 'button', {
-				name: 'Save',
-				type: 'submit',
-			} );
-
-			await expect( saveButton ).toBeDisabled();
-
-			const nameInput = renameModal.getByLabel( 'Block name' );
-
-			await expect( nameInput ).toHaveValue( 'My custom name' );
+			// Expect modal input to contain the custom name.
+			await expect( nameInput ).toHaveValue( 'My new name' );
 
 			// Clear the input of text content.
 			await nameInput.focus();
 			await pageUtils.pressKeys( 'primary+a' );
 			await page.keyboard.press( 'Delete' );
 
-			// Trigger blur event on input.
-			await saveButton.focus();
+			// Check placeholder for input is the original block name.
+			await expect( nameInput ).toHaveAttribute( 'placeholder', 'Group' );
 
-			// Expect value to automatically revert to original block name.
-			await expect( nameInput ).toHaveValue( 'Group' );
-
+			// It should be possible to submit empty.
 			await expect( saveButton ).toBeEnabled();
 
 			await saveButton.click();
 
+			// Expect block to have no custom name (i.e. it should be reset to the original block name).
 			await expect.poll( editor.getBlocks ).toMatchObject( [
 				{
 					name: 'core/group',


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
<img width="560" alt="Screen Shot 2023-08-16 at 14 29 09" src="https://github.com/WordPress/gutenberg/assets/444434/5c553eb6-3647-4eef-926f-fe33080dda3e">



Adds the ability to give blocks (currently limited to Group block) a custom name via a `Rename` item in the block's options menu.

This is then displayed in the List View (although that functionality was enabled in a previous PR).

⚠️ Unlike https://github.com/WordPress/gutenberg/pull/42605 you cannot double click to rename blocks in the List View. See below for why this PR doesn't pursue this approach.

Alternative to 
- https://github.com/WordPress/gutenberg/pull/53852
- https://github.com/WordPress/gutenberg/pull/42605

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Allowing users to distinguish between blocks in the List View is becoming increasingly important as the scope of the Site Editor grows. Given that all blocks are currently labelled by the block name  (e.g. `Group`) it can be difficult to distinguish between them. This is especially important if your Groups represent distinct "sections" of a given page/template.

As you can see [the feature is much requested](https://github.com/WordPress/gutenberg/pull/42605#issuecomment-1475904839).

### Why not pursue the existing PR for renaming within List View?

https://github.com/WordPress/gutenberg/pull/42605 has been around for a while and was my original attempt at this. Unfortunately it was beset by a number of a11y changes relating to editing/renaming _inline_ with the list view.

In the PR several contributors suggested making the it a global feature where rename could be handled via a modal. Returning to the PR it makes sense to land this simpler and more intuitive approach first and then circle back to the "inline" block editing (within the list view) if that is possible/desirable. 

### Why is this limited to the Group block?

The aim is to limit the scope of the change. Once merged it will be possible to follow up to enable this feature for other "container" type blocks.

### Where are you saving this custom name data?

It's saved to the block's `metadata` attribute under the `name` property. That's in WP Core and standard.

```json
{
    "attributes": {
        "metadata": {
            "name": "My custom name"
        }
    }
}
```

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Adds a `Rename` menu item to the block's options menu (available in canvas or in list view). When clicked a modal appears which allows you to provide a custom name for the block.

Once applied the block's metadata is set with a custom `name` attribute which is then reflected everywhere that consumes `useBlockInformation` (that was added previously in another PR).

This means that List View will show the custom name.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- New Post (or enter the Site Editor)
- Add some blocks and then Group them.
- Open List View
- Now open the block options menu (either via List View or via the block in the canvas) and click `Rename`.
- Type a custom name and save.
- See custom name is now shown in List View.
- Bring up the `Rename` UI again, but this time remove all of the text and click out of the input field (triggering `onBlur`).
- See the value reset to the block's original name (e.g. `Group`). See the `Save` button is active again.
- Save the change and verify it updated. 
- Switch to codeview and check the `metadata.name` attribute was reset (it should _not_ be `Group`).

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

- Do the same as for `Testing instructions` above but use the keyboard.
- Ensure that modal fields are perceivable and focus is placed inside the modal.
- Check that the form is intuitive to use and has accessible roles.
- Check you can submit / cancel the change.
- Key that focus is correctly restored to wherever you "came" from when you triggered "Rename".

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/444434/a36de689-59cc-498f-a6b4-968c3d3dc940

<img width="687" alt="Screen Shot 2023-08-16 at 14 28 25" src="https://github.com/WordPress/gutenberg/assets/444434/2e944c4f-ee66-443c-a61a-79839721d8ef">
