### PR TITLE
Remove `wp_store` from query block

### DIFF
--- a/packages/block-library/src/query/index.php
+++ b/packages/block-library/src/query/index.php
@@ -29,7 +29,7 @@ function render_block_core_query( $attributes, $content, $block ) {
 				wp_json_encode(
 					array(
 						'core' => array(
-							'query' => (object) array(
+							'query' => array(
 								'loadingText' => __( 'Loading page, please wait.' ),
 								'loadedText'  => __( 'Page Loaded.' ),
 							),

--- a/packages/block-library/src/query/index.php
+++ b/packages/block-library/src/query/index.php
@@ -25,7 +25,16 @@ function render_block_core_query( $attributes, $content, $block ) {
 			$p->set_attribute( 'data-wp-navigation-id', 'query-' . $attributes['queryId'] );
 			$p->set_attribute(
 				'data-wp-context',
-				wp_json_encode( array( 'core' => array( 'query' => (object) array() ) ) )
+				wp_json_encode(
+					array(
+						'core' => array(
+							'query' => (object) array(
+								'loadingText' => __( 'Loading page, please wait.' ),
+								'loadedText'  => __( 'Page Loaded.' ),
+							),
+						),
+					)
+				)
 			);
 			$content = $p->get_updated_html();
 
@@ -48,20 +57,6 @@ function render_block_core_query( $attributes, $content, $block ) {
 				></div>',
 				$last_div_position,
 				0
-			);
-
-			// Use state to send translated strings.
-			wp_store(
-				array(
-					'state' => array(
-						'core' => array(
-							'query' => array(
-								'loadingText' => __( 'Loading page, please wait.' ),
-								'loadedText'  => __( 'Page Loaded.' ),
-							),
-						),
-					),
-				)
 			);
 		}
 	}

--- a/packages/block-library/src/query/index.php
+++ b/packages/block-library/src/query/index.php
@@ -23,6 +23,7 @@ function render_block_core_query( $attributes, $content, $block ) {
 			// Add the necessary directives.
 			$p->set_attribute( 'data-wp-interactive', true );
 			$p->set_attribute( 'data-wp-navigation-id', 'query-' . $attributes['queryId'] );
+			// Use context to send translated strings.
 			$p->set_attribute(
 				'data-wp-context',
 				wp_json_encode(

--- a/packages/block-library/src/query/view.js
+++ b/packages/block-library/src/query/view.js
@@ -32,7 +32,7 @@ store( {
 	actions: {
 		core: {
 			query: {
-				navigate: async ( { event, ref, context, state } ) => {
+				navigate: async ( { event, ref, context } ) => {
 					if ( isValidLink( ref ) && isValidEvent( event ) ) {
 						event.preventDefault();
 
@@ -42,7 +42,7 @@ store( {
 						// Don't announce the navigation immediately, wait 300 ms.
 						const timeout = setTimeout( () => {
 							context.core.query.message =
-								state.core.query.loadingText;
+								context.core.query.loadingText;
 							context.core.query.animation = 'start';
 						}, 300 );
 
@@ -55,9 +55,9 @@ store( {
 						// same, we use a no-break space similar to the @wordpress/a11y
 						// package: https://github.com/WordPress/gutenberg/blob/c395242b8e6ee20f8b06c199e4fc2920d7018af1/packages/a11y/src/filter-message.js#L20-L26
 						context.core.query.message =
-							state.core.query.loadedText +
+							context.core.query.loadedText +
 							( context.core.query.message ===
-							state.core.query.loadedText
+							context.core.query.loadedText
 								? '\u00A0'
 								: '' );
 


### PR DESCRIPTION
## What?
Stop using `wp_store` in the query block.

## Why?
`wp_store` function won't be included in WordPress 6.4. I'm creating this pull request to stop using it in the Query block for now.

## How?
I moved the translation to context and use that instead.

## Testing Instructions
1. Add a query block using the Enhanced pagination setting.
2. Check that the `loadingText` and `loadedText` messages are showing as expected in the `enhanced-pagination-navigation-announce` element.
