### PR TITLE
Prevent the list view shortcut from typing unexpected characters

### DIFF
--- a/packages/edit-post/src/components/keyboard-shortcuts/index.js
+++ b/packages/edit-post/src/components/keyboard-shortcuts/index.js
@@ -252,8 +252,9 @@ function KeyboardShortcuts() {
 	} );
 
 	// Only opens the list view. Other functionality for this shortcut happens in the rendered sidebar.
-	useShortcut( 'core/edit-post/toggle-list-view', () => {
+	useShortcut( 'core/edit-post/toggle-list-view', ( event ) => {
 		if ( ! isListViewOpened() ) {
+			event.preventDefault();
 			setIsListViewOpened( true );
 		}
 	} );


### PR DESCRIPTION
## What?

In trunk, if the "post title" input is focused in the post editor and I hit the "open list view" shortcut (access + o, alt + ctrl + o), the list view opens but there's a weird unicode character that gets also inserted into the post title. This PR fixes that by preventing the default event behavior.

## Testing Instructions

1- Open the post editor
2- Focus the post title input
3- Hit Alt + Ctrl + o to open the list view
4- The list view should open without writing a random character on the post title input.
