### PR TITLE
url: update `filterURLForDisplay` to include all image, video, and audio file types

### DIFF
--- a/packages/block-editor/src/components/link-control/link-preview.js
+++ b/packages/block-editor/src/components/link-control/link-preview.js
@@ -11,6 +11,7 @@ import {
 	Button,
 	ExternalLink,
 	__experimentalText as Text,
+	Tooltip,
 } from '@wordpress/components';
 import { filterURLForDisplay, safeDecodeURI } from '@wordpress/url';
 import { Icon, globe, info, linkOff, edit } from '@wordpress/icons';
@@ -87,12 +88,17 @@ export default function LinkPreview( {
 					<span className="block-editor-link-control__search-item-details">
 						{ ! isEmptyURL ? (
 							<>
-								<ExternalLink
-									className="block-editor-link-control__search-item-title"
-									href={ value.url }
+								<Tooltip
+									text={ value.url }
+									placement="bottom-start"
 								>
-									{ displayTitle }
-								</ExternalLink>
+									<ExternalLink
+										className="block-editor-link-control__search-item-title"
+										href={ value.url }
+									>
+										{ displayTitle }
+									</ExternalLink>
+								</Tooltip>
 
 								{ value?.url && displayTitle !== displayURL && (
 									<span className="block-editor-link-control__search-item-info">

--- a/packages/block-editor/src/components/link-control/test/index.js
+++ b/packages/block-editor/src/components/link-control/test/index.js
@@ -2065,7 +2065,7 @@ describe( 'Addition Settings UI', () => {
 
 		const link = screen.getByRole( 'link' );
 
-		expect( link ).toHaveTextContent( /a-document.pdf/i );
+		expect( link ).toHaveTextContent( 'a-document.pdf' );
 
 		await user.hover( link );
 

--- a/packages/block-editor/src/components/link-control/test/index.js
+++ b/packages/block-editor/src/components/link-control/test/index.js
@@ -2056,6 +2056,26 @@ describe( 'Addition Settings UI', () => {
 			} )
 		);
 	} );
+
+	it( 'should show tooltip with full URL alongside filtered display', async () => {
+		const user = userEvent.setup();
+		const url = 'https://example.com';
+		render( <LinkControl value={ { url } } /> );
+
+		const link = screen.getByRole( 'link' );
+
+		expect( screen.getByRole( 'link' ) ).toHaveTextContent(
+			/example.com/i
+		);
+
+		await user.hover( link );
+
+		expect( await screen.findByRole( 'tooltip' ) ).toHaveTextContent( url );
+
+		await user.unhover( link );
+
+		expect( screen.queryByRole( 'tooltip' ) ).not.toBeInTheDocument();
+	} );
 } );
 
 describe( 'Post types', () => {

--- a/packages/block-editor/src/components/link-control/test/index.js
+++ b/packages/block-editor/src/components/link-control/test/index.js
@@ -2059,14 +2059,13 @@ describe( 'Addition Settings UI', () => {
 
 	it( 'should show tooltip with full URL alongside filtered display', async () => {
 		const user = userEvent.setup();
-		const url = 'https://example.com';
+		const url =
+			'http://www.wordpress.org/wp-content/uploads/a-document.pdf';
 		render( <LinkControl value={ { url } } /> );
 
 		const link = screen.getByRole( 'link' );
 
-		expect( screen.getByRole( 'link' ) ).toHaveTextContent(
-			/example.com/i
-		);
+		expect( link ).toHaveTextContent( /a-document.pdf/i );
 
 		await user.hover( link );
 

--- a/packages/block-editor/src/components/media-replace-flow/index.js
+++ b/packages/block-editor/src/components/media-replace-flow/index.js
@@ -16,7 +16,6 @@ import {
 	ToolbarButton,
 	Dropdown,
 	withFilters,
-	Tooltip,
 } from '@wordpress/components';
 import { useSelect, withDispatch } from '@wordpress/data';
 import { DOWN } from '@wordpress/keycodes';
@@ -220,19 +219,15 @@ const MediaReplaceFlow = ( {
 								{ __( 'Current media URL:' ) }
 							</span>
 
-							<Tooltip text={ mediaURL }>
-								<div>
-									<LinkControl
-										value={ { url: mediaURL } }
-										settings={ [] }
-										showSuggestions={ false }
-										onChange={ ( { url } ) => {
-											onSelectURL( url );
-											editMediaButtonRef.current.focus();
-										} }
-									/>
-								</div>
-							</Tooltip>
+							<LinkControl
+								value={ { url: mediaURL } }
+								settings={ [] }
+								showSuggestions={ false }
+								onChange={ ( { url } ) => {
+									onSelectURL( url );
+									editMediaButtonRef.current.focus();
+								} }
+							/>
 						</form>
 					) }
 				</>

--- a/packages/url/src/filter-url-for-display.js
+++ b/packages/url/src/filter-url-for-display.js
@@ -21,7 +21,7 @@ export function filterURLForDisplay( url, maxLength = null ) {
 		filteredURL = filteredURL.replace( '/', '' );
 	}
 
-	const mediaRegexp = /([\w|:])*\.(?:jpg|jpeg|gif|png|svg)/;
+	const mediaRegexp = /\/([^\/?]+)\.(?:[\w]+)(?=\?|$)/;
 
 	if (
 		! maxLength ||

--- a/packages/url/src/filter-url-for-display.js
+++ b/packages/url/src/filter-url-for-display.js
@@ -21,8 +21,8 @@ export function filterURLForDisplay( url, maxLength = null ) {
 		filteredURL = filteredURL.replace( '/', '' );
 	}
 
-	const mediaRegexp =
-		/([\w|:])*\.(?:jpg|jpeg|gif|png|svg|ico|webp|mp3|m4a|ogg|wav|mp4|m4v|mov|wmv|avi|mpg|ogv|3gp|3g2)/;
+	const mediaRegexp = /\/([^\/?]+)\.(?:[\w]+)(?=\?|$)/;
+
 	if (
 		! maxLength ||
 		filteredURL.length <= maxLength ||

--- a/packages/url/src/filter-url-for-display.js
+++ b/packages/url/src/filter-url-for-display.js
@@ -21,12 +21,13 @@ export function filterURLForDisplay( url, maxLength = null ) {
 		filteredURL = filteredURL.replace( '/', '' );
 	}
 
-	const mediaRegexp = /\/([^\/?]+)\.(?:[\w]+)(?=\?|$)/;
+	// capture file name from URL
+	const fileRegexp = /\/([^\/?]+)\.(?:[\w]+)(?=\?|$)/;
 
 	if (
 		! maxLength ||
 		filteredURL.length <= maxLength ||
-		! filteredURL.match( mediaRegexp )
+		! filteredURL.match( fileRegexp )
 	) {
 		return filteredURL;
 	}

--- a/packages/url/src/filter-url-for-display.js
+++ b/packages/url/src/filter-url-for-display.js
@@ -21,8 +21,8 @@ export function filterURLForDisplay( url, maxLength = null ) {
 		filteredURL = filteredURL.replace( '/', '' );
 	}
 
-	const mediaRegexp = /\/([^\/?]+)\.(?:[\w]+)(?=\?|$)/;
-
+	const mediaRegexp =
+		/([\w|:])*\.(?:jpg|jpeg|gif|png|svg|ico|webp|mp3|m4a|ogg|wav|mp4|m4v|mov|wmv|avi|mpg|ogv|3gp|3g2)/;
 	if (
 		! maxLength ||
 		filteredURL.length <= maxLength ||

--- a/packages/url/src/test/index.js
+++ b/packages/url/src/test/index.js
@@ -254,35 +254,20 @@ describe( 'isValidPath', () => {
 } );
 
 describe( 'getFilename', () => {
-	it( 'returns the filename part of the URL', () => {
-		expect( getFilename( 'https://wordpress.org/image.jpg' ) ).toBe(
-			'image.jpg'
-		);
-		expect(
-			getFilename( 'https://wordpress.org/image.jpg?query=test' )
-		).toBe( 'image.jpg' );
-		expect( getFilename( 'https://wordpress.org/image.jpg#anchor' ) ).toBe(
-			'image.jpg'
-		);
-		expect(
-			getFilename( 'http://localhost:8080/a/path/to/an/image.jpg' )
-		).toBe( 'image.jpg' );
-		expect( getFilename( '/path/to/an/image.jpg' ) ).toBe( 'image.jpg' );
-		expect( getFilename( 'path/to/an/image.jpg' ) ).toBe( 'image.jpg' );
-		expect( getFilename( '/image.jpg' ) ).toBe( 'image.jpg' );
-
-		expect( getFilename( 'https://wordpress.org/file.pdf' ) ).toBe(
-			'file.pdf'
-		);
-		expect(
-			getFilename( 'https://wordpress.org/image.webp?query=test' )
-		).toBe( 'image.webp' );
-		expect( getFilename( 'https://wordpress.org/video.mov#anchor' ) ).toBe(
-			'video.mov'
-		);
-		expect(
-			getFilename( 'http://localhost:8080/a/path/to/audio.mp3' )
-		).toBe( 'audio.mp3' );
+	it.each( [
+		[ 'https://wordpress.org/image.jpg', 'image.jpg' ],
+		[ 'https://wordpress.org/image.jpg?query=test', 'image.jpg' ],
+		[ 'https://wordpress.org/image.jpg#anchor', 'image.jpg' ],
+		[ 'http://localhost:8080/a/path/to/an/image.jpg', 'image.jpg' ],
+		[ '/path/to/an/image.jpg', 'image.jpg' ],
+		[ 'path/to/an/image.jpg', 'image.jpg' ],
+		[ '/image.jpg', 'image.jpg' ],
+		[ 'https://wordpress.org/file.pdf', 'file.pdf' ],
+		[ 'https://wordpress.org/image.webp?query=test', 'image.webp' ],
+		[ 'https://wordpress.org/video.mov#anchor', 'video.mov' ],
+		[ 'http://localhost:8080/a/path/to/audio.mp3', 'audio.mp3' ],
+	] )( 'returns the filename part of the URL: %s', ( url, filename ) => {
+		expect( getFilename( url ) ).toBe( filename );
 	} );
 
 	it( 'returns undefined when the provided value does not contain a filename', () => {

--- a/packages/url/src/test/index.js
+++ b/packages/url/src/test/index.js
@@ -270,10 +270,7 @@ describe( 'getFilename', () => {
 		expect( getFilename( '/path/to/an/image.jpg' ) ).toBe( 'image.jpg' );
 		expect( getFilename( 'path/to/an/image.jpg' ) ).toBe( 'image.jpg' );
 		expect( getFilename( '/image.jpg' ) ).toBe( 'image.jpg' );
-		expect( getFilename( 'image.jpg' ) ).toBe( 'image.jpg' );
-	} );
 
-	it( 'returns the filename for a variety of formats', () => {
 		expect( getFilename( 'https://wordpress.org/file.pdf' ) ).toBe(
 			'file.pdf'
 		);

--- a/packages/url/src/test/index.js
+++ b/packages/url/src/test/index.js
@@ -273,6 +273,21 @@ describe( 'getFilename', () => {
 		expect( getFilename( 'image.jpg' ) ).toBe( 'image.jpg' );
 	} );
 
+	it( 'returns the filename for a variety of formats', () => {
+		expect( getFilename( 'https://wordpress.org/file.pdf' ) ).toBe(
+			'file.pdf'
+		);
+		expect(
+			getFilename( 'https://wordpress.org/image.webp?query=test' )
+		).toBe( 'image.webp' );
+		expect( getFilename( 'https://wordpress.org/video.mov#anchor' ) ).toBe(
+			'video.mov'
+		);
+		expect(
+			getFilename( 'http://localhost:8080/a/path/to/audio.mp3' )
+		).toBe( 'audio.mp3' );
+	} );
+
 	it( 'returns undefined when the provided value does not contain a filename', () => {
 		expect( getFilename( 'http://localhost:8080/' ) ).toBe( undefined );
 		expect( getFilename( 'http://localhost:8080/a/path/' ) ).toBe(


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Closes #53154 

When replacing a file that is not a jpg, jpeg, gif, png, or svg, the link in the 'Replace' `Popover` overflows the width and covers up the edit icon. It makes editing extremely difficult as the link is much easier to click than the icon. 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The current RegEx used only captures limited image file types. However, this filter is used in `LinkControl`, which is used in many other cases, including the Video and Audio blocks, where it is completely broken. 

This particular RegEx is for the URL's display, so I'm unsure if there is a need for it to be so specific. If so, that might be beyond this PR's scope, but I wanted to see if we could get something started here, as it is a frustrating UX. 

## How?

By changing the RegEx for media in `filterURLForDisplay` to capture any file extension. 

## Testing Instructions

Ensure tests still pass: `npm run test:unit packages/url/src/test/index.js`

### For MediaReplaceFlow

1. Add a block that uses `LinkControl` (i.e. Video, Audio, Image)
2. Add a file format that wasn't included before (jpg, jpeg, gif, png, or svg)
3. See the URL is shortened, and the edit icon can easily be clicked again 

| Before  | After |
| ------------- | ------------- |
|  <img width="352" alt="Screenshot 2023-09-28 at 1 55 17 PM" src="https://github.com/WordPress/gutenberg/assets/35543432/8b52cd4d-cd8f-4efa-a2eb-ba802caa8fb4"> | <img width="351" alt="Screenshot 2023-09-28 at 1 53 48 PM" src="https://github.com/WordPress/gutenberg/assets/35543432/1e775bbc-b3c3-49c3-9bf6-863c50dbf588">  |

### For LinkPreview

Ensure tests still pass: `npm run test:unit packages/block-editor/src/components/link-control/test/index.js`

1. Add a Paragraph block 
2. Add an inline link and open the UI to edit
3. Hover on or tab to the link to see a tooltip with the full URL

<img width="426" alt="Screenshot 2023-10-06 at 9 04 45 AM" src="https://github.com/WordPress/gutenberg/assets/35543432/53b5c88f-7442-4f37-a287-8d62cc0d2146">
