### PR TITLE
Update/form token field onblur

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -14,7 +14,7 @@
 -   `Tooltip`: Add new `hideOnClick` prop ([#54406](https://github.com/WordPress/gutenberg/pull/54406)).
 -   `CircularOptionPicker`: Add option to use previous non-listbox behaviour, for contexts where buttons are more appropriate than a list of options ([#54290](https://github.com/WordPress/gutenberg/pull/54290)).
 -   `DuotonePicker/ColorListPicker`: Adds appropriate labels to 'Duotone Filter' color pickers ([#54468](https://github.com/WordPress/gutenberg/pull/54468)).
--   `FormTokenField`: Add `addOnBlur` prop to add any incompleteTokenValue as a new token when field loses focus ([#54445](https://github.com/WordPress/gutenberg/pull/54445)).
+-   `FormTokenField`: Add `tokenizeOnBlur` prop to add any incompleteTokenValue as a new token when field loses focus ([#54445](https://github.com/WordPress/gutenberg/pull/54445)).
 
 ### Bug Fix
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -14,7 +14,7 @@
 -   `Tooltip`: Add new `hideOnClick` prop ([#54406](https://github.com/WordPress/gutenberg/pull/54406)).
 -   `CircularOptionPicker`: Add option to use previous non-listbox behaviour, for contexts where buttons are more appropriate than a list of options ([#54290](https://github.com/WordPress/gutenberg/pull/54290)).
 -   `DuotonePicker/ColorListPicker`: Adds appropriate labels to 'Duotone Filter' color pickers ([#54468](https://github.com/WordPress/gutenberg/pull/54468)).
--   `FormTokenField`: Add `addOnBlur` prop to add any incompleteTokenValue as a new token when field loses focus ([#53976](https://github.com/WordPress/gutenberg/pull/53976)).
+-   `FormTokenField`: Add `addOnBlur` prop to add any incompleteTokenValue as a new token when field loses focus ([#54445](https://github.com/WordPress/gutenberg/pull/54445)).
 
 ### Bug Fix
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -14,7 +14,7 @@
 -   `Tooltip`: Add new `hideOnClick` prop ([#54406](https://github.com/WordPress/gutenberg/pull/54406)).
 -   `CircularOptionPicker`: Add option to use previous non-listbox behaviour, for contexts where buttons are more appropriate than a list of options ([#54290](https://github.com/WordPress/gutenberg/pull/54290)).
 -   `DuotonePicker/ColorListPicker`: Adds appropriate labels to 'Duotone Filter' color pickers ([#54468](https://github.com/WordPress/gutenberg/pull/54468)).
--   `FormTokenField`: Add `__experimentalAddOnBlur` prop to add any incompleteTokenValue as a new token when field loses focus.
+-   `FormTokenField`: Add `__experimentalAddOnBlur` prop to add any incompleteTokenValue as a new token when field loses focus ([#53976](https://github.com/WordPress/gutenberg/pull/53976)).
 
 ### Bug Fix
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -14,6 +14,7 @@
 -   `Tooltip`: Add new `hideOnClick` prop ([#54406](https://github.com/WordPress/gutenberg/pull/54406)).
 -   `CircularOptionPicker`: Add option to use previous non-listbox behaviour, for contexts where buttons are more appropriate than a list of options ([#54290](https://github.com/WordPress/gutenberg/pull/54290)).
 -   `DuotonePicker/ColorListPicker`: Adds appropriate labels to 'Duotone Filter' color pickers ([#54468](https://github.com/WordPress/gutenberg/pull/54468)).
+-   `FormTokenField`: Add `__experimentalAddOnBlur` prop to add any incompleteTokenValue as a new token when field loses focus.
 
 ### Bug Fix
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -14,7 +14,7 @@
 -   `Tooltip`: Add new `hideOnClick` prop ([#54406](https://github.com/WordPress/gutenberg/pull/54406)).
 -   `CircularOptionPicker`: Add option to use previous non-listbox behaviour, for contexts where buttons are more appropriate than a list of options ([#54290](https://github.com/WordPress/gutenberg/pull/54290)).
 -   `DuotonePicker/ColorListPicker`: Adds appropriate labels to 'Duotone Filter' color pickers ([#54468](https://github.com/WordPress/gutenberg/pull/54468)).
--   `FormTokenField`: Add `__experimentalAddOnBlur` prop to add any incompleteTokenValue as a new token when field loses focus ([#53976](https://github.com/WordPress/gutenberg/pull/53976)).
+-   `FormTokenField`: Add `addOnBlur` prop to add any incompleteTokenValue as a new token when field loses focus ([#53976](https://github.com/WordPress/gutenberg/pull/53976)).
 
 ### Bug Fix
 

--- a/packages/components/src/form-token-field/README.md
+++ b/packages/components/src/form-token-field/README.md
@@ -62,6 +62,7 @@ The `value` property is handled in a manner similar to controlled form component
 -   `__experimentalValidateInput` - If passed, all introduced values will be validated before being added as tokens.
 -   `__experimentalAutoSelectFirstMatch` - If true, the select the first matching suggestion when the user presses the Enter key (or space when tokenizeOnSpace is true).
 -   `__nextHasNoMarginBottom` - Start opting into the new margin-free styles that will become the default in a future version, currently scheduled to be WordPress 6.5. (The prop can be safely removed once this happens.)
+-   `__experimentalAddOnBlur` - If true adds any incompleteTokenValue as a new token when field loses focus.
 
 ## Usage
 

--- a/packages/components/src/form-token-field/README.md
+++ b/packages/components/src/form-token-field/README.md
@@ -62,7 +62,7 @@ The `value` property is handled in a manner similar to controlled form component
 -   `__experimentalValidateInput` - If passed, all introduced values will be validated before being added as tokens.
 -   `__experimentalAutoSelectFirstMatch` - If true, the select the first matching suggestion when the user presses the Enter key (or space when tokenizeOnSpace is true).
 -   `__nextHasNoMarginBottom` - Start opting into the new margin-free styles that will become the default in a future version, currently scheduled to be WordPress 6.5. (The prop can be safely removed once this happens.)
--   `__experimentalAddOnBlur` - If true adds any incompleteTokenValue as a new token when field loses focus.
+-   `tokenizeOnBlur` - If true adds any incompleteTokenValue as a new token when field loses focus.
 
 ## Usage
 

--- a/packages/components/src/form-token-field/README.md
+++ b/packages/components/src/form-token-field/README.md
@@ -62,7 +62,7 @@ The `value` property is handled in a manner similar to controlled form component
 -   `__experimentalValidateInput` - If passed, all introduced values will be validated before being added as tokens.
 -   `__experimentalAutoSelectFirstMatch` - If true, the select the first matching suggestion when the user presses the Enter key (or space when tokenizeOnSpace is true).
 -   `__nextHasNoMarginBottom` - Start opting into the new margin-free styles that will become the default in a future version, currently scheduled to be WordPress 6.5. (The prop can be safely removed once this happens.)
--   `tokenizeOnBlur` - If true adds any incompleteTokenValue as a new token when field loses focus.
+-   `tokenizeOnBlur` - If true, add any incompleteTokenValue as a new token when the field loses focus.
 
 ## Usage
 

--- a/packages/components/src/form-token-field/index.tsx
+++ b/packages/components/src/form-token-field/index.tsx
@@ -73,6 +73,7 @@ export function FormTokenField( props: FormTokenFieldProps ) {
 		__next40pxDefaultSize = false,
 		__experimentalAutoSelectFirstMatch = false,
 		__nextHasNoMarginBottom = false,
+		__experimentalAddOnBlur = false,
 	} = useDeprecated36pxDefaultSizeProp< FormTokenFieldProps >(
 		props,
 		'wp.components.FormTokenField'
@@ -167,6 +168,9 @@ export function FormTokenField( props: FormTokenFieldProps ) {
 			__experimentalValidateInput( incompleteTokenValue )
 		) {
 			setIsActive( false );
+			if ( __experimentalAddOnBlur ) {
+				addCurrentToken( true );
+			}
 		} else {
 			// Reset to initial state
 			setIncompleteTokenValue( '' );
@@ -406,7 +410,7 @@ export function FormTokenField( props: FormTokenFieldProps ) {
 		}
 	}
 
-	function addCurrentToken() {
+	function addCurrentToken( isOnBlur = false ) {
 		let preventDefault = false;
 		const selectedSuggestion = getSelectedSuggestion();
 
@@ -414,7 +418,7 @@ export function FormTokenField( props: FormTokenFieldProps ) {
 			addNewToken( selectedSuggestion );
 			preventDefault = true;
 		} else if ( inputHasValidValue() ) {
-			addNewToken( incompleteTokenValue );
+			addNewToken( incompleteTokenValue, isOnBlur );
 			preventDefault = true;
 		}
 
@@ -438,7 +442,7 @@ export function FormTokenField( props: FormTokenFieldProps ) {
 		}
 	}
 
-	function addNewToken( token: string ) {
+	function addNewToken( token: string, isOnBlur: boolean = false ) {
 		if ( ! __experimentalValidateInput( token ) ) {
 			speak( messages.__experimentalInvalid, 'assertive' );
 			return;
@@ -451,7 +455,7 @@ export function FormTokenField( props: FormTokenFieldProps ) {
 		setSelectedSuggestionScroll( false );
 		setIsExpanded( ! __experimentalExpandOnFocus );
 
-		if ( isActive ) {
+		if ( isActive && ! isOnBlur ) {
 			focus();
 		}
 	}

--- a/packages/components/src/form-token-field/index.tsx
+++ b/packages/components/src/form-token-field/index.tsx
@@ -168,8 +168,8 @@ export function FormTokenField( props: FormTokenFieldProps ) {
 			__experimentalValidateInput( incompleteTokenValue )
 		) {
 			setIsActive( false );
-			if ( tokenizeOnBlur ) {
-				addCurrentToken( true );
+			if ( tokenizeOnBlur && inputHasValidValue() ) {
+				addNewToken( incompleteTokenValue );
 			}
 		} else {
 			// Reset to initial state
@@ -410,7 +410,7 @@ export function FormTokenField( props: FormTokenFieldProps ) {
 		}
 	}
 
-	function addCurrentToken( isOnBlur = false ) {
+	function addCurrentToken() {
 		let preventDefault = false;
 		const selectedSuggestion = getSelectedSuggestion();
 
@@ -418,7 +418,7 @@ export function FormTokenField( props: FormTokenFieldProps ) {
 			addNewToken( selectedSuggestion );
 			preventDefault = true;
 		} else if ( inputHasValidValue() ) {
-			addNewToken( incompleteTokenValue, isOnBlur );
+			addNewToken( incompleteTokenValue );
 			preventDefault = true;
 		}
 
@@ -442,7 +442,7 @@ export function FormTokenField( props: FormTokenFieldProps ) {
 		}
 	}
 
-	function addNewToken( token: string, isOnBlur: boolean = false ) {
+	function addNewToken( token: string ) {
 		if ( ! __experimentalValidateInput( token ) ) {
 			speak( messages.__experimentalInvalid, 'assertive' );
 			return;
@@ -455,7 +455,7 @@ export function FormTokenField( props: FormTokenFieldProps ) {
 		setSelectedSuggestionScroll( false );
 		setIsExpanded( ! __experimentalExpandOnFocus );
 
-		if ( isActive && ! isOnBlur ) {
+		if ( isActive && ! tokenizeOnBlur ) {
 			focus();
 		}
 	}

--- a/packages/components/src/form-token-field/index.tsx
+++ b/packages/components/src/form-token-field/index.tsx
@@ -73,7 +73,7 @@ export function FormTokenField( props: FormTokenFieldProps ) {
 		__next40pxDefaultSize = false,
 		__experimentalAutoSelectFirstMatch = false,
 		__nextHasNoMarginBottom = false,
-		__experimentalAddOnBlur = false,
+		tokenizeOnBlur = false,
 	} = useDeprecated36pxDefaultSizeProp< FormTokenFieldProps >(
 		props,
 		'wp.components.FormTokenField'
@@ -168,7 +168,7 @@ export function FormTokenField( props: FormTokenFieldProps ) {
 			__experimentalValidateInput( incompleteTokenValue )
 		) {
 			setIsActive( false );
-			if ( __experimentalAddOnBlur ) {
+			if ( tokenizeOnBlur ) {
 				addCurrentToken( true );
 			}
 		} else {

--- a/packages/components/src/form-token-field/test/index.tsx
+++ b/packages/components/src/form-token-field/test/index.tsx
@@ -240,7 +240,7 @@ describe( 'FormTokenField', () => {
 			expectTokensToBeInTheDocument( [ 'grapefruit' ] );
 		} );
 
-		it( "should not add a token with the input's value when pressing the tab key", async () => {
+		it( "should not add a token with the input's value when tokenizeOnBlur is not set and pressing the tab key", async () => {
 			const user = userEvent.setup();
 
 			const onChangeSpy = jest.fn();

--- a/packages/components/src/form-token-field/test/index.tsx
+++ b/packages/components/src/form-token-field/test/index.tsx
@@ -9,6 +9,7 @@ import {
 	within,
 	getDefaultNormalizer,
 	waitFor,
+	act,
 } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import type { ComponentProps } from 'react';
@@ -203,6 +204,45 @@ describe( 'FormTokenField', () => {
 				'dragon',
 				'fruit',
 			] );
+		} );
+
+		it( 'should add a token with the input value with onBlur when `tokenizeOnBlur` prop is `true`', async () => {
+			const user = userEvent.setup();
+
+			const onChangeSpy = jest.fn();
+
+			const { rerender } = render(
+				<FormTokenFieldWithState onChange={ onChangeSpy } />
+			);
+
+			const input = screen.getByRole( 'combobox' );
+
+			// Add 'grapefruit' token by typing it and check blur of field does not tokenize it.
+			await user.type( input, 'grapefruit' );
+			act( () => {
+				input.blur();
+			} );
+			expect( onChangeSpy ).toHaveBeenCalledTimes( 0 );
+			expectTokensNotToBeInTheDocument( [ 'grapefruit' ] );
+
+			rerender(
+				<FormTokenFieldWithState
+					onChange={ onChangeSpy }
+					tokenizeOnBlur
+				/>
+			);
+			await user.clear( input );
+
+			// Add 'grapefruit' token by typing it and check blur of field tokenizes it.
+			await user.type( input, 'grapefruit' );
+
+			act( () => {
+				input.blur();
+			} );
+			expect( onChangeSpy ).toHaveBeenNthCalledWith( 1, [
+				'grapefruit',
+			] );
+			expectTokensToBeInTheDocument( [ 'grapefruit' ] );
 		} );
 
 		it( "should not add a token with the input's value when pressing the tab key", async () => {

--- a/packages/components/src/form-token-field/test/index.tsx
+++ b/packages/components/src/form-token-field/test/index.tsx
@@ -9,7 +9,6 @@ import {
 	within,
 	getDefaultNormalizer,
 	waitFor,
-	act,
 } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import type { ComponentProps } from 'react';
@@ -219,9 +218,7 @@ describe( 'FormTokenField', () => {
 
 			// Add 'grapefruit' token by typing it and check blur of field does not tokenize it.
 			await user.type( input, 'grapefruit' );
-			act( () => {
-				input.blur();
-			} );
+			await user.click( document.body );
 			expect( onChangeSpy ).toHaveBeenCalledTimes( 0 );
 			expectTokensNotToBeInTheDocument( [ 'grapefruit' ] );
 
@@ -236,9 +233,7 @@ describe( 'FormTokenField', () => {
 			// Add 'grapefruit' token by typing it and check blur of field tokenizes it.
 			await user.type( input, 'grapefruit' );
 
-			act( () => {
-				input.blur();
-			} );
+			await user.click( document.body );
 			expect( onChangeSpy ).toHaveBeenNthCalledWith( 1, [
 				'grapefruit',
 			] );

--- a/packages/components/src/form-token-field/types.ts
+++ b/packages/components/src/form-token-field/types.ts
@@ -182,6 +182,12 @@ export interface FormTokenFieldProps
 	 * @default false
 	 */
 	__nextHasNoMarginBottom?: boolean;
+	/**
+	 * If true add any incompleteTokenValue as a new token.
+	 *
+	 * @default false
+	 */
+	__experimentalAddOnBlur?: boolean;
 }
 
 /**

--- a/packages/components/src/form-token-field/types.ts
+++ b/packages/components/src/form-token-field/types.ts
@@ -183,7 +183,7 @@ export interface FormTokenFieldProps
 	 */
 	__nextHasNoMarginBottom?: boolean;
 	/**
-	 * If true add any incompleteTokenValue as a new token.
+	 * If true, add any incompleteTokenValue as a new token when the field loses focus.
 	 *
 	 * @default false
 	 */

--- a/packages/components/src/form-token-field/types.ts
+++ b/packages/components/src/form-token-field/types.ts
@@ -187,7 +187,7 @@ export interface FormTokenFieldProps
 	 *
 	 * @default false
 	 */
-	__experimentalAddOnBlur?: boolean;
+	tokenizeOnBlur?: boolean;
 }
 
 /**

--- a/packages/editor/src/components/provider/use-block-editor-settings.js
+++ b/packages/editor/src/components/provider/use-block-editor-settings.js
@@ -222,7 +222,6 @@ function useBlockEditorSettings( settings, hasTemplate ) {
 			userPatternCategories,
 			blockPatterns,
 			blockPatternCategories,
-			userPatternCategories,
 			canUseUnfilteredHTML,
 			undo,
 			hasTemplate,

--- a/packages/editor/src/components/provider/use-block-editor-settings.js
+++ b/packages/editor/src/components/provider/use-block-editor-settings.js
@@ -222,6 +222,7 @@ function useBlockEditorSettings( settings, hasTemplate ) {
 			userPatternCategories,
 			blockPatterns,
 			blockPatternCategories,
+			userPatternCategories,
 			canUseUnfilteredHTML,
 			undo,
 			hasTemplate,

--- a/packages/patterns/src/components/category-selector.js
+++ b/packages/patterns/src/components/category-selector.js
@@ -111,6 +111,7 @@ export default function CategorySelector( { onCategorySelection } ) {
 				onInputChange={ debouncedSearch }
 				maxSuggestions={ MAX_TERMS_SUGGESTIONS }
 				label={ __( 'Categories' ) }
+				__experimentalAddOnBlur={ true }
 			/>
 		</>
 	);

--- a/packages/patterns/src/components/category-selector.js
+++ b/packages/patterns/src/components/category-selector.js
@@ -111,7 +111,7 @@ export default function CategorySelector( { onCategorySelection } ) {
 				onInputChange={ debouncedSearch }
 				maxSuggestions={ MAX_TERMS_SUGGESTIONS }
 				label={ __( 'Categories' ) }
-				__experimentalAddOnBlur={ true }
+				tokenizeOnBlur={ true }
 			/>
 		</>
 	);


### PR DESCRIPTION
## What?
Adds a `tokenizeOnBlur` prop. This is a copy of #53976 as merging that into the feature branch was not the best approach, so reverted that and will rebase this against trunk and merge into trunk separately once the rest of the pattern category feature is merged.

## Why?
To allow consuming components to specify that any`incompleteTokenValue` is saved when the field loses focus. The main purpose for this is to prevent users saving the new [add patterns model](https://github.com/WordPress/gutenberg/pull/53835) with unsaved categories added.

## How?
If `tokenizeOnBlur` is `true` then `addNewToken` is run in `onBlur`

## Testing Instructions

- In the post editor add a new block and then in the block overflow menu choose the `Create pattern` menu option
- In the category input box add a category, and without hitting enter or `'` click outside the box so it loses focus
- Check that the category has been added and appears as token

## Screenshots or screencast <!-- if applicable -->

Before:

https://github.com/WordPress/gutenberg/assets/3629020/d863e518-ac56-4fe9-a87c-0979aeaf57ee

After:

https://github.com/WordPress/gutenberg/assets/3629020/6ac41a4e-4867-4f4d-b4db-c7b1545c069d

## ✍️ Dev note

A new `tokenizeOnBlur` prop has been added to `FormTokenField`, causing the component to tokenize its current input instead of discarding it when losing focus.

This is particularly useful when `FormTokenField` is used in places like modals, where the user may press a button causing the modal to close and `FormTokenField` to lose focus before its input could be tokenized.