### PR TITLE
Editor: Memoize 'getNestedEditedPostProperty' selector helper

### DIFF
--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -289,17 +289,23 @@ export function getCurrentPostAttribute( state, attributeName ) {
  *
  * @return {*} Post attribute value.
  */
-const getNestedEditedPostProperty = ( state, attributeName ) => {
-	const edits = getPostEdits( state );
-	if ( ! edits.hasOwnProperty( attributeName ) ) {
-		return getCurrentPostAttribute( state, attributeName );
-	}
+const getNestedEditedPostProperty = createSelector(
+	( state, attributeName ) => {
+		const edits = getPostEdits( state );
+		if ( ! edits.hasOwnProperty( attributeName ) ) {
+			return getCurrentPostAttribute( state, attributeName );
+		}
 
-	return {
-		...getCurrentPostAttribute( state, attributeName ),
-		...edits[ attributeName ],
-	};
-};
+		return {
+			...getCurrentPostAttribute( state, attributeName ),
+			...edits[ attributeName ],
+		};
+	},
+	( state, attributeName ) => [
+		getCurrentPostAttribute( state, attributeName ),
+		getPostEdits( state )[ attributeName ],
+	]
+);
 
 /**
  * Returns a single attribute of the post being edited, preferring the unsaved

--- a/packages/editor/src/store/test/selectors.js
+++ b/packages/editor/src/store/test/selectors.js
@@ -725,6 +725,31 @@ describe( 'selectors', () => {
 				b: 2,
 			} );
 		} );
+
+		it( 'should return the same value for mergeable properties when called multiple times', () => {
+			const state = {
+				currentPost: {
+					meta: {
+						a: 1,
+						b: 1,
+					},
+				},
+				editor: {
+					present: {
+						edits: {
+							meta: {
+								b: 2,
+							},
+						},
+					},
+				},
+				initialEdits: {},
+			};
+
+			expect( getEditedPostAttribute( state, 'meta' ) ).toBe(
+				getEditedPostAttribute( state, 'meta' )
+			);
+		} );
 	} );
 
 	describe( 'getCurrentPostLastRevisionId', () => {


### PR DESCRIPTION
## What?
Memoize the `getNestedEditedPostProperty` selector helper to avoid returning different values when called with the same state and parameters.

## Why?
While working on #54159, I noticed that `getEditedPostAttribute( 'meta' )` would return a different value on each call after making edits to the post meta.

When the meta property has been edited, the `getEditedPostAttribute` [will call `getNestedEditedPostProperty` internally](https://github.com/WordPress/gutenberg/blob/37f52ae884a40f7cb77ac2484648b4e4ad973b59/packages/editor/src/store/selectors.js#L327-L331), where merged values weren't memoized.

## Testing Instructions
PR includes the unit test.

### Prior to #54159.
1. Build plugin in dev mode - `npm run dev`.
2. Open a post or page.
3. Add footnotes.
4. Switch between the "Post" and "Block" document setting tabs.
5. The `useSelect` warning will be logged in the console.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2023-09-04 at 23 19 50](https://github.com/WordPress/gutenberg/assets/240569/87f8b8e2-8d7d-4b69-9b1d-a0c3fd2bd2ee)

