### PR TITLE
Make matrix position behave like valign

### DIFF
--- a/packages/block-library/src/cover/style.scss
+++ b/packages/block-library/src/cover/style.scss
@@ -171,8 +171,19 @@
 	&.has-custom-content-position.has-custom-content-position {
 		.wp-block-cover__inner-container {
 			margin: 0;
-			width: auto;
 		}
+		&.is-position-top-left,
+		&.is-position-top-right,
+		&.is-position-center-left,
+		&.is-position-center-right,
+		&.is-position-bottom-left,
+		&.is-position-bottom-right {
+			.wp-block-cover__inner-container {
+				margin: 0;
+				width: auto;
+			}
+		}
+
 	}
 
 	// Extra specificity for in edit mode where other styles would override it otherwise.


### PR DESCRIPTION
Fixes #50610

I am unsure of this PR, because the matrix alignment is not valign. Should the cover block have a valign prop as well?

###Before

https://github.com/WordPress/gutenberg/assets/107534/5ce39d0b-bb24-4238-8305-28f7b432e72b

###After

https://github.com/WordPress/gutenberg/assets/107534/4597b514-800e-4c6c-9bd9-1b9b2ad803f6


