### PR TITLE
Consistent, descriptive accessible name for command palette button

### DIFF
--- a/packages/edit-post/src/components/header/document-actions/index.js
+++ b/packages/edit-post/src/components/header/document-actions/index.js
@@ -64,9 +64,12 @@ function DocumentActions() {
 			<Button
 				className="edit-post-document-actions__command"
 				onClick={ () => openCommandCenter() }
-				aria-label={ __( 'Command Palette' ) }
 				aria-haspopup="dialog"
 				aria-expanded={ isCommandCenterOpen }
+				label={ `${ __(
+					'Command Palette'
+				) } ${ displayShortcut.primary( 'k' ) }` }
+				showTooltip
 			>
 				<HStack
 					className="edit-post-document-actions__title"

--- a/packages/edit-post/src/components/header/document-actions/index.js
+++ b/packages/edit-post/src/components/header/document-actions/index.js
@@ -20,16 +20,20 @@ import { displayShortcut } from '@wordpress/keycodes';
 import { store as editPostStore } from '../../../store';
 
 function DocumentActions() {
-	const { template, isEditing } = useSelect( ( select ) => {
-		const { isEditingTemplate, getEditedPostTemplate } =
-			select( editPostStore );
-		const _isEditing = isEditingTemplate();
+	const { template, isCommandCenterOpen, isEditing } = useSelect(
+		( select ) => {
+			const { isEditingTemplate, getEditedPostTemplate } =
+				select( editPostStore );
+			const _isEditing = isEditingTemplate();
 
-		return {
-			template: _isEditing ? getEditedPostTemplate() : null,
-			isEditing: _isEditing,
-		};
-	}, [] );
+			return {
+				template: _isEditing ? getEditedPostTemplate() : null,
+				isEditing: _isEditing,
+				isCommandCenterOpen: select( commandsStore ).isOpen(),
+			};
+		},
+		[]
+	);
 	const { clearSelectedBlock } = useDispatch( blockEditorStore );
 	const { setIsEditingTemplate } = useDispatch( editPostStore );
 	const { open: openCommandCenter } = useDispatch( commandsStore );
@@ -61,6 +65,8 @@ function DocumentActions() {
 				className="edit-post-document-actions__command"
 				onClick={ () => openCommandCenter() }
 				aria-label={ __( 'Command Palette' ) }
+				aria-haspopup="dialog"
+				aria-expanded={ isCommandCenterOpen }
 			>
 				<HStack
 					className="edit-post-document-actions__title"

--- a/packages/edit-post/src/components/header/document-actions/index.js
+++ b/packages/edit-post/src/components/header/document-actions/index.js
@@ -60,6 +60,7 @@ function DocumentActions() {
 			<Button
 				className="edit-post-document-actions__command"
 				onClick={ () => openCommandCenter() }
+				aria-label={ __( 'Command Palette' ) }
 			>
 				<HStack
 					className="edit-post-document-actions__title"
@@ -67,7 +68,12 @@ function DocumentActions() {
 					justify="center"
 				>
 					<BlockIcon icon={ layout } />
-					<Text size="body" as="h1">
+					<Text
+						className="edit-post-document-actions__text"
+						size="body"
+						as="span"
+						color={ undefined }
+					>
 						<VisuallyHidden as="span">
 							{ __( 'Editing template: ' ) }
 						</VisuallyHidden>

--- a/packages/edit-post/src/components/header/document-actions/style.scss
+++ b/packages/edit-post/src/components/header/document-actions/style.scss
@@ -40,7 +40,7 @@
 		flex-shrink: 0;
 	}
 
-	h1 {
+	.edit-post-document-actions__text {
 		white-space: nowrap;
 		overflow: hidden;
 		text-overflow: ellipsis;

--- a/packages/edit-site/src/components/header-edit-mode/document-actions/index.js
+++ b/packages/edit-site/src/components/header-edit-mode/document-actions/index.js
@@ -173,6 +173,7 @@ function BaseDocumentActions( { className, icon, children, onBack } ) {
 			<Button
 				className="edit-site-document-actions__command"
 				onClick={ () => openCommandCenter() }
+				aria-label={ __( 'Command Palette' ) }
 			>
 				<HStack
 					className="edit-site-document-actions__title"

--- a/packages/edit-site/src/components/header-edit-mode/document-actions/index.js
+++ b/packages/edit-site/src/components/header-edit-mode/document-actions/index.js
@@ -181,7 +181,11 @@ function BaseDocumentActions( { className, icon, children, onBack } ) {
 					justify="center"
 				>
 					<BlockIcon icon={ icon } />
-					<Text size="body" as="h1">
+					<Text
+						className="edit-site-document-actions__text"
+						size="body"
+						as="span"
+					>
 						{ children }
 					</Text>
 				</HStack>

--- a/packages/edit-site/src/components/header-edit-mode/document-actions/index.js
+++ b/packages/edit-site/src/components/header-edit-mode/document-actions/index.js
@@ -10,7 +10,6 @@ import { __, isRTL } from '@wordpress/i18n';
 import { useSelect, useDispatch } from '@wordpress/data';
 import {
 	Button,
-	VisuallyHidden,
 	__experimentalText as Text,
 	__experimentalHStack as HStack,
 } from '@wordpress/components';
@@ -32,13 +31,6 @@ import { store as coreStore } from '@wordpress/core-data';
  */
 import useEditedEntityRecord from '../../use-edited-entity-record';
 import { store as editSiteStore } from '../../../store';
-
-const typeLabels = {
-	wp_block: __( 'Editing pattern:' ),
-	wp_navigation: __( 'Editing navigation menu:' ),
-	wp_template: __( 'Editing template:' ),
-	wp_template_part: __( 'Editing template part:' ),
-};
 
 export default function DocumentActions() {
 	const isPage = useSelect(
@@ -144,9 +136,6 @@ function TemplateDocumentActions( { className, onBack } ) {
 			icon={ typeIcon }
 			onBack={ onBack }
 		>
-			<VisuallyHidden as="span">
-				{ typeLabels[ record.type ] ?? typeLabels.wp_template }
-			</VisuallyHidden>
 			{ getTitle() }
 		</BaseDocumentActions>
 	);

--- a/packages/edit-site/src/components/header-edit-mode/document-actions/index.js
+++ b/packages/edit-site/src/components/header-edit-mode/document-actions/index.js
@@ -168,9 +168,12 @@ function BaseDocumentActions( { className, icon, children, onBack } ) {
 			<Button
 				className="edit-site-document-actions__command"
 				onClick={ () => openCommandCenter() }
-				aria-label={ __( 'Command Palette' ) }
 				aria-haspopup="dialog"
 				aria-expanded={ isCommandCenterOpen }
+				label={ `${ __(
+					'Command Palette'
+				) } ${ displayShortcut.primary( 'k' ) }` }
+				showTooltip
 			>
 				<HStack
 					className="edit-site-document-actions__title"

--- a/packages/edit-site/src/components/header-edit-mode/document-actions/index.js
+++ b/packages/edit-site/src/components/header-edit-mode/document-actions/index.js
@@ -142,6 +142,12 @@ function TemplateDocumentActions( { className, onBack } ) {
 }
 
 function BaseDocumentActions( { className, icon, children, onBack } ) {
+	const { isCommandCenterOpen } = useSelect( ( select ) => {
+		return {
+			isCommandCenterOpen: select( commandsStore ).isOpen(),
+		};
+	}, [] );
+
 	const { open: openCommandCenter } = useDispatch( commandsStore );
 	return (
 		<div
@@ -163,6 +169,8 @@ function BaseDocumentActions( { className, icon, children, onBack } ) {
 				className="edit-site-document-actions__command"
 				onClick={ () => openCommandCenter() }
 				aria-label={ __( 'Command Palette' ) }
+				aria-haspopup="dialog"
+				aria-expanded={ isCommandCenterOpen }
 			>
 				<HStack
 					className="edit-site-document-actions__title"

--- a/packages/edit-site/src/components/header-edit-mode/document-actions/style.scss
+++ b/packages/edit-site/src/components/header-edit-mode/document-actions/style.scss
@@ -37,7 +37,7 @@
 	&.is-synced-entity {
 		.edit-site-document-actions__title {
 			color: var(--wp-block-synced-color);
-			h1 {
+			.edit-site-document-actions__text {
 				color: var(--wp-block-synced-color);
 			}
 		}
@@ -68,7 +68,7 @@
 		flex-shrink: 0;
 	}
 
-	h1 {
+	.edit-site-document-actions__text {
 		white-space: nowrap;
 		overflow: hidden;
 		text-overflow: ellipsis;

--- a/packages/edit-site/src/components/header-edit-mode/document-actions/style.scss
+++ b/packages/edit-site/src/components/header-edit-mode/document-actions/style.scss
@@ -78,7 +78,7 @@
 	.edit-site-document-actions.is-page & {
 		color: $gray-800;
 
-		h1 {
+		.edit-site-document-actions__text {
 			color: $gray-800;
 		}
 	}

--- a/packages/edit-site/src/components/header-edit-mode/index.js
+++ b/packages/edit-site/src/components/header-edit-mode/index.js
@@ -46,11 +46,19 @@ import {
 } from '../editor-canvas-container';
 import { unlock } from '../../lock-unlock';
 import { FOCUSABLE_ENTITIES } from '../../utils/constants';
+import useEditedEntityRecord from '../use-edited-entity-record';
 
 const { useShouldContextualToolbarShow } = unlock( blockEditorPrivateApis );
 
 const preventDefault = ( event ) => {
 	event.preventDefault();
+};
+
+const typeLabels = {
+	wp_block: __( 'Editing pattern:' ),
+	wp_navigation: __( 'Editing navigation menu:' ),
+	wp_template: __( 'Editing template:' ),
+	wp_template_part: __( 'Editing template part:' ),
 };
 
 export default function HeaderEditMode() {
@@ -116,6 +124,7 @@ export default function HeaderEditMode() {
 		};
 	}, [] );
 
+	const { record, getTitle } = useEditedEntityRecord();
 	const {
 		__experimentalSetPreviewDeviceType: setPreviewDeviceType,
 		setIsInserterOpened,
@@ -183,12 +192,19 @@ export default function HeaderEditMode() {
 		ease: 'easeOut',
 	};
 
+	const title = hasDefaultEditorCanvasView
+		? `${
+				typeLabels[ record.type ] ?? typeLabels.wp_template
+		  } ${ getTitle() }`
+		: getEditorCanvasContainerTitle( editorCanvasView );
+
 	return (
 		<div
 			className={ classnames( 'edit-site-header-edit-mode', {
 				'show-icon-labels': showIconLabels,
 			} ) }
 		>
+			<VisuallyHidden as="h1">{ title }</VisuallyHidden>
 			{ hasDefaultEditorCanvasView && (
 				<NavigableToolbar
 					as={ motion.div }


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/51394
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
The command palette activation button had an H1 for the page title inside of it, meaning the command palette action button was not consistently named. It would be the equivalent of having a Save button be called "Template: Blog Home ⌘S" instead of "Save."

This PR brings consistent names to the command palette activation.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Add an `aria-label` of `Command Palette` to the button
- Move the `<h1>` to be the first item in the header, and visually hide it. 

This keeps the H1 of the page consistent, all visual changes remain the same, and the command palette button is always consistently named.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
There are three places I could find the title being used.

### Site Editor
- Go to the Site Editor
- Select a template
- The command palette button should have an aria-label of `Command Palette`
- The H1 should be in the editor header, and accurate for the template you're on

### Style Guide H1
- Click the Style button in the header
- Navigate regions until reaching the sidebar (this seems like a bug how hard it is to reach the style guide sidebar after pressing that button)
- Click the Style Book button (it visually looks like an eyeball icon)
- The H1 of the page should be Style Book

### Template Editor within the Post Editor
I didn't know this existed. It seems easy to overlook. 
- Edit a Post
- Open the Settings sidebar
- Click the Template button
- Click Edit Template
- The command palette button should have an aria-label of `Command Palette`
- The H1 will still say Edit Post. Not sure if this should be updated.


### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
