### PR TITLE
Buttons Block: Show inserter if button have variations (#53498)

### DIFF
--- a/packages/block-library/src/buttons/edit.js
+++ b/packages/block-library/src/buttons/edit.js
@@ -61,6 +61,7 @@ function ButtonsEdit( { attributes, className } ) {
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {
 		allowedBlocks: ALLOWED_BLOCKS,
 		defaultBlock: DEFAULT_BLOCK,
+		// This check should be handled by the `Inserter` internally to be consistent across all blocks that use it.
 		directInsert: ! hasButtonVariations,
 		template: [
 			[

--- a/packages/block-library/src/buttons/edit.js
+++ b/packages/block-library/src/buttons/edit.js
@@ -43,19 +43,19 @@ function ButtonsEdit( { attributes, className } ) {
 			'has-custom-font-size': fontSize || style?.typography?.fontSize,
 		} ),
 	} );
-	const preferredStyle = useSelect( ( select ) => {
+	const { preferredStyle, hasButtonVariations } = useSelect( ( select ) => {
 		const preferredStyleVariations =
 			select( blockEditorStore ).getSettings()
 				.__experimentalPreferredStyleVariations;
-		return preferredStyleVariations?.value?.[ buttonBlockName ];
-	}, [] );
-
-	const hasButtonVariations = useSelect( ( select ) => {
 		const buttonVariations = select( blocksStore ).getBlockVariations(
 			buttonBlockName,
 			'inserter'
 		);
-		return buttonVariations.length > 0;
+		return {
+			preferredStyle:
+				preferredStyleVariations?.value?.[ buttonBlockName ],
+			hasButtonVariations: buttonVariations.length > 0,
+		};
 	}, [] );
 
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {

--- a/packages/block-library/src/buttons/edit.js
+++ b/packages/block-library/src/buttons/edit.js
@@ -12,6 +12,7 @@ import {
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import { useSelect } from '@wordpress/data';
+import { store as blocksStore } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -49,10 +50,18 @@ function ButtonsEdit( { attributes, className } ) {
 		return preferredStyleVariations?.value?.[ buttonBlockName ];
 	}, [] );
 
+	const hasButtonVariations = useSelect( ( select ) => {
+		const buttonVariations = select( blocksStore ).getBlockVariations(
+			buttonBlockName,
+			'inserter'
+		);
+		return buttonVariations.length > 0;
+	}, [] );
+
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {
 		allowedBlocks: ALLOWED_BLOCKS,
 		defaultBlock: DEFAULT_BLOCK,
-		directInsert: true,
+		directInsert: ! hasButtonVariations,
 		template: [
 			[
 				buttonBlockName,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This PR update the Buttons block to show the inserter if the button have variations. Fix #53498

## Why?
Currently, when adding a button's variation with the default `scope`, there is no way to use that variation due to the `directInsert` option in the `innerBlocksProps` which bypass the inserter. The only way is to add the `transform` scope.

## How?
This PR change the value of the `directInsert` option if button variations exists.

## Testing Instructions
Snippet to register a button variation :
```js
wp.blocks.registerBlockVariation('core/button', {
	name: 'custom-button',
	title: 'My custom button',
	scope: ['transform', 'inserter', 'block'],
	attributes: {className: 'my-custom-button'},
});
```

### Instructions
1. Edit a post,
2. Add a Buttons block,
3. Add a button, the button should be added directly without showing the inserter,
4. Using the browser console, register a button variation,
5. Add a button, the inserter should appear and let you select between the default button and the variation.

## Screenshots or screencast <!-- if applicable -->
<img width="826" alt="buttons_block_inserter" src="https://github.com/WordPress/gutenberg/assets/158572/d62c9d08-d67b-41c8-8793-271d9d99e120">

