### PR TITLE
Followup to #54206

### DIFF
--- a/packages/block-library/src/button/block.json
+++ b/packages/block-library/src/button/block.json
@@ -11,6 +11,7 @@
 	"attributes": {
 		"tagName": {
 			"type": "string",
+			"enum": [ "a", "button" ],
 			"default": "a"
 		},
 		"type": {

--- a/packages/block-library/src/button/edit.js
+++ b/packages/block-library/src/button/edit.js
@@ -139,6 +139,7 @@ function ButtonEdit( props ) {
 	const [ isEditingURL, setIsEditingURL ] = useState( false );
 	const isURLSet = !! url;
 	const opensInNewTab = linkTarget === '_blank';
+	const isLinkTag = 'a' === TagName;
 
 	function startEditing( event ) {
 		event.preventDefault();
@@ -220,7 +221,7 @@ function ButtonEdit( props ) {
 						setAttributes( { textAlign: nextAlign } );
 					} }
 				/>
-				{ ! isURLSet && 'a' === TagName && (
+				{ ! isURLSet && isLinkTag && (
 					<ToolbarButton
 						name="link"
 						icon={ link }
@@ -229,7 +230,7 @@ function ButtonEdit( props ) {
 						onClick={ startEditing }
 					/>
 				) }
-				{ isURLSet && 'a' === TagName && (
+				{ isURLSet && isLinkTag && (
 					<ToolbarButton
 						name="link"
 						icon={ linkOff }
@@ -240,7 +241,7 @@ function ButtonEdit( props ) {
 					/>
 				) }
 			</BlockControls>
-			{ 'a' === TagName && isSelected && ( isEditingURL || isURLSet ) && (
+			{ isLinkTag && isSelected && ( isEditingURL || isURLSet ) && (
 				<Popover
 					placement="bottom"
 					onClose={ () => {
@@ -279,7 +280,7 @@ function ButtonEdit( props ) {
 				/>
 			</InspectorControls>
 			<InspectorControls group="advanced">
-				{ 'a' === TagName && (
+				{ isLinkTag && (
 					<TextControl
 						__nextHasNoMarginBottom
 						label={ __( 'Link rel' ) }

--- a/packages/block-library/src/button/save.js
+++ b/packages/block-library/src/button/save.js
@@ -35,6 +35,7 @@ export default function save( { attributes, className } ) {
 	}
 
 	const TagName = tagName || 'a';
+	const isButtonTag = 'button' === TagName;
 	const buttonType = type || 'button';
 	const borderProps = getBorderClassesAndStyles( attributes );
 	const colorProps = getColorClassesAndStyles( attributes );
@@ -70,14 +71,14 @@ export default function save( { attributes, className } ) {
 		<div { ...useBlockProps.save( { className: wrapperClasses } ) }>
 			<RichText.Content
 				tagName={ TagName }
-				type={ 'button' === TagName ? buttonType : null }
+				type={ isButtonTag ? buttonType : null }
 				className={ buttonClasses }
-				href={ 'button' === TagName ? null : url }
+				href={ isButtonTag ? null : url }
 				title={ title }
 				style={ buttonStyle }
 				value={ text }
-				target={ 'button' === TagName ? null : linkTarget }
-				rel={ 'button' === TagName ? null : rel }
+				target={ isButtonTag ? null : linkTarget }
+				rel={ isButtonTag ? null : rel }
 			/>
 		</div>
 	);


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This is a followup to https://github.com/WordPress/gutenberg/pull/54206 with code improvements that came in a review _after_ the PR was merged

## Why?
Minor code-quality improvements

## How?
* [Add `isLinkTag` const to avoid code duplication](https://github.com/WordPress/gutenberg/commit/9e5d4407632bf1a54baf7aac09f4339f7c6b696e)
* [Add `isButtonTag` const to avoid code duplication](https://github.com/WordPress/gutenberg/pull/54419/commits/8457a87d72d5315af26857d325a2d14e352e66e9)
* [Add `enum` to the `tagName` definition in `block.json`](https://github.com/WordPress/gutenberg/pull/54419/commits/2934addc6e764ca47f2a0179e7d3564186c5896e)

## Testing Instructions
Nothing to test. If automated tests pass, we're OK.

### Testing Instructions for Keyboard
Nothing to test.