### PR TITLE
Font Face API: use `gutenberg_get_global_settings` instead of private API

### DIFF
--- a/lib/compat/wordpress-6.4/fonts/font-face/class-wp-font-face-resolver.php
+++ b/lib/compat/wordpress-6.4/fonts/font-face/class-wp-font-face-resolver.php
@@ -30,7 +30,7 @@ class WP_Font_Face_Resolver {
 	 * @return array Returns the font-families, each with their font-face variations.
 	 */
 	public static function get_fonts_from_theme_json() {
-		$settings = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data()->get_settings();
+		$settings = gutenberg_get_global_settings();
 
 		// Bail out early if there are no font settings.
 		if ( empty( $settings['typography'] ) || empty( $settings['typography']['fontFamilies'] ) ) {


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/41479.

## What

This substitutes the call to a private API `WP_Theme_JSON_Resolver_Gutenberg::get_merged_data()->get_settings();` for the public API equivalent `gutenberg_get_global_settings()`.

## Why

We should use our public APIs when possible.

## How to test

Verify all tests pass.