### PR TITLE
Global styles tests: fire hooks when updating post

### DIFF
--- a/phpunit/class-gutenberg-rest-global-styles-revisions-controller-test.php
+++ b/phpunit/class-gutenberg-rest-global-styles-revisions-controller-test.php
@@ -130,7 +130,7 @@ class Gutenberg_REST_Global_Styles_Revisions_Controller_Test extends WP_Test_RES
 			),
 		);
 
-		wp_update_post( $new_styles_post, true, false );
+		wp_update_post( $new_styles_post, true, true );
 
 		$new_styles_post = array(
 			'ID'           => self::$global_styles_id,
@@ -160,7 +160,7 @@ class Gutenberg_REST_Global_Styles_Revisions_Controller_Test extends WP_Test_RES
 			),
 		);
 
-		wp_update_post( $new_styles_post, true, false );
+		wp_update_post( $new_styles_post, true, true );
 
 		$new_styles_post = array(
 			'ID'           => self::$global_styles_id,
@@ -190,7 +190,7 @@ class Gutenberg_REST_Global_Styles_Revisions_Controller_Test extends WP_Test_RES
 			),
 		);
 
-		wp_update_post( $new_styles_post, true, false );
+		wp_update_post( $new_styles_post, true, true );
 		wp_set_current_user( 0 );
 	}
 


### PR DESCRIPTION
## What?
Cherry-picks changes from https://github.com/WordPress/gutenberg/pull/52988#issuecomment-1735938288 to fix failing PHPUnit tests on trunk.

## Testing Instructions
CI should be green.
