### PR TITLE
Fix: Wrapped `ref` in quotes in theme.json docs

### DIFF
--- a/docs/how-to-guides/themes/theme-json.md
+++ b/docs/how-to-guides/themes/theme-json.md
@@ -968,7 +968,7 @@ You can use `ref: "styles.color.background"`  to re-use the style for a block:
 ```JSON
 {
 	"color": {
-		"text": { ref: "styles.color.background" }
+		"text": { "ref": "styles.color.background" }
 	}
 }
 ```


### PR DESCRIPTION
## What?
In [how-to-guide theme.json](https://developer.wordpress.org/block-editor/how-to-guides/themes/theme-json/#referencing-a-style), wrapped `ref` in Quotes

## Why?
Closes #54537 

## How?
```
{
    "color": {
        "text": { "ref": "styles.color.background" }
    }
}
```


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
