### PR TITLE
Mobile Release v1.102.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55883,7 +55883,7 @@
 		},
 		"packages/react-native-aztec": {
 			"name": "@wordpress/react-native-aztec",
-			"version": "1.101.1",
+			"version": "1.102.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/element": "file:../element",
@@ -55896,7 +55896,7 @@
 		},
 		"packages/react-native-bridge": {
 			"name": "@wordpress/react-native-bridge",
-			"version": "1.101.1",
+			"version": "1.102.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/react-native-aztec": "file:../react-native-aztec"
@@ -55907,7 +55907,7 @@
 		},
 		"packages/react-native-editor": {
 			"name": "@wordpress/react-native-editor",
-			"version": "1.101.1",
+			"version": "1.102.0",
 			"hasInstallScript": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {

--- a/packages/react-native-aztec/package.json
+++ b/packages/react-native-aztec/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/react-native-aztec",
-	"version": "1.101.1",
+	"version": "1.102.0",
 	"description": "Aztec view for react-native.",
 	"private": true,
 	"author": "The WordPress Contributors",

--- a/packages/react-native-bridge/package.json
+++ b/packages/react-native-bridge/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/react-native-bridge",
-	"version": "1.101.1",
+	"version": "1.102.0",
 	"description": "Native bridge library used to integrate the block editor into a native App.",
 	"private": true,
 	"author": "The WordPress Contributors",

--- a/packages/react-native-editor/CHANGELOG.md
+++ b/packages/react-native-editor/CHANGELOG.md
@@ -10,6 +10,8 @@ For each user feature we should also add a importance categorization label  to i
 -->
 
 ## Unreleased
+
+## 1.102.0
 -   [*] Display custom color value in mobile Cover Block color picker [#51414]
 -   [**] Display outline around selected Social Link block [#51414]
 -   [**] Fixes font customization not getting updated on iOS [#53391]

--- a/packages/react-native-editor/CHANGELOG.md
+++ b/packages/react-native-editor/CHANGELOG.md
@@ -13,7 +13,7 @@ For each user feature we should also add a importance categorization label  to i
 
 ## 1.102.0
 -   [*] Display custom color value in mobile Cover Block color picker [#51414]
--   [**] Display outline around selected Social Link block [#51414]
+-   [**] Display outline around selected Social Link block [#53377]
 -   [**] Fixes font customization not getting updated on iOS [#53391]
 
 ## 1.101.1

--- a/packages/react-native-editor/ios/Podfile.lock
+++ b/packages/react-native-editor/ios/Podfile.lock
@@ -13,7 +13,7 @@ PODS:
     - ReactCommon/turbomodule/core (= 0.71.11)
   - fmt (6.2.1)
   - glog (0.3.5)
-  - Gutenberg (1.101.1):
+  - Gutenberg (1.102.0):
     - React-Core (= 0.71.11)
     - React-CoreModules (= 0.71.11)
     - React-RCTImage (= 0.71.11)
@@ -394,7 +394,7 @@ PODS:
     - React-RCTImage
   - RNSVG (13.9.0):
     - React-Core
-  - RNTAztecView (1.101.1):
+  - RNTAztecView (1.102.0):
     - React-Core
     - WordPress-Aztec-iOS (~> 1.19.8)
   - SDWebImage (5.11.1):
@@ -577,7 +577,7 @@ SPEC CHECKSUMS:
   FBReactNativeSpec: f07662560742d82a5b73cee116c70b0b49bcc220
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
   glog: 04b94705f318337d7ead9e6d17c019bd9b1f6b1b
-  Gutenberg: 8f153a8a9ce7343bc4533bc1d0728ce9c9bfb86a
+  Gutenberg: b4e5ee6c4271083049b46e31f98ab076e3d6a21a
   libwebp: 60305b2e989864154bd9be3d772730f08fc6a59c
   RCT-Folly: 424b8c9a7a0b9ab2886ffe9c3b041ef628fd4fb1
   RCTRequired: f6187ec763637e6a57f5728dd9a3bdabc6d6b4e0
@@ -620,7 +620,7 @@ SPEC CHECKSUMS:
   RNReanimated: df2567658c01135f9ff4709d372675bcb9fd1d83
   RNScreens: 68fd1060f57dd1023880bf4c05d74784b5392789
   RNSVG: 53c661b76829783cdaf9b7a57258f3d3b4c28315
-  RNTAztecView: 09cf0bda64c4a3a4d33bee3bdab4ed03506eba86
+  RNTAztecView: 660cdb1f9469ca251684c261f2bd0c700a1cc64e
   SDWebImage: a7f831e1a65eb5e285e3fb046a23fcfbf08e696d
   SDWebImageWebPCoder: 908b83b6adda48effe7667cd2b7f78c897e5111d
   WordPress-Aztec-iOS: 7d11d598f14c82c727c08b56bd35fbeb7dafb504

--- a/packages/react-native-editor/package.json
+++ b/packages/react-native-editor/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/react-native-editor",
-	"version": "1.101.1",
+	"version": "1.102.0",
 	"description": "Mobile WordPress gutenberg editor.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",


### PR DESCRIPTION
## Description
Release 1.102.0 of the react-native-editor and Gutenberg-Mobile.

For more information about this release and testing instructions, please see the related Gutenberg-Mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/6089