### PR TITLE
Post navigation link: Fix the writing mode setting on the front.

### DIFF
--- a/packages/block-library/src/post-navigation-link/index.php
+++ b/packages/block-library/src/post-navigation-link/index.php
@@ -28,7 +28,16 @@ function render_block_core_post_navigation_link( $attributes, $content ) {
 	if ( isset( $attributes['textAlign'] ) ) {
 		$classes .= " has-text-align-{$attributes['textAlign']}";
 	}
-	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => $classes ) );
+	$styles = '';
+	if ( isset( $attributes['style']['typography']['writingMode'] ) ) {
+		$styles = "writing-mode:{$attributes['style']['typography']['writingMode']};";
+	}
+	$wrapper_attributes = get_block_wrapper_attributes(
+		array(
+			'class' => $classes,
+			'style' => $styles,
+		)
+	);
 	// Set default values.
 	$format = '%link';
 	$link   = 'next' === $navigation_type ? _x( 'Next', 'label for next post link' ) : _x( 'Previous', 'label for previous post link' );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
The post navigation link block does not have the writing mode styles applied on the front.
This PR adds the styles to the wrapper in the index.php file.
Closes https://github.com/WordPress/gutenberg/issues/54052

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The style was not printed on the front, only in the editor.

## Testing Instructions

Activate a block theme.
The writing mode setting is disabled by default; set it to true in theme.json settings > typography > writingMode
```
	"settings": {
		"typography": {
			"writingMode": true
		}
	}
```

In the block editor, add a post navigation link block (next or previous). 
Open the block settings sidebar and select the more options in the typography panel.
Enable the text orientation panel, and the vertical text orientation option.
Save and view the front of the website.
Confirm that the text is vertical.

Try the vertical text orientation option together with some other options like the arrow, font size, and colors.

## Screenshots or screencast <!-- if applicable -->
