### PR TITLE
Upgrade wp-prettier to v3.0.3 (final)

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -6,3 +6,9 @@ f63053cace3c02e284f00918e1854284c85b9132
 
 # Prettier upgrade to 2.6.2.
 33d84b036592a5bf31af05b7710f3b2b14163dc4
+
+# Prettier upgrade to 2.8.5.
+c56e8a1910ed74f405b74bbb12fe81dea974e5c3
+
+# Prettier upgrade to 3.0.3.
+0bee15148fe4330c20cf372cb46a33693e45cb5f

--- a/package-lock.json
+++ b/package-lock.json
@@ -57067,7 +57067,7 @@
 			"peerDependencies": {
 				"@babel/core": ">=7",
 				"eslint": ">=8",
-				"prettier": ">=2",
+				"prettier": ">=3",
 				"typescript": ">=4"
 			},
 			"peerDependenciesMeta": {
@@ -57519,7 +57519,7 @@
 				"node": ">=14"
 			},
 			"peerDependencies": {
-				"prettier": ">=2"
+				"prettier": ">=3"
 			}
 		},
 		"packages/primitives": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -214,7 +214,7 @@
 				"patch-package": "6.2.2",
 				"postcss": "8.4.16",
 				"postcss-loader": "6.2.1",
-				"prettier": "npm:wp-prettier@3.0.3-beta-3",
+				"prettier": "npm:wp-prettier@3.0.3",
 				"progress": "2.0.3",
 				"react": "18.2.0",
 				"react-dom": "18.2.0",
@@ -46439,9 +46439,9 @@
 		},
 		"node_modules/prettier": {
 			"name": "wp-prettier",
-			"version": "3.0.3-beta-3",
-			"resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-3.0.3-beta-3.tgz",
-			"integrity": "sha512-R3+TD7j0rnqEpMgylrUrHdi1W6ypwh4QGeFOZQ9YjP9WvNnZzBAS71yry1h7xIcG/bVaNKBCoWNqbqJY6vkOKQ==",
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-3.0.3.tgz",
+			"integrity": "sha512-X4UlrxDTH8oom9qXlcjnydsjAOD2BmB6yFmvS4Z2zdTzqqpRWb+fbqrH412+l+OUXmbzJlSXjlMFYPgYG12IAA==",
 			"dev": true,
 			"bin": {
 				"prettier": "bin/prettier.cjs"
@@ -57837,7 +57837,7 @@
 				"playwright-core": "1.32.0",
 				"postcss": "^8.4.5",
 				"postcss-loader": "^6.2.1",
-				"prettier": "npm:wp-prettier@3.0.3-beta-3",
+				"prettier": "npm:wp-prettier@3.0.3",
 				"puppeteer-core": "^13.2.0",
 				"react-refresh": "^0.14.0",
 				"read-pkg-up": "^7.0.1",
@@ -70579,7 +70579,7 @@
 				"playwright-core": "1.32.0",
 				"postcss": "^8.4.5",
 				"postcss-loader": "^6.2.1",
-				"prettier": "npm:wp-prettier@3.0.3-beta-3",
+				"prettier": "npm:wp-prettier@3.0.3",
 				"puppeteer-core": "^13.2.0",
 				"react-refresh": "^0.14.0",
 				"read-pkg-up": "^7.0.1",
@@ -95595,9 +95595,9 @@
 			"dev": true
 		},
 		"prettier": {
-			"version": "npm:wp-prettier@3.0.3-beta-3",
-			"resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-3.0.3-beta-3.tgz",
-			"integrity": "sha512-R3+TD7j0rnqEpMgylrUrHdi1W6ypwh4QGeFOZQ9YjP9WvNnZzBAS71yry1h7xIcG/bVaNKBCoWNqbqJY6vkOKQ==",
+			"version": "npm:wp-prettier@3.0.3",
+			"resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-3.0.3.tgz",
+			"integrity": "sha512-X4UlrxDTH8oom9qXlcjnydsjAOD2BmB6yFmvS4Z2zdTzqqpRWb+fbqrH412+l+OUXmbzJlSXjlMFYPgYG12IAA==",
 			"dev": true
 		},
 		"prettier-linter-helpers": {

--- a/package.json
+++ b/package.json
@@ -226,7 +226,7 @@
 		"patch-package": "6.2.2",
 		"postcss": "8.4.16",
 		"postcss-loader": "6.2.1",
-		"prettier": "npm:wp-prettier@3.0.3-beta-3",
+		"prettier": "npm:wp-prettier@3.0.3",
 		"progress": "2.0.3",
 		"react": "18.2.0",
 		"react-dom": "18.2.0",

--- a/packages/eslint-plugin/CHANGELOG.md
+++ b/packages/eslint-plugin/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+-   Change the required major version of Prettier from v2 to v3 ([#54775](https://github.com/WordPress/gutenberg/pull/54775)).
+
 ## 16.0.0 (2023-09-20)
 
 ### Breaking Changes

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -52,7 +52,7 @@
 	"peerDependencies": {
 		"@babel/core": ">=7",
 		"eslint": ">=8",
-		"prettier": ">=2",
+		"prettier": ">=3",
 		"typescript": ">=4"
 	},
 	"peerDependenciesMeta": {

--- a/packages/prettier-config/CHANGELOG.md
+++ b/packages/prettier-config/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Change
+
+-   Change the required major version of Prettier from v2 to v3 ([#54775](https://github.com/WordPress/gutenberg/pull/54775)).
+
 ## 2.25.0 (2023-09-20)
 
 ## 2.24.0 (2023-08-31)

--- a/packages/prettier-config/package.json
+++ b/packages/prettier-config/package.json
@@ -28,7 +28,7 @@
 	"main": "lib/index.js",
 	"types": "build-types",
 	"peerDependencies": {
-		"prettier": ">=2"
+		"prettier": ">=3"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -75,7 +75,7 @@
 		"playwright-core": "1.32.0",
 		"postcss": "^8.4.5",
 		"postcss-loader": "^6.2.1",
-		"prettier": "npm:wp-prettier@3.0.3-beta-3",
+		"prettier": "npm:wp-prettier@3.0.3",
 		"puppeteer-core": "^13.2.0",
 		"react-refresh": "^0.14.0",
 		"read-pkg-up": "^7.0.1",


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/54749.

Finalizes the Prettier upgrade to 3.0.3. After a week without discovering any new bugs, I released final 3.0.3 version of `wp-prettier` (previous releases were betas), and updated Gutenberg's `package.json` files to use the final version.

I also added the reformatting commits for 3.0.3 (#54539) and 2.8.5 (#49258) to the `.git-blame-ignore-revs` file.