### PR TITLE
Edit Widgets: Fix invisible action area when the top toolbar is enabled

### DIFF
--- a/packages/block-editor/src/components/block-tools/block-contextual-toolbar.js
+++ b/packages/block-editor/src/components/block-tools/block-contextual-toolbar.js
@@ -112,9 +112,9 @@ function BlockContextualToolbar( { focusOnMount, isFixed, ...props } ) {
 			return;
 		}
 
-		// get the width of the pinned items in the post editor
+		// get the width of the pinned items in the post editor or widget editor
 		const pinnedItems = document.querySelector(
-			'.edit-post-header__settings'
+			'.edit-post-header__settings, .edit-widgets-header__actions'
 		);
 
 		// get the width of the left header in the site editor

--- a/packages/edit-widgets/src/components/header/style.scss
+++ b/packages/edit-widgets/src/components/header/style.scss
@@ -3,7 +3,6 @@
 	align-items: center;
 	justify-content: space-between;
 	height: $header-height;
-	padding: 0 $grid-unit-20;
 	overflow: auto;
 	background: #fff;
 
@@ -16,6 +15,7 @@
 	display: flex;
 	align-items: center;
 	justify-content: center;
+	padding-left: $grid-unit-20;
 }
 
 .edit-widgets-header__title {
@@ -27,7 +27,7 @@
 .edit-widgets-header__actions {
 	display: flex;
 	align-items: center;
-
+	padding-right: $grid-unit-20;
 	gap: $grid-unit-05;
 
 	@include break-small() {


### PR DESCRIPTION
Related to: #53526

## What?
This PR fixes a problem in the widget editor where the action area (pinned items) is not visible when the top toolbar is enabled.

![widget-editor](https://github.com/WordPress/gutenberg/assets/54422211/3180604d-2be5-4a7c-899f-6cead8788d27)

**Note**: When you open the widget editor, you will notice that the layout of the widget area is broken. This issue was reported in #54295.

## Why?

Like the Post Editor, the Widget Editor requires the width of the pinned items to be subtracted when calculating the width of the top toolbar.

## How?
Added the pinned items selector (`.edit-widgets-header__actions`) so that the width of the pinned items is taken into account when calculating the width of the top toolbar.
At the same time, the padding on both ends of the header area (`.edit-widgets-header`) has been moved to its child elements (`.edit-widgets-header__navigable-toolbar-wrapper`, `.edit-widgets-header__actions`) in order to accurately calculate the width of the top toolbar.

## Testing Instructions

- Activate Twenty Twenty One.
- Go to "Widgets"
- Enable "Top Toolbar"
- Select any of the blocks.
- Confirm that pinned items are not hidden.
- Additionally, verify that this change does not affect the Post Editor or Site Editor.