### PR TITLE
Query Loop: Use 'Choose pattern' in placeholder for clarity at narrower widths

### DIFF
--- a/packages/block-library/src/query/edit/query-placeholder.js
+++ b/packages/block-library/src/query/edit/query-placeholder.js
@@ -84,7 +84,7 @@ export default function QueryPlaceholder( {
 						variant="primary"
 						onClick={ openPatternSelectionModal }
 					>
-						{ __( 'Choose pattern' ) }
+						{ __( 'Choose design' ) }
 					</Button>
 				) }
 

--- a/packages/block-library/src/query/edit/query-placeholder.js
+++ b/packages/block-library/src/query/edit/query-placeholder.js
@@ -84,7 +84,7 @@ export default function QueryPlaceholder( {
 						variant="primary"
 						onClick={ openPatternSelectionModal }
 					>
-						{ __( 'Choose' ) }
+						{ __( 'Choose pattern' ) }
 					</Button>
 				) }
 


### PR DESCRIPTION
## What?

In the `QueryPlaceholder` component, update the button text for choosing a pattern to say "Choose pattern" instead of just "Choose."

## Why?

When the editor canvas has a narrower width, the instructions for the Query Loop block placeholder are hidden, making it unclear what the "Choose" button refers to.

## How?

Just changing the text.

## Testing Instructions

1. Open the block editor.
2. Make the editor canvas narrow enough to suppress the instructions by reducing the width of the browser window, or opening the left and right sidebars, or both.
3. Add a Query Loop block to the content.
4. Observe that the "Choose" button for selecting a pattern is different.

## Screenshots or screencast

Before:

<img width="1130" alt="Screenshot 2023-09-13 at 11 58 31 PM" src="https://github.com/WordPress/gutenberg/assets/697432/5ecb480e-cb82-4f45-9bba-ad75d7600727">

After:

<img width="1126" alt="Screenshot 2023-09-14 at 12 01 45 AM" src="https://github.com/WordPress/gutenberg/assets/697432/e7f02529-89dd-41bd-9afc-02cdd3a8049b">
