### PR TITLE
Ensure that 'Duotone Filter' color pickers have relevant labels

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -12,6 +12,7 @@
 -   `BorderControl`: Apply proper metrics and simpler text ([#53998](https://github.com/WordPress/gutenberg/pull/53998)).
 -   `FormTokenField`: Update styling for consistency and increased visibility ([#54402](https://github.com/WordPress/gutenberg/pull/54402)).
 -   `Tooltip`: Add new `hideOnClick` prop ([#54406](https://github.com/WordPress/gutenberg/pull/54406)).
+-   `DuotonePicker/ColorListPicker`: Adds appropriate labels to 'Duotone Filter' color pickers ([#54468](https://github.com/WordPress/gutenberg/pull/54468)).
 
 ### Bug Fix
 

--- a/packages/components/src/duotone-picker/color-list-picker/index.tsx
+++ b/packages/components/src/duotone-picker/color-list-picker/index.tsx
@@ -13,6 +13,7 @@ import ColorIndicator from '../../color-indicator';
 import Icon from '../../icon';
 import { HStack } from '../../h-stack';
 import type { ColorListPickerProps, ColorOptionProps } from './types';
+import { useInstanceId } from '@wordpress/compose';
 
 function ColorOption( {
 	label,
@@ -23,6 +24,8 @@ function ColorOption( {
 	onChange,
 }: ColorOptionProps ) {
 	const [ isOpen, setIsOpen ] = useState( false );
+	const labelId = useInstanceId( ColorOption, 'color-list-picker-option' );
+
 	return (
 		<>
 			<Button
@@ -38,11 +41,12 @@ function ColorOption( {
 					) : (
 						<Icon icon={ swatch } />
 					) }
-					<span>{ label }</span>
+					<span id={ labelId }>{ label }</span>
 				</HStack>
 			</Button>
 			{ isOpen && (
 				<ColorPalette
+					aria-labelledby={ labelId }
 					className="components-color-list-picker__color-picker"
 					colors={ colors }
 					value={ value }

--- a/packages/components/src/duotone-picker/color-list-picker/index.tsx
+++ b/packages/components/src/duotone-picker/color-list-picker/index.tsx
@@ -3,6 +3,7 @@
  */
 import { useState } from '@wordpress/element';
 import { swatch } from '@wordpress/icons';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -24,13 +25,17 @@ function ColorOption( {
 	onChange,
 }: ColorOptionProps ) {
 	const [ isOpen, setIsOpen ] = useState( false );
-	const labelId = useInstanceId( ColorOption, 'color-list-picker-option' );
+	const idRoot = useInstanceId( ColorOption, 'color-list-picker-option' );
+	const labelId = `${ idRoot }__label`;
+	const contentId = `${ idRoot }__content`;
 
 	return (
 		<>
 			<Button
 				className="components-color-list-picker__swatch-button"
 				onClick={ () => setIsOpen( ( prev ) => ! prev ) }
+				aria-expanded={ isOpen }
+				aria-controls={ contentId }
 			>
 				<HStack justify="flex-start" spacing={ 2 }>
 					{ value ? (
@@ -44,18 +49,25 @@ function ColorOption( {
 					<span id={ labelId }>{ label }</span>
 				</HStack>
 			</Button>
-			{ isOpen && (
-				<ColorPalette
-					aria-labelledby={ labelId }
-					className="components-color-list-picker__color-picker"
-					colors={ colors }
-					value={ value }
-					clearable={ false }
-					onChange={ onChange }
-					disableCustomColors={ disableCustomColors }
-					enableAlpha={ enableAlpha }
-				/>
-			) }
+			<div
+				role="group"
+				id={ contentId }
+				aria-labelledby={ labelId }
+				aria-hidden={ ! isOpen }
+			>
+				{ isOpen && (
+					<ColorPalette
+						aria-label={ __( 'Color options' ) }
+						className="components-color-list-picker__color-picker"
+						colors={ colors }
+						value={ value }
+						clearable={ false }
+						onChange={ onChange }
+						disableCustomColors={ disableCustomColors }
+						enableAlpha={ enableAlpha }
+					/>
+				) }
+			</div>
 		</>
 	);
 }


### PR DESCRIPTION
## What?
This PR ensures that the color pickers found in the image duotone filter panel have identifying labels.

<img src="https://github.com/WordPress/gutenberg/assets/159848/25b8152d-8292-4739-a556-ecc45a2d6384" alt="Screenshot of image duotone filter panel, with hand-drawn arrow connecting the label 'Shadows' with a color palette" width="280px">

## Why?
As per #54055, every `ColorPalette` needs to have an appropriate contextual label.

## How?
An ID is generated and assigned to the node containing the palette label strings. This is linked with the respective `ColorPalette`s with `aria-labelledby` props.

## Testing Instructions
* Add an image in the editor
* Open the 'Apply duotone filter' popup
* Expand the 'Shadows' and 'Highlights' sections
* Confirm that the color pickers have `aria-labelledby` attributes, and that these point to the relevant section headers
* Confirm that the generated name matches the value of the section header
