### PR TITLE
Fix long-press gestures not working in `RichText` component [Android]

### DIFF
--- a/packages/block-library/src/audio/test/__snapshots__/edit.native.js.snap
+++ b/packages/block-library/src/audio/test/__snapshots__/edit.native.js.snap
@@ -133,7 +133,7 @@ exports[`Audio block renders audio block error state without crashing 1`] = `
           ]
         }
       >
-        <View
+        <RCTAztecView
           accessibilityState={
             {
               "busy": undefined,
@@ -143,73 +143,59 @@ exports[`Audio block renders audio block error state without crashing 1`] = `
               "selected": undefined,
             }
           }
-          accessibilityValue={
+          accessible={true}
+          activeFormats={[]}
+          blockType={
             {
-              "max": undefined,
-              "min": undefined,
-              "now": undefined,
-              "text": undefined,
+              "tag": "p",
             }
           }
-          accessible={false}
-          collapsable={false}
+          deleteEnter={true}
+          disableEditingMenu={false}
           focusable={true}
+          fontFamily="serif"
+          fontSize={14}
+          isMultiline={false}
+          maxImagesWidth={200}
+          onBackspace={[Function]}
           onBlur={[Function]}
+          onChange={[Function]}
           onClick={[Function]}
+          onContentSizeChange={[Function]}
+          onEnter={[Function]}
           onFocus={[Function]}
+          onHTMLContentWithCursor={[Function]}
+          onKeyDown={[Function]}
+          onPaste={[Function]}
           onResponderGrant={[Function]}
           onResponderMove={[Function]}
           onResponderRelease={[Function]}
           onResponderTerminate={[Function]}
           onResponderTerminationRequest={[Function]}
+          onSelectionChange={[Function]}
           onStartShouldSetResponder={[Function]}
-        >
-          <RCTAztecView
-            activeFormats={[]}
-            blockType={
-              {
-                "tag": "p",
-              }
+          placeholder="Add caption"
+          placeholderTextColor="gray"
+          selectionColor="black"
+          style={
+            {
+              "backgroundColor": undefined,
+              "maxWidth": undefined,
+              "minHeight": 0,
             }
-            deleteEnter={true}
-            disableEditingMenu={false}
-            fontFamily="serif"
-            fontSize={14}
-            isMultiline={false}
-            maxImagesWidth={200}
-            onBackspace={[Function]}
-            onBlur={[Function]}
-            onChange={[Function]}
-            onContentSizeChange={[Function]}
-            onEnter={[Function]}
-            onFocus={[Function]}
-            onHTMLContentWithCursor={[Function]}
-            onKeyDown={[Function]}
-            onPaste={[Function]}
-            onSelectionChange={[Function]}
-            placeholder="Add caption"
-            placeholderTextColor="gray"
-            selectionColor="black"
-            style={
-              {
-                "backgroundColor": undefined,
-                "maxWidth": undefined,
-                "minHeight": 0,
-              }
+          }
+          text={
+            {
+              "eventCount": undefined,
+              "linkTextColor": undefined,
+              "selection": null,
+              "tag": "p",
+              "text": "",
             }
-            text={
-              {
-                "eventCount": undefined,
-                "linkTextColor": undefined,
-                "selection": null,
-                "tag": "p",
-                "text": "",
-              }
-            }
-            textAlign="center"
-            triggerKeyCodes={[]}
-          />
-        </View>
+          }
+          textAlign="center"
+          triggerKeyCodes={[]}
+        />
       </View>
     </View>
   </View>
@@ -373,7 +359,7 @@ exports[`Audio block renders audio file without crashing 1`] = `
           ]
         }
       >
-        <View
+        <RCTAztecView
           accessibilityState={
             {
               "busy": undefined,
@@ -383,73 +369,59 @@ exports[`Audio block renders audio file without crashing 1`] = `
               "selected": undefined,
             }
           }
-          accessibilityValue={
+          accessible={true}
+          activeFormats={[]}
+          blockType={
             {
-              "max": undefined,
-              "min": undefined,
-              "now": undefined,
-              "text": undefined,
+              "tag": "p",
             }
           }
-          accessible={false}
-          collapsable={false}
+          deleteEnter={true}
+          disableEditingMenu={false}
           focusable={true}
+          fontFamily="serif"
+          fontSize={14}
+          isMultiline={false}
+          maxImagesWidth={200}
+          onBackspace={[Function]}
           onBlur={[Function]}
+          onChange={[Function]}
           onClick={[Function]}
+          onContentSizeChange={[Function]}
+          onEnter={[Function]}
           onFocus={[Function]}
+          onHTMLContentWithCursor={[Function]}
+          onKeyDown={[Function]}
+          onPaste={[Function]}
           onResponderGrant={[Function]}
           onResponderMove={[Function]}
           onResponderRelease={[Function]}
           onResponderTerminate={[Function]}
           onResponderTerminationRequest={[Function]}
+          onSelectionChange={[Function]}
           onStartShouldSetResponder={[Function]}
-        >
-          <RCTAztecView
-            activeFormats={[]}
-            blockType={
-              {
-                "tag": "p",
-              }
+          placeholder="Add caption"
+          placeholderTextColor="gray"
+          selectionColor="black"
+          style={
+            {
+              "backgroundColor": undefined,
+              "maxWidth": undefined,
+              "minHeight": 0,
             }
-            deleteEnter={true}
-            disableEditingMenu={false}
-            fontFamily="serif"
-            fontSize={14}
-            isMultiline={false}
-            maxImagesWidth={200}
-            onBackspace={[Function]}
-            onBlur={[Function]}
-            onChange={[Function]}
-            onContentSizeChange={[Function]}
-            onEnter={[Function]}
-            onFocus={[Function]}
-            onHTMLContentWithCursor={[Function]}
-            onKeyDown={[Function]}
-            onPaste={[Function]}
-            onSelectionChange={[Function]}
-            placeholder="Add caption"
-            placeholderTextColor="gray"
-            selectionColor="black"
-            style={
-              {
-                "backgroundColor": undefined,
-                "maxWidth": undefined,
-                "minHeight": 0,
-              }
+          }
+          text={
+            {
+              "eventCount": undefined,
+              "linkTextColor": undefined,
+              "selection": null,
+              "tag": "p",
+              "text": "",
             }
-            text={
-              {
-                "eventCount": undefined,
-                "linkTextColor": undefined,
-                "selection": null,
-                "tag": "p",
-                "text": "",
-              }
-            }
-            textAlign="center"
-            triggerKeyCodes={[]}
-          />
-        </View>
+          }
+          textAlign="center"
+          triggerKeyCodes={[]}
+        />
       </View>
     </View>
   </View>

--- a/packages/block-library/src/file/test/__snapshots__/edit.native.js.snap
+++ b/packages/block-library/src/file/test/__snapshots__/edit.native.js.snap
@@ -64,7 +64,7 @@ exports[`File block renders file error state without crashing 1`] = `
           ]
         }
       >
-        <View
+        <RCTAztecView
           accessibilityState={
             {
               "busy": undefined,
@@ -74,73 +74,59 @@ exports[`File block renders file error state without crashing 1`] = `
               "selected": undefined,
             }
           }
-          accessibilityValue={
+          accessible={true}
+          activeFormats={[]}
+          blockType={
             {
-              "max": undefined,
-              "min": undefined,
-              "now": undefined,
-              "text": undefined,
+              "tag": "p",
             }
           }
-          accessible={false}
-          collapsable={false}
+          deleteEnter={true}
+          disableEditingMenu={false}
           focusable={true}
+          fontFamily="serif"
+          fontSize={16}
+          isMultiline={false}
+          maxImagesWidth={200}
+          onBackspace={[Function]}
           onBlur={[Function]}
+          onChange={[Function]}
           onClick={[Function]}
+          onContentSizeChange={[Function]}
+          onEnter={[Function]}
           onFocus={[Function]}
+          onHTMLContentWithCursor={[Function]}
+          onKeyDown={[Function]}
+          onPaste={[Function]}
           onResponderGrant={[Function]}
           onResponderMove={[Function]}
           onResponderRelease={[Function]}
           onResponderTerminate={[Function]}
           onResponderTerminationRequest={[Function]}
+          onSelectionChange={[Function]}
           onStartShouldSetResponder={[Function]}
-        >
-          <RCTAztecView
-            activeFormats={[]}
-            blockType={
-              {
-                "tag": "p",
-              }
+          placeholder="File name"
+          placeholderTextColor="gray"
+          selectionColor="black"
+          style={
+            {
+              "backgroundColor": undefined,
+              "maxWidth": undefined,
+              "minHeight": 0,
             }
-            deleteEnter={true}
-            disableEditingMenu={false}
-            fontFamily="serif"
-            fontSize={16}
-            isMultiline={false}
-            maxImagesWidth={200}
-            onBackspace={[Function]}
-            onBlur={[Function]}
-            onChange={[Function]}
-            onContentSizeChange={[Function]}
-            onEnter={[Function]}
-            onFocus={[Function]}
-            onHTMLContentWithCursor={[Function]}
-            onKeyDown={[Function]}
-            onPaste={[Function]}
-            onSelectionChange={[Function]}
-            placeholder="File name"
-            placeholderTextColor="gray"
-            selectionColor="black"
-            style={
-              {
-                "backgroundColor": undefined,
-                "maxWidth": undefined,
-                "minHeight": 0,
-              }
+          }
+          text={
+            {
+              "eventCount": undefined,
+              "linkTextColor": undefined,
+              "selection": null,
+              "tag": "p",
+              "text": "<p>File name</p>",
             }
-            text={
-              {
-                "eventCount": undefined,
-                "linkTextColor": undefined,
-                "selection": null,
-                "tag": "p",
-                "text": "<p>File name</p>",
-              }
-            }
-            textAlign="left"
-            triggerKeyCodes={[]}
-          />
-        </View>
+          }
+          textAlign="left"
+          triggerKeyCodes={[]}
+        />
       </View>
       <View>
         <Svg
@@ -193,7 +179,7 @@ exports[`File block renders file error state without crashing 1`] = `
           ]
         }
       >
-        <View
+        <RCTAztecView
           accessibilityState={
             {
               "busy": undefined,
@@ -203,76 +189,62 @@ exports[`File block renders file error state without crashing 1`] = `
               "selected": undefined,
             }
           }
-          accessibilityValue={
+          accessible={true}
+          activeFormats={[]}
+          blockType={
             {
-              "max": undefined,
-              "min": undefined,
-              "now": undefined,
-              "text": undefined,
+              "tag": "p",
             }
           }
-          accessible={false}
-          collapsable={false}
+          color="white"
+          deleteEnter={true}
+          disableEditingMenu={false}
           focusable={true}
+          fontFamily="serif"
+          fontSize={16}
+          isMultiline={false}
+          maxImagesWidth={200}
+          minWidth={40}
+          onBackspace={[Function]}
           onBlur={[Function]}
+          onChange={[Function]}
           onClick={[Function]}
+          onContentSizeChange={[Function]}
+          onEnter={[Function]}
           onFocus={[Function]}
+          onHTMLContentWithCursor={[Function]}
+          onKeyDown={[Function]}
+          onPaste={[Function]}
           onResponderGrant={[Function]}
           onResponderMove={[Function]}
           onResponderRelease={[Function]}
           onResponderTerminate={[Function]}
           onResponderTerminationRequest={[Function]}
+          onSelectionChange={[Function]}
           onStartShouldSetResponder={[Function]}
-        >
-          <RCTAztecView
-            activeFormats={[]}
-            blockType={
-              {
-                "tag": "p",
-              }
+          placeholder=""
+          placeholderTextColor="white"
+          selectionColor="white"
+          style={
+            {
+              "backgroundColor": undefined,
+              "color": "white",
+              "maxWidth": 80,
+              "minHeight": 0,
             }
-            color="white"
-            deleteEnter={true}
-            disableEditingMenu={false}
-            fontFamily="serif"
-            fontSize={16}
-            isMultiline={false}
-            maxImagesWidth={200}
-            minWidth={40}
-            onBackspace={[Function]}
-            onBlur={[Function]}
-            onChange={[Function]}
-            onContentSizeChange={[Function]}
-            onEnter={[Function]}
-            onFocus={[Function]}
-            onHTMLContentWithCursor={[Function]}
-            onKeyDown={[Function]}
-            onPaste={[Function]}
-            onSelectionChange={[Function]}
-            placeholder=""
-            placeholderTextColor="white"
-            selectionColor="white"
-            style={
-              {
-                "backgroundColor": undefined,
-                "color": "white",
-                "maxWidth": 80,
-                "minHeight": 0,
-              }
+          }
+          text={
+            {
+              "eventCount": undefined,
+              "linkTextColor": undefined,
+              "selection": null,
+              "tag": "p",
+              "text": "<p>Download</p>",
             }
-            text={
-              {
-                "eventCount": undefined,
-                "linkTextColor": undefined,
-                "selection": null,
-                "tag": "p",
-                "text": "<p>Download</p>",
-              }
-            }
-            textAlign="center"
-            triggerKeyCodes={[]}
-          />
-        </View>
+          }
+          textAlign="center"
+          triggerKeyCodes={[]}
+        />
       </View>
     </View>
   </View>
@@ -343,7 +315,7 @@ exports[`File block renders file without crashing 1`] = `
           ]
         }
       >
-        <View
+        <RCTAztecView
           accessibilityState={
             {
               "busy": undefined,
@@ -353,73 +325,59 @@ exports[`File block renders file without crashing 1`] = `
               "selected": undefined,
             }
           }
-          accessibilityValue={
+          accessible={true}
+          activeFormats={[]}
+          blockType={
             {
-              "max": undefined,
-              "min": undefined,
-              "now": undefined,
-              "text": undefined,
+              "tag": "p",
             }
           }
-          accessible={false}
-          collapsable={false}
+          deleteEnter={true}
+          disableEditingMenu={false}
           focusable={true}
+          fontFamily="serif"
+          fontSize={16}
+          isMultiline={false}
+          maxImagesWidth={200}
+          onBackspace={[Function]}
           onBlur={[Function]}
+          onChange={[Function]}
           onClick={[Function]}
+          onContentSizeChange={[Function]}
+          onEnter={[Function]}
           onFocus={[Function]}
+          onHTMLContentWithCursor={[Function]}
+          onKeyDown={[Function]}
+          onPaste={[Function]}
           onResponderGrant={[Function]}
           onResponderMove={[Function]}
           onResponderRelease={[Function]}
           onResponderTerminate={[Function]}
           onResponderTerminationRequest={[Function]}
+          onSelectionChange={[Function]}
           onStartShouldSetResponder={[Function]}
-        >
-          <RCTAztecView
-            activeFormats={[]}
-            blockType={
-              {
-                "tag": "p",
-              }
+          placeholder="File name"
+          placeholderTextColor="gray"
+          selectionColor="black"
+          style={
+            {
+              "backgroundColor": undefined,
+              "maxWidth": undefined,
+              "minHeight": 0,
             }
-            deleteEnter={true}
-            disableEditingMenu={false}
-            fontFamily="serif"
-            fontSize={16}
-            isMultiline={false}
-            maxImagesWidth={200}
-            onBackspace={[Function]}
-            onBlur={[Function]}
-            onChange={[Function]}
-            onContentSizeChange={[Function]}
-            onEnter={[Function]}
-            onFocus={[Function]}
-            onHTMLContentWithCursor={[Function]}
-            onKeyDown={[Function]}
-            onPaste={[Function]}
-            onSelectionChange={[Function]}
-            placeholder="File name"
-            placeholderTextColor="gray"
-            selectionColor="black"
-            style={
-              {
-                "backgroundColor": undefined,
-                "maxWidth": undefined,
-                "minHeight": 0,
-              }
+          }
+          text={
+            {
+              "eventCount": undefined,
+              "linkTextColor": undefined,
+              "selection": null,
+              "tag": "p",
+              "text": "<p>File name</p>",
             }
-            text={
-              {
-                "eventCount": undefined,
-                "linkTextColor": undefined,
-                "selection": null,
-                "tag": "p",
-                "text": "<p>File name</p>",
-              }
-            }
-            textAlign="left"
-            triggerKeyCodes={[]}
-          />
-        </View>
+          }
+          textAlign="left"
+          triggerKeyCodes={[]}
+        />
       </View>
     </View>
     <View
@@ -446,7 +404,7 @@ exports[`File block renders file without crashing 1`] = `
           ]
         }
       >
-        <View
+        <RCTAztecView
           accessibilityState={
             {
               "busy": undefined,
@@ -456,76 +414,62 @@ exports[`File block renders file without crashing 1`] = `
               "selected": undefined,
             }
           }
-          accessibilityValue={
+          accessible={true}
+          activeFormats={[]}
+          blockType={
             {
-              "max": undefined,
-              "min": undefined,
-              "now": undefined,
-              "text": undefined,
+              "tag": "p",
             }
           }
-          accessible={false}
-          collapsable={false}
+          color="white"
+          deleteEnter={true}
+          disableEditingMenu={false}
           focusable={true}
+          fontFamily="serif"
+          fontSize={16}
+          isMultiline={false}
+          maxImagesWidth={200}
+          minWidth={40}
+          onBackspace={[Function]}
           onBlur={[Function]}
+          onChange={[Function]}
           onClick={[Function]}
+          onContentSizeChange={[Function]}
+          onEnter={[Function]}
           onFocus={[Function]}
+          onHTMLContentWithCursor={[Function]}
+          onKeyDown={[Function]}
+          onPaste={[Function]}
           onResponderGrant={[Function]}
           onResponderMove={[Function]}
           onResponderRelease={[Function]}
           onResponderTerminate={[Function]}
           onResponderTerminationRequest={[Function]}
+          onSelectionChange={[Function]}
           onStartShouldSetResponder={[Function]}
-        >
-          <RCTAztecView
-            activeFormats={[]}
-            blockType={
-              {
-                "tag": "p",
-              }
+          placeholder=""
+          placeholderTextColor="white"
+          selectionColor="white"
+          style={
+            {
+              "backgroundColor": undefined,
+              "color": "white",
+              "maxWidth": 80,
+              "minHeight": 0,
             }
-            color="white"
-            deleteEnter={true}
-            disableEditingMenu={false}
-            fontFamily="serif"
-            fontSize={16}
-            isMultiline={false}
-            maxImagesWidth={200}
-            minWidth={40}
-            onBackspace={[Function]}
-            onBlur={[Function]}
-            onChange={[Function]}
-            onContentSizeChange={[Function]}
-            onEnter={[Function]}
-            onFocus={[Function]}
-            onHTMLContentWithCursor={[Function]}
-            onKeyDown={[Function]}
-            onPaste={[Function]}
-            onSelectionChange={[Function]}
-            placeholder=""
-            placeholderTextColor="white"
-            selectionColor="white"
-            style={
-              {
-                "backgroundColor": undefined,
-                "color": "white",
-                "maxWidth": 80,
-                "minHeight": 0,
-              }
+          }
+          text={
+            {
+              "eventCount": undefined,
+              "linkTextColor": undefined,
+              "selection": null,
+              "tag": "p",
+              "text": "<p>Download</p>",
             }
-            text={
-              {
-                "eventCount": undefined,
-                "linkTextColor": undefined,
-                "selection": null,
-                "tag": "p",
-                "text": "<p>Download</p>",
-              }
-            }
-            textAlign="center"
-            triggerKeyCodes={[]}
-          />
-        </View>
+          }
+          textAlign="center"
+          triggerKeyCodes={[]}
+        />
       </View>
     </View>
   </View>

--- a/packages/block-library/src/search/test/__snapshots__/edit.native.js.snap
+++ b/packages/block-library/src/search/test/__snapshots__/edit.native.js.snap
@@ -19,7 +19,7 @@ exports[`Search Block renders block with button inside option 1`] = `
         ]
       }
     >
-      <View
+      <RCTAztecView
         accessibilityState={
           {
             "busy": undefined,
@@ -29,71 +29,57 @@ exports[`Search Block renders block with button inside option 1`] = `
             "selected": undefined,
           }
         }
-        accessibilityValue={
+        accessible={true}
+        activeFormats={[]}
+        blockType={
           {
-            "max": undefined,
-            "min": undefined,
-            "now": undefined,
-            "text": undefined,
+            "tag": "p",
           }
         }
-        accessible={false}
-        collapsable={false}
+        disableEditingMenu={false}
         focusable={true}
+        fontFamily="serif"
+        fontSize={16}
+        isMultiline={false}
+        maxImagesWidth={200}
+        onBackspace={[Function]}
         onBlur={[Function]}
+        onChange={[Function]}
         onClick={[Function]}
+        onContentSizeChange={[Function]}
+        onEnter={[Function]}
         onFocus={[Function]}
+        onHTMLContentWithCursor={[Function]}
+        onKeyDown={[Function]}
+        onPaste={[Function]}
         onResponderGrant={[Function]}
         onResponderMove={[Function]}
         onResponderRelease={[Function]}
         onResponderTerminate={[Function]}
         onResponderTerminationRequest={[Function]}
+        onSelectionChange={[Function]}
         onStartShouldSetResponder={[Function]}
-      >
-        <RCTAztecView
-          activeFormats={[]}
-          blockType={
-            {
-              "tag": "p",
-            }
+        placeholder="Add label…"
+        placeholderTextColor="gray"
+        selectionColor="black"
+        style={
+          {
+            "backgroundColor": undefined,
+            "maxWidth": undefined,
+            "minHeight": 0,
           }
-          disableEditingMenu={false}
-          fontFamily="serif"
-          fontSize={16}
-          isMultiline={false}
-          maxImagesWidth={200}
-          onBackspace={[Function]}
-          onBlur={[Function]}
-          onChange={[Function]}
-          onContentSizeChange={[Function]}
-          onEnter={[Function]}
-          onFocus={[Function]}
-          onHTMLContentWithCursor={[Function]}
-          onKeyDown={[Function]}
-          onPaste={[Function]}
-          onSelectionChange={[Function]}
-          placeholder="Add label…"
-          placeholderTextColor="gray"
-          selectionColor="black"
-          style={
-            {
-              "backgroundColor": undefined,
-              "maxWidth": undefined,
-              "minHeight": 0,
-            }
+        }
+        text={
+          {
+            "eventCount": undefined,
+            "linkTextColor": undefined,
+            "selection": null,
+            "tag": "p",
+            "text": "<p>Search</p>",
           }
-          text={
-            {
-              "eventCount": undefined,
-              "linkTextColor": undefined,
-              "selection": null,
-              "tag": "p",
-              "text": "<p>Search</p>",
-            }
-          }
-          triggerKeyCodes={[]}
-        />
-      </View>
+        }
+        triggerKeyCodes={[]}
+      />
     </View>
   </View>
   <View
@@ -158,7 +144,7 @@ exports[`Search Block renders block with button inside option 1`] = `
             ]
           }
         >
-          <View
+          <RCTAztecView
             accessibilityState={
               {
                 "busy": undefined,
@@ -168,73 +154,59 @@ exports[`Search Block renders block with button inside option 1`] = `
                 "selected": undefined,
               }
             }
-            accessibilityValue={
+            accessible={true}
+            activeFormats={[]}
+            blockType={
               {
-                "max": undefined,
-                "min": undefined,
-                "now": undefined,
-                "text": undefined,
+                "tag": "p",
               }
             }
-            accessible={false}
-            collapsable={false}
+            disableEditingMenu={false}
             focusable={true}
+            fontFamily="serif"
+            fontSize={16}
+            isMultiline={false}
+            maxImagesWidth={200}
+            minWidth={75}
+            onBackspace={[Function]}
             onBlur={[Function]}
+            onChange={[Function]}
             onClick={[Function]}
+            onContentSizeChange={[Function]}
+            onEnter={[Function]}
             onFocus={[Function]}
+            onHTMLContentWithCursor={[Function]}
+            onKeyDown={[Function]}
+            onPaste={[Function]}
             onResponderGrant={[Function]}
             onResponderMove={[Function]}
             onResponderRelease={[Function]}
             onResponderTerminate={[Function]}
             onResponderTerminationRequest={[Function]}
+            onSelectionChange={[Function]}
             onStartShouldSetResponder={[Function]}
-          >
-            <RCTAztecView
-              activeFormats={[]}
-              blockType={
-                {
-                  "tag": "p",
-                }
+            placeholder=""
+            placeholderTextColor="gray"
+            selectionColor="black"
+            style={
+              {
+                "backgroundColor": undefined,
+                "maxWidth": NaN,
+                "minHeight": 0,
               }
-              disableEditingMenu={false}
-              fontFamily="serif"
-              fontSize={16}
-              isMultiline={false}
-              maxImagesWidth={200}
-              minWidth={75}
-              onBackspace={[Function]}
-              onBlur={[Function]}
-              onChange={[Function]}
-              onContentSizeChange={[Function]}
-              onEnter={[Function]}
-              onFocus={[Function]}
-              onHTMLContentWithCursor={[Function]}
-              onKeyDown={[Function]}
-              onPaste={[Function]}
-              onSelectionChange={[Function]}
-              placeholder=""
-              placeholderTextColor="gray"
-              selectionColor="black"
-              style={
-                {
-                  "backgroundColor": undefined,
-                  "maxWidth": NaN,
-                  "minHeight": 0,
-                }
+            }
+            text={
+              {
+                "eventCount": undefined,
+                "linkTextColor": undefined,
+                "selection": null,
+                "tag": "p",
+                "text": "<p>Search Button</p>",
               }
-              text={
-                {
-                  "eventCount": undefined,
-                  "linkTextColor": undefined,
-                  "selection": null,
-                  "tag": "p",
-                  "text": "<p>Search Button</p>",
-                }
-              }
-              textAlign="center"
-              triggerKeyCodes={[]}
-            />
-          </View>
+            }
+            textAlign="center"
+            triggerKeyCodes={[]}
+          />
         </View>
       </View>
     </View>
@@ -261,7 +233,7 @@ exports[`Search Block renders block with icon button option matches snapshot 1`]
         ]
       }
     >
-      <View
+      <RCTAztecView
         accessibilityState={
           {
             "busy": undefined,
@@ -271,71 +243,57 @@ exports[`Search Block renders block with icon button option matches snapshot 1`]
             "selected": undefined,
           }
         }
-        accessibilityValue={
+        accessible={true}
+        activeFormats={[]}
+        blockType={
           {
-            "max": undefined,
-            "min": undefined,
-            "now": undefined,
-            "text": undefined,
+            "tag": "p",
           }
         }
-        accessible={false}
-        collapsable={false}
+        disableEditingMenu={false}
         focusable={true}
+        fontFamily="serif"
+        fontSize={16}
+        isMultiline={false}
+        maxImagesWidth={200}
+        onBackspace={[Function]}
         onBlur={[Function]}
+        onChange={[Function]}
         onClick={[Function]}
+        onContentSizeChange={[Function]}
+        onEnter={[Function]}
         onFocus={[Function]}
+        onHTMLContentWithCursor={[Function]}
+        onKeyDown={[Function]}
+        onPaste={[Function]}
         onResponderGrant={[Function]}
         onResponderMove={[Function]}
         onResponderRelease={[Function]}
         onResponderTerminate={[Function]}
         onResponderTerminationRequest={[Function]}
+        onSelectionChange={[Function]}
         onStartShouldSetResponder={[Function]}
-      >
-        <RCTAztecView
-          activeFormats={[]}
-          blockType={
-            {
-              "tag": "p",
-            }
+        placeholder="Add label…"
+        placeholderTextColor="gray"
+        selectionColor="black"
+        style={
+          {
+            "backgroundColor": undefined,
+            "maxWidth": undefined,
+            "minHeight": 0,
           }
-          disableEditingMenu={false}
-          fontFamily="serif"
-          fontSize={16}
-          isMultiline={false}
-          maxImagesWidth={200}
-          onBackspace={[Function]}
-          onBlur={[Function]}
-          onChange={[Function]}
-          onContentSizeChange={[Function]}
-          onEnter={[Function]}
-          onFocus={[Function]}
-          onHTMLContentWithCursor={[Function]}
-          onKeyDown={[Function]}
-          onPaste={[Function]}
-          onSelectionChange={[Function]}
-          placeholder="Add label…"
-          placeholderTextColor="gray"
-          selectionColor="black"
-          style={
-            {
-              "backgroundColor": undefined,
-              "maxWidth": undefined,
-              "minHeight": 0,
-            }
+        }
+        text={
+          {
+            "eventCount": undefined,
+            "linkTextColor": undefined,
+            "selection": null,
+            "tag": "p",
+            "text": "<p>Search</p>",
           }
-          text={
-            {
-              "eventCount": undefined,
-              "linkTextColor": undefined,
-              "selection": null,
-              "tag": "p",
-              "text": "<p>Search</p>",
-            }
-          }
-          triggerKeyCodes={[]}
-        />
-      </View>
+        }
+        triggerKeyCodes={[]}
+      />
     </View>
   </View>
   <View
@@ -470,7 +428,7 @@ exports[`Search Block renders block with label hidden matches snapshot 1`] = `
             ]
           }
         >
-          <View
+          <RCTAztecView
             accessibilityState={
               {
                 "busy": undefined,
@@ -480,73 +438,59 @@ exports[`Search Block renders block with label hidden matches snapshot 1`] = `
                 "selected": undefined,
               }
             }
-            accessibilityValue={
+            accessible={true}
+            activeFormats={[]}
+            blockType={
               {
-                "max": undefined,
-                "min": undefined,
-                "now": undefined,
-                "text": undefined,
+                "tag": "p",
               }
             }
-            accessible={false}
-            collapsable={false}
+            disableEditingMenu={false}
             focusable={true}
+            fontFamily="serif"
+            fontSize={16}
+            isMultiline={false}
+            maxImagesWidth={200}
+            minWidth={75}
+            onBackspace={[Function]}
             onBlur={[Function]}
+            onChange={[Function]}
             onClick={[Function]}
+            onContentSizeChange={[Function]}
+            onEnter={[Function]}
             onFocus={[Function]}
+            onHTMLContentWithCursor={[Function]}
+            onKeyDown={[Function]}
+            onPaste={[Function]}
             onResponderGrant={[Function]}
             onResponderMove={[Function]}
             onResponderRelease={[Function]}
             onResponderTerminate={[Function]}
             onResponderTerminationRequest={[Function]}
+            onSelectionChange={[Function]}
             onStartShouldSetResponder={[Function]}
-          >
-            <RCTAztecView
-              activeFormats={[]}
-              blockType={
-                {
-                  "tag": "p",
-                }
+            placeholder=""
+            placeholderTextColor="gray"
+            selectionColor="black"
+            style={
+              {
+                "backgroundColor": undefined,
+                "maxWidth": NaN,
+                "minHeight": 0,
               }
-              disableEditingMenu={false}
-              fontFamily="serif"
-              fontSize={16}
-              isMultiline={false}
-              maxImagesWidth={200}
-              minWidth={75}
-              onBackspace={[Function]}
-              onBlur={[Function]}
-              onChange={[Function]}
-              onContentSizeChange={[Function]}
-              onEnter={[Function]}
-              onFocus={[Function]}
-              onHTMLContentWithCursor={[Function]}
-              onKeyDown={[Function]}
-              onPaste={[Function]}
-              onSelectionChange={[Function]}
-              placeholder=""
-              placeholderTextColor="gray"
-              selectionColor="black"
-              style={
-                {
-                  "backgroundColor": undefined,
-                  "maxWidth": NaN,
-                  "minHeight": 0,
-                }
+            }
+            text={
+              {
+                "eventCount": undefined,
+                "linkTextColor": undefined,
+                "selection": null,
+                "tag": "p",
+                "text": "<p>Search Button</p>",
               }
-              text={
-                {
-                  "eventCount": undefined,
-                  "linkTextColor": undefined,
-                  "selection": null,
-                  "tag": "p",
-                  "text": "<p>Search Button</p>",
-                }
-              }
-              textAlign="center"
-              triggerKeyCodes={[]}
-            />
-          </View>
+            }
+            textAlign="center"
+            triggerKeyCodes={[]}
+          />
         </View>
       </View>
     </View>
@@ -573,7 +517,7 @@ exports[`Search Block renders with default configuration matches snapshot 1`] = 
         ]
       }
     >
-      <View
+      <RCTAztecView
         accessibilityState={
           {
             "busy": undefined,
@@ -583,71 +527,57 @@ exports[`Search Block renders with default configuration matches snapshot 1`] = 
             "selected": undefined,
           }
         }
-        accessibilityValue={
+        accessible={true}
+        activeFormats={[]}
+        blockType={
           {
-            "max": undefined,
-            "min": undefined,
-            "now": undefined,
-            "text": undefined,
+            "tag": "p",
           }
         }
-        accessible={false}
-        collapsable={false}
+        disableEditingMenu={false}
         focusable={true}
+        fontFamily="serif"
+        fontSize={16}
+        isMultiline={false}
+        maxImagesWidth={200}
+        onBackspace={[Function]}
         onBlur={[Function]}
+        onChange={[Function]}
         onClick={[Function]}
+        onContentSizeChange={[Function]}
+        onEnter={[Function]}
         onFocus={[Function]}
+        onHTMLContentWithCursor={[Function]}
+        onKeyDown={[Function]}
+        onPaste={[Function]}
         onResponderGrant={[Function]}
         onResponderMove={[Function]}
         onResponderRelease={[Function]}
         onResponderTerminate={[Function]}
         onResponderTerminationRequest={[Function]}
+        onSelectionChange={[Function]}
         onStartShouldSetResponder={[Function]}
-      >
-        <RCTAztecView
-          activeFormats={[]}
-          blockType={
-            {
-              "tag": "p",
-            }
+        placeholder="Add label…"
+        placeholderTextColor="gray"
+        selectionColor="black"
+        style={
+          {
+            "backgroundColor": undefined,
+            "maxWidth": undefined,
+            "minHeight": 0,
           }
-          disableEditingMenu={false}
-          fontFamily="serif"
-          fontSize={16}
-          isMultiline={false}
-          maxImagesWidth={200}
-          onBackspace={[Function]}
-          onBlur={[Function]}
-          onChange={[Function]}
-          onContentSizeChange={[Function]}
-          onEnter={[Function]}
-          onFocus={[Function]}
-          onHTMLContentWithCursor={[Function]}
-          onKeyDown={[Function]}
-          onPaste={[Function]}
-          onSelectionChange={[Function]}
-          placeholder="Add label…"
-          placeholderTextColor="gray"
-          selectionColor="black"
-          style={
-            {
-              "backgroundColor": undefined,
-              "maxWidth": undefined,
-              "minHeight": 0,
-            }
+        }
+        text={
+          {
+            "eventCount": undefined,
+            "linkTextColor": undefined,
+            "selection": null,
+            "tag": "p",
+            "text": "<p>Search</p>",
           }
-          text={
-            {
-              "eventCount": undefined,
-              "linkTextColor": undefined,
-              "selection": null,
-              "tag": "p",
-              "text": "<p>Search</p>",
-            }
-          }
-          triggerKeyCodes={[]}
-        />
-      </View>
+        }
+        triggerKeyCodes={[]}
+      />
     </View>
   </View>
   <View
@@ -712,7 +642,7 @@ exports[`Search Block renders with default configuration matches snapshot 1`] = 
             ]
           }
         >
-          <View
+          <RCTAztecView
             accessibilityState={
               {
                 "busy": undefined,
@@ -722,73 +652,59 @@ exports[`Search Block renders with default configuration matches snapshot 1`] = 
                 "selected": undefined,
               }
             }
-            accessibilityValue={
+            accessible={true}
+            activeFormats={[]}
+            blockType={
               {
-                "max": undefined,
-                "min": undefined,
-                "now": undefined,
-                "text": undefined,
+                "tag": "p",
               }
             }
-            accessible={false}
-            collapsable={false}
+            disableEditingMenu={false}
             focusable={true}
+            fontFamily="serif"
+            fontSize={16}
+            isMultiline={false}
+            maxImagesWidth={200}
+            minWidth={75}
+            onBackspace={[Function]}
             onBlur={[Function]}
+            onChange={[Function]}
             onClick={[Function]}
+            onContentSizeChange={[Function]}
+            onEnter={[Function]}
             onFocus={[Function]}
+            onHTMLContentWithCursor={[Function]}
+            onKeyDown={[Function]}
+            onPaste={[Function]}
             onResponderGrant={[Function]}
             onResponderMove={[Function]}
             onResponderRelease={[Function]}
             onResponderTerminate={[Function]}
             onResponderTerminationRequest={[Function]}
+            onSelectionChange={[Function]}
             onStartShouldSetResponder={[Function]}
-          >
-            <RCTAztecView
-              activeFormats={[]}
-              blockType={
-                {
-                  "tag": "p",
-                }
+            placeholder=""
+            placeholderTextColor="gray"
+            selectionColor="black"
+            style={
+              {
+                "backgroundColor": undefined,
+                "maxWidth": NaN,
+                "minHeight": 0,
               }
-              disableEditingMenu={false}
-              fontFamily="serif"
-              fontSize={16}
-              isMultiline={false}
-              maxImagesWidth={200}
-              minWidth={75}
-              onBackspace={[Function]}
-              onBlur={[Function]}
-              onChange={[Function]}
-              onContentSizeChange={[Function]}
-              onEnter={[Function]}
-              onFocus={[Function]}
-              onHTMLContentWithCursor={[Function]}
-              onKeyDown={[Function]}
-              onPaste={[Function]}
-              onSelectionChange={[Function]}
-              placeholder=""
-              placeholderTextColor="gray"
-              selectionColor="black"
-              style={
-                {
-                  "backgroundColor": undefined,
-                  "maxWidth": NaN,
-                  "minHeight": 0,
-                }
+            }
+            text={
+              {
+                "eventCount": undefined,
+                "linkTextColor": undefined,
+                "selection": null,
+                "tag": "p",
+                "text": "<p>Search Button</p>",
               }
-              text={
-                {
-                  "eventCount": undefined,
-                  "linkTextColor": undefined,
-                  "selection": null,
-                  "tag": "p",
-                  "text": "<p>Search Button</p>",
-                }
-              }
-              textAlign="center"
-              triggerKeyCodes={[]}
-            />
-          </View>
+            }
+            textAlign="center"
+            triggerKeyCodes={[]}
+          />
         </View>
       </View>
     </View>
@@ -815,7 +731,7 @@ exports[`Search Block renders with no-button option matches snapshot 1`] = `
         ]
       }
     >
-      <View
+      <RCTAztecView
         accessibilityState={
           {
             "busy": undefined,
@@ -825,71 +741,57 @@ exports[`Search Block renders with no-button option matches snapshot 1`] = `
             "selected": undefined,
           }
         }
-        accessibilityValue={
+        accessible={true}
+        activeFormats={[]}
+        blockType={
           {
-            "max": undefined,
-            "min": undefined,
-            "now": undefined,
-            "text": undefined,
+            "tag": "p",
           }
         }
-        accessible={false}
-        collapsable={false}
+        disableEditingMenu={false}
         focusable={true}
+        fontFamily="serif"
+        fontSize={16}
+        isMultiline={false}
+        maxImagesWidth={200}
+        onBackspace={[Function]}
         onBlur={[Function]}
+        onChange={[Function]}
         onClick={[Function]}
+        onContentSizeChange={[Function]}
+        onEnter={[Function]}
         onFocus={[Function]}
+        onHTMLContentWithCursor={[Function]}
+        onKeyDown={[Function]}
+        onPaste={[Function]}
         onResponderGrant={[Function]}
         onResponderMove={[Function]}
         onResponderRelease={[Function]}
         onResponderTerminate={[Function]}
         onResponderTerminationRequest={[Function]}
+        onSelectionChange={[Function]}
         onStartShouldSetResponder={[Function]}
-      >
-        <RCTAztecView
-          activeFormats={[]}
-          blockType={
-            {
-              "tag": "p",
-            }
+        placeholder="Add label…"
+        placeholderTextColor="gray"
+        selectionColor="black"
+        style={
+          {
+            "backgroundColor": undefined,
+            "maxWidth": undefined,
+            "minHeight": 0,
           }
-          disableEditingMenu={false}
-          fontFamily="serif"
-          fontSize={16}
-          isMultiline={false}
-          maxImagesWidth={200}
-          onBackspace={[Function]}
-          onBlur={[Function]}
-          onChange={[Function]}
-          onContentSizeChange={[Function]}
-          onEnter={[Function]}
-          onFocus={[Function]}
-          onHTMLContentWithCursor={[Function]}
-          onKeyDown={[Function]}
-          onPaste={[Function]}
-          onSelectionChange={[Function]}
-          placeholder="Add label…"
-          placeholderTextColor="gray"
-          selectionColor="black"
-          style={
-            {
-              "backgroundColor": undefined,
-              "maxWidth": undefined,
-              "minHeight": 0,
-            }
+        }
+        text={
+          {
+            "eventCount": undefined,
+            "linkTextColor": undefined,
+            "selection": null,
+            "tag": "p",
+            "text": "<p>Search</p>",
           }
-          text={
-            {
-              "eventCount": undefined,
-              "linkTextColor": undefined,
-              "selection": null,
-              "tag": "p",
-              "text": "<p>Search</p>",
-            }
-          }
-          triggerKeyCodes={[]}
-        />
-      </View>
+        }
+        triggerKeyCodes={[]}
+      />
     </View>
   </View>
   <View

--- a/packages/react-native-aztec/src/AztecView.js
+++ b/packages/react-native-aztec/src/AztecView.js
@@ -6,6 +6,7 @@ import {
 	UIManager,
 	Pressable,
 	Platform,
+	TouchableWithoutFeedback,
 } from 'react-native';
 
 /**
@@ -304,8 +305,17 @@ class AztecView extends Component {
 			delete style.fontSize;
 		}
 
+		// We need to use `Pressable` on iOS to avoid issues with VoiceOver and assistive
+		// input like the Braille Screen Input.
+		// More information about this can be found in https://github.com/WordPress/gutenberg/pull/53895.
+		const TouchableComponent =
+			Platform.OS === 'ios' ? Pressable : TouchableWithoutFeedback;
+
 		return (
-			<Pressable accessible={ false } onPress={ this._onPress }>
+			<TouchableComponent
+				accessible={ Platform.OS !== 'ios' }
+				onPress={ this._onPress }
+			>
 				<RCTAztecView
 					{ ...otherProps }
 					style={ style }
@@ -322,7 +332,7 @@ class AztecView extends Component {
 					onBlur={ this._onBlur }
 					ref={ this.aztecViewRef }
 				/>
-			</Pressable>
+			</TouchableComponent>
 		);
 	}
 }


### PR DESCRIPTION
**Related PRs:**
* https://github.com/wordpress-mobile/gutenberg-mobile/pull/6162

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

The PR fixes a regression on Android introduced in Gutenberg Mobile `1.103.0` that affects the `RichText` component. Specifically, the long-press gestures are not working. This means that some of the text input functionalities like opening the context menu to copy/paste content, as well as moving the caret, are not available.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Fixes https://github.com/WordPress/gutenberg/issues/54210.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

In https://github.com/WordPress/gutenberg/pull/53895, we replaced the touchable component (`TouchableWithoutFeedback`) used in the Aztec view to address an accessibility issue on iOS. The new touchable component used (`Pressable`) seems to be absorbing the long-press gestures and therefore preventing some of the text input functionality. As a workaround, this PR uses a different touchable component based on the platform:
- Android: `TouchableWithoutFeedback` _(Previous component)_
- iOS: `Pressable`

Eventually, we should remove the touchable component and implement the `onPress` event directly in the Aztec native component.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

**PRs with installable builds:**
* https://github.com/wordpress-mobile/WordPress-Android/pull/19142
* https://github.com/wordpress-mobile/WordPress-iOS/pull/21500

### Long-press gestures work on Android
1. In the Android app, open/create a post.
2. Add a Paragraph block.
3. Select the Paragraph block.
4. Long-press over the block.
5. Observe that the context menu that allows copy/paste is not displayed.
6. Type some text in the paragraph.
7. Long-press over a word.
8. Observe that the word gets selected.

### Accessibility works on Android
**Preparation:**
Go to TalkBack configuration and enable Braille input _(Configuration/Accessibility/TalkBack/Settings/Braille keyboard)_.

1. In the Android app, open/create a post.
2. Add a Paragraph block.
3. Enable TalkBack.
4. Use TalkBack to focus the text input.
5. Use the Braille keyboard to insert some characters.
6. Close the Braille keyboard and observe that the text has been modified.

### Accessibility works on iOS
Follow testing instructions from https://github.com/WordPress/gutenberg/pull/53895 to verify that no regressions are introduced.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
N/A

## Screenshots or screencast <!-- if applicable -->

| Long-press gestures fix | TalkBack usage |
|--------|--------|
| <video src=https://github.com/WordPress/gutenberg/assets/14905380/d5baf0e6-ed9a-4f7f-92fc-5e4b2ec06477> | <video src=https://github.com/WordPress/gutenberg/assets/14905380/597a6469-e398-4ce1-94fb-53138b047189> | 