### PR TITLE
Patterns: Use slug as fallback for empty title

### DIFF
--- a/packages/edit-site/src/components/page-patterns/duplicate-menu-item.js
+++ b/packages/edit-site/src/components/page-patterns/duplicate-menu-item.js
@@ -156,7 +156,7 @@ export default function DuplicateMenuItem( {
 			const title = sprintf(
 				/* translators: %s: Existing pattern title */
 				__( '%s (Copy)' ),
-				item.title
+				item.title || item.name
 			);
 			const categories = await getCategories( item.categories );
 
@@ -179,7 +179,7 @@ export default function DuplicateMenuItem( {
 				sprintf(
 					// translators: %s: The new pattern's title e.g. 'Call to action (copy)'.
 					__( '"%s" duplicated.' ),
-					item.title
+					item.title || item.name
 				),
 				{
 					type: 'snackbar',

--- a/packages/edit-site/src/components/page-patterns/grid-item.js
+++ b/packages/edit-site/src/components/page-patterns/grid-item.js
@@ -113,14 +113,14 @@ function GridItem( { categoryId, item, ...props } ) {
 	const exportAsJSON = () => {
 		const json = {
 			__file: item.type,
-			title: item.title,
+			title: item.title || item.name,
 			content: item.patternBlock.content.raw,
 			syncStatus: item.patternBlock.wp_pattern_sync_status,
 		};
 
 		return downloadjs(
 			JSON.stringify( json, null, 2 ),
-			`${ kebabCase( item.title ) }.json`,
+			`${ kebabCase( item.title || item.name ) }.json`,
 			'application/json'
 		);
 	};
@@ -160,7 +160,7 @@ function GridItem( { categoryId, item, ...props } ) {
 		: sprintf(
 				// translators: %s: The pattern or template part's title e.g. 'Call to action'.
 				__( 'Are you sure you want to delete "%s"?' ),
-				item.title
+				item.title || item.name
 		  );
 
 	const additionalStyles = ! backgroundColor
@@ -246,7 +246,7 @@ function GridItem( { categoryId, item, ...props } ) {
 									// See https://github.com/WordPress/gutenberg/pull/51898#discussion_r1243399243.
 									tabIndex="-1"
 								>
-									{ item.title }
+									{ item.title || item.name }
 								</Button>
 							</Heading>
 						) }


### PR DESCRIPTION
Recloses #54693

## What?

This PR solves the following problem by using a slug as a fallback when the pattern doesn't have a title.

- Title is not displayed in the pattern library
- When deleting a pattern, the title part is blank in the confirmation dialog box
- When exporting a pattern, the file name is `json.json`
- Import fails because the title of the exported file is an empty string

## Why?

In #54717, it is now required to enter a title when creating a pattern. However, by accessing `edit.php?post_type=wp_block`, you can update the title to empty just like a normal post.

Therefore, we need a fallback that assumes the title is empty.

## How?

If there is no title for the pattern, use the slug.

## Testing Instructions

### Preparation

- Create patterns **with categories**. (If you don't have a category, you'll get an error like the one reported in [#54729](https://github.com/WordPress/gutenberg/issues/54729) when duplicating the pattern)
- Click "Manage all of my patterns".
- Empty the title of the created pattern.
- Enter some content into the pattern and save.
- Visit the patterns page in the sSite Editor.

### Title in the Patterns Library

- trunk: The title of the created pattern should be empty.
- This PR: The slug should be displayed instead of the title.

### Delete Pattern

Note: Attempt to delete the pattern, but do not actually delete it.

- trunk: You should see `Are you sure you want to delete ""?`.
- This PR: You should see `Are you sure you want to delete "my-pattern"?`.

### Duplicate Pattern

- trunk: should display as `"" duplicated.` and the new pattern title should display as `(Copy)`.
- This PR: `"{slug}" duplicated.` should be displayed and the new pattern title should be displayed as `{slug} (Copy)`.

### Exporting Pattern

- trunk: The exported file name should be `json.json`.
- This PR: The exported file name should be `{slug}.json`.

### Import Pattern

- trunk: The pattern import should fail.
- This PR: The pattern import should be successful.