### PR TITLE
Block API: Stabilize Block Hooks feature

### DIFF
--- a/docs/reference-guides/block-api/block-metadata.md
+++ b/docs/reference-guides/block-api/block-metadata.md
@@ -464,7 +464,7 @@ Plugins and Themes can also register [custom block style](/docs/reference-guides
 
 It provides structured example data for the block. This data is used to construct a preview for the block to be shown in the Inspector Help Panel when the user mouses over the block.
 
-See the [the example documentation](/docs/reference-guides/block-api/block-registration.md#example-optional) for more details.
+See the [Example documentation](/docs/reference-guides/block-api/block-registration.md#example-optional) for more details.
 
 ### Variations
 
@@ -496,6 +496,23 @@ Block Variations is the API that allows a block to have similar versions of it, 
 _Note: In JavaScript you can provide a function for the `isActive` property, and a React element for the `icon`. In the `block.json` file both only support strings_
 
 See the [the variations documentation](/docs/reference-guides/block-api/block-variations.md) for more details.
+
+### Block Hooks
+
+-   Type: `object`
+-   Optional
+-   Property: `blockHooks`
+-   Since: `WordPress 6.4.0`
+
+```json
+{
+	"blockHooks": {
+		"my-plugin/banner": "after"
+	}
+}
+```
+
+Block Hooks is the API that allows a block to hook into the rendering of another block. It will enable a block to render its content before or after another block. It's also possible to hook into the rendering of a parent block and prepend or append the block to the list of child blocks. The key is the name of the block to hook into, and the value is the position to hook into. Take a look at the [Block Hooks documentation](/docs/reference-guides/block-api/block-registration.md#block-hooks-optional) for more info about the available configurations.
 
 ### Editor Script
 

--- a/docs/reference-guides/block-api/block-metadata.md
+++ b/docs/reference-guides/block-api/block-metadata.md
@@ -514,7 +514,7 @@ See the [the variations documentation](/docs/reference-guides/block-api/block-va
 
 Block Hooks is an API that allows a block to automatically insert itself next to all instances of a given block type, in a relative position also specified by the "hooked" block. That is, a block can opt to be inserted before or after a given block type, or as its first or last child (i.e. to be prepended or appended to the list of its child blocks, respectively). Hooked blocks will appear both on the frontend and in the editor (to allow for customization by the user).
 
-The key is the name of the block to hook into, and the value is the position to hook into. Take a look at the [Block Hooks documentation](/docs/reference-guides/block-api/block-registration.md#block-hooks-optional) for more info about available configurations.
+The key is the name of the block (`string`) to hook into, and the value is the position to hook into (`string`). Take a look at the [Block Hooks documentation](/docs/reference-guides/block-api/block-registration.md#block-hooks-optional) for more info about available configurations.
 
 ### Editor Script
 

--- a/docs/reference-guides/block-api/block-metadata.md
+++ b/docs/reference-guides/block-api/block-metadata.md
@@ -512,7 +512,9 @@ See the [the variations documentation](/docs/reference-guides/block-api/block-va
 }
 ```
 
-Block Hooks is the API that allows a block to hook into the rendering of another block. It will enable a block to render its content before or after another block. It's also possible to hook into the rendering of a parent block and prepend or append the block to the list of child blocks. The key is the name of the block to hook into, and the value is the position to hook into. Take a look at the [Block Hooks documentation](/docs/reference-guides/block-api/block-registration.md#block-hooks-optional) for more info about the available configurations.
+Block Hooks is an API that allows a block to automatically insert itself next to all instances of a given block type, in a relative position also specified by the "hooked" block. That is, a block can opt to be inserted before or after a given block type, or as its first or last child (i.e. to be prepended or appended to the list of its child blocks, respectively). Hooked blocks will appear both on the frontend and in the editor (to allow for customization by the user).
+
+The key is the name of the block to hook into, and the value is the position to hook into. Take a look at the [Block Hooks documentation](/docs/reference-guides/block-api/block-registration.md#block-hooks-optional) for more info about available configurations.
 
 ### Editor Script
 

--- a/docs/reference-guides/block-api/block-registration.md
+++ b/docs/reference-guides/block-api/block-registration.md
@@ -234,6 +234,7 @@ example: {
 #### variations (optional)
 
 -   **Type:** `Object[]`
+-   **Since**: `WordPress 5.9.0`
 
 Similarly to how the block's styles can be declared, a block type can define block variations that the user can pick from. The difference is that, rather than changing only the visual appearance, this field provides a way to apply initial custom attributes and inner blocks at the time when a block is inserted. See the [Block Variations API](/docs/reference-guides/block-api/block-variations.md) for more details.
 
@@ -265,12 +266,36 @@ parent: [ 'core/columns' ],
 #### ancestor (optional)
 
 -   **Type:** `Array`
+-   **Since**: `WordPress 6.0.0`
 
 The `ancestor` property makes a block available inside the specified block types at any position of the ancestor block subtree. That allows, for example, to place a 'Comment Content' block inside a 'Column' block, as long as 'Column' is somewhere within a 'Comment Template' block. In comparison to the `parent` property blocks that specify their `ancestor` can be placed anywhere in the subtree whilst blocks with a specified `parent` need to be direct children.
 
 ```js
 // Only allow this block when it is nested at any level in a Columns block.
 ancestor: [ 'core/columns' ],
+```
+
+#### Block Hooks (optional)
+
+-   **Type:** `Object`
+-   **Since**: `WordPress 6.4.0`
+
+Block Hooks is the API that allows a block to hook into the rendering of another block or multiple blocks. It will enable a block to render its content before or after another block. Alternatively, it's possible to hook into the rendering of a parent block and prepend or append the block to the list of inner blocks. The key is the name of the block (`string`) to hook into, and the value is the position to hook into (`string`). Allowed target values are:
+
+-   `before` – inject before the target block.
+-   `after` - inject after the target block.
+-   `firstChild` - inject before the first inner block of the target container block.
+-   `lastChild` - inject after the last inner block of the target container block.
+
+```js
+{
+	blockHooks: {
+		'core/verse': 'before'
+		'core/spacer': 'after',
+		'core/column': 'firstChild',
+		'core/group': 'lastChild',
+	}
+}
 ```
 
 ## Block Collections

--- a/docs/reference-guides/block-api/block-registration.md
+++ b/docs/reference-guides/block-api/block-registration.md
@@ -298,6 +298,8 @@ Block Hooks is the API that allows a block to hook into the rendering of another
 }
 ```
 
+It’s crucial to emphasize that the Block Hooks feature is designed to work only with static templates, template parts, and patterns loaded from HTML files shipped with the theme. It also integrates with patterns registered on the server by the site. The modification will never apply to the post content or patterns crafted by the user, nor theme templates and template parts modified by the user.
+
 ## Block Collections
 
 ## `registerBlockCollection`

--- a/docs/reference-guides/block-api/block-registration.md
+++ b/docs/reference-guides/block-api/block-registration.md
@@ -298,7 +298,9 @@ Block Hooks is the API that allows a block to hook into the rendering of another
 }
 ```
 
-It’s crucial to emphasize that the Block Hooks feature is designed to work only with static templates, template parts, and patterns loaded from HTML files shipped with the theme. It also integrates with patterns registered on the server by the site. The modification will never apply to the post content or patterns crafted by the user, nor theme templates and template parts modified by the user.
+It’s crucial to emphasize that the Block Hooks feature is only designed to work with _static_ block-based templates, template parts, and patterns. For patterns, this includes those provided by the theme, from [Block Pattern Directory](https://wordpress.org/patterns/), or from calls to [`register_block_pattern`](https://developer.wordpress.org/reference/functions/register_block_pattern/).
+
+Block Hooks will not work with post content or patterns crafted by the user, such as synced patterns, or theme templates and template parts that have been modified by the user.
 
 ## Block Collections
 

--- a/docs/reference-guides/block-api/block-registration.md
+++ b/docs/reference-guides/block-api/block-registration.md
@@ -280,7 +280,9 @@ ancestor: [ 'core/columns' ],
 -   **Type:** `Object`
 -   **Since**: `WordPress 6.4.0`
 
-Block Hooks is the API that allows a block to hook into the rendering of another block or multiple blocks. It will enable a block to render its content before or after another block. Alternatively, it's possible to hook into the rendering of a parent block and prepend or append the block to the list of inner blocks. The key is the name of the block (`string`) to hook into, and the value is the position to hook into (`string`). Allowed target values are:
+Block Hooks is an API that allows a block to automatically insert itself next to all instances of a given block type, in a relative position also specified by the "hooked" block. That is, a block can opt to be inserted before or after a given block type, or as its first or last child (i.e. to be prepended or appended to the list of its child blocks, respectively). Hooked blocks will appear both on the frontend and in the editor (to allow for customization by the user).
+
+The key is the name of the block (`string`) to hook into, and the value is the position to hook into (`string`). Allowed target values are:
 
 -   `before` – inject before the target block.
 -   `after` - inject after the target block.

--- a/lib/compat/wordpress-6.3/rest-api.php
+++ b/lib/compat/wordpress-6.3/rest-api.php
@@ -85,19 +85,6 @@ if ( ! function_exists( 'add_modified_wp_template_schema' ) ) {
 }
 add_filter( 'rest_api_init', 'add_modified_wp_template_schema' );
 
-// If the Block Hooks experiment is enabled, we load the block patterns
-// controller in lib/experimental/rest-api.php instead.
-if ( ! gutenberg_is_experiment_enabled( 'gutenberg-block-hooks' ) ) {
-	/**
-	 * Registers the block patterns REST API routes.
-	 */
-	function gutenberg_register_rest_block_patterns() {
-		$block_patterns = new Gutenberg_REST_Block_Patterns_Controller_6_3();
-		$block_patterns->register_routes();
-	}
-	add_action( 'rest_api_init', 'gutenberg_register_rest_block_patterns' );
-}
-
 /**
  * Registers the Navigation Fallbacks REST API routes.
  */

--- a/lib/compat/wordpress-6.4/block-hooks.php
+++ b/lib/compat/wordpress-6.4/block-hooks.php
@@ -13,10 +13,10 @@
  * @return array Updated settings array.
  */
 function gutenberg_add_hooked_blocks( $settings, $metadata ) {
-	if ( ! isset( $metadata['__experimentalBlockHooks'] ) ) {
+	if ( ! isset( $metadata['blockHooks'] ) ) {
 		return $settings;
 	}
-	$block_hooks = $metadata['__experimentalBlockHooks'];
+	$block_hooks = $metadata['blockHooks'];
 
 	/**
 	 * Map the camelCased position string from block.json to the snake_cased block type position

--- a/lib/compat/wordpress-6.4/class-gutenberg-rest-block-patterns-controller.php
+++ b/lib/compat/wordpress-6.4/class-gutenberg-rest-block-patterns-controller.php
@@ -26,9 +26,6 @@ class Gutenberg_REST_Block_Patterns_Controller extends Gutenberg_REST_Block_Patt
 	 */
 	public function prepare_item_for_response( $item, $request ) {
 		$response = parent::prepare_item_for_response( $item, $request );
-		if ( ! gutenberg_is_experiment_enabled( 'gutenberg-block-hooks' ) ) {
-			return $response;
-		}
 
 		$data = $response->get_data();
 

--- a/lib/compat/wordpress-6.4/class-gutenberg-rest-block-patterns-controller.php
+++ b/lib/compat/wordpress-6.4/class-gutenberg-rest-block-patterns-controller.php
@@ -29,6 +29,10 @@ class Gutenberg_REST_Block_Patterns_Controller extends Gutenberg_REST_Block_Patt
 
 		$data = $response->get_data();
 
+		if ( empty( $data['content'] ) ) {
+			return $response;
+		}
+
 		$blocks          = parse_blocks( $data['content'] );
 		$data['content'] = gutenberg_serialize_blocks( $blocks ); // Serialize or render?
 

--- a/lib/compat/wordpress-6.4/rest-api.php
+++ b/lib/compat/wordpress-6.4/rest-api.php
@@ -11,6 +11,15 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
+ * Registers the block patterns REST API routes.
+ */
+function gutenberg_register_rest_block_patterns_routes() {
+	$block_patterns = new Gutenberg_REST_Block_Patterns_Controller();
+	$block_patterns->register_routes();
+}
+add_action( 'rest_api_init', 'gutenberg_register_rest_block_patterns_routes' );
+
+/**
  * Registers the Global Styles Revisions REST API routes.
  */
 function gutenberg_register_global_styles_revisions_endpoints() {

--- a/lib/experimental/editor-settings.php
+++ b/lib/experimental/editor-settings.php
@@ -30,10 +30,6 @@ function gutenberg_enable_experiments() {
 	if ( gutenberg_is_experiment_enabled( 'gutenberg-no-tinymce' ) ) {
 		wp_add_inline_script( 'wp-block-library', 'window.__experimentalDisableTinymce = true', 'before' );
 	}
-
-	if ( $gutenberg_experiments && array_key_exists( 'gutenberg-block-hooks', $gutenberg_experiments ) ) {
-		wp_add_inline_script( 'wp-block-editor', 'window.__experimentalBlockHooks = true', 'before' );
-	}
 }
 
 add_action( 'admin_init', 'gutenberg_enable_experiments' );

--- a/lib/experimental/rest-api.php
+++ b/lib/experimental/rest-api.php
@@ -10,17 +10,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 	die( 'Silence is golden.' );
 }
 
-if ( gutenberg_is_experiment_enabled( 'gutenberg-block-hooks' ) ) {
-	/**
-	 * Registers the block patterns REST API routes.
-	 */
-	function gutenberg_register_rest_block_patterns() {
-		$block_patterns = new Gutenberg_REST_Block_Patterns_Controller();
-		$block_patterns->register_routes();
-	}
-	add_action( 'rest_api_init', 'gutenberg_register_rest_block_patterns' );
-}
-
 /**
  * Registers the customizer nonces REST API routes.
  */

--- a/lib/experiments-page.php
+++ b/lib/experiments-page.php
@@ -104,18 +104,6 @@ function gutenberg_initialize_experiments_settings() {
 	);
 
 	add_settings_field(
-		'gutenberg-block-hooks',
-		__( 'Block hooks', 'gutenberg' ),
-		'gutenberg_display_experiment_field',
-		'gutenberg-experiments',
-		'gutenberg_experiments_section',
-		array(
-			'label' => __( 'Block hooks allow automatically inserting a block in a position relative to another.', 'gutenberg' ),
-			'id'    => 'gutenberg-block-hooks',
-		)
-	);
-
-	add_settings_field(
 		'gutenberg-custom-fields',
 		__( 'Connections', 'gutenberg' ),
 		'gutenberg_display_experiment_field',

--- a/lib/load.php
+++ b/lib/load.php
@@ -52,6 +52,7 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 
 	// WordPress 6.4 compat.
 	require_once __DIR__ . '/compat/wordpress-6.4/class-gutenberg-rest-global-styles-revisions-controller-6-4.php';
+	require_once __DIR__ . '/compat/wordpress-6.4/class-gutenberg-rest-block-patterns-controller.php';
 	require_once __DIR__ . '/compat/wordpress-6.4/rest-api.php';
 	require_once __DIR__ . '/compat/wordpress-6.4/theme-previews.php';
 
@@ -64,9 +65,6 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 		require_once __DIR__ . '/experimental/class-wp-rest-customizer-nonces.php';
 	}
 	require_once __DIR__ . '/experimental/class-gutenberg-rest-template-revision-count.php';
-	if ( gutenberg_is_experiment_enabled( 'gutenberg-block-hooks' ) ) {
-		require_once __DIR__ . '/experimental/class-gutenberg-rest-block-patterns-controller.php';
-	}
 	require_once __DIR__ . '/experimental/rest-api.php';
 }
 
@@ -96,6 +94,7 @@ require_once __DIR__ . '/compat/wordpress-6.3/kses.php';
 
 // WordPress 6.4 compat.
 require __DIR__ . '/compat/wordpress-6.4/blocks.php';
+require __DIR__ . '/compat/wordpress-6.4/block-hooks.php';
 require __DIR__ . '/compat/wordpress-6.4/block-patterns.php';
 require __DIR__ . '/compat/wordpress-6.4/script-loader.php';
 
@@ -111,9 +110,6 @@ if ( gutenberg_is_experiment_enabled( 'gutenberg-no-tinymce' ) ) {
 	require __DIR__ . '/experimental/disable-tinymce.php';
 }
 
-if ( gutenberg_is_experiment_enabled( 'gutenberg-block-hooks' ) ) {
-	require __DIR__ . '/experimental/block-hooks.php';
-}
 require __DIR__ . '/experimental/interactivity-api/class-wp-interactivity-store.php';
 require __DIR__ . '/experimental/interactivity-api/store.php';
 require __DIR__ . '/experimental/interactivity-api/scripts.php';

--- a/packages/block-editor/src/hooks/block-hooks.js
+++ b/packages/block-editor/src/hooks/block-hooks.js
@@ -250,10 +250,8 @@ export const withBlockHooks = createHigherOrderComponent( ( BlockEdit ) => {
 	};
 }, 'withBlockHooks' );
 
-if ( window?.__experimentalBlockHooks ) {
-	addFilter(
-		'editor.BlockEdit',
-		'core/block-hooks/with-inspector-control',
-		withBlockHooks
-	);
-}
+addFilter(
+	'editor.BlockEdit',
+	'core/block-hooks/with-inspector-control',
+	withBlockHooks
+);

--- a/packages/block-library/src/pattern/index.php
+++ b/packages/block-library/src/pattern/index.php
@@ -43,8 +43,8 @@ function render_block_core_pattern( $attributes ) {
 	$pattern = $registry->get_registered( $slug );
 	$content = _inject_theme_attribute_in_block_template_content( $pattern['content'] );
 
-	$gutenberg_experiments = get_option( 'gutenberg-experiments' );
-	if ( $gutenberg_experiments && ! empty( $gutenberg_experiments['gutenberg-block-hooks'] ) ) {
+	// This can be removed when the minimum supported WordPress is >= 6.4.
+	if ( defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN ) {
 		// TODO: In the long run, we'd likely want to have a filter in the `WP_Block_Patterns_Registry` class
 		// instead to allow us plugging in code like this.
 		$blocks  = parse_blocks( $content );

--- a/packages/blocks/src/api/registration.js
+++ b/packages/blocks/src/api/registration.js
@@ -167,7 +167,7 @@ function getBlockSettingsFromMetadata( { textdomain, ...metadata } ) {
 		'styles',
 		'example',
 		'variations',
-		'__experimentalBlockHooks',
+		'blockHooks',
 	];
 
 	const settings = Object.fromEntries(

--- a/packages/blocks/src/api/test/registration.js
+++ b/packages/blocks/src/api/test/registration.js
@@ -133,6 +133,7 @@ describe( 'blocks', () => {
 				supports: {},
 				styles: [],
 				variations: [],
+				blockHooks: {},
 				save: noop,
 				category: 'text',
 				title: 'block title',
@@ -280,6 +281,7 @@ describe( 'blocks', () => {
 				supports: {},
 				styles: [],
 				variations: [],
+				blockHooks: {},
 				save: expect.any( Function ),
 			} );
 		} );
@@ -317,6 +319,7 @@ describe( 'blocks', () => {
 					supports: {},
 					styles: [],
 					variations: [],
+					blockHooks: {},
 				}
 			);
 		} );
@@ -350,6 +353,7 @@ describe( 'blocks', () => {
 				supports: {},
 				styles: [],
 				variations: [],
+				blockHooks: {},
 			} );
 		} );
 
@@ -362,6 +366,9 @@ describe( 'blocks', () => {
 						fontSize: 'fontSize',
 					},
 					uses_context: [ 'textColor' ],
+					block_hooks: {
+						'tests/my-block': 'after',
+					},
 				},
 			} );
 
@@ -385,6 +392,9 @@ describe( 'blocks', () => {
 				supports: {},
 				styles: [],
 				variations: [],
+				blockHooks: {
+					'tests/my-block': 'after',
+				},
 			} );
 		} );
 
@@ -421,6 +431,7 @@ describe( 'blocks', () => {
 				supports: {},
 				styles: [],
 				variations: [],
+				blockHooks: {},
 			} );
 		} );
 
@@ -490,6 +501,7 @@ describe( 'blocks', () => {
 				supports: {},
 				styles: [],
 				variations: [],
+				blockHooks: {},
 			} );
 		} );
 
@@ -522,6 +534,7 @@ describe( 'blocks', () => {
 				supports: {},
 				styles: [],
 				variations: [],
+				blockHooks: {},
 			} );
 		} );
 
@@ -568,6 +581,7 @@ describe( 'blocks', () => {
 				supports: {},
 				styles: [],
 				variations: [],
+				blockHooks: {},
 			} );
 		} );
 
@@ -628,6 +642,7 @@ describe( 'blocks', () => {
 				supports: {},
 				styles: [],
 				variations: [],
+				blockHooks: {},
 			} );
 		} );
 
@@ -655,6 +670,7 @@ describe( 'blocks', () => {
 				supports: {},
 				styles: [],
 				variations: [],
+				blockHooks: {},
 			} );
 		} );
 
@@ -742,6 +758,7 @@ describe( 'blocks', () => {
 										supports: {},
 										styles: [],
 										variations: [],
+										blockHooks: {},
 										save: () => null,
 										...blockSettingsWithDeprecations,
 									},
@@ -916,6 +933,7 @@ describe( 'blocks', () => {
 						keywords: [ 'variation' ],
 					},
 				],
+				blockHooks: {},
 				edit: Edit,
 				save: noop,
 			} );
@@ -988,6 +1006,7 @@ describe( 'blocks', () => {
 						keywords: [ 'variation (translated)' ],
 					},
 				],
+				blockHooks: {},
 				edit: Edit,
 				save: noop,
 			} );
@@ -1042,6 +1061,7 @@ describe( 'blocks', () => {
 					supports: {},
 					styles: [],
 					variations: [],
+					blockHooks: {},
 				},
 			] );
 			const oldBlock = unregisterBlockType( 'core/test-block' );
@@ -1060,6 +1080,7 @@ describe( 'blocks', () => {
 				supports: {},
 				styles: [],
 				variations: [],
+				blockHooks: {},
 			} );
 			expect( getBlockTypes() ).toEqual( [] );
 		} );
@@ -1140,6 +1161,7 @@ describe( 'blocks', () => {
 				supports: {},
 				styles: [],
 				variations: [],
+				blockHooks: {},
 			} );
 		} );
 
@@ -1166,6 +1188,7 @@ describe( 'blocks', () => {
 				supports: {},
 				styles: [],
 				variations: [],
+				blockHooks: {},
 			} );
 		} );
 	} );
@@ -1199,6 +1222,7 @@ describe( 'blocks', () => {
 					supports: {},
 					styles: [],
 					variations: [],
+					blockHooks: {},
 				},
 				{
 					name: 'core/test-block-with-settings',
@@ -1215,6 +1239,7 @@ describe( 'blocks', () => {
 					supports: {},
 					styles: [],
 					variations: [],
+					blockHooks: {},
 				},
 			] );
 		} );

--- a/packages/blocks/src/api/test/registration.js
+++ b/packages/blocks/src/api/test/registration.js
@@ -435,6 +435,48 @@ describe( 'blocks', () => {
 			} );
 		} );
 
+		// This test can be removed once the polyfill for blockHooks gets removed.
+		it( 'should polyfill blockHooks using metadata on the client when not set on the server', () => {
+			const blockName = 'tests/hooked-block';
+			unstable__bootstrapServerSideBlockDefinitions( {
+				[ blockName ]: {
+					category: 'widgets',
+				},
+			} );
+
+			const blockType = {
+				title: 'block title',
+			};
+			registerBlockType(
+				{
+					name: blockName,
+					blockHooks: {
+						'tests/block': 'firstChild',
+					},
+					category: 'ignored',
+				},
+				blockType
+			);
+			expect( getBlockType( blockName ) ).toEqual( {
+				name: blockName,
+				save: expect.any( Function ),
+				title: 'block title',
+				category: 'widgets',
+				icon: { src: BLOCK_ICON_DEFAULT },
+				attributes: {},
+				providesContext: {},
+				usesContext: [],
+				keywords: [],
+				selectors: {},
+				supports: {},
+				styles: [],
+				variations: [],
+				blockHooks: {
+					'tests/block': 'firstChild',
+				},
+			} );
+		} );
+
 		it( 'should validate the icon', () => {
 			const blockType = {
 				save: noop,

--- a/packages/blocks/src/store/process-block-type.js
+++ b/packages/blocks/src/store/process-block-type.js
@@ -55,6 +55,7 @@ export const processBlockType =
 			supports: {},
 			styles: [],
 			variations: [],
+			blockHooks: {},
 			save: () => null,
 			...select.getBootstrappedBlockType( name ),
 			...blockSettings,

--- a/packages/blocks/src/store/reducer.js
+++ b/packages/blocks/src/store/reducer.js
@@ -83,14 +83,13 @@ function bootstrappedBlockTypes( state = {}, action ) {
 				// definitions and needs to be polyfilled. This can be removed when the
 				// minimum supported WordPress is >= 6.4.
 				if (
-					serverDefinition.__experimentalBlockHooks === undefined &&
-					blockType.__experimentalBlockHooks
+					serverDefinition.blockHooks === undefined &&
+					blockType.blockHooks
 				) {
 					newDefinition = {
 						...serverDefinition,
 						...newDefinition,
-						__experimentalBlockHooks:
-							blockType.__experimentalBlockHooks,
+						blockHooks: blockType.blockHooks,
 					};
 				}
 			} else {

--- a/schemas/json/block.json
+++ b/schemas/json/block.json
@@ -706,6 +706,16 @@
 				}
 			}
 		},
+		"blockHooks": {
+			"description": "Block Hooks allow a block to automatically insert itself next to all instances of a given block type.\n\nSee the Block Hooks documentation at https://developer.wordpress.org/block-editor/reference-guides/block-api/block-registration/#block-hooks-optional for more details.",
+			"type": "object",
+			"patternProperties": {
+				"^[a-z][a-z0-9-]*/[a-z][a-z0-9-]*$": {
+					"enum": [ "before", "after", "firstChild", "lastChild" ]
+				}
+			},
+			"additionalProperties": false
+		},
 		"editorScript": {
 			"description": "Block type editor script definition. It will only be enqueued in the context of the editor.",
 			"oneOf": [


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

- Part of #53987.

## What?
<!-- In a few words, what is the PR actually doing? -->

Adds all what's necessary to stabilize the Block Hooks feature. I also included some minimal additions to the documentation that should help later to shape the dev note.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

To ship Block Hooks as a stable feature in WordPress 6.4 beta 1.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Updates all code occurrences where the experimental name `__experimentalBlockHooks` was used. It also removes the experiment that guarded the feature in the Gutenberg plugin.

I believe that we still will have to provide a feature detection as a follow-up based on some new function that is going to be introduced for WordPress 6.4. This will allow ensuring that the custom logic added for the feature runs only for older versions of WordPress. For WordPress 6.4 and above, it should be all natively supported with the changes outlined in https://core.trac.wordpress.org/ticket/59313 and proposed in https://github.com/WordPress/wordpress-develop/pull/5158.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- Install the [Like Button example plugin](https://github.com/ockham/like-button/releases/download/v0.4.1/like-button.zip).
- Make sure you're using a Block Theme (e.g. Twenty Twenty Three) that uses the Comments (and Comment Template) block.
- Go to any of the existing posts with a comment and ensure that the Like Button is present without any changes to the theme:
  <img width="761" alt="Screenshot 2023-09-12 at 12 10 34" src="https://github.com/WordPress/gutenberg/assets/699132/8b33075d-3921-495e-89c5-d0154aee9e29">
- Open the Site Editor to view the "Single" template.
- Select the Comment Template block, and open the block inspector sidebar.
- Switch to the ⚙️ ("Settings") tab.
- Verify that the "Plugins" panel is present, contains the toggle for the Like Button block similar to:
![image](https://github.com/WordPress/gutenberg/assets/96308/de1d2c64-707d-4dcd-9f15-1918eaae9d9b)

