### PR TITLE
List View: Hack back in a border color for the list view drop indicator

### DIFF
--- a/packages/block-editor/src/components/list-view/drop-indicator.js
+++ b/packages/block-editor/src/components/list-view/drop-indicator.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
  * WordPress dependencies
  */
 import { Popover } from '@wordpress/components';
@@ -7,6 +12,7 @@ import { useCallback, useMemo } from '@wordpress/element';
 import { isRTL } from '@wordpress/i18n';
 
 export default function ListViewDropIndicator( {
+	dropIndicatorClassName,
 	listViewRef,
 	blockDropTarget,
 } ) {
@@ -243,7 +249,10 @@ export default function ListViewDropIndicator( {
 			animate={ false }
 			anchor={ popoverAnchor }
 			focusOnMount={ false }
-			className="block-editor-list-view-drop-indicator"
+			className={ classnames(
+				'block-editor-list-view-drop-indicator',
+				dropIndicatorClassName
+			) }
 			variant="unstyled"
 		>
 			<div

--- a/packages/block-editor/src/components/list-view/index.js
+++ b/packages/block-editor/src/components/list-view/index.js
@@ -60,12 +60,13 @@ export const BLOCK_LIST_ITEM_HEIGHT = 36;
  * @param {Object}         props                        Components props.
  * @param {string}         props.id                     An HTML element id for the root element of ListView.
  * @param {Array}          props.blocks                 _deprecated_ Custom subset of block client IDs to be used instead of the default hierarchy.
+ * @param {string}         props.dropIndicatorClassName Class name to be used for the drop indicator.
  * @param {?HTMLElement}   props.dropZoneElement        Optional element to be used as the drop zone.
  * @param {?boolean}       props.showBlockMovers        Flag to enable block movers. Defaults to `false`.
  * @param {?boolean}       props.isExpanded             Flag to determine whether nested levels are expanded by default. Defaults to `false`.
  * @param {?boolean}       props.showAppender           Flag to show or hide the block appender. Defaults to `false`.
  * @param {?ComponentType} props.blockSettingsMenu      Optional more menu substitution. Defaults to the standard `BlockSettingsDropdown` component.
- * @param {string}         props.rootClientId           The client id of the root block from which we determine the blocks to show in the list.
+ * @param {string}         props.rootClientId           The client id of the root block from which we determine the blocks to show in the list.}
  * @param {string}         props.description            Optional accessible description for the tree grid component.
  * @param {?Function}      props.onSelect               Optional callback to be invoked when a block is selected. Receives the block object that was selected.
  * @param {?ComponentType} props.additionalBlockContent Component that renders additional block content UI.
@@ -75,6 +76,7 @@ function ListViewComponent(
 	{
 		id,
 		blocks,
+		dropIndicatorClassName,
 		dropZoneElement,
 		showBlockMovers = false,
 		isExpanded = false,
@@ -256,6 +258,7 @@ function ListViewComponent(
 	return (
 		<AsyncModeProvider value={ true }>
 			<ListViewDropIndicator
+				dropIndicatorClassName={ dropIndicatorClassName }
 				listViewRef={ elementRef }
 				blockDropTarget={ blockDropTarget }
 			/>

--- a/packages/block-editor/src/components/list-view/style.scss
+++ b/packages/block-editor/src/components/list-view/style.scss
@@ -4,6 +4,10 @@
 	padding: 0;
 	margin: 0;
 
+	* {
+		box-sizing: border-box;
+	}
+
 	// Move upwards when in modal.
 	.components-modal__content & {
 		margin: (-$grid-unit-15) (-$grid-unit-15 * 0.5) 0;
@@ -431,8 +435,10 @@ $block-navigation-max-indent: 8;
 	pointer-events: none;
 
 	.block-editor-list-view-drop-indicator__line {
+		box-sizing: border-box;
 		background: var(--wp-admin-theme-color);
-		height: 4px;
+		height: 6px;
+		border: 1px solid $white;
 		border-radius: 4px;
 	}
 }

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/navigation-menu-content.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/navigation-menu-content.js
@@ -98,6 +98,7 @@ export default function NavigationMenuContent( { rootClientId } ) {
 		<>
 			{ ! isLoading && (
 				<PrivateListView
+					dropIndicatorClassName="edit-site-sidebar-navigation-screen-navigation-menus__list-view-drop-indicator"
 					rootClientId={ listViewRootClientId }
 					onSelect={ offCanvasOnselect }
 					blockSettingsMenu={ LeafMoreMenu }

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/style.scss
@@ -99,3 +99,10 @@
 .edit-site-sidebar-navigation-screen-navigation-menus__helper-block-editor {
 	display: none;
 }
+
+
+.edit-site-sidebar-navigation-screen-navigation-menus__list-view-drop-indicator {
+	.block-editor-list-view-drop-indicator__line {
+		border: 1px solid $gray-900 !important;
+	}
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Related to #52917 

🚧 🚧 🚧 WIP: I'm not sold on this approach, this PR exists for demonstration purposes 🚧 🚧 🚧 

Hack back in the border for the list view drop indicator line.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

As described in #52917, the visibility of the drop indicator line can be an issue when blocks are selected.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Try hacking the border back in there, and overriding the border color in dark mode via injecting a classname for the drop indicator line.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Select blocks in the block editor list view and drag a block over them — you should see the drop indicator has a white border again.
2. Try in dark mode via editing a navigation menu within the site editor's browse mode. The drop indicator's border should be dark here.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<img width="297" alt="image" src="https://github.com/WordPress/gutenberg/assets/14988353/96bfbbde-c5bd-466b-b1b4-91ec0df8c988">