### PR TITLE
Update editor package config to address "multiple Podfile" warn

### DIFF
--- a/packages/react-native-editor/.gitignore
+++ b/packages/react-native-editor/.gitignore
@@ -120,5 +120,4 @@ bin/wp-cli.phar
 # Ruby / CocoaPods
 
 ios/Pods
-ios/vendor
 /vendor/bundle/

--- a/packages/react-native-editor/ios/.bundle/config
+++ b/packages/react-native-editor/ios/.bundle/config
@@ -1,2 +1,2 @@
 ---
-BUNDLE_PATH: "vendor/bundle"
+BUNDLE_PATH: "../vendor/bundle"

--- a/packages/react-native-editor/react-native.config.js
+++ b/packages/react-native-editor/react-native.config.js
@@ -12,4 +12,9 @@ module.exports = {
 			root: path.resolve( __dirname, '../react-native-aztec' ),
 		},
 	},
+	project: {
+		ios: {
+			sourceDir: './ios/',
+		},
+	},
 };


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This PR tweaks the react-native-editor package setup to address the multiple Podfiles warning, formatted for readability:

```
warn Multiple Podfiles were found:

- ios/Podfile
- vendor/bundle/ruby/2.7.0/gems/cocoapods-core-1.11.3/lib/cocoapods-core/Podfile.
 
Choosing ios/Podfile automatically.
If you would like to select a different one, you can configure it via "project.ios.sourceDir". 
You can learn more about it here: https://github.com/react-native-community/cli/blob/master/docs/configuration.md
```

## Why?
Hygiene. The "issue" the warning raises in not blocking, since the `Podfile` that gets selected is the right one. Still, it's noise in the logs and it distracted me when trying to understand why a command that works on CircleCI [failed on Buildkite](https://buildkite.com/automattic/gutenberg-mobile/builds/7039#018a4555-02d8-4ce3-b463-b876b3e7a658).

## How?
The multiple `Podfile`s issue was due to, indeed, having multiple `Podfile`s in the same folder. The reason there were multiple `Podfile`s was out of our control: the `cocoapods-core` gem, which we need, comes with one.

To address it:

1. Moved the vendored gems location from `react-native-editor/ios/vendor` to `react-native-editor/vendor`
2. Set `./ios/` as the `project.ios.sourceDir` in the config file.

## Testing Instructions

`cd` in `packages/react-native-editor` and run `npm run preios` to verify that the warning is no longer there.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
N.A.

## Screenshots or screencast <!-- if applicable -->
N.A.