### PR TITLE
Patterns:  revert usePatternsState to return an array instead of object

### DIFF
--- a/packages/block-editor/src/components/inserter/block-patterns-explorer/patterns-list.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-explorer/patterns-list.js
@@ -74,7 +74,7 @@ function PatternList( {
 	const [ destinationRootClientId, onInsertBlocks ] = useInsertionPoint( {
 		shouldFocusBlock: true,
 	} );
-	const { patterns: allPatterns, onClickPattern } = usePatternsState(
+	const [ patterns, , onClickPattern ] = usePatternsState(
 		onInsertBlocks,
 		destinationRootClientId
 	);
@@ -88,7 +88,7 @@ function PatternList( {
 	);
 
 	const filteredBlockPatterns = useMemo( () => {
-		const filteredPatterns = allPatterns.filter( ( pattern ) => {
+		const filteredPatterns = patterns.filter( ( pattern ) => {
 			if (
 				isPatternFiltered(
 					pattern,
@@ -127,7 +127,7 @@ function PatternList( {
 	}, [
 		searchValue,
 		patternSourceFilter,
-		allPatterns,
+		patterns,
 		selectedCategory,
 		registeredPatternCategories,
 		patternSyncFilter,

--- a/packages/block-editor/src/components/inserter/block-patterns-tab.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-tab.js
@@ -74,7 +74,7 @@ export function isPatternFiltered( pattern, sourceFilter, syncFilter ) {
 }
 
 export function usePatternsCategories( rootClientId, sourceFilter = 'all' ) {
-	const { patterns: allPatterns, allCategories } = usePatternsState(
+	const [ patterns, allCategories ] = usePatternsState(
 		undefined,
 		rootClientId
 	);
@@ -82,12 +82,12 @@ export function usePatternsCategories( rootClientId, sourceFilter = 'all' ) {
 	const filteredPatterns = useMemo(
 		() =>
 			sourceFilter === 'all'
-				? allPatterns
-				: allPatterns.filter(
+				? patterns
+				: patterns.filter(
 						( pattern ) =>
 							! isPatternFiltered( pattern, sourceFilter )
 				  ),
-		[ sourceFilter, allPatterns ]
+		[ sourceFilter, patterns ]
 	);
 
 	const hasRegisteredCategory = useCallback(
@@ -192,7 +192,7 @@ export function BlockPatternsCategoryPanel( {
 	showTitlesAsTooltip,
 	patternFilter,
 } ) {
-	const { patterns: allPatterns, onClickPattern } = usePatternsState(
+	const [ allPatterns, , onClickPattern ] = usePatternsState(
 		onInsert,
 		rootClientId
 	);

--- a/packages/block-editor/src/components/inserter/hooks/use-patterns-state.js
+++ b/packages/block-editor/src/components/inserter/hooks/use-patterns-state.js
@@ -80,7 +80,7 @@ const usePatternsState = ( onInsert, rootClientId ) => {
 		[ createSuccessNotice, onInsert ]
 	);
 
-	return { patterns, allCategories, onClickPattern };
+	return [ patterns, allCategories, onClickPattern ];
 };
 
 export default usePatternsState;

--- a/packages/block-editor/src/components/inserter/quick-inserter.js
+++ b/packages/block-editor/src/components/inserter/quick-inserter.js
@@ -46,7 +46,7 @@ export default function QuickInserter( {
 		onInsertBlocks
 	);
 
-	const { patterns } = usePatternsState(
+	const [ patterns ] = usePatternsState(
 		onInsertBlocks,
 		destinationRootClientId
 	);

--- a/packages/block-editor/src/components/inserter/search-results.js
+++ b/packages/block-editor/src/components/inserter/search-results.js
@@ -81,7 +81,7 @@ function InserterSearchResults( {
 		blockTypeCollections,
 		onSelectBlockType,
 	] = useBlockTypesState( destinationRootClientId, onInsertBlocks );
-	const { patterns, onClickPattern } = usePatternsState(
+	const [ patterns, , onClickPattern ] = usePatternsState(
 		onInsertBlocks,
 		destinationRootClientId
 	);


### PR DESCRIPTION
## What?
Reverts the change made in #53835 to return an object from usePatternsState to instead return an array

## Why?
It was [noted here](https://github.com/WordPress/gutenberg/pull/53835#discussion_r1328531727) that this change meant that it was now not consistent anymore with useBlocksState.

However the object makes for a nicer API than the array, ie. it avoids the likes of `const [ patterns, , onClickPattern ] =`, so up for debate as to whether this is the best approach.

## How?

Changed return value from object to array and updated all the places the hook is called.

## Testing Instructions

- In the post editor add some synced and unsynced patterns with categories assigned
- Check that the patterns appear in the correct categories in the inserter patterns tab
- Check that the All patterns tab shows all patterns and that paging at the bottom of the tab works
- Check that the Source Filter select list works as expected and that correct patterns display for each selected filter
- Also check that when the My patterns source filter is selected that a Sync type filter appears at the top of the patterns list and works as expected
- Check that changing Source or Sync type filters when categories are selected resets the category to All
- Repeat all of the above in the patterns explorer modal


## Screenshots

https://github.com/WordPress/gutenberg/assets/3629020/4d50e1e8-cb31-44b0-9714-f9f14bc2f5df

