### PR TITLE
Always show the total number of patterns even with only one page

### DIFF
--- a/packages/block-editor/src/components/block-patterns-list/index.js
+++ b/packages/block-editor/src/components/block-patterns-list/index.js
@@ -180,9 +180,7 @@ function BlockPatternList(
 					<BlockPatternPlaceholder key={ pattern.name } />
 				);
 			} ) }
-			{ pagingProps && pagingProps.numPages > 1 && (
-				<BlockPatternsPaging { ...pagingProps } />
-			) }
+			{ pagingProps && <BlockPatternsPaging { ...pagingProps } /> }
 		</Composite>
 	);
 }

--- a/packages/block-editor/src/components/block-patterns-paging/index.js
+++ b/packages/block-editor/src/components/block-patterns-paging/index.js
@@ -27,66 +27,69 @@ export default function Pagination( {
 					)
 				}
 			</Text>
-			<HStack
-				expanded={ false }
-				spacing={ 3 }
-				justify="flex-start"
-				className="block-editor-patterns__grid-pagination"
-			>
+
+			{ numPages > 1 && (
 				<HStack
 					expanded={ false }
-					spacing={ 1 }
-					className="block-editor-patterns__grid-pagination-previous"
+					spacing={ 3 }
+					justify="flex-start"
+					className="block-editor-patterns__grid-pagination"
 				>
-					<Button
-						variant="tertiary"
-						onClick={ () => changePage( 1 ) }
-						disabled={ currentPage === 1 }
-						aria-label={ __( 'First page' ) }
+					<HStack
+						expanded={ false }
+						spacing={ 1 }
+						className="block-editor-patterns__grid-pagination-previous"
 					>
-						<span>«</span>
-					</Button>
-					<Button
-						variant="tertiary"
-						onClick={ () => changePage( currentPage - 1 ) }
-						disabled={ currentPage === 1 }
-						aria-label={ __( 'Previous page' ) }
+						<Button
+							variant="tertiary"
+							onClick={ () => changePage( 1 ) }
+							disabled={ currentPage === 1 }
+							aria-label={ __( 'First page' ) }
+						>
+							<span>«</span>
+						</Button>
+						<Button
+							variant="tertiary"
+							onClick={ () => changePage( currentPage - 1 ) }
+							disabled={ currentPage === 1 }
+							aria-label={ __( 'Previous page' ) }
+						>
+							<span>‹</span>
+						</Button>
+					</HStack>
+					<Text variant="muted">
+						{ sprintf(
+							// translators: %1$s: Current page number, %2$s: Total number of pages.
+							_x( '%1$s of %2$s', 'paging' ),
+							currentPage,
+							numPages
+						) }
+					</Text>
+					<HStack
+						expanded={ false }
+						spacing={ 1 }
+						className="block-editor-patterns__grid-pagination-next"
 					>
-						<span>‹</span>
-					</Button>
+						<Button
+							variant="tertiary"
+							onClick={ () => changePage( currentPage + 1 ) }
+							disabled={ currentPage === numPages }
+							aria-label={ __( 'Next page' ) }
+						>
+							<span>›</span>
+						</Button>
+						<Button
+							variant="tertiary"
+							onClick={ () => changePage( numPages ) }
+							disabled={ currentPage === numPages }
+							aria-label={ __( 'Last page' ) }
+							size="default"
+						>
+							<span>»</span>
+						</Button>
+					</HStack>
 				</HStack>
-				<Text variant="muted">
-					{ sprintf(
-						// translators: %1$s: Current page number, %2$s: Total number of pages.
-						_x( '%1$s of %2$s', 'paging' ),
-						currentPage,
-						numPages
-					) }
-				</Text>
-				<HStack
-					expanded={ false }
-					spacing={ 1 }
-					className="block-editor-patterns__grid-pagination-next"
-				>
-					<Button
-						variant="tertiary"
-						onClick={ () => changePage( currentPage + 1 ) }
-						disabled={ currentPage === numPages }
-						aria-label={ __( 'Next page' ) }
-					>
-						<span>›</span>
-					</Button>
-					<Button
-						variant="tertiary"
-						onClick={ () => changePage( numPages ) }
-						disabled={ currentPage === numPages }
-						aria-label={ __( 'Last page' ) }
-						size="default"
-					>
-						<span>»</span>
-					</Button>
-				</HStack>
-			</HStack>
+			) }
 		</VStack>
 	);
 }

