### PR TITLE
Add back tooltip to styles UI

### DIFF
--- a/packages/block-editor/src/components/block-styles/index.js
+++ b/packages/block-editor/src/components/block-styles/index.js
@@ -82,7 +82,6 @@ function BlockStyles( { clientId, onSwitch = noop, onHoverClassName = noop } ) {
 							key={ style.name }
 							variant="secondary"
 							label={ buttonText }
-							showTooltip={ false }
 							onMouseEnter={ () => styleItemHandler( style ) }
 							onFocus={ () => styleItemHandler( style ) }
 							onMouseLeave={ () => styleItemHandler( null ) }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Add the tooltip to the block style buttons. It's duplicative, but necessary as truncation can occur. Related to https://github.com/WordPress/gutenberg/pull/54446.

## Screenshots or screencast <!-- if applicable -->
<img width="281" alt="CleanShot 2023-09-18 at 16 23 31" src="https://github.com/WordPress/gutenberg/assets/1813435/4eb1cbfe-bd60-4f93-a9c5-e3c2109dc046">
