### PR TITLE
Font Library: syntax refactor repace strpos with str_contains

### DIFF
--- a/lib/experimental/fonts/font-library/class-wp-font-collection.php
+++ b/lib/experimental/fonts/font-library/class-wp-font-collection.php
@@ -79,7 +79,7 @@ class WP_Font_Collection {
 	 */
 	public function get_data() {
 		// If the src is a URL, fetch the data from the URL.
-		if ( false !== strpos( $this->config['src'], 'http' ) && false !== strpos( $this->config['src'], '://' ) ) {
+		if ( str_contains( $this->config['src'], 'http' ) && str_contains( $this->config['src'], '://' ) ) {
 			if ( ! wp_http_validate_url( $this->config['src'] ) ) {
 				return new WP_Error( 'font_collection_read_error', __( 'Invalid URL for Font Collection data.', 'gutenberg' ) );
 			}


### PR DESCRIPTION
## What?
syntax refactor repace strpos with str_contains
Follow up of this @anton-vlasenko comment: https://github.com/WordPress/gutenberg/pull/54067#issuecomment-1731798079

## Why?
to improve code readeability

## How?
repacing strpos with str_contains


## Testing Instructions
run php unit tests