### PR TITLE
Prevent layout changes from saving the whole inherited settings object

### DIFF
--- a/packages/edit-site/src/components/global-styles/dimensions-panel.js
+++ b/packages/edit-site/src/components/global-styles/dimensions-panel.js
@@ -33,6 +33,7 @@ export default function DimensionsPanel() {
 	const [ inheritedStyle, setStyle ] = useGlobalStyle( '', undefined, 'all', {
 		shouldDecodeEncode: false,
 	} );
+	const [ userSettings ] = useGlobalSetting( '', undefined, 'user' );
 	const [ rawSettings, setSettings ] = useGlobalSetting( '' );
 	const settings = useSettingsForBlockElement( rawSettings );
 
@@ -48,9 +49,9 @@ export default function DimensionsPanel() {
 	const styleWithLayout = useMemo( () => {
 		return {
 			...style,
-			layout: settings.layout,
+			layout: userSettings.layout,
 		};
-	}, [ style, settings.layout ] );
+	}, [ style, userSettings.layout ] );
 
 	const onChange = ( newStyle ) => {
 		const updatedStyle = { ...newStyle };
@@ -58,7 +59,10 @@ export default function DimensionsPanel() {
 		setStyle( updatedStyle );
 
 		if ( newStyle.layout !== settings.layout ) {
-			const updatedSettings = { ...rawSettings, layout: newStyle.layout };
+			const updatedSettings = {
+				...userSettings,
+				layout: newStyle.layout,
+			};
 
 			// Ensure any changes to layout definitions are not persisted.
 			if ( updatedSettings.layout?.definitions ) {

--- a/packages/edit-site/src/components/global-styles/dimensions-panel.js
+++ b/packages/edit-site/src/components/global-styles/dimensions-panel.js
@@ -58,7 +58,7 @@ export default function DimensionsPanel() {
 		delete updatedStyle.layout;
 		setStyle( updatedStyle );
 
-		if ( newStyle.layout !== settings.layout ) {
+		if ( newStyle.layout !== userSettings.layout ) {
 			const updatedSettings = {
 				...userSettings,
 				layout: newStyle.layout,

--- a/packages/edit-site/src/components/global-styles/screen-block.js
+++ b/packages/edit-site/src/components/global-styles/screen-block.js
@@ -93,7 +93,6 @@ function ScreenBlock( { name, variation } ) {
 	} );
 	const [ userSettings ] = useGlobalSetting( '', name, 'user' );
 	const [ rawSettings, setSettings ] = useGlobalSetting( '', name );
-	const [ userSettings ] = useGlobalSetting( '', name, 'user' );
 	const settings = useSettingsForBlockElement( rawSettings, name );
 	const blockType = getBlockType( name );
 

--- a/packages/edit-site/src/components/global-styles/screen-block.js
+++ b/packages/edit-site/src/components/global-styles/screen-block.js
@@ -91,6 +91,7 @@ function ScreenBlock( { name, variation } ) {
 	const [ inheritedStyle, setStyle ] = useGlobalStyle( prefix, name, 'all', {
 		shouldDecodeEncode: false,
 	} );
+	const [ userSettings ] = useGlobalSetting( '', name, 'user' );
 	const [ rawSettings, setSettings ] = useGlobalSetting( '', name );
 	const [ userSettings ] = useGlobalSetting( '', name, 'user' );
 	const settings = useSettingsForBlockElement( rawSettings, name );
@@ -151,9 +152,9 @@ function ScreenBlock( { name, variation } ) {
 	const styleWithLayout = useMemo( () => {
 		return {
 			...style,
-			layout: settings.layout,
+			layout: userSettings.layout,
 		};
-	}, [ style, settings.layout ] );
+	}, [ style, userSettings.layout ] );
 	const onChangeDimensions = ( newStyle ) => {
 		const updatedStyle = { ...newStyle };
 		delete updatedStyle.layout;
@@ -161,7 +162,7 @@ function ScreenBlock( { name, variation } ) {
 
 		if ( newStyle.layout !== settings.layout ) {
 			setSettings( {
-				...rawSettings,
+				...userSettings,
 				layout: newStyle.layout,
 			} );
 		}

--- a/packages/edit-site/src/components/global-styles/screen-block.js
+++ b/packages/edit-site/src/components/global-styles/screen-block.js
@@ -160,7 +160,7 @@ function ScreenBlock( { name, variation } ) {
 		delete updatedStyle.layout;
 		setStyle( updatedStyle );
 
-		if ( newStyle.layout !== settings.layout ) {
+		if ( newStyle.layout !== userSettings.layout ) {
 			setSettings( {
 				...userSettings,
 				layout: newStyle.layout,


### PR DESCRIPTION
Fixes #53868

## What?

When editing the layout config (contentSize for instance) in global styles, only this change need to be persisted in the backend, if you inspect the REST API request, you'll notice that the full settings object including all the settings that were inherited from the default core settings were being saved as "edits". This PR fixes that.

## Testing Instructions

1- Edit the layout settings in global styles, trigger a "save" for global styles and ensure that the settings object sent to the server (REST API request) only contains the modified settings (layout).

