### PR TITLE
Revert "Export ProgressBar to allow it to be used"

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 ## Unreleased
 -   `BorderControl`: Apply proper metrics and simpler text ([#53998](https://github.com/WordPress/gutenberg/pull/53998)).
--   `ProgressBar`: Export component to allow it to be used ([#54404](https://github.com/WordPress/gutenberg/pull/54404)).
 
 ### Enhancements
 

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -132,7 +132,6 @@ export { default as PanelHeader } from './panel/header';
 export { default as PanelRow } from './panel/row';
 export { default as Placeholder } from './placeholder';
 export { default as Popover } from './popover';
-export { default as __experimentalProgressBar } from './progress-bar';
 export { default as QueryControls } from './query-controls';
 export { default as __experimentalRadio } from './radio-group/radio';
 export { default as __experimentalRadioGroup } from './radio-group';


### PR DESCRIPTION
Reverts WordPress/gutenberg#54404

See explanation from https://github.com/WordPress/gutenberg/pull/54404#issuecomment-1717601330

cc @matiasbenedetto 