### PR TITLE
Memoize `useSelect` for `usePatterns`

### DIFF
--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { camelCase } from 'change-case';
-import createSelector from 'rememo';
 
 /**
  * WordPress dependencies
@@ -620,15 +619,6 @@ export const getBlockPatternCategories =
 		dispatch( { type: 'RECEIVE_BLOCK_PATTERN_CATEGORIES', categories } );
 	};
 
-const mapPatternCategories = createSelector(
-	( patternCategories ) =>
-		patternCategories?.map( ( userCategory ) => ( {
-			...userCategory,
-			label: userCategory.name,
-			name: userCategory.slug,
-		} ) ) || []
-);
-
 export const getUserPatternCategories =
 	() =>
 	async ( { dispatch, resolveSelect } ) => {
@@ -641,9 +631,16 @@ export const getUserPatternCategories =
 			}
 		);
 
+		const mappedPatternCategories =
+			patternCategories?.map( ( userCategory ) => ( {
+				...userCategory,
+				label: userCategory.name,
+				name: userCategory.slug,
+			} ) ) || [];
+
 		dispatch( {
 			type: 'RECEIVE_USER_PATTERN_CATEGORIES',
-			patternCategories: mapPatternCategories( patternCategories ),
+			patternCategories: mappedPatternCategories,
 		} );
 	};
 

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { camelCase } from 'change-case';
+import createSelector from 'rememo';
 
 /**
  * WordPress dependencies
@@ -619,6 +620,15 @@ export const getBlockPatternCategories =
 		dispatch( { type: 'RECEIVE_BLOCK_PATTERN_CATEGORIES', categories } );
 	};
 
+const mapPatternCategories = createSelector(
+	( patternCategories ) =>
+		patternCategories?.map( ( userCategory ) => ( {
+			...userCategory,
+			label: userCategory.name,
+			name: userCategory.slug,
+		} ) ) || []
+);
+
 export const getUserPatternCategories =
 	() =>
 	async ( { dispatch, resolveSelect } ) => {
@@ -631,16 +641,9 @@ export const getUserPatternCategories =
 			}
 		);
 
-		const mappedPatternCategories =
-			patternCategories?.map( ( userCategory ) => ( {
-				...userCategory,
-				label: userCategory.name,
-				name: userCategory.slug,
-			} ) ) || [];
-
 		dispatch( {
 			type: 'RECEIVE_USER_PATTERN_CATEGORIES',
-			patternCategories: mappedPatternCategories,
+			patternCategories: mapPatternCategories( patternCategories ),
 		} );
 	};
 

--- a/packages/edit-site/src/components/page-patterns/use-patterns.js
+++ b/packages/edit-site/src/components/page-patterns/use-patterns.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import createSelector from 'rememo';
+
+/**
  * WordPress dependencies
  */
 import { parse } from '@wordpress/blocks';
@@ -43,108 +48,136 @@ const templatePartToPattern = ( templatePart ) => ( {
 	templatePart,
 } );
 
