### PR TITLE
Default pattern terminology to Pattern instead of Block Pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 Welcome to the development hub for the WordPress Gutenberg project!
 
-"Gutenberg" is a codename for a whole new paradigm in WordPress site building and publishing, that aims to revolutionize the entire publishing experience as much as Gutenberg did the printed word. Right now, the project is in the second phase of a four-phase process that will touch every piece of WordPress -- Editing, **Customization** (which includes Full Site Editing, Block Patterns, Block Directory and Block based themes), Collaboration, and Multilingual -- and is focused on a new editing experience, the block editor.
+"Gutenberg" is a codename for a whole new paradigm in WordPress site building and publishing, that aims to revolutionize the entire publishing experience as much as Gutenberg did the printed word. Right now, the project is in the second phase of a four-phase process that will touch every piece of WordPress -- Editing, **Customization** (which includes Site Editing, Patterns, Block Directory and Block based themes), Collaboration, and Multilingual -- and is focused on a new editing experience, the block editor.
 
 The block editor introduces a modular approach to pages and posts: each piece of content in the editor, from a paragraph to an image gallery to a headline, is its own block. And just like physical blocks, WordPress blocks can be added, arranged, and rearranged, allowing WordPress users to create media-rich pages in a visually intuitive way -- and without work-arounds like shortcodes or custom HTML.
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 Welcome to the development hub for the WordPress Gutenberg project!
 
-"Gutenberg" is a codename for a whole new paradigm in WordPress site building and publishing, that aims to revolutionize the entire publishing experience as much as Gutenberg did the printed word. Right now, the project is in the second phase of a four-phase process that will touch every piece of WordPress -- Editing, **Customization** (which includes Site Editing, Patterns, Block Directory and Block based themes), Collaboration, and Multilingual -- and is focused on a new editing experience, the block editor.
+"Gutenberg" is a codename for a whole new paradigm in WordPress site building and publishing, that aims to revolutionize the entire publishing experience as much as Gutenberg did the printed word. Right now, the project is in the second phase of a four-phase process that will touch every piece of WordPress -- Editing, **Customization** (which includes Full Site Editing, Patterns, Block Directory and Block based themes), Collaboration, and Multilingual -- and is focused on a new editing experience, the block editor.
 
 The block editor introduces a modular approach to pages and posts: each piece of content in the editor, from a paragraph to an image gallery to a headline, is its own block. And just like physical blocks, WordPress blocks can be added, arranged, and rearranged, allowing WordPress users to create media-rich pages in a visually intuitive way -- and without work-arounds like shortcodes or custom HTML.
 

--- a/docs/explanations/architecture/key-concepts.md
+++ b/docs/explanations/architecture/key-concepts.md
@@ -51,7 +51,7 @@ Internally, reusable blocks are stored as a hidden post type (`wp_block`) and ar
 
 ## Patterns
 
-A [block pattern](/docs/reference-guides/block-api/block-patterns.md) is a group of blocks that have been combined together creating a design pattern. These design patterns provide a starting point for building more advanced pages and layouts quickly, instead of inserting individual blocks. A block pattern can be as small as a single block or as large as a full page of content. Unlike reusable blocks, once a pattern is inserted it doesn't remain in sync with the original content as the blocks contained are meant to be edited and customized by the user. Underneath the surface, patterns are just regular blocks composed together. Themes can register patterns to offer users quick starting points with a design language familiar to that theme's aesthetics.
+A [pattern](/docs/reference-guides/block-api/block-patterns.md) is a group of blocks that have been combined together creating a design pattern. These design patterns provide a starting point for building more advanced pages and layouts quickly, instead of inserting individual blocks. A pattern can be as small as a single block or as large as a full page of content. Unlike reusable blocks, once a pattern is inserted it doesn't remain in sync with the original content as the blocks contained are meant to be edited and customized by the user. Underneath the surface, patterns are just regular blocks composed together. Themes can register patterns to offer users quick starting points with a design language familiar to that theme's aesthetics.
 
 ## Templates
 

--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -1,6 +1,6 @@
 # Getting Started
 
