### PR TITLE
[RNMobile] Flatten inner blocks to fix call stack size exceeded crash

### DIFF
--- a/packages/block-library/src/column/edit.native.js
+++ b/packages/block-library/src/column/edit.native.js
@@ -239,7 +239,7 @@ function ColumnEditWrapper( props ) {
 	);
 }
 
-export default compose( [
+const ColumnEditWrapperComposed = compose( [
 	withSelect( ( select, { clientId } ) => {
 		const {
 			getBlockCount,
@@ -274,3 +274,11 @@ export default compose( [
 	} ),
 	withPreferredColorScheme,
 ] )( ColumnEditWrapper );
+
+// Determines if the block can be removed from the block hierarchy
+// in order to flatten deeply nested inner blocks. If true and the following conditions are met, its inner blocks will be rendered in the parent block.
+// - The block is being rendered as an inner block.
+// - The block is not selected.
+ColumnEditWrapperComposed.canFlattenInnerBlocks = () => true;
+
+export default ColumnEditWrapperComposed;

--- a/packages/block-library/src/group/edit.native.js
+++ b/packages/block-library/src/group/edit.native.js
@@ -99,7 +99,7 @@ function GroupEdit( {
 	);
 }
 
-export default compose( [
+const GroupEditComposed = compose( [
 	withSelect( ( select, { clientId } ) => {
 		const {
 			getBlock,
@@ -135,3 +135,11 @@ export default compose( [
 	} ),
 	withPreferredColorScheme,
 ] )( GroupEdit );
+
+// Determines if the block can be removed from the block hierarchy
+// in order to flatten deeply nested inner blocks. If true and the following conditions are met, its inner blocks will be rendered in the parent block.
+// - The block is being rendered as an inner block.
+// - The block is not selected.
+GroupEditComposed.canFlattenInnerBlocks = () => true;
+
+export default GroupEditComposed;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
This PR expands the block list logic to avoid having deeply nested inner blocks, which leads to crashing the editor. The idea is to identify the group blocks that don’t include any visuals when rendering the inner blocks, and dynamically remove them in the spirit of flattening the content structure.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Fixes https://github.com/wordpress-mobile/WordPress-Android/issues/18750.
Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/6123.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

### Extract the logic that calculates the block IDs to render in the block list component
https://github.com/WordPress/gutenberg/blob/ce38d4d8a795bd3fdd48bb5b36311dbacf176afb/packages/block-editor/src/components/block-list/index.native.js#L132-L137
https://github.com/WordPress/gutenberg/blob/ce38d4d8a795bd3fdd48bb5b36311dbacf176afb/packages/block-editor/src/components/block-list/index.native.js#L111

This logic hasn't been modified, as it remains as it was before the PR:
https://github.com/WordPress/gutenberg/blob/7d054a2d08d86291041fb2be35c3bbf694c18af1/packages/block-editor/src/components/block-list/index.native.js#L97-L101

### Detect when inner blocks can be flattened

https://github.com/WordPress/gutenberg/blob/ce38d4d8a795bd3fdd48bb5b36311dbacf176afb/packages/block-editor/src/components/block-list/index.native.js#L123-L125

https://github.com/WordPress/gutenberg/blob/ce38d4d8a795bd3fdd48bb5b36311dbacf176afb/packages/block-editor/src/components/block-list/index.native.js#L157-L159

https://github.com/WordPress/gutenberg/blob/ce38d4d8a795bd3fdd48bb5b36311dbacf176afb/packages/block-editor/src/components/block-list/index.native.js#L144-L155

The inner blocks of a block can be flattened if the following conditions are met:
- The block has nested inner blocks.
- The block is an inner block of another block.
- The block is not selected. If the block is selected we need to render it to allow the user to edit it.
- The block type allows the flattening via the `canFlattenInnerBlocks` setting. This is a per-block setting, as the block is the one to determine if its inner blocks can be flattened.

https://github.com/WordPress/gutenberg/blob/ce38d4d8a795bd3fdd48bb5b36311dbacf176afb/packages/block-library/src/group/edit.native.js#L143

### Flatten inner blocks

https://github.com/WordPress/gutenberg/blob/ce38d4d8a795bd3fdd48bb5b36311dbacf176afb/packages/block-editor/src/components/block-list/index.native.js#L161-L167

This functionality basically iterates through all inner blocks, including the nested ones. If it determines that a block opts to flatten its inner blocks, they will be rendered by the parent.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
[TBD]

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
N/A

## Screenshots or screencast <!-- if applicable -->
N/A