### PR TITLE
Patterns: Fix category control width in site editor

### DIFF
--- a/packages/edit-site/src/components/sidebar-edit-mode/template-panel/pattern-categories.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/template-panel/pattern-categories.js
@@ -256,7 +256,11 @@ export default function PatternCategories( { post } ) {
 	);
 
 	return (
-		<PanelRow initialOpen={ true } title={ __( 'Categories' ) }>
+		<PanelRow
+			className="edit-site-template-panel__pattern-categories"
+			initialOpen={ true }
+			title={ __( 'Categories' ) }
+		>
 			<FormTokenField
 				__next40pxDefaultSize
 				value={ values }

--- a/packages/edit-site/src/components/sidebar-edit-mode/template-panel/pattern-categories.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/template-panel/pattern-categories.js
@@ -3,7 +3,7 @@
  */
 import { __, _x, sprintf } from '@wordpress/i18n';
 import { useEffect, useMemo, useState } from '@wordpress/element';
-import { FormTokenField, PanelRow } from '@wordpress/components';
+import { FormTokenField, FlexBlock, PanelRow } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 import { useDebounce } from '@wordpress/compose';
@@ -256,26 +256,24 @@ export default function PatternCategories( { post } ) {
 	);
 
 	return (
-		<PanelRow
-			className="edit-site-template-panel__pattern-categories"
-			initialOpen={ true }
-			title={ __( 'Categories' ) }
-		>
-			<FormTokenField
-				__next40pxDefaultSize
-				value={ values }
-				suggestions={ suggestions }
-				onChange={ onChange }
-				onInputChange={ debouncedSearch }
-				maxSuggestions={ MAX_TERMS_SUGGESTIONS }
-				label={ __( 'Pattern categories' ) }
-				messages={ {
-					added: termAddedLabel,
-					removed: termRemovedLabel,
-					remove: removeTermLabel,
-				} }
-				tokenizeOnBlur
-			/>
+		<PanelRow initialOpen={ true } title={ __( 'Categories' ) }>
+			<FlexBlock>
+				<FormTokenField
+					__next40pxDefaultSize
+					value={ values }
+					suggestions={ suggestions }
+					onChange={ onChange }
+					onInputChange={ debouncedSearch }
+					maxSuggestions={ MAX_TERMS_SUGGESTIONS }
+					label={ __( 'Pattern categories' ) }
+					messages={ {
+						added: termAddedLabel,
+						removed: termRemovedLabel,
+						remove: removeTermLabel,
+					} }
+					tokenizeOnBlur
+				/>
+			</FlexBlock>
 		</PanelRow>
 	);
 }

--- a/packages/edit-site/src/components/sidebar-edit-mode/template-panel/style.scss
+++ b/packages/edit-site/src/components/sidebar-edit-mode/template-panel/style.scss
@@ -37,7 +37,3 @@ h3.edit-site-template-card__template-areas-title {
 	font-weight: 500;
 	margin: 0 0 $grid-unit-10;
 }
-
-.edit-site-template-panel__pattern-categories > * {
-	width: 100%;
-}

--- a/packages/edit-site/src/components/sidebar-edit-mode/template-panel/style.scss
+++ b/packages/edit-site/src/components/sidebar-edit-mode/template-panel/style.scss
@@ -37,3 +37,7 @@ h3.edit-site-template-card__template-areas-title {
 	font-weight: 500;
 	margin: 0 0 $grid-unit-10;
 }
+
+.edit-site-template-panel__pattern-categories > div {
+	width: 100%;
+}

--- a/packages/edit-site/src/components/sidebar-edit-mode/template-panel/style.scss
+++ b/packages/edit-site/src/components/sidebar-edit-mode/template-panel/style.scss
@@ -38,6 +38,6 @@ h3.edit-site-template-card__template-areas-title {
 	margin: 0 0 $grid-unit-10;
 }
 
-.edit-site-template-panel__pattern-categories > div {
+.edit-site-template-panel__pattern-categories > * {
 	width: 100%;
 }


### PR DESCRIPTION
## What?

Makes the pattern categories control in the site editor span the full width of the sidebar

## Why?

Small visual bugs like this add up. It also helps buy some time until the control receives some further enhancements

## How?

- Adds a CSS class to the wrapping panel row
- The CSS class and associated styles can't be added to the FormTokenField directly as that component passing its `className` prop to an inner element where we should be increasing the width on the component's wrapper.

## Testing Instructions

1. Navigate to Appearance > Editor > Patterns
2. Select a pattern to edit
3. Click on the preview to enter edit mode
4. Confirm that the pattern categories field in the sidebar fills the width of the sidebar

## Screenshots or screencast <!-- if applicable -->

| Before | After |
|---|---|
| <img width="279" alt="Screenshot 2023-09-27 at 5 58 18 pm" src="https://github.com/WordPress/gutenberg/assets/60436221/02f59e7a-27ca-4fe5-a660-c2d94daaa9f0"> | <img width="279" alt="Screenshot 2023-09-27 at 5 58 26 pm" src="https://github.com/WordPress/gutenberg/assets/60436221/7bc1b0e2-bb55-49b1-8d6b-3acbf08193ff"> |

