### PR TITLE
Proof of Concept: Improve Block Toolbar Semantics/Accessibility

### DIFF
--- a/docs/reference-guides/data/data-core-block-editor.md
+++ b/docs/reference-guides/data/data-core-block-editor.md
@@ -588,6 +588,18 @@ _Properties_
 -   _isDisabled_ `boolean`: Whether or not the user should be prevented from inserting this item.
 -   _frecency_ `number`: Heuristic that combines frequency and recency.
 
+### getLastFocus
+
+Returns the element of the last element that had focus when focus left the editor canvas.
+
+_Parameters_
+
+-   _state_ `Object`: Block editor state.
+
+_Returns_
+
+-   `Object`: Element.
+
 ### getLastMultiSelectedBlockClientId
 
 Returns the client ID of the last block in the multi-selection set, or null if there is no multi-selection.
@@ -1650,6 +1662,18 @@ _Parameters_
 
 -   _clientId_ `string`: The block's clientId.
 -   _hasControlledInnerBlocks_ `boolean`: True if the block's inner blocks are controlled.
+
+### setLastFocus
+
+Action that sets the element that had focus when focus leaves the editor canvas.
+
+_Parameters_
+
+-   _lastFocus_ `Object`: The last focused element.
+
+_Returns_
+
+-   `Object`: Action object.
 
 ### setNavigationMode
 

--- a/packages/block-editor/src/components/block-controls/slot.js
+++ b/packages/block-editor/src/components/block-controls/slot.js
@@ -42,7 +42,7 @@ export default function BlockControlsSlot( { group = 'default', ...props } ) {
 		return null;
 	}
 
