### PR TITLE
Add additional templateType label for commands

### DIFF
--- a/packages/core-commands/src/site-editor-navigation-commands.js
+++ b/packages/core-commands/src/site-editor-navigation-commands.js
@@ -172,12 +172,16 @@ const getNavigationCommandLoaderPerTemplate = ( templateType ) =>
 				const extraArgs = isSiteEditor
 					? { canvas: getQueryArg( window.location.href, 'canvas' ) }
 					: {};
+				const templateLabel =
+					templateType === 'wp_template_part'
+						? __( 'template part' )
+						: __( 'template' );
 
 				return {
 					name: templateType + '-' + record.id,
 					searchLabel: record.title?.rendered + ' ' + record.id,
 					label: record.title?.rendered
-						? record.title?.rendered
+						? record.title?.rendered + ' ' + templateLabel
 						: __( '(no title)' ),
 					icon: icons[ templateType ],
 					callback: ( { close } ) => {

--- a/packages/core-commands/src/site-editor-navigation-commands.js
+++ b/packages/core-commands/src/site-editor-navigation-commands.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { useCommandLoader } from '@wordpress/commands';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { useMemo } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
@@ -172,16 +172,19 @@ const getNavigationCommandLoaderPerTemplate = ( templateType ) =>
 				const extraArgs = isSiteEditor
 					? { canvas: getQueryArg( window.location.href, 'canvas' ) }
 					: {};
+
 				const templateLabel =
 					templateType === 'wp_template_part'
-						? __( 'template part' )
-						: __( 'template' );
+						? /* translators: %s: name of the template, e.g. "Header" */
+						  __( '%s template part' )
+						: /* translators: %s: name of the template, e.g. "Home" */
+						  __( '%s template' );
 
 				return {
 					name: templateType + '-' + record.id,
 					searchLabel: record.title?.rendered + ' ' + record.id,
 					label: record.title?.rendered
-						? record.title?.rendered + ' ' + templateLabel
+						? sprintf( templateLabel, record.title?.rendered )
 						: __( '(no title)' ),
 					icon: icons[ templateType ],
 					callback: ( { close } ) => {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Closes #54230 by appending the templateType to the command label. 

## Why?
Add a bit more context to the commands so you know what is a template, or part, or neither. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open the site editor. 
2. Search for templates. 
3. See "template" or "template part" appended to the command. 


## Screenshots or screencast <!-- if applicable -->


| Before  | After |
| ------------- | ------------- |
|<img width="432" alt="CleanShot 2023-09-11 at 20 22 41" src="https://github.com/WordPress/gutenberg/assets/1813435/4410d482-157b-49f3-af38-0096d9220b28">|<img width="437" alt="CleanShot 2023-09-11 at 19 37 33" src="https://github.com/WordPress/gutenberg/assets/1813435/596abcb3-a27d-4a81-bf29-6b7c9fe286e3">|


