### PR TITLE
Patterns: Fix user pattern categories in site editor inserter

### DIFF
--- a/packages/edit-site/src/components/block-editor/use-site-editor-settings.js
+++ b/packages/edit-site/src/components/block-editor/use-site-editor-settings.js
@@ -106,25 +106,30 @@ export default function useSiteEditorSettings() {
 		storedSettings.__experimentalAdditionalBlockPatternCategories ?? // WP 6.0
 		storedSettings.__experimentalBlockPatternCategories; // WP 5.9
 
-	const { restBlockPatterns, restBlockPatternCategories, templateSlug } =
-		useSelect( ( select ) => {
-			const { getEditedPostType, getEditedPostId } =
-				select( editSiteStore );
-			const { getEditedEntityRecord } = select( coreStore );
-			const usedPostType = getEditedPostType();
-			const usedPostId = getEditedPostId();
-			const _record = getEditedEntityRecord(
-				'postType',
-				usedPostType,
-				usedPostId
-			);
-			return {
-				restBlockPatterns: select( coreStore ).getBlockPatterns(),
-				restBlockPatternCategories:
-					select( coreStore ).getBlockPatternCategories(),
-				templateSlug: _record.slug,
-			};
-		}, [] );
+	const {
+		restBlockPatterns,
+		restBlockPatternCategories,
+		templateSlug,
+		userPatternCategories,
+	} = useSelect( ( select ) => {
+		const { getEditedPostType, getEditedPostId } = select( editSiteStore );
+		const { getEditedEntityRecord, getUserPatternCategories } =
+			select( coreStore );
+		const usedPostType = getEditedPostType();
+		const usedPostId = getEditedPostId();
+		const _record = getEditedEntityRecord(
+			'postType',
+			usedPostType,
+			usedPostId
+		);
+		return {
+			restBlockPatterns: select( coreStore ).getBlockPatterns(),
+			restBlockPatternCategories:
+				select( coreStore ).getBlockPatternCategories(),
+			templateSlug: _record.slug,
+			userPatternCategories: getUserPatternCategories(),
+		};
+	}, [] );
 	const archiveLabels = useArchiveLabel( templateSlug );
 
 	const blockPatterns = useMemo(
@@ -171,6 +176,7 @@ export default function useSiteEditorSettings() {
 			inserterMediaCategories,
 			__experimentalBlockPatterns: blockPatterns,
 			__experimentalBlockPatternCategories: blockPatternCategories,
+			__experimentalUserPatternCategories: userPatternCategories,
 			focusMode: canvasMode === 'view' && focusMode ? false : focusMode,
 			__experimentalArchiveTitleTypeLabel: archiveLabels.archiveTypeLabel,
 			__experimentalArchiveTitleNameLabel: archiveLabels.archiveNameLabel,
@@ -179,6 +185,7 @@ export default function useSiteEditorSettings() {
 		storedSettings,
 		blockPatterns,
 		blockPatternCategories,
+		userPatternCategories,
 		canvasMode,
 		archiveLabels.archiveTypeLabel,
 		archiveLabels.archiveNameLabel,


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/54616

## What?

Adds custom user pattern categories to the block editor settings for the site editor.

## Why?

Without these, the inserter in the site editor misses user pattern categories so they appear to be uncategorized.

## How?

Retrieve the custom user pattern categories from the core store and add to the site editor's settings as they are done for the post editor.

## Testing Instructions

1. Navigate to Appearance > Editor
2. Choose Patterns 
3. Add a number of different patterns both synced and unsynced, assigning them to varied categories
4. Ensure the Patterns page sidebar reflects the correct categories
5. Navigate back, then to Templates
6. Select a template to edit and open the inserter
7. Confirm the custom pattern categories you created are displayed and patterns are categorized correctly
8. Check that category source and sync type filtering work correctly
9. Navigate back to the root of the site editor
10. Click in the main preview to edit
11. Double check the inserter and pattern categories work correctly

## Screenshots or screencast <!-- if applicable -->


https://github.com/WordPress/gutenberg/assets/60436221/939ba92b-f2ce-4ce6-9e76-8bc172f48ba4


