### PR TITLE
Block Editor: Expose `getDuotoneFilter()` as private API

### DIFF
--- a/packages/block-editor/src/private-apis.js
+++ b/packages/block-editor/src/private-apis.js
@@ -24,6 +24,7 @@ import {
 } from './components/inserter/reusable-block-rename-hint';
 import { usesContextKey } from './components/rich-text/format-edit';
 import { ExperimentalBlockCanvas } from './components/block-canvas';
+import { getDuotoneFilter } from './components/duotone/utils';
 
 /**
  * Private @wordpress/block-editor APIs.
@@ -33,6 +34,7 @@ lock( privateApis, {
 	...globalStyles,
 	ExperimentalBlockCanvas,
 	ExperimentalBlockEditorProvider,
+	getDuotoneFilter,
 	getRichTextValues,
 	kebabCase,
 	PrivateInserter,


### PR DESCRIPTION
## What?
This PR exposes the `getDuotoneFilter()` utility as a private API.

## Why?
It was previously exposed as `__unstablePresetDuotoneFilter`, however since #52888 refactored `PresetDuotoneFilter` to `getDuotoneFilter()`, that was never exposed again. 

The `__unstablePresetDuotoneFilter` was used in external consumers of the `@wordpress/block-editor` package and ideally, we'd like to be able to port to the new version.
 
## How?
We're just adding `getDuotoneFilter()` to the list of private APIs of the package.

## Testing Instructions
All checks should be green.

### Testing Instructions for Keyboard
None.

## Screenshots or screencast <!-- if applicable -->
None.