### PR TITLE
Query Loop: Allow "enhanced pagination" only with core blocks

### DIFF
--- a/packages/block-library/src/query/edit/enhanced-pagination-modal.js
+++ b/packages/block-library/src/query/edit/enhanced-pagination-modal.js
@@ -1,0 +1,66 @@
+/**
+ * WordPress dependencies
+ */
+import { useDispatch } from '@wordpress/data';
+import {
+	Button,
+	Modal,
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { useContainsThirdPartyBlocks } from '../utils';
+
+const disableEnhancedPaginationDescription = __(
+	'Third-party blocks are not supported inside a Query Loop block with "Enhanced Pagination" enabled.'
+);
+
+const modalDescriptionId =
+	'wp-block-query-enhanced-pagination-modal__description';
+
+export default function EnhancedPaginationModal( {
+	clientId,
+	attributes: { enhancedPagination },
+	setAttributes,
+} ) {
+	const containsThirdPartyBlocks = useContainsThirdPartyBlocks( clientId );
+
+	// eslint-disable-next-line @wordpress/data-no-store-string-literals
+	const { undo } = useDispatch( 'core/editor' );
+
+	return (
+		containsThirdPartyBlocks &&
+		enhancedPagination && (
+			<Modal
+				title={ __( 'Disable "Enhanced Pagination"?' ) }
+				className={ 'wp-block-query-enhanced-pagination-modal' }
+				aria={ {
+					describedby: modalDescriptionId,
+				} }
+				isDismissible={ false }
+				shouldCloseOnEsc={ false }
+				shouldCloseOnClickOutside={ false }
+			>
+				<p id={ modalDescriptionId }>
+					{ disableEnhancedPaginationDescription }
+				</p>
+				<VStack alignment="right" spacing={ 3 }>
+					<Button
+						variant="primary"
+						onClick={ () => {
+							setAttributes( { enhancedPagination: false } );
+						} }
+					>
+						{ __( 'Disable it and keep third-party blocks' ) }
+					</Button>
+					<Button variant="tertiary" onClick={ undo }>
+						{ __( 'Undo changes' ) }
+					</Button>
+				</VStack>
+			</Modal>
+		)
+	);
+}

--- a/packages/block-library/src/query/edit/enhanced-pagination-modal.js
+++ b/packages/block-library/src/query/edit/enhanced-pagination-modal.js
@@ -7,6 +7,7 @@ import {
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { useState, useEffect } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -25,11 +26,16 @@ export default function EnhancedPaginationModal( {
 	attributes: { enhancedPagination },
 	setAttributes,
 } ) {
+	const [ isOpen, setOpen ] = useState( false );
+
 	const containsThirdPartyBlocks = useContainsThirdPartyBlocks( clientId );
 
+	useEffect( () => {
+		setOpen( containsThirdPartyBlocks && enhancedPagination );
+	}, [ containsThirdPartyBlocks, enhancedPagination, setOpen ] );
+
 	return (
-		containsThirdPartyBlocks &&
-		enhancedPagination && (
+		isOpen && (
 			<Modal
 				title={ __( 'Enhanced pagination will be disabled' ) }
 				className={ 'wp-block-query-enhanced-pagination-modal' }
@@ -40,10 +46,10 @@ export default function EnhancedPaginationModal( {
 				shouldCloseOnEsc={ false }
 				shouldCloseOnClickOutside={ false }
 			>
-				<p id={ modalDescriptionId }>
-					{ disableEnhancedPaginationDescription }
-				</p>
-				<VStack alignment="right" spacing={ 3 }>
+				<VStack alignment="right" spacing={ 8 }>
+					<span id={ modalDescriptionId }>
+						{ disableEnhancedPaginationDescription }
+					</span>
 					<Button
 						variant="primary"
 						onClick={ () => {

--- a/packages/block-library/src/query/edit/enhanced-pagination-modal.js
+++ b/packages/block-library/src/query/edit/enhanced-pagination-modal.js
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { useDispatch } from '@wordpress/data';
 import {
 	Button,
 	Modal,
@@ -15,7 +14,7 @@ import { __ } from '@wordpress/i18n';
 import { useContainsThirdPartyBlocks } from '../utils';
 
 const disableEnhancedPaginationDescription = __(
-	'Third-party blocks are not supported inside a Query Loop block with enhanced pagination enabled.'
+	'Third-party blocks are not supported inside a Query Loop block with enhanced pagination enabled. To re-enable it, remove any third-party block and then update it in the Query Loop settings.'
 );
 
 const modalDescriptionId =
@@ -28,14 +27,11 @@ export default function EnhancedPaginationModal( {
 } ) {
 	const containsThirdPartyBlocks = useContainsThirdPartyBlocks( clientId );
 
-	// eslint-disable-next-line @wordpress/data-no-store-string-literals
-	const { undo } = useDispatch( 'core/editor' );
-
 	return (
 		containsThirdPartyBlocks &&
 		enhancedPagination && (
 			<Modal
-				title={ __( "Disable Query Loop's enhanced pagination?" ) }
+				title={ __( 'Enhanced pagination will be disabled' ) }
 				className={ 'wp-block-query-enhanced-pagination-modal' }
 				aria={ {
 					describedby: modalDescriptionId,
@@ -54,10 +50,7 @@ export default function EnhancedPaginationModal( {
 							setAttributes( { enhancedPagination: false } );
 						} }
 					>
-						{ __( 'Disable it and keep third-party blocks' ) }
-					</Button>
-					<Button variant="tertiary" onClick={ undo }>
-						{ __( 'Undo changes' ) }
+						{ __( 'OK, understood' ) }
 					</Button>
 				</VStack>
 			</Modal>

--- a/packages/block-library/src/query/edit/enhanced-pagination-modal.js
+++ b/packages/block-library/src/query/edit/enhanced-pagination-modal.js
@@ -15,7 +15,7 @@ import { __ } from '@wordpress/i18n';
 import { useContainsThirdPartyBlocks } from '../utils';
 
 const disableEnhancedPaginationDescription = __(
-	'Third-party blocks are not supported inside a Query Loop block with "Enhanced Pagination" enabled.'
+	'Third-party blocks are not supported inside a Query Loop block with enhanced pagination enabled.'
 );
 
 const modalDescriptionId =
@@ -35,7 +35,7 @@ export default function EnhancedPaginationModal( {
 		containsThirdPartyBlocks &&
 		enhancedPagination && (
 			<Modal
-				title={ __( 'Disable "Enhanced Pagination"?' ) }
+				title={ __( "Disable Query Loop's enhanced pagination?" ) }
 				className={ 'wp-block-query-enhanced-pagination-modal' }
 				aria={ {
 					describedby: modalDescriptionId,

--- a/packages/block-library/src/query/edit/inspector-controls/enhanced-pagination-control.js
+++ b/packages/block-library/src/query/edit/inspector-controls/enhanced-pagination-control.js
@@ -15,7 +15,7 @@ export default function EnhancedPaginationControl( {
 	clientId,
 } ) {
 	const enhancedPaginationNotice = __(
-		'Enhanced pagination requires all descendants to be Core blocks. If you want to enable it, you have to remove all third-party blocks contained inside Post Template.'
+		'Enhanced pagination requires all descendants to be Core blocks. If you want to enable it, you have to remove all third-party blocks contained inside the Query Loop block.'
 	);
 
 	const containsThirdPartyBlocks = useContainsThirdPartyBlocks( clientId );

--- a/packages/block-library/src/query/edit/inspector-controls/enhanced-pagination-control.js
+++ b/packages/block-library/src/query/edit/inspector-controls/enhanced-pagination-control.js
@@ -1,0 +1,52 @@
+/**
+ * WordPress dependencies
+ */
+import { ToggleControl, Notice } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { useEffect, useRef } from '@wordpress/element';
+import { speak } from '@wordpress/a11y';
+
+export default function EnhancedPaginationControl( {
+	enhancedPagination,
+	setAttributes,
+} ) {
+	const enhancedPaginationNotice = __(
+		'Enhanced Pagination might cause interactive blocks within the Post Template to stop working. Disable it if you experience any issues.'
+	);
+
+	const isFirstRender = useRef( true ); // Don't speak on first render.
+	useEffect( () => {
+		if ( ! isFirstRender.current && enhancedPagination ) {
+			speak( enhancedPaginationNotice );
+		}
+		isFirstRender.current = false;
+	}, [ enhancedPagination, enhancedPaginationNotice ] );
+
+	return (
+		<>
+			<ToggleControl
+				label={ __( 'Enhanced pagination' ) }
+				help={ __(
+					'Browsing between pages won’t require a full page reload.'
+				) }
+				checked={ !! enhancedPagination }
+				onChange={ ( value ) => {
+					setAttributes( {
+						enhancedPagination: !! value,
+					} );
+				} }
+			/>
+			{ enhancedPagination && (
+				<div>
+					<Notice
+						spokenMessage={ null }
+						status="warning"
+						isDismissible={ false }
+					>
+						{ enhancedPaginationNotice }
+					</Notice>
+				</div>
+			) }
+		</>
+	);
+}

--- a/packages/block-library/src/query/edit/inspector-controls/enhanced-pagination-control.js
+++ b/packages/block-library/src/query/edit/inspector-controls/enhanced-pagination-control.js
@@ -15,7 +15,7 @@ export default function EnhancedPaginationControl( {
 	clientId,
 } ) {
 	const enhancedPaginationNotice = __(
-		'This setting requires all descendants to be Core blocks. If you want to enable it, you have to remove all third-party blocks contained inside Post Template.'
+		'Enhanced pagination requires all descendants to be Core blocks. If you want to enable it, you have to remove all third-party blocks contained inside Post Template.'
 	);
 
 	const containsThirdPartyBlocks = useContainsThirdPartyBlocks( clientId );
@@ -37,11 +37,7 @@ export default function EnhancedPaginationControl( {
 			/>
 			{ containsThirdPartyBlocks && (
 				<div>
-					<Notice
-						spokenMessage={ null }
-						status="warning"
-						isDismissible={ false }
-					>
+					<Notice status="warning" isDismissible={ false }>
 						{ enhancedPaginationNotice }
 					</Notice>
 				</div>

--- a/packages/block-library/src/query/edit/inspector-controls/enhanced-pagination-control.js
+++ b/packages/block-library/src/query/edit/inspector-controls/enhanced-pagination-control.js
@@ -3,24 +3,22 @@
  */
 import { ToggleControl, Notice } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { useEffect, useRef } from '@wordpress/element';
-import { speak } from '@wordpress/a11y';
+
+/**
+ * Internal dependencies
+ */
+import { useContainsThirdPartyBlocks } from '../../utils';
 
 export default function EnhancedPaginationControl( {
 	enhancedPagination,
 	setAttributes,
+	clientId,
 } ) {
 	const enhancedPaginationNotice = __(
-		'Enhanced Pagination might cause interactive blocks within the Post Template to stop working. Disable it if you experience any issues.'
+		'This setting requires all descendants to be Core blocks. If you want to enable it, you have to remove all third-party blocks contained inside Post Template.'
 	);
 
-	const isFirstRender = useRef( true ); // Don't speak on first render.
-	useEffect( () => {
-		if ( ! isFirstRender.current && enhancedPagination ) {
-			speak( enhancedPaginationNotice );
-		}
-		isFirstRender.current = false;
-	}, [ enhancedPagination, enhancedPaginationNotice ] );
+	const containsThirdPartyBlocks = useContainsThirdPartyBlocks( clientId );
 
 	return (
 		<>
@@ -30,13 +28,14 @@ export default function EnhancedPaginationControl( {
 					'Browsing between pages won’t require a full page reload.'
 				) }
 				checked={ !! enhancedPagination }
+				disabled={ containsThirdPartyBlocks }
 				onChange={ ( value ) => {
 					setAttributes( {
 						enhancedPagination: !! value,
 					} );
 				} }
 			/>
-			{ enhancedPagination && (
+			{ containsThirdPartyBlocks && (
 				<div>
 					<Notice
 						spokenMessage={ null }

--- a/packages/block-library/src/query/edit/inspector-controls/index.js
+++ b/packages/block-library/src/query/edit/inspector-controls/index.js
@@ -41,7 +41,8 @@ import {
 const { BlockInfo } = unlock( blockEditorPrivateApis );
 
 export default function QueryInspectorControls( props ) {
-	const { attributes, setQuery, setDisplayLayout, setAttributes } = props;
+	const { attributes, setQuery, setDisplayLayout, setAttributes, clientId } =
+		props;
 	const { query, displayLayout, enhancedPagination } = attributes;
 	const {
 		order,
@@ -206,6 +207,7 @@ export default function QueryInspectorControls( props ) {
 						<EnhancedPaginationControl
 							enhancedPagination={ enhancedPagination }
 							setAttributes={ setAttributes }
+							clientId={ clientId }
 						/>
 					</PanelBody>
 				</InspectorControls>

--- a/packages/block-library/src/query/edit/inspector-controls/index.js
+++ b/packages/block-library/src/query/edit/inspector-controls/index.js
@@ -17,8 +17,7 @@ import {
 	privateApis as blockEditorPrivateApis,
 } from '@wordpress/block-editor';
 import { debounce } from '@wordpress/compose';
-import { useEffect, useState, useCallback, useRef } from '@wordpress/element';
-import { speak } from '@wordpress/a11y';
+import { useEffect, useState, useCallback } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -28,6 +27,7 @@ import AuthorControl from './author-control';
 import ParentControl from './parent-control';
 import { TaxonomyControls } from './taxonomy-controls';
 import StickyControl from './sticky-control';
+import EnhancedPaginationControl from './enhanced-pagination-control';
 import CreateNewPostLink from './create-new-post-link';
 import { unlock } from '../../../lock-unlock';
 import {
@@ -124,18 +124,6 @@ export default function QueryInspectorControls( props ) {
 		isControlAllowed( allowedControls, 'parents' ) &&
 		isPostTypeHierarchical;
 
-	const enhancedPaginationNotice = __(
-		'Enhanced Pagination might cause interactive blocks within the Post Template to stop working. Disable it if you experience any issues.'
-	);
-
-	const isFirstRender = useRef( true ); // Don't speak on first render.
-	useEffect( () => {
-		if ( ! isFirstRender.current && enhancedPagination ) {
-			speak( enhancedPaginationNotice );
-		}
-		isFirstRender.current = false;
-	}, [ enhancedPagination, enhancedPaginationNotice ] );
-
 	const showFiltersPanel =
 		showTaxControl ||
 		showAuthorControl ||
@@ -215,29 +203,10 @@ export default function QueryInspectorControls( props ) {
 								}
 							/>
 						) }
-						<ToggleControl
-							label={ __( 'Enhanced pagination' ) }
-							help={ __(
-								'Browsing between pages won’t require a full page reload.'
-							) }
-							checked={ !! enhancedPagination }
-							onChange={ ( value ) =>
-								setAttributes( {
-									enhancedPagination: !! value,
-								} )
-							}
+						<EnhancedPaginationControl
+							enhancedPagination={ enhancedPagination }
+							setAttributes={ setAttributes }
 						/>
-						{ enhancedPagination && (
-							<div>
-								<Notice
-									spokenMessage={ null }
-									status="warning"
-									isDismissible={ false }
-								>
-									{ enhancedPaginationNotice }
-								</Notice>
-							</div>
-						) }
 					</PanelBody>
 				</InspectorControls>
 			) }

--- a/packages/block-library/src/query/edit/query-content.js
+++ b/packages/block-library/src/query/edit/query-content.js
@@ -110,6 +110,7 @@ export default function QueryContent( {
 				setQuery={ updateQuery }
 				setDisplayLayout={ updateDisplayLayout }
 				setAttributes={ setAttributes }
+				clientId={ clientId }
 			/>
 			<BlockControls>
 				<QueryToolbar

--- a/packages/block-library/src/query/edit/query-content.js
+++ b/packages/block-library/src/query/edit/query-content.js
@@ -20,6 +20,7 @@ import { store as coreStore } from '@wordpress/core-data';
  */
 import QueryToolbar from './query-toolbar';
 import QueryInspectorControls from './inspector-controls';
+import EnhancedPaginationModal from './enhanced-pagination-modal';
 
 const DEFAULTS_POSTS_PER_PAGE = 3;
 
@@ -103,8 +104,14 @@ export default function QueryContent( {
 			"The <aside> element should represent a portion of a document whose content is only indirectly related to the document's main content."
 		),
 	};
+
 	return (
 		<>
+			<EnhancedPaginationModal
+				attributes={ attributes }
+				setAttributes={ setAttributes }
+				clientId={ clientId }
+			/>
 			<QueryInspectorControls
 				attributes={ attributes }
 				setQuery={ updateQuery }

--- a/packages/block-library/src/query/editor.scss
+++ b/packages/block-library/src/query/editor.scss
@@ -52,3 +52,9 @@
 		margin-bottom: $grid-unit-30;
 	}
 }
+
+.wp-block-query-enhanced-pagination-modal {
+	@include break-small() {
+		max-width: $break-mobile;
+	}
+}

--- a/packages/block-library/src/query/utils.js
+++ b/packages/block-library/src/query/utils.js
@@ -344,3 +344,25 @@ export const usePatterns = ( clientId, name ) => {
 		[ name, clientId ]
 	);
 };
+
+/**
+ * Hook that returns whether the Query Loop with the given `clientId` contains
+ * third-party blocks inside its Post Template block.
+ *
+ * @param {string} clientId The block's client ID.
+ * @return {boolean} True if it contains third-party blocks.
+ */
+export const useContainsThirdPartyBlocks = ( clientId ) =>
+	useSelect( ( select ) => {
+		const { getClientIdsOfDescendants, getBlockName, getBlocks } =
+			select( blockEditorStore );
+
+		const postTemplate = getBlocks( clientId ).find(
+			( innerBlock ) => innerBlock.name === 'core/post-template'
+		);
+
+		return getClientIdsOfDescendants( [ postTemplate.clientId ] ).some(
+			( descendantClientId ) =>
+				! getBlockName( descendantClientId ).startsWith( 'core/' )
+		);
+	} );

--- a/packages/block-library/src/query/utils.js
+++ b/packages/block-library/src/query/utils.js
@@ -347,21 +347,17 @@ export const usePatterns = ( clientId, name ) => {
 
 /**
  * Hook that returns whether the Query Loop with the given `clientId` contains
- * third-party blocks inside its Post Template block.
+ * any third-party block.
  *
  * @param {string} clientId The block's client ID.
  * @return {boolean} True if it contains third-party blocks.
  */
 export const useContainsThirdPartyBlocks = ( clientId ) =>
 	useSelect( ( select ) => {
-		const { getClientIdsOfDescendants, getBlockName, getBlocks } =
+		const { getClientIdsOfDescendants, getBlockName } =
 			select( blockEditorStore );
 
-		const postTemplate = getBlocks( clientId ).find(
-			( innerBlock ) => innerBlock.name === 'core/post-template'
-		);
-
-		return getClientIdsOfDescendants( [ postTemplate.clientId ] ).some(
+		return getClientIdsOfDescendants( [ clientId ] ).some(
 			( descendantClientId ) =>
 				! getBlockName( descendantClientId ).startsWith( 'core/' )
 		);


### PR DESCRIPTION
## What?

Prevents enabling enhanced pagination in a Query Loop containing any third-party block. This ensures block compatibility.

The block follows this logic:

1. If the setting is disabled, third-party blocks can be added as usual.
2. If the setting is disabled and third-party blocks are found in the Query Loop, the setting can't be enabled.
3. If the setting is enabled and you add third-party blocks, a Modal indicates that the enhanced pagination will be disabled.

Tracking issue: https://github.com/WordPress/gutenberg/issues/54291

## Why?

Third-party blocks can be interactive and use a different library than the Interactivity API. This could lead to problems as the
Interactivity API can add, modify, or remove DOM nodes handled by third-party libraries, thus making the blocks that depend on those libraries stop working.

## How?

I haven't found an easy way to prevent certain blocks from being inserted inside another **at any level**, so I wrote a hook to detect what kind of blocks are contained. If a third-party block is found, and the setting is enabled, a modal appears, requiring action to keep a valid state.

## Testing Instructions

The feature is not stable yet, although the UX can be tested:

1. Go to the Blog Home template.
2. Activate "enhanced pagination" in the Query Loop block.
3. Install any third-party block,
5. Insert the block inside the Query Loop, at any position.
6. Ensure a modal appears, indicating that the "enhanced pagination" will be disabled.
10. Click on "OK, understood".
11. Ensure the setting is disabled and the new block is kept.
12. Try to enable the setting―it shouldn't be possible.
13. Remove the block manually and try again.
14. Ensure the setting can be enabled this time.

### Testing Instructions for Keyboard
TBD

## Screenshots or screencast

https://github.com/WordPress/gutenberg/assets/6917969/fadd5e0c-dc4a-466f-93db-722985ea34f2

