### PR TITLE
Use solid accent color selection in command palette

### DIFF
--- a/packages/commands/src/components/style.scss
+++ b/packages/commands/src/components/style.scss
@@ -78,11 +78,11 @@
 
 		&[aria-selected="true"],
 		&:active {
-			background: rgba(var(--wp-admin-theme-color--rgb), 0.04);
-			color: var(--wp-admin-theme-color);
+			background: var(--wp-admin-theme-color);
+			color: $white;
 
 			svg {
-				fill: var(--wp-admin-theme-color);
+				fill: $white;
 			}
 		}
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Closes #51582 by using the `var(--wp-admin-theme-color)` background color and white foreground color on `aria-selected="true"` commands within the command palette. 

## How?
Minor CSS change. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a post or page.
2. Open the command palette via CMD + K or CTRL + K. 
3. Search for commands.
4. See change. 

## Screenshots or screencast <!-- if applicable -->

### Before 
<img width="813" alt="CleanShot 2023-09-08 at 16 59 46" src="https://github.com/WordPress/gutenberg/assets/1813435/e11a8f08-4ab8-4261-b667-0e5afdb59749">


### After

https://github.com/WordPress/gutenberg/assets/1813435/bd48237f-e548-4d10-a6cf-64a9eb3acd08


