### PR TITLE
Include the active theme to the prompt

### DIFF
--- a/packages/edit-site/src/components/save-panel/index.js
+++ b/packages/edit-site/src/components/save-panel/index.js
@@ -39,19 +39,24 @@ const EntitiesSavedStatesForPreview = ( { onClose } ) => {
 		activateSaveLabel = __( 'Activate' );
 	}
 
-	const themeName = useSelect( ( select ) => {
-		const theme = select( coreStore ).getTheme(
+	const { currentTheme, previewingTheme } = useSelect( ( select ) => {
+		const _currentTheme = select( coreStore ).getCurrentTheme();
+		const _previewingTheme = select( coreStore ).getTheme(
 			currentlyPreviewingTheme()
 		);
 
-		return theme?.name?.rendered;
+		return {
+			currentTheme: _currentTheme?.name?.rendered,
+			previewingTheme: _previewingTheme?.name?.rendered,
+		};
 	}, [] );
 
 	const additionalPrompt = (
 		<p>
 			{ sprintf(
-				'Saving your changes will change your active theme to %s.',
-				themeName
+				'Saving your changes will change your active theme (%1$s) to %2$s.',
+				currentTheme,
+				previewingTheme
 			) }
 		</p>
 	);


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This PR shows the current theme in the prompt when users are to activate a previewing theme.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

- Block Theme Previews encourage more theme switching. It'd be helpful to know the name of the current theme when users think about going back to the previous theme. 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

- It gets the current theme with `getCurrentTheme` in the core store and displays it.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- Go to `/themes.php`
- Click `Live Preview` on any Block theme
- Click `Activate`
- See the current theme is displayed in the prompt text

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
