### PR TITLE
Navigation Link: restore tooltip

### DIFF
--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -486,13 +486,8 @@ export default function NavigationLinkEdit( {
 					{ /* eslint-enable */ }
 					{ ! url ? (
 						<div className="wp-block-navigation-link__placeholder-text">
-							<Tooltip position="top center" text={ tooltipText }>
-								<>
-									<span>{ missingText }</span>
-									<span className="wp-block-navigation-link__missing_text-tooltip">
-										{ tooltipText }
-									</span>
-								</>
+							<Tooltip text={ tooltipText }>
+								<span>{ missingText }</span>
 							</Tooltip>
 						</div>
 					) : (
@@ -548,35 +543,25 @@ export default function NavigationLinkEdit( {
 								isDraft ||
 								isLabelFieldFocused ) && (
 								<div className="wp-block-navigation-link__placeholder-text wp-block-navigation-link__label">
-									<Tooltip
-										position="top center"
-										text={ tooltipText }
-									>
-										<>
-											<span
-												aria-label={ __(
-													'Navigation link text'
-												) }
-											>
-												{
-													// Some attributes are stored in an escaped form. It's a legacy issue.
-													// Ideally they would be stored in a raw, unescaped form.
-													// Unescape is used here to "recover" the escaped characters
-													// so they display without encoding.
-													// See `updateAttributes` for more details.
-													`${ decodeEntities(
-														label
-													) } ${
-														isInvalid || isDraft
-															? placeholderText
-															: ''
-													}`.trim()
-												}
-											</span>
-											<span className="wp-block-navigation-link__missing_text-tooltip">
-												{ tooltipText }
-											</span>
-										</>
+									<Tooltip text={ tooltipText }>
+										<span
+											aria-label={ __(
+												'Navigation link text'
+											) }
+										>
+											{
+												// Some attributes are stored in an escaped form. It's a legacy issue.
+												// Ideally they would be stored in a raw, unescaped form.
+												// Unescape is used here to "recover" the escaped characters
+												// so they display without encoding.
+												// See `updateAttributes` for more details.
+												`${ decodeEntities( label ) } ${
+													isInvalid || isDraft
+														? placeholderText
+														: ''
+												}`.trim()
+											}
+										</span>
 									</Tooltip>
 								</div>
 							) }

--- a/packages/block-library/src/navigation-link/editor.scss
+++ b/packages/block-library/src/navigation-link/editor.scss
@@ -67,14 +67,6 @@
 	color: #000;
 }
 
-.wp-block-navigation-link__missing_text-tooltip {
-	position: absolute;
-	width: 1px;
-	height: 1px;
-	padding: 0;
-	margin: -1px;
-	overflow: hidden;
-}
 /**
  * Menu item setup state. Is shown when a menu item has no URL configured.
  */


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

While looking at our internal usage of our Tooltip component, I noticed that the tooltip isn't showing in the Navigation block. The tooltip was added in #35139 for missing URLs, and another was added for invalid links in #31716. In the latter PR, a span containing the tooltip text and custom CSS to hide it was added, in addition to the Tooltip component.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

From a glance, it appears that the tooltip is intended to show. It's been a while since it's been worked on, but perhaps @jasmussen and @vcanales can confirm whether the tooltip should be visible.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

If we do want to show a tooltip, we can remove the span and custom class and display the tooltip through the component. I also believe the position should be the default, `bottom`, so the toolbar does not hide it. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->

**For missing URLs:** 

1. Add Navigation block 
2. Click plus icon to add an icon
3. Close the popover without choosing a link 
4. Hover over the text 'Add link' to see the tooltip for missing URLs. 

**For invalid links:**

5. Add a page to the navigation 
6. Delete the page in Pages without removing it from the navigation 
7. Refresh and hover over the invalid link to see tooltip for invalid items. 

## Screenshots or screencast <!-- if applicable -->

**Position set to `top`:** 

<img width="444" alt="Screenshot 2023-09-07 at 5 51 34 PM" src="https://github.com/WordPress/gutenberg/assets/35543432/9d510565-84b7-4bc5-9412-38a126209736">

**Position set to `bottom` (default):** 
<img width="434" alt="Screenshot 2023-09-07 at 5 54 02 PM" src="https://github.com/WordPress/gutenberg/assets/35543432/224302c8-e324-4a2b-9259-dd3249914278">
