### PR TITLE
Patterns: Remove experimental prefixes from patterns package

### DIFF
--- a/packages/patterns/src/components/create-pattern-modal.js
+++ b/packages/patterns/src/components/create-pattern-modal.js
@@ -35,7 +35,7 @@ export default function CreatePatternModal( {
 } ) {
 	const [ syncType, setSyncType ] = useState( SYNC_TYPES.full );
 	const [ title, setTitle ] = useState( '' );
-	const { __experimentalCreatePattern: createPattern } = useDispatch( store );
+	const { createPattern } = useDispatch( store );
 
 	const { createErrorNotice } = useDispatch( noticesStore );
 	const onCreate = useCallback(

--- a/packages/patterns/src/components/patterns-manage-button.js
+++ b/packages/patterns/src/components/patterns-manage-button.js
@@ -51,8 +51,7 @@ function PatternsManageButton( { clientId } ) {
 			[ clientId ]
 		);
 
-	const { __experimentalConvertSyncedPatternToStatic: convertBlockToStatic } =
-		useDispatch( editorStore );
+	const { convertSyncedPatternToStatic } = useDispatch( editorStore );
 
 	if ( ! isVisible ) {
 		return null;
@@ -64,7 +63,9 @@ function PatternsManageButton( { clientId } ) {
 				{ __( 'Manage patterns' ) }
 			</MenuItem>
 			{ canRemove && (
-				<MenuItem onClick={ () => convertBlockToStatic( clientId ) }>
+				<MenuItem
+					onClick={ () => convertSyncedPatternToStatic( clientId ) }
+				>
 					{ innerBlockCount > 1
 						? __( 'Detach patterns' )
 						: __( 'Detach pattern' ) }

--- a/packages/patterns/src/store/actions.js
+++ b/packages/patterns/src/store/actions.js
@@ -13,7 +13,7 @@ import { store as blockEditorStore } from '@wordpress/block-editor';
  * @param {'full'|'unsynced'}  syncType  They way block is synced, 'full' or 'unsynced'.
  * @param {string[]|undefined} clientIds Optional client IDs of blocks to convert to pattern.
  */
-export const __experimentalCreatePattern =
+export const createPattern =
 	( title, syncType, clientIds ) =>
 	async ( { registry, dispatch } ) => {
 		const meta =
@@ -50,7 +50,7 @@ export const __experimentalCreatePattern =
 		registry
 			.dispatch( blockEditorStore )
 			.replaceBlocks( clientIds, newBlock );
-		dispatch.__experimentalSetEditingPattern( newBlock.clientId, true );
+		dispatch.setEditingPattern( newBlock.clientId, true );
 		return updatedRecord;
 	};
 
@@ -59,7 +59,7 @@ export const __experimentalCreatePattern =
  *
  * @param {string} clientId The client ID of the block to attach.
  */
-export const __experimentalConvertSyncedPatternToStatic =
+export const convertSyncedPatternToStatic =
 	( clientId ) =>
 	( { registry } ) => {
 		const oldBlock = registry
@@ -90,7 +90,7 @@ export const __experimentalConvertSyncedPatternToStatic =
  * @param {boolean} isEditing Whether the block should be in editing state.
  * @return {Object} Action descriptor.
  */
-export function __experimentalSetEditingPattern( clientId, isEditing ) {
+export function setEditingPattern( clientId, isEditing ) {
 	return {
 		type: 'SET_EDITING_PATTERN',
 		clientId,

--- a/packages/patterns/src/store/selectors.js
+++ b/packages/patterns/src/store/selectors.js
@@ -5,6 +5,6 @@
  * @param {number} clientId the clientID of the block.
  * @return {boolean} Whether the pattern is in the editing state.
  */
-export function __experimentalIsEditingPattern( state, clientId ) {
+export function isEditingPattern( state, clientId ) {
 	return state.isEditingPattern[ clientId ];
 }


### PR DESCRIPTION
## What?
Removes the `__experimental` prefix from the patterns package.

## Why?
This package currently doesn't have a public API so these are not really. 

## How?
Removed all occurences of `__experimental` from `@wordpress/patterns` package

## Testing Instructions

- In the post editor add a block and from block toolbar overflow menu select `Create pattern` option and make sure this still creates a pattern as expected. Try with both synced and unsynced patterns
- Create a synced pattern and insert in post editor and its block toolbar overflow menu make sure the `Manage patterns` and `Detach pattern` options work as expected

