### PR TITLE
Footnotes: Add missing placeholder instructions text

### DIFF
--- a/packages/block-library/src/footnotes/edit.js
+++ b/packages/block-library/src/footnotes/edit.js
@@ -23,7 +23,9 @@ export default function FootnotesEdit( { context: { postType, postId } } ) {
 				<Placeholder
 					icon={ <BlockIcon icon={ icon } /> }
 					label={ __( 'Footnotes' ) }
-					// To do: add instructions. We can't add new string in RC.
+					instructions={ __(
+						'Footnotes are not supported here. Add this block to post or page content.'
+					) }
 				/>
 			</div>
 		);


### PR DESCRIPTION
## What?
This is a follow-up to #52934.

PR adds placeholder instructions text when the Footnotes block isn't available for custom post types.

## Why?
While we can't introduce a new string during WP release RCs, there's no need to adhere to the same limitation in the plugin.

## Testing Instructions
1. Open any custom post type.
2. Add footnotes block.
3. Confirm placeholder instruction is correctly displayed.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2023-08-30 at 15 44 28](https://github.com/WordPress/gutenberg/assets/240569/149f4175-e1f7-4b13-9235-8e6eaf79d4b8)
