### PR TITLE
Navigation: Add the navigation selector to the block toolbar

### DIFF
--- a/packages/block-library/src/navigation/edit/menu-inspector-controls.js
+++ b/packages/block-library/src/navigation/edit/menu-inspector-controls.js
@@ -161,32 +161,34 @@ const MenuInspectorControls = ( props ) => {
 					>
 						{ __( 'Menu' ) }
 					</Heading>
-					{ navigationMenus && navigationMenus.length > 1 && (
-						<BlockControls group="inline">
-							<NavigationMenuSelector
-								currentMenuId={ currentMenuId }
-								onSelectClassicMenu={ onSelectClassicMenu }
-								onSelectNavigationMenu={
-									onSelectNavigationMenu
-								}
-								onCreateNew={ onCreateNew }
-								createNavigationMenuIsSuccess={
-									createNavigationMenuIsSuccess
-								}
-								createNavigationMenuIsError={
-									createNavigationMenuIsError
-								}
-								actionLabel={ actionLabel }
-								isManageMenusButtonDisabled={
-									isManageMenusButtonDisabled
-								}
-								ariaLabel={ __( 'Choose Navigation Menu' ) }
-								icon={ chevronDown }
-								text={ currentTitle }
-								toggleProps={ { iconPosition: 'right' } }
-							/>
-						</BlockControls>
-					) }
+					{ currentTitle &&
+						navigationMenus &&
+						navigationMenus.length > 1 && (
+							<BlockControls group="inline">
+								<NavigationMenuSelector
+									currentMenuId={ currentMenuId }
+									onSelectClassicMenu={ onSelectClassicMenu }
+									onSelectNavigationMenu={
+										onSelectNavigationMenu
+									}
+									onCreateNew={ onCreateNew }
+									createNavigationMenuIsSuccess={
+										createNavigationMenuIsSuccess
+									}
+									createNavigationMenuIsError={
+										createNavigationMenuIsError
+									}
+									actionLabel={ actionLabel }
+									isManageMenusButtonDisabled={
+										isManageMenusButtonDisabled
+									}
+									ariaLabel={ __( 'Choose Navigation Menu' ) }
+									icon={ chevronDown }
+									text={ currentTitle }
+									toggleProps={ { iconPosition: 'right' } }
+								/>
+							</BlockControls>
+						) }
 
 					{ blockEditingMode === 'default' && (
 						<NavigationMenuSelector

--- a/packages/block-library/src/navigation/edit/menu-inspector-controls.js
+++ b/packages/block-library/src/navigation/edit/menu-inspector-controls.js
@@ -13,6 +13,7 @@ import {
 	__experimentalHeading as Heading,
 	Spinner,
 } from '@wordpress/components';
+import { useEntityProp } from '@wordpress/core-data';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { __, sprintf } from '@wordpress/i18n';
 import { chevronDown, moreVertical } from '@wordpress/icons';
@@ -142,6 +143,14 @@ const MenuInspectorControls = ( props ) => {
 		blockEditingMode,
 	} = props;
 
+	const [ currentTitle ] = useEntityProp(
+		'postType',
+		'wp_navigation',
+		'title'
+	);
+
+	const { navigationMenus } = useNavigationMenu();
+
 	return (
 		<InspectorControls group="list">
 			<PanelBody title={ null }>
@@ -152,27 +161,33 @@ const MenuInspectorControls = ( props ) => {
 					>
 						{ __( 'Menu' ) }
 					</Heading>
-					<BlockControls group="inline">
-						<NavigationMenuSelector
-							currentMenuId={ currentMenuId }
-							onSelectClassicMenu={ onSelectClassicMenu }
-							onSelectNavigationMenu={ onSelectNavigationMenu }
-							onCreateNew={ onCreateNew }
-							createNavigationMenuIsSuccess={
-								createNavigationMenuIsSuccess
-							}
-							createNavigationMenuIsError={
-								createNavigationMenuIsError
-							}
-							actionLabel={ actionLabel }
-							isManageMenusButtonDisabled={
-								isManageMenusButtonDisabled
-							}
-							icon={ chevronDown }
-							text={ __( 'Change' ) }
-							toggleProps={ { iconPosition: 'right' } }
-						/>
-					</BlockControls>
+					{ navigationMenus && navigationMenus.length > 1 && (
+						<BlockControls group="inline">
+							<NavigationMenuSelector
+								currentMenuId={ currentMenuId }
+								onSelectClassicMenu={ onSelectClassicMenu }
+								onSelectNavigationMenu={
+									onSelectNavigationMenu
+								}
+								onCreateNew={ onCreateNew }
+								createNavigationMenuIsSuccess={
+									createNavigationMenuIsSuccess
+								}
+								createNavigationMenuIsError={
+									createNavigationMenuIsError
+								}
+								actionLabel={ actionLabel }
+								isManageMenusButtonDisabled={
+									isManageMenusButtonDisabled
+								}
+								ariaLabel={ __( 'Choose Navigation Menu' ) }
+								icon={ chevronDown }
+								text={ currentTitle }
+								toggleProps={ { iconPosition: 'right' } }
+							/>
+						</BlockControls>
+					) }
+
 					{ blockEditingMode === 'default' && (
 						<NavigationMenuSelector
 							currentMenuId={ currentMenuId }
@@ -189,6 +204,7 @@ const MenuInspectorControls = ( props ) => {
 							isManageMenusButtonDisabled={
 								isManageMenusButtonDisabled
 							}
+							ariaLabel={ currentTitle }
 							icon={ moreVertical }
 							toggleProps={ { isSmall: 'true' } }
 						/>

--- a/packages/block-library/src/navigation/edit/menu-inspector-controls.js
+++ b/packages/block-library/src/navigation/edit/menu-inspector-controls.js
@@ -5,6 +5,7 @@ import {
 	privateApis as blockEditorPrivateApis,
 	InspectorControls,
 	store as blockEditorStore,
+	BlockControls,
 } from '@wordpress/block-editor';
 import {
 	PanelBody,
@@ -14,6 +15,7 @@ import {
 } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { __, sprintf } from '@wordpress/i18n';
+import { chevronDown, moreVertical } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -150,6 +152,27 @@ const MenuInspectorControls = ( props ) => {
 					>
 						{ __( 'Menu' ) }
 					</Heading>
+					<BlockControls group="inline">
+						<NavigationMenuSelector
+							currentMenuId={ currentMenuId }
+							onSelectClassicMenu={ onSelectClassicMenu }
+							onSelectNavigationMenu={ onSelectNavigationMenu }
+							onCreateNew={ onCreateNew }
+							createNavigationMenuIsSuccess={
+								createNavigationMenuIsSuccess
+							}
+							createNavigationMenuIsError={
+								createNavigationMenuIsError
+							}
+							actionLabel={ actionLabel }
+							isManageMenusButtonDisabled={
+								isManageMenusButtonDisabled
+							}
+							icon={ chevronDown }
+							text={ __( 'Change' ) }
+							toggleProps={ { iconPosition: 'right' } }
+						/>
+					</BlockControls>
 					{ blockEditingMode === 'default' && (
 						<NavigationMenuSelector
 							currentMenuId={ currentMenuId }
@@ -166,6 +189,8 @@ const MenuInspectorControls = ( props ) => {
 							isManageMenusButtonDisabled={
 								isManageMenusButtonDisabled
 							}
+							icon={ moreVertical }
+							toggleProps={ { isSmall: 'true' } }
 						/>
 					) }
 				</HStack>

--- a/packages/block-library/src/navigation/edit/navigation-menu-selector.js
+++ b/packages/block-library/src/navigation/edit/navigation-menu-selector.js
@@ -10,7 +10,6 @@ import {
 import { __, sprintf } from '@wordpress/i18n';
 import { decodeEntities } from '@wordpress/html-entities';
 import { useEffect, useMemo, useState } from '@wordpress/element';
-import { useEntityProp } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
@@ -44,6 +43,7 @@ function NavigationMenuSelector( {
 	actionLabel,
 	createNavigationMenuIsSuccess,
 	createNavigationMenuIsError,
+	ariaLabel,
 	icon,
 	text = '',
 	toggleProps,
@@ -64,12 +64,6 @@ function NavigationMenuSelector( {
 		canUserCreateNavigationMenu,
 		canSwitchNavigationMenu,
 	} = useNavigationMenu();
-
-	const [ currentTitle ] = useEntityProp(
-		'postType',
-		'wp_navigation',
-		'title'
-	);
 
 	const menuChoices = useMemo( () => {
 		return (
@@ -100,15 +94,18 @@ function NavigationMenuSelector( {
 		hasResolvedNavigationMenus && currentMenuId === null;
 
 	let selectorLabel = '';
-
+	let selectorText = '';
 	if ( isCreatingMenu || isResolvingNavigationMenus ) {
-		selectorLabel = __( 'Loading…' );
+		selectorLabel = selectorText = __( 'Loading…' );
 	} else if ( noMenuSelected || noBlockMenus || menuUnavailable ) {
 		// Note: classic Menus may be available.
-		selectorLabel = __( 'Choose or create a Navigation menu' );
+		selectorLabel = selectorText = __(
+			'Choose or create a Navigation menu'
+		);
 	} else {
 		// Current Menu's title.
-		selectorLabel = currentTitle;
+		selectorLabel = ariaLabel;
+		selectorText = text;
 	}
 
 	useEffect( () => {
@@ -134,7 +131,7 @@ function NavigationMenuSelector( {
 			label={ selectorLabel }
 			icon={ icon }
 			toggleProps={ toggleProps }
-			text={ text }
+			text={ selectorText }
 		>
 			{ ( { onClose } ) => (
 				<>

--- a/packages/block-library/src/navigation/edit/navigation-menu-selector.js
+++ b/packages/block-library/src/navigation/edit/navigation-menu-selector.js
@@ -5,9 +5,8 @@ import {
 	MenuGroup,
 	MenuItem,
 	MenuItemsChoice,
-	DropdownMenu,
+	ToolbarDropdownMenu,
 } from '@wordpress/components';
-import { moreVertical } from '@wordpress/icons';
 import { __, sprintf } from '@wordpress/i18n';
 import { decodeEntities } from '@wordpress/html-entities';
 import { useEffect, useMemo, useState } from '@wordpress/element';
@@ -45,6 +44,9 @@ function NavigationMenuSelector( {
 	actionLabel,
 	createNavigationMenuIsSuccess,
 	createNavigationMenuIsError,
+	icon,
+	text = '',
+	toggleProps,
 } ) {
 	/* translators: %s: The name of a menu. */
 	const createActionLabel = __( "Create from '%s'" );
@@ -128,10 +130,11 @@ function NavigationMenuSelector( {
 	] );
 
 	const NavigationMenuSelectorDropdown = (
-		<DropdownMenu
+		<ToolbarDropdownMenu
 			label={ selectorLabel }
-			icon={ moreVertical }
-			toggleProps={ { isSmall: true } }
+			icon={ icon }
+			toggleProps={ toggleProps }
+			text={ text }
 		>
 			{ ( { onClose } ) => (
 				<>
@@ -190,7 +193,7 @@ function NavigationMenuSelector( {
 					) }
 				</>
 			) }
-		</DropdownMenu>
+		</ToolbarDropdownMenu>
 	);
 
 	return NavigationMenuSelectorDropdown;


### PR DESCRIPTION
## What?
This surfaces the interface for changing the active navigation to the block toolbar.

Closes https://github.com/WordPress/gutenberg/issues/37068

## Why?
This makes it easier for users to change the currently active navigation in the block.

## How?
- Adds the component to `<BlockControls>`
- Adds three new props to the NavigationMenuSelector component so that we can reuse the same component.

## Testing Instructions
1. Add a Navigation block
2. Select the block
3. Confirm that you see a "Change" button in the toolbar and that it allows you to change the currently active navigation and create a new one.

### Testing Instructions for Keyboard
1. Insert/select a navigation block
2. Press alt+F10 to move to the block toolbar
3. Use the arrow keys to select the "Change" button
4. Press enter to open the Drop down
5. Press arrow down to select a different navigation
6. Press enter to make the change

## Screenshots or screencast <!-- if applicable -->
<img width="616" alt="Screenshot 2023-09-06 at 11 47 49" src="https://github.com/WordPress/gutenberg/assets/275961/be206a30-c74b-486c-a653-7188d16c19c4">

## Notes
This needs some design feedback:
1. Is the chevron the correct icon?
8. Is "Change" the correct text?