### PR TITLE
Patterns: check that pattern is synced before replacing blocks with synced pattern on creation

### DIFF
--- a/packages/patterns/src/components/pattern-convert-button.js
+++ b/packages/patterns/src/components/pattern-convert-button.js
@@ -21,6 +21,7 @@ import { store as noticesStore } from '@wordpress/notices';
 import { store as patternsStore } from '../store';
 import CreatePatternModal from './create-pattern-modal';
 import { unlock } from '../lock-unlock';
+import { PATTERN_SYNC_TYPES } from '../constants';
 
 /**
  * Menu control to convert block(s) to a pattern block.
@@ -96,15 +97,17 @@ export default function PatternConvertButton( { clientIds, rootClientId } ) {
 	}
 
 	const handleSuccess = ( { pattern } ) => {
-		const newBlock = createBlock( 'core/block', {
-			ref: pattern.id,
-		} );
+		if ( pattern.wp_pattern_sync_status !== PATTERN_SYNC_TYPES.unsynced ) {
+			const newBlock = createBlock( 'core/block', {
+				ref: pattern.id,
+			} );
 
-		replaceBlocks( clientIds, newBlock );
-		setEditingPattern( newBlock.clientId, true );
+			replaceBlocks( clientIds, newBlock );
+			setEditingPattern( newBlock.clientId, true );
+		}
 
 		createSuccessNotice(
-			pattern.wp_pattern_sync_status === 'unsynced'
+			pattern.wp_pattern_sync_status === PATTERN_SYNC_TYPES.unsynced
 				? sprintf(
 						// translators: %s: the name the user has given to the pattern.
 						__( 'Unsynced Pattern created: %s' ),


### PR DESCRIPTION
## What?
Adds a check to the pattern creation code to make sure the new pattern is synced before replacing the existing blocks in the editor canvas.

## Why?
After a change in the [pattern creation modal to account for the import/export of patterns via JSON](https://github.com/WordPress/gutenberg/pull/54337/files#diff-57597c4236082d67c5cbe7c070695e6803d0961b99d8d84d5ff37d55c38a1983R99) new unsynced patterns are initially being inserted into the post editor canvas as synced even though they entity is successfully saved as unsynced.

Fixes: https://github.com/WordPress/gutenberg/issues/54803

## How?
Adds a check in the create pattern button success method to only replace the blocks in the editor canvas if the new pattern is not unsynced.

## Testing Instructions

- In the post editor add a block, and then in the block toolbar overflow menu select `Create pattern`
- Set the new pattern sync status to unsynced and make sure that the new pattern is added but the existing block in the canvas is not converted to a synced pattern
- Repeat but this time created a synced pattern and make sure the block on the editor canvas is replaced with a synced pattern
- In the site editor create a synced and an unsynced pattern and make sure that works as expected
- In the site editor export and import both synced and unsynced patterns and make sure that works as expected

## Screenshots or screencast <!-- if applicable -->

Before:

https://github.com/WordPress/gutenberg/assets/3629020/46742a7b-8673-44ca-a4bd-6c9d09918eca

After:

https://github.com/WordPress/gutenberg/assets/3629020/e6b0bb07-0353-4c6e-a222-151d898cf1b9




