### PR TITLE
Add init.js module for the Footnotes block

### DIFF
--- a/packages/block-library/src/footnotes/init.js
+++ b/packages/block-library/src/footnotes/init.js
@@ -1,0 +1,6 @@
+/**
+ * Internal dependencies
+ */
+import { init } from './';
+
+export default init();


### PR DESCRIPTION
Add an `init` module for the `footnotes` blocks. Allows importing blocks individually, as introduced in #42258. Async block loading makes use of these `init` modules.