### PR TITLE
Formats: Memoize link value passed to the LinkControl

### DIFF
--- a/packages/format-library/src/link/inline.js
+++ b/packages/format-library/src/link/inline.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useRef, createInterpolateElement } from '@wordpress/element';
+import { useMemo, useRef, createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { speak } from '@wordpress/a11y';
 import { Popover } from '@wordpress/components';
@@ -63,14 +63,24 @@ function InlineLinkUI( {
 		};
 	}, [] );
 
-	const linkValue = {
-		url: activeAttributes.url,
-		type: activeAttributes.type,
-		id: activeAttributes.id,
-		opensInNewTab: activeAttributes.target === '_blank',
-		nofollow: activeAttributes.rel?.includes( 'nofollow' ),
-		title: richTextText,
-	};
+	const linkValue = useMemo(
+		() => ( {
+			url: activeAttributes.url,
+			type: activeAttributes.type,
+			id: activeAttributes.id,
+			opensInNewTab: activeAttributes.target === '_blank',
+			nofollow: activeAttributes.rel?.includes( 'nofollow' ),
+			title: richTextText,
+		} ),
+		[
+			activeAttributes.id,
+			activeAttributes.rel,
+			activeAttributes.target,
+			activeAttributes.type,
+			activeAttributes.url,
+			richTextText,
+		]
+	);
 
 	function removeLink() {
 		const newValue = removeFormat( value, 'core/link' );


### PR DESCRIPTION
## What?
Same as #53507.

Pass memoized link value to the `LinkControl` component to avoid losing user changes when the `InlineLinkUI` component rerenders.

I noticed while testing the #54553.

## Why?
Referential stability of the `value` object prevents unnecessary value to state sync.

## Testing Instructions
1. Open a post or page.
2. Insert a Paragraph block.
3. Add text and start adding a link to it.
4. Type or paste any URL in the LinkControl input field.
5. Hover/over the block toolbar.
6. Confirm entered URL isn't cleared from the input.

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/240569/bb67ff3a-5d71-446b-832b-320d536adc08

