### PR TITLE
Fix dismissability deadspot around variations dropdown menu toggle

### DIFF
--- a/packages/block-editor/src/components/block-variation-transforms/index.js
+++ b/packages/block-editor/src/components/block-variation-transforms/index.js
@@ -74,7 +74,7 @@ function VariationsDropdown( {
 			label={ __( 'Transform to variation' ) }
 			text={ __( 'Transform to variation' ) }
 			popoverProps={ {
-				position: 'bottom center',
+				placement: 'bottom-end',
 				className: `${ className }__popover`,
 			} }
 			icon={ chevronDown }

--- a/packages/block-editor/src/components/block-variation-transforms/style.scss
+++ b/packages/block-editor/src/components/block-variation-transforms/style.scss
@@ -1,6 +1,6 @@
 .block-editor-block-variation-transforms {
-	padding: 0 $grid-unit-20 $grid-unit-20 52px;
-	width: 100%;
+	margin: 0 $grid-unit-20 $grid-unit-20 52px;
+	display: block;
 
 	.components-dropdown-menu__toggle {
 		border: 1px solid $gray-700;


### PR DESCRIPTION
## What?
Fixes a UX discrepancy in the variations dropdown menu where nearby outside interactions cause it to get stuck open instead of dismissed.

## Why?
It’s unexpected and a bother.

## How?
- Restyles with `margin` instead of `padding`
- Updates menu placement to compensate for changed popover anchor shape.

## Testing Instructions

Snippet to register a button variation to reveal the variations dropdown:
```javascript
wp.blocks.registerBlockVariation('core/button', {
	name: 'custom-button',
	title: 'My custom button',
	scope: ['transform', 'inserter', 'block'],
	attributes: {className: 'my-custom-button'},
});
```
1. In the post editor, execute the above snippet in the console
2. Insert a Buttons block
3. Expand the "Transform to variation" dropdown In the block’s inspector controls
4. Press beside or below the trigger button and still within the sidebar
5. Verify that the menu closes as expected

### Testing Instructions for Keyboard
n/a

## Screenshots or screencast
### Before

https://github.com/WordPress/gutenberg/assets/9000376/75161570-aa3f-41ef-a5fc-e51477554f02

### After

https://github.com/WordPress/gutenberg/assets/9000376/0028ed30-aa9c-43bb-b004-79c173e27b1b
