### PR TITLE
Storybook: Show main story before description

### DIFF
--- a/storybook/preview.js
+++ b/storybook/preview.js
@@ -1,4 +1,16 @@
 /**
+ * External dependencies
+ */
+import {
+	Controls,
+	Description,
+	Primary,
+	Stories,
+	Subtitle,
+	Title,
+} from '@storybook/blocks';
+
+/**
  * Internal dependencies
  */
 import { WithGlobalCSS } from './decorators/with-global-css';
@@ -89,6 +101,20 @@ export const decorators = [
 export const parameters = {
 	controls: {
 		sort: 'requiredFirst',
+	},
+	docs: {
+		// Flips the order of the description and the primary component story
+		// so the component is always visible before the fold.
+		page: () => (
+			<>
+				<Title />
+				<Subtitle />
+				<Primary />
+				<Description />
+				<Controls />
+				<Stories includePrimary={ false } />
+			</>
+		),
 	},
 	options: {
 		storySort: {


### PR DESCRIPTION
Follow-up to #53520 

## What?

Customizes the block order of our auto-generated docs so that the primary component story appears before the component description.

## Why?

To guarantee that the component is visible "above the fold" and not buried below a potentially long description block. This is especially important now that the Docs view is the default page that shows when you click a component in the sidebar.

## Testing Instructions

1. `npm run storybook:dev`
2. Smoke test some component Docs pages to see the order of the main story and description flipped. Everything else should be the same.

## Screenshots or screencast <!-- if applicable -->

| Before | After |
|--------|-------|
|<img src="https://github.com/WordPress/gutenberg/assets/555336/d7b1674c-4fe7-4ca8-922b-a39f1556f5eb" alt="Description comes before story" width="400">|<img src="https://github.com/WordPress/gutenberg/assets/555336/e05581f2-33dd-478c-bfc0-13c7b1957def" alt="Description comes after story" width="400">|




