### PR TITLE
PageAttributesParent: A minor fixes for useSelect and useMemo hook usages

### DIFF
--- a/packages/editor/src/components/page-attributes/parent.js
+++ b/packages/editor/src/components/page-attributes/parent.js
@@ -43,44 +43,47 @@ export const getItemPriority = ( name, searchValue ) => {
 export function PageAttributesParent() {
 	const { editPost } = useDispatch( editorStore );
 	const [ fieldValue, setFieldValue ] = useState( false );
-	const { isHierarchical, parentPost, parentPostId, pageItems } = useSelect(
-		( select ) => {
-			const { getPostType, getEntityRecords, getEntityRecord } =
-				select( coreStore );
-			const { getCurrentPostId, getEditedPostAttribute } =
-				select( editorStore );
-			const postTypeSlug = getEditedPostAttribute( 'type' );
-			const pageId = getEditedPostAttribute( 'parent' );
-			const pType = getPostType( postTypeSlug );
-			const postId = getCurrentPostId();
-			const postIsHierarchical = pType?.hierarchical ?? false;
-			const query = {
-				per_page: 100,
-				exclude: postId,
-				parent_exclude: postId,
-				orderby: 'menu_order',
-				order: 'asc',
-				_fields: 'id,title,parent',
-			};
+	const { isHierarchical, parentPostId, parentPostTitle, pageItems } =
+		useSelect(
+			( select ) => {
+				const { getPostType, getEntityRecords, getEntityRecord } =
+					select( coreStore );
+				const { getCurrentPostId, getEditedPostAttribute } =
+					select( editorStore );
+				const postTypeSlug = getEditedPostAttribute( 'type' );
+				const pageId = getEditedPostAttribute( 'parent' );
+				const pType = getPostType( postTypeSlug );
+				const postId = getCurrentPostId();
+				const postIsHierarchical = pType?.hierarchical ?? false;
+				const query = {
+					per_page: 100,
+					exclude: postId,
+					parent_exclude: postId,
+					orderby: 'menu_order',
+					order: 'asc',
+					_fields: 'id,title,parent',
+				};
 
-			// Perform a search when the field is changed.
-			if ( !! fieldValue ) {
-				query.search = fieldValue;
-			}
+				// Perform a search when the field is changed.
+				if ( !! fieldValue ) {
+					query.search = fieldValue;
+				}
 
-			return {
-				isHierarchical: postIsHierarchical,
-				parentPostId: pageId,
-				parentPost: pageId
+				const parentPost = pageId
 					? getEntityRecord( 'postType', postTypeSlug, pageId )
-					: null,
-				pageItems: postIsHierarchical
-					? getEntityRecords( 'postType', postTypeSlug, query )
-					: null,
-			};
-		},
-		[ fieldValue ]
-	);
+					: null;
+
+				return {
+					isHierarchical: postIsHierarchical,
+					parentPostId: pageId,
+					parentPostTitle: parentPost ? getTitle( parentPost ) : '',
+					pageItems: postIsHierarchical
+						? getEntityRecords( 'postType', postTypeSlug, query )
+						: null,
+				};
+			},
+			[ fieldValue ]
+		);
 
 	const parentOptions = useMemo( () => {
 		const getOptionsFromTree = ( tree, level = 0 ) => {
@@ -124,14 +127,14 @@ export function PageAttributesParent() {
 		const optsHasParent = opts.find(
 			( item ) => item.value === parentPostId
 		);
-		if ( parentPost && ! optsHasParent ) {
+		if ( parentPostTitle && ! optsHasParent ) {
 			opts.unshift( {
 				value: parentPostId,
-				label: getTitle( parentPost ),
+				label: parentPostTitle,
 			} );
 		}
 		return opts;
-	}, [ pageItems, fieldValue, parentPost, parentPostId ] );
+	}, [ pageItems, fieldValue, parentPostTitle, parentPostId ] );
 
 	if ( ! isHierarchical ) {
 		return null;

--- a/packages/editor/src/components/page-attributes/parent.js
+++ b/packages/editor/src/components/page-attributes/parent.js
@@ -129,7 +129,7 @@ export function PageAttributesParent() {
 			} );
 		}
 		return opts;
-	}, [ pageItems, fieldValue ] );
+	}, [ pageItems, fieldValue, parentPost, parentPostId ] );
 
 	if ( ! isHierarchical ) {
 		return null;

--- a/packages/editor/src/components/page-attributes/parent.js
+++ b/packages/editor/src/components/page-attributes/parent.js
@@ -43,7 +43,7 @@ export const getItemPriority = ( name, searchValue ) => {
 export function PageAttributesParent() {
 	const { editPost } = useDispatch( editorStore );
 	const [ fieldValue, setFieldValue ] = useState( false );
-	const { isHierarchical, parentPost, parentPostId, items } = useSelect(
+	const { isHierarchical, parentPost, parentPostId, pageItems } = useSelect(
 		( select ) => {
 			const { getPostType, getEntityRecords, getEntityRecord } =
 				select( coreStore );
@@ -74,15 +74,13 @@ export function PageAttributesParent() {
 				parentPost: pageId
 					? getEntityRecord( 'postType', postTypeSlug, pageId )
 					: null,
-				items: postIsHierarchical
+				pageItems: postIsHierarchical
 					? getEntityRecords( 'postType', postTypeSlug, query )
-					: [],
+					: null,
 			};
 		},
 		[ fieldValue ]
 	);
-
-	const pageItems = items || [];
 
 	const parentOptions = useMemo( () => {
 		const getOptionsFromTree = ( tree, level = 0 ) => {
@@ -104,6 +102,10 @@ export function PageAttributesParent() {
 
 			return sortedNodes.flat();
 		};
+
+		if ( ! pageItems ) {
+			return [];
+		}
 
 		let tree = pageItems.map( ( item ) => ( {
 			id: item.id,


### PR DESCRIPTION
## What?
PR fixes the following issues for the `PageAttributesParent` component.

* Avoid returning a new array instance on every `mapSelect` call when the post type isn't hierarchical - 448a92e209facb45d0f56372a88649aee6843089.
* Fix `useMemo` dependency warnings - c48fad5f5915779e0693e96bd281e8e70e651713.
* Only return parent post title, since whole post data isn't used anywhere - c22a8d29660bb252b1d1b32adb3536b35445e61d.

## Why?

I noticed a notice when viewing the post type that has `page-attributes` enabled.

## Testing Instructions
1. Enabled Page Attributes for posts.
2. Open or create a post.
3. Confirm there's no `useSelect` notice in the console.
4. Open a page.
5. Confirm you can select parent as before. I think this is also covered by e2e tests.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2023-09-13 at 19 33 08](https://github.com/WordPress/gutenberg/assets/240569/7db748e6-b02a-463a-93a8-d4559a48c327)
