### PR TITLE
CreateTemplatePartModal: Disable the 'Create' button while saving

### DIFF
--- a/packages/edit-site/src/components/create-template-part-modal/index.js
+++ b/packages/edit-site/src/components/create-template-part-modal/index.js
@@ -60,14 +60,12 @@ export default function CreateTemplatePartModal( {
 	);
 
 	async function createTemplatePart() {
-		if ( ! title ) {
-			createErrorNotice( __( 'Please enter a title.' ), {
-				type: 'snackbar',
-			} );
+		if ( ! title || isSubmitting ) {
 			return;
 		}
 
 		try {
+			setIsSubmitting( true );
 			const uniqueTitle = getUniqueTemplatePartTitle(
 				title,
 				existingTemplateParts
@@ -99,6 +97,8 @@ export default function CreateTemplatePartModal( {
 			createErrorNotice( errorMessage, { type: 'snackbar' } );
 
 			onError?.();
+		} finally {
+			setIsSubmitting( false );
 		}
 	}
 
@@ -111,10 +111,6 @@ export default function CreateTemplatePartModal( {
 			<form
 				onSubmit={ async ( event ) => {
 					event.preventDefault();
-					if ( ! title ) {
-						return;
-					}
-					setIsSubmitting( true );
 					await createTemplatePart();
 				} }
 			>
@@ -182,7 +178,7 @@ export default function CreateTemplatePartModal( {
 						<Button
 							variant="primary"
 							type="submit"
-							disabled={ ! title }
+							aria-disabled={ ! title || isSubmitting }
 							isBusy={ isSubmitting }
 						>
 							{ __( 'Create' ) }


### PR DESCRIPTION
## What?
PR updates logic in `CreateTemplatePartModal` to prevent submitting the form multiple times.

## Why?
Users on slow connections could click the "Create" button multiple times while creating the template part. This results in duplicate entities.

## How?
* Update conditions for the button's disabled state and use `aria-disabled` to prevent focus loss while creating the template part.
* Bail early in the `createTemplatePart` method when the button should be disabled.

## Testing Instructions
1. Go to `wp-admin/site-editor.php?path=/wp_template_part/all`
2. Click the "Add New Template Part" button in the header.
3. Trottle a network.
4. Confirm that clicking the "Create" button doesn't create duplicate template parts.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

![CleanShot 2023-09-22 at 11 06 21](https://github.com/WordPress/gutenberg/assets/240569/1602e76c-e9d9-4dd6-9ca0-73c02bd8d93d)
