### PR TITLE
Format Library: Try to fix highlight popover jumping

### DIFF
--- a/packages/format-library/src/text-color/inline.js
+++ b/packages/format-library/src/text-color/inline.js
@@ -137,6 +137,11 @@ export default function InlineColorUI( {
 	onClose,
 	contentRef,
 } ) {
+	const popoverAnchor = useAnchor( {
+		editableContentElement: contentRef.current,
+		settings,
+	} );
+
 	/*
 	 As you change the text color by typing a HEX value into a field,
 	 the return value of document.getSelection jumps to the field you're editing,
@@ -144,12 +149,8 @@ export default function InlineColorUI( {
 	 it will return null, since it can't find the <mark> element within the HEX input.
 	 This caches the last truthy value of the selection anchor reference.
 	 */
-	const popoverAnchor = useCachedTruthy(
-		useAnchor( {
-			editableContentElement: contentRef.current,
-			settings,
-		} )
-	);
+	const cachedRect = useCachedTruthy( popoverAnchor.getBoundingClientRect() );
+	popoverAnchor.getBoundingClientRect = () => cachedRect;
 
 	return (
 		<Popover


### PR DESCRIPTION
Fixes: #49286

## What?

This PR attempts to resolve an issue where popovers jump when applying inline highlighting to text.

## Why?

This popover caches the `popoverAnchor` to maintain its position and prevent "jumping" when the inline highlight is applied.

However, as mentioned in [this comment](https://github.com/WordPress/gutenberg/issues/49286#issuecomment-1497592542) by @ciampo, when text is surrounded by the `mark` element, the position seems to be out of sync for some reason.

## How?

I'm not sure if this approach is ideal, but caching only `getBoundingClientRect()` seems to solve the problem. If you have a more ideal approach, please let me know.

## Testing Instructions

- Enter text on the block editor.
- Select some text and choose "Highlight" from the block toolbar.
- Choose a palette, select a custom color, or enter a HEX color in the color popover.
- The popover should be in the same position.