### PR TITLE
Update versions in WP for 6.3.1

### DIFF
--- a/docs/contributors/versions-in-wordpress.md
+++ b/docs/contributors/versions-in-wordpress.md
@@ -6,6 +6,7 @@ If anything looks incorrect here, please bring it up in #core-editor in [WordPre
 
 | Gutenberg Versions | WordPress Version |
 | ------------------ | ----------------- |
+| 15.2-16.1          | 6.3.1             |
 | 15.2-16.1          | 6.3               |
 | 14.2-15.1          | 6.2               |
 | 13.1-14.1          | 6.1.1             |


### PR DESCRIPTION
Quick PR to update the versions in WP doc after the 6.3.1 release. 