### PR TITLE
Gutenberg Plugin: Add hook to allow `writing-mode` as a safe CSS property

### DIFF
--- a/lib/compat/wordpress-6.4/kses.php
+++ b/lib/compat/wordpress-6.4/kses.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * Temporary compatibility shims for block APIs present in Gutenberg.
+ *
+ * @package gutenberg
+ */
+
+/**
+ * Update allowed inline style attributes list.
+ *
+ * @param string[] $attrs Array of allowed CSS attributes.
+ * @return string[] CSS attributes.
+ */
+function gutenberg_safe_style_attrs_6_4( $attrs ) {
+	$attrs[] = 'writing-mode';
+	return $attrs;
+}
+add_filter( 'safe_style_css', 'gutenberg_safe_style_attrs_6_4' );

--- a/lib/load.php
+++ b/lib/load.php
@@ -97,6 +97,7 @@ require __DIR__ . '/compat/wordpress-6.4/blocks.php';
 require __DIR__ . '/compat/wordpress-6.4/block-hooks.php';
 require __DIR__ . '/compat/wordpress-6.4/block-patterns.php';
 require __DIR__ . '/compat/wordpress-6.4/script-loader.php';
+require __DIR__ . '/compat/wordpress-6.4/kses.php';
 
 // Experimental features.
 require __DIR__ . '/experimental/block-editor-settings-mobile.php';

--- a/packages/block-library/src/post-navigation-link/index.php
+++ b/packages/block-library/src/post-navigation-link/index.php
@@ -28,14 +28,9 @@ function render_block_core_post_navigation_link( $attributes, $content ) {
 	if ( isset( $attributes['textAlign'] ) ) {
 		$classes .= " has-text-align-{$attributes['textAlign']}";
 	}
-	$styles = '';
-	if ( isset( $attributes['style']['typography']['writingMode'] ) ) {
-		$styles = "writing-mode: {$attributes['style']['typography']['writingMode']};";
-	}
 	$wrapper_attributes = get_block_wrapper_attributes(
 		array(
 			'class' => $classes,
-			'style' => $styles,
 		)
 	);
 	// Set default values.

--- a/phpunit/style-engine/style-engine-test.php
+++ b/phpunit/style-engine/style-engine-test.php
@@ -192,11 +192,12 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 						'textDecoration' => 'underline',
 						'textTransform'  => 'uppercase',
 						'letterSpacing'  => '2',
+						'writingMode'    => 'vertical-rl',
 					),
 				),
 				'options'         => null,
 				'expected_output' => array(
-					'css'          => 'font-size:clamp(2em, 2vw, 4em);font-family:Roboto,Oxygen-Sans,Ubuntu,sans-serif;font-style:italic;font-weight:800;line-height:1.3;column-count:2;text-decoration:underline;text-transform:uppercase;letter-spacing:2;',
+					'css'          => 'font-size:clamp(2em, 2vw, 4em);font-family:Roboto,Oxygen-Sans,Ubuntu,sans-serif;font-style:italic;font-weight:800;line-height:1.3;column-count:2;text-decoration:underline;text-transform:uppercase;letter-spacing:2;writing-mode:vertical-rl;',
 					'declarations' => array(
 						'font-size'       => 'clamp(2em, 2vw, 4em)',
 						'font-family'     => 'Roboto,Oxygen-Sans,Ubuntu,sans-serif',
@@ -207,6 +208,7 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 						'text-decoration' => 'underline',
 						'text-transform'  => 'uppercase',
 						'letter-spacing'  => '2',
+						'writing-mode'    => 'vertical-rl',
 					),
 				),
 			),


### PR DESCRIPTION
Fixes #54344
Alternative to #54345
For more information, see [this comment](https://github.com/WordPress/gutenberg/pull/54345#pullrequestreview-1630084109)

## What?

This PR includes the following three:

- Added `safe_style_css` filter to prevent `wiriting-mode` property from being removed by `safecss_filter_attr()` function
- Remove explicit addition of `writing-mode` style in render callback function of the Post Navigation Link block which is no longer needed
- Updated the Style Engine testing

## Why?

For dynamic blocks, as with other block support styles, there is no need to explicitly pass the style, as it should be automatically output by the `get_wrapper_attributes()` function.

However, this property is not yet allowed in the core, so we need to allow it in the Gutenberg plugin first.

## How?

`writing-mode` (text orientation) is supported in WordPress 6.3. Therefore, this hook originally needed to be added in the `lib/compat/wordpress-6.3` directory. However, this property will only be allowed in core WordPress 6.4 and above, so I added the hook to the `lib/compat/wordpress-6.4` directory.

## Testing Instructions

To test this PR, enable Emptytheme and update theme.json as below:

```json
{
	"$schema": "https://schemas.wp.org/trunk/theme.json",
	"version": 2,
	"settings": {
		"appearanceTools": true,
		"layout": {
			"contentSize": "840px",
			"wideSize": "1100px"
		},
		"typography": {
			"writingMode": true
		}
	}
}
```

### Footnotes Block

- Add some footnotes to the paragraph block.
- In the Typography panel of the Footnotes block, change orientation to "vertical".
- In the front end, the block should be displayed vertically.

### Post Navigation Block

- Create three posts.
- Insert a Previous Post block and a Next Post block in the middle post.
- In the Typography panel, change orientation to "vertical".
- In the front end, the block should be displayed vertically.