### PR TITLE
Update nofollow control label

### DIFF
--- a/packages/format-library/src/link/inline.js
+++ b/packages/format-library/src/link/inline.js
@@ -35,7 +35,7 @@ const LINK_SETTINGS = [
 	...LinkControl.DEFAULT_LINK_SETTINGS,
 	{
 		id: 'nofollow',
-		title: __( 'Mark as nofollow for search engines' ),
+		title: __( 'Mark as nofollow' ),
 	},
 ];
 

--- a/packages/format-library/src/link/inline.js
+++ b/packages/format-library/src/link/inline.js
@@ -35,10 +35,7 @@ const LINK_SETTINGS = [
 	...LinkControl.DEFAULT_LINK_SETTINGS,
 	{
 		id: 'nofollow',
-		title: createInterpolateElement(
-			__( 'Mark as <code>nofollow</code>' ),
-			{ code: <code /> }
-		),
+		title: __( 'Add no-follow for search engines' ),
 	},
 ];
 

--- a/packages/format-library/src/link/inline.js
+++ b/packages/format-library/src/link/inline.js
@@ -35,7 +35,7 @@ const LINK_SETTINGS = [
 	...LinkControl.DEFAULT_LINK_SETTINGS,
 	{
 		id: 'nofollow',
-		title: __( 'Add no-follow for search engines' ),
+		title: __( 'Mark as nofollow for search engines' ),
 	},
 ];
 

--- a/test/e2e/specs/editor/blocks/links.spec.js
+++ b/test/e2e/specs/editor/blocks/links.spec.js
@@ -265,11 +265,13 @@ test.describe( 'Links', () => {
 
 		// expect settings for `Open in new tab` and `No follow`
 		await expect( page.getByLabel( 'Open in new tab' ) ).not.toBeChecked();
-		await expect( page.getByLabel( 'nofollow' ) ).not.toBeChecked();
+		await expect(
+			page.getByLabel( 'Add no-follow for search engines' )
+		).not.toBeChecked();
 
 		// Toggle both of the settings
 		await page.getByLabel( 'Open in new tab' ).click();
-		await page.getByLabel( 'nofollow' ).click();
+		await page.getByLabel( 'Add no-follow for search engines' ).click();
 
 		// Save the link
 		await page
@@ -297,7 +299,7 @@ test.describe( 'Links', () => {
 		// Toggle both the settings to be off.
 		// Note: no need to toggle settings again because the open setting should be persisted.
 		await page.getByLabel( 'Open in new tab' ).click();
-		await page.getByLabel( 'nofollow' ).click();
+		await page.getByLabel( 'Add no-follow for search engines' ).click();
 
 		// Save the link
 		await page

--- a/test/e2e/specs/editor/blocks/links.spec.js
+++ b/test/e2e/specs/editor/blocks/links.spec.js
@@ -271,7 +271,7 @@ test.describe( 'Links', () => {
 
 		// Toggle both of the settings
 		await page.getByLabel( 'Open in new tab' ).click();
-		await page.getByLabel( 'Add no-follow for search engines' ).click();
+		await page.getByLabel( 'nofollow' ).click();
 
 		// Save the link
 		await page

--- a/test/e2e/specs/editor/blocks/links.spec.js
+++ b/test/e2e/specs/editor/blocks/links.spec.js
@@ -299,7 +299,7 @@ test.describe( 'Links', () => {
 		// Toggle both the settings to be off.
 		// Note: no need to toggle settings again because the open setting should be persisted.
 		await page.getByLabel( 'Open in new tab' ).click();
-		await page.getByLabel( 'Add no-follow for search engines' ).click();
+		await page.getByLabel( 'nofollow' ).click();
 
 		// Save the link
 		await page

--- a/test/e2e/specs/editor/blocks/links.spec.js
+++ b/test/e2e/specs/editor/blocks/links.spec.js
@@ -266,7 +266,7 @@ test.describe( 'Links', () => {
 		// expect settings for `Open in new tab` and `No follow`
 		await expect( page.getByLabel( 'Open in new tab' ) ).not.toBeChecked();
 		await expect(
-			page.getByLabel( 'Add no-follow for search engines' )
+			page.getByLabel( 'nofollow' )
 		).not.toBeChecked();
 
 		// Toggle both of the settings

--- a/test/e2e/specs/editor/blocks/links.spec.js
+++ b/test/e2e/specs/editor/blocks/links.spec.js
@@ -265,9 +265,7 @@ test.describe( 'Links', () => {
 
 		// expect settings for `Open in new tab` and `No follow`
 		await expect( page.getByLabel( 'Open in new tab' ) ).not.toBeChecked();
-		await expect(
-			page.getByLabel( 'nofollow' )
-		).not.toBeChecked();
+		await expect( page.getByLabel( 'nofollow' ) ).not.toBeChecked();
 
 		// Toggle both of the settings
 		await page.getByLabel( 'Open in new tab' ).click();


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Address issue raised on https://github.com/WordPress/gutenberg/issues/54179 cc: @getdave 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Code tags on label causing a11y issue

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Update the label of nofollow control in LinkControl 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Open Post Editor
- Add new text block
- Add a link to the text
- Edit link
- Toggle the opensInNewTab and nofollow
- Check and confirm whether the rel and target attributes have been inserted correctly


https://github.com/WordPress/gutenberg/assets/10071857/0797604f-4d06-434f-b4f9-6e22934e8c65


### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
| Before  | After  |
|---|---|
|  <img width="357" alt="image" src="https://github.com/WordPress/gutenberg/assets/10071857/18072d82-2e88-4ce6-bd03-f8d741c1ea88"> |  <img width="356" alt="image" src="https://github.com/WordPress/gutenberg/assets/10071857/83d69fa3-3bd0-4fd9-a593-9ff7898160b9"> |


