### PR TITLE
Font Library: remove font files created by tests after tests run

### DIFF
--- a/phpunit/tests/fonts/font-library/wpRestFontLibraryController/base.php
+++ b/phpunit/tests/fonts/font-library/wpRestFontLibraryController/base.php
@@ -7,8 +7,18 @@
  */
 abstract class WP_REST_Font_Library_Controller_UnitTestCase extends WP_UnitTestCase {
 
+	/**
+	 * Fonts directory.
+	 *
+	 * @var string
+	 */
+	protected static $fonts_dir;
+
+
 	public function set_up() {
 		parent::set_up();
+
+		static::$fonts_dir = WP_Font_Library::get_fonts_dir();
 
 		// Create a user with administrator role.
 		$admin_id = $this->factory->user->create(
@@ -30,5 +40,10 @@ abstract class WP_REST_Font_Library_Controller_UnitTestCase extends WP_UnitTestC
 		$property   = $reflection->getProperty( 'collections' );
 		$property->setAccessible( true );
 		$property->setValue( array() );
+
+		// Clean up the /fonts directory.
+		foreach ( $this->files_in_dir( static::$fonts_dir ) as $file ) {
+			@unlink( $file );
+		}
 	}
 }


### PR DESCRIPTION
## What?
Font Library: remove font files created by tests after tests run

## Why?
To avoid unwated files in the test env.

## How?
By removing all the font files in the fonts directory after test run

## Testing Instructions
Run unit tests

