### PR TITLE
Puppeteer tests: Try to fix failing tests related to notices in core

### DIFF
--- a/packages/e2e-test-utils/src/posts.js
+++ b/packages/e2e-test-utils/src/posts.js
@@ -41,7 +41,7 @@ export async function trashAllPosts( postType = 'post', postStatus ) {
 	// Submit the form to send all draft/scheduled/published posts to the trash.
 	await page.click( '#doaction' );
 	await page.waitForXPath(
-		'//*[contains(@class, "updated notice")]/p[contains(text(), "moved to the Trash.")]'
+		'//*[contains(@class, "notice")]/p[contains(text(), "moved to the Trash.")]'
 	);
 	await switchUserToTest();
 }

--- a/packages/e2e-test-utils/src/trash-all-comments.js
+++ b/packages/e2e-test-utils/src/trash-all-comments.js
@@ -29,7 +29,7 @@ export async function trashAllComments() {
 	// Submit the form to send all mine/pendings/approved/spam comments to the trash.
 	await page.click( '#doaction' );
 	await page.waitForXPath(
-		'//*[contains(@class, "updated notice")]/p[contains(text(), "moved to the Trash.")]'
+		'//*[contains(@class, "notice")]/p[contains(text(), "moved to the Trash.")]'
 	);
 	await switchUserToTest();
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Try to fix failing Puppeteer tests.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

In core, recent commits update how notices are displayed. It looks like these existing tests might be dependent on the order in which some CSS classes are output. I notice that in core, previously the order was "updated notice is-dismissible", but the order is now "notice is-dismissible updated".

For these Gutenberg tests, the order is not significant, and I think we might be able to use a single class of "notice" in this Xpath query... at least that's what I'm trying out here!

### Notices in WP 6.3.1

<img width="374" alt="image" src="https://github.com/WordPress/gutenberg/assets/14988353/4cf907a6-565b-4b44-8ff6-7db75fe4873c">

### Notices in 6.4 alpha

<img width="407" alt="image" src="https://github.com/WordPress/gutenberg/assets/14988353/240073f5-fc92-4bd4-8e85-16f62656a0ac">

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Try making the Xpath query a little less specific to see if that pleases the tests.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

See if puppeteer tests pass

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
