### PR TITLE
`Modal`: make everything outside inert

### DIFF
--- a/packages/components/src/modal/aria-helper.ts
+++ b/packages/components/src/modal/aria-helper.ts
@@ -30,7 +30,7 @@ export function modalize( modalElement?: HTMLDivElement ) {
 		}
 
 		if ( elementShouldBeHidden( element ) ) {
-			element.setAttribute( 'aria-hidden', 'true' );
+			element.setAttribute( 'inert', '' );
 			hiddenElements.push( element );
 		}
 	}
@@ -49,6 +49,7 @@ export function elementShouldBeHidden( element: Element ) {
 		element.tagName === 'SCRIPT' ||
 		element.hasAttribute( 'hidden' ) ||
 		element.hasAttribute( 'aria-hidden' ) ||
+		element.hasAttribute( 'inert' ) ||
 		element.hasAttribute( 'aria-live' ) ||
 		( role && LIVE_REGION_ARIA_ROLES.has( role ) )
 	);
@@ -64,6 +65,6 @@ export function unmodalize() {
 	}
 
 	for ( const element of hiddenElements ) {
-		element.removeAttribute( 'aria-hidden' );
+		element.removeAttribute( 'inert' );
 	}
 }

--- a/packages/components/src/modal/aria-helper.ts
+++ b/packages/components/src/modal/aria-helper.ts
@@ -67,4 +67,14 @@ export function unmodalize() {
 	for ( const element of hiddenElements ) {
 		element.removeAttribute( 'inert' );
 	}
+
+	// Hacks around a Chromium bug where it may fail to restore a region to the
+	// accessibility tree after an ancestor had the `inert` attribute removed.
+	// The bug seems like a variation of this: https://crbug.com/1354313
+	// This workaround doesn't have to be a custom property. It also seems to
+	// not have to be done each invocation but it's inexpensive and ensures
+	// some other code didn't remove it.
+	document
+		.querySelectorAll< HTMLElement >( '[role=region]' )
+		.forEach( ( region ) => region.style.setProperty( '--∞', '8' ) );
 }

--- a/packages/components/src/modal/aria-helper.ts
+++ b/packages/components/src/modal/aria-helper.ts
@@ -67,14 +67,4 @@ export function unmodalize() {
 	for ( const element of hiddenElements ) {
 		element.removeAttribute( 'inert' );
 	}
-
-	// Hacks around a Chromium bug where it may fail to restore a region to the
-	// accessibility tree after an ancestor had the `inert` attribute removed.
-	// The bug seems like a variation of this: https://crbug.com/1354313
-	// This workaround doesn't have to be a custom property. It also seems to
-	// not have to be done each invocation but it's inexpensive and ensures
-	// some other code didn't remove it.
-	document
-		.querySelectorAll< HTMLElement >( '[role=region]' )
-		.forEach( ( region ) => region.style.setProperty( '--∞', '8' ) );
 }

--- a/packages/components/src/modal/index.tsx
+++ b/packages/components/src/modal/index.tsx
@@ -129,7 +129,7 @@ function UnforwardedModal(
 	}, [ contentRef ] );
 
 	// Accessibly isolates/unisolates the modal.
