### PR TITLE
Performance Tests: Support the Site Editor's legacy spinner

### DIFF
--- a/test/performance/specs/site-editor.spec.js
+++ b/test/performance/specs/site-editor.spec.js
@@ -139,7 +139,8 @@ test.describe( 'Site Editor Performance', () => {
 			// timings.
 			await page
 				.locator(
-					'.edit-site-canvas-loader, .edit-site-canvas-spinner' // Spinner is used in the legacy editor.
+					// Spinner was used instead of the progress bar in an earlier version of the site editor.
+					'.edit-site-canvas-loader, .edit-site-canvas-spinner'
 				)
 				.waitFor( { state: 'hidden', timeout: 120_000 } );
 

--- a/test/performance/specs/site-editor.spec.js
+++ b/test/performance/specs/site-editor.spec.js
@@ -138,7 +138,9 @@ test.describe( 'Site Editor Performance', () => {
 			// canvas is ready, and we don't want it to affect the typing
 			// timings.
 			await page
-				.locator( '.edit-site-canvas-loader' )
+				.locator(
+					'.edit-site-canvas-loader, .edit-site-canvas-spinner' // Spinner is used in the legacy editor.
+				)
 				.waitFor( { state: 'hidden', timeout: 120_000 } );
 
 			const canvas = await perfUtils.getCanvas();


### PR DESCRIPTION
## What?

This is needed for older branches where the current `loader` element is referred to as `spinner`. We need to be able to compare the current code to the older one (e.g. iframed vs legacy canvas) so some elements that are now legacy still need support in the performance tests. 

Without this selector, this locator resolves immediately because it doesn't find a spinner element. This can cause the consequent canvas body click to timeout (flaky). See the attached trace as an example (taken from a failed CI job):

👉 [trace.zip](https://github.com/WordPress/gutenberg/files/12715138/trace.zip) (_open via https://trace.playwright.dev/_)