### PR TITLE
getClientIdsOfDescendants: Support single 'clientId' as a argument

### DIFF
--- a/docs/reference-guides/data/data-core-block-editor.md
+++ b/docs/reference-guides/data/data-core-block-editor.md
@@ -473,11 +473,11 @@ Returns an array containing the clientIds of all descendants of the blocks given
 _Parameters_
 
 -   _state_ `Object`: Global application state.
--   _clientIds_ `Array`: Array of blocks to inspect.
+-   _clientIds_ `string|string[]`: Client ID(s) for which descendant blocks are to be returned.
 
 _Returns_
 
--   `Array`: ids of descendants.
+-   `Array`: Client IDs of descendants.
 
 ### getClientIdsWithDescendants
 

--- a/packages/block-editor/src/components/block-inspector/index.js
+++ b/packages/block-editor/src/components/block-inspector/index.js
@@ -39,7 +39,7 @@ function BlockInspectorLockedBlocks( { topLevelLockedBlock } ) {
 				getBlockName,
 				getBlockEditingMode,
 			} = select( blockEditorStore );
-			return getClientIdsOfDescendants( [ topLevelLockedBlock ] ).filter(
+			return getClientIdsOfDescendants( topLevelLockedBlock ).filter(
 				( clientId ) =>
 					getBlockName( clientId ) !== 'core/list-item' &&
 					getBlockEditingMode( clientId ) === 'contentOnly'

--- a/packages/block-editor/src/components/block-tools/block-selection-button.js
+++ b/packages/block-editor/src/components/block-tools/block-selection-button.js
@@ -165,7 +165,7 @@ function BlockSelectionButton( { clientId, rootClientId } ) {
 				selectedBlockClientId;
 		} else if ( navigateIn ) {
 			focusedBlockUid =
-				getClientIdsOfDescendants( [ selectedBlockClientId ] )[ 0 ] ??
+				getClientIdsOfDescendants( selectedBlockClientId )[ 0 ] ??
 				selectedBlockClientId;
 		}
 		const startingBlockClientId = hasBlockMovingClientId();

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -245,19 +245,20 @@ export const __unstableGetClientIdsTree = createSelector(
  * given. Returned ids are ordered first by the order of the ids given, then
  * by the order that they appear in the editor.
  *
- * @param {Object} state     Global application state.
- * @param {Array}  clientIds Array of blocks to inspect.
+ * @param {Object}          state     Global application state.
+ * @param {string|string[]} clientIds Client ID(s) for which descendant blocks are to be returned.
  *
- * @return {Array} ids of descendants.
+ * @return {Array} Client IDs of descendants.
  */
 export const getClientIdsOfDescendants = createSelector(
 	( state, clientIds ) => {
+		const givenIds = Array.isArray( clientIds ) ? clientIds : [ clientIds ];
 		const collectedIds = [];
-		for ( const givenId of clientIds ) {
+		for ( const givenId of givenIds ) {
 			for ( const descendantId of getBlockOrder( state, givenId ) ) {
 				collectedIds.push(
 					descendantId,
-					...getClientIdsOfDescendants( state, [ descendantId ] )
+					...getClientIdsOfDescendants( state, descendantId )
 				);
 			}
 		}
@@ -281,7 +282,7 @@ export const getClientIdsWithDescendants = createSelector(
 		for ( const topLevelId of getBlockOrder( state ) ) {
 			collectedIds.push(
 				topLevelId,
-				...getClientIdsOfDescendants( state, [ topLevelId ] )
+				...getClientIdsOfDescendants( state, topLevelId )
 			);
 		}
 		return collectedIds;

--- a/packages/block-editor/src/store/test/selectors.js
+++ b/packages/block-editor/src/store/test/selectors.js
@@ -526,130 +526,131 @@ describe( 'selectors', () => {
 	} );
 
 	describe( 'getClientIdsOfDescendants', () => {
+		const state = {
+			blocks: {
+				byClientId: new Map(
+					Object.entries( {
+						'uuid-2': {
+							clientId: 'uuid-2',
+							name: 'core/image',
+						},
+						'uuid-4': {
+							clientId: 'uuid-4',
+							name: 'core/paragraph',
+						},
+						'uuid-6': {
+							clientId: 'uuid-6',
+							name: 'core/paragraph',
+						},
+						'uuid-8': {
+							clientId: 'uuid-8',
+							name: 'core/block',
+						},
+						'uuid-10': {
+							clientId: 'uuid-10',
+							name: 'core/columns',
+						},
+						'uuid-12': {
+							clientId: 'uuid-12',
+							name: 'core/column',
+						},
+						'uuid-14': {
+							clientId: 'uuid-14',
+							name: 'core/column',
+						},
+						'uuid-16': {
+							clientId: 'uuid-16',
+							name: 'core/quote',
+						},
+						'uuid-18': {
+							clientId: 'uuid-18',
+							name: 'core/block',
+						},
+						'uuid-20': {
+							clientId: 'uuid-20',
+							name: 'core/gallery',
+						},
+						'uuid-22': {
+							clientId: 'uuid-22',
+							name: 'core/block',
+						},
+						'uuid-24': {
+							clientId: 'uuid-24',
+							name: 'core/columns',
+						},
+						'uuid-26': {
+							clientId: 'uuid-26',
+							name: 'core/column',
+						},
+						'uuid-28': {
+							clientId: 'uuid-28',
+							name: 'core/column',
+						},
+						'uuid-30': {
+							clientId: 'uuid-30',
+							name: 'core/paragraph',
+						},
+					} )
+				),
+				attributes: new Map(
+					Object.entries( {
+						'uuid-2': {},
+						'uuid-4': {},
+						'uuid-6': {},
+						'uuid-8': {},
+						'uuid-10': {},
+						'uuid-12': {},
+						'uuid-14': {},
+						'uuid-16': {},
+						'uuid-18': {},
+						'uuid-20': {},
+						'uuid-22': {},
+						'uuid-24': {},
+						'uuid-26': {},
+						'uuid-28': {},
+						'uuid-30': {},
+					} )
+				),
+				order: new Map(
+					Object.entries( {
+						'': [ 'uuid-6', 'uuid-8', 'uuid-10', 'uuid-22' ],
+						'uuid-2': [],
+						'uuid-4': [],
+						'uuid-6': [],
+						'uuid-8': [],
+						'uuid-10': [ 'uuid-12', 'uuid-14' ],
+						'uuid-12': [ 'uuid-16' ],
+						'uuid-14': [ 'uuid-18' ],
+						'uuid-16': [],
+						'uuid-18': [ 'uuid-24' ],
+						'uuid-20': [],
+						'uuid-22': [],
+						'uuid-24': [ 'uuid-26', 'uuid-28' ],
+						'uuid-26': [],
+						'uuid-28': [ 'uuid-30' ],
+					} )
+				),
+				parents: new Map(
+					Object.entries( {
+						'uuid-6': '',
+						'uuid-8': '',
+						'uuid-10': '',
+						'uuid-22': '',
+						'uuid-12': 'uuid-10',
+						'uuid-14': 'uuid-10',
+						'uuid-16': 'uuid-12',
+						'uuid-18': 'uuid-14',
+						'uuid-24': 'uuid-18',
+						'uuid-26': 'uuid-24',
+						'uuid-28': 'uuid-24',
+						'uuid-30': 'uuid-28',
+					} )
+				),
+				controlledInnerBlocks: {},
+			},
+		};
+
 		it( 'should return the ids of any descendants in sequential order, given an array of clientIds', () => {
-			const state = {
-				blocks: {
-					byClientId: new Map(
-						Object.entries( {
-							'uuid-2': {
-								clientId: 'uuid-2',
-								name: 'core/image',
-							},
-							'uuid-4': {
-								clientId: 'uuid-4',
-								name: 'core/paragraph',
-							},
-							'uuid-6': {
-								clientId: 'uuid-6',
-								name: 'core/paragraph',
-							},
-							'uuid-8': {
-								clientId: 'uuid-8',
-								name: 'core/block',
-							},
-							'uuid-10': {
-								clientId: 'uuid-10',
-								name: 'core/columns',
-							},
-							'uuid-12': {
-								clientId: 'uuid-12',
-								name: 'core/column',
-							},
-							'uuid-14': {
-								clientId: 'uuid-14',
-								name: 'core/column',
-							},
-							'uuid-16': {
-								clientId: 'uuid-16',
-								name: 'core/quote',
-							},
-							'uuid-18': {
-								clientId: 'uuid-18',
-								name: 'core/block',
-							},
-							'uuid-20': {
-								clientId: 'uuid-20',
-								name: 'core/gallery',
-							},
-							'uuid-22': {
-								clientId: 'uuid-22',
-								name: 'core/block',
-							},
-							'uuid-24': {
-								clientId: 'uuid-24',
-								name: 'core/columns',
-							},
-							'uuid-26': {
-								clientId: 'uuid-26',
-								name: 'core/column',
-							},
-							'uuid-28': {
-								clientId: 'uuid-28',
-								name: 'core/column',
-							},
-							'uuid-30': {
-								clientId: 'uuid-30',
-								name: 'core/paragraph',
-							},
-						} )
-					),
-					attributes: new Map(
-						Object.entries( {
-							'uuid-2': {},
-							'uuid-4': {},
-							'uuid-6': {},
-							'uuid-8': {},
-							'uuid-10': {},
-							'uuid-12': {},
-							'uuid-14': {},
-							'uuid-16': {},
-							'uuid-18': {},
-							'uuid-20': {},
-							'uuid-22': {},
-							'uuid-24': {},
-							'uuid-26': {},
-							'uuid-28': {},
-							'uuid-30': {},
-						} )
-					),
-					order: new Map(
-						Object.entries( {
-							'': [ 'uuid-6', 'uuid-8', 'uuid-10', 'uuid-22' ],
-							'uuid-2': [],
-							'uuid-4': [],
-							'uuid-6': [],
-							'uuid-8': [],
-							'uuid-10': [ 'uuid-12', 'uuid-14' ],
-							'uuid-12': [ 'uuid-16' ],
-							'uuid-14': [ 'uuid-18' ],
-							'uuid-16': [],
-							'uuid-18': [ 'uuid-24' ],
-							'uuid-20': [],
-							'uuid-22': [],
-							'uuid-24': [ 'uuid-26', 'uuid-28' ],
-							'uuid-26': [],
-							'uuid-28': [ 'uuid-30' ],
-						} )
-					),
-					parents: new Map(
-						Object.entries( {
-							'uuid-6': '',
-							'uuid-8': '',
-							'uuid-10': '',
-							'uuid-22': '',
-							'uuid-12': 'uuid-10',
-							'uuid-14': 'uuid-10',
-							'uuid-16': 'uuid-12',
-							'uuid-18': 'uuid-14',
-							'uuid-24': 'uuid-18',
-							'uuid-26': 'uuid-24',
-							'uuid-28': 'uuid-24',
-							'uuid-30': 'uuid-28',
-						} )
-					),
-					controlledInnerBlocks: {},
-				},
-			};
 			expect( getClientIdsOfDescendants( state, [ 'uuid-10' ] ) ).toEqual(
 				[
 					'uuid-12',
@@ -661,6 +662,12 @@ describe( 'selectors', () => {
 					'uuid-28',
 					'uuid-30',
 				]
+			);
+		} );
+
+		it( 'should return same value when called with same state and argument', () => {
+			expect( getClientIdsOfDescendants( state, 'uuid-10' ) ).toBe(
+				getClientIdsOfDescendants( state, 'uuid-10' )
 			);
 		} );
 	} );

--- a/packages/block-library/src/query/utils.js
+++ b/packages/block-library/src/query/utils.js
@@ -352,13 +352,17 @@ export const usePatterns = ( clientId, name ) => {
  * @param {string} clientId The block's client ID.
  * @return {boolean} True if it contains third-party blocks.
  */
-export const useContainsThirdPartyBlocks = ( clientId ) =>
-	useSelect( ( select ) => {
-		const { getClientIdsOfDescendants, getBlockName } =
-			select( blockEditorStore );
+export const useContainsThirdPartyBlocks = ( clientId ) => {
+	return useSelect(
+		( select ) => {
+			const { getClientIdsOfDescendants, getBlockName } =
+				select( blockEditorStore );
 
-		return getClientIdsOfDescendants( [ clientId ] ).some(
-			( descendantClientId ) =>
-				! getBlockName( descendantClientId ).startsWith( 'core/' )
-		);
-	} );
+			return getClientIdsOfDescendants( clientId ).some(
+				( descendantClientId ) =>
+					! getBlockName( descendantClientId ).startsWith( 'core/' )
+			);
+		},
+		[ clientId ]
+	);
+};


### PR DESCRIPTION
## What?
PR updates the `getClientIdsOfDescendants` selector to accept a single `clientId` as an argument by internally handling casting to an array.

Matches behavior of `getBlocksByClientId` and a few other memoized selectors.

## Why?
There are usages in the core where the consumers that call `getClientIdsOfDescendants` only have a single `clientId` and must cast it to an array before passing the argument. Passing a new argument on each call results in the selector recalculating its value instead of returning it from the cache, even though the ID hasn't changed.

## Testing Instructions
* CI checks should be green.
* Smoke test editors for any errors.

### Testing Instructions for Keyboard
Same.
