### PR TITLE
Fix the ShortcutProvider usage

### DIFF
--- a/packages/keyboard-shortcuts/src/components/shortcut-provider.js
+++ b/packages/keyboard-shortcuts/src/components/shortcut-provider.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useRef } from '@wordpress/element';
+import { useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -20,12 +20,12 @@ const { Provider } = context;
  * @return {import('@wordpress/element').WPElement} Component.
  */
 export function ShortcutProvider( props ) {
-	const keyboardShortcuts = useRef( new Set() );
+	const [ keyboardShortcuts ] = useState( new Set() );
 
 	function onKeyDown( event ) {
 		if ( props.onKeyDown ) props.onKeyDown( event );
 
-		for ( const keyboardShortcut of keyboardShortcuts.current ) {
+		for ( const keyboardShortcut of keyboardShortcuts ) {
 			keyboardShortcut( event );
 		}
 	}

--- a/packages/keyboard-shortcuts/src/components/shortcut-provider.js
+++ b/packages/keyboard-shortcuts/src/components/shortcut-provider.js
@@ -20,7 +20,7 @@ const { Provider } = context;
  * @return {import('@wordpress/element').WPElement} Component.
  */
 export function ShortcutProvider( props ) {
-	const [ keyboardShortcuts ] = useState( new Set() );
+	const [ keyboardShortcuts ] = useState( () => new Set() );
 
 	function onKeyDown( event ) {
 		if ( props.onKeyDown ) props.onKeyDown( event );


### PR DESCRIPTION
Follow-up to #54080 
Fixes the issue raised here https://github.com/WordPress/gutenberg/pull/54080#issuecomment-1733208834

## What?

We currently have two ways of providing the "context" for `useShortcut` hook. One is the default context and one is the `ShortcutProvider`. After #54080 we dropped the usage of `ShortcutProvider` in the WordPress pages (edit post, edit site...) but it's still possible to use it for third-party pages... When we removed the `.current` we missed the fact that the `ShortcutProvider` still provides the context as a "ref" so its usage in `useShortcut` was triggering JS errors.

In the current PR, I'm updating the `ShortcutProvider` to not use a ref and just pass a stable reference to the shortcuts set.

## Testing Instructions

1- Update the edit-post package and add a `ShortcutProvider` top level 
2- Ensure that there's no JS error