### PR TITLE
Snackbar: re-position snackbar above modals

### DIFF
--- a/packages/base-styles/_z-index.scss
+++ b/packages/base-styles/_z-index.scss
@@ -109,8 +109,8 @@ $z-layers: (
 	// Above the block list and the header.
 	".block-editor-block-popover": 31,
 
-	// Show snackbars above everything (similar to popovers)
-	".components-snackbar-list": 100000,
+	// Show snackbars above everything, including modals (similar to popovers)
+	".components-snackbar-list": 100001,
 
 	// Show modal under the wp-admin menus and the popover
 	".components-modal__screen-overlay": 100000,

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 -   Make the `Popover.Slot` optional and render popovers at the bottom of the document's body by default. ([#53889](https://github.com/WordPress/gutenberg/pull/53889), [#53982](https://github.com/WordPress/gutenberg/pull/53982)).
 
+### Bug Fixes
+
+-   `Snackbar`: Re-position Snackbar above Modals ([#54153](https://github.com/WordPress/gutenberg/pull/54153)).
+
 ## 25.7.0 (2023-08-31)
 
 ### Enhancements

--- a/packages/components/src/snackbar/list.tsx
+++ b/packages/components/src/snackbar/list.tsx
@@ -7,7 +7,7 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { useReducedMotion } from '@wordpress/compose';
-import { useRef } from '@wordpress/element';
+import { createPortal, useRef } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -72,7 +72,7 @@ export function SnackbarList( {
 	const removeNotice =
 		( notice: SnackbarListProps[ 'notices' ][ number ] ) => () =>
 			onRemove?.( notice.id );
-	return (
+	return createPortal(
 		<div className={ className } tabIndex={ -1 } ref={ listRef }>
 			{ children }
 			<AnimatePresence>
@@ -103,7 +103,8 @@ export function SnackbarList( {
 					);
 				} ) }
 			</AnimatePresence>
-		</div>
+		</div>,
+		document.body
 	);
 }
 

--- a/packages/components/src/snackbar/style.scss
+++ b/packages/components/src/snackbar/style.scss
@@ -78,6 +78,8 @@
 
 .components-snackbar-list {
 	position: absolute;
+	bottom: $grid-unit-50;
+	left: $grid-unit-20;
 	z-index: z-index(".components-snackbar-list");
 	width: 100%;
 	box-sizing: border-box;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
The snackbar notifications currently show underneath the modals, which becomes more of an issue when the modal takes up a large percentage of the screen (e.g. at smaller resolutions, or where large modals are used). This PR adjusts the position and z-index of the snackbar component to allow it to display over the top of the modal.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Closes https://github.com/WordPress/gutenberg/issues/52609.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
This PR wraps the `SnackbarList` component in `createPortal`, in order to attach it to the body. This is similar to how the `Modal` component works. This means the z-index can then be changed to allow the snackbar notifications to display over the top of the modal. The positioning of the snackbar has also been slightly adjusted as its position is now relative to the body element.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
The easiest way to test this is to test on a smaller viewport:

1. Set the viewport to a small enough size so that the modal takes up the majority of the screen, e.g. 900 x 595.
2. Update a setting that triggers a snackbar notification, such as changing the global text color.
3. Open the Preferences modal whilst the snackbar notification is still open, and check to see if the notification displays over the top of the modal.
4. Alternatively, comment out the timeout dismiss in the snackbar component (in /packages/components/src/snackbar/index.tsx, line 91-101), trigger a snackbar notification and then open a modal.

## Screenshots or screencast <!-- if applicable -->

| Before | After |
| ------ | ----- |
| <img width="899" alt="image" src="https://github.com/WordPress/gutenberg/assets/1645628/574b8a51-c23a-4669-b7c2-134a4fb4e58b"> | <img width="899" alt="image" src="https://github.com/WordPress/gutenberg/assets/1645628/e66391cb-6bae-44f7-9b03-538d2603eb1f"> |
