### PR TITLE
Query block: Move "Enhance pagination" toggle under Settings

### DIFF
--- a/packages/block-library/src/query/edit/inspector-controls/index.js
+++ b/packages/block-library/src/query/edit/inspector-controls/index.js
@@ -218,7 +218,7 @@ export default function QueryInspectorControls( props ) {
 						<ToggleControl
 							label={ __( 'Enhanced pagination' ) }
 							help={ __(
-								"Don't refresh the page when paginating to another page."
+								'Browsing between pages won’t require a full page reload.'
 							) }
 							checked={ !! enhancedPagination }
 							onChange={ ( value ) =>

--- a/packages/block-library/src/query/edit/inspector-controls/index.js
+++ b/packages/block-library/src/query/edit/inspector-controls/index.js
@@ -215,6 +215,29 @@ export default function QueryInspectorControls( props ) {
 								}
 							/>
 						) }
+						<ToggleControl
+							label={ __( 'Enhanced pagination' ) }
+							help={ __(
+								"Don't refresh the page when paginating to another page."
+							) }
+							checked={ !! enhancedPagination }
+							onChange={ ( value ) =>
+								setAttributes( {
+									enhancedPagination: !! value,
+								} )
+							}
+						/>
+						{ enhancedPagination && (
+							<div>
+								<Notice
+									spokenMessage={ null }
+									status="warning"
+									isDismissible={ false }
+								>
+									{ enhancedPaginationNotice }
+								</Notice>
+							</div>
+						) }
 					</PanelBody>
 				</InspectorControls>
 			) }
@@ -293,36 +316,6 @@ export default function QueryInspectorControls( props ) {
 					</ToolsPanel>
 				</InspectorControls>
 			) }
-			<InspectorControls>
-				<PanelBody
-					title={ __( 'User Experience' ) }
-					initialOpen={ false }
-				>
-					<ToggleControl
-						label={ __( 'Enhanced pagination' ) }
-						help={ __(
-							"Don't refresh the page when paginating to another page."
-						) }
-						checked={ !! enhancedPagination }
-						onChange={ ( value ) =>
-							setAttributes( {
-								enhancedPagination: !! value,
-							} )
-						}
-					/>
-					{ enhancedPagination && (
-						<div>
-							<Notice
-								spokenMessage={ null }
-								status="warning"
-								isDismissible={ false }
-							>
-								{ enhancedPaginationNotice }
-							</Notice>
-						</div>
-					) }
-				</PanelBody>
-			</InspectorControls>
 		</>
 	);
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Remove the "User Experience" dedicated panel, and move the "Enhance pagination" toggle under Settings, also modifying the toggle's description for one with a more positive tone.

Will close https://github.com/WordPress/gutenberg/issues/54059.

## Why?

To improve how we present the new enhanced mode for the Query loop in the Site Editor (see https://github.com/WordPress/gutenberg/pull/53812#issuecomment-1693305042).

## How?

Just moving the corresponding `ToggleControl` to the right position.

## Testing Instructions
You can use https://playground.wordpress.net/gutenberg.html to test this PR.

1. Add or use a template with the Query block.
2. Check that the "Enhanced Pagination" setting now appears under the "Settings" sidebar panel.
3. Check that enabling and disabling the settings works as in https://github.com/WordPress/gutenberg/pull/53812

## Screenshots or screencast

| Before | After |
| --- | --- |
| ![Screenshot 2023-09-05 at 19 20 01](https://github.com/WordPress/gutenberg/assets/6917969/31d36579-bd98-4218-b811-599b770845bc) | ![Screenshot 2023-09-05 at 19 15 58](https://github.com/WordPress/gutenberg/assets/6917969/6dd625e2-6cfd-4403-8dda-061ecf6fc6a9) |
