### PR TITLE
Site Editor: Clarify the "Entity" message of the snackbar

### DIFF
--- a/packages/edit-site/src/components/page-patterns/rename-menu-item.js
+++ b/packages/edit-site/src/components/page-patterns/rename-menu-item.js
@@ -49,14 +49,25 @@ export default function RenameMenuItem( { item, onClose } ) {
 				throwOnError: true,
 			} );
 
-			createSuccessNotice( __( 'Entity renamed.' ), {
-				type: 'snackbar',
-			} );
+			createSuccessNotice(
+				item.type === TEMPLATE_PARTS
+					? __( 'Template part renamed.' )
+					: __( 'Pattern renamed.' ),
+				{
+					type: 'snackbar',
+				}
+			);
 		} catch ( error ) {
+			const fallbackErrorMessage =
+				item.type === TEMPLATE_PARTS
+					? __(
+							'An error occurred while reverting the template part.'
+					  )
+					: __( 'An error occurred while reverting the pattern.' );
 			const errorMessage =
 				error.message && error.code !== 'unknown_error'
 					? error.message
-					: __( 'An error occurred while renaming the entity.' );
+					: fallbackErrorMessage;
 
 			createErrorNotice( errorMessage, { type: 'snackbar' } );
 		}

--- a/packages/edit-site/src/components/template-actions/index.js
+++ b/packages/edit-site/src/components/template-actions/index.js
@@ -67,10 +67,16 @@ export default function TemplateActions( {
 				}
 			);
 		} catch ( error ) {
+			const fallbackErrorMessage =
+				template.type === 'wp_template'
+					? __( 'An error occurred while reverting the template.' )
+					: __(
+							'An error occurred while reverting the template part.'
+					  );
 			const errorMessage =
 				error.message && error.code !== 'unknown_error'
 					? error.message
-					: __( 'An error occurred while reverting the entity.' );
+					: fallbackErrorMessage;
 
 			createErrorNotice( errorMessage, { type: 'snackbar' } );
 		}

--- a/packages/edit-site/src/components/template-actions/rename-menu-item.js
+++ b/packages/edit-site/src/components/template-actions/rename-menu-item.js
@@ -56,14 +56,25 @@ export default function RenameMenuItem( { template, onClose } ) {
 				}
 			);
 
-			createSuccessNotice( __( 'Entity renamed.' ), {
-				type: 'snackbar',
-			} );
+			createSuccessNotice(
+				template.type === 'wp_template'
+					? __( 'Template renamed.' )
+					: __( 'Template part renamed.' ),
+				{
+					type: 'snackbar',
+				}
+			);
 		} catch ( error ) {
+			const fallbackErrorMessage =
+				template.type === 'wp_template'
+					? __( 'An error occurred while renaming the template.' )
+					: __(
+							'An error occurred while renaming the template part.'
+					  );
 			const errorMessage =
 				error.message && error.code !== 'unknown_error'
 					? error.message
-					: __( 'An error occurred while renaming the entity.' );
+					: fallbackErrorMessage;
 
 			createErrorNotice( errorMessage, { type: 'snackbar' } );
 		}


### PR DESCRIPTION
Fixes: #47886

## What?
This PR clarifies the message when Pattern/Template/Template Part are renamed/customization is cleared in the Site Editor.

| Before | After |
|--------|--------|
| ![before](https://github.com/WordPress/gutenberg/assets/54422211/b6070f0b-efad-4b1b-8113-14ef59e30593) | ![after](https://github.com/WordPress/gutenberg/assets/54422211/b9372e07-5db3-4466-87c0-ed412588ddb1) | 

## Why?

"Entity" is a technical term and it is unclear what it refers to.

## How?
I have made the process return context-sensitive messages for successful and error-prone processing, instead of using the word Entity.

## Testing Instructions

- Do the following in the Site Editor.
  - Rename Pattern
  - Rename Template part
  - Rename Template
  - Clear Template Part customization
  - Clear Template customization
- The snack bar should show the correct message.

The error message can be confirmed by forcing an error at the beginning of the try statement, as shown below.

```javascript
try {
	throw 'unknown_error';
	// ...
} catch ( error ) {
	// ...
}
```

_Note:_ The modal does not close when an error occurs and the snack bar is covered by a translucent overlay that I find difficult to see. This issue could be addressed in a follow-up.
