### PR TITLE
Navigation Link block: register variations on post type / taxonomy registration

### DIFF
--- a/packages/block-library/src/navigation-link/index.php
+++ b/packages/block-library/src/navigation-link/index.php
@@ -348,6 +348,7 @@ function register_block_core_navigation_link_variation( $variation ) {
 function register_block_core_navigation_link() {
 	// This will only handle post types and taxonomies registered until this point (init on priority 9).
 	// See action hooks at the end of this function for other post types and taxonomies.
+	// See https://github.com/WordPress/gutenberg/issues/53826 for details.
 	$post_types = get_post_types( array( 'show_in_nav_menus' => true ), 'objects' );
 	$taxonomies = get_taxonomies( array( 'show_in_nav_menus' => true ), 'objects' );
 
@@ -387,9 +388,9 @@ function register_block_core_navigation_link() {
 		)
 	);
 
-	// Register actions for all post types and taxonomies not registered until now.
-	// This needs to happen in this function, because otherwise for post types/taxonomies
-	// registered before this block, those functions would add variations to a block that don't exist.
+	// Register actions for all post types and taxonomies that may not yet be registered.
+	// This needs to happen in this function, because otherwise any post types/taxonomies
+	// registered **before** this block will attempt to register on a block that does not yet exist.
 	add_action( 'registered_post_type', 'register_block_core_navigation_link_post_type_variation', 10, 2 );
 	add_action( 'registered_taxonomy', 'register_block_core_navigation_link_taxonomy_variation', 10, 3 );
 }

