### PR TITLE
Duotone: Backport from Core to fix filters in classic themes

### DIFF
--- a/lib/class-wp-duotone-gutenberg.php
+++ b/lib/class-wp-duotone-gutenberg.php
@@ -946,7 +946,7 @@ class WP_Duotone_Gutenberg {
 				wp_add_inline_style( $style_tag_id, self::get_global_styles_presets( self::$used_global_styles_presets ) );
 			}
 			if ( ! empty( self::$block_css_declarations ) ) {
-				wp_add_inline_style( $style_tag_id, wp_style_engine_get_stylesheet_from_css_rules( self::$block_css_declarations ) );
+				wp_add_inline_style( $style_tag_id, gutenberg_style_engine_get_stylesheet_from_css_rules( self::$block_css_declarations ) );
 			}
 			wp_enqueue_style( $style_tag_id );
 		}

--- a/lib/class-wp-duotone-gutenberg.php
+++ b/lib/class-wp-duotone-gutenberg.php
@@ -938,9 +938,17 @@ class WP_Duotone_Gutenberg {
 			echo self::get_svg_definitions( self::$used_svg_filter_data );
 		}
 
-		// This is for classic themes - in block themes, the CSS is added in the head via wp_add_inline_style in the wp_enqueue_scripts action.
-		if ( ! wp_is_block_theme() && ! empty( self::$used_global_styles_presets ) ) {
-			wp_add_inline_style( 'core-block-supports', self::get_global_styles_presets( self::$used_global_styles_presets ) );
+		// In block themes, the CSS is added in the head via wp_add_inline_style in the wp_enqueue_scripts action.
+		if ( ! wp_is_block_theme() ) {
+			$style_tag_id = 'core-block-supports-duotone';
+			wp_register_style( $style_tag_id, false );
+			if ( ! empty( self::$used_global_styles_presets ) ) {
+				wp_add_inline_style( $style_tag_id, self::get_global_styles_presets( self::$used_global_styles_presets ) );
+			}
+			if ( ! empty( self::$block_css_declarations ) ) {
+				wp_add_inline_style( $style_tag_id, wp_style_engine_get_stylesheet_from_css_rules( self::$block_css_declarations ) );
+			}
+			wp_enqueue_style( $style_tag_id );
 		}
 	}
 


### PR DESCRIPTION
Fixes #54099
Related Core PR: https://github.com/WordPress/wordpress-develop/pull/4839

## What?

This PR applies the Duotone filter fix in the Classic theme committed in Core to the Gutenberg plugin.

## Why?

Without this PR, the Dutone filter will not be applied to Classic themes when the Gutenberg plugin is activated, as reported in #54099.

## How?

I applied the changes made in the core as is.

## Testing Instructions

Verify that the image block duotone filter works in both block and classic themes.