### PR TITLE
Extract WordPress specific styles from the BlockTools component

### DIFF
--- a/packages/block-editor/src/components/block-tools/style.scss
+++ b/packages/block-editor/src/components/block-tools/style.scss
@@ -89,9 +89,6 @@
  * Block Toolbar when contextual.
  */
 
-// Base left position for the toolbar when fixed.
-@include editor-left(".block-editor-block-contextual-toolbar.is-fixed");
-
 .block-editor-block-contextual-toolbar {
 	// Block UI appearance.
 	display: inline-flex;
@@ -105,11 +102,6 @@
 	}
 
 	&.is-fixed {
-		position: sticky;
-		top: 0;
-		z-index: z-index(".block-editor-block-popover");
-		display: block;
-		width: 100%;
 		overflow: hidden;
 
 		.block-editor-block-toolbar {
@@ -137,51 +129,8 @@
 		background: linear-gradient(to right, $white, transparent);
 	}
 
-	// on desktop and tablet viewports the toolbar is fixed
-	// on top of interface header
-	$toolbar-margin: $grid-unit-80 * 3 - 2 * $grid-unit + $grid-unit-05;
 	@include break-medium() {
 		&.is-fixed {
-			// leave room for block inserter, undo and redo, list view
-			margin-left: $toolbar-margin;
-			// position on top of interface header
-			position: fixed;
-			top: $admin-bar-height;
-			// Don't fill up when empty
-			min-height: initial;
-			// remove the border
-			border-bottom: none;
-			// has to be flex for collapse button to fit
-			display: flex;
-
-			// Mimic the height of the parent, vertically align center, and provide a max-height.
-			height: $header-height;
-			align-items: center;
-
-			&.is-collapsed {
-				width: initial;
-			}
-
-			&:empty {
-				width: initial;
-			}
-
-			.is-fullscreen-mode & {
-				// leave room for block inserter, undo and redo, list view
-				// and some margin left
-				margin-left: $grid-unit-80 * 4 - 2 * $grid-unit;
-
-				top: 0;
-
-				&.is-collapsed {
-					width: initial;
-				}
-
-				&:empty {
-					width: initial;
-				}
-			}
-
 			& > .block-editor-block-toolbar {
 				flex-grow: initial;
 				width: initial;
@@ -264,13 +213,6 @@
 			}
 
 			.show-icon-labels & {
-
-				margin-left: $grid-unit-80 + 2 * $grid-unit; // inserter and margin
-
-				.is-fullscreen-mode & {
-					margin-left: $grid-unit * 18; // site hub, inserter and margin
-				}
-
 				.block-editor-block-parent-selector .block-editor-block-parent-selector__button::after {
 					left: 0;
 				}
@@ -285,14 +227,6 @@
 						background-color: $gray-300;
 						position: relative;
 					}
-				}
-			}
-
-			.blocks-widgets-container & {
-				margin-left: $grid-unit-80 * 2.4;
-
-				&.is-collapsed {
-					margin-left: $grid-unit-80 * 4.2;
 				}
 			}
 		}
@@ -330,38 +264,6 @@
 				margin-left: -$border-width;
 				margin-bottom: -$border-width;
 			}
