### PR TITLE
DateTimePicker: fix onChange callback check so that it also works inside iframes

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug fix
+
+-   `DateTimePicker`: fix onChange callback check so that it also works inside iframes ([#54669](https://github.com/WordPress/gutenberg/pull/54669)).
+
 ## 25.8.0 (2023-09-20)
 
 ### Enhancements

--- a/packages/components/src/date-time/time/index.tsx
+++ b/packages/components/src/date-time/time/index.tsx
@@ -127,7 +127,14 @@ export function TimePicker( {
 		method: 'hours' | 'minutes' | 'date' | 'year'
 	) => {
 		const callback: InputChangeCallback = ( value, { event } ) => {
-			if ( ! ( event.target instanceof HTMLInputElement ) ) {
+			// `instanceof` checks need to get the instance definition from the
+			// corresponding window object — therefore, the following logic makes
+			// the component work correctly even when rendered inside an iframe.
+			const HTMLInputElementInstance =
+				( event.target as HTMLInputElement )?.ownerDocument.defaultView
+					?.HTMLInputElement ?? HTMLInputElement;
+
+			if ( ! ( event.target instanceof HTMLInputElementInstance ) ) {
 				return;
 			}
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes https://github.com/WordPress/gutenberg/issues/54378
Inspired by #54643

Improve internal check in `DateTimePicker` so that the `onChange` callback fires even when the picker is rendered inside an iframe.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Making the component more robust by not assuming (in the `instanceof` check) that it always going to be rendered in the root window.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

By grabbing the `HTMLInputElement` value from the event target's owner window.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Apply the following diff:

<details>

<summary>Click to expand</summary>

```diff
diff --git a/packages/block-library/src/button/edit.js b/packages/block-library/src/button/edit.js
index 0c1892c6e4..4dbb6fcda3 100644
--- a/packages/block-library/src/button/edit.js
+++ b/packages/block-library/src/button/edit.js
@@ -15,6 +15,7 @@ import {
 	TextControl,
 	ToolbarButton,
 	Popover,
+	TimePicker,
 } from '@wordpress/components';
 import {
 	AlignmentControl,
@@ -170,6 +171,10 @@ function ButtonEdit( props ) {
 
 	return (
 		<>
+			<TimePicker
+				currentDate={ new Date() }
+				onChange={ ( date ) => console.log( 'logging here: ', date ) }
+			/>
 			<div
 				{ ...blockProps }
 				className={ classnames( blockProps.className, {
```
</details>

2. In the editor, add a "Buttons" block
3. Interact with the datetime picker fields, and make sure that the console logs are printed when changing every input field in the component
4. As a comparison, apply the same diff on trunk and check that only the month dropdown causes the console log to fite
5. Additionally, check that the callback fires as expected also in Storybook (this can be seen by checking the "actions" tab)
