### PR TITLE
Theme JSON schema: Fix "not allowed error" in settings property

### DIFF
--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -298,7 +298,6 @@
 		},
 		"settingsPropertiesLightbox": {
 			"type": "object",
-			"additionalProperties": false,
 			"properties": {
 				"lightbox": {
 					"description": "Settings related to the lightbox.",
@@ -312,7 +311,8 @@
 							"description": "Defines whether to show the Lightbox UI in the block editor. If set to `false`, the user won't be able to change the lightbox settings in the block editor.",
 							"type": "boolean"
 						}
-					}
+					},
+					"additionalProperties": false
 				}
 			}
 		},


### PR DESCRIPTION
Related to #54509

## What?

This PR fixes an issue in the theme.json schema that causes errors where all properties in the `settings` property are not allowed except `ligntbox`.

| Before | After |
|--------|--------|
| ![before](https://github.com/WordPress/gutenberg/assets/54422211/72b33a1d-945b-431f-9495-1fad6419f225) | ![after](https://github.com/WordPress/gutenberg/assets/54422211/a0046d23-c937-409b-8d27-1da3ac533b5a) |

## Why?
#54509 added a reference to the Lightbox schema (`settingsPropertiesLightbox`) to the `settings` property. `settingsPropertiesLightbox` defines `additionalProperties :true` at the root level of the object, so this applies to the `settings` property itself. As a result, properties other than the `lightbox` property are no longer allowed.

## How?
Moved `additionalProperties` inside the `lightbox` property. This will solve the problem with the `settings` property, and will also output errors for properties that are not allowed in the `lightbox` property. My guess is that this is expected behavior.

## Testing Instructions

Create a json file like the one below locally:

```json
{
	"$schema": "https://raw.githubusercontent.com/WordPress/gutenberg/schema/fix-settings-definition/schemas/json/theme.json",
	"version": 2,
	"settings": {
		"lightbox": {
		}
	}
}
```

- Confirm that no error occurs when you enter properties other than the `lightbox` property directly under `settings`.
- Confirm that an error occurs when you enter properties other than `allowEditing` and `enabled` in the `settings.lightbox` property.
