### PR TITLE
Font Library: fix space above theme fonts in font library modal

### DIFF
--- a/packages/edit-site/src/components/global-styles/font-library-modal/installed-fonts.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/installed-fonts.js
@@ -110,12 +110,12 @@ function InstalledFonts() {
 									/>
 								) ) }
 							</FontsGrid>
+							<Spacer margin={ 8 } />
 						</>
 					) }
 
 					{ baseThemeFonts.length > 0 && (
 						<>
-							<Spacer margin={ 8 } />
 							<FontsGrid title={ __( 'Theme Fonts' ) }>
 								{ baseThemeFonts.map( ( font ) => (
 									<LibraryFontCard


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

| Before | After |
| --- | --- |
| <img width="364" alt="image" src="https://github.com/WordPress/gutenberg/assets/1935113/ce4d1580-dcdd-43b3-97db-1bac21ab8f89"> <img width="364" alt="image" src="https://github.com/WordPress/gutenberg/assets/1935113/60b22b89-d2ae-4f46-a486-1a12922cec27"> | <img width="364" alt="image" src="https://github.com/WordPress/gutenberg/assets/1935113/c189826b-6f09-4d8f-98ce-047a1a5fe5fb"> <img width="364" alt="image" src="https://github.com/WordPress/gutenberg/assets/1935113/1414dedf-168e-4ff5-aa66-aa52adb72983"> |

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Open global styles in the site editor
2. Under typography, click `Aa` icon to open fonts modal
3. Test UI with and without installed fonts.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

NA

Fixes: #54592