### PR TITLE
Patterns: Move category map creation out of useSelect

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen-pattern/use-pattern-details.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-pattern/use-pattern-details.js
@@ -10,6 +10,7 @@ import { __, sprintf } from '@wordpress/i18n';
 import { store as coreStore } from '@wordpress/core-data';
 import { store as editorStore } from '@wordpress/editor';
 import { useSelect } from '@wordpress/data';
+import { useMemo } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -35,20 +36,24 @@ export default function usePatternDetails( postType, postId ) {
 			select( editorStore ).__experimentalGetDefaultTemplatePartAreas(),
 		[]
 	);
-	const { currentTheme, patternCategories } = useSelect( ( select ) => {
+	const { currentTheme, userPatternCategories } = useSelect( ( select ) => {
 		const { getCurrentTheme, getUserPatternCategories } =
 			select( coreStore );
-		const userPatternCategories = getUserPatternCategories();
+
+		return {
+			currentTheme: getCurrentTheme(),
+			userPatternCategories: getUserPatternCategories(),
+		};
+	}, [] );
+
+	const patternCategories = useMemo( () => {
 		const categories = new Map();
 		userPatternCategories.forEach( ( userCategory ) =>
 			categories.set( userCategory.id, userCategory )
 		);
 
-		return {
-			currentTheme: getCurrentTheme(),
-			patternCategories: categories,
-		};
-	}, [] );
+		return categories;
+	}, [ userPatternCategories ] );
 
 	const addedBy = useAddedBy( postType, postId );
 	const isAddedByActiveTheme =

--- a/packages/edit-site/src/components/sidebar-navigation-screen-pattern/use-pattern-details.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-pattern/use-pattern-details.js
@@ -10,7 +10,6 @@ import { __, sprintf } from '@wordpress/i18n';
 import { store as coreStore } from '@wordpress/core-data';
 import { store as editorStore } from '@wordpress/editor';
 import { useSelect } from '@wordpress/data';
-import { useMemo } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -45,15 +44,6 @@ export default function usePatternDetails( postType, postId ) {
 			userPatternCategories: getUserPatternCategories(),
 		};
 	}, [] );
-
-	const patternCategories = useMemo( () => {
-		const categories = new Map();
-		userPatternCategories.forEach( ( userCategory ) =>
-			categories.set( userCategory.id, userCategory )
-		);
-
-		return categories;
-	}, [ userPatternCategories ] );
 
 	const addedBy = useAddedBy( postType, postId );
 	const isAddedByActiveTheme =
@@ -106,6 +96,11 @@ export default function usePatternDetails( postType, postId ) {
 			} );
 		}
 		if ( record.wp_pattern_category?.length > 0 ) {
+			const patternCategories = new Map();
+			userPatternCategories.forEach( ( userCategory ) =>
+				patternCategories.set( userCategory.id, userCategory )
+			);
+
 			const categories = record.wp_pattern_category
 				.filter( ( category ) => patternCategories.get( category ) )
 				.map( ( category ) => patternCategories.get( category ).label );


### PR DESCRIPTION
Related:
- https://github.com/WordPress/gutenberg/pull/54576#discussion_r1329599052

## What?

Moves the category map creation outside of the `useSelect` that retrieves the categories.

## Why?

Avoids a new value being returned on each call of `mapSelect`.

## How?

Move the same logic outside the `useSelect` and into a `useMemo`

## Testing Instructions

1. Navigate to the patterns management page in the site editor
2. Select a pattern to view
3. Open dev tools, then reload the page
4. You should no longer see any useSelect warning notice
5. Confirm the correct pattern categories are list in the sidebar nav screen's details pane


## Screenshots or screencast <!-- if applicable -->

| Before | After |
|---|---|
| <img width="1162" alt="Screenshot 2023-09-19 at 4 04 53 pm" src="https://github.com/WordPress/gutenberg/assets/60436221/f79589bb-5f56-4b6c-8b2b-d4126de03d11"> | <img width="1162" alt="Screenshot 2023-09-19 at 4 04 04 pm" src="https://github.com/WordPress/gutenberg/assets/60436221/8ba7ddd4-9b1d-431b-8a64-61736bb22a44"> |

