### PR TITLE
Replace turbo-combine-reducers with combineReducers from Redux

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52954,11 +52954,6 @@
 				"node": "*"
 			}
 		},
-		"node_modules/turbo-combine-reducers": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/turbo-combine-reducers/-/turbo-combine-reducers-1.0.2.tgz",
-			"integrity": "sha512-gHbdMZlA6Ym6Ur5pSH/UWrNQMIM9IqTH6SoL1DbHpqEdQ8i+cFunSmSlFykPt0eGQwZ4d/XTHOl74H0/kFBVWw=="
-		},
 		"node_modules/tweetnacl": {
 			"version": "0.14.5",
 			"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
@@ -56501,7 +56496,6 @@
 				"is-promise": "^4.0.0",
 				"redux": "^4.1.2",
 				"rememo": "^4.0.2",
-				"turbo-combine-reducers": "^1.0.2",
 				"use-memo-one": "^1.1.1"
 			},
 			"engines": {
@@ -69764,7 +69758,6 @@
 				"is-promise": "^4.0.0",
 				"redux": "^4.1.2",
 				"rememo": "^4.0.2",
-				"turbo-combine-reducers": "^1.0.2",
 				"use-memo-one": "^1.1.1"
 			}
 		},
@@ -100700,11 +100693,6 @@
 			"requires": {
 				"safe-buffer": "^5.0.1"
 			}
