### PR TITLE
Navigation block: Add `core/buttons` to the allowed blocks.

### DIFF
--- a/packages/block-library/src/navigation-link/transforms.js
+++ b/packages/block-library/src/navigation-link/transforms.js
@@ -47,6 +47,13 @@ const transforms = {
 				return createBlock( 'core/navigation-link' );
 			},
 		},
+		{
+			type: 'block',
+			blocks: [ 'core/buttons' ],
+			transform: () => {
+				return createBlock( 'core/navigation-link' );
+			},
+		},
 	],
 	to: [
 		{
@@ -103,6 +110,21 @@ const transforms = {
 			blocks: [ 'core/page-list' ],
 			transform: () => {
 				return createBlock( 'core/page-list' );
+			},
+		},
+		{
+			type: 'block',
+			blocks: [ 'core/buttons' ],
+			transform: ( { label, url, rel, title, opensInNewTab } ) => {
+				return createBlock( 'core/buttons', {}, [
+					createBlock( 'core/button', {
+						text: label,
+						url,
+						rel,
+						title,
+						linkTarget: opensInNewTab ? '_blank' : undefined,
+					} ),
+				] );
 			},
 		},
 	],

--- a/packages/block-library/src/navigation/constants.js
+++ b/packages/block-library/src/navigation/constants.js
@@ -13,6 +13,7 @@ export const ALLOWED_BLOCKS = [
 	'core/site-logo',
 	'core/navigation-submenu',
 	'core/loginout',
+	'core/buttons',
 ];
 
 export const PRIORITIZED_INSERTER_BLOCKS = [


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
`core/buttons` can be added to innerBlocks of navigation block.

fix #35924

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Designs with buttons at the end of the navigation are commonly used on various websites, and you can find such themes in the WordPress theme directory. Here is an example

https://wordpress.org/themes/next-business/
https://wordpress.org/themes/gutenify-lynx/
https://wordpress.org/themes/blockverse/

https://wordpress.org also uses this type of navigation.

It is also common for menus to include buttons when the navigation is collapsed. (Like wordpress.org.)

Using a buttons block on the navigation block makes it easy to achieve these designs without writing any CSS or special classes.

## How?
add to `core/buttons` to `ALLOWED_BLOCKS` . 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open navigation editor.
2. Add custom link.
3. Transform to buttons.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
![](https://github.com/WordPress/gutenberg/assets/1908815/e509c621-d331-4af0-834f-8c5c7e7c7eb9)
![](https://github.com/WordPress/gutenberg/assets/1908815/73af5f54-274c-4522-aa47-6d79b7d9e12f)

