### PR TITLE
Font Library: Refactor logic to disable font library in the frontend.

### DIFF
--- a/lib/experimental/fonts/font-library/disable-font-library.php
+++ b/lib/experimental/fonts/font-library/disable-font-library.php
@@ -1,0 +1,9 @@
+<?php
+
+// @core-merge: this should not go to core.
+add_action(
+	'enqueue_block_editor_assets',
+	function () {
+		wp_add_inline_script( 'wp-block-editor', 'window.__experimentalDisableFontLibrary = true', 'before' );
+	}
+);

--- a/lib/experimental/fonts/font-library/disable-font-library.php
+++ b/lib/experimental/fonts/font-library/disable-font-library.php
@@ -1,9 +1,0 @@
-<?php
-
-// @core-merge: this should not go to core.
-add_action(
-	'enqueue_block_editor_assets',
-	function () {
-		wp_add_inline_script( 'wp-block-editor', 'window.__experimentalDisableFontLibrary = true', 'before' );
-	}
-);

--- a/lib/experimental/fonts/font-library/font-library.php
+++ b/lib/experimental/fonts/font-library/font-library.php
@@ -57,12 +57,6 @@ if ( ! function_exists( 'wp_register_font_collection' ) ) {
 	}
 }
 
-add_action(
-	'enqueue_block_editor_assets',
-	function () {
-		wp_add_inline_script( 'wp-block-editor', 'window.__experimentalFontLibrary = true', 'before' );
-	}
-);
 
 $default_font_collection = array(
 	'id'          => 'default-font-collection',

--- a/lib/load.php
+++ b/lib/load.php
@@ -173,8 +173,15 @@ if (
 	require __DIR__ . '/experimental/fonts/font-face/bc-layer/class-wp-webfonts.php';
 	require __DIR__ . '/experimental/fonts/font-face/bc-layer/class-wp-web-fonts.php';
 } elseif ( ! class_exists( 'WP_Fonts' ) ) {
+
 	// Disables the Font Library.
-	require __DIR__ . '/experimental/fonts/font-library/disable-font-library.php';
+	// @core-merge: this should not go to core.
+	add_action(
+		'enqueue_block_editor_assets',
+		function () {
+			wp_add_inline_script( 'wp-block-editor', 'window.__experimentalDisableFontLibrary = true', 'before' );
+		}
+	);
 
 	// Turns off Font Face hooks in Core.
 	// @since 6.4.0.

--- a/lib/load.php
+++ b/lib/load.php
@@ -173,6 +173,9 @@ if (
 	require __DIR__ . '/experimental/fonts/font-face/bc-layer/class-wp-webfonts.php';
 	require __DIR__ . '/experimental/fonts/font-face/bc-layer/class-wp-web-fonts.php';
 } elseif ( ! class_exists( 'WP_Fonts' ) ) {
+	// Disables the Font Library.
+	require __DIR__ . '/experimental/fonts/font-library/disable-font-library.php';
+
 	// Turns off Font Face hooks in Core.
 	// @since 6.4.0.
 	remove_action( 'wp_head', 'wp_print_font_faces', 50 );

--- a/packages/edit-site/src/components/global-styles/screen-typography.js
+++ b/packages/edit-site/src/components/global-styles/screen-typography.js
@@ -22,7 +22,9 @@ function ScreenTypography() {
 			/>
 			<div className="edit-site-global-styles-screen-typography">
 				<VStack spacing={ 6 }>
-					{ window.__experimentalFontLibrary && <FontFamilies /> }
+					{ ! window.__experimentalDisableFontLibrary && (
+						<FontFamilies />
+					) }
 					<TypographyElements />
 				</VStack>
 			</div>


### PR DESCRIPTION
## What?
Refactor logic to disable font library in the frontend.

## Why?
This change is needed in core because we will not be using the PHP constant FONT_LIBRARY_DISABLED. The previous code depended on this constant to render the library in the frontend. With this change, the library will render as default.

## How?
Previously we were enabling the library based on a constant that won't be in core. Now is enabled by default and we need to disable it explicitly.

## Testing Instructions
Try with these cases in `wp-config.php`:
`define( 'FONT_LIBRARY_DISABLED', true );` -> Should NOT render the library
`define( 'FONT_LIBRARY_DISABLED', false );` -> Should render the library
FONT_LIBRARY_DISABLED constant missing / undefined -> Should render the library.

