### PR TITLE
Gallery: re-enable block spacing at block level while still hiding in global styles

### DIFF
--- a/packages/blocks/src/store/private-selectors.js
+++ b/packages/blocks/src/store/private-selectors.js
@@ -106,15 +106,7 @@ export const getSupportedStyles = createSelector(
 
 		// Check for blockGap support.
 		// Block spacing support doesn't map directly to a single style property, so needs to be handled separately.
-		// Also, only allow `blockGap` support if serialization has not been skipped, to be sure global spacing can be applied.
-		if (
-			blockType?.supports?.spacing?.blockGap &&
-			blockType?.supports?.spacing?.__experimentalSkipSerialization !==
-				true &&
-			! blockType?.supports?.spacing?.__experimentalSkipSerialization?.some?.(
-				( spacingType ) => spacingType === 'blockGap'
-			)
-		) {
+		if ( blockType?.supports?.spacing?.blockGap ) {
 			supportKeys.push( 'blockGap' );
 		}
 

--- a/packages/edit-site/src/components/global-styles/screen-block.js
+++ b/packages/edit-site/src/components/global-styles/screen-block.js
@@ -98,6 +98,20 @@ function ScreenBlock( { name, variation } ) {
 	const { behavior } = useGlobalBehaviors( name, 'user' );
 
 	const blockType = getBlockType( name );
+
+	// Only allow `blockGap` support if serialization has not been skipped, to be sure global spacing can be applied.
+	if (
+		settings?.spacing?.blockGap &&
+		blockType?.supports?.spacing?.blockGap &&
+		( blockType?.supports?.spacing?.__experimentalSkipSerialization ===
+			true ||
+			blockType?.supports?.spacing?.__experimentalSkipSerialization?.some?.(
+				( spacingType ) => spacingType === 'blockGap'
+			) )
+	) {
+		settings.spacing.blockGap = false;
+	}
+
 	const blockVariations = useBlockVariations( name );
 	const hasTypographyPanel = useHasTypographyPanel( settings );
 	const hasColorPanel = useHasColorPanel( settings );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Follow-up to https://github.com/WordPress/gutenberg/pull/53008

Move logic to hide block spacing controls when `__experimentalSkipSerialization` is in use to the block screen in global styles.

This PR resolves an issue that possibly dates back to #48070, but was exposed in #53008.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The logic to hide the block spacing controls when `__experimentalSkipSerialization` is in use was only intended to be applied to global styles screens. Prior to this PR, the check runs in all cases, and with #53008, it meant that at the block level, `spacing.blockGap` was set to `false` for the Gallery block, when it should have been enabled.

An alternative to this PR would be to enable block spacing in global styles for the Gallery block. Unfortunately, I don't think we can _quite_ do that yet. I hacked around a little and found that do that, we'd need to:

* In the Gallery block's PHP, check that a global style value for the Gallery block isn't set before outputting gallery styles at render time (this is possible via a call to `wp_get_global_style`, and checking to see if a blockGap value is set for the gallery block)
* In the Gallery block's JS, check that a global style value for the Gallery block isn't set before outputting gallery styles at render time (this is not possible yet — while we can call `useGlobalStyle`, because the post editor does not yet have a global styles provider, we don't have access to the styles values)

So, in the shorter-term, I think the fix in this PR is likely the pragmatic way to go as it preserves the existing expected logic, but moves it to where it should be applied (by mutating `settings` to pass to the `DimensionsPanel` in the block screen in global styles). Once we have access to global styles values within the post editor, then in a follow-up, we could switch off the logic in this PR and enable Gallery block global styles.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Move logic to hide the block spacing controls if a block has `__experimentalSkipSerialization` set to the block screen in global styles.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Activate a blocks theme
2. With this PR applied, you should see the block spacing controls available at the block level in the post editor
3. Open the site editor, you should still see block spacing controls at the individual block level (when editing a block)
4. With global styles in the site editor, go to the screen for block-level global styles for the gallery block — no block spacing controls should be available
5. Go to the Buttons block in global styles — block spacing controls should still be available
6. Activate a Classic theme — block-level block spacing controls should not be available for the Gallery block

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

| Block level in post editor | Block level in global styles |
| --- | --- |
| <img width="1275" alt="image" src="https://github.com/WordPress/gutenberg/assets/14988353/5ead25d0-635c-4610-b02e-5d7fe1451b22"> | <img width="1274" alt="image" src="https://github.com/WordPress/gutenberg/assets/14988353/884e31eb-9ee1-47f9-9120-cbae68c84e39"> |