### PR TITLE
Navigation: Update the default query for the navigation suggestions

### DIFF
--- a/packages/block-library/src/navigation-link/link-ui.js
+++ b/packages/block-library/src/navigation-link/link-ui.js
@@ -44,7 +44,7 @@ export function getSuggestionsQuery( type, kind ) {
 			if ( kind === 'post-type' ) {
 				return { type: 'post', subtype: type };
 			}
-			return {};
+			return { type: 'post', subtype: 'page' };
 	}
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Update the query that suggests what to link to from the Navigation Link block.

## Why?
When creating a new link it's most likely people will want to link to a page, so we should default to that as a suggestion. Closes https://github.com/WordPress/gutenberg/issues/50432.

## How?
Updates the default suggestion query when you're using standard navigation link block.

## Testing Instructions
1. From a navigation block, add a new link.
2. Confirm that the suggestions are now pages.

## Notes
Although this solves one aspect of the issue, but problem is that now suggestions are always restricted to pages. We need a way to modify the suggestions query based on what you input. Alternatively we could find a way to sort the suggestions so that pages are first.