### PR TITLE
#53826 register variations in a later init hook

### DIFF
--- a/packages/block-library/src/navigation-link/index.php
+++ b/packages/block-library/src/navigation-link/index.php
@@ -329,6 +329,26 @@ function build_variation_for_navigation_link( $entity, $kind ) {
  * @throws WP_Error An WP_Error exception parsing the block definition.
  */
 function register_block_core_navigation_link() {
+	register_block_type_from_metadata(
+		__DIR__ . '/navigation-link',
+		array(
+			'render_callback' => 'render_block_core_navigation_link',
+		)
+	);
+}
+add_action( 'init', 'register_block_core_navigation_link' );
+
+/**
+ * Registers variations for taxonomies and post types.
+ * Runs on priority 1000, in which it's assumed all custom taxonomies and custom post types are registered.
+ * See 53826
+ */
+function register_block_core_navigation_link_variations() {
+	$navigation_block_type = WP_Block_Type_Registry::get_instance()->get_registered( 'core/navigation-link' );
+	if ( ! $navigation_block_type ) {
+		return;
+	}
+
 	$post_types = get_post_types( array( 'show_in_nav_menus' => true ), 'objects' );
 	$taxonomies = get_taxonomies( array( 'show_in_nav_menus' => true ), 'objects' );
 
@@ -360,12 +380,6 @@ function register_block_core_navigation_link() {
 		}
 	}
 
-	register_block_type_from_metadata(
-		__DIR__ . '/navigation-link',
-		array(
-			'render_callback' => 'render_block_core_navigation_link',
-			'variations'      => array_merge( $built_ins, $variations ),
-		)
-	);
+	$navigation_block_type->variations = array_merge( $navigation_block_type->variations, $built_ins, $variations );
 }
-add_action( 'init', 'register_block_core_navigation_link' );
+add_action( 'init', 'register_block_core_navigation_link_variations', 1000 );

--- a/packages/block-library/src/navigation-link/index.php
+++ b/packages/block-library/src/navigation-link/index.php
@@ -344,6 +344,8 @@ add_action( 'init', 'register_block_core_navigation_link' );
  * See 53826
  */
 function register_block_core_navigation_link_variations() {
+	// Directly set the variations on the registered block type
+	// because there's no server side registration for variations (see #47170).
 	$navigation_block_type = WP_Block_Type_Registry::get_instance()->get_registered( 'core/navigation-link' );
 	if ( ! $navigation_block_type ) {
 		return;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
This is a first try at fixing #53826.
I try to create the variations of the navigation link block for all taxonomies and post types in a seperate function hooked to init on priority 1000. 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
See #53826  - server side function runs too early to make sure it gets all custom taxonomies/post types by plugins, themes etc..

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
I just chose 1000 because I'd assume then most other plugins have registered their post types. I've seen plugins use 99, 100 etc - but I guess 1000 should be save. 
I'm using a seperate function and directly modify the registered `WP_Block_Type` instance. I'm not sure if that is really an intended way, but the properties of the class are public - so I guessed "yes".

Alternative solutions are described in the issue.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
### Custom Post Type
1. Register a custom post type ([example code from developer.wordpress.org](https://developer.wordpress.org/plugins/post-types/registering-custom-post-types/)).
```php
add_action('init', function () {
    register_post_type(
        'wporg_product',
        array(
            'labels'      => array(
                'name'          => __('Products', 'textdomain'),
                'singular_name' => __('Product', 'textdomain'),
                'item_link' => __('Product Link', 'textdomain')
            ),
            'public'      => true,
            'has_archive' => true,
            'show_in_rest' => true,
            'show_in_nav_menus' => true
        )
    );
}, 9);
```
Important: Set the item_link label or the block variation is called Post Link.
Important: change add_action priority to something lower than 10 (eg 9)
2. Go into site-editor and add a navigation block
3. try to search for a block named like the custom taxonomy (eg "Product Link").
4. Block is available

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
