### PR TITLE
Blocks: Fix incorrect placement for hooked blocks in the parent container

### DIFF
--- a/lib/compat/wordpress-6.4/block-hooks.php
+++ b/lib/compat/wordpress-6.4/block-hooks.php
@@ -158,14 +158,24 @@ function gutenberg_insert_hooked_block( $inserted_block, $relative_position, $an
 				array_unshift( $block['innerBlocks'], $inserted_block );
 				// Since WP_Block::render() iterates over `inner_content` (rather than `inner_blocks`)
 				// when rendering blocks, we also need to prepend a value (`null`, to mark a block
-				// location) to that array.
-				array_unshift( $block['innerContent'], null );
+				// location) to that array after HTML content for the inner blocks wrapper.
+				for ( $chunk_index = 0; $chunk_index < count( $block['innerContent'] ); $chunk_index++ ) {
+					if ( is_null( $block['innerContent'][ $chunk_index ] ) ) {
+						break;
+					}
+				}
+				array_splice( $block['innerContent'], $chunk_index, 0, array( null ) );
 			} elseif ( 'last_child' === $relative_position ) {
 				array_push( $block['innerBlocks'], $inserted_block );
 				// Since WP_Block::render() iterates over `inner_content` (rather than `inner_blocks`)
-				// when rendering blocks, we also need to prepend a value (`null`, to mark a block
-				// location) to that array.
-				array_push( $block['innerContent'], null );
+				// when rendering blocks, we also need to correctly prepend a value (`null`, to mark a block
+				// location) to that array after HTML content for the inner blocks wrapper.
+				for ( $chunk_index = count( $block['innerContent'] ) - 1; $chunk_index >= 0; $chunk_index-- ) {
+					if ( is_null( $block['innerContent'][ $chunk_index ] ) ) {
+						break;
+					}
+				}
+				array_splice( $block['innerContent'], $chunk_index, 0, array( null ) );
 			}
 			return $block;
 		}

