### PR TITLE
Experiment: Comments block: client-side form submission

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -187,7 +187,7 @@ An advanced block that allows displaying post comments using different visual co
 -	**Name:** core/comments
 -	**Category:** theme
 -	**Supports:** align (full, wide), color (background, gradients, heading, link, text), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
--	**Attributes:** legacy, tagName
+-	**Attributes:** enhancedSubmission, legacy, tagName
 
 ## Comments Pagination
 

--- a/packages/block-library/package.json
+++ b/packages/block-library/package.json
@@ -30,6 +30,7 @@
 		"./file/view": "./build-module/file/view.js",
 		"./image/view": "./build-module/image/view.js",
 		"./navigation/view": "./build-module/navigation/view.js",
+		"./post-comments-form/view": "./build-module/post-comments-form/view.js",
 		"./query/view": "./build-module/query/view.js",
 		"./search/view": "./build-module/search/view.js"
 	},

--- a/packages/block-library/src/comment-reply-link/block.json
+++ b/packages/block-library/src/comment-reply-link/block.json
@@ -7,7 +7,7 @@
 	"ancestor": [ "core/comment-template" ],
 	"description": "Displays a link to reply to a comment.",
 	"textdomain": "default",
-	"usesContext": [ "commentId" ],
+	"usesContext": [ "commentId", "enhancedSubmission" ],
 	"attributes": {
 		"textAlign": {
 			"type": "string"

--- a/packages/block-library/src/comment-reply-link/index.php
+++ b/packages/block-library/src/comment-reply-link/index.php
@@ -63,6 +63,17 @@ function render_block_core_comment_reply_link( $attributes, $content, $block ) {
 
 	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => implode( ' ', $classes ) ) );
 
+	$p = new WP_HTML_Tag_Processor( $comment_reply_link );
+	if ( $p->next_tag(
+		array(
+			'tag_name'   => 'A',
+			'class_name' => 'comment-reply-link',
+		)
+	) ) {
+		$p->set_attribute( 'data-wp-on--click', 'actions.core.comments.changeReplyTo' );
+	}
+	$comment_reply_link = $p->get_updated_html();
+
 	return sprintf(
 		'<div %1$s>%2$s</div>',
 		$wrapper_attributes,

--- a/packages/block-library/src/comment-reply-link/index.php
+++ b/packages/block-library/src/comment-reply-link/index.php
@@ -70,7 +70,7 @@ function render_block_core_comment_reply_link( $attributes, $content, $block ) {
 			'class_name' => 'comment-reply-link',
 		)
 	) ) {
-		$p->set_attribute( 'data-wp-on--click', 'actions.core.comments.changeReplyTo' );
+		$p->set_attribute( 'data-wp-on--click', 'actions.changeReplyTo' );
 	}
 	$comment_reply_link = $p->get_updated_html();
 

--- a/packages/block-library/src/comment-template/block.json
+++ b/packages/block-library/src/comment-template/block.json
@@ -7,7 +7,7 @@
 	"parent": [ "core/comments" ],
 	"description": "Contains the block elements used to display a comment, like the title, date, author, avatar and more.",
 	"textdomain": "default",
-	"usesContext": [ "postId" ],
+	"usesContext": [ "postId", "enhancedSubmission" ],
 	"supports": {
 		"align": true,
 		"html": false,

--- a/packages/block-library/src/comment-template/index.php
+++ b/packages/block-library/src/comment-template/index.php
@@ -20,6 +20,7 @@ function block_core_comment_template_render_comments( $comments, $block ) {
 	global $comment_depth;
 	$thread_comments       = get_option( 'thread_comments' );
 	$thread_comments_depth = get_option( 'thread_comments_depth' );
+	$enhanced_submission   = isset( $block->context['enhancedSubmission'] ) && $block->context['enhancedSubmission'];
 
 	if ( empty( $comment_depth ) ) {
 		$comment_depth = 1;
@@ -83,7 +84,15 @@ function block_core_comment_template_render_comments( $comments, $block ) {
 			}
 		}
 
-		$content .= sprintf( '<li id="comment-%1$s" %2$s>%3$s</li>', $comment->comment_ID, $comment_classes, $block_content );
+		$comment_directives = $enhanced_submission ? ' data-wp-key="comment-' . $comment->comment_ID . '" data-wp-slot=\'{"name":"comment-' . $comment->comment_ID . '","position":"after"}\'' : '';
+
+		$content .= sprintf(
+			'<li id="comment-%1$s" %2$s%3$s>%4$s</li>',
+			$comment->comment_ID,
+			$comment_classes,
+			$comment_directives,
+			$block_content
+		);
 	}
 
 	return $content;

--- a/packages/block-library/src/comments/block.json
+++ b/packages/block-library/src/comments/block.json
@@ -14,6 +14,10 @@
 		"legacy": {
 			"type": "boolean",
 			"default": false
+		},
+		"enhancedSubmission": {
+			"type": "boolean",
+			"default": false
 		}
 	},
 	"supports": {
@@ -60,5 +64,8 @@
 		}
 	},
 	"editorStyle": "wp-block-comments-editor",
-	"usesContext": [ "postId", "postType" ]
+	"usesContext": [ "postId", "postType" ],
+	"providesContext": {
+		"enhancedSubmission": "enhancedSubmission"
+	}
 }

--- a/packages/block-library/src/comments/index.php
+++ b/packages/block-library/src/comments/index.php
@@ -123,6 +123,15 @@ function register_block_core_comments() {
 			'skip_inner_blocks' => true,
 		)
 	);
+
+	if ( defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN ) {
+		gutenberg_register_module(
+			'@wordpress/block-library/comments',
+			gutenberg_url( '/build/interactivity/comments.min.js' ),
+			array( '@wordpress/interactivity' ),
+			defined( 'GUTENBERG_VERSION' ) ? GUTENBERG_VERSION : get_bloginfo( 'version' )
+		);
+	}
 }
 add_action( 'init', 'register_block_core_comments' );
 

