### PR TITLE
Auto-inserting blocks: Add block icon to block inspector panel toggles

### DIFF
--- a/packages/block-editor/src/hooks/auto-inserting-blocks.js
+++ b/packages/block-editor/src/hooks/auto-inserting-blocks.js
@@ -4,7 +4,11 @@
 import { __ } from '@wordpress/i18n';
 import { addFilter } from '@wordpress/hooks';
 import { Fragment } from '@wordpress/element';
-import { PanelBody, ToggleControl } from '@wordpress/components';
+import {
+	__experimentalHStack as HStack,
+	PanelBody,
+	ToggleControl,
+} from '@wordpress/components';
 import { createHigherOrderComponent } from '@wordpress/compose';
 import { createBlock, store as blocksStore } from '@wordpress/blocks';
 import { useDispatch, useSelect } from '@wordpress/data';
@@ -174,12 +178,12 @@ function AutoInsertingBlocksControl( props ) {
 											checked={ checked }
 											key={ block.title }
 											label={
-												<>
+												<HStack justify="flex-start">
 													<BlockIcon
 														icon={ block.icon }
 													/>
-													{ block.title }
-												</>
+													<span>{ block.title }</span>
+												</HStack>
 											}
 											onChange={ () => {
 												if ( ! checked ) {

--- a/packages/block-editor/src/hooks/auto-inserting-blocks.js
+++ b/packages/block-editor/src/hooks/auto-inserting-blocks.js
@@ -151,7 +151,11 @@ function AutoInsertingBlocksControl( props ) {
 
 	return (
 		<InspectorControls>
-			<PanelBody title={ __( 'Plugins' ) } initialOpen={ true }>
+			<PanelBody
+				className="auto-inserting-blocks-panel"
+				title={ __( 'Plugins' ) }
+				initialOpen={ true }
+			>
 				{ Object.keys( groupedAutoInsertedBlocks ).map( ( vendor ) => {
 					return (
 						<Fragment key={ vendor }>

--- a/packages/block-editor/src/hooks/auto-inserting-blocks.js
+++ b/packages/block-editor/src/hooks/auto-inserting-blocks.js
@@ -152,7 +152,7 @@ function AutoInsertingBlocksControl( props ) {
 	return (
 		<InspectorControls>
 			<PanelBody
-				className="auto-inserting-blocks-panel"
+				className="block-editor-hooks__auto-inserting-blocks"
 				title={ __( 'Plugins' ) }
 				initialOpen={ true }
 			>

--- a/packages/block-editor/src/hooks/auto-inserting-blocks.js
+++ b/packages/block-editor/src/hooks/auto-inserting-blocks.js
@@ -12,7 +12,7 @@ import { useDispatch, useSelect } from '@wordpress/data';
 /**
  * Internal dependencies
  */
-import { InspectorControls } from '../components';
+import { BlockIcon, InspectorControls } from '../components';
 import { store as blockEditorStore } from '../store';
 
 function AutoInsertingBlocksControl( props ) {
@@ -169,7 +169,14 @@ function AutoInsertingBlocksControl( props ) {
 										<ToggleControl
 											checked={ checked }
 											key={ block.title }
-											label={ block.title }
+											label={
+												<>
+													<BlockIcon
+														icon={ block.icon }
+													/>
+													{ block.title }
+												</>
+											}
 											onChange={ () => {
 												if ( ! checked ) {
 													// Create and insert block.

--- a/packages/block-editor/src/hooks/auto-inserting-blocks.scss
+++ b/packages/block-editor/src/hooks/auto-inserting-blocks.scss
@@ -1,0 +1,5 @@
+.auto-inserting-blocks-panel {
+	.components-toggle-control .components-h-stack {
+		flex-direction: row-reverse;
+	}
+}

--- a/packages/block-editor/src/hooks/auto-inserting-blocks.scss
+++ b/packages/block-editor/src/hooks/auto-inserting-blocks.scss
@@ -1,4 +1,8 @@
 .auto-inserting-blocks-panel {
+	/**
+	 * Since we're displaying the block icon alongside the block name,
+	 * we need to right-align the toggle.
+	 */
 	.components-toggle-control .components-h-stack {
 		flex-direction: row-reverse;
 	}

--- a/packages/block-editor/src/hooks/auto-inserting-blocks.scss
+++ b/packages/block-editor/src/hooks/auto-inserting-blocks.scss
@@ -6,4 +6,11 @@
 	.components-toggle-control .components-h-stack {
 		flex-direction: row-reverse;
 	}
+
+	/**
+	 * Un-reverse the flex direction for the toggle's label.
+	 */
+	.components-toggle-control .components-h-stack .components-h-stack {
+		flex-direction: row;
+	}
 }

--- a/packages/block-editor/src/hooks/auto-inserting-blocks.scss
+++ b/packages/block-editor/src/hooks/auto-inserting-blocks.scss
@@ -1,4 +1,4 @@
-.auto-inserting-blocks-panel {
+.block-editor-hooks__auto-inserting-blocks {
 	/**
 	 * Since we're displaying the block icon alongside the block name,
 	 * we need to right-align the toggle.

--- a/packages/block-editor/src/style.scss
+++ b/packages/block-editor/src/style.scss
@@ -46,6 +46,7 @@
 @import "./components/url-input/style.scss";
 @import "./components/url-popover/style.scss";
 @import "./hooks/anchor.scss";
+@import "./hooks/auto-inserting-blocks.scss";
 @import "./hooks/border.scss";
 @import "./hooks/color.scss";
 @import "./hooks/dimensions.scss";


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Add block icons to block inspector panel toggle labels, and right-align the toggles.

## Why?
To match the original mockup from #52969. (Note that we don't seem to have precedent for right-aligning toggles; this was [briefly](https://github.com/WordPress/gutenberg/pull/52969#issuecomment-1655261663) [discussed](https://github.com/WordPress/gutenberg/pull/52969#issuecomment-1655440501), resulting in a tentative okay for trying out this pattern for this new feature.)

## How?
A bit of applied flexbox magic.

## Testing Instructions

_If you prefer video over text, there's a 5-minute demo in the PR description of https://github.com/WordPress/gutenberg/pull/52969 (still using the "Before" styling for the toggles, but you get the idea)._

- Enable the "Auto-inserting blocks" experiment on the Experiments page.
- Install the [Like Button example plugin](https://github.com/ockham/like-button/releases/download/v0.2.0/like-button.zip).
- Make sure you're using a Block Theme (e.g. Twenty Twenty Three) that uses the Comments (and Comment Template) block.
- Open the Site Editor to view the "Single" template.
- Select the Comment Template block, and open the block inspector sidebar.
- Switch to the ⚙️ ("Settings") tab.
- Verify that the "Plugins" panel is present, contains the toggle for the Like Button block, and that the toggle is styled akin to the "After" screenshot below.

## Screenshots or screencast <!-- if applicable -->
| Before | After |
|--------|------|
| ![image](https://github.com/WordPress/gutenberg/assets/96308/5b2bcf1e-32f7-4b43-8dfd-4d3bb8b463c2) | ![image](https://github.com/WordPress/gutenberg/assets/96308/de1d2c64-707d-4dcd-9f15-1918eaae9d9b)|