### PR TITLE
Patterns: Use modal for pattern duplication flow as workaround for changing sync status

### DIFF
--- a/packages/edit-site/src/components/create-template-part-modal/index.js
+++ b/packages/edit-site/src/components/create-template-part-modal/index.js
@@ -39,21 +39,21 @@ import {
 } from '../../utils/template-part-create';
 
 export default function CreateTemplatePartModal( {
-	area: areaProp = TEMPLATE_PART_AREA_DEFAULT_CATEGORY,
+	area: defaultArea = TEMPLATE_PART_AREA_DEFAULT_CATEGORY,
 	blocks = [],
-	buttonLabel = __( 'Create' ),
+	confirmLabel = __( 'Create' ),
 	closeModal,
 	modalTitle = __( 'Create template part' ),
 	onCreate,
 	onError,
-	title: titleProp = '',
+	title: defaultTitle = '',
 } ) {
 	const { createErrorNotice } = useDispatch( noticesStore );
 	const { saveEntityRecord } = useDispatch( coreStore );
 	const existingTemplateParts = useExistingTemplateParts();
 
-	const [ title, setTitle ] = useState( titleProp );
-	const [ area, setArea ] = useState( areaProp );
+	const [ title, setTitle ] = useState( defaultTitle );
+	const [ area, setArea ] = useState( defaultArea );
 	const [ isSubmitting, setIsSubmitting ] = useState( false );
 	const instanceId = useInstanceId( CreateTemplatePartModal );
 
@@ -185,7 +185,7 @@ export default function CreateTemplatePartModal( {
 							aria-disabled={ ! title || isSubmitting }
 							isBusy={ isSubmitting }
 						>
-							{ buttonLabel }
+							{ confirmLabel }
 						</Button>
 					</HStack>
 				</VStack>

--- a/packages/edit-site/src/components/create-template-part-modal/index.js
+++ b/packages/edit-site/src/components/create-template-part-modal/index.js
@@ -39,14 +39,14 @@ import {
 } from '../../utils/template-part-create';
 
 export default function CreateTemplatePartModal( {
-	area: defaultArea = TEMPLATE_PART_AREA_DEFAULT_CATEGORY,
+	defaultArea = TEMPLATE_PART_AREA_DEFAULT_CATEGORY,
 	blocks = [],
 	confirmLabel = __( 'Create' ),
 	closeModal,
 	modalTitle = __( 'Create template part' ),
 	onCreate,
 	onError,
-	title: defaultTitle = '',
+	defaultTitle = '',
 } ) {
 	const { createErrorNotice } = useDispatch( noticesStore );
 	const { saveEntityRecord } = useDispatch( coreStore );

--- a/packages/edit-site/src/components/create-template-part-modal/index.js
+++ b/packages/edit-site/src/components/create-template-part-modal/index.js
@@ -39,17 +39,21 @@ import {
 } from '../../utils/template-part-create';
 
 export default function CreateTemplatePartModal( {
-	closeModal,
+	area: areaProp = TEMPLATE_PART_AREA_DEFAULT_CATEGORY,
 	blocks = [],
+	buttonLabel = __( 'Create' ),
+	closeModal,
+	modalTitle = __( 'Create template part' ),
 	onCreate,
 	onError,
+	title: titleProp = '',
 } ) {
 	const { createErrorNotice } = useDispatch( noticesStore );
 	const { saveEntityRecord } = useDispatch( coreStore );
 	const existingTemplateParts = useExistingTemplateParts();
 
-	const [ title, setTitle ] = useState( '' );
-	const [ area, setArea ] = useState( TEMPLATE_PART_AREA_DEFAULT_CATEGORY );
+	const [ title, setTitle ] = useState( titleProp );
+	const [ area, setArea ] = useState( areaProp );
 	const [ isSubmitting, setIsSubmitting ] = useState( false );
 	const instanceId = useInstanceId( CreateTemplatePartModal );
 
@@ -104,7 +108,7 @@ export default function CreateTemplatePartModal( {
 
 	return (
 		<Modal
-			title={ __( 'Create template part' ) }
+			title={ modalTitle }
 			onRequestClose={ closeModal }
 			overlayClassName="edit-site-create-template-part-modal"
 		>
@@ -181,7 +185,7 @@ export default function CreateTemplatePartModal( {
 							aria-disabled={ ! title || isSubmitting }
 							isBusy={ isSubmitting }
 						>
-							{ __( 'Create' ) }
+							{ buttonLabel }
 						</Button>
 					</HStack>
 				</VStack>

--- a/packages/edit-site/src/components/page-patterns/duplicate-menu-item.js
+++ b/packages/edit-site/src/components/page-patterns/duplicate-menu-item.js
@@ -119,7 +119,7 @@ export default function DuplicateMenuItem( {
 			</MenuItem>
 			{ isModalOpen && ! isTemplatePart && (
 				<CreatePatternModal
-					buttonLabel={ __( 'Duplicate' ) }
+					confirmLabel={ __( 'Duplicate' ) }
 					modalTitle={ __( 'Duplicate pattern' ) }
 					onClose={ closeModal }
 					onError={ closeModal }
@@ -129,7 +129,7 @@ export default function DuplicateMenuItem( {
 			) }
 			{ isModalOpen && isTemplatePart && (
 				<CreateTemplatePartModal
-					buttonLabel={ __( 'Duplicate' ) }
+					confirmLabel={ __( 'Duplicate' ) }
 					closeModal={ closeModal }
 					modalTitle={ __( 'Duplicate template part' ) }
 					onCreate={ onTemplatePartSuccess }

--- a/packages/edit-site/src/components/page-patterns/duplicate-menu-item.js
+++ b/packages/edit-site/src/components/page-patterns/duplicate-menu-item.js
@@ -86,22 +86,24 @@ export default function DuplicateMenuItem( {
 	const duplicatedProps = isTemplatePart
 		? {
 				blocks: item.blocks,
-				area: item.templatePart.area,
-				title: sprintf(
+				defaultArea: item.templatePart.area,
+				defaultTitle: sprintf(
 					/* translators: %s: Existing template part title */
 					__( '%s (Copy)' ),
 					item.title
 				),
 		  }
 		: {
-				categories: isThemePattern ? item.categories : item.termLabels,
+				defaultCategories: isThemePattern
+					? item.categories
+					: item.termLabels,
 				content: isThemePattern
 					? item.content
 					: item.patternBlock.content,
-				syncType: isThemePattern
+				defaultSyncType: isThemePattern
 					? PATTERN_SYNC_TYPES.unsynced
 					: item.syncStatus,
-				title: sprintf(
+				defaultTitle: sprintf(
 					/* translators: %s: Existing pattern title */
 					__( '%s (Copy)' ),
 					item.title || item.name

--- a/packages/edit-site/src/components/page-patterns/duplicate-menu-item.js
+++ b/packages/edit-site/src/components/page-patterns/duplicate-menu-item.js
@@ -63,7 +63,7 @@ export default function DuplicateMenuItem( {
 			sprintf(
 				// translators: %s: The new pattern's title e.g. 'Call to action (copy)'.
 				__( '"%s" duplicated.' ),
-				pattern.title
+				pattern.title.raw
 			),
 			{
 				type: 'snackbar',

--- a/packages/edit-site/src/components/page-patterns/duplicate-menu-item.js
+++ b/packages/edit-site/src/components/page-patterns/duplicate-menu-item.js
@@ -2,10 +2,11 @@
  * WordPress dependencies
  */
 import { MenuItem } from '@wordpress/components';
-import { store as coreStore } from '@wordpress/core-data';
 import { useDispatch } from '@wordpress/data';
+import { useState } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
+import { privateApis as patternsPrivateApis } from '@wordpress/patterns';
 import { privateApis as routerPrivateApis } from '@wordpress/router';
 
 /**
@@ -13,32 +14,14 @@ import { privateApis as routerPrivateApis } from '@wordpress/router';
  */
 import {
 	TEMPLATE_PART_POST_TYPE,
-	PATTERN_TYPES,
 	PATTERN_SYNC_TYPES,
+	PATTERN_TYPES,
 } from '../../utils/constants';
-import {
-	useExistingTemplateParts,
-	getUniqueTemplatePartTitle,
-	getCleanTemplatePartSlug,
-} from '../../utils/template-part-create';
 import { unlock } from '../../lock-unlock';
-import usePatternCategories from '../sidebar-navigation-screen-patterns/use-pattern-categories';
+import CreateTemplatePartModal from '../create-template-part-modal';
 
+const { CreatePatternModal } = unlock( patternsPrivateApis );
 const { useHistory } = unlock( routerPrivateApis );
-
-function getPatternMeta( item ) {
-	if ( item.type === PATTERN_TYPES.theme ) {
-		return { wp_pattern_sync_status: PATTERN_SYNC_TYPES.unsynced };
-	}
-
-	const syncStatus = item.patternBlock.wp_pattern_sync_status;
-	const isUnsynced = syncStatus === PATTERN_SYNC_TYPES.unsynced;
-
-	return {
-		...item.patternBlock.meta,
-		wp_pattern_sync_status: isUnsynced ? syncStatus : undefined,
-	};
-}
 
 export default function DuplicateMenuItem( {
 	categoryId,
@@ -46,173 +29,114 @@ export default function DuplicateMenuItem( {
 	label = __( 'Duplicate' ),
 	onClose,
 } ) {
-	const { saveEntityRecord, invalidateResolution } = useDispatch( coreStore );
-	const { createErrorNotice, createSuccessNotice } =
-		useDispatch( noticesStore );
-
+	const { createSuccessNotice } = useDispatch( noticesStore );
+	const [ isModalOpen, setIsModalOpen ] = useState( false );
 	const history = useHistory();
-	const existingTemplateParts = useExistingTemplateParts();
-	const { patternCategories } = usePatternCategories();
 
-	async function createTemplatePart() {
-		try {
-			const copiedTitle = sprintf(
-				/* translators: %s: Existing template part title */
-				__( '%s (Copy)' ),
+	const isTemplatePart = item.type === TEMPLATE_PART_POST_TYPE;
+
+	async function onTemplatePartSuccess( templatePart ) {
+		createSuccessNotice(
+			sprintf(
+				// translators: %s: The new template part's title e.g. 'Call to action (copy)'.
+				__( '"%s" duplicated.' ),
 				item.title
-			);
-			const title = getUniqueTemplatePartTitle(
-				copiedTitle,
-				existingTemplateParts
-			);
-			const slug = getCleanTemplatePartSlug( title );
-			const { area, content } = item.templatePart;
-
-			const result = await saveEntityRecord(
-				'postType',
-				TEMPLATE_PART_POST_TYPE,
-				{ slug, title, content, area },
-				{ throwOnError: true }
-			);
-
-			createSuccessNotice(
-				sprintf(
-					// translators: %s: The new template part's title e.g. 'Call to action (copy)'.
-					__( '"%s" duplicated.' ),
-					item.title
-				),
-				{
-					type: 'snackbar',
-					id: 'edit-site-patterns-success',
-				}
-			);
-
-			history.push( {
-				postType: TEMPLATE_PART_POST_TYPE,
-				postId: result?.id,
-				categoryType: TEMPLATE_PART_POST_TYPE,
-				categoryId,
-			} );
-
-			onClose();
-		} catch ( error ) {
-			const errorMessage =
-				error.message && error.code !== 'unknown_error'
-					? error.message
-					: __(
-							'An error occurred while creating the template part.'
-					  );
-
-			createErrorNotice( errorMessage, {
+			),
+			{
 				type: 'snackbar',
-				id: 'edit-site-patterns-error',
-			} );
-			onClose();
-		}
-	}
-
-	async function findOrCreateTerm( term ) {
-		try {
-			const newTerm = await saveEntityRecord(
-				'taxonomy',
-				'wp_pattern_category',
-				{
-					name: term.label,
-					slug: term.name,
-					description: term.description,
-				},
-				{
-					throwOnError: true,
-				}
-			);
-			invalidateResolution( 'getUserPatternCategories' );
-			return newTerm.id;
-		} catch ( error ) {
-			if ( error.code !== 'term_exists' ) {
-				throw error;
+				id: 'edit-site-patterns-success',
 			}
+		);
 
-			return error.data.term_id;
-		}
-	}
-
-	async function getCategories( categories ) {
-		const terms = categories.map( ( category ) => {
-			const fullCategory = patternCategories.find(
-				( cat ) => cat.name === category
-			);
-			if ( fullCategory.id ) {
-				return fullCategory.id;
-			}
-			return findOrCreateTerm( fullCategory );
+		history.push( {
+			postType: TEMPLATE_PART_POST_TYPE,
+			postId: templatePart?.id,
+			categoryType: TEMPLATE_PART_POST_TYPE,
+			categoryId,
 		} );
 
-		return Promise.all( terms );
+		onClose();
 	}
 
-	async function createPattern() {
-		try {
-			const isThemePattern = item.type === PATTERN_TYPES.theme;
-			const title = sprintf(
-				/* translators: %s: Existing pattern title */
-				__( '%s (Copy)' ),
-				item.title || item.name
-			);
-			const categories = await getCategories( item.categories || [] );
+	function onPatternSuccess( { pattern } ) {
+		createSuccessNotice(
+			sprintf(
+				// translators: %s: The new pattern's title e.g. 'Call to action (copy)'.
+				__( '"%s" duplicated.' ),
+				pattern.title
+			),
+			{
+				type: 'snackbar',
+				id: 'edit-site-patterns-success',
+			}
+		);
 
-			const result = await saveEntityRecord(
-				'postType',
-				PATTERN_TYPES.user,
-				{
-					content: isThemePattern
-						? item.content
-						: item.patternBlock.content,
-					meta: getPatternMeta( item ),
-					status: 'publish',
-					title,
-					wp_pattern_category: categories,
-				},
-				{ throwOnError: true }
-			);
+		history.push( {
+			categoryType: PATTERN_TYPES.theme,
+			categoryId,
+			postType: PATTERN_TYPES.user,
+			postId: pattern.id,
+		} );
 
-			createSuccessNotice(
-				sprintf(
-					// translators: %s: The new pattern's title e.g. 'Call to action (copy)'.
-					__( '"%s" duplicated.' ),
+		onClose();
+	}
+
+	const isThemePattern = item.type === PATTERN_TYPES.theme;
+	const closeModal = () => setIsModalOpen( false );
+	const duplicatedProps = isTemplatePart
+		? {
+				blocks: item.blocks,
+				area: item.templatePart.area,
+				title: sprintf(
+					/* translators: %s: Existing template part title */
+					__( '%s (Copy)' ),
+					item.title
+				),
+		  }
+		: {
+				categories: isThemePattern ? item.categories : item.termLabels,
+				content: isThemePattern
+					? item.content
+					: item.patternBlock.content,
+				syncType: isThemePattern
+					? PATTERN_SYNC_TYPES.unsynced
+					: item.syncStatus,
+				title: sprintf(
+					/* translators: %s: Existing pattern title */
+					__( '%s (Copy)' ),
 					item.title || item.name
 				),
-				{
-					type: 'snackbar',
-					id: 'edit-site-patterns-success',
-				}
-			);
+		  };
 
-			history.push( {
-				categoryType: PATTERN_TYPES.theme,
-				categoryId,
-				postType: PATTERN_TYPES.user,
-				postId: result?.id,
-			} );
-
-			onClose();
-		} catch ( error ) {
-			const errorMessage =
-				error.message && error.code !== 'unknown_error'
-					? error.message
-					: __( 'An error occurred while creating the pattern.' );
-
-			createErrorNotice( errorMessage, {
-				type: 'snackbar',
-				id: 'edit-site-patterns-error',
-			} );
-			onClose();
-		}
-	}
-
-	const createItem =
-		item.type === TEMPLATE_PART_POST_TYPE
-			? createTemplatePart
-			: createPattern;
-
-	return <MenuItem onClick={ createItem }>{ label }</MenuItem>;
+	return (
+		<>
+			<MenuItem
+				onClick={ () => setIsModalOpen( true ) }
+				aria-expanded={ isModalOpen }
+				aria-haspopup="dialog"
+			>
+				{ label }
+			</MenuItem>
+			{ isModalOpen && ! isTemplatePart && (
+				<CreatePatternModal
+					buttonLabel={ __( 'Duplicate' ) }
+					modalTitle={ __( 'Duplicate pattern' ) }
+					onClose={ closeModal }
+					onError={ closeModal }
+					onSuccess={ onPatternSuccess }
+					{ ...duplicatedProps }
+				/>
+			) }
+			{ isModalOpen && isTemplatePart && (
+				<CreateTemplatePartModal
+					buttonLabel={ __( 'Duplicate' ) }
+					closeModal={ closeModal }
+					modalTitle={ __( 'Duplicate template part' ) }
+					onCreate={ onTemplatePartSuccess }
+					onError={ closeModal }
+					{ ...duplicatedProps }
+				/>
+			) }
+		</>
+	);
 }

--- a/packages/edit-site/src/components/page-patterns/use-patterns.js
+++ b/packages/edit-site/src/components/page-patterns/use-patterns.js
@@ -195,6 +195,11 @@ const patternBlockToPattern = ( patternBlock, categories ) => ( {
 					: patternCategoryId
 		),
 	} ),
+	termLabels: patternBlock.wp_pattern_category.map( ( patternCategoryId ) =>
+		categories?.get( patternCategoryId )
+			? categories.get( patternCategoryId ).label
+			: patternCategoryId
+	),
 	id: patternBlock.id,
 	name: patternBlock.slug,
 	syncStatus: patternBlock.wp_pattern_sync_status || PATTERN_SYNC_TYPES.full,

--- a/packages/patterns/src/components/create-pattern-modal.js
+++ b/packages/patterns/src/components/create-pattern-modal.js
@@ -29,15 +29,15 @@ import { unlock } from '../lock-unlock';
 
 export default function CreatePatternModal( {
 	confirmLabel = __( 'Create' ),
-	categories: defaultCategories = [],
+	defaultCategories = [],
 	className = 'patterns-menu-items__convert-modal',
 	content,
 	modalTitle = __( 'Create pattern' ),
 	onClose,
 	onError,
 	onSuccess,
-	syncType: defaultSyncType = PATTERN_SYNC_TYPES.full,
-	title: defaultTitle = '',
+	defaultSyncType = PATTERN_SYNC_TYPES.full,
+	defaultTitle = '',
 } ) {
 	const [ syncType, setSyncType ] = useState( defaultSyncType );
 	const [ categoryTerms, setCategoryTerms ] = useState( defaultCategories );

--- a/packages/patterns/src/components/create-pattern-modal.js
+++ b/packages/patterns/src/components/create-pattern-modal.js
@@ -28,20 +28,20 @@ import CategorySelector, { CATEGORY_SLUG } from './category-selector';
 import { unlock } from '../lock-unlock';
 
 export default function CreatePatternModal( {
-	buttonLabel = __( 'Create' ),
-	categories: categoriesProp = [],
+	confirmLabel = __( 'Create' ),
+	categories: defaultCategories = [],
 	className = 'patterns-menu-items__convert-modal',
 	content,
 	modalTitle = __( 'Create pattern' ),
 	onClose,
 	onError,
 	onSuccess,
-	syncType: syncTypeProp = PATTERN_SYNC_TYPES.full,
-	title: titleProp = '',
+	syncType: defaultSyncType = PATTERN_SYNC_TYPES.full,
+	title: defaultTitle = '',
 } ) {
-	const [ syncType, setSyncType ] = useState( syncTypeProp );
-	const [ categoryTerms, setCategoryTerms ] = useState( categoriesProp );
-	const [ title, setTitle ] = useState( titleProp );
+	const [ syncType, setSyncType ] = useState( defaultSyncType );
+	const [ categoryTerms, setCategoryTerms ] = useState( defaultCategories );
+	const [ title, setTitle ] = useState( defaultTitle );
 
 	const [ isSaving, setIsSaving ] = useState( false );
 	const { createPattern } = unlock( useDispatch( patternsStore ) );
@@ -209,7 +209,7 @@ export default function CreatePatternModal( {
 							aria-disabled={ ! title || isSaving }
 							isBusy={ isSaving }
 						>
-							{ buttonLabel }
+							{ confirmLabel }
 						</Button>
 					</HStack>
 				</VStack>

--- a/packages/patterns/src/components/create-pattern-modal.js
+++ b/packages/patterns/src/components/create-pattern-modal.js
@@ -28,15 +28,21 @@ import CategorySelector, { CATEGORY_SLUG } from './category-selector';
 import { unlock } from '../lock-unlock';
 
 export default function CreatePatternModal( {
-	onSuccess,
-	onError,
-	content,
-	onClose,
+	buttonLabel = __( 'Create' ),
+	categories: categoriesProp = [],
 	className = 'patterns-menu-items__convert-modal',
+	content,
+	modalTitle = __( 'Create pattern' ),
+	onClose,
+	onError,
+	onSuccess,
+	syncType: syncTypeProp = PATTERN_SYNC_TYPES.full,
+	title: titleProp = '',
 } ) {
-	const [ syncType, setSyncType ] = useState( PATTERN_SYNC_TYPES.full );
-	const [ categoryTerms, setCategoryTerms ] = useState( [] );
-	const [ title, setTitle ] = useState( '' );
+	const [ syncType, setSyncType ] = useState( syncTypeProp );
+	const [ categoryTerms, setCategoryTerms ] = useState( categoriesProp );
+	const [ title, setTitle ] = useState( titleProp );
+
 	const [ isSaving, setIsSaving ] = useState( false );
 	const { createPattern } = unlock( useDispatch( patternsStore ) );
 	const { saveEntityRecord, invalidateResolution } = useDispatch( coreStore );
@@ -145,7 +151,7 @@ export default function CreatePatternModal( {
 
 	return (
 		<Modal
-			title={ __( 'Create pattern' ) }
+			title={ modalTitle }
 			onRequestClose={ () => {
 				onClose();
 				setTitle( '' );
@@ -203,7 +209,7 @@ export default function CreatePatternModal( {
 							aria-disabled={ ! title || isSaving }
 							isBusy={ isSaving }
 						>
-							{ __( 'Create' ) }
+							{ buttonLabel }
 						</Button>
 					</HStack>
 				</VStack>


### PR DESCRIPTION
Related:
- https://github.com/WordPress/gutenberg/issues/53320

## What?

- Switches pattern duplication to use a modal
- The modal provides an opportunity for users to edit the pattern data including sync status
- Duplication of template parts also updated to match patterns given they are triggered from the same menu item

## Why?

See https://github.com/WordPress/gutenberg/issues/53320

TL;DR

- Users cannot currently alter the sync status of an existing pattern
- There are technical limitations to changing a pattern's sync status
- The current workflow is:
    1. Edit a pattern
    2. Select its blocks
    3. Create a new pattern
    4. Apply the desired different sync status
    5. Paste into that pattern the copied blocks
    6. Save
- With this alternate duplication flow it is:
    1. Select to duplicate a pattern instead of edit
    2. Change sync status
    3. Optionally change title and categories as well
    4. Save

## How?

- Updates the CreatePatternModal and CreateTemplateModal components to accommodate duplication as a form of creation
- Update the pattern page's duplicate menu item to trigger the updated create modals passing them the required pattern/template part data

## Testing Instructions

1. Test duplication of synced and unsynced user-created patterns
2. Confirm duplication of theme patterns work in a similar manner 
3. Test duplicating template parts


## Screenshots or screencast <!-- if applicable -->


https://github.com/WordPress/gutenberg/assets/60436221/63b529bc-6c2f-4fd8-8f24-87be0914fc97


