### PR TITLE
Fix Font library unit tests

### DIFF
--- a/phpunit/tests/fonts/font-library/wpFontFamily/install.php
+++ b/phpunit/tests/fonts/font-library/wpFontFamily/install.php
@@ -315,7 +315,7 @@ class Tests_Fonts_WpFontFamily_Install extends WP_Font_Family_UnitTestCase {
 	public function test_should_not_install_duplicate_fontfaces( $font_data, array $files_data, array $expected ) {
 		// Set up the temporary files.
 		foreach ( $files_data as $file ) {
-			file_put_contents( $file['tmp_name'], 'Mocking file content' );
+			copy( __DIR__ . '/../../../data/fonts/Merriweather.ttf', $file['tmp_name'] );
 		}
 
 		$font = new WP_Font_Family( $font_data );
@@ -504,10 +504,18 @@ class Tests_Fonts_WpFontFamily_Install extends WP_Font_Family_UnitTestCase {
 
 		// Set up the temporary files.
 		foreach ( $files_data_initial as $file ) {
-			file_put_contents( $file['tmp_name'], 'Mocking file content' );
+			if ( 'font/ttf' === $file['type'] ) {
+				copy( __DIR__ . '/../../../data/fonts/Merriweather.ttf', $file['tmp_name'] );
+			} elseif ( 'font/woff' === $file['type'] ) {
+				copy( __DIR__ . '/../../../data/fonts/cooper-hewitt.woff', $file['tmp_name'] );
+			}
 		}
 		foreach ( $files_data_overwrite as $file ) {
-			file_put_contents( $file['tmp_name'], 'Mocking file content' );
+			if ( 'font/ttf' === $file['type'] ) {
+				copy( __DIR__ . '/../../../data/fonts/Merriweather.ttf', $file['tmp_name'] );
+			} elseif ( 'font/woff' === $file['type'] ) {
+				copy( __DIR__ . '/../../../data/fonts/cooper-hewitt.woff', $file['tmp_name'] );
+			}
 		}
 
 		$font = new WP_Font_Family( $font_data_initial );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This fixes the [failing unit tests](https://github.com/WordPress/gutenberg/pull/53986#issuecomment-1726767427)

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

They are failing due to introduction of mime validation in #53986

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Unit Tests should run without errors. No UI or API testing is needed.
