### PR TITLE
Remove Tooltip workarounds added in the site and block editor

### DIFF
--- a/packages/block-editor/src/components/border-radius-control/linked-button.js
+++ b/packages/block-editor/src/components/border-radius-control/linked-button.js
@@ -8,19 +8,16 @@ import { __ } from '@wordpress/i18n';
 export default function LinkedButton( { isLinked, ...props } ) {
 	const label = isLinked ? __( 'Unlink radii' ) : __( 'Link radii' );
 
-	// TODO: Remove span after merging https://github.com/WordPress/gutenberg/pull/44198
 	return (
 		<Tooltip text={ label }>
-			<span>
-				<Button
-					{ ...props }
-					className="component-border-radius-control__linked-button"
-					isSmall
-					icon={ isLinked ? link : linkOff }
-					iconSize={ 24 }
-					aria-label={ label }
-				/>
-			</span>
+			<Button
+				{ ...props }
+				className="component-border-radius-control__linked-button"
+				isSmall
+				icon={ isLinked ? link : linkOff }
+				iconSize={ 24 }
+				aria-label={ label }
+			/>
 		</Tooltip>
 	);
 }

--- a/packages/block-editor/src/components/list-view/block-select-button.js
+++ b/packages/block-editor/src/components/list-view/block-select-button.js
@@ -233,9 +233,7 @@ function ListViewBlockSelectButton(
 					) }
 					{ positionLabel && isSticky && (
 						<Tooltip text={ positionLabel }>
-							<span className="block-editor-list-view-block-select-button__sticky">
-								<Icon icon={ pinSmall } />
-							</span>
+							<Icon icon={ pinSmall } />
 						</Tooltip>
 					) }
 					{ images.length ? (

--- a/packages/block-editor/src/components/list-view/style.scss
+++ b/packages/block-editor/src/components/list-view/style.scss
@@ -335,8 +335,7 @@
 		background: rgba($black, 0.3);
 	}
 
-	.block-editor-list-view-block-select-button__lock,
-	.block-editor-list-view-block-select-button__sticky {
+	.block-editor-list-view-block-select-button__lock {
 		line-height: 0;
 	}
 

--- a/packages/edit-site/src/components/page-patterns/grid-item.js
+++ b/packages/edit-site/src/components/page-patterns/grid-item.js
@@ -184,12 +184,10 @@ function GridItem( { categoryId, item, ...props } ) {
 								'Editing this pattern will also update anywhere it is used'
 							) }
 						>
-							<span>
-								<Icon
-									className="edit-site-patterns__pattern-icon"
-									icon={ itemIcon }
-								/>
-							</span>
+							<Icon
+								className="edit-site-patterns__pattern-icon"
+								icon={ itemIcon }
+							/>
 						</Tooltip>
 					) }
 					<Flex as="span" gap={ 0 } justify="left">
@@ -213,9 +211,11 @@ function GridItem( { categoryId, item, ...props } ) {
 								position="top center"
 								text={ __( 'This pattern cannot be edited.' ) }
 							>
-								<span className="edit-site-patterns__pattern-lock-icon">
-									<Icon icon={ lockSmall } size={ 24 } />
-								</span>
+								<Icon
+									className="edit-site-patterns__pattern-lock-icon"
+									icon={ lockSmall }
+									size={ 24 }
+								/>
 							</Tooltip>
 						) }
 					</Flex>

--- a/packages/edit-site/src/components/page-patterns/style.scss
+++ b/packages/edit-site/src/components/page-patterns/style.scss
@@ -211,11 +211,7 @@
 	}
 
 	.edit-site-patterns__pattern-lock-icon {
-		display: inline-flex;
-
-		svg {
-			fill: currentcolor;
-		}
+		fill: currentcolor;
 	}
 }
 

--- a/packages/edit-site/src/components/sidebar-navigation-screen-pattern/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-pattern/style.scss
@@ -24,6 +24,3 @@
 	margin-right: $grid-unit-10;
 }
 
-.edit-site-sidebar-navigation-screen-pattern__lock-icon {
-	display: inline-flex;
-}

--- a/packages/edit-site/src/components/sidebar-navigation-screen-patterns/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-patterns/index.js
@@ -75,9 +75,7 @@ function ThemePatternsGroup( { categories, currentCategory, currentType } ) {
 										category.label
 									) }
 								>
-									<span className="edit-site-sidebar-navigation-screen-pattern__lock-icon">
-										<Icon icon={ lockSmall } size={ 24 } />
-									</span>
+									<Icon icon={ lockSmall } size={ 24 } />
 								</Tooltip>
 							</Flex>
 						}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

The recent update to Tooltip (#48222) fixed a bug where an `<Icon>` component could not be rendered as a child (#43129). A wrapper was added as a workaround, and in some cases, additional CSS. 

There was also a wrapper around a `<Button>` with a to-do note to remove after merging #44198, so I included that as well. 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

To clean up what is now unnecessary wrappers and CSS. Also, to highlight that this workaround is no longer needed. 

## How?

Removing the wrapper and unnecessary CSS, if any. 

## Testing Instructions

All of these changes can be tested in the Site Editor: 

### Patterns 

1. Open the Site Editor and go to Patterns
2. Look for the lock icon in the sidebar 
3. Ensure the lock icon and its tooltip appear the same as before

<img width="264" alt="Screenshot 2023-09-13 at 7 28 46 PM" src="https://github.com/WordPress/gutenberg/assets/35543432/7cd78e03-ee20-42c7-a5a1-019d88410639">

4. Click on one of the patterns with the lock icon from above step 
5. Ensure the lock icon and its tooltip appear the same as before 

<img width="261" alt="Screenshot 2023-09-13 at 6 50 54 PM" src="https://github.com/WordPress/gutenberg/assets/35543432/871c6db1-291d-42b6-87ce-c028bc8a5032">

6. Last step in Patterns, click on a template part (i.e. Header)
7. Ensure the purple icon and its tooltip appear the same as before

<img width="343" alt="Screenshot 2023-09-13 at 7 21 02 PM" src="https://github.com/WordPress/gutenberg/assets/35543432/a6caf994-2f76-4da9-a575-fff1522e5380">

### Editor (using Group block)

1. Add a Group block to the editor
2. In the sidebar, go to 'Position' and select 'Sticky'
3. Open the block list view (ctrl option O)
4. Ensure the pin icon and its tooltip appear the same as before

<img width="358" alt="Screenshot 2023-09-12 at 6 35 13 PM" src="https://github.com/WordPress/gutenberg/assets/35543432/da948f43-b8e9-4623-9f0f-078dbc3c131c">

5. With the Group block selected, click on styles to edit 
6. Ensure link/unlink icon and its tooltip look the same as before

<img width="274" alt="Screenshot 2023-09-13 at 8 16 50 PM" src="https://github.com/WordPress/gutenberg/assets/35543432/f30b43b3-3db2-4f38-a3b9-bfa7ff714b03">

