### PR TITLE
Add missing aria roles to the 'Create template part' menu item

### DIFF
--- a/packages/edit-site/src/components/template-part-converter/convert-to-template-part.js
+++ b/packages/edit-site/src/components/template-part-converter/convert-to-template-part.js
@@ -56,6 +56,8 @@ export default function ConvertToTemplatePart( { clientIds, blocks } ) {
 				onClick={ () => {
 					setIsModalOpen( true );
 				} }
+				aria-expanded={ isModalOpen }
+				aria-haspopup="dialog"
 			>
 				{ __( 'Create template part' ) }
 			</MenuItem>


### PR DESCRIPTION
## What?
Part of https://github.com/WordPress/gutenberg/issues/24796.

PR adds the missing aria roles to the "Create template part" menu item.

## Why?
The menu item opens a dialog but lacks the `aria-expanded` and `aria-haspopup` attributes.

## Testing Instructions
1. Open a template in the Site Editor
2. Insert a block block.
3. Navigate to the "Options" button in the block toolbar.
4. Open the dropdown and navigate to the "Create template part" menu item.
5. Confirm it has appropriate aria roles.

### Testing Instructions for Keyboard
Same

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2023-08-17 at 09 06 28](https://github.com/WordPress/gutenberg/assets/240569/61b1ecde-f152-4faf-946e-757584945f0f)
