### PR TITLE
Keeping heading style when prior block is empty on merging

### DIFF
--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -1111,6 +1111,23 @@ export const mergeBlocks =
 			return;
 		}
 
+		// If previous block is empty, remove previous block and update selection.
+		const blockAHasEmptyContent = blockA?.attributes.content === '';
+		if ( blockAHasEmptyContent && blockB?.attributes.content ) {
+			dispatch.removeBlock( clientIdA );
+
+			if ( canRestoreTextSelection ) {
+				dispatch.selectionChange(
+					blockB.clientId,
+					attributeKey,
+					offset,
+					offset
+				);
+			}
+
+			return;
+		}
+
 		// Calling the merge to update the attributes and remove the block to be merged.
 		const updatedAttributes = blockAType.merge(
 			cloneA.attributes,
@@ -1148,18 +1165,20 @@ export const mergeBlocks =
 			);
 		}
 
+		const replacementBlocks = [
+			{
+				...blockA,
+				attributes: {
+					...blockA.attributes,
+					...updatedAttributes,
+				},
+			},
+			...blocksWithTheSameType.slice( 1 ),
+		];
+
 		dispatch.replaceBlocks(
 			[ blockA.clientId, blockB.clientId ],
-			[
-				{
-					...blockA,
-					attributes: {
-						...blockA.attributes,
-						...updatedAttributes,
-					},
-				},
-				...blocksWithTheSameType.slice( 1 ),
-			],
+			replacementBlocks,
 			0 // If we don't pass the `indexToSelect` it will default to the last block.
 		);
 	};

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -13,6 +13,7 @@ import {
 	switchToBlockType,
 	synchronizeBlocksWithTemplate,
 	getBlockSupport,
+	isUnmodifiedBlock,
 } from '@wordpress/blocks';
 import { speak } from '@wordpress/a11y';
 import { __, _n, sprintf } from '@wordpress/i18n';
@@ -1112,19 +1113,10 @@ export const mergeBlocks =
 		}
 
 		// If previous block is empty, remove previous block and update selection.
-		const blockAHasEmptyContent = blockA?.attributes.content === '';
-		const blockBHastEmptyContent = blockB?.attributes.content === '';
+		const blockAHasEmptyContent = isUnmodifiedBlock( blockA );
+		const blockBHastEmptyContent = isUnmodifiedBlock( blockB );
 		if ( blockAHasEmptyContent && ! blockBHastEmptyContent ) {
-			dispatch.removeBlock( clientIdA );
-
-			if ( canRestoreTextSelection ) {
-				dispatch.selectionChange(
-					blockB.clientId,
-					attributeKey,
-					offset,
-					offset
-				);
-			}
+			dispatch.removeBlock( clientIdA, false );
 
 			return;
 		}

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -1113,7 +1113,8 @@ export const mergeBlocks =
 
 		// If previous block is empty, remove previous block and update selection.
 		const blockAHasEmptyContent = blockA?.attributes.content === '';
-		if ( blockAHasEmptyContent && blockB?.attributes.content ) {
+		const blockBHastEmptyContent = blockB?.attributes.content === '';
+		if ( blockAHasEmptyContent && ! blockBHastEmptyContent ) {
 			dispatch.removeBlock( clientIdA );
 
 			if ( canRestoreTextSelection ) {
@@ -1165,20 +1166,18 @@ export const mergeBlocks =
 			);
 		}
 
-		const replacementBlocks = [
-			{
-				...blockA,
-				attributes: {
-					...blockA.attributes,
-					...updatedAttributes,
-				},
-			},
-			...blocksWithTheSameType.slice( 1 ),
-		];
-
 		dispatch.replaceBlocks(
 			[ blockA.clientId, blockB.clientId ],
-			replacementBlocks,
+			[
+				{
+					...blockA,
+					attributes: {
+						...blockA.attributes,
+						...updatedAttributes,
+					},
+				},
+				...blocksWithTheSameType.slice( 1 ),
+			],
 			0 // If we don't pass the `indexToSelect` it will default to the last block.
 		);
 	};

--- a/test/e2e/specs/editor/various/splitting-merging.spec.js
+++ b/test/e2e/specs/editor/various/splitting-merging.spec.js
@@ -262,15 +262,16 @@ test.describe( 'splitting and merging blocks (@firefox, @webkit)', () => {
 	} ) => {
 		await editor.insertBlock( { name: 'core/paragraph' } );
 		await editor.insertBlock( { name: 'core/heading' } );
-		await page.keyboard.type( 'Heading' );
-		await pageUtils.pressKeys( 'ArrowLeft', { times: 7 } );
+		await page.keyboard.type( 'a' );
+		await pageUtils.pressKeys( 'ArrowLeft' );
 		await page.keyboard.press( 'Backspace' );
+		await page.keyboard.type( 'b' );
 
 		// Check the content.
 		const content = await editor.getEditedPostContent();
 		expect( content ).toBe(
 			`<!-- wp:heading -->
-<h2 class="wp-block-heading">Heading</h2>
+<h2 class="wp-block-heading">ba</h2>
 <!-- /wp:heading -->`
 		);
 	} );

