### PR TITLE
Columns: Adopt button and heading element colors

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -98,7 +98,7 @@ A single column within a columns block. ([Source](https://github.com/WordPress/g
 -	**Name:** core/column
 -	**Category:** design
 -	**Parent:** core/columns
--	**Supports:** anchor, color (background, gradients, heading, link, text), layout, spacing (blockGap, padding), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
+-	**Supports:** anchor, color (background, button, gradients, heading, link, text), layout, spacing (blockGap, padding), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
 -	**Attributes:** allowedBlocks, templateLock, verticalAlignment, width
 
 ## Columns
@@ -107,7 +107,7 @@ Display content in multiple columns, with blocks added to each column. ([Source]
 
 -	**Name:** core/columns
 -	**Category:** design
--	**Supports:** align (full, wide), anchor, color (background, gradients, link, text), layout (default, ~~allowEditing~~, ~~allowInheriting~~, ~~allowSwitching~~), spacing (blockGap, margin, padding), typography (fontSize, lineHeight), ~~html~~
+-	**Supports:** align (full, wide), anchor, color (background, button, gradients, heading, link, text), layout (default, ~~allowEditing~~, ~~allowInheriting~~, ~~allowSwitching~~), spacing (blockGap, margin, padding), typography (fontSize, lineHeight), ~~html~~
 -	**Attributes:** isStackedOnMobile, templateLock, verticalAlignment
 
 ## Comment Author Avatar (deprecated)

--- a/packages/block-library/src/column/block.json
+++ b/packages/block-library/src/column/block.json
@@ -30,6 +30,7 @@
 		"color": {
 			"gradients": true,
 			"heading": true,
+			"button": true,
 			"link": true,
 			"__experimentalDefaultControls": {
 				"background": true,

--- a/packages/block-library/src/columns/block.json
+++ b/packages/block-library/src/columns/block.json
@@ -26,6 +26,8 @@
 		"color": {
 			"gradients": true,
 			"link": true,
+			"heading": true,
+			"button": true,
 			"__experimentalDefaultControls": {
 				"background": true,
 				"text": true


### PR DESCRIPTION
Related:
- https://github.com/WordPress/gutenberg/pull/53667

## What?

Adds the ability to specify colors for button and heading elements with Column/s blocks instances.

## Why?

Provides greater flexibility in styling sections that may differ from the overall global styles e.g. a call-to-action pattern that might be darker or lighter than the overall theme.


## How?

Opts into `button` and `heading` color support.

## Known Issues

_There are some existing issues with the generic `heading` element gradient backgrounds overriding a simple background color on specific `h1-h6` elements. Similarly, a gradient applied by the container block can't be overridden by a simple background color set via an individual block within the container. These will be addressed separately._

## Next Steps

The might be further container like blocks that we could opt into this color support for e.g. Cover, Media & Text, Details, Post Template etc.

## Testing Instructions

1. Edit a post and add a Columns block and select a multi-column layout for the inner columns
2. In each column add a few different levels of headings along with a button or two
3. Select the overall Columns block
4. In the Block Inspector > Styles > Color panel, toggle on button and heading color controls
5. Adjust color for buttons and heading elements (check preset and custom colors, gradients etc). All the button and heading elements within the columns should reflect the correct color
6. Select a specific heading element now (`h1` - `h6`) that matches one of the headings and confirm that overrides the generic heading element style selected earlier
7. Repeat the process, selecting one of the inner columns, checking their button/heading colors update appropriately
8. Save the post and confirm the colors are correct on the frontend

## Screenshots or screencast <!-- if applicable -->

<img width="1200" alt="Screenshot 2023-09-01 at 3 13 49 pm" src="https://github.com/WordPress/gutenberg/assets/60436221/a0e7a3b2-3cc6-4ef2-aa69-46951b7160a0">
