### PR TITLE
E2E Tests: Fix 'no-useless-not' ESLint warnings

### DIFF
--- a/test/e2e/specs/editor/blocks/classic.spec.js
+++ b/test/e2e/specs/editor/blocks/classic.spec.js
@@ -76,7 +76,7 @@ test.describe( 'Classic', () => {
 		const createGallery = page.getByRole( 'button', {
 			name: 'Create a new gallery',
 		} );
-		await expect( createGallery ).not.toBeDisabled();
+		await expect( createGallery ).toBeEnabled();
 		await createGallery.click();
 		await page.click( 'role=button[name="Insert gallery"i]' );
 

--- a/test/e2e/specs/editor/blocks/links.spec.js
+++ b/test/e2e/specs/editor/blocks/links.spec.js
@@ -231,7 +231,7 @@ test.describe( 'Links', () => {
 
 		// Check that the Advanced settings are still closed.
 		// This verifies that the editor preference was persisted.
-		await expect( page.getByLabel( 'Open in new tab' ) ).not.toBeVisible();
+		await expect( page.getByLabel( 'Open in new tab' ) ).toBeHidden();
 	} );
 
 	test( 'can toggle link settings and save', async ( {

--- a/test/e2e/specs/editor/blocks/navigation-list-view.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation-list-view.spec.js
@@ -272,7 +272,7 @@ test.describe( 'Navigation block - List view editing', () => {
 					hasText: 'Block 2 of 2, Level 1', // proxy for filtering by description.
 				} )
 				.getByText( 'Top Level Item 2' )
-		).not.toBeVisible();
+		).toBeHidden();
 	} );
 
 	test( `can edit menu items`, async ( { page, editor, requestUtils } ) => {
@@ -522,7 +522,7 @@ test.describe( 'Navigation block - List view editing', () => {
 		// Check that despite being the last inserted block, the Link UI is not displayed
 		// in this scenario because it was not **just** inserted into the List View (i.e.
 		// we have unmounted the list view and then remounted it).
-		await expect( linkControl.getSearchInput() ).not.toBeVisible();
+		await expect( linkControl.getSearchInput() ).toBeHidden();
 	} );
 } );
 

--- a/test/e2e/specs/editor/blocks/paragraph.spec.js
+++ b/test/e2e/specs/editor/blocks/paragraph.spec.js
@@ -86,7 +86,7 @@ test.describe( 'Paragraph', () => {
 			);
 
 			await expect( draggingUtils.dropZone ).toBeVisible();
-			await expect( draggingUtils.insertionIndicator ).not.toBeVisible();
+			await expect( draggingUtils.insertionIndicator ).toBeHidden();
 
 			await drop(
 				editor.canvas.locator( '[data-type="core/paragraph"]' )
@@ -128,7 +128,7 @@ test.describe( 'Paragraph', () => {
 			await draggingUtils.dragOver( boundingBox.x, boundingBox.y );
 
 			await expect( draggingUtils.dropZone ).toBeVisible();
-			await expect( draggingUtils.insertionIndicator ).not.toBeVisible();
+			await expect( draggingUtils.insertionIndicator ).toBeHidden();
 
 			await page.mouse.up();
 
@@ -156,7 +156,7 @@ test.describe( 'Paragraph', () => {
 			await draggingUtils.dragOver( boundingBox.x, boundingBox.y );
 
 			await expect( draggingUtils.dropZone ).toBeVisible();
-			await expect( draggingUtils.insertionIndicator ).not.toBeVisible();
+			await expect( draggingUtils.insertionIndicator ).toBeHidden();
 
 			await page.mouse.up();
 
@@ -263,7 +263,7 @@ test.describe( 'Paragraph', () => {
 						headingBox.x,
 						headingBox.y + headingBox.height - 1
 					);
-					await expect( draggingUtils.dropZone ).not.toBeVisible();
+					await expect( draggingUtils.dropZone ).toBeHidden();
 					await expect(
 						draggingUtils.insertionIndicator
 					).toBeVisible();
@@ -309,7 +309,7 @@ test.describe( 'Paragraph', () => {
 						headingBox.x,
 						headingBox.y + 1
 					);
-					await expect( draggingUtils.dropZone ).not.toBeVisible();
+					await expect( draggingUtils.dropZone ).toBeHidden();
 					await expect(
 						draggingUtils.insertionIndicator
 					).toBeVisible();

--- a/test/e2e/specs/editor/various/autocomplete-and-mentions.spec.js
+++ b/test/e2e/specs/editor/various/autocomplete-and-mentions.spec.js
@@ -452,7 +452,7 @@ test.describe( 'Autocomplete (@firefox, @webkit)', () => {
 		await page.keyboard.press( 'ArrowLeft' );
 		await expect(
 			page.locator( 'role=option', { hasText: 'Frodo Baggins' } )
-		).not.toBeVisible();
+		).toBeHidden();
 	} );
 
 	test( 'should hide UI when selection changes (by mouse)', async ( {
@@ -473,7 +473,7 @@ test.describe( 'Autocomplete (@firefox, @webkit)', () => {
 		await editor.canvas.click( '[data-type="core/paragraph"] strong' );
 		await expect(
 			page.locator( 'role=option', { hasText: 'Frodo Baggins' } )
-		).not.toBeVisible();
+		).toBeHidden();
 	} );
 
 	test( 'should allow speaking number of initial results', async ( {

--- a/test/e2e/specs/editor/various/block-deletion.spec.js
+++ b/test/e2e/specs/editor/various/block-deletion.spec.js
@@ -377,7 +377,7 @@ test.describe( 'Block deletion', () => {
 		await expect.poll( editor.getBlocks ).toHaveLength( 0 );
 		await expect(
 			editor.canvas.getByRole( 'document', { name: 'Empty block' } )
-		).not.toBeVisible();
+		).toBeHidden();
 
 		// Ensure that the block appender button is visible.
 		await expect(

--- a/test/e2e/specs/editor/various/block-locking.spec.js
+++ b/test/e2e/specs/editor/various/block-locking.spec.js
@@ -19,7 +19,7 @@ test.describe( 'Block Locking', () => {
 
 		await expect(
 			page.locator( 'role=menuitem[name="Delete"]' )
-		).not.toBeVisible();
+		).toBeHidden();
 	} );
 
 	test( 'can disable movement', async ( { editor, page } ) => {
@@ -38,14 +38,12 @@ test.describe( 'Block Locking', () => {
 		await editor.clickBlockToolbarButton( 'Options' );
 
 		// Drag handle is hidden.
-		await expect(
-			page.locator( 'role=button[name="Drag"]' )
-		).not.toBeVisible();
+		await expect( page.locator( 'role=button[name="Drag"]' ) ).toBeHidden();
 
 		// Movers are hidden. No need to check for both.
 		await expect(
 			page.locator( 'role=button[name="Move up"]' )
-		).not.toBeVisible();
+		).toBeHidden();
 	} );
 
 	test( 'can lock everything', async ( { editor, page } ) => {

--- a/test/e2e/specs/editor/various/inserting-blocks.spec.js
+++ b/test/e2e/specs/editor/various/inserting-blocks.spec.js
@@ -155,8 +155,8 @@ test.describe( 'Inserting blocks (@firefox, @webkit)', () => {
 
 		await page.keyboard.press( 'Escape' );
 
-		await expect( insertingBlocksUtils.indicator ).not.toBeVisible();
-		await expect( insertingBlocksUtils.draggableChip ).not.toBeVisible();
+		await expect( insertingBlocksUtils.indicator ).toBeHidden();
+		await expect( insertingBlocksUtils.draggableChip ).toBeHidden();
 
 		await page.mouse.up();
 
@@ -294,8 +294,8 @@ test.describe( 'Inserting blocks (@firefox, @webkit)', () => {
 
 		await page.keyboard.press( 'Escape' );
 
-		await expect( insertingBlocksUtils.indicator ).not.toBeVisible();
-		await expect( insertingBlocksUtils.draggableChip ).not.toBeVisible();
+		await expect( insertingBlocksUtils.indicator ).toBeHidden();
+		await expect( insertingBlocksUtils.draggableChip ).toBeHidden();
 
 		await page.mouse.up();
 

--- a/test/e2e/specs/editor/various/list-view.spec.js
+++ b/test/e2e/specs/editor/various/list-view.spec.js
@@ -331,7 +331,7 @@ test.describe( 'List View', () => {
 		).toBeFocused();
 
 		// List View should be closed.
-		await expect( listView ).not.toBeVisible();
+		await expect( listView ).toBeHidden();
 
 		// Open List View.
 		await pageUtils.pressKeys( 'access+o' );
@@ -352,7 +352,7 @@ test.describe( 'List View', () => {
 
 		// Close List View and ensure it's closed.
 		await pageUtils.pressKeys( 'access+o' );
-		await expect( listView ).not.toBeVisible();
+		await expect( listView ).toBeHidden();
 
 		// Open List View.
 		await pageUtils.pressKeys( 'access+o' );
@@ -377,7 +377,7 @@ test.describe( 'List View', () => {
 
 		// Close List View and ensure it's closed.
 		await pageUtils.pressKeys( 'access+o' );
-		await expect( listView ).not.toBeVisible();
+		await expect( listView ).toBeHidden();
 	} );
 
 	test( 'should place focus on the currently selected block in the canvas', async ( {

--- a/test/e2e/specs/editor/various/popovers.spec.js
+++ b/test/e2e/specs/editor/various/popovers.spec.js
@@ -14,14 +14,14 @@ test.describe( 'popovers', () => {
 			const moreMenuToggleButton = page.locator(
 				'role=button[name="Options"i]'
 			);
-			await expect( moreMenu ).not.toBeVisible();
+			await expect( moreMenu ).toBeHidden();
 			// Toggle opened.
 			await moreMenuToggleButton.click();
 			await expect( moreMenu ).toBeVisible();
 
 			// Toggle closed.
 			await moreMenuToggleButton.click();
-			await expect( moreMenu ).not.toBeVisible();
+			await expect( moreMenu ).toBeHidden();
 		} );
 	} );
 } );

--- a/test/e2e/specs/editor/various/preview.spec.js
+++ b/test/e2e/specs/editor/various/preview.spec.js
@@ -297,7 +297,7 @@ test.describe( 'Preview with private custom post type', () => {
 
 		await expect(
 			page.locator( 'role=menuitem[name="Preview in new tab"i]' )
-		).not.toBeVisible();
+		).toBeHidden();
 	} );
 } );
 

--- a/test/e2e/specs/editor/various/shortcut-focus-toolbar.spec.js
+++ b/test/e2e/specs/editor/various/shortcut-focus-toolbar.spec.js
@@ -35,7 +35,7 @@ test.describe( 'Focus toolbar shortcut (alt + F10)', () => {
 		);
 		await toolbarUtils.moveToToolbarShortcut();
 		await expect( toolbarUtils.blockToolbarParagraphButton ).toBeFocused();
-		await expect( toolbarUtils.documentToolbarTooltip ).not.toBeVisible();
+		await expect( toolbarUtils.documentToolbarTooltip ).toBeHidden();
 
 		// Test: Focus block toolbar from block content when block toolbar is visible
 		await editor.insertBlock( { name: 'core/paragraph' } );
@@ -47,7 +47,7 @@ test.describe( 'Focus toolbar shortcut (alt + F10)', () => {
 		await editor.showBlockToolbar();
 		await toolbarUtils.moveToToolbarShortcut();
 		await expect( toolbarUtils.blockToolbarParagraphButton ).toBeFocused();
-		await expect( toolbarUtils.documentToolbarTooltip ).not.toBeVisible();
+		await expect( toolbarUtils.documentToolbarTooltip ).toBeHidden();
 	} );
 
 	test( 'Focuses correct toolbar in default view options in select mode', async ( {
@@ -169,9 +169,7 @@ test.describe( 'Focus toolbar shortcut (alt + F10)', () => {
 			await expect(
 				toolbarUtils.blockToolbarParagraphButton
 			).toBeFocused();
-			await expect(
-				toolbarUtils.documentToolbarTooltip
-			).not.toBeVisible();
+			await expect( toolbarUtils.documentToolbarTooltip ).toBeHidden();
 
 			// Test: Focus the block toolbar from paragraph block with content
 			await editor.insertBlock( { name: 'core/paragraph' } );
@@ -182,9 +180,7 @@ test.describe( 'Focus toolbar shortcut (alt + F10)', () => {
 			await expect(
 				toolbarUtils.blockToolbarParagraphButton
 			).toBeFocused();
-			await expect(
-				toolbarUtils.documentToolbarTooltip
-			).not.toBeVisible();
+			await expect( toolbarUtils.documentToolbarTooltip ).toBeHidden();
 		} );
 
 		test( 'Focuses the correct toolbar in select mode', async ( {
@@ -204,9 +200,7 @@ test.describe( 'Focus toolbar shortcut (alt + F10)', () => {
 			await expect(
 				toolbarUtils.blockToolbarParagraphButton
 			).toBeFocused();
-			await expect(
-				toolbarUtils.documentToolbarTooltip
-			).not.toBeVisible();
+			await expect( toolbarUtils.documentToolbarTooltip ).toBeHidden();
 
 			// Test: Focus the block toolbar from paragraph in select mode
 			await editor.insertBlock( { name: 'core/paragraph' } );
@@ -218,9 +212,7 @@ test.describe( 'Focus toolbar shortcut (alt + F10)', () => {
 			await expect(
 				toolbarUtils.blockToolbarParagraphButton
 			).toBeFocused();
-			await expect(
-				toolbarUtils.documentToolbarTooltip
-			).not.toBeVisible();
+			await expect( toolbarUtils.documentToolbarTooltip ).toBeHidden();
 		} );
 	} );
 } );

--- a/test/e2e/specs/editor/various/undo.spec.js
+++ b/test/e2e/specs/editor/various/undo.spec.js
@@ -453,7 +453,7 @@ test.describe( 'undo', () => {
 		await expect.poll( editor.getEditedPostContent ).toBe( '' );
 		await expect(
 			page.locator( 'role=button[name="Redo"]' )
-		).not.toBeDisabled();
+		).toBeEnabled();
 		await page.click( 'role=button[name="Redo"]' );
 
 		await expect.poll( editor.getBlocks ).toMatchObject( [


### PR DESCRIPTION
## What?
PR bulk fixes [`no-useless-not`](https://github.com/playwright-community/eslint-plugin-playwright/blob/main/docs/rules/no-useless-not.md) ESLint warnings for Playwright e2e tests.

## Why?
Ideally, the tests should produce no ESLint warnings. The exceptions must have a comment for a reason and be disabled inline.

## How?
```
npm run lint:js test/e2e/specs/editor -- --fix
```

## Testing Instructions
Playwright e2e tests should pass as before.