### PR TITLE
add juanmaguitar as codeowner of /packages/interactivity/docs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,6 @@
 # Documentation
 /docs                                           @ajitbohra @ryanwelcher @juanmaguitar @fabiankaegy @ndiego
+/packages/interactivity/docs                    @juanmaguitar
 
 # Schemas
 /schemas/json                                   @ajlende


### PR DESCRIPTION
## What?
Add @juanmaguitar as codeowner of /packages/interactivity/docs

## Why?
So any PRs that changes any file in that folder will automatically assign you as one of the reviewers.

## How?
By adding @juanmaguitar as codeowner of /packages/interactivity/docs in `.github/CODEOWNERS`

