### PR TITLE
Image: Fix Lightbox display bug in Classic Themes.

### DIFF
--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -292,7 +292,7 @@ function block_core_image_render_lightbox( $block_content, $block ) {
             data-wp-on--mousewheel="actions.core.image.hideLightbox"
             data-wp-on--click="actions.core.image.hideLightbox"
             >
-                <button type="button" aria-label="$close_button_label" style="fill: $close_button_color" class="close-button" data-wp-on--click="actions.core.image.hideLightbox">
+                <button type="button" aria-label="$close_button_label" style="color: $close_button_color" class="close-button" data-wp-on--click="actions.core.image.hideLightbox">
                     $close_button_icon
                 </button>
                 <div class="lightbox-image-container">$initial_image_content</div>

--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -252,10 +252,13 @@ function block_core_image_render_lightbox( $block_content, $block ) {
 	$q->set_attribute( 'data-wp-style--object-fit', 'selectors.core.image.lightboxObjectFit' );
 	$enlarged_image_content = $q->get_updated_html();
 
-	$background_color = esc_attr( wp_get_global_styles( array( 'color', 'background' ) ) );
+	// If the current theme is NOT a block theme, we need to set the background
+	// color & close button color to some default values because we can't get them
+	// from the Global Styles.
+	$background_color   = wp_is_block_theme() ? esc_attr( wp_get_global_styles( array( 'color', 'background' ) ) ) : 'white';
+	$close_button_color = wp_is_block_theme() ? esc_attr( wp_get_global_styles( array( 'color', 'text' ) ) ) : 'black';
 
 	$close_button_icon  = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="15" height="15" aria-hidden="true" focusable="false"><path d="M13 11.8l6.1-6.3-1-1-6.1 6.2-6.1-6.2-1 1 6.1 6.3-6.5 6.7 1 1 6.5-6.6 6.5 6.6 1-1z"></path></svg>';
-	$close_button_color = esc_attr( wp_get_global_styles( array( 'color', 'text' ) ) );
 	$dialog_label       = $alt_attribute ? esc_attr( $alt_attribute ) : esc_attr__( 'Image' );
 	$close_button_label = esc_attr__( 'Close' );
 

--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -252,11 +252,14 @@ function block_core_image_render_lightbox( $block_content, $block ) {
 	$q->set_attribute( 'data-wp-style--object-fit', 'selectors.core.image.lightboxObjectFit' );
 	$enlarged_image_content = $q->get_updated_html();
 
-	// If the current theme is NOT a block theme, we need to set the background
-	// color & close button color to some default values because we can't get them
-	// from the Global Styles.
-	$background_color   = wp_is_block_theme() ? esc_attr( wp_get_global_styles( array( 'color', 'background' ) ) ) : 'white';
-	$close_button_color = wp_is_block_theme() ? esc_attr( wp_get_global_styles( array( 'color', 'text' ) ) ) : 'black';
+	// If the current theme does NOT have a `theme.json`, or the colors are not defined,
+	// we need to set the background color & close button color to some default values
+	// because we can't get them from the Global Styles.
+	$global_styles_color  = wp_get_global_styles( array( 'color' ) );
+	$has_background_color = ! empty( $global_styles_color['background'] );
+	$has_text_color       = ! empty( $global_styles_color['text'] );
+	$background_color     = esc_attr( ( wp_theme_has_theme_json() && $has_background_color ) ? $global_styles_color['background'] : '#fff' );
+	$close_button_color   = esc_attr( ( wp_theme_has_theme_json() && $has_text_color ) ? $global_styles_color['text'] : '#000' );
 
 	$close_button_icon  = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="15" height="15" aria-hidden="true" focusable="false"><path d="M13 11.8l6.1-6.3-1-1-6.1 6.2-6.1-6.2-1 1 6.1 6.3-6.5 6.7 1 1 6.5-6.6 6.5 6.6 1-1z"></path></svg>';
 	$dialog_label       = $alt_attribute ? esc_attr( $alt_attribute ) : esc_attr__( 'Image' );

--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -255,6 +255,17 @@ function block_core_image_render_lightbox( $block_content, $block ) {
 	// If the current theme does NOT have a `theme.json`, or the colors are not defined,
 	// we need to set the background color & close button color to some default values
 	// because we can't get them from the Global Styles.
+	$background_color   = '#fff';
+	$close_button_color = '#000';
+	if ( wp_theme_has_theme_json() ) {
+		$global_styles_color = wp_get_global_styles( array( 'color' ) );
+		if ( ! empty( $global_styles_color['background'] ) ) {
+			$background_color = esc_attr( $global_styles_color['background'] );
+		}
+		if ( ! empty( $global_styles_color['text'] ) ) {
+			$close_button_color = esc_attr( $global_styles_color['text'] );
+		}
+	}
 	$global_styles_color  = wp_get_global_styles( array( 'color' ) );
 	$has_background_color = ! empty( $global_styles_color['background'] );
 	$has_text_color       = ! empty( $global_styles_color['text'] );

--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -266,11 +266,6 @@ function block_core_image_render_lightbox( $block_content, $block ) {
 			$close_button_color = esc_attr( $global_styles_color['text'] );
 		}
 	}
-	$global_styles_color  = wp_get_global_styles( array( 'color' ) );
-	$has_background_color = ! empty( $global_styles_color['background'] );
-	$has_text_color       = ! empty( $global_styles_color['text'] );
-	$background_color     = esc_attr( ( wp_theme_has_theme_json() && $has_background_color ) ? $global_styles_color['background'] : '#fff' );
-	$close_button_color   = esc_attr( ( wp_theme_has_theme_json() && $has_text_color ) ? $global_styles_color['text'] : '#000' );
 
 	$close_button_icon  = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="15" height="15" aria-hidden="true" focusable="false"><path d="M13 11.8l6.1-6.3-1-1-6.1 6.2-6.1-6.2-1 1 6.1 6.3-6.5 6.7 1 1 6.5-6.6 6.5 6.6 1-1z"></path></svg>';
 	$dialog_label       = $alt_attribute ? esc_attr( $alt_attribute ) : esc_attr__( 'Image' );

--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -287,7 +287,7 @@ function block_core_image_render_lightbox( $block_content, $block ) {
             data-wp-on--mousewheel="actions.core.image.hideLightbox"
             data-wp-on--click="actions.core.image.hideLightbox"
             >
-                <button type="button" aria-label="$close_button_label" style="color: $close_button_color" class="close-button" data-wp-on--click="actions.core.image.hideLightbox">
+                <button type="button" aria-label="$close_button_label" style="fill: $close_button_color" class="close-button" data-wp-on--click="actions.core.image.hideLightbox">
                     $close_button_icon
                 </button>
                 <div class="lightbox-image-container">$initial_image_content</div>

--- a/packages/block-library/src/image/style.scss
+++ b/packages/block-library/src/image/style.scss
@@ -169,6 +169,12 @@
 			outline: 5px auto -webkit-focus-ring-color;
 			outline-offset: 5px;
 		}
+
+		&:hover,
+		&:focus {
+			background: none;
+			border: none;
+		}
 	}
 }
 
@@ -191,6 +197,12 @@
 		padding: 0;
 		cursor: pointer;
 		z-index: 5000000;
+
+		&:hover,
+		&:focus {
+			background: none;
+			border: none;
+		}
 	}
 
 	.lightbox-image-container {

--- a/packages/block-library/src/image/style.scss
+++ b/packages/block-library/src/image/style.scss
@@ -171,7 +171,8 @@
 		}
 
 		&:hover,
