### PR TITLE
fix: Horizontal rule accepts style extensions

### DIFF
--- a/packages/primitives/src/horizontal-rule/index.native.js
+++ b/packages/primitives/src/horizontal-rule/index.native.js
@@ -18,6 +18,7 @@ const HR = ( {
 	lineStyle,
 	marginLeft,
 	marginRight,
+	style,
 	textStyle,
 	text,
 	...props
@@ -25,7 +26,10 @@ const HR = ( {
 	const renderLine = ( key ) => (
 		<View
 			key={ key }
-			style={ getStylesFromColorScheme( styles.line, styles.lineDark ) }
+			style={ [
+				getStylesFromColorScheme( styles.line, styles.lineDark ),
+				lineStyle,
+			] }
 		/>
 	);
 
@@ -44,11 +48,7 @@ const HR = ( {
 
 	return (
 		<View
-			style={ [
-				styles.container,
-				{ marginLeft, marginRight },
-				props.style,
-			] }
+			style={ [ styles.container, { marginLeft, marginRight }, style ] }
 			{ ...props }
 		>
 			{ renderInner() }

--- a/packages/react-native-editor/CHANGELOG.md
+++ b/packages/react-native-editor/CHANGELOG.md
@@ -12,6 +12,7 @@ For each user feature we should also add a importance categorization label  to i
 ## Unreleased
 -   [*] Search Control - Prevent calling TextInput's methods when undefined [#53745]
 -   [*] Improve horizontal rule styles to avoid invisible lines [#53883]
+-   [*] Fix horizontal rule style extensions [#53917]
 
 ## 1.102.0
 -   [*] Display custom color value in mobile Cover Block color picker [#51414]


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Fix existing style props implementation that allow extending the visual
presentation of `HorizontalRule`.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The broken style props inhibited the ability to apply custom styles to the
container and line elements.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Without applying the `lineStyle` prop to the relevant element, the
received styles were lost.

Without de-structuring the `style` prop, spreading the entirety of
`props` meant passing a `style` value would overwrite _all_ of the
existing styles for the component.


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Add a More block.
1. Verify no visual regressions occurred.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
n/a

## Screenshots or screencast <!-- if applicable -->
| Before | After |
| - | - |
| ![before-light-mode](https://github.com/WordPress/gutenberg/assets/438664/f53a400d-950d-424d-b5d0-285a983ed205)| ![after-light-mode](https://github.com/WordPress/gutenberg/assets/438664/ffc6297b-9cb0-4047-91ec-b77f2238d84e) |
| ![before-dark-mode](https://github.com/WordPress/gutenberg/assets/438664/e5e76b7f-1427-434c-8866-4d11a1464157) | ![after-dark-mode](https://github.com/WordPress/gutenberg/assets/438664/57563609-8be2-405c-b8f0-4e9fa240322e) |




