### PR TITLE
Patterns: Add My patterns back to post editor inserter categories

### DIFF
--- a/packages/block-editor/src/components/inserter/block-patterns-explorer/patterns-list.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-explorer/patterns-list.js
@@ -17,7 +17,7 @@ import InserterListbox from '../../inserter-listbox';
 import { searchItems } from '../search-items';
 import BlockPatternsPaging from '../../block-patterns-paging';
 import usePatternsPaging from '../hooks/use-patterns-paging';
-import { allPatternsCategory } from '../block-patterns-tab';
+import { allPatternsCategory, myPatternsCategory } from '../block-patterns-tab';
 
 function PatternsListHeader( { filterValue, filteredBlockPatternsLength } ) {
 	if ( ! filterValue ) {
@@ -67,7 +67,9 @@ function PatternList( { searchValue, selectedCategory, patternCategories } ) {
 			if ( selectedCategory === allPatternsCategory.name ) {
 				return true;
 			}
-
+			if ( selectedCategory === myPatternsCategory.name && pattern.id ) {
+				return true;
+			}
 			if ( selectedCategory === 'uncategorized' ) {
 				const hasKnownCategory = pattern.categories.some(
 					( category ) =>

--- a/packages/block-editor/src/components/inserter/block-patterns-filter.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-filter.js
@@ -52,7 +52,7 @@ export function BlockPatternsSyncFilter( {
 	const shouldDisableSyncFilter =
 		getShouldDisableSyncFilter( patternSourceFilter );
 
-	// We also need to disable the directory and theme source filter options if the if the category
+	// We also need to disable the directory and theme source filter options if the category
 	// is `myPatterns` otherwise applying them will also just result in no patterns being shown.
 	const shouldDisableNonUserSources =
 		getShouldDisableNonUserSources( category );

--- a/packages/block-editor/src/components/inserter/block-patterns-filter.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-filter.js
@@ -57,6 +57,11 @@ export function BlockPatternsSyncFilter( {
 	const shouldDisableNonUserSources =
 		getShouldDisableNonUserSources( category );
 
+	const currentPatternSoureFilter =
+		category.name === myPatternsCategory.name
+			? PATTERN_TYPES.user
+			: patternSourceFilter;
+
 	const patternSyncMenuOptions = useMemo(
 		() => [
 			{ value: SYNC_TYPES.all, label: __( 'All' ) },
@@ -149,7 +154,7 @@ export function BlockPatternsSyncFilter( {
 										0
 									);
 								} }
-								value={ patternSourceFilter }
+								value={ currentPatternSoureFilter }
 							/>
 						</MenuGroup>
 						<MenuGroup label={ __( 'Type' ) }>

--- a/packages/block-editor/src/components/inserter/block-patterns-filter.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-filter.js
@@ -12,6 +12,11 @@ import { __ } from '@wordpress/i18n';
 import { Icon } from '@wordpress/icons';
 import { useMemo } from '@wordpress/element';
 
+/**
+ * Internal dependencies
+ */
+import { myPatternsCategory } from './block-patterns-tab';
+
 export const PATTERN_TYPES = {
 	all: 'all',
 	synced: 'synced',
@@ -20,25 +25,6 @@ export const PATTERN_TYPES = {
 	theme: 'theme',
 	directory: 'directory',
 };
-
-const patternSourceOptions = [
-	{ value: PATTERN_TYPES.all, label: __( 'All' ) },
-	{
-		value: PATTERN_TYPES.directory,
-		label: __( 'Directory' ),
-		info: __( 'Pattern directory & core' ),
-	},
-	{
-		value: PATTERN_TYPES.theme,
-		label: __( 'Theme' ),
-		info: __( 'Bundled with the theme' ),
-	},
-	{
-		value: PATTERN_TYPES.user,
-		label: __( 'User' ),
-		info: __( 'Custom created' ),
-	},
-];
 
 export const SYNC_TYPES = {
 	all: 'all',
@@ -49,17 +35,27 @@ export const SYNC_TYPES = {
 const getShouldDisableSyncFilter = ( sourceFilter ) =>
 	sourceFilter !== PATTERN_TYPES.all && sourceFilter !== PATTERN_TYPES.user;
 
+const getShouldDisableNonUserSources = ( category ) => {
+	return category.name === myPatternsCategory.name;
+};
+
 export function BlockPatternsSyncFilter( {
 	setPatternSyncFilter,
 	setPatternSourceFilter,
 	patternSyncFilter,
 	patternSourceFilter,
 	scrollContainerRef,
+	category,
 } ) {
 	// We need to disable the sync filter option if the source filter is not 'all' or 'user'
 	// otherwise applying them will just result in no patterns being shown.
 	const shouldDisableSyncFilter =
 		getShouldDisableSyncFilter( patternSourceFilter );
+
+	// We also need to disable the directory and theme source filter options if the if the category
+	// is `myPatterns` otherwise applying them will also just result in no patterns being shown.
+	const shouldDisableNonUserSources =
+		getShouldDisableNonUserSources( category );
 
 	const patternSyncMenuOptions = useMemo(
 		() => [
@@ -78,6 +74,34 @@ export function BlockPatternsSyncFilter( {
 			},
 		],
 		[ shouldDisableSyncFilter ]
+	);
+
+	const patternSourceMenuOptions = useMemo(
+		() => [
+			{
+				value: PATTERN_TYPES.all,
+				label: __( 'All' ),
+				disabled: shouldDisableNonUserSources,
+			},
+			{
+				value: PATTERN_TYPES.directory,
+				label: __( 'Directory' ),
+				info: __( 'Pattern directory & core' ),
+				disabled: shouldDisableNonUserSources,
+			},
+			{
+				value: PATTERN_TYPES.theme,
+				label: __( 'Theme' ),
+				info: __( 'Bundled with the theme' ),
+				disabled: shouldDisableNonUserSources,
+			},
+			{
+				value: PATTERN_TYPES.user,
+				label: __( 'User' ),
+				info: __( 'Custom created' ),
+			},
+		],
+		[ shouldDisableNonUserSources ]
 	);
 
 	function handleSetSourceFilterChange( newSourceFilter ) {
@@ -117,7 +141,7 @@ export function BlockPatternsSyncFilter( {
 					<>
 						<MenuGroup label={ __( 'Author' ) }>
 							<MenuItemsChoice
-								choices={ patternSourceOptions }
+								choices={ patternSourceMenuOptions }
 								onSelect={ ( value ) => {
 									handleSetSourceFilterChange( value );
 									scrollContainerRef.current?.scrollTo(

--- a/packages/block-editor/src/components/inserter/block-patterns-filter.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-filter.js
@@ -47,20 +47,21 @@ export function BlockPatternsSyncFilter( {
 	scrollContainerRef,
 	category,
 } ) {
+	const currentPatternSoureFilter =
+		category.name === myPatternsCategory.name
+			? PATTERN_TYPES.user
+			: patternSourceFilter;
+
 	// We need to disable the sync filter option if the source filter is not 'all' or 'user'
 	// otherwise applying them will just result in no patterns being shown.
-	const shouldDisableSyncFilter =
-		getShouldDisableSyncFilter( patternSourceFilter );
+	const shouldDisableSyncFilter = getShouldDisableSyncFilter(
+		currentPatternSoureFilter
+	);
 
 	// We also need to disable the directory and theme source filter options if the category
 	// is `myPatterns` otherwise applying them will also just result in no patterns being shown.
 	const shouldDisableNonUserSources =
 		getShouldDisableNonUserSources( category );
-
-	const currentPatternSoureFilter =
-		category.name === myPatternsCategory.name
-			? PATTERN_TYPES.user
-			: patternSourceFilter;
 
 	const patternSyncMenuOptions = useMemo(
 		() => [

--- a/packages/block-editor/src/components/inserter/block-patterns-filter.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-filter.js
@@ -47,6 +47,10 @@ export function BlockPatternsSyncFilter( {
 	scrollContainerRef,
 	category,
 } ) {
+	// If the category is `myPatterns` then we need to set the source filter to `user`, but
+	// we do this by deriving from props rather than calling setPatternSourceFilter otherwise
+	// they may be confused when switching to another category if the haven't explicity set
+	// this filter themselves.
 	const currentPatternSourceFilter =
 		category.name === myPatternsCategory.name
 			? PATTERN_TYPES.user

--- a/packages/block-editor/src/components/inserter/block-patterns-filter.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-filter.js
@@ -47,7 +47,7 @@ export function BlockPatternsSyncFilter( {
 	scrollContainerRef,
 	category,
 } ) {
-	const currentPatternSoureFilter =
+	const currentPatternSourceFilter =
 		category.name === myPatternsCategory.name
 			? PATTERN_TYPES.user
 			: patternSourceFilter;
@@ -55,7 +55,7 @@ export function BlockPatternsSyncFilter( {
 	// We need to disable the sync filter option if the source filter is not 'all' or 'user'
 	// otherwise applying them will just result in no patterns being shown.
 	const shouldDisableSyncFilter = getShouldDisableSyncFilter(
-		currentPatternSoureFilter
+		currentPatternSourceFilter
 	);
 
 	// We also need to disable the directory and theme source filter options if the category
@@ -155,7 +155,7 @@ export function BlockPatternsSyncFilter( {
 										0
 									);
 								} }
-								value={ currentPatternSoureFilter }
+								value={ currentPatternSourceFilter }
 							/>
 						</MenuGroup>
 						<MenuGroup label={ __( 'Type' ) }>

--- a/packages/block-editor/src/components/inserter/block-patterns-filter.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-filter.js
@@ -49,7 +49,7 @@ export function BlockPatternsSyncFilter( {
 } ) {
 	// If the category is `myPatterns` then we need to set the source filter to `user`, but
 	// we do this by deriving from props rather than calling setPatternSourceFilter otherwise
-	// they may be confused when switching to another category if the haven't explicity set
+	// the user may be confused when switching to another category if the haven't explicity set
 	// this filter themselves.
 	const currentPatternSourceFilter =
 		category.name === myPatternsCategory.name

--- a/packages/block-editor/src/components/inserter/block-patterns-tab.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-tab.js
@@ -199,6 +199,7 @@ export function BlockPatternsCategoryDialog( {
 			className="block-editor-inserter__patterns-category-dialog"
 		>
 			<BlockPatternsCategoryPanel
+				key={ category.name }
 				rootClientId={ rootClientId }
 				onInsert={ onInsert }
 				onHover={ onHover }
@@ -410,6 +411,7 @@ function BlockPatternsTabs( {
 				<MobileTabNavigation categories={ categories }>
 					{ ( category ) => (
 						<BlockPatternsCategoryPanel
+							key={ category.name }
 							onInsert={ onInsert }
 							rootClientId={ rootClientId }
 							category={ category }

--- a/packages/block-editor/src/components/inserter/block-patterns-tab.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-tab.js
@@ -45,7 +45,7 @@ export const allPatternsCategory = {
 	label: __( 'All Patterns' ),
 };
 
-const myPatternsCategory = {
+export const myPatternsCategory = {
 	name: 'myPatterns',
 	label: __( 'My patterns' ),
 };

--- a/packages/block-editor/src/components/inserter/block-patterns-tab.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-tab.js
@@ -45,6 +45,11 @@ export const allPatternsCategory = {
 	label: __( 'All Patterns' ),
 };
 
+const myPatternsCategory = {
+	name: 'myPatterns',
+	label: __( 'My patterns' ),
+};
+
 export function isPatternFiltered( pattern, sourceFilter, syncFilter ) {
 	const isUserPattern = pattern.name.startsWith( 'core/block' );
 	const isDirectoryPattern =
@@ -146,8 +151,8 @@ export function usePatternsCategories( rootClientId, sourceFilter = 'all' ) {
 		}
 		if ( filteredPatterns.some( ( pattern ) => pattern.id ) ) {
 			categories.unshift( {
-				name: 'my-patterns',
-				label: _x( 'My patterns' ),
+				name: myPatternsCategory.name,
+				label: myPatternsCategory.label,
 			} );
 		}
 		if ( filteredPatterns.length > 0 ) {
@@ -243,7 +248,7 @@ export function BlockPatternsCategoryPanel( {
 				if ( category.name === allPatternsCategory.name ) {
 					return true;
 				}
-				if ( category.name === 'my-patterns' && pattern.id ) {
+				if ( category.name === myPatternsCategory.name && pattern.id ) {
 					return true;
 				}
 				if ( category.name !== 'uncategorized' ) {

--- a/packages/block-editor/src/components/inserter/block-patterns-tab.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-tab.js
@@ -301,6 +301,7 @@ export function BlockPatternsCategoryPanel( {
 						setPatternSyncFilter={ setPatternSyncFilter }
 						setPatternSourceFilter={ setPatternSourceFilter }
 						scrollContainerRef={ scrollContainerRef }
+						category={ category }
 					/>
 				</HStack>
 				{ category.description && (

--- a/packages/block-editor/src/components/inserter/block-patterns-tab.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-tab.js
@@ -150,10 +150,7 @@ export function usePatternsCategories( rootClientId, sourceFilter = 'all' ) {
 			} );
 		}
 		if ( filteredPatterns.some( ( pattern ) => pattern.id ) ) {
-			categories.unshift( {
-				name: myPatternsCategory.name,
-				label: myPatternsCategory.label,
-			} );
+			categories.unshift( myPatternsCategory );
 		}
 		if ( filteredPatterns.length > 0 ) {
 			categories.unshift( {

--- a/packages/block-editor/src/components/inserter/block-patterns-tab.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-tab.js
@@ -144,6 +144,12 @@ export function usePatternsCategories( rootClientId, sourceFilter = 'all' ) {
 				label: _x( 'Uncategorized' ),
 			} );
 		}
+		if ( filteredPatterns.some( ( pattern ) => pattern.id ) ) {
+			categories.unshift( {
+				name: 'my-patterns',
+				label: _x( 'My patterns' ),
+			} );
+		}
 		if ( filteredPatterns.length > 0 ) {
 			categories.unshift( {
 				name: allPatternsCategory.name,
@@ -235,6 +241,9 @@ export function BlockPatternsCategoryPanel( {
 				}
 
 				if ( category.name === allPatternsCategory.name ) {
+					return true;
+				}
+				if ( category.name === 'my-patterns' && pattern.id ) {
 					return true;
 				}
 				if ( category.name !== 'uncategorized' ) {


### PR DESCRIPTION
## What?
Reinstates the "My patterns" category in the post editor's inserter as an easy place for users to see all their custom patterns at once.

## Why?
Feedback has been provided that this category was missed after the addition of custom user-created pattern categories removed it in favour of an "All patterns" category.

## How?

- Add the "My patterns" category back to the usePatternCategories hook
- Update the filtering for patterns to handle the "My patterns" category
- Add a new constant for the "My patterns" category name

## Testing Instructions

- In the post editor add some new patterns with categories
- In the inserter tab select the patterns tab and make sure there is a `My patterns` category and that it displays the user created pattersn
- Make sure the `My patterns` category also works in the patterns explorer modal
- Make sure that when `My patterns` category is selected that the directory and theme source filters are disabled as it doesn't make sense to be able to enable these in this category tab

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/3629020/1cc4845d-a1d6-49aa-bbb2-35d346e7483f




