### PR TITLE
Post Title block should use esc_url()

### DIFF
--- a/packages/block-library/src/post-title/index.php
+++ b/packages/block-library/src/post-title/index.php
@@ -38,7 +38,7 @@ function render_block_core_post_title( $attributes, $content, $block ) {
 
 	if ( isset( $attributes['isLink'] ) && $attributes['isLink'] ) {
 		$rel   = ! empty( $attributes['rel'] ) ? 'rel="' . esc_attr( $attributes['rel'] ) . '"' : '';
-		$title = sprintf( '<a href="%1$s" target="%2$s" %3$s>%4$s</a>', get_the_permalink( $block->context['postId'] ), esc_attr( $attributes['linkTarget'] ), $rel, $title );
+		$title = sprintf( '<a href="%1$s" target="%2$s" %3$s>%4$s</a>', esc_url( get_the_permalink( $block->context['postId'] ) ), esc_attr( $attributes['linkTarget'] ), $rel, $title );
 	}
 
 	$classes = array();


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This PR adds URL escaping to the html output rendered by the Post Title block. It is not an issue of security, only of code quality.

## Why?
Good WP coding standards require the use of `esc_url()` when outputting a URL. This applies even to URLs generated by core functions such as `get_the_permalink()`; see for reference the Twenty Twenty One theme, which does exactly that:

https://github.com/WordPress/twentytwentyone/blob/ba9f20cad89163761185c0467b346ba42541ae22/template-parts/content/content.php#L19

The Post Title block currently fails to escape the URL.

For the record, the Post Title block also fails to escape the title itself; however this is correct behaviour as per the docs: https://developer.wordpress.org/reference/functions/the_title/#more-information. Personally I think that position ought to be reconsidered, but that's a whole other issue, so I have intentionally left it as-is for this PR.

Related: #53838.

## How?
The only change in this PR is adding the `esc_url()` call.

## Testing Instructions
1. Open any page with a Post Title block.
2. Verify that the `href` in the link tag for the `#wp-block-post-title` is correct.

## Screenshots or screencast <!-- if applicable -->
