### PR TITLE
Site Logo: Remove line-height for the anchor element

### DIFF
--- a/packages/block-library/src/site-logo/style.scss
+++ b/packages/block-library/src/site-logo/style.scss
@@ -5,6 +5,7 @@
 
 	a {
 		display: inline-block;
+		line-height: 0;
 	}
 
 	// Provide a sane starting point for the size.


### PR DESCRIPTION
Originally reported by @Ren2049 in the create-block-theme project: https://github.com/WordPress/create-block-theme/issues/432

Follow-up on #27623

## What?
This PR fixes a problem where the line-height of the link text affects the height of the Site Logo block.

| Before | After |
|--------|--------|
| ![before](https://github.com/WordPress/gutenberg/assets/54422211/749a1d3c-6604-4ba2-8f86-dcd1fd3bf45e) | ![after](https://github.com/WordPress/gutenberg/assets/54422211/2bec0c15-a48e-46e3-8646-f6f86b8ffe0c) | 

## Why?

By #27623, `line-height:0` has been added to the root block element to avoid the influence of the global line-height. However, the current global style allows the line-height to be set on the link element as well, so the anchor element inside is affected.

## How?

Added line-height: 0 to anchor elements as well. This should not be a problem since this block has no text.

## Testing Instructions

- Add a Site Logo block.
- Access to Site Editor > Styles > Typography.
- Change the Line Height of "Text" or "Links".
- Ensure that there is no extra space in the Site Logo block in both the editor and the front end.