--- a/packages/block-editor/src/components/inserter/block-patterns-explorer/patterns-list.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-explorer/patterns-list.js
@@ -142,9 +142,7 @@ function PatternList( { searchValue, selectedCategory, patternCategories } ) {
 						isDraggable={ false }
 					/>
 				) }
-				{ pagingProps.numPages > 1 && (
-					<BlockPatternsPaging { ...pagingProps } />
-				) }
+				<BlockPatternsPaging { ...pagingProps } />
 			</InserterListbox>
 		</div>
 	);

--- a/packages/block-editor/src/components/inserter/block-patterns-explorer/patterns-list.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-explorer/patterns-list.js
@@ -135,14 +135,18 @@ function PatternList( { searchValue, selectedCategory, patternCategories } ) {
 
 			<InserterListbox>
 				{ hasItems && (
-					<BlockPatternsList
-						shownPatterns={ pagingProps.categoryPatternsAsyncList }
-						blockPatterns={ pagingProps.categoryPatterns }
-						onClickPattern={ onClickPattern }
-						isDraggable={ false }
-					/>
+					<>
+						<BlockPatternsList
+							shownPatterns={
+								pagingProps.categoryPatternsAsyncList
+							}
+							blockPatterns={ pagingProps.categoryPatterns }
+							onClickPattern={ onClickPattern }
+							isDraggable={ false }
+						/>
+						<BlockPatternsPaging { ...pagingProps } />
+					</>
 				) }
-				<BlockPatternsPaging { ...pagingProps } />
 			</InserterListbox>
 		</div>
 	);

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -480,6 +480,7 @@ $block-inserter-tabs-height: 44px;
 		display: grid;
 		grid-gap: $grid-unit-40;
 		grid-template-columns: repeat(1, 1fr);
+		margin-bottom: $grid-unit-20;
 
 		@include break-xlarge() {
 			grid-template-columns: repeat(2, 1fr);


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Add "%d items" to the patterns list even when there is only one page.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Consistency with the multi-page list.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Move the condition to the paging component instead.

## Testing Instructions for Keyboard
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Open post editor
2. Open the global inserter ("Toggle block inserter"), and select the "Patterns" tab
3. Select a category that has under 20 patterns
4. Expect the list to still show the total number of patterns at the bottom.
5. Press <kbd>Shift</kbd>+<kbd>Tab</kbd> a couple of times to reach the "Explore all patterns" button and open the explorer modal.
6. Select a category that has under 20 patterns
7. Expect the patterns list in the explorer to still show the total number of patterns at the bottom.
8. Repeat the above but with empty results, and expect the total number of patterns to not show.

## Screenshots or screencast <!-- if applicable -->

| / | Before | After |
|---|--------|--------|
| **Inserter** | ![image](https://github.com/WordPress/gutenberg/assets/7753001/5e4c4353-4633-41aa-af17-e55df80a121e) | ![image](https://github.com/WordPress/gutenberg/assets/7753001/bad25898-b38d-4cd5-9ad8-985f7856bfcc) |
| **Explorer** | ![image](https://github.com/WordPress/gutenberg/assets/7753001/2b1d99f5-9f80-4654-9e87-c6fbdf3bfdf6) | ![image](https://github.com/WordPress/gutenberg/assets/7753001/07a8e320-855e-4200-8f11-52012c5890b9) |
