### PR TITLE
Block Editor: Fix cleanup in the 'useNavModeExit' hook

### DIFF
--- a/packages/block-editor/src/components/block-list/use-block-props/use-nav-mode-exit.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-nav-mode-exit.js
@@ -38,7 +38,7 @@ export function useNavModeExit( clientId ) {
 			node.addEventListener( 'mousedown', onMouseDown );
 
 			return () => {
-				node.addEventListener( 'mousedown', onMouseDown );
+				node.removeEventListener( 'mousedown', onMouseDown );
 			};
 		},
 		[ clientId, isNavigationMode, isBlockSelected, setNavigationMode ]


### PR DESCRIPTION
## What?
Fixes #53775.

PR fix cleanup in the `useNavModeEdit` hook to correctly remove the event handler

## Testing Instructions
* CI checks are green
* Enter navigation mode and click on the selected block. This should exit navigation mode.
