### PR TITLE
Allow accessing the patterns screen when the classic theme supports `block-template-parts`

### DIFF
--- a/packages/core-commands/src/admin-navigation-commands.js
+++ b/packages/core-commands/src/admin-navigation-commands.js
@@ -10,7 +10,11 @@ import { privateApis as routerPrivateApis } from '@wordpress/router';
 /**
  * Internal dependencies
  */
-import { useIsTemplatesAccessible, useIsBlockBasedTheme } from './hooks';
+import {
+	useIsTemplatesAccessible,
+	useIsBlockBasedTheme,
+	useSupportsBlockTemplateParts,
+} from './hooks';
 import { unlock } from './lock-unlock';
 
 const { useHistory } = unlock( routerPrivateApis );
@@ -19,6 +23,7 @@ export function useAdminNavigationCommands() {
 	const history = useHistory();
 	const isTemplatesAccessible = useIsTemplatesAccessible();
 	const isBlockBasedTheme = useIsBlockBasedTheme();
+	const supportsBlockTemplateParts = useSupportsBlockTemplateParts();
 
 	const isSiteEditor = getPath( window.location.href )?.includes(
 		'site-editor.php'
@@ -45,7 +50,10 @@ export function useAdminNavigationCommands() {
 		label: __( 'Patterns' ),
 		icon: symbol,
 		callback: ( { close } ) => {
-			if ( isTemplatesAccessible && isBlockBasedTheme ) {
+			if (
+				isTemplatesAccessible &&
+				( isBlockBasedTheme || supportsBlockTemplateParts )
+			) {
 				const args = {
 					path: '/patterns',
 				};

--- a/packages/core-commands/src/hooks.js
+++ b/packages/core-commands/src/hooks.js
@@ -17,3 +17,11 @@ export function useIsBlockBasedTheme() {
 		[]
 	);
 }
+
+export function useSupportsBlockTemplateParts() {
+	return useSelect(
+		( select ) =>
+			!! select( coreStore ).getThemeSupports()[ 'block-template-parts' ],
+		[]
+	);
+}

--- a/packages/edit-post/src/plugins/index.js
+++ b/packages/edit-post/src/plugins/index.js
@@ -20,10 +20,12 @@ import WelcomeGuideMenuItem from './welcome-guide-menu-item';
 
 function ManagePatternsMenuItem() {
 	const url = useSelect( ( select ) => {
-		const { canUser } = select( coreStore );
+		const { canUser, getThemeSupports } = select( coreStore );
 		const { getEditorSettings } = select( editorStore );
 
 		const isBlockTheme = getEditorSettings().__unstableIsBlockBasedTheme;
+		const supportsBlockTemplateParts =
+			!! getThemeSupports()[ 'block-template-parts' ];
 		const defaultUrl = addQueryArgs( 'edit.php', {
 			post_type: 'wp_block',
 		} );
@@ -34,7 +36,8 @@ function ManagePatternsMenuItem() {
 		// The site editor and templates both check whether the user has
 		// edit_theme_options capabilities. We can leverage that here and not
 		// display the manage patterns link if the user can't access it.
-		return canUser( 'read', 'templates' ) && isBlockTheme
+		return canUser( 'read', 'templates' ) &&
+			( isBlockTheme || supportsBlockTemplateParts )
 			? patternsUrl
 			: defaultUrl;
 	}, [] );

--- a/packages/edit-site/src/components/sidebar-navigation-screen-patterns/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-patterns/index.js
@@ -14,6 +14,8 @@ import { getTemplatePartIcon } from '@wordpress/editor';
 import { __, sprintf } from '@wordpress/i18n';
 import { getQueryArgs } from '@wordpress/url';
 import { file, starFilled, lockSmall } from '@wordpress/icons';
+import { store as coreStore } from '@wordpress/core-data';
+import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -105,6 +107,10 @@ export default function SidebarNavigationScreenPatterns() {
 		useTemplatePartAreas();
 	const { patternCategories, hasPatterns } = usePatternCategories();
 	const { myPatterns } = useMyPatterns();
+	const isBlockBasedTheme = useSelect(
+		( select ) => !! select( coreStore ).getCurrentTheme()?.is_block_theme,
+		[]
+	);
 
 	const templatePartsLink = useLink( { path: '/wp_template_part/all' } );
 	const footer = ! isMobileViewport ? (
@@ -124,6 +130,7 @@ export default function SidebarNavigationScreenPatterns() {
 
 	return (
 		<SidebarNavigationScreen
+			isRoot={ ! isBlockBasedTheme }
 			title={ __( 'Patterns' ) }
 			description={ __(
 				'Manage what patterns are available when editing the site.'

--- a/packages/edit-site/src/components/sidebar-navigation-screen-templates-browse/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-templates-browse/index.js
@@ -2,14 +2,12 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useSelect } from '@wordpress/data';
 import { __experimentalUseNavigator as useNavigator } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
 import SidebarNavigationScreen from '../sidebar-navigation-screen';
-import { store as editSiteStore } from '../../store';
 
 const config = {
 	wp_template: {
@@ -32,15 +30,8 @@ export default function SidebarNavigationScreenTemplatesBrowse() {
 		params: { postType },
 	} = useNavigator();
 
-	const isTemplatePartsMode = useSelect( ( select ) => {
-		const settings = select( editSiteStore ).getSettings();
-
-		return !! settings.supportsTemplatePartsMode;
-	}, [] );
-
 	return (
 		<SidebarNavigationScreen
-			isRoot={ isTemplatePartsMode }
 			title={ config[ postType ].title }
 			description={ config[ postType ].description }
 			backPath={ config[ postType ].backPath }

--- a/packages/patterns/src/components/patterns-manage-button.js
+++ b/packages/patterns/src/components/patterns-manage-button.js
@@ -20,9 +20,11 @@ function PatternsManageButton( { clientId } ) {
 			( select ) => {
 				const { getBlock, canRemoveBlock, getBlockCount, getSettings } =
 					select( blockEditorStore );
-				const { canUser } = select( coreStore );
+				const { canUser, getThemeSupports } = select( coreStore );
 				const reusableBlock = getBlock( clientId );
 				const isBlockTheme = getSettings().__unstableIsBlockBasedTheme;
+				const supportsBlockTemplateParts =
+					!! getThemeSupports()[ 'block-template-parts' ];
 
 				return {
 					canRemove: canRemoveBlock( clientId ),
@@ -39,7 +41,8 @@ function PatternsManageButton( { clientId } ) {
 					// has edit_theme_options capabilities. We can leverage that here
 					// and omit the manage patterns link if the user can't access it.
 					managePatternsUrl:
-						isBlockTheme && canUser( 'read', 'templates' )
+						( isBlockTheme || supportsBlockTemplateParts ) &&
+						canUser( 'read', 'templates' )
 							? addQueryArgs( 'site-editor.php', {
 									path: '/patterns',
 							  } )

--- a/packages/reusable-blocks/src/components/reusable-blocks-menu-items/reusable-blocks-manage-button.js
+++ b/packages/reusable-blocks/src/components/reusable-blocks-menu-items/reusable-blocks-manage-button.js
@@ -20,9 +20,11 @@ function ReusableBlocksManageButton( { clientId } ) {
 			( select ) => {
 				const { getBlock, canRemoveBlock, getBlockCount, getSettings } =
 					select( blockEditorStore );
-				const { canUser } = select( coreStore );
+				const { canUser, getThemeSupports } = select( coreStore );
 				const reusableBlock = getBlock( clientId );
 				const isBlockTheme = getSettings().__unstableIsBlockBasedTheme;
+				const supportsBlockTemplateParts =
+					!! getThemeSupports()[ 'block-template-parts' ];
 
 				return {
 					canRemove: canRemoveBlock( clientId ),
@@ -39,7 +41,8 @@ function ReusableBlocksManageButton( { clientId } ) {
 					// has edit_theme_options capabilities. We can leverage that here
 					// and omit the manage patterns link if the user can't access it.
 					managePatternsUrl:
-						isBlockTheme && canUser( 'read', 'templates' )
+						( isBlockTheme || supportsBlockTemplateParts ) &&
+						canUser( 'read', 'templates' )
 							? addQueryArgs( 'site-editor.php', {
 									path: '/patterns',
 							  } )


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
An alternative to https://github.com/WordPress/gutenberg/pull/54066 which implements the approach in https://github.com/WordPress/gutenberg/pull/54066#pullrequestreview-1619081472.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
See https://github.com/WordPress/gutenberg/issues/52150.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
For classic themes: "Manage patterns" points to `edit.php?post_type=wp_block`. Add a `Patterns` link under the Appearance section that points to `edit.php?post_type=wp_block` as well.

For classic themes with `block-template-parts` support: "Manage patterns" points to `site-editor.php?path=/patterns`. Add a `Patterns` link under the Appearance section that points to `site-editor.php?path=/patterns` as well.

For block themes: "Manage patterns" points to `site-editor.php?path=/patterns`.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
This PR requires https://github.com/WordPress/wordpress-develop/compare/trunk...kevin940726:wordpress-develop:fix/allow-patterns-access-for-block-template-parts. Please apply the diff in core before testing.

There are multiple places that we can link to the patterns page:
1. Via command palette (<kbd>Cmd</kbd>+<kbd>k</kbd>) in post/site editor, type in `patterns` and hit <kbd>Enter</kbd>.
2. In the "Options" dropdown on an existing synced pattern. Tab through each option and select "Manage patterns".
3. Via the "Options" dropdown in the editor top bar. Tab through each option and select "Manage patterns".

For classic themes without `block-template-parts` support (like `twentytwentyone`):
1. Test that each "Manage patterns" link points to `edit.php?post_type=wp_block`.
2. Test that Appearance -> Patterns links to `edit.php?post_type=wp_block`.

For classic themes with `block-template-parts` support (like `emptyhybrid`):
1. Test that each "Manage patterns" link points to `site-editor.php?path=/patterns`.
2. Test that Appearance -> Patterns links to `site-editor.php?path=/patterns`.

For block themes:
1. Test that each "Manage patterns" link points to `site-editor.php?path=/patterns`.
2. No Appearance -> Patterns link.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
Same as above.

## Screenshots or screencast <!-- if applicable -->
TBD
