### PR TITLE
Annotations: run e2e tests with iframe

### DIFF
--- a/packages/e2e-tests/specs/editor/plugins/annotations.test.js
+++ b/packages/e2e-tests/specs/editor/plugins/annotations.test.js
@@ -29,13 +29,6 @@ describe( 'Annotations', () => {
 
 	beforeEach( async () => {
 		await createNewPost();
-		// To do: run with iframe.
-		await page.evaluate( () => {
-			window.wp.blocks.registerBlockType( 'test/v2', {
-				apiVersion: '2',
-				title: 'test',
-			} );
-		} );
 	} );
 
 	/**
@@ -100,7 +93,7 @@ describe( 'Annotations', () => {
 	 */
 	async function getRichTextInnerHTML() {
 		const htmlContent = await canvas().$$( '.wp-block-paragraph' );
-		return await page.evaluate( ( el ) => {
+		return await canvas().evaluate( ( el ) => {
 			return el.innerHTML;
 		}, htmlContent[ 0 ] );
 	}
@@ -126,7 +119,7 @@ describe( 'Annotations', () => {
 		const htmlContent = await canvas().$$(
 			'.block-editor-block-list__block-html-textarea'
 		);
-		const html = await page.evaluate( ( el ) => {
+		const html = await canvas().evaluate( ( el ) => {
 			return el.innerHTML;
 		}, htmlContent[ 0 ] );
 
@@ -145,7 +138,7 @@ describe( 'Annotations', () => {
 
 		await removeAnnotations();
 		const htmlContent = await canvas().$$( '.wp-block-paragraph' );
-		const html = await page.evaluate( ( el ) => {
+		const html = await canvas().evaluate( ( el ) => {
 			return el.innerHTML;
 		}, htmlContent[ 0 ] );
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

In this case it turns out there's a few evaluations that need to be run in the canvas.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