--- a/test/e2e/specs/editor/various/splitting-merging.spec.js
+++ b/test/e2e/specs/editor/various/splitting-merging.spec.js
@@ -12,65 +12,6 @@ test.describe( 'splitting and merging blocks (@firefox, @webkit)', () => {
 		await requestUtils.deleteAllPosts();
 	} );
 
-	test( 'should not merge heading with empty paragraph block on backspace', async ( {
-		editor,
-		page,
-		pageUtils
-	} ) => {
-		await editor.insertBlock( { name: 'core/paragraph' } );
-		await editor.insertBlock( { name: 'core/heading' } );
-		await page.keyboard.type( 'Heading' );
-		await pageUtils.pressKeys( 'ArrowLeft', { times: 7 } );
-		await page.keyboard.press( 'Backspace' );
-
-		// Check the content.
-		const content = await editor.getEditedPostContent();
-		expect( content ).toBe(
-			`<!-- wp:heading -->
-<h2 class="wp-block-heading">Heading</h2>
-<!-- /wp:heading -->`
-		);
-	} );
-
-	test( 'should gracefully handle if placing caret in empty container', async ( {
-		editor,
-		page,
-		pageUtils,
-	} ) => {
-		// Regression Test: placeCaretAtHorizontalEdge previously did not
-		// account for contentEditables which have no children.
-		//
-		// See: https://github.com/WordPress/gutenberg/issues/8676
-		await editor.insertBlock( { name: 'core/paragraph' } );
-		await page.keyboard.type( 'Foo' );
-
-		// The regression appeared to only affect paragraphs created while
-		// within an inline boundary.
-		await page.keyboard.down( 'Shift' );
-		await pageUtils.pressKeys( 'ArrowLeft', { times: 3 } );
-		await page.keyboard.up( 'Shift' );
-		await pageUtils.pressKeys( 'primary+b' );
-		await page.keyboard.press( 'ArrowRight' );
-		await page.keyboard.press( 'Enter' );
-		await page.keyboard.press( 'Enter' );
-
-		await page.keyboard.press( 'Backspace' );
-
-		// Check the content.
-		const content = await editor.getEditedPostContent();
-		expect( content ).toBe(
-			`<!-- wp:paragraph -->
-<p><strong>Foo</strong></p>
-<!-- /wp:paragraph -->
-
-<!-- wp:paragraph -->
-<p></p>
-<!-- /wp:paragraph -->`
-		);
-	} );
-
-	return;
-
 	test( 'should split and merge paragraph blocks using Enter and Backspace', async ( {
 		editor,
 		page,
@@ -317,6 +258,7 @@ test.describe( 'splitting and merging blocks (@firefox, @webkit)', () => {
 	test( 'should not merge heading with empty paragraph block on backspace', async ( {
 		editor,
 		page,
+		pageUtils,
 	} ) => {
 		await editor.insertBlock( { name: 'core/paragraph' } );
 		await editor.insertBlock( { name: 'core/heading' } );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Address the issue on https://github.com/WordPress/gutenberg/issues/16436 cc: @ellatrix 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
- When Pressing `backspace` on Heading block, it is merged with the empty prior paragraph where its attribute will be [replaced with Paragraph attribute](https://github.com/WordPress/gutenberg/blob/564b646a5043b1aa321fa061e5ae744e2118ab2c/packages/block-editor/src/store/actions.js#L1104), therefore Heading is lost and replaced with regular Paragraph

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Check for the content of the blocks and remove the previous block in case it has empty content
- Assume there are 2 blockA and blockB in the editor, caret is place at start of blockB
   -  ➖ is empty text
   - 🆎 is non-empty text

| blockA | blockB | Actions |
| ------ | ------ | ------- |
| ➖      | ➖      |    Merge B to A     |
| ➖      | 🆎      |    **_Remove A_**     |
| 🆎      | ➖      |    Merge B to A     |
| 🆎      | 🆎      |    Merge B to A    |

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Insert an empty paragraph
- Insert a Heading
- Place caret at the Heading start and press `backspace`
- Expect the paragraph is removed and the heading is kept with its style

## E2E testings
- Introduce new test suite `should not merge heading with empty paragraph block on backspace`
- Run against `npm run test:e2e:playwright -- test/e2e/specs/editor/various/splitting-merging.spec.js`
- ~~Test failed on [should gracefully handle if placing caret in empty container](https://github.com/WordPress/gutenberg/blob/6c2a629d47197dfa229739135c13eb6a147f7ca3/test/e2e/specs/editor/various/splitting-merging.spec.js#L182)~~
    - ~~Reason: the backspace removes all empty paragraphs, making the snapshot mismatch~~

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/10071857/cad000fa-d8d4-4d13-adec-8401c051430c


