### PR TITLE
`Popover`: update `positionToPlacement` types

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -20,6 +20,7 @@
 -   `Composite`: Convert to TypeScript ([#54028](https://github.com/WordPress/gutenberg/pull/54028)).
 -   `BorderControl`: Refactor unit tests to use `userEvent` ([#54155](https://github.com/WordPress/gutenberg/pull/54155))
 -   `FocusableIframe`: Convert to TypeScript ([#53979](https://github.com/WordPress/gutenberg/pull/53979)).
+-   `Popover`: Remove unused `overlay` type from `positionToPlacement` utility function ([#54101](https://github.com/WordPress/gutenberg/pull/54101)).
 
 ## 25.7.0 (2023-08-31)
 

--- a/packages/components/src/popover/utils.ts
+++ b/packages/components/src/popover/utils.ts
@@ -3,7 +3,11 @@
  */
 // eslint-disable-next-line no-restricted-imports
 import type { MotionProps } from 'framer-motion';
-import type { ReferenceType, VirtualElement } from '@floating-ui/react-dom';
+import type {
+	Placement,
+	ReferenceType,
+	VirtualElement,
+} from '@floating-ui/react-dom';
 
 /**
  * Internal dependencies
@@ -16,7 +20,7 @@ import type {
 
 const POSITION_TO_PLACEMENT: Record<
 	NonNullable< PopoverProps[ 'position' ] >,
-	NonNullable< PopoverProps[ 'placement' ] >
+	Placement
 > = {
 	bottom: 'bottom',
 	top: 'top',
@@ -79,8 +83,7 @@ const POSITION_TO_PLACEMENT: Record<
  */
 export const positionToPlacement = (
 	position: NonNullable< PopoverProps[ 'position' ] >
-): NonNullable< PopoverProps[ 'placement' ] > =>
-	POSITION_TO_PLACEMENT[ position ] ?? 'bottom';
+) => POSITION_TO_PLACEMENT[ position ] ?? 'bottom';
 
 /**
  * @typedef AnimationOrigin


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This change is based on a[ diff ](https://github.com/WordPress/gutenberg/pull/48440#discussion_r1312093852)suggested by @mirka after reviewing upcoming changes to Tooltip in #48440. 

Last year, a utility function `positionToPlacement` was created to assist in converting values for the legacy `position` prop to the newer `placement` prop. #44377

The `position` prop supported `overlay`, but `placement` does not. However, @ciampo shared that `positionToPlacement` doesn't return `overlay` and proposed [a similar diff](https://github.com/WordPress/gutenberg/pull/48440#discussion_r1147927828) as well. 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The `overlay` type from `position` isn't part of `placement` from `floating-ui`, so we see TS errors in the aforementioned Tooltip. With more upcoming migrations, this may cause further TS errors in other components. Since `overlay` isn't returned, we can remove it. 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Replace `PopoverProps['placement']` type with `Placement` from `floating-ui` to remove type `overlay`. 

## Testing Instructions

CI checks pass
