### PR TITLE
Interactivity API: Add `timeout` option to `navigate()`

### DIFF
--- a/packages/e2e-tests/plugins/interactive-blocks/router-navigate/render.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/router-navigate/render.php
@@ -21,6 +21,13 @@
 		data-wp-text="state.router.status"
 	>undefined</output>
 
+	<button
+		data-wp-on--click="actions.router.toggleTimeout"
+		data-testid="toggle timeout"
+	>
+		Timeout <span data-wp-text="state.router.timeout">NaN</span>
+	</button>
+
 	<?php
 	if ( isset( $attributes['links'] ) ) {
 		foreach ( $attributes['links'] as $key => $link ) {

--- a/packages/e2e-tests/plugins/interactive-blocks/router-navigate/view.js
+++ b/packages/e2e-tests/plugins/interactive-blocks/router-navigate/view.js
@@ -9,6 +9,7 @@
 			router: {
 				status: 'idle',
 				navigations: 0,
+				timeout: 10000,
 			}
 		},
 		actions: {
@@ -20,8 +21,9 @@
 					state.router.status = 'busy';
 
 					const force = e.target.dataset.forceNavigation === 'true';
+					const { timeout } = state.router;
 
-					await navigate( e.target.href, { force } );
+					await navigate( e.target.href, { force, timeout } );
 
 					state.router.navigations -= 1;
 
@@ -29,6 +31,10 @@
 						state.router.status = 'idle';
 					}
 				},
+				toggleTimeout: ( { state }) => {
+					state.router.timeout =
+						state.router.timeout === 10000 ? 0 : 10000;
+				}
 			},
 		},
 	} );

--- a/packages/interactivity/CHANGELOG.md
+++ b/packages/interactivity/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 -   Improve `navigate()` to render only the result of the last call when multiple happen simultaneously. ([#54201](https://github.com/WordPress/gutenberg/pull/54201))
 
+-   Add `timeout` option to `navigate()`, with a default value of `10000` milliseconds. ([#54474](https://github.com/WordPress/gutenberg/pull/54474))
+
 ## 2.2.0 (2023-08-31)
 
 ### Enhancements

--- a/packages/interactivity/src/router.js
+++ b/packages/interactivity/src/router.js
@@ -89,9 +89,8 @@ export const navigate = async ( href, options = {} ) => {
 
 	// Create a promise that resolves when the specified timeout ends. The
 	// timeout value is 10 seconds by default.
-	const { timeout = 10000 } = options;
 	const timeoutPromise = new Promise( ( resolve ) =>
-		setTimeout( () => resolve( false ), timeout )
+		setTimeout( resolve, options.timeout ?? 10000 )
 	);
 
 	const page = await Promise.race( [ pages.get( url ), timeoutPromise ] );
@@ -110,6 +109,7 @@ export const navigate = async ( href, options = {} ) => {
 		);
 	} else {
 		window.location.assign( href );
+		await new Promise( () => {} );
 	}
 };
 

--- a/packages/interactivity/src/router.js
+++ b/packages/interactivity/src/router.js
@@ -86,7 +86,15 @@ export const navigate = async ( href, options = {} ) => {
 	const url = cleanUrl( href );
 	navigatingTo = href;
 	prefetch( url, options );
-	const page = await pages.get( url );
+
+	// Create a promise that resolves when the specified timeout ends. The
+	// timeout value is 10 seconds by default.
+	const { timeout = 10000 } = options;
+	const timeoutPromise = new Promise( ( resolve ) =>
+		setTimeout( () => resolve( false ), timeout )
+	);
+
+	const page = await Promise.race( [ pages.get( url ), timeoutPromise ] );
 
 	// Once the page is fetched, the destination URL could have changed (e.g.,
 	// by clicking another link in the meantime). If so, bail out, and let the

--- a/packages/interactivity/src/router.js
+++ b/packages/interactivity/src/router.js
@@ -80,21 +80,26 @@ const renderRegions = ( page ) => {
 
 // Variable to store the current navigation.
 let navigatingTo = '';
+// Variable to store the current timeout ID.
+let timeoutId = NaN;
 
 // Navigate to a new page.
 export const navigate = async ( href, options = {} ) => {
-	const url = cleanUrl( href );
 	navigatingTo = href;
+	clearTimeout( timeoutId );
+
+	const url = cleanUrl( href );
 	prefetch( url, options );
 
-	// Create a promise that resolves when the specified timeout ends. The
-	// timeout value is 10 seconds by default.
-	const { timeout = 10000 } = options;
-	const timeoutPromise = new Promise( ( resolve ) =>
-		setTimeout( () => resolve( false ), timeout )
-	);
+	const pagePromise = pages.get( url );
+	const timeoutPromise = new Promise( ( r ) => {
+		timeoutId = setTimeout( r, options.timeout ?? 10000 );
+	} ).then( () => {
+		window.location.assign( href );
+		throw new Error( 'timeout' );
+	} );
 
-	const page = await Promise.race( [ pages.get( url ), timeoutPromise ] );
+	const page = await Promise.race( [ pagePromise, timeoutPromise ] );
 
 	// Once the page is fetched, the destination URL could have changed (e.g.,
 	// by clicking another link in the meantime). If so, bail out, and let the


### PR DESCRIPTION
## What?

This PR adds an option to the `navigate()` function exposed by the Interactivity API.

When the timeout expires, the browser reloads the page you are visiting instead of waiting.

Part of https://github.com/WordPress/gutenberg/issues/54291

## Why?

To add a default behavior when a navigation takes too long.

## How?

Inside `navigation()`, where the function awaits the request to be resolved, I added another promise that fulfills when the timeout passes. Then, I used `Promise.race()` to return the resolved value of the fastest promise.

## Testing Instructions

You can use the Enhanced pagination feature of the Query Loop block to test this.

1. Inside the Site Editor, go to the Blog Home template.
2. Enable "Enhanced pagination" in the Query Loop settings.
3. Visit the homepage.
4. In the browser dev tools, go to the Network tab, and create a very slow throttling profile (slower than "Slow 3G").
5. Select that throttling profile
6. On the site, click "Older posts"
7. Wait 10 seconds
8. Deactivate network throttling
9. The browser should reload the requested page.

## Screenshots or screencast

https://github.com/WordPress/gutenberg/assets/6917969/3dc7c540-276c-4ab5-8e74-d72d76c77e77
