### PR TITLE
[WIP] Provide standardised tools for mapping Data to Link attributes

### DIFF
--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -306,6 +306,14 @@ _Related_
 
 -   <https://github.com/WordPress/gutenberg/blob/HEAD/packages/block-editor/src/components/block-vertical-alignment-control/README.md>
 
+### buildDataFromLinkValue
+
+Undocumented declaration.
+
+### buildLinkValueFromData
+
+Undocumented declaration.
+
 ### ButtonBlockAppender
 
 _Related_

--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -306,14 +306,6 @@ _Related_
 
 -   <https://github.com/WordPress/gutenberg/blob/HEAD/packages/block-editor/src/components/block-vertical-alignment-control/README.md>
 
-### buildDataFromLinkValue
-
-Undocumented declaration.
-
-### buildLinkValueFromData
-
-Undocumented declaration.
-
 ### ButtonBlockAppender
 
 _Related_
@@ -539,6 +531,10 @@ _Parameters_
 _Returns_
 
 -   `string`: Gradient value.
+
+### getLinkValueTransforms
+
+Undocumented declaration.
 
 ### getPxFromCssUnit
 

--- a/packages/block-editor/src/components/index.js
+++ b/packages/block-editor/src/components/index.js
@@ -71,6 +71,10 @@ export { default as __experimentalLinkControl } from './link-control';
 export { default as __experimentalLinkControlSearchInput } from './link-control/search-input';
 export { default as __experimentalLinkControlSearchResults } from './link-control/search-results';
 export { default as __experimentalLinkControlSearchItem } from './link-control/search-item';
+export {
+	buildLinkValueFromData,
+	buildDataFromLinkValue,
+} from './link-control/link-value-transforms';
 export { default as LineHeightControl } from './line-height-control';
 export { default as __experimentalListView } from './list-view';
 export { default as MediaReplaceFlow } from './media-replace-flow';

--- a/packages/block-editor/src/components/index.js
+++ b/packages/block-editor/src/components/index.js
@@ -71,10 +71,7 @@ export { default as __experimentalLinkControl } from './link-control';
 export { default as __experimentalLinkControlSearchInput } from './link-control/search-input';
 export { default as __experimentalLinkControlSearchResults } from './link-control/search-results';
 export { default as __experimentalLinkControlSearchItem } from './link-control/search-item';
-export {
-	buildLinkValueFromData,
-	buildDataFromLinkValue,
-} from './link-control/link-value-transforms';
+export { default as getLinkValueTransforms } from './link-control/link-value-transforms';
 export { default as LineHeightControl } from './line-height-control';
 export { default as __experimentalListView } from './list-view';
 export { default as MediaReplaceFlow } from './media-replace-flow';

--- a/packages/block-editor/src/components/link-control/link-value-transforms.js
+++ b/packages/block-editor/src/components/link-control/link-value-transforms.js
@@ -1,0 +1,28 @@
+export function buildLinkValueFromData( data, mapping ) {
+	const linkValue = {};
+	for ( const [ attributeName, valueGetter ] of Object.entries( mapping ) ) {
+		if ( typeof valueGetter === 'string' ) {
+			linkValue[ attributeName ] = data[ valueGetter ];
+		} else {
+			linkValue[ attributeName ] = valueGetter.toLink(
+				data[ valueGetter.dataKey ]
+			);
+		}
+	}
+	return linkValue;
+}
+
+export function buildDataFromLinkValue( linkValue, mapping ) {
+	const data = {};
+	for ( const [ attributeName, valueGetter ] of Object.entries( mapping ) ) {
+		if ( typeof valueGetter === 'string' ) {
+			data[ valueGetter ] = linkValue[ attributeName ];
+		} else {
+			data[ valueGetter.dataKey ] = valueGetter.toData(
+				linkValue[ attributeName ],
+				data[ valueGetter.dataKey ]
+			);
+		}
+	}
+	return data;
+}

