### PR TITLE
Enhance config discovery with cosmiconfig

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -56112,6 +56112,7 @@
 				"check-node-version": "^4.1.0",
 				"clean-webpack-plugin": "^3.0.0",
 				"copy-webpack-plugin": "^10.2.0",
+				"cosmiconfig": "^8.2.0",
 				"cross-spawn": "^5.1.0",
 				"css-loader": "^6.2.0",
 				"cssnano": "^6.0.1",
@@ -56159,6 +56160,51 @@
 			"peerDependencies": {
 				"react": "^18.0.0",
 				"react-dom": "^18.0.0"
+			}
+		},
+		"packages/scripts/node_modules/argparse": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+			"dev": true
+		},
+		"packages/scripts/node_modules/cosmiconfig": {
+			"version": "8.2.0",
+			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.2.0.tgz",
+			"integrity": "sha512-3rTMnFJA1tCOPwRxtgF4wd7Ab2qvDbL8jX+3smjIbS4HlZBagTlpERbdN7iAbWlrfxE3M8c27kTwTawQ7st+OQ==",
+			"dev": true,
+			"dependencies": {
+				"import-fresh": "^3.2.1",
+				"js-yaml": "^4.1.0",
+				"parse-json": "^5.0.0",
+				"path-type": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/d-fischer"
+			}
+		},
+		"packages/scripts/node_modules/js-yaml": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+			"integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+			"dev": true,
+			"dependencies": {
+				"argparse": "^2.0.1"
+			},
+			"bin": {
+				"js-yaml": "bin/js-yaml.js"
+			}
+		},
+		"packages/scripts/node_modules/path-type": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+			"integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"packages/server-side-render": {
@@ -68314,6 +68360,7 @@
 				"check-node-version": "^4.1.0",
 				"clean-webpack-plugin": "^3.0.0",
 				"copy-webpack-plugin": "^10.2.0",
+				"cosmiconfig": "^8.2.0",
 				"cross-spawn": "^5.1.0",
 				"css-loader": "^6.2.0",
 				"cssnano": "^6.0.1",
@@ -68350,6 +68397,41 @@
 				"webpack-bundle-analyzer": "^4.4.2",
 				"webpack-cli": "^4.9.1",
 				"webpack-dev-server": "^4.4.0"
