### PR TITLE
Try disabling FONT_LIBRARY_ENABLE in PHP tests now that the lib is in Core

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -9,7 +9,6 @@
 	>
 	<php>
 		<env name="WORDPRESS_TABLE_PREFIX" value="wptests_" />
-		<const name="FONT_LIBRARY_ENABLE" value="true"/>
 	</php>
 	<testsuites>
 		<testsuite name="default">

--- a/phpunit/multisite.xml
+++ b/phpunit/multisite.xml
@@ -10,7 +10,6 @@
 	<php>
 		<env name="WP_MULTISITE" value="1" />
 		<env name="WORDPRESS_TABLE_PREFIX" value="wptests_" />
-		<const name="FONT_LIBRARY_ENABLE" value="true"/>
 	</php>
 	<testsuites>
 		<testsuite name="default">


### PR DESCRIPTION
this is because PHP test are failing

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
