### PR TITLE
Adds explanatory text to view.js template

### DIFF
--- a/packages/create-block/lib/templates/block/view.js.mustache
+++ b/packages/create-block/lib/templates/block/view.js.mustache
@@ -1,3 +1,22 @@
+/**
+ * Use this file for JavaScript code that you want to run in the front-end 
+ * on posts/pages that contain this block.
+ *
+ * When this file is defined as the value of the `viewScript` property
+ * in `block.json` it will be enqueued when, and only when, viewing the
+ * content on the front of the site - i.e. it will *not* run in the editor.
+ *
+ * Example:
+ *
+ * ```js
+ * {
+ *   "viewScript": "file:./view.js"
+ * }
+ * ```
+ *
+ * @see https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#view-script
+ */
+ 
 /* eslint-disable no-console */
 console.log("Hello World! (from {{namespace}}-{{slug}} block)");
 /* eslint-enable no-console */

--- a/packages/create-block/lib/templates/block/view.js.mustache
+++ b/packages/create-block/lib/templates/block/view.js.mustache
@@ -4,7 +4,7 @@
  *
  * When this file is defined as the value of the `viewScript` property
  * in `block.json` it will be enqueued on the front end of the site.
- * content on the front of the site - i.e. it will *not* run in the editor.
+ 
  *
  * Example:
  *

--- a/packages/create-block/lib/templates/block/view.js.mustache
+++ b/packages/create-block/lib/templates/block/view.js.mustache
@@ -4,7 +4,6 @@
  *
  * When this file is defined as the value of the `viewScript` property
  * in `block.json` it will be enqueued on the front end of the site.
- 
  *
  * Example:
  *

--- a/packages/create-block/lib/templates/block/view.js.mustache
+++ b/packages/create-block/lib/templates/block/view.js.mustache
@@ -3,7 +3,7 @@
  * on posts/pages that contain this block.
  *
  * When this file is defined as the value of the `viewScript` property
- * in `block.json` it will be enqueued when, and only when, viewing the
+ * in `block.json` it will be enqueued on the front end of the site.
  * content on the front of the site - i.e. it will *not* run in the editor.
  *
  * Example:


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Adds some explanatory text to the `view.js` template in the `create-block` package.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
This file, namely `view.js`, was recently added to projects created with `@wordpress/create-block`, I believe due to the implementation of the Interactivity API (correct me if I'm wrong). For many people it's not clear what this file is for so some explanatory text has been added as a comment in the template file to clarify its purpose and usage.


