### PR TITLE
Auto-inserting blocks: Remove toggle if block is present elsewhere

### DIFF
--- a/packages/block-editor/src/hooks/auto-inserting-blocks.js
+++ b/packages/block-editor/src/hooks/auto-inserting-blocks.js
@@ -117,13 +117,11 @@ function AutoInsertingBlocksControl( props ) {
 			const { getBlock, getBlockIndex, getBlockRootClientId } =
 				select( blockEditorStore );
 
-			const _rootClientId = getBlockRootClientId( props.clientId );
-
 			return {
 				blockIndex: getBlockIndex( props.clientId ),
 				innerBlocksLength: getBlock( props.clientId )?.innerBlocks
 					?.length,
-				rootClientId: _rootClientId,
+				rootClientId: getBlockRootClientId( props.clientId ),
 			};
 		},
 		[ props.clientId ]

--- a/packages/block-editor/src/hooks/auto-inserting-blocks.js
+++ b/packages/block-editor/src/hooks/auto-inserting-blocks.js
@@ -46,6 +46,13 @@ function AutoInsertingBlocksControl( props ) {
 			const _autoInsertedBlockClientIds =
 				autoInsertedBlocksForCurrentBlock.reduce(
 					( clientIds, block ) => {
+						// If the block doesn't exist anywhere in the block tree,
+						// we know that we have to display the toggle for it, and set
+						// it to disabled.
+						if ( getGlobalBlockCount( block.name ) === 0 ) {
+							return clientIds;
+						}
+
 						const relativePosition =
 							block?.autoInsert?.[ props.blockName ];
 						let candidates;
@@ -75,23 +82,23 @@ function AutoInsertingBlocksControl( props ) {
 							( { name } ) => name === block.name
 						);
 
+						// If the block exists in the designated location, we consider it auto-inserted
+						// and show the toggle as enabled.
 						if ( autoInsertedBlock ) {
-							clientIds = {
+							return {
 								...clientIds,
 								[ block.name ]: autoInsertedBlock.clientId,
 							};
-						} else if ( getGlobalBlockCount( block.name ) > 0 ) {
-							// If no auto-inserted block was found in any of its designated locations,
-							// but it exists elsewhere in the block tree, we consider it manually inserted.
-							// In this case, we take note and will remove the corresponding toggle from the
-							// block inspector panel.
-							clientIds = {
-								...clientIds,
-								[ block.name ]: false,
-							};
 						}
 
-						return clientIds;
+						// If no auto-inserted block was found in any of its designated locations,
+						// but it exists elsewhere in the block tree, we consider it manually inserted.
+						// In this case, we take note and will remove the corresponding toggle from the
+						// block inspector panel.
+						return {
+							...clientIds,
+							[ block.name ]: false,
+						};
 					},
 					{}
 				);

--- a/packages/block-editor/src/hooks/auto-inserting-blocks.js
+++ b/packages/block-editor/src/hooks/auto-inserting-blocks.js
@@ -36,12 +36,25 @@ function AutoInsertingBlocksControl( props ) {
 		[ blockTypes, props.blockName ]
 	);
 
-	const autoInsertedBlockClientIds = useSelect(
+	const { blockIndex, rootClientId, innerBlocksLength } = useSelect(
 		( select ) => {
-			const { getBlock, getGlobalBlockCount, getBlockRootClientId } =
+			const { getBlock, getBlockIndex, getBlockRootClientId } =
 				select( blockEditorStore );
 
-			const _rootClientId = getBlockRootClientId( props.clientId );
+			return {
+				blockIndex: getBlockIndex( props.clientId ),
+				innerBlocksLength: getBlock( props.clientId )?.innerBlocks
+					?.length,
+				rootClientId: getBlockRootClientId( props.clientId ),
+			};
+		},
+		[ props.clientId ]
+	);
+
+	const autoInsertedBlockClientIds = useSelect(
+		( select ) => {
+			const { getBlock, getGlobalBlockCount } =
+				select( blockEditorStore );
 
 			const _autoInsertedBlockClientIds =
 				autoInsertedBlocksForCurrentBlock.reduce(
@@ -64,7 +77,7 @@ function AutoInsertingBlocksControl( props ) {
 								// as an auto-inserted block (inserted `before` or `after` the current one),
 								// as the block might've been auto-inserted and then moved around a bit by the user.
 								candidates =
-									getBlock( _rootClientId )?.innerBlocks;
+									getBlock( rootClientId )?.innerBlocks;
 								break;
 
 							case 'first_child':
@@ -109,22 +122,12 @@ function AutoInsertingBlocksControl( props ) {
 
 			return EMPTY_OBJECT;
 		},
-		[ autoInsertedBlocksForCurrentBlock, props.blockName, props.clientId ]
-	);
-
-	const { blockIndex, rootClientId, innerBlocksLength } = useSelect(
-		( select ) => {
-			const { getBlock, getBlockIndex, getBlockRootClientId } =
-				select( blockEditorStore );
-
-			return {
-				blockIndex: getBlockIndex( props.clientId ),
-				innerBlocksLength: getBlock( props.clientId )?.innerBlocks
-					?.length,
-				rootClientId: getBlockRootClientId( props.clientId ),
-			};
-		},
-		[ props.clientId ]
+		[
+			autoInsertedBlocksForCurrentBlock,
+			props.blockName,
+			props.clientId,
+			rootClientId,
+		]
 	);
 
 	const { insertBlock, removeBlock } = useDispatch( blockEditorStore );

--- a/packages/block-editor/src/hooks/auto-inserting-blocks.js
+++ b/packages/block-editor/src/hooks/auto-inserting-blocks.js
@@ -38,38 +38,13 @@ function someBlock( blocks, predicate, getBlocks ) {
 }
 
 function AutoInsertingBlocksControl( props ) {
-	const { autoInsertedBlocksForCurrentBlock, groupedAutoInsertedBlocks } =
-		useSelect(
-			( select ) => {
-				const { getBlockTypes } = select( blocksStore );
-				const _autoInsertedBlocksForCurrentBlock =
-					getBlockTypes()?.filter(
-						( { autoInsert } ) =>
-							autoInsert && props.blockName in autoInsert
-					);
+	const blockTypes = useSelect( ( select ) =>
+		select( blocksStore ).getBlockTypes()
+	);
 
-				// Group by block namespace (i.e. prefix before the slash).
-				const _groupedAutoInsertedBlocks =
-					_autoInsertedBlocksForCurrentBlock?.reduce(
-						( groups, block ) => {
-							const [ namespace ] = block.name.split( '/' );
-							if ( ! groups[ namespace ] ) {
-								groups[ namespace ] = [];
-							}
-							groups[ namespace ].push( block );
-							return groups;
-						},
-						{}
-					);
-
-				return {
-					autoInsertedBlocksForCurrentBlock:
-						_autoInsertedBlocksForCurrentBlock,
-					groupedAutoInsertedBlocks: _groupedAutoInsertedBlocks,
-				};
-			},
-			[ props.blockName ]
-		);
+	const autoInsertedBlocksForCurrentBlock = blockTypes?.filter(
+		( { autoInsert } ) => autoInsert && props.blockName in autoInsert
+	);
 
 	const {
 		autoInsertedBlockClientIds,
@@ -152,6 +127,19 @@ function AutoInsertingBlocksControl( props ) {
 	if ( ! autoInsertedBlocksForCurrentBlock.length ) {
 		return null;
 	}
+
+	// Group by block namespace (i.e. prefix before the slash).
+	const groupedAutoInsertedBlocks = autoInsertedBlocksForCurrentBlock?.reduce(
+		( groups, block ) => {
+			const [ namespace ] = block.name.split( '/' );
+			if ( ! groups[ namespace ] ) {
+				groups[ namespace ] = [];
+			}
+			groups[ namespace ].push( block );
+			return groups;
+		},
+		{}
+	);
 
 	const insertBlockIntoDesignatedLocation = ( block, relativePosition ) => {
 		switch ( relativePosition ) {

--- a/packages/block-editor/src/hooks/auto-inserting-blocks.js
+++ b/packages/block-editor/src/hooks/auto-inserting-blocks.js
@@ -19,6 +19,8 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { BlockIcon, InspectorControls } from '../components';
 import { store as blockEditorStore } from '../store';
 
+const emptyObject = {};
+
 function AutoInsertingBlocksControl( props ) {
 	const blockTypes = useSelect( ( select ) =>
 		select( blocksStore ).getBlockTypes()
@@ -77,18 +79,24 @@ function AutoInsertingBlocksControl( props ) {
 						);
 
 						if ( autoInsertedBlock ) {
-							clientIds[ block.name ] =
-								autoInsertedBlock.clientId;
+							clientIds = {
+								...clientIds,
+								[ block.name ]: autoInsertedBlock.clientId,
+							};
 						} else if ( getGlobalBlockCount( block.name ) > 0 ) {
 							// If no auto-inserted block was found in any of its designated locations,
 							// but it exists elsewhere in the block tree, we consider it manually inserted.
-							// In this case, we remove the corresponding toggle from the block inspector panel.
-							clientIds[ block.name ] = false;
+							// In this case, we take note and will remove the corresponding toggle from the
+							// block inspector panel.
+							clientIds = {
+								...clientIds,
+								[ block.name ]: false,
+							};
 						}
 
 						return clientIds;
 					},
-					{}
+					emptyObject // Retain reference equality across renders if there are no auto-inserted blocks.
 				);
 
 			return {

--- a/packages/block-editor/src/hooks/auto-inserting-blocks.js
+++ b/packages/block-editor/src/hooks/auto-inserting-blocks.js
@@ -103,7 +103,9 @@ function AutoInsertingBlocksControl( props ) {
 								( { name } ) => name === block.name,
 								getBlocks
 							);
-							// TODO: Remove the toggle from the block inspector panel.
+							if ( blockIsPresentElsewhereInTree ) {
+								clientIds[ block.name ] = false;
+							}
 						}
 
 						return clientIds;
@@ -124,12 +126,18 @@ function AutoInsertingBlocksControl( props ) {
 
 	const { insertBlock, removeBlock } = useDispatch( blockEditorStore );
 
-	if ( ! autoInsertedBlocksForCurrentBlock.length ) {
+	// Remove toggle if block isn't present in the designated location but elsewhere in the block tree.
+	const autoInsertedBlocksForCurrentBlockIfNotPresentElsewhere =
+		autoInsertedBlocksForCurrentBlock?.filter(
+			( block ) => autoInsertedBlockClientIds?.[ block.name ] !== false
+		);
+
+	if ( ! autoInsertedBlocksForCurrentBlockIfNotPresentElsewhere.length ) {
 		return null;
 	}
 
 	// Group by block namespace (i.e. prefix before the slash).
-	const groupedAutoInsertedBlocks = autoInsertedBlocksForCurrentBlock?.reduce(
+	const groupedAutoInsertedBlocks = autoInsertedBlocksForCurrentBlock.reduce(
 		( groups, block ) => {
 			const [ namespace ] = block.name.split( '/' );
 			if ( ! groups[ namespace ] ) {

--- a/packages/block-editor/src/hooks/auto-inserting-blocks.js
+++ b/packages/block-editor/src/hooks/auto-inserting-blocks.js
@@ -33,7 +33,7 @@ function someBlock( blocks, predicate, getBlocks ) {
 				? getBlocks( block.clientId )
 				: block.innerBlocks;
 
-		return someBlock( innerBlocks, predicate );
+		return someBlock( innerBlocks, predicate, getBlocks );
 	} );
 }
 


### PR DESCRIPTION
## What?
Follow-up to #52969.

Remove the Auto-inserting block inspector panel toggle for a block if it's present in a different location than expected for auto-insertion.

Additionally, this PR fixes most of the following warnings (raised [here](https://github.com/WordPress/gutenberg/pull/52969#discussion_r1308713275)):

``` 
The 'useSelect' hook returns different values when called with the same state and parameters. This can lead to unnecessary rerenders. 
```

## Why?
If a block that would normally be auto-inserted is not found in its designated position but elsewhere, we can assume somewhat safely that it was inserted manually, and that the user is aware of the block and won't need any UI elements to make it more visible.

This was first discussed [here](https://github.com/WordPress/gutenberg/pull/52969#issuecomment-1663956011).

## How?
By checking if the global block tree contains any instance of the block type in question. (Hat-tip @gziolo for pointing me to [`getGlobalBlockCount`](https://developer.wordpress.org/block-editor/reference-guides/data/data-core-block-editor/#getglobalblockcount) 🙌 )

## Testing Instructions
- Enable the "Auto-inserting blocks" experiment on the Experiments page.
- Install the [Like Button example plugin](https://github.com/ockham/like-button).
  - You can either download a plugin zip from the Releases tab, or clone the git repo and link it from your Gutenberg dev env, e.g. via a `.wp-env.override.json` file.
- Make sure you're using a Block Theme (e.g. Twenty Twenty Three) that uses the Comments (and Comment Template) blocks.
- Make sure that your theme's "Single" template and "Comments" template parts don't have any user modifications.
- Open the Site Editor to view the "Single" template.
- Verify that the Like Button block is inserted as the Comment Template block's last child.
- Select the Comment Template block, and open the block inspector sidebar.
- Verify that the "Plugins" panel is present, contains the toggle for the Like Button block, and that the toggle is enabled.
- Disable the toggle and verify that the block is removed.
- Re-enable the toggle and verify that it is brought back.
- Move the Like Button block to a different location, but _still within the Comment Template block_. Verify that the toggle still shows up as enabled.
- Now open the block list view and move the block to a different location _outside of the Comment Template block_.
- _Verify that the toggle (and "Plugins" panel) is gone from the Comment Template block's inspector panel altogether._ (This is different from the previous behavior, where the toggle would simply show as disabled.)

## Screenshots or screencast

![auto-insert-toggles-remove](https://github.com/WordPress/gutenberg/assets/96308/439705ed-8b87-4dfa-b512-ad1fed9ec87e)