-	const slot = <Slot { ...props } bubblesVirtually fillProps={ fillProps } />;
+	const slot = <Slot { ...props } fillProps={ fillProps } />;
 
 	if ( group === 'default' ) {
 		return slot;

--- a/packages/block-editor/src/components/block-tools/block-contextual-toolbar.js
+++ b/packages/block-editor/src/components/block-tools/block-contextual-toolbar.js
@@ -179,13 +179,13 @@ function BlockContextualToolbar( { focusOnMount, isFixed, ...props } ) {
 			className={ classes }
 			/* translators: accessibility text for the block toolbar */
 			aria-label={ __( 'Block tools' ) }
-			{ ...props }
-			onKeyDown={ ( event ) => {
+			onChildrenKeyDown={ ( event ) => {
 				if ( event.keyCode === ESCAPE && lastFocus?.current ) {
 					event.preventDefault();
 					lastFocus.current.focus();
 				}
 			} }
+			{ ...props }
 		>
 			{ ! isCollapsed && <BlockToolbar hideDragHandle={ isFixed } /> }
 			{ isFixed && isLargeViewport && blockType && (

--- a/packages/block-editor/src/components/block-tools/block-contextual-toolbar.js
+++ b/packages/block-editor/src/components/block-tools/block-contextual-toolbar.js
@@ -7,7 +7,7 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useEffect, useRef, useState } from '@wordpress/element';
+import { forwardRef, useEffect, useRef, useState } from '@wordpress/element';
 import { hasBlockSupport, store as blocksStore } from '@wordpress/blocks';
 import { useSelect } from '@wordpress/data';
 import {
@@ -27,7 +27,10 @@ import BlockToolbar from '../block-toolbar';
 import { store as blockEditorStore } from '../../store';
 import { useHasAnyBlockControls } from '../block-controls/use-has-block-controls';
 
-function BlockContextualToolbar( { focusOnMount, isFixed, ...props } ) {
+function UnforwardBlockContextualToolbar(
+	{ focusOnMount, isFixed, ...props },
+	ref
+) {
 	// When the toolbar is fixed it can be collapsed
 	const [ isCollapsed, setIsCollapsed ] = useState( false );
 	const toolbarButtonRef = useRef();
@@ -175,11 +178,12 @@ function BlockContextualToolbar( { focusOnMount, isFixed, ...props } ) {
 
 	return (
 		<NavigableToolbar
+			ref={ ref }
 			focusOnMount={ focusOnMount }
 			className={ classes }
 			/* translators: accessibility text for the block toolbar */
 			aria-label={ __( 'Block tools' ) }
-			onChildrenKeyDown={ ( event ) => {
+			handleOnKeyDown={ ( event ) => {
 				if ( event.keyCode === ESCAPE && lastFocus?.current ) {
 					event.preventDefault();
 					lastFocus.current.focus();
@@ -216,4 +220,4 @@ function BlockContextualToolbar( { focusOnMount, isFixed, ...props } ) {
 	);
 }
 
-export default BlockContextualToolbar;
+export default forwardRef( UnforwardBlockContextualToolbar );

--- a/packages/block-editor/src/components/block-tools/block-contextual-toolbar.js
+++ b/packages/block-editor/src/components/block-tools/block-contextual-toolbar.js
@@ -7,12 +7,7 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import {
-	useLayoutEffect,
-	useEffect,
-	useRef,
-	useState,
-} from '@wordpress/element';
+import { useEffect, useRef, useState } from '@wordpress/element';
 import { hasBlockSupport, store as blocksStore } from '@wordpress/blocks';
 import { useSelect } from '@wordpress/data';
 import {
@@ -82,77 +77,79 @@ function BlockContextualToolbar( { focusOnMount, isFixed, ...props } ) {
 		setIsCollapsed( false );
 	}, [ selectedBlockClientId ] );
 
-	const isLargerThanTabletViewport = useViewportMatch( 'large', '>=' );
-	const isFullscreen =
-		document.body.classList.contains( 'is-fullscreen-mode' );
+	// TODO: Do we need all of this width calculation??
 
-	useLayoutEffect( () => {
-		// don't do anything if not fixed toolbar
-		if ( ! isFixed || ! blockType ) {
-			return;
-		}
+	// const isLargerThanTabletViewport = useViewportMatch( 'large', '>=' );
+	// const isFullscreen =
+	// 	document.body.classList.contains( 'is-fullscreen-mode' );
 
-		const blockToolbar = document.querySelector(
-			'.block-editor-block-contextual-toolbar'
-		);
+	// useLayoutEffect( () => {
+	// 	// don't do anything if not fixed toolbar
+	// 	if ( ! isFixed || ! blockType ) {
+	// 		return;
+	// 	}
 
-		if ( ! blockToolbar ) {
-			return;
-		}
+	// 	const blockToolbar = document.querySelector(
+	// 		'.block-editor-block-contextual-toolbar'
+	// 	);
 
-		if ( ! isLargerThanTabletViewport ) {
-			// set the width of the toolbar to auto
-			blockToolbar.style = {};
-			return;
-		}
+	// 	if ( ! blockToolbar ) {
+	// 		return;
+	// 	}
 
-		if ( isCollapsed ) {
-			// set the width of the toolbar to auto
-			blockToolbar.style.width = 'auto';
-			return;
-		}
+	// 	if ( ! isLargerThanTabletViewport ) {
+	// 		// set the width of the toolbar to auto
+	// 		blockToolbar.style = {};
+	// 		return;
+	// 	}
 
-		// get the width of the pinned items in the post editor
-		const pinnedItems = document.querySelector(
-			'.edit-post-header__settings'
-		);
+	// 	if ( isCollapsed ) {
+	// 		// set the width of the toolbar to auto
+	// 		blockToolbar.style.width = 'auto';
+	// 		return;
+	// 	}
 
-		// get the width of the left header in the site editor
-		const leftHeader = document.querySelector(
-			'.edit-site-header-edit-mode__end'
-		);
+	// 	// get the width of the pinned items in the post editor
+	// 	const pinnedItems = document.querySelector(
+	// 		'.edit-post-header__settings'
+	// 	);
 
-		const computedToolbarStyle = window.getComputedStyle( blockToolbar );
-		const computedPinnedItemsStyle = pinnedItems
-			? window.getComputedStyle( pinnedItems )
-			: false;
-		const computedLeftHeaderStyle = leftHeader
-			? window.getComputedStyle( leftHeader )
-			: false;
+	// 	// get the width of the left header in the site editor
+	// 	const leftHeader = document.querySelector(
+	// 		'.edit-site-header-edit-mode__end'
+	// 	);
 
-		const marginLeft = parseFloat( computedToolbarStyle.marginLeft );
-		const pinnedItemsWidth = computedPinnedItemsStyle
-			? parseFloat( computedPinnedItemsStyle.width )
-			: 0;
-		const leftHeaderWidth = computedLeftHeaderStyle
-			? parseFloat( computedLeftHeaderStyle.width )
-			: 0;
+	// 	const computedToolbarStyle = window.getComputedStyle( blockToolbar );
+	// 	const computedPinnedItemsStyle = pinnedItems
+	// 		? window.getComputedStyle( pinnedItems )
+	// 		: false;
+	// 	const computedLeftHeaderStyle = leftHeader
+	// 		? window.getComputedStyle( leftHeader )
+	// 		: false;
 
-		// set the new witdth of the toolbar
-		blockToolbar.style.width = `calc(100% - ${
-			leftHeaderWidth +
-			pinnedItemsWidth +
-			marginLeft +
-			( pinnedItems || leftHeader ? 2 : 0 ) + // Prevents button focus border from being cut off
-			( isFullscreen ? 0 : 160 ) // the width of the admin sidebar expanded
-		}px)`;
-	}, [
-		isFixed,
-		isLargerThanTabletViewport,
-		isCollapsed,
-		isFullscreen,
-		blockType,
-	] );
+	// 	const marginLeft = parseFloat( computedToolbarStyle.marginLeft );
+	// 	const pinnedItemsWidth = computedPinnedItemsStyle
+	// 		? parseFloat( computedPinnedItemsStyle.width ) + 10 // 10 is the pinned items padding
+	// 		: 0;
+	// 	const leftHeaderWidth = computedLeftHeaderStyle
+	// 		? parseFloat( computedLeftHeaderStyle.width )
+	// 		: 0;
+
+	// 	// set the new witdth of the toolbar
+	//	blockToolbar.style.width = `calc(100% - ${
+	//		leftHeaderWidth +
+	//		pinnedItemsWidth +
+	// 		marginLeft +
+	// 		( pinnedItems || leftHeader ? 2 : 0 ) + // Prevents button focus border from being cut off
+	//		( isFullscreen ? 0 : 160 ) // the width of the admin sidebar expanded
+	//	}px)`;
+	// }, [
+	// 	isFixed,
+	// 	isLargerThanTabletViewport,
+	// 	isCollapsed,
+	// 	isFullscreen,
+	// 	blockType,
+	// ] );
 
 	const isToolbarEnabled =
 		! blockType ||

--- a/packages/block-editor/src/components/block-tools/block-contextual-toolbar.js
+++ b/packages/block-editor/src/components/block-tools/block-contextual-toolbar.js
@@ -17,7 +17,6 @@ import {
 } from '@wordpress/components';
 import { next, previous } from '@wordpress/icons';
 import { useViewportMatch } from '@wordpress/compose';
-import { ESCAPE } from '@wordpress/keycodes';
 
 /**
  * Internal dependencies
@@ -39,7 +38,6 @@ function UnforwardBlockContextualToolbar(
 	const {
 		blockType,
 		blockEditingMode,
-		lastFocus,
 		hasParents,
 		showParentSelector,
 		selectedBlockClientId,
@@ -47,7 +45,6 @@ function UnforwardBlockContextualToolbar(
 		const {
 			getBlockName,
 			getBlockParents,
-			getLastFocus,
 			getSelectedBlockClientIds,
 			getBlockEditingMode,
 		} = select( blockEditorStore );
@@ -65,7 +62,6 @@ function UnforwardBlockContextualToolbar(
 				_selectedBlockClientId &&
 				getBlockType( getBlockName( _selectedBlockClientId ) ),
 			blockEditingMode: getBlockEditingMode( _selectedBlockClientId ),
-			lastFocus: getLastFocus(),
 			hasParents: parents.length,
 			showParentSelector:
 				parentBlockType &&
@@ -183,12 +179,6 @@ function UnforwardBlockContextualToolbar(
 			className={ classes }
 			/* translators: accessibility text for the block toolbar */
 			aria-label={ __( 'Block tools' ) }
-			handleOnKeyDown={ ( event ) => {
-				if ( event.keyCode === ESCAPE && lastFocus?.current ) {
-					event.preventDefault();
-					lastFocus.current.focus();
-				}
-			} }
 			{ ...props }
 		>
 			{ ! isCollapsed && <BlockToolbar hideDragHandle={ isFixed } /> }

--- a/packages/block-editor/src/components/block-tools/block-contextual-toolbar.js
+++ b/packages/block-editor/src/components/block-tools/block-contextual-toolbar.js
@@ -17,6 +17,7 @@ import {
 } from '@wordpress/components';
 import { next, previous } from '@wordpress/icons';
 import { useViewportMatch } from '@wordpress/compose';
+import { ESCAPE } from '@wordpress/keycodes';
 
 /**
  * Internal dependencies
@@ -35,6 +36,7 @@ function BlockContextualToolbar( { focusOnMount, isFixed, ...props } ) {
 	const {
 		blockType,
 		blockEditingMode,
+		lastFocus,
 		hasParents,
 		showParentSelector,
 		selectedBlockClientId,
@@ -42,6 +44,7 @@ function BlockContextualToolbar( { focusOnMount, isFixed, ...props } ) {
 		const {
 			getBlockName,
 			getBlockParents,
+			getLastFocus,
 			getSelectedBlockClientIds,
 			getBlockEditingMode,
 		} = select( blockEditorStore );
@@ -59,6 +62,7 @@ function BlockContextualToolbar( { focusOnMount, isFixed, ...props } ) {
 				_selectedBlockClientId &&
 				getBlockType( getBlockName( _selectedBlockClientId ) ),
 			blockEditingMode: getBlockEditingMode( _selectedBlockClientId ),
+			lastFocus: getLastFocus(),
 			hasParents: parents.length,
 			showParentSelector:
 				parentBlockType &&
@@ -176,6 +180,12 @@ function BlockContextualToolbar( { focusOnMount, isFixed, ...props } ) {
 			/* translators: accessibility text for the block toolbar */
 			aria-label={ __( 'Block tools' ) }
 			{ ...props }
+			onKeyDown={ ( event ) => {
+				if ( event.keyCode === ESCAPE && lastFocus?.current ) {
+					event.preventDefault();
+					lastFocus.current.focus();
+				}
+			} }
 		>
 			{ ! isCollapsed && <BlockToolbar hideDragHandle={ isFixed } /> }
 			{ isFixed && isLargeViewport && blockType && (

--- a/packages/block-editor/src/components/block-tools/empty-block-inserter.js
+++ b/packages/block-editor/src/components/block-tools/empty-block-inserter.js
@@ -6,21 +6,16 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { useRef, useEffect } from '@wordpress/element';
 import { isUnmodifiedDefaultBlock } from '@wordpress/blocks';
-import { useDispatch, useSelect } from '@wordpress/data';
-import { useShortcut } from '@wordpress/keyboard-shortcuts';
+import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
-import BlockSelectionButton from './block-selection-button';
-import BlockContextualToolbar from './block-contextual-toolbar';
 import { store as blockEditorStore } from '../../store';
 import BlockPopover from '../block-popover';
 import useBlockToolbarPopoverProps from './use-block-toolbar-popover-props';
 import Inserter from '../inserter';
-import { useShouldContextualToolbarShow } from '../../utils/use-should-contextual-toolbar-show';
 
 function selector( select ) {
 	const {
@@ -40,7 +35,7 @@ function selector( select ) {
 	};
 }
 
-function SelectedBlockPopover( {
+function EmptyBlockInserter( {
 	clientId,
 	rootClientId,
 	isEmptyDefaultBlock,
@@ -48,10 +43,7 @@ function SelectedBlockPopover( {
 	__unstablePopoverSlot,
 	__unstableContentRef,
 } ) {
-	const { editorMode, hasMultiSelection, isTyping, lastClientId } = useSelect(
-		selector,
-		[]
-	);
+	const { editorMode, isTyping, lastClientId } = useSelect( selector, [] );
 
 	const isInsertionPointVisible = useSelect(
 		( select ) => {
@@ -71,42 +63,9 @@ function SelectedBlockPopover( {
 		},
 		[ clientId ]
 	);
-	const isToolbarForced = useRef( false );
-	const { shouldShowContextualToolbar, canFocusHiddenToolbar } =
-		useShouldContextualToolbarShow();
-
-	const { stopTyping } = useDispatch( blockEditorStore );
 
 	const showEmptyBlockSideInserter =
 		! isTyping && editorMode === 'edit' && isEmptyDefaultBlock;
-	const shouldShowBreadcrumb =
-		! hasMultiSelection &&
-		( editorMode === 'navigation' || editorMode === 'zoom-out' );
-
-	useShortcut(
-		'core/block-editor/focus-toolbar',
-		() => {
-			isToolbarForced.current = true;
-			stopTyping( true );
-		},
-		{
-			isDisabled: ! canFocusHiddenToolbar,
-		}
-	);
-
-	useEffect( () => {
-		isToolbarForced.current = false;
-	} );
-
-	// Stores the active toolbar item index so the block toolbar can return focus
-	// to it when re-mounting.
-	const initialToolbarItemIndexRef = useRef();
-
-	useEffect( () => {
-		// Resets the index whenever the active block changes so this is not
-		// persisted. See https://github.com/WordPress/gutenberg/pull/25760#issuecomment-717906169
-		initialToolbarItemIndexRef.current = undefined;
-	}, [ clientId ] );
 
 	const popoverProps = useBlockToolbarPopoverProps( {
 		contentElement: __unstableContentRef?.current,
@@ -139,48 +98,6 @@ function SelectedBlockPopover( {
 						__experimentalIsQuick
 					/>
 				</div>
-			</BlockPopover>
-		);
-	}
-
-	if ( shouldShowBreadcrumb || shouldShowContextualToolbar ) {
-		return (
-			<BlockPopover
-				clientId={ capturingClientId || clientId }
-				bottomClientId={ lastClientId }
-				className={ classnames(
-					'block-editor-block-list__block-popover',
-					{
-						'is-insertion-point-visible': isInsertionPointVisible,
-					}
-				) }
-				__unstablePopoverSlot={ __unstablePopoverSlot }
-				__unstableContentRef={ __unstableContentRef }
-				resize={ false }
-				{ ...popoverProps }
-			>
-				{ shouldShowContextualToolbar && (
-					<BlockContextualToolbar
-						// If the toolbar is being shown because of being forced
-						// it should focus the toolbar right after the mount.
-						focusOnMount={ isToolbarForced.current }
-						__experimentalInitialIndex={
-							initialToolbarItemIndexRef.current
-						}
-						__experimentalOnIndexChange={ ( index ) => {
-							initialToolbarItemIndexRef.current = index;
-						} }
-						// Resets the index whenever the active block changes so
-						// this is not persisted. See https://github.com/WordPress/gutenberg/pull/25760#issuecomment-717906169
-						key={ clientId }
-					/>
-				) }
-				{ shouldShowBreadcrumb && (
-					<BlockSelectionButton
-						clientId={ clientId }
-						rootClientId={ rootClientId }
-					/>
-				) }
 			</BlockPopover>
 		);
 	}
@@ -230,7 +147,7 @@ function wrapperSelector( select ) {
 	};
 }
 
-export default function WrappedBlockPopover( {
+export default function WrappedEmptyBlockInserter( {
 	__unstablePopoverSlot,
 	__unstableContentRef,
 } ) {
@@ -253,7 +170,7 @@ export default function WrappedBlockPopover( {
 	}
 
 	return (
-		<SelectedBlockPopover
+		<EmptyBlockInserter
 			clientId={ clientId }
 			rootClientId={ rootClientId }
 			isEmptyDefaultBlock={ isEmptyDefaultBlock }

--- a/packages/block-editor/src/components/block-tools/index.js
+++ b/packages/block-editor/src/components/block-tools/index.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { useSelect, useDispatch } from '@wordpress/data';
-import { Popover } from '@wordpress/components';
+import { Fill, Popover } from '@wordpress/components';
 import { __unstableUseShortcutEventMatch as useShortcutEventMatch } from '@wordpress/keyboard-shortcuts';
 import { useRef } from '@wordpress/element';
 
@@ -14,6 +14,7 @@ import {
 	default as InsertionPoint,
 } from './insertion-point';
 import EmptyBlockInserter from './empty-block-inserter';
+import SelectedBlockTools from './selected-block-tools';
 import { store as blockEditorStore } from '../../store';
 import usePopoverScroll from '../block-popover/use-popover-scroll';
 import ZoomOutModeInserters from './zoom-out-mode-inserters';
@@ -43,7 +44,10 @@ export default function BlockTools( {
 	__unstableContentRef,
 	...props
 } ) {
-	const { isZoomOutMode, isTyping } = useSelect( selector, [] );
+	const { hasFixedToolbar, isZoomOutMode, isTyping } = useSelect(
+		selector,
+		[]
+	);
 	const isMatch = useShortcutEventMatch();
 	const { getSelectedBlockClientIds, getBlockRootClientId } =
 		useSelect( blockEditorStore );
@@ -135,6 +139,9 @@ export default function BlockTools( {
 				<EmptyBlockInserter
 					__unstableContentRef={ __unstableContentRef }
 				/>
+				<Fill name="__experimentalSelectedBlockTools">
+					<SelectedBlockTools isFixed={ hasFixedToolbar } />
+				</Fill>
 				{ /* Used for the inline rich text toolbar. */ }
 				<Popover.Slot name="block-toolbar" ref={ blockToolbarRef } />
 				{ children }

--- a/packages/block-editor/src/components/block-tools/index.js
+++ b/packages/block-editor/src/components/block-tools/index.js
@@ -2,7 +2,6 @@
  * WordPress dependencies
  */
 import { useSelect, useDispatch } from '@wordpress/data';
-import { useViewportMatch } from '@wordpress/compose';
 import { Popover } from '@wordpress/components';
 import { __unstableUseShortcutEventMatch as useShortcutEventMatch } from '@wordpress/keyboard-shortcuts';
 import { useRef } from '@wordpress/element';
@@ -14,9 +13,8 @@ import {
 	InsertionPointOpenRef,
 	default as InsertionPoint,
 } from './insertion-point';
-import SelectedBlockPopover from './selected-block-popover';
+import EmptyBlockInserter from './empty-block-inserter';
 import { store as blockEditorStore } from '../../store';
-import BlockContextualToolbar from './block-contextual-toolbar';
 import usePopoverScroll from '../block-popover/use-popover-scroll';
 import ZoomOutModeInserters from './zoom-out-mode-inserters';
 
@@ -45,11 +43,7 @@ export default function BlockTools( {
 	__unstableContentRef,
 	...props
 } ) {
-	const isLargeViewport = useViewportMatch( 'medium' );
-	const { hasFixedToolbar, isZoomOutMode, isTyping } = useSelect(
-		selector,
-		[]
-	);
+	const { isZoomOutMode, isTyping } = useSelect( selector, [] );
 	const isMatch = useShortcutEventMatch();
 	const { getSelectedBlockClientIds, getBlockRootClientId } =
 		useSelect( blockEditorStore );
@@ -138,13 +132,7 @@ export default function BlockTools( {
 						__unstableContentRef={ __unstableContentRef }
 					/>
 				) }
-				{ ! isZoomOutMode &&
-					( hasFixedToolbar || ! isLargeViewport ) && (
-						<BlockContextualToolbar isFixed />
-					) }
-				{ /* Even if the toolbar is fixed, the block popover is still
-					needed for navigation and zoom-out mode. */ }
-				<SelectedBlockPopover
+				<EmptyBlockInserter
 					__unstableContentRef={ __unstableContentRef }
 				/>
 				{ /* Used for the inline rich text toolbar. */ }

--- a/packages/block-editor/src/components/block-tools/index.js
+++ b/packages/block-editor/src/components/block-tools/index.js
@@ -62,6 +62,9 @@ export default function BlockTools( {
 		moveBlocksDown,
 	} = useDispatch( blockEditorStore );
 
+	// If we go with removing bubblesVirtually from the block controls slot,
+	// we can also remove all of this and all the navigable toolbar forwardRef stuff,
+	// as we don't need to stop the escape unselect shortcut from hitting first.
 	const selectedBlockToolsRef = useRef( null );
 
 	function onKeyDown( event ) {
@@ -106,15 +109,6 @@ export default function BlockTools( {
 				insertBeforeBlock( clientIds[ 0 ] );
 			}
 		} else if ( isMatch( 'core/block-editor/unselect', event ) ) {
-			if ( selectedBlockToolsRef.current.contains( event.target ) ) {
-				// This shouldn't be necessary, but we have a combination of a few things all combining to create a situation where:
-				// - Because the block toolbar uses createPortal to populate the block toolbar fills, we can't rely on the React event bubbling to hit the onKeyDown listener for the block toolbar
-				// - Since we can't use the React tree, we use the DOM tree which _should_ handle the event bubbling correctly from a `createPortal` element.
-				// - This bubbles via the React tree, which hits this `unselect` escape keypress before the block toolbar DOM event listener has access to it.
-				// An alternative would be to remove the addEventListener on the navigableToolbar and use this event to handle it directly right here. That feels hacky too though.
-				return;
-			}
-
 			const clientIds = getSelectedBlockClientIds();
 			if ( clientIds.length ) {
 				event.preventDefault();

--- a/packages/block-editor/src/components/block-tools/index.js
+++ b/packages/block-editor/src/components/block-tools/index.js
@@ -150,8 +150,10 @@ export default function BlockTools( {
 						isFixed={ hasFixedToolbar }
 					/>
 				</Fill>
-				{ /* Used for the inline rich text toolbar. */ }
-				<Popover.Slot name="block-toolbar" ref={ blockToolbarRef } />
+				<Fill name="__experimentalInlineRichTextTools">
+					{ /* Used for the inline rich text toolbar. */ }
+					<Popover.Slot name="block-toolbar" ref={ blockToolbarRef } />
+				</Fill>
 				{ children }
 				{ /* Used for inline rich text popovers. */ }
 				<Popover.Slot

--- a/packages/block-editor/src/components/block-tools/selected-block-tools.js
+++ b/packages/block-editor/src/components/block-tools/selected-block-tools.js
@@ -1,0 +1,248 @@
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
+ * WordPress dependencies
+ */
+import { useRef, useEffect } from '@wordpress/element';
+import { isUnmodifiedDefaultBlock } from '@wordpress/blocks';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { useShortcut } from '@wordpress/keyboard-shortcuts';
+import { getScrollContainer } from '@wordpress/dom';
+
+/**
+ * Internal dependencies
+ */
+import BlockSelectionButton from './block-selection-button';
+import BlockContextualToolbar from './block-contextual-toolbar';
+import { store as blockEditorStore } from '../../store';
+import BlockPopover from '../block-popover';
+import useBlockToolbarPopoverProps from './use-block-toolbar-popover-props';
+import { useShouldContextualToolbarShow } from '../../utils/use-should-contextual-toolbar-show';
+
+function selector( select ) {
+	const {
+		__unstableGetEditorMode,
+		hasMultiSelection,
+		isTyping,
+		getLastMultiSelectedBlockClientId,
+	} = select( blockEditorStore );
+
+	return {
+		editorMode: __unstableGetEditorMode(),
+		hasMultiSelection: hasMultiSelection(),
+		isTyping: isTyping(),
+		lastClientId: hasMultiSelection()
+			? getLastMultiSelectedBlockClientId()
+			: null,
+	};
+}
+
+function SelectedBlockTools( {
+	clientId,
+	rootClientId,
+	isEmptyDefaultBlock,
+	isFixed,
+	capturingClientId,
+} ) {
+	const { editorMode, hasMultiSelection, isTyping, lastClientId } = useSelect(
+		selector,
+		[]
+	);
+
+	const isInsertionPointVisible = useSelect(
+		( select ) => {
+			const {
+				isBlockInsertionPointVisible,
+				getBlockInsertionPoint,
+				getBlockOrder,
+			} = select( blockEditorStore );
+
+			if ( ! isBlockInsertionPointVisible() ) {
+				return false;
+			}
+
+			const insertionPoint = getBlockInsertionPoint();
+			const order = getBlockOrder( insertionPoint.rootClientId );
+			return order[ insertionPoint.index ] === clientId;
+		},
+		[ clientId ]
+	);
+	const isToolbarForced = useRef( false );
+	const { shouldShowContextualToolbar, canFocusHiddenToolbar } =
+		useShouldContextualToolbarShow();
+
+	const { stopTyping } = useDispatch( blockEditorStore );
+
+	const showEmptyBlockSideInserter =
+		! isTyping && editorMode === 'edit' && isEmptyDefaultBlock;
+	const shouldShowBreadcrumb =
+		! hasMultiSelection &&
+		( editorMode === 'navigation' || editorMode === 'zoom-out' );
+
+	useShortcut(
+		'core/block-editor/focus-toolbar',
+		() => {
+			isToolbarForced.current = true;
+			stopTyping( true );
+		},
+		{
+			isDisabled: ! canFocusHiddenToolbar,
+		}
+	);
+
+	useEffect( () => {
+		isToolbarForced.current = false;
+	} );
+
+	// Stores the active toolbar item index so the block toolbar can return focus
+	// to it when re-mounting.
+	const initialToolbarItemIndexRef = useRef();
+
+	useEffect( () => {
+		// Resets the index whenever the active block changes so this is not
+		// persisted. See https://github.com/WordPress/gutenberg/pull/25760#issuecomment-717906169
+		initialToolbarItemIndexRef.current = undefined;
+	}, [ clientId ] );
+
+	const popoverProps = useBlockToolbarPopoverProps( {
+		contentElement: getScrollContainer(), // This is what useBlockToolbarPopoverProps does when the contentRef is undefined. This likely works by accident. It was being passed in via the BlockTools
+		clientId,
+	} );
+
+	if ( isFixed ) {
+		return (
+			<BlockContextualToolbar
+				__experimentalInitialIndex={
+					initialToolbarItemIndexRef.current
+				}
+				__experimentalOnIndexChange={ ( index ) => {
+					initialToolbarItemIndexRef.current = index;
+				} }
+				// Resets the index whenever the active block changes so
+				// this is not persisted. See https://github.com/WordPress/gutenberg/pull/25760#issuecomment-717906169
+				key={ clientId }
+			/>
+		);
+	}
+
+	if ( showEmptyBlockSideInserter ) {
+		return null;
+	}
+
+	if ( shouldShowBreadcrumb || shouldShowContextualToolbar ) {
+		return (
+			<BlockPopover
+				clientId={ capturingClientId || clientId }
+				bottomClientId={ lastClientId }
+				className={ classnames(
+					'block-editor-block-list__block-popover',
+					{
+						'is-insertion-point-visible': isInsertionPointVisible,
+					}
+				) }
+				resize={ false }
+				{ ...popoverProps }
+			>
+				{ shouldShowContextualToolbar && (
+					<BlockContextualToolbar
+						// If the toolbar is being shown because of being forced
+						// it should focus the toolbar right after the mount.
+						focusOnMount={ isToolbarForced.current }
+						__experimentalInitialIndex={
+							initialToolbarItemIndexRef.current
+						}
+						__experimentalOnIndexChange={ ( index ) => {
+							initialToolbarItemIndexRef.current = index;
+						} }
+						// Resets the index whenever the active block changes so
+						// this is not persisted. See https://github.com/WordPress/gutenberg/pull/25760#issuecomment-717906169
+						key={ clientId }
+					/>
+				) }
+				{ shouldShowBreadcrumb && (
+					<BlockSelectionButton
+						clientId={ clientId }
+						rootClientId={ rootClientId }
+					/>
+				) }
+			</BlockPopover>
+		);
+	}
+
+	return null;
+}
+
+function wrapperSelector( select ) {
+	const {
+		getSelectedBlockClientId,
+		getFirstMultiSelectedBlockClientId,
+		getBlockRootClientId,
+		getBlock,
+		getBlockParents,
+		__experimentalGetBlockListSettingsForBlocks,
+	} = select( blockEditorStore );
+
+	const clientId =
+		getSelectedBlockClientId() || getFirstMultiSelectedBlockClientId();
+
+	if ( ! clientId ) {
+		return;
+	}
+
+	const { name, attributes = {} } = getBlock( clientId ) || {};
+	const blockParentsClientIds = getBlockParents( clientId );
+
+	// Get Block List Settings for all ancestors of the current Block clientId.
+	const parentBlockListSettings = __experimentalGetBlockListSettingsForBlocks(
+		blockParentsClientIds
+	);
+
+	// Get the clientId of the topmost parent with the capture toolbars setting.
+	const capturingClientId = blockParentsClientIds.find(
+		( parentClientId ) =>
+			parentBlockListSettings[ parentClientId ]
+				?.__experimentalCaptureToolbars
+	);
+
+	return {
+		clientId,
+		rootClientId: getBlockRootClientId( clientId ),
+		name,
+		isEmptyDefaultBlock:
+			name && isUnmodifiedDefaultBlock( { name, attributes } ),
+		capturingClientId,
+	};
+}
+
+export default function WrappedSelectedBlockTools( { isFixed } ) {
+	const selected = useSelect( wrapperSelector, [] );
+
+	if ( ! selected ) {
+		return null;
+	}
+
+	const {
+		clientId,
+		rootClientId,
+		name,
+		isEmptyDefaultBlock,
+		capturingClientId,
+	} = selected;
+
+	if ( ! name ) {
+		return null;
+	}
+
+	return (
+		<SelectedBlockTools
+			clientId={ clientId }
+			rootClientId={ rootClientId }
+			isEmptyDefaultBlock={ isEmptyDefaultBlock }
+			isFixed={ isFixed }
+			capturingClientId={ capturingClientId }
+		/>
+	);
+}

--- a/packages/block-editor/src/components/block-tools/selected-block-tools.js
+++ b/packages/block-editor/src/components/block-tools/selected-block-tools.js
@@ -11,6 +11,7 @@ import { isUnmodifiedDefaultBlock } from '@wordpress/blocks';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useShortcut } from '@wordpress/keyboard-shortcuts';
 import { getScrollContainer } from '@wordpress/dom';
+import { useViewportMatch } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -70,6 +71,7 @@ function SelectedBlockTools( {
 		},
 		[ clientId ]
 	);
+	const isLargeViewport = useViewportMatch( 'medium' );
 	const isToolbarForced = useRef( false );
 	const { shouldShowContextualToolbar, canFocusHiddenToolbar } =
 		useShouldContextualToolbarShow();
@@ -112,10 +114,11 @@ function SelectedBlockTools( {
 		clientId,
 	} );
 
-	if ( isFixed ) {
+	// We need to show the toolbar as fixed when we're on the tablet breakpoint.
+	if ( isFixed || ! isLargeViewport ) {
 		return (
 			<BlockContextualToolbar
-				isFixed={ isFixed }
+				isFixed={ true }
 				__experimentalInitialIndex={
 					initialToolbarItemIndexRef.current
 				}

--- a/packages/block-editor/src/components/block-tools/selected-block-tools.js
+++ b/packages/block-editor/src/components/block-tools/selected-block-tools.js
@@ -115,6 +115,7 @@ function SelectedBlockTools( {
 	if ( isFixed ) {
 		return (
 			<BlockContextualToolbar
+				isFixed={ isFixed }
 				__experimentalInitialIndex={
 					initialToolbarItemIndexRef.current
 				}

--- a/packages/block-editor/src/components/block-tools/selected-block-tools.js
+++ b/packages/block-editor/src/components/block-tools/selected-block-tools.js
@@ -6,7 +6,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { useRef, useEffect } from '@wordpress/element';
+import { forwardRef, useRef, useEffect } from '@wordpress/element';
 import { isUnmodifiedDefaultBlock } from '@wordpress/blocks';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useShortcut } from '@wordpress/keyboard-shortcuts';
@@ -41,13 +41,10 @@ function selector( select ) {
 	};
 }
 
-function SelectedBlockTools( {
-	clientId,
-	rootClientId,
-	isEmptyDefaultBlock,
-	isFixed,
-	capturingClientId,
-} ) {
+function WrappedSelectedBlockTools(
+	{ clientId, rootClientId, isEmptyDefaultBlock, isFixed, capturingClientId },
+	ref
+) {
 	const { editorMode, hasMultiSelection, isTyping, lastClientId } = useSelect(
 		selector,
 		[]
@@ -118,6 +115,7 @@ function SelectedBlockTools( {
 	if ( isFixed || ! isLargeViewport ) {
 		return (
 			<BlockContextualToolbar
+				ref={ ref }
 				isFixed={ true }
 				__experimentalInitialIndex={
 					initialToolbarItemIndexRef.current
@@ -152,6 +150,7 @@ function SelectedBlockTools( {
 			>
 				{ shouldShowContextualToolbar && (
 					<BlockContextualToolbar
+						ref={ ref }
 						// If the toolbar is being shown because of being forced
 						// it should focus the toolbar right after the mount.
 						focusOnMount={ isToolbarForced.current }
@@ -178,6 +177,8 @@ function SelectedBlockTools( {
 
 	return null;
 }
+
+const SelectedBlockTools = forwardRef( WrappedSelectedBlockTools );
 
 function wrapperSelector( select ) {
 	const {
@@ -221,7 +222,8 @@ function wrapperSelector( select ) {
 	};
 }
 
-export default function WrappedSelectedBlockTools( { isFixed } ) {
+const UnforwardWrappedSelectedBlockTools = ( props, ref ) => {
+	const { isFixed } = props;
 	const selected = useSelect( wrapperSelector, [] );
 
 	if ( ! selected ) {
@@ -242,6 +244,7 @@ export default function WrappedSelectedBlockTools( { isFixed } ) {
 
 	return (
 		<SelectedBlockTools
+			ref={ ref }
 			clientId={ clientId }
 			rootClientId={ rootClientId }
 			isEmptyDefaultBlock={ isEmptyDefaultBlock }
@@ -249,4 +252,6 @@ export default function WrappedSelectedBlockTools( { isFixed } ) {
 			capturingClientId={ capturingClientId }
 		/>
 	);
-}
+};
+
+export default forwardRef( UnforwardWrappedSelectedBlockTools );

--- a/packages/block-editor/src/components/block-tools/style.scss
+++ b/packages/block-editor/src/components/block-tools/style.scss
@@ -107,7 +107,6 @@
 	&.is-fixed {
 		position: fixed;
 		top: $admin-bar-height-big + $header-height;
-		z-index: z-index(".block-editor-block-popover");
 		width: 100%;
 		overflow: hidden;
 

--- a/packages/block-editor/src/components/block-tools/style.scss
+++ b/packages/block-editor/src/components/block-tools/style.scss
@@ -90,7 +90,7 @@
  */
 
 // Base left position for the toolbar when fixed.
-@include editor-left(".block-editor-block-contextual-toolbar.is-fixed");
+// @include editor-left(".block-editor-block-contextual-toolbar.is-fixed");
 
 .block-editor-block-contextual-toolbar {
 	// Block UI appearance.
@@ -105,10 +105,9 @@
 	}
 
 	&.is-fixed {
-		position: sticky;
-		top: 0;
+		position: fixed;
+		top: 107px; // Magic number. Needs updated. Should be whatever the toolbar + admin toolbar is?
 		z-index: z-index(".block-editor-block-popover");
-		display: block;
 		width: 100%;
 		overflow: hidden;
 
@@ -142,48 +141,19 @@
 	$toolbar-margin: $grid-unit-80 * 3 - 2 * $grid-unit + $grid-unit-05;
 	@include break-medium() {
 		&.is-fixed {
-			// leave room for block inserter, undo and redo, list view
-			margin-left: $toolbar-margin;
-			// position on top of interface header
-			position: fixed;
-			top: $admin-bar-height;
-			// Don't fill up when empty
-			min-height: initial;
+			position: relative;
+			top: 0;
+			display: inline-flex;
+			width: auto;
+
 			// remove the border
 			border-bottom: none;
-			// has to be flex for collapse button to fit
-			display: flex;
-
-			// Mimic the height of the parent, vertically align center, and provide a max-height.
-			height: $header-height;
-			align-items: center;
 
 			&.is-collapsed {
 				width: initial;
 			}
 
-			&:empty {
-				width: initial;
-			}
-
-			.is-fullscreen-mode & {
-				// leave room for block inserter, undo and redo, list view
-				// and some margin left
-				margin-left: $grid-unit-80 * 4 - 2 * $grid-unit;
-
-				top: 0;
-
-				&.is-collapsed {
-					width: initial;
-				}
-
-				&:empty {
-					width: initial;
-				}
-			}
-
 			& > .block-editor-block-toolbar {
-				flex-grow: initial;
 				width: initial;
 
 				// Add a border as separator in the block toolbar.
@@ -330,38 +300,6 @@
 				margin-left: -$border-width;
 				margin-bottom: -$border-width;
 			}
-		}
-	}
-
-	// on tablet viewports the toolbar is fixed
-	// on top of interface header and covers the whole header
-	// except for the inserter on the left
-	@include break-medium() {
-		&.is-fixed {
-			width: calc(100% - #{$toolbar-margin});
-
-			.show-icon-labels & {
-				width: calc(100% + 40px - #{$toolbar-margin}); //there are no undo, redo and list view buttons
-			}
-
-		}
-	}
-
-	// on desktop viewports the toolbar is fixed
-	// on top of interface header and leaves room
-	// for the block inserter the publish button
-	@include break-large() {
-		&.is-fixed {
-			width: auto;
-			.show-icon-labels & {
-				width: auto; //there are no undo, redo and list view buttons
-			}
-		}
-		.is-fullscreen-mode &.is-fixed {
-			// in full screen mode we need to account for
-			// the combined with of the tools at the right of the header and the margin left
-			// of the toolbar which includes four buttons
-			width: calc(100% - 280px - #{4 * $grid-unit-80});
 		}
 	}
 }

--- a/packages/block-editor/src/components/block-tools/style.scss
+++ b/packages/block-editor/src/components/block-tools/style.scss
@@ -106,7 +106,7 @@
 
 	&.is-fixed {
 		position: fixed;
-		top: 107px; // Magic number. Needs updated. Should be whatever the toolbar + admin toolbar is?
+		top: $admin-bar-height-big + $header-height;
 		z-index: z-index(".block-editor-block-popover");
 		width: 100%;
 		overflow: hidden;
@@ -118,6 +118,7 @@
 
 		border: none;
 		border-bottom: $border-width solid $gray-200;
+		border-top: $border-width solid $gray-200;
 		border-radius: 0;
 
 		.block-editor-block-toolbar .components-toolbar-group,
@@ -147,7 +148,7 @@
 			width: auto;
 
 			// remove the border
-			border-bottom: none;
+			border: none;
 
 			&.is-collapsed {
 				width: initial;

--- a/packages/block-editor/src/components/index.js
+++ b/packages/block-editor/src/components/index.js
@@ -127,6 +127,7 @@ export { default as BlockSettingsMenuControls } from './block-settings-menu-cont
 export { default as BlockTitle } from './block-title';
 export { default as BlockToolbar } from './block-toolbar';
 export { default as BlockTools } from './block-tools';
+export { default as _experimentalSelectedBlockTools } from './block-tools/selected-block-tools';
 export {
 	default as CopyHandler,
 	useClipboardHandler as __unstableUseClipboardHandler,

--- a/packages/block-editor/src/components/index.js
+++ b/packages/block-editor/src/components/index.js
@@ -127,7 +127,6 @@ export { default as BlockSettingsMenuControls } from './block-settings-menu-cont
 export { default as BlockTitle } from './block-title';
 export { default as BlockToolbar } from './block-toolbar';
 export { default as BlockTools } from './block-tools';
-export { default as _experimentalSelectedBlockTools } from './block-tools/selected-block-tools';
 export {
 	default as CopyHandler,
 	useClipboardHandler as __unstableUseClipboardHandler,

--- a/packages/block-editor/src/components/navigable-toolbar/index.js
+++ b/packages/block-editor/src/components/navigable-toolbar/index.js
@@ -156,6 +156,7 @@ function useToolbarFocus(
 function NavigableToolbar( {
 	children,
 	focusOnMount,
+	onChildrenKeyDown = () => {},
 	shouldUseKeyboardFocusShortcut = true,
 	__experimentalInitialIndex: initialIndex,
 	__experimentalOnIndexChange: onIndexChange,
@@ -163,7 +164,6 @@ function NavigableToolbar( {
 } ) {
 	const ref = useRef();
 	const isAccessibleToolbar = useIsAccessibleToolbar( ref );
-
 	useToolbarFocus(
 		ref,
 		focusOnMount,
@@ -172,6 +172,35 @@ function NavigableToolbar( {
 		onIndexChange,
 		shouldUseKeyboardFocusShortcut
 	);
+
+	useEffect( () => {
+		const navigableToolbarRef = ref.current;
+		const toolbarButtons = navigableToolbarRef.querySelectorAll(
+			'[data-toolbar-item="true"]'
+		);
+
+		if ( onChildrenKeyDown ) {
+			const handleChildrenKeyDown = ( event ) => {
+				onChildrenKeyDown( event );
+			};
+
+			toolbarButtons.forEach( ( toolbarButton ) => {
+				toolbarButton.addEventListener(
+					'keydown',
+					handleChildrenKeyDown
+				);
+			} );
+
+			return () => {
+				toolbarButtons.forEach( ( toolbarButton ) => {
+					toolbarButton.removeEventListener(
+						'keydown',
+						handleChildrenKeyDown
+					);
+				} );
+			};
+		}
+	}, [ onChildrenKeyDown, children ] );
 
 	if ( isAccessibleToolbar ) {
 		return (

--- a/packages/block-editor/src/components/navigable-toolbar/index.js
+++ b/packages/block-editor/src/components/navigable-toolbar/index.js
@@ -3,6 +3,7 @@
  */
 import { NavigableMenu, Toolbar } from '@wordpress/components';
 import {
+	forwardRef,
 	useState,
 	useRef,
 	useLayoutEffect,
@@ -38,7 +39,7 @@ function focusFirstTabbableIn( container ) {
 	}
 }
 
-function useIsAccessibleToolbar( ref ) {
+function useIsAccessibleToolbar( toolbarRef ) {
 	/*
 	 * By default, we'll assume the starting accessible state of the Toolbar
 	 * is true, as it seems to be the most common case.
@@ -62,7 +63,7 @@ function useIsAccessibleToolbar( ref ) {
 	);
 
 	const determineIsAccessibleToolbar = useCallback( () => {
-		const tabbables = focus.tabbable.find( ref.current );
+		const tabbables = focus.tabbable.find( toolbarRef.current );
 		const onlyToolbarItem = hasOnlyToolbarItem( tabbables );
 		if ( ! onlyToolbarItem ) {
 			deprecated( 'Using custom components as toolbar controls', {
@@ -73,7 +74,7 @@ function useIsAccessibleToolbar( ref ) {
 			} );
 		}
 		setIsAccessibleToolbar( onlyToolbarItem );
-	}, [] );
+	}, [ toolbarRef ] );
 
 	useLayoutEffect( () => {
 		// Toolbar buttons may be rendered asynchronously, so we use
@@ -81,15 +82,18 @@ function useIsAccessibleToolbar( ref ) {
 		const observer = new window.MutationObserver(
 			determineIsAccessibleToolbar
 		);
-		observer.observe( ref.current, { childList: true, subtree: true } );
+		observer.observe( toolbarRef.current, {
+			childList: true,
+			subtree: true,
+		} );
 		return () => observer.disconnect();
-	}, [ isAccessibleToolbar ] );
+	}, [ isAccessibleToolbar, determineIsAccessibleToolbar, toolbarRef ] );
 
 	return isAccessibleToolbar;
 }
 
 function useToolbarFocus(
-	ref,
+	toolbarRef,
 	focusOnMount,
 	isAccessibleToolbar,
 	defaultIndex,
@@ -101,8 +105,8 @@ function useToolbarFocus(
 	const [ initialIndex ] = useState( defaultIndex );
 
 	const focusToolbar = useCallback( () => {
-		focusFirstTabbableIn( ref.current );
-	}, [] );
+		focusFirstTabbableIn( toolbarRef.current );
+	}, [ toolbarRef ] );
 
 	const focusToolbarViaShortcut = () => {
 		if ( shouldUseKeyboardFocusShortcut ) {
@@ -121,7 +125,7 @@ function useToolbarFocus(
 
 	useEffect( () => {
 		// Store ref so we have access on useEffect cleanup: https://legacy.reactjs.org/blog/2020/08/10/react-v17-rc.html#effect-cleanup-timing
-		const navigableToolbarRef = ref.current;
+		const navigableToolbarRef = toolbarRef.current;
 		// If initialIndex is passed, we focus on that toolbar item when the
 		// toolbar gets mounted and initial focus is not forced.
 		// We have to wait for the next browser paint because block controls aren't
@@ -150,22 +154,27 @@ function useToolbarFocus(
 			const index = items.findIndex( ( item ) => item.tabIndex === 0 );
 			onIndexChange( index );
 		};
-	}, [ initialIndex, initialFocusOnMount ] );
+	}, [ initialIndex, initialFocusOnMount, toolbarRef, onIndexChange ] );
 }
 
-function NavigableToolbar( {
-	children,
-	focusOnMount,
-	onChildrenKeyDown = () => {},
-	shouldUseKeyboardFocusShortcut = true,
-	__experimentalInitialIndex: initialIndex,
-	__experimentalOnIndexChange: onIndexChange,
-	...props
-} ) {
-	const ref = useRef();
-	const isAccessibleToolbar = useIsAccessibleToolbar( ref );
+function UnforwardNavigableToolbar(
+	{
+		children,
+		focusOnMount,
+		handleOnKeyDown,
+		shouldUseKeyboardFocusShortcut = true,
+		__experimentalInitialIndex: initialIndex,
+		__experimentalOnIndexChange: onIndexChange,
+		...props
+	},
+	ref
+) {
+	const maybeRef = useRef();
+	// If a ref was not forwarded, we create one.
+	const toolbarRef = ref || maybeRef;
+	const isAccessibleToolbar = useIsAccessibleToolbar( toolbarRef );
 	useToolbarFocus(
-		ref,
+		toolbarRef,
 		focusOnMount,
 		isAccessibleToolbar,
 		initialIndex,
@@ -174,37 +183,31 @@ function NavigableToolbar( {
 	);
 
 	useEffect( () => {
-		const navigableToolbarRef = ref.current;
-		const toolbarButtons = navigableToolbarRef.querySelectorAll(
-			'[data-toolbar-item="true"]'
-		);
+		const navigableToolbarRef = toolbarRef.current;
 
-		if ( onChildrenKeyDown ) {
-			const handleChildrenKeyDown = ( event ) => {
-				onChildrenKeyDown( event );
+		if ( handleOnKeyDown ) {
+			const handleKeyDown = ( event ) => {
+				handleOnKeyDown( event );
 			};
 
-			toolbarButtons.forEach( ( toolbarButton ) => {
-				toolbarButton.addEventListener(
-					'keydown',
-					handleChildrenKeyDown
-				);
-			} );
+			navigableToolbarRef.addEventListener( 'keydown', handleKeyDown );
 
 			return () => {
-				toolbarButtons.forEach( ( toolbarButton ) => {
-					toolbarButton.removeEventListener(
-						'keydown',
-						handleChildrenKeyDown
-					);
-				} );
+				navigableToolbarRef.removeEventListener(
+					'keydown',
+					handleKeyDown
+				);
 			};
 		}
-	}, [ onChildrenKeyDown, children ] );
+	}, [ handleOnKeyDown, toolbarRef ] );
 
 	if ( isAccessibleToolbar ) {
 		return (
-			<Toolbar label={ props[ 'aria-label' ] } ref={ ref } { ...props }>
+			<Toolbar
+				label={ props[ 'aria-label' ] }
+				ref={ toolbarRef }
+				{ ...props }
+			>
 				{ children }
 			</Toolbar>
 		);
@@ -214,7 +217,7 @@ function NavigableToolbar( {
 		<NavigableMenu
 			orientation="horizontal"
 			role="toolbar"
-			ref={ ref }
+			ref={ toolbarRef }
 			{ ...props }
 		>
 			{ children }
@@ -222,4 +225,4 @@ function NavigableToolbar( {
 	);
 }
 
-export default NavigableToolbar;
+export default forwardRef( UnforwardNavigableToolbar );

--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -37,6 +37,7 @@ import { useBeforeInputRules } from './use-before-input-rules';
 import { useInputRules } from './use-input-rules';
 import { useDelete } from './use-delete';
 import { useEnter } from './use-enter';
+import { useTab } from './use-tab';
 import { useFormatTypes } from './use-format-types';
 import { useRemoveBrowserShortcuts } from './use-remove-browser-shortcuts';
 import { useShortcuts } from './use-shortcuts';
@@ -398,6 +399,10 @@ function RichTextWrapper(
 						onChange,
 						disableLineBreaks,
 						onSplitAtEnd,
+					} ),
+					useTab( {
+						value,
+						onChange,
 					} ),
 					useFirefoxCompat(),
 					anchorRef,

--- a/packages/block-editor/src/components/rich-text/use-tab.js
+++ b/packages/block-editor/src/components/rich-text/use-tab.js
@@ -1,0 +1,38 @@
+/**
+ * WordPress dependencies
+ */
+import { useRef } from '@wordpress/element';
+import { insert } from '@wordpress/rich-text';
+import { useRefEffect } from '@wordpress/compose';
+import { TAB } from '@wordpress/keycodes';
+
+export function useTab( props ) {
+	const propsRef = useRef( props );
+	propsRef.current = props;
+	return useRefEffect( ( element ) => {
+		function onKeyDown( event ) {
+			const { keyCode } = event;
+
+			if ( event.defaultPrevented ) {
+				return;
+			}
+
+			const { value, onChange } = propsRef.current;
+            const _value = { ...value };
+
+			if ( keyCode === TAB  ) {
+                event.preventDefault();
+
+				const { start, end } = value;
+
+				onChange( insert( _value, '\t', start, end ) );
+			}
+		}
+
+		element.addEventListener( 'keydown', onKeyDown );
+		return () => {
+			element.removeEventListener( 'keydown', onKeyDown );
+		};
+	}, [] );
+
+}

--- a/packages/block-editor/src/components/writing-flow/use-tab-nav.js
+++ b/packages/block-editor/src/components/writing-flow/use-tab-nav.js
@@ -17,12 +17,17 @@ export default function useTabNav() {
 	const container = useRef();
 	const focusCaptureBeforeRef = useRef();
 	const focusCaptureAfterRef = useRef();
-	const lastFocus = useRef();
+
 	const { hasMultiSelection, getSelectedBlockClientId, getBlockCount } =
 		useSelect( blockEditorStore );
-	const { setNavigationMode } = useDispatch( blockEditorStore );
+	const { setNavigationMode, setLastFocus } = useDispatch( blockEditorStore );
 	const isNavigationMode = useSelect(
 		( select ) => select( blockEditorStore ).isNavigationMode(),
+		[]
+	);
+
+	const lastFocus = useSelect(
+		( select ) => select( blockEditorStore ).getLastFocus(),
 		[]
 	);
 
@@ -158,7 +163,7 @@ export default function useTabNav() {
 		}
 
 		function onFocusOut( event ) {
-			lastFocus.current = event.target;
+			setLastFocus( { ...lastFocus, current: event.target } );
 
 			const { ownerDocument } = node;
 

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -1925,3 +1925,18 @@ export function unsetBlockEditingMode( clientId = '' ) {
 		clientId,
 	};
 }
+
+/**
+ * Action that sets the element that had focus when focus leaves the editor canvas.
+ *
+ * @param {Object} lastFocus The last focused element.
+ *
+ *
+ * @return {Object} Action object.
+ */
+export function setLastFocus( lastFocus = null ) {
+	return {
+		type: 'LAST_FOCUS',
+		lastFocus,
+	};
+}

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -1913,6 +1913,23 @@ export function blockEditingModes( state = new Map(), action ) {
 	return state;
 }
 
+/**
+ * Reducer setting last focused element
+ *
+ * @param {boolean} state  Current state.
+ * @param {Object}  action Dispatched action.
+ *
+ * @return {boolean} Updated state.
+ */
+export function lastFocus( state = false, action ) {
+	switch ( action.type ) {
+		case 'LAST_FOCUS':
+			return action.lastFocus;
+	}
+
+	return state;
+}
+
 const combinedReducers = combineReducers( {
 	blocks,
 	isTyping,
@@ -1929,6 +1946,7 @@ const combinedReducers = combineReducers( {
 	settings,
 	preferences,
 	lastBlockAttributesChange,
+	lastFocus,
 	editorMode,
 	hasBlockMovingClientId,
 	highlightedBlock,

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -3006,3 +3006,14 @@ export const isGroupable = createRegistrySelector(
 			);
 		}
 );
+
+/*
+ * Returns the element of the last element that had focus when focus left the editor canvas.
+ *
+ * @param {Object} state Block editor state.
+ *
+ * @return {Object} Element.
+ */
+export function getLastFocus( state ) {
+	return state.lastFocus;
+}

--- a/packages/edit-post/src/components/header/header-toolbar/index.js
+++ b/packages/edit-post/src/components/header/header-toolbar/index.js
@@ -131,7 +131,7 @@ function HeaderToolbar() {
 	const shortLabel = ! isInserterOpened ? __( 'Add' ) : __( 'Close' );
 
 	return (
-		<span role="menubar">
+		<>
 			<NavigableToolbar
 				className="edit-post-header-toolbar"
 				aria-label={ toolbarAriaLabel }
@@ -193,7 +193,7 @@ function HeaderToolbar() {
 				name="__experimentalInlineRichTextTools"
 				bubblesVirtually
 			/>
-		</span>
+		</>
 	);
 }
 

--- a/packages/edit-post/src/components/header/header-toolbar/index.js
+++ b/packages/edit-post/src/components/header/header-toolbar/index.js
@@ -188,6 +188,11 @@ function HeaderToolbar() {
 				name="__experimentalSelectedBlockTools"
 				bubblesVirtually
 			/>
+			<Slot
+				className="inline-rich-text-tools-wrapper"
+				name="__experimentalInlineRichTextTools"
+				bubblesVirtually
+			/>
 		</>
 	);
 }

--- a/packages/edit-post/src/components/header/header-toolbar/index.js
+++ b/packages/edit-post/src/components/header/header-toolbar/index.js
@@ -131,7 +131,7 @@ function HeaderToolbar() {
 	const shortLabel = ! isInserterOpened ? __( 'Add' ) : __( 'Close' );
 
 	return (
-		<>
+		<span role="menubar">
 			<NavigableToolbar
 				className="edit-post-header-toolbar"
 				aria-label={ toolbarAriaLabel }
@@ -193,7 +193,7 @@ function HeaderToolbar() {
 				name="__experimentalInlineRichTextTools"
 				bubblesVirtually
 			/>
-		</>
+		</span>
 	);
 }
 

--- a/packages/edit-post/src/components/header/header-toolbar/index.js
+++ b/packages/edit-post/src/components/header/header-toolbar/index.js
@@ -183,7 +183,11 @@ function HeaderToolbar() {
 					) }
 				</div>
 			</NavigableToolbar>
-			<Slot name="__experimentalSelectedBlockTools" />
+			<Slot
+				className="selected-block-toolbar-wrapper"
+				name="__experimentalSelectedBlockTools"
+				bubblesVirtually
+			/>
 		</>
 	);
 }

--- a/packages/edit-post/src/components/header/header-toolbar/index.js
+++ b/packages/edit-post/src/components/header/header-toolbar/index.js
@@ -7,7 +7,6 @@ import { __, _x } from '@wordpress/i18n';
 import {
 	NavigableToolbar,
 	ToolSelector,
-	_experimentalSelectedBlockTools,
 	store as blockEditorStore,
 	privateApis as blockEditorPrivateApis,
 } from '@wordpress/block-editor';
@@ -16,7 +15,7 @@ import {
 	EditorHistoryUndo,
 	store as editorStore,
 } from '@wordpress/editor';
-import { Button, ToolbarItem } from '@wordpress/components';
+import { Button, Slot, ToolbarItem } from '@wordpress/components';
 import { listView, plus } from '@wordpress/icons';
 import { useRef, useCallback } from '@wordpress/element';
 import { store as keyboardShortcutsStore } from '@wordpress/keyboard-shortcuts';
@@ -184,7 +183,7 @@ function HeaderToolbar() {
 					) }
 				</div>
 			</NavigableToolbar>
-			<_experimentalSelectedBlockTools isFixed={ hasFixedToolbar } />
+			<Slot name="__experimentalSelectedBlockTools" />
 		</>
 	);
 }

--- a/packages/edit-post/src/components/header/header-toolbar/index.js
+++ b/packages/edit-post/src/components/header/header-toolbar/index.js
@@ -7,6 +7,7 @@ import { __, _x } from '@wordpress/i18n';
 import {
 	NavigableToolbar,
 	ToolSelector,
+	_experimentalSelectedBlockTools,
 	store as blockEditorStore,
 	privateApis as blockEditorPrivateApis,
 } from '@wordpress/block-editor';
@@ -131,53 +132,60 @@ function HeaderToolbar() {
 	const shortLabel = ! isInserterOpened ? __( 'Add' ) : __( 'Close' );
 
 	return (
-		<NavigableToolbar
-			className="edit-post-header-toolbar"
-			aria-label={ toolbarAriaLabel }
-			shouldUseKeyboardFocusShortcut={ ! blockToolbarCanBeFocused }
-		>
-			<div className="edit-post-header-toolbar__left">
-				<ToolbarItem
-					ref={ inserterButton }
-					as={ Button }
-					className="edit-post-header-toolbar__inserter-toggle"
-					variant="primary"
-					isPressed={ isInserterOpened }
-					onMouseDown={ preventDefault }
-					onClick={ toggleInserter }
-					disabled={ ! isInserterEnabled }
-					icon={ plus }
-					label={ showIconLabels ? shortLabel : longLabel }
-					showTooltip={ ! showIconLabels }
-					aria-expanded={ isInserterOpened }
-				/>
-				{ ( isWideViewport || ! showIconLabels ) && (
-					<>
-						{ isLargeViewport && ! hasFixedToolbar && (
+		<>
+			<NavigableToolbar
+				className="edit-post-header-toolbar"
+				aria-label={ toolbarAriaLabel }
+				shouldUseKeyboardFocusShortcut={ ! blockToolbarCanBeFocused }
+			>
+				<div className="edit-post-header-toolbar__left">
+					<ToolbarItem
+						ref={ inserterButton }
+						as={ Button }
+						className="edit-post-header-toolbar__inserter-toggle"
+						variant="primary"
+						isPressed={ isInserterOpened }
+						onMouseDown={ preventDefault }
+						onClick={ toggleInserter }
+						disabled={ ! isInserterEnabled }
+						icon={ plus }
+						label={ showIconLabels ? shortLabel : longLabel }
+						showTooltip={ ! showIconLabels }
+						aria-expanded={ isInserterOpened }
+					/>
+					{ ( isWideViewport || ! showIconLabels ) && (
+						<>
+							{ isLargeViewport && ! hasFixedToolbar && (
+								<ToolbarItem
+									as={ ToolSelector }
+									showTooltip={ ! showIconLabels }
+									variant={
+										showIconLabels ? 'tertiary' : undefined
+									}
+									disabled={ isTextModeEnabled }
+								/>
+							) }
 							<ToolbarItem
-								as={ ToolSelector }
+								as={ EditorHistoryUndo }
 								showTooltip={ ! showIconLabels }
 								variant={
 									showIconLabels ? 'tertiary' : undefined
 								}
-								disabled={ isTextModeEnabled }
 							/>
-						) }
-						<ToolbarItem
-							as={ EditorHistoryUndo }
-							showTooltip={ ! showIconLabels }
-							variant={ showIconLabels ? 'tertiary' : undefined }
-						/>
-						<ToolbarItem
-							as={ EditorHistoryRedo }
-							showTooltip={ ! showIconLabels }
-							variant={ showIconLabels ? 'tertiary' : undefined }
-						/>
-						{ overflowItems }
-					</>
-				) }
-			</div>
-		</NavigableToolbar>
+							<ToolbarItem
+								as={ EditorHistoryRedo }
+								showTooltip={ ! showIconLabels }
+								variant={
+									showIconLabels ? 'tertiary' : undefined
+								}
+							/>
+							{ overflowItems }
+						</>
+					) }
+				</div>
+			</NavigableToolbar>
+			<_experimentalSelectedBlockTools isFixed={ hasFixedToolbar } />
+		</>
 	);
 }
 

--- a/packages/edit-post/src/components/header/index.js
+++ b/packages/edit-post/src/components/header/index.js
@@ -45,7 +45,7 @@ function Header( { setEntitiesSavedStatesCallback } ) {
 		);
 
 	return (
-		<div className="edit-post-header">
+		<div role="menubar" className="edit-post-header">
 			<MainDashboardButton.Slot>
 				<motion.div
 					variants={ slideX }

--- a/packages/edit-site/src/components/header-edit-mode/index.js
+++ b/packages/edit-site/src/components/header-edit-mode/index.js
@@ -26,6 +26,7 @@ import {
 	ToolbarItem,
 	MenuGroup,
 	MenuItem,
+	Slot,
 	VisuallyHidden,
 } from '@wordpress/components';
 import { store as keyboardShortcutsStore } from '@wordpress/keyboard-shortcuts';
@@ -190,6 +191,7 @@ export default function HeaderEditMode() {
 			} ) }
 		>
 			{ hasDefaultEditorCanvasView && (
+				<>
 				<NavigableToolbar
 					as={ motion.div }
 					className="edit-site-header-edit-mode__start"
@@ -234,18 +236,19 @@ export default function HeaderEditMode() {
 									/>
 								) }
 								<ToolbarItem
-									as={ UndoButton }
-									showTooltip={ ! showIconLabels }
-									variant={
-										showIconLabels ? 'tertiary' : undefined
+									ref={ inserterButton }
+									as={ Button }
+									className="edit-site-header-edit-mode__inserter-toggle"
+									variant="primary"
+									isPressed={ isInserterOpen }
+									onMouseDown={ preventDefault }
+									onClick={ toggleInserter }
+									disabled={ ! isVisualMode }
+									icon={ plus }
+									label={
+										showIconLabels ? shortLabel : longLabel
 									}
-								/>
-								<ToolbarItem
-									as={ RedoButton }
 									showTooltip={ ! showIconLabels }
-									variant={
-										showIconLabels ? 'tertiary' : undefined
-									}
 								/>
 								{ ! isDistractionFree && (
 									<ToolbarItem
@@ -273,28 +276,87 @@ export default function HeaderEditMode() {
 									! isDistractionFree &&
 									! hasFixedToolbar && (
 										<ToolbarItem
-											as={ Button }
-											className="edit-site-header-edit-mode__zoom-out-view-toggle"
-											icon={ chevronUpDown }
-											isPressed={ isZoomedOutView }
-											/* translators: button label text should, if possible, be under 16 characters. */
-											label={ __( 'Zoom-out View' ) }
-											onClick={ () => {
-												setPreviewDeviceType(
-													'Desktop'
-												);
-												__unstableSetEditorMode(
-													isZoomedOutView
-														? 'edit'
-														: 'zoom-out'
-												);
-											} }
+											as={ ToolSelector }
+											showTooltip={ ! showIconLabels }
+											variant={
+												showIconLabels
+													? 'tertiary'
+													: undefined
+											}
+											disabled={ ! isVisualMode }
 										/>
 									) }
-							</>
-						) }
-					</div>
-				</NavigableToolbar>
+									<ToolbarItem
+										as={ UndoButton }
+										showTooltip={ ! showIconLabels }
+										variant={
+											showIconLabels
+												? 'tertiary'
+												: undefined
+										}
+									/>
+									<ToolbarItem
+										as={ RedoButton }
+										showTooltip={ ! showIconLabels }
+										variant={
+											showIconLabels
+												? 'tertiary'
+												: undefined
+										}
+									/>
+									{ ! isDistractionFree && (
+										<ToolbarItem
+											as={ Button }
+											className="edit-site-header-edit-mode__list-view-toggle"
+											disabled={
+												! isVisualMode ||
+												isZoomedOutView
+											}
+											icon={ listView }
+											isPressed={ isListViewOpen }
+											/* translators: button label text should, if possible, be under 16 characters. */
+											label={ __( 'List View' ) }
+											onClick={ toggleListView }
+											shortcut={ listViewShortcut }
+											showTooltip={ ! showIconLabels }
+											variant={
+												showIconLabels
+													? 'tertiary'
+													: undefined
+											}
+										/>
+									) }
+									{ isZoomedOutViewExperimentEnabled &&
+										! isDistractionFree &&
+										! hasFixedToolbar && (
+											<ToolbarItem
+												as={ Button }
+												className="edit-site-header-edit-mode__zoom-out-view-toggle"
+												icon={ chevronUpDown }
+												isPressed={ isZoomedOutView }
+												/* translators: button label text should, if possible, be under 16 characters. */
+												label={ __( 'Zoom-out View' ) }
+												onClick={ () => {
+													setPreviewDeviceType(
+														'Desktop'
+													);
+													__unstableSetEditorMode(
+														isZoomedOutView
+															? 'edit'
+															: 'zoom-out'
+													);
+												} }
+											/>
+										) }
+								</>
+							) }
+						</div>
+					</NavigableToolbar>
+					<Slot
+						name="__experimentalSelectedBlockTools"
+						bubblesVirtually
+					/>
+				</>
 			) }
 
 			{ ! isDistractionFree && (

--- a/packages/edit-site/src/components/header-edit-mode/index.js
+++ b/packages/edit-site/src/components/header-edit-mode/index.js
@@ -236,60 +236,6 @@ export default function HeaderEditMode() {
 										/>
 									) }
 									<ToolbarItem
-										ref={ inserterButton }
-										as={ Button }
-										className="edit-site-header-edit-mode__inserter-toggle"
-										variant="primary"
-										isPressed={ isInserterOpen }
-										onMouseDown={ preventDefault }
-										onClick={ toggleInserter }
-										disabled={ ! isVisualMode }
-										icon={ plus }
-										label={
-											showIconLabels
-												? shortLabel
-												: longLabel
-										}
-										showTooltip={ ! showIconLabels }
-									/>
-									{ ! isDistractionFree && (
-										<ToolbarItem
-											as={ Button }
-											className="edit-site-header-edit-mode__list-view-toggle"
-											disabled={
-												! isVisualMode ||
-												isZoomedOutView
-											}
-											icon={ listView }
-											isPressed={ isListViewOpen }
-											/* translators: button label text should, if possible, be under 16 characters. */
-											label={ __( 'List View' ) }
-											onClick={ toggleListView }
-											shortcut={ listViewShortcut }
-											showTooltip={ ! showIconLabels }
-											variant={
-												showIconLabels
-													? 'tertiary'
-													: undefined
-											}
-											aria-expanded={ isListViewOpen }
-										/>
-									) }
-									{ isZoomedOutViewExperimentEnabled &&
-										! isDistractionFree &&
-										! hasFixedToolbar && (
-											<ToolbarItem
-												as={ ToolSelector }
-												showTooltip={ ! showIconLabels }
-												variant={
-													showIconLabels
-														? 'tertiary'
-														: undefined
-												}
-												disabled={ ! isVisualMode }
-											/>
-										) }
-									<ToolbarItem
 										as={ UndoButton }
 										showTooltip={ ! showIconLabels }
 										variant={
@@ -327,6 +273,7 @@ export default function HeaderEditMode() {
 													? 'tertiary'
 													: undefined
 											}
+											aria-expanded={ isListViewOpen }
 										/>
 									) }
 									{ isZoomedOutViewExperimentEnabled &&

--- a/packages/edit-site/src/components/header-edit-mode/index.js
+++ b/packages/edit-site/src/components/header-edit-mode/index.js
@@ -353,6 +353,7 @@ export default function HeaderEditMode() {
 						</div>
 					</NavigableToolbar>
 					<Slot
+						className="selected-block-toolbar-wrapper"
 						name="__experimentalSelectedBlockTools"
 						bubblesVirtually
 					/>

--- a/packages/edit-site/src/components/header-edit-mode/index.js
+++ b/packages/edit-site/src/components/header-edit-mode/index.js
@@ -357,6 +357,11 @@ export default function HeaderEditMode() {
 						name="__experimentalSelectedBlockTools"
 						bubblesVirtually
 					/>
+					<Slot
+						className="inline-rich-text-tools-wrapper"
+						name="__experimentalInlineRichTextTools"
+						bubblesVirtually
+					/>
 				</>
 			) }
 

--- a/packages/edit-site/src/components/header-edit-mode/index.js
+++ b/packages/edit-site/src/components/header-edit-mode/index.js
@@ -191,50 +191,19 @@ export default function HeaderEditMode() {
 			} ) }
 		>
 			{ hasDefaultEditorCanvasView && (
-				<>
-				<NavigableToolbar
-					as={ motion.div }
-					className="edit-site-header-edit-mode__start"
-					aria-label={ __( 'Document tools' ) }
-					shouldUseKeyboardFocusShortcut={
-						! blockToolbarCanBeFocused
-					}
-					variants={ toolbarVariants }
-					transition={ toolbarTransition }
-				>
-					<div className="edit-site-header-edit-mode__toolbar">
-						{ ! isDistractionFree && (
-							<ToolbarItem
-								ref={ inserterButton }
-								as={ Button }
-								className="edit-site-header-edit-mode__inserter-toggle"
-								variant="primary"
-								isPressed={ isInserterOpen }
-								onMouseDown={ preventDefault }
-								onClick={ toggleInserter }
-								disabled={ ! isVisualMode }
-								icon={ plus }
-								label={
-									showIconLabels ? shortLabel : longLabel
-								}
-								showTooltip={ ! showIconLabels }
-								aria-expanded={ isInserterOpen }
-							/>
-						) }
-						{ isLargeViewport && (
-							<>
-								{ ! hasFixedToolbar && (
-									<ToolbarItem
-										as={ ToolSelector }
-										showTooltip={ ! showIconLabels }
-										variant={
-											showIconLabels
-												? 'tertiary'
-												: undefined
-										}
-										disabled={ ! isVisualMode }
-									/>
-								) }
+				<span role="menubar">
+					<NavigableToolbar
+						as={ motion.div }
+						className="edit-site-header-edit-mode__start"
+						aria-label={ __( 'Document tools' ) }
+						shouldUseKeyboardFocusShortcut={
+							! blockToolbarCanBeFocused
+						}
+						variants={ toolbarVariants }
+						transition={ toolbarTransition }
+					>
+						<div className="edit-site-header-edit-mode__toolbar">
+							{ ! isDistractionFree && (
 								<ToolbarItem
 									ref={ inserterButton }
 									as={ Button }
@@ -249,32 +218,12 @@ export default function HeaderEditMode() {
 										showIconLabels ? shortLabel : longLabel
 									}
 									showTooltip={ ! showIconLabels }
+									aria-expanded={ isInserterOpen }
 								/>
-								{ ! isDistractionFree && (
-									<ToolbarItem
-										as={ Button }
-										className="edit-site-header-edit-mode__list-view-toggle"
-										disabled={
-											! isVisualMode || isZoomedOutView
-										}
-										icon={ listView }
-										isPressed={ isListViewOpen }
-										/* translators: button label text should, if possible, be under 16 characters. */
-										label={ __( 'List View' ) }
-										onClick={ toggleListView }
-										shortcut={ listViewShortcut }
-										showTooltip={ ! showIconLabels }
-										variant={
-											showIconLabels
-												? 'tertiary'
-												: undefined
-										}
-										aria-expanded={ isListViewOpen }
-									/>
-								) }
-								{ isZoomedOutViewExperimentEnabled &&
-									! isDistractionFree &&
-									! hasFixedToolbar && (
+							) }
+							{ isLargeViewport && (
+								<>
+									{ ! hasFixedToolbar && (
 										<ToolbarItem
 											as={ ToolSelector }
 											showTooltip={ ! showIconLabels }
@@ -286,6 +235,60 @@ export default function HeaderEditMode() {
 											disabled={ ! isVisualMode }
 										/>
 									) }
+									<ToolbarItem
+										ref={ inserterButton }
+										as={ Button }
+										className="edit-site-header-edit-mode__inserter-toggle"
+										variant="primary"
+										isPressed={ isInserterOpen }
+										onMouseDown={ preventDefault }
+										onClick={ toggleInserter }
+										disabled={ ! isVisualMode }
+										icon={ plus }
+										label={
+											showIconLabels
+												? shortLabel
+												: longLabel
+										}
+										showTooltip={ ! showIconLabels }
+									/>
+									{ ! isDistractionFree && (
+										<ToolbarItem
+											as={ Button }
+											className="edit-site-header-edit-mode__list-view-toggle"
+											disabled={
+												! isVisualMode ||
+												isZoomedOutView
+											}
+											icon={ listView }
+											isPressed={ isListViewOpen }
+											/* translators: button label text should, if possible, be under 16 characters. */
+											label={ __( 'List View' ) }
+											onClick={ toggleListView }
+											shortcut={ listViewShortcut }
+											showTooltip={ ! showIconLabels }
+											variant={
+												showIconLabels
+													? 'tertiary'
+													: undefined
+											}
+											aria-expanded={ isListViewOpen }
+										/>
+									) }
+									{ isZoomedOutViewExperimentEnabled &&
+										! isDistractionFree &&
+										! hasFixedToolbar && (
+											<ToolbarItem
+												as={ ToolSelector }
+												showTooltip={ ! showIconLabels }
+												variant={
+													showIconLabels
+														? 'tertiary'
+														: undefined
+												}
+												disabled={ ! isVisualMode }
+											/>
+										) }
 									<ToolbarItem
 										as={ UndoButton }
 										showTooltip={ ! showIconLabels }
@@ -362,7 +365,7 @@ export default function HeaderEditMode() {
 						name="__experimentalInlineRichTextTools"
 						bubblesVirtually
 					/>
-				</>
+				</span>
 			) }
 
 			{ ! isDistractionFree && (

--- a/packages/edit-site/src/components/header-edit-mode/index.js
+++ b/packages/edit-site/src/components/header-edit-mode/index.js
@@ -186,12 +186,13 @@ export default function HeaderEditMode() {
 
 	return (
 		<div
+			role="menubar"
 			className={ classnames( 'edit-site-header-edit-mode', {
 				'show-icon-labels': showIconLabels,
 			} ) }
 		>
 			{ hasDefaultEditorCanvasView && (
-				<span role="menubar">
+				<>
 					<NavigableToolbar
 						as={ motion.div }
 						className="edit-site-header-edit-mode__start"
@@ -312,7 +313,7 @@ export default function HeaderEditMode() {
 						name="__experimentalInlineRichTextTools"
 						bubblesVirtually
 					/>
-				</span>
+				</>
 			) }
 
 			{ ! isDistractionFree && (

--- a/packages/edit-site/src/components/keyboard-shortcuts/edit-mode.js
+++ b/packages/edit-site/src/components/keyboard-shortcuts/edit-mode.js
@@ -35,8 +35,12 @@ function KeyboardShortcutsEditMode() {
 		useDispatch( interfaceStore );
 
 	const { replaceBlocks } = useDispatch( blockEditorStore );
-	const { getBlockName, getSelectedBlockClientId, getBlockAttributes } =
-		useSelect( blockEditorStore );
+	const {
+		getBlockName,
+		getLastFocus,
+		getSelectedBlockClientId,
+		getBlockAttributes,
+	} = useSelect( blockEditorStore );
 
 	const handleTextLevelShortcut = ( event, level ) => {
 		event.preventDefault();
@@ -116,6 +120,19 @@ function KeyboardShortcutsEditMode() {
 
 	useShortcut( 'core/edit-site/toggle-distraction-free', () => {
 		toggleDistractionFree();
+	} );
+
+	useShortcut( 'core/edit-site/focus-editor', ( event ) => {
+		event.preventDefault();
+		const lastFocus = getLastFocus();
+		// Only move focus if the selected block is a match with the last focused block
+		if (
+			getSelectedBlockClientId() &&
+			lastFocus?.current &&
+			lastFocus?.current.id.includes( getSelectedBlockClientId() )
+		) {
+			lastFocus.current.focus();
+		}
 	} );
 
 	return null;

--- a/packages/edit-site/src/components/keyboard-shortcuts/register.js
+++ b/packages/edit-site/src/components/keyboard-shortcuts/register.js
@@ -159,6 +159,18 @@ function KeyboardShortcutsRegister() {
 				character: '\\',
 			},
 		} );
+
+		registerShortcut( {
+			name: 'core/edit-site/focus-editor',
+			category: 'global',
+			description: __(
+				'Navigate to the last focused element in the editor.'
+			),
+			keyCombination: {
+				modifier: 'alt',
+				character: 'F9',
+			},
+		} );
 	}, [ registerShortcut ] );
 
 	return null;

--- a/packages/edit-site/src/components/layout/style.scss
+++ b/packages/edit-site/src/components/layout/style.scss
@@ -249,23 +249,6 @@
 	}
 }
 
-.edit-site-layout.has-fixed-toolbar {
-	// making the header be lower than the content
-	// so the fixed toolbar can be positioned on top of it
-	// but only on desktop
-	@include break-medium() {
-		.edit-site-layout__canvas-container {
-			z-index: 5;
-		}
-		.edit-site-site-hub {
-			z-index: 4;
-		}
-		.edit-site-layout__header:focus-within {
-			z-index: 3;
-		}
-	}
-}
-
 .is-edit-mode.is-distraction-free {
 
 	.edit-site-layout__header-container {

--- a/packages/editor/src/components/global-keyboard-shortcuts/index.js
+++ b/packages/editor/src/components/global-keyboard-shortcuts/index.js
@@ -48,7 +48,7 @@ export default function EditorKeyboardShortcuts() {
 		savePost();
 	} );
 
-	useShortcut( 'core/block-editor/focus-editor', ( event ) => {
+	useShortcut( 'core/editor/focus-editor', ( event ) => {
 		event.preventDefault();
 		const lastFocus = getLastFocus();
 		// Only move focus if the selected block is a match with the last focused block

--- a/packages/editor/src/components/global-keyboard-shortcuts/index.js
+++ b/packages/editor/src/components/global-keyboard-shortcuts/index.js
@@ -3,6 +3,7 @@
  */
 import { useShortcut } from '@wordpress/keyboard-shortcuts';
 import { useDispatch, useSelect } from '@wordpress/data';
+import { store as blockEditorStore } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
@@ -12,6 +13,8 @@ import { store as editorStore } from '../../store';
 export default function EditorKeyboardShortcuts() {
 	const { redo, undo, savePost } = useDispatch( editorStore );
 	const { isEditedPostDirty, isPostSavingLocked } = useSelect( editorStore );
+	const { getLastFocus, getSelectedBlockClientId } =
+		useSelect( blockEditorStore );
 
 	useShortcut( 'core/editor/undo', ( event ) => {
 		undo();
@@ -43,6 +46,19 @@ export default function EditorKeyboardShortcuts() {
 		}
 
 		savePost();
+	} );
+
+	useShortcut( 'core/block-editor/focus-editor', ( event ) => {
+		event.preventDefault();
+		const lastFocus = getLastFocus();
+		// Only move focus if the selected block is a match with the last focused block
+		if (
+			getSelectedBlockClientId() &&
+			lastFocus?.current &&
+			lastFocus?.current.id.includes( getSelectedBlockClientId() )
+		) {
+			lastFocus.current.focus();
+		}
 	} );
 
 	return null;

--- a/packages/editor/src/components/global-keyboard-shortcuts/register-shortcuts.js
+++ b/packages/editor/src/components/global-keyboard-shortcuts/register-shortcuts.js
@@ -55,7 +55,7 @@ function EditorKeyboardShortcutsRegister() {
 		} );
 
 		registerShortcut( {
-			name: 'core/block-editor/focus-editor',
+			name: 'core/editor/focus-editor',
 			category: 'global',
 			description: __(
 				'Navigate to the last focused element in the editor.'

--- a/packages/editor/src/components/global-keyboard-shortcuts/register-shortcuts.js
+++ b/packages/editor/src/components/global-keyboard-shortcuts/register-shortcuts.js
@@ -53,6 +53,18 @@ function EditorKeyboardShortcutsRegister() {
 						},
 				  ],
 		} );
+
+		registerShortcut( {
+			name: 'core/block-editor/focus-editor',
+			category: 'global',
+			description: __(
+				'Navigate to the last focused element in the editor.'
+			),
+			keyCombination: {
+				modifier: 'alt',
+				character: 'F9',
+			},
+		} );
 	}, [ registerShortcut ] );
 
 	return <BlockEditorKeyboardShortcuts.Register />;

--- a/packages/rich-text/src/create.js
+++ b/packages/rich-text/src/create.js
@@ -298,7 +298,7 @@ function filterRange( node, range, filter ) {
  * @param {string} string
  */
 function collapseWhiteSpace( string ) {
-	return string.replace( /[\n\r\t]+/g, ' ' );
+	return string.replace( /[\n\r]+/g, ' ' );
 }
 
 /**


### PR DESCRIPTION
Large refactor/spike to test out how combining block tools in the DOM might be possible, as discussed in https://github.com/WordPress/gutenberg/issues/53013. All mouse + visual placements should be the same. 

This is a big commit with a large potential for bugs. Think of this as a spike or POC for now. There'll be a lot to address. Some general TODOs:
- [ ] Refactor shared code between empty-block-inserter and selected-block-tools
- [x] Shortcut/keystrokes for returning from the toolbar to where the cursor was before moving into the toolbar.
- [x] Inline Tools either move to the top toolbar or get inserted into the main block toolbar (think image caption formatting tools)
- [ ] Communicate that Tab/Shift+Tab can navigate between different toolbars, potentially via a dismissible notice the first time focus is moved into it via the shortcut: "Tip: Press Tab/Shift+Tab to navigate to other toolbars, and press Escape to return focus to the editor"
- [ ] Visual styles for the top toolbar:
   - [ ] Site Editor: When top toolbar is expanded, hide the central command + k button
   - [ ] Post Editor: When top toolbar is expanded at smaller screens, hide the right side save/preview button area
   

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
This PR is intended as an exploration if we can refactor how the block toolbar structure works to be more like a classic word editor where alt + f10 moves you to all of the block tools. An escape keypress would bring you back to where you were in the editor. If we move forward with this idea, this PR can be split into smaller, more production ready PRs. Think of this as a playground for how it could work.

## What?
Moving all Document and Block Tools together into the DOM. 

## Why?
- Find a more accessible implementation of the toolbars that can be better communicated to AT
- Allow tab and shift + tab to work natively in the editor (i.e. a tab keypress should indent the text)

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Moves Block Tools into the editor header using slot/fill.

## Ideas
- If the entire header is a menubar, if focus is in the menubar, can an escape keypress return focus to the editor canvas?

## Testing Instructions
Visual and mouse interactions should all be identical to trunk for both Top Toolbar and the default floating block toolbar. Ideally, you don't notice any changes. 

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

#### Combined Toolbar Controls
- The block toolbar is now always positioned within the header toolbar, even if it is visually floating next to a block. 
- Edit a block
- Press alt + f10 (fn + option + f10 on mac) to reach the block toolbar
- Shift + tab should focus the document tools

#### Focusing the block toolbar
- Press alt + f10 (fn + option + f10 on mac) to reach the block toolbar
- This should work from anywhere in or outside of the editor, no change from trunk

#### Returning focus to the block
- Edit a block
- Press alt + f10 (fn + option + f10 on mac) to reach the block toolbar
- Press escape to return the caret to the same place in the editor
- This currently does not have a "reset" so if you tab off and back into the block toolbar, an escape keypress will still return you to the editor canvas. 

#### Returning focus to the block from anywhere outside the block toolbar (Could be removed if superfluous, but I feel like it's quite nice for navigating)
- Make edits
- Leave the editor canvas (interact with the sidebar, etc)
- Press alt + f9 (fn + option + f9 on mac) Shortcut could be any reasonable combo. I just chose one similar to the toolbar focus one.
- Focus should return to the editor canvas at the same location you previously were

#### Stretch goal, shouldn't be merged in this PR. Used as an example of what's possible now: Tab keypresses on rich text blocks enter tab space.
- Insert paragraph block
- Press Tab
- Type
- You should have a tab space and then text
- shift + tab does not work to 

## Screenshots or screencast <!-- if applicable -->
