### PR TITLE
Site Editor: remove `overflow: hidden` from the entity title in the site editor sidebar

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-screen/style.scss
@@ -68,7 +68,6 @@
 .edit-site-sidebar-navigation-screen__title {
 	flex-grow: 1;
 	padding: $grid-unit-15 * 0.5 0 0 0;
-	overflow: hidden;
 	overflow-wrap: break-word;
 }
 


### PR DESCRIPTION
## What?
Resolves https://github.com/WordPress/gutenberg/issues/52218

Removing `overflow: hidden` from `.edit-site-sidebar-navigation-screen__title`, which is the entity title in the site editor sidebar.

## Why?
1. It doesn't appear to be required to hide text overflow in general (checked in modern browsers)
2. In Windows Edge the descender segment of letters are cut off, e.g., for "g", "p", "y" and so on.



## Testing Instructions
1. In Windows Edge, head on over to `/wp-admin/site-editor.php` and view a single entity (page, template, pattern etc) that has characters with descenders. 
2. Check those descenders are not cut off.
3. Try with a long entity title and in narrow viewport widths
4. Ensure there are no side-effects for other major browsers.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

| Before  | After |
| ------------- | ------------- |
| <img width="300" alt="Screenshot 2023-09-25 at 10 49 12 am" src="https://github.com/WordPress/gutenberg/assets/6458278/077fd9b6-022a-4f4f-a633-70c6b40dad02">  | <img width="300" alt="Screenshot 2023-09-25 at 10 48 40 am" src="https://github.com/WordPress/gutenberg/assets/6458278/7534f492-d18a-49ab-8c1e-f8d774ef4ac2">  |
| <img width="300" alt="Screenshot 2023-09-25 at 10 30 06 am" src="https://github.com/WordPress/gutenberg/assets/6458278/e1ffd294-0d47-430f-aaa8-4b072c90df5c">  | <img width="300" alt="Screenshot 2023-09-25 at 10 51 17 am" src="https://github.com/WordPress/gutenberg/assets/6458278/8056e872-7c12-4e40-8f09-57c880ad06d9"> |


Also check long entity titles:

<img width="340" alt="Screenshot 2023-09-25 at 10 58 02 am" src="https://github.com/WordPress/gutenberg/assets/6458278/af9c3b18-841c-4a21-b852-789533268e81">

And in mobile view:


https://github.com/WordPress/gutenberg/assets/6458278/a061b3fa-b4c3-43f2-bb89-bd1adb65c26f




