### PR TITLE
Copy: End the Templates page description in the Site Editor with a period

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen-templates/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-templates/index.js
@@ -49,7 +49,7 @@ export default function SidebarNavigationScreenTemplates() {
 		<SidebarNavigationScreen
 			title={ __( 'Templates' ) }
 			description={ __(
-				'Express the layout of your site with templates'
+				'Express the layout of your site with templates.'
 			) }
 			actions={
 				canCreate && (


### PR DESCRIPTION
## What?

This PR adds a period to the end of the description text on the Templates page of the Site Editor.

![templates](https://github.com/WordPress/gutenberg/assets/54422211/341f8290-d450-4e8c-bccb-f9be89e86859)

## Why?

With the exception of the Templates page, all descriptions that appear in the sidebar of the Site Editor end with a period.

![design](https://github.com/WordPress/gutenberg/assets/54422211/744082f8-433c-414f-883a-427319249658)
![navigation](https://github.com/WordPress/gutenberg/assets/54422211/e9dce86d-7953-4db3-b18c-fde60f214b09)
![styles](https://github.com/WordPress/gutenberg/assets/54422211/5d60823d-3346-46e9-96e6-d6fbfadaee9a)
