### PR TITLE
Make the Back link extensible on theme previews

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen/index.js
@@ -41,10 +41,12 @@ export default function SidebarNavigationScreen( {
 	description,
 	backPath: backPathProp,
 } ) {
-	const { dashboardLink } = useSelect( ( select ) => {
+	const { dashboardLink, themePreviewBackLink } = useSelect( ( select ) => {
 		const { getSettings } = unlock( select( editSiteStore ) );
 		return {
 			dashboardLink: getSettings().__experimentalDashboardLink,
+			themePreviewBackLink:
+				getSettings().__experimentalThemePreviewBackLink,
 		};
 	}, [] );
 	const { getTheme } = useSelect( coreStore );
@@ -99,7 +101,7 @@ export default function SidebarNavigationScreen( {
 							href={
 								! isPreviewingTheme()
 									? dashboardLink || 'index.php'
-									: 'themes.php'
+									: themePreviewBackLink || 'themes.php'
 							}
 						/>
 					) }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This PR makes the Back link on Block Theme Previews extensible with the settings store.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Sometimes, 3rd party apps want to extend the Back link, as going back to `/themes.php` does not always make sense. c.f. https://github.com/Automattic/wp-calypso/issues/80595

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Added `__experimentalThemePreviewBackLink` to the settings store same as `__experimentalDashboardLink`.
I did not use `dashboardLink` here because a user does not go back to the "dashboard" in the theme previews flow.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

It's rather a test to ensure existing functionality. 

- Go to `/themes.php`
- Click the Live Preview button on the Block theme
- Verify the Back link works as before

## Screenshots or screencast <!-- if applicable -->

<img width="340" alt="Screen Shot 2023-09-05 at 15 07 46" src="https://github.com/WordPress/gutenberg/assets/5287479/8fc45351-d3c2-4e56-8a2f-d8a7ef722287">
