### PR TITLE
env: add `init` command

### DIFF
--- a/packages/env/CHANGELOG.md
+++ b/packages/env/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancement
+
+-   Added command `wp-env init` to generate a `.wp-env.json` file.
+
 ## 8.6.0 (2023-08-16)
 
 ## 8.5.0 (2023-08-10)

--- a/packages/env/README.md
+++ b/packages/env/README.md
@@ -473,6 +473,10 @@ $ wp-env install-path
 /home/user/.wp-env/63263e6506becb7b8613b02d42280a49
 ```
 
+### `wp-env init`
+
+Generates a .wp-env.json file into the current directory.
+
 ## .wp-env.json
 
 You can customize the WordPress installation, plugins and themes that the development environment will use by specifying a `.wp-env.json` file in the directory that you run `wp-env` from.

--- a/packages/env/lib/cli.js
+++ b/packages/env/lib/cli.js
@@ -253,6 +253,12 @@ module.exports = function cli() {
 		() => {},
 		withSpinner( env.installPath )
 	);
+	yargs.command(
+		'init',
+		'Generates a .wp-env.json file.',
+		() => {},
+		withSpinner( env.init )
+	);
 
 	return yargs;
 };

--- a/packages/env/lib/commands/index.js
+++ b/packages/env/lib/commands/index.js
@@ -9,6 +9,7 @@ const run = require( './run' );
 const destroy = require( './destroy' );
 const logs = require( './logs' );
 const installPath = require( './install-path' );
+const init = require( './init' );
 
 module.exports = {
 	start,
@@ -18,4 +19,5 @@ module.exports = {
 	destroy,
 	logs,
 	installPath,
+	init,
 };

--- a/packages/env/lib/commands/init.js
+++ b/packages/env/lib/commands/init.js
@@ -9,7 +9,7 @@ const { existsSync } = require( 'fs' );
 const inquirer = require( 'inquirer' );
 
 /**
- * Generates a .wp-env.json file.
+ * Generates a .wp-env.json file into the current directory.
  * @param {Object} options
  * @param {Object} options.spinner A CLI spinner which indicates progress.
  */

--- a/packages/env/lib/commands/init.js
+++ b/packages/env/lib/commands/init.js
@@ -1,0 +1,58 @@
+'use strict';
+
+/**
+ * External dependencies
+ */
+const { join } = require( 'path' );
+const { writeFile } = require( 'fs' ).promises;
+const { existsSync } = require( 'fs' );
+const inquirer = require( 'inquirer' );
+
+/**
+ * Generates a .wp-env.json file.
+ * @param {Object} options
+ * @param {Object} options.spinner A CLI spinner which indicates progress.
+ */
+module.exports = async function init( { spinner } ) {
+	spinner.info( 'Generates a .wp-env.json file.' );
+
+	if ( existsSync( '.wp-env.json' ) ) {
+		const { yesDelete } = await inquirer.prompt( [
+			{
+				type: 'confirm',
+				name: 'yesDelete',
+				message:
+					'".wp-env.json" file already exists. Are you sure you want to continue?',
+				default: false,
+			},
+		] );
+		if ( ! yesDelete ) {
+			spinner.text = 'Cancelled.';
+		}
+	}
+
+	const { type } = await inquirer.prompt( [
+		{
+			type: 'list',
+			name: 'type',
+			message: 'Which environment do you use wp-env?',
+			choices: [ 'Plugin', 'Theme' ],
+			default: 'Plugin',
+		},
+	] );
+
+	spinner.info( 'Generating a "wp-env.json" file.' );
+
+	await writeFile(
+		join( process.cwd(), '.wp-env.json' ),
+		JSON.stringify(
+			{
+				core: 'WordPress/WordPress',
+				...( type === 'Plugin' && { plugins: [ '.' ] } ),
+				...( type === 'Theme' && { themes: [ '.' ] } ),
+			},
+			null,
+			'\t'
+		)
+	);
+};


### PR DESCRIPTION
Fixes: #53962

## What?
This PR adds `init` command to wp-env with basic prompts.

![env-init](https://github.com/WordPress/gutenberg/assets/54422211/12f21da6-6ccc-4e58-a14d-6014e5ddea86)


## Why?
Developers who install the env package must manually create a .wp-env.json file. If this PR makes sense, then adding various prompts in the future would save the developer the trouble of having to refer to the documentation and manually add properties (`core`, `phpVersion`, `port`, `config`, etc.). If a JSON schema like the one suggested in #36275 is added, it may be also a good idea to include it in the `.wp-env.json`.

## How?
I have added `init` command with the following two prompts:

- Checks if there is already a `.wp-env.json` file and asks if you want to continue
- To add a `plugins` or `themes` property, ask which environment it is intended to be used in

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard

- In the Gutenberg repository, delete the `.wp-env.json` file.
- Run `./node_modules/.bin/wp-env init`
- Check help by running `./node_modules/.bin/wp-env init --help` command
