### PR TITLE
Performance Tests: Support legacy selector for expanded elements

### DIFF
--- a/test/performance/fixtures/perf-utils.ts
+++ b/test/performance/fixtures/perf-utils.ts
@@ -8,7 +8,7 @@ import { expect } from '@wordpress/e2e-test-utils-playwright';
  */
 import fs from 'fs';
 import path from 'path';
-import type { Page } from '@playwright/test';
+import type { Locator, Page } from '@playwright/test';
 
 /**
  * Internal dependencies
@@ -167,5 +167,15 @@ export class PerfUtils {
 			);
 			dispatch( 'core/block-editor' ).resetBlocks( blocks );
 		} );
+	}
+
+	async expectExpandedState( locator: Locator, state: 'true' | 'false' ) {
+		return await Promise.any( [
+			// eslint-disable-next-line playwright/missing-playwright-await
+			expect( locator ).toHaveAttribute( 'aria-expanded', state ),
+			// Legacy selector.
+			// eslint-disable-next-line playwright/missing-playwright-await
+			expect( locator ).toHaveAttribute( 'aria-pressed', state ),
+		] );
 	}
 }

--- a/test/performance/specs/post-editor.spec.js
+++ b/test/performance/specs/post-editor.spec.js
@@ -3,7 +3,7 @@
 /**
  * WordPress dependencies
  */
-import { test, expect, Metrics } from '@wordpress/e2e-test-utils-playwright';
+import { test, Metrics } from '@wordpress/e2e-test-utils-playwright';
 
 /**
  * Internal dependencies
@@ -280,10 +280,7 @@ test.describe( 'Post Editor Performance', () => {
 
 				// Open List View.
 				await listViewToggle.click();
-				await expect( listViewToggle ).toHaveAttribute(
-					'aria-expanded',
-					'true'
-				);
+				await perfUtils.expectExpandedState( listViewToggle, 'true' );
 
 				// Stop tracing.
 				await metrics.stopTracing();
@@ -298,10 +295,7 @@ test.describe( 'Post Editor Performance', () => {
 
 				// Close List View
 				await listViewToggle.click();
-				await expect( listViewToggle ).toHaveAttribute(
-					'aria-expanded',
-					'false'
-				);
+				await perfUtils.expectExpandedState( listViewToggle, 'false' );
 			}
 		} );
 	} );
@@ -336,8 +330,8 @@ test.describe( 'Post Editor Performance', () => {
 
 				// Open Inserter.
 				await globalInserterToggle.click();
-				await expect( globalInserterToggle ).toHaveAttribute(
-					'aria-expanded',
+				await perfUtils.expectExpandedState(
+					globalInserterToggle,
 					'true'
 				);
 
@@ -354,8 +348,8 @@ test.describe( 'Post Editor Performance', () => {
 
 				// Close Inserter.
 				await globalInserterToggle.click();
-				await expect( globalInserterToggle ).toHaveAttribute(
-					'aria-expanded',
+				await perfUtils.expectExpandedState(
+					globalInserterToggle,
 					'false'
 				);
 			}
@@ -381,10 +375,7 @@ test.describe( 'Post Editor Performance', () => {
 
 			// Open Inserter.
 			await globalInserterToggle.click();
-			await expect( globalInserterToggle ).toHaveAttribute(
-				'aria-expanded',
-				'true'
-			);
+			await perfUtils.expectExpandedState( globalInserterToggle, 'true' );
 
 			const samples = 10;
 			const throwaway = 1;
@@ -447,10 +438,7 @@ test.describe( 'Post Editor Performance', () => {
 
 			// Open Inserter.
 			await globalInserterToggle.click();
-			await expect( globalInserterToggle ).toHaveAttribute(
-				'aria-expanded',
-				'true'
-			);
+			await perfUtils.expectExpandedState( globalInserterToggle, 'true' );
 
 			const samples = 10;
 			const throwaway = 1;


### PR DESCRIPTION
## What?
Support legacy selector for expanded elements so we're able to run the tests against the base branch. This should fix the currently failing merge commit performance jobs.

## Testing Instructions
Performance tests should pass