### PR TITLE
Font Face: remove static instance in wp_print_font_faces()

### DIFF
--- a/lib/compat/wordpress-6.4/fonts/fonts.php
+++ b/lib/compat/wordpress-6.4/fonts/fonts.php
@@ -22,7 +22,6 @@ if ( ! function_exists( 'wp_print_font_faces' ) ) {
 	 *                     Default empty array.
 	 */
 	function wp_print_font_faces( $fonts = array() ) {
-		static $wp_font_face = null;
 
 		if ( empty( $fonts ) ) {
 			$fonts = WP_Font_Face_Resolver::get_fonts_from_theme_json();
@@ -32,15 +31,7 @@ if ( ! function_exists( 'wp_print_font_faces' ) ) {
 			return;
 		}
 
-		if (
-			null === $wp_font_face ||
-
-			// Ignore cache when automated test suites are running.
-			( defined( 'WP_RUN_CORE_TESTS' ) && WP_RUN_CORE_TESTS )
-		) {
-			$wp_font_face = new WP_Font_Face();
-		}
-
+		$wp_font_face = new WP_Font_Face();
 		$wp_font_face->generate_and_print( $fonts );
 	}
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

See WordPress Core https://github.com/WordPress/wordpress-develop/pull/5159 and commit https://core.trac.wordpress.org/changeset/56540.

## What?

Removes the static instance of `WP_Font_Face` from `wp_print_font_faces()`.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

This static is an unnecessary carryover from the Fonts API. 

Whereas the Fonts API needed to persist its data (i.e. to maintain the registered and enqueued fonts throughout the web request), Font Face does not have data to persist.

Font Face processes the fonts it receives when `::generate_and_print( $fonts )` is invoked. Thus, a singleton is not needed.

Removing the static reduces the amount of the code in the function and eliminates running its tests in separate processes to ensure a different instance is always used.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Removes the static variable.
Instantiates a new instance each time the function is invoked.

## Testing Instructions

There's no functionality changes.

All fonts tests and CI jobs should pass:
```
npm run test:unit:php:base -- --group fonts
```