### PR TITLE
Docs: Rename Block Hooks handbook page to Block Filters

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -492,7 +492,7 @@
 		"parent": "reference-guides"
 	},
 	{
-		"title": "Block Hooks",
+		"title": "Block Filters",
 		"slug": "block-filters",
 		"markdown_source": "../docs/reference-guides/filters/block-filters.md",
 		"parent": "filters"

--- a/docs/reference-guides/README.md
+++ b/docs/reference-guides/README.md
@@ -18,7 +18,7 @@
 
 ## [Hooks Reference](/docs/reference-guides/filters/README.md)
 
--   [Block Hooks](/docs/reference-guides/filters/block-filters.md)
+-   [Block Filters](/docs/reference-guides/filters/block-filters.md)
 -   [Editor Hooks](/docs/reference-guides/filters/editor-filters.md)
 -   [i18n Hooks](/docs/reference-guides/filters/i18n-filters.md)
 -   [Parser Hooks](/docs/reference-guides/filters/parser-filters.md)

--- a/docs/reference-guides/filters/block-filters.md
+++ b/docs/reference-guides/filters/block-filters.md
@@ -1,4 +1,4 @@
-# Block Hooks
+# Block Filters
 
 To modify the behavior of existing blocks, WordPress exposes several APIs.
 


### PR DESCRIPTION
## What?

Rename the handbook page currently entitled "Block Hooks" to "Block Filters".

## Why?

To distinguish from the new ["Block Hooks" feature](https://core.trac.wordpress.org/ticket/59313), which is conceptually very different.

## How?

By renaming the handbook page from "Block Hooks" to "Block Filters".

AFAICT, the handbook page makes no direct reference to hooks, other than the title; furthermore, the relevant client-side `@wordpress/` package happens to be called `@wordpress/hooks`. Reading the page, it’s all about filters though (both on the client and server sides), whereas "hooks" traditionally denotes the union of filters and actions — the latter of which are pretty much absent from the page.

Finally, note that the filename has already been `block-filters.md` before.

Thus, changing the title to "Block Filters" seems warranted.

Flagged by @juanmaguitar in Slack.