### PR TITLE
Scripts:  Correctly resolve entry points when the directory is symlinked

### DIFF
--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 -   Added support for `test-playwright` script ([#53108](https://github.com/WordPress/gutenberg/pull/53108)).
 
+### Bug Fix
+
+-   Correctly resolve entry points when the directory is symlinked ([#54212](https://github.com/WordPress/gutenberg/pull/54212)).
+
 ## 26.12.0 (2023-08-31)
 
 ## 26.11.0 (2023-08-16)

--- a/packages/scripts/config/webpack.config.js
+++ b/packages/scripts/config/webpack.config.js
@@ -10,6 +10,7 @@ const MiniCSSExtractPlugin = require( 'mini-css-extract-plugin' );
 const { basename, dirname, resolve } = require( 'path' );
 const ReactRefreshWebpackPlugin = require( '@pmmmwh/react-refresh-webpack-plugin' );
 const TerserPlugin = require( 'terser-webpack-plugin' );
+const { realpathSync } = require( 'fs' );
 
 /**
  * WordPress dependencies
@@ -302,7 +303,9 @@ const config = {
 					filter: ( filepath ) => {
 						return (
 							process.env.WP_COPY_PHP_FILES_TO_DIST ||
-							RenderPathsPlugin.renderPaths.includes( filepath )
+							RenderPathsPlugin.renderPaths.includes(
+								realpathSync( filepath ).replace( /\\/g, '/' )
+							)
 						);
 					},
 				},

--- a/packages/scripts/utils/config.js
+++ b/packages/scripts/utils/config.js
@@ -206,15 +206,15 @@ function getWebpackEntryPoints() {
 
 	// 2. Checks whether any block metadata files can be detected in the defined source directory.
 	//    It scans all discovered files looking for JavaScript assets and converts them to entry points.
-	const srcDirectory = fromProjectRoot( getWordPressSrcDirectory() ) + sep;
-	const blockMetadataFiles = glob(
-		join( srcDirectory, '**/block.json' ).replace( /\\/g, '/' ),
-		{
-			absolute: true,
-		}
-	);
+	const blockMetadataFiles = glob( '**/block.json', {
+		absolute: true,
+		cwd: fromProjectRoot( getWordPressSrcDirectory() ),
+	} );
 
 	if ( blockMetadataFiles.length > 0 ) {
+		const srcDirectory = fromProjectRoot(
+			getWordPressSrcDirectory() + sep
+		);
 		const entryPoints = blockMetadataFiles.reduce(
 			( accumulator, blockMetadataFile ) => {
 				// wrapping in try/catch in case the file is malformed
@@ -333,13 +333,12 @@ function getRenderPropPaths() {
 	}
 
 	// Checks whether any block metadata files can be detected in the defined source directory.
+	const blockMetadataFiles = glob( '**/block.json', {
+		absolute: true,
+		cwd: fromProjectRoot( getWordPressSrcDirectory() ),
+	} );
+
 	const srcDirectory = fromProjectRoot( getWordPressSrcDirectory() + sep );
-	const blockMetadataFiles = glob(
-		join( srcDirectory, '**/block.json' ).replace( /\\/g, '/' ),
-		{
-			absolute: true,
-		}
-	);
 
 	const renderPaths = blockMetadataFiles.map( ( blockMetadataFile ) => {
 		const { render } = JSON.parse( readFileSync( blockMetadataFile ) );

--- a/packages/scripts/utils/config.js
+++ b/packages/scripts/utils/config.js
@@ -206,17 +206,15 @@ function getWebpackEntryPoints() {
 
 	// 2. Checks whether any block metadata files can be detected in the defined source directory.
 	//    It scans all discovered files looking for JavaScript assets and converts them to entry points.
+	const srcDirectory = fromProjectRoot( getWordPressSrcDirectory() ) + sep;
 	const blockMetadataFiles = glob(
-		`${ getWordPressSrcDirectory() }/**/block.json`,
+		join( srcDirectory, '**/block.json' ).replace( /\\/g, '/' ),
 		{
 			absolute: true,
 		}
 	);
 
 	if ( blockMetadataFiles.length > 0 ) {
-		const srcDirectory = fromProjectRoot(
-			getWordPressSrcDirectory() + sep
-		);
 		const entryPoints = blockMetadataFiles.reduce(
 			( accumulator, blockMetadataFile ) => {
 				// wrapping in try/catch in case the file is malformed
@@ -335,14 +333,13 @@ function getRenderPropPaths() {
 	}
 
 	// Checks whether any block metadata files can be detected in the defined source directory.
+	const srcDirectory = fromProjectRoot( getWordPressSrcDirectory() + sep );
 	const blockMetadataFiles = glob(
-		`${ getWordPressSrcDirectory() }/**/block.json`,
+		join( srcDirectory, '**/block.json' ).replace( /\\/g, '/' ),
 		{
 			absolute: true,
 		}
 	);
-
-	const srcDirectory = fromProjectRoot( getWordPressSrcDirectory() + sep );
 
 	const renderPaths = blockMetadataFiles.map( ( blockMetadataFile ) => {
 		const { render } = JSON.parse( readFileSync( blockMetadataFile ) );

--- a/packages/scripts/utils/config.js
+++ b/packages/scripts/utils/config.js
@@ -258,9 +258,12 @@ function getWebpackEntryPoints() {
 
 							// Detects the proper file extension used in the defined source directory.
 							const [ entryFilepath ] = glob(
-								`${ getWordPressSrcDirectory() }/${ entryName }.[jt]s?(x)`,
+								`${ entryName }.[jt]s?(x)`,
 								{
 									absolute: true,
+									cwd: fromProjectRoot(
+										getWordPressSrcDirectory()
+									),
 								}
 							);
 
@@ -300,13 +303,12 @@ function getWebpackEntryPoints() {
 	}
 
 	// 3. Checks whether a standard file name can be detected in the defined source directory,
-	//    and converts the discovered file to entry point.
-	const [ entryFile ] = glob(
-		`${ getWordPressSrcDirectory() }/index.[jt]s?(x)`,
-		{
-			absolute: true,
-		}
-	);
+	//  and converts the discovered file to entry point.
+	const [ entryFile ] = glob( 'index.[jt]s?(x)', {
+		absolute: true,
+		cwd: fromProjectRoot( getWordPressSrcDirectory() ),
+	} );
+
 	if ( ! entryFile ) {
 		log(
 			chalk.yellow(


### PR DESCRIPTION
Fixes #44937

## What?
This PR fixes a problem where a file other than `block.json` is not generated when building a block using wp-scripts with a symlinked path.

Note: This PR probably fixes a Windows-specific problem; nothing should change on MacOS, but I would appreciate it if you could test it to see if it works correctly.

## Why?
In scripts, the path of `block.json` is first searched for by `glob()` function.

However, since the argument of the `glob()` function is not an absolute path, such as `src/**/block.json`, I expected that the path would not be resolved correctly when the `block.json` path was symlinked.

Also, as with #38781, it appears that when using regular expressions in the `glob()` function, they need to be unified with forward slashes.

## How?

Explicitly use the full path when searching for the path of `block.json` and replace backslashes with forward slashes at the same time. This seems to have resulted in block.json being detected correctly and returning the resolved path at the same time.

## Testing Instructions

Note: For Windows users, start the command prompt with the administrator role.

- Create a `plugins` directory in the root of the Gutenberg repository. and move to the `plugins` directory.
- Run `npx @wordpress/create-block test-block --no-wp-scripts`. In the `plugins` directory, `test-block` directory should be created.
- Remove `test-block/build` directory.
- Add the `render` property to the `test-block/src/block-a/block.json` file: `"render": "file:./render.php"`
- Add `render.php` file to the `test-block/src/block-a/` directory.
- Move everything in the `test-block/src` directory to the subdirectory called `test-block/src/block-a`.
- Create a symlink of the `plugins` directory in another location called `plugins-symlink`.
  - On Windows: `mklink /d "C:\path\to\gutenberg/\plugins-symlink" "C:\path\to\gutenberg\plugins"`
  - On Linux/MacOS: `ln -s /path/to/gutenberg/plugins /path/to/gutenberg/plugins-symlink`
- In your terminal, move to the **symlink's path**:
  - On Windows: `cd C:\path\to\plugins-symlink\test-block`
  - On Linux/MacOS: `cd /path/to/gutenberg/plugins-symlink/test-block`
- Build the block:
  - On Windows: `C:\path\to\gutenberg\node_modules\.bin\wp-scripts build`
  - On Linux/MacOS: `/path/to/node_modules/.bin/wp-scripts build`
- The terminal should not output any errors and all files should be generated in the `test-block/build/block-a` directory.
