### PR TITLE
Try: use `ariakit` for DropdownMenu v2, test it in block editor settings

### DIFF
--- a/packages/block-editor/src/components/block-settings-menu-controls/index.js
+++ b/packages/block-editor/src/components/block-settings-menu-controls/index.js
@@ -72,8 +72,8 @@ const BlockSettingsMenuControlsSlot = ( {
 				}
 
 				return (
-					<MenuGroup>
-						{ showConvertToGroupButton && (
+					<>
+						{ /* { showConvertToGroupButton && (
 							<ConvertToGroupButton
 								{ ...convertToGroupButtonProps }
 								onClose={ fillProps?.onClose }
@@ -83,9 +83,9 @@ const BlockSettingsMenuControlsSlot = ( {
 							<BlockLockMenuItem
 								clientId={ selectedClientIds[ 0 ] }
 							/>
-						) }
+						) } */ }
 						{ fills }
-						{ fillProps?.canMove && ! fillProps?.onlyBlock && (
+						{ /* { fillProps?.canMove && ! fillProps?.onlyBlock && (
 							<MenuItem
 								onClick={ pipe(
 									fillProps?.onClose,
@@ -100,8 +100,8 @@ const BlockSettingsMenuControlsSlot = ( {
 								clientId={ fillProps?.firstBlockClientId }
 								onToggle={ fillProps?.onClose }
 							/>
-						) }
-					</MenuGroup>
+						) } */ }
+					</>
 				);
 			} }
 		</Slot>

--- a/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
@@ -6,7 +6,11 @@ import {
 	serialize,
 	store as blocksStore,
 } from '@wordpress/blocks';
-import { DropdownMenu, MenuGroup, MenuItem } from '@wordpress/components';
+import {
+	// DropdownMenu, MenuGroup, MenuItem
+	Icon,
+	privateApis as componentsPrivateApis,
+} from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { moreVertical } from '@wordpress/icons';
 import {
@@ -34,6 +38,10 @@ import { store as blockEditorStore } from '../../store';
 import { unlock } from '../../lock-unlock';
 import { useShowHoveredOrFocusedGestures } from '../block-toolbar/utils';
 
+const { DropdownMenuV2Ariakit, DropdownMenuItemV2Ariakit } = unlock(
+	componentsPrivateApis
+);
+
 const POPOVER_PROPS = {
 	className: 'block-editor-block-settings-menu__popover',
 	placement: 'bottom-start',
@@ -44,7 +52,11 @@ function CopyMenuItem( { blocks, onCopy, label } ) {
 	const copyMenuItemBlocksLabel =
 		blocks.length > 1 ? __( 'Copy blocks' ) : __( 'Copy' );
 	const copyMenuItemLabel = label ? label : copyMenuItemBlocksLabel;
-	return <MenuItem ref={ ref }>{ copyMenuItemLabel }</MenuItem>;
+	return (
+		<DropdownMenuItemV2Ariakit ref={ ref }>
+			{ copyMenuItemLabel }
+		</DropdownMenuItemV2Ariakit>
+	);
 }
 
 export function BlockSettingsDropdown( {
@@ -234,153 +246,28 @@ export function BlockSettingsDropdown( {
 				onMoveTo,
 				blocks,
 			} ) => (
-				<DropdownMenu
-					icon={ moreVertical }
-					label={ __( 'Options' ) }
-					className="block-editor-block-settings-menu"
-					popoverProps={ POPOVER_PROPS }
-					open={ open }
-					onToggle={ onToggle }
-					noIcons
-					menuProps={ {
-						/**
-						 * @param {KeyboardEvent} event
-						 */
-						onKeyDown( event ) {
-							if ( event.defaultPrevented ) return;
-
-							if (
-								isMatch( 'core/block-editor/remove', event ) &&
-								canRemove
-							) {
-								event.preventDefault();
-								updateSelectionAfterRemove( onRemove() );
-							} else if (
-								isMatch(
-									'core/block-editor/duplicate',
-									event
-								) &&
-								canDuplicate
-							) {
-								event.preventDefault();
-								updateSelectionAfterDuplicate( onDuplicate() );
-							} else if (
-								isMatch(
-									'core/block-editor/insert-after',
-									event
-								) &&
-								canInsertDefaultBlock
-							) {
-								event.preventDefault();
-								setOpenedBlockSettingsMenu( undefined );
-								onInsertAfter();
-							} else if (
-								isMatch(
-									'core/block-editor/insert-before',
-									event
-								) &&
-								canInsertDefaultBlock
-							) {
-								event.preventDefault();
-								setOpenedBlockSettingsMenu( undefined );
-								onInsertBefore();
-							}
-						},
-					} }
-					{ ...props }
+				<DropdownMenuV2Ariakit
+					trigger={ <Icon icon={ moreVertical } /> }
 				>
-					{ ( { onClose } ) => (
+					<DropdownMenuItemV2Ariakit>
+						Hello Brooke
+					</DropdownMenuItemV2Ariakit>
+					{ canCopyStyles && (
 						<>
-							<MenuGroup>
-								<__unstableBlockSettingsMenuFirstItem.Slot
-									fillProps={ { onClose } }
-								/>
-								{ ! parentBlockIsSelected &&
-									!! firstParentClientId && (
-										<MenuItem
-											{ ...showParentOutlineGestures }
-											ref={ selectParentButtonRef }
-											icon={
-												<BlockIcon
-													icon={
-														parentBlockType.icon
-													}
-												/>
-											}
-											onClick={ () =>
-												selectBlock(
-													firstParentClientId
-												)
-											}
-										>
-											{ sprintf(
-												/* translators: %s: Name of the block's parent. */
-												__(
-													'Select parent block (%s)'
-												),
-												parentBlockType.title
-											) }
-										</MenuItem>
-									) }
-								{ count === 1 && (
-									<BlockHTMLConvertButton
-										clientId={ firstBlockClientId }
-									/>
-								) }
-								<CopyMenuItem
-									blocks={ blocks }
-									onCopy={ onCopy }
-								/>
-								{ canDuplicate && (
-									<MenuItem
-										onClick={ pipe(
-											onClose,
-											onDuplicate,
-											updateSelectionAfterDuplicate
-										) }
-										shortcut={ shortcuts.duplicate }
-									>
-										{ __( 'Duplicate' ) }
-									</MenuItem>
-								) }
-								{ canInsertDefaultBlock && (
-									<>
-										<MenuItem
-											onClick={ pipe(
-												onClose,
-												onInsertBefore
-											) }
-											shortcut={ shortcuts.insertBefore }
-										>
-											{ __( 'Add before' ) }
-										</MenuItem>
-										<MenuItem
-											onClick={ pipe(
-												onClose,
-												onInsertAfter
-											) }
-											shortcut={ shortcuts.insertAfter }
-										>
-											{ __( 'Add after' ) }
-										</MenuItem>
-									</>
-								) }
-							</MenuGroup>
-							{ canCopyStyles && (
-								<MenuGroup>
-									<CopyMenuItem
-										blocks={ blocks }
-										onCopy={ onCopy }
-										label={ __( 'Copy styles' ) }
-									/>
-									<MenuItem onClick={ onPasteStyles }>
-										{ __( 'Paste styles' ) }
-									</MenuItem>
-								</MenuGroup>
-							) }
+							<CopyMenuItem
+								blocks={ blocks }
+								onCopy={ onCopy }
+								label={ __( 'Copy styles' ) }
+							/>
+							<DropdownMenuItemV2Ariakit
+								onClick={ onPasteStyles }
+							>
+								{ __( 'Paste styles' ) }
+							</DropdownMenuItemV2Ariakit>
+
 							<BlockSettingsMenuControls.Slot
 								fillProps={ {
-									onClose,
+									// onClose,
 									canMove,
 									onMoveTo,
 									onlyBlock,
@@ -392,28 +279,202 @@ export function BlockSettingsDropdown( {
 									__unstableDisplayLocation
 								}
 							/>
-							{ typeof children === 'function'
-								? children( { onClose } )
-								: Children.map( ( child ) =>
-										cloneElement( child, { onClose } )
-								  ) }
-							{ canRemove && (
-								<MenuGroup>
-									<MenuItem
-										onClick={ pipe(
-											onClose,
-											onRemove,
-											updateSelectionAfterRemove
-										) }
-										shortcut={ shortcuts.remove }
-									>
-										{ removeBlockLabel }
-									</MenuItem>
-								</MenuGroup>
-							) }
+
+							<DropdownMenuItemV2Ariakit
+								render={
+									<a
+										href="https://theverge.com"
+										target="_blank"
+										rel="noreferrer"
+									/>
+								}
+								hideOnClick={ false }
+							>
+								{ __( 'I am a link' ) }
+							</DropdownMenuItemV2Ariakit>
 						</>
 					) }
-				</DropdownMenu>
+				</DropdownMenuV2Ariakit>
+				// <DropdownMenu
+				// 	icon={ moreVertical }
+				// 	label={ __( 'Options' ) }
+				// 	className="block-editor-block-settings-menu"
+				// 	popoverProps={ POPOVER_PROPS }
+				// 	open={ open }
+				// 	onToggle={ onToggle }
+				// 	noIcons
+				// 	menuProps={ {
+				// 		/**
+				// 		 * @param {KeyboardEvent} event
+				// 		 */
+				// 		onKeyDown( event ) {
+				// 			if ( event.defaultPrevented ) return;
+
+				// 			if (
+				// 				isMatch( 'core/block-editor/remove', event ) &&
+				// 				canRemove
+				// 			) {
+				// 				event.preventDefault();
+				// 				updateSelectionAfterRemove( onRemove() );
+				// 			} else if (
+				// 				isMatch(
+				// 					'core/block-editor/duplicate',
+				// 					event
+				// 				) &&
+				// 				canDuplicate
+				// 			) {
+				// 				event.preventDefault();
+				// 				updateSelectionAfterDuplicate( onDuplicate() );
+				// 			} else if (
+				// 				isMatch(
+				// 					'core/block-editor/insert-after',
+				// 					event
+				// 				) &&
+				// 				canInsertDefaultBlock
+				// 			) {
+				// 				event.preventDefault();
+				// 				setOpenedBlockSettingsMenu( undefined );
+				// 				onInsertAfter();
+				// 			} else if (
+				// 				isMatch(
+				// 					'core/block-editor/insert-before',
+				// 					event
+				// 				) &&
+				// 				canInsertDefaultBlock
+				// 			) {
+				// 				event.preventDefault();
+				// 				setOpenedBlockSettingsMenu( undefined );
+				// 				onInsertBefore();
+				// 			}
+				// 		},
+				// 	} }
+				// 	{ ...props }
+				// >
+				// 	{ ( { onClose } ) => (
+				// 		<>
+				// 			<MenuGroup>
+				// 				<__unstableBlockSettingsMenuFirstItem.Slot
+				// 					fillProps={ { onClose } }
+				// 				/>
+				// 				{ ! parentBlockIsSelected &&
+				// 					!! firstParentClientId && (
+				// 						<MenuItem
+				// 							{ ...showParentOutlineGestures }
+				// 							ref={ selectParentButtonRef }
+				// 							icon={
+				// 								<BlockIcon
+				// 									icon={
+				// 										parentBlockType.icon
+				// 									}
+				// 								/>
+				// 							}
+				// 							onClick={ () =>
+				// 								selectBlock(
+				// 									firstParentClientId
+				// 								)
+				// 							}
+				// 						>
+				// 							{ sprintf(
+				// 								/* translators: %s: Name of the block's parent. */
+				// 								__(
+				// 									'Select parent block (%s)'
+				// 								),
+				// 								parentBlockType.title
+				// 							) }
+				// 						</MenuItem>
+				// 					) }
+				// 				{ count === 1 && (
+				// 					<BlockHTMLConvertButton
+				// 						clientId={ firstBlockClientId }
+				// 					/>
+				// 				) }
+				// 				<CopyMenuItem
+				// 					blocks={ blocks }
+				// 					onCopy={ onCopy }
+				// 				/>
+				// 				{ canDuplicate && (
+				// 					<MenuItem
+				// 						onClick={ pipe(
+				// 							onClose,
+				// 							onDuplicate,
+				// 							updateSelectionAfterDuplicate
+				// 						) }
+				// 						shortcut={ shortcuts.duplicate }
+				// 					>
+				// 						{ __( 'Duplicate' ) }
+				// 					</MenuItem>
+				// 				) }
+				// 				{ canInsertDefaultBlock && (
+				// 					<>
+				// 						<MenuItem
+				// 							onClick={ pipe(
+				// 								onClose,
+				// 								onInsertBefore
+				// 							) }
+				// 							shortcut={ shortcuts.insertBefore }
+				// 						>
+				// 							{ __( 'Add before' ) }
+				// 						</MenuItem>
+				// 						<MenuItem
+				// 							onClick={ pipe(
+				// 								onClose,
+				// 								onInsertAfter
+				// 							) }
+				// 							shortcut={ shortcuts.insertAfter }
+				// 						>
+				// 							{ __( 'Add after' ) }
+				// 						</MenuItem>
+				// 					</>
+				// 				) }
+				// 			</MenuGroup>
+				// 			{ canCopyStyles && (
+				// 				<MenuGroup>
+				// 					<CopyMenuItem
+				// 						blocks={ blocks }
+				// 						onCopy={ onCopy }
+				// 						label={ __( 'Copy styles' ) }
+				// 					/>
+				// 					<MenuItem onClick={ onPasteStyles }>
+				// 						{ __( 'Paste styles' ) }
+				// 					</MenuItem>
+				// 				</MenuGroup>
+				// 			) }
+				// 			<BlockSettingsMenuControls.Slot
+				// 				fillProps={ {
+				// 					onClose,
+				// 					canMove,
+				// 					onMoveTo,
+				// 					onlyBlock,
+				// 					count,
+				// 					firstBlockClientId,
+				// 				} }
+				// 				clientIds={ clientIds }
+				// 				__unstableDisplayLocation={
+				// 					__unstableDisplayLocation
+				// 				}
+				// 			/>
+				// 			{ typeof children === 'function'
+				// 				? children( { onClose } )
+				// 				: Children.map( ( child ) =>
+				// 						cloneElement( child, { onClose } )
+				// 				  ) }
+				// 			{ canRemove && (
+				// 				<MenuGroup>
+				// 					<MenuItem
+				// 						onClick={ pipe(
+				// 							onClose,
+				// 							onRemove,
+				// 							updateSelectionAfterRemove
+				// 						) }
+				// 						shortcut={ shortcuts.remove }
+				// 					>
+				// 						{ removeBlockLabel }
+				// 					</MenuItem>
+				// 				</MenuGroup>
+				// 			) }
+				// 		</>
+				// 	) }
+				// </DropdownMenu>
 			) }
 		</BlockActions>
 	);

--- a/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
@@ -250,7 +250,7 @@ export function BlockSettingsDropdown( {
 					trigger={ <Icon icon={ moreVertical } /> }
 				>
 					<DropdownMenuItemV2Ariakit>
-						Hello Brooke
+						Test item
 					</DropdownMenuItemV2Ariakit>
 					{ canCopyStyles && (
 						<>

--- a/packages/components/src/dropdown-menu-v2-ariakit/index.tsx
+++ b/packages/components/src/dropdown-menu-v2-ariakit/index.tsx
@@ -56,7 +56,11 @@ export const DropdownMenu = forwardRef< HTMLDivElement, DropdownMenuProps >(
 					{ trigger }
 					<Ariakit.MenuButtonArrow />
 				</Ariakit.MenuButton>
-				<StyledAriakitMenu gutter={ 8 } shift={ menu.parent ? -9 : 0 }>
+				<StyledAriakitMenu
+					gutter={ 8 }
+					shift={ menu.parent ? -9 : 0 }
+					modal
+				>
 					{ children }
 				</StyledAriakitMenu>
 			</Ariakit.MenuProvider>

--- a/packages/components/src/dropdown-menu-v2-ariakit/index.tsx
+++ b/packages/components/src/dropdown-menu-v2-ariakit/index.tsx
@@ -1,0 +1,65 @@
+/**
+ * External dependencies
+ */
+import * as Ariakit from '@ariakit/react';
+
+/**
+ * WordPress dependencies
+ */
+import { forwardRef } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import {
+	StyledAriakitMenu,
+	StyledAriakitMenuItem,
+	toggleButton,
+} from './styles';
+import { useCx } from '../utils';
+
+export interface DropdownMenuItemProps extends Ariakit.MenuItemProps {}
+
+export const DropdownMenuItem = forwardRef<
+	HTMLDivElement,
+	DropdownMenuItemProps
+>( function DropdownMenuItem( props, ref ) {
+	return <StyledAriakitMenuItem ref={ ref } { ...props } />;
+} );
+
+export interface DropdownMenuProps extends Ariakit.MenuButtonProps {
+	trigger: React.ReactNode;
+}
+
+export const DropdownMenu = forwardRef< HTMLDivElement, DropdownMenuProps >(
+	function DropdownMenu( { trigger, children, ...props }, ref ) {
+		const cx = useCx();
+		const menu = Ariakit.useMenuStore();
+
+		const menuButtonClassName = cx(
+			! menu.parent && toggleButton,
+			props.className
+		);
+
+		return (
+			<Ariakit.MenuProvider store={ menu }>
+				<Ariakit.MenuButton
+					ref={ ref }
+					{ ...props }
+					className={ menuButtonClassName }
+					render={
+						menu.parent ? (
+							<DropdownMenuItem render={ props.render } />
+						) : undefined
+					}
+				>
+					{ trigger }
+					<Ariakit.MenuButtonArrow />
+				</Ariakit.MenuButton>
+				<StyledAriakitMenu gutter={ 8 } shift={ menu.parent ? -9 : 0 }>
+					{ children }
+				</StyledAriakitMenu>
+			</Ariakit.MenuProvider>
+		);
+	}
+);

--- a/packages/components/src/dropdown-menu-v2-ariakit/index.tsx
+++ b/packages/components/src/dropdown-menu-v2-ariakit/index.tsx
@@ -92,13 +92,6 @@ export const DropdownMenu = forwardRef< HTMLDivElement, DropdownMenuProps >(
 					store={ dropdownMenuStore }
 					gutter={ dropdownMenuStore.parent ? 16 : 8 }
 					shift={ dropdownMenuStore.parent ? -9 : 0 }
-					getPersistentElements={ () =>
-						Array.from(
-							document.querySelectorAll(
-								'.components-modal__screen-overlay'
-							)
-						)
-					}
 					modal
 				>
 					<DropdownMenuContext.Provider value={ contextValue }>

--- a/packages/components/src/dropdown-menu-v2-ariakit/index.tsx
+++ b/packages/components/src/dropdown-menu-v2-ariakit/index.tsx
@@ -61,6 +61,13 @@ export const DropdownMenu = forwardRef< HTMLDivElement, DropdownMenuProps >(
 				<StyledAriakitMenu
 					gutter={ 8 }
 					shift={ menu.parent ? -9 : 0 }
+					getPersistentElements={ () =>
+						Array.from(
+							document.querySelectorAll(
+								'.components-modal__screen-overlay'
+							)
+						)
+					}
 					modal
 				>
 					{ children }

--- a/packages/components/src/dropdown-menu-v2-ariakit/index.tsx
+++ b/packages/components/src/dropdown-menu-v2-ariakit/index.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+// eslint-disable-next-line no-restricted-imports
 import * as Ariakit from '@ariakit/react';
 
 /**
@@ -24,7 +25,8 @@ export const DropdownMenuItem = forwardRef<
 	HTMLDivElement,
 	DropdownMenuItemProps
 >( function DropdownMenuItem( props, ref ) {
-	return <StyledAriakitMenuItem ref={ ref } { ...props } />;
+	const store = Ariakit.useMenuContext();
+	return <StyledAriakitMenuItem ref={ ref } store={ store } { ...props } />;
 } );
 
 export interface DropdownMenuProps extends Ariakit.MenuButtonProps {

--- a/packages/components/src/dropdown-menu-v2-ariakit/index.tsx
+++ b/packages/components/src/dropdown-menu-v2-ariakit/index.tsx
@@ -7,7 +7,12 @@ import * as Ariakit from '@ariakit/react';
 /**
  * WordPress dependencies
  */
-import { forwardRef } from '@wordpress/element';
+import {
+	forwardRef,
+	createContext,
+	useContext,
+	useMemo,
+} from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -19,38 +24,61 @@ import {
 } from './styles';
 import { useCx } from '../utils';
 
-export interface DropdownMenuItemProps extends Ariakit.MenuItemProps {}
+export const DropdownMenuContext = createContext<
+	{ store: Ariakit.MenuStore } | undefined
+>( undefined );
+
+export interface DropdownMenuItemProps
+	extends Omit< Ariakit.MenuItemProps, 'store' > {}
 
 export const DropdownMenuItem = forwardRef<
 	HTMLDivElement,
 	DropdownMenuItemProps
 >( function DropdownMenuItem( props, ref ) {
-	const store = Ariakit.useMenuContext();
-	return <StyledAriakitMenuItem ref={ ref } store={ store } { ...props } />;
+	const dropdownMenuContext = useContext( DropdownMenuContext );
+	return (
+		<StyledAriakitMenuItem
+			ref={ ref }
+			{ ...props }
+			store={ dropdownMenuContext?.store }
+		/>
+	);
 } );
 
 export interface DropdownMenuProps extends Ariakit.MenuButtonProps {
 	trigger: React.ReactNode;
+	children?: React.ReactNode;
 }
 
 export const DropdownMenu = forwardRef< HTMLDivElement, DropdownMenuProps >(
-	function DropdownMenu( { trigger, children, ...props }, ref ) {
-		const cx = useCx();
-		const menu = Ariakit.useMenuStore();
+	function DropdownMenu( { trigger, children, className, ...props }, ref ) {
+		const parentContext = useContext( DropdownMenuContext );
 
-		const menuButtonClassName = cx(
-			! menu.parent && toggleButton,
-			props.className
+		const dropdownMenuStore = Ariakit.useMenuStore( {
+			parent: parentContext?.store,
+		} );
+
+		const cx = useCx();
+		const menuButtonClassName = useMemo(
+			() => cx( ! dropdownMenuStore.parent && toggleButton, className ),
+			[ cx, dropdownMenuStore.parent, className ]
+		);
+
+		const contextValue = useMemo(
+			() => ( { store: dropdownMenuStore } ),
+			[ dropdownMenuStore ]
 		);
 
 		return (
-			<Ariakit.MenuProvider store={ menu }>
+			<>
+				{ /* Menu trigger */ }
 				<Ariakit.MenuButton
 					ref={ ref }
 					{ ...props }
+					store={ dropdownMenuStore }
 					className={ menuButtonClassName }
 					render={
-						menu.parent ? (
+						dropdownMenuStore.parent ? (
 							<DropdownMenuItem render={ props.render } />
 						) : undefined
 					}
@@ -58,9 +86,12 @@ export const DropdownMenu = forwardRef< HTMLDivElement, DropdownMenuProps >(
 					{ trigger }
 					<Ariakit.MenuButtonArrow />
 				</Ariakit.MenuButton>
+
+				{ /* Menu popover */ }
 				<StyledAriakitMenu
-					gutter={ 8 }
-					shift={ menu.parent ? -9 : 0 }
+					store={ dropdownMenuStore }
+					gutter={ dropdownMenuStore.parent ? 16 : 8 }
+					shift={ dropdownMenuStore.parent ? -9 : 0 }
 					getPersistentElements={ () =>
 						Array.from(
 							document.querySelectorAll(
@@ -70,9 +101,11 @@ export const DropdownMenu = forwardRef< HTMLDivElement, DropdownMenuProps >(
 					}
 					modal
 				>
-					{ children }
+					<DropdownMenuContext.Provider value={ contextValue }>
+						{ children }
+					</DropdownMenuContext.Provider>
 				</StyledAriakitMenu>
-			</Ariakit.MenuProvider>
+			</>
 		);
 	}
 );

--- a/packages/components/src/dropdown-menu-v2-ariakit/index.tsx
+++ b/packages/components/src/dropdown-menu-v2-ariakit/index.tsx
@@ -92,6 +92,7 @@ export const DropdownMenu = forwardRef< HTMLDivElement, DropdownMenuProps >(
 					store={ dropdownMenuStore }
 					gutter={ dropdownMenuStore.parent ? 16 : 8 }
 					shift={ dropdownMenuStore.parent ? -9 : 0 }
+					hideOnHoverOutside={ false }
 					modal
 				>
 					<DropdownMenuContext.Provider value={ contextValue }>

--- a/packages/components/src/dropdown-menu-v2-ariakit/stories/index.story.tsx
+++ b/packages/components/src/dropdown-menu-v2-ariakit/stories/index.story.tsx
@@ -7,12 +7,14 @@ import type { Meta, StoryFn } from '@storybook/react';
  * WordPress dependencies
  */
 import { menu } from '@wordpress/icons';
+import { useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import { DropdownMenu, DropdownMenuItem } from '..';
 import Icon from '../../icon';
+import Modal from '../../modal';
 
 const meta: Meta< typeof DropdownMenu > = {
 	title: 'Components (Experimental)/DropdownMenu v2 ariakit',
@@ -69,4 +71,39 @@ Default.args = {
 			</DropdownMenu>
 		</>
 	),
+};
+
+export const WithModal: StoryFn< typeof DropdownMenu > = ( props ) => {
+	const [ isModalOpen, setModalOpen ] = useState( false );
+	return (
+		<>
+			<DropdownMenu { ...props }>
+				<DropdownMenuItem onClick={ () => setModalOpen( true ) }>
+					Open modal
+				</DropdownMenuItem>
+				<DropdownMenuItem>Redo</DropdownMenuItem>
+				<DropdownMenu trigger="Find">
+					<DropdownMenuItem>Search the Web...</DropdownMenuItem>
+					<DropdownMenuItem>Find...</DropdownMenuItem>
+					<DropdownMenuItem>Find Next</DropdownMenuItem>
+					<DropdownMenuItem>Find Previous</DropdownMenuItem>
+				</DropdownMenu>
+				<DropdownMenu trigger="Speech">
+					<DropdownMenuItem>Start Speaking</DropdownMenuItem>
+					<DropdownMenuItem disabled>Stop Speaking</DropdownMenuItem>
+				</DropdownMenu>
+			</DropdownMenu>
+			{ isModalOpen && (
+				<Modal onRequestClose={ () => setModalOpen( false ) }>
+					Yo!
+					<button onClick={ () => setModalOpen( false ) }>
+						Close
+					</button>
+				</Modal>
+			) }
+		</>
+	);
+};
+WithModal.args = {
+	trigger: <Icon icon={ menu } size={ 24 } />,
 };

--- a/packages/components/src/dropdown-menu-v2-ariakit/stories/index.story.tsx
+++ b/packages/components/src/dropdown-menu-v2-ariakit/stories/index.story.tsx
@@ -1,0 +1,72 @@
+/**
+ * External dependencies
+ */
+import type { Meta, StoryFn } from '@storybook/react';
+
+/**
+ * WordPress dependencies
+ */
+import { menu } from '@wordpress/icons';
+
+/**
+ * Internal dependencies
+ */
+import { DropdownMenu, DropdownMenuItem } from '..';
+import Icon from '../../icon';
+
+const meta: Meta< typeof DropdownMenu > = {
+	title: 'Components (Experimental)/DropdownMenu v2 ariakit',
+	component: DropdownMenu,
+	subcomponents: {
+		// @ts-expect-error - See https://github.com/storybookjs/storybook/issues/23170
+		DropdownMenuItem,
+	},
+	argTypes: {
+		children: { control: { type: null } },
+	},
+	parameters: {
+		actions: { argTypesRegex: '^on.*' },
+		controls: { expanded: true },
+		docs: {
+			canvas: { sourceState: 'shown' },
+			source: { excludeDecorators: true },
+		},
+	},
+	decorators: [
+		// Layout wrapper
+		( Story ) => (
+			<div
+				style={ {
+					minHeight: '300px',
+				} }
+			>
+				<Story />
+			</div>
+		),
+	],
+};
+export default meta;
+
+const Template: StoryFn< typeof DropdownMenu > = ( props ) => (
+	<DropdownMenu { ...props } />
+);
+export const Default = Template.bind( {} );
+Default.args = {
+	trigger: <Icon icon={ menu } size={ 24 } />,
+	children: (
+		<>
+			<DropdownMenuItem>Undo</DropdownMenuItem>
+			<DropdownMenuItem>Redo</DropdownMenuItem>
+			<DropdownMenu trigger="Find">
+				<DropdownMenuItem>Search the Web...</DropdownMenuItem>
+				<DropdownMenuItem>Find...</DropdownMenuItem>
+				<DropdownMenuItem>Find Next</DropdownMenuItem>
+				<DropdownMenuItem>Find Previous</DropdownMenuItem>
+			</DropdownMenu>
+			<DropdownMenu trigger="Speech">
+				<DropdownMenuItem>Start Speaking</DropdownMenuItem>
+				<DropdownMenuItem disabled>Stop Speaking</DropdownMenuItem>
+			</DropdownMenu>
+		</>
+	),
+};

--- a/packages/components/src/dropdown-menu-v2-ariakit/stories/index.story.tsx
+++ b/packages/components/src/dropdown-menu-v2-ariakit/stories/index.story.tsx
@@ -1,20 +1,18 @@
 /**
  * External dependencies
  */
-// eslint-disable-next-line no-restricted-imports
-import * as Ariakit from '@ariakit/react';
 import type { Meta, StoryFn } from '@storybook/react';
 
 /**
  * WordPress dependencies
  */
 import { menu } from '@wordpress/icons';
-import { useState, useMemo } from '@wordpress/element';
+import { useState, useMemo, useContext } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
-import { DropdownMenu, DropdownMenuItem } from '..';
+import { DropdownMenu, DropdownMenuItem, DropdownMenuContext } from '..';
 import Icon from '../../icon';
 import Modal from '../../modal';
 import { createSlotFill, Provider as SlotFillProvider } from '../../slot-fill';
@@ -108,7 +106,10 @@ export const WithModalAsSiblingOfMenuItem: StoryFn< typeof DropdownMenu > = (
 	const [ isModalOpen, setModalOpen ] = useState( false );
 	return (
 		<DropdownMenu { ...props }>
-			<DropdownMenuItem onClick={ () => setModalOpen( true ) }>
+			<DropdownMenuItem
+				hideOnClick={ false }
+				onClick={ () => setModalOpen( true ) }
+			>
 				Open modal
 			</DropdownMenuItem>
 			{ isModalOpen && (
@@ -129,16 +130,19 @@ WithModalAsSiblingOfMenuItem.args = {
 const ExampleSlotFill = createSlotFill( 'Example' );
 
 const Slot = () => {
-	const ariakitMenuStore = Ariakit.useMenuContext();
+	const dropdownMenuContext = useContext( DropdownMenuContext );
 
 	// Forwarding the content of the slot so that it can be used by the fill
 	const fillProps = useMemo(
 		() => ( {
 			forwardedContext: [
-				[ Ariakit.MenuProvider, { store: ariakitMenuStore } ],
+				[
+					DropdownMenuContext.Provider,
+					{ value: dropdownMenuContext },
+				],
 			],
 		} ),
-		[ ariakitMenuStore ]
+		[ dropdownMenuContext ]
 	);
 
 	return <ExampleSlotFill.Slot fillProps={ fillProps } bubblesVirtually />;
@@ -175,13 +179,20 @@ export const AddItemsViaSlotFill: StoryFn< typeof DropdownMenu > = (
 		<SlotFillProvider>
 			<DropdownMenu { ...props }>
 				<DropdownMenuItem>Item</DropdownMenuItem>
-				<Slot />
+				<DropdownMenu trigger="Nested">
+					<Slot />
+				</DropdownMenu>
 			</DropdownMenu>
 
 			<Fill>
 				<DropdownMenuItem hideOnClick={ false }>
 					Item from fill
 				</DropdownMenuItem>
+				<DropdownMenu trigger="Nested in fill">
+					<DropdownMenuItem hideOnClick={ false }>
+						Test
+					</DropdownMenuItem>
+				</DropdownMenu>
 			</Fill>
 		</SlotFillProvider>
 	);

--- a/packages/components/src/dropdown-menu-v2-ariakit/styles.ts
+++ b/packages/components/src/dropdown-menu-v2-ariakit/styles.ts
@@ -1,0 +1,147 @@
+/**
+ * External dependencies
+ */
+import * as Ariakit from '@ariakit/react';
+import styled from '@emotion/styled';
+import { css } from '@emotion/react';
+
+export const toggleButton = css`
+	display: flex;
+	height: 2.5rem;
+	touch-action: none;
+	user-select: none;
+	align-items: center;
+	justify-content: center;
+	gap: 0.25rem;
+	white-space: nowrap;
+	border-radius: 0.5rem;
+	border-style: none;
+	background-color: hsl( 204 20% 100% );
+	padding-left: 1rem;
+	padding-right: 1rem;
+	font-size: 1rem;
+	line-height: 1.5rem;
+	color: hsl( 204 10% 10% );
+	text-decoration-line: none;
+	outline-width: 2px;
+	outline-offset: 2px;
+	outline-color: hsl( 204 100% 40% );
+	box-shadow: inset 0 0 0 1px rgba( 0, 0, 0, 0.1 ),
+		inset 0 -1px 0 rgba( 0, 0, 0, 0.1 ), 0 1px 1px rgba( 0, 0, 0, 0.1 );
+	font-weight: 500;
+
+	&:hover {
+		background-color: hsl( 204 20% 96% );
+	}
+
+	&[aria-disabled='true'] {
+		opacity: 0.5;
+	}
+
+	&[aria-expanded='true'] {
+		background-color: hsl( 204 20% 96% );
+	}
+
+	&[data-focus-visible] {
+		outline-style: solid;
+	}
+
+	&:active,
+	&[data-active] {
+		transform: scale( 0.98 );
+	}
+
+	&:active[aria-expanded='true'],
+	&[data-active][aria-expanded='true'] {
+		transform: scale( 1 );
+	}
+
+	@media ( min-width: 640px ) {
+		gap: 0.5rem;
+	}
+`;
+
+// :is(.dark .button) {
+//   background-color: hsl(204 20% 100% / 0.05);
+//   color: hsl(204 20% 100%);
+//   box-shadow:
+//     inset 0 0 0 1px rgba(255, 255, 255, 0.1),
+//     inset 0 -1px 0 1px rgba(0, 0, 0, 0.2),
+//     inset 0 1px 0 rgba(255, 255, 255, 0.05);
+// }
+
+// :is(.dark .button:hover) {
+//   background-color: hsl(204 20% 100% / 0.1);
+// }
+
+// :is(.dark .button)[aria-expanded="true"] {
+//   background-color: hsl(204 20% 100% / 0.1);
+// }
+
+export const StyledAriakitMenu = styled( Ariakit.Menu )`
+	position: relative;
+	z-index: 50;
+	display: flex;
+	max-height: var( --popover-available-height );
+	min-width: 180px;
+	flex-direction: column;
+	overscroll-behavior: contain;
+	border-radius: 0.5rem;
+	border-width: 1px;
+	border-style: solid;
+	border-color: hsl( 204 20% 88% );
+	background-color: hsl( 204 20% 100% );
+	padding: 0.5rem;
+	color: hsl( 204 10% 10% );
+	box-shadow: 0 10px 15px -3px rgb( 0 0 0 / 0.1 ),
+		0 4px 6px -4px rgb( 0 0 0 / 0.1 );
+	outline: none !important;
+	overflow: visible;
+`;
+
+// :is(.dark .menu) {
+//   border-color: hsl(204 3% 26%);
+//   background-color: hsl(204 3% 18%);
+//   color: hsl(204 20% 100%);
+//   box-shadow:
+//     0 10px 15px -3px rgb(0 0 0 / 0.25),
+//     0 4px 6px -4px rgb(0 0 0 / 0.1);
+// }
+
+export const StyledAriakitMenuItem = styled( Ariakit.MenuItem )`
+	display: flex;
+	cursor: default;
+	scroll-margin: 0.5rem;
+	align-items: center;
+	gap: 0.5rem;
+	border-radius: 0.25rem;
+	padding: 0.5rem;
+	outline: none !important;
+
+	&[aria-disabled='true'] {
+		opacity: 0.25;
+	}
+
+	&[data-active-item] {
+		background-color: hsl( 204 100% 40% );
+		color: hsl( 204 20% 100% );
+	}
+
+	&:active,
+	&[data-active] {
+		background-color: hsl( 204 100% 32% );
+	}
+
+	${ StyledAriakitMenu }:not(:focus) &:not(:focus)[aria-expanded="true"] {
+		background-color: hsl( 204 10% 10% / 0.1 );
+		color: currentColor;
+	}
+`;
+
+// :is(.dark .menu:not(:focus) .menu-item:not(:focus)[aria-expanded="true"]) {
+//   background-color: hsl(204 20% 100% / 0.1);
+// }
+
+export const StyledMenuButtonLabel = styled.span`
+	flex: 1 1 0%;
+`;

--- a/packages/components/src/dropdown-menu-v2-ariakit/styles.ts
+++ b/packages/components/src/dropdown-menu-v2-ariakit/styles.ts
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+// eslint-disable-next-line no-restricted-imports
 import * as Ariakit from '@ariakit/react';
 import styled from '@emotion/styled';
 import { css } from '@emotion/react';
@@ -26,8 +27,10 @@ export const toggleButton = css`
 	outline-width: 2px;
 	outline-offset: 2px;
 	outline-color: hsl( 204 100% 40% );
-	box-shadow: inset 0 0 0 1px rgba( 0, 0, 0, 0.1 ),
-		inset 0 -1px 0 rgba( 0, 0, 0, 0.1 ), 0 1px 1px rgba( 0, 0, 0, 0.1 );
+	box-shadow:
+		inset 0 0 0 1px rgba( 0, 0, 0, 0.1 ),
+		inset 0 -1px 0 rgba( 0, 0, 0, 0.1 ),
+		0 1px 1px rgba( 0, 0, 0, 0.1 );
 	font-weight: 500;
 
 	&:hover {
@@ -93,7 +96,8 @@ export const StyledAriakitMenu = styled( Ariakit.Menu )`
 	background-color: hsl( 204 20% 100% );
 	padding: 0.5rem;
 	color: hsl( 204 10% 10% );
-	box-shadow: 0 10px 15px -3px rgb( 0 0 0 / 0.1 ),
+	box-shadow:
+		0 10px 15px -3px rgb( 0 0 0 / 0.1 ),
 		0 4px 6px -4px rgb( 0 0 0 / 0.1 );
 	outline: none !important;
 	overflow: visible;

--- a/packages/components/src/dropdown-menu/index.tsx
+++ b/packages/components/src/dropdown-menu/index.tsx
@@ -22,7 +22,7 @@ import type {
 } from './types';
 
 function mergeProps<
-	T extends { className?: string; [ key: string ]: unknown },
+	T extends { className?: string; [ key: string ]: unknown }
 >( defaultProps: Partial< T > = {}, props: T = {} as T ) {
 	const mergedProps: T = {
 		...defaultProps,

--- a/packages/components/src/private-apis.ts
+++ b/packages/components/src/private-apis.ts
@@ -22,6 +22,10 @@ import {
 	DropdownSubMenu as DropdownSubMenuV2,
 	DropdownSubMenuTrigger as DropdownSubMenuTriggerV2,
 } from './dropdown-menu-v2';
+import {
+	DropdownMenu as DropdownMenuV2Ariakit,
+	DropdownMenuItem as DropdownMenuItemV2Ariakit,
+} from './dropdown-menu-v2-ariakit';
 import { ComponentsContext } from './ui/context/context-system-provider';
 import Theme from './theme';
 
@@ -49,4 +53,6 @@ lock( privateApis, {
 	DropdownSubMenuTriggerV2,
 	ProgressBar,
 	Theme,
+	DropdownMenuV2Ariakit,
+	DropdownMenuItemV2Ariakit,
 } );

--- a/packages/patterns/src/components/pattern-convert-button.js
+++ b/packages/patterns/src/components/pattern-convert-button.js
@@ -23,7 +23,9 @@ import CreatePatternModal from './create-pattern-modal';
 import { unlock } from '../lock-unlock';
 import { PATTERN_SYNC_TYPES } from '../constants';
 
-const { DropdownMenuItemV2Ariakit } = unlock( componentsPrivateApis );
+const { DropdownMenuV2Ariakit, DropdownMenuItemV2Ariakit } = unlock(
+	componentsPrivateApis
+);
 
 /**
  * Menu control to convert block(s) to a pattern block.
@@ -128,13 +130,11 @@ export default function PatternConvertButton( { clientIds, rootClientId } ) {
 		setIsModalOpen( false );
 	};
 	return (
-		<>
+		<DropdownMenuV2Ariakit trigger="Nested test">
 			<DropdownMenuItemV2Ariakit
 				// icon={ symbol }
-				onClick={ ( event ) => {
-					setIsModalOpen( true );
-					event.preventDefault();
-				} }
+				onClick={ () => setIsModalOpen( true ) }
+				hideOnClick={ false }
 				aria-expanded={ isModalOpen }
 				aria-haspopup="dialog"
 			>
@@ -154,6 +154,6 @@ export default function PatternConvertButton( { clientIds, rootClientId } ) {
 					} }
 				/>
 			) }
-		</>
+		</DropdownMenuV2Ariakit>
 	);
 }

--- a/packages/patterns/src/components/pattern-convert-button.js
+++ b/packages/patterns/src/components/pattern-convert-button.js
@@ -9,8 +9,8 @@ import {
 } from '@wordpress/blocks';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 import { useState, useCallback } from '@wordpress/element';
-import { MenuItem } from '@wordpress/components';
-import { symbol } from '@wordpress/icons';
+import { privateApis as componentsPrivateApis } from '@wordpress/components';
+// import { symbol } from '@wordpress/icons';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 import { __, sprintf } from '@wordpress/i18n';
@@ -22,6 +22,8 @@ import { store as patternsStore } from '../store';
 import CreatePatternModal from './create-pattern-modal';
 import { unlock } from '../lock-unlock';
 import { PATTERN_SYNC_TYPES } from '../constants';
+
+const { DropdownMenuItemV2Ariakit } = unlock( componentsPrivateApis );
 
 /**
  * Menu control to convert block(s) to a pattern block.
@@ -127,14 +129,17 @@ export default function PatternConvertButton( { clientIds, rootClientId } ) {
 	};
 	return (
 		<>
-			<MenuItem
-				icon={ symbol }
-				onClick={ () => setIsModalOpen( true ) }
+			<DropdownMenuItemV2Ariakit
+				// icon={ symbol }
+				onClick={ ( event ) => {
+					setIsModalOpen( true );
+					event.preventDefault();
+				} }
 				aria-expanded={ isModalOpen }
 				aria-haspopup="dialog"
 			>
 				{ __( 'Create pattern' ) }
-			</MenuItem>
+			</DropdownMenuItemV2Ariakit>
 			{ isModalOpen && (
 				<CreatePatternModal
 					content={ getContent }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This PR aims at investigating if [`ariakit`'s `Menu`](https://ariakit.org/reference/menu) can handle all edge cases that were flagged while working on the `radix-ui` version (see #51400)

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

We want to provide a new version of `DropdownMenu`, supporting (among other things) nested submenus.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Things to look for:

- [x] when not modal, it aligns correctly with the toolbar even on iframed editor, both when resizing and scrolling the window
- [x] when modal:
    - [x] it doesn't interfere with other modal pieces of UI (ie. our own `Modal` component, command palette, any browser extensions like GTranslate)
    - [x] it doesn't break the copy-paste functionality
- [x] works correctly across slotfills, including nested submenus (ie. forwards context correctly)
- [x] supports links (ie. `<a />`) as menu items


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
