### PR TITLE
[RNMobile] Add block outline to all Social Link blocks when selected

### DIFF
--- a/packages/block-editor/src/components/block-list/block-outline.native.js
+++ b/packages/block-editor/src/components/block-list/block-outline.native.js
@@ -13,7 +13,7 @@ import { usePreferredColorSchemeStyle } from '@wordpress/compose';
  */
 import styles from './block.scss';
 
-const BLOCKS_WITH_OUTLINE = [ 'core/social-link', 'core/missing' ];
+const TEXT_BLOCKS_WITH_OUTLINE = [ 'core/missing' ];
 
 function BlockOutline( {
 	blockCategory,
@@ -22,7 +22,9 @@ function BlockOutline( {
 	isSelected,
 	name,
 } ) {
-	const textBlockWithOutline = BLOCKS_WITH_OUTLINE.includes( name );
+	const textBlockWithOutline = TEXT_BLOCKS_WITH_OUTLINE.includes( name );
+	const socialBlockWithOutline = name.includes( 'core/social-link' );
+
 	const hasBlockTextCategory =
 		blockCategory === 'text' && ! textBlockWithOutline;
 	const hasBlockMediaCategory =
@@ -47,6 +49,7 @@ function BlockOutline( {
 		( ( hasBlockTextCategory && hasInnerBlocks ) ||
 			( ! hasBlockTextCategory && hasInnerBlocks ) ||
 			( ! hasBlockTextCategory && isRootList ) ||
+			socialBlockWithOutline ||
 			textBlockWithOutline );
 
 	return (

--- a/packages/block-library/src/social-link/edit.native.js
+++ b/packages/block-library/src/social-link/edit.native.js
@@ -158,7 +158,7 @@ const SocialLinkEdit = ( {
 		  );
 
 	return (
-		<View style={ styles.container }>
+		<View>
 			{ isSelected && (
 				<>
 					<BlockControls>

--- a/packages/block-library/src/social-link/editor.native.scss
+++ b/packages/block-library/src/social-link/editor.native.scss
@@ -1,9 +1,5 @@
 @import "./socials-with-bg.scss";
 
-.container {
-	margin: $block-selected-margin;
-}
-
 .linkSettingsPanel {
 	padding-left: 0;
 	padding-right: 0;

--- a/packages/react-native-editor/CHANGELOG.md
+++ b/packages/react-native-editor/CHANGELOG.md
@@ -14,6 +14,7 @@ For each user feature we should also add a importance categorization label  to i
 -   [*] Search Control - Prevent calling TextInput's methods when undefined [#53745]
 -   [*] Improve horizontal rule styles to avoid invisible lines [#53883]
 -   [*] Fix horizontal rule style extensions [#53917]
+-   [*] Add block outline to all Social Link blocks when selected [#54011]
 
 ## 1.102.1
 - [**] Fix Voice Over and assistive keyboards [#53895]


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Updates the native block outline component to add outlines to all Social Link blocks when selected.

* https://github.com/wordpress-mobile/gutenberg-mobile/pull/6133

## Why?
Not all Social Link blocks were receiving the outline when selected. Blocks added via the [+] icon block inserter did not receive the outline. This was due to the block name itself, and how it was being matched as a string in the native Block Outline component. The initial four Social Link blocks (WordPress, Facebook, Twitter, Instagram) all have an initial HTML value of `core/social-link`. When new Social Link blocks are added from the inserter, they use the specific name of the block, e.g.: `core/social-link-amazon`. 

## How?
This PR updates the Block Outline pattern matching to outline any block whose name _contains_ `core/social-link` (rather than the previous other way around where the block name had to _match_ `core/social-link` as a string). This PR also restores some of the [previous separation-of-concerns](https://github.com/WordPress/gutenberg/pull/53377/files#diff-aa3c0eaa5827df206a5617b063c0da847ae960f3198b432ac7b036afe928ac80L16-L17) by separating Social blocks from Text blocks in the Block Outline component, and providing Social Link blocks their own `const` for matching.

## Testing Instructions
1. Create a Post and add a Social Links block.
2. Tap one of the four initial blocks (WordPress, Facebook, Twitter, Instagram) and note the blue Block Outline appears when the block is selected.
3. Tap the [+] button to the right of the initial blocks to open the Social Link block inserter. 
4. Add any block from the inserter: Amazon, Dribbble, Dropbox, etc.
5. When the new block is added, the blue Block Outline should appear around the new block. When de-selected by tapping anywhere else in the editor, and reselecting the block by tapping it, the blue Block Outline should appear.

## Screenshots or screencast <!-- if applicable -->
Before | After
-|-
<video src="https://github.com/WordPress/gutenberg/assets/643285/3bd9d23f-7287-4fa0-977f-763e416affc3" /> | <video src="https://github.com/WordPress/gutenberg/assets/643285/b491f9c7-b32c-42c5-ae57-d309cefb45af" />







