### PR TITLE
Pattern Category: Set 'publicly_queryable' to false

### DIFF
--- a/lib/compat/wordpress-6.4/block-patterns.php
+++ b/lib/compat/wordpress-6.4/block-patterns.php
@@ -16,19 +16,20 @@
  */
 function gutenberg_register_taxonomy_patterns() {
 	$args = array(
-		'public'            => true,
-		'hierarchical'      => false,
-		'labels'            => array(
+		'public'             => true,
+		'publicly_queryable' => false,
+		'hierarchical'       => false,
+		'labels'             => array(
 			'name'          => _x( 'Pattern Categories', 'taxonomy general name' ),
 			'singular_name' => _x( 'Pattern Category', 'taxonomy singular name' ),
 		),
-		'query_var'         => false,
-		'rewrite'           => false,
-		'show_ui'           => true,
-		'_builtin'          => true,
-		'show_in_nav_menus' => false,
-		'show_in_rest'      => true,
-		'show_admin_column' => true,
+		'query_var'          => false,
+		'rewrite'            => false,
+		'show_ui'            => true,
+		'_builtin'           => true,
+		'show_in_nav_menus'  => false,
+		'show_in_rest'       => true,
+		'show_admin_column'  => true,
 	);
 	register_taxonomy( 'wp_pattern_category', array( 'wp_block' ), $args );
 }

--- a/packages/block-library/src/post-terms/index.php
+++ b/packages/block-library/src/post-terms/index.php
@@ -78,11 +78,6 @@ function register_block_core_post_terms() {
 
 	// Create and register the eligible taxonomies variations.
 	foreach ( $taxonomies as $taxonomy ) {
-		// Skip the `wp_pattern_category` taxonomy as this should not be an
-		// available variation for the `core/post-terms` block.
-		if ( 'wp_pattern_category' === $taxonomy->name ) {
-			continue;
-		}
 		$variation = array(
 			'name'        => $taxonomy->name,
 			'title'       => $taxonomy->label,


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/54575

## What?
PR sets the `publicly_queryable` parameter for the Pattern Category to `false`; this prevents adding it to Category block variations.

The `publicly_queryable` argument is used for front-end queries of taxonomy, which I think doesn't apply to the Pattern Category.

## Why?
An alternative to #54532, which avoid hardcoding exception for the taxonomy.

## Testing Instructions
See #54532.
