### PR TITLE
package(e2e-test-utils): update fixtures

### DIFF
--- a/packages/e2e-test-utils/CHANGELOG.md
+++ b/packages/e2e-test-utils/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+### Enhancement
+
+-    Update promise order in `loginUser` to avoid any flakiness in the tests.
+-    Update `activateTheme` to redirect to `themes.php` after theme activation, if theme redirects to some other page.
+-    Update `activatePlugin` to redirect to `plugins.php` after plugin activation, if plugin redirects to some other page.
+
 ## 10.12.0 (2023-08-31)
 
 ## 10.11.0 (2023-08-16)

--- a/packages/e2e-test-utils/src/activate-plugin.js
+++ b/packages/e2e-test-utils/src/activate-plugin.js
@@ -21,6 +21,10 @@ export async function activatePlugin( slug ) {
 		return;
 	}
 	await page.click( `tr[data-slug="${ slug }"] .activate a` );
+
+	if ( ! isCurrentURL( 'plugins.php' ) ) {
+		await visitAdminPage( 'plugins.php' );
+	}
 	await page.waitForSelector( `tr[data-slug="${ slug }"] .deactivate a` );
 	await switchUserToTest();
 }

--- a/packages/e2e-test-utils/src/activate-plugin.js
+++ b/packages/e2e-test-utils/src/activate-plugin.js
@@ -4,6 +4,7 @@
 import { switchUserToAdmin } from './switch-user-to-admin';
 import { switchUserToTest } from './switch-user-to-test';
 import { visitAdminPage } from './visit-admin-page';
+import { isCurrentURL } from './is-current-url';
 
 /**
  * Activates an installed plugin.

--- a/packages/e2e-test-utils/src/activate-theme.js
+++ b/packages/e2e-test-utils/src/activate-theme.js
@@ -23,6 +23,10 @@ export async function activateTheme( slug ) {
 	}
 
 	await page.click( `div[data-slug="${ slug }"] .button.activate` );
+
+	if ( ! isCurrentURL( 'themes.php' ) ) {
+		await visitAdminPage( 'themes.php' );
+	}
 	await page.waitForSelector( `div[data-slug="${ slug }"].active` );
 	await switchUserToTest();
 }

--- a/packages/e2e-test-utils/src/activate-theme.js
+++ b/packages/e2e-test-utils/src/activate-theme.js
@@ -4,6 +4,7 @@
 import { switchUserToAdmin } from './switch-user-to-admin';
 import { switchUserToTest } from './switch-user-to-test';
 import { visitAdminPage } from './visit-admin-page';
+import { isCurrentURL } from './is-current-url';
 
 /**
  * Activates an installed theme.

--- a/packages/e2e-test-utils/src/login-user.js
+++ b/packages/e2e-test-utils/src/login-user.js
@@ -29,6 +29,8 @@ export async function loginUser(
 	await pressKeyWithModifier( 'primary', 'a' );
 	await page.type( '#user_pass', password );
 
-	const waitForLoginNavigation = page.waitForNavigation();
-	await Promise.all( [ waitForLoginNavigation, page.click( '#wp-submit' ) ] );
+	await Promise.all( [
+		page.click( '#wp-submit' ),
+		page.waitForNavigation( { waitUntil: 'networkidle0' } ),
+	] );
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
-    Update promise order in `loginUser` to avoid any flakiness in the tests.
-    Update `activateTheme` to redirect to `themes.php` after theme activation, if the theme redirects to some other page.
-    Update `activatePlugin` to redirect to `plugins.php` after plugin activation, if the plugin redirects to some other page.

## Why?
Many plugins and themes redirect to a setup screen just after the activation. In such cases `activatePlugin` and `activateTheme` later fail to evaluate the required selector since it's not on the `themes.php` or `plugins.php` admin pages.

## How?
Added a guard to check if we are still on required pages after plugin/theme activation. If not then go to the required pages.

## Testing Instructions
Try to run  `activatePlugin` with the `WooCommerce` plugin, `activateTheme` with the `Hestia` theme, and note the before and after results.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