-		},
-		"turbo-combine-reducers": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/turbo-combine-reducers/-/turbo-combine-reducers-1.0.2.tgz",
-			"integrity": "sha512-gHbdMZlA6Ym6Ur5pSH/UWrNQMIM9IqTH6SoL1DbHpqEdQ8i+cFunSmSlFykPt0eGQwZ4d/XTHOl74H0/kFBVWw=="
 		},
 		"tweetnacl": {
 			"version": "0.14.5",

--- a/packages/block-library/src/embed/test/index.native.js
+++ b/packages/block-library/src/embed/test/index.native.js
@@ -138,7 +138,12 @@ const mockEmbedResponses = ( mockedResponses ) => {
 
 async function mockOtherResponses( { path } ) {
 	if ( path.startsWith( '/wp/v2/themes' ) ) {
-		return [ { theme_supports: { 'responsive-embeds': true } } ];
+		return [
+			{
+				stylesheet: 'test-theme',
+				theme_supports: { 'responsive-embeds': true },
+			},
+		];
 	}
 
 	if ( path.startsWith( '/wp/v2/block-patterns/patterns' ) ) {

--- a/packages/core-data/src/selectors.ts
+++ b/packages/core-data/src/selectors.ts
@@ -936,6 +936,9 @@ export function hasRedo( state: State ): boolean {
  * @return The current theme.
  */
 export function getCurrentTheme( state: State ): any {
+	if ( ! state.currentTheme ) {
+		return null;
+	}
 	return getEntityRecord( state, 'root', 'theme', state.currentTheme );
 }
 

--- a/packages/data/CHANGELOG.md
+++ b/packages/data/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancements
+
+-  Change implementation of `combineReducers` so that it doesn't use `eval` internally, and can run with a CSP policy that doesn't allow `unsafe-eval` ([#54606](https://github.com/WordPress/gutenberg/pull/54606)).
+
 ## 9.12.0 (2023-09-20)
 
 ## 9.11.0 (2023-08-31)

--- a/packages/data/package.json
+++ b/packages/data/package.json
@@ -42,7 +42,6 @@
 		"is-promise": "^4.0.0",
 		"redux": "^4.1.2",
 		"rememo": "^4.0.2",
-		"turbo-combine-reducers": "^1.0.2",
 		"use-memo-one": "^1.1.1"
 	},
 	"peerDependencies": {

--- a/packages/data/src/index.js
+++ b/packages/data/src/index.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import turboCombineReducers from 'turbo-combine-reducers';
-
-/**
  * Internal dependencies
  */
 import defaultRegistry from './default-registry';
@@ -28,7 +23,7 @@ export { AsyncModeProvider } from './components/async-mode-provider';
 export { createRegistry } from './registry';
 export { createRegistrySelector, createRegistryControl } from './factory';
 export { controls } from './controls';
-export { default as createReduxStore } from './redux-store';
+import { combineReducers, default as createReduxStore } from './redux-store';
 export { dispatch } from './dispatch';
 export { select } from './select';
 
@@ -80,7 +75,35 @@ export { plugins };
  * @return {Function} A reducer that invokes every reducer inside the reducers
  *                    object, and constructs a state object with the same shape.
  */
-export const combineReducers = turboCombineReducers;
+export { combineReducers };
+
+/**
+ * Creates a data store descriptor for the provided Redux store configuration containing
+ * properties describing reducer, actions, selectors, controls and resolvers.
+ *
+ * @example
+ * ```js
+ * import { createReduxStore } from '@wordpress/data';
+ *
+ * const store = createReduxStore( 'demo', {
+ *     reducer: ( state = 'OK' ) => state,
+ *     selectors: {
+ *         getValue: ( state ) => state,
+ *     },
+ * } );
+ * ```
+ *
+ * @template State
+ * @template {Record<string,import('../../types').ActionCreator>} Actions
+ * @template Selectors
+ * @param {string}                                    key     Unique namespace identifier.
+ * @param {ReduxStoreConfig<State,Actions,Selectors>} options Registered store options, with properties
+ *                                                            describing reducer, actions, selectors,
+ *                                                            and resolvers.
+ *
+ * @return   {StoreDescriptor<ReduxStoreConfig<State,Actions,Selectors>>} Store Object.
+ */
+export { createReduxStore };
 
 /**
  * Given a store descriptor, returns an object containing the store's selectors pre-bound to state

--- a/packages/data/src/index.js
+++ b/packages/data/src/index.js
@@ -23,7 +23,7 @@ export { AsyncModeProvider } from './components/async-mode-provider';
 export { createRegistry } from './registry';
 export { createRegistrySelector, createRegistryControl } from './factory';
 export { controls } from './controls';
-import { combineReducers, default as createReduxStore } from './redux-store';
+export { default as createReduxStore } from './redux-store';
 export { dispatch } from './dispatch';
 export { select } from './select';
 
@@ -75,35 +75,7 @@ export { plugins };
  * @return {Function} A reducer that invokes every reducer inside the reducers
  *                    object, and constructs a state object with the same shape.
  */
-export { combineReducers };
-
-/**
- * Creates a data store descriptor for the provided Redux store configuration containing
- * properties describing reducer, actions, selectors, controls and resolvers.
- *
- * @example
- * ```js
- * import { createReduxStore } from '@wordpress/data';
- *
- * const store = createReduxStore( 'demo', {
- *     reducer: ( state = 'OK' ) => state,
- *     selectors: {
- *         getValue: ( state ) => state,
- *     },
- * } );
- * ```
- *
- * @template State
- * @template {Record<string,import('../../types').ActionCreator>} Actions
- * @template Selectors
- * @param {string}                                    key     Unique namespace identifier.
- * @param {ReduxStoreConfig<State,Actions,Selectors>} options Registered store options, with properties
- *                                                            describing reducer, actions, selectors,
- *                                                            and resolvers.
- *
- * @return   {StoreDescriptor<ReduxStoreConfig<State,Actions,Selectors>>} Store Object.
- */
-export { createReduxStore };
+export { combineReducers } from './redux-store';
 
 /**
  * Given a store descriptor, returns an object containing the store's selectors pre-bound to state

--- a/packages/data/src/redux-store/combine-reducers.js
+++ b/packages/data/src/redux-store/combine-reducers.js
@@ -1,27 +1,17 @@
 export function combineReducers( reducers ) {
 	const keys = Object.keys( reducers );
 
-	function getNextState( state, action ) {
+	return function combinedReducer( state = {}, action ) {
 		const nextState = {};
+		let hasChanged = false;
 		for ( const key of keys ) {
-			nextState[ key ] = reducers[ key ]( state[ key ], action );
-		}
-		return nextState;
-	}
-
-	return function combinedReducer( state, action ) {
-		// Assumed changed if initial state.
-		if ( state === undefined ) {
-			return getNextState( {}, action );
+			const reducer = reducers[ key ];
+			const prevStateForKey = state[ key ];
+			const nextStateForKey = reducer( prevStateForKey, action );
+			nextState[ key ] = nextStateForKey;
+			hasChanged = hasChanged || nextStateForKey !== prevStateForKey;
 		}
 
-		const nextState = getNextState( state, action );
-
-		// Determine whether state has changed.
-		if ( keys.some( ( key ) => state[ key ] !== nextState[ key ] ) ) {
-			return nextState;
-		}
-
-		return state;
+		return hasChanged ? nextState : state;
 	};
 }

--- a/packages/data/src/redux-store/combine-reducers.js
+++ b/packages/data/src/redux-store/combine-reducers.js
@@ -1,0 +1,27 @@
+export function combineReducers( reducers ) {
+	const keys = Object.keys( reducers );
+
+	function getNextState( state, action ) {
+		const nextState = {};
+		for ( const key of keys ) {
+			nextState[ key ] = reducers[ key ]( state[ key ], action );
+		}
+		return nextState;
+	}
+
+	return function combinedReducer( state, action ) {
+		// Assumed changed if initial state.
+		if ( state === undefined ) {
+			return getNextState( {}, action );
+		}
+
+		const nextState = getNextState( state, action );
+
+		// Determine whether state has changed.
+		if ( keys.some( ( key ) => state[ key ] !== nextState[ key ] ) ) {
+			return nextState;
+		}
+
+		return state;
+	};
+}

--- a/packages/data/src/redux-store/index.js
+++ b/packages/data/src/redux-store/index.js
@@ -1,8 +1,7 @@
 /**
  * External dependencies
  */
-// eslint-disable-next-line no-restricted-imports
-import { combineReducers, createStore, applyMiddleware } from 'redux';
+import { createStore, applyMiddleware } from 'redux';
 import EquivalentKeyMap from 'equivalent-key-map';
 
 /**
@@ -14,6 +13,7 @@ import { compose } from '@wordpress/compose';
 /**
  * Internal dependencies
  */
+import { combineReducers } from './combine-reducers';
 import { builtinControls } from '../controls';
 import { lock } from '../lock-unlock';
 import promise from '../promise-middleware';

--- a/packages/data/src/redux-store/index.js
+++ b/packages/data/src/redux-store/index.js
@@ -1,8 +1,8 @@
 /**
  * External dependencies
  */
-import { createStore, applyMiddleware } from 'redux';
-import combineReducers from 'turbo-combine-reducers';
+// eslint-disable-next-line no-restricted-imports
+import { combineReducers, createStore, applyMiddleware } from 'redux';
 import EquivalentKeyMap from 'equivalent-key-map';
 
 /**
@@ -22,6 +22,8 @@ import createThunkMiddleware from './thunk-middleware';
 import metadataReducer from './metadata/reducer';
 import * as metadataSelectors from './metadata/selectors';
 import * as metadataActions from './metadata/actions';
+
+export { combineReducers };
 
 /** @typedef {import('../types').DataRegistry} DataRegistry */
 /** @typedef {import('../types').ListenerFunction} ListenerFunction */
@@ -117,32 +119,6 @@ function createBindingCache( bind ) {
 	};
 }
 
-/**
- * Creates a data store descriptor for the provided Redux store configuration containing
- * properties describing reducer, actions, selectors, controls and resolvers.
- *
- * @example
- * ```js
- * import { createReduxStore } from '@wordpress/data';
- *
- * const store = createReduxStore( 'demo', {
- *     reducer: ( state = 'OK' ) => state,
- *     selectors: {
- *         getValue: ( state ) => state,
- *     },
- * } );
- * ```
- *
- * @template State
- * @template {Record<string,import('../../types').ActionCreator>} Actions
- * @template Selectors
- * @param {string}                                    key     Unique namespace identifier.
- * @param {ReduxStoreConfig<State,Actions,Selectors>} options Registered store options, with properties
- *                                                            describing reducer, actions, selectors,
- *                                                            and resolvers.
- *
- * @return   {StoreDescriptor<ReduxStoreConfig<State,Actions,Selectors>>} Store Object.
- */
 export default function createReduxStore( key, options ) {
 	const privateActions = {};
 	const privateSelectors = {};

--- a/packages/data/src/redux-store/index.js
+++ b/packages/data/src/redux-store/index.js
@@ -34,7 +34,7 @@ export { combineReducers };
 /**
  * @typedef {import('../types').ReduxStoreConfig<State,Actions,Selectors>} ReduxStoreConfig
  * @template State
- * @template {Record<string,import('../../types').ActionCreator>} Actions
+ * @template {Record<string,import('../types').ActionCreator>} Actions
  * @template Selectors
  */
 
@@ -119,6 +119,32 @@ function createBindingCache( bind ) {
 	};
 }
 
+/**
+ * Creates a data store descriptor for the provided Redux store configuration containing
+ * properties describing reducer, actions, selectors, controls and resolvers.
+ *
+ * @example
+ * ```js
+ * import { createReduxStore } from '@wordpress/data';
+ *
+ * const store = createReduxStore( 'demo', {
+ *     reducer: ( state = 'OK' ) => state,
+ *     selectors: {
+ *         getValue: ( state ) => state,
+ *     },
+ * } );
+ * ```
+ *
+ * @template State
+ * @template {Record<string,import('../types').ActionCreator>} Actions
+ * @template Selectors
+ * @param {string}                                    key     Unique namespace identifier.
+ * @param {ReduxStoreConfig<State,Actions,Selectors>} options Registered store options, with properties
+ *                                                            describing reducer, actions, selectors,
+ *                                                            and resolvers.
+ *
+ * @return   {StoreDescriptor<ReduxStoreConfig<State,Actions,Selectors>>} Store Object.
+ */
 export default function createReduxStore( key, options ) {
 	const privateActions = {};
 	const privateSelectors = {};

--- a/packages/data/src/redux-store/test/combine-reducers.js
+++ b/packages/data/src/redux-store/test/combine-reducers.js
@@ -1,0 +1,58 @@
+/**
+ * Internal dependencies
+ */
+import { combineReducers } from '../combine-reducers';
+
+function counterReducer( count = 0, action ) {
+	if ( action.type === 'INC' ) {
+		return count + 1;
+	}
+	return count;
+}
+
+describe( 'combineReducers', () => {
+	it( 'initializes state', () => {
+		const reducer = combineReducers( { foo: counterReducer } );
+		expect( reducer( undefined, { type: 'INIT' } ) ).toEqual( { foo: 0 } );
+	} );
+
+	it( 'dispatches actions to subreducers', () => {
+		const reducer = combineReducers( { foo: counterReducer } );
+		expect( reducer( { foo: 1 }, { type: 'INC' } ) ).toEqual( { foo: 2 } );
+	} );
+
+	it( 'returns identical state when there is no change', () => {
+		const reducer = combineReducers( { foo: counterReducer } );
+		const state = { foo: 1 };
+		expect( reducer( state, { type: 'NOOP' } ) ).toBe( state );
+	} );
+
+	it( 'returns identical substate when there is no change', () => {
+		const reducer = combineReducers( {
+			foo: counterReducer,
+			bar: combineReducers( { baz: ( s ) => s } ),
+		} );
+		const prevState = { foo: 1, bar: { baz: 1 } };
+		const nextState = reducer( prevState, { type: 'INC' } );
+		expect( nextState.foo ).toBe( 2 ); // changed
+		expect( nextState.bar ).toBe( prevState.bar ); // not changed
+	} );
+
+	it( 'does not mind undefined state', () => {
+		const reducer = combineReducers( { foo: ( s ) => s } );
+		// combineReducers from Redux would throw an exception when a reducer returns
+		// `undefined` state, but we don't mind and treat is as any other value.
+		expect( reducer( undefined, { type: 'INIT' } ) ).toEqual( {
+			foo: undefined,
+		} );
+	} );
+
+	it( 'does not mind unknown state keys', () => {
+		const reducer = combineReducers( { foo: counterReducer } );
+		// combineReducers from Redux would warn about the unknown `bar` key as
+		// there is no reducer for it, but we don't mind and just ignore it.
+		expect( reducer( { foo: 1, bar: 1 }, { type: 'INC' } ) ).toEqual( {
+			foo: 2,
+		} );
+	} );
+} );

--- a/packages/data/src/redux-store/test/combine-reducers.js
+++ b/packages/data/src/redux-store/test/combine-reducers.js
@@ -55,4 +55,12 @@ describe( 'combineReducers', () => {
 			foo: 2,
 		} );
 	} );
+
+	it( 'supports a "unit" reducer with no subreducers', () => {
+		const reducer = combineReducers( {} );
+		const initialState = reducer( undefined, { type: 'INIT' } );
+		expect( initialState ).toEqual( {} );
+		const nextState = reducer( initialState, { type: 'INC' } );
+		expect( nextState ).toBe( initialState );
+	} );
 } );


### PR DESCRIPTION
This is still an experiment, I'm opening a PR mainly to get performance test results.

There are two major problems with `combineReducers` in Redux.

First, it doesn't allow slice reducers to ever return `undefined` state. `undefined` means uninitialized and every reducer is supposed to return an "initialized" inital state when `undefined` state is passed. We have many reducers that use `undefined`, and this PR has to modify them to use `null` instead. Otherwise, `combineReducers` will throw an exception and the app will crash. The prohibition on `undefined` will be a breaking change that we probably can't afford to do.

Second, it logs a warning when the combined reducer function is called with a state that contains unknown keys, with no reducer for them. For example, consider combining `foo` and `bar` reducers with `combineReducers( { foo, bar } )`. Then, when you pass an object with shape `{ foo, bar, baz }` as `state`, `combineReducers` doesn't like the `baz` field, because there is no sub-reducer to pass it to. The warning is:
```
Unexpected key "baz" found in preloadedState argument passed to createStore.
Expected to find one of the known reducer keys instead: "foo", "bar".
Unexpected keys will be ignored.
```

The `core/blocks` store very often uses an enhancer pattern that leads to these "unexpected key" warnings:
```js
function withIgnoredBlockChange( reducer ) {
  return ( state, action ) => {
    const nextState = reducer( state, action );
    if ( nextState !== state ) {
      nextState.isIgnoredChange = action.type === 'RECEIVE_BLOCKS';
    }
    return nextState;
  };
}
```
This enhancer calls the inner reducer and then adds the `isIgnoredChange` field to the existing ones. If the inner reducer is a result of `combineReducers`, it will complain about the unknown key. Although everything works, there's nothing really wrong with this pattern.

For these two reasons, we'll probably have to write our own version of `combineReducers`.

Fixes #42513.