### PR TITLE
Docs: Remove outdated info 

### DIFF
--- a/packages/components/README.md
+++ b/packages/components/README.md
@@ -31,8 +31,6 @@ In non-WordPress projects, link to the `build-style/style.css` file directly, it
 
 ### Popovers
 
-_If you're using [`Popover`](/packages/components/src/popover/README.md) outside of the editor, make sure they are rendered within a `SlotFillProvider` and with a `Popover.Slot` somewhere up the element tree._
-
 By default, the `Popover` component will render within an extra element appended to the body of the document.
 
 If you want to precisely contol where the popovers render, you will need to use the `Popover.Slot` component.
@@ -55,7 +53,7 @@ const Example = () => {
 	<SlotFillProvider>
 		<MyComponentWithPopover />
 		<Popover.Slot />
-	</SlotFillProvider>
+	</SlotFillProvider>;
 };
 ```
 

--- a/packages/components/README.md
+++ b/packages/components/README.md
@@ -29,16 +29,13 @@ Many components include CSS to add styles, which you will need to load in order 
 
 In non-WordPress projects, link to the `build-style/style.css` file directly, it is located at `node_modules/@wordpress/components/build-style/style.css`.
 
-### Popovers and Tooltips
+### Popovers
 
-_If you're using [`Popover`](/packages/components/src/popover/README.md) or [`Tooltip`](/packages/components/src/tooltip/README.md) components outside of the editor, make sure they are rendered within a `SlotFillProvider` and with a `Popover.Slot` somewhere up the element tree._
+_If you're using [`Popover`](/packages/components/src/popover/README.md) outside of the editor, make sure they are rendered within a `SlotFillProvider` and with a `Popover.Slot` somewhere up the element tree._
 
 By default, the `Popover` component will render within an extra element appended to the body of the document.
 
 If you want to precisely contol where the popovers render, you will need to use the `Popover.Slot` component.
-
-A `Popover` is also used as the underlying mechanism to display `Tooltip` components.
-So the same considerations should be applied to them.
 
 The following example illustrates how you can wrap a component using a
 `Popover` and have those popovers render to a single location in the DOM.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Tooltip no longer uses our Popover component since the refactor in #48440, so this removes the info on our legacy tooltip in the Popover section of the components package README. 

