### PR TITLE
Make the reset styles command consistent

### DIFF
--- a/packages/edit-site/src/hooks/commands/use-common-commands.js
+++ b/packages/edit-site/src/hooks/commands/use-common-commands.js
@@ -3,8 +3,16 @@
  */
 import { useMemo } from '@wordpress/element';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { __ } from '@wordpress/i18n';
-import { trash, backup, help, styles, external, brush } from '@wordpress/icons';
+import { __, isRTL } from '@wordpress/i18n';
+import {
+	rotateLeft,
+	rotateRight,
+	backup,
+	help,
+	styles,
+	external,
+	brush,
+} from '@wordpress/icons';
 import { useCommandLoader, useCommand } from '@wordpress/commands';
 import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
 import { privateApis as routerPrivateApis } from '@wordpress/router';
@@ -148,8 +156,8 @@ function useGlobalStylesResetCommands() {
 		return [
 			{
 				name: 'core/edit-site/reset-global-styles',
-				label: __( 'Reset styles to defaults' ),
-				icon: trash,
+				label: __( 'Reset styles' ),
+				icon: isRTL() ? rotateRight : rotateLeft,
 				callback: ( { close } ) => {
 					close();
 					onReset();


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Cleaning up the "Reset styles to defaults" command to be consistent with resetting templates/template parts. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open the site editor.
2. Make changes to global styles.
3. Open the command palette.
4. Search for "reset".
5. See changes.

## Screenshots or screencast <!-- if applicable -->

| Before  | After |
| ------------- | ------------- |
|<img width="443" alt="before" src="https://github.com/WordPress/gutenberg/assets/1813435/f540d0fa-261d-425f-b2d1-2e75a3fb37b8">|<img width="436" alt="CleanShot 2023-09-26 at 14 59 41" src="https://github.com/WordPress/gutenberg/assets/1813435/347c6b3b-a729-448a-9b55-b07b120e26b2">|


Related (the reset command for templates/parts): 
<img width="417" alt="CleanShot 2023-09-26 at 15 01 42" src="https://github.com/WordPress/gutenberg/assets/1813435/540acbd9-a194-4b73-bc70-8536ea87fc03">


