### PR TITLE
Font Library: use resolvable domain in test

### DIFF
--- a/phpunit/tests/fonts/font-library/wpRestFontLibraryController/getFontCollection.php
+++ b/phpunit/tests/fonts/font-library/wpRestFontLibraryController/getFontCollection.php
@@ -36,7 +36,7 @@ class Tests_Fonts_WPRESTFontLibraryController_GetFontCollection extends WP_REST_
 			'id'          => 'collection-with-url',
 			'name'        => 'Another Font Collection',
 			'description' => 'Demo about how to a font collection to your WordPress Font Library.',
-			'src'         => 'https://localhost/fonts/mock-font-collection.json',
+			'src'         => 'https://wordpress.org/fonts/mock-font-collection.json',
 		);
 
 		wp_register_font_collection( $config_with_url );
@@ -62,7 +62,7 @@ class Tests_Fonts_WPRESTFontLibraryController_GetFontCollection extends WP_REST_
 
 	public function mock_request( $preempt, $args, $url ) {
 		// Check if it's the URL you want to mock.
-		if ( 'https://localhost/fonts/mock-font-collection.json' === $url ) {
+		if ( 'https://wordpress.org/fonts/mock-font-collection.json' === $url ) {
 
 			// Mock the response body.
 			$mock_collection_data = array(


### PR DESCRIPTION
## What?
Fix test than can break in different test envs depending the URL of the test env run.


## Why?
 To validate the URL of a font collection we have a function that calls [`wp_http_validate_url()`](https://github.com/WordPress/wordpress-develop/blob/33b6dcc97618fc3d0f94bdd3a60a9d5d3c776dfb/src/wp-includes/http.php#L529-L618) function. 
Because wp_http_validate_url() function uses the PHP native function [`gethostbyname()`](https://www.php.net/manual/en/function.gethostbyname.php) function that is not being mocked. We just mock the URL request to fetch the data. If the domain of the url used can't be resolved or the url of the test env is not localhost, the url like `https://localhost/example` can be evaluated as invalid.

## How?
To fix this problem easily we can use a resolvable domain as `wordpress.org` in the test instead of `localhost.`

## Testing Instructions
Run PHP unit tests and check if they are running ok.
