### PR TITLE
Hide ghost top toolbar

### DIFF
--- a/packages/block-editor/src/components/block-tools/block-contextual-toolbar.js
+++ b/packages/block-editor/src/components/block-tools/block-contextual-toolbar.js
@@ -86,6 +86,12 @@ function BlockContextualToolbar( { focusOnMount, isFixed, ...props } ) {
 	const isFullscreen =
 		document.body.classList.contains( 'is-fullscreen-mode' );
 
+	/**
+	 * The following code is a workaround to fix the width of the toolbar
+	 * it should be removed when the toolbar will be rendered inline
+	 * FIXME: remove this layout effect when the toolbar is no longer
+	 * 				absolutely positioned
+	 */
 	useLayoutEffect( () => {
 		// don't do anything if not fixed toolbar
 		if ( ! isFixed || ! blockType ) {
@@ -116,7 +122,6 @@ function BlockContextualToolbar( { focusOnMount, isFixed, ...props } ) {
 		const pinnedItems = document.querySelector(
 			'.edit-post-header__settings, .edit-widgets-header__actions'
 		);
-
 		// get the width of the left header in the site editor
 		const leftHeader = document.querySelector(
 			'.edit-site-header-edit-mode__end'

--- a/packages/block-editor/src/components/block-tools/block-contextual-toolbar.js
+++ b/packages/block-editor/src/components/block-tools/block-contextual-toolbar.js
@@ -94,7 +94,7 @@ function BlockContextualToolbar( { focusOnMount, isFixed, ...props } ) {
 	 */
 	useLayoutEffect( () => {
 		// don't do anything if not fixed toolbar
-		if ( ! isFixed || ! blockType ) {
+		if ( ! isFixed ) {
 			return;
 		}
 
@@ -103,6 +103,11 @@ function BlockContextualToolbar( { focusOnMount, isFixed, ...props } ) {
 		);
 
 		if ( ! blockToolbar ) {
+			return;
+		}
+
+		if ( ! blockType ) {
+			blockToolbar.style.width = 'initial';
 			return;
 		}
 

--- a/packages/edit-site/src/components/block-editor/style.scss
+++ b/packages/edit-site/src/components/block-editor/style.scss
@@ -77,7 +77,7 @@
 			contextual toolbar has been redesigned.
 			See: https://github.com/WordPress/gutenberg/issues/40450
 		*/
-		.block-editor-block-contextual-toolbar {
+		.block-editor-block-contextual-toolbar.is-fixed {
 			display: none;
 		}
 	}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Solves a bug where a white rectangle that appears in the site editor when moving between edit and view mode.

This bug:

https://github.com/WordPress/gutenberg/assets/107534/f982ed50-2964-4388-9221-22567ab659ae




## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

To fix the bug.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Fixes a previously existing rule which was not strong enough, which hides the block toolbar in view mode.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Go to the site editor
2. Click on the preview frame
3. In the top right dot menu select Top toolbar
4. Click some block
5. Click the top left Site hub (usually site logo)
6. In view mode notice there is no white rectangle

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

N/A

## Screenshots or screencast <!-- if applicable -->


https://github.com/WordPress/gutenberg/assets/107534/6fc13782-6745-41f5-85aa-0dc826a108a2