-		&:focus {
+		&:focus,
+		&:not(:hover):not(:active):not(.has-background) {
 			background: none;
 			border: none;
 		}
@@ -199,7 +200,8 @@
 		z-index: 5000000;
 
 		&:hover,
-		&:focus {
+		&:focus,
+		&:not(:hover):not(:active):not(.has-background) {
 			background: none;
 			border: none;
 		}


### PR DESCRIPTION
Co-authored with @SantosGuillamot 

## What?
Fixes #54682. 

## Why?
1. In Classic Themes, the [`wp_get_global_styles()`](https://developer.wordpress.org/reference/functions/wp_get_global_styles/) call returns the whole array of all styles, instead of an individual string value. An array cannot be interpolated into HTML (on this line):

   https://github.com/WordPress/gutenberg/blob/d3986f0766e37f6cb985806f33d8e68d0e658642/packages/block-library/src/image/index.php#L286

   so it throws a warning.

2. The CSS of a theme can include styles for `button:hover` and `button:focus`. Since the Lightbox contains a `<button>` element, we want to reset those styles to avoid the ugly unwanted flashes of content. 

## How?
- Adding a `wp_is_block_theme()` check before getting the value from `wp_get_global_styles()`.
- Resetting the Image block's CSS on `button:hover` & `button:focus`.


## Screenshots or screencast

### Before

https://github.com/WordPress/gutenberg/assets/5417266/dbd723a6-1e22-46fa-9b26-451cd9351ab5


### After 

https://github.com/WordPress/gutenberg/assets/5417266/6731f0e1-2b01-4a49-8473-6932cc46e4d8


