### PR TITLE
Backport tools: filter PRs to be cherry picked by merged date 

### DIFF
--- a/bin/cherry-pick.mjs
+++ b/bin/cherry-pick.mjs
@@ -118,19 +118,10 @@ async function fetchPRs() {
 		id,
 		number,
 		title,
-		closed_at,
 		pull_request,
-	} ) ).sort( ( a, b ) => {
-		/*
-		 * `closed_at` and `pull_request.merged_at` are _usually_ the same,
-		 * but let's prefer the latter if it's available.
-		 */
-		if ( a?.pull_request?.merged_at && b?.pull_request?.merged_at ) {
-			return new Date(  a?.pull_request?.merged_at ) - new Date( b?.pull_request?.merged_at );
-		}
-		return new Date( a.closed_at ) - new Date( b.closed_at );
-	} );
-
+	} ) )
+		.filter( ( { pull_request } ) => !! pull_request?.merged_at )
+		.sort( ( a, b ) => new Date(  a?.pull_request?.merged_at ) - new Date( b?.pull_request?.merged_at ) );
 
 	console.log( 'Found the following PRs to cherry-pick (sorted by closed date in ascending order): ' );
 	PRs.forEach( ( { number, title } ) =>


### PR DESCRIPTION
## What?
A follow up to:

- https://github.com/WordPress/gutenberg/pull/52667

This PR removes the `closed_at` fallback when remapping fetched PRs. 

## Why?
We only want merged PRs so we filter then use by `merged_at`.

`closed_at` might catch closed PRs that have not been merged.

## Testing Instructions

As in https://github.com/WordPress/gutenberg/pull/52667 you can test against any set of Gutenberg PR labels on a test branch by running `npm run other:cherry-pick "LABEL_NAME"`

`npm run other:cherry-pick` alone will run against the "[Backport to WP Beta/RC](https://api.github.com/search/issues?q=is:pr%20state:closed%20sort:updated%20label:%22Backport%20to%20WP%20Beta/RC%22%20repo:WordPress/gutenberg)" label.
