### PR TITLE
Block Editor: Memoize the createPageEntity callback 

### DIFF
--- a/packages/editor/src/components/provider/use-block-editor-settings.js
+++ b/packages/editor/src/components/provider/use-block-editor-settings.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { Platform, useMemo } from '@wordpress/element';
+import { Platform, useMemo, useCallback } from '@wordpress/element';
 import { useDispatch, useSelect } from '@wordpress/data';
 import {
 	store as coreStore,
@@ -182,14 +182,19 @@ function useBlockEditorSettings( settings, hasTemplate ) {
 	 * @param {Object} options parameters for the post being created. These mirror those used on 3rd param of saveEntityRecord.
 	 * @return {Object} the post type object that was created.
 	 */
-	const createPageEntity = ( options ) => {
-		if ( ! userCanCreatePages ) {
-			return Promise.reject( {
-				message: __( 'You do not have permission to create Pages.' ),
-			} );
-		}
-		return saveEntityRecord( 'postType', 'page', options );
-	};
+	const createPageEntity = useCallback(
+		( options ) => {
+			if ( ! userCanCreatePages ) {
+				return Promise.reject( {
+					message: __(
+						'You do not have permission to create Pages.'
+					),
+				} );
+			}
+			return saveEntityRecord( 'postType', 'page', options );
+		},
+		[ saveEntityRecord, userCanCreatePages ]
+	);
 
 	return useMemo(
 		() => ( {


### PR DESCRIPTION
## What?
Memoizes the createPageEntity callback in the useBlockEditorSettings hook.

## Why?
Because a new function is generated with every call currently the useBlockEditorSettings useMemo return hook is being rerun with every keystroke in the block editor.

## How?
Wraps the function in a `useCallback`.

## Testing Instructions

- In post editor add a paragraph with some text
- Highlight text and select link button in the toolbar
- Start typing a new page name and select the `Create page` option that appears in dropdown
- Save page and make sure link works and new page was created

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/3629020/355c4805-dd95-4ea1-8f00-85193ce297b2


