### PR TITLE
Add __next40pxDefaultSize to featured image opacity control

### DIFF
--- a/packages/block-library/src/post-featured-image/overlay.js
+++ b/packages/block-library/src/post-featured-image/overlay.js
@@ -113,6 +113,7 @@ const Overlay = ( {
 						max={ 100 }
 						step={ 10 }
 						required
+						__next40pxDefaultSize
 					/>
 				</ToolsPanelItem>
 			</InspectorControls>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Updating the featured image block's RangeControl to use the proper size. 

## Why?
Consistency. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a post or page.
2. Insert a post featured image block.
3. Click the block's styles tab.
4. See overlay opacity control as the proper size.

## Screenshots or screencast <!-- if applicable -->


| Before  | After |
| ------------- | ------------- |
|<img width="280" alt="CleanShot 2023-09-12 at 12 29 25" src="https://github.com/WordPress/gutenberg/assets/1813435/38ad086e-6e27-405a-a916-7b533591eac9">|<img width="279" alt="CleanShot 2023-09-12 at 12 29 40" src="https://github.com/WordPress/gutenberg/assets/1813435/51f2ab45-d779-4d74-a3db-53a956f3ad39">|


