### PR TITLE
StartPageOptions: improve conditions to show modal only on a brand new page

### DIFF
--- a/packages/edit-post/src/components/start-page-options/index.js
+++ b/packages/edit-post/src/components/start-page-options/index.js
@@ -97,17 +97,13 @@ function StartPageOptionsModal() {
 
 export default function StartPageOptions() {
 	const shouldEnableModal = useSelect( ( select ) => {
-		const { getEditedPostAttribute, isEditedPostEmpty, isEditedPostDirty } =
-			select( editorStore );
+		const { isCleanNewPost } = select( editorStore );
 		const { isEditingTemplate, isFeatureActive } = select( editPostStore );
 
-		return ! (
-			isEditingTemplate() ||
-			isFeatureActive( 'welcomeGuide' ) ||
-			isEditedPostDirty() ||
-			getEditedPostAttribute( 'title' ) ||
-			getEditedPostAttribute( 'excerpt' ) ||
-			! isEditedPostEmpty()
+		return (
+			! isEditingTemplate() &&
+			! isFeatureActive( 'welcomeGuide' ) &&
+			isCleanNewPost()
 		);
 	}, [] );
 

--- a/packages/edit-post/src/components/start-page-options/index.js
+++ b/packages/edit-post/src/components/start-page-options/index.js
@@ -97,14 +97,17 @@ function StartPageOptionsModal() {
 
 export default function StartPageOptions() {
 	const shouldEnableModal = useSelect( ( select ) => {
-		const { getEditedPostContent, isEditedPostSaveable } =
+		const { getEditedPostAttribute, isEditedPostEmpty, isEditedPostDirty } =
 			select( editorStore );
 		const { isEditingTemplate, isFeatureActive } = select( editPostStore );
-		return (
-			! isEditedPostSaveable() &&
-			'' === getEditedPostContent() &&
-			! isEditingTemplate() &&
-			! isFeatureActive( 'welcomeGuide' )
+
+		return ! (
+			isEditingTemplate() ||
+			isFeatureActive( 'welcomeGuide' ) ||
+			isEditedPostDirty() ||
+			getEditedPostAttribute( 'title' ) ||
+			getEditedPostAttribute( 'excerpt' ) ||
+			! isEditedPostEmpty()
 		);
 	}, [] );
 


### PR DESCRIPTION
Fixes #54227.

The condition that inspects the current post, and triggers displaying the pattern selection modal, it was wrong. It fired also in two cases where it shouldn't fire:
- removing all content and clearing the title on a page that's already been saved.
- while save of a page with a title but no content is in progress

See the comments in #54227 for more details.

The fix improves the condition in several ways:
- instead of using the `isEditedPostSaveable` selector, check explicitly the `title`, `excerpt` and `content` attributes of the post
- now when we stopped using the `isEditedPostSaveable`, we're not evaluating the `isSavingPost` condition (is save in progress?) which is irrelevant for us
- use `isEditedPostEmpty` to detect empty content in a more optimized way -- if `post.content` is a function, we no longer call it all the time
- use `isEditedPostDirty` to verify that the post is brand new, and not just an edit of existing non-empty post

**How to test:**
Verify that the patterns modal is shown when it should be (when creating a new page), and that it's not shown in the two reported cases:
- removing content from existing post
- while save is in progress