### PR TITLE
Add new e2e test for creating a pattern

### DIFF
--- a/test/e2e/specs/site-editor/patterns.spec.js
+++ b/test/e2e/specs/site-editor/patterns.spec.js
@@ -1,0 +1,114 @@
+/**
+ * WordPress dependencies
+ */
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+
+test.describe( 'Patterns', () => {
+	test.beforeAll( async ( { requestUtils } ) => {
+		await requestUtils.activateTheme( 'emptytheme' );
+		await requestUtils.deleteAllBlocks();
+	} );
+	test.afterAll( async ( { requestUtils } ) => {
+		await requestUtils.activateTheme( 'twentytwentyone' );
+	} );
+
+	test.afterEach( async ( { requestUtils } ) => {
+		await requestUtils.deleteAllBlocks();
+	} );
+
+	test( 'create a new pattern', async ( { page, editor, admin } ) => {
+		await admin.visitSiteEditor();
+
+		const navigation = page.getByRole( 'region', { name: 'Navigation' } );
+		const patternsContent = page.getByRole( 'region', {
+			name: 'Patterns content',
+		} );
+
+		await navigation.getByRole( 'button', { name: 'Patterns' } ).click();
+
+		await expect(
+			navigation.getByRole( 'heading', { name: 'Patterns', level: 1 } )
+		).toBeVisible();
+		await expect( patternsContent ).toContainText( 'No patterns found.' );
+
+		await navigation
+			.getByRole( 'button', { name: 'Create pattern' } )
+			.click();
+
+		const createPatternMenu = page.getByRole( 'menu', {
+			name: 'Create pattern',
+		} );
+		await expect(
+			createPatternMenu.getByRole( 'menuitem', {
+				name: 'Create pattern',
+			} )
+		).toBeFocused();
+		await createPatternMenu
+			.getByRole( 'menuitem', { name: 'Create pattern' } )
+			.click();
+
+		const createPatternDialog = page.getByRole( 'dialog', {
+			name: 'Create pattern',
+		} );
+		await createPatternDialog
+			.getByRole( 'textbox', { name: 'Name' } )
+			.fill( 'My pattern' );
+		await page.keyboard.press( 'Enter' );
+		await expect(
+			createPatternDialog.getByRole( 'button', { name: 'Create' } )
+		).toBeDisabled();
+
+		await expect( page ).toHaveTitle( /^My pattern/ );
+		await expect(
+			page
+				.getByRole( 'region', { name: 'Editor top bar' } )
+				.getByRole( 'heading', { name: 'My pattern', level: 1 } )
+		).toBeVisible();
+
+		await editor.canvas
+			.getByRole( 'button', { name: 'Add default block' } )
+			.click();
+		await page.keyboard.type( 'My pattern' );
+
+		await page
+			.getByRole( 'region', { name: 'Editor top bar' } )
+			.getByRole( 'button', { name: 'Save' } )
+			.click();
+		await page
+			.getByRole( 'region', { name: 'Save panel' } )
+			.getByRole( 'button', { name: 'Save' } )
+			.click();
+		await expect(
+			page.getByRole( 'button', { name: 'Dismiss this notice' } )
+		).toContainText( 'Site updated' );
+
+		await page.getByRole( 'button', { name: 'Open navigation' } ).click();
+		await navigation.getByRole( 'button', { name: 'Back' } ).click();
+		// TODO: await expect( page ).toHaveTitle( /^Patterns/ );
+
+		await expect(
+			navigation.getByRole( 'button', { name: 'All patterns' } )
+		).toBeVisible();
+		await expect(
+			navigation.getByRole( 'button', { name: 'My patterns' } )
+		).toBeVisible();
+		await expect(
+			navigation.getByRole( 'button', { name: 'Uncategorized' } )
+		).toBeVisible();
+
+		await expect(
+			patternsContent.getByRole( 'heading', {
+				name: 'All patterns',
+				level: 2,
+			} )
+		).toBeVisible();
+		await expect(
+			patternsContent
+				.getByRole( 'listbox', { name: 'All patterns' } )
+				// TODO: should be `getByRole( 'option', { name: 'My pattern' } )`
+				.getByRole( 'button', { name: 'My pattern', exact: true } )
+				// TODO: Shouldn't need this.
+				.nth( 0 )
+		).toBeVisible();
+	} );
+} );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
A basic e2e test to create a new pattern in the patterns screen.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
To cover some of the most critical path in the patterns page to allow us to move faster with confidence.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Know your tools and write an e2e test! ✍️ 

Note that there are some `// TODO`s that each represents a bug. We'll look into those in follow-up PRs.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
CI should pass

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
N/A

## Screenshots or screencast <!-- if applicable -->
N/A
