### PR TITLE
[Mobile] - Fix Voice Over and assistive keyboards

### DIFF
--- a/packages/block-library/src/audio/test/__snapshots__/edit.native.js.snap
+++ b/packages/block-library/src/audio/test/__snapshots__/edit.native.js.snap
@@ -151,7 +151,7 @@ exports[`Audio block renders audio block error state without crashing 1`] = `
               "text": undefined,
             }
           }
-          accessible={true}
+          accessible={false}
           collapsable={false}
           focusable={true}
           onBlur={[Function]}
@@ -391,7 +391,7 @@ exports[`Audio block renders audio file without crashing 1`] = `
               "text": undefined,
             }
           }
-          accessible={true}
+          accessible={false}
           collapsable={false}
           focusable={true}
           onBlur={[Function]}

--- a/packages/block-library/src/audio/test/__snapshots__/edit.native.js.snap
+++ b/packages/block-library/src/audio/test/__snapshots__/edit.native.js.snap
@@ -133,7 +133,7 @@ exports[`Audio block renders audio block error state without crashing 1`] = `
           ]
         }
       >
-        <RCTAztecView
+        <View
           accessibilityState={
             {
               "busy": undefined,
@@ -143,59 +143,73 @@ exports[`Audio block renders audio block error state without crashing 1`] = `
               "selected": undefined,
             }
           }
