### PR TITLE
Upgrade Playwright to 1.39.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -95,7 +95,7 @@
 				"@octokit/rest": "16.26.0",
 				"@octokit/types": "6.34.0",
 				"@octokit/webhooks-types": "5.6.0",
-				"@playwright/test": "1.38.1",
+				"@playwright/test": "1.39.0",
 				"@pmmmwh/react-refresh-webpack-plugin": "0.5.11",
 				"@storybook/addon-a11y": "7.2.2",
 				"@storybook/addon-actions": "7.2.2",
@@ -7136,12 +7136,12 @@
 			}
 		},
 		"node_modules/@playwright/test": {
-			"version": "1.38.1",
-			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.38.1.tgz",
-			"integrity": "sha512-NqRp8XMwj3AK+zKLbZShl0r/9wKgzqI/527bkptKXomtuo+dOjU9NdMASQ8DNC9z9zLOMbG53T4eihYr3XR+BQ==",
+			"version": "1.39.0",
+			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.39.0.tgz",
+			"integrity": "sha512-3u1iFqgzl7zr004bGPYiN/5EZpRUSFddQBra8Rqll5N0/vfpqlP9I9EXqAoGacuAbX6c9Ulg/Cjqglp5VkK6UQ==",
 			"dev": true,
 			"dependencies": {
-				"playwright": "1.38.1"
+				"playwright": "1.39.0"
 			},
 			"bin": {
 				"playwright": "cli.js"
@@ -43226,12 +43226,12 @@
 			"dev": true
 		},
 		"node_modules/playwright": {
-			"version": "1.38.1",
-			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.38.1.tgz",
-			"integrity": "sha512-oRMSJmZrOu1FP5iu3UrCx8JEFRIMxLDM0c/3o4bpzU5Tz97BypefWf7TuTNPWeCe279TPal5RtPPZ+9lW/Qkow==",
+			"version": "1.39.0",
+			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.39.0.tgz",
+			"integrity": "sha512-naE5QT11uC/Oiq0BwZ50gDmy8c8WLPRTEWuSSFVG2egBka/1qMoSqYQcROMT9zLwJ86oPofcTH2jBY/5wWOgIw==",
 			"dev": true,
 			"dependencies": {
-				"playwright-core": "1.38.1"
+				"playwright-core": "1.39.0"
 			},
 			"bin": {
 				"playwright": "cli.js"
@@ -43256,9 +43256,9 @@
 			}
 		},
 		"node_modules/playwright/node_modules/playwright-core": {
-			"version": "1.38.1",
-			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.38.1.tgz",
-			"integrity": "sha512-tQqNFUKa3OfMf4b2jQ7aGLB8o9bS3bOY0yMEtldtC2+spf8QXG9zvXLTXUeRsoNuxEYMgLYR+NXfAa1rjKRcrg==",
+			"version": "1.39.0",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.39.0.tgz",
+			"integrity": "sha512-+k4pdZgs1qiM+OUkSjx96YiKsXsmb59evFoqv8SKO067qBA+Z2s/dCzJij/ZhdQcs2zlTAgRKfeiiLm8PQ2qvw==",
 			"dev": true,
 			"bin": {
 				"playwright-core": "cli.js"
@@ -56496,7 +56496,7 @@
 				"npm": ">=6.14.4"
 			},
 			"peerDependencies": {
-				"@playwright/test": "^1.32.0",
+				"@playwright/test": "^1.39.0",
 				"react": "^18.0.0",
 				"react-dom": "^18.0.0"
 			}
@@ -61645,12 +61645,12 @@
 			}
 		},
 		"@playwright/test": {
-			"version": "1.38.1",
-			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.38.1.tgz",
-			"integrity": "sha512-NqRp8XMwj3AK+zKLbZShl0r/9wKgzqI/527bkptKXomtuo+dOjU9NdMASQ8DNC9z9zLOMbG53T4eihYr3XR+BQ==",
+			"version": "1.39.0",
+			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.39.0.tgz",
+			"integrity": "sha512-3u1iFqgzl7zr004bGPYiN/5EZpRUSFddQBra8Rqll5N0/vfpqlP9I9EXqAoGacuAbX6c9Ulg/Cjqglp5VkK6UQ==",
 			"dev": true,
 			"requires": {
-				"playwright": "1.38.1"
+				"playwright": "1.39.0"
 			}
 		},
 		"@pmmmwh/react-refresh-webpack-plugin": {
@@ -90210,19 +90210,19 @@
 			"dev": true
 		},
 		"playwright": {
-			"version": "1.38.1",
-			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.38.1.tgz",
-			"integrity": "sha512-oRMSJmZrOu1FP5iu3UrCx8JEFRIMxLDM0c/3o4bpzU5Tz97BypefWf7TuTNPWeCe279TPal5RtPPZ+9lW/Qkow==",
+			"version": "1.39.0",
+			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.39.0.tgz",
+			"integrity": "sha512-naE5QT11uC/Oiq0BwZ50gDmy8c8WLPRTEWuSSFVG2egBka/1qMoSqYQcROMT9zLwJ86oPofcTH2jBY/5wWOgIw==",
 			"dev": true,
 			"requires": {
 				"fsevents": "2.3.2",
-				"playwright-core": "1.38.1"
+				"playwright-core": "1.39.0"
 			},
 			"dependencies": {
 				"playwright-core": {
-					"version": "1.38.1",
-					"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.38.1.tgz",
-					"integrity": "sha512-tQqNFUKa3OfMf4b2jQ7aGLB8o9bS3bOY0yMEtldtC2+spf8QXG9zvXLTXUeRsoNuxEYMgLYR+NXfAa1rjKRcrg==",
+					"version": "1.39.0",
+					"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.39.0.tgz",
+					"integrity": "sha512-+k4pdZgs1qiM+OUkSjx96YiKsXsmb59evFoqv8SKO067qBA+Z2s/dCzJij/ZhdQcs2zlTAgRKfeiiLm8PQ2qvw==",
 					"dev": true
 				}
 			}

--- a/package-lock.json
+++ b/package-lock.json
@@ -43243,18 +43243,6 @@
 				"fsevents": "2.3.2"
 			}
 		},
