### PR TITLE
Update block styles UI

### DIFF
--- a/packages/block-editor/src/components/block-styles/index.js
+++ b/packages/block-editor/src/components/block-styles/index.js
@@ -71,6 +71,7 @@ function BlockStyles( { clientId, onSwitch = noop, onHoverClassName = noop } ) {
 
 					return (
 						<Button
+							__next40pxDefaultSize
 							className={ classnames(
 								'block-editor-block-styles__item',
 								{

--- a/packages/block-editor/src/components/block-styles/index.js
+++ b/packages/block-editor/src/components/block-styles/index.js
@@ -81,6 +81,7 @@ function BlockStyles( { clientId, onSwitch = noop, onHoverClassName = noop } ) {
 							key={ style.name }
 							variant="secondary"
 							label={ buttonText }
+							showTooltip={ false }
 							onMouseEnter={ () => styleItemHandler( style ) }
 							onFocus={ () => styleItemHandler( style ) }
 							onMouseLeave={ () => styleItemHandler( null ) }

--- a/packages/block-editor/src/components/block-styles/style.scss
+++ b/packages/block-editor/src/components/block-styles/style.scss
@@ -36,13 +36,13 @@
 
 	button.components-button.block-editor-block-styles__item {
 		color: $gray-900;
-		box-shadow: inset 0 0 0 1px $gray-300;
+		box-shadow: inset 0 0 0 $border-width $gray-300;
 		display: inline-block;
 		width: calc(50% - #{$grid-unit-05});
 
 		&:hover {
 			color: var(--wp-admin-theme-color);
-			box-shadow: inset 0 0 0 1px $gray-300;
+			box-shadow: inset 0 0 0 $border-width $gray-300;
 		}
 
 		&.is-active,

--- a/packages/block-editor/src/components/block-styles/style.scss
+++ b/packages/block-editor/src/components/block-styles/style.scss
@@ -36,13 +36,13 @@
 
 	button.components-button.block-editor-block-styles__item {
 		color: $gray-900;
-		box-shadow: inset 0 0 0 1px $gray-400;
+		box-shadow: inset 0 0 0 1px $gray-300;
 		display: inline-block;
 		width: calc(50% - #{$grid-unit-05});
 
 		&:hover {
 			color: var(--wp-admin-theme-color);
-			box-shadow: inset 0 0 0 1px $gray-400;
+			box-shadow: inset 0 0 0 1px $gray-300;
 		}
 
 		&.is-active,
@@ -58,7 +58,7 @@
 
 		&:focus,
 		&.is-active:focus {
-			@include button-style__focus();
+			box-shadow: inset 0 0 0 $border-width var(--wp-components-color-background, #fff), 0 0 0 var(--wp-admin-border-width-focus) var(--wp-components-color-accent, var(--wp-admin-theme-color, #3858e9));
 		}
 	}
 


### PR DESCRIPTION
Updating block styles UI to use the larger size re https://github.com/WordPress/gutenberg/issues/46734. 

Also improves the focus shadow to not clash with the buttons (matching primary button and toggle style focus). 

Removes the tooltip (which was just the visual title duplicated). 

And uses the same border color as the color, and similar controls. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a post or page.
2. Insert a buttons block.
3. Select the styles tab in the block inspector. 
4. See changes. 

## Screenshots or screencast <!-- if applicable -->


| Before  | After |
| ------------- | ------------- |
|<img width="280" alt="CleanShot 2023-09-13 at 17 56 10" src="https://github.com/WordPress/gutenberg/assets/1813435/16c370a8-5ba7-4a1d-8cf6-252d08416f7d">|<img width="280" alt="CleanShot 2023-09-13 at 17 56 39" src="https://github.com/WordPress/gutenberg/assets/1813435/fe42525b-c186-414b-8bd7-40caa60c32cb">|


Related: 

<img width="52" alt="CleanShot 2023-09-13 at 20 20 48" src="https://github.com/WordPress/gutenberg/assets/1813435/dcefecf8-7072-4621-b684-e8d7f4190ba4">

