### PR TITLE
Site editor: use constants rather than hard coded template strings

### DIFF
--- a/packages/edit-site/src/components/add-new-pattern/index.js
+++ b/packages/edit-site/src/components/add-new-pattern/index.js
@@ -23,7 +23,6 @@ import { store as editSiteStore } from '../../store';
 import {
 	PATTERN_TYPES,
 	PATTERN_DEFAULT_CATEGORY,
-	TEMPLATE_POST_TYPE,
 	TEMPLATE_PART_POST_TYPE,
 } from '../../utils/constants';
 import usePatternCategories from '../sidebar-navigation-screen-patterns/use-pattern-categories';
@@ -65,7 +64,7 @@ export default function AddNewPattern() {
 		// Navigate to the created template part editor.
 		history.push( {
 			postId: templatePart.id,
-			postType: TEMPLATE_POST_TYPE,
+			postType: TEMPLATE_PART_POST_TYPE,
 			canvas: 'edit',
 		} );
 	}

--- a/packages/edit-site/src/components/add-new-pattern/index.js
+++ b/packages/edit-site/src/components/add-new-pattern/index.js
@@ -23,6 +23,7 @@ import { store as editSiteStore } from '../../store';
 import {
 	PATTERN_TYPES,
 	PATTERN_DEFAULT_CATEGORY,
+	TEMPLATE_POST_TYPE,
 	TEMPLATE_PART_POST_TYPE,
 } from '../../utils/constants';
 import usePatternCategories from '../sidebar-navigation-screen-patterns/use-pattern-categories';
