### PR TITLE
Interactivity API: Update `data-wp-bind` directive logic

### DIFF
--- a/packages/e2e-tests/plugins/interactive-blocks/directive-bind/render.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-bind/render.php
@@ -59,14 +59,13 @@
 
 	<?php
 		$hydration_cases = array(
-			'false'          => '{ "disabled": false }',
-			'true'           => '{ "disabled": true }',
-			'string "false"' => '{ "disabled": "false" }',
-			'string "true"'  => '{ "disabled": "true" }',
-			'null'           => '{ "disabled": null }',
-			'undefined'      => '{ "other": "other" }',
-			'empty string'   => '{ "disabled": "" }',
-			'any string'     => '{ "disabled": "any" }',
+			'false'       => '{ "value": false }',
+			'true'        => '{ "value": true }',
+			'null'        => '{ "value": null }',
+			'undef'       => '{ "__any": "any" }',
+			'emptyString' => '{ "value": "" }',
+			'anyString'   => '{ "value": "any" }',
+			'number'      => '{ "value": 10 }'
 		);
 	?>
 
@@ -75,16 +74,25 @@
 		data-testid='hydrating <?php echo $type; ?>'
 		data-wp-context='<?php echo $context; ?>'
 	>
+		<img
+			alt="Red dot"
+			data-testid="image"
+			data-wp-bind--width="context.value"
+			src="data:image/png;base64, iVBORw0KGgoAAAANSUhEUgAAAAUA
+			AAAFCAYAAACNbyblAAAAHElEQVQI12P4//8/w38GIAXDIBKE0DHxgljNBAAO
+			9TXL0Y4OHwAAAABJRU5ErkJggg=="
+		>
 		<input
 			type="text"
 			data-testid="input"
-			data-wp-bind--disabled="context.disabled"
-			data-wp-bind--aria-disabled="context.disabled"
-			data-wp-bind--data-disabled="context.disabled"
+			data-wp-bind--name="context.value"
+			data-wp-bind--value="context.value"
+			data-wp-bind--disabled="context.value"
+			data-wp-bind--aria-disabled="context.value"
 		>
 		<button
-			data-testid="toggle-prop"
-			data-wp-on--click="actions.toggleDisabled"
+			data-testid="toggle value"
+			data-wp-on--click="actions.toggleValue"
 		>Toggle</button>
 	</div>
 	<?php endforeach; ?>

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-bind/render.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-bind/render.php
@@ -56,4 +56,36 @@
 	>
 		Some Text
 	</p>
+
+	<?php
+		$hydration_cases = array(
+			'false'          => '{ "disabled": false }',
+			'true'           => '{ "disabled": true }',
+			'string "false"' => '{ "disabled": "false" }',
+			'string "true"'  => '{ "disabled": "true" }',
+			'null'           => '{ "disabled": null }',
+			'undefined'      => '{ "other": "other" }',
+			'empty string'   => '{ "disabled": "" }',
+			'any string'     => '{ "disabled": "any" }',
+		);
+	?>
+
+	<?php foreach( $hydration_cases as $type => $context ): ?>
+	<div
+		data-testid='hydrating <?php echo $type; ?>'
+		data-wp-context='<?php echo $context; ?>'
+	>
+		<input
+			type="text"
+			data-testid="input"
+			data-wp-bind--disabled="context.disabled"
+			data-wp-bind--aria-disabled="context.disabled"
+			data-wp-bind--data-disabled="context.disabled"
+		>
+		<button
+			data-testid="toggle-prop"
+			data-wp-on--click="actions.toggleDisabled"
+		>Toggle</button>
+	</div>
+	<?php endforeach; ?>
 </div>

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-bind/render.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-bind/render.php
@@ -58,18 +58,18 @@
 	</p>
 
 	<?php
-		$hydration_cases = array(
-			'false'       => '{ "value": false }',
-			'true'        => '{ "value": true }',
-			'null'        => '{ "value": null }',
-			'undef'       => '{ "__any": "any" }',
-			'emptyString' => '{ "value": "" }',
-			'anyString'   => '{ "value": "any" }',
-			'number'      => '{ "value": 10 }'
-		);
+	$hydration_cases = array(
+		'false'       => '{ "value": false }',
+		'true'        => '{ "value": true }',
+		'null'        => '{ "value": null }',
+		'undef'       => '{ "__any": "any" }',
+		'emptyString' => '{ "value": "" }',
+		'anyString'   => '{ "value": "any" }',
+		'number'      => '{ "value": 10 }',
+	);
 	?>
 
