### PR TITLE
List View: Add keyboard shortcut to select all blocks

### DIFF
--- a/packages/block-editor/src/components/list-view/block-select-button.js
+++ b/packages/block-editor/src/components/list-view/block-select-button.js
@@ -30,6 +30,7 @@ import ListViewExpander from './expander';
 import { useBlockLock } from '../block-lock';
 import { store as blockEditorStore } from '../../store';
 import useListViewImages from './use-list-view-images';
+import { useListViewContext } from './context';
 
 function ListViewBlockSelectButton(
 	{
@@ -64,10 +65,12 @@ function ListViewBlockSelectButton(
 		getBlocksByClientId,
 		canRemoveBlocks,
 	} = useSelect( blockEditorStore );
-	const { duplicateBlocks, removeBlocks } = useDispatch( blockEditorStore );
+	const { duplicateBlocks, multiSelect, removeBlocks } =
+		useDispatch( blockEditorStore );
 	const isMatch = useShortcutEventMatch();
 	const isSticky = blockInformation?.positionType === 'sticky';
 	const images = useListViewImages( { clientId, isExpanded } );
+	const { rootClientId } = useListViewContext();
 
 	const positionLabel = blockInformation?.positionLabel
 		? sprintf(
@@ -183,6 +186,24 @@ function ListViewBlockSelectButton(
 					updateFocusAndSelection( updatedBlocks[ 0 ], false );
 				}
 			}
+		} else if ( isMatch( 'core/block-editor/select-all', event ) ) {
+			if ( event.defaultPrevented ) {
+				return;
+			}
+			event.preventDefault();
+
+			const blockClientIds = getBlockOrder( rootClientId );
+			if ( ! blockClientIds.length ) {
+				return;
+			}
+
+			// Select all while passing `null` to skip focusing to the editor canvas,
+			// and retain focus within the list view.
+			multiSelect(
+				blockClientIds[ 0 ],
+				blockClientIds[ blockClientIds.length - 1 ],
+				null
+			);
 		}
 	}
 

--- a/packages/block-editor/src/components/list-view/block-select-button.js
+++ b/packages/block-editor/src/components/list-view/block-select-button.js
@@ -19,6 +19,7 @@ import { SPACE, ENTER, BACKSPACE, DELETE } from '@wordpress/keycodes';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { __unstableUseShortcutEventMatch as useShortcutEventMatch } from '@wordpress/keyboard-shortcuts';
 import { __, sprintf } from '@wordpress/i18n';
