### PR TITLE
Fix Search Block not updating in Nav block

### DIFF
--- a/packages/block-library/src/search/edit.js
+++ b/packages/block-library/src/search/edit.js
@@ -84,7 +84,7 @@ export default function SearchEdit( {
 		style,
 	} = attributes;
 
-	const insertedInNavigationBlock = useSelect(
+	const wasJustInsertedIntoNavigationBlock = useSelect(
 		( select ) => {
 			const { getBlockParentsByBlockName, wasBlockJustInserted } =
 				select( blockEditorStore );
@@ -98,15 +98,21 @@ export default function SearchEdit( {
 	const { __unstableMarkNextChangeAsNotPersistent } =
 		useDispatch( blockEditorStore );
 
-	if ( insertedInNavigationBlock ) {
-		// This side-effect should not create an undo level.
-		__unstableMarkNextChangeAsNotPersistent();
-		setAttributes( {
-			showLabel: false,
-			buttonUseIcon: true,
-			buttonPosition: 'button-inside',
-		} );
-	}
+	useEffect( () => {
+		if ( wasJustInsertedIntoNavigationBlock ) {
+			// This side-effect should not create an undo level.
+			__unstableMarkNextChangeAsNotPersistent();
+			setAttributes( {
+				showLabel: false,
+				buttonUseIcon: true,
+				buttonPosition: 'button-inside',
+			} );
+		}
+	}, [
+		__unstableMarkNextChangeAsNotPersistent,
+		wasJustInsertedIntoNavigationBlock,
+		setAttributes,
+	] );
 
 	const borderRadius = style?.border?.radius;
 	const borderProps = useBorderProps( attributes );

--- a/test/e2e/specs/editor/blocks/search.spec.js
+++ b/test/e2e/specs/editor/blocks/search.spec.js
@@ -74,26 +74,21 @@ test.describe( 'Search', () => {
 
 		await expect( searchBlock ).toBeVisible();
 
-		const navBlockInEditor = await page.evaluate( () => {
-			const allBlocks = window.wp.data
-				.select( 'core/block-editor' )
-				.getBlocks();
+		// The only way to access the inner controlled blocks of the Navigation block
+		// is to access the edited entity record for the associated Navigation Menu record.
+		const editedMenuRecord = await page.evaluate( ( menuId ) => {
+			return window.wp.data
+				.select( 'core' )
+				.getEditedEntityRecord( 'postType', 'wp_navigation', menuId );
+		}, createdMenu?.id );
 
-			const block = window.wp.data
-				.select( 'core/block-editor' )
-				.getBlock( allBlocks[ 0 ].clientId );
-			return block;
+		// The 2nd block in the Navigation block is the Search block.
+		const searchBlockAttributes = editedMenuRecord.blocks[ 1 ].attributes;
+
+		expect( searchBlockAttributes ).toMatchObject( {
+			showLabel: false,
+			buttonUseIcon: true,
+			buttonPosition: 'button-inside',
 		} );
-
-		await expect.poll( navBlockInEditor ).toMatchObject( [
-			{
-				name: 'core/search',
-				attributes: {
-					showLabel: false,
-					buttonUseIcon: true,
-					buttonPosition: 'button-inside',
-				},
-			},
-		] );
 	} );
 } );

--- a/test/e2e/specs/editor/blocks/search.spec.js
+++ b/test/e2e/specs/editor/blocks/search.spec.js
@@ -1,0 +1,99 @@
+/**
+ * WordPress dependencies
+ */
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+
+test.describe( 'Search', () => {
+	test.beforeEach( async ( { admin, requestUtils } ) => {
+		await requestUtils.deleteAllMenus();
+		await admin.createNewPost();
+	} );
+
+	test.afterAll( async ( { requestUtils } ) => {
+		await requestUtils.deleteAllMenus();
+	} );
+
+	test.afterEach( async ( { requestUtils } ) => {
+		await Promise.all( [
+			requestUtils.deleteAllPosts(),
+			requestUtils.deleteAllMenus(),
+		] );
+	} );
+
+	test( 'should auto-configure itself to sensible defaults when inserted into a Navigation block', async ( {
+		page,
+		editor,
+		requestUtils,
+	} ) => {
+		const createdMenu = await requestUtils.createNavigationMenu( {
+			title: 'Test Menu',
+			content: `<!-- wp:spacer -->
+<div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->`,
+		} );
+
+		await editor.insertBlock( {
+			name: 'core/navigation',
+			attributes: {
+				ref: createdMenu?.id,
+			},
+		} );
+
+		const navBlockInserter = editor.canvas.getByRole( 'button', {
+			name: 'Add block',
+		} );
+		await navBlockInserter.click();
+
+		// Expect to see the block inserter.
+		await expect(
+			page.getByRole( 'searchbox', {
+				name: 'Search for blocks and patterns',
+			} )
+		).toBeFocused();
+
+		// Search for the Search block.
+		await page.keyboard.type( 'Search' );
+
+		const blockResults = page.getByRole( 'listbox', {
+			name: 'Blocks',
+		} );
+
+		await expect( blockResults ).toBeVisible();
+
+		const searchBlockResult = blockResults.getByRole( 'option', {
+			name: 'Search',
+		} );
+
+		// Select the Search block.
+		await searchBlockResult.click();
+
+		// Expect to see the Search block.
+		const searchBlock = editor.canvas.getByRole( 'document', {
+			name: 'Block: Search',
+		} );
+
+		await expect( searchBlock ).toBeVisible();
+
+		const navBlockInEditor = await page.evaluate( () => {
+			const allBlocks = window.wp.data
+				.select( 'core/block-editor' )
+				.getBlocks();
+
+			const block = window.wp.data
+				.select( 'core/block-editor' )
+				.getBlock( allBlocks[ 0 ].clientId );
+			return block;
+		} );
+
+		await expect.poll( navBlockInEditor ).toMatchObject( [
+			{
+				name: 'core/search',
+				attributes: {
+					showLabel: false,
+					buttonUseIcon: true,
+					buttonPosition: 'button-inside',
+				},
+			},
+		] );
+	} );
+} );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes Search blocks to allow them to have changes to their configuration when they are within a Navigation block.

Closes https://github.com/WordPress/gutenberg/issues/53038

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Blocks should be configurable via their UI controls.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

There was a console error when inserting a Search block into Navigation block. This was referring to a `setState` in render.

The culprit was `setAttributes` called conditionally within the render method.

Moving this code to an effect fixes the problem. This is likely because we cannot treat `setAttributes` like idiomatic React's "setState". `setAttributes` actually updates an external global store (Redux) and so it could caused other blocks to re-render. This is likely what triggers the console error.

The idea of attempting to derive the "state" of the block once it has been inserted seems to go against the React paradigm. The "insert" [is in fact an "event" and thus it might be better to handle this in a callback](https://react.dev/learn/you-might-not-need-an-effect) which inserts the block with a given state based on some context. Instead, we are inserting the block and _then_ trying to derive it's state which is problematic.

However, we don't have such APIs available to us so moving to an effect is the best we can do for now.





## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- Add Nav block.
- Add search block to the Nav block (you can find this at the bottom of the Link UI that appears).
- Change configuration of the Search block.
- Save the Navigation (top right "Publish" button in editor).
- See that changes are persisted.
- Reload editor.
- See that changes are persisted.
- Make some more changes.
- Switch editor to "Code" view.
- Switch back to "Visual" view.
- See that changes are persisted.
- Try anything listed in comments in https://github.com/WordPress/gutenberg/issues/53038 to try and replicate the original Issue.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/444434/40ac6056-d52f-4d85-bac5-aad463f3d95c

