### PR TITLE
Add `set -o pipefail` to script that builds iOS E2E version

### DIFF
--- a/packages/react-native-editor/bin/build_e2e_ios_app
+++ b/packages/react-native-editor/bin/build_e2e_ios_app
@@ -1,5 +1,7 @@
 #!/bin/bash -eu
 
+set -o pipefail
+
 DEFAULT_DESTINATION='platform=iOS Simulator,name=iPhone 13'
 if [[ -z "${RN_EDITOR_E2E_IOS_DESTINATION-}" ]]; then
 	DESTINATION="$DEFAULT_DESTINATION"


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Addresses a dumb oversight on my end in #54079. I piped output without accounting for the script returning with the pipe status code instead of that of the piped command.

## Why?
Without it, [we'd get false positives in the mobile CI pipeline](https://github.com/wordpress-mobile/gutenberg-mobile/pull/6134#issuecomment-1709272954). 

## How?
`set -o pipefail` 🤦‍♂️ 

## Testing Instructions
Notice how [a CI build with this change fails](https://buildkite.com/automattic/gutenberg-mobile/builds/7179#018a6cea-f319-47f2-bdb0-5dd193738322):

<img width="1183" alt="Screenshot 2023-09-07 at 1 24 19 pm" src="https://github.com/WordPress/gutenberg/assets/1218433/b218df0a-7813-4a37-8d3d-4df7b523efc2">

While [one without it passes](https://buildkite.com/automattic/gutenberg-mobile/builds/7164#018a695f-f47a-4488-9baf-6e554109722c):

<img width="1167" alt="Screenshot 2023-09-07 at 1 25 31 pm" src="https://github.com/WordPress/gutenberg/assets/1218433/dda2db8e-35b2-41f7-a34a-3b2fc98fdfd4">

### Testing Instructions for Keyboard
N.A.

## Screenshots or screencast
N.A.
