### PR TITLE
Patterns: Fix category type for back link

### DIFF
--- a/packages/edit-site/src/components/page-patterns/grid-item.js
+++ b/packages/edit-site/src/components/page-patterns/grid-item.js
@@ -75,7 +75,7 @@ function GridItem( { categoryId, item, ...props } ) {
 		postType: item.type,
 		postId: isUserPattern ? item.id : item.name,
 		categoryId,
-		categoryType: item.type,
+		categoryType: isTemplatePart ? item.type : PATTERN_TYPES.theme,
 	} );
 
 	const isEmpty = ! item.blocks?.length;


### PR DESCRIPTION
Related:
- https://github.com/WordPress/gutenberg/pull/53933

## What?

Fixes the category type applied to a pattern's URL so that when navigating back to the pattern management page the sync filters are shown as they were before selecting the pattern.

## Why?

UI elements coming and going isn't great.

## How?

Set the correct category type in the query string params

## Testing Instructions

#### Replicate Issue
1. On trunk, navigate to Appearance > Editor > Patterns
2. Select a pattern category and note the sync status filters at the top of the page
3. Select a pattern, then navigate back to the Patterns page
4. Note the sync status filters are missing

#### Test fix
1. Checkout this PR and repeat the above steps
2. When viewing the pattern the category type in the query string should be `pattern`
3. Confirm that the sync status filters are shown once you've navigate back to the Patterns page


## Screenshots or screencast <!-- if applicable -->

| Before | After |
|---|---|
| <video src="https://github.com/WordPress/gutenberg/assets/60436221/8f4d1240-41f6-42e9-97a7-fcefcac82666" /> | <video src="https://github.com/WordPress/gutenberg/assets/60436221/8113faec-e43f-42d8-982c-10e0ca102a53" /> |








