### PR TITLE
core-data: Fix nested property access with undefined name

### DIFF
--- a/packages/core-data/src/queried-data/selectors.js
+++ b/packages/core-data/src/queried-data/selectors.js
@@ -68,7 +68,7 @@ function getQueriedItemsUncached( state, query ) {
 				const field = fields[ f ].split( '.' );
 				let value = item;
 				field.forEach( ( fieldName ) => {
-					value = value[ fieldName ];
+					value = value?.[ fieldName ];
 				} );
 
 				setNestedValue( filteredItem, field, value );

--- a/packages/core-data/src/selectors.ts
+++ b/packages/core-data/src/selectors.ts
@@ -344,7 +344,7 @@ export const getEntityRecord = createSelector(
 				const field = fields[ f ].split( '.' );
 				let value = item;
 				field.forEach( ( fieldName ) => {
-					value = value[ fieldName ];
+					value = value?.[ fieldName ];
 				} );
 				setNestedValue( filteredItem, field, value );
 			}

--- a/packages/core-data/src/test/selectors.js
+++ b/packages/core-data/src/test/selectors.js
@@ -135,6 +135,43 @@ describe.each( [
 			} )
 		).toEqual( { content: 'chicken' } );
 	} );
+
+	it( 'should work well for nested fields properties', () => {
+		const state = deepFreeze( {
+			entities: {
+				records: {
+					root: {
+						postType: {
+							queriedData: {
+								items: {
+									default: {
+										post: {
+											foo: undefined,
+										},
+									},
+								},
+								itemIsComplete: {
+									default: {
+										post: true,
+									},
+								},
+								queries: {},
+							},
+						},
+					},
+				},
+			},
+		} );
+		expect(
+			getEntityRecord( state, 'root', 'postType', 'post', {
+				_fields: [ 'foo.bar' ],
+			} )
+		).toEqual( {
+			foo: {
+				bar: undefined,
+			},
+		} );
+	} );
 } );
 
 describe( 'hasEntityRecords', () => {


### PR DESCRIPTION
## What?
This PR fixes a [regression](https://github.com/WordPress/gutenberg/issues/54735) we introduced in https://github.com/WordPress/gutenberg/pull/48310 when migrating away from `_.get()`.

The issue is thoroughly explained in #54735.

Fixes #54735, cc @kraftner.

## Why?
Fixes an issue with how we're handling `getEntityRecord()` calls with `undefined` `name`s.

## How?
We're adding optional chaining so entities with `undefined` name won't throw an error.

## Testing Instructions
* Build this branch locally
* Run `wp.data.select( 'core' ).getEntityRecord( 'root', '__unstableBase', undefined, { _fields: [ 'routes./wp/v2/posts' ] } )` in your console.
* Verify you don't get any errors.

### Testing Instructions for Keyboard
None.

## Screenshots or screencast <!-- if applicable -->
None.
