### PR TITLE
Storybook: update doc param values for ConfirmDialog

### DIFF
--- a/packages/components/src/confirm-dialog/stories/index.story.js
+++ b/packages/components/src/confirm-dialog/stories/index.story.js
@@ -87,22 +87,22 @@ const _defaultSnippet = `() => {
 
   return (
     <>
-    <ConfirmDialog
-      isOpen={ isOpen }
-      onConfirm={ handleConfirm }
-      onCancel={ handleCancel }
-    >
-      Would you like to privately publish the post now?
-    </ConfirmDialog>
+      <ConfirmDialog
+        isOpen={ isOpen }
+        onConfirm={ handleConfirm }
+        onCancel={ handleCancel }
+      >
+        Would you like to privately publish the post now?
+      </ConfirmDialog>
 
-    <Heading level={ 1 }>{ confirmVal }</Heading>
+      <Heading level={ 1 }>{ confirmVal }</Heading>
 
-    <Button variant="primary" onClick={ () => setIsOpen( true ) }>
-      Open ConfirmDialog
-    </Button>
+      <Button variant="primary" onClick={ () => setIsOpen( true ) }>
+        Open ConfirmDialog
+      </Button>
     </>
-    );
-  };`;
+  );
+};`;
 _default.args = {};
 _default.parameters = {
 	docs: {
@@ -110,7 +110,6 @@ _default.parameters = {
 			code: _defaultSnippet,
 			language: 'jsx',
 			type: 'auto',
-			format: true,
 		},
 	},
 };

--- a/packages/components/src/confirm-dialog/stories/index.story.js
+++ b/packages/components/src/confirm-dialog/stories/index.story.js
@@ -110,7 +110,7 @@ _default.parameters = {
 			code: _defaultSnippet,
 			language: 'jsx',
 			type: 'auto',
-			format: 'true',
+			format: true,
 		},
 	},
 };


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/54123

## What?
Just updating storybook doc format value with boolean in the `<ConfirmDialog />` component. Formerly it was a string.

## Why?
Storybook was throwing an error:

```console
Uncaught Error: Couldn't resolve parser "true". Parsers must be explicitly added to the standalone bundle.
```


## Testing Instructions
Run `npm run storybook:dev` and head to:

http://localhost:50240/?path=/docs/components-experimental-confirmdialog--docs

You should see the docs page.

<img width="894" alt="Screenshot 2023-09-03 at 11 42 33 am" src="https://github.com/WordPress/gutenberg/assets/6458278/da03b616-704c-42c3-912c-0d23a316ca76">

