### PR TITLE
`ProgressBar`: Add transition to determinate indicator

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 -   `SandBox`: Fix the cleanup method in useEffect ([#53796](https://github.com/WordPress/gutenberg/pull/53796)).
 
+### Enhancements
+
+-   `ProgressBar`: Add transition to determinate indicator ([#53877](https://github.com/WordPress/gutenberg/pull/53877)).
+
 ## 25.6.0 (2023-08-16)
 
 ### Enhancements

--- a/packages/components/src/progress-bar/styles.ts
+++ b/packages/components/src/progress-bar/styles.ts
@@ -56,7 +56,7 @@ export const Indicator = styled.div< {
 			  } )
 			: css( {
 					width: `${ value }%`,
-					transition: 'width 0.2s ease-in-out',
+					transition: 'width 0.4s ease-in-out',
 			  } ) };
 `;
 

--- a/packages/components/src/progress-bar/styles.ts
+++ b/packages/components/src/progress-bar/styles.ts
@@ -54,7 +54,10 @@ export const Indicator = styled.div< {
 					animationName: animateProgressBar,
 					width: `${ INDETERMINATE_TRACK_WIDTH }%`,
 			  } )
-			: css( { width: `${ value }%` } ) };
+			: css( {
+					width: `${ value }%`,
+					transition: 'width 0.2s ease-in-out',
+			  } ) };
 `;
 
 export const ProgressElement = styled.progress`


### PR DESCRIPTION
## What?
This PR adds a transition to the progress bar indicator when in determinate mode. 

Suggested by @jasmussen and @mtias [here](https://github.com/WordPress/gutenberg/pull/53399#issuecomment-1683781552).

## Why?
To make the progress bar feel smoother to the end user. Here's some additional rationale: https://github.com/WordPress/gutenberg/pull/53399#issuecomment-1683781552

## How?
We're just adding a `width` transition for the determinate mode only. The indeterminate one doesn't need it, because the indicator there keeps a constant width. 

## Testing Instructions
* Spin up storybook: `npm run storybook:dev`
* Open the `ProgressBar` component: http://localhost:50240/?path=/docs/components-experimental-progressbar--docs
* Play with the `value` field and witness how the indicator animates when transitioning.

### Testing Instructions for Keyboard
None

## Screenshots or screencast <!-- if applicable -->
Before:

https://github.com/WordPress/gutenberg/assets/8436925/3ac44b55-b1c9-4c0f-944b-e831952e46dd

After:

https://github.com/WordPress/gutenberg/assets/8436925/09a82ea7-6aae-48b0-9198-99efa0368d0f

