### PR TITLE
Query Loop: Update modal role and focus first element

### DIFF
--- a/packages/block-library/src/query/edit/enhanced-pagination-modal.js
+++ b/packages/block-library/src/query/edit/enhanced-pagination-modal.js
@@ -42,6 +42,8 @@ export default function EnhancedPaginationModal( {
 				aria={ {
 					describedby: modalDescriptionId,
 				} }
+				role="alertdialog"
+				focusOnMount="firstElement"
 				isDismissible={ false }
 				shouldCloseOnEsc={ false }
 				shouldCloseOnClickOutside={ false }


### PR DESCRIPTION
## What?

Makes the "Enhanced pagination will be disabled" modal to be announced by screen readers, also focusing the "OK" button.

Suggested by @SantosGuillamot.

## Why?

To improve accesibility.

## How?

Adding the following properties to the`Modal` component.

```jsx
role="alertdialog"
focusOnMount="firstElement"
```

## Testing Instructions

1. On the Home Blog template, enable "Enhanced pagination" in the Query Loop.
2. Activate the screen reader.
3. Add any third-party block from the Block Directory inside the Query Loop.
4. The modal should be announced automatically.
5. The "OK" button should be focused automatically.
