### PR TITLE
Update cherry-pick script to correctly verify GitHub CLI setup

### DIFF
--- a/bin/cherry-pick.mjs
+++ b/bin/cherry-pick.mjs
@@ -9,7 +9,7 @@ import { spawnSync } from 'node:child_process';
 const LABEL = process.argv[ 2 ] || 'Backport to WP Beta/RC';
 const BRANCH = getCurrentBranch();
 const GITHUB_CLI_AVAILABLE = spawnSync( 'gh', [ 'auth', 'status' ] )
-	?.stderr?.toString()
+	?.stdout?.toString()
 	.includes( '✓ Logged in to github.com as' );
 
 const AUTO_PROPAGATE_RESULTS_TO_GITHUB = GITHUB_CLI_AVAILABLE;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
I noticed when running the `npm run other:cherry-pick` script that the check fails for GitHub CLI being setup correctly on your local machine.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Fix the `npm run other:cherry-pick` script to make it easier to cherry-pick commits.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Swaps `stderr` for `stdout` in the `spawnSync` response.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Ensure that you have the GitHub CLI setup: https://cli.github.com/
2. Manually run `gh auth status` to check that the response includes "✓ Logged in to github.com as [username]"
3. Run `npm run other:cherry-pick "Backport to Gutenberg RC"`
4. Check that the script can continue beyond the GitHub CLI check; you shouldn't see the "Github CLI is not setup." message
