### PR TITLE
Pass entire link value on toggle of setting on Link Preview

### DIFF
--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -422,11 +422,7 @@ function LinkControl( {
 									settings={ settings?.filter(
 										( { id } ) => id === 'opensInNewTab'
 									) }
-									onChange={ ( { opensInNewTab } ) => {
-										onChange( {
-											opensInNewTab,
-										} );
-									} }
+									onChange={ onChange }
 								/>
 							);
 						}

--- a/packages/block-editor/src/components/link-control/test/index.js
+++ b/packages/block-editor/src/components/link-control/test/index.js
@@ -1789,6 +1789,7 @@ describe( 'Addition Settings UI', () => {
 
 		expect( mockOnChange ).toHaveBeenCalledTimes( 1 );
 		expect( mockOnChange ).toHaveBeenCalledWith( {
+			...selectedLink,
 			opensInNewTab: true,
 		} );
 	} );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes potential bug with not passing the entire `value` object on `onChange` of `LinkControl` when toggling `Open in new tab` on preview mode.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Need to always [fulfil contract of passing full value object](https://github.com/WordPress/gutenberg/blob/935be24b5e828d4e91effdb45267965a740cdc73/packages/block-editor/src/components/link-control/index.js#L91-L92).

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Pass full object `onChange`.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Check tests pass.

- New Post
- Add link
- Click link to bring up preview
- Toggle open in new tab
- See that value updates and persists as expected.


### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
