### PR TITLE
Block Hooks: Avoid processing empty content for loaded templates

### DIFF
--- a/lib/compat/wordpress-6.4/block-hooks.php
+++ b/lib/compat/wordpress-6.4/block-hooks.php
@@ -247,7 +247,7 @@ function gutenberg_add_block_hooks_field_to_block_type_controller( $inserted_blo
  */
 function gutenberg_parse_and_serialize_block_templates( $query_result ) {
 	foreach ( $query_result as $block_template ) {
-		if ( 'custom' === $block_template->source ) {
+		if ( empty( $block_template->content ) || 'custom' === $block_template->source ) {
 			continue;
 		}
 		$blocks                  = parse_blocks( $block_template->content );
@@ -270,6 +270,9 @@ add_filter( 'get_block_templates', 'gutenberg_parse_and_serialize_block_template
  * @param WP_Block_Template|null $block_template The found block template, or null if there is none.
  */
 function gutenberg_parse_and_serialize_blocks( $block_template ) {
+	if ( empty( $block_template->content ) ) {
+		return $block_template;
+	}
 
 	$blocks                  = parse_blocks( $block_template->content );
 	$block_template->content = gutenberg_serialize_blocks( $blocks );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

The changes applied for Block Hooks cause processing the content a value to return differently (`content`: `""` instead of `null`) even when the template doesn't exist. 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Filters used for injecting hooked blocks didn't check whether the content is non empty.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Additional checks are added to ensure that the logic for Block Hooks runs only when the content of the template is non-empty.