### PR TITLE
Add a documentation page about the block editor settings

### DIFF
--- a/platform-docs/docs/basic-concepts/settings.md
+++ b/platform-docs/docs/basic-concepts/settings.md
@@ -11,6 +11,8 @@ You can customize the block editor by providing a `settings` prop to the `BlockE
 The styles setting is an array of editor styles to enqueue in the iframe/canvas of the block editor. Each style is an object with a `css` property. Example:
 
 ```jsx
+import { BlockEditorProvider, BlockCanvas } from '@wordpress/block-editor';
+
 export const editorStyles = [
 	{
 		css: `
@@ -18,19 +20,10 @@ export const editorStyles = [
 				font-family: Arial;
 				font-size: 16px;
 			}
+
 			p {
 				font-size: inherit;
 				line-height: inherit;
-			}
-			ul,
-			ol {
-				margin: 0;
-				padding: 0;
-			}
-
-			ul li,
-			ol li {
-				margin-bottom: initial;
 			}
 
 			ul {
@@ -40,25 +33,6 @@ export const editorStyles = [
 			ol {
 				list-style-type: decimal;
 			}
-
-			ul ul,
-			ol ul {
-				list-style-type: circle;
-			}
-
-			.wp-block {
-				max-width: 700px;
-				margin-left: auto;
-				margin-right: auto;
-			}
-			.wp-block[data-align="wide"],
-			.wp-block.alignwide {
-				max-width: 900px;
-			}
-			.wp-block[data-align="full"],
-			.wp-block.alignfull {
-				max-width: none;
-			}
 		`,
 	},
 ];
