### PR TITLE
Workflow: Fix the issue with npm publishing for WP major version

### DIFF
--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -30,17 +30,27 @@ jobs:
         environment: WordPress packages
         steps:
             - name: Checkout (for CLI)
+              if: ${{ github.event.inputs.release_type != 'wp' }}
               uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
               with:
                   path: cli
                   ref: trunk
 
             - name: Checkout (for publishing)
+              if: ${{ github.event.inputs.release_type != 'wp' }}
               uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
               with:
                   path: publish
                   # Later, we switch this branch in the script that publishes packages.
                   ref: trunk
+                  token: ${{ secrets.GUTENBERG_TOKEN }}
+
+            - name: Checkout (for publishing WP major version)
+              if: ${{ github.event.inputs.release_type == 'wp' && github.event.inputs.wp_version }}
+              uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+              with:
+                  path: publish
+                  ref: wp/${{ github.event.inputs.wp_version }}
                   token: ${{ secrets.GUTENBERG_TOKEN }}
 
             - name: Configure git user name and email (for publishing)
@@ -50,9 +60,17 @@ jobs:
                   git config user.email gutenberg@wordpress.org
 
             - name: Setup Node.js
+              if: ${{ github.event.inputs.release_type != 'wp' }}
               uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
               with:
                   node-version-file: 'cli/.nvmrc'
+                  registry-url: 'https://registry.npmjs.org'
+
+            - name: Setup Node.js (for WP major version)
+              if: ${{ github.event.inputs.release_type == 'wp' && github.event.inputs.wp_version }}
+              uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
+              with:
+                  node-version-file: 'publish/.nvmrc'
                   registry-url: 'https://registry.npmjs.org'
 
             - name: Publish development packages to npm ("next" dist-tag)
@@ -73,7 +91,7 @@ jobs:
               env:
                   NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-            - name: Publish packages to npm for WP major ("wp/${{ github.event.inputs.wp_version || 'X.Y' }}" dist-tag)
+            - name: Publish packages to npm for WP major version ("wp/${{ github.event.inputs.wp_version || 'X.Y' }}" dist-tag)
               if: ${{ github.event.inputs.release_type == 'wp' && github.event.inputs.wp_version }}
               run: |
                   cd publish


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Closes #53628

Follow-up for https://github.com/WordPress/gutenberg/pull/53762. My hope was that publishing to npm targeting WP core got resolved by running Lerna directly from GitHub action. 
## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

However, the changes applied didn't work out as expected. I missed the important part that are taken care by the Node.js script we use for all types of publishing – switching to the correct branch in the publish folder. More details in https://github.com/WordPress/gutenberg/pull/53762#issuecomment-1685194154.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

It looks like publishing for the WP major version has an almost completely customized set of steps. That's why I updated the workflow to run most of the steps conditionally to account for it.
- Checkout (for CLI) isn't used for `wp` type so it won't trigger in that case
- Checkout (for publishing) is now split into two alternative steps, because for `wp` type we use a different branch (that's a key change which impacts publishing that I missed before as it is handled by the script in other cases)
- Setup Node.js is now split into two alternative steps, because for `wp` type we want to use npm version defined in the release branch (I missed that before as it is handled by the script in other cases)

### Testing instruction

I don't know what would be the best way to test it without merging. It should just work the next time we have to publish npm packages for WordPress 6.4.x minor release following the instructions:

https://github.com/WordPress/gutenberg/blob/trunk/docs/contributors/code/release.md#wordpress-releases

One way to test it after merging, would be triggering an action with `wp` type and `6.3` version. It doesn't have any changes at the moment, so the script should just run and report that there are no changes to publish.