### PR TITLE
Paragraph: Make 'aria-label' consistent with other blocks

### DIFF
--- a/packages/block-library/src/paragraph/edit.js
+++ b/packages/block-library/src/paragraph/edit.js
@@ -155,7 +155,7 @@ function ParagraphBlock( {
 				onRemove={ onRemove }
 				aria-label={
 					content
-						? __( 'Paragraph block' )
+						? __( 'Block: Paragraph' )
 						: __(
 								'Empty block; start writing or type forward slash to choose a block'
 						  )

--- a/packages/e2e-tests/specs/editor/various/inserting-blocks.test.js
+++ b/packages/e2e-tests/specs/editor/various/inserting-blocks.test.js
@@ -249,7 +249,7 @@ describe( 'Inserting blocks', () => {
 		await page.keyboard.type( 'First paragraph' );
 		await insertBlock( 'Image' );
 		const paragraphBlock = await canvas().$(
-			'p[aria-label="Paragraph block"]'
+			'p[aria-label="Block: Paragraph"]'
 		);
 		paragraphBlock.click();
 		await page.evaluate( () => new Promise( window.requestIdleCallback ) );

--- a/packages/e2e-tests/specs/editor/various/keyboard-navigable-blocks.test.js
+++ b/packages/e2e-tests/specs/editor/various/keyboard-navigable-blocks.test.js
@@ -35,7 +35,7 @@ const tabThroughParagraphBlock = async ( paragraphText ) => {
 	await tabThroughBlockToolbar();
 
 	await page.keyboard.press( 'Tab' );
-	await expect( await getActiveLabel() ).toBe( 'Paragraph block' );
+	await expect( await getActiveLabel() ).toBe( 'Block: Paragraph' );
 	await expect(
 		await page.evaluate( () => {
 			const { activeElement } =
@@ -49,7 +49,7 @@ const tabThroughParagraphBlock = async ( paragraphText ) => {
 
 	// Need to shift+tab here to end back in the block. If not, we'll be in the next region and it will only require 4 region jumps instead of 5.
 	await pressKeyWithModifier( 'shift', 'Tab' );
-	await expect( await getActiveLabel() ).toBe( 'Paragraph block' );
+	await expect( await getActiveLabel() ).toBe( 'Block: Paragraph' );
 };
 
 const tabThroughBlockToolbar = async () => {

--- a/packages/e2e-tests/specs/editor/various/pattern-blocks.test.js
+++ b/packages/e2e-tests/specs/editor/various/pattern-blocks.test.js
@@ -136,7 +136,7 @@ describe( 'Pattern blocks', () => {
 		);
 
 		// Make sure the reusable block has loaded properly before attempting to publish the post.
-		await canvas().waitForSelector( 'p[aria-label="Paragraph block"]' );
+		await canvas().waitForSelector( 'p[aria-label="Block: Paragraph"]' );
 
 		await publishPost();
 
@@ -146,8 +146,8 @@ describe( 'Pattern blocks', () => {
 		await page.waitForSelector( closePublishPanelSelector );
 		await page.click( closePublishPanelSelector );
 
-		await canvas().waitForSelector( 'p[aria-label="Paragraph block"]' );
-		await canvas().focus( 'p[aria-label="Paragraph block"]' );
+		await canvas().waitForSelector( 'p[aria-label="Block: Paragraph"]' );
+		await canvas().focus( 'p[aria-label="Block: Paragraph"]' );
 
 		// Change the block's content.
 		await page.keyboard.type( 'Einen ' );
@@ -157,7 +157,7 @@ describe( 'Pattern blocks', () => {
 
 		// Check that its content is up to date.
 		const paragraphContent = await canvas().$eval(
-			'p[aria-label="Paragraph block"]',
+			'p[aria-label="Block: Paragraph"]',
 			( element ) => element.innerText
 		);
 		expect( paragraphContent ).toMatch( 'Einen Guten Berg!' );
@@ -341,11 +341,11 @@ describe( 'Pattern blocks', () => {
 
 		// Make an edit to the reusable block and assert that there's only a
 		// paragraph in a reusable block.
-		await canvas().waitForSelector( 'p[aria-label="Paragraph block"]' );
-		await canvas().click( 'p[aria-label="Paragraph block"]' );
+		await canvas().waitForSelector( 'p[aria-label="Block: Paragraph"]' );
+		await canvas().click( 'p[aria-label="Block: Paragraph"]' );
 		await page.keyboard.type( '2' );
 		const selector =
-			'//div[@aria-label="Block: Pattern"]//p[@aria-label="Paragraph block"][.="12"]';
+			'//div[@aria-label="Block: Pattern"]//p[@aria-label="Block: Paragraph"][.="12"]';
 		const reusableBlockWithParagraph = await page.$x( selector );
 		expect( reusableBlockWithParagraph ).toBeTruthy();
 

--- a/packages/e2e-tests/specs/widgets/editing-widgets.test.js
+++ b/packages/e2e-tests/specs/widgets/editing-widgets.test.js
@@ -738,7 +738,7 @@ describe( 'Widgets screen', () => {
 		await find(
 			{
 				role: 'document',
-				name: 'Paragraph block',
+				name: 'Block: Paragraph',
 				value: 'First Paragraph',
 			},
 			{
@@ -759,7 +759,7 @@ describe( 'Widgets screen', () => {
 		await find(
 			{
 				role: 'document',
-				name: 'Paragraph block',
+				name: 'Block: Paragraph',
 				value: 'First Paragraph',
 			},
 			{
@@ -875,7 +875,7 @@ describe( 'Widgets screen', () => {
 		await page.keyboard.type( 'First Paragraph' );
 		const updatedParagraphBlockInFirstWidgetArea = await find(
 			{
-				name: 'Paragraph block',
+				name: 'Block: Paragraph',
 				value: 'First Paragraph',
 			},
 			{

--- a/test/e2e/specs/editor/blocks/columns.spec.js
+++ b/test/e2e/specs/editor/blocks/columns.spec.js
@@ -143,7 +143,7 @@ test.describe( 'Columns', () => {
 		} );
 
 		await editor.selectBlocks(
-			editor.canvas.locator( 'role=document[name="Paragraph block"i]' )
+			editor.canvas.locator( 'role=document[name="Block: Paragraph"i]' )
 		);
 		await page.keyboard.press( 'ArrowRight' );
 		await page.keyboard.press( 'Enter' );
@@ -200,7 +200,7 @@ test.describe( 'Columns', () => {
 
 		await editor.selectBlocks(
 			editor.canvas.locator(
-				'role=document[name="Paragraph block"i] >> text="1"'
+				'role=document[name="Block: Paragraph"i] >> text="1"'
 			)
 		);
 		await page.keyboard.press( 'ArrowRight' );

--- a/test/e2e/specs/editor/blocks/cover.spec.js
+++ b/test/e2e/specs/editor/blocks/cover.spec.js
@@ -119,7 +119,7 @@ test.describe( 'Cover', () => {
 		// Activate the paragraph block inside the Cover block.
 		// The name of the block differs depending on whether text has been entered or not.
 		const coverBlockParagraph = coverBlock.getByRole( 'document', {
-			name: /Paragraph block|Empty block; start writing or type forward slash to choose a block/,
+			name: /Block: Paragraph|Empty block; start writing or type forward slash to choose a block/,
 		} );
 		await expect( coverBlockParagraph ).toBeEditable();
 

--- a/test/e2e/specs/editor/blocks/quote.spec.js
+++ b/test/e2e/specs/editor/blocks/quote.spec.js
@@ -110,7 +110,7 @@ test.describe( 'Quote', () => {
 		await page.keyboard.type( 'two' );
 		await page.keyboard.down( 'Shift' );
 		await editor.canvas.click(
-			'role=document[name="Paragraph block"i] >> text=one'
+			'role=document[name="Block: Paragraph"i] >> text=one'
 		);
 		await page.keyboard.up( 'Shift' );
 		await editor.transformBlockTo( 'core/quote' );

--- a/test/e2e/specs/editor/plugins/block-variations.spec.js
+++ b/test/e2e/specs/editor/plugins/block-variations.spec.js
@@ -89,7 +89,7 @@ test.describe( 'Block variations', () => {
 		await page.keyboard.press( 'Enter' );
 
 		await expect(
-			editor.canvas.getByRole( 'document', { name: 'Paragraph block' } )
+			editor.canvas.getByRole( 'document', { name: 'Block: Paragraph' } )
 		).toHaveText( 'This is a success message!' );
 	} );
 

--- a/test/e2e/specs/editor/plugins/hooks-api.spec.js
+++ b/test/e2e/specs/editor/plugins/hooks-api.spec.js
@@ -41,7 +41,7 @@ test.describe( 'Using Hooks API', () => {
 		await page.keyboard.type( 'First paragraph' );
 
 		const paragraphBlock = editor.canvas.locator(
-			'role=document[name="Paragraph block"i]'
+			'role=document[name="Block: Paragraph"i]'
 		);
 		await expect( paragraphBlock ).toHaveText( 'First paragraph' );
 		await page.click(

--- a/test/e2e/specs/editor/various/block-deletion.spec.js
+++ b/test/e2e/specs/editor/various/block-deletion.spec.js
@@ -30,7 +30,7 @@ test.describe( 'Block deletion', () => {
 		await expect(
 			editor.canvas
 				.getByRole( 'document', {
-					name: 'Paragraph block',
+					name: 'Block: Paragraph',
 				} )
 				.last()
 		).toBeFocused();
@@ -78,7 +78,7 @@ test.describe( 'Block deletion', () => {
 
 		// Select the paragraph.
 		const paragraph = editor.canvas.getByRole( 'document', {
-			name: 'Paragraph block',
+			name: 'Block: Paragraph',
 		} );
 		await editor.selectBlocks( paragraph );
 
@@ -128,7 +128,7 @@ test.describe( 'Block deletion', () => {
 		await expect(
 			editor.canvas
 				.getByRole( 'document', {
-					name: 'Paragraph block',
+					name: 'Block: Paragraph',
 				} )
 				.last()
 		).toBeFocused();
@@ -307,7 +307,7 @@ test.describe( 'Block deletion', () => {
 		} );
 		await expect(
 			editor.canvas.getByRole( 'document', {
-				name: 'Paragraph block',
+				name: 'Block: Paragraph',
 			} )
 		).toBeFocused();
 

--- a/test/e2e/specs/editor/various/block-locking.spec.js
+++ b/test/e2e/specs/editor/various/block-locking.spec.js
@@ -104,7 +104,7 @@ test.describe( 'Block Locking', () => {
 		} );
 
 		const paragraph = editor.canvas.getByRole( 'document', {
-			name: 'Paragraph block',
+			name: 'Block: Paragraph',
 		} );
 		await paragraph.click();
 

--- a/test/e2e/specs/editor/various/content-only-lock.spec.js
+++ b/test/e2e/specs/editor/various/content-only-lock.spec.js
@@ -25,7 +25,7 @@ test.describe( 'Content-only lock', () => {
 
 		await pageUtils.pressKeys( 'secondary+M' );
 		await page.waitForSelector( 'iframe[name="editor-canvas"]' );
-		await editor.canvas.click( 'role=document[name="Paragraph block"i]' );
+		await editor.canvas.click( 'role=document[name="Block: Paragraph"i]' );
 		await page.keyboard.type( ' World' );
 		expect( await editor.getEditedPostContent() ).toMatchSnapshot();
 	} );
@@ -50,7 +50,7 @@ test.describe( 'Content-only lock', () => {
 
 		await pageUtils.pressKeys( 'secondary+M' );
 		await page.waitForSelector( 'iframe[name="editor-canvas"]' );
-		await editor.canvas.click( 'role=document[name="Paragraph block"i]' );
+		await editor.canvas.click( 'role=document[name="Block: Paragraph"i]' );
 		await page.keyboard.type( ' WP' );
 		await expect.poll( editor.getBlocks ).toMatchObject( [
 			{

--- a/test/e2e/specs/editor/various/draggable-blocks.spec.js
+++ b/test/e2e/specs/editor/various/draggable-blocks.spec.js
@@ -43,7 +43,7 @@ test.describe( 'Draggable block', () => {
 <!-- /wp:paragraph -->` );
 
 		await editor.canvas.focus(
-			'role=document[name="Paragraph block"i] >> text=2'
+			'role=document[name="Block: Paragraph"i] >> text=2'
 		);
 		await editor.showBlockToolbar();
 
@@ -57,7 +57,7 @@ test.describe( 'Draggable block', () => {
 
 		// Move to and hover on the upper half of the paragraph block to trigger the indicator.
 		const firstParagraph = editor.canvas.locator(
-			'role=document[name="Paragraph block"i] >> text=1'
+			'role=document[name="Block: Paragraph"i] >> text=1'
 		);
 		const firstParagraphBound = await firstParagraph.boundingBox();
 		// Call the move function twice to make sure the `dragOver` event is sent.
@@ -115,7 +115,7 @@ test.describe( 'Draggable block', () => {
 <!-- /wp:paragraph -->` );
 
 		await editor.canvas.focus(
-			'role=document[name="Paragraph block"i] >> text=1'
+			'role=document[name="Block: Paragraph"i] >> text=1'
 		);
 		await editor.showBlockToolbar();
 
@@ -129,7 +129,7 @@ test.describe( 'Draggable block', () => {
 
 		// Move to and hover on the bottom half of the paragraph block to trigger the indicator.
 		const secondParagraph = editor.canvas.locator(
-			'role=document[name="Paragraph block"i] >> text=2'
+			'role=document[name="Block: Paragraph"i] >> text=2'
 		);
 		const secondParagraphBound = await secondParagraph.boundingBox();
 		// Call the move function twice to make sure the `dragOver` event is sent.
@@ -198,7 +198,7 @@ test.describe( 'Draggable block', () => {
 		} );
 
 		await editor.canvas.focus(
-			'role=document[name="Paragraph block"i] >> text=2'
+			'role=document[name="Block: Paragraph"i] >> text=2'
 		);
 		await editor.showBlockToolbar();
 
@@ -212,7 +212,7 @@ test.describe( 'Draggable block', () => {
 
 		// Move to and hover on the left half of the paragraph block to trigger the indicator.
 		const firstParagraph = editor.canvas.locator(
-			'role=document[name="Paragraph block"i] >> text=1'
+			'role=document[name="Block: Paragraph"i] >> text=1'
 		);
 		const firstParagraphBound = await firstParagraph.boundingBox();
 		// Call the move function twice to make sure the `dragOver` event is sent.
@@ -279,7 +279,7 @@ test.describe( 'Draggable block', () => {
 		} );
 
 		await editor.canvas.focus(
-			'role=document[name="Paragraph block"i] >> text=1'
+			'role=document[name="Block: Paragraph"i] >> text=1'
 		);
 		await editor.showBlockToolbar();
 
@@ -293,7 +293,7 @@ test.describe( 'Draggable block', () => {
 
 		// Move to and hover on the right half of the paragraph block to trigger the indicator.
 		const secondParagraph = editor.canvas.locator(
-			'role=document[name="Paragraph block"i] >> text=2'
+			'role=document[name="Block: Paragraph"i] >> text=2'
 		);
 		const secondParagraphBound = await secondParagraph.boundingBox();
 		// Call the move function twice to make sure the `dragOver` event is sent.

--- a/test/e2e/specs/editor/various/list-view.spec.js
+++ b/test/e2e/specs/editor/various/list-view.spec.js
@@ -275,7 +275,7 @@ test.describe( 'List View', () => {
 		} );
 		await expect(
 			editor.canvas.getByRole( 'document', {
-				name: 'Paragraph block',
+				name: 'Block: Paragraph',
 			} )
 		).toBeFocused();
 

--- a/test/e2e/specs/editor/various/multi-block-selection.spec.js
+++ b/test/e2e/specs/editor/various/multi-block-selection.spec.js
@@ -162,7 +162,7 @@ test.describe( 'Multi-block selection', () => {
 			} );
 		}
 		await editor.canvas
-			.getByRole( 'document', { name: 'Paragraph block' } )
+			.getByRole( 'document', { name: 'Block: Paragraph' } )
 			.filter( { hasText: '3' } )
 			.click();
 
@@ -262,7 +262,7 @@ test.describe( 'Multi-block selection', () => {
 		await page.keyboard.type( '2' );
 
 		await editor.canvas
-			.getByRole( 'document', { name: 'Paragraph block' } )
+			.getByRole( 'document', { name: 'Block: Paragraph' } )
 			.filter( { hasText: '1' } )
 			.click( { modifiers: [ 'Shift' ] } );
 
@@ -279,11 +279,11 @@ test.describe( 'Multi-block selection', () => {
 			.getByRole( 'button', { name: 'Group' } )
 			.click();
 		await editor.canvas
-			.getByRole( 'document', { name: 'Paragraph block' } )
+			.getByRole( 'document', { name: 'Block: Paragraph' } )
 			.filter( { hasText: '1' } )
 			.click();
 		await editor.canvas
-			.getByRole( 'document', { name: 'Paragraph block' } )
+			.getByRole( 'document', { name: 'Block: Paragraph' } )
 			.filter( { hasText: '2' } )
 			.click( { modifiers: [ 'Shift' ] } );
 
@@ -327,7 +327,7 @@ test.describe( 'Multi-block selection', () => {
 		} );
 
 		await editor.canvas
-			.getByRole( 'document', { name: 'Paragraph block' } )
+			.getByRole( 'document', { name: 'Block: Paragraph' } )
 			.click( { modifiers: [ 'Shift' ] } );
 		await pageUtils.pressKeys( 'primary+a' );
 		await page.keyboard.type( 'new content' );
@@ -360,12 +360,12 @@ test.describe( 'Multi-block selection', () => {
 		} );
 
 		await editor.canvas
-			.getByRole( 'document', { name: 'Paragraph block' } )
+			.getByRole( 'document', { name: 'Block: Paragraph' } )
 			.filter( { hasText: 'group' } )
 			.nth( 1 )
 			.click();
 		await editor.canvas
-			.getByRole( 'document', { name: 'Paragraph block' } )
+			.getByRole( 'document', { name: 'Block: Paragraph' } )
 			.filter( { hasText: 'first' } )
 			.click( { modifiers: [ 'Shift' ] } );
 
@@ -389,7 +389,7 @@ test.describe( 'Multi-block selection', () => {
 		} );
 
 		const paragraphBlock = editor.canvas.getByRole( 'document', {
-			name: 'Paragraph block',
+			name: 'Block: Paragraph',
 		} );
 		const { height } = await paragraphBlock.boundingBox();
 		await paragraphBlock.click( { position: { x: 0, y: height / 2 } } );
@@ -429,7 +429,7 @@ test.describe( 'Multi-block selection', () => {
 		await page.keyboard.press( 'ArrowDown' );
 
 		const [ paragraph1, paragraph2 ] = await editor.canvas
-			.getByRole( 'document', { name: 'Paragraph block' } )
+			.getByRole( 'document', { name: 'Block: Paragraph' } )
 			.all();
 
 		await paragraph1.hover();
@@ -466,7 +466,7 @@ test.describe( 'Multi-block selection', () => {
 		await page.keyboard.press( 'ArrowDown' );
 
 		const [ paragraph1, paragraph2 ] = await editor.canvas
-			.getByRole( 'document', { name: 'Paragraph block' } )
+			.getByRole( 'document', { name: 'Block: Paragraph' } )
 			.all();
 
 		await paragraph1.hover();
@@ -644,7 +644,7 @@ test.describe( 'Multi-block selection', () => {
 		}
 
 		const [ , paragraph2, paragraph3 ] = await editor.canvas
-			.getByRole( 'document', { name: 'Paragraph block' } )
+			.getByRole( 'document', { name: 'Block: Paragraph' } )
 			.all();
 
 		// Focus the last paragraph block and hide the block toolbar.
@@ -700,7 +700,7 @@ test.describe( 'Multi-block selection', () => {
 
 		const paragraph1 = editor.canvas
 			.getByRole( 'document', {
-				name: 'Paragraph block',
+				name: 'Block: Paragraph',
 			} )
 			.filter( { hasText: '1' } );
 		await paragraph1.click( {
@@ -803,7 +803,7 @@ test.describe( 'Multi-block selection', () => {
 		} );
 		// Focus the last paragraph block.
 		await editor.canvas
-			.getByRole( 'document', { name: 'Paragraph block' } )
+			.getByRole( 'document', { name: 'Block: Paragraph' } )
 			.nth( 1 )
 			.click();
 
@@ -1162,7 +1162,7 @@ test.describe( 'Multi-block selection', () => {
 
 		// Focus and move the caret to the right of the first paragraph.
 		await editor.canvas
-			.getByRole( 'document', { name: 'Paragraph block' } )
+			.getByRole( 'document', { name: 'Block: Paragraph' } )
 			.filter( { hasText: 'a' } )
 			.click();
 
@@ -1200,7 +1200,7 @@ test.describe( 'Multi-block selection', () => {
 		} );
 		// Focus and move the caret to the end.
 		await editor.canvas
-			.getByRole( 'document', { name: 'Paragraph block' } )
+			.getByRole( 'document', { name: 'Block: Paragraph' } )
 			.filter( { hasText: ']2' } )
 			.click();
 
@@ -1211,7 +1211,7 @@ test.describe( 'Multi-block selection', () => {
 		const strongBox = await strongText.boundingBox();
 		// Focus and move the caret to the end.
 		await editor.canvas
-			.getByRole( 'document', { name: 'Paragraph block' } )
+			.getByRole( 'document', { name: 'Block: Paragraph' } )
 			.filter( { hasText: '1[' } )
 			.click( {
 				// Ensure clicking on the right half of the element.
@@ -1296,7 +1296,7 @@ test.describe( 'Multi-block selection', () => {
 		await page.keyboard.press( 'ArrowUp' );
 
 		await editor.canvas
-			.getByRole( 'document', { name: 'Paragraph block' } )
+			.getByRole( 'document', { name: 'Block: Paragraph' } )
 			.hover();
 		await page.mouse.down();
 		await editor.canvas

--- a/test/e2e/specs/editor/various/toolbar-roving-tabindex.spec.js
+++ b/test/e2e/specs/editor/various/toolbar-roving-tabindex.spec.js
@@ -26,14 +26,14 @@ test.describe( 'Toolbar roving tabindex', () => {
 		await editor.insertBlock( { name: 'core/paragraph' } );
 		await page.keyboard.type( 'Paragraph' );
 		await ToolbarRovingTabindexUtils.testBlockToolbarKeyboardNavigation(
-			'Paragraph block',
+			'Block: Paragraph',
 			'Paragraph'
 		);
 		await ToolbarRovingTabindexUtils.wrapCurrentBlockWithGroup(
 			'Paragraph'
 		);
 		await ToolbarRovingTabindexUtils.testGroupKeyboardNavigation(
-			'Paragraph block',
+			'Block: Paragraph',
 			'Paragraph'
 		);
 

--- a/test/e2e/specs/editor/various/writing-flow.spec.js
+++ b/test/e2e/specs/editor/various/writing-flow.spec.js
@@ -385,7 +385,7 @@ test.describe( 'Writing Flow (@firefox, @webkit)', () => {
 		// Should navigate to the next block.
 		await page.keyboard.press( 'ArrowDown' );
 		await expect(
-			editor.canvas.locator( 'role=document[name="Paragraph block"i]' )
+			editor.canvas.locator( 'role=document[name="Block: Paragraph"i]' )
 		).toHaveClass( /is-selected/ );
 	} );
 
@@ -805,7 +805,7 @@ test.describe( 'Writing Flow (@firefox, @webkit)', () => {
 		await page.keyboard.press( 'ArrowUp' );
 
 		const paragraphBlock = editor.canvas
-			.locator( 'role=document[name="Paragraph block"i]' )
+			.locator( 'role=document[name="Block: Paragraph"i]' )
 			.first();
 		const paragraphRect = await paragraphBlock.boundingBox();
 		const x = paragraphRect.x + ( 2 * paragraphRect.width ) / 3;
@@ -870,7 +870,7 @@ test.describe( 'Writing Flow (@firefox, @webkit)', () => {
 <!-- /wp:image -->` );
 
 		const paragraphBlock = editor.canvas.locator(
-			'role=document[name="Paragraph block"i]'
+			'role=document[name="Block: Paragraph"i]'
 		);
 
 		// Find a point outside the paragraph between the blocks where it's
@@ -975,7 +975,7 @@ test.describe( 'Writing Flow (@firefox, @webkit)', () => {
 		await page.mouse.up();
 
 		await expect(
-			editor.canvas.locator( 'role=document[name="Paragraph block"i]' )
+			editor.canvas.locator( 'role=document[name="Block: Paragraph"i]' )
 		).toHaveClass( /is-selected/ );
 	} );
 
@@ -1037,7 +1037,7 @@ test.describe( 'Writing Flow (@firefox, @webkit)', () => {
 
 		// Expect the "." to be added at the start of the paragraph
 		await expect(
-			editor.canvas.locator( 'role=document[name="Paragraph block"i]' )
+			editor.canvas.locator( 'role=document[name="Block: Paragraph"i]' )
 		).toHaveText( /^\.a+$/ );
 	} );
 
@@ -1071,7 +1071,7 @@ test.describe( 'Writing Flow (@firefox, @webkit)', () => {
 
 		// Expect the "." to be added at the start of the paragraph
 		await expect(
-			editor.canvas.locator( 'role=document[name="Paragraph block"i]' )
+			editor.canvas.locator( 'role=document[name="Block: Paragraph"i]' )
 		).toHaveText( /^a+\.a$/ );
 	} );
 
@@ -1107,7 +1107,7 @@ test.describe( 'Writing Flow (@firefox, @webkit)', () => {
 		// Expect the "." to be added at the start of the paragraph
 		await expect(
 			editor.canvas.locator(
-				'role=document[name="Paragraph block"i] >> nth = 0'
+				'role=document[name="Block: Paragraph"i] >> nth = 0'
 			)
 		).toHaveText( /^.a+$/ );
 	} );

--- a/test/e2e/specs/widgets/customizing-widgets.spec.js
+++ b/test/e2e/specs/widgets/customizing-widgets.spec.js
@@ -147,7 +147,7 @@ test.describe( 'Widgets Customizer', () => {
 		// Go back to the widgets editor.
 		await backButton.click();
 		await expect( widgetsFooter1Heading ).toBeVisible();
-		await expect( inspectorHeading ).not.toBeVisible();
+		await expect( inspectorHeading ).toBeHidden();
 
 		await editor.clickBlockToolbarButton( 'Options' );
 		await showMoreSettingsButton.click();
@@ -161,7 +161,7 @@ test.describe( 'Widgets Customizer', () => {
 		// Go back to the widgets editor.
 		await expect( widgetsFooter1Heading ).toBeVisible();
 
-		await expect( inspectorHeading ).not.toBeVisible();
+		await expect( inspectorHeading ).toBeHidden();
 	} );
 
 	test( 'should handle the inserter outer section', async ( {
@@ -207,11 +207,11 @@ test.describe( 'Widgets Customizer', () => {
 		await expect( publishSettings ).toBeVisible();
 
 		// Expect the inserter outer section to be closed.
-		await expect( inserterHeading ).not.toBeVisible();
+		await expect( inserterHeading ).toBeHidden();
 
 		// Focus the block and start typing to hide the block toolbar.
 		// Shouldn't be needed if we automatically hide the toolbar on blur.
-		await page.focus( 'role=document[name="Paragraph block"i]' );
+		await page.focus( 'role=document[name="Block: Paragraph"i]' );
 		await page.keyboard.type( ' ' );
 
 		// Open the inserter outer section.
@@ -226,7 +226,7 @@ test.describe( 'Widgets Customizer', () => {
 		await page.click( 'role=button[name=/Back$/] >> visible=true' );
 
 		// Expect the inserter outer section to be closed.
-		await expect( inserterHeading ).not.toBeVisible();
+		await expect( inserterHeading ).toBeHidden();
 	} );
 
 	test( 'should move focus to the block', async ( {
@@ -262,7 +262,7 @@ test.describe( 'Widgets Customizer', () => {
 		await editParagraphWidget.click();
 
 		const firstParagraphBlock = page.locator(
-			'role=document[name="Paragraph block"i] >> text="First Paragraph"'
+			'role=document[name="Block: Paragraph"i] >> text="First Paragraph"'
 		);
 		await expect( firstParagraphBlock ).toBeFocused();
 
@@ -315,7 +315,7 @@ test.describe( 'Widgets Customizer', () => {
 			await page.click(
 				'role=heading[name="Customizing ▸ Widgets Footer #1"i][level=3]'
 			);
-			await expect( blockToolbar ).not.toBeVisible();
+			await expect( blockToolbar ).toBeHidden();
 
 			await paragraphBlock.focus();
 			await editor.showBlockToolbar();
@@ -324,7 +324,7 @@ test.describe( 'Widgets Customizer', () => {
 		// Expect clicking on the preview iframe should clear the selection.
 		{
 			await page.click( '#customize-preview' );
-			await expect( blockToolbar ).not.toBeVisible();
+			await expect( blockToolbar ).toBeHidden();
 
 			await paragraphBlock.focus();
 			await editor.showBlockToolbar();
@@ -339,7 +339,7 @@ test.describe( 'Widgets Customizer', () => {
 			const { x, y, width, height } = await editorContainer.boundingBox();
 			// Simulate Clicking on the empty space at the end of the editor.
 			await page.mouse.click( x + width / 2, y + height + 10 );
-			await expect( blockToolbar ).not.toBeVisible();
+			await expect( blockToolbar ).toBeHidden();
 		}
 	} );
 
@@ -460,7 +460,7 @@ test.describe( 'Widgets Customizer', () => {
 		// Expect pressing the Escape key to close the dropdown,
 		// but not close the editor.
 		await page.keyboard.press( 'Escape' );
-		await expect( optionsMenu ).not.toBeVisible();
+		await expect( optionsMenu ).toBeHidden();
 		await expect( paragraphBlock ).toBeVisible();
 
 		await paragraphBlock.focus();
@@ -496,7 +496,7 @@ test.describe( 'Widgets Customizer', () => {
 
 		// Refocus the paragraph block.
 		await page.focus(
-			'*role=document[name="Paragraph block"i] >> text="First Paragraph"'
+			'*role=document[name="Block: Paragraph"i] >> text="First Paragraph"'
 		);
 		await editor.clickBlockToolbarButton( 'Move to widget area' );
 
@@ -511,7 +511,7 @@ test.describe( 'Widgets Customizer', () => {
 
 		// The paragraph block should be moved to the new sidebar and have focus.
 		const movedParagraphBlock = page.locator(
-			'*role=document[name="Paragraph block"i] >> text="First Paragraph"'
+			'*role=document[name="Block: Paragraph"i] >> text="First Paragraph"'
 		);
 		await expect( movedParagraphBlock ).toBeVisible();
 		await expect( movedParagraphBlock ).toBeFocused();
@@ -528,7 +528,7 @@ test.describe( 'Widgets Customizer', () => {
 		// integrate the G sidebar inside the customizer.
 		await expect(
 			page.locator( 'role=heading[name=/Block Settings/][level=3]' )
-		).not.toBeVisible();
+		).toBeHidden();
 	} );
 
 	test( 'should stay in block settings after making a change in that area', async ( {
@@ -554,7 +554,7 @@ test.describe( 'Widgets Customizer', () => {
 		).toBeDisabled();
 
 		// Select the paragraph block
-		await page.focus( 'role=document[name="Paragraph block"i]' );
+		await page.focus( 'role=document[name="Block: Paragraph"i]' );
 
 		// Click the three dots button, then click "Show More Settings".
 		await editor.clickBlockToolbarButton( 'Options' );

--- a/test/performance/specs/post-editor.spec.js
+++ b/test/performance/specs/post-editor.spec.js
@@ -162,7 +162,7 @@ test.describe( 'Post Editor Performance', () => {
 
 			// Select the block where we type in.
 			const firstParagraph = canvas
-				.getByRole( 'document', { name: 'Paragraph block' } )
+				.getByRole( 'document', { name: 'Block: Paragraph' } )
 				.first();
 			await firstParagraph.click();
 

--- a/test/performance/specs/post-editor.spec.js
+++ b/test/performance/specs/post-editor.spec.js
@@ -162,7 +162,9 @@ test.describe( 'Post Editor Performance', () => {
 
 			// Select the block where we type in.
 			const firstParagraph = canvas
-				.getByRole( 'document', { name: 'Block: Paragraph' } )
+				.getByRole( 'document', {
+					name: /Paragraph block|Block: Paragraph/,
+				} )
 				.first();
 			await firstParagraph.click();
 


### PR DESCRIPTION
## What?
PR changes the Paragraph block label when it has content to match the general pattern used for blocks - `Block: {blockTitle}`

## Why?
Primarily for consistency, but this difference is very annoying when writing e2e tests.

## Testing Instructions
CI checks should pass as before.
