### PR TITLE
Use "Not synced" in place of "Standard" nomenclature for patterns

### DIFF
--- a/packages/edit-site/src/components/page-patterns/patterns-list.js
+++ b/packages/edit-site/src/components/page-patterns/patterns-list.js
@@ -35,7 +35,7 @@ const { useLocation, useHistory } = unlock( routerPrivateApis );
 const SYNC_FILTERS = {
 	all: __( 'All' ),
 	[ PATTERN_SYNC_TYPES.full ]: __( 'Synced' ),
-	[ PATTERN_SYNC_TYPES.unsynced ]: __( 'Standard' ),
+	[ PATTERN_SYNC_TYPES.unsynced ]: __( 'Not synced' ),
 };
 
 const SYNC_DESCRIPTIONS = {

--- a/test/e2e/specs/editor/blocks/query.spec.js
+++ b/test/e2e/specs/editor/blocks/query.spec.js
@@ -39,7 +39,7 @@ test.describe( 'Query block', () => {
 
 			await page
 				.getByRole( 'dialog', { name: 'Choose a pattern' } )
-				.getByRole( 'option', { name: 'Not synced' } )
+				.getByRole( 'option', { name: 'Standard' } )
 				.click();
 
 			await expect.poll( editor.getBlocks ).toMatchObject( [

--- a/test/e2e/specs/editor/blocks/query.spec.js
+++ b/test/e2e/specs/editor/blocks/query.spec.js
@@ -39,7 +39,7 @@ test.describe( 'Query block', () => {
 
 			await page
 				.getByRole( 'dialog', { name: 'Choose a pattern' } )
-				.getByRole( 'option', { name: 'Standard' } )
+				.getByRole( 'option', { name: 'Not synced' } )
 				.click();
 
 			await expect.poll( editor.getBlocks ).toMatchObject( [


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Uses "Not synced" in place of "Standard" nomenclature for patterns that are not synced. This reduces potential confusion about the differences between patterns that are synced, and patterns that are not (currently called "Standard" patterns). I already made the change in `BlockPatternsSyncFilter` in https://github.com/WordPress/gutenberg/pull/54838.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
 1. Open the site editor in the patterns view.
2. See the ToggleGroup render Synced/Not synced.

## Screenshots or screencast <!-- if applicable -->
| Before  | After |
| ------------- | ------------- |
|<img width="314" alt="CleanShot 2023-09-26 at 14 29 10" src="https://github.com/WordPress/gutenberg/assets/1813435/b23ed6d7-79a9-44d0-9ca1-3e9096a02216">|<img width="312" alt="CleanShot 2023-09-26 at 14 29 31" src="https://github.com/WordPress/gutenberg/assets/1813435/8e007f13-7414-4ca5-aad4-b1a32f22750c">|
