### PR TITLE
Update CODEOWNERS for `core/image` block

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -22,6 +22,7 @@
 /packages/block-library/src/comment-template    @michalczaplinski
 /packages/block-library/src/comments            @michalczaplinski
 /packages/block-library/src/table-of-contents   @ZebulanStanphill
+/packages/block-library/src/image								@artemiomorales @michalczaplinski
 
 # Duotone
 /lib/block-supports/duotone.php                       @ajlende


### PR DESCRIPTION
Just adding @artemiomorales and myself to the CODEOWNERS for the Image block to keep an eye on the Lightbox-related issues.