### PR TITLE
Don't use the null-coalescing operator in PHP yet - It's 7.4+ only

### DIFF
--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -531,7 +531,7 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 function gutenberg_render_layout_support_flag( $block_content, $block ) {
 	$block_type            = WP_Block_Type_Registry::get_instance()->get_registered( $block['blockName'] );
 	$block_supports_layout = block_has_support( $block_type, array( 'layout' ), false ) || block_has_support( $block_type, array( '__experimentalLayout' ), false );
-	$layout_from_parent    = $block['attrs']['style']['layout']['selfStretch'] ?? null;
+	$layout_from_parent    = isset( $block['attrs']['style']['layout']['selfStretch'] ) ? $block['attrs']['style']['layout']['selfStretch'] : null;
 
 	if ( ! $block_supports_layout && ! $layout_from_parent ) {
 		return $block_content;
@@ -750,7 +750,7 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 	 * @var string|null
 	 */
 	$inner_block_wrapper_classes = null;
-	$first_chunk                 = $block['innerContent'][0] ?? null;
+	$first_chunk                 = isset( $block['innerContent'][0] ) ? $block['innerContent'][0] : null;
 	if ( is_string( $first_chunk ) && count( $block['innerContent'] ) > 1 ) {
 		$first_chunk_processor = new WP_HTML_Tag_Processor( $first_chunk );
 		while ( $first_chunk_processor->next_tag() ) {


### PR DESCRIPTION
## What?
The PHP null coalescing operator was implemented in PHP v7.4 (see https://wiki.php.net/rfc/null_coalesce_equal_operator)
Since WordPress & Gutenberg need to be compatible with PHP 7.0+, we should not be using that syntactic sugar yet.

## Why?
PHP compatibility

## How?

Wrote 2 lines a bit more verbose, using `isset()` checks. They function identically, and are backwards compatible.

## Testing Instructions
No need for actual manual testing... If automated tests keep passing, we're good.
