### PR TITLE
Font Library: Fix error installing system fonts

### DIFF
--- a/packages/edit-site/src/components/global-styles/font-library-modal/collection-font-details.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/collection-font-details.js
@@ -42,7 +42,7 @@ function CollectionFontDetails( {
 						handleToggleVariant={ handleToggleVariant }
 						selected={ isFontFontFaceInOutline(
 							font.slug,
-							face,
+							font.fontFace ? face : null, // If the font has no fontFace, we want to check if the font is in the outline
 							fontToInstallOutline
 						) }
 					/>

--- a/packages/edit-site/src/components/global-styles/font-library-modal/context.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/context.js
@@ -281,14 +281,16 @@ function FontLibraryProvider( { children } ) {
 		} );
 		// Add custom fonts to the browser.
 		fontsToAdd.forEach( ( font ) => {
-			font.fontFace.forEach( ( face ) => {
-				// Load font faces just in the iframe because they already are in the document.
-				loadFontFaceInBrowser(
-					face,
-					getDisplaySrcFromFontFace( face.src ),
-					'iframe'
-				);
-			} );
+			if ( font.fontFace ) {
+				font.fontFace.forEach( ( face ) => {
+					// Load font faces just in the iframe because they already are in the document.
+					loadFontFaceInBrowser(
+						face,
+						getDisplaySrcFromFontFace( face.src ),
+						'iframe'
+					);
+				} );
+			}
 		} );
 	};
 

--- a/packages/edit-site/src/components/global-styles/font-library-modal/utils/fonts-outline.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/utils/fonts-outline.js
@@ -15,7 +15,8 @@ export function getFontsOutline( fonts ) {
 }
 
 export function isFontFontFaceInOutline( slug, face, outline ) {
-	return (
-		outline[ slug ]?.[ `${ face.fontStyle }-${ face.fontWeight }` ] || false
-	);
+	if ( ! face ) {
+		return !! outline[ slug ];
+	}
+	return !! outline[ slug ]?.[ `${ face.fontStyle }-${ face.fontWeight }` ];
 }


### PR DESCRIPTION
## What?
Fix error installing system fonts (fonts without font faces).

## Why?
Currently, if you try to install systems fonts you get an error. That shouldn't happen.

## How?
Fixing the logic when a font family doesn't have font faces.

## Testing Instructions

- Check out this branch.
- Add a font collection that provides system fonts, for example: [Modern Fonts Stacks for WordPress Font Library](https://github.com/matiasbenedetto/modern-fonts-stacks-for-wp-font-library#modern-fonts-stacks-for-wordpress-font-library)
You can do that by installing the plugin mentioned using  [this zip file](https://github.com/matiasbenedetto/modern-fonts-stacks-for-wp-font-library/archive/refs/tags/0.0.2.zip).
- Check that the font collection appears as a new tab in the font library modal.
- Install any of the fonts provided, it should work as expected.

---
If you want to compare with current version you can:
- Checkout trunk Gutenberg version.
- Check that installing any of this collection's fonts doesn't work (because system fonts in collections are failing).


## Screenshots or screencast <!-- if applicable -->
https://github.com/WordPress/gutenberg/assets/1310626/f4601e8f-6d2e-4cd4-a12a-2e4d1cd2f780