### PR TITLE
[POC] Patterns: explore options for partial syncing

### DIFF
--- a/packages/block-library/src/block/block.json
+++ b/packages/block-library/src/block/block.json
@@ -10,7 +10,17 @@
 	"attributes": {
 		"ref": {
 			"type": "number"
+		},
+		"dynamicContent": {
+			"type": "object"
+		},
+		"setDynamicContent": {
+			"type": "function"
 		}
+	},
+	"providesContext": {
+		"dynamicContent": "dynamicContent",
+		"setDynamicContent": "setDynamicContent"
 	},
 	"supports": {
 		"customClassName": false,

--- a/packages/block-library/src/block/edit.js
+++ b/packages/block-library/src/block/edit.js
@@ -22,8 +22,22 @@ import {
 	useBlockProps,
 	Warning,
 } from '@wordpress/block-editor';
+import { useEffect } from '@wordpress/element';
 
-export default function ReusableBlockEdit( { attributes: { ref } } ) {
+export default function ReusableBlockEdit( {
+	attributes: { ref },
+	setAttributes,
+} ) {
+	const setDynamicContent = ( newDynamicContent ) => {
+		setAttributes( {
+			dynamicContent: newDynamicContent,
+		} );
+	};
+
+	useEffect( () => {
+		setAttributes( { setDynamicContent } );
+	}, [] );
+
 	const hasAlreadyRendered = useHasRecursion( ref );
 	const { record, hasResolved } = useEntityRecord(
 		'postType',

--- a/packages/block-library/src/paragraph/block.json
+++ b/packages/block-library/src/paragraph/block.json
@@ -7,7 +7,7 @@
 	"description": "Start with the basic building block of all narrative.",
 	"keywords": [ "text" ],
 	"textdomain": "default",
-	"usesContext": [ "postId" ],
+	"usesContext": [ "postId", "dynamicContent", "setDynamicContent" ],
 	"attributes": {
 		"align": {
 			"type": "string"
@@ -32,6 +32,7 @@
 		}
 	},
 	"supports": {
+		"__experimentalMetadata": true,
 		"anchor": true,
 		"className": false,
 		"color": {

--- a/packages/block-library/src/paragraph/edit.js
+++ b/packages/block-library/src/paragraph/edit.js
@@ -12,6 +12,7 @@ import {
 	ToolbarButton,
 	ToggleControl,
 	__experimentalToolsPanelItem as ToolsPanelItem,
+	PanelBody,
 } from '@wordpress/components';
 import {
 	AlignmentControl,
@@ -145,6 +146,30 @@ function ParagraphBlock( {
 					</ToolsPanelItem>
 				</InspectorControls>
 			) }
+			{ dynamicContent && (
+				<InspectorControls>
+					<PanelBody title={ __( 'Syncing' ) } initialOpen={ true }>
+						<ToggleControl
+							__nextHasNoMarginBottom
+							label={ __( 'Sync' ) }
+							checked={
+								! dynamicContent[ attributes.metadata?.id ]
+							}
+							onChange={ () =>
+								setAttributes( {
+									metadata: {
+										...attributes.metadata,
+										id: undefined,
+									},
+								} )
+							}
+							help={ __(
+								'Toggle to sync original pattern content'
+							) }
+						/>
+					</PanelBody>
+				</InspectorControls>
+			) }
 			<RichText
 				identifier="content"
 				tagName="p"
@@ -157,6 +182,7 @@ function ParagraphBlock( {
 					if ( isOriginal || value ) {
 						newAttributes = {
 							...attributes,
+							metadata: { ...attributes.metadata, id: undefined },
 							content: value,
 						};
 					}


### PR DESCRIPTION
## What?
Very much a draft  PoC to explore options for allowing partial syncing of user created patterns, ie. allow some blocks to be synced with the source pattern, and others to have unique content per instance.

## Why?
See https://github.com/WordPress/gutenberg/issues/53705 for reasoning

## How?

- This PR is exploring the option of storing dynamic content in the source pattern's attributes. Each child block is assigned a unique id to allow the dynamic content to be stored in a flat object keyed by id
- The parent pattern makes this dynamic content object, along with a function to update it available via block context
- If dynamic content for a given block is present in context this overrides the child blocks own content
- If the dynamic content for a block is removed the block reverts to the original content attribute from the pattern

## Important notes

- **This is just a rough prototype hard coded to gain understanding - it is not intended for production implementation** - the next step is to look how to move all this to the [custom attribute provider approach outlined here](https://github.com/WordPress/gutenberg/pull/51375).
- This currently only works with the paragraph block
- This prototype works by hardcoding additional functionality into the paragraph block edit method. This is just to try and shake out all the different functionality/flows that are going to be needed to make this work, so we know what is going to be needed in a [custom attribute provider approach outlined here](https://github.com/WordPress/gutenberg/pull/51375)
- There are currently lots of glitches to work through with this prototype, so don't worry about detailed testing and bug reporting at this stage

## Testing Instructions

- Add a group with a couple of paragraphs, try nesting other paragraphs in nested groups, columns, etc. within parent group
- Convert the parent block to a synced pattern
- Insert the synced pattern in another post and try editing the paragraphs
- Insert another copy and see that source pattern content still there, and see that you can still edit that independently
- Use the `Sync` toggle in paragraph inspector panel to switch back to patterns source content


### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/3629020/923e2b61-9fdd-4111-9f74-b2e57f990caa





