### PR TITLE
Multi select: prevent blocks from gaining focus

### DIFF
--- a/packages/block-editor/src/components/writing-flow/use-selection-observer.js
+++ b/packages/block-editor/src/components/writing-flow/use-selection-observer.js
@@ -187,19 +187,27 @@ export default function useSelectionObserver() {
 				defaultView.removeEventListener( 'mouseup', onSelectionChange );
 			}
 
-			function resetListeners() {
+			function resetListeners( event ) {
 				removeListeners();
 				addListeners();
+
+				// Forbid focus within the writing flow wrapper when it is
+				// editable. The browser might focus a child element, for
+				// example in some cases when it has a tabindex. There might be
+				// other unknown cases, so we just forbid focus altogether.
+				if ( node.isContentEditable && node !== event.target ) {
+					node.focus();
+				}
 			}
 
 			addListeners();
 			// We must allow rich text to set selection first. This ensures that
 			// our `selectionchange` listener is always reset to be called after
 			// the rich text one.
-			node.addEventListener( 'focusin', resetListeners );
+			node.addEventListener( 'focusin', resetListeners, true );
 			return () => {
 				removeListeners();
-				node.removeEventListener( 'focusin', resetListeners );
+				node.removeEventListener( 'focusin', resetListeners, true );
 			};
 		},
 		[ multiSelect, selectBlock, selectionChange, getBlockParents ]


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

I'm curious about the e2e tests. Whenever there's block multi-selection, blocks should never receive focus. If tests rely on this, there's a bug.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
