### PR TITLE
Adds 'nofollow' setting to inline links (rich text only)

### DIFF
--- a/packages/block-editor/src/components/link-control/constants.js
+++ b/packages/block-editor/src/components/link-control/constants.js
@@ -24,4 +24,8 @@ export const DEFAULT_LINK_SETTINGS = [
 		id: 'opensInNewTab',
 		title: __( 'Open in new tab' ),
 	},
+	{
+		id: 'noFollow',
+		title: __( 'No follow' ),
+	},
 ];

--- a/packages/block-editor/src/components/link-control/constants.js
+++ b/packages/block-editor/src/components/link-control/constants.js
@@ -24,8 +24,4 @@ export const DEFAULT_LINK_SETTINGS = [
 		id: 'opensInNewTab',
 		title: __( 'Open in new tab' ),
 	},
-	{
-		id: 'noFollow',
-		title: __( 'No follow' ),
-	},
 ];

--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -475,5 +475,6 @@ function LinkControl( {
 }
 
 LinkControl.ViewerFill = ViewerFill;
+LinkControl.DEFAULT_LINK_SETTINGS = DEFAULT_LINK_SETTINGS;
 
 export default LinkControl;

--- a/packages/block-editor/src/components/link-control/settings.js
+++ b/packages/block-editor/src/components/link-control/settings.js
@@ -26,6 +26,7 @@ const LinkControlSettings = ( { value, onChange = noop, settings } ) => {
 			label={ setting.title }
 			onChange={ handleSettingChange( setting ) }
 			checked={ value ? !! value[ setting.id ] : false }
+			help={ setting?.help }
 		/>
 	) );
 

