### PR TITLE
Update readme.txt "tested up to 6.3"

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,6 +1,6 @@
 === Gutenberg ===
 Contributors: matveb, joen, karmatosed
-Tested up to: 6.2
+Tested up to: 6.3
 Stable tag: V.V.V
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
## What?
Update the version in "Tested up to" section of the readme.txt of the plugin

## Why?
To avoid "This plugin hasn't been tested for your current version of WordPress" banner  in the plugin repo and plugin workflow on WPAdmin
