### PR TITLE
FormTokenField: Add `box-sizing` reset style and reset default padding

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 -   `Placeholder`: Improved DOM structure and screen reader announcements ([#45801](https://github.com/WordPress/gutenberg/pull/45801)).
 -   `DateTimePicker`: fix onChange callback check so that it also works inside iframes ([#54669](https://github.com/WordPress/gutenberg/pull/54669)).
+-   `FormTokenField`: Add `box-sizing` reset style and reset default padding ([#54734](https://github.com/WordPress/gutenberg/pull/54734)).
 
 ### Internal
 

--- a/packages/components/src/form-token-field/style.scss
+++ b/packages/components/src/form-token-field/style.scss
@@ -164,6 +164,7 @@
 	list-style: none;
 	box-shadow: inset 0 $border-width 0 0 $gray-600; // Matches the border color of the input.
 	margin: 0;
+	padding: 0;
 }
 
 .components-form-token-field__suggestion {
@@ -174,6 +175,7 @@
 	min-height: $button-size-compact;
 	margin: 0;
 	cursor: pointer;
+	box-sizing: border-box;
 
 	&.is-selected {
 		background: $components-color-accent;


### PR DESCRIPTION
## What?

This PR resolves the following three issues in the `FormTokenField` component:

- The suggestion list has default padding of `ul` element on the left side
- The suggestion list items are not as high as expected.

As a result, the same problem is resolved for the `ComboBoxControl` that includes this component.

| Before | After |
|--------|--------|
| ![form-token-field-before](https://github.com/WordPress/gutenberg/assets/54422211/a8795ac1-d02b-4d55-9b34-025c18ee39a2) | ![form-token-field-after](https://github.com/WordPress/gutenberg/assets/54422211/6b1270ae-65ff-43db-9b37-9edb1cd51eab) |
| ![combo-box-control-before](https://github.com/WordPress/gutenberg/assets/54422211/6104fb5b-c238-458d-a5be-3f6321b86f5b) | ![combo-box-control-after](https://github.com/WordPress/gutenberg/assets/54422211/ac4c0411-7240-4827-a085-aeae8722d461) | 

## Why?

This issue does not occur on the block editor. Because reset styles such as post editor and WP-Admin are applied to these elements.

## How?

Added styles to fix unintended appearance.

## Testing Instructions

- Run Storybook.
- In the `FormTokenField` and `ComboBoxControl` components, enter characters that match the suggestion list.
- Confirm that the suggestion list is displayed as you intended.
- Inject WordPress style from the top toolbar.
- There should be no change in the appearance of the component.