### PR TITLE
Simplify BlockPatternsSyncFilter with clearer labels and additional context

### DIFF
--- a/packages/block-editor/src/components/inserter/block-patterns-filter.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-filter.js
@@ -99,7 +99,7 @@ export function BlockPatternsSyncFilter( {
 			},
 			{
 				value: PATTERN_TYPES.theme,
-				label: __( 'Theme' ),
+				label: __( 'Theme & Plugins' ),
 				disabled: shouldDisableNonUserSources,
 			},
 			{

--- a/packages/block-editor/src/components/inserter/block-patterns-filter.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-filter.js
@@ -7,10 +7,11 @@ import {
 	DropdownMenu,
 	MenuGroup,
 	MenuItemsChoice,
+	ExternalLink,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { Icon } from '@wordpress/icons';
-import { useMemo } from '@wordpress/element';
+import { useMemo, createInterpolateElement } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -73,13 +74,11 @@ export function BlockPatternsSyncFilter( {
 			{
 				value: SYNC_TYPES.full,
 				label: __( 'Synced' ),
-				info: __( 'Updated everywhere' ),
 				disabled: shouldDisableSyncFilter,
 			},
 			{
 				value: SYNC_TYPES.unsynced,
-				label: __( 'Standard' ),
-				info: __( 'Edit freely' ),
+				label: __( 'Not synced' ),
 				disabled: shouldDisableSyncFilter,
 			},
 		],
@@ -95,20 +94,17 @@ export function BlockPatternsSyncFilter( {
 			},
 			{
 				value: PATTERN_TYPES.directory,
-				label: __( 'Directory' ),
-				info: __( 'Pattern directory & core' ),
+				label: __( 'Pattern Directory' ),
 				disabled: shouldDisableNonUserSources,
 			},
 			{
 				value: PATTERN_TYPES.theme,
 				label: __( 'Theme' ),
-				info: __( 'Bundled with the theme' ),
 				disabled: shouldDisableNonUserSources,
 			},
 			{
 				value: PATTERN_TYPES.user,
 				label: __( 'User' ),
-				info: __( 'Custom created' ),
 			},
 		],
 		[ shouldDisableNonUserSources ]
@@ -149,7 +145,7 @@ export function BlockPatternsSyncFilter( {
 			>
 				{ () => (
 					<>
-						<MenuGroup label={ __( 'Author' ) }>
+						<MenuGroup label={ __( 'Source' ) }>
 							<MenuItemsChoice
 								choices={ patternSourceMenuOptions }
 								onSelect={ ( value ) => {
@@ -175,6 +171,22 @@ export function BlockPatternsSyncFilter( {
 								value={ patternSyncFilter }
 							/>
 						</MenuGroup>
+						<div className="block-editor-tool-selector__help">
+							{ createInterpolateElement(
+								__(
+									'Patterns are available from the <Link>WordPress.org Pattern Directory</Link>, bundled in the active theme, or created by users on this site. Only patterns created on this site can be synced.'
+								),
+								{
+									Link: (
+										<ExternalLink
+											href={ __(
+												'https://wordpress.org/patterns/'
+											) }
+										/>
+									),
+								}
+							) }
+						</div>
 					</>
 				) }
 			</DropdownMenu>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
A follow-up to https://github.com/WordPress/gutenberg/pull/54681 that:

- Reduces individual labeling and help text with more context below (similar to the "Tools" control in the block editor header). 
- Renames "Standard" to "Not synced", which adds more context to what these patterns are - and reduces nomenclature. 

Props @jasmussen. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a post or page.
2. Open the pattern inserter.
3. Select the "Filter patterns" control.
4. See changes.

## Screenshots or screencast <!-- if applicable -->

### Before

<img width="923" alt="CleanShot 2023-09-26 at 14 21 22" src="https://github.com/WordPress/gutenberg/assets/1813435/02ae80b8-7d6a-40c2-9b17-a58cce5a0945">

### After

<img width="966" alt="CleanShot 2023-09-26 at 14 20 44" src="https://github.com/WordPress/gutenberg/assets/1813435/fd60e170-bed8-42df-9efc-46c4ff6ff1fd">

