### PR TITLE
Comments form: Accessibility fixes for back-end

### DIFF
--- a/packages/block-library/src/post-comments-form/edit.js
+++ b/packages/block-library/src/post-comments-form/edit.js
@@ -11,6 +11,9 @@ import {
 	BlockControls,
 	useBlockProps,
 } from '@wordpress/block-editor';
+import { VisuallyHidden } from '@wordpress/components';
+import { useInstanceId } from '@wordpress/compose';
+import { __, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -25,10 +28,14 @@ export default function PostCommentsFormEdit( {
 	const { textAlign } = attributes;
 	const { postId, postType } = context;
 
+	const instanceId = useInstanceId( PostCommentsFormEdit );
+	const instanceIdDesc = sprintf( 'comments-form-edit-%d-desc', instanceId );
+
 	const blockProps = useBlockProps( {
 		className: classnames( {
 			[ `has-text-align-${ textAlign }` ]: textAlign,
 		} ),
+		'aria-describedby': instanceIdDesc,
 	} );
 
 	return (
@@ -43,6 +50,9 @@ export default function PostCommentsFormEdit( {
 			</BlockControls>
 			<div { ...blockProps }>
 				<CommentsForm postId={ postId } postType={ postType } />
+				<VisuallyHidden id={ instanceIdDesc }>
+					{ __( 'Comments form disabled on back-end.' ) }
+				</VisuallyHidden>
 			</div>
 		</>
 	);

--- a/packages/block-library/src/post-comments-form/edit.js
+++ b/packages/block-library/src/post-comments-form/edit.js
@@ -51,7 +51,7 @@ export default function PostCommentsFormEdit( {
 			<div { ...blockProps }>
 				<CommentsForm postId={ postId } postType={ postType } />
 				<VisuallyHidden id={ instanceIdDesc }>
-					{ __( 'Comments form disabled on back-end.' ) }
+					{ __( 'Comments form disabled in editor.' ) }
 				</VisuallyHidden>
 			</div>
 		</>

--- a/packages/block-library/src/post-comments-form/form.js
+++ b/packages/block-library/src/post-comments-form/form.js
@@ -37,7 +37,7 @@ const CommentsFormPlaceholder = () => {
 						name="comment"
 						cols="45"
 						rows="8"
-						aria-disabled="true"
+						readOnly
 					/>
 				</p>
 				<p className="form-submit wp-block-button">

--- a/packages/block-library/src/post-comments-form/form.js
+++ b/packages/block-library/src/post-comments-form/form.js
@@ -23,7 +23,11 @@ const CommentsFormPlaceholder = () => {
 	return (
 		<div className="comment-respond">
 			<h3 className="comment-reply-title">{ __( 'Leave a Reply' ) }</h3>
-			<form noValidate className="comment-form" inert="true">
+			<form
+				noValidate
+				className="comment-form"
+				onSubmit={ ( event ) => event.preventDefault() }
+			>
 				<p>
 					<label htmlFor={ `comment-${ instanceId }` }>
 						{ __( 'Comment' ) }
@@ -33,6 +37,7 @@ const CommentsFormPlaceholder = () => {
 						name="comment"
 						cols="45"
 						rows="8"
+						aria-disabled="true"
 					/>
 				</p>
 				<p className="form-submit wp-block-button">
@@ -45,6 +50,7 @@ const CommentsFormPlaceholder = () => {
 						) }
 						label={ __( 'Post Comment' ) }
 						value={ __( 'Post Comment' ) }
+						aria-disabled="true"
 					/>
 				</p>
 			</form>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Try to make the comments form on the back-end accessible.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Accessibility is important.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

1. Remove `inert`.
2. Add `aria-disabled` to fields.
3. Add `aria-describedby` to communicate that the form is disabled on the back-end to assistive tech.
4. Add `onSubmit` event handler to disable the form submission.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Open the post editor.
2. Insert a comments block.
3. Select the comments form block.
4. Notice how the comment and submit form controls have `aria-disabled`.
5. Notice how trying to submit a comment does not work. The event is prevented.
6. Notice how there is an `aria-describedby` attribute that points to a unique description which is wrapped in the visually-hidden `<div>` after the comments form.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
