### PR TITLE
E2E Playwright Utils: Automatically detect canvas type

### DIFF
--- a/packages/e2e-test-utils-playwright/src/admin/create-new-post.js
+++ b/packages/e2e-test-utils-playwright/src/admin/create-new-post.js
@@ -30,8 +30,10 @@ export async function createNewPost( {
 
 	await this.visitAdminPage( 'post-new.php', query );
 
-	// Wait for both iframed and non-iframed canvas locator and resolve once the
-	// currently available one is ready.
+	// Wait for both iframed and non-iframed canvas and resolve once the
+	// currently available one is ready. To make this work, we need an inner
+	// legacy canvas selector that is unavailable directly when the canvas is
+	// iframed.
 	await Promise.any( [
 		this.page.locator( '.wp-block-post-content' ).waitFor(),
 		this.page

--- a/packages/e2e-test-utils-playwright/src/admin/create-new-post.js
+++ b/packages/e2e-test-utils-playwright/src/admin/create-new-post.js
@@ -13,7 +13,6 @@ import { addQueryArgs } from '@wordpress/url';
  * @param {string}  [object.content]          Content of the new post.
  * @param {string}  [object.excerpt]          Excerpt of the new post.
  * @param {boolean} [object.showWelcomeGuide] Whether to show the welcome guide.
- * @param {boolean} [object.legacyCanvas]     Whether the non-iframed editor canvas is awaited.
  */
 export async function createNewPost( {
 	postType,
@@ -21,7 +20,6 @@ export async function createNewPost( {
 	content,
 	excerpt,
 	showWelcomeGuide = false,
-	legacyCanvas = false,
 } = {} ) {
 	const query = addQueryArgs( '', {
 		post_type: postType,
@@ -32,14 +30,16 @@ export async function createNewPost( {
 
 	await this.visitAdminPage( 'post-new.php', query );
 
-	const canvasReadyLocator = legacyCanvas
-		? this.page.locator( '.edit-post-layout' )
-		: this.page
-				.frameLocator( '[name=editor-canvas]' )
-				.locator( 'body > *' )
-				.first();
-
-	await canvasReadyLocator.waitFor();
+	// Wait for both iframed and non-iframed canvas locator and resolve once the
+	// currently available one is ready.
+	await Promise.any( [
+		this.page.locator( '.wp-block-post-content' ).waitFor(),
+		this.page
+			.frameLocator( '[name=editor-canvas]' )
+			.locator( 'body > *' )
+			.first()
+			.waitFor(),
+	] );
 
 	await this.page.evaluate( ( welcomeGuide ) => {
 		window.wp.data

--- a/test/e2e/specs/editor/plugins/wp-editor-meta-box.spec.js
+++ b/test/e2e/specs/editor/plugins/wp-editor-meta-box.spec.js
@@ -17,7 +17,7 @@ test.describe( 'WP Editor Meta Boxes', () => {
 	} );
 
 	test( 'Should save the changes', async ( { admin, editor, page } ) => {
-		await admin.createNewPost( { legacyCanvas: true } );
+		await admin.createNewPost();
 
 		// Add title to enable valid non-empty post save.
 		await editor.canvas.type(


### PR DESCRIPTION
Automatically handle waiting for the canvas locator when creating a new page, regardless of whether it's iframed or not. This should prevent issues like [this one](https://github.com/WordPress/gutenberg/pull/53741).