### PR TITLE
Support controlling open/closed state for Dropdown and DropdownMenu

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,16 +2,13 @@
 
 ## Unreleased
 
-### Breaking changes
-
--   Make the `Popover.Slot` optional and render popovers at the bottom of the document's body by default. ([#53889](https://github.com/WordPress/gutenberg/pull/53889), [#53982](https://github.com/WordPress/gutenberg/pull/53982)).
-
 ### Enhancements
 
 -   Making Circular Option Picker a `listbox`. Note that while this changes some public API, new props are optional, and currently have default values; this will change in another patch ([#52255](https://github.com/WordPress/gutenberg/pull/52255)).
 -   `ToggleGroupControl`: Rewrite backdrop animation using framer motion shared layout animations, add better support for controlled and uncontrolled modes ([#50278](https://github.com/WordPress/gutenberg/pull/50278)).
 -   `Popover`: Add the `is-positioned` CSS class only after the popover has finished animating ([#54178](https://github.com/WordPress/gutenberg/pull/54178)).
 -   `Tooltip`: Replace the existing tooltip to simplify the implementation and improve accessibility while maintaining the same behaviors and API ([#48440](https://github.com/WordPress/gutenberg/pull/48440)).
+-   `Dropdown` and `DropdownMenu`: support controlled mode for the dropdown's open/closed state ([#54257](https://github.com/WordPress/gutenberg/pull/54257)).
 
 ### Bug Fix
 
@@ -32,9 +29,12 @@
 
 ## 25.7.0 (2023-08-31)
 
+### Breaking changes
+
+-   Make the `Popover.Slot` optional and render popovers at the bottom of the document's body by default. ([#53889](https://github.com/WordPress/gutenberg/pull/53889), [#53982](https://github.com/WordPress/gutenberg/pull/53982)).
+
 ### Enhancements
 
--   Make the `Popover.Slot` optional and render popovers at the bottom of the document's body by default. ([#53889](https://github.com/WordPress/gutenberg/pull/53889)).
 -   `ProgressBar`: Add transition to determinate indicator ([#53877](https://github.com/WordPress/gutenberg/pull/53877)).
 -   Prevent nested `SlotFillProvider` from rendering ([#53940](https://github.com/WordPress/gutenberg/pull/53940)).
 

--- a/packages/components/src/dropdown-menu/README.md
+++ b/packages/components/src/dropdown-menu/README.md
@@ -198,3 +198,21 @@ In some contexts, the arrow down key used to open the dropdown menu might need t
 
 -   Required: No
 -   Default: `false`
+
+### `defaultOpen`: `boolean`
+
+The open state of the dropdown menu when initially rendered. Use when you do not need to control its open state. It will be overridden by the `open` prop if it is specified on the component's first render.
+
+-   Required: No
+
+### `open`: `boolean`
+
+The controlled open state of the dropdown menu. Must be used in conjunction with `onToggle`.
+
+-   Required: No
+
+### `onToggle`: `( willOpen: boolean ) => void`
+
+A callback invoked when the state of the dropdown changes from open to closed and vice versa.
+
+-   Required: No

--- a/packages/components/src/dropdown-menu/index.tsx
+++ b/packages/components/src/dropdown-menu/index.tsx
@@ -57,6 +57,10 @@ function UnconnectedDropdownMenu( dropdownMenuProps: DropdownMenuProps ) {
 		text,
 		noIcons,
 
+		open,
+		defaultOpen,
+		onToggle: onToggleProp,
+
 		// Context
 		variant,
 	} = useContextSystem< DropdownMenuProps & DropdownMenuInternalContext >(
@@ -211,6 +215,9 @@ function UnconnectedDropdownMenu( dropdownMenuProps: DropdownMenuProps ) {
 					</NavigableMenu>
 				);
 			} }
+			open={ open }
+			defaultOpen={ defaultOpen }
+			onToggle={ onToggleProp }
 		/>
 	);
 }

--- a/packages/components/src/dropdown-menu/stories/index.story.tsx
+++ b/packages/components/src/dropdown-menu/stories/index.story.tsx
@@ -4,10 +4,6 @@
 import type { Meta, StoryFn } from '@storybook/react';
 
 /**
- * WordPress dependencies
- */
-import { useState } from '@wordpress/element';
-/**
  * Internal dependencies
  */
 import { DropdownMenu } from '..';
@@ -47,27 +43,11 @@ const meta: Meta< typeof DropdownMenu > = {
 };
 export default meta;
 
-const Template: StoryFn< typeof DropdownMenu > = ( props ) => {
-	const [ open, setOpen ] = useState( false );
-	return (
-		<div style={ { height: 150 } }>
-			<DropdownMenu
-				{ ...props }
-				open={ open }
-				onToggle={ ( willOpen ) => {
-					setOpen( willOpen );
-					props.onToggle?.( willOpen );
-				} }
-				// Only used if uncontrolled (ie. no `open` prop passed)
-				// defaultOpen={ false }
-			/>
-
-			<button onClick={ () => setOpen( ! open ) }>
-				Toggle (controlled update)
-			</button>
-		</div>
-	);
-};
+const Template: StoryFn< typeof DropdownMenu > = ( props ) => (
+	<div style={ { height: 150 } }>
+		<DropdownMenu { ...props } />
+	</div>
+);
 
 export const Default = Template.bind( {} );
 Default.args = {

--- a/packages/components/src/dropdown-menu/stories/index.story.tsx
+++ b/packages/components/src/dropdown-menu/stories/index.story.tsx
@@ -6,7 +6,7 @@ import type { Meta, StoryFn } from '@storybook/react';
 /**
  * WordPress dependencies
  */
-import { useState, useId, createContext, useContext } from '@wordpress/element';
+import { useState } from '@wordpress/element';
 /**
  * Internal dependencies
  */
@@ -135,76 +135,4 @@ WithChildren.args = {
 			</MenuGroup>
 		</>
 	),
-};
-
-const OnlyOneDropdownOpenContext = createContext< {
-	openDropdownId?: string;
-	setOpenDropdownId: ( id: string | undefined ) => void;
-} >( {
-	openDropdownId: undefined,
-	setOpenDropdownId: ( _instanceId ) => {},
-} );
-
-const ItemWithDropdown = () => {
-	const { openDropdownId, setOpenDropdownId } = useContext(
-		OnlyOneDropdownOpenContext
-	);
-
-	const instanceId = useId();
-
-	return (
-		<div>
-			Some text
-			<DropdownMenu
-				label="Open dropdown"
-				icon={ menu }
-				controls={ [
-					{
-						title: 'First Menu Item Label',
-						icon: arrowUp,
-						// eslint-disable-next-line no-console
-						onClick: () => console.log( 'up!' ),
-					},
-					{
-						title: 'Second Menu Item Label',
-						icon: arrowDown,
-						// eslint-disable-next-line no-console
-						onClick: () => console.log( 'down!' ),
-					},
-				] }
-				open={ openDropdownId === instanceId }
-				onToggle={ ( willOpen ) => {
-					if ( willOpen ) {
-						setOpenDropdownId( instanceId );
-					} else {
-						setOpenDropdownId( undefined );
-					}
-				} }
-			/>
-		</div>
-	);
-};
-
-export const OnlyOneOpened: StoryFn< typeof DropdownMenu > = () => {
-	const [ openDropdownId, setOpenDropdownId ] = useState<
-		string | undefined
-	>( undefined );
-
-	return (
-		<OnlyOneDropdownOpenContext.Provider
-			value={ { openDropdownId, setOpenDropdownId } }
-		>
-			<ItemWithDropdown />
-			<ItemWithDropdown />
-			<ItemWithDropdown />
-			<ItemWithDropdown />
-			<ItemWithDropdown />
-			<ItemWithDropdown />
-			<ItemWithDropdown />
-			<ItemWithDropdown />
-			<ItemWithDropdown />
-			<ItemWithDropdown />
-			<ItemWithDropdown />
-		</OnlyOneDropdownOpenContext.Provider>
-	);
 };

--- a/packages/components/src/dropdown-menu/stories/index.story.tsx
+++ b/packages/components/src/dropdown-menu/stories/index.story.tsx
@@ -6,7 +6,7 @@ import type { Meta, StoryFn } from '@storybook/react';
 /**
  * WordPress dependencies
  */
-import { useState } from '@wordpress/element';
+import { useState, useId, createContext, useContext } from '@wordpress/element';
 /**
  * Internal dependencies
  */
@@ -135,4 +135,76 @@ WithChildren.args = {
 			</MenuGroup>
 		</>
 	),
+};
+
+const OnlyOneDropdownOpenContext = createContext< {
+	openDropdownId?: string;
+	setOpenDropdownId: ( id: string | undefined ) => void;
+} >( {
+	openDropdownId: undefined,
+	setOpenDropdownId: ( _instanceId ) => {},
+} );
+
+const ItemWithDropdown = () => {
+	const { openDropdownId, setOpenDropdownId } = useContext(
+		OnlyOneDropdownOpenContext
+	);
+
+	const instanceId = useId();
+
+	return (
+		<div>
+			Some text
+			<DropdownMenu
+				label="Open dropdown"
+				icon={ menu }
+				controls={ [
+					{
+						title: 'First Menu Item Label',
+						icon: arrowUp,
+						// eslint-disable-next-line no-console
+						onClick: () => console.log( 'up!' ),
+					},
+					{
+						title: 'Second Menu Item Label',
+						icon: arrowDown,
+						// eslint-disable-next-line no-console
+						onClick: () => console.log( 'down!' ),
+					},
+				] }
+				open={ openDropdownId === instanceId }
+				onToggle={ ( willOpen ) => {
+					if ( willOpen ) {
+						setOpenDropdownId( instanceId );
+					} else {
+						setOpenDropdownId( undefined );
+					}
+				} }
+			/>
+		</div>
+	);
+};
+
+export const OnlyOneOpened: StoryFn< typeof DropdownMenu > = () => {
+	const [ openDropdownId, setOpenDropdownId ] = useState<
+		string | undefined
+	>( undefined );
+
+	return (
+		<OnlyOneDropdownOpenContext.Provider
+			value={ { openDropdownId, setOpenDropdownId } }
+		>
+			<ItemWithDropdown />
+			<ItemWithDropdown />
+			<ItemWithDropdown />
+			<ItemWithDropdown />
+			<ItemWithDropdown />
+			<ItemWithDropdown />
+			<ItemWithDropdown />
+			<ItemWithDropdown />
+			<ItemWithDropdown />
+			<ItemWithDropdown />
+			<ItemWithDropdown />
+		</OnlyOneDropdownOpenContext.Provider>
+	);
 };

--- a/packages/components/src/dropdown-menu/stories/index.story.tsx
+++ b/packages/components/src/dropdown-menu/stories/index.story.tsx
@@ -2,6 +2,11 @@
  * External dependencies
  */
 import type { Meta, StoryFn } from '@storybook/react';
+
+/**
+ * WordPress dependencies
+ */
+import { useState } from '@wordpress/element';
 /**
  * Internal dependencies
  */
@@ -25,6 +30,7 @@ const meta: Meta< typeof DropdownMenu > = {
 	title: 'Components/DropdownMenu',
 	component: DropdownMenu,
 	parameters: {
+		actions: { argTypesRegex: '^on.*' },
 		controls: { expanded: true },
 		docs: { canvas: { sourceState: 'shown' } },
 	},
@@ -34,15 +40,34 @@ const meta: Meta< typeof DropdownMenu > = {
 			mapping: { menu, chevronDown, more },
 			control: { type: 'select' },
 		},
+		open: { control: { type: null } },
+		defaultOpen: { control: { type: null } },
+		onToggle: { control: { type: null } },
 	},
 };
 export default meta;
 
-const Template: StoryFn< typeof DropdownMenu > = ( props ) => (
-	<div style={ { height: 150 } }>
-		<DropdownMenu { ...props } />
-	</div>
-);
+const Template: StoryFn< typeof DropdownMenu > = ( props ) => {
+	const [ open, setOpen ] = useState( false );
+	return (
+		<div style={ { height: 150 } }>
+			<DropdownMenu
+				{ ...props }
+				open={ open }
+				onToggle={ ( willOpen ) => {
+					setOpen( willOpen );
+					props.onToggle?.( willOpen );
+				} }
+				// Only used if uncontrolled (ie. no `open` prop passed)
+				// defaultOpen={ false }
+			/>
+
+			<button onClick={ () => setOpen( ! open ) }>
+				Toggle (controlled update)
+			</button>
+		</div>
+	);
+};
 
 export const Default = Template.bind( {} );
 Default.args = {

--- a/packages/components/src/dropdown-menu/types.ts
+++ b/packages/components/src/dropdown-menu/types.ts
@@ -140,10 +140,22 @@ export type DropdownMenuProps = {
 	 * A valid DropdownMenu must specify a `controls` or `children` prop, or both.
 	 */
 	controls?: DropdownOption[] | DropdownOption[][];
-
+	/**
+	 * The controlled open state of the dropdown menu.
+	 * Must be used in conjunction with `onToggle`.
+	 */
 	open?: boolean;
-	onToggle?: ( willOpen: boolean ) => void;
+	/**
+	 * The open state of the dropdown menu when initially rendered.
+	 * Use when you do not need to control its open state. It will be overridden
+	 * by the `open` prop if it is specified on the component's first render.
+	 */
 	defaultOpen?: boolean;
+	/**
+	 * A callback invoked when the state of the dropdown menu changes
+	 * from open to closed and vice versa.
+	 */
+	onToggle?: ( willOpen: boolean ) => void;
 };
 
 export type DropdownMenuInternalContext = {

--- a/packages/components/src/dropdown-menu/types.ts
+++ b/packages/components/src/dropdown-menu/types.ts
@@ -140,6 +140,10 @@ export type DropdownMenuProps = {
 	 * A valid DropdownMenu must specify a `controls` or `children` prop, or both.
 	 */
 	controls?: DropdownOption[] | DropdownOption[][];
+
+	open?: boolean;
+	onToggle?: ( willOpen: boolean ) => void;
+	defaultOpen?: boolean;
 };
 
 export type DropdownMenuInternalContext = {

--- a/packages/components/src/dropdown/README.md
+++ b/packages/components/src/dropdown/README.md
@@ -44,6 +44,12 @@ If you want to target the dropdown menu for styling purposes, you need to provid
 
 -   Required: No
 
+### `defaultOpen`: `boolean`
+
+The open state of the dropdown when initially rendered. Use when you do not need to control its open state. It will be overridden by the `open` prop if it is specified on the component's first render.
+
+-   Required: No
+
 ### `expandOnMobile`: `boolean`
 
 Opt-in prop to show popovers fullscreen on mobile.
@@ -74,11 +80,15 @@ A callback invoked when the popover should be closed.
 
 -   Required: No
 
+### `open`: `boolean`
+
+The controlled open state of the dropdown. Must be used in conjunction with `onToggle`.
+
+-   Required: No
+
 ### `onToggle`: `( willOpen: boolean ) => void`
 
-A callback invoked when the state of the popover changes from open to closed and vice versa.
-
-The callback receives a boolean as a parameter. If `true`, the popover will open. If `false`, the popover will close.
+A callback invoked when the state of the dropdown changes from open to closed and vice versa.
 
 -   Required: No
 

--- a/packages/components/src/dropdown/index.tsx
+++ b/packages/components/src/dropdown/index.tsx
@@ -7,7 +7,7 @@ import type { ForwardedRef } from 'react';
 /**
  * WordPress dependencies
  */
-import { useEffect, useRef, useState } from '@wordpress/element';
+import { useRef, useState } from '@wordpress/element';
 import { useMergeRefs } from '@wordpress/compose';
 import deprecated from '@wordpress/deprecated';
 
@@ -15,24 +15,9 @@ import deprecated from '@wordpress/deprecated';
  * Internal dependencies
  */
 import { contextConnect, useContextSystem } from '../ui/context';
+import { useControlledValue } from '../utils/hooks';
 import Popover from '../popover';
 import type { DropdownProps, DropdownInternalContext } from './types';
-
-function useObservableState(
-	initialState: boolean,
-	onStateChange?: ( newState: boolean ) => void
-) {
-	const [ state, setState ] = useState( initialState );
-	return [
-		state,
-		( value: boolean ) => {
-			setState( value );
-			if ( onStateChange ) {
-				onStateChange( value );
-			}
-		},
-	] as const;
-}
 
 const UnconnectedDropdown = (
 	props: DropdownProps,
@@ -50,6 +35,9 @@ const UnconnectedDropdown = (
 		onClose,
 		onToggle,
 		style,
+
+		open,
+		defaultOpen,
 
 		// Deprecated props
 		position,
@@ -74,20 +62,12 @@ const UnconnectedDropdown = (
 	const [ fallbackPopoverAnchor, setFallbackPopoverAnchor ] =
 		useState< HTMLDivElement | null >( null );
 	const containerRef = useRef< HTMLDivElement >();
-	const [ isOpen, setIsOpen ] = useObservableState( false, onToggle );
 
-	useEffect(
-		() => () => {
-			if ( onToggle && isOpen ) {
-				onToggle( false );
-			}
-		},
-		[ onToggle, isOpen ]
-	);
-
-	function toggle() {
-		setIsOpen( ! isOpen );
-	}
+	const [ isOpen, setIsOpen ] = useControlledValue( {
+		defaultValue: defaultOpen,
+		value: open,
+		onChange: onToggle,
+	} );
 
 	/**
 	 * Closes the popover when focus leaves it unless the toggle was pressed or
@@ -112,13 +92,15 @@ const UnconnectedDropdown = (
 	}
 
 	function close() {
-		if ( onClose ) {
-			onClose();
-		}
+		onClose?.();
 		setIsOpen( false );
 	}
 
-	const args = { isOpen, onToggle: toggle, onClose: close };
+	const args = {
+		isOpen: !! isOpen,
+		onToggle: () => setIsOpen( ! isOpen ),
+		onClose: close,
+	};
 	const popoverPropsHaveAnchor =
 		!! popoverProps?.anchor ||
 		// Note: `anchorRef`, `getAnchorRect` and `anchorRect` are deprecated and

--- a/packages/components/src/dropdown/index.tsx
+++ b/packages/components/src/dropdown/index.tsx
@@ -87,7 +87,9 @@ const UnconnectedDropdown = (
 			! containerRef.current.contains( ownerDocument.activeElement ) &&
 			( ! dialog || dialog.contains( containerRef.current ) )
 		) {
-			close();
+			// Temporarily disable this functionality to make sure that the storybook
+			// example works
+			// close();
 		}
 	}
 

--- a/packages/components/src/dropdown/index.tsx
+++ b/packages/components/src/dropdown/index.tsx
@@ -87,9 +87,7 @@ const UnconnectedDropdown = (
 			! containerRef.current.contains( ownerDocument.activeElement ) &&
 			( ! dialog || dialog.contains( containerRef.current ) )
 		) {
-			// Temporarily disable this functionality to make sure that the storybook
-			// example works
-			// close();
+			close();
 		}
 	}
 

--- a/packages/components/src/dropdown/stories/index.story.tsx
+++ b/packages/components/src/dropdown/stories/index.story.tsx
@@ -4,11 +4,6 @@
 import type { Meta, StoryFn } from '@storybook/react';
 
 /**
- * WordPress dependencies
- */
-import { useState } from '@wordpress/element';
-
-/**
  * Internal dependencies
  */
 import Dropdown from '..';
@@ -44,27 +39,11 @@ const meta: Meta< typeof Dropdown > = {
 };
 export default meta;
 
-const Template: StoryFn< typeof Dropdown > = ( args ) => {
-	const [ open, setOpen ] = useState( false );
-	return (
-		<div style={ { height: 150 } }>
-			<Dropdown
-				{ ...args }
-				open={ open }
-				onToggle={ ( willOpen ) => {
-					setOpen( willOpen );
-					args.onToggle?.( willOpen );
-				} }
-				// Only used if uncontrolled (ie. no `open` prop passed)
-				// defaultOpen={ false }
-			/>
-
-			<button onClick={ () => setOpen( ! open ) }>
-				Toggle (controlled update)
-			</button>
-		</div>
-	);
-};
+const Template: StoryFn< typeof Dropdown > = ( args ) => (
+	<div style={ { height: 150 } }>
+		<Dropdown { ...args } />
+	</div>
+);
 
 export const Default = Template.bind( {} );
 Default.args = {

--- a/packages/components/src/dropdown/stories/index.story.tsx
+++ b/packages/components/src/dropdown/stories/index.story.tsx
@@ -4,6 +4,11 @@
 import type { Meta, StoryFn } from '@storybook/react';
 
 /**
+ * WordPress dependencies
+ */
+import { useState } from '@wordpress/element';
+
+/**
  * Internal dependencies
  */
 import Dropdown from '..';
@@ -25,8 +30,13 @@ const meta: Meta< typeof Dropdown > = {
 		position: { control: { type: null } },
 		renderContent: { control: { type: null } },
 		renderToggle: { control: { type: null } },
+		open: { control: { type: null } },
+		defaultOpen: { control: { type: null } },
+		onToggle: { control: { type: null } },
+		onClose: { control: { type: null } },
 	},
 	parameters: {
+		actions: { argTypesRegex: '^on.*' },
 		controls: {
 			expanded: true,
 		},
@@ -35,9 +45,23 @@ const meta: Meta< typeof Dropdown > = {
 export default meta;
 
 const Template: StoryFn< typeof Dropdown > = ( args ) => {
+	const [ open, setOpen ] = useState( false );
 	return (
 		<div style={ { height: 150 } }>
-			<Dropdown { ...args } />
+			<Dropdown
+				{ ...args }
+				open={ open }
+				onToggle={ ( willOpen ) => {
+					setOpen( willOpen );
+					args.onToggle?.( willOpen );
+				} }
+				// Only used if uncontrolled (ie. no `open` prop passed)
+				// defaultOpen={ false }
+			/>
+
+			<button onClick={ () => setOpen( ! open ) }>
+				Toggle (controlled update)
+			</button>
 		</div>
 	);
 };

--- a/packages/components/src/dropdown/types.ts
+++ b/packages/components/src/dropdown/types.ts
@@ -62,11 +62,8 @@ export type DropdownProps = {
 	 */
 	onClose?: () => void;
 	/**
-	 * A callback invoked when the state of the popover changes
+	 * A callback invoked when the state of the dropdown changes
 	 * from open to closed and vice versa.
-	 * The callback receives a boolean as a parameter.
-	 * If true, the popover will open.
-	 * If false, the popover will close.
 	 */
 	onToggle?: ( willOpen: boolean ) => void;
 	/**
@@ -111,9 +108,16 @@ export type DropdownProps = {
 	 * @deprecated
 	 */
 	position?: PopoverProps[ 'position' ];
-
+	/**
+	 * The controlled open state of the dropdown.
+	 * Must be used in conjunction with `onToggle`.
+	 */
 	open?: boolean;
-
+	/**
+	 * The open state of the dropdown when initially rendered.
+	 * Use when you do not need to control its open state. It will be overridden
+	 * by the `open` prop if it is specified on the component's first render.
+	 */
 	defaultOpen?: boolean;
 };
 

--- a/packages/components/src/dropdown/types.ts
+++ b/packages/components/src/dropdown/types.ts
@@ -111,6 +111,10 @@ export type DropdownProps = {
 	 * @deprecated
 	 */
 	position?: PopoverProps[ 'position' ];
+
+	open?: boolean;
+
+	defaultOpen?: boolean;
 };
 
 export type DropdownInternalContext = {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Add support to control the open state of `Dropdown` and `DropdownMenu` components 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

To give more choice to consumers of the components on how to use such components (see for example https://github.com/WordPress/gutenberg/pull/54083)

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

By adding `open` / `onToggle` / `defaultOpen` props, using the `useControlledValue` hook and refactoring as needed.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- Tweak Storybook examples locally to use `Dropdown` and `DropdownMenu` in controlled mode (see https://github.com/WordPress/gutenberg/pull/54257/commits/d8379d92a99be0d77f1c223d0f02d6313996421e and https://github.com/WordPress/gutenberg/pull/54257/commits/2d35f365a978a9328eaddab079d5c832a6a3b457 to see the required changes)
- Test the tweaked Storybook examples on your machine (`npm run storybook:dev`) and make sure that the components continue to work as expected

## ✍️ Dev note

The open/closed state of the `Dropdown` and `DropdownMenu` components can now be controlled by their consumers via the `open`, `onToggle` and `defaultOpen` props, allowing more flexibility and more advanced behaviors when using these components.