### PR TITLE
`SlotFill`: Pass `Component` instance to unregisterSlot.

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -11,6 +11,7 @@
 -   `Placeholder`: Improved DOM structure and screen reader announcements ([#45801](https://github.com/WordPress/gutenberg/pull/45801)).
 -   `DateTimePicker`: fix onChange callback check so that it also works inside iframes ([#54669](https://github.com/WordPress/gutenberg/pull/54669)).
 -   `FormTokenField`: Add `box-sizing` reset style and reset default padding ([#54734](https://github.com/WordPress/gutenberg/pull/54734)).
+-   `SlotFill`: Pass `Component` instance to unregisterSlot ([#54765](https://github.com/WordPress/gutenberg/pull/54765)).
 
 ### Internal
 

--- a/packages/components/src/slot-fill/slot.js
+++ b/packages/components/src/slot-fill/slot.js
@@ -47,7 +47,7 @@ class SlotComponent extends Component {
 		const { name, unregisterSlot, registerSlot } = this.props;
 
 		if ( prevProps.name !== name ) {
-			unregisterSlot( prevProps.name );
+			unregisterSlot( prevProps.name, this );
 			registerSlot( name, this );
 		}
 	}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
part of https://github.com/WordPress/gutenberg/pull/51350.

https://github.com/WordPress/gutenberg/pull/51350#discussion_r1239378390

When the slot name is updated, unregisterSlot is executed and the instance is unregistered, but it is not working correctly because the component instance is not passed. Fix this issue.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

bug fix.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

add `this` .

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

```
npm run test:unit -- --testPathPattern packages/components/src/slot-fill
```

