### PR TITLE
[RNMobile] HTML mode: Add dark mode color to post title

### DIFF
--- a/packages/components/src/mobile/html-text-input/index.native.js
+++ b/packages/components/src/mobile/html-text-input/index.native.js
@@ -81,7 +81,10 @@ export class HTMLTextInput extends Component {
 			title,
 		} = this.props;
 		const titleStyle = [
-			styles.htmlViewTitle,
+			getStylesFromColorScheme(
+				styles.htmlViewTitle,
+				styles.htmlViewTitleDark
+			),
 			style?.text && { color: style.text },
 		];
 		const htmlStyle = [

--- a/packages/components/src/mobile/html-text-input/style.scss
+++ b/packages/components/src/mobile/html-text-input/style.scss
@@ -37,3 +37,7 @@ $textColorDark: $white;
 .scrollView {
 	flex: 1;
 }
+
+.htmlViewTitleDark {
+	color: $textColorDark;
+}

--- a/packages/components/src/mobile/html-text-input/test/__snapshots__/index.native.js.snap
+++ b/packages/components/src/mobile/html-text-input/test/__snapshots__/index.native.js.snap
@@ -14,7 +14,9 @@ exports[`HTMLTextInput HTMLTextInput renders and matches snapshot 1`] = `
         placeholderTextColor="white"
         style={
           [
-            undefined,
+            {
+              "color": "white",
+            },
             undefined,
           ]
         }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

In HTML mode and with dark mode enabled, the post title might be not visible due to using the same color as the background. This issue only happens when using themes that don't provide global styles.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

This issue affects negatively the experience when editing in HTML mode.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Adds a style to be used in the title element when in dark mode.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. In a browser, navigate to the Theme page of a site.
2. Set a theme that doesn't provide global styles (e.g. Seedlet theme).
3. In the app, open/create a post.
4. Set a post title.
5. Tap on the `...` button and "Switch to HTML mode".
6. Observe that the post title is visible.
7. Enable dark mode in the device.
8. Observe that the post title is displayed with a different color and is visible.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
N/A

## Screenshots or screencast <!-- if applicable -->
<img src=https://github.com/WordPress/gutenberg/assets/14905380/8e44e99c-4e23-4a79-8f09-b14dfe03ed8c width=300>
