### PR TITLE
Post Editor: Fix browser console error when changing device preview mode

### DIFF
--- a/packages/edit-post/src/components/visual-editor/index.js
+++ b/packages/edit-post/src/components/visual-editor/index.js
@@ -180,7 +180,8 @@ export default function VisualEditor( { styles } ) {
 	const desktopCanvasStyles = {
 		height: '100%',
 		width: '100%',
-		margin: 0,
+		marginLeft: 'auto',
+		marginRight: 'auto',
 		display: 'flex',
 		flexFlow: 'column',
 		// Default background color so that grey


### PR DESCRIPTION
## What?

This PR fixes browser console errors when changing device preview mode in the Post Editor.

```
You are trying to animate marginLeft from "0" to "auto". 0 is not an animatable value - to enable this animation set 0 to a value animatable to auto via the `style` property. 
```

```
You are trying to animate marginRight from "0" to "auto". 0 is not an animatable value - to enable this animation set 0 to a value animatable to auto via the `style` property. 
```

https://github.com/WordPress/gutenberg/assets/54422211/b5e1d711-68f5-4e4e-9a2a-f001a5dbdd39

## Why?

In motion, it does not seem to be allowed to animate the margin from `0` to `auto`.

## How?
I have tried `margin: '0 auto'`, `margin: 0px auto`, etc., but could not get rid of the error. Finally, I was able to solve the problem by applying auto margin only to the left and right sides.

## Testing Instructions

- Open the Post Editor.
- Change the preview mode.
- No errors should appear in the browser console.
- Furthermore, nothing should have affected the layout of the initial desktop canvas or the template editing canvas.
