### PR TITLE
Patterns: Fix sidebar nav screen fallback category

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen-patterns/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-patterns/index.js
@@ -88,7 +88,7 @@ export default function SidebarNavigationScreenPatterns() {
 	const isMobileViewport = useViewportMatch( 'medium', '<' );
 	const { categoryType, categoryId } = getQueryArgs( window.location.href );
 	const currentCategory = categoryId || PATTERN_DEFAULT_CATEGORY;
-	const currentType = categoryType || PATTERN_TYPES.user;
+	const currentType = categoryType || PATTERN_TYPES.theme;
 
 	const { templatePartAreas, hasTemplateParts, isLoading } =
 		useTemplatePartAreas();


### PR DESCRIPTION
Related: 
- https://github.com/WordPress/gutenberg/pull/54484

## What?

Fixes the fallback category type to match the category prior to the constants refactor.

**Given the check within the `PatternCategoriesGroup` the incorrect value didn't change final behaviour, this is to avoid future headaches**

## Why?

When getting to merging all types of patterns (template parts, user patterns, themes etc.) it will be easier to reconcile if the default pattern and fallbacks all match.

## How?

Corrects the fallback for the current category type to match what it was before the constants refactor.

## Testing Instructions

1. Confirm that the new category type matches the old `DEFAULT_TYPE` again
    - [Change in refactor](https://github.com/WordPress/gutenberg/pull/54484/files#diff-20e7141e1d9fbcb0ceb1efaacf329846003172fd36f43cdcffe86ec8672a9fc4L87) 
    - [Original `DEFAULT_TYPE` value](https://github.com/WordPress/gutenberg/pull/54484/files#diff-1a918c26a230e72dac0256bf17fbd30345d5fab8c78064aa98f21796f97a60f4L3-L4)
3. Navigate to the Patterns page and confirm navigating pattern categories works as intended