### PR TITLE
Conditionally remove deprecated 'print_emoji_styles'

### DIFF
--- a/lib/compat/wordpress-6.4/script-loader.php
+++ b/lib/compat/wordpress-6.4/script-loader.php
@@ -158,13 +158,22 @@ function _gutenberg_get_iframed_editor_assets_6_4() {
 		}
 	}
 
-	// Remove the deprecated `print_emoji_styles` handler.
-	// It avoids breaking style generation with a deprecation message.
-	remove_action( 'wp_print_styles', 'print_emoji_styles' );
+	/**
+	 * Remove the deprecated `print_emoji_styles` handler.
+	 * It avoids breaking style generation with a deprecation message.
+	 */
+	$has_emoji_styles = has_action( 'wp_print_styles', 'print_emoji_styles' );
+	if ( $has_emoji_styles ) {
+		remove_action( 'wp_print_styles', 'print_emoji_styles' );
+	}
+
 	ob_start();
 	wp_print_styles();
 	$styles = ob_get_clean();
-	add_action( 'wp_print_styles', 'print_emoji_styles' );
+
+	if ( $has_emoji_styles ) {
+		add_action( 'wp_print_styles', 'print_emoji_styles' );
+	}
 
 	ob_start();
 	wp_print_head_scripts();


### PR DESCRIPTION
## What?
Backports changes from https://github.com/WordPress/wordpress-develop/pull/5305.

Conditionally remove/add deprecated 'print_emoji_styles'.

Note: I'm skipping updates for `lib/compat/wordpress-6.3/script-loader.php`, asset load for 6.3 needs to be removed. See #54812.

## Testing Instructions
See https://github.com/WordPress/wordpress-develop/pull/5305.
