### PR TITLE
Tooltip: Add new `hideOnClick` prop

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -10,6 +10,7 @@
 -   `Tooltip`: Replace the existing tooltip to simplify the implementation and improve accessibility while maintaining the same behaviors and API ([#48440](https://github.com/WordPress/gutenberg/pull/48440)).
 -   `Dropdown` and `DropdownMenu`: support controlled mode for the dropdown's open/closed state ([#54257](https://github.com/WordPress/gutenberg/pull/54257)).
 -   `BorderControl`: Apply proper metrics and simpler text ([#53998](https://github.com/WordPress/gutenberg/pull/53998)).
+-   `Tooltip`: Add new `hideOnClick` prop ([#54406](https://github.com/WordPress/gutenberg/pull/54406)).
 
 ### Bug Fix
 

--- a/packages/components/src/tooltip/README.md
+++ b/packages/components/src/tooltip/README.md
@@ -35,6 +35,13 @@ The amount of time in milliseconds to wait before showing the tooltip.
 -   Required: No
 -   Default: `700`
 
+#### `hideOnClick`: `boolean`
+
+Option to hide the tooltip when the anchor is clicked.
+
+-   Required: No
+-   Default: `true`
+
 #### `position`: `string`
 
 The direction in which the tooltip should open relative to its parent node. Specify y- and x-axis as a space-separated string. Supports `"top"`, `"middle"`, `"bottom"` y axis, and `"left"`, `"center"`, `"right"` x axis.

--- a/packages/components/src/tooltip/index.tsx
+++ b/packages/components/src/tooltip/index.tsx
@@ -25,6 +25,7 @@ function Tooltip( props: TooltipProps ) {
 	const {
 		children,
 		delay = TOOLTIP_DELAY,
+		hideOnClick = true,
 		position = 'bottom',
 		shortcut,
 		text,
@@ -55,7 +56,7 @@ function Tooltip( props: TooltipProps ) {
 		<>
 			<Ariakit.TooltipAnchor
 				onBlur={ tooltipStore.hide }
-				onClick={ tooltipStore.hide }
+				onClick={ hideOnClick ? tooltipStore.hide : undefined }
 				store={ tooltipStore }
 				render={ isOnlyChild ? children : undefined }
 			>

--- a/packages/components/src/tooltip/test/index.tsx
+++ b/packages/components/src/tooltip/test/index.tsx
@@ -310,4 +310,26 @@ describe( 'Tooltip', () => {
 			await screen.findByRole( 'button', { description: 'tooltip text' } )
 		).toBeInTheDocument();
 	} );
+
+	it( 'should not hide tooltip when the anchor is clicked if hideOnClick is false', async () => {
+		const user = userEvent.setup();
+
+		render( <Tooltip { ...props } hideOnClick={ false } /> );
+
+		const button = screen.getByRole( 'button', { name: /Button/i } );
+
+		await user.hover( button );
+
+		expect(
+			await screen.findByRole( 'tooltip', { name: /tooltip text/i } )
+		).toBeVisible();
+
+		await user.click( button );
+
+		expect(
+			screen.getByRole( 'tooltip', { name: /tooltip text/i } )
+		).toBeVisible();
+
+		await cleanupTooltip( user );
+	} );
 } );

--- a/packages/components/src/tooltip/types.ts
+++ b/packages/components/src/tooltip/types.ts
@@ -12,6 +12,12 @@ export type TooltipProps = {
 	 */
 	children: React.ReactElement;
 	/**
+	 * Option to hide the tooltip when the anchor is clicked.
+	 *
+	 * @default true
+	 */
+	hideOnClick?: boolean;
+	/**
 	 * The amount of time in milliseconds to wait before showing the tooltip.
 	 *
 	 * @default 700


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

While looking into replacing the `ui/tooltip` component, I came across a feature that isn't currently possible with our Tooltip component, due to legacy behavior where the tooltip is hidden on anchor click. This implementation of `ui/tooltip` can be found in ColorPicker and the feature by using the copy button: 

![Screen Recording 2023-09-12 at 5 51 30 PM](https://github.com/WordPress/gutenberg/assets/35543432/5ddd7dae-30b6-4359-809a-f2041b4806d5)

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

To make a more dynamic tooltip possible, like in the case of ColorPicker's copy button: 

https://github.com/WordPress/gutenberg/blob/0cf7898b5f251f9bb1b5c2f5f72b8e37016a6949/packages/components/src/color-picker/color-copy-button.tsx#L61-L63

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

To avoid a regression, an optional prop of `hideOnClick` with a default of `true` has been added. By default, it will behave the same as it does now, but there will be an option to hide the tooltip when the anchor. This will allow for possibilities like the abovementioned example. 

A test has been added to test the `false` case to ensure the behavior is as expected. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Ensure tests pass `npm run test:unit packages/components/src/tooltip/test/index.tsx`
2. `npm run storybook:dev`
3. See new prop and type
4. Toggle option and ensure tooltip is hidden on anchor click when `hideOnClick` is set to `true` and stays visible when `false`
