### PR TITLE
Patterns: Require a title in the creation modal

### DIFF
--- a/packages/patterns/src/components/create-pattern-modal.js
+++ b/packages/patterns/src/components/create-pattern-modal.js
@@ -43,7 +43,9 @@ export default function CreatePatternModal( {
 	const { createErrorNotice } = useDispatch( noticesStore );
 
 	async function onCreate( patternTitle, sync ) {
-		if ( isSaving ) return;
+		if ( ! title || isSaving ) {
+			return;
+		}
 
 		try {
 			setIsSaving( true );
@@ -155,7 +157,7 @@ export default function CreatePatternModal( {
 						<Button
 							variant="primary"
 							type="submit"
-							aria-disabled={ isSaving }
+							aria-disabled={ ! title || isSaving }
 							isBusy={ isSaving }
 						>
 							{ __( 'Create' ) }


### PR DESCRIPTION
## What?
Fixes #54693.

PR updates pattern creation logic in the modal and makes the title a requirement.

## Why?
While WP allows post-type creation without titles, patterns are probably not very useful without them. This also matches the template part creation flow.

P.S. The post-editor template creation uses a fallback title, but I think this method is better.

## Testing Instructions
1. Open a post or page. 
2. Add a block.
3. Select "Create pattern" from block options.
4. Verify that the "Create" button is disabled when the empty title field.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2023-09-22 at 11 44 56](https://github.com/WordPress/gutenberg/assets/240569/c8b2a593-792b-49b7-896f-6cfb3ef9812c)
