### PR TITLE
Patterns: Fix back navigation after pattern creation

### DIFF
--- a/packages/edit-site/src/components/add-new-pattern/index.js
+++ b/packages/edit-site/src/components/add-new-pattern/index.js
@@ -51,7 +51,7 @@ export default function AddNewPattern() {
 		history.push( {
 			postId: pattern.id,
 			postType: PATTERN_TYPES.user,
-			categoryType: PATTERN_TYPES.user,
+			categoryType: PATTERN_TYPES.theme,
 			categoryId,
 			canvas: 'edit',
 		} );


### PR DESCRIPTION
## What?

Fixes the category type when navigating back from a newly created pattern. After the addition of user-created pattern categories the category type should be `pattern` not `wp_block`. 

## Why?

Without the appropriate category type, the correct category isn't matched and we lose the pattern title, sync filters etc.

## How?

Set the correct `categoryType` in the history set when adding a pattern.

## Testing Instructions

1. Navigate to Appearance > Editor > Patterns
2. Create a new pattern via the `+` menu
3. Navigate back to the patterns page
4. Confirm you are in the `All patterns` category with the title and sync filters showing


## Screenshots or screencast <!-- if applicable -->


| Before | After |
|---|---|
| <video src="https://github.com/WordPress/gutenberg/assets/60436221/02789349-19a7-49c8-88be-ccbd5df57ea2" /> | <video src="https://github.com/WordPress/gutenberg/assets/60436221/03a39efd-f084-4b0e-b02a-0b53a29ca925" /> |





