### PR TITLE
[Block Library - Featured Image]: Don't exceed the width of the parent block just like the Image Block

### DIFF
--- a/packages/block-library/src/post-featured-image/edit.js
+++ b/packages/block-library/src/post-featured-image/edit.js
@@ -140,7 +140,10 @@ export default function PostFeaturedImageEdit( {
 		} ) );
 
 	const blockProps = useBlockProps( {
-		style: { width, height, aspectRatio },
+		style: {
+			width,
+			maxWidth: !! width && '100%',
+		},
 	} );
 	const borderProps = useBorderProps( attributes );
 
@@ -264,8 +267,9 @@ export default function PostFeaturedImageEdit( {
 	const label = __( 'Add a featured image' );
 	const imageStyles = {
 		...borderProps.style,
-		height: aspectRatio ? '100%' : height,
-		width: !! aspectRatio && '100%',
+		aspectRatio,
+		height,
+		width,
 		objectFit: !! ( height || aspectRatio ) && scale,
 	};
 

--- a/packages/block-library/src/post-featured-image/index.php
+++ b/packages/block-library/src/post-featured-image/index.php
@@ -111,13 +111,13 @@ function render_block_core_post_featured_image( $attributes, $content, $block ) 
 		$featured_image = $featured_image . $overlay_markup;
 	}
 
-	$width        = ! empty( $attributes['width'] )
+	$width = ! empty( $attributes['width'] )
 		? esc_attr( safecss_filter_attr( 'width:' . $attributes['width'] ) ) . ';'
 		: '';
 	if ( ! $width ) {
 		$wrapper_attributes = get_block_wrapper_attributes();
 	} else {
-		$wrapper_attributes = get_block_wrapper_attributes(array( 'style' => $width ));
+		$wrapper_attributes = get_block_wrapper_attributes( array( 'style' => $width ) );
 	}
 	return "<figure {$wrapper_attributes}>{$featured_image}</figure>";
 }

--- a/packages/block-library/src/post-featured-image/index.php
+++ b/packages/block-library/src/post-featured-image/index.php
@@ -40,7 +40,7 @@ function render_block_core_post_featured_image( $attributes, $content, $block ) 
 
 	// Aspect ratio with a height set needs to override the default width/height.
 	if ( ! empty( $attributes['aspectRatio'] ) ) {
-		$extra_styles .= esc_attr( safecss_filter_attr( 'aspect-ratio:' . $attributes['aspectRatio'] ) ). ';';
+		$extra_styles .= esc_attr( safecss_filter_attr( 'aspect-ratio:' . $attributes['aspectRatio'] ) ) . ';';
 	}
 
 	if ( ! empty( $attributes['width'] ) ) {

--- a/packages/block-library/src/post-featured-image/index.php
+++ b/packages/block-library/src/post-featured-image/index.php
@@ -40,8 +40,14 @@ function render_block_core_post_featured_image( $attributes, $content, $block ) 
 
 	// Aspect ratio with a height set needs to override the default width/height.
 	if ( ! empty( $attributes['aspectRatio'] ) ) {
-		$extra_styles .= 'width:100%;height:100%;';
-	} elseif ( ! empty( $attributes['height'] ) ) {
+		$extra_styles .= esc_attr( safecss_filter_attr( 'aspect-ratio:' . $attributes['aspectRatio'] ) ). ';';
+	}
+
+	if ( ! empty( $attributes['width'] ) ) {
+		$extra_styles .= "width:{$attributes['width']};";
+	}
+
+	if ( ! empty( $attributes['height'] ) ) {
 		$extra_styles .= "height:{$attributes['height']};";
 	}
 
@@ -105,19 +111,13 @@ function render_block_core_post_featured_image( $attributes, $content, $block ) 
 		$featured_image = $featured_image . $overlay_markup;
 	}
 
-	$aspect_ratio = ! empty( $attributes['aspectRatio'] )
-		? esc_attr( safecss_filter_attr( 'aspect-ratio:' . $attributes['aspectRatio'] ) ) . ';'
-		: '';
 	$width        = ! empty( $attributes['width'] )
 		? esc_attr( safecss_filter_attr( 'width:' . $attributes['width'] ) ) . ';'
 		: '';
-	$height       = ! empty( $attributes['height'] )
-		? esc_attr( safecss_filter_attr( 'height:' . $attributes['height'] ) ) . ';'
-		: '';
-	if ( ! $height && ! $width && ! $aspect_ratio ) {
+	if ( ! $width ) {
 		$wrapper_attributes = get_block_wrapper_attributes();
 	} else {
-		$wrapper_attributes = get_block_wrapper_attributes( array( 'style' => $aspect_ratio . $width . $height ) );
+		$wrapper_attributes = get_block_wrapper_attributes(array( 'style' => $width ));
 	}
 	return "<figure {$wrapper_attributes}>{$featured_image}</figure>";
 }

--- a/packages/block-library/src/post-featured-image/style.scss
+++ b/packages/block-library/src/post-featured-image/style.scss
@@ -1,6 +1,8 @@
 .wp-block-post-featured-image {
 	margin-left: 0;
 	margin-right: 0;
+	max-width: 100%;
+
 	a {
 		display: block;
 		height: 100%;


### PR DESCRIPTION
## What?
Don't exceed the width of the parent block just like the Image Block

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

#54004 
#52238

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
1. Place Image Block and Featured Image Block in the column block.
Or paste the HTML below.
```HTML
<!-- wp:columns -->
<div class="wp-block-columns"><!-- wp:column {"width":"33.33%","backgroundColor":"light-green-cyan"} -->
<div class="wp-block-column has-light-green-cyan-background-color has-background" style="flex-basis:33.33%"><!-- wp:paragraph -->
<p>↓ This is Featured Image block.</p>
<!-- /wp:paragraph -->

<!-- wp:post-featured-image {"aspectRatio":"1","height":"400px","style":{"color":{}}} /-->

<!-- wp:paragraph -->
<p>↓ This is Image block.</p>
<!-- /wp:paragraph -->

<!-- wp:image {"id":7335,"width":"undefinedpx","height":"400px","scale":"cover","sizeSlug":"full","linkDestination":"none"} -->
<figure class="wp-block-image size-full is-resized"><img src="https://s.w.org/images/core/5.3/MtBlanc1.jpg" alt="" class="wp-image-7335" style="object-fit:cover;width:undefinedpx;height:400px"/></figure>
<!-- /wp:image --></div>
<!-- /wp:column -->

<!-- wp:column {"width":"66.66%","backgroundColor":"pale-pink"} -->
<div class="wp-block-column has-pale-pink-background-color has-background" style="flex-basis:66.66%"><!-- wp:paragraph -->
<p>right column text right column text right column text right column text right column text right column text</p>
<!-- /wp:paragraph --></div>
<!-- /wp:column --></div>
<!-- /wp:columns -->
```
2. Change the width height.
3. The image jumps over the width of the column.
4. Check the display on the front end
5. Image Block width does not jump over column width, Featured Image Block jumps over column width.

## this branch
https://github.com/WordPress/gutenberg/assets/42362903/debb5715-68cf-4a88-8aec-0428e6801a35

## trunk branch
https://github.com/WordPress/gutenberg/assets/42362903/e4d7446a-b81d-461d-aeef-d13b1831f830

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
