### PR TITLE
Patterns: add a new spec for for adding an unsynced pattern

### DIFF
--- a/test/e2e/specs/editor/various/patterns.spec.js
+++ b/test/e2e/specs/editor/various/patterns.spec.js
@@ -55,18 +55,14 @@ test.describe( 'Unsynced pattern', () => {
 			.fill( 'My unsynced pattern' );
 		await page.getByLabel( 'My unsynced pattern' ).click();
 
-		// Just get the block name and content to compare as the clientIDs will be different.
-		const originalBlock = await before.map( ( block ) => ( {
-			name: block.name,
-			content: block.attributes.content,
-		} ) );
-
+		// Just compare the block name and content as the clientIDs will be different.
+		const existingBlock = before[ 0 ];
 		const newBlocks = await editor.getBlocks();
-		expect(
-			newBlocks.map( ( block ) => ( {
-				name: block.name,
-				content: block.attributes.content,
-			} ) )
-		).toEqual( [ ...originalBlock, ...originalBlock ] );
+		newBlocks.forEach( ( block ) =>
+			expect( block ).toMatchObject( {
+				name: existingBlock.name,
+				attributes: { content: existingBlock.attributes.content },
+			} )
+		);
 	} );
 } );

--- a/test/e2e/specs/editor/various/patterns.spec.js
+++ b/test/e2e/specs/editor/various/patterns.spec.js
@@ -32,10 +32,9 @@ test.describe( 'Unsynced pattern', () => {
 		await createPatternDialog
 			.getByRole( 'textbox', { name: 'Name' } )
 			.fill( 'My unsynced pattern' );
-		await createPatternDialog.getByRole(
-			'checkbox',
-			{ name: 'Synced' }
-		).setChecked( false );
+		await createPatternDialog
+			.getByRole( 'checkbox', { name: 'Synced' } )
+			.setChecked( false );
 
 		await page.keyboard.press( 'Enter' );
 

--- a/test/e2e/specs/editor/various/patterns.spec.js
+++ b/test/e2e/specs/editor/various/patterns.spec.js
@@ -45,7 +45,7 @@ test.describe( 'Unsynced pattern', () => {
 			)
 			.toEqual( before );
 
-		// Check that the new pattern is availble in the inserter and that it gets inserted as
+		// Check that the new pattern is available in the inserter and that it gets inserted as
 		// a plain paragraph block.
 		await page.getByLabel( 'Toggle block inserter' ).click();
 		await page

--- a/test/e2e/specs/editor/various/patterns.spec.js
+++ b/test/e2e/specs/editor/various/patterns.spec.js
@@ -32,7 +32,10 @@ test.describe( 'Unsynced pattern', () => {
 		await createPatternDialog
 			.getByRole( 'textbox', { name: 'Name' } )
 			.fill( 'My unsynced pattern' );
-		await createPatternDialog.getByRole( 'checkbox' ).setChecked( false );
+		await createPatternDialog.getByRole(
+			'checkbox',
+			{ name: 'Synced' }
+		).setChecked( false );
 
 		await page.keyboard.press( 'Enter' );
 

--- a/test/e2e/specs/editor/various/unsynced-pattern.spec.js
+++ b/test/e2e/specs/editor/various/unsynced-pattern.spec.js
@@ -1,0 +1,58 @@
+/**
+ * WordPress dependencies
+ */
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+
+test.describe( 'Unsynced pattern', () => {
+	test.beforeEach( async ( { admin } ) => {
+		await admin.createNewPost();
+	} );
+
+	test( 'create a new unsynced pattern via the block options menu', async ( {
+		editor,
+		page,
+	} ) => {
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: { content: 'A useful paragraph to reuse' },
+		} );
+
+		// Create an unsynced pattern from the paragraph block.
+		await editor.showBlockToolbar();
+		await page
+			.getByRole( 'toolbar', { name: 'Block tools' } )
+			.getByRole( 'button', { name: 'Options' } )
+			.click();
+		await page.getByRole( 'menuitem', { name: 'Create pattern' } ).click();
+
+		const createPatternDialog = page.getByRole( 'dialog', {
+			name: 'Create pattern',
+		} );
+		await createPatternDialog
+			.getByRole( 'textbox', { name: 'Name' } )
+			.fill( 'My unsynced pattern' );
+		await page.getByLabel( 'Synced' ).click();
+
+		await page.keyboard.press( 'Enter' );
+		const content = await editor.getEditedPostContent();
+
+		// Check that the block content is still the same. If the pattern was added as synced
+		// the content would be wrapped by a pattern block.
+		expect( content ).toBe(
+			`<!-- wp:paragraph -->
+<p>A useful paragraph to reuse</p>
+<!-- /wp:paragraph -->`
+		);
+
+		// Check that the new pattern is availble in the inserter.
+		await page.getByLabel( 'Toggle block inserter' ).click();
+		await page
+			.getByRole( 'searchbox', {
+				name: 'Search for blocks and patterns',
+			} )
+			.fill( 'My unsynced pattern' );
+		await page.getByLabel( 'Search for blocks and patterns' ).click();
+
+		await expect( page.getByLabel( 'My unsynced pattern' ) ).toBeVisible();
+	} );
+} );

--- a/test/e2e/specs/editor/various/unsynced-pattern.spec.js
+++ b/test/e2e/specs/editor/various/unsynced-pattern.spec.js
@@ -44,7 +44,7 @@ test.describe( 'Unsynced pattern', () => {
 <!-- /wp:paragraph -->`
 		);
 
-		// Check that the new pattern is availble in the inserter and that is gets inserted as
+		// Check that the new pattern is availble in the inserter and that it gets inserted as
 		// a plain paragraph block.
 		await page.getByLabel( 'Toggle block inserter' ).click();
 		await page

--- a/test/e2e/specs/editor/various/unsynced-pattern.spec.js
+++ b/test/e2e/specs/editor/various/unsynced-pattern.spec.js
@@ -52,7 +52,6 @@ test.describe( 'Unsynced pattern', () => {
 				name: 'Search for blocks and patterns',
 			} )
 			.fill( 'My unsynced pattern' );
-		await page.getByLabel( 'Search for blocks and patterns' ).click();
 		await page.getByLabel( 'My unsynced pattern' ).click();
 
 		const updatedContent = await editor.getEditedPostContent();

--- a/test/e2e/specs/editor/various/unsynced-pattern.spec.js
+++ b/test/e2e/specs/editor/various/unsynced-pattern.spec.js
@@ -44,7 +44,8 @@ test.describe( 'Unsynced pattern', () => {
 <!-- /wp:paragraph -->`
 		);
 
-		// Check that the new pattern is availble in the inserter.
+		// Check that the new pattern is availble in the inserter and that is gets inserted as
+		// a plain paragraph block.
 		await page.getByLabel( 'Toggle block inserter' ).click();
 		await page
 			.getByRole( 'searchbox', {
@@ -52,7 +53,17 @@ test.describe( 'Unsynced pattern', () => {
 			} )
 			.fill( 'My unsynced pattern' );
 		await page.getByLabel( 'Search for blocks and patterns' ).click();
+		await page.getByLabel( 'My unsynced pattern' ).click();
 
-		await expect( page.getByLabel( 'My unsynced pattern' ) ).toBeVisible();
+		const updatedContent = await editor.getEditedPostContent();
+		expect( updatedContent ).toBe(
+			`<!-- wp:paragraph -->
+<p>A useful paragraph to reuse</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>A useful paragraph to reuse</p>
+<!-- /wp:paragraph -->`
+		);
 	} );
 } );


### PR DESCRIPTION
## What?
Adds an e2e spec for adding an unsynced pattern in the post editor.

## Why?
To try and guard against future regressions like https://github.com/WordPress/gutenberg/pull/54804.

## How?
Adds a new spec that goes through the flow of adding an unsynced pattern in the post editor, checking that it is not mistakingly added as synced, and checking that it is then available in the inserter, and gets inserted as a plain block.

## Testing Instructions

- Check that CI tests pass
- Check test locally with `npm run test:e2e:playwright specs/editor/various/unsynced-pattern.spec.js`


