### PR TITLE
Search block: update alignment and icon button width

### DIFF
--- a/packages/block-library/src/search/edit.js
+++ b/packages/block-library/src/search/edit.js
@@ -345,6 +345,7 @@ export default function SearchEdit( {
 
 				{ ! buttonUseIcon && (
 					<RichText
+						tagName="button"
 						className={ buttonClasses }
 						style={ buttonStyles }
 						aria-label={ __( 'Button text' ) }

--- a/packages/block-library/src/search/edit.js
+++ b/packages/block-library/src/search/edit.js
@@ -345,7 +345,6 @@ export default function SearchEdit( {
 
 				{ ! buttonUseIcon && (
 					<RichText
-						tagName="button"
 						className={ buttonClasses }
 						style={ buttonStyles }
 						aria-label={ __( 'Button text' ) }

--- a/packages/block-library/src/search/editor.scss
+++ b/packages/block-library/src/search/editor.scss
@@ -13,6 +13,7 @@
 		display: flex;
 		align-items: center;
 		justify-content: center;
+		text-align: center;
 	}
 
 	&__components-button-group {

--- a/packages/block-library/src/search/style.scss
+++ b/packages/block-library/src/search/style.scss
@@ -55,6 +55,11 @@ $button-spacing-y: math.div($grid-unit-15, 2); // 6px
 		margin-left: 0;
 		// Prevent unintended text wrapping.
 		flex-shrink: 0;
+		// Ensure minimum input field width in small viewports.
+		max-width: calc(100% - 100px);
+		&.has-icon {
+			max-width: 100%;
+		}
 	}
 }
 

--- a/packages/block-library/src/search/style.scss
+++ b/packages/block-library/src/search/style.scss
@@ -55,8 +55,6 @@ $button-spacing-y: math.div($grid-unit-15, 2); // 6px
 		margin-left: 0;
 		// Prevent unintended text wrapping.
 		flex-shrink: 0;
-		// Ensure minimum input field width in small viewports.
-		max-width: calc(100% - 100px);
 	}
 }
 


### PR DESCRIPTION
## What?
1. Give the rich text button a CSS declaration of `text:center`
2. Remove max-width change for buttons with icons only so that it doesn't affect search button icons in the header or in narrow widths


## Why?
1. In the editor, the button text was aligned left because it was being rendered as a text field (and not a button). In the frontend the text is centered because it's a button 😄 
2. For search buttons with icons only, the `-100px` in the `calc()` formula was causing the button to be a bit squished

## Testing Instructions
I'm using 2023 to test, though this should work in other block themes.

Add a search block to a page. Use text for the button label and add a break point so you can see how the text is aligned.

Save the page. The search block button text alignment in the editor should match the frontend.

<img width="682" alt="Screenshot 2023-09-25 at 12 20 10 pm" src="https://github.com/WordPress/gutenberg/assets/6458278/1c4abb08-e84e-4e9c-a931-c5a4c9ccc14a">
<img width="681" alt="Screenshot 2023-09-25 at 12 19 52 pm" src="https://github.com/WordPress/gutenberg/assets/6458278/3389c3a7-55b3-4297-a97d-64811883a64c">

Add a search block to a navigation block or in the header, or elsewhere where space is constricted.

Select button with icon and button only options for the search block. Save and check the frontend:

| Before  | After |
| ------------- | ------------- |
|  <img width="288" alt="Screenshot 2023-09-25 at 1 07 12 pm" src="https://github.com/WordPress/gutenberg/assets/6458278/390b2da8-10f6-48b4-9e4b-de3fc11ceda3"> | <img width="283" alt="Screenshot 2023-09-25 at 1 07 22 pm" src="https://github.com/WordPress/gutenberg/assets/6458278/93f9a44e-aa59-4fc1-a953-6752651ac370">  |

