### PR TITLE
Make sure sync code only runs when experiment is enabled.

### DIFF
--- a/packages/core-data/src/entities.js
+++ b/packages/core-data/src/entities.js
@@ -400,7 +400,9 @@ export const getOrLoadEntitiesConfig =
 	async ( { select, dispatch } ) => {
 		let configs = select.getEntitiesConfig( kind );
 		if ( configs && configs.length !== 0 ) {
-			registerSyncConfigs( configs );
+			if ( window.__experimentalEnableSync ) {
+				registerSyncConfigs( configs );
+			}
 			return configs;
 		}
 
@@ -412,7 +414,9 @@ export const getOrLoadEntitiesConfig =
 		}
 
 		configs = await loader.loadEntities();
-		registerSyncConfigs( configs );
+		if ( window.__experimentalEnableSync ) {
+			registerSyncConfigs( configs );
+		}
 		dispatch( addEntities( configs ) );
 
 		return configs;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Wraps two calls to `registerSyncConfigs` in experiment flags so the function doesn't get called if the sync experiment is disabled from the Gutenberg experiments page.

This is an attempt to fix [this core sync issue](https://github.com/WordPress/wordpress-develop/pull/5262/files#r1332048037).


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. On trunk, with the sync experiment disabled, try commenting out the imports from the sync package in [this file](https://github.com/WordPress/gutenberg/blob/trunk/packages/core-data/src/sync.js). 
2. Verify that the post editor doesn't load.
3. On this PR branch, commenting out those imports when the sync experiment is disabled should result in the editor loading and working normally.
4. Uncomment the imports and enable the sync experiment. Open the same post in two browser tabs and check that typing in one tab, changes appear immediately in the other tab, so sync experiment is working as expected.

