### PR TITLE
Use aria-describedBy to communicate border button style and color state

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-## 25.13.0 (2023-11-29)
+- `BorderControlDropdown`: Switches from appending state to the aria-label and adds an aria-describedBy attribute with hidden text (via display: none;, as the text will be read via focus on the button and doesn't need to announced otherwise ([#54469](https://github.com/WordPress/gutenberg/pull/54469)).
 
 ### Enhancements
 

--- a/packages/components/src/border-box-control/test/index.tsx
+++ b/packages/components/src/border-box-control/test/index.tsx
@@ -46,8 +46,8 @@ const props = {
 	value: undefined,
 };
 
-const toggleLabelRegex = /Border color( and style)* picker/;
-const colorPickerRegex = /Border color picker/;
+const toggleLabelRegex = /The currently selected color has/;
+const colorPickerRegex = /The currently selected color is called/;
 
 describe( 'BorderBoxControl', () => {
 	describe( 'Linked view rendering', () => {

--- a/packages/components/src/border-control/border-control-dropdown/component.tsx
+++ b/packages/components/src/border-control/border-control-dropdown/component.tsx
@@ -66,7 +66,7 @@ const getColorObject = (
 	return colors.find( ( color ) => color.color === colorValue );
 };
 
-const getToggleAriaDescription = (
+const getToggleDescription = (
 	colorValue: CSSProperties[ 'borderColor' ],
 	colorObject: ColorObject | undefined,
 	style: CSSProperties[ 'borderStyle' ],
@@ -165,12 +165,12 @@ const BorderControlDropdown = (
 
 	const { color, style } = border || {};
 	const colorObject = getColorObject( color, colors );
-	const descriptionId = useInstanceId(
+	const toggleDescriptionId = useInstanceId(
 		BorderControlDropdown,
 		'border-control-dropdown'
 	);
 
-	const toggleAriaDescription = getToggleAriaDescription(
+	const toggleDescription = getToggleDescription(
 		color,
 		colorObject,
 		style,
@@ -182,20 +182,22 @@ const BorderControlDropdown = (
 		? 'bottom left'
 		: undefined;
 
+	const renderToggleDescribedBy: DropdownComponentProps[ 'renderToggleDescribedBy' ] = () => (
+		<VisuallyHidden id={ toggleDescriptionId }>
+			{ toggleDescription }
+		</VisuallyHidden>
+	);
+
 	const renderToggle: DropdownComponentProps[ 'renderToggle' ] = ( {
 		onToggle,
 	} ) => (
-		<>
-			<VisuallyHidden id={ descriptionId }>
-				{ toggleAriaDescription }
-			</VisuallyHidden>
 			<Button
 				onClick={ onToggle }
 				variant="tertiary"
 				tooltipPosition={ dropdownPosition }
 				label={ __( 'Border color and style picker' ) }
 				showTooltip={ true }
-				aria-describedby={ descriptionId }
+				aria-describedby={ toggleDescriptionId }
 			>
 				<span className={ indicatorWrapperClassName }>
 					<ColorIndicator
@@ -204,7 +206,6 @@ const BorderControlDropdown = (
 					/>
 				</span>
 			</Button>
-		</>
 	);
 
 	const renderContent: DropdownComponentProps[ 'renderContent' ] = ( {
@@ -262,15 +263,18 @@ const BorderControlDropdown = (
 	);
 
 	return (
-		<Dropdown
-			renderToggle={ renderToggle }
-			renderContent={ renderContent }
-			popoverProps={ {
-				...__unstablePopoverProps,
-			} }
-			{ ...otherProps }
-			ref={ forwardedRef }
-		/>
+		<>
+			{ renderToggleDescribedBy() }
+			<Dropdown
+				renderToggle={ renderToggle }
+				renderContent={ renderContent }
+				popoverProps={ {
+					...__unstablePopoverProps,
+				} }
+				{ ...otherProps }
+				ref={ forwardedRef }
+			/>
+		</>
 	);
 };
 

--- a/packages/components/src/border-control/border-control-dropdown/component.tsx
+++ b/packages/components/src/border-control/border-control-dropdown/component.tsx
@@ -6,6 +6,7 @@ import type { CSSProperties } from 'react';
 /**
  * WordPress dependencies
  */
+import { useInstanceId } from '@wordpress/compose';
 import { __, sprintf } from '@wordpress/i18n';
 import { closeSmall } from '@wordpress/icons';
 
@@ -30,7 +31,7 @@ import { isMultiplePaletteArray } from '../../color-palette/utils';
 import type { DropdownProps as DropdownComponentProps } from '../../dropdown/types';
 import type { ColorProps, DropdownProps } from '../types';
 
-const getAriaLabelColorValue = ( colorValue: string ) => {
+const getAriaDescriptionColorValue = ( colorValue: string ) => {
 	// Leave hex values as-is. Remove the `var()` wrapper from CSS vars.
 	return colorValue.replace( /^var\((.+)\)$/, '$1' );
 };
@@ -65,7 +66,7 @@ const getColorObject = (
 	return colors.find( ( color ) => color.color === colorValue );
 };
 
-const getToggleAriaLabel = (
+const getToggleAriaDescription = (
 	colorValue: CSSProperties[ 'borderColor' ],
 	colorObject: ColorObject | undefined,
 	style: CSSProperties[ 'borderStyle' ],
@@ -73,60 +74,69 @@ const getToggleAriaLabel = (
 ) => {
 	if ( isStyleEnabled ) {
 		if ( colorObject ) {
-			const ariaLabelValue = getAriaLabelColorValue( colorObject.color );
+			const ariaDescriptionValue = getAriaDescriptionColorValue(
+				colorObject.color
+			);
 			return style
 				? sprintf(
 						// translators: %1$s: The name of the color e.g. "vivid red". %2$s: The color's hex code e.g.: "#f00:". %3$s: The current border style selection e.g. "solid".
-						'Border color and style picker. The currently selected color is called "%1$s" and has a value of "%2$s". The currently selected style is "%3$s".',
+						'The currently selected color is called "%1$s" and has a value of "%2$s". The currently selected style is "%3$s".',
 						colorObject.name,
-						ariaLabelValue,
+						ariaDescriptionValue,
 						style
 				  )
 				: sprintf(
 						// translators: %1$s: The name of the color e.g. "vivid red". %2$s: The color's hex code e.g.: "#f00:".
-						'Border color and style picker. The currently selected color is called "%1$s" and has a value of "%2$s".',
+						'The currently selected color is called "%1$s" and has a value of "%2$s".',
 						colorObject.name,
-						ariaLabelValue
+						ariaDescriptionValue
 				  );
 		}
 
 		if ( colorValue ) {
-			const ariaLabelValue = getAriaLabelColorValue( colorValue );
+			const ariaDescriptionValue =
+				getAriaDescriptionColorValue( colorValue );
 			return style
 				? sprintf(
 						// translators: %1$s: The color's hex code e.g.: "#f00:". %2$s: The current border style selection e.g. "solid".
-						'Border color and style picker. The currently selected color has a value of "%1$s". The currently selected style is "%2$s".',
-						ariaLabelValue,
+						'The currently selected color has a value of "%1$s". The currently selected style is "%2$s".',
+						ariaDescriptionValue,
 						style
 				  )
 				: sprintf(
 						// translators: %1$s: The color's hex code e.g: "#f00".
-						'Border color and style picker. The currently selected color has a value of "%1$s".',
-						ariaLabelValue
+						'The currently selected color has a value of "%1$s".',
+						ariaDescriptionValue
 				  );
 		}
 
-		return __( 'Border color and style picker.' );
+		if ( style ) {
+			return sprintf(
+				// translators: %1$s: The current border style selection e.g. "solid".
+				'The currently selected style is "%1$s". No color is selected. Select a color to display the border.',
+				style
+			);
+		}
 	}
 
 	if ( colorObject ) {
 		return sprintf(
 			// translators: %1$s: The name of the color e.g. "vivid red". %2$s: The color's hex code e.g: "#f00".
-			'Border color picker. The currently selected color is called "%1$s" and has a value of "%2$s".',
+			'The currently selected color is called "%1$s" and has a value of "%2$s".',
 			colorObject.name,
-			getAriaLabelColorValue( colorObject.color )
+			getAriaDescriptionColorValue( colorObject.color )
 		);
 	}
 
 	if ( colorValue ) {
 		return sprintf(
 			// translators: %1$s: The color's hex code e.g: "#f00".
-			'Border color picker. The currently selected color has a value of "%1$s".',
-			getAriaLabelColorValue( colorValue )
+			'The currently selected color has a value of "%1$s".',
+			getAriaDescriptionColorValue( colorValue )
 		);
 	}
 
-	return __( 'Border color picker.' );
+	return __( 'Select a border color and style.' );
 };
 
 const BorderControlDropdown = (
@@ -155,8 +165,12 @@ const BorderControlDropdown = (
 
 	const { color, style } = border || {};
 	const colorObject = getColorObject( color, colors );
+	const descriptionId = useInstanceId(
+		BorderControlDropdown,
+		'border-control-dropdown'
+	);
 
-	const toggleAriaLabel = getToggleAriaLabel(
+	const toggleAriaDescription = getToggleAriaDescription(
 		color,
 		colorObject,
 		style,
@@ -171,21 +185,26 @@ const BorderControlDropdown = (
 	const renderToggle: DropdownComponentProps[ 'renderToggle' ] = ( {
 		onToggle,
 	} ) => (
-		<Button
-			onClick={ onToggle }
-			variant="tertiary"
-			aria-label={ toggleAriaLabel }
-			tooltipPosition={ dropdownPosition }
-			label={ __( 'Border color and style picker' ) }
-			showTooltip={ true }
-		>
-			<span className={ indicatorWrapperClassName }>
-				<ColorIndicator
-					className={ indicatorClassName }
-					colorValue={ color }
-				/>
-			</span>
-		</Button>
+		<>
+			<div id={ descriptionId } style={ { display: 'none' } }>
+				{ toggleAriaDescription }
+			</div>
+			<Button
+				onClick={ onToggle }
+				variant="tertiary"
+				tooltipPosition={ dropdownPosition }
+				label={ __( 'Border color and style picker' ) }
+				showTooltip={ true }
+				aria-describedby={ descriptionId }
+			>
+				<span className={ indicatorWrapperClassName }>
+					<ColorIndicator
+						className={ indicatorClassName }
+						colorValue={ color }
+					/>
+				</span>
+			</Button>
+		</>
 	);
 
 	const renderContent: DropdownComponentProps[ 'renderContent' ] = ( {

--- a/packages/components/src/border-control/border-control-dropdown/component.tsx
+++ b/packages/components/src/border-control/border-control-dropdown/component.tsx
@@ -182,7 +182,7 @@ const BorderControlDropdown = (
 		? 'bottom left'
 		: undefined;
 
-	const renderToggleDescribedBy: DropdownComponentProps[ 'renderToggleDescribedBy' ] = () => (
+	const ToggleDescribedBy = () => (
 		<VisuallyHidden id={ toggleDescriptionId }>
 			{ toggleDescription }
 		</VisuallyHidden>
@@ -191,21 +191,21 @@ const BorderControlDropdown = (
 	const renderToggle: DropdownComponentProps[ 'renderToggle' ] = ( {
 		onToggle,
 	} ) => (
-			<Button
-				onClick={ onToggle }
-				variant="tertiary"
-				tooltipPosition={ dropdownPosition }
-				label={ __( 'Border color and style picker' ) }
-				showTooltip={ true }
-				aria-describedby={ toggleDescriptionId }
-			>
-				<span className={ indicatorWrapperClassName }>
-					<ColorIndicator
-						className={ indicatorClassName }
-						colorValue={ color }
-					/>
-				</span>
-			</Button>
+		<Button
+			onClick={ onToggle }
+			variant="tertiary"
+			tooltipPosition={ dropdownPosition }
+			label={ __( 'Border color and style picker' ) }
+			showTooltip={ true }
+			aria-describedby={ toggleDescriptionId }
+		>
+			<span className={ indicatorWrapperClassName }>
+				<ColorIndicator
+					className={ indicatorClassName }
+					colorValue={ color }
+				/>
+			</span>
+		</Button>
 	);
 
 	const renderContent: DropdownComponentProps[ 'renderContent' ] = ( {
@@ -264,7 +264,7 @@ const BorderControlDropdown = (
 
 	return (
 		<>
-			{ renderToggleDescribedBy() }
+			<ToggleDescribedBy />
 			<Dropdown
 				renderToggle={ renderToggle }
 				renderContent={ renderContent }

--- a/packages/components/src/border-control/border-control-dropdown/component.tsx
+++ b/packages/components/src/border-control/border-control-dropdown/component.tsx
@@ -182,12 +182,6 @@ const BorderControlDropdown = (
 		? 'bottom left'
 		: undefined;
 
-	const ToggleDescribedBy = () => (
-		<VisuallyHidden id={ toggleDescriptionId }>
-			{ toggleDescription }
-		</VisuallyHidden>
-	);
-
 	const renderToggle: DropdownComponentProps[ 'renderToggle' ] = ( {
 		onToggle,
 	} ) => (
@@ -264,7 +258,9 @@ const BorderControlDropdown = (
 
 	return (
 		<>
-			<ToggleDescribedBy />
+			<VisuallyHidden id={ toggleDescriptionId }>
+				{ toggleDescription }
+			</VisuallyHidden>
 			<Dropdown
 				renderToggle={ renderToggle }
 				renderContent={ renderContent }

--- a/packages/components/src/border-control/border-control-dropdown/component.tsx
+++ b/packages/components/src/border-control/border-control-dropdown/component.tsx
@@ -25,7 +25,7 @@ import { contextConnect } from '../../context';
 import { useBorderControlDropdown } from './hook';
 import { StyledLabel } from '../../base-control/styles/base-control-styles';
 import DropdownContentWrapper from '../../dropdown/dropdown-content-wrapper';
-
+import { VisuallyHidden } from '../../visually-hidden';
 import type { ColorObject } from '../../color-palette/types';
 import { isMultiplePaletteArray } from '../../color-palette/utils';
 import type { DropdownProps as DropdownComponentProps } from '../../dropdown/types';
@@ -186,9 +186,9 @@ const BorderControlDropdown = (
 		onToggle,
 	} ) => (
 		<>
-			<div id={ descriptionId } style={ { display: 'none' } }>
+			<VisuallyHidden id={ descriptionId }>
 				{ toggleAriaDescription }
-			</div>
+			</VisuallyHidden>
 			<Button
 				onClick={ onToggle }
 				variant="tertiary"

--- a/packages/components/src/border-control/border-control-dropdown/component.tsx
+++ b/packages/components/src/border-control/border-control-dropdown/component.tsx
@@ -25,7 +25,6 @@ import { contextConnect } from '../../context';
 import { useBorderControlDropdown } from './hook';
 import { StyledLabel } from '../../base-control/styles/base-control-styles';
 import DropdownContentWrapper from '../../dropdown/dropdown-content-wrapper';
-import { VisuallyHidden } from '../../visually-hidden';
 import type { ColorObject } from '../../color-palette/types';
 import { isMultiplePaletteArray } from '../../color-palette/utils';
 import type { DropdownProps as DropdownComponentProps } from '../../dropdown/types';
@@ -258,9 +257,9 @@ const BorderControlDropdown = (
 
 	return (
 		<>
-			<VisuallyHidden id={ toggleDescriptionId }>
+			<div id={ toggleDescriptionId } style={ { display: 'none' } }>
 				{ toggleDescription }
-			</VisuallyHidden>
+			</div>
 			<Dropdown
 				renderToggle={ renderToggle }
 				renderContent={ renderContent }

--- a/packages/components/src/border-control/test/index.js
+++ b/packages/components/src/border-control/test/index.js
@@ -186,7 +186,7 @@ describe( 'BorderControl', () => {
 				render( <BorderControl { ...props } /> );
 
 				expect(
-					screen.getByLabelText( 'Border color and style picker.' )
+					screen.getByText( 'Select a border color and style.' )
 				).toBeInTheDocument();
 			} );
 
@@ -195,8 +195,8 @@ describe( 'BorderControl', () => {
 				render( <BorderControl { ...props } /> );
 
 				expect(
-					screen.getByLabelText(
-						'Border color and style picker. The currently selected color is called "Blue" and has a value of "#72aee6".'
+					screen.getByText(
+						'The currently selected color is called "Blue" and has a value of "#72aee6".'
 					)
 				).toBeInTheDocument();
 			} );
@@ -206,8 +206,8 @@ describe( 'BorderControl', () => {
 				render( <BorderControl { ...props } /> );
 
 				expect(
-					screen.getByLabelText(
-						'Border color and style picker. The currently selected color has a value of "#4b1d80".'
+					screen.getByText(
+						'The currently selected color has a value of "#4b1d80".'
 					)
 				).toBeInTheDocument();
 			} );
@@ -219,8 +219,8 @@ describe( 'BorderControl', () => {
 				render( <BorderControl { ...props } /> );
 
 				expect(
-					screen.getByLabelText(
-						'Border color and style picker. The currently selected color is called "Blue" and has a value of "#72aee6". The currently selected style is "dotted".'
+					screen.getByText(
+						'The currently selected color is called "Blue" and has a value of "#72aee6". The currently selected style is "dotted".'
 					)
 				).toBeInTheDocument();
 			} );
@@ -232,8 +232,8 @@ describe( 'BorderControl', () => {
 				render( <BorderControl { ...props } /> );
 
 				expect(
-					screen.getByLabelText(
-						'Border color and style picker. The currently selected color has a value of "#4b1d80". The currently selected style is "dashed".'
+					screen.getByText(
+						'The currently selected color has a value of "#4b1d80". The currently selected style is "dashed".'
 					)
 				).toBeInTheDocument();
 			} );
@@ -248,7 +248,7 @@ describe( 'BorderControl', () => {
 				render( <BorderControl { ...props } /> );
 
 				expect(
-					screen.getByLabelText( 'Border color picker.' )
+					screen.getByText( 'Select a border color and style.' )
 				).toBeInTheDocument();
 			} );
 
@@ -260,8 +260,8 @@ describe( 'BorderControl', () => {
 				render( <BorderControl { ...props } /> );
 
 				expect(
-					screen.getByLabelText(
-						'Border color picker. The currently selected color is called "Blue" and has a value of "#72aee6".'
+					screen.getByText(
+						'The currently selected color is called "Blue" and has a value of "#72aee6".'
 					)
 				).toBeInTheDocument();
 			} );
@@ -274,8 +274,8 @@ describe( 'BorderControl', () => {
 				render( <BorderControl { ...props } /> );
 
 				expect(
-					screen.getByLabelText(
-						'Border color picker. The currently selected color has a value of "#4b1d80".'
+					screen.getByText(
+						'The currently selected color has a value of "#4b1d80".'
 					)
 				).toBeInTheDocument();
 			} );

--- a/packages/components/src/dropdown/types.ts
+++ b/packages/components/src/dropdown/types.ts
@@ -13,7 +13,6 @@ type CallbackProps = {
 	isOpen: boolean;
 	onToggle: () => void;
 	onClose: () => void;
-	renderToggleDescribedBy: () => ReactNode;
 };
 
 export type DropdownContentWrapperProps = {
@@ -84,11 +83,6 @@ export type DropdownProps = {
 	 * Its first argument is the same as the renderToggle prop.
 	 */
 	renderContent: ( props: CallbackProps ) => ReactNode;
-
-	/**
-	 * A callback invoked to render the aria description container of the dropdown menu.
-	 */
-	renderToggleDescribedBy: () => ReactNode;
 
 	/**
 	 * A callback invoked to render the Dropdown Toggle Button.

--- a/packages/components/src/dropdown/types.ts
+++ b/packages/components/src/dropdown/types.ts
@@ -13,6 +13,7 @@ type CallbackProps = {
 	isOpen: boolean;
 	onToggle: () => void;
 	onClose: () => void;
+	renderToggleDescribedBy: () => ReactNode;
 };
 
 export type DropdownContentWrapperProps = {
@@ -83,6 +84,12 @@ export type DropdownProps = {
 	 * Its first argument is the same as the renderToggle prop.
 	 */
 	renderContent: ( props: CallbackProps ) => ReactNode;
+
+	/**
+	 * A callback invoked to render the aria description container of the dropdown menu.
+	 */
+	renderToggleDescribedBy: () => ReactNode;
+
 	/**
 	 * A callback invoked to render the Dropdown Toggle Button.
 	 *

--- a/packages/components/src/dropdown/types.ts
+++ b/packages/components/src/dropdown/types.ts
@@ -83,7 +83,6 @@ export type DropdownProps = {
 	 * Its first argument is the same as the renderToggle prop.
 	 */
 	renderContent: ( props: CallbackProps ) => ReactNode;
-
 	/**
 	 * A callback invoked to render the Dropdown Toggle Button.
 	 *


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Communicate border color and style via `aria-describedBy` using an approach explained by @afercia in https://github.com/WordPress/gutenberg/pull/54439#issuecomment-1719006321

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The previous approach appended a long message to the aria-label to communicate the state of the color selection. This is not desireable, as it changes the accessible name of the button. The accessible name of the button should be stable and brief, and not be used to communicate state. By using aria-describedBy, we can communicate the state in a way that is similarly announced but keeps button name and state separate.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Switches from appending state to the aria-label and adds an aria-describedBy attribute with hidden text (via `display: none;`, as the text will be read via focus on the button and doesn't need to announced otherwise.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a screenreader (Command + F5 on MacOS)
2. Focus the border picker button of a group block (Sidebar styles menu)
3. Test the various states and that announcements are sensible. States to test are:
  - No style, no color
  - Style,  no color
  - Named color, no style
  - Named color, with style
  - Hex/rgba color, no style
  - Hex/rgba color, with style

## Screenshots or screencast <!-- if applicable -->
<img width="959" alt="Border color and style picker, with screen reader announcement text window saying, 'Border color and style picker The currentlv selected color is called 'Secondary' and has a value of '#345C00' The currently selected style is 'solid'., button" src="https://github.com/WordPress/gutenberg/assets/967608/af1b6d6e-b4c5-4cfa-a404-d3921ef56aeb">

