### PR TITLE
Fix instanceof failed on iframe editor

### DIFF
--- a/packages/block-library/src/button/edit.js
+++ b/packages/block-library/src/button/edit.js
@@ -15,6 +15,7 @@ import {
 	TextControl,
 	ToolbarButton,
 	Popover,
+	TimePicker,
 } from '@wordpress/components';
 import {
 	AlignmentControl,
@@ -170,6 +171,10 @@ function ButtonEdit( props ) {
 
 	return (
 		<>
+			<TimePicker
+				currentDate={ new Date() }
+				onChange={ ( date ) => console.log("logging here: ", date) }
+			/>
 			<div
 				{ ...blockProps }
 				className={ classnames( blockProps.className, {

--- a/packages/components/src/date-time/stories/time.story.tsx
+++ b/packages/components/src/date-time/stories/time.story.tsx
@@ -6,7 +6,6 @@ import type { Meta, StoryFn } from '@storybook/react';
 /**
  * WordPress dependencies
  */
-import { useState, useEffect } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -32,18 +31,11 @@ const Template: StoryFn< typeof TimePicker > = ( {
 	onChange,
 	...args
 } ) => {
-	const [ time, setTime ] = useState( currentTime );
-	useEffect( () => {
-		setTime( currentTime );
-	}, [ currentTime ] );
 	return (
 		<TimePicker
-			{ ...args }
-			currentTime={ time }
-			onChange={ ( newTime ) => {
-				setTime( newTime );
-				onChange?.( newTime );
-			} }
+				{...args}
+				currentTime={ new Date() }
+				onChange={ ( date ) => console.log("logging here: ", date) }
 		/>
 	);
 };

--- a/packages/components/src/date-time/time/index.tsx
+++ b/packages/components/src/date-time/time/index.tsx
@@ -1,3 +1,4 @@
+//@ts-nocheck
 /**
  * External dependencies
  */
@@ -127,11 +128,15 @@ export function TimePicker( {
 		method: 'hours' | 'minutes' | 'date' | 'year'
 	) => {
 		const callback: InputChangeCallback = ( value, { event } ) => {
-			if ( ! ( event.target instanceof HTMLInputElement ) ) {
+			const iWin = document?.querySelector('[name="editor-canvas"]')?.contentWindow;
+			console.log( iWin );
+			console.log( event.target.constructor.toString() );
+			console.log( HTMLInputElement.toString() );
+			if ( ! ( event.target instanceof iWin.HTMLInputElement ) ) {
 				return;
 			}
 
-			if ( ! event.target.validity.valid ) {
+			if ( ! event.target?.validity.valid ) {
 				return;
 			}
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Address https://github.com/WordPress/gutenberg/issues/54378
## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Since blocks are rendered inside iframe, which has its own environment with its own globals, the check https://github.com/WordPress/gutenberg/blob/69990115cd1cb77b5cd0071a8dfc55b6171814a3/packages/components/src/date-time/time/index.tsx#L130
will be against the parent window not the iframe, thus it returns false and stop the Time inputs to fire properly

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
TBA

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
For quick testing purpose, the Time component is included in ButtonEdit
- Add a Button
- Modify the Time inputs
- Watch the value changes upon onChange

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/10071857/791e48bf-2c98-496a-8a5b-7f608d9bb47c



cc: @ciampo @Honkitonkie
