### PR TITLE
Set max height of block preview according to viewport dimension

### DIFF
--- a/packages/block-editor/src/components/block-preview/auto.js
+++ b/packages/block-editor/src/components/block-preview/auto.js
@@ -13,11 +13,10 @@ import BlockList from '../block-list';
 import Iframe from '../iframe';
 import EditorStyles from '../editor-styles';
 import { store } from '../../store';
+import useViewportAspectRatio from './use-viewport-aspect-ratio';
 
 // This is used to avoid rendering the block list if the sizes change.
 let MemoizedBlockList;
-
-const MAX_HEIGHT = 2000;
 
 function ScaledBlockPreview( {
 	viewportWidth,
@@ -28,6 +27,8 @@ function ScaledBlockPreview( {
 	if ( ! viewportWidth ) {
 		viewportWidth = containerWidth;
 	}
+
+	const viewportAspectRatio = useViewportAspectRatio();
 
 	const [ contentResizeListener, { height: contentHeight } ] =
 		useResizeObserver();
@@ -58,6 +59,7 @@ function ScaledBlockPreview( {
 	MemoizedBlockList = MemoizedBlockList || pure( BlockList );
 
 	const scale = containerWidth / viewportWidth;
+	const maxHeight = containerWidth / viewportAspectRatio / scale;
 	const aspectRatio = contentHeight
 		? containerWidth / ( contentHeight * scale )
 		: 0;
@@ -72,7 +74,7 @@ function ScaledBlockPreview( {
 				// See https://github.com/WordPress/gutenberg/pull/52921 for more info.
 				aspectRatio,
 				maxHeight:
-					contentHeight > MAX_HEIGHT ? MAX_HEIGHT * scale : undefined,
+					contentHeight > maxHeight ? maxHeight * scale : undefined,
 				minHeight,
 			} }
 		>
@@ -100,8 +102,9 @@ function ScaledBlockPreview( {
 					height: contentHeight,
 					pointerEvents: 'none',
 					// This is a catch-all max-height for patterns.
-					// See: https://github.com/WordPress/gutenberg/pull/38175.
-					maxHeight: MAX_HEIGHT,
+					// See: https://github.com/WordPress/gutenberg/pull/38175,
+					// and https://github.com/WordPress/gutenberg/issues/50449.
+					maxHeight,
 					minHeight:
 						scale !== 0 && scale < 1 && minHeight
 							? minHeight / scale

--- a/packages/block-editor/src/components/block-preview/use-viewport-aspect-ratio.js
+++ b/packages/block-editor/src/components/block-preview/use-viewport-aspect-ratio.js
@@ -1,0 +1,33 @@
+/**
+ * WordPress dependencies
+ */
+import { useSyncExternalStore } from '@wordpress/element';
+
+class ViewportAspectRatioStore {
+	constructor() {
+		this.aspectRatio = window.innerWidth / window.innerHeight;
+	}
+
+	getSnapshot = () => {
+		return this.aspectRatio;
+	};
+
+	subscribe = () => {
+		function onResize() {
+			this.aspectRatio = window.innerWidth / window.innerHeight;
+		}
+		window.addEventListener( 'resize', onResize );
+		return () => {
+			window.removeEventListener( 'resize', onResize );
+		};
+	};
+}
+
+const viewportAspectRatioStore = new ViewportAspectRatioStore();
+
+export default function useViewportAspectRatio() {
+	return useSyncExternalStore(
+		viewportAspectRatioStore.subscribe,
+		viewportAspectRatioStore.getSnapshot
+	);
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Close https://github.com/WordPress/gutenberg/issues/50449. Set `max-height` for `<BlockPreview>` to the current viewport's ratio.

See the below before & after screenshots for comparison. Let's discuss if the outcome is desired or if we should find another alternative?

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
See https://github.com/WordPress/gutenberg/issues/50449#issuecomment-1684002018

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Calculate the viewport's aspect ratio in `useViewportAspectRatio` hook and use it to compute the max height of the preview.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Go to post editor
2. Click on the global inserter -> Patterns
3. Select a pattern category. (The **Banners** category in the twentytwentythree theme has some good examples)
4. See that the patterns don't grow beyond a certain height based on the viewport's dimension.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
Same as above. The changes are UI-only and can't be tested with screen readers.

## Screenshots or screencast <!-- if applicable -->
**Before**
![Before 1](https://github.com/WordPress/gutenberg/assets/7753001/43978781-6399-405f-b526-885ad1c41e78)

![Before 2](https://github.com/WordPress/gutenberg/assets/7753001/2ffd9458-c358-466c-bdbf-84bde334c143)

**After**
![After](https://github.com/WordPress/gutenberg/assets/7753001/0985fd23-eb2c-4fad-8e05-cabede27eb79)
