### PR TITLE
Image Block: Fix browser console error when clicking "Expand on Click"

### DIFF
--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -375,7 +375,7 @@ export default function Image( {
 		!! lightbox || lightboxSetting?.allowEditing === true;
 
 	const lightboxChecked =
-		lightbox?.enabled || ( ! lightbox && lightboxSetting?.enabled );
+		!! lightbox?.enabled || ( ! lightbox && !! lightboxSetting?.enabled );
 
 	const dimensionsControl = (
 		<DimensionsTool


### PR DESCRIPTION
## What?
This PR fixes a browser console error that occurs when you click "Expand on lick" for the first time after inserting an image block.


https://github.com/WordPress/gutenberg/assets/54422211/cafbf953-4456-4907-9bd5-faedf095652d



## Why?

This is because the lightboxChecked variable returns undefined the first time the image block is inserted.

## How?

I made it always return a boolean value.
