### PR TITLE
Patterns: Make theme pattern lock icons consistent with block toolbar's menu item

### DIFF
--- a/packages/edit-site/src/components/page-patterns/grid-item.js
+++ b/packages/edit-site/src/components/page-patterns/grid-item.js
@@ -28,7 +28,7 @@ import {
 	symbolFilled as uncategorized,
 	symbol,
 	moreVertical,
-	lockSmall,
+	lockOutline,
 } from '@wordpress/icons';
 import { store as noticesStore } from '@wordpress/notices';
 import { store as reusableBlocksStore } from '@wordpress/reusable-blocks';
@@ -213,7 +213,7 @@ function GridItem( { categoryId, item, ...props } ) {
 								text={ __( 'This pattern cannot be edited.' ) }
 							>
 								<span className="edit-site-patterns__pattern-lock-icon">
-									<Icon icon={ lockSmall } size={ 24 } />
+									<Icon icon={ lockOutline } size={ 18 } />
 								</span>
 							</Tooltip>
 						) }

--- a/packages/edit-site/src/components/sidebar-navigation-screen-patterns/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-patterns/index.js
@@ -13,7 +13,7 @@ import { useViewportMatch } from '@wordpress/compose';
 import { getTemplatePartIcon } from '@wordpress/editor';
 import { __, sprintf } from '@wordpress/i18n';
 import { getQueryArgs } from '@wordpress/url';
-import { file, starFilled, lockSmall } from '@wordpress/icons';
+import { file, starFilled, lockOutline } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -76,7 +76,10 @@ function ThemePatternsGroup( { categories, currentCategory, currentType } ) {
 									) }
 								>
 									<span className="edit-site-sidebar-navigation-screen-pattern__lock-icon">
-										<Icon icon={ lockSmall } size={ 24 } />
+										<Icon
+											icon={ lockOutline }
+											size={ 18 }
+										/>
 									</span>
 								</Tooltip>
 							</Flex>


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/53285

## What?

Updates the lock icons used in the site editor Patterns page, to match the lock outline icon used in block toolbar more menu's lock item.

## Why?

Consistency is good.

See: https://github.com/WordPress/gutenberg/issues/51948#issuecomment-1631540891

## How?

Reuses the `lockOutline` icon however this PR also currently tweaks the rendered size of the icon so it is more inline with what was already there. 

Would it be better to have a `lockOutlineSmall` icon as an equivalent to the `lockSmall` icon?

## Testing Instructions

1. Navigate to Appearance > Editor > Patterns
2. Confirm the lock icon beside theme pattern categories is the outline version
3. Select a theme pattern category and confirm the same icon is beside the locked theme patterns


## Screenshots or screencast <!-- if applicable -->

| Before | After |
|---|---|
| <img width="864" alt="Screenshot 2023-09-07 at 12 35 01 pm" src="https://github.com/WordPress/gutenberg/assets/60436221/ccbf2035-3fa1-44e8-9164-197396e55ee2"> | <img width="847" alt="Screenshot 2023-09-07 at 12 40 54 pm" src="https://github.com/WordPress/gutenberg/assets/60436221/369532c5-51cb-4a40-af27-fe5b6b35b8a9"> |

Lock icon in block toolbar more menu:
<img width="267" alt="Screenshot 2023-09-07 at 12 41 18 pm" src="https://github.com/WordPress/gutenberg/assets/60436221/1da76c3f-72ae-4c62-9a83-0e72f8cc7f07">
