### PR TITLE
Reverting addition of `aria-selected` style hook in `Button`

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -15,6 +15,7 @@
 -   `DateTimePicker`: fix onChange callback check so that it also works inside iframes ([#54669](https://github.com/WordPress/gutenberg/pull/54669)).
 -   `FormTokenField`: Add `box-sizing` reset style and reset default padding ([#54734](https://github.com/WordPress/gutenberg/pull/54734)).
 -   `SlotFill`: Pass `Component` instance to unregisterSlot ([#54765](https://github.com/WordPress/gutenberg/pull/54765)).
+-   `Button`: Remove `aria-selected` CSS selector from styling 'active' buttons ([#54931](https://github.com/WordPress/gutenberg/pull/54931)).
 
 ### Internal
 

--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -309,8 +309,7 @@
 
 	// Toggled style.
 	&[aria-pressed="true"],
-	&[aria-pressed="mixed"],
-	&[aria-selected="true"] {
+	&[aria-pressed="mixed"] {
 		color: $components-color-foreground-inverted;
 		background: $components-color-foreground;
 


### PR DESCRIPTION
## What?
This PR removes the addition of `aria-selected` as a styling hook from `Button`.

## Why?
[As pointed out](https://github.com/WordPress/gutenberg/pull/54903#issuecomment-1740537243) by @madhusudhand, #54903 inadvertently changed how tabs are rendered.

## How?
The `[aria-selected="true"]` selector has been removed from `Button`.

## Testing Instructions

1.  Under global styles -> typography, click on `Aa` or any font to invoke the font library modal.
2. Observe that the active tab no longer has a black background.

## Screenshots

### Before

![Screenshot of tabs, the selected one having an unexpected dark background.](https://github.com/WordPress/gutenberg/assets/159848/780d5362-f023-45d8-8815-28d16f2a95e3)

### After

![Screenshot of tabs, the selected one having no background.](https://github.com/WordPress/gutenberg/assets/159848/237ec917-aa3b-45f9-a18c-da03a0b952f5)
