### PR TITLE
Add `aria-label` attribute to navigation block only when it is open

### DIFF
--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -875,7 +875,6 @@ function Navigation( {
 						<ResponsiveWrapper
 							id={ clientId }
 							onToggle={ setResponsiveMenuVisibility }
-							label={ __( 'Menu' ) }
 							hasIcon={ hasIcon }
 							icon={ icon }
 							isOpen={ isResponsiveMenuOpen }

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -698,7 +698,7 @@ function render_block_core_navigation( $attributes, $content, $block ) {
 	if ( $should_load_view_script ) {
 		$nav_element_directives          = '
 			data-wp-interactive
-			data-wp-context=\'{ "core": { "navigation": { "overlayOpenedBy": {}, "type": "overlay", "roleAttribute": "" } } }\'
+			data-wp-context=\'{ "core": { "navigation": { "overlayOpenedBy": {}, "type": "overlay", "roleAttribute": "", "ariaLabel": "' . __( 'Menu' ) . '" } } }\'
 		';
 		$open_button_directives          = '
 			data-wp-on--click="actions.core.navigation.openMenuOnClick"
@@ -714,6 +714,7 @@ function render_block_core_navigation( $attributes, $content, $block ) {
 		';
 		$responsive_dialog_directives    = '
 			data-wp-bind--aria-modal="selectors.core.navigation.ariaModal"
+			data-wp-bind--aria-label="selectors.core.navigation.ariaLabel"
 			data-wp-bind--role="selectors.core.navigation.roleAttribute"
 			data-wp-effect="effects.core.navigation.focusFirstElement"
 		';
@@ -723,11 +724,11 @@ function render_block_core_navigation( $attributes, $content, $block ) {
 	}
 
 	$responsive_container_markup = sprintf(
-		'<button aria-haspopup="true" %3$s class="%6$s" %11$s>%9$s</button>
-			<div class="%5$s" style="%7$s" id="%1$s" %12$s>
+		'<button aria-haspopup="true" %3$s class="%6$s" %10$s>%8$s</button>
+			<div class="%5$s" style="%7$s" id="%1$s" %11$s>
 				<div class="wp-block-navigation__responsive-close" tabindex="-1">
-					<div class="wp-block-navigation__responsive-dialog" aria-label="%8$s" %13$s>
-							<button %4$s class="wp-block-navigation__responsive-container-close" %14$s>%10$s</button>
+					<div class="wp-block-navigation__responsive-dialog" %12$s>
+							<button %4$s class="wp-block-navigation__responsive-container-close" %13$s>%9$s</button>
 						<div class="wp-block-navigation__responsive-container-content" id="%1$s-content">
 							%2$s
 						</div>
@@ -741,7 +742,6 @@ function render_block_core_navigation( $attributes, $content, $block ) {
 		esc_attr( implode( ' ', $responsive_container_classes ) ),
 		esc_attr( implode( ' ', $open_button_classes ) ),
 		esc_attr( safecss_filter_attr( $colors['overlay_inline_styles'] ) ),
-		__( 'Menu' ),
 		$toggle_button_content,
 		$toggle_close_button_content,
 		$open_button_directives,

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -696,9 +696,21 @@ function render_block_core_navigation( $attributes, $content, $block ) {
 	$responsive_dialog_directives    = '';
 	$close_button_directives         = '';
 	if ( $should_load_view_script ) {
+		$nav_element_context             = wp_json_encode(
+			array(
+				'core' => array(
+					'navigation' => array(
+						'overlayOpenedBy' => array(),
+						'type'            => 'overlay',
+						'roleAttribute'   => '',
+						'ariaLabel'       => __( 'Menu' ),
+					),
+				),
+			)
+		);
 		$nav_element_directives          = '
 			data-wp-interactive
-			data-wp-context=\'{ "core": { "navigation": { "overlayOpenedBy": {}, "type": "overlay", "roleAttribute": "", "ariaLabel": "' . esc_attr__( 'Menu' ) . '" } } }\'
+			data-wp-context=\'' . $nav_element_context . '\'
 		';
 		$open_button_directives          = '
 			data-wp-on--click="actions.core.navigation.openMenuOnClick"

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -698,7 +698,7 @@ function render_block_core_navigation( $attributes, $content, $block ) {
 	if ( $should_load_view_script ) {
 		$nav_element_directives          = '
 			data-wp-interactive
-			data-wp-context=\'{ "core": { "navigation": { "overlayOpenedBy": {}, "type": "overlay", "roleAttribute": "", "ariaLabel": "' . __( 'Menu' ) . '" } } }\'
+			data-wp-context=\'{ "core": { "navigation": { "overlayOpenedBy": {}, "type": "overlay", "roleAttribute": "", "ariaLabel": "' . esc_attr__( 'Menu' ) . '" } } }\'
 		';
 		$open_button_directives          = '
 			data-wp-on--click="actions.core.navigation.openMenuOnClick"

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -706,7 +706,8 @@ function render_block_core_navigation( $attributes, $content, $block ) {
 						'ariaLabel'       => __( 'Menu' ),
 					),
 				),
-			)
+			),
+			JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_AMP
 		);
 		$nav_element_directives          = '
 			data-wp-interactive

--- a/packages/block-library/src/navigation/view.js
+++ b/packages/block-library/src/navigation/view.js
@@ -87,6 +87,13 @@ wpStore( {
 						? 'true'
 						: null;
 				},
+				ariaLabel: ( store ) => {
+					const { context, selectors } = store;
+					return context.core.navigation.type === 'overlay' &&
+						selectors.core.navigation.isMenuOpen( store )
+						? context.core.navigation.ariaLabel
+						: null;
+				},
 				isMenuOpen: ( { context } ) =>
 					// The menu is opened if either `click`, `hover` or `focus` is true.
 					Object.values(

--- a/packages/block-library/src/query/index.php
+++ b/packages/block-library/src/query/index.php
@@ -34,7 +34,8 @@ function render_block_core_query( $attributes, $content, $block ) {
 								'loadedText'  => __( 'Page Loaded.' ),
 							),
 						),
-					)
+					),
+					JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_AMP
 				)
 			);
 			$content = $p->get_updated_html();


### PR DESCRIPTION
## What?
Fix the issue reported [here](https://github.com/WordPress/gutenberg/issues/54560#issuecomment-1727635726).

This pull request adds the logic to only add the `aria-label` attribute to the navigation block when this is open.

## Why?

As reported [in the mentioned issue](https://github.com/WordPress/gutenberg/issues/54560#issuecomment-1727635726), it is causing accessibility issues.

## How?
I basically removed that attribute from the server side rendering and added some logic in JavaScript to load it conditionally only when the menu is open.

I also removed an unnecessary prop of the React component used in the editor.

## Testing Instructions

**Before this fix**
1. Add a navigation block to your site with the overlay setting set to "Mobile".
2. In the desktop view: Go to the frontend and inspect the `div` with class `wp-block-navigation__responsive-dialog`. It has the attribute `aria-label="Menu"`, which is not correct.

**After this fix**
1. Add a navigation block to your site with the overlay setting set to "Mobile".
2. In the desktop view: Go to the frontend and inspect the `div` with class `wp-block-navigation__responsive-dialog`. It has NOT the attribute `aria-label`.
3. In the mobile view: Open the menu and check that the attribute `aria-label="Menu"` is added.
4. Close the menu and check that the attribute is removed.
