### PR TITLE
useMediaQuery: Avoid crashing on Safari < 14

### DIFF
--- a/packages/compose/src/hooks/use-media-query/index.js
+++ b/packages/compose/src/hooks/use-media-query/index.js
@@ -38,6 +38,7 @@ export default function useMediaQuery( query ) {
 					return () => {};
 				}
 
+				// Avoid a fatal error when browsers don't support `addEventListener` on MediaQueryList.
 				mediaQueryList.addEventListener?.( 'change', onStoreChange );
 				return () => {
 					mediaQueryList.removeEventListener?.(

--- a/packages/compose/src/hooks/use-media-query/index.js
+++ b/packages/compose/src/hooks/use-media-query/index.js
@@ -38,9 +38,9 @@ export default function useMediaQuery( query ) {
 					return () => {};
 				}
 
-				mediaQueryList.addEventListener( 'change', onStoreChange );
+				mediaQueryList.addEventListener?.( 'change', onStoreChange );
 				return () => {
-					mediaQueryList.removeEventListener(
+					mediaQueryList.removeEventListener?.(
 						'change',
 						onStoreChange
 					);


### PR DESCRIPTION
## What?
Closes #53251.

Avoid a fatal error when the editor and `useMediaQuery` hook are used with Safari < 14.

## Why?
The older versions of Safari only support deprecated `addListener` and `removeListener` methods.

Considering that Safari < 14 usage is less than 1%, there's [no need to be fully compatible with them](https://make.wordpress.org/core/handbook/best-practices/browser-support/).

## How?
Use the optional chaining operator.

## Testing Instructions
I'm not sure how to downgrade the Safari version. The hook has test coverage, so CI checks should be green.
