### PR TITLE
All Nav block items to break long titles

### DIFF
--- a/packages/block-library/src/navigation-link/style.scss
+++ b/packages/block-library/src/navigation-link/style.scss
@@ -5,7 +5,6 @@
 .wp-block-navigation {
 	// This wraps just the innermost text for custom menu items.
 	.wp-block-navigation-item__label {
-		word-break: normal;
 		overflow-wrap: break-word;
 	}
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Nav block _items_ may have long titles which do not have natural word breaks. In certain cases this may causes them to overflow their container.

This PR seeks to address that by removing a (seemingly) redundant CSS proprerty thereby allowing menu item titles to wrap.

Closes https://github.com/WordPress/gutenberg/issues/52298

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Having menu item text break out of it's container is not good for visual design.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Removes seemingly redundant property [`word-break: normal;`](https://developer.mozilla.org/en-US/docs/Web/CSS/word-break).

> normal - Use the default line break rule.

## Questions/concerns

This property seems to indicate it was added intentionally to cover some special case. T[he PR that added](https://github.com/WordPress/gutenberg/pull/29975) it was authored by @jasmussen but has some complexities that I don't fully understand. It's also a large PR.

It would be good to get context from @jasmussen before we look to merge this one.


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- New Post
- Add Nav block
- Add a nav item with some very long title text that doesn't contain any spaces (e.g. `Supercalifragilisticexpialidocious`).
- Set the Navigation to "vertivcal" orientation in the sidebar controls.
- Create Columns block with 3 columns. Add a background to each column to make things clearer.
- Drag the Nav block into Column 1.
- See that Nav item `Supercalifragilisticexpialidocious` does not overflow the boundary (as [per the Issue](https://github.com/WordPress/gutenberg/issues/52298)) but instead wraps.
- Add another Nav block which is in horizontal orientation and check this change does not effect those items.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->


https://github.com/WordPress/gutenberg/assets/444434/a34c9883-bc89-415f-9b47-64fdb3599a11


