### PR TITLE
Footnotes/Edit Site: fix focus in fn insert

### DIFF
--- a/packages/block-editor/src/components/provider/use-block-sync.js
+++ b/packages/block-editor/src/components/provider/use-block-sync.js
@@ -3,7 +3,6 @@
  */
 import { useEffect, useRef } from '@wordpress/element';
 import { useRegistry, useSelect } from '@wordpress/data';
-import { cloneBlock } from '@wordpress/blocks';
 
 /**
  * Internal dependencies

--- a/packages/block-editor/src/components/provider/use-block-sync.js
+++ b/packages/block-editor/src/components/provider/use-block-sync.js
@@ -111,9 +111,7 @@ export default function useBlockSync( {
 			// before the actual blocks get set properly in state.
 			registry.batch( () => {
 				setHasControlledInnerBlocks( clientId, true );
-				const storeBlocks = controlledBlocks.map( ( block ) =>
-					cloneBlock( block )
-				);
+				const storeBlocks = controlledBlocks.map( ( block ) => block );
 				if ( subscribed.current ) {
 					pendingChanges.current.incoming = storeBlocks;
 				}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This fixes the issues but @youknowriad says it's necessary because otherwise it breaks using reusable blocks multiple times. So we need to figure out a different solution here.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
