### PR TITLE
Background Image block support: Add reset menu item

### DIFF
--- a/packages/block-editor/src/hooks/background.js
+++ b/packages/block-editor/src/hooks/background.js
@@ -8,6 +8,7 @@ import {
 	Button,
 	DropZone,
 	FlexItem,
+	MenuItem,
 	__experimentalItemGroup as ItemGroup,
 	__experimentalHStack as HStack,
 	__experimentalTruncate as Truncate,
@@ -236,7 +237,13 @@ function BackgroundImagePanelItem( props ) {
 							/>
 						}
 						variant="secondary"
-					/>
+					>
+						<MenuItem
+							onClick={ () => resetBackgroundImage( props ) }
+						>
+							{ __( 'Reset ' ) }
+						</MenuItem>
+					</MediaReplaceFlow>
 				) }
 				{ ! url && (
 					<MediaUploadCheck>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes https://github.com/WordPress/gutenberg/issues/54319

Add a `Reset` menu item to the background image block support's replace media control.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

As raised in https://github.com/WordPress/gutenberg/issues/54319 while the background image can be reset by the tools panel's dropdown menu, since the replace button displays a list of options, it'd be good for it to include `Reset` here, too, for discoverability.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Add a `MenuItem` to the use of `MediaReplaceFlow` to render a `Reset` button that clears out the background image.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Add a Group block and some child blocks to a post, page, or template
2. Select the Group block and set a background image in the Styles tab of the block inspector
3. Click on the button for the image and select the newly added "Reset" button
4. It should clear out the background image

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

As above, but you should be able to tab over to the image button in the block inspector, press Enter, and then use arrow keys to reach the Reset button and then press Enter to clear the background image.

## Screenshots or screencast <!-- if applicable -->

| Before | After |
| --- | --- |
| ![image](https://github.com/WordPress/gutenberg/assets/14988353/494d921a-cc5e-4af1-9ec4-94ce078b671a) | ![image](https://github.com/WordPress/gutenberg/assets/14988353/8cc3e429-da2a-4490-8e39-509ba375c6ca) |

Screengrab:

https://github.com/WordPress/gutenberg/assets/14988353/b073c9f8-c534-4915-9800-82eee5cc806e