### PR TITLE
Patterns: Update empty template part label

### DIFF
--- a/packages/edit-site/src/components/page-patterns/grid-item.js
+++ b/packages/edit-site/src/components/page-patterns/grid-item.js
@@ -154,7 +154,9 @@ function GridItem( { categoryId, item, ...props } ) {
 						: undefined
 				}
 			>
-				{ isEmpty && __( 'Empty pattern' ) }
+				{ isEmpty && isTemplatePart
+					? __( 'Empty template part' )
+					: __( 'Empty pattern' ) }
 				{ ! isEmpty && <BlockPreview blocks={ item.blocks } /> }
 			</button>
 			{ ariaDescriptions.map( ( ariaDescription, index ) => (

--- a/packages/edit-site/src/components/page-patterns/grid-item.js
+++ b/packages/edit-site/src/components/page-patterns/grid-item.js
@@ -154,9 +154,8 @@ function GridItem( { categoryId, item, ...props } ) {
 						: undefined
 				}
 			>
-				{ isEmpty && isTemplatePart
-					? __( 'Empty template part' )
-					: __( 'Empty pattern' ) }
+				{ isEmpty && isTemplatePart && __( 'Empty template part' ) }
+				{ isEmpty && ! isTemplatePart && __( 'Empty pattern' ) }
 				{ ! isEmpty && <BlockPreview blocks={ item.blocks } /> }
 			</button>
 			{ ariaDescriptions.map( ( ariaDescription, index ) => (

--- a/packages/edit-site/src/components/sidebar-navigation-screen-pattern/use-pattern-details.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-pattern/use-pattern-details.js
@@ -46,11 +46,18 @@ export default function usePatternDetails( postType, postId ) {
 	let description = getDescription();
 
 	if ( ! description && addedBy.text ) {
-		description = sprintf(
-			// translators: %s: pattern title e.g: "Header".
-			__( 'This is the %s pattern.' ),
-			getTitle()
-		);
+		description =
+			postType === 'wp_block'
+				? sprintf(
+						// translators: %s: pattern title e.g: "Header".
+						__( 'This is the %s pattern.' ),
+						getTitle()
+				  )
+				: sprintf(
+						// translators: %s: template part title e.g: "Header".
+						__( 'This is the %s template part.' ),
+						getTitle()
+				  );
 	}
 
 	if ( ! description && postType === 'wp_block' && record?.title ) {


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/53821

## What?

Updates the empty label for template parts

## Why?

Avoids some confusion between template parts and patterns until they are all merged.

## How?

Label text is determined based off the current item type.

## Testing Instructions

Follow instructions from https://github.com/WordPress/gutenberg/issues/53821

> Create a custom empty template part through the interface
Go to Admin > Editor > Patterns > Template parts. Select the area used for the part, for example, General.
Confirm that the preview is empty, which is correct, but that the text says "Empty pattern"

## Screenshots or screencast <!-- if applicable -->


| Before | After |
|---|---|
| <img width="473" alt="Screenshot 2023-08-21 at 7 28 32 pm" src="https://github.com/WordPress/gutenberg/assets/60436221/a5bd29ff-49d7-401f-9c1f-0ec73e176551"> | <img width="488" alt="Screenshot 2023-08-21 at 7 28 08 pm" src="https://github.com/WordPress/gutenberg/assets/60436221/a6ed588e-6813-46ac-9262-897bb35898b0"> |