-		}
-	}
-
-	// on tablet viewports the toolbar is fixed
-	// on top of interface header and covers the whole header
-	// except for the inserter on the left
-	@include break-medium() {
-		&.is-fixed {
-			width: calc(100% - #{$toolbar-margin});
-
-			.show-icon-labels & {
-				width: calc(100% + 40px - #{$toolbar-margin}); //there are no undo, redo and list view buttons
-			}
-
-		}
-	}
-
-	// on desktop viewports the toolbar is fixed
-	// on top of interface header and leaves room
-	// for the block inserter the publish button
-	@include break-large() {
-		&.is-fixed {
-			width: auto;
-			.show-icon-labels & {
-				width: auto; //there are no undo, redo and list view buttons
-			}
-		}
-		.is-fullscreen-mode &.is-fixed {
-			// in full screen mode we need to account for
-			// the combined with of the tools at the right of the header and the margin left
-			// of the toolbar which includes four buttons
-			width: calc(100% - 280px - #{4 * $grid-unit-80});
 		}
 	}
 }

--- a/packages/edit-post/src/components/visual-editor/style.scss
+++ b/packages/edit-post/src/components/visual-editor/style.scss
@@ -67,3 +67,92 @@
 	// See also https://www.w3.org/TR/CSS22/visudet.html#the-height-property
 	flex-grow: 1;
 }
+
+// Fixed contextual toolbar
+@include editor-left(".edit-post-visual-editor .block-editor-block-contextual-toolbar.is-fixed");
+
+.edit-post-visual-editor .block-editor-block-contextual-toolbar.is-fixed {
+	position: sticky;
+	top: 0;
+	z-index: z-index(".block-editor-block-popover");
+	display: block;
+	width: 100%;
+
+	// on desktop and tablet viewports the toolbar is fixed
+	// on top of interface header
+	$toolbar-margin: $grid-unit-80 * 3 - 2 * $grid-unit + $grid-unit-05;
+
+	@include break-medium() {
+		// leave room for block inserter, undo and redo, list view
+		margin-left: $toolbar-margin;
+		// position on top of interface header
+		position: fixed;
+		top: $admin-bar-height;
+		// Don't fill up when empty
+		min-height: initial;
+		// remove the border
+		border-bottom: none;
+		// has to be flex for collapse button to fit
+		display: flex;
+
+		// Mimic the height of the parent, vertically align center, and provide a max-height.
+		height: $header-height;
+		align-items: center;
+
+
+		// on tablet viewports the toolbar is fixed
+		// on top of interface header and covers the whole header
+		// except for the inserter on the left
+		width: calc(100% - #{$toolbar-margin});
+
+		&.is-collapsed {
+			width: initial;
+		}
+
+		&:empty {
+			width: initial;
+		}
+
+		.is-fullscreen-mode & {
+			// leave room for block inserter, undo and redo, list view
+			// and some margin left
+			margin-left: $grid-unit-80 * 4 - 2 * $grid-unit;
+
+			top: 0;
+
+			&.is-collapsed {
+				width: initial;
+			}
+
+			&:empty {
+				width: initial;
+			}
+		}
+
+		.show-icon-labels & {
+			width: calc(100% + 40px - #{$toolbar-margin}); //there are no undo, redo and list view buttons
+			margin-left: $grid-unit-80 + 2 * $grid-unit; // inserter and margin
+
+			.is-fullscreen-mode & {
+				margin-left: $grid-unit * 18; // site hub, inserter and margin
+			}
+		}
+	}
+
+	// on desktop viewports the toolbar is fixed
+	// on top of interface header and leaves room
+	// for the block inserter the publish button
+	@include break-large() {
+		width: auto;
+		.show-icon-labels & {
+			width: auto; //there are no undo, redo and list view buttons
+		}
+
+		.is-fullscreen-mode & {
+			// in full screen mode we need to account for
+			// the combined with of the tools at the right of the header and the margin left
+			// of the toolbar which includes four buttons
+			width: calc(100% - 280px - #{4 * $grid-unit-80});
+		}
+	}
+}

--- a/packages/edit-site/src/components/block-editor/style.scss
+++ b/packages/edit-site/src/components/block-editor/style.scss
@@ -172,3 +172,89 @@
 	}
 }
 
+// Fixed contextual toolbar
+@include editor-left(".edit-site-visual-editor .block-editor-block-contextual-toolbar.is-fixed");
+
+.edit-site-visual-editor .block-editor-block-contextual-toolbar.is-fixed {
+	position: sticky;
+	top: 0;
+	z-index: z-index(".block-editor-block-popover");
+	display: block;
+	width: 100%;
+
+	// on desktop and tablet viewports the toolbar is fixed
+	// on top of interface header
+	$toolbar-margin: $grid-unit-80 * 3 - 2 * $grid-unit + $grid-unit-05;
+
+	@include break-medium() {
+		// leave room for block inserter, undo and redo, list view
+		margin-left: $toolbar-margin;
+		// position on top of interface header
+		position: fixed;
+		top: $admin-bar-height;
+		// Don't fill up when empty
+		min-height: initial;
+		// has to be flex for collapse button to fit
+		display: flex;
+
+		// Mimic the height of the parent, vertically align center, and provide a max-height.
+		height: $header-height;
+		align-items: center;
+
+
+		// on tablet viewports the toolbar is fixed
+		// on top of interface header and covers the whole header
+		// except for the inserter on the left
+		width: calc(100% - #{$toolbar-margin});
+
+		&.is-collapsed {
+			width: initial;
+		}
+
+		&:empty {
+			width: initial;
+		}
+
+		.is-fullscreen-mode & {
+			// leave room for block inserter, undo and redo, list view
+			// and some margin left
+			margin-left: $grid-unit-80 * 4 - 2 * $grid-unit;
+
+			top: 0;
+
+			&.is-collapsed {
+				width: initial;
+			}
+
+			&:empty {
+				width: initial;
+			}
+		}
+
+		.show-icon-labels & {
+			margin-left: $grid-unit-80 + 2 * $grid-unit; // inserter and margin
+			width: calc(100% + 40px - #{$toolbar-margin}); //there are no undo, redo and list view buttons
+
+			.is-fullscreen-mode & {
+				margin-left: $grid-unit * 18; // site hub, inserter and margin
+			}
+		}
+	}
+
+	// on desktop viewports the toolbar is fixed
+	// on top of interface header and leaves room
+	// for the block inserter the publish button
+	@include break-large() {
+		width: auto;
+		.show-icon-labels & {
+			width: auto; //there are no undo, redo and list view buttons
+		}
+
+		.is-fullscreen-mode & {
+			// in full screen mode we need to account for
+			// the combined with of the tools at the right of the header and the margin left
+			// of the toolbar which includes four buttons
+			width: calc(100% - 280px - #{4 * $grid-unit-80});
+		}
+	}
+}

--- a/packages/edit-widgets/src/components/widget-areas-block-editor-content/style.scss
+++ b/packages/edit-widgets/src/components/widget-areas-block-editor-content/style.scss
@@ -35,3 +35,101 @@
 		}
 	}
 }
+
+// Fixed contextual toolbar
+@include editor-left(".edit-widgets-block-editor .block-editor-block-contextual-toolbar.is-fixed");
+
+
+.edit-widgets-block-editor .block-editor-block-contextual-toolbar.is-fixed {
+	position: sticky;
+	top: 0;
+	z-index: z-index(".block-editor-block-popover");
+	display: block;
+	width: 100%;
+
+	// on desktop and tablet viewports the toolbar is fixed
+	// on top of interface header
+	$toolbar-margin: $grid-unit-80 * 3 - 2 * $grid-unit + $grid-unit-05;
+
+	@include break-medium() {
+		// leave room for block inserter, undo and redo, list view
+		margin-left: $toolbar-margin;
+		// position on top of interface header
+		position: fixed;
+		top: $admin-bar-height;
+		// Don't fill up when empty
+		min-height: initial;
+		// remove the border
+		border-bottom: none;
+		// has to be flex for collapse button to fit
+		display: flex;
+
+		// Mimic the height of the parent, vertically align center, and provide a max-height.
+		height: $header-height;
+		align-items: center;
+
+
+		// on tablet viewports the toolbar is fixed
+		// on top of interface header and covers the whole header
+		// except for the inserter on the left
+		width: calc(100% - #{$toolbar-margin});
+
+		&.is-collapsed {
+			width: initial;
+		}
+
+		&:empty {
+			width: initial;
+		}
+
+		.is-fullscreen-mode & {
+			// leave room for block inserter, undo and redo, list view
+			// and some margin left
+			margin-left: $grid-unit-80 * 4 - 2 * $grid-unit;
+
+			top: 0;
+
+			&.is-collapsed {
+				width: initial;
+			}
+
+			&:empty {
+				width: initial;
+			}
+		}
+
+		.show-icon-labels & {
+			margin-left: $grid-unit-80 + 2 * $grid-unit; // inserter and margin
+			width: calc(100% + 40px - #{$toolbar-margin}); //there are no undo, redo and list view buttons
+
+			.is-fullscreen-mode & {
+				margin-left: $grid-unit * 18; // site hub, inserter and margin
+			}
+		}
+
+		.blocks-widgets-container & {
+			margin-left: $grid-unit-80 * 2.4;
+
+			&.is-collapsed {
+				margin-left: $grid-unit-80 * 4.2;
+			}
+		}
+	}
+
+	// on desktop viewports the toolbar is fixed
+	// on top of interface header and leaves room
+	// for the block inserter the publish button
+	@include break-large() {
+		width: auto;
+		.show-icon-labels & {
+			width: auto; //there are no undo, redo and list view buttons
+		}
+
+		.is-fullscreen-mode & {
+			// in full screen mode we need to account for
+			// the combined with of the tools at the right of the header and the margin left
+			// of the toolbar which includes four buttons
+			width: calc(100% - 280px - #{4 * $grid-unit-80});
+		}
+	}
+}

--- a/storybook/stories/playground/index.story.js
+++ b/storybook/stories/playground/index.story.js
@@ -33,7 +33,11 @@ function App() {
 	} );
 
 	return (
-		<div className="playground">
+		// eslint-disable-next-line jsx-a11y/no-static-element-interactions
+		<div
+			className="playground"
+			onKeyDown={ ( event ) => event.stopPropagation() }
+		>
 			<BlockEditorProvider
 				value={ blocks }
 				onInput={ updateBlocks }
@@ -59,4 +63,37 @@ export default {
 
 export const _default = () => {
 	return <App />;
+};
+
+function EditorBox() {
+	const [ blocks, updateBlocks ] = useState( [] );
+
+	useEffect( () => {
+		registerCoreBlocks();
+	}, [] );
+
+	return (
+		// eslint-disable-next-line jsx-a11y/no-static-element-interactions
+		<div
+			className="editor-box"
+			style={ { border: '1px solid #eee' } }
+			onKeyDown={ ( event ) => event.stopPropagation() }
+		>
+			<BlockEditorProvider
+				value={ blocks }
+				onInput={ updateBlocks }
+				onChange={ updateBlocks }
+				settings={ {
+					hasFixedToolbar: true,
+				} }
+			>
+				<BlockTools />
+				<BlockCanvas height="100%" styles={ editorStyles } />
+			</BlockEditorProvider>
+		</div>
+	);
+}
+
+export const Box = () => {
+	return <EditorBox />;
 };


### PR DESCRIPTION
Related #53874 

## What?

When using Gutenberg for third-party block editors, there's a lot of small issues. One of them is that we have some CSS styles that are written with the generic block editor package that should be specific to the WordPress implementation of these components.

One of these components is the BlockToolbar, in order to support the fixed position (top toolbar) in all the wordpress editors (post editor, site editor and widgets editor), we have accumulated some CSS that is not meant to be included with all usage of the fixed "BlockToolbar" components or "BlockTools" components.

In this PR, I'm adding a new story to Storybook that tries to implement a TinyMCE like box using the block editor package. This highlighted these issues, so this PR also extract these specific styles to the WordPress specific packages.

## Testing Instructions

1- Ensure that the "top toolbar" mode still works as intended in all of the following situations:

 - Post Editor 
 - Site Editor
 - Widgets editor
 - Mobile and desktop
 - show and hide icons

2- You can also try running storybook and checking the new "playground box" story to understand why these changes are necessary.
