### PR TITLE
Docs [Block Editor Handbook / Getting Started / Block Development Environment]: Fix links 

### DIFF
--- a/docs/getting-started/devenv/README.md
+++ b/docs/getting-started/devenv/README.md
@@ -7,7 +7,7 @@ To contribute to the Gutenberg project itself, refer to the additional documenta
 A block development environment includes the tools you need on your computer to successfully develop for the Block Editor. The three essential requirements are:
 
 1.  [Code editor](#code-editor)
-2.  [Node.js development tools](#nodejs-development-tools)
+2.  [Node.js development tools](#node-js-development-tools)
 3.  [Local WordPress environment (site)](#local-wordpress-environment)
 
 ## Code editor

--- a/docs/getting-started/devenv/get-started-with-wp-env.md
+++ b/docs/getting-started/devenv/get-started-with-wp-env.md
@@ -44,7 +44,7 @@ wp-env start
 
 Once the script completes, you can access the local environment at: `http://localhost:8888`. Log into the WordPress dashboard using username `admin` and password `password`.
 
-<div class="callout-tip">
+<div class="callout callout-tip">
     Some projects, like Gutenberg, include their own specific <code>wp-env</code> configurations, and the documentation might prompt you to run <code>npm run start wp-env</code> instead.
 </div>
 

--- a/docs/getting-started/devenv/get-started-with-wp-now.md
+++ b/docs/getting-started/devenv/get-started-with-wp-now.md
@@ -2,7 +2,7 @@
 
 The [@wp-now/wp-now](https://www.npmjs.com/package/@wordpress/env) package (`wp-now`) is a lightweight tool powered by [WordPress Playground](https://developer.wordpress.org/playground/) that streamlines setting up a local WordPress environment.
 
-Before following this guide, install [Node.js development tools](/docs/getting-started/devenv#nodejs-development-tools) if you have not already done so. It's recommended that you use the latest version of `node`. `wp-now` requires at least `node` v18 and v20 if you intend to use its [Blueprints](https://github.com/WordPress/playground-tools/tree/trunk/packages/wp-now#using-blueprints) feature. 
+Before following this guide, install [Node.js development tools](/docs/getting-started/devenv#node-js-development-tools) if you have not already done so. It's recommended that you use the latest version of `node`. `wp-now` requires at least `node` v18 and v20 if you intend to use its [Blueprints](https://github.com/WordPress/playground-tools/tree/trunk/packages/wp-now#using-blueprints) feature. 
 
 ## Quick start
  

--- a/docs/getting-started/devenv/nodejs-development-environment.md
+++ b/docs/getting-started/devenv/nodejs-development-environment.md
@@ -1,6 +1,6 @@
 # Node.js development environment
 
-When developing for the Block Editor, you will need [Node.js](https://nodejs.org/en) development tools along with a code editor and a local WordPress environment (see [Block Development Environment](/docs/getting-started/devenv/)). Node.js (`node`) is an open-source runtime environment that allows you to execute JavaScript code from the terminal (also known as a command-line interface, CLI, or shell)
+When developing for the Block Editor, you will need [Node.js](https://nodejs.org/en) development tools along with a code editor and a local WordPress environment (see [Block Development Environment](/docs/getting-started/devenv/README.md)). Node.js (`node`) is an open-source runtime environment that allows you to execute JavaScript code from the terminal (also known as a command-line interface, CLI, or shell)
 
 Installing `node` will automatically include the Node Package Manager (`npm`) and the Node Package eXecute (`npx`), two tools you will frequently use in block and plugin development.
 

--- a/docs/getting-started/devenv/nodejs-development-environment.md
+++ b/docs/getting-started/devenv/nodejs-development-environment.md
@@ -1,6 +1,6 @@
 # Node.js development environment
 
-When developing for the Block Editor, you will need [Node.js](https://nodejs.org/en) development tools along with a code editor and a local WordPress environment (see [Block Development Environment](README.md)). Node.js (`node`) is an open-source runtime environment that allows you to execute JavaScript code from the terminal (also known as a command-line interface, CLI, or shell)
+When developing for the Block Editor, you will need [Node.js](https://nodejs.org/en) development tools along with a code editor and a local WordPress environment (see [Block Development Environment](/docs/getting-started/devenv/)). Node.js (`node`) is an open-source runtime environment that allows you to execute JavaScript code from the terminal (also known as a command-line interface, CLI, or shell)
 
 Installing `node` will automatically include the Node Package Manager (`npm`) and the Node Package eXecute (`npx`), two tools you will frequently use in block and plugin development.
 


### PR DESCRIPTION
## What?
Fix a few links in [Block Editor Handbook](https://developer.wordpress.org/block-editor/) / [Getting Started](https://developer.wordpress.org/block-editor/getting-started/) / Block Development Environment
It also includes a missing `callout` CSS class that was causing callout styles not to display correctly.

## Why?
To ensure a nice learning and discovering experience
