### PR TITLE
Rich text: Try debouncing `useInput` to improve performance and fix infinite loop

### DIFF
--- a/packages/rich-text/src/component/use-input-and-selection.js
+++ b/packages/rich-text/src/component/use-input-and-selection.js
@@ -111,7 +111,7 @@ export function useInputAndSelection( props ) {
 
 				handleChange( change );
 			},
-			50,
+			1,
 			{ leading: true, trailing: false }
 		);
 


### PR DESCRIPTION
## What?
This PR attempts to debounce `useInput` inside the rich text component in order to resolve an issue when typing quickly. In my testing, it also improves the performance when typing quickly - the typed characters start appearing faster and there's way smaller delay between them.

Also related to #22822.

## Why?
There are a few different problems this PR is attempting to improve:

**1. React warning Maximum update depth exceeded error**
When working with a large post, and typing very very fast inside a paragraph, we can see this error in the console:
![Screenshot 2023-09-26 at 13 16 30](https://github.com/WordPress/gutenberg/assets/8436925/ac2d9bea-2273-46d8-b68f-ece7fd1819f5)
Since this will debounce the `onInput()` function, it resolves that issue since `onInput()` no longer calls that often when typing swiftly. 

**2. Typing performance**
When working with a large post, and typing very very fast inside a paragraph, we can see that typing gets slower and the delay between each character that gets added gets bigger and bigger. I see a huge improvement when testing with this branch.

## How?
We're simply debouncing `useInput()` so it won't be called that often, and that way it won't cause infinite loops and delayed typing feedback.  

May be easier to review with ignored whitespace.

## Testing Instructions
* Start a new post and add [this large post](https://github.com/WordPress/gutenberg/blob/72b7d89dbcda2ba63bc1ad99e8fc5f33309401d3/test/performance/assets/large-post.html) as its content.
* Go to the bottom of the post and start a new paragraph.
* Start typing jibberish as fast as you can.
* Verify that you no longer get the error from above.
* Verify that the delays of character appearance are significantly smaller or non-existent.
* Verify all tests still pass.

### Testing Instructions for Keyboard
None

## Screenshots or screencast <!-- if applicable -->
None