### PR TITLE
ESLint: Update eslint-plugin-testing-library to v6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -186,7 +186,7 @@
 				"eslint-plugin-prettier": "5.0.0",
 				"eslint-plugin-ssr-friendly": "1.0.6",
 				"eslint-plugin-storybook": "0.6.13",
-				"eslint-plugin-testing-library": "5.7.2",
+				"eslint-plugin-testing-library": "6.0.2",
 				"execa": "4.0.2",
 				"fast-glob": "3.2.7",
 				"filenamify": "4.2.0",
@@ -29940,12 +29940,12 @@
 			}
 		},
 		"node_modules/eslint-plugin-testing-library": {
-			"version": "5.7.2",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-testing-library/-/eslint-plugin-testing-library-5.7.2.tgz",
-			"integrity": "sha512-0ZmHeR/DUUgEzW8rwUBRWxuqntipDtpvxK0hymdHnLlABryJkzd+CAHr+XnISaVsTisZ5MLHp6nQF+8COHLLTA==",
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-testing-library/-/eslint-plugin-testing-library-6.0.2.tgz",
+			"integrity": "sha512-3BV6FWtLbpKFb4Y1obSdt8PC9xSqz6T+7EHB/6pSCXqVjKPoS67ck903feKMKQphd5VhrX+N51yHuVaPa7elsw==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/utils": "^5.13.0"
+				"@typescript-eslint/utils": "^5.58.0"
 			},
 			"engines": {
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0",
@@ -83265,12 +83265,12 @@
 			}
 		},
 		"eslint-plugin-testing-library": {
-			"version": "5.7.2",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-testing-library/-/eslint-plugin-testing-library-5.7.2.tgz",
-			"integrity": "sha512-0ZmHeR/DUUgEzW8rwUBRWxuqntipDtpvxK0hymdHnLlABryJkzd+CAHr+XnISaVsTisZ5MLHp6nQF+8COHLLTA==",
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-testing-library/-/eslint-plugin-testing-library-6.0.2.tgz",
+			"integrity": "sha512-3BV6FWtLbpKFb4Y1obSdt8PC9xSqz6T+7EHB/6pSCXqVjKPoS67ck903feKMKQphd5VhrX+N51yHuVaPa7elsw==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/utils": "^5.13.0"
+				"@typescript-eslint/utils": "^5.58.0"
 			}
 		},
 		"eslint-scope": {

--- a/package.json
+++ b/package.json
@@ -198,7 +198,7 @@
 		"eslint-plugin-prettier": "5.0.0",
 		"eslint-plugin-ssr-friendly": "1.0.6",
 		"eslint-plugin-storybook": "0.6.13",
-		"eslint-plugin-testing-library": "5.7.2",
+		"eslint-plugin-testing-library": "6.0.2",
 		"execa": "4.0.2",
 		"fast-glob": "3.2.7",
 		"filenamify": "4.2.0",

--- a/packages/block-library/src/cover/test/edit.js
+++ b/packages/block-library/src/cover/test/edit.js
@@ -260,7 +260,7 @@ describe( 'Cover block', () => {
 				} )
 			);
 			expect(
-				within( screen.queryByLabelText( 'Block: Cover' ) ).queryByRole(
+				within( screen.getByLabelText( 'Block: Cover' ) ).queryByRole(
 					'img'
 				)
 			).not.toBeInTheDocument();

--- a/packages/components/src/combobox-control/test/index.tsx
+++ b/packages/components/src/combobox-control/test/index.tsx
@@ -56,7 +56,6 @@ const getOption = ( name: string ) => screen.getByRole( 'option', { name } );
 const getAllOptions = () => screen.getAllByRole( 'option' );
 const getOptionSearchString = ( option: ComboboxControlOption ) =>
 	option.label.substring( 0, 11 );
-const setupUser = () => userEvent.setup();
 
 const ControlledComboboxControl = ( {
 	value: valueProp,
@@ -112,7 +111,7 @@ describe.each( [
 	} );
 
 	it( 'should render with the correct options', async () => {
-		const user = setupUser();
+		const user = await userEvent.setup();
 		render(
 			<Component options={ timezones } label={ defaultLabelText } />
 		);
@@ -133,7 +132,7 @@ describe.each( [
 	} );
 
 	it( 'should select the correct option via click events', async () => {
-		const user = setupUser();
+		const user = await userEvent.setup();
 		const targetOption = timezones[ 2 ];
 		const onChangeSpy = jest.fn();
 		render(
@@ -157,7 +156,7 @@ describe.each( [
 	} );
 
 	it( 'should select the correct option via keypress events', async () => {
-		const user = setupUser();
+		const user = await userEvent.setup();
 		const targetIndex = 4;
 		const targetOption = timezones[ targetIndex ];
 		const onChangeSpy = jest.fn();
@@ -187,7 +186,7 @@ describe.each( [
 	} );
 
 	it( 'should select the correct option from a search', async () => {
-		const user = setupUser();
+		const user = await userEvent.setup();
 		const targetOption = timezones[ 13 ];
 		const onChangeSpy = jest.fn();
 		render(
@@ -214,7 +213,7 @@ describe.each( [
 	} );
 
 	it( 'should render aria-live announcement upon selection', async () => {
-		const user = setupUser();
+		const user = await userEvent.setup();
 		const targetOption = timezones[ 9 ];
 		const onChangeSpy = jest.fn();
 		render(
@@ -242,7 +241,7 @@ describe.each( [
 	} );
 
 	it( 'should process multiple entries in a single session', async () => {
-		const user = setupUser();
+		const user = await userEvent.setup();
 		const unmatchedString = 'Mordor';
 		const targetOption = timezones[ 6 ];
 		const onChangeSpy = jest.fn();

--- a/packages/components/src/external-link/test/index.tsx
+++ b/packages/components/src/external-link/test/index.tsx
@@ -9,11 +9,9 @@ import userEvent from '@testing-library/user-event';
  */
 import { ExternalLink } from '..';
 
-const setupUser = () => userEvent.setup();
-
 describe( 'ExternalLink', () => {
 	test( 'should call function passed in onClick handler when clicking the link', async () => {
-		const user = setupUser();
+		const user = await userEvent.setup();
 		const onClickMock = jest.fn();
 
 		render(
@@ -32,7 +30,7 @@ describe( 'ExternalLink', () => {
 	} );
 
 	test( 'should prevent default action when clicking an internal anchor link without passing onClick prop', async () => {
-		const user = setupUser();
+		const user = await userEvent.setup();
 
 		render(
 			<ExternalLink href="#test">I&apos;m an anchor link!</ExternalLink>
@@ -55,7 +53,7 @@ describe( 'ExternalLink', () => {
 	} );
 
 	test( 'should call function passed in onClick handler and prevent default action when clicking an internal anchor link', async () => {
-		const user = setupUser();
+		const user = await userEvent.setup();
 		const onClickMock = jest.fn();
 
 		render(
@@ -76,7 +74,7 @@ describe( 'ExternalLink', () => {
 	} );
 
 	test( 'should not prevent default action when clicking a non anchor link without passing onClick prop', async () => {
-		const user = setupUser();
+		const user = await userEvent.setup();
 
 		render(
 			<ExternalLink href="https://wordpress.org">

--- a/packages/components/src/input-control/test/index.js
+++ b/packages/components/src/input-control/test/index.js
@@ -14,8 +14,6 @@ import { useState } from '@wordpress/element';
  */
 import BaseInputControl from '../';
 
-const setupUser = () => userEvent.setup();
-
 const getInput = () => screen.getByTestId( 'input' );
 
 describe( 'InputControl', () => {
@@ -70,7 +68,7 @@ describe( 'InputControl', () => {
 
 	describe( 'Ensurance of focus for number inputs', () => {
 		it( 'should focus its input on mousedown events', async () => {
-			const user = setupUser();
+			const user = await userEvent.setup();
 			const spy = jest.fn();
 			render( <InputControl type="number" onFocus={ spy } /> );
 			const target = getInput();
@@ -87,7 +85,7 @@ describe( 'InputControl', () => {
 
 	describe( 'Value', () => {
 		it( 'should update value onChange', async () => {
-			const user = setupUser();
+			const user = await userEvent.setup();
 			const spy = jest.fn();
 			render(
 				<InputControl value="Hello" onChange={ ( v ) => spy( v ) } />
@@ -102,7 +100,7 @@ describe( 'InputControl', () => {
 		} );
 
 		it( 'should work as a controlled component given normal, falsy or nullish values', async () => {
-			const user = setupUser();
+			const user = await userEvent.setup();
 			const spy = jest.fn();
 			const heldKeySet = new Set();
 			const Example = () => {
@@ -173,7 +171,7 @@ describe( 'InputControl', () => {
 		} );
 
 		it( 'should not commit value until blurred when isPressEnterToChange is true', async () => {
-			const user = setupUser();
+			const user = await userEvent.setup();
 			const spy = jest.fn();
 			render(
 				<InputControl
@@ -193,7 +191,7 @@ describe( 'InputControl', () => {
 		} );
 
 		it( 'should commit value when blurred if value is invalid', async () => {
-			const user = setupUser();
+			const user = await userEvent.setup();
 			const spyChange = jest.fn();
 			render(
 				<InputControl

--- a/packages/components/src/select-control/test/select-control.tsx
+++ b/packages/components/src/select-control/test/select-control.tsx
@@ -9,8 +9,6 @@ import userEvent from '@testing-library/user-event';
  */
 import SelectControl from '..';
 
-const setupUser = () => userEvent.setup();
-
 describe( 'SelectControl', () => {
 	it( 'should not render when no options or children are provided', () => {
 		render( <SelectControl /> );
@@ -20,7 +18,7 @@ describe( 'SelectControl', () => {
 	} );
 
 	it( 'should not render its children', async () => {
-		const user = setupUser();
+		const user = await userEvent.setup();
 		const handleChangeMock = jest.fn();
 
 		render(
@@ -49,7 +47,7 @@ describe( 'SelectControl', () => {
 	} );
 
 	it( 'should not render its options', async () => {
-		const user = setupUser();
+		const user = await userEvent.setup();
 		const handleChangeMock = jest.fn();
 
 		render(

--- a/packages/plugins/src/components/test/plugin-area.js
+++ b/packages/plugins/src/components/test/plugin-area.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+// eslint-disable-next-line testing-library/no-manual-cleanup
 import { act, render, cleanup } from '@testing-library/react';
 
 /**


### PR DESCRIPTION
## What?
This PR bumps `eslint-plugin-testing-library` to v6.

## Why?
It's simply a dependency change, to keep the testing library tests up to date with the latest best practices of writing component tests.

## How?
We're bumping the version and fixing a couple of ESLint errors.

## Testing Instructions
Verify all checks are green.

### Testing Instructions for Keyboard
None.

## Screenshots or screencast <!-- if applicable -->
None.