### PR TITLE
Reset page after changing pattern filters or search value

### DIFF
--- a/packages/block-editor/src/components/inserter/block-patterns-explorer/patterns-list.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-explorer/patterns-list.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useMemo, useEffect, useRef } from '@wordpress/element';
+import { useMemo, useEffect, useRef, useState } from '@wordpress/element';
 import { _n, sprintf } from '@wordpress/i18n';
 import { useDebounce } from '@wordpress/compose';
 import { __experimentalHeading as Heading } from '@wordpress/components';
@@ -111,6 +111,14 @@ function PatternList( { searchValue, selectedCategory, patternCategories } ) {
 		selectedCategory,
 		container
 	);
+
+	// Reset page when search value changes.
+	const [ previousSearchValue, setPreviousSearchValue ] =
+		useState( searchValue );
+	if ( searchValue !== previousSearchValue ) {
+		setPreviousSearchValue( searchValue );
+		pagingProps.changePage( 1 );
+	}
 
 	const hasItems = !! filteredBlockPatterns?.length;
 	return (

--- a/packages/block-editor/src/components/inserter/block-patterns-tab.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-tab.js
@@ -267,10 +267,26 @@ export function BlockPatternsCategoryPanel( {
 		category,
 		scrollContainerRef
 	);
+	const { changePage } = pagingProps;
 
 	// Hide block pattern preview on unmount.
 	// eslint-disable-next-line react-hooks/exhaustive-deps
 	useEffect( () => () => onHover( null ), [] );
+
+	const onSetPatternSyncFilter = useCallback(
+		( value ) => {
+			setPatternSyncFilter( value );
+			changePage( 1 );
+		},
+		[ setPatternSyncFilter, changePage ]
+	);
+	const onSetPatternSourceFilter = useCallback(
+		( value ) => {
+			setPatternSourceFilter( value );
+			changePage( 1 );
+		},
+		[ setPatternSourceFilter, changePage ]
+	);
 
 	return (
 		<div className="block-editor-inserter__patterns-category-panel">
@@ -287,8 +303,8 @@ export function BlockPatternsCategoryPanel( {
 					<BlockPatternsSyncFilter
 						patternSyncFilter={ patternSyncFilter }
 						patternSourceFilter={ patternSourceFilter }
-						setPatternSyncFilter={ setPatternSyncFilter }
-						setPatternSourceFilter={ setPatternSourceFilter }
+						setPatternSyncFilter={ onSetPatternSyncFilter }
+						setPatternSourceFilter={ onSetPatternSourceFilter }
 						scrollContainerRef={ scrollContainerRef }
 					/>
 				</HStack>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Reset the page in the patterns inserter and explorer when changing the filters or the search value.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
It could result in no patterns when filtering or searching while there are results.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Calling `changePage( 1 )` at the right time and place.

## Testing Instructions for Keyboard
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Open post editor
2. Click on the global inserter button and navigate to the "Patterns" tab
3. Visit the "All patterns" category, scroll to the bottom in the panel, and navigate to the next page (you'll need to have enough patterns to be able to change pages).
4. <kbd>Shift</kbd>+<kbd>Tab</kbd> a couple of times until you land on the "Filter patterns" dropdown button and open it.
5. Select "Theme" (or other filters) in the filter dropdown and close the dropdown (<kbd>Escape</kbd>).
6. The filtered patterns should begin from page 1.
7. <kbd>Shift</kbd>+<kbd>Tab</kbd> and open the "Explore all patterns" button to open the explorer modal.
8. Scroll to the bottom and navigate to the next page.
9. <kbd>Tab</kbd> until you focus the search value input.
10. Type something to search for existing patterns.
11. Expect the patterns list page to reset to 1.

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/7753001/74c70ee4-f0eb-4e92-bd36-195f88924852

