### PR TITLE
Fix: Broken links on ToolbarGroup documentation.

### DIFF
--- a/packages/components/src/toolbar/toolbar-group/README.md
+++ b/packages/components/src/toolbar/toolbar-group/README.md
@@ -1,6 +1,6 @@
 # ToolbarGroup
 
-A ToolbarGroup can be used to create subgroups of controls inside a [Toolbar](/packages/components/src/toolbar/README.md).
+A ToolbarGroup can be used to create subgroups of controls inside a [Toolbar](/packages/components/src/toolbar/toolbar/README.md).
 
 ## Usage
 
@@ -30,4 +30,4 @@ ToolbarGroup will pass all HTML props to the underlying element.
 
 ## Related components
 
--   ToolbarGroup may contain [ToolbarButton](/packages/components/src/toolbar/toolbar-button/README.md) and [ToolbarItem](/packages/components/src/toolbar/toolbar-Item/README.md) as children.
+-   ToolbarGroup may contain [ToolbarButton](/packages/components/src/toolbar/toolbar-button/README.md) and [ToolbarItem](/packages/components/src/toolbar/toolbar-item/README.md) as children.


### PR DESCRIPTION
This PR is a follow-up to https://github.com/WordPress/gutenberg/pull/49176 and fixes the remaining links in the documentation of ToolbarGroup.
