### PR TITLE
Add missing dependency of `@wordpress/patterns` on `@babel/runtime`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55686,6 +55686,7 @@
 			"version": "1.2.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
+				"@babel/runtime": "^7.16.0",
 				"@wordpress/block-editor": "file:../block-editor",
 				"@wordpress/blocks": "file:../blocks",
 				"@wordpress/components": "file:../components",
@@ -68032,6 +68033,7 @@
 		"@wordpress/patterns": {
 			"version": "file:packages/patterns",
 			"requires": {
+				"@babel/runtime": "^7.16.0",
 				"@wordpress/block-editor": "file:../block-editor",
 				"@wordpress/blocks": "file:../blocks",
 				"@wordpress/components": "file:../components",

--- a/packages/patterns/package.json
+++ b/packages/patterns/package.json
@@ -31,6 +31,7 @@
 		"{src,build,build-module}/{index.js,store/index.js,hooks/**}"
 	],
 	"dependencies": {
+		"@babel/runtime": "^7.16.0",
 		"@wordpress/block-editor": "file:../block-editor",
 		"@wordpress/blocks": "file:../blocks",
 		"@wordpress/components": "file:../components",


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Add missing dependency of `@wordpress/patterns` on `@babel/runtime`

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Build code transformations can introduce dependencies on packages such as @wordpress/element and @babel/runtime. These need to be declared if the package is to function correctly with yarn's p'n'p or pnpm with hoisting disabled.

- @wordpress/patterns depends on @babel/runtime (fixes #54115)

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Adding the missing dependencies. Normally I'd probably have done the `@babel/runtime` dep as a peer dep, but I see you use a normal dependency everywhere else so I followed along.

## Testing Instructions

1. Follow the reproduction instructions in the linked bug to set up the test and reproduce the bug.
2. Do `yarn add <package>@file:/path/to/gutenberg/packages/<package>` or `pnpm add <package>@file:/path/to/gutenberg/packages/<package>` to point yarn or pnpm at the locally built version of the package.
3. Repeat the final instruction in the reproduction to check that the bug is fixed.