@@ -66,7 +40,7 @@ export const editorStyles = [
 export default function App() {
 	return (
 		<BlockEditorProvider settings={ { styles: editorStyles } }>
-			<Editor />
+			<BlockCanvas />
 		</BlockEditorProvider>
 	);
 }
@@ -74,7 +48,7 @@ export default function App() {
 
 ## mediaUpload
 
-Some core blocks like the image or video blocks allow users to render media within the block editor, by default you can use external URLs but if you want to allow users to upload media from their computer you need to provide a `mediaUpload` function. Here's a quick example of such function:
+Some core blocks, like the image or video blocks, allow users to render media within the block editor. By default, you can use external URLs but if you want to allow users to upload media from their computer, you need to provide a `mediaUpload` function. Here's a quick example of such function:
 
 ```jsx
 async function mediaUpload( {
@@ -114,7 +88,7 @@ Providing a `mediaUpload` function also enables drag and dropping files into the
 
 ## inserterMediaCategories
 
-The inserter media categories setting is an array of media categories to display in the inserter. Each category is an object with a `name`, `labels` a `fetch` function and a few extra keys. Example:
+The inserter media categories setting is an array of media categories to display in the inserter. Each category is an object with `name` and `labels` values, a `fetch` function and a few extra keys. Example:
 
 ```jsx
 {
@@ -131,7 +105,7 @@ The inserter media categories setting is an array of media categories to display
             license: 'pdm,cc0',
         };
         const finalQuery = { ...query, ...defaultArgs };
-        // Sometimes you might need to map the supported request params according to `InserterMediaRequest`.
+        // Sometimes you might need to map the supported request params according to the `InserterMediaRequest`
         // interface. In this example the `search` query param is named `q`.
         const mapFromInserterMediaRequest = {
             per_page: 'page_size',
@@ -170,7 +144,7 @@ The inserter media categories setting is an array of media categories to display
 
 ## hasFixedToolbar
 
-Whether or not the `BlockTools` component renders the toolbar in a fixed position or if follows the position of the selected block. Defaults to `false`.
+Whether the `BlockTools` component renders the toolbar in a fixed position or if follows the position of the selected block. Defaults to `false`.
 
 ## focusMode
 
@@ -178,7 +152,7 @@ The focus mode is a special mode where any block that is not selected is shown w
 
 ## keepCaretInsideBlock
 
-By default arrow keys can be used to navigate accross blocks. You can turn off that behavior by and keep the caret inside the currently selected block using this setting. Defaults to `false`.
+By default, arrow keys can be used to navigate across blocks. You can turn off that behavior and keep the caret inside the currently selected block using this setting. Defaults to `false`.
 
 ## codeEditingEnabled
 
@@ -186,4 +160,4 @@ Allows the user to edit the currently selected block using an HTML code editor. 
 
 ## canLockBlocks
 
-Whether or not the user can lock blocks. Defaults to `true`.
+Whether the user can lock blocks. Defaults to `true`.

--- a/platform-docs/docs/basic-concepts/settings.md
+++ b/platform-docs/docs/basic-concepts/settings.md
@@ -3,3 +3,187 @@ sidebar_position: 4
 ---
 
 # Block Editor Settings
+
+You can customize the block editor by providing a `settings` prop to the `BlockEditorProvider` component. This prop accepts an object with the following properties:
+
+## styles
+
+The styles setting is an array of editor styles to enqueue in the iframe/canvas of the block editor. Each style is an object with a `css` property. Example:
+
+```jsx
+export const editorStyles = [
+	{
+		css: `
+			body {
+				font-family: Arial;
+				font-size: 16px;
+			}
+			p {
+				font-size: inherit;
+				line-height: inherit;
+			}
+			ul,
+			ol {
+				margin: 0;
+				padding: 0;
+			}
+
+			ul li,
+			ol li {
+				margin-bottom: initial;
+			}
+
+			ul {
+				list-style-type: disc;
+			}
+
+			ol {
+				list-style-type: decimal;
+			}
+
+			ul ul,
+			ol ul {
+				list-style-type: circle;
+			}
+
+			.wp-block {
+				max-width: 700px;
+				margin-left: auto;
+				margin-right: auto;
+			}
+			.wp-block[data-align="wide"],
+			.wp-block.alignwide {
+				max-width: 900px;
+			}
+			.wp-block[data-align="full"],
+			.wp-block.alignfull {
+				max-width: none;
+			}
+		`,
+	},
+];
+
+export default function App() {
+	return (
+		<BlockEditorProvider settings={ { styles: editorStyles } }>
+			<Editor />
+		</BlockEditorProvider>
+	);
+}
+```
+
+## mediaUpload
+
+Some core blocks like the image or video blocks allow users to render media within the block editor, by default you can use external URLs but if you want to allow users to upload media from their computer you need to provide a `mediaUpload` function. Here's a quick example of such function:
+
+```jsx
+async function mediaUpload( {
+	additionalData = {},
+	filesList,
+	onError = noop,
+	onFileChange,
+} ) {
+	const uploadedMedia = [];
+	for ( const file of filesList ) {
+		try {
+			const data = await someApiCallToUploadTheFile( file );
+			const mediaObject = {
+				alt: data.alt,
+				caption: data.caption,
+				title: data.title,
+				url: data.url,
+			};
+			uploadedMedia.push( mediaObject );
+		} catch ( error ) {
+			onError( {
+				code: 'SOME_ERROR_CODE',
+				message:
+					mediaFile.name +
+					' : Sorry, an error happened while uploading this file.',
+				file: mediaFile,
+			} );
+		}
+		if ( uploadedMedia.length ) {
+			onFileChange( uploadedMedia );
+		}
+	}
+}
+```
+
+Providing a `mediaUpload` function also enables drag and dropping files into the editor to upload them.
+
+## inserterMediaCategories
+
+The inserter media categories setting is an array of media categories to display in the inserter. Each category is an object with a `name`, `labels` a `fetch` function and a few extra keys. Example:
+
+```jsx
+{
+    name: 'openverse',
+    labels: {
+        name: 'Openverse',
+        search_items: 'Search Openverse',
+    },
+    mediaType: 'image',
+    async fetch( query = {} ) {
+        const defaultArgs = {
+            mature: false,
+            excluded_source: 'flickr,inaturalist,wikimedia',
+            license: 'pdm,cc0',
+        };
+        const finalQuery = { ...query, ...defaultArgs };
+        // Sometimes you might need to map the supported request params according to `InserterMediaRequest`.
+        // interface. In this example the `search` query param is named `q`.
+        const mapFromInserterMediaRequest = {
+            per_page: 'page_size',
+            search: 'q',
+        };
+        const url = new URL( 'https://api.openverse.engineering/v1/images/' );
+        Object.entries( finalQuery ).forEach( ( [ key, value ] ) => {
+            const queryKey = mapFromInserterMediaRequest[ key ] || key;
+            url.searchParams.set( queryKey, value );
+        } );
+        const response = await window.fetch( url, {
+            headers: {
+                'User-Agent': 'WordPress/inserter-media-fetch',
+            },
+        } );
+        const jsonResponse = await response.json();
+        const results = jsonResponse.results;
+        return results.map( ( result ) => ( {
+            ...result,
+            // If your response result includes an `id` prop that you want to access later, it should
+            // be mapped to `InserterMediaItem`'s `sourceId` prop. This can be useful if you provide
+            // a report URL getter.
+            // Additionally you should always clear the `id` value of your response results because
+            // it is used to identify WordPress media items.
+            sourceId: result.id,
+            id: undefined,
+            caption: result.caption,
+            previewUrl: result.thumbnail,
+        } ) );
+    },
+    getReportUrl: ( { sourceId } ) =>
+        `https://wordpress.org/openverse/image/${ sourceId }/report/`,
+    isExternalResource: true,
+}
+```
+
+## hasFixedToolbar
+
+Whether or not the `BlockTools` component renders the toolbar in a fixed position or if follows the position of the selected block. Defaults to `false`.
+
+## focusMode
+
+The focus mode is a special mode where any block that is not selected is shown with a reduced opacity, giving more prominence to the selected block. Defaults to `false`.
+
+## keepCaretInsideBlock
+
+By default arrow keys can be used to navigate accross blocks. You can turn off that behavior by and keep the caret inside the currently selected block using this setting. Defaults to `false`.
+
+## codeEditingEnabled
+
+Allows the user to edit the currently selected block using an HTML code editor. Note that using the code editor is not supported by all blocks and that it has the potential to create invalid blocks depending on the markup the user provides. Defaults to `true`.
+
+## canLockBlocks
+
+Whether or not the user can lock blocks. Defaults to `true`.


### PR DESCRIPTION
Related #53874

## What?

Just documents some of the most important settings a user can pass as a prop to the `BlockEditorProvider` component. I think we're still missing the "theme.json" settings and styles from this list but these should be added when we decided on a stable name.

### Test the documentation website

```
cd platform-docs
npm install
npm start
```