### PR TITLE
test: E2E tests require supported iOS version

### DIFF
--- a/packages/react-native-editor/__device-tests__/helpers/utils.js
+++ b/packages/react-native-editor/__device-tests__/helpers/utils.js
@@ -59,11 +59,12 @@ const getIOSPlatformVersions = () => {
 		childProcess.execSync( 'xcrun simctl list runtimes --json' ).toString()
 	);
 
-	return runtimes
-		.reverse()
-		.filter(
-			( { name, isAvailable } ) => name.startsWith( 'iOS' ) && isAvailable
-		);
+	return runtimes.reverse().filter(
+		( { name, isAvailable, version } ) =>
+			name.startsWith( 'iOS' ) &&
+			/15(\.\d+)+/.test( version ) && // Appium 1 does not support newer iOS versions
+			isAvailable
+	);
 };
 
 // Initialises the driver and desired capabilities for appium.
@@ -122,7 +123,7 @@ const setupDriver = async () => {
 			const iosPlatformVersions = getIOSPlatformVersions();
 			if ( iosPlatformVersions.length === 0 ) {
 				throw new Error(
-					'No iOS simulators available! Please verify that you have iOS simulators installed.'
+					'No compatible iOS simulators available! Please verify that you have iOS 15 simulators installed.'
 				);
 			}
 			// eslint-disable-next-line no-console


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Update local Appium capabilities utilities to require a simulator with a
supported iOS version.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Appium 1 does not support newer versions of iOS. This improves automatic
simulator selection logic to avoid loading incompatible iOS simulators
and provide helpful error messages during compatibility failures.

This logic can be removed or simplified once we upgrade to Appium 2.


## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Limit automatic iOS simulator selection to compatible OS versions, e.g. iOS 15.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Ensure a compatible iOS 15 simulator is installed on your machine.
1. Check out this branch.
1. `npm run native test:e2e:ios:local -- gutenberg-editor-heading-@canary.test.js`
1. Verify the tests succeed on an iOS simulator.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
n/a

## Screenshots or screencast <!-- if applicable -->
n/a
