### PR TITLE
[Block Library - Featured Image]: As with Image block, DimensionControls will not be displayed when wide or full.

### DIFF
--- a/packages/block-library/src/post-featured-image/edit.js
+++ b/packages/block-library/src/post-featured-image/edit.js
@@ -28,6 +28,7 @@ import {
 import { __, sprintf } from '@wordpress/i18n';
 import { upload } from '@wordpress/icons';
 import { store as noticesStore } from '@wordpress/notices';
+import { useEffect } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -59,6 +60,7 @@ export default function PostFeaturedImageEdit( {
 		sizeSlug,
 		rel,
 		linkTarget,
+		align,
 	} = attributes;
 	const [ featuredImage, setFeaturedImage ] = useEntityProp(
 		'postType',
@@ -66,6 +68,17 @@ export default function PostFeaturedImageEdit( {
 		'featured_media',
 		postId
 	);
+
+	useEffect( () => {
+		const extraUpdatedAttributes = [ 'wide', 'full' ].includes( align )
+			? { width: undefined, height: undefined }
+			: {};
+		setAttributes( {
+			...extraUpdatedAttributes,
+		} );
+	}, [ align ] );
+
+	const isWideAligned = [ 'wide', 'full' ].includes( align );
 
 	const { media, postType } = useSelect(
 		( select ) => {
@@ -133,12 +146,14 @@ export default function PostFeaturedImageEdit( {
 
 	const controls = (
 		<>
-			<DimensionControls
-				clientId={ clientId }
-				attributes={ attributes }
-				setAttributes={ setAttributes }
-				imageSizeOptions={ imageSizeOptions }
-			/>
+			{ ! isWideAligned && (
+				<DimensionControls
+					clientId={ clientId }
+					attributes={ attributes }
+					setAttributes={ setAttributes }
+					imageSizeOptions={ imageSizeOptions }
+				/>
+			) }
 			<InspectorControls>
 				<PanelBody title={ __( 'Settings' ) }>
 					<ToggleControl


### PR DESCRIPTION
## What?
<!-- In a few words, what is the PR actually doing? -->
As with Image block, DimensionControls will not be displayed when wide or full.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Referenced code
https://github.com/WordPress/gutenberg/blob/5f925548c9860add90a96da6d7ed54966d1b4380/packages/block-library/src/image/image.js#L178

https://github.com/WordPress/gutenberg/blob/5f925548c9860add90a96da6d7ed54966d1b4380/packages/block-library/src/image/image.js#L327-L340

## Testing Instructions
1. Place a Featured Image block.
2. Change the width.
3. Change align to wide or full from the toolbar.
4. You can confirm that the image will be wide or full.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

### this branch
https://github.com/WordPress/gutenberg/assets/42362903/71130108-f339-4fc5-88ee-9f1dae10e7dd

### trunk branch
https://github.com/WordPress/gutenberg/assets/42362903/b2eed6b6-1bb0-42bc-a07d-3e9d17a1fa1b
