### PR TITLE
Patterns: Reinstate my patterns category in site editor

### DIFF
--- a/packages/edit-site/src/components/page-patterns/search-items.js
+++ b/packages/edit-site/src/components/page-patterns/search-items.js
@@ -7,7 +7,11 @@ import { noCase } from 'change-case';
 /**
  * Internal dependencies
  */
-import { PATTERN_DEFAULT_CATEGORY } from '../../utils/constants';
+import {
+	PATTERN_DEFAULT_CATEGORY,
+	PATTERN_USER_CATEGORY,
+	PATTERN_TYPES,
+} from '../../utils/constants';
 
 // Default search helpers.
 const defaultGetName = ( item ) => item.name || '';
@@ -141,6 +145,8 @@ function getItemSearchRank( item, searchTerm, config ) {
 
 	let rank =
 		categoryId === PATTERN_DEFAULT_CATEGORY ||
+		( categoryId === PATTERN_USER_CATEGORY &&
+			item.type === PATTERN_TYPES.user ) ||
 		hasCategory( item, categoryId )
 			? 1
 			: 0;

--- a/packages/edit-site/src/components/sidebar-navigation-screen-patterns/use-pattern-categories.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-patterns/use-pattern-categories.js
@@ -13,6 +13,7 @@ import usePatterns from '../page-patterns/use-patterns';
 import {
 	PATTERN_TYPES,
 	PATTERN_DEFAULT_CATEGORY,
+	PATTERN_USER_CATEGORY,
 	TEMPLATE_PART_AREA_DEFAULT_CATEGORY,
 } from '../../utils/constants';
 
@@ -84,12 +85,20 @@ export default function usePatternCategories() {
 		const sortedCategories = categoriesWithCounts.sort( ( a, b ) =>
 			a.label.localeCompare( b.label )
 		);
+
+		sortedCategories.unshift( {
+			name: PATTERN_USER_CATEGORY,
+			label: __( 'My patterns' ),
+			count: userPatterns.length,
+		} );
+
 		sortedCategories.unshift( {
 			name: PATTERN_DEFAULT_CATEGORY,
-			label: __( 'All Patterns' ),
+			label: __( 'All patterns' ),
 			description: __( 'A list of all patterns from all sources' ),
 			count: themePatterns.length + userPatterns.length,
 		} );
+
 		return sortedCategories;
 	}, [
 		defaultCategories,

--- a/packages/edit-site/src/utils/constants.js
+++ b/packages/edit-site/src/utils/constants.js
@@ -26,6 +26,7 @@ export const TEMPLATE_PART_AREA_DEFAULT_CATEGORY = 'uncategorized';
 export const {
 	PATTERN_TYPES,
 	PATTERN_DEFAULT_CATEGORY,
+	PATTERN_USER_CATEGORY,
 	PATTERN_CORE_SOURCES,
 	PATTERN_SYNC_TYPES,
 } = unlock( patternPrivateApis );

--- a/packages/patterns/src/constants.js
+++ b/packages/patterns/src/constants.js
@@ -4,6 +4,7 @@ export const PATTERN_TYPES = {
 };
 
 export const PATTERN_DEFAULT_CATEGORY = 'all-patterns';
+export const PATTERN_USER_CATEGORY = 'my-patterns';
 export const PATTERN_CORE_SOURCES = [
 	'core',
 	'pattern-directory/core',

--- a/packages/patterns/src/private-apis.js
+++ b/packages/patterns/src/private-apis.js
@@ -7,6 +7,7 @@ import PatternsMenuItems from './components';
 import {
 	PATTERN_TYPES,
 	PATTERN_DEFAULT_CATEGORY,
+	PATTERN_USER_CATEGORY,
 	PATTERN_CORE_SOURCES,
 	PATTERN_SYNC_TYPES,
 } from './constants';
@@ -17,6 +18,7 @@ lock( privateApis, {
 	PatternsMenuItems,
 	PATTERN_TYPES,
 	PATTERN_DEFAULT_CATEGORY,
+	PATTERN_USER_CATEGORY,
 	PATTERN_CORE_SOURCES,
 	PATTERN_SYNC_TYPES,
 } );


### PR DESCRIPTION
_**NOTE: This PR only reinstates the My Patterns category, sync status filtering is being addressed separately.**_

## What?

Reinstates the "My patterns" category in the site editor's pattern library as an easy place for users to see all their custom patterns at once.

## Why?

Feedback has been provided that this category was missed after the addition of custom user-created pattern categories removed it in favour of an "All patterns" category.

## How?

- Add the "My patterns" category back to the use pattern categories hook
- Update the search items filtering for patterns to handle the "My patterns" category
- Add a new constant for the "My patterns" category name

## Testing Instructions

1. Navigate to Appearance > Patterns
2. Confirm the presence of the My Patterns category
3. Select that category and confirm the correct user patterns are displayed
4. Test the search and sync status filtering of the My Patterns category works as expected
5. Select a user created pattern to view or edit and ensure that returning to the patterns page has My patterns selected

**When returning to the Patterns page the sync status filters will be missing. A fix for this is available in https://github.com/WordPress/gutenberg/pull/54753**

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/60436221/dea9de3a-5b45-4dc3-bca9-7801c7b9c656


