### PR TITLE
Patterns: Fix All Patterns category default display

### DIFF
--- a/packages/edit-site/src/components/page-patterns/index.js
+++ b/packages/edit-site/src/components/page-patterns/index.js
@@ -18,7 +18,7 @@ const { ExperimentalBlockEditorProvider } = unlock( blockEditorPrivateApis );
 
 export default function PagePatterns() {
 	const { categoryType, categoryId } = getQueryArgs( window.location.href );
-	const type = categoryType || PATTERN_TYPES.user;
+	const type = categoryType || PATTERN_TYPES.theme;
 	const category = categoryId || PATTERN_DEFAULT_CATEGORY;
 	const settings = usePatternSettings();
 


### PR DESCRIPTION
Related:
- https://github.com/WordPress/gutenberg/pull/54484

## What?

Fixes regression in "All Patterns" display when it is the default category before a selection is made.

## Why?

It's broken and doesn't match the correct count next to the All Patterns category in the sidebar navigation.

## How?

Assign the original default pattern type back on the patterns page.

- Original type was `DEFAULT_TYPE` set [here](https://github.com/WordPress/gutenberg/pull/54484/files#diff-6bf3516e0ae1bb3480576679a3d438ee8d381a33ab4b521e123c348e7614750fL21)
- The value of `DEFAULT_TYPE` was originally set [here](https://github.com/WordPress/gutenberg/pull/54484/files#diff-1a918c26a230e72dac0256bf17fbd30345d5fab8c78064aa98f21796f97a60f4L3-L4)
- The [new `PATTERN_TYPES.theme`](https://github.com/WordPress/gutenberg/pull/54484/files#diff-9c023b571e7096ee646e148e20f4bb1454bdfcf0aceefc2a2b613cd604ebca65R2) value matches the original default so that's what it was switched to

## Testing Instructions

1. Replicte the original issue on trunk: navigate Appearance > Patterns and note that only user patterns are shown 
2. Check out this PR and repeat the process, all the theme patterns should appear correctly
3. Confirm the total patterns displayed matches the count next to the category


## Screenshots or screencast <!-- if applicable -->

| Before | After |
|---|---|
| <video src="https://github.com/WordPress/gutenberg/assets/60436221/fa8cfba9-bb56-42fd-8824-78cf4b44fcb8" /> | <video src="https://github.com/WordPress/gutenberg/assets/60436221/96e26134-95ad-48ce-be35-72cf2eb5cfb8" /> |






