### PR TITLE
Update FormTokenField styling for consistency and visibility

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 ## Unreleased
 -   `ProgressBar`: Export component to allow it to be used ([#54404](https://github.com/WordPress/gutenberg/pull/54404)).
--   `FormTokenField`: Update styling for consistency and increased visibility ([#54402](https://github.com/WordPress/gutenberg/pull/54402)).
 
 ### Enhancements
 
@@ -12,6 +11,7 @@
 -   `Tooltip`: Replace the existing tooltip to simplify the implementation and improve accessibility while maintaining the same behaviors and API ([#48440](https://github.com/WordPress/gutenberg/pull/48440)).
 -   `Dropdown` and `DropdownMenu`: support controlled mode for the dropdown's open/closed state ([#54257](https://github.com/WordPress/gutenberg/pull/54257)).
 -   `BorderControl`: Apply proper metrics and simpler text ([#53998](https://github.com/WordPress/gutenberg/pull/53998)).
+-   `FormTokenField`: Update styling for consistency and increased visibility ([#54402](https://github.com/WordPress/gutenberg/pull/54402)).
 
 ### Bug Fix
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 -   `ProgressBar`: Export component to allow it to be used ([#54404](https://github.com/WordPress/gutenberg/pull/54404)).
+-   `FormTokenField`: Update styling for consistency and increased visibility ([#54402](https://github.com/WordPress/gutenberg/pull/54402)).
 
 ### Enhancements
 

--- a/packages/components/src/form-token-field/style.scss
+++ b/packages/components/src/form-token-field/style.scss
@@ -157,21 +157,20 @@
 .components-form-token-field__suggestions-list {
 	flex: 1 0 100%;
 	min-width: 100%;
-	max-height: 9em;
+	max-height: $grid-unit-80 * 2;
 	overflow-y: auto;
 	transition: all 0.15s ease-in-out;
 	@include reduce-motion("transition");
 	list-style: none;
-	border-top: $border-width solid $components-color-border;
+	box-shadow: inset 0 1px 0 0 rgba(0, 0, 0, 0.5); // Matches the border color of the input.
 	margin: 0;
-	padding: 0;
 }
 
 .components-form-token-field__suggestion {
-	color: $gray-700;
+	color: $gray-900;
 	display: block;
 	font-size: $default-font-size;
-	padding: 4px 8px;
+	padding: $grid-unit-10 $grid-unit-15;
 	margin: 0;
 	cursor: pointer;
 
@@ -179,8 +178,4 @@
 		background: $components-color-accent;
 		color: $white;
 	}
-}
-
-.components-form-token-field__suggestion-match {
-	text-decoration: underline;
 }

--- a/packages/components/src/form-token-field/style.scss
+++ b/packages/components/src/form-token-field/style.scss
@@ -162,7 +162,7 @@
 	transition: all 0.15s ease-in-out;
 	@include reduce-motion("transition");
 	list-style: none;
-	box-shadow: inset 0 1px 0 0 rgba(0, 0, 0, 0.5); // Matches the border color of the input.
+	box-shadow: inset 0 $border-width 0 0 rgba(0, 0, 0, 0.5); // Matches the border color of the input.
 	margin: 0;
 }
 

--- a/packages/components/src/form-token-field/style.scss
+++ b/packages/components/src/form-token-field/style.scss
@@ -171,6 +171,7 @@
 	display: block;
 	font-size: $default-font-size;
 	padding: $grid-unit-10 $grid-unit-15;
+	min-height: $button-size-compact;
 	margin: 0;
 	cursor: pointer;
 

--- a/packages/components/src/form-token-field/style.scss
+++ b/packages/components/src/form-token-field/style.scss
@@ -162,7 +162,7 @@
 	transition: all 0.15s ease-in-out;
 	@include reduce-motion("transition");
 	list-style: none;
-	box-shadow: inset 0 $border-width 0 0 rgba(0, 0, 0, 0.5); // Matches the border color of the input.
+	box-shadow: inset 0 $border-width 0 0 $gray-600; // Matches the border color of the input.
 	margin: 0;
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Updated the styling for FormTokenField to make it more consistent with the recent tweaks in https://github.com/WordPress/gutenberg/pull/54318, while making the items a bit more visible with increased spacing. [This comment ](https://github.com/WordPress/gutenberg/issues/51582#issuecomment-1600355521) details a number of inconsistencies for other consolidation candidates. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a page. 
2. Open the settings sidebar.
3. See the parent page control within the Page Attributes panel. 
4. Search for pages to see the changes.

## Screenshots or screencast <!-- if applicable -->

| Before  | After |
| ------------- | ------------- |
|<img width="280" alt="CleanShot 2023-09-12 at 16 36 09" src="https://github.com/WordPress/gutenberg/assets/1813435/65e439b7-a041-416f-a5e4-c326b0b8e6fa">|<img width="279" alt="CleanShot 2023-09-12 at 16 35 36" src="https://github.com/WordPress/gutenberg/assets/1813435/c5e81d4e-2038-4f6a-af18-b932b661b0eb">|

I made a couple related PRs to resolve holistic issues that target this component as well (https://github.com/WordPress/gutenberg/pull/54398 and https://github.com/WordPress/gutenberg/pull/54400). Combined, the controls will look as such: 

https://github.com/WordPress/gutenberg/assets/1813435/c045c1e9-ab6e-482e-a878-25e1507227b5

Notably, the top border does not clash with the selected color, and the padding looks ace. 