### PR TITLE
[Commands]: Fix `move to` command condition for registering

### DIFF
--- a/packages/block-editor/src/components/use-block-commands/index.js
+++ b/packages/block-editor/src/components/use-block-commands/index.js
@@ -126,6 +126,7 @@ const useActionsCommands = () => {
 		getBlocksByClientId,
 		canMoveBlocks,
 		canRemoveBlocks,
+		getBlockCount,
 	} = useSelect( blockEditorStore );
 	const { getDefaultBlockName, getGroupingBlockName } =
 		useSelect( blocksStore );
@@ -189,7 +190,9 @@ const useActionsCommands = () => {
 		);
 	} );
 	const canRemove = canRemoveBlocks( clientIds, rootClientId );
-	const canMove = canMoveBlocks( clientIds, rootClientId );
+	const canMove =
+		canMoveBlocks( clientIds, rootClientId ) &&
+		getBlockCount( rootClientId ) !== 1;
 
 	const commands = [
 		{


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Follow up of: https://github.com/WordPress/gutenberg/pull/53994, addressing @t-hamano 's [comment](https://github.com/WordPress/gutenberg/pull/53994#discussion_r1308763509) for fixing the condition where the `move to` command should be available.

>I think we also need to check that there is more than one block, just as [the Move to action on the block toolbar does](https://github.com/WordPress/gutenberg/blob/3a7404dd80067715da65caffb7f830b3ca218617/packages/block-editor/src/components/block-settings-menu-controls/index.js#L93).



## Testing Instructions
1. `move to` command should not be available when we have only one block at the first parent. Example is create a Group block and inserter just one block. Then test the command availability to that child block.
