### PR TITLE
Cover block: fix exception when adding video background

### DIFF
--- a/packages/block-library/src/cover/edit/index.js
+++ b/packages/block-library/src/cover/edit/index.js
@@ -151,6 +151,7 @@ function CoverEdit( {
 	const setMedia = attributesFromMedia( setAttributes, dimRatio );
 
 	const onSelectMedia = async ( newMedia ) => {
+		// Only pass the url to getCoverIsDark if the media is an image as video is not handled.
 		const newUrl = newMedia?.type === 'image' ? newMedia.url : undefined;
 		const isDarkSetting = await getCoverIsDark(
 			newUrl,

--- a/packages/block-library/src/cover/edit/index.js
+++ b/packages/block-library/src/cover/edit/index.js
@@ -151,8 +151,9 @@ function CoverEdit( {
 	const setMedia = attributesFromMedia( setAttributes, dimRatio );
 
 	const onSelectMedia = async ( newMedia ) => {
+		const newUrl = newMedia?.type === 'image' ? newMedia.url : undefined;
 		const isDarkSetting = await getCoverIsDark(
-			newMedia.url,
+			newUrl,
 			dimRatio,
 			overlayColor.color
 		);

--- a/packages/block-library/src/cover/shared.js
+++ b/packages/block-library/src/cover/shared.js
@@ -167,26 +167,31 @@ export async function getCoverIsDark( url, dimRatio = 50, overlayColor ) {
 		.toRgb();
 
 	if ( url ) {
-		const imgCrossOrigin = applyFilters(
-			'media.crossOrigin',
-			undefined,
-			url
-		);
-		const {
-			value: [ r, g, b, a ],
-		} = await retrieveFastAverageColor().getColorAsync( url, {
-			// Previously the default color was white, but that changed
-			// in v6.0.0 so it has to be manually set now.
-			defaultColor: [ 255, 255, 255, 255 ],
-			// Errors that come up don't reject the promise, so error
-			// logging has to be silenced with this option.
-			silent: process.env.NODE_ENV === 'production',
-			crossOrigin: imgCrossOrigin,
-		} );
-		// FAC uses 0-255 for alpha, but colord expects 0-1.
-		const media = { r, g, b, a: a / 255 };
-		const composite = compositeSourceOver( overlay, media );
-		return colord( composite ).isDark();
+		try {
+			const imgCrossOrigin = applyFilters(
+				'media.crossOrigin',
+				undefined,
+				url
+			);
+			const {
+				value: [ r, g, b, a ],
+			} = await retrieveFastAverageColor().getColorAsync( url, {
+				// Previously the default color was white, but that changed
+				// in v6.0.0 so it has to be manually set now.
+				defaultColor: [ 255, 255, 255, 255 ],
+				// Errors that come up don't reject the promise, so error
+				// logging has to be silenced with this option.
+				silent: process.env.NODE_ENV === 'production',
+				crossOrigin: imgCrossOrigin,
+			} );
+			// FAC uses 0-255 for alpha, but colord expects 0-1.
+			const media = { r, g, b, a: a / 255 };
+			const composite = compositeSourceOver( overlay, media );
+			return colord( composite ).isDark();
+		} catch ( error ) {
+			// If there's an error, just assume the image is dark.
+			return true;
+		}
 	}
 
 	// Assume a white background because it isn't easy to get the actual


### PR DESCRIPTION
## What?
Fixes exception that is thrown if video is added as cover background.

## Why?
Adding a video causes fastAverageColor to throw an exception. This was an existing problem but was previously masked by the fact that the exception was thrown in an effect, but now that the check is done in an event handle it disrupts the attribute update process.

Fixes: #53956

## How?
Wraps the call to fastAverageColor in a try/catch and also only passes images to this call, not video.

## Testing Instructions
- Add a Cover block and set a black overlay color, then add text and ensure the text is white
- Reduce the dimRatio below 50 and check that the text turns black
- Increase the dimRatio above 50 again and check that the text turns white again
- Change the overlay color to a light color and check that the text turns black
- Change the dimRatio above and below 50 and check that the text remains black
- Make sure dimRatio is above 50 with the light background and then add a very dark overlay image and check that the text remains black
- Reduce the dimRatio below 50 and check that the text turns white
- Replace the image with a very light one and check that the text turns black
- Remove both the image and the overlay color and check that the text turns white
- Add a new cover block with black overlay color and dimRation < 50
- Add light featured image to the post and toggle it on as the overlay image in the Cover block toolbar and check that the text color is black
- Toggle the feature image back off and check that the text is white again
- Repeat the above two steps with a dark feature image
- Add a Cover block and add a video as the background and make sure it works as expected
- Try replacing the video with another video, and also replacing a video with an image or an image with a video

## Screenshots or screencast <!-- if applicable -->

Before:

https://github.com/WordPress/gutenberg/assets/3629020/1a34b531-744b-4fd9-87ad-83d9dcf76206

After:

https://github.com/WordPress/gutenberg/assets/3629020/e34a5b85-f9c3-46f0-bd1e-cd6323776125



