### PR TITLE
BlockList: Ensure element styles (and svg) are always appended at the end of the document

### DIFF
--- a/packages/block-editor/src/components/block-list/index.js
+++ b/packages/block-editor/src/components/block-list/index.js
@@ -104,7 +104,6 @@ function Root( { className, ...settings } ) {
 			ref: useMergeRefs( [
 				useBlockSelectionClearer(),
 				useInBetweenInserter(),
-				setElement,
 				useTypingObserver(),
 			] ),
 			className: classnames( 'is-root-container', className, {
@@ -119,6 +118,8 @@ function Root( { className, ...settings } ) {
 		<elementContext.Provider value={ element }>
 			<IntersectionObserver.Provider value={ intersectionObserver }>
 				<div { ...innerBlocksProps } />
+				{ /* Ensure element and layout styles are always at the end of the document */ }
+				<div hidden ref={ setElement } />
 			</IntersectionObserver.Provider>
 		</elementContext.Provider>
 	);

--- a/packages/block-editor/src/components/block-list/index.js
+++ b/packages/block-editor/src/components/block-list/index.js
@@ -119,7 +119,7 @@ function Root( { className, ...settings } ) {
 			<IntersectionObserver.Provider value={ intersectionObserver }>
 				<div { ...innerBlocksProps } />
 				{ /* Ensure element and layout styles are always at the end of the document */ }
-				<div hidden ref={ setElement } />
+				<div ref={ setElement } />
 			</IntersectionObserver.Provider>
 		</elementContext.Provider>
 	);


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes #36053

Update the `BlockList`'s `Root` component to always output element styles (e.g. `style` and `svg` elements for layout, element, and duotone block supports) to the end of the document. To do so, add an extra `div` to the end of `Root` to ensure that any changes to the `useInnerBlocksProps` element occur prior to the injected `style` and `svg` tags.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The reason this change is needed is fairly subtle. React's `createPortal` appends nodes as the list child of an element. In an already loaded post or page, the inner blocks for the block list will all be rendered at the top, and the injected `style` tags will appear at the bottom of the DOM.

Something interesting happens when we go to make changes, though. When hovering over the end of the document and going to insert blocks, the block appender will be rendered _after_ the injects `style` tags in the DOM. Then, when we go to insert blocks, inserted blocks will _also_ be rendered after the injected styles. Whereas, what we expect to happen is that the styles would still appear at the end.

The reason why, I think, is because after the original injection, when React rerenders elements into the portal, it doesn't attempt to remount into the portal, rather it makes updates in place since the elements have already been rendered into the DOM. This means that subsequent additions are added to the end, but we wind up in an unexpected situation where `style` tags wind up "randomly" sitting between other blocks once we go to make changes to blocks within a document.

To avoid this collision between an element where lots of mutation is happening due to addition, removal, or moving of blocks, and the injection of styles and svg tags, a solution is to create a separate `div` as the entrypoint for portal-based injection of style and svg tags, and have this always sit at the bottom of the document.

For further explanation as to why the style and svg tags sitting between blocks is an issue, see the discussion in: https://github.com/WordPress/gutenberg/issues/36053 — the TL;DR is that the presence of these tags can break CSS selectors as such sibling, first / last child, etc.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* Add an extra `div` to the bottom of the `Root`.
* Move the `setElement` ref state function to this node.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Add a variety of Group and Row blocks to a post, page, or template and adjust layout and element settings (like color, custom constrained width, content justification), and ensure the styles all render correctly. Add an Image block and set custom Duotone on the image, also check that this renders correctly.
2. Save and reload the page, ensure rendering is still correct.
3. Inspect the document and observe that there should be `style` tags in a `div` at the end of the document (beneath the block content).
4. Go to insert blocks at the end of the document, using the block inserter button within the editor canvas. Observe that the newly inserted blocks should still be inserted _before_ the injected `style` tags that contain the `wp-container-123` etc rules.
5. Test in a range of browsers to make sure this doesn't introduce any regressions (of note, I noticed that we can't add the `hidden` attribute to the container `div`, because Firefox requires the container to be visible in order for the `svg` elements to be accessible for rendering Duotone). As far as I can tell, the current state of this PR doesn't cause any styling issues, but it would be good to confirm via manual testing.

<details>

<summary>
Here is some test markup to begin with (you'll need to add your own Image blocks with Duotone for testing):
</summary>

```html

<!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"center"}} -->
<div class="wp-block-group"><!-- wp:paragraph -->
<p>A paragraph</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph -->
<p>Another paragraph in a row</p>
<!-- /wp:paragraph --></div>
<!-- /wp:group -->

<!-- wp:group {"style":{"elements":{"link":{"color":{"text":"#ff4545"}}}},"layout":{"type":"constrained","contentSize":"320px","wideSize":"480px"}} -->
<div class="wp-block-group has-link-color"><!-- wp:paragraph -->
<p>A paragraph in a constrained Group block</p>
<!-- /wp:paragraph -->

<!-- wp:cover {"dimRatio":50,"overlayColor":"luminous-vivid-orange","minHeight":123,"minHeightUnit":"px","isDark":false} -->
<div class="wp-block-cover is-light" style="min-height:123px"><span aria-hidden="true" class="wp-block-cover__background has-luminous-vivid-orange-background-color has-background-dim"></span><div class="wp-block-cover__inner-container"><!-- wp:paragraph -->
<p>A cover in a <a href="http://wordpress.org" data-type="link" data-id="wordpress.org">constrained</a> Group block</p>
<!-- /wp:paragraph --></div></div>
<!-- /wp:cover -->

<!-- wp:cover {"dimRatio":50,"overlayColor":"luminous-vivid-orange","minHeight":123,"minHeightUnit":"px","isDark":false,"align":"wide"} -->
<div class="wp-block-cover alignwide is-light" style="min-height:123px"><span aria-hidden="true" class="wp-block-cover__background has-luminous-vivid-orange-background-color has-background-dim"></span><div class="wp-block-cover__inner-container"><!-- wp:paragraph -->
<p>A cover in a constrained Group block</p>
<!-- /wp:paragraph --></div></div>
<!-- /wp:cover --></div>
<!-- /wp:group -->

<!-- wp:group {"style":{"position":{"type":"sticky","top":"0px"},"spacing":{"padding":{"top":"var:preset|spacing|30","bottom":"var:preset|spacing|30","left":"var:preset|spacing|30","right":"var:preset|spacing|30"}}},"backgroundColor":"vivid-red","layout":{"type":"constrained"}} -->
<div class="wp-block-group has-vivid-red-background-color has-background" style="padding-top:var(--wp--preset--spacing--30);padding-right:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--30);padding-left:var(--wp--preset--spacing--30)"><!-- wp:paragraph -->
<p>A paragraph in a sticky group</p>
<!-- /wp:paragraph --></div>
<!-- /wp:group -->

```

</details>

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

The below screenshots show the in editor markup for a post just after a paragraph block has been inserted at the end of the document.

Note that in the "before" screenshot, there is a Figure element for the image block, then a series of `style` and `svg` tags, then the paragraph block, then the block appender.

In the "after" screenshot, in the top area there is the Figure element for thee image block, then the paragraph block, then the block appender. And below all of them is a separate `div` to contain all the `style` and `svg` tags.

| Before | After |
| --- | --- |
| <img width="784" alt="image" src="https://github.com/WordPress/gutenberg/assets/14988353/ab75a3fb-c3b0-4b10-be13-a5e2a5b0e02e"> | <img width="805" alt="image" src="https://github.com/WordPress/gutenberg/assets/14988353/d2c6045c-fe26-4fb1-8a01-32dcd5dbe13f"> |