### PR TITLE
Remove `role` attribute when set to `null` in `data-wp-bind`

### DIFF
--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -713,10 +713,8 @@ function render_block_core_navigation( $attributes, $content, $block ) {
 			tabindex="-1"
 		';
 		$responsive_dialog_directives    = '
-			data-wp-bind--aria-modal="selectors.core.navigation.isMenuOpen"
-			aria-modal="false"
+			data-wp-bind--aria-modal="selectors.core.navigation.ariaModal"
 			data-wp-bind--role="selectors.core.navigation.roleAttribute"
-			role=""
 			data-wp-effect="effects.core.navigation.focusFirstElement"
 		';
 		$close_button_directives         = '

--- a/packages/block-library/src/navigation/view.js
+++ b/packages/block-library/src/navigation/view.js
@@ -78,7 +78,14 @@ wpStore( {
 					return context.core.navigation.type === 'overlay' &&
 						selectors.core.navigation.isMenuOpen( store )
 						? 'dialog'
-						: '';
+						: undefined;
+				},
+				ariaModal: ( store ) => {
+					const { context, selectors } = store;
+					return context.core.navigation.type === 'overlay' &&
+						selectors.core.navigation.isMenuOpen( store )
+						? 'true'
+						: undefined;
 				},
 				isMenuOpen: ( { context } ) =>
 					// The menu is opened if either `click`, `hover` or `focus` is true.

--- a/packages/block-library/src/navigation/view.js
+++ b/packages/block-library/src/navigation/view.js
@@ -78,14 +78,14 @@ wpStore( {
 					return context.core.navigation.type === 'overlay' &&
 						selectors.core.navigation.isMenuOpen( store )
 						? 'dialog'
-						: undefined;
+						: null;
 				},
 				ariaModal: ( store ) => {
 					const { context, selectors } = store;
 					return context.core.navigation.type === 'overlay' &&
 						selectors.core.navigation.isMenuOpen( store )
 						? 'true'
-						: undefined;
+						: null;
 				},
 				isMenuOpen: ( { context } ) =>
 					// The menu is opened if either `click`, `hover` or `focus` is true.

--- a/packages/interactivity/CHANGELOG.md
+++ b/packages/interactivity/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 -   Improve `navigate()` to render only the result of the last call when multiple happen simultaneously. ([#54201](https://github.com/WordPress/gutenberg/pull/54201))
 
+### Bug Fix
+
+-   Remove `role` attribute when set to `null` in `data-wp-bind`. ([#54608](https://github.com/WordPress/gutenberg/pull/54608))
+
 ## 2.2.0 (2023-08-31)
 
 ### Enhancements

--- a/packages/interactivity/src/directives.js
+++ b/packages/interactivity/src/directives.js
@@ -217,7 +217,12 @@ export default () => {
 					const result = evaluate( path, {
 						context: contextValue,
 					} );
-					element.props[ attribute ] = result;
+					if ( result !== null && result !== undefined ) {
+						element.ref.current?.setAttribute( attribute, result );
+					} else {
+						element.ref?.current?.removeAttribute( attribute );
+					}
+					// element.props[ attribute ] = result;
 
 					// This seems necessary because Preact doesn't change the attributes
 					// on the hydration, so we have to do it manually. It doesn't need
@@ -241,13 +246,12 @@ export default () => {
 							attribute !== 'download' &&
 							attribute !== 'rowSpan' &&
 							attribute !== 'colSpan' &&
-							attribute in el
+							el.getAttribute( attribute )
 						) {
 							try {
-								el[ attribute ] =
-									result === null || result === undefined
-										? ''
-										: result;
+								if ( result === null || result === undefined ) {
+									el[ attribute ] = result;
+								}
 								return;
 							} catch ( err ) {}
 						}


### PR DESCRIPTION
## What?
In this pull request I'm adding a workaround to handle the `role` attribute properly until it is solved in Preact. Basically, when we pass a `null` value to `role`, it is using and empty string instead of removing the HTML element. I submitted [this issue](https://github.com/preactjs/preact/issues/4136) to Preact repo.

As part of this, I also removed the Server Side Rendering attributes to fix the issue reported [here](https://github.com/WordPress/gutenberg/issues/54560). After this fix it seems that the `aria-modal` and `role` attributes are properly removed in the Server Side Rendering and after opening and closing the menu.

I didn't add logic to remove the `aria-label` because it was there before adding the Interactivity API, and some users may be using that. Additionally, as reported in the issue, it shouldn't affect the accessibility.

## Why?

Right now, there is no way to remove the `role` attribute dynamically, which ends up in an empty value, which is not valid HTML.

## How?
I added a workaround to handle the `role` attribute until the issue in Preact is solved. Additionally, I removed the attributes for the Server Side Rendering.

## Testing Instructions

1. Include a navigation block in your theme.
2. Go the the frontend, inspect the navigation menu, and check that the `div` element with class `wp-block-navigation__responsive-dialog` doesn't have `aria-modal` or `role` attributes.
3. Open the menu and check that the same `div` has `aria-modal="true"` and `role="dialog"`.
4. Close the menu and check that both attributes are removed.
