### PR TITLE
Search block: allow space for input field only when form expanded

### DIFF
--- a/packages/block-library/src/search/style.scss
+++ b/packages/block-library/src/search/style.scss
@@ -55,11 +55,12 @@ $button-spacing-y: math.div($grid-unit-15, 2); // 6px
 		margin-left: 0;
 		// Prevent unintended text wrapping.
 		flex-shrink: 0;
-		// Ensure minimum input field width in small viewports.
+		max-width: 100%;
+	}
+
+	// Ensure minimum input field width in small viewports.
+	.wp-block-search__button[aria-expanded="true"] {
 		max-width: calc(100% - 100px);
-		&.has-icon {
-			max-width: 100%;
-		}
 	}
 }
 


### PR DESCRIPTION
Resolves https://github.com/WordPress/gutenberg/issues/54842

## What? 🙈 
A follow up to https://github.com/WordPress/gutenberg/pull/54773

1. When a search box has an expandable input field and is in "button only" mode, provide a max-width for the button and take away 100px when the form is expanded. 
2. When the search form is collapsed revert to max-width of 100%.

## Why? 🙉 
1.  To avoid text wrapping and overflow in narrow viewport widths. See https://github.com/WordPress/gutenberg/pull/53373#discussion_r1285736216 for context
2. To ensure the button fills its container. (First fix attempt in https://github.com/WordPress/gutenberg/pull/54773) The input is not there so we don't need the 100px.

## How? 🙊 
See "What"

## Testing Instructions
1. Create or edit a navigation block in a theme header, and add a search block.
2. Add a few search blocks in a post, some with lots of search button text and with the input field hidden/displayed. 
3. For icon-only buttons in the navigation block, the button should stretch the full width. See test steps in https://github.com/WordPress/gutenberg/pull/54773
4. In narrow viewports the search button with text should not be cut off and single words shouldn't wrap (unless there are spaces between multiple words) See test steps in https://github.com/WordPress/gutenberg/pull/53373

### Some example block code

```html
<!-- wp:search {"label":"Search","showLabel":false,"buttonText":"天気 天気 天気 天気 天気 天気 天気 天気 天気 天気 天気 天気 天気","buttonPosition":"button-only"} /-->

<!-- wp:search {"label":"Search","showLabel":false,"buttonText":"天気","buttonPosition":"button-inside"} /-->
```






## Screenshots or screencast <!-- if applicable -->




### With icon as button

https://github.com/WordPress/gutenberg/assets/6458278/702c7ce6-afd5-4956-9316-0f443dbc881b

### With button text

https://github.com/WordPress/gutenberg/assets/6458278/3c2e0250-e454-4632-bc87-b1b37493755c

## No text overflow


<img width="358" alt="Screenshot 2023-09-27 at 9 08 29 am" src="https://github.com/WordPress/gutenberg/assets/6458278/debce5e9-0c55-47d5-b2e9-d1b4bc57acbb">

https://github.com/WordPress/gutenberg/assets/6458278/65e74997-44a8-4db3-a9b3-ab3a4f367df6

