### PR TITLE
PostSyncStatus: Derive sync status inside the selector

### DIFF
--- a/packages/editor/src/components/post-sync-status/index.js
+++ b/packages/editor/src/components/post-sync-status/index.js
@@ -21,11 +21,18 @@ import { store as editorStore } from '../../store';
 import { unlock } from '../../lock-unlock';
 
 export default function PostSyncStatus() {
-	const { syncStatus, postType, meta } = useSelect( ( select ) => {
+	const { syncStatus, postType } = useSelect( ( select ) => {
 		const { getEditedPostAttribute } = select( editorStore );
+		const meta = getEditedPostAttribute( 'meta' );
+
+		// When the post is first created, the top level wp_pattern_sync_status is not set so get meta value instead.
+		const currentSyncStatus =
+			meta?.wp_pattern_sync_status === 'unsynced'
+				? 'unsynced'
+				: getEditedPostAttribute( 'wp_pattern_sync_status' );
+
 		return {
-			syncStatus: getEditedPostAttribute( 'wp_pattern_sync_status' ),
-			meta: getEditedPostAttribute( 'meta' ),
+			syncStatus: currentSyncStatus,
 			postType: getEditedPostAttribute( 'type' ),
 		};
 	} );
@@ -33,15 +40,12 @@ export default function PostSyncStatus() {
 	if ( postType !== 'wp_block' ) {
 		return null;
 	}
-	// When the post is first created, the top level wp_pattern_sync_status is not set so get meta value instead.
-	const currentSyncStatus =
-		meta?.wp_pattern_sync_status === 'unsynced' ? 'unsynced' : syncStatus;
 
 	return (
 		<PanelRow className="edit-post-sync-status">
 			<span>{ __( 'Sync status' ) }</span>
 			<div>
-				{ currentSyncStatus === 'unsynced'
+				{ syncStatus === 'unsynced'
 					? __( 'Not synced' )
 					: __( 'Fully synced' ) }
 			</div>

--- a/packages/editor/src/components/post-sync-status/index.js
+++ b/packages/editor/src/components/post-sync-status/index.js
@@ -20,6 +20,8 @@ import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
 import { store as editorStore } from '../../store';
 import { unlock } from '../../lock-unlock';
 
+const { ReusableBlocksRenameHint } = unlock( blockEditorPrivateApis );
+
 export default function PostSyncStatus() {
 	const { syncStatus, postType } = useSelect( ( select ) => {
 		const { getEditedPostAttribute } = select( editorStore );
@@ -86,7 +88,7 @@ export function PostSyncStatusModal() {
 	if ( postType !== 'wp_block' || ! isNewPost ) {
 		return null;
 	}
-	const { ReusableBlocksRenameHint } = unlock( blockEditorPrivateApis );
+
 	return (
 		<>
 			{ isModalOpen && (


### PR DESCRIPTION
## What?
PR updates `PostSyncStatus` to derive sync status inside the selector.

## Why?
It's good practice for components to select only the data they need. In this case, it's better to derive status inside the selector and return string value instead of the whole post meta object.

P.S. The Component occasionally triggered a new `useSelect` warning, meaning that `getEditedPostAttribute( 'meta' )` might not return a referentially stable object. I'm investigating this separately.

## Testing Instructions
The component should work as before. I used testing instructions from #52352.

## Screenshots or screencast <!-- if applicable -->

![CleanShot 2023-09-04 at 20 50 22](https://github.com/WordPress/gutenberg/assets/240569/f284821b-61bc-434b-bced-d36f1812beab)