### PR TITLE
Add "supports.interactivity" to Image block

### DIFF
--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -54,6 +54,11 @@ function render_block_core_image( $attributes, $content, $block ) {
 		$should_load_view_script = true;
 	}
 
+	// If at least one block in the page has the lightbox, mark the block type as interactive.
+	if ( $should_load_view_script ) {
+		$block->block_type->supports['interactivity'] = true;
+	}
+
 	$view_js_file = 'wp-block-image-view';
 	if ( ! wp_script_is( $view_js_file ) ) {
 		$script_handles = $block->block_type->view_script_handles;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Add `"supports.interactivity"` to the Image block.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Because if not, the script won't be loaded in the footer for WP < 6.3.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

By changing dynamically the value of `"supports.interactivity"` in the render callback.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- Use WP 6.2.
- Check that the script loads in the footer.

## Screenshots or screencast <!-- if applicable -->

<div>
    <a href="https://www.loom.com/share/12ab7d9e65224049b2c4228a2b89c8c5">
      <img style="max-width:300px;" src="https://cdn.loom.com/sessions/thumbnails/12ab7d9e65224049b2c4228a2b89c8c5-with-play.gif">
    </a>
  </div>

https://www.loom.com/share/12ab7d9e65224049b2c4228a2b89c8c5