### PR TITLE
Register the block editor keyboard shortcuts automatically when using BlockEditorProvider

### DIFF
--- a/packages/block-editor/src/components/provider/index.js
+++ b/packages/block-editor/src/components/provider/index.js
@@ -12,6 +12,7 @@ import useBlockSync from './use-block-sync';
 import { store as blockEditorStore } from '../../store';
 import { BlockRefsProvider } from './block-refs-provider';
 import { unlock } from '../../lock-unlock';
+import KeyboardShortcuts from '../keyboard-shortcuts';
 
 /** @typedef {import('@wordpress/data').WPDataRegistry} WPDataRegistry */
 
@@ -42,7 +43,12 @@ export const ExperimentalBlockEditorProvider = withRegistryProvider(
 		// Syncs the entity provider with changes in the block-editor store.
 		useBlockSync( props );
 
-		return <BlockRefsProvider>{ children }</BlockRefsProvider>;
+		return (
+			<>
+				<KeyboardShortcuts.Register />
+				<BlockRefsProvider>{ children }</BlockRefsProvider>
+			</>
+		);
 	}
 );
 

--- a/packages/customize-widgets/src/components/sidebar-block-editor/index.js
+++ b/packages/customize-widgets/src/components/sidebar-block-editor/index.js
@@ -11,7 +11,6 @@ import {
 	BlockInspector,
 	CopyHandler,
 	WritingFlow,
-	BlockEditorKeyboardShortcuts,
 	__unstableBlockSettingsMenuFirstItem,
 	__unstableEditorStyles as EditorStyles,
 } from '@wordpress/block-editor';
@@ -94,7 +93,6 @@ export default function SidebarBlockEditor( {
 
 	return (
 		<>
-			<BlockEditorKeyboardShortcuts.Register />
 			<KeyboardShortcuts.Register />
 
 			<SidebarEditorProvider sidebar={ sidebar } settings={ settings }>

--- a/packages/edit-site/src/components/block-editor/site-editor-canvas.js
+++ b/packages/edit-site/src/components/block-editor/site-editor-canvas.js
@@ -11,7 +11,6 @@ import {
 	BlockList,
 	BlockTools,
 	__unstableUseClipboardHandler as useClipboardHandler,
-	BlockEditorKeyboardShortcuts,
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import {
@@ -116,7 +115,6 @@ export default function SiteEditorCanvas() {
 								}
 							} }
 						>
-							<BlockEditorKeyboardShortcuts.Register />
 							<BackButton />
 							<ResizableEditor
 								enableResizing={ enableResizing }

--- a/packages/edit-widgets/src/components/widget-areas-block-editor-provider/index.js
+++ b/packages/edit-widgets/src/components/widget-areas-block-editor-provider/index.js
@@ -11,7 +11,6 @@ import {
 } from '@wordpress/core-data';
 import { useMemo } from '@wordpress/element';
 import {
-	BlockEditorKeyboardShortcuts,
 	CopyHandler,
 	privateApis as blockEditorPrivateApis,
 } from '@wordpress/block-editor';
@@ -100,7 +99,6 @@ export default function WidgetAreasBlockEditorProvider( {
 
 	return (
 		<ShortcutProvider>
-			<BlockEditorKeyboardShortcuts.Register />
 			<KeyboardShortcuts.Register />
 			<SlotFillProvider>
 				<ExperimentalBlockEditorProvider

--- a/storybook/stories/playground/index.story.js
+++ b/storybook/stories/playground/index.story.js
@@ -3,7 +3,6 @@
  */
 import { useEffect, useState } from '@wordpress/element';
 import {
-	BlockEditorKeyboardShortcuts,
 	BlockEditorProvider,
 	BlockList,
 	BlockTools,
@@ -50,7 +49,6 @@ function App() {
 						<div className="playground__content">
 							<BlockTools>
 								<div className="editor-styles-wrapper">
-									<BlockEditorKeyboardShortcuts.Register />
 									<WritingFlow>
 										<BlockList />
 									</WritingFlow>

--- a/test/integration/helpers/integration-test-editor.js
+++ b/test/integration/helpers/integration-test-editor.js
@@ -9,7 +9,6 @@ import userEvent from '@testing-library/user-event';
  */
 import { useState, useEffect } from '@wordpress/element';
 import {
-	BlockEditorKeyboardShortcuts,
 	BlockEditorProvider,
 	BlockList,
 	BlockTools,
@@ -78,7 +77,6 @@ export function Editor( { testBlocks, settings = {} } ) {
 				>
 					<BlockInspector />
 					<BlockTools>
-						<BlockEditorKeyboardShortcuts.Register />
 						<WritingFlow>
 							<BlockList />
 						</WritingFlow>


### PR DESCRIPTION
Related #53874

## What and why?

Gutenberg can be used as a platform/framework to build block editors. Mainly thanks to the @wordpress/block-editor package. That said, the experience today is not as straightforward as it can be. There can be a lot of small gotchas and hacks you need to do in order to achieve the desired result. One of these small things is the need to manually render `BlockEditorKeyboardShortcuts.Register` component, this PR bundles this behavior within the BlockEditorProvider component, that way custom block editors don't have to render this extra component.

There's potentially a small impact here, if the "BlockEditorProvider" is not rendered, the keyboard shortcuts are not registered, so they're not visible in the "keyboard shortcuts" modal. This is why I kept rendering that component within edit-post for the moment. That decision is arguable though, should we show these shortcuts if the user is in the code editor for instance). At least though, third-party block editors don't have to render these manually.

## Testing Instructions

1- Nothing really, there shouldn't be any impact.
