### PR TITLE
Edit Post: Avoid fetching the edited template for non-viewable posts

### DIFF
--- a/packages/edit-post/src/components/visual-editor/index.js
+++ b/packages/edit-post/src/components/visual-editor/index.js
@@ -123,9 +123,10 @@ export default function VisualEditor( { styles } ) {
 			select( editorStore );
 		const { getBlockTypes } = select( blocksStore );
 		const _isTemplateMode = isEditingTemplate();
+		const postTypeSlug = getCurrentPostType();
 		let _wrapperBlockName;
 
-		if ( getCurrentPostType() === 'wp_block' ) {
+		if ( postTypeSlug === 'wp_block' ) {
 			_wrapperBlockName = 'core/block';
 		} else if ( ! _isTemplateMode ) {
 			_wrapperBlockName = 'core/post-content';
@@ -133,6 +134,7 @@ export default function VisualEditor( { styles } ) {
 
 		const editorSettings = getEditorSettings();
 		const supportsTemplateMode = editorSettings.supportsTemplateMode;
+		const postType = select( coreStore ).getPostType( postTypeSlug );
 		const canEditTemplate = select( coreStore ).canUser(
 			'create',
 			'templates'
@@ -146,7 +148,7 @@ export default function VisualEditor( { styles } ) {
 			// Post template fetch returns a 404 on classic themes, which
 			// messes with e2e tests, so check it's a block theme first.
 			editedPostTemplate:
-				supportsTemplateMode && canEditTemplate
+				postType?.viewable && supportsTemplateMode && canEditTemplate
 					? getEditedPostTemplate()
 					: undefined,
 			wrapperBlockName: _wrapperBlockName,


### PR DESCRIPTION
## What?
PR adds an extra check before fetching the edited post template to avoid a 404 error with private post types. I noticed while working with Patterns - which can't be viewed on the front end.

## Why?
A template can't be assigned to a non-public or non-viewable post.

## How
Check if the post type is also viewable before calling `getEditedPostTemplate()`. A similar check is used in the `PostTemplate` component to avoid rendering it.

## Testing Instructions
1. Go to `/wp-admin/edit.php?post_type=wp_block`.
2. Open or create a new Pattern.
3. Confirm that the 404 error isn't logged in the console.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2023-09-04 at 20 20 48](https://github.com/WordPress/gutenberg/assets/240569/71b0d912-adeb-4f82-88e6-075f84f27292)