### PR TITLE
Improve Link Control accessibility

### DIFF
--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -22,7 +22,7 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import { store as preferencesStore } from '@wordpress/preferences';
 import { keyboardReturn } from '@wordpress/icons';
 import { useInstanceId } from '@wordpress/compose';
-
+import { speak } from '@wordpress/a11y';
 /**
  * Internal dependencies
  */
@@ -208,11 +208,24 @@ function LinkControl( {
 	const { createPage, isCreatingPage, errorMessage } =
 		useCreatePage( createSuggestion );
 
+	function setEditingMode( nextEditingMode ) {
+		setIsEditingLink( nextEditingMode );
+
+		speak(
+			nextEditingMode
+				? __( 'Entering link edit mode' )
+				: __( 'Leaving link edit mode' ),
+			'assertive'
+		);
+	}
+
 	useEffect( () => {
 		if ( forceIsEditingLink === undefined ) {
 			return;
 		}
 
+		// Do not announcement automattic mode state change
+		// via speak().
 		setIsEditingLink( forceIsEditingLink );
 	}, [ forceIsEditingLink ] );
 
@@ -250,7 +263,7 @@ function LinkControl( {
 			wrapperNode.current.ownerDocument.activeElement
 		);
 
-		setIsEditingLink( false );
+		setEditingMode( false );
 	};
 
 	const handleSelectSuggestion = ( updatedValue ) => {
@@ -452,7 +465,7 @@ function LinkControl( {
 					<LinkPreview
 						key={ value?.url } // force remount when URL changes to avoid race conditions for rich previews
 						value={ value }
-						onEditClick={ () => setIsEditingLink( true ) }
+						onEditClick={ () => setEditingMode( true ) }
 						hasRichPreviews={ hasRichPreviews }
 						hasUnlinkControl={ shownUnlinkControl }
 						additionalControls={ () => {
@@ -477,7 +490,7 @@ function LinkControl( {
 						} }
 						onRemove={ () => {
 							onRemove();
-							setIsEditingLink( true );
+							setEditingMode( true );
 						} }
 					/>
 				</>

--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -376,10 +376,6 @@ function LinkControl( {
 			aria-labelledby={ dialogTitleId }
 			aria-describedby={ dialogDescritionId }
 		>
-			<VisuallyHidden>
-				<h2 id={ dialogTitleId }>Link</h2>
-			</VisuallyHidden>
-
 			{ isCreatingPage && (
 				<div className="block-editor-link-control__loading">
 					<Spinner />
@@ -390,6 +386,8 @@ function LinkControl( {
 			{ isEditing && (
 				<>
 					<VisuallyHidden>
+						<h2 id={ dialogTitleId }>{ __( 'Edit Link' ) }</h2>
+
 						<p id={ dialogDescritionId }>
 							{ __( 'Editing the link.' ) }
 						</p>
@@ -496,6 +494,7 @@ function LinkControl( {
 			{ isPreviewing && (
 				<>
 					<VisuallyHidden>
+						<h2 id={ dialogTitleId }>{ __( 'Preview Link' ) }</h2>
 						<p id={ dialogDescritionId }>
 							{ __( 'Previewing the currently selected link.' ) }
 						</p>

--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -224,7 +224,7 @@ function LinkControl( {
 			return;
 		}
 
-		// Do not announcement automattic mode state change
+		// Do not announcement automatic mode state change
 		// via speak().
 		setIsEditingLink( forceIsEditingLink );
 	}, [ forceIsEditingLink ] );

--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -13,7 +13,7 @@ import {
 	TextControl,
 	VisuallyHidden,
 } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { useRef, useState, useEffect } from '@wordpress/element';
 import { focus } from '@wordpress/dom';
 import { ENTER } from '@wordpress/keycodes';
@@ -355,6 +355,7 @@ function LinkControl( {
 	const showTextControl = hasLinkValue && hasTextControl;
 
 	const isEditing = ( isEditingLink || ! value ) && ! isCreatingPage;
+	const isCreating = isEditingLink && ! value && ! isCreatingPage;
 	const isDisabled = ! valueHasChanges || currentInputIsEmpty;
 	const showSettings = !! settings?.length && isEditingLink && hasLinkValue;
 
@@ -386,10 +387,20 @@ function LinkControl( {
 			{ isEditing && (
 				<>
 					<VisuallyHidden>
-						<h2 id={ dialogTitleId }>{ __( 'Edit Link' ) }</h2>
+						<h2 id={ dialogTitleId }>
+							{ sprintf(
+								// translators: %s: action name for the link mode (edit or create).
+								__( '%s Link' ),
+								isCreating ? __( 'Create' ) : __( 'Edit' )
+							) }
+						</h2>
 
 						<p id={ dialogDescritionId }>
-							{ __( 'Editing the link.' ) }
+							{ sprintf(
+								// translators: %s: action name for the link action (edit or create).
+								__( '%s the link' ),
+								isCreating ? __( 'Creating' ) : __( 'Editing' )
+							) }
 						</p>
 					</VisuallyHidden>
 					<div

--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -367,6 +367,7 @@ function LinkControl( {
 		`block-editor-link-control___description`
 	);
 
+	const isPreviewing = value && ! isEditingLink && ! isCreatingPage;
 	return (
 		<div
 			tabIndex={ -1 }
@@ -452,10 +453,47 @@ function LinkControl( {
 							{ errorMessage }
 						</Notice>
 					) }
+
+					{ showSettings && (
+						<div className="block-editor-link-control__tools">
+							{ ! currentInputIsEmpty && (
+								<LinkControlSettingsDrawer
+									settingsOpen={ isSettingsOpen }
+									setSettingsOpen={
+										setSettingsOpenWithPreference
+									}
+								>
+									<LinkSettings
+										value={ internalControlValue }
+										settings={ settings }
+										onChange={ createSetInternalSettingValueHandler(
+											settingsKeys
+										) }
+									/>
+								</LinkControlSettingsDrawer>
+							) }
+						</div>
+					) }
+
+					{ showActions && (
+						<div className="block-editor-link-control__search-actions">
+							<Button
+								variant="primary"
+								onClick={ isDisabled ? noop : handleSubmit }
+								className="block-editor-link-control__search-submit"
+								aria-disabled={ isDisabled }
+							>
+								{ __( 'Save' ) }
+							</Button>
+							<Button variant="tertiary" onClick={ handleCancel }>
+								{ __( 'Cancel' ) }
+							</Button>
+						</div>
+					) }
 				</>
 			) }
 
-			{ value && ! isEditingLink && ! isCreatingPage && (
+			{ isPreviewing && (
 				<>
 					<VisuallyHidden>
 						<p id={ dialogDescritionId }>
@@ -494,41 +532,6 @@ function LinkControl( {
 						} }
 					/>
 				</>
-			) }
-
-			{ showSettings && (
-				<div className="block-editor-link-control__tools">
-					{ ! currentInputIsEmpty && (
-						<LinkControlSettingsDrawer
-							settingsOpen={ isSettingsOpen }
-							setSettingsOpen={ setSettingsOpenWithPreference }
-						>
-							<LinkSettings
-								value={ internalControlValue }
-								settings={ settings }
-								onChange={ createSetInternalSettingValueHandler(
-									settingsKeys
-								) }
-							/>
-						</LinkControlSettingsDrawer>
-					) }
-				</div>
-			) }
-
-			{ showActions && (
-				<div className="block-editor-link-control__search-actions">
-					<Button
-						variant="primary"
-						onClick={ isDisabled ? noop : handleSubmit }
-						className="block-editor-link-control__search-submit"
-						aria-disabled={ isDisabled }
-					>
-						{ __( 'Save' ) }
-					</Button>
-					<Button variant="tertiary" onClick={ handleCancel }>
-						{ __( 'Cancel' ) }
-					</Button>
-				</div>
 			) }
 
 			{ renderControlBottom && renderControlBottom() }

--- a/packages/block-editor/src/components/link-control/link-preview.js
+++ b/packages/block-editor/src/components/link-control/link-preview.js
@@ -10,6 +10,7 @@ import { __ } from '@wordpress/i18n';
 import {
 	Button,
 	ExternalLink,
+	VisuallyHidden,
 	__experimentalText as Text,
 } from '@wordpress/components';
 import { filterURLForDisplay, safeDecodeURI } from '@wordpress/url';
@@ -20,7 +21,6 @@ import { __unstableStripHTML as stripHTML } from '@wordpress/dom';
  * Internal dependencies
  */
 import { ViewerSlot } from './viewer-slot';
-
 import useRichUrlData from './use-rich-url-data';
 
 export default function LinkPreview( {
@@ -84,28 +84,43 @@ export default function LinkPreview( {
 					>
 						{ icon }
 					</span>
-					<span className="block-editor-link-control__search-item-details">
+					<dl className="block-editor-link-control__search-item-details">
 						{ ! isEmptyURL ? (
 							<>
-								<ExternalLink
-									className="block-editor-link-control__search-item-title"
-									href={ value.url }
-								>
-									{ displayTitle }
-								</ExternalLink>
+								<VisuallyHidden>
+									<dt>Link title</dt>
+								</VisuallyHidden>
+								<dd>
+									<ExternalLink
+										className="block-editor-link-control__search-item-title"
+										href={ value.url }
+									>
+										{ displayTitle }
+									</ExternalLink>
+								</dd>
 
 								{ value?.url && displayTitle !== displayURL && (
-									<span className="block-editor-link-control__search-item-info">
-										{ displayURL }
-									</span>
+									<>
+										<VisuallyHidden>
+											<dt>Link URL</dt>
+										</VisuallyHidden>
+										<dd className="block-editor-link-control__search-item-info">
+											{ displayURL }
+										</dd>
+									</>
 								) }
 							</>
 						) : (
-							<span className="block-editor-link-control__search-item-error-notice">
-								{ __( 'Link is empty' ) }
-							</span>
+							<>
+								<VisuallyHidden>
+									<dt>Link value</dt>
+								</VisuallyHidden>
+								<dd className="block-editor-link-control__search-item-error-notice">
+									{ __( 'Link is empty' ) }
+								</dd>
+							</>
 						) }
-					</span>
+					</dl>
 				</span>
 
 				<Button

--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -412,6 +412,16 @@ $preview-image-height: 140px;
 	padding-right: $grid-unit-20;
 }
 
+.block-editor-link-control__search-item-details {
+	margin-block-start: 0;
+	margin-block-end: 0;
+
+	dd {
+		margin-inline-start: 0;
+		margin-block-end: 0;
+	}
+}
+
 .block-editor-link-control__setting {
 	margin-bottom: 0;
 	flex: 1;

--- a/packages/block-library/src/navigation-link/link-ui.js
+++ b/packages/block-library/src/navigation-link/link-ui.js
@@ -4,6 +4,7 @@
 import { __unstableStripHTML as stripHTML } from '@wordpress/dom';
 import { Popover, Button } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
+import { speak } from '@wordpress/a11y';
 import {
 	__experimentalLinkControl as LinkControl,
 	BlockIcon,
@@ -138,6 +139,14 @@ export function LinkUI( props ) {
 			title: pageTitle,
 			status: 'draft',
 		} );
+
+		speak(
+			sprintf(
+				/* translators: %s: title of the page that has been created. */
+				__( 'Draft Page "%s" created.' ),
+				pageTitle
+			)
+		);
 
 		return {
 			id: page.id,

--- a/packages/block-library/src/navigation-link/link-ui.js
+++ b/packages/block-library/src/navigation-link/link-ui.js
@@ -180,6 +180,7 @@ export function LinkUI( props ) {
 
 	return (
 		<Popover
+			role="dialog"
 			placement="bottom"
 			onClose={ props.onClose }
 			anchor={ props.anchor }

--- a/packages/format-library/src/link/inline.js
+++ b/packages/format-library/src/link/inline.js
@@ -242,6 +242,7 @@ function InlineLinkUI( {
 
 	return (
 		<Popover
+			role="dialog"
 			anchor={ popoverAnchor }
 			focusOnMount={ focusOnMount.current }
 			onClose={ stopAddingLink }

--- a/packages/format-library/src/link/inline.js
+++ b/packages/format-library/src/link/inline.js
@@ -220,6 +220,14 @@ function InlineLinkUI( {
 			status: 'draft',
 		} );
 
+		speak(
+			sprintf(
+				/* translators: %s: title of the page that has been created. */
+				__( 'Draft Page "%s" created.' ),
+				pageTitle
+			)
+		);
+
 		return {
 			id: page.id,
 			type: page.type,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

An iteration to improve the accessibility of the Link Control component.

No visuals should change as a result of the PR.

Complimented by https://github.com/WordPress/gutenberg/pull/54085

Requires https://github.com/WordPress/gutenberg/pull/52620

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Some issues were identified in https://github.com/WordPress/gutenberg/issues/51060. This starts to look to address these a long with other issues.

It's currently very difficult to write e2e tests using Playwright's accessible selectors and so this further supports my theory that the a11y of this control is not what it could / should be.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Please also see `Questions` section below.

I tested the following with Voiceover on MacOS:

- Announce (via `speak()`) when _user_ switches mode from "edit mode" to "preview mode".
- Use `aria-labelledby` and `aria-describedby` attributes on component to improve labelling and (hopefully) comprehension of the control.
- Use `role=dialog` on all instances that are within a `Popover` to indicate that they are overlaid on the content.
- Use `<dl>` markup when in "preview" mode so that all fields have associated definitions.
- Announce success when creating pages via the Link UI.

## Questions

- We are missing `<form>` tag when in edit mode. This was intentionally removed because there are instances where the component is used when it is _already_ within a wrapping `<form>` element and this was causing problems. However, should we perhaps have an option to utilise a `<form>` tag in "edit" mode? Is this useful for users of assistive tech? If so why and what advantages does it convey?
- If implementing `role=dialog` when the control is used within a `Popover` do we _need_ to have a focus trap? Officially Dialog's do not _have_ to trap focus but given that the UI can enter an "edit" mode where there is a form it seems like you shouldn't be able to tab _out_ of the UI whilst in the middle of editing. If so we cannot use the existing `<Modal>` from `@wordpress/components` but I should be able to modify our usage of `Popover`.
- Does the usage of definition list in the link preview mode markup provide any utility for screenreaders? The idea was to make it obvious which piece of text conveys is conveying what. For example, for a sighted user it's relatively easier to see which text is the URL and which is the title/label but I think it's much harder for users of assistive tech. 
- should the `aria-labelledby` and `aria-describedby` attributes be on the Popover _or_ the LinkControl component markup?

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- New Post
- Add some text in paragraph block
- Select some text inside the block and then create a link (the shortcut is Cmd + K).
- The Link Control will appear rendering inside a Popover.
- Test the accessibility of the control

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
