### PR TITLE
Popover: remove custom frame scroll/resize listeners

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3813,9 +3813,9 @@
 			}
 		},
 		"node_modules/@floating-ui/utils": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.1.1.tgz",
-			"integrity": "sha512-m0G6wlnhm/AX0H12IOWtK8gASEMffnX08RtKkCgTdHb9JpHKGloI7icFfLg9ZmQeavcvR0PKmzxClyuFPSjKWw=="
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.1.2.tgz",
+			"integrity": "sha512-ou3elfqG/hZsbmF4bxeJhPHIf3G2pm0ujc39hYEZrfVqt7Vk/Zji6CXc3W0pmYM8BW1g40U+akTl9DKZhFhInQ=="
 		},
 		"node_modules/@hapi/hoek": {
 			"version": "9.2.1",
@@ -59083,9 +59083,9 @@
 			}
 		},
 		"@floating-ui/utils": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.1.1.tgz",
-			"integrity": "sha512-m0G6wlnhm/AX0H12IOWtK8gASEMffnX08RtKkCgTdHb9JpHKGloI7icFfLg9ZmQeavcvR0PKmzxClyuFPSjKWw=="
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.1.2.tgz",
+			"integrity": "sha512-ou3elfqG/hZsbmF4bxeJhPHIf3G2pm0ujc39hYEZrfVqt7Vk/Zji6CXc3W0pmYM8BW1g40U+akTl9DKZhFhInQ=="
 		},
 		"@hapi/hoek": {
 			"version": "9.2.1",

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -25,6 +25,7 @@
 -   `Popover`: Remove unused `overlay` type from `positionToPlacement` utility function ([#54101](https://github.com/WordPress/gutenberg/pull/54101)).
 -   `Higher Order` -- `with-focus-outside`: Convert to TypeScript ([#53980](https://github.com/WordPress/gutenberg/pull/53980)).
 -   `IsolatedEventContainer`: Convert unit test to TypeScript ([#54316](https://github.com/WordPress/gutenberg/pull/54316)).
+-   `Popover`: Remove `scroll` and `resize` listeners for iframe overflow parents and rely on recently added native Floating UI support ([#54286](https://github.com/WordPress/gutenberg/pull/54286)).
 
 ### Experimental
 


### PR DESCRIPTION
After Floating UI ships a fix for iframe support in `getOverflowAncestors` (my WIP PR is here: https://github.com/floating-ui/floating-ui/pull/2535), we'll be able to remove a lot of custom code from `Popover`, code that finds the iframe of the reference and floating elements and attaches `resize` and `scroll` listeners to the iframe parent.

This is a draft PR that works together with the Floating UI changes, and is useful for testing that the changes really work.

It will remain a draft until we can really upgrade to a fixed version of Floating UI.