### PR TITLE
Interactivity API: Fix non stable context reference on client side navigation

### DIFF
--- a/packages/e2e-tests/plugins/interactive-blocks/directive-context/render.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-context/render.php
@@ -128,6 +128,7 @@
 	<div data-testid="navigation text" data-wp-text="context.text"></div>
 	<div data-testid="navigation new text" data-wp-text="context.newText"></div>
 	<button data-testid="toggle text" data-wp-on--click="actions.toggleText">Toggle Text</button>
-	<button data-testid="add new text" data-wp-on--click="actions.addNewText">Add new text</button>
+	<button data-testid="add new text" data-wp-on--click="actions.addNewText">Add New Text</button>
 	<button data-testid="navigate" data-wp-on--click="actions.navigate">Navigate</button>
+	<button data-testid="async navigate" data-wp-on--click="actions.asyncNavigate">Async Navigate</button>
 </div>

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-context/view.js
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-context/view.js
@@ -12,6 +12,7 @@
 			<button data-testid="toggle text" data-wp-on--click="actions.toggleText">Toggle Text</button>
 			<button data-testid="add new text" data-wp-on--click="actions.addNewText">Add new text</button>
 			<button data-testid="navigate" data-wp-on--click="actions.navigate">Navigate</button>
+			<button data-testid="async navigate" data-wp-on--click="actions.asyncNavigate">Async Navigate</button>
 		</div>`;
 
 	store( {
@@ -41,6 +42,13 @@
 					force: true,
 					html,
 				} );
+			},
+			asyncNavigate: async ({ context }) => {
+				await navigate( window.location, {
+					force: true,
+					html,
+				} );
+				context.newText = 'changed from async action';
 			}
 		},
 	} );

--- a/test/e2e/specs/interactivity/directives-context.spec.ts
+++ b/test/e2e/specs/interactivity/directives-context.spec.ts
@@ -180,4 +180,13 @@ test.describe( 'data-wp-context', () => {
 		await page.getByTestId( 'navigate' ).click();
 		await expect( element ).toHaveText( 'some new text' );
 	} );
+
+	test( 'should maintain the same context reference on async actions', async ( {
+		page,
+	} ) => {
+		const element = page.getByTestId( 'navigation new text' );
+		await expect( element ).toHaveText( '' );
+		await page.getByTestId( 'async navigate' ).click();
+		await expect( element ).toHaveText( 'changed from async action' );
+	} );
 } );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

A small fix for https://github.com/WordPress/gutenberg/pull/53853.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Because the `context` reference was replaced during the client-side navigation, and async functions lost their reference:

```js
store({
  actions: {
    someAction: async ({ context }) => {
      context.something // This is fine.
      await someAsync();
      context.something // This no longer points to the current context.
    }
  }
})
```

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

By making sure that we reuse the same reference when the `data-wp-context` directive is executed again.

## Tasks

- [x] Add e2e test
- [x] Fix logic

It doesn't need an entry on the changelog because this is a fix for https://github.com/WordPress/gutenberg/pull/53853 which hasn't been released yet.
