### PR TITLE
Patterns: Inject the theme name into the block attributes

### DIFF
--- a/packages/block-library/src/pattern/edit.js
+++ b/packages/block-library/src/pattern/edit.js
@@ -29,6 +29,7 @@ const PatternEdit = ( { attributes, clientId } ) => {
 	const { getBlockRootClientId, getBlockEditingMode } =
 		useSelect( blockEditorStore );
 
+	// Duplicated in packages/edit-site/src/components/start-template-options/index.js.
 	function injectThemeAttributeInBlockTemplateContent( block ) {
 		if (
 			block.innerBlocks.find(


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Inject the theme name into the block attributes when a pattern is loaded in the start template screen. 

## Why?
This means that themes can live in any directory and the templates will still work. Fix here: https://github.com/WordPress/gutenberg/issues/53194

## How?
Reusing the approach from https://github.com/WordPress/gutenberg/pull/53423. We might want to refactor this so that these two instances use the same code, but I'm hesitant because I'm not sure we want to expose this as an API.

## Testing Instructions
1. Install TT4 in a subdirectory (not directly inside /themes)
2. Check out this PR: https://github.com/WordPress/twentytwentyfour/pull/403
3. Open the templates section of the site editor and go to add a new template (wp-admin/site-editor.php?postId=test%2Ftwentytwentyfour%2F%2Ffront-page&postType=wp_template&canvas=edit)
4. You should see three templates without errors

## Screenshots or screencast <!-- if applicable -->
<img width="1409" alt="Screenshot 2023-09-19 at 12 39 07" src="https://github.com/WordPress/gutenberg/assets/275961/0db19be8-478a-4dac-a3e2-cf847f45028c">
