### PR TITLE
Fix React forwardRef warnings for `TooltipAnchor`s

### DIFF
--- a/packages/icons/CHANGELOG.md
+++ b/packages/icons/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancement
+
+-   `<Icon>` now forwards ref to the underlying child component ([#54492](https://github.com/WordPress/gutenberg/pull/54492)).
+
 ## 9.32.0 (2023-08-31)
 
 ### Bug Fix

--- a/packages/icons/src/icon/index.js
+++ b/packages/icons/src/icon/index.js
@@ -8,10 +8,10 @@ import { cloneElement, forwardRef } from '@wordpress/element';
 /**
  * Return an SVG icon.
  *
- * @param {IconProps}                          props icon is the SVG component to render
- *                                                   size is a number specifiying the icon size in pixels
- *                                                   Other props will be passed to wrapped SVG component
- * @param {import('react').Ref<SVGSVGElement>} ref   The forwarded ref to the SVG element.
+ * @param {IconProps}                                 props icon is the SVG component to render
+ *                                                          size is a number specifiying the icon size in pixels
+ *                                                          Other props will be passed to wrapped SVG component
+ * @param {import('react').ForwardedRef<HTMLElement>} ref   The forwarded ref to the SVG element.
  *
  * @return {JSX.Element}  Icon component
  */

--- a/packages/icons/src/icon/index.js
+++ b/packages/icons/src/icon/index.js
@@ -1,25 +1,27 @@
 /**
  * WordPress dependencies
  */
-import { cloneElement } from '@wordpress/element';
+import { cloneElement, forwardRef } from '@wordpress/element';
 
 /** @typedef {{icon: JSX.Element, size?: number} & import('@wordpress/primitives').SVGProps} IconProps */
 
 /**
  * Return an SVG icon.
  *
- * @param {IconProps} props icon is the SVG component to render
- *                          size is a number specifiying the icon size in pixels
- *                          Other props will be passed to wrapped SVG component
+ * @param {IconProps}                          props icon is the SVG component to render
+ *                                                   size is a number specifiying the icon size in pixels
+ *                                                   Other props will be passed to wrapped SVG component
+ * @param {import('react').Ref<SVGSVGElement>} ref   The forwarded ref to the SVG element.
  *
  * @return {JSX.Element}  Icon component
  */
-function Icon( { icon, size = 24, ...props } ) {
+function Icon( { icon, size = 24, ...props }, ref ) {
 	return cloneElement( icon, {
 		width: size,
 		height: size,
 		...props,
+		ref,
 	} );
 }
 
-export default Icon;
+export default forwardRef( Icon );

--- a/packages/primitives/CHANGELOG.md
+++ b/packages/primitives/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancement
+
+-   `<SVG>` now forwards ref to the underlying `<svg>` element ([#54492](https://github.com/WordPress/gutenberg/pull/54492)).
+
 ## 3.39.0 (2023-08-31)
 
 ## 3.38.0 (2023-08-16)

--- a/packages/primitives/src/svg/index.js
+++ b/packages/primitives/src/svg/index.js
@@ -105,3 +105,4 @@ export const SVG = forwardRef(
 		return <svg { ...appliedProps } ref={ ref } />;
 	}
 );
+SVG.displayName = 'SVG';

--- a/packages/primitives/src/svg/index.js
+++ b/packages/primitives/src/svg/index.js
@@ -6,7 +6,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { createElement } from '@wordpress/element';
+import { createElement, forwardRef } from '@wordpress/element';
 
 /** @typedef {{isPressed?: boolean} & import('react').ComponentPropsWithoutRef<'svg'>} SVGProps */
 
@@ -82,23 +82,26 @@ export const LinearGradient = ( props ) =>
  */
 export const Stop = ( props ) => createElement( 'stop', props );
 
-/**
- *
- * @param {SVGProps} props isPressed indicates whether the SVG should appear as pressed.
- *                         Other props will be passed through to svg component.
- *
- * @return {JSX.Element} Stop component
- */
-export const SVG = ( { className, isPressed, ...props } ) => {
-	const appliedProps = {
-		...props,
-		className:
-			classnames( className, { 'is-pressed': isPressed } ) || undefined,
-		'aria-hidden': true,
-		focusable: false,
-	};
+export const SVG = forwardRef(
+	/**
+	 * @param {SVGProps}                           props isPressed indicates whether the SVG should appear as pressed.
+	 *                                                   Other props will be passed through to svg component.
+	 * @param {import('react').Ref<SVGSVGElement>} ref   The forwarded ref to the SVG element.
+	 *
+	 * @return {JSX.Element} Stop component
+	 */
+	( { className, isPressed, ...props }, ref ) => {
+		const appliedProps = {
+			...props,
+			className:
+				classnames( className, { 'is-pressed': isPressed } ) ||
+				undefined,
+			'aria-hidden': true,
+			focusable: false,
+		};
 
-	// Disable reason: We need to have a way to render HTML tag for web.
-	// eslint-disable-next-line react/forbid-elements
-	return <svg { ...appliedProps } />;
-};
+		// Disable reason: We need to have a way to render HTML tag for web.
+		// eslint-disable-next-line react/forbid-elements
+		return <svg { ...appliedProps } ref={ ref } />;
+	}
+);

--- a/packages/primitives/src/svg/index.js
+++ b/packages/primitives/src/svg/index.js
@@ -84,9 +84,9 @@ export const Stop = ( props ) => createElement( 'stop', props );
 
 export const SVG = forwardRef(
 	/**
-	 * @param {SVGProps}                           props isPressed indicates whether the SVG should appear as pressed.
-	 *                                                   Other props will be passed through to svg component.
-	 * @param {import('react').Ref<SVGSVGElement>} ref   The forwarded ref to the SVG element.
+	 * @param {SVGProps}                                    props isPressed indicates whether the SVG should appear as pressed.
+	 *                                                            Other props will be passed through to svg component.
+	 * @param {import('react').ForwardedRef<SVGSVGElement>} ref   The forwarded ref to the SVG element.
 	 *
 	 * @return {JSX.Element} Stop component
 	 */


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
A bug introduced in https://github.com/WordPress/gutenberg/pull/54450. This PR fixes the warning as originally reported in https://github.com/WordPress/gutenberg/pull/53835#issuecomment-1720669088.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Even though it's only a warning, it prevents the ref from being passed to the underlying DOM element, which might cause some unexpected behaviors.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
`<TooltipAnchor>` implicitly requires the rendered child to be wrapped by `forwardRef` so that it can pass its own refs down to the element. This is briefly mentioned [here] in the docs.

This PR adds `forwardRef` to both the `<Icon>` and the `<SVG>` component.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Go to `http://localhost:8888/wp-admin/site-editor.php?path=%2Fpatterns&categoryType=pattern&categoryId=all-patterns`
2. Ensure that the console doesn't have warnings regarding missing `forwardRef` when there are tooltips on the page.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
Same as above, it's a technical change that doesn't affect the UI.

## Screenshots or screencast <!-- if applicable -->
N/A
