### PR TITLE
Image: Ensure Expand on Click toggle is shown if block-level lightbox setting exists

### DIFF
--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -372,7 +372,7 @@ export default function Image( {
 	const lightboxSetting = useSetting( 'lightbox' );
 
 	const showLightboxToggle =
-		lightboxSetting === true || lightboxSetting?.allowEditing === true;
+		!! lightbox || lightboxSetting?.allowEditing === true;
 
 	const lightboxChecked =
 		lightbox?.enabled || ( ! lightbox && lightboxSetting?.enabled );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
If a user turns on `Expand on Click` in the image's block settings, then subsequently sets `settings.blocks.core/image.lightbox.allowEditing` to `false`, the Expand on Click UI disappears for the image block in question when it should remain visible. This PR fixes that.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Users should be able to access their manual overrides of the Expand on Click setting, even if `allowEditing` is disabled, otherwise they are unable to modify the settings without opening the code editor.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
It revises a conditional check when determining whether to show the toggle or not.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Add an image to a post.
2. Enable the image's `Expand on Click` option.
3. Save the post.
4. In the theme's `theme.json`, set `settings.blocks.core/image.lightbox.allowEditing` to `false`.
5. Refresh the post page and click on the image block — ensure that the `Expand on Click` option is still visible.
6. Now, reset the `Expand on Click` option to default using the Settings dropdown, and verify that the toggle disappears due to `allowEditing` being false and the block-level setting being removed.

### Testing Instructions for Keyboard
 N/A

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/5360536/d3062d65-e035-4748-b02e-6d361098f0e2