### PR TITLE
Background support: Backport fix for undefined array key

### DIFF
--- a/lib/block-supports/background.php
+++ b/lib/block-supports/background.php
@@ -41,7 +41,7 @@ function gutenberg_register_background_support( $block_type ) {
  */
 function gutenberg_render_background_support( $block_content, $block ) {
 	$block_type                   = WP_Block_Type_Registry::get_instance()->get_registered( $block['blockName'] );
-	$block_attributes             = $block['attrs'];
+	$block_attributes             = ( isset( $block['attrs'] ) && is_array( $block['attrs'] ) ) ? $block['attrs'] : array();
 	$has_background_image_support = block_has_support( $block_type, array( 'background', 'backgroundImage' ), false );
 
 	if (


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Backport https://github.com/WordPress/wordpress-develop/pull/5326

Check that `$block['attrs']` is set and is an array before assigning to `$block_attributes` in the Background image block support.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

As raised in https://core.trac.wordpress.org/ticket/59468 it is possible for this array key not to exist, so this check makes for safe accessing of the block attributes.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Check that the `attrs` value is set and is an array before using it.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Smoke testing:

1. Add a couple of Group blocks to a post or page
2. Set one of the Group blocks to have a background image
3. Ensure the background image is displayed correctly on the site frontend