### PR TITLE
Fix warning when a template calls a template area twice

### DIFF
--- a/packages/edit-site/src/store/utils.js
+++ b/packages/edit-site/src/store/utils.js
@@ -51,7 +51,7 @@ function getFilteredTemplatePartBlocks( blocks = EMPTY_ARRAY, templateParts ) {
 
 			// Make sure we don't duplicate template parts.
 			const existingTemplatePart = result.find(
-				( e ) => e.templatePart.id === templatePartId
+				( oneResult ) => oneResult.templatePart.id === templatePartId
 			);
 
 			// Only add to output if the found template part block is in the list of available template parts.

--- a/packages/edit-site/src/store/utils.js
+++ b/packages/edit-site/src/store/utils.js
@@ -49,8 +49,13 @@ function getFilteredTemplatePartBlocks( blocks = EMPTY_ARRAY, templateParts ) {
 			const templatePartId = `${ theme }//${ slug }`;
 			const templatePart = templatePartsById[ templatePartId ];
 
+			// Make sure we don't duplicate template parts.
+			const existingTemplatePart = result.find(
+				( e ) => e.templatePart.id === templatePartId
+			);
+
 			// Only add to output if the found template part block is in the list of available template parts.
-			if ( templatePart ) {
+			if ( templatePart && ! existingTemplatePart ) {
 				result.push( {
 					templatePart,
 					block,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This PR removes duplicate template areas from the sidebar when in Site View.

The list of areas is based on the template parts used on the page, but we may use some template parts twice. 

## Why?
We only want to display these template areas and corresponding parts once in the sidebar even if they are used multiple times.

## How?
By making sure that `getFilteredTemplatePartBlocks` only returns one instance of each `templateId`, making them unique

## Screenshot
<img width="436" alt="Screenshot 2023-09-28 at 15 56 20" src="https://github.com/WordPress/gutenberg/assets/275961/12fc1521-80a8-427e-8ed0-71a2143b713d">
