### PR TITLE
Drop support for otf font installation in font library

### DIFF
--- a/lib/experimental/fonts/font-library/class-wp-font-library.php
+++ b/lib/experimental/fonts/font-library/class-wp-font-library.php
@@ -23,7 +23,6 @@ class WP_Font_Library {
 	const PHP_7_TTF_MIME_TYPE = PHP_VERSION_ID >= 70300 ? 'application/font-sfnt' : 'application/x-font-ttf';
 
 	const ALLOWED_FONT_MIME_TYPES = array(
-		'otf'   => 'font/otf',
 		'ttf'   => PHP_VERSION_ID >= 70400 ? 'font/sfnt' : self::PHP_7_TTF_MIME_TYPE,
 		'woff'  => PHP_VERSION_ID >= 80100 ? 'font/woff' : 'application/font-woff',
 		'woff2' => PHP_VERSION_ID >= 80100 ? 'font/woff2' : 'application/font-woff2',

--- a/packages/edit-site/src/components/global-styles/font-library-modal/utils/constants.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/utils/constants.js
@@ -3,7 +3,7 @@
  */
 import { _x } from '@wordpress/i18n';
 
-export const ALLOWED_FILE_EXTENSIONS = [ 'otf', 'ttf', 'woff', 'woff2' ];
+export const ALLOWED_FILE_EXTENSIONS = [ 'ttf', 'woff', 'woff2' ];
 
 export const FONT_WEIGHTS = {
 	100: _x( 'Thin', 'font weight' ),


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This drops support for `otf` fonts because of the two different mimes being returned for the same extension.
`font/otf` and `application/vnd.ms-opentype`

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Currently the core function `wp_handle_upload` doesn't support multiple mime values as overrides.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Try uploading `otf` font file.
2. It should not allow in the UI and API.

## Related issues

Fixes: #54759
