### PR TITLE
Enhancement/update button component aria pressed revised

### DIFF
--- a/packages/block-editor/src/hooks/block-rename-ui.js
+++ b/packages/block-editor/src/hooks/block-rename-ui.js
@@ -69,6 +69,7 @@ function RenameModal( { blockName, originalBlockName, onClose, onSave } ) {
 			aria={ {
 				describedby: dialogDescription,
 			} }
+			focusOnMount="firstContentElement"
 		>
 			<p id={ dialogDescription }>
 				{ __( 'Enter a custom name for this block.' ) }

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Enhancements
 
+-   Add new option `firstContentElement` to Modal's `focusOnMount` prop to allow consumers to focus the first element within the Modal's **contents** ([#54590](https://github.com/WordPress/gutenberg/pull/54590)).
 -   `Notice`: Improve accessibility by adding visually hidden text to clarify what a notice text is about and the notice type (success, error, warning, info) ([#54498](https://github.com/WordPress/gutenberg/pull/54498)).
 -   Making Circular Option Picker a `listbox`. Note that while this changes some public API, new props are optional, and currently have default values; this will change in another patch ([#52255](https://github.com/WordPress/gutenberg/pull/52255)).
 -   `ToggleGroupControl`: Rewrite backdrop animation using framer motion shared layout animations, add better support for controlled and uncontrolled modes ([#50278](https://github.com/WordPress/gutenberg/pull/50278)).

--- a/packages/components/src/button/README.md
+++ b/packages/components/src/button/README.md
@@ -186,6 +186,8 @@ Renders a red text-based button style to indicate destructive behavior.
 
 Renders a pressed button style.
 
+Deprecated in favor of the native `aria-pressed` prop. If both props are defined, the `aria-pressed` prop will take precedence.
+
 -   Required: No
 
 #### `isSmall`: `boolean`

--- a/packages/components/src/button/index.tsx
+++ b/packages/components/src/button/index.tsx
@@ -34,6 +34,7 @@ function useDeprecatedProps( {
 	isSecondary,
 	isTertiary,
 	isLink,
+	isPressed,
 	isSmall,
 	size,
 	variant,
@@ -41,6 +42,9 @@ function useDeprecatedProps( {
 }: ButtonProps & DeprecatedButtonProps ): ButtonProps {
 	let computedSize = size;
 	let computedVariant = variant;
+	const newProps: { 'aria-pressed'?: boolean } = {
+		'aria-pressed': isPressed,
+	};
 
 	if ( isSmall ) {
 		computedSize ??= 'small';
@@ -72,7 +76,14 @@ function useDeprecatedProps( {
 		computedVariant ??= 'link';
 	}
 
+	if ( isPressed ) {
+		deprecated( 'Button isPressed prop', {
+			alternative: 'aria-pressed={ true }',
+		} );
+	}
+
 	return {
+		...newProps,
 		...otherProps,
 		size: computedSize,
 		variant: computedVariant,
@@ -85,7 +96,6 @@ export function UnforwardedButton(
 ) {
 	const {
 		__next40pxDefaultSize,
-		isPressed,
 		isBusy,
 		isDestructive,
 		className,
@@ -106,10 +116,16 @@ export function UnforwardedButton(
 		...buttonOrAnchorProps
 	} = useDeprecatedProps( props );
 
-	const { href, target, ...additionalProps } =
-		'href' in buttonOrAnchorProps
-			? buttonOrAnchorProps
-			: { href: undefined, target: undefined, ...buttonOrAnchorProps };
+	const {
+		href,
+		target,
+		'aria-checked': ariaChecked,
+		'aria-pressed': ariaPressed,
+		'aria-selected': ariaSelected,
+		...additionalProps
+	} = 'href' in buttonOrAnchorProps
+		? buttonOrAnchorProps
+		: { href: undefined, target: undefined, ...buttonOrAnchorProps };
 
 	const instanceId = useInstanceId(
 		Button,
@@ -131,7 +147,17 @@ export function UnforwardedButton(
 		'is-small': size === 'small',
 		'is-compact': size === 'compact',
 		'is-tertiary': variant === 'tertiary',
-		'is-pressed': isPressed,
+
+		// Including these classes for consistency and legacy purposes.
+		// `is-pressed` was added by the (deprecated) `isPressed` prop.
+		// Component styling is tied to the value of the respective
+		// `aria-*` attributes.
+		'is-checked': ariaChecked && ariaChecked !== 'false',
+		'is-checked-mixed': ariaChecked === 'mixed',
+		'is-pressed': ariaPressed && ariaPressed !== 'false',
+		'is-pressed-mixed': ariaPressed === 'mixed',
+		'is-selected': ariaSelected && ariaSelected !== 'false',
+
 		'is-busy': isBusy,
 		'is-link': variant === 'link',
 		'is-destructive': isDestructive,
@@ -146,7 +172,9 @@ export function UnforwardedButton(
 			? {
 					type: 'button',
 					disabled: trulyDisabled,
-					'aria-pressed': isPressed,
+					'aria-checked': ariaChecked,
+					'aria-pressed': ariaPressed,
+					'aria-selected': ariaSelected,
 			  }
 			: {};
 	const anchorProps: ComponentPropsWithoutRef< 'a' > =

--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -308,7 +308,11 @@
 	}
 
 	// Toggled style.
-	&.is-pressed {
+	&[aria-checked="true"],
+	&[aria-checked="mixed"],
+	&[aria-pressed="true"],
+	&[aria-pressed="mixed"],
+	&[aria-selected="true"] {
 		color: $components-color-foreground-inverted;
 		background: $components-color-foreground;
 

--- a/packages/components/src/button/test/index.tsx
+++ b/packages/components/src/button/test/index.tsx
@@ -28,7 +28,9 @@ describe( 'Button', () => {
 			expect( button ).toHaveClass( 'components-button' );
 			expect( button ).not.toHaveClass( 'is-large' );
 			expect( button ).not.toHaveClass( 'is-primary' );
+			expect( button ).not.toHaveClass( 'is-checked' );
 			expect( button ).not.toHaveClass( 'is-pressed' );
+			expect( button ).not.toHaveClass( 'is-selected' );
 			expect( button ).toBeEnabled();
 			expect( button ).not.toHaveAttribute( 'aria-disabled' );
 			expect( button ).toHaveAttribute( 'type', 'button' );
@@ -72,10 +74,38 @@ describe( 'Button', () => {
 			expect( button ).toHaveClass( 'is-link' );
 		} );
 
+		it( 'should render a button element with is-checked without button class', () => {
+			render( <Button aria-checked /> );
+
+			expect( screen.getByRole( 'button' ) ).toHaveClass( 'is-checked' );
+		} );
+
+		it( 'should render a button element with is-checked-mixed without button class', () => {
+			render( <Button aria-checked="mixed" /> );
+
+			expect( screen.getByRole( 'button' ) ).toHaveClass(
+				'is-checked is-checked-mixed'
+			);
+		} );
+
 		it( 'should render a button element with is-pressed without button class', () => {
-			render( <Button isPressed /> );
+			render( <Button aria-pressed /> );
 
 			expect( screen.getByRole( 'button' ) ).toHaveClass( 'is-pressed' );
+		} );
+
+		it( 'should render a button element with is-pressed-mixed without button class', () => {
+			render( <Button aria-pressed="mixed" /> );
+
+			expect( screen.getByRole( 'button' ) ).toHaveClass(
+				'is-pressed is-pressed-mixed'
+			);
+		} );
+
+		it( 'should render a button element with is-selected without button class', () => {
+			render( <Button aria-selected /> );
+
+			expect( screen.getByRole( 'button' ) ).toHaveClass( 'is-selected' );
 		} );
 
 		it( 'should render a button element with has-text when children are passed', async () => {
@@ -433,6 +463,26 @@ describe( 'Button', () => {
 				'is-small'
 			);
 			expect( screen.getByRole( 'button' ) ).toHaveClass( 'is-compact' );
+		} );
+
+		it( 'should not break when the legacy isPressed prop is passed', () => {
+			render( <Button isPressed /> );
+
+			expect( screen.getByRole( 'button' ) ).toHaveAttribute(
+				'aria-pressed',
+				'true'
+			);
+
+			// Expect a deprecation message.
+			expect( console ).toHaveWarned();
+		} );
+
+		it( 'should prioritize the `aria-pressed` prop over `isPressed`', () => {
+			render( <Button isPressed aria-pressed="mixed" /> );
+			expect( screen.getByRole( 'button' ) ).toHaveAttribute(
+				'aria-pressed',
+				'mixed'
+			);
 		} );
 	} );
 

--- a/packages/components/src/button/types.ts
+++ b/packages/components/src/button/types.ts
@@ -59,6 +59,8 @@ type BaseButtonProps = {
 	isDestructive?: boolean;
 	/**
 	 * Renders a pressed button style.
+	 *
+	 * @deprecated Use `aria-pressed` instead
 	 */
 	isPressed?: boolean;
 	// TODO: Deprecate officially (add console warning and move to DeprecatedButtonProps).

--- a/packages/components/src/modal/README.md
+++ b/packages/components/src/modal/README.md
@@ -187,9 +187,13 @@ Titles are required for accessibility reasons, see `aria.labelledby` and `title`
 
 -   Required: No
 
-#### `focusOnMount`: `boolean | 'firstElement'`
+#### `focusOnMount`: `boolean | 'firstElement'` | 'firstContentElement'
 
 If this property is true, it will focus the first tabbable element rendered in the modal.
+
+If set to `firstElement` it will focus the first focusable element anywhere within the Modal.
+
+If set to `firstContentElement` it will focus the first focusable element within the Modal's **content** (i.e. children).
 
 -   Required: No
 -   Default: `true`

--- a/packages/components/src/modal/index.tsx
+++ b/packages/components/src/modal/index.tsx
@@ -71,16 +71,20 @@ function UnforwardedModal(
 	} = props;
 
 	const ref = useRef< HTMLDivElement >();
+
 	const instanceId = useInstanceId( Modal );
 	const headingId = title
 		? `components-modal-header-${ instanceId }`
 		: aria.labelledby;
-	const focusOnMountRef = useFocusOnMount( focusOnMount );
+	const focusOnMountRef = useFocusOnMount(
+		focusOnMount === 'firstContentElement' ? 'firstElement' : focusOnMount
+	);
 	const constrainedTabbingRef = useConstrainedTabbing();
 	const focusReturnRef = useFocusReturn();
 	const focusOutsideProps = useFocusOutside( onRequestClose );
 	const contentRef = useRef< HTMLDivElement >( null );
 	const childrenContainerRef = useRef< HTMLDivElement >( null );
+	const noopRef = useRef< HTMLDivElement >( null );
 
 	const [ hasScrolledContent, setHasScrolledContent ] = useState( false );
 	const [ hasScrollableContent, setHasScrollableContent ] = useState( false );
@@ -223,7 +227,9 @@ function UnforwardedModal(
 					ref={ useMergeRefs( [
 						constrainedTabbingRef,
 						focusReturnRef,
-						focusOnMountRef,
+						focusOnMount !== 'firstContentElement'
+							? focusOnMountRef
+							: noopRef,
 					] ) }
 					role={ role }
 					aria-label={ contentLabel }
@@ -283,7 +289,17 @@ function UnforwardedModal(
 								) }
 							</div>
 						) }
-						<div ref={ childrenContainerRef }>{ children }</div>
+						<div ref={ childrenContainerRef }>
+							<div
+								ref={
+									focusOnMount === 'firstContentElement'
+										? focusOnMountRef
+										: noopRef
+								}
+							>
+								{ children }
+							</div>
+						</div>
 					</div>
 				</div>
 			</StyleProvider>

--- a/packages/components/src/modal/index.tsx
+++ b/packages/components/src/modal/index.tsx
@@ -79,11 +79,12 @@ function UnforwardedModal(
 
 	// The focus hook does not support 'firstContentElement' but this is a valid
 	// value for the Modal's focusOnMount prop. The following code ensures the focus
-	// hook will focus the first element in the element to which it is applied.
+	// hook will focus the first focusable node within the element to which it is applied.
 	// When `firstContentElement` is passed as the value of the focusOnMount prop,
-	// the focus hook is applied to the Modal's contentRef. Otherwise, the focus hook
-	// is applied to the Modal's ref. This ensures that the focus hook will focus the
-	// first element in the Modal's **content** when `firstContentElement` is passed.
+	// the focus hook is applied to the Modal's content element.
+	// Otherwise, the focus hook is applied to the Modal's ref. This ensures that the
+	// focus hook will focus the first element in the Modal's **content** when
+	// `firstContentElement` is passed.
 	const focusOnMountRef = useFocusOnMount(
 		focusOnMount === 'firstContentElement' ? 'firstElement' : focusOnMount
 	);

--- a/packages/components/src/modal/index.tsx
+++ b/packages/components/src/modal/index.tsx
@@ -296,16 +296,16 @@ function UnforwardedModal(
 								) }
 							</div>
 						) }
-						<div ref={ childrenContainerRef }>
-							<div
-								ref={
-									focusOnMount === 'firstContentElement'
-										? focusOnMountRef
-										: undefined
-								}
-							>
-								{ children }
-							</div>
+
+						<div
+							ref={ useMergeRefs( [
+								childrenContainerRef,
+								focusOnMount === 'firstContentElement'
+									? focusOnMountRef
+									: null,
+							] ) }
+						>
+							{ children }
 						</div>
 					</div>
 				</div>

--- a/packages/components/src/modal/index.tsx
+++ b/packages/components/src/modal/index.tsx
@@ -84,7 +84,6 @@ function UnforwardedModal(
 	const focusOutsideProps = useFocusOutside( onRequestClose );
 	const contentRef = useRef< HTMLDivElement >( null );
 	const childrenContainerRef = useRef< HTMLDivElement >( null );
-	const noopRef = useRef< HTMLDivElement >( null );
 
 	const [ hasScrolledContent, setHasScrolledContent ] = useState( false );
 	const [ hasScrollableContent, setHasScrollableContent ] = useState( false );
@@ -229,7 +228,7 @@ function UnforwardedModal(
 						focusReturnRef,
 						focusOnMount !== 'firstContentElement'
 							? focusOnMountRef
-							: noopRef,
+							: null,
 					] ) }
 					role={ role }
 					aria-label={ contentLabel }
@@ -294,7 +293,7 @@ function UnforwardedModal(
 								ref={
 									focusOnMount === 'firstContentElement'
 										? focusOnMountRef
-										: noopRef
+										: undefined
 								}
 							>
 								{ children }

--- a/packages/components/src/modal/index.tsx
+++ b/packages/components/src/modal/index.tsx
@@ -76,6 +76,14 @@ function UnforwardedModal(
 	const headingId = title
 		? `components-modal-header-${ instanceId }`
 		: aria.labelledby;
+
+	// The focus hook does not support 'firstContentElement' but this is a valid
+	// value for the Modal's focusOnMount prop. The following code ensures the focus
+	// hook will focus the first element in the element to which it is applied.
+	// When `firstContentElement` is passed as the value of the focusOnMount prop,
+	// the focus hook is applied to the Modal's contentRef. Otherwise, the focus hook
+	// is applied to the Modal's ref. This ensures that the focus hook will focus the
+	// first element in the Modal's **content** when `firstContentElement` is passed.
 	const focusOnMountRef = useFocusOnMount(
 		focusOnMount === 'firstContentElement' ? 'firstElement' : focusOnMount
 	);

--- a/packages/components/src/modal/stories/index.story.tsx
+++ b/packages/components/src/modal/stories/index.story.tsx
@@ -28,7 +28,8 @@ const meta: Meta< typeof Modal > = {
 			control: { type: null },
 		},
 		focusOnMount: {
-			control: { type: 'boolean' },
+			options: [ true, false, 'firstElement', 'firstContentElement' ],
+			control: { type: 'select' },
 		},
 		role: {
 			control: { type: 'text' },

--- a/packages/components/src/modal/types.ts
+++ b/packages/components/src/modal/types.ts
@@ -68,7 +68,9 @@ export type ModalProps = {
 	 *
 	 * @default true
 	 */
-	focusOnMount?: Parameters< typeof useFocusOnMount >[ 0 ];
+	focusOnMount?:
+		| Parameters< typeof useFocusOnMount >[ 0 ]
+		| 'firstContentElement';
 	/**
 	 * Elements that are injected into the modal header to the left of the close button (if rendered).
 	 * Hidden if `__experimentalHideHeader` is `true`.

--- a/test/e2e/specs/editor/various/block-renaming.spec.js
+++ b/test/e2e/specs/editor/various/block-renaming.spec.js
@@ -58,11 +58,13 @@ test.describe( 'Block Renaming', () => {
 				name: 'Rename',
 			} );
 
-			// Check focus is transferred into modal.
-			await expect( renameModal ).toBeFocused();
-
 			// Check the Modal is perceivable.
 			await expect( renameModal ).toBeVisible();
+
+			const nameInput = renameModal.getByLabel( 'Block name' );
+
+			// Check focus is transferred into the input within the Modal.
+			await expect( nameInput ).toBeFocused();
 
 			const saveButton = renameModal.getByRole( 'button', {
 				name: 'Save',
@@ -70,8 +72,6 @@ test.describe( 'Block Renaming', () => {
 			} );
 
 			await expect( saveButton ).toBeDisabled();
-
-			const nameInput = renameModal.getByLabel( 'Block name' );
 
 			await expect( nameInput ).toHaveAttribute( 'placeholder', 'Group' );
 


### PR DESCRIPTION
## What?
This PR deprecates the `isPressed` prop on the `Button` component, deferring to the native `aria-pressed` attribute instead.

## Why?
When the `isPressed` prop is used on `Button`, `aria-pressed` is explicitly set accordingly. But sometimes `Button` is used for roles other than `button`, such as `option` and `checkbox`, where `aria-pressed` is not appropriate. Instead consumers should be able to decide for themselves the appropriate semantics.

## How?
The `isPressed` prop is marked as deprecated, and transformed into `aria-pressed`. The value of `aria-pressed` is then used instead to determine how the component should be styled.

## Testing Instructions
Unit tests have been added to confirm that the legacy `isPressed` behaviour continues, and that using `aria-pressed` directly behaves in the same way. Tests have also been included to validate similar behaviour for `aria-checked` and `aria-selected`, which are now visually supported in the same way.

99% of the time, this change should have no impact, as it's a straight swap from `isPressed` to `aria-pressed`, and both behave the same. Some controls, such as `CircularOptionPicker`, which set their own semantics around `Button`, will need to be updated.