@@ -51,8 +52,8 @@ export default function AddNewPattern() {
 
 		history.push( {
 			postId: pattern.id,
-			postType: 'wp_block',
-			categoryType: 'wp_block',
+			postType: PATTERN_TYPES.user,
+			categoryType: PATTERN_TYPES.user,
 			categoryId,
 			canvas: 'edit',
 		} );
@@ -64,7 +65,7 @@ export default function AddNewPattern() {
 		// Navigate to the created template part editor.
 		history.push( {
 			postId: templatePart.id,
-			postType: 'wp_template_part',
+			postType: TEMPLATE_POST_TYPE,
 			canvas: 'edit',
 		} );
 	}

--- a/packages/edit-site/src/components/block-editor/block-editor-provider/navigation-block-editor-provider.js
+++ b/packages/edit-site/src/components/block-editor/block-editor-provider/navigation-block-editor-provider.js
@@ -16,6 +16,7 @@ import { createBlock } from '@wordpress/blocks';
 import { unlock } from '../../../lock-unlock';
 import useSiteEditorSettings from '../use-site-editor-settings';
 import { store as editSiteStore } from '../../../store';
+import { NAVIGATION_POST_TYPE } from '../../../utils/constants';
 
 const { ExperimentalBlockEditorProvider } = unlock( blockEditorPrivateApis );
 
@@ -37,7 +38,7 @@ const noop = () => {};
 export default function NavigationBlockEditorProvider( { children } ) {
 	const defaultSettings = useSiteEditorSettings();
 
-	const navigationMenuId = useEntityId( 'postType', 'wp_navigation' );
+	const navigationMenuId = useEntityId( 'postType', NAVIGATION_POST_TYPE );
 
 	const blocks = useMemo( () => {
 		return [

--- a/packages/edit-site/src/components/block-editor/site-editor-canvas.js
+++ b/packages/edit-site/src/components/block-editor/site-editor-canvas.js
@@ -22,7 +22,10 @@ import EditorCanvas from './editor-canvas';
 import EditorCanvasContainer from '../editor-canvas-container';
 import useSiteEditorSettings from './use-site-editor-settings';
 import { store as editSiteStore } from '../../store';
-import { FOCUSABLE_ENTITIES } from '../../utils/constants';
+import {
+	FOCUSABLE_ENTITIES,
+	NAVIGATION_POST_TYPE,
+} from '../../utils/constants';
 import { unlock } from '../../lock-unlock';
 import PageContentFocusManager from '../page-content-focus-manager';
 
@@ -71,7 +74,7 @@ export default function SiteEditorCanvas() {
 		! isMobileViewport;
 
 	const contentRef = useRef();
-	const isTemplateTypeNavigation = templateType === 'wp_navigation';
+	const isTemplateTypeNavigation = templateType === NAVIGATION_POST_TYPE;
 
 	const isNavigationFocusMode = isTemplateTypeNavigation && isFocusMode;
 

--- a/packages/edit-site/src/components/create-template-part-modal/index.js
+++ b/packages/edit-site/src/components/create-template-part-modal/index.js
@@ -34,6 +34,7 @@ import {
 	getUniqueTemplatePartTitle,
 	getCleanTemplatePartSlug,
 } from '../../utils/template-part-create';
+import { TEMPLATE_PART_POST_TYPE } from '../../utils/constants';
 
 export default function CreateTemplatePartModal( {
 	closeModal,
@@ -73,7 +74,7 @@ export default function CreateTemplatePartModal( {
 
 			const templatePart = await saveEntityRecord(
 				'postType',
-				'wp_template_part',
+				TEMPLATE_PART_POST_TYPE,
 				{
 					slug: cleanSlug,
 					title: uniqueTitle,

--- a/packages/edit-site/src/components/create-template-part-modal/index.js
+++ b/packages/edit-site/src/components/create-template-part-modal/index.js
@@ -28,13 +28,15 @@ import { serialize } from '@wordpress/blocks';
 /**
  * Internal dependencies
  */
-import { TEMPLATE_PART_AREA_DEFAULT_CATEGORY } from '../../utils/constants';
+import {
+	TEMPLATE_PART_POST_TYPE,
+	TEMPLATE_PART_AREA_DEFAULT_CATEGORY,
+} from '../../utils/constants';
 import {
 	useExistingTemplateParts,
 	getUniqueTemplatePartTitle,
 	getCleanTemplatePartSlug,
 } from '../../utils/template-part-create';
-import { TEMPLATE_PART_POST_TYPE } from '../../utils/constants';
 
 export default function CreateTemplatePartModal( {
 	closeModal,

--- a/packages/edit-site/src/components/header-edit-mode/document-actions/index.js
+++ b/packages/edit-site/src/components/header-edit-mode/document-actions/index.js
@@ -32,12 +32,19 @@ import { store as coreStore } from '@wordpress/core-data';
  */
 import useEditedEntityRecord from '../../use-edited-entity-record';
 import { store as editSiteStore } from '../../../store';
+import {
+	TEMPLATE_POST_TYPE,
+	NAVIGATION_POST_TYPE,
+	TEMPLATE_PART_POST_TYPE,
+	PATTERN_TYPES,
+	PATTERN_SYNC_TYPES,
+} from '../../../utils/constants';
 
 const typeLabels = {
-	wp_block: __( 'Editing pattern:' ),
-	wp_navigation: __( 'Editing navigation menu:' ),
-	wp_template: __( 'Editing template:' ),
-	wp_template_part: __( 'Editing template part:' ),
+	[ PATTERN_TYPES.user ]: __( 'Editing pattern:' ),
+	[ NAVIGATION_POST_TYPE ]: __( 'Editing navigation menu:' ),
+	[ TEMPLATE_POST_TYPE ]: __( 'Editing template:' ),
+	[ TEMPLATE_PART_POST_TYPE ]: __( 'Editing template part:' ),
 };
 
 export default function DocumentActions() {
@@ -129,9 +136,9 @@ function TemplateDocumentActions( { className, onBack } ) {
 	}
 
 	let typeIcon = icon;
-	if ( record.type === 'wp_navigation' ) {
+	if ( record.type === NAVIGATION_POST_TYPE ) {
 		typeIcon = navigationIcon;
-	} else if ( record.type === 'wp_block' ) {
+	} else if ( record.type === PATTERN_TYPES.user ) {
 		typeIcon = symbol;
 	}
 
@@ -139,13 +146,15 @@ function TemplateDocumentActions( { className, onBack } ) {
 		<BaseDocumentActions
 			className={ classnames( className, {
 				'is-synced-entity':
-					record.wp_pattern_sync_status !== 'unsynced',
+					record.wp_pattern_sync_status !==
+					PATTERN_SYNC_TYPES.unsynced,
 			} ) }
 			icon={ typeIcon }
 			onBack={ onBack }
 		>
 			<VisuallyHidden as="span">
-				{ typeLabels[ record.type ] ?? typeLabels.wp_template }
+				{ typeLabels[ record.type ] ??
+					typeLabels[ TEMPLATE_POST_TYPE ] }
 			</VisuallyHidden>
 			{ getTitle() }
 		</BaseDocumentActions>

--- a/packages/edit-site/src/components/list/added-by.js
+++ b/packages/edit-site/src/components/list/added-by.js
@@ -19,10 +19,21 @@ import {
 } from '@wordpress/icons';
 import { _x } from '@wordpress/i18n';
 
+/**
+ * Internal dependencies
+ */
+import {
+	TEMPLATE_POST_TYPE,
+	TEMPLATE_PART_POST_TYPE,
+} from '../../utils/constants';
+
 /** @typedef {'wp_template'|'wp_template_part'} TemplateType */
 
 /** @type {TemplateType} */
-const TEMPLATE_POST_TYPE_NAMES = [ 'wp_template', 'wp_template_part' ];
+const TEMPLATE_POST_TYPE_NAMES = [
+	TEMPLATE_POST_TYPE,
+	TEMPLATE_PART_POST_TYPE,
+];
 
 /**
  * @typedef {'theme'|'plugin'|'site'|'user'} AddedByType
@@ -176,7 +187,7 @@ export default function AddedBy( { postType, postId } ) {
 				{ text }
 				{ isCustomized && (
 					<span className="edit-site-list-added-by__customized-info">
-						{ postType === 'wp_template'
+						{ postType === TEMPLATE_POST_TYPE
 							? _x( 'Customized', 'template' )
 							: _x( 'Customized', 'template part' ) }
 					</span>

--- a/packages/edit-site/src/components/list/added-by.js
+++ b/packages/edit-site/src/components/list/added-by.js
@@ -25,6 +25,7 @@ import { _x } from '@wordpress/i18n';
 import {
 	TEMPLATE_POST_TYPE,
 	TEMPLATE_PART_POST_TYPE,
+	TEMPLATE_ORIGINS,
 } from '../../utils/constants';
 
 /** @typedef {'wp_template'|'wp_template_part'} TemplateType */
@@ -75,11 +76,12 @@ export function useAddedBy( postType, postId ) {
 				// or 'custom' source.
 				if (
 					template.has_theme_file &&
-					( template.origin === 'theme' ||
+					( template.origin === TEMPLATE_ORIGINS.theme ||
 						( ! template.origin &&
-							[ 'theme', 'custom' ].includes(
-								template.source
-							) ) )
+							[
+								TEMPLATE_ORIGINS.theme,
+								TEMPLATE_ORIGINS.custom,
+							].includes( template.source ) ) )
 				) {
 					return {
 						type: 'theme',
@@ -87,18 +89,23 @@ export function useAddedBy( postType, postId ) {
 						text:
 							getTheme( template.theme )?.name?.rendered ||
 							template.theme,
-						isCustomized: template.source === 'custom',
+						isCustomized:
+							template.source === TEMPLATE_ORIGINS.custom,
 					};
 				}
 
 				// Added by plugin.
-				if ( template.has_theme_file && template.origin === 'plugin' ) {
+				if (
+					template.has_theme_file &&
+					template.origin === TEMPLATE_ORIGINS.plugin
+				) {
 					return {
-						type: 'plugin',
+						type: TEMPLATE_ORIGINS.plugin,
 						icon: pluginIcon,
 						text:
 							getPlugin( template.theme )?.name || template.theme,
-						isCustomized: template.source === 'custom',
+						isCustomized:
+							template.source === TEMPLATE_ORIGINS.custom,
 					};
 				}
 
@@ -108,7 +115,7 @@ export function useAddedBy( postType, postId ) {
 				// site logo and title.
 				if (
 					! template.has_theme_file &&
-					template.source === 'custom' &&
+					template.source === TEMPLATE_ORIGINS.custom &&
 					! template.author
 				) {
 					const siteData = getEntityRecord(

--- a/packages/edit-site/src/components/list/index.js
+++ b/packages/edit-site/src/components/list/index.js
@@ -17,6 +17,10 @@ import Header from './header';
 import Table from './table';
 import useTitle from '../routes/use-title';
 import { unlock } from '../../lock-unlock';
+import {
+	TEMPLATE_POST_TYPE,
+	TEMPLATE_PART_POST_TYPE,
+} from '../../utils/constants';
 
 const { useLocation } = unlock( routerPrivateApis );
 
@@ -25,7 +29,9 @@ export default function List() {
 		params: { path },
 	} = useLocation();
 	const templateType =
-		path === '/wp_template/all' ? 'wp_template' : 'wp_template_part';
+		path === '/wp_template/all'
+			? TEMPLATE_POST_TYPE
+			: TEMPLATE_PART_POST_TYPE;
 
 	useRegisterShortcuts();
 

--- a/packages/edit-site/src/components/page-patterns/duplicate-menu-item.js
+++ b/packages/edit-site/src/components/page-patterns/duplicate-menu-item.js
@@ -70,7 +70,7 @@ export default function DuplicateMenuItem( {
 
 			const result = await saveEntityRecord(
 				'postType',
-				'wp_template_part',
+				TEMPLATE_PART_POST_TYPE,
 				{ slug, title, content, area },
 				{ throwOnError: true }
 			);
@@ -162,7 +162,7 @@ export default function DuplicateMenuItem( {
 
 			const result = await saveEntityRecord(
 				'postType',
-				'wp_block',
+				PATTERN_TYPES.user,
 				{
 					content: isThemePattern
 						? item.content

--- a/packages/edit-site/src/components/page-patterns/use-patterns.js
+++ b/packages/edit-site/src/components/page-patterns/use-patterns.js
@@ -16,6 +16,7 @@ import {
 	PATTERN_TYPES,
 	PATTERN_SYNC_TYPES,
 	TEMPLATE_PART_POST_TYPE,
+	TEMPLATE_ORIGINS,
 	TEMPLATE_PART_AREA_DEFAULT_CATEGORY,
 } from '../../utils/constants';
 import { unlock } from '../../lock-unlock';
@@ -33,7 +34,7 @@ const templatePartToPattern = ( templatePart ) => ( {
 	} ),
 	categories: [ templatePart.area ],
 	description: templatePart.description || '',
-	isCustom: templatePart.source === 'custom',
+	isCustom: templatePart.source === TEMPLATE_ORIGINS.custom,
 	keywords: templatePart.keywords || [],
 	id: createTemplatePartId( templatePart.theme, templatePart.slug ),
 	name: createTemplatePartId( templatePart.theme, templatePart.slug ),

--- a/packages/edit-site/src/components/page-template-parts/add-new-template-part.js
+++ b/packages/edit-site/src/components/page-template-parts/add-new-template-part.js
@@ -13,6 +13,7 @@ import { Button } from '@wordpress/components';
 import { unlock } from '../../lock-unlock';
 import { store as editSiteStore } from '../../store';
 import CreateTemplatePartModal from '../create-template-part-modal';
+import { TEMPLATE_PART_POST_TYPE } from '../../utils/constants';
 
 const { useHistory } = unlock( routerPrivateApis );
 
@@ -22,7 +23,9 @@ export default function AddNewTemplatePart() {
 			select( editSiteStore ).getSettings();
 		return {
 			canCreate: ! supportsTemplatePartsMode,
-			postType: select( coreStore ).getPostType( 'wp_template_part' ),
+			postType: select( coreStore ).getPostType(
+				TEMPLATE_PART_POST_TYPE
+			),
 		};
 	}, [] );
 	const [ isModalOpen, setIsModalOpen ] = useState( false );
@@ -45,7 +48,7 @@ export default function AddNewTemplatePart() {
 						setIsModalOpen( false );
 						history.push( {
 							postId: templatePart.id,
-							postType: 'wp_template_part',
+							postType: TEMPLATE_PART_POST_TYPE,
 							canvas: 'edit',
 						} );
 					} }

--- a/packages/edit-site/src/components/page-template-parts/index.js
+++ b/packages/edit-site/src/components/page-template-parts/index.js
@@ -19,11 +19,12 @@ import Link from '../routes/link';
 import AddedBy from '../list/added-by';
 import TemplateActions from '../template-actions';
 import AddNewTemplatePart from './add-new-template-part';
+import { TEMPLATE_PART_POST_TYPE } from '../../utils/constants';
 
 export default function PageTemplateParts() {
 	const { records: templateParts } = useEntityRecords(
 		'postType',
-		'wp_template_part',
+		TEMPLATE_PART_POST_TYPE,
 		{
 			per_page: -1,
 		}

--- a/packages/edit-site/src/components/page-templates/index.js
+++ b/packages/edit-site/src/components/page-templates/index.js
@@ -20,11 +20,12 @@ import Link from '../routes/link';
 import AddedBy from '../list/added-by';
 import TemplateActions from '../template-actions';
 import AddNewTemplate from '../add-new-template';
+import { TEMPLATE_POST_TYPE } from '../../utils/constants';
 
 export default function PageTemplates() {
 	const { records: templates } = useEntityRecords(
 		'postType',
-		'wp_template',
+		TEMPLATE_POST_TYPE,
 		{
 			per_page: -1,
 		}
@@ -79,7 +80,7 @@ export default function PageTemplates() {
 			title={ __( 'Templates' ) }
 			actions={
 				<AddNewTemplate
-					templateType={ 'wp_template' }
+					templateType={ TEMPLATE_POST_TYPE }
 					showIcon={ false }
 					toggleProps={ { variant: 'primary' } }
 				/>

--- a/packages/edit-site/src/components/save-hub/index.js
+++ b/packages/edit-site/src/components/save-hub/index.js
@@ -16,13 +16,14 @@ import { store as noticesStore } from '@wordpress/notices';
 import SaveButton from '../save-button';
 import { isPreviewingTheme } from '../../utils/is-previewing-theme';
 import { unlock } from '../../lock-unlock';
+import { NAVIGATION_POST_TYPE } from '../../utils/constants';
 
 const { useLocation } = unlock( routerPrivateApis );
 
 const PUBLISH_ON_SAVE_ENTITIES = [
 	{
 		kind: 'postType',
-		name: 'wp_navigation',
+		name: NAVIGATION_POST_TYPE,
 	},
 ];
 

--- a/packages/edit-site/src/components/sidebar-edit-mode/page-panels/hooks.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/page-panels/hooks.js
@@ -9,6 +9,7 @@ import { store as coreStore } from '@wordpress/core-data';
  * Internal dependencies
  */
 import { store as editSiteStore } from '../../../store';
+import { TEMPLATE_POST_TYPE } from '../../../utils/constants';
 
 export function useEditedPostContext() {
 	return useSelect(
@@ -31,10 +32,14 @@ export function useIsPostsPage() {
 function useTemplates() {
 	return useSelect(
 		( select ) =>
-			select( coreStore ).getEntityRecords( 'postType', 'wp_template', {
-				per_page: -1,
-				post_type: 'page',
-			} ),
+			select( coreStore ).getEntityRecords(
+				'postType',
+				TEMPLATE_POST_TYPE,
+				{
+					per_page: -1,
+					post_type: 'page',
+				}
+			),
 		[]
 	);
 }

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/edit-button.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/edit-button.js
@@ -8,11 +8,12 @@ import { pencil } from '@wordpress/icons';
  */
 import SidebarButton from '../sidebar-button';
 import { useLink } from '../routes/link';
+import { NAVIGATION_POST_TYPE } from '../../utils/constants';
 
 export default function EditButton( { postId } ) {
 	const linkInfo = useLink( {
 		postId,
-		postType: 'wp_navigation',
+		postType: NAVIGATION_POST_TYPE,
 		canvas: 'edit',
 	} );
 	return (

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/use-navigation-menu-handlers.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/use-navigation-menu-handlers.js
@@ -6,10 +6,12 @@ import { __experimentalUseNavigator as useNavigator } from '@wordpress/component
 import { __, sprintf } from '@wordpress/i18n';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { store as noticesStore } from '@wordpress/notices';
+
 /**
  * Internal dependencies
  */
 import { postType } from '.';
+import { NAVIGATION_POST_TYPE } from '../../utils/constants';
 
 function useDeleteNavigationMenu() {
 	const { goTo } = useNavigator();
@@ -82,7 +84,7 @@ function useSaveNavigationMenu() {
 		// Prepare for revert in case of error.
 		const originalRecord = getEditedEntityRecord(
 			'postType',
-			'wp_navigation',
+			NAVIGATION_POST_TYPE,
 			postId
 		);
 

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/index.js
@@ -22,6 +22,7 @@ import { useLink } from '../routes/link';
 import SingleNavigationMenu from '../sidebar-navigation-screen-navigation-menu/single-navigation-menu';
 import useNavigationMenuHandlers from '../sidebar-navigation-screen-navigation-menu/use-navigation-menu-handlers';
 import { unlock } from '../../lock-unlock';
+import { NAVIGATION_POST_TYPE } from '../../utils/constants';
 
 // Copied from packages/block-library/src/navigation/edit/navigation-menu-selector.js.
 function buildMenuLabel( title, id, status ) {
@@ -52,7 +53,7 @@ export default function SidebarNavigationScreenNavigationMenus() {
 		hasResolved: hasResolvedNavigationMenus,
 	} = useEntityRecords(
 		'postType',
-		`wp_navigation`,
+		NAVIGATION_POST_TYPE,
 		PRELOADED_NAVIGATION_MENUS_QUERY
 	);
 
@@ -151,7 +152,7 @@ export function SidebarNavigationScreenWrapper( {
 const NavMenuItem = ( { postId, ...props } ) => {
 	const linkInfo = useLink( {
 		postId,
-		postType: 'wp_navigation',
+		postType: NAVIGATION_POST_TYPE,
 	} );
 	return <SidebarNavigationItem { ...linkInfo } { ...props } />;
 };

--- a/packages/edit-site/src/components/sidebar-navigation-screen-page/page-details.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-page/page-details.js
@@ -21,6 +21,7 @@ import {
 	SidebarNavigationScreenDetailsPanelLabel,
 	SidebarNavigationScreenDetailsPanelValue,
 } from '../sidebar-navigation-screen-details-panel';
+import { TEMPLATE_POST_TYPE } from '../../utils/constants';
 
 // Taken from packages/editor/src/components/time-to-read/index.js.
 const AVERAGE_READING_RATE = 189;
@@ -106,7 +107,7 @@ export default function PageDetails( { id } ) {
 			const postContext = getEditedPostContext();
 			const templates = select( coreStore ).getEntityRecords(
 				'postType',
-				'wp_template',
+				TEMPLATE_POST_TYPE,
 				{ per_page: -1 }
 			);
 			// Template title.

--- a/packages/edit-site/src/components/sidebar-navigation-screen-pages/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-pages/index.js
@@ -24,6 +24,7 @@ import SidebarNavigationItem from '../sidebar-navigation-item';
 import SidebarButton from '../sidebar-button';
 import AddNewPageModal from '../add-new-page';
 import { unlock } from '../../lock-unlock';
+import { TEMPLATE_POST_TYPE } from '../../utils/constants';
 
 const { useHistory } = unlock( routerPrivateApis );
 
@@ -50,7 +51,7 @@ export default function SidebarNavigationScreenPages() {
 		}
 	);
 	const { records: templates, isResolving: isLoadingTemplates } =
-		useEntityRecords( 'postType', 'wp_template', {
+		useEntityRecords( 'postType', TEMPLATE_POST_TYPE, {
 			per_page: -1,
 		} );
 
@@ -130,7 +131,7 @@ export default function SidebarNavigationScreenPages() {
 
 		return {
 			icon: itemIcon,
-			postType: postsPageTemplateId ? 'wp_template' : 'page',
+			postType: postsPageTemplateId ? TEMPLATE_POST_TYPE : 'page',
 			postId: postsPageTemplateId || id,
 		};
 	};

--- a/packages/edit-site/src/components/sidebar-navigation-screen-pattern/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-pattern/index.js
@@ -17,6 +17,7 @@ import usePatternDetails from './use-pattern-details';
 import { store as editSiteStore } from '../../store';
 import { unlock } from '../../lock-unlock';
 import TemplateActions from '../template-actions';
+import { TEMPLATE_PART_POST_TYPE } from '../../utils/constants';
 
 export default function SidebarNavigationScreenPattern() {
 	const navigator = useNavigator();
@@ -34,7 +35,7 @@ export default function SidebarNavigationScreenPattern() {
 	// indicates the user has arrived at the template part via the "manage all"
 	// page and the back button should return them to that list page.
 	const backPath =
-		! categoryType && postType === 'wp_template_part'
+		! categoryType && postType === TEMPLATE_PART_POST_TYPE
 			? '/wp_template_part/all'
 			: '/patterns';
 

--- a/packages/edit-site/src/components/sidebar-navigation-screen-pattern/template-part-navigation-menu-list-item.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-pattern/template-part-navigation-menu-list-item.js
@@ -9,13 +9,19 @@ import { __ } from '@wordpress/i18n';
  */
 import SidebarNavigationItem from '../sidebar-navigation-item';
 import { useLink } from '../routes/link';
+import { NAVIGATION_POST_TYPE } from '../../utils/constants';
 
 export default function TemplatePartNavigationMenuListItem( { id } ) {
-	const [ title ] = useEntityProp( 'postType', 'wp_navigation', 'title', id );
+	const [ title ] = useEntityProp(
+		'postType',
+		NAVIGATION_POST_TYPE,
+		'title',
+		id
+	);
 
 	const linkInfo = useLink( {
 		postId: id,
-		postType: 'wp_navigation',
+		postType: NAVIGATION_POST_TYPE,
 	} );
 
 	if ( ! id ) return null;

--- a/packages/edit-site/src/components/sidebar-navigation-screen-pattern/template-part-navigation-menu.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-pattern/template-part-navigation-menu.js
@@ -9,9 +9,15 @@ import { useEntityProp } from '@wordpress/core-data';
  * Internal dependencies
  */
 import NavigationMenuEditor from '../sidebar-navigation-screen-navigation-menu/navigation-menu-editor';
+import { NAVIGATION_POST_TYPE } from '../../utils/constants';
 
 export default function TemplatePartNavigationMenu( { id } ) {
-	const [ title ] = useEntityProp( 'postType', 'wp_navigation', 'title', id );
+	const [ title ] = useEntityProp(
+		'postType',
+		NAVIGATION_POST_TYPE,
+		'title',
+		id
+	);
 
 	if ( ! id ) return null;
 

--- a/packages/edit-site/src/components/sidebar-navigation-screen-pattern/use-navigation-menu-content.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-pattern/use-navigation-menu-content.js
@@ -8,6 +8,7 @@ import { parse } from '@wordpress/blocks';
  */
 import TemplatePartNavigationMenus from './template-part-navigation-menus';
 import useEditedEntityRecord from '../use-edited-entity-record';
+import { TEMPLATE_PART_POST_TYPE } from '../../utils/constants';
 
 /**
  * Retrieves a list of specific blocks from a given tree of blocks.
@@ -55,7 +56,7 @@ export default function useNavigationMenuContent( postType, postId ) {
 	// Only managing navigation menus in template parts is supported
 	// to match previous behaviour. This could potentially be expanded
 	// to patterns as well.
-	if ( postType !== 'wp_template_part' ) {
+	if ( postType !== TEMPLATE_PART_POST_TYPE ) {
 		return;
 	}
 

--- a/packages/edit-site/src/components/sidebar-navigation-screen-pattern/use-pattern-details.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-pattern/use-pattern-details.js
@@ -86,7 +86,10 @@ export default function usePatternDetails( postType, postId ) {
 
 	const details = [];
 
-	if ( postType === PATTERN_TYPES.user || postType === TEMPLATE_PART_POST_TYPE ) {
+	if (
+		postType === PATTERN_TYPES.user ||
+		postType === TEMPLATE_PART_POST_TYPE
+	) {
 		details.push( {
 			label: __( 'Syncing' ),
 			value:

--- a/packages/edit-site/src/components/sidebar-navigation-screen-pattern/use-pattern-details.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-pattern/use-pattern-details.js
@@ -86,7 +86,7 @@ export default function usePatternDetails( postType, postId ) {
 
 	const details = [];
 
-	if ( postType === PATTERN_TYPES.user || TEMPLATE_PART_POST_TYPE ) {
+	if ( postType === PATTERN_TYPES.user || postType === TEMPLATE_PART_POST_TYPE ) {
 		details.push( {
 			label: __( 'Syncing' ),
 			value:

--- a/packages/edit-site/src/components/sidebar-navigation-screen-pattern/use-pattern-details.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-pattern/use-pattern-details.js
@@ -24,6 +24,11 @@ import {
 	SidebarNavigationScreenDetailsPanelLabel,
 	SidebarNavigationScreenDetailsPanelValue,
 } from '../sidebar-navigation-screen-details-panel';
+import {
+	PATTERN_TYPES,
+	TEMPLATE_PART_POST_TYPE,
+	PATTERN_SYNC_TYPES,
+} from '../../utils/constants';
 
 export default function usePatternDetails( postType, postId ) {
 	const { getDescription, getTitle, record } = useEditedEntityRecord(
@@ -53,7 +58,7 @@ export default function usePatternDetails( postType, postId ) {
 
 	if ( ! description && addedBy.text ) {
 		description =
-			postType === 'wp_block'
+			postType === PATTERN_TYPES.user
 				? sprintf(
 						// translators: %s: pattern title e.g: "Header".
 						__( 'This is the %s pattern.' ),
@@ -66,7 +71,7 @@ export default function usePatternDetails( postType, postId ) {
 				  );
 	}
 
-	if ( ! description && postType === 'wp_block' && record?.title ) {
+	if ( ! description && postType === PATTERN_TYPES.user && record?.title ) {
 		description = sprintf(
 			// translators: %s: user created pattern title e.g. "Footer".
 			__( 'This is the %s pattern.' ),
@@ -80,11 +85,11 @@ export default function usePatternDetails( postType, postId ) {
 
 	const details = [];
 
-	if ( postType === 'wp_block' || 'wp_template_part' ) {
+	if ( postType === PATTERN_TYPES.user || TEMPLATE_PART_POST_TYPE ) {
 		details.push( {
 			label: __( 'Syncing' ),
 			value:
-				record.wp_pattern_sync_status === 'unsynced'
+				record.wp_pattern_sync_status === PATTERN_SYNC_TYPES.unsynced
 					? __( 'Not synced' )
 					: __( 'Fully synced' ),
 		} );
@@ -112,7 +117,7 @@ export default function usePatternDetails( postType, postId ) {
 		}
 	}
 
-	if ( postType === 'wp_template_part' ) {
+	if ( postType === TEMPLATE_PART_POST_TYPE ) {
 		const templatePartArea = templatePartAreas.find(
 			( area ) => area.area === record.area
 		);
@@ -133,7 +138,7 @@ export default function usePatternDetails( postType, postId ) {
 	}
 
 	if (
-		postType === 'wp_template_part' &&
+		postType === TEMPLATE_PART_POST_TYPE &&
 		addedBy.text &&
 		! isAddedByActiveTheme
 	) {
@@ -148,7 +153,7 @@ export default function usePatternDetails( postType, postId ) {
 	}
 
 	if (
-		postType === 'wp_template_part' &&
+		postType === TEMPLATE_PART_POST_TYPE &&
 		addedBy.text &&
 		( record.origin === 'plugin' || record.has_theme_file === true )
 	) {

--- a/packages/edit-site/src/components/sidebar-navigation-screen-pattern/use-pattern-details.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-pattern/use-pattern-details.js
@@ -28,6 +28,7 @@ import {
 	PATTERN_TYPES,
 	TEMPLATE_PART_POST_TYPE,
 	PATTERN_SYNC_TYPES,
+	TEMPLATE_ORIGINS,
 } from '../../utils/constants';
 
 export default function usePatternDetails( postType, postId ) {
@@ -155,7 +156,8 @@ export default function usePatternDetails( postType, postId ) {
 	if (
 		postType === TEMPLATE_PART_POST_TYPE &&
 		addedBy.text &&
-		( record.origin === 'plugin' || record.has_theme_file === true )
+		( record.origin === TEMPLATE_ORIGINS.plugin ||
+			record.has_theme_file === true )
 	) {
 		details.push( {
 			label: __( 'Customized' ),

--- a/packages/edit-site/src/components/sidebar-navigation-screen-patterns/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-patterns/index.js
@@ -19,7 +19,11 @@ import AddNewPattern from '../add-new-pattern';
 import SidebarNavigationItem from '../sidebar-navigation-item';
 import SidebarNavigationScreen from '../sidebar-navigation-screen';
 import CategoryItem from './category-item';
-import { PATTERN_DEFAULT_CATEGORY, PATTERN_TYPES } from '../../utils/constants';
+import {
+	PATTERN_DEFAULT_CATEGORY,
+	PATTERN_TYPES,
+	TEMPLATE_PART_POST_TYPE,
+} from '../../utils/constants';
 import { useLink } from '../routes/link';
 import usePatternCategories from './use-pattern-categories';
 import useTemplatePartAreas from './use-template-part-areas';
@@ -39,10 +43,10 @@ function TemplatePartGroup( { areas, currentArea, currentType } ) {
 							icon={ getTemplatePartIcon( area ) }
 							label={ label }
 							id={ area }
-							type="wp_template_part"
+							type={ TEMPLATE_PART_POST_TYPE }
 							isActive={
 								currentArea === area &&
-								currentType === 'wp_template_part'
+								currentType === TEMPLATE_PART_POST_TYPE
 							}
 						/>
 					)

--- a/packages/edit-site/src/components/template-actions/rename-menu-item.js
+++ b/packages/edit-site/src/components/template-actions/rename-menu-item.js
@@ -16,6 +16,11 @@ import { store as coreStore } from '@wordpress/core-data';
 import { store as noticesStore } from '@wordpress/notices';
 import { decodeEntities } from '@wordpress/html-entities';
 
+/**
+ * Internal dependencies
+ */
+import { TEMPLATE_POST_TYPE } from '../../utils/constants';
+
 export default function RenameMenuItem( { template, onClose } ) {
 	const title = decodeEntities( template.title.rendered );
 	const [ editedTitle, setEditedTitle ] = useState( title );
@@ -28,7 +33,7 @@ export default function RenameMenuItem( { template, onClose } ) {
 	const { createSuccessNotice, createErrorNotice } =
 		useDispatch( noticesStore );
 
-	if ( template.type === 'wp_template' && ! template.is_custom ) {
+	if ( template.type === TEMPLATE_POST_TYPE && ! template.is_custom ) {
 		return null;
 	}
 
@@ -57,7 +62,7 @@ export default function RenameMenuItem( { template, onClose } ) {
 			);
 
 			createSuccessNotice(
-				template.type === 'wp_template'
+				template.type === TEMPLATE_POST_TYPE
 					? __( 'Template renamed.' )
 					: __( 'Template part renamed.' ),
 				{
@@ -66,7 +71,7 @@ export default function RenameMenuItem( { template, onClose } ) {
 			);
 		} catch ( error ) {
 			const fallbackErrorMessage =
-				template.type === 'wp_template'
+				template.type === TEMPLATE_POST_TYPE
 					? __( 'An error occurred while renaming the template.' )
 					: __(
 							'An error occurred while renaming the template part.'

--- a/packages/edit-site/src/hooks/navigation-menu-edit.js
+++ b/packages/edit-site/src/hooks/navigation-menu-edit.js
@@ -15,6 +15,7 @@ import { privateApis as routerPrivateApis } from '@wordpress/router';
  */
 import { useLink } from '../components/routes/link';
 import { unlock } from '../lock-unlock';
+import { NAVIGATION_POST_TYPE } from '../utils/constants';
 
 const { useLocation } = unlock( routerPrivateApis );
 
@@ -26,7 +27,7 @@ function NavigationMenuEdit( { attributes } ) {
 		( select ) => {
 			return select( coreStore ).getEntityRecord(
 				'postType',
-				'wp_navigation',
+				NAVIGATION_POST_TYPE,
 				// Ideally this should be an official public API.
 				ref
 			);

--- a/packages/edit-site/src/hooks/template-part-edit.js
+++ b/packages/edit-site/src/hooks/template-part-edit.js
@@ -15,6 +15,7 @@ import { privateApis as routerPrivateApis } from '@wordpress/router';
  */
 import { useLink } from '../components/routes/link';
 import { unlock } from '../lock-unlock';
+import { TEMPLATE_PART_POST_TYPE } from '../utils/constants';
 
 const { useLocation } = unlock( routerPrivateApis );
 
@@ -25,7 +26,7 @@ function EditTemplatePartMenuItem( { attributes } ) {
 		( select ) => {
 			return select( coreStore ).getEntityRecord(
 				'postType',
-				'wp_template_part',
+				TEMPLATE_PART_POST_TYPE,
 				// Ideally this should be an official public API.
 				`${ theme }//${ slug }`
 			);

--- a/packages/edit-site/src/store/selectors.js
+++ b/packages/edit-site/src/store/selectors.js
@@ -18,7 +18,10 @@ import { store as blockEditorStore } from '@wordpress/block-editor';
  * Internal dependencies
  */
 import { getFilteredTemplatePartBlocks } from './utils';
-
+import {
+	TEMPLATE_POST_TYPE,
+	TEMPLATE_PART_POST_TYPE,
+} from '../utils/constants';
 /**
  * @typedef {'template'|'template_type'} TemplateType Template type.
  */
@@ -126,7 +129,7 @@ export const getSettings = createSelector(
 			__experimentalSetIsInserterOpened: setIsInserterOpen,
 			__experimentalReusableBlocks: getReusableBlocks( state ),
 			__experimentalPreferPatternsOnRoot:
-				'wp_template' === getEditedPostType( state ),
+				TEMPLATE_POST_TYPE === getEditedPostType( state ),
 		};
 
 		const canUserCreateMedia = getCanUserCreateMedia( state );
@@ -300,7 +303,7 @@ export const getCurrentTemplateTemplateParts = createRegistrySelector(
 
 		const templateParts = select( coreDataStore ).getEntityRecords(
 			'postType',
-			'wp_template_part',
+			TEMPLATE_PART_POST_TYPE,
 			{ per_page: -1 }
 		);
 

--- a/packages/edit-site/src/utils/constants.js
+++ b/packages/edit-site/src/utils/constants.js
@@ -15,7 +15,11 @@ export const NAVIGATION_POST_TYPE = 'wp_navigation';
 // Templates.
 export const TEMPLATE_POST_TYPE = 'wp_template';
 export const TEMPLATE_PART_POST_TYPE = 'wp_template_part';
-export const TEMPLATE_CUSTOM_SOURCE = 'custom';
+export const TEMPLATE_ORIGINS = {
+	custom: 'custom',
+	theme: 'theme',
+	plugin: 'plugin',
+};
 export const TEMPLATE_PART_AREA_DEFAULT_CATEGORY = 'uncategorized';
 
 // Patterns.

--- a/packages/edit-site/src/utils/is-template-removable.js
+++ b/packages/edit-site/src/utils/is-template-removable.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { TEMPLATE_CUSTOM_SOURCE } from './constants';
+import { TEMPLATE_ORIGINS } from './constants';
 
 /**
  * Check if a template is removable.
@@ -15,6 +15,6 @@ export default function isTemplateRemovable( template ) {
 	}
 
 	return (
-		template.source === TEMPLATE_CUSTOM_SOURCE && ! template.has_theme_file
+		template.source === TEMPLATE_ORIGINS.custom && ! template.has_theme_file
 	);
 }

--- a/packages/edit-site/src/utils/is-template-revertable.js
+++ b/packages/edit-site/src/utils/is-template-revertable.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { TEMPLATE_CUSTOM_SOURCE } from './constants';
+import { TEMPLATE_ORIGINS } from './constants';
 
 /**
  * Check if a template is revertable to its original theme-provided template file.
@@ -15,7 +15,7 @@ export default function isTemplateRevertable( template ) {
 	}
 	/* eslint-disable camelcase */
 	return (
-		template?.source === TEMPLATE_CUSTOM_SOURCE && template?.has_theme_file
+		template?.source === TEMPLATE_ORIGINS.custom && template?.has_theme_file
 	);
 	/* eslint-enable camelcase */
 }

--- a/packages/edit-site/src/utils/template-part-create.js
+++ b/packages/edit-site/src/utils/template-part-create.js
@@ -9,12 +9,17 @@ import { paramCase as kebabCase } from 'change-case';
 import { useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 
+/**
+ * Internal dependencies
+ */
+import { TEMPLATE_PART_POST_TYPE } from './constants';
+
 export const useExistingTemplateParts = () => {
 	return useSelect(
 		( select ) =>
 			select( coreStore ).getEntityRecords(
 				'postType',
-				'wp_template_part',
+				TEMPLATE_PART_POST_TYPE,
 				{
 					per_page: -1,
 				}


### PR DESCRIPTION
## What?

Hello!

This is a follow up to

- https://github.com/WordPress/gutenberg/pull/54484 

The effort continues to consolidate constants. 🔨 

❗ To reduce the amount of files and testing involved, this PR doesn't replace all instances of hard-coded strings. There will be more follow ups.

## Why?
To centralize names for post types and so on. Ease of management. Giving search and replace a well-deserved rest.

## How?
Replacing the following strings with constants

| String | Constant |
| ------------- | ------------- |
| 'wp_navigation'  | `NAVIGATION_POST_TYPE`  |
| 'wp_template' | `TEMPLATE_POST_TYPE`  |
| 'wp_template_part'  | `TEMPLATE_PART_POST_TYPE` |
| 'custom' | `TEMPLATE_CUSTOM_SOURCE` |
| 'wp_block'  | `PATTERN_TYPES.user`  |
| 'custom'  | `TEMPLATE_ORIGINS.custom`  |
| 'theme'  | `TEMPLATE_ORIGINS.theme`  |
| 'plugin'  | `TEMPLATE_ORIGINS.plugin`  |
| 'unsynced' | `PATTERN_SYNC_TYPES.unsynced` |


## Testing Instructions

- CI tests should pass.
- Check that the replaced strings match a constant.
- Smoke test site editor, e.g., create and edit some templates. Rename them, delete them. All should work as expected.


