### PR TITLE
Try using fallback layout instead of default in post editor

### DIFF
--- a/packages/edit-post/src/components/visual-editor/index.js
+++ b/packages/edit-post/src/components/visual-editor/index.js
@@ -265,6 +265,9 @@ export default function VisualEditor( { styles } ) {
 		? postContentLayout
 		: fallbackLayout;
 
+	const postEditorLayout =
+		blockListLayout?.type === 'default' ? fallbackLayout : blockListLayout;
+
 	const observeTypingRef = useTypingObserver();
 	const titleRef = useRef();
 	useEffect( () => {
@@ -337,7 +340,7 @@ export default function VisualEditor( { styles } ) {
 									/>
 									<LayoutStyle
 										selector=".block-editor-block-list__layout.is-root-container"
-										layout={ blockListLayout }
+										layout={ postEditorLayout }
 									/>
 									{ align && (
 										<LayoutStyle css={ alignCSS } />


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes #52163.

Adds a check for the Post Content layout type, and if it's "default" we use the fallback layout instead, which essentially renders as if it were a "constrained" layout and uses the theme.json content width if there is one. The blocks _won't_ have the options to align full or wide though, to avoid introducing discrepancies with the front end (if Post Content has default layout set, its child blocks won't be able to align full or wide, so we respect that)

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Edit the single post template to set Post Content layout type to "default", by toggling off "Inner blocks use content width".
2. Save and check that content in the post editor no longer stretches the full width of the screen.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
