### PR TITLE
Fix focus outline of block items in blocks menu

### DIFF
--- a/packages/components/src/item-group/styles.ts
+++ b/packages/components/src/item-group/styles.ts
@@ -42,6 +42,7 @@ export const unstyledButton = ( as: 'a' | 'button' ) => {
 			// Windows high contrast mode.
 			outline: 2px solid transparent;
 			outline-offset: 0;
+			border-radius: 2px;
 		}
 	`;
 };

--- a/packages/edit-site/src/components/global-styles/style.scss
+++ b/packages/edit-site/src/components/global-styles/style.scss
@@ -56,7 +56,8 @@
 	padding: 0 $grid-unit-20;
 }
 
-.edit-site-block-types-search {
+.edit-site-block-types-search,
+.edit-site-block-types-item-list {
 	margin-bottom: $grid-unit-10;
 	padding: 0 $grid-unit-20;
 }


### PR DESCRIPTION
These changes clean up the outline styles for the blocks menu.

Fixes https://github.com/WordPress/gutenberg/issues/53600

## Demo of Proposed Changes

https://github.com/WordPress/gutenberg/assets/6676674/16832206-723d-4bb0-b1b5-97ff5ab3a1b5