### PR TITLE
Style engine: sync doc changes from core

### DIFF
--- a/packages/style-engine/class-wp-style-engine.php
+++ b/packages/style-engine/class-wp-style-engine.php
@@ -25,7 +25,9 @@ if ( class_exists( 'WP_Style_Engine' ) ) {
 final class WP_Style_Engine {
 	/**
 	 * Style definitions that contain the instructions to parse/output valid Gutenberg styles from a block's attributes.
-	 * For every style definition, the follow properties are valid:
+	 *
+	 * For every style definition, the following properties are valid:
+	 *
 	 *  - classnames    => (array) an array of classnames to be returned for block styles. The key is a classname or pattern.
 	 *                    A value of `true` means the classname should be applied always. Otherwise, a valid CSS property (string)
 	 *                    to match the incoming value, e.g., "color" to match var:preset|color|somePresetSlug.


### PR DESCRIPTION
## What?
Spelling error and formatting from https://github.com/WordPress/wordpress-develop/pull/5256

## Why?
Sync changes from Core


