### PR TITLE
Fix a broken MD link in callout

### DIFF
--- a/docs/how-to-guides/block-tutorial/writing-your-first-block-type.md
+++ b/docs/how-to-guides/block-tutorial/writing-your-first-block-type.md
@@ -7,7 +7,7 @@ This guide takes you through creating a basic block to display a message in a po
 There are two main types of blocks: static and dynamic, this guide focuses on static blocks. A static block is used to insert HTML content into the post and save it with the post. A dynamic block builds the content on the fly when rendered on the front end, see the [dynamic blocks guide](/docs/how-to-guides/block-tutorial/creating-dynamic-blocks.md).
 
 <div class="callout callout-alert">
-This guide focuses on just the block, see the <a href="/docs/getting-started/create-block">Create a Block tutorial</a> for a complete setup.
+This guide focuses on just the block, see the <a href="https://developer.wordpress.org/block-editor/getting-started/create-block/">Create a Block tutorial</a> for a complete setup.
 </div>
 
 ## Before you start

--- a/docs/how-to-guides/block-tutorial/writing-your-first-block-type.md
+++ b/docs/how-to-guides/block-tutorial/writing-your-first-block-type.md
@@ -7,7 +7,7 @@ This guide takes you through creating a basic block to display a message in a po
 There are two main types of blocks: static and dynamic, this guide focuses on static blocks. A static block is used to insert HTML content into the post and save it with the post. A dynamic block builds the content on the fly when rendered on the front end, see the [dynamic blocks guide](/docs/how-to-guides/block-tutorial/creating-dynamic-blocks.md).
 
 <div class="callout callout-alert">
-This guide focuses on just the block, see the [Create a Block tutorial](/docs/getting-started/create-block/README.md) for a complete setup.
+This guide focuses on just the block, see the <a href="/docs/getting-started/create-block">Create a Block tutorial</a> for a complete setup.
 </div>
 
 ## Before you start

--- a/packages/components/README.md
+++ b/packages/components/README.md
@@ -35,7 +35,7 @@ _If you're using [`Popover`](/packages/components/src/popover/README.md) or [`To
 
 By default, the `Popover` component will render within an extra element appended to the body of the document.
 
-If you want to precisely contol where the popovers render, you will need to use the `Popover.Slot` component.
+If you want to precisely control where the popovers render, you will need to use the `Popover.Slot` component.
 
 A `Popover` is also used as the underlying mechanism to display `Tooltip` components.
 So the same considerations should be applied to them.

--- a/packages/components/README.md
+++ b/packages/components/README.md
@@ -35,7 +35,7 @@ _If you're using [`Popover`](/packages/components/src/popover/README.md) or [`To
 
 By default, the `Popover` component will render within an extra element appended to the body of the document.
 
-If you want to precisely control where the popovers render, you will need to use the `Popover.Slot` component.
+If you want to precisely contol where the popovers render, you will need to use the `Popover.Slot` component.
 
 A `Popover` is also used as the underlying mechanism to display `Tooltip` components.
 So the same considerations should be applied to them.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
MarkDown link broken in callout div. Use pure HTML link to solve it.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
Use MD editor Preview or Open https://developer.wordpress.org/block-editor/how-to-guides/block-tutorial/writing-your-first-block-type/ to see how MD link broken.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
![MD_link_broken_in_Callout](https://github.com/WordPress/gutenberg/assets/3759923/e7c40259-758b-47b1-a839-1c0a42544309)
