### PR TITLE
use tanstack and migrate templates and parts

### DIFF
--- a/packages/edit-site/package.json
+++ b/packages/edit-site/package.json
@@ -27,6 +27,7 @@
 	"react-native": "src/index",
 	"dependencies": {
 		"@babel/runtime": "^7.16.0",
+		"@tanstack/react-table": "^8.9.3",
 		"@wordpress/a11y": "file:../a11y",
 		"@wordpress/api-fetch": "file:../api-fetch",
 		"@wordpress/block-editor": "file:../block-editor",

--- a/packages/edit-site/src/components/table/index.js
+++ b/packages/edit-site/src/components/table/index.js
@@ -1,27 +1,156 @@
-export default function Table( { data, columns } ) {
+/**
+ * External dependencies
+ */
+import {
+	useReactTable,
+	getCoreRowModel,
+	flexRender,
+	createColumnHelper,
+} from '@tanstack/react-table';
+import cx from 'classnames';
+
+/**
+ * WordPress dependencies
+ */
+import { Button, Icon } from '@wordpress/components';
+import { chevronUp, chevronDown } from '@wordpress/icons';
+
+/** @type {import('@tanstack/react-table').ColumnHelper<unknown>} */
+const columnHelper = createColumnHelper();
+
+/**
+ * @typedef {import('@tanstack/react-table').Header<unknown, unknown>} Header
+ * @typedef {import('@tanstack/react-table').Table<unknown>} Table
+ */
+
+/**
+ * @param {Object} props
+ * @param {Header} props.header
+ */
+function HeaderColumn( { header } ) {
+	if ( header.isPlaceholder ) return null;
+
+	const rendered = flexRender(
+		header.column.columnDef.header,
+		header.getContext()
+	);
+
+	if ( ! header.column.getCanSort() ) {
+		return rendered;
+	}
+
 	return (
-		<div className="edit-site-table-wrapper">
+		<Button
+			className="edit-site-table-header__button"
+			onClick={ header.column.getToggleSortingHandler() }
+		>
+			{ rendered }
+			{ !! header.column.getIsSorted() && (
+				<Icon
+					icon={
+						header.column.getIsSorted() === 'asc'
+							? chevronUp
+							: chevronDown
+					}
+				/>
+			) }
+		</Button>
+	);
+}
+
+/**
+ * @param {Object}  props
+ * @param {string}  props.className
+ * @param {Array}   props.data
+ * @param {Array}   props.columns
+ * @param {string}  props.rowId
+ * @param {boolean} props.enableSorting
+ */
+export default function Table( {
+	data,
+	columns,
+	rowId,
+	enableSorting = false,
+	className,
+	...props
+} ) {
+	const tableRows = columns.map( ( { accessor = null, cell, ...rest } ) => {
+		const column = {
+			cell: ( cellProps ) =>
+				cell( {
+					value: cellProps.getValue(),
+					row: cellProps.row.original,
+				} ),
+			...rest,
+		};
+
+		if ( accessor ) {
+			return columnHelper.accessor( accessor, column );
+		}
+
+		return columnHelper.display( column );
+	} );
+
+	const table = useReactTable( {
+		data,
+		columns: tableRows,
+		getRowId: ( row ) => row[ rowId ],
+		getCoreRowModel: getCoreRowModel(),
+		enableSorting,
+	} );
+
+	return (
+		<div
+			className={ cx( 'edit-site-table-wrapper', className ) }
+			{ ...props }
+		>
 			<table className="edit-site-table">
 				<thead>
-					<tr>
-						{ columns.map( ( column ) => (
-							<th key={ column.header }>{ column.header }</th>
-						) ) }
-					</tr>
+					{ table.getHeaderGroups().map( ( headerGroup ) => (
+						<tr key={ headerGroup.id }>
+							{ headerGroup.headers.map( ( header ) => (
+								<th
+									style={ {
+										width:
+											header.column.columnDef.width ||
+											undefined,
+										maxWidth:
+											header.column.columnDef.maxWidth ||
+											undefined,
+									} }
+									key={ header.id }
+								>
+									<HeaderColumn header={ header } />
+								</th>
+							) ) }
+						</tr>
+					) ) }
 				</thead>
 				<tbody>
-					{ data.map( ( row, rowIndex ) => (
-						<tr key={ rowIndex }>
-							{ columns.map( ( column, columnIndex ) => (
+					{ table.getRowModel().rows.map( ( row ) => (
+						<tr
+							key={ row.id }
+							style={ {
+								// TODO: More generic way of dimming row.
+								opacity: row.original.id ? 1 : 0.5,
+							} }
+						>
+							{ row.getVisibleCells().map( ( cell ) => (
 								<td
 									style={ {
-										maxWidth: column.maxWidth
-											? column.maxWidth
-											: undefined,
+										width:
+											cell.column.columnDef.width ||
+											undefined,
+										maxWidth:
+											cell.column.columnDef.maxWidth ||
+											undefined,
 									} }
-									key={ columnIndex }
+									key={ cell.id }
 								>
-									{ column.cell( row ) }
+									{ flexRender(
+										cell.column.columnDef.cell,
+										cell.getContext()
+									) }
 								</td>
 							) ) }
 						</tr>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Updates the existing table component in edit-site to use TanStack.

## Why?
Preparation for a more powerful table component outlined [here](https://github.com/WordPress/gutenberg/issues/53233) that will be needed as the site editor expands and admin redesign work kicks off.

## How?
Adds TanStack package and makes use of it in the existing Table component. This PR also updates existing template and template part pages to comply with the new Table.

## Testing Instructions
1. Open site editor
2. Click templates -> manage all templates
3. Make sure table is identical to what's on trunk
4. Do the same for template parts in patterns