### PR TITLE
Adds removal notice to view.js.mustache

### DIFF
--- a/packages/create-block/lib/templates/block/view.js.mustache
+++ b/packages/create-block/lib/templates/block/view.js.mustache
@@ -13,8 +13,9 @@
  * }
  * ```
  *
- * If your project doesn't need any JavaScript running in the front-end you can 
- * safely delete this file and remove the `viewScript` property from `block.json`. 
+ * If you're not making any changes to this file because your project doesn't need any 
+ * JavaScript running in the front-end, then you should delete this file and remove 
+ * the `viewScript` property from `block.json`. 
  *
  * @see https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#view-script
  */

--- a/packages/create-block/lib/templates/block/view.js.mustache
+++ b/packages/create-block/lib/templates/block/view.js.mustache
@@ -13,6 +13,9 @@
  * }
  * ```
  *
+ * If your project doesn't need any JavaScript running in the front-end you can 
+ * safely delete this file and remove the `viewScript` property from `block.json`. 
+ *
  * @see https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#view-script
  */
  


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Adds a line to `view.js.mustache` in the `create-block` package stating that it's safe to remove the file if no JavaScript is running in the front end.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Because the file is not needed if no JavaScript is going to run in the front end.


