### PR TITLE
Patterns: Fix duplication of uncategorized patterns

### DIFF
--- a/packages/edit-site/src/components/page-patterns/duplicate-menu-item.js
+++ b/packages/edit-site/src/components/page-patterns/duplicate-menu-item.js
@@ -158,7 +158,7 @@ export default function DuplicateMenuItem( {
 				__( '%s (Copy)' ),
 				item.title || item.name
 			);
-			const categories = await getCategories( item.categories );
+			const categories = await getCategories( item.categories || [] );
 
 			const result = await saveEntityRecord(
 				'postType',


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/54729

## What?

Prevents error that blocks duplication of uncategorized patterns

## Why?

Bugs = bad

A lot of users will have uncategorized patterns they may need to duplicate. Especially once we can duplicate and set an alternative sync status as well. 

## How?

Ensure array is passed to `getCategories` as it expects.

## Testing Instructions

1. Navigate to Appearance > Editor > Patterns
2. Create a pattern and do not assign it any categories
3. Duplicate the newly created uncategorized pattern and make sure it works
4. Confirm categorized patterns are still correctly duplicated as well


## Screenshots or screencast <!-- if applicable -->

<img width="368" alt="Screenshot 2023-09-23 at 5 32 56 pm" src="https://github.com/WordPress/gutenberg/assets/60436221/ec428046-20c2-4f42-9a63-ba9b739ac18a">

