### PR TITLE
[RNMobile] Fix social icons block alignment

### DIFF
--- a/packages/block-library/src/social-link/edit.native.js
+++ b/packages/block-library/src/social-link/edit.native.js
@@ -158,7 +158,7 @@ const SocialLinkEdit = ( {
 		  );
 
 	return (
-		<View>
+		<View style={ styles.container }>
 			{ isSelected && (
 				<>
 					<BlockControls>

--- a/packages/block-library/src/social-link/editor.native.scss
+++ b/packages/block-library/src/social-link/editor.native.scss
@@ -21,3 +21,7 @@
 .inactiveIconDark {
 	background-color: $dark-quaternary;
 }
+
+.container {
+	margin: $block-selected-margin;
+}

--- a/packages/react-native-editor/CHANGELOG.md
+++ b/packages/react-native-editor/CHANGELOG.md
@@ -16,6 +16,7 @@ For each user feature we should also add a importance categorization label  to i
 -   [*] Fix horizontal rule style extensions [#53917]
 -   [*] Add block outline to all Social Link blocks when selected [#54011]
 -   [*] Columns block - Fix transforming into a Group block crash [#54035]
+-   [*] Fix Social Icons block alignment [#54100]
 
 ## 1.102.1
 - [**] Fix Voice Over and assistive keyboards [#53895]


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes a visual regression with the Social Icons block button alignment on mobile.

**Related:**
* https://github.com/wordpress-mobile/gutenberg-mobile/issues/6140
* https://github.com/wordpress-mobile/gutenberg-mobile/pull/6146

## How?
Updates Social Icons block container margin in the native editor scss.

## Testing Instructions
1. Create a post and add a Social Icons block
2. Observe that the Social Link buttons are aligned vertically within the block (compare screenshots below).

## Screenshots or screencast <!-- if applicable -->
Before | After
-|-
<img width="332" alt="Screenshot 2023-09-01 at 9 59 16 am" src="https://github.com/WordPress/gutenberg/assets/643285/7eecb181-0a96-484a-a242-72021b5a0b62"> | <img width="333" alt="Screenshot 2023-09-01 at 9 34 56 am" src="https://github.com/WordPress/gutenberg/assets/643285/f6307719-1dba-4c83-b8c8-a98aa3d63b5f">




