### PR TITLE
Upgrade wp-prettier to v3.0.3

### DIFF
--- a/bin/packages/check-build-type-declaration-files.js
+++ b/bin/packages/check-build-type-declaration-files.js
@@ -83,7 +83,7 @@ async function checkUnverifiedDeclarationFiles() {
 	const packageDir = path.resolve( 'packages' );
 	const packageDirs = (
 		await fs.readdir( packageDir, { withFileTypes: true } )
-	 )
+	)
 		.filter( ( dirent ) => dirent.isDirectory() )
 		.map( ( dirent ) => path.join( packageDir, dirent.name ) );
 
@@ -97,7 +97,7 @@ async function checkUnverifiedDeclarationFiles() {
 					: null
 			)
 		)
-	 ).filter( Boolean );
+	).filter( Boolean );
 
 	const tscResults = await Promise.allSettled(
 		declarations.map( typecheckDeclarations )

--- a/bin/plugin/commands/packages.js
+++ b/bin/plugin/commands/packages.js
@@ -198,10 +198,9 @@ async function updatePackages( config ) {
 	);
 	const changelogFilesPublicPackages = changelogFiles.filter(
 		( changelogPath ) => {
-			const pkg = require( path.join(
-				path.dirname( changelogPath ),
-				'package.json'
-			) );
+			const pkg = require(
+				path.join( path.dirname( changelogPath ), 'package.json' )
+			);
 			return pkg.private !== true;
 		}
 	);

--- a/docs/contributors/code/coding-guidelines.md
+++ b/docs/contributors/code/coding-guidelines.md
@@ -207,24 +207,25 @@ You can attach private selectors and actions to a public store:
 
 ```js
 // In packages/package1/store.js:
-import { privateHasContentRoleAttribute, ...selectors } from './selectors';
-import { privateToggleFeature, ...actions } from './selectors';
+import { privateHasContentRoleAttribute } from './private-selectors';
+import { privateToggleFeature } from './private-actions';
 // The `lock` function is exported from the internal private-apis.js file where
 // the opt-in function was called.
 import { lock, unlock } from './lock-unlock';
 
-export const store = registerStore(/* ... */);
+export const store = registerStore( /* ... */ );
 // Attach a private action to the exported store:
-unlock( store ).registerPrivateActions({
-	privateToggleFeature
+unlock( store ).registerPrivateActions( {
+	privateToggleFeature,
 } );
 
 // Attach a private action to the exported store:
-unlock( store ).registerPrivateSelectors({
-	privateHasContentRoleAttribute
+unlock( store ).registerPrivateSelectors( {
+	privateHasContentRoleAttribute,
 } );
+```
 
-
+```js
 // In packages/package2/MyComponent.js:
 import { store } from '@wordpress/package1';
 import { useSelect } from '@wordpress/data';
@@ -233,17 +234,18 @@ import { useSelect } from '@wordpress/data';
 import { unlock } from './lock-unlock';
 
 function MyComponent() {
-    const hasRole = useSelect( ( select ) => (
-		// Use the private selector:
-        unlock( select( store ) ).privateHasContentRoleAttribute()
+	const hasRole = useSelect(
+		( select ) =>
+			// Use the private selector:
+			unlock( select( store ) ).privateHasContentRoleAttribute()
 		// Note the unlock() is required. This line wouldn't work:
-        // select( store ).privateHasContentRoleAttribute()
-    ) );
+		// select( store ).privateHasContentRoleAttribute()
+	);
 
 	// Use the private action:
 	unlock( useDispatch( store ) ).privateToggleFeature();
 
-    // ...
+	// ...
 }
 ```
 
@@ -263,7 +265,9 @@ lock( privateApis, {
 	privateClass: class PrivateClass {},
 	privateVariable: 5,
 } );
+```
 
+```js
 // In packages/package2/index.js:
 import { privateApis } from '@wordpress/package1';
 import { unlock } from './lock-unlock';
@@ -336,7 +340,9 @@ export function validateBlocks( blocks ) {
 
 export const privateApis = {};
 lock( privateApis, { privateValidateBlocks } );
+```
 
+```js
 // In @wordpress/package2/index.js:
 import { privateApis as package1PrivateApis } from '@wordpress/package1';
 import { unlock } from './lock-unlock';
@@ -363,30 +369,30 @@ const PrivateMyButton = ( { title, privateShowIcon = true } ) => {
 
 	return (
 		<button>
-			{ privateShowIcon  && <Icon src={some icon} /> } { title }
+			{ privateShowIcon && <Icon src={ someIcon } /> } { title }
 		</button>
 	);
-}
+};
 
 // The stable public component is a thin wrapper that calls the
 // private component with the private features disabled
-export const MyButton = ( { title } ) =>
-    <PrivateMyButton title={ title } privateShowIcon={ false } />
+export const MyButton = ( { title } ) => (
+	<PrivateMyButton title={ title } privateShowIcon={ false } />
+);
 
 export const privateApis = {};
 lock( privateApis, { PrivateMyButton } );
+```
 
-
+```js
 // In @wordpress/package2/index.js:
 import { privateApis } from '@wordpress/package1';
 import { unlock } from './lock-unlock';
 
 // The private component may be "unlocked" given the stable component:
-const { PrivateMyButton } = unlock(privateApis);
+const { PrivateMyButton } = unlock( privateApis );
 export function MyComponent() {
-	return (
-		<PrivateMyButton data={data} privateShowIcon={ true } />
-	)
+	return <PrivateMyButton data={ data } privateShowIcon={ true } />;
 }
 ```
 
@@ -438,13 +444,14 @@ function privateInCorePublicInPlugin() {}
 
 // Gutenberg treats both functions as private APIs internally:
 const privateApis = {};
-lock(privateApis, { privateEverywhere, privateInCorePublicInPlugin });
+lock( privateApis, { privateEverywhere, privateInCorePublicInPlugin } );
 
 // The privateInCorePublicInPlugin function is explicitly exported,
 // but this export will not be merged into WordPress core thanks to
 // the process.env.IS_GUTENBERG_PLUGIN check.
 if ( process.env.IS_GUTENBERG_PLUGIN ) {
-   export const privateInCorePublicInPlugin = unlock( privateApis ).privateInCorePublicInPlugin;
+	export const privateInCorePublicInPlugin =
+		unlock( privateApis ).privateInCorePublicInPlugin;
 }
 ```
 
@@ -459,7 +466,7 @@ const a = 10;
 // Bad:
 const object = {
 	a: a,
-	performAction: function() {
+	performAction: function () {
 		// ...
 	},
 };
@@ -771,7 +778,7 @@ Documenting a function component should be treated the same as any other functio
  *
  * @return {?string} Block title.
  */
-```
+````
 
 For class components, there is no recommendation for documenting the props of the component. Gutenberg does not use or endorse the [`propTypes` static class member](https://react.dev/reference/react/Component#static-proptypes).
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -183,6 +183,7 @@
 				"eslint-plugin-import": "2.25.2",
 				"eslint-plugin-jest": "27.2.3",
 				"eslint-plugin-jest-dom": "5.0.2",
+				"eslint-plugin-prettier": "5.0.0",
 				"eslint-plugin-ssr-friendly": "1.0.6",
 				"eslint-plugin-storybook": "0.6.13",
 				"eslint-plugin-testing-library": "5.7.2",
@@ -5649,6 +5650,155 @@
 			"optional": true,
 			"engines": {
 				"node": ">=14"
+			}
+		},
+		"node_modules/@pkgr/utils": {
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/@pkgr/utils/-/utils-2.4.2.tgz",
+			"integrity": "sha512-POgTXhjrTfbTV63DiFXav4lBHiICLKKwDeaKn9Nphwj7WH6m0hMMCaJkMyRWjgtPFyRKRVoMXXjczsTQRDEhYw==",
+			"dev": true,
+			"dependencies": {
+				"cross-spawn": "^7.0.3",
+				"fast-glob": "^3.3.0",
+				"is-glob": "^4.0.3",
+				"open": "^9.1.0",
+				"picocolors": "^1.0.0",
+				"tslib": "^2.6.0"
+			},
+			"engines": {
+				"node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/unts"
+			}
+		},
+		"node_modules/@pkgr/utils/node_modules/cross-spawn": {
+			"version": "7.0.3",
+			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+			"integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+			"dev": true,
+			"dependencies": {
+				"path-key": "^3.1.0",
+				"shebang-command": "^2.0.0",
+				"which": "^2.0.1"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/@pkgr/utils/node_modules/define-lazy-prop": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+			"integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+			"dev": true,
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@pkgr/utils/node_modules/fast-glob": {
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.1.tgz",
+			"integrity": "sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==",
+			"dev": true,
+			"dependencies": {
+				"@nodelib/fs.stat": "^2.0.2",
+				"@nodelib/fs.walk": "^1.2.3",
+				"glob-parent": "^5.1.2",
+				"merge2": "^1.3.0",
+				"micromatch": "^4.0.4"
+			},
+			"engines": {
+				"node": ">=8.6.0"
+			}
+		},
+		"node_modules/@pkgr/utils/node_modules/glob-parent": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+			"integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+			"dev": true,
+			"dependencies": {
+				"is-glob": "^4.0.1"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
+		},
+		"node_modules/@pkgr/utils/node_modules/is-wsl": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+			"integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+			"dev": true,
+			"dependencies": {
+				"is-docker": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@pkgr/utils/node_modules/open": {
+			"version": "9.1.0",
+			"resolved": "https://registry.npmjs.org/open/-/open-9.1.0.tgz",
+			"integrity": "sha512-OS+QTnw1/4vrf+9hh1jc1jnYjzSG4ttTBB8UxOwAnInG3Uo4ssetzC1ihqaIHjLJnA5GGlRl6QlZXOTQhRBUvg==",
+			"dev": true,
+			"dependencies": {
+				"default-browser": "^4.0.0",
+				"define-lazy-prop": "^3.0.0",
+				"is-inside-container": "^1.0.0",
+				"is-wsl": "^2.2.0"
+			},
+			"engines": {
+				"node": ">=14.16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@pkgr/utils/node_modules/path-key": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+			"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@pkgr/utils/node_modules/shebang-command": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+			"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+			"dev": true,
+			"dependencies": {
+				"shebang-regex": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@pkgr/utils/node_modules/shebang-regex": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+			"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@pkgr/utils/node_modules/which": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+			"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+			"dev": true,
+			"dependencies": {
+				"isexe": "^2.0.0"
+			},
+			"bin": {
+				"node-which": "bin/node-which"
+			},
+			"engines": {
+				"node": ">= 8"
 			}
 		},
 		"node_modules/@playwright/test": {
@@ -24270,6 +24420,21 @@
 			"integrity": "sha512-uYBjakWipfaO/bXI7E8rq6kpwHRZK5cNYrUv2OzZSI/FvmdMyXJ2tG9dKcjEC5YHmHpUAwsargWIZNWdxb/bnQ==",
 			"dev": true
 		},
+		"node_modules/bundle-name": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-3.0.0.tgz",
+			"integrity": "sha512-PKA4BeSvBpQKQ8iPOGCSiell+N8P+Tf1DlwqmYhpe2gAhKPHn8EYOxVT+ShuGmhg8lN8XiSlS80yiExKXrURlw==",
+			"dev": true,
+			"dependencies": {
+				"run-applescript": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/byte-size": {
 			"version": "8.1.1",
 			"resolved": "https://registry.npmjs.org/byte-size/-/byte-size-8.1.1.tgz",
@@ -27427,6 +27592,24 @@
 				}
 			}
 		},
+		"node_modules/default-browser": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/default-browser/-/default-browser-4.0.0.tgz",
+			"integrity": "sha512-wX5pXO1+BrhMkSbROFsyxUm0i/cJEScyNhA4PPxc41ICuv05ZZB/MX28s8aZx6xjmatvebIapF6hLEKEcpneUA==",
+			"dev": true,
+			"dependencies": {
+				"bundle-name": "^3.0.0",
+				"default-browser-id": "^3.0.0",
+				"execa": "^7.1.1",
+				"titleize": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=14.16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/default-browser-id": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-3.0.0.tgz",
@@ -27441,6 +27624,187 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/default-browser/node_modules/cross-spawn": {
+			"version": "7.0.3",
+			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+			"integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+			"dev": true,
+			"dependencies": {
+				"path-key": "^3.1.0",
+				"shebang-command": "^2.0.0",
+				"which": "^2.0.1"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/default-browser/node_modules/execa": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/execa/-/execa-7.2.0.tgz",
+			"integrity": "sha512-UduyVP7TLB5IcAQl+OzLyLcS/l32W/GLg+AhHJ+ow40FOk2U3SAllPwR44v4vmdFwIWqpdwxxpQbF1n5ta9seA==",
+			"dev": true,
+			"dependencies": {
+				"cross-spawn": "^7.0.3",
+				"get-stream": "^6.0.1",
+				"human-signals": "^4.3.0",
+				"is-stream": "^3.0.0",
+				"merge-stream": "^2.0.0",
+				"npm-run-path": "^5.1.0",
+				"onetime": "^6.0.0",
+				"signal-exit": "^3.0.7",
+				"strip-final-newline": "^3.0.0"
+			},
+			"engines": {
+				"node": "^14.18.0 || ^16.14.0 || >=18.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sindresorhus/execa?sponsor=1"
+			}
+		},
+		"node_modules/default-browser/node_modules/get-stream": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+			"integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/default-browser/node_modules/human-signals": {
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/human-signals/-/human-signals-4.3.1.tgz",
+			"integrity": "sha512-nZXjEF2nbo7lIw3mgYjItAfgQXog3OjJogSbKa2CQIIvSGWcKgeJnQlNXip6NglNzYH45nSRiEVimMvYL8DDqQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=14.18.0"
+			}
+		},
+		"node_modules/default-browser/node_modules/is-stream": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+			"integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+			"dev": true,
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/default-browser/node_modules/mimic-fn": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+			"integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+			"dev": true,
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/default-browser/node_modules/npm-run-path": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.1.0.tgz",
+			"integrity": "sha512-sJOdmRGrY2sjNTRMbSvluQqg+8X7ZK61yvzBEIDhz4f8z1TZFYABsqjjCBd/0PUNE9M6QDgHJXQkGUEm7Q+l9Q==",
+			"dev": true,
+			"dependencies": {
+				"path-key": "^4.0.0"
+			},
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/default-browser/node_modules/npm-run-path/node_modules/path-key": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+			"integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/default-browser/node_modules/onetime": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+			"integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+			"dev": true,
+			"dependencies": {
+				"mimic-fn": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/default-browser/node_modules/path-key": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+			"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/default-browser/node_modules/shebang-command": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+			"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+			"dev": true,
+			"dependencies": {
+				"shebang-regex": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/default-browser/node_modules/shebang-regex": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+			"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/default-browser/node_modules/strip-final-newline": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+			"integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+			"dev": true,
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/default-browser/node_modules/which": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+			"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+			"dev": true,
+			"dependencies": {
+				"isexe": "^2.0.0"
+			},
+			"bin": {
+				"node-which": "bin/node-which"
+			},
+			"engines": {
+				"node": ">= 8"
 			}
 		},
 		"node_modules/default-gateway": {
@@ -29190,22 +29554,30 @@
 			}
 		},
 		"node_modules/eslint-plugin-prettier": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.3.0.tgz",
-			"integrity": "sha512-tMTwO8iUWlSRZIwS9k7/E4vrTsfvsrcM5p1eftyuqWH25nKsz/o6/54I7jwQ/3zobISyC7wMy9ZsFwgTxOcOpQ==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.0.0.tgz",
+			"integrity": "sha512-AgaZCVuYDXHUGxj/ZGu1u8H8CYgDY3iG6w5kUFw4AzMVXzB7VvbKgYR4nATIN+OvUrghMbiDLeimVjVY5ilq3w==",
 			"dev": true,
 			"dependencies": {
-				"prettier-linter-helpers": "^1.0.0"
+				"prettier-linter-helpers": "^1.0.0",
+				"synckit": "^0.8.5"
 			},
 			"engines": {
-				"node": ">=6.0.0"
+				"node": "^14.18.0 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/prettier"
 			},
 			"peerDependencies": {
-				"eslint": ">=5.0.0",
-				"prettier": ">=1.13.0"
+				"@types/eslint": ">=8.0.0",
+				"eslint": ">=8.0.0",
+				"prettier": ">=3.0.0"
 			},
 			"peerDependenciesMeta": {
-				"eslint-plugin-prettier": {
+				"@types/eslint": {
+					"optional": true
+				},
+				"eslint-config-prettier": {
 					"optional": true
 				}
 			}
@@ -33697,6 +34069,39 @@
 			"resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.2.tgz",
 			"integrity": "sha512-but/G3sapV3MNyqiDBLrOi4x8uCIw0RY3o/Vb5GT0sMFHrVV7731wFSVy41T5FO1og7G0gXLJh0MkgPRouko/A==",
 			"dev": true
+		},
+		"node_modules/is-inside-container": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+			"integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+			"dev": true,
+			"dependencies": {
+				"is-docker": "^3.0.0"
+			},
+			"bin": {
+				"is-inside-container": "cli.js"
+			},
+			"engines": {
+				"node": ">=14.16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/is-inside-container/node_modules/is-docker": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+			"integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+			"dev": true,
+			"bin": {
+				"is-docker": "cli.js"
+			},
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
 		},
 		"node_modules/is-interactive": {
 			"version": "1.0.0",
@@ -48225,6 +48630,172 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/run-applescript": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-5.0.0.tgz",
+			"integrity": "sha512-XcT5rBksx1QdIhlFOCtgZkB99ZEouFZ1E2Kc2LHqNW13U3/74YGdkQRmThTwxy4QIyookibDKYZOPqX//6BlAg==",
+			"dev": true,
+			"dependencies": {
+				"execa": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/run-applescript/node_modules/cross-spawn": {
+			"version": "7.0.3",
+			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+			"integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+			"dev": true,
+			"dependencies": {
+				"path-key": "^3.1.0",
+				"shebang-command": "^2.0.0",
+				"which": "^2.0.1"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/run-applescript/node_modules/execa": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+			"integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+			"dev": true,
+			"dependencies": {
+				"cross-spawn": "^7.0.3",
+				"get-stream": "^6.0.0",
+				"human-signals": "^2.1.0",
+				"is-stream": "^2.0.0",
+				"merge-stream": "^2.0.0",
+				"npm-run-path": "^4.0.1",
+				"onetime": "^5.1.2",
+				"signal-exit": "^3.0.3",
+				"strip-final-newline": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sindresorhus/execa?sponsor=1"
+			}
+		},
+		"node_modules/run-applescript/node_modules/get-stream": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+			"integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/run-applescript/node_modules/human-signals": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+			"integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+			"dev": true,
+			"engines": {
+				"node": ">=10.17.0"
+			}
+		},
+		"node_modules/run-applescript/node_modules/is-stream": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+			"integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/run-applescript/node_modules/mimic-fn": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+			"integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+			"dev": true,
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/run-applescript/node_modules/npm-run-path": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+			"integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+			"dev": true,
+			"dependencies": {
+				"path-key": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/run-applescript/node_modules/onetime": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+			"integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+			"dev": true,
+			"dependencies": {
+				"mimic-fn": "^2.1.0"
+			},
+			"engines": {
+				"node": ">=6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/run-applescript/node_modules/path-key": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+			"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/run-applescript/node_modules/shebang-command": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+			"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+			"dev": true,
+			"dependencies": {
+				"shebang-regex": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/run-applescript/node_modules/shebang-regex": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+			"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/run-applescript/node_modules/which": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+			"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+			"dev": true,
+			"dependencies": {
+				"isexe": "^2.0.0"
+			},
+			"bin": {
+				"node-which": "bin/node-which"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
 		"node_modules/run-async": {
 			"version": "2.4.1",
 			"resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
@@ -50708,6 +51279,22 @@
 			"integrity": "sha512-k8uzYIkIVwmT+TcglpdN50pS2y1BDcUnBPK9iJeGu0Pl1lOI8pD6wtzgw91Pjpe+RxtTncw32tLxs/R0yNL2Mg==",
 			"dev": true
 		},
+		"node_modules/synckit": {
+			"version": "0.8.5",
+			"resolved": "https://registry.npmjs.org/synckit/-/synckit-0.8.5.tgz",
+			"integrity": "sha512-L1dapNV6vu2s/4Sputv8xGsCdAVlb5nRDMFU/E27D44l5U6cw1g0dGd45uLc+OXjNMmF4ntiMdCimzcjFKQI8Q==",
+			"dev": true,
+			"dependencies": {
+				"@pkgr/utils": "^2.3.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": "^14.18.0 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/unts"
+			}
+		},
 		"node_modules/table": {
 			"version": "6.8.0",
 			"resolved": "https://registry.npmjs.org/table/-/table-6.8.0.tgz",
@@ -51262,6 +51849,18 @@
 			"resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.1.tgz",
 			"integrity": "sha512-AD5ih2NlSssTCwsMznbvwMZpJ1cbhkGd2uueNxzv2jDlEeZdU04JQfRnggJQ8DrcVBGjAsCKwFBbDlVNtEMlzw==",
 			"dev": true
+		},
+		"node_modules/titleize": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/titleize/-/titleize-3.0.0.tgz",
+			"integrity": "sha512-KxVu8EYHDPBdUYdKZdKtU2aj2XfEx9AfjXxE/Aj0vT06w2icA09Vus1rh6eSu1y01akYg6BjIK/hxyLJINoMLQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
 		},
 		"node_modules/tmp": {
 			"version": "0.0.33",
@@ -55721,7 +56320,7 @@
 				"eslint-plugin-jsdoc": "^46.4.6",
 				"eslint-plugin-jsx-a11y": "^6.5.1",
 				"eslint-plugin-playwright": "^0.15.3",
-				"eslint-plugin-prettier": "^3.3.0",
+				"eslint-plugin-prettier": "^5.0.0",
 				"eslint-plugin-react": "^7.27.0",
 				"eslint-plugin-react-hooks": "^4.3.0",
 				"globals": "^13.12.0",
@@ -60580,6 +61179,112 @@
 			"integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
 			"dev": true,
 			"optional": true
+		},
+		"@pkgr/utils": {
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/@pkgr/utils/-/utils-2.4.2.tgz",
+			"integrity": "sha512-POgTXhjrTfbTV63DiFXav4lBHiICLKKwDeaKn9Nphwj7WH6m0hMMCaJkMyRWjgtPFyRKRVoMXXjczsTQRDEhYw==",
+			"dev": true,
+			"requires": {
+				"cross-spawn": "^7.0.3",
+				"fast-glob": "^3.3.0",
+				"is-glob": "^4.0.3",
+				"open": "^9.1.0",
+				"picocolors": "^1.0.0",
+				"tslib": "^2.6.0"
+			},
+			"dependencies": {
+				"cross-spawn": {
+					"version": "7.0.3",
+					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+					"integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+					"dev": true,
+					"requires": {
+						"path-key": "^3.1.0",
+						"shebang-command": "^2.0.0",
+						"which": "^2.0.1"
+					}
+				},
+				"define-lazy-prop": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+					"integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+					"dev": true
+				},
+				"fast-glob": {
+					"version": "3.3.1",
+					"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.1.tgz",
+					"integrity": "sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==",
+					"dev": true,
+					"requires": {
+						"@nodelib/fs.stat": "^2.0.2",
+						"@nodelib/fs.walk": "^1.2.3",
+						"glob-parent": "^5.1.2",
+						"merge2": "^1.3.0",
+						"micromatch": "^4.0.4"
+					}
+				},
+				"glob-parent": {
+					"version": "5.1.2",
+					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+					"integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+					"dev": true,
+					"requires": {
+						"is-glob": "^4.0.1"
+					}
+				},
+				"is-wsl": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+					"integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+					"dev": true,
+					"requires": {
+						"is-docker": "^2.0.0"
+					}
+				},
+				"open": {
+					"version": "9.1.0",
+					"resolved": "https://registry.npmjs.org/open/-/open-9.1.0.tgz",
+					"integrity": "sha512-OS+QTnw1/4vrf+9hh1jc1jnYjzSG4ttTBB8UxOwAnInG3Uo4ssetzC1ihqaIHjLJnA5GGlRl6QlZXOTQhRBUvg==",
+					"dev": true,
+					"requires": {
+						"default-browser": "^4.0.0",
+						"define-lazy-prop": "^3.0.0",
+						"is-inside-container": "^1.0.0",
+						"is-wsl": "^2.2.0"
+					}
+				},
+				"path-key": {
+					"version": "3.1.1",
+					"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+					"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+					"dev": true
+				},
+				"shebang-command": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+					"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+					"dev": true,
+					"requires": {
+						"shebang-regex": "^3.0.0"
+					}
+				},
+				"shebang-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+					"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+					"dev": true
+				},
+				"which": {
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+					"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+					"dev": true,
+					"requires": {
+						"isexe": "^2.0.0"
+					}
+				}
+			}
 		},
 		"@playwright/test": {
 			"version": "1.32.0",
@@ -68455,7 +69160,7 @@
 				"eslint-plugin-jsdoc": "^46.4.6",
 				"eslint-plugin-jsx-a11y": "^6.5.1",
 				"eslint-plugin-playwright": "^0.15.3",
-				"eslint-plugin-prettier": "^3.3.0",
+				"eslint-plugin-prettier": "^5.0.0",
 				"eslint-plugin-react": "^7.27.0",
 				"eslint-plugin-react-hooks": "^4.3.0",
 				"globals": "^13.12.0",
@@ -77220,6 +77925,15 @@
 			"integrity": "sha512-uYBjakWipfaO/bXI7E8rq6kpwHRZK5cNYrUv2OzZSI/FvmdMyXJ2tG9dKcjEC5YHmHpUAwsargWIZNWdxb/bnQ==",
 			"dev": true
 		},
+		"bundle-name": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-3.0.0.tgz",
+			"integrity": "sha512-PKA4BeSvBpQKQ8iPOGCSiell+N8P+Tf1DlwqmYhpe2gAhKPHn8EYOxVT+ShuGmhg8lN8XiSlS80yiExKXrURlw==",
+			"dev": true,
+			"requires": {
+				"run-applescript": "^5.0.0"
+			}
+		},
 		"byte-size": {
 			"version": "8.1.1",
 			"resolved": "https://registry.npmjs.org/byte-size/-/byte-size-8.1.1.tgz",
@@ -79643,6 +80357,134 @@
 			"resolved": "https://registry.npmjs.org/deepsignal/-/deepsignal-1.3.6.tgz",
 			"integrity": "sha512-yjd+vtiznL6YaMptOsKnEKkPr60OEApa+LRe+Qe6Ile/RfCOrELKk/YM3qVpXFZiyOI3Ng67GDEyjAlqVc697g=="
 		},
+		"default-browser": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/default-browser/-/default-browser-4.0.0.tgz",
+			"integrity": "sha512-wX5pXO1+BrhMkSbROFsyxUm0i/cJEScyNhA4PPxc41ICuv05ZZB/MX28s8aZx6xjmatvebIapF6hLEKEcpneUA==",
+			"dev": true,
+			"requires": {
+				"bundle-name": "^3.0.0",
+				"default-browser-id": "^3.0.0",
+				"execa": "^7.1.1",
+				"titleize": "^3.0.0"
+			},
+			"dependencies": {
+				"cross-spawn": {
+					"version": "7.0.3",
+					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+					"integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+					"dev": true,
+					"requires": {
+						"path-key": "^3.1.0",
+						"shebang-command": "^2.0.0",
+						"which": "^2.0.1"
+					}
+				},
+				"execa": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/execa/-/execa-7.2.0.tgz",
+					"integrity": "sha512-UduyVP7TLB5IcAQl+OzLyLcS/l32W/GLg+AhHJ+ow40FOk2U3SAllPwR44v4vmdFwIWqpdwxxpQbF1n5ta9seA==",
+					"dev": true,
+					"requires": {
+						"cross-spawn": "^7.0.3",
+						"get-stream": "^6.0.1",
+						"human-signals": "^4.3.0",
+						"is-stream": "^3.0.0",
+						"merge-stream": "^2.0.0",
+						"npm-run-path": "^5.1.0",
+						"onetime": "^6.0.0",
+						"signal-exit": "^3.0.7",
+						"strip-final-newline": "^3.0.0"
+					}
+				},
+				"get-stream": {
+					"version": "6.0.1",
+					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+					"integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+					"dev": true
+				},
+				"human-signals": {
+					"version": "4.3.1",
+					"resolved": "https://registry.npmjs.org/human-signals/-/human-signals-4.3.1.tgz",
+					"integrity": "sha512-nZXjEF2nbo7lIw3mgYjItAfgQXog3OjJogSbKa2CQIIvSGWcKgeJnQlNXip6NglNzYH45nSRiEVimMvYL8DDqQ==",
+					"dev": true
+				},
+				"is-stream": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+					"integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+					"dev": true
+				},
+				"mimic-fn": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+					"integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+					"dev": true
+				},
+				"npm-run-path": {
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.1.0.tgz",
+					"integrity": "sha512-sJOdmRGrY2sjNTRMbSvluQqg+8X7ZK61yvzBEIDhz4f8z1TZFYABsqjjCBd/0PUNE9M6QDgHJXQkGUEm7Q+l9Q==",
+					"dev": true,
+					"requires": {
+						"path-key": "^4.0.0"
+					},
+					"dependencies": {
+						"path-key": {
+							"version": "4.0.0",
+							"resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+							"integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+							"dev": true
+						}
+					}
+				},
+				"onetime": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+					"integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+					"dev": true,
+					"requires": {
+						"mimic-fn": "^4.0.0"
+					}
+				},
+				"path-key": {
+					"version": "3.1.1",
+					"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+					"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+					"dev": true
+				},
+				"shebang-command": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+					"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+					"dev": true,
+					"requires": {
+						"shebang-regex": "^3.0.0"
+					}
+				},
+				"shebang-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+					"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+					"dev": true
+				},
+				"strip-final-newline": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+					"integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+					"dev": true
+				},
+				"which": {
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+					"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+					"dev": true,
+					"requires": {
+						"isexe": "^2.0.0"
+					}
+				}
+			}
+		},
 		"default-browser-id": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-3.0.0.tgz",
@@ -81202,12 +82044,13 @@
 			"dev": true
 		},
 		"eslint-plugin-prettier": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.3.0.tgz",
-			"integrity": "sha512-tMTwO8iUWlSRZIwS9k7/E4vrTsfvsrcM5p1eftyuqWH25nKsz/o6/54I7jwQ/3zobISyC7wMy9ZsFwgTxOcOpQ==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.0.0.tgz",
+			"integrity": "sha512-AgaZCVuYDXHUGxj/ZGu1u8H8CYgDY3iG6w5kUFw4AzMVXzB7VvbKgYR4nATIN+OvUrghMbiDLeimVjVY5ilq3w==",
 			"dev": true,
 			"requires": {
-				"prettier-linter-helpers": "^1.0.0"
+				"prettier-linter-helpers": "^1.0.0",
+				"synckit": "^0.8.5"
 			}
 		},
 		"eslint-plugin-react": {
@@ -84461,6 +85304,23 @@
 			"resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.2.tgz",
 			"integrity": "sha512-but/G3sapV3MNyqiDBLrOi4x8uCIw0RY3o/Vb5GT0sMFHrVV7731wFSVy41T5FO1og7G0gXLJh0MkgPRouko/A==",
 			"dev": true
+		},
+		"is-inside-container": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+			"integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+			"dev": true,
+			"requires": {
+				"is-docker": "^3.0.0"
+			},
+			"dependencies": {
+				"is-docker": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+					"integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+					"dev": true
+				}
+			}
 		},
 		"is-interactive": {
 			"version": "1.0.0",
@@ -95553,6 +96413,117 @@
 				}
 			}
 		},
+		"run-applescript": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-5.0.0.tgz",
+			"integrity": "sha512-XcT5rBksx1QdIhlFOCtgZkB99ZEouFZ1E2Kc2LHqNW13U3/74YGdkQRmThTwxy4QIyookibDKYZOPqX//6BlAg==",
+			"dev": true,
+			"requires": {
+				"execa": "^5.0.0"
+			},
+			"dependencies": {
+				"cross-spawn": {
+					"version": "7.0.3",
+					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+					"integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+					"dev": true,
+					"requires": {
+						"path-key": "^3.1.0",
+						"shebang-command": "^2.0.0",
+						"which": "^2.0.1"
+					}
+				},
+				"execa": {
+					"version": "5.1.1",
+					"resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+					"integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+					"dev": true,
+					"requires": {
+						"cross-spawn": "^7.0.3",
+						"get-stream": "^6.0.0",
+						"human-signals": "^2.1.0",
+						"is-stream": "^2.0.0",
+						"merge-stream": "^2.0.0",
+						"npm-run-path": "^4.0.1",
+						"onetime": "^5.1.2",
+						"signal-exit": "^3.0.3",
+						"strip-final-newline": "^2.0.0"
+					}
+				},
+				"get-stream": {
+					"version": "6.0.1",
+					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+					"integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+					"dev": true
+				},
+				"human-signals": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+					"integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+					"dev": true
+				},
+				"is-stream": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+					"integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+					"dev": true
+				},
+				"mimic-fn": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+					"integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+					"dev": true
+				},
+				"npm-run-path": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+					"integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+					"dev": true,
+					"requires": {
+						"path-key": "^3.0.0"
+					}
+				},
+				"onetime": {
+					"version": "5.1.2",
+					"resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+					"integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+					"dev": true,
+					"requires": {
+						"mimic-fn": "^2.1.0"
+					}
+				},
+				"path-key": {
+					"version": "3.1.1",
+					"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+					"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+					"dev": true
+				},
+				"shebang-command": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+					"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+					"dev": true,
+					"requires": {
+						"shebang-regex": "^3.0.0"
+					}
+				},
+				"shebang-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+					"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+					"dev": true
+				},
+				"which": {
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+					"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+					"dev": true,
+					"requires": {
+						"isexe": "^2.0.0"
+					}
+				}
+			}
+		},
 		"run-async": {
 			"version": "2.4.1",
 			"resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
@@ -97496,6 +98467,16 @@
 			"integrity": "sha512-k8uzYIkIVwmT+TcglpdN50pS2y1BDcUnBPK9iJeGu0Pl1lOI8pD6wtzgw91Pjpe+RxtTncw32tLxs/R0yNL2Mg==",
 			"dev": true
 		},
+		"synckit": {
+			"version": "0.8.5",
+			"resolved": "https://registry.npmjs.org/synckit/-/synckit-0.8.5.tgz",
+			"integrity": "sha512-L1dapNV6vu2s/4Sputv8xGsCdAVlb5nRDMFU/E27D44l5U6cw1g0dGd45uLc+OXjNMmF4ntiMdCimzcjFKQI8Q==",
+			"dev": true,
+			"requires": {
+				"@pkgr/utils": "^2.3.1",
+				"tslib": "^2.5.0"
+			}
+		},
 		"table": {
 			"version": "6.8.0",
 			"resolved": "https://registry.npmjs.org/table/-/table-6.8.0.tgz",
@@ -97915,6 +98896,12 @@
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.1.tgz",
 			"integrity": "sha512-AD5ih2NlSssTCwsMznbvwMZpJ1cbhkGd2uueNxzv2jDlEeZdU04JQfRnggJQ8DrcVBGjAsCKwFBbDlVNtEMlzw==",
+			"dev": true
+		},
+		"titleize": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/titleize/-/titleize-3.0.0.tgz",
+			"integrity": "sha512-KxVu8EYHDPBdUYdKZdKtU2aj2XfEx9AfjXxE/Aj0vT06w2icA09Vus1rh6eSu1y01akYg6BjIK/hxyLJINoMLQ==",
 			"dev": true
 		},
 		"tmp": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -213,7 +213,7 @@
 				"patch-package": "6.2.2",
 				"postcss": "8.4.16",
 				"postcss-loader": "6.2.1",
-				"prettier": "npm:wp-prettier@2.8.5",
+				"prettier": "npm:wp-prettier@3.0.3-beta-3",
 				"progress": "2.0.3",
 				"react": "18.2.0",
 				"react-dom": "18.2.0",
@@ -10449,6 +10449,21 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/@storybook/cli/node_modules/prettier": {
+			"version": "2.8.8",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+			"integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+			"dev": true,
+			"bin": {
+				"prettier": "bin-prettier.js"
+			},
+			"engines": {
+				"node": ">=10.13.0"
+			},
+			"funding": {
+				"url": "https://github.com/prettier/prettier?sponsor=1"
+			}
+		},
 		"node_modules/@storybook/cli/node_modules/puppeteer-core": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-2.1.1.tgz",
@@ -10945,6 +10960,21 @@
 			"dev": true,
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/@storybook/codemod/node_modules/prettier": {
+			"version": "2.8.8",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+			"integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+			"dev": true,
+			"bin": {
+				"prettier": "bin-prettier.js"
+			},
+			"engines": {
+				"node": ">=10.13.0"
+			},
+			"funding": {
+				"url": "https://github.com/prettier/prettier?sponsor=1"
 			}
 		},
 		"node_modules/@storybook/codemod/node_modules/recast": {
@@ -12657,6 +12687,21 @@
 			"dev": true,
 			"engines": {
 				"node": ">=4.0"
+			}
+		},
+		"node_modules/@storybook/source-loader/node_modules/prettier": {
+			"version": "2.8.8",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+			"integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+			"dev": true,
+			"bin": {
+				"prettier": "bin-prettier.js"
+			},
+			"engines": {
+				"node": ">=10.13.0"
+			},
+			"funding": {
+				"url": "https://github.com/prettier/prettier?sponsor=1"
 			}
 		},
 		"node_modules/@storybook/telemetry": {
@@ -45293,10 +45338,19 @@
 		},
 		"node_modules/prettier": {
 			"name": "wp-prettier",
-			"version": "2.8.5",
-			"resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-2.8.5.tgz",
-			"integrity": "sha512-gkphzYtVksWV6D7/V530bTehKkhrABUru/Gy4reOLOHJoKH4i9lcE1SxqU2VDxC3gCOx/Nk9alZmWk6xL/IBCw==",
-			"dev": true
+			"version": "3.0.3-beta-3",
+			"resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-3.0.3-beta-3.tgz",
+			"integrity": "sha512-R3+TD7j0rnqEpMgylrUrHdi1W6ypwh4QGeFOZQ9YjP9WvNnZzBAS71yry1h7xIcG/bVaNKBCoWNqbqJY6vkOKQ==",
+			"dev": true,
+			"bin": {
+				"prettier": "bin/prettier.cjs"
+			},
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/prettier/prettier?sponsor=1"
+			}
 		},
 		"node_modules/prettier-linter-helpers": {
 			"version": "1.0.0",
@@ -56450,7 +56504,7 @@
 				"playwright-core": "1.32.0",
 				"postcss": "^8.4.5",
 				"postcss-loader": "^6.2.1",
-				"prettier": "npm:wp-prettier@2.8.5",
+				"prettier": "npm:wp-prettier@3.0.3-beta-3",
 				"puppeteer-core": "^13.2.0",
 				"react-refresh": "^0.10.0",
 				"read-pkg-up": "^7.0.1",
@@ -63921,6 +63975,12 @@
 					"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
 					"dev": true
 				},
+				"prettier": {
+					"version": "2.8.8",
+					"resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+					"integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+					"dev": true
+				},
 				"puppeteer-core": {
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-2.1.1.tgz",
@@ -64308,6 +64368,12 @@
 					"version": "3.1.1",
 					"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
 					"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+					"dev": true
+				},
+				"prettier": {
+					"version": "2.8.8",
+					"resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+					"integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
 					"dev": true
 				},
 				"recast": {
@@ -65528,6 +65594,12 @@
 					"version": "5.3.0",
 					"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
 					"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+					"dev": true
+				},
+				"prettier": {
+					"version": "2.8.8",
+					"resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+					"integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
 					"dev": true
 				}
 			}
@@ -68853,7 +68925,7 @@
 				"playwright-core": "1.32.0",
 				"postcss": "^8.4.5",
 				"postcss-loader": "^6.2.1",
-				"prettier": "npm:wp-prettier@2.8.5",
+				"prettier": "npm:wp-prettier@3.0.3-beta-3",
 				"puppeteer-core": "^13.2.0",
 				"react-refresh": "^0.10.0",
 				"read-pkg-up": "^7.0.1",
@@ -93303,9 +93375,9 @@
 			"dev": true
 		},
 		"prettier": {
-			"version": "npm:wp-prettier@2.8.5",
-			"resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-2.8.5.tgz",
-			"integrity": "sha512-gkphzYtVksWV6D7/V530bTehKkhrABUru/Gy4reOLOHJoKH4i9lcE1SxqU2VDxC3gCOx/Nk9alZmWk6xL/IBCw==",
+			"version": "npm:wp-prettier@3.0.3-beta-3",
+			"resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-3.0.3-beta-3.tgz",
+			"integrity": "sha512-R3+TD7j0rnqEpMgylrUrHdi1W6ypwh4QGeFOZQ9YjP9WvNnZzBAS71yry1h7xIcG/bVaNKBCoWNqbqJY6vkOKQ==",
 			"dev": true
 		},
 		"prettier-linter-helpers": {

--- a/package.json
+++ b/package.json
@@ -225,7 +225,7 @@
 		"patch-package": "6.2.2",
 		"postcss": "8.4.16",
 		"postcss-loader": "6.2.1",
-		"prettier": "npm:wp-prettier@2.8.5",
+		"prettier": "npm:wp-prettier@3.0.3-beta-3",
 		"progress": "2.0.3",
 		"react": "18.2.0",
 		"react-dom": "18.2.0",

--- a/package.json
+++ b/package.json
@@ -195,6 +195,7 @@
 		"eslint-plugin-import": "2.25.2",
 		"eslint-plugin-jest": "27.2.3",
 		"eslint-plugin-jest-dom": "5.0.2",
+		"eslint-plugin-prettier": "5.0.0",
 		"eslint-plugin-ssr-friendly": "1.0.6",
 		"eslint-plugin-storybook": "0.6.13",
 		"eslint-plugin-testing-library": "5.7.2",

--- a/packages/block-editor/src/components/colors/with-colors.js
+++ b/packages/block-editor/src/components/colors/with-colors.js
@@ -36,8 +36,9 @@ const upperFirst = ( [ firstLetter, ...rest ] ) =>
  */
 const withCustomColorPalette = ( colorsArray ) =>
 	createHigherOrderComponent(
-		( WrappedComponent ) => ( props ) =>
-			<WrappedComponent { ...props } colors={ colorsArray } />,
+		( WrappedComponent ) => ( props ) => (
+			<WrappedComponent { ...props } colors={ colorsArray } />
+		),
 		'withCustomColorPalette'
 	);
 

--- a/packages/block-editor/src/components/inserter/test/index.native.js
+++ b/packages/block-editor/src/components/inserter/test/index.native.js
@@ -67,9 +67,8 @@ describe( 'Inserter', () => {
 			fireEvent( addBlockButton, 'onLongPress' );
 
 			// Get Add To Beginning option
-			const addBlockToBeginningButton = await getByLabelText(
-				'Add To Beginning'
-			);
+			const addBlockToBeginningButton =
+				await getByLabelText( 'Add To Beginning' );
 			expect( addBlockToBeginningButton ).toBeVisible();
 			fireEvent.press( addBlockToBeginningButton );
 
@@ -97,9 +96,8 @@ describe( 'Inserter', () => {
 			fireEvent( addBlockButton, 'onLongPress' );
 
 			// Get Add Block Before option
-			const addBlockBeforeButton = await getByLabelText(
-				'Add Block Before'
-			);
+			const addBlockBeforeButton =
+				await getByLabelText( 'Add Block Before' );
 			expect( addBlockBeforeButton ).toBeVisible();
 			fireEvent.press( addBlockBeforeButton );
 
@@ -135,9 +133,8 @@ describe( 'Inserter', () => {
 			fireEvent( addBlockButton, 'onLongPress' );
 
 			// Get Add Block After option
-			const addBlockAfterButton = await getByLabelText(
-				'Add Block After'
-			);
+			const addBlockAfterButton =
+				await getByLabelText( 'Add Block After' );
 			expect( addBlockAfterButton ).toBeVisible();
 			fireEvent.press( addBlockAfterButton );
 
@@ -233,9 +230,8 @@ describe( 'Inserter', () => {
 			await addBlock( screen, 'Heading' );
 
 			// Select the title
-			const titleInputElement = await getAllByLabelText(
-				'Post title. test'
-			)[ 0 ];
+			const titleInputElement =
+				await getAllByLabelText( 'Post title. test' )[ 0 ];
 			expect( titleInputElement ).toBeVisible();
 			fireEvent.press( titleInputElement );
 

--- a/packages/block-editor/src/components/link-control/test/index.js
+++ b/packages/block-editor/src/components/link-control/test/index.js
@@ -1218,9 +1218,8 @@ describe( 'Creating Entities (eg: Posts, Pages)', () => {
 			// Resolve the `createSuggestion` promise.
 			resolver();
 
-			const currentLink = await screen.findByLabelText(
-				'Currently selected'
-			);
+			const currentLink =
+				await screen.findByLabelText( 'Currently selected' );
 
 			expect( currentLink ).toHaveTextContent( entityNameText );
 			expect( currentLink ).toHaveTextContent( '/?p=123' );

--- a/packages/block-editor/src/hooks/test/align.native.js
+++ b/packages/block-editor/src/hooks/test/align.native.js
@@ -108,9 +108,10 @@ describe( 'Align options', () => {
 				expect( groupBlock ).toBeVisible();
 
 				// Trigger inner blocks layout
-				const innerBlockListWrapper = await within(
-					groupBlock
-				).findByTestId( 'block-list-wrapper' );
+				const innerBlockListWrapper =
+					await within( groupBlock ).findByTestId(
+						'block-list-wrapper'
+					);
 				fireEvent( innerBlockListWrapper, 'layout', {
 					nativeEvent: {
 						layout: {

--- a/packages/block-library/src/block/test/edit.native.js
+++ b/packages/block-library/src/block/test/edit.native.js
@@ -165,9 +165,8 @@ describe( 'Synced patterns', () => {
 			/Pattern Block\. Row 1/
 		);
 
-		const innerBlockListWrapper = await within(
-			reusableBlock
-		).findByTestId( 'block-list-wrapper' );
+		const innerBlockListWrapper =
+			await within( reusableBlock ).findByTestId( 'block-list-wrapper' );
 
 		// onLayout event has to be explicitly dispatched in BlockList component,
 		// otherwise the inner blocks are not rendered.

--- a/packages/block-library/src/buttons/test/edit.native.js
+++ b/packages/block-library/src/buttons/test/edit.native.js
@@ -55,9 +55,10 @@ describe( 'Buttons block', () => {
 
 			// onLayout event has to be explicitly dispatched in BlockList component,
 			// otherwise the inner blocks are not rendered.
-			const innerBlockListWrapper = await within(
-				buttonsBlock
-			).findByTestId( 'block-list-wrapper' );
+			const innerBlockListWrapper =
+				await within( buttonsBlock ).findByTestId(
+					'block-list-wrapper'
+				);
 			fireEvent( innerBlockListWrapper, 'layout', {
 				nativeEvent: {
 					layout: {
@@ -66,19 +67,18 @@ describe( 'Buttons block', () => {
 				},
 			} );
 
-			const [ buttonInnerBlock ] = await within(
-				buttonsBlock
-			).findAllByLabelText( /Button Block\. Row 1/ );
+			const [ buttonInnerBlock ] =
+				await within( buttonsBlock ).findAllByLabelText(
+					/Button Block\. Row 1/
+				);
 			fireEvent.press( buttonInnerBlock );
 
-			const settingsButton = await editor.findByLabelText(
-				'Open Settings'
-			);
+			const settingsButton =
+				await editor.findByLabelText( 'Open Settings' );
 			fireEvent.press( settingsButton );
 
-			const radiusStepper = await editor.findByLabelText(
-				/Border Radius/
-			);
+			const radiusStepper =
+				await editor.findByLabelText( /Border Radius/ );
 
 			const incrementButton = await within( radiusStepper ).findByTestId(
 				'Increment',
@@ -98,9 +98,10 @@ describe( 'Buttons block', () => {
 			const buttonsBlock = await getBlock( screen, 'Buttons' );
 
 			// Trigger inner blocks layout
-			const innerBlockListWrapper = await within(
-				buttonsBlock
-			).findByTestId( 'block-list-wrapper' );
+			const innerBlockListWrapper =
+				await within( buttonsBlock ).findByTestId(
+					'block-list-wrapper'
+				);
 			fireEvent( innerBlockListWrapper, 'layout', {
 				nativeEvent: {
 					layout: {
@@ -119,9 +120,10 @@ describe( 'Buttons block', () => {
 			fireEvent.press( appenderButton );
 
 			// Check for new button
-			const [ secondButtonBlock ] = await within(
-				buttonsBlock
-			).findAllByLabelText( /Button Block\. Row 2/ );
+			const [ secondButtonBlock ] =
+				await within( buttonsBlock ).findAllByLabelText(
+					/Button Block\. Row 2/
+				);
 			expect( secondButtonBlock ).toBeVisible();
 
 			// Add a Paragraph block using the empty placeholder at the bottom
@@ -148,9 +150,10 @@ describe( 'Buttons block', () => {
 			fireEvent.press( buttonsBlock );
 
 			// Trigger inner blocks layout
-			const innerBlockListWrapper = await within(
-				buttonsBlock
-			).findByTestId( 'block-list-wrapper' );
+			const innerBlockListWrapper =
+				await within( buttonsBlock ).findByTestId(
+					'block-list-wrapper'
+				);
 			fireEvent( innerBlockListWrapper, 'layout', {
 				nativeEvent: {
 					layout: {
@@ -207,9 +210,10 @@ describe( 'Buttons block', () => {
 				const buttonsBlock = await getBlock( screen, 'Buttons' );
 
 				// Trigger inner blocks layout
-				const innerBlockListWrapper = await within(
-					buttonsBlock
-				).findByTestId( 'block-list-wrapper' );
+				const innerBlockListWrapper =
+					await within( buttonsBlock ).findByTestId(
+						'block-list-wrapper'
+					);
 				fireEvent( innerBlockListWrapper, 'layout', {
 					nativeEvent: {
 						layout: {

--- a/packages/block-library/src/cover/test/edit.native.js
+++ b/packages/block-library/src/cover/test/edit.native.js
@@ -169,9 +169,8 @@ describe( 'when an image is attached', () => {
 			/>
 		);
 		fireEvent.press( screen.getByLabelText( 'Edit image' ) );
-		const [ clearMediaButton ] = await screen.findAllByText(
-			'Clear Media'
-		);
+		const [ clearMediaButton ] =
+			await screen.findAllByText( 'Clear Media' );
 		fireEvent.press( clearMediaButton );
 
 		expect( setAttributes ).toHaveBeenCalledWith(
@@ -191,9 +190,8 @@ describe( 'when an image is attached', () => {
 				setAttributes={ setAttributes }
 			/>
 		);
-		const fixedBackgroundButton = await screen.findByText(
-			'Fixed background'
-		);
+		const fixedBackgroundButton =
+			await screen.findByText( 'Fixed background' );
 		fireEvent.press( fixedBackgroundButton );
 
 		expect( setAttributes ).toHaveBeenCalledWith(
@@ -210,9 +208,8 @@ describe( 'when an image is attached', () => {
 				setAttributes={ setAttributes }
 			/>
 		);
-		const editFocalPointButton = await screen.findByText(
-			'Edit focal point'
-		);
+		const editFocalPointButton =
+			await screen.findByText( 'Edit focal point' );
 		fireEvent.press( editFocalPointButton );
 		fireEvent(
 			screen.getByTestId( 'Slider Y-Axis Position', { hidden: true } ),
@@ -239,9 +236,8 @@ describe( 'when an image is attached', () => {
 				setAttributes={ setAttributes }
 			/>
 		);
-		const editFocalPointButton = await screen.findByText(
-			'Edit focal point'
-		);
+		const editFocalPointButton =
+			await screen.findByText( 'Edit focal point' );
 		fireEvent.press( editFocalPointButton );
 		fireEvent.press(
 			screen.getByText( ( attributes.focalPoint.x * 100 ).toString(), {
@@ -268,9 +264,8 @@ describe( 'when an image is attached', () => {
 				setAttributes={ setAttributes }
 			/>
 		);
-		const editFocalPointButton = await screen.findByText(
-			'Edit focal point'
-		);
+		const editFocalPointButton =
+			await screen.findByText( 'Edit focal point' );
 		fireEvent.press( editFocalPointButton );
 		fireEvent.press(
 			screen.getByText( ( attributes.focalPoint.x * 100 ).toString(), {
@@ -360,9 +355,8 @@ describe( 'color settings', () => {
 		fireEvent.press( colorButton );
 
 		// Wait for the block to be created.
-		const [ coverBlockWithOverlay ] = await screen.findAllByLabelText(
-			/Cover Block\. Row 1/
-		);
+		const [ coverBlockWithOverlay ] =
+			await screen.findAllByLabelText( /Cover Block\. Row 1/ );
 		fireEvent.press( coverBlockWithOverlay );
 
 		// Open Block Settings.
@@ -399,9 +393,8 @@ describe( 'color settings', () => {
 		} );
 
 		// Wait for the block to be created.
-		const [ coverBlock ] = await screen.findAllByLabelText(
-			/Cover Block\. Row 1/
-		);
+		const [ coverBlock ] =
+			await screen.findAllByLabelText( /Cover Block\. Row 1/ );
 		fireEvent.press( coverBlock );
 
 		// Open Block Settings.
@@ -455,9 +448,8 @@ describe( 'color settings', () => {
 		fireEvent.press( colorButton );
 
 		// Wait for the block to be created.
-		const [ coverBlockWithOverlay ] = await screen.findAllByLabelText(
-			/Cover Block\. Row 1/
-		);
+		const [ coverBlockWithOverlay ] =
+			await screen.findAllByLabelText( /Cover Block\. Row 1/ );
 		fireEvent.press( coverBlockWithOverlay );
 
 		// Open Block Settings.
@@ -511,9 +503,8 @@ describe( 'color settings', () => {
 		} );
 
 		// Wait for the block to be created.
-		const [ coverBlock ] = await screen.findAllByLabelText(
-			/Cover Block\. Row 1/
-		);
+		const [ coverBlock ] =
+			await screen.findAllByLabelText( /Cover Block\. Row 1/ );
 		fireEvent.press( coverBlock );
 
 		// Open Block Settings.

--- a/packages/block-library/src/embed/test/index.native.js
+++ b/packages/block-library/src/embed/test/index.native.js
@@ -432,9 +432,8 @@ describe( 'Embed block', () => {
 
 	describe( 'edit URL', () => {
 		it( 'keeps the previous URL if no URL is set', async () => {
-			const editor = await initializeWithEmbedBlock(
-				RICH_TEXT_EMBED_HTML
-			);
+			const editor =
+				await initializeWithEmbedBlock( RICH_TEXT_EMBED_HTML );
 
 			// Open Block Settings.
 			fireEvent.press( await editor.findByLabelText( 'Open Settings' ) );
@@ -456,9 +455,8 @@ describe( 'Embed block', () => {
 			const initialURL = 'https://twitter.com/notnownikki';
 			const expectedURL = 'https://www.youtube.com/watch?v=lXMskKTw3Bc';
 
-			const editor = await initializeWithEmbedBlock(
-				RICH_TEXT_EMBED_HTML
-			);
+			const editor =
+				await initializeWithEmbedBlock( RICH_TEXT_EMBED_HTML );
 
 			// Open Block Settings.
 			fireEvent.press( await editor.findByLabelText( 'Open Settings' ) );
@@ -501,9 +499,8 @@ describe( 'Embed block', () => {
 			const previousURL = 'https://twitter.com/notnownikki';
 			const invalidURL = 'http://';
 
-			const editor = await initializeWithEmbedBlock(
-				RICH_TEXT_EMBED_HTML
-			);
+			const editor =
+				await initializeWithEmbedBlock( RICH_TEXT_EMBED_HTML );
 
 			// Open Block Settings.
 			fireEvent.press( await editor.findByLabelText( 'Open Settings' ) );
@@ -541,9 +538,8 @@ describe( 'Embed block', () => {
 		it( 'sets empty state when setting an empty URL', async () => {
 			const previousURL = 'https://twitter.com/notnownikki';
 
-			const editor = await initializeWithEmbedBlock(
-				RICH_TEXT_EMBED_HTML
-			);
+			const editor =
+				await initializeWithEmbedBlock( RICH_TEXT_EMBED_HTML );
 
 			// Open Block Settings.
 			fireEvent.press( await editor.findByLabelText( 'Open Settings' ) );
@@ -570,9 +566,8 @@ describe( 'Embed block', () => {
 			fireEvent( blockSettingsModal, MODAL_DISMISS_EVENT );
 
 			// Get empty embed link.
-			const emptyLinkTextInput = await editor.findByPlaceholderText(
-				'Add link'
-			);
+			const emptyLinkTextInput =
+				await editor.findByPlaceholderText( 'Add link' );
 
 			expect( emptyLinkTextInput ).toBeDefined();
 			expect( getEditorHtml() ).toMatchSnapshot();
@@ -680,9 +675,8 @@ describe( 'Embed block', () => {
 			'Full width',
 		].forEach( ( alignmentOption ) =>
 			it( `sets ${ alignmentOption } option`, async () => {
-				const editor = await initializeWithEmbedBlock(
-					RICH_TEXT_EMBED_HTML
-				);
+				const editor =
+					await initializeWithEmbedBlock( RICH_TEXT_EMBED_HTML );
 
 				// Open alignment options.
 				fireEvent.press( await editor.findByLabelText( 'Align' ) );
@@ -714,9 +708,8 @@ describe( 'Embed block', () => {
 				return mockOtherResponses( req );
 			} );
 
-			const editor = await initializeWithEmbedBlock(
-				RICH_TEXT_EMBED_HTML
-			);
+			const editor =
+				await initializeWithEmbedBlock( RICH_TEXT_EMBED_HTML );
 
 			await editor.findByText( 'Unable to embed media' );
 
@@ -749,9 +742,8 @@ describe( 'Embed block', () => {
 				return mockOtherResponses( req );
 			} );
 
-			const editor = await initializeWithEmbedBlock(
-				RICH_TEXT_EMBED_HTML
-			);
+			const editor =
+				await initializeWithEmbedBlock( RICH_TEXT_EMBED_HTML );
 
 			// Convert embed to link.
 			fireEvent.press( editor.getByText( 'More options' ) );
@@ -826,9 +818,8 @@ describe( 'Embed block', () => {
 
 	describe( 'preview coming soon', () => {
 		it( 'previews post for providers which embed preview is not available yet', async () => {
-			const { getByText, getByTestId } = await initializeWithEmbedBlock(
-				PHOTO_EMBED_HTML
-			);
+			const { getByText, getByTestId } =
+				await initializeWithEmbedBlock( PHOTO_EMBED_HTML );
 
 			// Try to preview the post.
 			fireEvent.press( getByText( 'PREVIEW POST' ) );
@@ -848,9 +839,8 @@ describe( 'Embed block', () => {
 		} );
 
 		it( 'dismisses no preview modal', async () => {
-			const { getByText, getByTestId } = await initializeWithEmbedBlock(
-				PHOTO_EMBED_HTML
-			);
+			const { getByText, getByTestId } =
+				await initializeWithEmbedBlock( PHOTO_EMBED_HTML );
 
 			// Try to preview the post.
 			fireEvent.press( getByText( 'PREVIEW POST' ) );
@@ -908,9 +898,8 @@ describe( 'Embed block', () => {
 			);
 
 			// Get the created embed block.
-			const [ embedBlock ] = await editor.findAllByLabelText(
-				/Embed Block\. Row 1/
-			);
+			const [ embedBlock ] =
+				await editor.findAllByLabelText( /Embed Block\. Row 1/ );
 
 			expect( embedBlock ).toBeDefined();
 
@@ -996,9 +985,8 @@ describe( 'Embed block', () => {
 
 			fireEvent.press( await editor.findByText( 'Embed' ) );
 
-			const [ block ] = await editor.findAllByLabelText(
-				/Embed Block\. Row 1/
-			);
+			const [ block ] =
+				await editor.findAllByLabelText( /Embed Block\. Row 1/ );
 
 			const blockName = within( block ).getByText( 'Embed' );
 
@@ -1037,9 +1025,8 @@ describe( 'Embed block', () => {
 
 				fireEvent.press( await editor.findByText( title ) );
 
-				const [ block ] = await editor.findAllByLabelText(
-					/Embed Block\. Row 1/
-				);
+				const [ block ] =
+					await editor.findAllByLabelText( /Embed Block\. Row 1/ );
 
 				const blockName = within( block ).getByText( title );
 
@@ -1096,9 +1083,8 @@ describe( 'Embed block', () => {
 
 	describe( 'block settings', () => {
 		it( 'toggles resize for smaller devices media settings', async () => {
-			const screen = await initializeWithEmbedBlock(
-				RICH_TEXT_EMBED_HTML
-			);
+			const screen =
+				await initializeWithEmbedBlock( RICH_TEXT_EMBED_HTML );
 
 			// Open Block Settings.
 			fireEvent.press( await screen.findByLabelText( 'Open Settings' ) );
@@ -1120,9 +1106,8 @@ describe( 'Embed block', () => {
 			// Wait for media settings panel.
 			let mediaSettingsPanel;
 			try {
-				mediaSettingsPanel = await screen.findByText(
-					'Media settings'
-				);
+				mediaSettingsPanel =
+					await screen.findByText( 'Media settings' );
 			} catch ( e ) {
 				// NOOP.
 			}

--- a/packages/block-library/src/verse/test/edit.native.js
+++ b/packages/block-library/src/verse/test/edit.native.js
@@ -61,9 +61,8 @@ describe( 'Verse block', () => {
 		await addBlock( screen, 'Verse' );
 
 		// Act
-		const verseTextInput = await screen.findByPlaceholderText(
-			'Write verse…'
-		);
+		const verseTextInput =
+			await screen.findByPlaceholderText( 'Write verse…' );
 		typeInRichText( verseTextInput, 'A great statement.' );
 		fireEvent( verseTextInput, 'onKeyDown', {
 			nativeEvent: {},

--- a/packages/components/src/circular-option-picker/types.ts
+++ b/packages/components/src/circular-option-picker/types.ts
@@ -69,7 +69,7 @@ type FullListboxCircularOptionPickerProps = CommonCircularOptionPickerProps & {
 				'aria-label'?: never;
 				'aria-labelledby': string;
 		  }
-	 );
+	);
 
 export type ListboxCircularOptionPickerProps = WithBaseId &
 	Omit< FullListboxCircularOptionPickerProps, 'asButtons' >;

--- a/packages/components/src/color-palette/types.ts
+++ b/packages/components/src/color-palette/types.ts
@@ -121,4 +121,4 @@ export type ColorPaletteProps = Pick< PaletteProps, 'onChange' > & {
 				'aria-labelledby'?: string;
 				'aria-label'?: never;
 		  }
-	 );
+	);

--- a/packages/components/src/custom-gradient-picker/gradient-bar/control-points.tsx
+++ b/packages/components/src/custom-gradient-picker/gradient-bar/control-points.tsx
@@ -93,7 +93,7 @@ function GradientColorPickerDropdown( {
 			( {
 				placement: 'bottom',
 				offset: 8,
-			} as const ),
+			} ) as const,
 		[]
 	);
 

--- a/packages/components/src/custom-gradient-picker/gradient-bar/test/utils.ts
+++ b/packages/components/src/custom-gradient-picker/gradient-bar/test/utils.ts
@@ -13,7 +13,7 @@ describe( 'getHorizontalRelativeGradientPosition', () => {
 				( {
 					x: 0,
 					width: 1000,
-				} as DOMRect )
+				} ) as DOMRect
 		);
 
 		const containerElement = document.createElement( 'div' );
@@ -31,7 +31,7 @@ describe( 'getHorizontalRelativeGradientPosition', () => {
 				( {
 					x: 50,
 					width: 1000,
-				} as DOMRect )
+				} ) as DOMRect
 		);
 
 		const containerElement = document.createElement( 'div' );
@@ -49,7 +49,7 @@ describe( 'getHorizontalRelativeGradientPosition', () => {
 				( {
 					x: 0,
 					width: 1000,
-				} as DOMRect )
+				} ) as DOMRect
 		);
 
 		const containerElement = document.createElement( 'div' );
@@ -68,7 +68,7 @@ describe( 'getHorizontalRelativeGradientPosition', () => {
 				( {
 					x: 50,
 					width: 1000,
-				} as DOMRect )
+				} ) as DOMRect
 		);
 		const containerElement = document.createElement( 'div' );
 
@@ -86,7 +86,7 @@ describe( 'getHorizontalRelativeGradientPosition', () => {
 				( {
 					x: 50,
 					width: 1000,
-				} as DOMRect )
+				} ) as DOMRect
 		);
 
 		const containerElement = document.createElement( 'div' );

--- a/packages/components/src/dropdown-menu/index.tsx
+++ b/packages/components/src/dropdown-menu/index.tsx
@@ -22,7 +22,7 @@ import type {
 } from './types';
 
 function mergeProps<
-	T extends { className?: string; [ key: string ]: unknown }
+	T extends { className?: string; [ key: string ]: unknown },
 >( defaultProps: Partial< T > = {}, props: T = {} as T ) {
 	const mergedProps: T = {
 		...defaultProps,

--- a/packages/components/src/duotone-picker/types.ts
+++ b/packages/components/src/duotone-picker/types.ts
@@ -72,7 +72,7 @@ export type DuotonePickerProps = {
 			'aria-labelledby'?: string;
 			'aria-label'?: never;
 	  }
- );
+);
 
 type Color = {
 	color: string;

--- a/packages/components/src/form-token-field/types.ts
+++ b/packages/components/src/form-token-field/types.ts
@@ -194,7 +194,7 @@ export interface FormTokenFieldProps
  * `T` can be either a `string` or an object which must have a `value` prop as a string.
  */
 export interface SuggestionsListProps<
-	T = string | ( Record< string, unknown > & { value: string } )
+	T = string | ( Record< string, unknown > & { value: string } ),
 > {
 	selectedIndex: number;
 	scrollIntoView: boolean;

--- a/packages/components/src/gradient-picker/types.ts
+++ b/packages/components/src/gradient-picker/types.ts
@@ -75,7 +75,7 @@ type GradientPickerBaseProps = {
 			'aria-labelledby'?: string;
 			'aria-label'?: never;
 	  }
- );
+);
 
 export type GradientPickerComponentProps = GradientPickerBaseProps & {
 	/**

--- a/packages/components/src/higher-order/navigate-regions/index.tsx
+++ b/packages/components/src/higher-order/navigate-regions/index.tsx
@@ -139,11 +139,10 @@ export function useNavigateRegions( shortcuts: Shortcuts = defaultShortcuts ) {
  */
 export default createHigherOrderComponent(
 	( Component ) =>
-		( { shortcuts, ...props } ) =>
-			(
-				<div { ...useNavigateRegions( shortcuts ) }>
-					<Component { ...props } />
-				</div>
-			),
+		( { shortcuts, ...props } ) => (
+			<div { ...useNavigateRegions( shortcuts ) }>
+				<Component { ...props } />
+			</div>
+		),
 	'navigateRegions'
 );

--- a/packages/components/src/higher-order/with-filters/test/index.tsx
+++ b/packages/components/src/higher-order/with-filters/test/index.tsx
@@ -52,13 +52,12 @@ describe( 'withFilters', () => {
 		addFilter(
 			hookName,
 			'test/enhanced-component-compose',
-			( FilteredComponent ) => () =>
-				(
-					<div>
-						<FilteredComponent />
-						<ComposedComponent />
-					</div>
-				)
+			( FilteredComponent ) => () => (
+				<div>
+					<FilteredComponent />
+					<ComposedComponent />
+				</div>
+			)
 		);
 		const EnhancedComponent = withFilters( hookName )( MyComponent );
 
@@ -72,12 +71,11 @@ describe( 'withFilters', () => {
 		addFilter(
 			hookName,
 			'test/enhanced-component-spy-1',
-			( FilteredComponent ) => () =>
-				(
-					<blockquote>
-						<FilteredComponent />
-					</blockquote>
-				)
+			( FilteredComponent ) => () => (
+				<blockquote>
+					<FilteredComponent />
+				</blockquote>
+			)
 		);
 		const EnhancedComponent = withFilters( hookName )( SpiedComponent );
 
@@ -100,12 +98,11 @@ describe( 'withFilters', () => {
 		addFilter(
 			hookName,
 			'test/enhanced-component-spy-1',
-			( FilteredComponent ) => () =>
-				(
-					<blockquote>
-						<FilteredComponent />
-					</blockquote>
-				)
+			( FilteredComponent ) => () => (
+				<blockquote>
+					<FilteredComponent />
+				</blockquote>
+			)
 		);
 
 		await waitFor( () =>
@@ -125,22 +122,20 @@ describe( 'withFilters', () => {
 		addFilter(
 			hookName,
 			'test/enhanced-component-spy-1',
-			( FilteredComponent ) => () =>
-				(
-					<blockquote>
-						<FilteredComponent />
-					</blockquote>
-				)
+			( FilteredComponent ) => () => (
+				<blockquote>
+					<FilteredComponent />
+				</blockquote>
+			)
 		);
 		addFilter(
 			hookName,
 			'test/enhanced-component-spy-2',
-			( FilteredComponent ) => () =>
-				(
-					<section>
-						<FilteredComponent />
-					</section>
-				)
+			( FilteredComponent ) => () => (
+				<section>
+					<FilteredComponent />
+				</section>
+			)
 		);
 
 		await waitFor( () =>
@@ -159,12 +154,11 @@ describe( 'withFilters', () => {
 		addFilter(
 			hookName,
 			'test/enhanced-component-spy',
-			( FilteredComponent ) => () =>
-				(
-					<div>
-						<FilteredComponent />
-					</div>
-				)
+			( FilteredComponent ) => () => (
+				<div>
+					<FilteredComponent />
+				</div>
+			)
 		);
 
 		await waitFor( () =>
@@ -196,12 +190,11 @@ describe( 'withFilters', () => {
 		addFilter(
 			hookName,
 			'test/enhanced-component-spy-1',
-			( FilteredComponent ) => () =>
-				(
-					<blockquote>
-						<FilteredComponent />
-					</blockquote>
-				)
+			( FilteredComponent ) => () => (
+				<blockquote>
+					<FilteredComponent />
+				</blockquote>
+			)
 		);
 
 		await waitFor( () =>

--- a/packages/components/src/higher-order/with-spoken-messages/index.tsx
+++ b/packages/components/src/higher-order/with-spoken-messages/index.tsx
@@ -17,13 +17,12 @@ import { speak } from '@wordpress/a11y';
  * @return {WPComponent} The wrapped component.
  */
 export default createHigherOrderComponent(
-	( Component ) => ( props ) =>
-		(
-			<Component
-				{ ...props }
-				speak={ speak }
-				debouncedSpeak={ useDebounce( speak, 500 ) }
-			/>
-		),
+	( Component ) => ( props ) => (
+		<Component
+			{ ...props }
+			speak={ speak }
+			debouncedSpeak={ useDebounce( speak, 500 ) }
+		/>
+	),
 	'withSpokenMessages'
 );

--- a/packages/components/src/mobile/global-styles-context/index.native.js
+++ b/packages/components/src/mobile/global-styles-context/index.native.js
@@ -92,13 +92,12 @@ export const useGlobalStyles = () => {
 	return globalStyles;
 };
 
-export const withGlobalStyles = ( WrappedComponent ) => ( props ) =>
-	(
-		<GlobalStylesContext.Consumer>
-			{ ( globalStyles ) => (
-				<WrappedComponent { ...props } globalStyles={ globalStyles } />
-			) }
-		</GlobalStylesContext.Consumer>
-	);
+export const withGlobalStyles = ( WrappedComponent ) => ( props ) => (
+	<GlobalStylesContext.Consumer>
+		{ ( globalStyles ) => (
+			<WrappedComponent { ...props } globalStyles={ globalStyles } />
+		) }
+	</GlobalStylesContext.Consumer>
+);
 
 export default GlobalStylesContext;

--- a/packages/components/src/navigation/use-navigation-tree-nodes.tsx
+++ b/packages/components/src/navigation/use-navigation-tree-nodes.tsx
@@ -4,7 +4,7 @@
 import { useState } from '@wordpress/element';
 
 export function useNavigationTreeNodes<
-	TNode extends { children?: React.ReactNode; [ key: string ]: unknown }
+	TNode extends { children?: React.ReactNode; [ key: string ]: unknown },
 >() {
 	const [ nodes, setNodes ] = useState<
 		Record< string, Omit< TNode, 'children' > >

--- a/packages/components/src/popover/test/index.tsx
+++ b/packages/components/src/popover/test/index.tsx
@@ -23,17 +23,17 @@ import { PopoverInsideIframeRenderedInExternalSlot } from './utils';
 
 type PositionToPlacementTuple = [
 	NonNullable< PopoverProps[ 'position' ] >,
-	NonNullable< PopoverProps[ 'placement' ] >
+	NonNullable< PopoverProps[ 'placement' ] >,
 ];
 type PlacementToAnimationOriginTuple = [
 	NonNullable< PopoverProps[ 'placement' ] >,
 	number,
-	number
+	number,
 ];
 type PlacementToInitialTranslationTuple = [
 	NonNullable< PopoverProps[ 'placement' ] >,
-	'translateY' | 'translateX',
-	CSSProperties[ 'translate' ]
+	'translateY' | 'translateX' ,
+	CSSProperties[ 'translate' ],
 ];
 
 // There's no matching `placement` for 'middle center' positions,

--- a/packages/components/src/popover/test/index.tsx
+++ b/packages/components/src/popover/test/index.tsx
@@ -32,7 +32,7 @@ type PlacementToAnimationOriginTuple = [
 ];
 type PlacementToInitialTranslationTuple = [
 	NonNullable< PopoverProps[ 'placement' ] >,
-	'translateY' | 'translateX' ,
+	'translateY' | 'translateX',
 	CSSProperties[ 'translate' ],
 ];
 

--- a/packages/components/src/text/styles.js
+++ b/packages/components/src/text/styles.js
@@ -34,7 +34,8 @@ export const highlighterText = css`
 	mark {
 		background: ${ COLORS.alert.yellow };
 		border-radius: 2px;
-		box-shadow: 0 0 0 1px rgba( 0, 0, 0, 0.05 ) inset,
+		box-shadow:
+			0 0 0 1px rgba( 0, 0, 0, 0.05 ) inset,
 			0 -1px 0 rgba( 0, 0, 0, 0.1 ) inset;
 	}
 `;

--- a/packages/components/src/toggle-group-control/toggle-group-control-option-base/styles.ts
+++ b/packages/components/src/toggle-group-control/toggle-group-control-option-base/styles.ts
@@ -50,8 +50,10 @@ export const buttonView = ( {
 	padding: 0 12px;
 	position: relative;
 	text-align: center;
-	transition: background ${ CONFIG.transitionDurationFast } linear,
-		color ${ CONFIG.transitionDurationFast } linear, font-weight 60ms linear;
+	transition:
+		background ${ CONFIG.transitionDurationFast } linear,
+		color ${ CONFIG.transitionDurationFast } linear,
+		font-weight 60ms linear;
 	${ reduceMotion( 'transition' ) }
 	user-select: none;
 	width: 100%;
@@ -82,7 +84,8 @@ const deselectable = css`
 	color: ${ COLORS.gray[ 900 ] };
 
 	&:focus {
-		box-shadow: inset 0 0 0 1px ${ COLORS.white },
+		box-shadow:
+			inset 0 0 0 1px ${ COLORS.white },
 			0 0 0 ${ CONFIG.borderWidthFocus } ${ COLORS.theme.accent };
 		outline: 2px solid transparent;
 	}

--- a/packages/components/src/toggle-group-control/toggle-group-control/as-button-group.tsx
+++ b/packages/components/src/toggle-group-control/toggle-group-control/as-button-group.tsx
@@ -62,7 +62,7 @@ function UnforwardedToggleGroupControlAsButtonGroup(
 				isBlock: ! isAdaptiveWidth,
 				isDeselectable: true,
 				size,
-			} as ToggleGroupControlContextProps ),
+			} ) as ToggleGroupControlContextProps,
 		[ baseId, selectedValue, setSelectedValue, isAdaptiveWidth, size ]
 	);
 

