### PR TITLE
E2E Tests: Revert temporary fixes

### DIFF
--- a/packages/e2e-tests/specs/editor/various/datepicker.test.js
+++ b/packages/e2e-tests/specs/editor/various/datepicker.test.js
@@ -61,9 +61,7 @@ async function getPublishingDate() {
 	);
 }
 
-// @todo: Change `UTC+1` back to `UTC` once the core regressions is resolved.
-// See: https://github.com/WordPress/gutenberg/pull/54806#issuecomment-1734840171.
-describe.each( [ [ 'UTC-10' ], [ 'UTC+1' ], [ 'UTC+10' ] ] )(
+describe.each( [ [ 'UTC-10' ], [ 'UTC' ], [ 'UTC+10' ] ] )(
 	`Datepicker %s`,
 	( timezone ) => {
 		let oldTimezone;

--- a/packages/e2e-tests/specs/editor/various/scheduling.test.js
+++ b/packages/e2e-tests/specs/editor/various/scheduling.test.js
@@ -23,9 +23,7 @@ describe( 'Scheduling', () => {
 		} );
 	};
 
-	// @todo: Change `UTC+1` back to `UTC` once the core regressions is resolved.
-	// See: https://github.com/WordPress/gutenberg/pull/54806#issuecomment-1734840171.
-	describe.each( [ [ 'UTC-10' ], [ 'UTC+1' ], [ 'UTC+10' ] ] )(
+	describe.each( [ [ 'UTC-10' ], [ 'UTC' ], [ 'UTC+10' ] ] )(
 		`Timezone %s`,
 		( timezone ) => {
 			let oldTimezone;


### PR DESCRIPTION
## What?
PR reverts temporary fixes from `datepicker` and `scheduling` e2e tests.

The bug was fixed in WP Core - https://core.trac.wordpress.org/changeset/56717.

## Testing Instructions
CI check should pass.
