### PR TITLE
Update pattern import menu item

### DIFF
--- a/packages/edit-site/src/components/add-new-pattern/index.js
+++ b/packages/edit-site/src/components/add-new-pattern/index.js
@@ -4,7 +4,7 @@
 import { DropdownMenu } from '@wordpress/components';
 import { useState, useRef } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
-import { plus, symbol, symbolFilled } from '@wordpress/icons';
+import { plus, symbol, symbolFilled, upload } from '@wordpress/icons';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { privateApis as routerPrivateApis } from '@wordpress/router';
 import {
@@ -93,11 +93,11 @@ export default function AddNewPattern() {
 	}
 
 	controls.push( {
-		icon: symbol,
+		icon: upload,
 		onClick: () => {
 			patternUploadInputRef.current.click();
 		},
-		title: __( 'Import pattern from JSON' ),
+		title: __( 'Import .json' ),
 	} );
 
 	return (

--- a/packages/edit-site/src/components/add-new-pattern/index.js
+++ b/packages/edit-site/src/components/add-new-pattern/index.js
@@ -97,7 +97,7 @@ export default function AddNewPattern() {
 		onClick: () => {
 			patternUploadInputRef.current.click();
 		},
-		title: __( 'Import .json' ),
+		title: __( 'Import pattern from JSON' ),
 	} );
 
 	return (


### PR DESCRIPTION
Follow-up to https://github.com/WordPress/gutenberg/pull/54337.

## What?
Update the appearance / label of the pattern import menu item.

### Before
<img width="549" alt="Screenshot 2023-09-25 at 11 06 39" src="https://github.com/WordPress/gutenberg/assets/846565/7dd7ffb4-3e91-46e9-941a-8f6c3397bbc0">


### After
<img width="513" alt="Screenshot 2023-09-25 at 11 24 33" src="https://github.com/WordPress/gutenberg/assets/846565/f3e40feb-5b2d-4252-8052-37470cbf86f6">

## Why?
The `upload` icon is more indicative of the action. The shorter label is less noisy and a bit easier to interpret at a glance. 