### PR TITLE
Storybook: Restore previous URL for the introduction docs page

### DIFF
--- a/storybook/stories/docs/introduction.mdx
+++ b/storybook/stories/docs/introduction.mdx
@@ -1,7 +1,7 @@
 import { Meta } from '@storybook/blocks';
 import { InlineIcon } from './inline-icon';
 
-<Meta title="Docs/Introduction" />
+<Meta title="Docs/Introduction" name="page"/>
 
 # Introduction
 

--- a/storybook/stories/docs/introduction.mdx
+++ b/storybook/stories/docs/introduction.mdx
@@ -1,7 +1,7 @@
 import { Meta } from '@storybook/blocks';
 import { InlineIcon } from './inline-icon';
 
-<Meta title="Docs/Introduction" name="page"/>
+<Meta title="Docs/Introduction" name="page" />
 
 # Introduction
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Restores the URL of the Storybook's introduction docs page, which apparently changed as a consequence of the update to Storybook v7.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

That URL is shared in various documentation pages, and those links are currently broken

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Using the `Meta` component to specify the document's `name`, which contributes to the final URL of the page (see [docs](https://storybook.js.org/docs/react/configure/sidebar-and-urls#processing-custom-titles))

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- Build Storybook locally
- Make sure that the intro docs page can be accessed at the URL `/?path=/docs/docs-introduction--page/`
