### PR TITLE
Default suggested links to pages

### DIFF
--- a/packages/block-library/src/navigation-link/link-ui.js
+++ b/packages/block-library/src/navigation-link/link-ui.js
@@ -47,7 +47,7 @@ export function getSuggestionsQuery( type, kind ) {
 			return {
 				// for custom link which has no type
 				// always show pages as initial suggestions
-				initialSuggestionsOptions: {
+				initialSuggestionsSearchOptions: {
 					type: 'post',
 					subtype: 'page',
 					perPage: 20,

--- a/packages/block-library/src/navigation-link/link-ui.js
+++ b/packages/block-library/src/navigation-link/link-ui.js
@@ -44,7 +44,15 @@ export function getSuggestionsQuery( type, kind ) {
 			if ( kind === 'post-type' ) {
 				return { type: 'post', subtype: type };
 			}
-			return {};
+			return {
+				// for custom link which has no type
+				// always show pages as initial suggestions
+				initialSuggestionsOptions: {
+					type: 'post',
+					subtype: 'page',
+					perPage: 20,
+				},
+			};
 	}
 }
 

--- a/packages/core-data/src/fetch/__experimental-fetch-link-suggestions.js
+++ b/packages/core-data/src/fetch/__experimental-fetch-link-suggestions.js
@@ -88,7 +88,7 @@ const fetchLinkSuggestions = async (
 		type = undefined,
 		subtype = undefined,
 		page = undefined,
-		perPage = 20,
+		perPage = isInitialSuggestions ? 3 : 20,
 	} = searchOptions;
 
 	const { disablePostFormats = false } = settings;
@@ -96,7 +96,7 @@ const fetchLinkSuggestions = async (
 	/** @type {Promise<WPLinkSearchResult>[]} */
 	const queries = [];
 
-	if ( isInitialSuggestions ) {
+	if ( ! type || type === 'post' ) {
 		queries.push(
 			apiFetch( {
 				path: addQueryArgs( '/wp/v2/search', {
@@ -104,7 +104,7 @@ const fetchLinkSuggestions = async (
 					page,
 					per_page: perPage,
 					type: 'post',
-					subtype: 'page',
+					subtype,
 				} ),
 			} )
 				.then( ( results ) => {
@@ -117,96 +117,73 @@ const fetchLinkSuggestions = async (
 				} )
 				.catch( () => [] ) // Fail by returning no results.
 		);
-	} else {
-		if ( ! type || type === 'post' ) {
-			queries.push(
-				apiFetch( {
-					path: addQueryArgs( '/wp/v2/search', {
-						search,
-						page,
-						per_page: perPage,
-						type: 'post',
-						subtype,
-					} ),
-				} )
-					.then( ( results ) => {
-						return results.map( ( result ) => {
-							return {
-								...result,
-								meta: { kind: 'post-type', subtype },
-							};
-						} );
-					} )
-					.catch( () => [] ) // Fail by returning no results.
-			);
-		}
+	}
 
-		if ( ! type || type === 'term' ) {
-			queries.push(
-				apiFetch( {
-					path: addQueryArgs( '/wp/v2/search', {
-						search,
-						page,
-						per_page: perPage,
-						type: 'term',
-						subtype,
-					} ),
+	if ( ! type || type === 'term' ) {
+		queries.push(
+			apiFetch( {
+				path: addQueryArgs( '/wp/v2/search', {
+					search,
+					page,
+					per_page: perPage,
+					type: 'term',
+					subtype,
+				} ),
+			} )
+				.then( ( results ) => {
+					return results.map( ( result ) => {
+						return {
+							...result,
+							meta: { kind: 'taxonomy', subtype },
+						};
+					} );
 				} )
-					.then( ( results ) => {
-						return results.map( ( result ) => {
-							return {
-								...result,
-								meta: { kind: 'taxonomy', subtype },
-							};
-						} );
-					} )
-					.catch( () => [] ) // Fail by returning no results.
-			);
-		}
+				.catch( () => [] ) // Fail by returning no results.
+		);
+	}
 
-		if ( ! disablePostFormats && ( ! type || type === 'post-format' ) ) {
-			queries.push(
-				apiFetch( {
-					path: addQueryArgs( '/wp/v2/search', {
-						search,
-						page,
-						per_page: perPage,
-						type: 'post-format',
-						subtype,
-					} ),
+	if ( ! disablePostFormats && ( ! type || type === 'post-format' ) ) {
+		queries.push(
+			apiFetch( {
+				path: addQueryArgs( '/wp/v2/search', {
+					search,
+					page,
+					per_page: perPage,
+					type: 'post-format',
+					subtype,
+				} ),
+			} )
+				.then( ( results ) => {
+					return results.map( ( result ) => {
+						return {
+							...result,
+							meta: { kind: 'taxonomy', subtype },
+						};
+					} );
 				} )
-					.then( ( results ) => {
-						return results.map( ( result ) => {
-							return {
-								...result,
-								meta: { kind: 'taxonomy', subtype },
-							};
-						} );
-					} )
-					.catch( () => [] ) // Fail by returning no results.
-			);
-		}
+				.catch( () => [] ) // Fail by returning no results.
+		);
+	}
 
-		if ( ! type || type === 'attachment' ) {
-			queries.push(
-				apiFetch( {
-					path: addQueryArgs( '/wp/v2/media', {
-						search,
-						page,
-						per_page: perPage,
-					} ),
+	if ( ! type || type === 'attachment' ) {
+		queries.push(
+			apiFetch( {
+				path: addQueryArgs( '/wp/v2/media', {
+					search,
+					page,
+					per_page: perPage,
+				} ),
+			} )
+				.then( ( results ) => {
+					return results.map( ( result ) => {
+						return {
+							...result,
+							meta: { kind: 'media' },
+						};
+					} );
 				} )
-					.then( ( results ) => {
-						return results.map( ( result ) => {
-							return {
-								...result,
-								meta: { kind: 'media' },
-							};
-						} );
-					} )
-					.catch( () => [] ) // Fail by returning no results.
-			);
-		}
+				.catch( () => [] ) // Fail by returning no results.
+		);
 	}
 
 	return Promise.all( queries ).then( ( results ) => {

--- a/packages/core-data/src/fetch/__experimental-fetch-link-suggestions.js
+++ b/packages/core-data/src/fetch/__experimental-fetch-link-suggestions.js
@@ -85,16 +85,27 @@ const fetchLinkSuggestions = async (
 ) => {
 	const {
 		isInitialSuggestions = false,
+		initialSuggestionsOptions = undefined,
+	} = searchOptions;
+
+	const { disablePostFormats = false } = settings;
+
+	let {
 		type = undefined,
 		subtype = undefined,
 		page = undefined,
 		perPage = isInitialSuggestions ? 3 : 20,
 	} = searchOptions;
 
-	const { disablePostFormats = false } = settings;
-
 	/** @type {Promise<WPLinkSearchResult>[]} */
 	const queries = [];
+
+	if ( isInitialSuggestions && initialSuggestionsOptions ) {
+		type = initialSuggestionsOptions.type;
+		subtype = initialSuggestionsOptions.subtype;
+		page = initialSuggestionsOptions.page;
+		perPage = initialSuggestionsOptions.perPage;
+	}
 
 	if ( ! type || type === 'post' ) {
 		queries.push(

--- a/packages/core-data/src/fetch/__experimental-fetch-link-suggestions.js
+++ b/packages/core-data/src/fetch/__experimental-fetch-link-suggestions.js
@@ -101,10 +101,10 @@ const fetchLinkSuggestions = async (
 	const queries = [];
 
 	if ( isInitialSuggestions && initialSuggestionsOptions ) {
-		type = initialSuggestionsOptions.type;
-		subtype = initialSuggestionsOptions.subtype;
-		page = initialSuggestionsOptions.page;
-		perPage = initialSuggestionsOptions.perPage;
+		type = initialSuggestionsOptions.type || type;
+		subtype = initialSuggestionsOptions.subtype || subtype;
+		page = initialSuggestionsOptions.page || page;
+		perPage = initialSuggestionsOptions.perPage || perPage;
 	}
 
 	if ( ! type || type === 'post' ) {

--- a/packages/core-data/src/fetch/__experimental-fetch-link-suggestions.js
+++ b/packages/core-data/src/fetch/__experimental-fetch-link-suggestions.js
@@ -85,7 +85,7 @@ const fetchLinkSuggestions = async (
 ) => {
 	const {
 		isInitialSuggestions = false,
-		initialSuggestionsOptions = undefined,
+		initialSuggestionsSearchOptions = undefined,
 	} = searchOptions;
 
 	const { disablePostFormats = false } = settings;
@@ -100,11 +100,11 @@ const fetchLinkSuggestions = async (
 	/** @type {Promise<WPLinkSearchResult>[]} */
 	const queries = [];
 
-	if ( isInitialSuggestions && initialSuggestionsOptions ) {
-		type = initialSuggestionsOptions.type || type;
-		subtype = initialSuggestionsOptions.subtype || subtype;
-		page = initialSuggestionsOptions.page || page;
-		perPage = initialSuggestionsOptions.perPage || perPage;
+	if ( isInitialSuggestions && initialSuggestionsSearchOptions ) {
+		type = initialSuggestionsSearchOptions.type || type;
+		subtype = initialSuggestionsSearchOptions.subtype || subtype;
+		page = initialSuggestionsSearchOptions.page || page;
+		perPage = initialSuggestionsSearchOptions.perPage || perPage;
 	}
 
 	if ( ! type || type === 'post' ) {

--- a/packages/core-data/src/fetch/test/__experimental-fetch-link-suggestions.js
+++ b/packages/core-data/src/fetch/test/__experimental-fetch-link-suggestions.js
@@ -256,7 +256,7 @@ describe( 'fetchLinkSuggestions', () => {
 				subtype: 'category',
 				page: 11,
 				isInitialSuggestions: true,
-				initialSuggestionsOptions: {
+				initialSuggestionsSearchOptions: {
 					type: 'post',
 					subtype: 'page',
 					perPage: 20,
@@ -282,7 +282,7 @@ describe( 'fetchLinkSuggestions', () => {
 				page: 11,
 				perPage: 20,
 				isInitialSuggestions: true,
-				initialSuggestionsOptions: {
+				initialSuggestionsSearchOptions: {
 					// intentionally missing.
 					// expected to default to those from the main search options.
 				},

--- a/packages/core-data/src/fetch/test/__experimental-fetch-link-suggestions.js
+++ b/packages/core-data/src/fetch/test/__experimental-fetch-link-suggestions.js
@@ -231,22 +231,73 @@ describe( 'fetchLinkSuggestions', () => {
 			] )
 		);
 	} );
-	it( 'initial search suggestions limits results', () => {
-		return fetchLinkSuggestions( '', {
-			type: 'post',
-			subtype: 'page',
-			isInitialSuggestions: true,
-		} ).then( ( suggestions ) =>
-			expect( suggestions ).toEqual( [
-				{
-					id: 11,
-					title: 'Limit Case',
-					url: 'http://wordpress.local/limit-case/',
-					type: 'page',
-					kind: 'post-type',
+	describe( 'Initial search suggestions', () => {
+		it( 'initial search suggestions limits results', () => {
+			return fetchLinkSuggestions( '', {
+				type: 'post',
+				subtype: 'page',
+				isInitialSuggestions: true,
+			} ).then( ( suggestions ) =>
+				expect( suggestions ).toEqual( [
+					{
+						id: 11,
+						title: 'Limit Case',
+						url: 'http://wordpress.local/limit-case/',
+						type: 'page',
+						kind: 'post-type',
+					},
+				] )
+			);
+		} );
+
+		it( 'should allow custom search options for initial suggestions', () => {
+			return fetchLinkSuggestions( '', {
+				type: 'term',
+				subtype: 'category',
+				page: 11,
+				isInitialSuggestions: true,
+				initialSuggestionsOptions: {
+					type: 'post',
+					subtype: 'page',
+					perPage: 20,
+					page: 11,
 				},
-			] )
-		);
+			} ).then( ( suggestions ) =>
+				expect( suggestions ).toEqual( [
+					{
+						id: 22,
+						title: 'Page Case',
+						url: 'http://wordpress.local/page-case/',
+						type: 'page',
+						kind: 'post-type',
+					},
+				] )
+			);
+		} );
+
+		it( 'should default any missing initial search options to those from the main search options', () => {
+			return fetchLinkSuggestions( '', {
+				type: 'post',
+				subtype: 'page',
+				page: 11,
+				perPage: 20,
+				isInitialSuggestions: true,
+				initialSuggestionsOptions: {
+					// intentionally missing.
+					// expected to default to those from the main search options.
+				},
+			} ).then( ( suggestions ) =>
+				expect( suggestions ).toEqual( [
+					{
+						id: 22,
+						title: 'Page Case',
+						url: 'http://wordpress.local/page-case/',
+						type: 'page',
+						kind: 'post-type',
+					},
+				] )
+			);
+		} );
 	} );
 	it( 'allows searching from a page', () => {
 		return fetchLinkSuggestions( '', {

--- a/test/e2e/specs/editor/blocks/navigation-list-view.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation-list-view.spec.js
@@ -195,8 +195,8 @@ test.describe( 'Navigation block - List view editing', () => {
 		await expect( blockResultOptions.nth( 1 ) ).toHaveText( 'Custom Link' );
 
 		// Select the Page Link option.
-		const pageLinkResult = blockResultOptions.nth( 0 );
-		await pageLinkResult.click();
+		const customLinkResult = blockResultOptions.nth( 1 );
+		await customLinkResult.click();
 
 		// Expect to see the Link creation UI be focused.
 		const linkUIInput = linkControl.getSearchInput();
@@ -209,7 +209,26 @@ test.describe( 'Navigation block - List view editing', () => {
 		await expect( linkUIInput ).toBeFocused();
 		await expect( linkUIInput ).toBeEmpty();
 
+		// Provides test coverage for feature whereby Custom Link type
+		// should default to `Pages` when displaying the "initial suggestions"
+		// in the Link UI.
+		// See https://github.com/WordPress/gutenberg/pull/54622.
 		const firstResult = await linkControl.getNthSearchResult( 0 );
+		const secondResult = await linkControl.getNthSearchResult( 1 );
+		const thirdResult = await linkControl.getNthSearchResult( 2 );
+
+		const firstResultType =
+			await linkControl.getSearchResultType( firstResult );
+
+		const secondResultType =
+			await linkControl.getSearchResultType( secondResult );
+
+		const thirdResultType =
+			await linkControl.getSearchResultType( thirdResult );
+
+		expect( firstResultType ).toBe( 'Page' );
+		expect( secondResultType ).toBe( 'Page' );
+		expect( thirdResultType ).toBe( 'Page' );
 
 		// Grab the text from the first result so we can check (later on) that it was inserted.
 		const firstResultText =
@@ -571,6 +590,14 @@ class LinkControl {
 
 		return result
 			.locator( '.components-menu-item__item' ) // this is the only way to get the label text without the URL.
+			.innerText();
+	}
+
+	async getSearchResultType( result ) {
+		await expect( result ).toBeVisible();
+
+		return result
+			.locator( '.components-menu-item__shortcut' ) // this is the only way to get the type text.
 			.innerText();
 	}
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Closes #53904 - defaults suggestions in LinkUI to pages.

~~This change applies in all linking instances where linking UI shows suggestions, not only in the navigation block as the original issue asks.

I think this is good for consistency and also because the mixed suggestions seem less likely to be helpful.~~

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Because most linking is either towards pages or external links. ~~For taxonomy links or posts it is far more likely to need to filter by search term.~~

Pages are generally few in number and therefore it makes sense to always default to suggesting existing pages.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

This is how the suggestions are setup and shown in the navigation link block, part of the navigation block:

![Untitled-2023-09-28-1158(1)](https://github.com/WordPress/gutenberg/assets/107534/c9497cae-9a77-4029-a1d8-3da32a936f24)

~~This exploration changes how the core data (!) `fetchLinkSuggestions` ... util? works. This currently searches through everything and tries to show _something_.

The change defaults to always showing pages if the call is for "initial suggestions" - which also means:

- if there are no pages there are no suggestions
- there will always be the same suggestions~~

The PR introduces a new member of the search options object that gets eventually used by `fetchLinkSuggestions`. This new `initialSuggestionsSearchOptions` member overrides all the options in `searchOptions;` for the initial suggestions.

The navigation link block now uses this to default to suggesting a max of 20 pages initially for the custom link variation.


## Testing Instructions

0. Make sure you have some published pages, then
1. In a post 
2. Add a navigation block
3. Notice when adding items the suggestions are only pages

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

N/A

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/107534/052de3bb-a75b-48a4-b3f6-d1f2dc615ff0

