### PR TITLE
Font Library: avoid rendering font library ui outisde gutenberg plugin

### DIFF
--- a/packages/edit-site/src/components/global-styles/font-families.js
+++ b/packages/edit-site/src/components/global-styles/font-families.js
@@ -64,8 +64,12 @@ function FontFamilies() {
 	);
 }
 
-export default ( { ...props } ) => (
+const FontFamiliesComponent = ( { ...props } ) => (
 	<FontLibraryProvider>
 		<FontFamilies { ...props } />
 	</FontLibraryProvider>
 );
+
+export default process.env.IS_GUTENBERG_PLUGIN
+	? FontFamiliesComponent
+	: undefined;

--- a/packages/edit-site/src/components/global-styles/screen-typography.js
+++ b/packages/edit-site/src/components/global-styles/screen-typography.js
@@ -22,9 +22,10 @@ function ScreenTypography() {
 			/>
 			<div className="edit-site-global-styles-screen-typography">
 				<VStack spacing={ 6 }>
-					{ ! window.__experimentalDisableFontLibrary && (
-						<FontFamilies />
-					) }
+					{ FontFamilies &&
+						! window.__experimentalDisableFontLibrary && (
+							<FontFamilies />
+						) }
 					<TypographyElements />
 				</VStack>
 			</div>


### PR DESCRIPTION
## What?
Font Library: avoid rendering the font library UI outside Gutenberg plugin

## Why?
Avoid rendering the font library in the core.

## How?
Exporting the component only if it's a Gutenberg build.
