### PR TITLE
Edit site: prevent enqueuing entire stylesheet in iframe

### DIFF
--- a/lib/compat/wordpress-6.3/script-loader.php
+++ b/lib/compat/wordpress-6.3/script-loader.php
@@ -53,10 +53,6 @@ function _gutenberg_get_iframed_editor_assets() {
 	// Enqueue the `editorStyle` handles for all core block, and dependencies.
 	wp_enqueue_style( 'wp-edit-blocks' );
 
-	if ( 'site-editor.php' === $pagenow ) {
-		wp_enqueue_style( 'wp-edit-site' );
-	}
-
 	if ( current_theme_supports( 'wp-block-styles' ) ) {
 		wp_enqueue_style( 'wp-block-library-theme' );
 	}

--- a/lib/compat/wordpress-6.3/script-loader.php
+++ b/lib/compat/wordpress-6.3/script-loader.php
@@ -27,7 +27,7 @@ remove_action( 'in_admin_header', 'wp_global_styles_render_svg_filters' );
  * }
  */
 function _gutenberg_get_iframed_editor_assets() {
-	global $wp_styles, $wp_scripts, $pagenow;
+	global $wp_styles, $wp_scripts;
 
 	// Keep track of the styles and scripts instance to restore later.
 	$current_wp_styles  = $wp_styles;

--- a/lib/compat/wordpress-6.3/script-loader.php
+++ b/lib/compat/wordpress-6.3/script-loader.php
@@ -27,7 +27,7 @@ remove_action( 'in_admin_header', 'wp_global_styles_render_svg_filters' );
  * }
  */
 function _gutenberg_get_iframed_editor_assets() {
-	global $wp_styles, $wp_scripts;
+	global $wp_styles, $wp_scripts, $pagenow;
 
 	// Keep track of the styles and scripts instance to restore later.
 	$current_wp_styles  = $wp_styles;
@@ -52,6 +52,10 @@ function _gutenberg_get_iframed_editor_assets() {
 	wp_enqueue_script( 'wp-polyfill' );
 	// Enqueue the `editorStyle` handles for all core block, and dependencies.
 	wp_enqueue_style( 'wp-edit-blocks' );
+
+	if ( 'site-editor.php' === $pagenow ) {
+		wp_enqueue_style( 'wp-edit-site' );
+	}
 
 	if ( current_theme_supports( 'wp-block-styles' ) ) {
 		wp_enqueue_style( 'wp-block-library-theme' );

--- a/lib/compat/wordpress-6.4/script-loader.php
+++ b/lib/compat/wordpress-6.4/script-loader.php
@@ -96,3 +96,92 @@ function gutenberg_update_wp_date_settings( $scripts ) {
 
 add_action( 'wp_default_scripts', 'gutenberg_update_wp_date_settings' );
 
+/**
+ * Collect the block editor assets that need to be loaded into the editor's iframe.
+ *
+ * @since 6.0.0
+ * @access private
+ *
+ * @return array {
+ *     The block editor assets.
+ *
+ *     @type string|false $styles  String containing the HTML for styles.
+ *     @type string|false $scripts String containing the HTML for scripts.
+ * }
+ */
+function _gutenberg_get_iframed_editor_assets_6_4() {
+	global $wp_styles, $wp_scripts;
+
+	// Keep track of the styles and scripts instance to restore later.
+	$current_wp_styles  = $wp_styles;
+	$current_wp_scripts = $wp_scripts;
+
+	// Create new instances to collect the assets.
+	$wp_styles  = new WP_Styles();
+	$wp_scripts = new WP_Scripts();
+
+	// Register all currently registered styles and scripts. The actions that
+	// follow enqueue assets, but don't necessarily register them.
+	$wp_styles->registered  = $current_wp_styles->registered;
+	$wp_scripts->registered = $current_wp_scripts->registered;
+
+	// We generally do not need reset styles for the iframed editor.
+	// However, if it's a classic theme, margins will be added to every block,
+	// which is reset specifically for list items, so classic themes rely on
+	// these reset styles.
+	$wp_styles->done =
+		wp_theme_has_theme_json() ? array( 'wp-reset-editor-styles' ) : array();
+
+	wp_enqueue_script( 'wp-polyfill' );
+	// Enqueue the `editorStyle` handles for all core block, and dependencies.
+	wp_enqueue_style( 'wp-edit-blocks' );
+
+	if ( current_theme_supports( 'wp-block-styles' ) ) {
+		wp_enqueue_style( 'wp-block-library-theme' );
+	}
+
+	// We don't want to load EDITOR scripts in the iframe, only enqueue
+	// front-end assets for the content.
+	add_filter( 'should_load_block_editor_scripts_and_styles', '__return_false' );
+	do_action( 'enqueue_block_assets' );
+	remove_filter( 'should_load_block_editor_scripts_and_styles', '__return_false' );
+
+	$block_registry = WP_Block_Type_Registry::get_instance();
+
+	// Additionally, do enqueue `editorStyle` assets for all blocks, which
+	// contains editor-only styling for blocks (editor content).
+	foreach ( $block_registry->get_all_registered() as $block_type ) {
+		if ( isset( $block_type->editor_style_handles ) && is_array( $block_type->editor_style_handles ) ) {
+			foreach ( $block_type->editor_style_handles as $style_handle ) {
+				wp_enqueue_style( $style_handle );
+			}
+		}
+	}
+
+	ob_start();
+	wp_print_styles();
+	$styles = ob_get_clean();
+
+	ob_start();
+	wp_print_head_scripts();
+	wp_print_footer_scripts();
+	$scripts = ob_get_clean();
+
+	// Restore the original instances.
+	$wp_styles  = $current_wp_styles;
+	$wp_scripts = $current_wp_scripts;
+
+	return array(
+		'styles'  => $styles,
+		'scripts' => $scripts,
+	);
+}
+
+add_filter(
+	'block_editor_settings_all',
+	static function( $settings ) {
+		// We must override what core is passing now.
+		$settings['__unstableResolvedAssets'] = _gutenberg_get_iframed_editor_assets_6_4();
+		return $settings;
+	}
+);

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/style.scss
@@ -90,10 +90,6 @@
 	}
 }
 
-.edit-site-sidebar-navigation-screen-navigation-menus__content .popover-slot .wp-block-navigation-submenu {
-	display: none;
-}
-
 .edit-site-sidebar-navigation-screen-navigation-menus__loading.components-spinner {
 	margin-left: auto;
 	margin-right: auto;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

I tried to remove enqueuing the `edit-site` stylesheet from the iframe. We were forced to enqueue it because it was triggering the compat styles function, and we didn't investigate further.

It turns out this is caused by #48941. The addition of the `.wp-block-*` selector causes the compat function to enqueue it in the iframe and log a warning. I removed this line which means the stylesheet can now safely be removed from the iframe. However, I don't understand why this line is necessary. @jorgefilipecosta could you have a look?

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The `edit-site` stylesheet is meant to style UI, not editor content. Loading it in the iframe slow it down, and it can potentially clash with editor content rules.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
