### PR TITLE
Site editor: consolidate constants

### DIFF
--- a/packages/edit-site/src/components/add-new-template/index.js
+++ b/packages/edit-site/src/components/add-new-template/index.js
@@ -8,9 +8,10 @@ import { store as coreStore } from '@wordpress/core-data';
  * Internal dependencies
  */
 import NewTemplate from './new-template';
+import { TEMPLATE_POST_TYPE } from '../../utils/constants';
 
 export default function AddNewTemplate( {
-	templateType = 'wp_template',
+	templateType = TEMPLATE_POST_TYPE,
 	...props
 } ) {
 	const postType = useSelect(
@@ -22,7 +23,7 @@ export default function AddNewTemplate( {
 		return null;
 	}
 
-	if ( templateType === 'wp_template' ) {
+	if ( templateType === TEMPLATE_POST_TYPE ) {
 		return <NewTemplate { ...props } postType={ postType } />;
 	}
 

--- a/packages/edit-site/src/components/add-new-template/new-template.js
+++ b/packages/edit-site/src/components/add-new-template/new-template.js
@@ -45,6 +45,11 @@ import { privateApis as routerPrivateApis } from '@wordpress/router';
 /**
  * Internal dependencies
  */
+import { TEMPLATE_POST_TYPE } from '../../utils/constants';
+
+/**
+ * Internal dependencies
+ */
 import AddCustomTemplateModalContent from './add-custom-template-modal-content';
 import {
 	useExistingTemplates,
@@ -190,7 +195,7 @@ export default function NewTemplate( {
 			const { title, description, slug } = template;
 			const newTemplate = await saveEntityRecord(
 				'postType',
-				'wp_template',
+				TEMPLATE_POST_TYPE,
 				{
 					description,
 					// Slugs need to be strings, so this is for template `404`

--- a/packages/edit-site/src/components/add-new-template/utils.js
+++ b/packages/edit-site/src/components/add-new-template/utils.js
@@ -10,6 +10,11 @@ import { __, sprintf } from '@wordpress/i18n';
 import { blockMeta, post, archive } from '@wordpress/icons';
 
 /**
+ * Internal dependencies
+ */
+import { TEMPLATE_POST_TYPE } from '../../utils/constants';
+
+/**
  * @typedef IHasNameAndId
  * @property {string|number} id   The entity's id.
  * @property {string}        name The entity's name.
@@ -48,9 +53,13 @@ export const mapToIHasNameAndId = ( entities, path ) => {
 export const useExistingTemplates = () => {
 	return useSelect(
 		( select ) =>
-			select( coreStore ).getEntityRecords( 'postType', 'wp_template', {
-				per_page: -1,
-			} ),
+			select( coreStore ).getEntityRecords(
+				'postType',
+				TEMPLATE_POST_TYPE,
+				{
+					per_page: -1,
+				}
+			),
 		[]
 	);
 };

--- a/packages/edit-site/src/components/block-editor/back-button.js
+++ b/packages/edit-site/src/components/block-editor/back-button.js
@@ -9,6 +9,10 @@ import { privateApis as routerPrivateApis } from '@wordpress/router';
 /**
  * Internal dependencies
  */
+import {
+	TEMPLATE_PART_POST_TYPE,
+	NAVIGATION_POST_TYPE,
+} from '../../utils/constants';
 import { unlock } from '../../lock-unlock';
 
 const { useLocation, useHistory } = unlock( routerPrivateApis );
@@ -16,8 +20,8 @@ const { useLocation, useHistory } = unlock( routerPrivateApis );
 function BackButton() {
 	const location = useLocation();
 	const history = useHistory();
-	const isTemplatePart = location.params.postType === 'wp_template_part';
-	const isNavigationMenu = location.params.postType === 'wp_navigation';
+	const isTemplatePart = location.params.postType === TEMPLATE_PART_POST_TYPE;
+	const isNavigationMenu = location.params.postType === NAVIGATION_POST_TYPE;
 	const previousTemplateId = location.state?.fromTemplateId;
 
 	const isFocusMode = isTemplatePart || isNavigationMenu;

--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -44,7 +44,7 @@ import CanvasLoader from '../canvas-loader';
 import { unlock } from '../../lock-unlock';
 import useEditedEntityRecord from '../use-edited-entity-record';
 import { SidebarFixedBottomSlot } from '../sidebar-edit-mode/sidebar-fixed-bottom';
-import { POST_TYPE_LABELS } from '../../utils/constants';
+import { POST_TYPE_LABELS, TEMPLATE_POST_TYPE } from '../../utils/constants';
 
 const { BlockRemovalWarningModal } = unlock( blockEditorPrivateApis );
 
@@ -165,7 +165,8 @@ export default function Editor( { isLoading } ) {
 			// translators: A breadcrumb trail in browser tab. %1$s: title of template being edited, %2$s: type of template (Template or Template Part).
 			__( '%1$s ‹ %2$s ‹ Editor' ),
 			getTitle(),
-			POST_TYPE_LABELS[ editedPostType ] ?? POST_TYPE_LABELS.wp_template
+			POST_TYPE_LABELS[ editedPostType ] ??
+				POST_TYPE_LABELS[ TEMPLATE_POST_TYPE ]
 		);
 	}
 

--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -44,6 +44,7 @@ import CanvasLoader from '../canvas-loader';
 import { unlock } from '../../lock-unlock';
 import useEditedEntityRecord from '../use-edited-entity-record';
 import { SidebarFixedBottomSlot } from '../sidebar-edit-mode/sidebar-fixed-bottom';
+import { POST_TYPE_LABELS } from '../../utils/constants';
 
 const { BlockRemovalWarningModal } = unlock( blockEditorPrivateApis );
 
@@ -56,13 +57,6 @@ const interfaceLabels = {
 	actions: __( 'Editor publish' ),
 	/* translators: accessibility text for the editor footer landmark region. */
 	footer: __( 'Editor footer' ),
-};
-
-const typeLabels = {
-	wp_template: __( 'Template' ),
-	wp_template_part: __( 'Template Part' ),
-	wp_block: __( 'Pattern' ),
-	wp_navigation: __( 'Navigation' ),
 };
 
 // Prevent accidental removal of certain blocks, asking the user for
@@ -171,7 +165,7 @@ export default function Editor( { isLoading } ) {
 			// translators: A breadcrumb trail in browser tab. %1$s: title of template being edited, %2$s: type of template (Template or Template Part).
 			__( '%1$s ‹ %2$s ‹ Editor' ),
 			getTitle(),
-			typeLabels[ editedPostType ] ?? typeLabels.wp_template
+			POST_TYPE_LABELS[ editedPostType ] ?? POST_TYPE_LABELS.wp_template
 		);
 	}
 

--- a/packages/edit-site/src/components/page-patterns/duplicate-menu-item.js
+++ b/packages/edit-site/src/components/page-patterns/duplicate-menu-item.js
@@ -13,9 +13,8 @@ import { privateApis as routerPrivateApis } from '@wordpress/router';
  */
 import {
 	TEMPLATE_PART_POST_TYPE,
-	PATTERN_THEME_TYPE,
-	PATTERN_SYNC_STATUSES,
-	PATTERN_POST_TYPE,
+	PATTERN_TYPES,
+	PATTERN_SYNC_TYPES,
 } from '../../utils/constants';
 import {
 	useExistingTemplateParts,
@@ -28,12 +27,12 @@ import usePatternCategories from '../sidebar-navigation-screen-patterns/use-patt
 const { useHistory } = unlock( routerPrivateApis );
 
 function getPatternMeta( item ) {
-	if ( item.type === PATTERN_THEME_TYPE ) {
-		return { wp_pattern_sync_status: PATTERN_SYNC_STATUSES.unsynced };
+	if ( item.type === PATTERN_TYPES.theme ) {
+		return { wp_pattern_sync_status: PATTERN_SYNC_TYPES.unsynced };
 	}
 
 	const syncStatus = item.patternBlock.wp_pattern_sync_status;
-	const isUnsynced = syncStatus === PATTERN_SYNC_STATUSES.unsynced;
+	const isUnsynced = syncStatus === PATTERN_SYNC_TYPES.unsynced;
 
 	return {
 		...item.patternBlock.meta,
@@ -153,7 +152,7 @@ export default function DuplicateMenuItem( {
 
 	async function createPattern() {
 		try {
-			const isThemePattern = item.type === PATTERN_THEME_TYPE;
+			const isThemePattern = item.type === PATTERN_TYPES.theme;
 			const title = sprintf(
 				/* translators: %s: Existing pattern title */
 				__( '%s (Copy)' ),
@@ -189,9 +188,9 @@ export default function DuplicateMenuItem( {
 			);
 
 			history.push( {
-				categoryType: PATTERN_THEME_TYPE,
+				categoryType: PATTERN_TYPES.theme,
 				categoryId,
-				postType: PATTERN_POST_TYPE,
+				postType: PATTERN_TYPES.user,
 				postId: result?.id,
 			} );
 

--- a/packages/edit-site/src/components/page-patterns/duplicate-menu-item.js
+++ b/packages/edit-site/src/components/page-patterns/duplicate-menu-item.js
@@ -11,7 +11,12 @@ import { privateApis as routerPrivateApis } from '@wordpress/router';
 /**
  * Internal dependencies
  */
-import { TEMPLATE_PARTS, PATTERNS, SYNC_TYPES, USER_PATTERNS } from './utils';
+import {
+	TEMPLATE_PART_POST_TYPE,
+	PATTERN_THEME_TYPE,
+	PATTERN_SYNC_STATUSES,
+	PATTERN_POST_TYPE,
+} from '../../utils/constants';
 import {
 	useExistingTemplateParts,
 	getUniqueTemplatePartTitle,
@@ -23,12 +28,12 @@ import usePatternCategories from '../sidebar-navigation-screen-patterns/use-patt
 const { useHistory } = unlock( routerPrivateApis );
 
 function getPatternMeta( item ) {
-	if ( item.type === PATTERNS ) {
-		return { wp_pattern_sync_status: SYNC_TYPES.unsynced };
+	if ( item.type === PATTERN_THEME_TYPE ) {
+		return { wp_pattern_sync_status: PATTERN_SYNC_STATUSES.unsynced };
 	}
 
 	const syncStatus = item.patternBlock.wp_pattern_sync_status;
-	const isUnsynced = syncStatus === SYNC_TYPES.unsynced;
+	const isUnsynced = syncStatus === PATTERN_SYNC_STATUSES.unsynced;
 
 	return {
 		...item.patternBlock.meta,
@@ -84,9 +89,9 @@ export default function DuplicateMenuItem( {
 			);
 
 			history.push( {
-				postType: TEMPLATE_PARTS,
+				postType: TEMPLATE_PART_POST_TYPE,
 				postId: result?.id,
-				categoryType: TEMPLATE_PARTS,
+				categoryType: TEMPLATE_PART_POST_TYPE,
 				categoryId,
 			} );
 
@@ -148,7 +153,7 @@ export default function DuplicateMenuItem( {
 
 	async function createPattern() {
 		try {
-			const isThemePattern = item.type === PATTERNS;
+			const isThemePattern = item.type === PATTERN_THEME_TYPE;
 			const title = sprintf(
 				/* translators: %s: Existing pattern title */
 				__( '%s (Copy)' ),
@@ -184,9 +189,9 @@ export default function DuplicateMenuItem( {
 			);
 
 			history.push( {
-				categoryType: PATTERNS,
+				categoryType: PATTERN_THEME_TYPE,
 				categoryId,
-				postType: USER_PATTERNS,
+				postType: PATTERN_POST_TYPE,
 				postId: result?.id,
 			} );
 
@@ -206,7 +211,9 @@ export default function DuplicateMenuItem( {
 	}
 
 	const createItem =
-		item.type === TEMPLATE_PARTS ? createTemplatePart : createPattern;
+		item.type === TEMPLATE_PART_POST_TYPE
+			? createTemplatePart
+			: createPattern;
 
 	return <MenuItem onClick={ createItem }>{ label }</MenuItem>;
 }

--- a/packages/edit-site/src/components/page-patterns/grid-item.js
+++ b/packages/edit-site/src/components/page-patterns/grid-item.js
@@ -39,10 +39,9 @@ import { store as reusableBlocksStore } from '@wordpress/reusable-blocks';
 import RenameMenuItem from './rename-menu-item';
 import DuplicateMenuItem from './duplicate-menu-item';
 import {
-	PATTERN_THEME_TYPE,
+	PATTERN_TYPES,
 	TEMPLATE_PART_POST_TYPE,
-	PATTERN_POST_TYPE,
-	PATTERN_SYNC_STATUSES,
+	PATTERN_SYNC_TYPES,
 } from '../../utils/constants';
 import { store as editSiteStore } from '../../store';
 import { useLink } from '../routes/link';
@@ -59,8 +58,8 @@ function GridItem( { categoryId, item, ...props } ) {
 	const { createErrorNotice, createSuccessNotice } =
 		useDispatch( noticesStore );
 
-	const isUserPattern = item.type === PATTERN_POST_TYPE;
-	const isNonUserPattern = item.type === PATTERN_THEME_TYPE;
+	const isUserPattern = item.type === PATTERN_TYPES.user;
+	const isNonUserPattern = item.type === PATTERN_TYPES.theme;
 	const isTemplatePart = item.type === TEMPLATE_PART_POST_TYPE;
 
 	const { onClick } = useLink( {
@@ -129,7 +128,7 @@ function GridItem( { categoryId, item, ...props } ) {
 		itemIcon = templatePartIcons[ categoryId ];
 	} else {
 		itemIcon =
-			item.syncStatus === PATTERN_SYNC_STATUSES.full ? symbol : undefined;
+			item.syncStatus === PATTERN_SYNC_TYPES.full ? symbol : undefined;
 	}
 
 	const confirmButtonText = hasThemeFile ? __( 'Clear' ) : __( 'Delete' );
@@ -150,10 +149,10 @@ function GridItem( { categoryId, item, ...props } ) {
 				id={ `edit-site-patterns-${ item.name }` }
 				{ ...props }
 				onClick={
-					item.type !== PATTERN_THEME_TYPE ? onClick : undefined
+					item.type !== PATTERN_TYPES.theme ? onClick : undefined
 				}
 				aria-disabled={
-					item.type !== PATTERN_THEME_TYPE ? 'false' : 'true'
+					item.type !== PATTERN_TYPES.theme ? 'false' : 'true'
 				}
 				aria-label={ item.title }
 				aria-describedby={
@@ -204,7 +203,7 @@ function GridItem( { categoryId, item, ...props } ) {
 						</Tooltip>
 					) }
 					<Flex as="span" gap={ 0 } justify="left">
-						{ item.type === PATTERN_THEME_TYPE ? (
+						{ item.type === PATTERN_TYPES.theme ? (
 							item.title
 						) : (
 							<Heading level={ 5 }>
@@ -219,7 +218,7 @@ function GridItem( { categoryId, item, ...props } ) {
 								</Button>
 							</Heading>
 						) }
-						{ item.type === PATTERN_THEME_TYPE && (
+						{ item.type === PATTERN_TYPES.theme && (
 							<Tooltip
 								position="top center"
 								text={ __( 'This pattern cannot be edited.' ) }

--- a/packages/edit-site/src/components/page-patterns/grid-item.js
+++ b/packages/edit-site/src/components/page-patterns/grid-item.js
@@ -38,7 +38,12 @@ import { store as reusableBlocksStore } from '@wordpress/reusable-blocks';
  */
 import RenameMenuItem from './rename-menu-item';
 import DuplicateMenuItem from './duplicate-menu-item';
-import { PATTERNS, TEMPLATE_PARTS, USER_PATTERNS, SYNC_TYPES } from './utils';
+import {
+	PATTERN_THEME_TYPE,
+	TEMPLATE_PART_POST_TYPE,
+	PATTERN_POST_TYPE,
+	PATTERN_SYNC_STATUSES,
+} from '../../utils/constants';
 import { store as editSiteStore } from '../../store';
 import { useLink } from '../routes/link';
 
@@ -54,9 +59,9 @@ function GridItem( { categoryId, item, ...props } ) {
 	const { createErrorNotice, createSuccessNotice } =
 		useDispatch( noticesStore );
 
-	const isUserPattern = item.type === USER_PATTERNS;
-	const isNonUserPattern = item.type === PATTERNS;
-	const isTemplatePart = item.type === TEMPLATE_PARTS;
+	const isUserPattern = item.type === PATTERN_POST_TYPE;
+	const isNonUserPattern = item.type === PATTERN_THEME_TYPE;
+	const isTemplatePart = item.type === TEMPLATE_PART_POST_TYPE;
 
 	const { onClick } = useLink( {
 		postType: item.type,
@@ -123,7 +128,8 @@ function GridItem( { categoryId, item, ...props } ) {
 	if ( ! isUserPattern && templatePartIcons[ categoryId ] ) {
 		itemIcon = templatePartIcons[ categoryId ];
 	} else {
-		itemIcon = item.syncStatus === SYNC_TYPES.full ? symbol : undefined;
+		itemIcon =
+			item.syncStatus === PATTERN_SYNC_STATUSES.full ? symbol : undefined;
 	}
 
 	const confirmButtonText = hasThemeFile ? __( 'Clear' ) : __( 'Delete' );
@@ -143,8 +149,12 @@ function GridItem( { categoryId, item, ...props } ) {
 				// @see https://reakit.io/docs/composite/#performance.
 				id={ `edit-site-patterns-${ item.name }` }
 				{ ...props }
-				onClick={ item.type !== PATTERNS ? onClick : undefined }
-				aria-disabled={ item.type !== PATTERNS ? 'false' : 'true' }
+				onClick={
+					item.type !== PATTERN_THEME_TYPE ? onClick : undefined
+				}
+				aria-disabled={
+					item.type !== PATTERN_THEME_TYPE ? 'false' : 'true'
+				}
 				aria-label={ item.title }
 				aria-describedby={
 					ariaDescriptions.length
@@ -194,7 +204,7 @@ function GridItem( { categoryId, item, ...props } ) {
 						</Tooltip>
 					) }
 					<Flex as="span" gap={ 0 } justify="left">
-						{ item.type === PATTERNS ? (
+						{ item.type === PATTERN_THEME_TYPE ? (
 							item.title
 						) : (
 							<Heading level={ 5 }>
@@ -209,7 +219,7 @@ function GridItem( { categoryId, item, ...props } ) {
 								</Button>
 							</Heading>
 						) }
-						{ item.type === PATTERNS && (
+						{ item.type === PATTERN_THEME_TYPE && (
 							<Tooltip
 								position="top center"
 								text={ __( 'This pattern cannot be edited.' ) }

--- a/packages/edit-site/src/components/page-patterns/header.js
+++ b/packages/edit-site/src/components/page-patterns/header.js
@@ -13,10 +13,7 @@ import { useSelect } from '@wordpress/data';
  * Internal dependencies
  */
 import usePatternCategories from '../sidebar-navigation-screen-patterns/use-pattern-categories';
-import {
-	TEMPLATE_PART_POST_TYPE,
-	PATTERN_THEME_TYPE,
-} from '../../utils/constants';
+import { TEMPLATE_PART_POST_TYPE, PATTERN_TYPES } from '../../utils/constants';
 
 export default function PatternsHeader( {
 	categoryId,
@@ -38,7 +35,7 @@ export default function PatternsHeader( {
 		);
 		title = templatePartArea?.label;
 		description = templatePartArea?.description;
-	} else if ( type === PATTERN_THEME_TYPE ) {
+	} else if ( type === PATTERN_TYPES.theme ) {
 		const patternCategory = patternCategories.find(
 			( category ) => category.name === categoryId
 		);

--- a/packages/edit-site/src/components/page-patterns/header.js
+++ b/packages/edit-site/src/components/page-patterns/header.js
@@ -13,7 +13,10 @@ import { useSelect } from '@wordpress/data';
  * Internal dependencies
  */
 import usePatternCategories from '../sidebar-navigation-screen-patterns/use-pattern-categories';
-import { TEMPLATE_PARTS, PATTERNS } from './utils';
+import {
+	TEMPLATE_PART_POST_TYPE,
+	PATTERN_THEME_TYPE,
+} from '../../utils/constants';
 
 export default function PatternsHeader( {
 	categoryId,
@@ -29,13 +32,13 @@ export default function PatternsHeader( {
 	);
 
 	let title, description;
-	if ( type === TEMPLATE_PARTS ) {
+	if ( type === TEMPLATE_PART_POST_TYPE ) {
 		const templatePartArea = templatePartAreas.find(
 			( area ) => area.area === categoryId
 		);
 		title = templatePartArea?.label;
 		description = templatePartArea?.description;
-	} else if ( type === PATTERNS ) {
+	} else if ( type === PATTERN_THEME_TYPE ) {
 		const patternCategory = patternCategories.find(
 			( category ) => category.name === categoryId
 		);

--- a/packages/edit-site/src/components/page-patterns/index.js
+++ b/packages/edit-site/src/components/page-patterns/index.js
@@ -8,10 +8,7 @@ import { getQueryArgs } from '@wordpress/url';
 /**
  * Internal dependencies
  */
-import {
-	PATTERN_DEFAULT_CATEGORY,
-	PATTERN_POST_TYPE,
-} from '../../utils/constants';
+import { PATTERN_DEFAULT_CATEGORY, PATTERN_TYPES } from '../../utils/constants';
 import Page from '../page';
 import PatternsList from './patterns-list';
 import usePatternSettings from './use-pattern-settings';
@@ -21,7 +18,7 @@ const { ExperimentalBlockEditorProvider } = unlock( blockEditorPrivateApis );
 
 export default function PagePatterns() {
 	const { categoryType, categoryId } = getQueryArgs( window.location.href );
-	const type = categoryType || PATTERN_POST_TYPE;
+	const type = categoryType || PATTERN_TYPES.user;
 	const category = categoryId || PATTERN_DEFAULT_CATEGORY;
 	const settings = usePatternSettings();
 

--- a/packages/edit-site/src/components/page-patterns/index.js
+++ b/packages/edit-site/src/components/page-patterns/index.js
@@ -8,7 +8,10 @@ import { getQueryArgs } from '@wordpress/url';
 /**
  * Internal dependencies
  */
-import { DEFAULT_CATEGORY, DEFAULT_TYPE } from './utils';
+import {
+	PATTERN_DEFAULT_CATEGORY,
+	PATTERN_POST_TYPE,
+} from '../../utils/constants';
 import Page from '../page';
 import PatternsList from './patterns-list';
 import usePatternSettings from './use-pattern-settings';
@@ -18,8 +21,8 @@ const { ExperimentalBlockEditorProvider } = unlock( blockEditorPrivateApis );
 
 export default function PagePatterns() {
 	const { categoryType, categoryId } = getQueryArgs( window.location.href );
-	const type = categoryType || DEFAULT_TYPE;
-	const category = categoryId || DEFAULT_CATEGORY;
+	const type = categoryType || PATTERN_POST_TYPE;
+	const category = categoryId || PATTERN_DEFAULT_CATEGORY;
 	const settings = usePatternSettings();
 
 	// Wrap everything in a block editor provider.

--- a/packages/edit-site/src/components/page-patterns/patterns-list.js
+++ b/packages/edit-site/src/components/page-patterns/patterns-list.js
@@ -27,23 +27,26 @@ import usePatterns from './use-patterns';
 import SidebarButton from '../sidebar-button';
 import useDebouncedInput from '../../utils/use-debounced-input';
 import { unlock } from '../../lock-unlock';
-import { SYNC_TYPES, PATTERNS } from './utils';
+import {
+	PATTERN_SYNC_STATUSES,
+	PATTERN_THEME_TYPE,
+} from '../../utils/constants';
 import Pagination from './pagination';
 
 const { useLocation, useHistory } = unlock( routerPrivateApis );
 
 const SYNC_FILTERS = {
 	all: __( 'All' ),
-	[ SYNC_TYPES.full ]: __( 'Synced' ),
-	[ SYNC_TYPES.unsynced ]: __( 'Standard' ),
+	[ PATTERN_SYNC_STATUSES.full ]: __( 'Synced' ),
+	[ PATTERN_SYNC_STATUSES.unsynced ]: __( 'Standard' ),
 };
 
 const SYNC_DESCRIPTIONS = {
 	all: '',
-	[ SYNC_TYPES.full ]: __(
+	[ PATTERN_SYNC_STATUSES.full ]: __(
 		'Patterns that are kept in sync across the site.'
 	),
-	[ SYNC_TYPES.unsynced ]: __(
+	[ PATTERN_SYNC_STATUSES.unsynced ]: __(
 		'Patterns that can be changed freely without affecting the site.'
 	),
 };
@@ -64,7 +67,7 @@ export default function PatternsList( { categoryId, type } ) {
 	const deferredSyncedFilter = useDeferredValue( syncFilter );
 
 	const isUncategorizedThemePatterns =
-		type === PATTERNS && categoryId === 'uncategorized';
+		type === PATTERN_THEME_TYPE && categoryId === 'uncategorized';
 
 	const { patterns, isResolving } = usePatterns(
 		type,
@@ -155,7 +158,7 @@ export default function PatternsList( { categoryId, type } ) {
 							__nextHasNoMarginBottom
 						/>
 					</FlexBlock>
-					{ type === PATTERNS && (
+					{ type === PATTERN_THEME_TYPE && (
 						<ToggleGroupControl
 							className="edit-site-patterns__sync-status-filter"
 							hideLabelFromVision

--- a/packages/edit-site/src/components/page-patterns/patterns-list.js
+++ b/packages/edit-site/src/components/page-patterns/patterns-list.js
@@ -27,26 +27,23 @@ import usePatterns from './use-patterns';
 import SidebarButton from '../sidebar-button';
 import useDebouncedInput from '../../utils/use-debounced-input';
 import { unlock } from '../../lock-unlock';
-import {
-	PATTERN_SYNC_STATUSES,
-	PATTERN_THEME_TYPE,
-} from '../../utils/constants';
+import { PATTERN_SYNC_TYPES, PATTERN_TYPES } from '../../utils/constants';
 import Pagination from './pagination';
 
 const { useLocation, useHistory } = unlock( routerPrivateApis );
 
 const SYNC_FILTERS = {
 	all: __( 'All' ),
-	[ PATTERN_SYNC_STATUSES.full ]: __( 'Synced' ),
-	[ PATTERN_SYNC_STATUSES.unsynced ]: __( 'Standard' ),
+	[ PATTERN_SYNC_TYPES.full ]: __( 'Synced' ),
+	[ PATTERN_SYNC_TYPES.unsynced ]: __( 'Standard' ),
 };
 
 const SYNC_DESCRIPTIONS = {
 	all: '',
-	[ PATTERN_SYNC_STATUSES.full ]: __(
+	[ PATTERN_SYNC_TYPES.full ]: __(
 		'Patterns that are kept in sync across the site.'
 	),
-	[ PATTERN_SYNC_STATUSES.unsynced ]: __(
+	[ PATTERN_SYNC_TYPES.unsynced ]: __(
 		'Patterns that can be changed freely without affecting the site.'
 	),
 };
@@ -67,7 +64,7 @@ export default function PatternsList( { categoryId, type } ) {
 	const deferredSyncedFilter = useDeferredValue( syncFilter );
 
 	const isUncategorizedThemePatterns =
-		type === PATTERN_THEME_TYPE && categoryId === 'uncategorized';
+		type === PATTERN_TYPES.theme && categoryId === 'uncategorized';
 
 	const { patterns, isResolving } = usePatterns(
 		type,
@@ -158,7 +155,7 @@ export default function PatternsList( { categoryId, type } ) {
 							__nextHasNoMarginBottom
 						/>
 					</FlexBlock>
-					{ type === PATTERN_THEME_TYPE && (
+					{ type === PATTERN_TYPES.theme && (
 						<ToggleGroupControl
 							className="edit-site-patterns__sync-status-filter"
 							hideLabelFromVision

--- a/packages/edit-site/src/components/page-patterns/rename-menu-item.js
+++ b/packages/edit-site/src/components/page-patterns/rename-menu-item.js
@@ -18,7 +18,7 @@ import { store as noticesStore } from '@wordpress/notices';
 /**
  * Internal dependencies
  */
-import { TEMPLATE_PARTS } from './utils';
+import { TEMPLATE_PART_POST_TYPE } from '../../utils/constants';
 
 export default function RenameMenuItem( { item, onClose } ) {
 	const [ title, setTitle ] = useState( () => item.title );
@@ -29,7 +29,7 @@ export default function RenameMenuItem( { item, onClose } ) {
 	const { createSuccessNotice, createErrorNotice } =
 		useDispatch( noticesStore );
 
-	if ( item.type === TEMPLATE_PARTS && ! item.isCustom ) {
+	if ( item.type === TEMPLATE_PART_POST_TYPE && ! item.isCustom ) {
 		return null;
 	}
 
@@ -50,7 +50,7 @@ export default function RenameMenuItem( { item, onClose } ) {
 			} );
 
 			createSuccessNotice(
-				item.type === TEMPLATE_PARTS
+				item.type === TEMPLATE_PART_POST_TYPE
 					? __( 'Template part renamed.' )
 					: __( 'Pattern renamed.' ),
 				{
@@ -59,7 +59,7 @@ export default function RenameMenuItem( { item, onClose } ) {
 			);
 		} catch ( error ) {
 			const fallbackErrorMessage =
-				item.type === TEMPLATE_PARTS
+				item.type === TEMPLATE_PART_POST_TYPE
 					? __(
 							'An error occurred while reverting the template part.'
 					  )

--- a/packages/edit-site/src/components/page-patterns/search-items.js
+++ b/packages/edit-site/src/components/page-patterns/search-items.js
@@ -7,7 +7,7 @@ import { noCase } from 'change-case';
 /**
  * Internal dependencies
  */
-import { ALL_PATTERNS_CATEGORY } from './utils';
+import { PATTERN_DEFAULT_CATEGORY } from '../../utils/constants';
 
 // Default search helpers.
 const defaultGetName = ( item ) => item.name || '';
@@ -90,7 +90,7 @@ const removeMatchingTerms = ( unmatchedTerms, unprocessedTerms ) => {
 export const searchItems = ( items = [], searchInput = '', config = {} ) => {
 	const normalizedSearchTerms = getNormalizedSearchTerms( searchInput );
 	const onlyFilterByCategory =
-		config.categoryId !== ALL_PATTERNS_CATEGORY &&
+		config.categoryId !== PATTERN_DEFAULT_CATEGORY &&
 		! normalizedSearchTerms.length;
 	const searchRankConfig = { ...config, onlyFilterByCategory };
 
@@ -139,7 +139,8 @@ function getItemSearchRank( item, searchTerm, config ) {
 	} = config;
 
 	let rank =
-		categoryId === ALL_PATTERNS_CATEGORY || hasCategory( item, categoryId )
+		categoryId === PATTERN_DEFAULT_CATEGORY ||
+		hasCategory( item, categoryId )
 			? 1
 			: 0;
 

--- a/packages/edit-site/src/components/page-patterns/search-items.js
+++ b/packages/edit-site/src/components/page-patterns/search-items.js
@@ -89,6 +89,7 @@ const removeMatchingTerms = ( unmatchedTerms, unprocessedTerms ) => {
  */
 export const searchItems = ( items = [], searchInput = '', config = {} ) => {
 	const normalizedSearchTerms = getNormalizedSearchTerms( searchInput );
+	// Filter patterns by category: the default category indicates that all patterns will be shown.
 	const onlyFilterByCategory =
 		config.categoryId !== PATTERN_DEFAULT_CATEGORY &&
 		! normalizedSearchTerms.length;

--- a/packages/edit-site/src/components/page-patterns/use-patterns.js
+++ b/packages/edit-site/src/components/page-patterns/use-patterns.js
@@ -10,14 +10,14 @@ import { decodeEntities } from '@wordpress/html-entities';
 /**
  * Internal dependencies
  */
+import { filterOutDuplicatesByName } from './utils';
 import {
-	CORE_PATTERN_SOURCES,
-	PATTERNS,
-	SYNC_TYPES,
-	TEMPLATE_PARTS,
-	USER_PATTERNS,
-	filterOutDuplicatesByName,
-} from './utils';
+	PATTERN_CORE_SOURCES,
+	PATTERN_THEME_TYPE,
+	PATTERN_SYNC_STATUSES,
+	TEMPLATE_PART_POST_TYPE,
+	PATTERN_POST_TYPE,
+} from '../../utils/constants';
 import { unlock } from '../../lock-unlock';
 import { searchItems } from './search-items';
 import { store as editSiteStore } from '../../store';
@@ -50,7 +50,7 @@ const selectTemplatePartsAsPatterns = (
 	const { __experimentalGetDefaultTemplatePartAreas } = select( editorStore );
 	const query = { per_page: -1 };
 	const rawTemplateParts =
-		getEntityRecords( 'postType', TEMPLATE_PARTS, query ) ??
+		getEntityRecords( 'postType', TEMPLATE_PART_POST_TYPE, query ) ??
 		EMPTY_PATTERN_LIST;
 	const templateParts = rawTemplateParts.map( ( templatePart ) =>
 		templatePartToPattern( templatePart )
@@ -101,7 +101,7 @@ const selectThemePatterns = ( select ) => {
 		...( restBlockPatterns || [] ),
 	]
 		.filter(
-			( pattern ) => ! CORE_PATTERN_SOURCES.includes( pattern.source )
+			( pattern ) => ! PATTERN_CORE_SOURCES.includes( pattern.source )
 		)
 		.filter( filterOutDuplicatesByName )
 		.filter( ( pattern ) => pattern.inserter !== false )
@@ -159,9 +159,10 @@ const patternBlockToPattern = ( patternBlock, categories ) => ( {
 	} ),
 	id: patternBlock.id,
 	name: patternBlock.slug,
-	syncStatus: patternBlock.wp_pattern_sync_status || SYNC_TYPES.full,
+	syncStatus:
+		patternBlock.wp_pattern_sync_status || PATTERN_SYNC_STATUSES.full,
 	title: patternBlock.title.raw,
-	type: USER_PATTERNS,
+	type: PATTERN_POST_TYPE,
 	patternBlock,
 } );
 
@@ -170,7 +171,7 @@ const selectUserPatterns = ( select, { search = '', syncStatus } = {} ) => {
 		select( coreStore );
 
 	const query = { per_page: -1 };
-	const records = getEntityRecords( 'postType', USER_PATTERNS, query );
+	const records = getEntityRecords( 'postType', PATTERN_POST_TYPE, query );
 	const categories = getUserPatternCategories();
 
 	let patterns = records
@@ -181,7 +182,7 @@ const selectUserPatterns = ( select, { search = '', syncStatus } = {} ) => {
 
 	const isResolving = getIsResolving( 'getEntityRecords', [
 		'postType',
-		USER_PATTERNS,
+		PATTERN_POST_TYPE,
 		query,
 	] );
 
@@ -208,18 +209,18 @@ export const usePatterns = (
 ) => {
 	return useSelect(
 		( select ) => {
-			if ( categoryType === TEMPLATE_PARTS ) {
+			if ( categoryType === TEMPLATE_PART_POST_TYPE ) {
 				return selectTemplatePartsAsPatterns( select, {
 					categoryId,
 					search,
 				} );
-			} else if ( categoryType === PATTERNS ) {
+			} else if ( categoryType === PATTERN_THEME_TYPE ) {
 				return selectPatterns( select, {
 					categoryId,
 					search,
 					syncStatus,
 				} );
-			} else if ( categoryType === USER_PATTERNS ) {
+			} else if ( categoryType === PATTERN_POST_TYPE ) {
 				return selectUserPatterns( select, { search, syncStatus } );
 			}
 			return { patterns: EMPTY_PATTERN_LIST, isResolving: false };

--- a/packages/edit-site/src/components/page-patterns/use-patterns.js
+++ b/packages/edit-site/src/components/page-patterns/use-patterns.js
@@ -13,10 +13,9 @@ import { decodeEntities } from '@wordpress/html-entities';
 import { filterOutDuplicatesByName } from './utils';
 import {
 	PATTERN_CORE_SOURCES,
-	PATTERN_THEME_TYPE,
-	PATTERN_SYNC_STATUSES,
+	PATTERN_TYPES,
+	PATTERN_SYNC_TYPES,
 	TEMPLATE_PART_POST_TYPE,
-	PATTERN_POST_TYPE,
 } from '../../utils/constants';
 import { unlock } from '../../lock-unlock';
 import { searchItems } from './search-items';
@@ -108,7 +107,7 @@ const selectThemePatterns = ( select ) => {
 		.map( ( pattern ) => ( {
 			...pattern,
 			keywords: pattern.keywords || [],
-			type: 'pattern',
+			type: PATTERN_TYPES.theme,
 			blocks: parse( pattern.content, {
 				__unstableSkipMigrationLogs: true,
 			} ),
@@ -159,10 +158,9 @@ const patternBlockToPattern = ( patternBlock, categories ) => ( {
 	} ),
 	id: patternBlock.id,
 	name: patternBlock.slug,
-	syncStatus:
-		patternBlock.wp_pattern_sync_status || PATTERN_SYNC_STATUSES.full,
+	syncStatus: patternBlock.wp_pattern_sync_status || PATTERN_SYNC_TYPES.full,
 	title: patternBlock.title.raw,
-	type: PATTERN_POST_TYPE,
+	type: PATTERN_TYPES.user,
 	patternBlock,
 } );
 
@@ -171,7 +169,7 @@ const selectUserPatterns = ( select, { search = '', syncStatus } = {} ) => {
 		select( coreStore );
 
 	const query = { per_page: -1 };
-	const records = getEntityRecords( 'postType', PATTERN_POST_TYPE, query );
+	const records = getEntityRecords( 'postType', PATTERN_TYPES.user, query );
 	const categories = getUserPatternCategories();
 
 	let patterns = records
@@ -182,7 +180,7 @@ const selectUserPatterns = ( select, { search = '', syncStatus } = {} ) => {
 
 	const isResolving = getIsResolving( 'getEntityRecords', [
 		'postType',
-		PATTERN_POST_TYPE,
+		PATTERN_TYPES.user,
 		query,
 	] );
 
@@ -214,13 +212,13 @@ export const usePatterns = (
 					categoryId,
 					search,
 				} );
-			} else if ( categoryType === PATTERN_THEME_TYPE ) {
+			} else if ( categoryType === PATTERN_TYPES.theme ) {
 				return selectPatterns( select, {
 					categoryId,
 					search,
 					syncStatus,
 				} );
-			} else if ( categoryType === PATTERN_POST_TYPE ) {
+			} else if ( categoryType === PATTERN_TYPES.user ) {
 				return selectUserPatterns( select, { search, syncStatus } );
 			}
 			return { patterns: EMPTY_PATTERN_LIST, isResolving: false };

--- a/packages/edit-site/src/components/page-patterns/utils.js
+++ b/packages/edit-site/src/components/page-patterns/utils.js
@@ -1,21 +1,2 @@
-export const ALL_PATTERNS_CATEGORY = 'all-patterns';
-export const DEFAULT_CATEGORY = ALL_PATTERNS_CATEGORY;
-export const PATTERNS = 'pattern';
-export const DEFAULT_TYPE = PATTERNS;
-export const TEMPLATE_PARTS = 'wp_template_part';
-export const USER_PATTERNS = 'wp_block';
-
-export const CORE_PATTERN_SOURCES = [
-	'core',
-	'pattern-directory/core',
-	'pattern-directory/featured',
-	'pattern-directory/theme',
-];
-
-export const SYNC_TYPES = {
-	full: 'fully',
-	unsynced: 'unsynced',
-};
-
 export const filterOutDuplicatesByName = ( currentItem, index, items ) =>
 	index === items.findIndex( ( item ) => currentItem.name === item.name );

--- a/packages/edit-site/src/components/sidebar-navigation-screen-patterns/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-patterns/index.js
@@ -19,11 +19,7 @@ import AddNewPattern from '../add-new-pattern';
 import SidebarNavigationItem from '../sidebar-navigation-item';
 import SidebarNavigationScreen from '../sidebar-navigation-screen';
 import CategoryItem from './category-item';
-import {
-	PATTERN_DEFAULT_CATEGORY,
-	PATTERN_THEME_TYPE,
-	PATTERN_POST_TYPE,
-} from '../../utils/constants';
+import { PATTERN_DEFAULT_CATEGORY, PATTERN_TYPES } from '../../utils/constants';
 import { useLink } from '../routes/link';
 import usePatternCategories from './use-pattern-categories';
 import useTemplatePartAreas from './use-template-part-areas';
@@ -74,8 +70,8 @@ function PatternCategoriesGroup( {
 						type="pattern"
 						isActive={
 							currentCategory === `${ category.name }` &&
-							( currentType === PATTERN_THEME_TYPE ||
-								currentType === PATTERN_POST_TYPE )
+							( currentType === PATTERN_TYPES.theme ||
+								currentType === PATTERN_TYPES.user )
 						}
 					/>
 				) ) }
@@ -88,7 +84,7 @@ export default function SidebarNavigationScreenPatterns() {
 	const isMobileViewport = useViewportMatch( 'medium', '<' );
 	const { categoryType, categoryId } = getQueryArgs( window.location.href );
 	const currentCategory = categoryId || PATTERN_DEFAULT_CATEGORY;
-	const currentType = categoryType || PATTERN_POST_TYPE;
+	const currentType = categoryType || PATTERN_TYPES.user;
 
 	const { templatePartAreas, hasTemplateParts, isLoading } =
 		useTemplatePartAreas();

--- a/packages/edit-site/src/components/sidebar-navigation-screen-patterns/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-patterns/index.js
@@ -19,7 +19,11 @@ import AddNewPattern from '../add-new-pattern';
 import SidebarNavigationItem from '../sidebar-navigation-item';
 import SidebarNavigationScreen from '../sidebar-navigation-screen';
 import CategoryItem from './category-item';
-import { DEFAULT_CATEGORY, DEFAULT_TYPE } from '../page-patterns/utils';
+import {
+	PATTERN_DEFAULT_CATEGORY,
+	PATTERN_THEME_TYPE,
+	PATTERN_POST_TYPE,
+} from '../../utils/constants';
 import { useLink } from '../routes/link';
 import usePatternCategories from './use-pattern-categories';
 import useTemplatePartAreas from './use-template-part-areas';
@@ -70,8 +74,8 @@ function PatternCategoriesGroup( {
 						type="pattern"
 						isActive={
 							currentCategory === `${ category.name }` &&
-							( currentType === 'pattern' ||
-								currentType === 'wp_block' )
+							( currentType === PATTERN_THEME_TYPE ||
+								currentType === PATTERN_POST_TYPE )
 						}
 					/>
 				) ) }
@@ -83,8 +87,8 @@ function PatternCategoriesGroup( {
 export default function SidebarNavigationScreenPatterns() {
 	const isMobileViewport = useViewportMatch( 'medium', '<' );
 	const { categoryType, categoryId } = getQueryArgs( window.location.href );
-	const currentCategory = categoryId || DEFAULT_CATEGORY;
-	const currentType = categoryType || DEFAULT_TYPE;
+	const currentCategory = categoryId || PATTERN_DEFAULT_CATEGORY;
+	const currentType = categoryType || PATTERN_POST_TYPE;
 
 	const { templatePartAreas, hasTemplateParts, isLoading } =
 		useTemplatePartAreas();

--- a/packages/edit-site/src/components/sidebar-navigation-screen-patterns/use-pattern-categories.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-patterns/use-pattern-categories.js
@@ -10,7 +10,10 @@ import { __ } from '@wordpress/i18n';
 import useDefaultPatternCategories from './use-default-pattern-categories';
 import useThemePatterns from './use-theme-patterns';
 import usePatterns from '../page-patterns/use-patterns';
-import { USER_PATTERNS, ALL_PATTERNS_CATEGORY } from '../page-patterns/utils';
+import {
+	PATTERN_POST_TYPE,
+	PATTERN_DEFAULT_CATEGORY,
+} from '../../utils/constants';
 
 export default function usePatternCategories() {
 	const defaultCategories = useDefaultPatternCategories();
@@ -20,7 +23,7 @@ export default function usePatternCategories() {
 	} );
 	const themePatterns = useThemePatterns();
 	const { patterns: userPatterns, categories: userPatternCategories } =
-		usePatterns( USER_PATTERNS );
+		usePatterns( PATTERN_POST_TYPE );
 
 	const patternCategories = useMemo( () => {
 		const categoryMap = {};
@@ -81,7 +84,7 @@ export default function usePatternCategories() {
 			a.label.localeCompare( b.label )
 		);
 		sortedCategories.unshift( {
-			name: ALL_PATTERNS_CATEGORY,
+			name: PATTERN_DEFAULT_CATEGORY,
 			label: __( 'All Patterns' ),
 			description: __( 'A list of all patterns from all sources' ),
 			count: themePatterns.length + userPatterns.length,

--- a/packages/edit-site/src/components/sidebar-navigation-screen-patterns/use-pattern-categories.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-patterns/use-pattern-categories.js
@@ -10,10 +10,7 @@ import { __ } from '@wordpress/i18n';
 import useDefaultPatternCategories from './use-default-pattern-categories';
 import useThemePatterns from './use-theme-patterns';
 import usePatterns from '../page-patterns/use-patterns';
-import {
-	PATTERN_POST_TYPE,
-	PATTERN_DEFAULT_CATEGORY,
-} from '../../utils/constants';
+import { PATTERN_TYPES, PATTERN_DEFAULT_CATEGORY } from '../../utils/constants';
 
 export default function usePatternCategories() {
 	const defaultCategories = useDefaultPatternCategories();
@@ -23,7 +20,7 @@ export default function usePatternCategories() {
 	} );
 	const themePatterns = useThemePatterns();
 	const { patterns: userPatterns, categories: userPatternCategories } =
-		usePatterns( PATTERN_POST_TYPE );
+		usePatterns( PATTERN_TYPES.user );
 
 	const patternCategories = useMemo( () => {
 		const categoryMap = {};

--- a/packages/edit-site/src/components/sidebar-navigation-screen-patterns/use-theme-patterns.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-patterns/use-theme-patterns.js
@@ -8,10 +8,8 @@ import { useMemo } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import {
-	CORE_PATTERN_SOURCES,
-	filterOutDuplicatesByName,
-} from '../page-patterns/utils';
+import { filterOutDuplicatesByName } from '../page-patterns/utils';
+import { PATTERN_CORE_SOURCES } from '../../utils/constants';
 import { unlock } from '../../lock-unlock';
 import { store as editSiteStore } from '../../store';
 
@@ -34,7 +32,7 @@ export default function useThemePatterns() {
 			[ ...( blockPatterns || [] ), ...( restBlockPatterns || [] ) ]
 				.filter(
 					( pattern ) =>
-						! CORE_PATTERN_SOURCES.includes( pattern.source )
+						! PATTERN_CORE_SOURCES.includes( pattern.source )
 				)
 				.filter( filterOutDuplicatesByName )
 				.filter( ( pattern ) => pattern.inserter !== false ),

--- a/packages/edit-site/src/utils/constants.js
+++ b/packages/edit-site/src/utils/constants.js
@@ -2,6 +2,12 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { privateApis as patternPrivateApis } from '@wordpress/patterns';
+
+/**
+ * Internal dependencies
+ */
+import { unlock } from '../lock-unlock';
 
 // Navigation
 export const NAVIGATION_POST_TYPE = 'wp_navigation';
@@ -12,30 +18,23 @@ export const TEMPLATE_PART_POST_TYPE = 'wp_template_part';
 export const TEMPLATE_CUSTOM_SOURCE = 'custom';
 
 // Patterns.
-export const PATTERN_POST_TYPE = 'wp_block';
-export const PATTERN_DEFAULT_CATEGORY = 'all-patterns';
-export const PATTERN_THEME_TYPE = 'pattern';
-export const PATTERN_CORE_SOURCES = [
-	'core',
-	'pattern-directory/core',
-	'pattern-directory/featured',
-	'pattern-directory/theme',
-];
-export const PATTERN_SYNC_STATUSES = {
-	full: 'fully',
-	unsynced: 'unsynced',
-};
+export const {
+	PATTERN_TYPES,
+	PATTERN_DEFAULT_CATEGORY,
+	PATTERN_CORE_SOURCES,
+	PATTERN_SYNC_TYPES,
+} = unlock( patternPrivateApis );
 
 // Entities that are editable in focus mode.
 export const FOCUSABLE_ENTITIES = [
 	TEMPLATE_PART_POST_TYPE,
 	NAVIGATION_POST_TYPE,
-	PATTERN_POST_TYPE,
+	PATTERN_TYPES.user,
 ];
 
 export const POST_TYPE_LABELS = {
 	[ TEMPLATE_POST_TYPE ]: __( 'Template' ),
 	[ TEMPLATE_PART_POST_TYPE ]: __( 'Template Part' ),
-	[ PATTERN_POST_TYPE ]: __( 'Pattern' ),
+	[ PATTERN_TYPES.user ]: __( 'Pattern' ),
 	[ NAVIGATION_POST_TYPE ]: __( 'Navigation' ),
 };

--- a/packages/edit-site/src/utils/constants.js
+++ b/packages/edit-site/src/utils/constants.js
@@ -1,5 +1,41 @@
-export const FOCUSABLE_ENTITIES = [
-	'wp_template_part',
-	'wp_navigation',
-	'wp_block',
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+// Navigation
+export const NAVIGATION_POST_TYPE = 'wp_navigation';
+
+// Templates.
+export const TEMPLATE_POST_TYPE = 'wp_template';
+export const TEMPLATE_PART_POST_TYPE = 'wp_template_part';
+export const TEMPLATE_CUSTOM_SOURCE = 'custom';
+
+// Patterns.
+export const PATTERN_POST_TYPE = 'wp_block';
+export const PATTERN_DEFAULT_CATEGORY = 'all-patterns';
+export const PATTERN_THEME_TYPE = 'pattern';
+export const PATTERN_CORE_SOURCES = [
+	'core',
+	'pattern-directory/core',
+	'pattern-directory/featured',
+	'pattern-directory/theme',
 ];
+export const PATTERN_SYNC_STATUSES = {
+	full: 'fully',
+	unsynced: 'unsynced',
+};
+
+// Entities that are editable in focus mode.
+export const FOCUSABLE_ENTITIES = [
+	TEMPLATE_PART_POST_TYPE,
+	NAVIGATION_POST_TYPE,
+	PATTERN_POST_TYPE,
+];
+
+export const POST_TYPE_LABELS = {
+	[ TEMPLATE_POST_TYPE ]: __( 'Template' ),
+	[ TEMPLATE_PART_POST_TYPE ]: __( 'Template Part' ),
+	[ PATTERN_POST_TYPE ]: __( 'Pattern' ),
+	[ NAVIGATION_POST_TYPE ]: __( 'Navigation' ),
+};

--- a/packages/edit-site/src/utils/is-template-removable.js
+++ b/packages/edit-site/src/utils/is-template-removable.js
@@ -1,4 +1,9 @@
 /**
+ * Internal dependencies
+ */
+import { TEMPLATE_CUSTOM_SOURCE } from './constants';
+
+/**
  * Check if a template is removable.
  *
  * @param {Object} template The template entity to check.
@@ -9,5 +14,7 @@ export default function isTemplateRemovable( template ) {
 		return false;
 	}
 
-	return template.source === 'custom' && ! template.has_theme_file;
+	return (
+		template.source === TEMPLATE_CUSTOM_SOURCE && ! template.has_theme_file
+	);
 }

--- a/packages/edit-site/src/utils/is-template-revertable.js
+++ b/packages/edit-site/src/utils/is-template-revertable.js
@@ -1,4 +1,9 @@
 /**
+ * Internal dependencies
+ */
+import { TEMPLATE_CUSTOM_SOURCE } from './constants';
+
+/**
  * Check if a template is revertable to its original theme-provided template file.
  *
  * @param {Object} template The template entity to check.
@@ -9,6 +14,8 @@ export default function isTemplateRevertable( template ) {
 		return false;
 	}
 	/* eslint-disable camelcase */
-	return template?.source === 'custom' && template?.has_theme_file;
+	return (
+		template?.source === TEMPLATE_CUSTOM_SOURCE && template?.has_theme_file
+	);
 	/* eslint-enable camelcase */
 }

--- a/packages/patterns/src/components/create-pattern-modal.js
+++ b/packages/patterns/src/components/create-pattern-modal.js
@@ -14,9 +14,9 @@ import { useState, useCallback } from '@wordpress/element';
 import { useDispatch } from '@wordpress/data';
 import { store as noticesStore } from '@wordpress/notices';
 
-export const ALL_PATTERNS_CATEGORY = 'all-patterns';
+export const PATTERN_DEFAULT_CATEGORY = 'all-patterns';
 
-export const SYNC_TYPES = {
+export const PATTERN_SYNC_STATUSES = {
 	full: undefined,
 	unsynced: 'unsynced',
 };
@@ -34,7 +34,7 @@ export default function CreatePatternModal( {
 	onClose,
 	className = 'patterns-menu-items__convert-modal',
 } ) {
-	const [ syncType, setSyncType ] = useState( SYNC_TYPES.full );
+	const [ syncType, setSyncType ] = useState( PATTERN_SYNC_STATUSES.full );
 	const [ categories, setCategories ] = useState( [] );
 	const [ title, setTitle ] = useState( '' );
 	const { createPattern } = useDispatch( store );
@@ -51,7 +51,7 @@ export default function CreatePatternModal( {
 				);
 				onSuccess( {
 					pattern: newPattern,
-					categoryId: ALL_PATTERNS_CATEGORY,
+					categoryId: PATTERN_DEFAULT_CATEGORY,
 				} );
 			} catch ( error ) {
 				createErrorNotice( error.message, {
@@ -111,9 +111,9 @@ export default function CreatePatternModal( {
 						checked={ ! syncType }
 						onChange={ () => {
 							setSyncType(
-								syncType === SYNC_TYPES.full
-									? SYNC_TYPES.unsynced
-									: SYNC_TYPES.full
+								syncType === PATTERN_SYNC_STATUSES.full
+									? PATTERN_SYNC_STATUSES.unsynced
+									: PATTERN_SYNC_STATUSES.full
 							);
 						} }
 					/>

--- a/packages/patterns/src/components/create-pattern-modal.js
+++ b/packages/patterns/src/components/create-pattern-modal.js
@@ -14,12 +14,10 @@ import { useState, useCallback } from '@wordpress/element';
 import { useDispatch } from '@wordpress/data';
 import { store as noticesStore } from '@wordpress/notices';
 
-export const PATTERN_DEFAULT_CATEGORY = 'all-patterns';
-
-export const PATTERN_SYNC_STATUSES = {
-	full: undefined,
-	unsynced: 'unsynced',
-};
+/**
+ * Internal dependencies
+ */
+import { PATTERN_DEFAULT_CATEGORY, PATTERN_SYNC_TYPES } from '../constants';
 
 /**
  * Internal dependencies
@@ -34,7 +32,7 @@ export default function CreatePatternModal( {
 	onClose,
 	className = 'patterns-menu-items__convert-modal',
 } ) {
-	const [ syncType, setSyncType ] = useState( PATTERN_SYNC_STATUSES.full );
+	const [ syncType, setSyncType ] = useState( PATTERN_SYNC_TYPES.full );
 	const [ categories, setCategories ] = useState( [] );
 	const [ title, setTitle ] = useState( '' );
 	const { createPattern } = useDispatch( store );
@@ -108,12 +106,12 @@ export default function CreatePatternModal( {
 						help={ __(
 							'Editing the pattern will update it anywhere it is used.'
 						) }
-						checked={ ! syncType }
+						checked={ syncType === PATTERN_SYNC_TYPES.full }
 						onChange={ () => {
 							setSyncType(
-								syncType === PATTERN_SYNC_STATUSES.full
-									? PATTERN_SYNC_STATUSES.unsynced
-									: PATTERN_SYNC_STATUSES.full
+								syncType === PATTERN_SYNC_TYPES.full
+									? PATTERN_SYNC_TYPES.unsynced
+									: PATTERN_SYNC_TYPES.full
 							);
 						} }
 					/>

--- a/packages/patterns/src/constants.js
+++ b/packages/patterns/src/constants.js
@@ -1,0 +1,16 @@
+export const PATTERN_TYPES = {
+	theme: 'pattern',
+	user: 'wp_block',
+};
+
+export const PATTERN_DEFAULT_CATEGORY = 'all-patterns';
+export const PATTERN_CORE_SOURCES = [
+	'core',
+	'pattern-directory/core',
+	'pattern-directory/featured',
+	'pattern-directory/theme',
+];
+export const PATTERN_SYNC_TYPES = {
+	full: 'fully',
+	unsynced: 'unsynced',
+};

--- a/packages/patterns/src/private-apis.js
+++ b/packages/patterns/src/private-apis.js
@@ -4,9 +4,19 @@
 import { lock } from './lock-unlock';
 import CreatePatternModal from './components/create-pattern-modal';
 import PatternsMenuItems from './components';
+import {
+	PATTERN_TYPES,
+	PATTERN_DEFAULT_CATEGORY,
+	PATTERN_CORE_SOURCES,
+	PATTERN_SYNC_TYPES,
+} from './constants';
 
 export const privateApis = {};
 lock( privateApis, {
 	CreatePatternModal,
 	PatternsMenuItems,
+	PATTERN_TYPES,
+	PATTERN_DEFAULT_CATEGORY,
+	PATTERN_CORE_SOURCES,
+	PATTERN_SYNC_TYPES,
 } );

--- a/packages/patterns/src/store/actions.js
+++ b/packages/patterns/src/store/actions.js
@@ -7,6 +7,11 @@ import { store as coreStore } from '@wordpress/core-data';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 
 /**
+ * Internal dependencies
+ */
+import { PATTERN_SYNC_TYPES } from '../constants';
+
+/**
  * Returns a generator converting one or more static blocks into a pattern, or creating a new empty pattern.
  *
  * @param {string}             title      Pattern title.
@@ -18,7 +23,7 @@ export const createPattern =
 	( title, syncType, clientIds, categories ) =>
 	async ( { registry, dispatch } ) => {
 		const meta =
-			syncType === 'unsynced'
+			syncType === PATTERN_SYNC_TYPES.unsynced
 				? {
 						wp_pattern_sync_status: syncType,
 				  }


### PR DESCRIPTION
❗ Don't merge until the following PR is merged:

- https://github.com/WordPress/gutenberg/pull/53835

## What?

Consolidating constants in the edit-site package.

Primarily hoisting pattern constants and removing duplicates.

I also removed duplicate constants. :trollface: That was a joke.

Move pattern-specifc constants to the patterns package and update its files to use them.

To keep this PR small, I haven't replaced all hard-coded values with CONSTANTS, but can do in a follow up once we've finalized the approach.

## Why?
While working on [unifying the template/pattern actions drop down component](https://github.com/WordPress/gutenberg/pull/54271), I noticed that there were a few constants that we could use across the edit-site package.

Also, it would be good to centralize our references to post types.

## Testing Instructions
The site editor in general should work, tests should pass.

In particular, create, rename, and generally manage patterns and template parts in the site editor. Path: `/wp-admin/site-editor.php?categoryType=wp_block&categoryId=my-patterns&path=%2Fpatterns`
