### PR TITLE
feat: Insert from URL leverages a bottom sheet

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46294,11 +46294,6 @@
 				"react-native": ">=0.65.0"
 			}
 		},
-		"node_modules/react-native-prompt-android": {
-			"version": "1.0.0-wp-4",
-			"resolved": "https://raw.githubusercontent.com/wordpress-mobile/react-native-prompt-android/v1.0.0-wp-4/react-native-prompt-android-1.0.0-wp-4.tgz",
-			"integrity": "sha512-brKcM8Uh1If+PVPV2lDjCifBYgm/BqtkVuSEE6SA6nVw1gCYFpj6GRQ4tUDKVo4+zI8436DTifVl/3QwlM9aJg=="
-		},
 		"node_modules/react-native-reanimated": {
 			"version": "2.17.0",
 			"resolved": "https://registry.npmjs.org/react-native-reanimated/-/react-native-reanimated-2.17.0.tgz",
@@ -56261,7 +56256,6 @@
 				"react-native-get-random-values": "1.4.0",
 				"react-native-linear-gradient": "2.7.3",
 				"react-native-modal": "13.0.1",
-				"react-native-prompt-android": "https://raw.githubusercontent.com/wordpress-mobile/react-native-prompt-android/v1.0.0-wp-4/react-native-prompt-android-1.0.0-wp-4.tgz",
 				"react-native-reanimated": "2.17.0",
 				"react-native-safe-area": "^0.5.0",
 				"react-native-safe-area-context": "4.6.3",
@@ -68704,7 +68698,6 @@
 				"react-native-get-random-values": "1.4.0",
 				"react-native-linear-gradient": "2.7.3",
 				"react-native-modal": "13.0.1",
-				"react-native-prompt-android": "https://raw.githubusercontent.com/wordpress-mobile/react-native-prompt-android/v1.0.0-wp-4/react-native-prompt-android-1.0.0-wp-4.tgz",
 				"react-native-reanimated": "2.17.0",
 				"react-native-safe-area": "^0.5.0",
 				"react-native-safe-area-context": "4.6.3",
@@ -94267,10 +94260,6 @@
 				"prop-types": "^15.6.2",
 				"react-native-animatable": "1.3.3"
 			}
