### PR TITLE
Add template replace flow to template inspector

### DIFF
--- a/packages/base-styles/_z-index.scss
+++ b/packages/base-styles/_z-index.scss
@@ -128,6 +128,7 @@ $z-layers: (
 	".block-editor-block-rename-modal": 1000001,
 	".edit-site-list__rename-modal": 1000001,
 	".edit-site-swap-template-modal": 1000001,
+	".edit-site-template-panel__replace-template-modal": 1000001,
 
 	// Note: The ConfirmDialog component's z-index is being set to 1000001 in packages/components/src/confirm-dialog/styles.ts
 	// because it uses emotion and not sass. We need it to render on top its parent popover.

--- a/packages/edit-site/src/components/sidebar-edit-mode/page-panels/hooks.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/page-panels/hooks.js
@@ -48,6 +48,7 @@ export function useAvailableTemplates() {
 	const currentTemplateSlug = useCurrentTemplateSlug();
 	const isPostsPage = useIsPostsPage();
 	const templates = useTemplates();
+	console.log( 'templates', templates );
 	return useMemo(
 		() =>
 			// The posts page template cannot be changed.

--- a/packages/edit-site/src/components/sidebar-edit-mode/page-panels/hooks.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/page-panels/hooks.js
@@ -102,12 +102,6 @@ function injectThemeAttributeInBlockTemplateContent(
 	currentThemeStylesheet
 ) {
 	block.innerBlocks = block.innerBlocks.map( ( innerBlock ) => {
-		if (
-			innerBlock.name === 'core/template-part' &&
-			innerBlock.attributes.theme === undefined
-		) {
-			innerBlock.attributes.theme = currentThemeStylesheet;
-		}
 		return injectThemeAttributeInBlockTemplateContent(
 			innerBlock,
 			currentThemeStylesheet

--- a/packages/edit-site/src/components/sidebar-edit-mode/page-panels/hooks.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/page-panels/hooks.js
@@ -158,14 +158,9 @@ export function useAvailablePatterns( template ) {
 				currentThemeStylesheet:
 					select( coreStore ).getCurrentTheme().stylesheet,
 			};
-		} );
+		}, [] );
 
-	const mergedPatterns = [
-		...( blockPatterns || [] ),
-		...( restBlockPatterns || [] ),
-	];
-
-return useMemo( () => {
+	return useMemo( () => {
 		const mergedPatterns = [
 			...( blockPatterns || [] ),
 			...( restBlockPatterns || [] ),

--- a/packages/edit-site/src/components/sidebar-edit-mode/page-panels/hooks.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/page-panels/hooks.js
@@ -166,9 +166,7 @@ export function useAvailablePatterns( template ) {
 		return patterns;
 	} );
 
-	return preparePatterns(
-		availablePatterns,
-		template,
-		currentThemeStylesheet
+	return useMemo( () =>
+		preparePatterns( availablePatterns, template, currentThemeStylesheet )
 	);
 }

--- a/packages/edit-site/src/components/sidebar-edit-mode/page-panels/hooks.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/page-panels/hooks.js
@@ -101,21 +101,18 @@ function injectThemeAttributeInBlockTemplateContent(
 	block,
 	currentThemeStylesheet
 ) {
-	if (
-		block.innerBlocks.find(
-			( innerBlock ) => innerBlock.name === 'core/template-part'
-		)
-	) {
-		block.innerBlocks = block.innerBlocks.map( ( innerBlock ) => {
-			if (
-				innerBlock.name === 'core/template-part' &&
-				innerBlock.attributes.theme === undefined
-			) {
-				innerBlock.attributes.theme = currentThemeStylesheet;
-			}
-			return innerBlock;
-		} );
-	}
+	block.innerBlocks = block.innerBlocks.map( ( innerBlock ) => {
+		if (
+			innerBlock.name === 'core/template-part' &&
+			innerBlock.attributes.theme === undefined
+		) {
+			innerBlock.attributes.theme = currentThemeStylesheet;
+		}
+		return injectThemeAttributeInBlockTemplateContent(
+			innerBlock,
+			currentThemeStylesheet
+		);
+	} );
 
 	if (
 		block.name === 'core/template-part' &&

--- a/packages/edit-site/src/components/sidebar-edit-mode/page-panels/hooks.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/page-panels/hooks.js
@@ -149,7 +149,7 @@ export function useAvailablePatterns( template ) {
 		( select ) => select( coreStore ).getCurrentTheme().stylesheet
 	);
 
-	let availablePatterns = useSelect( ( select ) => {
+	const availablePatterns = useSelect( ( select ) => {
 		const { getSettings } = unlock( select( editSiteStore ) );
 		const settings = getSettings();
 
@@ -166,11 +166,9 @@ export function useAvailablePatterns( template ) {
 		return patterns;
 	} );
 
-	availablePatterns = preparePatterns(
+	return preparePatterns(
 		availablePatterns,
 		template,
 		currentThemeStylesheet
 	);
-
-	return availablePatterns;
 }

--- a/packages/edit-site/src/components/sidebar-edit-mode/page-panels/hooks.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/page-panels/hooks.js
@@ -165,7 +165,15 @@ export function useAvailablePatterns( template ) {
 		...( restBlockPatterns || [] ),
 	];
 
-	return useMemo( () =>
-		preparePatterns( mergedPatterns, template, currentThemeStylesheet )
-	);
+return useMemo( () => {
+		const mergedPatterns = [
+			...( blockPatterns || [] ),
+			...( restBlockPatterns || [] ),
+		];
+		return preparePatterns(
+			mergedPatterns,
+			template,
+			currentThemeStylesheet
+		);
+	}, [ blockPatterns, restBlockPatterns, template, currentThemeStylesheet ] );
 }

--- a/packages/edit-site/src/components/sidebar-edit-mode/page-panels/hooks.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/page-panels/hooks.js
@@ -140,13 +140,12 @@ function preparePatterns( patterns, template, currentThemeStylesheet ) {
 				type: PATTERN_TYPES.theme,
 				blocks: parse( pattern.content, {
 					__unstableSkipMigrationLogs: true,
-				} ).map( ( block ) => {
-					const injected = injectThemeAttributeInBlockTemplateContent(
+				} ).map( ( block ) =>
+					injectThemeAttributeInBlockTemplateContent(
 						block,
 						currentThemeStylesheet
-					);
-					return injected;
-				} ),
+					)
+				),
 			} ) )
 	);
 }

--- a/packages/edit-site/src/components/sidebar-edit-mode/page-panels/hooks.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/page-panels/hooks.js
@@ -145,28 +145,27 @@ function preparePatterns( patterns, template, currentThemeStylesheet ) {
 }
 
 export function useAvailablePatterns( template ) {
-	const currentThemeStylesheet = useSelect(
-		( select ) => select( coreStore ).getCurrentTheme().stylesheet
-	);
+	const { blockPatterns, restBlockPatterns, currentThemeStylesheet } =
+		useSelect( ( select ) => {
+			const { getSettings } = unlock( select( editSiteStore ) );
+			const settings = getSettings();
 
-	const availablePatterns = useSelect( ( select ) => {
-		const { getSettings } = unlock( select( editSiteStore ) );
-		const settings = getSettings();
+			return {
+				blockPatterns:
+					settings.__experimentalAdditionalBlockPatterns ??
+					settings.__experimentalBlockPatterns,
+				restBlockPatterns: select( coreStore ).getBlockPatterns(),
+				currentThemeStylesheet:
+					select( coreStore ).getCurrentTheme().stylesheet,
+			};
+		} );
 
-		const blockPatterns =
-			settings.__experimentalAdditionalBlockPatterns ??
-			settings.__experimentalBlockPatterns;
-
-		const restBlockPatterns = select( coreStore ).getBlockPatterns();
-
-		const patterns = [
-			...( blockPatterns || [] ),
-			...( restBlockPatterns || [] ),
-		];
-		return patterns;
-	} );
+	const mergedPatterns = [
+		...( blockPatterns || [] ),
+		...( restBlockPatterns || [] ),
+	];
 
 	return useMemo( () =>
-		preparePatterns( availablePatterns, template, currentThemeStylesheet )
+		preparePatterns( mergedPatterns, template, currentThemeStylesheet )
 	);
 }

--- a/packages/edit-site/src/components/sidebar-edit-mode/page-panels/hooks.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/page-panels/hooks.js
@@ -144,7 +144,6 @@ function preparePatterns( patterns, template, currentThemeStylesheet ) {
 	);
 }
 
-// Should we also get templates?
 export function useAvailablePatterns( template ) {
 	const currentThemeStylesheet = useSelect(
 		( select ) => select( coreStore ).getCurrentTheme().stylesheet

--- a/packages/edit-site/src/components/sidebar-edit-mode/page-panels/hooks.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/page-panels/hooks.js
@@ -99,6 +99,36 @@ const filterOutDuplicatesByName = ( currentItem, index, items ) =>
 
 // Should we also get templates?
 export function useAvailablePatterns( template ) {
+	const currentThemeStylesheet = useSelect(
+		( select ) => select( coreStore ).getCurrentTheme().stylesheet
+	);
+
+	function injectThemeAttributeInBlockTemplateContent( block ) {
+		if (
+			block.innerBlocks.find(
+				( innerBlock ) => innerBlock.name === 'core/template-part'
+			)
+		) {
+			block.innerBlocks = block.innerBlocks.map( ( innerBlock ) => {
+				if (
+					innerBlock.name === 'core/template-part' &&
+					innerBlock.attributes.theme === undefined
+				) {
+					innerBlock.attributes.theme = currentThemeStylesheet;
+				}
+				return innerBlock;
+			} );
+		}
+
+		if (
+			block.name === 'core/template-part' &&
+			block.attributes.theme === undefined
+		) {
+			block.attributes.theme = currentThemeStylesheet;
+		}
+		return block;
+	}
+
 	return useSelect(
 		( select ) => {
 			const { getSettings } = unlock( select( editSiteStore ) );
@@ -128,7 +158,9 @@ export function useAvailablePatterns( template ) {
 					type: PATTERN_TYPES.theme,
 					blocks: parse( pattern.content, {
 						__unstableSkipMigrationLogs: true,
-					} ),
+					} ).map( ( block ) =>
+						injectThemeAttributeInBlockTemplateContent( block )
+					),
 				} ) );
 
 			return patterns;

--- a/packages/edit-site/src/components/sidebar-edit-mode/template-panel/hooks.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/template-panel/hooks.js
@@ -34,10 +34,11 @@ function injectThemeAttributeInBlockTemplateContent(
 }
 
 function preparePatterns( patterns, template, currentThemeStylesheet ) {
-	// This is duplicated.
+	// Filter out duplicates.
 	const filterOutDuplicatesByName = ( currentItem, index, items ) =>
 		index === items.findIndex( ( item ) => currentItem.name === item.name );
 
+	// Filter out core patterns.
 	const filterOutCorePatterns = ( pattern ) =>
 		! PATTERN_CORE_SOURCES.includes( pattern.source );
 

--- a/packages/edit-site/src/components/sidebar-edit-mode/template-panel/hooks.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/template-panel/hooks.js
@@ -1,0 +1,94 @@
+/**
+ * WordPress dependencies
+ */
+import { useSelect } from '@wordpress/data';
+import { useMemo } from '@wordpress/element';
+import { store as coreStore } from '@wordpress/core-data';
+import { parse } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import { store as editSiteStore } from '../../../store';
+import { PATTERN_CORE_SOURCES, PATTERN_TYPES } from '../../../utils/constants';
+import { unlock } from '../../../lock-unlock';
+
+// This is duplicated.
+const filterOutDuplicatesByName = ( currentItem, index, items ) =>
+	index === items.findIndex( ( item ) => currentItem.name === item.name );
+
+function injectThemeAttributeInBlockTemplateContent(
+	block,
+	currentThemeStylesheet
+) {
+	block.innerBlocks = block.innerBlocks.map( ( innerBlock ) => {
+		return injectThemeAttributeInBlockTemplateContent(
+			innerBlock,
+			currentThemeStylesheet
+		);
+	} );
+
+	if (
+		block.name === 'core/template-part' &&
+		block.attributes.theme === undefined
+	) {
+		block.attributes.theme = currentThemeStylesheet;
+	}
+	return block;
+}
+
+function preparePatterns( patterns, template, currentThemeStylesheet ) {
+	return (
+		patterns
+			.filter(
+				( pattern ) => ! PATTERN_CORE_SOURCES.includes( pattern.source )
+			)
+			.filter( filterOutDuplicatesByName )
+			// Filter only the patterns that are compatible with the current template.
+			.filter( ( pattern ) =>
+				pattern.templateTypes?.includes( template.slug )
+			)
+			.map( ( pattern ) => ( {
+				...pattern,
+				keywords: pattern.keywords || [],
+				type: PATTERN_TYPES.theme,
+				blocks: parse( pattern.content, {
+					__unstableSkipMigrationLogs: true,
+				} ).map( ( block ) =>
+					injectThemeAttributeInBlockTemplateContent(
+						block,
+						currentThemeStylesheet
+					)
+				),
+			} ) )
+	);
+}
+
+export function useAvailablePatterns( template ) {
+	const { blockPatterns, restBlockPatterns, currentThemeStylesheet } =
+		useSelect( ( select ) => {
+			const { getSettings } = unlock( select( editSiteStore ) );
+			const settings = getSettings();
+
+			return {
+				blockPatterns:
+					settings.__experimentalAdditionalBlockPatterns ??
+					settings.__experimentalBlockPatterns,
+				restBlockPatterns: select( coreStore ).getBlockPatterns(),
+				currentThemeStylesheet:
+					select( coreStore ).getCurrentTheme().stylesheet,
+			};
+		}, [] );
+
+	return useMemo( () => {
+		const mergedPatterns = [
+			...( blockPatterns || [] ),
+			...( restBlockPatterns || [] ),
+		];
+		return preparePatterns(
+			mergedPatterns,
+			template,
+			currentThemeStylesheet
+		);
+	}, [ blockPatterns, restBlockPatterns, template, currentThemeStylesheet ] );
+}

--- a/packages/edit-site/src/components/sidebar-edit-mode/template-panel/replace-template-button.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/template-panel/replace-template-button.js
@@ -35,7 +35,7 @@ export default function ReplaceTemplateButton( {
 	const onTemplateSelect = async ( selectedTemplate ) => {
 		onClose(); // Close the template suggestions modal first.
 		onClick();
-		editEntityRecord( 'postType', postType, postId, {
+		await editEntityRecord( 'postType', postType, postId, {
 			blocks: selectedTemplate.blocks,
 			content: serialize( selectedTemplate.blocks ),
 		} );

--- a/packages/edit-site/src/components/sidebar-edit-mode/template-panel/replace-template-button.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/template-panel/replace-template-button.js
@@ -1,12 +1,12 @@
 /**
  * WordPress dependencies
  */
-import { useSelect } from '@wordpress/data';
+import { useSelect, useDispatch } from '@wordpress/data';
 import { useState } from '@wordpress/element';
 import { __experimentalBlockPatternsList as BlockPatternsList } from '@wordpress/block-editor';
 import { MenuItem, Modal } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { useEntityRecord } from '@wordpress/core-data';
+import { store as coreStore } from '@wordpress/core-data';
 import { useAsyncList } from '@wordpress/compose';
 import { serialize } from '@wordpress/blocks';
 
@@ -19,6 +19,7 @@ export default function ReplaceTemplateButton( {
 	onClick,
 	availableTemplates,
 } ) {
+	const { editEntityRecord } = useDispatch( coreStore );
 	const [ showModal, setShowModal ] = useState( false );
 	const onClose = () => {
 		setShowModal( false );
@@ -31,11 +32,10 @@ export default function ReplaceTemplateButton( {
 		};
 	}, [] );
 
-	const entity = useEntityRecord( 'postType', postType, postId );
 	const onTemplateSelect = async ( selectedTemplate ) => {
 		onClose(); // Close the template suggestions modal first.
 		onClick();
-		await entity.edit( {
+		editEntityRecord( 'postType', postType, postId, {
 			blocks: selectedTemplate.blocks,
 			content: serialize( selectedTemplate.blocks ),
 		} );

--- a/packages/edit-site/src/components/sidebar-edit-mode/template-panel/replace-template-button.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/template-panel/replace-template-button.js
@@ -44,7 +44,7 @@ export default function ReplaceTemplateButton( {
 		<>
 			<MenuItem
 				info={ __(
-					'Replace this template entirely with another like it.'
+					'Replace the contents of this template with another.'
 				) }
 				onClick={ () => setShowModal( true ) }
 			>

--- a/packages/edit-site/src/components/sidebar-edit-mode/template-panel/replace-template-button.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/template-panel/replace-template-button.js
@@ -40,6 +40,11 @@ export default function ReplaceTemplateButton( {
 			content: serialize( selectedTemplate.blocks ),
 		} );
 	};
+
+	if ( ! availableTemplates.length || availableTemplates.length < 1 ) {
+		return null;
+	}
+
 	return (
 		<>
 			<MenuItem

--- a/packages/edit-site/src/components/sidebar-edit-mode/template-panel/replace-template-button.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/template-panel/replace-template-button.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { useSelect } from '@wordpress/data';
-import { useState, useCallback } from '@wordpress/element';
+import { useState } from '@wordpress/element';
 import { __experimentalBlockPatternsList as BlockPatternsList } from '@wordpress/block-editor';
 import { MenuItem, Modal } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
@@ -20,9 +20,9 @@ export default function ReplaceTemplateButton( {
 	availableTemplates,
 } ) {
 	const [ showModal, setShowModal ] = useState( false );
-	const onClose = useCallback( () => {
+	const onClose = () => {
 		setShowModal( false );
-	}, [] );
+	};
 
 	const { postId, postType } = useSelect( ( select ) => {
 		return {

--- a/packages/edit-site/src/components/sidebar-edit-mode/template-panel/replace-template-button.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/template-panel/replace-template-button.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useSelect } from '@wordpress/data';
+import { useSelect, useDispatch } from '@wordpress/data';
 import { useState, useCallback } from '@wordpress/element';
 import { __experimentalBlockPatternsList as BlockPatternsList } from '@wordpress/block-editor';
 import { MenuItem, Modal } from '@wordpress/components';
@@ -16,8 +16,10 @@ import { store as editSiteStore } from '../../../store';
 
 export default function ReplaceTemplateButton( {
 	onClick,
+	template,
 	availableTemplates,
 } ) {
+	const { setTemplate } = useDispatch( editSiteStore );
 	const [ showModal, setShowModal ] = useState( false );
 	const onClose = useCallback( () => {
 		setShowModal( false );
@@ -30,12 +32,12 @@ export default function ReplaceTemplateButton( {
 		};
 	}, [] );
 
-	const entitiy = useEntityRecord( 'postType', postType, postId );
-
+	const entity = useEntityRecord( 'postType', postType, postId );
 	const onTemplateSelect = async ( selectedTemplate ) => {
-		// TODO - trigger a reload
-		entitiy.edit( { content: selectedTemplate.content } );
-
+		//FIXME: This is a hack to get around the fact that the template is not being set correctly.
+		await setTemplate( null, null );
+		await entity.edit( { content: selectedTemplate.content } );
+		await setTemplate( postId, template.slug );
 		onClose(); // Close the template suggestions modal first.
 		onClick();
 	};

--- a/packages/edit-site/src/components/sidebar-edit-mode/template-panel/replace-template-button.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/template-panel/replace-template-button.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useSelect, useDispatch } from '@wordpress/data';
+import { useSelect } from '@wordpress/data';
 import { useState, useCallback } from '@wordpress/element';
 import { __experimentalBlockPatternsList as BlockPatternsList } from '@wordpress/block-editor';
 import { MenuItem, Modal } from '@wordpress/components';
@@ -16,10 +16,8 @@ import { store as editSiteStore } from '../../../store';
 
 export default function ReplaceTemplateButton( {
 	onClick,
-	template,
 	availableTemplates,
 } ) {
-	const { setTemplate } = useDispatch( editSiteStore );
 	const [ showModal, setShowModal ] = useState( false );
 	const onClose = useCallback( () => {
 		setShowModal( false );
@@ -34,13 +32,10 @@ export default function ReplaceTemplateButton( {
 
 	const entity = useEntityRecord( 'postType', postType, postId );
 	const onTemplateSelect = async ( selectedTemplate ) => {
-		//FIXME: This is a hack to get around the fact that the template is not being set correctly.
-		await setTemplate( null, null );
 		await entity.edit( {
 			blocks: selectedTemplate.blocks,
 			content: selectedTemplate.content,
 		} );
-		await setTemplate( postId, template.slug );
 		onClose(); // Close the template suggestions modal first.
 		onClick();
 	};

--- a/packages/edit-site/src/components/sidebar-edit-mode/template-panel/replace-template-button.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/template-panel/replace-template-button.js
@@ -8,6 +8,7 @@ import { MenuItem, Modal } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useEntityRecord } from '@wordpress/core-data';
 import { useAsyncList } from '@wordpress/compose';
+import { serialize } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -34,7 +35,7 @@ export default function ReplaceTemplateButton( {
 	const onTemplateSelect = async ( selectedTemplate ) => {
 		await entity.edit( {
 			blocks: selectedTemplate.blocks,
-			content: selectedTemplate.content,
+			content: serialize( selectedTemplate.blocks ),
 		} );
 		onClose(); // Close the template suggestions modal first.
 		onClick();

--- a/packages/edit-site/src/components/sidebar-edit-mode/template-panel/replace-template-button.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/template-panel/replace-template-button.js
@@ -1,0 +1,96 @@
+/**
+ * WordPress dependencies
+ */
+import { useDispatch } from '@wordpress/data';
+import { useMemo, useState, useCallback } from '@wordpress/element';
+import { decodeEntities } from '@wordpress/html-entities';
+import { __experimentalBlockPatternsList as BlockPatternsList } from '@wordpress/block-editor';
+import { MenuItem, Modal } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { useEntityRecord } from '@wordpress/core-data';
+import { parse } from '@wordpress/blocks';
+import { useAsyncList } from '@wordpress/compose';
+
+/**
+ * Internal dependencies
+ */
+import { store as editSiteStore } from '../../../store';
+import {
+	useAvailableTemplates,
+	useEditedPostContext,
+} from '../page-panels/hooks';
+
+export default function ReplaceTemplateButton( { onClick } ) {
+	const [ showModal, setShowModal ] = useState( false );
+	const availableTemplates = useAvailableTemplates();
+	const onClose = useCallback( () => {
+		setShowModal( false );
+	}, [] );
+
+	// TODO - this isn't a post, it's a template, so fetch the template entity.
+	const { postType, postId } = useEditedPostContext();
+	const entitiy = useEntityRecord( 'postType', postType, postId );
+	const { setPage } = useDispatch( editSiteStore );
+	if ( ! availableTemplates?.length ) {
+		return null;
+	}
+	const onTemplateSelect = async ( template ) => {
+		entitiy.edit( { template: template.name }, { undoIgnore: true } );
+		// TODO - work out how to save the template.
+		await setPage( {
+			context: { postType, postId },
+		} );
+		onClose(); // Close the template suggestions modal first.
+		onClick();
+	};
+	return (
+		<>
+			<MenuItem
+				info={ __(
+					'Replace this template entirely with another like it.'
+				) }
+				onClick={ () => setShowModal( true ) }
+			>
+				{ __( 'Replace template' ) }
+			</MenuItem>
+
+			{ showModal && (
+				<Modal
+					title={ __( 'Choose a template' ) }
+					onRequestClose={ onClose }
+					overlayClassName="edit-site-template-panel__replace-template-modal"
+					isFullScreen
+				>
+					<div className="edit-site-template-panel__replace-template-modal__content">
+						<TemplatesList onSelect={ onTemplateSelect } />
+					</div>
+				</Modal>
+			) }
+		</>
+	);
+}
+
+function TemplatesList( { onSelect } ) {
+	const availableTemplates = useAvailableTemplates();
+	const templatesAsPatterns = useMemo(
+		() =>
+			availableTemplates.map( ( template ) => ( {
+				name: template.slug,
+				blocks: parse( template.content.raw ),
+				title: decodeEntities( template.title.rendered ),
+				id: template.id,
+			} ) ),
+		[ availableTemplates ]
+	);
+	const shownTemplates = useAsyncList( templatesAsPatterns );
+
+	// TODO - make this use a grid layout.
+	return (
+		<BlockPatternsList
+			label={ __( 'Templates' ) }
+			blockPatterns={ templatesAsPatterns }
+			shownPatterns={ shownTemplates }
+			onClickPattern={ onSelect }
+		/>
+	);
+}

--- a/packages/edit-site/src/components/sidebar-edit-mode/template-panel/replace-template-button.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/template-panel/replace-template-button.js
@@ -72,7 +72,6 @@ export default function ReplaceTemplateButton( {
 function TemplatesList( { availableTemplates, onSelect } ) {
 	const shownTemplates = useAsyncList( availableTemplates );
 
-	// TODO - make this use a grid layout.
 	return (
 		<BlockPatternsList
 			label={ __( 'Templates' ) }

--- a/packages/edit-site/src/components/sidebar-edit-mode/template-panel/replace-template-button.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/template-panel/replace-template-button.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useSelect } from '@wordpress/data';
+import { useSelect, useDispatch } from '@wordpress/data';
 import { useMemo, useState, useCallback } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
 import { __experimentalBlockPatternsList as BlockPatternsList } from '@wordpress/block-editor';
@@ -41,6 +41,7 @@ const selectAvailablePatterns = ( select ) => {
 			( pattern ) => ! PATTERN_CORE_SOURCES.includes( pattern.source )
 		)
 		.filter( filterOutDuplicatesByName )
+		// TODO use the correct type.
 		.filter( ( pattern ) => pattern.templateTypes?.includes( 'home' ) )
 		.map( ( pattern ) => ( {
 			...pattern,
@@ -68,29 +69,17 @@ export default function ReplaceTemplateButton( { onClick } ) {
 		};
 	}, [] );
 
-	// Should we also get templates?
-
-	//console.log( selectThemePatterns );
 	const entitiy = useEntityRecord( 'postType', postType, postId );
-	console.log( 'entitiy', entitiy );
 
+	// Should we also get templates?
 	const availableTemplates = useSelect( selectAvailablePatterns );
-	console.log( availableTemplates );
-	//const { setPage } = useDispatch( editSiteStore );
 	if ( ! availableTemplates?.length ) {
 		return null;
 	}
-	const onTemplateSelect = async ( template ) => {
-		const templateObjectItself = availableTemplates.find(
-			( availableTemplate ) => availableTemplate.name === template.id
-		);
-		console.log( templateObjectItself.content );
 
-		entitiy.edit( { content: templateObjectItself.content } );
-		// TODO - work out how to save the template.
-		//	await setPage( {
-		//		context: { postType, postId },
-		//	} );
+	const onTemplateSelect = async ( template ) => {
+		entitiy.edit( { content: template.content } );
+		// TODO - trigger a reload
 		onClose(); // Close the template suggestions modal first.
 		onClick();
 	};
@@ -132,6 +121,7 @@ function TemplatesList( { onSelect } ) {
 					blocks: template.blocks,
 					title: template.title,
 					id: template.name,
+					content: template.content,
 				};
 			} ),
 		[ availableTemplates ]

--- a/packages/edit-site/src/components/sidebar-edit-mode/template-panel/replace-template-button.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/template-panel/replace-template-button.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { useSelect } from '@wordpress/data';
-import { useMemo, useState, useCallback } from '@wordpress/element';
+import { useState, useCallback } from '@wordpress/element';
 import { __experimentalBlockPatternsList as BlockPatternsList } from '@wordpress/block-editor';
 import { MenuItem, Modal } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
@@ -19,7 +19,6 @@ export default function ReplaceTemplateButton( {
 	availableTemplates,
 } ) {
 	const [ showModal, setShowModal ] = useState( false );
-	//const availableTemplates = useAvailableTemplates();
 	const onClose = useCallback( () => {
 		setShowModal( false );
 	}, [] );
@@ -32,10 +31,6 @@ export default function ReplaceTemplateButton( {
 	}, [] );
 
 	const entitiy = useEntityRecord( 'postType', postType, postId );
-
-	if ( ! availableTemplates?.length ) {
-		return null;
-	}
 
 	const onTemplateSelect = async ( selectedTemplate ) => {
 		// TODO - trigger a reload
@@ -75,25 +70,13 @@ export default function ReplaceTemplateButton( {
 }
 
 function TemplatesList( { availableTemplates, onSelect } ) {
-	const templatesAsPatterns = useMemo(
-		() =>
-			availableTemplates.map( ( template ) => {
-				return {
-					name: template.name,
-					blocks: template.blocks,
-					title: template.title,
-					content: template.content,
-				};
-			} ),
-		[ availableTemplates ]
-	);
-	const shownTemplates = useAsyncList( templatesAsPatterns );
+	const shownTemplates = useAsyncList( availableTemplates );
 
 	// TODO - make this use a grid layout.
 	return (
 		<BlockPatternsList
 			label={ __( 'Templates' ) }
-			blockPatterns={ templatesAsPatterns }
+			blockPatterns={ availableTemplates }
 			shownPatterns={ shownTemplates }
 			onClickPattern={ onSelect }
 		/>

--- a/packages/edit-site/src/components/sidebar-edit-mode/template-panel/replace-template-button.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/template-panel/replace-template-button.js
@@ -36,7 +36,10 @@ export default function ReplaceTemplateButton( {
 	const onTemplateSelect = async ( selectedTemplate ) => {
 		//FIXME: This is a hack to get around the fact that the template is not being set correctly.
 		await setTemplate( null, null );
-		await entity.edit( { content: selectedTemplate.content } );
+		await entity.edit( {
+			blocks: selectedTemplate.blocks,
+			content: selectedTemplate.content,
+		} );
 		await setTemplate( postId, template.slug );
 		onClose(); // Close the template suggestions modal first.
 		onClick();

--- a/packages/edit-site/src/components/sidebar-edit-mode/template-panel/replace-template-button.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/template-panel/replace-template-button.js
@@ -33,12 +33,12 @@ export default function ReplaceTemplateButton( {
 
 	const entity = useEntityRecord( 'postType', postType, postId );
 	const onTemplateSelect = async ( selectedTemplate ) => {
+		onClose(); // Close the template suggestions modal first.
+		onClick();
 		await entity.edit( {
 			blocks: selectedTemplate.blocks,
 			content: serialize( selectedTemplate.blocks ),
 		} );
-		onClose(); // Close the template suggestions modal first.
-		onClick();
 	};
 	return (
 		<>

--- a/packages/edit-site/src/components/sidebar-edit-mode/template-panel/style.scss
+++ b/packages/edit-site/src/components/sidebar-edit-mode/template-panel/style.scss
@@ -37,3 +37,16 @@ h3.edit-site-template-card__template-areas-title {
 	font-weight: 500;
 	margin: 0 0 $grid-unit-10;
 }
+
+.edit-site-template-panel__replace-template-modal__content {
+	column-count: 2;
+	column-gap: $grid-unit-30;
+
+	@include break-medium() {
+		column-count: 3;
+	}
+
+	@include break-wide() {
+		column-count: 4;
+	}
+}

--- a/packages/edit-site/src/components/sidebar-edit-mode/template-panel/style.scss
+++ b/packages/edit-site/src/components/sidebar-edit-mode/template-panel/style.scss
@@ -38,6 +38,11 @@ h3.edit-site-template-card__template-areas-title {
 	margin: 0 0 $grid-unit-10;
 }
 
+
+.edit-site-template-panel__replace-template-modal {
+	z-index: z-index(".edit-site-template-panel__replace-template-modal");
+}
+
 .edit-site-template-panel__replace-template-modal__content {
 	column-count: 2;
 	column-gap: $grid-unit-30;

--- a/packages/edit-site/src/components/sidebar-edit-mode/template-panel/template-actions.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/template-panel/template-actions.js
@@ -49,14 +49,11 @@ export default function Actions( { template } ) {
 							{ __( 'Clear customizations' ) }
 						</MenuItem>
 					) }
-					{ !! availablePatterns.length &&
-						availablePatterns.length > 1 && (
-							<ReplaceTemplateButton
-								availableTemplates={ availablePatterns }
-								template={ template }
-								onClick={ onClose }
-							/>
-						) }
+					<ReplaceTemplateButton
+						availableTemplates={ availablePatterns }
+						template={ template }
+						onClick={ onClose }
+					/>
 				</MenuGroup>
 			) }
 		</DropdownMenu>

--- a/packages/edit-site/src/components/sidebar-edit-mode/template-panel/template-actions.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/template-panel/template-actions.js
@@ -19,7 +19,11 @@ export default function Actions( { template } ) {
 	const { revertTemplate } = useDispatch( editSiteStore );
 	const isRevertable = isTemplateRevertable( template );
 
-	if ( ! isRevertable && availablePatterns.length === 0 ) {
+	if (
+		! isRevertable &&
+		!! availablePatterns.length &&
+		availablePatterns.length < 1
+	) {
 		return null;
 	}
 
@@ -45,13 +49,14 @@ export default function Actions( { template } ) {
 							{ __( 'Clear customizations' ) }
 						</MenuItem>
 					) }
-					{ availablePatterns.length > 1 && (
-						<ReplaceTemplateButton
-							availableTemplates={ availablePatterns }
-							template={ template }
-							onClick={ onClose }
-						/>
-					) }
+					{ !! availablePatterns.length &&
+						availablePatterns.length > 1 && (
+							<ReplaceTemplateButton
+								availableTemplates={ availablePatterns }
+								template={ template }
+								onClick={ onClose }
+							/>
+						) }
 				</MenuGroup>
 			) }
 		</DropdownMenu>

--- a/packages/edit-site/src/components/sidebar-edit-mode/template-panel/template-actions.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/template-panel/template-actions.js
@@ -21,7 +21,7 @@ export default function Actions( { template } ) {
 
 	if (
 		! isRevertable &&
-		( !! availablePatterns.length || availablePatterns.length < 1 )
+		( ! availablePatterns.length || availablePatterns.length < 1 )
 	) {
 		return null;
 	}

--- a/packages/edit-site/src/components/sidebar-edit-mode/template-panel/template-actions.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/template-panel/template-actions.js
@@ -21,8 +21,7 @@ export default function Actions( { template } ) {
 
 	if (
 		! isRevertable &&
-		!! availablePatterns.length &&
-		availablePatterns.length < 1
+		( !! availablePatterns.length || availablePatterns.length < 1 )
 	) {
 		return null;
 	}

--- a/packages/edit-site/src/components/sidebar-edit-mode/template-panel/template-actions.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/template-panel/template-actions.js
@@ -12,7 +12,8 @@ import { moreVertical } from '@wordpress/icons';
 import { store as editSiteStore } from '../../../store';
 import isTemplateRevertable from '../../../utils/is-template-revertable';
 import ReplaceTemplateButton from './replace-template-button';
-import { useAvailablePatterns } from '../page-panels/hooks';
+import { useAvailablePatterns } from './hooks';
+
 export default function Actions( { template } ) {
 	const availablePatterns = useAvailablePatterns( template );
 	const { revertTemplate } = useDispatch( editSiteStore );

--- a/packages/edit-site/src/components/sidebar-edit-mode/template-panel/template-actions.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/template-panel/template-actions.js
@@ -39,8 +39,10 @@ export default function Actions( { template } ) {
 				( pattern ) => ! PATTERN_CORE_SOURCES.includes( pattern.source )
 			)
 			.filter( filterOutDuplicatesByName )
-			// TODO use the correct type.
-			.filter( ( pattern ) => pattern.templateTypes?.includes( 'home' ) )
+			// Filter only the patterns that are compatible with the current template.
+			.filter( ( pattern ) =>
+				pattern.templateTypes?.includes( template.slug )
+			)
 			.map( ( pattern ) => ( {
 				...pattern,
 				keywords: pattern.keywords || [],

--- a/packages/edit-site/src/components/sidebar-edit-mode/template-panel/template-actions.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/template-panel/template-actions.js
@@ -44,7 +44,7 @@ export default function Actions( { template } ) {
 							{ __( 'Clear customizations' ) }
 						</MenuItem>
 					) }
-					{ availablePatterns.length > 0 && (
+					{ availablePatterns.length > 1 && (
 						<ReplaceTemplateButton
 							availableTemplates={ availablePatterns }
 							template={ template }

--- a/packages/edit-site/src/components/sidebar-edit-mode/template-panel/template-actions.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/template-panel/template-actions.js
@@ -15,18 +15,10 @@ import ReplaceTemplateButton from './replace-template-button';
 import { useAvailablePatterns } from '../page-panels/hooks';
 export default function Actions( { template } ) {
 	const availablePatterns = useAvailablePatterns( template );
-	const availableTemplates = availablePatterns.map( ( pattern ) => {
-		return {
-			name: pattern.name,
-			blocks: pattern.blocks,
-			title: pattern.title,
-			content: pattern.content,
-		};
-	} );
 	const { revertTemplate } = useDispatch( editSiteStore );
 	const isRevertable = isTemplateRevertable( template );
 
-	if ( ! isRevertable && availableTemplates.length === 0 ) {
+	if ( ! isRevertable && availablePatterns.length === 0 ) {
 		return null;
 	}
 
@@ -52,9 +44,9 @@ export default function Actions( { template } ) {
 							{ __( 'Clear customizations' ) }
 						</MenuItem>
 					) }
-					{ availableTemplates.length > 0 && (
+					{ availablePatterns.length > 0 && (
 						<ReplaceTemplateButton
-							availableTemplates={ availableTemplates }
+							availableTemplates={ availablePatterns }
 							template={ template }
 							onClick={ onClose }
 						/>

--- a/packages/edit-site/src/components/sidebar-edit-mode/template-panel/template-actions.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/template-panel/template-actions.js
@@ -1,10 +1,12 @@
 /**
  * WordPress dependencies
  */
-import { useDispatch } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { DropdownMenu, MenuGroup, MenuItem } from '@wordpress/components';
 import { moreVertical } from '@wordpress/icons';
+import { parse } from '@wordpress/blocks';
+import { store as coreStore } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
@@ -12,12 +14,50 @@ import { moreVertical } from '@wordpress/icons';
 import { store as editSiteStore } from '../../../store';
 import isTemplateRevertable from '../../../utils/is-template-revertable';
 import ReplaceTemplateButton from './replace-template-button';
+import { unlock } from '../../../lock-unlock';
+import { PATTERN_CORE_SOURCES, PATTERN_TYPES } from '../../../utils/constants';
 
 export default function Actions( { template } ) {
+	// This is duplicated.
+	const filterOutDuplicatesByName = ( currentItem, index, items ) =>
+		index === items.findIndex( ( item ) => currentItem.name === item.name );
+
+	const selectAvailablePatterns = ( select ) => {
+		const { getSettings } = unlock( select( editSiteStore ) );
+		const settings = getSettings();
+		const blockPatterns =
+			settings.__experimentalAdditionalBlockPatterns ??
+			settings.__experimentalBlockPatterns;
+
+		const restBlockPatterns = select( coreStore ).getBlockPatterns();
+
+		const patterns = [
+			...( blockPatterns || [] ),
+			...( restBlockPatterns || [] ),
+		]
+			.filter(
+				( pattern ) => ! PATTERN_CORE_SOURCES.includes( pattern.source )
+			)
+			.filter( filterOutDuplicatesByName )
+			// TODO use the correct type.
+			.filter( ( pattern ) => pattern.templateTypes?.includes( 'home' ) )
+			.map( ( pattern ) => ( {
+				...pattern,
+				keywords: pattern.keywords || [],
+				type: PATTERN_TYPES.theme,
+				blocks: parse( pattern.content, {
+					__unstableSkipMigrationLogs: true,
+				} ),
+			} ) );
+
+		return patterns;
+	};
+	// Should we also get templates?
+	const availableTemplates = useSelect( selectAvailablePatterns );
 	const { revertTemplate } = useDispatch( editSiteStore );
 	const isRevertable = isTemplateRevertable( template );
-	// TODO - update this condition so that we also show the dropdown when there are other template options.
-	if ( ! isRevertable ) {
+
+	if ( ! isRevertable && availableTemplates.length === 0 ) {
 		return null;
 	}
 
@@ -30,18 +70,26 @@ export default function Actions( { template } ) {
 		>
 			{ ( { onClose } ) => (
 				<MenuGroup>
-					<MenuItem
-						info={ __(
-							'Use the template as supplied by the theme.'
-						) }
-						onClick={ () => {
-							revertTemplate( template );
-							onClose();
-						} }
-					>
-						{ __( 'Clear customizations' ) }
-					</MenuItem>
-					<ReplaceTemplateButton onClick={ onClose } />
+					{ isRevertable && (
+						<MenuItem
+							info={ __(
+								'Use the template as supplied by the theme.'
+							) }
+							onClick={ () => {
+								revertTemplate( template );
+								onClose();
+							} }
+						>
+							{ __( 'Clear customizations' ) }
+						</MenuItem>
+					) }
+					{ availableTemplates.length > 0 && (
+						<ReplaceTemplateButton
+							availableTemplates={ availableTemplates }
+							template={ template }
+							onClick={ onClose }
+						/>
+					) }
 				</MenuGroup>
 			) }
 		</DropdownMenu>

--- a/packages/edit-site/src/components/sidebar-edit-mode/template-panel/template-actions.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/template-panel/template-actions.js
@@ -22,7 +22,8 @@ export default function Actions( { template } ) {
 	const filterOutDuplicatesByName = ( currentItem, index, items ) =>
 		index === items.findIndex( ( item ) => currentItem.name === item.name );
 
-	const selectAvailablePatterns = ( select ) => {
+	// Should we also get templates?
+	const availableTemplates = useSelect( ( select ) => {
 		const { getSettings } = unlock( select( editSiteStore ) );
 		const settings = getSettings();
 		const blockPatterns =
@@ -52,10 +53,15 @@ export default function Actions( { template } ) {
 				} ),
 			} ) );
 
-		return patterns;
-	};
-	// Should we also get templates?
-	const availableTemplates = useSelect( selectAvailablePatterns );
+		return patterns.map( ( pattern ) => {
+			return {
+				name: pattern.name,
+				blocks: pattern.blocks,
+				title: pattern.title,
+				content: pattern.content,
+			};
+		} );
+	} );
 	const { revertTemplate } = useDispatch( editSiteStore );
 	const isRevertable = isTemplateRevertable( template );
 

--- a/packages/edit-site/src/components/sidebar-edit-mode/template-panel/template-actions.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/template-panel/template-actions.js
@@ -1,12 +1,10 @@
 /**
  * WordPress dependencies
  */
-import { useDispatch, useSelect } from '@wordpress/data';
+import { useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { DropdownMenu, MenuGroup, MenuItem } from '@wordpress/components';
 import { moreVertical } from '@wordpress/icons';
-import { parse } from '@wordpress/blocks';
-import { store as coreStore } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
@@ -14,53 +12,16 @@ import { store as coreStore } from '@wordpress/core-data';
 import { store as editSiteStore } from '../../../store';
 import isTemplateRevertable from '../../../utils/is-template-revertable';
 import ReplaceTemplateButton from './replace-template-button';
-import { unlock } from '../../../lock-unlock';
-import { PATTERN_CORE_SOURCES, PATTERN_TYPES } from '../../../utils/constants';
-
+import { useAvailablePatterns } from '../page-panels/hooks';
 export default function Actions( { template } ) {
-	// This is duplicated.
-	const filterOutDuplicatesByName = ( currentItem, index, items ) =>
-		index === items.findIndex( ( item ) => currentItem.name === item.name );
-
-	// Should we also get templates?
-	const availableTemplates = useSelect( ( select ) => {
-		const { getSettings } = unlock( select( editSiteStore ) );
-		const settings = getSettings();
-		const blockPatterns =
-			settings.__experimentalAdditionalBlockPatterns ??
-			settings.__experimentalBlockPatterns;
-
-		const restBlockPatterns = select( coreStore ).getBlockPatterns();
-
-		const patterns = [
-			...( blockPatterns || [] ),
-			...( restBlockPatterns || [] ),
-		]
-			.filter(
-				( pattern ) => ! PATTERN_CORE_SOURCES.includes( pattern.source )
-			)
-			.filter( filterOutDuplicatesByName )
-			// Filter only the patterns that are compatible with the current template.
-			.filter( ( pattern ) =>
-				pattern.templateTypes?.includes( template.slug )
-			)
-			.map( ( pattern ) => ( {
-				...pattern,
-				keywords: pattern.keywords || [],
-				type: PATTERN_TYPES.theme,
-				blocks: parse( pattern.content, {
-					__unstableSkipMigrationLogs: true,
-				} ),
-			} ) );
-
-		return patterns.map( ( pattern ) => {
-			return {
-				name: pattern.name,
-				blocks: pattern.blocks,
-				title: pattern.title,
-				content: pattern.content,
-			};
-		} );
+	const availablePatterns = useAvailablePatterns( template );
+	const availableTemplates = availablePatterns.map( ( pattern ) => {
+		return {
+			name: pattern.name,
+			blocks: pattern.blocks,
+			title: pattern.title,
+			content: pattern.content,
+		};
 	} );
 	const { revertTemplate } = useDispatch( editSiteStore );
 	const isRevertable = isTemplateRevertable( template );

--- a/packages/edit-site/src/components/sidebar-edit-mode/template-panel/template-actions.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/template-panel/template-actions.js
@@ -11,13 +11,16 @@ import { moreVertical } from '@wordpress/icons';
  */
 import { store as editSiteStore } from '../../../store';
 import isTemplateRevertable from '../../../utils/is-template-revertable';
+import ReplaceTemplateButton from './replace-template-button';
 
 export default function Actions( { template } ) {
 	const { revertTemplate } = useDispatch( editSiteStore );
 	const isRevertable = isTemplateRevertable( template );
+	// TODO - update this condition so that we also show the dropdown when there are other template options.
 	if ( ! isRevertable ) {
 		return null;
 	}
+
 	return (
 		<DropdownMenu
 			icon={ moreVertical }
@@ -38,6 +41,7 @@ export default function Actions( { template } ) {
 					>
 						{ __( 'Clear customizations' ) }
 					</MenuItem>
+					<ReplaceTemplateButton onClick={ onClose } />
 				</MenuGroup>
 			) }
 		</DropdownMenu>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Add template replace flow to template inspector - fixes https://github.com/WordPress/gutenberg/issues/54562

## Why?
Twenty Twenty-Four is exploring adding alternate template types for the home, index, single and page templates. While the effort in https://github.com/WordPress/gutenberg/pull/51477 brings alternate template selection to pages, templates still do not have this capability.

There's currently not a method for someone to swap a template directly with another templateType.

## How?
Add a new ReplaceTemplateButton component which opens a modal of available templates and lets a user pick the correct on.

## Testing Instructions
1. Open the Site Editor and go to the template inspector.
2. You should see a button that allows you to replace your current template
3. This button should open a modal allowing you to select a different template
4. When you select a different template, the contents of your old template should be replace with the one you selected and the entity should be dirty.

## Screenshots or screencast <!-- if applicable -->



https://github.com/WordPress/gutenberg/assets/107534/391a3c24-4b5d-4754-b51b-4c99851097b2




This work is heavily based on https://github.com/WordPress/gutenberg/pull/51477