### PR TITLE
Background Image control: use consistent button, ensure descriptive text accounts for no image selected

### DIFF
--- a/packages/block-editor/src/hooks/background.js
+++ b/packages/block-editor/src/hooks/background.js
@@ -5,7 +5,6 @@ import { isBlobURL } from '@wordpress/blob';
 import { getBlockSupport } from '@wordpress/blocks';
 import {
 	__experimentalToolsPanelItem as ToolsPanelItem,
-	Button,
 	DropZone,
 	FlexItem,
 	MenuItem,
@@ -25,8 +24,6 @@ import { getFilename } from '@wordpress/url';
  */
 import InspectorControls from '../components/inspector-controls';
 import MediaReplaceFlow from '../components/media-replace-flow';
-import MediaUpload from '../components/media-upload';
-import MediaUploadCheck from '../components/media-upload/check';
 import useSetting from '../components/use-setting';
 import { cleanEmptyObject } from './utils';
 import { store as blockEditorStore } from '../store';
@@ -123,11 +120,13 @@ function InspectorImagePreview( { label, filename, url: imgUrl } ) {
 						{ imgLabel }
 					</Truncate>
 					<VisuallyHidden as="span">
-						{ sprintf(
-							/* translators: %s: file name */
-							__( 'Selected image: %s' ),
-							filename
-						) }
+						{ filename
+							? sprintf(
+									/* translators: %s: file name */
+									__( 'Selected image: %s' ),
+									filename
+							  )
+							: __( 'No image selected' ) }
 					</VisuallyHidden>
 				</FlexItem>
 			</HStack>
@@ -243,55 +242,29 @@ function BackgroundImagePanelItem( props ) {
 			panelId={ clientId }
 		>
 			<div className="block-editor-hooks__background__inspector-media-replace-container">
-				{ !! url && (
-					<MediaReplaceFlow
-						mediaId={ id }
-						mediaURL={ url }
-						allowedTypes={ [ IMAGE_BACKGROUND_TYPE ] }
-						accept="image/*"
-						onSelect={ onSelectMedia }
-						name={
-							<InspectorImagePreview
-								label={ __( 'Background image' ) }
-								filename={ title }
-								url={ url }
-							/>
-						}
-						variant="secondary"
-					>
-						<MenuItem
-							onClick={ () => resetBackgroundImage( props ) }
-						>
-							{ __( 'Reset ' ) }
-						</MenuItem>
-					</MediaReplaceFlow>
-				) }
-				{ ! url && (
-					<MediaUploadCheck>
-						<MediaUpload
-							onSelect={ onSelectMedia }
-							allowedTypes={ [ IMAGE_BACKGROUND_TYPE ] }
-							render={ ( { open } ) => (
-								<div className="block-editor-hooks__background__inspector-upload-container">
-									<Button
-										onClick={ open }
-										aria-label={ __(
-											'Background image style'
-										) }
-									>
-										<InspectorImagePreview
-											label={ __( 'Background image' ) }
-										/>
-									</Button>
-									<DropZone
-										onFilesDrop={ onFilesDrop }
-										label={ __( 'Drop to upload' ) }
-									/>
-								</div>
-							) }
+				<MediaReplaceFlow
+					mediaId={ id }
+					mediaURL={ url }
+					allowedTypes={ [ IMAGE_BACKGROUND_TYPE ] }
+					accept="image/*"
+					onSelect={ onSelectMedia }
+					name={
+						<InspectorImagePreview
+							label={ __( 'Background image' ) }
+							filename={ title }
+							url={ url }
 						/>
-					</MediaUploadCheck>
-				) }
+					}
+					variant="secondary"
+				>
+					<MenuItem onClick={ () => resetBackgroundImage( props ) }>
+						{ __( 'Reset ' ) }
+					</MenuItem>
+				</MediaReplaceFlow>
+				<DropZone
+					onFilesDrop={ onFilesDrop }
+					label={ __( 'Drop to upload' ) }
+				/>
 			</div>
 		</ToolsPanelItem>
 	);

--- a/packages/block-editor/src/hooks/background.js
+++ b/packages/block-editor/src/hooks/background.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
  * WordPress dependencies
  */
 import { isBlobURL } from '@wordpress/blob';
@@ -100,7 +105,12 @@ function InspectorImagePreview( { label, filename, url: imgUrl } ) {
 		<ItemGroup as="span">
 			<HStack justify="flex-start" as="span">
 				<span
-					className="block-editor-hooks__background__inspector-image-indicator-wrapper"
+					className={ classnames(
+						'block-editor-hooks__background__inspector-image-indicator-wrapper',
+						{
+							'has-image': imgUrl,
+						}
+					) }
 					aria-hidden
 				>
 					{ imgUrl && (

--- a/packages/block-editor/src/hooks/background.scss
+++ b/packages/block-editor/src/hooks/background.scss
@@ -45,6 +45,10 @@
 	width: 20px;
 	height: 20px;
 	flex: none;
+
+	&.has-image {
+		background: #fff; // No diagonal line for non-empty background image. A background color is in use to account for partially transparent images.
+	}
 }
 
 .block-editor-hooks__background__inspector-image-indicator {

--- a/packages/block-editor/src/hooks/background.scss
+++ b/packages/block-editor/src/hooks/background.scss
@@ -1,14 +1,11 @@
-.block-editor-hooks__background__inspector-upload-container {
+.block-editor-hooks__background__inspector-media-replace-container {
 	position: relative;
 	// Since there is no option to skip rendering the drag'n'drop icon in drop
 	// zone, we hide it for now.
 	.components-drop-zone__content-icon {
 		display: none;
 	}
-}
 
-.block-editor-hooks__background__inspector-upload-container,
-.block-editor-hooks__background__inspector-media-replace-container {
 	button.components-button {
 		color: $gray-900;
 		box-shadow: inset 0 0 0 $border-width $gray-300;
@@ -34,9 +31,7 @@
 		text-align: start;
 		text-align-last: center;
 	}
-}
 
-.block-editor-hooks__background__inspector-media-replace-container {
 	.components-dropdown {
 		display: block;
 	}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Part of #54336, and a follow-up to #54439 and #53934.

Update the background image block support's control to use a consistent button (via the `MediaReplaceFlow` component) — this resolves an accessibility issue where upon selecting a media item (or closing the media library modal) focus would become lost, rather than be on the button.

This also introduces another change, which is that the dropdown menu is available from the control's empty state, rather than immediately opening the media library. This is also desirable as it sets us up for further follow-ups where one of the options in the dropdown could be to set the background image to be the post's "featured image".

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

As raised in feedback on #54439, on `trunk`, when you go to add a background image from the control's empty state, and select an image, after the image is added, focus is lost. This makes the UI harder to use for folks navigating the UI via keyboard.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* Use the `MediaReplaceFlow` component for the background image block support's empty state, in addition to when an image is applied
* Update the visually hidden text so that if no image is set, the description says "No image selected"
* Remove no-longer needed classname selectors in the styling (consolidates things slightly)

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. With TT3 theme active, add a group block with some child blocks within it to a post, page, or template.
2. Go to add a background image via keyboard. Once you've added an image, notice that the focus should be on the button again, where it isn't on trunk.
3. Go to add a background image, but press `Escape` / close the modal. The focus should be returned to the dropdown.
4. Make sure that dragging and dropping images from your computer's desktop onto the control still works (it should now also be possible to drag and drop even if the control already has an image applied, too)

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

As above, tab within the block inspector sidebar to the Background image control, and use the Enter key and cursor keys to select an image. With this PR active, you shouldn't unexpectedly experience focus loss when selecting an image.

## Screenshots or screencast <!-- if applicable -->

Screengrab of adding a background image to a Group block. Note that after an image is selected, the focus is returned to the button as expected:

https://github.com/WordPress/gutenberg/assets/14988353/5813c1b2-e5be-4f14-865f-bc41fdf3b188

This PR also tweaks the CSS slightly so that the crossed out line is only applied when no background image is set. This is noticeable when using a partially transparent image.

| Trunk (crossed out line shows through) | This PR (solid background color |
| --- | --- |
| ![image](https://github.com/WordPress/gutenberg/assets/14988353/bcf997db-dace-4328-b7fe-05b8f4f7a42a) | ![image](https://github.com/WordPress/gutenberg/assets/14988353/1b9d4144-df37-4a42-a2cf-6743abed8ae1) |