### PR TITLE
Adjust input-style__focus mixin to proper focus size

### DIFF
--- a/packages/base-styles/_mixins.scss
+++ b/packages/base-styles/_mixins.scss
@@ -82,6 +82,7 @@
 
 @mixin input-style__focus() {
 	border-color: var(--wp-admin-theme-color);
+	// Expand the default border focus style by .5px to be a total of 1.5px.
 	box-shadow: 0 0 0 0.5px var(--wp-admin-theme-color);
 	// Windows High Contrast mode will show this outline, but not the box-shadow.
 	outline: 2px solid transparent;

--- a/packages/base-styles/_mixins.scss
+++ b/packages/base-styles/_mixins.scss
@@ -82,8 +82,7 @@
 
 @mixin input-style__focus() {
 	border-color: var(--wp-admin-theme-color);
-	box-shadow: 0 0 0 ($border-width-focus-fallback - $border-width) var(--wp-admin-theme-color);
-
+	box-shadow: 0 0 0 0.5px var(--wp-admin-theme-color);
 	// Windows High Contrast mode will show this outline, but not the box-shadow.
 	outline: 2px solid transparent;
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Small style adjustment to make focus consistent across components. These two use the `@input-style__focus` mixin, which was adding too large of a focus shadow; I used the same technique used elsewhere — and recently in https://github.com/WordPress/gutenberg/pull/54394. 

## Why?
Consistency. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a post or page.
2. See changes on the parent page control (page). 
3. See changes on the tags control (posts). 

## Screenshots or screencast <!-- if applicable -->

| Before  | After |
| ------------- | ------------- |
|<img width="280" alt="CleanShot 2023-09-12 at 15 56 18" src="https://github.com/WordPress/gutenberg/assets/1813435/a73a8de1-2c60-4271-a0fe-4b6c6d851d89"><img width="278" alt="CleanShot 2023-09-12 at 16 12 49" src="https://github.com/WordPress/gutenberg/assets/1813435/f898b9c5-26ee-45af-989f-64751ae09cbf">|<img width="278" alt="CleanShot 2023-09-12 at 15 20 01" src="https://github.com/WordPress/gutenberg/assets/1813435/911aeb73-a025-4356-974f-3203eabf63e0"><img width="279" alt="CleanShot 2023-09-12 at 16 13 23" src="https://github.com/WordPress/gutenberg/assets/1813435/69ed6d43-2799-4873-88eb-095c4a7d5765">|




