### PR TITLE
Revert: Rich text: copy tag name on internal paste

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -310,7 +310,7 @@ Introduce new sections and organize content to help visitors (and search engines
 
 -	**Name:** core/heading
 -	**Category:** text
--	**Supports:** align (full, wide), anchor, className, color (background, gradients, link, text), spacing (margin, padding), typography (fontSize, lineHeight)
+-	**Supports:** __unstablePasteTextInline, align (full, wide), anchor, className, color (background, gradients, link, text), spacing (margin, padding), typography (fontSize, lineHeight)
 -	**Attributes:** content, level, placeholder, textAlign
 
 ## Home Link

--- a/packages/block-editor/src/components/rich-text/use-paste-handler.js
+++ b/packages/block-editor/src/components/rich-text/use-paste-handler.js
@@ -110,19 +110,10 @@ export function usePasteHandler( props ) {
 			// without filtering the data. The filters are only meant for externally
 			// pasted content and remove inline styles.
 			if ( isInternal ) {
-				const pastedMultilineTag =
-					clipboardData.getData( 'rich-text-multi-line-tag' ) ||
-					undefined;
-				let pastedValue = create( {
+				const pastedValue = create( {
 					html,
-					multilineTag: pastedMultilineTag,
-					multilineWrapperTags:
-						pastedMultilineTag === 'li'
-							? [ 'ul', 'ol' ]
-							: undefined,
 					preserveWhiteSpace,
 				} );
-				pastedValue = adjustLines( pastedValue, !! multilineTag );
 				addActiveFormats( pastedValue, value.activeFormats );
 				onChange( insert( value, pastedValue ) );
 				return;

--- a/packages/block-editor/src/components/rich-text/use-paste-handler.js
+++ b/packages/block-editor/src/components/rich-text/use-paste-handler.js
@@ -104,6 +104,29 @@ export function usePasteHandler( props ) {
 			}
 
 			const files = [ ...getFilesFromDataTransfer( clipboardData ) ];
+			const isInternal = clipboardData.getData( 'rich-text' ) === 'true';
+
+			// If the data comes from a rich text instance, we can directly use it
+			// without filtering the data. The filters are only meant for externally
+			// pasted content and remove inline styles.
+			if ( isInternal ) {
+				const pastedMultilineTag =
+					clipboardData.getData( 'rich-text-multi-line-tag' ) ||
+					undefined;
+				let pastedValue = create( {
+					html,
+					multilineTag: pastedMultilineTag,
+					multilineWrapperTags:
+						pastedMultilineTag === 'li'
+							? [ 'ul', 'ol' ]
+							: undefined,
+					preserveWhiteSpace,
+				} );
+				pastedValue = adjustLines( pastedValue, !! multilineTag );
+				addActiveFormats( pastedValue, value.activeFormats );
+				onChange( insert( value, pastedValue ) );
+				return;
+			}
 
 			if ( pastePlainText ) {
 				onChange( insert( value, create( { text: plainText } ) ) );
@@ -188,10 +211,6 @@ export function usePasteHandler( props ) {
 				mode,
 				tagName,
 				preserveWhiteSpace,
-				// If the data comes from a rich text instance, we can directly
-				// use it without filtering the data. The filters are only meant
-				// for externally pasted content and remove inline styles.
-				disableFilters: !! clipboardData.getData( 'rich-text' ),
 			} );
 
 			if ( typeof content === 'string' ) {

--- a/packages/block-library/src/heading/block.json
+++ b/packages/block-library/src/heading/block.json
@@ -61,6 +61,7 @@
 				"textTransform": true
 			}
 		},
+		"__unstablePasteTextInline": true,
 		"__experimentalSlashInserter": true
 	},
 	"editorStyle": "wp-block-heading-editor",

--- a/packages/blocks/README.md
+++ b/packages/blocks/README.md
@@ -458,7 +458,6 @@ _Parameters_
 -   _options.mode_ `[string]`: Handle content as blocks or inline content. _ 'AUTO': Decide based on the content passed. _ 'INLINE': Always handle as inline content, and return string. \* 'BLOCKS': Always handle as blocks, and return array of blocks.
 -   _options.tagName_ `[Array]`: The tag into which content will be inserted.
 -   _options.preserveWhiteSpace_ `[boolean]`: Whether or not to preserve consequent white space.
--   _options.disableFilters_ `[boolean]`: Whether or not to filter non semantic content.
 
 _Returns_
 

--- a/packages/blocks/src/api/raw-handling/paste-handler.js
+++ b/packages/blocks/src/api/raw-handling/paste-handler.js
@@ -8,6 +8,7 @@ import { getPhrasingContentSchema, removeInvalidHTML } from '@wordpress/dom';
  */
 import { htmlToBlocks } from './html-to-blocks';
 import { hasBlockSupport } from '../registration';
+import { getBlockInnerHTML } from '../serializer';
 import parse from '../parser';
 import normaliseBlocks from './normalise-blocks';
 import specialCommentConverter from './special-comment-converter';
@@ -66,40 +67,6 @@ function filterInlineHTML( HTML, preserveWhiteSpace ) {
 }
 
 /**
- * If we're allowed to return inline content, and there is only one inlineable
- * block, and the original plain text content does not have any line breaks,
- * then treat it as inline paste.
- *
- * @param {Object} options
- * @param {Array}  options.blocks
- * @param {string} options.plainText
- * @param {string} options.mode
- */
-function maybeConvertToInline( { blocks, plainText, mode } ) {
-	if (
-		mode === 'AUTO' &&
-		blocks.length === 1 &&
-		hasBlockSupport( blocks[ 0 ].name, '__unstablePasteTextInline', false )
-	) {
-		const trimRegex = /^[\n]+|[\n]+$/g;
-		// Don't catch line breaks at the start or end.
-		const trimmedPlainText = plainText.replace( trimRegex, '' );
-
-		if (
-			trimmedPlainText !== '' &&
-			trimmedPlainText.indexOf( '\n' ) === -1
-		) {
-			const target = blocks[ 0 ].innerBlocks.length
-				? blocks[ 0 ].innerBlocks[ 0 ]
-				: blocks[ 0 ];
-			return target.attributes.content;
-		}
-	}
-
-	return blocks;
-}
-
-/**
  * Converts an HTML string to known blocks. Strips everything else.
  *
  * @param {Object}  options
@@ -112,7 +79,6 @@ function maybeConvertToInline( { blocks, plainText, mode } ) {
  * @param {Array}   [options.tagName]            The tag into which content will be inserted.
  * @param {boolean} [options.preserveWhiteSpace] Whether or not to preserve consequent white space.
  *
- * @param {boolean} [options.disableFilters]     Whether or not to filter non semantic content.
  * @return {Array|string} A list of blocks or a string, depending on `handlerMode`.
  */
 export function pasteHandler( {
@@ -121,7 +87,6 @@ export function pasteHandler( {
 	mode = 'AUTO',
 	tagName,
 	preserveWhiteSpace,
-	disableFilters,
 } ) {
 	// First of all, strip any meta tags.
 	HTML = HTML.replace( /<meta[^>]+>/g, '' );
@@ -154,14 +119,6 @@ export function pasteHandler( {
 	// See: https://github.com/WordPress/gutenberg/pull/6983#pullrequestreview-125151075
 	if ( String.prototype.normalize ) {
 		HTML = HTML.normalize();
-	}
-
-	if ( disableFilters ) {
-		return maybeConvertToInline( {
-			blocks: htmlToBlocks( normaliseBlocks( HTML ), pasteHandler ),
-			plainText,
-			mode,
-		} );
 	}
 
 	// Parse Markdown (and encoded HTML) if:
@@ -262,5 +219,28 @@ export function pasteHandler( {
 		.flat()
 		.filter( Boolean );
 
-	return maybeConvertToInline( { blocks, plainText, mode } );
+	// If we're allowed to return inline content, and there is only one
+	// inlineable block, and the original plain text content does not have any
+	// line breaks, then treat it as inline paste.
+	if (
+		mode === 'AUTO' &&
+		blocks.length === 1 &&
+		hasBlockSupport( blocks[ 0 ].name, '__unstablePasteTextInline', false )
+	) {
+		const trimRegex = /^[\n]+|[\n]+$/g;
+		// Don't catch line breaks at the start or end.
+		const trimmedPlainText = plainText.replace( trimRegex, '' );
+
+		if (
+			trimmedPlainText !== '' &&
+			trimmedPlainText.indexOf( '\n' ) === -1
+		) {
+			return removeInvalidHTML(
+				getBlockInnerHTML( blocks[ 0 ] ),
+				phrasingContentSchema
+			).replace( trimRegex, '' );
+		}
+	}
+
+	return blocks;
 }

--- a/packages/rich-text/src/component/use-copy-handler.js
+++ b/packages/rich-text/src/component/use-copy-handler.js
@@ -28,20 +28,17 @@ export function useCopyHandler( props ) {
 
 			const selectedRecord = slice( record.current );
 			const plainText = getTextContent( selectedRecord );
-			const tagName = element.tagName.toLowerCase();
-
-			let html = toHTMLString( {
+			const html = toHTMLString( {
 				value: selectedRecord,
 				preserveWhiteSpace,
 			} );
-
-			if ( tagName && tagName !== 'span' && tagName !== 'div' ) {
-				html = `<${ tagName }>${ html }</${ tagName }>`;
-			}
-
 			event.clipboardData.setData( 'text/plain', plainText );
 			event.clipboardData.setData( 'text/html', html );
 			event.clipboardData.setData( 'rich-text', 'true' );
+			event.clipboardData.setData(
+				'rich-text-multi-line-tag',
+				multilineTag || ''
+			);
 			event.preventDefault();
 
 			if ( event.type === 'cut' ) {

--- a/packages/rich-text/src/component/use-copy-handler.js
+++ b/packages/rich-text/src/component/use-copy-handler.js
@@ -35,10 +35,6 @@ export function useCopyHandler( props ) {
 			event.clipboardData.setData( 'text/plain', plainText );
 			event.clipboardData.setData( 'text/html', html );
 			event.clipboardData.setData( 'rich-text', 'true' );
-			event.clipboardData.setData(
-				'rich-text-multi-line-tag',
-				multilineTag || ''
-			);
 			event.preventDefault();
 
 			if ( event.type === 'cut' ) {

--- a/test/e2e/specs/editor/various/rich-text.spec.js
+++ b/test/e2e/specs/editor/various/rich-text.spec.js
@@ -802,25 +802,4 @@ test.describe( 'RichText', () => {
 			},
 		] );
 	} );
-
-	test( 'should copy/paste heading', async ( {
-		page,
-		editor,
-		pageUtils,
-	} ) => {
-		await editor.insertBlock( { name: 'core/heading' } );
-		await page.keyboard.type( 'Heading' );
-		await pageUtils.pressKeys( 'primary+a' );
-		await pageUtils.pressKeys( 'primary+c' );
-		await page.keyboard.press( 'ArrowRight' );
-		await page.keyboard.press( 'Enter' );
-		await pageUtils.pressKeys( 'primary+v' );
-
-		expect( await editor.getBlocks() ).toMatchObject(
-			Array( 2 ).fill( {
-				name: 'core/heading',
-				attributes: { content: 'Heading' },
-			} )
-		);
-	} );
 } );

--- a/test/e2e/specs/editor/various/rich-text.spec.js
+++ b/test/e2e/specs/editor/various/rich-text.spec.js
@@ -656,11 +656,7 @@ test.describe( 'RichText', () => {
 				innerBlocks: [
 					{
 						name: 'core/list-item',
-						attributes: { content: '1' },
-					},
-					{
-						name: 'core/list-item',
-						attributes: { content: '2' },
+						attributes: { content: '1<br>2' },
 					},
 				],
 			},

--- a/test/integration/blocks-raw-handling.test.js
+++ b/test/integration/blocks-raw-handling.test.js
@@ -291,11 +291,9 @@ describe( 'Blocks raw handling', () => {
 			HTML: '<h1>FOO</h1>',
 			plainText: 'FOO\n',
 			mode: 'AUTO',
-		} )
-			.map( getBlockContent )
-			.join( '' );
+		} );
 
-		expect( filtered ).toBe( '<h1 class="wp-block-heading">FOO</h1>' );
+		expect( filtered ).toBe( 'FOO' );
 		expect( console ).toHaveLogged();
 	} );
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This reverts #48254.
Fixes #53422
See https://github.com/WordPress/gutenberg/pull/53453#issuecomment-1706687896

Sorry for the problems this introduced. And sorry to remove the new behaviour, I'll try to find a different way to do it at some point.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

#48254 introduced new copying behaviour, copying the rich text wrapper tag for context when pasting. For example it allow us to retain the heading tag when pasting into an empty paragraph. But a fundamental problem is that the rich text tags could really be anything: e.g. quote has a cite rich text area, so copying the cite wrapper doesn't make sense.

Also think about instances where the structure matters: details block with rich text summary, you can't just copy the wrapper tag (summary) on its own.

It seems like we need to somehow check wether the rich text element is a full block or not. Only then it makes sense because the HTML can always be parsed as a block. Let's try that in a follow up.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