-		"node_modules/playwright-core": {
-			"version": "1.32.0",
-			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.32.0.tgz",
-			"integrity": "sha512-Z9Ij17X5Z3bjpp6XKujGBp9Gv4eViESac9aDmwgQFUEJBW0K80T21m/Z+XJQlu4cNsvPygw33b6V1Va6Bda5zQ==",
-			"dev": true,
-			"bin": {
-				"playwright": "cli.js"
-			},
-			"engines": {
-				"node": ">=14"
-			}
-		},
 		"node_modules/playwright/node_modules/playwright-core": {
 			"version": "1.39.0",
 			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.39.0.tgz",
@@ -56469,7 +56457,7 @@
 				"minimist": "^1.2.0",
 				"npm-package-json-lint": "^6.4.0",
 				"npm-packlist": "^3.0.0",
-				"playwright-core": "1.32.0",
+				"playwright-core": "1.39.0",
 				"postcss": "^8.4.5",
 				"postcss-loader": "^6.2.1",
 				"prettier": "npm:wp-prettier@3.0.3",
@@ -56499,6 +56487,18 @@
 				"@playwright/test": "^1.39.0",
 				"react": "^18.0.0",
 				"react-dom": "^18.0.0"
+			}
+		},
+		"packages/scripts/node_modules/playwright-core": {
+			"version": "1.39.0",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.39.0.tgz",
+			"integrity": "sha512-+k4pdZgs1qiM+OUkSjx96YiKsXsmb59evFoqv8SKO067qBA+Z2s/dCzJij/ZhdQcs2zlTAgRKfeiiLm8PQ2qvw==",
+			"dev": true,
+			"bin": {
+				"playwright-core": "cli.js"
+			},
+			"engines": {
+				"node": ">=16"
 			}
 		},
 		"packages/server-side-render": {
@@ -71140,7 +71140,7 @@
 				"minimist": "^1.2.0",
 				"npm-package-json-lint": "^6.4.0",
 				"npm-packlist": "^3.0.0",
-				"playwright-core": "1.32.0",
+				"playwright-core": "1.39.0",
 				"postcss": "^8.4.5",
 				"postcss-loader": "^6.2.1",
 				"prettier": "npm:wp-prettier@3.0.3",
@@ -71158,6 +71158,14 @@
 				"webpack-bundle-analyzer": "^4.9.1",
 				"webpack-cli": "^5.1.4",
 				"webpack-dev-server": "^4.15.1"
+			},
+			"dependencies": {
+				"playwright-core": {
+					"version": "1.39.0",
+					"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.39.0.tgz",
+					"integrity": "sha512-+k4pdZgs1qiM+OUkSjx96YiKsXsmb59evFoqv8SKO067qBA+Z2s/dCzJij/ZhdQcs2zlTAgRKfeiiLm8PQ2qvw==",
+					"dev": true
+				}
 			}
 		},
 		"@wordpress/server-side-render": {
@@ -90226,12 +90234,6 @@
 					"dev": true
 				}
 			}
