### PR TITLE
Try fixing the flaky 'Toolbar roving tabindex' e2e test

### DIFF
--- a/test/e2e/specs/editor/various/toolbar-roving-tabindex.spec.js
+++ b/test/e2e/specs/editor/various/toolbar-roving-tabindex.spec.js
@@ -14,6 +14,9 @@ test.describe( 'Toolbar roving tabindex', () => {
 		await admin.createNewPost();
 		await editor.insertBlock( { name: 'core/paragraph' } );
 		await page.keyboard.type( 'First block' );
+
+		// Ensure the fixed toolbar option is off.
+		await editor.setIsFixedToolbar( false );
 	} );
 
 	test( 'ensures base block toolbars use roving tabindex', async ( {

--- a/test/e2e/specs/editor/various/toolbar-roving-tabindex.spec.js
+++ b/test/e2e/specs/editor/various/toolbar-roving-tabindex.spec.js
@@ -16,6 +16,7 @@ test.describe( 'Toolbar roving tabindex', () => {
 		await page.keyboard.type( 'First block' );
 
 		// Ensure the fixed toolbar option is off.
+		// See: https://github.com/WordPress/gutenberg/pull/54785.
 		await editor.setIsFixedToolbar( false );
 	} );
 


### PR DESCRIPTION
## What?
PR tries to fix the flaky e2e test - `ensures base block toolbars use roving tabindex`, which has been failing recently.

Failure reports:

* https://github.com/WordPress/gutenberg/actions/runs/6257434872/job/16989799230
* https://github.com/WordPress/gutenberg/actions/runs/6263647737/job/17008506615?pr=54695#step:7:21
* https://github.com/WordPress/gutenberg/actions/runs/6264468875/job/17011238781?pr=54695
* https://github.com/WordPress/gutenberg/actions/runs/6298998901/job/17098912446

## Why?
The [previous attempt](https://github.com/WordPress/gutenberg/pull/51600) wasn't enough; the user preferences sometimes still leak between e2e tests.

## How?
Explicitly turn off 'fixedToolbar' before running the tests.

## Testing Instructions
```
npm run test:e2e:playwright -- test/e2e/specs/editor/various/toolbar-roving-tabindex.spec.js
```
