### PR TITLE
Backport themes `is_block_theme` collection param from core

### DIFF
--- a/lib/compat/wordpress-6.3/rest-api.php
+++ b/lib/compat/wordpress-6.3/rest-api.php
@@ -126,7 +126,7 @@ add_filter( 'rest_themes_collection_params', 'gutenberg_themes_collection_params
 /**
  * Updates REST API response for the themes and adds the `is_block_theme` flag.
  *
- * @param WP_REST_Response $response The sidebar response object.
+ * @param WP_REST_Response $response The response object.
  * @param WP_Theme         $theme    Theme object used to create response.
  * @return WP_REST_Response $response Updated response object.
  */

--- a/lib/compat/wordpress-6.3/rest-api.php
+++ b/lib/compat/wordpress-6.3/rest-api.php
@@ -106,3 +106,32 @@ function gutenberg_register_rest_navigation_fallbacks() {
 	$editor_settings->register_routes();
 }
 add_action( 'rest_api_init', 'gutenberg_register_rest_navigation_fallbacks' );
+
+/**
+ * Add extra collection params to themes requests.
+ *
+ * @param array $query_params JSON Schema-formatted collection parameters.
+ * @return array Updated parameters.
+ */
+function gutenberg_themes_collection_params_6_3( $query_params ) {
+	$query_params['is_block_theme'] = array(
+		'description' => __( 'Whether the theme is a block-based theme.' ),
+		'type'        => 'boolean',
+		'readonly'    => true,
+	);
+	return $query_params;
+}
+add_filter( 'rest_themes_collection_params', 'gutenberg_themes_collection_params_6_3' );
+
+/**
+ * Updates REST API response for the themes and adds the `is_block_theme` flag.
+ *
+ * @param WP_REST_Response $response The sidebar response object.
+ * @param WP_Theme         $theme    Theme object used to create response.
+ * @return WP_REST_Response $response Updated response object.
+ */
+function gutenberg_modify_rest_themes_response( $response, $theme ) {
+	$response->data['is_block_theme'] = $theme->is_block_theme();
+	return $response;
+}
+add_filter( 'rest_prepare_theme', 'gutenberg_modify_rest_themes_response', 10, 2 );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Currently for the command packages we are using the `is_block_theme` theme's collection param to handle some callbacks conditionally. This param though was introduced directly in core [here](https://github.com/WordPress/wordpress-develop/commit/1e8b61bd4da9e1961aeaad10ae2ec9033199783c) for `6.3` and since in GB we support one more WP version, we need to add it in GB too, under `compat/6.3` files.

This PR does that.
<!-- In a few words, what is the PR actually doing? -->


## Testing Instructions
Have WP `6.2` installed.
1. You can test different handling of commands based on this param
2. Example would be the redirection to site editor or post editor from [this PR](https://github.com/WordPress/gutenberg/pull/53718) from the commands. Enable a block theme and through the commands select a different page. 
3. It should redirect you to the site editor.


Alternatively of course you can just test the response of a rest client, when requesting themes.

