### PR TITLE
`Modal`: Accessibly hide/show outer modal when nested

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -7,6 +7,7 @@
 -   `SearchControl`: polish metrics for `compact` size variant ([#54663](https://github.com/WordPress/gutenberg/pull/54663)).
 -   `Button`: deprecating `isPressed` prop in favour of `aria-pressed` ([#54740](https://github.com/WordPress/gutenberg/pull/54740)).
 -   `DuotonePicker/ColorListPicker`: Adds appropriate label and description to 'Duotone Filter' picker ([#54473](https://github.com/WordPress/gutenberg/pull/54473)).
+-   `Modal`: Accessibly hide/show outer modal when nested ([#54743](https://github.com/WordPress/gutenberg/pull/54743)).
 
 ### Bug Fix
 

--- a/packages/components/src/modal/aria-helper.ts
+++ b/packages/components/src/modal/aria-helper.ts
@@ -6,8 +6,7 @@ const LIVE_REGION_ARIA_ROLES = new Set( [
 	'timer',
 ] );
 
-let hiddenElements: Element[] = [],
-	isHidden = false;
+const hiddenElementsByDepth: Element[][] = [];
 
 /**
  * Hides all elements in the body element from screen-readers except
@@ -19,31 +18,28 @@ let hiddenElements: Element[] = [],
  * we should consider removing these helper functions in favor of
  * `aria-modal="true"`.
  *
- * @param {HTMLDivElement} unhiddenElement The element that should not be hidden.
+ * @param modalElement The element that should not be hidden.
  */
-export function hideApp( unhiddenElement?: HTMLDivElement ) {
-	if ( isHidden ) {
-		return;
-	}
+export function modalize( modalElement?: HTMLDivElement ) {
 	const elements = Array.from( document.body.children );
-	elements.forEach( ( element ) => {
-		if ( element === unhiddenElement ) {
-			return;
-		}
+	const hiddenElements: Element[] = [];
+	hiddenElementsByDepth.push( hiddenElements );
+	for ( const element of elements ) {
+		if ( element === modalElement ) continue;
+
 		if ( elementShouldBeHidden( element ) ) {
 			element.setAttribute( 'aria-hidden', 'true' );
 			hiddenElements.push( element );
 		}
-	} );
-	isHidden = true;
+	}
 }
 
 /**
  * Determines if the passed element should not be hidden from screen readers.
  *
- * @param {HTMLElement} element The element that should be checked.
+ * @param element The element that should be checked.
  *
- * @return {boolean} Whether the element should not be hidden from screen-readers.
+ * @return Whether the element should not be hidden from screen-readers.
  */
 export function elementShouldBeHidden( element: Element ) {
 	const role = element.getAttribute( 'role' );
@@ -56,16 +52,12 @@ export function elementShouldBeHidden( element: Element ) {
 }
 
 /**
- * Makes all elements in the body that have been hidden by `hideApp`
- * visible again to screen-readers.
+ * Accessibly reveals the elements hidden by the latest modal.
  */
-export function showApp() {
-	if ( ! isHidden ) {
-		return;
-	}
-	hiddenElements.forEach( ( element ) => {
+export function unmodalize() {
+	const hiddenElements = hiddenElementsByDepth.pop();
+	if ( ! hiddenElements ) return;
+
+	for ( const element of hiddenElements )
 		element.removeAttribute( 'aria-hidden' );
-	} );
-	hiddenElements = [];
-	isHidden = false;
 }

--- a/packages/components/src/modal/index.tsx
+++ b/packages/components/src/modal/index.tsx
@@ -113,10 +113,14 @@ function UnforwardedModal(
 	}, [ contentRef ] );
 
 	useEffect( () => {
+		ariaHelper.modalize( ref.current );
+		return () => ariaHelper.unmodalize();
+	}, [] );
+
+	useEffect( () => {
 		openModalCount++;
 
 		if ( openModalCount === 1 ) {
-			ariaHelper.hideApp( ref.current );
 			document.body.classList.add( bodyOpenClassName );
 		}
 
@@ -125,7 +129,6 @@ function UnforwardedModal(
 
 			if ( openModalCount === 0 ) {
 				document.body.classList.remove( bodyOpenClassName );
-				ariaHelper.showApp();
 			}
 		};
 	}, [ bodyOpenClassName ] );

--- a/packages/components/src/modal/test/index.tsx
+++ b/packages/components/src/modal/test/index.tsx
@@ -167,8 +167,7 @@ describe( 'Modal', () => {
 		expect( onRequestClose ).not.toHaveBeenCalled();
 	} );
 
-	// TODO enable once nested modals hide outer modals.
-	it.skip( 'should accessibly hide and show siblings including outer modals', async () => {
+	it( 'should accessibly hide and show siblings including outer modals', async () => {
 		const user = userEvent.setup();
 
 		const AriaDemo = () => {


### PR DESCRIPTION
## What?
Updates the existing logic for accessibly isolating the `Modal` component so that it works for nested modals. More specifically, when the nested modal is opened the "opener" modal has its `aria-hidden` attribute set to `"true"`.

## Why?
It seems like how it’s supposed to work and we added a test for it in #54569.

## How?
- Executes the isolation logic every time a `Modal` mounts/unmounts instead of only for the first/final modal.
- Revises tracking of hidden elements to use a 2d array to support levels of isolation.

## Testing Instructions
1. Open a post or page.
2. Paste and execute the following snippet in the javascript console.
```javascript
( ( {
	components: { Button, Modal },
	editPost: { PluginDocumentSettingPanel },
	element: { createElement: el, Fragment, useState },
	plugins: { registerPlugin }
} ) => {
	registerPlugin( 'modal-nesting-demo', {
		render: () => el( PluginDocumentSettingPanel, {
			name: 'modal-nesting-demo',
			title: 'Modal nesting demo',
			children: el( ModalNesting )
		} ),
	} );

	function ModalNesting() {
		const [ isOpen, setOpen ] = useState( false );
		const [ isInnerOpen, setIsInnerOpen ] = useState( false );
		return (
			el( Fragment, null,
				el( Button, { variant: "primary", onClick: () => setOpen( true ) }, "Open Modal" ),
				isOpen && (
					el( Modal, {
						onRequestClose: () => setOpen( false ),
						style: { maxWidth: '600px' },
						title: 'Nested modals vs. a11y isolation',
					},
						el( 'p', null, 'This modal should be accessibly hidden when the nested modal is open. When the nested modal is closed this modal should again be accessible while the rest of the tree remains inaccessible until this modal is closed.' ),

						isInnerOpen && el(
							Modal,
							{ onRequestClose: () => setIsInnerOpen( false ), title: '🪧 Nested' },
							el( 'p', null, 'Nothing to see here.' ),
						),

						el( Button, { variant: "secondary", onClick: () => setIsInnerOpen( true ) }, 'Open Nested'),
					)
				)
			)
		);
	}
} )( wp );
```
3. Press the "Open Modal" button added to the post settings ("Editor Settings" > "Modal nesting demo").
4. Note the Modal is opened and verify the rest of the page is no longer in the accessibility tree.
5. Press the "Open Nested" button.
6. Note the nested modal is opened and verify the outer modal is no longer in the accessibility tree.
7. Close the nested modal.
8. Verify the original modal is returned to the accessibility tree while the rest of the page is not.
9. Close the modal.
10. Verify the rest of the page is returned to the accessibility tree.

### Testing Instructions for Keyboard
I tried to make the instructions above applicable for keyboard use.

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/9000376/7041978b-0155-4fc3-8ca6-03db7479716f

