### PR TITLE
Add a documentation page to explain how to implement undo/redo in a third-party editor

### DIFF
--- a/platform-docs/docs/basic-concepts/internationalization.md
+++ b/platform-docs/docs/basic-concepts/internationalization.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 5
+sidebar_position: 6
 ---
 
 # Internationalization

--- a/platform-docs/docs/basic-concepts/rendering.md
+++ b/platform-docs/docs/basic-concepts/rendering.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 6
+sidebar_position: 7
 ---
 
 # Rendering blocks

--- a/platform-docs/docs/basic-concepts/rich-text.md
+++ b/platform-docs/docs/basic-concepts/rich-text.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 4
+sidebar_position: 5
 ---
 
 # RichText and Format Library

--- a/platform-docs/docs/basic-concepts/settings.md
+++ b/platform-docs/docs/basic-concepts/settings.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 3
+sidebar_position: 4
 ---
 
 # Block Editor Settings

--- a/platform-docs/docs/basic-concepts/undo-redo.md
+++ b/platform-docs/docs/basic-concepts/undo-redo.md
@@ -6,7 +6,7 @@ sidebar_position: 3
 
 ## Undo/Redo using `useStateWithHistory`
 
-By default the block editor doesn't enable undo/redo. This is because in most scenarios, the block editor is rendered as part of a larger application that already has its own undo/redo functionality. However, to help you implement undo/redo in your application, the block editor provides a set of APIs that you can use.
+By default, the block editor doesn't enable undo/redo. This is because in most scenarios, the block editor is rendered as part of a larger application that already has its own undo/redo functionality. However, to help you implement undo/redo in your application, the block editor provides a set of APIs that you can use.
 
 The simplest approach is to rely on the `useStateWithHistory` hook provided by the `@wordpress/compose` package. This hook is a wrapper around the `useState` hook that adds undo/redo functionality to the state. 
 
@@ -62,6 +62,6 @@ Notice that in addition to the `blocks` property, the `value` object also tracks
 
 ## Going Further...
 
-Often times, editors allows to track changes accross multiple objects and properties. For instance a basic writing experience might allow editing the title of a post in a normal input, and the content of the post in the block editor. Or your editor might allow edits to related objects like categories, tags... In these cases, you might want to implement undo/redo functionality that can be used to track changes across all of these objects and properties.
+Oftentimes, editors allow to track changes across multiple objects and properties. For instance, a basic writing experience might allow editing the title of a post in a normal input and the content of the post in the block editor. Or your editor might allow edits to related objects like categories, tags, etc... In these cases, you might want to implement undo/redo functionality that can be used to track changes across all of these objects and properties.
 
 The `useStateWithHistory` might not always be the right approach in these situations. Consider checking the `@wordpress/undo-manager` package that offers a lower level undo manager that can be adapted more easily to your specific needs.

--- a/platform-docs/docs/basic-concepts/undo-redo.md
+++ b/platform-docs/docs/basic-concepts/undo-redo.md
@@ -12,7 +12,7 @@ The simplest approach is to rely on the `useStateWithHistory` hook provided by t
 
 First, make sure you add the `@wordpress/compose` package to your dependencies, then use the hook like so:
 
-```js
+```jsx
 import { useStateWithHistory } from '@wordpress/compose';
 import { createRoot, createElement, useState } from "@wordpress/element";
 import {
@@ -36,18 +36,12 @@ function Editor() {
             }
         >
             <div className="undo-redo-toolbar">
-                <Button
-                    onClick={ undo }
-                    disabled={ ! hasUndo }
-                    icon={ undoIcon }
-                    label="Undo"
-                />
-                <Button
-                    onClick={ redo }
-                    disabled={ ! hasRedo }
-                    icon={ redoIcon }
-                    label="Redo"
-                />
+                <button onClick={ undo } disabled={ ! hasUndo }>
+                    Undo
+                </button>
+                <button onClick={ redo } disabled={ ! hasRedo }>
+                    Redo
+                </button>
             </div>
             <BlockCanvas />
         </BlockEditorProvider>

--- a/platform-docs/docs/basic-concepts/undo-redo.md
+++ b/platform-docs/docs/basic-concepts/undo-redo.md
@@ -1,0 +1,73 @@
+---
+sidebar_position: 3
+---
+
+# Undo Redo
+
+## Undo/Redo using `useStateWithHistory`
+
+By default the block editor doesn't enable undo/redo. This is because in most scenarios, the block editor is rendered as part of a larger application that already has its own undo/redo functionality. However, to help you implement undo/redo in your application, the block editor provides a set of APIs that you can use.
+
+The simplest approach is to rely on the `useStateWithHistory` hook provided by the `@wordpress/compose` package. This hook is a wrapper around the `useState` hook that adds undo/redo functionality to the state. 
+
+First, make sure you add the `@wordpress/compose` package to your dependencies, then use the hook like so:
+
+```js
+import { useStateWithHistory } from '@wordpress/compose';
+import { createRoot, createElement, useState } from "@wordpress/element";
+import {
+  BlockEditorProvider,
+  BlockCanvas,
+} from "@wordpress/block-editor";
+
+function Editor() {
+	const { value, setValue, hasUndo, hasRedo, undo, redo } =
+		useStateWithHistory( { blocks: [] } );
+
+	return (
+        <BlockEditorProvider
+            value={ value.blocks }
+            selection={ value.selection }
+            onInput={ ( blocks, { selection } ) =>
+                setValue( { blocks, selection }, true )
+            }
+            onChange={ ( blocks, { selection } ) =>
+                setValue( { blocks, selection }, false )
+            }
+        >
+            <div className="undo-redo-toolbar">
+                <Button
+                    onClick={ undo }
+                    disabled={ ! hasUndo }
+                    icon={ undoIcon }
+                    label="Undo"
+                />
+                <Button
+                    onClick={ redo }
+                    disabled={ ! hasRedo }
+                    icon={ redoIcon }
+                    label="Redo"
+                />
+            </div>
+            <BlockCanvas />
+        </BlockEditorProvider>
+	);
+}
+```
+
+The `useStateWithHistory` hook returns an object with the following properties:
+
+- `value`: the current value of the state.
+- `setValue`: a function that can be used to update the state.
+- `hasUndo`: a boolean indicating whether there are any actions that can be undone.
+- `hasRedo`: a boolean indicating whether there are any actions that can be redone.
+- `undo`: a function that can be used to undo the last action.
+- `redo`: a function that can be used to redo the last action.
+
+Notice that in addition to the `blocks` property, the `value` object also tracks a `selection` property. This property is used to store and control the cursor position within the block editor. This allows the editor to restore the right position when undoing or redoing changes.
+
+## Going Further...
+
+Often times, editors allows to track changes accross multiple objects and properties. For instance a basic writing experience might allow editing the title of a post in a normal input, and the content of the post in the block editor. Or your editor might allow edits to related objects like categories, tags... In these cases, you might want to implement undo/redo functionality that can be used to track changes across all of these objects and properties.
+
+The `useStateWithHistory` might not always be the right approach in these situations. Consider checking the `@wordpress/undo-manager` package that offers a lower level undo manager that can be adapted more easily to your specific needs.


### PR DESCRIPTION
Related #53874 

## What?

Undo/Redo is something most block editor want to integrate. This PR adds a guide to the "platform docs" site that explains how to do so using the APIs we provide.

## Testing Instructions

You can run the documentation website locally by doing:

```
cd platform-docs
npm install && npm start
```