-		},
-		"playwright-core": {
-			"version": "1.32.0",
-			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.32.0.tgz",
-			"integrity": "sha512-Z9Ij17X5Z3bjpp6XKujGBp9Gv4eViESac9aDmwgQFUEJBW0K80T21m/Z+XJQlu4cNsvPygw33b6V1Va6Bda5zQ==",
-			"dev": true
 		},
 		"please-upgrade-node": {
 			"version": "3.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -95,7 +95,7 @@
 				"@octokit/rest": "16.26.0",
 				"@octokit/types": "6.34.0",
 				"@octokit/webhooks-types": "5.6.0",
-				"@playwright/test": "1.32.0",
+				"@playwright/test": "1.38.1",
 				"@pmmmwh/react-refresh-webpack-plugin": "0.5.11",
 				"@storybook/addon-a11y": "7.2.2",
 				"@storybook/addon-actions": "7.2.2",
@@ -7136,22 +7136,18 @@
 			}
 		},
 		"node_modules/@playwright/test": {
-			"version": "1.32.0",
-			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.32.0.tgz",
-			"integrity": "sha512-zOdGloaF0jeec7hqoLqM5S3L2rR4WxMJs6lgiAeR70JlH7Ml54ZPoIIf3X7cvnKde3Q9jJ/gaxkFh8fYI9s1rg==",
+			"version": "1.38.1",
+			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.38.1.tgz",
+			"integrity": "sha512-NqRp8XMwj3AK+zKLbZShl0r/9wKgzqI/527bkptKXomtuo+dOjU9NdMASQ8DNC9z9zLOMbG53T4eihYr3XR+BQ==",
 			"dev": true,
 			"dependencies": {
-				"@types/node": "*",
-				"playwright-core": "1.32.0"
+				"playwright": "1.38.1"
 			},
 			"bin": {
 				"playwright": "cli.js"
 			},
 			"engines": {
-				"node": ">=14"
-			},
-			"optionalDependencies": {
-				"fsevents": "2.3.2"
+				"node": ">=16"
 			}
 		},
 		"node_modules/@pmmmwh/react-refresh-webpack-plugin": {
@@ -43229,6 +43225,24 @@
 			"integrity": "sha512-TuvHS8AOIZNAlE77WUDiR4rySV/VMptyMfcfeoMgs4P8apaZM3JrnbzBiixKUv+XR6i+BXrQh8WAnjaSPFO65Q==",
 			"dev": true
 		},
