### PR TITLE
Site editor: prune store constants

### DIFF
--- a/packages/edit-site/src/components/create-template-part-modal/index.js
+++ b/packages/edit-site/src/components/create-template-part-modal/index.js
@@ -28,7 +28,7 @@ import { serialize } from '@wordpress/blocks';
 /**
  * Internal dependencies
  */
-import { TEMPLATE_PART_AREA_GENERAL } from '../../store/constants';
+import { TEMPLATE_PART_AREA_GENERAL } from '../../utils/constants';
 import {
 	useExistingTemplateParts,
 	getUniqueTemplatePartTitle,

--- a/packages/edit-site/src/components/create-template-part-modal/index.js
+++ b/packages/edit-site/src/components/create-template-part-modal/index.js
@@ -28,7 +28,7 @@ import { serialize } from '@wordpress/blocks';
 /**
  * Internal dependencies
  */
-import { TEMPLATE_PART_AREA_GENERAL } from '../../utils/constants';
+import { TEMPLATE_PART_AREA_DEFAULT_CATEGORY } from '../../utils/constants';
 import {
 	useExistingTemplateParts,
 	getUniqueTemplatePartTitle,
@@ -46,7 +46,7 @@ export default function CreateTemplatePartModal( {
 	const existingTemplateParts = useExistingTemplateParts();
 
 	const [ title, setTitle ] = useState( '' );
-	const [ area, setArea ] = useState( TEMPLATE_PART_AREA_GENERAL );
+	const [ area, setArea ] = useState( TEMPLATE_PART_AREA_DEFAULT_CATEGORY );
 	const [ isSubmitting, setIsSubmitting ] = useState( false );
 	const instanceId = useInstanceId( CreateTemplatePartModal );
 

--- a/packages/edit-site/src/components/page-patterns/use-patterns.js
+++ b/packages/edit-site/src/components/page-patterns/use-patterns.js
@@ -16,6 +16,7 @@ import {
 	PATTERN_TYPES,
 	PATTERN_SYNC_TYPES,
 	TEMPLATE_PART_POST_TYPE,
+	TEMPLATE_PART_AREA_DEFAULT_CATEGORY,
 } from '../../utils/constants';
 import { unlock } from '../../lock-unlock';
 import { searchItems } from './search-items';
@@ -62,7 +63,7 @@ const selectTemplatePartsAsPatterns = (
 	const templatePartAreas = knownAreas.map( ( area ) => area.area );
 
 	const templatePartHasCategory = ( item, category ) => {
-		if ( category !== 'uncategorized' ) {
+		if ( category !== TEMPLATE_PART_AREA_DEFAULT_CATEGORY ) {
 			return item.templatePart.area === category;
 		}
 
@@ -74,7 +75,7 @@ const selectTemplatePartsAsPatterns = (
 
 	const isResolving = getIsResolving( 'getEntityRecords', [
 		'postType',
-		'wp_template_part',
+		TEMPLATE_PART_POST_TYPE,
 		query,
 	] );
 

--- a/packages/edit-site/src/components/sidebar-navigation-screen-patterns/use-pattern-categories.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-patterns/use-pattern-categories.js
@@ -10,12 +10,16 @@ import { __ } from '@wordpress/i18n';
 import useDefaultPatternCategories from './use-default-pattern-categories';
 import useThemePatterns from './use-theme-patterns';
 import usePatterns from '../page-patterns/use-patterns';
-import { PATTERN_TYPES, PATTERN_DEFAULT_CATEGORY } from '../../utils/constants';
+import {
+	PATTERN_TYPES,
+	PATTERN_DEFAULT_CATEGORY,
+	TEMPLATE_PART_AREA_DEFAULT_CATEGORY,
+} from '../../utils/constants';
 
 export default function usePatternCategories() {
 	const defaultCategories = useDefaultPatternCategories();
 	defaultCategories.push( {
-		name: 'uncategorized',
+		name: TEMPLATE_PART_AREA_DEFAULT_CATEGORY,
 		label: __( 'Uncategorized' ),
 	} );
 	const themePatterns = useThemePatterns();

--- a/packages/edit-site/src/components/sidebar-navigation-screen-patterns/use-template-part-areas.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-patterns/use-template-part-areas.js
@@ -5,6 +5,14 @@ import { useEntityRecords } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
 
+/**
+ * Internal dependencies
+ */
+import {
+	TEMPLATE_PART_AREA_DEFAULT_CATEGORY,
+	TEMPLATE_PART_POST_TYPE,
+} from '../../utils/constants';
+
 const useTemplatePartsGroupedByArea = ( items ) => {
 	const allItems = items || [];
 
@@ -32,7 +40,9 @@ const useTemplatePartsGroupedByArea = ( items ) => {
 	);
 
 	const groupedByArea = allItems.reduce( ( accumulator, item ) => {
-		const key = accumulator[ item.area ] ? item.area : 'uncategorized';
+		const key = accumulator[ item.area ]
+			? item.area
+			: TEMPLATE_PART_AREA_DEFAULT_CATEGORY;
 		accumulator[ key ].templateParts.push( item );
 		return accumulator;
 	}, knownAreas );
@@ -43,7 +53,7 @@ const useTemplatePartsGroupedByArea = ( items ) => {
 export default function useTemplatePartAreas() {
 	const { records: templateParts, isResolving: isLoading } = useEntityRecords(
 		'postType',
-		'wp_template_part',
+		TEMPLATE_PART_POST_TYPE,
 		{ per_page: -1 }
 	);
 

--- a/packages/edit-site/src/store/constants.js
+++ b/packages/edit-site/src/store/constants.js
@@ -4,8 +4,3 @@
  * @type {string}
  */
 export const STORE_NAME = 'core/edit-site';
-
-export const TEMPLATE_PART_AREA_HEADER = 'header';
-export const TEMPLATE_PART_AREA_FOOTER = 'footer';
-export const TEMPLATE_PART_AREA_SIDEBAR = 'sidebar';
-export const TEMPLATE_PART_AREA_GENERAL = 'uncategorized';

--- a/packages/edit-site/src/utils/constants.js
+++ b/packages/edit-site/src/utils/constants.js
@@ -16,6 +16,7 @@ export const NAVIGATION_POST_TYPE = 'wp_navigation';
 export const TEMPLATE_POST_TYPE = 'wp_template';
 export const TEMPLATE_PART_POST_TYPE = 'wp_template_part';
 export const TEMPLATE_CUSTOM_SOURCE = 'custom';
+export const TEMPLATE_PART_AREA_GENERAL = 'uncategorized';
 
 // Patterns.
 export const {

--- a/packages/edit-site/src/utils/constants.js
+++ b/packages/edit-site/src/utils/constants.js
@@ -16,7 +16,7 @@ export const NAVIGATION_POST_TYPE = 'wp_navigation';
 export const TEMPLATE_POST_TYPE = 'wp_template';
 export const TEMPLATE_PART_POST_TYPE = 'wp_template_part';
 export const TEMPLATE_CUSTOM_SOURCE = 'custom';
-export const TEMPLATE_PART_AREA_GENERAL = 'uncategorized';
+export const TEMPLATE_PART_AREA_DEFAULT_CATEGORY = 'uncategorized';
 
 // Patterns.
 export const {


### PR DESCRIPTION

## What?

Consolidate and prune edit site store constants for template part strings



## Why?
When working on https://github.com/WordPress/gutenberg/pull/54484 I noticed that some constants in the edit site store weren't being used.

One was, and I moved it over to a centralized file.


## Testing Instructions
Tests should pass. Imports shouldn't break build :) 

Create template part modal should work as expected


<img width="524" alt="Screenshot 2023-09-19 at 4 22 07 pm" src="https://github.com/WordPress/gutenberg/assets/6458278/d23815e2-00fc-427e-8fc7-484c31e3ea54">

