### PR TITLE
Fix "Blog title" input border radius in Index / Home details panel

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-screen/style.scss
@@ -134,6 +134,7 @@
 	.components-input-control__input {
 		color: $gray-200 !important;
 		background: $gray-800 !important;
+		border-radius: $radius-block-ui;
 	}
 	.components-input-control__backdrop {
 		border: 4px !important;


### PR DESCRIPTION
## What?
Fix "Blog title" input border radius in Index / Home details panel.

## Why?
It's hard to spot, but currently no radius is applied to this input making it inconsistent with all others.

## Testing Instructions
1. Open Index or Blog Home template details panel
2. Zoom in
3. Observe that the "Blog title" input now has 2px border radius applied.

## Before
<img width="995" alt="Screenshot 2023-09-05 at 15 33 19" src="https://github.com/WordPress/gutenberg/assets/846565/68a7aaac-65d3-4d7d-8fba-a79f0e5e3722">

## After
<img width="1003" alt="Screenshot 2023-09-05 at 15 33 01" src="https://github.com/WordPress/gutenberg/assets/846565/7477573e-a9cd-437f-8317-1429ce7f3b19">
