### PR TITLE
Edit Widgets: Fix broken layout

### DIFF
--- a/packages/edit-widgets/src/components/widget-areas-block-editor-content/index.js
+++ b/packages/edit-widgets/src/components/widget-areas-block-editor-content/index.js
@@ -4,7 +4,9 @@
 import {
 	BlockList,
 	BlockTools,
-	privateApis as blockEditorPrivateApis,
+	BlockSelectionClearer,
+	WritingFlow,
+	__unstableEditorStyles as EditorStyles,
 } from '@wordpress/block-editor';
 import { useSelect } from '@wordpress/data';
 import { useMemo } from '@wordpress/element';
@@ -15,11 +17,6 @@ import { store as preferencesStore } from '@wordpress/preferences';
  */
 import Notices from '../notices';
 import KeyboardShortcuts from '../keyboard-shortcuts';
-import { unlock } from '../../lock-unlock';
-
-const { ExperimentalBlockCanvas: BlockCanvas } = unlock(
-	blockEditorPrivateApis
-);
 
 export default function WidgetAreasBlockEditorContent( {
 	blockEditorSettings,
@@ -42,13 +39,15 @@ export default function WidgetAreasBlockEditorContent( {
 			<Notices />
 			<BlockTools>
 				<KeyboardShortcuts />
-				<BlockCanvas
-					shouldIframe={ false }
+				<EditorStyles
 					styles={ styles }
-					height="100%"
-				>
-					<BlockList className="edit-widgets-main-block-list" />
-				</BlockCanvas>
+					scope=".editor-styles-wrapper"
+				/>
+				<BlockSelectionClearer>
+					<WritingFlow>
+						<BlockList className="edit-widgets-main-block-list" />
+					</WritingFlow>
+				</BlockSelectionClearer>
 			</BlockTools>
 		</div>
 	);

--- a/packages/edit-widgets/src/components/widget-areas-block-editor-content/style.scss
+++ b/packages/edit-widgets/src/components/widget-areas-block-editor-content/style.scss
@@ -11,8 +11,7 @@
 	flex-grow: 1;
 
 	> div:last-of-type,
-	.block-editor-writing-flow,
-	.block-editor-writing-flow > div {
+	.block-editor-writing-flow {
 		display: flex;
 		flex-direction: column;
 		flex-grow: 1;

--- a/packages/edit-widgets/src/components/widget-areas-block-editor-provider/index.js
+++ b/packages/edit-widgets/src/components/widget-areas-block-editor-provider/index.js
@@ -10,7 +10,10 @@ import {
 	useResourcePermissions,
 } from '@wordpress/core-data';
 import { useMemo } from '@wordpress/element';
-import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
+import {
+	CopyHandler,
+	privateApis as blockEditorPrivateApis,
+} from '@wordpress/block-editor';
 import { privateApis as editPatternsPrivateApis } from '@wordpress/patterns';
 import { store as preferencesStore } from '@wordpress/preferences';
 
@@ -104,7 +107,7 @@ export default function WidgetAreasBlockEditorProvider( {
 				useSubRegistry={ false }
 				{ ...props }
 			>
-				{ children }
+				<CopyHandler>{ children }</CopyHandler>
 				<PatternsMenuItems rootClientId={ widgetAreaId } />
 			</ExperimentalBlockEditorProvider>
 		</SlotFillProvider>


### PR DESCRIPTION
Fixes #54295

## What?
This PR fixes the broken layout in the widget editor.

## Why?
See [this comment](https://github.com/WordPress/gutenberg/issues/54295#issuecomment-1714152170)

## How?

Ideally, each widget area may need to have its own separate editor, but for now, we think it is safe to revert to the previous implementation, without the `BlockCanvas` component.

## Testing Instructions

- Activate Twenty Twenty-One.
- Open Widgets menu.
- Make sure the layout is exactly the same as when you disabled the Gutenberg plugin that checked out this PR.