### PR TITLE
Fix incorrect image src in Design Contributions doc

### DIFF
--- a/docs/contributors/design/README.md
+++ b/docs/contributors/design/README.md
@@ -22,7 +22,7 @@ This section outlines the design principles and patterns of the editor interface
 
 <img width="200" src="https://raw.githubusercontent.com/WordPress/gutenberg/HEAD/docs/contributors/assets/gutenberg-logo-black.svg" alt="Gutenberg Logo" />
 
-The Gutenberg logo was made by [Cristel Rossignol](https://twitter.com/cristelrossi), and is released under the GPL license. [Download the SVG logo](/docs/contributors/assets/gutenberg-logo-black.svg).
+The Gutenberg logo was made by [Cristel Rossignol](https://twitter.com/cristelrossi), and is released under the GPL license. [Download the SVG logo](https://raw.githubusercontent.com/WordPress/gutenberg/HEAD/docs/contributors/assets/gutenberg-logo-black.svg).
 
 ### Goal of Gutenberg
 

--- a/docs/contributors/design/README.md
+++ b/docs/contributors/design/README.md
@@ -20,7 +20,7 @@ The [WordPress Design team](http://make.wordpress.org/design/) uses [Figma](http
 
 This section outlines the design principles and patterns of the editor interface—to explain the background of the design, inform future improvements, and help people design great blocks.
 
-<img width="200" src="https://github.com/WordPress/gutenberg/blob/trunk/docs/contributors/assets/gutenberg-logo-black.svg" alt="Gutenberg Logo" />
+<img width="200" src="https://raw.githubusercontent.com/WordPress/gutenberg/HEAD/docs/contributors/assets/gutenberg-logo-black.svg" alt="Gutenberg Logo" />
 
 The Gutenberg logo was made by [Cristel Rossignol](https://twitter.com/cristelrossi), and is released under the GPL license. [Download the SVG logo](/docs/contributors/assets/gutenberg-logo-black.svg).
 

--- a/docs/contributors/design/README.md
+++ b/docs/contributors/design/README.md
@@ -20,7 +20,7 @@ The [WordPress Design team](http://make.wordpress.org/design/) uses [Figma](http
 
 This section outlines the design principles and patterns of the editor interface—to explain the background of the design, inform future improvements, and help people design great blocks.
 
-<img width="200" src="/docs/contributors/assets/gutenberg-logo-black.svg?sanitize=true" alt="Gutenberg Logo" />
+<img width="200" src="https://github.com/WordPress/gutenberg/blob/trunk/docs/contributors/assets/gutenberg-logo-black.svg" alt="Gutenberg Logo" />
 
 The Gutenberg logo was made by [Cristel Rossignol](https://twitter.com/cristelrossi), and is released under the GPL license. [Download the SVG logo](/docs/contributors/assets/gutenberg-logo-black.svg).
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This is a follow-up to #51065. The image src was incorrect, and this PR corrects that. 

## Why?
To fix the broken image.
