### PR TITLE
Auto-inserting blocks: Remove obsolete TODO, fix REST API field description

### DIFF
--- a/lib/experimental/auto-inserting-blocks.php
+++ b/lib/experimental/auto-inserting-blocks.php
@@ -335,7 +335,7 @@ function gutenberg_register_auto_insert_rest_field() {
 		'auto_insert',
 		array(
 			'schema' => array(
-				'description'       => __( 'Block types that may be automatically inserted near this block and the associated relative position where they are inserted.', 'gutenberg' ),
+				'description'       => __( 'This block is automatically inserted near any occurence of the block types used as keys of this map, into a relative position given by the corresponding value.', 'gutenberg' ),
 				'patternProperties' => array(
 					'^[a-zA-Z0-9-]+/[a-zA-Z0-9-]+$' => array(
 						'type' => 'string',

--- a/packages/block-editor/src/hooks/auto-inserting-blocks.js
+++ b/packages/block-editor/src/hooks/auto-inserting-blocks.js
@@ -193,9 +193,6 @@ function AutoInsertingBlocksControl( props ) {
 							<h3>{ vendor }</h3>
 							{ groupedAutoInsertedBlocks[ vendor ].map(
 								( block ) => {
-									// TODO: Display block icon.
-									// <BlockIcon icon={ block.icon } />
-
 									const checked =
 										block.name in
 										autoInsertedBlockClientIds;


### PR DESCRIPTION
## What?
Two minor changes to auto-inserting blocks:
- Remove a now-obsolete TODO note from the block inspector panel code -- this was implemented by #52969.
- Fix the REST API field description. It used to claim that the field lists blocks that are auto-inserted next to this block, when it's really the other way round: This block is auto-inserted next to those blocks.

## Why?
'cause those things were factually inaccurate.
They're also part of #54147, but since that PR is overall more controversial and might need more time, I wanted at least the unrelated, non-controversial stuff to get in.

## How?
Simple replacements.

## Testing Instructions
Verify that auto-inserting blocks still work.