### PR TITLE
Patterns: fix bug with pattern categories not saving sometimes

### DIFF
--- a/packages/patterns/src/components/category-selector.js
+++ b/packages/patterns/src/components/category-selector.js
@@ -4,20 +4,13 @@
 import { __ } from '@wordpress/i18n';
 import { useMemo, useState } from '@wordpress/element';
 import { FormTokenField } from '@wordpress/components';
-import { useSelect, useDispatch } from '@wordpress/data';
+import { useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 import { useDebounce } from '@wordpress/compose';
 import { decodeEntities } from '@wordpress/html-entities';
 
 const unescapeString = ( arg ) => {
 	return decodeEntities( arg );
-};
-
-const unescapeTerm = ( term ) => {
-	return {
-		...term,
-		name: unescapeString( term.name ),
-	};
 };
 
 const EMPTY_ARRAY = [];
@@ -27,16 +20,11 @@ const DEFAULT_QUERY = {
 	_fields: 'id,name',
 	context: 'view',
 };
-const slug = 'wp_pattern_category';
+export const CATEGORY_SLUG = 'wp_pattern_category';
 
-export default function CategorySelector( {
-	onCategorySelection,
-	setSaveCategoryPromise,
-} ) {
-	const [ values, setValues ] = useState( [] );
+export default function CategorySelector( { values, onChange } ) {
 	const [ search, setSearch ] = useState( '' );
 	const debouncedSearch = useDebounce( setSearch, 500 );
-	const { invalidateResolution } = useDispatch( coreStore );
 
 	const { searchResults } = useSelect(
 		( select ) => {
@@ -44,7 +32,7 @@ export default function CategorySelector( {
 
 			return {
 				searchResults: !! search
-					? getEntityRecords( 'taxonomy', slug, {
+					? getEntityRecords( 'taxonomy', CATEGORY_SLUG, {
 							...DEFAULT_QUERY,
 							search,
 					  } )
@@ -60,28 +48,7 @@ export default function CategorySelector( {
 		);
 	}, [ searchResults ] );
 
-	const { saveEntityRecord } = useDispatch( coreStore );
-
-	async function findOrCreateTerm( term ) {
-		try {
-			const newTerm = await saveEntityRecord( 'taxonomy', slug, term, {
-				throwOnError: true,
-			} );
-			invalidateResolution( 'getUserPatternCategories' );
-			return unescapeTerm( newTerm );
-		} catch ( error ) {
-			if ( error.code !== 'term_exists' ) {
-				throw error;
-			}
-
-			return {
-				id: error.data.term_id,
-				name: term.name,
-			};
-		}
-	}
-
-	function onChange( termNames ) {
+	function handleChange( termNames ) {
 		const uniqueTerms = termNames.reduce( ( terms, newTerm ) => {
 			if (
 				! terms.some(
@@ -93,21 +60,7 @@ export default function CategorySelector( {
 			return terms;
 		}, [] );
 
-		setValues( uniqueTerms );
-
-		// If the user clicks the create pattern modal button directly after entering
-		// a category we need to return a promise so the pattern doesn't save before
-		// the save of the categories is completed.
-		const categorySaving = Promise.all(
-			uniqueTerms.map( ( termName ) =>
-				findOrCreateTerm( { name: termName } )
-			)
-		).then( ( newTerms ) => {
-			setSaveCategoryPromise();
-			onCategorySelection( newTerms );
-			return newTerms;
-		} );
-		setSaveCategoryPromise( categorySaving );
+		onChange( uniqueTerms );
 	}
 
 	return (
@@ -116,7 +69,7 @@ export default function CategorySelector( {
 				className="patterns-menu-items__convert-modal-categories"
 				value={ values }
 				suggestions={ suggestions }
-				onChange={ onChange }
+				onChange={ handleChange }
 				onInputChange={ debouncedSearch }
 				maxSuggestions={ MAX_TERMS_SUGGESTIONS }
 				label={ __( 'Categories' ) }

--- a/packages/patterns/src/components/category-selector.js
+++ b/packages/patterns/src/components/category-selector.js
@@ -31,7 +31,7 @@ const slug = 'wp_pattern_category';
 
 export default function CategorySelector( {
 	onCategorySelection,
-	setCategorySaving,
+	setSaveCategoryPromise,
 } ) {
 	const [ values, setValues ] = useState( [] );
 	const [ search, setSearch ] = useState( '' );
@@ -98,18 +98,16 @@ export default function CategorySelector( {
 		// If the user clicks the create pattern modal button directly after entering
 		// a category we need to return a promise so the pattern doesn't save before
 		// the save of the categories is completed.
-		const categorySaving = new Promise( function ( resolve ) {
-			Promise.all(
-				uniqueTerms.map( ( termName ) =>
-					findOrCreateTerm( { name: termName } )
-				)
-			).then( ( newTerms ) => {
-				setCategorySaving();
-				onCategorySelection( newTerms );
-				resolve( newTerms );
-			} );
+		const categorySaving = Promise.all(
+			uniqueTerms.map( ( termName ) =>
+				findOrCreateTerm( { name: termName } )
+			)
+		).then( ( newTerms ) => {
+			setSaveCategoryPromise();
+			onCategorySelection( newTerms );
+			return newTerms;
 		} );
-		setCategorySaving( categorySaving );
+		setSaveCategoryPromise( categorySaving );
 	}
 
 	return (

--- a/packages/patterns/src/components/create-pattern-modal.js
+++ b/packages/patterns/src/components/create-pattern-modal.js
@@ -144,6 +144,7 @@ export default function CreatePatternModal( {
 							type="submit"
 							disabled={ isSaving }
 							aria-disabled={ isSaving }
+							isBusy={ isSaving }
 						>
 							{ __( 'Create' ) }
 						</Button>

--- a/packages/patterns/src/components/create-pattern-modal.js
+++ b/packages/patterns/src/components/create-pattern-modal.js
@@ -62,17 +62,17 @@ export default function CreatePatternModal( {
 		}
 	}
 
-	function onCreate( patternTitle, sync ) {
+	async function onCreate( patternTitle, sync ) {
 		// Check that any onBlur save of the categories is completed
 		// before creating the pattern and closing the modal.
 		if ( categorySaving ) {
-			return categorySaving.then( ( newTerms ) => {
-				addPattern(
-					patternTitle,
-					sync,
-					newTerms.map( ( cat ) => cat.id )
-				);
-			} );
+			const newTerms = await categorySaving;
+			addPattern(
+				patternTitle,
+				sync,
+				newTerms.map( ( cat ) => cat.id )
+			);
+			return;
 		}
 		addPattern( patternTitle, sync, categories );
 	}

--- a/packages/patterns/src/components/create-pattern-modal.js
+++ b/packages/patterns/src/components/create-pattern-modal.js
@@ -36,7 +36,8 @@ export default function CreatePatternModal( {
 	const [ syncType, setSyncType ] = useState( PATTERN_SYNC_TYPES.full );
 	const [ categories, setCategories ] = useState( [] );
 	const [ title, setTitle ] = useState( '' );
-	const [ categorySaving, setCategorySaving ] = useState();
+	const [ saveCategoryPromise, setSaveCategoryPromise ] = useState();
+	const [ isSaving, setIsSaving ] = useState();
 	const { createPattern } = unlock( useDispatch( patternsStore ) );
 
 	const { createErrorNotice } = useDispatch( noticesStore );
@@ -49,11 +50,13 @@ export default function CreatePatternModal( {
 				typeof content === 'function' ? content() : content,
 				patternCategories
 			);
+			setIsSaving( false );
 			onSuccess( {
 				pattern: newPattern,
 				categoryId: PATTERN_DEFAULT_CATEGORY,
 			} );
 		} catch ( error ) {
+			setIsSaving( false );
 			createErrorNotice( error.message, {
 				type: 'snackbar',
 				id: 'convert-to-pattern-error',
@@ -63,10 +66,11 @@ export default function CreatePatternModal( {
 	}
 
 	async function onCreate( patternTitle, sync ) {
+		setIsSaving( true );
 		// Check that any onBlur save of the categories is completed
 		// before creating the pattern and closing the modal.
-		if ( categorySaving ) {
-			const newTerms = await categorySaving;
+		if ( saveCategoryPromise ) {
+			const newTerms = await saveCategoryPromise;
 			addPattern(
 				patternTitle,
 				sync,
@@ -108,7 +112,7 @@ export default function CreatePatternModal( {
 					/>
 					<CategorySelector
 						onCategorySelection={ handleCategorySelection }
-						setCategorySaving={ setCategorySaving }
+						setSaveCategoryPromise={ setSaveCategoryPromise }
 					/>
 					<ToggleControl
 						label={ __( 'Synced' ) }
@@ -135,7 +139,12 @@ export default function CreatePatternModal( {
 							{ __( 'Cancel' ) }
 						</Button>
 
-						<Button variant="primary" type="submit">
+						<Button
+							variant="primary"
+							type="submit"
+							disabled={ isSaving }
+							aria-disabled={ isSaving }
+						>
 							{ __( 'Create' ) }
 						</Button>
 					</HStack>


### PR DESCRIPTION
## What?
Ensures that the pattern categories that are entered in the pattern creation modal are always saved before the new pattern is saved.

## Why?
Currently if the modal save button is clicked directly after entering a category the pattern is saved before the onBlur add category event has completed, so the pattern ends up as `uncategorised`
Fixes: #54617

## How?
Only create the pattern categories on submit to also prevent intermediate categories from being created.

## Testing Instructions

- In the site editor Patterns library use the + option at top left menu to add a new pattern
- Add a name and enter a new category, and then directly click on the `Create` button
- Check that the category was correctly added to the pattern
- Create another pattern and this time toggle to `unsynced` after entering category and then click `Create`
- Add a number of patterns with different sync statuses and vary adding new and existing categories, single and multiple categories and check that they all save as expected
- When clicking the Create button double check that it turns to a disabled/busy state and that multiple clicks on it do not affect the save process

## Screenshots or screencast <!-- if applicable -->
Before:

https://github.com/WordPress/gutenberg/assets/26996883/32a95e1a-b6a2-4b48-8c69-b08c78934aa8

After:

https://github.com/WordPress/gutenberg/assets/3629020/03c4c338-8f23-498e-a315-a38b60dd45e9


