### PR TITLE
Updates Edit and Save code examples to have matching open/closing tags

### DIFF
--- a/docs/reference-guides/block-api/block-edit-save.md
+++ b/docs/reference-guides/block-api/block-edit-save.md
@@ -385,7 +385,7 @@ edit: ( { attributes, setAttributes } ) => {
 				value={ attributes.content }
 				onChange={ updateFieldValue }
 			/>
-		</p>
+		</div>
 	);
 },
 
@@ -465,7 +465,7 @@ edit: ( { attributes, setAttributes } ) => {
 					setAttributes( { postsToShow: parseInt( val ) } );
 				}}
 			/>
-		</p>
+		</div>
 	);
 },
 


### PR DESCRIPTION
## What?
Fixes https://github.com/WordPress/Documentation-Issue-Tracker/issues/1059 where some code samples had an opening `<div>` tag, but a mismatched, closing `</p>` tag.
