### PR TITLE
Editor: Fix the 'useSelect' warning in the 'useIsDirty' hook

### DIFF
--- a/packages/editor/src/components/entities-saved-states/hooks/use-is-dirty.js
+++ b/packages/editor/src/components/entities-saved-states/hooks/use-is-dirty.js
@@ -3,7 +3,7 @@
  */
 import { useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
-import { useState } from '@wordpress/element';
+import { useMemo, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 const TRANSLATED_SITE_PROPERTIES = {
@@ -18,38 +18,34 @@ const TRANSLATED_SITE_PROPERTIES = {
 };
 
 export const useIsDirty = () => {
-	const { dirtyEntityRecords } = useSelect( ( select ) => {
-		const dirtyRecords =
-			select( coreStore ).__experimentalGetDirtyEntityRecords();
+	const { editedEntities, siteEdits } = useSelect( ( select ) => {
+		const { __experimentalGetDirtyEntityRecords, getEntityRecordEdits } =
+			select( coreStore );
 
+		return {
+			editedEntities: __experimentalGetDirtyEntityRecords(),
+			siteEdits: getEntityRecordEdits( 'root', 'site' ),
+		};
+	}, [] );
+
+	const dirtyEntityRecords = useMemo( () => {
 		// Remove site object and decouple into its edited pieces.
-		const dirtyRecordsWithoutSite = dirtyRecords.filter(
+		const editedEntitiesWithoutSite = editedEntities.filter(
 			( record ) => ! ( record.kind === 'root' && record.name === 'site' )
 		);
 
-		const siteEdits = select( coreStore ).getEntityRecordEdits(
-			'root',
-			'site'
-		);
-
-		const siteEditsAsEntities = [];
+		const editedSiteEntities = [];
 		for ( const property in siteEdits ) {
-			siteEditsAsEntities.push( {
+			editedSiteEntities.push( {
 				kind: 'root',
 				name: 'site',
 				title: TRANSLATED_SITE_PROPERTIES[ property ] || property,
 				property,
 			} );
 		}
-		const dirtyRecordsWithSiteItems = [
-			...dirtyRecordsWithoutSite,
-			...siteEditsAsEntities,
-		];
 
-		return {
-			dirtyEntityRecords: dirtyRecordsWithSiteItems,
-		};
-	}, [] );
+		return [ ...editedEntitiesWithoutSite, ...editedSiteEntities ];
+	}, [ editedEntities, siteEdits ] );
 
 	// Unchecked entities to be ignored by save function.
 	const [ unselectedEntities, _setUnselectedEntities ] = useState( [] );


### PR DESCRIPTION
## What?
This is a follow-up to #50863.

PR fixes the following warning triggered by the `useIsDirty` hook:

```
The 'useSelect' hook returns different values when called with the same state and parameters.
```

## Why?
Array operations like `filter` and `map` will return a new array on each mapSelect call. This can cause unnecessary rerenders. See #53666.

## How?
I moved the filtering logic outside into the `useMemo` hook. Similar to #53596.

## Testing Instructions
1. Open the Site Editor and add the following to your URL: `?theme_preview=[themePath]`, where `themePath` is the relative path to the theme you want to preview (e.g., `twentytwentythree`).
2. Edit a template.
3. Confirm the "Activate" button changes into an "Activate & Save".
4. Unchecking the edited entity changes button label back.

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/240569/40b85d65-3504-448d-8ccc-5322162d8bbb

![CleanShot 2023-08-17 at 13 54 04](https://github.com/WordPress/gutenberg/assets/240569/bc9573d9-aa6b-42b2-916a-d94f575a8e5b)
