### PR TITLE
[Site Editor]: Update copy of using  the default template in a page

### DIFF
--- a/packages/edit-site/src/components/sidebar-edit-mode/page-panels/reset-default-template.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/page-panels/reset-default-template.js
@@ -37,7 +37,7 @@ export default function ResetDefaultTemplate( { onClick } ) {
 					} );
 				} }
 			>
-				{ __( 'Reset' ) }
+				{ __( 'Use default template' ) }
 			</MenuItem>
 		</MenuGroup>
 	);

--- a/test/e2e/specs/site-editor/pages.spec.js
+++ b/test/e2e/specs/site-editor/pages.spec.js
@@ -190,7 +190,7 @@ test.describe( 'Pages', () => {
 		await templateOptionsButton.click();
 		const resetButton = page
 			.getByRole( 'menu', { name: 'Template options' } )
-			.getByText( 'Reset' );
+			.getByText( 'Use default template' );
 		await expect( resetButton ).toBeVisible();
 		await resetButton.click();
 		await expect( templateOptionsButton ).toHaveText( 'Single Entries' );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Resolves: https://github.com/WordPress/gutenberg/issues/54572

This PR just updates the copy of the `reset` button that results in using the default template of a page, based on the template hierarchy.




## Testing Instructions
In site editor go to a page that has not the default template assigned(or just use the `swap template` button) and observe that the copy to use the default template has been changed from `Reset` to `Use default template`.
