### PR TITLE
Docs: Extend the information about using `render` with `block.json`

### DIFF
--- a/docs/reference-guides/block-api/block-metadata.md
+++ b/docs/reference-guides/block-api/block-metadata.md
@@ -601,6 +601,16 @@ PHP file to use when rendering the block type on the server to show on the front
 -   `$content` (`string`): The block default content.
 -   `$block` (`WP_Block`): The block instance.
 
+An example implementation of the `render.php` file defined with `render` could look like:
+
+```php
+<div <?php echo get_block_wrapper_attributes(); ?>>
+	<?php echo $content; ?>
+</div>
+```
+
+_Note: This file loads for every instance of the block type when rendering a single page. Accounting for that is essential when declaring functions or classes in the file. The simplest way to avoid the risk of errors is to consume that shared logic from another file._
+
 ## Assets
 
 ### `WPDefinedPath`

--- a/docs/reference-guides/block-api/block-metadata.md
+++ b/docs/reference-guides/block-api/block-metadata.md
@@ -605,7 +605,7 @@ An example implementation of the `render.php` file defined with `render` could l
 
 ```php
 <div <?php echo get_block_wrapper_attributes(); ?>>
-	<?php echo $content; ?>
+	<?php echo esc_html( $attributes['label'] ); ?>
 </div>
 ```
 

--- a/docs/reference-guides/block-api/block-metadata.md
+++ b/docs/reference-guides/block-api/block-metadata.md
@@ -609,7 +609,7 @@ An example implementation of the `render.php` file defined with `render` could l
 </div>
 ```
 
-_Note: This file loads for every instance of the block type when rendering a single page. Accounting for that is essential when declaring functions or classes in the file. The simplest way to avoid the risk of errors is to consume that shared logic from another file._
+_Note: This file loads for every instance of the block type when rendering the page HTML on the server. Accounting for that is essential when declaring functions or classes in the file. The simplest way to avoid the risk of errors is to consume that shared logic from another file._
 
 ## Assets
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Closes #47826.

Cover the last missing part of the improvements around the usage of `render` field with `blocks.json`:

> We could also include an example of how to use available variables in this document:
https://github.com/WordPress/gutenberg/blob/trunk/docs/reference-guides/block-api/block-metadata.md#render

## Why

It will help to address concerns people have when using examples how the PHP file implementing `render` field could look like. Originally reported on WordPress Slack (link requires registration at https://make.wordpress.org/chat/) in https://wordpress.slack.com/archives/C02QB2JS7/p1675506119596039. I also popped up in the context of function and classes declaration in https://wordpress.slack.com/archives/C02QB2JS7/p1692791842083579.

## How

I extended the section at https://github.com/WordPress/gutenberg/blob/trunk/docs/reference-guides/block-api/block-metadata.md#render.