--- a/packages/components/src/toggle-group-control/toggle-group-control/as-radio-group.tsx
+++ b/packages/components/src/toggle-group-control/toggle-group-control/as-radio-group.tsx
@@ -78,7 +78,7 @@ function UnforwardedToggleGroupControlAsRadioGroup(
 				size,
 				value: selectedValue,
 				setValue,
-			} as ToggleGroupControlContextProps ),
+			} ) as ToggleGroupControlContextProps,
 		[ baseId, isAdaptiveWidth, size, selectedValue, setValue ]
 	);
 

--- a/packages/components/src/toolbar/toolbar-group/types.ts
+++ b/packages/components/src/toolbar/toolbar-group/types.ts
@@ -72,7 +72,7 @@ export type ToolbarGroupProps = ToolbarGroupPropsBase &
 				 */
 				title: string;
 		  }
-	 );
+	);
 
 export type ToolbarGroupCollapsedProps = DropdownMenuProps;
 

--- a/packages/components/src/ui/context/context-connect.ts
+++ b/packages/components/src/ui/context/context-connect.ts
@@ -18,7 +18,7 @@ import type { WordPressComponentFromProps } from '.';
 
 type AcceptsTwoArgs<
 	F extends ( ...args: any ) => any,
-	ErrorMessage = never
+	ErrorMessage = never,
 > = Parameters< F >[ 'length' ] extends 2 ? {} : ErrorMessage;
 
 type ContextConnectOptions = {
@@ -34,7 +34,7 @@ type ContextConnectOptions = {
  * @return The connected WordPressComponent
  */
 export function contextConnect<
-	C extends ( props: any, ref: ForwardedRef< any > ) => JSX.Element | null
+	C extends ( props: any, ref: ForwardedRef< any > ) => JSX.Element | null,
 >(
 	Component: C &
 		AcceptsTwoArgs<
@@ -66,7 +66,7 @@ export function contextConnectWithoutRef< P >(
 // component wrappers.
 function _contextConnect<
 	C extends ( props: any, ref: ForwardedRef< any > ) => JSX.Element | null,
-	O extends ContextConnectOptions
+	O extends ContextConnectOptions,
 >(
 	Component: C,
 	namespace: string,

--- a/packages/components/src/ui/context/wordpress-component.ts
+++ b/packages/components/src/ui/context/wordpress-component.ts
@@ -10,7 +10,7 @@ export type WordPressComponentProps<
 	/** The HTML element to inherit props from. */
 	T extends React.ElementType,
 	/** Supports polymorphism through the `as` prop. */
-	IsPolymorphic extends boolean = true
+	IsPolymorphic extends boolean = true,
 > = P &
 	// The `children` prop is being explicitly omitted since it is otherwise implicitly added
 	// by `ComponentPropsWithRef`. The context is that components should require the `children`
@@ -26,7 +26,7 @@ export type WordPressComponentProps<
 export type WordPressComponent<
 	T extends React.ElementType,
 	O,
-	IsPolymorphic extends boolean
+	IsPolymorphic extends boolean,
 > = {
 	< TT extends React.ElementType >(
 		props: WordPressComponentProps< O, TT, IsPolymorphic > &
@@ -49,7 +49,7 @@ export type WordPressComponent<
 
 export type WordPressComponentFromProps<
 	Props,
-	ForwardsRef extends boolean = true
+	ForwardsRef extends boolean = true,
 > = Props extends WordPressComponentProps< infer P, infer T, infer I >
 	? WordPressComponent<
 			T,

--- a/packages/components/src/unit-control/index.tsx
+++ b/packages/components/src/unit-control/index.tsx
@@ -76,10 +76,15 @@ function UnforwardedUnitControl(
 			unitsProp
 		);
 		const [ { value: firstUnitValue = '' } = {}, ...rest ] = list;
-		const firstCharacters = rest.reduce( ( carry, { value } ) => {
-			const first = escapeRegExp( value?.substring( 0, 1 ) || '' );
-			return carry.includes( first ) ? carry : `${ carry }|${ first }`;
-		}, escapeRegExp( firstUnitValue.substring( 0, 1 ) ) );
+		const firstCharacters = rest.reduce(
+			( carry, { value } ) => {
+				const first = escapeRegExp( value?.substring( 0, 1 ) || '' );
+				return carry.includes( first )
+					? carry
+					: `${ carry }|${ first }`;
+			},
+			escapeRegExp( firstUnitValue.substring( 0, 1 ) )
+		);
 		return [ list, new RegExp( `^(?:${ firstCharacters })$`, 'i' ) ];
 	}, [ nonNullValueProp, unitProp, unitsProp ] );
 	const [ parsedQuantity, parsedUnit ] = getParsedQuantityAndUnit(

--- a/packages/components/src/unit-control/styles/unit-control-styles.ts
+++ b/packages/components/src/unit-control/styles/unit-control-styles.ts
@@ -82,7 +82,9 @@ const unitSelectSizes = ( { selectSize = 'default' }: SelectProps ) => {
 		default: css`
 			height: 100%;
 			border: 1px solid transparent;
-			transition: box-shadow 0.1s linear, border 0.1s linear;
+			transition:
+				box-shadow 0.1s linear,
+				border 0.1s linear;
 
 			${ rtl( { borderTopLeftRadius: 0, borderBottomLeftRadius: 0 } )() }
 

--- a/packages/components/src/unit-control/test/utils.ts
+++ b/packages/components/src/unit-control/test/utils.ts
@@ -246,9 +246,9 @@ describe( 'UnitControl utils', () => {
 
 	describe( 'parseQuantityAndUnitFromRawValue', () => {
 		const cases: [
-			number | string | undefined,
-			number | undefined,
-			string | undefined
+			number | string | undefined ,
+			number | undefined ,
+			string | undefined ,
 		][] = [
 			// Test undefined.
 			[ undefined, undefined, undefined ],

--- a/packages/components/src/unit-control/test/utils.ts
+++ b/packages/components/src/unit-control/test/utils.ts
@@ -246,9 +246,9 @@ describe( 'UnitControl utils', () => {
 
 	describe( 'parseQuantityAndUnitFromRawValue', () => {
 		const cases: [
-			number | string | undefined ,
-			number | undefined ,
-			string | undefined ,
+			number | string | undefined,
+			number | undefined,
+			string | undefined,
 		][] = [
 			// Test undefined.
 			[ undefined, undefined, undefined ],

--- a/packages/components/src/unit-control/utils.ts
+++ b/packages/components/src/unit-control/utils.ts
@@ -141,7 +141,7 @@ export function getParsedQuantityAndUnit(
 	rawValue?: string | number,
 	fallbackUnit?: string,
 	allowedUnits?: WPUnitControlUnit[]
-): [ number | undefined, string | undefined ] {
+): [ number | undefined , string | undefined  ] {
 	const initialValue = fallbackUnit
 		? `${ rawValue ?? '' }${ fallbackUnit }`
 		: rawValue;
@@ -177,7 +177,7 @@ export function hasUnits(
 export function parseQuantityAndUnitFromRawValue(
 	rawValue?: string | number,
 	allowedUnits: WPUnitControlUnit[] = ALL_CSS_UNITS
-): [ number | undefined, string | undefined ] {
+): [ number | undefined , string | undefined  ] {
 	let trimmedValue;
 	let quantityToReturn;
 
@@ -223,7 +223,7 @@ export function getValidParsedQuantityAndUnit(
 	allowedUnits?: WPUnitControlUnit[],
 	fallbackQuantity?: number,
 	fallbackUnit?: string
-): [ number | undefined, string | undefined ] {
+): [ number | undefined , string | undefined  ] {
 	const [ parsedQuantity, parsedUnit ] = parseQuantityAndUnitFromRawValue(
 		rawValue,
 		allowedUnits

--- a/packages/components/src/unit-control/utils.ts
+++ b/packages/components/src/unit-control/utils.ts
@@ -141,7 +141,7 @@ export function getParsedQuantityAndUnit(
 	rawValue?: string | number,
 	fallbackUnit?: string,
 	allowedUnits?: WPUnitControlUnit[]
-): [ number | undefined , string | undefined  ] {
+): [ number | undefined, string | undefined ] {
 	const initialValue = fallbackUnit
 		? `${ rawValue ?? '' }${ fallbackUnit }`
 		: rawValue;
@@ -177,7 +177,7 @@ export function hasUnits(
 export function parseQuantityAndUnitFromRawValue(
 	rawValue?: string | number,
 	allowedUnits: WPUnitControlUnit[] = ALL_CSS_UNITS
-): [ number | undefined , string | undefined  ] {
+): [ number | undefined, string | undefined ] {
 	let trimmedValue;
 	let quantityToReturn;
 
@@ -223,7 +223,7 @@ export function getValidParsedQuantityAndUnit(
 	allowedUnits?: WPUnitControlUnit[],
 	fallbackQuantity?: number,
 	fallbackUnit?: string
-): [ number | undefined , string | undefined  ] {
+): [ number | undefined, string | undefined ] {
 	const [ parsedQuantity, parsedUnit ] = parseQuantityAndUnitFromRawValue(
 		rawValue,
 		allowedUnits

--- a/packages/components/src/utils/unit-values.ts
+++ b/packages/components/src/utils/unit-values.ts
@@ -10,7 +10,7 @@ const UNITED_VALUE_REGEX =
  */
 export function parseCSSUnitValue(
 	toParse: string
-): [ number | undefined, string | undefined ] {
+): [ number | undefined , string | undefined  ] {
 	const value = toParse.trim();
 
 	const matched = value.match( UNITED_VALUE_REGEX );

--- a/packages/components/src/utils/unit-values.ts
+++ b/packages/components/src/utils/unit-values.ts
@@ -10,7 +10,7 @@ const UNITED_VALUE_REGEX =
  */
 export function parseCSSUnitValue(
 	toParse: string
-): [ number | undefined , string | undefined  ] {
+): [ number | undefined, string | undefined ] {
 	const value = toParse.trim();
 
 	const matched = value.match( UNITED_VALUE_REGEX );

--- a/packages/components/src/utils/use-deprecated-props.ts
+++ b/packages/components/src/utils/use-deprecated-props.ts
@@ -7,7 +7,7 @@ export function useDeprecated36pxDefaultSizeProp<
 	P extends Record< string, any > & {
 		__next36pxDefaultSize?: boolean;
 		__next40pxDefaultSize?: boolean;
-	}
+	},
 >(
 	props: P,
 	/** The component identifier in dot notation, e.g. `wp.components.ComponentName`. */

--- a/packages/compose/README.md
+++ b/packages/compose/README.md
@@ -116,9 +116,7 @@ _Usage_
 ```ts
 type Props = { foo: string };
 const Component = ( props: Props ) => <div>{ props.foo }</div>;
-const ConditionalComponent = ifCondition(
-	( props: Props ) => props.foo.length !== 0
-)( Component );
+const ConditionalComponent = ifCondition( ( props: Props ) => props.foo.length !== 0 )( Component );
 <ConditionalComponent foo="" />; // => null
 <ConditionalComponent foo="bar" />; // => <div>bar</div>;
 ```

--- a/packages/compose/src/higher-order/pure/index.tsx
+++ b/packages/compose/src/higher-order/pure/index.tsx
@@ -41,7 +41,6 @@ const pure = createHigherOrderComponent( function < Props extends {} >(
 			return <WrappedComponent { ...this.props } />;
 		}
 	};
-},
-'pure' );
+}, 'pure' );
 
 export default pure;

--- a/packages/compose/src/hooks/use-dialog/index.ts
+++ b/packages/compose/src/hooks/use-dialog/index.ts
@@ -34,7 +34,7 @@ type DialogOptions = {
 
 type useDialogReturn = [
 	RefCallback< HTMLElement >,
-	ReturnType< typeof useFocusOutside > & Pick< HTMLElement, 'tabIndex' >
+	ReturnType< typeof useFocusOutside > & Pick< HTMLElement, 'tabIndex' >,
 ];
 
 /**

--- a/packages/compose/src/hooks/use-resize-observer/index.tsx
+++ b/packages/compose/src/hooks/use-resize-observer/index.tsx
@@ -336,7 +336,7 @@ function useResizeObserver< T extends HTMLElement >(
  */
 export default function useResizeAware(): [
 	WPElement,
-	{ width: number | null; height: number | null }
+	{ width: number | null; height: number | null },
 ] {
 	const { ref, width, height } = useResizeObserver();
 	const sizes = useMemo( () => {

--- a/packages/compose/src/utils/create-higher-order-component/index.ts
+++ b/packages/compose/src/utils/create-higher-order-component/index.ts
@@ -23,7 +23,7 @@ export type WithInjectedProps< C, I > = ComponentType<
  */
 export function createHigherOrderComponent<
 	TInner extends ComponentType< any >,
-	TOuter extends ComponentType< any >
+	TOuter extends ComponentType< any >,
 >( mapComponent: ( Inner: TInner ) => TOuter, modifierName: string ) {
 	return ( Inner: TInner ) => {
 		const Outer = mapComponent( Inner );

--- a/packages/core-data/src/entity-types/helpers.ts
+++ b/packages/core-data/src/entity-types/helpers.ts
@@ -64,7 +64,7 @@ export type Context = 'view' | 'edit' | 'embed';
 export type ContextualField<
 	FieldType,
 	AvailableInContexts extends Context,
-	C extends Context
+	C extends Context,
 > = AvailableInContexts extends C ? FieldType : never;
 
 /**
@@ -93,7 +93,7 @@ export type OmitNevers<
 			: T[ K ] extends Record< string, unknown >
 			? OmitNevers< T[ K ] >
 			: T[ K ];
-	}
+	},
 > = Pick<
 	Nevers,
 	{

--- a/packages/core-data/src/hooks/use-resource-permissions.ts
+++ b/packages/core-data/src/hooks/use-resource-permissions.ts
@@ -38,7 +38,7 @@ type ResourcePermissionsResolution< IdType > = [
 	HasResolved,
 	ResolutionDetails &
 		GlobalResourcePermissionsResolution &
-		( IdType extends void ? SpecificResourcePermissionsResolution : {} )
+		( IdType extends void ? SpecificResourcePermissionsResolution : {} ),
 ];
 
 /**

--- a/packages/core-data/src/selectors.ts
+++ b/packages/core-data/src/selectors.ts
@@ -278,7 +278,7 @@ export interface GetEntityRecord {
 	<
 		EntityRecord extends
 			| ET.EntityRecord< any >
-			| Partial< ET.EntityRecord< any > >
+			| Partial< ET.EntityRecord< any > >,
 	>(
 		state: State,
 		kind: string,
@@ -290,7 +290,7 @@ export interface GetEntityRecord {
 	CurriedSignature: <
 		EntityRecord extends
 			| ET.EntityRecord< any >
-			| Partial< ET.EntityRecord< any > >
+			| Partial< ET.EntityRecord< any > >,
 	>(
 		kind: string,
 		name: string,
@@ -317,7 +317,7 @@ export const getEntityRecord = createSelector(
 	( <
 		EntityRecord extends
 			| ET.EntityRecord< any >
-			| Partial< ET.EntityRecord< any > >
+			| Partial< ET.EntityRecord< any > >,
 	>(
 		state: State,
 		kind: string,
@@ -381,7 +381,7 @@ export const getEntityRecord = createSelector(
  * @return Record.
  */
 export function __experimentalGetEntityRecordNoResolver<
-	EntityRecord extends ET.EntityRecord< any >
+	EntityRecord extends ET.EntityRecord< any >,
 >( state: State, kind: string, name: string, key: EntityRecordKey ) {
 	return getEntityRecord< EntityRecord >( state, kind, name, key );
 }
@@ -478,7 +478,7 @@ export interface GetEntityRecords {
 	<
 		EntityRecord extends
 			| ET.EntityRecord< any >
-			| Partial< ET.EntityRecord< any > >
+			| Partial< ET.EntityRecord< any > >,
 	>(
 		state: State,
 		kind: string,
@@ -489,7 +489,7 @@ export interface GetEntityRecords {
 	CurriedSignature: <
 		EntityRecord extends
 			| ET.EntityRecord< any >
-			| Partial< ET.EntityRecord< any > >
+			| Partial< ET.EntityRecord< any > >,
 	>(
 		kind: string,
 		name: string,
@@ -511,7 +511,7 @@ export interface GetEntityRecords {
 export const getEntityRecords = ( <
 	EntityRecord extends
 		| ET.EntityRecord< any >
-		| Partial< ET.EntityRecord< any > >
+		| Partial< ET.EntityRecord< any > >,
 >(
 	state: State,
 	kind: string,

--- a/packages/create-block/lib/index.js
+++ b/packages/create-block/lib/index.js
@@ -185,9 +185,8 @@ program
 										],
 										variant
 									).filter( filterOptionsProvided );
-									const result = await inquirer.prompt(
-										pluginPrompts
-									);
+									const result =
+										await inquirer.prompt( pluginPrompts );
 									return result;
 								} )
 						: {};

--- a/packages/create-block/lib/templates.js
+++ b/packages/create-block/lib/templates.js
@@ -202,9 +202,11 @@ const getPluginTemplate = async ( templateName ) => {
 
 		const { name } = npmPackageArg( templateName );
 		return await configToTemplate(
-			require( require.resolve( name, {
-				paths: [ tempCwd ],
-			} ) )
+			require(
+				require.resolve( name, {
+					paths: [ tempCwd ],
+				} )
+			)
 		);
 	} catch ( error ) {
 		if ( error instanceof CLIError ) {

--- a/packages/data/src/components/with-registry/index.js
+++ b/packages/data/src/components/with-registry/index.js
@@ -17,14 +17,13 @@ import { RegistryConsumer } from '../registry-provider';
  * @return {WPComponent} Enhanced component.
  */
 const withRegistry = createHigherOrderComponent(
-	( OriginalComponent ) => ( props ) =>
-		(
-			<RegistryConsumer>
-				{ ( registry ) => (
-					<OriginalComponent { ...props } registry={ registry } />
-				) }
-			</RegistryConsumer>
-		),
+	( OriginalComponent ) => ( props ) => (
+		<RegistryConsumer>
+			{ ( registry ) => (
+				<OriginalComponent { ...props } registry={ registry } />
+			) }
+		</RegistryConsumer>
+	),
 	'withRegistry'
 );
 

--- a/packages/data/src/dispatch.ts
+++ b/packages/data/src/dispatch.ts
@@ -24,7 +24,7 @@ import defaultRegistry from './default-registry';
  * @return Object containing the action creators.
  */
 export function dispatch<
-	StoreNameOrDescriptor extends StoreDescriptor< AnyConfig > | string
+	StoreNameOrDescriptor extends StoreDescriptor< AnyConfig > | string,
 >(
 	storeNameOrDescriptor: StoreNameOrDescriptor
 ): DispatchReturn< StoreNameOrDescriptor > {

--- a/packages/data/src/types.ts
+++ b/packages/data/src/types.ts
@@ -33,7 +33,7 @@ export interface StoreDescriptor< Config extends AnyConfig > {
 export interface ReduxStoreConfig<
 	State,
 	ActionCreators extends MapOf< ActionCreator >,
-	Selectors
+	Selectors,
 > {
 	initialState?: State;
 	reducer: ( state: any, action: any ) => any;
@@ -182,7 +182,7 @@ export type ActionCreatorsOf< Config extends AnyConfig > =
 // return type of each action creator to account for internal registry details --
 // for example, dispatched actions are wrapped with a Promise.
 export type PromisifiedActionCreators<
-	ActionCreators extends MapOf< ActionCreator >
+	ActionCreators extends MapOf< ActionCreator >,
 > = {
 	[ Action in keyof ActionCreators ]: PromisifyActionCreator<
 		ActionCreators[ Action ]

--- a/packages/e2e-test-utils/src/inserter.js
+++ b/packages/e2e-test-utils/src/inserter.js
@@ -238,7 +238,7 @@ export async function insertFromGlobalInserter( category, searchTerm ) {
 				await page.$x(
 					`//*[@role='option' and contains(., '${ searchTerm }')]`
 				)
-			 )[ 0 ];
+			)[ 0 ];
 		} catch ( error ) {
 			// noop
 		}

--- a/packages/e2e-tests/specs/editor/plugins/annotations.test.js
+++ b/packages/e2e-tests/specs/editor/plugins/annotations.test.js
@@ -50,7 +50,7 @@ describe( 'Annotations', () => {
 		// Click add annotation button.
 		const addAnnotationButton = (
 			await page.$x( "//button[contains(text(), 'Add annotation')]" )
-		 )[ 0 ];
+		)[ 0 ];
 		await addAnnotationButton.click();
 		await canvas().evaluate( () =>
 			document.querySelector( '.wp-block-paragraph' ).focus()
@@ -66,7 +66,7 @@ describe( 'Annotations', () => {
 		// Click remove annotations button.
 		const addAnnotationButton = (
 			await page.$x( "//button[contains(text(), 'Remove annotations')]" )
-		 )[ 0 ];
+		)[ 0 ];
 		await addAnnotationButton.click();
 		await canvas().evaluate( () =>
 			document.querySelector( '[contenteditable]' ).focus()

--- a/packages/e2e-tests/specs/editor/plugins/container-blocks.test.js
+++ b/packages/e2e-tests/specs/editor/plugins/container-blocks.test.js
@@ -121,7 +121,7 @@ describe( 'Container block without paragraph support', () => {
 		// Insert an image block.
 		const insertButton = (
 			await page.$x( `//button//span[contains(text(), 'Image')]` )
-		 )[ 0 ];
+		)[ 0 ];
 		await insertButton.click();
 
 		// Check the inserted content.

--- a/packages/e2e-tests/specs/editor/plugins/custom-taxonomies.test.js
+++ b/packages/e2e-tests/specs/editor/plugins/custom-taxonomies.test.js
@@ -32,7 +32,7 @@ describe( 'Custom Taxonomies labels are used', () => {
 		// Get the classes from the panel.
 		const buttonClassName = await (
 			await openButton.getProperty( 'className' )
-		 ).jsonValue();
+		).jsonValue();
 
 		// Open the panel if needed.
 		if ( -1 === buttonClassName.indexOf( 'is-opened' ) ) {

--- a/packages/e2e-tests/specs/editor/plugins/inner-blocks-render-appender.test.js
+++ b/packages/e2e-tests/specs/editor/plugins/inner-blocks-render-appender.test.js
@@ -58,7 +58,7 @@ describe( 'RenderAppender prop of InnerBlocks', () => {
 		const inserterPopover = await page.$( INSERTER_RESULTS_SELECTOR );
 		const quoteButton = (
 			await inserterPopover.$x( QUOTE_INSERT_BUTTON_SELECTOR )
-		 )[ 0 ];
+		)[ 0 ];
 
 		// Insert a quote block.
 		await quoteButton.click();
@@ -93,7 +93,7 @@ describe( 'RenderAppender prop of InnerBlocks', () => {
 		const inserterPopover = await page.$( INSERTER_RESULTS_SELECTOR );
 		const quoteButton = (
 			await inserterPopover.$x( QUOTE_INSERT_BUTTON_SELECTOR )
-		 )[ 0 ];
+		)[ 0 ];
 
 		// Insert a quote block.
 		await quoteButton.click();

--- a/packages/e2e-tests/specs/editor/plugins/meta-boxes.test.js
+++ b/packages/e2e-tests/specs/editor/plugins/meta-boxes.test.js
@@ -103,9 +103,8 @@ describe( 'Meta boxes', () => {
 
 		// Open the excerpt panel.
 		await openDocumentSettingsSidebar();
-		const excerptButton = await findSidebarPanelToggleButtonWithTitle(
-			'Excerpt'
-		);
+		const excerptButton =
+			await findSidebarPanelToggleButtonWithTitle( 'Excerpt' );
 		if ( excerptButton ) {
 			await excerptButton.click( 'button' );
 		}

--- a/packages/e2e-tests/specs/editor/various/change-detection.test.js
+++ b/packages/e2e-tests/specs/editor/various/change-detection.test.js
@@ -102,7 +102,7 @@ describe( 'Change detection', () => {
 
 		const postPendingReviewButton = (
 			await page.$x( "//label[contains(text(), 'Pending review')]" )
-		 )[ 0 ];
+		)[ 0 ];
 		await postPendingReviewButton.click( 'button' );
 
 		// Force autosave to occur immediately.

--- a/packages/e2e-tests/specs/editor/various/inserting-blocks.test.js
+++ b/packages/e2e-tests/specs/editor/various/inserting-blocks.test.js
@@ -259,7 +259,7 @@ describe( 'Inserting blocks', () => {
 
 		const headingButton = (
 			await page.$x( `//button//span[contains(text(), 'Heading')]` )
-		 )[ 0 ];
+		)[ 0 ];
 		// Hover over the block should show the blue line indicator.
 		await headingButton.hover();
 
@@ -354,7 +354,7 @@ describe( 'Inserting blocks', () => {
 		await openGlobalBlockInserter();
 		const paragraphButton = (
 			await page.$x( `//button//span[contains(text(), 'Paragraph')]` )
-		 )[ 0 ];
+		)[ 0 ];
 		await paragraphButton.hover();
 		const preview = await page.waitForSelector(
 			'.block-editor-inserter__preview',

--- a/packages/e2e-tests/specs/site-editor/multi-entity-saving.test.js
+++ b/packages/e2e-tests/specs/site-editor/multi-entity-saving.test.js
@@ -77,9 +77,8 @@ describe( 'Multi-entity save flow', () => {
 
 		// Reusable assertions inside Post editor.
 		const assertMultiSaveEnabled = async () => {
-			const multiSaveButton = await page.waitForSelector(
-				multiSaveSelector
-			);
+			const multiSaveButton =
+				await page.waitForSelector( multiSaveSelector );
 			expect( multiSaveButton ).not.toBeNull();
 		};
 		const assertMultiSaveDisabled = async () => {

--- a/packages/e2e-tests/specs/widgets/editing-widgets.test.js
+++ b/packages/e2e-tests/specs/widgets/editing-widgets.test.js
@@ -388,9 +388,8 @@ describe( 'Widgets screen', () => {
 				name: 'Block: Widget Area',
 			} );
 			await firstWidgetArea.focus();
-			const marqueeBlock = await getBlockInGlobalInserter(
-				'Marquee Greeting'
-			);
+			const marqueeBlock =
+				await getBlockInGlobalInserter( 'Marquee Greeting' );
 			await marqueeBlock.click();
 			await page.waitForFunction(
 				( expectedMarquees ) => {
@@ -721,9 +720,8 @@ describe( 'Widgets screen', () => {
 		const [ firstWidgetArea, secondWidgetArea ] = widgetAreas;
 
 		// Insert a paragraph it should be in the first widget area.
-		const inserterParagraphBlock = await getBlockInGlobalInserter(
-			'Paragraph'
-		);
+		const inserterParagraphBlock =
+			await getBlockInGlobalInserter( 'Paragraph' );
 		await inserterParagraphBlock.hover();
 		await inserterParagraphBlock.click();
 		const addedParagraphBlockInFirstWidgetArea = await find(

--- a/packages/edit-site/src/store/actions.js
+++ b/packages/edit-site/src/store/actions.js
@@ -285,7 +285,7 @@ export const setPage =
 						.getEntityRecords( 'postType', 'wp_template', {
 							per_page: -1,
 						} )
-				 )?.find( ( { slug } ) => slug === currentTemplateSlug );
+				)?.find( ( { slug } ) => slug === currentTemplateSlug );
 				if ( currentTemplate ) {
 					template = currentTemplate;
 				} else {

--- a/packages/env/lib/download-sources.js
+++ b/packages/env/lib/download-sources.js
@@ -176,7 +176,7 @@ async function downloadZipSource( source, { onProgress, spinner, debug } ) {
 			rimraf( source.path ),
 			fs.promises.readdir( tempDir ),
 		] )
-	 )[ 2 ];
+	)[ 2 ];
 
 	/**
 	 * The plugin container is the extracted directory which is the direct parent

--- a/packages/eslint-plugin/CHANGELOG.md
+++ b/packages/eslint-plugin/CHANGELOG.md
@@ -7,9 +7,10 @@
 -   The bundled `@typescript-eslint/parser` and `@typescript-eslint/eslint-plugin` dependencies has been updated from requiring ^5.62.0 to requiring ^6.4.1 ([#53975](https://github.com/WordPress/gutenberg/pull/53975)):
     -   Removes the deprecated `@typescript-eslint/no-duplicate-imports` rule in favor of `import/no-duplicates`.
 
-### Enhancement
+### Enhancements
 
 -   Added a new `test-playwright` ruleset using [`eslint-plugin-playwright`](https://www.npmjs.com/package/eslint-plugin-playwright).
+-   The bundled `eslint-plugin-prettier` dependency has been updated from requiring `^3.3.0` to requiring `^5.0.0` ([#54539](https://github.com/WordPress/gutenberg/pull/54539)).
 
 ## 15.1.0 (2023-08-31)
 

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -43,7 +43,7 @@
 		"eslint-plugin-jsdoc": "^46.4.6",
 		"eslint-plugin-jsx-a11y": "^6.5.1",
 		"eslint-plugin-playwright": "^0.15.3",
-		"eslint-plugin-prettier": "^3.3.0",
+		"eslint-plugin-prettier": "^5.0.0",
 		"eslint-plugin-react": "^7.27.0",
 		"eslint-plugin-react-hooks": "^4.3.0",
 		"globals": "^13.12.0",

--- a/packages/lazy-import/README.md
+++ b/packages/lazy-import/README.md
@@ -55,7 +55,7 @@ function onInstall() {
 lazyImport( 'fbjs@^1.0.0', {
 	localPath: './lib/shallowEqual',
 	onInstall,
-} ).then(/* ... */);
+} ).then( /* ... */ );
 ```
 
 Note that `lazyImport` can throw an error when offline and unable to install the dependency using NPM. You may want to anticipate this and provide remediation steps for a failed install, such as logging a warning messsage:

--- a/packages/react-native-editor/__device-tests__/helpers/utils.js
+++ b/packages/react-native-editor/__device-tests__/helpers/utils.js
@@ -526,9 +526,8 @@ const dragAndDropAfterElement = async ( driver, element, nextElement ) => {
 
 const toggleHtmlMode = async ( driver, toggleOn ) => {
 	if ( isAndroid() ) {
-		const moreOptionsButton = await driver.elementByAccessibilityId(
-			'More options'
-		);
+		const moreOptionsButton =
+			await driver.elementByAccessibilityId( 'More options' );
 		await moreOptionsButton.click();
 
 		const showHtmlButtonXpath =
@@ -536,9 +535,8 @@ const toggleHtmlMode = async ( driver, toggleOn ) => {
 
 		await clickIfClickable( driver, showHtmlButtonXpath );
 	} else if ( toggleOn ) {
-		const moreOptionsButton = await driver.elementByAccessibilityId(
-			'editor-menu-button'
-		);
+		const moreOptionsButton =
+			await driver.elementByAccessibilityId( 'editor-menu-button' );
 		await moreOptionsButton.click();
 
 		await clickIfClickable(
@@ -548,9 +546,8 @@ const toggleHtmlMode = async ( driver, toggleOn ) => {
 	} else {
 		// This is to wait for the clipboard paste notification to disappear, currently it overlaps with the menu button
 		await driver.sleep( 3000 );
-		const moreOptionsButton = await driver.elementByAccessibilityId(
-			'editor-menu-button'
-		);
+		const moreOptionsButton =
+			await driver.elementByAccessibilityId( 'editor-menu-button' );
 		await moreOptionsButton.click();
 		await clickIfClickable(
 			driver,

--- a/packages/react-native-editor/__device-tests__/pages/editor-page.js
+++ b/packages/react-native-editor/__device-tests__/pages/editor-page.js
@@ -57,9 +57,8 @@ class EditorPage {
 		await launchApp( this.driver, { initialData } );
 
 		// Stores initial values from the editor for different helpers.
-		const addButton = await this.driver.elementsByAccessibilityId(
-			ADD_BLOCK_ID
-		);
+		const addButton =
+			await this.driver.elementsByAccessibilityId( ADD_BLOCK_ID );
 
 		if ( addButton.length !== 0 ) {
 			this.initialValues.addButtonLocation =
@@ -74,9 +73,8 @@ class EditorPage {
 	}
 
 	async getAddBlockButton() {
-		const elements = await this.driver.elementsByAccessibilityId(
-			ADD_BLOCK_ID
-		);
+		const elements =
+			await this.driver.elementsByAccessibilityId( ADD_BLOCK_ID );
 		return elements[ 0 ];
 	}
 
@@ -197,9 +195,8 @@ class EditorPage {
 			await swipeDown( this.driver );
 		}
 
-		const elements = await this.driver.elementsByAccessibilityId(
-			titleElement
-		);
+		const elements =
+			await this.driver.elementsByAccessibilityId( titleElement );
 
 		if (
 			elements.length === 0 ||
@@ -530,9 +527,8 @@ class EditorPage {
 	}
 
 	async clickToolBarButton( buttonName ) {
-		const toolBarButton = await this.driver.elementByAccessibilityId(
-			buttonName
-		);
+		const toolBarButton =
+			await this.driver.elementByAccessibilityId( buttonName );
 		await toolBarButton.click();
 	}
 
@@ -540,9 +536,8 @@ class EditorPage {
 		let navigateUpElements = [];
 		do {
 			await this.driver.sleep( 2000 );
-			navigateUpElements = await this.driver.elementsByAccessibilityId(
-				'Navigate Up'
-			);
+			navigateUpElements =
+				await this.driver.elementsByAccessibilityId( 'Navigate Up' );
 			if ( navigateUpElements.length > 0 ) {
 				await navigateUpElements[ 0 ].click();
 			}
@@ -784,9 +779,8 @@ class EditorPage {
 			this.driver,
 			'//XCUIElementTypeOther[@name="Media Add image or video"]'
 		);
-		const addMediaButton = await mediaSection.elementByAccessibilityId(
-			'Add image or video'
-		);
+		const addMediaButton =
+			await mediaSection.elementByAccessibilityId( 'Add image or video' );
 		await addMediaButton.click();
 	}
 
@@ -810,9 +804,8 @@ class EditorPage {
 			this.accessibilityIdKey
 		);
 		const blockLocator = `//*[@${ this.accessibilityIdXPathAttrib }="${ accessibilityId }"]//XCUIElementTypeButton[@name="Image block. Empty"]`;
-		const imageBlockInnerElement = await this.driver.elementByXPath(
-			blockLocator
-		);
+		const imageBlockInnerElement =
+			await this.driver.elementByXPath( blockLocator );
 		await imageBlockInnerElement.click();
 	}
 

--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -2,9 +2,10 @@
 
 ## Unreleased
 
-### Enhancement
+### Enhancements
 
 -   Added support for `test-playwright` script ([#53108](https://github.com/WordPress/gutenberg/pull/53108)).
+-   The bundled `wp-prettier` dependency has been upgraded from `2.8.5` to `3.0.3` ([#54539](https://github.com/WordPress/gutenberg/pull/54539)).
 
 ### Bug Fix
 

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -75,7 +75,7 @@
 		"playwright-core": "1.32.0",
 		"postcss": "^8.4.5",
 		"postcss-loader": "^6.2.1",
-		"prettier": "npm:wp-prettier@2.8.5",
+		"prettier": "npm:wp-prettier@3.0.3-beta-3",
 		"puppeteer-core": "^13.2.0",
 		"react-refresh": "^0.10.0",
 		"read-pkg-up": "^7.0.1",

--- a/test/e2e/specs/editor/blocks/cover.spec.js
+++ b/test/e2e/specs/editor/blocks/cover.spec.js
@@ -40,9 +40,8 @@ test.describe( 'Cover', () => {
 		await expect( blackColorSwatch ).toBeVisible();
 
 		// Get the RGB value of Black.
-		const [ blackRGB ] = await coverBlockUtils.getBackgroundColorAndOpacity(
-			coverBlock
-		);
+		const [ blackRGB ] =
+			await coverBlockUtils.getBackgroundColorAndOpacity( coverBlock );
 
 		// Create the block by clicking selected color button.
 		await blackColorSwatch.click();

--- a/test/e2e/specs/editor/blocks/image.spec.js
+++ b/test/e2e/specs/editor/blocks/image.spec.js
@@ -853,9 +853,8 @@ test.describe.skip( 'Image - interactivity', () => {
 					'.entry-content figure img'
 				);
 
-				const wpContext = await contentFigure.getAttribute(
-					'data-wp-context'
-				);
+				const wpContext =
+					await contentFigure.getAttribute( 'data-wp-context' );
 
 				const imageUploadedSrc =
 					JSON.parse( wpContext ).core.image.imageUploadedSrc;

--- a/test/e2e/specs/editor/blocks/navigation-list-view.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation-list-view.spec.js
@@ -140,9 +140,8 @@ test.describe( 'Navigation block - List view editing', () => {
 		requestUtils,
 		linkControl,
 	} ) => {
-		const { id: menuId } = await requestUtils.createNavigationMenu(
-			navMenuBlocksFixture
-		);
+		const { id: menuId } =
+			await requestUtils.createNavigationMenu( navMenuBlocksFixture );
 
 		// Insert x2 blocks as a stress test as several bugs have been found with inserting
 		// blocks into the navigation block when there are multiple blocks referencing the
@@ -213,9 +212,8 @@ test.describe( 'Navigation block - List view editing', () => {
 		const firstResult = await linkControl.getNthSearchResult( 0 );
 
 		// Grab the text from the first result so we can check (later on) that it was inserted.
-		const firstResultText = await linkControl.getSearchResultText(
-			firstResult
-		);
+		const firstResultText =
+			await linkControl.getSearchResultText( firstResult );
 
 		// Create the link.
 		await firstResult.click();
@@ -454,9 +452,8 @@ test.describe( 'Navigation block - List view editing', () => {
 		// inserted block even if the block had been deselected and then reselected.
 		// See: https://github.com/WordPress/gutenberg/issues/50601
 
-		const { id: menuId } = await requestUtils.createNavigationMenu(
-			navMenuBlocksFixture
-		);
+		const { id: menuId } =
+			await requestUtils.createNavigationMenu( navMenuBlocksFixture );
 
 		// Insert x2 blocks as a stress test as several bugs have been found with inserting
 		// blocks into the navigation block when there are multiple blocks referencing the

--- a/test/e2e/specs/editor/blocks/paragraph.spec.js
+++ b/test/e2e/specs/editor/blocks/paragraph.spec.js
@@ -78,9 +78,8 @@ test.describe( 'Paragraph', () => {
 				testImageName
 			);
 
-			const { dragOver, drop } = await pageUtils.dragFiles(
-				testImagePath
-			);
+			const { dragOver, drop } =
+				await pageUtils.dragFiles( testImagePath );
 
 			await dragOver(
 				editor.canvas.locator( '[data-type="core/paragraph"]' )

--- a/test/e2e/specs/editor/various/draggable-blocks.spec.js
+++ b/test/e2e/specs/editor/various/draggable-blocks.spec.js
@@ -394,9 +394,8 @@ test.describe( 'Draggable block', () => {
 		);
 
 		{
-			const { dragOver, drop } = await pageUtils.dragFiles(
-				testImagePath
-			);
+			const { dragOver, drop } =
+				await pageUtils.dragFiles( testImagePath );
 
 			const rowBlock = editor.canvas.getByRole( 'document', {
 				name: 'Block: Row',
@@ -434,9 +433,8 @@ test.describe( 'Draggable block', () => {
 		}
 
 		{
-			const { dragOver, drop } = await pageUtils.dragFiles(
-				testImagePath
-			);
+			const { dragOver, drop } =
+				await pageUtils.dragFiles( testImagePath );
 
 			const columnAppender = editor.canvas
 				.getByRole( 'document', {

--- a/test/e2e/specs/interactivity/directive-bind.spec.ts
+++ b/test/e2e/specs/interactivity/directive-bind.spec.ts
@@ -126,7 +126,7 @@ test.describe( 'data-wp-bind', () => {
 					 * Value that the HTMLElement instance property should
 					 * contain after hydration.
 					 */
-					entityPropValue: any
+					entityPropValue: any,
 				]
 			>;
 		};

--- a/test/e2e/specs/widgets/customizing-widgets.spec.js
+++ b/test/e2e/specs/widgets/customizing-widgets.spec.js
@@ -352,9 +352,8 @@ test.describe( 'Widgets Customizer', () => {
 		await widgetsCustomizerPage.visitCustomizerPage();
 		await widgetsCustomizerPage.expandWidgetArea( 'Footer #1' );
 
-		const legacyWidgetBlock = await widgetsCustomizerPage.addBlock(
-			'Legacy Widget'
-		);
+		const legacyWidgetBlock =
+			await widgetsCustomizerPage.addBlock( 'Legacy Widget' );
 		await page
 			.locator(
 				'role=combobox[name="Select a legacy widget to display:"i]'
@@ -401,9 +400,8 @@ test.describe( 'Widgets Customizer', () => {
 		await page.click( 'role=menuitem[name=/Delete/]' );
 
 		// Add it back again using the variant.
-		const testWidgetBlock = await widgetsCustomizerPage.addBlock(
-			'Test Widget'
-		);
+		const testWidgetBlock =
+			await widgetsCustomizerPage.addBlock( 'Test Widget' );
 
 		titleInput = testWidgetBlock.locator( 'role=textbox[name="Title:"i]' );
 


### PR DESCRIPTION
Upgrades the `wp-prettier` fork to version 3.0.3.

Most visible formatting changes are:
- fixed bug where parenthesized and broken `( await x )` expression had an extra trailing space
- fixed bug where function params with only a comment (`call( /* none */ )`) didn't have paren spaces
- many function calls now have a trailing comma in argument list where it was previously missing
- assignments (`const x = y;`) are now formatted more nicely, often breaking after the `=`

**How to test:**
Go through the list of the formatting changes and report anything suspicious.