### PR TITLE
Table block: Fix semantic structure for screen readers on back-end

### DIFF
--- a/packages/block-library/src/table/edit.js
+++ b/packages/block-library/src/table/edit.js
@@ -419,15 +419,14 @@ function TableEdit( {
 								scope={ CellTag === 'th' ? scope : undefined }
 								colSpan={ colspan }
 								rowSpan={ rowspan }
+								className={ classnames(
+									{
+										[ `has-text-align-${ align }` ]: align,
+									},
+									'wp-block-table__cell-content'
+								) }
 							>
 								<RichText
-									className={ classnames(
-										{
-											[ `has-text-align-${ align }` ]:
-												align,
-										},
-										'wp-block-table__cell-content'
-									) }
 									value={ content }
 									onChange={ onChange }
 									onFocus={ () => {

--- a/packages/block-library/src/table/edit.js
+++ b/packages/block-library/src/table/edit.js
@@ -414,31 +414,35 @@ function TableEdit( {
 							},
 							columnIndex
 						) => (
-							<RichText
-								tagName={ CellTag }
-								key={ columnIndex }
-								className={ classnames(
-									{
-										[ `has-text-align-${ align }` ]: align,
-									},
-									'wp-block-table__cell-content'
-								) }
-								scope={ CellTag === 'th' ? scope : undefined }
-								colSpan={ colspan }
-								rowSpan={ rowspan }
-								value={ content }
-								onChange={ onChange }
-								onFocus={ () => {
-									setSelectedCell( {
-										sectionName: name,
-										rowIndex,
-										columnIndex,
-										type: 'cell',
-									} );
-								} }
-								aria-label={ cellAriaLabel[ name ] }
-								placeholder={ placeholder[ name ] }
-							/>
+							<CellTag key={ columnIndex }>
+								<RichText
+									key={ columnIndex }
+									className={ classnames(
+										{
+											[ `has-text-align-${ align }` ]:
+												align,
+										},
+										'wp-block-table__cell-content'
+									) }
+									scope={
+										CellTag === 'th' ? scope : undefined
+									}
+									colSpan={ colspan }
+									rowSpan={ rowspan }
+									value={ content }
+									onChange={ onChange }
+									onFocus={ () => {
+										setSelectedCell( {
+											sectionName: name,
+											rowIndex,
+											columnIndex,
+											type: 'cell',
+										} );
+									} }
+									aria-label={ cellAriaLabel[ name ] }
+									placeholder={ placeholder[ name ] }
+								/>
+							</CellTag>
 						)
 					) }
 				</tr>

--- a/packages/block-library/src/table/edit.js
+++ b/packages/block-library/src/table/edit.js
@@ -349,7 +349,7 @@ function TableEdit( {
 	useEffect( () => {
 		if ( hasTableCreated ) {
 			tableRef?.current
-				?.querySelector( 'td[contentEditable="true"]' )
+				?.querySelector( 'td div[contentEditable="true"]' )
 				?.focus();
 			setHasTableCreated( false );
 		}
@@ -414,9 +414,13 @@ function TableEdit( {
 							},
 							columnIndex
 						) => (
-							<CellTag key={ columnIndex }>
+							<CellTag
+								key={ columnIndex }
+								scope={ CellTag === 'th' ? scope : undefined }
+								colSpan={ colspan }
+								rowSpan={ rowspan }
+							>
 								<RichText
-									key={ columnIndex }
 									className={ classnames(
 										{
 											[ `has-text-align-${ align }` ]:
@@ -424,11 +428,6 @@ function TableEdit( {
 										},
 										'wp-block-table__cell-content'
 									) }
-									scope={
-										CellTag === 'th' ? scope : undefined
-									}
-									colSpan={ colspan }
-									rowSpan={ rowspan }
 									value={ content }
 									onChange={ onChange }
 									onFocus={ () => {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Currently, the table block on the back-end is not discoverable as a table by screen readers due to the `role="textbox"` and `contenteditable="true"` attributes set directly on `<td>`. The PR restructures the table so the edit field is contained within the `<td>`.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

It is important that screen readers behave well with native HTML elements.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Change HTML structure.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Insert a table block and select the Create Table button.
2. Switch into a virtual mode with one of the Windows screen readers. NVDA or JAWS.
3. You should now be able to navigate the table columns and rows with table navigation commands.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
