### PR TITLE
Disable duotone until media is provided in Cover block

### DIFF
--- a/packages/block-editor/src/hooks/duotone.js
+++ b/packages/block-editor/src/hooks/duotone.js
@@ -130,6 +130,16 @@ function DuotonePanel( { attributes, setAttributes, name } ) {
 		return null;
 	}
 
+	// Ensures media details exist in specific blocks; if they're missing, it hides the control.
+	const blockNamesToCheck = [ 'core/cover', 'core/image' ];
+	const requiredAttributes = [ 'id', 'useFeaturedImage' ];
+	if (
+		blockNamesToCheck.includes( name ) &&
+		! requiredAttributes.some( ( key ) => attributes?.[ key ] )
+	) {
+		return null;
+	}
+
 	const duotonePresetOrColors = ! Array.isArray( duotoneStyle )
 		? getColorsFromDuotonePreset( duotoneStyle, duotonePalette )
 		: duotoneStyle;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Within the Duotone control hook, assess specific blocks (cover and image) and associated media attributes to determine whether Duotone block controls should be displayed. It's worth noting that, since this feature is enabled through block.json, there's no known method for other blocks to conditionally render these controls in a similar manner.

## Why?
Resolves #48804

## How?
By looking at the block name and the media attributes we know.

Even though this works for now, it might not work well in the future. Media attributes can vary a lot and aren't standardized, making it tricky to set conditions.

## Screenshots or screencast <!-- if applicable -->

**New cover block**
![Screenshot 2023-09-14 at 00-32-16 Edit Page “Sample Page” ‹ gutenberg — WordPress](https://github.com/WordPress/gutenberg/assets/375788/0f696961-7d4c-400c-9d22-1349af3e441c)

**Cover block with `useFeaturedImage`**
![Screenshot 2023-09-14 at 00-32-36 Edit Page “Sample Page” ‹ gutenberg — WordPress](https://github.com/WordPress/gutenberg/assets/375788/04c0a21a-8691-4666-95af-d26601cc1692)

**Cover block with media `id`**
![Screenshot 2023-09-14 at 00-32-54 Edit Page “Sample Page” ‹ gutenberg — WordPress](https://github.com/WordPress/gutenberg/assets/375788/60b48779-8179-4cea-8090-a74c21b8fc0f)

**Cover block with overlay color only**
![Screenshot 2023-09-14 at 00-33-11 Edit Page “Sample Page” ‹ gutenberg — WordPress](https://github.com/WordPress/gutenberg/assets/375788/dc4e33af-d3bc-444f-9483-39100466f7bc)

**New image block**
![Screenshot 2023-09-14 at 00-33-30 Edit Page “Sample Page” ‹ gutenberg — WordPress](https://github.com/WordPress/gutenberg/assets/375788/09f47de7-3bad-4bf4-8160-c9d93d2583bd)

**Image block with media `id`**
![Screenshot 2023-09-14 at 00-33-46 Edit Page “Sample Page” ‹ gutenberg — WordPress](https://github.com/WordPress/gutenberg/assets/375788/ea1a231e-d076-432e-bcfb-dc27b5559cba)