+import isShallowEqual from '@wordpress/is-shallow-equal';
 
 /**
  * Internal dependencies
@@ -201,7 +202,11 @@ function ListViewBlockSelectButton(
 
 			// If we have selected all sibling nested blocks, try selecting up a level.
 			// This is a similar implementation to that used by `useSelectAll`.
-			if ( selectedBlockClientIds.length === blockClientIds.length ) {
+			// `isShallowEqual` is used for the list view instead of a length check,
+			// as the array of siblings of the currently focused block may be a different
+			// set of blocks from the current block selection if the user is focused
+			// on a different part of the list view from the block selection.
+			if ( isShallowEqual( selectedBlockClientIds, blockClientIds ) ) {
 				// Only select up a level if the first block is not the root block.
 				// This ensures that the block selection can't break out of the root block
 				// used by the list view, if the list view is only showing a partial hierarchy.

--- a/packages/block-editor/src/components/list-view/block-select-button.js
+++ b/packages/block-editor/src/components/list-view/block-select-button.js
@@ -192,9 +192,26 @@ function ListViewBlockSelectButton(
 			}
 			event.preventDefault();
 
-			const blockClientIds = getBlockOrder( rootClientId );
+			const { firstBlockRootClientId, selectedBlockClientIds } =
+				getBlocksToUpdate();
+			const blockClientIds = getBlockOrder( firstBlockRootClientId );
 			if ( ! blockClientIds.length ) {
 				return;
+			}
+
+			// If we have selected all sibling nested blocks, try selecting up a level.
+			// This is a similar implementation to that used by `useSelectAll`.
+			if ( selectedBlockClientIds.length === blockClientIds.length ) {
+				// Only select up a level if the first block is not the root block.
+				// This ensures that the block selection can't break out of the root block
+				// used by the list view, if the list view is only showing a partial hierarchy.
+				if (
+					firstBlockRootClientId &&
+					firstBlockRootClientId !== rootClientId
+				) {
+					updateFocusAndSelection( firstBlockRootClientId, true );
+					return;
+				}
 			}
 
 			// Select all while passing `null` to skip focusing to the editor canvas,

--- a/packages/block-editor/src/components/list-view/index.js
+++ b/packages/block-editor/src/components/list-view/index.js
@@ -222,6 +222,7 @@ function ListViewComponent(
 			insertedBlock,
 			setInsertedBlock,
 			treeGridElementRef: elementRef,
+			rootClientId,
 		} ),
 		[
 			draggedClientIds,
@@ -233,6 +234,7 @@ function ListViewComponent(
 			AdditionalBlockContent,
 			insertedBlock,
 			setInsertedBlock,
+			rootClientId,
 		]
 	);
 

--- a/test/e2e/specs/editor/various/list-view.spec.js
+++ b/test/e2e/specs/editor/various/list-view.spec.js
@@ -421,7 +421,7 @@ test.describe( 'List View', () => {
 		).toBeFocused();
 	} );
 
-	test( 'should duplicate, delete, and deselect blocks using keyboard', async ( {
+	test( 'should select, duplicate, delete, and deselect blocks using keyboard', async ( {
 		editor,
 		page,
 		pageUtils,
@@ -464,6 +464,215 @@ test.describe( 'List View', () => {
 				{ name: 'core/file', selected: true, focused: true },
 			] );
 
+		// Move up to the paragraph block in the first column block.
+		// Expand children to get to the deeply nested paragraph block.
+		await page.keyboard.press( 'ArrowUp' );
+		await page.keyboard.press( 'ArrowRight' );
+		await page.keyboard.press( 'ArrowDown' );
+		await page.keyboard.press( 'ArrowRight' );
+		await page.keyboard.press( 'ArrowDown' );
+		await page.keyboard.press( 'ArrowDown' );
+
+		await expect
+			.poll(
+				listViewUtils.getBlocksWithA11yAttributes,
+				'The last inserted block should be selected, while the deeply nested paragraph block should be focused.'
+			)
+			.toMatchObject( [
+				{ name: 'core/group' },
+				{
+					name: 'core/columns',
+					innerBlocks: [
+						{
+							name: 'core/column',
+							innerBlocks: [
+								{ name: 'core/heading' },
+								{
+									name: 'core/paragraph',
+									selected: false,
+									focused: true,
+								},
+							],
+						},
+						{ name: 'core/column' },
+					],
+				},
+				{ name: 'core/file', selected: true, focused: false },
+			] );
+
+		// Select all siblings at the current level.
+		await pageUtils.pressKeys( 'primary+a' );
+		await expect
+			.poll(
+				listViewUtils.getBlocksWithA11yAttributes,
+				'The deeply nested paragraph block should be selected, along with its sibling heading.'
+			)
+			.toMatchObject( [
+				{ name: 'core/group' },
+				{
+					name: 'core/columns',
+					innerBlocks: [
+						{
+							name: 'core/column',
+							innerBlocks: [
+								{ name: 'core/heading', selected: true },
+								{
+									name: 'core/paragraph',
+									selected: true,
+									focused: true,
+								},
+							],
+						},
+						{ name: 'core/column' },
+					],
+				},
+				{ name: 'core/file', selected: false, focused: false },
+			] );
+
+		// Select next parent.
+		await pageUtils.pressKeys( 'primary+a' );
+		await expect
+			.poll(
+				listViewUtils.getBlocksWithA11yAttributes,
+				'The first column block should be selected and focused.'
+			)
+			.toMatchObject( [
+				{ name: 'core/group' },
+				{
+					name: 'core/columns',
+					innerBlocks: [
+						{
+							name: 'core/column',
+							innerBlocks: [
+								{ name: 'core/heading' },
+								{
+									name: 'core/paragraph',
+								},
+							],
+							selected: true,
+							focused: true,
+						},
+						{ name: 'core/column', selected: false },
+					],
+				},
+				{ name: 'core/file', selected: false, focused: false },
+			] );
+
+		// Select all siblings at current level.
+		await pageUtils.pressKeys( 'primary+a' );
+		await expect
+			.poll(
+				listViewUtils.getBlocksWithA11yAttributes,
+				'All column blocks should be selected, with the first one focused.'
+			)
+			.toMatchObject( [
+				{ name: 'core/group' },
+				{
+					name: 'core/columns',
+					innerBlocks: [
+						{
+							name: 'core/column',
+							innerBlocks: [
+								{ name: 'core/heading' },
+								{
+									name: 'core/paragraph',
+								},
+							],
+							selected: true,
+							focused: true,
+						},
+						{ name: 'core/column', selected: true },
+					],
+				},
+				{ name: 'core/file', selected: false, focused: false },
+			] );
+		// Select next parent.
+		await pageUtils.pressKeys( 'primary+a' );
+		await expect
+			.poll(
+				listViewUtils.getBlocksWithA11yAttributes,
+				'The columns block should be selected and focused.'
+			)
+			.toMatchObject( [
+				{ name: 'core/group' },
+				{
+					name: 'core/columns',
+					innerBlocks: [
+						{
+							name: 'core/column',
+							innerBlocks: [
+								{ name: 'core/heading' },
+								{
+									name: 'core/paragraph',
+								},
+							],
+						},
+						{ name: 'core/column' },
+					],
+					selected: true,
+					focused: true,
+				},
+				{ name: 'core/file', selected: false, focused: false },
+			] );
+
+		// Select all siblings at root level.
+		await pageUtils.pressKeys( 'primary+a' );
+		await expect
+			.poll(
+				listViewUtils.getBlocksWithA11yAttributes,
+				'All blocks should be selected.'
+			)
+			.toMatchObject( [
+				{ name: 'core/group', selected: true, focused: false },
+				{
+					name: 'core/columns',
+					innerBlocks: [
+						{
+							name: 'core/column',
+							innerBlocks: [
+								{ name: 'core/heading' },
+								{
+									name: 'core/paragraph',
+								},
+							],
+						},
+						{ name: 'core/column' },
+					],
+					selected: true,
+					focused: true,
+				},
+				{ name: 'core/file', selected: true, focused: false },
+			] );
+
+		// Deselect blocks via Escape key.
+		await page.keyboard.press( 'Escape' );
+		// Collapse the column block and the columns block.
+		await page.keyboard.press( 'ArrowDown' );
+		await page.keyboard.press( 'ArrowLeft' );
+		await page.keyboard.press( 'ArrowUp' );
+		await page.keyboard.press( 'ArrowLeft' );
+
+		await expect
+			.poll(
+				listViewUtils.getBlocksWithA11yAttributes,
+				'All blocks should be deselected, with focus on the Columns block.'
+			)
+			.toMatchObject( [
+				{ name: 'core/group', selected: false, focused: false },
+				{
+					name: 'core/columns',
+					selected: false,
+					focused: true,
+				},
+				{ name: 'core/file', selected: false, focused: false },
+			] );
+
+		// Move focus and selection to the file block to set up for testing duplication.
+		await listView
+			.getByRole( 'gridcell', { name: 'File', exact: true } )
+			.dblclick();
+
+		// Test duplication behaviour.
 		await pageUtils.pressKeys( 'primaryShift+d' );
 
 		await expect

--- a/test/e2e/specs/editor/various/list-view.spec.js
+++ b/test/e2e/specs/editor/various/list-view.spec.js
@@ -464,101 +464,29 @@ test.describe( 'List View', () => {
 				{ name: 'core/file', selected: true, focused: true },
 			] );
 
-		// Move up to the paragraph block in the first column block.
-		// Expand children to get to the deeply nested paragraph block.
+		// Move up to columns block, expand, and then move to the first column block.
 		await page.keyboard.press( 'ArrowUp' );
 		await page.keyboard.press( 'ArrowRight' );
-		await page.keyboard.press( 'ArrowDown' );
-		await page.keyboard.press( 'ArrowRight' );
-		await page.keyboard.press( 'ArrowDown' );
 		await page.keyboard.press( 'ArrowDown' );
 
 		await expect
 			.poll(
 				listViewUtils.getBlocksWithA11yAttributes,
-				'The last inserted block should be selected, while the deeply nested paragraph block should be focused.'
+				'The last inserted block should be selected, while the first column block should be focused.'
 			)
 			.toMatchObject( [
 				{ name: 'core/group' },
 				{
 					name: 'core/columns',
 					innerBlocks: [
-						{
-							name: 'core/column',
-							innerBlocks: [
-								{ name: 'core/heading' },
-								{
-									name: 'core/paragraph',
-									selected: false,
-									focused: true,
-								},
-							],
-						},
+						{ name: 'core/column', selected: false, focused: true },
 						{ name: 'core/column' },
 					],
 				},
 				{ name: 'core/file', selected: true, focused: false },
 			] );
 
-		// Select all siblings at the current level.
-		await pageUtils.pressKeys( 'primary+a' );
-		await expect
-			.poll(
-				listViewUtils.getBlocksWithA11yAttributes,
-				'The deeply nested paragraph block should be selected, along with its sibling heading.'
-			)
-			.toMatchObject( [
-				{ name: 'core/group' },
-				{
-					name: 'core/columns',
-					innerBlocks: [
-						{
-							name: 'core/column',
-							innerBlocks: [
-								{ name: 'core/heading', selected: true },
-								{
-									name: 'core/paragraph',
-									selected: true,
-									focused: true,
-								},
-							],
-						},
-						{ name: 'core/column' },
-					],
-				},
-				{ name: 'core/file', selected: false, focused: false },
-			] );
-
-		// Select next parent.
-		await pageUtils.pressKeys( 'primary+a' );
-		await expect
-			.poll(
-				listViewUtils.getBlocksWithA11yAttributes,
-				'The first column block should be selected and focused.'
-			)
-			.toMatchObject( [
-				{ name: 'core/group' },
-				{
-					name: 'core/columns',
-					innerBlocks: [
-						{
-							name: 'core/column',
-							innerBlocks: [
-								{ name: 'core/heading' },
-								{
-									name: 'core/paragraph',
-								},
-							],
-							selected: true,
-							focused: true,
-						},
-						{ name: 'core/column', selected: false },
-					],
-				},
-				{ name: 'core/file', selected: false, focused: false },
-			] );
-
-		// Select all siblings at current level.
+		// Select all sibling column blocks at current level.
 		await pageUtils.pressKeys( 'primary+a' );
 		await expect
 			.poll(
@@ -570,23 +498,15 @@ test.describe( 'List View', () => {
 				{
 					name: 'core/columns',
 					innerBlocks: [
-						{
-							name: 'core/column',
-							innerBlocks: [
-								{ name: 'core/heading' },
-								{
-									name: 'core/paragraph',
-								},
-							],
-							selected: true,
-							focused: true,
-						},
-						{ name: 'core/column', selected: true },
+						{ name: 'core/column', selected: true, focused: true },
+						{ name: 'core/column', selected: true, focused: false },
 					],
+					selected: false,
 				},
 				{ name: 'core/file', selected: false, focused: false },
 			] );
-		// Select next parent.
+
+		// Select next parent (the columns block).
 		await pageUtils.pressKeys( 'primary+a' );
 		await expect
 			.poll(
@@ -598,15 +518,7 @@ test.describe( 'List View', () => {
 				{
 					name: 'core/columns',
 					innerBlocks: [
-						{
-							name: 'core/column',
-							innerBlocks: [
-								{ name: 'core/heading' },
-								{
-									name: 'core/paragraph',
-								},
-							],
-						},
+						{ name: 'core/column' },
 						{ name: 'core/column' },
 					],
 					selected: true,
@@ -627,15 +539,7 @@ test.describe( 'List View', () => {
 				{
 					name: 'core/columns',
 					innerBlocks: [
-						{
-							name: 'core/column',
-							innerBlocks: [
-								{ name: 'core/heading' },
-								{
-									name: 'core/paragraph',
-								},
-							],
-						},
+						{ name: 'core/column' },
 						{ name: 'core/column' },
 					],
 					selected: true,
@@ -646,10 +550,7 @@ test.describe( 'List View', () => {
 
 		// Deselect blocks via Escape key.
 		await page.keyboard.press( 'Escape' );
-		// Collapse the column block and the columns block.
-		await page.keyboard.press( 'ArrowDown' );
-		await page.keyboard.press( 'ArrowLeft' );
-		await page.keyboard.press( 'ArrowUp' );
+		// Collapse the columns block.
 		await page.keyboard.press( 'ArrowLeft' );
 
 		await expect

--- a/test/e2e/specs/editor/various/list-view.spec.js
+++ b/test/e2e/specs/editor/various/list-view.spec.js
@@ -494,7 +494,7 @@ test.describe( 'List View', () => {
 				'All column blocks should be selected, with the first one focused.'
 			)
 			.toMatchObject( [
-				{ name: 'core/group' },
+				{ name: 'core/group', selected: false, focused: false },
 				{
 					name: 'core/columns',
 					innerBlocks: [
@@ -514,7 +514,7 @@ test.describe( 'List View', () => {
 				'The columns block should be selected and focused.'
 			)
 			.toMatchObject( [
-				{ name: 'core/group' },
+				{ name: 'core/group', selected: false, focused: false },
 				{
 					name: 'core/columns',
 					innerBlocks: [


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Part of: https://github.com/WordPress/gutenberg/issues/49563

Within the list view, add handling for the keyboard shortcut to select all blocks (CMD+A on Mac, CTRL+A on Windows).

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

While navigating around the list view via keyboard, it could be handy for users to be able to quickly select all blocks via CMD+A on Mac / CTRL+A on Windows.

The approach in this PR follows that used in the editor canvas, where each press of CMD+A / CTRL+A moves one level up the block hierarchy until all blocks are selected.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Add in similar handling to what's used in the editor canvas for `'core/block-editor/select-all'` and select all blocks when that keyboard shortcut is used.

This approach will first select all siblings at the current level of the hierarchy, and will then iteratively move up the block hierarchy with each subsequent press of the keyboard shortcut until eventually all blocks are selected.

<!-- 

## To-do

* [x] ~Investigate performance issue with selecting all blocks on posts with heaps of blocks (e.g. > 150 blocks) — PR to fix this is open in: https://github.com/WordPress/gutenberg/pull/54900~
* [x] ~Move up the block hierarchy, using a similar approach as to that used in https://github.com/WordPress/gutenberg/pull/31859/~
* [x] ~Fix bug when user is focused elsewhere in the list and the focused block has the same number of blocks as the current block selection — in this case it can erroneously move up the hierarchy when you don't expect it to~
* [x] Add e2e test coverage

-->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Add some blocks to a post, with various levels of nesting
2. Open the list view and shift focus to the list view (e.g. by clicking a paragraph block twice in the list)
3. Press CMD+A (on Mac) or CTRL+A (on Windows) to select all blocks from a block at the root of the document
4. Deselect blocks (i.e. via Escape key).
5. Select and focus a block within the list view that is at a particular level of nesting. Try selecting all blocks, and it should select either all blocks at the current nesting level, or move one level up the hierarchy if all sibling blocks are already selected. Subsequent presses should continue selecting up the hierarchy.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

1. As above, but an additional thing to test via keyboard is to select multiple blocks in one part of the document and then navigate up or down the list view via keyboard so that you are focused on nested blocks that aren't a part of the block selection.
2. When you press CMD+A / CTRL+A it should select the block you have focused and all its siblings, instead of expanding the current block selection.

## Screenshots or screencast <!-- if applicable -->

Screengrab of selecting up the hierarchy:

https://github.com/WordPress/gutenberg/assets/14988353/a4328496-a49c-4da3-b7b0-763cf0eb381a

<!--
Works pretty well so far in shorter posts:

https://github.com/WordPress/gutenberg/assets/14988353/b8427901-6692-419d-acc4-9d430fc93d8d

Big slowdown for posts with heaps of blocks — this will need some investigating. In the following screengrab, there are 184 blocks in the post, and the selection takes around 8 seconds to perform 😬

https://github.com/WordPress/gutenberg/assets/14988353/a7e504b0-b9ac-4ee5-a979-f6c01d62e594

-->