### PR TITLE
Fix layout when post content is root block

### DIFF
--- a/lib/compat/wordpress-6.3/block-editor-settings.php
+++ b/lib/compat/wordpress-6.3/block-editor-settings.php
@@ -78,7 +78,7 @@ function gutenberg_get_block_editor_settings_experimental( $settings ) {
 		$template_blocks    = parse_blocks( $current_template[0]->content );
 		$post_content_block = gutenberg_find_first_block( 'core/post-content', $template_blocks );
 
-		if ( isset( $post_content_block['attrs'] )  ) {
+		if ( isset( $post_content_block['attrs'] ) ) {
 			$settings['postContentAttributes'] = $post_content_block['attrs'];
 		}
 	}

--- a/lib/compat/wordpress-6.3/block-editor-settings.php
+++ b/lib/compat/wordpress-6.3/block-editor-settings.php
@@ -78,7 +78,7 @@ function gutenberg_get_block_editor_settings_experimental( $settings ) {
 		$template_blocks    = parse_blocks( $current_template[0]->content );
 		$post_content_block = gutenberg_find_first_block( 'core/post-content', $template_blocks );
 
-		if ( ! empty( $post_content_block['attrs'] ) ) {
+		if ( is_array( $post_content_block['attrs'] ) || is_object( $post_content_block['attrs'] ) ) {
 			$settings['postContentAttributes'] = $post_content_block['attrs'];
 		}
 	}

--- a/lib/compat/wordpress-6.3/block-editor-settings.php
+++ b/lib/compat/wordpress-6.3/block-editor-settings.php
@@ -78,7 +78,7 @@ function gutenberg_get_block_editor_settings_experimental( $settings ) {
 		$template_blocks    = parse_blocks( $current_template[0]->content );
 		$post_content_block = gutenberg_find_first_block( 'core/post-content', $template_blocks );
 
-		if ( is_array( $post_content_block['attrs'] ) || is_object( $post_content_block['attrs'] ) ) {
+		if ( isset( $post_content_block['attrs'] )  ) {
 			$settings['postContentAttributes'] = $post_content_block['attrs'];
 		}
 	}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

In #54371 we reintroduced content size in the post editor when the Post Content block has a default layout type and is nested inside other blocks. However, if Post Content is at root level and has default layout, we should assume that it is meant to stretch full width and let that happen. 

The problem is we're using the Post Content attributes to check whether the template being used is a block template; if layout is set to default there are no attributes (because it's using the default layout type) and we don't add anything to the editor settings. This results in the fallback layout (with content width) being used instead of the default.

This PR proposes changing the check that adds the Post Content attributes to the editor settings so that it still outputs an empty array if the block exists but the attributes are empty.

An alternative to this would be using the `__unstableIsBlockBasedTheme` editor setting to check whether the theme is a block theme, but that wouldn't work for hybrid themes that might have one or two templates with Post Content blocks.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Create a post template with a Post Content block at root level, and make sure the "Inner blocks use content width" toggle is off;
2. Check that posts using that template have no max content width in the post editor;
3. Check that Post Content blocks with "Inner blocks use content width"  toggled on, and with it toggled off but with the block nested inside other blocks, still correctly display a max content width in the post editor.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
