### PR TITLE
Font Face & Font Library: Load PHP files only if the main class does not exist.

### DIFF
--- a/lib/load.php
+++ b/lib/load.php
@@ -165,19 +165,21 @@ if (
 	( defined( 'FONTS_LIBRARY_ENABLE' ) && FONTS_LIBRARY_ENABLE )
 ) {
 	// Loads the Font Library.
-	require __DIR__ . '/experimental/fonts/font-library/class-wp-font-collection.php';
-	require __DIR__ . '/experimental/fonts/font-library/class-wp-font-library.php';
-	require __DIR__ . '/experimental/fonts/font-library/class-wp-font-family-utils.php';
-	require __DIR__ . '/experimental/fonts/font-library/class-wp-font-family.php';
-	require __DIR__ . '/experimental/fonts/font-library/class-wp-rest-font-library-controller.php';
-	require __DIR__ . '/experimental/fonts/font-library/font-library.php';
+	if ( ! class_exists( 'WP_Font_Library' ) ) {
+		require __DIR__ . '/experimental/fonts/font-library/class-wp-font-collection.php';
+		require __DIR__ . '/experimental/fonts/font-library/class-wp-font-library.php';
+		require __DIR__ . '/experimental/fonts/font-library/class-wp-font-family-utils.php';
+		require __DIR__ . '/experimental/fonts/font-library/class-wp-font-family.php';
+		require __DIR__ . '/experimental/fonts/font-library/class-wp-rest-font-library-controller.php';
+		require __DIR__ . '/experimental/fonts/font-library/font-library.php';
+	}
 
 	// Load the Font Face.
-	require __DIR__ . '/compat/wordpress-6.4/fonts/font-face/class-wp-font-face.php';
-	require __DIR__ . '/compat/wordpress-6.4/fonts/font-face/class-wp-font-face-resolver.php';
-
-	// A general purpose file for all fonts PHP functions and hooks.
-	require __DIR__ . '/compat/wordpress-6.4/fonts/fonts.php';
+	if ( ! class_exists( 'WP_Font_Face' ) ) {
+		require __DIR__ . '/compat/wordpress-6.4/fonts/font-face/class-wp-font-face.php';
+		require __DIR__ . '/compat/wordpress-6.4/fonts/font-face/class-wp-font-face-resolver.php';
+		require __DIR__ . '/compat/wordpress-6.4/fonts/fonts.php';
+	}
 
 	// Load the BC Layer to avoid fatal errors of extenders using the Fonts API.
 	// @core-merge: do not merge the BC layer files into WordPress Core.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Prevents Font Face and Font Library PHP files from loading into memory if each main class already exists in memory (i.e. meaning already in WordPress Core).

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

As a fail-safe to avoid `Fatal error: Cannot declare class`.

In all PRs after Font Face was merged into Core, the PHP 7.0 multisite tests fail:

```
Fatal error: Cannot declare class WP_Font_Face, because the name is already in use in /var/www/html/wp-content/plugins/gutenberg/lib/compat/wordpress-6.4/fonts/font-face/class-wp-font-face.php on line 19
```

This change is being made to unblock all PRs.

A follow-up review will happen to investigate why only PHP 7.0 multisite tests fail with this fatal error, while all other PHP versions do not fail. From that follow-up review, recommendations can be made for if this approach should be adopted instead of class_exists guard at the top of each class file.

## How?

In the `load.php` file, it wraps each group of files to only load if its main class does not exist in memory.

## Testing Instructions

The PHP 7.0 tests should pass.
