### PR TITLE
Update to node 16 and npm 8 in the getting started with code contribution doc

### DIFF
--- a/docs/contributors/code/getting-started-with-code-contribution.md
+++ b/docs/contributors/code/getting-started-with-code-contribution.md
@@ -5,7 +5,7 @@ The following guide is for setting up your local environment to contribute to th
 ## Prerequisites
 
 -   Node.js
-    Gutenberg is a JavaScript project and requires [Node.js](https://nodejs.org/). The project is built using Node.js v14, and npm v6. See the [LTS release schedule](https://github.com/nodejs/Release#release-schedule) for details.
+    Gutenberg is a JavaScript project and requires [Node.js](https://nodejs.org/). The project is built using Node.js v16, and npm v8. See the [LTS release schedule](https://github.com/nodejs/Release#release-schedule) for details.
 
 We recommend using the [Node Version Manager](https://github.com/nvm-sh/nvm) (nvm) since it is the easiest way to install and manage node for macOS, Linux, and Windows 10 using WSL2. See [our Development Tools guide](/docs/getting-started/devenv/README.md#development-tools) or the Nodejs site for additional installation instructions.
 


### PR DESCRIPTION
## What?

Correct an outdated reference to node and npm versions in the "Getting Started with Code Contribution" doc

## Why?

Bring docs in line with the versions we're using:

https://github.com/WordPress/gutenberg/blob/bc94b203029bd2a2aea191a3ecb681dcddefe045/package.json#L17-L20

https://github.com/WordPress/gutenberg/blob/bc94b203029bd2a2aea191a3ecb681dcddefe045/.nvmrc#L1

## How?

simple doc update

## Testing Instructions
n/a

### Testing Instructions for Keyboard

n/a

## Screenshots or screencast <!-- if applicable -->

n/a
