### PR TITLE
Improve background image control

### DIFF
--- a/packages/block-editor/src/components/inspector-controls-tabs/styles-tab.js
+++ b/packages/block-editor/src/components/inspector-controls-tabs/styles-tab.js
@@ -34,7 +34,7 @@ const StylesTab = ( { blockName, clientId, hasBlockStyles } ) => {
 			/>
 			<InspectorControls.Slot
 				group="background"
-				label={ __( 'Background image' ) }
+				label={ __( 'Background' ) }
 			/>
 			<InspectorControls.Slot group="filter" />
 			<InspectorControls.Slot

--- a/packages/block-editor/src/hooks/background.js
+++ b/packages/block-editor/src/hooks/background.js
@@ -101,7 +101,20 @@ function InspectorImagePreview( { label, url: imgUrl } ) {
 	return (
 		<ItemGroup as="span">
 			<HStack justify="flex-start" as="span">
-				<img src={ imgUrl } alt="" />
+				<span
+					className="block-editor-hooks__background__inspector-image-indicator"
+					aria-hidden
+				>
+					{ imgUrl && (
+						<span
+							className="block-editor-hooks__background__inspector-image-indicator-image"
+							aria-hidden
+							style={ {
+								backgroundImage: `url(${ imgUrl })`,
+							} }
+						/>
+					) }
+				</span>
 				<FlexItem as="span">
 					<Truncate
 						numberOfLines={ 1 }
@@ -254,11 +267,18 @@ function BackgroundImagePanelItem( props ) {
 								<div className="block-editor-hooks__background__inspector-upload-container">
 									<Button
 										onClick={ open }
-										variant="secondary"
+										aria-label={ __(
+											'Background image style'
+										) }
 									>
-										{ __( 'Add background image' ) }
+										<InspectorImagePreview
+											label={ __( 'Image' ) }
+										/>
 									</Button>
-									<DropZone onFilesDrop={ onFilesDrop } />
+									<DropZone
+										onFilesDrop={ onFilesDrop }
+										label={ __( 'Drop to upload' ) }
+									/>
 								</div>
 							) }
 						/>

--- a/packages/block-editor/src/hooks/background.js
+++ b/packages/block-editor/src/hooks/background.js
@@ -9,15 +9,17 @@ import {
 	DropZone,
 	FlexItem,
 	MenuItem,
+	VisuallyHidden,
 	__experimentalItemGroup as ItemGroup,
 	__experimentalHStack as HStack,
 	__experimentalTruncate as Truncate,
 } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { Platform, useCallback } from '@wordpress/element';
-import { __, sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { getFilename } from '@wordpress/url';
+import { useInstanceId } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -96,7 +98,7 @@ export function resetBackgroundImage( { attributes = {}, setAttributes } ) {
 	} );
 }
 
-function InspectorImagePreview( { label, filename, url: imgUrl } ) {
+function InspectorImagePreview( { label, url: imgUrl } ) {
 	const imgLabel = label || getFilename( imgUrl );
 	return (
 		<ItemGroup as="span">
@@ -111,11 +113,6 @@ function InspectorImagePreview( { label, filename, url: imgUrl } ) {
 							style={ {
 								backgroundImage: `url(${ imgUrl })`,
 							} }
-							aria-describedby={ sprintf(
-								/* translators: %s: file name */
-								__( 'This background image file name is %s' ),
-								filename
-							) }
 						/>
 					) }
 				</span>
@@ -133,6 +130,7 @@ function InspectorImagePreview( { label, filename, url: imgUrl } ) {
 }
 
 function BackgroundImagePanelItem( props ) {
+	const instanceId = useInstanceId( BackgroundImagePanelItem );
 	const { attributes, clientId, setAttributes } = props;
 
 	const { id, title, url } =
@@ -270,11 +268,17 @@ function BackgroundImagePanelItem( props ) {
 							allowedTypes={ [ IMAGE_BACKGROUND_TYPE ] }
 							render={ ( { open } ) => (
 								<div className="block-editor-hooks__background__inspector-upload-container">
-									<Button
-										onClick={ open }
-										aria-describedby={ __(
+									<VisuallyHidden
+										as="span"
+										id={ `block-editor-hooks__background__inspector-empty-state-${ instanceId }` }
+									>
+										{ __(
 											'No background image selected. Open Media Library to select an image.'
 										) }
+									</VisuallyHidden>
+									<Button
+										onClick={ open }
+										id={ `block-editor-hooks__background__inspector-empty-state-${ instanceId }` }
 									>
 										<InspectorImagePreview
 											label={ __( 'Background image' ) }

--- a/packages/block-editor/src/hooks/background.js
+++ b/packages/block-editor/src/hooks/background.js
@@ -16,7 +16,7 @@ import {
 } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { Platform, useCallback } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { getFilename } from '@wordpress/url';
 import { useInstanceId } from '@wordpress/compose';
@@ -98,7 +98,7 @@ export function resetBackgroundImage( { attributes = {}, setAttributes } ) {
 	} );
 }
 
-function InspectorImagePreview( { label, url: imgUrl } ) {
+function InspectorImagePreview( { label, filename, url: imgUrl } ) {
 	const imgLabel = label || getFilename( imgUrl );
 	return (
 		<ItemGroup as="span">
@@ -113,6 +113,12 @@ function InspectorImagePreview( { label, url: imgUrl } ) {
 							style={ {
 								backgroundImage: `url(${ imgUrl })`,
 							} }
+							// eslint-disable-next-line jsx-a11y/aria-props
+							aria-description={ sprintf(
+								/* translators: %s: file name */
+								__( 'This background image file name is %s' ),
+								filename
+							) }
 						/>
 					) }
 				</span>

--- a/packages/block-editor/src/hooks/background.js
+++ b/packages/block-editor/src/hooks/background.js
@@ -15,7 +15,7 @@ import {
 } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { Platform, useCallback } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { getFilename } from '@wordpress/url';
 
@@ -96,22 +96,26 @@ export function resetBackgroundImage( { attributes = {}, setAttributes } ) {
 	} );
 }
 
-function InspectorImagePreview( { label, url: imgUrl } ) {
+function InspectorImagePreview( { label, filename, url: imgUrl } ) {
 	const imgLabel = label || getFilename( imgUrl );
 	return (
 		<ItemGroup as="span">
 			<HStack justify="flex-start" as="span">
 				<span
-					className="block-editor-hooks__background__inspector-image-indicator"
+					className="block-editor-hooks__background__inspector-image-indicator-wrapper"
 					aria-hidden
 				>
 					{ imgUrl && (
 						<span
-							className="block-editor-hooks__background__inspector-image-indicator-image"
-							aria-hidden
+							className="block-editor-hooks__background__inspector-image-indicator"
 							style={ {
 								backgroundImage: `url(${ imgUrl })`,
 							} }
+							aria-describedby={ sprintf(
+								/* translators: %s: file name */
+								__( 'This background image file name is %s' ),
+								filename
+							) }
 						/>
 					) }
 				</span>
@@ -245,7 +249,8 @@ function BackgroundImagePanelItem( props ) {
 						onSelect={ onSelectMedia }
 						name={
 							<InspectorImagePreview
-								label={ title }
+								label={ __( 'Background image' ) }
+								filename={ title }
 								url={ url }
 							/>
 						}
@@ -267,12 +272,12 @@ function BackgroundImagePanelItem( props ) {
 								<div className="block-editor-hooks__background__inspector-upload-container">
 									<Button
 										onClick={ open }
-										aria-label={ __(
-											'Background image style'
+										aria-describedby={ __(
+											'No background image selected. Open Media Library to select an image.'
 										) }
 									>
 										<InspectorImagePreview
-											label={ __( 'Image' ) }
+											label={ __( 'Background image' ) }
 										/>
 									</Button>
 									<DropZone

--- a/packages/block-editor/src/hooks/background.js
+++ b/packages/block-editor/src/hooks/background.js
@@ -19,7 +19,6 @@ import { Platform, useCallback } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { getFilename } from '@wordpress/url';
-import { useInstanceId } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -113,12 +112,6 @@ function InspectorImagePreview( { label, filename, url: imgUrl } ) {
 							style={ {
 								backgroundImage: `url(${ imgUrl })`,
 							} }
-							// eslint-disable-next-line jsx-a11y/aria-props
-							aria-description={ sprintf(
-								/* translators: %s: file name */
-								__( 'This background image file name is %s' ),
-								filename
-							) }
 						/>
 					) }
 				</span>
@@ -129,6 +122,13 @@ function InspectorImagePreview( { label, filename, url: imgUrl } ) {
 					>
 						{ imgLabel }
 					</Truncate>
+					<VisuallyHidden as="span">
+						{ sprintf(
+							/* translators: %s: file name */
+							__( 'Selected image: %s' ),
+							filename
+						) }
+					</VisuallyHidden>
 				</FlexItem>
 			</HStack>
 		</ItemGroup>
@@ -136,7 +136,6 @@ function InspectorImagePreview( { label, filename, url: imgUrl } ) {
 }
 
 function BackgroundImagePanelItem( props ) {
-	const instanceId = useInstanceId( BackgroundImagePanelItem );
 	const { attributes, clientId, setAttributes } = props;
 
 	const { id, title, url } =
@@ -274,17 +273,11 @@ function BackgroundImagePanelItem( props ) {
 							allowedTypes={ [ IMAGE_BACKGROUND_TYPE ] }
 							render={ ( { open } ) => (
 								<div className="block-editor-hooks__background__inspector-upload-container">
-									<VisuallyHidden
-										as="span"
-										id={ `block-editor-hooks__background__inspector-empty-state-${ instanceId }` }
-									>
-										{ __(
-											'No background image selected. Open Media Library to select an image.'
-										) }
-									</VisuallyHidden>
 									<Button
 										onClick={ open }
-										id={ `block-editor-hooks__background__inspector-empty-state-${ instanceId }` }
+										aria-label={ __(
+											'Background image style'
+										) }
 									>
 										<InspectorImagePreview
 											label={ __( 'Background image' ) }

--- a/packages/block-editor/src/hooks/background.scss
+++ b/packages/block-editor/src/hooks/background.scss
@@ -11,7 +11,7 @@
 .block-editor-hooks__background__inspector-media-replace-container {
 	button.components-button {
 		color: $gray-900;
-		box-shadow: inset 0 0 0 1px $gray-300;
+		box-shadow: inset 0 0 0 $border-width $gray-300;
 		width: 100%;
 		display: block;
 		height: $grid-unit-50;
@@ -45,7 +45,7 @@
 .block-editor-hooks__background__inspector-image-indicator-wrapper {
 	background: #fff linear-gradient(-45deg, transparent 48%, $gray-300 48%, $gray-300 52%, transparent 52%); // Show a diagonal line (crossed out) for empty background image.
 	border-radius: $radius-round !important; // Override the default border-radius inherited from FlexItem.
-	box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.2);
+	box-shadow: inset 0 0 0 $border-width rgba(0, 0, 0, 0.2);
 	display: block;
 	width: 20px;
 	height: 20px;
@@ -69,7 +69,7 @@
 	bottom: -1px;
 	right: -1px;
 	border-radius: $radius-round;
-	box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.2);
+	box-shadow: inset 0 0 0 $border-width rgba(0, 0, 0, 0.2);
 	// Show a thin outline in Windows high contrast mode, otherwise the button is invisible.
 	border: 1px solid transparent;
 	box-sizing: inherit;

--- a/packages/block-editor/src/hooks/background.scss
+++ b/packages/block-editor/src/hooks/background.scss
@@ -11,7 +11,7 @@
 .block-editor-hooks__background__inspector-media-replace-container {
 	button.components-button {
 		color: $gray-900;
-		box-shadow: inset 0 0 0 1px $gray-400;
+		box-shadow: inset 0 0 0 1px $gray-300;
 		width: 100%;
 		display: block;
 		height: $grid-unit-50;
@@ -36,6 +36,40 @@
 	}
 }
 
+.block-editor-hooks__background__inspector-image-indicator {
+	background: #fff linear-gradient(-45deg, #0000 48%, #ddd 0, #ddd 52%, #0000 0);
+	border-radius: 50% !important;
+	box-shadow: inset 0 0 0 1px #0003;
+	display: block;
+	width: 20px;
+	height: 20px;
+	flex: none;
+}
+
+
+.block-editor-hooks__background__inspector-image-indicator-image {
+	background-size: cover;
+	border-radius: 50%;
+	width: 20px;
+	height: 20px;
+	display: block;
+	position: relative;
+}
+
+.block-editor-hooks__background__inspector-image-indicator-image::after {
+	content: "";
+	position: absolute;
+	top: -1px;
+	left: -1px;
+	bottom: -1px;
+	right: -1px;
+	border-radius: $radius-round;
+	box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.2);
+	// Show a thin circular outline in Windows high contrast mode, otherwise the button is invisible.
+	border: 1px solid transparent;
+	box-sizing: inherit;
+}
+
 .block-editor-hooks__background__inspector-media-replace-container {
 	.components-dropdown {
 		display: block;
@@ -45,7 +79,7 @@
 		width: 20px;
 		min-width: 20px;
 		aspect-ratio: 1;
-		box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.2);
+		// box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.2);
 		border-radius: 50% !important;
 	}
 

--- a/packages/block-editor/src/hooks/background.scss
+++ b/packages/block-editor/src/hooks/background.scss
@@ -36,27 +36,32 @@
 	}
 }
 
-.block-editor-hooks__background__inspector-image-indicator {
-	background: #fff linear-gradient(-45deg, #0000 48%, #ddd 0, #ddd 52%, #0000 0);
-	border-radius: 50% !important;
-	box-shadow: inset 0 0 0 1px #0003;
+.block-editor-hooks__background__inspector-media-replace-container {
+	.components-dropdown {
+		display: block;
+	}
+}
+
+.block-editor-hooks__background__inspector-image-indicator-wrapper {
+	background: #fff linear-gradient(-45deg, transparent 48%, $gray-300 48%, $gray-300 52%, transparent 52%); // Show a diagonal line (crossed out) for empty background image.
+	border-radius: $radius-round !important; // Override the default border-radius inherited from FlexItem.
+	box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.2);
 	display: block;
 	width: 20px;
 	height: 20px;
 	flex: none;
 }
 
-
-.block-editor-hooks__background__inspector-image-indicator-image {
+.block-editor-hooks__background__inspector-image-indicator {
 	background-size: cover;
-	border-radius: 50%;
+	border-radius: $radius-round;
 	width: 20px;
 	height: 20px;
 	display: block;
 	position: relative;
 }
 
-.block-editor-hooks__background__inspector-image-indicator-image::after {
+.block-editor-hooks__background__inspector-image-indicator::after {
 	content: "";
 	position: absolute;
 	top: -1px;
@@ -65,27 +70,7 @@
 	right: -1px;
 	border-radius: $radius-round;
 	box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.2);
-	// Show a thin circular outline in Windows high contrast mode, otherwise the button is invisible.
+	// Show a thin outline in Windows high contrast mode, otherwise the button is invisible.
 	border: 1px solid transparent;
 	box-sizing: inherit;
-}
-
-.block-editor-hooks__background__inspector-media-replace-container {
-	.components-dropdown {
-		display: block;
-	}
-
-	img {
-		width: 20px;
-		min-width: 20px;
-		aspect-ratio: 1;
-		// box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.2);
-		border-radius: 50% !important;
-	}
-
-	.block-editor-hooks__background__inspector-readonly-logo-preview {
-		padding: 6px 12px;
-		display: flex;
-		height: $grid-unit-50;
-	}
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Follow-up https://github.com/WordPress/gutenberg/pull/53934 to bring this more in line with the color controls. There are also less changes between states (with or without a background image added).  I don't love the duplicate panel and button labels though. 

A11y based on [feedback](https://wordpress.slack.com/archives/C02RP4X03/p1694640824753459) from the accessibility channel on the Making WordPress Slack. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a post or page.
2. Insert a group block. 
3. Add a background image via the control.
4. See changes.

## Screenshots or screencast <!-- if applicable -->

### After

https://github.com/WordPress/gutenberg/assets/1813435/485d59a6-1945-487c-9857-f61afb40f45d