-Welcome! Let's get started building with blocks. Blocks are at the core of extending WordPress. You can create custom blocks, your own block patterns, or combine them together to build a block theme. At a high level, here are a few ways to begin your journey but read on to explore more:
+Welcome! Let's get started building with blocks. Blocks are at the core of extending WordPress. You can create custom blocks, your own patterns, or combine them together to build a block theme. At a high level, here are a few ways to begin your journey but read on to explore more:
 
 - Learn more about where this work is going by [reviewing the long term roadmap](https://wordpress.org/about/roadmap/).
 - Explore the [GitHub repo](https://github.com/WordPress/gutenberg/) to see the latest issues and PRs folks are working on, especially [Good First Issues](https://github.com/WordPress/gutenberg/issues?q=is%3Aopen+is%3Aissue+label%3A%22Good+First+Issue%22).

--- a/docs/getting-started/faq.md
+++ b/docs/getting-started/faq.md
@@ -74,7 +74,7 @@ Gutenberg is developed on [GitHub](https://github.com/WordPress/gutenberg) under
 There are four phases of Gutenberg which you can see on the [official WordPress roadmap](https://wordpress.org/about/roadmap/). As of writing this, we’re currently in phase 2:
 
 1. Easier Editing — Already available in WordPress since 5.0, with ongoing improvements.
-2. Customization — Site Editing, Patterns, Block Directory, Block based themes.
+2. Customization — Full Site editing, Patterns, Block Directory, Block based themes.
 3. Collaboration — A more intuitive way to co-author content
 4. Multi-lingual — Core implementation for Multi-lingual sites
 

--- a/docs/getting-started/faq.md
+++ b/docs/getting-started/faq.md
@@ -74,7 +74,7 @@ Gutenberg is developed on [GitHub](https://github.com/WordPress/gutenberg) under
 There are four phases of Gutenberg which you can see on the [official WordPress roadmap](https://wordpress.org/about/roadmap/). As of writing this, we’re currently in phase 2:
 
 1. Easier Editing — Already available in WordPress since 5.0, with ongoing improvements.
-2. Customization — Full Site editing, Block Patterns, Block Directory, Block based themes.
+2. Customization — Site Editing, Patterns, Block Directory, Block based themes.
 3. Collaboration — A more intuitive way to co-author content
 4. Multi-lingual — Core implementation for Multi-lingual sites
 

--- a/docs/getting-started/glossary.md
+++ b/docs/getting-started/glossary.md
@@ -64,7 +64,7 @@ A type of block where the content of which may change and cannot be determined a
 
 ## Full Site Editing
 
-This refers to a collection of features that ultimately allows users to edit their entire website using blocks as the starting point. This feature set includes everything from block patterns to global styles to templates to design tools for blocks (and more). First released in WordPress 5.9.
+This refers to a collection of features that ultimately allows users to edit their entire website using blocks as the starting point. This feature set includes everything from patterns to global styles to templates to design tools for blocks (and more). First released in WordPress 5.9.
 
 ## Global Styles
 

--- a/docs/how-to-guides/themes/theme-support.md
+++ b/docs/how-to-guides/themes/theme-support.md
@@ -9,7 +9,7 @@ There are a few new concepts to consider when building themes:
 -   **Responsive Embeds** - Themes must opt-in to responsive embeds.
 -   **Frontend & Editor Styles** - To get the most out of blocks, theme authors will want to make sure Core styles look good and opt-in, or write their own styles to best fit their theme.
 -   **Block Tools** - Themes can opt-in to several block tools like line height, custom units.
--   **Core Block Patterns** - Themes can opt-out of the default block patterns.
+-   **Core Patterns** - Themes can opt-out of the default patterns.
 
 By default, blocks provide their styles to enable basic support for blocks in themes without any change. They also [provide opt-in opinionated styles](#default-block-styles). Themes can add/override these styles, or they can provide no styles at all, and rely fully on what the blocks provide.
 
@@ -339,9 +339,9 @@ Themes can also filter the available custom units.
 add_theme_support( 'custom-units', 'rem', 'em' );
 ```
 
-### Disabling the default block patterns.
+### Disabling the default patterns
 
-WordPress comes with a number of block patterns built-in, themes can opt-out of the bundled patterns and provide their own set using the following code:
+WordPress comes with a number of patterns built-in, themes can opt-out of the bundled patterns and provide their own set using the following code:
 
 ```php
 remove_theme_support( 'core-block-patterns' );

--- a/docs/reference-guides/block-api/block-patterns.md
+++ b/docs/reference-guides/block-api/block-patterns.md
@@ -1,35 +1,35 @@
 # Patterns
 
-Block Patterns are predefined block layouts, available from the patterns tab of the block inserter. Once inserted into content, the blocks are ready for additional or modified content and configuration.
+Patterns are predefined block layouts, available from the patterns tab of the block inserter. Once inserted into content, the blocks are ready for additional or modified content and configuration.
 
 In this Document:
 - [Patterns](#patterns)
-	- [Block Patterns](#block-patterns)
+	- [Patterns](#patterns)
 		- [register_block_pattern](#register_block_pattern)
-	- [Unregistering Block Patterns](#unregistering-block-patterns)
+	- [Unregistering Patterns](#unregistering-patterns)
 		- [unregister_block_pattern](#unregister_block_pattern)
-	- [Block Pattern Categories](#block-pattern-categories)
+	- [Pattern Categories](#block-pattern-categories)
 		- [register_block_pattern_category](#register_block_pattern_category)
 		- [unregister_block_pattern_category](#unregister_block_pattern_category)
-	- [Block patterns contextual to block types and pattern transformations](#block-patterns-contextual-to-block-types-and-pattern-transformations)
-	- [Semantic block patterns](#semantic-block-patterns)
+	- [Patterns contextual to block types and pattern transformations](#block-patterns-contextual-to-block-types-and-pattern-transformations)
+	- [Semantic patterns](#semantic-block-patterns)
 
-## Block Patterns
+## Patterns
 
 ### register_block_pattern
 
-The editor comes with several core block patterns. Theme and plugin authors can register additional custom block patterns using the `register_block_pattern` helper function.
+The editor comes with several core patterns. Theme and plugin authors can register additional custom patterns using the `register_block_pattern` helper function.
 
 The `register_block_pattern` helper function receives two arguments.
 -   `title`: A machine-readable title with a naming convention of `namespace/title`.
 -	`properties`: An array describing properties of the pattern.
 
-The properties available for block patterns are:
+The properties available for patterns are:
 
 -   `title` (required): A human-readable title for the pattern.
 -   `content` (required): Block HTML Markup for the pattern.
 -   `description` (optional): A visually hidden text used to describe the pattern in the inserter. A description is optional but it is strongly encouraged when the title does not fully describe what the pattern does. The description will help users discover the pattern while searching.
--   `categories` (optional): An array of registered pattern categories used to group block patterns. Block patterns can be shown on multiple categories. A category must be registered separately in order to be used here.
+-   `categories` (optional): An array of registered pattern categories used to group patterns. Patterns can be shown on multiple categories. A category must be registered separately in order to be used here.
 -   `keywords` (optional): An array of aliases or keywords that help users discover the pattern while searching.
 -   `viewportWidth` (optional): An integer specifying the intended width of the pattern to allow for a scaled preview of the pattern in the inserter.
 -   `blockTypes` (optional): An array of block types that the pattern is intended to be used with. Each value needs to be the declared block's `name`.
@@ -38,14 +38,14 @@ The properties available for block patterns are:
 -   `inserter` (optional): By default, all patterns will appear in the inserter. To hide a pattern so that it can only be inserted programmatically, set the `inserter` to `false`.
 -   `source` (optional): A string that denotes the source of the pattern. For a plugin registering a pattern, pass the string 'plugin'. For a theme, pass the string 'theme'.
 
-The following code sample registers a block pattern named 'my-plugin/my-awesome-pattern':
+The following code sample registers a pattern named 'my-plugin/my-awesome-pattern':
 
 ```php
 register_block_pattern(
 	'my-plugin/my-awesome-pattern',
 	array(
 		'title'       => __( 'Two buttons', 'my-plugin' ),
-		'description' => _x( 'Two horizontal buttons, the left button is filled in, and the right button is outlined.', 'Block pattern description', 'my-plugin' ),
+		'description' => _x( 'Two horizontal buttons, the left button is filled in, and the right button is outlined.', 'Pattern description', 'my-plugin' ),
 		'content'     => "<!-- wp:buttons {\"align\":\"center\"} -->\n<div class=\"wp-block-buttons aligncenter\"><!-- wp:button {\"backgroundColor\":\"very-dark-gray\",\"borderRadius\":0} -->\n<div class=\"wp-block-button\"><a class=\"wp-block-button__link has-background has-very-dark-gray-background-color no-border-radius\">" . esc_html__( 'Button One', 'my-plugin' ) . "</a></div>\n<!-- /wp:button -->\n\n<!-- wp:button {\"textColor\":\"very-dark-gray\",\"borderRadius\":0,\"className\":\"is-style-outline\"} -->\n<div class=\"wp-block-button is-style-outline\"><a class=\"wp-block-button__link has-text-color has-very-dark-gray-color no-border-radius\">" . esc_html__( 'Button Two', 'my-plugin' ) . "</a></div>\n<!-- /wp:button --></div>\n<!-- /wp:buttons -->",
 	)
 );
@@ -63,14 +63,14 @@ function my_plugin_register_my_patterns() {
 add_action( 'init', 'my_plugin_register_my_patterns' );
 ```
 
-## Unregistering Block Patterns
+## Unregistering Patterns
 
 ### unregister_block_pattern
 
-The `unregister_block_pattern` helper function allows for a previously registered block pattern to be unregistered from a theme or plugin and receives one argument.
--   `title`: The name of the block pattern to be unregistered.
+The `unregister_block_pattern` helper function allows for a previously registered pattern to be unregistered from a theme or plugin and receives one argument.
+-   `title`: The name of the pattern to be unregistered.
 
-The following code sample unregisters the block pattern named 'my-plugin/my-awesome-pattern':
+The following code sample unregisters the pattern named 'my-plugin/my-awesome-pattern':
 
 ```php
 unregister_block_pattern( 'my-plugin/my-awesome-pattern' );
@@ -88,14 +88,14 @@ function my_plugin_unregister_my_patterns() {
 add_action( 'init', 'my_plugin_unregister_my_patterns' );
 ```
 
-## Block Pattern Categories
+## Pattern Categories
 
-Block patterns can be grouped using categories. The block editor comes with bundled categories you can use on your custom block patterns. You can also register your own block pattern categories.
+Patterns can be grouped using categories. The block editor comes with bundled categories you can use on your custom patterns. You can also register your own pattern categories.
 
 ### register_block_pattern_category
 
 The `register_block_pattern_category` helper function receives two arguments.
--   `title`: A machine-readable title for the block pattern category.
+-   `title`: A machine-readable title for the pattern category.
 -	`properties`: An array describing properties of the pattern category.
 
 The properties of the pattern categories include:
@@ -129,8 +129,8 @@ add_action( 'init', 'my_plugin_register_my_pattern_categories' );
 
 `unregister_block_pattern_category` allows unregistering a pattern category.
 
-The `unregister_block_pattern_category` helper function allows for a previously registered block pattern category to be unregistered from a theme or plugin and receives one argument.
--   `title`: The name of the block pattern category to be unregistered.
+The `unregister_block_pattern_category` helper function allows for a previously registered pattern category to be unregistered from a theme or plugin and receives one argument.
+-   `title`: The name of the pattern category to be unregistered.
 
 The following code sample unregisters the category named 'hero':
 
@@ -150,11 +150,11 @@ function my_plugin_unregister_my_pattern_categories() {
 add_action( 'init', 'my_plugin_unregister_my_pattern_categories' );
 ```
 
-## Block patterns contextual to block types and pattern transformations
+## Patterns contextual to block types and pattern transformations
 
-It is possible to attach a block pattern to one or more block types. This adds the block pattern as an available transform for that block type.
+It is possible to attach a pattern to one or more block types. This adds the pattern as an available transform for that block type.
 
-Currently these transformations are available only to simple blocks (blocks without inner blocks). In order for a pattern to be suggested, **every selected block must be present in the block pattern**.
+Currently these transformations are available only to simple blocks (blocks without inner blocks). In order for a pattern to be suggested, **every selected block must be present in the pattern**.
 
 For instance:
 
@@ -171,7 +171,7 @@ register_block_pattern(
 );
 ```
 
-The above code registers a block pattern named 'my-plugin/powered-by-wordpress' and also shows the pattern in the "transform menu" of paragraph blocks. The transformation result will be keeping the paragraph's existing content and also apply the other attributes - in this case the background and text color.
+The above code registers a pattern named 'my-plugin/powered-by-wordpress' and also shows the pattern in the "transform menu" of paragraph blocks. The transformation result will be keeping the paragraph's existing content and also apply the other attributes - in this case the background and text color.
 
 As mentioned above pattern transformations for simple blocks can also work if we have selected multiple blocks and there are matching contextual patterns to these blocks. Let's see an example of a pattern where two block types are attached.
 
@@ -196,11 +196,11 @@ register_block_pattern(
 
 In the above example if we select **one of the two** block types, either a paragraph or a heading block, this pattern will be suggested by transforming the selected block using its content and will also add the remaining blocks from the pattern. If on the other hand we multi select one paragraph and one heading block, both blocks will be transformed.
 
-Blocks can also use these contextual block patterns in other places. For instance, when inserting a new Query Loop block, the user is provided with a list of all patterns attached to the block.
+Blocks can also use these contextual patterns in other places. For instance, when inserting a new Query Loop block, the user is provided with a list of all patterns attached to the block.
 
-## Semantic block patterns
+## Semantic patterns
 
-In block themes, you can also mark block patterns as "header" or "footer" patterns (template part areas). We call these "semantic block patterns". These patterns are shown to the user when inserting or replacing header or footer template parts.
+In block themes, you can also mark patterns as "header" or "footer" patterns (template part areas). We call these "semantic patterns". These patterns are shown to the user when inserting or replacing header or footer template parts.
 
 Example:
 
@@ -213,7 +213,7 @@ register_block_pattern(
 		'categories' => array( 'header' ),
 		// Assigning the pattern the "header" area.
 		'blockTypes' => array( 'core/template-part/header' ),
-		'content'    => 'Content of my block pattern',
+		'content'    => 'Content of my pattern',
 	)
 );
 ```

--- a/docs/reference-guides/block-api/block-registration.md
+++ b/docs/reference-guides/block-api/block-registration.md
@@ -300,7 +300,7 @@ The key is the name of the block (`string`) to hook into, and the value is the p
 }
 ```
 
-It’s crucial to emphasize that the Block Hooks feature is only designed to work with _static_ block-based templates, template parts, and patterns. For patterns, this includes those provided by the theme, from [Block Pattern Directory](https://wordpress.org/patterns/), or from calls to [`register_block_pattern`](https://developer.wordpress.org/reference/functions/register_block_pattern/).
+It’s crucial to emphasize that the Block Hooks feature is only designed to work with _static_ block-based templates, template parts, and patterns. For patterns, this includes those provided by the theme, from [Pattern Directory](https://wordpress.org/patterns/), or from calls to [`register_block_pattern`](https://developer.wordpress.org/reference/functions/register_block_pattern/).
 
 Block Hooks will not work with post content or patterns crafted by the user, such as synced patterns, or theme templates and template parts that have been modified by the user.
 

--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -526,7 +526,7 @@ Start with the basic building block of all narrative. ([Source](https://github.c
 
 ## Pattern placeholder
 
-Show a block pattern. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/pattern))
+Show a pattern. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/pattern))
 
 -	**Name:** core/pattern
 -	**Category:** theme

--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -483,7 +483,7 @@ Start with the basic building block of all narrative. ([Source](https://github.c
 
 ## Pattern placeholder
 
-Show a block pattern. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/pattern))
+Show a pattern. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/pattern))
 
 -	**Name:** core/pattern
 -	**Category:** theme

--- a/docs/reference-guides/data/data-core-block-editor.md
+++ b/docs/reference-guides/data/data-core-block-editor.md
@@ -698,7 +698,7 @@ _Parameters_
 
 _Returns_
 
--   `Array`: The list of matched block patterns based on declared `blockTypes` and block name.
+-   `Array`: The list of matched patterns based on declared `blockTypes` and block name.
 
 ### getPreviousBlockClientId
 

--- a/docs/reference-guides/data/data-core.md
+++ b/docs/reference-guides/data/data-core.md
@@ -92,7 +92,7 @@ _Returns_
 
 ### getBlockPatternCategories
 
-Retrieve the list of registered block pattern categories.
+Retrieve the list of registered pattern categories.
 
 _Parameters_
 
@@ -100,11 +100,11 @@ _Parameters_
 
 _Returns_
 
--   `Array< any >`: Block pattern category list.
+-   `Array< any >`: Pattern category list.
 
 ### getBlockPatterns
 
-Retrieve the list of registered block patterns.
+Retrieve the list of registered patterns.
 
 _Parameters_
 
@@ -112,7 +112,7 @@ _Parameters_
 
 _Returns_
 
--   `Array< any >`: Block pattern list.
+-   `Array< any >`: Pattern list.
 
 ### getCurrentTheme
 

--- a/docs/reference-guides/filters/editor-filters.md
+++ b/docs/reference-guides/filters/editor-filters.md
@@ -164,11 +164,11 @@ The Block Directory enables installing new block plugins from [WordPress.org.](h
 remove_action( 'enqueue_block_editor_assets', 'wp_enqueue_editor_block_directory_assets' );
 ```
 
-## Block Patterns
+## Patterns
 
 ### `should_load_remote_block_patterns`
 
-Default `true`. The filter is checked when registering remote block patterns, set to false to disable.
+Default `true`. The filter is checked when registering remote patterns, set to false to disable.
 
 For example, to disable use:
 

--- a/lib/compat/wordpress-6.3/block-patterns.php
+++ b/lib/compat/wordpress-6.3/block-patterns.php
@@ -6,9 +6,9 @@
  */
 
 /**
- * Registers the block pattern sources.
+ * Registers the pattern sources.
  *
- * @since 6.3.0 Added source to core block patterns.
+ * @since 6.3.0 Added source to core patterns.
  */
 function gutenberg_register_core_block_patterns_and_categories() {
 	$should_register_core_patterns = get_theme_support( 'core-block-patterns' );
@@ -55,7 +55,7 @@ function gutenberg_load_remote_block_patterns( $deprecated = null ) {
 	$supports_core_patterns = get_theme_support( 'core-block-patterns' );
 
 	/**
-	 * Filter to disable remote block patterns.
+	 * Filter to disable remote patterns.
 	 *
 	 * @since 5.8.0
 	 *

--- a/lib/compat/wordpress-6.3/blocks.php
+++ b/lib/compat/wordpress-6.3/blocks.php
@@ -45,7 +45,7 @@ function gutenberg_rename_reusable_block_cpt_to_pattern( $args, $post_type ) {
 		$args['labels']['singular_name']            = _x( 'Pattern', 'post type singular name' );
 		$args['labels']['add_new_item']             = __( 'Add new Pattern' );
 		$args['labels']['new_item']                 = __( 'New Pattern' );
-		$args['labels']['edit_item']                = __( 'Edit Block Pattern' );
+		$args['labels']['edit_item']                = __( 'Edit Pattern' );
 		$args['labels']['view_item']                = __( 'View Pattern' );
 		$args['labels']['view_items']               = __( 'View Patterns' );
 		$args['labels']['all_items']                = __( 'All Patterns' );

--- a/lib/compat/wordpress-6.3/class-gutenberg-rest-block-patterns-controller-6-3.php
+++ b/lib/compat/wordpress-6.3/class-gutenberg-rest-block-patterns-controller-6-3.php
@@ -7,7 +7,7 @@
  */
 
 /**
- * Core class used to access block patterns via the REST API.
+ * Core class used to access patterns via the REST API.
  *
  * @since 6.0.0
  *
@@ -23,7 +23,7 @@ class Gutenberg_REST_Block_Patterns_Controller_6_3 extends WP_REST_Block_Pattern
 	private $remote_patterns_loaded;
 
 	/**
-	 * Prepare a raw block pattern before it gets output in a REST API response.
+	 * Prepare a raw pattern before it gets output in a REST API response.
 	 *
 	 * @since 6.0.0
 	 * @since 6.3.0 Added `source` property.
@@ -61,7 +61,7 @@ class Gutenberg_REST_Block_Patterns_Controller_6_3 extends WP_REST_Block_Pattern
 	}
 
 	/**
-	 * Retrieves the block pattern schema, conforming to JSON Schema.
+	 * Retrieves the pattern schema, conforming to JSON Schema.
 	 *
 	 * @since 6.0.0
 	 * @since 6.1.0 Added `post_types` property.
@@ -168,7 +168,7 @@ class Gutenberg_REST_Block_Patterns_Controller_6_3 extends WP_REST_Block_Pattern
 	}
 
 	/**
-	 * Retrieves all block patterns.
+	 * Retrieves all patterns.
 	 *
 	 * @since 6.0.0
 	 * @since 6.2.0 Added migration for old core pattern categories to the new ones.
@@ -178,7 +178,7 @@ class Gutenberg_REST_Block_Patterns_Controller_6_3 extends WP_REST_Block_Pattern
 	 */
 	public function get_items( $request ) {
 		if ( ! $this->remote_patterns_loaded ) {
-			// Load block patterns from w.org.
+			// Load patterns from w.org.
 			gutenberg_load_remote_block_patterns(); // Patterns with the `core` keyword.
 			gutenberg_load_remote_featured_patterns(); // Patterns in the `featured` category.
 			gutenberg_register_remote_theme_patterns(); // Patterns requested by current theme.

--- a/lib/compat/wordpress-6.4/class-gutenberg-rest-block-patterns-controller.php
+++ b/lib/compat/wordpress-6.4/class-gutenberg-rest-block-patterns-controller.php
@@ -7,7 +7,7 @@
  */
 
 /**
- * Core class used to access block patterns via the REST API.
+ * Core class used to access patterns via the REST API.
  *
  * @since 6.4.0
  *
@@ -15,7 +15,7 @@
  */
 class Gutenberg_REST_Block_Patterns_Controller extends Gutenberg_REST_Block_Patterns_Controller_6_3 {
 	/**
-	 * Prepare a raw block pattern before it gets output in a REST API response.
+	 * Prepare a raw pattern before it gets output in a REST API response.
 	 *
 	 * @todo In the long run, we'd likely want to have a filter in the `WP_Block_Patterns_Registry` class
 	 * instead to allow us plugging in code like this.

--- a/lib/compat/wordpress-6.4/rest-api.php
+++ b/lib/compat/wordpress-6.4/rest-api.php
@@ -11,7 +11,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * Registers the block patterns REST API routes.
+ * Registers the patterns REST API routes.
  */
 function gutenberg_register_rest_block_patterns_routes() {
 	$block_patterns = new Gutenberg_REST_Block_Patterns_Controller();

--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -753,8 +753,8 @@ _Properties_
 -   _clearBlockSelection_ `boolean`: Whether the block editor should clear selection on mousedown when a block is not clicked.
 -   _\_\_experimentalCanUserUseUnfilteredHTML_ `boolean`: Whether the user should be able to use unfiltered HTML or the HTML should be filtered e.g., to remove elements considered insecure like iframes.
 -   _\_\_experimentalBlockDirectory_ `boolean`: Whether the user has enabled the Block Directory
--   _\_\_experimentalBlockPatterns_ `Array`: Array of objects representing the block patterns
--   _\_\_experimentalBlockPatternCategories_ `Array`: Array of objects representing the block pattern categories
+-   _\_\_experimentalBlockPatterns_ `Array`: Array of objects representing the patterns
+-   _\_\_experimentalBlockPatternCategories_ `Array`: Array of objects representing the pattern categories
 -   _\_\_unstableGalleryWithImageBlocks_ `boolean`: Whether the user has enabled the refactored gallery block which uses InnerBlocks
 
 ### SkipToSelectedBlock

--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -751,8 +751,8 @@ _Properties_
 -   _clearBlockSelection_ `boolean`: Whether the block editor should clear selection on mousedown when a block is not clicked.
 -   _\_\_experimentalCanUserUseUnfilteredHTML_ `boolean`: Whether the user should be able to use unfiltered HTML or the HTML should be filtered e.g., to remove elements considered insecure like iframes.
 -   _\_\_experimentalBlockDirectory_ `boolean`: Whether the user has enabled the Block Directory
--   _\_\_experimentalBlockPatterns_ `Array`: Array of objects representing the block patterns
--   _\_\_experimentalBlockPatternCategories_ `Array`: Array of objects representing the block pattern categories
+-   _\_\_experimentalBlockPatterns_ `Array`: Array of objects representing the patterns
+-   _\_\_experimentalBlockPatternCategories_ `Array`: Array of objects representing the pattern categories
 -   _\_\_unstableGalleryWithImageBlocks_ `boolean`: Whether the user has enabled the refactored gallery block which uses InnerBlocks
 
 ### SkipToSelectedBlock

--- a/packages/block-editor/src/components/block-patterns-list/README.md
+++ b/packages/block-editor/src/components/block-patterns-list/README.md
@@ -1,10 +1,10 @@
-# Block Patterns List
+# Patterns List
 
-The `BlockPatternList` component makes a list of the different registered block patterns. It uses the `BlockPreview` component to display a preview for each block pattern.
+The `BlockPatternList` component makes a list of the different registered patterns. It uses the `BlockPreview` component to display a preview for each pattern.
 
 For more infos about blocks patterns, read [this](https://make.wordpress.org/core/2020/07/16/block-patterns-in-wordpress-5-5/).
 
-![Block patterns sidebar in WordPress 5.5](https://make.wordpress.org/core/files/2020/09/blocks-patterns-sidebar-in-wordpress-5-5.png)
+![Patterns sidebar in WordPress 5.5](https://make.wordpress.org/core/files/2020/09/blocks-patterns-sidebar-in-wordpress-5-5.png)
 
 ## Table of contents
 
@@ -15,7 +15,7 @@ For more infos about blocks patterns, read [this](https://make.wordpress.org/cor
 
 ### Usage
 
-Renders a block patterns list.
+Renders a patterns list.
 
 ```jsx
 import { BlockPatternList } from '@wordpress/block-editor';
@@ -33,28 +33,28 @@ const MyBlockPatternList = () => (
 
 #### blockPatterns
 
-An array of block patterns that can be shown in the block patterns list.
+An array of patterns that can be shown in the patterns list.
 
 -   Type: `Array`
 -   Required: Yes
 
 #### shownPatterns
 
-An array of shown block patterns objects.
+An array of shown patterns objects.
 
 -   Type: `Array`
 -   Required: Yes
 
 #### onClickPattern
 
-The performed event after a click on a block pattern. In most cases, the pattern is inserted in the block editor.
+The performed event after a click on a pattern. In most cases, the pattern is inserted in the block editor.
 
 -   Type: `Function`
 -   Required: Yes
 
 #### isDraggable
 
-Enables drag and drop functionality to the available block patterns.
+Enables drag and drop functionality to the available patterns.
 
 -   Type: `boolean`
 -   Required: No
@@ -68,11 +68,11 @@ The orientation value determines which arrow keys can be used to move focus. Ava
 
 #### label
 
-The aria label for the block patterns list.
+The aria label for the patterns list.
 
 -   Type: `string`
 -   Required: No
--   Default: `Block Patterns`
+-   Default: `Patterns`
 
 ## Related components
 

--- a/packages/block-editor/src/components/block-patterns-list/index.js
+++ b/packages/block-editor/src/components/block-patterns-list/index.js
@@ -149,7 +149,7 @@ function BlockPatternList(
 		onHover,
 		onClickPattern,
 		orientation,
-		label = __( 'Block patterns' ),
+		label = __( 'Patterns' ),
 		showTitlesAsTooltip,
 		pagingProps,
 	},

--- a/packages/block-editor/src/components/block-patterns-list/index.js
+++ b/packages/block-editor/src/components/block-patterns-list/index.js
@@ -147,7 +147,7 @@ function BlockPatternList( {
 	onHover,
 	onClickPattern,
 	orientation,
-	label = __( 'Block Patterns' ),
+	label = __( 'Patterns' ),
 	showTitlesAsTooltip,
 } ) {
 	const composite = useCompositeState( { orientation } );

--- a/packages/block-editor/src/components/inserter/block-patterns-explorer/patterns-list.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-explorer/patterns-list.js
@@ -49,7 +49,7 @@ function PatternsListHeader( {
 			className="block-editor-block-patterns-explorer__search-results-count"
 		>
 			{ sprintf(
-				/* translators: %d: number of patterns. %s: block pattern search query */
+				/* translators: %d: number of patterns. %s: pattern search query */
 				_n(
 					'%1$d pattern found for "%2$s"',
 					'%1$d patterns found for "%2$s"',

--- a/packages/block-editor/src/components/inserter/block-patterns-tab.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-tab.js
@@ -281,7 +281,7 @@ export function BlockPatternsCategoryPanel( {
 	);
 	const { changePage } = pagingProps;
 
-	// Hide block pattern preview on unmount.
+	// Hide pattern preview on unmount.
 	// eslint-disable-next-line react-hooks/exhaustive-deps
 	useEffect( () => () => onHover( null ), [] );
 
@@ -368,7 +368,7 @@ function BlockPatternsTabs( {
 			{ ! isMobile && (
 				<div className="block-editor-inserter__block-patterns-tabs-container">
 					<nav
-						aria-label={ __( 'Block pattern categories' ) }
+						aria-label={ __( 'Pattern categories' ) }
 						className="block-editor-inserter__block-patterns-tabs"
 					>
 						<ItemGroup role="list">

--- a/packages/block-editor/src/components/inserter/block-patterns-tab.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-tab.js
@@ -250,7 +250,7 @@ export function BlockPatternsCategoryPanel( {
 		container
 	);
 
-	// Hide block pattern preview on unmount.
+	// Hide pattern preview on unmount.
 	// eslint-disable-next-line react-hooks/exhaustive-deps
 	useEffect( () => () => onHover( null ), [] );
 
@@ -314,7 +314,7 @@ function BlockPatternsTabs( {
 			{ ! isMobile && (
 				<div className="block-editor-inserter__block-patterns-tabs-container">
 					<nav
-						aria-label={ __( 'Block pattern categories' ) }
+						aria-label={ __( 'Pattern categories' ) }
 						className="block-editor-inserter__block-patterns-tabs"
 					>
 						<BlockPatternsSourceFilter

--- a/packages/block-editor/src/components/inserter/hooks/use-patterns-state.js
+++ b/packages/block-editor/src/components/inserter/hooks/use-patterns-state.js
@@ -13,7 +13,7 @@ import { store as noticesStore } from '@wordpress/notices';
 import { store as blockEditorStore } from '../../../store';
 
 /**
- * Retrieves the block patterns inserter state.
+ * Retrieves the patterns inserter state.
  *
  * @param {Function} onInsert     function called when inserter a list of blocks.
  * @param {string=}  rootClientId Insertion's root client ID.
@@ -66,8 +66,8 @@ const usePatternsState = ( onInsert, rootClientId ) => {
 			);
 			createSuccessNotice(
 				sprintf(
-					/* translators: %s: block pattern title. */
-					__( 'Block pattern "%s" inserted.' ),
+					/* translators: %s: pattern title. */
+					__( 'Pattern "%s" inserted.' ),
 					pattern.title
 				),
 				{

--- a/packages/block-editor/src/components/inserter/search-results.js
+++ b/packages/block-editor/src/components/inserter/search-results.js
@@ -184,7 +184,7 @@ function InserterSearchResults( {
 	const patternsUI = !! filteredBlockPatterns.length && (
 		<InserterPanel
 			title={
-				<VisuallyHidden>{ __( 'Block patterns' ) }</VisuallyHidden>
+				<VisuallyHidden>{ __( 'Patterns' ) }</VisuallyHidden>
 			}
 		>
 			<div className="block-editor-inserter__quick-inserter-patterns">

--- a/packages/block-editor/src/components/inserter/search-results.js
+++ b/packages/block-editor/src/components/inserter/search-results.js
@@ -183,9 +183,7 @@ function InserterSearchResults( {
 
 	const patternsUI = !! filteredBlockPatterns.length && (
 		<InserterPanel
-			title={
-				<VisuallyHidden>{ __( 'Block Patterns' ) }</VisuallyHidden>
-			}
+			title={ <VisuallyHidden>{ __( 'Patterns' ) }</VisuallyHidden> }
 		>
 			<div className="block-editor-inserter__quick-inserter-patterns">
 				<BlockPatternsList

--- a/packages/block-editor/src/store/defaults.js
+++ b/packages/block-editor/src/store/defaults.js
@@ -31,8 +31,8 @@ export const PREFERENCES_DEFAULTS = {
  * @property {boolean}       clearBlockSelection                    Whether the block editor should clear selection on mousedown when a block is not clicked.
  * @property {boolean}       __experimentalCanUserUseUnfilteredHTML Whether the user should be able to use unfiltered HTML or the HTML should be filtered e.g., to remove elements considered insecure like iframes.
  * @property {boolean}       __experimentalBlockDirectory           Whether the user has enabled the Block Directory
- * @property {Array}         __experimentalBlockPatterns            Array of objects representing the block patterns
- * @property {Array}         __experimentalBlockPatternCategories   Array of objects representing the block pattern categories
+ * @property {Array}         __experimentalBlockPatterns            Array of objects representing the patterns
+ * @property {Array}         __experimentalBlockPatternCategories   Array of objects representing the pattern categories
  * @property {boolean}       __unstableGalleryWithImageBlocks       Whether the user has enabled the refactored gallery block which uses InnerBlocks
  */
 export const SETTINGS_DEFAULTS = {

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -2414,7 +2414,7 @@ export const __experimentalGetAllowedPatterns = createSelector(
  * @param {string|string[]} blockNames   Block's name or array of block names to find matching pattens.
  * @param {?string}         rootClientId Optional target root client ID.
  *
- * @return {Array} The list of matched block patterns based on declared `blockTypes` and block name.
+ * @return {Array} The list of matched patterns based on declared `blockTypes` and block name.
  */
 export const getPatternsByBlockTypes = createSelector(
 	( state, blockNames, rootClientId = null ) => {
@@ -2471,9 +2471,9 @@ export const __experimentalGetPatternsByBlockTypes = createSelector(
  * For now we only handle blocks without InnerBlocks and take into account
  * the `__experimentalRole` property of blocks' attributes for the transformation.
  *
- * We return the first set of possible eligible block patterns,
+ * We return the first set of possible eligible patterns,
  * by checking the `blockTypes` property. We still have to recurse through
- * block pattern's blocks and try to find matches from the selected blocks.
+ * pattern's blocks and try to find matches from the selected blocks.
  * Now this happens in the consumer to avoid heavy operations in the selector.
  *
  * @param {Object}   state        Editor state.
@@ -2507,9 +2507,9 @@ export const __experimentalGetPatternTransformItems = createSelector(
 			new Set( blocks.map( ( { name } ) => name ) )
 		);
 		/**
-		 * Here we will return first set of possible eligible block patterns,
+		 * Here we will return first set of possible eligible patterns,
 		 * by checking the `blockTypes` property. We still have to recurse through
-		 * block pattern's blocks and try to find matches from the selected blocks.
+		 * pattern's blocks and try to find matches from the selected blocks.
 		 * Now this happens in the consumer to avoid heavy operations in the selector.
 		 */
 		return getPatternsByBlockTypes(

--- a/packages/block-editor/src/store/test/selectors.js
+++ b/packages/block-editor/src/store/test/selectors.js
@@ -4406,7 +4406,7 @@ describe( 'selectors', () => {
 			);
 			expect( patterns1 ).toBe( patterns2 );
 		} );
-		it( 'should return proper results when there are matched block patterns', () => {
+		it( 'should return proper results when there are matched patterns', () => {
 			const patterns = getPatternsByBlockTypes( state, 'test/block-a' );
 			expect( patterns ).toHaveLength( 2 );
 			expect( patterns ).toEqual(

--- a/packages/block-library/src/pattern/block.json
+++ b/packages/block-library/src/pattern/block.json
@@ -4,7 +4,7 @@
 	"name": "core/pattern",
 	"title": "Pattern placeholder",
 	"category": "theme",
-	"description": "Show a block pattern.",
+	"description": "Show a pattern.",
 	"supports": {
 		"html": false,
 		"inserter": false,

--- a/packages/block-library/src/pattern/block.json
+++ b/packages/block-library/src/pattern/block.json
@@ -4,7 +4,7 @@
 	"name": "core/pattern",
 	"title": "Pattern placeholder",
 	"category": "theme",
-	"description": "Show a block pattern.",
+	"description": "Show a pattern.",
 	"supports": {
 		"html": false,
 		"inserter": false

--- a/packages/block-library/src/query/utils.js
+++ b/packages/block-library/src/query/utils.js
@@ -327,11 +327,11 @@ export function useScopedBlockVariations( attributes ) {
 }
 
 /**
- * Hook that returns the block patterns for a specific block type.
+ * Hook that returns the patterns for a specific block type.
  *
  * @param {string} clientId The block's client ID.
  * @param {string} name     The block type name.
- * @return {Object[]} An array of valid block patterns.
+ * @return {Object[]} An array of valid patterns.
  */
 export const usePatterns = ( clientId, name ) => {
 	return useSelect(

--- a/packages/block-library/src/template-part/edit/utils/hooks.js
+++ b/packages/block-library/src/template-part/edit/utils/hooks.js
@@ -70,12 +70,12 @@ export function useAlternativeTemplateParts( area, excludedId ) {
 }
 
 /**
- * Retrieves the available block patterns for the given area.
+ * Retrieves the available patterns for the given area.
  *
  * @param {string} area     Template part area.
  * @param {string} clientId Block Client ID. (The container of the block can impact allowed blocks).
  *
- * @return {Array} array of block patterns.
+ * @return {Array} array of patterns.
  */
 export function useAlternativeBlockPatterns( area, clientId ) {
 	return useSelect(

--- a/packages/core-data/CHANGELOG.md
+++ b/packages/core-data/CHANGELOG.md
@@ -102,7 +102,7 @@
 
 ### New Features
 -   The saveEntityRecord, saveEditedEntityRecord, and deleteEntityRecord actions now accept an optional throwOnError option (defaults to false). When set to true, any exceptions occurring when the action was executing are re-thrown, causing dispatch().saveEntityRecord() to reject with an error. ([#39258](https://github.com/WordPress/gutenberg/pull/39258))
--   Added support for fetching block patterns and their categories, with the `getBlockPatterns` and `getBlockPatternCategories` selectors.
+-   Added support for fetching patterns and their categories, with the `getBlockPatterns` and `getBlockPatternCategories` selectors.
 
 ## 4.2.0 (2022-03-11)
 

--- a/packages/core-data/CHANGELOG.md
+++ b/packages/core-data/CHANGELOG.md
@@ -96,7 +96,7 @@
 
 ### New Features
 -   The saveEntityRecord, saveEditedEntityRecord, and deleteEntityRecord actions now accept an optional throwOnError option (defaults to false). When set to true, any exceptions occurring when the action was executing are re-thrown, causing dispatch().saveEntityRecord() to reject with an error. ([#39258](https://github.com/WordPress/gutenberg/pull/39258))
--   Added support for fetching block patterns and their categories, with the `getBlockPatterns` and `getBlockPatternCategories` selectors.
+-   Added support for fetching patterns and their categories, with the `getBlockPatterns` and `getBlockPatternCategories` selectors.
 
 ## 4.2.0 (2022-03-11)
 

--- a/packages/core-data/README.md
+++ b/packages/core-data/README.md
@@ -386,7 +386,7 @@ _Returns_
 
 ### getBlockPatternCategories
 
-Retrieve the list of registered block pattern categories.
+Retrieve the list of registered pattern categories.
 
 _Parameters_
 
@@ -394,11 +394,11 @@ _Parameters_
 
 _Returns_
 
--   `Array< any >`: Block pattern category list.
+-   `Array< any >`: Pattern category list.
 
 ### getBlockPatterns
 
-Retrieve the list of registered block patterns.
+Retrieve the list of registered patterns.
 
 _Parameters_
 
@@ -406,7 +406,7 @@ _Parameters_
 
 _Returns_
 
--   `Array< any >`: Block pattern list.
+-   `Array< any >`: Pattern list.
 
 ### getCurrentTheme
 

--- a/packages/core-data/README.md
+++ b/packages/core-data/README.md
@@ -269,7 +269,7 @@ _Returns_
 
 ### getBlockPatternCategories
 
-Retrieve the list of registered block pattern categories.
+Retrieve the list of registered pattern categories.
 
 _Parameters_
 
@@ -277,11 +277,11 @@ _Parameters_
 
 _Returns_
 
--   `Array< any >`: Block pattern category list.
+-   `Array< any >`: Pattern category list.
 
 ### getBlockPatterns
 
-Retrieve the list of registered block patterns.
+Retrieve the list of registered patterns.
 
 _Parameters_
 
@@ -289,7 +289,7 @@ _Parameters_
 
 _Returns_
 
--   `Array< any >`: Block pattern list.
+-   `Array< any >`: Pattern list.
 
 ### getCurrentTheme
 

--- a/packages/core-data/src/selectors.ts
+++ b/packages/core-data/src/selectors.ts
@@ -1271,22 +1271,22 @@ export function __experimentalGetCurrentThemeGlobalStylesVariations(
 }
 
 /**
- * Retrieve the list of registered block patterns.
+ * Retrieve the list of registered patterns.
  *
  * @param state Data state.
  *
- * @return Block pattern list.
+ * @return Pattern list.
  */
 export function getBlockPatterns( state: State ): Array< any > {
 	return state.blockPatterns;
 }
 
 /**
- * Retrieve the list of registered block pattern categories.
+ * Retrieve the list of registered pattern categories.
  *
  * @param state Data state.
  *
- * @return Block pattern category list.
+ * @return Pattern category list.
  */
 export function getBlockPatternCategories( state: State ): Array< any > {
 	return state.blockPatternCategories;

--- a/packages/core-data/src/selectors.ts
+++ b/packages/core-data/src/selectors.ts
@@ -1210,22 +1210,22 @@ export function __experimentalGetCurrentThemeGlobalStylesVariations(
 }
 
 /**
- * Retrieve the list of registered block patterns.
+ * Retrieve the list of registered patterns.
  *
  * @param state Data state.
  *
- * @return Block pattern list.
+ * @return Pattern list.
  */
 export function getBlockPatterns( state: State ): Array< any > {
 	return state.blockPatterns;
 }
 
 /**
- * Retrieve the list of registered block pattern categories.
+ * Retrieve the list of registered pattern categories.
  *
  * @param state Data state.
  *
- * @return Block pattern category list.
+ * @return Pattern category list.
  */
 export function getBlockPatternCategories( state: State ): Array< any > {
 	return state.blockPatternCategories;

--- a/phpunit/class-gutenberg-rest-block-patterns-controller-test.php
+++ b/phpunit/class-gutenberg-rest-block-patterns-controller-test.php
@@ -7,7 +7,7 @@
  */
 
 /**
- * Unit tests for REST API for Block Patterns.
+ * Unit tests for REST API for Patterns.
  *
  * @group restapi
  * @covers Gutenberg_REST_Block_Patterns_Controller_6_2

--- a/phpunit/class-wp-rest-block-pattern-categories-controller-test.php
+++ b/phpunit/class-wp-rest-block-pattern-categories-controller-test.php
@@ -7,7 +7,7 @@
  */
 
 /**
- * Unit tests for REST API for Block Pattern Categories.
+ * Unit tests for REST API for Pattern Categories.
  *
  * @group restapi
  * @covers WP_REST_Block_Pattern_Categories_Controller

--- a/test/e2e/specs/editor/various/adding-patterns.spec.js
+++ b/test/e2e/specs/editor/various/adding-patterns.spec.js
@@ -8,7 +8,7 @@ test.describe( 'adding patterns', () => {
 		await admin.createNewPost();
 	} );
 
-	test( 'should insert a block pattern', async ( { page, editor } ) => {
+	test( 'should insert a pattern', async ( { page, editor } ) => {
 		await page.click(
 			'role=region[name="Editor top bar"i] >> role=button[name="Toggle block inserter"i]'
 		);

--- a/test/e2e/specs/editor/various/inserting-blocks.spec.js
+++ b/test/e2e/specs/editor/various/inserting-blocks.spec.js
@@ -200,7 +200,7 @@ test.describe( 'Inserting blocks (@firefox, @webkit)', () => {
 		);
 
 		await page.hover(
-			`role=listbox[name="Block Patterns"i] >> role=option[name="${ PATTERN_NAME }"i]`
+			`role=listbox[name="Patterns"i] >> role=option[name="${ PATTERN_NAME }"i]`
 		);
 
 		// FIXME: I think we should show the indicator when hovering on patterns as well?
@@ -272,7 +272,7 @@ test.describe( 'Inserting blocks (@firefox, @webkit)', () => {
 		);
 
 		await page.hover(
-			`role=listbox[name="Block Patterns"i] >> role=option[name="${ PATTERN_NAME }"i]`
+			`role=listbox[name="Patterns"i] >> role=option[name="${ PATTERN_NAME }"i]`
 		);
 
 		const paragraphBoundingBox = await paragraphBlock.boundingBox();

--- a/test/e2e/specs/site-editor/template-part.spec.js
+++ b/test/e2e/specs/site-editor/template-part.spec.js
@@ -70,7 +70,7 @@ test.describe( 'Template Part', () => {
 		await editor.insertBlock( { name: 'core/template-part' } );
 		await editor.canvas.locator( 'role=button[name="Choose"i]' ).click();
 		await page.click(
-			'role=listbox[name="Block Patterns"i] >> role=option[name="header"i]'
+			'role=listbox[name="Patterns"i] >> role=option[name="header"i]'
 		);
 
 		// There are now two header template parts.

--- a/test/e2e/specs/site-editor/template-part.spec.js
+++ b/test/e2e/specs/site-editor/template-part.spec.js
@@ -68,7 +68,7 @@ test.describe( 'Template Part', () => {
 		await editor.insertBlock( { name: 'core/template-part' } );
 		await editor.canvas.click( 'role=button[name="Choose"i]' );
 		await page.click(
-			'role=listbox[name="Block Patterns"i] >> role=option[name="header"i]'
+			'role=listbox[name="Patterns"i] >> role=option[name="header"i]'
 		);
 
 		// There are now two header template parts.


### PR DESCRIPTION
## What?

This PR replaces mentions of "Block Patterns" with "Patterns" only. 

Fixes #49617.

## Why?

There's an inconsistency in the labeling of the Patterns — sometimes it's "Pattern" while sometimes it's "Block Patterns" — and the goal would be to fix that.

## How?

I mostly searched for the mentions of "Block Patterns" and replaced them manually based on the context.

## Testing Instructions

Basically, a good step would be to search for mentions of patterns in the code and see if makes sense for these contexts.