### PR TITLE
php.net/date links made functional

### DIFF
--- a/packages/date/README.md
+++ b/packages/date/README.md
@@ -27,7 +27,7 @@ _Related_
 
 _Parameters_
 
--   _dateFormat_ `string`: PHP-style formatting string. See php.net/date.
+-   _dateFormat_ `string`: PHP-style formatting string. See [php.net/date](https://php.net/date).
 -   _dateValue_ `Moment | Date | string | undefined`: Date object or string, parsable by moment.js.
 -   _timezone_ `string | number | undefined`: Timezone to output result in or a UTC offset. Defaults to timezone from site.
 
@@ -48,7 +48,7 @@ _Related_
 
 _Parameters_
 
--   _dateFormat_ `string`: PHP-style formatting string. See php.net/date.
+-   _dateFormat_ `string`: PHP-style formatting string. See [php.net/date](https://php.net/date).
 -   _dateValue_ `Moment | Date | string | undefined`: Date object or string, parsable by moment.js.
 -   _timezone_ `string | number | boolean | undefined`: Timezone to output result in or a UTC offset. Defaults to timezone from site. Notice: `boolean` is effectively deprecated, but still supported for backward compatibility reasons.
 
@@ -62,7 +62,7 @@ Formats a date. Does not alter the date's timezone.
 
 _Parameters_
 
--   _dateFormat_ `string`: PHP-style formatting string. See php.net/date.
+-   _dateFormat_ `string`: PHP-style formatting string. See [php.net/date](https://php.net/date).
 -   _dateValue_ `Moment | Date | string | undefined`: Date object or string, parsable by moment.js.
 
 _Returns_
@@ -95,7 +95,7 @@ Formats a date (like `date()` in PHP), in the UTC timezone.
 
 _Parameters_
 
--   _dateFormat_ `string`: PHP-style formatting string. See php.net/date.
+-   _dateFormat_ `string`: PHP-style formatting string. See [php.net/date](https://php.net/date).
 -   _dateValue_ `Moment | Date | string | undefined`: Date object or string, parsable by moment.js.
 
 _Returns_
@@ -108,7 +108,7 @@ Formats a date (like `wp_date()` in PHP), translating it into site's locale and 
 
 _Parameters_
 
--   _dateFormat_ `string`: PHP-style formatting string. See php.net/date.
+-   _dateFormat_ `string`: PHP-style formatting string. See [php.net/date](https://php.net/date).
 -   _dateValue_ `Moment | Date | string | undefined`: Date object or string, parsable by moment.js.
 
 _Returns_


### PR DESCRIPTION
Either the link given is intended to work (it does by forwarding) - then it should be functional. Or not - then it should be replaced. Right?

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
