### PR TITLE
Image: Fix block serialization test case to cover deprecation of `behaviors`

### DIFF
--- a/test/integration/fixtures/blocks/core__image__deprecated-v8-deprecate-behaviors-lightbox.html
+++ b/test/integration/fixtures/blocks/core__image__deprecated-v8-deprecate-behaviors-lightbox.html
@@ -1,3 +1,3 @@
-<!-- wp:image {"lightbox":{"enabled":true},"id":8,"sizeSlug":"large","linkDestination":"none"} -->
+<!-- wp:image {"behaviors":{"lightbox":{"enabled": true,	"animation": "fade"}},"id":8,"sizeSlug":"large","linkDestination":"none"} -->
 <figure class="wp-block-image size-large"><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==" alt="" class="wp-image-8"/></figure>
 <!-- /wp:image -->

--- a/test/integration/fixtures/blocks/core__image__deprecated-v8-deprecate-behaviors-lightbox.json
+++ b/test/integration/fixtures/blocks/core__image__deprecated-v8-deprecate-behaviors-lightbox.json
@@ -6,12 +6,12 @@
 			"url": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==",
 			"alt": "",
 			"caption": "",
-			"lightbox": {
-				"enabled": true
-			},
 			"id": 8,
 			"sizeSlug": "large",
-			"linkDestination": "none"
+			"linkDestination": "none",
+			"lightbox": {
+				"enabled": true
+			}
 		},
 		"innerBlocks": []
 	}

--- a/test/integration/fixtures/blocks/core__image__deprecated-v8-deprecate-behaviors-lightbox.parsed.json
+++ b/test/integration/fixtures/blocks/core__image__deprecated-v8-deprecate-behaviors-lightbox.parsed.json
@@ -2,8 +2,11 @@
 	{
 		"blockName": "core/image",
 		"attrs": {
-			"lightbox": {
-				"enabled": true
+			"behaviors": {
+				"lightbox": {
+					"enabled": true,
+					"animation": "fade"
+				}
 			},
 			"id": 8,
 			"sizeSlug": "large",


### PR DESCRIPTION
## What?

The block serialization test was not correctly covering the deprecation of `behaviors` as noted in https://github.com/WordPress/gutenberg/pull/54509#discussion_r1328299756.

This PR fixes it.
