### PR TITLE
Add missing aria roles to the 'Replace template part' menu item

### DIFF
--- a/packages/block-library/src/template-part/edit/index.js
+++ b/packages/block-library/src/template-part/edit/index.js
@@ -169,6 +169,10 @@ export default function TemplatePartEdit( {
 									onClick={ () => {
 										setIsTemplatePartSelectionOpen( true );
 									} }
+									aria-expanded={
+										isTemplatePartSelectionOpen
+									}
+									aria-haspopup="dialog"
 								>
 									{ createInterpolateElement(
 										__( 'Replace <BlockTitle />' ),


### PR DESCRIPTION
## What?
Part of #24796.
This is similar to #53754.

PR adds the missing aria roles to the "Replace template part" menu item.

## Why?
The menu item opens a dialog but lacks the `aria-expanded` and `aria-haspopup` attributes.

## Testing Instructions
1. Open a template in the Site Editor
2. Insert a block block.
3. Navigate to the "Options" button in the block toolbar.
4. Open the dropdown and navigate to the "Replace <TemplatePartName>" menu item.
5. Confirm it has appropriate aria roles.

### Testing Instructions for Keyboard
Same

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2023-08-17 at 09 23 31](https://github.com/WordPress/gutenberg/assets/240569/bf607a4d-21ba-41eb-892f-0e0ea394a48b)
