### PR TITLE
Query Loop: Select first anchor inside Post Template with "enhanced pagination" enabled

### DIFF
--- a/packages/block-library/src/query/view.js
+++ b/packages/block-library/src/query/view.js
@@ -64,11 +64,8 @@ store( {
 						context.core.query.animation = 'finish';
 
 						// Focus the first anchor of the Query block.
-						document
-							.querySelector(
-								`[data-wp-navigation-id=${ id }] a[href]`
-							)
-							?.focus();
+						const firstAnchor = `[data-wp-navigation-id=${ id }] .wp-block-post-template a[href]`;
+						document.querySelector( firstAnchor )?.focus();
 					}
 				},
 				prefetch: async ( { ref } ) => {


### PR DESCRIPTION
## What?

Fixes focus after navigating through a Query Loop with "enhanced pagination" enabled. It should be on the first link inside the Post Template block.

## Why?

To go back to the newly loaded results as mentioned in https://github.com/WordPress/gutenberg/pull/53812#discussion_r1312092555.

## How?

Just adding the `wp-block-post-template` class to the first anchor selector.

## Testing Instructions

To reproduce the problem (without these changes):
1. In the site editor, open the Blog Home template.
2. Enable "enhanced pagination" in the Query Loop block settings.
3. Inside the Query Loop block, move the Pagination block above the Post Template one.
4. Save the changes.
5. Visit the site's homepage.
6. Click on "Older Posts".
7. Focus is on the "Newer Posts" link (it should be on the first link inside the Post Template block).

To check the problem is fixed:
1. Repeat steps 1 to 6.
2. Ensure the focus is on the first link inside the Post Template block.

## Screenshots or screencast

| Before | After |
| --- | --- |
| <video src="https://github.com/WordPress/gutenberg/assets/6917969/1caf1319-1164-4563-ae84-23ea9d8a5d6a"></video> | <video src="https://github.com/WordPress/gutenberg/assets/6917969/26bdca7d-b146-4b13-a1e1-fb61e0032062"></video> |




