### PR TITLE
Add contributors to the readme file to populate the plugin page in the plugin directory

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,5 +1,5 @@
 === Gutenberg ===
-Contributors: matveb, joen, karmatosed
+Contributors: matveb, joen, karmatosed, youknowriad, aduth, ellatrix, gziolo, jorgefilipecosta, mamaduka, tyxla, talldanwp, ntsekouras, noisysocks, mkaz, get_dave, oandregal, aaronrobertshaw, wildworks, ramonopoly, mciampini, scruffian, afercia, zieladam, kevin940726, andrewserong, isabel_brison, annezazu
 Tested up to: 6.3
 Stable tag: V.V.V
 License: GPLv2 or later


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Adds around 25 contributors to the plugin readme file.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Right now, only three contributors are featured when browsing the [Gutenberg plugin in the plugin directory](https://wordpress.org/plugins/gutenberg/).

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
By adding the [top contributors as listed by GitHub](https://github.com/WordPress/gutenberg/graphs/contributors). Drawing a line to cut is not objective, but I stopped at around 25 to see how the list shows in the directory with such many folks. The idea is to add more if it works well.

## Testing Instructions
Only after merging can we check the [Gutenberg plugin in the plugin directory](https://wordpress.org/plugins/gutenberg/).

## Screenshots or screencast <!-- if applicable -->
This is how the list of contributors looks right now in the directory:
![image](https://github.com/WordPress/gutenberg/assets/27339341/4a70aa87-98fc-48b1-9109-a62f886e478a)
