### PR TITLE
Iframe: adjust keydown event bubbling

### DIFF
--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -237,6 +237,7 @@ function Iframe( {
 	return (
 		<>
 			{ tabIndex >= 0 && before }
+			{ /* eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions */ }
 			<iframe
 				{ ...props }
 				style={ {
@@ -264,6 +265,25 @@ function Iframe( {
 				// content.
 				src={ src }
 				title={ __( 'Editor canvas' ) }
+				onKeyDown={ ( event ) => {
+					// If the event originates from inside the iframe, it means
+					// it bubbled through the portal, but only with React
+					// events. We need to to bubble native events as well,
+					// though by doing so we also trigger another React event,
+					// so we need to stop the propagation of this event to avoid
+					// duplication.
+					if (
+						event.currentTarget.ownerDocument !==
+						event.target.ownerDocument
+					) {
+						event.stopPropagation();
+						bubbleEvent(
+							event,
+							window.KeyboardEvent,
+							event.currentTarget
+						);
+					}
+				} }
 			>
 				{ iframeDocument &&
 					createPortal(
@@ -277,18 +297,6 @@ function Iframe( {
 								'editor-styles-wrapper',
 								...bodyClasses
 							) }
-							onKeyDown={ ( event ) => {
-								// This stopPropagation call ensures React doesn't create a syncthetic event to bubble this event
-								// which would result in two React events being bubbled throught the iframe.
-								event.stopPropagation();
-								const { defaultView } = iframeDocument;
-								const { frameElement } = defaultView;
-								bubbleEvent(
-									event,
-									window.KeyboardEvent,
-									frameElement
-								);
-							} }
 						>
 							{ contentResizeListener }
 							<StyleProvider document={ iframeDocument }>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

The current implementation prevents any component inside the iframe from listening to events on the document or window. A cleaner solution would be to stop event probation exactly at the element at which we re-dispatch the events: the iframe element.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
