### PR TITLE
Workflows: Make 'Enforce labels on PRs' action less strict

### DIFF
--- a/.github/workflows/enforce-pr-labels.yml
+++ b/.github/workflows/enforce-pr-labels.yml
@@ -10,7 +10,7 @@ jobs:
         steps:
             - uses: mheap/github-action-required-labels@v5
               with:
-                  mode: exactly
+                  mode: minimum
                   count: 1
                   labels: '[Type] Accessibility (a11y), [Type] Automated Testing, [Type] Breaking Change, [Type] Bug, [Type] Build Tooling, [Type] Code Quality, [Type] Copy, [Type] Developer Documentation, [Type] Enhancement, [Type] Experimental, [Type] Feature, [Type] New API, [Type] Task, [Type] Performance, [Type] Project Management, [Type] Regression, [Type] Security, [Type] WP Core Ticket, Backport from WordPress Core'
                   add_comment: true


### PR DESCRIPTION
## What?
When setting two labels for change type - [Type] {type}, I noticed that the action was producing a failure.

The PR makes the action less strict by changing the `mode` to [`minimum`](https://github.com/mheap/github-action-required-labels#require-multiple-labels). This way, it will require at least one label from the list, but it won't fail when more are provided.

## Why?
Some changes can span across multiple type groups. Examples:

* `[Type] a11y` change can be a bug fix or an enhancement.
* `[Type] Bug` can also introduce a breaking change in code

## Testing Instructions
These changes are hard to test in the repo. But I double-checked this would be expected behavior in [the action's tests](https://github.com/mheap/github-action-required-labels/blob/main/index.test.js).