### PR TITLE
Ensure that the view scripts of core blocks have the `wp-interactivity` dependency

### DIFF
--- a/packages/block-library/src/file/index.php
+++ b/packages/block-library/src/file/index.php
@@ -67,6 +67,23 @@ function render_block_core_file( $attributes, $content, $block ) {
 }
 
 /**
+ * Ensure that the view script has the `wp-interactivity` dependency.
+ *
+ * @since 6.4.0
+ */
+function block_core_file_ensure_interactivity_dependency() {
+	global $wp_scripts;
+	if (
+		isset( $wp_scripts->registered['wp-block-file-view'] ) &&
+		! in_array( 'wp-interactivity', $wp_scripts->registered['wp-block-file-view']->deps, true )
+	) {
+		$wp_scripts->registered['wp-block-file-view']->deps[] = 'wp-interactivity';
+	}
+}
+
+add_action( 'wp_print_scripts', 'block_core_file_ensure_interactivity_dependency' );
+
+/**
  * Registers the `core/file` block on server.
  */
 function register_block_core_file() {

--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -283,6 +283,23 @@ HTML;
 }
 
 /**
+ * Ensure that the view script has the `wp-interactivity` dependency.
+ *
+ * @since 6.4.0
+ */
+function block_core_image_ensure_interactivity_dependency() {
+	global $wp_scripts;
+	if (
+		isset( $wp_scripts->registered['wp-block-image-view'] ) &&
+		! in_array( 'wp-interactivity', $wp_scripts->registered['wp-block-image-view']->deps, true )
+	) {
+		$wp_scripts->registered['wp-block-image-view']->deps[] = 'wp-interactivity';
+	}
+}
+
+add_action( 'wp_print_scripts', 'block_core_image_ensure_interactivity_dependency' );
+
+/**
  * Registers the `core/image` block on server.
  */
 function register_block_core_image() {

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -812,6 +812,23 @@ function block_core_navigation_typographic_presets_backcompatibility( $parsed_bl
 add_filter( 'render_block_data', 'block_core_navigation_typographic_presets_backcompatibility' );
 
 /**
+ * Ensure that the view script has the `wp-interactivity` dependency.
+ *
+ * @since 6.4.0
+ */
+function block_core_navigation_ensure_interactivity_dependency() {
+	global $wp_scripts;
+	if (
+		isset( $wp_scripts->registered['wp-block-navigation-view'] ) &&
+		! in_array( 'wp-interactivity', $wp_scripts->registered['wp-block-navigation-view']->deps, true )
+	) {
+		$wp_scripts->registered['wp-block-navigation-view']->deps[] = 'wp-interactivity';
+	}
+}
+
+add_action( 'wp_print_scripts', 'block_core_navigation_ensure_interactivity_dependency' );
+
+/**
  * Turns menu item data into a nested array of parsed blocks
  *
  * @deprecated 6.3.0 Use WP_Navigation_Fallback::parse_blocks_from_menu_items() instead.

--- a/packages/block-library/src/query/index.php
+++ b/packages/block-library/src/query/index.php
@@ -8,7 +8,7 @@
 /**
  * Modifies the static `core/query` block on the server.
  *
- * @since X.X.X
+ * @since 6.4.0
  *
  * @param array  $attributes Block attributes.
  * @param string $content    Block default content.
@@ -90,6 +90,23 @@ function render_block_core_query( $attributes, $content, $block ) {
 
 	return $content;
 }
+
+/**
+ * Ensure that the view script has the `wp-interactivity` dependency.
+ *
+ * @since 6.4.0
+ */
+function block_core_query_ensure_interactivity_dependency() {
+	global $wp_scripts;
+	if (
+		isset( $wp_scripts->registered['wp-block-query-view'] ) &&
+		! in_array( 'wp-interactivity', $wp_scripts->registered['wp-block-query-view']->deps, true )
+	) {
+		$wp_scripts->registered['wp-block-query-view']->deps[] = 'wp-interactivity';
+	}
+}
+
+add_action( 'wp_print_scripts', 'block_core_query_ensure_interactivity_dependency' );
 
 /**
  * Registers the `core/query` block on the server.

--- a/packages/block-library/src/search/index.php
+++ b/packages/block-library/src/search/index.php
@@ -207,6 +207,23 @@ function register_block_core_search() {
 add_action( 'init', 'register_block_core_search' );
 
 /**
+ * Ensure that the view script has the `wp-interactivity` dependency.
+ *
+ * @since 6.4.0
+ */
+function block_core_search_ensure_interactivity_dependency() {
+	global $wp_scripts;
+	if (
+		isset( $wp_scripts->registered['wp-block-search-view'] ) &&
+		! in_array( 'wp-interactivity', $wp_scripts->registered['wp-block-search-view']->deps, true )
+	) {
+		$wp_scripts->registered['wp-block-search-view']->deps[] = 'wp-interactivity';
+	}
+}
+
+add_action( 'wp_print_scripts', 'block_core_search_ensure_interactivity_dependency' );
+
+/**
  * Builds the correct top level classnames for the 'core/search' block.
  *
  * @param array $attributes The block attributes.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Ensure that the view scripts of core blocks have the `wp-interactivity` dependency.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Because in WordPress 6.4 the Interactivity API will be private and therefore we won't use the `DependencyExtractionPlugin` with `@wordpress/interactivity` so we have to declare the dependencies manually somehow. See this WP Core PR:

- https://github.com/WordPress/wordpress-develop/pull/5195

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

By adding an action that ensures that the dependency is there. Those actions will be removed once they are no longer needed.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

There's no easy way to test this in Gutenberg because here the dependency is already added. You can add a breakpoint and inspect the code to see that it works, or copy and paste it in WordPress Core.

---

By the way, do we have to populate the `@since` with the correct WP version? Or is that automated?