### PR TITLE
Update versions in WP for 6.4

### DIFF
--- a/docs/contributors/versions-in-wordpress.md
+++ b/docs/contributors/versions-in-wordpress.md
@@ -6,6 +6,7 @@ If anything looks incorrect here, please bring it up in #core-editor in [WordPre
 
 | Gutenberg Versions | WordPress Version |
 | ------------------ | ----------------- |
+| 16.2-16.7          | 6.4               |
 | 15.2-16.1          | 6.3.1             |
 | 15.2-16.1          | 6.3               |
 | 14.2-15.1          | 6.2               |


### PR DESCRIPTION
Quick update to the Versions in WP doc for 6.4 with beta 1 out in the world.