### PR TITLE
Heading: Remove unused 'aria-label'

### DIFF
--- a/packages/block-library/src/heading/edit.js
+++ b/packages/block-library/src/heading/edit.js
@@ -132,7 +132,6 @@ function HeadingEdit( {
 				} }
 				onReplace={ onReplace }
 				onRemove={ () => onReplace( [] ) }
-				aria-label={ __( 'Heading text' ) }
 				placeholder={ placeholder || __( 'Heading' ) }
 				textAlign={ textAlign }
 				{ ...( Platform.isNative && { deleteEnter: true } ) } // setup RichText on native mobile to delete the "Enter" key as it's handled by the JS/RN side


### PR DESCRIPTION
## What?
The Heading block had a separate `aria-label` specified, which is always overridden by the `aria-label` provided via `blockProps`.

PR removes unused `aria-label`.

## Testing Instructions
1. Open a post or page.
2. Insert a heading block.
3. Confirm heading block still has `aria-label` - "Block: Heading".

### Testing Instructions for Keyboard
Same

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2023-09-06 at 21 33 18](https://github.com/WordPress/gutenberg/assets/240569/b81023d9-7228-4c29-a89a-075c2e157f38)

