### PR TITLE
Font Library: use wporg cdn to host the google fonts json data

### DIFF
--- a/lib/experimental/fonts/font-library/font-library.php
+++ b/lib/experimental/fonts/font-library/font-library.php
@@ -62,7 +62,7 @@ $default_font_collection = array(
 	'id'          => 'default-font-collection',
 	'name'        => 'Google Fonts',
 	'description' => __( 'Add from Google Fonts. Fonts are copied to and served from your site.', 'gutenberg' ),
-	'src'         => 'https://raw.githubusercontent.com/WordPress/google-fonts-to-wordpress-collection/main/output/google-fonts-with-previews.json',
+	'src'         => 'https://s.w.org/images/fonts/16.7/collections/google-fonts-with-preview.json',
 );
 
 wp_register_font_collection( $default_font_collection );


### PR DESCRIPTION
fix: https://github.com/WordPress/gutenberg/issues/54685