### PR TITLE
Font Face: avoid using non required property as index and use right property to render font face

### DIFF
--- a/lib/compat/wordpress-6.4/fonts/font-face/class-wp-font-face-resolver.php
+++ b/lib/compat/wordpress-6.4/fonts/font-face/class-wp-font-face-resolver.php
@@ -73,7 +73,7 @@ class WP_Font_Face_Resolver {
 					$fonts[ $font_family ] = array();
 				}
 				
-				$fonts[ $font_family ] = static::convert_font_face_properties( $definition['fontFace'], $font_family );
+				$fonts[ $font_family ] = static::convert_font_face_properties( $definition['fontFace'] );
 			}
 		}
 
@@ -86,15 +86,14 @@ class WP_Font_Face_Resolver {
 	 * @since 6.4.0
 	 *
 	 * @param array  $font_face_definition The font-face definitions to convert.
-	 * @param string $font_family_property The value to store in the font-face font-family property.
 	 * @return array Converted font-face properties.
 	 */
-	private static function convert_font_face_properties( array $font_face_definition, $font_family_property ) {
+	private static function convert_font_face_properties( array $font_face_definition ) {
 		$converted_font_faces = array();
 
 		foreach ( $font_face_definition as $font_face ) {
 			// Add the font-family property to the font-face.
-			$font_face['font-family'] = $font_family_property;
+			$font_face['font-family'] = $font_face['fontFamily'];
 
 			// Converts the "file:./" src placeholder into a theme font file URI.
 			if ( ! empty( $font_face['src'] ) ) {

--- a/lib/compat/wordpress-6.4/fonts/font-face/class-wp-font-face-resolver.php
+++ b/lib/compat/wordpress-6.4/fonts/font-face/class-wp-font-face-resolver.php
@@ -56,8 +56,8 @@ class WP_Font_Face_Resolver {
 		foreach ( $settings['typography']['fontFamilies'] as $font_families ) {
 			foreach ( $font_families as $definition ) {
 
-				// Skip if font-family "name" is not defined.
-				if ( empty( $definition['name'] ) ) {
+				// Skip if font-family "slug" is not defined.
+				if ( empty( $definition['slug'] ) ) {
 					continue;
 				}
 
@@ -66,13 +66,13 @@ class WP_Font_Face_Resolver {
 					continue;
 				}
 
-				$font_family = $definition['name'];
+				$font_family = $definition['slug'];
 
 				// Prepare the fonts array structure for this font-family.
 				if ( ! array_key_exists( $font_family, $fonts ) ) {
 					$fonts[ $font_family ] = array();
 				}
-
+				
 				$fonts[ $font_family ] = static::convert_font_face_properties( $definition['fontFace'], $font_family );
 			}
 		}

--- a/lib/compat/wordpress-6.4/fonts/font-face/class-wp-font-face-resolver.php
+++ b/lib/compat/wordpress-6.4/fonts/font-face/class-wp-font-face-resolver.php
@@ -72,7 +72,7 @@ class WP_Font_Face_Resolver {
 				if ( ! array_key_exists( $font_family, $fonts ) ) {
 					$fonts[ $font_family ] = array();
 				}
-				
+
 				$fonts[ $font_family ] = static::convert_font_face_properties( $definition['fontFace'] );
 			}
 		}
@@ -85,7 +85,7 @@ class WP_Font_Face_Resolver {
 	 *
 	 * @since 6.4.0
 	 *
-	 * @param array  $font_face_definition The font-face definitions to convert.
+	 * @param array $font_face_definition The font-face definitions to convert.
 	 * @return array Converted font-face properties.
 	 */
 	private static function convert_font_face_properties( array $font_face_definition ) {


### PR DESCRIPTION
## What?
- Fixes font face rendering when a name property is not defined.
- Fix the potential error when rendering font face CSS font family.

## Why?
Breaking with fonts families definitions, not including a name property.

## How?
 - Avoid using non-required property as the index of an associative array.
 - Use the right property to render font face. (fontFamily property of a font face).

## Testing Instructions
- Activate a theme with font families not containing the `name` property set.

## Todo:
Fix the tests accordingly to these changes.