### PR TITLE
Query block: Start prefetching on first click to next/previous

### DIFF
--- a/packages/block-library/src/query-pagination-next/index.php
+++ b/packages/block-library/src/query-pagination-next/index.php
@@ -74,6 +74,7 @@ function render_block_core_query_pagination_next( $attributes, $content, $block 
 			$p->set_attribute( 'data-wp-key', 'query-pagination-next' );
 			$p->set_attribute( 'data-wp-on--click', 'actions.core.query.navigate' );
 			$p->set_attribute( 'data-wp-on--mouseenter', 'actions.core.query.prefetch' );
+			$p->set_attribute( 'data-wp-effect', 'effects.core.query.prefetch' );
 			$content = $p->get_updated_html();
 		}
 	}

--- a/packages/block-library/src/query-pagination-previous/index.php
+++ b/packages/block-library/src/query-pagination-previous/index.php
@@ -62,6 +62,7 @@ function render_block_core_query_pagination_previous( $attributes, $content, $bl
 			$p->set_attribute( 'data-wp-key', 'query-pagination-previous' );
 			$p->set_attribute( 'data-wp-on--click', 'actions.core.query.navigate' );
 			$p->set_attribute( 'data-wp-on--mouseenter', 'actions.core.query.prefetch' );
+			$p->set_attribute( 'data-wp-effect', 'effects.core.query.prefetch' );
 			$content = $p->get_updated_html();
 		}
 	}

--- a/packages/block-library/src/query/view.js
+++ b/packages/block-library/src/query/view.js
@@ -62,6 +62,7 @@ store( {
 								: '' );
 
 						context.core.query.animation = 'finish';
+						context.core.query.url = ref.href;
 
 						// Focus the first anchor of the Query block.
 						const firstAnchor = `[data-wp-navigation-id=${ id }] .wp-block-post-template a[href]`;
@@ -70,6 +71,17 @@ store( {
 				},
 				prefetch: async ( { ref } ) => {
 					if ( isValidLink( ref ) ) {
+						await prefetch( ref.href );
+					}
+				},
+			},
+		},
+	},
+	effects: {
+		core: {
+			query: {
+				prefetch: async ( { ref, context } ) => {
+					if ( context.core.query.url && isValidLink( ref ) ) {
 						await prefetch( ref.href );
 					}
 				},


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

I added logic to start prefetching the next page on the first click to the next and previous buttons.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Because when the user starts to paginate, it's very likely that they will continue paginating. Prefetching the next/previous links automatically makes the subsequent pagination feel 100% instant.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

By adding an effect that triggers when the url changes and the user has paginated at least once.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- Enable the enhanced pagination
- Inspect the Fetch requests using your browser's devtools
- Check that after you navigate for the first time, the new next/previous links are automatically prefetched.

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/3305402/a57d06e7-7fd7-4ef6-bd69-1936acb036c5


