### PR TITLE
Modal: add `size` prop to support a selection of preset modal sizes

### DIFF
--- a/packages/base-styles/_variables.scss
+++ b/packages/base-styles/_variables.scss
@@ -58,6 +58,9 @@ $admin-sidebar-width: 160px;
 $admin-sidebar-width-big: 190px;
 $admin-sidebar-width-collapsed: 36px;
 $modal-min-width: 350px;
+$modal-width-small: 384px;
+$modal-width-medium: 512px;
+$modal-width-large: 840px;
 $spinner-size: 16px;
 $canvas-padding: $grid-unit-30;
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -9,6 +9,7 @@
 -   `DuotonePicker/ColorListPicker`: Adds appropriate label and description to 'Duotone Filter' picker ([#54473](https://github.com/WordPress/gutenberg/pull/54473)).
 -   `Modal`: Accessibly hide/show outer modal when nested ([#54743](https://github.com/WordPress/gutenberg/pull/54743)).
 -   `InputControl`, `NumberControl`, `UnitControl`, `SelectControl`, `CustomSelectControl`, `TreeSelect`: Add opt-in prop for next 40px default size, superseding the `__next36pxDefaultSize` prop ([#53819](https://github.com/WordPress/gutenberg/pull/53819)).
+-   `Modal`: add a new `size` prop to support preset widths, including a `fill` option to eventually replace the `isFullScreen` prop ([#54471](https://github.com/WordPress/gutenberg/pull/54471)).
 
 ### Bug Fix
 

--- a/packages/components/src/modal/README.md
+++ b/packages/components/src/modal/README.md
@@ -227,7 +227,7 @@ If this property is added, it will constrain the `max-width` of the modal's cont
 
 -   Required: No
 
-Note: `Modal`'s width can also be controlled by adjusting the width of the modal's contents, or using the `style` prop to set a specific `max-width`.
+Note: `Modal`'s width can also be controlled by adjusting the width of the modal's contents via CSS.
 
 #### `onRequestClose`: ``
 

--- a/packages/components/src/modal/README.md
+++ b/packages/components/src/modal/README.md
@@ -221,6 +221,12 @@ This property when set to `true` will render a full screen modal.
 -   Required: No
 -   Default: `false`
 
+#### `contentWidth`: `'small' | 'medium' | 'large'`
+
+If this property is added, it will constrain the `max-width` of the modal's contents, preventing it from growing too wide. This prop only applies when `isFullScreen` is `false`.
+
+Note: `Modal`'s width can also be controlled by adjusting the width of the modal's contents, or using the `style` prop to set a specific `max-width`.
+
 #### `onRequestClose`: ``
 
 This function is called to indicate that the modal should be closed.

--- a/packages/components/src/modal/README.md
+++ b/packages/components/src/modal/README.md
@@ -221,7 +221,7 @@ This property when set to `true` will render a full screen modal.
 -   Required: No
 -   Default: `false`
 
-#### `size`: `'small' | 'medium' | 'large'`
+#### `size`: `'small' | 'medium' | 'large' | 'fill'`
 
 If this property is added it will cause the modal to render at a preset width, or expand to fill the screen.
 

--- a/packages/components/src/modal/README.md
+++ b/packages/components/src/modal/README.md
@@ -221,9 +221,9 @@ This property when set to `true` will render a full screen modal.
 -   Required: No
 -   Default: `false`
 
-#### `contentWidth`: `'small' | 'medium' | 'large'`
+#### `size`: `'small' | 'medium' | 'large'`
 
-If this property is added, it will constrain the `max-width` of the modal's contents, preventing it from growing too wide. This prop only applies when `isFullScreen` is `false`.
+If this property is added it will cause the modal to render at a preset width, or expand to fill the screen.
 
 -   Required: No
 

--- a/packages/components/src/modal/README.md
+++ b/packages/components/src/modal/README.md
@@ -225,6 +225,8 @@ This property when set to `true` will render a full screen modal.
 
 If this property is added, it will constrain the `max-width` of the modal's contents, preventing it from growing too wide. This prop only applies when `isFullScreen` is `false`.
 
+-   Required: No
+
 Note: `Modal`'s width can also be controlled by adjusting the width of the modal's contents, or using the `style` prop to set a specific `max-width`.
 
 #### `onRequestClose`: ``

--- a/packages/components/src/modal/README.md
+++ b/packages/components/src/modal/README.md
@@ -223,7 +223,7 @@ This property when set to `true` will render a full screen modal.
 
 #### `size`: `'small' | 'medium' | 'large' | 'fill'`
 
-If this property is added it will cause the modal to render at a preset width, or expand to fill the screen.
+If this property is added it will cause the modal to render at a preset width, or expand to fill the screen. This prop will be ignored if `isFullScreen` is set to `true`.
 
 -   Required: No
 

--- a/packages/components/src/modal/index.tsx
+++ b/packages/components/src/modal/index.tsx
@@ -27,7 +27,6 @@ import {
 import { __ } from '@wordpress/i18n';
 import { close } from '@wordpress/icons';
 import { getScrollContainer } from '@wordpress/dom';
-import deprecated from '@wordpress/deprecated';
 
 /**
  * Internal dependencies
@@ -103,14 +102,6 @@ function UnforwardedModal(
 		contentWidth && contentWidth !== 'fill'
 			? `has-width-${ contentWidth }`
 			: '';
-
-	if ( !! isFullScreen ) {
-		deprecated( '`isFullScreen` prop for wp.components.Modal', {
-			since: '6.4',
-			version: '6.7',
-			hint: 'Set the `contentWidth` prop to `fill` instead.',
-		} );
-	}
 
 	// Determines whether the Modal content is scrollable and updates the state.
 	const isContentScrollable = useCallback( () => {

--- a/packages/components/src/modal/index.tsx
+++ b/packages/components/src/modal/index.tsx
@@ -248,6 +248,12 @@ function UnforwardedModal(
 						{
 							'is-full-screen':
 								isFullScreen || contentWidth === 'fill',
+						},
+						{
+							[ contentWidthClass ]:
+								! isFullScreen &&
+								contentWidth &&
+								contentWidth !== 'fill',
 						}
 					) }
 					style={ style }
@@ -273,10 +279,6 @@ function UnforwardedModal(
 							'hide-header': __experimentalHideHeader,
 							'is-scrollable': hasScrollableContent,
 							'has-scrolled-content': hasScrolledContent,
-							[ contentWidthClass ]:
-								! isFullScreen &&
-								contentWidth &&
-								contentWidth !== 'fill',
 						} ) }
 						role="document"
 						onScroll={ onContentContainerScroll }

--- a/packages/components/src/modal/index.tsx
+++ b/packages/components/src/modal/index.tsx
@@ -98,7 +98,7 @@ function UnforwardedModal(
 	const [ hasScrolledContent, setHasScrolledContent ] = useState( false );
 	const [ hasScrollableContent, setHasScrollableContent ] = useState( false );
 
-	const contentWidthClass = contentWidth ? `width-${ contentWidth }` : '';
+	const contentWidthClass = contentWidth ? `has-width-${ contentWidth }` : '';
 
 	// Determines whether the Modal content is scrollable and updates the state.
 	const isContentScrollable = useCallback( () => {

--- a/packages/components/src/modal/index.tsx
+++ b/packages/components/src/modal/index.tsx
@@ -66,7 +66,7 @@ function UnforwardedModal(
 		contentLabel,
 		onKeyDown,
 		isFullScreen = false,
-		contentWidth,
+		size,
 		headerActions = null,
 		__experimentalHideHeader = false,
 	} = props;
@@ -98,10 +98,7 @@ function UnforwardedModal(
 	const [ hasScrolledContent, setHasScrolledContent ] = useState( false );
 	const [ hasScrollableContent, setHasScrollableContent ] = useState( false );
 
-	const contentWidthClass =
-		contentWidth && contentWidth !== 'fill'
-			? `has-width-${ contentWidth }`
-			: '';
+	const sizeClass = size && size !== 'fill' ? `has-size-${ size }` : '';
 
 	// Determines whether the Modal content is scrollable and updates the state.
 	const isContentScrollable = useCallback( () => {
@@ -237,14 +234,11 @@ function UnforwardedModal(
 						'components-modal__frame',
 						className,
 						{
-							'is-full-screen':
-								isFullScreen || contentWidth === 'fill',
+							'is-full-screen': isFullScreen || size === 'fill',
 						},
 						{
-							[ contentWidthClass ]:
-								! isFullScreen &&
-								contentWidth &&
-								contentWidth !== 'fill',
+							[ sizeClass ]:
+								! isFullScreen && size && size !== 'fill',
 						}
 					) }
 					style={ style }

--- a/packages/components/src/modal/index.tsx
+++ b/packages/components/src/modal/index.tsx
@@ -66,6 +66,7 @@ function UnforwardedModal(
 		contentLabel,
 		onKeyDown,
 		isFullScreen = false,
+		contentWidth,
 		headerActions = null,
 		__experimentalHideHeader = false,
 	} = props;
@@ -96,6 +97,8 @@ function UnforwardedModal(
 
 	const [ hasScrolledContent, setHasScrolledContent ] = useState( false );
 	const [ hasScrollableContent, setHasScrollableContent ] = useState( false );
+
+	const contentWidthClass = contentWidth ? `width-${ contentWidth }` : '';
 
 	// Determines whether the Modal content is scrollable and updates the state.
 	const isContentScrollable = useCallback( () => {
@@ -257,6 +260,7 @@ function UnforwardedModal(
 							'hide-header': __experimentalHideHeader,
 							'is-scrollable': hasScrollableContent,
 							'has-scrolled-content': hasScrolledContent,
+							[ contentWidthClass ]: ! isFullScreen,
 						} ) }
 						role="document"
 						onScroll={ onContentContainerScroll }

--- a/packages/components/src/modal/index.tsx
+++ b/packages/components/src/modal/index.tsx
@@ -98,7 +98,12 @@ function UnforwardedModal(
 	const [ hasScrolledContent, setHasScrolledContent ] = useState( false );
 	const [ hasScrollableContent, setHasScrollableContent ] = useState( false );
 
-	const sizeClass = size && size !== 'fill' ? `has-size-${ size }` : '';
+	let sizeClass;
+	if ( isFullScreen || size === 'fill' ) {
+		sizeClass = 'is-full-screen';
+	} else if ( size ) {
+		sizeClass = `has-size-${ size }`;
+	}
 
 	// Determines whether the Modal content is scrollable and updates the state.
 	const isContentScrollable = useCallback( () => {
@@ -232,14 +237,8 @@ function UnforwardedModal(
 				<div
 					className={ classnames(
 						'components-modal__frame',
-						className,
-						{
-							'is-full-screen': isFullScreen || size === 'fill',
-						},
-						{
-							[ sizeClass ]:
-								! isFullScreen && size && size !== 'fill',
-						}
+						sizeClass,
+						className
 					) }
 					style={ style }
 					ref={ useMergeRefs( [

--- a/packages/components/src/modal/index.tsx
+++ b/packages/components/src/modal/index.tsx
@@ -27,6 +27,7 @@ import {
 import { __ } from '@wordpress/i18n';
 import { close } from '@wordpress/icons';
 import { getScrollContainer } from '@wordpress/dom';
+import deprecated from '@wordpress/deprecated';
 
 /**
  * Internal dependencies
@@ -98,7 +99,18 @@ function UnforwardedModal(
 	const [ hasScrolledContent, setHasScrolledContent ] = useState( false );
 	const [ hasScrollableContent, setHasScrollableContent ] = useState( false );
 
-	const contentWidthClass = contentWidth ? `has-width-${ contentWidth }` : '';
+	const contentWidthClass =
+		contentWidth && contentWidth !== 'fill'
+			? `has-width-${ contentWidth }`
+			: '';
+
+	if ( !! isFullScreen ) {
+		deprecated( '`isFullScreen` prop for wp.components.Modal', {
+			since: '6.4',
+			version: '6.7',
+			hint: 'Set the `contentWidth` prop to `fill` instead.',
+		} );
+	}
 
 	// Determines whether the Modal content is scrollable and updates the state.
 	const isContentScrollable = useCallback( () => {
@@ -234,7 +246,8 @@ function UnforwardedModal(
 						'components-modal__frame',
 						className,
 						{
-							'is-full-screen': isFullScreen,
+							'is-full-screen':
+								isFullScreen || contentWidth === 'fill',
 						}
 					) }
 					style={ style }
@@ -260,7 +273,10 @@ function UnforwardedModal(
 							'hide-header': __experimentalHideHeader,
 							'is-scrollable': hasScrollableContent,
 							'has-scrolled-content': hasScrolledContent,
-							[ contentWidthClass ]: ! isFullScreen,
+							[ contentWidthClass ]:
+								! isFullScreen &&
+								contentWidth &&
+								contentWidth !== 'fill',
 						} ) }
 						role="document"
 						onScroll={ onContentContainerScroll }

--- a/packages/components/src/modal/stories/index.story.tsx
+++ b/packages/components/src/modal/stories/index.story.tsx
@@ -88,7 +88,6 @@ const Template: StoryFn< typeof Modal > = ( { onRequestClose, ...args } ) => {
 export const Default: StoryFn< typeof Modal > = Template.bind( {} );
 Default.args = {
 	title: 'Title',
-	style: { maxWidth: '600px' },
 };
 Default.parameters = {
 	docs: {

--- a/packages/components/src/modal/stories/index.story.tsx
+++ b/packages/components/src/modal/stories/index.story.tsx
@@ -61,11 +61,7 @@ const Template: StoryFn< typeof Modal > = ( { onRequestClose, ...args } ) => {
 				Open Modal
 			</Button>
 			{ isOpen && (
-				<Modal
-					onRequestClose={ closeModal }
-					contentWidth="medium"
-					{ ...args }
-				>
+				<Modal onRequestClose={ closeModal } { ...args }>
 					<p>
 						Lorem ipsum dolor sit amet, consectetur adipiscing elit,
 						sed do eiusmod tempor incididunt ut labore et magna
@@ -92,6 +88,7 @@ const Template: StoryFn< typeof Modal > = ( { onRequestClose, ...args } ) => {
 export const Default: StoryFn< typeof Modal > = Template.bind( {} );
 Default.args = {
 	title: 'Title',
+	style: { maxWidth: '600px' },
 };
 Default.parameters = {
 	docs: {
@@ -100,6 +97,14 @@ Default.parameters = {
 		},
 	},
 };
+
+export const WithcontentWidthSmall: StoryFn< typeof Modal > = Template.bind(
+	{}
+);
+WithcontentWidthSmall.args = {
+	contentWidth: 'small',
+};
+WithcontentWidthSmall.storyName = 'With contentWidth: small';
 
 const LikeButton = () => {
 	const [ isLiked, setIsLiked ] = useState( false );

--- a/packages/components/src/modal/stories/index.story.tsx
+++ b/packages/components/src/modal/stories/index.story.tsx
@@ -63,7 +63,7 @@ const Template: StoryFn< typeof Modal > = ( { onRequestClose, ...args } ) => {
 			{ isOpen && (
 				<Modal
 					onRequestClose={ closeModal }
-					style={ { maxWidth: '600px' } }
+					contentWidth="medium"
 					{ ...args }
 				>
 					<p>

--- a/packages/components/src/modal/stories/index.story.tsx
+++ b/packages/components/src/modal/stories/index.story.tsx
@@ -97,13 +97,11 @@ Default.parameters = {
 	},
 };
 
-export const WithcontentWidthSmall: StoryFn< typeof Modal > = Template.bind(
-	{}
-);
-WithcontentWidthSmall.args = {
-	contentWidth: 'small',
+export const WithsizeSmall: StoryFn< typeof Modal > = Template.bind( {} );
+WithsizeSmall.args = {
+	size: 'small',
 };
-WithcontentWidthSmall.storyName = 'With contentWidth: small';
+WithsizeSmall.storyName = 'With size: small';
 
 const LikeButton = () => {
 	const [ isLiked, setIsLiked ] = useState( false );

--- a/packages/components/src/modal/style.scss
+++ b/packages/components/src/modal/style.scss
@@ -148,19 +148,19 @@
 	}
 
 	@include break-small() {
-		&.width-small,
-		.width-medium,
-		.width-large {
+		&.has-width-small,
+		.has-width-medium,
+		.has-width-large {
 			width: 100%;
 		}
 
-		&.width-small {
+		&.has-width-small {
 			max-width: 300px;
 		}
-		&.width-medium {
+		&.has-width-medium {
 			max-width: 600px;
 		}
-		&.width-large {
+		&.has-width-large {
 			max-width: 900px;
 		}
 	}

--- a/packages/components/src/modal/style.scss
+++ b/packages/components/src/modal/style.scss
@@ -50,6 +50,26 @@
 				max-width: none;
 			}
 		}
+
+		&.has-width-small,
+		&.has-width-medium,
+		&.has-width-large {
+			width: 100%;
+		}
+
+		// The following widths were selected to align with existing baselines
+		// found elsewhere in the editor.
+		// See https://github.com/WordPress/gutenberg/pull/54471#issuecomment-1723818809
+		&.has-width-small {
+			max-width: 384px;
+		}
+		&.has-width-medium {
+			max-width: 512px;
+		}
+		&.has-width-large {
+			max-width: 832px;
+		}
+
 	}
 
 	@include break-large() {
@@ -145,26 +165,5 @@
 		// Windows High Contrast mode will show this outline, but not the box-shadow.
 		outline: 2px solid transparent;
 		outline-offset: -2px;
-	}
-
-	@include break-small() {
-		&.has-width-small,
-		.has-width-medium,
-		.has-width-large {
-			width: 100%;
-		}
-
-		// The following widths were selected to align with existing baselines
-		// found elsewhere in the editor.
-		// See https://github.com/WordPress/gutenberg/pull/54471#issuecomment-1723818809
-		&.has-width-small {
-			max-width: 384px;
-		}
-		&.has-width-medium {
-			max-width: 512px;
-		}
-		&.has-width-large {
-			max-width: 832px;
-		}
 	}
 }

--- a/packages/components/src/modal/style.scss
+++ b/packages/components/src/modal/style.scss
@@ -35,7 +35,7 @@
 		margin: auto;
 		width: auto;
 		min-width: $modal-min-width;
-		max-width: $modal-width-medium;
+		max-width: calc(100% - #{$grid-unit-20 * 2});
 		max-height: calc(100% - #{$header-height * 2});
 
 		&.is-full-screen {

--- a/packages/components/src/modal/style.scss
+++ b/packages/components/src/modal/style.scss
@@ -61,13 +61,13 @@
 		// found elsewhere in the editor.
 		// See https://github.com/WordPress/gutenberg/pull/54471#issuecomment-1723818809
 		&.has-size-small {
-			max-width: 384px;
+			max-width: $modal-width-small;
 		}
 		&.has-size-medium {
-			max-width: 512px;
+			max-width: $modal-width-medium;
 		}
 		&.has-size-large {
-			max-width: 832px;
+			max-width: $modal-width-large;
 		}
 
 	}

--- a/packages/components/src/modal/style.scss
+++ b/packages/components/src/modal/style.scss
@@ -51,22 +51,22 @@
 			}
 		}
 
-		&.has-width-small,
-		&.has-width-medium,
-		&.has-width-large {
+		&.has-size-small,
+		&.has-size-medium,
+		&.has-size-large {
 			width: 100%;
 		}
 
 		// The following widths were selected to align with existing baselines
 		// found elsewhere in the editor.
 		// See https://github.com/WordPress/gutenberg/pull/54471#issuecomment-1723818809
-		&.has-width-small {
+		&.has-size-small {
 			max-width: 384px;
 		}
-		&.has-width-medium {
+		&.has-size-medium {
 			max-width: 512px;
 		}
-		&.has-width-large {
+		&.has-size-large {
 			max-width: 832px;
 		}
 

--- a/packages/components/src/modal/style.scss
+++ b/packages/components/src/modal/style.scss
@@ -35,7 +35,7 @@
 		margin: auto;
 		width: auto;
 		min-width: $modal-min-width;
-		max-width: calc(100% - #{$grid-unit-20 * 2});
+		max-width: $modal-width-medium;
 		max-height: calc(100% - #{$header-height * 2});
 
 		&.is-full-screen {

--- a/packages/components/src/modal/style.scss
+++ b/packages/components/src/modal/style.scss
@@ -146,4 +146,22 @@
 		outline: 2px solid transparent;
 		outline-offset: -2px;
 	}
+
+	@include break-small() {
+		&.width-small,
+		.width-medium,
+		.width-large {
+			width: 100%;
+		}
+
+		&.width-small {
+			max-width: 300px;
+		}
+		&.width-medium {
+			max-width: 600px;
+		}
+		&.width-large {
+			max-width: 900px;
+		}
+	}
 }

--- a/packages/components/src/modal/style.scss
+++ b/packages/components/src/modal/style.scss
@@ -154,14 +154,17 @@
 			width: 100%;
 		}
 
+		// The following widths were selected to align with existing baselines
+		// found elsewhere in the editor.
+		// See https://github.com/WordPress/gutenberg/pull/54471#issuecomment-1723818809
 		&.has-width-small {
-			max-width: 300px;
+			max-width: 384px;
 		}
 		&.has-width-medium {
-			max-width: 600px;
+			max-width: 512px;
 		}
 		&.has-width-large {
-			max-width: 900px;
+			max-width: 832px;
 		}
 	}
 }

--- a/packages/components/src/modal/types.ts
+++ b/packages/components/src/modal/types.ts
@@ -104,7 +104,7 @@ export type ModalProps = {
 	 * Note: `Modal`'s width can also be controlled by adjusting the width of the
 	 * modal's contents, or using the `style` prop to set a specific `max-width`.
 	 */
-	contentWidth?: 'small' | 'medium' | 'large';
+	contentWidth?: 'small' | 'medium' | 'large' | 'fill';
 	/**
 	 *  Handle the key down on the modal frame `div`.
 	 */

--- a/packages/components/src/modal/types.ts
+++ b/packages/components/src/modal/types.ts
@@ -97,6 +97,15 @@ export type ModalProps = {
 	 */
 	isFullScreen?: boolean;
 	/**
+	 * If this property is added, it will constrain the `max-width` of the modal's
+	 * contents, preventing it from growing too wide. This prop only applies
+	 * when `isFullScreen` is `false`.
+	 *
+	 * Note: `Modal`'s width can also be controlled by adjusting the width of the
+	 * modal's contents, or using the `style` prop to set a specific `max-width`.
+	 */
+	contentWidth?: 'small' | 'medium' | 'large';
+	/**
 	 *  Handle the key down on the modal frame `div`.
 	 */
 	onKeyDown?: KeyboardEventHandler< HTMLDivElement >;

--- a/packages/components/src/modal/types.ts
+++ b/packages/components/src/modal/types.ts
@@ -98,7 +98,8 @@ export type ModalProps = {
 	isFullScreen?: boolean;
 	/**
 	 * If this property is added it will cause the modal to render at a preset
-	 * width, or expand to fill the screen.
+	 * width, or expand to fill the screen. This prop will be ignored if
+	 * `isFullScreen` is set to `true`.
 	 *
 	 * Note: `Modal`'s width can also be controlled by adjusting the width of the
 	 * modal's contents, or via CSS using the `style` prop.

--- a/packages/components/src/modal/types.ts
+++ b/packages/components/src/modal/types.ts
@@ -97,14 +97,13 @@ export type ModalProps = {
 	 */
 	isFullScreen?: boolean;
 	/**
-	 * If this property is added, it will constrain the `max-width` of the modal's
-	 * contents, preventing it from growing too wide. This prop only applies
-	 * when `isFullScreen` is `false`.
+	 * If this property is added it will cause the modal to render at a preset
+	 * width, or expand to fill the screen.
 	 *
 	 * Note: `Modal`'s width can also be controlled by adjusting the width of the
-	 * modal's contents, or using the `style` prop to set a specific `max-width`.
+	 * modal's contents, or via CSS using the `style` prop.
 	 */
-	contentWidth?: 'small' | 'medium' | 'large' | 'fill';
+	size?: 'small' | 'medium' | 'large' | 'fill';
 	/**
 	 *  Handle the key down on the modal frame `div`.
 	 */


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Implements a new prop for `Modal` that constrains the content width to one of a selection of preset sizes.

## Why?
Consumers were finding they often needed to manually set a max width on the child elements they provided to `Modal` to prevent them from pushing `Modal`'s size to the full with of the viewport.

## How?
The optional new prop accepts values of `small`, `medium`, and `large`. If provided, the width of the `Modal`'s contents will be limited to `300px`, `600px`, or `900px`, respectively. (Note: these are just my initial values, and can most certainly be changed as needed when this PR is reviewed).

The value provided to the prop is used to add an additional class name to the relevant DOM element, but this class is only added if `isFullscreen` is `false`, so full screen modals will not be affected. Further, the styles implementing this change are limited to larger screens, so the automatically full screen `Modal` rendering on mobile devices should not be affected either.


- [x] TODO: rebase and refactor changes in #54518 to use the new APIs proposed in this PR
---

dropping a ping for some folks who may want to weigh in on any design considerations for this one: @jordesign @koster @SaxonF

## Testing Instructions
`npm run storybook:dev`

- Open `Modal`'s new `With contentWidth: small` story and test the `contentWidth` control.
- Confirm that both `isFullScreen` behaves as expected with the new prop applied
- Confirm smaller viewports still render the modal in full screen, regardless of the new prop's value

### Testing Instructions for Keyboard
n/a
