### PR TITLE
Clarification for `parent` and `ancestor` hierarchical relationships

### DIFF
--- a/docs/how-to-guides/block-tutorial/nested-blocks-inner-blocks.md
+++ b/docs/how-to-guides/block-tutorial/nested-blocks-inner-blocks.md
@@ -155,15 +155,20 @@ add_action( 'init', function() {
 } );
 ```
 
-## Using Hierarchical Context in InnerBlocks
+## Using Parent and Ancestor Relationships in Blocks
 
-A common pattern for using InnerBlocks is to create a custom block that will be included _only_ in the InnerBlocks. This allows InnerBlocks to have a hierarchical context for nesting child blocks.
+A common pattern for using InnerBlocks is to create a custom block that will be only be available if its parent block is inserted. This allows builders to establish a relationship between blocks, while limiting a nested block's discoverability. Currently, there are two relationships builders can use: `parent` and `ancestor`. The differences are: 
 
-### Defining Parent Block Context
+- If you assign a `parent` then you’re stating that the nested block can only be used and inserted as a __direct descendant of the parent__.
+- If you assign an `ancestor` then you’re stating that the nested block can only be used and inserted as a __descendent of the parent__.
 
-An example of this is the Column block, which is assigned the `parent` block setting. This allows the Column block to only be available in its parent Columns block context. Otherwise, the Column block will not be available as an option within the block inserter. See [Column code for reference](https://github.com/WordPress/gutenberg/tree/HEAD/packages/block-library/src/column).
+The key difference between `parent` and `ancestor` is `parent` has finer specificity, while an `ancestor` has greater flexibility in its nested hierarchy.
 
-When defining a direct child block, use the `parent` block setting to define which block is the parent. This prevents the child block from showing in the inserter outside of the InnerBlock it is defined for.
+### Defining Parent Block Relationship
+
+An example of this is the Column block, which is assigned the `parent` block setting. This allows the Column block to only be available as a nested direct descendant in its parent Columns block. Otherwise, the Column block will not be available as an option within the block inserter. See [Column code for reference](https://github.com/WordPress/gutenberg/tree/HEAD/packages/block-library/src/column).
+
+When defining a direct descendent block, use the `parent` block setting to define which block is the parent. This prevents the nested block from showing in the inserter outside of the InnerBlock it is defined for.
 
 ```json
 {
@@ -174,11 +179,13 @@ When defining a direct child block, use the `parent` block setting to define whi
 }
 ```
 
-### Defining Ancestor Block Context
+### Defining Ancestor Block Relationship
 
-Another example is using the `ancestor` block setting. The Comment Author Name block utilizes the `ancestor` setting to assign the Comment Template block to allow it to be a descendant of the Comment Template block while refraining from explicitly assigning it a direct child hierarchy. 
+An example of this is the Comment Author Name block, which is assigned the `ancestor` block setting. This allows the Comment Author Name block to only be available as a nested descendant in its ancestral Comment Template block. Otherwise, the Comment Author Name block will not be available as an option within the block inserter. See [Comment Author Name code for reference](https://github.com/WordPress/gutenberg/tree/HEAD/packages/block-library/src/comment-author-name).
 
-This context allows the Comment Author Name block to be anywhere in the hierarchical tree, and not _just_ a direct child of the parent Comment Template block, while still limiting its availability within the block inserter to only be visible an an option to insert if the Comment Template block is available.
+The `ancestor` relationship allows the Comment Author Name block to be anywhere in the hierarchical tree, and not _just_ a direct child of the parent Comment Template block, while still limiting its availability within the block inserter to only be visible an an option to insert if the Comment Template block is available.
+
+When defining a descendent block, use the `ancestor` block setting. This prevents the nested block from showing in the inserter outside of the InnerBlock it is defined for.
 
 ```json
 {

--- a/docs/how-to-guides/block-tutorial/nested-blocks-inner-blocks.md
+++ b/docs/how-to-guides/block-tutorial/nested-blocks-inner-blocks.md
@@ -155,13 +155,15 @@ add_action( 'init', function() {
 } );
 ```
 
-## Child InnerBlocks: Parent and Ancestors
+## Using Hierarchical Context in InnerBlocks
 
-A common pattern for using InnerBlocks is to create a custom block that will be included only in the InnerBlocks.
+A common pattern for using InnerBlocks is to create a custom block that will be included _only_ in the InnerBlocks. This allows InnerBlocks to have a hierarchical context for nesting child blocks.
 
-An example of this is the Columns block, that creates a single parent block called `columns` and then creates an child block called `column`. The parent block is defined to only allow the child blocks. See [Column code for reference](https://github.com/WordPress/gutenberg/tree/HEAD/packages/block-library/src/column).
+### Defining Parent Block Context
 
-When defining a child block, use the `parent` block setting to define which block is the parent. This prevents the block showing in the inserter outside of the InnerBlock it is defined for.
+An example of this is the Column block, which is assigned the `parent` block setting. This allows the Column block to only be available in its parent Columns block context. Otherwise, the Column block will not be available as an option within the block inserter. See [Column code for reference](https://github.com/WordPress/gutenberg/tree/HEAD/packages/block-library/src/column).
+
+When defining a direct child block, use the `parent` block setting to define which block is the parent. This prevents the child block from showing in the inserter outside of the InnerBlock it is defined for.
 
 ```json
 {
@@ -172,7 +174,11 @@ When defining a child block, use the `parent` block setting to define which bloc
 }
 ```
 
-Another example is using the `ancestors` block setting to define a block that must be present as an ancestor, but it doesn't need to be the direct parent (like with `parent`). This prevents the block from showing in the inserter if the ancestor is not in the tree, but other blocks can be added in between, like a Columns or Group block. See [Comment Author Name code for reference](https://github.com/WordPress/gutenberg/tree/HEAD/packages/block-library/src/comment-author-name).
+### Defining Ancestor Block Context
+
+Another example is using the `ancestor` block setting. The Comment Author Name block utilizes the `ancestor` setting to assign the Comment Template block to allow it to be a descendant of the Comment Template block while refraining from explicitly assigning it a direct child hierarchy. 
+
+This context allows the Comment Author Name block to be anywhere in the hierarchical tree, and not _just_ a direct child of the parent Comment Template block, while still limiting its availability within the block inserter to only be visible an an option to insert if the Comment Template block is available.
 
 ```json
 {
@@ -183,7 +189,7 @@ Another example is using the `ancestors` block setting to define a block that mu
 }
 ```
 
-## Using a react hook
+## Using a React Hook
 
 You can use a react hook called `useInnerBlocksProps` instead of the `InnerBlocks` component. This hook allows you to take more control over the markup of inner blocks areas.
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Attempting to offer clarity on the usage of `parent` and `ancestor` hierarchical relationship in InnerBlocks nesting.

Some notes:
- Try to downplay the usage of "child", because I think it is confusing. Especially in headings. Although, I still left a few references.

## Why?
Hierarchical relationshiops can be hard to explain.

## How?
Change wording.

## Testing Instructions

Just a docs change and compare the diff is probably best.

### Testing Instructions for Keyboard

Not applicable.
