### PR TITLE
Popover: Fix the styles for components that use emotion within popovers

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -16,6 +16,7 @@
 -   `FormTokenField`: Add `box-sizing` reset style and reset default padding ([#54734](https://github.com/WordPress/gutenberg/pull/54734)).
 -   `SlotFill`: Pass `Component` instance to unregisterSlot ([#54765](https://github.com/WordPress/gutenberg/pull/54765)).
 -   `Button`: Remove `aria-selected` CSS selector from styling 'active' buttons ([#54931](https://github.com/WordPress/gutenberg/pull/54931)).
+-   `Popover`: Apply the CSS in JS styles properly for components used within popovers. ([#54912](https://github.com/WordPress/gutenberg/pull/54912))
 
 ### Internal
 

--- a/packages/components/src/popover/index.tsx
+++ b/packages/components/src/popover/index.tsx
@@ -60,6 +60,7 @@ import type {
 	PopoverAnchorRefTopBottom,
 } from './types';
 import { overlayMiddlewares } from './overlay-middlewares';
+import { StyleProvider } from '../style-provider';
 
 /**
  * Name of slot in which popover should fill.
@@ -447,7 +448,10 @@ const UnforwardedPopover = (
 	if ( shouldRenderWithinSlot ) {
 		content = <Fill name={ slotName }>{ content }</Fill>;
 	} else if ( ! inline ) {
-		content = createPortal( content, getPopoverFallbackContainer() );
+		content = createPortal(
+			<StyleProvider document={ document }>{ content }</StyleProvider>,
+			getPopoverFallbackContainer()
+		);
 	}
 
 	if ( hasAnchor ) {


### PR DESCRIPTION
Fix regression introduced in #53889

## What?

In #53889 default popovers moved from using a "Slot" to just rendering within the "body" of the page. But we missed the fact that when using a `Slot`, there's an "emotion" `StyleProvider` that gets automatically applied which ensures that any CSS in JS styles rendered within the Slot are rendered properly to the right document. Since we're now using `createPortal` directly, we need to ensure the right `StyleProvider` is applied which would ensure that the styles are applied properly within that particular popover.

## Testing Instructions

1- A bit hard cause I'm not sure we have a use-case right now in Gutenberg. You'll have to render a `<Popover>` or `<Dropdown>` within a "block" (so within the iframe) and use an "emotion" based component within it. (I have been personally testing using a private plugin that I can't share publicly)