--- a/packages/block-library/src/comments/index.php
+++ b/packages/block-library/src/comments/index.php
@@ -27,6 +27,7 @@
  */
 function render_block_core_comments( $attributes, $content, $block ) {
 	global $post;
+	static $id = 0;
 
 	$post_id = $block->context['postId'];
 	if ( ! isset( $post_id ) ) {
@@ -41,7 +42,35 @@ function render_block_core_comments( $attributes, $content, $block ) {
 	// If this isn't the legacy block, we need to render the static version of this block.
 	$is_legacy = 'core/post-comments' === $block->name || ! empty( $attributes['legacy'] );
 	if ( ! $is_legacy ) {
-		return $block->render( array( 'dynamic' => false ) );
+		$output = $block->render( array( 'dynamic' => false ) );
+		if ( $attributes['enhancedSubmission'] ) {
+			$p = new WP_HTML_Tag_Processor( $output );
+			if ( $p->next_tag( array( 'class_name' => 'wp-block-comments' ) ) ) {
+				// Add the necessary directives.
+				$p->set_attribute( 'data-wp-interactive', true );
+				$p->set_attribute( 'data-wp-navigation-id', 'comments-' . ++$id );
+				$p->set_attribute( 'data-wp-slot-provider', true );
+				$p->set_attribute(
+					'data-wp-context',
+					wp_json_encode(
+						array(
+							'core' => array(
+								'comments' => (object) array(
+									'fields' => (object) array(
+										'comment_parent' => 0,
+									),
+								),
+							),
+						)
+					)
+				);
+				$output = $p->get_updated_html();
+
+				// Mark the block as interactive.
+				$block->block_type->supports['interactivity'] = true;
+			}
+		}
+		return $output;
 	}
 
 	$post_before = $post;

--- a/packages/block-library/src/comments/index.php
+++ b/packages/block-library/src/comments/index.php
@@ -47,8 +47,8 @@ function render_block_core_comments( $attributes, $content, $block ) {
 			$p = new WP_HTML_Tag_Processor( $output );
 			if ( $p->next_tag( array( 'class_name' => 'wp-block-comments' ) ) ) {
 				// Add the necessary directives.
-				$p->set_attribute( 'data-wp-interactive', '{ "namespace": "core/comments" }' );
-				$p->set_attribute( 'data-wp-navigation-id', 'comments-' . ++$id );
+				$p->set_attribute( 'data-wp-interactive', 'core/comments' );
+				$p->set_attribute( 'data-wp-router-region', 'comments-' . ++$id );
 				$p->set_attribute( 'data-wp-slot-provider', true );
 				$p->set_attribute(
 					'data-wp-context',
@@ -124,14 +124,14 @@ function register_block_core_comments() {
 		)
 	);
 
-	if ( defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN ) {
-		gutenberg_register_module(
-			'@wordpress/block-library/comments',
-			gutenberg_url( '/build/interactivity/comments.min.js' ),
-			array( '@wordpress/interactivity' ),
-			defined( 'GUTENBERG_VERSION' ) ? GUTENBERG_VERSION : get_bloginfo( 'version' )
-		);
-	}
+	// if ( defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN ) {
+	// 	gutenberg_register_module(
+	// 		'@wordpress/block-library/comments',
+	// 		gutenberg_url( '/build/interactivity/comments.min.js' ),
+	// 		array( '@wordpress/interactivity' ),
+	// 		defined( 'GUTENBERG_VERSION' ) ? GUTENBERG_VERSION : get_bloginfo( 'version' )
+	// 	);
+	// }
 }
 add_action( 'init', 'register_block_core_comments' );
 

--- a/packages/block-library/src/comments/index.php
+++ b/packages/block-library/src/comments/index.php
@@ -47,19 +47,15 @@ function render_block_core_comments( $attributes, $content, $block ) {
 			$p = new WP_HTML_Tag_Processor( $output );
 			if ( $p->next_tag( array( 'class_name' => 'wp-block-comments' ) ) ) {
 				// Add the necessary directives.
-				$p->set_attribute( 'data-wp-interactive', true );
+				$p->set_attribute( 'data-wp-interactive', 'core/comments' );
 				$p->set_attribute( 'data-wp-navigation-id', 'comments-' . ++$id );
 				$p->set_attribute( 'data-wp-slot-provider', true );
 				$p->set_attribute(
 					'data-wp-context',
 					wp_json_encode(
 						array(
-							'core' => array(
-								'comments' => (object) array(
-									'fields' => (object) array(
-										'comment_parent' => 0,
-									),
-								),
+							'fields' => (object) array(
+								'comment_parent' => 0,
 							),
 						)
 					)

--- a/packages/block-library/src/comments/index.php
+++ b/packages/block-library/src/comments/index.php
@@ -47,7 +47,7 @@ function render_block_core_comments( $attributes, $content, $block ) {
 			$p = new WP_HTML_Tag_Processor( $output );
 			if ( $p->next_tag( array( 'class_name' => 'wp-block-comments' ) ) ) {
 				// Add the necessary directives.
-				$p->set_attribute( 'data-wp-interactive', 'core/comments' );
+				$p->set_attribute( 'data-wp-interactive', '{ "namespace": "core/comments" }' );
 				$p->set_attribute( 'data-wp-navigation-id', 'comments-' . ++$id );
 				$p->set_attribute( 'data-wp-slot-provider', true );
 				$p->set_attribute(

--- a/packages/block-library/src/post-comments-form/block.json
+++ b/packages/block-library/src/post-comments-form/block.json
@@ -11,7 +11,7 @@
 			"type": "string"
 		}
 	},
-	"usesContext": [ "postId", "postType" ],
+	"usesContext": [ "postId", "postType", "enhancedSubmission" ],
 	"supports": {
 		"html": false,
 		"color": {
@@ -56,5 +56,6 @@
 		"wp-block-post-comments-form",
 		"wp-block-buttons",
 		"wp-block-button"
-	]
+	],
+	"viewScript": "file:./view.min.js"
 }

--- a/packages/block-library/src/post-comments-form/block.json
+++ b/packages/block-library/src/post-comments-form/block.json
@@ -56,6 +56,5 @@
 		"wp-block-post-comments-form",
 		"wp-block-buttons",
 		"wp-block-button"
-	],
-	"viewScript": "file:./view.min.js"
+	]
 }

--- a/packages/block-library/src/post-comments-form/index.php
+++ b/packages/block-library/src/post-comments-form/index.php
@@ -176,9 +176,15 @@ function render_block_core_post_comments_form( $attributes, $content, $block ) {
 		}
 	}
 
-	$view_asset = 'wp-block-post-comments-form-view';
-	if ( ! wp_script_is( $view_asset ) ) {
-		$script_handles = $block->block_type->view_script_handles;
+	$is_gutenberg_plugin = defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN;
+	$view_asset          = 'wp-block-post-comments-form-view';
+	$script_handles      = $block->block_type->view_script_handles;
+
+	if ( $is_gutenberg_plugin ) {
+		gutenberg_enqueue_module( '@wordpress/block-library/post-comments-form' );
+		// Remove the view script because we are using the module.
+		$block->block_type->view_script_handles = array_diff( $script_handles, array( $view_asset ) );
+	} elseif ( ! wp_script_is( $view_asset ) ) {
 		// If the script is not needed, and it is still in the `view_script_handles`, remove it.
 		if ( ! $enhanced_submission && in_array( $view_asset, $script_handles, true ) ) {
 			$block->block_type->view_script_handles = array_diff( $script_handles, array( $view_asset ) );
@@ -211,6 +217,15 @@ function register_block_core_post_comments_form() {
 			'render_callback' => 'render_block_core_post_comments_form',
 		)
 	);
+
+	if ( defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN ) {
+		gutenberg_register_module(
+			'@wordpress/block-library/post-comments-form',
+			'/wp-content/plugins/gutenberg/build/interactivity/comments.min.js',
+			array( '@wordpress/interactivity' ),
+			defined( 'GUTENBERG_VERSION' ) ? GUTENBERG_VERSION : get_bloginfo( 'version' )
+		);
+	}
 }
 add_action( 'init', 'register_block_core_post_comments_form' );
 

--- a/packages/block-library/src/post-comments-form/index.php
+++ b/packages/block-library/src/post-comments-form/index.php
@@ -110,12 +110,11 @@ function render_block_core_post_comments_form( $attributes, $content, $block ) {
 
 					// Add translated strings to the state.
 					$submit_text = $p->get_attribute( 'value' );
-					wp_store(
+					wp_interactivity_state(
+						'core/comments',
 						array(
-							'core/comments' => array(
-								'submitText'  => $submit_text,
-								'loadingText' => __( 'Submitting…' ),
-							),
+							'submitText'  => $submit_text,
+							'loadingText' => __( 'Submitting…' ),
 						)
 					);
 				}
@@ -140,11 +139,10 @@ function render_block_core_post_comments_form( $attributes, $content, $block ) {
 
 			// Add a div to show error messages below the form and another div to
 			// announce the spoken notices.
-			wp_store(
+			wp_interactivity_state(
+				'core/comments',
 				array(
-					'core/comments' => array(
-						'submittedNotice' => __( 'Comment submitted.' ),
-					),
+					'submittedNotice' => __( 'Comment submitted.' ),
 				)
 			);
 			$enhanced_form     = $p->get_updated_html();

--- a/packages/block-library/src/post-comments-form/index.php
+++ b/packages/block-library/src/post-comments-form/index.php
@@ -105,7 +105,7 @@ function render_block_core_post_comments_form( $attributes, $content, $block ) {
 				// on submission. This is optional.
 				if ( 'INPUT' === $tag && 'submit' === $type ) {
 					// Add the necessary directives.
-					$p->set_attribute( 'data-wp-bind--value', 'state.submitText' );
+					$p->set_attribute( 'data-wp-bind--value', 'state.submitButtonText' );
 					$p->set_attribute( 'data-wp-bind--disabled', 'context.isSubmitting' );
 
 					// Add translated strings to the state.

--- a/packages/block-library/src/post-comments-form/index.php
+++ b/packages/block-library/src/post-comments-form/index.php
@@ -31,7 +31,13 @@ function render_block_core_post_comments_form( $attributes, $content, $block ) {
 	if ( isset( $attributes['style']['elements']['link']['color']['text'] ) ) {
 		$classes[] = 'has-link-color';
 	}
-	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => implode( ' ', $classes ) ) );
+	$wrapper_attributes = get_block_wrapper_attributes(
+		array(
+			'class'          => implode( ' ', $classes ),
+			'data-wp-fill'   => 'context.core.comments.formSlot',
+			'data-wp-effect' => 'effects.core.comments.scrollOnReply',
+		)
+	);
 
 	add_filter( 'comment_form_defaults', 'post_comments_form_block_form_defaults' );
 
@@ -48,9 +54,163 @@ function render_block_core_post_comments_form( $attributes, $content, $block ) {
 	// of the 'Reply' link that the user clicked by Core's `comment-reply.js` script.
 	$form = str_replace( 'class="comment-respond"', $wrapper_attributes, $form );
 
-	// Enqueue the comment-reply script.
-	wp_enqueue_script( 'comment-reply' );
+	$enhanced_submission = $block->context['enhancedSubmission'];
+	$enhanced_form       = false;
 
+	if ( $enhanced_submission ) {
+		$p = new WP_HTML_Tag_Processor( $form );
+
+		// Move to the first tag and add a bookmark. This is supposed to be OK considering
+		// that the first element is not the form element.
+		$p->next_tag();
+		$p->set_bookmark( 'first-tag' );
+
+		// Try to find the form element. This is not optional; if it fails, we don't
+		// enhance the submission.
+		if ( $p->next_tag(
+			array(
+				'tag_name' => 'FORM',
+				'id'       => 'commentform',
+			)
+		) ) {
+			// Add the necessary directives.
+			$p->set_attribute( 'data-wp-on--submit', 'actions.core.comments.submit' );
+
+			while ( $p->next_tag() ) {
+				$tag  = $p->get_tag();
+				$name = $p->get_attribute( 'name' );
+				$type = $p->get_attribute( 'type' );
+
+				// Try to find the different input fields and save their values on the
+				// context so it can be restored when the form is moved around. This is
+				// optional.
+				if ( 'TEXTAREA' === $tag && 'comment' === $name ) {
+					$p->set_attribute( 'data-wp-bind--value', 'context.core.comments.fields.' . $name );
+					$p->set_attribute( 'data-wp-on--change', 'actions.core.comments.updateField' );
+				}
+
+				if (
+					'INPUT' === $tag &&
+					in_array( $name, array( 'author', 'email', 'url' ), true )
+				) {
+					$p->set_attribute( 'data-wp-bind--value', 'context.core.comments.fields.' . $name );
+					$p->set_attribute( 'data-wp-on--input', 'actions.core.comments.updateField' );
+				}
+
+				if ( 'INPUT' === $tag && 'comment_parent' === $name ) {
+					$p->set_attribute( 'data-wp-bind--value', 'context.core.comments.fields.' . $name );
+				}
+
+				// Try to find the submit button and add directives to change its value
+				// on submission. This is optional.
+				if ( 'INPUT' === $tag && 'submit' === $type ) {
+					// Add the necessary directives.
+					$p->set_attribute( 'data-wp-bind--value', 'selectors.core.comments.submitText' );
+					$p->set_attribute( 'data-wp-bind--disabled', 'context.core.comments.isSubmitting' );
+
+					// Add translated strings to the state.
+					$submit_text = $p->get_attribute( 'value' );
+					wp_store(
+						array(
+							'state'     => array(
+								'core' => array(
+									'comments' => array(
+										'submitText'  => $submit_text,
+										'loadingText' => __( 'Submitting…' ),
+									),
+								),
+							),
+							'selectors' => array(
+								'core' => array(
+									'comments' => array(
+										'submitText' => $submit_text,
+									),
+								),
+							),
+						)
+					);
+				}
+			}
+
+			// Start again to add directives to the reply title elements.
+			$p->seek( 'first-tag' );
+			if ( $p->next_tag( array( 'class_name' => 'comment-reply-title' ) ) ) {
+				$p->set_attribute( 'data-wp-effect', 'actions.core.comments.updateReplyTitle' );
+			}
+
+			while ( $p->next_tag( array( 'tag_name' => 'a' ) ) ) {
+				if ( 'cancel-comment-reply-link' === $p->get_attribute( 'id' ) ) {
+					$p->set_attribute( 'data-wp-style--display', 'selectors.core.comments.displayCancelReply' );
+					$p->set_attribute( 'data-wp-on--click', 'actions.core.comments.cancelReply' );
+					break;
+				}
+			}
+
+			// Mark the block as interactive.
+			$block->block_type->supports['interactivity'] = true;
+
+			// Add a div to show error messages below the form and another div to
+			// announce the spoken notices.
+			wp_store(
+				array(
+					'state' => array(
+						'core' => array(
+							'comments' => array(
+								'submittedNotice' => __( 'Comment submitted.' ),
+							),
+						),
+					),
+				)
+			);
+			$enhanced_form     = $p->get_updated_html();
+			$last_div_position = strripos( $enhanced_form, '</form>' );
+			$enhanced_form     = substr_replace(
+				$enhanced_form,
+				'<div
+					class="wp-block-post-comments-form__error"
+					data-wp-style--display="selectors.core.comments.showError"
+					data-wp-effect="effects.core.comments.scrollToError"
+				>
+					<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true" focusable="false">
+						<path d="M12 3.2c-4.8 0-8.8 3.9-8.8 8.8 0 4.8 3.9 8.8 8.8 8.8 4.8 0 8.8-3.9 8.8-8.8 0-4.8-4-8.8-8.8-8.8zm0 16c-4 0-7.2-3.3-7.2-7.2C4.8 8 8 4.8 12 4.8s7.2 3.3 7.2 7.2c0 4-3.2 7.2-7.2 7.2zM11 17h2v-6h-2v6zm0-8h2V7h-2v2z"></path>
+					</svg>
+					<span
+						data-wp-text="state.core.comments.error"
+						aria-live="polite"
+					></span>
+				</div>
+				<div
+					style="position:absolute;clip:rect(0,0,0,0);width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;border:0;"
+					aria-live="polite"
+					data-wp-text="context.core.comments.notice"
+				></div>
+				</form>',
+				$last_div_position,
+				0
+			);
+		}
+	}
+
+	$view_asset = 'wp-block-post-comments-form-view';
+	if ( ! wp_script_is( $view_asset ) ) {
+		$script_handles = $block->block_type->view_script_handles;
+		// If the script is not needed, and it is still in the `view_script_handles`, remove it.
+		if ( ! $enhanced_submission && in_array( $view_asset, $script_handles, true ) ) {
+			$block->block_type->view_script_handles = array_diff( $script_handles, array( $view_asset ) );
+		}
+		// If the script is needed, but it was previously removed, add it again.
+		if ( $enhanced_submission && ! in_array( $view_asset, $script_handles, true ) ) {
+			$block->block_type->view_script_handles = array_merge( $script_handles, array( $view_asset ) );
+		}
+	}
+
+	if ( $enhanced_form ) {
+		return $enhanced_form;
+	}
+
+	// If something failed or there is no enhanced submission, enqueue the regular
+	// comment-reply script and return the HTML without the directives.
+	wp_enqueue_script( 'comment-reply' );
 	return $form;
 }
 

--- a/packages/block-library/src/post-comments-form/index.php
+++ b/packages/block-library/src/post-comments-form/index.php
@@ -142,12 +142,8 @@ function render_block_core_post_comments_form( $attributes, $content, $block ) {
 			// announce the spoken notices.
 			wp_store(
 				array(
-					'state' => array(
-						'core' => array(
-							'comments' => array(
-								'submittedNotice' => __( 'Comment submitted.' ),
-							),
-						),
+					'core/comments' => array(
+						'submittedNotice' => __( 'Comment submitted.' ),
 					),
 				)
 			);

--- a/packages/block-library/src/post-comments-form/index.php
+++ b/packages/block-library/src/post-comments-form/index.php
@@ -181,7 +181,7 @@ function render_block_core_post_comments_form( $attributes, $content, $block ) {
 	$script_handles      = $block->block_type->view_script_handles;
 
 	if ( $is_gutenberg_plugin ) {
-		gutenberg_enqueue_module( '@wordpress/block-library/post-comments-form' );
+		wp_enqueue_script_module( '@wordpress/block-library/post-comments-form/view' );
 		// Remove the view script because we are using the module.
 		$block->block_type->view_script_handles = array_diff( $script_handles, array( $view_asset ) );
 	} elseif ( ! wp_script_is( $view_asset ) ) {
@@ -217,15 +217,6 @@ function register_block_core_post_comments_form() {
 			'render_callback' => 'render_block_core_post_comments_form',
 		)
 	);
-
-	if ( defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN ) {
-		gutenberg_register_module(
-			'@wordpress/block-library/post-comments-form',
-			'/wp-content/plugins/gutenberg/build/interactivity/comments.min.js',
-			array( '@wordpress/interactivity' ),
-			defined( 'GUTENBERG_VERSION' ) ? GUTENBERG_VERSION : get_bloginfo( 'version' )
-		);
-	}
 }
 add_action( 'init', 'register_block_core_post_comments_form' );
 

--- a/packages/block-library/src/post-comments-form/index.php
+++ b/packages/block-library/src/post-comments-form/index.php
@@ -33,9 +33,9 @@ function render_block_core_post_comments_form( $attributes, $content, $block ) {
 	}
 	$wrapper_attributes = get_block_wrapper_attributes(
 		array(
-			'class'          => implode( ' ', $classes ),
-			'data-wp-fill'   => 'context.core.comments.formSlot',
-			'data-wp-effect' => 'effects.core.comments.scrollOnReply',
+			'class'         => implode( ' ', $classes ),
+			'data-wp-fill'  => 'context.formSlot',
+			'data-wp-watch' => 'callbacks.scrollOnReply',
 		)
 	);
 
@@ -74,7 +74,7 @@ function render_block_core_post_comments_form( $attributes, $content, $block ) {
 			)
 		) ) {
 			// Add the necessary directives.
-			$p->set_attribute( 'data-wp-on--submit', 'actions.core.comments.submit' );
+			$p->set_attribute( 'data-wp-on--submit', 'actions.submit' );
 
 			while ( $p->next_tag() ) {
 				$tag  = $p->get_tag();
@@ -85,47 +85,36 @@ function render_block_core_post_comments_form( $attributes, $content, $block ) {
 				// context so it can be restored when the form is moved around. This is
 				// optional.
 				if ( 'TEXTAREA' === $tag && 'comment' === $name ) {
-					$p->set_attribute( 'data-wp-bind--value', 'context.core.comments.fields.' . $name );
-					$p->set_attribute( 'data-wp-on--change', 'actions.core.comments.updateField' );
+					$p->set_attribute( 'data-wp-bind--value', 'context.fields.' . $name );
+					$p->set_attribute( 'data-wp-on--change', 'actions.updateField' );
 				}
 
 				if (
 					'INPUT' === $tag &&
 					in_array( $name, array( 'author', 'email', 'url' ), true )
 				) {
-					$p->set_attribute( 'data-wp-bind--value', 'context.core.comments.fields.' . $name );
-					$p->set_attribute( 'data-wp-on--input', 'actions.core.comments.updateField' );
+					$p->set_attribute( 'data-wp-bind--value', 'context.fields.' . $name );
+					$p->set_attribute( 'data-wp-on--input', 'actions.updateField' );
 				}
 
 				if ( 'INPUT' === $tag && 'comment_parent' === $name ) {
-					$p->set_attribute( 'data-wp-bind--value', 'context.core.comments.fields.' . $name );
+					$p->set_attribute( 'data-wp-bind--value', 'context.fields.' . $name );
 				}
 
 				// Try to find the submit button and add directives to change its value
 				// on submission. This is optional.
 				if ( 'INPUT' === $tag && 'submit' === $type ) {
 					// Add the necessary directives.
-					$p->set_attribute( 'data-wp-bind--value', 'selectors.core.comments.submitText' );
-					$p->set_attribute( 'data-wp-bind--disabled', 'context.core.comments.isSubmitting' );
+					$p->set_attribute( 'data-wp-bind--value', 'state.submitText' );
+					$p->set_attribute( 'data-wp-bind--disabled', 'context.isSubmitting' );
 
 					// Add translated strings to the state.
 					$submit_text = $p->get_attribute( 'value' );
 					wp_store(
 						array(
-							'state'     => array(
-								'core' => array(
-									'comments' => array(
-										'submitText'  => $submit_text,
-										'loadingText' => __( 'Submitting…' ),
-									),
-								),
-							),
-							'selectors' => array(
-								'core' => array(
-									'comments' => array(
-										'submitText' => $submit_text,
-									),
-								),
+							'core/comments' => array(
+								'submitText'  => $submit_text,
+								'loadingText' => __( 'Submitting…' ),
 							),
 						)
 					);
@@ -135,13 +124,13 @@ function render_block_core_post_comments_form( $attributes, $content, $block ) {
 			// Start again to add directives to the reply title elements.
 			$p->seek( 'first-tag' );
 			if ( $p->next_tag( array( 'class_name' => 'comment-reply-title' ) ) ) {
-				$p->set_attribute( 'data-wp-effect', 'actions.core.comments.updateReplyTitle' );
+				$p->set_attribute( 'data-wp-watch', 'actions.updateReplyTitle' );
 			}
 
 			while ( $p->next_tag( array( 'tag_name' => 'a' ) ) ) {
 				if ( 'cancel-comment-reply-link' === $p->get_attribute( 'id' ) ) {
-					$p->set_attribute( 'data-wp-style--display', 'selectors.core.comments.displayCancelReply' );
-					$p->set_attribute( 'data-wp-on--click', 'actions.core.comments.cancelReply' );
+					$p->set_attribute( 'data-wp-style--display', 'state.displayCancelReply' );
+					$p->set_attribute( 'data-wp-on--click', 'actions.cancelReply' );
 					break;
 				}
 			}
@@ -168,21 +157,21 @@ function render_block_core_post_comments_form( $attributes, $content, $block ) {
 				$enhanced_form,
 				'<div
 					class="wp-block-post-comments-form__error"
-					data-wp-style--display="selectors.core.comments.showError"
-					data-wp-effect="effects.core.comments.scrollToError"
+					data-wp-style--display="state.showError"
+					data-wp-watch="callbacks.scrollToError"
 				>
 					<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true" focusable="false">
 						<path d="M12 3.2c-4.8 0-8.8 3.9-8.8 8.8 0 4.8 3.9 8.8 8.8 8.8 4.8 0 8.8-3.9 8.8-8.8 0-4.8-4-8.8-8.8-8.8zm0 16c-4 0-7.2-3.3-7.2-7.2C4.8 8 8 4.8 12 4.8s7.2 3.3 7.2 7.2c0 4-3.2 7.2-7.2 7.2zM11 17h2v-6h-2v6zm0-8h2V7h-2v2z"></path>
 					</svg>
 					<span
-						data-wp-text="state.core.comments.error"
+						data-wp-text="state.error"
 						aria-live="polite"
 					></span>
 				</div>
 				<div
 					style="position:absolute;clip:rect(0,0,0,0);width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;border:0;"
 					aria-live="polite"
-					data-wp-text="context.core.comments.notice"
+					data-wp-text="context.notice"
 				></div>
 				</form>',
 				$last_div_position,

--- a/packages/block-library/src/post-comments-form/style.scss
+++ b/packages/block-library/src/post-comments-form/style.scss
@@ -82,4 +82,25 @@
 			margin-left: 0.5em;
 		}
 	}
+
+	.wp-block-post-comments-form__error {
+		display: none;
+		gap: 12px;
+		align-items: stretch;
+		border: 1px solid #cc1818;
+		border-radius: 4px;
+		color: #2f2f2f;
+		padding: 16px;
+		margin-bottom: 20px;
+		background-color: #fff0f0;
+		& > svg {
+			background-color: #cc1818;
+			transform: rotate(180deg);
+			fill: #fff;
+			border-radius: 50%;
+			padding: 2px;
+			flex-shrink: 0;
+			flex-grow: 0;
+		}
+	}
 }

--- a/packages/block-library/src/post-comments-form/view.js
+++ b/packages/block-library/src/post-comments-form/view.js
@@ -33,7 +33,7 @@ const { state } = store( 'core/comments', {
 		},
 	},
 	actions: {
-		submit: async ( event ) => {
+		*submit( event ) {
 			let response;
 			const context = getContext();
 			const { ref } = getElement();
@@ -49,7 +49,7 @@ const { state } = store( 'core/comments', {
 				state.error = '';
 				context.isSubmitting = true;
 
-				response = await window.fetch( ref.action, {
+				response = yield window.fetch( ref.action, {
 					method: 'POST',
 					body: new window.FormData( ref ),
 				} );
@@ -62,7 +62,7 @@ const { state } = store( 'core/comments', {
 			}
 
 			try {
-				const html = await response.text();
+				const html = yield response.text();
 				const dom = new window.DOMParser().parseFromString(
 					html,
 					'text/html'
@@ -72,7 +72,7 @@ const { state } = store( 'core/comments', {
 					state.error =
 						dom.querySelector( '.wp-die-message' ).innerText;
 				} else {
-					await navigate( response.url, {
+					yield navigate( response.url, {
 						html,
 						replace: true,
 						force: true,
@@ -82,8 +82,9 @@ const { state } = store( 'core/comments', {
 					comments
 						.querySelectorAll( 'li[id^="comment-"]' )
 						.forEach( ( comment ) => {
-							if ( ! existingComments.has( comment.id ) )
+							if ( ! existingComments.has( comment.id ) ) {
 								newComment = comment;
+							}
 						} );
 
 					// Scroll the new comment into view.
@@ -167,10 +168,11 @@ const { state } = store( 'core/comments', {
 			const { ref } = getElement();
 
 			// Focus on the first field in the comment form.
-			if ( formSlot )
+			if ( formSlot ) {
 				ref.querySelector( 'form' )
 					.querySelector( focusableSelectors )
 					.focus();
+			}
 		},
 	},
 } );

--- a/packages/block-library/src/post-comments-form/view.js
+++ b/packages/block-library/src/post-comments-form/view.js
@@ -1,12 +1,7 @@
 /**
  * WordPress dependencies
  */
-import {
-	getContext,
-	getElement,
-	store,
-	navigate,
-} from '@wordpress/interactivity';
+import { getContext, getElement, store } from '@wordpress/interactivity';
 
 const focusableSelectors = [
 	'input:not([disabled]):not([type="hidden"]):not([aria-hidden])',
@@ -72,7 +67,10 @@ const { state } = store( 'core/comments', {
 					state.error =
 						dom.querySelector( '.wp-die-message' ).innerText;
 				} else {
-					yield navigate( response.url, {
+					const router = yield import(
+						'@wordpress/interactivity-router'
+					);
+					yield router.actions.navigate( response.url, {
 						html,
 						replace: true,
 						force: true,

--- a/packages/block-library/src/post-comments-form/view.js
+++ b/packages/block-library/src/post-comments-form/view.js
@@ -1,0 +1,189 @@
+/**
+ * WordPress dependencies
+ */
+import { store, navigate } from '@wordpress/interactivity';
+
+const focusableSelectors = [
+	'input:not([disabled]):not([type="hidden"]):not([aria-hidden])',
+	'select:not([disabled]):not([aria-hidden])',
+	'textarea:not([disabled]):not([aria-hidden])',
+	'[contenteditable]',
+	'[tabindex]:not([tabindex^="-"])',
+];
+
+store( {
+	state: {
+		core: {
+			comments: {
+				error: '',
+			},
+		},
+	},
+	selectors: {
+		core: {
+			comments: {
+				showError: ( { state } ) =>
+					state.core.comments.error ? 'flex' : 'none',
+				submitText: ( { context, state } ) =>
+					context.core.comments.isSubmitting
+						? state.core.comments.loadingText
+						: state.core.comments.submitText,
+				displayCancelReply: ( { context } ) => {
+					return context.core.comments.formSlot ? undefined : 'none';
+				},
+			},
+		},
+	},
+	actions: {
+		core: {
+			comments: {
+				submit: async ( { event, context, state, ref } ) => {
+					let response;
+					const existingComments = new Set();
+					const comments = ref.closest( '.wp-block-comments' );
+					comments
+						.querySelectorAll( 'li[id^="comment-"]' )
+						.forEach( ( comment ) =>
+							existingComments.add( comment.id )
+						);
+
+					try {
+						event.preventDefault();
+
+						state.core.comments.error = '';
+						context.core.comments.isSubmitting = true;
+
+						response = await window.fetch( ref.action, {
+							method: 'POST',
+							body: new window.FormData( ref ),
+						} );
+					} catch ( e ) {
+						// If something fails at this point, the form hasn't been submitted
+						// and we can submit it again manually to the server. This is using
+						// the prototype because ref.submit() could be overwritten by an
+						// `<input name="submit"> element.
+						window.HTMLFormElement.prototype.submit.bind( ref )();
+					}
+
+					try {
+						const html = await response.text();
+						const dom = new window.DOMParser().parseFromString(
+							html,
+							'text/html'
+						);
+
+						if (
+							response.status !== 200 ||
+							dom.body.id === 'error-page'
+						) {
+							state.core.comments.error =
+								dom.querySelector(
+									'.wp-die-message'
+								).innerText;
+						} else {
+							await navigate( response.url, {
+								html,
+								replace: true,
+								force: true,
+							} );
+
+							let newComment;
+							comments
+								.querySelectorAll( 'li[id^="comment-"]' )
+								.forEach( ( comment ) => {
+									if ( ! existingComments.has( comment.id ) )
+										newComment = comment;
+								} );
+
+							// Scroll the new comment into view.
+							newComment.querySelector( 'a[href]' ).focus();
+
+							// Announce that the comment has been submitted. If the notice is
+							// the same, we use a no-break space similar to the trick used by
+							// the @wordpress/a11y package: https://github.com/WordPress/gutenberg/blob/c395242b8e6ee20f8b06c199e4fc2920d7018af1/packages/a11y/src/filter-message.js#L20-L26
+							context.core.comments.notice =
+								state.core.comments.submittedNotice +
+								( context.core.comments.notice ===
+								state.core.comments.submittedNotice
+									? '\u00A0'
+									: '' );
+
+							// Add hash to the URL.
+							window.history.replaceState(
+								{},
+								'',
+								window.location.pathname +
+									window.location.search +
+									`#${ newComment.id }`
+							);
+
+							// Reset form fields and position.
+							context.core.comments.formSlot = undefined;
+							const { fields } = context.core.comments;
+							for ( const key in fields ) {
+								fields[ key ] =
+									key !== 'comment_parent' ? '' : 0;
+							}
+						}
+
+						context.core.comments.isSubmitting = false;
+					} catch ( e ) {
+						// If something happens at this point, the form has been submitted
+						// but we were not able to show it in the screen, so we can just
+						// refresh the page.
+						window.location.assign(
+							response.url || window.location
+						);
+					}
+				},
+				changeReplyTo: ( { context, ref, event } ) => {
+					event.preventDefault();
+					const { commentid, replyto } = ref.dataset;
+					context.core.comments.replyTitle = replyto;
+					context.core.comments.formSlot = `comment-${ commentid }`;
+					context.core.comments.fields.comment_parent = commentid;
+				},
+				cancelReply: ( { context, event } ) => {
+					event.preventDefault();
+					context.core.comments.formSlot = undefined;
+					context.core.comments.fields.comment_parent = 0;
+				},
+				updateField: ( { context, event } ) => {
+					const { name, value } = event.target;
+					context.core.comments.fields[ name ] = value;
+				},
+				updateReplyTitle: ( { context, ref } ) => {
+					if ( context.core.comments.fields.comment_parent !== 0 ) {
+						ref.firstChild.replaceWith(
+							context.core.comments.replyTitle
+						);
+					}
+				},
+			},
+		},
+	},
+	effects: {
+		core: {
+			comments: {
+				scrollToError: ( st ) => {
+					// Scroll to the error when it's shown.
+					if ( st.state.core.comments.error ) {
+						st.ref.scrollIntoView( {
+							behavior: 'smooth',
+							block: 'end',
+						} );
+					}
+				},
+				scrollOnReply: ( { context, ref } ) => {
+					const { formSlot } = context.core.comments;
+
+					// Focus on the first field in the comment form.
+					if ( formSlot )
+						ref.querySelector( 'form' )
+							.querySelector( focusableSelectors )
+							.focus();
+				},
+			},
+		},
+	},
+} );

--- a/packages/block-library/src/post-comments-form/view.js
+++ b/packages/block-library/src/post-comments-form/view.js
@@ -22,8 +22,9 @@ const { state } = store( 'core/comments', {
 		get showError() {
 			return state.error ? 'flex' : 'none';
 		},
-		get submitText() {
-			const { isSubmitting, loadingText, submitText } = getContext();
+		get submitButtonText() {
+			const { isSubmitting } = getContext();
+			const { loadingText, submitText } = state;
 			return isSubmitting ? loadingText : submitText;
 		},
 		get displayCancelReply() {

--- a/packages/block-library/src/post-comments-form/view.js
+++ b/packages/block-library/src/post-comments-form/view.js
@@ -1,7 +1,12 @@
 /**
  * WordPress dependencies
  */
-import { store, navigate } from '@wordpress/interactivity';
+import {
+	getContext,
+	getElement,
+	store,
+	navigate,
+} from '@wordpress/interactivity';
 
 const focusableSelectors = [
 	'input:not([disabled]):not([type="hidden"]):not([aria-hidden])',
@@ -11,179 +16,160 @@ const focusableSelectors = [
 	'[tabindex]:not([tabindex^="-"])',
 ];
 
-store( {
+const { state } = store( 'core/comments', {
 	state: {
-		core: {
-			comments: {
-				error: '',
-			},
+		error: '',
+		get showError() {
+			return state.error ? 'flex' : 'none';
 		},
-	},
-	selectors: {
-		core: {
-			comments: {
-				showError: ( { state } ) =>
-					state.core.comments.error ? 'flex' : 'none',
-				submitText: ( { context, state } ) =>
-					context.core.comments.isSubmitting
-						? state.core.comments.loadingText
-						: state.core.comments.submitText,
-				displayCancelReply: ( { context } ) => {
-					return context.core.comments.formSlot ? undefined : 'none';
-				},
-			},
+		get submitText() {
+			const { isSubmitting, loadingText, submitText } = getContext();
+			return isSubmitting ? loadingText : submitText;
+		},
+		get displayCancelReply() {
+			const { formSlot } = getContext();
+			return formSlot ? undefined : 'none';
 		},
 	},
 	actions: {
-		core: {
-			comments: {
-				submit: async ( { event, context, state, ref } ) => {
-					let response;
-					const existingComments = new Set();
-					const comments = ref.closest( '.wp-block-comments' );
+		submit: async ( event ) => {
+			let response;
+			const context = getContext();
+			const { ref } = getElement();
+			const existingComments = new Set();
+			const comments = ref.closest( '.wp-block-comments' );
+			comments
+				.querySelectorAll( 'li[id^="comment-"]' )
+				.forEach( ( comment ) => existingComments.add( comment.id ) );
+
+			try {
+				event.preventDefault();
+
+				state.error = '';
+				context.isSubmitting = true;
+
+				response = await window.fetch( ref.action, {
+					method: 'POST',
+					body: new window.FormData( ref ),
+				} );
+			} catch ( e ) {
+				// If something fails at this point, the form hasn't been submitted
+				// and we can submit it again manually to the server. This is using
+				// the prototype because ref.submit() could be overwritten by an
+				// `<input name="submit"> element.
+				window.HTMLFormElement.prototype.submit.bind( ref )();
+			}
+
+			try {
+				const html = await response.text();
+				const dom = new window.DOMParser().parseFromString(
+					html,
+					'text/html'
+				);
+
+				if ( response.status !== 200 || dom.body.id === 'error-page' ) {
+					state.error =
+						dom.querySelector( '.wp-die-message' ).innerText;
+				} else {
+					await navigate( response.url, {
+						html,
+						replace: true,
+						force: true,
+					} );
+
+					let newComment;
 					comments
 						.querySelectorAll( 'li[id^="comment-"]' )
-						.forEach( ( comment ) =>
-							existingComments.add( comment.id )
-						);
-
-					try {
-						event.preventDefault();
-
-						state.core.comments.error = '';
-						context.core.comments.isSubmitting = true;
-
-						response = await window.fetch( ref.action, {
-							method: 'POST',
-							body: new window.FormData( ref ),
+						.forEach( ( comment ) => {
+							if ( ! existingComments.has( comment.id ) )
+								newComment = comment;
 						} );
-					} catch ( e ) {
-						// If something fails at this point, the form hasn't been submitted
-						// and we can submit it again manually to the server. This is using
-						// the prototype because ref.submit() could be overwritten by an
-						// `<input name="submit"> element.
-						window.HTMLFormElement.prototype.submit.bind( ref )();
+
+					// Scroll the new comment into view.
+					newComment.querySelector( 'a[href]' ).focus();
+
+					// Announce that the comment has been submitted. If the notice is
+					// the same, we use a no-break space similar to the trick used by
+					// the @wordpress/a11y package: https://github.com/WordPress/gutenberg/blob/c395242b8e6ee20f8b06c199e4fc2920d7018af1/packages/a11y/src/filter-message.js#L20-L26
+					context.notice =
+						state.submittedNotice +
+						( context.notice === state.submittedNotice
+							? '\u00A0'
+							: '' );
+
+					// Add hash to the URL.
+					window.history.replaceState(
+						{},
+						'',
+						window.location.pathname +
+							window.location.search +
+							`#${ newComment.id }`
+					);
+
+					// Reset form fields and position.
+					context.formSlot = undefined;
+					const { fields } = context;
+					for ( const key in fields ) {
+						fields[ key ] = key !== 'comment_parent' ? '' : 0;
 					}
+				}
 
-					try {
-						const html = await response.text();
-						const dom = new window.DOMParser().parseFromString(
-							html,
-							'text/html'
-						);
-
-						if (
-							response.status !== 200 ||
-							dom.body.id === 'error-page'
-						) {
-							state.core.comments.error =
-								dom.querySelector(
-									'.wp-die-message'
-								).innerText;
-						} else {
-							await navigate( response.url, {
-								html,
-								replace: true,
-								force: true,
-							} );
-
-							let newComment;
-							comments
-								.querySelectorAll( 'li[id^="comment-"]' )
-								.forEach( ( comment ) => {
-									if ( ! existingComments.has( comment.id ) )
-										newComment = comment;
-								} );
-
-							// Scroll the new comment into view.
-							newComment.querySelector( 'a[href]' ).focus();
-
-							// Announce that the comment has been submitted. If the notice is
-							// the same, we use a no-break space similar to the trick used by
-							// the @wordpress/a11y package: https://github.com/WordPress/gutenberg/blob/c395242b8e6ee20f8b06c199e4fc2920d7018af1/packages/a11y/src/filter-message.js#L20-L26
-							context.core.comments.notice =
-								state.core.comments.submittedNotice +
-								( context.core.comments.notice ===
-								state.core.comments.submittedNotice
-									? '\u00A0'
-									: '' );
-
-							// Add hash to the URL.
-							window.history.replaceState(
-								{},
-								'',
-								window.location.pathname +
-									window.location.search +
-									`#${ newComment.id }`
-							);
-
-							// Reset form fields and position.
-							context.core.comments.formSlot = undefined;
-							const { fields } = context.core.comments;
-							for ( const key in fields ) {
-								fields[ key ] =
-									key !== 'comment_parent' ? '' : 0;
-							}
-						}
-
-						context.core.comments.isSubmitting = false;
-					} catch ( e ) {
-						// If something happens at this point, the form has been submitted
-						// but we were not able to show it in the screen, so we can just
-						// refresh the page.
-						window.location.assign(
-							response.url || window.location
-						);
-					}
-				},
-				changeReplyTo: ( { context, ref, event } ) => {
-					event.preventDefault();
-					const { commentid, replyto } = ref.dataset;
-					context.core.comments.replyTitle = replyto;
-					context.core.comments.formSlot = `comment-${ commentid }`;
-					context.core.comments.fields.comment_parent = commentid;
-				},
-				cancelReply: ( { context, event } ) => {
-					event.preventDefault();
-					context.core.comments.formSlot = undefined;
-					context.core.comments.fields.comment_parent = 0;
-				},
-				updateField: ( { context, event } ) => {
-					const { name, value } = event.target;
-					context.core.comments.fields[ name ] = value;
-				},
-				updateReplyTitle: ( { context, ref } ) => {
-					if ( context.core.comments.fields.comment_parent !== 0 ) {
-						ref.firstChild.replaceWith(
-							context.core.comments.replyTitle
-						);
-					}
-				},
-			},
+				context.isSubmitting = false;
+			} catch ( e ) {
+				// If something happens at this point, the form has been submitted
+				// but we were not able to show it in the screen, so we can just
+				// refresh the page.
+				window.location.assign( response.url || window.location );
+			}
+		},
+		changeReplyTo: ( event ) => {
+			event.preventDefault();
+			const context = getContext();
+			const { ref } = getElement();
+			const { commentid, replyto } = ref.dataset;
+			context.replyTitle = replyto;
+			context.formSlot = `comment-${ commentid }`;
+			context.fields.comment_parent = commentid;
+		},
+		cancelReply: ( event ) => {
+			event.preventDefault();
+			const context = getContext();
+			context.formSlot = undefined;
+			context.fields.comment_parent = 0;
+		},
+		updateField: ( event ) => {
+			const { name, value } = event.target;
+			const context = getContext();
+			context.fields[ name ] = value;
+		},
+		updateReplyTitle: () => {
+			const context = getContext();
+			const { ref } = getElement();
+			if ( context.fields.comment_parent !== 0 ) {
+				ref.firstChild.replaceWith( context.replyTitle );
+			}
 		},
 	},
-	effects: {
-		core: {
-			comments: {
-				scrollToError: ( st ) => {
-					// Scroll to the error when it's shown.
-					if ( st.state.core.comments.error ) {
-						st.ref.scrollIntoView( {
-							behavior: 'smooth',
-							block: 'end',
-						} );
-					}
-				},
-				scrollOnReply: ( { context, ref } ) => {
-					const { formSlot } = context.core.comments;
+	callbacks: {
+		scrollToError: () => {
+			// Scroll to the error when it's shown.
+			if ( state.error ) {
+				const { ref } = getElement();
+				ref.scrollIntoView( {
+					behavior: 'smooth',
+					block: 'end',
+				} );
+			}
+		},
+		scrollOnReply: () => {
+			const { formSlot } = getContext();
+			const { ref } = getElement();
 
-					// Focus on the first field in the comment form.
-					if ( formSlot )
-						ref.querySelector( 'form' )
-							.querySelector( focusableSelectors )
-							.focus();
-				},
-			},
+			// Focus on the first field in the comment form.
+			if ( formSlot )
+				ref.querySelector( 'form' )
+					.querySelector( focusableSelectors )
+					.focus();
 		},
 	},
 } );

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-slots/block.json
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-slots/block.json
@@ -1,0 +1,15 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 2,
+	"name": "test/directive-slots",
+	"title": "E2E Interactivity tests - directive slots",
+	"category": "text",
+	"icon": "heart",
+	"description": "",
+	"supports": {
+		"interactivity": true
+	},
+	"textdomain": "e2e-interactivity",
+	"viewScript": "directive-slots-view",
+	"render": "file:./render.php"
+}

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-slots/render.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-slots/render.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * HTML for testing the directive `data-wp-bind`.
+ *
+ * @package gutenberg-test-interactive-blocks
+ */
+
+gutenberg_enqueue_module( 'directive-slots-view' );
+?>
+
+<div
+	data-wp-interactive='{ "namespace": "directive-slots" }'
+	data-wp-slot-provider
+	data-wp-context='{ "text": "fill" }'
+>
+	<div data-testid="slots" data-wp-context='{ "text": "fill inside slots" }'>
+		<div
+			data-testid="slot-1"
+			data-wp-key="slot-1"
+			data-wp-slot="slot-1"
+			data-wp-context='{ "text": "fill inside slot 1" }'
+		>[1]</div>
+		<div
+			data-testid="slot-2"
+			data-wp-key="slot-2"
+			data-wp-slot='{ "name": "slot-2", "position": "before" }'
+			data-wp-context='{ "text": "[2]" }'
+			data-wp-text='context.text'
+			data-wp-on--click="actions.updateSlotText"
+		>[2]</div>
+		<div
+			data-testid="slot-3"
+			data-wp-key="slot-3"
+			data-wp-slot='{ "name": "slot-3", "position": "after" }'
+			data-wp-context='{ "text": "[3]" }'
+			data-wp-text='context.text'
+			data-wp-on--click="actions.updateSlotText"
+		>[3]</div>
+		<div
+			data-testid="slot-4"
+			data-wp-key="slot-4"
+			data-wp-slot='{ "name": "slot-4", "position": "children" }'
+			data-wp-context='{ "text": "fill inside slot 4" }'
+		>[4]</div>
+		<div
+			data-testid="slot-5"
+			data-wp-key="slot-5"
+			data-wp-slot='{ "name": "slot-5", "position": "replace" }'
+			data-wp-context='{ "text": "fill inside slot 5" }'
+		>[5]</div>
+	</div>
+
+	<div data-testid="fill-container">
+		<span
+			data-testid="fill"
+			data-wp-fill="state.slot"
+			data-wp-text="context.text"
+		>initial</span>
+	</div>
+
+	<div data-wp-on--click="actions.changeSlot">
+		<button data-testid="slot-1-button" data-slot="slot-1">slot-1</button>
+		<button data-testid="slot-2-button" data-slot="slot-2">slot-2</button>
+		<button data-testid="slot-3-button" data-slot="slot-3">slot-3</button>
+		<button data-testid="slot-4-button" data-slot="slot-4">slot-4</button>
+		<button data-testid="slot-5-button" data-slot="slot-5">slot-5</button>
+		<button data-testid="reset" data-slot="">reset</button>
+	</div>
+</div>

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-slots/view.js
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-slots/view.js
@@ -1,0 +1,20 @@
+/**
+ * WordPress dependencies
+ */
+import { store, getContext } from '@wordpress/interactivity';
+
+const { state } = store( 'directive-slots', {
+	state: {
+		slot: '',
+	},
+	actions: {
+		changeSlot( event ) {
+			state.slot = event.target.dataset.slot;
+		},
+		updateSlotText() {
+			const context = getContext();
+			const n = context.text[ 1 ];
+			context.text = `[${ n } updated]`;
+		},
+	},
+} );

--- a/packages/interactivity/src/slots.tsx
+++ b/packages/interactivity/src/slots.tsx
@@ -1,0 +1,37 @@
+/**
+ * External dependencies
+ */
+import { h, createContext } from 'preact';
+import { useContext, useEffect } from 'preact/hooks';
+import { signal } from '@preact/signals';
+
+const slotsContext = createContext( { value: {} } );
+
+export const Fill = ( { slot, children = null } ) => {
+	const slots = useContext( slotsContext );
+
+	useEffect( () => {
+		if ( slot ) {
+			slots.value = { ...slots.value, [ slot ]: children };
+			return () => {
+				slots.value = { ...slots.value, [ slot ]: null };
+			};
+		}
+		return undefined;
+	}, [ slots, slot, children ] );
+
+	return !! slot ? null : children;
+};
+
+export const SlotProvider = ( { children } ) => {
+	return (
+		// TODO: We can change this to use deepsignal once this PR is merged.
+		// https://github.com/luisherranz/deepsignal/pull/38
+		h( slotsContext.Provider, { value: signal( {} ) }, children )
+	);
+};
+
+export const Slot = ( { name, children = null } ) => {
+	const slots = useContext( slotsContext );
+	return slots.value[ name ] || children;
+};

--- a/test/e2e/specs/interactivity/directive-slots.spec.ts
+++ b/test/e2e/specs/interactivity/directive-slots.spec.ts
@@ -1,0 +1,186 @@
+/**
+ * Internal dependencies
+ */
+import { test, expect } from './fixtures';
+
+test.describe( 'data-wp-slot', () => {
+	test.beforeAll( async ( { interactivityUtils: utils } ) => {
+		await utils.activatePlugins();
+		await utils.addPostWithBlock( 'test/directive-slots' );
+	} );
+
+	test.beforeEach( async ( { interactivityUtils: utils, page } ) => {
+		await page.goto( utils.getLink( 'test/directive-slots' ) );
+	} );
+
+	test.afterAll( async ( { interactivityUtils: utils } ) => {
+		await utils.deactivatePlugins();
+		await utils.deleteAllPosts();
+	} );
+
+	test( 'should render the fill in its children by default', async ( {
+		page,
+	} ) => {
+		const slot1 = page.getByTestId( 'slot-1' );
+		const slots = page.getByTestId( 'slots' );
+		const fillContainer = page.getByTestId( 'fill-container' );
+
+		await page.getByTestId( 'slot-1-button' ).click();
+
+		await expect( fillContainer ).toBeEmpty();
+		await expect( slot1.getByTestId( 'fill' ) ).toBeVisible();
+		await expect( slot1 ).toHaveText( 'fill inside slot 1' );
+		await expect( slots.locator( 'css= > *' ) ).toHaveText( [
+			'fill inside slot 1',
+			'[2]',
+			'[3]',
+			'[4]',
+			'[5]',
+		] );
+	} );
+
+	test( 'should render the fill before if specified', async ( { page } ) => {
+		const slot2 = page.getByTestId( 'slot-2' );
+		const slots = page.getByTestId( 'slots' );
+		const fillContainer = page.getByTestId( 'fill-container' );
+
+		await page.getByTestId( 'slot-2-button' ).click();
+
+		await expect( fillContainer ).toBeEmpty();
+		await expect( slot2 ).toHaveText( '[2]' );
+		await expect( slots.getByTestId( 'fill' ) ).toBeVisible();
+		await expect( slots.locator( 'css= > *' ) ).toHaveText( [
+			'[1]',
+			'fill inside slots',
+			'[2]',
+			'[3]',
+			'[4]',
+			'[5]',
+		] );
+	} );
+
+	test( 'should render the fill after if specified', async ( { page } ) => {
+		const slot3 = page.getByTestId( 'slot-3' );
+		const slots = page.getByTestId( 'slots' );
+		const fillContainer = page.getByTestId( 'fill-container' );
+
+		await page.getByTestId( 'slot-3-button' ).click();
+
+		await expect( fillContainer ).toBeEmpty();
+		await expect( slot3 ).toHaveText( '[3]' );
+		await expect( slots.getByTestId( 'fill' ) ).toBeVisible();
+		await expect( slots.locator( 'css= > *' ) ).toHaveText( [
+			'[1]',
+			'[2]',
+			'[3]',
+			'fill inside slots',
+			'[4]',
+			'[5]',
+		] );
+	} );
+
+	test( 'should render the fill in its children if specified', async ( {
+		page,
+	} ) => {
+		const slot4 = page.getByTestId( 'slot-4' );
+		const slots = page.getByTestId( 'slots' );
+		const fillContainer = page.getByTestId( 'fill-container' );
+
+		await page.getByTestId( 'slot-4-button' ).click();
+
+		await expect( fillContainer ).toBeEmpty();
+		await expect( slot4.getByTestId( 'fill' ) ).toBeVisible();
+		await expect( slot4 ).toHaveText( 'fill inside slot 4' );
+		await expect( slots.locator( 'css= > *' ) ).toHaveText( [
+			'[1]',
+			'[2]',
+			'[3]',
+			'fill inside slot 4',
+			'[5]',
+		] );
+	} );
+
+	test( 'should be replaced by the fill if specified', async ( { page } ) => {
+		const slot5 = page.getByTestId( 'slot-5' );
+		const slots = page.getByTestId( 'slots' );
+		const fillContainer = page.getByTestId( 'fill-container' );
+
+		await page.getByTestId( 'slot-5-button' ).click();
+
+		await expect( fillContainer ).toBeEmpty();
+		await expect( slot5 ).toBeHidden();
+		await expect( slots.getByTestId( 'fill' ) ).toBeVisible();
+		await expect( slots.locator( 'css= > *' ) ).toHaveText( [
+			'[1]',
+			'[2]',
+			'[3]',
+			'[4]',
+			'fill inside slots',
+		] );
+	} );
+
+	test( 'should keep the fill in its original position if no slot matches', async ( {
+		page,
+	} ) => {
+		const fillContainer = page.getByTestId( 'fill-container' );
+		await expect( fillContainer.getByTestId( 'fill' ) ).toBeVisible();
+
+		await page.getByTestId( 'slot-1-button' ).click();
+
+		await expect( fillContainer ).toBeEmpty();
+
+		await page.getByTestId( 'reset' ).click();
+
+		await expect( fillContainer.getByTestId( 'fill' ) ).toBeVisible();
+	} );
+
+	test( 'should not be re-mounted when adding the fill before', async ( {
+		page,
+	} ) => {
+		const slot2 = page.getByTestId( 'slot-2' );
+		const slots = page.getByTestId( 'slots' );
+
+		await expect( slot2 ).toHaveText( '[2]' );
+
+		await slot2.click();
+
+		await expect( slot2 ).toHaveText( '[2 updated]' );
+
+		await page.getByTestId( 'slot-2-button' ).click();
+
+		await expect( slots.getByTestId( 'fill' ) ).toBeVisible();
+		await expect( slots.locator( 'css= > *' ) ).toHaveText( [
+			'[1]',
+			'fill inside slots',
+			'[2 updated]',
+			'[3]',
+			'[4]',
+			'[5]',
+		] );
+	} );
+
+	test( 'should not be re-mounted when adding the fill after', async ( {
+		page,
+	} ) => {
+		const slot3 = page.getByTestId( 'slot-3' );
+		const slots = page.getByTestId( 'slots' );
+
+		await expect( slot3 ).toHaveText( '[3]' );
+
+		await slot3.click();
+
+		await expect( slot3 ).toHaveText( '[3 updated]' );
+
+		await page.getByTestId( 'slot-3-button' ).click();
+
+		await expect( slots.getByTestId( 'fill' ) ).toBeVisible();
+		await expect( slots.locator( 'css= > *' ) ).toHaveText( [
+			'[1]',
+			'[2]',
+			'[3 updated]',
+			'fill inside slots',
+			'[4]',
+			'[5]',
+		] );
+	} );
+} );

--- a/test/integration/fixtures/blocks/core__comments.json
+++ b/test/integration/fixtures/blocks/core__comments.json
@@ -5,6 +5,7 @@
 		"attributes": {
 			"tagName": "div",
 			"legacy": false,
+			"enhancedSubmission": false,
 			"className": "comments-post-extra"
 		},
 		"innerBlocks": [

--- a/test/integration/fixtures/blocks/core__post-comments.json
+++ b/test/integration/fixtures/blocks/core__post-comments.json
@@ -4,7 +4,8 @@
 		"isValid": true,
 		"attributes": {
 			"tagName": "div",
-			"legacy": true
+			"legacy": true,
+			"enhancedSubmission": false
 		},
 		"innerBlocks": []
 	}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

<!-- In a few words, what is the PR actually doing? -->

Built on top of https://github.com/WordPress/gutenberg/pull/53733. Supersedes https://github.com/WordPress/gutenberg/pull/49305.

This PR adds an option to the Comments block to replace the current server-side form submission with a client-side one.

## Why?

<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

To improve the user experience.

## How?

<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

The form submission is intercepted using a directive (`data-wp-on--submit`), which stops the regular form behavior and makes an HTTP request using JavaScript. If the submission goes through successfully, the comments list is updated with the HTML response. If the submission fails, the problem is shown on the screen.

## Tasks

There are still many tasks that need to be done before this can be considered ready. I'll probably add more as we progress and find out what needs to be done.

- [x] Add a UI option to the Comments block. This is disabled by default.
- [x] Only add `data-wp-navigation-id` if the option is enabled.
- [x] Pass down that option using Block Context.
- [x] Only add the directives, `supports.interactivity` and enqueue the `view.js` file in the Post Comments Form block if the option is enabled.
- [x] Add `data-wp-key` to the individual comments.
- [x] If something fails in the JS logic, fall back to server-side submission.
- [x] Include the hash with the comment ID in the URL to facilitate linking.
- [x] Scroll to the new comment on success.
- [x] Add loading status while sending the comment.
- [x] Scroll to the error on failure (if it's not already on the screen).
- [x] Add accessibility.
- [x] Improve the error display (styles).
- [x] Move the form when the `reply` buttons are clicked.
- [x] Reset the position of the form when it is successfully submitted.
- [x] Change the hidden input that holds the parent comment id when using the `reply` button.
- [x] Changed the form title to "Reply to Author" when using the `reply` button.
- [x] Show the `cancel reply` buttons when using the `reply` button.
- [x] Control all the inputs so they are not wiped out when the form is moved around.
- [x] Move improved `data-wp-bind` logic to its own PR. https://github.com/WordPress/gutenberg/pull/54003
- [x] Move `data-wp-slot`/`data-wp-fill` implementation to its own PR. https://github.com/WordPress/gutenberg/pull/53958

### Tasks left for subsequent PRs

- Render the error message using `data-wp-dangerous-html` instead of `data-wp-text`.
- Display a popup when a user tries to enable the enhanced submission and the Comments Form block is not included inside the Comments block. The user should be able to choose between canceling the action, or adding the Comments Form block (added at the end) using buttons in the popup.
- Let people configure the position and styles of the error messages using a different block.
- Improve the loading indicator. It'd be better not to change the text of the submit button and use an animation instead.
- Move the error styles to a separate CSS file and only enqueue it when the enhanced submission is activated.
- Don't move the scroll to the elements if they are already inside the viewport.
- Add a `dom` option to `navigate` that accepts the parsed DOM instead of the `html` and use that instead of the `html`.
- Maintain focus and selected text range after moving the form below the comment being replied to.

## Testing Instructions

<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

To test the initial implementation:

- Add or use a template with the Comments block.
- Submit a comment.
- The page should not refresh, and the new comment should appear on the screen.
- If there's an error, you should see the error below the submit button.
- The number of comments should be updated.
- If the comment is awaiting moderation, the message should appear.

### Testing Instructions for Keyboard

<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

None yet.

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/3305402/bc8a6fdd-2e72-467c-9ef5-da8c99672b81 


