### PR TITLE
Buttons block: Support default button variation in template and default block

### DIFF
--- a/packages/block-library/src/buttons/edit.js
+++ b/packages/block-library/src/buttons/edit.js
@@ -49,11 +49,12 @@ function ButtonsEdit( { attributes, className } ) {
 		const defaultButton = select( blocksStore ).getDefaultBlockVariation(
 			buttonBlockName
 		) || { attributes: {} };
+		const buttonClasses = classnames( defaultButton.attributes.className, {
+			[ `is-style-${ preferredStyle }` ]: !! preferredStyle,
+		} );
 		return {
 			...defaultButton.attributes,
-			className: classnames( defaultButton.attributes.className, {
-				[ `is-style-${ preferredStyle }` ]: !! preferredStyle,
-			} ),
+			className: buttonClasses === '' ? undefined : buttonClasses,
 		};
 	}, [] );
 

--- a/packages/block-library/src/buttons/edit.js
+++ b/packages/block-library/src/buttons/edit.js
@@ -11,12 +11,10 @@ import {
 	useInnerBlocksProps,
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
+import { store as blocksStore } from '@wordpress/blocks';
 import { useSelect } from '@wordpress/data';
 
-/**
- * Internal dependencies
- */
-import { name as buttonBlockName } from '../button';
+const buttonBlockName = 'core/button';
 
 const ALLOWED_BLOCKS = [ buttonBlockName ];
 
@@ -42,23 +40,28 @@ function ButtonsEdit( { attributes, className } ) {
 			'has-custom-font-size': fontSize || style?.typography?.fontSize,
 		} ),
 	} );
-	const preferredStyle = useSelect( ( select ) => {
+	const defaultButtonAttributes = useSelect( ( select ) => {
 		const preferredStyleVariations =
 			select( blockEditorStore ).getSettings()
 				.__experimentalPreferredStyleVariations;
-		return preferredStyleVariations?.value?.[ buttonBlockName ];
+		const preferredStyle =
+			preferredStyleVariations?.value?.[ buttonBlockName ];
+		const defaultButton = select( blocksStore ).getDefaultBlockVariation(
+			buttonBlockName
+		) || { attributes: {} };
+		return {
+			...defaultButton.attributes,
+			className: classnames( defaultButton.attributes.className, {
+				[ `is-style-${ preferredStyle }` ]: !! preferredStyle,
+			} ),
+		};
 	}, [] );
 
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {
 		allowedBlocks: ALLOWED_BLOCKS,
-		defaultBlock: DEFAULT_BLOCK,
+		defaultBlock: { ...DEFAULT_BLOCK, attributes: defaultButtonAttributes },
 		directInsert: true,
-		template: [
-			[
-				buttonBlockName,
-				{ className: preferredStyle && `is-style-${ preferredStyle }` },
-			],
-		],
+		template: [ [ buttonBlockName, defaultButtonAttributes ] ],
 		templateInsertUpdatesSelection: true,
 		orientation: layout?.orientation ?? 'horizontal',
 	} );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes #53517 the lack of respect for default style variations in the Buttons block.

## Why?
Default block variations ought to be respected.

## How?
Reads the default block variation from the block editor store and applies said variation’s attributes to the inner blocks template and the default block.

## Testing Instructions
…soon

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
