### PR TITLE
Add a unit test for the "ValidBlockLibraryFunctionNameSniff" sniff

### DIFF
--- a/test/php/gutenberg-coding-standards/.phpcs.xml.dist
+++ b/test/php/gutenberg-coding-standards/.phpcs.xml.dist
@@ -27,7 +27,6 @@
 	<!-- Check up to 8 files simultaneously. -->
 	<arg name="parallel" value="8"/>
 
-
 	<!--
 	#############################################################################
 	SET UP THE RULESETS
@@ -38,51 +37,15 @@
 		<!-- This project needs to comply with naming standards from PHPCS, not WP. -->
 		<exclude name="WordPress.Files.FileName"/>
 		<exclude name="WordPress.NamingConventions.ValidVariableName"/>
+	</rule>
 
-		<!-- While conditions with assignments are a typical way to walk the token stream. -->
-		<exclude name="Generic.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition"/>
-
-		<!-- The code in this project is run in the context of PHPCS, not WP. -->
-		<exclude name="WordPress.DateTime"/>
-		<exclude name="WordPress.DB"/>
-		<exclude name="WordPress.Security"/>
-		<exclude name="WordPress.WP"/>
-
-		<!-- Linting is done in a separate CI job, no need to duplicate it. -->
-		<exclude name="Generic.PHP.Syntax"/>
-		<!--This rule should only be applied to code that is intended to be merged into Core. -->
-		<exclude name="Gutenberg.CodeAnalysis.GuardedFunctionAndClassNames"/>
+	<rule ref="Squiz.Commenting.FunctionCommentThrowTag.Missing">
+		<exclude-pattern>/Gutenberg/Tests/.+$</exclude-pattern>
 	</rule>
 
 	<!-- Check code for cross-version PHP compatibility. -->
-	<config name="testVersion" value="5.4-"/>
-	<rule ref="PHPCompatibility">
-		<!-- Exclude PHP constants back-filled by PHPCS. -->
-		<exclude name="PHPCompatibility.Constants.NewConstants.t_finallyFound"/>
-		<exclude name="PHPCompatibility.Constants.NewConstants.t_yieldFound"/>
-		<exclude name="PHPCompatibility.Constants.NewConstants.t_ellipsisFound"/>
-		<exclude name="PHPCompatibility.Constants.NewConstants.t_powFound"/>
-		<exclude name="PHPCompatibility.Constants.NewConstants.t_pow_equalFound"/>
-		<exclude name="PHPCompatibility.Constants.NewConstants.t_spaceshipFound"/>
-		<exclude name="PHPCompatibility.Constants.NewConstants.t_coalesceFound"/>
-		<exclude name="PHPCompatibility.Constants.NewConstants.t_coalesce_equalFound"/>
-		<exclude name="PHPCompatibility.Constants.NewConstants.t_yield_fromFound"/>
-	</rule>
+	<config name="testVersion" value="7.0-"/>
 
 	<!-- Enforce PSR1 compatible namespaces. -->
 	<rule ref="PSR1.Classes.ClassDeclaration"/>
-
-	<!--
-	#############################################################################
-	SNIFF SPECIFIC CONFIGURATION
-	#############################################################################
-	-->
-
-	<rule ref="WordPress.Arrays.MultipleStatementAlignment">
-		<properties>
-			<property name="alignMultilineItems" value="!=100"/>
-			<property name="exact" value="false" phpcs-only="true"/>
-		</properties>
-	</rule>
-
 </ruleset>

--- a/test/php/gutenberg-coding-standards/Gutenberg/Sniffs/NamingConventions/ValidBlockLibraryFunctionNameSniff.php
+++ b/test/php/gutenberg-coding-standards/Gutenberg/Sniffs/NamingConventions/ValidBlockLibraryFunctionNameSniff.php
@@ -114,22 +114,22 @@ final class ValidBlockLibraryFunctionNameSniff implements Sniff {
 		$parent_directory_name = basename( dirname( $phpcsFile->getFilename() ) );
 
 		$allowed_function_prefixes = array();
-		$is_function_name_valid    = false;
 		foreach ( $this->prefixes as $prefix ) {
 			$prefix                      = rtrim( $prefix, '_' );
 			$allowed_function_prefix     = $prefix . '_' . self::sanitize_directory_name( $parent_directory_name );
 			$allowed_function_prefixes[] = $allowed_function_prefix;
 			// Validate the name's correctness and ensure it does not end with an underscore.
-			$regexp                 = sprintf( '/^%s(|_.+)$/', preg_quote( $allowed_function_prefix, '/' ) );
-			$is_function_name_valid |= ( 1 === preg_match( $regexp, $function_name ) );
+			$regexp = sprintf( '/^%s(|_.+)$/', preg_quote( $allowed_function_prefix, '/' ) );
+
+			if ( 1 === preg_match( $regexp, $function_name ) ) {
+				// The function has a valid prefix; bypassing further checks.
+				return;
+			}
 		}
 
-		if ( $is_function_name_valid ) {
-			return;
-		}
-
-		$error_message = "The function name `{$function_name}()` is invalid because PHP function names in this file should start with one of the following prefixes: `"
-		                 . implode( '`, `', $allowed_function_prefixes ) . '`.';
+		$error_message = "The function name '{$function_name}()' is invalid."
+		. ' In this file, PHP function names must either match one of the allowed prefixes exactly or begin with one of them, followed by an underscore.'
+		. " The allowed prefixes are: '" . implode( "', '", $allowed_function_prefixes ) . "'.";
 		$phpcsFile->addError( $error_message, $function_token, 'FunctionNameInvalid' );
 	}
 
