### PR TITLE
Font Library: Fix notification error for actions related to custom fonts

### DIFF
--- a/packages/edit-site/src/components/global-styles/font-library-modal/context.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/context.js
@@ -253,7 +253,7 @@ function FontLibraryProvider( { children } ) {
 	const deactivateFontFamily = ( font ) => {
 		// If the user doesn't have custom fonts defined, include as custom fonts all the theme fonts
 		// We want to save as active all the theme fonts at the beginning
-		const initialCustomFonts = fontFamilies[ font.source ] || [];
+		const initialCustomFonts = fontFamilies?.[ font.source ] ?? [];
 		const newCustomFonts = initialCustomFonts.filter(
 			( f ) => f.slug !== font.slug
 		);
@@ -266,7 +266,7 @@ function FontLibraryProvider( { children } ) {
 	const activateCustomFontFamilies = ( fontsToAdd ) => {
 		// Merge the existing custom fonts with the new fonts.
 		const newCustomFonts = mergeFontFamilies(
-			fontFamilies.custom,
+			fontFamilies?.custom,
 			fontsToAdd
 		);
 		// Activate the fonts by set the new custom fonts array.
@@ -290,7 +290,7 @@ function FontLibraryProvider( { children } ) {
 	const toggleActivateFont = ( font, face ) => {
 		// If the user doesn't have custom fonts defined, include as custom fonts all the theme fonts
 		// We want to save as active all the theme fonts at the beginning
-		const initialFonts = fontFamilies[ font.source ] || [];
+		const initialFonts = fontFamilies?.[ font.source ] ?? [];
 		// Toggles the received font family or font face
 		const newFonts = toggleFont( font, face, initialFonts );
 		// Updates the font families activated in global settings:


### PR DESCRIPTION
Fixes: #54529

## What?

This PR fixes errors that occur when uploading, enabling/disabling, and deleting custom fonts in Font Manager.

## Why?

The `fontFamilies` variable with fonts obtained via the `useGlobalSetting` hook can be undefined, for example, if the current theme does not define font families in theme.json.

So we need to handle whether the expected properties are accessible or not.

## How?

Use the optional chaining and the nullish coalescing operator to avoid the error.

## Testing Instructions

1. Activate Emptytheme.
2. Open the Font Manager.
3. Try to upload local fonts.
   - trunk: `Error installing fonts.` should appear behind the modal and the browser console should log the error. Also, internally the font should have been uploaded, but you don't see the font in the library.
   - This PR: There should be no error and the uploaded font should be added to the library.
4. Reopen Font Manager.
5. Try to activate/deactivate the font variations you have uploaded.
   - trunk: Unable to change check state, the browser console should log an error.
   - This PR: Should be able to change the check state.
6. Click the Delete button.
   - trunk: `Error uninstalling fonts.` should appear behind the modal and the browser console should log the error.
   - This PR: There should be no error and the font should be removed from the library.