### PR TITLE
Button: Undocument the `focus` prop

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -28,9 +28,6 @@
 -   `Higher Order` -- `with-focus-outside`: Convert to TypeScript ([#53980](https://github.com/WordPress/gutenberg/pull/53980)).
 -   `IsolatedEventContainer`: Convert unit test to TypeScript ([#54316](https://github.com/WordPress/gutenberg/pull/54316)).
 -   `Popover`: Remove `scroll` and `resize` listeners for iframe overflow parents and rely on recently added native Floating UI support ([#54286](https://github.com/WordPress/gutenberg/pull/54286)).
-
-### Documentation
-
 -   `Button`: Update documentation to remove the button `focus` prop ([#54397](https://github.com/WordPress/gutenberg/pull/54397)).
 
 ### Experimental

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -132,6 +132,10 @@
 
 ## 25.2.0 (2023-06-23)
 
+### Documentation
+
+-   Button `focus` prop: Update documentation to remove the button `focus` prop ([#50972](https://github.com/WordPress/gutenberg/issues/50972)).
+
 ### Enhancements
 
 -   `UnitControl`: Revamp support for changing unit by typing ([#39303](https://github.com/WordPress/gutenberg/pull/39303)).

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -29,6 +29,10 @@
 -   `IsolatedEventContainer`: Convert unit test to TypeScript ([#54316](https://github.com/WordPress/gutenberg/pull/54316)).
 -   `Popover`: Remove `scroll` and `resize` listeners for iframe overflow parents and rely on recently added native Floating UI support ([#54286](https://github.com/WordPress/gutenberg/pull/54286)).
 
+### Documentation
+
+-   Button `focus` prop: Update documentation to remove the button `focus` prop ([#51808](https://github.com/WordPress/gutenberg/pull/51808)).
+
 ### Experimental
 
 -   `DropdownMenu` v2: Fix submenu chevron direction in RTL languages ([#54036](https://github.com/WordPress/gutenberg/pull/54036).
@@ -131,10 +135,6 @@
 -   `Guide`: Place focus on the guide's container instead of its first tabbable ([#52300](https://github.com/WordPress/gutenberg/pull/52300)).
 
 ## 25.2.0 (2023-06-23)
-
-### Documentation
-
--   Button `focus` prop: Update documentation to remove the button `focus` prop ([#50972](https://github.com/WordPress/gutenberg/issues/50972)).
 
 ### Enhancements
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -31,7 +31,7 @@
 
 ### Documentation
 
--   Button `focus` prop: Update documentation to remove the button `focus` prop ([#54397](https://github.com/WordPress/gutenberg/pull/54397)).
+-   `Button`: Update documentation to remove the button `focus` prop ([#54397](https://github.com/WordPress/gutenberg/pull/54397)).
 
 ### Experimental
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -31,7 +31,7 @@
 
 ### Documentation
 
--   Button `focus` prop: Update documentation to remove the button `focus` prop ([#51808](https://github.com/WordPress/gutenberg/pull/51808)).
+-   Button `focus` prop: Update documentation to remove the button `focus` prop ([#54397](https://github.com/WordPress/gutenberg/pull/54397)).
 
 ### Experimental
 

--- a/packages/components/src/button/README.md
+++ b/packages/components/src/button/README.md
@@ -145,12 +145,6 @@ Whether the button is disabled. If `true`, this will force a `button` element to
 
 -   Required: No
 
-#### `focus`: `boolean`
-
-Whether the button is focused.
-
--   Required: No
-
 #### `href`: `string`
 
 If provided, renders `a` instead of `button`.

--- a/packages/components/src/button/types.ts
+++ b/packages/components/src/button/types.ts
@@ -34,7 +34,7 @@ type BaseButtonProps = {
 	 */
 	describedBy?: string;
 	/**
-	 * Whether the button is focused.
+	 * If provided, renders an Icon component inside the button.
 	 */
 	icon?: IconProps[ 'icon' ];
 	/**

--- a/packages/components/src/button/types.ts
+++ b/packages/components/src/button/types.ts
@@ -36,10 +36,6 @@ type BaseButtonProps = {
 	/**
 	 * Whether the button is focused.
 	 */
-	focus?: boolean;
-	/**
-	 * If provided, renders an Icon component inside the button.
-	 */
 	icon?: IconProps[ 'icon' ];
 	/**
 	 * If provided with `icon`, sets the position of icon relative to the `text`.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
fixes #50972
## What?
Wrapping up the work started in #51808, a new PR was easier to wrangle with the previous PR being generated from a fork. This PR removes the `focus` prop from the `Button` component's documentation. 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
This prop is no longer active on the component (see the above issue for more details) and shouldn't be listed in the docs.

## How?
I used the delete button 😉

## Testing Instructions
Check the `Button` component's README and `types` files, confirm the `focus` prop is no longer listed.