### PR TITLE
Use gray color on link control advanced toggle

### DIFF
--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -439,6 +439,10 @@ $preview-image-height: 140px;
 		padding-left: 0;
 		gap: 0;
 
+		&[aria-expanded="true"] {
+			color: $gray-900;
+		}
+
 		// Point downwards when open (same as list view expander)
 		&[aria-expanded="true"] svg {
 			visibility: visible;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Maintains the gray color on the `Advanced` toggle when in "expanded" state.

Closes https://github.com/WordPress/gutenberg/issues/53069

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Polish and consistency.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

CSS.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- Make a link in new Post
- Open link and switch to editing the link.
- Toggle open the `Advanced` settings area of the control
- See the text color of the `Advanced` button remains as `$gray-900`


### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<img width="512" alt="Screen Shot 2023-09-18 at 11 22 55" src="https://github.com/WordPress/gutenberg/assets/444434/251593f7-9181-4458-ada0-d0d8d9ddf81d">

