### PR TITLE
Popover: set is-positioned class only after animation has finished

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -8,7 +8,8 @@
 
 ### Enhancements
 
--   Making Circular Option Picker a `listbox`. Note that while this changes some public API, new props are optional, and currently have default values; this will change in another patch. ([#52255](https://github.com/WordPress/gutenberg/pull/52255))
+-   Making Circular Option Picker a `listbox`. Note that while this changes some public API, new props are optional, and currently have default values; this will change in another patch ([#52255](https://github.com/WordPress/gutenberg/pull/52255)).
+-   `Popover`: Add the `is-positioned` CSS class only after the popover has finished animating ([54178](https://github.com/WordPress/gutenberg/pull/54178)).
 
 ### Bug Fix
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -6,10 +6,10 @@
 
 -   Make the `Popover.Slot` optional and render popovers at the bottom of the document's body by default. ([#53889](https://github.com/WordPress/gutenberg/pull/53889), [#53982](https://github.com/WordPress/gutenberg/pull/53982)).
 
-### Enhancements
+### Enhancements
 
 -   Making Circular Option Picker a `listbox`. Note that while this changes some public API, new props are optional, and currently have default values; this will change in another patch ([#52255](https://github.com/WordPress/gutenberg/pull/52255)).
--   `Popover`: Add the `is-positioned` CSS class only after the popover has finished animating ([54178](https://github.com/WordPress/gutenberg/pull/54178)).
+-   `Popover`: Add the `is-positioned` CSS class only after the popover has finished animating ([#54178](https://github.com/WordPress/gutenberg/pull/54178)).
 
 ### Bug Fix
 

--- a/packages/components/src/popover/index.tsx
+++ b/packages/components/src/popover/index.tsx
@@ -399,6 +399,8 @@ const UnforwardedPopover = (
 	const shouldReduceMotion = useReducedMotion();
 	const shouldAnimate = animate && ! isExpanded && ! shouldReduceMotion;
 
+	const [ animationFinished, setAnimationFinished ] = useState( false );
+
 	const { style: motionInlineStyles, ...otherMotionProps } = useMemo(
 		() => placementToMotionAnimationProps( computedPlacement ),
 		[ computedPlacement ]
@@ -410,6 +412,7 @@ const UnforwardedPopover = (
 					...motionInlineStyles,
 					...style,
 				},
+				onAnimationComplete: () => setAnimationFinished( true ),
 				...otherMotionProps,
 		  }
 		: {
@@ -417,16 +420,16 @@ const UnforwardedPopover = (
 				style,
 		  };
 
-	// Disable reason: We care to capture the _bubbled_ events from inputs
-	// within popover as inferring close intent.
+	// When Floating UI has finished positioning and Framer Motion has finished animating
+	// the popover, add the `is-positioned` class to signal that all transitions have finished.
+	const isPositioned =
+		( ! shouldAnimate || animationFinished ) && x !== null && y !== null;
 
 	let content = (
-		// eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions
-		// eslint-disable-next-line jsx-a11y/no-static-element-interactions
 		<motion.div
 			className={ classnames( 'components-popover', className, {
 				'is-expanded': isExpanded,
-				'is-positioned': x !== null && y !== null,
+				'is-positioned': isPositioned,
 				// Use the 'alternate' classname for 'toolbar' variant for back compat.
 				[ `is-${
 					computedVariant === 'toolbar'

--- a/packages/components/src/popover/index.tsx
+++ b/packages/components/src/popover/index.tsx
@@ -58,7 +58,6 @@ import {
 import type { WordPressComponentProps } from '../ui/context';
 import type {
 	PopoverProps,
-	AnimatedWrapperProps,
 	PopoverAnchorRefReference,
 	PopoverAnchorRefTopBottom,
 } from './types';
@@ -92,47 +91,6 @@ const ArrowTriangle = () => (
 			vectorEffect="non-scaling-stroke"
 		/>
 	</SVG>
-);
-
-const AnimatedWrapper = forwardRef(
-	(
-		{
-			style: receivedInlineStyles,
-			placement,
-			shouldAnimate = false,
-			...props
-		}: HTMLMotionProps< 'div' > & AnimatedWrapperProps,
-		forwardedRef: ForwardedRef< any >
-	) => {
-		const shouldReduceMotion = useReducedMotion();
-
-		const { style: motionInlineStyles, ...otherMotionProps } = useMemo(
-			() => placementToMotionAnimationProps( placement ),
-			[ placement ]
-		);
-
-		const computedAnimationProps: HTMLMotionProps< 'div' > =
-			shouldAnimate && ! shouldReduceMotion
-				? {
-						style: {
-							...motionInlineStyles,
-							...receivedInlineStyles,
-						},
-						...otherMotionProps,
-				  }
-				: {
-						animate: false,
-						style: receivedInlineStyles,
-				  };
-
-		return (
-			<motion.div
-				{ ...computedAnimationProps }
-				{ ...props }
-				ref={ forwardedRef }
-			/>
-		);
-	}
 );
 
 const slotNameContext = createContext< string | undefined >( undefined );
@@ -423,15 +381,49 @@ const UnforwardedPopover = (
 		forwardedRef,
 	] );
 
+	const style = isExpanded
+		? undefined
+		: {
+				position: strategy,
+				top: 0,
+				left: 0,
+				// `x` and `y` are framer-motion specific props and are shorthands
+				// for `translateX` and `translateY`. Currently it is not possible
+				// to use `translateX` and `translateY` because those values would
+				// be overridden by the return value of the
+				// `placementToMotionAnimationProps` function.
+				x: computePopoverPosition( x ),
+				y: computePopoverPosition( y ),
+		  };
+
+	const shouldReduceMotion = useReducedMotion();
+	const shouldAnimate = animate && ! isExpanded && ! shouldReduceMotion;
+
+	const { style: motionInlineStyles, ...otherMotionProps } = useMemo(
+		() => placementToMotionAnimationProps( computedPlacement ),
+		[ computedPlacement ]
+	);
+
+	const animationProps: HTMLMotionProps< 'div' > = shouldAnimate
+		? {
+				style: {
+					...motionInlineStyles,
+					...style,
+				},
+				...otherMotionProps,
+		  }
+		: {
+				animate: false,
+				style,
+		  };
+
 	// Disable reason: We care to capture the _bubbled_ events from inputs
 	// within popover as inferring close intent.
 
 	let content = (
 		// eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions
 		// eslint-disable-next-line jsx-a11y/no-static-element-interactions
-		<AnimatedWrapper
-			shouldAnimate={ animate && ! isExpanded }
-			placement={ computedPlacement }
+		<motion.div
 			className={ classnames( 'components-popover', className, {
 				'is-expanded': isExpanded,
 				'is-positioned': x !== null && y !== null,
@@ -442,26 +434,11 @@ const UnforwardedPopover = (
 						: computedVariant
 				}` ]: computedVariant,
 			} ) }
+			{ ...animationProps }
 			{ ...contentProps }
 			ref={ mergedFloatingRef }
 			{ ...dialogProps }
 			tabIndex={ -1 }
-			style={
-				isExpanded
-					? undefined
-					: {
-							position: strategy,
-							top: 0,
-							left: 0,
-							// `x` and `y` are framer-motion specific props and are shorthands
-							// for `translateX` and `translateY`. Currently it is not possible
-							// to use `translateX` and `translateY` because those values would
-							// be overridden by the return value of the
-							// `placementToMotionAnimationProps` function in `AnimatedWrapper`
-							x: computePopoverPosition( x ),
-							y: computePopoverPosition( y ),
-					  }
-			}
 		>
 			{ /* Prevents scroll on the document */ }
 			{ isExpanded && <ScrollLock /> }
@@ -501,7 +478,7 @@ const UnforwardedPopover = (
 					<ArrowTriangle />
 				</div>
 			) }
-		</AnimatedWrapper>
+		</motion.div>
 	);
 
 	const shouldRenderWithinSlot = slot.ref && ! inline;

--- a/packages/components/src/popover/types.ts
+++ b/packages/components/src/popover/types.ts
@@ -14,11 +14,6 @@ type DomRectWithOwnerDocument = DOMRect & {
 
 type PopoverPlacement = Placement | 'overlay';
 
-export type AnimatedWrapperProps = {
-	placement: PopoverPlacement;
-	shouldAnimate?: boolean;
-};
-
 export type PopoverAnchorRefReference = MutableRefObject<
 	Element | null | undefined
 >;

--- a/packages/nux/src/components/dot-tip/test/__snapshots__/index.js.snap
+++ b/packages/nux/src/components/dot-tip/test/__snapshots__/index.js.snap
@@ -5,7 +5,7 @@ exports[`DotTip should render correctly 1`] = `
   aria-label="Editor tips"
   class="components-popover nux-dot-tip is-positioned"
   role="dialog"
-  style="position: absolute; top: 0px; left: 0px; opacity: 0; transform: translateX(0px) translateY(0px) translateX(-2em) scale(0) translateZ(0); transform-origin: 0% 50% 0;"
+  style="position: absolute; top: 0px; left: 0px; opacity: 1; transform: none; transform-origin: 0% 50% 0;"
   tabindex="-1"
 >
   <div


### PR DESCRIPTION
This should be the ultimate fix for the flaky popover tests (like `DotTip`) that @ramonjd has been trying to fix in #54168. The snapshot differences are caused by the fact that the popover's Framer Motion animation is still running when we are checking the snapshot, and the animated style properties like `opacity` or `translateY` have non-deterministic values.

The fix is to set the `is-positioned` CSS class on the popover element only after the animation is complete. Then the `.toBePositionedPopover` Jest helper will reliably wait for the animation to finish.

To achieve this, I first had to merge the `AnimationWrapper` component into the base `UnforwardedPopover` component. Their internals need to communicate with each other now, and the separation is no longer tenable.

After merging, it's easy to introduce a `finishedAnimation` state variable, set by the Framer Motion's `onAnimationComplete` callback, and use `finishedAnimation` as another pre-condition for `is-positioned`.

We've discussed this a year ago with @ciampo and @tyxla, but at the time merging the `AnimationWrapper` was too hard. Today, after many incremental refactorings, it's possible.

Note that the updated `DotTip` snapshot now correctly reflects the "animation complete" state: opacity is 1, i.e., element is fully visible, and there are no `translate` and `scale` transforms.