### PR TITLE
(chore) Revert the 16.7 RC2 release in order to release it again due to wrong changelog

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,56 +1,5 @@
 == Changelog ==
 
-= 16.7.0-rc.2 =
-
-
-
-## Changelog
-
-### Features
-
-#### Site Editor
-- Add 'Show template' toggle when editing pages. ([52674](https://github.com/WordPress/gutenberg/pull/52674))
-
-
-### Enhancements
-
-#### Patterns
-- Memoize `useSelect` for `usePatterns`. ([54588](https://github.com/WordPress/gutenberg/pull/54588))
-
-#### Design Tools
-- Improve background image control. ([54439](https://github.com/WordPress/gutenberg/pull/54439))
-
-#### List View
-- Try directing focus to the list view toggle button when closing the list view. ([54175](https://github.com/WordPress/gutenberg/pull/54175))
-
-
-### Bug Fixes
-
-#### Plugin
-- Update cherry-pick script to correctly verify GitHub CLI setup. ([54720](https://github.com/WordPress/gutenberg/pull/54720))
-
-#### Block API
-- Block Hooks: Avoid processing empty content for loaded templates. ([54719](https://github.com/WordPress/gutenberg/pull/54719))
-
-#### Design Tools
-- Background Image control: Use consistent button, ensure descriptive text accounts for no image selected. ([54711](https://github.com/WordPress/gutenberg/pull/54711))
-
-
-### Various
-
-#### Plugin
-- Update uuid package to 9.0.1. ([54725](https://github.com/WordPress/gutenberg/pull/54725))
-
-
-
-
-## Contributors
-
-The following contributors merged PRs in this release:
-
-@andrewserong @gziolo @kevin940726 @mikachan @noisysocks @richtabor
-
-
 = 16.7.0-rc.1 =
 
 ## Changelog

--- a/gutenberg.php
+++ b/gutenberg.php
@@ -5,7 +5,7 @@
  * Description: Printing since 1440. This is the development plugin for the block editor, site editor, and other future WordPress core functionality.
  * Requires at least: 6.2
  * Requires PHP: 7.0
- * Version: 16.7.0-rc.2
+ * Version: 16.7.0-rc.1
  * Author: Gutenberg Team
  * Text Domain: gutenberg
  *

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "gutenberg",
-	"version": "16.7.0-rc.2",
+	"version": "16.7.0-rc.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "gutenberg",
-			"version": "16.7.0-rc.2",
+			"version": "16.7.0-rc.1",
 			"hasInstallScript": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gutenberg",
-	"version": "16.7.0-rc.2",
+	"version": "16.7.0-rc.1",
 	"private": true,
 	"description": "A new WordPress editor experience.",
 	"author": "The WordPress Contributors",


### PR DESCRIPTION
## What?

Revert the changelog and version bump commits in trunk.

## Why?

I released 16.7 RC2 today, but the changelog generated was wrong due to two commits listed there not being included in the release branch:

https://github.com/WordPress/gutenberg/pull/52674 and https://github.com/WordPress/gutenberg/pull/54720., but they were still listed in the changelog.

Since it's an RC, I think the cleanest way to go is to revert and release it again, or the asset s attached in the release will still contain the wrong changelog.

## How?

- Revert the changelog and bump commits for 16.7 RC2 in the `trunk` branch (this PR)
- Revert the equivalent commits in the release/16.7 branch (already done, see linked commits below)
- Remove the 16.7.2-rc.2 tag (done)
- Remove the 16.7.2-rc.2 release  (done)
- Release again (Build Plugin Zip) (todo)

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
