### PR TITLE
Search block: Fix width input field

### DIFF
--- a/packages/block-library/src/search/edit.js
+++ b/packages/block-library/src/search/edit.js
@@ -52,7 +52,7 @@ import {
 	PC_WIDTH_DEFAULT,
 	PX_WIDTH_DEFAULT,
 	MIN_WIDTH,
-	MIN_WIDTH_UNIT,
+	isPercentageUnit,
 } from './utils.js';
 
 // Used to calculate border radius adjustment to avoid "fat" corners when
@@ -405,7 +405,13 @@ export default function SearchEdit( {
 					>
 						<UnitControl
 							id={ unitControlInputId }
-							min={ `${ MIN_WIDTH }${ MIN_WIDTH_UNIT }` }
+							min={
+								isPercentageUnit( widthUnit ) ? 0 : MIN_WIDTH
+							}
+							max={
+								isPercentageUnit( widthUnit ) ? 100 : undefined
+							}
+							step={ 1 }
 							onChange={ ( newWidth ) => {
 								const filteredWidth =
 									widthUnit === '%' &&

--- a/packages/block-library/src/search/utils.js
+++ b/packages/block-library/src/search/utils.js
@@ -4,7 +4,6 @@
 export const PC_WIDTH_DEFAULT = 50;
 export const PX_WIDTH_DEFAULT = 350;
 export const MIN_WIDTH = 220;
-export const MIN_WIDTH_UNIT = 'px';
 
 /**
  * Returns a boolean whether passed unit is percentage


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
In the search block: Change the input width `min` value to a number to fix a bug and add a `max` value if the unit it %.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The input width field isn't working as it should when the `min` value is a string that includes the unit. Arrow-up, arrow-down and the drag behavor all resets the input field to `0`.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Change the `min` prop to be a number. Have also optimized the min/max value based on the unit.

## Testing Instructions
1. Insert a Search block in the editor.
2. Try to change the width value with keyboard (if unit is percentage you should only be able to select values from 0-100).
3. Try to change the width value with mousedrag.

## Screenshots or screencast <!-- if applicable -->

### Before
https://github.com/WordPress/gutenberg/assets/1415747/4a66f7a9-e4a3-4f85-ab69-8de3d43e972c 

### After
https://github.com/WordPress/gutenberg/assets/1415747/1f985607-bc55-4dfb-b54f-dc97e20452ba

