### PR TITLE
Default appender: Hide the dashed indicator until ancestor is selected.

### DIFF
--- a/packages/block-editor/src/components/button-block-appender/content.scss
+++ b/packages/block-editor/src/components/button-block-appender/content.scss
@@ -35,6 +35,7 @@
 
 // When the appender shows up in empty container blocks, such as Group and Columns, add an extra click state.
 .block-list-appender:only-child {
+	// One level of nesting
 	.is-layout-constrained.block-editor-block-list__block:not(.is-selected) > &,
 	.is-layout-flow.block-editor-block-list__block:not(.is-selected) > &,
 	// Legacy groups have an inner container so need to be targeted separately
@@ -69,6 +70,13 @@
 		}
 	}
 
+	// Hide the dashed outline in 2-level nested cases, so for example the dashed
+	// empty column is only shown when the columns block is selected.
+	.block-editor-block-list__block:not(.is-selected) > .block-editor-block-list__block > &::after {
+		border: none;
+	}
+
+	// Drop zone.
 	&.is-drag-over .block-editor-button-block-appender {
 		background-color: var(--wp-admin-theme-color);
 		box-shadow: inset 0 0 0 $border-width $light-gray-placeholder;


### PR DESCRIPTION
## What?

Currently when using the Columns block for certain layouts, an empty column will show a dashed outline indicator, as shown in this GIF:

![currently](https://github.com/WordPress/gutenberg/assets/1204802/516b78d9-10d3-4666-bf51-11dc349eeb9d)

The dashed outline indicator comes from the appender block, and serves both to indicate an empty container, and to serve as a clickable area to _select the block itself_, because when the block gets selected it becomes an inserter.

But for column based layouts, occasionally you _want_ a column to be empty, to stay that way to simply space out a layout. That breaks with WYSIWYG. 

This PR changes it so that the appender in 2 level nesting cases (i.e. columns), the appender is invisible until an ancestor has been selected first. In other words, if you have an intentionally empty column, the dashed indicator won't show up for the empty _column_ until the _columns_ block itself has been selected, as shown in this GIF:

![hidden until selected](https://github.com/WordPress/gutenberg/assets/1204802/207138fd-068d-4e0e-b265-1296297e4b66)

The group, row, and stack empty states remain the same as before:
<img width="724" alt="group resting state" src="https://github.com/WordPress/gutenberg/assets/1204802/c883e0ed-9b55-466e-9c45-60f8e90a81e9">

<img width="669" alt="row" src="https://github.com/WordPress/gutenberg/assets/1204802/273b5875-fd8f-4c51-b15f-6c1b6463843d">

<img width="663" alt="stack" src="https://github.com/WordPress/gutenberg/assets/1204802/f507e516-36d8-4996-8d4f-7402f004f820">

## Testing Instructions

Insert a columns block with content in one column, and no content in the other. Deselect it, and observe that the empty column should visually appear empty, with no dashed line indicators until you select the columns block.