### PR TITLE
Allow Modals to optionally ignore the `Close` button when determining where to place focus 

### DIFF
--- a/packages/block-editor/src/hooks/block-rename-ui.js
+++ b/packages/block-editor/src/hooks/block-rename-ui.js
@@ -69,6 +69,7 @@ function RenameModal( { blockName, originalBlockName, onClose, onSave } ) {
 			aria={ {
 				describedby: dialogDescription,
 			} }
+			focusOnMount="firstElement"
 		>
 			<p id={ dialogDescription }>
 				{ __( 'Enter a custom name for this block.' ) }

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking changes
+
+-   Update `Modal` so that when passing `firstElement` as the `focusOnMount` prop it will optimize for focusing first element within the Modal's _contents_ as opposed to the entire component. ([#54296](https://github.com/WordPress/gutenberg/pull/54296)).
+
 ### Enhancements
 
 -   Making Circular Option Picker a `listbox`. Note that while this changes some public API, new props are optional, and currently have default values; this will change in another patch ([#52255](https://github.com/WordPress/gutenberg/pull/52255)).

--- a/packages/components/src/modal/README.md
+++ b/packages/components/src/modal/README.md
@@ -189,7 +189,11 @@ Titles are required for accessibility reasons, see `aria.labelledby` and `title`
 
 #### `focusOnMount`: `boolean | 'firstElement'`
 
-If this property is true, it will focus the first tabbable element rendered in the modal.
+If this property is true, it will focus the first tabbable element rendered anywhere within the modal.
+
+If the value `firstElement` is used then the component will attempt to place focus
+within the Modal's **contents**, ignoring focusable nodes within the Modal's header. This is useful
+for Modal's which contain immediately focusable elements such as form fields.
 
 -   Required: No
 -   Default: `true`

--- a/packages/components/src/modal/README.md
+++ b/packages/components/src/modal/README.md
@@ -192,7 +192,7 @@ Titles are required for accessibility reasons, see `aria.labelledby` and `title`
 If this property is true, it will focus the first tabbable element rendered anywhere within the modal.
 
 If the value `firstElement` is used then the component will attempt to place focus
-within the Modal's **contents**, initially skipping focusable nodes within the Modal's header. This is useful
+within the Modal's **contents**, ignoring focusable nodes within the Modal's header. This is useful
 for Modal's which contain immediately focusable elements such as form fields.
 
 -   Required: No

--- a/packages/components/src/modal/README.md
+++ b/packages/components/src/modal/README.md
@@ -192,7 +192,7 @@ Titles are required for accessibility reasons, see `aria.labelledby` and `title`
 If this property is true, it will focus the first tabbable element rendered anywhere within the modal.
 
 If the value `firstElement` is used then the component will attempt to place focus
-within the Modal's **contents**, ignoring focusable nodes within the Modal's header. This is useful
+within the Modal's **contents**, initially skipping focusable nodes within the Modal's header. This is useful
 for Modal's which contain immediately focusable elements such as form fields.
 
 -   Required: No

--- a/packages/components/src/modal/index.tsx
+++ b/packages/components/src/modal/index.tsx
@@ -39,10 +39,14 @@ import type { ModalProps } from './types';
 // Used to count the number of open modals.
 let openModalCount = 0;
 
+/**
+ * Returns the first tabbable element that is not a close button.
+ * See: https://github.com/WordPress/gutenberg/issues/54106.
+ * @param tabbables HTMLElement[] an array of tabbable elements.
+ * @return HTMLElement the first tabbable element that is not a close button.
+ */
 function focusFirstNonCloseButtonElement( tabbables: HTMLElement[] ) {
 	return tabbables.find(
-		// Ignore the `Close` button.
-		// See: https://github.com/WordPress/gutenberg/issues/54106.
 		( tabbableNode ) => tabbableNode?.ariaLabel !== 'Close'
 	);
 }
@@ -55,7 +59,7 @@ function UnforwardedModal(
 		bodyOpenClassName = 'modal-open',
 		role = 'dialog',
 		title = null,
-		focusOnMount = focusFirstNonCloseButtonElement,
+		focusOnMount = true,
 		shouldCloseOnEsc = true,
 		shouldCloseOnClickOutside = true,
 		isDismissible = true,
@@ -83,7 +87,13 @@ function UnforwardedModal(
 	const headingId = title
 		? `components-modal-header-${ instanceId }`
 		: aria.labelledby;
-	const focusOnMountRef = useFocusOnMount( focusOnMount );
+
+	// Modals should ignore the `Close` button which is the first focusable element.
+	// Remap `true` to select the next focusable element instead.
+	const focusOnMountRef = useFocusOnMount(
+		focusOnMount === true ? focusFirstNonCloseButtonElement : focusOnMount
+	);
+
 	const constrainedTabbingRef = useConstrainedTabbing();
 	const focusReturnRef = useFocusReturn();
 	const focusOutsideProps = useFocusOutside( onRequestClose );

--- a/packages/components/src/modal/index.tsx
+++ b/packages/components/src/modal/index.tsx
@@ -104,8 +104,6 @@ function UnforwardedModal(
 		? `components-modal-header-${ instanceId }`
 		: aria.labelledby;
 
-	// Modals should ignore the `Close` button which is the first focusable element.
-	// Remap `true` to select the next focusable element instead.
 	const focusOnMountRef = useFocusOnMount(
 		focusOnMount === 'firstElement' ? getFirstTabbableElement : focusOnMount
 	);

--- a/packages/components/src/modal/index.tsx
+++ b/packages/components/src/modal/index.tsx
@@ -39,6 +39,8 @@ import type { ModalProps } from './types';
 // Used to count the number of open modals.
 let openModalCount = 0;
 
+const MODAL_HEADER_CLASSNAME = 'components-modal__header';
+
 /**
  * When `firstElement` is passed to `focusOnMount`, this function is optimised to
  * avoid focusing on the `Close` button (or other "header" elements of the Modal
@@ -55,7 +57,7 @@ let openModalCount = 0;
 function getFirstTabbableElement( tabbables: HTMLElement[] ) {
 	// Attempt to locate tabbable outside of the header portion of the Modal.
 	const firstContentTabbable = tabbables.find( ( tabbable ) => {
-		return tabbable.closest( '.components-modal__header' ) === null;
+		return tabbable.closest( `.${ MODAL_HEADER_CLASSNAME }` ) === null;
 	} );
 
 	if ( firstContentTabbable ) {
@@ -284,7 +286,7 @@ function UnforwardedModal(
 						tabIndex={ hasScrollableContent ? 0 : undefined }
 					>
 						{ ! __experimentalHideHeader && (
-							<div className="components-modal__header">
+							<div className={ MODAL_HEADER_CLASSNAME }>
 								<div className="components-modal__header-heading-container">
 									{ icon && (
 										<span

--- a/packages/components/src/modal/index.tsx
+++ b/packages/components/src/modal/index.tsx
@@ -39,6 +39,14 @@ import type { ModalProps } from './types';
 // Used to count the number of open modals.
 let openModalCount = 0;
 
+function focusFirstNonCloseButtonElement( tabbables: HTMLElement[] ) {
+	return tabbables.find(
+		// Ignore the `Close` button.
+		// See: https://github.com/WordPress/gutenberg/issues/54106.
+		( tabbableNode ) => tabbableNode?.ariaLabel !== 'Close'
+	);
+}
+
 function UnforwardedModal(
 	props: ModalProps,
 	forwardedRef: ForwardedRef< HTMLDivElement >
@@ -47,7 +55,7 @@ function UnforwardedModal(
 		bodyOpenClassName = 'modal-open',
 		role = 'dialog',
 		title = null,
-		focusOnMount = true,
+		focusOnMount = focusFirstNonCloseButtonElement,
 		shouldCloseOnEsc = true,
 		shouldCloseOnClickOutside = true,
 		isDismissible = true,

--- a/packages/components/src/modal/index.tsx
+++ b/packages/components/src/modal/index.tsx
@@ -39,8 +39,6 @@ import type { ModalProps } from './types';
 // Used to count the number of open modals.
 let openModalCount = 0;
 
-const MODAL_HEADER_CLASSNAME = 'components-modal__header';
-
 /**
  * When `firstElement` is passed to `focusOnMount`, this function is optimised to
  * avoid focusing on the `Close` button (or other "header" elements of the Modal
@@ -57,7 +55,7 @@ const MODAL_HEADER_CLASSNAME = 'components-modal__header';
 function getFirstTabbableElement( tabbables: HTMLElement[] ) {
 	// Attempt to locate tabbable outside of the header portion of the Modal.
 	const firstContentTabbable = tabbables.find( ( tabbable ) => {
-		return tabbable.closest( `.${ MODAL_HEADER_CLASSNAME }` ) === null;
+		return tabbable.closest( '.components-modal__header' ) === null;
 	} );
 
 	if ( firstContentTabbable ) {
@@ -106,6 +104,8 @@ function UnforwardedModal(
 		? `components-modal-header-${ instanceId }`
 		: aria.labelledby;
 
+	// Modals should ignore the `Close` button which is the first focusable element.
+	// Remap `true` to select the next focusable element instead.
 	const focusOnMountRef = useFocusOnMount(
 		focusOnMount === 'firstElement' ? getFirstTabbableElement : focusOnMount
 	);
@@ -286,7 +286,7 @@ function UnforwardedModal(
 						tabIndex={ hasScrollableContent ? 0 : undefined }
 					>
 						{ ! __experimentalHideHeader && (
-							<div className={ MODAL_HEADER_CLASSNAME }>
+							<div className="components-modal__header">
 								<div className="components-modal__header-heading-container">
 									{ icon && (
 										<span

--- a/packages/components/src/modal/index.tsx
+++ b/packages/components/src/modal/index.tsx
@@ -49,10 +49,10 @@ let openModalCount = 0;
  * for the best a11y experience.
  *
  * See: https://github.com/WordPress/gutenberg/issues/54106.
- * @param tabbables HTMLElement[] an array of tabbable elements.
- * @return HTMLElement the first tabbable element that is not a close button.
+ * @param tabbables Element[] an array of tabbable elements.
+ * @return Element the first tabbable element that is not a close button.
  */
-function getFirstTabbableElement( tabbables: HTMLElement[] ) {
+function getFirstTabbableElement( tabbables: Element[] ) {
 	// Attempt to locate tabbable outside of the header portion of the Modal.
 	const firstContentTabbable = tabbables.find( ( tabbable ) => {
 		return tabbable.closest( '.components-modal__header' ) === null;

--- a/packages/components/src/modal/index.tsx
+++ b/packages/components/src/modal/index.tsx
@@ -40,17 +40,17 @@ import type { ModalProps } from './types';
 let openModalCount = 0;
 
 /**
- * When `firstElement` is passed to `focusOnMount`, this function is optimised to
+ * When `firstElement` is passed to `focusOnMount`, this function is optimized to
  * avoid focusing on the `Close` button (or other "header" elements of the Modal
  * and instead focus within the Modal's contents.
  * However, if no tabbable elements are found within the Modal's contents, the
  * first tabbable element (likely the `Close` button) will be focused instead.
- * This ensures that at least one element is focused whilst still optimising
+ * This ensures that at least one element is focused whilst still optimizing
  * for the best a11y experience.
  *
  * See: https://github.com/WordPress/gutenberg/issues/54106.
  * @param tabbables Element[] an array of tabbable elements.
- * @return Element the first tabbable element that is not a close button.
+ * @return Element the first tabbable element in the Modal contents (or any tabbable element if none are found in content).
  */
 function getFirstTabbableElement( tabbables: Element[] ) {
 	// Attempt to locate tabbable outside of the header portion of the Modal.

--- a/packages/components/src/modal/index.tsx
+++ b/packages/components/src/modal/index.tsx
@@ -53,18 +53,16 @@ let openModalCount = 0;
  * @return Element the first tabbable element in the Modal contents (or any tabbable element if none are found in content).
  */
 function getFirstTabbableElement( tabbables: Element[] ) {
-	// Attempt to locate tabbable outside of the header portion of the Modal.
-	const firstContentTabbable = tabbables.find( ( tabbable ) => {
-		return tabbable.closest( '.components-modal__header' ) === null;
-	} );
-
-	if ( firstContentTabbable ) {
-		return firstContentTabbable;
-	}
-
-	// Fallback to the first tabbable element anywhere within the Modal.
-	// Likely the `Close` button.
-	return tabbables[ 0 ];
+	return (
+		// Attempt to locate tabbable outside of the header portion of the Modal.
+		tabbables.find(
+			( tabbable ) =>
+				tabbable.closest( `.${ MODAL_HEADER_CLASSNAME }` ) === null
+		) ??
+		// Fallback to the first tabbable element anywhere within the Modal.
+		// Likely the `Close` button.
+		tabbables[ 0 ]
+	);
 }
 
 function UnforwardedModal(

--- a/packages/components/src/modal/index.tsx
+++ b/packages/components/src/modal/index.tsx
@@ -104,7 +104,7 @@ function UnforwardedModal(
 		? `components-modal-header-${ instanceId }`
 		: aria.labelledby;
 
-	// Modals should ignore the `Close` button which is the first focusable element.
+	// If focusOnMount is `firstElement`, Modals should ignore the `Close` button which is the first focusable element.
 	// Remap `true` to select the next focusable element instead.
 	const focusOnMountRef = useFocusOnMount(
 		focusOnMount === 'firstElement' ? getFirstTabbableElement : focusOnMount

--- a/packages/components/src/modal/stories/index.story.tsx
+++ b/packages/components/src/modal/stories/index.story.tsx
@@ -28,7 +28,8 @@ const meta: Meta< typeof Modal > = {
 			control: { type: null },
 		},
 		focusOnMount: {
-			control: { type: 'boolean' },
+			options: [ true, false, 'firstElement' ],
+			control: { type: 'select' },
 		},
 		role: {
 			control: { type: 'text' },

--- a/packages/components/src/modal/test/index.tsx
+++ b/packages/components/src/modal/test/index.tsx
@@ -131,22 +131,11 @@ describe( 'Modal', () => {
 	} );
 
 	describe( 'Focus handling', () => {
-		it( 'should focus the first focusable element in the contents (if found) when `firstElement` passed as value for `focusOnMount` prop', async () => {
-			const originalOffsetWidth = Object.getOwnPropertyDescriptor(
-				HTMLElement.prototype,
-				'offsetWidth'
-			);
+		let originalOffsetWidth: PropertyDescriptor | undefined;
+		let originalOffsetHeight: PropertyDescriptor | undefined;
+		let originalGetClientRects: PropertyDescriptor | undefined;
 
-			const originalOffsetHeight = Object.getOwnPropertyDescriptor(
-				HTMLElement.prototype,
-				'offsetHeight'
-			);
-
-			const originalGetClientRects = Object.getOwnPropertyDescriptor(
-				HTMLElement.prototype,
-				'getClientRects'
-			);
-
+		beforeEach( () => {
 			/**
 			 * The test environment does not have a layout engine, so we need to mock
 			 * the offsetWidth, offsetHeight and getClientRects methods to return a
@@ -155,6 +144,21 @@ describe( 'Modal', () => {
 			 * to determine if the element is visible or not.
 			 * See https://github.com/WordPress/gutenberg/blob/trunk/packages/dom/src/focusable.js#L55-L61.
 			 */
+			originalOffsetWidth = Object.getOwnPropertyDescriptor(
+				HTMLElement.prototype,
+				'offsetWidth'
+			);
+
+			originalOffsetHeight = Object.getOwnPropertyDescriptor(
+				HTMLElement.prototype,
+				'offsetHeight'
+			);
+
+			originalGetClientRects = Object.getOwnPropertyDescriptor(
+				HTMLElement.prototype,
+				'getClientRects'
+			);
+
 			Object.defineProperty( HTMLElement.prototype, 'offsetWidth', {
 				configurable: true,
 				value: 100,
@@ -169,7 +173,28 @@ describe( 'Modal', () => {
 				configurable: true,
 				value: () => [ 1, 2, 3 ],
 			} );
+		} );
 
+		afterEach( () => {
+			// Restore original HTMLElement prototype.
+			// See beforeEach for details.
+			Object.defineProperty( HTMLElement.prototype, 'offsetWidth', {
+				configurable: true,
+				value: originalOffsetWidth,
+			} );
+
+			Object.defineProperty( HTMLElement.prototype, 'offsetHeight', {
+				configurable: true,
+				value: originalOffsetHeight,
+			} );
+
+			Object.defineProperty( HTMLElement.prototype, 'getClientRects', {
+				configurable: true,
+				value: originalGetClientRects,
+			} );
+		} );
+
+		it( 'should focus the first focusable element in the contents (if found) when `firstElement` passed as value for `focusOnMount` prop', async () => {
 			const user = userEvent.setup();
 
 			const FocusMountDemo = () => {
@@ -208,63 +233,9 @@ describe( 'Modal', () => {
 			expect(
 				screen.getByTestId( 'first-focusable-element' )
 			).toHaveFocus();
-
-			// Restore original HTMLElement prototype
-			Object.defineProperty( HTMLElement.prototype, 'offsetWidth', {
-				configurable: true,
-				value: originalOffsetWidth,
-			} );
-
-			Object.defineProperty( HTMLElement.prototype, 'offsetHeight', {
-				configurable: true,
-				value: originalOffsetHeight,
-			} );
-
-			Object.defineProperty( HTMLElement.prototype, 'getClientRects', {
-				configurable: true,
-				value: originalGetClientRects,
-			} );
 		} );
 
 		it( 'should focus the first focusable element anywhere within the dialog when `firstElement` passed as value for `focusOnMount` prop but there is no focusable element in the Modal contents', async () => {
-			const originalOffsetWidth = Object.getOwnPropertyDescriptor(
-				HTMLElement.prototype,
-				'offsetWidth'
-			);
-
-			const originalOffsetHeight = Object.getOwnPropertyDescriptor(
-				HTMLElement.prototype,
-				'offsetHeight'
-			);
-
-			const originalGetClientRects = Object.getOwnPropertyDescriptor(
-				HTMLElement.prototype,
-				'getClientRects'
-			);
-
-			/**
-			 * The test environment does not have a layout engine, so we need to mock
-			 * the offsetWidth, offsetHeight and getClientRects methods to return a
-			 * value that is not 0. This ensures that the focusable elements can be
-			 * found by the `focusOnMount` logic which depends on layout information
-			 * to determine if the element is visible or not.
-			 * See https://github.com/WordPress/gutenberg/blob/trunk/packages/dom/src/focusable.js#L55-L61.
-			 */
-			Object.defineProperty( HTMLElement.prototype, 'offsetWidth', {
-				configurable: true,
-				value: 100,
-			} );
-
-			Object.defineProperty( HTMLElement.prototype, 'offsetHeight', {
-				configurable: true,
-				value: 100,
-			} );
-
-			Object.defineProperty( HTMLElement.prototype, 'getClientRects', {
-				configurable: true,
-				value: () => [ 1, 2, 3 ],
-			} );
-
 			const user = userEvent.setup();
 
 			const FocusMountDemo = () => {
@@ -296,22 +267,6 @@ describe( 'Modal', () => {
 					name: 'Close',
 				} )
 			).toHaveFocus();
-
-			// Restore original HTMLElement prototype
-			Object.defineProperty( HTMLElement.prototype, 'offsetWidth', {
-				configurable: true,
-				value: originalOffsetWidth,
-			} );
-
-			Object.defineProperty( HTMLElement.prototype, 'offsetHeight', {
-				configurable: true,
-				value: originalOffsetHeight,
-			} );
-
-			Object.defineProperty( HTMLElement.prototype, 'getClientRects', {
-				configurable: true,
-				value: originalGetClientRects,
-			} );
 		} );
 
 		it( 'should focus the Modal dialog when `true` passed as value for `focusOnMount` prop', async () => {

--- a/packages/components/src/modal/test/index.tsx
+++ b/packages/components/src/modal/test/index.tsx
@@ -131,67 +131,27 @@ describe( 'Modal', () => {
 	} );
 
 	describe( 'Focus handling', () => {
-		let originalOffsetWidth: PropertyDescriptor | undefined;
-		let originalOffsetHeight: PropertyDescriptor | undefined;
-		let originalGetClientRects: PropertyDescriptor | undefined;
+		let originalGetClientRects: () => DOMRectList;
 
 		beforeEach( () => {
 			/**
 			 * The test environment does not have a layout engine, so we need to mock
-			 * the offsetWidth, offsetHeight and getClientRects methods to return a
-			 * value that is not 0. This ensures that the focusable elements can be
+			 * the getClientRects method. This ensures that the focusable elements can be
 			 * found by the `focusOnMount` logic which depends on layout information
 			 * to determine if the element is visible or not.
 			 * See https://github.com/WordPress/gutenberg/blob/trunk/packages/dom/src/focusable.js#L55-L61.
 			 */
-			originalOffsetWidth = Object.getOwnPropertyDescriptor(
-				HTMLElement.prototype,
-				'offsetWidth'
-			);
-
-			originalOffsetHeight = Object.getOwnPropertyDescriptor(
-				HTMLElement.prototype,
-				'offsetHeight'
-			);
-
-			originalGetClientRects = Object.getOwnPropertyDescriptor(
-				HTMLElement.prototype,
-				'getClientRects'
-			);
-
-			Object.defineProperty( HTMLElement.prototype, 'offsetWidth', {
-				configurable: true,
-				value: 100,
-			} );
-
-			Object.defineProperty( HTMLElement.prototype, 'offsetHeight', {
-				configurable: true,
-				value: 100,
-			} );
-
-			Object.defineProperty( HTMLElement.prototype, 'getClientRects', {
-				configurable: true,
-				value: () => [ 1, 2, 3 ],
-			} );
+			// @ts-expect-error We're not trying to comply to the DOM spec, only mocking
+			window.HTMLElement.prototype.getClientRects = function () {
+				return [ 'trick-jsdom-into-having-size-for-element-rect' ];
+			};
 		} );
 
 		afterEach( () => {
 			// Restore original HTMLElement prototype.
 			// See beforeEach for details.
-			Object.defineProperty( HTMLElement.prototype, 'offsetWidth', {
-				configurable: true,
-				value: originalOffsetWidth,
-			} );
-
-			Object.defineProperty( HTMLElement.prototype, 'offsetHeight', {
-				configurable: true,
-				value: originalOffsetHeight,
-			} );
-
-			Object.defineProperty( HTMLElement.prototype, 'getClientRects', {
-				configurable: true,
-				value: originalGetClientRects,
-			} );
+			window.HTMLElement.prototype.getClientRects =
+				originalGetClientRects;
 		} );
 
 		it( 'should focus the first focusable element in the contents (if found) when `firstElement` passed as value for `focusOnMount` prop', async () => {

--- a/packages/components/src/modal/test/index.tsx
+++ b/packages/components/src/modal/test/index.tsx
@@ -184,9 +184,13 @@ describe( 'Modal', () => {
 								<p>Modal content</p>
 								<a
 									href="https://wordpress.org"
-									data-testid="button-with-focus"
+									data-testid="first-focusable-element"
 								>
-									Button
+									First Focusable Element
+								</a>
+
+								<a href="https://wordpress.org">
+									Another Focusable Element
 								</a>
 							</Modal>
 						) }
@@ -199,7 +203,9 @@ describe( 'Modal', () => {
 
 			await user.click( opener );
 
-			expect( screen.getByTestId( 'button-with-focus' ) ).toHaveFocus();
+			expect(
+				screen.getByTestId( 'first-focusable-element' )
+			).toHaveFocus();
 
 			// Restore original HTMLElement prototype
 			Object.defineProperty( HTMLElement.prototype, 'offsetWidth', {

--- a/packages/components/src/modal/test/index.tsx
+++ b/packages/components/src/modal/test/index.tsx
@@ -129,4 +129,39 @@ describe( 'Modal', () => {
 			screen.getByText( 'A sweet button', { selector: 'button' } )
 		).toBeInTheDocument();
 	} );
+
+	describe( 'Focus handling', () => {
+		it( 'should focus the first focusable element in the contents when `firstElement` passed as value for `focusOnMount` prop', async () => {
+			const user = userEvent.setup();
+			const FocusMountDemo = () => {
+				const [ isShown, setIsShown ] = useState( false );
+				return (
+					<>
+						<button onClick={ () => setIsShown( true ) }>📣</button>
+						{ isShown && (
+							<Modal
+								focusOnMount="firstElement"
+								onRequestClose={ () => setIsShown( false ) }
+							>
+								<p>Modal content</p>
+								<a
+									href="https://wordpress.org"
+									data-testid="button-with-focus"
+								>
+									Button
+								</a>
+							</Modal>
+						) }
+					</>
+				);
+			};
+			render( <FocusMountDemo /> );
+
+			const opener = screen.getByRole( 'button' );
+
+			await user.click( opener );
+
+			expect( screen.getByTestId( 'button-with-focus' ) ).toHaveFocus();
+		} );
+	} );
 } );

--- a/packages/compose/CHANGELOG.md
+++ b/packages/compose/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+-   Update `useFocusOnMount` to allow passing a callback as the primary argument. This allows for consumers to optionally implement custom focus handling. ([#54296](https://github.com/WordPress/gutenberg/pull/54296)).
+
 ## 6.18.0 (2023-08-31)
 
 ## 6.17.0 (2023-08-16)

--- a/packages/compose/README.md
+++ b/packages/compose/README.md
@@ -315,7 +315,7 @@ const WithFocusOnMount = () => {
 
 _Parameters_
 
--   _focusOnMount_ `boolean | 'firstElement'`: Focus on mount mode.
+-   _focusOnMount_ `boolean | 'firstElement' | Function`: Focus on mount mode.
 
 _Returns_
 

--- a/packages/compose/README.md
+++ b/packages/compose/README.md
@@ -315,7 +315,7 @@ const WithFocusOnMount = () => {
 
 _Parameters_
 
--   _focusOnMount_ `boolean | 'firstElement' | Function`: Focus on mount mode.
+-   _focusOnMount_ `boolean | 'firstElement' | ((tabbables: Element[]) => Element | null | undefined)`: Focus on mount mode. May optionally be a callback that receives an array of tabbable elements and should return the element to focus.
 
 _Returns_
 

--- a/packages/compose/src/hooks/use-focus-on-mount/index.js
+++ b/packages/compose/src/hooks/use-focus-on-mount/index.js
@@ -7,7 +7,7 @@ import { focus } from '@wordpress/dom';
 /**
  * Hook used to focus the first tabbable element on mount.
  *
- * @param {boolean | 'firstElement'} focusOnMount Focus on mount mode.
+ * @param {boolean | 'firstElement' | Function} focusOnMount Focus on mount mode.
  * @return {import('react').RefCallback<HTMLElement>} Ref callback.
  *
  * @example
@@ -73,6 +73,20 @@ export default function useFocusOnMount( focusOnMount = 'firstElement' ) {
 
 				if ( firstTabbable ) {
 					setFocus( /** @type {HTMLElement} */ ( firstTabbable ) );
+				}
+			}, 0 );
+
+			return;
+		}
+
+		if ( typeof focusOnMountRef?.current === 'function' ) {
+			timerId.current = setTimeout( () => {
+				const tabbables = focus.tabbable.find( node );
+
+				const elementToFocus = focusOnMountRef.current( tabbables );
+
+				if ( elementToFocus ) {
+					setFocus( /** @type {HTMLElement} */ ( elementToFocus ) );
 				}
 			}, 0 );
 

--- a/packages/compose/src/hooks/use-focus-on-mount/index.js
+++ b/packages/compose/src/hooks/use-focus-on-mount/index.js
@@ -83,6 +83,9 @@ export default function useFocusOnMount( focusOnMount = 'firstElement' ) {
 			timerId.current = setTimeout( () => {
 				const tabbables = focus.tabbable.find( node );
 
+				// Ignoring next line because the type is actually callable,
+				// but the linter cannot recognise the outer typeof check.
+				// @ts-ignore
 				const elementToFocus = focusOnMountRef.current( tabbables );
 
 				if ( elementToFocus ) {

--- a/packages/compose/src/hooks/use-focus-on-mount/index.js
+++ b/packages/compose/src/hooks/use-focus-on-mount/index.js
@@ -80,13 +80,15 @@ export default function useFocusOnMount( focusOnMount = 'firstElement' ) {
 		}
 
 		if ( typeof focusOnMountRef?.current === 'function' ) {
+			// Store a reference to the function to ensure that the
+			// focusOnMountRef will still hold a reference to a function
+			// when the timeout fires.
+			const focusOnMountFunc = focusOnMountRef.current;
+
 			timerId.current = setTimeout( () => {
 				const tabbables = focus.tabbable.find( node );
 
-				// Ignoring next line because the type is actually callable,
-				// but the linter cannot recognise the outer typeof check.
-				// @ts-ignore
-				const elementToFocus = focusOnMountRef.current( tabbables );
+				const elementToFocus = focusOnMountFunc( tabbables );
 
 				if ( elementToFocus ) {
 					setFocus( /** @type {HTMLElement} */ ( elementToFocus ) );

--- a/packages/compose/src/hooks/use-focus-on-mount/index.js
+++ b/packages/compose/src/hooks/use-focus-on-mount/index.js
@@ -7,7 +7,7 @@ import { focus } from '@wordpress/dom';
 /**
  * Hook used to focus the first tabbable element on mount.
  *
- * @param {boolean | 'firstElement' | Function} focusOnMount Focus on mount mode.
+ * @param {boolean | 'firstElement' | ((tabbables: Element[]) => Element | null | undefined) } focusOnMount Focus on mount mode. May optionally be a callback that receives an array of tabbable elements and should return the element to focus.
  * @return {import('react').RefCallback<HTMLElement>} Ref callback.
  *
  * @example

--- a/test/e2e/specs/editor/various/block-renaming.spec.js
+++ b/test/e2e/specs/editor/various/block-renaming.spec.js
@@ -58,11 +58,13 @@ test.describe( 'Block Renaming', () => {
 				name: 'Rename',
 			} );
 
-			// Check focus is transferred into modal.
-			await expect( renameModal ).toBeFocused();
-
 			// Check the Modal is perceivable.
 			await expect( renameModal ).toBeVisible();
+
+			const nameInput = renameModal.getByLabel( 'Block name' );
+
+			// Check focus is transferred into the input within the Modal.
+			await expect( nameInput ).toBeFocused();
 
 			const saveButton = renameModal.getByRole( 'button', {
 				name: 'Save',
@@ -70,8 +72,6 @@ test.describe( 'Block Renaming', () => {
 			} );
 
 			await expect( saveButton ).toBeDisabled();
-
-			const nameInput = renameModal.getByLabel( 'Block name' );
 
 			await expect( nameInput ).toHaveAttribute( 'placeholder', 'Group' );
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Updates all instances of `<Modal>` in order that they ignore the `Close` button when determining where to place focus when mounting.

Alternative to https://github.com/WordPress/gutenberg/pull/54590

Closes https://github.com/WordPress/gutenberg/issues/54106

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

As discussed in https://github.com/WordPress/gutenberg/issues/54106 dialogs (including Modal) should ideally place focus on the first focusable element on mount. Currently _all_ Modals find that the `Close` button is the first element in the DOM inside the Modal that is focusable and thus it receives focus. A11y feedback has been that this is unhelpful.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Updates the `useFocusOnMount` hook API to (optionally) accept a callback which is passed a list of "tabbable" elements within the Modal. The consumer can then use this to programmatically select the element which should received focus.

Previously the API only allowed for "first element".

The `<Modal>` component is then updated to utilise this API to ensure that it selects the first focusable element which is _not_ the `Close` button

This appraoch is inline with that @ciampo suggested in https://github.com/WordPress/gutenberg/issues/54106#issuecomment-1710423257.

## Questions/Concerns

- this change has a wide scope of impact on _all_ Modals. Should we first test it in isolation the Block Rename Modal instance and if it's ok then roll out to the underlying component?
- @youknowriad cautioned that exposing such an "open" API could be a concern for backwards compatibility. We should also explore whether it's possible to simply this by moving the `Close` button outside of the `focusOnMount` _ref_ whilst remaining _within_ the constrained tabbing ref. @ciampo felt this would be very difficult however.
- what should happen if there are no _other_ focusable nodes other than the `Close` button? Is that the developer's problem? Or should we focus the `Close` button in that case?
- how do I fix the lint warning where it complains that `focusOnMount.current` is not callable?
- how can we simplify the code to avoid duplicating the `setTimeout()` portion?

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- New Post
- Add some blocks and then Group them.
- Open List View
- Click options menu on Griup block and click `Rename`.
- See focus placed on `input` and not on `Close` button
- verify it's still possible to reach the `Close` button and constrained tabbing is still active
- open some other Modals and verify the behaviour still makes sense in other contexts.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->


https://github.com/WordPress/gutenberg/assets/444434/632c07e8-7740-4253-add9-ad854921ff0c


