### PR TITLE
Fix: Remove unrequired code from BorderControl documentation.

### DIFF
--- a/packages/components/src/border-control/border-control/README.md
+++ b/packages/components/src/border-control/border-control/README.md
@@ -31,13 +31,12 @@ const colors = [
 
 const MyBorderControl = () => {
 	const [ border, setBorder ] = useState();
-	const onChange = ( newBorder ) => setBorder( newBorder );
 
 	return (
 		<BorderControl
 			colors={ colors }
 			label={ __( 'Border' ) }
-			onChange={ onChange }
+			onChange={ setBorder }
 			value={ border }
 		/>
 	);


### PR DESCRIPTION
Follow up to https://github.com/WordPress/gutenberg/pull/49476.

Addresses a comment from @talldan and removes unrequited code making the example simpler.
