### PR TITLE
Allow using a button element for button blocks

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -53,7 +53,7 @@ Prompt visitors to take action with a button-style link. ([Source](https://githu
 -	**Category:** design
 -	**Parent:** core/buttons
 -	**Supports:** anchor, color (background, gradients, text), shadow, spacing (padding), typography (fontSize, lineHeight), ~~alignWide~~, ~~align~~, ~~reusable~~
--	**Attributes:** backgroundColor, gradient, linkTarget, placeholder, rel, text, textAlign, textColor, title, url, width
+-	**Attributes:** backgroundColor, gradient, linkTarget, placeholder, rel, tagName, text, textAlign, textColor, title, url, width
 
 ## Buttons
 

--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -53,7 +53,7 @@ Prompt visitors to take action with a button-style link. ([Source](https://githu
 -	**Category:** design
 -	**Parent:** core/buttons
 -	**Supports:** anchor, color (background, gradients, text), shadow, spacing (padding), typography (fontSize, lineHeight), ~~alignWide~~, ~~align~~, ~~reusable~~
--	**Attributes:** backgroundColor, gradient, linkTarget, placeholder, rel, tagName, text, textAlign, textColor, title, url, width
+-	**Attributes:** backgroundColor, gradient, linkTarget, placeholder, rel, tagName, text, textAlign, textColor, title, type, url, width
 
 ## Buttons
 

--- a/packages/block-library/src/button/block.json
+++ b/packages/block-library/src/button/block.json
@@ -9,6 +9,10 @@
 	"keywords": [ "link" ],
 	"textdomain": "default",
 	"attributes": {
+		"tagName": {
+			"type": "string",
+			"default": "a"
+		},
 		"textAlign": {
 			"type": "string"
 		},
@@ -22,14 +26,14 @@
 		"title": {
 			"type": "string",
 			"source": "attribute",
-			"selector": "a",
+			"selector": "a,button",
 			"attribute": "title",
 			"__experimentalRole": "content"
 		},
 		"text": {
 			"type": "string",
 			"source": "html",
-			"selector": "a",
+			"selector": "a,button",
 			"__experimentalRole": "content"
 		},
 		"linkTarget": {

--- a/packages/block-library/src/button/block.json
+++ b/packages/block-library/src/button/block.json
@@ -13,6 +13,10 @@
 			"type": "string",
 			"default": "a"
 		},
+		"type": {
+			"type": "string",
+			"default": "button"
+		},
 		"textAlign": {
 			"type": "string"
 		},

--- a/packages/block-library/src/button/edit.js
+++ b/packages/block-library/src/button/edit.js
@@ -78,8 +78,19 @@ function ButtonEdit( props ) {
 		onReplace,
 		mergeBlocks,
 	} = props;
-	const { textAlign, linkTarget, placeholder, rel, style, text, url, width } =
-		attributes;
+	const {
+		tagName,
+		textAlign,
+		linkTarget,
+		placeholder,
+		rel,
+		style,
+		text,
+		url,
+		width,
+	} = attributes;
+
+	const TagName = tagName || 'a';
 
 	function onToggleOpenInNewTab( value ) {
 		const newLinkTarget = value ? '_blank' : undefined;
@@ -209,7 +220,7 @@ function ButtonEdit( props ) {
 						setAttributes( { textAlign: nextAlign } );
 					} }
 				/>
-				{ ! isURLSet && (
+				{ ! isURLSet && 'a' === TagName && (
 					<ToolbarButton
 						name="link"
 						icon={ link }
@@ -218,7 +229,7 @@ function ButtonEdit( props ) {
 						onClick={ startEditing }
 					/>
 				) }
-				{ isURLSet && (
+				{ isURLSet && 'a' === TagName && (
 					<ToolbarButton
 						name="link"
 						icon={ linkOff }
@@ -229,7 +240,7 @@ function ButtonEdit( props ) {
 					/>
 				) }
 			</BlockControls>
-			{ isSelected && ( isEditingURL || isURLSet ) && (
+			{ 'a' === TagName && isSelected && ( isEditingURL || isURLSet ) && (
 				<Popover
 					placement="bottom"
 					onClose={ () => {
@@ -268,12 +279,16 @@ function ButtonEdit( props ) {
 				/>
 			</InspectorControls>
 			<InspectorControls group="advanced">
-				<TextControl
-					__nextHasNoMarginBottom
-					label={ __( 'Link rel' ) }
-					value={ rel || '' }
-					onChange={ ( newRel ) => setAttributes( { rel: newRel } ) }
-				/>
+				{ 'a' === TagName && (
+					<TextControl
+						__nextHasNoMarginBottom
+						label={ __( 'Link rel' ) }
+						value={ rel || '' }
+						onChange={ ( newRel ) =>
+							setAttributes( { rel: newRel } )
+						}
+					/>
+				) }
 			</InspectorControls>
 		</>
 	);

--- a/packages/block-library/src/button/save.js
+++ b/packages/block-library/src/button/save.js
@@ -18,6 +18,7 @@ import {
 export default function save( { attributes, className } ) {
 	const {
 		tagName,
+		type,
 		textAlign,
 		fontSize,
 		linkTarget,
@@ -34,6 +35,7 @@ export default function save( { attributes, className } ) {
 	}
 
 	const TagName = tagName || 'a';
+	const buttonType = type || 'button';
 	const borderProps = getBorderClassesAndStyles( attributes );
 	const colorProps = getColorClassesAndStyles( attributes );
 	const spacingProps = getSpacingClassesAndStyles( attributes );
@@ -68,6 +70,7 @@ export default function save( { attributes, className } ) {
 		<div { ...useBlockProps.save( { className: wrapperClasses } ) }>
 			<RichText.Content
 				tagName={ TagName }
+				type={ 'button' === TagName ? buttonType : null }
 				className={ buttonClasses }
 				href={ 'button' === TagName ? null : url }
 				title={ title }

--- a/packages/block-library/src/button/save.js
+++ b/packages/block-library/src/button/save.js
@@ -17,6 +17,7 @@ import {
 
 export default function save( { attributes, className } ) {
 	const {
+		tagName,
 		textAlign,
 		fontSize,
 		linkTarget,
@@ -32,6 +33,7 @@ export default function save( { attributes, className } ) {
 		return null;
 	}
 
+	const TagName = tagName || 'a';
 	const borderProps = getBorderClassesAndStyles( attributes );
 	const colorProps = getColorClassesAndStyles( attributes );
 	const spacingProps = getSpacingClassesAndStyles( attributes );
@@ -65,14 +67,14 @@ export default function save( { attributes, className } ) {
 	return (
 		<div { ...useBlockProps.save( { className: wrapperClasses } ) }>
 			<RichText.Content
-				tagName="a"
+				tagName={ TagName }
 				className={ buttonClasses }
-				href={ url }
+				href={ 'button' === TagName ? null : url }
 				title={ title }
 				style={ buttonStyle }
 				value={ text }
-				target={ linkTarget }
-				rel={ rel }
+				target={ 'button' === TagName ? null : linkTarget }
+				rel={ 'button' === TagName ? null : rel }
 			/>
 		</div>
 	);

--- a/test/integration/fixtures/blocks/core__button__squared.json
+++ b/test/integration/fixtures/blocks/core__button__squared.json
@@ -3,6 +3,7 @@
 		"name": "core/button",
 		"isValid": true,
 		"attributes": {
+			"tagName": "a",
 			"text": "My button",
 			"style": {
 				"border": {

--- a/test/integration/fixtures/blocks/core__button__squared.json
+++ b/test/integration/fixtures/blocks/core__button__squared.json
@@ -4,6 +4,7 @@
 		"isValid": true,
 		"attributes": {
 			"tagName": "a",
+			"type": "button",
 			"text": "My button",
 			"style": {
 				"border": {

--- a/test/integration/fixtures/blocks/core__buttons.html
+++ b/test/integration/fixtures/blocks/core__buttons.html
@@ -13,7 +13,7 @@
 	<!-- /wp:button -->
 
 	<!-- wp:button {"tagName":"button"} -->
-	<div class="wp-block-button"><button class="wp-block-button__link wp-element-button">My button 4</button></div>
+	<div class="wp-block-button"><button type="button" class="wp-block-button__link wp-element-button">My button 4</button></div>
 	<!-- /wp:button -->
 </div>
 <!-- /wp:buttons -->

--- a/test/integration/fixtures/blocks/core__buttons.html
+++ b/test/integration/fixtures/blocks/core__buttons.html
@@ -7,5 +7,13 @@
 	<!-- wp:button -->
 	<div class="wp-block-button"><a class="wp-block-button__link wp-element-button">My button 2</a></div>
 	<!-- /wp:button -->
+
+	<!-- wp:button {"tagName":"a"} -->
+	<div class="wp-block-button"><a class="wp-block-button__link wp-element-button">My button 3</a></div>
+	<!-- /wp:button -->
+
+	<!-- wp:button {"tagName":"button"} -->
+	<div class="wp-block-button"><button class="wp-block-button__link wp-element-button">My button 4</button></div>
+	<!-- /wp:button -->
 </div>
 <!-- /wp:buttons -->

--- a/test/integration/fixtures/blocks/core__buttons.json
+++ b/test/integration/fixtures/blocks/core__buttons.json
@@ -14,6 +14,7 @@
 				"name": "core/button",
 				"isValid": true,
 				"attributes": {
+					"tagName": "a",
 					"text": "My button 1"
 				},
 				"innerBlocks": []
@@ -22,7 +23,26 @@
 				"name": "core/button",
 				"isValid": true,
 				"attributes": {
+					"tagName": "a",
 					"text": "My button 2"
+				},
+				"innerBlocks": []
+			},
+			{
+				"name": "core/button",
+				"isValid": true,
+				"attributes": {
+					"tagName": "a",
+					"text": "My button 3"
+				},
+				"innerBlocks": []
+			},
+			{
+				"name": "core/button",
+				"isValid": true,
+				"attributes": {
+					"tagName": "button",
+					"text": "My button 4"
 				},
 				"innerBlocks": []
 			}

--- a/test/integration/fixtures/blocks/core__buttons.json
+++ b/test/integration/fixtures/blocks/core__buttons.json
@@ -15,6 +15,7 @@
 				"isValid": true,
 				"attributes": {
 					"tagName": "a",
+					"type": "button",
 					"text": "My button 1"
 				},
 				"innerBlocks": []
@@ -24,6 +25,7 @@
 				"isValid": true,
 				"attributes": {
 					"tagName": "a",
+					"type": "button",
 					"text": "My button 2"
 				},
 				"innerBlocks": []
@@ -33,6 +35,7 @@
 				"isValid": true,
 				"attributes": {
 					"tagName": "a",
+					"type": "button",
 					"text": "My button 3"
 				},
 				"innerBlocks": []
@@ -42,6 +45,7 @@
 				"isValid": true,
 				"attributes": {
 					"tagName": "button",
+					"type": "button",
 					"text": "My button 4"
 				},
 				"innerBlocks": []

--- a/test/integration/fixtures/blocks/core__buttons.parsed.json
+++ b/test/integration/fixtures/blocks/core__buttons.parsed.json
@@ -44,9 +44,9 @@
 					"tagName": "button"
 				},
 				"innerBlocks": [],
-				"innerHTML": "\n\t<div class=\"wp-block-button\"><button class=\"wp-block-button__link wp-element-button\">My button 4</button></div>\n\t",
+				"innerHTML": "\n\t<div class=\"wp-block-button\"><button type=\"button\" class=\"wp-block-button__link wp-element-button\">My button 4</button></div>\n\t",
 				"innerContent": [
-					"\n\t<div class=\"wp-block-button\"><button class=\"wp-block-button__link wp-element-button\">My button 4</button></div>\n\t"
+					"\n\t<div class=\"wp-block-button\"><button type=\"button\" class=\"wp-block-button__link wp-element-button\">My button 4</button></div>\n\t"
 				]
 			}
 		],

--- a/test/integration/fixtures/blocks/core__buttons.parsed.json
+++ b/test/integration/fixtures/blocks/core__buttons.parsed.json
@@ -26,11 +26,37 @@
 				"innerContent": [
 					"\n\t<div class=\"wp-block-button\"><a class=\"wp-block-button__link wp-element-button\">My button 2</a></div>\n\t"
 				]
+			},
+			{
+				"blockName": "core/button",
+				"attrs": {
+					"tagName": "a"
+				},
+				"innerBlocks": [],
+				"innerHTML": "\n\t<div class=\"wp-block-button\"><a class=\"wp-block-button__link wp-element-button\">My button 3</a></div>\n\t",
+				"innerContent": [
+					"\n\t<div class=\"wp-block-button\"><a class=\"wp-block-button__link wp-element-button\">My button 3</a></div>\n\t"
+				]
+			},
+			{
+				"blockName": "core/button",
+				"attrs": {
+					"tagName": "button"
+				},
+				"innerBlocks": [],
+				"innerHTML": "\n\t<div class=\"wp-block-button\"><button class=\"wp-block-button__link wp-element-button\">My button 4</button></div>\n\t",
+				"innerContent": [
+					"\n\t<div class=\"wp-block-button\"><button class=\"wp-block-button__link wp-element-button\">My button 4</button></div>\n\t"
+				]
 			}
 		],
-		"innerHTML": "\n<div class=\"wp-block-buttons alignwide\">\n\t\n\n\t\n</div>\n",
+		"innerHTML": "\n<div class=\"wp-block-buttons alignwide\">\n\t\n\n\t\n\n\t\n\n\t\n</div>\n",
 		"innerContent": [
 			"\n<div class=\"wp-block-buttons alignwide\">\n\t",
+			null,
+			"\n\n\t",
+			null,
+			"\n\n\t",
 			null,
 			"\n\n\t",
 			null,

--- a/test/integration/fixtures/blocks/core__buttons.serialized.html
+++ b/test/integration/fixtures/blocks/core__buttons.serialized.html
@@ -12,6 +12,6 @@
 <!-- /wp:button -->
 
 <!-- wp:button {"tagName":"button"} -->
-<div class="wp-block-button"><button class="wp-block-button__link wp-element-button">My button 4</button></div>
+<div class="wp-block-button"><button type="button" class="wp-block-button__link wp-element-button">My button 4</button></div>
 <!-- /wp:button --></div>
 <!-- /wp:buttons -->

--- a/test/integration/fixtures/blocks/core__buttons.serialized.html
+++ b/test/integration/fixtures/blocks/core__buttons.serialized.html
@@ -5,5 +5,13 @@
 
 <!-- wp:button -->
 <div class="wp-block-button"><a class="wp-block-button__link wp-element-button">My button 2</a></div>
+<!-- /wp:button -->
+
+<!-- wp:button -->
+<div class="wp-block-button"><a class="wp-block-button__link wp-element-button">My button 3</a></div>
+<!-- /wp:button -->
+
+<!-- wp:button {"tagName":"button"} -->
+<div class="wp-block-button"><button class="wp-block-button__link wp-element-button">My button 4</button></div>
 <!-- /wp:button --></div>
 <!-- /wp:buttons -->


### PR DESCRIPTION
## What?
Allows using a `<button>` element for button blocks.

## Why?

Because it would improve semantics (and therefore also a11y), and allow us to use the block in more scenarios where a link is not the right element to use. 
Right now, the `core/button` blocks prints a link. Though visually this is OK, semantically it can be limiting and in some cases incorrect. Currently, we have no way to add an actual `<button>` element, and the button block doesn't do what someone with some basic HTML knowledge would expect it to do.
Additionally, a real `<button>` element is something we could use in other blocks like the search block, comments block, as well as other future blocks.

This came out of https://github.com/WordPress/gutenberg/pull/44214

## How?
Added a `tagName` attribute to the `core/button` block. `<button>` elements don't have `href`, so when using a button HTML element, the URL input is hidden from the UI.
UPDATE: After [this comment](https://github.com/WordPress/gutenberg/pull/54206#issuecomment-1708040803), A `type` attribute was also added to allow defining the button type. 

Nothing changes for link buttons.

IMPORTANT:
This PR does not add a UI for selecting the element. It just makes it possible for users to manually change it via the Code Editor, without getting an error when they switch back to the visual editor.

## Testing Instructions
1. Check any previous post that had a pre-existing button block, and make sure there are no errors in the console
2. In a post add a new button and check that it works as expected
3. Switch to the code editor, and add this:
```html
<!-- wp:buttons -->
<div class="wp-block-buttons"><!-- wp:button {"tagName":"button","type":"button"} -->
<div class="wp-block-button"><button type="button" class="wp-block-button__link wp-element-button">Actual button</button></div>
<!-- /wp:button --></div>
<!-- /wp:buttons --></div>
```
4. Switch back to the visual editor and confirm it works
5. Save the post, view it on the frontend of the site, inspect the buttons and confirm that they use the right element

### Testing Instructions for Keyboard
Nothing to test
