### PR TITLE
[TRY] Fix Gutenberg Mobile commit error

### DIFF
--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1972,7 +1972,7 @@ export const getInserterItems = createSelector(
 				id,
 				name: 'core/block',
 				initialAttributes: { ref: reusableBlock.id },
-				title: reusableBlock.title.raw,
+				title: reusableBlock.title?.raw,
 				icon,
 				category: 'reusable',
 				keywords: [ 'reusable' ],

--- a/packages/editor/src/components/editor-help/index.native.js
+++ b/packages/editor/src/components/editor-help/index.native.js
@@ -102,7 +102,7 @@ function EditorHelpTopics( { close, isVisible, onClose, showSupport } ) {
 			contentStyle={ styles.contentContainer }
 			testID="editor-help-modal"
 		>
-			<SafeAreaView>
+			<SafeAreaView style={ styles.safeAreaContainer }>
 				<BottomSheet.NavigationContainer
 					animate
 					main

--- a/packages/editor/src/components/editor-help/style.scss
+++ b/packages/editor/src/components/editor-help/style.scss
@@ -19,7 +19,12 @@
 	color: $dark-primary;
 }
 
+.safeAreaContainer {
+	flex: 1;
+}
+
 .navigationContainer {
+	flex: 1;
 	overflow: hidden;
 }
 

--- a/packages/react-native-aztec/package.json
+++ b/packages/react-native-aztec/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/react-native-aztec",
-	"version": "1.100.1",
+	"version": "1.101.0",
 	"description": "Aztec view for react-native.",
 	"private": true,
 	"author": "The WordPress Contributors",

--- a/packages/react-native-aztec/package.json
+++ b/packages/react-native-aztec/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/react-native-aztec",
-	"version": "1.101.0",
+	"version": "1.101.1",
 	"description": "Aztec view for react-native.",
 	"private": true,
 	"author": "The WordPress Contributors",

--- a/packages/react-native-bridge/package.json
+++ b/packages/react-native-bridge/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/react-native-bridge",
-	"version": "1.100.1",
+	"version": "1.101.0",
 	"description": "Native bridge library used to integrate the block editor into a native App.",
 	"private": true,
 	"author": "The WordPress Contributors",

--- a/packages/react-native-bridge/package.json
+++ b/packages/react-native-bridge/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/react-native-bridge",
-	"version": "1.101.0",
+	"version": "1.101.1",
 	"description": "Native bridge library used to integrate the block editor into a native App.",
 	"private": true,
 	"author": "The WordPress Contributors",

--- a/packages/react-native-editor/CHANGELOG.md
+++ b/packages/react-native-editor/CHANGELOG.md
@@ -17,7 +17,6 @@ For each user feature we should also add a importance categorization label  to i
 -   [**] Upgrade React Native to 0.71.11 [#51303]
 -   [*] Upgrade Gradle to 8.2.1 & AGP to 8.1.0 [#52872]
 -   [*] Fix Gallery block selection when adding media [#53127]
--   [**] Fix iOS Focus loop for RichText components [#53217]
 
 ## 1.100.1
 -   [**] Add WP hook for registering non-core blocks [#52791]

--- a/packages/react-native-editor/CHANGELOG.md
+++ b/packages/react-native-editor/CHANGELOG.md
@@ -11,6 +11,9 @@ For each user feature we should also add a importance categorization label  to i
 
 ## Unreleased
 
+## 1.101.1
+-   [**] Fix the dynamic height when opening/closing navigation screens within the bottom sheet. [#53608]
+
 ## 1.101.0
 -   [*] Remove visual gap in mobile toolbar when a Gallery block is selected [#52966]
 -   [*] Remove Gallery caption button on mobile [#53010]

--- a/packages/react-native-editor/CHANGELOG.md
+++ b/packages/react-native-editor/CHANGELOG.md
@@ -10,6 +10,8 @@ For each user feature we should also add a importance categorization label  to i
 -->
 
 ## Unreleased
+
+## 1.101.0
 -   [*] Remove visual gap in mobile toolbar when a Gallery block is selected [#52966]
 -   [*] Remove Gallery caption button on mobile [#53010]
 -   [**] Upgrade React Native to 0.71.11 [#51303]

--- a/packages/react-native-editor/ios/Podfile.lock
+++ b/packages/react-native-editor/ios/Podfile.lock
@@ -13,7 +13,7 @@ PODS:
     - ReactCommon/turbomodule/core (= 0.71.11)
   - fmt (6.2.1)
   - glog (0.3.5)
-  - Gutenberg (1.100.1):
+  - Gutenberg (1.101.0):
     - React-Core (= 0.71.11)
     - React-CoreModules (= 0.71.11)
     - React-RCTImage (= 0.71.11)
@@ -394,7 +394,7 @@ PODS:
     - React-RCTImage
   - RNSVG (13.9.0):
     - React-Core
-  - RNTAztecView (1.100.1):
+  - RNTAztecView (1.101.0):
     - React-Core
     - WordPress-Aztec-iOS (~> 1.19.8)
   - SDWebImage (5.11.1):
@@ -577,7 +577,7 @@ SPEC CHECKSUMS:
   FBReactNativeSpec: f07662560742d82a5b73cee116c70b0b49bcc220
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
   glog: 04b94705f318337d7ead9e6d17c019bd9b1f6b1b
-  Gutenberg: 68bee259a516c052424d03936ddd961cf8b906cb
+  Gutenberg: d0808b714cad9e66130dcce03f5030ac09f0276d
   libwebp: 60305b2e989864154bd9be3d772730f08fc6a59c
   RCT-Folly: 424b8c9a7a0b9ab2886ffe9c3b041ef628fd4fb1
   RCTRequired: f6187ec763637e6a57f5728dd9a3bdabc6d6b4e0
@@ -593,13 +593,13 @@ SPEC CHECKSUMS:
   React-jsiexecutor: 089cd07c76ecf498960a64ba8ae0f2dddd382f44
   React-jsinspector: b6ed4cb3ffa27a041cd440300503dc512b761450
   React-logger: 186dd536128ae5924bc38ed70932c00aa740cd5b
-  react-native-blur: 8cd9b4a8007166ad643f4dff914c3fddd2ff5b9a
+  react-native-blur: 3e9c8e8e9f7d17fa1b94e1a0ae9fd816675f5382
   react-native-get-random-values: b6fb85e7169b9822976793e467458c151c3e8b69
   react-native-safe-area: c9cf765aa2dd96159476a99633e7d462ce5bb94f
-  react-native-safe-area-context: 5496bfc1fb0f0e096eeb740377d6a3d62597abe2
+  react-native-safe-area-context: 36cc67648134e89465663b8172336a19eeda493d
   react-native-slider: dff0d8a46f368a8d1bacd8638570d75b9b0be400
-  react-native-video: afb806880af4f6612683ab678a793ae41bc39705
-  react-native-webview: e3b659a6d614bb37fb12a2de82c91a378c59d84b
+  react-native-video: 6dee623307ed9d04d1be2de87494f9a0fa2041d1
+  react-native-webview: 9f111dfbcfc826084d6c507f569e5e03342ee1c1
   React-perflogger: e706562ab7eb8eb590aa83a224d26fa13963d7f2
   React-RCTActionSheet: 57d4bd98122f557479a3359ad5dad8e109e20c5a
   React-RCTAnimation: ccf3ef00101ea74bda73a045d79a658b36728a60
@@ -613,14 +613,14 @@ SPEC CHECKSUMS:
   React-RCTVibration: f09f08de63e4122deb32506e20ca4cae6e4e14c1
   React-runtimeexecutor: 4817d63dbc9d658f8dc0ec56bd9b83ce531129f0
   ReactCommon: e2d70ebcd90a2eaab343fb0cc23bbdb5ac321f5c
-  RNCClipboard: 33ec5830d149587a7d9de7bee1f80889f101dda6
-  RNCMaskedView: 627993e2ddd1ed09c1d540a61c4311cfc507bbe7
+  RNCClipboard: 3f0451a8100393908bea5c5c5b16f96d45f30bfc
+  RNCMaskedView: 949696f25ec596bfc697fc88e6f95cf0c79669b6
   RNFastImage: 1f2cab428712a4baaf78d6169eaec7f622556dd7
   RNGestureHandler: f75d81410b40aaa99e71ae8f8bb7a88620c95042
   RNReanimated: df2567658c01135f9ff4709d372675bcb9fd1d83
   RNScreens: 68fd1060f57dd1023880bf4c05d74784b5392789
   RNSVG: 53c661b76829783cdaf9b7a57258f3d3b4c28315
-  RNTAztecView: f959829b0cfd6b660f5a0cc6b92bf60ba96c0ab7
+  RNTAztecView: eace043b38d25193a2e7d9dfce1ce890b9348b98
   SDWebImage: a7f831e1a65eb5e285e3fb046a23fcfbf08e696d
   SDWebImageWebPCoder: 908b83b6adda48effe7667cd2b7f78c897e5111d
   WordPress-Aztec-iOS: 7d11d598f14c82c727c08b56bd35fbeb7dafb504

--- a/packages/react-native-editor/ios/Podfile.lock
+++ b/packages/react-native-editor/ios/Podfile.lock
@@ -13,7 +13,7 @@ PODS:
     - ReactCommon/turbomodule/core (= 0.71.11)
   - fmt (6.2.1)
   - glog (0.3.5)
-  - Gutenberg (1.101.0):
+  - Gutenberg (1.101.1):
     - React-Core (= 0.71.11)
     - React-CoreModules (= 0.71.11)
     - React-RCTImage (= 0.71.11)
@@ -394,7 +394,7 @@ PODS:
     - React-RCTImage
   - RNSVG (13.9.0):
     - React-Core
-  - RNTAztecView (1.101.0):
+  - RNTAztecView (1.101.1):
     - React-Core
     - WordPress-Aztec-iOS (~> 1.19.8)
   - SDWebImage (5.11.1):
@@ -577,7 +577,7 @@ SPEC CHECKSUMS:
   FBReactNativeSpec: f07662560742d82a5b73cee116c70b0b49bcc220
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
   glog: 04b94705f318337d7ead9e6d17c019bd9b1f6b1b
-  Gutenberg: d0808b714cad9e66130dcce03f5030ac09f0276d
+  Gutenberg: 8f153a8a9ce7343bc4533bc1d0728ce9c9bfb86a
   libwebp: 60305b2e989864154bd9be3d772730f08fc6a59c
   RCT-Folly: 424b8c9a7a0b9ab2886ffe9c3b041ef628fd4fb1
   RCTRequired: f6187ec763637e6a57f5728dd9a3bdabc6d6b4e0
@@ -620,7 +620,7 @@ SPEC CHECKSUMS:
   RNReanimated: df2567658c01135f9ff4709d372675bcb9fd1d83
   RNScreens: 68fd1060f57dd1023880bf4c05d74784b5392789
   RNSVG: 53c661b76829783cdaf9b7a57258f3d3b4c28315
-  RNTAztecView: eace043b38d25193a2e7d9dfce1ce890b9348b98
+  RNTAztecView: 09cf0bda64c4a3a4d33bee3bdab4ed03506eba86
   SDWebImage: a7f831e1a65eb5e285e3fb046a23fcfbf08e696d
   SDWebImageWebPCoder: 908b83b6adda48effe7667cd2b7f78c897e5111d
   WordPress-Aztec-iOS: 7d11d598f14c82c727c08b56bd35fbeb7dafb504

--- a/packages/react-native-editor/package.json
+++ b/packages/react-native-editor/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/react-native-editor",
-	"version": "1.100.1",
+	"version": "1.101.0",
 	"description": "Mobile WordPress gutenberg editor.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/react-native-editor/package.json
+++ b/packages/react-native-editor/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/react-native-editor",
-	"version": "1.101.0",
+	"version": "1.101.1",
 	"description": "Mobile WordPress gutenberg editor.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",


### PR DESCRIPTION
We're currently experiencing the following error on Gutenberg Mobile: `upload-pack: not our ref 62dd7816cfc387aaaf1fa0d51f8820cb4be5a6b3`.

The issue was due to an unpublished commit being referenced. With this PR, that commit is now published.