### PR TITLE
Editor: Always render the 'Switch to Draft' button to avoid focus loss

### DIFF
--- a/packages/editor/src/components/post-switch-to-draft-button/index.js
+++ b/packages/editor/src/components/post-switch-to-draft-button/index.js
@@ -28,9 +28,7 @@ export default function PostSwitchToDraftButton() {
 		};
 	}, [] );
 
-	if ( ! isPublished && ! isScheduled ) {
-		return null;
-	}
+	const isDisabled = isSaving || ( ! isPublished && ! isScheduled );
 
 	let alertMessage;
 	if ( isPublished ) {
@@ -50,9 +48,11 @@ export default function PostSwitchToDraftButton() {
 			<Button
 				className="editor-post-switch-to-draft"
 				onClick={ () => {
-					setShowConfirmDialog( true );
+					if ( ! isDisabled ) {
+						setShowConfirmDialog( true );
+					}
 				} }
-				disabled={ isSaving }
+				aria-disabled={ isDisabled }
 				variant="secondary"
 				style={ { flexGrow: '1', justifyContent: 'center' } }
 			>


### PR DESCRIPTION
## What?
Fixes #51901.

PR updates the `PostSwitchToDraftButton` component always to render to button, but using a disabled state when switching to draft isn't possible.

## Why?
See #51901.

> Instead, with the new placement of the Switch to Draft button in the settings panel, users are now forced to navigate almost the entire editor UI to go back where they were.

> The expected behavior is that focus is returned to the UI control that opened the modal dialog. As such, the 'Switch to Draft' button should not be removed from the DOM. Ideally, it shoul dstay in the DOM, be still focusable, use an aria-disabled attribute and 'noop'. See: ARIA Authoring Practices: [Focusability of disabled controls](https://www.w3.org/WAI/ARIA/apg/practices/keyboard-interface/#focusabilityofdisabledcontrols).

## How?
* Updates button to use `aria-disabled` instead of `disabled` prop.
* Noops the `onClick` callback when the button is disabled.

## Testing Instructions
1. Open a published or scheduled post.
2. Navigate to the "Switch to Draft" button in document settings.
3. Switch the post to draft.
4. Verify that the button is visible, but has a disabled state.

### Testing Instructions for Keyboard
Same

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/240569/e830a441-7d75-4ea6-bd3d-5e37e4d99d05