@@ -146,7 +146,7 @@ final class ValidBlockLibraryFunctionNameSniff implements Sniff {
 	 * Sanitize a directory name by converting it to lowercase and replacing non-letter
 	 * and non-digit characters with underscores.
 	 *
-	 * @param string $directory_name
+	 * @param string $directory_name Directory name.
 	 *
 	 * @return string
 	 */

--- a/test/php/gutenberg-coding-standards/Gutenberg/Tests/NamingConventions/ValidBlockLibraryFunctionNameUnitTest.php
+++ b/test/php/gutenberg-coding-standards/Gutenberg/Tests/NamingConventions/ValidBlockLibraryFunctionNameUnitTest.php
@@ -1,0 +1,116 @@
+<?php
+/**
+ * Unit test class for Gutenberg Coding Standard.
+ *
+ * @package gutenberg-coding-standards/gbc
+ * @link    https://github.com/WordPress/gutenberg
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace GutenbergCS\Gutenberg\Tests\NamingConventions;
+
+use GutenbergCS\Gutenberg\Sniffs\NamingConventions\ValidBlockLibraryFunctionNameSniff;
+use PHP_CodeSniffer\Config;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Ruleset;
+
+/**
+ * Unit test class for the ValidBlockLibraryFunctionNameSniff sniff.
+ */
+final class ValidBlockLibraryFunctionNameUnitTest extends AbstractSniffUnitTest {
+
+	/**
+	 * Holds the original Ruleset instance.
+	 *
+	 * @var Ruleset
+	 */
+	private static $original_ruleset;
+
+	/**
+	 * Returns the lines where errors should occur.
+	 *
+	 * @return array <int line number> => <int number of errors>
+	 */
+	public function getErrorList() {
+		return array(
+			8  => 1,
+			17 => 1,
+			26 => 1,
+			35 => 1,
+		);
+	}
+
+	/**
+	 * Returns the lines where warnings should occur.
+	 *
+	 * @return array <int line number> => <int number of warnings>
+	 */
+	public function getWarningList() {
+		return array();
+	}
+
+	/**
+	 *
+	 * This method resets the 'Gutenberg' ruleset in the $GLOBALS['PHP_CODESNIFFER_RULESETS']
+	 * to its original state.
+	 */
+	public static function tearDownAfterClass() {
+		parent::tearDownAfterClass();
+
+		$GLOBALS['PHP_CODESNIFFER_RULESETS']['Gutenberg'] = self::$original_ruleset;
+		self::$original_ruleset                           = null;
+	}
+
+
+	/**
+	 * Prepares the environment before executing tests. Specifically, sets prefixes for the
+	 * ValidBlockLibraryFunctionName sniff.This is needed since AbstractSniffUnitTest class
+	 * doesn't apply sniff properties from the Gutenberg/ruleset.xml file.
+	 *
+	 * @param string $filename The name of the file being tested.
+	 * @param Config $config   The config data for the run.
+	 *
+	 * @return void
+	 */
+	public function setCliValues( $filename, $config ) {
+		parent::setCliValues( $filename, $config );
+
+		if ( ! isset( $GLOBALS['PHP_CODESNIFFER_RULESETS']['Gutenberg'] )
+			|| ( ! $GLOBALS['PHP_CODESNIFFER_RULESETS']['Gutenberg'] instanceof Ruleset )
+		) {
+			throw new \RuntimeException( 'Cannot set ruleset parameters required for this test.' );
+		}
+
+		// Backup the original Ruleset instance.
+		self::$original_ruleset = $GLOBALS['PHP_CODESNIFFER_RULESETS']['Gutenberg'];
+
+		$current_ruleset                                  = clone self::$original_ruleset;
+		$GLOBALS['PHP_CODESNIFFER_RULESETS']['Gutenberg'] = $current_ruleset;
+
+		if ( ! isset( $current_ruleset->sniffs[ ValidBlockLibraryFunctionNameSniff::class ] )
+			|| ( ! $current_ruleset->sniffs[ ValidBlockLibraryFunctionNameSniff::class ] instanceof ValidBlockLibraryFunctionNameSniff )
+		) {
+			throw new \RuntimeException( 'Cannot set ruleset parameters required for this test.' );
+		}
+
+		$sniff           = $current_ruleset->sniffs[ ValidBlockLibraryFunctionNameSniff::class ];
+		$sniff->prefixes = array(
+			'block_core_',
+			'render_block_core_',
+			'register_block_core_',
+		);
+	}
+
+	/**
+	 * Get a list of all test files to check.
+	 *
+	 * @param string $testFileBase The base path that the unit tests files will have.
+	 *
+	 * @return string[]
+	 */
+	protected function getTestFiles( $testFileBase ) {
+		return array(
+			__DIR__ . '/../fixtures/block-library/src/my-block/index.inc',
+		);
+	}
+}

--- a/test/php/gutenberg-coding-standards/Gutenberg/Tests/fixtures/block-library/src/my-block/index.inc
+++ b/test/php/gutenberg-coding-standards/Gutenberg/Tests/fixtures/block-library/src/my-block/index.inc
@@ -1,0 +1,36 @@
+<?php
+function block_core_my_block() {
+}
+
+function block_core_my_block_with_some_postfix() {
+}
+
+function block_core_my_blockwith_no_underscore_after_the_prefix() {
+}
+
+function render_block_core_my_block() {
+}
+
+function render_block_core_my_block_with_some_postfix() {
+}
+
+function render_block_core_my_blockwith_no_underscore_after_the_prefix() {
+}
+
+function register_block_core_my_block() {
+}
+
+function register_block_core_my_block_with_some_postfix() {
+}
+
+function register_block_core_my_blockwith_no_underscore_after_the_prefix() {
+}
+
+class MyClass {
+	// Represents a non-prefixed method within the class.
+	public function some_non_prefixed_class_method() {
+	}
+}
+
+function foo() {
+}

--- a/test/php/gutenberg-coding-standards/composer.json
+++ b/test/php/gutenberg-coding-standards/composer.json
@@ -16,17 +16,18 @@
 		}
 	],
 	"require": {
-		"php": ">=5.4",
-		"ext-filter": "*",
+		"php": ">=7.0",
+		"ext-libxml": "*",
+		"ext-tokenizer": "*",
+		"ext-xmlreader": "*",
 		"squizlabs/php_codesniffer": "^3.7.2"
 	},
 	"require-dev": {
 		"phpcompatibility/php-compatibility": "^9.0",
-		"phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0",
+		"phpunit/phpunit": "^5.0 || ^6.0 || ^7.0",
 		"php-parallel-lint/php-parallel-lint": "^1.3.2",
 		"php-parallel-lint/php-console-highlighter": "^1.0.0",
-		"dealerdirect/phpcodesniffer-composer-installer": "*",
-		"wp-coding-standards/wpcs": "^2.2"
+		"wp-coding-standards/wpcs": "^3.0"
 	},
 	"suggest": {
 		"ext-mbstring": "For improved results"
@@ -47,7 +48,7 @@
 			"@php ./vendor/squizlabs/php_codesniffer/bin/phpcbf"
 		],
 		"run-tests": [
-			"@php ./vendor/phpunit/phpunit/phpunit -c phpunit.xml.dist --filter Gutenberg ./vendor/squizlabs/php_codesniffer/tests/AllTests.php"
+			"@php ./vendor/phpunit/phpunit/phpunit --filter Gutenberg ./vendor/squizlabs/php_codesniffer/tests/AllTests.php --no-coverage"
 		],
 		"check-all": [
 			"@lint",


### PR DESCRIPTION
<!-- Thank you for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This PR aims to add a unit test for the recently introduced `ValidBlockLibraryFunctionNameSniff` sniff.
It also brings a few other minor improvements.
Fixes https://github.com/WordPress/gutenberg/issues/53731.

## Why?
It's considered best practice to write unit tests for PHPCS sniffs.
Additionally, as Gutenberg moves toward bumping the minimum supported PHP version, this package should also be updated.


## How?
<!-- How does your PR address the issue? Are there any specific implementation details to note? -->

 - [x] Add a unit test for the `ValidBlockLibraryFunctionNameSniff` sniff.
 - [x] Bump the minimum required PHP version to 7.0.
 - [x] Refine `phpcs.xml.dist` by only excluding necessary rules.
 - [x] Update WPCS to 3.0.
 - [x] Refactor `ValidBlockLibraryFunctionNameSniff::processFunctionToken()`: eliminate the need to loop through all available prefixes once the function name is confirmed as valid; this results in a minor performance improvement.
 - [x] Remove `dealerdirect/phpcodesniffer-composer-installer` from the list of dependencies per WPCS 3.0 [upgrade guide](https://github.com/WordPress/WordPress-Coding-Standards/wiki/Upgrade-Guide-to-WordPressCS-3.0.0-for-ruleset-maintainers).

## Testing Instructions

1. Ensure that GitHub CI jobs pass.
2. Navigate to `test/php/gutenberg-coding-standards/`.
3. Run `composer update`.
4. Run `composer run check-all`.

Ensure that the PHPUnit tests in the console pass. PHPUnit should report 0 assertions, but that is expected.

`Note`: The unit tests will not work on PHP 8.0 and above. This is because the latest stable version of the `squizlabs/php_codesniffer` package [doesn't support](https://packagist.org/packages/squizlabs/php_codesniffer#3.7.2) PHPUnit 8.x. Also, PHPUnit 7.x [is not compatible](https://phpunit.de/supported-versions.html) with PHP 8.0. The unit tests have been confirmed to work on PHP 7.3.
