### PR TITLE
Plugin: Ensure that Block Hooks work correctly after landing in WP core

### DIFF
--- a/lib/compat/wordpress-6.4/class-gutenberg-rest-block-patterns-controller.php
+++ b/lib/compat/wordpress-6.4/class-gutenberg-rest-block-patterns-controller.php
@@ -27,6 +27,11 @@ class Gutenberg_REST_Block_Patterns_Controller extends Gutenberg_REST_Block_Patt
 	public function prepare_item_for_response( $item, $request ) {
 		$response = parent::prepare_item_for_response( $item, $request );
 
+		// Run the polyfill for Block Hooks only if it isn't already handled in WordPress core.
+		if ( function_exists( 'traverse_and_serialize_blocks' ) ) {
+			return $response;
+		}
+
 		$data = $response->get_data();
 
 		if ( empty( $data['content'] ) ) {

--- a/lib/load.php
+++ b/lib/load.php
@@ -94,10 +94,7 @@ require_once __DIR__ . '/compat/wordpress-6.3/kses.php';
 
 // WordPress 6.4 compat.
 require __DIR__ . '/compat/wordpress-6.4/blocks.php';
-if ( ! function_exists( 'traverse_and_serialize_blocks' ) ) {
-	// Install the polyfill for Block Hooks only if it isn't already handled in WordPress core.
-	require __DIR__ . '/compat/wordpress-6.4/block-hooks.php';
-}
+require __DIR__ . '/compat/wordpress-6.4/block-hooks.php';
 require __DIR__ . '/compat/wordpress-6.4/block-patterns.php';
 require __DIR__ . '/compat/wordpress-6.4/script-loader.php';
 require __DIR__ . '/compat/wordpress-6.4/kses.php';

--- a/lib/load.php
+++ b/lib/load.php
@@ -94,7 +94,10 @@ require_once __DIR__ . '/compat/wordpress-6.3/kses.php';
 
 // WordPress 6.4 compat.
 require __DIR__ . '/compat/wordpress-6.4/blocks.php';
-require __DIR__ . '/compat/wordpress-6.4/block-hooks.php';
+if ( ! function_exists( 'traverse_and_serialize_blocks' ) ) {
+	// Install the polyfill for Block Hooks only if it isn't already handled in WordPress core.
+	require __DIR__ . '/compat/wordpress-6.4/block-hooks.php';
+}
 require __DIR__ . '/compat/wordpress-6.4/block-patterns.php';
 require __DIR__ . '/compat/wordpress-6.4/script-loader.php';
 require __DIR__ . '/compat/wordpress-6.4/kses.php';

--- a/packages/block-library/src/pattern/index.php
+++ b/packages/block-library/src/pattern/index.php
@@ -41,12 +41,12 @@ function render_block_core_pattern( $attributes ) {
 	}
 
 	$pattern = $registry->get_registered( $slug );
-	$content = _inject_theme_attribute_in_block_template_content( $pattern['content'] );
+	$content = $pattern['content'];
 
+	// Backward compatibility for handling Block Hooks and injecting the theme attribute in the Gutenberg plugin.
 	// This can be removed when the minimum supported WordPress is >= 6.4.
-	if ( defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN ) {
-		// TODO: In the long run, we'd likely want to have a filter in the `WP_Block_Patterns_Registry` class
-		// instead to allow us plugging in code like this.
+	if ( defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN && ! function_exists( 'traverse_and_serialize_blocks' ) ) {
+		$content = _inject_theme_attribute_in_block_template_content( $content );
 		$blocks  = parse_blocks( $content );
 		$content = gutenberg_serialize_blocks( $blocks );
 	}

--- a/phpunit/tests/blocks/renderHookedBlocks.php
+++ b/phpunit/tests/blocks/renderHookedBlocks.php
@@ -1,7 +1,5 @@
 <?php
 
-use PHP_CodeSniffer\Generators\HTML;
-
 /**
  * Tests for hooked blocks rendering.
  *
@@ -12,6 +10,16 @@ use PHP_CodeSniffer\Generators\HTML;
  * @group blocks
  */
 class Tests_Blocks_RenderHookedBlocks extends WP_UnitTestCase {
+	public function set_up() {
+		parent::set_up();
+		add_filter( 'block_type_metadata_settings', 'gutenberg_add_hooked_blocks', 10, 2 );
+	}
+
+	public function tear_down() {
+		remove_filter( 'block_type_metadata_settings', 'gutenberg_add_hooked_blocks' );
+		parent::tear_down();
+	}
+
 	/**
 	 * @ticket 59313
 	 */


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Part of #53987.

Includes necessary changes to ensure that Block Hooks continues working correctly after [Porting PHP code to Core](https://core.trac.wordpress.org/ticket/59313).

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

At the moment, hooked blocks get inserted twice:

<img width="868" alt="Screenshot 2023-09-25 at 11 29 49" src="https://github.com/WordPress/gutenberg/assets/699132/bb11fa2e-c5e9-4394-be5a-9fe84918948b">


## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Everything should continue working as in WordPress core. Hooked blocks should be inserted only once:

<img width="829" alt="Screenshot 2023-09-25 at 11 31 55" src="https://github.com/WordPress/gutenberg/assets/699132/74bd8e3c-6cf4-4cdd-8279-024cd12aa91c">

The challenge is that it has to be tested with WordPress 6.3 and WordPress 6.4 alpha.

Other than that all PHP unit tests should pass.

### Testing Instructions

1. Activate Twenty Twenty-Three theme.
2. Download [Like Button](https://github.com/ockham/like-button/releases/tag/v0.4.1) plugin that contains the hooked block with the Comment Template block.
3. Install and activate the plugin.
4. Open the site and navigate to the single posts page.
5. Ensure that there are comments and the Like Button is rendered once for every comment.