### PR TITLE
Query Loop: Add design enhancements for the "enhanced pagination" setting

### DIFF
--- a/packages/block-library/src/query/edit/enhanced-pagination-modal.js
+++ b/packages/block-library/src/query/edit/enhanced-pagination-modal.js
@@ -15,7 +15,7 @@ import { useState, useEffect } from '@wordpress/element';
 import { useContainsThirdPartyBlocks } from '../utils';
 
 const disableEnhancedPaginationDescription = __(
-	'Plugin blocks are not supported yet. For enhanced pagination to work, remove the plugin block, then re-enable enhanced pagination in settings.'
+	'Plugin blocks are not supported yet. For the enhanced pagination to work, remove the plugin block, then re-enable "Enhanced pagination" in the Query Block settings.'
 );
 
 const modalDescriptionId =

--- a/packages/block-library/src/query/edit/enhanced-pagination-modal.js
+++ b/packages/block-library/src/query/edit/enhanced-pagination-modal.js
@@ -38,7 +38,7 @@ export default function EnhancedPaginationModal( {
 		isOpen && (
 			<Modal
 				title={ __( 'Enhanced pagination will be disabled' ) }
-				className={ 'wp-block-query-enhanced-pagination-modal' }
+				className="wp-block-query__enhanced-pagination-modal"
 				aria={ {
 					describedby: modalDescriptionId,
 				} }

--- a/packages/block-library/src/query/edit/enhanced-pagination-modal.js
+++ b/packages/block-library/src/query/edit/enhanced-pagination-modal.js
@@ -15,7 +15,7 @@ import { useState, useEffect } from '@wordpress/element';
 import { useContainsThirdPartyBlocks } from '../utils';
 
 const disableEnhancedPaginationDescription = __(
-	'Third-party blocks are not supported inside a Query Loop block with enhanced pagination enabled. To re-enable it, remove any third-party block and then update it in the Query Loop settings.'
+	'Plugin blocks are not supported. For enhanced pagination to work, remove the plugin block, then re-enable it in settings.'
 );
 
 const modalDescriptionId =
@@ -56,7 +56,7 @@ export default function EnhancedPaginationModal( {
 							setAttributes( { enhancedPagination: false } );
 						} }
 					>
-						{ __( 'OK, understood' ) }
+						{ __( 'OK' ) }
 					</Button>
 				</VStack>
 			</Modal>

--- a/packages/block-library/src/query/edit/enhanced-pagination-modal.js
+++ b/packages/block-library/src/query/edit/enhanced-pagination-modal.js
@@ -15,7 +15,7 @@ import { useState, useEffect } from '@wordpress/element';
 import { useContainsThirdPartyBlocks } from '../utils';
 
 const disableEnhancedPaginationDescription = __(
-	'Plugin blocks are not supported. For enhanced pagination to work, remove the plugin block, then re-enable it in settings.'
+	'Plugin blocks are not supported yet. For enhanced pagination to work, remove the plugin block, then re-enable it in settings.'
 );
 
 const modalDescriptionId =

--- a/packages/block-library/src/query/edit/enhanced-pagination-modal.js
+++ b/packages/block-library/src/query/edit/enhanced-pagination-modal.js
@@ -46,7 +46,7 @@ export default function EnhancedPaginationModal( {
 				shouldCloseOnEsc={ false }
 				shouldCloseOnClickOutside={ false }
 			>
-				<VStack alignment="right" spacing={ 8 }>
+				<VStack alignment="right" spacing={ 5 }>
 					<span id={ modalDescriptionId }>
 						{ disableEnhancedPaginationDescription }
 					</span>

--- a/packages/block-library/src/query/edit/enhanced-pagination-modal.js
+++ b/packages/block-library/src/query/edit/enhanced-pagination-modal.js
@@ -15,7 +15,7 @@ import { useState, useEffect } from '@wordpress/element';
 import { useContainsThirdPartyBlocks } from '../utils';
 
 const disableEnhancedPaginationDescription = __(
-	'Plugin blocks are not supported yet. For enhanced pagination to work, remove the plugin block, then re-enable it in settings.'
+	'Plugin blocks are not supported yet. For enhanced pagination to work, remove the plugin block, then re-enable enhanced pagination in settings.'
 );
 
 const modalDescriptionId =

--- a/packages/block-library/src/query/edit/inspector-controls/enhanced-pagination-control.js
+++ b/packages/block-library/src/query/edit/inspector-controls/enhanced-pagination-control.js
@@ -15,7 +15,7 @@ export default function EnhancedPaginationControl( {
 	clientId,
 } ) {
 	const enhancedPaginationNotice = __(
-		'Enhanced pagination only works with the blocks bundled with WordPress. If you want to enable it, you have to remove all plugin blocks from the Query Loop.'
+		'Enhanced pagination doesn\'t support plugin blocks yet. If you want to enable it, you have to remove all plugin blocks from the Query Loop.'
 	);
 
 	const containsThirdPartyBlocks = useContainsThirdPartyBlocks( clientId );

--- a/packages/block-library/src/query/edit/inspector-controls/enhanced-pagination-control.js
+++ b/packages/block-library/src/query/edit/inspector-controls/enhanced-pagination-control.js
@@ -15,7 +15,7 @@ export default function EnhancedPaginationControl( {
 	clientId,
 } ) {
 	const enhancedPaginationNotice = __(
-		'Enhanced pagination doesn\'t support plugin blocks yet. If you want to enable it, you have to remove all plugin blocks from the Query Loop.'
+		"Enhanced pagination doesn't support plugin blocks yet. If you want to enable it, you have to remove all plugin blocks from the Query Loop."
 	);
 
 	const containsThirdPartyBlocks = useContainsThirdPartyBlocks( clientId );

--- a/packages/block-library/src/query/edit/inspector-controls/enhanced-pagination-control.js
+++ b/packages/block-library/src/query/edit/inspector-controls/enhanced-pagination-control.js
@@ -15,7 +15,7 @@ export default function EnhancedPaginationControl( {
 	clientId,
 } ) {
 	const enhancedPaginationNotice = __(
-		'Enhanced pagination requires all descendants to be Core blocks. If you want to enable it, you have to remove all third-party blocks contained inside the Query Loop block.'
+		'Enhanced pagination only works with the blocks bundled with WordPress. If you want to enable it, you have to remove all plugin blocks from the Query Loop.'
 	);
 
 	const containsThirdPartyBlocks = useContainsThirdPartyBlocks( clientId );

--- a/packages/block-library/src/query/edit/inspector-controls/enhanced-pagination-control.js
+++ b/packages/block-library/src/query/edit/inspector-controls/enhanced-pagination-control.js
@@ -36,11 +36,13 @@ export default function EnhancedPaginationControl( {
 				} }
 			/>
 			{ containsThirdPartyBlocks && (
-				<div>
-					<Notice status="warning" isDismissible={ false }>
-						{ enhancedPaginationNotice }
-					</Notice>
-				</div>
+				<Notice
+					status="warning"
+					isDismissible={ false }
+					className="wp-block-query__enhanced-pagination-notice"
+				>
+					{ enhancedPaginationNotice }
+				</Notice>
 			) }
 		</>
 	);

--- a/packages/block-library/src/query/editor.scss
+++ b/packages/block-library/src/query/editor.scss
@@ -53,7 +53,7 @@
 	}
 }
 
-.wp-block-query-enhanced-pagination-modal {
+.wp-block-query__enhanced-pagination-modal {
 	@include break-small() {
 		max-width: $break-mobile;
 	}

--- a/packages/block-library/src/query/editor.scss
+++ b/packages/block-library/src/query/editor.scss
@@ -58,3 +58,7 @@
 		max-width: $break-mobile;
 	}
 }
+
+.wp-block-query__enhanced-pagination-notice {
+	margin: 0;
+}

--- a/packages/block-library/src/query/style.scss
+++ b/packages/block-library/src/query/style.scss
@@ -14,8 +14,8 @@
 		animation:
 			wp-block-query__enhanced-pagination-start-animation
 			30s
-			cubic-bezier(0, 1, 0, 1)
-			infinite;
+			cubic-bezier(0.03, 0.5, 0, 1)
+			forwards;
 	}
 
 	&.finish-animation {

--- a/packages/block-library/src/query/style.scss
+++ b/packages/block-library/src/query/style.scss
@@ -24,6 +24,16 @@
 			300ms
 			ease-in;
 	}
+
+	&.start-animation,
+	&.finish-animation {
+		@media (prefers-reduced-motion: reduce) {
+			transition-duration: 0s;
+			transition-delay: 0s;
+			animation-duration: 1ms;
+			animation-delay: 0s;
+		}
+	}
 }
 
 @keyframes wp-block-query__enhanced-pagination-start-animation {

--- a/packages/block-library/src/query/style.scss
+++ b/packages/block-library/src/query/style.scss
@@ -24,16 +24,6 @@
 			300ms
 			ease-in;
 	}
-
-	&.start-animation,
-	&.finish-animation {
-		@media (prefers-reduced-motion: reduce) {
-			transition-duration: 0s;
-			transition-delay: 0s;
-			animation-duration: 1ms;
-			animation-delay: 0s;
-		}
-	}
 }
 
 @keyframes wp-block-query__enhanced-pagination-start-animation {

--- a/packages/block-library/src/query/view.js
+++ b/packages/block-library/src/query/view.js
@@ -44,7 +44,7 @@ store( {
 							context.core.query.message =
 								context.core.query.loadingText;
 							context.core.query.animation = 'start';
-						}, 300 );
+						}, 400 );
 
 						await navigate( ref.href );
 


### PR DESCRIPTION
## What?

This PR addresses most of the tasks listed in https://github.com/WordPress/gutenberg/issues/54414 to improve the design of Query Loop's enhanced pagination setting.

- Updates all texts with the proposed ones.
- Removes the left/right margin of the error notice.
- Modifies the loading bar animation so it doesn't progress too fast initially.
- Changes the animation starting delay from 300 to 400 ms.

## Why?

To improve the feature design.

## How?

Please take a look at the code changes; they're pretty easy to follow. 🙂 

Regarding the loading bar animation, I tried to use an animation timing function that reaches the midpoint in 1-2 seconds approx., and the final point after 30 seconds.

This animation is also disabled when reduced motion is preferred.

## Testing Instructions

For the editor changes:
1. Go to the Blog Home template.
2. Activate "enhanced pagination" in the Query Loop block.
3. Install any plugin block,
5. Insert the block inside the Query Loop, at any position.
6. Ensure a modal appears, indicating that the "enhanced pagination" will be disabled. The texts should be:
   - Title: `Enhanced pagination will be disabled`
   - Content:
      ```
      Plugin blocks are not supported. For enhanced pagination to work, remove the plugin block, then re-enable it in settings.
      ```
   - Button: `OK`
10. Click `OK`
11. Check the setting has been disabled and a notice appears below with the following text:
      ```
      Enhanced pagination only works with the blocks bundled with WordPress. If you want to enable it, you have to remove all plugin blocks from the Query Loop.
      ```
12. Check that the notice box is aligned with the text around (i.e., it doesn't have any margin).
13. Try to enable the setting―it shouldn't be possible.
14. Remove the block manually and activate enhanced pagination again.
15. Save changes.

For the loading bar animation:
1. With the enhanced pagination enabled in the Blog Home's Query Loop, go to the WP dashboard
2. In Settings / Reading, modify "Blog pages show at most" to, e.g., `1`.
3. Add a couple of posts.
4. Visit the blog home in Incognito so the admin top bar doesn't appear.
5. In the browser dev tools, modify the network throttling option to Slow 3G (or any other value to emulate a slow connection).
6. Click on Previous posts.
7. Check that the loading bar appears, it's animated, and takes around 1-2 seconds to reach the midpoint.
8. Disable network throttling and repeat.
9. The loading bar should not appear (if the local server responds in less than 400ms).
10. In your OS accessibility settings, enable "reduce motion"
11. Repeat the process again with the network throttling set to Slow 3G.
12. The bar should appear but not be animated.


## Screenshots or screencast

| Editor changes | Loading bar changes |
| --- | --- |
| <video src="https://github.com/WordPress/gutenberg/assets/6917969/eda82e10-71d7-4191-967b-bb3f70e6d1d4"></video> | <video src="https://github.com/WordPress/gutenberg/assets/6917969/9ab1513e-1e14-438d-ac18-913634ef0e18"></video> |
