### PR TITLE
Patterns: fix bug with new categories not showing

### DIFF
--- a/packages/edit-site/src/components/sidebar-edit-mode/template-panel/pattern-categories.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/template-panel/pattern-categories.js
@@ -150,7 +150,8 @@ export default function PatternCategories( { post } ) {
 		);
 	}, [ searchResults ] );
 
-	const { saveEntityRecord, editEntityRecord } = useDispatch( coreStore );
+	const { saveEntityRecord, editEntityRecord, invalidateResolution } =
+		useDispatch( coreStore );
 	const { createErrorNotice } = useDispatch( noticesStore );
 
 	if ( ! hasAssignAction ) {
@@ -162,6 +163,7 @@ export default function PatternCategories( { post } ) {
 			const newTerm = await saveEntityRecord( 'taxonomy', slug, term, {
 				throwOnError: true,
 			} );
+			invalidateResolution( 'getUserPatternCategories' );
 			return unescapeTerm( newTerm );
 		} catch ( error ) {
 			if ( error.code !== 'term_exists' ) {


### PR DESCRIPTION
## What?
Fixes a bug where new patterns categories added in the site editor pattern editor sidebar do not show until browser is refreshed.

## Why?
Fixes: https://github.com/WordPress/gutenberg/issues/54752

## How?
Invalidates the pattern category resolver when a new category is added in the site editor right sidebar.

## Testing Instructions
- Access `wp-admin/edit-tags.php?taxonomy=wp_pattern_category` and delete all categories.
- Create a pattern in the Site Editor. Do not add categories.
- When the pattern editor window opens add categories in the editor's right sidebar and save the entity.
- Return to the view mode.
- Check that the added category isdisplayed in "Categories" in the details panel.
- Go back to back to the Patterns page.
- Check the newly added categories are not displayed in left navigation bar.

## Screenshots or screencast <!-- if applicable -->

Before:

https://github.com/WordPress/gutenberg/assets/54422211/d6269115-c8ed-4b09-8b77-aae7711c03de

After:

https://github.com/WordPress/gutenberg/assets/3629020/ad66e8c1-80a9-4659-86a1-51854e41cb0f