-	<?php foreach( $hydration_cases as $type => $context ): ?>
+	<?php foreach ( $hydration_cases as $type => $context ) : ?>
 	<div
 		data-testid='hydrating <?php echo $type; ?>'
 		data-wp-context='<?php echo $context; ?>'

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-bind/view.js
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-bind/view.js
@@ -18,15 +18,16 @@
 				state.show = ! state.show;
 				state.width += foo.bar;
 			},
-			toggleDisabled: ( { context } ) => {
-				const prevDisabled = ( 'prevDisabled' in context )
-					? context.prevDisabled
+			toggleValue: ( { context } ) => {
+				const previousValue = ( 'previousValue' in context )
+					? context.previousValue
 					// Any string works here; we just want to toggle the value
-					// to ensure Preact renders the same we are hydrating.
-					: 'disabled';
+					// to ensure Preact renders the same we are hydrating in the
+					// first place.
+					: 'tacocat';
 
-				context.prevDisabled = context.disabled;
-				context.disabled = prevDisabled;
+				context.previousValue = context.value;
+				context.value = previousValue;
 			}
 		},
 	} );

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-bind/view.js
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-bind/view.js
@@ -18,6 +18,16 @@
 				state.show = ! state.show;
 				state.width += foo.bar;
 			},
+			toggleDisabled: ( { context } ) => {
+				const prevDisabled = ( 'prevDisabled' in context )
+					? context.prevDisabled
+					// Any string works here; we just want to toggle the value
+					// to ensure Preact renders the same we are hydrating.
+					: 'disabled';
+
+				context.prevDisabled = context.disabled;
+				context.disabled = prevDisabled;
+			}
 		},
 	} );
 } )( window );

