### PR TITLE
Mobile - Inserter - Fix useSelect warnings for SearchResults and ReusableBlocksTab

### DIFF
--- a/packages/block-editor/src/components/inserter/reusable-blocks-tab.native.js
+++ b/packages/block-editor/src/components/inserter/reusable-blocks-tab.native.js
@@ -3,6 +3,7 @@
  */
 import { useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
+import { useMemo } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -12,17 +13,21 @@ import { store as blockEditorStore } from '../../store';
 import { createInserterSection, filterInserterItems } from './utils';
 
 function ReusableBlocksTab( { onSelect, rootClientId, listProps } ) {
-	const { items } = useSelect(
+	const { inserterItems } = useSelect(
 		( select ) => {
 			const { getInserterItems } = select( blockEditorStore );
 			const allItems = getInserterItems( rootClientId );
 
 			return {
-				items: filterInserterItems( allItems, { onlyReusable: true } ),
+				inserterItems: allItems,
 			};
 		},
 		[ rootClientId ]
 	);
+
+	const items = useMemo( () => {
+		return filterInserterItems( inserterItems, { onlyReusable: true } );
+	}, [ inserterItems ] );
 
 	const sections = [ createInserterSection( { key: 'reuseable', items } ) ];
 

--- a/packages/block-editor/src/components/inserter/search-results.native.js
+++ b/packages/block-editor/src/components/inserter/search-results.native.js
@@ -3,6 +3,7 @@
  */
 import { useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
+import { useMemo } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -21,20 +22,23 @@ function InserterSearchResults( {
 	rootClientId,
 	isFullScreen,
 } ) {
-	const { blockTypes } = useSelect(
+	const { inserterItems } = useSelect(
 		( select ) => {
-			const allItems =
+			const items =
 				select( blockEditorStore ).getInserterItems( rootClientId );
 
-			const availableItems = filterInserterItems( allItems, {
-				allowReusable: true,
-			} );
-			const filteredItems = searchItems( availableItems, filterValue );
-
-			return { blockTypes: filteredItems };
+			return { inserterItems: items };
 		},
-		[ rootClientId, filterValue ]
+		[ rootClientId ]
 	);
+
+	const blockTypes = useMemo( () => {
+		const availableItems = filterInserterItems( inserterItems, {
+			allowReusable: true,
+		} );
+
+		return searchItems( availableItems, filterValue );
+	}, [ inserterItems, filterValue ] );
 
 	const { items, trackBlockTypeSelected } =
 		useBlockTypeImpressions( blockTypes );


### PR DESCRIPTION
Addresses part of https://github.com/WordPress/gutenberg/issues/53738

**Related PRs:**
- https://github.com/wordpress-mobile/gutenberg-mobile/pull/6091

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
After the https://github.com/WordPress/gutenberg/pull/53666 merge, some warnings started to appear when opening/interacting with the inserter menu due to the usage of some `useSelect`.

## Why?
To avoid showing these warnings while running the app in development mode and to improve the performance by preventing unnecessary re-renders.

## How?
This PR addresses the warnings by extracting the filtering logic from `useSelect` within the `SearchResults` and `ReusableBlocksTab` components, to avoid returning new references and now they're stored in a variable wrapped in a `useMemo`.

## Testing Instructions
- Open the app
- Open the inserter
- **Expect** to not see any warnings related to `useSelect`
- Use the search box and type in a block's name
- **Expect** to see filtered results
- Use the search box and type in a synced pattern name
- **Expect** to see the filtered result with the pattern

### Testing Instructions for Keyboard
N/A

## Screenshots or screencast <!-- if applicable -->
Before|After
-|-
<video src="https://github.com/WordPress/gutenberg/assets/4885740/1f31fb00-c21b-4bf7-8d7d-e39deaf381eb" />|<video src="https://github.com/WordPress/gutenberg/assets/4885740/2292cc98-7d1a-466d-8e3c-791cdb244d22" />