### PR TITLE
Export ProgressBar to allow it to be used

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 -   `BorderControl`: Apply proper metrics and simpler text ([#53998](https://github.com/WordPress/gutenberg/pull/53998)).
+-   `ProgressBar`: Export component to allow it to be used ([#54404](https://github.com/WordPress/gutenberg/pull/54404)).
 
 ### Enhancements
 

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -132,6 +132,7 @@ export { default as PanelHeader } from './panel/header';
 export { default as PanelRow } from './panel/row';
 export { default as Placeholder } from './placeholder';
 export { default as Popover } from './popover';
+export { default as __experimentalProgressBar } from './progress-bar';
 export { default as QueryControls } from './query-controls';
 export { default as __experimentalRadio } from './radio-group/radio';
 export { default as __experimentalRadioGroup } from './radio-group';


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Export `ProgressBar` component as `__experimentalProgressBar`

## Why?
To allow it to be used.


## Testing Instructions
In a react component add:

```
import { _experimentalProgressBar as ProgressBar } from '@wordpress/components';


function TestComponent () {
    return (
      <div> HI! <ProgressBar /> </div>
    )
}

```

