### PR TITLE
List View: Allow replacing template part when a block isn't selected

### DIFF
--- a/packages/block-library/src/template-part/edit/index.js
+++ b/packages/block-library/src/template-part/edit/index.js
@@ -34,7 +34,6 @@ export default function TemplatePartEdit( {
 	attributes,
 	setAttributes,
 	clientId,
-	isSelected,
 } ) {
 	const { slug, theme, tagName, layout = {} } = attributes;
 	const templatePartId = createTemplatePartId( theme, slug );
@@ -91,10 +90,7 @@ export default function TemplatePartEdit( {
 	const isEntityAvailable = ! isPlaceholder && ! isMissing && isResolved;
 	const TagName = tagName || areaObject.tagName;
 
-	// The `isSelected` check ensures the `BlockSettingsMenuControls` fill
-	// doesn't render multiple times. The block controls has similar internal check.
 	const canReplace =
-		isSelected &&
 		isEntityAvailable &&
 		hasReplacements &&
 		( area === 'header' || area === 'footer' );
@@ -156,25 +152,38 @@ export default function TemplatePartEdit( {
 				) }
 				{ canReplace && (
 					<BlockSettingsMenuControls>
-						{ () => (
-							<MenuItem
-								onClick={ () => {
-									setIsTemplatePartSelectionOpen( true );
-								} }
-							>
-								{ createInterpolateElement(
-									__( 'Replace <BlockTitle />' ),
-									{
-										BlockTitle: (
-											<BlockTitle
-												clientId={ clientId }
-												maximumLength={ 25 }
-											/>
-										),
-									}
-								) }
-							</MenuItem>
-						) }
+						{ ( { selectedClientIds } ) => {
+							// Only enable for single selection that matches the current block.
+							// Ensures menu item doesn't render multiple times.
+							if (
+								! (
+									selectedClientIds.length === 1 &&
+									clientId === selectedClientIds[ 0 ]
+								)
+							) {
+								return null;
+							}
+
+							return (
+								<MenuItem
+									onClick={ () => {
+										setIsTemplatePartSelectionOpen( true );
+									} }
+								>
+									{ createInterpolateElement(
+										__( 'Replace <BlockTitle />' ),
+										{
+											BlockTitle: (
+												<BlockTitle
+													clientId={ clientId }
+													maximumLength={ 25 }
+												/>
+											),
+										}
+									) }
+								</MenuItem>
+							);
+						} }
 					</BlockSettingsMenuControls>
 				) }
 				{ isEntityAvailable && (


### PR DESCRIPTION
## What?
Fixes #50928.

PR allows replacing a template part from List View block options when the block itself isn't selected.

## Why?
This makes the feature consistent with block options in the toolbar.

## How?
I've replaced the block level `isSelected` safeguard with a similar check inside the `BlockSettingsMenuControls` render callback.

Props to @getdave for inspiration.

P.S. I noticed that the focus isn't returned to the "Options" dropdown after replacement. Probably due to that, the new component in the list view is replaced, unmounting the old one and mounting the new one.

This also happens on the `trunk`; we should investigate this separately.

## Testing Instructions
1. Open a template in Site Editor.
2. Insert multiple `footer` or `header` area template parts.
3. Open the List View and select any other block.
4. Open the options for one of the inserted template parts without selecting the block.
5. Confirm that replace menu item is displayed only once.
6. Confirm action successfully replaces the correct template part block.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2023-08-17 at 09 53 41](https://github.com/WordPress/gutenberg/assets/240569/fb2ed40b-c752-4dce-ad21-d24f72b60b70)
