### PR TITLE
Docs: Add missing callout class.

### DIFF
--- a/docs/getting-started/devenv/get-started-with-wp-now.md
+++ b/docs/getting-started/devenv/get-started-with-wp-now.md
@@ -29,7 +29,7 @@ wp-now start
 
 After the script runs, your default web browser will automatically open the new local site, and you'll be logged in with the username `admin` and the password `password`.
 
-<div class="callout-tip">
+<div class="callout callout-tip">
     If you encounter any errors when running <code>wp-now start</code>, make sure that you are using at least <code>node</code> v18, or v20 if you are using the Blueprint feature.
 </div>
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
The class `callout` was missing from the callout in #54395. This PR adds it. 
 
## Why?
To fix the callout styling.
