### PR TITLE
[Edit Post]: Toggle Distraction free mode mode based on compatibility

### DIFF
--- a/docs/reference-guides/data/data-core-edit-post.md
+++ b/docs/reference-guides/data/data-core-edit-post.md
@@ -490,6 +490,10 @@ _Parameters_
 
 -   _mode_ `string`: The editor mode.
 
+### toggleDistractionFree
+
+Action that toggles Distraction free mode. Distraction free mode expects there are no sidebars, as due to the z-index values set, you can't close sidebars.
+
 ### toggleEditorPanelEnabled
 
 Returns an action object used to enable or disable a panel in the editor.

--- a/packages/edit-post/src/components/keyboard-shortcuts/index.js
+++ b/packages/edit-post/src/components/keyboard-shortcuts/index.js
@@ -10,8 +10,6 @@ import {
 import { __ } from '@wordpress/i18n';
 import { store as editorStore } from '@wordpress/editor';
 import { store as blockEditorStore } from '@wordpress/block-editor';
-import { store as noticesStore } from '@wordpress/notices';
-import { store as preferencesStore } from '@wordpress/preferences';
 import { createBlock } from '@wordpress/blocks';
 
 /**
@@ -21,19 +19,13 @@ import { store as editPostStore } from '../../store';
 
 function KeyboardShortcuts() {
 	const { getBlockSelectionStart } = useSelect( blockEditorStore );
-	const {
-		getEditorMode,
-		isEditorSidebarOpened,
-		isListViewOpened,
-		isFeatureActive,
-	} = useSelect( editPostStore );
+	const { getEditorMode, isEditorSidebarOpened, isListViewOpened } =
+		useSelect( editPostStore );
 	const isModeToggleDisabled = useSelect( ( select ) => {
 		const { richEditingEnabled, codeEditingEnabled } =
 			select( editorStore ).getEditorSettings();
 		return ! richEditingEnabled || ! codeEditingEnabled;
 	}, [] );
-
-	const { createInfoNotice } = useDispatch( noticesStore );
 
 	const {
 		switchEditorMode,
@@ -41,18 +33,9 @@ function KeyboardShortcuts() {
 		closeGeneralSidebar,
 		toggleFeature,
 		setIsListViewOpened,
-		setIsInserterOpened,
+		toggleDistractionFree,
 	} = useDispatch( editPostStore );
 	const { registerShortcut } = useDispatch( keyboardShortcutsStore );
-
-	const { set: setPreference } = useDispatch( preferencesStore );
-
-	const toggleDistractionFree = () => {
-		setPreference( 'core/edit-post', 'fixedToolbar', false );
-		setIsInserterOpened( false );
-		setIsListViewOpened( false );
-		closeGeneralSidebar();
-	};
 
 	const { replaceBlocks } = useDispatch( blockEditorStore );
 	const { getBlockName, getSelectedBlockClientId, getBlockAttributes } =
@@ -224,16 +207,6 @@ function KeyboardShortcuts() {
 
 	useShortcut( 'core/edit-post/toggle-distraction-free', () => {
 		toggleDistractionFree();
-		toggleFeature( 'distractionFree' );
-		createInfoNotice(
-			isFeatureActive( 'distractionFree' )
-				? __( 'Distraction free on.' )
-				: __( 'Distraction free off.' ),
-			{
-				id: 'core/edit-post/distraction-free-mode/notice',
-				type: 'snackbar',
-			}
-		);
 	} );
 
 	useShortcut( 'core/edit-post/toggle-sidebar', ( event ) => {

--- a/packages/edit-post/src/hooks/commands/use-common-commands.js
+++ b/packages/edit-post/src/hooks/commands/use-common-commands.js
@@ -33,6 +33,7 @@ export default function useCommonCommands() {
 		closeGeneralSidebar,
 		switchEditorMode,
 		setIsListViewOpened,
+		toggleDistractionFree,
 	} = useDispatch( editPostStore );
 	const { openModal } = useDispatch( interfaceStore );
 	const {
@@ -41,6 +42,7 @@ export default function useCommonCommands() {
 		isListViewOpen,
 		isPublishSidebarEnabled,
 		showBlockBreadcrumbs,
+		isDistractionFree,
 	} = useSelect( ( select ) => {
 		const { getEditorMode, isListViewOpened, isFeatureActive } =
 			select( editPostStore );
@@ -53,6 +55,10 @@ export default function useCommonCommands() {
 			isPublishSidebarEnabled:
 				select( editorStore ).isPublishSidebarEnabled(),
 			showBlockBreadcrumbs: isFeatureActive( 'showBlockBreadcrumbs' ),
+			isDistractionFree: select( preferencesStore ).get(
+				editPostStore.name,
+				'distractionFree'
+			),
 		};
 	}, [] );
 	const { toggle } = useDispatch( preferencesStore );
@@ -92,7 +98,7 @@ export default function useCommonCommands() {
 		name: 'core/toggle-distraction-free',
 		label: __( 'Toggle distraction free' ),
 		callback: ( { close } ) => {
-			toggle( 'core/edit-post', 'distractionFree' );
+			toggleDistractionFree();
 			close();
 		},
 	} );
@@ -131,6 +137,9 @@ export default function useCommonCommands() {
 		label: __( 'Toggle top toolbar' ),
 		callback: ( { close } ) => {
 			toggle( 'core/edit-post', 'fixedToolbar' );
+			if ( isDistractionFree ) {
+				toggleDistractionFree();
+			}
 			close();
 		},
 	} );

--- a/packages/edit-post/src/store/test/actions.js
+++ b/packages/edit-post/src/store/test/actions.js
@@ -53,6 +53,20 @@ describe( 'actions', () => {
 		).toBeNull();
 	} );
 
+	it( 'openGeneralSidebar - should turn off distraction free mode when opening a general sidebar', () => {
+		registry
+			.dispatch( preferencesStore )
+			.set( 'core/edit-post', 'distractionFree', true );
+		registry
+			.dispatch( editPostStore )
+			.openGeneralSidebar( 'edit-post/block' );
+		expect(
+			registry
+				.select( preferencesStore )
+				.get( 'core/edit-post', 'distractionFree' )
+		).toBe( false );
+	} );
+
 	it( 'toggleFeature', () => {
 		registry.dispatch( editPostStore ).toggleFeature( 'welcomeGuide' );
 		expect(
@@ -101,6 +115,17 @@ describe( 'actions', () => {
 			expect( registry.select( editPostStore ).getEditorMode() ).toEqual(
 				'text'
 			);
+		} );
+		it( 'should turn off distraction free mode when switching to code editor', () => {
+			registry
+				.dispatch( preferencesStore )
+				.set( 'core/edit-post', 'distractionFree', true );
+			registry.dispatch( editPostStore ).switchEditorMode( 'text' );
+			expect(
+				registry
+					.select( preferencesStore )
+					.get( 'core/edit-post', 'distractionFree' )
+			).toBe( false );
 		} );
 	} );
 
@@ -331,6 +356,56 @@ describe( 'actions', () => {
 			).toEqual( {
 				'core/quote': 'posh',
 			} );
+		} );
+	} );
+
+	describe( 'toggleDistractionFree', () => {
+		it( 'should properly update settings to prevent layout corruption when enabling distraction free mode', () => {
+			// Enable everything that shouldn't be enabled in distraction free mode.
+			registry
+				.dispatch( preferencesStore )
+				.set( 'core/edit-post', 'fixedToolbar', true );
+			registry.dispatch( editPostStore ).setIsListViewOpened( true );
+			registry
+				.dispatch( editPostStore )
+				.openGeneralSidebar( 'edit-post/block' );
+			// Initial state is falsy.
+			registry.dispatch( editPostStore ).toggleDistractionFree();
+			expect(
+				registry
+					.select( preferencesStore )
+					.get( 'core/edit-post', 'fixedToolbar' )
+			).toBe( false );
+			expect( registry.select( editPostStore ).isListViewOpened() ).toBe(
+				false
+			);
+			expect( registry.select( editPostStore ).isInserterOpened() ).toBe(
+				false
+			);
+			expect(
+				registry
+					.select( interfaceStore )
+					.getActiveComplementaryArea( editPostStore.name )
+			).toBeNull();
+			expect(
+				registry
+					.select( preferencesStore )
+					.get( 'core/edit-post', 'distractionFree' )
+			).toBe( true );
+		} );
+	} );
+
+	describe( 'setIsListViewOpened', () => {
+		it( 'should turn off distraction free mode when opening the list view', () => {
+			registry
+				.dispatch( preferencesStore )
+				.set( 'core/edit-post', 'distractionFree', true );
+			registry.dispatch( editPostStore ).setIsListViewOpened( true );
+			expect(
+				registry
+					.select( preferencesStore )
+					.get( 'core/edit-post', 'distractionFree' )
+			).toBe( false );
 		} );
 	} );
 } );

--- a/packages/edit-post/src/store/test/reducer.js
+++ b/packages/edit-post/src/store/test/reducer.js
@@ -14,7 +14,7 @@ import {
 	listViewPanel,
 } from '../reducer';
 
-import { setIsInserterOpened, setIsListViewOpened } from '../actions';
+import { setIsInserterOpened } from '../actions';
 
 describe( 'state', () => {
 	describe( 'isSavingMetaBoxes', () => {
@@ -135,13 +135,19 @@ describe( 'state', () => {
 
 		it( 'should close the inserter when opening the list view panel', () => {
 			expect(
-				blockInserterPanel( true, setIsListViewOpened( true ) )
+				blockInserterPanel( true, {
+					type: 'SET_IS_LIST_VIEW_OPENED',
+					isOpen: true,
+				} )
 			).toBe( false );
 		} );
 
 		it( 'should not change the state when closing the list view panel', () => {
 			expect(
-				blockInserterPanel( true, setIsListViewOpened( false ) )
+				blockInserterPanel( true, {
+					type: 'SET_IS_LIST_VIEW_OPENED',
+					isOpen: false,
+				} )
 			).toBe( true );
 		} );
 	} );
@@ -156,12 +162,18 @@ describe( 'state', () => {
 		} );
 
 		it( 'should set the open state of the list view panel', () => {
-			expect( listViewPanel( false, setIsListViewOpened( true ) ) ).toBe(
-				true
-			);
-			expect( listViewPanel( true, setIsListViewOpened( false ) ) ).toBe(
-				false
-			);
+			expect(
+				listViewPanel( false, {
+					type: 'SET_IS_LIST_VIEW_OPENED',
+					isOpen: true,
+				} )
+			).toBe( true );
+			expect(
+				listViewPanel( true, {
+					type: 'SET_IS_LIST_VIEW_OPENED',
+					isOpen: false,
+				} )
+			).toBe( false );
 		} );
 
 		it( 'should close the list view when opening the inserter panel', () => {

--- a/packages/edit-site/src/store/test/actions.js
+++ b/packages/edit-site/src/store/test/actions.js
@@ -235,7 +235,6 @@ describe( 'actions', () => {
 			registry
 				.dispatch( preferencesStore )
 				.set( 'core/edit-site', 'distractionFree', true );
-
 			registry
 				.dispatch( editSiteStore )
 				.openGeneralSidebar( 'edit-site/global-styles' );

--- a/packages/edit-site/src/store/test/reducer.js
+++ b/packages/edit-site/src/store/test/reducer.js
@@ -122,7 +122,6 @@ describe( 'state', () => {
 		} );
 
 		it( 'should set the open state of the list view panel', () => {
-			// registry.dispatch( editSiteStore ).toggleFeature( 'name' );
 			expect(
 				listViewPanel( false, {
 					type: 'SET_IS_LIST_VIEW_OPENED',


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Part of: https://github.com/WordPress/gutenberg/issues/53993



Distraction free mode in combination with some commands/shortcuts etc may cause layout corruption. This is mostly due to the fact that DFM expect there are no sidebars opened. Currently in trunk we handled some of these cases by manually closing those sidebars and toggling some settings like the top toolbar. In order to avoid having to do this every time we need to, I've moved this logic in some of the actions.

This is very similar PR with https://github.com/WordPress/gutenberg/pull/54030, that handled most cases in site editor.


## Testing Instructions for post editor
1. Test when we enable DFM either through shortcut or command, that any sidebar is closed.
2. Whenever we toggle the DFM observe that a snackbar appears with related information.

3. Test the following commands when DFM is on and observe that the sidebars are closed:
- Toggle code editor
- Toggle distraction free
- Toggle list view
- Toggle top toolbar
- Toggle settings sidebar
- Toggle block inspector


