### PR TITLE
Fix ToolSelector popover variant

### DIFF
--- a/packages/block-editor/src/components/tool-selector/index.js
+++ b/packages/block-editor/src/components/tool-selector/index.js
@@ -51,7 +51,7 @@ function ToolSelector( props, ref ) {
 					label={ __( 'Tools' ) }
 				/>
 			) }
-			popoverProps={ { placement: 'bottom-start' } }
+			popoverProps={ { placement: 'bottom-start', variant: undefined } }
 			renderContent={ () => (
 				<>
 					<NavigableMenu role="menu" aria-label={ __( 'Tools' ) }>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Use the proper popover variant for the ToolSelector in the editor header.

## Why?
It's inconsistent with other popovers not connected to the block toolbar.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a post or page.
2. Select the "Tools" control in the editor header.
3. See the lighter border with a shadow, instead of the hard dark line.


## Screenshots or screencast <!-- if applicable -->

| Before  | After |
| ------------- | ------------- |
|<img width="436" alt="CleanShot 2023-09-26 at 14 35 49" src="https://github.com/WordPress/gutenberg/assets/1813435/cd91c959-c04c-4c9a-9016-6245c4d102b0">|<img width="432" alt="CleanShot 2023-09-26 at 14 36 27" src="https://github.com/WordPress/gutenberg/assets/1813435/68f5a343-ea97-4a40-82dc-e5e0402eb487">|



