### PR TITLE
Patterns: Allow non-user patterns under Standard sync filter

### DIFF
--- a/packages/edit-site/src/components/page-patterns/use-patterns.js
+++ b/packages/edit-site/src/components/page-patterns/use-patterns.js
@@ -155,9 +155,13 @@ const selectPatterns = createSelector(
 		];
 
 		if ( syncStatus ) {
-			patterns = patterns.filter(
-				( pattern ) => pattern.syncStatus === syncStatus
-			);
+			// User patterns can have their sync statuses checked directly
+			// Non-user patterns are all unsynced for the time being.
+			patterns = patterns.filter( ( pattern ) => {
+				return pattern.id
+					? pattern.syncStatus === syncStatus
+					: syncStatus === PATTERN_SYNC_TYPES.unsynced;
+			} );
 		}
 
 		if ( categoryId ) {


### PR DESCRIPTION

## What?

Given all theme patterns are "unsynced" they should be shown under the "Standard" sync filter until we have more refined source and sync filtering on the Patterns management page.

This is only a small change but means that all the patterns that are shown on under the "all" sync status filter, are then also reflected across both the "Synced" and "Standard" sync filters. 

## Why?

This will minimise unexpected filtering behaviour on the Patterns page until source filters are added to align the site editor patterns page more with the block editor's inserter.

## How?

Updates the sync status filtering to include non-user patterns if the current sync filter is `unsynced`

## Testing Instructions

1. Navigate to Appearance > Editor > Patterns
2. Activate TT3 and create patterns of different sync statuses
3. Select the "All patterns" category
4. Confirm that all the correct patterns are shown
5. Toggle on the "Synced" filter and confirm only synced patterns are shown
6. Switch to the "Standard" filter and confirm both unsynced user patterns and theme patterns are shown

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/60436221/cfcefc2c-390a-430a-a4fd-ab606752c551

