### PR TITLE
Add aspect ratio to image placeholder

### DIFF
--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -111,6 +111,8 @@ export function ImageEdit( {
 		width,
 		height,
 		sizeSlug,
+		aspectRatio,
+		scale,
 	} = attributes;
 	const [ temporaryURL, setTemporaryURL ] = useState();
 
@@ -335,7 +337,16 @@ export function ImageEdit( {
 				instructions={ __(
 					'Upload an image file, pick one from your media library, or add one with a URL.'
 				) }
-				style={ isSelected ? undefined : borderProps.style }
+				style={ {
+					aspectRatio:
+						! ( width && height ) && aspectRatio
+							? aspectRatio
+							: undefined,
+					width: height && aspectRatio ? '100%' : width,
+					height: width && aspectRatio ? '100%' : height,
+					objectFit: scale,
+					...borderProps.style,
+				} }
 			>
 				{ content }
 			</Placeholder>
@@ -344,23 +355,21 @@ export function ImageEdit( {
 
 	return (
 		<figure { ...blockProps }>
-			{ ( temporaryURL || url ) && (
-				<Image
-					temporaryURL={ temporaryURL }
-					attributes={ attributes }
-					setAttributes={ setAttributes }
-					isSelected={ isSelected }
-					insertBlocksAfter={ insertBlocksAfter }
-					onReplace={ onReplace }
-					onSelectImage={ onSelectImage }
-					onSelectURL={ onSelectURL }
-					onUploadError={ onUploadError }
-					containerRef={ ref }
-					context={ context }
-					clientId={ clientId }
-					blockEditingMode={ blockEditingMode }
-				/>
-			) }
+			<Image
+				temporaryURL={ temporaryURL }
+				attributes={ attributes }
+				setAttributes={ setAttributes }
+				isSelected={ isSelected }
+				insertBlocksAfter={ insertBlocksAfter }
+				onReplace={ onReplace }
+				onSelectImage={ onSelectImage }
+				onSelectURL={ onSelectURL }
+				onUploadError={ onUploadError }
+				containerRef={ ref }
+				context={ context }
+				clientId={ clientId }
+				blockEditingMode={ blockEditingMode }
+			/>
 			{ ! url && blockEditingMode === 'default' && (
 				<BlockControls group="block">
 					<BlockAlignmentControl

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -408,11 +408,6 @@ export default function Image( {
 						unitsOptions={ dimensionsUnitsOptions }
 					/>
 				) }
-				<ResolutionTool
-					value={ sizeSlug }
-					onChange={ updateImage }
-					options={ imageSizeOptions }
-				/>
 			</ToolsPanel>
 		</InspectorControls>
 	);

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -365,6 +365,58 @@ export default function Image( {
 		availableUnits: [ 'px' ],
 	} );
 
+	const sizeControls = (
+		<InspectorControls>
+			<ToolsPanel
+				label={ __( 'Settings' ) }
+				resetAll={ () =>
+					setAttributes( {
+						width: undefined,
+						height: undefined,
+						scale: undefined,
+						aspectRatio: undefined,
+					} )
+				}
+			>
+				{ isResizable && (
+					<DimensionsTool
+						value={ { width, height, scale, aspectRatio } }
+						onChange={ ( {
+							width: newWidth,
+							height: newHeight,
+							scale: newScale,
+							aspectRatio: newAspectRatio,
+						} ) => {
+							// Rebuilding the object forces setting `undefined`
+							// for values that are removed since setAttributes
+							// doesn't do anything with keys that aren't set.
+							setAttributes( {
+								// CSS includes `height: auto`, but we need
+								// `width: auto` to fix the aspect ratio when
+								// only height is set due to the width and
+								// height attributes set via the server.
+								width:
+									! newWidth && newHeight ? 'auto' : newWidth,
+								height: newHeight,
+								scale: newScale,
+								aspectRatio: newAspectRatio,
+							} );
+						} }
+						defaultScale="cover"
+						defaultAspectRatio="auto"
+						scaleOptions={ scaleOptions }
+						unitsOptions={ dimensionsUnitsOptions }
+					/>
+				) }
+				<ResolutionTool
+					value={ sizeSlug }
+					onChange={ updateImage }
+					options={ imageSizeOptions }
+				/>
+			</ToolsPanel>
+		</InspectorControls>
+	);
+
 	const controls = (
 		<>
 			<BlockControls group="block">
@@ -724,6 +776,10 @@ export default function Image( {
 				{ img }
 			</ResizableBox>
 		);
+	}
+
+	if ( ! url && ! temporaryURL ) {
+		return sizeControls;
 	}
 
 	return (

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -365,49 +365,49 @@ export default function Image( {
 		availableUnits: [ 'px' ],
 	} );
 
+	const dimensionsControl = (
+		<DimensionsTool
+			value={ { width, height, scale, aspectRatio } }
+			onChange={ ( {
+				width: newWidth,
+				height: newHeight,
+				scale: newScale,
+				aspectRatio: newAspectRatio,
+			} ) => {
+				// Rebuilding the object forces setting `undefined`
+				// for values that are removed since setAttributes
+				// doesn't do anything with keys that aren't set.
+				setAttributes( {
+					// CSS includes `height: auto`, but we need
+					// `width: auto` to fix the aspect ratio when
+					// only height is set due to the width and
+					// height attributes set via the server.
+					width: ! newWidth && newHeight ? 'auto' : newWidth,
+					height: newHeight,
+					scale: newScale,
+					aspectRatio: newAspectRatio,
+				} );
+			} }
+			defaultScale="cover"
+			defaultAspectRatio="auto"
+			scaleOptions={ scaleOptions }
+			unitsOptions={ dimensionsUnitsOptions }
+		/>
+	);
+
+	const resetAll = () => {
+		setAttributes( {
+			width: undefined,
+			height: undefined,
+			scale: undefined,
+			aspectRatio: undefined,
+		} );
+	};
+
 	const sizeControls = (
 		<InspectorControls>
-			<ToolsPanel
-				label={ __( 'Settings' ) }
-				resetAll={ () =>
-					setAttributes( {
-						width: undefined,
-						height: undefined,
-						scale: undefined,
-						aspectRatio: undefined,
-					} )
-				}
-			>
-				{ isResizable && (
-					<DimensionsTool
-						value={ { width, height, scale, aspectRatio } }
-						onChange={ ( {
-							width: newWidth,
-							height: newHeight,
-							scale: newScale,
-							aspectRatio: newAspectRatio,
-						} ) => {
-							// Rebuilding the object forces setting `undefined`
-							// for values that are removed since setAttributes
-							// doesn't do anything with keys that aren't set.
-							setAttributes( {
-								// CSS includes `height: auto`, but we need
-								// `width: auto` to fix the aspect ratio when
-								// only height is set due to the width and
-								// height attributes set via the server.
-								width:
-									! newWidth && newHeight ? 'auto' : newWidth,
-								height: newHeight,
-								scale: newScale,
-								aspectRatio: newAspectRatio,
-							} );
-						} }
-						defaultScale="cover"
-						defaultAspectRatio="auto"
-						scaleOptions={ scaleOptions }
-						unitsOptions={ dimensionsUnitsOptions }
-					/>
-				) }
+			<ToolsPanel label={ __( 'Settings' ) } resetAll={ resetAll }>
+				{ isResizable && dimensionsControl }
 			</ToolsPanel>
 		</InspectorControls>
 	);
@@ -490,17 +490,7 @@ export default function Image( {
 				</BlockControls>
 			) }
 			<InspectorControls>
-				<ToolsPanel
-					label={ __( 'Settings' ) }
-					resetAll={ () =>
-						setAttributes( {
-							width: undefined,
-							height: undefined,
-							scale: undefined,
-							aspectRatio: undefined,
-						} )
-					}
-				>
+				<ToolsPanel label={ __( 'Settings' ) } resetAll={ resetAll }>
 					{ ! multiImageSelection && (
 						<ToolsPanelItem
 							label={ __( 'Alternative text' ) }
@@ -529,38 +519,7 @@ export default function Image( {
 							/>
 						</ToolsPanelItem>
 					) }
-					{ isResizable && (
-						<DimensionsTool
-							value={ { width, height, scale, aspectRatio } }
-							onChange={ ( {
-								width: newWidth,
-								height: newHeight,
-								scale: newScale,
-								aspectRatio: newAspectRatio,
-							} ) => {
-								// Rebuilding the object forces setting `undefined`
-								// for values that are removed since setAttributes
-								// doesn't do anything with keys that aren't set.
-								setAttributes( {
-									// CSS includes `height: auto`, but we need
-									// `width: auto` to fix the aspect ratio when
-									// only height is set due to the width and
-									// height attributes set via the server.
-									width:
-										! newWidth && newHeight
-											? 'auto'
-											: newWidth,
-									height: newHeight,
-									scale: newScale,
-									aspectRatio: newAspectRatio,
-								} );
-							} }
-							defaultScale="cover"
-							defaultAspectRatio="auto"
-							scaleOptions={ scaleOptions }
-							unitsOptions={ dimensionsUnitsOptions }
-						/>
-					) }
+					{ isResizable && dimensionsControl }
 					<ResolutionTool
 						value={ sizeSlug }
 						onChange={ updateImage }

--- a/packages/components/src/placeholder/index.tsx
+++ b/packages/components/src/placeholder/index.tsx
@@ -75,6 +75,7 @@ export function Placeholder(
 	const fieldsetClasses = classnames( 'components-placeholder__fieldset', {
 		'is-column-layout': isColumnLayout,
 	} );
+
 	return (
 		<div { ...additionalProps } className={ classes }>
 			{ withIllustration ? PlaceholderIllustration : null }

--- a/packages/components/src/placeholder/style.scss
+++ b/packages/components/src/placeholder/style.scss
@@ -16,7 +16,7 @@
 	@supports (position: sticky) {
 		display: flex;
 		flex-direction: column;
-		justify-content: center;
+		justify-content: top;
 		align-items: flex-start;
 	}
 

--- a/packages/components/src/placeholder/style.scss
+++ b/packages/components/src/placeholder/style.scss
@@ -3,7 +3,6 @@
 	box-sizing: border-box;
 	position: relative;
 	padding: 1em;
-	min-height: 200px;
 	width: 100%;
 	text-align: left;
 	margin: 0;
@@ -180,7 +179,6 @@
 	color: inherit;
 	display: flex;
 	box-shadow: none;
-	min-width: 100px;
 
 	// Blur the background so layered dashed placeholders are still visually separate.
 	// Make the background transparent to not interfere with the background overlay in placeholder-style() pseudo element
@@ -225,7 +223,7 @@
 
 	// By painting the borders here, we enable them to be replaced by the Border control.
 	@include placeholder-style();
-	overflow: hidden;
+	overflow: auto;
 }
 
 // Position the spinner.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Closes #48081

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

To make placeholders better for layout construction.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

1. Adds the aspect ratio and size controls to image placeholder.
2. Style the placeholder to represent the setup (size and aspect ratio)

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. In a post or page
2. Insert an image
3. In the inspector you should see size and aspect ratio controls
4. Set them up
5. The placeholder should resize to reflect the changes
6. Add an image
7. The image should maintain the size and aspect ratio

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

N/A

## Screenshots or screencast <!-- if applicable -->


https://github.com/WordPress/gutenberg/assets/107534/17e7ebdb-d33a-4edd-b123-d1cd2894ca51


