### PR TITLE
Command Palette: Fix duplicate Patterns command

### DIFF
--- a/packages/core-commands/src/admin-navigation-commands.js
+++ b/packages/core-commands/src/admin-navigation-commands.js
@@ -3,7 +3,7 @@
  */
 import { useCommand } from '@wordpress/commands';
 import { __ } from '@wordpress/i18n';
-import { external, plus, symbol } from '@wordpress/icons';
+import { plus, symbol } from '@wordpress/icons';
 import { addQueryArgs, getPath } from '@wordpress/url';
 import { privateApis as routerPrivateApis } from '@wordpress/router';
 
@@ -42,7 +42,8 @@ export function useAdminNavigationCommands() {
 	} );
 	useCommand( {
 		name: 'core/manage-reusable-blocks',
-		label: __( 'Open patterns' ),
+		label: __( 'Patterns' ),
+		icon: symbol,
 		callback: ( { close } ) => {
 			if ( isTemplatesAccessible && isBlockBasedTheme ) {
 				const args = {
@@ -58,6 +59,5 @@ export function useAdminNavigationCommands() {
 				document.location.href = 'edit.php?post_type=wp_block';
 			}
 		},
-		icon: isSiteEditor ? symbol : external,
 	} );
 }

--- a/packages/core-commands/src/site-editor-navigation-commands.js
+++ b/packages/core-commands/src/site-editor-navigation-commands.js
@@ -10,7 +10,6 @@ import {
 	post,
 	page,
 	layout,
-	symbol,
 	symbolFilled,
 	styles,
 	navigation,
@@ -292,24 +291,6 @@ function useSiteEditorBasicNavigationCommands() {
 			callback: ( { close } ) => {
 				const args = {
 					path: '/wp_template',
-				};
-				const targetUrl = addQueryArgs( 'site-editor.php', args );
-				if ( isSiteEditor ) {
-					history.push( args );
-				} else {
-					document.location = targetUrl;
-				}
-				close();
-			},
-		} );
-
-		result.push( {
-			name: 'core/edit-site/open-patterns',
-			label: __( 'Patterns' ),
-			icon: symbol,
-			callback: ( { close } ) => {
-				const args = {
-					path: '/patterns',
 				};
 				const targetUrl = addQueryArgs( 'site-editor.php', args );
 				if ( isSiteEditor ) {


### PR DESCRIPTION
Derived from [this comment](https://github.com/WordPress/gutenberg/pull/54066#pullrequestreview-1606350703)

## What?

This PR fixes a duplicate command regarding pattern pages.

| Before | After |
|--------|--------|
| ![before](https://github.com/WordPress/gutenberg/assets/54422211/54f2eb9f-789a-4e02-98b9-67119759c72a) | ![after](https://github.com/WordPress/gutenberg/assets/54422211/49131eb1-7a1a-44d9-a309-7c4ef9b1dec4) | 

## Why?
As part of #53496, a command regarding pattern pages was added. However, since a similar command was already added in #52817, I believe it was necessary to update the existing command.

## How?
Removed the commands added in #53496 and updated the commands that were originally there.

One thing that is of interest is which of the following files this command should belong to.

- `packages/core-commands/src/admin-navigation-commands.js`
- `packages/core-commands/src/site-editor-navigation-commands.js`

As suggested in #54066, if the classic theme has access to the Patterns page of the Site Editor, this command should belong in the latter file. Currently, however, the classic theme does not have access to the Patterns page in the Site Editor, so it goes to the post list page with a post type of wp_block. Therefore, I believe it should belong in the former file for now.

## Testing Instructions

To test all themes (Block Theme, Hybrid Theme, Classic Theme), it is better to use `localhost:8889/wp-admin`.

- Block Theme (TT3): This command should always take you to the Patterns page of the Site Editor.
- Hybrid Theme (Emptyhybrid): This command should take you to the post list page where the post type is `wp_block`.
- Classic Theme (TT1): This command should take you to the post list page where the post type is `wp_block`.