### PR TITLE
Interactivity API: Override unfinished `navigate` calls

### DIFF
--- a/packages/e2e-tests/plugins/interactive-blocks/router-navigate/block.json
+++ b/packages/e2e-tests/plugins/interactive-blocks/router-navigate/block.json
@@ -1,0 +1,14 @@
+{
+	"apiVersion": 2,
+	"name": "test/router-navigate",
+	"title": "E2E Interactivity tests - router navigate",
+	"category": "text",
+	"icon": "heart",
+	"description": "",
+	"supports": {
+		"interactivity": true
+	},
+	"textdomain": "e2e-interactivity",
+	"viewScript": "router-navigate-view",
+	"render": "file:./render.php"
+}

--- a/packages/e2e-tests/plugins/interactive-blocks/router-navigate/render.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/router-navigate/render.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * HTML for testing the router navigate function.
+ *
+ * @package gutenberg-test-interactive-blocks
+ * @phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
+ */
+
+?>
+
+
+<div data-wp-interactive data-wp-navigation-id="region-1">
+	<h2 data-testid="title"><?php echo $attributes['title']; ?></h2>
+
+	<output
+		data-testid="router navigations"
+		data-wp-text="state.router.navigations"
+	>NaN</output>
+	<output
+		data-testid="router status"
+		data-wp-text="state.router.status"
+	>undefined</output>
+
+	<?php
+	if ( isset( $attributes['links'] ) ) {
+		foreach ( $attributes['links'] as $key => $link ) {
+			$i = $key += 1;
+			echo <<<HTML
+			<a
+				data-testid="link $i"
+				data-wp-on--click="actions.router.navigate"
+				href="$link"
+			>link $i</a>
+HTML;
+		}
+	}
+	?>
+</div>

--- a/packages/e2e-tests/plugins/interactive-blocks/router-navigate/render.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/router-navigate/render.php
@@ -31,6 +31,12 @@
 				data-wp-on--click="actions.router.navigate"
 				href="$link"
 			>link $i</a>
+			<a
+				data-testid="link $i with hash"
+				data-wp-on--click="actions.router.navigate"
+				data-force-navigation="true"
+				href="$link#link-$i-with-hash"
+			>link $i with hash</a>
 HTML;
 		}
 	}

--- a/packages/e2e-tests/plugins/interactive-blocks/router-navigate/view.js
+++ b/packages/e2e-tests/plugins/interactive-blocks/router-navigate/view.js
@@ -1,0 +1,33 @@
+( ( { wp } ) => {
+	/**
+	 * WordPress dependencies
+	 */
+	const { store, navigate } = wp.interactivity;
+
+	store( {
+		state: {
+			router: {
+				status: 'idle',
+				navigations: 0,
+			}
+		},
+		actions: {
+			router: {
+				navigate: async ( { state, event: e } ) => {
+					e.preventDefault();
+
+					state.router.navigations += 1;
+					state.router.status = 'busy';
+
+					await navigate( e.target.href );
+
+					state.router.navigations -= 1;
+
+					if ( state.router.navigations === 0) {
+						state.router.status = 'idle';
+					}
+				},
+			},
+		},
+	} );
+} )( window );

--- a/packages/e2e-tests/plugins/interactive-blocks/router-navigate/view.js
+++ b/packages/e2e-tests/plugins/interactive-blocks/router-navigate/view.js
@@ -19,7 +19,9 @@
 					state.router.navigations += 1;
 					state.router.status = 'busy';
 
-					await navigate( e.target.href );
+					const force = e.target.dataset.forceNavigation === 'true';
+
+					await navigate( e.target.href, { force } );
 
 					state.router.navigations -= 1;
 