--- a/packages/interactivity/CHANGELOG.md
+++ b/packages/interactivity/CHANGELOG.md
@@ -7,6 +7,7 @@
 -   Support keys using `data-wp-key`. ([#53844](https://github.com/WordPress/gutenberg/pull/53844))
 -   Merge new server-side rendered context on client-side navigation. ([#53853](https://github.com/WordPress/gutenberg/pull/53853))
 -   Support region-based client-side navigation. ([#53733](https://github.com/WordPress/gutenberg/pull/53733))
+-   Improve `data-wp-bind` hydration to match Preact's logic. ([#54003](https://github.com/WordPress/gutenberg/pull/54003))
 
 ## 2.1.0 (2023-08-16)
 

--- a/packages/interactivity/src/directives.js
+++ b/packages/interactivity/src/directives.js
@@ -226,7 +226,12 @@ export default () => {
 						// A `false` value is different from the attribute not being
 						// present, so we can't remove it.
 						// We follow Preact's logic: https://github.com/preactjs/preact/blob/ea49f7a0f9d1ff2c98c0bdd66aa0cbc583055246/src/diff/props.js#L131C24-L136
-						if ( result === false && attribute[ 4 ] !== '-' ) {
+						if (
+							( result === false ||
+								result === undefined ||
+								result === null ) &&
+							attribute[ 4 ] !== '-'
+						) {
 							element.ref.current.removeAttribute( attribute );
 						} else {
 							element.ref.current.setAttribute(

--- a/packages/interactivity/src/directives.js
+++ b/packages/interactivity/src/directives.js
@@ -247,7 +247,6 @@ export default () => {
 									result === null || result === undefined
 										? ''
 										: result;
-								// labelled break is 1b smaller here than a return statement (sorry)
 								return;
 							} catch ( err ) {}
 						}

--- a/packages/interactivity/src/directives.js
+++ b/packages/interactivity/src/directives.js
@@ -224,6 +224,10 @@ export default () => {
 					useEffect( () => {
 						const el = element.ref.current;
 
+						// We set the value directly to the corresponding
+						// HTMLElement instance property excluding the following
+						// special cases.
+						// We follow Preact's logic: https://github.com/preactjs/preact/blob/ea49f7a0f9d1ff2c98c0bdd66aa0cbc583055246/src/diff/props.js#L110-L129
 						if (
 							attribute !== 'width' &&
 							attribute !== 'height' &&

--- a/packages/interactivity/src/directives.js
+++ b/packages/interactivity/src/directives.js
@@ -255,7 +255,8 @@ export default () => {
 						// present, so we can't remove it.
 						// We follow Preact's logic: https://github.com/preactjs/preact/blob/ea49f7a0f9d1ff2c98c0bdd66aa0cbc583055246/src/diff/props.js#L131C24-L136
 						if (
-							( result !== null || result !== undefined ) &&
+							result !== null &&
+							result !== undefined &&
 							( result !== false || attribute[ 4 ] === '-' )
 						) {
 							el.setAttribute( attribute, result );

--- a/packages/interactivity/src/directives.js
+++ b/packages/interactivity/src/directives.js
@@ -222,24 +222,42 @@ export default () => {
 					// on the hydration, so we have to do it manually. It doesn't need
 					// deps because it only needs to do it the first time.
 					useEffect( () => {
+						const el = element.ref.current;
+
+						if (
+							attribute !== 'width' &&
+							attribute !== 'height' &&
+							attribute !== 'href' &&
+							attribute !== 'list' &&
+							attribute !== 'form' &&
+							// Default value in browsers is `-1` and an empty string is
+							// cast to `0` instead
+							attribute !== 'tabIndex' &&
+							attribute !== 'download' &&
+							attribute !== 'rowSpan' &&
+							attribute !== 'colSpan' &&
+							attribute in el
+						) {
+							try {
+								el[ attribute ] =
+									result === null || result === undefined
+										? ''
+										: result;
+								// labelled break is 1b smaller here than a return statement (sorry)
+								return;
+							} catch ( err ) {}
+						}
 						// aria- and data- attributes have no boolean representation.
 						// A `false` value is different from the attribute not being
 						// present, so we can't remove it.
 						// We follow Preact's logic: https://github.com/preactjs/preact/blob/ea49f7a0f9d1ff2c98c0bdd66aa0cbc583055246/src/diff/props.js#L131C24-L136
 						if (
-							( result === false ||
-								result === undefined ||
-								result === null ) &&
-							attribute[ 4 ] !== '-'
+							( result !== null || result !== undefined ) &&
+							( result !== false || attribute[ 4 ] === '-' )
 						) {
-							element.ref.current.removeAttribute( attribute );
+							el.setAttribute( attribute, result );
 						} else {
-							element.ref.current.setAttribute(
-								attribute,
-								result === true && attribute[ 4 ] !== '-'
-									? ''
-									: result
-							);
+							el.removeAttribute( attribute );
 						}
 					}, [] );
 				} );

--- a/test/e2e/specs/interactivity/directive-bind.spec.ts
+++ b/test/e2e/specs/interactivity/directive-bind.spec.ts
@@ -93,4 +93,65 @@ test.describe( 'data-wp-bind', () => {
 		await expect( el ).toHaveAttribute( 'aria-expanded', 'true' );
 		await expect( el ).toHaveAttribute( 'data-some-value', 'true' );
 	} );
+
+	// `width`:    using the red-dot image (default value comes from image)
+	// `tabIndex`: can be a div (default value is -1)
+	// `hidden`:   can be a div (values are treated as boolean)
+	// `value`:    a text input (can be any string)
+	// `aria-disabled`: an input field
+	// `data-disabled`: the same input field
+
+	test.describe( 'attribute hydration', () => {
+		const cases = [
+			{ type: 'false', attrValues: [ null, 'false' ] },
+			{ type: 'true', attrValues: [ '', 'true' ] },
+			{ type: 'string "false"', attrValues: [ '', 'false' ] },
+			{ type: 'string "true"', attrValues: [ '', 'true' ] },
+			{ type: 'null', attrValues: [ null, null ] },
+			{ type: 'undefined', attrValues: [ null, null ] },
+			{ type: 'empty string', attrValues: [ null, '' ] },
+			{ type: 'any string', attrValues: [ '', 'any' ] },
+		];
+
+		for ( const {
+			type,
+			attrValues: [ regularValue, ariaDataValue ],
+		} of cases ) {
+			test( `works for ${ type } values correctly`, async ( {
+				page,
+			} ) => {
+				const el = page.getByTestId( `hydrating ${ type }` );
+				const input = el.getByTestId( 'input' );
+				const toggle = el.getByTestId( 'toggle-prop' );
+
+				const initialValues = {
+					ariaDisabled: await input.getAttribute( 'aria-disabled' ),
+					dataDisabled: await input.getAttribute( 'data-disabled' ),
+					disabled: await input.getAttribute( 'disabled' ),
+				};
+
+				expect( initialValues.disabled ).toBe( regularValue );
+				expect( initialValues.ariaDisabled ).toBe( ariaDataValue );
+				expect( initialValues.dataDisabled ).toBe( ariaDataValue );
+
+				// Here we check that the hydrated values match the rendered
+				// values.
+				await toggle.click( { clickCount: 2, delay: 50 } );
+
+				const finalValues = {
+					ariaDisabled: await input.getAttribute( 'aria-disabled' ),
+					dataDisabled: await input.getAttribute( 'data-disabled' ),
+					disabled: await input.getAttribute( 'disabled' ),
+				};
+
+				expect( initialValues.disabled ).toBe( finalValues.disabled );
+				expect( initialValues.ariaDisabled ).toBe(
+					finalValues.ariaDisabled
+				);
+				expect( initialValues.dataDisabled ).toBe(
+					finalValues.dataDisabled
+				);
+			} );
+		}
+	} );
 } );

--- a/test/e2e/specs/interactivity/directive-bind.spec.ts
+++ b/test/e2e/specs/interactivity/directive-bind.spec.ts
@@ -95,7 +95,43 @@ test.describe( 'data-wp-bind', () => {
 	} );
 
 	test.describe( 'attribute hydration', () => {
-		const matrix = [
+		/**
+		 * Data structure to define a hydration test case.
+		 */
+		type MatrixEntry = {
+			/**
+			 * Test ID of the element (the `data-testid` attr).
+			 */
+			testid: string;
+			/**
+			 *  Name of the attribute being hydrated.
+			 */
+			name: string;
+			/**
+			 * Array of different values to test.
+			 */
+			values: Record<
+				/**
+				 * The type of value we are hydrating. E.g., false is `false`,
+				 * undef is `undefined`, emptyString is `''`, etc.
+				 */
+				string,
+				[
+					/**
+					 * Value that the attribute should contain after hydration.
+					 * If the attribute is missing, this value is `null`.
+					 */
+					attributeValue: any,
+					/**
+					 * Value that the HTMLElement instance property should
+					 * contain after hydration.
+					 */
+					entityPropValue: any
+				]
+			>;
+		};
+
+		const matrix: MatrixEntry[] = [
 			{
 				testid: 'image',
 				name: 'width',
@@ -168,7 +204,7 @@ test.describe( 'data-wp-bind', () => {
 				page,
 			} ) => {
 				for ( const type in values ) {
-					const [ attrValue, propValue ] = ( values as any )[ type ];
+					const [ attrValue, propValue ] = values[ type ];
 
 					const container = page.getByTestId( `hydrating ${ type }` );
 					const el = container.getByTestId( testid );


### PR DESCRIPTION
## What?

Update the logic of `data-wp-bind` to match Preact's logic during hydration.

## Why?
Required by https://github.com/WordPress/gutenberg/pull/53737, see https://github.com/WordPress/gutenberg/pull/53737#discussion_r1304141657)

## How?

We copied Preact's code ([link](https://github.com/preactjs/preact/blob/ea49f7a0f9d1ff2c98c0bdd66aa0cbc583055246/src/diff/props.js#L110-L144)) into the `useEffect` hook used to initialize bound values and added e2e tests to cover several representative cases.

Note that, most of the time, Preact modifies the `HTMLElement` instance properties instead of the attributes, so the final values vary depending on the modified property.  In some cases, **attributes may not even change at all.**


## Testing Instructions
E2E tests should pass.
