### PR TITLE
Add missing global declaration in DocBlock of interactivity files

### DIFF
--- a/packages/block-library/src/file/index.php
+++ b/packages/block-library/src/file/index.php
@@ -70,6 +70,8 @@ function render_block_core_file( $attributes, $content, $block ) {
  * Ensure that the view script has the `wp-interactivity` dependency.
  *
  * @since 6.4.0
+ *
+ * @global WP_Scripts $wp_scripts
  */
 function block_core_file_ensure_interactivity_dependency() {
 	global $wp_scripts;

--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -286,6 +286,8 @@ HTML;
  * Ensure that the view script has the `wp-interactivity` dependency.
  *
  * @since 6.4.0
+ *
+ * @global WP_Scripts $wp_scripts
  */
 function block_core_image_ensure_interactivity_dependency() {
 	global $wp_scripts;

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -813,6 +813,8 @@ add_filter( 'render_block_data', 'block_core_navigation_typographic_presets_back
  * Ensure that the view script has the `wp-interactivity` dependency.
  *
  * @since 6.4.0
+ *
+ * @global WP_Scripts $wp_scripts
  */
 function block_core_navigation_ensure_interactivity_dependency() {
 	global $wp_scripts;

--- a/packages/block-library/src/query/index.php
+++ b/packages/block-library/src/query/index.php
@@ -95,6 +95,8 @@ function render_block_core_query( $attributes, $content, $block ) {
  * Ensure that the view script has the `wp-interactivity` dependency.
  *
  * @since 6.4.0
+ *
+ * @global WP_Scripts $wp_scripts
  */
 function block_core_query_ensure_interactivity_dependency() {
 	global $wp_scripts;

--- a/packages/block-library/src/search/index.php
+++ b/packages/block-library/src/search/index.php
@@ -210,6 +210,8 @@ add_action( 'init', 'register_block_core_search' );
  * Ensure that the view script has the `wp-interactivity` dependency.
  *
  * @since 6.4.0
+ *
+ * @global WP_Scripts $wp_scripts
  */
 function block_core_search_ensure_interactivity_dependency() {
 	global $wp_scripts;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Add missing global declaration in DocBlock of interactivity files.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Because I forgot to include it in the original PR.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

By adding it to the DocBlocks.