-          accessible={true}
-          activeFormats={[]}
-          blockType={
+          accessibilityValue={
             {
-              "tag": "p",
+              "max": undefined,
+              "min": undefined,
+              "now": undefined,
+              "text": undefined,
             }
           }
-          deleteEnter={true}
-          disableEditingMenu={false}
+          accessible={true}
+          collapsable={false}
           focusable={true}
-          fontFamily="serif"
-          fontSize={14}
-          isMultiline={false}
-          maxImagesWidth={200}
-          onBackspace={[Function]}
           onBlur={[Function]}
-          onChange={[Function]}
           onClick={[Function]}
-          onContentSizeChange={[Function]}
-          onEnter={[Function]}
           onFocus={[Function]}
-          onHTMLContentWithCursor={[Function]}
-          onKeyDown={[Function]}
-          onPaste={[Function]}
           onResponderGrant={[Function]}
           onResponderMove={[Function]}
           onResponderRelease={[Function]}
           onResponderTerminate={[Function]}
           onResponderTerminationRequest={[Function]}
-          onSelectionChange={[Function]}
           onStartShouldSetResponder={[Function]}
-          placeholder="Add caption"
-          placeholderTextColor="gray"
-          selectionColor="black"
-          style={
-            {
-              "backgroundColor": undefined,
-              "maxWidth": undefined,
-              "minHeight": 0,
+        >
+          <RCTAztecView
+            activeFormats={[]}
+            blockType={
+              {
+                "tag": "p",
+              }
             }
-          }
-          text={
-            {
-              "eventCount": undefined,
-              "linkTextColor": undefined,
-              "selection": null,
-              "tag": "p",
-              "text": "",
+            deleteEnter={true}
+            disableEditingMenu={false}
+            fontFamily="serif"
+            fontSize={14}
+            isMultiline={false}
+            maxImagesWidth={200}
+            onBackspace={[Function]}
+            onBlur={[Function]}
+            onChange={[Function]}
+            onContentSizeChange={[Function]}
+            onEnter={[Function]}
+            onFocus={[Function]}
+            onHTMLContentWithCursor={[Function]}
+            onKeyDown={[Function]}
+            onPaste={[Function]}
+            onSelectionChange={[Function]}
+            placeholder="Add caption"
+            placeholderTextColor="gray"
+            selectionColor="black"
+            style={
+              {
+                "backgroundColor": undefined,
+                "maxWidth": undefined,
+                "minHeight": 0,
+              }
             }
-          }
-          textAlign="center"
-          triggerKeyCodes={[]}
-        />
+            text={
+              {
+                "eventCount": undefined,
+                "linkTextColor": undefined,
+                "selection": null,
+                "tag": "p",
+                "text": "",
+              }
+            }
+            textAlign="center"
+            triggerKeyCodes={[]}
+          />
+        </View>
       </View>
     </View>
   </View>
@@ -359,7 +373,7 @@ exports[`Audio block renders audio file without crashing 1`] = `
           ]
         }
       >
-        <RCTAztecView
+        <View
           accessibilityState={
             {
               "busy": undefined,
@@ -369,59 +383,73 @@ exports[`Audio block renders audio file without crashing 1`] = `
               "selected": undefined,
             }
           }
-          accessible={true}
-          activeFormats={[]}
-          blockType={
+          accessibilityValue={
             {
-              "tag": "p",
+              "max": undefined,
+              "min": undefined,
+              "now": undefined,
+              "text": undefined,
             }
           }
-          deleteEnter={true}
-          disableEditingMenu={false}
+          accessible={true}
+          collapsable={false}
           focusable={true}
-          fontFamily="serif"
-          fontSize={14}
-          isMultiline={false}
-          maxImagesWidth={200}
-          onBackspace={[Function]}
           onBlur={[Function]}
-          onChange={[Function]}
           onClick={[Function]}
-          onContentSizeChange={[Function]}
-          onEnter={[Function]}
           onFocus={[Function]}
-          onHTMLContentWithCursor={[Function]}
-          onKeyDown={[Function]}
-          onPaste={[Function]}
           onResponderGrant={[Function]}
           onResponderMove={[Function]}
           onResponderRelease={[Function]}
           onResponderTerminate={[Function]}
           onResponderTerminationRequest={[Function]}
-          onSelectionChange={[Function]}
           onStartShouldSetResponder={[Function]}
-          placeholder="Add caption"
-          placeholderTextColor="gray"
-          selectionColor="black"
-          style={
-            {
-              "backgroundColor": undefined,
-              "maxWidth": undefined,
-              "minHeight": 0,
+        >
+          <RCTAztecView
+            activeFormats={[]}
+            blockType={
+              {
+                "tag": "p",
+              }
             }
-          }
-          text={
-            {
-              "eventCount": undefined,
-              "linkTextColor": undefined,
-              "selection": null,
-              "tag": "p",
-              "text": "",
+            deleteEnter={true}
+            disableEditingMenu={false}
+            fontFamily="serif"
+            fontSize={14}
+            isMultiline={false}
+            maxImagesWidth={200}
+            onBackspace={[Function]}
+            onBlur={[Function]}
+            onChange={[Function]}
+            onContentSizeChange={[Function]}
+            onEnter={[Function]}
+            onFocus={[Function]}
+            onHTMLContentWithCursor={[Function]}
+            onKeyDown={[Function]}
+            onPaste={[Function]}
+            onSelectionChange={[Function]}
+            placeholder="Add caption"
+            placeholderTextColor="gray"
+            selectionColor="black"
+            style={
+              {
+                "backgroundColor": undefined,
+                "maxWidth": undefined,
+                "minHeight": 0,
+              }
             }
-          }
-          textAlign="center"
-          triggerKeyCodes={[]}
-        />
+            text={
+              {
+                "eventCount": undefined,
+                "linkTextColor": undefined,
+                "selection": null,
+                "tag": "p",
+                "text": "",
+              }
+            }
+            textAlign="center"
+            triggerKeyCodes={[]}
+          />
+        </View>
       </View>
     </View>
   </View>

--- a/packages/block-library/src/file/test/__snapshots__/edit.native.js.snap
+++ b/packages/block-library/src/file/test/__snapshots__/edit.native.js.snap
@@ -64,7 +64,7 @@ exports[`File block renders file error state without crashing 1`] = `
           ]
         }
       >
-        <RCTAztecView
+        <View
           accessibilityState={
             {
               "busy": undefined,
@@ -74,59 +74,73 @@ exports[`File block renders file error state without crashing 1`] = `
               "selected": undefined,
             }
           }
-          accessible={true}
-          activeFormats={[]}
-          blockType={
+          accessibilityValue={
             {
-              "tag": "p",
+              "max": undefined,
+              "min": undefined,
+              "now": undefined,
+              "text": undefined,
             }
           }
-          deleteEnter={true}
-          disableEditingMenu={false}
+          accessible={true}
+          collapsable={false}
           focusable={true}
-          fontFamily="serif"
-          fontSize={16}
-          isMultiline={false}
-          maxImagesWidth={200}
-          onBackspace={[Function]}
           onBlur={[Function]}
-          onChange={[Function]}
           onClick={[Function]}
-          onContentSizeChange={[Function]}
-          onEnter={[Function]}
           onFocus={[Function]}
-          onHTMLContentWithCursor={[Function]}
-          onKeyDown={[Function]}
-          onPaste={[Function]}
           onResponderGrant={[Function]}
           onResponderMove={[Function]}
           onResponderRelease={[Function]}
           onResponderTerminate={[Function]}
           onResponderTerminationRequest={[Function]}
-          onSelectionChange={[Function]}
           onStartShouldSetResponder={[Function]}
-          placeholder="File name"
-          placeholderTextColor="gray"
-          selectionColor="black"
-          style={
-            {
-              "backgroundColor": undefined,
-              "maxWidth": undefined,
-              "minHeight": 0,
+        >
+          <RCTAztecView
+            activeFormats={[]}
+            blockType={
+              {
+                "tag": "p",
+              }
             }
-          }
-          text={
-            {
-              "eventCount": undefined,
-              "linkTextColor": undefined,
-              "selection": null,
-              "tag": "p",
-              "text": "<p>File name</p>",
+            deleteEnter={true}
+            disableEditingMenu={false}
+            fontFamily="serif"
+            fontSize={16}
+            isMultiline={false}
+            maxImagesWidth={200}
+            onBackspace={[Function]}
+            onBlur={[Function]}
+            onChange={[Function]}
+            onContentSizeChange={[Function]}
+            onEnter={[Function]}
+            onFocus={[Function]}
+            onHTMLContentWithCursor={[Function]}
+            onKeyDown={[Function]}
+            onPaste={[Function]}
+            onSelectionChange={[Function]}
+            placeholder="File name"
+            placeholderTextColor="gray"
+            selectionColor="black"
+            style={
+              {
+                "backgroundColor": undefined,
+                "maxWidth": undefined,
+                "minHeight": 0,
+              }
             }
-          }
-          textAlign="left"
-          triggerKeyCodes={[]}
-        />
+            text={
+              {
+                "eventCount": undefined,
+                "linkTextColor": undefined,
+                "selection": null,
+                "tag": "p",
+                "text": "<p>File name</p>",
+              }
+            }
+            textAlign="left"
+            triggerKeyCodes={[]}
+          />
+        </View>
       </View>
       <View>
         <Svg
@@ -179,7 +193,7 @@ exports[`File block renders file error state without crashing 1`] = `
           ]
         }
       >
-        <RCTAztecView
+        <View
           accessibilityState={
             {
               "busy": undefined,
@@ -189,62 +203,76 @@ exports[`File block renders file error state without crashing 1`] = `
               "selected": undefined,
             }
           }
-          accessible={true}
-          activeFormats={[]}
-          blockType={
+          accessibilityValue={
             {
-              "tag": "p",
+              "max": undefined,
+              "min": undefined,
+              "now": undefined,
+              "text": undefined,
             }
           }
-          color="white"
-          deleteEnter={true}
-          disableEditingMenu={false}
+          accessible={true}
+          collapsable={false}
           focusable={true}
-          fontFamily="serif"
-          fontSize={16}
-          isMultiline={false}
-          maxImagesWidth={200}
-          minWidth={40}
-          onBackspace={[Function]}
           onBlur={[Function]}
-          onChange={[Function]}
           onClick={[Function]}
-          onContentSizeChange={[Function]}
-          onEnter={[Function]}
           onFocus={[Function]}
-          onHTMLContentWithCursor={[Function]}
-          onKeyDown={[Function]}
-          onPaste={[Function]}
           onResponderGrant={[Function]}
           onResponderMove={[Function]}
           onResponderRelease={[Function]}
           onResponderTerminate={[Function]}
           onResponderTerminationRequest={[Function]}
-          onSelectionChange={[Function]}
           onStartShouldSetResponder={[Function]}
-          placeholder=""
-          placeholderTextColor="white"
-          selectionColor="white"
-          style={
-            {
-              "backgroundColor": undefined,
-              "color": "white",
-              "maxWidth": 80,
-              "minHeight": 0,
+        >
+          <RCTAztecView
+            activeFormats={[]}
+            blockType={
+              {
+                "tag": "p",
+              }
             }
-          }
-          text={
-            {
-              "eventCount": undefined,
-              "linkTextColor": undefined,
-              "selection": null,
-              "tag": "p",
-              "text": "<p>Download</p>",
+            color="white"
+            deleteEnter={true}
+            disableEditingMenu={false}
+            fontFamily="serif"
+            fontSize={16}
+            isMultiline={false}
+            maxImagesWidth={200}
+            minWidth={40}
+            onBackspace={[Function]}
+            onBlur={[Function]}
+            onChange={[Function]}
+            onContentSizeChange={[Function]}
+            onEnter={[Function]}
+            onFocus={[Function]}
+            onHTMLContentWithCursor={[Function]}
+            onKeyDown={[Function]}
+            onPaste={[Function]}
+            onSelectionChange={[Function]}
+            placeholder=""
+            placeholderTextColor="white"
+            selectionColor="white"
+            style={
+              {
+                "backgroundColor": undefined,
+                "color": "white",
+                "maxWidth": 80,
+                "minHeight": 0,
+              }
             }
-          }
-          textAlign="center"
-          triggerKeyCodes={[]}
-        />
+            text={
+              {
+                "eventCount": undefined,
+                "linkTextColor": undefined,
+                "selection": null,
+                "tag": "p",
+                "text": "<p>Download</p>",
+              }
+            }
+            textAlign="center"
+            triggerKeyCodes={[]}
+          />
+        </View>
       </View>
     </View>
   </View>
@@ -315,7 +343,7 @@ exports[`File block renders file without crashing 1`] = `
           ]
         }
       >
-        <RCTAztecView
+        <View
           accessibilityState={
             {
               "busy": undefined,
@@ -325,59 +353,73 @@ exports[`File block renders file without crashing 1`] = `
               "selected": undefined,
             }
           }
-          accessible={true}
-          activeFormats={[]}
-          blockType={
+          accessibilityValue={
             {
-              "tag": "p",
+              "max": undefined,
+              "min": undefined,
+              "now": undefined,
+              "text": undefined,
             }
           }
-          deleteEnter={true}
-          disableEditingMenu={false}
+          accessible={true}
+          collapsable={false}
           focusable={true}
-          fontFamily="serif"
-          fontSize={16}
-          isMultiline={false}
-          maxImagesWidth={200}
-          onBackspace={[Function]}
           onBlur={[Function]}
-          onChange={[Function]}
           onClick={[Function]}
-          onContentSizeChange={[Function]}
-          onEnter={[Function]}
           onFocus={[Function]}
-          onHTMLContentWithCursor={[Function]}
-          onKeyDown={[Function]}
-          onPaste={[Function]}
           onResponderGrant={[Function]}
           onResponderMove={[Function]}
           onResponderRelease={[Function]}
           onResponderTerminate={[Function]}
           onResponderTerminationRequest={[Function]}
-          onSelectionChange={[Function]}
           onStartShouldSetResponder={[Function]}
-          placeholder="File name"
-          placeholderTextColor="gray"
-          selectionColor="black"
-          style={
-            {
-              "backgroundColor": undefined,
-              "maxWidth": undefined,
-              "minHeight": 0,
+        >
+          <RCTAztecView
+            activeFormats={[]}
+            blockType={
+              {
+                "tag": "p",
+              }
             }
-          }
-          text={
-            {
-              "eventCount": undefined,
-              "linkTextColor": undefined,
-              "selection": null,
-              "tag": "p",
-              "text": "<p>File name</p>",
+            deleteEnter={true}
+            disableEditingMenu={false}
+            fontFamily="serif"
+            fontSize={16}
+            isMultiline={false}
+            maxImagesWidth={200}
+            onBackspace={[Function]}
+            onBlur={[Function]}
+            onChange={[Function]}
+            onContentSizeChange={[Function]}
+            onEnter={[Function]}
+            onFocus={[Function]}
+            onHTMLContentWithCursor={[Function]}
+            onKeyDown={[Function]}
+            onPaste={[Function]}
+            onSelectionChange={[Function]}
+            placeholder="File name"
+            placeholderTextColor="gray"
+            selectionColor="black"
+            style={
+              {
+                "backgroundColor": undefined,
+                "maxWidth": undefined,
+                "minHeight": 0,
+              }
             }
-          }
-          textAlign="left"
-          triggerKeyCodes={[]}
-        />
+            text={
+              {
+                "eventCount": undefined,
+                "linkTextColor": undefined,
+                "selection": null,
+                "tag": "p",
+                "text": "<p>File name</p>",
+              }
+            }
+            textAlign="left"
+            triggerKeyCodes={[]}
+          />
+        </View>
       </View>
     </View>
     <View
@@ -404,7 +446,7 @@ exports[`File block renders file without crashing 1`] = `
           ]
         }
       >
-        <RCTAztecView
+        <View
           accessibilityState={
             {
               "busy": undefined,
@@ -414,62 +456,76 @@ exports[`File block renders file without crashing 1`] = `
               "selected": undefined,
             }
           }
-          accessible={true}
-          activeFormats={[]}
-          blockType={
+          accessibilityValue={
             {
-              "tag": "p",
+              "max": undefined,
+              "min": undefined,
+              "now": undefined,
+              "text": undefined,
             }
           }
-          color="white"
-          deleteEnter={true}
-          disableEditingMenu={false}
+          accessible={true}
+          collapsable={false}
           focusable={true}
-          fontFamily="serif"
-          fontSize={16}
-          isMultiline={false}
-          maxImagesWidth={200}
-          minWidth={40}
-          onBackspace={[Function]}
           onBlur={[Function]}
-          onChange={[Function]}
           onClick={[Function]}
-          onContentSizeChange={[Function]}
-          onEnter={[Function]}
           onFocus={[Function]}
-          onHTMLContentWithCursor={[Function]}
-          onKeyDown={[Function]}
-          onPaste={[Function]}
           onResponderGrant={[Function]}
           onResponderMove={[Function]}
           onResponderRelease={[Function]}
           onResponderTerminate={[Function]}
           onResponderTerminationRequest={[Function]}
-          onSelectionChange={[Function]}
           onStartShouldSetResponder={[Function]}
-          placeholder=""
-          placeholderTextColor="white"
-          selectionColor="white"
-          style={
-            {
-              "backgroundColor": undefined,
-              "color": "white",
-              "maxWidth": 80,
-              "minHeight": 0,
+        >
+          <RCTAztecView
+            activeFormats={[]}
+            blockType={
+              {
+                "tag": "p",
+              }
             }
-          }
-          text={
-            {
-              "eventCount": undefined,
-              "linkTextColor": undefined,
-              "selection": null,
-              "tag": "p",
-              "text": "<p>Download</p>",
+            color="white"
+            deleteEnter={true}
+            disableEditingMenu={false}
+            fontFamily="serif"
+            fontSize={16}
+            isMultiline={false}
+            maxImagesWidth={200}
+            minWidth={40}
+            onBackspace={[Function]}
+            onBlur={[Function]}
+            onChange={[Function]}
+            onContentSizeChange={[Function]}
+            onEnter={[Function]}
+            onFocus={[Function]}
+            onHTMLContentWithCursor={[Function]}
+            onKeyDown={[Function]}
+            onPaste={[Function]}
+            onSelectionChange={[Function]}
+            placeholder=""
+            placeholderTextColor="white"
+            selectionColor="white"
+            style={
+              {
+                "backgroundColor": undefined,
+                "color": "white",
+                "maxWidth": 80,
+                "minHeight": 0,
+              }
             }
-          }
-          textAlign="center"
-          triggerKeyCodes={[]}
-        />
+            text={
+              {
+                "eventCount": undefined,
+                "linkTextColor": undefined,
+                "selection": null,
+                "tag": "p",
+                "text": "<p>Download</p>",
+              }
+            }
+            textAlign="center"
+            triggerKeyCodes={[]}
+          />
+        </View>
       </View>
     </View>
   </View>

--- a/packages/block-library/src/file/test/__snapshots__/edit.native.js.snap
+++ b/packages/block-library/src/file/test/__snapshots__/edit.native.js.snap
@@ -82,7 +82,7 @@ exports[`File block renders file error state without crashing 1`] = `
               "text": undefined,
             }
           }
-          accessible={true}
+          accessible={false}
           collapsable={false}
           focusable={true}
           onBlur={[Function]}
@@ -211,7 +211,7 @@ exports[`File block renders file error state without crashing 1`] = `
               "text": undefined,
             }
           }
-          accessible={true}
+          accessible={false}
           collapsable={false}
           focusable={true}
           onBlur={[Function]}
@@ -361,7 +361,7 @@ exports[`File block renders file without crashing 1`] = `
               "text": undefined,
             }
           }
-          accessible={true}
+          accessible={false}
           collapsable={false}
           focusable={true}
           onBlur={[Function]}
@@ -464,7 +464,7 @@ exports[`File block renders file without crashing 1`] = `
               "text": undefined,
             }
           }
-          accessible={true}
+          accessible={false}
           collapsable={false}
           focusable={true}
           onBlur={[Function]}

--- a/packages/block-library/src/search/test/__snapshots__/edit.native.js.snap
+++ b/packages/block-library/src/search/test/__snapshots__/edit.native.js.snap
@@ -37,7 +37,7 @@ exports[`Search Block renders block with button inside option 1`] = `
             "text": undefined,
           }
         }
-        accessible={true}
+        accessible={false}
         collapsable={false}
         focusable={true}
         onBlur={[Function]}
@@ -176,7 +176,7 @@ exports[`Search Block renders block with button inside option 1`] = `
                 "text": undefined,
               }
             }
-            accessible={true}
+            accessible={false}
             collapsable={false}
             focusable={true}
             onBlur={[Function]}
@@ -279,7 +279,7 @@ exports[`Search Block renders block with icon button option matches snapshot 1`]
             "text": undefined,
           }
         }