+			},
+			"dependencies": {
+				"argparse": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+					"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+					"dev": true
+				},
+				"cosmiconfig": {
+					"version": "8.2.0",
+					"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.2.0.tgz",
+					"integrity": "sha512-3rTMnFJA1tCOPwRxtgF4wd7Ab2qvDbL8jX+3smjIbS4HlZBagTlpERbdN7iAbWlrfxE3M8c27kTwTawQ7st+OQ==",
+					"dev": true,
+					"requires": {
+						"import-fresh": "^3.2.1",
+						"js-yaml": "^4.1.0",
+						"parse-json": "^5.0.0",
+						"path-type": "^4.0.0"
+					}
+				},
+				"js-yaml": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+					"integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+					"dev": true,
+					"requires": {
+						"argparse": "^2.0.1"
+					}
+				},
+				"path-type": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+					"integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+					"dev": true
+				}
 			}
 		},
 		"@wordpress/server-side-render": {

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -52,6 +52,7 @@
 		"check-node-version": "^4.1.0",
 		"clean-webpack-plugin": "^3.0.0",
 		"copy-webpack-plugin": "^10.2.0",
+		"cosmiconfig": "^8.2.0",
 		"cross-spawn": "^5.1.0",
 		"css-loader": "^6.2.0",
 		"cssnano": "^6.0.1",

--- a/packages/scripts/scripts/lint-js.js
+++ b/packages/scripts/scripts/lint-js.js
@@ -14,6 +14,7 @@ const {
 	hasFileArgInCLI,
 	hasPackageProp,
 	hasProjectFile,
+	searchConfig,
 } = require( '../utils' );
 
 const args = getArgsFromCLI();
@@ -24,12 +25,7 @@ const defaultFilesArgs = hasFileArgInCLI() ? [] : [ '.' ];
 const hasLintConfig =
 	hasArgInCLI( '-c' ) ||
 	hasArgInCLI( '--config' ) ||
-	hasProjectFile( '.eslintrc.js' ) ||
-	hasProjectFile( '.eslintrc.json' ) ||
-	hasProjectFile( '.eslintrc.yaml' ) ||
-	hasProjectFile( '.eslintrc.yml' ) ||
-	hasProjectFile( 'eslintrc.config.js' ) ||
-	hasProjectFile( '.eslintrc' ) ||
+	searchConfig( 'eslint' ) ||
 	hasPackageProp( 'eslintConfig' );
 
 // When a configuration is not provided by the project, use from the default

--- a/packages/scripts/scripts/lint-pkg-json.js
+++ b/packages/scripts/scripts/lint-pkg-json.js
@@ -14,6 +14,7 @@ const {
 	hasFileArgInCLI,
 	hasProjectFile,
 	hasPackageProp,
+	searchConfig,
 } = require( '../utils' );
 
 const args = getArgsFromCLI();
@@ -24,12 +25,7 @@ const defaultFilesArgs = hasFileArgInCLI() ? [] : [ '.' ];
 const hasLintConfig =
 	hasArgInCLI( '-c' ) ||
 	hasArgInCLI( '--configFile' ) ||
-	hasProjectFile( '.npmpackagejsonlintrc.js' ) ||
-	hasProjectFile( '.npmpackagejsonlintrc.json' ) ||
-	hasProjectFile( '.npmpackagejsonlintrc.yaml' ) ||
-	hasProjectFile( '.npmpackagejsonlintrc.yml' ) ||
-	hasProjectFile( 'npmpackagejsonlint.config.js' ) ||
-	hasProjectFile( '.npmpackagejsonlintrc' ) ||
+	searchConfig( 'npmpackagejsonlint' ) ||
 	hasPackageProp( 'npmpackagejsonlint' ) ||
 	// npm-package-json-lint v3.x used a different prop name.
 	hasPackageProp( 'npmPackageJsonLintConfig' );

--- a/packages/scripts/scripts/lint-style.js
+++ b/packages/scripts/scripts/lint-style.js
@@ -14,6 +14,7 @@ const {
 	hasFileArgInCLI,
 	hasProjectFile,
 	hasPackageProp,
+	searchConfig,
 } = require( '../utils' );
 
 const args = getArgsFromCLI();
@@ -23,12 +24,7 @@ const defaultFilesArgs = hasFileArgInCLI() ? [] : [ '**/*.{css,pcss,scss}' ];
 // See: https://stylelint.io/user-guide/configuration
 const hasLintConfig =
 	hasArgInCLI( '--config' ) ||
-	hasProjectFile( '.stylelintrc.js' ) ||
-	hasProjectFile( '.stylelintrc.json' ) ||
-	hasProjectFile( '.stylelintrc.yaml' ) ||
-	hasProjectFile( '.stylelintrc.yml' ) ||
-	hasProjectFile( 'stylelint.config.js' ) ||
-	hasProjectFile( '.stylelintrc' ) ||
+	searchConfig( 'stylelint' ) ||
 	hasPackageProp( 'stylelint' );
 
 const defaultConfigArgs = ! hasLintConfig

--- a/packages/scripts/utils/cosmiconf.js
+++ b/packages/scripts/utils/cosmiconf.js
@@ -1,0 +1,12 @@
+/**
+ * External dependencies
+ */
+// eslint-disable-next-line import/no-extraneous-dependencies
+const { cosmiconfigSync } = require( 'cosmiconfig' );
+
+const searchConfig = ( confName ) => {
+	const explorer = cosmiconfigSync( confName );
+	return explorer.search() !== null;
+};
+
+module.exports = { searchConfig };

--- a/packages/scripts/utils/index.js
+++ b/packages/scripts/utils/index.js
@@ -24,6 +24,7 @@ const {
 } = require( './config' );
 const { fromProjectRoot, fromConfigRoot, hasProjectFile } = require( './file' );
 const { getPackageProp, hasPackageProp } = require( './package' );
+const { searchConfig } = require( './cosmiconf' );
 
 module.exports = {
 	fromProjectRoot,
@@ -48,4 +49,5 @@ module.exports = {
 	hasPrettierConfig,
 	hasProjectFile,
 	spawnScript,
+	searchConfig,
 };


### PR DESCRIPTION
## What?
The modifications made here align with the objectives set out in issue  #30842. 
## Why?
in `@wordpress/scripts` package  lint-js, lint-pkg-json and lint-style scripts try's to locate relevant configs using `hasProjectFile` repeatedly.
## How?
By utilizing [cosmiconfig](https://www.npmjs.com/package/cosmiconfig), a tool crafted to establish a standardized approach for identifying configuration files across different tools, we can simplify the logic of configuration file discovery. Moreover, this approach allows us to enhance performance by minimizing the redundant invocation of helper functions.

## Testing Instructions

1. install the necessary dependencies.
2. Set up a test configuration file for any of the affected scripts (e.g., lint-js, lint-pkg-json, or lint-style).
3. Run the respective script and verify that the configuration is correctly detected and utilized.
4. Ensure that existing functionality remains unaffected.

### Testing Instructions for Keyboard
none

## Screenshots or screencast <!-- if applicable -->
none