### PR TITLE
Patterns: Apply white background to the preview as a fallback

### DIFF
--- a/packages/edit-site/src/components/page-patterns/grid-item.js
+++ b/packages/edit-site/src/components/page-patterns/grid-item.js
@@ -6,7 +6,10 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { BlockPreview } from '@wordpress/block-editor';
+import {
+	BlockPreview,
+	privateApis as blockEditorPrivateApis,
+} from '@wordpress/block-editor';
 import {
 	Button,
 	__experimentalConfirmDialog as ConfirmDialog,
@@ -41,12 +44,16 @@ import DuplicateMenuItem from './duplicate-menu-item';
 import { PATTERNS, TEMPLATE_PARTS, USER_PATTERNS, SYNC_TYPES } from './utils';
 import { store as editSiteStore } from '../../store';
 import { useLink } from '../routes/link';
+import { unlock } from '../../lock-unlock';
+
+const { useGlobalStyle } = unlock( blockEditorPrivateApis );
 
 const templatePartIcons = { header, footer, uncategorized };
 
 function GridItem( { categoryId, item, ...props } ) {
 	const descriptionId = useId();
 	const [ isDeleteDialogOpen, setIsDeleteDialogOpen ] = useState( false );
+	const [ backgroundColor ] = useGlobalStyle( 'color.background' );
 
 	const { removeTemplate } = useDispatch( editSiteStore );
 	const { __experimentalDeleteReusableBlock } =
@@ -135,6 +142,10 @@ function GridItem( { categoryId, item, ...props } ) {
 				item.title
 		  );
 
+	const additionalStyles = ! backgroundColor
+		? [ { css: 'body { background: #fff; }' } ]
+		: undefined;
+
 	return (
 		<li className={ patternClassNames }>
 			<button
@@ -159,7 +170,12 @@ function GridItem( { categoryId, item, ...props } ) {
 			>
 				{ isEmpty && isTemplatePart && __( 'Empty template part' ) }
 				{ isEmpty && ! isTemplatePart && __( 'Empty pattern' ) }
-				{ ! isEmpty && <BlockPreview blocks={ item.blocks } /> }
+				{ ! isEmpty && (
+					<BlockPreview
+						blocks={ item.blocks }
+						additionalStyles={ additionalStyles }
+					/>
+				) }
 			</button>
 			{ ariaDescriptions.map( ( ariaDescription, index ) => (
 				<div


### PR DESCRIPTION
Fixes #54533

## What?
This PR applies a white background to the pattern page preview when the currently activated theme does not have a background color.

| Before | After |
|--------|--------|
| ![before](https://github.com/WordPress/gutenberg/assets/54422211/2f9fa414-a60f-441f-a4ce-97ab205ffeb7) | ![after](https://github.com/WordPress/gutenberg/assets/54422211/3192f69c-a7aa-4598-b998-4908b9315b33)| 

## Why?

This is because if the currently active theme does not have a background color, it will be affected by the black canvas background behind the preview.

## How?

If the background color obtained via the `useGlobalStyle` hook is `undefined`, the default white color is passed to the BlockPreview component.

Before this approach, I also tried a simple CSS solution as follows.

```css
.edit-site-patterns__preview iframe {
	background-color: #fff;
}
```

However, this is not a problem for themes that do not define a background color, but for themes that do have a background color, the following flickering occurs:

<details><summary>Screencast</summary>

https://github.com/WordPress/gutenberg/assets/54422211/260a982f-1f81-4c72-a218-88a643d4d2fb

</details> 

## Testing Instructions

- Enable Emptytheme.
- On the Patterns page, select the General category.
- Make sure the background of the `header` template is white.
- Enable TwentyTwentyThree and switch to a theme style with a non-white background.
- On the Patterns page, make sure the pattern preview has the theme's background.
