### PR TITLE
Block Editor: Fix 'isBlockSubtreeDisabled' private selector

### DIFF
--- a/packages/block-editor/src/store/private-selectors.js
+++ b/packages/block-editor/src/store/private-selectors.js
@@ -45,9 +45,8 @@ export function getLastInsertedBlocksClientIds( state ) {
 export const isBlockSubtreeDisabled = createSelector(
 	( state, clientId ) => {
 		const isChildSubtreeDisabled = ( childClientId ) => {
-			const mode = state.blockEditingModes.get( childClientId );
 			return (
-				( mode === undefined || mode === 'disabled' ) &&
+				getBlockEditingMode( state, childClientId ) === 'disabled' &&
 				getBlockOrder( state, childClientId ).every(
 					isChildSubtreeDisabled
 				)

--- a/packages/block-editor/src/store/private-selectors.js
+++ b/packages/block-editor/src/store/private-selectors.js
@@ -58,7 +58,12 @@ export const isBlockSubtreeDisabled = createSelector(
 			getBlockOrder( state, clientId ).every( isChildSubtreeDisabled )
 		);
 	},
-	( state ) => [ state.blockEditingModes, state.blocks.parents ]
+	( state ) => [
+		state.blocks.parents,
+		state.blocks.order,
+		state.blockEditingModes,
+		state.blockListSettings,
+	]
 );
 
 /**

--- a/test/e2e/specs/editor/various/content-only-lock.spec.js
+++ b/test/e2e/specs/editor/various/content-only-lock.spec.js
@@ -29,4 +29,49 @@ test.describe( 'Content-only lock', () => {
 		await page.keyboard.type( ' World' );
 		expect( await editor.getEditedPostContent() ).toMatchSnapshot();
 	} );
+
+	// See: https://github.com/WordPress/gutenberg/pull/54618
+	test( 'should be able to edit the content of deeply nested blocks', async ( {
+		editor,
+		page,
+		pageUtils,
+	} ) => {
+		// Add content only locked block in the code editor
+		await pageUtils.pressKeys( 'secondary+M' ); // Emulates CTRL+Shift+Alt + M => toggle code editor
+
+		await page.getByPlaceholder( 'Start writing with text or HTML' )
+			.fill( `<!-- wp:group {"templateLock":"contentOnly","layout":{"type":"constrained"}} -->
+<div class="wp-block-group"><!-- wp:group {"layout":{"type":"constrained"}} -->
+<div class="wp-block-group"><!-- wp:paragraph -->
+<p>Hello</p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:group --></div>
+<!-- /wp:group -->` );
+
+		await pageUtils.pressKeys( 'secondary+M' );
+		await page.waitForSelector( 'iframe[name="editor-canvas"]' );
+		await editor.canvas.click( 'role=document[name="Paragraph block"i]' );
+		await page.keyboard.type( ' WP' );
+		await expect.poll( editor.getBlocks ).toMatchObject( [
+			{
+				name: 'core/group',
+				attributes: {
+					layout: { type: 'constrained' },
+					templateLock: 'contentOnly',
+				},
+				innerBlocks: [
+					{
+						name: 'core/group',
+						attributes: { layout: { type: 'constrained' } },
+						innerBlocks: [
+							{
+								name: 'core/paragraph',
+								attributes: { content: 'Hello WP' },
+							},
+						],
+					},
+				],
+			},
+		] );
+	} );
 } );


### PR DESCRIPTION
## What?
Fixes #54561.

PR fixes a bug with the `isBlockSubtreeDisabled` private selector incorrectly marking deeply nested blocks in the `contentOnly` template locked parent as non-editable.

## Why?
The selector had two issues:

1. It was returning a stale value because of missing dependencies. The first commit (4d5d02024e31f7601799608946faaf225e125257) confirms that the block isn't editable even when a synced pattern isn't present in the canvas.
2. The block editing mode condition for child blocks needed to be improved. The `getBlockEditingMode` checks blocks for attributes with content roles.

## How?
1. Update memoized selector dependencies.
3. Use `getBlockEditingMode` for the child block checks.

## Testing Instructions
1. Open a post or page.
4. Add example content.
5. Confirm that the nested Paragraph block is editable.
6. Add a synced pattern to the canvas.
7. Confirm that the paragraph is still editable.

### Example content

```html
<!-- wp:group {"templateLock":"contentOnly","layout":{"type":"default"}} -->
<div class="wp-block-group">
  <!-- wp:group {"layout":{"type":"constrained"}} -->
  <div class="wp-block-group">
    <!-- wp:paragraph -->
    <p>Some text</p>
    <!-- /wp:paragraph -->
  </div>
  <!-- /wp:group -->
</div>
<!-- /wp:group -->
```

### Testing Instructions for Keyboard
Same

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/240569/88f5bd4c-501c-4d9d-b130-11e44ab34e71

