### PR TITLE
List View: Fix performance issue when selecting all blocks

### DIFF
--- a/packages/block-editor/src/components/list-view/block.js
+++ b/packages/block-editor/src/components/list-view/block.js
@@ -13,16 +13,9 @@ import {
 } from '@wordpress/components';
 import { useInstanceId } from '@wordpress/compose';
 import { moreVertical } from '@wordpress/icons';
-import {
-	useState,
-	useRef,
-	useEffect,
-	useCallback,
-	memo,
-} from '@wordpress/element';
+import { useState, useRef, useCallback, memo } from '@wordpress/element';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { sprintf, __ } from '@wordpress/i18n';
-import { focus } from '@wordpress/dom';
 import { ESCAPE } from '@wordpress/keycodes';
 
 /**
@@ -36,7 +29,7 @@ import {
 } from '../block-mover/button';
 import ListViewBlockContents from './block-contents';
 import { useListViewContext } from './context';
-import { getBlockPositionDescription } from './utils';
+import { getBlockPositionDescription, focusListItem } from './utils';
 import { store as blockEditorStore } from '../../store';
 import useBlockDisplayInformation from '../use-block-display-information';
 import { useBlockLock } from '../block-lock';
@@ -120,7 +113,6 @@ function ListViewBlock( {
 	);
 
 	const {
-		isTreeGridMounted,
 		expand,
 		collapse,
 		BlockSettingsMenu,
@@ -141,15 +133,6 @@ function ListViewBlock( {
 		'block-editor-list-view-block__menu-cell',
 		{ 'is-visible': isHovered || isFirstSelectedBlock }
 	);
-
-	// If ListView has experimental features related to the Persistent List View,
-	// only focus the selected list item on mount; otherwise the list would always
-	// try to steal the focus from the editor canvas.
-	useEffect( () => {
-		if ( ! isTreeGridMounted && isSelected ) {
-			cellRef.current.focus();
-		}
-	}, [] );
 
 	// If multiple blocks are selected, deselect all blocks when the user
 	// presses the escape key.
@@ -188,30 +171,7 @@ function ListViewBlock( {
 				selectBlock( undefined, focusClientId, null, null );
 			}
 
-			const getFocusElement = () => {
-				const row = treeGridElementRef.current?.querySelector(
-					`[role=row][data-block="${ focusClientId }"]`
-				);
-				if ( ! row ) return null;
-				// Focus the first focusable in the row, which is the ListViewBlockSelectButton.
-				return focus.focusable.find( row )[ 0 ];
-			};
-
-			let focusElement = getFocusElement();
-			if ( focusElement ) {
-				focusElement.focus();
-			} else {
-				// The element hasn't been painted yet. Defer focusing on the next frame.
-				// This could happen when all blocks have been deleted and the default block
-				// hasn't been added to the editor yet.
-				window.requestAnimationFrame( () => {
-					focusElement = getFocusElement();
-					// Ignore if the element still doesn't exist.
-					if ( focusElement ) {
-						focusElement.focus();
-					}
-				} );
-			}
+			focusListItem( focusClientId, treeGridElementRef );
 		},
 		[ selectBlock, treeGridElementRef ]
 	);

--- a/packages/block-editor/src/components/list-view/branch.js
+++ b/packages/block-editor/src/components/list-view/branch.js
@@ -128,7 +128,7 @@ function ListViewBranch( props ) {
 	// The appender means an extra row in List View, so add 1 to the row count.
 	const rowCount = showAppender ? blockCount + 1 : blockCount;
 	let nextPosition = listPosition;
-	const singleBlockSelection = selectedClientIds?.length === 1;
+	const isSingleBlockSelection = selectedClientIds?.length === 1;
 
 	return (
 		<>
@@ -169,11 +169,18 @@ function ListViewBranch( props ) {
 				);
 				const isSelectedBranch =
 					isBranchSelected || ( isSelected && hasNestedBlocks );
+
+				// To avoid performance issues, we only render blocks that are
+				// in view, or blocks that are selected or dragged.
+				// If a block is selected, it is only counted if it is the only
+				// block selected. This prevents the entire tree from being
+				// rendered when a branch is selected, or a user selects all blocks,
+				// while still enabling scroll into view behavior when selecting a block.
 				const showBlock =
 					isDragged ||
 					blockInView ||
 					isBranchDragged ||
-					( isSelected && singleBlockSelection );
+					( isSelected && isSingleBlockSelection );
 				return (
 					<AsyncModeProvider key={ clientId } value={ ! isSelected }>
 						{ showBlock && (

--- a/packages/block-editor/src/components/list-view/branch.js
+++ b/packages/block-editor/src/components/list-view/branch.js
@@ -128,6 +128,7 @@ function ListViewBranch( props ) {
 	// The appender means an extra row in List View, so add 1 to the row count.
 	const rowCount = showAppender ? blockCount + 1 : blockCount;
 	let nextPosition = listPosition;
+	const singleBlockSelection = selectedClientIds?.length === 1;
 
 	return (
 		<>
@@ -169,7 +170,10 @@ function ListViewBranch( props ) {
 				const isSelectedBranch =
 					isBranchSelected || ( isSelected && hasNestedBlocks );
 				const showBlock =
-					isDragged || blockInView || isSelected || isBranchDragged;
+					isDragged ||
+					blockInView ||
+					isBranchDragged ||
+					( isSelected && singleBlockSelection );
 				return (
 					<AsyncModeProvider key={ clientId } value={ ! isSelected }>
 						{ showBlock && (

--- a/packages/block-editor/src/components/list-view/branch.js
+++ b/packages/block-editor/src/components/list-view/branch.js
@@ -128,7 +128,6 @@ function ListViewBranch( props ) {
 	// The appender means an extra row in List View, so add 1 to the row count.
 	const rowCount = showAppender ? blockCount + 1 : blockCount;
 	let nextPosition = listPosition;
-	const isSingleBlockSelection = selectedClientIds?.length === 1;
 
 	return (
 		<>
@@ -170,17 +169,17 @@ function ListViewBranch( props ) {
 				const isSelectedBranch =
 					isBranchSelected || ( isSelected && hasNestedBlocks );
 
-				// To avoid performance issues, we only render blocks that are
-				// in view, or blocks that are selected or dragged.
-				// If a block is selected, it is only counted if it is the only
-				// block selected. This prevents the entire tree from being
-				// rendered when a branch is selected, or a user selects all blocks,
-				// while still enabling scroll into view behavior when selecting a block.
+				// To avoid performance issues, we only render blocks that are in view,
+				// or blocks that are selected or dragged. If a block is selected,
+				// it is only counted if it is the first of the block selection.
+				// This prevents the entire tree from being rendered when a branch is
+				// selected, or a user selects all blocks, while still enabling scroll
+				// into view behavior when selecting a block or opening the list view.
 				const showBlock =
 					isDragged ||
 					blockInView ||
 					isBranchDragged ||
-					( isSelected && isSingleBlockSelection );
+					( isSelected && clientId === selectedClientIds[ 0 ] );
 				return (
 					<AsyncModeProvider key={ clientId } value={ ! isSelected }>
 						{ showBlock && (

--- a/packages/block-editor/src/components/list-view/index.js
+++ b/packages/block-editor/src/components/list-view/index.js
@@ -32,6 +32,7 @@ import useListViewDropZone from './use-list-view-drop-zone';
 import useListViewExpandSelectedItem from './use-list-view-expand-selected-item';
 import { store as blockEditorStore } from '../../store';
 import { BlockSettingsDropdown } from '../block-settings-menu/block-settings-dropdown';
+import { focusListItem } from './utils';
 
 const expanded = ( state, action ) => {
 	if ( Array.isArray( action.clientIds ) ) {
@@ -132,8 +133,6 @@ function ListViewComponent(
 	const elementRef = useRef();
 	const treeGridRef = useMergeRefs( [ elementRef, dropZoneRef, ref ] );
 
-	const isMounted = useRef( false );
-
 	const [ insertedBlock, setInsertedBlock ] = useState( null );
 
 	const { setSelectedTreeId } = useListViewExpandSelectedItem( {
@@ -156,7 +155,13 @@ function ListViewComponent(
 		[ setSelectedTreeId, updateBlockSelection, onSelect, getBlock ]
 	);
 	useEffect( () => {
-		isMounted.current = true;
+		// If a blocks are already selected when the list view is initially
+		// mounted, shift focus to the first selected block.
+		if ( selectedClientIds?.length ) {
+			focusListItem( selectedClientIds[ 0 ], elementRef );
+		}
+		// Disable reason: Only focus on the selected item when the list view is mounted.
+		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [] );
 
 	const expand = useCallback(
@@ -204,7 +209,6 @@ function ListViewComponent(
 
 	const contextValue = useMemo(
 		() => ( {
-			isTreeGridMounted: isMounted.current,
 			draggedClientIds,
 			expandedState,
 			expand,

--- a/packages/block-editor/src/components/list-view/utils.js
+++ b/packages/block-editor/src/components/list-view/utils.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
+import { focus } from '@wordpress/dom';
 
 export const getBlockPositionDescription = ( position, siblingCount, level ) =>
 	sprintf(
@@ -55,4 +56,40 @@ export function getCommonDepthClientIds(
 		start,
 		end,
 	};
+}
+
+/**
+ * Shift focus to the list view item associated with a particular clientId.
+ *
+ * @typedef {import('@wordpress/element').RefObject} RefObject
+ *
+ * @param {string}                 focusClientId      The client ID of the block to focus.
+ * @param {RefObject<HTMLElement>} treeGridElementRef The container element to search within.
+ */
+export function focusListItem( focusClientId, treeGridElementRef ) {
+	const getFocusElement = () => {
+		const row = treeGridElementRef.current?.querySelector(
+			`[role=row][data-block="${ focusClientId }"]`
+		);
+		if ( ! row ) return null;
+		// Focus the first focusable in the row, which is the ListViewBlockSelectButton.
+		return focus.focusable.find( row )[ 0 ];
+	};
+
+	let focusElement = getFocusElement();
+	if ( focusElement ) {
+		focusElement.focus();
+	} else {
+		// The element hasn't been painted yet. Defer focusing on the next frame.
+		// This could happen when all blocks have been deleted and the default block
+		// hasn't been added to the editor yet.
+		window.requestAnimationFrame( () => {
+			focusElement = getFocusElement();
+
+			// Ignore if the element still doesn't exist.
+			if ( focusElement ) {
+				focusElement.focus();
+			}
+		} );
+	}
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Part of: https://github.com/WordPress/gutenberg/issues/49563

Fix a performance issue with the List View when selecting all blocks within the editor canvas, with the list view open. For long posts or pages, the current performance issue means it will likely feel broken as it can take many seconds to apply the selection.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

<!--
Currently, when a user goes to select all blocks from the editor canvas (press CMD+A a couple of times from within the editor canvas), if the list view is open, it can be very slow to update on a long post or page. This is because if the post is long enough to invoke the windowing logic for the list view, then currently changing the block selection will cause the non-displayed list view items to all be swapped out for real list view items, resulting in many hundreds of components being mounted.

The existing rule to render "real" list view items for selected blocks even if they're outside the list view window was introduced back in https://github.com/WordPress/gutenberg/pull/46895. The reason it was introduced was so that if a user selects a single block that is outside the current window (e.g. if the list view is scrolled to the top and a user selects a nested block at the very bottom of the post) then the "scroll into view" behaviour still needs to fire. This can only occur if the real list view item is used.

However, we don't need _all_ selected blocks to be rendered in order for that to work, just the one will do. Switching over to only rendering a selected block if it's outside the window if it's the only selected block, appears to do the trick. -->

There are two related performance issues on `trunk` that affect this behaviour:

* Currently all selected blocks are rendered as "real" list view items, bypassing the windowing logic, which means that there are unnecessary renders / mounts of selected blocks.
* The block item (`ListViewBlock`) is currently responsible for directing focus to it when the list view is mounted. Because it occurs at the block item level, it is possible for dozens of calls to competing `cellRef.current.focus()` to occur at once, causing the editor to slow down until they are all complete.

The result of these two issues interacting is that when you select all blocks with the list view open, (or go to open the list view after selecting all blocks), the list view slows to a crawl until all the `.focus()` calls have completed.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

1. Only render list view items for selected blocks that exist outside the current windowing logic if it is the first of the block selection. This prevents a large amount of re-rendering / re-mounting when a user goes to select all blocks.
2. Move the focus logic up to the list view root, so that it is only fired once, irrespective of the number of list view items rendered. To do so, I've moved the existing logic for focusing a list view item to a shared function in `utils` (the logic was introduced back in https://github.com/WordPress/gutenberg/issues/50422).

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Add a post or page with heaps of blocks (e.g. for testing that makes all this clear, add > 150 paragraphs)
3. Ensure the list view is open
4. Focus somewhere within a block in the editor canvas
5. Press CMD+A once to select all of that block. Press CMD+A again to select all blocks (if you're in a nested block, it'll just select the parent — keep pressing to eventually select all blocks, one level of hierarchy at a time)
6. If you're on `trunk`, it'll take a _long_ time to select all blocks in a long post or page
7. With this PR applied, it should take under a second to select all blocks. Maybe not snappy, but fast enough that it doesn't feel broken
8. Ensure scrolling up and down the list view remains performant (there'll still be a slight delay rendering items, caused by the windowing logic, but there shouldn't be any big slowdowns)

Assuming all this is working okay for this PR, we then need to make sure that we haven't broken the scroll into view logic when single block selection changes (introduced in https://github.com/WordPress/gutenberg/pull/46895). Follow the testing instructions from that PR:

> In a really long post or page, with the list view opened, scroll the editor canvas to far down the page or post and select a block outside of the currently visible area within the list view. The list view should scroll the selected block into view.
> To test the windowed area versus the non-windowed area, add a very large number of blocks (e.g. 60+) and try selecting from the very top block to the very bottom block in the list, via the editor canvas.

Finally, double check that focus still appears to be correct when deleting blocks via the list view (with an item in the list view focused, press the Backspace key).

## Screenshots or screencast <!-- if applicable -->

Note: the List View must be open to test out this performance issue.

The following screengrabs are from a post containing 203 blocks. The first press of CMD+A works quickly to select the individual block. It's the second press of CMD+A to select all blocks that's the problem here!

### Before (takes 8 seconds or so to select all)

https://github.com/WordPress/gutenberg/assets/14988353/700f8d73-4194-4f44-b635-f5b08604b3c4

### After (takes < 1 second to select all)

https://github.com/WordPress/gutenberg/assets/14988353/9cf84750-b9f4-45e4-9267-ee9e3ec562ac

