### PR TITLE
Attempt to fix intermittent e2e test failure

### DIFF
--- a/test/e2e/playwright.config.ts
+++ b/test/e2e/playwright.config.ts
@@ -17,7 +17,7 @@ const config = defineConfig( {
 	forbidOnly: !! process.env.CI,
 	workers: 1,
 	retries: process.env.CI ? 2 : 0,
-	timeout: parseInt( process.env.TIMEOUT || '', 10 ) || 100_000, // Defaults to 100 seconds.
+	timeout: parseInt( process.env.TIMEOUT || '', 10 ) || 200_000, // Defaults to 200 seconds.
 	// Don't report slow test "files", as we will be running our tests in serial.
 	reportSlowTests: null,
 	testDir: fileURLToPath( new URL( './specs', 'file:' + __filename ).href ),


### PR DESCRIPTION
From https://github.com/WordPress/gutenberg/pull/53905#issuecomment-1696621351:

> Just to help with context this PR was in response to this test failing way too often: `[firefox] › editor/various/inserting-blocks.spec.js:34:2 › Inserting blocks (@firefox, @webkit) › inserts blocks by dragging and dropping from the global inserter `
> 
> There was some speculation on why this started happening in [#53768 (comment)](https://github.com/WordPress/gutenberg/pull/53768#issuecomment-1683713660).
> 
> It looks like the change here helped but it'd be nice to actually fix that test.
