### PR TITLE
Template parts: use the template actions component for template parts patterns

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen-pattern/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-pattern/index.js
@@ -16,11 +16,14 @@ import useInitEditedEntityFromURL from '../sync-state-with-url/use-init-edited-e
 import usePatternDetails from './use-pattern-details';
 import { store as editSiteStore } from '../../store';
 import { unlock } from '../../lock-unlock';
+import TemplateActions from '../template-actions';
 
 export default function SidebarNavigationScreenPattern() {
-	const { params } = useNavigator();
+	const navigator = useNavigator();
+	const {
+		params: { postType, postId },
+	} = navigator;
 	const { categoryType } = getQueryArgs( window.location.href );
-	const { postType, postId } = params;
 	const { setCanvasMode } = unlock( useDispatch( editSiteStore ) );
 
 	useInitEditedEntityFromURL();
@@ -38,11 +41,21 @@ export default function SidebarNavigationScreenPattern() {
 	return (
 		<SidebarNavigationScreen
 			actions={
-				<SidebarButton
-					onClick={ () => setCanvasMode( 'edit' ) }
-					label={ __( 'Edit' ) }
-					icon={ pencil }
-				/>
+				<>
+					<TemplateActions
+						postType={ postType }
+						postId={ postId }
+						toggleProps={ { as: SidebarButton } }
+						onRemove={ () => {
+							navigator.goTo( `/${ postType }/all` );
+						} }
+					/>
+					<SidebarButton
+						onClick={ () => setCanvasMode( 'edit' ) }
+						label={ __( 'Edit' ) }
+						icon={ pencil }
+					/>
+				</>
 			}
 			backPath={ backPath }
 			{ ...patternDetails }

--- a/packages/edit-site/src/components/sidebar-navigation-screen-pattern/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-pattern/index.js
@@ -47,7 +47,7 @@ export default function SidebarNavigationScreenPattern() {
 						postId={ postId }
 						toggleProps={ { as: SidebarButton } }
 						onRemove={ () => {
-							navigator.goTo( `/${ postType }/all` );
+							navigator.goTo( backPath );
 						} }
 					/>
 					<SidebarButton

--- a/packages/edit-site/src/components/template-actions/index.js
+++ b/packages/edit-site/src/components/template-actions/index.js
@@ -97,7 +97,7 @@ export default function TemplateActions( {
 									onRemove?.();
 									onClose();
 								} }
-								isTemplate={ template.type === 'wp_template' }
+								title={ template.title.rendered }
 							/>
 						</>
 					) }
@@ -120,7 +120,7 @@ export default function TemplateActions( {
 	);
 }
 
-function DeleteMenuItem( { onRemove, isTemplate } ) {
+function DeleteMenuItem( { onRemove, title } ) {
 	const [ isModalOpen, setIsModalOpen ] = useState( false );
 	return (
 		<>
@@ -133,11 +133,11 @@ function DeleteMenuItem( { onRemove, isTemplate } ) {
 				onCancel={ () => setIsModalOpen( false ) }
 				confirmButtonText={ __( 'Delete' ) }
 			>
-				{ isTemplate
-					? __( 'Are you sure you want to delete this template?' )
-					: __(
-							'Are you sure you want to delete this template part?'
-					  ) }
+				{ sprintf(
+					// translators: %s: The template or template part's title.
+					__( 'Are you sure you want to delete "%s"?' ),
+					decodeEntities( title )
+				) }
 			</ConfirmDialog>
 		</>
 	);


### PR DESCRIPTION
Maybe resolves https://github.com/WordPress/gutenberg/issues/54146 not sure

## What?
Adds template actions to custom and theme template parts. It goes a bit further than  https://github.com/WordPress/gutenberg/issues/54146 requires as it also allows renaming and deleting custom template parts.


### TODO

- [x] Check whether the UI messaging needs to be changed from "template part" to pattern, e.g., when deleting

## How?
Using the existing `<TemplateActions />` component used in [/packages/edit-site/src/components/sidebar-navigation-screen-template/index.js](https://github.com/WordPress/gutenberg/blob/eb64bf8e99ef9f4e4f60ef62906bbe476ce0c034/packages/edit-site/src/components/sidebar-navigation-screen-template/index.js)

## Testing Instructions
In a block theme, make some changes to a theme template part (header or footer). Also create a new custom template part.

The same actions available to templates should be present:

<img width="553" alt="Screenshot 2023-09-05 at 3 00 40 pm" src="https://github.com/WordPress/gutenberg/assets/6458278/3a8b4363-5493-44a1-ab56-6fd4cc0565be">

<img width="513" alt="Screenshot 2023-09-05 at 3 01 03 pm" src="https://github.com/WordPress/gutenberg/assets/6458278/510e58ca-4702-45a7-b0a9-e88a985ed187">

When deleting custom template parts, ensure the confirmation dialogues match the entity type ("template type"). This also affects deleting in the table list view (`/wp-admin/site-editor.php?path=%2Fwp_template%2Fall`). 

<img width="667" alt="Screenshot 2023-09-06 at 12 41 27 pm" src="https://github.com/WordPress/gutenberg/assets/6458278/5fa9b6bd-89e2-4e34-a505-b4b9083ae987">


These actions should not be available for patterns that are not template parts.

