### PR TITLE
Image: Ensure `false` values are preserved in memory when defined in `theme.json`

### DIFF
--- a/packages/block-editor/src/components/global-styles/hooks.js
+++ b/packages/block-editor/src/components/global-styles/hooks.js
@@ -117,7 +117,7 @@ export function useGlobalSetting( propertyPath, blockName, source = 'all' ) {
 					`settings${ appendedBlockPath }.${ setting }`
 				) ??
 				getValueFromObjectPath( configToUse, `settings.${ setting }` );
-			if ( value !== undefined && value !== null ) {
+			if ( value !== undefined ) {
 				result = setImmutably( result, setting.split( '.' ), value );
 			}
 		} );

--- a/packages/block-editor/src/components/global-styles/hooks.js
+++ b/packages/block-editor/src/components/global-styles/hooks.js
@@ -117,7 +117,7 @@ export function useGlobalSetting( propertyPath, blockName, source = 'all' ) {
 					`settings${ appendedBlockPath }.${ setting }`
 				) ??
 				getValueFromObjectPath( configToUse, `settings.${ setting }` );
-			if ( value ) {
+			if ( value !== undefined && value !== null ) {
 				result = setImmutably( result, setting.split( '.' ), value );
 			}
 		} );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
This PR ensures `false` values are preserved in our in-memory representation of `theme.json` settings when constructing the Global Styles UI.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Addresses https://github.com/WordPress/gutenberg/issues/54638

By making the in-memory settings match the settings provided in the `theme.json`, I believe this will help us achieve consistency in https://github.com/WordPress/gutenberg/issues/54544 and  https://github.com/WordPress/gutenberg/issues/54635.

Largely I'm opening this PR to discuss what the expected behavior should be, and to see if this is an appropriate change.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
It modifies the conditional in `useGlobalSetting` of [packages/block-editor/src/components/global-styles/hooks.js](https://github.com/WordPress/gutenberg/blob/23bb9301902bb5825480240bd5aaec9d3cc3c380/packages/block-editor/src/components/global-styles/hooks.js#L91).

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. In the [screen-block.js file](https://github.com/WordPress/gutenberg/blob/23bb9301902bb5825480240bd5aaec9d3cc3c380/packages/edit-site/src/components/global-styles/screen-block.js#L95), add a console.log for `rawSettings` around line 95.
2. Open your web inspector and go to the Image settings in the Global Styles.
3. See that the `lightbox.allowEditing: true` from the default Gutenberg `theme.json` is visible in the logged statement as expected.

<img width="1421" alt="Screenshot 2023-09-19 at 7 26 42 PM" src="https://github.com/WordPress/gutenberg/assets/5360536/24976f1d-5061-45a5-904f-bd7faab12506">

4. Modify your theme's `theme.json` to include the following setting to overwrite the default `allowEditing` value:
```
"settings": {
    "blocks": {
        "core/image": {
            "lightbox": {
                "allowEditing" false
            }
        }
    }
}
```
5. Revisit the Image settings in the Global Styles, and see that the `rawSettings` value is preserved.

<img width="1400" alt="Screenshot 2023-09-19 at 8 01 13 PM" src="https://github.com/WordPress/gutenberg/assets/5360536/c975d5ec-108a-492b-9c90-33ebc1a8d42e">