+		"node_modules/playwright": {
+			"version": "1.38.1",
+			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.38.1.tgz",
+			"integrity": "sha512-oRMSJmZrOu1FP5iu3UrCx8JEFRIMxLDM0c/3o4bpzU5Tz97BypefWf7TuTNPWeCe279TPal5RtPPZ+9lW/Qkow==",
+			"dev": true,
+			"dependencies": {
+				"playwright-core": "1.38.1"
+			},
+			"bin": {
+				"playwright": "cli.js"
+			},
+			"engines": {
+				"node": ">=16"
+			},
+			"optionalDependencies": {
+				"fsevents": "2.3.2"
+			}
+		},
 		"node_modules/playwright-core": {
 			"version": "1.32.0",
 			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.32.0.tgz",
@@ -43239,6 +43253,18 @@
 			},
 			"engines": {
 				"node": ">=14"
+			}
+		},
+		"node_modules/playwright/node_modules/playwright-core": {
+			"version": "1.38.1",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.38.1.tgz",
+			"integrity": "sha512-tQqNFUKa3OfMf4b2jQ7aGLB8o9bS3bOY0yMEtldtC2+spf8QXG9zvXLTXUeRsoNuxEYMgLYR+NXfAa1rjKRcrg==",
+			"dev": true,
+			"bin": {
+				"playwright-core": "cli.js"
+			},
+			"engines": {
+				"node": ">=16"
 			}
 		},
 		"node_modules/please-upgrade-node": {
@@ -61619,14 +61645,12 @@
 			}
 		},
 		"@playwright/test": {
-			"version": "1.32.0",
-			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.32.0.tgz",
-			"integrity": "sha512-zOdGloaF0jeec7hqoLqM5S3L2rR4WxMJs6lgiAeR70JlH7Ml54ZPoIIf3X7cvnKde3Q9jJ/gaxkFh8fYI9s1rg==",
+			"version": "1.38.1",
+			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.38.1.tgz",
+			"integrity": "sha512-NqRp8XMwj3AK+zKLbZShl0r/9wKgzqI/527bkptKXomtuo+dOjU9NdMASQ8DNC9z9zLOMbG53T4eihYr3XR+BQ==",
 			"dev": true,
 			"requires": {
-				"@types/node": "*",
-				"fsevents": "2.3.2",
-				"playwright-core": "1.32.0"
+				"playwright": "1.38.1"
 			}
 		},
 		"@pmmmwh/react-refresh-webpack-plugin": {
@@ -90184,6 +90208,24 @@
 			"resolved": "https://registry.npmjs.org/platform/-/platform-1.3.5.tgz",
 			"integrity": "sha512-TuvHS8AOIZNAlE77WUDiR4rySV/VMptyMfcfeoMgs4P8apaZM3JrnbzBiixKUv+XR6i+BXrQh8WAnjaSPFO65Q==",
 			"dev": true
+		},
+		"playwright": {
+			"version": "1.38.1",
+			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.38.1.tgz",
+			"integrity": "sha512-oRMSJmZrOu1FP5iu3UrCx8JEFRIMxLDM0c/3o4bpzU5Tz97BypefWf7TuTNPWeCe279TPal5RtPPZ+9lW/Qkow==",
+			"dev": true,
+			"requires": {
+				"fsevents": "2.3.2",
+				"playwright-core": "1.38.1"
+			},
+			"dependencies": {
+				"playwright-core": {
+					"version": "1.38.1",
+					"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.38.1.tgz",
+					"integrity": "sha512-tQqNFUKa3OfMf4b2jQ7aGLB8o9bS3bOY0yMEtldtC2+spf8QXG9zvXLTXUeRsoNuxEYMgLYR+NXfAa1rjKRcrg==",
+					"dev": true
+				}
+			}
 		},
 		"playwright-core": {
 			"version": "1.32.0",

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
 		"@octokit/rest": "16.26.0",
 		"@octokit/types": "6.34.0",
 		"@octokit/webhooks-types": "5.6.0",
-		"@playwright/test": "1.32.0",
+		"@playwright/test": "1.38.1",
 		"@pmmmwh/react-refresh-webpack-plugin": "0.5.11",
 		"@storybook/addon-a11y": "7.2.2",
 		"@storybook/addon-actions": "7.2.2",

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
 		"@octokit/rest": "16.26.0",
 		"@octokit/types": "6.34.0",
 		"@octokit/webhooks-types": "5.6.0",
-		"@playwright/test": "1.38.1",
+		"@playwright/test": "1.39.0",
 		"@pmmmwh/react-refresh-webpack-plugin": "0.5.11",
 		"@storybook/addon-a11y": "7.2.2",
 		"@storybook/addon-actions": "7.2.2",

--- a/packages/e2e-test-utils-playwright/src/page-utils/drag-files.ts
+++ b/packages/e2e-test-utils-playwright/src/page-utils/drag-files.ts
@@ -9,7 +9,7 @@ import { getType } from 'mime';
  * Internal dependencies
  */
 import type { PageUtils } from './index';
-import type { ElementHandle, Locator } from '@playwright/test';
+import type { Locator } from '@playwright/test';
 
 type FileObject = {
 	name: string;
@@ -118,25 +118,21 @@ async function dragFiles(
 
 		/**
 		 * Drop the files at the current position.
-		 *
-		 * @param locator
 		 */
-		drop: async ( locator: Locator | ElementHandle | null ) => {
-			if ( ! locator ) {
-				const topMostElement = await this.page.evaluateHandle(
-					( { x, y } ) => {
-						return document.elementFromPoint( x, y );
-					},
-					position
-				);
-				locator = topMostElement.asElement();
-			}
+		drop: async () => {
+			const topMostElement = await this.page.evaluateHandle(
+				( { x, y } ) => {
+					return document.elementFromPoint( x, y );
+				},
+				position
+			);
+			const elementHandle = topMostElement.asElement();
 
-			if ( ! locator ) {
+			if ( ! elementHandle ) {
 				throw new Error( 'Element not found.' );
 			}
 
-			const dataTransfer = await locator.evaluateHandle(
+			const dataTransfer = await elementHandle.evaluateHandle(
 				async ( _node, _fileObjects ) => {
 					const dt = new DataTransfer();
 					const fileInstances = await Promise.all(
@@ -159,7 +155,7 @@ async function dragFiles(
 				fileObjects
 			);
 
-			await locator.dispatchEvent( 'drop', { dataTransfer } );
+			await elementHandle.dispatchEvent( 'drop', { dataTransfer } );
 
 			await cdpSession.detach();
 		},

--- a/packages/e2e-test-utils-playwright/src/page-utils/drag-files.ts
+++ b/packages/e2e-test-utils-playwright/src/page-utils/drag-files.ts
@@ -122,7 +122,15 @@ async function dragFiles(
 		drop: async () => {
 			const topMostElement = await this.page.evaluateHandle(
 				( { x, y } ) => {
-					return document.elementFromPoint( x, y );
+					const element = document.elementFromPoint( x, y );
+					if ( element instanceof HTMLIFrameElement ) {
+						const offsetBox = element.getBoundingClientRect();
+						return element.contentDocument!.elementFromPoint(
+							x - offsetBox.x,
+							y - offsetBox.y
+						);
+					}
+					return element;
 				},
 				position
 			);

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -92,7 +92,7 @@
 		"webpack-dev-server": "^4.15.1"
 	},
 	"peerDependencies": {
-		"@playwright/test": "^1.32.0",
+		"@playwright/test": "^1.39.0",
 		"react": "^18.0.0",
 		"react-dom": "^18.0.0"
 	},

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -72,7 +72,7 @@
 		"minimist": "^1.2.0",
 		"npm-package-json-lint": "^6.4.0",
 		"npm-packlist": "^3.0.0",
-		"playwright-core": "1.32.0",
+		"playwright-core": "1.39.0",
 		"postcss": "^8.4.5",
 		"postcss-loader": "^6.2.1",
 		"prettier": "npm:wp-prettier@3.0.3",

--- a/packages/scripts/scripts/test-playwright.js
+++ b/packages/scripts/scripts/test-playwright.js
@@ -12,6 +12,7 @@ process.on( 'unhandledRejection', ( err ) => {
 /**
  * External dependencies
  */
+const path = require( 'path' );
 const { resolve } = require( 'node:path' );
 const { sync: spawn } = require( 'cross-spawn' );
 
@@ -27,7 +28,10 @@ const {
 
 const result = spawn(
 	'node',
-	[ require.resolve( 'playwright-core/cli' ), 'install' ],
+	[
+		path.resolve( require.resolve( 'playwright-core' ), '..', 'cli.js' ),
+		'install',
+	],
 	{
 		stdio: 'inherit',
 	}

--- a/test/e2e/specs/editor/blocks/image.spec.js
+++ b/test/e2e/specs/editor/blocks/image.spec.js
@@ -47,7 +47,9 @@ test.describe( 'Image', () => {
 			imageBlock.locator( 'data-testid=form-file-upload-input' )
 		);
 
-		const image = imageBlock.locator( 'role=img' );
+		const image = imageBlock.getByRole( 'img', {
+			name: 'This image has an empty alt attribute',
+		} );
 		await expect( image ).toBeVisible();
 		await expect( image ).toHaveAttribute( 'src', new RegExp( filename ) );
 
@@ -69,7 +71,9 @@ test.describe( 'Image', () => {
 		const imageBlock = editor.canvas.locator(
 			'role=document[name="Block: Image"i]'
 		);
-		const image = imageBlock.locator( 'role=img' );
+		const image = imageBlock.getByRole( 'img', {
+			name: 'This image has an empty alt attribute',
+		} );
 
 		const filename = await imageBlockUtils.upload(
 			imageBlock.locator( 'data-testid=form-file-upload-input' )
@@ -98,7 +102,9 @@ test.describe( 'Image', () => {
 		const imageBlock = editor.canvas.locator(
 			'role=document[name="Block: Image"i]'
 		);
-		const image = imageBlock.locator( 'role=img' );
+		const image = imageBlock.getByRole( 'img', {
+			name: 'This image has an empty alt attribute',
+		} );
 
 		const fileName = await imageBlockUtils.upload(
 			imageBlock.locator( 'data-testid=form-file-upload-input' )
@@ -129,7 +135,9 @@ test.describe( 'Image', () => {
 		const imageBlock = editor.canvas.locator(
 			'role=document[name="Block: Image"i]'
 		);
-		const image = imageBlock.locator( 'role=img' );
+		const image = imageBlock.getByRole( 'img', {
+			name: 'This image has an empty alt attribute',
+		} );
 
 		const fileName = await imageBlockUtils.upload(
 			imageBlock.locator( 'data-testid=form-file-upload-input' )
@@ -182,7 +190,9 @@ test.describe( 'Image', () => {
 		const imageBlock = editor.canvas.locator(
 			'role=document[name="Block: Image"i]'
 		);
-		const image = imageBlock.locator( 'role=img' );
+		const image = imageBlock.getByRole( 'img', {
+			name: 'This image has an empty alt attribute',
+		} );
 
 		const tmpInput = await page.evaluateHandle( () => {
 			const input = document.createElement( 'input' );
@@ -226,7 +236,9 @@ test.describe( 'Image', () => {
 		const imageBlock = editor.canvas.locator(
 			'role=document[name="Block: Image"i]'
 		);
-		const image = imageBlock.locator( 'role=img' );
+		const image = imageBlock.getByRole( 'img', {
+			name: 'This image has an empty alt attribute',
+		} );
 
 		const filename = await imageBlockUtils.upload(
 			imageBlock.locator( 'data-testid=form-file-upload-input' )
@@ -292,7 +304,9 @@ test.describe( 'Image', () => {
 		const imageBlock = editor.canvas.locator(
 			'role=document[name="Block: Image"i]'
 		);
-		const image = imageBlock.locator( 'role=img' );
+		const image = imageBlock.getByRole( 'img', {
+			name: 'This image has an empty alt attribute',
+		} );
 
 		const filename = await imageBlockUtils.upload(
 			imageBlock.locator( 'data-testid=form-file-upload-input' )
@@ -349,7 +363,9 @@ test.describe( 'Image', () => {
 		const imageBlock = editor.canvas.locator(
 			'role=document[name="Block: Image"i]'
 		);
-		const image = imageBlock.locator( 'role=img' );
+		const image = imageBlock.getByRole( 'img', {
+			name: 'This image has an empty alt attribute',
+		} );
 
 		const filename = await imageBlockUtils.upload(
 			imageBlock.locator( 'data-testid=form-file-upload-input' )
@@ -385,7 +401,9 @@ test.describe( 'Image', () => {
 		const imageBlock = editor.canvas.locator(
 			'role=document[name="Block: Image"i]'
 		);
-		const image = imageBlock.locator( 'role=img' );
+		const image = imageBlock.getByRole( 'img', {
+			name: 'This image has an empty alt attribute',
+		} );
 
 		const filename = await imageBlockUtils.upload(
 			imageBlock.locator( 'data-testid=form-file-upload-input' )
@@ -572,7 +590,9 @@ test.describe( 'Image', () => {
 			imageBlock.locator( 'data-testid=form-file-upload-input' )
 		);
 
-		const imageInEditor = imageBlock.locator( 'role=img' );
+		const imageInEditor = imageBlock.getByRole( 'img', {
+			name: 'This image has an empty alt attribute',
+		} );
 		await expect( imageInEditor ).toBeVisible();
 		await expect( imageInEditor ).toHaveAttribute(
 			'src',

--- a/test/e2e/specs/editor/blocks/paragraph.spec.js
+++ b/test/e2e/specs/editor/blocks/paragraph.spec.js
@@ -83,9 +83,7 @@ test.describe( 'Paragraph', () => {
 			await expect( draggingUtils.dropZone ).toBeVisible();
 			await expect( draggingUtils.insertionIndicator ).toBeHidden();
 
-			await drop(
-				editor.canvas.locator( '[data-type="core/paragraph"]' )
-			);
+			await drop();
 
 			const imageBlock = editor.canvas.locator(
 				'role=document[name="Block: Image"i]'

--- a/test/e2e/specs/editor/various/draggable-blocks.spec.js
+++ b/test/e2e/specs/editor/various/draggable-blocks.spec.js
@@ -414,7 +414,7 @@ test.describe( 'Draggable block', () => {
 				'Dragging over the empty group block but outside the appender should still show the blue background'
 			).toHaveCSS( 'background-color', 'rgb(0, 124, 186)' );
 
-			await drop( rowBlock );
+			await drop();
 			await expect( rowAppender ).toBeHidden();
 			await expect.poll( editor.getBlocks ).toMatchObject( [
 				{
@@ -446,7 +446,7 @@ test.describe( 'Draggable block', () => {
 				'rgb(0, 124, 186)'
 			);
 
-			await drop( columnAppender );
+			await drop();
 			await expect( columnAppender ).toBeHidden();
 			await expect.poll( editor.getBlocks ).toMatchObject( [
 				{ name: 'core/group' },

--- a/test/e2e/specs/editor/various/multi-block-selection.spec.js
+++ b/test/e2e/specs/editor/various/multi-block-selection.spec.js
@@ -247,15 +247,14 @@ test.describe( 'Multi-block selection', () => {
 		editor,
 		multiBlockSelectionUtils,
 	} ) => {
-		// To do: run with iframe.
-		await editor.switchToLegacyCanvas();
-
-		await page.getByRole( 'button', { name: 'Add default block' } ).click();
+		await editor.canvas
+			.getByRole( 'button', { name: 'Add default block' } )
+			.click();
 		await page.keyboard.type( '1' );
 		await page.keyboard.press( 'Enter' );
 		await page.keyboard.type( '2' );
 
-		await page
+		await editor.canvas
 			.getByRole( 'document', { name: 'Block: Paragraph' } )
 			.filter( { hasText: '1' } )
 			.click( { modifiers: [ 'Shift' ] } );
@@ -272,11 +271,11 @@ test.describe( 'Multi-block selection', () => {
 			.getByRole( 'toolbar', { name: 'Block tools' } )
 			.getByRole( 'button', { name: 'Group' } )
 			.click();
-		await page
+		await editor.canvas
 			.getByRole( 'document', { name: 'Block: Paragraph' } )
 			.filter( { hasText: '1' } )
 			.click();
-		await page
+		await editor.canvas
 			.getByRole( 'document', { name: 'Block: Paragraph' } )
 			.filter( { hasText: '2' } )
 			.click( { modifiers: [ 'Shift' ] } );


### PR DESCRIPTION
## What?
Upgrade Playwright to 1.39.0

## What's new?
* [locatorAssertions.toBeAttached()](https://playwright.dev/docs/api/class-locatorassertions#locator-assertions-to-be-attached).
* [locator.and()](https://playwright.dev/docs/api/class-locator#locator-and) and [locator.or()](https://playwright.dev/docs/api/class-locator#locator-or).
* UI Mode now shows steps, fixtures, and attachments.
* Requires Node.js >= 16.

## Testing Instructions
CI checks are green.