### PR TITLE
Remove empty attrs.

### DIFF
--- a/packages/block-serialization-default-parser/class-wp-block-parser.php
+++ b/packages/block-serialization-default-parser/class-wp-block-parser.php
@@ -61,10 +61,10 @@ class WP_Block_Parser {
 	 * @return array[]
 	 */
 	public function parse( $document ) {
-		$this->document    = $document;
-		$this->offset      = 0;
-		$this->output      = array();
-		$this->stack       = array();
+		$this->document = $document;
+		$this->offset   = 0;
+		$this->output   = array();
+		$this->stack    = array();
 
 		while ( $this->proceed() ) {
 			continue;

--- a/packages/block-serialization-default-parser/class-wp-block-parser.php
+++ b/packages/block-serialization-default-parser/class-wp-block-parser.php
@@ -49,14 +49,6 @@ class WP_Block_Parser {
 	public $stack;
 
 	/**
-	 * Empty associative array, here due to PHP quirks
-	 *
-	 * @since 4.4.0
-	 * @var array empty associative array
-	 */
-	public $empty_attrs;
-
-	/**
 	 * Parses a document and returns a list of block structures
 	 *
 	 * When encountering an invalid parse will return a best-effort
@@ -73,7 +65,6 @@ class WP_Block_Parser {
 		$this->offset      = 0;
 		$this->output      = array();
 		$this->stack       = array();
-		$this->empty_attrs = array();
 
 		while ( $this->proceed() ) {
 			continue;
@@ -287,7 +278,7 @@ class WP_Block_Parser {
 		 */
 		$attrs = $has_attrs
 			? json_decode( $matches['attrs'][0], /* as-associative */ true )
-			: $this->empty_attrs;
+			: array();
 
 		/*
 		 * This state isn't allowed
@@ -318,7 +309,7 @@ class WP_Block_Parser {
 	 * @return WP_Block_Parser_Block freeform block object.
 	 */
 	public function freeform( $inner_html ) {
-		return new WP_Block_Parser_Block( null, $this->empty_attrs, array(), $inner_html, array( $inner_html ) );
+		return new WP_Block_Parser_Block( null, array(), array(), $inner_html, array( $inner_html ) );
 	}
 
 	/**


### PR DESCRIPTION
## What?

Following work in #54424, this replaces the `$empty_attrs` object, which used to have a role, with an empty array wherever it was previously used.

## Why?

The reason for having the property was that the block parser used to create a special object for empty attributes to disambiguate an empty object and an empty array in JSON. Because the block parser no longer creates this special object there's no more need to have an `$empty_attrs` property. It's not causing harm, but its continued presence might confuse people who are wondering what its purpose is.

## How?

Directly replaces the property lookup with in-place `array()` construction.

## Testing Instructions

A basic smoke test should verify failure because any problem in the block parser is likely to break a site in obvious ways. Ensure that the test suite passes.