### PR TITLE
Allow import/export patterns as JSON files

### DIFF
--- a/packages/edit-site/src/components/add-new-pattern/index.js
+++ b/packages/edit-site/src/components/add-new-pattern/index.js
@@ -3,7 +3,7 @@
  */
 import { DropdownMenu } from '@wordpress/components';
 import { useState, useRef } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { plus, symbol, symbolFilled } from '@wordpress/icons';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { privateApis as routerPrivateApis } from '@wordpress/router';
@@ -19,7 +19,6 @@ import { store as noticesStore } from '@wordpress/notices';
 import CreateTemplatePartModal from '../create-template-part-modal';
 import SidebarButton from '../sidebar-button';
 import { unlock } from '../../lock-unlock';
-import { USER_PATTERN_CATEGORY } from '../page-patterns/utils';
 import { store as editSiteStore } from '../../store';
 
 const { useHistory } = unlock( routerPrivateApis );
@@ -36,7 +35,8 @@ export default function AddNewPattern() {
 	}, [] );
 	const { __experimentalCreatePatternFromFile: createPatternFromFile } =
 		useDispatch( patternsStore );
-	const { createErrorNotice } = useDispatch( noticesStore );
+	const { createSuccessNotice, createErrorNotice } =
+		useDispatch( noticesStore );
 	const patternUploadInputRef = useRef();
 
 	function handleCreatePattern( { pattern, categoryId } ) {
@@ -128,10 +128,18 @@ export default function AddNewPattern() {
 					if ( ! file ) return;
 					try {
 						const pattern = await createPatternFromFile( file );
-						handleCreatePattern( {
-							pattern,
-							categoryId: USER_PATTERN_CATEGORY,
-						} );
+
+						createSuccessNotice(
+							sprintf(
+								// translators: %s: The imported pattern's title.
+								__( 'Imported "%s" from JSON.' ),
+								pattern.title.raw
+							),
+							{
+								type: 'snackbar',
+								id: 'import-pattern-success',
+							}
+						);
 					} catch ( err ) {
 						createErrorNotice( err.message, {
 							type: 'snackbar',

--- a/packages/edit-site/src/components/add-new-pattern/index.js
+++ b/packages/edit-site/src/components/add-new-pattern/index.js
@@ -33,8 +33,7 @@ export default function AddNewPattern() {
 		const settings = select( editSiteStore ).getSettings();
 		return !! settings.supportsTemplatePartsMode;
 	}, [] );
-	const { __experimentalCreatePatternFromFile: createPatternFromFile } =
-		useDispatch( patternsStore );
+	const { createPatternFromFile } = unlock( useDispatch( patternsStore ) );
 	const { createSuccessNotice, createErrorNotice } =
 		useDispatch( noticesStore );
 	const patternUploadInputRef = useRef();

--- a/packages/edit-site/src/components/add-new-pattern/index.js
+++ b/packages/edit-site/src/components/add-new-pattern/index.js
@@ -20,12 +20,14 @@ import CreateTemplatePartModal from '../create-template-part-modal';
 import SidebarButton from '../sidebar-button';
 import { unlock } from '../../lock-unlock';
 import { store as editSiteStore } from '../../store';
+import { PATTERN_TYPES, PATTERN_DEFAULT_CATEGORY } from '../../utils/constants';
 
-const { useHistory } = unlock( routerPrivateApis );
+const { useHistory, useLocation } = unlock( routerPrivateApis );
 const { CreatePatternModal } = unlock( editPatternsPrivateApis );
 
 export default function AddNewPattern() {
 	const history = useHistory();
+	const { params } = useLocation();
 	const [ showPatternModal, setShowPatternModal ] = useState( false );
 	const [ showTemplatePartModal, setShowTemplatePartModal ] =
 		useState( false );
@@ -128,6 +130,18 @@ export default function AddNewPattern() {
 					if ( ! file ) return;
 					try {
 						const pattern = await createPatternFromFile( file );
+
+						// Navigate to the All patterns category for the newly created pattern.
+						if (
+							params.categoryType !== PATTERN_TYPES.theme ||
+							params.categoryId !== PATTERN_DEFAULT_CATEGORY
+						) {
+							history.push( {
+								path: `/patterns`,
+								categoryType: PATTERN_TYPES.theme,
+								categoryId: PATTERN_DEFAULT_CATEGORY,
+							} );
+						}
 
 						createSuccessNotice(
 							sprintf(

--- a/packages/edit-site/src/components/add-new-pattern/index.js
+++ b/packages/edit-site/src/components/add-new-pattern/index.js
@@ -20,7 +20,12 @@ import CreateTemplatePartModal from '../create-template-part-modal';
 import SidebarButton from '../sidebar-button';
 import { unlock } from '../../lock-unlock';
 import { store as editSiteStore } from '../../store';
-import { PATTERN_TYPES, PATTERN_DEFAULT_CATEGORY } from '../../utils/constants';
+import {
+	PATTERN_TYPES,
+	PATTERN_DEFAULT_CATEGORY,
+	TEMPLATE_PART_POST_TYPE,
+} from '../../utils/constants';
+import usePatternCategories from '../sidebar-navigation-screen-patterns/use-pattern-categories';
 
 const { useHistory, useLocation } = unlock( routerPrivateApis );
 const { CreatePatternModal } = unlock( editPatternsPrivateApis );
@@ -39,6 +44,7 @@ export default function AddNewPattern() {
 	const { createSuccessNotice, createErrorNotice } =
 		useDispatch( noticesStore );
 	const patternUploadInputRef = useRef();
+	const { patternCategories } = usePatternCategories();
 
 	function handleCreatePattern( { pattern, categoryId } ) {
 		setShowPatternModal( false );
@@ -129,13 +135,22 @@ export default function AddNewPattern() {
 					const file = event.target.files?.[ 0 ];
 					if ( ! file ) return;
 					try {
-						const pattern = await createPatternFromFile( file );
+						const currentCategoryId =
+							params.categoryType !== TEMPLATE_PART_POST_TYPE &&
+							patternCategories.find(
+								( category ) =>
+									category.name === params.categoryId
+							)?.id;
+						const pattern = await createPatternFromFile(
+							file,
+							currentCategoryId
+								? [ currentCategoryId ]
+								: undefined
+						);
 
-						// Navigate to the All patterns category for the newly created pattern.
-						if (
-							params.categoryType !== PATTERN_TYPES.theme ||
-							params.categoryId !== PATTERN_DEFAULT_CATEGORY
-						) {
+						// Navigate to the All patterns category for the newly created pattern
+						// if we're not on that page already.
+						if ( ! currentCategoryId ) {
 							history.push( {
 								path: `/patterns`,
 								categoryType: PATTERN_TYPES.theme,

--- a/packages/edit-site/src/components/add-new-pattern/index.js
+++ b/packages/edit-site/src/components/add-new-pattern/index.js
@@ -72,13 +72,6 @@ export default function AddNewPattern() {
 			onClick: () => setShowPatternModal( true ),
 			title: __( 'Create pattern' ),
 		},
-		{
-			icon: symbol,
-			onClick: () => {
-				patternUploadInputRef.current.click();
-			},
-			title: __( 'Import pattern from JSON' ),
-		},
 	];
 
 	// Remove condition when command palette issues are resolved.
@@ -90,6 +83,14 @@ export default function AddNewPattern() {
 			title: __( 'Create template part' ),
 		} );
 	}
+
+	controls.push( {
+		icon: symbol,
+		onClick: () => {
+			patternUploadInputRef.current.click();
+		},
+		title: __( 'Import pattern from JSON' ),
+	} );
 
 	return (
 		<>

--- a/packages/edit-site/src/components/add-new-pattern/index.js
+++ b/packages/edit-site/src/components/add-new-pattern/index.js
@@ -145,6 +145,8 @@ export default function AddNewPattern() {
 							type: 'snackbar',
 							id: 'import-pattern-error',
 						} );
+					} finally {
+						event.target.value = '';
 					}
 				} }
 			/>

--- a/packages/edit-site/src/components/page-patterns/grid-item.js
+++ b/packages/edit-site/src/components/page-patterns/grid-item.js
@@ -118,7 +118,7 @@ function GridItem( { categoryId, item, ...props } ) {
 			syncStatus: item.reusableBlock.wp_pattern_sync_status,
 		};
 
-		downloadjs(
+		return downloadjs(
 			JSON.stringify( json, null, 2 ),
 			`${ kebabCase( item.title ) }.json`,
 			'application/json'

--- a/packages/edit-site/src/components/page-patterns/grid-item.js
+++ b/packages/edit-site/src/components/page-patterns/grid-item.js
@@ -114,8 +114,8 @@ function GridItem( { categoryId, item, ...props } ) {
 		const json = {
 			__file: item.type,
 			title: item.title,
-			content: item.reusableBlock.content.raw,
-			syncStatus: item.reusableBlock.wp_pattern_sync_status,
+			content: item.patternBlock.content.raw,
+			syncStatus: item.patternBlock.wp_pattern_sync_status,
 		};
 
 		return downloadjs(

--- a/packages/edit-site/src/components/page-patterns/grid-item.js
+++ b/packages/edit-site/src/components/page-patterns/grid-item.js
@@ -2,6 +2,8 @@
  * External dependencies
  */
 import classnames from 'classnames';
+import downloadjs from 'downloadjs';
+import { paramCase as kebabCase } from 'change-case';
 
 /**
  * WordPress dependencies
@@ -108,6 +110,20 @@ function GridItem( { categoryId, item, ...props } ) {
 	};
 	const deleteItem = () =>
 		isTemplatePart ? removeTemplate( item ) : deletePattern();
+	const exportAsJSON = () => {
+		const json = {
+			__file: item.type,
+			title: item.title,
+			content: item.reusableBlock.content.raw,
+			syncStatus: item.reusableBlock.wp_pattern_sync_status,
+		};
+
+		downloadjs(
+			JSON.stringify( json, null, 2 ),
+			`${ kebabCase( item.title ) }.json`,
+			'application/json'
+		);
+	};
 
 	// Only custom patterns or custom template parts can be renamed or deleted.
 	const isCustomPattern =
@@ -276,6 +292,12 @@ function GridItem( { categoryId, item, ...props } ) {
 								onClose={ onClose }
 								label={ __( 'Duplicate' ) }
 							/>
+							{ item.type === USER_PATTERNS && (
+								<MenuItem onClick={ () => exportAsJSON() }>
+									{ __( 'Export as JSON' ) }
+								</MenuItem>
+							) }
+
 							{ isCustomPattern && (
 								<MenuItem
 									isDestructive={ ! hasThemeFile }

--- a/packages/edit-site/src/components/page-patterns/grid-item.js
+++ b/packages/edit-site/src/components/page-patterns/grid-item.js
@@ -292,7 +292,7 @@ function GridItem( { categoryId, item, ...props } ) {
 								onClose={ onClose }
 								label={ __( 'Duplicate' ) }
 							/>
-							{ item.type === USER_PATTERNS && (
+							{ item.type === PATTERN_TYPES.user && (
 								<MenuItem onClick={ () => exportAsJSON() }>
 									{ __( 'Export as JSON' ) }
 								</MenuItem>

--- a/packages/patterns/src/components/create-pattern-modal.js
+++ b/packages/patterns/src/components/create-pattern-modal.js
@@ -28,7 +28,7 @@ import CategorySelector from './category-selector';
 export default function CreatePatternModal( {
 	onSuccess,
 	onError,
-	clientIds,
+	content,
 	onClose,
 	className = 'patterns-menu-items__convert-modal',
 } ) {
@@ -44,7 +44,7 @@ export default function CreatePatternModal( {
 				const newPattern = await createPattern(
 					patternTitle,
 					sync,
-					clientIds,
+					content,
 					categories
 				);
 				onSuccess( {
@@ -61,11 +61,11 @@ export default function CreatePatternModal( {
 		},
 		[
 			createPattern,
-			clientIds,
+			content,
+			categories,
 			onSuccess,
 			createErrorNotice,
 			onError,
-			categories,
 		]
 	);
 

--- a/packages/patterns/src/components/create-pattern-modal.js
+++ b/packages/patterns/src/components/create-pattern-modal.js
@@ -22,8 +22,9 @@ import { PATTERN_DEFAULT_CATEGORY, PATTERN_SYNC_TYPES } from '../constants';
 /**
  * Internal dependencies
  */
-import { store } from '../store';
+import { store as patternsStore } from '../store';
 import CategorySelector from './category-selector';
+import { unlock } from '../lock-unlock';
 
 export default function CreatePatternModal( {
 	onSuccess,
@@ -35,7 +36,7 @@ export default function CreatePatternModal( {
 	const [ syncType, setSyncType ] = useState( PATTERN_SYNC_TYPES.full );
 	const [ categories, setCategories ] = useState( [] );
 	const [ title, setTitle ] = useState( '' );
-	const { createPattern } = useDispatch( store );
+	const { createPattern } = unlock( useDispatch( patternsStore ) );
 
 	const { createErrorNotice } = useDispatch( noticesStore );
 	async function onCreate( patternTitle, sync ) {

--- a/packages/patterns/src/components/create-pattern-modal.js
+++ b/packages/patterns/src/components/create-pattern-modal.js
@@ -10,7 +10,7 @@ import {
 	ToggleControl,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { useState, useCallback } from '@wordpress/element';
+import { useState } from '@wordpress/element';
 import { useDispatch } from '@wordpress/data';
 import { store as noticesStore } from '@wordpress/notices';
 
@@ -38,36 +38,26 @@ export default function CreatePatternModal( {
 	const { createPattern } = useDispatch( store );
 
 	const { createErrorNotice } = useDispatch( noticesStore );
-	const onCreate = useCallback(
-		async function ( patternTitle, sync ) {
-			try {
-				const newPattern = await createPattern(
-					patternTitle,
-					sync,
-					content,
-					categories
-				);
-				onSuccess( {
-					pattern: newPattern,
-					categoryId: PATTERN_DEFAULT_CATEGORY,
-				} );
-			} catch ( error ) {
-				createErrorNotice( error.message, {
-					type: 'snackbar',
-					id: 'convert-to-pattern-error',
-				} );
-				onError();
-			}
-		},
-		[
-			createPattern,
-			content,
-			categories,
-			onSuccess,
-			createErrorNotice,
-			onError,
-		]
-	);
+	async function onCreate( patternTitle, sync ) {
+		try {
+			const newPattern = await createPattern(
+				patternTitle,
+				sync,
+				typeof content === 'function' ? content() : content,
+				categories
+			);
+			onSuccess( {
+				pattern: newPattern,
+				categoryId: PATTERN_DEFAULT_CATEGORY,
+			} );
+		} catch ( error ) {
+			createErrorNotice( error.message, {
+				type: 'snackbar',
+				id: 'convert-to-pattern-error',
+			} );
+			onError();
+		}
+	}
 
 	const handleCategorySelection = ( selectedCategories ) => {
 		setCategories( selectedCategories.map( ( cat ) => cat.id ) );

--- a/packages/patterns/src/components/pattern-convert-button.js
+++ b/packages/patterns/src/components/pattern-convert-button.js
@@ -8,7 +8,7 @@ import {
 	serialize,
 } from '@wordpress/blocks';
 import { store as blockEditorStore } from '@wordpress/block-editor';
-import { useState } from '@wordpress/element';
+import { useState, useCallback } from '@wordpress/element';
 import { MenuItem } from '@wordpress/components';
 import { symbol } from '@wordpress/icons';
 import { useSelect, useDispatch } from '@wordpress/data';
@@ -82,12 +82,10 @@ export default function PatternConvertButton( { clientIds, rootClientId } ) {
 		},
 		[ clientIds, rootClientId ]
 	);
-	const content = useSelect(
-		( select ) =>
-			serialize(
-				select( blockEditorStore ).getBlocksByClientId( clientIds )
-			),
-		[ clientIds ]
+	const { getBlocksByClientId } = useSelect( blockEditorStore );
+	const getContent = useCallback(
+		() => serialize( getBlocksByClientId( clientIds ) ),
+		[ getBlocksByClientId, clientIds ]
 	);
 
 	if ( ! canConvert ) {
@@ -133,7 +131,7 @@ export default function PatternConvertButton( { clientIds, rootClientId } ) {
 			</MenuItem>
 			{ isModalOpen && (
 				<CreatePatternModal
-					content={ content }
+					content={ getContent }
 					onSuccess={ ( pattern ) => {
 						handleSuccess( pattern );
 					} }

--- a/packages/patterns/src/components/pattern-convert-button.js
+++ b/packages/patterns/src/components/pattern-convert-button.js
@@ -20,6 +20,7 @@ import { store as noticesStore } from '@wordpress/notices';
  */
 import { store as patternsStore } from '../store';
 import CreatePatternModal from './create-pattern-modal';
+import { unlock } from '../lock-unlock';
 
 /**
  * Menu control to convert block(s) to a pattern block.
@@ -32,7 +33,9 @@ import CreatePatternModal from './create-pattern-modal';
 export default function PatternConvertButton( { clientIds, rootClientId } ) {
 	const { createSuccessNotice } = useDispatch( noticesStore );
 	const { replaceBlocks } = useDispatch( blockEditorStore );
-	const { __experimentalSetEditingPattern } = useDispatch( patternsStore );
+	// Ignore reason: false positive of the lint rule.
+	// eslint-disable-next-line @wordpress/no-unused-vars-before-return
+	const { setEditingPattern } = unlock( useDispatch( patternsStore ) );
 	const [ isModalOpen, setIsModalOpen ] = useState( false );
 	const canConvert = useSelect(
 		( select ) => {
@@ -98,7 +101,7 @@ export default function PatternConvertButton( { clientIds, rootClientId } ) {
 		} );
 
 		replaceBlocks( clientIds, newBlock );
-		__experimentalSetEditingPattern( newBlock.clientId, true );
+		setEditingPattern( newBlock.clientId, true );
 
 		createSuccessNotice(
 			pattern.wp_pattern_sync_status === 'unsynced'

--- a/packages/patterns/src/components/patterns-manage-button.js
+++ b/packages/patterns/src/components/patterns-manage-button.js
@@ -12,7 +12,8 @@ import { store as coreStore } from '@wordpress/core-data';
 /**
  * Internal dependencies
  */
-import { store as editorStore } from '../store';
+import { store as patternsStore } from '../store';
+import { unlock } from '../lock-unlock';
 
 function PatternsManageButton( { clientId } ) {
 	const { canRemove, isVisible, innerBlockCount, managePatternsUrl } =
@@ -51,7 +52,11 @@ function PatternsManageButton( { clientId } ) {
 			[ clientId ]
 		);
 
-	const { convertSyncedPatternToStatic } = useDispatch( editorStore );
+	// Ignore reason: false positive of the lint rule.
+	// eslint-disable-next-line @wordpress/no-unused-vars-before-return
+	const { convertSyncedPatternToStatic } = unlock(
+		useDispatch( patternsStore )
+	);
 
 	if ( ! isVisible ) {
 		return null;

--- a/packages/patterns/src/index.js
+++ b/packages/patterns/src/index.js
@@ -1,6 +1,5 @@
 /**
  * Internal dependencies
  */
-import './store';
-
+export { store } from './store';
 export * from './private-apis';

--- a/packages/patterns/src/store/actions.js
+++ b/packages/patterns/src/store/actions.js
@@ -71,7 +71,7 @@ export const createPatternFromFile =
 			throw new Error( 'Invalid Pattern JSON file' );
 		}
 
-		const pattern = await dispatch.__experimentalCreatePattern(
+		const pattern = await dispatch.createPattern(
 			parsedContent.title,
 			parsedContent.syncStatus,
 			parsedContent.content

--- a/packages/patterns/src/store/actions.js
+++ b/packages/patterns/src/store/actions.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 
-import { parse, serialize, createBlock } from '@wordpress/blocks';
+import { parse } from '@wordpress/blocks';
 import { store as coreStore } from '@wordpress/core-data';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 
@@ -14,14 +14,14 @@ import { PATTERN_SYNC_TYPES } from '../constants';
 /**
  * Returns a generator converting one or more static blocks into a pattern, or creating a new empty pattern.
  *
- * @param {string}             title      Pattern title.
- * @param {'full'|'unsynced'}  syncType   They way block is synced, 'full' or 'unsynced'.
- * @param {string[]|undefined} clientIds  Optional client IDs of blocks to convert to pattern.
- * @param {number[]|undefined} categories Ids of any selected categories.
+ * @param {string}             title        Pattern title.
+ * @param {'full'|'unsynced'}  syncType     They way block is synced, 'full' or 'unsynced'.
+ * @param {string|undefined}   [content]    Optional serialized content of blocks to convert to pattern.
+ * @param {number[]|undefined} [categories] Ids of any selected categories.
  */
 export const createPattern =
-	( title, syncType, clientIds, categories ) =>
-	async ( { registry, dispatch } ) => {
+	( title, syncType, content, categories ) =>
+	async ( { registry } ) => {
 		const meta =
 			syncType === PATTERN_SYNC_TYPES.unsynced
 				? {
@@ -31,13 +31,7 @@ export const createPattern =
 
 		const reusableBlock = {
 			title,
-			content: clientIds
-				? serialize(
-						registry
-							.select( blockEditorStore )
-							.getBlocksByClientId( clientIds )
-				  )
-				: undefined,
+			content,
 			status: 'publish',
 			meta,
 			wp_pattern_category: categories,
@@ -47,18 +41,43 @@ export const createPattern =
 			.dispatch( coreStore )
 			.saveEntityRecord( 'postType', 'wp_block', reusableBlock );
 
-		if ( syncType === 'unsynced' || ! clientIds ) {
-			return updatedRecord;
+		return updatedRecord;
+	};
+
+/**
+ * Create a pattern from a JSON file.
+ * @param {File} file The JSON file instance of the pattern.
+ */
+export const createPatternFromFile =
+	( file ) =>
+	async ( { dispatch } ) => {
+		const fileContent = await file.text();
+		/** @type {import('./types').PatternJSON} */
+		let parsedContent;
+		try {
+			parsedContent = JSON.parse( fileContent );
+		} catch ( e ) {
+			throw new Error( 'Invalid JSON file' );
+		}
+		if (
+			parsedContent.__file !== 'wp_block' ||
+			! parsedContent.title ||
+			! parsedContent.content ||
+			typeof parsedContent.title !== 'string' ||
+			typeof parsedContent.content !== 'string' ||
+			( parsedContent.syncStatus &&
+				typeof parsedContent.syncStatus !== 'string' )
+		) {
+			throw new Error( 'Invalid Pattern JSON file' );
 		}
 
-		const newBlock = createBlock( 'core/block', {
-			ref: updatedRecord.id,
-		} );
-		registry
-			.dispatch( blockEditorStore )
-			.replaceBlocks( clientIds, newBlock );
-		dispatch.setEditingPattern( newBlock.clientId, true );
-		return updatedRecord;
+		const pattern = await dispatch.__experimentalCreatePattern(
+			parsedContent.title,
+			parsedContent.syncStatus,
+			parsedContent.content
+		);
+
+		return pattern;
 	};
 
 /**

--- a/packages/patterns/src/store/actions.js
+++ b/packages/patterns/src/store/actions.js
@@ -46,10 +46,11 @@ export const createPattern =
 
 /**
  * Create a pattern from a JSON file.
- * @param {File} file The JSON file instance of the pattern.
+ * @param {File}               file         The JSON file instance of the pattern.
+ * @param {number[]|undefined} [categories] Ids of any selected categories.
  */
 export const createPatternFromFile =
-	( file ) =>
+	( file, categories ) =>
 	async ( { dispatch } ) => {
 		const fileContent = await file.text();
 		/** @type {import('./types').PatternJSON} */
@@ -74,7 +75,8 @@ export const createPatternFromFile =
 		const pattern = await dispatch.createPattern(
 			parsedContent.title,
 			parsedContent.syncStatus,
-			parsedContent.content
+			parsedContent.content,
+			categories
 		);
 
 		return pattern;

--- a/packages/patterns/src/store/index.js
+++ b/packages/patterns/src/store/index.js
@@ -10,6 +10,7 @@ import reducer from './reducer';
 import * as actions from './actions';
 import { STORE_NAME } from './constants';
 import * as selectors from './selectors';
+import { unlock } from '../lock-unlock';
 
 /**
  * Post editor data store configuration.
@@ -20,8 +21,6 @@ import * as selectors from './selectors';
  */
 export const storeConfig = {
 	reducer,
-	selectors,
-	actions,
 };
 
 /**
@@ -36,3 +35,5 @@ export const store = createReduxStore( STORE_NAME, {
 } );
 
 register( store );
+unlock( store ).registerPrivateActions( actions );
+unlock( store ).registerPrivateSelectors( selectors );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Close #53288. Allow import/export patterns as JSON files in the site editor's pattern screen.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
To match wp-admin functionality.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
The implementation is quite straightforward. Just add some menu items to the corresponding dropdown menus.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Create some synced/unsynced patterns.
2. Visit Site Editor -> Patterns -> My patterns. Tab through the grid list to the "Actions" menu dropdown of a pattern, and select "Export as JSON".
3. You should be prompted by a native download dialog to decide where to download the JSON file.
4. Verify that the downloaded JSON file is the same as the one downloaded in `/wp-admin/edit.php?post_type=wp_block`.
5. Go back to Site Editor -> Patterns
6. Press <kbd>Tab</kbd> once to navigate to the "Create pattern" button. Hit <kbd>Enter</kbd> to open the dropdown, and select "Import pattern from JSON"
7. You should be prompted by a native upload dialog that only accepts a `.json` file.
8. Choose a validated pattern JSON file to import it to the patterns screen. There should also be a snackbar announcing the successful message `Imported "title" from JSON.`.
9. Choosing an invalid pattern JSON file should announce "Invalid JSON file" in the snackbar.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
Same as above.

## Screenshots or screencast <!-- if applicable -->


https://github.com/WordPress/gutenberg/assets/7753001/22e965c8-07c8-4fba-8e91-0a4fdc91e293

