### PR TITLE
getInsertionPoint: Fix type check for the state value

### DIFF
--- a/packages/customize-widgets/src/store/selectors.js
+++ b/packages/customize-widgets/src/store/selectors.js
@@ -40,7 +40,7 @@ export function isInserterOpened( state ) {
  * @return {Object} The root client ID and index to insert at.
  */
 export function __experimentalGetInsertionPoint( state ) {
-	if ( typeof state === 'boolean' ) {
+	if ( typeof state.blockInserterPanel === 'boolean' ) {
 		return EMPTY_INSERTION_POINT;
 	}
 

--- a/packages/edit-post/src/store/selectors.js
+++ b/packages/edit-post/src/store/selectors.js
@@ -477,7 +477,7 @@ export function isInserterOpened( state ) {
  * @return {Object} The root client ID, index to insert at and starting filter value.
  */
 export function __experimentalGetInsertionPoint( state ) {
-	if ( typeof state === 'boolean' ) {
+	if ( typeof state.blockInserterPanel === 'boolean' ) {
 		return EMPTY_INSERTION_POINT;
 	}
 

--- a/packages/edit-widgets/src/store/selectors.js
+++ b/packages/edit-widgets/src/store/selectors.js
@@ -259,7 +259,7 @@ export function isInserterOpened( state ) {
  * @return {Object} The root client ID and index to insert at.
  */
 export function __experimentalGetInsertionPoint( state ) {
-	if ( typeof state === 'boolean' ) {
+	if ( typeof state.blockInserterPanel === 'boolean' ) {
 		return EMPTY_INSERTION_POINT;
 	}
 


### PR DESCRIPTION
## What?
This is a follow-up to #53722.

I just realized that I made a huge typo in #53722. The selector should check the `state.blockInserterPanel` type, instead, it was checking the type of the whole global state object.

This PR fixes that issue.

## Testing Instructions
Same as in #53722.
