### PR TITLE
Block Editor: Update strings in blocks 'RenameModal' component

### DIFF
--- a/packages/block-editor/src/hooks/block-rename-ui.js
+++ b/packages/block-editor/src/hooks/block-rename-ui.js
@@ -44,17 +44,21 @@ function RenameModal( { blockName, originalBlockName, onClose, onSave } ) {
 	);
 
 	const handleSubmit = () => {
-		// Must be assertive to immediately announce change.
-		speak(
-			sprintf(
-				/* translators: %1$s: type of update (either reset of changed). %2$s: new name/label for the block */
-				__( 'Block name %1$s to: "%2$s".' ),
-				nameIsOriginal || nameIsEmpty ? __( 'reset' ) : __( 'changed' ),
-				editedBlockName
-			),
-			'assertive'
-		);
+		const message =
+			nameIsOriginal || nameIsEmpty
+				? sprintf(
+						/* translators: %s: new name/label for the block */
+						__( 'Block name reset to: "%s".' ),
+						editedBlockName
+				  )
+				: sprintf(
+						/* translators: %s: new name/label for the block */
+						__( 'Block name changed to: "%s".' ),
+						editedBlockName
+				  );
 
+		// Must be assertive to immediately announce change.
+		speak( message, 'assertive' );
 		onSave( editedBlockName );
 
 		// Immediate close avoids ability to hit save multiple times.


### PR DESCRIPTION
## What?
Fixes #54872.

PR simplifies the action announcement message text in blocks `RenameModal` component. The submit action only resolves in two states - "reset" and "changed," let's make them part of the message.

## Why?
To make translations easier.

## Testing Instructions
All CI checks pass. There are no changes in component behavior.
