### PR TITLE
Gutenberg Plugin: Correctly enqueue core block theme styles

### DIFF
--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -293,9 +293,10 @@ function gutenberg_register_core_block_assets( $block_name ) {
 
 		// If the file exists, enqueue it.
 		if ( file_exists( gutenberg_dir_path() . $theme_style_path ) ) {
-
+			wp_deregister_style( "wp-block-{$block_name}-theme" );
 			if ( file_exists( $stylesheet_path ) ) {
-				// If there is a main stylesheet for this block, append the theme styles to main styles.
+				// If there is a main stylesheet for this block, deregister the core theme
+				// styles and append the theme styles to main styles.
 				wp_add_inline_style(
 					"wp-block-{$block_name}",
 					file_get_contents( gutenberg_dir_path() . $theme_style_path )
@@ -303,7 +304,7 @@ function gutenberg_register_core_block_assets( $block_name ) {
 			} else {
 				// If there is no main stylesheet for this block, register theme style.
 				wp_register_style(
-					"wp-block-{$block_name}",
+					"wp-block-{$block_name}-theme",
 					gutenberg_url( $theme_style_path ),
 					array(),
 					$default_version


### PR DESCRIPTION
Closes #54783
Related to: #31239

## What?
This PR ensures that the Gutenberg plugin's core block theme styles properly override the WordPress core block theme styles.

This PR solves the following two problems:

1. Even if you update the `theme.scss` with the Gutenberg plugin, the style will be overridden in the core `theme.scss`
2. The theme style of blocks without a main style sheet (template part block) is not enqueued correctly

## Why?

Regarding the first problem, please check [the issue comments](https://github.com/WordPress/gutenberg/issues/54783#issue-1911219021) for details.

Regarding the second problem, I think it's because the style handle name (`wp-block-{$block_name}`) passed to the `wp_register_style function()` is already in use.


## How?

Remove core theme styles via `wp_deregister_style()`. For blocks without a main stylesheet, I added the `-theme` suffix to the handle name to ensure that styles are enqueued correctly.


## Testing Instructions

Here we will test the code block and template parts block.

- Activate Twenty Twenty-two: This theme opts in to `wp-block-styles`, so you can test the code I've made.
- Insert a code block into the post. This block has the main stylesheet and theme styles.
- Open the post and check the source code.

### trunk

Looking at the code, we see the following:

- Regarding the code block, the core theme styles are located after the Gutenberg plugin theme styles, so the Gutenberg plugin cannot overwrite them.
- Only the core theme styles for template parts block are output.

Even if you update the theme.scss of these two blocks on the Gutenberg plugin side, the styles should not be reflected.

```html
<style id='wp-block-code-inline-css'>
.wp-block-code{
  box-sizing:border-box;
}
.wp-block-code code{
  display:block;
  font-family:inherit;
  overflow-wrap:break-word;
  white-space:pre-wrap;
}

// theme styles enqueued by Gutenberg plugin
.wp-block-code{
  border:1px solid #ccc;
  border-radius:4px;
  font-family:Menlo,Consolas,monaco,monospace;
  padding:.8em 1em;
}
</style>

<style id='wp-block-code-theme-inline-css'>
// theme styles enqueued by core
.wp-block-code{
  border:1px solid #ccc;
  border-radius:4px;
  font-family:Menlo,Consolas,monaco,monospace;
  padding:.8em 1em;
}
</style>

<!-- theme styles enqueued by core -->
<style id='wp-block-template-part-theme-inline-css'>
.wp-block-template-part.has-background{
  margin-bottom:0;
  margin-top:0;
  padding:1.25em 2.375em;
}
</style>
```

### This PR

Looking at the code, we see the following:

- Regarding the code block, there are no theme styles for the core block, and theme styles from the Gutenberg plugin are added to the main inline CSS.
- Regarding the template part block, There is no inline theme theme style from the core block, and the theme style from the Gutenberg plugin is output as a style tag.

```html
<style id='wp-block-code-inline-css'>
.wp-block-code{
  box-sizing:border-box;
}
.wp-block-code code{
  display:block;
  font-family:inherit;
  overflow-wrap:break-word;
  white-space:pre-wrap;
}

// theme styles enqueued by Gutenberg plugin
.wp-block-code{
  border:1px solid #ccc;
  border-radius:4px;
  font-family:Menlo,Consolas,monaco,monospace;
  padding:.8em 1em;
}
</style>

<!-- theme styles enqueued by Gutenberg plugin -->
<link rel='stylesheet' id='wp-block-template-part-theme-css' href='XXXX/gutenberg/build/block-library/blocks/template-part/theme.css?ver=1695994259' media='all' />
```