--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -401,17 +401,13 @@ $preview-image-height: 140px;
 }
 
 .block-editor-link-control__setting {
-	margin-bottom: $grid-unit-20;
+	margin-bottom: 0;
 	flex: 1;
 	padding: $grid-unit-10 0 $grid-unit-10 $grid-unit-30;
 
 	// Cancel left margin inherited from WP Admin Forms CSS.
 	input {
 		margin-left: 0;
-	}
-
-	&.block-editor-link-control__setting:last-child {
-		margin-bottom: 0;
 	}
 
 	.is-preview & {

--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -405,6 +405,10 @@ $preview-image-height: 140px;
 	flex: 1;
 	padding: $grid-unit-10 0 $grid-unit-10 $grid-unit-30;
 
+	.components-base-control__field {
+		display: flex; // don't allow label to wrap under checkbox.
+	}
+
 	// Cancel left margin inherited from WP Admin Forms CSS.
 	input {
 		margin-left: 0;

--- a/packages/format-library/src/link/index.js
+++ b/packages/format-library/src/link/index.js
@@ -131,6 +131,7 @@ export const link = {
 		type: 'data-type',
 		id: 'data-id',
 		target: 'target',
+		rel: 'rel',
 	},
 	__unstablePasteRule( value, { html, plainText } ) {
 		if ( isCollapsed( value ) ) {

--- a/packages/format-library/src/link/inline.js
+++ b/packages/format-library/src/link/inline.js
@@ -36,11 +36,10 @@ const LINK_SETTINGS = [
 	{
 		id: 'nofollow',
 		title: createInterpolateElement(
-			__(
-				'Search engines should ignore this link (mark as <code>nofollow</code>)'
-			),
+			__( 'Mark as <code>nofollow</code>' ),
 			{ code: <code /> }
 		),
+		help: __( 'Search engines should ignore this link.' ),
 	},
 ];
 

--- a/packages/format-library/src/link/inline.js
+++ b/packages/format-library/src/link/inline.js
@@ -60,6 +60,7 @@ function InlineLinkUI( {
 		type: activeAttributes.type,
 		id: activeAttributes.id,
 		opensInNewTab: activeAttributes.target === '_blank',
+		noFollow: activeAttributes.rel?.includes( 'nofollow' ),
 		title: richTextText,
 	};
 
@@ -77,7 +78,6 @@ function InlineLinkUI( {
 		const didToggleSetting =
 			linkValue.opensInNewTab !== nextValue.opensInNewTab &&
 			nextValue.url === undefined;
-
 		// Merge the next value with the current link value.
 		nextValue = {
 			...linkValue,
@@ -93,6 +93,7 @@ function InlineLinkUI( {
 					? String( nextValue.id )
 					: undefined,
 			opensInNewWindow: nextValue.opensInNewTab,
+			noFollow: nextValue.noFollow,
 		} );
 
 		const newText = nextValue.title || newUrl;

--- a/packages/format-library/src/link/inline.js
+++ b/packages/format-library/src/link/inline.js
@@ -39,7 +39,7 @@ const LINK_SETTINGS = [
 			__( 'Mark as <code>nofollow</code>' ),
 			{ code: <code /> }
 		),
-		help: __( 'Search engines should ignore this link.' ),
+		help: __( 'Ask search engines to ignore this link.' ),
 	},
 ];
 

--- a/packages/format-library/src/link/inline.js
+++ b/packages/format-library/src/link/inline.js
@@ -39,7 +39,6 @@ const LINK_SETTINGS = [
 			__( 'Mark as <code>nofollow</code>' ),
 			{ code: <code /> }
 		),
-		help: __( 'Ask search engines to ignore this link.' ),
 	},
 ];
 

--- a/packages/format-library/src/link/inline.js
+++ b/packages/format-library/src/link/inline.js
@@ -35,8 +35,7 @@ const LINK_SETTINGS = [
 	...LinkControl.DEFAULT_LINK_SETTINGS,
 	{
 		id: 'nofollow',
-		title: __( 'No follow' ),
-		help: createInterpolateElement(
+		title: createInterpolateElement(
 			__(
 				'Search engines should ignore this link (mark as <code>nofollow</code>)'
 			),

--- a/packages/format-library/src/link/inline.js
+++ b/packages/format-library/src/link/inline.js
@@ -34,9 +34,14 @@ import useLinkInstanceKey from './use-link-instance-key';
 const LINK_SETTINGS = [
 	...LinkControl.DEFAULT_LINK_SETTINGS,
 	{
-		id: 'noFollow',
+		id: 'nofollow',
 		title: __( 'No follow' ),
-		help: __( 'Search engines should ignore this link' ),
+		help: createInterpolateElement(
+			__(
+				'Search engines should ignore this link (mark as <code>nofollow</code>)'
+			),
+			{ code: <code /> }
+		),
 	},
 ];
 
@@ -69,7 +74,7 @@ function InlineLinkUI( {
 		type: activeAttributes.type,
 		id: activeAttributes.id,
 		opensInNewTab: activeAttributes.target === '_blank',
-		noFollow: activeAttributes.rel?.includes( 'nofollow' ),
+		nofollow: activeAttributes.rel?.includes( 'nofollow' ),
 		title: richTextText,
 	};
 
@@ -102,7 +107,7 @@ function InlineLinkUI( {
 					? String( nextValue.id )
 					: undefined,
 			opensInNewWindow: nextValue.opensInNewTab,
-			noFollow: nextValue.noFollow,
+			nofollow: nextValue.nofollow,
 		} );
 
 		const newText = nextValue.title || newUrl;

--- a/packages/format-library/src/link/inline.js
+++ b/packages/format-library/src/link/inline.js
@@ -31,6 +31,18 @@ import { createLinkFormat, isValidHref, getFormatBoundary } from './utils';
 import { link as settings } from './index';
 import useLinkInstanceKey from './use-link-instance-key';
 
+const LINK_SETTINGS = [
+	{
+		id: 'opensInNewTab',
+		title: __( 'Open in new tab' ),
+	},
+	{
+		id: 'noFollow',
+		title: __( 'No follow' ),
+		help: __( 'Search engines should ignore this link' ),
+	},
+];
+
 function InlineLinkUI( {
 	isActive,
 	activeAttributes,
@@ -248,6 +260,7 @@ function InlineLinkUI( {
 				withCreateSuggestion={ userCanCreatePages }
 				createSuggestionButtonText={ createButtonText }
 				hasTextControl
+				settings={ LINK_SETTINGS }
 			/>
 		</Popover>
 	);

--- a/packages/format-library/src/link/inline.js
+++ b/packages/format-library/src/link/inline.js
@@ -32,10 +32,7 @@ import { link as settings } from './index';
 import useLinkInstanceKey from './use-link-instance-key';
 
 const LINK_SETTINGS = [
-	{
-		id: 'opensInNewTab',
-		title: __( 'Open in new tab' ),
-	},
+	...LinkControl.DEFAULT_LINK_SETTINGS,
 	{
 		id: 'noFollow',
 		title: __( 'No follow' ),

--- a/packages/format-library/src/link/utils.js
+++ b/packages/format-library/src/link/utils.js
@@ -85,10 +85,16 @@ export function isValidHref( href ) {
  * @param {string}  options.type             The type of the link.
  * @param {string}  options.id               The ID of the link.
  * @param {boolean} options.opensInNewWindow Whether this link will open in a new window.
- *
+ * @param {boolean} options.noFollow         Whether this link is marked as no follow relationship.
  * @return {Object} The final format object.
  */
-export function createLinkFormat( { url, type, id, opensInNewWindow } ) {
+export function createLinkFormat( {
+	url,
+	type,
+	id,
+	opensInNewWindow,
+	noFollow,
+} ) {
 	const format = {
 		type: 'core/link',
 		attributes: {
@@ -101,7 +107,15 @@ export function createLinkFormat( { url, type, id, opensInNewWindow } ) {
 
 	if ( opensInNewWindow ) {
 		format.attributes.target = '_blank';
-		format.attributes.rel = 'noreferrer noopener';
+		format.attributes.rel = format.attributes.rel
+			? format.attributes.rel + ' noreferrer noopener'
+			: 'noreferrer noopener';
+	}
+
+	if ( noFollow ) {
+		format.attributes.rel = format.attributes.rel
+			? format.attributes.rel + ' nofollow'
+			: 'nofollow';
 	}
 
 	return format;

--- a/packages/format-library/src/link/utils.js
+++ b/packages/format-library/src/link/utils.js
@@ -85,7 +85,7 @@ export function isValidHref( href ) {
  * @param {string}  options.type             The type of the link.
  * @param {string}  options.id               The ID of the link.
  * @param {boolean} options.opensInNewWindow Whether this link will open in a new window.
- * @param {boolean} options.noFollow         Whether this link is marked as no follow relationship.
+ * @param {boolean} options.nofollow         Whether this link is marked as no follow relationship.
  * @return {Object} The final format object.
  */
 export function createLinkFormat( {
@@ -93,7 +93,7 @@ export function createLinkFormat( {
 	type,
 	id,
 	opensInNewWindow,
-	noFollow,
+	nofollow,
 } ) {
 	const format = {
 		type: 'core/link',
@@ -112,7 +112,7 @@ export function createLinkFormat( {
 			: 'noreferrer noopener';
 	}
 
-	if ( noFollow ) {
+	if ( nofollow ) {
 		format.attributes.rel = format.attributes.rel
 			? format.attributes.rel + ' nofollow'
 			: 'nofollow';


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Adds the ability to toggle `nofollow` for a given link via the Link UI in rich text only (at this initial stage).

Addresses _part_ of https://github.com/WordPress/gutenberg/issues/23011

Kudos to https://github.com/WordPress/gutenberg/pull/48722 for the inspiration.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

This is a standard practice for those utilising more advanced SEO techniques. It is [recommended by major search providers as a way of qualifying outbound links](https://developers.google.com/search/docs/crawling-indexing/qualify-outbound-links).

This paves the way for the _possibility_ of adding other settings such as `sponsored` which is also recommend by major search providers.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Utilises the new foundations that contributors have been putting in place for a while now including (but not limited to):

- `Advanced` settings area.
- Persisting state of the Advanced settings area to a user preference
- More robust settings toggling behaviour.

The `nofollow` setting can now be easily added without overloading the interface with too many options that may not not helpful to portion of WordPress users (i.e. non-technical or not focused on SEO). For those users who make regular use of this feature this can still be easily accessed because the toggle state of the `Advanced` area is persisted once toggled meaning it does not have to be repeatedly re-opened.

Note that to avoid 

- exposing settings in the Link UI that are potentially not handled by 3rd party consumers (or other parts of Core - e.g. Nav block, buttons block...etc)
- overriding existing settings behaviour implemented by 3rd party consumers.

...the new setting is not provided by default to all instances of `LinkControl`. Rather we are now exposing the default settings from `LinkControl` to allow them to be extended.

This means that in the rich text implemented, we can safely extent the default settings with a new setting for `nofollow`.



## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- New Post
- Add text in a paragraph block
- Link some text
- Click link
- Click edit
- Toggle Advanced Settings
- Toggle the setitngs shown there
- Save the link
- Switch to code view
- Check the correct attributes have been persisted to the underlying markup.
- Now switch back to Visual Mode, uncheck the attributes and `Save` again.
- Switch to code view
- Check the relevant attributes have been removed from the underlying markup.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
<img width="672" alt="Screen Shot 2023-08-25 at 13 12 54" src="https://github.com/WordPress/gutenberg/assets/444434/ad6546e2-7890-4371-a49e-b0479558fab1">
