### PR TITLE
Update parent labels in page attributes panel and page list block

### DIFF
--- a/packages/block-library/src/page-list/edit.js
+++ b/packages/block-library/src/page-list/edit.js
@@ -321,7 +321,7 @@ export default function PageListEdit( {
 					<PanelBody>
 						<ComboboxControl
 							className="editor-page-attributes__parent"
-							label={ __( 'Parent page' ) }
+							label={ __( 'Parent' ) }
 							value={ parentPageID }
 							options={ pagesTree }
 							onChange={ ( value ) =>

--- a/packages/editor/src/components/page-attributes/parent.js
+++ b/packages/editor/src/components/page-attributes/parent.js
@@ -55,7 +55,7 @@ export function PageAttributesParent() {
 			const postId = getCurrentPostId();
 			const postIsHierarchical = pType?.hierarchical ?? false;
 			const query = {
-				per_page: 101,
+				per_page: 100,
 				exclude: postId,
 				parent_exclude: postId,
 				orderby: 'menu_order',

--- a/packages/editor/src/components/page-attributes/parent.js
+++ b/packages/editor/src/components/page-attributes/parent.js
@@ -77,7 +77,6 @@ export function PageAttributesParent() {
 				items: postIsHierarchical
 					? getEntityRecords( 'postType', postTypeSlug, query )
 					: [],
-				postType: pType,
 			};
 		},
 		[ fieldValue ]

--- a/packages/editor/src/components/page-attributes/parent.js
+++ b/packages/editor/src/components/page-attributes/parent.js
@@ -55,7 +55,7 @@ export function PageAttributesParent() {
 			const postId = getCurrentPostId();
 			const postIsHierarchical = pType?.hierarchical ?? false;
 			const query = {
-				per_page: 100,
+				per_page: 101,
 				exclude: postId,
 				parent_exclude: postId,
 				orderby: 'menu_order',

--- a/packages/editor/src/components/page-attributes/parent.js
+++ b/packages/editor/src/components/page-attributes/parent.js
@@ -43,48 +43,46 @@ export const getItemPriority = ( name, searchValue ) => {
 export function PageAttributesParent() {
 	const { editPost } = useDispatch( editorStore );
 	const [ fieldValue, setFieldValue ] = useState( false );
-	const { isHierarchical, parentPost, parentPostId, items, postType } =
-		useSelect(
-			( select ) => {
-				const { getPostType, getEntityRecords, getEntityRecord } =
-					select( coreStore );
-				const { getCurrentPostId, getEditedPostAttribute } =
-					select( editorStore );
-				const postTypeSlug = getEditedPostAttribute( 'type' );
-				const pageId = getEditedPostAttribute( 'parent' );
-				const pType = getPostType( postTypeSlug );
-				const postId = getCurrentPostId();
-				const postIsHierarchical = pType?.hierarchical ?? false;
-				const query = {
-					per_page: 100,
-					exclude: postId,
-					parent_exclude: postId,
-					orderby: 'menu_order',
-					order: 'asc',
-					_fields: 'id,title,parent',
-				};
+	const { isHierarchical, parentPost, parentPostId, items } = useSelect(
+		( select ) => {
+			const { getPostType, getEntityRecords, getEntityRecord } =
+				select( coreStore );
+			const { getCurrentPostId, getEditedPostAttribute } =
+				select( editorStore );
+			const postTypeSlug = getEditedPostAttribute( 'type' );
+			const pageId = getEditedPostAttribute( 'parent' );
+			const pType = getPostType( postTypeSlug );
+			const postId = getCurrentPostId();
+			const postIsHierarchical = pType?.hierarchical ?? false;
+			const query = {
+				per_page: 100,
+				exclude: postId,
+				parent_exclude: postId,
+				orderby: 'menu_order',
+				order: 'asc',
+				_fields: 'id,title,parent',
+			};
 
-				// Perform a search when the field is changed.
-				if ( !! fieldValue ) {
-					query.search = fieldValue;
-				}
+			// Perform a search when the field is changed.
+			if ( !! fieldValue ) {
+				query.search = fieldValue;
+			}
 
-				return {
-					isHierarchical: postIsHierarchical,
-					parentPostId: pageId,
-					parentPost: pageId
-						? getEntityRecord( 'postType', postTypeSlug, pageId )
-						: null,
-					items: postIsHierarchical
-						? getEntityRecords( 'postType', postTypeSlug, query )
-						: [],
-					postType: pType,
-				};
-			},
-			[ fieldValue ]
-		);
+			return {
+				isHierarchical: postIsHierarchical,
+				parentPostId: pageId,
+				parentPost: pageId
+					? getEntityRecord( 'postType', postTypeSlug, pageId )
+					: null,
+				items: postIsHierarchical
+					? getEntityRecords( 'postType', postTypeSlug, query )
+					: [],
+				postType: pType,
+			};
+		},
+		[ fieldValue ]
+	);
 
-	const parentPageLabel = postType?.labels?.parent_item_colon;
 	const pageItems = items || [];
 
 	const parentOptions = useMemo( () => {
@@ -134,7 +132,7 @@ export function PageAttributesParent() {
 		return opts;
 	}, [ pageItems, fieldValue ] );
 
-	if ( ! isHierarchical || ! parentPageLabel ) {
+	if ( ! isHierarchical ) {
 		return null;
 	}
 	/**
@@ -159,7 +157,7 @@ export function PageAttributesParent() {
 		<ComboboxControl
 			__nextHasNoMarginBottom
 			className="editor-page-attributes__parent"
-			label={ parentPageLabel }
+			label={ __( 'Parent' ) }
 			value={ parentPostId }
 			options={ parentOptions }
 			onFilterValueChange={ debounce( handleKeydown, 300 ) }

--- a/test/e2e/specs/editor/blocks/navigation-frontend-interactivity.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation-frontend-interactivity.spec.js
@@ -289,7 +289,7 @@ test.describe( 'Navigation block - Frontend interactivity', () => {
 		} ) => {
 			await page.goto( '/' );
 			const submenuButton = page.getByRole( 'button', {
-				name: 'Parent Page',
+				name: 'Parent',
 			} );
 			const innerElement = page.getByRole( 'link', {
 				name: 'Subpage',

--- a/test/e2e/specs/editor/plugins/custom-post-types.spec.js
+++ b/test/e2e/specs/editor/plugins/custom-post-types.spec.js
@@ -46,7 +46,7 @@ test.describe( 'Test Custom Post Types', () => {
 		}
 
 		const parentPageLocator = page.getByRole( 'combobox', {
-			name: 'Parent Page',
+			name: 'Parent',
 		} );
 
 		await parentPageLocator.click();


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Makes the labels a bit simpler as the panel already indicates this is "Page attributes". I don't think it's necessary to include it again in the label. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a page.
2. See changes in the page attributes panel.

## Screenshots or screencast <!-- if applicable -->

| Before  | After |
| ------------- | ------------- |
|<img width="280" alt="CleanShot 2023-09-12 at 16 50 05" src="https://github.com/WordPress/gutenberg/assets/1813435/ea9fbe4b-2919-40ff-9b27-79ac88f13f22"><img width="278" alt="CleanShot 2023-09-12 at 16 50 19" src="https://github.com/WordPress/gutenberg/assets/1813435/8a24fae1-2ebd-4a33-a2bb-05f8b6fc0204">|<img width="278" alt="CleanShot 2023-09-12 at 16 50 39" src="https://github.com/WordPress/gutenberg/assets/1813435/b360b003-f70f-4ef6-bb59-ddaae498ca16"><img width="278" alt="CleanShot 2023-09-12 at 16 50 31" src="https://github.com/WordPress/gutenberg/assets/1813435/d9e9e00c-95e1-46ba-9223-5acf92130357">|




