### PR TITLE
HTML API: Backport updates from Core - removing duplicate attributes

### DIFF
--- a/lib/compat/wordpress-6.3/html-api/class-gutenberg-html-tag-processor-6-3.php
+++ b/lib/compat/wordpress-6.3/html-api/class-gutenberg-html-tag-processor-6-3.php
@@ -408,7 +408,7 @@ class Gutenberg_HTML_Tag_Processor_6_3 {
 	 * Tracks spans of duplicate attributes on a given tag, used for removing
 	 * all copies of an attribute when calling `remove_attribute()`.
 	 *
-	 * @since 6.3.1
+	 * @since 6.3.2
 	 *
 	 * @var (WP_HTML_Span[])[]|null
 	 */

--- a/lib/compat/wordpress-6.4/html-api/class-gutenberg-html-tag-processor-6-4.php
+++ b/lib/compat/wordpress-6.4/html-api/class-gutenberg-html-tag-processor-6-4.php
@@ -243,7 +243,7 @@
  *
  * @since 6.2.0
  */
-class Gutenberg_HTML_Tag_Processor_6_3 {
+class Gutenberg_HTML_Tag_Processor_6_4 {
 	/**
 	 * The maximum number of bookmarks allowed to exist at
 	 * any given time.
@@ -961,7 +961,7 @@ class Gutenberg_HTML_Tag_Processor_6_3 {
 
 			if ( '/' === $this->html[ $at + 1 ] ) {
 				$this->is_closing_tag = true;
-				++$at;
+				$at++;
 			} else {
 				$this->is_closing_tag = false;
 			}
@@ -1030,7 +1030,7 @@ class Gutenberg_HTML_Tag_Processor_6_3 {
 					 *
 					 * See https://html.spec.whatwg.org/#parse-error-incorrectly-closed-comment
 					 */
-					--$closer_at; // Pre-increment inside condition below reduces risk of accidental infinite looping.
+					$closer_at--; // Pre-increment inside condition below reduces risk of accidental infinite looping.
 					while ( ++$closer_at < strlen( $html ) ) {
 						$closer_at = strpos( $html, '--', $closer_at );
 						if ( false === $closer_at ) {
@@ -1111,7 +1111,7 @@ class Gutenberg_HTML_Tag_Processor_6_3 {
 			 * See https://html.spec.whatwg.org/#parse-error-missing-end-tag-name
 			 */
 			if ( '>' === $html[ $at + 1 ] ) {
-				++$at;
+				$at++;
 				continue;
 			}
 
@@ -2327,9 +2327,11 @@ class Gutenberg_HTML_Tag_Processor_6_3 {
 			 * See https://html.spec.whatwg.org/#attributes-3
 			 * See https://html.spec.whatwg.org/#space-separated-tokens
 			 */
-			do {
-				$class_at = strpos( $this->html, $this->sought_class_name, $class_at );
-
+			while (
+				// phpcs:ignore WordPress.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition
+				false !== ( $class_at = strpos( $this->html, $this->sought_class_name, $class_at ) ) &&
+				$class_at < $class_end
+			) {
 				/*
 				 * Verify this class starts at a boundary.
 				 */
@@ -2355,7 +2357,7 @@ class Gutenberg_HTML_Tag_Processor_6_3 {
 				}
 
 				return true;
-			} while ( false !== $class_at && $class_at < $class_end );
+			}
 
 			return false;
 		}

--- a/lib/compat/wordpress-6.4/html-api/class-gutenberg-html-tag-processor-6-4.php
+++ b/lib/compat/wordpress-6.4/html-api/class-gutenberg-html-tag-processor-6-4.php
@@ -408,7 +408,7 @@ class Gutenberg_HTML_Tag_Processor_6_4 {
 	 * Tracks spans of duplicate attributes on a given tag, used for removing
 	 * all copies of an attribute when calling `remove_attribute()`.
 	 *
-	 * @since 6.3.1
+	 * @since 6.3.2
 	 *
 	 * @var (WP_HTML_Span[])[]|null
 	 */


### PR DESCRIPTION
## Status

**DO NOT MERGE** This is a preparatory PR paired with https://github.com/WordPress/wordpress-develop/pull/4317 to verify that the coding style enforced here doesn't provoke additional changes upstream in Core due to the different coding style rules there.

## Description

When removing an attribute from a tag where duplicate copies of that attribute exist (with or without the same values), the tag processor previously wasn't removing all copies of the attribute. This left one or more after the removal, in effect not removing it.

The Core patch updates the behavior to removall all copies of a removed attribute.