### PR TITLE
[Do not merge] Update block settings menu to use a controlled dropdown menu component

### DIFF
--- a/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
@@ -191,26 +191,25 @@ export function BlockSettingsDropdown( {
 	const parentBlockIsSelected =
 		selectedBlockClientIds?.includes( firstParentClientId );
 
-	// Only override the `open` prop if the current block is not the one that
-	// opened the menu. The logic here is to ensure that non-current
-	// block menus are automatically closed when a new block menu is opened.
-	// This is useful for cases where focus is not present in the current window.
-	// All other behavior of the drop down menu should be otherwise unaffected.
-	const open =
-		! currentClientId || openedBlockSettingsMenu === currentClientId
-			? undefined
-			: false;
+	// When a currentClientId is in use, treat the menu as a controlled component.
+	// This ensures that only one block settings menu is open at a time.
+	const open = ! currentClientId
+		? undefined
+		: openedBlockSettingsMenu === currentClientId || false;
 
 	const onToggle = useCallback(
 		( localOpen ) => {
-			// When the current menu is opened, update the state to reflect
-			// the new current menu. This allows all other instances of the
-			// menu to close if they already open.
-			if ( localOpen ) {
+			if ( localOpen && openedBlockSettingsMenu !== currentClientId ) {
 				setOpenedBlockSettingsMenu( currentClientId );
+			} else if (
+				! localOpen &&
+				openedBlockSettingsMenu &&
+				openedBlockSettingsMenu === currentClientId
+			) {
+				setOpenedBlockSettingsMenu( undefined );
 			}
 		},
-		[ currentClientId, setOpenedBlockSettingsMenu ]
+		[ currentClientId, openedBlockSettingsMenu, setOpenedBlockSettingsMenu ]
 	);
 
 	return (

--- a/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
@@ -191,22 +191,22 @@ export function BlockSettingsDropdown( {
 	const parentBlockIsSelected =
 		selectedBlockClientIds?.includes( firstParentClientId );
 
-	// Only override the isOpen prop if the current block is not the one that
+	// Only override the `open` prop if the current block is not the one that
 	// opened the menu. The logic here is to ensure that non-current
 	// block menus are automatically closed when a new block menu is opened.
 	// This is useful for cases where focus is not present in the current window.
 	// All other behavior of the drop down menu should be otherwise unaffected.
-	const isOpen =
+	const open =
 		! currentClientId || openedBlockSettingsMenu === currentClientId
 			? undefined
 			: false;
 
 	const onToggle = useCallback(
-		( localIsOpen ) => {
+		( localOpen ) => {
 			// When the current menu is opened, update the state to reflect
 			// the new current menu. This allows all other instances of the
 			// menu to close if they already open.
-			if ( localIsOpen ) {
+			if ( localOpen ) {
 				setOpenedBlockSettingsMenu( currentClientId );
 			}
 		},
@@ -238,7 +238,7 @@ export function BlockSettingsDropdown( {
 					label={ __( 'Options' ) }
 					className="block-editor-block-settings-menu"
 					popoverProps={ POPOVER_PROPS }
-					isOpen={ isOpen }
+					open={ open }
 					onToggle={ onToggle }
 					noIcons
 					menuProps={ {

--- a/packages/block-editor/src/store/private-actions.js
+++ b/packages/block-editor/src/store/private-actions.js
@@ -259,3 +259,16 @@ export function setBlockRemovalRules( rules = false ) {
 		rules,
 	};
 }
+
+/**
+ * Sets the client ID of the block settings menu that is currently open.
+ *
+ * @param {string} clientId The block client ID.
+ * @return {Object} Action object.
+ */
+export function setOpenedBlockSettingsMenu( clientId = '' ) {
+	return {
+		type: 'SET_OPENED_BLOCK_SETTINGS_MENU',
+		clientId,
+	};
+}

--- a/packages/block-editor/src/store/private-selectors.js
+++ b/packages/block-editor/src/store/private-selectors.js
@@ -139,3 +139,13 @@ export function getRemovalPromptData( state ) {
 export function getBlockRemovalRules( state ) {
 	return state.blockRemovalRules;
 }
+
+/**
+ * Returns the client ID of the block settings menu that is currently open.
+ *
+ * @param {Object} state Global application state.
+ * @return {string|undefined} The client ID of the block menu that is currently open.
+ */
+export function getOpenedBlockSettingsMenu( state ) {
+	return state.openedBlockSettingsMenu;
+}

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -1913,6 +1913,14 @@ export function blockEditingModes( state = new Map(), action ) {
 	return state;
 }
 
+export function openedBlockSettingsMenu( state = null, action ) {
+	switch ( action.type ) {
+		case 'SET_OPENED_BLOCK_SETTINGS_MENU':
+			return action.clientId || null;
+	}
+	return state;
+}
+
 const combinedReducers = combineReducers( {
 	blocks,
 	isTyping,
@@ -1938,6 +1946,7 @@ const combinedReducers = combineReducers( {
 	blockEditingModes,
 	removalPromptData,
 	blockRemovalRules,
+	openedBlockSettingsMenu,
 } );
 
 function withAutomaticChangeReset( reducer ) {

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -1914,9 +1914,8 @@ export function blockEditingModes( state = new Map(), action ) {
 }
 
 export function openedBlockSettingsMenu( state = null, action ) {
-	switch ( action.type ) {
-		case 'SET_OPENED_BLOCK_SETTINGS_MENU':
-			return action.clientId || null;
+	if ( 'SET_OPENED_BLOCK_SETTINGS_MENU' === action.type ) {
+		return action?.clientId;
 	}
 	return state;
 }

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -11,7 +11,7 @@
 -   Making Circular Option Picker a `listbox`. Note that while this changes some public API, new props are optional, and currently have default values; this will change in another patch ([#52255](https://github.com/WordPress/gutenberg/pull/52255)).
 -   `ToggleGroupControl`: Rewrite backdrop animation using framer motion shared layout animations, add better support for controlled and uncontrolled modes ([#50278](https://github.com/WordPress/gutenberg/pull/50278)).
 -   `Popover`: Add the `is-positioned` CSS class only after the popover has finished animating ([#54178](https://github.com/WordPress/gutenberg/pull/54178)).
--   `Dropdown` and `DropdownMenu` allow controlled `isOpen` prop. `DropdownMenu` allow `onToggle` callback ([#54083](https://github.com/WordPress/gutenberg/pull/54083)).
+-   `Dropdown` and `DropdownMenu` allow controlled `open` prop. `DropdownMenu` allow `onToggle` callback ([#54083](https://github.com/WordPress/gutenberg/pull/54083)).
 
 ### Bug Fix
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -11,6 +11,7 @@
 -   Making Circular Option Picker a `listbox`. Note that while this changes some public API, new props are optional, and currently have default values; this will change in another patch ([#52255](https://github.com/WordPress/gutenberg/pull/52255)).
 -   `ToggleGroupControl`: Rewrite backdrop animation using framer motion shared layout animations, add better support for controlled and uncontrolled modes ([#50278](https://github.com/WordPress/gutenberg/pull/50278)).
 -   `Popover`: Add the `is-positioned` CSS class only after the popover has finished animating ([#54178](https://github.com/WordPress/gutenberg/pull/54178)).
+-   `Dropdown` and `DropdownMenu` allow controlled `isOpen` prop. `DropdownMenu` allow `onToggle` callback ([#54083](https://github.com/WordPress/gutenberg/pull/54083)).
 
 ### Bug Fix
 
@@ -31,7 +32,6 @@
 
 ### Enhancements
 
--   `Dropdown` and `DropdownMenu` allow controlled `isOpen` prop. `DropdownMenu` allow `onToggle` callback ([#54083](https://github.com/WordPress/gutenberg/pull/54083)).
 -   `ProgressBar`: Add transition to determinate indicator ([#53877](https://github.com/WordPress/gutenberg/pull/53877)).
 -   Prevent nested `SlotFillProvider` from rendering ([#53940](https://github.com/WordPress/gutenberg/pull/53940)).
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -31,6 +31,7 @@
 
 ### Enhancements
 
+-   `Dropdown` and `DropdownMenu` allow controlled `isOpen` prop. `DropdownMenu` allow `onToggle` callback ([#54083](https://github.com/WordPress/gutenberg/pull/54083)).
 -   `ProgressBar`: Add transition to determinate indicator ([#53877](https://github.com/WordPress/gutenberg/pull/53877)).
 -   Prevent nested `SlotFillProvider` from rendering ([#53940](https://github.com/WordPress/gutenberg/pull/53940)).
 

--- a/packages/components/src/dropdown-menu/README.md
+++ b/packages/components/src/dropdown-menu/README.md
@@ -171,7 +171,7 @@ A class name to apply to the dropdown menu's toggle element wrapper.
 
 -   Required: No
 
-### `isOpen`: `boolean`
+### `open`: `boolean`
 
 Control whether the dropdown is open or not.
 

--- a/packages/components/src/dropdown-menu/README.md
+++ b/packages/components/src/dropdown-menu/README.md
@@ -171,6 +171,20 @@ A class name to apply to the dropdown menu's toggle element wrapper.
 
 -   Required: No
 
+### `isOpen`: `boolean`
+
+Control whether the dropdown is open or not.
+
+-   Required: No
+
+### `onToggle`: `( willOpen: boolean ) => void`
+
+A callback invoked when the state of the popover changes from open to closed and vice versa.
+
+The callback receives a boolean as a parameter. If `true`, the popover will open. If `false`, the popover will close.
+
+-   Required: No
+
 #### `popoverProps`: `DropdownProps[ 'popoverProps' ]`
 
 Properties of `popoverProps` object will be passed as props to the nested `Popover` component.

--- a/packages/components/src/dropdown-menu/README.md
+++ b/packages/components/src/dropdown-menu/README.md
@@ -171,13 +171,20 @@ A class name to apply to the dropdown menu's toggle element wrapper.
 
 -   Required: No
 
-### `open`: `boolean`
+#### `defaultOpen`: `boolean`
+
+The initial open state of the dropdown.
+
+-   Required: No
+-   Default: `false`
+
+#### `open`: `boolean`
 
 Control whether the dropdown is open or not.
 
 -   Required: No
 
-### `onToggle`: `( willOpen: boolean ) => void`
+#### `onToggle`: `( willOpen: boolean ) => void`
 
 A callback invoked when the state of the popover changes from open to closed and vice versa.
 

--- a/packages/components/src/dropdown-menu/index.tsx
+++ b/packages/components/src/dropdown-menu/index.tsx
@@ -49,7 +49,7 @@ function UnconnectedDropdownMenu( dropdownMenuProps: DropdownMenuProps ) {
 		className,
 		controls,
 		icon = menu,
-		isOpen: isOpenProp,
+		open: openProp,
 		label,
 		popoverProps,
 		toggleProps,
@@ -94,7 +94,7 @@ function UnconnectedDropdownMenu( dropdownMenuProps: DropdownMenuProps ) {
 	return (
 		<Dropdown
 			className={ className }
-			isOpen={ isOpenProp }
+			open={ openProp }
 			onToggle={ onToggleProp }
 			popoverProps={ mergedPopoverProps }
 			renderToggle={ ( { isOpen, onToggle } ) => {

--- a/packages/components/src/dropdown-menu/index.tsx
+++ b/packages/components/src/dropdown-menu/index.tsx
@@ -49,9 +49,11 @@ function UnconnectedDropdownMenu( dropdownMenuProps: DropdownMenuProps ) {
 		className,
 		controls,
 		icon = menu,
+		isOpen: isOpenProp,
 		label,
 		popoverProps,
 		toggleProps,
+		onToggle: onToggleProp,
 		menuProps,
 		disableOpenOnArrowDown = false,
 		text,
@@ -92,6 +94,8 @@ function UnconnectedDropdownMenu( dropdownMenuProps: DropdownMenuProps ) {
 	return (
 		<Dropdown
 			className={ className }
+			isOpen={ isOpenProp }
+			onToggle={ onToggleProp }
 			popoverProps={ mergedPopoverProps }
 			renderToggle={ ( { isOpen, onToggle } ) => {
 				const openOnArrowDown = ( event: React.KeyboardEvent ) => {

--- a/packages/components/src/dropdown-menu/index.tsx
+++ b/packages/components/src/dropdown-menu/index.tsx
@@ -49,6 +49,7 @@ function UnconnectedDropdownMenu( dropdownMenuProps: DropdownMenuProps ) {
 		className,
 		controls,
 		icon = menu,
+		defaultOpen,
 		open: openProp,
 		label,
 		popoverProps,
@@ -94,6 +95,7 @@ function UnconnectedDropdownMenu( dropdownMenuProps: DropdownMenuProps ) {
 	return (
 		<Dropdown
 			className={ className }
+			defaultOpen={ defaultOpen }
 			open={ openProp }
 			onToggle={ onToggleProp }
 			popoverProps={ mergedPopoverProps }

--- a/packages/components/src/dropdown-menu/types.ts
+++ b/packages/components/src/dropdown-menu/types.ts
@@ -71,7 +71,7 @@ export type DropdownMenuProps = {
 	/**
 	 * Whether the dropdown is opened or not.
 	 */
-	isOpen?: boolean;
+	open?: boolean;
 	/**
 	 * A human-readable label to present as accessibility text on the focused
 	 * collapsed menu button.

--- a/packages/components/src/dropdown-menu/types.ts
+++ b/packages/components/src/dropdown-menu/types.ts
@@ -69,6 +69,10 @@ export type DropdownMenuProps = {
 	 */
 	icon?: IconProps[ 'icon' ] | null;
 	/**
+	 * Whether the dropdown is opened or not.
+	 */
+	isOpen?: boolean;
+	/**
 	 * A human-readable label to present as accessibility text on the focused
 	 * collapsed menu button.
 	 */
@@ -86,6 +90,11 @@ export type DropdownMenuProps = {
 	 * set with `position` prop.
 	 */
 	popoverProps?: DropdownProps[ 'popoverProps' ];
+	/**
+	 * A function that is called any time the menu is toggled from its closed
+	 * state to its opened state, or vice versa.
+	 */
+	onToggle?: ( next: boolean ) => void;
 	/**
 	 * Properties of `toggleProps` object will be passed as props to the nested
 	 * `Button` component in the `renderToggle` implementation of the `Dropdown`

--- a/packages/components/src/dropdown-menu/types.ts
+++ b/packages/components/src/dropdown-menu/types.ts
@@ -69,6 +69,12 @@ export type DropdownMenuProps = {
 	 */
 	icon?: IconProps[ 'icon' ] | null;
 	/**
+	 * The initial open state of the dropdown.
+	 *
+	 * @default false
+	 */
+	defaultOpen?: boolean;
+	/**
 	 * Whether the dropdown is opened or not.
 	 */
 	open?: boolean;

--- a/packages/components/src/dropdown/README.md
+++ b/packages/components/src/dropdown/README.md
@@ -68,6 +68,12 @@ Set this to customize the text that is shown in the dropdown's header when it is
 
 -   Required: No
 
+### `isOpen`: `boolean`
+
+Control whether the dropdown is open or not.
+
+-   Required: No
+
 ### `onClose`: `() => void`
 
 A callback invoked when the popover should be closed.

--- a/packages/components/src/dropdown/README.md
+++ b/packages/components/src/dropdown/README.md
@@ -68,7 +68,7 @@ Set this to customize the text that is shown in the dropdown's header when it is
 
 -   Required: No
 
-### `isOpen`: `boolean`
+### `open`: `boolean`
 
 Control whether the dropdown is open or not.
 

--- a/packages/components/src/dropdown/README.md
+++ b/packages/components/src/dropdown/README.md
@@ -68,6 +68,13 @@ Set this to customize the text that is shown in the dropdown's header when it is
 
 -   Required: No
 
+### `defaultOpen`: `boolean`
+
+The initial open state of the dropdown.
+
+-   Required: No
+-   Default: `false`
+
 ### `open`: `boolean`
 
 Control whether the dropdown is open or not.

--- a/packages/components/src/dropdown/index.tsx
+++ b/packages/components/src/dropdown/index.tsx
@@ -50,7 +50,7 @@ const UnconnectedDropdown = (
 		onClose,
 		onToggle,
 		style,
-		isOpen: isOpenProp,
+		open: openProp,
 
 		// Deprecated props
 		position,
@@ -78,7 +78,7 @@ const UnconnectedDropdown = (
 	const [ isOpenState, setIsOpen ] = useObservableState( false, onToggle );
 
 	// Allow provided `isOpen` prop to override internal state.
-	const isOpen = isOpenProp ?? isOpenState;
+	const isOpen = openProp ?? isOpenState;
 
 	useEffect(
 		() => () => {

--- a/packages/components/src/dropdown/index.tsx
+++ b/packages/components/src/dropdown/index.tsx
@@ -50,6 +50,7 @@ const UnconnectedDropdown = (
 		onClose,
 		onToggle,
 		style,
+		isOpen: isOpenProp,
 
 		// Deprecated props
 		position,
@@ -74,7 +75,10 @@ const UnconnectedDropdown = (
 	const [ fallbackPopoverAnchor, setFallbackPopoverAnchor ] =
 		useState< HTMLDivElement | null >( null );
 	const containerRef = useRef< HTMLDivElement >();
-	const [ isOpen, setIsOpen ] = useObservableState( false, onToggle );
+	const [ isOpenState, setIsOpen ] = useObservableState( false, onToggle );
+
+	// Allow provided `isOpen` prop to override internal state.
+	const isOpen = isOpenProp ?? isOpenState;
 
 	useEffect(
 		() => () => {

--- a/packages/components/src/dropdown/types.ts
+++ b/packages/components/src/dropdown/types.ts
@@ -58,6 +58,10 @@ export type DropdownProps = {
 	 */
 	headerTitle?: string;
 	/**
+	 * Whether the dropdown is opened or not.
+	 */
+	isOpen?: boolean;
+	/**
 	 * A callback invoked when the popover should be closed.
 	 */
 	onClose?: () => void;

--- a/packages/components/src/dropdown/types.ts
+++ b/packages/components/src/dropdown/types.ts
@@ -60,7 +60,7 @@ export type DropdownProps = {
 	/**
 	 * Whether the dropdown is opened or not.
 	 */
-	isOpen?: boolean;
+	open?: boolean;
 	/**
 	 * A callback invoked when the popover should be closed.
 	 */

--- a/packages/components/src/dropdown/types.ts
+++ b/packages/components/src/dropdown/types.ts
@@ -36,6 +36,12 @@ export type DropdownProps = {
 	 */
 	contentClassName?: string;
 	/**
+	 * The initial open state of the dropdown.
+	 *
+	 * @default false
+	 */
+	defaultOpen?: boolean;
+	/**
 	 * Opt-in prop to show popovers fullscreen on mobile.
 	 *
 	 * @default false


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

🚧 🚧 🚧 🚧 This PR is forked from #54083 as an experiment, it is not intended to land 🚧 🚧 🚧 🚧

This PR is exactly the same as #54083 except that it attempts to use a controlled component. Unfortunately, it doesn't quite appear to be viable to use this approach, but I thought I'd push this PR for visibility so that we can compare it to #54083 when evaluating approaches

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

To explore feedback in https://github.com/WordPress/gutenberg/pull/54083#pullrequestreview-1614109134, and to hone in on a good solution.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

See the implementation in https://github.com/WordPress/gutenberg/commit/67801dd3ba30672574ea97ec86dc4ac792be6731

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. On a Mac, with focus in a window that is not your test site, hover the mouse cursor over an inactive window that's open to the post or site editors and that also has the list view open.
2. CMD+Click on the area of list view items where the ellipsis block settings menu button should be.
3. Move the mouse cursor up to another list view item and CMD+Click on where the ellipsis menu button should be.
4. Prior to this PR, multiple instances of the dropdown menu will be open.
5. With this PR applied, any already open menus should automatically close.

Note: in the current state of this PR, it's buggy as shown in the screengrab below.

## Screenshots or screencast <!-- if applicable -->

Buggy current state:

https://github.com/WordPress/gutenberg/assets/14988353/aba21314-c331-461a-8dbb-063b5182b4fe
