### PR TITLE
Use standard focus style on BorderControl 

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -19,6 +19,7 @@
 -   `ToolbarItem`: Fix children not showing in rendered components ([#53314](https://github.com/WordPress/gutenberg/pull/53314)).
 -   `CircularOptionPicker`: make focus styles resilient to button size changes ([#54196](https://github.com/WordPress/gutenberg/pull/54196)).
 -   `InputControl`: Fix focus style size ([#54394](https://github.com/WordPress/gutenberg/pull/54394)).
+-   `BorderControl`: Use standard focus style on BorderControl ([#54429](https://github.com/WordPress/gutenberg/pull/54429)).
 
 ### Internal
 

--- a/packages/components/src/border-control/styles.ts
+++ b/packages/components/src/border-control/styles.ts
@@ -21,7 +21,7 @@ const labelStyles = css`
 `;
 
 const focusBoxShadow = css`
-	box-shadow: inset 0 0 0 ${ CONFIG.borderWidth } ${ COLORS.ui.borderFocus };
+	box-shadow: inset ${ CONFIG.controlBoxShadowFocus };
 `;
 
 export const borderControl = css`


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
I checked through the other use cases of COLORS.ui.borderFocus, as part of a follow-up to #54394. I identified one small fix within BorderControl. 

It's better, but still not ideal. 

## Testing Instructions
1. Add a group block. 
2. Interact with the border controls. 

## Screenshots or screencast <!-- if applicable -->


| Before  | After |
| ------------- | ------------- |
|<img width="279" alt="CleanShot 2023-09-13 at 09 29 53" src="https://github.com/WordPress/gutenberg/assets/1813435/bed4002e-5078-415e-acc4-3bfbcffd04ce"><img width="278" alt="CleanShot 2023-09-13 at 09 29 44" src="https://github.com/WordPress/gutenberg/assets/1813435/22a626b1-be0e-4230-a7db-3e5960161fa1">|<img width="278" alt="CleanShot 2023-09-13 at 09 28 43" src="https://github.com/WordPress/gutenberg/assets/1813435/33ce09d5-318f-43fd-882e-7cbb81ac6136"><img width="280" alt="CleanShot 2023-09-13 at 09 28 57" src="https://github.com/WordPress/gutenberg/assets/1813435/3212af07-f274-49de-af11-3620d6b27f32">|


