### PR TITLE
PaletteEdit: Fix component height

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Bug Fix
 
 -   `SandBox`: Fix the cleanup method in useEffect ([#53796](https://github.com/WordPress/gutenberg/pull/53796)).
+-   `PaletteEdit`: Fix the height of the `PaletteItems`. Don't rely on styles only present in the block editor ([#54000](https://github.com/WordPress/gutenberg/pull/54000)).
 
 ### Internal
 

--- a/packages/components/src/palette-edit/styles.js
+++ b/packages/components/src/palette-edit/styles.js
@@ -42,7 +42,6 @@ export const NameInputControl = styled( InputControl )`
 
 export const PaletteItem = styled( View )`
 	padding: 3px 0 3px ${ space( 3 ) };
-	height: calc( 40px - ${ CONFIG.borderWidth } );
 	border: 1px solid ${ CONFIG.surfaceBorderColor };
 	border-bottom-color: transparent;
 	&:first-of-type {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
See #49041

Fixes `PaletteEdit` height, both in the editor and in the storybook.

## Why?
The component has less padding below the input field (1px) in the block editor, and in the storybook at was way to heigh. This PR fixes so the padding issue and so the height doesn't depend on style only present in the block editor.

## How?
Remove the height from the container. The elements inside the container is styled to have the same height so the container doesn't need it. (Alternative approach would be to set correct height on the container and add boxSizing).

## Testing Instructions
1. Test the component in the storybook.
2. Test the component in the site editor.
3. Height should be the same both everywhere.

## Screenshots or screencast <!-- if applicable -->

### Editor
| Before | After |
|-----|-----|
| <img width="280" alt="image" src="https://github.com/WordPress/gutenberg/assets/1415747/ab8964d9-d4aa-4f94-abc9-5eedbf2d8b3d">| <img width="280" alt="image" src="https://github.com/WordPress/gutenberg/assets/1415747/2422b9ab-9d00-460c-aa66-3487bac46e1d"> |

### Storybook
| Before | After |
|-----|-----|
| <img width="280" alt="image" src="https://github.com/WordPress/gutenberg/assets/1415747/ef014d68-a28d-4c06-9a78-64f76736ddb6"> | <img width="280" alt="image" src="https://github.com/WordPress/gutenberg/assets/1415747/b6d3aa2f-635f-45ae-b211-c2ea30aea53b"> |

