### PR TITLE
Fix typo in code sample for Interactivity API

### DIFF
--- a/packages/interactivity/docs/2-api-reference.md
+++ b/packages/interactivity/docs/2-api-reference.md
@@ -508,7 +508,7 @@ Defines data available to the HTML nodes of the page. It is important to differe
 store( {
   state: {
     someText: "Hello Universe!"
-  }
+  },
   actions: {
     someAction: ({ state, context }) => {
       state.someText // Access or modify global state - "Hello Universe!"


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Adds a missing comma to a code sample in the Interactivity API reference

## Why?
To improve the developer experience for people copying/pasting code sample
