### PR TITLE
Always render the fallback Popover anchor within the Popover's parent element

### DIFF
--- a/packages/components/src/popover/index.tsx
+++ b/packages/components/src/popover/index.tsx
@@ -569,17 +569,16 @@ const UnforwardedPopover = (
 
 	if ( shouldRenderWithinSlot ) {
 		content = <Fill name={ slotName }>{ content }</Fill>;
+	} else if ( ! inline ) {
+		content = createPortal( content, getPopoverFallbackContainer() );
 	}
 
-	if ( ! hasAnchor ) {
-		content = <span ref={ anchorRefFallback }>{ content }</span>;
-	}
-
-	if ( shouldRenderWithinSlot || inline ) {
-		return content;
-	}
-
-	return createPortal( content, getPopoverFallbackContainer() );
+	return (
+		<>
+			{ ! hasAnchor && <span ref={ anchorRefFallback } /> }
+			{ content }
+		</>
+	);
 };
 
 /**

--- a/packages/components/src/popover/index.tsx
+++ b/packages/components/src/popover/index.tsx
@@ -573,9 +573,13 @@ const UnforwardedPopover = (
 		content = createPortal( content, getPopoverFallbackContainer() );
 	}
 
+	if ( ! hasAnchor ) {
+		return content;
+	}
+
 	return (
 		<>
-			{ ! hasAnchor && <span ref={ anchorRefFallback } /> }
+			<span ref={ anchorRefFallback } />
 			{ content }
 		</>
 	);

--- a/packages/components/src/popover/index.tsx
+++ b/packages/components/src/popover/index.tsx
@@ -573,7 +573,7 @@ const UnforwardedPopover = (
 		content = createPortal( content, getPopoverFallbackContainer() );
 	}
 
-	if ( ! hasAnchor ) {
+	if ( hasAnchor ) {
 		return content;
 	}
 

--- a/packages/nux/src/components/dot-tip/test/__snapshots__/index.js.snap
+++ b/packages/nux/src/components/dot-tip/test/__snapshots__/index.js.snap
@@ -5,7 +5,7 @@ exports[`DotTip should render correctly 1`] = `
   aria-label="Editor tips"
   class="components-popover nux-dot-tip is-positioned"
   role="dialog"
-  style="position: absolute; top: 0px; left: 0px; opacity: 0; transform: translateX(0px) translateY(0px) translateX(-2em) scale(0) translateZ(0); transform-origin: 0% 50% 0;"
+  style="position: absolute; top: 0px; left: 0px; opacity: 1; transform: none; transform-origin: 0% 50% 0;"
   tabindex="-1"
 >
   <div

--- a/packages/nux/src/components/dot-tip/test/index.js
+++ b/packages/nux/src/components/dot-tip/test/index.js
@@ -1,15 +1,13 @@
 /**
  * External dependencies
  */
-import { act, render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 /**
  * Internal dependencies
  */
 import { DotTip } from '..';
-
-const noop = () => {};
 
 describe( 'DotTip', () => {
 	beforeEach( () => {
@@ -20,26 +18,26 @@ describe( 'DotTip', () => {
 		jest.useRealTimers();
 	} );
 
-	it( 'should not render anything if invisible', async () => {
+	it( 'should not render anything if invisible', () => {
 		render(
 			<DotTip>
 				It looks like you’re writing a letter. Would you like help?
 			</DotTip>
 		);
 
-		await act( () => Promise.resolve() );
-
 		expect( screen.queryByRole( 'dialog' ) ).not.toBeInTheDocument();
 	} );
 
 	it( 'should render correctly', async () => {
 		render(
-			<DotTip isVisible setTimeout={ noop }>
+			<DotTip isVisible>
 				It looks like you’re writing a letter. Would you like help?
 			</DotTip>
 		);
 
-		await act( () => Promise.resolve() );
+		await waitFor( () =>
+			expect( screen.getByRole( 'dialog' ) ).toBePositionedPopover()
+		);
 
 		expect( screen.getByRole( 'dialog' ) ).toMatchSnapshot();
 	} );
@@ -51,12 +49,14 @@ describe( 'DotTip', () => {
 		const onDismiss = jest.fn();
 
 		render(
-			<DotTip isVisible onDismiss={ onDismiss } setTimeout={ noop }>
+			<DotTip isVisible onDismiss={ onDismiss }>
 				It looks like you’re writing a letter. Would you like help?
 			</DotTip>
 		);
 
-		await act( () => Promise.resolve() );
+		await waitFor( () =>
+			expect( screen.getByRole( 'dialog' ) ).toBePositionedPopover()
+		);
 
 		await user.click( screen.getByRole( 'button', { name: 'Got it' } ) );
 
@@ -70,12 +70,14 @@ describe( 'DotTip', () => {
 		const onDisable = jest.fn();
 
 		render(
-			<DotTip isVisible onDisable={ onDisable } setTimeout={ noop }>
+			<DotTip isVisible onDisable={ onDisable }>
 				It looks like you’re writing a letter. Would you like help?
 			</DotTip>
 		);
 
-		await act( () => Promise.resolve() );
+		await waitFor( () =>
+			expect( screen.getByRole( 'dialog' ) ).toBePositionedPopover()
+		);
 
 		await user.click(
 			screen.getByRole( 'button', { name: 'Disable tips' } )


### PR DESCRIPTION
Fix https://github.com/WordPress/gutenberg/pull/53889#issuecomment-1693715653
Regression introduced in #53889

## What?

We did a small refactor to how popover renders in #53889 but introduce a small subtle regression. Basically if the Popover doesn't define an "anchor", we used to render the anchor inline while after #53889 it has been mistakenly "portaled" to the popover container. This PR solves that by always rendering the popover anchor inline.

## Testing Instructions

1- Run storybook `npm run storybook:dev`
2- The default popover story should work properly.

## ✍️  Dev Note

As part of a wider effort to streamline the developer experience of using Gutenberg as a platform/framework to build block editors, the `Popover` component has been tweaked so that it's not necessary anymore to manually specify a `Popover.Slot` component (and a `SlotFillProvider`) somewhere in the React tree.

The `Popover` component now works out of the box, and the `Popover.Slot` component can be optionally used to tweak where the popover should render in the DOM tree.

A side-effect of this change is that some instances of `Popover` may not render inline anymore when a `Popover.Slot` is not rendered on the page, affecting both the popover's DOM position and the styles inherited via the CSS cascade. To mitigate this use case, a new `inline` prop has been added to the `Popover` component, to force the component to render inline, thus preserving the legacy behavior.