### PR TITLE
Command Palette: Fix crash on block-related commands

### DIFF
--- a/packages/block-editor/src/components/use-block-commands/index.js
+++ b/packages/block-editor/src/components/use-block-commands/index.js
@@ -229,39 +229,54 @@ const useActionsCommands = () => {
 		return { isLoading: false, commands: [] };
 	}
 
-	const icons = {
-		ungroup,
-		group,
-		move,
-		add,
-		remove,
-		duplicate: copy,
-	};
-
 	const commands = [
-		onUngroup,
-		onGroup,
-		onMoveTo,
-		onAddAfter,
-		onAddBefore,
-		onRemove,
-		onDuplicate,
-	].map( ( callback ) => {
-		const action = callback.name
-			.replace( 'on', '' )
-			.replace( /([a-z])([A-Z])/g, '$1 $2' );
-
+		{
+			name: 'ungroup',
+			label: __( 'Ungroup' ),
+			callback: onUngroup,
+			icon: ungroup,
+		},
+		{
+			name: 'Group',
+			label: __( 'Group' ),
+			callback: onGroup,
+			icon: group,
+		},
+		{
+			name: 'move-to',
+			label: __( 'Move to' ),
+			callback: onMoveTo,
+			icon: move,
+		},
+		{
+			name: 'add-after',
+			label: __( 'Add After' ),
+			callback: onAddAfter,
+			icon: add,
+		},
+		{
+			name: 'add-before',
+			label: __( 'Add Before' ),
+			callback: onAddBefore,
+			icon: add,
+		},
+		{
+			name: 'remove',
+			label: __( 'Remove' ),
+			callback: onRemove,
+			icon: remove,
+		},
+		{
+			name: 'duplicate',
+			label: __( 'Duplicate' ),
+			callback: onDuplicate,
+			icon: copy,
+		},
+	].map( ( { name, label, callback, icon } ) => {
 		return {
-			name: 'core/block-editor/action-' + callback.name,
-			// translators: %s: type of the command.
-			label: action,
-			icon: icons[
-				callback.name
-					.replace( 'on', '' )
-					.match( /[A-Z]{1}[a-z]*/ )
-					.toString()
-					.toLowerCase()
-			],
+			name: 'core/block-editor/action-' + name,
+			label,
+			icon,
 			callback: ( { close } ) => {
 				callback();
 				close();

--- a/packages/block-editor/src/components/use-block-commands/index.js
+++ b/packages/block-editor/src/components/use-block-commands/index.js
@@ -250,13 +250,13 @@ const useActionsCommands = () => {
 		},
 		{
 			name: 'add-after',
-			label: __( 'Add After' ),
+			label: __( 'Add after' ),
 			callback: onAddAfter,
 			icon: add,
 		},
 		{
 			name: 'add-before',
-			label: __( 'Add Before' ),
+			label: __( 'Add before' ),
 			callback: onAddBefore,
 			icon: add,
 		},


### PR DESCRIPTION
Fixes #53863
Related to #52509

## What?

This PR fixes a problem in the command palette where the editor crashes due to block-related commands.

## Why?
This problem occurs when **building** a Gutenberg project, as mentioned in [this comment](https://github.com/WordPress/gutenberg/issues/53863#issuecomment-1691961566). Also, when built, the callback function name is also compressed, so the replace method does not produce the intended string. There is also a problem in terms of localization

## How?

I changed the command item to an object and specified the label, icon, callback function, etc. as individual properties.

## Testing Instructions

- Build this PR.
- Add a block.
- Launch the command palette.
- Confirm that the editor does not crash when typing `add`, `move`, etc. and that the commands are displayed.

Note: While I was investigating this issue, I discovered several problems in block related actions. These are not addressed in this PR as they also occur in trunk.

- #53921
- #53920
