### PR TITLE
Font Face: Prepare for merge into Core.

### DIFF
--- a/lib/compat/wordpress-6.4/fonts/font-face/class-wp-font-face-resolver.php
+++ b/lib/compat/wordpress-6.4/fonts/font-face/class-wp-font-face-resolver.php
@@ -4,7 +4,7 @@
  *
  * @package    WordPress
  * @subpackage Fonts
- * @since      X.X.X
+ * @since      6.4.0
  */
 
 if ( class_exists( 'WP_Font_Face_Resolver' ) ) {
@@ -25,7 +25,7 @@ class WP_Font_Face_Resolver {
 	/**
 	 * Gets fonts defined in theme.json.
 	 *
-	 * @since X.X.X
+	 * @since 6.4.0
 	 *
 	 * @return array Returns the font-families, each with their font-face variations.
 	 */
@@ -43,7 +43,7 @@ class WP_Font_Face_Resolver {
 	/**
 	 * Parse theme.json settings to extract font definitions with variations grouped by font-family.
 	 *
-	 * @since X.X.X
+	 * @since 6.4.0
 	 *
 	 * @param array $settings Font settings to parse.
 	 * @return array Returns an array of fonts, grouped by font-family.
@@ -81,7 +81,7 @@ class WP_Font_Face_Resolver {
 	/**
 	 * Converts font-face properties from theme.json format.
 	 *
-	 * @since X.X.X
+	 * @since 6.4.0
 	 *
 	 * @param array  $font_face_definition The font-face definitions to convert.
 	 * @param string $font_family_property The value to store in the font-face font-family property.
@@ -115,7 +115,7 @@ class WP_Font_Face_Resolver {
 	 * replaced with the URI to the font file's location in the theme. When a "src"
 	 * beings with this placeholder, it is replaced, converting the src into a URI.
 	 *
-	 * @since X.X.X
+	 * @since 6.4.0
 	 *
 	 * @param array $src An array of font file sources to process.
 	 * @return array An array of font file src URI(s).
@@ -139,7 +139,7 @@ class WP_Font_Face_Resolver {
 	/**
 	 * Converts all first dimension keys into kebab-case.
 	 *
-	 * @since X.X.X
+	 * @since 6.4.0
 	 *
 	 * @param array $data The array to process.
 	 * @return array Data with first dimension keys converted into kebab-case.

--- a/lib/compat/wordpress-6.4/fonts/font-face/class-wp-font-face.php
+++ b/lib/compat/wordpress-6.4/fonts/font-face/class-wp-font-face.php
@@ -4,7 +4,7 @@
  *
  * @package    WordPress
  * @subpackage Fonts
- * @since      X.X.X
+ * @since      6.4.0
  */
 
 if ( class_exists( 'WP_Font_Face' ) ) {
@@ -14,14 +14,14 @@ if ( class_exists( 'WP_Font_Face' ) ) {
 /**
  * Font Face generates and prints `@font-face` styles for given fonts.
  *
- * @since X.X.X
+ * @since 6.4.0
  */
 class WP_Font_Face {
 
 	/**
 	 * The font-face property defaults.
 	 *
-	 * @since X.X.X
+	 * @since 6.4.0
 	 *
 	 * @var string[]
 	 */
@@ -35,7 +35,7 @@ class WP_Font_Face {
 	/**
 	 * Valid font-face property names.
 	 *
-	 * @since X.X.X
+	 * @since 6.4.0
 	 *
 	 * @var string[]
 	 */
@@ -59,7 +59,7 @@ class WP_Font_Face {
 	/**
 	 * Valid font-display values.
 	 *
-	 * @since X.X.X
+	 * @since 6.4.0
 	 *
 	 * @var string[]
 	 */
@@ -70,7 +70,7 @@ class WP_Font_Face {
 	 * where the key is the attribute name and the
 	 * value is its value.
 	 *
-	 * @since X.X.X
+	 * @since 6.4.0
 	 *
 	 * @var string[]
 	 */
@@ -79,13 +79,13 @@ class WP_Font_Face {
 	/**
 	 * Creates and initializes an instance of WP_Font_Face.
 	 *
-	 * @since X.X.X
+	 * @since 6.4.0
 	 */
 	public function __construct() {
 		/**
 		 * Filters the font-face property defaults.
 		 *
-		 * @since X.X.X
+		 * @since 6.4.0
 		 *
 		 * @param array $defaults {
 		 *     An array of required font-face properties and defaults.
@@ -111,7 +111,7 @@ class WP_Font_Face {
 	/**
 	 * Generates and prints the `@font-face` styles for the given fonts.
 	 *
-	 * @since X.X.X
+	 * @since 6.4.0
 	 *
 	 * @param array $fonts The fonts to generate and print @font-face styles.
 	 */
@@ -132,7 +132,7 @@ class WP_Font_Face {
 	/**
 	 * Validates each of the font-face properties.
 	 *
-	 * @since X.X.X
+	 * @since 6.4.0
 	 *
 	 * @param array $fonts The fonts to valid.
 	 * @return array Prepared font-faces organized by provider and font-family.
@@ -158,7 +158,7 @@ class WP_Font_Face {
 	/**
 	 * Validates each font-face property.
 	 *
-	 * @since X.X.X
+	 * @since 6.4.0
 	 *
 	 * @param array $font_face Font face properties to validate.
 	 * @return false|array Validated font-face on success. Else, false.
@@ -212,7 +212,7 @@ class WP_Font_Face {
 	/**
 	 * Gets the `<style>` element for wrapping the `@font-face` CSS.
 	 *
-	 * @since X.X.X
+	 * @since 6.4.0
 	 *
 	 * @return string The style element.
 	 */
@@ -225,7 +225,7 @@ class WP_Font_Face {
 	/**
 	 * Gets the defined <style> element's attributes.
 	 *
-	 * @since X.X.X
+	 * @since 6.4.0
 	 *
 	 * @return string A string of attribute=value when defined, else, empty string.
 	 */
@@ -244,7 +244,7 @@ class WP_Font_Face {
 	 *    1. Orchestrates an optimized `src` (with format) for browser support.
 	 *    2. Generates the `@font-face` for all its fonts.
 	 *
-	 * @since X.X.X
+	 * @since 6.4.0
 	 *
 	 * @param array $font_faces The font-faces to generate @font-face CSS styles.
 	 * @return string The `@font-face` CSS styles.
@@ -267,7 +267,7 @@ class WP_Font_Face {
 	/**
 	 * Orders `src` items to optimize for browser support.
 	 *
-	 * @since X.X.X
+	 * @since 6.4.0
 	 *
 	 * @param array $font_face Font face to process.
 	 * @return array Font-face with ordered src items.
@@ -340,7 +340,7 @@ class WP_Font_Face {
 	/**
 	 * Builds the font-family's CSS.
 	 *
-	 * @since X.X.X
+	 * @since 6.4.0
 	 *
 	 * @param array $font_face Font face to process.
 	 * @return string This font-family's CSS.
@@ -380,7 +380,7 @@ class WP_Font_Face {
 	/**
 	 * Compiles the `src` into valid CSS.
 	 *
-	 * @since X.X.X
+	 * @since 6.4.0
 	 *
 	 * @param array $value Value to process.
 	 * @return string The CSS.
@@ -401,7 +401,7 @@ class WP_Font_Face {
 	/**
 	 * Compiles the font variation settings.
 	 *
-	 * @since X.X.X
+	 * @since 6.4.0
 	 *
 	 * @param array $font_variation_settings Array of font variation settings.
 	 * @return string The CSS.

--- a/lib/compat/wordpress-6.4/fonts/fonts.php
+++ b/lib/compat/wordpress-6.4/fonts/fonts.php
@@ -4,17 +4,19 @@
  *
  * @package    WordPress
  * @subpackage Fonts
- * @since      X.X.X
+ * @since      6.4.0
  */
 
-add_action( 'wp_head', 'wp_print_font_faces', 50 );
-add_action( 'admin_print_styles', 'wp_print_font_faces', 50 );
-
 if ( ! function_exists( 'wp_print_font_faces' ) ) {
+	// @core-merge: will merge into Core's `wp-includes/default-filters.php` file.
+	add_action( 'wp_head', 'wp_print_font_faces', 50 );
+	// @core-merge: will merge into Core's `wp-admin/includes/admin-filters.php.` file.
+	add_action( 'admin_print_styles', 'wp_print_font_faces', 50 );
+
 	/**
 	 * Generates and prints font-face styles for given fonts or theme.json fonts.
 	 *
-	 * @since X.X.X
+	 * @since 6.4.0
 	 *
 	 * @param array $fonts Optional. The fonts to generate and print @font-face styles.
 	 *                     Default empty array.
@@ -41,18 +43,20 @@ if ( ! function_exists( 'wp_print_font_faces' ) ) {
 
 		$wp_font_face->generate_and_print( $fonts );
 	}
+
+	// @core-merge: do not merge this code into Core.
+	add_filter(
+		'block_editor_settings_all',
+		static function( $settings ) {
+			ob_start();
+			// @core-merge: add only this line into Core's `_wp_get_iframed_editor_assets()` function after `wp_print_styles()`.
+			wp_print_font_faces();
+			$styles = ob_get_clean();
+
+			// Add the font-face styles to iframed editor assets.
+			$settings['__unstableResolvedAssets']['styles'] .= $styles;
+			return $settings;
+		},
+		11
+	);
 }
-
-add_filter(
-	'block_editor_settings_all',
-	static function( $settings ) {
-		ob_start();
-		wp_print_font_faces();
-		$styles = ob_get_clean();
-
-		// Add the font-face styles to iframed editor assets.
-		$settings['__unstableResolvedAssets']['styles'] .= $styles;
-		return $settings;
-	},
-	11
-);

--- a/lib/load.php
+++ b/lib/load.php
@@ -170,26 +170,33 @@ if (
 	require __DIR__ . '/experimental/fonts/font-library/class-wp-rest-font-library-controller.php';
 	require __DIR__ . '/experimental/fonts/font-library/font-library.php';
 
-	if ( ! class_exists( 'WP_Font_Face' ) ) {
-		require __DIR__ . '/experimental/fonts/font-face/class-wp-font-face.php';
-		require __DIR__ . '/experimental/fonts/font-face/class-wp-font-face-resolver.php';
-		require __DIR__ . '/experimental/fonts/font-face/fonts.php';
+	// Load the Font Face.
+	require __DIR__ . '/compat/wordpress-6.4/fonts/font-face/class-wp-font-face.php';
+	require __DIR__ . '/compat/wordpress-6.4/fonts/font-face/class-wp-font-face-resolver.php';
 
-		// Load the BC Layer. Do no backport to WP Core.
-		require __DIR__ . '/experimental/fonts/font-face/bc-layer/class-wp-fonts-provider.php';
-		require __DIR__ . '/experimental/fonts/font-face/bc-layer/class-wp-fonts-utils.php';
-		require __DIR__ . '/experimental/fonts/font-face/bc-layer/class-wp-fonts.php';
-		require __DIR__ . '/experimental/fonts/font-face/bc-layer/class-wp-fonts-provider-local.php';
-		require __DIR__ . '/experimental/fonts/font-face/bc-layer/class-wp-fonts-resolver.php';
-		require __DIR__ . '/experimental/fonts/font-face/bc-layer/class-gutenberg-fonts-api-bc-layer.php';
-		require __DIR__ . '/experimental/fonts/font-face/bc-layer/webfonts-deprecations.php';
-		require __DIR__ . '/experimental/fonts/font-face/bc-layer/class-wp-webfonts-utils.php';
-		require __DIR__ . '/experimental/fonts/font-face/bc-layer/class-wp-webfonts-provider.php';
-		require __DIR__ . '/experimental/fonts/font-face/bc-layer/class-wp-webfonts-provider-local.php';
-		require __DIR__ . '/experimental/fonts/font-face/bc-layer/class-wp-webfonts.php';
-		require __DIR__ . '/experimental/fonts/font-face/bc-layer/class-wp-web-fonts.php';
-	}
+	// A general purpose file for all fonts PHP functions and hooks.
+	require __DIR__ . '/compat/wordpress-6.4/fonts/fonts.php';
+
+	// Load the BC Layer to avoid fatal errors of extenders using the Fonts API.
+	// @core-merge: do not merge the BC layer files into WordPress Core.
+	require __DIR__ . '/experimental/fonts/font-face/bc-layer/class-wp-fonts-provider.php';
+	require __DIR__ . '/experimental/fonts/font-face/bc-layer/class-wp-fonts-utils.php';
+	require __DIR__ . '/experimental/fonts/font-face/bc-layer/class-wp-fonts.php';
+	require __DIR__ . '/experimental/fonts/font-face/bc-layer/class-wp-fonts-provider-local.php';
+	require __DIR__ . '/experimental/fonts/font-face/bc-layer/class-wp-fonts-resolver.php';
+	require __DIR__ . '/experimental/fonts/font-face/bc-layer/class-gutenberg-fonts-api-bc-layer.php';
+	require __DIR__ . '/experimental/fonts/font-face/bc-layer/webfonts-deprecations.php';
+	require __DIR__ . '/experimental/fonts/font-face/bc-layer/class-wp-webfonts-utils.php';
+	require __DIR__ . '/experimental/fonts/font-face/bc-layer/class-wp-webfonts-provider.php';
+	require __DIR__ . '/experimental/fonts/font-face/bc-layer/class-wp-webfonts-provider-local.php';
+	require __DIR__ . '/experimental/fonts/font-face/bc-layer/class-wp-webfonts.php';
+	require __DIR__ . '/experimental/fonts/font-face/bc-layer/class-wp-web-fonts.php';
 } elseif ( ! class_exists( 'WP_Fonts' ) ) {
+	// Turns off Font Face hooks in Core.
+	// @since 6.4.0
+	remove_action( 'wp_head', 'wp_print_font_faces', 50 );
+	remove_action( 'admin_print_styles', 'wp_print_font_faces', 50 );
+
 	// Fonts API files.
 	require __DIR__ . '/experimental/fonts-api/class-wp-fonts-provider.php';
 	require __DIR__ . '/experimental/fonts-api/class-wp-fonts-utils.php';

--- a/lib/load.php
+++ b/lib/load.php
@@ -193,7 +193,7 @@ if (
 	require __DIR__ . '/experimental/fonts/font-face/bc-layer/class-wp-web-fonts.php';
 } elseif ( ! class_exists( 'WP_Fonts' ) ) {
 	// Turns off Font Face hooks in Core.
-	// @since 6.4.0
+	// @since 6.4.0.
 	remove_action( 'wp_head', 'wp_print_font_faces', 50 );
 	remove_action( 'admin_print_styles', 'wp_print_font_faces', 50 );
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Prepares Font Face for merge into Core.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

When ready, I'll create a Core PR to merge it into Core's `trunk` for WP 6.4, i.e. to replace the temporary stopgap code.

Font Face is a direct replacement for Core's `_wp_theme_json_webfonts_handler()`.   
* It works off the same theme.json merged data layer.
* Handles the `'file:./'` placeholder within a theme's `theme.json` file.
* Validates the `@font-face` properties.
* Uses the same local provider processing code.
* Builds the `@font-face` CSS in the same way.

Thus, Font Face can go into Core with or without Font Library.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* Moves the Font Face files into the compat directory.
* Adds `@since 6.4.0`.
* Adds Core merge instructions.

Note: Leaves the BC Layer files in experimental, as these are plugin only.

## Testing Instructions
All CI jobs should pass ✅ 

As functionality is not touched and remains the same as before, no further testing is required.