### PR TITLE
Remove block assets enqueuing from editor document

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -595,6 +595,8 @@ remove_action( 'wp_footer', 'wp_enqueue_stored_styles', 1 );
 add_action( 'wp_enqueue_scripts', 'gutenberg_enqueue_stored_styles' );
 add_action( 'wp_footer', 'gutenberg_enqueue_stored_styles', 1 );
 
-// This action should be removed in core when backporting.
-// https://github.com/WordPress/wordpress-develop/blob/362624176cba41a2dda57c3e89031aa6c3e4decf/src/wp-includes/default-filters.php#L573
+/*
+ * This action should be removed in core when backporting.
+ * See https://github.com/WordPress/wordpress-develop/blob/362624176cba41a2dda57c3e89031aa6c3e4decf/src/wp-includes/default-filters.php#L573.
+ */
 remove_action( 'admin_enqueue_scripts', 'wp_common_block_scripts_and_styles' );

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -284,7 +284,7 @@ function gutenberg_register_packages_styles( $styles ) {
 		$styles,
 		'wp-edit-post',
 		gutenberg_url( 'build/edit-post/style.css' ),
-		array( 'wp-components', 'wp-block-editor', 'wp-editor', 'wp-edit-blocks', 'wp-block-library', 'wp-commands' ),
+		array( 'wp-components', 'wp-block-editor', 'wp-editor', 'wp-commands' ),
 		$version
 	);
 	$styles->add_data( 'wp-edit-post', 'rtl', 'replace' );
@@ -409,7 +409,7 @@ function gutenberg_register_packages_styles( $styles ) {
 		$styles,
 		'wp-edit-site',
 		gutenberg_url( 'build/edit-site/style.css' ),
-		array( 'wp-components', 'wp-block-editor', 'wp-editor', 'wp-edit-blocks', 'wp-commands' ),
+		array( 'wp-components', 'wp-block-editor', 'wp-editor', 'wp-commands' ),
 		$version
 	);
 	$styles->add_data( 'wp-edit-site', 'rtl', 'replace' );
@@ -594,3 +594,7 @@ remove_action( 'wp_footer', 'wp_enqueue_stored_styles', 1 );
 // Enqueue stored styles.
 add_action( 'wp_enqueue_scripts', 'gutenberg_enqueue_stored_styles' );
 add_action( 'wp_footer', 'gutenberg_enqueue_stored_styles', 1 );
+
+// This action should be removed in core when backporting.
+// https://github.com/WordPress/wordpress-develop/blob/362624176cba41a2dda57c3e89031aa6c3e4decf/src/wp-includes/default-filters.php#L573
+remove_action( 'admin_enqueue_scripts', 'wp_common_block_scripts_and_styles' );

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -284,7 +284,7 @@ function gutenberg_register_packages_styles( $styles ) {
 		$styles,
 		'wp-edit-post',
 		gutenberg_url( 'build/edit-post/style.css' ),
-		array( 'wp-components', 'wp-block-editor', 'wp-editor', 'wp-commands' ),
+		array( 'wp-components', 'wp-block-editor', 'wp-editor', 'wp-block-library-editor', 'wp-block-library', 'wp-commands' ),
 		$version
 	);
 	$styles->add_data( 'wp-edit-post', 'rtl', 'replace' );
@@ -369,6 +369,19 @@ function gutenberg_register_packages_styles( $styles ) {
 	);
 	$styles->add_data( 'wp-edit-blocks', 'rtl', 'replace' );
 
+	// Essentially the same as wp-edit-blocks, but without dependencies.
+	// wp-edit-blocks is for use in the editor iframe, while
+	// wp-block-library-editor is for use outside the iframe. Editor styles are
+	// expected to be enqueued both inside and outside the iframe.
+	gutenberg_override_style(
+		$styles,
+		'wp-block-library-editor',
+		gutenberg_url( 'build/block-library/editor.css' ),
+		array(),
+		$version
+	);
+	$styles->add_data( 'wp-edit-blocks', 'rtl', 'replace' );
+
 	gutenberg_override_style(
 		$styles,
 		'wp-nux',
@@ -409,7 +422,7 @@ function gutenberg_register_packages_styles( $styles ) {
 		$styles,
 		'wp-edit-site',
 		gutenberg_url( 'build/edit-site/style.css' ),
-		array( 'wp-components', 'wp-block-editor', 'wp-editor', 'wp-commands' ),
+		array( 'wp-components', 'wp-block-editor', 'wp-editor', 'wp-block-library-editor', 'wp-commands' ),
 		$version
 	);
 	$styles->add_data( 'wp-edit-site', 'rtl', 'replace' );
@@ -596,7 +609,27 @@ add_action( 'wp_enqueue_scripts', 'gutenberg_enqueue_stored_styles' );
 add_action( 'wp_footer', 'gutenberg_enqueue_stored_styles', 1 );
 
 /*
- * This action should be removed in core when backporting.
+ * This action should be removed in core when backporting. We no longer want to
+ * enqueue all assets added through enqueue_block_assets, they are added
+ * separately to the editor through block editor settings.
  * See https://github.com/WordPress/wordpress-develop/blob/362624176cba41a2dda57c3e89031aa6c3e4decf/src/wp-includes/default-filters.php#L573.
  */
 remove_action( 'admin_enqueue_scripts', 'wp_common_block_scripts_and_styles' );
+
+/*
+ * We DO want to enqueue EDITOR scripts and styles.
+ */
+add_action( 'admin_enqueue_scripts', function() {
+	$block_registry = WP_Block_Type_Registry::get_instance();
+	foreach ( $block_registry->get_all_registered() as $block_name => $block_type ) {
+		// Editor styles.
+		foreach ( $block_type->editor_style_handles as $editor_style_handle ) {
+			wp_enqueue_style( $editor_style_handle );
+		}
+
+		// Editor scripts.
+		foreach ( $block_type->editor_script_handles as $editor_script_handle ) {
+			wp_enqueue_script( $editor_script_handle );
+		}
+	}
+} );

--- a/packages/block-editor/src/components/block-canvas/index.js
+++ b/packages/block-editor/src/components/block-canvas/index.js
@@ -23,14 +23,14 @@ import { store as blockEditorStore } from '../../store';
  * editor, so we need to filter them out.
  */
 function UnIframedBlockAssets() {
-	const blockAssets =
-		useSelect( ( select ) => {
-			return select( blockEditorStore ).getSettings()
-				.__unstableResolvedAssets;
-		}, [] ) || {};
-	const { styles: _styles = '', scripts: _scripts = '' } = blockAssets;
+	const blockAssets = useSelect( ( select ) => {
+		return select( blockEditorStore ).getSettings()
+			.__unstableResolvedAssets;
+	}, [] );
+	const { styles: _styles = '', scripts: _scripts = '' } = blockAssets || {};
 	const assetsHtml = _styles + _scripts;
 	const filteredAssetsHtml = useMemo( () => {
+		if ( ! assetsHtml ) return '';
 		const doc = document.implementation.createHTMLDocument( '' );
 		doc.body.innerHTML = assetsHtml;
 		// Remove assets already enqueued in the editor document.
@@ -41,6 +41,8 @@ function UnIframedBlockAssets() {
 		} );
 		return doc.body.innerHTML;
 	}, [ assetsHtml ] );
+
+	if ( ! filteredAssetsHtml ) return null;
 
 	return (
 		<div dangerouslySetInnerHTML={ { __html: filteredAssetsHtml } }></div>

--- a/packages/block-editor/src/components/block-tools/style.scss
+++ b/packages/block-editor/src/components/block-tools/style.scss
@@ -78,6 +78,20 @@
 	}
 }
 
