### PR TITLE
Navigation: Make the navigation selector larger and separate the create new option

### DIFF
--- a/packages/block-library/src/navigation/edit/menu-inspector-controls.js
+++ b/packages/block-library/src/navigation/edit/menu-inspector-controls.js
@@ -9,7 +9,6 @@ import {
 import {
 	PanelBody,
 	__experimentalHStack as HStack,
-	__experimentalHeading as Heading,
 	Spinner,
 } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
@@ -19,6 +18,7 @@ import { __, sprintf } from '@wordpress/i18n';
  * Internal dependencies
  */
 import NavigationMenuSelector from './navigation-menu-selector';
+import NavigationTools from './navigation-tools';
 import { unlock } from '../../lock-unlock';
 import DeletedNavigationWarning from './deleted-navigation-warning';
 import useNavigationMenu from '../use-navigation-menu';
@@ -144,29 +144,36 @@ const MenuInspectorControls = ( props ) => {
 		<InspectorControls group="list">
 			<PanelBody title={ null }>
 				<HStack className="wp-block-navigation-off-canvas-editor__header">
-					<Heading
-						className="wp-block-navigation-off-canvas-editor__title"
-						level={ 2 }
-					>
-						{ __( 'Menu' ) }
-					</Heading>
 					{ blockEditingMode === 'default' && (
-						<NavigationMenuSelector
-							currentMenuId={ currentMenuId }
-							onSelectClassicMenu={ onSelectClassicMenu }
-							onSelectNavigationMenu={ onSelectNavigationMenu }
-							onCreateNew={ onCreateNew }
-							createNavigationMenuIsSuccess={
-								createNavigationMenuIsSuccess
-							}
-							createNavigationMenuIsError={
-								createNavigationMenuIsError
-							}
-							actionLabel={ actionLabel }
-							isManageMenusButtonDisabled={
-								isManageMenusButtonDisabled
-							}
-						/>
+						<>
+							<NavigationMenuSelector
+								currentMenuId={ currentMenuId }
+								onSelectClassicMenu={ onSelectClassicMenu }
+								onSelectNavigationMenu={
+									onSelectNavigationMenu
+								}
+								onCreateNew={ onCreateNew }
+								createNavigationMenuIsSuccess={
+									createNavigationMenuIsSuccess
+								}
+								createNavigationMenuIsError={
+									createNavigationMenuIsError
+								}
+								actionLabel={ actionLabel }
+								isManageMenusButtonDisabled={
+									isManageMenusButtonDisabled
+								}
+							/>
+							<NavigationTools
+								onCreateNew={ onCreateNew }
+								createNavigationMenuIsSuccess={
+									createNavigationMenuIsSuccess
+								}
+								createNavigationMenuIsError={
+									createNavigationMenuIsError
+								}
+							/>
+						</>
 					) }
 				</HStack>
 				<MainContent { ...props } />

--- a/packages/block-library/src/navigation/edit/navigation-menu-selector.js
+++ b/packages/block-library/src/navigation/edit/navigation-menu-selector.js
@@ -7,7 +7,7 @@ import {
 	MenuItemsChoice,
 	DropdownMenu,
 } from '@wordpress/components';
-import { moreVertical } from '@wordpress/icons';
+import { chevronDown } from '@wordpress/icons';
 import { __, sprintf } from '@wordpress/i18n';
 import { decodeEntities } from '@wordpress/html-entities';
 import { useEffect, useMemo, useState } from '@wordpress/element';
@@ -41,7 +41,6 @@ function NavigationMenuSelector( {
 	currentMenuId,
 	onSelectNavigationMenu,
 	onSelectClassicMenu,
-	onCreateNew,
 	actionLabel,
 	createNavigationMenuIsSuccess,
 	createNavigationMenuIsError,
@@ -130,13 +129,14 @@ function NavigationMenuSelector( {
 	const NavigationMenuSelectorDropdown = (
 		<DropdownMenu
 			label={ selectorLabel }
-			icon={ moreVertical }
-			toggleProps={ { isSmall: true } }
+			icon={ chevronDown }
+			text={ currentTitle ? currentTitle : __( 'Navigation menu' ) }
+			toggleProps={ { iconPosition: 'right' } }
 		>
 			{ ( { onClose } ) => (
 				<>
 					{ showNavigationMenus && hasNavigationMenus && (
-						<MenuGroup label={ __( 'Menus' ) }>
+						<MenuGroup label={ __( 'Navigation Menus' ) }>
 							<MenuItemsChoice
 								value={ currentMenuId }
 								onSelect={ ( menuId ) => {
@@ -173,27 +173,22 @@ function NavigationMenuSelector( {
 							} ) }
 						</MenuGroup>
 					) }
-
-					{ canUserCreateNavigationMenu && (
-						<MenuGroup label={ __( 'Tools' ) }>
-							<MenuItem
-								disabled={ isCreatingMenu }
-								onClick={ () => {
-									onClose();
-									onCreateNew();
-									setIsCreatingMenu( true );
-								} }
-							>
-								{ __( 'Create new menu' ) }
-							</MenuItem>
-						</MenuGroup>
-					) }
 				</>
 			) }
 		</DropdownMenu>
 	);
 
-	return NavigationMenuSelectorDropdown;
+	// TODO If there are more than one...
+	if (
+		( showNavigationMenus &&
+			hasNavigationMenus &&
+			navigationMenus?.length > 1 ) ||
+		( showClassicMenus && hasClassicMenus )
+	) {
+		return NavigationMenuSelectorDropdown;
+	}
+
+	return currentTitle ? currentTitle : __( 'Navigation' );
 }
 
 export default NavigationMenuSelector;

--- a/packages/block-library/src/navigation/edit/navigation-tools.js
+++ b/packages/block-library/src/navigation/edit/navigation-tools.js
@@ -1,0 +1,64 @@
+/**
+ * WordPress dependencies
+ */
+import { MenuGroup, MenuItem, DropdownMenu } from '@wordpress/components';
+import { moreVertical } from '@wordpress/icons';
+import { __ } from '@wordpress/i18n';
+import { useEffect, useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import useNavigationMenu from '../use-navigation-menu';
+
+function NavigationTools( {
+	onCreateNew,
+	createNavigationMenuIsSuccess,
+	createNavigationMenuIsError,
+} ) {
+	const [ isCreatingMenu, setIsCreatingMenu ] = useState( false );
+
+	const { canUserCreateNavigationMenu } = useNavigationMenu();
+
+	useEffect( () => {
+		if (
+			isCreatingMenu &&
+			( createNavigationMenuIsSuccess || createNavigationMenuIsError )
+		) {
+			setIsCreatingMenu( false );
+		}
+	}, [
+		createNavigationMenuIsSuccess,
+		createNavigationMenuIsError,
+		isCreatingMenu,
+	] );
+
+	const NavigationMenuSelectorDropdown = (
+		<DropdownMenu
+			label={ __( 'Navigation Tools' ) }
+			icon={ moreVertical }
+			toggleProps={ { isSmall: 'true' } }
+		>
+			{ ( { onClose } ) =>
+				canUserCreateNavigationMenu && (
+					<MenuGroup>
+						<MenuItem
+							disabled={ isCreatingMenu }
+							onClick={ () => {
+								onClose();
+								onCreateNew();
+								setIsCreatingMenu( true );
+							} }
+						>
+							{ __( 'Create new menu' ) }
+						</MenuItem>
+					</MenuGroup>
+				)
+			}
+		</DropdownMenu>
+	);
+
+	return NavigationMenuSelectorDropdown;
+}
+
+export default NavigationTools;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This makes the navigation menu selector larger and more prominent in the sidebar, while keeping the "Create new menu" option under the three dots menu.

## Why?
This has a few of benefits:

1. It makes it easier for users to change their navigation if they want to.
2. It shows users the name of their selected navigation more prominently.
3. It gives us the opportunity to add "Rename" and "Delete" option in this UI (under "create new")

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Create a new component called `NavigationTools` and move the "Create new menu" option here.
- Remove the "Create new menu" option from the `NavigationMenuSelector` component.
- Make the `NavigationMenuSelector` a full width dropdown.

## Testing Instructions
- Delete all your navigations and classic menus
- Add a navigation block
- Open the Inspector Controls
- Check whether you see the name of the navigation and an option to create a new menu
- Add a classic menu
- Check whether you see the a drop down to import your classic menu
- Add a second navigation
- Check that you see an option to switch between your two navigations

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/275961/3e3d90fc-9ca8-4deb-98a2-6017a51f7dc1

