### PR TITLE
Change dialogdescription for renaming group block

### DIFF
--- a/packages/block-editor/src/hooks/block-rename-ui.js
+++ b/packages/block-editor/src/hooks/block-rename-ui.js
@@ -71,7 +71,7 @@ function RenameModal( { blockName, originalBlockName, onClose, onSave } ) {
 			} }
 		>
 			<p id={ dialogDescription }>
-				{ __( 'Choose a custom name for this block.' ) }
+				{ __( 'Enter a custom name for this block.' ) }
 			</p>
 			<form
 				onSubmit={ ( e ) => {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

Fixes #54346

## What?
@t-hamano made a good point i also noticed while testing. we should precise the popup message for the renaming introduced in #53735

## Why?
Be more precise. there is nothing to be choosen you have to enter the text as you want :)

## How?
Changing the text inserted in code.

## Testing Instructions

1. New Post (or enter the Site Editor)
2. Add some blocks and then Group them.
3. Open List View
4. Now open the block options menu (either via List View or via the block in the canvas) and click Rename.
5. Check message above field

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
