### PR TITLE
Document the naming convention for `block-library` PHP functions

### DIFF
--- a/packages/block-library/README.md
+++ b/packages/block-library/README.md
@@ -123,17 +123,19 @@ To find out more about contributing to this package or Gutenberg as a whole, ple
 
 All PHP function names within the subdirectories of the `packages/block-library/src/` directory should start with one of the following prefixes:
 
-- `block_core_<directory_name>`
-- `render_block_core_<directory_name>`
-- `register_block_core_<directory_name>`
+-   `block_core_<directory_name>`
+-   `render_block_core_<directory_name>`
+-   `register_block_core_<directory_name>`
 
 In this context, `<directory_name>` represents the name of the directory where the corresponding `.php` file is located.
 The directory name is converted to lowercase, and any characters except for letters and digits are replaced with underscores.
 
 #### Example:
+
 For the PHP functions in the `packages/block-library/src/my-block/index.php` file, the correct prefixes would be:
-- `block_core_my_block`
-- `render_block_core_my_block`
-- `register_block_core_my_block`
+
+-   `block_core_my_block`
+-   `render_block_core_my_block`
+-   `register_block_core_my_block`
 
 <br /><br /><p align="center"><img src="https://s.w.org/style/images/codeispoetry.png?1" alt="Code is Poetry." /></p>

--- a/packages/block-library/README.md
+++ b/packages/block-library/README.md
@@ -132,7 +132,7 @@ The directory name is converted to lowercase, and any characters except for lett
 
 #### Example:
 
-For the PHP functions in the `packages/block-library/src/my-block/index.php` file, the correct prefixes would be:
+For the PHP functions declared in the `packages/block-library/src/my-block/index.php` file, the correct prefixes would be:
 
 -   `block_core_my_block`
 -   `render_block_core_my_block`

--- a/packages/block-library/README.md
+++ b/packages/block-library/README.md
@@ -121,7 +121,7 @@ To find out more about contributing to this package or Gutenberg as a whole, ple
 
 ### Naming convention for PHP functions
 
-All PHP function names within the subdirectories of the `packages/block-library/src/` directory should start with one of the following prefixes:
+All PHP function names declared within the subdirectories of the `packages/block-library/src/` directory should start with one of the following prefixes:
 
 -   `block_core_<directory_name>`
 -   `render_block_core_<directory_name>`

--- a/packages/block-library/README.md
+++ b/packages/block-library/README.md
@@ -83,7 +83,7 @@ To find out more about contributing to this package or Gutenberg as a whole, ple
     }
     ```
 
-2.  Register the block in the `gutenberg_reregister_core_block_types()` function of the [`lib/blocks.php`](https://github.com/WordPress/gutenberg/blob/trunk/lib/blocks.php) file. Add it to the `block_folders` array if it's a [static block](https://developer.wordpress.org/block-editor/explanations/glossary/#static-block) or to the `block_names` array if it's a [dynamic block](https://developer.wordpress.org/block-editor/explanations/glossary/#dynamic-block).
+2.  Register the block in the `gutenberg_reregister_core_block_types()` function of the [`lib/blocks.php`](https://github.com/WordPress/gutenberg/blob/trunk/lib/blocks.php) file. Add it to the `block_directories` array if it's a [static block](https://developer.wordpress.org/block-editor/explanations/glossary/#static-block) or to the `block_names` array if it's a [dynamic block](https://developer.wordpress.org/block-editor/explanations/glossary/#dynamic-block).
 
 3.  Add `init.js` file to the directory of the new block:
 
@@ -118,5 +118,22 @@ To find out more about contributing to this package or Gutenberg as a whole, ple
     	return $content;
     }
     ```
+
+### Naming convention for PHP functions
+
+All PHP function names within the subdirectories of the `packages/block-library/src/` directory should start with one of the following prefixes:
+
+- `block_core_<directory_name>`
+- `render_block_core_<directory_name>`
+- `register_block_core_<directory_name>`
+
+In this context, `<directory_name>` represents the name of the directory where the corresponding `.php` file is located.
+The directory name is converted to lowercase, and any characters except for letters and digits are replaced with underscores.
+
+#### Example:
+For the PHP functions in the `packages/block-library/src/my-block/index.php` file, the correct prefixes would be:
+- `block_core_my_block`
+- `render_block_core_my_block`
+- `register_block_core_my_block`
 
 <br /><br /><p align="center"><img src="https://s.w.org/style/images/codeispoetry.png?1" alt="Code is Poetry." /></p>

--- a/packages/block-library/README.md
+++ b/packages/block-library/README.md
@@ -83,7 +83,7 @@ To find out more about contributing to this package or Gutenberg as a whole, ple
     }
     ```
 
-2.  Register the block in the `gutenberg_reregister_core_block_types()` function of the [`lib/blocks.php`](https://github.com/WordPress/gutenberg/blob/trunk/lib/blocks.php) file. Add it to the `block_directories` array if it's a [static block](https://developer.wordpress.org/block-editor/explanations/glossary/#static-block) or to the `block_names` array if it's a [dynamic block](https://developer.wordpress.org/block-editor/explanations/glossary/#dynamic-block).
+2.  Register the block in the `gutenberg_reregister_core_block_types()` function of the [`lib/blocks.php`](https://github.com/WordPress/gutenberg/blob/trunk/lib/blocks.php) file. Add it to the `block_folders` array if it's a [static block](https://developer.wordpress.org/block-editor/explanations/glossary/#static-block) or to the `block_names` array if it's a [dynamic block](https://developer.wordpress.org/block-editor/explanations/glossary/#dynamic-block).
 
 3.  Add `init.js` file to the directory of the new block:
 

--- a/test/php/gutenberg-coding-standards/Gutenberg/Sniffs/NamingConventions/ValidBlockLibraryFunctionNameSniff.php
+++ b/test/php/gutenberg-coding-standards/Gutenberg/Sniffs/NamingConventions/ValidBlockLibraryFunctionNameSniff.php
@@ -18,6 +18,8 @@ use PHP_CodeSniffer\Sniffs\Sniff;
  * determined by the parent directory name. It enforces that function names start
  * with one of the allowed prefixes defined in the sniffer configuration.
  *
+ * @link https://github.com/WordPress/gutenberg/blob/trunk/packages/block-library/README.md#naming-convention-for-php-functions
+ *
  * @package gutenberg/gutenberg-coding-standards
  *
  * @since   1.0.0


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

This PR is intended to document the following naming convention: https://github.com/WordPress/gutenberg/issues/52769#issuecomment-1669540435.
Fixes https://github.com/WordPress/gutenberg/issues/53732.

## Why?

Documenting every naming convention is essential.

## How?

- [x] Add the naming convention to the documentation.
- [x] Include a link to the documentation in `ValidBlockLibraryFunctionNameSniff`.

## Testing Instructions
Please review the suggested changes for accuracy, grammar, and style errors.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