-	useEffect( () => {
+	useLayoutEffect( () => {
 		ariaHelper.modalize( ref.current );
 		return () => ariaHelper.unmodalize();
 	}, [] );

--- a/packages/components/src/modal/test/aria-helper.ts
+++ b/packages/components/src/modal/test/aria-helper.ts
@@ -17,16 +17,9 @@ describe( 'aria-helper', () => {
 			expect( elementShouldBeHidden( element ) ).toBe( false );
 		} );
 
-		it( 'should return false when an element has the aria-hidden attribute with value "true"', () => {
+		it( 'should return false when an element has the inert attribute', () => {
 			const element = document.createElement( 'div' );
-			element.setAttribute( 'aria-hidden', 'true' );
-
-			expect( elementShouldBeHidden( element ) ).toBe( false );
-		} );
-
-		it( 'should return false when an element has the aria-hidden attribute with value "false"', () => {
-			const element = document.createElement( 'div' );
-			element.setAttribute( 'aria-hidden', 'false' );
+			element.setAttribute( 'inert', '' );
 
 			expect( elementShouldBeHidden( element ) ).toBe( false );
 		} );

--- a/packages/components/src/modal/test/index.tsx
+++ b/packages/components/src/modal/test/index.tsx
@@ -234,7 +234,7 @@ describe( 'Modal', () => {
 
 		// Opens outer modal > hides container.
 		await user.click( screen.getByRole( 'button', { name: 'Start' } ) );
-		expect( container ).toHaveAttribute( 'aria-hidden', 'true' );
+		expect( container ).toHaveAttribute( 'inert' );
 
 		// Disable reason: No semantic query can reach the overlay.
 		// eslint-disable-next-line testing-library/no-node-access
@@ -242,16 +242,16 @@ describe( 'Modal', () => {
 
 		// Opens inner modal > hides outer modal.
 		await user.click( screen.getByRole( 'button', { name: 'Nest' } ) );
-		expect( outer ).toHaveAttribute( 'aria-hidden', 'true' );
+		expect( outer ).toHaveAttribute( 'inert' );
 
 		// Closes inner modal > Unhides outer modal and container stays hidden.
 		await user.keyboard( '[Escape]' );
-		expect( outer ).not.toHaveAttribute( 'aria-hidden' );
-		expect( container ).toHaveAttribute( 'aria-hidden', 'true' );
+		expect( outer ).not.toHaveAttribute( 'inert' );
+		expect( container ).toHaveAttribute( 'inert' );
 
 		// Closes outer modal > Unhides container.
 		await user.keyboard( '[Escape]' );
-		expect( container ).not.toHaveAttribute( 'aria-hidden' );
+		expect( container ).not.toHaveAttribute( 'inert' );
 	} );
 
 	it( 'should render `headerActions` React nodes', async () => {

--- a/test/e2e/specs/site-editor/font-library.spec.js
+++ b/test/e2e/specs/site-editor/font-library.spec.js
@@ -87,9 +87,10 @@ test.describe( 'Font Library', () => {
 					name: 'Manage fonts',
 				} )
 				.click();
-			await expect( page.getByRole( 'dialog' ) ).toBeVisible();
 			await expect(
-				page.getByRole( 'heading', { name: 'Fonts', exact: true } )
+				page
+					.getByRole( 'dialog' )
+					.getByRole( 'heading', { name: 'Fonts', exact: true } )
 			).toBeVisible();
 		} );
 
@@ -106,12 +107,13 @@ test.describe( 'Font Library', () => {
 					name: 'Manage fonts',
 				} )
 				.click();
-			await page.getByRole( 'button', { name: 'System Font' } ).click();
+			const dialog = page.getByRole( 'dialog' );
+			await dialog.getByRole( 'button', { name: 'System Font' } ).click();
 			await expect(
-				page.getByRole( 'heading', { name: 'System Font' } )
+				dialog.getByRole( 'heading', { name: 'System Font' } )
 			).toBeVisible();
 			await expect(
-				page.getByRole( 'checkbox', { name: 'System Font Normal' } )
+				dialog.getByRole( 'checkbox', { name: 'System Font Normal' } )
 			).toBeVisible();
 		} );
 	} );
@@ -174,15 +176,16 @@ test.describe( 'Font Library', () => {
 					.getByText( 'Fonts were installed successfully.' )
 			).toBeVisible();
 			await page.getByRole( 'tab', { name: 'Library' } ).click();
+			const dialog = page.getByRole( 'dialog' );
 			// Provides coverage for https://github.com/WordPress/gutenberg/issues/60040.
-			await page.getByRole( 'button', { name: 'Exo 2' } ).click();
+			await dialog.getByRole( 'button', { name: 'Exo 2' } ).click();
 			await expect( page.getByLabel( 'Exo 2 Normal' ) ).toBeVisible();
 			await expect(
 				page.getByLabel( 'Exo 2 Semi-bold Italic' )
 			).toBeVisible();
 
 			// Check CSS preset was created.
-			await page.getByRole( 'button', { name: 'Close' } ).click();
+			await dialog.getByRole( 'button', { name: 'Close' } ).click();
 			await page
 				.getByRole( 'button', { name: 'Headings', exact: true } )
 				.click();
@@ -200,9 +203,13 @@ test.describe( 'Font Library', () => {
 				} )
 				.click();
 
-			await page.getByRole( 'button', { name: 'Exo 2' } ).click();
-			await page.getByRole( 'button', { name: 'Delete' } ).click();
-			await page.getByRole( 'button', { name: 'Delete' } ).click();
+			await dialog.getByRole( 'button', { name: 'Exo 2' } ).click();
+			await dialog.getByRole( 'button', { name: 'Delete' } ).click();
+			await page
+				.getByRole( 'dialog' )
+				.last()
+				.getByRole( 'button', { name: 'Delete' } )
+				.click();
 			await expect(
 				page
 					.getByLabel( 'Library' )
@@ -248,9 +255,9 @@ test.describe( 'Font Library', () => {
 				.getByRole( 'button', { name: 'Jost 2 variants' } )
 				.click();
 
-			await expect( page.getByRole( 'dialog' ) ).toBeVisible();
+			const dialog = page.getByRole( 'dialog' );
 			await expect(
-				page.getByRole( 'heading', { name: 'Fonts' } )
+				dialog.getByRole( 'heading', { name: 'Fonts' } )
 			).toBeVisible();
 
 			// Check correct font is displayed in Font Library
@@ -259,7 +266,7 @@ test.describe( 'Font Library', () => {
 			).toBeVisible();
 
 			// Close the Font Library dialog
-			await page.getByRole( 'button', { name: 'Close' } ).click();
+			await dialog.getByRole( 'button', { name: 'Close' } ).click();
 
 			// Click "Back"
 			await page.getByRole( 'button', { name: 'Back' } ).click();
@@ -280,9 +287,8 @@ test.describe( 'Font Library', () => {
 				.getByRole( 'button', { name: 'Cardo 3 variants' } )
 				.click();
 
-			await expect( page.getByRole( 'dialog' ) ).toBeVisible();
 			await expect(
-				page.getByRole( 'heading', { name: 'Fonts' } )
+				dialog.getByRole( 'heading', { name: 'Fonts' } )
 			).toBeVisible();
 
 			// Check correct font is displayed in Font Library

--- a/test/e2e/specs/site-editor/template-registration.spec.js
+++ b/test/e2e/specs/site-editor/template-registration.spec.js
@@ -84,7 +84,10 @@ test.describe( 'Block template registration', () => {
 		const searchResults = page.getByLabel( 'Actions' );
 		await searchResults.first().click();
 		await page.getByRole( 'menuitem', { name: 'Reset' } ).click();
-		await page.getByRole( 'button', { name: 'Reset' } ).click();
+		await page
+			.getByRole( 'dialog' )
+			.getByRole( 'button', { name: 'Reset' } )
+			.click();
 
 		await expect( resetNotice ).toBeVisible();
 		await expect( savedButton ).toBeVisible();


### PR DESCRIPTION
## What?
Bug fix/enhancement to `Modal` component.

## Why?
I think `inert` is what we'd have used from the get go had it been well supported then.
To fix #41503
This should also help with other obscure problems like one that can be triggered by undo/redo keyboard shortcuts while a Modal is open. 
>  a textbox underneath a modal will probably be focussed by the browser
> —https://github.com/WordPress/gutenberg/issues/18755#issuecomment-726731981

## How?
Updates use of `aria-hidden` to `inert`.

## Testing Instructions
1. Open a post or page.
2. Launch a Modal.
3. Click some part of your browser chrome
4. Use keyboard tab to return focus back to the Modal.

 <!-- ## Screenshots or screencast -->
