### PR TITLE
Patterns: Remove pattern category as a variation for post terms block

### DIFF
--- a/packages/block-library/src/post-terms/index.php
+++ b/packages/block-library/src/post-terms/index.php
@@ -80,7 +80,7 @@ function register_block_core_post_terms() {
 	foreach ( $taxonomies as $taxonomy ) {
 		// Skip the `wp_pattern_category` taxonomy as this should not be an
 		// available variation for the `core/post-terms` block.
-		if ('wp_pattern_category' === $taxonomy->name) {
+		if ( 'wp_pattern_category' === $taxonomy->name ) {
 			continue;
 		}
 		$variation = array(

--- a/packages/block-library/src/post-terms/index.php
+++ b/packages/block-library/src/post-terms/index.php
@@ -78,6 +78,11 @@ function register_block_core_post_terms() {
 
 	// Create and register the eligible taxonomies variations.
 	foreach ( $taxonomies as $taxonomy ) {
+		// Skip the `wp_pattern_category` taxonomy as this should not be an
+		// available variation for the `core/post-terms` block.
+		if ('wp_pattern_category' === $taxonomy->name) {
+			continue;
+		}
 		$variation = array(
 			'name'        => $taxonomy->name,
 			'title'       => $taxonomy->label,


### PR DESCRIPTION
## What?
Remove pattern category as a variation for post terms block.

## Why?
There is no use case for allowing this as a variation and it will likely just cause confusion.
Fixes: #54524

## How?
Returns early from the loop that adds variations if the taxonony name === `wp_pattern_category`

## Testing Instructions

- Create a new post or page.
- In the canvas, start typing /cat: Confirm that pattern categories do not show up as a shortcut.
- Insert a categories block.
- In the block sidebar, confirm that "Transform to variation" does not include pattern categories.


## Screenshots or screencast <!-- if applicable -->

Before:

<img width="296" alt="Screenshot 2023-09-18 at 1 45 51 PM" src="https://github.com/WordPress/gutenberg/assets/3629020/96acdd37-a226-46e8-84c0-d0fe8e3cf1aa">

After:

<img width="301" alt="Screenshot 2023-09-18 at 1 43 24 PM" src="https://github.com/WordPress/gutenberg/assets/3629020/0a3c248d-aee0-4d11-a27a-c985d829039a">


