### PR TITLE
Follow up visual tweaks to block-specific commands

### DIFF
--- a/packages/block-editor/src/components/use-block-commands/index.js
+++ b/packages/block-editor/src/components/use-block-commands/index.js
@@ -230,7 +230,7 @@ const useActionsCommands = () => {
 	if ( canRemove ) {
 		commands.push( {
 			name: 'remove',
-			label: __( 'Remove' ),
+			label: __( 'Delete' ),
 			callback: () => removeBlocks( clientIds, true ),
 			icon: remove,
 		} );

--- a/packages/block-editor/src/components/use-block-commands/index.js
+++ b/packages/block-editor/src/components/use-block-commands/index.js
@@ -12,8 +12,8 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import { useCommandLoader } from '@wordpress/commands';
 import {
 	copy,
-	edit as remove,
-	create as add,
+	trash as remove,
+	plus as add,
 	group,
 	ungroup,
 	moveTo as move,


### PR DESCRIPTION
Fixes #53538

## Screenshots or screencast

<img width="590" alt="Screenshot 2023-09-13 at 8 57 36 AM" src="https://github.com/WordPress/gutenberg/assets/375788/1d2f0a48-2744-42ea-8910-de14df7ecdba">

<img width="527" alt="Screenshot 2023-09-13 at 9 05 59 AM" src="https://github.com/WordPress/gutenberg/assets/375788/08bda6db-078b-4717-8e54-6400daa90092">