### PR TITLE
Update the default JSX pragma to React instead of @wordpress/element

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55891,10 +55891,10 @@
 				"@babel/runtime": "^7.16.0",
 				"@wordpress/babel-plugin-import-jsx-pragma": "file:../babel-plugin-import-jsx-pragma",
 				"@wordpress/browserslist-config": "file:../browserslist-config",
-				"@wordpress/element": "file:../element",
 				"@wordpress/warning": "file:../warning",
 				"browserslist": "^4.21.10",
-				"core-js": "^3.31.0"
+				"core-js": "^3.31.0",
+				"react": "^18.2.0"
 			},
 			"engines": {
 				"node": ">=14"
@@ -69255,10 +69255,10 @@
 				"@babel/runtime": "^7.16.0",
 				"@wordpress/babel-plugin-import-jsx-pragma": "file:../babel-plugin-import-jsx-pragma",
 				"@wordpress/browserslist-config": "file:../browserslist-config",
-				"@wordpress/element": "file:../element",
 				"@wordpress/warning": "file:../warning",
 				"browserslist": "^4.21.10",
-				"core-js": "^3.31.0"
+				"core-js": "^3.31.0",
+				"react": "^18.2.0"
 			}
 		},
 		"@wordpress/base-styles": {

--- a/packages/babel-plugin-import-jsx-pragma/README.md
+++ b/packages/babel-plugin-import-jsx-pragma/README.md
@@ -38,7 +38,7 @@ _Note:_ `@wordpress/babel-plugin-import-jsx-pragma` is included in `@wordpress/b
 
 As the `@babel/plugin-transform-react-jsx` plugin offers options to customize the `pragma` to which the transform references, there are equivalent options to assign for customizing the imports generated.
 
-For example, if you are using the `React` package, you may want to use the following configuration:
+For example, if you are using the `react` package, you may want to use the following configuration:
 
 ```js
 // .babelrc.js

--- a/packages/babel-plugin-import-jsx-pragma/README.md
+++ b/packages/babel-plugin-import-jsx-pragma/README.md
@@ -38,7 +38,7 @@ _Note:_ `@wordpress/babel-plugin-import-jsx-pragma` is included in `@wordpress/b
 
 As the `@babel/plugin-transform-react-jsx` plugin offers options to customize the `pragma` to which the transform references, there are equivalent options to assign for customizing the imports generated.
 
-For example, if you are using the `@wordpress/element` package, you may want to use the following configuration:
+For example, if you are using the `React` package, you may want to use the following configuration:
 
 ```js
 // .babelrc.js
@@ -49,7 +49,7 @@ module.exports = {
 			{
 				scopeVariable: 'createElement',
 				scopeVariableFrag: 'Fragment',
-				source: '@wordpress/element',
+				source: 'react',
 				isDefault: false,
 			},
 		],

--- a/packages/babel-preset-default/CHANGELOG.md
+++ b/packages/babel-preset-default/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ## Enhancements
 
--   Use `React` as the default scope variable for JSX pragma instead of `@wordpress/element`.
+-   Use `react` as the default scope variable for JSX pragma instead of `@wordpress/element`.
 
 ## 7.26.0 (2023-09-20)
 

--- a/packages/babel-preset-default/CHANGELOG.md
+++ b/packages/babel-preset-default/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 -   The bundled `browserslist` dependency has been updated from requiring `^4.21.9` to requiring `^4.21.10` ([#54657](https://github.com/WordPress/gutenberg/pull/54657)).
 
+## Enhancements
+
+-   Use `React` as the default scope variable for JSX pragma instead of `@wordpress/element`.
+
 ## 7.26.0 (2023-09-20)
 
 ## 7.25.0 (2023-08-31)

--- a/packages/babel-preset-default/index.js
+++ b/packages/babel-preset-default/index.js
@@ -80,7 +80,7 @@ module.exports = ( api ) => {
 				{
 					scopeVariable: 'createElement',
 					scopeVariableFrag: 'Fragment',
-					source: '@wordpress/element',
+					source: 'react',
 					isDefault: false,
 				},
 			],

--- a/packages/babel-preset-default/package.json
+++ b/packages/babel-preset-default/package.json
@@ -37,10 +37,10 @@
 		"@babel/runtime": "^7.16.0",
 		"@wordpress/babel-plugin-import-jsx-pragma": "file:../babel-plugin-import-jsx-pragma",
 		"@wordpress/browserslist-config": "file:../browserslist-config",
-		"@wordpress/element": "file:../element",
 		"@wordpress/warning": "file:../warning",
 		"browserslist": "^4.21.10",
-		"core-js": "^3.31.0"
+		"core-js": "^3.31.0",
+		"react": "^18.2.0"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/react-native-editor/babel.config.js
+++ b/packages/react-native-editor/babel.config.js
@@ -41,7 +41,7 @@ module.exports = function ( api ) {
 					/node_modules\/(react-native|@react-native-community|@react-navigation|react-native-reanimated)/,
 			},
 			{
-				// Auto-add `import { createElement } from 'React';` when JSX is found.
+				// Auto-add `import { createElement } from 'react';` when JSX is found.
 				plugins: [
 					[
 						'@wordpress/babel-plugin-import-jsx-pragma',

--- a/packages/react-native-editor/babel.config.js
+++ b/packages/react-native-editor/babel.config.js
@@ -41,14 +41,14 @@ module.exports = function ( api ) {
 					/node_modules\/(react-native|@react-native-community|@react-navigation|react-native-reanimated)/,
 			},
 			{
-				// Auto-add `import { createElement } from '@wordpress/element';` when JSX is found.
+				// Auto-add `import { createElement } from 'React';` when JSX is found.
 				plugins: [
 					[
 						'@wordpress/babel-plugin-import-jsx-pragma',
 						{
 							scopeVariable: 'createElement',
 							scopeVariableFrag: 'Fragment',
-							source: '@wordpress/element',
+							source: 'react',
 							isDefault: false,
 						},
 					],


### PR DESCRIPTION
See #54074 for the reasoning/discussions

This PR implements the change proposed in #54074 to switch the default JSX pragma from @wordpress/element to React. In addition to the current changes, we may want to update our documentation and the files where we currently import `@wordpress/element` and might not need to. I decided to not update these in the same PR to ensure/clarify that with this change, everything continues to work exactly the same without any change to the code base. Also updating documentation and code will quickly result in conflicts unless we merge those PRs quickly, so I'm leaving them separate until the decision is made to merge the current PR.
