### PR TITLE
Post Terms: Fix a 'useSelect' warning in the 'usePostTerms' hook

### DIFF
--- a/packages/block-library/src/post-terms/use-post-terms.js
+++ b/packages/block-library/src/post-terms/use-post-terms.js
@@ -4,6 +4,8 @@
 import { store as coreStore } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
 
+const EMPTY_ARRAY = [];
+
 export default function usePostTerms( { postId, term } ) {
 	const { slug } = term;
 
@@ -12,8 +14,8 @@ export default function usePostTerms( { postId, term } ) {
 			const visible = term?.visibility?.publicly_queryable;
 			if ( ! visible ) {
 				return {
-					postTerms: [],
-					_isLoading: false,
+					postTerms: EMPTY_ARRAY,
+					isLoading: false,
 					hasPostTerms: false,
 				};
 			}


### PR DESCRIPTION
## What?
PR fixes a 'useSelect' warning in the 'usePostTerms' hook by using a stable array reference.

```
The 'useSelect' hook returns different values when called with the same state and parameters. This can lead to unnecessary rerenders.
```

## Testing Instructions
1. Open a post.
2. Insert Tags or Categories block.
3. Save the post and reload.
4. Confirm that the warning isn't logged in the console.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2023-08-30 at 20 11 48](https://github.com/WordPress/gutenberg/assets/240569/7e74f928-b7bc-4d9b-befd-ec72acdb63e4)
