### PR TITLE
Tidying `CircularOptionPicker.Option`

### DIFF
--- a/packages/block-editor/src/components/color-palette/test/__snapshots__/control.js.snap
+++ b/packages/block-editor/src/components/color-palette/test/__snapshots__/control.js.snap
@@ -218,7 +218,7 @@ exports[`ColorPaletteControl matches the snapshot 1`] = `
                         <button
                           aria-label="Color: red"
                           aria-selected="true"
-                          class="components-button components-circular-option-picker__option is-pressed"
+                          class="components-button components-circular-option-picker__option"
                           id="components-circular-option-picker-0-0"
                           role="option"
                           style="background-color: rgb(255, 0, 0); color: rgb(255, 0, 0);"

--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -309,7 +309,8 @@
 
 	// Toggled style.
 	&[aria-pressed="true"],
-	&[aria-pressed="mixed"] {
+	&[aria-pressed="mixed"],
+	&[aria-selected="true"] {
 		color: $components-color-foreground-inverted;
 		background: $components-color-foreground;
 

--- a/packages/components/src/circular-option-picker/circular-option-picker-option.tsx
+++ b/packages/components/src/circular-option-picker/circular-option-picker-option.tsx
@@ -34,7 +34,14 @@ function UnforwardedOptionAsButton(
 	},
 	forwardedRef: ForwardedRef< any >
 ) {
-	return <Button { ...props } ref={ forwardedRef }></Button>;
+	const { isPressed, ...additionalProps } = props;
+	return (
+		<Button
+			{ ...additionalProps }
+			aria-pressed={ isPressed }
+			ref={ forwardedRef }
+		></Button>
+	);
 }
 
 const OptionAsButton = forwardRef( UnforwardedOptionAsButton );
@@ -48,7 +55,7 @@ function UnforwardedOptionAsOption(
 	},
 	forwardedRef: ForwardedRef< any >
 ) {
-	const { id, className, isSelected, context, ...additionalProps } = props;
+	const { id, isSelected, context, ...additionalProps } = props;
 	const { isComposite, ..._compositeState } = context;
 	const compositeState =
 		_compositeState as CircularOptionPickerCompositeState;
@@ -73,15 +80,6 @@ function UnforwardedOptionAsOption(
 			{ ...compositeState }
 			as={ Button }
 			id={ id }
-			// Ideally we'd let the underlying `Button` component
-			// handle this by passing `isPressed` as a prop.
-			// Unfortunately doing so also sets `aria-pressed` as
-			// an attribute on the element, which is incompatible
-			// with `role="option"`, and there is no way at this
-			// point to override that behaviour.
-			className={ classnames( className, {
-				'is-pressed': isSelected,
-			} ) }
 			role="option"
 			aria-selected={ !! isSelected }
 			ref={ forwardedRef }

--- a/packages/components/src/circular-option-picker/style.scss
+++ b/packages/components/src/circular-option-picker/style.scss
@@ -83,7 +83,8 @@ $color-palette-circle-spacing: 12px;
 		box-shadow: inset 0 0 0 ($color-palette-circle-size * 0.5) !important;
 	}
 
-	&.is-pressed {
+	&[aria-pressed="true"],
+	&[aria-selected="true"] {
 		box-shadow: inset 0 0 0 4px;
 		position: relative;
 		z-index: z-index(".components-circular-option-picker__option.is-pressed");


### PR DESCRIPTION
## What?
This PR removes some now-defunct styling workarounds from `CircularOptionPicker.Option`, and normalises style application between it and `Button`.

## Why?
Before `Button` was refactored in #54740, it was necessary to explicitly add an `is-pressed` class to the `CircularOptionPicker.Option`, to avoid using `isPressed` which automatically added `aria-pressed`. With those changes, and the refactor here, `is-pressed` is no longer necessary as a class for `CircularOptionPicker.Option`, so the workaround isn't necessary.

## How?
The dependency on the `is-pressed` class is removed from `CircularOptionPicker.Option` instead using the `aria-selected`/`aria-pressed` attribute directly.

`aria-selected` is also added to `Button` to ensure styling is normalised for other consumers.

## Testing Instructions
There should be no visual changes, either in `Button` or `CircularOptionPicker`. Both of these components can be checked in StoryBook.

### Testing Instructions for Keyboard
There should be no interaction changes to either `Button` or `CircularOptionPicker`.
