### PR TITLE
EditPostPreferencesModal: fix intermittently failing tests

### DIFF
--- a/packages/edit-post/src/components/preferences-modal/test/index.js
+++ b/packages/edit-post/src/components/preferences-modal/test/index.js
@@ -32,7 +32,7 @@ describe( 'EditPostPreferencesModal', () => {
 				screen.getByRole( 'dialog', { name: 'Preferences' } )
 			).toMatchSnapshot();
 		} );
-		it( 'small viewports', async () => {
+		it( 'small viewports', () => {
 			useSelect.mockImplementation( () => [ true, true, false ] );
 			useViewportMatch.mockImplementation( () => false );
 			render( <EditPostPreferencesModal /> );

--- a/packages/edit-post/src/components/preferences-modal/test/index.js
+++ b/packages/edit-post/src/components/preferences-modal/test/index.js
@@ -24,8 +24,12 @@ describe( 'EditPostPreferencesModal', () => {
 			useSelect.mockImplementation( () => [ true, true, false ] );
 			useViewportMatch.mockImplementation( () => true );
 			render( <EditPostPreferencesModal /> );
+			await screen.findByRole( 'tab', {
+				name: 'General',
+				selected: true,
+			} );
 			expect(
-				await screen.findByRole( 'dialog', { name: 'Preferences' } )
+				screen.getByRole( 'dialog', { name: 'Preferences' } )
 			).toMatchSnapshot();
 		} );
 		it( 'small viewports', async () => {
@@ -33,7 +37,7 @@ describe( 'EditPostPreferencesModal', () => {
 			useViewportMatch.mockImplementation( () => false );
 			render( <EditPostPreferencesModal /> );
 			expect(
-				await screen.findByRole( 'dialog', { name: 'Preferences' } )
+				screen.getByRole( 'dialog', { name: 'Preferences' } )
 			).toMatchSnapshot();
 		} );
 	} );


### PR DESCRIPTION
Fixes unit tests that started failing randomly since #52133. See https://github.com/WordPress/gutenberg/pull/52133#issuecomment-1680399985 for details.

The fix makes sure that we wait until the default tab (General) is selected, before comparing rendered markup with the snapshot.

The selection is not done on initial render, but is delayed until some effects and rAFs are flushed. The symptoms is that `tabindex` and sometimes also `data-active-item` attributes on the `<button role="tab">` elements don't match.

It can be tracked down to [Ariakit's `useCompositeItem` hook, where the `isTabbable` value](https://github.com/ariakit/ariakit/blob/0eacd26eb42fb5c54208dc31b71ef675306f940f/packages/ariakit-react-core/src/composite/composite-item.tsx#L371-L387) takes some time to settle on the expected value.