### PR TITLE
Add edits data to the useEntityRecord

### DIFF
--- a/packages/core-data/src/hooks/test/use-entity-record.js
+++ b/packages/core-data/src/hooks/test/use-entity-record.js
@@ -46,6 +46,7 @@ describe( 'useEntityRecord', () => {
 			edit: expect.any( Function ),
 			editedRecord: {},
 			hasEdits: false,
+			edits: {},
 			record: undefined,
 			save: expect.any( Function ),
 			hasResolved: false,
@@ -64,6 +65,7 @@ describe( 'useEntityRecord', () => {
 			edit: expect.any( Function ),
 			editedRecord: { hello: 'world', id: 1 },
 			hasEdits: false,
+			edits: {},
 			record: { hello: 'world', id: 1 },
 			save: expect.any( Function ),
 			hasResolved: true,
@@ -92,6 +94,7 @@ describe( 'useEntityRecord', () => {
 				edit: expect.any( Function ),
 				editedRecord: { hello: 'world', id: 1 },
 				hasEdits: false,
+				edits: {},
 				record: { hello: 'world', id: 1 },
 				save: expect.any( Function ),
 				hasResolved: true,
@@ -108,5 +111,6 @@ describe( 'useEntityRecord', () => {
 
 		expect( widget.record ).toEqual( { hello: 'world', id: 1 } );
 		expect( widget.editedRecord ).toEqual( { hello: 'foo', id: 1 } );
+		expect( widget.edits ).toEqual( { hello: 'foo' } );
 	} );
 } );

--- a/packages/core-data/src/hooks/use-entity-record.ts
+++ b/packages/core-data/src/hooks/use-entity-record.ts
@@ -19,6 +19,9 @@ export interface EntityRecordResolution< RecordType > {
 	/** The edited entity record */
 	editedRecord: Partial< RecordType >;
 
+	/** The edits to the edited entity record */
+	edits: Partial< RecordType >;
+
 	/** Apply local (in-browser) edits to the edited entity record */
 	edit: ( diff: Partial< RecordType > ) => void;
 
@@ -163,7 +166,7 @@ export default function useEntityRecord< RecordType >(
 		[ editEntityRecord, kind, name, recordId, saveEditedEntityRecord ]
 	);
 
-	const { editedRecord, hasEdits } = useSelect(
+	const { editedRecord, hasEdits, edits } = useSelect(
 		( select ) => ( {
 			editedRecord: select( coreStore ).getEditedEntityRecord(
 				kind,
@@ -171,6 +174,11 @@ export default function useEntityRecord< RecordType >(
 				recordId
 			),
 			hasEdits: select( coreStore ).hasEditsForEntityRecord(
+				kind,
+				name,
+				recordId
+			),
+			edits: select( coreStore ).getEntityRecordNonTransientEdits(
 				kind,
 				name,
 				recordId
@@ -195,6 +203,7 @@ export default function useEntityRecord< RecordType >(
 		record,
 		editedRecord,
 		hasEdits,
+		edits,
 		...querySelectRest,
 		...mutations,
 	};


### PR DESCRIPTION
## What?
Get the edits from an entity record using the `useEntityRecord` hook.

## Why?
Currently, we can know if the entity has edits or not. With this change, we are getting the edits from the entity.

## How?
By returning a `edits` key in the output of the `useEntityRecord` hook containing the nonTransientEdits of an entity record.

## Testing Instructions
```
const widget = useEntityRecord( 'root', 'widget', 1 );
widget.edit( { hello: 'foo' } );

```

Expected result:
```
{
    edits:  { hello: 'foo' }
    ...
}
