### PR TITLE
Patterns: Update pattern inserter to show all categories regardless of sync status

### DIFF
--- a/packages/block-editor/src/components/inserter/block-patterns-explorer/explorer.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-explorer/explorer.js
@@ -2,10 +2,9 @@
  * WordPress dependencies
  */
 import { Modal } from '@wordpress/components';
-import { useState, useEffect } from '@wordpress/element';
+import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
-import { usePrevious } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -27,25 +26,9 @@ function PatternsExplorer( { initialCategory, rootClientId } ) {
 		initialCategory?.name
 	);
 
-	const previousSyncFilter = usePrevious( patternSyncFilter );
-
-	// If the sync filter changes, we need to select the "All" category to avoid
-	// showing a confusing no results screen.
-	useEffect( () => {
-		if ( patternSyncFilter && patternSyncFilter !== previousSyncFilter ) {
-			setSelectedCategory( initialCategory?.name );
-		}
-	}, [
-		patternSyncFilter,
-		previousSyncFilter,
-		patternSourceFilter,
-		initialCategory?.name,
-	] );
-
 	const patternCategories = usePatternsCategories(
 		rootClientId,
-		patternSourceFilter,
-		patternSyncFilter
+		patternSourceFilter
 	);
 
 	return (

--- a/packages/block-editor/src/components/inserter/block-patterns-explorer/explorer.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-explorer/explorer.js
@@ -4,7 +4,6 @@
 import { Modal } from '@wordpress/components';
 import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -12,16 +11,11 @@ import { useSelect } from '@wordpress/data';
 import PatternExplorerSidebar from './sidebar';
 import PatternList from './patterns-list';
 import { usePatternsCategories } from '../block-patterns-tab';
-import { store as blockEditorStore } from '../../../store';
 
 function PatternsExplorer( { initialCategory, rootClientId } ) {
 	const [ searchValue, setSearchValue ] = useState( '' );
 	const [ patternSourceFilter, setPatternSourceFilter ] = useState( 'all' );
-	const patternSyncFilter = useSelect( ( select ) => {
-		const { getSettings } = select( blockEditorStore );
-		const settings = getSettings();
-		return settings.patternsSyncFilter || 'all';
-	}, [] );
+
 	const [ selectedCategory, setSelectedCategory ] = useState(
 		initialCategory?.name
 	);
@@ -47,7 +41,6 @@ function PatternsExplorer( { initialCategory, rootClientId } ) {
 				selectedCategory={ selectedCategory }
 				patternCategories={ patternCategories }
 				patternSourceFilter={ patternSourceFilter }
-				patternSyncFilter={ patternSyncFilter }
 			/>
 		</div>
 	);

--- a/packages/block-editor/src/components/inserter/block-patterns-explorer/patterns-list.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-explorer/patterns-list.js
@@ -11,7 +11,6 @@ import { speak } from '@wordpress/a11y';
  * Internal dependencies
  */
 import BlockPatternsList from '../../block-patterns-list';
-import InserterNoResults from '../no-results';
 import useInsertionPoint from '../hooks/use-insertion-point';
 import usePatternsState from '../hooks/use-patterns-state';
 import InserterListbox from '../../inserter-listbox';
@@ -25,9 +24,23 @@ import {
 	PATTERN_SOURCE_FILTERS,
 } from '../block-patterns-source-filter';
 
-function PatternsListHeader( { filterValue, filteredBlockPatternsLength } ) {
+function PatternsListHeader( {
+	filterValue,
+	filteredBlockPatternsLength,
+	selectedCategory,
+	patternCategories,
+} ) {
 	if ( ! filterValue ) {
 		return null;
+	}
+	let filter = filterValue;
+	if ( selectedCategory !== allPatternsCategory.name ) {
+		const category = patternCategories.find(
+			( patternCategory ) => patternCategory.name === selectedCategory
+		);
+		if ( category ) {
+			filter = `${ filter } - ${ category?.label }`;
+		}
 	}
 	return (
 		<Heading
@@ -43,7 +56,7 @@ function PatternsListHeader( { filterValue, filteredBlockPatternsLength } ) {
 					filteredBlockPatternsLength
 				),
 				filteredBlockPatternsLength,
-				filterValue
+				filter
 			) }
 		</Heading>
 	);
@@ -147,19 +160,19 @@ function PatternList( {
 			className="block-editor-block-patterns-explorer__list"
 			ref={ container }
 		>
-			{ hasItems && (
-				<PatternsListHeader
-					filterValue={
-						searchValue ||
-						PATTERN_SOURCE_FILTERS[ patternSourceFilter ]
-					}
-					filteredBlockPatternsLength={ filteredBlockPatterns.length }
-				/>
-			) }
+			<PatternsListHeader
+				filterValue={
+					searchValue || PATTERN_SOURCE_FILTERS[ patternSourceFilter ]
+				}
+				filteredBlockPatternsLength={ filteredBlockPatterns.length }
+				selectedCategory={ selectedCategory }
+				patternCategories={ patternCategories }
+			/>
+
 			<InserterListbox>
-				{ ! hasItems && <InserterNoResults /> }
 				{ patternSourceFilter === PATTERN_TYPES.user &&
 					! searchValue && <BlockPatternsSyncFilter /> }
+
 				{ hasItems && (
 					<BlockPatternsList
 						shownPatterns={ pagingProps.categoryPatternsAsyncList }

--- a/packages/block-editor/src/components/inserter/block-patterns-explorer/patterns-list.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-explorer/patterns-list.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useMemo, useEffect, useRef } from '@wordpress/element';
+import { useMemo, useEffect, useRef, useState } from '@wordpress/element';
 import { _n, sprintf } from '@wordpress/i18n';
 import { useDebounce } from '@wordpress/compose';
 import { __experimentalHeading as Heading } from '@wordpress/components';
@@ -67,8 +67,8 @@ function PatternList( {
 	patternSourceFilter,
 	selectedCategory,
 	patternCategories,
-	patternSyncFilter,
 } ) {
+	const [ patternSyncFilter, setPatternSyncFilter ] = useState( 'all' );
 	const container = useRef();
 	const debouncedSpeak = useDebounce( speak, 500 );
 	const [ destinationRootClientId, onInsertBlocks ] = useInsertionPoint( {
@@ -171,7 +171,12 @@ function PatternList( {
 
 			<InserterListbox>
 				{ patternSourceFilter === PATTERN_TYPES.user &&
-					! searchValue && <BlockPatternsSyncFilter /> }
+					! searchValue && (
+						<BlockPatternsSyncFilter
+							patternSyncFilter={ patternSyncFilter }
+							setPatternSyncFilter={ setPatternSyncFilter }
+						/>
+					) }
 
 				{ hasItems && (
 					<BlockPatternsList

--- a/packages/block-editor/src/components/inserter/block-patterns-sync-filter.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-sync-filter.js
@@ -3,12 +3,10 @@
  */
 import { SelectControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { useDispatch, useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
-import { store as blockEditorStore } from '../../store';
 export const SYNC_TYPES = {
 	full: 'fully',
 	unsynced: 'unsynced',
@@ -20,28 +18,17 @@ const patternSyncOptions = [
 	{ value: SYNC_TYPES.unsynced, label: __( 'Standard' ) },
 ];
 
-export function BlockPatternsSyncFilter() {
-	const { updateSettings } = useDispatch( blockEditorStore );
-
-	const syncFilter = useSelect( ( select ) => {
-		const { getSettings } = select( blockEditorStore );
-		const settings = getSettings();
-		return settings.patternsSyncFilter || 'all';
-	}, [] );
-
-	const handleUpdateSyncFilter = ( value ) => {
-		updateSettings( {
-			patternsSyncFilter: value,
-		} );
-	};
-
+export function BlockPatternsSyncFilter( {
+	setPatternSyncFilter,
+	patternSyncFilter,
+} ) {
 	return (
 		<SelectControl
 			className="block-editor-patterns__sync-status-filter"
 			label={ __( 'Syncing' ) }
 			options={ patternSyncOptions }
-			value={ syncFilter }
-			onChange={ ( value ) => handleUpdateSyncFilter( value ) }
+			value={ patternSyncFilter }
+			onChange={ setPatternSyncFilter }
 			aria-label={ __( 'Filter patterns by sync type' ) }
 		/>
 	);

--- a/packages/block-editor/src/components/inserter/block-patterns-tab.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-tab.js
@@ -9,7 +9,7 @@ import {
 	useEffect,
 } from '@wordpress/element';
 import { _x, __, _n, isRTL, sprintf } from '@wordpress/i18n';
-import { useViewportMatch, usePrevious } from '@wordpress/compose';
+import { useViewportMatch } from '@wordpress/compose';
 import {
 	__experimentalItemGroup as ItemGroup,
 	__experimentalItem as Item,
@@ -75,11 +75,7 @@ export function isPatternFiltered( pattern, sourceFilter, syncFilter ) {
 	return false;
 }
 
-export function usePatternsCategories(
-	rootClientId,
-	sourceFilter = 'all',
-	syncFilter
-) {
+export function usePatternsCategories( rootClientId, sourceFilter = 'all' ) {
 	const { patterns: allPatterns, allCategories } = usePatternsState(
 		undefined,
 		rootClientId
@@ -91,13 +87,9 @@ export function usePatternsCategories(
 				? allPatterns
 				: allPatterns.filter(
 						( pattern ) =>
-							! isPatternFiltered(
-								pattern,
-								sourceFilter,
-								syncFilter
-							)
+							! isPatternFiltered( pattern, sourceFilter )
 				  ),
-		[ sourceFilter, syncFilter, allPatterns ]
+		[ sourceFilter, allPatterns ]
 	);
 
 	const hasRegisteredCategory = useCallback(
@@ -213,8 +205,7 @@ export function BlockPatternsCategoryPanel( {
 	}, [] );
 	const availableCategories = usePatternsCategories(
 		rootClientId,
-		patternFilter,
-		patternSyncFilter
+		patternFilter
 	);
 	const container = useRef();
 	const currentCategoryPatterns = useMemo(
@@ -311,30 +302,10 @@ function BlockPatternsTabs( {
 } ) {
 	const [ showPatternsExplorer, setShowPatternsExplorer ] = useState( false );
 	const [ patternSourceFilter, setPatternSourceFilter ] = useState( 'all' );
-	const patternSyncFilter = useSelect( ( select ) => {
-		const { getSettings } = select( blockEditorStore );
-		const settings = getSettings();
-		return settings.patternsSyncFilter;
-	}, [] );
-	const previousSyncFilter = usePrevious( patternSyncFilter );
-
-	// If the sync filter changes, we need to select the "All" category to avoid
-	// showing a confusing no results screen.
-	useEffect( () => {
-		if ( patternSyncFilter && patternSyncFilter !== previousSyncFilter ) {
-			onSelectCategory( allPatternsCategory, patternSourceFilter );
-		}
-	}, [
-		patternSyncFilter,
-		previousSyncFilter,
-		onSelectCategory,
-		patternSourceFilter,
-	] );
 
 	const categories = usePatternsCategories(
 		rootClientId,
-		patternSourceFilter,
-		patternSyncFilter
+		patternSourceFilter
 	);
 
 	const initialCategory = selectedCategory || categories[ 0 ];

--- a/packages/block-editor/src/components/inserter/block-patterns-tab.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-tab.js
@@ -267,7 +267,6 @@ export function BlockPatternsCategoryPanel( {
 				<BlockPatternsSyncFilter
 					patternSyncFilter={ patternSyncFilter }
 					setPatternSyncFilter={ setPatternSyncFilter }
-					test={ 'bob' }
 				/>
 			) }
 			{ ! currentCategoryPatterns.length && (

--- a/packages/block-editor/src/components/inserter/block-patterns-tab.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-tab.js
@@ -20,7 +20,6 @@ import {
 import { Icon, chevronRight, chevronLeft } from '@wordpress/icons';
 import { focus } from '@wordpress/dom';
 import { speak } from '@wordpress/a11y';
-import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -39,7 +38,6 @@ import {
 	BlockPatternsSyncFilter,
 	SYNC_TYPES,
 } from './block-patterns-sync-filter';
-import { store as blockEditorStore } from '../../store';
 
 const noop = () => {};
 
@@ -198,11 +196,8 @@ export function BlockPatternsCategoryPanel( {
 		onInsert,
 		rootClientId
 	);
-	const patternSyncFilter = useSelect( ( select ) => {
-		const { getSettings } = select( blockEditorStore );
-		const settings = getSettings();
-		return settings.patternsSyncFilter || 'all';
-	}, [] );
+	const [ patternSyncFilter, setPatternSyncFilter ] = useState( 'all' );
+
 	const availableCategories = usePatternsCategories(
 		rootClientId,
 		patternFilter
@@ -256,6 +251,7 @@ export function BlockPatternsCategoryPanel( {
 	);
 
 	// Hide block pattern preview on unmount.
+	// eslint-disable-next-line react-hooks/exhaustive-deps
 	useEffect( () => () => onHover( null ), [] );
 
 	return (
@@ -268,7 +264,11 @@ export function BlockPatternsCategoryPanel( {
 			</div>
 			<p>{ category.description }</p>
 			{ patternFilter === PATTERN_TYPES.user && (
-				<BlockPatternsSyncFilter />
+				<BlockPatternsSyncFilter
+					patternSyncFilter={ patternSyncFilter }
+					setPatternSyncFilter={ setPatternSyncFilter }
+					test={ 'bob' }
+				/>
 			) }
 			{ ! currentCategoryPatterns.length && (
 				<div>{ __( 'No results found' ) }</div>


### PR DESCRIPTION
## What?
Removes the sync type filter from the category list generation.

## Why?
Currently in #53835 when the pattern sync status filter is changed the category list changes to show only the categories that have patterns of that sync status. This was to avoid showing categories that were in fact empty as generally only populated categories display, but it complicates the code, and the UX is a little odd in the way the sync filter in one panel affects categories in another.

## How?
Removes the plumbing that was passing the sync status back through to the category hook, and also made sure 0 resutls messages were showing.

## Testing Instructions

- In the post editor add some synced and unsynced patterns with categories assigned
- Check that the patterns appear in the correct categories in the inserter patterns tab
- Check that the All patterns tab shows all patterns and that paging at the bottom of the tab works
- Check that the Source Filter select list works as expected and that correct patterns display for each selected filter
- Also check that when the My patterns source filter is selected that a Sync type filter appears at the top of the patterns list and works as expected
- Check that changing the sync filter does not change the categories displayed, and that a no results message appears if a category has no patterns of that sync status
- Repeat all of the above in the patterns explorer modal

## Screenshots or screencast <!-- if applicable -->


https://github.com/WordPress/gutenberg/assets/3629020/e04a43ed-889b-48ef-9a7d-f6fb2b7a8c82


