### PR TITLE
Update index.js

### DIFF
--- a/packages/block-library/src/verse/index.js
+++ b/packages/block-library/src/verse/index.js
@@ -25,7 +25,7 @@ export const settings = {
 			/* eslint-disable @wordpress/i18n-no-collapsible-whitespace */
 			// translators: Sample content for the Verse block. Can be replaced with a more locale-adequate work.
 			content: __(
-				'WHAT was he doing, the great god Pan,\n	Down in the reeds by the river?\nSpreading ruin and scattering ban,\nSplashing and paddling with hoofs of a goat,\nAnd breaking the golden lilies afloat\n    With the dragon-fly on the river.'
+				'WHAT was he doing, the great god Pan,\n	Down in the reeds by the river?\nSpreading ruin and scattering ban,\nSplashing and paddling with hoofs of a goat,\nAnd breaking the golden lilies afloat\nWith the dragon-fly on the river.'
 			),
 			/* eslint-enable @wordpress/i18n-no-collapsible-whitespace */
 		},


### PR DESCRIPTION
Removed unwanted space in packages/block-library/src/verse/index.js

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Removing unwanted space from the string

## Why?
Causing warning in translations

## How?
Text correction

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
Text correction

## Screenshots or screencast
![image](https://github.com/WordPress/gutenberg/assets/33219669/6f4605a7-864e-47be-a3b8-576e661e5c98)
