### PR TITLE
Revert "Fix warning when a template calls a template area twice"

### DIFF
--- a/packages/edit-site/src/store/utils.js
+++ b/packages/edit-site/src/store/utils.js
@@ -49,13 +49,8 @@ function getFilteredTemplatePartBlocks( blocks = EMPTY_ARRAY, templateParts ) {
 			const templatePartId = `${ theme }//${ slug }`;
 			const templatePart = templatePartsById[ templatePartId ];
 
-			// Make sure we don't duplicate template parts.
-			const existingTemplatePart = result.find(
-				( oneResult ) => oneResult.templatePart.id === templatePartId
-			);
-
 			// Only add to output if the found template part block is in the list of available template parts.
-			if ( templatePart && ! existingTemplatePart ) {
+			if ( templatePart ) {
 				result.push( {
 					templatePart,
 					block,


### PR DESCRIPTION
Reverts WordPress/gutenberg#54861