### PR TITLE
Top Toolbar: Prevent the focus outline of the button from being cut off

### DIFF
--- a/packages/block-editor/src/components/block-tools/block-contextual-toolbar.js
+++ b/packages/block-editor/src/components/block-tools/block-contextual-toolbar.js
@@ -132,7 +132,7 @@ function BlockContextualToolbar( { focusOnMount, isFixed, ...props } ) {
 
 		const marginLeft = parseFloat( computedToolbarStyle.marginLeft );
 		const pinnedItemsWidth = computedPinnedItemsStyle
-			? parseFloat( computedPinnedItemsStyle.width ) + 10 // 10 is the pinned items padding
+			? parseFloat( computedPinnedItemsStyle.width )
 			: 0;
 		const leftHeaderWidth = computedLeftHeaderStyle
 			? parseFloat( computedLeftHeaderStyle.width )
@@ -143,6 +143,7 @@ function BlockContextualToolbar( { focusOnMount, isFixed, ...props } ) {
 			leftHeaderWidth +
 			pinnedItemsWidth +
 			marginLeft +
+			( pinnedItems || leftHeader ? 2 : 0 ) + // Prevents button focus border from being cut off
 			( isFullscreen ? 0 : 160 ) // the width of the admin sidebar expanded
 		}px)`;
 	}, [

--- a/packages/edit-post/src/style.scss
+++ b/packages/edit-post/src/style.scss
@@ -93,15 +93,6 @@ body.js.block-editor-page {
 
 @include wordpress-admin-schemes();
 
-.interface-interface-skeleton__header .edit-post-header {
-	@supports (scrollbar-gutter: stable) {
-		// The scrollbar-gutter property ensures space is reserved for the scrollbar to appear,
-		// when scrollbars are set to be always visible. This ensure icons stay visually aligned.
-		scrollbar-gutter: stable;
-		overflow: hidden;
-	}
-}
-
 // The edit-site package adds or removes the sidebar when it's opened or closed.
 // The edit-post package, however, always has the sidebar in the canvas.
 // These edit-post specific rules ensures there isn't a border on the right of


### PR DESCRIPTION
## What?
This PR prevents the focus outline of the device preview button from cutting off when the top toolbar is enabled.

### Site Editor

#### Before

![site-editor-before](https://github.com/WordPress/gutenberg/assets/54422211/5934072a-d095-43d3-a8d2-fe65d9edb10a)

#### After

![site-editor-after](https://github.com/WordPress/gutenberg/assets/54422211/afbf8d88-8a25-4a09-8917-15c2f26c75b4)

### Post Editor

#### Before

![post-editor-before](https://github.com/WordPress/gutenberg/assets/54422211/e28b1960-da31-4a0e-89a4-eb77ab9fc65b)

#### After

![post-editor-after](https://github.com/WordPress/gutenberg/assets/54422211/399ad873-508b-4f68-945a-ca8250249186)

## Why?

### Site Editor

The fixed toolbar dynamically has its own width, minus the total width of the other UI in the header, margins, etc. However, when the first button (device preview button) in the right header is focused, the outline has a width of 2px, so it is hidden under the top toolbar.

### Post Editor

The Post Editor is a little more complicated. In #47177, the sidebar now always has the scrollbar to prevent sidebar UI shifting. At the same time, `scrollbar-gutter: stable;` was added to align the header icons with the sidebar. This will push the right-hand header to the left by the width of the scrollbar. As a result, even if the top toolbar has the correct width, it will overlap by the width of this scrollbar.

## How?

### Site Editor

When calculating the fixed toolbar width, I took the outline into account and subtracted 2px.

### Post Editor

Removed `scrollbar-gutter:stable` from the right header. This causes problems in Windows OS and Mac OS (where scrollbars are always set to appear), where the scrollbar has a physical width that prevents the header and sidebar icons from aligning.

However, this approach also has the effect of removing unnecessary spacing on the right side of the header when the sidebar is not displayed.

So far I haven't found an approach that would ideally solve everything, so if anyone has any ideas, I'd love to hear them.

## Testing Instructions

- Enable top toolbar.
- Select a block.
- Focus the device preview button.
- Make sure the outline is not cut off.
- Check in both the Post Editor and the Site Editor.

Note: I've noticed an issue with the widget editor where the top toolbar obscures the header on the right. I would like to address this issue in another PR.

![widget-editor](https://github.com/WordPress/gutenberg/assets/54422211/eb862f00-61ba-46b1-b8d1-030d1e0ff129)
