### PR TITLE
Editor: Use hooks instead of HoCs in 'PostSwitchToDraftButton'

### DIFF
--- a/packages/editor/src/components/post-switch-to-draft-button/index.js
+++ b/packages/editor/src/components/post-switch-to-draft-button/index.js
@@ -6,8 +6,7 @@ import {
 	__experimentalConfirmDialog as ConfirmDialog,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { withSelect, withDispatch } from '@wordpress/data';
-import { compose } from '@wordpress/compose';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { useState } from '@wordpress/element';
 
 /**
@@ -15,13 +14,19 @@ import { useState } from '@wordpress/element';
  */
 import { store as editorStore } from '../../store';
 
-function PostSwitchToDraftButton( {
-	isSaving,
-	isPublished,
-	isScheduled,
-	onClick,
-} ) {
+export default function PostSwitchToDraftButton() {
 	const [ showConfirmDialog, setShowConfirmDialog ] = useState( false );
+
+	const { editPost, savePost } = useDispatch( editorStore );
+	const { isSaving, isPublished, isScheduled } = useSelect( ( select ) => {
+		const { isSavingPost, isCurrentPostPublished, isCurrentPostScheduled } =
+			select( editorStore );
+		return {
+			isSaving: isSavingPost(),
+			isPublished: isCurrentPostPublished(),
+			isScheduled: isCurrentPostScheduled(),
+		};
+	}, [] );
 
 	if ( ! isPublished && ! isScheduled ) {
 		return null;
@@ -36,7 +41,8 @@ function PostSwitchToDraftButton( {
 
 	const handleConfirm = () => {
 		setShowConfirmDialog( false );
-		onClick();
+		editPost( { status: 'draft' } );
+		savePost();
 	};
 
 	return (
@@ -62,24 +68,3 @@ function PostSwitchToDraftButton( {
 		</>
 	);
 }
-
-export default compose( [
-	withSelect( ( select ) => {
-		const { isSavingPost, isCurrentPostPublished, isCurrentPostScheduled } =
-			select( editorStore );
-		return {
-			isSaving: isSavingPost(),
-			isPublished: isCurrentPostPublished(),
-			isScheduled: isCurrentPostScheduled(),
-		};
-	} ),
-	withDispatch( ( dispatch ) => {
-		const { editPost, savePost } = dispatch( editorStore );
-		return {
-			onClick: () => {
-				editPost( { status: 'draft' } );
-				savePost();
-			},
-		};
-	} ),
-] )( PostSwitchToDraftButton );


### PR DESCRIPTION
## What?
PR updates the `PostSwitchToDraftButton` component to use `data` hooks instead of HoCs.

## Why?
A micro-optimization makes the rendered component tree smaller.

This is similar to #53773.

## Testing Instructions
1. Open a post or page.
2. Verify "Switch to Draft" action works as before.

### Testing Instructions for Keyboard
Same

## Screenshots or screencast <!-- if applicable -->

**Before**
![CleanShot 2023-09-21 at 18 52 33](https://github.com/WordPress/gutenberg/assets/240569/a574c5a2-b35b-4b07-907b-f294aa683a1a)

**After**
![CleanShot 2023-09-21 at 19 08 30](https://github.com/WordPress/gutenberg/assets/240569/3292b12e-9f7b-4f8d-9705-db429963dcdf)
