### PR TITLE
Theme Previews: Make the back button customizable

### DIFF
--- a/lib/compat/wordpress-6.4/theme-previews.php
+++ b/lib/compat/wordpress-6.4/theme-previews.php
@@ -12,7 +12,7 @@
  * @return array The editor settings.
  */
 function gutenberg_theme_preview_block_editor_settings_all( $settings ) {
-	$settings['__experimentalDashboardLink'] = 'themes.php';
+	$settings['__experimentalDashboardLink']     = 'themes.php';
 	$settings['__experimentalDashboardLinkText'] = __( 'Go back to the theme showcase' );
 	return $settings;
 }

--- a/lib/compat/wordpress-6.4/theme-previews.php
+++ b/lib/compat/wordpress-6.4/theme-previews.php
@@ -13,6 +13,7 @@
  */
 function gutenberg_theme_preview_block_editor_settings_all( $settings ) {
 	$settings['__experimentalDashboardLink'] = 'themes.php';
+	$settings['__experimentalDashboardLinkText'] = __( 'Go back to the theme showcase' );
 	return $settings;
 }
 

--- a/lib/compat/wordpress-6.4/theme-previews.php
+++ b/lib/compat/wordpress-6.4/theme-previews.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * Enable theme previews in the Site Editor for block themes.
+ *
+ * @package gutenberg
+ */
+
+/**
+ * Allow developers to customize the back to dashboard link in the Site Editor
+ *
+ * @param array $settings The editor settings.
+ * @return array The editor settings.
+ */
+
+function gutenberg_theme_preview_block_editor_settings_all( $settings ) {
+	$settings['__experimentalDashboardLink'] = 'themes.php';
+	return $settings;
+}
+
+// Attaches filters to enable theme previews in the Site Editor.
+if ( ! empty( $_GET['wp_theme_preview'] ) ) {
+	add_filter( 'block_editor_settings_all', 'gutenberg_theme_preview_block_editor_settings_all' );
+}

--- a/lib/compat/wordpress-6.4/theme-previews.php
+++ b/lib/compat/wordpress-6.4/theme-previews.php
@@ -11,13 +11,16 @@
  * @param array $settings The editor settings.
  * @return array The editor settings.
  */
-
 function gutenberg_theme_preview_block_editor_settings_all( $settings ) {
 	$settings['__experimentalDashboardLink'] = 'themes.php';
 	return $settings;
 }
 
-// Attaches filters to enable theme previews in the Site Editor.
+/**
+ * Attaches filters to enable theme previews in the Site Editor.
+ * This would go inside of `initialize_theme_preview_hooks`
+ * to avoid the global scope when we port this to the core.
+ */
 if ( ! empty( $_GET['wp_theme_preview'] ) ) {
 	add_filter( 'block_editor_settings_all', 'gutenberg_theme_preview_block_editor_settings_all' );
 }

--- a/lib/load.php
+++ b/lib/load.php
@@ -53,6 +53,7 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 	// WordPress 6.4 compat.
 	require_once __DIR__ . '/compat/wordpress-6.4/class-gutenberg-rest-global-styles-revisions-controller-6-4.php';
 	require_once __DIR__ . '/compat/wordpress-6.4/rest-api.php';
+	require_once __DIR__ . '/compat/wordpress-6.4/theme-previews.php';
 
 	// Plugin specific code.
 	require_once __DIR__ . '/class-wp-rest-global-styles-controller-gutenberg.php';

--- a/packages/edit-site/src/components/sidebar-navigation-screen/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen/index.js
@@ -96,11 +96,7 @@ export default function SidebarNavigationScreen( {
 									? __( 'Go to the Dashboard' )
 									: __( 'Go back to the theme showcase' )
 							}
-							href={
-								! isPreviewingTheme()
-									? dashboardLink || 'index.php'
-									: 'themes.php'
-							}
+							href={ dashboardLink || 'index.php' }
 						/>
 					) }
 					<Heading

--- a/packages/edit-site/src/components/sidebar-navigation-screen/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen/index.js
@@ -41,10 +41,11 @@ export default function SidebarNavigationScreen( {
 	description,
 	backPath: backPathProp,
 } ) {
-	const { dashboardLink } = useSelect( ( select ) => {
+	const { dashboardLink, dashboardLinkText } = useSelect( ( select ) => {
 		const { getSettings } = unlock( select( editSiteStore ) );
 		return {
 			dashboardLink: getSettings().__experimentalDashboardLink,
+			dashboardLinkText: getSettings().__experimentalDashboardLinkText,
 		};
 	}, [] );
 	const { getTheme } = useSelect( coreStore );
@@ -92,9 +93,7 @@ export default function SidebarNavigationScreen( {
 						<SidebarButton
 							icon={ icon }
 							label={
-								! isPreviewingTheme()
-									? __( 'Go to the Dashboard' )
-									: __( 'Go back to the theme showcase' )
+								dashboardLinkText || __( 'Go to the Dashboard' )
 							}
 							href={ dashboardLink || 'index.php' }
 						/>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This PR makes the Back link on Block Theme Previews extensible with the settings store. Alternative to https://github.com/WordPress/gutenberg/pull/54174.

## Why?
Sometimes, 3rd party apps want to extend the Back link, as going back to /themes.php does not always make sense. c.f. https://github.com/Automattic/wp-calypso/issues/80595

## How?
The dashboard link is already customizable, but the theme preview path doesn't allow for the customization. This changes the way we modify the back link for the theme preview path so that it is also customizable.

## Testing Instructions
1. Go to /themes.php
2. Click the Live Preview button on the Block theme
3. Verify the Back link works as before

You can also test that this is extensible by adding a plugin that modifies the editor settings:
```
function test_theme_preview_block_editor_settings_all( $settings ) {
	$settings['__experimentalDashboardLink'] = 'example.com';
	return $settings;
}

// Attaches filters to enable theme previews in the Site Editor.
if ( ! empty( $_GET['wp_theme_preview'] ) ) {
	add_filter( 'block_editor_settings_all', 'test_theme_preview_block_editor_settings_all' );
}
```

## Screenshots or screencast <!-- if applicable -->
<img width="340" alt="Screen Shot 2023-09-05 at 15 07 46" src="https://github.com/WordPress/gutenberg/assets/5287479/8fc45351-d3c2-4e56-8a2f-d8a7ef722287">
