### PR TITLE
Post Content: Ensure layout classnames are applied in readonly preview

### DIFF
--- a/packages/block-library/src/post-content/edit.js
+++ b/packages/block-library/src/post-content/edit.js
@@ -20,14 +20,19 @@ import { useSelect } from '@wordpress/data';
  */
 import { useCanEditEntity } from '../utils/hooks';
 
-function ReadOnlyContent( { userCanEdit, postType, postId } ) {
+function ReadOnlyContent( {
+	layoutClassNames,
+	userCanEdit,
+	postType,
+	postId,
+} ) {
 	const [ , , content ] = useEntityProp(
 		'postType',
 		postType,
 		'content',
 		postId
 	);
-	const blockProps = useBlockProps();
+	const blockProps = useBlockProps( { className: layoutClassNames } );
 	return content?.protected && ! userCanEdit ? (
 		<div { ...blockProps }>
 			<Warning>{ __( 'This content is password protected.' ) }</Warning>
@@ -77,7 +82,8 @@ function EditableContent( { context = {} } ) {
 }
 
 function Content( props ) {
-	const { context: { queryId, postType, postId } = {} } = props;
+	const { context: { queryId, postType, postId } = {}, layoutClassNames } =
+		props;
 	const userCanEdit = useCanEditEntity( 'postType', postType, postId );
 	if ( userCanEdit === undefined ) {
 		return null;
@@ -90,6 +96,7 @@ function Content( props ) {
 		<EditableContent { ...props } />
 	) : (
 		<ReadOnlyContent
+			layoutClassNames={ layoutClassNames }
 			userCanEdit={ userCanEdit }
 			postType={ postType }
 			postId={ postId }
@@ -133,11 +140,9 @@ function RecursionError() {
 
 export default function PostContentEdit( {
 	context,
-	attributes,
 	__unstableLayoutClassNames: layoutClassNames,
 } ) {
 	const { postId: contextPostId, postType: contextPostType } = context;
-	const { layout = {} } = attributes;
 	const hasAlreadyRendered = useHasRecursion( contextPostId );
 
 	if ( contextPostId && contextPostType && hasAlreadyRendered ) {
@@ -147,7 +152,10 @@ export default function PostContentEdit( {
 	return (
 		<RecursionProvider uniqueId={ contextPostId }>
 			{ contextPostId && contextPostType ? (
-				<Content context={ context } layout={ layout } />
+				<Content
+					context={ context }
+					layoutClassNames={ layoutClassNames }
+				/>
 			) : (
 				<Placeholder layoutClassNames={ layoutClassNames } />
 			) }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes #53752

Ensure that layout classnames are output for the readonly preview of the Post Content block by passing them in to `useBlockProps`.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The Placeholder state already uses these layout classnames, and the editable view should already be getting the layout classnames via `useInnerBlocksProps`. Because the read only preview is a bit of a special case, we need to manually pass the layout classnames in order for them to be applied to the preview. (The preview / read only state does not use `useInnerBlocksProps` so does not receive layout classnames automatically without wiring them up like in this PR).

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

1. Rearrange things slightly in the Post Content block's `edit.js` so that the layout classnames are passed down to and output for the read only content state of the block.
2. While here, remove the unused `layout` prop being passed to `Content` as it was a leftover after #47477 landed.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

In a site's home template, at the following at the root level to add a Query Loop block where the Content block within Post Template is set to use constrained layout:

<details>

<summary>Query Loop markup</summary>

```html
<!-- wp:query {"queryId":2,"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false}} -->
<div class="wp-block-query"><!-- wp:post-template {"layout":{"type":"default"}} -->
<!-- wp:post-title /-->

<!-- wp:post-content {"layout":{"type":"constrained"}} /-->
<!-- /wp:post-template --></div>
<!-- /wp:query -->
```

</details>

Then, add a post containing a few blocks, one at content width, one at wide width, and one at full-wide width. For example, here's a few cover blocks:

<details>

<summary>Cover block markup</summary>

```html
<!-- wp:cover {"overlayColor":"secondary","minHeight":197,"minHeightUnit":"px","layout":{"type":"constrained"}} -->
<div class="wp-block-cover" style="min-height:197px"><span aria-hidden="true" class="wp-block-cover__background has-secondary-background-color has-background-dim-100 has-background-dim"></span><div class="wp-block-cover__inner-container"><!-- wp:paragraph {"align":"center","placeholder":"Write title…","fontSize":"large"} -->
<p class="has-text-align-center has-large-font-size">A content-width cover block</p>
<!-- /wp:paragraph --></div></div>
<!-- /wp:cover -->

<!-- wp:cover {"overlayColor":"secondary","minHeight":197,"minHeightUnit":"px","align":"wide","layout":{"type":"constrained"}} -->
<div class="wp-block-cover alignwide" style="min-height:197px"><span aria-hidden="true" class="wp-block-cover__background has-secondary-background-color has-background-dim-100 has-background-dim"></span><div class="wp-block-cover__inner-container"><!-- wp:paragraph {"align":"center","placeholder":"Write title…","fontSize":"large"} -->
<p class="has-text-align-center has-large-font-size">A wide cover block</p>
<!-- /wp:paragraph --></div></div>
<!-- /wp:cover -->

<!-- wp:cover {"overlayColor":"secondary","minHeight":197,"minHeightUnit":"px","align":"full","layout":{"type":"constrained"}} -->
<div class="wp-block-cover alignfull" style="min-height:197px"><span aria-hidden="true" class="wp-block-cover__background has-secondary-background-color has-background-dim-100 has-background-dim"></span><div class="wp-block-cover__inner-container"><!-- wp:paragraph {"align":"center","placeholder":"Write title…","fontSize":"large"} -->
<p class="has-text-align-center has-large-font-size">A full-wide cover block</p>
<!-- /wp:paragraph --></div></div>
<!-- /wp:cover -->
```

</details>

1. With the above Query Loop added to the site template, and then a post created with the above Cover block markup, test that on `trunk` the post will display in the site editor's content preview as full width, with no spacing between blocks, due to the lack of layout classnames being output.
3. With this PR applied, toggling `Inner blocks use content width` at the Content block level should update and reflect in the site editor, along with any custom values entered for `Content` and `Wide` sizes.

## Screenshots or screencast <!-- if applicable -->

### Before

![image](https://github.com/WordPress/gutenberg/assets/14988353/b121033c-729f-45ab-9256-bda72824ed17)

### After

![image](https://github.com/WordPress/gutenberg/assets/14988353/98fd6e1a-eb10-46f5-9bdf-a71614b26768)
