### PR TITLE
Use list role instead of listbox in patterns list

### DIFF
--- a/packages/edit-site/src/components/page-patterns/grid.js
+++ b/packages/edit-site/src/components/page-patterns/grid.js
@@ -9,7 +9,7 @@ export default function Grid( { categoryId, items, ...props } ) {
 	}
 
 	return (
-		<ul role="listbox" className="edit-site-patterns__grid" { ...props }>
+		<ul className="edit-site-patterns__grid" { ...props }>
 			{ items.map( ( item ) => (
 				<GridItem
 					key={ item.name }

--- a/test/e2e/specs/site-editor/patterns.spec.js
+++ b/test/e2e/specs/site-editor/patterns.spec.js
@@ -88,13 +88,13 @@ test.describe( 'Patterns', () => {
 
 		await expect(
 			navigation.getByRole( 'button', { name: 'All patterns' } )
-		).toBeVisible();
+		).toContainText( '1' );
 		await expect(
 			navigation.getByRole( 'button', { name: 'My patterns' } )
-		).toBeVisible();
+		).toContainText( '1' );
 		await expect(
 			navigation.getByRole( 'button', { name: 'Uncategorized' } )
-		).toBeVisible();
+		).toContainText( '1' );
 
 		await expect(
 			patternsContent.getByRole( 'heading', {
@@ -102,13 +102,14 @@ test.describe( 'Patterns', () => {
 				level: 2,
 			} )
 		).toBeVisible();
+		const patternsList = patternsContent.getByRole( 'list', {
+			name: 'All patterns',
+		} );
+		await expect( patternsList.getByRole( 'listitem' ) ).toHaveCount( 1 );
 		await expect(
-			patternsContent
-				.getByRole( 'listbox', { name: 'All patterns' } )
-				// TODO: should be `getByRole( 'option', { name: 'My pattern' } )`
+			patternsList
+				.getByRole( 'heading', { name: 'My pattern' } )
 				.getByRole( 'button', { name: 'My pattern', exact: true } )
-				// TODO: Shouldn't need this.
-				.nth( 0 )
 		).toBeVisible();
 	} );
 } );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
A follow-up to https://github.com/WordPress/gutenberg/pull/52357. It was discussed in https://github.com/WordPress/gutenberg/issues/52009#issuecomment-1619832166 to implement the patterns in `list` not `listbox`, but it seems like we missed it in https://github.com/WordPress/gutenberg/pull/52357. This PR fixes that.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
For accessibility and simplicity.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Remove `role="listbox"` and tweak e2e tests.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
CI should pass.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
1. Visit Site editor -> Patterns.
2. Tabbing through each pattern should announce the title and the description in screen readers.

## Screenshots or screencast <!-- if applicable -->
N/A