--- a/packages/block-library/src/navigation-link/index.php
+++ b/packages/block-library/src/navigation-link/index.php
@@ -415,9 +415,9 @@ function register_block_core_navigation_link_post_type_variation( $post_type, $p
  * Register a custom taxonomy variation for navigation link on taxonomy registration
  * Handles all taxonomies registered after the block is registered in register_navigation_link_post_type_variations
  *
- * @param string       $taxonomy Taxonomy name.
- * @param array|string $object_type Name of the object type for the taxonomy object.
- * @param array|string $args Optional args used in taxonomy registration.
+ * @param string       $taxonomy Taxonomy slug.
+ * @param array|string $object_type Object type or array of object types.
+ * @param array        $args Array of taxonomy registration arguments.
  * @return void
  */
 function register_block_core_navigation_link_taxonomy_variation( $taxonomy, $object_type, $args ) {

--- a/packages/block-library/src/navigation-link/index.php
+++ b/packages/block-library/src/navigation-link/index.php
@@ -332,6 +332,8 @@ function register_block_core_navigation_link_variation( $variation ) {
 	// Directly set the variations on the registered block type
 	// because there's no server side registration for variations (see #47170).
 	$navigation_block_type = WP_Block_Type_Registry::get_instance()->get_registered( 'core/navigation-link' );
+	// If the block is not registered yet, bail early.
+	// Variation will be registered in register_block_core_navigation_link then.
 	if ( ! $navigation_block_type ) {
 		return;
 	}
@@ -347,7 +349,7 @@ function register_block_core_navigation_link_variation( $variation ) {
  */
 function register_block_core_navigation_link() {
 	// This will only handle post types and taxonomies registered until this point (init on priority 9).
-	// See action hooks at the end of this function for other post types and taxonomies.
+	// See action hooks below for other post types and taxonomies.
 	// See https://github.com/WordPress/gutenberg/issues/53826 for details.
 	$post_types = get_post_types( array( 'show_in_nav_menus' => true ), 'objects' );
 	$taxonomies = get_taxonomies( array( 'show_in_nav_menus' => true ), 'objects' );
@@ -387,14 +389,12 @@ function register_block_core_navigation_link() {
 			'variations'      => array_merge( $built_ins, $variations ),
 		)
 	);
-
-	// Register actions for all post types and taxonomies that may not yet be registered.
-	// This needs to happen in this function, because otherwise any post types/taxonomies
-	// registered **before** this block will attempt to register on a block that does not yet exist.
-	add_action( 'registered_post_type', 'register_block_core_navigation_link_post_type_variation', 10, 2 );
-	add_action( 'registered_taxonomy', 'register_block_core_navigation_link_taxonomy_variation', 10, 3 );
 }
 add_action( 'init', 'register_block_core_navigation_link' );
+// Register actions for all post types and taxonomies, to add variations when they are registered.
+// All post types/taxonomies registered before register_block_core_navigation_link, will be handled by that function.
+add_action( 'registered_post_type', 'register_block_core_navigation_link_post_type_variation', 10, 2 );
+add_action( 'registered_taxonomy', 'register_block_core_navigation_link_taxonomy_variation', 10, 3 );
 
 /**
  * Register custom post type variations for navigation link on post type registration

--- a/phpunit/blocks/block-navigation-link-variations-test.php
+++ b/phpunit/blocks/block-navigation-link-variations-test.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * Navigation block rendering tests.
+ *
+ * @package WordPress
+ * @subpackage Blocks
+ */
+
+/**
+ * Tests for the Navigation block variations for post types.
+ *
+ * @group blocks
+ */
+class Block_Navigation_Link_Variations_Test extends WP_UnitTestCase {
+	public function set_up() {
+		parent::set_up();
+		register_post_type(
+			'custom_book',
+			array(
+				'labels'            => array(
+					'item_link' => 'Custom Book',
+				),
+				'public'            => true,
+				'show_in_rest'      => true,
+				'show_in_nav_menus' => true,
+			)
+		);
+		register_taxonomy(
+			'book_type',
+			'custom_book',
+			array(
+				'labels'            => array(
+					'item_link' => 'Book Type',
+				),
+				'show_in_nav_menus' => true,
+			)
+		);
+	}
+
+	public function tear_down() {
+		unregister_post_type( 'custom_book' );
+		unregister_taxonomy( 'book_type' );
+		parent::tear_down();
+	}
+
+	/**
+	 * @covers ::register_block_core_navigation_link_post_type_variation
+	 */
+	public function test_navigation_link_variations_custom_post_type() {
+		$registry       = WP_Block_Type_Registry::get_instance();
+		$nav_link_block = $registry->get_registered( 'core/navigation-link' );
+		$this->assertFalse( empty( $nav_link_block->variations ) );
+		$variation = $this->get_variation_by_name( 'custom_book', $nav_link_block->variations );
+		$this->assertIsArray( $variation );
+		$this->assertArrayHasKey( 'title', $variation );
+		$this->assertEquals( 'Custom Book', $variation['title'] );
+	}
+
+	/**
+	 * @covers ::register_block_core_navigation_link_taxonomy_variation
+	 */
+	public function test_navigation_link_variations_custom_taxonomy() {
+		$registry       = WP_Block_Type_Registry::get_instance();
+		$nav_link_block = $registry->get_registered( 'core/navigation-link' );
+		$this->assertFalse( empty( $nav_link_block->variations ) );
+		$variation = $this->get_variation_by_name( 'book_type', $nav_link_block->variations );
+		$this->assertIsArray( $variation );
+		$this->assertArrayHasKey( 'title', $variation );
+		$this->assertEquals( 'Book Type', $variation['title'] );
+	}
+
+	/**
+	 * Get a variation by its name from an array of variations.
+	 *
+	 * @param string $variation_name The name (= slug) of the variation.
+	 * @param array  $variations An array of variations.
+	 * @return array|null The found variation or null.
+	 */
+	private function get_variation_by_name( $variation_name, $variations ) {
+		$found_variation = null;
+		foreach ( $variations as $variation ) {
+			if ( $variation['name'] === $variation_name ) {
+				$found_variation = $variation;
+			}
+		}
+
+		return $found_variation;
+	}
+}

--- a/phpunit/blocks/block-navigation-link-variations-test.php
+++ b/phpunit/blocks/block-navigation-link-variations-test.php
@@ -49,11 +49,11 @@ class Block_Navigation_Link_Variations_Test extends WP_UnitTestCase {
 	public function test_navigation_link_variations_custom_post_type() {
 		$registry       = WP_Block_Type_Registry::get_instance();
 		$nav_link_block = $registry->get_registered( 'core/navigation-link' );
-		$this->assertFalse( empty( $nav_link_block->variations ) );
+		$this->assertNotEmpty( $nav_link_block->variations, 'Block has no variations' );
 		$variation = $this->get_variation_by_name( 'custom_book', $nav_link_block->variations );
-		$this->assertIsArray( $variation );
-		$this->assertArrayHasKey( 'title', $variation );
-		$this->assertEquals( 'Custom Book', $variation['title'] );
+		$this->assertIsArray( $variation, 'Block variation is not an array' );
+		$this->assertArrayHasKey( 'title', $variation, 'Block variation has no title' );
+		$this->assertEquals( 'Custom Book', $variation['title'], 'Variation title is different than the post type label' );
 	}
 
 	/**
@@ -62,11 +62,11 @@ class Block_Navigation_Link_Variations_Test extends WP_UnitTestCase {
 	public function test_navigation_link_variations_custom_taxonomy() {
 		$registry       = WP_Block_Type_Registry::get_instance();
 		$nav_link_block = $registry->get_registered( 'core/navigation-link' );
-		$this->assertFalse( empty( $nav_link_block->variations ) );
+		$this->assertNotEmpty( $nav_link_block->variations, 'Block has no variations' );
 		$variation = $this->get_variation_by_name( 'book_type', $nav_link_block->variations );
-		$this->assertIsArray( $variation );
-		$this->assertArrayHasKey( 'title', $variation );
-		$this->assertEquals( 'Book Type', $variation['title'] );
+		$this->assertIsArray( $variation, 'Block variation is not an array' );
+		$this->assertArrayHasKey( 'title', $variation, 'Block variation has no title' );
+		$this->assertEquals( 'Book Type', $variation['title'], 'Variation title is different than the post type label' );
 	}
 
 	/**


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
This is a different approach to solving #53826. Instead of using a later priority for the init hook (as in #54434), this PR directly hooks into `registered_post_type` and `registered_taxonomy`. 

Closes https://github.com/WordPress/gutenberg/issues/53826

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
See #53826 - server side function runs too early to make sure it gets all custom taxonomies/post types by plugins, themes etc..

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Variations for all post types and taxonomies registered until `register_block_core_navigation_link` (at init priority 10) are registered directly in here. For all post types and taxonomies registered after that, actions are added to `registered_post_type` and `registered_taxonomy`, which will register variations during post type/taxonomy registration. 

We can't use the second approach for _all_ post types/taxonomies, because some of them (eg builtin ones) are registered before the navigation link block is registered, therefore variations can't yet be added. 

I'm directly adding the variation on the WP_Block_Type object from WP_Block_Type_Registry, because there's no API for registering variations in PHP (yet). 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Manual Testing
#### Post Type
1. Register a custom post type ([example code from developer.wordpress.org](https://developer.wordpress.org/plugins/post-types/registering-custom-post-types/)).
```php
add_action('init', function () {
    register_post_type(
        'wporg_product',
        array(
            'labels'      => array(
                'name'          => __('Products', 'textdomain'),
                'singular_name' => __('Product', 'textdomain'),
                'item_link' => __('Product Link', 'textdomain')
            ),
            'public'      => true,
            'has_archive' => true,
            'show_in_rest' => true,
            'show_in_nav_menus' => true
        )
    );
}, 11);
```
Important: Set the item_link label or the block variation is called Post Link.
Important: change add_action priority to something higher than 10 (eg 11) - when using something lower it already works in trunk.
2. Go into site-editor and add a navigation block
3. try to search for a block named like the custom taxonomy (eg "Product Link").
4. Block is available

#### Taxonomy
1. Register a custom taxonomy ([example code from developer.wordpress.org](https://developer.wordpress.org/plugins/taxonomies/working-with-custom-taxonomies/#step-2-creating-a-new-plugin)) 
```php
add_action('init', function() {
	 $args   = array(
		 'labels'            => array(
		     'link_item'         => __( 'Course' ),
	         ),
		 'show_in_nav_menus' => true
	 );
	 register_taxonomy( 'course', [ 'post' ], $args );
});
```
Important: Set the item_link label or the block variation is called Post Link.
Important: change add_action priority to something higher than 10 (eg 11) - when using something lower it already works in trunk.
3. Go into site-editor and add a navigation block
4. try to search for a block named like the custom taxonomy (eg "Product Link").
5. Block is available


### Automated testing

Run `npm run test:unit:php:base -- --filter Block_Navigation_Link_Variations_Test`
