### PR TITLE
Default template lookup should use slug, not the full permalink, in the site editor

### DIFF
--- a/packages/edit-site/src/store/actions.js
+++ b/packages/edit-site/src/store/actions.js
@@ -291,11 +291,11 @@ export const setPage =
 				} else {
 					// If a page has a `template` set and is not included in the list
 					// of the current theme's templates, query for current theme's default template.
-					template = await getDefaultTemplate( editedEntity?.link );
+					template = await getDefaultTemplate( editedEntity?.slug );
 				}
 			} else {
 				// Page's `template` is empty, that indicates we need to use the default template for the page.
-				template = await getDefaultTemplate( editedEntity?.link );
+				template = await getDefaultTemplate( editedEntity?.slug );
 			}
 		}
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
[#51477](https://github.com/WordPress/gutenberg/pull/51477) introduced template swap UX, but in doing so it broke the default template lookup. [Details and screenshots of the issue can be found in the issue here](https://github.com/WordPress/gutenberg/issues/54596) but the heart of the issue was that requests to the API were including the permalink instead of the slug, so for example, it tried to lookup the slug `page-http://xxxxx` instead of `page-slug`.

## Why?
This restores the correct template for pages and avoids them defaulting to "pages" template, even if custom templates are in place.

## How?
This replaces the `link` property with the correct `slug` property.

## Testing Instructions
1. Open your browser network console and filter to see fetch/XHR requests
1. Go to Appearance > Editor > Pages and select any page. 
2. Before this patch you'd see a request to `https://store.local/wp-json/wp/v2/templates/lookup?slug=page-https%3A%2F%2Fstore.local%2Fcart%2F&_locale=user` or similar. After this patch you'll see the correct lookup address of `https://store.local/wp-json/wp/v2/templates/lookup?slug=page-cart%2F&_locale=user` or similar. Note the `slug` parameter is fixed.