### PR TITLE
Incorrect file extension?

### DIFF
--- a/docs/how-to-guides/enqueueing-assets-in-the-editor.md
+++ b/docs/how-to-guides/enqueueing-assets-in-the-editor.md
@@ -27,7 +27,7 @@ Examples might be adding custom inspector or toolbar controls, registering block
 function example_enqueue_editor_assets() {
     wp_enqueue_script( 
         'example-editor-scripts', 
-        plugins_url( 'editor-scripts.css', __FILE__ ) );
+        plugins_url( 'editor-scripts.js', __FILE__ ) );
     }
     wp_enqueue_style( 
         'example-editor-styles', 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
If you are loading a JavaScript file in the relevant section, the extension is wrong.

## Why?
Typo?
