### PR TITLE
fix: Prevent crash from invalid media URLs

### DIFF
--- a/packages/block-library/src/audio/edit.native.js
+++ b/packages/block-library/src/audio/edit.native.js
@@ -30,7 +30,7 @@ import { audio as icon, replace } from '@wordpress/icons';
 import { useState } from '@wordpress/element';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { store as noticesStore } from '@wordpress/notices';
-import { isURL } from '@wordpress/url';
+import { isURL, getProtocol } from '@wordpress/url';
 
 /**
  * Internal dependencies
@@ -73,7 +73,7 @@ function AudioEdit( {
 
 	function onSelectURL( newSrc ) {
 		if ( newSrc !== src ) {
-			if ( isURL( newSrc ) ) {
+			if ( isURL( newSrc ) && /^https?:/.test( getProtocol( newSrc ) ) ) {
 				setAttributes( { src: newSrc, id: undefined } );
 			} else {
 				createErrorNotice( __( 'Invalid URL. Audio file not found.' ) );

--- a/packages/block-library/src/audio/test/edit.native.js
+++ b/packages/block-library/src/audio/test/edit.native.js
@@ -1,13 +1,20 @@
 /**
  * External dependencies
  */
-import { render } from 'test/helpers';
+import {
+	addBlock,
+	dismissModal,
+	fireEvent,
+	initializeEditor,
+	render,
+	screen,
+	setupCoreBlocks,
+} from 'test/helpers';
 
 /**
  * WordPress dependencies
  */
 import { BlockEdit } from '@wordpress/block-editor';
-import { registerBlockType, unregisterBlockType } from '@wordpress/blocks';
 import {
 	subscribeMediaUpload,
 	sendMediaUpload,
@@ -16,7 +23,7 @@ import {
 /**
  * Internal dependencies
  */
-import { metadata, settings, name } from '../index';
+import { name } from '../index';
 
 // react-native-aztec shouldn't be mocked because these tests are based on
 // snapshot testing where we want to keep the original component.
@@ -42,18 +49,9 @@ const getTestComponentWithContent = ( attributes = {} ) => {
 	);
 };
 
+setupCoreBlocks( [ 'core/audio' ] );
+
 describe( 'Audio block', () => {
-	beforeAll( () => {
-		registerBlockType( name, {
-			...metadata,
-			...settings,
-		} );
-	} );
-
-	afterAll( () => {
-		unregisterBlockType( name );
-	} );
-
 	it( 'renders placeholder without crashing', () => {
 		const component = getTestComponentWithContent();
 		const rendered = component.toJSON();
@@ -85,5 +83,21 @@ describe( 'Audio block', () => {
 
 		const rendered = component.toJSON();
 		expect( rendered ).toMatchSnapshot();
+	} );
+
+	it( 'should gracefully handle invalid URLs', async () => {
+		await initializeEditor();
+
+		await addBlock( screen, 'Audio' );
+		fireEvent.press( screen.getByText( 'Insert from URL' ) );
+		fireEvent.changeText(
+			screen.getByPlaceholderText( 'Type a URL' ),
+			'h://wordpress.org/audio.mp3'
+		);
+		dismissModal( screen.getByTestId( 'bottom-sheet' ) );
+
+		expect(
+			screen.getByText( 'Invalid URL. Audio file not found.' )
+		).toBeVisible();
 	} );
 } );

--- a/packages/block-library/src/video/edit.native.js
+++ b/packages/block-library/src/video/edit.native.js
@@ -162,7 +162,7 @@ class VideoEdit extends Component {
 	onSelectURL( url ) {
 		const { createErrorNotice, onReplace, setAttributes } = this.props;
 
-		if ( isURL( url ) ) {
+		if ( isURL( url ) && /^https?:/.test( getProtocol( url ) ) ) {
 			// Check if there's an embed block that handles this URL.
 			const embedBlock = createUpgradedEmbedBlock( {
 				attributes: { url },

--- a/packages/block-library/src/video/test/edit.native.js
+++ b/packages/block-library/src/video/test/edit.native.js
@@ -1,0 +1,29 @@
+/**
+ * External dependencies
+ */
+import {
+	addBlock,
+	dismissModal,
+	fireEvent,
+	initializeEditor,
+	screen,
+	setupCoreBlocks,
+} from 'test/helpers';
+
+setupCoreBlocks( [ 'core/video' ] );
+
+describe( 'Video block', () => {
+	it( 'should gracefully handle invalid URLs', async () => {
+		await initializeEditor();
+
+		await addBlock( screen, 'Video' );
+		fireEvent.press( screen.getByText( 'Insert from URL' ) );
+		fireEvent.changeText(
+			screen.getByPlaceholderText( 'Type a URL' ),
+			'h://wordpress.org/video.mp4'
+		);
+		dismissModal( screen.getByTestId( 'bottom-sheet' ) );
+
+		expect( screen.getByText( 'Invalid URL.' ) ).toBeVisible();
+	} );
+} );

--- a/packages/react-native-editor/CHANGELOG.md
+++ b/packages/react-native-editor/CHANGELOG.md
@@ -11,6 +11,7 @@ For each user feature we should also add a importance categorization label  to i
 
 ## Unreleased
 -   [*] Limit inner blocks nesting depth to avoid call stack size exceeded crash [#54382]
+-   [*] Prevent crashes when setting an invalid media URL for Video or Audio blocks [#54834]
 
 ## 1.104.0
 -   [*] Fix the obscurred "Insert from URL" input for media blocks when using a device in landscape orientation. [#54096]


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Prevent crashes resulting from attempts to set an invalid URL for a video or
audio file, e.g. `h://domain.org/video.mp4`.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/6233. The crash is disruptive for users.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Detect and avoid sending URLs that do not begin with `http:` or `http://` to the
`react-native-video` package as it will attempt and fail to load the URL as a
local app bundle resource. Instead, display a notice to the user that the
provided URL is invalid.

The `isURL` utility considers URLs using uncommon protocols to be valid,
as constructing `URL` with, say, `h://a-path.com` is valid.
Contrastingly, the `react-native-video` package [only considers](https://github.com/react-native-video/react-native-video/blob/81ae785090f5ce3d5e45cc51f68a3360a85be853/Video.js#L277) a URL
using the `http:` or `https:` protocols to be a "network" asset. This
leads to an attempt to load the URL as a local asset, which fails as the
asset does not exist in the app bundle.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Add a Video or Audio block.
1. Select "Insert from URL."
1. Type an invalid URL, e.g. `h://wordpress.org/video.mp4`.
1. Dismiss the bottom sheet.
1. Verify the app does not crash and a helpful message is displayed.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
n/a

## Screenshots or screencast <!-- if applicable -->
n/a
