### PR TITLE
Add missing aria roles to the 'Create pattern' menu item

### DIFF
--- a/packages/patterns/src/components/pattern-convert-button.js
+++ b/packages/patterns/src/components/pattern-convert-button.js
@@ -101,7 +101,12 @@ export default function PatternConvertButton( { clientIds, rootClientId } ) {
 	};
 	return (
 		<>
-			<MenuItem icon={ symbol } onClick={ () => setIsModalOpen( true ) }>
+			<MenuItem
+				icon={ symbol }
+				onClick={ () => setIsModalOpen( true ) }
+				aria-expanded={ isModalOpen }
+				aria-haspopup="dialog"
+			>
 				{ __( 'Create pattern' ) }
 			</MenuItem>
 			{ isModalOpen && (


### PR DESCRIPTION
## What?
Part of #24796.

PR adds the missing aria roles to the "Create pattern" menu item.

## Why?
The menu item opens a dialog but lacks the `aria-expanded` and `aria-haspopup` attributes.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
1. Open a post or page.
2. Insert a heading block.
3. Navigate to the "Options" button in the block toolbar.
4. Open the dropdown and navigate to the "Create pattern" menu item.
5. Confirm it has appropriate aria roles.

### Testing Instructions for Keyboard
Same

## Screenshots or screencast <!-- if applicable -->

![CleanShot 2023-08-16 at 17 55 15](https://github.com/WordPress/gutenberg/assets/240569/2d6705ed-355d-4d29-b649-fc95675025f6)