--- a/packages/interactivity/CHANGELOG.md
+++ b/packages/interactivity/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancements
+
+-   Improve `navigate()` to render only the result of the last call when multiple happen simultaneously. ([#54201](https://github.com/WordPress/gutenberg/pull/54201))
+
 ## 2.2.0 (2023-08-31)
 
 ### Enhancements

--- a/packages/interactivity/src/router.js
+++ b/packages/interactivity/src/router.js
@@ -84,14 +84,14 @@ let navigatingTo = '';
 // Navigate to a new page.
 export const navigate = async ( href, options = {} ) => {
 	const url = cleanUrl( href );
-	navigatingTo = url;
+	navigatingTo = href;
 	prefetch( url, options );
 	const page = await pages.get( url );
 
 	// Once the page is fetched, the destination URL could have changed (e.g.,
 	// by clicking another link in the meantime). If so, bail out, and let the
 	// newer execution to update the HTML.
-	if ( navigatingTo !== url ) return;
+	if ( navigatingTo !== href ) return;
 
 	if ( page ) {
 		renderRegions( page );

--- a/packages/interactivity/src/router.js
+++ b/packages/interactivity/src/router.js
@@ -78,11 +78,21 @@ const renderRegions = ( page ) => {
 	} );
 };
 
+// Variable to store the current navigation.
+let navigatingTo = '';
+
 // Navigate to a new page.
 export const navigate = async ( href, options = {} ) => {
 	const url = cleanUrl( href );
+	navigatingTo = url;
 	prefetch( url, options );
 	const page = await pages.get( url );
+
+	// Once the page is fetched, the destination URL could have changed (e.g.,
+	// by clicking another link in the meantime). If so, bail out, and let the
+	// newer execution to update the HTML.
+	if ( navigatingTo !== url ) return;
+
 	if ( page ) {
 		renderRegions( page );
 		window.history[ options.replace ? 'replaceState' : 'pushState' ](

--- a/test/e2e/specs/interactivity/router-navigate.spec.ts
+++ b/test/e2e/specs/interactivity/router-navigate.spec.ts
@@ -55,8 +55,8 @@ test.describe( 'Router navigate', () => {
 			await route.continue();
 		} );
 
-		await page.getByTestId( 'link 1' ).click( { delay: 60 } );
-		await page.getByTestId( 'link 2' ).click( { delay: 60 } );
+		await page.getByTestId( 'link 1' ).click();
+		await page.getByTestId( 'link 2' ).click();
 
 		await expect( navigations ).toHaveText( '2' );
 		await expect( status ).toHaveText( 'busy' );

--- a/test/e2e/specs/interactivity/router-navigate.spec.ts
+++ b/test/e2e/specs/interactivity/router-navigate.spec.ts
@@ -1,0 +1,77 @@
+/**
+ * Internal dependencies
+ */
+import { test, expect } from './fixtures';
+
+test.describe( 'Router navigate', () => {
+	test.beforeAll( async ( { interactivityUtils: utils } ) => {
+		await utils.activatePlugins();
+		const link2 = await utils.addPostWithBlock( 'test/router-navigate', {
+			alias: 'router navigate - link 2',
+			attributes: { title: 'Link 2' },
+		} );
+		const link1 = await utils.addPostWithBlock( 'test/router-navigate', {
+			alias: 'router navigate - link 1',
+			attributes: { title: 'Link 1' },
+		} );
+		await utils.addPostWithBlock( 'test/router-navigate', {
+			alias: 'router navigate - main',
+			attributes: { title: 'Main', links: [ link1, link2 ] },
+		} );
+	} );
+
+	test.beforeEach( async ( { interactivityUtils: utils, page } ) => {
+		await page.goto( utils.getLink( 'router navigate - main' ) );
+	} );
+
+	test.afterAll( async ( { interactivityUtils: utils } ) => {
+		await utils.deactivatePlugins();
+		await utils.deleteAllPosts();
+	} );
+
+	test( 'should update the HTML only for the latest navigation', async ( {
+		page,
+		interactivityUtils: utils,
+	} ) => {
+		const link1 = utils.getLink( 'router navigate - link 1' );
+		const link2 = utils.getLink( 'router navigate - link 2' );
+
+		const navigations = page.getByTestId( 'router navigations' );
+		const status = page.getByTestId( 'router status' );
+		const title = page.getByTestId( 'title' );
+
+		await expect( navigations ).toHaveText( '0' );
+		await expect( status ).toHaveText( 'idle' );
+
+		let resolveLink1: Function;
+		let resolveLink2: Function;
+
+		await page.route( link1, async ( route ) => {
+			await new Promise( ( r ) => ( resolveLink1 = r ) );
+			await route.continue();
+		} );
+		await page.route( link2, async ( route ) => {
+			await new Promise( ( r ) => ( resolveLink2 = r ) );
+			await route.continue();
+		} );
+
+		await page.getByTestId( 'link 1' ).click( { delay: 60 } );
+		await page.getByTestId( 'link 2' ).click( { delay: 60 } );
+
+		await expect( navigations ).toHaveText( '2' );
+		await expect( status ).toHaveText( 'busy' );
+		await expect( title ).toHaveText( 'Main' );
+
+		await Promise.resolve().then( () => resolveLink2() );
+
+		await expect( navigations ).toHaveText( '1' );
+		await expect( status ).toHaveText( 'busy' );
+		await expect( title ).toHaveText( 'Link 2' );
+
+		await Promise.resolve().then( () => resolveLink1() );
+
+		await expect( navigations ).toHaveText( '0' );
+		await expect( status ).toHaveText( 'idle' );
+		await expect( title ).toHaveText( 'Link 2' );
+	} );
+} );


### PR DESCRIPTION
## What?

Improve `navigate()` to render only the result of the last call when multiple happen simultaneously.

## Why?

Required for the Query Loop block with enhanced pagination.
- https://github.com/WordPress/gutenberg/issues/53740

## How?

Previous `navigate()` calls are not canceled, so the related HTML is still fetched. However, only the last one executes Preact's `render()`.

## Testing Instructions
1. Open the Blog Home template in the Site Editor and enable "Enhanced pagination" for the Query Loop.
2. Add the Page Numbers block inside the Pagination block.
3. In the Dashboard / Settings / Reading, set "Blog pages show at most" to 1.
4. Add posts to have at least three in total.
5. Add a code snippet to delay the request for the page 2, like this one:
   ```php
   add_action(
     'shutdown',
     function () {
       if ( is_paged() && 2 === get_query_var( 'paged' ) ) {
         sleep( 3 );
       }
     }
   );
   ```
6. Visit the homepage and open the browser's dev tools, in the Network tab.
7. Locate the Page numbers block and click the links for pages 2 and 3 consecutively.
8. Check that you are on page 3.
9. On the Network tab, wait for the page 2 request to be fulfilled.
10. Check that you are still on page 3.
11. Click on the link for page 2 and ensure that there is no delay this time.