-        accessible={true}
+        accessible={false}
         collapsable={false}
         focusable={true}
         onBlur={[Function]}
@@ -488,7 +488,7 @@ exports[`Search Block renders block with label hidden matches snapshot 1`] = `
                 "text": undefined,
               }
             }
-            accessible={true}
+            accessible={false}
             collapsable={false}
             focusable={true}
             onBlur={[Function]}
@@ -591,7 +591,7 @@ exports[`Search Block renders with default configuration matches snapshot 1`] = 
             "text": undefined,
           }
         }
-        accessible={true}
+        accessible={false}
         collapsable={false}
         focusable={true}
         onBlur={[Function]}
@@ -730,7 +730,7 @@ exports[`Search Block renders with default configuration matches snapshot 1`] = 
                 "text": undefined,
               }
             }
-            accessible={true}
+            accessible={false}
             collapsable={false}
             focusable={true}
             onBlur={[Function]}
@@ -833,7 +833,7 @@ exports[`Search Block renders with no-button option matches snapshot 1`] = `
             "text": undefined,
           }
         }
-        accessible={true}
+        accessible={false}
         collapsable={false}
         focusable={true}
         onBlur={[Function]}

--- a/packages/block-library/src/search/test/__snapshots__/edit.native.js.snap
+++ b/packages/block-library/src/search/test/__snapshots__/edit.native.js.snap
@@ -19,7 +19,7 @@ exports[`Search Block renders block with button inside option 1`] = `
         ]
       }
     >
-      <RCTAztecView
+      <View
         accessibilityState={
           {
             "busy": undefined,
@@ -29,57 +29,71 @@ exports[`Search Block renders block with button inside option 1`] = `
             "selected": undefined,
           }
         }
