### PR TITLE
Move mime-type collection generation to a function that can be tested…

### DIFF
--- a/lib/experimental/fonts/font-library/class-wp-font-family-utils.php
+++ b/lib/experimental/fonts/font-library/class-wp-font-family-utils.php
@@ -85,8 +85,8 @@ class WP_Font_Family_Utils {
 	 * @return bool True if the file has a font MIME type, false otherwise.
 	 */
 	public static function has_font_mime_type( $filepath ) {
-		$allowed_mime_types = WP_Font_Library::get_expected_font_mime_types_per_PHP_version();
-		$filetype = wp_check_filetype( $filepath, $allowed_mime_types );
+		$allowed_mime_types = WP_Font_Library::get_expected_font_mime_types_per_php_version();
+		$filetype           = wp_check_filetype( $filepath, $allowed_mime_types );
 
 		return in_array( $filetype['type'], $allowed_mime_types, true );
 	}

--- a/lib/experimental/fonts/font-library/class-wp-font-family-utils.php
+++ b/lib/experimental/fonts/font-library/class-wp-font-family-utils.php
@@ -85,8 +85,9 @@ class WP_Font_Family_Utils {
 	 * @return bool True if the file has a font MIME type, false otherwise.
 	 */
 	public static function has_font_mime_type( $filepath ) {
-		$filetype = wp_check_filetype( $filepath, WP_Font_Library::ALLOWED_FONT_MIME_TYPES );
+		$allowed_mime_types = WP_Font_Library::get_expected_font_mime_types_per_PHP_version();
+		$filetype = wp_check_filetype( $filepath, $allowed_mime_types );
 
-		return in_array( $filetype['type'], WP_Font_Library::ALLOWED_FONT_MIME_TYPES, true );
+		return in_array( $filetype['type'], $allowed_mime_types, true );
 	}
 }

--- a/lib/experimental/fonts/font-library/class-wp-font-family.php
+++ b/lib/experimental/fonts/font-library/class-wp-font-family.php
@@ -182,7 +182,7 @@ class WP_Font_Family {
 			// Seems mime type for files that are not images cannot be tested.
 			// See wp_check_filetype_and_ext().
 			'test_type'                => true,
-			'mimes'                    => WP_Font_Library::ALLOWED_FONT_MIME_TYPES,
+			'mimes'                    => WP_Font_Library::get_expected_font_mime_types_per_PHP_version(),
 			'unique_filename_callback' => static function () use ( $filename ) {
 				// Keep the original filename.
 				return $filename;

--- a/lib/experimental/fonts/font-library/class-wp-font-family.php
+++ b/lib/experimental/fonts/font-library/class-wp-font-family.php
@@ -182,7 +182,7 @@ class WP_Font_Family {
 			// Seems mime type for files that are not images cannot be tested.
 			// See wp_check_filetype_and_ext().
 			'test_type'                => true,
-			'mimes'                    => WP_Font_Library::get_expected_font_mime_types_per_PHP_version(),
+			'mimes'                    => WP_Font_Library::get_expected_font_mime_types_per_php_version(),
 			'unique_filename_callback' => static function () use ( $filename ) {
 				// Keep the original filename.
 				return $filename;

--- a/lib/experimental/fonts/font-library/class-wp-font-library.php
+++ b/lib/experimental/fonts/font-library/class-wp-font-library.php
@@ -20,14 +20,28 @@ if ( class_exists( 'WP_Font_Library' ) ) {
  */
 class WP_Font_Library {
 
-	const PHP_7_TTF_MIME_TYPE = PHP_VERSION_ID >= 70300 ? 'application/font-sfnt' : 'application/x-font-ttf';
+	/**
+	 * Provide the expected mime-type value for font files per-PHP release. Due to differences in the values returned these values differ between PHP versions.
+	 *
+	 * This is necessary until a collection of valid mime-types per-file extension can be provided to 'upload_mimes' filter.
+	 *
+	 * @since 6.4.0
+	 *
+	 * @param array $php_version_id The version of PHP to provide mime types for. The default is the current PHP version.
+	 *
+	 * @return Array A collection of mime types keyed by file extension.
+	 */
+	public static function get_expected_font_mime_types_per_PHP_version( $php_version_id = PHP_VERSION_ID ) {
 
-	const ALLOWED_FONT_MIME_TYPES = array(
-		'otf'   => 'font/otf',
-		'ttf'   => PHP_VERSION_ID >= 70400 ? 'font/sfnt' : self::PHP_7_TTF_MIME_TYPE,
-		'woff'  => PHP_VERSION_ID >= 80100 ? 'font/woff' : 'application/font-woff',
-		'woff2' => PHP_VERSION_ID >= 80100 ? 'font/woff2' : 'application/font-woff2',
-	);
+		$php_7_ttf_mime_type = $php_version_id >= 70300 ? 'application/font-sfnt' : 'application/x-font-ttf';
+
+		return array(
+			'otf'   => 'font/otf',
+			'ttf'   => $php_version_id >= 70400 ? 'font/sfnt' : $php_7_ttf_mime_type,
+			'woff'  => $php_version_id >= 80100 ? 'font/woff' : 'application/font-woff',
+			'woff2' => $php_version_id >= 80100 ? 'font/woff2' : 'application/font-woff2',
+		);
+	}
 
 	/**
 	 * Font collections.
@@ -130,6 +144,6 @@ class WP_Font_Library {
 	 * @return array Modified upload directory.
 	 */
 	public static function set_allowed_mime_types( $mime_types ) {
-		return array_merge( $mime_types, self::ALLOWED_FONT_MIME_TYPES );
+		return array_merge( $mime_types, self::get_expected_font_mime_types_per_PHP_version() );
 	}
 }

--- a/lib/experimental/fonts/font-library/class-wp-font-library.php
+++ b/lib/experimental/fonts/font-library/class-wp-font-library.php
@@ -31,7 +31,7 @@ class WP_Font_Library {
 	 *
 	 * @return Array A collection of mime types keyed by file extension.
 	 */
-	public static function get_expected_font_mime_types_per_PHP_version( $php_version_id = PHP_VERSION_ID ) {
+	public static function get_expected_font_mime_types_per_php_version( $php_version_id = PHP_VERSION_ID ) {
 
 		$php_7_ttf_mime_type = $php_version_id >= 70300 ? 'application/font-sfnt' : 'application/x-font-ttf';
 
@@ -144,6 +144,6 @@ class WP_Font_Library {
 	 * @return array Modified upload directory.
 	 */
 	public static function set_allowed_mime_types( $mime_types ) {
-		return array_merge( $mime_types, self::get_expected_font_mime_types_per_PHP_version() );
+		return array_merge( $mime_types, self::get_expected_font_mime_types_per_php_version() );
 	}
 }

--- a/phpunit/tests/fonts/font-library/wpFontLibrary/getMimeTypes.php
+++ b/phpunit/tests/fonts/font-library/wpFontLibrary/getMimeTypes.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * Test WP_Font_Family_Utils::get_expected_font_mime_types_per_php_version().
+ *
+ * @package WordPress
+ * @subpackage Font Library
+ *
+ * @group fonts
+ * @group font-library
+ *
+ * @covers WP_Font_Family_Utils::get_expected_font_mime_types_per_php_version
+ */
+class Tests_Fonts_WpFontsFamilyUtils_GetMimeTypes extends WP_UnitTestCase {
+
+	/**
+	 *
+	 * @dataProvider data_should_supply_correct_mime_type_for_php_version
+	 *
+	 * @param array $php_version Font file path.
+
+	 */
+	public function test_should_supply_correct_mime_type_for_php_version( $php_info ) {
+
+		$mime_types = WP_Font_Library::get_expected_font_mime_types_per_php_version( $php_info[ 'php_version_id' ] );
+
+		$this->assertTrue( $mime_types['otf'] === $php_info['otf'] );
+		$this->assertTrue( $mime_types['ttf'] === $php_info['ttf'] );
+		$this->assertTrue( $mime_types['woff'] === $php_info['woff'] );
+		$this->assertTrue( $mime_types['woff2'] === $php_info['woff2'] );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array[]
+	 */
+ 	public function data_should_supply_correct_mime_type_for_php_version() {
+		return array(array(
+			'version 7.2' => array(
+				'php_version_id' => 70200,
+				'otf' => 'font/otf',
+				'ttf' => 'application/x-font-ttf',
+				'woff' => 'application/font-woff',
+				'woff2' => 'application/font-woff2'
+			),
+			'version 7.3' => array(
+				'php_version_id' => 70300,
+				'otf' => 'font/otf',
+				'ttf' => 'application/font-sfnt',
+				'woff' => 'application/font-woff',
+				'woff2' => 'application/font-woff2'
+			),
+			'version 7.4' => array(
+				'php_version_id' => 70400,
+				'otf' => 'font/otf',
+				'ttf' => 'font/sfnt',
+				'woff' => 'application/font-woff',
+				'woff2' => 'application/font-woff2'
+			),
+			'version 8.0' => array(
+				'php_version_id' => 80000,
+				'otf' => 'font/otf',
+				'ttf' => 'font/sfnt',
+				'woff' => 'application/font-woff',
+				'woff2' => 'application/font-woff2'
+			),
+			'version 8.1' => array(
+				'php_version_id' => 80100,
+				'otf' => 'font/otf',
+				'ttf' => 'font/sfnt',
+				'woff' => 'font/woff',
+				'woff2' => 'font/woff2'
+			),
+			'version 8.2' => array(
+				'php_version_id' => 80200,
+				'otf' => 'font/otf',
+				'ttf' => 'font/sfnt',
+				'woff' => 'font/woff',
+				'woff2' => 'font/woff2'
+			),
+		));
+
+	}
+
+}

--- a/phpunit/tests/fonts/font-library/wpFontLibrary/getMimeTypes.php
+++ b/phpunit/tests/fonts/font-library/wpFontLibrary/getMimeTypes.php
@@ -16,12 +16,11 @@ class Tests_Fonts_WpFontsFamilyUtils_GetMimeTypes extends WP_UnitTestCase {
 	 *
 	 * @dataProvider data_should_supply_correct_mime_type_for_php_version
 	 *
-	 * @param array $php_version Font file path.
-
+	 * @param array $php_info Info about php version and expected mime type values.
 	 */
 	public function test_should_supply_correct_mime_type_for_php_version( $php_info ) {
 
-		$mime_types = WP_Font_Library::get_expected_font_mime_types_per_php_version( $php_info[ 'php_version_id' ] );
+		$mime_types = WP_Font_Library::get_expected_font_mime_types_per_php_version( $php_info['php_version_id'] );
 
 		$this->assertTrue( $mime_types['otf'] === $php_info['otf'] );
 		$this->assertTrue( $mime_types['ttf'] === $php_info['ttf'] );
@@ -34,52 +33,52 @@ class Tests_Fonts_WpFontsFamilyUtils_GetMimeTypes extends WP_UnitTestCase {
 	 *
 	 * @return array[]
 	 */
- 	public function data_should_supply_correct_mime_type_for_php_version() {
-		return array(array(
-			'version 7.2' => array(
-				'php_version_id' => 70200,
-				'otf' => 'font/otf',
-				'ttf' => 'application/x-font-ttf',
-				'woff' => 'application/font-woff',
-				'woff2' => 'application/font-woff2'
+	public function data_should_supply_correct_mime_type_for_php_version() {
+		return array(
+			array(
+				'version 7.2' => array(
+					'php_version_id' => 70200,
+					'otf'            => 'font/otf',
+					'ttf'            => 'application/x-font-ttf',
+					'woff'           => 'application/font-woff',
+					'woff2'          => 'application/font-woff2',
+				),
+				'version 7.3' => array(
+					'php_version_id' => 70300,
+					'otf'            => 'font/otf',
+					'ttf'            => 'application/font-sfnt',
+					'woff'           => 'application/font-woff',
+					'woff2'          => 'application/font-woff2',
+				),
+				'version 7.4' => array(
+					'php_version_id' => 70400,
+					'otf'            => 'font/otf',
+					'ttf'            => 'font/sfnt',
+					'woff'           => 'application/font-woff',
+					'woff2'          => 'application/font-woff2',
+				),
+				'version 8.0' => array(
+					'php_version_id' => 80000,
+					'otf'            => 'font/otf',
+					'ttf'            => 'font/sfnt',
+					'woff'           => 'application/font-woff',
+					'woff2'          => 'application/font-woff2',
+				),
+				'version 8.1' => array(
+					'php_version_id' => 80100,
+					'otf'            => 'font/otf',
+					'ttf'            => 'font/sfnt',
+					'woff'           => 'font/woff',
+					'woff2'          => 'font/woff2',
+				),
+				'version 8.2' => array(
+					'php_version_id' => 80200,
+					'otf'            => 'font/otf',
+					'ttf'            => 'font/sfnt',
+					'woff'           => 'font/woff',
+					'woff2'          => 'font/woff2',
+				),
 			),
-			'version 7.3' => array(
-				'php_version_id' => 70300,
-				'otf' => 'font/otf',
-				'ttf' => 'application/font-sfnt',
-				'woff' => 'application/font-woff',
-				'woff2' => 'application/font-woff2'
-			),
-			'version 7.4' => array(
-				'php_version_id' => 70400,
-				'otf' => 'font/otf',
-				'ttf' => 'font/sfnt',
-				'woff' => 'application/font-woff',
-				'woff2' => 'application/font-woff2'
-			),
-			'version 8.0' => array(
-				'php_version_id' => 80000,
-				'otf' => 'font/otf',
-				'ttf' => 'font/sfnt',
-				'woff' => 'application/font-woff',
-				'woff2' => 'application/font-woff2'
-			),
-			'version 8.1' => array(
-				'php_version_id' => 80100,
-				'otf' => 'font/otf',
-				'ttf' => 'font/sfnt',
-				'woff' => 'font/woff',
-				'woff2' => 'font/woff2'
-			),
-			'version 8.2' => array(
-				'php_version_id' => 80200,
-				'otf' => 'font/otf',
-				'ttf' => 'font/sfnt',
-				'woff' => 'font/woff',
-				'woff2' => 'font/woff2'
-			),
-		));
-
+		);
 	}
-
 }

--- a/phpunit/tests/fonts/font-library/wpFontLibrary/getMimeTypes.php
+++ b/phpunit/tests/fonts/font-library/wpFontLibrary/getMimeTypes.php
@@ -18,14 +18,9 @@ class Tests_Fonts_WpFontsFamilyUtils_GetMimeTypes extends WP_UnitTestCase {
 	 *
 	 * @param array $php_info Info about php version and expected mime type values.
 	 */
-	public function test_should_supply_correct_mime_type_for_php_version( $php_info ) {
-
-		$mime_types = WP_Font_Library::get_expected_font_mime_types_per_php_version( $php_info['php_version_id'] );
-
-		$this->assertTrue( $mime_types['otf'] === $php_info['otf'] );
-		$this->assertTrue( $mime_types['ttf'] === $php_info['ttf'] );
-		$this->assertTrue( $mime_types['woff'] === $php_info['woff'] );
-		$this->assertTrue( $mime_types['woff2'] === $php_info['woff2'] );
+	public function test_should_supply_correct_mime_type_for_php_version( $php_version_id, $expected ) {
+		$mimes = WP_Font_Library::get_expected_font_mime_types_per_php_version( $php_version_id );
+		$this->assertEquals( $mimes, $expected );
 	}
 
 	/**
@@ -35,48 +30,58 @@ class Tests_Fonts_WpFontsFamilyUtils_GetMimeTypes extends WP_UnitTestCase {
 	 */
 	public function data_should_supply_correct_mime_type_for_php_version() {
 		return array(
-			array(
-				'version 7.2' => array(
-					'php_version_id' => 70200,
-					'otf'            => 'font/otf',
-					'ttf'            => 'application/x-font-ttf',
-					'woff'           => 'application/font-woff',
-					'woff2'          => 'application/font-woff2',
+			'version 7.2' => array(
+				'php_version_id' => 70200,
+				'expected'       => array(
+					'otf'   => 'font/otf',
+					'ttf'   => 'application/x-font-ttf',
+					'woff'  => 'application/font-woff',
+					'woff2' => 'application/font-woff2',
 				),
-				'version 7.3' => array(
-					'php_version_id' => 70300,
-					'otf'            => 'font/otf',
-					'ttf'            => 'application/font-sfnt',
-					'woff'           => 'application/font-woff',
-					'woff2'          => 'application/font-woff2',
+			),
+			'version 7.3' => array(
+				'php_version_id' => 70300,
+				'expected'       => array(
+					'otf'   => 'font/otf',
+					'ttf'   => 'application/font-sfnt',
+					'woff'  => 'application/font-woff',
+					'woff2' => 'application/font-woff2',
 				),
-				'version 7.4' => array(
-					'php_version_id' => 70400,
-					'otf'            => 'font/otf',
-					'ttf'            => 'font/sfnt',
-					'woff'           => 'application/font-woff',
-					'woff2'          => 'application/font-woff2',
+			),
+			'version 7.4' => array(
+				'php_version_id' => 70400,
+				'expected'       => array(
+					'otf'   => 'font/otf',
+					'ttf'   => 'font/sfnt',
+					'woff'  => 'application/font-woff',
+					'woff2' => 'application/font-woff2',
 				),
-				'version 8.0' => array(
-					'php_version_id' => 80000,
-					'otf'            => 'font/otf',
-					'ttf'            => 'font/sfnt',
-					'woff'           => 'application/font-woff',
-					'woff2'          => 'application/font-woff2',
+			),
+			'version 8.0' => array(
+				'php_version_id' => 80000,
+				'expected'       => array(
+					'otf'   => 'font/otf',
+					'ttf'   => 'font/sfnt',
+					'woff'  => 'application/font-woff',
+					'woff2' => 'application/font-woff2',
 				),
-				'version 8.1' => array(
-					'php_version_id' => 80100,
-					'otf'            => 'font/otf',
-					'ttf'            => 'font/sfnt',
-					'woff'           => 'font/woff',
-					'woff2'          => 'font/woff2',
+			),
+			'version 8.1' => array(
+				'php_version_id' => 80100,
+				'expected'       => array(
+					'otf'   => 'font/otf',
+					'ttf'   => 'font/sfnt',
+					'woff'  => 'font/woff',
+					'woff2' => 'font/woff2',
 				),
-				'version 8.2' => array(
-					'php_version_id' => 80200,
-					'otf'            => 'font/otf',
-					'ttf'            => 'font/sfnt',
-					'woff'           => 'font/woff',
-					'woff2'          => 'font/woff2',
+			),
+			'version 8.2' => array(
+				'php_version_id' => 80200,
+				'expected'       => array(
+					'otf'   => 'font/otf',
+					'ttf'   => 'font/sfnt',
+					'woff'  => 'font/woff',
+					'woff2' => 'font/woff2',
 				),
 			),
 		);

--- a/phpunit/tests/fonts/font-library/wpFontLibrary/getMimeTypes.php
+++ b/phpunit/tests/fonts/font-library/wpFontLibrary/getMimeTypes.php
@@ -16,7 +16,8 @@ class Tests_Fonts_WpFontsFamilyUtils_GetMimeTypes extends WP_UnitTestCase {
 	 *
 	 * @dataProvider data_should_supply_correct_mime_type_for_php_version
 	 *
-	 * @param array $php_info Info about php version and expected mime type values.
+	 * @param array $php_version_id PHP_VERSION_ID value.
+	 * @param array $expected Expected mime types.
 	 */
 	public function test_should_supply_correct_mime_type_for_php_version( $php_version_id, $expected ) {
 		$mimes = WP_Font_Library::get_expected_font_mime_types_per_php_version( $php_version_id );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Refactors the logic that determines which mime-types are expected based on the PHP version into a function so that it may be unit tested and given better comments.

## How?
Puts the existing logic into a static function that is used in place of the previous constant and added unit test coverage for that function.

