### PR TITLE
Fixed top toolbar: adjust height to ensure parent's bottom border displays

### DIFF
--- a/packages/block-editor/src/components/block-tools/style.scss
+++ b/packages/block-editor/src/components/block-tools/style.scss
@@ -155,7 +155,8 @@
 			display: flex;
 
 			// Mimic the height of the parent, vertically align center, and provide a max-height.
-			height: $header-height;
+			// Minus one to account for the bottom border of the .is-fixed parent.
+			height: $header-height - 1;
 			align-items: center;
 
 			&.is-collapsed {

--- a/packages/block-editor/src/components/block-tools/style.scss
+++ b/packages/block-editor/src/components/block-tools/style.scss
@@ -155,8 +155,7 @@
 			display: flex;
 
 			// Mimic the height of the parent, vertically align center, and provide a max-height.
-			// Minus one to account for the bottom border of the .is-fixed parent.
-			height: $header-height - 1;
+			height: $header-height;
 			align-items: center;
 
 			&.is-collapsed {

--- a/packages/edit-site/src/components/block-editor/style.scss
+++ b/packages/edit-site/src/components/block-editor/style.scss
@@ -179,8 +179,8 @@
 @include break-medium() {
 	.block-editor-block-contextual-toolbar.is-fixed {
 		// Minus one to account for the bottom border of the .is-fixed parent.
-		height: $header-height - 1;
+		height: $header-height - $border-width;
 		// Ensure the block tools icons remain aligned with the main toolbar items.
-		padding-top: 1px;
+		padding-top: $border-width;
 	}
 }

--- a/packages/edit-site/src/components/block-editor/style.scss
+++ b/packages/edit-site/src/components/block-editor/style.scss
@@ -173,3 +173,14 @@
 	}
 }
 
+// These site editor-specific are to ensure the fixed block toolbar
+// sits neatly within the header. See: https://github.com/WordPress/gutenberg/pull/54131
+// Can be removed when the header is refactored to be consistent across editors.
+@include break-medium() {
+	.block-editor-block-contextual-toolbar.is-fixed {
+		// Minus one to account for the bottom border of the .is-fixed parent.
+		height: $header-height - 1;
+		// Ensure the block tools icons remain aligned with the main toolbar items.
+		padding-top: 1px;
+	}
+}


### PR DESCRIPTION
Resolves https://github.com/WordPress/gutenberg/issues/54093

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Reduce the height of the fixed block toolbar by 1px. 

## Why and how?
When the block toolbar is fixed, account for parent's bottom border. The [parent is also set at 60px high](https://github.com/WordPress/gutenberg/blob/57c4a6ea53038423d8fff35e8d65c1ff782895b8/packages/edit-site/src/components/header-edit-mode/style.scss#L4), including the border so to make it fit we have to squish the toolbar to 59px. 

Another approach would be to give the block toolbar a bottom border, but seems fragile since if the toolbar is pushed out in a vertical direction the double border would show.

## Testing Instructions

In the site editor, enable the fixed block tookbar in the settings panel

<img width="365" alt="Screenshot 2023-09-03 at 1 00 59 pm" src="https://github.com/WordPress/gutenberg/assets/6458278/3c5c566b-2235-4b3c-83e0-55deef18c806">

Select a block, e.g., the site title block. The bottom border on the fixed toolbar should display properly.

Check the post editor as well.

| Before | After |
| ------------- | ------------- |
| <img width="300" alt="Screenshot 2023-09-03 at 12 40 56 pm" src="https://github.com/WordPress/gutenberg/assets/6458278/088f4221-919d-4c7e-9907-b3f51c730d95">  | <img width="300" alt="Screenshot 2023-09-03 at 12 40 40 pm" src="https://github.com/WordPress/gutenberg/assets/6458278/5fac200a-4863-4406-9491-005fe4627010">  |


Note: you might see a horizontal scroll bar, this is also a feature on trunk too:


https://github.com/WordPress/gutenberg/assets/6458278/f780e62f-6c2d-4872-bd00-ce171b83231f