-        accessible={true}
-        activeFormats={[]}
-        blockType={
+        accessibilityValue={
           {
-            "tag": "p",
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
           }
         }
-        disableEditingMenu={false}
+        accessible={true}
+        collapsable={false}
         focusable={true}
-        fontFamily="serif"
-        fontSize={16}
-        isMultiline={false}
-        maxImagesWidth={200}
-        onBackspace={[Function]}
         onBlur={[Function]}
-        onChange={[Function]}
         onClick={[Function]}
-        onContentSizeChange={[Function]}
-        onEnter={[Function]}
         onFocus={[Function]}
-        onHTMLContentWithCursor={[Function]}
-        onKeyDown={[Function]}
-        onPaste={[Function]}
         onResponderGrant={[Function]}
         onResponderMove={[Function]}
         onResponderRelease={[Function]}
         onResponderTerminate={[Function]}
         onResponderTerminationRequest={[Function]}
-        onSelectionChange={[Function]}
         onStartShouldSetResponder={[Function]}
-        placeholder="Add label…"
-        placeholderTextColor="gray"
-        selectionColor="black"
-        style={
-          {
-            "backgroundColor": undefined,
-            "maxWidth": undefined,
-            "minHeight": 0,
+      >
+        <RCTAztecView
+          activeFormats={[]}
+          blockType={
+            {
+              "tag": "p",
+            }
           }
-        }
-        text={
-          {
-            "eventCount": undefined,
-            "linkTextColor": undefined,
-            "selection": null,
-            "tag": "p",
-            "text": "<p>Search</p>",
+          disableEditingMenu={false}
+          fontFamily="serif"
+          fontSize={16}
+          isMultiline={false}
+          maxImagesWidth={200}
+          onBackspace={[Function]}
+          onBlur={[Function]}
+          onChange={[Function]}
+          onContentSizeChange={[Function]}
+          onEnter={[Function]}
+          onFocus={[Function]}
+          onHTMLContentWithCursor={[Function]}
+          onKeyDown={[Function]}
+          onPaste={[Function]}
+          onSelectionChange={[Function]}
+          placeholder="Add label…"
+          placeholderTextColor="gray"
+          selectionColor="black"
+          style={
+            {
+              "backgroundColor": undefined,
+              "maxWidth": undefined,
+              "minHeight": 0,
+            }
           }
-        }
-        triggerKeyCodes={[]}
-      />
+          text={
+            {
+              "eventCount": undefined,
+              "linkTextColor": undefined,
+              "selection": null,
+              "tag": "p",
+              "text": "<p>Search</p>",
+            }
+          }
+          triggerKeyCodes={[]}
+        />
+      </View>
     </View>
   </View>
   <View
@@ -144,7 +158,7 @@ exports[`Search Block renders block with button inside option 1`] = `
             ]
           }
         >
-          <RCTAztecView
+          <View
             accessibilityState={
               {
                 "busy": undefined,
@@ -154,59 +168,73 @@ exports[`Search Block renders block with button inside option 1`] = `
                 "selected": undefined,
               }
             }
-            accessible={true}
-            activeFormats={[]}
-            blockType={
+            accessibilityValue={
               {
-                "tag": "p",
+                "max": undefined,
+                "min": undefined,
+                "now": undefined,
+                "text": undefined,
               }
             }
-            disableEditingMenu={false}
+            accessible={true}
+            collapsable={false}
             focusable={true}
-            fontFamily="serif"
-            fontSize={16}
-            isMultiline={false}
-            maxImagesWidth={200}
-            minWidth={75}
-            onBackspace={[Function]}
             onBlur={[Function]}
-            onChange={[Function]}
             onClick={[Function]}
-            onContentSizeChange={[Function]}
-            onEnter={[Function]}
             onFocus={[Function]}
-            onHTMLContentWithCursor={[Function]}
-            onKeyDown={[Function]}
-            onPaste={[Function]}
             onResponderGrant={[Function]}
             onResponderMove={[Function]}
             onResponderRelease={[Function]}
             onResponderTerminate={[Function]}
             onResponderTerminationRequest={[Function]}
-            onSelectionChange={[Function]}
             onStartShouldSetResponder={[Function]}
-            placeholder=""
-            placeholderTextColor="gray"
-            selectionColor="black"
-            style={
-              {
-                "backgroundColor": undefined,
-                "maxWidth": NaN,
-                "minHeight": 0,
+          >
+            <RCTAztecView
+              activeFormats={[]}
+              blockType={
+                {
+                  "tag": "p",
+                }
               }
-            }
-            text={
-              {
-                "eventCount": undefined,
-                "linkTextColor": undefined,
-                "selection": null,
-                "tag": "p",
-                "text": "<p>Search Button</p>",
+              disableEditingMenu={false}
+              fontFamily="serif"
+              fontSize={16}
+              isMultiline={false}
+              maxImagesWidth={200}
+              minWidth={75}
+              onBackspace={[Function]}
+              onBlur={[Function]}
+              onChange={[Function]}
+              onContentSizeChange={[Function]}
+              onEnter={[Function]}
+              onFocus={[Function]}
+              onHTMLContentWithCursor={[Function]}
+              onKeyDown={[Function]}
+              onPaste={[Function]}
+              onSelectionChange={[Function]}
+              placeholder=""
+              placeholderTextColor="gray"
+              selectionColor="black"
+              style={
+                {
+                  "backgroundColor": undefined,
+                  "maxWidth": NaN,
+                  "minHeight": 0,
+                }
               }
-            }
-            textAlign="center"
-            triggerKeyCodes={[]}
-          />
+              text={
+                {
+                  "eventCount": undefined,
+                  "linkTextColor": undefined,
+                  "selection": null,
+                  "tag": "p",
+                  "text": "<p>Search Button</p>",
+                }
+              }
+              textAlign="center"
+              triggerKeyCodes={[]}
+            />
+          </View>
         </View>
       </View>
     </View>
@@ -233,7 +261,7 @@ exports[`Search Block renders block with icon button option matches snapshot 1`]
         ]
       }
     >
-      <RCTAztecView
+      <View
         accessibilityState={
           {
             "busy": undefined,
@@ -243,57 +271,71 @@ exports[`Search Block renders block with icon button option matches snapshot 1`]
             "selected": undefined,
           }
         }
-        accessible={true}
-        activeFormats={[]}
-        blockType={
+        accessibilityValue={
           {
-            "tag": "p",
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
           }
         }
-        disableEditingMenu={false}
+        accessible={true}
+        collapsable={false}
         focusable={true}
-        fontFamily="serif"
-        fontSize={16}
-        isMultiline={false}
-        maxImagesWidth={200}
-        onBackspace={[Function]}
         onBlur={[Function]}
-        onChange={[Function]}
         onClick={[Function]}
-        onContentSizeChange={[Function]}
-        onEnter={[Function]}
         onFocus={[Function]}
-        onHTMLContentWithCursor={[Function]}
-        onKeyDown={[Function]}
-        onPaste={[Function]}
         onResponderGrant={[Function]}
         onResponderMove={[Function]}
         onResponderRelease={[Function]}
         onResponderTerminate={[Function]}
         onResponderTerminationRequest={[Function]}
-        onSelectionChange={[Function]}
         onStartShouldSetResponder={[Function]}
-        placeholder="Add label…"
-        placeholderTextColor="gray"
-        selectionColor="black"
-        style={
-          {
-            "backgroundColor": undefined,
-            "maxWidth": undefined,
-            "minHeight": 0,
+      >
+        <RCTAztecView
+          activeFormats={[]}
+          blockType={
+            {
+              "tag": "p",
+            }
           }
-        }
-        text={
-          {
-            "eventCount": undefined,
-            "linkTextColor": undefined,
-            "selection": null,
-            "tag": "p",
-            "text": "<p>Search</p>",
+          disableEditingMenu={false}
+          fontFamily="serif"
+          fontSize={16}
+          isMultiline={false}
+          maxImagesWidth={200}
+          onBackspace={[Function]}
+          onBlur={[Function]}
+          onChange={[Function]}
+          onContentSizeChange={[Function]}
+          onEnter={[Function]}
+          onFocus={[Function]}
+          onHTMLContentWithCursor={[Function]}
+          onKeyDown={[Function]}
+          onPaste={[Function]}
+          onSelectionChange={[Function]}
+          placeholder="Add label…"
+          placeholderTextColor="gray"
+          selectionColor="black"
+          style={
+            {
+              "backgroundColor": undefined,
+              "maxWidth": undefined,
+              "minHeight": 0,
+            }
           }
-        }
-        triggerKeyCodes={[]}
-      />
+          text={
+            {
+              "eventCount": undefined,
+              "linkTextColor": undefined,
+              "selection": null,
+              "tag": "p",
+              "text": "<p>Search</p>",
+            }
+          }
+          triggerKeyCodes={[]}
+        />
+      </View>
     </View>
   </View>
   <View
@@ -428,7 +470,7 @@ exports[`Search Block renders block with label hidden matches snapshot 1`] = `
             ]
           }
         >
-          <RCTAztecView
+          <View
             accessibilityState={
               {
                 "busy": undefined,
@@ -438,59 +480,73 @@ exports[`Search Block renders block with label hidden matches snapshot 1`] = `
                 "selected": undefined,
               }
             }
-            accessible={true}
-            activeFormats={[]}
-            blockType={
+            accessibilityValue={
               {
-                "tag": "p",
+                "max": undefined,
+                "min": undefined,
+                "now": undefined,
+                "text": undefined,
               }
             }
-            disableEditingMenu={false}
+            accessible={true}
+            collapsable={false}
             focusable={true}
-            fontFamily="serif"
-            fontSize={16}
-            isMultiline={false}
-            maxImagesWidth={200}
-            minWidth={75}
-            onBackspace={[Function]}
             onBlur={[Function]}
-            onChange={[Function]}
             onClick={[Function]}
-            onContentSizeChange={[Function]}
-            onEnter={[Function]}
             onFocus={[Function]}
-            onHTMLContentWithCursor={[Function]}
-            onKeyDown={[Function]}
-            onPaste={[Function]}
             onResponderGrant={[Function]}
             onResponderMove={[Function]}
             onResponderRelease={[Function]}
             onResponderTerminate={[Function]}
             onResponderTerminationRequest={[Function]}
-            onSelectionChange={[Function]}
             onStartShouldSetResponder={[Function]}
-            placeholder=""
-            placeholderTextColor="gray"
-            selectionColor="black"
-            style={
-              {
-                "backgroundColor": undefined,
-                "maxWidth": NaN,
-                "minHeight": 0,
+          >
+            <RCTAztecView
+              activeFormats={[]}
+              blockType={
+                {
+                  "tag": "p",
+                }
               }
-            }
-            text={
-              {
-                "eventCount": undefined,
-                "linkTextColor": undefined,
-                "selection": null,
-                "tag": "p",
-                "text": "<p>Search Button</p>",
+              disableEditingMenu={false}
+              fontFamily="serif"
+              fontSize={16}
+              isMultiline={false}
+              maxImagesWidth={200}
+              minWidth={75}
+              onBackspace={[Function]}
+              onBlur={[Function]}
+              onChange={[Function]}
+              onContentSizeChange={[Function]}
+              onEnter={[Function]}
+              onFocus={[Function]}
+              onHTMLContentWithCursor={[Function]}
+              onKeyDown={[Function]}
+              onPaste={[Function]}
+              onSelectionChange={[Function]}
+              placeholder=""
+              placeholderTextColor="gray"
+              selectionColor="black"
+              style={
+                {
+                  "backgroundColor": undefined,
+                  "maxWidth": NaN,
+                  "minHeight": 0,
+                }
               }
-            }
-            textAlign="center"
-            triggerKeyCodes={[]}
-          />
+              text={
+                {
+                  "eventCount": undefined,
+                  "linkTextColor": undefined,
+                  "selection": null,
+                  "tag": "p",
+                  "text": "<p>Search Button</p>",
+                }
+              }
+              textAlign="center"
+              triggerKeyCodes={[]}
+            />
+          </View>
         </View>
       </View>
     </View>
@@ -517,7 +573,7 @@ exports[`Search Block renders with default configuration matches snapshot 1`] = 
         ]
       }
     >
-      <RCTAztecView
+      <View
         accessibilityState={
           {
             "busy": undefined,
@@ -527,57 +583,71 @@ exports[`Search Block renders with default configuration matches snapshot 1`] = 
             "selected": undefined,
           }
         }
-        accessible={true}
-        activeFormats={[]}
-        blockType={
+        accessibilityValue={
           {
-            "tag": "p",
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
           }
         }
-        disableEditingMenu={false}
+        accessible={true}
+        collapsable={false}
         focusable={true}
-        fontFamily="serif"
-        fontSize={16}
-        isMultiline={false}
-        maxImagesWidth={200}
-        onBackspace={[Function]}
         onBlur={[Function]}
-        onChange={[Function]}
         onClick={[Function]}
-        onContentSizeChange={[Function]}
-        onEnter={[Function]}
         onFocus={[Function]}
-        onHTMLContentWithCursor={[Function]}
-        onKeyDown={[Function]}
-        onPaste={[Function]}
         onResponderGrant={[Function]}
         onResponderMove={[Function]}
         onResponderRelease={[Function]}
         onResponderTerminate={[Function]}
         onResponderTerminationRequest={[Function]}
-        onSelectionChange={[Function]}
         onStartShouldSetResponder={[Function]}
-        placeholder="Add label…"
-        placeholderTextColor="gray"
-        selectionColor="black"
-        style={
-          {
-            "backgroundColor": undefined,
-            "maxWidth": undefined,
-            "minHeight": 0,
+      >
+        <RCTAztecView
+          activeFormats={[]}
+          blockType={
+            {
+              "tag": "p",
+            }
           }
-        }
-        text={
-          {
-            "eventCount": undefined,
-            "linkTextColor": undefined,
-            "selection": null,
-            "tag": "p",
-            "text": "<p>Search</p>",
+          disableEditingMenu={false}
+          fontFamily="serif"
+          fontSize={16}
+          isMultiline={false}
+          maxImagesWidth={200}
+          onBackspace={[Function]}
+          onBlur={[Function]}
+          onChange={[Function]}
+          onContentSizeChange={[Function]}
+          onEnter={[Function]}
+          onFocus={[Function]}
+          onHTMLContentWithCursor={[Function]}
+          onKeyDown={[Function]}
+          onPaste={[Function]}
+          onSelectionChange={[Function]}
+          placeholder="Add label…"
+          placeholderTextColor="gray"
+          selectionColor="black"
+          style={
+            {
+              "backgroundColor": undefined,
+              "maxWidth": undefined,
+              "minHeight": 0,
+            }
           }
-        }
-        triggerKeyCodes={[]}
-      />
+          text={
+            {
+              "eventCount": undefined,
+              "linkTextColor": undefined,
+              "selection": null,
+              "tag": "p",
+              "text": "<p>Search</p>",
+            }
+          }
+          triggerKeyCodes={[]}
+        />
+      </View>
     </View>
   </View>
   <View
@@ -642,7 +712,7 @@ exports[`Search Block renders with default configuration matches snapshot 1`] = 
             ]
           }
         >
-          <RCTAztecView
+          <View
             accessibilityState={
               {
                 "busy": undefined,
@@ -652,59 +722,73 @@ exports[`Search Block renders with default configuration matches snapshot 1`] = 
                 "selected": undefined,
               }
             }
-            accessible={true}
-            activeFormats={[]}
-            blockType={
+            accessibilityValue={
               {
-                "tag": "p",
+                "max": undefined,
+                "min": undefined,
+                "now": undefined,
+                "text": undefined,
               }
             }
-            disableEditingMenu={false}
+            accessible={true}
+            collapsable={false}
             focusable={true}
-            fontFamily="serif"
-            fontSize={16}
-            isMultiline={false}
-            maxImagesWidth={200}
-            minWidth={75}
-            onBackspace={[Function]}
             onBlur={[Function]}
-            onChange={[Function]}
             onClick={[Function]}
-            onContentSizeChange={[Function]}
-            onEnter={[Function]}
             onFocus={[Function]}
-            onHTMLContentWithCursor={[Function]}
-            onKeyDown={[Function]}
-            onPaste={[Function]}
             onResponderGrant={[Function]}
             onResponderMove={[Function]}
             onResponderRelease={[Function]}
             onResponderTerminate={[Function]}
             onResponderTerminationRequest={[Function]}
-            onSelectionChange={[Function]}
             onStartShouldSetResponder={[Function]}
-            placeholder=""
-            placeholderTextColor="gray"
-            selectionColor="black"
-            style={
-              {
-                "backgroundColor": undefined,
-                "maxWidth": NaN,
-                "minHeight": 0,
+          >
+            <RCTAztecView
+              activeFormats={[]}
+              blockType={
+                {
+                  "tag": "p",
+                }
               }
-            }
-            text={
-              {
-                "eventCount": undefined,
-                "linkTextColor": undefined,
-                "selection": null,
-                "tag": "p",
-                "text": "<p>Search Button</p>",
+              disableEditingMenu={false}
+              fontFamily="serif"
+              fontSize={16}
+              isMultiline={false}
+              maxImagesWidth={200}
+              minWidth={75}
+              onBackspace={[Function]}
+              onBlur={[Function]}
+              onChange={[Function]}
+              onContentSizeChange={[Function]}
+              onEnter={[Function]}
+              onFocus={[Function]}
+              onHTMLContentWithCursor={[Function]}
+              onKeyDown={[Function]}
+              onPaste={[Function]}
+              onSelectionChange={[Function]}
+              placeholder=""
+              placeholderTextColor="gray"
+              selectionColor="black"
+              style={
+                {
+                  "backgroundColor": undefined,
+                  "maxWidth": NaN,
+                  "minHeight": 0,
+                }
               }
-            }
-            textAlign="center"
-            triggerKeyCodes={[]}
-          />
+              text={
+                {
+                  "eventCount": undefined,
+                  "linkTextColor": undefined,
+                  "selection": null,
+                  "tag": "p",
+                  "text": "<p>Search Button</p>",
+                }
+              }
+              textAlign="center"
+              triggerKeyCodes={[]}
+            />
+          </View>
         </View>
       </View>
     </View>
@@ -731,7 +815,7 @@ exports[`Search Block renders with no-button option matches snapshot 1`] = `
         ]
       }
     >
-      <RCTAztecView
+      <View
         accessibilityState={
           {
             "busy": undefined,
@@ -741,57 +825,71 @@ exports[`Search Block renders with no-button option matches snapshot 1`] = `
             "selected": undefined,
           }
         }
-        accessible={true}
-        activeFormats={[]}
-        blockType={
+        accessibilityValue={
           {
-            "tag": "p",
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
           }
         }
-        disableEditingMenu={false}
+        accessible={true}
+        collapsable={false}
         focusable={true}
-        fontFamily="serif"
-        fontSize={16}
-        isMultiline={false}
-        maxImagesWidth={200}
-        onBackspace={[Function]}
         onBlur={[Function]}
-        onChange={[Function]}
         onClick={[Function]}
-        onContentSizeChange={[Function]}
-        onEnter={[Function]}
         onFocus={[Function]}
-        onHTMLContentWithCursor={[Function]}
-        onKeyDown={[Function]}
-        onPaste={[Function]}
         onResponderGrant={[Function]}
         onResponderMove={[Function]}
         onResponderRelease={[Function]}
         onResponderTerminate={[Function]}
         onResponderTerminationRequest={[Function]}
-        onSelectionChange={[Function]}
         onStartShouldSetResponder={[Function]}
-        placeholder="Add label…"
-        placeholderTextColor="gray"
-        selectionColor="black"
-        style={
-          {
-            "backgroundColor": undefined,
-            "maxWidth": undefined,
-            "minHeight": 0,
+      >
+        <RCTAztecView
+          activeFormats={[]}
+          blockType={
+            {
+              "tag": "p",
+            }
           }
-        }
-        text={
-          {
-            "eventCount": undefined,
-            "linkTextColor": undefined,
-            "selection": null,
-            "tag": "p",
-            "text": "<p>Search</p>",
+          disableEditingMenu={false}
+          fontFamily="serif"
+          fontSize={16}
+          isMultiline={false}
+          maxImagesWidth={200}
+          onBackspace={[Function]}
+          onBlur={[Function]}
+          onChange={[Function]}
+          onContentSizeChange={[Function]}
+          onEnter={[Function]}
+          onFocus={[Function]}
+          onHTMLContentWithCursor={[Function]}
+          onKeyDown={[Function]}
+          onPaste={[Function]}
+          onSelectionChange={[Function]}
+          placeholder="Add label…"
+          placeholderTextColor="gray"
+          selectionColor="black"
+          style={
+            {
+              "backgroundColor": undefined,
+              "maxWidth": undefined,
+              "minHeight": 0,
+            }
           }
-        }
-        triggerKeyCodes={[]}
-      />
+          text={
+            {
+              "eventCount": undefined,
+              "linkTextColor": undefined,
+              "selection": null,
+              "tag": "p",
+              "text": "<p>Search</p>",
+            }
+          }
+          triggerKeyCodes={[]}
+        />
+      </View>
     </View>
   </View>
   <View

--- a/packages/react-native-aztec/src/AztecView.js
+++ b/packages/react-native-aztec/src/AztecView.js
@@ -4,7 +4,7 @@
 import {
 	requireNativeComponent,
 	UIManager,
-	TouchableWithoutFeedback,
+	Pressable,
 	Platform,
 } from 'react-native';
 
@@ -305,7 +305,7 @@ class AztecView extends Component {
 		}
 
 		return (
-			<TouchableWithoutFeedback onPress={ this._onPress }>
+			<Pressable onPress={ this._onPress }>
 				<RCTAztecView
 					{ ...otherProps }
 					style={ style }
@@ -322,7 +322,7 @@ class AztecView extends Component {
 					onBlur={ this._onBlur }
 					ref={ this.aztecViewRef }
 				/>
-			</TouchableWithoutFeedback>
+			</Pressable>
 		);
 	}
 }

--- a/packages/react-native-aztec/src/AztecView.js
+++ b/packages/react-native-aztec/src/AztecView.js
@@ -305,7 +305,7 @@ class AztecView extends Component {
 		}
 
 		return (
-			<Pressable onPress={ this._onPress }>
+			<Pressable accessible={ false } onPress={ this._onPress }>
 				<RCTAztecView
 					{ ...otherProps }
 					style={ style }

--- a/patches/react-native+0.71.11.patch
+++ b/patches/react-native+0.71.11.patch
@@ -1,0 +1,12 @@
+diff --git a/node_modules/react-native/Libraries/Components/TextInput/TextInput.js b/node_modules/react-native/Libraries/Components/TextInput/TextInput.js
+index 0758df6..18c5687 100644
+--- a/node_modules/react-native/Libraries/Components/TextInput/TextInput.js
++++ b/node_modules/react-native/Libraries/Components/TextInput/TextInput.js
+@@ -1410,7 +1410,6 @@ function InternalTextInput(props: Props): React.Node {
+         {...props}
+         {...eventHandlers}
+         accessible={accessible}
+-        accessibilityState={_accessibilityState}
+         submitBehavior={submitBehavior}
+         caretHidden={caretHidden}
+         dataDetectorTypes={props.dataDetectorTypes}


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-iOS/issues/21399

**Related PRs:**
- https://github.com/wordpress-mobile/gutenberg-mobile/pull/6102
- https://github.com/wordpress-mobile/WordPress-iOS/pull/21401

## What?
This PR addresses a regression after the React Native `0.71` upgrade, affecting how VoiceOver works with assistive input like Braille Screen Input, as well as using a Bluetooth keyboard and VoiceOver enabled.

There's an existing [GitHub ticket](https://github.com/facebook/react-native/issues/36465) in the React Native repo about this problem, it seems it only affects the legacy renderer.

## Why?
React Native `0.71` includes [several accessibility changes](https://github.com/facebook/react-native/commit/98d84e571df64b00e1ed3484923a1d8169dcfda1#diff-712da1fe12a3b8c4a5e7ff3d72135cc81c382e9cec7175d4eb34d5edbd040ff6) and these introduced this regression of the mobile editor.

## How?
First, it replaces the `TouchableWithoutFeedback` component in `AztecView` with `Pressable` as it restores the expected behavior when using VoiceOver and an assistive keyboard. It adds the `accessible` prop to `false` so the children components get accessed directly.

Due to updating the component that wraps `RCTAztecView` some snapshots needed to be updated.

Another important change is the new `patches/react-native+0.71.11.patch` patch, This was needed due to standard TextInputs being broken as well, so it applies a change that reverts the changes introduced in [React Native](https://github.com/facebook/react-native/commit/98d84e571df64b00e1ed3484923a1d8169dcfda1#diff-846840f37831efe100d9ef18d888a2ef838ad986a8c0e3107bf8029b1401d0bf).

## Testing Instructions

**Note:** This only affects the iOS platform and the VoiceOver functionality.

**Preconditions**: 
- Use the build [from this PR](https://github.com/wordpress-mobile/WordPress-iOS/pull/21401#issuecomment-1690382674).
- Make sure you have `Braille Screen Input` [enabled in the VoiceOver Rotor](https://support.apple.com/en-us/101637).
- All tests need VoiceOver to be enabled.

**Tip**: You can enable/disable VoiceOver with Siri.

## VoiceOver with an assistive input (Braille Screen Input)

### Adding content to the title and a Paragraph block

- Open the app
- Open the editor
- Focus on the title
- Type in some text with the Braille screen input
- **Expect** to see the text in the title field
- Add a Paragraph block
- Focus on the Paragraph block
- Type in some text with the Braille screen input
- **Expect** to see the text added in the Paragraph block

### Adding content to the HTML editor

- Open the app
- Open the editor
- Toggle to the HTML mode
- Type in some text with the Braille screen input
- **Expect** to see the text added in the HTML editor TextInput

### Using the Search block in the inserter

- Open the app
- Open the editor
- Open the Inserter
- Using the Search input, type in some content with the Braille screen input
- **Expect** to see the search text added

### Updating an Image caption
- Open the app
- Open the editor
- Add an Image block
- Add an image
- Focus on the caption field
- Type in a caption with the Braille screen input
- **Expect** to see the caption added to the Image block

## Bluetooth keyboard input with **VoiceOver enabled**

- Open the app
- Open the editor
- Connect a Bluetooth keyboard to your device
- Add a Paragraph block
- Type in some content
- On your keyboard hit the return key
- Type in new text in the new Paragraph block
- Make sure that the VoiceOver focus is on the newly added block
- Repeat these steps a few times
- **Expect** to see the VoiceOver focus to be in the block you last added and that is currently focused.

## Screenshots or screencast <!-- if applicable -->

## VoiceOver with an assistive input (Braille Screen Input)

Before|After
-|-
<video src="https://github.com/WordPress/gutenberg/assets/4885740/e0adb925-af61-46e8-bdae-732447351000" />|<video src="https://github.com/WordPress/gutenberg/assets/4885740/dabef83c-a9d6-4b3c-9cfd-035a34a69893" />

## Bluetooth keyboard input with **VoiceOver enabled**

Before|After
-|-
<video src="https://github.com/WordPress/gutenberg/assets/4885740/dbbe870c-db79-4a03-9602-6682b4f11d7d" />|<video src="https://github.com/WordPress/gutenberg/assets/4885740/ef5fb19e-e1c0-4806-bdb6-b271054d3c4b" />