### PR TITLE
Gutenberg Plugin: Use plugin header to varidate WP/PHP version requirements

### DIFF
--- a/gutenberg.php
+++ b/gutenberg.php
@@ -23,13 +23,20 @@ gutenberg_pre_init();
 /**
  * Display a version notice and deactivate the Gutenberg plugin.
  *
- * @since 0.1.0
+ * @since 19.6.0
  */
-function gutenberg_wordpress_version_notice() {
-	echo '<div class="error"><p>';
-	/* translators: %s: Minimum required version */
-	printf( __( 'Gutenberg requires WordPress %s or later to function properly. Please upgrade WordPress before activating Gutenberg.', 'gutenberg' ), GUTENBERG_MINIMUM_WP_VERSION );
-	echo '</p></div>';
+function gutenberg_version_notice() {
+	require_once ABSPATH . 'wp-admin/includes/plugin.php';
+	$requirements = validate_plugin_requirements( 'gutenberg/gutenberg.php' );
+	$errors       = $requirements->errors;
+
+	if ( isset( $errors['plugin_wp_php_incompatible'][0] ) ) {
+		echo '<div class="error">' . $errors['plugin_wp_php_incompatible'][0] . '</div>';
+	} elseif ( isset( $errors['plugin_wp_incompatible'][0] ) ) {
+		echo '<div class="error">' . $errors['plugin_wp_incompatible'][0] . '</div>';
+	} elseif ( isset( $errors['plugin_php_incompatible'][0] ) ) {
+		echo '<div class="error">' . $errors['plugin_php_incompatible'][0] . '</div>';
+	}
 
 	deactivate_plugins( array( 'gutenberg/gutenberg.php' ) );
 }
@@ -49,28 +56,20 @@ function gutenberg_build_files_notice() {
  * Verify that we can initialize the Gutenberg editor , then load it.
  *
  * @since 1.5.0
- *
- * @global string $wp_version             The WordPress version string.
- *
+ * @since 19.6.0 Use `validate_plugin_requirements()` to validate WordPress
+ *               version and PHP version requirements.
  */
 function gutenberg_pre_init() {
-	global $wp_version;
 	if ( defined( 'GUTENBERG_DEVELOPMENT_MODE' ) && GUTENBERG_DEVELOPMENT_MODE && ! file_exists( __DIR__ . '/build/blocks' ) ) {
 		add_action( 'admin_notices', 'gutenberg_build_files_notice' );
 		return;
 	}
 
-	// Get unmodified $wp_version.
-	include ABSPATH . WPINC . '/version.php';
+	require_once ABSPATH . 'wp-admin/includes/plugin.php';
+	$requirements = validate_plugin_requirements( 'gutenberg/gutenberg.php' );
 
-	// Strip '-src' from the version string. Messes up version_compare().
-	$version = str_replace( '-src', '', $wp_version );
-
-	// Compare against major release versions (X.Y) rather than minor (X.Y.Z)
-	// unless a minor release is the actual minimum requirement. WordPress reports
-	// X.Y for its major releases.
-	if ( version_compare( $version, GUTENBERG_MINIMUM_WP_VERSION, '<' ) ) {
-		add_action( 'admin_notices', 'gutenberg_wordpress_version_notice' );
+	if ( is_wp_error( $requirements ) ) {
+		add_action( 'admin_notices', 'gutenberg_version_notice' );
 		return;
 	}
 


### PR DESCRIPTION
Maybe related to #35194

## What?
This PR _always_ checks whether the current environment meets the WP version and PHP version requirements based on the information in the Gutenberg plugin header, and disables the plugin if not.

![wp-php](https://github.com/WordPress/gutenberg/assets/54422211/d78ac32e-65b8-4f41-b856-1fc88b8d8c96)

![wp](https://github.com/WordPress/gutenberg/assets/54422211/d5494a2f-7cb8-4687-b3e3-09e4994ff466)

![php](https://github.com/WordPress/gutenberg/assets/54422211/cd3376f3-80a7-4f9f-ac6a-9dfb4bd4fec1)

## Why?
At the time of submitting this PR, the plugin header requires the following versions

```
* Requires at least: 6.1
* Requires PHP: 7.0
```

The process performed in the initialization function (`gutenberg_pre_init`) checks if the WordPress version is 5.9 or higher. This is lower than the `Requires at least` defined in the plugin header.

Therefore, if you already have the Gutenberg plugin installed and your environment is actually lower than the WordPress version expected by this plugin (e.g. WordPress 6.0), it will pass this check and you may get a critical error.

Furthermore, since the version number may include suffixes such as `-alpha`, `-RC`, `-beta`, etc., I do not consider it sufficient to just use the version number without the `-src` suffix.

A similar problem may occur with PHP, since there is no explicit version check in the first place.

## How?

I have used the [validate_plugin_requirements()](https://developer.wordpress.org/reference/functions/validate_plugin_requirements/) function introduced in WordPress 5.8 to check for WP/PHP compatibility. This function checks for the minimum WP/PHP version defined in the plugin header and returns an appropriate error message if the requirement is not met.

As for the WordPress version check, the internal [is_wp_version_compatible()](https://developer.wordpress.org/reference/functions/is_wp_version_compatible/) function removes any suffixes from the version number.

This way, when we want to increase the WP/PHP version required by Gutenberg, we only need to update the plugin header, and the plugin will always be disabled if the environment does not meet the plugin's requirements.

## Testing Instructions

The following is a test procedure using wp-env.

- run `npm run wp-env destroy` and `npm run wp-env start`.
- Check out `trunk` branch.
- Log in to WordPress and make sure the Gutenberg plugin is enabled.
- Downgrade your WP/PHP version using the following command: `WP_ENV_PHP_VERSION=5.6 WP_ENV_CORE=WordPress/WordPress#6.0 npm run wp-env start -- --update`
- Reload your browser at `http://localhost:8888/wp-admin/`.
- You should get a Fatal error because the Gutenberg plugin does not match your current environment.
- Check out this branch and reload your browser.
  - Verify that the admin page displays correctly.
  - Verify that the Gutenberg plugin is displaying an error message indicating a version request.
  - Verify that the Gutenberg plugin has been deactivated (the "Gutenberg" menu should not be visible)
