### PR TITLE
List View: Try directing focus to the list view toggle button when closing the list view

### DIFF
--- a/packages/edit-post/src/components/header/header-toolbar/index.js
+++ b/packages/edit-post/src/components/header/header-toolbar/index.js
@@ -33,7 +33,7 @@ const preventDefault = ( event ) => {
 	event.preventDefault();
 };
 
-function HeaderToolbar() {
+function HeaderToolbar( { setListViewToggleElement } ) {
 	const inserterButton = useRef();
 	const { setIsInserterOpened, setIsListViewOpened } =
 		useDispatch( editPostStore );
@@ -108,6 +108,7 @@ function HeaderToolbar() {
 				showTooltip={ ! showIconLabels }
 				variant={ showIconLabels ? 'tertiary' : undefined }
 				aria-expanded={ isListViewOpen }
+				ref={ setListViewToggleElement }
 			/>
 		</>
 	);

--- a/packages/edit-post/src/components/header/index.js
+++ b/packages/edit-post/src/components/header/index.js
@@ -32,7 +32,10 @@ const slideX = {
 	hover: { x: 0, transition: { type: 'tween', delay: 0.2 } },
 };
 
-function Header( { setEntitiesSavedStatesCallback } ) {
+function Header( {
+	setEntitiesSavedStatesCallback,
+	setListViewToggleElement,
+} ) {
 	const isLargeViewport = useViewportMatch( 'large' );
 	const { hasActiveMetaboxes, isPublishSidebarOpened, showIconLabels } =
 		useSelect(
@@ -61,7 +64,9 @@ function Header( { setEntitiesSavedStatesCallback } ) {
 				transition={ { type: 'tween', delay: 0.8 } }
 				className="edit-post-header__toolbar"
 			>
-				<HeaderToolbar />
+				<HeaderToolbar
+					setListViewToggleElement={ setListViewToggleElement }
+				/>
 				<div className="edit-post-header__center">
 					<DocumentActions />
 				</div>

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -210,6 +210,10 @@ function Layout() {
 	// Note 'truthy' callback implies an open panel.
 	const [ entitiesSavedStatesCallback, setEntitiesSavedStatesCallback ] =
 		useState( false );
+
+	const [ listViewToggleElement, setListViewToggleElement ] =
+		useState( null );
+
 	const closeEntitiesSavedStates = useCallback(
 		( arg ) => {
 			if ( typeof entitiesSavedStatesCallback === 'function' ) {
@@ -244,7 +248,11 @@ function Layout() {
 			return <InserterSidebar />;
 		}
 		if ( mode === 'visual' && isListViewOpened ) {
-			return <ListViewSidebar />;
+			return (
+				<ListViewSidebar
+					listViewToggleElement={ listViewToggleElement }
+				/>
+			);
 		}
 
 		return null;
@@ -285,6 +293,7 @@ function Layout() {
 						setEntitiesSavedStatesCallback={
 							setEntitiesSavedStatesCallback
 						}
+						setListViewToggleElement={ setListViewToggleElement }
 					/>
 				}
 				editorNotices={ <EditorNotices /> }

--- a/packages/edit-post/src/components/secondary-sidebar/list-view-sidebar.js
+++ b/packages/edit-post/src/components/secondary-sidebar/list-view-sidebar.js
@@ -22,7 +22,7 @@ import { ESCAPE } from '@wordpress/keycodes';
 import { store as editPostStore } from '../../store';
 import ListViewOutline from './list-view-outline';
 
-export default function ListViewSidebar() {
+export default function ListViewSidebar( { listViewToggleElement } ) {
 	const { setIsListViewOpened } = useDispatch( editPostStore );
 
 	// This hook handles focus when the sidebar first renders.
@@ -35,6 +35,9 @@ export default function ListViewSidebar() {
 		if ( event.keyCode === ESCAPE && ! event.defaultPrevented ) {
 			event.preventDefault();
 			setIsListViewOpened( false );
+
+			// TODO: Only set the focus here if no blocks are selected.
+			listViewToggleElement?.focus();
 		}
 	}
 
@@ -96,8 +99,9 @@ export default function ListViewSidebar() {
 			)
 		) {
 			setIsListViewOpened( false );
-			// If the list view or outline does not have focus, focus should be moved to it.
+			// TODO: Should we set focus here on the list view button toggle, too?
 		} else {
+			// If the list view or outline does not have focus, focus should be moved to it.
 			handleSidebarFocus( tab );
 		}
 	} );

--- a/packages/edit-post/src/components/secondary-sidebar/list-view-sidebar.js
+++ b/packages/edit-post/src/components/secondary-sidebar/list-view-sidebar.js
@@ -101,8 +101,7 @@ export default function ListViewSidebar( { listViewToggleElement } ) {
 		}
 	}
 
-	// This only fires when the sidebar is open because of the conditional rendering. It is the same shortcut to open but that is defined as a global shortcut and only fires when the sidebar is closed.
-	useShortcut( 'core/edit-post/toggle-list-view', () => {
+	const handleToggleListViewShortcut = useCallback( () => {
 		// If the sidebar has focus, it is safe to close.
 		if (
 			sidebarRef.current.contains(
@@ -110,12 +109,21 @@ export default function ListViewSidebar( { listViewToggleElement } ) {
 			)
 		) {
 			setIsListViewOpened( false );
-			// TODO: Should we set focus here on the list view button toggle, too?
+			if ( ! hasBlocksSelected ) {
+				listViewToggleElement?.focus();
+			}
 		} else {
 			// If the list view or outline does not have focus, focus should be moved to it.
 			handleSidebarFocus( tab );
 		}
-	} );
+	}, [ hasBlocksSelected, listViewToggleElement, setIsListViewOpened, tab ] );
+
+	// This only fires when the sidebar is open because of the conditional rendering.
+	// It is the same shortcut to open but that is defined as a global shortcut and only fires when the sidebar is closed.
+	useShortcut(
+		'core/edit-post/toggle-list-view',
+		handleToggleListViewShortcut
+	);
 
 	/**
 	 * Render tab content for a given tab name.

--- a/packages/edit-post/src/components/secondary-sidebar/list-view-sidebar.js
+++ b/packages/edit-post/src/components/secondary-sidebar/list-view-sidebar.js
@@ -109,6 +109,8 @@ export default function ListViewSidebar( { listViewToggleElement } ) {
 			)
 		) {
 			setIsListViewOpened( false );
+			// When no block is selected and the sidebar is closed,
+			// focus should be returned to the list view toggle button.
 			if ( ! hasBlocksSelected ) {
 				listViewToggleElement?.focus();
 			}

--- a/packages/edit-post/src/components/secondary-sidebar/list-view-sidebar.js
+++ b/packages/edit-post/src/components/secondary-sidebar/list-view-sidebar.js
@@ -1,17 +1,10 @@
 /**
  * WordPress dependencies
  */
-import {
-	__experimentalListView as ListView,
-	store as blockEditorStore,
-} from '@wordpress/block-editor';
+import { __experimentalListView as ListView } from '@wordpress/block-editor';
 import { Button, TabPanel } from '@wordpress/components';
-import {
-	useFocusOnMount,
-	useFocusReturn,
-	useMergeRefs,
-} from '@wordpress/compose';
-import { useSelect, useDispatch } from '@wordpress/data';
+import { useFocusOnMount, useMergeRefs } from '@wordpress/compose';
+import { useDispatch } from '@wordpress/data';
 import { focus } from '@wordpress/dom';
 import { useCallback, useRef, useState } from '@wordpress/element';
 import { __, _x } from '@wordpress/i18n';
@@ -26,30 +19,25 @@ import { store as editPostStore } from '../../store';
 import ListViewOutline from './list-view-outline';
 
 export default function ListViewSidebar( { listViewToggleElement } ) {
-	const hasBlocksSelected = useSelect(
-		( select ) => !! select( blockEditorStore ).getBlockSelectionStart(),
-		[]
-	);
 	const { setIsListViewOpened } = useDispatch( editPostStore );
 
 	// This hook handles focus when the sidebar first renders.
 	const focusOnMountRef = useFocusOnMount( 'firstElement' );
-	// The next 2 hooks handle focus for when the sidebar closes and returning focus to the element that had focus before sidebar opened.
-	const headerFocusReturnRef = useFocusReturn();
-	const contentFocusReturnRef = useFocusReturn();
+
+	// When closing the list view, focus should return to the toggle button.
+	const closeListView = useCallback( () => {
+		setIsListViewOpened( false );
+		listViewToggleElement?.focus();
+	}, [ listViewToggleElement, setIsListViewOpened ] );
 
 	const closeOnEscape = useCallback(
 		( event ) => {
 			if ( event.keyCode === ESCAPE && ! event.defaultPrevented ) {
 				event.preventDefault();
-				setIsListViewOpened( false );
-
-				if ( ! hasBlocksSelected ) {
-					listViewToggleElement?.focus();
-				}
+				closeListView();
 			}
 		},
-		[ hasBlocksSelected, listViewToggleElement, setIsListViewOpened ]
+		[ closeListView ]
 	);
 
 	// Use internal state instead of a ref to make sure that the component
@@ -67,7 +55,6 @@ export default function ListViewSidebar( { listViewToggleElement } ) {
 
 	// Must merge the refs together so focus can be handled properly in the next function.
 	const listViewContainerRef = useMergeRefs( [
-		contentFocusReturnRef,
 		focusOnMountRef,
 		listViewRef,
 		setDropZoneElement,
@@ -108,17 +95,12 @@ export default function ListViewSidebar( { listViewToggleElement } ) {
 				sidebarRef.current.ownerDocument.activeElement
 			)
 		) {
-			setIsListViewOpened( false );
-			// When no block is selected and the sidebar is closed,
-			// focus should be returned to the list view toggle button.
-			if ( ! hasBlocksSelected ) {
-				listViewToggleElement?.focus();
-			}
+			closeListView();
 		} else {
 			// If the list view or outline does not have focus, focus should be moved to it.
 			handleSidebarFocus( tab );
 		}
-	}, [ hasBlocksSelected, listViewToggleElement, setIsListViewOpened, tab ] );
+	}, [ closeListView, tab ] );
 
 	// This only fires when the sidebar is open because of the conditional rendering.
 	// It is the same shortcut to open but that is defined as a global shortcut and only fires when the sidebar is closed.
@@ -152,10 +134,9 @@ export default function ListViewSidebar( { listViewToggleElement } ) {
 		>
 			<Button
 				className="edit-post-editor__document-overview-panel__close-button"
-				ref={ headerFocusReturnRef }
 				icon={ closeSmall }
 				label={ __( 'Close' ) }
-				onClick={ () => setIsListViewOpened( false ) }
+				onClick={ closeListView }
 			/>
 			<TabPanel
 				className="edit-post-editor__document-overview-panel__tab-panel"

--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -71,7 +71,7 @@ const blockRemovalRules = {
 	),
 };
 
-export default function Editor( { isLoading } ) {
+export default function Editor( { listViewToggleElement, isLoading } ) {
 	const {
 		record: editedPost,
 		getTitle,
@@ -247,7 +247,11 @@ export default function Editor( { isLoading } ) {
 									<InserterSidebar />
 								) ) ||
 									( shouldShowListView && (
-										<ListViewSidebar />
+										<ListViewSidebar
+											listViewToggleElement={
+												listViewToggleElement
+											}
+										/>
 									) ) )
 							}
 							sidebar={

--- a/packages/edit-site/src/components/header-edit-mode/index.js
+++ b/packages/edit-site/src/components/header-edit-mode/index.js
@@ -53,7 +53,7 @@ const preventDefault = ( event ) => {
 	event.preventDefault();
 };
 
-export default function HeaderEditMode() {
+export default function HeaderEditMode( { setListViewToggleElement } ) {
 	const inserterButton = useRef();
 	const {
 		deviceType,
@@ -259,6 +259,7 @@ export default function HeaderEditMode() {
 										/* translators: button label text should, if possible, be under 16 characters. */
 										label={ __( 'List View' ) }
 										onClick={ toggleListView }
+										ref={ setListViewToggleElement }
 										shortcut={ listViewShortcut }
 										showTooltip={ ! showIconLabels }
 										variant={

--- a/packages/edit-site/src/components/layout/index.js
+++ b/packages/edit-site/src/components/layout/index.js
@@ -127,6 +127,8 @@ export default function Layout() {
 	const isEditorLoading = useIsSiteEditorLoading();
 	const [ isResizableFrameOversized, setIsResizableFrameOversized ] =
 		useState( false );
+	const [ listViewToggleElement, setListViewToggleElement ] =
+		useState( null );
 
 	// This determines which animation variant should apply to the header.
 	// There is also a `isDistractionFreeHovering` state that gets priority
@@ -256,7 +258,11 @@ export default function Layout() {
 									ease: 'easeOut',
 								} }
 							>
-								<Header />
+								<Header
+									setListViewToggleElement={
+										setListViewToggleElement
+									}
+								/>
 							</NavigableRegion>
 						) }
 					</AnimatePresence>
@@ -369,6 +375,9 @@ export default function Layout() {
 													} }
 												>
 													<Editor
+														listViewToggleElement={
+															listViewToggleElement
+														}
 														isLoading={
 															isEditorLoading
 														}

--- a/packages/edit-widgets/src/components/header/index.js
+++ b/packages/edit-widgets/src/components/header/index.js
@@ -27,7 +27,7 @@ import { unlock } from '../../lock-unlock';
 
 const { useShouldContextualToolbarShow } = unlock( blockEditorPrivateApis );
 
-function Header() {
+function Header( { setListViewToggleElement } ) {
 	const isMediumViewport = useViewportMatch( 'medium' );
 	const inserterButton = useRef();
 	const widgetAreaClientId = useLastSelectedWidgetArea();
@@ -140,6 +140,7 @@ function Header() {
 									/* translators: button label text should, if possible, be under 16 characters. */
 									label={ __( 'List View' ) }
 									onClick={ toggleListView }
+									ref={ setListViewToggleElement }
 								/>
 							</>
 						) }

--- a/packages/edit-widgets/src/components/layout/interface.js
+++ b/packages/edit-widgets/src/components/layout/interface.js
@@ -3,7 +3,7 @@
  */
 import { useViewportMatch } from '@wordpress/compose';
 import { BlockBreadcrumb } from '@wordpress/block-editor';
-import { useEffect } from '@wordpress/element';
+import { useEffect, useState } from '@wordpress/element';
 import { useDispatch, useSelect } from '@wordpress/data';
 import {
 	InterfaceSkeleton,
@@ -68,6 +68,9 @@ function Interface( { blockEditorSettings } ) {
 		[]
 	);
 
+	const [ listViewToggleElement, setListViewToggleElement ] =
+		useState( null );
+
 	// Inserter and Sidebars are mutually exclusive
 	useEffect( () => {
 		if ( hasSidebarEnabled && ! isHugeViewport ) {
@@ -94,8 +97,16 @@ function Interface( { blockEditorSettings } ) {
 				...interfaceLabels,
 				secondarySidebar: secondarySidebarLabel,
 			} }
-			header={ <Header /> }
-			secondarySidebar={ hasSecondarySidebar && <SecondarySidebar /> }
+			header={
+				<Header setListViewToggleElement={ setListViewToggleElement } />
+			}
+			secondarySidebar={
+				hasSecondarySidebar && (
+					<SecondarySidebar
+						listViewToggleElement={ listViewToggleElement }
+					/>
+				)
+			}
 			sidebar={
 				hasSidebarEnabled && (
 					<ComplementaryArea.Slot scope="core/edit-widgets" />

--- a/packages/edit-widgets/src/components/secondary-sidebar/index.js
+++ b/packages/edit-widgets/src/components/secondary-sidebar/index.js
@@ -13,7 +13,7 @@ import { store as editWidgetsStore } from '../../store';
 import InserterSidebar from './inserter-sidebar';
 import ListViewSidebar from './list-view-sidebar';
 
-export default function SecondarySidebar() {
+export default function SecondarySidebar( { listViewToggleElement } ) {
 	const { isInserterOpen, isListViewOpen } = useSelect( ( select ) => {
 		const { isInserterOpened, isListViewOpened } =
 			select( editWidgetsStore );
@@ -27,7 +27,9 @@ export default function SecondarySidebar() {
 		return <InserterSidebar />;
 	}
 	if ( isListViewOpen ) {
-		return <ListViewSidebar />;
+		return (
+			<ListViewSidebar listViewToggleElement={ listViewToggleElement } />
+		);
 	}
 	return null;
 }

--- a/test/e2e/specs/editor/various/list-view.spec.js
+++ b/test/e2e/specs/editor/various/list-view.spec.js
@@ -322,12 +322,9 @@ test.describe( 'List View', () => {
 		// the sidebar.
 		await pageUtils.pressKeys( 'access+o' );
 
-		// Focus should now be on the paragraph block since that is
-		// where we opened the list view sidebar. This is not a perfect
-		// solution, but current functionality prevents a better way at
-		// the moment.
+		// Focus should now be on the list view toggle button.
 		await expect(
-			editor.canvas.getByRole( 'document', { name: 'Paragraph block' } )
+			page.getByRole( 'button', { name: 'Document Overview' } )
 		).toBeFocused();
 
 		// List View should be closed.

--- a/test/e2e/specs/site-editor/list-view.spec.js
+++ b/test/e2e/specs/site-editor/list-view.spec.js
@@ -107,11 +107,10 @@ test.describe( 'Site Editor List View', () => {
 		await pageUtils.pressKeys( 'access+o' );
 		await expect( listView ).not.toBeVisible();
 
-		// Focus should now be on the Open Navigation button since that is
-		// where we opened the list view sidebar. This is not a perfect
-		// solution, but current functionality prevents a better way at
-		// the moment.
-		await expect( openNavigationButton ).toBeFocused();
+		// Focus should now be on the list view toggle button.
+		await expect(
+			page.getByRole( 'button', { name: 'List View' } )
+		).toBeFocused();
 
 		// Open List View.
 		await pageUtils.pressKeys( 'access+o' );
@@ -131,6 +130,8 @@ test.describe( 'Site Editor List View', () => {
 		).toBeFocused();
 		await pageUtils.pressKeys( 'access+o' );
 		await expect( listView ).not.toBeVisible();
-		await expect( openNavigationButton ).toBeFocused();
+		await expect(
+			page.getByRole( 'button', { name: 'List View' } )
+		).toBeFocused();
 	} );
 } );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This is an exploration into https://github.com/WordPress/gutenberg/issues/54165 to see if we can manually direct focus to the list view toggle button when the list view is closed.

For reference, the keyboard shortcut for closing the list view is alt+shift+o on Windows, and control+option+o on Mac.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

As raised in #54165, it is confusing for the user that sometimes when closing the list view, focus is lost completely. This happens most often when the list view was opened via the keyboard shortcut and is then closed after blocks have been deselected. There could be circumstances that exist not covered by this PR, but the hope is that this PR will improve things when closing the list view.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Try using state in editor's layout, and pass down a setter to the heading in order to set a ref for the toggle button. Then, pass down the state that's keeping track of the toggle button element to the list view sidebar.

This requires a bit of prop drilling, as well as duplication between the editors. Because the editors are fairly different, I couldn't quite think of a better way to do it. I'm very happy to try out ideas if folks have ideas for a better way to do this!

Note: this PR previously only shifted focus if no blocks are selected. Based on discussion in the PR comments, I've since updated it to always shift focus when the list view is closed, to hopefully achieve more consistency.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Open the post editor and add at least one block. With the block selected in the canvas, open the list view.
2. Press the Escape key once to deselect blocks.
3. Press the Escape key again to close the list view. The focus should now be on the list view button in the header.
4. Select a block in the canvas and open the list view via the keyboard shortcut (alt+shift+o on Windows, and control+option+o on Mac)
5. Press the Escape key once to deselect blocks.
6. Use the keyboard shortcut to close the list view again. Focus should now be on the list view button in the header.
7. Repeat the above in the site editor.

Note: if closing the list view via the keyboard shortcut while blocks are still selected, then the list view should close and focus won't be explicitly moved to the list view toggle button (but it might go there anywhere depending on other logic already in place).

## Screenshots or screencast <!-- if applicable -->

The below screengrab demos selecting a block in the list view and using the escape key to deselect and then close the list view, with focus ending up on the list view toggle button. Then, the list view is opened using the keyboard shortcut, with the blocks deselected using the escape key, and then finally the list view is closed via the keyboard shortcut again, with focus ending up on the list view toggle button.

https://github.com/WordPress/gutenberg/assets/14988353/cd7af143-458e-42f8-abb4-de2d278a609e