### PR TITLE
Add manual Server Side Rendering (SSR) to the Interactivity API blocks

### DIFF
--- a/packages/block-library/src/file/index.php
+++ b/packages/block-library/src/file/index.php
@@ -59,8 +59,7 @@ function render_block_core_file( $attributes, $content, $block ) {
 		$processor->next_tag();
 		$processor->set_attribute( 'data-wp-interactive', '' );
 		$processor->next_tag( 'object' );
-		$processor->set_attribute( 'data-wp-bind--hidden', '!selectors.core.file.hasPdfPreview' );
-		$processor->set_attribute( 'hidden', true );
+		$processor->set_attribute( 'data-wp-style--display', 'selectors.core.file.hasPdfPreview' );
 		return $processor->get_updated_html();
 	}
 

--- a/packages/block-library/src/file/style.scss
+++ b/packages/block-library/src/file/style.scss
@@ -29,6 +29,12 @@
 	margin-bottom: 1em;
 }
 
+@media (max-width: 768px) {
+	.wp-block-file__embed {
+		display: none;
+	}
+}
+
 //This needs a low specificity so it won't override the rules from the button element if defined in theme.json.
 :where(.wp-block-file__button) {
 	border-radius: 2em;
@@ -36,7 +42,6 @@
 	display: inline-block;
 
 	&:is(a) {
-
 		&:hover,
 		&:visited,
 		&:focus,

--- a/packages/block-library/src/file/view.js
+++ b/packages/block-library/src/file/view.js
@@ -5,13 +5,13 @@ import { store } from '@wordpress/interactivity';
 /**
  * Internal dependencies
  */
-import { browserSupportsPdfs as hasPdfPreview } from './utils';
+import { browserSupportsPdfs } from './utils';
 
 store( {
 	selectors: {
 		core: {
 			file: {
-				hasPdfPreview,
+				hasPdfPreview: browserSupportsPdfs() ? 'inherit' : 'none',
 			},
 		},
 	},

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -104,6 +104,7 @@ function block_core_navigation_add_directives_to_submenu( $w, $block_attributes 
 		) ) {
 			$w->set_attribute( 'data-wp-on--click', 'actions.core.navigation.toggleMenuOnClick' );
 			$w->set_attribute( 'data-wp-bind--aria-expanded', 'selectors.core.navigation.isMenuOpen' );
+			// The `aria-expanded` attribute for SSR is already added in the submenu block.
 		};
 		// Add directives to the submenu.
 		if ( $w->next_tag(
@@ -713,7 +714,9 @@ function render_block_core_navigation( $attributes, $content, $block ) {
 		';
 		$responsive_dialog_directives    = '
 			data-wp-bind--aria-modal="selectors.core.navigation.isMenuOpen"
+			aria-modal="false"
 			data-wp-bind--role="selectors.core.navigation.roleAttribute"
+			role=""
 			data-wp-effect="effects.core.navigation.focusFirstElement"
 		';
 		$close_button_directives         = '


### PR DESCRIPTION
## What?
Add manual SSR for the attributes needed in the Interactivity API blocks. Covering the File and the Navigation block.

## Why?
The Interactivity API has its own logic to handle the Server Side Rendering (SSR): [link](https://github.com/WordPress/gutenberg/tree/76b0165002690569cc693fefc6b3e94e7e09204a/lib/experimental/interactivity-api). With this, it can translate `data-wp-bind--aria-hidden="context.core.navigation.isOpen` and handle the SSR automatically.

However, this logic won't be included in WordPress 6.4, while the idea is to include the File and Navigation block using the Interactivity API.

## How?
I made sure to define the needed attributes directly in the SSR.

**Navigation block**

I just had to add the `aria-modal="false"` and the `role=""`. The other `aria-expanded` attribute in the submenu was already included in the submenu and page list blocks.

**File block**

It seems that the `hidden` attribute was already included: [link](https://github.com/WordPress/gutenberg/blob/76b0165002690569cc693fefc6b3e94e7e09204a/packages/block-library/src/file/index.php#L63).

In the file block, it shows the preview when it is a Desktop and hides it when it is mobile. This logic seems complicate to replicate in the server, that's why I guess it was added in the first place. I assume we have two options:

* Hidden by default (current approach): In desktop, it is hidden in the SSR and shown when JS runs.
* Not hidden by default: In mobile, it is shown in the SSR and hidden when JS runs.


## Testing Instructions
1. Disable the current Interactivity API logic by commenting these lines: [link](https://github.com/WordPress/gutenberg/tree/76b0165002690569cc693fefc6b3e94e7e09204a/lib/experimental/interactivity-api). This way we can simulate how it will work in WordPress 6.4.
2. Add a navigation block to your site.
3. Disable the JS through the Dev Tools or view the page source.
4. Check that the proper HTML (with its attributes/classes) comes from the server without running JS. 
5. Repeat the process for the File block, where you have to enable the preview setting.
