### PR TITLE
[RNMobile] Upgrade `compileSdkVersion` to 34 (Android)

### DIFF
--- a/packages/react-native-aztec/android/build.gradle
+++ b/packages/react-native-aztec/android/build.gradle
@@ -49,7 +49,7 @@ List<String> dirs = [
 android {
     namespace "org.wordpress.mobile.ReactNativeAztec"
 
-    compileSdkVersion 33
+    compileSdkVersion 34
 
     defaultConfig {
         minSdkVersion 24

--- a/packages/react-native-aztec/android/build.gradle
+++ b/packages/react-native-aztec/android/build.gradle
@@ -11,7 +11,7 @@ buildscript {
         espressoVersion = '3.0.1'
 
         // libs
-        aztecVersion = 'v1.6.4'
+        aztecVersion = 'v1.8.0'
         wordpressUtilsVersion = '3.3.0'
 
         // main

--- a/packages/react-native-bridge/android/react-native-bridge/build.gradle
+++ b/packages/react-native-bridge/android/react-native-bridge/build.gradle
@@ -35,7 +35,7 @@ android {
     // File reference: `react-native-bridge/android/react-native-bridge/src/main/AndroidManifest.xml`
     namespace "org.wordpress.mobile.ReactNativeGutenbergBridge"
 
-    compileSdkVersion 33
+    compileSdkVersion 34
 
     defaultConfig {
         minSdkVersion 24

--- a/packages/react-native-editor/android/build.gradle
+++ b/packages/react-native-editor/android/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         kotlinVersion = '1.6.10'
         buildToolsVersion = "33.0.0"
         minSdkVersion = 24
-        compileSdkVersion = 33
+        compileSdkVersion = 34
         targetSdkVersion = 33
         supportLibVersion = '28.0.0'
         


### PR DESCRIPTION
Related PRs:
* https://github.com/wordpress-mobile/gutenberg-mobile/pull/6196
* https://github.com/wordpress-mobile/WordPress-Android/pull/19182

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Upgrades the `compileSdkVersion` to 34 as part of the support for Android 14.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Closes https://github.com/wordpress-mobile/gutenberg-mobile/issues/6142.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Updates the value in all references of `compileSdkVersion`:
- `react-native-aztec`
- `react-native-bridge`
- `react-native-editor`

Bump `AztecEditor-Android` version to `1.8.0`, which also uses version 34 of `compileSdkVersion`.

**⚠️ NOTE:** In past PRs where we upgraded Android ([example](https://github.com/WordPress/gutenberg/pull/50731)), we also updated the React Native third-party libraries:
- Libraries published via [react-native-libraries-publisher](https://github.com/wordpress-mobile/react-native-libraries-publisher/blob/2746ac55f78dd540efb2fa8089f1e05a2f7899a0/package.json#L3-L12)
- [react-native-slider](https://github.com/wordpress-mobile/react-native-slider)
- [react-native-video](https://github.com/wordpress-mobile/react-native-video)

I assume that since we are only updating the `compileSdkVersion` and not `targetSdkVersion`, it's safe to leave them with an older version. But once we fully upgrade to Android 14, we'd need to update them.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
* Observe that all CI jobs pass.
* Smoke test the editor on Android.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
N/A

## Screenshots or screencast <!-- if applicable -->
N/A