### PR TITLE
Replace edit icon for text based button in details panel

### DIFF
--- a/packages/edit-site/src/components/sidebar-button/index.js
+++ b/packages/edit-site/src/components/sidebar-button/index.js
@@ -16,6 +16,8 @@ export default function SidebarButton( props ) {
 				'edit-site-sidebar-button',
 				props.className
 			) }
-		/>
+		>
+			{ props.children }
+		</Button>
 	);
 }

--- a/packages/edit-site/src/components/sidebar-button/style.scss
+++ b/packages/edit-site/src/components/sidebar-button/style.scss
@@ -1,4 +1,5 @@
-.edit-site-sidebar-button {
+.edit-site-sidebar-button,
+.edit-site-sidebar-button--primary {
 	color: $gray-200;
 	flex-shrink: 0;
 
@@ -20,5 +21,19 @@
 	&:not([aria-disabled="true"]):active,
 	&[aria-expanded="true"] {
 		color: $gray-100;
+	}
+}
+
+.edit-site-sidebar-button--primary {
+	background: $gray-800;
+	color: $gray-100;
+
+	&:hover,
+	&:focus-visible,
+	&:focus,
+	&:not([aria-disabled="true"]):active,
+	&[aria-expanded="true"] {
+		background: $gray-700;
+		color: $white;
 	}
 }

--- a/packages/edit-site/src/components/sidebar-navigation-screen-template/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-template/index.js
@@ -3,7 +3,6 @@
  */
 import { __, _x } from '@wordpress/i18n';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { pencil } from '@wordpress/icons';
 import {
 	__experimentalUseNavigator as useNavigator,
 	Icon,
@@ -114,8 +113,10 @@ export default function SidebarNavigationScreenTemplate() {
 					<SidebarButton
 						onClick={ () => setCanvasMode( 'edit' ) }
 						label={ __( 'Edit' ) }
-						icon={ pencil }
-					/>
+						className="edit-site-sidebar-button--primary"
+					>
+						{ __( 'Edit' ) }
+					</SidebarButton>
 				</>
 			}
 			description={ description }

--- a/packages/edit-site/src/components/sidebar-navigation-screen/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen/index.js
@@ -66,8 +66,8 @@ export default function SidebarNavigationScreen( {
 				justify="flex-start"
 			>
 				<HStack
-					spacing={ 4 }
-					alignment="flex-start"
+					spacing={ 2 }
+					alignment="center"
 					className="edit-site-sidebar-navigation-screen__title-icon"
 				>
 					{ ! isRoot && (
@@ -118,9 +118,14 @@ export default function SidebarNavigationScreen( {
 							  ) }
 					</Heading>
 					{ actions && (
-						<div className="edit-site-sidebar-navigation-screen__actions">
+						<HStack
+							spacing={ 2 }
+							alignment="center"
+							justify="end"
+							className="edit-site-sidebar-navigation-screen__actions"
+						>
 							{ actions }
-						</div>
+						</HStack>
 					) }
 				</HStack>
 				{ meta && (

--- a/packages/edit-site/src/components/sidebar-navigation-screen/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-screen/style.scss
@@ -67,13 +67,9 @@
 
 .edit-site-sidebar-navigation-screen__title {
 	flex-grow: 1;
-	padding: $grid-unit-15 * 0.5 0 0 0;
+	flex-shrink: 0;
 	overflow: hidden;
 	overflow-wrap: break-word;
-}
-
-.edit-site-sidebar-navigation-screen__actions {
-	flex-shrink: 0;
 }
 
 .edit-site-sidebar-navigation-screen__content .edit-site-global-styles-style-variations-container {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
An alternative to #54190, which aims to reduce the confusion between the pencil icon for renaming and editing the template/page. I used the 

Also cleans up the title area metrics a bit. 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. In the site editor, open navigate to a template e.g. Index.
2. Observe the pencil icon button is replaced with an "Edit" icon. 

## Screenshots or screencast <!-- if applicable -->
<img width="454" alt="CleanShot 2023-09-11 at 17 09 45" src="https://github.com/WordPress/gutenberg/assets/1813435/c157548c-aa77-4156-9392-53e2d9c0e3f0">
