### PR TITLE
Use __next40pxDefaultSize on more UI

### DIFF
--- a/packages/block-library/src/page-list/edit.js
+++ b/packages/block-library/src/page-list/edit.js
@@ -320,6 +320,7 @@ export default function PageListEdit( {
 				{ pagesTree.length > 0 && (
 					<PanelBody>
 						<ComboboxControl
+							__next40pxDefaultSize
 							className="editor-page-attributes__parent"
 							label={ __( 'Parent page' ) }
 							value={ parentPageID }

--- a/packages/editor/src/components/page-attributes/parent.js
+++ b/packages/editor/src/components/page-attributes/parent.js
@@ -158,6 +158,7 @@ export function PageAttributesParent() {
 	return (
 		<ComboboxControl
 			__nextHasNoMarginBottom
+			__next40pxDefaultSize
 			className="editor-page-attributes__parent"
 			label={ parentPageLabel }
 			value={ parentPostId }

--- a/packages/editor/src/components/post-author/combobox.js
+++ b/packages/editor/src/components/post-author/combobox.js
@@ -96,6 +96,7 @@ function PostAuthorCombobox() {
 	return (
 		<ComboboxControl
 			__nextHasNoMarginBottom
+			__next40pxDefaultSize
 			label={ __( 'Author' ) }
 			options={ authorOptions }
 			value={ authorId }

--- a/packages/editor/src/components/post-taxonomies/flat-term-selector.js
+++ b/packages/editor/src/components/post-taxonomies/flat-term-selector.js
@@ -254,6 +254,7 @@ export function FlatTermSelector( { slug } ) {
 	return (
 		<>
 			<FormTokenField
+				__next40pxDefaultSize
 				value={ values }
 				suggestions={ suggestions }
 				onChange={ onChange }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Adding more support for the 40px default size for components. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->

Test: 

1. Page List block.
2. Page attributes parent control.
3. Add new tag control.
4. Post author (if 25+ authors).

<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

| Before  | After |
| ------------- | ------------- |
|<img width="279" alt="CleanShot 2023-09-12 at 16 22 47" src="https://github.com/WordPress/gutenberg/assets/1813435/e55fe470-2fc6-4c88-aeea-29dd573da941"><img width="279" alt="CleanShot 2023-09-12 at 16 21 45" src="https://github.com/WordPress/gutenberg/assets/1813435/c10eb8e4-a2f9-4963-941e-860facca8318"><img width="279" alt="CleanShot 2023-09-12 at 16 22 18" src="https://github.com/WordPress/gutenberg/assets/1813435/6b6dcbf7-7c85-4963-b466-3ba4b3fa0ad4">|<img width="280" alt="CleanShot 2023-09-12 at 16 19 59" src="https://github.com/WordPress/gutenberg/assets/1813435/a7745696-4924-4c5a-a03e-2e009ca5250d"><img width="278" alt="CleanShot 2023-09-12 at 16 19 42" src="https://github.com/WordPress/gutenberg/assets/1813435/9074933b-b957-4189-8557-ea89c2b60ffa"><img width="279" alt="CleanShot 2023-09-12 at 16 19 32" src="https://github.com/WordPress/gutenberg/assets/1813435/9ceb57e6-534b-461b-888e-cb332f36a5fe">|