-const selectTemplatePartsAsPatterns = (
-	select,
-	{ categoryId, search = '' } = {}
-) => {
-	const { getEntityRecords, getIsResolving } = select( coreStore );
-	const { __experimentalGetDefaultTemplatePartAreas } = select( editorStore );
-	const query = { per_page: -1 };
-	const rawTemplateParts =
-		getEntityRecords( 'postType', TEMPLATE_PART_POST_TYPE, query ) ??
-		EMPTY_PATTERN_LIST;
-	const templateParts = rawTemplateParts.map( ( templatePart ) =>
-		templatePartToPattern( templatePart )
-	);
+const selectTemplatePartsAsPatterns = createSelector(
+	( select, categoryId, search = '' ) => {
+		const { getEntityRecords, getIsResolving } = select( coreStore );
+		const { __experimentalGetDefaultTemplatePartAreas } =
+			select( editorStore );
+		const query = { per_page: -1 };
+		const rawTemplateParts =
+			getEntityRecords( 'postType', TEMPLATE_PART_POST_TYPE, query ) ??
+			EMPTY_PATTERN_LIST;
+		const templateParts = rawTemplateParts.map( ( templatePart ) =>
+			templatePartToPattern( templatePart )
+		);
 
-	// In the case where a custom template part area has been removed we need
-	// the current list of areas to cross check against so orphaned template
-	// parts can be treated as uncategorized.
-	const knownAreas = __experimentalGetDefaultTemplatePartAreas() || [];
-	const templatePartAreas = knownAreas.map( ( area ) => area.area );
+		// In the case where a custom template part area has been removed we need
+		// the current list of areas to cross check against so orphaned template
+		// parts can be treated as uncategorized.
+		const knownAreas = __experimentalGetDefaultTemplatePartAreas() || [];
+		const templatePartAreas = knownAreas.map( ( area ) => area.area );
 
-	const templatePartHasCategory = ( item, category ) => {
-		if ( category !== TEMPLATE_PART_AREA_DEFAULT_CATEGORY ) {
-			return item.templatePart.area === category;
+		const templatePartHasCategory = ( item, category ) => {
+			if ( category !== TEMPLATE_PART_AREA_DEFAULT_CATEGORY ) {
+				return item.templatePart.area === category;
+			}
+
+			return (
+				item.templatePart.area === category ||
+				! templatePartAreas.includes( item.templatePart.area )
+			);
+		};
+
+		const isResolving = getIsResolving( 'getEntityRecords', [
+			'postType',
+			TEMPLATE_PART_POST_TYPE,
+			query,
+		] );
+
+		const patterns = searchItems( templateParts, search, {
+			categoryId,
+			hasCategory: templatePartHasCategory,
+		} );
+
+		return { patterns, isResolving };
+	},
+	( select ) => [
+		select( coreStore ).getEntityRecords(
+			'postType',
+			TEMPLATE_PART_POST_TYPE,
+			{
+				per_page: -1,
+			}
+		),
+		select( coreStore ).getIsResolving( 'getEntityRecords', [
+			'postType',
+			TEMPLATE_PART_POST_TYPE,
+			{ per_page: -1 },
+		] ),
+		select( editorStore ).__experimentalGetDefaultTemplatePartAreas(),
+	]
+);
+
+const selectThemePatterns = createSelector(
+	( select ) => {
+		const { getSettings } = unlock( select( editSiteStore ) );
+		const settings = getSettings();
+		const blockPatterns =
+			settings.__experimentalAdditionalBlockPatterns ??
+			settings.__experimentalBlockPatterns;
+
+		const restBlockPatterns = select( coreStore ).getBlockPatterns();
+
+		const patterns = [
+			...( blockPatterns || [] ),
+			...( restBlockPatterns || [] ),
+		]
+			.filter(
+				( pattern ) => ! PATTERN_CORE_SOURCES.includes( pattern.source )
+			)
+			.filter( filterOutDuplicatesByName )
+			.filter( ( pattern ) => pattern.inserter !== false )
+			.map( ( pattern ) => ( {
+				...pattern,
+				keywords: pattern.keywords || [],
+				type: PATTERN_TYPES.theme,
+				blocks: parse( pattern.content, {
+					__unstableSkipMigrationLogs: true,
+				} ),
+			} ) );
+
+		return { patterns, isResolving: false };
+	},
+	( select ) => [
+		select( coreStore ).getBlockPatterns(),
+		unlock( select( editSiteStore ) ).getSettings(),
+	]
+);
+
+const selectPatterns = createSelector(
+	( select, categoryId, syncStatus, search = '' ) => {
+		const { patterns: themePatterns } = selectThemePatterns( select );
+		const { patterns: userPatterns } = selectUserPatterns( select );
+
+		let patterns = [
+			...( themePatterns || [] ),
+			...( userPatterns || [] ),
+		];
+
+		if ( syncStatus ) {
+			patterns = patterns.filter(
+				( pattern ) => pattern.syncStatus === syncStatus
+			);
 		}
 
-		return (
-			item.templatePart.area === category ||
-			! templatePartAreas.includes( item.templatePart.area )
-		);
-	};
-
-	const isResolving = getIsResolving( 'getEntityRecords', [
-		'postType',
-		TEMPLATE_PART_POST_TYPE,
-		query,
-	] );
-
-	const patterns = searchItems( templateParts, search, {
-		categoryId,
-		hasCategory: templatePartHasCategory,
-	} );
-
-	return { patterns, isResolving };
-};
-
-const selectThemePatterns = ( select ) => {
-	const { getSettings } = unlock( select( editSiteStore ) );
-	const settings = getSettings();
-	const blockPatterns =
-		settings.__experimentalAdditionalBlockPatterns ??
-		settings.__experimentalBlockPatterns;
-
-	const restBlockPatterns = select( coreStore ).getBlockPatterns();
-
-	const patterns = [
-		...( blockPatterns || [] ),
-		...( restBlockPatterns || [] ),
+		if ( categoryId ) {
+			patterns = searchItems( patterns, search, {
+				categoryId,
+				hasCategory: ( item, currentCategory ) =>
+					item.categories?.includes( currentCategory ),
+			} );
+		} else {
+			patterns = searchItems( patterns, search, {
+				hasCategory: ( item ) => ! item.hasOwnProperty( 'categories' ),
+			} );
+		}
+		return { patterns, isResolving: false };
+	},
+	( select ) => [
+		selectThemePatterns( select ),
+		selectUserPatterns( select ),
 	]
-		.filter(
-			( pattern ) => ! PATTERN_CORE_SOURCES.includes( pattern.source )
-		)
-		.filter( filterOutDuplicatesByName )
-		.filter( ( pattern ) => pattern.inserter !== false )
-		.map( ( pattern ) => ( {
-			...pattern,
-			keywords: pattern.keywords || [],
-			type: PATTERN_TYPES.theme,
-			blocks: parse( pattern.content, {
-				__unstableSkipMigrationLogs: true,
-			} ),
-		} ) );
-
-	return { patterns, isResolving: false };
-};
-const selectPatterns = (
-	select,
-	{ categoryId, search = '', syncStatus } = {}
-) => {
-	const { patterns: themePatterns } = selectThemePatterns( select );
-	const { patterns: userPatterns } = selectUserPatterns( select );
-
-	let patterns = [ ...( themePatterns || [] ), ...( userPatterns || [] ) ];
-
-	if ( syncStatus ) {
-		patterns = patterns.filter(
-			( pattern ) => pattern.syncStatus === syncStatus
-		);
-	}
-
-	if ( categoryId ) {
-		patterns = searchItems( patterns, search, {
-			categoryId,
-			hasCategory: ( item, currentCategory ) =>
-				item.categories?.includes( currentCategory ),
-		} );
-	} else {
-		patterns = searchItems( patterns, search, {
-			hasCategory: ( item ) => ! item.hasOwnProperty( 'categories' ),
-		} );
-	}
-	return { patterns, isResolving: false };
-};
+);
 
 const patternBlockToPattern = ( patternBlock, categories ) => ( {
 	blocks: parse( patternBlock.content.raw, {
@@ -166,44 +199,67 @@ const patternBlockToPattern = ( patternBlock, categories ) => ( {
 	patternBlock,
 } );
 
-const selectUserPatterns = ( select, { search = '', syncStatus } = {} ) => {
-	const { getEntityRecords, getIsResolving, getUserPatternCategories } =
-		select( coreStore );
+const selectUserPatterns = createSelector(
+	( select, syncStatus, search = '' ) => {
+		const { getEntityRecords, getIsResolving, getUserPatternCategories } =
+			select( coreStore );
 
-	const query = { per_page: -1 };
-	const records = getEntityRecords( 'postType', PATTERN_TYPES.user, query );
-	const userPatternCategories = getUserPatternCategories();
-	const categories = new Map();
-	userPatternCategories.forEach( ( userCategory ) =>
-		categories.set( userCategory.id, userCategory )
-	);
-	let patterns = records
-		? records.map( ( record ) =>
-				patternBlockToPattern( record, categories )
-		  )
-		: EMPTY_PATTERN_LIST;
-
-	const isResolving = getIsResolving( 'getEntityRecords', [
-		'postType',
-		PATTERN_TYPES.user,
-		query,
-	] );
-
-	if ( syncStatus ) {
-		patterns = patterns.filter(
-			( pattern ) => pattern.syncStatus === syncStatus
+		const query = { per_page: -1 };
+		const records = getEntityRecords(
+			'postType',
+			PATTERN_TYPES.user,
+			query
 		);
-	}
+		const userPatternCategories = getUserPatternCategories();
+		const categories = new Map();
+		userPatternCategories.forEach( ( userCategory ) =>
+			categories.set( userCategory.id, userCategory )
+		);
+		let patterns = records
+			? records.map( ( record ) =>
+					patternBlockToPattern( record, categories )
+			  )
+			: EMPTY_PATTERN_LIST;
 
-	patterns = searchItems( patterns, search, {
-		// We exit user pattern retrieval early if we aren't in the
-		// catch-all category for user created patterns, so it has
-		// to be in the category.
-		hasCategory: () => true,
-	} );
+		const isResolving = getIsResolving( 'getEntityRecords', [
+			'postType',
+			PATTERN_TYPES.user,
+			query,
+		] );
 
-	return { patterns, isResolving, categories: userPatternCategories };
-};
+		if ( syncStatus ) {
+			patterns = patterns.filter(
+				( pattern ) => pattern.syncStatus === syncStatus
+			);
+		}
+
+		patterns = searchItems( patterns, search, {
+			// We exit user pattern retrieval early if we aren't in the
+			// catch-all category for user created patterns, so it has
+			// to be in the category.
+			hasCategory: () => true,
+		} );
+
+		return {
+			patterns,
+			isResolving,
+			categories: userPatternCategories,
+		};
+	},
+	( select, { search, syncStatus } = {} ) => [
+		select( coreStore ).getEntityRecords( 'postType', PATTERN_TYPES.user, {
+			per_page: -1,
+		} ),
+		select( coreStore ).getIsResolving( 'getEntityRecords', [
+			'postType',
+			PATTERN_TYPES.user,
+			{ per_page: -1 },
+		] ),
+		select( coreStore ).getUserPatternCategories(),
+		search,
+		syncStatus,
+	]
+);
 
 export const usePatterns = (
 	categoryType,
@@ -213,20 +269,20 @@ export const usePatterns = (
 	return useSelect(
 		( select ) => {
 			if ( categoryType === TEMPLATE_PART_POST_TYPE ) {
-				return selectTemplatePartsAsPatterns( select, {
+				return selectTemplatePartsAsPatterns(
+					select,
 					categoryId,
-					search,
-				} );
+					search
+				);
 			} else if ( categoryType === PATTERN_TYPES.theme ) {
-				return selectPatterns( select, {
-					categoryId,
-					search,
-					syncStatus,
-				} );
+				return selectPatterns( select, categoryId, syncStatus, search );
 			} else if ( categoryType === PATTERN_TYPES.user ) {
-				return selectUserPatterns( select, { search, syncStatus } );
+				return selectUserPatterns( select, syncStatus, search );
 			}
-			return { patterns: EMPTY_PATTERN_LIST, isResolving: false };
+			return {
+				patterns: EMPTY_PATTERN_LIST,
+				isResolving: false,
+			};
 		},
 		[ categoryId, categoryType, search, syncStatus ]
 	);

--- a/packages/edit-site/src/components/page-patterns/use-patterns.js
+++ b/packages/edit-site/src/components/page-patterns/use-patterns.js
@@ -246,7 +246,7 @@ const selectUserPatterns = createSelector(
 			categories: userPatternCategories,
 		};
 	},
-	( select, { search, syncStatus } = {} ) => [
+	( select ) => [
 		select( coreStore ).getEntityRecords( 'postType', PATTERN_TYPES.user, {
 			per_page: -1,
 		} ),
@@ -256,8 +256,6 @@ const selectUserPatterns = createSelector(
 			{ per_page: -1 },
 		] ),
 		select( coreStore ).getUserPatternCategories(),
-		search,
-		syncStatus,
 	]
 );
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Originally reported in https://github.com/WordPress/gutenberg/pull/52303#issuecomment-1678885719 by @Mamaduka. This PR memoizes some selectors to avoid re-renders.

It's best to be reviewed with whitespaces hidden.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Even though re-renders aren't necessarily bad, and sometimes over-memoizing selectors comes with a cost, I don't think memoizing it brings any harm either. It silences a warning in console so that must be good! 😆 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Use `rememo` to memoize some selectors used in `usePatterns`.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Open the page that uses `usePatterns` (`site-editor.php?path=/patterns`) and navigate around or interact with it.
2. Expect the console not to output the `useSelect` warning about `usePatterns`.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
Same as above.

## Screenshots or screencast <!-- if applicable -->
N/A