### PR TITLE
Performance Tests: Improve the environment setup 

### DIFF
--- a/bin/plugin/commands/performance.js
+++ b/bin/plugin/commands/performance.js
@@ -146,6 +146,7 @@ async function runPerformanceTests( branches, options ) {
 		logTask( 1, 'Removing existing files' );
 		fs.rmSync( baseDir, { recursive: true } );
 	}
+
 	logTask( 1, 'Creating base directory:', fAccent( baseDir ) );
 	fs.mkdirSync( baseDir );
 
@@ -192,11 +193,14 @@ async function runPerformanceTests( branches, options ) {
 	logTask( 1, 'Setting up test runner' );
 
 	const testRunnerDir = path.join( baseDir + '/tests' );
+
 	logTask( 2, 'Copying source to:', fAccent( testRunnerDir ) );
 	await runShellScript( `cp -R  ${ sourceDir } ${ testRunnerDir }` );
+
 	logTask( 2, 'Checking out branch:', fAccent( testRunnerBranch ) );
 	// @ts-ignore
 	await SimpleGit( testRunnerDir ).raw( 'checkout', testRunnerBranch );
+
 	logTask( 2, 'Installing dependencies and building' );
 	await runShellScript(
 		`bash -c "${ [
@@ -229,18 +233,20 @@ async function runPerformanceTests( branches, options ) {
 
 	const branchDirs = {};
 	for ( const branch of branches ) {
-		logTask( 2, fAccent( branch ) );
+		logTask( 2, 'Branch:', fAccent( branch ) );
 		const sanitizedBranchName = sanitizeBranchName( branch );
 		const envDir = path.join( envsDir, sanitizedBranchName );
+
 		logTask( 3, 'Creating directory:', fAccent( envDir ) );
 		fs.mkdirSync( envDir );
 		// @ts-ignore
 		branchDirs[ branch ] = envDir;
 		const buildDir = path.join( envDir, 'plugin' );
+
 		logTask( 3, 'Copying source to:', fAccent( buildDir ) );
 		await runShellScript( `cp -R ${ sourceDir } ${ buildDir }` );
-		logTask( 3, 'Checking out:', fAccent( branch ) );
 
+		logTask( 3, 'Checking out:', fAccent( branch ) );
 		// @ts-ignore
 		await SimpleGit( buildDir ).raw( 'checkout', branch );
 
@@ -256,6 +262,7 @@ async function runPerformanceTests( branches, options ) {
 		);
 
 		const wpEnvConfigPath = path.join( envDir, '.wp-env.json' );
+
 		logTask( 3, 'Saving wp-env config to:', fAccent( wpEnvConfigPath ) );
 
 		fs.writeFileSync(
@@ -313,7 +320,7 @@ async function runPerformanceTests( branches, options ) {
 	logTask( 0, 'Running the tests' );
 
 	if ( wpZipUrl ) {
-		logTask( 1, 'Using:', fAccent( 'WordPress v%s' ), options.wpVersion );
+		logTask( 1, 'Using:', fAccent( `WordPress v${ options.wpVersion }` ) );
 	} else {
 		logTask( 1, 'Using:', fAccent( 'WordPress trunk' ) );
 	}
@@ -329,15 +336,19 @@ async function runPerformanceTests( branches, options ) {
 				) } (round ${ i } of ${ TEST_ROUNDS })`
 			);
 			for ( const branch of branches ) {
+				logTask( 2, 'Branch:', fAccent( branch ) );
+
 				const sanitizedBranchName = sanitizeBranchName( branch );
 				const runKey = `${ testSuite }_${ sanitizedBranchName }_round-${ i }`;
 				// @ts-ignore
 				const envDir = branchDirs[ branch ];
-				logTask( 2, 'Branch:', fAccent( branch ) );
+
 				logTask( 3, 'Starting the environment.' );
 				await runShellScript( `${ wpEnvPath } start`, envDir );
+
 				logTask( 3, 'Running the test.' );
 				await runTestSuite( testSuite, testRunnerDir, runKey );
+
 				logTask( 3, 'Stopping the environment' );
 				await runShellScript( `${ wpEnvPath } stop`, envDir );
 			}
@@ -388,6 +399,7 @@ async function runPerformanceTests( branches, options ) {
 			ARTIFACTS_PATH,
 			testSuite + RESULTS_FILE_SUFFIX
 		);
+
 		logTask( 1, 'Saving:', fAccent( calculatedResultsPath ) );
 		fs.writeFileSync(
 			calculatedResultsPath,

--- a/bin/plugin/commands/performance.js
+++ b/bin/plugin/commands/performance.js
@@ -31,10 +31,8 @@ const RESULTS_FILE_SUFFIX = '.performance-results.json';
  * @property {string=}  wpVersion   The WordPress version to be used as the base install for testing.
  */
 
-/**
- * Formats a log string to be accented.
- */
 const fAccent = formats.success;
+const fWarning = formats.warning;
 
 /**
  * A logging helper for printing tasks and their subtasks.
@@ -119,9 +117,7 @@ async function runPerformanceTests( branches, options ) {
 		[
 			'Welcome! This tool runs the performance tests on multiple branches and displays a comparison table.',
 			'In order to run the tests, the tool is going to load a WordPress environment on ports 8888 and 8889.',
-			formats.warning(
-				'Make sure these ports are not used before continuing.'
-			),
+			fWarning( 'Make sure these ports are not used before continuing.' ),
 		].join( '\n' )
 	);
 
@@ -365,8 +361,9 @@ async function runPerformanceTests( branches, options ) {
 
 	// Calculate medians from all rounds.
 	for ( const testSuite of testSuites ) {
-		results[ testSuite ] = {};
+		logTask( 1, 'Test suite:', fAccent( testSuite ) );
 
+		results[ testSuite ] = {};
 		for ( const branch of branches ) {
 			const sanitizedBranchName = sanitizeBranchName( branch );
 			const resultsRounds = resultFiles
@@ -376,14 +373,13 @@ async function runPerformanceTests( branches, options ) {
 					)
 				)
 				.map( ( file ) => {
-					logTask( 1, 'Reading:', fAccent( file ) );
+					logTask( 2, 'Reading from:', fAccent( file ) );
 					return readJSONFile( file );
 				} );
 
 			const metrics = Object.keys( resultsRounds[ 0 ] );
 			results[ testSuite ][ branch ] = {};
 
-			logTask( 1, 'Calculating medians from all rounds' );
 			for ( const metric of metrics ) {
 				const values = resultsRounds
 					.map( ( round ) => round[ metric ] )
@@ -400,7 +396,11 @@ async function runPerformanceTests( branches, options ) {
 			testSuite + RESULTS_FILE_SUFFIX
 		);
 
-		logTask( 1, 'Saving:', fAccent( calculatedResultsPath ) );
+		logTask(
+			2,
+			'Saving curated results to:',
+			fAccent( calculatedResultsPath )
+		);
 		fs.writeFileSync(
 			calculatedResultsPath,
 			JSON.stringify( results[ testSuite ], null, 2 )
@@ -409,7 +409,7 @@ async function runPerformanceTests( branches, options ) {
 
 	logTask( 0, 'Printing results' );
 	log(
-		formats.warning(
+		fWarning(
 			'\nPlease note that client side metrics EXCLUDE the server response time.'
 		)
 	);

--- a/bin/plugin/commands/performance.js
+++ b/bin/plugin/commands/performance.js
@@ -32,6 +32,7 @@ const RESULTS_FILE_SUFFIX = '.performance-results.json';
  */
 
 const fAccent = formats.success;
+const fTitle = formats.title;
 const fWarning = formats.warning;
 
 /**
@@ -112,17 +113,21 @@ async function runPerformanceTests( branches, options ) {
 		branches = [ 'trunk' ];
 	}
 
-	log( formats.title( '\n💃 Performance Tests 🕺\n' ) );
+	log( fTitle( '\n💃 Performance Tests 🕺' ) );
 	log(
-		[
-			'Welcome! This tool runs the performance tests on multiple branches and displays a comparison table.',
-			'In order to run the tests, the tool is going to load a WordPress environment on ports 8888 and 8889.',
-			fWarning( 'Make sure these ports are not used before continuing.' ),
-		].join( '\n' )
+		'\nWelcome! This tool runs the performance tests on multiple branches and displays a comparison table.'
 	);
 
 	if ( ! runningInCI ) {
-		log( '' );
+		log(
+			fWarning(
+				[
+					'\nIn order to run the tests, the tool is going to load a WordPress environment on ports 8888 and 8889.',
+					'Make sure these ports are not used before continuing.\n',
+				].join( '\n' )
+			)
+		);
+
 		await askForConfirmation( 'Ready to go? ' );
 	}
 
@@ -313,7 +318,7 @@ async function runPerformanceTests( branches, options ) {
 		return path.basename( file, '.spec.js' );
 	} );
 
-	logTask( 0, 'Running the tests' );
+	logTask( 0, 'Running tests' );
 
 	if ( wpZipUrl ) {
 		logTask( 1, 'Using:', fAccent( `WordPress v${ options.wpVersion }` ) );
@@ -339,13 +344,13 @@ async function runPerformanceTests( branches, options ) {
 				// @ts-ignore
 				const envDir = branchDirs[ branch ];
 
-				logTask( 3, 'Starting the environment.' );
+				logTask( 3, 'Starting environment' );
 				await runShellScript( `${ wpEnvPath } start`, envDir );
 
-				logTask( 3, 'Running the test.' );
+				logTask( 3, 'Running tests' );
 				await runTestSuite( testSuite, testRunnerDir, runKey );
 
-				logTask( 3, 'Stopping the environment' );
+				logTask( 3, 'Stopping environment' );
 				await runShellScript( `${ wpEnvPath } stop`, envDir );
 			}
 		}
@@ -415,7 +420,7 @@ async function runPerformanceTests( branches, options ) {
 	);
 
 	for ( const testSuite of testSuites ) {
-		logTask( 0, testSuite );
+		logTask( 0, fAccent( testSuite ) );
 
 		// Invert the results so we can display them in a table.
 		/** @type {Record<string, Record<string, string>>} */

--- a/bin/plugin/commands/performance.js
+++ b/bin/plugin/commands/performance.js
@@ -36,13 +36,13 @@ const fTitle = formats.title;
 const fWarning = formats.warning;
 
 /**
- * A logging helper for printing tasks and their subtasks.
+ * A logging helper for printing steps and their substeps.
  *
  * @param {number} sub  Value to indent the log.
  * @param {any}    msg  Message to log.
  * @param {...any} args Rest of the arguments to pass to console.log.
  */
-function logTask( sub, msg, ...args ) {
+function logStep( sub, msg, ...args ) {
 	const indent = '    ';
 	const prefix = sub === 0 ? '▶\u00A0' : '>\u00A0';
 	const newline = sub === 0 ? '\n' : '';
@@ -131,7 +131,7 @@ async function runPerformanceTests( branches, options ) {
 		await askForConfirmation( 'Ready to go? ' );
 	}
 
-	logTask( 0, 'Setting up' );
+	logStep( 0, 'Setting up' );
 
 	/**
 	 * @type {string[]} git refs against which to run tests;
@@ -144,28 +144,28 @@ async function runPerformanceTests( branches, options ) {
 	const baseDir = path.join( os.tmpdir(), 'wp-performance-tests' );
 
 	if ( fs.existsSync( baseDir ) ) {
-		logTask( 1, 'Removing existing files' );
+		logStep( 1, 'Removing existing files' );
 		fs.rmSync( baseDir, { recursive: true } );
 	}
 
-	logTask( 1, 'Creating base directory:', fAccent( baseDir ) );
+	logStep( 1, 'Creating base directory:', fAccent( baseDir ) );
 	fs.mkdirSync( baseDir );
 
-	logTask( 1, 'Setting up repository' );
+	logStep( 1, 'Setting up repository' );
 	const sourceDir = path.join( baseDir, 'source' );
 
-	logTask( 2, 'Creating directory:', fAccent( sourceDir ) );
+	logStep( 2, 'Creating directory:', fAccent( sourceDir ) );
 	fs.mkdirSync( sourceDir );
 
 	// @ts-ignore
 	const sourceGit = SimpleGit( sourceDir );
-	logTask( 2, 'Initializing:', fAccent( config.gitRepositoryURL ) );
+	logStep( 2, 'Initializing:', fAccent( config.gitRepositoryURL ) );
 	await sourceGit
 		.raw( 'init' )
 		.raw( 'remote', 'add', 'origin', config.gitRepositoryURL );
 
 	for ( const [ i, branch ] of branches.entries() ) {
-		logTask(
+		logStep(
 			2,
 			`Fetching environment branch (${ i + 1 } of ${ branches.length }):`,
 			fAccent( branch )
@@ -175,7 +175,7 @@ async function runPerformanceTests( branches, options ) {
 
 	const testRunnerBranch = options.testsBranch || branches[ 0 ];
 	if ( options.testsBranch && ! branches.includes( options.testsBranch ) ) {
-		logTask(
+		logStep(
 			2,
 			'Fetching test runner branch:',
 			fAccent( options.testsBranch )
@@ -188,21 +188,21 @@ async function runPerformanceTests( branches, options ) {
 			options.testsBranch
 		);
 	} else {
-		logTask( 2, 'Using test runner branch:', fAccent( testRunnerBranch ) );
+		logStep( 2, 'Using test runner branch:', fAccent( testRunnerBranch ) );
 	}
 
-	logTask( 1, 'Setting up test runner' );
+	logStep( 1, 'Setting up test runner' );
 
 	const testRunnerDir = path.join( baseDir + '/tests' );
 
-	logTask( 2, 'Copying source to:', fAccent( testRunnerDir ) );
+	logStep( 2, 'Copying source to:', fAccent( testRunnerDir ) );
 	await runShellScript( `cp -R  ${ sourceDir } ${ testRunnerDir }` );
 
-	logTask( 2, 'Checking out branch:', fAccent( testRunnerBranch ) );
+	logStep( 2, 'Checking out branch:', fAccent( testRunnerBranch ) );
 	// @ts-ignore
 	await SimpleGit( testRunnerDir ).raw( 'checkout', testRunnerBranch );
 
-	logTask( 2, 'Installing dependencies and building' );
+	logStep( 2, 'Installing dependencies and building' );
 	await runShellScript(
 		`bash -c "${ [
 			'source $HOME/.nvm/nvm.sh',
@@ -214,10 +214,10 @@ async function runPerformanceTests( branches, options ) {
 		testRunnerDir
 	);
 
-	logTask( 1, 'Setting up test environments' );
+	logStep( 1, 'Setting up test environments' );
 
 	const envsDir = path.join( baseDir, 'environments' );
-	logTask( 2, 'Creating parent directory:', fAccent( envsDir ) );
+	logStep( 2, 'Creating parent directory:', fAccent( envsDir ) );
 	fs.mkdirSync( envsDir );
 
 	let wpZipUrl = null;
@@ -234,24 +234,24 @@ async function runPerformanceTests( branches, options ) {
 
 	const branchDirs = {};
 	for ( const branch of branches ) {
-		logTask( 2, 'Branch:', fAccent( branch ) );
+		logStep( 2, 'Branch:', fAccent( branch ) );
 		const sanitizedBranchName = sanitizeBranchName( branch );
 		const envDir = path.join( envsDir, sanitizedBranchName );
 
-		logTask( 3, 'Creating directory:', fAccent( envDir ) );
+		logStep( 3, 'Creating directory:', fAccent( envDir ) );
 		fs.mkdirSync( envDir );
 		// @ts-ignore
 		branchDirs[ branch ] = envDir;
 		const buildDir = path.join( envDir, 'plugin' );
 
-		logTask( 3, 'Copying source to:', fAccent( buildDir ) );
+		logStep( 3, 'Copying source to:', fAccent( buildDir ) );
 		await runShellScript( `cp -R ${ sourceDir } ${ buildDir }` );
 
-		logTask( 3, 'Checking out:', fAccent( branch ) );
+		logStep( 3, 'Checking out:', fAccent( branch ) );
 		// @ts-ignore
 		await SimpleGit( buildDir ).raw( 'checkout', branch );
 
-		logTask( 3, 'Installing dependencies and building' );
+		logStep( 3, 'Installing dependencies and building' );
 		await runShellScript(
 			`bash -c "${ [
 				'source $HOME/.nvm/nvm.sh',
@@ -264,7 +264,7 @@ async function runPerformanceTests( branches, options ) {
 
 		const wpEnvConfigPath = path.join( envDir, '.wp-env.json' );
 
-		logTask( 3, 'Saving wp-env config to:', fAccent( wpEnvConfigPath ) );
+		logStep( 3, 'Saving wp-env config to:', fAccent( wpEnvConfigPath ) );
 
 		fs.writeFileSync(
 			wpEnvConfigPath,
@@ -309,54 +309,54 @@ async function runPerformanceTests( branches, options ) {
 		);
 	}
 
-	logTask( 0, 'Looking for test files' );
+	logStep( 0, 'Looking for test files' );
 
 	const testSuites = getFilesFromDir(
 		path.join( testRunnerDir, 'test/performance/specs' )
 	).map( ( file ) => {
-		logTask( 1, 'Found:', fAccent( file ) );
+		logStep( 1, 'Found:', fAccent( file ) );
 		return path.basename( file, '.spec.js' );
 	} );
 
-	logTask( 0, 'Running tests' );
+	logStep( 0, 'Running tests' );
 
 	if ( wpZipUrl ) {
-		logTask( 1, 'Using:', fAccent( `WordPress v${ options.wpVersion }` ) );
+		logStep( 1, 'Using:', fAccent( `WordPress v${ options.wpVersion }` ) );
 	} else {
-		logTask( 1, 'Using:', fAccent( 'WordPress trunk' ) );
+		logStep( 1, 'Using:', fAccent( 'WordPress trunk' ) );
 	}
 
 	const wpEnvPath = path.join( testRunnerDir, 'node_modules/.bin/wp-env' );
 
 	for ( const testSuite of testSuites ) {
 		for ( let i = 1; i <= TEST_ROUNDS; i++ ) {
-			logTask(
+			logStep(
 				1,
 				`Suite: ${ fAccent(
 					testSuite
 				) } (round ${ i } of ${ TEST_ROUNDS })`
 			);
 			for ( const branch of branches ) {
-				logTask( 2, 'Branch:', fAccent( branch ) );
+				logStep( 2, 'Branch:', fAccent( branch ) );
 
 				const sanitizedBranchName = sanitizeBranchName( branch );
 				const runKey = `${ testSuite }_${ sanitizedBranchName }_round-${ i }`;
 				// @ts-ignore
 				const envDir = branchDirs[ branch ];
 
-				logTask( 3, 'Starting environment' );
+				logStep( 3, 'Starting environment' );
 				await runShellScript( `${ wpEnvPath } start`, envDir );
 
-				logTask( 3, 'Running tests' );
+				logStep( 3, 'Running tests' );
 				await runTestSuite( testSuite, testRunnerDir, runKey );
 
-				logTask( 3, 'Stopping environment' );
+				logStep( 3, 'Stopping environment' );
 				await runShellScript( `${ wpEnvPath } stop`, envDir );
 			}
 		}
 	}
 
-	logTask( 0, 'Calculating results' );
+	logStep( 0, 'Calculating results' );
 
 	const resultFiles = getFilesFromDir( ARTIFACTS_PATH ).filter( ( file ) =>
 		file.endsWith( RESULTS_FILE_SUFFIX )
@@ -366,7 +366,7 @@ async function runPerformanceTests( branches, options ) {
 
 	// Calculate medians from all rounds.
 	for ( const testSuite of testSuites ) {
-		logTask( 1, 'Test suite:', fAccent( testSuite ) );
+		logStep( 1, 'Test suite:', fAccent( testSuite ) );
 
 		results[ testSuite ] = {};
 		for ( const branch of branches ) {
@@ -378,7 +378,7 @@ async function runPerformanceTests( branches, options ) {
 					)
 				)
 				.map( ( file ) => {
-					logTask( 2, 'Reading from:', fAccent( file ) );
+					logStep( 2, 'Reading from:', fAccent( file ) );
 					return readJSONFile( file );
 				} );
 
@@ -401,7 +401,7 @@ async function runPerformanceTests( branches, options ) {
 			testSuite + RESULTS_FILE_SUFFIX
 		);
 
-		logTask(
+		logStep(
 			2,
 			'Saving curated results to:',
 			fAccent( calculatedResultsPath )
@@ -412,7 +412,7 @@ async function runPerformanceTests( branches, options ) {
 		);
 	}
 
-	logTask( 0, 'Printing results' );
+	logStep( 0, 'Printing results' );
 	log(
 		fWarning(
 			'\nPlease note that client side metrics EXCLUDE the server response time.'
@@ -420,7 +420,7 @@ async function runPerformanceTests( branches, options ) {
 	);
 
 	for ( const testSuite of testSuites ) {
-		logTask( 0, fAccent( testSuite ) );
+		logStep( 0, fAccent( testSuite ) );
 
 		// Invert the results so we can display them in a table.
 		/** @type {Record<string, Record<string, string>>} */


### PR DESCRIPTION
## What?

This PR introduces some setup enhancements to make the performance comparison runner script more UX-friendly. The following are mostly cosmetic improvements, but they help a lot when actively using and debugging the script, especially in the local environment.

- **Don't use uuid tmp folders for the setup to avoid eating up disk space.**
   This is mostly beneficial when running the tool multiple times locally, as each run takes away ~5GB of disk space, and it's not freed until the OS tmp folder empties itself.
- **Streamline the setup logic.**
   Sort the setup steps, as they've become a bit chaotic and difficult to follow/debug.
- **Add more useful logs.**
   Make the setup easy to follow and the created environments/artifacts/etc. easy to access. 

| Before | After |
| ------------- | ------------- |
| <img width="701" alt="Screenshot 2023-09-13 at 12 29 52" src="https://github.com/WordPress/gutenberg/assets/1451471/4d0a9153-bfe1-429c-b8f5-b86ee6b8e1b5"> | <img width="636" alt="Screenshot 2023-09-13 at 12 07 41" src="https://github.com/WordPress/gutenberg/assets/1451471/4ff01c8f-0f4f-4858-b844-6aff67f72335"> |
 

## Next steps

- Make the environment reusable so the script doesn't need to build everything from scratch every time we run it.
