### PR TITLE
Fix #54352 prevent php 8.1 fatal when template parts are not found in non-debug environments

### DIFF
--- a/packages/block-library/src/template-part/index.php
+++ b/packages/block-library/src/template-part/index.php
@@ -109,16 +109,20 @@ function render_block_core_template_part( $attributes ) {
 	// is set in `wp_debug_mode()`.
 	$is_debug = WP_DEBUG && WP_DEBUG_DISPLAY;
 
-	if ( is_null( $content ) && $is_debug ) {
-		if ( ! isset( $attributes['slug'] ) ) {
-			// If there is no slug this is a placeholder and we dont want to return any message.
-			return;
+	if ( is_null( $content ) ) {
+		if ( $is_debug ) {
+			if ( ! isset( $attributes['slug'] ) ) {
+				// If there is no slug this is a placeholder and we dont want to return any message.
+				return '';
+			}
+			return sprintf(
+				/* translators: %s: Template part slug. */
+				__( 'Template part has been deleted or is unavailable: %s' ),
+				$attributes['slug']
+			);
 		}
-		return sprintf(
-			/* translators: %s: Template part slug. */
-			__( 'Template part has been deleted or is unavailable: %s' ),
-			$attributes['slug']
-		);
+
+		return '';
 	}
 
 	if ( isset( $seen_ids[ $template_part_id ] ) ) {

--- a/packages/block-library/src/template-part/index.php
+++ b/packages/block-library/src/template-part/index.php
@@ -112,7 +112,7 @@ function render_block_core_template_part( $attributes ) {
 	if ( is_null( $content ) ) {
 		if ( $is_debug ) {
 			if ( ! isset( $attributes['slug'] ) ) {
-				// If there is no slug this is a placeholder and we dont want to return any message.
+				// If there is no slug, this acts as a placeholder and no message should be returned.
 				return '';
 			}
 			return sprintf(

--- a/packages/block-library/src/template-part/index.php
+++ b/packages/block-library/src/template-part/index.php
@@ -110,11 +110,7 @@ function render_block_core_template_part( $attributes ) {
 	$is_debug = WP_DEBUG && WP_DEBUG_DISPLAY;
 
 	if ( is_null( $content ) ) {
-		if ( $is_debug ) {
-			if ( ! isset( $attributes['slug'] ) ) {
-				// If there is no slug, this acts as a placeholder and no message should be returned.
-				return '';
-			}
+		if ( $is_debug && isset( $attributes['slug'] ) ) {
 			return sprintf(
 				/* translators: %s: Template part slug. */
 				__( 'Template part has been deleted or is unavailable: %s' ),


### PR DESCRIPTION
## What?

If the template part is not found content will be null which will cause fatal errors in PHP 8.1 when passed to shortcode_unautop, but this case is already handled if debug mode is turned on. This changeset allows it to be handled in all environments, not just when the admin has turned on WP_DEBUG and display debug messages.

Closes https://github.com/WordPress/gutenberg/issues/54352

## Why?

Because it's fixing a fatal error on PHP 8.1+

## How?

This change separates the debug part into a sub-condition so that it can return `''` if we are not in debugging mode.

## Testing Instructions

 - Create a template with a template part
 - Go into the code editor and change the slug to something that does not exist on that site
 - ensure you are using PHP 8.1+
 - ensure that WP_DEBUG is false, it is essential that the `$debug` in the code has the value of `false` not `true`
 - visit a page with that template on the frontend
 - you should see that the page loads with this change, but crashes without it with a deprecation fatal error
