### PR TITLE
Revisions: remove 'gutenberg' query param from revisions.php

### DIFF
--- a/packages/edit-site/src/components/sidebar-edit-mode/template-panel/last-revision.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/template-panel/last-revision.js
@@ -50,7 +50,6 @@ const PostLastRevision = () => {
 			<Button
 				href={ addQueryArgs( 'revision.php', {
 					revision: lastRevisionId,
-					gutenberg: true,
 				} ) }
 				className="edit-site-template-last-revision__title"
 				icon={ backup }

--- a/packages/editor/src/components/post-last-revision/index.js
+++ b/packages/editor/src/components/post-last-revision/index.js
@@ -28,7 +28,6 @@ function LastRevision() {
 			<Button
 				href={ addQueryArgs( 'revision.php', {
 					revision: lastRevisionId,
-					gutenberg: true,
 				} ) }
 				className="editor-post-last-revision__title"
 				icon={ backup }


### PR DESCRIPTION


## What?
remove 'gutenberg' query param and value from revisions.php links

Context: https://github.com/WordPress/gutenberg/pull/54082#discussion_r1315237269

## Why?
The query param was introduced in https://github.com/WordPress/gutenberg/pull/3511 for the following reasons:

> Add a gutenberg query var to the revisions link. This helps identify the correct link to use for returning to the editor from the revisions screen.

This was almost 6 years ago and the [relevant plugin file](https://github.com/WordPress/gutenberg/pull/3511/files#diff-e50f9b4c9183a86d62e4277f4746bb7738dd45c8f6ac50dc563ef7028681832b) as been deleted. 

We can remove support for these versions. 

## How?
Delete key.

## Testing Instructions
There should be no regressions.

Check that the revisions link works in posts and pages and also for templates. 

The title and "← Go to editor" links on the revisions.php page should work as expected.

## Screenshots or screencast <!-- if applicable -->

<img width="453" alt="Screenshot 2023-09-05 at 11 24 44 am" src="https://github.com/WordPress/gutenberg/assets/6458278/402937c4-1930-4825-96c3-ce646edd7539">
<img width="287" alt="Screenshot 2023-09-05 at 11 19 21 am" src="https://github.com/WordPress/gutenberg/assets/6458278/35e4203c-0a89-429b-8462-9f40afeae1b5">
<img width="321" alt="Screenshot 2023-09-05 at 11 19 08 am" src="https://github.com/WordPress/gutenberg/assets/6458278/d322d146-66cc-4de1-825c-bfa13f38fb5d">
