### PR TITLE
Fix the `useSelect` warning of the “Copy all blocks” menu item

### DIFF
--- a/packages/edit-post/src/plugins/copy-content-menu-item/index.js
+++ b/packages/edit-post/src/plugins/copy-content-menu-item/index.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { MenuItem } from '@wordpress/components';
-import { useSelect, useDispatch } from '@wordpress/data';
+import { select, useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { useCopyToClipboard } from '@wordpress/compose';
 import { store as noticesStore } from '@wordpress/notices';
@@ -10,11 +10,6 @@ import { store as editorStore } from '@wordpress/editor';
 
 export default function CopyContentMenuItem() {
 	const { createNotice } = useDispatch( noticesStore );
-	const getText = useSelect(
-		( select ) => () =>
-			select( editorStore ).getEditedPostAttribute( 'content' ),
-		[]
-	);
 
 	function onSuccess() {
 		createNotice( 'info', __( 'All content copied.' ), {
@@ -23,7 +18,10 @@ export default function CopyContentMenuItem() {
 		} );
 	}
 
-	const ref = useCopyToClipboard( getText, onSuccess );
+	const ref = useCopyToClipboard(
+		() => select( editorStore ).getEditedPostAttribute( 'content' ),
+		onSuccess
+	);
 
 	return <MenuItem ref={ ref }>{ __( 'Copy all blocks' ) }</MenuItem>;
 }


### PR DESCRIPTION
## What?
Avoids the console warning about changing return value of `useSelect`.

## Why?
To keep the console cleaner. In this case it doesn't seem like the changing return value would cause extra renders or be otherwise problematic so this is just nice to have.

## How?
Use `select` instead of `useSelect`.

At first, I tried returning `getEditedPostAttribute` from the hook’s callback but that doesn't avoid the warning because it isn't a memoized selector. I assumed it's not memoized for a reason. I hope a reviewer may know better. Even were it memoized I'm not aware of the advantage `useSelect` would provide in this specific case.

## Testing Instructions
1. In the Post editor with some blocks in the post
2. Press the "Options" button from the "Editor top bar" region
3. Check the console to verify there's no warning about the `useSelect` hook
4. Select the “Copy all blocks” menu item
5. Paste somewhere to verify current content was copied

### Testing Instructions for Keyboard
I think the instructions above work

## Screenshots or screencast

### Before

https://github.com/WordPress/gutenberg/assets/9000376/94744970-9ec4-4b05-b8ec-e2210eec68b8

### After

https://github.com/WordPress/gutenberg/assets/9000376/dbaf73d0-9e14-43a4-a44b-6e69acc87577

