### PR TITLE
[RNMobile] Fix issue with missing characters in Add Media placeholder button

### DIFF
--- a/packages/block-editor/src/components/media-placeholder/index.native.js
+++ b/packages/block-editor/src/components/media-placeholder/index.native.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { View, Text, TouchableOpacity } from 'react-native';
-import { sentenceCase } from 'change-case';
 
 /**
  * WordPress dependencies
@@ -104,13 +103,13 @@ function MediaPlaceholder( props ) {
 	let instructions = labels.instructions;
 	if ( instructions === undefined ) {
 		if ( isImage ) {
-			instructions = __( 'ADD IMAGE' );
+			instructions = __( 'Add image' );
 		} else if ( isVideo ) {
-			instructions = __( 'ADD VIDEO' );
+			instructions = __( 'Add video' );
 		} else if ( isAudio ) {
-			instructions = __( 'ADD AUDIO' );
+			instructions = __( 'Add audio' );
 		} else {
-			instructions = __( 'ADD IMAGE OR VIDEO' );
+			instructions = __( 'Add image or video' );
 		}
 	}
 
@@ -171,7 +170,7 @@ function MediaPlaceholder( props ) {
 						onPress={ onButtonPress( open ) }
 					>
 						<Text style={ emptyStateDescriptionStyles }>
-							{ sentenceCase( instructions ) }
+							{ instructions }
 						</Text>
 					</TouchableOpacity>
 				</>

--- a/packages/block-library/src/file/edit.native.js
+++ b/packages/block-library/src/file/edit.native.js
@@ -552,7 +552,7 @@ export class FileEdit extends Component {
 					icon={ <BlockIcon icon={ icon } /> }
 					labels={ {
 						title: __( 'File' ),
-						instructions: __( 'CHOOSE A FILE' ),
+						instructions: __( 'Choose a file' ),
 					} }
 					onSelect={ this.onSelectFile }
 					onFocus={ this.props.onFocus }

--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -75,7 +75,7 @@ const ALLOWED_MEDIA_TYPES = [ 'image' ];
 const allowedBlocks = [ 'core/image' ];
 
 const PLACEHOLDER_TEXT = Platform.isNative
-	? __( 'ADD MEDIA' )
+	? __( 'Add media' )
 	: __( 'Drag images, upload new ones or select files from your library.' );
 
 const MOBILE_CONTROL_PROPS_RANGE_CONTROL = Platform.isNative

--- a/packages/react-native-editor/CHANGELOG.md
+++ b/packages/react-native-editor/CHANGELOG.md
@@ -11,6 +11,7 @@ For each user feature we should also add a importance categorization label  to i
 
 ## Unreleased
 -   [*] Fix the obscurred "Insert from URL" input for media blocks when using a device in landscape orientation. [#54096]
+-   [*] Fix issue with missing characters in Add Media placeholder button [#54281]
 
 ## 1.103.1
 -   [**] Fix long-press gestures not working in RichText component [Android] [#54213]


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes an issue with the Media Placholder text button where characters were missing.

* https://github.com/wordpress-mobile/gutenberg-mobile/issues/6168
* https://github.com/wordpress-mobile/gutenberg-mobile/pull/6175

## Why?
The library that was handling sentence casing does not support internationalization. Any words containing diacritic marks are dropped. 

## How?
Removes `sentenceCase`, and updates casing of Media Placeholder strings.

## Testing Instructions
1. Switch app to a local that uses diacritic marks (like Español) 
2. Add a Gallery block
3. Note letters with diacritic marks should not be missing from Media Placeholder button (Añadir medios)
