### PR TITLE
Use consistent capitalization for template parts in Site Editor constants

### DIFF
--- a/packages/edit-site/src/utils/constants.js
+++ b/packages/edit-site/src/utils/constants.js
@@ -49,7 +49,7 @@ export const PAGE_CONTENT_BLOCK_TYPES = {
 
 export const POST_TYPE_LABELS = {
 	[ TEMPLATE_POST_TYPE ]: __( 'Template' ),
-	[ TEMPLATE_PART_POST_TYPE ]: __( 'Template Part' ),
+	[ TEMPLATE_PART_POST_TYPE ]: __( 'Template part' ),
 	[ PATTERN_TYPES.user ]: __( 'Pattern' ),
 	[ NAVIGATION_POST_TYPE ]: __( 'Navigation' ),
 };

--- a/test/e2e/specs/site-editor/writing-flow.spec.js
+++ b/test/e2e/specs/site-editor/writing-flow.spec.js
@@ -66,7 +66,7 @@ test.describe( 'Site editor writing flow', () => {
 		// Tab to the inspector, tabbing three times to go past the two resize handles.
 		await pageUtils.pressKeys( 'Tab', { times: 3 } );
 		const inspectorTemplateTab = page.locator(
-			'role=region[name="Editor settings"i] >> role=button[name="Template Part"i]'
+			'role=region[name="Editor settings"i] >> role=button[name="Template part"i]'
 		);
 		await expect( inspectorTemplateTab ).toBeFocused();
 	} );


### PR DESCRIPTION


<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Based on the efforts in https://github.com/WordPress/gutenberg/pull/51761, remove caps case from Template Part and prefer sentence case. As all instances of this string are stand alone, it's okay to have Template capitalized as it's the start of a sentence.


## Testing Instructions
Instances where the constant `POST_TYPE_LABELS[ TEMPLATE_PART_POST_TYPE ]` is used, the output should be "Template part" and not "Template Part".

Thank you!