--- a/lib/compat/wordpress-6.4/block-hooks.php
+++ b/lib/compat/wordpress-6.4/block-hooks.php
@@ -159,8 +159,10 @@ function gutenberg_insert_hooked_block( $inserted_block, $relative_position, $an
 				// Since WP_Block::render() iterates over `inner_content` (rather than `inner_blocks`)
 				// when rendering blocks, we also need to prepend a value (`null`, to mark a block
 				// location) to that array after HTML content for the inner blocks wrapper.
-				for ( $chunk_index = 0; $chunk_index < count( $block['innerContent'] ); $chunk_index++ ) {
-					if ( is_null( $block['innerContent'][ $chunk_index ] ) ) {
+				$chunk_index = 0;
+				for ( $index = $chunk_index; $index < count( $block['innerContent'] ); $index++ ) {
+					if ( is_null( $block['innerContent'][ $index ] ) ) {
+						$chunk_index = $index;
 						break;
 					}
 				}
@@ -170,8 +172,10 @@ function gutenberg_insert_hooked_block( $inserted_block, $relative_position, $an
 				// Since WP_Block::render() iterates over `inner_content` (rather than `inner_blocks`)
 				// when rendering blocks, we also need to correctly prepend a value (`null`, to mark a block
 				// location) to that array after HTML content for the inner blocks wrapper.
-				for ( $chunk_index = count( $block['innerContent'] ) - 1; $chunk_index >= 0; $chunk_index-- ) {
-					if ( is_null( $block['innerContent'][ $chunk_index ] ) ) {
+				$chunk_index = count( $block['innerContent'] ) - 1;
+				for ( $index = $chunk_index; $index >= 0; $index-- ) {
+					if ( is_null( $block['innerContent'][ $index ] ) ) {
+						$chunk_index = $index;
 						break;
 					}
 				}

--- a/lib/compat/wordpress-6.4/block-hooks.php
+++ b/lib/compat/wordpress-6.4/block-hooks.php
@@ -172,8 +172,8 @@ function gutenberg_insert_hooked_block( $inserted_block, $relative_position, $an
 				// Since WP_Block::render() iterates over `inner_content` (rather than `inner_blocks`)
 				// when rendering blocks, we also need to correctly append a value (`null`, to mark a block
 				// location) to that array before the remaining HTML content for the inner blocks wrapper.
-				$chunk_index = count( $block['innerContent'] ) - 1;
-				for ( $index = $chunk_index; $index >= 0; $index-- ) {
+				$chunk_index = 0;
+				for ( $index = count( $block['innerContent'] ) - 1; $index >= 0; $index-- ) {
 					if ( is_null( $block['innerContent'][ $index ] ) ) {
 						$chunk_index = $index;
 						break;

--- a/lib/compat/wordpress-6.4/block-hooks.php
+++ b/lib/compat/wordpress-6.4/block-hooks.php
@@ -170,8 +170,8 @@ function gutenberg_insert_hooked_block( $inserted_block, $relative_position, $an
 			} elseif ( 'last_child' === $relative_position ) {
 				array_push( $block['innerBlocks'], $inserted_block );
 				// Since WP_Block::render() iterates over `inner_content` (rather than `inner_blocks`)
-				// when rendering blocks, we also need to correctly prepend a value (`null`, to mark a block
-				// location) to that array after HTML content for the inner blocks wrapper.
+				// when rendering blocks, we also need to correctly append a value (`null`, to mark a block
+				// location) to that array before the remaining HTML content for the inner blocks wrapper.
 				$chunk_index = count( $block['innerContent'] ) - 1;
 				for ( $index = $chunk_index; $index >= 0; $index-- ) {
 					if ( is_null( $block['innerContent'][ $index ] ) ) {

--- a/lib/compat/wordpress-6.4/block-hooks.php
+++ b/lib/compat/wordpress-6.4/block-hooks.php
@@ -172,9 +172,9 @@ function gutenberg_insert_hooked_block( $inserted_block, $relative_position, $an
 				// Since WP_Block::render() iterates over `inner_content` (rather than `inner_blocks`)
 				// when rendering blocks, we also need to correctly append a value (`null`, to mark a block
 				// location) to that array before the remaining HTML content for the inner blocks wrapper.
-				$chunk_index = 0;
-				for ( $index = count( $block['innerContent'] ) - 1; $index >= 0; $index-- ) {
-					if ( is_null( $block['innerContent'][ $index ] ) ) {
+				$chunk_index = count( $block['innerContent'] );
+				for ( $index = count( $block['innerContent'] ); $index > 0; $index-- ) {
+					if ( is_null( $block['innerContent'][ $index - 1 ] ) ) {
 						$chunk_index = $index;
 						break;
 					}

--- a/phpunit/bootstrap.php
+++ b/phpunit/bootstrap.php
@@ -66,6 +66,9 @@ define( 'GUTENBERG_LOAD_VENDOR_SCRIPTS', false );
  */
 function _manually_load_plugin() {
 	require dirname( __DIR__ ) . '/lib/load.php';
+	// Temporary fix to ensure that necessary functions are defined.
+	require dirname( __DIR__ ) . '/lib/experimental/block-hooks.php';
+
 }
 tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );
 

--- a/phpunit/bootstrap.php
+++ b/phpunit/bootstrap.php
@@ -66,9 +66,6 @@ define( 'GUTENBERG_LOAD_VENDOR_SCRIPTS', false );
  */
 function _manually_load_plugin() {
 	require dirname( __DIR__ ) . '/lib/load.php';
-	// Temporary fix to ensure that necessary functions are defined.
-	require dirname( __DIR__ ) . '/lib/experimental/block-hooks.php';
-
 }
 tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );
 

--- a/phpunit/fixtures/hooked-block/block.json
+++ b/phpunit/fixtures/hooked-block/block.json
@@ -1,0 +1,7 @@
+{
+	"name": "tests/hooked-block",
+	"__experimentalBlockHooks": {
+		"tests/group-first-child": "firstChild",
+		"tests/group-last-child": "lastChild"
+	}
+}

--- a/phpunit/fixtures/hooked-block/block.json
+++ b/phpunit/fixtures/hooked-block/block.json
@@ -1,6 +1,6 @@
 {
 	"name": "tests/hooked-block",
-	"__experimentalBlockHooks": {
+	"blockHooks": {
 		"tests/group-first-child": "firstChild",
 		"tests/group-last-child": "lastChild"
 	}

--- a/phpunit/tests/blocks/renderHookedBlocks.php
+++ b/phpunit/tests/blocks/renderHookedBlocks.php
@@ -1,0 +1,78 @@
+<?php
+
+use PHP_CodeSniffer\Generators\HTML;
+
+/**
+ * Tests for hooked blocks rendering.
+ *
+ * @package WordPress
+ * @subpackage Blocks
+ * @since 6.4.0
+ *
+ * @group blocks
+ */
+class Tests_Blocks_RenderHookedBlocks extends WP_UnitTestCase {
+	/**
+	 * @ticket 59313
+	 */
+	public function test_inject_hooked_block_at_first_child_position() {
+		$content = <<<HTML
+<!-- wp:tests/group-first-child {"layout":{"type":"constrained"}} -->
+	<div class="wp-block-group">
+		<!-- wp:paragraph -->
+			<p>Foo</p>
+		<!-- /wp:paragraph -->
+	</div>
+<!-- /wp:tests/group-first-child -->
+HTML;
+
+		$block_type = register_block_type( GUTENBERG_DIR_TESTFIXTURES . '/hooked-block/' );
+		$blocks     = parse_blocks( $content );
+		$result     = gutenberg_serialize_blocks( $blocks );
+
+		unregister_block_type( $block_type->name );
+
+		$expected_result = <<<HTML
+<!-- wp:tests/group-first-child {"layout":{"type":"constrained"}} -->
+	<div class="wp-block-group">
+		<!-- wp:tests/hooked-block /--><!-- wp:paragraph -->
+			<p>Foo</p>
+		<!-- /wp:paragraph -->
+	</div>
+<!-- /wp:tests/group-first-child -->
+HTML;
+		$this->assertSame( $expected_result, $result );
+	}
+
+	/**
+	 * @ticket 59313
+	 */
+	public function test_inject_hooked_block_at_last_child_position() {
+		$content = <<<HTML
+<!-- wp:tests/group-last-child {"layout":{"type":"constrained"}} -->
+	<div class="wp-block-group">
+		<!-- wp:paragraph -->
+			<p>Foo</p>
+		<!-- /wp:paragraph -->
+	</div>
+<!-- /wp:tests/group-last-child -->
+HTML;
+
+		$block_type = register_block_type( GUTENBERG_DIR_TESTFIXTURES . '/hooked-block/' );
+		$blocks     = parse_blocks( $content );
+		$result     = gutenberg_serialize_blocks( $blocks );
+
+		unregister_block_type( $block_type->name );
+
+		$expected_result = <<<HTML
+<!-- wp:tests/group-last-child {"layout":{"type":"constrained"}} -->
+	<div class="wp-block-group">
+		<!-- wp:paragraph -->
+			<p>Foo</p>
+		<!-- /wp:paragraph --><!-- wp:tests/hooked-block /-->
+	</div>
+<!-- /wp:tests/group-last-child -->
+HTML;
+		$this->assertSame( $expected_result, $result );
+	}
+}

--- a/phpunit/tests/blocks/renderHookedBlocks.php
+++ b/phpunit/tests/blocks/renderHookedBlocks.php
@@ -47,8 +47,8 @@ HTML;
 	/**
 	 * @ticket 59313
 	 */
-	public function test_inject_hooked_block_at_first_child_position_no_child_blocks() {
-		$content = '<!-- wp:tests/group-first-child {"layout":{"type":"constrained"}} /-->';
+	public function test_inject_hooked_block_at_first_child_position_no_inner_content() {
+		$content = '<!-- wp:tests/group-first-child /-->';
 
 		$block_type = register_block_type( GUTENBERG_DIR_TESTFIXTURES . '/hooked-block/' );
 		$blocks     = parse_blocks( $content );
@@ -56,7 +56,32 @@ HTML;
 
 		unregister_block_type( $block_type->name );
 
-		$expected_result = '<!-- wp:tests/group-first-child {"layout":{"type":"constrained"}} --><!-- wp:tests/hooked-block /--><!-- /wp:tests/group-first-child -->';
+		$expected_result = '<!-- wp:tests/group-first-child --><!-- wp:tests/hooked-block /--><!-- /wp:tests/group-first-child -->';
+		$this->assertSame( $expected_result, $result );
+	}
+
+	/**
+	 * @ticket 59313
+	 */
+	public function test_inject_hooked_block_at_first_child_position_no_child_blocks() {
+		$content = <<<HTML
+<!-- wp:tests/group-first-child -->
+	<div class="wp-block-group"></div>
+<!-- /wp:tests/group-first-child -->
+HTML;
+
+		$block_type = register_block_type( GUTENBERG_DIR_TESTFIXTURES . '/hooked-block/' );
+		$blocks     = parse_blocks( $content );
+		$result     = gutenberg_serialize_blocks( $blocks );
+
+		unregister_block_type( $block_type->name );
+
+		// @todo In the perfect world, the hooked block would be injected inside the `div` tag.
+		$expected_result = <<<HTML
+<!-- wp:tests/group-first-child --><!-- wp:tests/hooked-block /-->
+	<div class="wp-block-group"></div>
+<!-- /wp:tests/group-first-child -->
+HTML;
 		$this->assertSame( $expected_result, $result );
 	}
 
@@ -95,8 +120,8 @@ HTML;
 	/**
 	 * @ticket 59313
 	 */
-	public function test_inject_hooked_block_at_last_child_position_no_child_blocks() {
-		$content = '<!-- wp:tests/group-last-child {"layout":{"type":"constrained"}} /-->';
+	public function test_inject_hooked_block_at_last_child_position_no_inner_content() {
+		$content = '<!-- wp:tests/group-last-child /-->';
 
 		$block_type = register_block_type( GUTENBERG_DIR_TESTFIXTURES . '/hooked-block/' );
 		$blocks     = parse_blocks( $content );
@@ -104,7 +129,32 @@ HTML;
 
 		unregister_block_type( $block_type->name );
 
-		$expected_result = '<!-- wp:tests/group-last-child {"layout":{"type":"constrained"}} --><!-- wp:tests/hooked-block /--><!-- /wp:tests/group-last-child -->';
+		$expected_result = '<!-- wp:tests/group-last-child --><!-- wp:tests/hooked-block /--><!-- /wp:tests/group-last-child -->';
+		$this->assertSame( $expected_result, $result );
+	}
+
+	/**
+	 * @ticket 59313
+	 */
+	public function test_inject_hooked_block_at_last_child_position_no_child_blocks() {
+		$content = <<<HTML
+<!-- wp:tests/group-last-child -->
+	<div class="wp-block-group"></div>
+<!-- /wp:tests/group-last-child -->
+HTML;
+
+		$block_type = register_block_type( GUTENBERG_DIR_TESTFIXTURES . '/hooked-block/' );
+		$blocks     = parse_blocks( $content );
+		$result     = gutenberg_serialize_blocks( $blocks );
+
+		unregister_block_type( $block_type->name );
+
+		// @todo In the perfect world, the hooked block would be injected inside the `div` tag.
+		$expected_result = <<<HTML
+<!-- wp:tests/group-last-child -->
+	<div class="wp-block-group"></div>
+<!-- wp:tests/hooked-block /--><!-- /wp:tests/group-last-child -->
+HTML;
 		$this->assertSame( $expected_result, $result );
 	}
 }

--- a/phpunit/tests/blocks/renderHookedBlocks.php
+++ b/phpunit/tests/blocks/renderHookedBlocks.php
@@ -47,6 +47,22 @@ HTML;
 	/**
 	 * @ticket 59313
 	 */
+	public function test_inject_hooked_block_at_first_child_position_no_child_blocks() {
+		$content = '<!-- wp:tests/group-first-child {"layout":{"type":"constrained"}} /-->';
+
+		$block_type = register_block_type( GUTENBERG_DIR_TESTFIXTURES . '/hooked-block/' );
+		$blocks     = parse_blocks( $content );
+		$result     = gutenberg_serialize_blocks( $blocks );
+
+		unregister_block_type( $block_type->name );
+
+		$expected_result = '<!-- wp:tests/group-first-child {"layout":{"type":"constrained"}} --><!-- wp:tests/hooked-block /--><!-- /wp:tests/group-first-child -->';
+		$this->assertSame( $expected_result, $result );
+	}
+
+	/**
+	 * @ticket 59313
+	 */
 	public function test_inject_hooked_block_at_last_child_position() {
 		$content = <<<HTML
 <!-- wp:tests/group-last-child {"layout":{"type":"constrained"}} -->
@@ -73,6 +89,22 @@ HTML;
 	</div>
 <!-- /wp:tests/group-last-child -->
 HTML;
+		$this->assertSame( $expected_result, $result );
+	}
+
+	/**
+	 * @ticket 59313
+	 */
+	public function test_inject_hooked_block_at_last_child_position_no_child_blocks() {
+		$content = '<!-- wp:tests/group-last-child {"layout":{"type":"constrained"}} /-->';
+
+		$block_type = register_block_type( GUTENBERG_DIR_TESTFIXTURES . '/hooked-block/' );
+		$blocks     = parse_blocks( $content );
+		$result     = gutenberg_serialize_blocks( $blocks );
+
+		unregister_block_type( $block_type->name );
+
+		$expected_result = '<!-- wp:tests/group-last-child {"layout":{"type":"constrained"}} --><!-- wp:tests/hooked-block /--><!-- /wp:tests/group-last-child -->';
 		$this->assertSame( $expected_result, $result );
 	}
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes #54307.

Every block that has inner blocks also has some wrapping HTML element. The way hooked blocks are currently implemented is that it puts the injected block at exactly first (`firstChild`) or last place (`lastChild`) in the parsed block, which happens to be outside the wrapping element. A simplified example based on REST API response that shows the issue:

```html
<!-- wp:group {"tagName":"main","style":{"spacing":{"margin":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|70"}}},"layout":{"type":"constrained"}} -->
    <main class="wp-block-group" style="margin-top:var(--wp--preset--spacing--50);margin-bottom:var(--wp--preset--spacing--70)">
        <!-- wp:pattern {"slug":"twentytwentythree/cta"} /-->
    </main>
    <!-- wp:ockham/like-button /-->
<!-- /wp:group /-->
```

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The injected block is misplaced and therefore incorrectly styled on the front end. It should be with the `main` tag instead in the example provided:

```html
<!-- wp:group {"tagName":"main","style":{"spacing":{"margin":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|70"}}},"layout":{"type":"constrained"}} -->
    <main class="wp-block-group" style="margin-top:var(--wp--preset--spacing--50);margin-bottom:var(--wp--preset--spacing--70)">
        <!-- wp:pattern {"slug":"twentytwentythree/cta"} /-->
        <!-- wp:ockham/like-button /-->
    </main>
<!-- /wp:group /-->
```

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Instead of injecting the hooked block as the first item (`firstChild`) or the last item (`lastChild`), there is no logic that tries to locate the exact place where the child block is marked with `null` in the array containing `innerContent` of the block. Once the first `null` value is found, then another `null` value is placed next to it. In the case, when there is no child block (no `null` value), then the `null` marker is added as the first item (`firstChild`) or the last item (`lastItem`) in the array.

Note: the handling for the case with no inner blocks but the existing HTML wrapper for inner blocks isn't handled perfectly. We can discuss options for improving that separately.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Install and activate the plugin with the hooked block. Example block can be downloaded from https://github.com/ockham/like-button/releases/tag/v0.4.1.
2. Activate Twenty Twenty-Three theme or any other theme that uses `core/comment-template` block.
3. Go to the single post page and see where the Like Button gets injected. Ensure that all templates and template parts used on that page don't have any customizations applied.
4. Check the source of the page and notice that the Like button is placed correctly before the closing tag for the comment row wrapper.

There is now a test coverage presenting how hooked blocks get injected depending on the state of the container block:
- inner blocks present
- no inner blocks present
- no inner blocks and inner content present

## Screenshots or screencast <!-- if applicable -->

<img width="1248" alt="Screenshot 2023-09-11 at 11 56 31" src="https://github.com/WordPress/gutenberg/assets/699132/88c27c8e-bf19-463b-8077-216e91e174b3">

<img width="976" alt="Screenshot 2023-09-11 at 13 22 39" src="https://github.com/WordPress/gutenberg/assets/699132/69a2b100-005f-43bf-9184-491292b6f591">

