### PR TITLE
Code Owners: Add code owner for HTML API

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -135,6 +135,7 @@
 
 # PHP
 /lib                                            @spacedmonkey
+/lib/compat/*/html-api                          @dmsnell
 /lib/experimental/rest-api.php                  @timothybjacobs
 /lib/experimental/class-wp-rest-*               @timothybjacobs
 /lib/experimental/class-wp-rest-block-editor-settings-controller.php @timothybjacobs @spacedmonkey @geriux


### PR DESCRIPTION
Adds a code owner for the HTML API, which is a component merged into Gutenberg from Core.
After a few incidents where people modify the code here without making the changes in Core first, I'd like to be able to monitor changes and address these problems before they cause headache.

Strangely I couldn't find an example of a wildcard in a directory like this; my goal is to be alerted to changes in any WordPress version inside the compat directories.