### PR TITLE
[Mobile] Set the Gutenberg version from the host apps

### DIFF
--- a/packages/editor/src/components/provider/index.native.js
+++ b/packages/editor/src/components/provider/index.native.js
@@ -94,6 +94,7 @@ class NativeEditorProvider extends Component {
 	componentDidMount() {
 		const {
 			capabilities,
+			gutenbergVersion,
 			locale,
 			hostAppNamespace,
 			updateEditorSettings,
@@ -105,6 +106,7 @@ class NativeEditorProvider extends Component {
 			...this.getThemeColors( this.props ),
 			locale,
 			hostAppNamespace,
+			gutenbergVersion,
 		} );
 
 		this.subscriptionParentGetHtml = subscribeParentGetHtml( () => {
@@ -152,14 +154,19 @@ class NativeEditorProvider extends Component {
 
 		this.subscriptionParentUpdateEditorSettings =
 			subscribeUpdateEditorSettings(
-				( { galleryWithImageBlocks, ...editorSettings } ) => {
+				( {
+					galleryWithImageBlocks,
+					gutenbergVersion: updatedGutenbergVersion,
+					...editorSettings
+				} ) => {
 					if ( typeof galleryWithImageBlocks === 'boolean' ) {
 						window.wp.galleryBlockV2Enabled =
 							galleryWithImageBlocks;
 					}
-					updateEditorSettings(
-						this.getThemeColors( editorSettings )
-					);
+					updateEditorSettings( {
+						gutenbergVersion: updatedGutenbergVersion,
+						...this.getThemeColors( editorSettings ),
+					} );
 				}
 			);
 

--- a/packages/react-native-bridge/android/react-native-bridge/src/main/java/org/wordpress/mobile/ReactNativeGutenbergBridge/RNReactNativeGutenbergBridgeModule.java
+++ b/packages/react-native-bridge/android/react-native-bridge/src/main/java/org/wordpress/mobile/ReactNativeGutenbergBridge/RNReactNativeGutenbergBridgeModule.java
@@ -72,6 +72,7 @@ public class RNReactNativeGutenbergBridgeModule extends ReactContextBaseJavaModu
     private static final String MAP_KEY_THEME_UPDATE_RAW_STYLES = "rawStyles";
     private static final String MAP_KEY_THEME_UPDATE_RAW_FEATURES = "rawFeatures";
     private static final String MAP_KEY_GALLERY_WITH_IMAGE_BLOCKS = "galleryWithImageBlocks";
+    private static final String MAP_KEY_GUTENBERG_VERSION = "gutenbergVersion";
     public static final String MAP_KEY_MEDIA_FINAL_SAVE_RESULT_SUCCESS_VALUE = "success";
 
     private static final String MAP_KEY_IS_PREFERRED_COLOR_SCHEME_DARK = "isPreferredColorSchemeDark";
@@ -161,6 +162,7 @@ public class RNReactNativeGutenbergBridgeModule extends ReactContextBaseJavaModu
         Serializable gradients = editorTheme.getSerializable(MAP_KEY_THEME_UPDATE_GRADIENTS);
         Serializable rawStyles = editorTheme.getSerializable(MAP_KEY_THEME_UPDATE_RAW_STYLES);
         Serializable rawFeatures = editorTheme.getSerializable(MAP_KEY_THEME_UPDATE_RAW_FEATURES);
+        Serializable gutenbergVersion = editorTheme.getSerializable(MAP_KEY_GUTENBERG_VERSION);
 
         // We must assign null here to distinguish between a missing value and false
         Boolean galleryWithImageBlocks = null;
@@ -187,6 +189,10 @@ public class RNReactNativeGutenbergBridgeModule extends ReactContextBaseJavaModu
 
         if (galleryWithImageBlocks != null) {
             writableMap.putBoolean(MAP_KEY_GALLERY_WITH_IMAGE_BLOCKS, galleryWithImageBlocks);
+        }
+
+        if (gutenbergVersion != null) {
+            writableMap.putString(MAP_KEY_GUTENBERG_VERSION, gutenbergVersion.toString());
         }
 
         emitToJS(EVENT_NAME_UPDATE_EDITOR_SETTINGS, writableMap);

--- a/packages/react-native-bridge/android/react-native-bridge/src/main/java/org/wordpress/mobile/WPAndroidGlue/GutenbergProps.kt
+++ b/packages/react-native-bridge/android/react-native-bridge/src/main/java/org/wordpress/mobile/WPAndroidGlue/GutenbergProps.kt
@@ -60,6 +60,8 @@ data class GutenbergProps @JvmOverloads constructor(
                     ?.let { putSerializable(PROP_QUOTE_BLOCK_V2, it) }
             theme.getSerializable(PROP_LIST_BLOCK_V2)
                     ?.let { putSerializable(PROP_LIST_BLOCK_V2, it) }
+            theme.getSerializable(PROP_GUTENBERG_VERSION)
+                ?.let { putSerializable(PROP_GUTENBERG_VERSION, it) }
         }
     }
 
@@ -106,6 +108,7 @@ data class GutenbergProps @JvmOverloads constructor(
         private const val PROP_GALLERY_WITH_IMAGE_BLOCKS = "galleryWithImageBlocks"
         private const val PROP_QUOTE_BLOCK_V2 = "quoteBlockV2"
         private const val PROP_LIST_BLOCK_V2 = "listBlockV2"
+        private const val PROP_GUTENBERG_VERSION = "gutenbergVersion"
 
         const val PROP_INITIAL_DATA = "initialData"
         const val PROP_LOCALE = "locale"

--- a/packages/react-native-bridge/ios/Gutenberg.swift
+++ b/packages/react-native-bridge/ios/Gutenberg.swift
@@ -241,6 +241,10 @@ public class Gutenberg: UIResponder {
         if let gradients = editorSettings?.gradients {
             settingsUpdates["gradients"] = gradients
         }
+        
+        if let gutenbergVersion = editorSettings?.gutenbergVersion {
+            settingsUpdates["gutenbergVersion"] = gutenbergVersion
+        }
 
         return settingsUpdates
     }

--- a/packages/react-native-bridge/ios/GutenbergBridgeDataSource.swift
+++ b/packages/react-native-bridge/ios/GutenbergBridgeDataSource.swift
@@ -89,4 +89,5 @@ public protocol GutenbergEditorSettings {
     var rawFeatures: String? { get }
     var colors: [[String: String]]? { get }
     var gradients: [[String: String]]? { get }
+    var gutenbergVersion: String? { get }
 }

--- a/packages/react-native-editor/src/setup.js
+++ b/packages/react-native-editor/src/setup.js
@@ -71,6 +71,7 @@ const setupInitHooks = () => {
 				rawStyles,
 				rawFeatures,
 				galleryWithImageBlocks,
+				gutenbergVersion,
 				locale,
 			} = props;
 
@@ -95,6 +96,7 @@ const setupInitHooks = () => {
 				rawStyles,
 				rawFeatures,
 				galleryWithImageBlocks,
+				gutenbergVersion,
 				locale,
 			};
 		}


### PR DESCRIPTION
**In progress...**

This is a follow-up of https://github.com/WordPress/gutenberg/pull/54215

**Related PRs:**
- https://github.com/wordpress-mobile/gutenberg-mobile/pull/6165
- https://github.com/wordpress-mobile/WordPressKit-iOS/pull/625
- https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2847

## What?
<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
