### PR TITLE
Removed unwanted space from the string

### DIFF
--- a/packages/edit-site/src/components/welcome-guide/styles.js
+++ b/packages/edit-site/src/components/welcome-guide/styles.js
@@ -77,7 +77,7 @@ export default function WelcomeGuideStyles() {
 							</h1>
 							<p className="edit-site-welcome-guide__text">
 								{ __(
-									'You can customize your site as much as you like with different colors, typography, and layouts. Or if you prefer, just leave it up to your theme to handle! '
+									'You can customize your site as much as you like with different colors, typography, and layouts. Or if you prefer, just leave it up to your theme to handle!'
 								) }
 							</p>
 						</>
@@ -117,7 +117,7 @@ export default function WelcomeGuideStyles() {
 							</h1>
 							<p className="edit-site-welcome-guide__text">
 								{ __(
-									'New to block themes and styling your site? '
+									'New to block themes and styling your site?'
 								) }
 								<ExternalLink
 									href={ __(


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Removed unwanted space in the string

## Why?
Unwanted space at the end of the string shows warning at translation.

## How?
Removed unwanted space in the string

## Testing Instructions
Text correction only

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast 

<img width="885" alt="Screenshot 2023-09-18 at 3 13 59 PM" src="https://github.com/WordPress/gutenberg/assets/459367/14be77e1-e2fe-4540-b5d0-7f2563a259a4">

<img width="883" alt="Screenshot 2023-09-18 at 3 14 53 PM" src="https://github.com/WordPress/gutenberg/assets/459367/064c332a-e587-4649-a009-29f37c5c8cbf">
