### PR TITLE
Navigation: Add ariaLabel block support

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -421,7 +421,7 @@ A collection of blocks that allow visitors to get around your site. ([Source](ht
 
 -	**Name:** core/navigation
 -	**Category:** theme
--	**Supports:** align (full, wide), inserter, interactivity, layout (allowSizingOnChildren, default, ~~allowInheriting~~, ~~allowSwitching~~, ~~allowVerticalAlignment~~), spacing (blockGap, units), typography (fontSize, lineHeight), ~~html~~
+-	**Supports:** align (full, wide), ariaLabel, inserter, interactivity, layout (allowSizingOnChildren, default, ~~allowInheriting~~, ~~allowSwitching~~, ~~allowVerticalAlignment~~), spacing (blockGap, units), typography (fontSize, lineHeight), ~~html~~
 -	**Attributes:** __unstableLocation, backgroundColor, customBackgroundColor, customOverlayBackgroundColor, customOverlayTextColor, customTextColor, hasIcon, icon, maxNestingLevel, openSubmenusOnClick, overlayBackgroundColor, overlayMenu, overlayTextColor, ref, rgbBackgroundColor, rgbTextColor, showSubmenuIcon, templateLock, textColor
 
 ## Custom Link

--- a/packages/block-library/src/navigation/block.json
+++ b/packages/block-library/src/navigation/block.json
@@ -91,6 +91,7 @@
 	},
 	"supports": {
 		"align": [ "wide", "full" ],
+		"ariaLabel": true,
 		"html": false,
 		"inserter": true,
 		"typography": {

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -393,7 +393,6 @@ function render_block_core_navigation( $attributes, $content, $block ) {
 	// a fallback (i.e. the block has no menu associated with it).
 	$is_fallback = false;
 
-	// Check for manually entered aria-labels:
 	$nav_menu_name = isset( $attributes['ariaLabel'] ) ? $attributes['ariaLabel'] : '';
 
 	/**

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -393,7 +393,8 @@ function render_block_core_navigation( $attributes, $content, $block ) {
 	// a fallback (i.e. the block has no menu associated with it).
 	$is_fallback = false;
 
-	$nav_menu_name = '';
+	// Check for manually entered aria-labels:
+	$nav_menu_name = isset( $attributes['ariaLabel'] ) ? $attributes['ariaLabel'] : '';
 
 	/**
 	 * Deprecated:

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -393,7 +393,7 @@ function render_block_core_navigation( $attributes, $content, $block ) {
 	// a fallback (i.e. the block has no menu associated with it).
 	$is_fallback = false;
 
-	$nav_menu_name = isset( $attributes['ariaLabel'] ) ? $attributes['ariaLabel'] : '';
+	$nav_menu_name = $attributes['ariaLabel'] ?? '';
 
 	/**
 	 * Deprecated:


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
This PR enables the `ariaLabel` block support for the navigation block. This allows developers to manually add an aria-label to the `<nav>` element when they are using placeholder links and not an existing _menu._ 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
In Twenty Twenty-Four, the footer design has a 3 column menu, each column uses its own navigation block.
Each navigation block has placeholder links in the markup. To improve the accessibility, the three `<nav>` elements need to be differentiated and identifiable: they need an aria-label.

See https://github.com/WordPress/twentytwentyfour/pull/345

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Enables the ariaLabel block support in block.json.
Adds a condition that populates a variable in the index.php file with the ariaLabel attribute, if it is set.

This allows developers to include the aria-label in the following format:

`"ariaLabel":"Custom label here"`

```
<!-- wp:navigation {"overlayMenu":"never","layout":{"type":"flex","orientation":"vertical"},"style":{"typography":{"fontStyle":"normal","fontWeight":"400"}},"fontSize":"small","ariaLabel":"Custom label here"} -->

<!-- wp:navigation-link {"label":"Team","url":"#"} /-->
<!-- wp:navigation-link {"label":"History","url":"#"} /-->
<!-- wp:navigation-link {"label":"Careers","url":"#"} /-->

<!-- /wp:navigation -->
```

And when the user updates the navigation block to use a _menu_ the correct aria-label, the menu name,  will be used because it will override the manually entered value.

## Testing Instructions
Please add the example code above to your theme. Either to a block theme template,
or copy and paste the code into the code editor in a post or page.
View the navigation on the front of the website, view the HTML source, and confirm if the label is printed correctly.

Next, please test that the aria-label still works correctly for a regular navigation block with a _menu_ assigned to it:
Add a new navigation block, create a menu, note the name of the menu in the Advanced panel, save, and view the navigation on the front.  View the HTML source, and confirm if the label is printed correctly.
