### PR TITLE
Use admin colors in CanvasLoader ProgressBar

### DIFF
--- a/packages/components/src/progress-bar/styles.ts
+++ b/packages/components/src/progress-bar/styles.ts
@@ -26,7 +26,8 @@ export const Track = styled.div`
 	overflow: hidden;
 	width: 100%;
 	max-width: 160px;
-	height: ${ CONFIG.borderWidthFocus };
+	height: ${ CONFIG.borderWidth };
+	height: calc( ${ CONFIG.borderWidth } * 2 );
 	background-color: var(
 		--wp-components-color-gray-300,
 		${ COLORS.gray[ 300 ] }

--- a/packages/edit-site/src/components/canvas-loader/index.js
+++ b/packages/edit-site/src/components/canvas-loader/index.js
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
 import { privateApis as componentsPrivateApis } from '@wordpress/components';
 import { store as coreStore } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
@@ -10,17 +9,10 @@ import { useSelect } from '@wordpress/data';
  * Internal dependencies
  */
 import { unlock } from '../../lock-unlock';
-import { useStylesPreviewColors } from '../global-styles/hooks';
 
-const { ProgressBar, Theme } = unlock( componentsPrivateApis );
-const { useGlobalStyle } = unlock( blockEditorPrivateApis );
+const { ProgressBar } = unlock( componentsPrivateApis );
 
 export default function CanvasLoader( { id } ) {
-	const [ fallbackIndicatorColor ] = useGlobalStyle( 'color.text' );
-	const [ backgroundColor ] = useGlobalStyle( 'color.background' );
-	const { highlightedColors } = useStylesPreviewColors();
-	const indicatorColor =
-		highlightedColors[ 0 ]?.color ?? fallbackIndicatorColor;
 	const { elapsed, total } = useSelect( ( select ) => {
 		const selectorsByStatus = select( coreStore ).countSelectorsByStatus();
 		const resolving = selectorsByStatus.resolving ?? 0;
@@ -33,9 +25,7 @@ export default function CanvasLoader( { id } ) {
 
 	return (
 		<div className="edit-site-canvas-loader">
-			<Theme accent={ indicatorColor } background={ backgroundColor }>
-				<ProgressBar id={ id } max={ total } value={ elapsed } />
-			</Theme>
+			<ProgressBar id={ id } max={ total } value={ elapsed } />
 		</div>
 	);
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Closes #54202. 

Instead of pulling colors from Global Styles (which is unpredictable, as noted in the original issue), editor interface elements should be using editor colors. 

I also noted that the 1.5px height bar was shifting between 1.5 and 1px at varying viewport sizes, so I added a quick fix here to set it to 2px. Makes it more visible as well.

## How?
- Removes the references to useGlobalStyle within the CanvasLoader ProgressBar. 
- Sets the height of ProgressBar to 2px, instead of 1.5px (makes it more visible and reducing shifting). 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open the site editor.
2. See the ProgressBar using the admin theme color instead of the theme's accent color.

## Screenshots or screencast <!-- if applicable -->

| Before  | After |
| ------------- | ------------- |
|<img width="400" alt="before" src="https://github.com/WordPress/gutenberg/assets/1813435/9dc3858f-fe66-43b7-9883-871456e83b0d">|<img width="400" alt="after" src="https://github.com/WordPress/gutenberg/assets/1813435/70565924-e968-4807-a072-08664c08e4d4">|


