### PR TITLE
Patterns: Improve sentence case consistency of labels and notices

### DIFF
--- a/packages/block-editor/src/components/block-patterns-list/index.js
+++ b/packages/block-editor/src/components/block-patterns-list/index.js
@@ -149,7 +149,7 @@ function BlockPatternList(
 		onHover,
 		onClickPattern,
 		orientation,
-		label = __( 'Block Patterns' ),
+		label = __( 'Block patterns' ),
 		showTitlesAsTooltip,
 		pagingProps,
 	},

--- a/packages/block-editor/src/components/inserter/block-patterns-tab.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-tab.js
@@ -42,7 +42,7 @@ const noop = () => {};
 
 export const allPatternsCategory = {
 	name: 'allPatterns',
-	label: __( 'All Patterns' ),
+	label: __( 'All patterns' ),
 };
 
 export const myPatternsCategory = {

--- a/packages/block-editor/src/components/inserter/search-results.js
+++ b/packages/block-editor/src/components/inserter/search-results.js
@@ -184,7 +184,7 @@ function InserterSearchResults( {
 	const patternsUI = !! filteredBlockPatterns.length && (
 		<InserterPanel
 			title={
-				<VisuallyHidden>{ __( 'Block Patterns' ) }</VisuallyHidden>
+				<VisuallyHidden>{ __( 'Block patterns' ) }</VisuallyHidden>
 			}
 		>
 			<div className="block-editor-inserter__quick-inserter-patterns">

--- a/packages/e2e-test-utils/src/create-reusable-block.js
+++ b/packages/e2e-test-utils/src/create-reusable-block.js
@@ -34,7 +34,7 @@ export const createReusableBlock = async ( content, title ) => {
 
 	// Wait for creation to finish
 	await page.waitForXPath(
-		'//*[contains(@class, "components-snackbar")]/*[contains(text(),"Pattern created:")]'
+		'//*[contains(@class, "components-snackbar")]/*[contains(text(),"pattern created:")]'
 	);
 
 	// Check that we have a reusable block on the page

--- a/packages/e2e-tests/specs/editor/various/pattern-blocks.test.js
+++ b/packages/e2e-tests/specs/editor/various/pattern-blocks.test.js
@@ -209,7 +209,7 @@ describe( 'Pattern blocks', () => {
 
 		// Wait for creation to finish.
 		await page.waitForXPath(
-			'//*[contains(@class, "components-snackbar")]/*[contains(text(),"Pattern created:")]'
+			'//*[contains(@class, "components-snackbar")]/*[contains(text(),"pattern created:")]'
 		);
 
 		await clearAllBlocks();

--- a/packages/list-reusable-blocks/src/components/import-form/index.js
+++ b/packages/list-reusable-blocks/src/components/import-form/index.js
@@ -49,7 +49,7 @@ function ImportForm( { instanceId, onUpload } ) {
 					case 'Invalid JSON file':
 						uiMessage = __( 'Invalid JSON file' );
 						break;
-					case 'Invalid Pattern JSON file':
+					case 'Invalid pattern JSON file':
 						uiMessage = __( 'Invalid pattern JSON file' );
 						break;
 					default:

--- a/packages/list-reusable-blocks/src/components/import-form/index.js
+++ b/packages/list-reusable-blocks/src/components/import-form/index.js
@@ -50,7 +50,7 @@ function ImportForm( { instanceId, onUpload } ) {
 						uiMessage = __( 'Invalid JSON file' );
 						break;
 					case 'Invalid Pattern JSON file':
-						uiMessage = __( 'Invalid Pattern JSON file' );
+						uiMessage = __( 'Invalid pattern JSON file' );
 						break;
 					default:
 						uiMessage = __( 'Unknown error' );

--- a/packages/list-reusable-blocks/src/utils/import.js
+++ b/packages/list-reusable-blocks/src/utils/import.js
@@ -31,7 +31,7 @@ async function importReusableBlock( file ) {
 		( parsedContent.syncStatus &&
 			typeof parsedContent.syncStatus !== 'string' )
 	) {
-		throw new Error( 'Invalid Pattern JSON file' );
+		throw new Error( 'Invalid pattern JSON file' );
 	}
 	const postType = await apiFetch( { path: `/wp/v2/types/wp_block` } );
 	const reusableBlock = await apiFetch( {

--- a/packages/patterns/src/components/pattern-convert-button.js
+++ b/packages/patterns/src/components/pattern-convert-button.js
@@ -110,12 +110,12 @@ export default function PatternConvertButton( { clientIds, rootClientId } ) {
 			pattern.wp_pattern_sync_status === PATTERN_SYNC_TYPES.unsynced
 				? sprintf(
 						// translators: %s: the name the user has given to the pattern.
-						__( 'Unsynced Pattern created: %s' ),
+						__( 'Unsynced pattern created: %s' ),
 						pattern.title.raw
 				  )
 				: sprintf(
 						// translators: %s: the name the user has given to the pattern.
-						__( 'Synced Pattern created: %s' ),
+						__( 'Synced pattern created: %s' ),
 						pattern.title.raw
 				  ),
 			{

--- a/packages/patterns/src/store/actions.js
+++ b/packages/patterns/src/store/actions.js
@@ -69,7 +69,7 @@ export const createPatternFromFile =
 			( parsedContent.syncStatus &&
 				typeof parsedContent.syncStatus !== 'string' )
 		) {
-			throw new Error( 'Invalid Pattern JSON file' );
+			throw new Error( 'Invalid pattern JSON file' );
 		}
 
 		const pattern = await dispatch.createPattern(

--- a/packages/reusable-blocks/src/components/reusable-blocks-menu-items/reusable-block-convert-button.js
+++ b/packages/reusable-blocks/src/components/reusable-blocks-menu-items/reusable-block-convert-button.js
@@ -115,12 +115,12 @@ export default function ReusableBlockConvertButton( {
 					! syncType
 						? sprintf(
 								// translators: %s: the name the user has given to the pattern.
-								__( 'Synced Pattern created: %s' ),
+								__( 'Synced pattern created: %s' ),
 								reusableBlockTitle
 						  )
 						: sprintf(
 								// translators: %s: the name the user has given to the pattern.
-								__( 'Unsynced Pattern created: %s' ),
+								__( 'Unsynced pattern created: %s' ),
 								reusableBlockTitle
 						  ),
 					{

--- a/packages/reusable-blocks/src/store/actions.js
+++ b/packages/reusable-blocks/src/store/actions.js
@@ -57,7 +57,7 @@ export const __experimentalConvertBlocksToReusable =
 				: undefined;
 
 		const reusableBlock = {
-			title: title || __( 'Untitled Pattern block' ),
+			title: title || __( 'Untitled pattern block' ),
 			content: serialize(
 				registry
 					.select( blockEditorStore )


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/54799

## What?

Improves consistency of pattern labels and notices using sentence case.

## Why?

Consistency.

## How?

- Replace `P` with `p`

## Testing Instructions

1. Navigate around pattern pages and see if you can spot any incorrect casing
2. Search codebase for further instances of incorrect casing for the UI

_Note: The custom post type still uses title case for "Patterns" in all its label config. Not sure if that should be changed. I'm leaning towards leaving it as_

## Screenshots or screencast <!-- if applicable -->

| Before | After |
|---|---|
| <img width="352" alt="Screenshot 2023-09-26 at 9 45 31 am" src="https://github.com/WordPress/gutenberg/assets/60436221/2273034b-36d3-4408-b77d-5df378387c38"> | <img width="351" alt="Screenshot 2023-09-26 at 9 45 45 am" src="https://github.com/WordPress/gutenberg/assets/60436221/37b5732a-719f-4cc9-adce-3dbb9b06ae3e"> |
