### PR TITLE
feat: Improve horizontal rule layout

### DIFF
--- a/packages/primitives/src/horizontal-rule/index.native.js
+++ b/packages/primitives/src/horizontal-rule/index.native.js
@@ -30,7 +30,7 @@ const HR = ( {
 	);
 
 	const renderText = ( key ) => (
-		<View key={ key }>
+		<View key={ key } style={ styles.textContainer }>
 			<Text style={ [ styles.text, textStyle ] }>{ text }</Text>
 		</View>
 	);

--- a/packages/primitives/src/horizontal-rule/styles.native.scss
+++ b/packages/primitives/src/horizontal-rule/styles.native.scss
@@ -7,7 +7,7 @@
 
 .line {
 	background-color: $gray-lighten-20;
-	flex: 1;
+	flex: 1 0 10px;
 	height: 2;
 }
 
@@ -15,9 +15,12 @@
 	background-color: $gray-50;
 }
 
-.text {
-	flex: 1;
+.textContainer {
+	flex: 0 1 auto;
 	margin-left: 15px;
 	margin-right: 15px;
+}
+
+.text {
 	text-align: center;
 }

--- a/packages/react-native-editor/CHANGELOG.md
+++ b/packages/react-native-editor/CHANGELOG.md
@@ -11,6 +11,7 @@ For each user feature we should also add a importance categorization label  to i
 
 ## Unreleased
 -   [*] Search Control - Prevent calling TextInput's methods when undefined [#53745]
+-   [*] Improve horizontal rule styles to avoid invisible lines [#53883]
 
 ## 1.102.0
 -   [*] Display custom color value in mobile Cover Block color picker [#51414]


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Improve horizontal rule layout in the native mobile editor.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
When very large or long text was used, the horizontal lines bookending the text
would shrink to the point where they were barely visible. 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
This enforces a 10 pixel width for the lines, causing the text to wrap lines as
necessary.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Add a More block.
1. Verify no visual regressions have occurred.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
n/a

## Screenshots or screencast <!-- if applicable -->
| Before | After |
| - | - |
| ![before](https://github.com/WordPress/gutenberg/assets/438664/4fef1279-ec77-4ad7-a496-0d7d0a939f9a) | ![after](https://github.com/WordPress/gutenberg/assets/438664/fe3c4856-d06f-47ed-86dd-f91522ce8859) |
