### PR TITLE
Fix: indicator style when block moving mode

### DIFF
--- a/packages/block-editor/src/components/block-list/content.scss
+++ b/packages/block-editor/src/components/block-list/content.scss
@@ -85,7 +85,6 @@
 	.block-editor-block-list__block.is-highlighted,
 	.block-editor-block-list__block.is-highlighted ~ .is-multi-selected,
 	&.is-navigate-mode .block-editor-block-list__block.is-selected,
-	& .is-block-moving-mode.block-editor-block-list__block.has-child-selected,
 	.block-editor-block-list__block:not([contenteditable]):focus {
 		outline: none;
 
@@ -113,8 +112,6 @@
 
 	// Moving blocks using keyboard (Ellipsis > Move).
 	& .is-block-moving-mode.block-editor-block-list__block.is-selected {
-		box-shadow: none;
-		outline: none;
 
 		&::after {
 			content: "";
@@ -130,6 +127,8 @@
 			top: -$default-block-margin * 0.5;
 			border-radius: $radius-block-ui;
 			border-top: 4px solid $gray-400;
+			bottom: auto;
+			box-shadow: none;
 		}
 	}
 


### PR DESCRIPTION
Fixes: #53920
Related to: #44150

## What?
This PR fixes the indicator style that is displayed when a "Move to" action is performed.

| Before | After |
|--------|--------|
| ![before](https://github.com/WordPress/gutenberg/assets/54422211/919c5285-bdc6-4770-94b5-542e6566d1ed) | ![after](https://github.com/WordPress/gutenberg/assets/54422211/6699b305-9ff2-4984-9b73-e7fdbe14aa39) | 

## Why?

The `.is-navigate-mode` class is added to the root container when the block editor is in Select mode. This class is used to highlight the selected block by the outline. When in Move Block mode, `.is-block-moving-mode` class is added to the destination block in addition to this CSS class. This class is used to display a horizontal bar indicator above the destination block.

In order for this bar to display correctly, the style applied by the `.is-navigate-mode` class must be overridden so that unnecessary styles, such as block outlines, are not applied.

## How?

Added override styles to correctly display the indicator bar. At the same time, I removed selectors that would never be applied.

## Testing Instructions

- Insert some blocks. You may also want to create nested blocks.
- Select "Move to" from the block toolbar.
- Make sure the indicator is displayed correctly.
- Press the up and down keys to move the indicator.
- To move in and out of the nested block, press the left and right keys.
- When you press the Enter key, the block move should be complete.

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/54422211/bb24013d-8a3a-4e23-8797-ba3d8e68559f