### PR TITLE
[Format library]: Fix `language` popover position

### DIFF
--- a/packages/format-library/src/language/index.js
+++ b/packages/format-library/src/language/index.js
@@ -76,7 +76,6 @@ function InlineLanguageUI( { value, contentRef, onChange, onClose } ) {
 		<Popover
 			className="block-editor-format-toolbar__language-popover"
 			anchor={ popoverAnchor }
-			placement="bottom"
 			onClose={ onClose }
 		>
 			<form


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes: https://github.com/WordPress/gutenberg/issues/53366

When a user opens the Languages rich text format with the List View open, the settings are obscured by the List View. This PR removes the `bottom` position and matches the position of other formats like `highlight`.

## Testing Instructions
1. Open the List View
2. Insert a paragraph block
3. Open the "More" option to show Rich Editing and select the "Languages" option
4. Observe that the popover is not obscured

