### PR TITLE
Patterns: Remove category description in inserter panel

### DIFF
--- a/packages/block-editor/src/components/inserter/block-patterns-tab.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-tab.js
@@ -321,9 +321,6 @@ export function BlockPatternsCategoryPanel( {
 						category={ category }
 					/>
 				</HStack>
-				{ category.description && (
-					<Text>{ category.description }</Text>
-				) }
 				{ ! currentCategoryPatterns.length && (
 					<Text
 						variant="muted"

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -314,7 +314,7 @@ $block-inserter-tabs-height: 44px;
 		overflow-y: auto;
 		flex-grow: 1;
 		height: 100%;
-		padding: $grid-unit-40 $grid-unit-30;
+		padding: $grid-unit-20 $grid-unit-30;
 	}
 }
 


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/54874

## What?

Removes pattern category description from inserter panel.

## Why?

Not all pattern categories have a description and those that do have varying length descriptions leading to additional variance in the UI.

## How?

Remove rendering of the category description and tweak spacing between the panel header and patterns list. 

**Note: This spacing will likely need tweaking further but the header and pattern list padding now total 32px between them matching the padding at the bottom of the pattern list**

## Testing Instructions

1. Open the post editor
2. Open the Block Inserter and select the patterns tab
3. Navigate through various pattern categories and ensure no category descriptions are shown

## Screenshots or screencast <!-- if applicable -->

<img width="298" alt="Screenshot 2023-09-28 at 10 33 01 am" src="https://github.com/WordPress/gutenberg/assets/60436221/9f23a7d6-6572-43fc-aed5-6b58a73ff571"><img width="299" alt="Screenshot 2023-09-28 at 10 33 20 am" src="https://github.com/WordPress/gutenberg/assets/60436221/a99e959d-3bbb-4861-9cc1-0bb04bae6a30">
<img width="297" alt="Screenshot 2023-09-28 at 10 32 42 am" src="https://github.com/WordPress/gutenberg/assets/60436221/10f71217-3a72-4389-bc48-3e2bb4f4ca4d"><img width="300" alt="Screenshot 2023-09-28 at 10 32 24 am" src="https://github.com/WordPress/gutenberg/assets/60436221/a59c7159-0d9c-427f-8d4e-3c3b56ac0af7">
