### PR TITLE
Replace the `gutenberg_` prefix with `wp_` in image block

### DIFF
--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -117,7 +117,7 @@ function block_core_image_get_lightbox_settings( $block ) {
 function block_core_image_render_lightbox( $block_content, $block ) {
 	$processor = new WP_HTML_Tag_Processor( $block_content );
 
-	$aria_label = __( 'Enlarge image', 'gutenberg' );
+	$aria_label = __( 'Enlarge image' );
 
 	$alt_attribute = $processor->get_attribute( 'alt' );
 
@@ -127,7 +127,7 @@ function block_core_image_render_lightbox( $block_content, $block ) {
 
 	if ( $alt_attribute ) {
 		/* translators: %s: Image alt text. */
-		$aria_label = sprintf( __( 'Enlarge image: %s', 'gutenberg' ), $alt_attribute );
+		$aria_label = sprintf( __( 'Enlarge image: %s' ), $alt_attribute );
 	}
 	$content = $processor->get_updated_html();
 
@@ -251,8 +251,8 @@ function block_core_image_render_lightbox( $block_content, $block ) {
 
 	$close_button_icon  = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="15" height="15" aria-hidden="true" focusable="false"><path d="M13 11.8l6.1-6.3-1-1-6.1 6.2-6.1-6.2-1 1 6.1 6.3-6.5 6.7 1 1 6.5-6.6 6.5 6.6 1-1z"></path></svg>';
 	$close_button_color = esc_attr( wp_get_global_styles( array( 'color', 'text' ) ) );
-	$dialog_label       = $alt_attribute ? esc_attr( $alt_attribute ) : esc_attr__( 'Image', 'gutenberg' );
-	$close_button_label = esc_attr__( 'Close', 'gutenberg' );
+	$dialog_label       = $alt_attribute ? esc_attr( $alt_attribute ) : esc_attr__( 'Image' );
+	$close_button_label = esc_attr__( 'Close' );
 
 	$lightbox_html = <<<HTML
         <div data-wp-body="" class="wp-lightbox-overlay $lightbox_animation"

--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -91,16 +91,16 @@ function block_core_image_get_lightbox_settings( $block ) {
 	}
 
 	if ( ! isset( $lightbox_settings ) ) {
-		$lightbox_settings = gutenberg_get_global_settings( array( 'lightbox' ), array( 'block_name' => 'core/image' ) );
+		$lightbox_settings = wp_get_global_settings( array( 'lightbox' ), array( 'block_name' => 'core/image' ) );
 
 		// If not present in global settings, check the top-level global settings.
 		//
 		// NOTE: If no block-level settings are found, the previous call to
-		// `gutenberg_get_global_settings` will return the whole `theme.json`
+		// `wp_get_global_settings` will return the whole `theme.json`
 		// structure in which case we can check if the "lightbox" key is present at
 		// the top-level of the global settings and use its value.
 		if ( isset( $lightbox_settings['lightbox'] ) ) {
-			$lightbox_settings = gutenberg_get_global_settings( array( 'lightbox' ) );
+			$lightbox_settings = wp_get_global_settings( array( 'lightbox' ) );
 		}
 	}
 

--- a/tools/webpack/blocks.js
+++ b/tools/webpack/blocks.js
@@ -32,6 +32,7 @@ const prefixFunctions = [
 	'wp_enqueue_block_support_styles',
 	'wp_get_typography_font_size_value',
 	'wp_style_engine_get_styles',
+	'wp_get_global_settings',
 ];
 
 /**


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Removes the `gutenberg_` namespace erroneously introduced to `block-library` in #54509. 

In order for the lightbox to still work when enabled from theme.json, I had to add the function to the webpack list of functions to be renamed when built. Does this mean there are changes in `gutenberg_get_global_settings` that need to be updated in core?

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Add image block to post;
2. Make sure lightbox works when "Expend on click" is enabled in the image settings;
3. Make sure lightbox also works when enabled in theme.json settings with
```
"blocks": {
		"core/image": {
			"lightbox": {
				"enabled": true
			}
		}
	}
```

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
