### PR TITLE
Allow Modal to place focus on first element within contents via new API

### DIFF
--- a/packages/block-editor/src/hooks/block-rename-ui.js
+++ b/packages/block-editor/src/hooks/block-rename-ui.js
@@ -69,6 +69,7 @@ function RenameModal( { blockName, originalBlockName, onClose, onSave } ) {
 			aria={ {
 				describedby: dialogDescription,
 			} }
+			focusOnMount="firstContentElement"
 		>
 			<p id={ dialogDescription }>
 				{ __( 'Enter a custom name for this block.' ) }

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Enhancements
 
+-   Add new option `firstContentElement` to Modal's `focusOnMount` prop to allow consumers to focus the first element within the Modal's **contents** ([#54590](https://github.com/WordPress/gutenberg/pull/54590)).
 -   `Notice`: Improve accessibility by adding visually hidden text to clarify what a notice text is about and the notice type (success, error, warning, info) ([#54498](https://github.com/WordPress/gutenberg/pull/54498)).
 -   Making Circular Option Picker a `listbox`. Note that while this changes some public API, new props are optional, and currently have default values; this will change in another patch ([#52255](https://github.com/WordPress/gutenberg/pull/52255)).
 -   `ToggleGroupControl`: Rewrite backdrop animation using framer motion shared layout animations, add better support for controlled and uncontrolled modes ([#50278](https://github.com/WordPress/gutenberg/pull/50278)).

--- a/packages/components/src/modal/README.md
+++ b/packages/components/src/modal/README.md
@@ -191,9 +191,11 @@ Titles are required for accessibility reasons, see `aria.labelledby` and `title`
 
 If this property is true, it will focus the first tabbable element rendered in the modal.
 
-If set to `firstElement` it will focus the first focusable element anywhere within the Modal.
+If this property is false, focus will not be transferred and it is the responsibility of the consumer to ensure accessible focus management.
 
-If set to `firstContentElement` it will focus the first focusable element within the Modal's **content** (i.e. children).
+If set to `firstElement` focus will be placed on the first tabbable element anywhere within the Modal.
+
+If set to `firstContentElement` focus will be placed on the first tabbable element within the Modal's **content** (i.e. children). Note that it is the responsibility of the consumer to ensure there is at least one tabbable element within the children **or the focus will be lost**.
 
 -   Required: No
 -   Default: `true`

--- a/packages/components/src/modal/README.md
+++ b/packages/components/src/modal/README.md
@@ -187,9 +187,13 @@ Titles are required for accessibility reasons, see `aria.labelledby` and `title`
 
 -   Required: No
 
-#### `focusOnMount`: `boolean | 'firstElement'`
+#### `focusOnMount`: `boolean | 'firstElement'` | 'firstContentElement'
 
 If this property is true, it will focus the first tabbable element rendered in the modal.
+
+If set to `firstElement` it will focus the first focusable element anywhere within the Modal.
+
+If set to `firstContentElement` it will focus the first focusable element within the Modal's **content** (i.e. children).
 
 -   Required: No
 -   Default: `true`

--- a/packages/components/src/modal/index.tsx
+++ b/packages/components/src/modal/index.tsx
@@ -71,16 +71,20 @@ function UnforwardedModal(
 	} = props;
 
 	const ref = useRef< HTMLDivElement >();
+
 	const instanceId = useInstanceId( Modal );
 	const headingId = title
 		? `components-modal-header-${ instanceId }`
 		: aria.labelledby;
-	const focusOnMountRef = useFocusOnMount( focusOnMount );
+	const focusOnMountRef = useFocusOnMount(
+		focusOnMount === 'firstContentElement' ? 'firstElement' : focusOnMount
+	);
 	const constrainedTabbingRef = useConstrainedTabbing();
 	const focusReturnRef = useFocusReturn();
 	const focusOutsideProps = useFocusOutside( onRequestClose );
 	const contentRef = useRef< HTMLDivElement >( null );
 	const childrenContainerRef = useRef< HTMLDivElement >( null );
+	const noopRef = useRef< HTMLDivElement >( null );
 
 	const [ hasScrolledContent, setHasScrolledContent ] = useState( false );
 	const [ hasScrollableContent, setHasScrollableContent ] = useState( false );
@@ -223,7 +227,9 @@ function UnforwardedModal(
 					ref={ useMergeRefs( [
 						constrainedTabbingRef,
 						focusReturnRef,
-						focusOnMountRef,
+						focusOnMount !== 'firstContentElement'
+							? focusOnMountRef
+							: noopRef,
 					] ) }
 					role={ role }
 					aria-label={ contentLabel }
@@ -283,7 +289,17 @@ function UnforwardedModal(
 								) }
 							</div>
 						) }
-						<div ref={ childrenContainerRef }>{ children }</div>
+						<div ref={ childrenContainerRef }>
+							<div
+								ref={
+									focusOnMount === 'firstContentElement'
+										? focusOnMountRef
+										: noopRef
+								}
+							>
+								{ children }
+							</div>
+						</div>
 					</div>
 				</div>
 			</StyleProvider>

--- a/packages/components/src/modal/index.tsx
+++ b/packages/components/src/modal/index.tsx
@@ -79,11 +79,12 @@ function UnforwardedModal(
 
 	// The focus hook does not support 'firstContentElement' but this is a valid
 	// value for the Modal's focusOnMount prop. The following code ensures the focus
-	// hook will focus the first element in the element to which it is applied.
+	// hook will focus the first focusable node within the element to which it is applied.
 	// When `firstContentElement` is passed as the value of the focusOnMount prop,
-	// the focus hook is applied to the Modal's contentRef. Otherwise, the focus hook
-	// is applied to the Modal's ref. This ensures that the focus hook will focus the
-	// first element in the Modal's **content** when `firstContentElement` is passed.
+	// the focus hook is applied to the Modal's content element.
+	// Otherwise, the focus hook is applied to the Modal's ref. This ensures that the
+	// focus hook will focus the first element in the Modal's **content** when
+	// `firstContentElement` is passed.
 	const focusOnMountRef = useFocusOnMount(
 		focusOnMount === 'firstContentElement' ? 'firstElement' : focusOnMount
 	);

--- a/packages/components/src/modal/index.tsx
+++ b/packages/components/src/modal/index.tsx
@@ -296,16 +296,16 @@ function UnforwardedModal(
 								) }
 							</div>
 						) }
-						<div ref={ childrenContainerRef }>
-							<div
-								ref={
-									focusOnMount === 'firstContentElement'
-										? focusOnMountRef
-										: undefined
-								}
-							>
-								{ children }
-							</div>
+
+						<div
+							ref={ useMergeRefs( [
+								childrenContainerRef,
+								focusOnMount === 'firstContentElement'
+									? focusOnMountRef
+									: null,
+							] ) }
+						>
+							{ children }
 						</div>
 					</div>
 				</div>

--- a/packages/components/src/modal/index.tsx
+++ b/packages/components/src/modal/index.tsx
@@ -84,7 +84,6 @@ function UnforwardedModal(
 	const focusOutsideProps = useFocusOutside( onRequestClose );
 	const contentRef = useRef< HTMLDivElement >( null );
 	const childrenContainerRef = useRef< HTMLDivElement >( null );
-	const noopRef = useRef< HTMLDivElement >( null );
 
 	const [ hasScrolledContent, setHasScrolledContent ] = useState( false );
 	const [ hasScrollableContent, setHasScrollableContent ] = useState( false );
@@ -229,7 +228,7 @@ function UnforwardedModal(
 						focusReturnRef,
 						focusOnMount !== 'firstContentElement'
 							? focusOnMountRef
-							: noopRef,
+							: null,
 					] ) }
 					role={ role }
 					aria-label={ contentLabel }
@@ -294,7 +293,7 @@ function UnforwardedModal(
 								ref={
 									focusOnMount === 'firstContentElement'
 										? focusOnMountRef
-										: noopRef
+										: undefined
 								}
 							>
 								{ children }

--- a/packages/components/src/modal/index.tsx
+++ b/packages/components/src/modal/index.tsx
@@ -76,6 +76,14 @@ function UnforwardedModal(
 	const headingId = title
 		? `components-modal-header-${ instanceId }`
 		: aria.labelledby;
+
+	// The focus hook does not support 'firstContentElement' but this is a valid
+	// value for the Modal's focusOnMount prop. The following code ensures the focus
+	// hook will focus the first element in the element to which it is applied.
+	// When `firstContentElement` is passed as the value of the focusOnMount prop,
+	// the focus hook is applied to the Modal's contentRef. Otherwise, the focus hook
+	// is applied to the Modal's ref. This ensures that the focus hook will focus the
+	// first element in the Modal's **content** when `firstContentElement` is passed.
 	const focusOnMountRef = useFocusOnMount(
 		focusOnMount === 'firstContentElement' ? 'firstElement' : focusOnMount
 	);

--- a/packages/components/src/modal/stories/index.story.tsx
+++ b/packages/components/src/modal/stories/index.story.tsx
@@ -28,7 +28,8 @@ const meta: Meta< typeof Modal > = {
 			control: { type: null },
 		},
 		focusOnMount: {
-			control: { type: 'boolean' },
+			options: [ true, false, 'firstElement', 'firstContentElement' ],
+			control: { type: 'select' },
 		},
 		role: {
 			control: { type: 'text' },

--- a/packages/components/src/modal/test/index.tsx
+++ b/packages/components/src/modal/test/index.tsx
@@ -302,6 +302,47 @@ describe( 'Modal', () => {
 			).toHaveFocus();
 		} );
 
+		it( 'should focus the first element anywhere within the Modal when `firstElement` passed as value for `focusOnMount` prop', async () => {
+			const user = userEvent.setup();
+
+			const FocusMountDemo = () => {
+				const [ isShown, setIsShown ] = useState( false );
+				return (
+					<>
+						<button onClick={ () => setIsShown( true ) }>📣</button>
+						{ isShown && (
+							<Modal
+								focusOnMount="firstElement"
+								onRequestClose={ () => setIsShown( false ) }
+							>
+								<p>Modal content</p>
+								<a
+									href="https://wordpress.org"
+									data-testid="first-focusable-element"
+								>
+									Focusable Element
+								</a>
+
+								<a href="https://wordpress.org">
+									Another Focusable Element
+								</a>
+							</Modal>
+						) }
+					</>
+				);
+			};
+
+			render( <FocusMountDemo /> );
+
+			const opener = screen.getByRole( 'button' );
+
+			await user.click( opener );
+
+			expect(
+				screen.getByRole( 'button', { name: 'Close' } )
+			).toHaveFocus();
+		} );
+
 		it( 'should focus the Modal dialog when `true` passed as value for `focusOnMount` prop', async () => {
 			const user = userEvent.setup();
 			const FocusMountDemo = () => {

--- a/packages/components/src/modal/test/index.tsx
+++ b/packages/components/src/modal/test/index.tsx
@@ -293,7 +293,7 @@ describe( 'Modal', () => {
 		it( 'should focus the Modal dialog by default when `focusOnMount` prop is not provided', async () => {
 			const user = userEvent.setup();
 
-			render( <FocusMountDemo focusOnMount={ true } /> );
+			render( <FocusMountDemo /> );
 
 			const opener = screen.getByRole( 'button', {
 				name: 'Toggle Modal',

--- a/packages/components/src/modal/test/index.tsx
+++ b/packages/components/src/modal/test/index.tsx
@@ -13,6 +13,7 @@ import { useState } from '@wordpress/element';
  * Internal dependencies
  */
 import Modal from '../';
+import type { ModalProps } from '../types';
 
 const noop = () => {};
 
@@ -240,6 +241,34 @@ describe( 'Modal', () => {
 	describe( 'Focus handling', () => {
 		let originalGetClientRects: () => DOMRectList;
 
+		const FocusMountDemo = ( {
+			focusOnMount,
+		}: Pick< ModalProps, 'focusOnMount' > ) => {
+			const [ isShown, setIsShown ] = useState( false );
+			return (
+				<>
+					<button onClick={ () => setIsShown( true ) }>
+						Toggle Modal
+					</button>
+					{ isShown && (
+						<Modal
+							focusOnMount={ focusOnMount }
+							onRequestClose={ () => setIsShown( false ) }
+						>
+							<p>Modal content</p>
+							<a href="https://wordpress.org">
+								First Focusable Content Element
+							</a>
+
+							<a href="https://wordpress.org">
+								Another Focusable Content Element
+							</a>
+						</Modal>
+					) }
+				</>
+			);
+		};
+
 		beforeEach( () => {
 			/**
 			 * The test environment does not have a layout engine, so we need to mock
@@ -261,78 +290,52 @@ describe( 'Modal', () => {
 				originalGetClientRects;
 		} );
 
+		it( 'should focus the Modal dialog by default when `focusOnMount` prop is not provided', async () => {
+			const user = userEvent.setup();
+
+			render( <FocusMountDemo focusOnMount={ true } /> );
+
+			const opener = screen.getByRole( 'button', {
+				name: 'Toggle Modal',
+			} );
+
+			await user.click( opener );
+
+			expect( screen.getByRole( 'dialog' ) ).toHaveFocus();
+		} );
+
+		it( 'should focus the Modal dialog when `true` passed as value for `focusOnMount` prop', async () => {
+			const user = userEvent.setup();
+
+			render( <FocusMountDemo focusOnMount={ true } /> );
+
+			const opener = screen.getByRole( 'button', {
+				name: 'Toggle Modal',
+			} );
+
+			await user.click( opener );
+
+			expect( screen.getByRole( 'dialog' ) ).toHaveFocus();
+		} );
+
 		it( 'should focus the first focusable element in the contents (if found) when `firstContentElement` passed as value for `focusOnMount` prop', async () => {
 			const user = userEvent.setup();
 
-			const FocusMountDemo = () => {
-				const [ isShown, setIsShown ] = useState( false );
-				return (
-					<>
-						<button onClick={ () => setIsShown( true ) }>📣</button>
-						{ isShown && (
-							<Modal
-								focusOnMount="firstContentElement"
-								onRequestClose={ () => setIsShown( false ) }
-							>
-								<p>Modal content</p>
-								<a
-									href="https://wordpress.org"
-									data-testid="first-focusable-element"
-								>
-									First Focusable Element
-								</a>
-
-								<a href="https://wordpress.org">
-									Another Focusable Element
-								</a>
-							</Modal>
-						) }
-					</>
-				);
-			};
-
-			render( <FocusMountDemo /> );
+			render( <FocusMountDemo focusOnMount="firstContentElement" /> );
 
 			const opener = screen.getByRole( 'button' );
 
 			await user.click( opener );
 
 			expect(
-				screen.getByTestId( 'first-focusable-element' )
+				screen.getByText( 'First Focusable Content Element' )
 			).toHaveFocus();
 		} );
 
 		it( 'should focus the first element anywhere within the Modal when `firstElement` passed as value for `focusOnMount` prop', async () => {
 			const user = userEvent.setup();
 
-			const FocusMountDemo = () => {
-				const [ isShown, setIsShown ] = useState( false );
-				return (
-					<>
-						<button onClick={ () => setIsShown( true ) }>📣</button>
-						{ isShown && (
-							<Modal
-								focusOnMount="firstElement"
-								onRequestClose={ () => setIsShown( false ) }
-							>
-								<p>Modal content</p>
-								<a
-									href="https://wordpress.org"
-									data-testid="first-focusable-element"
-								>
-									Focusable Element
-								</a>
-
-								<a href="https://wordpress.org">
-									Another Focusable Element
-								</a>
-							</Modal>
-						) }
-					</>
-				);
-			};
-
-			render( <FocusMountDemo /> );
+			render( <FocusMountDemo focusOnMount="firstElement" /> );
 
 			const opener = screen.getByRole( 'button' );
 
@@ -343,74 +346,14 @@ describe( 'Modal', () => {
 			).toHaveFocus();
 		} );
 
-		it( 'should focus the Modal dialog when `true` passed as value for `focusOnMount` prop', async () => {
-			const user = userEvent.setup();
-			const FocusMountDemo = () => {
-				const [ isShown, setIsShown ] = useState( false );
-				return (
-					<>
-						<button onClick={ () => setIsShown( true ) }>📣</button>
-						{ isShown && (
-							<Modal
-								focusOnMount
-								onRequestClose={ () => setIsShown( false ) }
-							>
-								<p>Modal content</p>
-								<a
-									href="https://wordpress.org"
-									data-testid="first-focusable-element"
-								>
-									First Focusable Element
-								</a>
-
-								<a href="https://wordpress.org">
-									Another Focusable Element
-								</a>
-							</Modal>
-						) }
-					</>
-				);
-			};
-			render( <FocusMountDemo /> );
-
-			const opener = screen.getByRole( 'button' );
-
-			await user.click( opener );
-
-			expect( screen.getByRole( 'dialog' ) ).toHaveFocus();
-		} );
-
 		it( 'should not move focus when `false` passed as value for `focusOnMount` prop', async () => {
 			const user = userEvent.setup();
-			const FocusMountDemo = () => {
-				const [ isShown, setIsShown ] = useState( false );
-				return (
-					<>
-						<button onClick={ () => setIsShown( true ) }>📣</button>
-						{ isShown && (
-							<Modal
-								focusOnMount={ false }
-								onRequestClose={ () => setIsShown( false ) }
-							>
-								<p>Modal content</p>
-								<a
-									href="https://wordpress.org"
-									data-testid="first-focusable-element"
-								>
-									First Focusable Element
-								</a>
 
-								<a href="https://wordpress.org">
-									Another Focusable Element
-								</a>
-							</Modal>
-						) }
-					</>
-				);
-			};
-			render( <FocusMountDemo /> );
+			render( <FocusMountDemo focusOnMount={ false } /> );
 
-			const opener = screen.getByRole( 'button' );
+			const opener = screen.getByRole( 'button', {
+				name: 'Toggle Modal',
+			} );
 
 			await user.click( opener );
 

--- a/packages/components/src/modal/types.ts
+++ b/packages/components/src/modal/types.ts
@@ -68,7 +68,9 @@ export type ModalProps = {
 	 *
 	 * @default true
 	 */
-	focusOnMount?: Parameters< typeof useFocusOnMount >[ 0 ];
+	focusOnMount?:
+		| Parameters< typeof useFocusOnMount >[ 0 ]
+		| 'firstContentElement';
 	/**
 	 * Elements that are injected into the modal header to the left of the close button (if rendered).
 	 * Hidden if `__experimentalHideHeader` is `true`.

--- a/test/e2e/specs/editor/various/block-renaming.spec.js
+++ b/test/e2e/specs/editor/various/block-renaming.spec.js
@@ -58,11 +58,13 @@ test.describe( 'Block Renaming', () => {
 				name: 'Rename',
 			} );
 
-			// Check focus is transferred into modal.
-			await expect( renameModal ).toBeFocused();
-
 			// Check the Modal is perceivable.
 			await expect( renameModal ).toBeVisible();
+
+			const nameInput = renameModal.getByLabel( 'Block name' );
+
+			// Check focus is transferred into the input within the Modal.
+			await expect( nameInput ).toBeFocused();
 
 			const saveButton = renameModal.getByRole( 'button', {
 				name: 'Save',
@@ -70,8 +72,6 @@ test.describe( 'Block Renaming', () => {
 			} );
 
 			await expect( saveButton ).toBeDisabled();
-
-			const nameInput = renameModal.getByLabel( 'Block name' );
 
 			await expect( nameInput ).toHaveAttribute( 'placeholder', 'Group' );
 

--- a/test/e2e/specs/editor/various/block-renaming.spec.js
+++ b/test/e2e/specs/editor/various/block-renaming.spec.js
@@ -61,7 +61,9 @@ test.describe( 'Block Renaming', () => {
 			// Check the Modal is perceivable.
 			await expect( renameModal ).toBeVisible();
 
-			const nameInput = renameModal.getByLabel( 'Block name' );
+			const nameInput = renameModal.getByRole( 'textbox', {
+				name: 'Block name',
+			} );
 
 			// Check focus is transferred into the input within the Modal.
 			await expect( nameInput ).toBeFocused();


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Adds new API to `Modal` to allow focus to be placed on first element in the _content_ on mount.

Alternative to https://github.com/WordPress/gutenberg/pull/54296

Closes https://github.com/WordPress/gutenberg/issues/54106

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

As discussed in https://github.com/WordPress/gutenberg/issues/54106 dialogs (including Modal) should ideally place focus on the first focusable element on mount. Currently all Modals find that the Close button is the first element in the DOM inside the Modal that is focusable and thus it receives focus. A11y feedback has been that this is unhelpful.

For further explanation as to how we arrived at this approach see

https://github.com/WordPress/gutenberg/pull/54296#discussion_r1325856634

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Conditionally places the `focusOnMountRef` on the Modal _contents_ `<div>` when `firstContentElement` is passed as `focusOnMount` prop. This ensures the focus is attempted within the Modal's _contents_.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- New Post
- Add some blocks and then Group them.
- Open List View
- Click options menu on Griup block and click `Rename`.
- See focus placed on `input` and not on `Close` button
- verify it's still possible to reach the `Close` button and constrained tabbing is still active.


### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## ✍️ Dev Note

The `Modal' component's `focusOnMount` prop has received an update, and it now accepts a new `"firstContentElement"` option. When setting `focusOnMount="firstContentElement"`, the `Modal` component will try to focus on the first tabbable element within the `Modal`'s content (ie. the markup passed via the `children` prop).

This is different from the pre-existing `"firstElement"` option, which causes focus to go to the first element anywhere within the `Modal`, including its header (usually the close button).

Note that it is the responsibility of the consumer to ensure that, when `focusOnMount="firstContentElement"`, there is at least one tabbable element within the `Modal`'s children.
