### PR TITLE
Make `editor.getBlocks` to return only testing-related properties

### DIFF
--- a/packages/e2e-test-utils-playwright/src/editor/get-blocks.ts
+++ b/packages/e2e-test-utils-playwright/src/editor/get-blocks.ts
@@ -3,25 +3,49 @@
  */
 import type { Editor } from './index';
 
+type Block = {
+	name: string;
+	attributes: Record< string, unknown >;
+	innerBlocks: Block[];
+};
+
 /**
  * Returns the edited blocks.
  *
  * @param this
+ * @param options
+ * @param options.full Whether to return the full block data or just the name and attributes.
  *
  * @return  The blocks.
  */
-export async function getBlocks( this: Editor ) {
-	return await this.page.evaluate( () => {
-		const blocks = window.wp.data.select( 'core/block-editor' ).getBlocks();
+export async function getBlocks( this: Editor, { full = false } = {} ) {
+	return await this.page.evaluate(
+		( [ _full ] ) => {
+			// Remove other unpredictable properties like clientId from blocks for testing purposes.
+			function recursivelyTransformBlocks( blocks: Block[] ): Block[] {
+				return blocks.map( ( block ) => ( {
+					name: block.name,
+					attributes: block.attributes,
+					innerBlocks: recursivelyTransformBlocks(
+						block.innerBlocks
+					),
+				} ) );
+			}
 
-		// The editor might still contain an unmodified empty block even when it's technically "empty".
-		if (
-			blocks.length === 1 &&
-			window.wp.blocks.isUnmodifiedDefaultBlock( blocks[ 0 ] )
-		) {
-			return [];
-		}
+			const blocks = window.wp.data
+				.select( 'core/block-editor' )
+				.getBlocks();
 
-		return blocks;
-	} );
+			// The editor might still contain an unmodified empty block even when it's technically "empty".
+			if (
+				blocks.length === 1 &&
+				window.wp.blocks.isUnmodifiedDefaultBlock( blocks[ 0 ] )
+			) {
+				return [];
+			}
+
+			return _full ? blocks : recursivelyTransformBlocks( blocks );
+		},
+		[ full ]
+	);
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
As suggested by @ellatrix in a private conversation some time ago, we probably don't need `getBlocks` to return `clientId` and other properties for testing purposes.

A recent encounter is https://github.com/WordPress/gutenberg/pull/54892#discussion_r1339563443.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
This is going to make `editor.getBlocks` slightly more helpful in some situations that we can just compare using `toEqual` rather than having to get rid of `clientId` first.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Recursively transform the blocks before returning. A `full` option can be passed if the users want to retain the previous behavior.

Another idea would be to allow comparing blocks with consideration of the default attributes' values. That would be probably be better suited in a different PR though.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
CI should pass.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
N/A

## Screenshots or screencast <!-- if applicable -->
N/A