### PR TITLE
Font Library: setting wp_font_family custom post type as _builtin and not plublic

### DIFF
--- a/lib/experimental/fonts/font-library/font-library.php
+++ b/lib/experimental/fonts/font-library/font-library.php
@@ -23,7 +23,7 @@ function gutenberg_init_font_library_routes() {
 	// @core-merge: This code will go into Core's `create_initial_post_types()`.
 	$args = array(
 		'public'       => false,
-		'_builtin'     => true,
+		'_builtin'     => true,  /* internal use only. don't use this when registering your own post type. */
 		'label'        => 'Font Library',
 		'show_in_rest' => true,
 	);

--- a/lib/experimental/fonts/font-library/font-library.php
+++ b/lib/experimental/fonts/font-library/font-library.php
@@ -22,7 +22,8 @@
 function gutenberg_init_font_library_routes() {
 	// @core-merge: This code will go into Core's `create_initial_post_types()`.
 	$args = array(
-		'public'       => true,
+		'public'       => false,
+		'_builtin'     => true,
 		'label'        => 'Font Library',
 		'show_in_rest' => true,
 	);


### PR DESCRIPTION
## What?
fixes https://github.com/WordPress/gutenberg/issues/54526
