### PR TITLE
Font Library: ensure merged fontFace data is enconded as an array instead of an object

### DIFF
--- a/lib/experimental/fonts/font-library/class-wp-font-family-utils.php
+++ b/lib/experimental/fonts/font-library/class-wp-font-family-utils.php
@@ -71,7 +71,7 @@ class WP_Font_Family_Utils {
 		$unique_faces            = array_map( 'unserialize', $unique_serialized_faces );
 
 		$merged_font             = array_merge( $font1, $font2 );
-		$merged_font['fontFace'] = $unique_faces;
+		$merged_font['fontFace'] = array_values( $unique_faces );
 
 		return $merged_font;
 	}

--- a/phpunit/tests/fonts/font-library/wpFontFamilyUtils/mergeFontsData.php
+++ b/phpunit/tests/fonts/font-library/wpFontFamilyUtils/mergeFontsData.php
@@ -78,8 +78,8 @@ class Tests_Fonts_WpFontsFamilyUtils_MergeFontsData extends WP_UnitTestCase {
 	public function test_should_merge( array $font1, array $font2, array $expected_result ) {
 		$result = WP_Font_Family_Utils::merge_fonts_data( $font1, $font2 );
 		$this->assertSame( $expected_result, $result, 'Merged font data should match expected result.' );
-		$json_result  = wp_json_encode( $result );
-		$this->assertStringContainsString('"fontFace":[', $json_result, 'fontFace data should be enconded as an array and not an object.' );
+		$json_result = wp_json_encode( $result );
+		$this->assertStringContainsString( '"fontFace":[', $json_result, 'fontFace data should be enconded as an array and not an object.' );
 	}
 
 	/**
@@ -230,7 +230,7 @@ class Tests_Fonts_WpFontsFamilyUtils_MergeFontsData extends WP_UnitTestCase {
 					),
 				),
 			),
-			'repeated font faces with non consecutive index positions' => array (
+			'repeated font faces with non consecutive index positions' => array(
 				'font1'           => array(
 					'slug'       => 'piazzolla',
 					'name'       => 'Piazzolla',
@@ -294,7 +294,7 @@ class Tests_Fonts_WpFontsFamilyUtils_MergeFontsData extends WP_UnitTestCase {
 						),
 					),
 				),
-			)
+			),
 		);
 	}
 }

--- a/phpunit/tests/fonts/font-library/wpFontFamilyUtils/mergeFontsData.php
+++ b/phpunit/tests/fonts/font-library/wpFontFamilyUtils/mergeFontsData.php
@@ -76,9 +76,10 @@ class Tests_Fonts_WpFontsFamilyUtils_MergeFontsData extends WP_UnitTestCase {
 	 * @param array $expected_result Expected result.
 	 */
 	public function test_should_merge( array $font1, array $font2, array $expected_result ) {
-		$actual = WP_Font_Family_Utils::merge_fonts_data( $font1, $font2 );
-
-		$this->assertSame( $expected_result, $actual );
+		$result = WP_Font_Family_Utils::merge_fonts_data( $font1, $font2 );
+		$this->assertSame( $expected_result, $result, 'Merged font data should match expected result.' );
+		$json_result  = wp_json_encode( $result );
+		$this->assertStringContainsString('"fontFace":[', $json_result, 'fontFace data should be enconded as an array and not an object.' );
 	}
 
 	/**
@@ -229,6 +230,71 @@ class Tests_Fonts_WpFontsFamilyUtils_MergeFontsData extends WP_UnitTestCase {
 					),
 				),
 			),
+			'repeated font faces with non consecutive index positions' => array (
+				'font1'           => array(
+					'slug'       => 'piazzolla',
+					'name'       => 'Piazzolla',
+					'fontFamily' => 'Piazzolla',
+					'fontFace'   => array(
+						array(
+							'fontFamily' => 'Piazzolla',
+							'fontStyle'  => 'italic',
+							'fontWeight' => '400',
+							'src'        => 'http://example.com/fonts/piazzolla_400_italic.ttf',
+						),
+
+					),
+				),
+				'font2'           => array(
+					'slug'       => 'piazzolla',
+					'fontFamily' => 'Piazzolla',
+					'fontFace'   => array(
+						array(
+							'fontFamily' => 'Piazzolla',
+							'fontStyle'  => 'normal',
+							'fontWeight' => '600',
+							'src'        => 'http://example.com/fonts/piazzolla_600_normal.ttf',
+						),
+						array(
+							'fontFamily' => 'Piazzolla',
+							'fontStyle'  => 'italic',
+							'fontWeight' => '400',
+							'src'        => 'http://example.com/fonts/piazzolla_400_italic.ttf',
+						),
+						array(
+							'fontFamily' => 'Piazzolla',
+							'fontStyle'  => 'italic',
+							'fontWeight' => '500',
+							'src'        => 'http://example.com/fonts/piazzolla_500_italic.ttf',
+						),
+					),
+				),
+				'expected_result' => array(
+					'slug'       => 'piazzolla',
+					'name'       => 'Piazzolla',
+					'fontFamily' => 'Piazzolla',
+					'fontFace'   => array(
+						array(
+							'fontFamily' => 'Piazzolla',
+							'fontStyle'  => 'italic',
+							'fontWeight' => '400',
+							'src'        => 'http://example.com/fonts/piazzolla_400_italic.ttf',
+						),
+						array(
+							'fontFamily' => 'Piazzolla',
+							'fontStyle'  => 'normal',
+							'fontWeight' => '600',
+							'src'        => 'http://example.com/fonts/piazzolla_600_normal.ttf',
+						),
+						array(
+							'fontFamily' => 'Piazzolla',
+							'fontStyle'  => 'italic',
+							'fontWeight' => '500',
+							'src'        => 'http://example.com/fonts/piazzolla_500_italic.ttf',
+						),
+					),
+				),
+			)
 		);
 	}
 }


### PR DESCRIPTION
## What?
- Ensure merged fontFace data is JSON encoded as an array instead of an object.
- Add a test case to ensure that.

## Why?
To fix a bug consisting of fontFace data being JSON encoded as an object ( {...} ) instead of an array ( [...] ).


When we remove duplicates, we could end up with missing sequential array keys in the fontFace list.

Because of the nature of PHP arrays and how they are encoded into JSON. In PHP, arrays can behave like indexed arrays or associative arrays (hashmaps). When they are encoded into JSON, indexed arrays become JSON arrays (e.g., [...]), while associative arrays become JSON objects (e.g., {...}).

The reason fontFace is being encoded as an object in your JSON output is due to the non-sequential keys.



## How?
To ensure that fontFace is always encoded as a JSON array, I reset the keys of the `$unique_face`s array using `array_values()` before assigning it to `$merged_font['fontFace']`. This will reindex the keys and make sure they are sequential.

## Testing Instructions
Run PHP unit tests with and without calling `array_values()` on this line:
```
$merged_font['fontFace'] = array_values( $unique_faces );
```

```
$merged_font['fontFace'] =  $unique_faces;
```

The added test case should fail when `array_values()` is not used.