### PR TITLE
Performance: Fix first block locator's page reference

### DIFF
--- a/test/performance/specs/post-editor.spec.js
+++ b/test/performance/specs/post-editor.spec.js
@@ -92,14 +92,14 @@ test.describe( 'Post Editor Performance', () => {
 			// Get canvas (handles both legacy and iframed canvas).
 			const canvas = await Promise.any( [
 				( async () => {
-					const legacyCanvasLocator = page.locator(
+					const legacyCanvasLocator = testPage.locator(
 						'.wp-block-post-content'
 					);
 					await legacyCanvasLocator.waitFor();
 					return legacyCanvasLocator;
 				} )(),
 				( async () => {
-					const iframedCanvasLocator = page.frameLocator(
+					const iframedCanvasLocator = testPage.frameLocator(
 						'[name=editor-canvas]'
 					);
 					await iframedCanvasLocator.locator( 'body' ).waitFor();

--- a/test/performance/specs/post-editor.spec.js
+++ b/test/performance/specs/post-editor.spec.js
@@ -95,14 +95,16 @@ test.describe( 'Post Editor Performance', () => {
 					const legacyCanvasLocator = testPage.locator(
 						'.wp-block-post-content'
 					);
-					await legacyCanvasLocator.waitFor();
+					await legacyCanvasLocator.waitFor( { timeout: 120_000 } );
 					return legacyCanvasLocator;
 				} )(),
 				( async () => {
 					const iframedCanvasLocator = testPage.frameLocator(
 						'[name=editor-canvas]'
 					);
-					await iframedCanvasLocator.locator( 'body' ).waitFor();
+					await iframedCanvasLocator
+						.locator( 'body' )
+						.waitFor( { timeout: 120_000 } );
 					return iframedCanvasLocator;
 				} )(),
 			] );

--- a/test/performance/specs/site-editor.spec.js
+++ b/test/performance/specs/site-editor.spec.js
@@ -85,9 +85,7 @@ test.describe( 'Site Editor Performance', () => {
 		).toBeDisabled();
 
 		// Get the ID of the saved page.
-		testPageId = await page.evaluate( () =>
-			new URL( document.location ).searchParams.get( 'post' )
-		);
+		testPageId = new URL( page.url() ).searchParams.get( 'post' );
 
 		// Open the test page in Site Editor.
 		await admin.visitSiteEditor( {
@@ -109,17 +107,12 @@ test.describe( 'Site Editor Performance', () => {
 			// Go to the test page URL.
 			await testPage.goto( draftURL );
 
-			// Wait for the canvas to appear.
-			await testPage
-				.locator( '.edit-site-canvas-loader' )
-				.waitFor( { state: 'hidden', timeout: 60_000 } );
-
 			// Wait for the first block.
 			await testPage
 				.frameLocator( 'iframe[name="editor-canvas"]' )
 				.locator( '.wp-block' )
 				.first()
-				.waitFor( { timeout: 60_000 } );
+				.waitFor( { timeout: 120_000 } );
 
 			// Save the results.
 			if ( i >= throwaway ) {


### PR DESCRIPTION
## What?
**Bug:** Current page for locating the first block is the one in the background (`page`), not the one that is subject to the test (`testPage`). This might have been the reason for the [recently unstable loading metrics](https://github.com/WordPress/gutenberg/pull/53768#issuecomment-1703387553).

This PR fixes that + makes the Site Editor Loading test consistent with the Post Editor one + increases the timeout value for the canvas locator which fixes its recent flakiness (e.g. [this job](https://github.com/WordPress/gutenberg/actions/runs/6085203745?pr=54188)).