--- a/packages/block-editor/src/components/link-control/link-value-transforms.js
+++ b/packages/block-editor/src/components/link-control/link-value-transforms.js
@@ -5,7 +5,8 @@ export function buildLinkValueFromData( data, mapping ) {
 			linkValue[ attributeName ] = data[ valueGetter ];
 		} else {
 			linkValue[ attributeName ] = valueGetter.toLink(
-				data[ valueGetter.dataKey ]
+				data[ valueGetter.dataKey ],
+				data
 			);
 		}
 	}
@@ -20,7 +21,7 @@ export function buildDataFromLinkValue( linkValue, mapping ) {
 		} else {
 			data[ valueGetter.dataKey ] = valueGetter.toData(
 				linkValue[ attributeName ],
-				data[ valueGetter.dataKey ]
+				linkValue
 			);
 		}
 	}

--- a/packages/block-editor/src/components/link-control/link-value-transforms.js
+++ b/packages/block-editor/src/components/link-control/link-value-transforms.js
@@ -1,4 +1,4 @@
-export function buildLinkValueFromData( data, mapping ) {
+function buildLinkValueFromData( data, mapping ) {
 	const linkValue = {};
 	for ( const [ attributeName, valueGetter ] of Object.entries( mapping ) ) {
 		if ( typeof valueGetter === 'string' ) {
@@ -13,7 +13,7 @@ export function buildLinkValueFromData( data, mapping ) {
 	return linkValue;
 }
 
-export function buildDataFromLinkValue( linkValue, mapping ) {
+function buildDataFromLinkValue( linkValue, mapping ) {
 	const data = {};
 	for ( const [ attributeName, valueGetter ] of Object.entries( mapping ) ) {
 		if ( typeof valueGetter === 'string' ) {
@@ -26,4 +26,11 @@ export function buildDataFromLinkValue( linkValue, mapping ) {
 		}
 	}
 	return data;
+}
+
+export default function getLinkValueTransforms( mapping ) {
+	return {
+		toLink: ( data ) => buildLinkValueFromData( data, mapping ),
+		toData: ( linkValue ) => buildDataFromLinkValue( linkValue, mapping ),
+	};
 }

--- a/packages/block-editor/src/components/link-control/link-value-transforms.js
+++ b/packages/block-editor/src/components/link-control/link-value-transforms.js
@@ -1,13 +1,19 @@
+function isCallable( value ) {
+	return value && typeof value === 'function';
+}
+
 function buildLinkValueFromData( data, mapping ) {
 	const linkValue = {};
 	for ( const [ attributeName, valueGetter ] of Object.entries( mapping ) ) {
 		if ( typeof valueGetter === 'string' ) {
 			linkValue[ attributeName ] = data[ valueGetter ];
-		} else {
+		} else if ( isCallable( valueGetter.toLink ) ) {
 			linkValue[ attributeName ] = valueGetter.toLink(
 				data[ valueGetter.dataKey ],
 				data
 			);
+		} else {
+			linkValue[ attributeName ] = data[ valueGetter.dataKey ];
 		}
 	}
 	return linkValue;
@@ -18,12 +24,14 @@ function buildDataFromLinkValue( linkValue, mapping ) {
 	for ( const [ attributeName, valueGetter ] of Object.entries( mapping ) ) {
 		if ( typeof valueGetter === 'string' ) {
 			data[ valueGetter ] = linkValue[ attributeName ];
-		} else {
+		} else if ( isCallable( valueGetter.toData ) ) {
 			data[ valueGetter.dataKey ] = valueGetter.toData(
 				linkValue[ attributeName ],
 				linkValue,
 				data
 			);
+		} else {
+			data[ valueGetter.dataKey ] = linkValue[ attributeName ];
 		}
 	}
 	return data;

--- a/packages/block-editor/src/components/link-control/link-value-transforms.js
+++ b/packages/block-editor/src/components/link-control/link-value-transforms.js
@@ -21,7 +21,8 @@ function buildDataFromLinkValue( linkValue, mapping ) {
 		} else {
 			data[ valueGetter.dataKey ] = valueGetter.toData(
 				linkValue[ attributeName ],
-				linkValue
+				linkValue,
+				data
 			);
 		}
 	}

--- a/packages/block-editor/src/components/link-control/test/link-value-transforms.js
+++ b/packages/block-editor/src/components/link-control/test/link-value-transforms.js
@@ -1,0 +1,97 @@
+/**
+ * Internal dependencies
+ */
+import {
+	buildLinkValueFromData,
+	buildDataFromLinkValue,
+} from '../link-value-transforms';
+
+/**
+ * Maps the standard LinkControl values to a given data object.
+ * Complex mappings may supply an object with a `getter` and `setter` function
+ * which represent how to get the link value for the given property and how to
+ * set it back on the data object.
+ */
+const mapping = {
+	url: 'href',
+	type: 'postType',
+	id: 'id',
+	opensInNewTab: {
+		dataKey: 'linkTarget',
+		toLink: ( value ) => value === '_blank',
+		toData: ( value ) => ( value ? '_blank' : undefined ),
+	},
+	noFollow: {
+		dataKey: 'linkRel',
+		toLink: ( value ) => value.includes( 'nofollow' ),
+		toData: ( value, currentVal ) => {
+			// if the value is truthy and the current value is set
+			// then append otherwise just add the value
+			if ( value && currentVal ) {
+				return `${ currentVal } nofollow`;
+			} else if ( value ) {
+				return 'nofollow';
+			}
+		},
+	},
+	sponsored: {
+		dataKey: 'linkRel',
+		toLink: ( value ) => value.includes( 'sponsored' ),
+		toData: ( value, currentVal ) => {
+			// if the value is truthy and the current value is set
+			// then append otherwise just add the value
+			if ( value && currentVal ) {
+				return `${ currentVal } sponsored`;
+			} else if ( value ) {
+				return 'sponsored';
+			}
+		},
+	},
+};
+
+describe( 'buildLinkValueFromData', () => {
+	it( 'build a valid link value from supplied data mapping', () => {
+		const data = {
+			href: 'https://www.google.com',
+			postType: 'post',
+			id: 123,
+			linkTarget: '_blank',
+			linkRel: 'nofollow noopenner sponsored',
+			keyToIgnore: 'valueToIgnore',
+		};
+
+		const linkValue = buildLinkValueFromData( data, mapping );
+
+		expect( linkValue ).toEqual( {
+			url: 'https://www.google.com',
+			type: 'post',
+			id: 123,
+			opensInNewTab: true,
+			noFollow: true,
+			sponsored: true,
+		} );
+	} );
+} );
+
+describe( 'buildDataFromLinkValue', () => {
+	it( 'build a valid data object from supplied link value mapping', () => {
+		const linkValue = {
+			url: 'https://www.google.com',
+			type: 'post',
+			id: 123,
+			opensInNewTab: true,
+			noFollow: true,
+			sponsored: true,
+		};
+
+		const data = buildDataFromLinkValue( linkValue, mapping );
+
+		expect( data ).toEqual( {
+			href: 'https://www.google.com',
+			postType: 'post',
+			id: 123,
+			linkTarget: '_blank',
+			linkRel: 'nofollow sponsored',
+		} );
+	} );
+} );

--- a/packages/block-editor/src/components/link-control/test/link-value-transforms.js
+++ b/packages/block-editor/src/components/link-control/test/link-value-transforms.js
@@ -50,27 +50,49 @@ const mapping = {
 };
 
 describe( 'buildLinkValueFromData', () => {
-	it( 'build a valid link value from supplied data mapping', () => {
-		const data = {
-			href: 'https://www.google.com',
-			postType: 'post',
-			id: 123,
-			linkTarget: '_blank',
-			linkRel: 'nofollow noopenner sponsored',
-			keyToIgnore: 'valueToIgnore',
-		};
+	it.each( [
+		[
+			{
+				href: 'https://www.google.com',
+				postType: 'post',
+				id: 123,
+				linkTarget: '_blank',
+				linkRel: 'nofollow noopenner sponsored',
+				keyToIgnore: 'valueToIgnore',
+			},
+			{
+				url: 'https://www.google.com',
+				type: 'post',
+				id: 123,
+				opensInNewTab: true,
+				noFollow: true,
+				sponsored: true,
+			},
+		],
+		[
+			{
+				href: 'https://www.google.com',
+				postType: 'post',
+				id: 123,
+				linkRel: 'sponsored neyfollow',
+			},
+			{
+				url: 'https://www.google.com',
+				type: 'post',
+				id: 123,
+				opensInNewTab: false,
+				noFollow: false,
+				sponsored: true,
+			},
+		],
+	] )(
+		'build a valid link value from supplied data mapping',
+		( data, expected ) => {
+			const linkValue = buildLinkValueFromData( data, mapping );
 
-		const linkValue = buildLinkValueFromData( data, mapping );
-
-		expect( linkValue ).toEqual( {
-			url: 'https://www.google.com',
-			type: 'post',
-			id: 123,
-			opensInNewTab: true,
-			noFollow: true,
-			sponsored: true,
-		} );
-	} );
+			expect( linkValue ).toEqual( expected );
+		}
+	);
 } );
 
 describe( 'buildDataFromLinkValue', () => {

--- a/packages/block-editor/src/components/link-control/test/link-value-transforms.js
+++ b/packages/block-editor/src/components/link-control/test/link-value-transforms.js
@@ -50,7 +50,7 @@ const mapping = {
 	},
 };
 
-describe( 'buildLinkValueFromData', () => {
+describe( 'building a link value from data', () => {
 	it.each( [
 		[
 			{
@@ -117,7 +117,7 @@ describe( 'buildLinkValueFromData', () => {
 	} );
 } );
 
-describe( 'buildDataFromLinkValue', () => {
+describe( 'building data from a link value', () => {
 	it( 'build a valid data object from supplied link value mapping', () => {
 		const linkValue = {
 			url: 'https://www.wordpress.org',

--- a/packages/block-editor/src/components/link-control/test/link-value-transforms.js
+++ b/packages/block-editor/src/components/link-control/test/link-value-transforms.js
@@ -1,10 +1,7 @@
 /**
  * Internal dependencies
  */
-import {
-	buildLinkValueFromData,
-	buildDataFromLinkValue,
-} from '../link-value-transforms';
+import getLinkValueTransforms from '../link-value-transforms';
 
 /**
  * Maps the standard LinkControl values to a given data object.
@@ -88,7 +85,9 @@ describe( 'buildLinkValueFromData', () => {
 	] )(
 		'build a valid link value from supplied data mapping',
 		( data, expected ) => {
-			const linkValue = buildLinkValueFromData( data, mapping );
+			const { toLink } = getLinkValueTransforms( mapping );
+
+			const linkValue = toLink( data );
 
 			expect( linkValue ).toEqual( expected );
 		}
@@ -106,7 +105,10 @@ describe( 'buildDataFromLinkValue', () => {
 			sponsored: true,
 		};
 
-		const data = buildDataFromLinkValue( linkValue, mapping );
+		// const data = buildDataFromLinkValue( linkValue, mapping );
+
+		const { toData } = getLinkValueTransforms( mapping );
+		const data = toData( linkValue );
 
 		expect( data ).toEqual( {
 			href: 'https://www.google.com',

--- a/packages/block-editor/src/components/link-control/test/link-value-transforms.js
+++ b/packages/block-editor/src/components/link-control/test/link-value-transforms.js
@@ -21,11 +21,11 @@ const mapping = {
 	noFollow: {
 		dataKey: 'linkRel',
 		toLink: ( value ) => value.includes( 'nofollow' ),
-		toData: ( value, currentVal ) => {
+		toData: ( value, _, { linkRel: currentLinkRel } ) => {
 			// if the value is truthy and the current value is set
 			// then append otherwise just add the value
-			if ( value && currentVal ) {
-				return `${ currentVal } nofollow`;
+			if ( value && currentLinkRel ) {
+				return `${ currentLinkRel } nofollow`;
 			} else if ( value ) {
 				return 'nofollow';
 			}
@@ -34,11 +34,11 @@ const mapping = {
 	sponsored: {
 		dataKey: 'linkRel',
 		toLink: ( value ) => value.includes( 'sponsored' ),
-		toData: ( value, currentVal ) => {
+		toData: ( value, _, { linkRel: currentLinkRel } ) => {
 			// if the value is truthy and the current value is set
 			// then append otherwise just add the value
-			if ( value && currentVal ) {
-				return `${ currentVal } sponsored`;
+			if ( value && currentLinkRel ) {
+				return `${ currentLinkRel } sponsored`;
 			} else if ( value ) {
 				return 'sponsored';
 			}

--- a/packages/block-editor/src/components/link-control/test/link-value-transforms.js
+++ b/packages/block-editor/src/components/link-control/test/link-value-transforms.js
@@ -3,6 +3,10 @@
  */
 import getLinkValueTransforms from '../link-value-transforms';
 
+function identity( value ) {
+	return value;
+}
+
 /**
  * Maps the standard LinkControl values to a given data object.
  * Complex mappings may supply an object with a `getter` and `setter` function
@@ -50,7 +54,7 @@ describe( 'buildLinkValueFromData', () => {
 	it.each( [
 		[
 			{
-				href: 'https://www.google.com',
+				href: 'https://www.wordpress.org',
 				postType: 'post',
 				id: 123,
 				linkTarget: '_blank',
@@ -58,7 +62,7 @@ describe( 'buildLinkValueFromData', () => {
 				keyToIgnore: 'valueToIgnore',
 			},
 			{
-				url: 'https://www.google.com',
+				url: 'https://www.wordpress.org',
 				type: 'post',
 				id: 123,
 				opensInNewTab: true,
@@ -68,13 +72,13 @@ describe( 'buildLinkValueFromData', () => {
 		],
 		[
 			{
-				href: 'https://www.google.com',
+				href: 'https://www.wordpress.org',
 				postType: 'post',
 				id: 123,
 				linkRel: 'sponsored neyfollow',
 			},
 			{
-				url: 'https://www.google.com',
+				url: 'https://www.wordpress.org',
 				type: 'post',
 				id: 123,
 				opensInNewTab: false,
@@ -92,12 +96,31 @@ describe( 'buildLinkValueFromData', () => {
 			expect( linkValue ).toEqual( expected );
 		}
 	);
+
+	it( 'returns raw data attribute value when toLink transform is not callable', () => {
+		const { toLink } = getLinkValueTransforms( {
+			url: {
+				dataKey: 'href',
+				// allows toLink to be ommitted in case of simple mapping
+				// but still allows toData to be defined.
+				toData: identity,
+			},
+		} );
+
+		const linkValue = toLink( {
+			href: 'https://www.wordpress.org',
+		} );
+
+		expect( linkValue ).toEqual( {
+			url: 'https://www.wordpress.org',
+		} );
+	} );
 } );
 
 describe( 'buildDataFromLinkValue', () => {
 	it( 'build a valid data object from supplied link value mapping', () => {
 		const linkValue = {
-			url: 'https://www.google.com',
+			url: 'https://www.wordpress.org',
 			type: 'post',
 			id: 123,
 			opensInNewTab: true,
@@ -105,17 +128,34 @@ describe( 'buildDataFromLinkValue', () => {
 			sponsored: true,
 		};
 
-		// const data = buildDataFromLinkValue( linkValue, mapping );
-
 		const { toData } = getLinkValueTransforms( mapping );
 		const data = toData( linkValue );
 
 		expect( data ).toEqual( {
-			href: 'https://www.google.com',
+			href: 'https://www.wordpress.org',
 			postType: 'post',
 			id: 123,
 			linkTarget: '_blank',
 			linkRel: 'nofollow sponsored',
+		} );
+	} );
+
+	it( 'returns raw link value attribute when toData transform is not callable', () => {
+		const { toData } = getLinkValueTransforms( {
+			url: {
+				dataKey: 'href',
+				// allows toData to be ommitted in case of simple mapping
+				// but still allows toLink to be defined.
+				toLink: identity, // added for example purposes.
+			},
+		} );
+
+		const data = toData( {
+			url: 'https://www.wordpress.org',
+		} );
+
+		expect( data ).toEqual( {
+			href: 'https://www.wordpress.org',
 		} );
 	} );
 } );

--- a/packages/block-library/src/button/edit.js
+++ b/packages/block-library/src/button/edit.js
@@ -39,6 +39,7 @@ import { displayShortcut, isKeyboardEvent } from '@wordpress/keycodes';
 import { link, linkOff } from '@wordpress/icons';
 import { createBlock } from '@wordpress/blocks';
 import { useMergeRefs } from '@wordpress/compose';
+import { prependHTTP } from '@wordpress/url';
 
 const LINK_SETTINGS = [
 	...LinkControl.DEFAULT_LINK_SETTINGS,
@@ -139,7 +140,10 @@ function ButtonEdit( props ) {
 
 	// Defines how block attributes map to link value and vice versa.
 	const linkValueAttrsToDataMapping = {
-		url: 'url',
+		url: {
+			dataKey: 'url',
+			toData: ( value ) => prependHTTP( value ),
+		},
 		opensInNewTab: {
 			dataKey: 'linkTarget',
 			toLink: ( value ) => value === NEW_TAB_TARGET,

--- a/packages/block-library/src/button/edit.js
+++ b/packages/block-library/src/button/edit.js
@@ -31,8 +31,7 @@ import {
 	__experimentalUseColorProps as useColorProps,
 	__experimentalGetSpacingClassesAndStyles as useSpacingProps,
 	__experimentalLinkControl as LinkControl,
-	buildLinkValueFromData,
-	buildDataFromLinkValue,
+	getLinkValueTransforms,
 	__experimentalGetElementClassName,
 } from '@wordpress/block-editor';
 import { displayShortcut, isKeyboardEvent } from '@wordpress/keycodes';
@@ -192,6 +191,10 @@ function ButtonEdit( props ) {
 		},
 	};
 
+	const { toLink, toData } = getLinkValueTransforms(
+		linkValueAttrsToDataMapping
+	);
+
 	function startEditing( event ) {
 		event.preventDefault();
 		setIsEditingURL( true );
@@ -215,14 +218,11 @@ function ButtonEdit( props ) {
 	// NOT NOT MERGE WITHOUT RE-INTSTAINTG THIS MEMOIZATION
 	// Memoize link value to avoid overriding the LinkControl's internal state.
 	// This is a temporary fix. See https://github.com/WordPress/gutenberg/issues/51256.
-	const linkValue = buildLinkValueFromData(
-		{
-			url,
-			linkTarget,
-			rel,
-		},
-		linkValueAttrsToDataMapping
-	);
+	const linkValue = toLink( {
+		url,
+		linkTarget,
+		rel,
+	} );
 	// NOT NOT MERGE WITHOUT RE-INTSTAINTG THIS MEMOIZATION
 
 	return (
@@ -313,12 +313,7 @@ function ButtonEdit( props ) {
 					<LinkControl
 						value={ linkValue }
 						onChange={ ( newLinkValue ) =>
-							setAttributes(
-								buildDataFromLinkValue(
-									newLinkValue,
-									linkValueAttrsToDataMapping
-								)
-							)
+							setAttributes( toData( newLinkValue ) )
 						}
 						onRemove={ () => {
 							unlink();

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -575,11 +575,7 @@ export default function NavigationLinkEdit( {
 							anchor={ popoverAnchor }
 							onRemove={ removeLink }
 							onChange={ ( updatedValue ) => {
-								updateAttributes(
-									updatedValue,
-									setAttributes,
-									attributes
-								);
+								setAttributes( updatedValue );
 							} }
 						/>
 					) }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Provides a set of standardised functions to map stored data attributes into valid `LinkControl` `value` attributes. 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

There are numerous places in Core (and beyond) where some data must be mapped to the `LinkControl`'s `value` object. This process must also happen in reverse when `LinkControl` `onChange` is called.

- [Button](https://github.com/WordPress/gutenberg/blob/9eaf30c97ada390273f0d12e49b968344dc919c1/packages/block-library/src/button/edit.js#L259-L266)
- [Rich text links](https://github.com/WordPress/gutenberg/blob/9eaf30c97ada390273f0d12e49b968344dc919c1/packages/format-library/src/link/inline.js#L92)
- [Navigation](https://github.com/WordPress/gutenberg/blob/9eaf30c97ada390273f0d12e49b968344dc919c1/packages/block-library/src/navigation-link/edit.js#L578-L582)


There are several implementations and each one has it's own quirks, is complex to reason about/change, and lacks automated test coverage. 

In addition there are no extension points for how the data should be mapped/transformed, meaning that it is not possible to add additional settings/controls to the various Link UIs used throughtout the editor. Chief amongst these is the RichText implementation which 3rd party extenders regularly want to modify to add additional settings.

This PR seeks to resolve this by providing consumers with a standardised (largely declarative) API for describing how data objects should be mapped to `LinkControl` values.

It also paves the way for the possibility of making the "map" objects passed to these functions extensible. This would allow 3rd party extenders to add additional controls to the Link UI within the editor without the current process which requires re-registering the `core/link` format from scratch! 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Instead of imperitively coding how the link value should be decoded/encoded, instead we provide utility functions which act over standardised "map" objects which describe how the `LinkControl`'s `value` fields map to the given data object.

By default the mapping works 1:1 based on string equivalence. So in the case below the `url` attribute of the `LinkControl` object is mapped to the `href` field of the data object. The data object might be block attributes or any other form of storage.

For more complex examples, consumers may define more complex transformations by way of `toLink` and `toData` which describe how the different values should be transformed.

Below is a simplified example of this:

```js
// Define how LinkValue object should map to associate data values.
const mapping = {
	url: 'href',
	type: 'postType',
	id: 'id',
	opensInNewTab: {
		dataKey: 'linkTarget',
		toLink: ( dataAttr ) => toLinkDataAttr === '_blank', // `opensInNewTab should be `true` when `linkTarget` is `_blank`.
		toData: ( linkAttr ) => ( linkAttr ? '_blank' : undefined ), // if `opensInNewTab` is `true` then `linkTarget` should be set to `_blank`.
	},
}

// Now get the pre-bound transformation functions.
const { toLink, toData } = getLinkValueTransforms(mapping);
```

Now the values can be passed to either transformation function as required and the result will be the desired object ready to either:

- pass directly to `LinkControl` as the `value` prop
- persist to some storage mechanism (e.g. `setAttributes()`)

```js
// Build a `value` to pass to `LinkControl`.
const linkValue = toLink( blockData, mapping );

// Build object from a Link Value to be persisted (e.g. to block attributes or somewhere else).
const blockData = toData( linkValue, mapping );

```

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
