### PR TITLE
Rich text: fix useAnchor (remove nextElementSibling)

### DIFF
--- a/packages/rich-text/src/component/use-anchor.js
+++ b/packages/rich-text/src/component/use-anchor.js
@@ -20,8 +20,22 @@ import { useState, useLayoutEffect } from '@wordpress/element';
 function getFormatElement( range, editableContentElement, tagName, className ) {
 	let element = range.startContainer;
 
-	// If the caret is right before the element, select the next element.
-	element = element.nextElementSibling || element;
+	// One issues with format boundaries is that the caret can be right before
+	// the element while we make it look to be inside the element. So if the
+	// startContainer is a text node and the caret is at the end of the text,
+	// we should use the next sibling and the deepest first child so we can
+	// select the correct format element. Do not use nextElementSibling, it must
+	// otherwise you may be matching an element further away.
+	if (
+		element.nodeType === element.TEXT_NODE &&
+		range.startOffset === element.length
+	) {
+		element = element.nextSibling;
+
+		while ( element.firstChild ) {
+			element = element.firstChild;
+		}
+	}
 
 	if ( element.nodeType !== element.ELEMENT_NODE ) {
 		element = element.parentElement;

--- a/packages/rich-text/src/component/use-anchor.js
+++ b/packages/rich-text/src/component/use-anchor.js
@@ -20,12 +20,10 @@ import { useState, useLayoutEffect } from '@wordpress/element';
 function getFormatElement( range, editableContentElement, tagName, className ) {
 	let element = range.startContainer;
 
-	// One issues with format boundaries is that the caret can be right before
-	// the element while we make it look to be inside the element. So if the
-	// startContainer is a text node and the caret is at the end of the text,
-	// we should use the next sibling and the deepest first child so we can
-	// select the correct format element. Do not use nextElementSibling, it must
-	// otherwise you may be matching an element further away.
+	// Even if the active format is defined, the actualy DOM range's start
+	// container may be outside of the format's DOM element:
+	// `a‸<strong>b</strong>` (DOM) while visually it's `a<strong>‸b</strong>`.
+	// So at a given selection index, start with the deepest format DOM element.
 	if (
 		element.nodeType === element.TEXT_NODE &&
 		range.startOffset === element.length &&

--- a/packages/rich-text/src/component/use-anchor.js
+++ b/packages/rich-text/src/component/use-anchor.js
@@ -28,7 +28,8 @@ function getFormatElement( range, editableContentElement, tagName, className ) {
 	// otherwise you may be matching an element further away.
 	if (
 		element.nodeType === element.TEXT_NODE &&
-		range.startOffset === element.length
+		range.startOffset === element.length &&
+		element.nextSibling
 	) {
 		element = element.nextSibling;
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Fixes https://github.com/WordPress/gutenberg/issues/53641, alternative to #53642.

The root of the problem is `element.nextElementSibling`, which is selecting whatever next _element_ sibling of the range's start container, which could be an element way down the line, resulting in an element returned that is not connected to the given range.

The solution is to restrict this more: only if the selection is at the end of a text node, use the next sibling (not next _element_ sibling, because there might be other things in between), then select the deepest first child so it works with nested formatting.

Why do we need this is the first place? Well, format boundaries are purely visual and when you put the caret in front of a link, the collapsed selection is actually _outside_ the link, even though we've made it to look inside the link when you press arrow right.

Worth noting for testing: there's some other issue going on with popovers being mispositioned when selecting a link (I'm not sure if this is just for me locally, but it's an issue in trunk too and should be fixed separately).

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
