### PR TITLE
Ensure font-face styles are printed in iframe editors.

### DIFF
--- a/lib/compat/wordpress-6.4/fonts/fonts.php
+++ b/lib/compat/wordpress-6.4/fonts/fonts.php
@@ -34,20 +34,20 @@ if ( ! function_exists( 'wp_print_font_faces' ) ) {
 		$wp_font_face = new WP_Font_Face();
 		$wp_font_face->generate_and_print( $fonts );
 	}
-
-	// @core-merge: do not merge this code into Core.
-	add_filter(
-		'block_editor_settings_all',
-		static function( $settings ) {
-			ob_start();
-			// @core-merge: add only this line into Core's `_wp_get_iframed_editor_assets()` function after `wp_print_styles()`.
-			wp_print_font_faces();
-			$styles = ob_get_clean();
-
-			// Add the font-face styles to iframed editor assets.
-			$settings['__unstableResolvedAssets']['styles'] .= $styles;
-			return $settings;
-		},
-		11
-	);
 }
+
+// @core-merge: do not merge this code into Core.
+add_filter(
+	'block_editor_settings_all',
+	static function( $settings ) {
+		ob_start();
+		// @core-merge: add only this line into Core's `_wp_get_iframed_editor_assets()` function after `wp_print_styles()`.
+		wp_print_font_faces();
+		$styles = ob_get_clean();
+
+		// Add the font-face styles to iframed editor assets.
+		$settings['__unstableResolvedAssets']['styles'] .= $styles;
+		return $settings;
+	},
+	11
+);

--- a/lib/load.php
+++ b/lib/load.php
@@ -152,8 +152,14 @@ if (
 	if ( ! class_exists( 'WP_Font_Face' ) ) {
 		require __DIR__ . '/compat/wordpress-6.4/fonts/font-face/class-wp-font-face.php';
 		require __DIR__ . '/compat/wordpress-6.4/fonts/font-face/class-wp-font-face-resolver.php';
-		require __DIR__ . '/compat/wordpress-6.4/fonts/fonts.php';
 	}
+
+	/*
+	 * As _gutenberg_get_iframed_editor_assets_6_4() overrides Core's _wp_get_iframed_editor_assets(),
+	 * load this file to ensure wp_print_font_faces() is invoked to load the styles into the
+	 * iframed editor.
+	 */
+	require __DIR__ . '/compat/wordpress-6.4/fonts/fonts.php';
 
 	// Load the BC Layer to avoid fatal errors of extenders using the Fonts API.
 	// @core-merge: do not merge the BC layer files into WordPress Core.


### PR DESCRIPTION
## What?
In the plugin, ensure `wp_print_font_faces()` is invoked and added to the iframed editors' styles.

## Why?
Gutenberg overrides Core's `_wp_get_iframed_editor_assets()` styles results. Font Face's `wp_print_font_faces()` is in Core's `_wp_get_iframed_editor_assets()`. But Gutenberg overrides the results of that function in `_gutenberg_get_iframed_editor_assets()` (for WP 6.3) and `_gutenberg_get_iframed_editor_assets_6_4()` (for WP 6.4).

## How?

Loads the plugin's `fonts.php` file and moves the hooked code for `'block_editor_settings_all'` out of the guard.

## Testing Instructions

1. Set `FONT_LIBRARY_ENABLE` constant to `true` in your test site's `config.php`:
```php
define( 'FONT_LIBRARY_ENABLE', true );
```
2. Activate the Gutenberg plugin.
3. Go to the Site Editor.
4. Open your browser's dev tools and search  the HTML for `wp-fonts-local`.

Expected: After applying this PR, it should also exist in the `iframe`. 