### PR TITLE
Components: Fix the cleanup method for SandBox

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fix
+
+-   `SandBox`: Fix the cleanup method in useEffect ([#53796](https://github.com/WordPress/gutenberg/pull/53796)).
+
 ## 25.6.0 (2023-08-16)
 
 ### Enhancements

--- a/packages/components/src/sandbox/index.tsx
+++ b/packages/components/src/sandbox/index.tsx
@@ -254,7 +254,10 @@ function SandBox( {
 
 		return () => {
 			iframe?.removeEventListener( 'load', tryNoForceSandBox, false );
-			defaultView?.addEventListener( 'message', checkMessageForResize );
+			defaultView?.removeEventListener(
+				'message',
+				checkMessageForResize
+			);
 		};
 		// Ignore reason: passing `exhaustive-deps` will likely involve a more detailed refactor.
 		// See https://github.com/WordPress/gutenberg/pull/44378


### PR DESCRIPTION
## What?
PR fixes cleanup in the `SandBox` component to correctly remove the event handler.

## Testing Instructions
CI checks are green.