### PR TITLE
Patterns: move mapping of values from core-data selector into consumers

### DIFF
--- a/docs/reference-guides/data/data-core.md
+++ b/docs/reference-guides/data/data-core.md
@@ -413,7 +413,7 @@ _Parameters_
 
 _Returns_
 
--   `UserPatternCategories`: User patterns category array and map keyed by id.
+-   `Array< UserPatternCategory >`: User patterns category array.
 
 ### getUserQueryResults
 

--- a/packages/block-editor/src/components/inserter/hooks/use-patterns-state.js
+++ b/packages/block-editor/src/components/inserter/hooks/use-patterns-state.js
@@ -31,8 +31,7 @@ const usePatternsState = ( onInsert, rootClientId ) => {
 			} = getSettings();
 			return {
 				patterns: __experimentalGetAllowedPatterns( rootClientId ),
-				userPatternCategories:
-					__experimentalUserPatternCategories?.patternCategories,
+				userPatternCategories: __experimentalUserPatternCategories,
 				patternCategories: __experimentalBlockPatternCategories,
 			};
 		},

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -2297,7 +2297,7 @@ function getUserPatterns( state ) {
 	const userPatternCategories =
 		state?.settings?.__experimentalUserPatternCategories ?? [];
 	const categories = new Map();
-	userPatternCategories?.forEach( ( userCategory ) =>
+	userPatternCategories?forEach( ( userCategory ) =>
 		categories.set( userCategory.id, userCategory )
 	);
 	return userPatterns.map( ( userPattern ) => {

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -2297,7 +2297,7 @@ function getUserPatterns( state ) {
 	const userPatternCategories =
 		state?.settings?.__experimentalUserPatternCategories ?? [];
 	const categories = new Map();
-	userPatternCategories?forEach( ( userCategory ) =>
+	userPatternCategories.forEach( ( userCategory ) =>
 		categories.set( userCategory.id, userCategory )
 	);
 	return userPatterns.map( ( userPattern ) => {

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -2294,8 +2294,12 @@ const checkAllowListRecursive = ( blocks, allowedBlockTypes ) => {
 function getUserPatterns( state ) {
 	const userPatterns =
 		state?.settings?.__experimentalReusableBlocks ?? EMPTY_ARRAY;
-	const { patternCategoriesMap: categories } =
-		state?.settings?.__experimentalUserPatternCategories ?? {};
+	const userPatternCategories =
+		state?.settings?.__experimentalUserPatternCategories ?? [];
+	const categories = new Map();
+	userPatternCategories?.forEach( ( userCategory ) =>
+		categories.set( userCategory.id, userCategory )
+	);
 	return userPatterns.map( ( userPattern ) => {
 		return {
 			name: `core/block/${ userPattern.id }`,

--- a/packages/core-data/README.md
+++ b/packages/core-data/README.md
@@ -590,7 +590,7 @@ _Parameters_
 
 _Returns_
 
--   `UserPatternCategories`: User patterns category array and map keyed by id.
+-   `Array< UserPatternCategory >`: User patterns category array.
 
 ### getUserQueryResults
 

--- a/packages/core-data/src/selectors.ts
+++ b/packages/core-data/src/selectors.ts
@@ -80,17 +80,12 @@ interface UserState {
 	byId: Record< EntityRecordKey, ET.User< 'edit' > >;
 }
 
-interface UserPatternCategory {
+export interface UserPatternCategory {
 	id: number;
 	name: string;
 	label: string;
 	slug: string;
 	description: string;
-}
-
-export interface UserPatternCategories {
-	patternCategories: Array< UserPatternCategory >;
-	patternCategoriesMap: Map< number, UserPatternCategory >;
 }
 
 type Optional< T > = T | undefined;
@@ -1241,21 +1236,13 @@ export function getBlockPatternCategories( state: State ): Array< any > {
  *
  * @param state Data state.
  *
- * @return User patterns category array and map keyed by id.
+ * @return User patterns category array.
  */
 
 export function getUserPatternCategories(
 	state: State
-): UserPatternCategories {
-	const patternCategoriesMap = new Map< number, UserPatternCategory >();
-	state.userPatternCategories?.forEach(
-		( userCategory: UserPatternCategory ) =>
-			patternCategoriesMap.set( userCategory.id, userCategory )
-	);
-	return {
-		patternCategories: state.userPatternCategories,
-		patternCategoriesMap,
-	};
+): Array< UserPatternCategory > {
+	return state.userPatternCategories;
 }
 
 /**

--- a/packages/edit-site/src/components/page-patterns/use-patterns.js
+++ b/packages/edit-site/src/components/page-patterns/use-patterns.js
@@ -170,11 +170,14 @@ const selectUserPatterns = ( select, { search = '', syncStatus } = {} ) => {
 
 	const query = { per_page: -1 };
 	const records = getEntityRecords( 'postType', PATTERN_TYPES.user, query );
-	const categories = getUserPatternCategories();
-
+	const userPatternCategories = getUserPatternCategories();
+	const categories = new Map();
+	userPatternCategories?.forEach( ( userCategory ) =>
+		categories.set( userCategory.id, userCategory )
+	);
 	let patterns = records
 		? records.map( ( record ) =>
-				patternBlockToPattern( record, categories.patternCategoriesMap )
+				patternBlockToPattern( record, categories )
 		  )
 		: EMPTY_PATTERN_LIST;
 
@@ -197,7 +200,7 @@ const selectUserPatterns = ( select, { search = '', syncStatus } = {} ) => {
 		hasCategory: () => true,
 	} );
 
-	return { patterns, isResolving, categories: categories.patternCategories };
+	return { patterns, isResolving, categories: userPatternCategories };
 };
 
 export const usePatterns = (

--- a/packages/edit-site/src/components/page-patterns/use-patterns.js
+++ b/packages/edit-site/src/components/page-patterns/use-patterns.js
@@ -172,7 +172,7 @@ const selectUserPatterns = ( select, { search = '', syncStatus } = {} ) => {
 	const records = getEntityRecords( 'postType', PATTERN_TYPES.user, query );
 	const userPatternCategories = getUserPatternCategories();
 	const categories = new Map();
-	userPatternCategories?.forEach( ( userCategory ) =>
+	userPatternCategories.forEach( ( userCategory ) =>
 		categories.set( userCategory.id, userCategory )
 	);
 	let patterns = records

--- a/packages/edit-site/src/components/sidebar-navigation-screen-pattern/use-pattern-details.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-pattern/use-pattern-details.js
@@ -38,10 +38,15 @@ export default function usePatternDetails( postType, postId ) {
 	const { currentTheme, patternCategories } = useSelect( ( select ) => {
 		const { getCurrentTheme, getUserPatternCategories } =
 			select( coreStore );
+		const userPatternCategories = getUserPatternCategories();
+		const categories = new Map();
+		userPatternCategories?.forEach( ( userCategory ) =>
+			categories.set( userCategory.id, userCategory )
+		);
 
 		return {
 			currentTheme: getCurrentTheme(),
-			patternCategories: getUserPatternCategories().patternCategoriesMap,
+			patternCategories: categories,
 		};
 	}, [] );
 

--- a/packages/edit-site/src/components/sidebar-navigation-screen-pattern/use-pattern-details.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-pattern/use-pattern-details.js
@@ -40,7 +40,7 @@ export default function usePatternDetails( postType, postId ) {
 			select( coreStore );
 		const userPatternCategories = getUserPatternCategories();
 		const categories = new Map();
-		userPatternCategories?.forEach( ( userCategory ) =>
+		userPatternCategories.forEach( ( userCategory ) =>
 			categories.set( userCategory.id, userCategory )
 		);
 


### PR DESCRIPTION
## What?
Moves mapping of values from core-data selector into consumers.

## Why?
The introduction of the [user pattern categories](https://github.com/WordPress/gutenberg/pull/53835) has caused a [decrease in typing performance](https://github.com/WordPress/gutenberg/pull/53835#issuecomment-1723127137) in the post editor, so this PR is cleaning up a selector that was added as part of this merge in an attempt to improve the typing performance again.

## How?
Removes the creation of the pattern categories by id for the selector, and instead create this map in the consumers of the selector.

While investigating this issue another similar performance issue that could affect typing was found in the useBlockEditorSettings hook and this was fixed in https://github.com/WordPress/gutenberg/pull/54580.

## Testing Instructions

- In the post editor add some synced and unsynced patterns with categories assigned
- Check that the patterns appear in the correct categories in the inserter patterns tab
- Check that the All patterns tab shows all patterns and that paging at the bottom of the tab works
- Check that the Source Filter select list works as expected and that correct patterns display for each selected filter
- Also check that when the My patterns source filter is selected that a Sync type filter appears at the top of the patterns list and works as expected
- Check that changing Source or Sync type filters when categories are selected resets the category to All
- Repeat all of the above in the patterns explorer modal


## Screenshots

https://github.com/WordPress/gutenberg/assets/3629020/4d50e1e8-cb31-44b0-9714-f9f14bc2f5df

