### PR TITLE
Add block gap to Post Content block.

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -563,7 +563,7 @@ Displays the contents of a post or page. ([Source](https://github.com/WordPress/
 
 -	**Name:** core/post-content
 -	**Category:** theme
--	**Supports:** align (full, wide), color (background, gradients, link, text), dimensions (minHeight), layout, typography (fontSize, lineHeight), ~~html~~
+-	**Supports:** align (full, wide), color (background, gradients, link, text), dimensions (minHeight), layout, spacing (blockGap), typography (fontSize, lineHeight), ~~html~~
 -	**Attributes:** 
 
 ## Date

--- a/packages/block-library/src/post-content/block.json
+++ b/packages/block-library/src/post-content/block.json
@@ -14,6 +14,9 @@
 		"dimensions": {
 			"minHeight": true
 		},
+		"spacing": {
+			"blockGap": true
+		},
 		"color": {
 			"gradients": true,
 			"link": true,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Partially addresses #48902. (I'm not sure how useful adding margin and padding to Post Content might be, though happy to also do so if it's desirable)

We should be able to set a custom spacing in Post Content.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Check that block gap can be set on Post Content at the block level as well as in global styles. Gap value should also be correctly reflected in the post editor.

<img width="1168" alt="Screenshot 2023-09-08 at 4 07 58 pm" src="https://github.com/WordPress/gutenberg/assets/8096000/ff32b8ea-06cb-4c40-b7b5-16595d28e25a">
