### PR TITLE
Simplify check for no posts in query-no-results block

### DIFF
--- a/packages/block-library/src/query-no-results/index.php
+++ b/packages/block-library/src/query-no-results/index.php
@@ -32,12 +32,8 @@ function render_block_core_query_no_results( $attributes, $content, $block ) {
 		$query      = new WP_Query( $query_args );
 	}
 
-	if ( $query->have_posts() ) {
+	if ( $query->post_count > 0 ) {
 		return '';
-	}
-
-	if ( ! $use_global_query ) {
-		wp_reset_postdata();
 	}
 
 	$classes            = ( isset( $attributes['style']['elements']['link']['color']['text'] ) ) ? 'has-link-color' : '';


### PR DESCRIPTION
## What?
Replace `have_posts()` check with the `post_count` property to workaround queries which haven't rewinded properly. 

## Why?
Fixes #47793.

## How?
Instead of setting up the query loop, just check if post count is > 0 and bail.

## Testing Instructions
See #47793.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
