### PR TITLE
Improve Notice component accessibility.

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Enhancements
 
+-   `Notice`: Improve accessibility by adding visually hidden text to clarify what a notice text is about and the notice type (success, error, warning, info) ([#54498](https://github.com/WordPress/gutenberg/pull/54498)).
 -   Making Circular Option Picker a `listbox`. Note that while this changes some public API, new props are optional, and currently have default values; this will change in another patch ([#52255](https://github.com/WordPress/gutenberg/pull/52255)).
 -   `ToggleGroupControl`: Rewrite backdrop animation using framer motion shared layout animations, add better support for controlled and uncontrolled modes ([#50278](https://github.com/WordPress/gutenberg/pull/50278)).
 -   `Popover`: Add the `is-positioned` CSS class only after the popover has finished animating ([#54178](https://github.com/WordPress/gutenberg/pull/54178)).
@@ -15,6 +16,7 @@
 
 ### Bug Fix
 
+-   `Notice`: Make the Close button render a tooltip to visually expose its accessible name. All icon buttons must always show a tooltip ([#54498](https://github.com/WordPress/gutenberg/pull/54498)).
 -   `Tooltip`: dynamically render in the DOM only when visible ([#54312](https://github.com/WordPress/gutenberg/pull/54312)).
 -   `PaletteEdit`: Fix padding in RTL languages ([#54034](https://github.com/WordPress/gutenberg/pull/54034)).
 -   `ToolbarItem`: Fix children not showing in rendered components ([#53314](https://github.com/WordPress/gutenberg/pull/53314)).

--- a/packages/components/src/higher-order/with-notices/test/index.tsx
+++ b/packages/components/src/higher-order/with-notices/test/index.tsx
@@ -27,7 +27,7 @@ import withNotices from '..';
 import type { WithNoticeProps } from '../types';
 
 // Implementation detail of Notice component used to query the dismissal button.
-const stockDismissText = 'Dismiss this notice';
+const stockDismissText = 'Close';
 
 function noticesFrom( list: string[] ) {
 	return list.map( ( item ) => ( { id: item, content: item } ) );

--- a/packages/components/src/notice/index.tsx
+++ b/packages/components/src/notice/index.tsx
@@ -16,7 +16,6 @@ import { close } from '@wordpress/icons';
  */
 import Button from '../button';
 import type { NoticeAction, NoticeProps } from './types';
-import type { SyntheticEvent } from 'react';
 import type { DeprecatedButtonProps } from '../button/types';
 import { VisuallyHidden } from '../visually-hidden';
 
@@ -108,8 +107,7 @@ function Notice( {
 		children = <RawHTML>{ children }</RawHTML>;
 	}
 
-	const onDismissNotice = ( event: SyntheticEvent ) => {
-		event?.preventDefault?.();
+	const onDismissNotice = () => {
 		onDismiss();
 		onRemove();
 	};

--- a/packages/components/src/notice/index.tsx
+++ b/packages/components/src/notice/index.tsx
@@ -59,7 +59,6 @@ function getStatusLabel( status: NoticeProps[ 'status' ] ) {
 			return __( 'Warning notice' );
 		case 'info':
 			return __( 'Information notice' );
-
 		case 'error':
 			return __( 'Error notice' );
 		case 'success':

--- a/packages/components/src/notice/index.tsx
+++ b/packages/components/src/notice/index.tsx
@@ -45,8 +45,7 @@ function getDefaultPoliteness( status: NoticeProps[ 'status' ] ) {
 		case 'warning':
 		case 'info':
 			return 'polite';
-
-		case 'error':
+		// The default will also catch the 'error' status.
 		default:
 			return 'assertive';
 	}
@@ -60,7 +59,7 @@ function getStatusLabel( status: NoticeProps[ 'status' ] ) {
 			return __( 'Information notice' );
 		case 'error':
 			return __( 'Error notice' );
-		case 'success':
+		// The default will also catch the 'success' status.
 		default:
 			return __( 'Notice' );
 	}

--- a/packages/components/src/notice/index.tsx
+++ b/packages/components/src/notice/index.tsx
@@ -18,6 +18,7 @@ import Button from '../button';
 import type { NoticeAction, NoticeProps } from './types';
 import type { SyntheticEvent } from 'react';
 import type { DeprecatedButtonProps } from '../button/types';
+import { VisuallyHidden } from '../visually-hidden';
 
 const noop = () => {};
 
@@ -49,6 +50,21 @@ function getDefaultPoliteness( status: NoticeProps[ 'status' ] ) {
 		case 'error':
 		default:
 			return 'assertive';
+	}
+}
+
+function getStatusLabel( status: NoticeProps[ 'status' ] ) {
+	switch ( status ) {
+		case 'warning':
+			return __( 'Warning notice' );
+		case 'info':
+			return __( 'Information notice' );
+
+		case 'error':
+			return __( 'Error notice' );
+		case 'success':
+		default:
+			return __( 'Notice' );
 	}
 }
 
@@ -101,6 +117,7 @@ function Notice( {
 
 	return (
 		<div className={ classes }>
+			<VisuallyHidden>{ getStatusLabel( status ) }</VisuallyHidden>
 			<div className="components-notice__content">
 				{ children }
 				<div className="components-notice__actions">
@@ -154,9 +171,8 @@ function Notice( {
 				<Button
 					className="components-notice__dismiss"
 					icon={ close }
-					label={ __( 'Dismiss this notice' ) }
+					label={ __( 'Close' ) }
 					onClick={ onDismissNotice }
-					showTooltip={ false }
 				/>
 			) }
 		</div>

--- a/packages/components/src/notice/test/__snapshots__/index.tsx.snap
+++ b/packages/components/src/notice/test/__snapshots__/index.tsx.snap
@@ -6,6 +6,14 @@ exports[`Notice should match snapshot 1`] = `
     class="components-notice is-success is-dismissible"
   >
     <div
+      class="components-visually-hidden emotion-0 emotion-1"
+      data-wp-c16t="true"
+      data-wp-component="VisuallyHidden"
+      style="border: 0px; clip: rect(1px, 1px, 1px, 1px); clip-path: inset( 50% ); height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; word-wrap: normal;"
+    >
+      Notice
+    </div>
+    <div
       class="components-notice__content"
     >
       Example
@@ -33,7 +41,7 @@ exports[`Notice should match snapshot 1`] = `
       </div>
     </div>
     <button
-      aria-label="Dismiss this notice"
+      aria-label="Close"
       class="components-button components-notice__dismiss has-icon"
       type="button"
     >

--- a/packages/edit-site/src/components/sidebar-navigation-screen/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-screen/style.scss
@@ -109,10 +109,15 @@
 	&.is-dismissible {
 		padding-right: $grid-unit-10;
 	}
+
+	.components-notice__dismiss:not(:disabled):not([aria-disabled="true"]) {
+		color: $gray-400;
+	}
+
 	.components-notice__dismiss:not(:disabled):not([aria-disabled="true"]):focus,
 	.components-notice__dismiss:not(:disabled):not([aria-disabled="true"]):not(.is-secondary):active,
 	.components-notice__dismiss:not(:disabled):not([aria-disabled="true"]):not(.is-secondary):hover {
-		color: $gray-100;
+		color: $white;
 	}
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

Fixes https://github.com/WordPress/gutenberg/issues/54497

First pass at improving / fixing the Notice component accessibility. Please do not merge yet, needs design feedback.

## What?
<!-- In a few words, what is the PR actually doing? -->
Imrpoves / fixes the Notice component accessibility.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
There is no parity between the information provided visually and the information provided semantically / with text. As such, some users experience is less than ideal.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Added visually hidden text to inform non-visual users this is a notice and about its type. About this point, the ideal solution would be to use visible text. Needs design feedback.
- Depending on the notice type, the added text is:
  - Notice (for success notices and default)
  - Warning notice
  - Error notic
  - Information notice
- Changed the x close button aria-label from `Information notice` to `Close` so that accessible name matches more closely the concept provided by the X icon.
- Removed `showTooltip={ false }` so that the button renders its tooltip. Again worth reminding all icon buttons **must visually expose their accessible name**,

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Use a clean database or make sure the preference isTemplatePartMoveHintVisible in the database wp_usermeta > wp_persisted_preferences is set to 1.
- Go to the side editor
- In the navigation panel observe the `Looking for template parts? Find them in "Patterns". notice is rendered`.
- Inspect the source and observe the notice contains a visually hidden text `Information notice`.
- Hover or focus the X close button and observe a tooltip with text `Close` is rendered.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