+// The black plus that shows up on the right side of an empty paragraph block, or the initial appender
+// that exists only on empty documents.
+.block-editor-block-list__empty-block-inserter.block-editor-block-list__empty-block-inserter,
+.block-editor-default-block-appender .block-editor-inserter {
+	position: absolute;
+	top: 0;
+	right: 0;
+	line-height: 0;
+
+	&:disabled {
+		display: none;
+	}
+}
+
 .block-editor-block-list__insertion-point-inserter .block-editor-inserter__toggle.components-button.has-icon {
 	background: var(--wp-admin-theme-color);
 	&:hover {

--- a/packages/block-editor/src/components/default-block-appender/content.scss
+++ b/packages/block-editor/src/components/default-block-appender/content.scss
@@ -60,20 +60,6 @@
 	}
 }
 
-// The black plus that shows up on the right side of an empty paragraph block, or the initial appender
-// that exists only on empty documents.
-.block-editor-block-list__empty-block-inserter.block-editor-block-list__empty-block-inserter,
-.block-editor-default-block-appender .block-editor-inserter {
-	position: absolute;
-	top: 0;
-	right: 0;
-	line-height: 0;
-
-	&:disabled {
-		display: none;
-	}
-}
-
 
 /**
  * Fixed position appender.

--- a/packages/block-editor/src/components/iframe/use-compatibility-styles.js
+++ b/packages/block-editor/src/components/iframe/use-compatibility-styles.js
@@ -45,6 +45,12 @@ export function useCompatibilityStyles() {
 					return accumulator;
 				}
 
+				// This is the same stylesheet as wp-edit-block but without
+				// its dependencies, so we don't need to add it.
+				if ( ownerNode.id === 'wp-block-library-editor-css' ) {
+					return accumulator;
+				}
+
 				// Don't try to add styles without ID. Styles enqueued via the WP dependency system will always have IDs.
 				if ( ! ownerNode.id ) {
 					return accumulator;

--- a/packages/e2e-tests/plugins/inner-blocks-allowed-blocks.php
+++ b/packages/e2e-tests/plugins/inner-blocks-allowed-blocks.php
@@ -24,4 +24,4 @@ function enqueue_inner_blocks_allowed_blocks_script() {
 		true
 	);
 }
-add_action( 'enqueue_block_assets', 'enqueue_inner_blocks_allowed_blocks_script' );
+add_action( 'enqueue_block_editor_assets', 'enqueue_inner_blocks_allowed_blocks_script' );

--- a/packages/e2e-tests/plugins/meta-attribute-block.php
+++ b/packages/e2e-tests/plugins/meta-attribute-block.php
@@ -49,4 +49,4 @@ function enqueue_test_meta_attribute_block() {
 		true
 	);
 }
-add_action( 'enqueue_block_assets', 'enqueue_test_meta_attribute_block' );
+add_action( 'enqueue_block_editor_assets', 'enqueue_test_meta_attribute_block' );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This PR removes enqueuing of _block assets_ (meant for editor content) from the main editor document. For the iframed editor, these assets are already loaded inside the iframe, so they are not needed and currently loaded twice. For the non iframed editor, they should still be loaded in the main editor document, so we can render them only when needed.

## Why?

For the iframed editor (most cases), the assets are loaded twice.
Fixes #53590.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Load the editor. Everything should look as expected.

Run the following script:

```
window.wp.blocks.registerBlockType( 'test/v2', {
    apiVersion: 2,
    title: 'test',
} );
```

The iframe will be removed, but everything should look the same.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
