### PR TITLE
Improve code commenting around focus mount behaviour of rich text Link UI

### DIFF
--- a/packages/format-library/src/link/inline.js
+++ b/packages/format-library/src/link/inline.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useRef, createInterpolateElement } from '@wordpress/element';
+import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { speak } from '@wordpress/a11y';
 import { Popover } from '@wordpress/components';
@@ -197,9 +197,9 @@ function InlineLinkUI( {
 	// See https://github.com/WordPress/gutenberg/pull/34742.
 	const forceRemountKey = useLinkInstanceKey( popoverAnchor );
 
-	// The focusOnMount prop shouldn't evolve during render of a Popover
-	// otherwise it causes a render of the content.
-	const focusOnMount = useRef( addingLink ? 'firstElement' : false );
+	// Ensure focus is set on the first element when the popover is opened.
+	// This also ensures a focus trap is active on the Popover.
+	const focusOnMountWithTrap = 'firstElement';
 
 	async function handleCreate( pageTitle ) {
 		const page = await createPageEntity( {
@@ -230,7 +230,7 @@ function InlineLinkUI( {
 	return (
 		<Popover
 			anchor={ popoverAnchor }
-			focusOnMount={ focusOnMount.current }
+			focusOnMount={ focusOnMountWithTrap }
 			onClose={ stopAddingLink }
 			onFocusOutside={ () => stopAddingLink( false ) }
 			placement="bottom"

--- a/packages/format-library/src/link/inline.js
+++ b/packages/format-library/src/link/inline.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { createInterpolateElement } from '@wordpress/element';
+import { useRef, createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { speak } from '@wordpress/a11y';
 import { Popover } from '@wordpress/components';
@@ -197,9 +197,13 @@ function InlineLinkUI( {
 	// See https://github.com/WordPress/gutenberg/pull/34742.
 	const forceRemountKey = useLinkInstanceKey( popoverAnchor );
 
-	// Ensure focus is set on the first element when the popover is opened.
-	// This also ensures a focus trap is active on the Popover.
-	const focusOnMountWithTrap = 'firstElement';
+	// Focus should only be moved into the Popover when the Link is being created or edited.
+	// When the Link is in "preview" mode focus should remain on the rich text because at
+	// this point the Link dialog is informational only and thus the user should be able to
+	// continue editing the rich text.
+	// Ref used because the focusOnMount prop shouldn't evolve during render of a Popover
+	// otherwise it causes a render of the content.
+	const focusOnMount = useRef( addingLink ? 'firstElement' : false );
 
 	async function handleCreate( pageTitle ) {
 		const page = await createPageEntity( {
@@ -230,7 +234,7 @@ function InlineLinkUI( {
 	return (
 		<Popover
 			anchor={ popoverAnchor }
-			focusOnMount={ focusOnMountWithTrap }
+			focusOnMount={ focusOnMount.current }
 			onClose={ stopAddingLink }
 			onFocusOutside={ () => stopAddingLink( false ) }
 			placement="bottom"


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Improves the documentation around why the focus on mount handling is implemented in the way it is on the Link UI popover for rich text.

Complements https://github.com/WordPress/gutenberg/pull/54063

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The code around managing focus seems unusual, especially as for most dialogs the focus should always be moved into the dialog on mount. 

The comment now fully documents the code and avoid potential future regressions and also avoids relying on stakeholder knowledge.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Adds comment to explain why the code is as it is.



## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- New Post
- Add some text in paragraph block
- Select some text inside the block and then create a link (the shortcut is Cmd + K).
- The Link Control will appear rendering inside a Popover.
- Behaviour should be as on `trunk`.
- 
### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->



