### PR TITLE
HTML API: Backport updates from Core - stop processing after unsupported markup

### DIFF
--- a/lib/compat/wordpress-6.4/html-api/class-wp-html-processor.php
+++ b/lib/compat/wordpress-6.4/html-api/class-wp-html-processor.php
@@ -436,6 +436,11 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 	 * @return bool Whether a tag was matched.
 	 */
 	public function step( $node_to_process = self::PROCESS_NEXT_NODE ) {
+		// Refuse to proceed if there was a previous error.
+		if ( null !== $this->last_error ) {
+			return false;
+		}
+
 		if ( self::PROCESS_NEXT_NODE === $node_to_process ) {
 			$top_node = $this->state->stack_of_open_elements->current_node();
 			if ( $top_node && self::is_void( $top_node->node_name ) ) {
@@ -748,6 +753,10 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 	 * @return string|null Name of currently matched tag in input HTML, or `null` if none found.
 	 */
 	public function get_tag() {
+		if ( null !== $this->last_error ) {
+			return null;
+		}
+
 		$tag_name = parent::get_tag();
 
 		switch ( $tag_name ) {


### PR DESCRIPTION
## Description

WordPress/WordPress-develop#5048 fixes a bug where the HTML Processor continues to process input HTML once it encounters unsupported markup, which it shouldn't. It should stop and abort all processing.

As a blessed PR, once this is merged into Core it should need no further review here other than to make sure that the backport was properly written and applied.