-		},
-		"react-native-prompt-android": {
-			"version": "https://raw.githubusercontent.com/wordpress-mobile/react-native-prompt-android/v1.0.0-wp-4/react-native-prompt-android-1.0.0-wp-4.tgz",
-			"integrity": "sha512-brKcM8Uh1If+PVPV2lDjCifBYgm/BqtkVuSEE6SA6nVw1gCYFpj6GRQ4tUDKVo4+zI8436DTifVl/3QwlM9aJg=="
 		},
 		"react-native-reanimated": {
 			"version": "2.17.0",

--- a/packages/block-editor/src/components/index.native.js
+++ b/packages/block-editor/src/components/index.native.js
@@ -38,13 +38,13 @@ export {
 } from './rich-text';
 export { default as MediaReplaceFlow } from './media-replace-flow';
 export { default as MediaPlaceholder } from './media-placeholder';
+export { default as MediaUpload } from './media-upload';
 export {
-	default as MediaUpload,
 	MEDIA_TYPE_IMAGE,
 	MEDIA_TYPE_VIDEO,
 	MEDIA_TYPE_AUDIO,
 	MEDIA_TYPE_ANY,
-} from './media-upload';
+} from './media-upload/constants';
 export {
 	default as MediaUploadProgress,
 	MEDIA_UPLOAD_STATE_UPLOADING,

--- a/packages/block-editor/src/components/media-placeholder/index.native.js
+++ b/packages/block-editor/src/components/media-placeholder/index.native.js
@@ -8,12 +8,6 @@ import { sentenceCase } from 'change-case';
  * WordPress dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
-import {
-	MediaUpload,
-	MEDIA_TYPE_IMAGE,
-	MEDIA_TYPE_VIDEO,
-	MEDIA_TYPE_AUDIO,
-} from '@wordpress/block-editor';
 import { usePreferredColorSchemeStyle } from '@wordpress/compose';
 import { cloneElement, useCallback, useRef } from '@wordpress/element';
 import { Icon, plusCircleFilled } from '@wordpress/icons';
@@ -23,6 +17,12 @@ import { Icon, plusCircleFilled } from '@wordpress/icons';
  */
 import styles from './styles.scss';
 import { useBlockEditContext } from '../block-edit/context';
+import MediaUpload from '../media-upload';
+import {
+	MEDIA_TYPE_IMAGE,
+	MEDIA_TYPE_VIDEO,
+	MEDIA_TYPE_AUDIO,
+} from '../media-upload/constants';
 
 const isMediaEqual = ( media1, media2 ) =>
 	media1.id === media2.id || media1.url === media2.url;

--- a/packages/block-editor/src/components/media-upload/constants.js
+++ b/packages/block-editor/src/components/media-upload/constants.js
@@ -1,0 +1,15 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+export const MEDIA_TYPE_IMAGE = 'image';
+export const MEDIA_TYPE_VIDEO = 'video';
+export const MEDIA_TYPE_AUDIO = 'audio';
+export const MEDIA_TYPE_ANY = 'any';
+
+export const OPTION_TAKE_VIDEO = __( 'Take a Video' );
+export const OPTION_TAKE_PHOTO = __( 'Take a Photo' );
+export const OPTION_TAKE_PHOTO_OR_VIDEO = __( 'Take a Photo or Video' );
+export const OPTION_INSERT_FROM_URL = __( 'Insert from URL' );
+export const OPTION_WORDPRESS_MEDIA_LIBRARY = __( 'WordPress Media Library' );

--- a/packages/block-editor/src/components/media-upload/index.native.js
+++ b/packages/block-editor/src/components/media-upload/index.native.js
@@ -3,14 +3,17 @@
  */
 import { Platform } from 'react-native';
 
-import prompt from 'react-native-prompt-android';
-
 /**
  * WordPress dependencies
  */
 import { Component, React } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { Picker } from '@wordpress/components';
+import {
+	BottomSheet,
+	PanelBody,
+	Picker,
+	TextControl,
+} from '@wordpress/components';
 import {
 	getOtherMediaOptions,
 	requestMediaPicker,
@@ -51,6 +54,8 @@ export class MediaUpload extends Component {
 		this.onPickerSelect = this.onPickerSelect.bind( this );
 		this.getAllSources = this.getAllSources.bind( this );
 		this.state = {
+			url: '',
+			showURLInput: false,
 			otherMediaOptions: [],
 		};
 	}
@@ -203,31 +208,10 @@ export class MediaUpload extends Component {
 	}
 
 	onPickerSelect( value ) {
-		const {
-			allowedTypes = [],
-			onSelect,
-			onSelectURL,
-			multiple = false,
-		} = this.props;
+		const { allowedTypes = [], onSelect, multiple = false } = this.props;
 
 		if ( value === URL_MEDIA_SOURCE ) {
-			prompt(
-				__( 'Type a URL' ), // title
-				undefined, // message
-				[
-					{
-						text: __( 'Cancel' ),
-						style: 'cancel',
-					},
-					{
-						text: __( 'Apply' ),
-						onPress: onSelectURL,
-					},
-				], // Buttons.
-				'plain-text', // type
-				undefined, // defaultValue
-				'url' // keyboardType
-			);
+			this.setState( { showURLInput: true } );
 			return;
 		}
 
@@ -305,11 +289,47 @@ export class MediaUpload extends Component {
 			/>
 		);
 
-		return this.props.render( {
-			open: this.onPickerPresent,
-			getMediaOptions,
-		} );
+		return (
+			<>
+				<URLInput
+					isVisible={ this.state.showURLInput }
+					onClose={ () => {
+						if ( this.state.url !== '' ) {
+							this.props.onSelectURL( this.state.url );
+						}
+						this.setState( { showURLInput: false, url: '' } );
+					} }
+					onChange={ ( url ) => {
+						this.setState( { url } );
+					} }
+					value={ this.state.url }
+				/>
+				{ this.props.render( {
+					open: this.onPickerPresent,
+					getMediaOptions,
+				} ) }
+			</>
+		);
 	}
+}
+
+function URLInput( props ) {
+	return (
+		<BottomSheet
+			hideHeader
+			isVisible={ props.isVisible }
+			onClose={ props.onClose }
+		>
+			<PanelBody>
+				<TextControl
+					label={ __( 'Insert from URL' ) }
+					onChange={ props.onChange }
+					placeholder={ __( 'Type a URL' ) }
+					value={ props.value }
+				/>
+			</PanelBody>
+		</BottomSheet>
+	);
 }
 
 export default compose( [

--- a/packages/block-editor/src/components/media-upload/index.native.js
+++ b/packages/block-editor/src/components/media-upload/index.native.js
@@ -28,16 +28,15 @@ import { store as blockEditorStore } from '@wordpress/block-editor';
 import { compose } from '@wordpress/compose';
 import { withSelect } from '@wordpress/data';
 
-export const MEDIA_TYPE_IMAGE = 'image';
-export const MEDIA_TYPE_VIDEO = 'video';
-export const MEDIA_TYPE_AUDIO = 'audio';
-export const MEDIA_TYPE_ANY = 'any';
-
-export const OPTION_TAKE_VIDEO = __( 'Take a Video' );
-export const OPTION_TAKE_PHOTO = __( 'Take a Photo' );
-export const OPTION_TAKE_PHOTO_OR_VIDEO = __( 'Take a Photo or Video' );
-export const OPTION_INSERT_FROM_URL = __( 'Insert from URL' );
-export const OPTION_WORDPRESS_MEDIA_LIBRARY = __( 'WordPress Media Library' );
+/**
+ * Internal dependencies
+ */
+import {
+	MEDIA_TYPE_IMAGE,
+	MEDIA_TYPE_VIDEO,
+	MEDIA_TYPE_AUDIO,
+	MEDIA_TYPE_ANY,
+} from './constants';
 
 const URL_MEDIA_SOURCE = 'URL';
 

--- a/packages/block-editor/src/components/media-upload/index.native.js
+++ b/packages/block-editor/src/components/media-upload/index.native.js
@@ -322,6 +322,8 @@ function URLInput( props ) {
 		>
 			<PanelBody>
 				<TextControl
+					// eslint-disable-next-line jsx-a11y/no-autofocus
+					autoFocus
 					label={ __( 'Insert from URL' ) }
 					onChange={ props.onChange }
 					placeholder={ __( 'Type a URL' ) }

--- a/packages/block-editor/src/components/media-upload/index.native.js
+++ b/packages/block-editor/src/components/media-upload/index.native.js
@@ -40,6 +40,7 @@ import {
 	MEDIA_TYPE_AUDIO,
 	MEDIA_TYPE_ANY,
 } from './constants';
+import styles from './style.scss';
 
 const URL_MEDIA_SOURCE = 'URL';
 
@@ -320,7 +321,7 @@ function URLInput( props ) {
 			isVisible={ props.isVisible }
 			onClose={ props.onClose }
 		>
-			<PanelBody>
+			<PanelBody style={ styles[ 'media-upload__link-input' ] }>
 				<TextControl
 					// eslint-disable-next-line jsx-a11y/no-autofocus
 					autoFocus

--- a/packages/block-editor/src/components/media-upload/index.native.js
+++ b/packages/block-editor/src/components/media-upload/index.native.js
@@ -325,6 +325,10 @@ function URLInput( props ) {
 				<TextControl
 					// eslint-disable-next-line jsx-a11y/no-autofocus
 					autoFocus
+					autoCapitalize="none"
+					autoCorrect={ false }
+					autoComplete={ Platform.isIOS ? 'url' : 'off' }
+					keyboardType="url"
 					label={ __( 'Insert from URL' ) }
 					onChange={ props.onChange }
 					placeholder={ __( 'Type a URL' ) }

--- a/packages/block-editor/src/components/media-upload/style.native.scss
+++ b/packages/block-editor/src/components/media-upload/style.native.scss
@@ -1,0 +1,4 @@
+.media-upload__link-input {
+	padding-left: 0;
+	padding-right: 0;
+}

--- a/packages/block-editor/src/components/media-upload/test/index.native.js
+++ b/packages/block-editor/src/components/media-upload/test/index.native.js
@@ -14,8 +14,8 @@ import { requestMediaPicker } from '@wordpress/react-native-bridge';
 /**
  * Internal dependencies
  */
+import { MediaUpload } from '../index';
 import {
-	MediaUpload,
 	MEDIA_TYPE_IMAGE,
 	MEDIA_TYPE_VIDEO,
 	MEDIA_TYPE_AUDIO,
@@ -23,7 +23,7 @@ import {
 	OPTION_TAKE_PHOTO,
 	OPTION_INSERT_FROM_URL,
 	OPTION_WORDPRESS_MEDIA_LIBRARY,
-} from '../index';
+} from '../constants';
 
 const MEDIA_URL = 'http://host.media.type';
 const MEDIA_ID = 123;

--- a/packages/components/src/mobile/bottom-sheet/index.native.js
+++ b/packages/components/src/mobile/bottom-sheet/index.native.js
@@ -527,6 +527,7 @@ class BottomSheet extends Component {
 					panResponder.panHandlers.onMoveShouldSetResponderCapture
 				}
 				onAccessibilityEscape={ this.onCloseBottomSheet }
+				testID="bottom-sheet"
 				{ ...rest }
 			>
 				<KeyboardAvoidingView

--- a/packages/react-native-bridge/android/react-native-bridge/build.gradle
+++ b/packages/react-native-bridge/android/react-native-bridge/build.gradle
@@ -90,7 +90,6 @@ dependencies {
     implementation "com.facebook.react:react-android:$rnVersion"
     implementation "com.github.wordpress-mobile:react-native-video:${extractPackageVersion(packageJson, 'react-native-video', 'dependencies')}"
     implementation "com.github.wordpress-mobile:react-native-slider:${extractPackageVersion(packageJson, '@react-native-community/slider', 'dependencies')}"
-    implementation "com.github.wordpress-mobile:react-native-prompt-android:${extractPackageVersion(packageJson, 'react-native-prompt-android', 'dependencies')}"
 
     // Published by `wordpress-mobile/react-native-libraries-publisher`
     // See the documentation for this value in `build.gradle.kts` of `wordpress-mobile/react-native-libraries-publisher`

--- a/packages/react-native-bridge/android/react-native-bridge/src/main/java/org/wordpress/mobile/WPAndroidGlue/WPAndroidGlueCode.java
+++ b/packages/react-native-bridge/android/react-native-bridge/src/main/java/org/wordpress/mobile/WPAndroidGlue/WPAndroidGlueCode.java
@@ -73,7 +73,6 @@ import java.util.Map.Entry;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-import im.shimo.react.prompt.RNPromptPackage;
 import okhttp3.OkHttpClient;
 
 
@@ -618,7 +617,6 @@ public class WPAndroidGlueCode {
                         return mReactInstanceManager;
                     }
                 },
-                new RNPromptPackage(),
                 new RNCWebViewPackage(),
                 new ClipboardPackage(),
                 new FastImageViewPackage(),

--- a/packages/react-native-editor/CHANGELOG.md
+++ b/packages/react-native-editor/CHANGELOG.md
@@ -10,6 +10,7 @@ For each user feature we should also add a importance categorization label  to i
 -->
 
 ## Unreleased
+-   [*] Fix the obscurred "Insert from URL" input for media blocks when using a device in landscape orientation. [#54096]
 
 ## 1.103.0
 -   [**] Replace third-party dependency react-native-hsv-color-picker with first-party code [#53329]

--- a/packages/react-native-editor/android/app/build.gradle
+++ b/packages/react-native-editor/android/app/build.gradle
@@ -142,7 +142,6 @@ dependencies {
 
     implementation "com.github.wordpress-mobile:react-native-video:${extractPackageVersion(packageJson, 'react-native-video', 'dependencies')}"
     implementation "com.github.wordpress-mobile:react-native-slider:${extractPackageVersion(packageJson, '@react-native-community/slider', 'dependencies')}"
-    implementation "com.github.wordpress-mobile:react-native-prompt-android:${extractPackageVersion(packageJson, 'react-native-prompt-android', 'dependencies')}"
 
     // Published by `wordpress-mobile/react-native-libraries-publisher`
     // See the documentation for this value in `build.gradle.kts` of `wordpress-mobile/react-native-libraries-publisher`

--- a/packages/react-native-editor/android/app/src/main/java/com/gutenberg/MainApplication.java
+++ b/packages/react-native-editor/android/app/src/main/java/com/gutenberg/MainApplication.java
@@ -51,8 +51,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.ArrayList;
 
-import im.shimo.react.prompt.RNPromptPackage;
-
 public class MainApplication extends Application implements ReactApplication, GutenbergBridgeInterface {
 
     private static final String TAG = "MainApplication";
@@ -334,7 +332,6 @@ public class MainApplication extends Application implements ReactApplication, Gu
                         new ReanimatedPackage(),
                         new SafeAreaContextPackage(),
                         new RNScreensPackage(),
-                        new RNPromptPackage(),
                         new RNCWebViewPackage(),
                         new ClipboardPackage(),
                         new FastImageViewPackage(),

--- a/packages/react-native-editor/package.json
+++ b/packages/react-native-editor/package.json
@@ -63,7 +63,6 @@
 		"react-native-get-random-values": "1.4.0",
 		"react-native-linear-gradient": "2.7.3",
 		"react-native-modal": "13.0.1",
-		"react-native-prompt-android": "https://raw.githubusercontent.com/wordpress-mobile/react-native-prompt-android/v1.0.0-wp-4/react-native-prompt-android-1.0.0-wp-4.tgz",
 		"react-native-reanimated": "2.17.0",
 		"react-native-safe-area": "^0.5.0",
 		"react-native-safe-area-context": "4.6.3",


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## Related PRs
* https://github.com/wordpress-mobile/gutenberg-mobile/pull/6143
* https://github.com/wordpress-mobile/WordPress-iOS/pull/21479
* https://github.com/wordpress-mobile/WordPress-Android/pull/19127

## What?
<!-- In a few words, what is the PR actually doing? -->
Replace the usage of an OS alert with a bottom sheet for the "Insert from URL"
flow for supported media blocks.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/4936.

The usage of iOS `UIAlertController` via `react-native-prompt-android` resulted
in an obscured alert on small devices in landscape orientation as there was not
enough vertical space between the keyboard and the top of the editor view.

Replacing the usage of alerts with the existing bottom sheet avoids the obscured
UI.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Refactor MediaUploader to export constants seprately, to enable fast refresh
support through only exporting a React component.

Replace usage of `react-native-prompt-android` with a bottom sheet containing a
text input.

Given the refactor, stepping through the commits individually may simplify code review. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

> **Note**  
> First install an [iOS](https://github.com/wordpress-mobile/WordPress-iOS/pull/21479#issuecomment-1701974997) or [Android](https://github.com/wordpress-mobile/WordPress-Android/pull/19127#issuecomment-1701959592) prototype build. 

**Valid Media**
1. Add an Audio or Image block.
1. Select the "Insert from URL" option.
1. Input a valid URL.
1. Dismiss the bottom sheet (tap backdrop, swipe downward, etc).
1. Verify the successfully media is set for the block.

**Invalid Media**
1. Add an Audio or Image block.
1. Select the "Insert from URL" option.
1. Input an invalid URL.
1. Dismiss the bottom sheet (tap backdrop, swipe downward, etc).
1. Verify the media is not set for the block and an error message is displayed.

**Replace Media**
1. Select an Audio or Image block already attached to valid media.
1. Tap the "Replace media" toolbar button.
1. Select the "Insert from URL" option.
1. Input a valid URL.
1. Dismiss the bottom sheet (tap backdrop, swipe downward, etc).
1. Verify the successfully media is set for the block.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
n/a

## Screenshots or screencast <!-- if applicable -->
| iOS | Android |
| - | - |
| ![ios](https://github.com/WordPress/gutenberg/assets/438664/b17def43-dd2f-4694-ac29-487bf64896ec) | ![android](https://github.com/WordPress/gutenberg/assets/438664/17080423-b9e4-4cb1-ab21-e1dbf5962758) |
| ![ios-landscape](https://github.com/WordPress/gutenberg/assets/438664/0fea5073-c0da-4fc3-9025-574c36639c71) | | 


